### PR TITLE
Fail iree_cc_test on TSAN reports

### DIFF
--- a/runtime/src/iree/testing/gtest_main.cc
+++ b/runtime/src/iree/testing/gtest_main.cc
@@ -5,8 +5,21 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/base/api.h"
+#include "iree/base/target_platform.h"
 #include "iree/base/tooling/flags.h"
 #include "iree/testing/gtest.h"
+
+#if defined(IREE_SANITIZER_THREAD)
+// Treat any TSan report as a test failure. Without this, TSan prints WARNING
+// lines to stderr but the process exits 0 and ctest marks the test PASSed,
+// so a race that doesn't otherwise crash the test is silently ignored.
+// User-provided TSAN_OPTIONS still wins (the env var overrides these
+// program-level defaults), so developers can pass halt_on_error=0 to keep
+// running after the first race.
+extern "C" const char* __tsan_default_options() {
+  return "halt_on_error=1:abort_on_error=1";
+}
+#endif  // IREE_SANITIZER_THREAD
 
 int main(int argc, char** argv) {
   IREE_TRACE_APP_ENTER();


### PR DESCRIPTION
Define __tsan_default_options() in gtest_main to set halt_on_error=1:abort_on_error=1, so a TSAN warning aborts the test binary instead of exiting 0 and being marked PASSed by ctest. TSAN_OPTIONS in the environment still wins for local debugging.