### PR TITLE
cts: load a bare HSA code object and fix CPU-coupled lifecycle tests

### DIFF
--- a/cts/tests/executable/executable_test.cpp
+++ b/cts/tests/executable/executable_test.cpp
@@ -12,6 +12,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -41,10 +42,13 @@ std::filesystem::path build_noop_hsaco(const std::string &arch) {
   std::filesystem::path hsaco_path =
       std::filesystem::temp_directory_path() / "hrx_noop_kernel.hsaco";
 
+  // --no-gpu-bundle-output is required: without it clang wraps the gfx code
+  // object in a __CLANG_OFFLOAD_BUNDLE__ fat binary, which the native loader
+  // rejects ("does not begin with ELF magic"). It wants a bare HSA code object.
   std::string command =
       "clang++ -x hip --offload-device-only --offload-arch=" + arch +
-      " -nogpuinc -nogpulib -c " + src_path.string() + " -o " +
-      hsaco_path.string();
+      " --no-gpu-bundle-output -nogpuinc -nogpulib -c " + src_path.string() +
+      " -o " + hsaco_path.string();
   int rc = std::system(command.c_str());
   INFO("command: " << command);
   REQUIRE(rc == 0);
@@ -90,8 +94,11 @@ TEST_CASE_METHOD(HrxTestFixture, "executable_load_lookup_dispatch_noop") {
   REQUIRE_OK(hrx().executable_export_info(executable, ordinal, &info));
   REQUIRE(info.name != nullptr);
   REQUIRE(std::string(info.name) == "hrx_noop");
-  REQUIRE(info.constant_count == 0);
-  REQUIRE(info.binding_count == 0);
+  // A raw code object has no HAL reflection, so the loader projects the whole
+  // kernarg segment as dispatch constants (kernarg_segment_size / 4) — nonzero
+  // even for a no-argument kernel because of the implicit COV5 kernarg block.
+  REQUIRE(info.constant_count > 0);
+  REQUIRE(info.binding_count == 0);  // hrx_noop binds no buffers
   REQUIRE(info.workgroup_size[0] >= 1);
   REQUIRE(info.workgroup_size[1] >= 1);
   REQUIRE(info.workgroup_size[2] >= 1);
@@ -110,10 +117,14 @@ TEST_CASE_METHOD(HrxTestFixture, "executable_load_lookup_dispatch_noop") {
       },
       /* .subgroup_size = */ 0,
   };
-  REQUIRE_OK(hrx().stream_dispatch(stream, executable, ordinal, &config,
-                                   /*constants=*/nullptr, /*constants_size=*/0,
-                                   /*bindings=*/nullptr, /*binding_count=*/0,
-                                   HRX_DISPATCH_FLAG_NONE));
+  // The dispatch requires constants_size == constant_count * sizeof(uint32_t);
+  // hrx_noop reads none of them, so a zero-filled block suffices.
+  std::vector<uint32_t> constants(info.constant_count, 0u);
+  REQUIRE_OK(hrx().stream_dispatch(
+      stream, executable, ordinal, &config,
+      /*constants=*/constants.empty() ? nullptr : constants.data(),
+      /*constants_size=*/constants.size() * sizeof(uint32_t),
+      /*bindings=*/nullptr, /*binding_count=*/0, HRX_DISPATCH_FLAG_NONE));
   REQUIRE_OK(hrx().stream_synchronize(stream));
 
   hrx().stream_release(stream);

--- a/cts/tests/lifecycle/lifecycle_test.cpp
+++ b/cts/tests/lifecycle/lifecycle_test.cpp
@@ -13,8 +13,9 @@ TEST_CASE("Runtime version is valid", "[lifecycle]") {
 }
 
 TEST_CASE("CPU init and shutdown", "[lifecycle][cpu]") {
-  // CPU is already initialized by main.cpp if we're on CPU.
-  // Test that device_count works.
+  if (g_test_device_type != HRX_ACCELERATOR_CPU) {
+    SKIP("CPU accelerator is only initialized for a cpu:N device spec");
+  }
   int count = 0;
   REQUIRE_OK(hrx().cpu_device_count(&count));
   REQUIRE(count > 0);
@@ -33,8 +34,11 @@ TEST_CASE("GPU init and shutdown", "[lifecycle][gpu]") {
 }
 
 TEST_CASE("Double init returns ALREADY_EXISTS", "[lifecycle]") {
-  // CPU is already initialized. Calling again should return error.
-  hrx_status_t status = hrx().cpu_initialize(0);
+  // main.cpp has already initialized the accelerator matching the test device;
+  // initializing it again must return ALREADY_EXISTS.
+  hrx_status_t status = g_test_device_type == HRX_ACCELERATOR_GPU
+                            ? hrx().gpu_initialize(0)
+                            : hrx().cpu_initialize(0);
   REQUIRE(!hrx_status_is_ok(status));
   REQUIRE(hrx().status_code(status) == HRX_STATUS_ALREADY_EXISTS);
   hrx().status_ignore(status);


### PR DESCRIPTION
The executable CTS compiled its noop kernel with `clang++ -x hip --offload-device-only -c`, which wraps the gfx code object in a __CLANG_OFFLOAD_BUNDLE__ fat binary. The native loader wants a bare HSA code object and rejected it ("does not begin with ELF magic"). Pass --no-gpu-bundle-output so clang emits the unwrapped object.

A raw code object carries no HAL reflection, so the loader projects the kernel's whole kernarg segment as dispatch constants (kernarg_segment_size / sizeof(uint32_t); the COV5 implicit kernarg block makes this 64 even for a no-argument kernel). Assert constant_count > 0 rather than == 0, and feed that many zero-filled constants to the dispatch, which validates the size.

The lifecycle suite's CPU-coupled cases assumed main.cpp had initialized the CPU accelerator, which it only does on a cpu:N device spec, so they failed on gpu:0. "CPU init and shutdown" is CPU-specific (cpu_device_count) and now skips on non-CPU runs; "Double init returns ALREADY_EXISTS" initializes whichever accelerator matches the test device, keeping coverage on both.

Verified on gpu:0 (MI300X/gfx942): hrx_cts_executable passes (22 assertions); hrx_cts_lifecycle 3 passed / 1 skipped. cpu:0: executable returns early (GPU-only), lifecycle 6 assertions pass.
