### PR TITLE
Support raw HSACO custom kernargs

### DIFF
--- a/libhrx/cts/tests/executable/executable_test.cpp
+++ b/libhrx/cts/tests/executable/executable_test.cpp
@@ -128,7 +128,7 @@ TEST_CASE_METHOD(HrxTestFixture, "executable_load_lookup_dispatch_noop") {
   REQUIRE_OK(hrx().stream_dispatch(stream, executable, ordinal, &config,
                                    /*constants=*/nullptr, /*constants_size=*/0,
                                    /*bindings=*/nullptr, /*binding_count=*/0,
-                                   HRX_DISPATCH_FLAG_NONE));
+                                   HRX_DISPATCH_FLAG_CUSTOM_DIRECT_ARGUMENTS));
   REQUIRE_OK(hrx().stream_synchronize(stream));
 
   hrx().stream_release(stream);

--- a/libhrx/src/libhrx/hrx_internal.h
+++ b/libhrx/src/libhrx/hrx_internal.h
@@ -124,9 +124,8 @@ _Static_assert(HRX_BUFFER_USAGE_DEFAULT == IREE_HAL_BUFFER_USAGE_DEFAULT,
 
 // HRX dispatch flags intentionally use their own bit assignments. Translate
 // them instead of casting into IREE HAL dispatch flags.
-static inline hrx_status_t
-hrx_iree_dispatch_flags_from_hrx(uint32_t hrx_flags,
-                                 iree_hal_dispatch_flags_t *out_iree_flags) {
+static inline hrx_status_t hrx_iree_dispatch_flags_from_hrx(
+    uint32_t hrx_flags, iree_hal_dispatch_flags_t* out_iree_flags) {
   *out_iree_flags = IREE_HAL_DISPATCH_FLAG_NONE;
   const uint32_t supported_flags = HRX_DISPATCH_FLAG_CUSTOM_DIRECT_ARGUMENTS |
                                    HRX_DISPATCH_FLAG_ALLOW_INLINE_EXECUTION;

--- a/libhrx/src/libhrx/hrx_internal.h
+++ b/libhrx/src/libhrx/hrx_internal.h
@@ -122,6 +122,27 @@ _Static_assert(HRX_BUFFER_USAGE_DISPATCH_STORAGE ==
 _Static_assert(HRX_BUFFER_USAGE_DEFAULT == IREE_HAL_BUFFER_USAGE_DEFAULT,
                "buffer usage mismatch");
 
+// HRX dispatch flags intentionally use their own bit assignments. Translate
+// them instead of casting into IREE HAL dispatch flags.
+static inline hrx_status_t
+hrx_iree_dispatch_flags_from_hrx(uint32_t hrx_flags,
+                                 iree_hal_dispatch_flags_t *out_iree_flags) {
+  *out_iree_flags = IREE_HAL_DISPATCH_FLAG_NONE;
+  const uint32_t supported_flags = HRX_DISPATCH_FLAG_CUSTOM_DIRECT_ARGUMENTS |
+                                   HRX_DISPATCH_FLAG_ALLOW_INLINE_EXECUTION;
+  if (IREE_UNLIKELY(hrx_flags & ~supported_flags)) {
+    return hrx_make_status(HRX_STATUS_INVALID_ARGUMENT,
+                           "unsupported HRX dispatch flags");
+  }
+  if (hrx_flags & HRX_DISPATCH_FLAG_CUSTOM_DIRECT_ARGUMENTS) {
+    *out_iree_flags |= IREE_HAL_DISPATCH_FLAG_CUSTOM_DIRECT_ARGUMENTS;
+  }
+  if (hrx_flags & HRX_DISPATCH_FLAG_ALLOW_INLINE_EXECUTION) {
+    *out_iree_flags |= IREE_HAL_DISPATCH_FLAG_ALLOW_INLINE_EXECUTION;
+  }
+  return hrx_ok_status();
+}
+
 // Buffer view metadata.
 _Static_assert(HRX_ELEMENT_TYPE_NONE == IREE_HAL_ELEMENT_TYPE_NONE,
                "element type mismatch");

--- a/libhrx/src/libhrx/queue_ops.c
+++ b/libhrx/src/libhrx/queue_ops.c
@@ -225,6 +225,12 @@ hrx_status_t hrx_queue_dispatch(
             "device, executable, config, constants, or bindings are invalid"));
   }
 
+  iree_hal_dispatch_flags_t hal_flags = IREE_HAL_DISPATCH_FLAG_NONE;
+  hrx_status_t flag_status =
+      hrx_iree_dispatch_flags_from_hrx(flags, &hal_flags);
+  if (!hrx_status_is_ok(flag_status))
+    HRX_RETURN_AND_END_ZONE(z0, flag_status);
+
   iree_hal_buffer_ref_t* hal_bindings = NULL;
   if (binding_count > 0) {
     hal_bindings = (iree_hal_buffer_ref_t*)calloc(
@@ -282,7 +288,7 @@ hrx_status_t hrx_queue_dispatch(
       device->hal_device, hrx_normalize_queue_affinity(affinity), wait_list,
       sig_list, executable->hal_executable,
       iree_hal_executable_function_from_index(export_ordinal), hal_config,
-      hal_constants, hal_binding_list, (iree_hal_dispatch_flags_t)flags);
+      hal_constants, hal_binding_list, hal_flags);
   free(hal_bindings);
   HRX_RETURN_AND_END_ZONE(z0, hrx_status_from_iree(status));
 }

--- a/libhrx/src/libhrx/queue_ops.c
+++ b/libhrx/src/libhrx/queue_ops.c
@@ -228,8 +228,7 @@ hrx_status_t hrx_queue_dispatch(
   iree_hal_dispatch_flags_t hal_flags = IREE_HAL_DISPATCH_FLAG_NONE;
   hrx_status_t flag_status =
       hrx_iree_dispatch_flags_from_hrx(flags, &hal_flags);
-  if (!hrx_status_is_ok(flag_status))
-    HRX_RETURN_AND_END_ZONE(z0, flag_status);
+  if (!hrx_status_is_ok(flag_status)) HRX_RETURN_AND_END_ZONE(z0, flag_status);
 
   iree_hal_buffer_ref_t* hal_bindings = NULL;
   if (binding_count > 0) {

--- a/libhrx/src/libhrx/stream.c
+++ b/libhrx/src/libhrx/stream.c
@@ -401,7 +401,11 @@ hrx_status_t hrx_stream_dispatch(hrx_stream_t stream,
             "stream, executable, config, constants, or bindings are invalid"));
   }
 
-  hrx_status_t status = hrx_stream_begin_cb(stream);
+  iree_hal_dispatch_flags_t hal_flags = IREE_HAL_DISPATCH_FLAG_NONE;
+  hrx_status_t status = hrx_iree_dispatch_flags_from_hrx(flags, &hal_flags);
+  if (!hrx_status_is_ok(status)) HRX_RETURN_AND_END_ZONE(z0, status);
+
+  status = hrx_stream_begin_cb(stream);
   if (!hrx_status_is_ok(status)) HRX_RETURN_AND_END_ZONE(z0, status);
 
   iree_hal_buffer_ref_t* hal_bindings = NULL;
@@ -450,7 +454,7 @@ hrx_status_t hrx_stream_dispatch(hrx_stream_t stream,
   iree_status_t iree_status = iree_hal_command_buffer_dispatch(
       stream->pending_cb, executable->hal_executable,
       iree_hal_executable_function_from_index(export_ordinal), hal_config,
-      hal_constants, hal_binding_list, (iree_hal_dispatch_flags_t)flags);
+      hal_constants, hal_binding_list, hal_flags);
   free(hal_bindings);
   if (!iree_status_is_ok(iree_status)) {
     HRX_RETURN_AND_END_ZONE(z0, hrx_status_from_iree(iree_status));

--- a/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
@@ -408,6 +408,7 @@ iree_runtime_cc_test(
         "//runtime/src/iree/base:core_headers",
         "//runtime/src/iree/base/internal/flatcc:building",
         "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/drivers/amdgpu/util:hsaco_metadata",
         "//runtime/src/iree/schemas:amdgpu_executable_def_c_fbs",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",

--- a/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
@@ -489,6 +489,7 @@ iree_cc_test(
     iree::base::core_headers
     iree::base::internal::flatcc::building
     iree::hal
+    iree::hal::drivers::amdgpu::util::hsaco_metadata
     iree::schemas::amdgpu_executable_def_c_fbs
     iree::testing::gtest
     iree::testing::gtest_main

--- a/runtime/src/iree/hal/drivers/amdgpu/abi/kernel_args.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/abi/kernel_args.h
@@ -54,8 +54,11 @@ typedef struct iree_hal_amdgpu_device_kernel_args_t {
   uint16_t constant_count;
   // Total number of bindings used by the dispatch (if a HAL dispatch).
   uint16_t binding_count;
+  // Offset of HIP/OpenCL implicit args within custom-direct kernargs, or
+  // UINT16_MAX if the kernel does not use an implicit suffix.
+  uint16_t implicit_args_offset;
   // Reserved for future hot kernel metadata. Must be zero.
-  uint32_t reserved;
+  uint16_t reserved;
 } iree_hal_amdgpu_device_kernel_args_t;
 IREE_AMDGPU_STATIC_ASSERT(
     sizeof(iree_hal_amdgpu_device_kernel_args_t) <= 64,

--- a/runtime/src/iree/hal/drivers/amdgpu/abi/kernel_args.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/abi/kernel_args.h
@@ -54,11 +54,8 @@ typedef struct iree_hal_amdgpu_device_kernel_args_t {
   uint16_t constant_count;
   // Total number of bindings used by the dispatch (if a HAL dispatch).
   uint16_t binding_count;
-  // Offset of HIP/OpenCL implicit args within custom-direct kernargs, or
-  // UINT16_MAX if the kernel does not use an implicit suffix.
-  uint16_t implicit_args_offset;
   // Reserved for future hot kernel metadata. Must be zero.
-  uint16_t reserved;
+  uint32_t reserved;
 } iree_hal_amdgpu_device_kernel_args_t;
 IREE_AMDGPU_STATIC_ASSERT(
     sizeof(iree_hal_amdgpu_device_kernel_args_t) <= 64,

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
@@ -2035,6 +2035,13 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_prepare_dispatch_plan(
   }
   out_plan->kernarg_strategy =
       IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STRATEGY_HAL;
+  if (IREE_UNLIKELY(out_plan->descriptor->custom_direct_only &&
+                    !iree_hal_amdgpu_aql_dispatch_plan_uses_custom_direct_arguments(
+                        out_plan))) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "dispatch export requires custom direct kernarg arguments");
+  }
   if (IREE_UNLIKELY(inputs->constants.data_length > 0 &&
                     !inputs->constants.data)) {
     return iree_make_status(

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
@@ -1348,7 +1348,16 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_validate_dispatch_shape(
     const iree_hal_dispatch_config_t config, iree_hal_dispatch_flags_t flags) {
   const bool uses_indirect_parameters =
       iree_hal_dispatch_uses_indirect_parameters(flags);
-  if (iree_hal_amdgpu_dispatch_config_has_workgroup_size_override(config)) {
+  const bool has_workgroup_size_override =
+      iree_hal_amdgpu_dispatch_config_has_workgroup_size_override(config);
+  if (IREE_UNLIKELY(descriptor->custom_direct_only &&
+                    !has_workgroup_size_override)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "custom-direct-only ELF exports require a dispatch workgroup size "
+        "override");
+  }
+  if (has_workgroup_size_override) {
     for (iree_host_size_t i = 0; i < 3; ++i) {
       if (IREE_UNLIKELY(!config.workgroup_size[i])) {
         return iree_make_status(
@@ -2035,6 +2044,30 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_prepare_dispatch_plan(
   }
   out_plan->kernarg_strategy =
       IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STRATEGY_HAL;
+  if (out_plan->descriptor->custom_direct_only) {
+    if (IREE_UNLIKELY(
+            !iree_hal_amdgpu_dispatch_config_has_workgroup_size_override(
+                inputs->config))) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "custom-direct-only ELF exports require a dispatch workgroup size "
+          "override");
+    }
+    for (iree_host_size_t i = 0; i < 3; ++i) {
+      if (IREE_UNLIKELY(!inputs->config.workgroup_size[i])) {
+        return iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "dispatch workgroup size override must specify all dimensions");
+      }
+      if (IREE_UNLIKELY(inputs->config.workgroup_size[i] > UINT16_MAX)) {
+        return iree_make_status(
+            IREE_STATUS_OUT_OF_RANGE,
+            "dispatch workgroup size override dimension %" PRIhsz
+            " value %u exceeds %u",
+            i, inputs->config.workgroup_size[i], UINT16_MAX);
+      }
+    }
+  }
   if (IREE_UNLIKELY(out_plan->descriptor->custom_direct_only &&
                     !iree_hal_amdgpu_aql_dispatch_plan_uses_custom_direct_arguments(
                         out_plan))) {
@@ -2081,12 +2114,18 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_prepare_dispatch_plan(
     out_plan->kernarg_block_count =
         iree_max(1u, out_plan->descriptor->custom_kernarg_block_count);
     if (out_plan->layout->total_kernarg_size > 0) {
-      const uint32_t provided_kernarg_block_count =
-          (uint32_t)iree_host_size_ceil_div(
-              out_plan->layout->total_kernarg_size,
-              sizeof(iree_hal_amdgpu_kernarg_block_t));
+      const iree_host_size_t provided_kernarg_block_count =
+          iree_host_size_ceil_div(out_plan->layout->total_kernarg_size,
+                                  sizeof(iree_hal_amdgpu_kernarg_block_t));
+      if (IREE_UNLIKELY(provided_kernarg_block_count > UINT32_MAX)) {
+        return iree_make_status(
+            IREE_STATUS_OUT_OF_RANGE,
+            "dispatch kernargs require too many blocks (%" PRIhsz ", max=%u)",
+            provided_kernarg_block_count, UINT32_MAX);
+      }
       out_plan->kernarg_block_count =
-          iree_max(out_plan->kernarg_block_count, provided_kernarg_block_count);
+          iree_max(out_plan->kernarg_block_count,
+                   (uint32_t)provided_kernarg_block_count);
     }
     out_plan->kernarg_strategy =
         IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STRATEGY_CUSTOM_DIRECT;

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
@@ -1690,11 +1690,32 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_write_dispatch_tail(
       }
       return iree_ok_status();
     }
-    case IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STRATEGY_CUSTOM_DIRECT:
-      if (constants.data_length > 0) {
-        memcpy(tail_payload, constants.data, constants.data_length);
+    case IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STRATEGY_CUSTOM_DIRECT: {
+      // Custom-direct callers hand us a pre-packed HIP ABI blob. Some raw
+      // HSACO kernels also need an implicit suffix synthesized after that blob,
+      // so zero the full reservation before copying only caller-owned bytes.
+      const iree_host_size_t total_kernarg_size =
+          layout->total_kernarg_size ? layout->total_kernarg_size
+                                     : constants.data_length;
+      memset(tail_payload, 0, total_kernarg_size);
+      const iree_host_size_t explicit_bytes =
+          layout->has_implicit_args ? layout->implicit_args_offset
+                                    : total_kernarg_size;
+      const iree_host_size_t copy_bytes =
+          constants.data_length < explicit_bytes ? constants.data_length
+                                                 : explicit_bytes;
+      if (copy_bytes > 0) {
+        memcpy(tail_payload, constants.data, copy_bytes);
+      }
+      if (layout->has_implicit_args) {
+        iree_amdgpu_kernel_implicit_args_t* implicit_args =
+            (iree_amdgpu_kernel_implicit_args_t*)(tail_payload +
+                                                  layout->implicit_args_offset);
+        iree_hal_amdgpu_aql_command_buffer_write_implicit_args(
+            kernel_args, config, implicit_args);
       }
       return iree_ok_status();
+    }
     case IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STRATEGY_INDIRECT:
       return iree_make_status(
           IREE_STATUS_UNIMPLEMENTED,
@@ -2017,18 +2038,40 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_prepare_dispatch_plan(
 
   if (iree_hal_amdgpu_aql_dispatch_plan_uses_custom_direct_arguments(
           out_plan)) {
-    if (IREE_UNLIKELY(inputs->constants.data_length !=
-                      out_plan->descriptor->kernel_args.kernarg_size)) {
+    // Callers (e.g. rocBLAS/Tensile) sometimes omit trailing ABI padding or pad
+    // beyond the declared kernarg_segment_size with extra trailing scalars. The
+    // kernel only reads its declared size, so trailing bytes are ignored and the
+    // memcpy in write_dispatch_tail clamps to the declared size.
+    //
+    // Validate after 8-byte ABI padding so we accept missing tail padding while
+    // still rejecting truly short pre-packed HIP argument buffers.
+    const uint32_t required_explicit_bytes =
+        (uint32_t)out_plan->descriptor->custom_kernarg_layout
+            .explicit_kernarg_size;
+    const iree_host_size_t padded_constant_length =
+        iree_host_align(inputs->constants.data_length, /*alignment=*/8);
+    if (IREE_UNLIKELY(padded_constant_length < required_explicit_bytes)) {
       return iree_make_status(
           IREE_STATUS_INVALID_ARGUMENT,
-          "custom dispatch argument length mismatch; expected %u but got "
-          "%" PRIhsz,
-          out_plan->descriptor->kernel_args.kernarg_size,
-          inputs->constants.data_length);
+          "custom dispatch argument length too short; expected at least %u "
+          "but got %" PRIhsz " (padded to %" PRIhsz ")",
+          required_explicit_bytes, inputs->constants.data_length,
+          padded_constant_length);
     }
     out_plan->layout = &out_plan->descriptor->custom_kernarg_layout;
     out_plan->kernarg_block_count =
         iree_max(1u, out_plan->descriptor->custom_kernarg_block_count);
+    if (out_plan->layout->total_kernarg_size == 0 &&
+        inputs->constants.data_length > 0) {
+      // Some raw kernels have no reflected kernarg size. In that case the
+      // caller-provided blob is the only reservation size we can trust.
+      const uint32_t provided_kernarg_block_count =
+          (uint32_t)iree_host_size_ceil_div(
+              inputs->constants.data_length,
+              sizeof(iree_hal_amdgpu_kernarg_block_t));
+      out_plan->kernarg_block_count =
+          iree_max(out_plan->kernarg_block_count, provided_kernarg_block_count);
+    }
     out_plan->kernarg_strategy =
         IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STRATEGY_CUSTOM_DIRECT;
     return iree_ok_status();
@@ -2102,14 +2145,18 @@ iree_hal_amdgpu_aql_command_buffer_calculate_dispatch_layout(
           ? 0
           : (iree_host_size_t)plan->kernel_args->binding_count *
                 sizeof(uint64_t);
-  const iree_host_size_t tail_byte_length =
-      plan->layout->total_kernarg_size - binding_bytes;
+  const iree_host_size_t total_kernarg_size =
+      iree_hal_amdgpu_aql_dispatch_plan_uses_custom_direct_arguments(plan) &&
+              plan->layout->total_kernarg_size == 0
+          ? inputs->constants.data_length
+          : plan->layout->total_kernarg_size;
+  const iree_host_size_t tail_byte_length = total_kernarg_size - binding_bytes;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_aql_command_buffer_qword_length(
       tail_byte_length, "dispatch tail payload",
       &out_layout->kernarg.tail_length_qwords,
       &out_layout->kernarg.tail_padded_length));
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_aql_command_buffer_qword_length(
-      plan->layout->total_kernarg_size, "dispatch kernarg",
+      total_kernarg_size, "dispatch kernarg",
       &out_layout->kernarg.total_length_qwords,
       &out_layout->kernarg.total_padded_length));
   out_layout->kernarg.implicit_args_offset_qwords =

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
@@ -1691,21 +1691,15 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_write_dispatch_tail(
       return iree_ok_status();
     }
     case IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STRATEGY_CUSTOM_DIRECT: {
-      // Custom-direct callers hand us a pre-packed HIP ABI blob. Some raw
-      // HSACO kernels also need an implicit suffix synthesized after that blob,
-      // so zero the full reservation before copying only caller-owned bytes.
-      const iree_host_size_t total_kernarg_size =
-          layout->total_kernarg_size ? layout->total_kernarg_size
-                                     : constants.data_length;
-      memset(tail_payload, 0, total_kernarg_size);
-      const iree_host_size_t explicit_bytes =
-          layout->has_implicit_args ? layout->implicit_args_offset
-                                    : total_kernarg_size;
+      const iree_host_size_t explicit_bytes = layout->explicit_kernarg_size;
       const iree_host_size_t copy_bytes =
           constants.data_length < explicit_bytes ? constants.data_length
                                                  : explicit_bytes;
       if (copy_bytes > 0) {
         memcpy(tail_payload, constants.data, copy_bytes);
+      }
+      if (copy_bytes < explicit_bytes) {
+        memset(tail_payload + copy_bytes, 0, explicit_bytes - copy_bytes);
       }
       if (layout->has_implicit_args) {
         iree_amdgpu_kernel_implicit_args_t* implicit_args =
@@ -1713,6 +1707,13 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_write_dispatch_tail(
                                                   layout->implicit_args_offset);
         iree_hal_amdgpu_aql_command_buffer_write_implicit_args(
             kernel_args, config, implicit_args);
+        const iree_host_size_t implicit_args_end =
+            layout->implicit_args_offset +
+            IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE;
+        if (layout->total_kernarg_size > implicit_args_end) {
+          memset(tail_payload + implicit_args_end, 0,
+                 layout->total_kernarg_size - implicit_args_end);
+        }
       }
       return iree_ok_status();
     }
@@ -1901,6 +1902,11 @@ typedef struct iree_hal_amdgpu_aql_dispatch_plan_t {
   // Kernarg layout selected for HAL or custom-direct arguments.
   const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* layout;
 
+  // Resolved per-dispatch custom-direct layout. Used when descriptor metadata
+  // leaves the raw kernarg size dynamic and the caller-provided byte length is
+  // the only exact reservation size.
+  iree_hal_amdgpu_device_dispatch_kernarg_layout_t custom_layout;
+
   // Number of kernarg blocks required by the selected descriptor path.
   uint32_t kernarg_block_count;
 
@@ -2058,16 +2064,19 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_prepare_dispatch_plan(
           required_explicit_bytes, inputs->constants.data_length,
           padded_constant_length);
     }
-    out_plan->layout = &out_plan->descriptor->custom_kernarg_layout;
+    out_plan->custom_layout = out_plan->descriptor->custom_kernarg_layout;
+    if (out_plan->custom_layout.total_kernarg_size == 0) {
+      out_plan->custom_layout.explicit_kernarg_size =
+          inputs->constants.data_length;
+      out_plan->custom_layout.total_kernarg_size = inputs->constants.data_length;
+    }
+    out_plan->layout = &out_plan->custom_layout;
     out_plan->kernarg_block_count =
         iree_max(1u, out_plan->descriptor->custom_kernarg_block_count);
-    if (out_plan->layout->total_kernarg_size == 0 &&
-        inputs->constants.data_length > 0) {
-      // Some raw kernels have no reflected kernarg size. In that case the
-      // caller-provided blob is the only reservation size we can trust.
+    if (out_plan->layout->total_kernarg_size > 0) {
       const uint32_t provided_kernarg_block_count =
           (uint32_t)iree_host_size_ceil_div(
-              inputs->constants.data_length,
+              out_plan->layout->total_kernarg_size,
               sizeof(iree_hal_amdgpu_kernarg_block_t));
       out_plan->kernarg_block_count =
           iree_max(out_plan->kernarg_block_count, provided_kernarg_block_count);
@@ -2145,11 +2154,14 @@ iree_hal_amdgpu_aql_command_buffer_calculate_dispatch_layout(
           ? 0
           : (iree_host_size_t)plan->kernel_args->binding_count *
                 sizeof(uint64_t);
-  const iree_host_size_t total_kernarg_size =
-      iree_hal_amdgpu_aql_dispatch_plan_uses_custom_direct_arguments(plan) &&
-              plan->layout->total_kernarg_size == 0
-          ? inputs->constants.data_length
-          : plan->layout->total_kernarg_size;
+  const iree_host_size_t total_kernarg_size = plan->layout->total_kernarg_size;
+  if (IREE_UNLIKELY(total_kernarg_size < binding_bytes)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "dispatch kernarg size %" PRIhsz
+        " is smaller than binding table size %" PRIhsz,
+        total_kernarg_size, binding_bytes);
+  }
   const iree_host_size_t tail_byte_length = total_kernarg_size - binding_bytes;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_aql_command_buffer_qword_length(
       tail_byte_length, "dispatch tail payload",

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
@@ -1701,9 +1701,9 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_write_dispatch_tail(
     }
     case IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STRATEGY_CUSTOM_DIRECT: {
       const iree_host_size_t explicit_bytes = layout->explicit_kernarg_size;
-      const iree_host_size_t copy_bytes =
-          constants.data_length < explicit_bytes ? constants.data_length
-                                                 : explicit_bytes;
+      const iree_host_size_t copy_bytes = constants.data_length < explicit_bytes
+                                              ? constants.data_length
+                                              : explicit_bytes;
       if (copy_bytes > 0) {
         memcpy(tail_payload, constants.data, copy_bytes);
       }
@@ -2068,9 +2068,10 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_prepare_dispatch_plan(
       }
     }
   }
-  if (IREE_UNLIKELY(out_plan->descriptor->custom_direct_only &&
-                    !iree_hal_amdgpu_aql_dispatch_plan_uses_custom_direct_arguments(
-                        out_plan))) {
+  if (IREE_UNLIKELY(
+          out_plan->descriptor->custom_direct_only &&
+          !iree_hal_amdgpu_aql_dispatch_plan_uses_custom_direct_arguments(
+              out_plan))) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
         "dispatch export requires custom direct kernarg arguments");
@@ -2086,14 +2087,14 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_prepare_dispatch_plan(
           out_plan)) {
     // Callers (e.g. rocBLAS/Tensile) sometimes omit trailing ABI padding or pad
     // beyond the declared kernarg_segment_size with extra trailing scalars. The
-    // kernel only reads its declared size, so trailing bytes are ignored and the
-    // memcpy in write_dispatch_tail clamps to the declared size.
+    // kernel only reads its declared size, so trailing bytes are ignored and
+    // the memcpy in write_dispatch_tail clamps to the declared size.
     //
     // Validate after 8-byte ABI padding so we accept missing tail padding while
     // still rejecting truly short pre-packed HIP argument buffers.
     const uint32_t required_explicit_bytes =
-        (uint32_t)out_plan->descriptor->custom_kernarg_layout
-            .explicit_kernarg_size;
+        (uint32_t)
+            out_plan->descriptor->custom_kernarg_layout.explicit_kernarg_size;
     const iree_host_size_t padded_constant_length =
         iree_host_align(inputs->constants.data_length, /*alignment=*/8);
     if (IREE_UNLIKELY(padded_constant_length < required_explicit_bytes)) {
@@ -2108,7 +2109,8 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_prepare_dispatch_plan(
     if (out_plan->custom_layout.total_kernarg_size == 0) {
       out_plan->custom_layout.explicit_kernarg_size =
           inputs->constants.data_length;
-      out_plan->custom_layout.total_kernarg_size = inputs->constants.data_length;
+      out_plan->custom_layout.total_kernarg_size =
+          inputs->constants.data_length;
     }
     out_plan->layout = &out_plan->custom_layout;
     out_plan->kernarg_block_count =
@@ -2202,11 +2204,10 @@ iree_hal_amdgpu_aql_command_buffer_calculate_dispatch_layout(
                 sizeof(uint64_t);
   const iree_host_size_t total_kernarg_size = plan->layout->total_kernarg_size;
   if (IREE_UNLIKELY(total_kernarg_size < binding_bytes)) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "dispatch kernarg size %" PRIhsz
-        " is smaller than binding table size %" PRIhsz,
-        total_kernarg_size, binding_bytes);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "dispatch kernarg size %" PRIhsz
+                            " is smaller than binding table size %" PRIhsz,
+                            total_kernarg_size, binding_bytes);
   }
   const iree_host_size_t tail_byte_length = total_kernarg_size - binding_bytes;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_aql_command_buffer_qword_length(

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.c
@@ -42,7 +42,7 @@ void iree_hal_amdgpu_device_dispatch_emplace_packet(
 // Dispatch kernarg emission
 //===----------------------------------------------------------------------===//
 
-static void iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
+void iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
     const iree_hal_amdgpu_device_kernel_args_t* IREE_AMDGPU_RESTRICT
         kernel_args,
     const uint32_t workgroup_count[3], uint32_t dynamic_workgroup_local_memory,
@@ -70,7 +70,6 @@ static void iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
 void iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
     const iree_hal_amdgpu_device_kernel_args_t* IREE_AMDGPU_RESTRICT
         kernel_args,
-    const uint32_t workgroup_count[3], uint32_t dynamic_workgroup_local_memory,
     const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* IREE_AMDGPU_RESTRICT
         layout,
     const uint64_t* IREE_AMDGPU_RESTRICT binding_ptrs,
@@ -89,16 +88,9 @@ void iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
     iree_amdgpu_memcpy((uint8_t*)kernarg_ptr + binding_bytes, constants,
                        constant_bytes);
   }
-
-  iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
-      kernel_args, workgroup_count, dynamic_workgroup_local_memory, layout,
-      kernarg_ptr);
 }
 
 void iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
-    const iree_hal_amdgpu_device_kernel_args_t* IREE_AMDGPU_RESTRICT
-        kernel_args,
-    const uint32_t workgroup_count[3], uint32_t dynamic_workgroup_local_memory,
     const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* IREE_AMDGPU_RESTRICT
         layout,
     const void* IREE_AMDGPU_RESTRICT custom_kernarg_ptr,
@@ -120,10 +112,6 @@ void iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
       iree_amdgpu_memcpy(kernarg_ptr, custom_kernarg_ptr, copy_bytes);
     }
   }
-
-  iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
-      kernel_args, workgroup_count, dynamic_workgroup_local_memory, layout,
-      kernarg_ptr);
 }
 
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.c
@@ -94,19 +94,18 @@ void iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
     const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* IREE_AMDGPU_RESTRICT
         layout,
     const void* IREE_AMDGPU_RESTRICT custom_kernarg_ptr,
-    size_t custom_kernarg_length,
-    void* IREE_AMDGPU_RESTRICT kernarg_ptr) {
-  const size_t total_kernarg_size =
-      layout->total_kernarg_size ? layout->total_kernarg_size
-                                 : custom_kernarg_length;
+    size_t custom_kernarg_length, void* IREE_AMDGPU_RESTRICT kernarg_ptr) {
+  const size_t total_kernarg_size = layout->total_kernarg_size
+                                        ? layout->total_kernarg_size
+                                        : custom_kernarg_length;
   if (total_kernarg_size > 0) {
     iree_amdgpu_memset(kernarg_ptr, 0, total_kernarg_size);
-    const size_t explicit_bytes =
-        layout->explicit_kernarg_size ? layout->explicit_kernarg_size
+    const size_t explicit_bytes = layout->explicit_kernarg_size
+                                      ? layout->explicit_kernarg_size
                                       : total_kernarg_size;
-    const size_t copy_bytes =
-        custom_kernarg_length < explicit_bytes ? custom_kernarg_length
-                                               : explicit_bytes;
+    const size_t copy_bytes = custom_kernarg_length < explicit_bytes
+                                  ? custom_kernarg_length
+                                  : explicit_bytes;
     if (copy_bytes > 0) {
       iree_amdgpu_memcpy(kernarg_ptr, custom_kernarg_ptr, copy_bytes);
     }

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.c
@@ -102,9 +102,8 @@ void iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
   if (total_kernarg_size > 0) {
     iree_amdgpu_memset(kernarg_ptr, 0, total_kernarg_size);
     const size_t explicit_bytes =
-        layout->has_implicit_args
-            ? layout->implicit_args_offset
-            : total_kernarg_size;
+        layout->explicit_kernarg_size ? layout->explicit_kernarg_size
+                                      : total_kernarg_size;
     const size_t copy_bytes =
         custom_kernarg_length < explicit_bytes ? custom_kernarg_length
                                                : explicit_bytes;

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.c
@@ -96,14 +96,34 @@ void iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
 }
 
 void iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
+    const iree_hal_amdgpu_device_kernel_args_t* IREE_AMDGPU_RESTRICT
+        kernel_args,
+    const uint32_t workgroup_count[3], uint32_t dynamic_workgroup_local_memory,
     const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* IREE_AMDGPU_RESTRICT
         layout,
     const void* IREE_AMDGPU_RESTRICT custom_kernarg_ptr,
+    size_t custom_kernarg_length,
     void* IREE_AMDGPU_RESTRICT kernarg_ptr) {
-  if (layout->total_kernarg_size > 0) {
-    iree_amdgpu_memcpy(kernarg_ptr, custom_kernarg_ptr,
-                       layout->total_kernarg_size);
+  const size_t total_kernarg_size =
+      layout->total_kernarg_size ? layout->total_kernarg_size
+                                 : custom_kernarg_length;
+  if (total_kernarg_size > 0) {
+    iree_amdgpu_memset(kernarg_ptr, 0, total_kernarg_size);
+    const size_t explicit_bytes =
+        layout->has_implicit_args
+            ? layout->implicit_args_offset
+            : total_kernarg_size;
+    const size_t copy_bytes =
+        custom_kernarg_length < explicit_bytes ? custom_kernarg_length
+                                               : explicit_bytes;
+    if (copy_bytes > 0) {
+      iree_amdgpu_memcpy(kernarg_ptr, custom_kernarg_ptr, copy_bytes);
+    }
   }
+
+  iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
+      kernel_args, workgroup_count, dynamic_workgroup_local_memory, layout,
+      kernarg_ptr);
 }
 
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
@@ -136,7 +136,26 @@ void iree_hal_amdgpu_device_dispatch_emplace_packet(
     iree_hsa_kernel_dispatch_packet_t* IREE_AMDGPU_RESTRICT dispatch_packet,
     void* IREE_AMDGPU_RESTRICT kernarg_ptr);
 
-// Populates HAL ABI kernargs in already-reserved storage.
+// Populates the HIP/OpenCL implicit args suffix in already-reserved storage.
+//
+// This must be called after explicit HAL/custom kernargs have been populated
+// whenever |layout->has_implicit_args| is true.
+//
+// Preconditions:
+//   - |kernel_args|, |workgroup_count|, |layout|, and |kernarg_ptr| are
+//     non-NULL.
+//   - |layout| describes a reservation with an implicit suffix.
+//   - |kernarg_ptr| points to at least |layout->total_kernarg_size| bytes of
+//     writable storage.
+void iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
+    const iree_hal_amdgpu_device_kernel_args_t* IREE_AMDGPU_RESTRICT
+        kernel_args,
+    const uint32_t workgroup_count[3], uint32_t dynamic_workgroup_local_memory,
+    const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* IREE_AMDGPU_RESTRICT
+        layout,
+    void* IREE_AMDGPU_RESTRICT kernarg_ptr);
+
+// Populates HAL ABI explicit kernargs in already-reserved storage.
 //
 // |binding_ptrs| must provide |kernel_args->binding_count| device pointers as
 // raw 64-bit values. |constants| must provide
@@ -153,31 +172,26 @@ void iree_hal_amdgpu_device_dispatch_emplace_packet(
 void iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
     const iree_hal_amdgpu_device_kernel_args_t* IREE_AMDGPU_RESTRICT
         kernel_args,
-    const uint32_t workgroup_count[3], uint32_t dynamic_workgroup_local_memory,
     const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* IREE_AMDGPU_RESTRICT
         layout,
     const uint64_t* IREE_AMDGPU_RESTRICT binding_ptrs,
     const uint32_t* IREE_AMDGPU_RESTRICT constants,
     void* IREE_AMDGPU_RESTRICT kernarg_ptr);
 
-// Populates custom direct kernargs in already-reserved storage.
+// Populates custom direct explicit kernargs in already-reserved storage.
 //
 // |custom_kernarg_ptr| provides up to |layout->total_kernarg_size| bytes in the
 // final kernel ABI shape expected by the target kernel. Missing trailing padding
 // bytes remain zeroed.
 //
 // Preconditions:
-//   - |kernel_args|, |workgroup_count|, |layout|, and |kernarg_ptr| are
-//     non-NULL.
+//   - |layout| and |kernarg_ptr| are non-NULL.
 //   - |layout| describes either a fixed custom-direct reservation with optional
 //     implicit suffix storage or a dynamic custom-direct reservation where
 //     |layout->total_kernarg_size == 0| and |custom_kernarg_length| determines
 //     the reservation size.
 //   - |custom_kernarg_ptr| is non-NULL when |custom_kernarg_length| > 0.
 void iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
-    const iree_hal_amdgpu_device_kernel_args_t* IREE_AMDGPU_RESTRICT
-        kernel_args,
-    const uint32_t workgroup_count[3], uint32_t dynamic_workgroup_local_memory,
     const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* IREE_AMDGPU_RESTRICT
         layout,
     const void* IREE_AMDGPU_RESTRICT custom_kernarg_ptr,

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
@@ -86,10 +86,11 @@ iree_hal_amdgpu_device_dispatch_make_hal_kernarg_layout(
 static inline iree_hal_amdgpu_device_dispatch_kernarg_layout_t
 iree_hal_amdgpu_device_dispatch_make_custom_kernarg_layout(
     size_t kernarg_size) {
+  (void)kernarg_size;
   return (iree_hal_amdgpu_device_dispatch_kernarg_layout_t){
-      .explicit_kernarg_size = kernarg_size,
-      .implicit_args_offset = kernarg_size,
-      .total_kernarg_size = kernarg_size,
+      .explicit_kernarg_size = 0,
+      .implicit_args_offset = 0,
+      .total_kernarg_size = 0,
       .has_implicit_args = false,
   };
 }
@@ -178,18 +179,24 @@ void iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
 
 // Populates custom direct kernargs in already-reserved storage.
 //
-// |custom_kernarg_ptr| must provide |layout->total_kernarg_size| bytes in the
-// final kernel ABI shape expected by the target kernel.
+// |custom_kernarg_ptr| provides up to |layout->total_kernarg_size| bytes in the
+// final kernel ABI shape expected by the target kernel. Missing trailing padding
+// bytes remain zeroed.
 //
 // Preconditions:
-//   - |layout| and |kernarg_ptr| are non-NULL.
+//   - |kernel_args|, |workgroup_count|, |layout|, and |kernarg_ptr| are
+//     non-NULL.
 //   - |layout| was derived with
 //     iree_hal_amdgpu_device_dispatch_make_custom_kernarg_layout.
-//   - |custom_kernarg_ptr| is non-NULL when |layout->total_kernarg_size| > 0.
+//   - |custom_kernarg_ptr| is non-NULL when |custom_kernarg_length| > 0.
 void iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
+    const iree_hal_amdgpu_device_kernel_args_t* IREE_AMDGPU_RESTRICT
+        kernel_args,
+    const uint32_t workgroup_count[3], uint32_t dynamic_workgroup_local_memory,
     const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* IREE_AMDGPU_RESTRICT
         layout,
     const void* IREE_AMDGPU_RESTRICT custom_kernarg_ptr,
+    size_t custom_kernarg_length,
     void* IREE_AMDGPU_RESTRICT kernarg_ptr);
 
 // Populates the builtin patch dispatch that updates an indirect-parameter

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
@@ -78,23 +78,6 @@ iree_hal_amdgpu_device_dispatch_make_hal_kernarg_layout(
   };
 }
 
-// Returns a custom-direct-argument layout for a raw kernarg blob of
-// |kernarg_size| bytes.
-//
-// The caller owns all packing and padding in the raw argument blob. No implicit
-// suffix is synthesized in this mode.
-static inline iree_hal_amdgpu_device_dispatch_kernarg_layout_t
-iree_hal_amdgpu_device_dispatch_make_custom_kernarg_layout(
-    size_t kernarg_size) {
-  (void)kernarg_size;
-  return (iree_hal_amdgpu_device_dispatch_kernarg_layout_t){
-      .explicit_kernarg_size = 0,
-      .implicit_args_offset = 0,
-      .total_kernarg_size = 0,
-      .has_implicit_args = false,
-  };
-}
-
 //===----------------------------------------------------------------------===//
 // Dispatch Packet/Kernarg Emission
 //===----------------------------------------------------------------------===//
@@ -186,8 +169,10 @@ void iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
 // Preconditions:
 //   - |kernel_args|, |workgroup_count|, |layout|, and |kernarg_ptr| are
 //     non-NULL.
-//   - |layout| was derived with
-//     iree_hal_amdgpu_device_dispatch_make_custom_kernarg_layout.
+//   - |layout| describes either a fixed custom-direct reservation with optional
+//     implicit suffix storage or a dynamic custom-direct reservation where
+//     |layout->total_kernarg_size == 0| and |custom_kernarg_length| determines
+//     the reservation size.
 //   - |custom_kernarg_ptr| is non-NULL when |custom_kernarg_length| > 0.
 void iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
     const iree_hal_amdgpu_device_kernel_args_t* IREE_AMDGPU_RESTRICT

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
@@ -181,8 +181,8 @@ void iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
 // Populates custom direct explicit kernargs in already-reserved storage.
 //
 // |custom_kernarg_ptr| provides up to |layout->total_kernarg_size| bytes in the
-// final kernel ABI shape expected by the target kernel. Missing trailing padding
-// bytes remain zeroed.
+// final kernel ABI shape expected by the target kernel. Missing trailing
+// padding bytes remain zeroed.
 //
 // Preconditions:
 //   - |layout| and |kernarg_ptr| are non-NULL.
@@ -195,8 +195,7 @@ void iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
     const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* IREE_AMDGPU_RESTRICT
         layout,
     const void* IREE_AMDGPU_RESTRICT custom_kernarg_ptr,
-    size_t custom_kernarg_length,
-    void* IREE_AMDGPU_RESTRICT kernarg_ptr);
+    size_t custom_kernarg_length, void* IREE_AMDGPU_RESTRICT kernarg_ptr);
 
 // Populates the builtin patch dispatch that updates an indirect-parameter
 // dispatch packet and then publishes its header.

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch_test.cc
@@ -111,9 +111,10 @@ TEST(DispatchTest, EmplaceHalKernargsWritesBindingsConstantsAndImplicitArgs) {
   kernargs.fill(0xFD);
 
   iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
-      &kernel_args, workgroup_count,
-      /*dynamic_workgroup_local_memory=*/13, &layout, bindings, constants,
-      kernargs.data());
+      &kernel_args, &layout, bindings, constants, kernargs.data());
+  iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
+      &kernel_args, workgroup_count, /*dynamic_workgroup_local_memory=*/13,
+      &layout, kernargs.data());
 
   const uint64_t* binding_words =
       reinterpret_cast<const uint64_t*>(kernargs.data());
@@ -158,10 +159,6 @@ TEST(DispatchTest, EmplaceHalKernargsWritesBindingsConstantsAndImplicitArgs) {
 }
 
 TEST(DispatchTest, EmplaceCustomKernargsCopiesRawBlob) {
-  iree_hal_amdgpu_device_kernel_args_t kernel_args =
-      MakeKernelArgs(/*kernel_object=*/0x1234u, /*kernarg_size=*/20,
-                     /*kernarg_alignment=*/16, /*binding_count=*/0,
-                     /*constant_count=*/0);
   iree_hal_amdgpu_device_dispatch_kernarg_layout_t layout = {};
   const std::array<uint8_t, 20> custom_kernargs = {
       0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
@@ -170,11 +167,8 @@ TEST(DispatchTest, EmplaceCustomKernargsCopiesRawBlob) {
   alignas(16) std::array<uint8_t, 32> kernargs = {};
   kernargs.fill(0xFD);
 
-  const uint32_t workgroup_count[3] = {7, 8, 9};
   iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
-      &kernel_args, workgroup_count, /*dynamic_workgroup_local_memory=*/13,
-      &layout, custom_kernargs.data(), custom_kernargs.size(),
-      kernargs.data());
+      &layout, custom_kernargs.data(), custom_kernargs.size(), kernargs.data());
 
   EXPECT_EQ(std::memcmp(kernargs.data(), custom_kernargs.data(),
                         custom_kernargs.size()),

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch_test.cc
@@ -162,8 +162,7 @@ TEST(DispatchTest, EmplaceCustomKernargsCopiesRawBlob) {
       MakeKernelArgs(/*kernel_object=*/0x1234u, /*kernarg_size=*/20,
                      /*kernarg_alignment=*/16, /*binding_count=*/0,
                      /*constant_count=*/0);
-  iree_hal_amdgpu_device_dispatch_kernarg_layout_t layout =
-      iree_hal_amdgpu_device_dispatch_make_custom_kernarg_layout(20);
+  iree_hal_amdgpu_device_dispatch_kernarg_layout_t layout = {};
   const std::array<uint8_t, 20> custom_kernargs = {
       0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
       0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13,

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch_test.cc
@@ -158,6 +158,10 @@ TEST(DispatchTest, EmplaceHalKernargsWritesBindingsConstantsAndImplicitArgs) {
 }
 
 TEST(DispatchTest, EmplaceCustomKernargsCopiesRawBlob) {
+  iree_hal_amdgpu_device_kernel_args_t kernel_args =
+      MakeKernelArgs(/*kernel_object=*/0x1234u, /*kernarg_size=*/20,
+                     /*kernarg_alignment=*/16, /*binding_count=*/0,
+                     /*constant_count=*/0);
   iree_hal_amdgpu_device_dispatch_kernarg_layout_t layout =
       iree_hal_amdgpu_device_dispatch_make_custom_kernarg_layout(20);
   const std::array<uint8_t, 20> custom_kernargs = {
@@ -167,8 +171,11 @@ TEST(DispatchTest, EmplaceCustomKernargsCopiesRawBlob) {
   alignas(16) std::array<uint8_t, 32> kernargs = {};
   kernargs.fill(0xFD);
 
+  const uint32_t workgroup_count[3] = {7, 8, 9};
   iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
-      &layout, custom_kernargs.data(), kernargs.data());
+      &kernel_args, workgroup_count, /*dynamic_workgroup_local_memory=*/13,
+      &layout, custom_kernargs.data(), custom_kernargs.size(),
+      kernargs.data());
 
   EXPECT_EQ(std::memcmp(kernargs.data(), custom_kernargs.data(),
                         custom_kernargs.size()),

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -1139,9 +1139,11 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_dispatch_descriptor(
       &out_descriptor->hal_kernarg_layout,
       &out_descriptor->hal_kernarg_block_count));
 
+  // Dynamic custom-direct layout: callers provide a prepacked ABI blob and its
+  // length at dispatch time. Fixed fields are only needed when the metadata
+  // requires an implicit suffix we must synthesize.
   out_descriptor->custom_kernarg_layout =
-      iree_hal_amdgpu_device_dispatch_make_custom_kernarg_layout(
-          kernel_args->kernarg_size);
+      (iree_hal_amdgpu_device_dispatch_kernarg_layout_t){0};
   if (custom_implicit_args_offset != UINT16_MAX) {
     out_descriptor->custom_kernarg_layout.explicit_kernarg_size =
         custom_implicit_args_offset;

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -1591,7 +1591,7 @@ static iree_status_t iree_hal_amdgpu_executable_calculate_reflection_storage(
 
     iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
     IREE_RETURN_IF_ERROR(
-        iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
+        iree_hal_amdgpu_hsaco_metadata_calculate_flatbuffer_hal_export_parameter_requirements(
             kernel, &requirements),
         "projecting HSACO parameters for export `%.*s`", (int)symbol_name.size,
         symbol_name.data);
@@ -1692,7 +1692,7 @@ iree_hal_amdgpu_executable_calculate_raw_hsaco_reflection_storage(
 
     iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
     IREE_RETURN_IF_ERROR(
-        iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
+        iree_hal_amdgpu_hsaco_metadata_calculate_native_kernarg_export_parameter_requirements(
             kernel, &requirements),
         "projecting HSACO parameters for raw kernel `%.*s`",
         (int)kernel->symbol_name.size, kernel->symbol_name.data);
@@ -1740,7 +1740,7 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_export_infos(
 
     iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
     IREE_RETURN_IF_ERROR(
-        iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
+        iree_hal_amdgpu_hsaco_metadata_calculate_flatbuffer_hal_export_parameter_requirements(
             kernel, &requirements),
         "projecting HSACO parameters for export `%.*s`", (int)symbol_name.size,
         symbol_name.data);
@@ -1779,7 +1779,7 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_export_infos(
     char* export_parameter_name_base =
         requirements.name_storage_size ? export_parameter_name_storage : NULL;
     IREE_RETURN_IF_ERROR(
-        iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
+        iree_hal_amdgpu_hsaco_metadata_populate_flatbuffer_hal_export_parameters(
             kernel, requirements.parameter_count, export_parameter_base,
             requirements.name_storage_size, export_parameter_name_base),
         "populating reflected parameters for export `%.*s`",
@@ -1809,7 +1809,7 @@ iree_hal_amdgpu_executable_initialize_raw_hsaco_export_infos(
 
     iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
     IREE_RETURN_IF_ERROR(
-        iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
+        iree_hal_amdgpu_hsaco_metadata_calculate_native_kernarg_export_parameter_requirements(
             kernel, &requirements),
         "projecting HSACO parameters for raw kernel `%.*s`",
         (int)kernel->symbol_name.size, kernel->symbol_name.data);
@@ -1838,7 +1838,7 @@ iree_hal_amdgpu_executable_initialize_raw_hsaco_export_infos(
     char* export_parameter_name_base =
         requirements.name_storage_size ? export_parameter_name_storage : NULL;
     IREE_RETURN_IF_ERROR(
-        iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
+        iree_hal_amdgpu_hsaco_metadata_populate_native_kernarg_export_parameters(
             kernel, requirements.parameter_count, export_parameter_base,
             requirements.name_storage_size, export_parameter_name_base),
         "populating reflected parameters for raw kernel `%.*s`",
@@ -1918,7 +1918,7 @@ static iree_status_t iree_hal_amdgpu_executable_resolve_raw_hsaco_kernel_args(
 
   iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
   IREE_RETURN_IF_ERROR(
-      iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
+      iree_hal_amdgpu_hsaco_metadata_calculate_native_kernarg_export_parameter_requirements(
           kernel, &requirements),
       "projecting HSACO parameters for raw kernel `%.*s`",
       (int)symbol_name.size, symbol_name.data);

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -1107,6 +1107,7 @@ static iree_status_t iree_hal_amdgpu_executable_calculate_kernarg_block_count(
 
 static iree_status_t iree_hal_amdgpu_executable_initialize_dispatch_descriptor(
     const iree_hal_amdgpu_device_kernel_args_t* kernel_args,
+    iree_host_size_t custom_explicit_kernarg_size,
     uint16_t custom_implicit_args_offset,
     iree_hal_amdgpu_executable_dispatch_descriptor_t* out_descriptor) {
   memset(out_descriptor, 0, sizeof(*out_descriptor));
@@ -1143,8 +1144,21 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_dispatch_descriptor(
   // length at dispatch time. Fixed fields are only needed when the metadata
   // requires an implicit suffix we must synthesize.
   out_descriptor->custom_kernarg_layout =
-      (iree_hal_amdgpu_device_dispatch_kernarg_layout_t){0};
+      (iree_hal_amdgpu_device_dispatch_kernarg_layout_t){
+          .explicit_kernarg_size = custom_explicit_kernarg_size,
+      };
   if (custom_implicit_args_offset != UINT16_MAX) {
+    if (IREE_UNLIKELY(custom_explicit_kernarg_size >
+                      custom_implicit_args_offset)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "custom explicit kernargs end at %" PRIhsz
+          " beyond implicit args offset %u",
+          custom_explicit_kernarg_size, custom_implicit_args_offset);
+    }
+    // Custom-direct callers own all bytes before the implicit suffix; requiring
+    // the suffix offset rejects truly short prepacked buffers while still
+    // allowing missing trailing ABI padding inside that explicit region.
     out_descriptor->custom_kernarg_layout.explicit_kernarg_size =
         custom_implicit_args_offset;
     out_descriptor->custom_kernarg_layout.implicit_args_offset =
@@ -1428,17 +1442,23 @@ static void iree_hal_amdgpu_executable_invalidate_host_kernel_objects(
 static iree_status_t
 iree_hal_amdgpu_executable_initialize_dispatch_descriptors_for_device(
     iree_hal_amdgpu_executable_t* executable, iree_host_size_t device_ordinal,
+    const iree_host_size_t* custom_explicit_kernarg_sizes,
     const uint16_t* custom_implicit_args_offsets) {
   for (iree_host_size_t kernel_ordinal = 0;
        kernel_ordinal < executable->kernel_count; ++kernel_ordinal) {
     const iree_host_size_t descriptor_ordinal =
         device_ordinal * executable->kernel_count + kernel_ordinal;
+    const iree_host_size_t custom_explicit_kernarg_size =
+        custom_explicit_kernarg_sizes
+            ? custom_explicit_kernarg_sizes[kernel_ordinal]
+            : executable->host_kernel_args[kernel_ordinal].kernarg_size;
     const uint16_t custom_implicit_args_offset =
         custom_implicit_args_offsets ? custom_implicit_args_offsets[kernel_ordinal]
                                      : UINT16_MAX;
     IREE_RETURN_IF_ERROR(
         iree_hal_amdgpu_executable_initialize_dispatch_descriptor(
             &executable->host_kernel_args[kernel_ordinal],
+            custom_explicit_kernarg_size,
             custom_implicit_args_offset,
             &executable->host_dispatch_descriptors[descriptor_ordinal]),
         "initializing dispatch descriptor for device %" PRIhsz
@@ -1946,14 +1966,17 @@ static iree_status_t iree_hal_amdgpu_executable_resolve_raw_hsaco_kernel_args(
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_amdgpu_executable_raw_hsaco_implicit_args_offset(
+static iree_status_t
+iree_hal_amdgpu_executable_raw_hsaco_custom_kernarg_layout(
     const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
     const iree_hal_amdgpu_device_kernel_args_t* kernel_args,
+    iree_host_size_t* out_explicit_kernarg_size,
     uint16_t* out_implicit_args_offset) {
+  *out_explicit_kernarg_size = 0;
   *out_implicit_args_offset = UINT16_MAX;
   iree_string_view_t symbol_name = kernel->symbol_name;
   uint16_t implicit_args_offset = UINT16_MAX;
-  uint32_t explicit_args_end = 0;
+  iree_host_size_t explicit_args_end = 0;
   for (iree_host_size_t arg_i = 0; arg_i < kernel->arg_count; ++arg_i) {
     const iree_hal_amdgpu_hsaco_metadata_arg_t* arg = &kernel->args[arg_i];
     if (arg->kind == IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN ||
@@ -1972,15 +1995,19 @@ static iree_status_t iree_hal_amdgpu_executable_raw_hsaco_implicit_args_offset(
             "AMDGPU kernel `%.*s` argument offset overflows",
             (int)symbol_name.size, symbol_name.data);
       }
-      explicit_args_end = iree_max(explicit_args_end, (uint32_t)arg_end);
+      explicit_args_end = iree_max(explicit_args_end, arg_end);
     }
   }
   if (implicit_args_offset != UINT16_MAX && implicit_args_offset > 0) {
+    *out_explicit_kernarg_size = implicit_args_offset;
     *out_implicit_args_offset = implicit_args_offset;
-  } else if (explicit_args_end <= UINT16_MAX &&
-             kernel_args->kernarg_size >=
-                 explicit_args_end + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE) {
-    *out_implicit_args_offset = (uint16_t)explicit_args_end;
+  } else {
+    *out_explicit_kernarg_size = explicit_args_end;
+    if (explicit_args_end <= UINT16_MAX &&
+        kernel_args->kernarg_size >=
+            explicit_args_end + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE) {
+      *out_implicit_args_offset = (uint16_t)explicit_args_end;
+    }
   }
   return iree_ok_status();
 }
@@ -2096,6 +2123,7 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_flatbuffer(
       status =
           iree_hal_amdgpu_executable_initialize_dispatch_descriptors_for_device(
               executable, device_ordinal,
+              /*custom_explicit_kernarg_sizes=*/NULL,
               /*custom_implicit_args_offsets=*/NULL);
     }
   }
@@ -2179,8 +2207,12 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
   // devices have the same ISA. The only thing that will differ is the
   // kernel_object pointer and we handle that per-device during table upload.
   if (iree_status_is_ok(status)) {
+    iree_host_size_t* custom_explicit_kernarg_sizes = NULL;
     uint16_t* custom_implicit_args_offsets = NULL;
     if (hsaco_metadata.kernel_count > 0) {
+      custom_explicit_kernarg_sizes = (iree_host_size_t*)iree_alloca(
+          hsaco_metadata.kernel_count *
+          sizeof(custom_explicit_kernarg_sizes[0]));
       custom_implicit_args_offsets = (uint16_t*)iree_alloca(
           hsaco_metadata.kernel_count * sizeof(custom_implicit_args_offsets[0]));
     }
@@ -2196,8 +2228,9 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
           host_kernel_args);
       if (iree_status_is_ok(status)) {
         status =
-            iree_hal_amdgpu_executable_raw_hsaco_implicit_args_offset(
+            iree_hal_amdgpu_executable_raw_hsaco_custom_kernarg_layout(
                 kernel, host_kernel_args,
+                &custom_explicit_kernarg_sizes[kernel_ordinal],
                 &custom_implicit_args_offsets[kernel_ordinal]);
       }
     }
@@ -2219,7 +2252,8 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
       if (iree_status_is_ok(status)) {
         status =
             iree_hal_amdgpu_executable_initialize_dispatch_descriptors_for_device(
-                executable, device_ordinal, custom_implicit_args_offsets);
+                executable, device_ordinal, custom_explicit_kernarg_sizes,
+                custom_implicit_args_offsets);
       }
     }
   }

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -1082,9 +1082,23 @@ static iree_status_t iree_hal_amdgpu_executable_upload_raw_hsaco_kernel_table(
     IREE_RETURN_IF_ERROR(iree_hal_amdgpu_executable_resolve_kernel_object(
         libhsa, symbol, &host_kernel_args[kernel_ordinal].kernel_object));
   }
+  for (iree_host_size_t i = 0; i < hsaco_metadata->elf_kernel_symbol_count;
+       ++i) {
+    const iree_host_size_t kernel_ordinal = hsaco_metadata->kernel_count + i;
+    iree_string_view_t symbol_name =
+        hsaco_metadata->elf_kernel_symbols[i].symbol_name;
+    hsa_executable_symbol_t symbol = {0};
+    IREE_RETURN_IF_ERROR(
+        iree_hal_amdgpu_executable_get_raw_hsaco_symbol_by_name(
+            libhsa, executable, symbol_name, device_agent, &symbol),
+        "resolving ELF-only `%.*s`", (int)symbol_name.size, symbol_name.data);
+    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_executable_resolve_kernel_object(
+        libhsa, symbol, &host_kernel_args[kernel_ordinal].kernel_object));
+  }
   return iree_hal_amdgpu_executable_upload_resolved_kernel_table(
-      libhsa, hsaco_metadata->kernel_count, host_kernel_args, device_agent,
-      out_device_kernel_args);
+      libhsa, hsaco_metadata->kernel_count +
+                  hsaco_metadata->elf_kernel_symbol_count,
+      host_kernel_args, device_agent, out_device_kernel_args);
 }
 
 static iree_status_t iree_hal_amdgpu_executable_calculate_kernarg_block_count(
@@ -1253,6 +1267,8 @@ typedef struct iree_hal_amdgpu_executable_t {
   iree_host_size_t* export_parameter_offsets /*[kernel_count + 1]*/;
   // Host-resident parameter reflection records for all exports.
   iree_hal_executable_function_parameter_t* export_parameters;
+  // True for exports discovered from ELF symbols without AMDGPU metadata.
+  bool* custom_direct_only_exports /*[kernel_count]*/;
   // Table of kernel args stored in host memory. We have them local so that
   // host-side command buffer recording doesn't need to access device memory.
   // The kernel object specified in each is invalid as it's agent-specific.
@@ -1352,6 +1368,7 @@ static iree_status_t iree_hal_amdgpu_executable_allocate(
   iree_host_size_t export_parameter_offsets_offset = 0;
   iree_host_size_t export_parameters_offset = 0;
   iree_host_size_t export_parameter_name_storage_offset = 0;
+  iree_host_size_t custom_direct_only_exports_offset = 0;
   iree_host_size_t host_kernel_args_offset = 0;
   iree_host_size_t host_dispatch_descriptors_offset = 0;
   iree_host_size_t device_agents_offset = 0;
@@ -1371,6 +1388,8 @@ static iree_status_t iree_hal_amdgpu_executable_allocate(
                         &export_parameters_offset),
       IREE_STRUCT_FIELD(export_parameter_name_storage_size, char,
                         &export_parameter_name_storage_offset),
+      IREE_STRUCT_FIELD(export_count, bool,
+                        &custom_direct_only_exports_offset),
       IREE_STRUCT_FIELD(export_count, iree_hal_amdgpu_device_kernel_args_t,
                         &host_kernel_args_offset),
       IREE_STRUCT_FIELD(dispatch_descriptor_count,
@@ -1400,6 +1419,8 @@ static iree_status_t iree_hal_amdgpu_executable_allocate(
           ? (iree_hal_executable_function_parameter_t*)(executable_storage +
                                                         export_parameters_offset)
           : NULL;
+  executable->custom_direct_only_exports =
+      (bool*)(executable_storage + custom_direct_only_exports_offset);
   executable->host_kernel_args =
       (iree_hal_amdgpu_device_kernel_args_t*)(executable_storage +
                                               host_kernel_args_offset);
@@ -1464,6 +1485,9 @@ iree_hal_amdgpu_executable_initialize_dispatch_descriptors_for_device(
         "initializing dispatch descriptor for device %" PRIhsz
         " export %" PRIhsz,
         device_ordinal, kernel_ordinal);
+    executable->host_dispatch_descriptors[descriptor_ordinal]
+        .custom_direct_only =
+        executable->custom_direct_only_exports[kernel_ordinal];
   }
   return iree_ok_status();
 }
@@ -1727,6 +1751,16 @@ iree_hal_amdgpu_executable_calculate_raw_hsaco_reflection_storage(
           "export parameter reflection storage size overflow");
     }
   }
+  for (iree_host_size_t i = 0; i < hsaco_metadata->elf_kernel_symbol_count;
+       ++i) {
+    if (!iree_host_size_checked_add(export_name_storage_size,
+                                    hsaco_metadata->elf_kernel_symbols[i]
+                                        .name.size,
+                                    &export_name_storage_size)) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "export name storage size overflow");
+    }
+  }
   *out_export_name_storage_size = export_name_storage_size;
   *out_export_parameter_count = export_parameter_count;
   *out_export_parameter_name_storage_size = export_parameter_name_storage_size;
@@ -1816,6 +1850,7 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_export_infos(
 static iree_status_t
 iree_hal_amdgpu_executable_initialize_raw_hsaco_export_infos(
     const iree_hal_amdgpu_hsaco_metadata_t* hsaco_metadata,
+    bool* custom_direct_only_exports,
     iree_hal_executable_function_info_t* export_infos,
     iree_host_size_t* export_parameter_offsets,
     iree_hal_executable_function_parameter_t* export_parameters,
@@ -1868,7 +1903,30 @@ iree_hal_amdgpu_executable_initialize_raw_hsaco_export_infos(
     export_parameter_offset += requirements.parameter_count;
     export_parameter_name_storage += requirements.name_storage_size;
   }
-  export_parameter_offsets[hsaco_metadata->kernel_count] =
+  for (iree_host_size_t i = 0; i < hsaco_metadata->elf_kernel_symbol_count;
+       ++i) {
+    const iree_host_size_t export_ordinal = hsaco_metadata->kernel_count + i;
+    const iree_hal_amdgpu_hsaco_metadata_elf_kernel_symbol_t* elf_symbol =
+        &hsaco_metadata->elf_kernel_symbols[i];
+    iree_hal_executable_function_info_t* info = &export_infos[export_ordinal];
+    export_parameter_offsets[export_ordinal] = export_parameter_offset;
+
+    iree_string_view_t name = elf_symbol->name;
+    if (!iree_string_view_is_empty(name)) {
+      memcpy(export_name_storage, name.data, name.size);
+    }
+
+    memset(info, 0, sizeof(*info));
+    info->name = iree_make_string_view(export_name_storage, name.size);
+    info->flags = IREE_HAL_EXECUTABLE_FUNCTION_FLAG_WORKGROUP_SIZE_DYNAMIC;
+    info->workgroup_size[0] = 1;
+    info->workgroup_size[1] = 1;
+    info->workgroup_size[2] = 1;
+    custom_direct_only_exports[export_ordinal] = true;
+    export_name_storage += name.size;
+  }
+  export_parameter_offsets[hsaco_metadata->kernel_count +
+                           hsaco_metadata->elf_kernel_symbol_count] =
       export_parameter_offset;
   return iree_ok_status();
 }
@@ -1964,6 +2022,26 @@ static iree_status_t iree_hal_amdgpu_executable_resolve_raw_hsaco_kernel_args(
   }
 
   return iree_ok_status();
+}
+
+static iree_status_t
+iree_hal_amdgpu_executable_resolve_raw_hsaco_elf_kernel_args(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_executable_t executable,
+    const iree_hal_amdgpu_hsaco_metadata_elf_kernel_symbol_t* elf_symbol,
+    hsa_agent_t any_device_agent,
+    iree_hal_amdgpu_device_kernel_args_t* out_host_kernel_args) {
+  hsa_executable_symbol_t symbol = {0};
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_executable_get_raw_hsaco_symbol_by_name(
+          libhsa, executable, elf_symbol->symbol_name, any_device_agent,
+          &symbol),
+      "looking up HSA symbol for ELF-only kernel `%.*s`",
+      (int)elf_symbol->symbol_name.size, elf_symbol->symbol_name.data);
+
+  const uint32_t workgroup_size[3] = {1, 1, 1};
+  return iree_hal_amdgpu_executable_resolve_kernel_args_from_symbol(
+      libhsa, symbol, workgroup_size, /*constant_count=*/0,
+      /*binding_count=*/0, out_host_kernel_args);
 }
 
 static iree_status_t
@@ -2164,6 +2242,8 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
   iree_hal_amdgpu_hsaco_metadata_t hsaco_metadata = {0};
   iree_status_t status = iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
       code_object_data, host_allocator, &hsaco_metadata);
+  const iree_host_size_t export_count =
+      hsaco_metadata.kernel_count + hsaco_metadata.elf_kernel_symbol_count;
 
   iree_host_size_t export_name_storage_size = 0;
   iree_host_size_t export_parameter_count = 0;
@@ -2179,16 +2259,17 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
   char* export_parameter_name_storage = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_executable_allocate(
-        device, libhsa, topology, physical_devices, hsaco_metadata.kernel_count,
+        device, libhsa, topology, physical_devices, export_count,
         export_name_storage_size, export_parameter_count,
         export_parameter_name_storage_size, host_allocator,
         &export_name_storage, &export_parameter_name_storage, &executable);
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_executable_initialize_raw_hsaco_export_infos(
-        &hsaco_metadata, executable->export_infos,
-        executable->export_parameter_offsets, executable->export_parameters,
-        export_name_storage, export_parameter_name_storage);
+        &hsaco_metadata, executable->custom_direct_only_exports,
+        executable->export_infos, executable->export_parameter_offsets,
+        executable->export_parameters, export_name_storage,
+        export_parameter_name_storage);
   }
   if (iree_status_is_ok(status)) {
     iree_hal_amdgpu_profile_metadata_hash_code_object(
@@ -2209,12 +2290,11 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
   if (iree_status_is_ok(status)) {
     iree_host_size_t* custom_explicit_kernarg_sizes = NULL;
     uint16_t* custom_implicit_args_offsets = NULL;
-    if (hsaco_metadata.kernel_count > 0) {
+    if (export_count > 0) {
       custom_explicit_kernarg_sizes = (iree_host_size_t*)iree_alloca(
-          hsaco_metadata.kernel_count *
-          sizeof(custom_explicit_kernarg_sizes[0]));
+          export_count * sizeof(custom_explicit_kernarg_sizes[0]));
       custom_implicit_args_offsets = (uint16_t*)iree_alloca(
-          hsaco_metadata.kernel_count * sizeof(custom_implicit_args_offsets[0]));
+          export_count * sizeof(custom_implicit_args_offsets[0]));
     }
     for (iree_host_size_t kernel_ordinal = 0;
          iree_status_is_ok(status) &&
@@ -2232,6 +2312,24 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
                 kernel, host_kernel_args,
                 &custom_explicit_kernarg_sizes[kernel_ordinal],
                 &custom_implicit_args_offsets[kernel_ordinal]);
+      }
+    }
+    for (iree_host_size_t i = 0;
+         iree_status_is_ok(status) &&
+         i < hsaco_metadata.elf_kernel_symbol_count; ++i) {
+      const iree_host_size_t kernel_ordinal = hsaco_metadata.kernel_count + i;
+      const iree_hal_amdgpu_hsaco_metadata_elf_kernel_symbol_t* elf_symbol =
+          &hsaco_metadata.elf_kernel_symbols[i];
+      iree_hal_amdgpu_device_kernel_args_t* host_kernel_args =
+          &executable->host_kernel_args[kernel_ordinal];
+      status =
+          iree_hal_amdgpu_executable_resolve_raw_hsaco_elf_kernel_args(
+              libhsa, executable->handle, elf_symbol, any_device_agent,
+              host_kernel_args);
+      if (iree_status_is_ok(status)) {
+        custom_explicit_kernarg_sizes[kernel_ordinal] =
+            host_kernel_args->kernarg_size;
+        custom_implicit_args_offsets[kernel_ordinal] = UINT16_MAX;
       }
     }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -1386,8 +1386,7 @@ static iree_status_t iree_hal_amdgpu_executable_allocate(
                         &export_parameters_offset),
       IREE_STRUCT_FIELD(export_parameter_name_storage_size, char,
                         &export_parameter_name_storage_offset),
-      IREE_STRUCT_FIELD(export_count, bool,
-                        &custom_direct_only_exports_offset),
+      IREE_STRUCT_FIELD(export_count, bool, &custom_direct_only_exports_offset),
       IREE_STRUCT_FIELD(export_count, iree_hal_amdgpu_device_kernel_args_t,
                         &host_kernel_args_offset),
       IREE_STRUCT_FIELD(dispatch_descriptor_count,
@@ -1472,13 +1471,13 @@ iree_hal_amdgpu_executable_initialize_dispatch_descriptors_for_device(
             ? custom_explicit_kernarg_sizes[kernel_ordinal]
             : executable->host_kernel_args[kernel_ordinal].kernarg_size;
     const uint16_t custom_implicit_args_offset =
-        custom_implicit_args_offsets ? custom_implicit_args_offsets[kernel_ordinal]
-                                     : UINT16_MAX;
+        custom_implicit_args_offsets
+            ? custom_implicit_args_offsets[kernel_ordinal]
+            : UINT16_MAX;
     IREE_RETURN_IF_ERROR(
         iree_hal_amdgpu_executable_initialize_dispatch_descriptor(
             &executable->host_kernel_args[kernel_ordinal],
-            custom_explicit_kernarg_size,
-            custom_implicit_args_offset,
+            custom_explicit_kernarg_size, custom_implicit_args_offset,
             &executable->host_dispatch_descriptors[descriptor_ordinal]),
         "initializing dispatch descriptor for device %" PRIhsz
         " export %" PRIhsz,
@@ -1751,10 +1750,10 @@ iree_hal_amdgpu_executable_calculate_raw_hsaco_reflection_storage(
   }
   for (iree_host_size_t i = 0; i < hsaco_metadata->elf_kernel_symbol_count;
        ++i) {
-    if (!iree_host_size_checked_add(export_name_storage_size,
-                                    hsaco_metadata->elf_kernel_symbols[i]
-                                        .name.size,
-                                    &export_name_storage_size)) {
+    if (!iree_host_size_checked_add(
+            export_name_storage_size,
+            hsaco_metadata->elf_kernel_symbols[i].name.size,
+            &export_name_storage_size)) {
       return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                               "export name storage size overflow");
     }
@@ -2029,12 +2028,12 @@ iree_hal_amdgpu_executable_resolve_raw_hsaco_elf_kernel_args(
     hsa_agent_t any_device_agent,
     iree_hal_amdgpu_device_kernel_args_t* out_host_kernel_args) {
   hsa_executable_symbol_t symbol = {0};
-  IREE_RETURN_IF_ERROR(
-      iree_hal_amdgpu_executable_get_raw_hsaco_symbol_by_name(
-          libhsa, executable, elf_symbol->symbol_name, any_device_agent,
-          &symbol),
-      "looking up HSA symbol for ELF-only kernel `%.*s`",
-      (int)elf_symbol->symbol_name.size, elf_symbol->symbol_name.data);
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_executable_get_raw_hsaco_symbol_by_name(
+                           libhsa, executable, elf_symbol->symbol_name,
+                           any_device_agent, &symbol),
+                       "looking up HSA symbol for ELF-only kernel `%.*s`",
+                       (int)elf_symbol->symbol_name.size,
+                       elf_symbol->symbol_name.data);
 
   const uint32_t workgroup_size[3] = {1, 1, 1};
   return iree_hal_amdgpu_executable_resolve_kernel_args_from_symbol(
@@ -2056,9 +2055,8 @@ iree_status_t iree_hal_amdgpu_executable_raw_hsaco_custom_kernarg_layout(
     const iree_hal_amdgpu_hsaco_metadata_arg_t* arg = &kernel->args[arg_i];
     if (arg->kind == IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN ||
         arg->kind == IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN_NONE) {
-      if (arg->offset <= UINT16_MAX &&
-          (implicit_args_offset == UINT16_MAX ||
-           arg->offset < implicit_args_offset)) {
+      if (arg->offset <= UINT16_MAX && (implicit_args_offset == UINT16_MAX ||
+                                        arg->offset < implicit_args_offset)) {
         implicit_args_offset = (uint16_t)arg->offset;
       }
     } else {
@@ -2312,7 +2310,8 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
     }
     for (iree_host_size_t kernel_ordinal = 0;
          iree_status_is_ok(status) &&
-         kernel_ordinal < hsaco_metadata.kernel_count; ++kernel_ordinal) {
+         kernel_ordinal < hsaco_metadata.kernel_count;
+         ++kernel_ordinal) {
       const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel =
           &hsaco_metadata.kernels[kernel_ordinal];
       iree_hal_amdgpu_device_kernel_args_t* host_kernel_args =
@@ -2321,25 +2320,23 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
           libhsa, executable->handle, kernel, any_device_agent,
           host_kernel_args);
       if (iree_status_is_ok(status)) {
-        status =
-            iree_hal_amdgpu_executable_raw_hsaco_custom_kernarg_layout(
-                kernel, host_kernel_args,
-                &custom_explicit_kernarg_sizes[kernel_ordinal],
-                &custom_implicit_args_offsets[kernel_ordinal]);
+        status = iree_hal_amdgpu_executable_raw_hsaco_custom_kernarg_layout(
+            kernel, host_kernel_args,
+            &custom_explicit_kernarg_sizes[kernel_ordinal],
+            &custom_implicit_args_offsets[kernel_ordinal]);
       }
     }
-    for (iree_host_size_t i = 0;
-         iree_status_is_ok(status) &&
-         i < hsaco_metadata.elf_kernel_symbol_count; ++i) {
+    for (iree_host_size_t i = 0; iree_status_is_ok(status) &&
+                                 i < hsaco_metadata.elf_kernel_symbol_count;
+         ++i) {
       const iree_host_size_t kernel_ordinal = hsaco_metadata.kernel_count + i;
       const iree_hal_amdgpu_hsaco_metadata_elf_kernel_symbol_t* elf_symbol =
           &hsaco_metadata.elf_kernel_symbols[i];
       iree_hal_amdgpu_device_kernel_args_t* host_kernel_args =
           &executable->host_kernel_args[kernel_ordinal];
-      status =
-          iree_hal_amdgpu_executable_resolve_raw_hsaco_elf_kernel_args(
-              libhsa, executable->handle, elf_symbol, any_device_agent,
-              host_kernel_args);
+      status = iree_hal_amdgpu_executable_resolve_raw_hsaco_elf_kernel_args(
+          libhsa, executable->handle, elf_symbol, any_device_agent,
+          host_kernel_args);
       if (iree_status_is_ok(status)) {
         custom_explicit_kernarg_sizes[kernel_ordinal] =
             host_kernel_args->kernarg_size;

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -1845,8 +1845,7 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_export_infos(
   return iree_ok_status();
 }
 
-static iree_status_t
-iree_hal_amdgpu_executable_initialize_raw_hsaco_export_infos(
+iree_status_t iree_hal_amdgpu_executable_initialize_raw_hsaco_export_infos(
     const iree_hal_amdgpu_hsaco_metadata_t* hsaco_metadata,
     bool* custom_direct_only_exports,
     iree_hal_executable_function_info_t* export_infos,
@@ -1883,6 +1882,7 @@ iree_hal_amdgpu_executable_initialize_raw_hsaco_export_infos(
     info->parameter_count = requirements.parameter_count;
     iree_hal_amdgpu_executable_raw_hsaco_workgroup_size(kernel,
                                                         info->workgroup_size);
+    custom_direct_only_exports[i] = true;
 
     iree_hal_executable_function_parameter_t* export_parameter_base =
         requirements.parameter_count
@@ -2042,8 +2042,7 @@ iree_hal_amdgpu_executable_resolve_raw_hsaco_elf_kernel_args(
       /*binding_count=*/0, out_host_kernel_args);
 }
 
-static iree_status_t
-iree_hal_amdgpu_executable_raw_hsaco_custom_kernarg_layout(
+iree_status_t iree_hal_amdgpu_executable_raw_hsaco_custom_kernarg_layout(
     const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
     const iree_hal_amdgpu_device_kernel_args_t* kernel_args,
     iree_host_size_t* out_explicit_kernarg_size,
@@ -2074,14 +2073,27 @@ iree_hal_amdgpu_executable_raw_hsaco_custom_kernarg_layout(
       explicit_args_end = iree_max(explicit_args_end, arg_end);
     }
   }
+  *out_explicit_kernarg_size = explicit_args_end;
   if (implicit_args_offset != UINT16_MAX) {
-    *out_explicit_kernarg_size =
-        iree_max(explicit_args_end, (iree_host_size_t)implicit_args_offset);
+    if (explicit_args_end > implicit_args_offset) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "AMDGPU kernel `%.*s` has unsupported interleaved hidden kernarg "
+          "metadata",
+          (int)symbol_name.size, symbol_name.data);
+    }
+    iree_host_size_t implicit_args_end = 0;
+    if (!iree_host_size_checked_add(
+            (iree_host_size_t)implicit_args_offset,
+            (iree_host_size_t)IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE,
+            &implicit_args_end) ||
+        kernel_args->kernarg_size < implicit_args_end) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "AMDGPU kernel `%.*s` has truncated implicit kernarg suffix",
+          (int)symbol_name.size, symbol_name.data);
+    }
     *out_implicit_args_offset = implicit_args_offset;
-  } else if (explicit_args_end <= UINT16_MAX &&
-             kernel_args->kernarg_size >=
-                 explicit_args_end + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE) {
-    *out_implicit_args_offset = (uint16_t)explicit_args_end;
   }
   return iree_ok_status();
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -965,6 +965,7 @@ static iree_status_t iree_hal_amdgpu_executable_resolve_kernel_args_from_symbol(
 
   out_kernel_args->binding_count = binding_count;
   out_kernel_args->constant_count = constant_count;
+  out_kernel_args->implicit_args_offset = UINT16_MAX;
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -1141,6 +1142,19 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_dispatch_descriptor(
   out_descriptor->custom_kernarg_layout =
       iree_hal_amdgpu_device_dispatch_make_custom_kernarg_layout(
           kernel_args->kernarg_size);
+  if (kernel_args->implicit_args_offset != UINT16_MAX) {
+    const uint16_t custom_implicit_args_offset =
+        kernel_args->implicit_args_offset;
+    out_descriptor->custom_kernarg_layout.explicit_kernarg_size =
+        custom_implicit_args_offset;
+    out_descriptor->custom_kernarg_layout.implicit_args_offset =
+        custom_implicit_args_offset;
+    out_descriptor->custom_kernarg_layout.total_kernarg_size = iree_max(
+        (size_t)kernel_args->kernarg_size,
+        (size_t)custom_implicit_args_offset +
+            IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE);
+    out_descriptor->custom_kernarg_layout.has_implicit_args = true;
+  }
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_executable_calculate_kernarg_block_count(
       &out_descriptor->custom_kernarg_layout,
       &out_descriptor->custom_kernarg_block_count));
@@ -1656,13 +1670,6 @@ iree_hal_amdgpu_executable_calculate_raw_hsaco_reflection_storage(
     iree_host_size_t* out_export_name_storage_size,
     iree_host_size_t* out_export_parameter_count,
     iree_host_size_t* out_export_parameter_name_storage_size) {
-  if (iree_string_view_is_empty(hsaco_metadata->target)) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "raw HSACO metadata is missing `amdhsa.target`; direct loading "
-        "requires the code object to declare its target ISA");
-  }
-
   iree_host_size_t export_name_storage_size = 0;
   iree_host_size_t export_parameter_count = 0;
   iree_host_size_t export_parameter_name_storage_size = 0;
@@ -1923,6 +1930,53 @@ static iree_status_t iree_hal_amdgpu_executable_resolve_raw_hsaco_kernel_args(
             requirements.binding_count, &host_kernel_args[kernel_ordinal]),
         "resolving kernel args for raw kernel `%.*s`", (int)symbol_name.size,
         symbol_name.data);
+    // Raw HSACO metadata is the source of truth for caller-visible kernargs:
+    // some code objects report a smaller HSA symbol size than the metadata
+    // segment needed by pre-packed HIP launch buffers.
+    if (host_kernel_args[kernel_ordinal].kernarg_size <
+        kernel->kernarg_segment_size) {
+      host_kernel_args[kernel_ordinal].kernarg_size =
+          kernel->kernarg_segment_size;
+    }
+    if (host_kernel_args[kernel_ordinal].kernarg_alignment <
+        kernel->kernarg_segment_alignment) {
+      host_kernel_args[kernel_ordinal].kernarg_alignment =
+          kernel->kernarg_segment_alignment;
+    }
+
+    uint16_t implicit_args_offset = UINT16_MAX;
+    uint32_t explicit_args_end = 0;
+    for (iree_host_size_t arg_i = 0; arg_i < kernel->arg_count; ++arg_i) {
+      const iree_hal_amdgpu_hsaco_metadata_arg_t* arg =
+          &kernel->args[arg_i];
+      if (arg->kind == IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN ||
+          arg->kind == IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN_NONE) {
+        if (arg->offset <= UINT16_MAX &&
+            (implicit_args_offset == UINT16_MAX ||
+             arg->offset < implicit_args_offset)) {
+          implicit_args_offset = (uint16_t)arg->offset;
+        }
+      } else {
+        iree_host_size_t arg_end = 0;
+        if (!iree_host_size_checked_add(arg->offset, arg->size, &arg_end) ||
+            arg_end > UINT32_MAX) {
+          return iree_make_status(
+              IREE_STATUS_OUT_OF_RANGE,
+              "AMDGPU kernel `%.*s` argument offset overflows",
+              (int)symbol_name.size, symbol_name.data);
+        }
+        explicit_args_end = iree_max(explicit_args_end, (uint32_t)arg_end);
+      }
+    }
+    if (implicit_args_offset != UINT16_MAX && implicit_args_offset > 0) {
+      host_kernel_args[kernel_ordinal].implicit_args_offset =
+          implicit_args_offset;
+    } else if (explicit_args_end <= UINT16_MAX &&
+               host_kernel_args[kernel_ordinal].kernarg_size >=
+                   explicit_args_end + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE) {
+      host_kernel_args[kernel_ordinal].implicit_args_offset =
+          (uint16_t)explicit_args_end;
+    }
   }
   return iree_ok_status();
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -1899,85 +1899,74 @@ static iree_status_t iree_hal_amdgpu_executable_resolve_flatbuffer_kernel_args(
 
 static iree_status_t iree_hal_amdgpu_executable_resolve_raw_hsaco_kernel_args(
     const iree_hal_amdgpu_libhsa_t* libhsa, hsa_executable_t executable,
-    const iree_hal_amdgpu_hsaco_metadata_t* hsaco_metadata,
+    const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
     hsa_agent_t any_device_agent,
-    iree_hal_amdgpu_device_kernel_args_t* host_kernel_args) {
-  for (iree_host_size_t kernel_ordinal = 0;
-       kernel_ordinal < hsaco_metadata->kernel_count; ++kernel_ordinal) {
-    const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel =
-        &hsaco_metadata->kernels[kernel_ordinal];
-    iree_string_view_t symbol_name = kernel->symbol_name;
+    iree_hal_amdgpu_device_kernel_args_t* out_host_kernel_args) {
+  iree_string_view_t symbol_name = kernel->symbol_name;
 
-    hsa_executable_symbol_t symbol = {0};
-    IREE_RETURN_IF_ERROR(
-        iree_hal_amdgpu_executable_get_raw_hsaco_symbol_by_name(
-            libhsa, executable, symbol_name, any_device_agent, &symbol),
-        "looking up HSA symbol for raw kernel `%.*s`", (int)symbol_name.size,
-        symbol_name.data);
+  hsa_executable_symbol_t symbol = {0};
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_executable_get_raw_hsaco_symbol_by_name(
+          libhsa, executable, symbol_name, any_device_agent, &symbol),
+      "looking up HSA symbol for raw kernel `%.*s`", (int)symbol_name.size,
+      symbol_name.data);
 
-    iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
-    IREE_RETURN_IF_ERROR(
-        iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
-            kernel, &requirements),
-        "projecting HSACO parameters for raw kernel `%.*s`",
-        (int)symbol_name.size, symbol_name.data);
+  iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
+          kernel, &requirements),
+      "projecting HSACO parameters for raw kernel `%.*s`",
+      (int)symbol_name.size, symbol_name.data);
 
-    uint32_t workgroup_size[3] = {0};
-    iree_hal_amdgpu_executable_raw_hsaco_workgroup_size(kernel, workgroup_size);
-    IREE_RETURN_IF_ERROR(
-        iree_hal_amdgpu_executable_resolve_kernel_args_from_symbol(
-            libhsa, symbol, workgroup_size, requirements.constant_count,
-            requirements.binding_count, &host_kernel_args[kernel_ordinal]),
-        "resolving kernel args for raw kernel `%.*s`", (int)symbol_name.size,
-        symbol_name.data);
+  uint32_t workgroup_size[3] = {0};
+  iree_hal_amdgpu_executable_raw_hsaco_workgroup_size(kernel, workgroup_size);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_executable_resolve_kernel_args_from_symbol(
+          libhsa, symbol, workgroup_size, requirements.constant_count,
+          requirements.binding_count, out_host_kernel_args),
+      "resolving kernel args for raw kernel `%.*s`", (int)symbol_name.size,
+      symbol_name.data);
 
-    // Raw HSACO metadata is the source of truth for caller-visible kernargs:
-    // some code objects report a smaller HSA symbol size than the metadata
-    // segment needed by pre-packed HIP launch buffers.
-    if (host_kernel_args[kernel_ordinal].kernarg_size <
-        kernel->kernarg_segment_size) {
-      host_kernel_args[kernel_ordinal].kernarg_size =
-          kernel->kernarg_segment_size;
-    }
-    if (host_kernel_args[kernel_ordinal].kernarg_alignment <
-        kernel->kernarg_segment_alignment) {
-      host_kernel_args[kernel_ordinal].kernarg_alignment =
-          kernel->kernarg_segment_alignment;
-    }
+  // Raw HSACO metadata is the source of truth for caller-visible kernargs:
+  // some code objects report a smaller HSA symbol size than the metadata
+  // segment needed by pre-packed HIP launch buffers.
+  if (out_host_kernel_args->kernarg_size < kernel->kernarg_segment_size) {
+    out_host_kernel_args->kernarg_size = kernel->kernarg_segment_size;
+  }
+  if (out_host_kernel_args->kernarg_alignment <
+      kernel->kernarg_segment_alignment) {
+    out_host_kernel_args->kernarg_alignment = kernel->kernarg_segment_alignment;
+  }
 
-    uint16_t implicit_args_offset = UINT16_MAX;
-    uint32_t explicit_args_end = 0;
-    for (iree_host_size_t arg_i = 0; arg_i < kernel->arg_count; ++arg_i) {
-      const iree_hal_amdgpu_hsaco_metadata_arg_t* arg =
-          &kernel->args[arg_i];
-      if (arg->kind == IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN ||
-          arg->kind == IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN_NONE) {
-        if (arg->offset <= UINT16_MAX &&
-            (implicit_args_offset == UINT16_MAX ||
-             arg->offset < implicit_args_offset)) {
-          implicit_args_offset = (uint16_t)arg->offset;
-        }
-      } else {
-        iree_host_size_t arg_end = 0;
-        if (!iree_host_size_checked_add(arg->offset, arg->size, &arg_end) ||
-            arg_end > UINT32_MAX) {
-          return iree_make_status(
-              IREE_STATUS_OUT_OF_RANGE,
-              "AMDGPU kernel `%.*s` argument offset overflows",
-              (int)symbol_name.size, symbol_name.data);
-        }
-        explicit_args_end = iree_max(explicit_args_end, (uint32_t)arg_end);
+  uint16_t implicit_args_offset = UINT16_MAX;
+  uint32_t explicit_args_end = 0;
+  for (iree_host_size_t arg_i = 0; arg_i < kernel->arg_count; ++arg_i) {
+    const iree_hal_amdgpu_hsaco_metadata_arg_t* arg = &kernel->args[arg_i];
+    if (arg->kind == IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN ||
+        arg->kind == IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN_NONE) {
+      if (arg->offset <= UINT16_MAX &&
+          (implicit_args_offset == UINT16_MAX ||
+           arg->offset < implicit_args_offset)) {
+        implicit_args_offset = (uint16_t)arg->offset;
       }
+    } else {
+      iree_host_size_t arg_end = 0;
+      if (!iree_host_size_checked_add(arg->offset, arg->size, &arg_end) ||
+          arg_end > UINT32_MAX) {
+        return iree_make_status(
+            IREE_STATUS_OUT_OF_RANGE,
+            "AMDGPU kernel `%.*s` argument offset overflows",
+            (int)symbol_name.size, symbol_name.data);
+      }
+      explicit_args_end = iree_max(explicit_args_end, (uint32_t)arg_end);
     }
-    if (implicit_args_offset != UINT16_MAX && implicit_args_offset > 0) {
-      host_kernel_args[kernel_ordinal].implicit_args_offset =
-          implicit_args_offset;
-    } else if (explicit_args_end <= UINT16_MAX &&
-               host_kernel_args[kernel_ordinal].kernarg_size >=
-                   explicit_args_end + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE) {
-      host_kernel_args[kernel_ordinal].implicit_args_offset =
-          (uint16_t)explicit_args_end;
-    }
+  }
+  if (implicit_args_offset != UINT16_MAX && implicit_args_offset > 0) {
+    out_host_kernel_args->implicit_args_offset = implicit_args_offset;
+  } else if (explicit_args_end <= UINT16_MAX &&
+             out_host_kernel_args->kernarg_size >=
+                 explicit_args_end + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE) {
+    out_host_kernel_args->implicit_args_offset = (uint16_t)explicit_args_end;
   }
   return iree_ok_status();
 }
@@ -2175,9 +2164,15 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
   // devices have the same ISA. The only thing that will differ is the
   // kernel_object pointer and we handle that per-device during table upload.
   if (iree_status_is_ok(status)) {
-    status = iree_hal_amdgpu_executable_resolve_raw_hsaco_kernel_args(
-        libhsa, executable->handle, &hsaco_metadata, any_device_agent,
-        executable->host_kernel_args);
+    for (iree_host_size_t kernel_ordinal = 0;
+         iree_status_is_ok(status) &&
+         kernel_ordinal < hsaco_metadata.kernel_count; ++kernel_ordinal) {
+      const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel =
+          &hsaco_metadata.kernels[kernel_ordinal];
+      status = iree_hal_amdgpu_executable_resolve_raw_hsaco_kernel_args(
+          libhsa, executable->handle, kernel, any_device_agent,
+          &executable->host_kernel_args[kernel_ordinal]);
+    }
   }
 
   // Upload copies of kernel arguments for each device.

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -965,7 +965,6 @@ static iree_status_t iree_hal_amdgpu_executable_resolve_kernel_args_from_symbol(
 
   out_kernel_args->binding_count = binding_count;
   out_kernel_args->constant_count = constant_count;
-  out_kernel_args->implicit_args_offset = UINT16_MAX;
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -1108,6 +1107,7 @@ static iree_status_t iree_hal_amdgpu_executable_calculate_kernarg_block_count(
 
 static iree_status_t iree_hal_amdgpu_executable_initialize_dispatch_descriptor(
     const iree_hal_amdgpu_device_kernel_args_t* kernel_args,
+    uint16_t custom_implicit_args_offset,
     iree_hal_amdgpu_executable_dispatch_descriptor_t* out_descriptor) {
   memset(out_descriptor, 0, sizeof(*out_descriptor));
 
@@ -1142,9 +1142,7 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_dispatch_descriptor(
   out_descriptor->custom_kernarg_layout =
       iree_hal_amdgpu_device_dispatch_make_custom_kernarg_layout(
           kernel_args->kernarg_size);
-  if (kernel_args->implicit_args_offset != UINT16_MAX) {
-    const uint16_t custom_implicit_args_offset =
-        kernel_args->implicit_args_offset;
+  if (custom_implicit_args_offset != UINT16_MAX) {
     out_descriptor->custom_kernarg_layout.explicit_kernarg_size =
         custom_implicit_args_offset;
     out_descriptor->custom_kernarg_layout.implicit_args_offset =
@@ -1427,14 +1425,19 @@ static void iree_hal_amdgpu_executable_invalidate_host_kernel_objects(
 
 static iree_status_t
 iree_hal_amdgpu_executable_initialize_dispatch_descriptors_for_device(
-    iree_hal_amdgpu_executable_t* executable, iree_host_size_t device_ordinal) {
+    iree_hal_amdgpu_executable_t* executable, iree_host_size_t device_ordinal,
+    const uint16_t* custom_implicit_args_offsets) {
   for (iree_host_size_t kernel_ordinal = 0;
        kernel_ordinal < executable->kernel_count; ++kernel_ordinal) {
     const iree_host_size_t descriptor_ordinal =
         device_ordinal * executable->kernel_count + kernel_ordinal;
+    const uint16_t custom_implicit_args_offset =
+        custom_implicit_args_offsets ? custom_implicit_args_offsets[kernel_ordinal]
+                                     : UINT16_MAX;
     IREE_RETURN_IF_ERROR(
         iree_hal_amdgpu_executable_initialize_dispatch_descriptor(
             &executable->host_kernel_args[kernel_ordinal],
+            custom_implicit_args_offset,
             &executable->host_dispatch_descriptors[descriptor_ordinal]),
         "initializing dispatch descriptor for device %" PRIhsz
         " export %" PRIhsz,
@@ -1938,6 +1941,15 @@ static iree_status_t iree_hal_amdgpu_executable_resolve_raw_hsaco_kernel_args(
     out_host_kernel_args->kernarg_alignment = kernel->kernarg_segment_alignment;
   }
 
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_executable_raw_hsaco_implicit_args_offset(
+    const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
+    const iree_hal_amdgpu_device_kernel_args_t* kernel_args,
+    uint16_t* out_implicit_args_offset) {
+  *out_implicit_args_offset = UINT16_MAX;
+  iree_string_view_t symbol_name = kernel->symbol_name;
   uint16_t implicit_args_offset = UINT16_MAX;
   uint32_t explicit_args_end = 0;
   for (iree_host_size_t arg_i = 0; arg_i < kernel->arg_count; ++arg_i) {
@@ -1962,11 +1974,11 @@ static iree_status_t iree_hal_amdgpu_executable_resolve_raw_hsaco_kernel_args(
     }
   }
   if (implicit_args_offset != UINT16_MAX && implicit_args_offset > 0) {
-    out_host_kernel_args->implicit_args_offset = implicit_args_offset;
+    *out_implicit_args_offset = implicit_args_offset;
   } else if (explicit_args_end <= UINT16_MAX &&
-             out_host_kernel_args->kernarg_size >=
+             kernel_args->kernarg_size >=
                  explicit_args_end + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE) {
-    out_host_kernel_args->implicit_args_offset = (uint16_t)explicit_args_end;
+    *out_implicit_args_offset = (uint16_t)explicit_args_end;
   }
   return iree_ok_status();
 }
@@ -2081,7 +2093,8 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_flatbuffer(
     if (iree_status_is_ok(status)) {
       status =
           iree_hal_amdgpu_executable_initialize_dispatch_descriptors_for_device(
-              executable, device_ordinal);
+              executable, device_ordinal,
+              /*custom_implicit_args_offsets=*/NULL);
     }
   }
 
@@ -2164,35 +2177,48 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
   // devices have the same ISA. The only thing that will differ is the
   // kernel_object pointer and we handle that per-device during table upload.
   if (iree_status_is_ok(status)) {
+    uint16_t* custom_implicit_args_offsets = NULL;
+    if (hsaco_metadata.kernel_count > 0) {
+      custom_implicit_args_offsets = (uint16_t*)iree_alloca(
+          hsaco_metadata.kernel_count * sizeof(custom_implicit_args_offsets[0]));
+    }
     for (iree_host_size_t kernel_ordinal = 0;
          iree_status_is_ok(status) &&
          kernel_ordinal < hsaco_metadata.kernel_count; ++kernel_ordinal) {
       const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel =
           &hsaco_metadata.kernels[kernel_ordinal];
+      iree_hal_amdgpu_device_kernel_args_t* host_kernel_args =
+          &executable->host_kernel_args[kernel_ordinal];
       status = iree_hal_amdgpu_executable_resolve_raw_hsaco_kernel_args(
           libhsa, executable->handle, kernel, any_device_agent,
-          &executable->host_kernel_args[kernel_ordinal]);
+          host_kernel_args);
+      if (iree_status_is_ok(status)) {
+        status =
+            iree_hal_amdgpu_executable_raw_hsaco_implicit_args_offset(
+                kernel, host_kernel_args,
+                &custom_implicit_args_offsets[kernel_ordinal]);
+      }
     }
-  }
 
-  // Upload copies of kernel arguments for each device.
-  // We reuse the host storage we already allocated to make it possible to
-  // memcpy the entire table in one go from host memory.
-  for (iree_host_size_t device_ordinal = 0;
-       iree_status_is_ok(status) && device_ordinal < executable->device_count;
-       ++device_ordinal) {
-    if (!iree_hal_amdgpu_physical_device_mask_contains(
-            executable->loaded_physical_device_mask, device_ordinal)) {
-      continue;
-    }
-    status = iree_hal_amdgpu_executable_upload_raw_hsaco_kernel_table(
-        libhsa, executable->handle, &hsaco_metadata,
-        executable->host_kernel_args, topology->gpu_agents[device_ordinal],
-        &executable->device_kernel_args[device_ordinal]);
-    if (iree_status_is_ok(status)) {
-      status =
-          iree_hal_amdgpu_executable_initialize_dispatch_descriptors_for_device(
-              executable, device_ordinal);
+    // Upload copies of kernel arguments for each device.
+    // We reuse the host storage we already allocated to make it possible to
+    // memcpy the entire table in one go from host memory.
+    for (iree_host_size_t device_ordinal = 0;
+         iree_status_is_ok(status) && device_ordinal < executable->device_count;
+         ++device_ordinal) {
+      if (!iree_hal_amdgpu_physical_device_mask_contains(
+              executable->loaded_physical_device_mask, device_ordinal)) {
+        continue;
+      }
+      status = iree_hal_amdgpu_executable_upload_raw_hsaco_kernel_table(
+          libhsa, executable->handle, &hsaco_metadata,
+          executable->host_kernel_args, topology->gpu_agents[device_ordinal],
+          &executable->device_kernel_args[device_ordinal]);
+      if (iree_status_is_ok(status)) {
+        status =
+            iree_hal_amdgpu_executable_initialize_dispatch_descriptors_for_device(
+                executable, device_ordinal, custom_implicit_args_offsets);
+      }
     }
   }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -1930,6 +1930,7 @@ static iree_status_t iree_hal_amdgpu_executable_resolve_raw_hsaco_kernel_args(
             requirements.binding_count, &host_kernel_args[kernel_ordinal]),
         "resolving kernel args for raw kernel `%.*s`", (int)symbol_name.size,
         symbol_name.data);
+
     // Raw HSACO metadata is the source of truth for caller-visible kernargs:
     // some code objects report a smaller HSA symbol size than the metadata
     // segment needed by pre-packed HIP launch buffers.

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -1070,6 +1070,13 @@ static iree_status_t iree_hal_amdgpu_executable_upload_raw_hsaco_kernel_table(
     hsa_agent_t device_agent,
     IREE_AMDGPU_DEVICE_PTR const iree_hal_amdgpu_device_kernel_args_t**
         out_device_kernel_args) {
+  iree_host_size_t kernel_count = 0;
+  if (!iree_host_size_checked_add(hsaco_metadata->kernel_count,
+                                  hsaco_metadata->elf_kernel_symbol_count,
+                                  &kernel_count)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "raw HSACO kernel table count overflow");
+  }
   for (iree_host_size_t kernel_ordinal = 0;
        kernel_ordinal < hsaco_metadata->kernel_count; ++kernel_ordinal) {
     iree_string_view_t symbol_name =
@@ -1096,9 +1103,8 @@ static iree_status_t iree_hal_amdgpu_executable_upload_raw_hsaco_kernel_table(
         libhsa, symbol, &host_kernel_args[kernel_ordinal].kernel_object));
   }
   return iree_hal_amdgpu_executable_upload_resolved_kernel_table(
-      libhsa, hsaco_metadata->kernel_count +
-                  hsaco_metadata->elf_kernel_symbol_count,
-      host_kernel_args, device_agent, out_device_kernel_args);
+      libhsa, kernel_count, host_kernel_args, device_agent,
+      out_device_kernel_args);
 }
 
 static iree_status_t iree_hal_amdgpu_executable_calculate_kernarg_block_count(
@@ -1162,25 +1168,17 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_dispatch_descriptor(
           .explicit_kernarg_size = custom_explicit_kernarg_size,
       };
   if (custom_implicit_args_offset != UINT16_MAX) {
-    if (IREE_UNLIKELY(custom_explicit_kernarg_size >
-                      custom_implicit_args_offset)) {
-      return iree_make_status(
-          IREE_STATUS_INVALID_ARGUMENT,
-          "custom explicit kernargs end at %" PRIhsz
-          " beyond implicit args offset %u",
-          custom_explicit_kernarg_size, custom_implicit_args_offset);
-    }
-    // Custom-direct callers own all bytes before the implicit suffix; requiring
-    // the suffix offset rejects truly short prepacked buffers while still
-    // allowing missing trailing ABI padding inside that explicit region.
-    out_descriptor->custom_kernarg_layout.explicit_kernarg_size =
-        custom_implicit_args_offset;
+    // Custom-direct callers own every visible native kernarg byte. Hidden
+    // metadata marks the implicit suffix location, but visible args may appear
+    // after the first hidden record in some code objects, so validate/copy the
+    // full visible extent instead of truncating at the suffix offset.
     out_descriptor->custom_kernarg_layout.implicit_args_offset =
         custom_implicit_args_offset;
-    out_descriptor->custom_kernarg_layout.total_kernarg_size = iree_max(
-        (size_t)kernel_args->kernarg_size,
-        (size_t)custom_implicit_args_offset +
-            IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE);
+    out_descriptor->custom_kernarg_layout.total_kernarg_size =
+        iree_max((size_t)kernel_args->kernarg_size,
+                 iree_max((size_t)custom_explicit_kernarg_size,
+                          (size_t)custom_implicit_args_offset +
+                              IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE));
     out_descriptor->custom_kernarg_layout.has_implicit_args = true;
   }
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_executable_calculate_kernarg_block_count(
@@ -2076,16 +2074,14 @@ iree_hal_amdgpu_executable_raw_hsaco_custom_kernarg_layout(
       explicit_args_end = iree_max(explicit_args_end, arg_end);
     }
   }
-  if (implicit_args_offset != UINT16_MAX && implicit_args_offset > 0) {
-    *out_explicit_kernarg_size = implicit_args_offset;
+  if (implicit_args_offset != UINT16_MAX) {
+    *out_explicit_kernarg_size =
+        iree_max(explicit_args_end, (iree_host_size_t)implicit_args_offset);
     *out_implicit_args_offset = implicit_args_offset;
-  } else {
-    *out_explicit_kernarg_size = explicit_args_end;
-    if (explicit_args_end <= UINT16_MAX &&
-        kernel_args->kernarg_size >=
-            explicit_args_end + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE) {
-      *out_implicit_args_offset = (uint16_t)explicit_args_end;
-    }
+  } else if (explicit_args_end <= UINT16_MAX &&
+             kernel_args->kernarg_size >=
+                 explicit_args_end + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE) {
+    *out_implicit_args_offset = (uint16_t)explicit_args_end;
   }
   return iree_ok_status();
 }
@@ -2242,8 +2238,14 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
   iree_hal_amdgpu_hsaco_metadata_t hsaco_metadata = {0};
   iree_status_t status = iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
       code_object_data, host_allocator, &hsaco_metadata);
-  const iree_host_size_t export_count =
-      hsaco_metadata.kernel_count + hsaco_metadata.elf_kernel_symbol_count;
+  iree_host_size_t export_count = 0;
+  if (iree_status_is_ok(status) &&
+      !iree_host_size_checked_add(hsaco_metadata.kernel_count,
+                                  hsaco_metadata.elf_kernel_symbol_count,
+                                  &export_count)) {
+    status = iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "raw HSACO export count overflow");
+  }
 
   iree_host_size_t export_name_storage_size = 0;
   iree_host_size_t export_parameter_count = 0;

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.h
@@ -92,6 +92,9 @@ typedef struct iree_hal_amdgpu_executable_dispatch_descriptor_t {
   uint32_t pm4_setup_dword_count;
   // AMDHSA descriptor fixed group segment byte size validated for PM4 launch.
   uint32_t pm4_group_segment_fixed_size;
+  // True when this export has no reflected parameter metadata and may only be
+  // launched with a caller-provided native kernarg buffer.
+  bool custom_direct_only;
   // True when the PM4 metadata fields are valid for this dispatch.
   bool pm4_launch_state_valid;
 } iree_hal_amdgpu_executable_dispatch_descriptor_t;

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_test.cc
@@ -14,9 +14,26 @@
 #include "iree/base/alignment.h"
 #include "iree/base/api.h"
 #include "iree/base/internal/flatcc/building.h"
+#include "iree/hal/drivers/amdgpu/util/hsaco_metadata.h"
 #include "iree/schemas/amdgpu_executable_def_builder.h"
 #include "iree/testing/gtest.h"
 #include "iree/testing/status_matchers.h"
+
+extern "C" {
+iree_status_t iree_hal_amdgpu_executable_initialize_raw_hsaco_export_infos(
+    const iree_hal_amdgpu_hsaco_metadata_t* hsaco_metadata,
+    bool* custom_direct_only_exports,
+    iree_hal_executable_function_info_t* export_infos,
+    iree_host_size_t* export_parameter_offsets,
+    iree_hal_executable_function_parameter_t* export_parameters,
+    char* export_name_storage, char* export_parameter_name_storage);
+
+iree_status_t iree_hal_amdgpu_executable_raw_hsaco_custom_kernarg_layout(
+    const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
+    const iree_hal_amdgpu_device_kernel_args_t* kernel_args,
+    iree_host_size_t* out_explicit_kernarg_size,
+    uint16_t* out_implicit_args_offset);
+}  // extern "C"
 
 namespace iree::hal::amdgpu {
 namespace {
@@ -150,6 +167,42 @@ static std::string InferExecutableFormat(iree_const_byte_span_t executable_data,
   return std::string(executable_format);
 }
 
+static iree_hal_amdgpu_device_kernel_args_t MakeKernelArgs(
+    uint32_t kernarg_size) {
+  iree_hal_amdgpu_device_kernel_args_t kernel_args = {};
+  kernel_args.kernarg_size = kernarg_size;
+  kernel_args.kernarg_alignment = 8;
+  kernel_args.workgroup_size[0] = 1;
+  kernel_args.workgroup_size[1] = 1;
+  kernel_args.workgroup_size[2] = 1;
+  return kernel_args;
+}
+
+static iree_hal_amdgpu_hsaco_metadata_arg_t MakeArg(
+    iree_hal_amdgpu_hsaco_metadata_arg_kind_t kind, uint32_t offset,
+    uint32_t size, iree_string_view_t name = iree_string_view_empty()) {
+  iree_hal_amdgpu_hsaco_metadata_arg_t arg = {};
+  arg.name = name;
+  arg.kind = kind;
+  arg.offset = offset;
+  arg.size = size;
+  return arg;
+}
+
+static iree_hal_amdgpu_hsaco_metadata_kernel_t MakeKernel(
+    uint32_t kernarg_size, const iree_hal_amdgpu_hsaco_metadata_arg_t* args,
+    iree_host_size_t arg_count) {
+  iree_hal_amdgpu_hsaco_metadata_kernel_t kernel = {};
+  kernel.name = IREE_SV("raw");
+  kernel.symbol_name = IREE_SV("raw.kd");
+  kernel.reflection_name = IREE_SV("raw");
+  kernel.kernarg_segment_size = kernarg_size;
+  kernel.kernarg_segment_alignment = 8;
+  kernel.arg_count = arg_count;
+  kernel.args = args;
+  return kernel;
+}
+
 TEST(ExecutableTest, InfersRawHsacoTargetIdFromElfFlags) {
   const auto elf = MakeElf64AmdgpuHsa(
       kElfAbiVersionV5, kElfMachineAmdgpu,
@@ -179,6 +232,121 @@ TEST(ExecutableTest, InfersWrappedFlatbufferTargetIdFromEmbeddedElf) {
                             &inferred_size),
       "gfx942:sramecc+:xnack-");
   EXPECT_EQ(inferred_size, executable_data.size());
+}
+
+TEST(ExecutableTest, RawHsacoMetadataExportsAreCustomDirectOnly) {
+  const iree_hal_amdgpu_hsaco_metadata_arg_t args[] = {
+      MakeArg(IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_BY_VALUE, /*offset=*/0,
+              /*size=*/4, IREE_SV("x")),
+  };
+  iree_hal_amdgpu_hsaco_metadata_kernel_t kernel =
+      MakeKernel(/*kernarg_size=*/4, args, IREE_ARRAYSIZE(args));
+  iree_hal_amdgpu_hsaco_metadata_t metadata = {};
+  metadata.kernel_count = 1;
+  metadata.kernels = &kernel;
+
+  bool custom_direct_only_exports[1] = {};
+  iree_hal_executable_function_info_t export_infos[1] = {};
+  iree_host_size_t export_parameter_offsets[2] = {};
+  iree_hal_executable_function_parameter_t export_parameters[1] = {};
+  char export_name_storage[16] = {};
+  char export_parameter_name_storage[16] = {};
+  IREE_ASSERT_OK(iree_hal_amdgpu_executable_initialize_raw_hsaco_export_infos(
+      &metadata, custom_direct_only_exports, export_infos,
+      export_parameter_offsets, export_parameters, export_name_storage,
+      export_parameter_name_storage));
+
+  EXPECT_TRUE(custom_direct_only_exports[0]);
+  EXPECT_EQ(export_infos[0].parameter_count, 1u);
+  EXPECT_EQ(export_infos[0].constant_count, 1u);
+  EXPECT_EQ(export_parameter_offsets[0], 0u);
+  EXPECT_EQ(export_parameter_offsets[1], 1u);
+}
+
+TEST(ExecutableTest, RawHsacoCustomKernargLayoutRequiresVisibleExtent) {
+  const iree_hal_amdgpu_hsaco_metadata_arg_t args[] = {
+      MakeArg(IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_GLOBAL_BUFFER,
+              /*offset=*/0, /*size=*/8),
+      MakeArg(IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_BY_VALUE,
+              /*offset=*/16, /*size=*/4),
+  };
+  iree_hal_amdgpu_hsaco_metadata_kernel_t kernel =
+      MakeKernel(/*kernarg_size=*/20, args, IREE_ARRAYSIZE(args));
+  iree_hal_amdgpu_device_kernel_args_t kernel_args =
+      MakeKernelArgs(/*kernarg_size=*/20);
+
+  iree_host_size_t explicit_kernarg_size = 0;
+  uint16_t implicit_args_offset = 0;
+  IREE_ASSERT_OK(iree_hal_amdgpu_executable_raw_hsaco_custom_kernarg_layout(
+      &kernel, &kernel_args, &explicit_kernarg_size, &implicit_args_offset));
+  EXPECT_EQ(explicit_kernarg_size, 20u);
+  EXPECT_EQ(implicit_args_offset, UINT16_MAX);
+}
+
+TEST(ExecutableTest, RawHsacoCustomKernargLayoutRejectsInterleavedHiddenArgs) {
+  const iree_hal_amdgpu_hsaco_metadata_arg_t args[] = {
+      MakeArg(IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_GLOBAL_BUFFER,
+              /*offset=*/0, /*size=*/8),
+      MakeArg(IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+              /*offset=*/8, /*size=*/8),
+      MakeArg(IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_BY_VALUE,
+              /*offset=*/16, /*size=*/4),
+  };
+  iree_hal_amdgpu_hsaco_metadata_kernel_t kernel =
+      MakeKernel(/*kernarg_size=*/8 + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE,
+                 args, IREE_ARRAYSIZE(args));
+  iree_hal_amdgpu_device_kernel_args_t kernel_args =
+      MakeKernelArgs(/*kernarg_size=*/8 + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE);
+
+  iree_host_size_t explicit_kernarg_size = 0;
+  uint16_t implicit_args_offset = 0;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_executable_raw_hsaco_custom_kernarg_layout(
+          &kernel, &kernel_args, &explicit_kernarg_size,
+          &implicit_args_offset));
+}
+
+TEST(ExecutableTest, RawHsacoCustomKernargLayoutAcceptsFullImplicitSuffix) {
+  const iree_hal_amdgpu_hsaco_metadata_arg_t args[] = {
+      MakeArg(IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_GLOBAL_BUFFER,
+              /*offset=*/0, /*size=*/8),
+      MakeArg(IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+              /*offset=*/16, /*size=*/8),
+  };
+  iree_hal_amdgpu_hsaco_metadata_kernel_t kernel =
+      MakeKernel(/*kernarg_size=*/16 + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE,
+                 args, IREE_ARRAYSIZE(args));
+  iree_hal_amdgpu_device_kernel_args_t kernel_args = MakeKernelArgs(
+      /*kernarg_size=*/16 + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE);
+
+  iree_host_size_t explicit_kernarg_size = 0;
+  uint16_t implicit_args_offset = 0;
+  IREE_ASSERT_OK(iree_hal_amdgpu_executable_raw_hsaco_custom_kernarg_layout(
+      &kernel, &kernel_args, &explicit_kernarg_size, &implicit_args_offset));
+  EXPECT_EQ(explicit_kernarg_size, 8u);
+  EXPECT_EQ(implicit_args_offset, 16u);
+}
+
+TEST(ExecutableTest, RawHsacoCustomKernargLayoutRejectsTruncatedImplicitSuffix) {
+  const iree_hal_amdgpu_hsaco_metadata_arg_t args[] = {
+      MakeArg(IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_GLOBAL_BUFFER,
+              /*offset=*/0, /*size=*/8),
+      MakeArg(IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+              /*offset=*/16, /*size=*/8),
+  };
+  iree_hal_amdgpu_hsaco_metadata_kernel_t kernel =
+      MakeKernel(/*kernarg_size=*/16, args, IREE_ARRAYSIZE(args));
+  iree_hal_amdgpu_device_kernel_args_t kernel_args =
+      MakeKernelArgs(/*kernarg_size=*/16);
+
+  iree_host_size_t explicit_kernarg_size = 0;
+  uint16_t implicit_args_offset = 0;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_executable_raw_hsaco_custom_kernarg_layout(
+          &kernel, &kernel_args, &explicit_kernarg_size,
+          &implicit_args_offset));
 }
 
 }  // namespace

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_test.cc
@@ -295,8 +295,8 @@ TEST(ExecutableTest, RawHsacoCustomKernargLayoutRejectsInterleavedHiddenArgs) {
   iree_hal_amdgpu_hsaco_metadata_kernel_t kernel =
       MakeKernel(/*kernarg_size=*/8 + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE,
                  args, IREE_ARRAYSIZE(args));
-  iree_hal_amdgpu_device_kernel_args_t kernel_args =
-      MakeKernelArgs(/*kernarg_size=*/8 + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE);
+  iree_hal_amdgpu_device_kernel_args_t kernel_args = MakeKernelArgs(
+      /*kernarg_size=*/8 + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE);
 
   iree_host_size_t explicit_kernarg_size = 0;
   uint16_t implicit_args_offset = 0;
@@ -328,7 +328,8 @@ TEST(ExecutableTest, RawHsacoCustomKernargLayoutAcceptsFullImplicitSuffix) {
   EXPECT_EQ(implicit_args_offset, 16u);
 }
 
-TEST(ExecutableTest, RawHsacoCustomKernargLayoutRejectsTruncatedImplicitSuffix) {
+TEST(ExecutableTest,
+     RawHsacoCustomKernargLayoutRejectsTruncatedImplicitSuffix) {
   const iree_hal_amdgpu_hsaco_metadata_arg_t args[] = {
       MakeArg(IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_GLOBAL_BUFFER,
               /*offset=*/0, /*size=*/8),

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
@@ -261,9 +261,8 @@ static iree_status_t iree_hal_amdgpu_host_queue_validate_dispatch_kernargs(
             "dispatch kernargs require too many blocks (%" PRIhsz ", max=%u)",
             provided_kernarg_block_count, UINT32_MAX);
       }
-      *out_kernarg_block_count =
-          iree_max(*out_kernarg_block_count,
-                   (uint32_t)provided_kernarg_block_count);
+      *out_kernarg_block_count = iree_max(
+          *out_kernarg_block_count, (uint32_t)provided_kernarg_block_count);
     }
   } else {
     if (IREE_UNLIKELY(descriptor->custom_direct_only)) {
@@ -569,7 +568,8 @@ static iree_status_t iree_hal_amdgpu_host_queue_submit_direct_dispatch(
   } else {
     iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
         plan->kernel_args, plan->layout, binding_ptrs,
-        (const uint32_t*)constants.data, submission.kernel.kernargs.blocks->data);
+        (const uint32_t*)constants.data,
+        submission.kernel.kernargs.blocks->data);
   }
   iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
       plan->kernel_args, config.workgroup_count,

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
@@ -243,11 +243,18 @@ static iree_status_t iree_hal_amdgpu_host_queue_validate_dispatch_kernargs(
     *out_kernarg_block_count =
         iree_max(1u, descriptor->custom_kernarg_block_count);
     if ((*out_layout)->total_kernarg_size == 0 && constants.data_length > 0) {
-      const uint32_t provided_kernarg_block_count =
-          (uint32_t)iree_host_size_ceil_div(
-              constants.data_length, sizeof(iree_hal_amdgpu_kernarg_block_t));
+      const iree_host_size_t provided_kernarg_block_count =
+          iree_host_size_ceil_div(constants.data_length,
+                                  sizeof(iree_hal_amdgpu_kernarg_block_t));
+      if (IREE_UNLIKELY(provided_kernarg_block_count > UINT32_MAX)) {
+        return iree_make_status(
+            IREE_STATUS_OUT_OF_RANGE,
+            "dispatch kernargs require too many blocks (%" PRIhsz ", max=%u)",
+            provided_kernarg_block_count, UINT32_MAX);
+      }
       *out_kernarg_block_count =
-          iree_max(*out_kernarg_block_count, provided_kernarg_block_count);
+          iree_max(*out_kernarg_block_count,
+                   (uint32_t)provided_kernarg_block_count);
     }
   } else {
     if (IREE_UNLIKELY(constants.data_length > 0 && !constants.data)) {

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
@@ -543,16 +543,17 @@ static iree_status_t iree_hal_amdgpu_host_queue_submit_direct_dispatch(
 
   if (uses_custom_direct_arguments) {
     iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
-        plan->kernel_args, config.workgroup_count,
-        config.dynamic_workgroup_local_memory, plan->layout, constants.data,
-        constants.data_length, submission.kernel.kernargs.blocks->data);
+        plan->layout, constants.data, constants.data_length,
+        submission.kernel.kernargs.blocks->data);
   } else {
     iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
-        plan->kernel_args, config.workgroup_count,
-        config.dynamic_workgroup_local_memory, plan->layout, binding_ptrs,
-        (const uint32_t*)constants.data,
-        submission.kernel.kernargs.blocks->data);
+        plan->kernel_args, plan->layout, binding_ptrs,
+        (const uint32_t*)constants.data, submission.kernel.kernargs.blocks->data);
   }
+  iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
+      plan->kernel_args, config.workgroup_count,
+      config.dynamic_workgroup_local_memory, plan->layout,
+      submission.kernel.kernargs.blocks->data);
   iree_hal_amdgpu_device_dispatch_emplace_packet(
       plan->kernel_args, config.workgroup_count,
       config.dynamic_workgroup_local_memory,
@@ -739,15 +740,17 @@ static iree_status_t iree_hal_amdgpu_host_queue_submit_indirect_dispatch(
   const uint32_t placeholder_workgroup_count[3] = {0, 0, 0};
   if (uses_custom_direct_arguments) {
     iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
-        plan->kernel_args, placeholder_workgroup_count,
-        config.dynamic_workgroup_local_memory, plan->layout, constants.data,
-        constants.data_length, dispatch_kernarg_data);
+        plan->layout, constants.data, constants.data_length,
+        dispatch_kernarg_data);
   } else {
     iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
-        plan->kernel_args, placeholder_workgroup_count,
-        config.dynamic_workgroup_local_memory, plan->layout, binding_ptrs,
+        plan->kernel_args, plan->layout, binding_ptrs,
         (const uint32_t*)constants.data, dispatch_kernarg_data);
   }
+  iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
+      plan->kernel_args, placeholder_workgroup_count,
+      config.dynamic_workgroup_local_memory, plan->layout,
+      dispatch_kernarg_data);
   iree_hal_amdgpu_device_dispatch_emplace_packet(
       plan->kernel_args, placeholder_workgroup_count,
       config.dynamic_workgroup_local_memory, &dispatch_packet->dispatch,

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
@@ -112,7 +112,16 @@ static iree_status_t iree_hal_amdgpu_host_queue_validate_dispatch_shape(
     const iree_hal_dispatch_config_t config, iree_hal_dispatch_flags_t flags) {
   const bool uses_indirect_parameters =
       iree_hal_dispatch_uses_indirect_parameters(flags);
-  if (iree_hal_amdgpu_dispatch_config_has_workgroup_size_override(config)) {
+  const bool has_workgroup_size_override =
+      iree_hal_amdgpu_dispatch_config_has_workgroup_size_override(config);
+  if (IREE_UNLIKELY(descriptor->custom_direct_only &&
+                    !has_workgroup_size_override)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "custom-direct-only ELF exports require a dispatch workgroup size "
+        "override");
+  }
+  if (has_workgroup_size_override) {
     for (iree_host_size_t i = 0; i < 3; ++i) {
       const uint64_t grid_size =
           (uint64_t)config.workgroup_count[i] * kernel_args->workgroup_size[i];

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
@@ -257,6 +257,11 @@ static iree_status_t iree_hal_amdgpu_host_queue_validate_dispatch_kernargs(
                    (uint32_t)provided_kernarg_block_count);
     }
   } else {
+    if (IREE_UNLIKELY(descriptor->custom_direct_only)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "dispatch export requires custom direct kernarg arguments");
+    }
     if (IREE_UNLIKELY(constants.data_length > 0 && !constants.data)) {
       return iree_make_status(
           IREE_STATUS_INVALID_ARGUMENT,

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
@@ -221,13 +221,17 @@ static iree_status_t iree_hal_amdgpu_host_queue_validate_dispatch_kernargs(
 
   iree_host_size_t operation_resource_count = 1;
   if (iree_any_bit_set(flags, IREE_HAL_DISPATCH_FLAG_CUSTOM_DIRECT_ARGUMENTS)) {
-    if (IREE_UNLIKELY(constants.data_length !=
-                      descriptor->kernel_args.kernarg_size)) {
+    const uint32_t required_explicit_bytes =
+        (uint32_t)descriptor->custom_kernarg_layout.explicit_kernarg_size;
+    const iree_host_size_t padded_constant_length =
+        iree_host_align(constants.data_length, /*alignment=*/8);
+    if (IREE_UNLIKELY(padded_constant_length < required_explicit_bytes)) {
       return iree_make_status(
           IREE_STATUS_INVALID_ARGUMENT,
-          "custom dispatch argument length mismatch; expected %u but got "
-          "%" PRIhsz,
-          descriptor->kernel_args.kernarg_size, constants.data_length);
+          "custom dispatch argument length too short; expected at least %u "
+          "but got %" PRIhsz " (padded to %" PRIhsz ")",
+          required_explicit_bytes, constants.data_length,
+          padded_constant_length);
     }
     if (IREE_UNLIKELY(constants.data_length > 0 && !constants.data)) {
       return iree_make_status(
@@ -238,6 +242,13 @@ static iree_status_t iree_hal_amdgpu_host_queue_validate_dispatch_kernargs(
     *out_layout = &descriptor->custom_kernarg_layout;
     *out_kernarg_block_count =
         iree_max(1u, descriptor->custom_kernarg_block_count);
+    if ((*out_layout)->total_kernarg_size == 0 && constants.data_length > 0) {
+      const uint32_t provided_kernarg_block_count =
+          (uint32_t)iree_host_size_ceil_div(
+              constants.data_length, sizeof(iree_hal_amdgpu_kernarg_block_t));
+      *out_kernarg_block_count =
+          iree_max(*out_kernarg_block_count, provided_kernarg_block_count);
+    }
   } else {
     if (IREE_UNLIKELY(constants.data_length > 0 && !constants.data)) {
       return iree_make_status(
@@ -532,7 +543,9 @@ static iree_status_t iree_hal_amdgpu_host_queue_submit_direct_dispatch(
 
   if (uses_custom_direct_arguments) {
     iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
-        plan->layout, constants.data, submission.kernel.kernargs.blocks->data);
+        plan->kernel_args, config.workgroup_count,
+        config.dynamic_workgroup_local_memory, plan->layout, constants.data,
+        constants.data_length, submission.kernel.kernargs.blocks->data);
   } else {
     iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
         plan->kernel_args, config.workgroup_count,
@@ -726,7 +739,9 @@ static iree_status_t iree_hal_amdgpu_host_queue_submit_indirect_dispatch(
   const uint32_t placeholder_workgroup_count[3] = {0, 0, 0};
   if (uses_custom_direct_arguments) {
     iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
-        plan->layout, constants.data, dispatch_kernarg_data);
+        plan->kernel_args, placeholder_workgroup_count,
+        config.dynamic_workgroup_local_memory, plan->layout, constants.data,
+        constants.data_length, dispatch_kernarg_data);
   } else {
     iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
         plan->kernel_args, placeholder_workgroup_count,

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -1427,14 +1427,13 @@ iree_hal_amdgpu_hsaco_metadata_append_elf_kernel_symbols(
         continue;
       }
       ++extra_count;
-      IREE_RETURN_IF_ERROR(iree_host_size_checked_add(
+      if (!iree_host_size_checked_add(
           extra_symbol_name_storage_size, name.size + 3,
-          &extra_symbol_name_storage_size)
-                            ? iree_ok_status()
-                            : iree_make_status(
-                                  IREE_STATUS_OUT_OF_RANGE,
-                                  "AMDGPU metadata symbol name storage "
-                                  "size overflow"));
+          &extra_symbol_name_storage_size)) {
+            return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                                    "AMDGPU metadata symbol name storage "
+                                    "size overflow");
+      }
     }
   }
   if (extra_count == 0) return iree_ok_status();

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -1169,8 +1169,8 @@ static bool iree_hal_amdgpu_hsaco_metadata_elf_section(
     return false;
   }
   iree_host_size_t section_offset_host = 0;
-  if (!iree_hal_amdgpu_hsaco_metadata_u64_to_host_size(
-          section_offset, &section_offset_host)) {
+  if (!iree_hal_amdgpu_hsaco_metadata_u64_to_host_size(section_offset,
+                                                       &section_offset_host)) {
     return false;
   }
   iree_host_size_t section_relative_offset = 0;
@@ -1224,9 +1224,9 @@ static iree_string_view_t iree_hal_amdgpu_hsaco_metadata_elf_symbol_name(
   }
   iree_host_size_t symbol_section_offset = 0;
   iree_host_size_t symbol_section_size = 0;
-  if (!iree_hal_amdgpu_hsaco_metadata_section_range(
-          elf_data, symbol_section, &symbol_section_offset,
-          &symbol_section_size)) {
+  if (!iree_hal_amdgpu_hsaco_metadata_section_range(elf_data, symbol_section,
+                                                    &symbol_section_offset,
+                                                    &symbol_section_size)) {
     return iree_string_view_empty();
   }
   const iree_host_size_t symbol_entry_size =
@@ -1282,8 +1282,8 @@ static bool iree_hal_amdgpu_hsaco_metadata_symbol_section_range(
       iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
   iree_host_size_t symbol_entry_size = 0;
   if (symbol_entry_size_u64 < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
-      !iree_hal_amdgpu_hsaco_metadata_u64_to_host_size(
-          symbol_entry_size_u64, &symbol_entry_size)) {
+      !iree_hal_amdgpu_hsaco_metadata_u64_to_host_size(symbol_entry_size_u64,
+                                                       &symbol_entry_size)) {
     return false;
   }
 
@@ -1302,10 +1302,11 @@ static bool iree_hal_amdgpu_hsaco_metadata_elf_symbol_ptr(
   iree_host_size_t symbol_offset = 0;
   if (!iree_host_size_checked_mul(symbol_index, symbol_entry_size,
                                   &symbol_relative_offset) ||
-      !iree_host_size_checked_add(symbol_section_offset,
-                                  symbol_relative_offset, &symbol_offset) ||
+      !iree_host_size_checked_add(symbol_section_offset, symbol_relative_offset,
+                                  &symbol_offset) ||
       symbol_offset > elf_data.data_length ||
-      IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE > elf_data.data_length - symbol_offset) {
+      IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE >
+          elf_data.data_length - symbol_offset) {
     return false;
   }
   *out_symbol = elf_data.data + symbol_offset;
@@ -1333,8 +1334,8 @@ static bool iree_hal_amdgpu_hsaco_metadata_find_kernel_descriptor_symbol(
   for (uint16_t section_index = 0; section_index < section_count;
        ++section_index) {
     const uint8_t* section = NULL;
-    if (!iree_hal_amdgpu_hsaco_metadata_elf_section(
-            elf_data, section_index, &section)) {
+    if (!iree_hal_amdgpu_hsaco_metadata_elf_section(elf_data, section_index,
+                                                    &section)) {
       continue;
     }
     uint32_t section_type =
@@ -1354,8 +1355,7 @@ static bool iree_hal_amdgpu_hsaco_metadata_find_kernel_descriptor_symbol(
     for (iree_host_size_t i = 0; i < symbol_count; ++i) {
       const uint8_t* symbol = NULL;
       if (!iree_hal_amdgpu_hsaco_metadata_elf_symbol_ptr(
-              elf_data, symbol_section_offset, symbol_entry_size, i,
-              &symbol)) {
+              elf_data, symbol_section_offset, symbol_entry_size, i, &symbol)) {
         continue;
       }
       uint8_t binding = symbol[4] >> 4;
@@ -1421,8 +1421,8 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_count_elf_kernel_symbols(
   for (uint16_t section_index = 0; section_index < section_count;
        ++section_index) {
     const uint8_t* section = NULL;
-    if (!iree_hal_amdgpu_hsaco_metadata_elf_section(
-            elf_data, section_index, &section)) {
+    if (!iree_hal_amdgpu_hsaco_metadata_elf_section(elf_data, section_index,
+                                                    &section)) {
       continue;
     }
     uint32_t section_type =
@@ -1442,8 +1442,7 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_count_elf_kernel_symbols(
     for (iree_host_size_t i = 0; i < symbol_count; ++i) {
       const uint8_t* symbol = NULL;
       if (!iree_hal_amdgpu_hsaco_metadata_elf_symbol_ptr(
-              elf_data, symbol_section_offset, symbol_entry_size, i,
-              &symbol)) {
+              elf_data, symbol_section_offset, symbol_entry_size, i, &symbol)) {
         continue;
       }
       uint8_t binding = symbol[4] >> 4;
@@ -1475,21 +1474,20 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_count_elf_kernel_symbols(
 static iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_elf_kernel_symbols(
     iree_hal_amdgpu_hsaco_metadata_t* metadata) {
   iree_host_size_t candidate_count = 0;
-  IREE_RETURN_IF_ERROR(
-      iree_hal_amdgpu_hsaco_metadata_count_elf_kernel_symbols(
-          metadata, &candidate_count));
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_metadata_count_elf_kernel_symbols(
+      metadata, &candidate_count));
   if (candidate_count == 0) return iree_ok_status();
 
   iree_host_size_t elf_kernel_symbols_size = 0;
-  if (!iree_host_size_checked_mul(
-          candidate_count, sizeof(metadata->elf_kernel_symbols[0]),
-          &elf_kernel_symbols_size)) {
+  if (!iree_host_size_checked_mul(candidate_count,
+                                  sizeof(metadata->elf_kernel_symbols[0]),
+                                  &elf_kernel_symbols_size)) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "AMDGPU ELF-only kernel symbol storage overflow");
   }
-  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
-      metadata->host_allocator, elf_kernel_symbols_size,
-      (void**)&metadata->elf_kernel_symbols));
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(metadata->host_allocator, elf_kernel_symbols_size,
+                            (void**)&metadata->elf_kernel_symbols));
   memset(metadata->elf_kernel_symbols, 0, elf_kernel_symbols_size);
 
   iree_const_byte_span_t elf_data = metadata->elf_data;
@@ -1499,8 +1497,8 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_elf_kernel_symbols(
   for (uint16_t section_index = 0; section_index < section_count;
        ++section_index) {
     const uint8_t* section = NULL;
-    if (!iree_hal_amdgpu_hsaco_metadata_elf_section(
-            elf_data, section_index, &section)) {
+    if (!iree_hal_amdgpu_hsaco_metadata_elf_section(elf_data, section_index,
+                                                    &section)) {
       continue;
     }
     uint32_t section_type =
@@ -1520,8 +1518,7 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_elf_kernel_symbols(
     for (iree_host_size_t i = 0; i < symbol_count; ++i) {
       const uint8_t* symbol = NULL;
       if (!iree_hal_amdgpu_hsaco_metadata_elf_symbol_ptr(
-              elf_data, symbol_section_offset, symbol_entry_size, i,
-              &symbol)) {
+              elf_data, symbol_section_offset, symbol_entry_size, i, &symbol)) {
         continue;
       }
       uint8_t binding = symbol[4] >> 4;
@@ -1583,8 +1580,8 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
         out_metadata->message_pack_data, out_metadata);
   }
   if (iree_status_is_ok(status)) {
-    status =
-        iree_hal_amdgpu_hsaco_metadata_populate_elf_kernel_symbols(out_metadata);
+    status = iree_hal_amdgpu_hsaco_metadata_populate_elf_kernel_symbols(
+        out_metadata);
   }
   if (!iree_status_is_ok(status)) {
     iree_hal_amdgpu_hsaco_metadata_deinitialize(out_metadata);
@@ -1705,7 +1702,8 @@ iree_hal_amdgpu_hsaco_metadata_calculate_flatbuffer_hal_export_parameter_require
         IREE_STATUS_OUT_OF_RANGE,
         "AMDGPU metadata reflected constant byte count exceeds HAL range");
   }
-  const iree_host_size_t constant_count = constant_byte_count / sizeof(uint32_t);
+  const iree_host_size_t constant_count =
+      constant_byte_count / sizeof(uint32_t);
   if (parameter_count > UINT16_MAX || binding_count > UINT16_MAX ||
       constant_count > UINT16_MAX) {
     return iree_make_status(
@@ -1720,7 +1718,8 @@ iree_hal_amdgpu_hsaco_metadata_calculate_flatbuffer_hal_export_parameter_require
   return iree_ok_status();
 }
 
-iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_flatbuffer_hal_export_parameters(
+iree_status_t
+iree_hal_amdgpu_hsaco_metadata_populate_flatbuffer_hal_export_parameters(
     const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
     iree_host_size_t parameter_capacity,
     iree_hal_executable_function_parameter_t* out_parameters,

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -22,9 +22,16 @@
 #define IREE_HAL_AMDGPU_ELF_MACHINE_AMDGPU 224
 #define IREE_HAL_AMDGPU_ELF_PT_NOTE 4
 #define IREE_HAL_AMDGPU_ELF_NOTE_AMDGPU_METADATA 32
+#define IREE_HAL_AMDGPU_ELF_SHT_SYMTAB 2
+#define IREE_HAL_AMDGPU_ELF_SHT_DYNSYM 11
+#define IREE_HAL_AMDGPU_ELF_STT_FUNC 2
+#define IREE_HAL_AMDGPU_ELF_STB_GLOBAL 1
+#define IREE_HAL_AMDGPU_ELF_STB_WEAK 2
 
 #define IREE_HAL_AMDGPU_ELF64_HEADER_SIZE 64
 #define IREE_HAL_AMDGPU_ELF64_PROGRAM_HEADER_SIZE 56
+#define IREE_HAL_AMDGPU_ELF64_SECTION_HEADER_SIZE 64
+#define IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE 24
 
 static uint16_t iree_hal_amdgpu_hsaco_metadata_load_le_u16(const uint8_t* ptr) {
   return iree_unaligned_load_le((const uint16_t*)ptr);
@@ -1143,6 +1150,418 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_allocate_storage(
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_amdgpu_hsaco_metadata_elf_section(
+    iree_const_byte_span_t elf_data, uint16_t section_index,
+    const uint8_t** out_section) {
+  *out_section = NULL;
+  if (elf_data.data_length < IREE_HAL_AMDGPU_ELF64_HEADER_SIZE) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU ELF data too small");
+  }
+  const uint8_t* header = elf_data.data;
+  uint64_t section_offset =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(header + 40);
+  uint16_t section_entry_size =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 58);
+  uint16_t section_count =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 60);
+  if (section_index >= section_count ||
+      section_entry_size < IREE_HAL_AMDGPU_ELF64_SECTION_HEADER_SIZE) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "AMDGPU ELF section index out of range");
+  }
+  uint64_t selected_offset =
+      section_offset + (uint64_t)section_index * section_entry_size;
+  if (selected_offset > elf_data.data_length ||
+      IREE_HAL_AMDGPU_ELF64_SECTION_HEADER_SIZE >
+          elf_data.data_length - selected_offset) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU ELF section header out of bounds");
+  }
+  *out_section = elf_data.data + selected_offset;
+  return iree_ok_status();
+}
+
+static iree_string_view_t iree_hal_amdgpu_hsaco_metadata_elf_symbol_name(
+    iree_const_byte_span_t elf_data, const uint8_t* symbol_section,
+    iree_host_size_t symbol_index) {
+  uint64_t symbol_section_offset =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(symbol_section + 24);
+  uint64_t symbol_section_size =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(symbol_section + 32);
+  uint64_t symbol_entry_size =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(symbol_section + 56);
+  if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE) {
+    return iree_string_view_empty();
+  }
+  uint64_t symbol_offset =
+      symbol_section_offset + (uint64_t)symbol_index * symbol_entry_size;
+  if (symbol_offset > elf_data.data_length ||
+      IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE >
+          elf_data.data_length - symbol_offset ||
+      symbol_offset >= symbol_section_offset + symbol_section_size) {
+    return iree_string_view_empty();
+  }
+  const uint8_t* symbol = elf_data.data + symbol_offset;
+  uint32_t name_offset = iree_hal_amdgpu_hsaco_metadata_load_le_u32(symbol);
+  uint32_t string_section_index =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u32(symbol_section + 40);
+  const uint8_t* string_section = NULL;
+  if (!iree_status_is_ok(iree_hal_amdgpu_hsaco_metadata_elf_section(
+          elf_data, (uint16_t)string_section_index, &string_section))) {
+    return iree_string_view_empty();
+  }
+  uint64_t string_offset =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(string_section + 24);
+  uint64_t string_size =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(string_section + 32);
+  if (name_offset >= string_size ||
+      string_offset + name_offset >= elf_data.data_length) {
+    return iree_string_view_empty();
+  }
+  const char* name = (const char*)elf_data.data + string_offset + name_offset;
+  const char* end = (const char*)elf_data.data + string_offset + string_size;
+  const char* p = name;
+  while (p < end && *p) ++p;
+  return iree_make_string_view(name, (iree_host_size_t)(p - name));
+}
+
+static bool iree_hal_amdgpu_hsaco_metadata_kernel_name_exists(
+    const iree_hal_amdgpu_hsaco_metadata_t* metadata,
+    iree_host_size_t kernel_count, iree_string_view_t name) {
+  for (iree_host_size_t i = 0; i < kernel_count; ++i) {
+    const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel =
+        &metadata->kernels[i];
+    if (iree_string_view_equal(kernel->symbol_name, name) ||
+        iree_string_view_equal(kernel->reflection_name, name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool iree_hal_amdgpu_hsaco_metadata_is_kernel_descriptor_name(
+    iree_string_view_t descriptor_name, iree_string_view_t kernel_name) {
+  return descriptor_name.size == kernel_name.size + 3 &&
+         iree_string_view_starts_with(descriptor_name, kernel_name) &&
+         iree_string_view_ends_with(descriptor_name, IREE_SV(".kd"));
+}
+
+static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_descriptor_symbol(
+    iree_const_byte_span_t elf_data, iree_string_view_t kernel_name) {
+  if (iree_string_view_is_empty(kernel_name) ||
+      elf_data.data_length < IREE_HAL_AMDGPU_ELF64_HEADER_SIZE) {
+    return false;
+  }
+  const uint8_t* header = elf_data.data;
+  uint16_t section_count =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 60);
+  for (uint16_t section_index = 0; section_index < section_count;
+       ++section_index) {
+    const uint8_t* section = NULL;
+    if (!iree_status_is_ok(iree_hal_amdgpu_hsaco_metadata_elf_section(
+            elf_data, section_index, &section))) {
+      return false;
+    }
+    uint32_t section_type =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u32(section + 4);
+    if (section_type != IREE_HAL_AMDGPU_ELF_SHT_DYNSYM &&
+        section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
+      continue;
+    }
+    uint64_t symbol_section_offset =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
+    uint64_t symbol_section_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
+    uint64_t symbol_entry_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
+    if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
+        symbol_section_offset > elf_data.data_length ||
+        symbol_section_size > elf_data.data_length - symbol_section_offset) {
+      continue;
+    }
+    iree_host_size_t symbol_count =
+        (iree_host_size_t)(symbol_section_size / symbol_entry_size);
+    for (iree_host_size_t i = 0; i < symbol_count; ++i) {
+      const uint8_t* symbol =
+          elf_data.data + symbol_section_offset + (uint64_t)i * symbol_entry_size;
+      uint8_t binding = symbol[4] >> 4;
+      if (binding != IREE_HAL_AMDGPU_ELF_STB_GLOBAL &&
+          binding != IREE_HAL_AMDGPU_ELF_STB_WEAK) {
+        continue;
+      }
+      iree_string_view_t name =
+          iree_hal_amdgpu_hsaco_metadata_elf_symbol_name(elf_data, section, i);
+      if (iree_hal_amdgpu_hsaco_metadata_is_kernel_descriptor_name(
+              name, kernel_name)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+static bool iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
+    iree_const_byte_span_t elf_data, const uint8_t* symbol_section,
+    const uint8_t* symbol, iree_host_size_t symbol_index,
+    iree_string_view_t* out_name) {
+  *out_name = iree_string_view_empty();
+  uint8_t binding = symbol[4] >> 4;
+  uint8_t type = symbol[4] & 0x0F;
+  if (type != IREE_HAL_AMDGPU_ELF_STT_FUNC ||
+      (binding != IREE_HAL_AMDGPU_ELF_STB_GLOBAL &&
+       binding != IREE_HAL_AMDGPU_ELF_STB_WEAK)) {
+    return false;
+  }
+  iree_string_view_t name = iree_hal_amdgpu_hsaco_metadata_elf_symbol_name(
+      elf_data, symbol_section, symbol_index);
+  if (iree_string_view_is_empty(name) ||
+      !iree_hal_amdgpu_hsaco_metadata_has_kernel_descriptor_symbol(elf_data,
+                                                                   name)) {
+    return false;
+  }
+  *out_name = name;
+  return true;
+}
+
+static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_function_symbol(
+    iree_const_byte_span_t elf_data, iree_string_view_t kernel_name) {
+  if (iree_string_view_is_empty(kernel_name) ||
+      elf_data.data_length < IREE_HAL_AMDGPU_ELF64_HEADER_SIZE) {
+    return false;
+  }
+  const uint8_t* header = elf_data.data;
+  uint16_t section_count =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 60);
+  for (uint16_t section_index = 0; section_index < section_count;
+       ++section_index) {
+    const uint8_t* section = NULL;
+    if (!iree_status_is_ok(iree_hal_amdgpu_hsaco_metadata_elf_section(
+            elf_data, section_index, &section))) {
+      return false;
+    }
+    uint32_t section_type =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u32(section + 4);
+    if (section_type != IREE_HAL_AMDGPU_ELF_SHT_DYNSYM &&
+        section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
+      continue;
+    }
+    uint64_t symbol_section_offset =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
+    uint64_t symbol_section_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
+    uint64_t symbol_entry_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
+    if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
+        symbol_section_offset > elf_data.data_length ||
+        symbol_section_size > elf_data.data_length - symbol_section_offset) {
+      continue;
+    }
+    iree_host_size_t symbol_count =
+        (iree_host_size_t)(symbol_section_size / symbol_entry_size);
+    for (iree_host_size_t i = 0; i < symbol_count; ++i) {
+      const uint8_t* symbol =
+          elf_data.data + symbol_section_offset + (uint64_t)i * symbol_entry_size;
+      iree_string_view_t name = iree_string_view_empty();
+      if (iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
+              elf_data, section, symbol, i, &name) &&
+          iree_string_view_equal(name, kernel_name)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+static iree_status_t
+iree_hal_amdgpu_hsaco_metadata_append_elf_kernel_symbols(
+    iree_hal_amdgpu_hsaco_metadata_t* metadata) {
+  iree_const_byte_span_t elf_data = metadata->elf_data;
+  if (elf_data.data_length < IREE_HAL_AMDGPU_ELF64_HEADER_SIZE) {
+    return iree_ok_status();
+  }
+  const uint8_t* header = elf_data.data;
+  uint64_t section_offset =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(header + 40);
+  uint16_t section_entry_size =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 58);
+  uint16_t section_count =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 60);
+  if (section_entry_size < IREE_HAL_AMDGPU_ELF64_SECTION_HEADER_SIZE ||
+      section_offset > elf_data.data_length) {
+    return iree_ok_status();
+  }
+
+  iree_host_size_t extra_count = 0;
+  iree_host_size_t extra_symbol_name_storage_size = 0;
+  for (uint16_t section_index = 0; section_index < section_count;
+       ++section_index) {
+    const uint8_t* section = NULL;
+    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_metadata_elf_section(
+        elf_data, section_index, &section));
+    uint32_t section_type = iree_hal_amdgpu_hsaco_metadata_load_le_u32(section + 4);
+    if (section_type != IREE_HAL_AMDGPU_ELF_SHT_DYNSYM &&
+        section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
+      continue;
+    }
+    uint64_t symbol_section_offset =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
+    uint64_t symbol_section_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
+    uint64_t symbol_entry_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
+    if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
+        symbol_section_offset > elf_data.data_length) {
+      continue;
+    }
+    iree_host_size_t symbol_count =
+        (iree_host_size_t)(symbol_section_size / symbol_entry_size);
+    for (iree_host_size_t i = 0; i < symbol_count; ++i) {
+      const uint8_t* symbol =
+          elf_data.data + symbol_section_offset + (uint64_t)i * symbol_entry_size;
+      iree_string_view_t name = iree_string_view_empty();
+      if (!iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
+              elf_data, section, symbol, i, &name) ||
+          iree_hal_amdgpu_hsaco_metadata_kernel_name_exists(
+              metadata, metadata->kernel_count, name)) {
+        continue;
+      }
+      ++extra_count;
+      IREE_RETURN_IF_ERROR(iree_host_size_checked_add(
+          extra_symbol_name_storage_size, name.size + 3,
+          &extra_symbol_name_storage_size)
+                            ? iree_ok_status()
+                            : iree_make_status(
+                                  IREE_STATUS_OUT_OF_RANGE,
+                                  "AMDGPU metadata symbol name storage "
+                                  "size overflow"));
+    }
+  }
+  if (extra_count == 0) return iree_ok_status();
+
+  iree_host_size_t template_kernel_index = IREE_HOST_SIZE_MAX;
+  for (iree_host_size_t i = 0; i < metadata->kernel_count; ++i) {
+    iree_string_view_t template_name = iree_string_view_strip_suffix(
+        metadata->kernels[i].symbol_name, IREE_SV(".kd"));
+    if (metadata->kernels[i].arg_count > 0 &&
+        iree_hal_amdgpu_hsaco_metadata_has_kernel_function_symbol(
+            elf_data, template_name)) {
+      template_kernel_index = i;
+      break;
+    }
+  }
+  if (template_kernel_index == IREE_HOST_SIZE_MAX) {
+    return iree_ok_status();
+  }
+
+  iree_hal_amdgpu_hsaco_metadata_t expanded = *metadata;
+  iree_hal_amdgpu_hsaco_metadata_count_t expanded_count = {
+      .kernel_count = metadata->kernel_count + extra_count,
+      .arg_count = metadata->arg_count,
+  };
+  expanded.kernels = NULL;
+  expanded.args = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_metadata_allocate_storage(
+      expanded_count, metadata->host_allocator, &expanded));
+  char* extra_symbol_name_storage = NULL;
+  if (extra_symbol_name_storage_size) {
+    IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+        metadata->host_allocator, extra_symbol_name_storage_size,
+        (void**)&extra_symbol_name_storage));
+    expanded.owned_string_storage = extra_symbol_name_storage;
+  }
+  if (metadata->arg_count) {
+    memcpy(expanded.args, metadata->args,
+           metadata->arg_count * sizeof(metadata->args[0]));
+  }
+  for (iree_host_size_t i = 0; i < metadata->kernel_count; ++i) {
+    expanded.kernels[i] = metadata->kernels[i];
+    if (metadata->kernels[i].args) {
+      iree_host_size_t arg_offset =
+          (iree_host_size_t)(metadata->kernels[i].args - metadata->args);
+      expanded.kernels[i].args = &expanded.args[arg_offset];
+    }
+  }
+
+  iree_host_size_t write_index = metadata->kernel_count;
+  iree_host_size_t extra_symbol_name_storage_offset = 0;
+  for (uint16_t section_index = 0; section_index < section_count;
+       ++section_index) {
+    const uint8_t* section = NULL;
+    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_metadata_elf_section(
+        elf_data, section_index, &section));
+    uint32_t section_type = iree_hal_amdgpu_hsaco_metadata_load_le_u32(section + 4);
+    if (section_type != IREE_HAL_AMDGPU_ELF_SHT_DYNSYM &&
+        section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
+      continue;
+    }
+    uint64_t symbol_section_offset =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
+    uint64_t symbol_section_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
+    uint64_t symbol_entry_size =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
+    if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
+        symbol_section_offset > elf_data.data_length) {
+      continue;
+    }
+    iree_host_size_t symbol_count =
+        (iree_host_size_t)(symbol_section_size / symbol_entry_size);
+    for (iree_host_size_t i = 0; i < symbol_count; ++i) {
+      const uint8_t* symbol =
+          elf_data.data + symbol_section_offset + (uint64_t)i * symbol_entry_size;
+      iree_string_view_t name = iree_string_view_empty();
+      if (!iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
+              elf_data, section, symbol, i, &name) ||
+          iree_hal_amdgpu_hsaco_metadata_kernel_name_exists(
+              &expanded, write_index, name)) {
+        continue;
+      }
+      iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel =
+          &expanded.kernels[write_index++];
+      memset(kernel, 0, sizeof(*kernel));
+      char* symbol_name_storage =
+          extra_symbol_name_storage + extra_symbol_name_storage_offset;
+      memcpy(symbol_name_storage, name.data, name.size);
+      memcpy(symbol_name_storage + name.size, ".kd", 3);
+      extra_symbol_name_storage_offset += name.size + 3;
+      kernel->name = name;
+      kernel->symbol_name =
+          iree_make_string_view(symbol_name_storage, name.size + 3);
+      kernel->reflection_name = name;
+      const iree_hal_amdgpu_hsaco_metadata_kernel_t* template_kernel =
+          &expanded.kernels[template_kernel_index];
+      kernel->arg_name_storage_size = template_kernel->arg_name_storage_size;
+      kernel->kernarg_segment_size = template_kernel->kernarg_segment_size;
+      kernel->kernarg_segment_alignment =
+          template_kernel->kernarg_segment_alignment;
+      kernel->group_segment_fixed_size =
+          template_kernel->group_segment_fixed_size;
+      kernel->private_segment_fixed_size =
+          template_kernel->private_segment_fixed_size;
+      memcpy(kernel->required_workgroup_size,
+             template_kernel->required_workgroup_size,
+             sizeof(kernel->required_workgroup_size));
+      kernel->has_required_workgroup_size =
+          template_kernel->has_required_workgroup_size;
+      kernel->arg_count = template_kernel->arg_count;
+      kernel->args = template_kernel->args;
+      kernel->uses_borrowed_arg_layout = true;
+    }
+  }
+  expanded.kernel_count = write_index;
+
+  if (metadata->owned_string_storage) {
+    iree_allocator_free(metadata->host_allocator, metadata->owned_string_storage);
+  }
+  iree_allocator_free(metadata->host_allocator, metadata->kernels);
+  metadata->kernels = expanded.kernels;
+  metadata->args = expanded.args;
+  metadata->owned_string_storage = expanded.owned_string_storage;
+  metadata->kernel_count = expanded.kernel_count;
+  return iree_ok_status();
+}
+
 iree_status_t iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
     iree_const_byte_span_t elf_data, iree_allocator_t host_allocator,
     iree_hal_amdgpu_hsaco_metadata_t* out_metadata) {
@@ -1169,6 +1588,10 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
     status = iree_hal_amdgpu_hsaco_metadata_parse_message_pack(
         out_metadata->message_pack_data, out_metadata);
   }
+  if (iree_status_is_ok(status)) {
+    status =
+        iree_hal_amdgpu_hsaco_metadata_append_elf_kernel_symbols(out_metadata);
+  }
   if (!iree_status_is_ok(status)) {
     iree_hal_amdgpu_hsaco_metadata_deinitialize(out_metadata);
   }
@@ -1182,6 +1605,9 @@ void iree_hal_amdgpu_hsaco_metadata_deinitialize(
     return;
   }
   IREE_TRACE_ZONE_BEGIN(z0);
+  if (metadata->owned_string_storage) {
+    iree_allocator_free(metadata->host_allocator, metadata->owned_string_storage);
+  }
   if (metadata->kernels) {
     iree_allocator_free(metadata->host_allocator, metadata->kernels);
   }
@@ -1242,7 +1668,7 @@ iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
                 arg, &name_storage_size));
         break;
       case IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_BY_VALUE: {
-        if (arg->size > UINT8_MAX) {
+        if (arg->size > UINT16_MAX) {
           return iree_make_status(
               IREE_STATUS_OUT_OF_RANGE,
               "AMDGPU kernel `%.*s` by_value argument %" PRIhsz
@@ -1250,19 +1676,11 @@ iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
               (int)kernel->symbol_name.size, kernel->symbol_name.data, i,
               arg->size);
         }
-        if (!iree_host_size_has_alignment(arg->size, sizeof(uint32_t))) {
-          return iree_make_status(
-              IREE_STATUS_INVALID_ARGUMENT,
-              "AMDGPU kernel `%.*s` by_value argument %" PRIhsz
-              " size %u is not a whole number of 32-bit HAL constants",
-              (int)kernel->symbol_name.size, kernel->symbol_name.data, i,
-              arg->size);
-        }
-        if (constant_byte_count > UINT16_MAX) {
+        if (arg->offset > UINT16_MAX) {
           return iree_make_status(
               IREE_STATUS_OUT_OF_RANGE,
               "AMDGPU kernel `%.*s` by_value argument %" PRIhsz
-              " constant offset exceeds HAL parameter offset range",
+              " kernarg offset exceeds HAL parameter offset range",
               (int)kernel->symbol_name.size, kernel->symbol_name.data, i);
         }
         ++parameter_count;
@@ -1288,11 +1706,12 @@ iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
   }
 
   iree_host_size_t aligned_constant_byte_count = 0;
-  if (!iree_host_size_checked_align(constant_byte_count, sizeof(uint32_t),
+  if (!iree_host_size_checked_align(kernel->kernarg_segment_size,
+                                    sizeof(uint32_t),
                                     &aligned_constant_byte_count)) {
     return iree_make_status(
         IREE_STATUS_OUT_OF_RANGE,
-        "AMDGPU metadata reflected constant byte count alignment overflow");
+        "AMDGPU metadata kernarg segment size alignment overflow");
   }
   const iree_host_size_t constant_count =
       aligned_constant_byte_count / sizeof(uint32_t);
@@ -1338,8 +1757,6 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
 
   iree_host_size_t parameter_index = 0;
   iree_host_size_t name_storage_offset = 0;
-  uint16_t binding_ordinal = 0;
-  iree_host_size_t constant_offset = 0;
   for (iree_host_size_t i = 0; i < kernel->arg_count; ++i) {
     const iree_hal_amdgpu_hsaco_metadata_arg_t* arg = &kernel->args[i];
     if (iree_hal_amdgpu_hsaco_metadata_arg_kind_is_hidden(arg->kind)) {
@@ -1350,7 +1767,7 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
         &out_parameters[parameter_index++];
     memset(parameter, 0, sizeof(*parameter));
     parameter->flags = IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_FLAG_NONE;
-    parameter->size = (uint8_t)arg->size;
+    parameter->size = (uint16_t)arg->size;
     if (!iree_string_view_is_empty(arg->name)) {
       memcpy(name_storage + name_storage_offset, arg->name.data,
              arg->name.size);
@@ -1361,15 +1778,15 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
       parameter->name = iree_string_view_empty();
     }
 
+    parameter->offset = (uint16_t)arg->offset;
+    parameter->kernarg_offset = (uint16_t)arg->offset;
     switch (arg->kind) {
       case IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_GLOBAL_BUFFER:
         parameter->type = IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_BINDING;
-        parameter->offset = binding_ordinal++;
         break;
       case IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_BY_VALUE:
         parameter->type = IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT;
-        parameter->offset = (uint16_t)constant_offset;
-        constant_offset += arg->size;
+        parameter->offset = (uint16_t)arg->offset;
         break;
       default:
         return iree_make_status(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -1546,7 +1546,6 @@ iree_hal_amdgpu_hsaco_metadata_append_elf_kernel_symbols(
           template_kernel->has_required_workgroup_size;
       kernel->arg_count = template_kernel->arg_count;
       kernel->args = template_kernel->args;
-      kernel->uses_borrowed_arg_layout = true;
     }
   }
   expanded.kernel_count = write_index;
@@ -1779,7 +1778,6 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
     }
 
     parameter->offset = (uint16_t)arg->offset;
-    parameter->kernarg_offset = (uint16_t)arg->offset;
     switch (arg->kind) {
       case IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_GLOBAL_BUFFER:
         parameter->type = IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_BINDING;

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -1632,7 +1632,7 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_add_parameter_name_size(
 }
 
 iree_status_t
-iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
+iree_hal_amdgpu_hsaco_metadata_calculate_flatbuffer_hal_export_parameter_requirements(
     const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
     iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t*
         out_requirements) {
@@ -1666,6 +1666,14 @@ iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
                 arg, &name_storage_size));
         break;
       case IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_BY_VALUE: {
+        if (arg->size % sizeof(uint32_t) != 0) {
+          return iree_make_status(
+              IREE_STATUS_INVALID_ARGUMENT,
+              "AMDGPU kernel `%.*s` by_value argument %" PRIhsz
+              " size %u is not a whole number of HAL constants",
+              (int)kernel->symbol_name.size, kernel->symbol_name.data, i,
+              arg->size);
+        }
         if (arg->size > UINT16_MAX) {
           return iree_make_status(
               IREE_STATUS_OUT_OF_RANGE,
@@ -1673,13 +1681,6 @@ iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
               " size %u exceeds HAL parameter size range",
               (int)kernel->symbol_name.size, kernel->symbol_name.data, i,
               arg->size);
-        }
-        if (arg->offset > UINT16_MAX) {
-          return iree_make_status(
-              IREE_STATUS_OUT_OF_RANGE,
-              "AMDGPU kernel `%.*s` by_value argument %" PRIhsz
-              " kernarg offset exceeds HAL parameter offset range",
-              (int)kernel->symbol_name.size, kernel->symbol_name.data, i);
         }
         ++parameter_count;
         if (!iree_host_size_checked_add(constant_byte_count, arg->size,
@@ -1693,6 +1694,163 @@ iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
                 arg, &name_storage_size));
         break;
       }
+      default:
+        return iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "AMDGPU kernel `%.*s` argument %" PRIhsz
+            " uses unsupported reflected value_kind `%.*s`",
+            (int)kernel->symbol_name.size, kernel->symbol_name.data, i,
+            (int)arg->value_kind.size, arg->value_kind.data);
+    }
+  }
+
+  if (constant_byte_count > UINT16_MAX) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "AMDGPU metadata reflected constant byte count exceeds HAL range");
+  }
+  const iree_host_size_t constant_count = constant_byte_count / sizeof(uint32_t);
+  if (parameter_count > UINT16_MAX || binding_count > UINT16_MAX ||
+      constant_count > UINT16_MAX) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "AMDGPU metadata reflected parameter counts exceed HAL ranges");
+  }
+
+  out_requirements->parameter_count = (uint16_t)parameter_count;
+  out_requirements->constant_count = (uint16_t)constant_count;
+  out_requirements->binding_count = (uint16_t)binding_count;
+  out_requirements->name_storage_size = name_storage_size;
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_flatbuffer_hal_export_parameters(
+    const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
+    iree_host_size_t parameter_capacity,
+    iree_hal_executable_function_parameter_t* out_parameters,
+    iree_host_size_t name_storage_capacity, char* name_storage) {
+  IREE_ASSERT_ARGUMENT(kernel);
+  IREE_ASSERT_ARGUMENT(out_parameters || parameter_capacity == 0);
+  IREE_ASSERT_ARGUMENT(name_storage || name_storage_capacity == 0);
+
+  iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_hsaco_metadata_calculate_flatbuffer_hal_export_parameter_requirements(
+          kernel, &requirements));
+  if (parameter_capacity < requirements.parameter_count ||
+      name_storage_capacity < requirements.name_storage_size) {
+    return iree_make_status(
+        IREE_STATUS_RESOURCE_EXHAUSTED,
+        "AMDGPU metadata export parameter output capacity too small");
+  }
+  if ((requirements.parameter_count != 0 && !out_parameters) ||
+      (requirements.name_storage_size != 0 && !name_storage)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU metadata export parameter output storage is null");
+  }
+
+  iree_host_size_t parameter_index = 0;
+  uint16_t binding_ordinal = 0;
+  uint16_t constant_offset = 0;
+  iree_host_size_t name_storage_offset = 0;
+  for (iree_host_size_t i = 0; i < kernel->arg_count; ++i) {
+    const iree_hal_amdgpu_hsaco_metadata_arg_t* arg = &kernel->args[i];
+    if (iree_hal_amdgpu_hsaco_metadata_arg_kind_is_hidden(arg->kind)) {
+      continue;
+    }
+
+    iree_hal_executable_function_parameter_t* parameter =
+        &out_parameters[parameter_index++];
+    memset(parameter, 0, sizeof(*parameter));
+    parameter->flags = IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_FLAG_NONE;
+    parameter->size = (uint16_t)arg->size;
+    if (!iree_string_view_is_empty(arg->name)) {
+      memcpy(name_storage + name_storage_offset, arg->name.data,
+             arg->name.size);
+      parameter->name = iree_make_string_view(
+          name_storage + name_storage_offset, arg->name.size);
+      name_storage_offset += arg->name.size;
+    } else {
+      parameter->name = iree_string_view_empty();
+    }
+
+    switch (arg->kind) {
+      case IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_GLOBAL_BUFFER:
+        parameter->type = IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_BINDING;
+        parameter->offset = binding_ordinal++;
+        break;
+      case IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_BY_VALUE:
+        parameter->type = IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT;
+        parameter->offset = constant_offset;
+        constant_offset = (uint16_t)(constant_offset + arg->size);
+        break;
+      default:
+        return iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "AMDGPU kernel `%.*s` argument %" PRIhsz
+            " uses unsupported reflected value_kind `%.*s`",
+            (int)kernel->symbol_name.size, kernel->symbol_name.data, i,
+            (int)arg->value_kind.size, arg->value_kind.data);
+    }
+  }
+  return iree_ok_status();
+}
+
+iree_status_t
+iree_hal_amdgpu_hsaco_metadata_calculate_native_kernarg_export_parameter_requirements(
+    const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
+    iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t*
+        out_requirements) {
+  IREE_ASSERT_ARGUMENT(kernel);
+  IREE_ASSERT_ARGUMENT(out_requirements);
+  memset(out_requirements, 0, sizeof(*out_requirements));
+
+  iree_host_size_t parameter_count = 0;
+  iree_host_size_t binding_count = 0;
+  iree_host_size_t name_storage_size = 0;
+  for (iree_host_size_t i = 0; i < kernel->arg_count; ++i) {
+    const iree_hal_amdgpu_hsaco_metadata_arg_t* arg = &kernel->args[i];
+    if (iree_hal_amdgpu_hsaco_metadata_arg_kind_is_hidden(arg->kind)) {
+      continue;
+    }
+    if (arg->offset > UINT16_MAX) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "AMDGPU kernel `%.*s` argument %" PRIhsz
+          " kernarg offset exceeds HAL parameter offset range",
+          (int)kernel->symbol_name.size, kernel->symbol_name.data, i);
+    }
+    switch (arg->kind) {
+      case IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_GLOBAL_BUFFER:
+        if (arg->size != sizeof(uint64_t)) {
+          return iree_make_status(
+              IREE_STATUS_INVALID_ARGUMENT,
+              "AMDGPU kernel `%.*s` global_buffer argument %" PRIhsz
+              " has unsupported size %u",
+              (int)kernel->symbol_name.size, kernel->symbol_name.data, i,
+              arg->size);
+        }
+        ++parameter_count;
+        ++binding_count;
+        IREE_RETURN_IF_ERROR(
+            iree_hal_amdgpu_hsaco_metadata_add_parameter_name_size(
+                arg, &name_storage_size));
+        break;
+      case IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_BY_VALUE:
+        if (arg->size > UINT16_MAX) {
+          return iree_make_status(
+              IREE_STATUS_OUT_OF_RANGE,
+              "AMDGPU kernel `%.*s` by_value argument %" PRIhsz
+              " size %u exceeds HAL parameter size range",
+              (int)kernel->symbol_name.size, kernel->symbol_name.data, i,
+              arg->size);
+        }
+        ++parameter_count;
+        IREE_RETURN_IF_ERROR(
+            iree_hal_amdgpu_hsaco_metadata_add_parameter_name_size(
+                arg, &name_storage_size));
+        break;
       default:
         return iree_make_status(
             IREE_STATUS_INVALID_ARGUMENT,
@@ -1727,7 +1885,8 @@ iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
   return iree_ok_status();
 }
 
-iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
+iree_status_t
+iree_hal_amdgpu_hsaco_metadata_populate_native_kernarg_export_parameters(
     const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
     iree_host_size_t parameter_capacity,
     iree_hal_executable_function_parameter_t* out_parameters,
@@ -1738,7 +1897,7 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
 
   iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
   IREE_RETURN_IF_ERROR(
-      iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
+      iree_hal_amdgpu_hsaco_metadata_calculate_native_kernarg_export_parameter_requirements(
           kernel, &requirements));
   if (parameter_capacity < requirements.parameter_count ||
       name_storage_capacity < requirements.name_storage_size) {
@@ -1766,6 +1925,7 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
     memset(parameter, 0, sizeof(*parameter));
     parameter->flags = IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_FLAG_NONE;
     parameter->size = (uint16_t)arg->size;
+    parameter->offset = (uint16_t)arg->offset;
     if (!iree_string_view_is_empty(arg->name)) {
       memcpy(name_storage + name_storage_offset, arg->name.data,
              arg->name.size);
@@ -1776,14 +1936,12 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
       parameter->name = iree_string_view_empty();
     }
 
-    parameter->offset = (uint16_t)arg->offset;
     switch (arg->kind) {
       case IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_GLOBAL_BUFFER:
         parameter->type = IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_BINDING;
         break;
       case IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_BY_VALUE:
         parameter->type = IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT;
-        parameter->offset = (uint16_t)arg->offset;
         break;
       default:
         return iree_make_status(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -1247,6 +1247,46 @@ static bool iree_hal_amdgpu_hsaco_metadata_is_kernel_descriptor_name(
          iree_string_view_ends_with(descriptor_name, IREE_SV(".kd"));
 }
 
+static bool iree_hal_amdgpu_hsaco_metadata_symbol_section_range(
+    iree_const_byte_span_t elf_data, const uint8_t* section,
+    iree_host_size_t* out_symbol_section_offset,
+    iree_host_size_t* out_symbol_entry_size,
+    iree_host_size_t* out_symbol_count) {
+  *out_symbol_section_offset = 0;
+  *out_symbol_entry_size = 0;
+  *out_symbol_count = 0;
+
+  uint64_t symbol_section_offset_u64 =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
+  uint64_t symbol_section_size_u64 =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
+  uint64_t symbol_entry_size_u64 =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
+  if (symbol_entry_size_u64 < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
+      symbol_section_offset_u64 > elf_data.data_length ||
+      symbol_section_size_u64 >
+          elf_data.data_length - symbol_section_offset_u64) {
+    return false;
+  }
+
+  iree_host_size_t symbol_section_offset = 0;
+  iree_host_size_t symbol_section_size = 0;
+  iree_host_size_t symbol_entry_size = 0;
+  if (!iree_hal_amdgpu_hsaco_metadata_u64_to_host_size(
+          symbol_section_offset_u64, &symbol_section_offset) ||
+      !iree_hal_amdgpu_hsaco_metadata_u64_to_host_size(
+          symbol_section_size_u64, &symbol_section_size) ||
+      !iree_hal_amdgpu_hsaco_metadata_u64_to_host_size(
+          symbol_entry_size_u64, &symbol_entry_size)) {
+    return false;
+  }
+
+  *out_symbol_section_offset = symbol_section_offset;
+  *out_symbol_entry_size = symbol_entry_size;
+  *out_symbol_count = symbol_section_size / symbol_entry_size;
+  return true;
+}
+
 static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_descriptor_symbol(
     iree_const_byte_span_t elf_data, iree_string_view_t kernel_name) {
   if (iree_string_view_is_empty(kernel_name) ||
@@ -1269,22 +1309,17 @@ static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_descriptor_symbol(
         section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
       continue;
     }
-    uint64_t symbol_section_offset =
-        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
-    uint64_t symbol_section_size =
-        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
-    uint64_t symbol_entry_size =
-        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
-    if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
-        symbol_section_offset > elf_data.data_length ||
-        symbol_section_size > elf_data.data_length - symbol_section_offset) {
+    iree_host_size_t symbol_section_offset = 0;
+    iree_host_size_t symbol_entry_size = 0;
+    iree_host_size_t symbol_count = 0;
+    if (!iree_hal_amdgpu_hsaco_metadata_symbol_section_range(
+            elf_data, section, &symbol_section_offset, &symbol_entry_size,
+            &symbol_count)) {
       continue;
     }
-    iree_host_size_t symbol_count =
-        (iree_host_size_t)(symbol_section_size / symbol_entry_size);
     for (iree_host_size_t i = 0; i < symbol_count; ++i) {
       const uint8_t* symbol =
-          elf_data.data + symbol_section_offset + (uint64_t)i * symbol_entry_size;
+          elf_data.data + symbol_section_offset + i * symbol_entry_size;
       uint8_t binding = symbol[4] >> 4;
       if (binding != IREE_HAL_AMDGPU_ELF_STB_GLOBAL &&
           binding != IREE_HAL_AMDGPU_ELF_STB_WEAK) {
@@ -1346,22 +1381,17 @@ static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_function_symbol(
         section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
       continue;
     }
-    uint64_t symbol_section_offset =
-        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
-    uint64_t symbol_section_size =
-        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
-    uint64_t symbol_entry_size =
-        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
-    if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
-        symbol_section_offset > elf_data.data_length ||
-        symbol_section_size > elf_data.data_length - symbol_section_offset) {
+    iree_host_size_t symbol_section_offset = 0;
+    iree_host_size_t symbol_entry_size = 0;
+    iree_host_size_t symbol_count = 0;
+    if (!iree_hal_amdgpu_hsaco_metadata_symbol_section_range(
+            elf_data, section, &symbol_section_offset, &symbol_entry_size,
+            &symbol_count)) {
       continue;
     }
-    iree_host_size_t symbol_count =
-        (iree_host_size_t)(symbol_section_size / symbol_entry_size);
     for (iree_host_size_t i = 0; i < symbol_count; ++i) {
       const uint8_t* symbol =
-          elf_data.data + symbol_section_offset + (uint64_t)i * symbol_entry_size;
+          elf_data.data + symbol_section_offset + i * symbol_entry_size;
       iree_string_view_t name = iree_string_view_empty();
       if (iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
               elf_data, section, symbol, i, &name) &&
@@ -1404,21 +1434,17 @@ iree_hal_amdgpu_hsaco_metadata_append_elf_kernel_symbols(
         section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
       continue;
     }
-    uint64_t symbol_section_offset =
-        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
-    uint64_t symbol_section_size =
-        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
-    uint64_t symbol_entry_size =
-        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
-    if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
-        symbol_section_offset > elf_data.data_length) {
+    iree_host_size_t symbol_section_offset = 0;
+    iree_host_size_t symbol_entry_size = 0;
+    iree_host_size_t symbol_count = 0;
+    if (!iree_hal_amdgpu_hsaco_metadata_symbol_section_range(
+            elf_data, section, &symbol_section_offset, &symbol_entry_size,
+            &symbol_count)) {
       continue;
     }
-    iree_host_size_t symbol_count =
-        (iree_host_size_t)(symbol_section_size / symbol_entry_size);
     for (iree_host_size_t i = 0; i < symbol_count; ++i) {
       const uint8_t* symbol =
-          elf_data.data + symbol_section_offset + (uint64_t)i * symbol_entry_size;
+          elf_data.data + symbol_section_offset + i * symbol_entry_size;
       iree_string_view_t name = iree_string_view_empty();
       if (!iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
               elf_data, section, symbol, i, &name) ||
@@ -1494,21 +1520,17 @@ iree_hal_amdgpu_hsaco_metadata_append_elf_kernel_symbols(
         section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
       continue;
     }
-    uint64_t symbol_section_offset =
-        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
-    uint64_t symbol_section_size =
-        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
-    uint64_t symbol_entry_size =
-        iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
-    if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
-        symbol_section_offset > elf_data.data_length) {
+    iree_host_size_t symbol_section_offset = 0;
+    iree_host_size_t symbol_entry_size = 0;
+    iree_host_size_t symbol_count = 0;
+    if (!iree_hal_amdgpu_hsaco_metadata_symbol_section_range(
+            elf_data, section, &symbol_section_offset, &symbol_entry_size,
+            &symbol_count)) {
       continue;
     }
-    iree_host_size_t symbol_count =
-        (iree_host_size_t)(symbol_section_size / symbol_entry_size);
     for (iree_host_size_t i = 0; i < symbol_count; ++i) {
       const uint8_t* symbol =
-          elf_data.data + symbol_section_offset + (uint64_t)i * symbol_entry_size;
+          elf_data.data + symbol_section_offset + i * symbol_entry_size;
       iree_string_view_t name = iree_string_view_empty();
       if (!iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
               elf_data, section, symbol, i, &name) ||

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -1486,13 +1486,18 @@ iree_hal_amdgpu_hsaco_metadata_append_elf_kernel_symbols(
   };
   expanded.kernels = NULL;
   expanded.args = NULL;
+  expanded.owned_string_storage = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_metadata_allocate_storage(
       expanded_count, metadata->host_allocator, &expanded));
   char* extra_symbol_name_storage = NULL;
   if (extra_symbol_name_storage_size) {
-    IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+    iree_status_t allocation_status = iree_allocator_malloc(
         metadata->host_allocator, extra_symbol_name_storage_size,
-        (void**)&extra_symbol_name_storage));
+        (void**)&extra_symbol_name_storage);
+    if (!iree_status_is_ok(allocation_status)) {
+      iree_allocator_free(metadata->host_allocator, expanded.kernels);
+      return allocation_status;
+    }
     expanded.owned_string_storage = extra_symbol_name_storage;
   }
   if (metadata->arg_count) {
@@ -1510,11 +1515,13 @@ iree_hal_amdgpu_hsaco_metadata_append_elf_kernel_symbols(
 
   iree_host_size_t write_index = metadata->kernel_count;
   iree_host_size_t extra_symbol_name_storage_offset = 0;
+  iree_status_t status = iree_ok_status();
   for (uint16_t section_index = 0; section_index < section_count;
        ++section_index) {
     const uint8_t* section = NULL;
-    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_metadata_elf_section(
-        elf_data, section_index, &section));
+    status = iree_hal_amdgpu_hsaco_metadata_elf_section(elf_data, section_index,
+                                                        &section);
+    if (!iree_status_is_ok(status)) break;
     uint32_t section_type = iree_hal_amdgpu_hsaco_metadata_load_le_u32(section + 4);
     if (section_type != IREE_HAL_AMDGPU_ELF_SHT_DYNSYM &&
         section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
@@ -1568,6 +1575,14 @@ iree_hal_amdgpu_hsaco_metadata_append_elf_kernel_symbols(
       kernel->arg_count = template_kernel->arg_count;
       kernel->args = template_kernel->args;
     }
+  }
+  if (!iree_status_is_ok(status)) {
+    if (expanded.owned_string_storage) {
+      iree_allocator_free(metadata->host_allocator,
+                          expanded.owned_string_storage);
+    }
+    iree_allocator_free(metadata->host_allocator, expanded.kernels);
+    return status;
   }
   expanded.kernel_count = write_index;
 

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -1166,8 +1166,19 @@ static bool iree_hal_amdgpu_hsaco_metadata_elf_section(
       section_entry_size < IREE_HAL_AMDGPU_ELF64_SECTION_HEADER_SIZE) {
     return false;
   }
-  uint64_t selected_offset =
-      section_offset + (uint64_t)section_index * section_entry_size;
+  iree_host_size_t section_offset_host = 0;
+  if (!iree_hal_amdgpu_hsaco_metadata_u64_to_host_size(
+          section_offset, &section_offset_host)) {
+    return false;
+  }
+  iree_host_size_t section_relative_offset = 0;
+  iree_host_size_t selected_offset = 0;
+  if (!iree_host_size_checked_mul(section_index, section_entry_size,
+                                  &section_relative_offset) ||
+      !iree_host_size_checked_add(section_offset_host, section_relative_offset,
+                                  &selected_offset)) {
+    return false;
+  }
   if (selected_offset > elf_data.data_length ||
       IREE_HAL_AMDGPU_ELF64_SECTION_HEADER_SIZE >
           elf_data.data_length - selected_offset) {
@@ -1280,6 +1291,25 @@ static bool iree_hal_amdgpu_hsaco_metadata_symbol_section_range(
   return true;
 }
 
+static bool iree_hal_amdgpu_hsaco_metadata_elf_symbol_ptr(
+    iree_const_byte_span_t elf_data, iree_host_size_t symbol_section_offset,
+    iree_host_size_t symbol_entry_size, iree_host_size_t symbol_index,
+    const uint8_t** out_symbol) {
+  *out_symbol = NULL;
+  iree_host_size_t symbol_relative_offset = 0;
+  iree_host_size_t symbol_offset = 0;
+  if (!iree_host_size_checked_mul(symbol_index, symbol_entry_size,
+                                  &symbol_relative_offset) ||
+      !iree_host_size_checked_add(symbol_section_offset,
+                                  symbol_relative_offset, &symbol_offset) ||
+      symbol_offset > elf_data.data_length ||
+      IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE > elf_data.data_length - symbol_offset) {
+    return false;
+  }
+  *out_symbol = elf_data.data + symbol_offset;
+  return true;
+}
+
 static bool iree_hal_amdgpu_hsaco_metadata_is_kernel_descriptor_name(
     iree_string_view_t descriptor_name, iree_string_view_t kernel_name) {
   return descriptor_name.size == kernel_name.size + 3 &&
@@ -1320,8 +1350,12 @@ static bool iree_hal_amdgpu_hsaco_metadata_find_kernel_descriptor_symbol(
       continue;
     }
     for (iree_host_size_t i = 0; i < symbol_count; ++i) {
-      const uint8_t* symbol =
-          elf_data.data + symbol_section_offset + i * symbol_entry_size;
+      const uint8_t* symbol = NULL;
+      if (!iree_hal_amdgpu_hsaco_metadata_elf_symbol_ptr(
+              elf_data, symbol_section_offset, symbol_entry_size, i,
+              &symbol)) {
+        continue;
+      }
       uint8_t binding = symbol[4] >> 4;
       if (binding != IREE_HAL_AMDGPU_ELF_STB_GLOBAL &&
           binding != IREE_HAL_AMDGPU_ELF_STB_WEAK) {
@@ -1399,8 +1433,12 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_count_elf_kernel_symbols(
       continue;
     }
     for (iree_host_size_t i = 0; i < symbol_count; ++i) {
-      const uint8_t* symbol =
-          elf_data.data + symbol_section_offset + i * symbol_entry_size;
+      const uint8_t* symbol = NULL;
+      if (!iree_hal_amdgpu_hsaco_metadata_elf_symbol_ptr(
+              elf_data, symbol_section_offset, symbol_entry_size, i,
+              &symbol)) {
+        continue;
+      }
       uint8_t binding = symbol[4] >> 4;
       uint8_t type = symbol[4] & 0x0F;
       if (type != IREE_HAL_AMDGPU_ELF_STT_FUNC ||
@@ -1432,12 +1470,17 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_elf_kernel_symbols(
           metadata, &candidate_count));
   if (candidate_count == 0) return iree_ok_status();
 
+  iree_host_size_t elf_kernel_symbols_size = 0;
+  if (!iree_host_size_checked_mul(
+          candidate_count, sizeof(metadata->elf_kernel_symbols[0]),
+          &elf_kernel_symbols_size)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "AMDGPU ELF-only kernel symbol storage overflow");
+  }
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(
-      metadata->host_allocator,
-      candidate_count * sizeof(metadata->elf_kernel_symbols[0]),
+      metadata->host_allocator, elf_kernel_symbols_size,
       (void**)&metadata->elf_kernel_symbols));
-  memset(metadata->elf_kernel_symbols, 0,
-         candidate_count * sizeof(metadata->elf_kernel_symbols[0]));
+  memset(metadata->elf_kernel_symbols, 0, elf_kernel_symbols_size);
 
   iree_const_byte_span_t elf_data = metadata->elf_data;
   const uint8_t* header = elf_data.data;
@@ -1465,8 +1508,12 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_elf_kernel_symbols(
       continue;
     }
     for (iree_host_size_t i = 0; i < symbol_count; ++i) {
-      const uint8_t* symbol =
-          elf_data.data + symbol_section_offset + i * symbol_entry_size;
+      const uint8_t* symbol = NULL;
+      if (!iree_hal_amdgpu_hsaco_metadata_elf_symbol_ptr(
+              elf_data, symbol_section_offset, symbol_entry_size, i,
+              &symbol)) {
+        continue;
+      }
       uint8_t binding = symbol[4] >> 4;
       uint8_t type = symbol[4] & 0x0F;
       if (type != IREE_HAL_AMDGPU_ELF_STT_FUNC ||

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -1150,14 +1150,11 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_allocate_storage(
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_amdgpu_hsaco_metadata_elf_section(
+static bool iree_hal_amdgpu_hsaco_metadata_elf_section(
     iree_const_byte_span_t elf_data, uint16_t section_index,
     const uint8_t** out_section) {
   *out_section = NULL;
-  if (elf_data.data_length < IREE_HAL_AMDGPU_ELF64_HEADER_SIZE) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "AMDGPU ELF data too small");
-  }
+  if (elf_data.data_length < IREE_HAL_AMDGPU_ELF64_HEADER_SIZE) return false;
   const uint8_t* header = elf_data.data;
   uint64_t section_offset =
       iree_hal_amdgpu_hsaco_metadata_load_le_u64(header + 40);
@@ -1167,56 +1164,83 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_elf_section(
       iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 60);
   if (section_index >= section_count ||
       section_entry_size < IREE_HAL_AMDGPU_ELF64_SECTION_HEADER_SIZE) {
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "AMDGPU ELF section index out of range");
+    return false;
   }
   uint64_t selected_offset =
       section_offset + (uint64_t)section_index * section_entry_size;
   if (selected_offset > elf_data.data_length ||
       IREE_HAL_AMDGPU_ELF64_SECTION_HEADER_SIZE >
           elf_data.data_length - selected_offset) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "AMDGPU ELF section header out of bounds");
+    return false;
   }
   *out_section = elf_data.data + selected_offset;
-  return iree_ok_status();
+  return true;
+}
+
+static bool iree_hal_amdgpu_hsaco_metadata_section_range(
+    iree_const_byte_span_t elf_data, const uint8_t* section,
+    iree_host_size_t* out_offset, iree_host_size_t* out_size) {
+  *out_offset = 0;
+  *out_size = 0;
+  uint64_t offset_u64 =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
+  uint64_t size_u64 = iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
+  if (offset_u64 > elf_data.data_length ||
+      size_u64 > elf_data.data_length - offset_u64) {
+    return false;
+  }
+  iree_host_size_t offset = 0;
+  iree_host_size_t size = 0;
+  if (!iree_hal_amdgpu_hsaco_metadata_u64_to_host_size(offset_u64, &offset) ||
+      !iree_hal_amdgpu_hsaco_metadata_u64_to_host_size(size_u64, &size)) {
+    return false;
+  }
+  *out_offset = offset;
+  *out_size = size;
+  return true;
 }
 
 static iree_string_view_t iree_hal_amdgpu_hsaco_metadata_elf_symbol_name(
     iree_const_byte_span_t elf_data, const uint8_t* symbol_section,
     iree_host_size_t symbol_index) {
-  uint64_t symbol_section_offset =
-      iree_hal_amdgpu_hsaco_metadata_load_le_u64(symbol_section + 24);
-  uint64_t symbol_section_size =
-      iree_hal_amdgpu_hsaco_metadata_load_le_u64(symbol_section + 32);
-  uint64_t symbol_entry_size =
+  uint64_t symbol_entry_size_u64 =
       iree_hal_amdgpu_hsaco_metadata_load_le_u64(symbol_section + 56);
-  if (symbol_entry_size < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE) {
+  if (symbol_entry_size_u64 < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
+      symbol_entry_size_u64 > IREE_HOST_SIZE_MAX) {
     return iree_string_view_empty();
   }
-  uint64_t symbol_offset =
-      symbol_section_offset + (uint64_t)symbol_index * symbol_entry_size;
-  if (symbol_offset > elf_data.data_length ||
+  iree_host_size_t symbol_section_offset = 0;
+  iree_host_size_t symbol_section_size = 0;
+  if (!iree_hal_amdgpu_hsaco_metadata_section_range(
+          elf_data, symbol_section, &symbol_section_offset,
+          &symbol_section_size)) {
+    return iree_string_view_empty();
+  }
+  const iree_host_size_t symbol_entry_size =
+      (iree_host_size_t)symbol_entry_size_u64;
+  iree_host_size_t symbol_relative_offset = 0;
+  if (!iree_host_size_checked_mul(symbol_index, symbol_entry_size,
+                                  &symbol_relative_offset) ||
+      symbol_relative_offset >= symbol_section_size ||
       IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE >
-          elf_data.data_length - symbol_offset ||
-      symbol_offset >= symbol_section_offset + symbol_section_size) {
+          symbol_section_size - symbol_relative_offset) {
     return iree_string_view_empty();
   }
-  const uint8_t* symbol = elf_data.data + symbol_offset;
+  const uint8_t* symbol =
+      elf_data.data + symbol_section_offset + symbol_relative_offset;
   uint32_t name_offset = iree_hal_amdgpu_hsaco_metadata_load_le_u32(symbol);
   uint32_t string_section_index =
       iree_hal_amdgpu_hsaco_metadata_load_le_u32(symbol_section + 40);
   const uint8_t* string_section = NULL;
-  if (!iree_status_is_ok(iree_hal_amdgpu_hsaco_metadata_elf_section(
-          elf_data, (uint16_t)string_section_index, &string_section))) {
+  if (!iree_hal_amdgpu_hsaco_metadata_elf_section(
+          elf_data, (uint16_t)string_section_index, &string_section)) {
     return iree_string_view_empty();
   }
-  uint64_t string_offset =
-      iree_hal_amdgpu_hsaco_metadata_load_le_u64(string_section + 24);
-  uint64_t string_size =
-      iree_hal_amdgpu_hsaco_metadata_load_le_u64(string_section + 32);
-  if (name_offset >= string_size ||
-      string_offset + name_offset >= elf_data.data_length) {
+  iree_host_size_t string_offset = 0;
+  iree_host_size_t string_size = 0;
+  if (!iree_hal_amdgpu_hsaco_metadata_section_range(
+          elf_data, string_section, &string_offset, &string_size) ||
+      name_offset >= string_size) {
     return iree_string_view_empty();
   }
   const char* name = (const char*)elf_data.data + string_offset + name_offset;
@@ -1224,27 +1248,6 @@ static iree_string_view_t iree_hal_amdgpu_hsaco_metadata_elf_symbol_name(
   const char* p = name;
   while (p < end && *p) ++p;
   return iree_make_string_view(name, (iree_host_size_t)(p - name));
-}
-
-static bool iree_hal_amdgpu_hsaco_metadata_kernel_name_exists(
-    const iree_hal_amdgpu_hsaco_metadata_t* metadata,
-    iree_host_size_t kernel_count, iree_string_view_t name) {
-  for (iree_host_size_t i = 0; i < kernel_count; ++i) {
-    const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel =
-        &metadata->kernels[i];
-    if (iree_string_view_equal(kernel->symbol_name, name) ||
-        iree_string_view_equal(kernel->reflection_name, name)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-static bool iree_hal_amdgpu_hsaco_metadata_is_kernel_descriptor_name(
-    iree_string_view_t descriptor_name, iree_string_view_t kernel_name) {
-  return descriptor_name.size == kernel_name.size + 3 &&
-         iree_string_view_starts_with(descriptor_name, kernel_name) &&
-         iree_string_view_ends_with(descriptor_name, IREE_SV(".kd"));
 }
 
 static bool iree_hal_amdgpu_hsaco_metadata_symbol_section_range(
@@ -1256,26 +1259,16 @@ static bool iree_hal_amdgpu_hsaco_metadata_symbol_section_range(
   *out_symbol_entry_size = 0;
   *out_symbol_count = 0;
 
-  uint64_t symbol_section_offset_u64 =
-      iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 24);
-  uint64_t symbol_section_size_u64 =
-      iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 32);
-  uint64_t symbol_entry_size_u64 =
-      iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
-  if (symbol_entry_size_u64 < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
-      symbol_section_offset_u64 > elf_data.data_length ||
-      symbol_section_size_u64 >
-          elf_data.data_length - symbol_section_offset_u64) {
-    return false;
-  }
-
   iree_host_size_t symbol_section_offset = 0;
   iree_host_size_t symbol_section_size = 0;
+  if (!iree_hal_amdgpu_hsaco_metadata_section_range(
+          elf_data, section, &symbol_section_offset, &symbol_section_size)) {
+    return false;
+  }
+  uint64_t symbol_entry_size_u64 =
+      iree_hal_amdgpu_hsaco_metadata_load_le_u64(section + 56);
   iree_host_size_t symbol_entry_size = 0;
-  if (!iree_hal_amdgpu_hsaco_metadata_u64_to_host_size(
-          symbol_section_offset_u64, &symbol_section_offset) ||
-      !iree_hal_amdgpu_hsaco_metadata_u64_to_host_size(
-          symbol_section_size_u64, &symbol_section_size) ||
+  if (symbol_entry_size_u64 < IREE_HAL_AMDGPU_ELF64_SYMBOL_SIZE ||
       !iree_hal_amdgpu_hsaco_metadata_u64_to_host_size(
           symbol_entry_size_u64, &symbol_entry_size)) {
     return false;
@@ -1287,8 +1280,17 @@ static bool iree_hal_amdgpu_hsaco_metadata_symbol_section_range(
   return true;
 }
 
-static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_descriptor_symbol(
-    iree_const_byte_span_t elf_data, iree_string_view_t kernel_name) {
+static bool iree_hal_amdgpu_hsaco_metadata_is_kernel_descriptor_name(
+    iree_string_view_t descriptor_name, iree_string_view_t kernel_name) {
+  return descriptor_name.size == kernel_name.size + 3 &&
+         iree_string_view_starts_with(descriptor_name, kernel_name) &&
+         iree_string_view_ends_with(descriptor_name, IREE_SV(".kd"));
+}
+
+static bool iree_hal_amdgpu_hsaco_metadata_find_kernel_descriptor_symbol(
+    iree_const_byte_span_t elf_data, iree_string_view_t kernel_name,
+    iree_string_view_t* out_descriptor_name) {
+  *out_descriptor_name = iree_string_view_empty();
   if (iree_string_view_is_empty(kernel_name) ||
       elf_data.data_length < IREE_HAL_AMDGPU_ELF64_HEADER_SIZE) {
     return false;
@@ -1299,9 +1301,9 @@ static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_descriptor_symbol(
   for (uint16_t section_index = 0; section_index < section_count;
        ++section_index) {
     const uint8_t* section = NULL;
-    if (!iree_status_is_ok(iree_hal_amdgpu_hsaco_metadata_elf_section(
-            elf_data, section_index, &section))) {
-      return false;
+    if (!iree_hal_amdgpu_hsaco_metadata_elf_section(
+            elf_data, section_index, &section)) {
+      continue;
     }
     uint32_t section_type =
         iree_hal_amdgpu_hsaco_metadata_load_le_u32(section + 4);
@@ -1329,6 +1331,7 @@ static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_descriptor_symbol(
           iree_hal_amdgpu_hsaco_metadata_elf_symbol_name(elf_data, section, i);
       if (iree_hal_amdgpu_hsaco_metadata_is_kernel_descriptor_name(
               name, kernel_name)) {
+        *out_descriptor_name = name;
         return true;
       }
     }
@@ -1336,34 +1339,40 @@ static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_descriptor_symbol(
   return false;
 }
 
-static bool iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
-    iree_const_byte_span_t elf_data, const uint8_t* symbol_section,
-    const uint8_t* symbol, iree_host_size_t symbol_index,
-    iree_string_view_t* out_name) {
-  *out_name = iree_string_view_empty();
-  uint8_t binding = symbol[4] >> 4;
-  uint8_t type = symbol[4] & 0x0F;
-  if (type != IREE_HAL_AMDGPU_ELF_STT_FUNC ||
-      (binding != IREE_HAL_AMDGPU_ELF_STB_GLOBAL &&
-       binding != IREE_HAL_AMDGPU_ELF_STB_WEAK)) {
-    return false;
+static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_export_name(
+    const iree_hal_amdgpu_hsaco_metadata_t* metadata, iree_string_view_t name) {
+  for (iree_host_size_t i = 0; i < metadata->kernel_count; ++i) {
+    const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel =
+        &metadata->kernels[i];
+    if (iree_string_view_equal(kernel->reflection_name, name) ||
+        iree_string_view_equal(kernel->name, name) ||
+        iree_string_view_equal(
+            iree_string_view_strip_suffix(kernel->symbol_name, IREE_SV(".kd")),
+            name)) {
+      return true;
+    }
   }
-  iree_string_view_t name = iree_hal_amdgpu_hsaco_metadata_elf_symbol_name(
-      elf_data, symbol_section, symbol_index);
-  if (iree_string_view_is_empty(name) ||
-      !iree_hal_amdgpu_hsaco_metadata_has_kernel_descriptor_symbol(elf_data,
-                                                                   name)) {
-    return false;
-  }
-  *out_name = name;
-  return true;
+  return false;
 }
 
-static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_function_symbol(
-    iree_const_byte_span_t elf_data, iree_string_view_t kernel_name) {
-  if (iree_string_view_is_empty(kernel_name) ||
-      elf_data.data_length < IREE_HAL_AMDGPU_ELF64_HEADER_SIZE) {
-    return false;
+static bool iree_hal_amdgpu_hsaco_metadata_has_elf_kernel_symbol(
+    const iree_hal_amdgpu_hsaco_metadata_t* metadata,
+    iree_host_size_t symbol_count, iree_string_view_t name) {
+  for (iree_host_size_t i = 0; i < symbol_count; ++i) {
+    if (iree_string_view_equal(metadata->elf_kernel_symbols[i].name, name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static iree_status_t iree_hal_amdgpu_hsaco_metadata_count_elf_kernel_symbols(
+    const iree_hal_amdgpu_hsaco_metadata_t* metadata,
+    iree_host_size_t* out_symbol_count) {
+  *out_symbol_count = 0;
+  iree_const_byte_span_t elf_data = metadata->elf_data;
+  if (elf_data.data_length < IREE_HAL_AMDGPU_ELF64_HEADER_SIZE) {
+    return iree_ok_status();
   }
   const uint8_t* header = elf_data.data;
   uint16_t section_count =
@@ -1371,9 +1380,9 @@ static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_function_symbol(
   for (uint16_t section_index = 0; section_index < section_count;
        ++section_index) {
     const uint8_t* section = NULL;
-    if (!iree_status_is_ok(iree_hal_amdgpu_hsaco_metadata_elf_section(
-            elf_data, section_index, &section))) {
-      return false;
+    if (!iree_hal_amdgpu_hsaco_metadata_elf_section(
+            elf_data, section_index, &section)) {
+      continue;
     }
     uint32_t section_type =
         iree_hal_amdgpu_hsaco_metadata_load_le_u32(section + 4);
@@ -1392,44 +1401,57 @@ static bool iree_hal_amdgpu_hsaco_metadata_has_kernel_function_symbol(
     for (iree_host_size_t i = 0; i < symbol_count; ++i) {
       const uint8_t* symbol =
           elf_data.data + symbol_section_offset + i * symbol_entry_size;
-      iree_string_view_t name = iree_string_view_empty();
-      if (iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
-              elf_data, section, symbol, i, &name) &&
-          iree_string_view_equal(name, kernel_name)) {
-        return true;
+      uint8_t binding = symbol[4] >> 4;
+      uint8_t type = symbol[4] & 0x0F;
+      if (type != IREE_HAL_AMDGPU_ELF_STT_FUNC ||
+          (binding != IREE_HAL_AMDGPU_ELF_STB_GLOBAL &&
+           binding != IREE_HAL_AMDGPU_ELF_STB_WEAK)) {
+        continue;
       }
+      iree_string_view_t name =
+          iree_hal_amdgpu_hsaco_metadata_elf_symbol_name(elf_data, section, i);
+      iree_string_view_t descriptor_name = iree_string_view_empty();
+      if (iree_string_view_is_empty(name) ||
+          iree_hal_amdgpu_hsaco_metadata_has_kernel_export_name(metadata,
+                                                                name) ||
+          !iree_hal_amdgpu_hsaco_metadata_find_kernel_descriptor_symbol(
+              elf_data, name, &descriptor_name)) {
+        continue;
+      }
+      ++(*out_symbol_count);
     }
   }
-  return false;
+  return iree_ok_status();
 }
 
-static iree_status_t
-iree_hal_amdgpu_hsaco_metadata_append_elf_kernel_symbols(
+static iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_elf_kernel_symbols(
     iree_hal_amdgpu_hsaco_metadata_t* metadata) {
+  iree_host_size_t candidate_count = 0;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_hsaco_metadata_count_elf_kernel_symbols(
+          metadata, &candidate_count));
+  if (candidate_count == 0) return iree_ok_status();
+
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+      metadata->host_allocator,
+      candidate_count * sizeof(metadata->elf_kernel_symbols[0]),
+      (void**)&metadata->elf_kernel_symbols));
+  memset(metadata->elf_kernel_symbols, 0,
+         candidate_count * sizeof(metadata->elf_kernel_symbols[0]));
+
   iree_const_byte_span_t elf_data = metadata->elf_data;
-  if (elf_data.data_length < IREE_HAL_AMDGPU_ELF64_HEADER_SIZE) {
-    return iree_ok_status();
-  }
   const uint8_t* header = elf_data.data;
-  uint64_t section_offset =
-      iree_hal_amdgpu_hsaco_metadata_load_le_u64(header + 40);
-  uint16_t section_entry_size =
-      iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 58);
   uint16_t section_count =
       iree_hal_amdgpu_hsaco_metadata_load_le_u16(header + 60);
-  if (section_entry_size < IREE_HAL_AMDGPU_ELF64_SECTION_HEADER_SIZE ||
-      section_offset > elf_data.data_length) {
-    return iree_ok_status();
-  }
-
-  iree_host_size_t extra_count = 0;
-  iree_host_size_t extra_symbol_name_storage_size = 0;
   for (uint16_t section_index = 0; section_index < section_count;
        ++section_index) {
     const uint8_t* section = NULL;
-    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_metadata_elf_section(
-        elf_data, section_index, &section));
-    uint32_t section_type = iree_hal_amdgpu_hsaco_metadata_load_le_u32(section + 4);
+    if (!iree_hal_amdgpu_hsaco_metadata_elf_section(
+            elf_data, section_index, &section)) {
+      continue;
+    }
+    uint32_t section_type =
+        iree_hal_amdgpu_hsaco_metadata_load_le_u32(section + 4);
     if (section_type != IREE_HAL_AMDGPU_ELF_SHT_DYNSYM &&
         section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
       continue;
@@ -1445,155 +1467,32 @@ iree_hal_amdgpu_hsaco_metadata_append_elf_kernel_symbols(
     for (iree_host_size_t i = 0; i < symbol_count; ++i) {
       const uint8_t* symbol =
           elf_data.data + symbol_section_offset + i * symbol_entry_size;
-      iree_string_view_t name = iree_string_view_empty();
-      if (!iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
-              elf_data, section, symbol, i, &name) ||
-          iree_hal_amdgpu_hsaco_metadata_kernel_name_exists(
-              metadata, metadata->kernel_count, name)) {
+      uint8_t binding = symbol[4] >> 4;
+      uint8_t type = symbol[4] & 0x0F;
+      if (type != IREE_HAL_AMDGPU_ELF_STT_FUNC ||
+          (binding != IREE_HAL_AMDGPU_ELF_STB_GLOBAL &&
+           binding != IREE_HAL_AMDGPU_ELF_STB_WEAK)) {
         continue;
       }
-      ++extra_count;
-      if (!iree_host_size_checked_add(
-          extra_symbol_name_storage_size, name.size + 3,
-          &extra_symbol_name_storage_size)) {
-            return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                                    "AMDGPU metadata symbol name storage "
-                                    "size overflow");
-      }
-    }
-  }
-  if (extra_count == 0) return iree_ok_status();
-
-  iree_host_size_t template_kernel_index = IREE_HOST_SIZE_MAX;
-  for (iree_host_size_t i = 0; i < metadata->kernel_count; ++i) {
-    iree_string_view_t template_name = iree_string_view_strip_suffix(
-        metadata->kernels[i].symbol_name, IREE_SV(".kd"));
-    if (metadata->kernels[i].arg_count > 0 &&
-        iree_hal_amdgpu_hsaco_metadata_has_kernel_function_symbol(
-            elf_data, template_name)) {
-      template_kernel_index = i;
-      break;
-    }
-  }
-  if (template_kernel_index == IREE_HOST_SIZE_MAX) {
-    return iree_ok_status();
-  }
-
-  iree_hal_amdgpu_hsaco_metadata_t expanded = *metadata;
-  iree_hal_amdgpu_hsaco_metadata_count_t expanded_count = {
-      .kernel_count = metadata->kernel_count + extra_count,
-      .arg_count = metadata->arg_count,
-  };
-  expanded.kernels = NULL;
-  expanded.args = NULL;
-  expanded.owned_string_storage = NULL;
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_metadata_allocate_storage(
-      expanded_count, metadata->host_allocator, &expanded));
-  char* extra_symbol_name_storage = NULL;
-  if (extra_symbol_name_storage_size) {
-    iree_status_t allocation_status = iree_allocator_malloc(
-        metadata->host_allocator, extra_symbol_name_storage_size,
-        (void**)&extra_symbol_name_storage);
-    if (!iree_status_is_ok(allocation_status)) {
-      iree_allocator_free(metadata->host_allocator, expanded.kernels);
-      return allocation_status;
-    }
-    expanded.owned_string_storage = extra_symbol_name_storage;
-  }
-  if (metadata->arg_count) {
-    memcpy(expanded.args, metadata->args,
-           metadata->arg_count * sizeof(metadata->args[0]));
-  }
-  for (iree_host_size_t i = 0; i < metadata->kernel_count; ++i) {
-    expanded.kernels[i] = metadata->kernels[i];
-    if (metadata->kernels[i].args) {
-      iree_host_size_t arg_offset =
-          (iree_host_size_t)(metadata->kernels[i].args - metadata->args);
-      expanded.kernels[i].args = &expanded.args[arg_offset];
-    }
-  }
-
-  iree_host_size_t write_index = metadata->kernel_count;
-  iree_host_size_t extra_symbol_name_storage_offset = 0;
-  iree_status_t status = iree_ok_status();
-  for (uint16_t section_index = 0; section_index < section_count;
-       ++section_index) {
-    const uint8_t* section = NULL;
-    status = iree_hal_amdgpu_hsaco_metadata_elf_section(elf_data, section_index,
-                                                        &section);
-    if (!iree_status_is_ok(status)) break;
-    uint32_t section_type = iree_hal_amdgpu_hsaco_metadata_load_le_u32(section + 4);
-    if (section_type != IREE_HAL_AMDGPU_ELF_SHT_DYNSYM &&
-        section_type != IREE_HAL_AMDGPU_ELF_SHT_SYMTAB) {
-      continue;
-    }
-    iree_host_size_t symbol_section_offset = 0;
-    iree_host_size_t symbol_entry_size = 0;
-    iree_host_size_t symbol_count = 0;
-    if (!iree_hal_amdgpu_hsaco_metadata_symbol_section_range(
-            elf_data, section, &symbol_section_offset, &symbol_entry_size,
-            &symbol_count)) {
-      continue;
-    }
-    for (iree_host_size_t i = 0; i < symbol_count; ++i) {
-      const uint8_t* symbol =
-          elf_data.data + symbol_section_offset + i * symbol_entry_size;
-      iree_string_view_t name = iree_string_view_empty();
-      if (!iree_hal_amdgpu_hsaco_metadata_is_elf_kernel_symbol(
-              elf_data, section, symbol, i, &name) ||
-          iree_hal_amdgpu_hsaco_metadata_kernel_name_exists(
-              &expanded, write_index, name)) {
+      iree_string_view_t name =
+          iree_hal_amdgpu_hsaco_metadata_elf_symbol_name(elf_data, section, i);
+      iree_string_view_t descriptor_name = iree_string_view_empty();
+      if (iree_string_view_is_empty(name) ||
+          iree_hal_amdgpu_hsaco_metadata_has_kernel_export_name(metadata,
+                                                                name) ||
+          iree_hal_amdgpu_hsaco_metadata_has_elf_kernel_symbol(
+              metadata, metadata->elf_kernel_symbol_count, name) ||
+          !iree_hal_amdgpu_hsaco_metadata_find_kernel_descriptor_symbol(
+              elf_data, name, &descriptor_name)) {
         continue;
       }
-      iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel =
-          &expanded.kernels[write_index++];
-      memset(kernel, 0, sizeof(*kernel));
-      char* symbol_name_storage =
-          extra_symbol_name_storage + extra_symbol_name_storage_offset;
-      memcpy(symbol_name_storage, name.data, name.size);
-      memcpy(symbol_name_storage + name.size, ".kd", 3);
-      extra_symbol_name_storage_offset += name.size + 3;
-      kernel->name = name;
-      kernel->symbol_name =
-          iree_make_string_view(symbol_name_storage, name.size + 3);
-      kernel->reflection_name = name;
-      const iree_hal_amdgpu_hsaco_metadata_kernel_t* template_kernel =
-          &expanded.kernels[template_kernel_index];
-      kernel->arg_name_storage_size = template_kernel->arg_name_storage_size;
-      kernel->kernarg_segment_size = template_kernel->kernarg_segment_size;
-      kernel->kernarg_segment_alignment =
-          template_kernel->kernarg_segment_alignment;
-      kernel->group_segment_fixed_size =
-          template_kernel->group_segment_fixed_size;
-      kernel->private_segment_fixed_size =
-          template_kernel->private_segment_fixed_size;
-      memcpy(kernel->required_workgroup_size,
-             template_kernel->required_workgroup_size,
-             sizeof(kernel->required_workgroup_size));
-      kernel->has_required_workgroup_size =
-          template_kernel->has_required_workgroup_size;
-      kernel->arg_count = template_kernel->arg_count;
-      kernel->args = template_kernel->args;
+      metadata->elf_kernel_symbols[metadata->elf_kernel_symbol_count++] =
+          (iree_hal_amdgpu_hsaco_metadata_elf_kernel_symbol_t){
+              .name = name,
+              .symbol_name = descriptor_name,
+          };
     }
   }
-  if (!iree_status_is_ok(status)) {
-    if (expanded.owned_string_storage) {
-      iree_allocator_free(metadata->host_allocator,
-                          expanded.owned_string_storage);
-    }
-    iree_allocator_free(metadata->host_allocator, expanded.kernels);
-    return status;
-  }
-  expanded.kernel_count = write_index;
-
-  if (metadata->owned_string_storage) {
-    iree_allocator_free(metadata->host_allocator, metadata->owned_string_storage);
-  }
-  iree_allocator_free(metadata->host_allocator, metadata->kernels);
-  metadata->kernels = expanded.kernels;
-  metadata->args = expanded.args;
-  metadata->owned_string_storage = expanded.owned_string_storage;
-  metadata->kernel_count = expanded.kernel_count;
   return iree_ok_status();
 }
 
@@ -1625,7 +1524,7 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
   }
   if (iree_status_is_ok(status)) {
     status =
-        iree_hal_amdgpu_hsaco_metadata_append_elf_kernel_symbols(out_metadata);
+        iree_hal_amdgpu_hsaco_metadata_populate_elf_kernel_symbols(out_metadata);
   }
   if (!iree_status_is_ok(status)) {
     iree_hal_amdgpu_hsaco_metadata_deinitialize(out_metadata);
@@ -1640,11 +1539,11 @@ void iree_hal_amdgpu_hsaco_metadata_deinitialize(
     return;
   }
   IREE_TRACE_ZONE_BEGIN(z0);
-  if (metadata->owned_string_storage) {
-    iree_allocator_free(metadata->host_allocator, metadata->owned_string_storage);
-  }
   if (metadata->kernels) {
     iree_allocator_free(metadata->host_allocator, metadata->kernels);
+  }
+  if (metadata->elf_kernel_symbols) {
+    iree_allocator_free(metadata->host_allocator, metadata->elf_kernel_symbols);
   }
   memset(metadata, 0, sizeof(*metadata));
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -25,8 +25,10 @@
 #define IREE_HAL_AMDGPU_ELF_SHT_SYMTAB 2
 #define IREE_HAL_AMDGPU_ELF_SHT_DYNSYM 11
 #define IREE_HAL_AMDGPU_ELF_STT_FUNC 2
+#define IREE_HAL_AMDGPU_ELF_STT_OBJECT 1
 #define IREE_HAL_AMDGPU_ELF_STB_GLOBAL 1
 #define IREE_HAL_AMDGPU_ELF_STB_WEAK 2
+#define IREE_HAL_AMDGPU_ELF_SHN_UNDEF 0
 
 #define IREE_HAL_AMDGPU_ELF64_HEADER_SIZE 64
 #define IREE_HAL_AMDGPU_ELF64_PROGRAM_HEADER_SIZE 56
@@ -1357,8 +1359,13 @@ static bool iree_hal_amdgpu_hsaco_metadata_find_kernel_descriptor_symbol(
         continue;
       }
       uint8_t binding = symbol[4] >> 4;
-      if (binding != IREE_HAL_AMDGPU_ELF_STB_GLOBAL &&
-          binding != IREE_HAL_AMDGPU_ELF_STB_WEAK) {
+      uint8_t type = symbol[4] & 0x0F;
+      uint16_t section_index_for_symbol =
+          iree_hal_amdgpu_hsaco_metadata_load_le_u16(symbol + 6);
+      if (type != IREE_HAL_AMDGPU_ELF_STT_OBJECT ||
+          section_index_for_symbol == IREE_HAL_AMDGPU_ELF_SHN_UNDEF ||
+          (binding != IREE_HAL_AMDGPU_ELF_STB_GLOBAL &&
+           binding != IREE_HAL_AMDGPU_ELF_STB_WEAK)) {
         continue;
       }
       iree_string_view_t name =
@@ -1441,7 +1448,10 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_count_elf_kernel_symbols(
       }
       uint8_t binding = symbol[4] >> 4;
       uint8_t type = symbol[4] & 0x0F;
+      uint16_t section_index_for_symbol =
+          iree_hal_amdgpu_hsaco_metadata_load_le_u16(symbol + 6);
       if (type != IREE_HAL_AMDGPU_ELF_STT_FUNC ||
+          section_index_for_symbol == IREE_HAL_AMDGPU_ELF_SHN_UNDEF ||
           (binding != IREE_HAL_AMDGPU_ELF_STB_GLOBAL &&
            binding != IREE_HAL_AMDGPU_ELF_STB_WEAK)) {
         continue;
@@ -1516,7 +1526,10 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_elf_kernel_symbols(
       }
       uint8_t binding = symbol[4] >> 4;
       uint8_t type = symbol[4] & 0x0F;
+      uint16_t section_index_for_symbol =
+          iree_hal_amdgpu_hsaco_metadata_load_le_u16(symbol + 6);
       if (type != IREE_HAL_AMDGPU_ELF_STT_FUNC ||
+          section_index_for_symbol == IREE_HAL_AMDGPU_ELF_SHN_UNDEF ||
           (binding != IREE_HAL_AMDGPU_ELF_STB_GLOBAL &&
            binding != IREE_HAL_AMDGPU_ELF_STB_WEAK)) {
         continue;

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
@@ -90,9 +90,6 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_kernel_t {
   iree_host_size_t arg_count;
   // Argument records borrowed from the owning metadata object.
   const iree_hal_amdgpu_hsaco_metadata_arg_t* args;
-  // True when this kernel was synthesized from an ELF symbol and borrowed
-  // argument layout metadata from another kernel in the same code object.
-  bool uses_borrowed_arg_layout;
 } iree_hal_amdgpu_hsaco_metadata_kernel_t;
 
 // Decoded AMDGPU code object metadata.

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
@@ -90,6 +90,9 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_kernel_t {
   iree_host_size_t arg_count;
   // Argument records borrowed from the owning metadata object.
   const iree_hal_amdgpu_hsaco_metadata_arg_t* args;
+  // True when this kernel was synthesized from an ELF symbol and borrowed
+  // argument layout metadata from another kernel in the same code object.
+  bool uses_borrowed_arg_layout;
 } iree_hal_amdgpu_hsaco_metadata_kernel_t;
 
 // Decoded AMDGPU code object metadata.
@@ -109,6 +112,8 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_t {
   iree_host_size_t reflection_name_storage_size;
   // Bytes required to clone all decoded argument names.
   iree_host_size_t arg_name_storage_size;
+  // Extra string storage owned by HRX metadata augmentation.
+  char* owned_string_storage;
   // Number of decoded kernels.
   iree_host_size_t kernel_count;
   // Decoded kernel records.

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
@@ -174,14 +174,16 @@ iree_hal_amdgpu_hsaco_metadata_calculate_flatbuffer_hal_export_parameter_require
     iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t*
         out_requirements);
 
-// Populates |out_parameters| using the flatbuffer HAL ABI reflection projection.
+// Populates |out_parameters| using the flatbuffer HAL ABI reflection
+// projection.
 //
 // |parameter_capacity| and |name_storage_capacity| must satisfy the
 // requirements returned by
 // iree_hal_amdgpu_hsaco_metadata_calculate_flatbuffer_hal_export_parameter_requirements.
 // Reflected parameter names are cloned into |name_storage| and borrowed by the
 // returned parameter records. No NUL terminators are written or required.
-iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_flatbuffer_hal_export_parameters(
+iree_status_t
+iree_hal_amdgpu_hsaco_metadata_populate_flatbuffer_hal_export_parameters(
     const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
     iree_host_size_t parameter_capacity,
     iree_hal_executable_function_parameter_t* out_parameters,

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
@@ -155,11 +155,12 @@ void iree_hal_amdgpu_hsaco_metadata_deinitialize(
 // reflection projection for |kernel|.
 //
 // This projection maps `.value_kind == "global_buffer"` arguments to bindings
-// in metadata argument order and `.value_kind == "by_value"` arguments to
-// constants in metadata argument order. Reflected by-value sizes must be
-// whole 32-bit constants. Hidden ABI arguments are skipped. Any
-// other visible argument kind fails with IREE_STATUS_INVALID_ARGUMENT so
-// callers do not accidentally publish partial reflection for unsupported ABIs.
+// and `.value_kind == "by_value"` arguments to constants while preserving their
+// raw kernarg byte offsets. The constant table covers the full aligned kernarg
+// segment so custom/direct HIP argument buffers can be copied without compacting
+// or dropping padding/trailing bytes. Hidden ABI arguments are skipped. Any
+// other visible argument kind fails with IREE_STATUS_INVALID_ARGUMENT so callers
+// do not accidentally publish partial reflection for unsupported ABIs.
 iree_status_t
 iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
     const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
@@ -92,6 +92,14 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_kernel_t {
   const iree_hal_amdgpu_hsaco_metadata_arg_t* args;
 } iree_hal_amdgpu_hsaco_metadata_kernel_t;
 
+// ELF kernel symbol with no decoded AMDGPU metadata entry.
+typedef struct iree_hal_amdgpu_hsaco_metadata_elf_kernel_symbol_t {
+  // Function/export name, usually the symbol name without a `.kd` suffix.
+  iree_string_view_t name;
+  // Kernel descriptor symbol name used to resolve the HSA kernel object.
+  iree_string_view_t symbol_name;
+} iree_hal_amdgpu_hsaco_metadata_elf_kernel_symbol_t;
+
 // Decoded AMDGPU code object metadata.
 //
 // All string views and |message_pack_data| borrow from |elf_data|. Callers must
@@ -109,12 +117,15 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_t {
   iree_host_size_t reflection_name_storage_size;
   // Bytes required to clone all decoded argument names.
   iree_host_size_t arg_name_storage_size;
-  // Extra string storage owned by HRX metadata augmentation.
-  char* owned_string_storage;
   // Number of decoded kernels.
   iree_host_size_t kernel_count;
   // Decoded kernel records.
   iree_hal_amdgpu_hsaco_metadata_kernel_t* kernels;
+  // Number of ELF kernel symbols that have no decoded metadata entry.
+  iree_host_size_t elf_kernel_symbol_count;
+  // ELF-only kernel symbols. These are not reflected metadata and must only be
+  // used by custom-direct native kernarg launch paths.
+  iree_hal_amdgpu_hsaco_metadata_elf_kernel_symbol_t* elf_kernel_symbols;
   // Total number of decoded argument records.
   iree_host_size_t arg_count;
   // Contiguous argument storage referenced by |kernels|.

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
@@ -121,7 +121,7 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_t {
   iree_hal_amdgpu_hsaco_metadata_arg_t* args;
 } iree_hal_amdgpu_hsaco_metadata_t;
 
-// Requirements for materializing default HAL export parameter reflection.
+// Requirements for materializing export parameter reflection.
 typedef struct iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t {
   // Number of HAL-visible parameters after hidden ABI arguments are skipped.
   uint16_t parameter_count;
@@ -148,30 +148,51 @@ iree_status_t iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
 void iree_hal_amdgpu_hsaco_metadata_deinitialize(
     iree_hal_amdgpu_hsaco_metadata_t* metadata);
 
-// Calculates the storage and export-info counts required by the default HAL
-// reflection projection for |kernel|.
+// Calculates the storage and export-info counts required by the flatbuffer HAL
+// ABI reflection projection for |kernel|.
 //
 // This projection maps `.value_kind == "global_buffer"` arguments to bindings
-// and `.value_kind == "by_value"` arguments to constants while preserving their
-// raw kernarg byte offsets. The constant table covers the full aligned kernarg
-// segment so custom/direct HIP argument buffers can be copied without compacting
-// or dropping padding/trailing bytes. Hidden ABI arguments are skipped. Any
-// other visible argument kind fails with IREE_STATUS_INVALID_ARGUMENT so callers
-// do not accidentally publish partial reflection for unsupported ABIs.
+// using compact binding ordinals and `.value_kind == "by_value"` arguments to
+// constants using compact byte offsets. Reflected by-value sizes must be whole
+// 32-bit constants. Hidden ABI arguments are skipped. Any other visible
+// argument kind fails with IREE_STATUS_INVALID_ARGUMENT so callers do not
+// accidentally publish partial reflection for unsupported ABIs.
 iree_status_t
-iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
+iree_hal_amdgpu_hsaco_metadata_calculate_flatbuffer_hal_export_parameter_requirements(
     const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
     iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t*
         out_requirements);
 
-// Populates |out_parameters| using the default HAL reflection projection.
+// Populates |out_parameters| using the flatbuffer HAL ABI reflection projection.
 //
 // |parameter_capacity| and |name_storage_capacity| must satisfy the
 // requirements returned by
-// iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements.
+// iree_hal_amdgpu_hsaco_metadata_calculate_flatbuffer_hal_export_parameter_requirements.
 // Reflected parameter names are cloned into |name_storage| and borrowed by the
 // returned parameter records. No NUL terminators are written or required.
-iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
+iree_status_t iree_hal_amdgpu_hsaco_metadata_populate_flatbuffer_hal_export_parameters(
+    const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
+    iree_host_size_t parameter_capacity,
+    iree_hal_executable_function_parameter_t* out_parameters,
+    iree_host_size_t name_storage_capacity, char* name_storage);
+
+// Calculates the storage and export-info counts required by the native raw
+// kernarg reflection projection for |kernel|.
+//
+// This projection preserves raw kernarg byte offsets for all visible parameters
+// and covers the full aligned native kernarg segment as constants so
+// custom-direct prepacked argument buffers can be copied without compacting or
+// dropping padding/trailing bytes. Use this only for raw HSACO executables.
+iree_status_t
+iree_hal_amdgpu_hsaco_metadata_calculate_native_kernarg_export_parameter_requirements(
+    const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
+    iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t*
+        out_requirements);
+
+// Populates |out_parameters| using the native raw kernarg reflection
+// projection.
+iree_status_t
+iree_hal_amdgpu_hsaco_metadata_populate_native_kernarg_export_parameters(
     const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
     iree_host_size_t parameter_capacity,
     iree_hal_executable_function_parameter_t* out_parameters,

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
@@ -399,7 +399,7 @@ TEST(HsacoMetadataTest, PopulatesDefaultExportParameters) {
           &kernel, &requirements));
   EXPECT_EQ(requirements.parameter_count, 4);
   EXPECT_EQ(requirements.binding_count, 2);
-  EXPECT_EQ(requirements.constant_count, 2);
+  EXPECT_EQ(requirements.constant_count, 6);
   EXPECT_EQ(requirements.name_storage_size, 12);
 
   std::vector<iree_hal_executable_function_parameter_t> parameters(
@@ -414,24 +414,28 @@ TEST(HsacoMetadataTest, PopulatesDefaultExportParameters) {
             IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_BINDING);
   EXPECT_EQ(parameters[0].size, 8);
   EXPECT_EQ(parameters[0].offset, 0);
+  EXPECT_EQ(parameters[0].kernarg_offset, 0);
   EXPECT_EQ(ToString(parameters[0].name), "lhs");
 
   EXPECT_EQ(parameters[1].type,
             IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_BINDING);
   EXPECT_EQ(parameters[1].size, 8);
-  EXPECT_EQ(parameters[1].offset, 1);
+  EXPECT_EQ(parameters[1].offset, 8);
+  EXPECT_EQ(parameters[1].kernarg_offset, 8);
   EXPECT_EQ(ToString(parameters[1].name), "rhs");
 
   EXPECT_EQ(parameters[2].type,
             IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT);
   EXPECT_EQ(parameters[2].size, 4);
-  EXPECT_EQ(parameters[2].offset, 0);
+  EXPECT_EQ(parameters[2].offset, 16);
+  EXPECT_EQ(parameters[2].kernarg_offset, 16);
   EXPECT_EQ(ToString(parameters[2].name), "n");
 
   EXPECT_EQ(parameters[3].type,
             IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT);
   EXPECT_EQ(parameters[3].size, 4);
-  EXPECT_EQ(parameters[3].offset, 4);
+  EXPECT_EQ(parameters[3].offset, 20);
+  EXPECT_EQ(parameters[3].kernarg_offset, 20);
   EXPECT_EQ(ToString(parameters[3].name), "alpha");
 
   IREE_EXPECT_STATUS_IS(
@@ -463,7 +467,7 @@ TEST(HsacoMetadataTest, DefaultExportParametersSkipHiddenArguments) {
           &kernel, &requirements));
   EXPECT_EQ(requirements.parameter_count, 2);
   EXPECT_EQ(requirements.binding_count, 1);
-  EXPECT_EQ(requirements.constant_count, 1);
+  EXPECT_EQ(requirements.constant_count, 5);
   EXPECT_EQ(requirements.name_storage_size, 11);
 
   std::vector<iree_hal_executable_function_parameter_t> parameters(
@@ -483,7 +487,7 @@ TEST(HsacoMetadataTest, DefaultExportParametersSkipHiddenArguments) {
   iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
 }
 
-TEST(HsacoMetadataTest, RejectsNarrowByValueDefaultExportParameter) {
+TEST(HsacoMetadataTest, AllowsNarrowByValueDefaultExportParameter) {
   std::vector<uint8_t> elf = BuildElfWithMetadata(BuildKernelMetadata(
       /*out_of_range_arg=*/false, /*unknown_value_kind=*/false,
       /*narrow_by_value_arg=*/true));
@@ -493,10 +497,12 @@ TEST(HsacoMetadataTest, RejectsNarrowByValueDefaultExportParameter) {
       ByteSpan(elf), iree_allocator_system(), &metadata));
 
   iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
-  IREE_EXPECT_STATUS_IS(
-      IREE_STATUS_INVALID_ARGUMENT,
+  IREE_ASSERT_OK(
       iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
           &metadata.kernels[0], &requirements));
+  EXPECT_EQ(requirements.parameter_count, 4);
+  EXPECT_EQ(requirements.binding_count, 2);
+  EXPECT_EQ(requirements.constant_count, 6);
 
   iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
@@ -314,6 +314,23 @@ static std::vector<uint8_t> BuildElfWithMetadata(
   return BuildElfWithNote(metadata, IREE_SV("AMDGPU"), 32);
 }
 
+static std::vector<uint8_t> AddMalformedSymbolSection(
+    std::vector<uint8_t> elf) {
+  constexpr size_t kSectionHeaderSize = 64;
+  size_t section_offset = elf.size();
+  StoreU64LE(&elf, 40, section_offset);
+  StoreU16LE(&elf, 58, kSectionHeaderSize);
+  StoreU16LE(&elf, 60, 1);
+
+  elf.resize(section_offset + kSectionHeaderSize, 0);
+  StoreU32LE(&elf, section_offset + 4, 2);  // SHT_SYMTAB.
+  // Point inside the ELF but declare a section size that extends beyond EOF.
+  StoreU64LE(&elf, section_offset + 24, elf.size() - 8);
+  StoreU64LE(&elf, section_offset + 32, 64);
+  StoreU64LE(&elf, section_offset + 56, 24);
+  return elf;
+}
+
 static iree_const_byte_span_t ByteSpan(const std::vector<uint8_t>& data) {
   return iree_make_const_byte_span(data.data(), data.size());
 }
@@ -637,6 +654,19 @@ TEST(HsacoMetadataTest, RejectsMalformedMessagePackMetadata) {
   IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
                         iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
                             ByteSpan(elf), iree_allocator_system(), &metadata));
+}
+
+TEST(HsacoMetadataTest, IgnoresMalformedElfSymbolSectionBounds) {
+  std::vector<uint8_t> elf =
+      AddMalformedSymbolSection(BuildElfWithMetadata(BuildKernelMetadata()));
+
+  iree_hal_amdgpu_hsaco_metadata_t metadata;
+  IREE_ASSERT_OK(iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
+      ByteSpan(elf), iree_allocator_system(), &metadata));
+  EXPECT_EQ(metadata.kernel_count, 1);
+  EXPECT_EQ(ToString(metadata.kernels[0].symbol_name), "vector_add.kd");
+
+  iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
 }
 
 TEST(HsacoMetadataTest, RejectsDuplicateArgumentField) {

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
@@ -378,7 +378,8 @@ static std::vector<uint8_t> AddSyntheticCandidateSymbolSection(
   return elf;
 }
 
-static std::vector<uint8_t> AddMalformedSymbolSection(std::vector<uint8_t> elf) {
+static std::vector<uint8_t> AddMalformedSymbolSection(
+    std::vector<uint8_t> elf) {
   constexpr size_t kSectionHeaderSize = 64;
   size_t section_offset = elf.size();
   StoreU64LE(&elf, 40, section_offset);
@@ -720,8 +721,8 @@ TEST(HsacoMetadataTest, RejectsMalformedMessagePackMetadata) {
 }
 
 TEST(HsacoMetadataTest, DiscoversElfSymbolsWithoutSynthesizingKernels) {
-  std::vector<uint8_t> elf =
-      AddSyntheticCandidateSymbolSection(BuildElfWithMetadata(BuildKernelMetadata()));
+  std::vector<uint8_t> elf = AddSyntheticCandidateSymbolSection(
+      BuildElfWithMetadata(BuildKernelMetadata()));
 
   iree_hal_amdgpu_hsaco_metadata_t metadata;
   IREE_ASSERT_OK(iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
@@ -414,28 +414,24 @@ TEST(HsacoMetadataTest, PopulatesDefaultExportParameters) {
             IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_BINDING);
   EXPECT_EQ(parameters[0].size, 8);
   EXPECT_EQ(parameters[0].offset, 0);
-  EXPECT_EQ(parameters[0].kernarg_offset, 0);
   EXPECT_EQ(ToString(parameters[0].name), "lhs");
 
   EXPECT_EQ(parameters[1].type,
             IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_BINDING);
   EXPECT_EQ(parameters[1].size, 8);
   EXPECT_EQ(parameters[1].offset, 8);
-  EXPECT_EQ(parameters[1].kernarg_offset, 8);
   EXPECT_EQ(ToString(parameters[1].name), "rhs");
 
   EXPECT_EQ(parameters[2].type,
             IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT);
   EXPECT_EQ(parameters[2].size, 4);
   EXPECT_EQ(parameters[2].offset, 16);
-  EXPECT_EQ(parameters[2].kernarg_offset, 16);
   EXPECT_EQ(ToString(parameters[2].name), "n");
 
   EXPECT_EQ(parameters[3].type,
             IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT);
   EXPECT_EQ(parameters[3].size, 4);
   EXPECT_EQ(parameters[3].offset, 20);
-  EXPECT_EQ(parameters[3].kernarg_offset, 20);
   EXPECT_EQ(ToString(parameters[3].name), "alpha");
 
   IREE_EXPECT_STATUS_IS(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
@@ -314,20 +314,65 @@ static std::vector<uint8_t> BuildElfWithMetadata(
   return BuildElfWithNote(metadata, IREE_SV("AMDGPU"), 32);
 }
 
-static std::vector<uint8_t> AddMalformedSymbolSection(
+static void AlignVector(std::vector<uint8_t>* output, size_t alignment) {
+  while ((output->size() % alignment) != 0) output->push_back(0);
+}
+
+static void AppendElf64Symbol(std::vector<uint8_t>* output,
+                              uint32_t name_offset, uint8_t info) {
+  size_t symbol_offset = output->size();
+  output->resize(symbol_offset + 24, 0);
+  StoreU32LE(output, symbol_offset + 0, name_offset);
+  (*output)[symbol_offset + 4] = info;
+  StoreU16LE(output, symbol_offset + 6, 1);
+}
+
+static std::vector<uint8_t> AddSyntheticCandidateSymbolSection(
     std::vector<uint8_t> elf) {
+  constexpr uint8_t kGlobalFunction = 0x12;  // STB_GLOBAL | STT_FUNC.
+  constexpr uint8_t kGlobalObject = 0x11;    // STB_GLOBAL | STT_OBJECT.
   constexpr size_t kSectionHeaderSize = 64;
-  size_t section_offset = elf.size();
+
+  const size_t string_offset = elf.size();
+  elf.push_back(0);
+  const uint32_t function_name_offset =
+      static_cast<uint32_t>(elf.size() - string_offset);
+  const char kFunctionName[] = "extra_kernel";
+  elf.insert(elf.end(), kFunctionName, kFunctionName + sizeof(kFunctionName));
+  const uint32_t descriptor_name_offset =
+      static_cast<uint32_t>(elf.size() - string_offset);
+  const char kDescriptorName[] = "extra_kernel.kd";
+  elf.insert(elf.end(), kDescriptorName,
+             kDescriptorName + sizeof(kDescriptorName));
+  const size_t string_size = elf.size() - string_offset;
+
+  AlignVector(&elf, 8);
+  const size_t symbol_offset = elf.size();
+  AppendElf64Symbol(&elf, 0, 0);
+  AppendElf64Symbol(&elf, function_name_offset, kGlobalFunction);
+  AppendElf64Symbol(&elf, descriptor_name_offset, kGlobalObject);
+  const size_t symbol_size = elf.size() - symbol_offset;
+
+  AlignVector(&elf, 8);
+  const size_t section_offset = elf.size();
   StoreU64LE(&elf, 40, section_offset);
   StoreU16LE(&elf, 58, kSectionHeaderSize);
-  StoreU16LE(&elf, 60, 1);
+  StoreU16LE(&elf, 60, 3);
 
-  elf.resize(section_offset + kSectionHeaderSize, 0);
-  StoreU32LE(&elf, section_offset + 4, 2);  // SHT_SYMTAB.
-  // Point inside the ELF but declare a section size that extends beyond EOF.
-  StoreU64LE(&elf, section_offset + 24, elf.size() - 8);
-  StoreU64LE(&elf, section_offset + 32, 64);
-  StoreU64LE(&elf, section_offset + 56, 24);
+  elf.resize(section_offset + 3 * kSectionHeaderSize, 0);
+  const size_t string_section = section_offset + kSectionHeaderSize;
+  StoreU32LE(&elf, string_section + 4, 3);  // SHT_STRTAB.
+  StoreU64LE(&elf, string_section + 24, string_offset);
+  StoreU64LE(&elf, string_section + 32, string_size);
+  StoreU64LE(&elf, string_section + 48, 1);
+
+  const size_t symbol_section = section_offset + 2 * kSectionHeaderSize;
+  StoreU32LE(&elf, symbol_section + 4, 2);  // SHT_SYMTAB.
+  StoreU64LE(&elf, symbol_section + 24, symbol_offset);
+  StoreU64LE(&elf, symbol_section + 32, symbol_size);
+  StoreU32LE(&elf, symbol_section + 40, 1);  // sh_link: string table section.
+  StoreU64LE(&elf, symbol_section + 48, 8);
+  StoreU64LE(&elf, symbol_section + 56, 24);
   return elf;
 }
 
@@ -656,15 +701,19 @@ TEST(HsacoMetadataTest, RejectsMalformedMessagePackMetadata) {
                             ByteSpan(elf), iree_allocator_system(), &metadata));
 }
 
-TEST(HsacoMetadataTest, IgnoresMalformedElfSymbolSectionBounds) {
+TEST(HsacoMetadataTest, DiscoversElfSymbolsWithoutSynthesizingKernels) {
   std::vector<uint8_t> elf =
-      AddMalformedSymbolSection(BuildElfWithMetadata(BuildKernelMetadata()));
+      AddSyntheticCandidateSymbolSection(BuildElfWithMetadata(BuildKernelMetadata()));
 
   iree_hal_amdgpu_hsaco_metadata_t metadata;
   IREE_ASSERT_OK(iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
       ByteSpan(elf), iree_allocator_system(), &metadata));
-  EXPECT_EQ(metadata.kernel_count, 1);
+  ASSERT_EQ(metadata.kernel_count, 1);
   EXPECT_EQ(ToString(metadata.kernels[0].symbol_name), "vector_add.kd");
+  ASSERT_EQ(metadata.elf_kernel_symbol_count, 1);
+  EXPECT_EQ(ToString(metadata.elf_kernel_symbols[0].name), "extra_kernel");
+  EXPECT_EQ(ToString(metadata.elf_kernel_symbols[0].symbol_name),
+            "extra_kernel.kd");
 
   iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
@@ -385,7 +385,7 @@ TEST(HsacoMetadataTest, ParsesValidMetadata) {
   iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
 }
 
-TEST(HsacoMetadataTest, PopulatesDefaultExportParameters) {
+TEST(HsacoMetadataTest, PopulatesFlatbufferHalExportParameters) {
   std::vector<uint8_t> elf = BuildElfWithMetadata(BuildKernelMetadata());
 
   iree_hal_amdgpu_hsaco_metadata_t metadata;
@@ -395,18 +395,18 @@ TEST(HsacoMetadataTest, PopulatesDefaultExportParameters) {
   const iree_hal_amdgpu_hsaco_metadata_kernel_t& kernel = metadata.kernels[0];
   iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
   IREE_ASSERT_OK(
-      iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
+      iree_hal_amdgpu_hsaco_metadata_calculate_flatbuffer_hal_export_parameter_requirements(
           &kernel, &requirements));
   EXPECT_EQ(requirements.parameter_count, 4);
   EXPECT_EQ(requirements.binding_count, 2);
-  EXPECT_EQ(requirements.constant_count, 6);
+  EXPECT_EQ(requirements.constant_count, 2);
   EXPECT_EQ(requirements.name_storage_size, 12);
 
   std::vector<iree_hal_executable_function_parameter_t> parameters(
       requirements.parameter_count);
   std::vector<char> name_storage(requirements.name_storage_size);
   IREE_ASSERT_OK(
-      iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
+      iree_hal_amdgpu_hsaco_metadata_populate_flatbuffer_hal_export_parameters(
           &kernel, parameters.size(), parameters.data(), name_storage.size(),
           name_storage.data()));
 
@@ -419,31 +419,76 @@ TEST(HsacoMetadataTest, PopulatesDefaultExportParameters) {
   EXPECT_EQ(parameters[1].type,
             IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_BINDING);
   EXPECT_EQ(parameters[1].size, 8);
-  EXPECT_EQ(parameters[1].offset, 8);
+  EXPECT_EQ(parameters[1].offset, 1);
   EXPECT_EQ(ToString(parameters[1].name), "rhs");
 
   EXPECT_EQ(parameters[2].type,
             IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT);
   EXPECT_EQ(parameters[2].size, 4);
-  EXPECT_EQ(parameters[2].offset, 16);
+  EXPECT_EQ(parameters[2].offset, 0);
   EXPECT_EQ(ToString(parameters[2].name), "n");
 
   EXPECT_EQ(parameters[3].type,
             IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT);
   EXPECT_EQ(parameters[3].size, 4);
-  EXPECT_EQ(parameters[3].offset, 20);
+  EXPECT_EQ(parameters[3].offset, 4);
   EXPECT_EQ(ToString(parameters[3].name), "alpha");
 
   IREE_EXPECT_STATUS_IS(
       IREE_STATUS_RESOURCE_EXHAUSTED,
-      iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
+      iree_hal_amdgpu_hsaco_metadata_populate_flatbuffer_hal_export_parameters(
           &kernel, parameters.size() - 1, parameters.data(),
           name_storage.size(), name_storage.data()));
 
   iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
 }
 
-TEST(HsacoMetadataTest, DefaultExportParametersSkipHiddenArguments) {
+TEST(HsacoMetadataTest, PopulatesNativeKernargExportParameters) {
+  std::vector<uint8_t> elf = BuildElfWithMetadata(BuildKernelMetadata());
+
+  iree_hal_amdgpu_hsaco_metadata_t metadata;
+  IREE_ASSERT_OK(iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
+      ByteSpan(elf), iree_allocator_system(), &metadata));
+
+  const iree_hal_amdgpu_hsaco_metadata_kernel_t& kernel = metadata.kernels[0];
+  iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
+  IREE_ASSERT_OK(
+      iree_hal_amdgpu_hsaco_metadata_calculate_native_kernarg_export_parameter_requirements(
+          &kernel, &requirements));
+  EXPECT_EQ(requirements.parameter_count, 4);
+  EXPECT_EQ(requirements.binding_count, 2);
+  EXPECT_EQ(requirements.constant_count, 6);
+  EXPECT_EQ(requirements.name_storage_size, 12);
+
+  std::vector<iree_hal_executable_function_parameter_t> parameters(
+      requirements.parameter_count);
+  std::vector<char> name_storage(requirements.name_storage_size);
+  IREE_ASSERT_OK(
+      iree_hal_amdgpu_hsaco_metadata_populate_native_kernarg_export_parameters(
+          &kernel, parameters.size(), parameters.data(), name_storage.size(),
+          name_storage.data()));
+
+  EXPECT_EQ(parameters[0].type,
+            IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_BINDING);
+  EXPECT_EQ(parameters[0].offset, 0);
+  EXPECT_EQ(ToString(parameters[0].name), "lhs");
+  EXPECT_EQ(parameters[1].type,
+            IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_BINDING);
+  EXPECT_EQ(parameters[1].offset, 8);
+  EXPECT_EQ(ToString(parameters[1].name), "rhs");
+  EXPECT_EQ(parameters[2].type,
+            IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT);
+  EXPECT_EQ(parameters[2].offset, 16);
+  EXPECT_EQ(ToString(parameters[2].name), "n");
+  EXPECT_EQ(parameters[3].type,
+            IREE_HAL_EXECUTABLE_FUNCTION_PARAMETER_TYPE_CONSTANT);
+  EXPECT_EQ(parameters[3].offset, 20);
+  EXPECT_EQ(ToString(parameters[3].name), "alpha");
+
+  iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
+}
+
+TEST(HsacoMetadataTest, FlatbufferHalExportParametersSkipHiddenArguments) {
   std::vector<uint8_t> elf =
       BuildElfWithMetadata(BuildHiddenArgumentMetadata());
 
@@ -459,18 +504,18 @@ TEST(HsacoMetadataTest, DefaultExportParametersSkipHiddenArguments) {
 
   iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
   IREE_ASSERT_OK(
-      iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
+      iree_hal_amdgpu_hsaco_metadata_calculate_flatbuffer_hal_export_parameter_requirements(
           &kernel, &requirements));
   EXPECT_EQ(requirements.parameter_count, 2);
   EXPECT_EQ(requirements.binding_count, 1);
-  EXPECT_EQ(requirements.constant_count, 5);
+  EXPECT_EQ(requirements.constant_count, 1);
   EXPECT_EQ(requirements.name_storage_size, 11);
 
   std::vector<iree_hal_executable_function_parameter_t> parameters(
       requirements.parameter_count);
   std::vector<char> name_storage(requirements.name_storage_size);
   IREE_ASSERT_OK(
-      iree_hal_amdgpu_hsaco_metadata_populate_default_export_parameters(
+      iree_hal_amdgpu_hsaco_metadata_populate_flatbuffer_hal_export_parameters(
           &kernel, parameters.size(), parameters.data(), name_storage.size(),
           name_storage.data()));
   EXPECT_EQ(ToString(parameters[0].name), "buffer");
@@ -483,7 +528,25 @@ TEST(HsacoMetadataTest, DefaultExportParametersSkipHiddenArguments) {
   iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
 }
 
-TEST(HsacoMetadataTest, AllowsNarrowByValueDefaultExportParameter) {
+TEST(HsacoMetadataTest, RejectsNarrowByValueFlatbufferHalExportParameter) {
+  std::vector<uint8_t> elf = BuildElfWithMetadata(BuildKernelMetadata(
+      /*out_of_range_arg=*/false, /*unknown_value_kind=*/false,
+      /*narrow_by_value_arg=*/true));
+
+  iree_hal_amdgpu_hsaco_metadata_t metadata;
+  IREE_ASSERT_OK(iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
+      ByteSpan(elf), iree_allocator_system(), &metadata));
+
+  iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_hsaco_metadata_calculate_flatbuffer_hal_export_parameter_requirements(
+          &metadata.kernels[0], &requirements));
+
+  iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
+}
+
+TEST(HsacoMetadataTest, AllowsNarrowByValueNativeKernargExportParameter) {
   std::vector<uint8_t> elf = BuildElfWithMetadata(BuildKernelMetadata(
       /*out_of_range_arg=*/false, /*unknown_value_kind=*/false,
       /*narrow_by_value_arg=*/true));
@@ -494,7 +557,7 @@ TEST(HsacoMetadataTest, AllowsNarrowByValueDefaultExportParameter) {
 
   iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
   IREE_ASSERT_OK(
-      iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
+      iree_hal_amdgpu_hsaco_metadata_calculate_native_kernarg_export_parameter_requirements(
           &metadata.kernels[0], &requirements));
   EXPECT_EQ(requirements.parameter_count, 4);
   EXPECT_EQ(requirements.binding_count, 2);
@@ -540,7 +603,7 @@ TEST(HsacoMetadataTest, AllowsUnknownValueKindAsOpaqueMetadata) {
   iree_hal_amdgpu_hsaco_metadata_export_parameter_requirements_t requirements;
   IREE_EXPECT_STATUS_IS(
       IREE_STATUS_INVALID_ARGUMENT,
-      iree_hal_amdgpu_hsaco_metadata_calculate_default_export_parameter_requirements(
+      iree_hal_amdgpu_hsaco_metadata_calculate_flatbuffer_hal_export_parameter_requirements(
           &metadata.kernels[0], &requirements));
 
   iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
@@ -319,18 +319,19 @@ static void AlignVector(std::vector<uint8_t>* output, size_t alignment) {
 }
 
 static void AppendElf64Symbol(std::vector<uint8_t>* output,
-                              uint32_t name_offset, uint8_t info) {
+                              uint32_t name_offset, uint8_t info,
+                              uint16_t section_index = 1) {
   size_t symbol_offset = output->size();
   output->resize(symbol_offset + 24, 0);
   StoreU32LE(output, symbol_offset + 0, name_offset);
   (*output)[symbol_offset + 4] = info;
-  StoreU16LE(output, symbol_offset + 6, 1);
+  StoreU16LE(output, symbol_offset + 6, section_index);
 }
 
 static std::vector<uint8_t> AddSyntheticCandidateSymbolSection(
-    std::vector<uint8_t> elf) {
+    std::vector<uint8_t> elf, uint8_t descriptor_info = 0x11,
+    uint16_t function_section_index = 1) {
   constexpr uint8_t kGlobalFunction = 0x12;  // STB_GLOBAL | STT_FUNC.
-  constexpr uint8_t kGlobalObject = 0x11;    // STB_GLOBAL | STT_OBJECT.
   constexpr size_t kSectionHeaderSize = 64;
 
   const size_t string_offset = elf.size();
@@ -349,8 +350,9 @@ static std::vector<uint8_t> AddSyntheticCandidateSymbolSection(
   AlignVector(&elf, 8);
   const size_t symbol_offset = elf.size();
   AppendElf64Symbol(&elf, 0, 0);
-  AppendElf64Symbol(&elf, function_name_offset, kGlobalFunction);
-  AppendElf64Symbol(&elf, descriptor_name_offset, kGlobalObject);
+  AppendElf64Symbol(&elf, function_name_offset, kGlobalFunction,
+                    function_section_index);
+  AppendElf64Symbol(&elf, descriptor_name_offset, descriptor_info);
   const size_t symbol_size = elf.size() - symbol_offset;
 
   AlignVector(&elf, 8);
@@ -730,6 +732,36 @@ TEST(HsacoMetadataTest, DiscoversElfSymbolsWithoutSynthesizingKernels) {
   EXPECT_EQ(ToString(metadata.elf_kernel_symbols[0].name), "extra_kernel");
   EXPECT_EQ(ToString(metadata.elf_kernel_symbols[0].symbol_name),
             "extra_kernel.kd");
+
+  iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
+}
+
+TEST(HsacoMetadataTest, IgnoresElfFunctionWithWrongDescriptorType) {
+  constexpr uint8_t kGlobalFunction = 0x12;  // STB_GLOBAL | STT_FUNC.
+  std::vector<uint8_t> elf = AddSyntheticCandidateSymbolSection(
+      BuildElfWithMetadata(BuildKernelMetadata()),
+      /*descriptor_info=*/kGlobalFunction);
+
+  iree_hal_amdgpu_hsaco_metadata_t metadata;
+  IREE_ASSERT_OK(iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
+      ByteSpan(elf), iree_allocator_system(), &metadata));
+  ASSERT_EQ(metadata.kernel_count, 1);
+  EXPECT_EQ(metadata.elf_kernel_symbol_count, 0);
+
+  iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
+}
+
+TEST(HsacoMetadataTest, IgnoresUndefinedElfFunctionSymbol) {
+  constexpr uint16_t kUndefinedSectionIndex = 0;
+  std::vector<uint8_t> elf = AddSyntheticCandidateSymbolSection(
+      BuildElfWithMetadata(BuildKernelMetadata()),
+      /*descriptor_info=*/0x11, kUndefinedSectionIndex);
+
+  iree_hal_amdgpu_hsaco_metadata_t metadata;
+  IREE_ASSERT_OK(iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
+      ByteSpan(elf), iree_allocator_system(), &metadata));
+  ASSERT_EQ(metadata.kernel_count, 1);
+  EXPECT_EQ(metadata.elf_kernel_symbol_count, 0);
 
   iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
@@ -376,6 +376,22 @@ static std::vector<uint8_t> AddSyntheticCandidateSymbolSection(
   return elf;
 }
 
+static std::vector<uint8_t> AddMalformedSymbolSection(std::vector<uint8_t> elf) {
+  constexpr size_t kSectionHeaderSize = 64;
+  size_t section_offset = elf.size();
+  StoreU64LE(&elf, 40, section_offset);
+  StoreU16LE(&elf, 58, kSectionHeaderSize);
+  StoreU16LE(&elf, 60, 1);
+
+  elf.resize(section_offset + kSectionHeaderSize, 0);
+  StoreU32LE(&elf, section_offset + 4, 2);  // SHT_SYMTAB.
+  // Point inside the ELF but declare a section size that extends beyond EOF.
+  StoreU64LE(&elf, section_offset + 24, elf.size() - 8);
+  StoreU64LE(&elf, section_offset + 32, 64);
+  StoreU64LE(&elf, section_offset + 56, 24);
+  return elf;
+}
+
 static iree_const_byte_span_t ByteSpan(const std::vector<uint8_t>& data) {
   return iree_make_const_byte_span(data.data(), data.size());
 }
@@ -714,6 +730,20 @@ TEST(HsacoMetadataTest, DiscoversElfSymbolsWithoutSynthesizingKernels) {
   EXPECT_EQ(ToString(metadata.elf_kernel_symbols[0].name), "extra_kernel");
   EXPECT_EQ(ToString(metadata.elf_kernel_symbols[0].symbol_name),
             "extra_kernel.kd");
+
+  iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
+}
+
+TEST(HsacoMetadataTest, IgnoresMalformedElfSymbolSectionBounds) {
+  std::vector<uint8_t> elf =
+      AddMalformedSymbolSection(BuildElfWithMetadata(BuildKernelMetadata()));
+
+  iree_hal_amdgpu_hsaco_metadata_t metadata;
+  IREE_ASSERT_OK(iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
+      ByteSpan(elf), iree_allocator_system(), &metadata));
+  EXPECT_EQ(metadata.kernel_count, 1);
+  EXPECT_EQ(metadata.elf_kernel_symbol_count, 0);
+  EXPECT_EQ(ToString(metadata.kernels[0].symbol_name), "vector_add.kd");
 
   iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/util/queue_benchmark.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/queue_benchmark.cc
@@ -1555,8 +1555,11 @@ class QueueBenchmark : public benchmark::Fixture {
 
     const uint32_t constant_data[] = {3, 10};
     iree_hal_amdgpu_device_dispatch_emplace_hal_kernargs(
+        kernel_args, &descriptor->hal_kernarg_layout, binding_ptrs,
+        constant_data, kernargs);
+    iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
         kernel_args, workgroup_count, dynamic_workgroup_local_memory,
-        &descriptor->hal_kernarg_layout, binding_ptrs, constant_data, kernargs);
+        &descriptor->hal_kernarg_layout, kernargs);
     std::memset(&pre_resolved_dispatch_packet_template_, 0,
                 sizeof(pre_resolved_dispatch_packet_template_));
     iree_hal_amdgpu_device_dispatch_emplace_packet(

--- a/runtime/src/iree/hal/executable.h
+++ b/runtime/src/iree/hal/executable.h
@@ -149,14 +149,21 @@ typedef uint16_t iree_hal_executable_function_parameter_flags_t;
 typedef struct iree_hal_executable_function_parameter_t {
   // Type of the parameter.
   iree_hal_executable_function_parameter_type_t type;
-  // Size of the parameter in bytes. Does not contain padding.
-  uint8_t size;
   // Flags indicating parameter behavior.
   iree_hal_executable_function_parameter_flags_t flags;
-  // Parameter name if available, otherwise empty.
-  iree_string_view_t name;
+  // Size of the parameter in bytes. Does not contain padding.
+  // Widened from uint8_t so we can represent kernarg structs emitted by
+  // user toolchains.
+  uint16_t size;
   // Offset of the parameter in bytes or binding ordinal, depending on type.
   uint16_t offset;
+  // Backend-reported byte offset of this parameter within the raw kernarg
+  // segment. Consumers that synthesize raw kernarg blobs must use this field
+  // for BINDING parameters because |offset| may be a binding ordinal for
+  // backends that follow the generic HAL contract.
+  uint16_t kernarg_offset;
+  // Parameter name if available, otherwise empty.
+  iree_string_view_t name;
 } iree_hal_executable_function_parameter_t;
 
 // Handle to a loaded executable.

--- a/runtime/src/iree/hal/executable.h
+++ b/runtime/src/iree/hal/executable.h
@@ -157,11 +157,6 @@ typedef struct iree_hal_executable_function_parameter_t {
   uint16_t size;
   // Offset of the parameter in bytes or binding ordinal, depending on type.
   uint16_t offset;
-  // Backend-reported byte offset of this parameter within the raw kernarg
-  // segment. Consumers that synthesize raw kernarg blobs must use this field
-  // for BINDING parameters because |offset| may be a binding ordinal for
-  // backends that follow the generic HAL contract.
-  uint16_t kernarg_offset;
   // Parameter name if available, otherwise empty.
   iree_string_view_t name;
 } iree_hal_executable_function_parameter_t;


### PR DESCRIPTION
Preserve native kernarg layouts for raw HSACO kernels so prepacked HIP argument buffers from libraries such as hipBLASLt can dispatch correctly through the AMDGPU HAL.
