### PR TITLE
Fix iree_arena_reset write-after-release in embedded-arena pattern

### DIFF
--- a/runtime/src/iree/base/internal/arena.c
+++ b/runtime/src/iree/base/internal/arena.c
@@ -164,35 +164,45 @@ void iree_arena_deinitialize(iree_arena_allocator_t* arena) {
 void iree_arena_reset(iree_arena_allocator_t* arena) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  if (arena->allocation_head != NULL) {
-    iree_arena_oversized_allocation_t* head = arena->allocation_head;
-    do {
-      void* ptr = (void*)head;
-      head = head->next;
-      iree_allocator_free(arena->block_pool->block_allocator, ptr);
-    } while (head);
-    arena->allocation_head = NULL;
-  }
+  // Snapshot block pool + per-arena state BEFORE clearing or releasing
+  // anything. The arena struct itself may live within one of its own blocks
+  // (e.g., when an embedded object owns its enclosing arena), in which case
+  // once iree_arena_block_pool_release returns those blocks become available
+  // for reuse by another thread and any subsequent write to the arena's
+  // fields would corrupt the next owner's data. Clearing the fields up
+  // front avoids that use-after-release.
+  iree_arena_block_pool_t* block_pool = arena->block_pool;
+  iree_arena_oversized_allocation_t* allocation_head = arena->allocation_head;
+  iree_arena_block_t* block_head = arena->block_head;
+  iree_arena_block_t* block_tail = arena->block_tail;
 
-  if (arena->block_head != NULL) {
-#if defined(IREE_SANITIZER_ADDRESS)
-    iree_arena_block_t* block = arena->block_head;
-    while (block) {
-      IREE_ASAN_UNPOISON_MEMORY_REGION(
-          iree_arena_block_ptr(arena->block_pool, block),
-          arena->block_pool->usable_block_size);
-      block = block->next;
-    }
-#endif  // IREE_SANITIZER_ADDRESS
-    iree_arena_block_pool_release(arena->block_pool, arena->block_head,
-                                  arena->block_tail);
-    arena->block_head = NULL;
-    arena->block_tail = NULL;
-  }
-
+  arena->allocation_head = NULL;
+  arena->block_head = NULL;
+  arena->block_tail = NULL;
   arena->total_allocation_size = 0;
   arena->used_allocation_size = 0;
   arena->block_bytes_remaining = 0;
+
+  if (allocation_head != NULL) {
+    iree_arena_oversized_allocation_t* head = allocation_head;
+    do {
+      void* ptr = (void*)head;
+      head = head->next;
+      iree_allocator_free(block_pool->block_allocator, ptr);
+    } while (head);
+  }
+
+  if (block_head != NULL) {
+#if defined(IREE_SANITIZER_ADDRESS)
+    iree_arena_block_t* block = block_head;
+    while (block) {
+      IREE_ASAN_UNPOISON_MEMORY_REGION(iree_arena_block_ptr(block_pool, block),
+                                       block_pool->usable_block_size);
+      block = block->next;
+    }
+#endif  // IREE_SANITIZER_ADDRESS
+    iree_arena_block_pool_release(block_pool, block_head, block_tail);
+  }
 
   IREE_TRACE_ZONE_END(z0);
 }


### PR DESCRIPTION
iree_arena_reset (called from iree_arena_deinitialize) clears the arena's bookkeeping fields *after* releasing the arena's blocks:

    iree_arena_block_pool_release(arena->block_pool,
                                  arena->block_head, arena->block_tail);
    arena->block_head = NULL;            // (1) WRITE AFTER RELEASE
    arena->block_tail = NULL;            // (2)
    arena->total_allocation_size = 0;    // (3)
    arena->used_allocation_size = 0;     // (4)
    arena->block_bytes_remaining = 0;    // (5)

iree_arena_block_pool_release pushes the blocks onto the pool's thread-safe atomic slist. As soon as that call returns another thread can acquire the same blocks for its own arena (the whole point of the pool) and start writing into them. The post-release writes (1)-(5) are therefore writes to memory the arena may no longer own.

The writes are harmless when the iree_arena_allocator_t lives outside its own blocks -- on the stack, or as a field of a struct allocated by the host allocator (as in hip/graph_command_buffer.c and amdgpu/aql_command_buffer.c) -- because they hit a distinct allocation no other code is racing on. The writes are a real data race when the descriptor is embedded in one of its own blocks, the pattern used by local_task/task_queue.c (~line 745) and amdgpu/host_queue_pending.c
(~line 869):

    iree_arena_allocator_t arena;
    iree_arena_initialize(queue->block_pool, &arena);
    iree_arena_allocate(&arena, sizeof(*op), (void**)&op);
    memcpy(&op->arena, &arena, sizeof(arena));   // descriptor in block 0
    /* ... op is used cross-thread, then ... */
    iree_arena_deinitialize(&op->arena);

In that case (1)-(5) overwrite up to ~48 bytes at fixed offsets inside the released block, clobbering whatever the next consumer of the pool placed there. The race is microsecond-scale and the alignment is narrow, so the failure rate is small but nonzero and invisible to typical correctness tests at low repetition. TSan flags it deterministically (see arena_test.cc: Arena.ResetWithEmbeddedArenaIsThreadSafe).

Either way, writing to a struct after handing its backing memory to a thread-safe pool is incorrect: the function should finish updating the struct before publishing the blocks, regardless of whether the struct lives in those blocks today.

Fix: reorder, no new logic. Snapshot the pool pointer and the block / oversized-allocation list heads into locals, clear the arena's fields, and only then release the blocks. After release nothing in this function touches the arena struct again.
