### PR TITLE
[AMDGPU] Make fine-grained device memory optional

### DIFF
--- a/build_tools/devtools/cli.py
+++ b/build_tools/devtools/cli.py
@@ -391,6 +391,7 @@ def parse_arguments(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="dev.py",
         description="Repository developer command router.",
+        epilog=help_text.ROOT_COMMAND_EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     add_common_options(parser)

--- a/build_tools/devtools/cli_test.py
+++ b/build_tools/devtools/cli_test.py
@@ -770,6 +770,15 @@ class CliTest(unittest.TestCase):
         self.assertNotIn("../builds", output)
         self.assertNotIn("backend configure tool", output)
 
+    def test_root_help_lists_nested_build_system_commands(self):
+        output = self.parse_help(["--help"])
+
+        self.assertIn("Common build-system commands", output)
+        self.assertIn("python dev.py bazel precommit", output)
+        self.assertIn("python dev.py bazel run", output)
+        self.assertIn("python dev.py cmake precommit", output)
+        self.assertIn("python dev.py cmake run", output)
+
     def test_bazel_build_help_explains_default_targets(self):
         output = self.parse_help(["bazel", "build", "--help"])
 

--- a/build_tools/devtools/help_text.py
+++ b/build_tools/devtools/help_text.py
@@ -18,6 +18,29 @@ class CommandHelp:
     epilog: str | None = None
 
 
+ROOT_COMMAND_EPILOG = """Common build-system commands:
+  python dev.py bazel configure
+  python dev.py bazel build
+  python dev.py bazel test
+  python dev.py bazel precommit
+  python dev.py bazel presubmit
+  python dev.py bazel run
+  python dev.py bazel try
+  python dev.py bazel fuzz
+
+  python dev.py cmake configure
+  python dev.py cmake build
+  python dev.py cmake test
+  python dev.py cmake precommit
+  python dev.py cmake presubmit
+  python dev.py cmake run
+  python dev.py cmake try
+  python dev.py cmake fuzz
+
+Use `python dev.py bazel --help` or `python dev.py cmake --help` for the full
+subcommand list for that build system."""
+
+
 def root_command_help(command: str) -> CommandHelp:
     if command == "setup":
         return CommandHelp(

--- a/runtime/src/iree/hal/cts/buffer/mapping_test.cc
+++ b/runtime/src/iree/hal/cts/buffer/mapping_test.cc
@@ -33,19 +33,47 @@ class BufferMappingTest : public CtsTestBase<> {
  protected:
   // Allocates a buffer with HOST_VISIBLE + MAPPING usage for mapping tests.
   // This differs from the base class helpers which use DISPATCH_STORAGE.
-  void AllocateUninitializedBuffer(iree_device_size_t buffer_size,
-                                   iree_hal_buffer_t** out_buffer) {
+  iree_status_t AllocateUninitializedBuffer(iree_device_size_t buffer_size,
+                                            iree_hal_buffer_t** out_buffer) {
+    *out_buffer = NULL;
     iree_hal_buffer_params_t params = {0};
-    params.type =
-        IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
+    params.type = IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
     params.usage =
         IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING;
+    iree_device_size_t allocation_size = buffer_size;
+    iree_hal_buffer_compatibility_t compatibility =
+        iree_hal_allocator_query_buffer_compatibility(
+            device_allocator_, params, buffer_size, &params, &allocation_size);
+    if (!iree_all_bits_set(compatibility,
+                           IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE)) {
+      return iree_make_status(
+          IREE_STATUS_UNAVAILABLE,
+          "allocator does not support host-visible mapped buffers");
+    }
     iree_hal_buffer_t* buffer = NULL;
-    IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(device_allocator_, params,
-                                                      buffer_size, &buffer));
+    iree_status_t status = iree_hal_allocator_allocate_buffer(
+        device_allocator_, params, allocation_size, &buffer);
+    if (!iree_status_is_ok(status)) {
+      iree_hal_buffer_release(buffer);
+      return status;
+    }
     *out_buffer = buffer;
+    return iree_ok_status();
   }
 };
+
+#define IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(buffer_size, \
+                                                           out_buffer)  \
+  do {                                                                  \
+    iree_status_t allocate_status =                                     \
+        AllocateUninitializedBuffer((buffer_size), (out_buffer));       \
+    if (iree_status_is_unavailable(allocate_status)) {                  \
+      iree_status_free(allocate_status);                                \
+      GTEST_SKIP() << "Allocator does not support host-visible mapped " \
+                      "buffers";                                        \
+    }                                                                   \
+    IREE_ASSERT_OK(allocate_status);                                    \
+  } while (false)
 
 TEST_P(BufferMappingTest, AllocatorSupportsBufferMapping) {
   iree_hal_buffer_params_t params = {0};
@@ -56,11 +84,13 @@ TEST_P(BufferMappingTest, AllocatorSupportsBufferMapping) {
       iree_hal_allocator_query_buffer_compatibility(device_allocator_, params,
                                                     kDefaultAllocationSize,
                                                     &params, &allocation_size);
-  EXPECT_TRUE(iree_all_bits_set(compatibility,
-                                IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE));
+  if (!iree_all_bits_set(compatibility,
+                         IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE)) {
+    GTEST_SKIP() << "Allocator does not support host-visible mapped buffers";
+  }
 
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(allocation_size, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(allocation_size, &buffer);
 
   EXPECT_TRUE(
       iree_all_bits_set(iree_hal_buffer_memory_type(buffer), params.type));
@@ -73,7 +103,8 @@ TEST_P(BufferMappingTest, AllocatorSupportsBufferMapping) {
 
 TEST_P(BufferMappingTest, ZeroWholeBuffer) {
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(kDefaultAllocationSize, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(kDefaultAllocationSize,
+                                                     &buffer);
 
   IREE_ASSERT_OK(iree_hal_buffer_map_zero(buffer, /*byte_offset=*/0,
                                           IREE_HAL_WHOLE_BUFFER));
@@ -90,7 +121,7 @@ TEST_P(BufferMappingTest, ZeroWholeBuffer) {
 TEST_P(BufferMappingTest, ZeroWithOffset) {
   iree_device_size_t buffer_size = 16;
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(buffer_size, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(buffer_size, &buffer);
 
   // Fill the entire buffer then zero only a segment of it.
   uint8_t fill_value = 0xFF;
@@ -115,7 +146,7 @@ TEST_P(BufferMappingTest, ZeroWithOffset) {
 TEST_P(BufferMappingTest, ZeroSubspan) {
   iree_device_size_t buffer_size = 16;
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(buffer_size, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(buffer_size, &buffer);
 
   uint8_t fill_value = 0xFF;
   IREE_ASSERT_OK(iree_hal_buffer_map_fill(buffer, /*byte_offset=*/0,
@@ -157,7 +188,8 @@ TEST_P(BufferMappingTest, ZeroSubspan) {
 
 TEST_P(BufferMappingTest, FillEmpty) {
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(kDefaultAllocationSize, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(kDefaultAllocationSize,
+                                                     &buffer);
 
   // Zero the buffer then "fill" 0 bytes with a different pattern.
   IREE_ASSERT_OK(iree_hal_buffer_map_zero(buffer, 0, IREE_HAL_WHOLE_BUFFER));
@@ -180,7 +212,8 @@ TEST_P(BufferMappingTest, FillEmpty) {
 
 TEST_P(BufferMappingTest, FillWholeBuffer) {
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(kDefaultAllocationSize, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(kDefaultAllocationSize,
+                                                     &buffer);
 
   uint8_t fill_value = 0xFF;
   IREE_ASSERT_OK(
@@ -201,7 +234,7 @@ TEST_P(BufferMappingTest, FillWholeBuffer) {
 TEST_P(BufferMappingTest, FillWithOffset) {
   iree_device_size_t buffer_size = 16;
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(buffer_size, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(buffer_size, &buffer);
 
   IREE_ASSERT_OK(iree_hal_buffer_map_zero(buffer, 0, IREE_HAL_WHOLE_BUFFER));
   uint8_t fill_value = 0xFF;
@@ -226,7 +259,7 @@ TEST_P(BufferMappingTest, FillWithOffset) {
 TEST_P(BufferMappingTest, FillSubspan) {
   iree_device_size_t buffer_size = 16;
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(buffer_size, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(buffer_size, &buffer);
 
   IREE_ASSERT_OK(iree_hal_buffer_map_zero(buffer, 0, IREE_HAL_WHOLE_BUFFER));
 
@@ -267,7 +300,7 @@ TEST_P(BufferMappingTest, FillSubspan) {
 TEST_P(BufferMappingTest, ReadData) {
   iree_device_size_t buffer_size = 16;
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(buffer_size, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(buffer_size, &buffer);
 
   IREE_ASSERT_OK(
       iree_hal_buffer_map_zero(buffer, /*byte_offset=*/0, /*byte_length=*/8));
@@ -303,7 +336,7 @@ TEST_P(BufferMappingTest, ReadData) {
 TEST_P(BufferMappingTest, ReadDataSubspan) {
   iree_device_size_t buffer_size = 16;
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(buffer_size, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(buffer_size, &buffer);
 
   // Fill segments with distinct values.
   uint8_t value = 0xAA;
@@ -346,7 +379,7 @@ TEST_P(BufferMappingTest, ReadDataSubspan) {
 TEST_P(BufferMappingTest, WriteDataWholeBuffer) {
   iree_device_size_t buffer_size = 16;
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(buffer_size, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(buffer_size, &buffer);
 
   uint8_t fill_value = 0xFF;
   std::vector<uint8_t> reference_buffer(buffer_size, fill_value);
@@ -365,7 +398,7 @@ TEST_P(BufferMappingTest, WriteDataWholeBuffer) {
 TEST_P(BufferMappingTest, WriteDataWithOffset) {
   iree_device_size_t buffer_size = 16;
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(buffer_size, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(buffer_size, &buffer);
 
   IREE_ASSERT_OK(iree_hal_buffer_map_zero(buffer, 0, IREE_HAL_WHOLE_BUFFER));
 
@@ -389,7 +422,7 @@ TEST_P(BufferMappingTest, WriteDataWithOffset) {
 TEST_P(BufferMappingTest, WriteDataSubspan) {
   iree_device_size_t buffer_size = 16;
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(buffer_size, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(buffer_size, &buffer);
 
   IREE_ASSERT_OK(iree_hal_buffer_map_zero(buffer, 0, IREE_HAL_WHOLE_BUFFER));
 
@@ -430,8 +463,10 @@ TEST_P(BufferMappingTest, WriteDataSubspan) {
 TEST_P(BufferMappingTest, CopyData) {
   iree_hal_buffer_t* buffer_a = NULL;
   iree_hal_buffer_t* buffer_b = NULL;
-  AllocateUninitializedBuffer(kDefaultAllocationSize, &buffer_a);
-  AllocateUninitializedBuffer(kDefaultAllocationSize, &buffer_b);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(kDefaultAllocationSize,
+                                                     &buffer_a);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(kDefaultAllocationSize,
+                                                     &buffer_b);
 
   uint8_t fill_value = 0x07;
   IREE_ASSERT_OK(
@@ -458,7 +493,7 @@ TEST_P(BufferMappingTest, CopyData) {
 TEST_P(BufferMappingTest, MapRangeRead) {
   iree_device_size_t buffer_size = 16;
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(buffer_size, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(buffer_size, &buffer);
 
   uint8_t fill_value = 0xEF;
   IREE_ASSERT_OK(iree_hal_buffer_map_fill(buffer, /*byte_offset=*/0,
@@ -486,7 +521,7 @@ TEST_P(BufferMappingTest, MapRangeRead) {
 TEST_P(BufferMappingTest, MapRangeWrite) {
   iree_device_size_t buffer_size = 16;
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(buffer_size, &buffer);
+  IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP(buffer_size, &buffer);
 
   iree_hal_buffer_mapping_t mapping;
   IREE_ASSERT_OK(iree_hal_buffer_map_range(
@@ -513,5 +548,7 @@ TEST_P(BufferMappingTest, MapRangeWrite) {
 }
 
 CTS_REGISTER_TEST_SUITE(BufferMappingTest);
+
+#undef IREE_HAL_CTS_ALLOCATE_UNINITIALIZED_BUFFER_OR_SKIP
 
 }  // namespace iree::hal::cts

--- a/runtime/src/iree/hal/cts/command_buffer/stress_test.cc
+++ b/runtime/src/iree/hal/cts/command_buffer/stress_test.cc
@@ -21,7 +21,21 @@ namespace iree::hal::cts {
 using ::testing::Each;
 using ::testing::ElementsAreArray;
 
-class CommandBufferStressTest : public CtsTestBase<> {};
+class CommandBufferStressTest : public CtsTestBase<> {
+ protected:
+  void QueueFillAndWait(iree_hal_buffer_t* target_buffer,
+                        iree_device_size_t length, const void* pattern,
+                        iree_host_size_t pattern_length) {
+    SemaphoreList empty_wait;
+    SemaphoreList fill_signal(device_, {0}, {1});
+    IREE_ASSERT_OK(iree_hal_device_queue_fill(
+        device_, IREE_HAL_QUEUE_AFFINITY_ANY, empty_wait, fill_signal,
+        target_buffer, /*target_offset=*/0, length, pattern, pattern_length,
+        IREE_HAL_FILL_FLAG_NONE));
+    IREE_ASSERT_OK(iree_hal_semaphore_list_wait(
+        fill_signal, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE));
+  }
+};
 
 // Submits 200 one-shot fill command buffers in a tight loop, each writing
 // a different pattern. This stresses the recording item pool: each submit
@@ -67,19 +81,8 @@ TEST_P(CommandBufferStressTest, RapidCopySubmit) {
   IREE_ASSERT_OK(CreateZeroedDeviceBuffer(buffer_size, target.out()));
 
   for (int i = 0; i < 200; ++i) {
-    // Fill source with pattern via host mapping.
     uint32_t pattern = (uint32_t)(0xCAFE0000 | i);
-    {
-      iree_hal_buffer_mapping_t mapping;
-      IREE_ASSERT_OK(iree_hal_buffer_map_range(
-          source, IREE_HAL_MAPPING_MODE_SCOPED,
-          IREE_HAL_MEMORY_ACCESS_DISCARD_WRITE, 0, buffer_size, &mapping));
-      uint32_t* data = (uint32_t*)mapping.contents.data;
-      for (iree_device_size_t j = 0; j < buffer_size / sizeof(uint32_t); ++j) {
-        data[j] = pattern;
-      }
-      IREE_ASSERT_OK(iree_hal_buffer_unmap_range(&mapping));
-    }
+    QueueFillAndWait(source, buffer_size, &pattern, sizeof(pattern));
 
     // Copy source→target via command buffer.
     Ref<iree_hal_command_buffer_t> command_buffer;

--- a/runtime/src/iree/hal/cts/queue/queue_transfer_test.cc
+++ b/runtime/src/iree/hal/cts/queue/queue_transfer_test.cc
@@ -79,10 +79,11 @@ class QueueTransferTest : public CtsTestBase<> {
                                                 IREE_ASYNC_WAIT_FLAG_NONE));
   }
 
-  // Writes |pattern| to the entire host-visible source buffer.
-  void FillBufferFromHost(iree_hal_buffer_t* buffer, uint32_t pattern) {
-    IREE_ASSERT_OK(iree_hal_buffer_map_fill(buffer, 0, IREE_HAL_WHOLE_BUFFER,
-                                            &pattern, sizeof(pattern)));
+  // Writes |pattern| to the entire source buffer.
+  void FillBuffer(iree_hal_buffer_t* buffer, uint32_t pattern) {
+    QueueFillAndWait(buffer, /*target_offset=*/0,
+                     iree_hal_buffer_byte_length(buffer), &pattern,
+                     sizeof(pattern));
   }
 };
 
@@ -555,7 +556,7 @@ TEST_P(QueueTransferTest, BurstCopySubmit) {
 
   for (int iteration = 0; iteration < kBurstSubmitIterations; ++iteration) {
     uint32_t pattern = (uint32_t)(0xC0DE0000 | iteration);
-    FillBufferFromHost(source, pattern);
+    FillBuffer(source, pattern);
 
     SemaphoreList empty_wait;
     std::vector<SemaphoreList> copy_signals;

--- a/runtime/src/iree/hal/cts/util/test_base.h
+++ b/runtime/src/iree/hal/cts/util/test_base.h
@@ -441,32 +441,35 @@ class CtsTestBase : public BaseType {
       iree_device_size_t buffer_size, iree_hal_buffer_t** out_buffer) {
     *out_buffer = nullptr;
     iree_hal_buffer_params_t params = {0};
-    params.type =
-        IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
-    params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
-                   IREE_HAL_BUFFER_USAGE_TRANSFER |
-                   IREE_HAL_BUFFER_USAGE_MAPPING;
-    iree_hal_buffer_t* buffer = nullptr;
-    IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
-        device_allocator_, params, buffer_size, &buffer));
-    *out_buffer = buffer;
-    return iree_ok_status();
+    params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
+    params.usage =
+        IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE | IREE_HAL_BUFFER_USAGE_TRANSFER;
+    return iree_hal_allocator_allocate_buffer(device_allocator_, params,
+                                              buffer_size, out_buffer);
   }
 
   iree_status_t CreateZeroedDeviceBuffer(iree_device_size_t buffer_size,
                                          iree_hal_buffer_t** out_buffer) {
     *out_buffer = nullptr;
     iree_hal_buffer_params_t params = {0};
-    params.type =
-        IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
-    params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
-                   IREE_HAL_BUFFER_USAGE_TRANSFER |
-                   IREE_HAL_BUFFER_USAGE_MAPPING;
+    params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
+    params.usage =
+        IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE | IREE_HAL_BUFFER_USAGE_TRANSFER;
     iree_hal_buffer_t* buffer = nullptr;
     iree_status_t status = iree_hal_allocator_allocate_buffer(
         device_allocator_, params, buffer_size, &buffer);
     if (iree_status_is_ok(status)) {
-      status = iree_hal_buffer_map_zero(buffer, 0, IREE_HAL_WHOLE_BUFFER);
+      uint8_t pattern = 0;
+      SemaphoreList empty_wait;
+      SemaphoreList fill_signal(device_, {0}, {1});
+      status = iree_hal_device_queue_fill(
+          device_, IREE_HAL_QUEUE_AFFINITY_ANY, empty_wait, fill_signal, buffer,
+          /*target_offset=*/0, buffer_size, &pattern, sizeof(pattern),
+          IREE_HAL_FILL_FLAG_NONE);
+      if (iree_status_is_ok(status)) {
+        status = iree_hal_semaphore_list_wait(
+            fill_signal, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
+      }
     }
     if (iree_status_is_ok(status)) {
       *out_buffer = buffer;
@@ -481,11 +484,9 @@ class CtsTestBase : public BaseType {
                                            iree_hal_buffer_t** out_buffer) {
     *out_buffer = nullptr;
     iree_hal_buffer_params_t params = {0};
-    params.type =
-        IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
-    params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
-                   IREE_HAL_BUFFER_USAGE_TRANSFER |
-                   IREE_HAL_BUFFER_USAGE_MAPPING;
+    params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
+    params.usage =
+        IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE | IREE_HAL_BUFFER_USAGE_TRANSFER;
     iree_hal_buffer_t* buffer = nullptr;
     iree_status_t status = iree_hal_allocator_allocate_buffer(
         device_allocator_, params, buffer_size, &buffer);
@@ -515,17 +516,23 @@ class CtsTestBase : public BaseType {
                                          iree_hal_buffer_t** out_buffer) {
     *out_buffer = nullptr;
     iree_hal_buffer_params_t params = {0};
-    params.type = IREE_HAL_MEMORY_TYPE_OPTIMAL_FOR_DEVICE |
-                  IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
-    params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
-                   IREE_HAL_BUFFER_USAGE_TRANSFER |
-                   IREE_HAL_BUFFER_USAGE_MAPPING;
+    params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
+    params.usage =
+        IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE | IREE_HAL_BUFFER_USAGE_TRANSFER;
     iree_hal_buffer_t* buffer = nullptr;
     iree_status_t status = iree_hal_allocator_allocate_buffer(
         device_allocator_, params, buffer_size, &buffer);
     if (iree_status_is_ok(status)) {
-      status = iree_hal_buffer_map_fill(buffer, 0, IREE_HAL_WHOLE_BUFFER,
-                                        &pattern, sizeof(pattern));
+      SemaphoreList empty_wait;
+      SemaphoreList fill_signal(device_, {0}, {1});
+      status = iree_hal_device_queue_fill(
+          device_, IREE_HAL_QUEUE_AFFINITY_ANY, empty_wait, fill_signal, buffer,
+          /*target_offset=*/0, buffer_size, &pattern, sizeof(pattern),
+          IREE_HAL_FILL_FLAG_NONE);
+      if (iree_status_is_ok(status)) {
+        status = iree_hal_semaphore_list_wait(
+            fill_signal, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
+      }
     }
     if (iree_status_is_ok(status)) {
       *out_buffer = buffer;

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator.c
@@ -475,10 +475,15 @@ static bool iree_hal_amdgpu_allocator_resolve_placement(
       requested_type & ~IREE_HAL_MEMORY_TYPE_OPTIMAL;
   const bool requires_host_local =
       iree_all_bits_set(required_type, IREE_HAL_MEMORY_TYPE_HOST_LOCAL);
-  const bool requires_host_visible =
-      iree_all_bits_set(required_type, IREE_HAL_MEMORY_TYPE_HOST_VISIBLE);
+  const bool requires_host_access = iree_any_bit_set(
+      required_type,
+      IREE_HAL_MEMORY_TYPE_HOST_VISIBLE | IREE_HAL_MEMORY_TYPE_HOST_COHERENT |
+          IREE_HAL_MEMORY_TYPE_HOST_CACHED | IREE_HAL_MEMORY_TYPE_HOST_LOCAL);
   const bool requires_device_local =
       iree_all_bits_set(required_type, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL);
+  const bool prefers_device_local =
+      iree_any_bit_set(requested_type, IREE_HAL_MEMORY_TYPE_OPTIMAL) &&
+      iree_any_bit_set(required_type, IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE);
 
   const iree_hal_amdgpu_allocator_memory_pool_t* memory_pool = NULL;
   iree_hal_memory_type_t memory_type = 0;
@@ -495,11 +500,19 @@ static bool iree_hal_amdgpu_allocator_resolve_placement(
     memory_pool = &allocator->memory_pools.host_fine[device_ordinal];
     memory_type =
         IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
-  } else if (requires_host_visible) {
+  } else if (requires_host_access &&
+             (requires_device_local ||
+              (prefers_device_local &&
+               allocator->memory_pools.device_fine[device_ordinal]
+                   .memory_pool.handle))) {
     memory_pool = &allocator->memory_pools.device_fine[device_ordinal];
     memory_type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
                   IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
                   IREE_HAL_MEMORY_TYPE_HOST_COHERENT;
+  } else if (requires_host_access) {
+    memory_pool = &allocator->memory_pools.host_fine[device_ordinal];
+    memory_type =
+        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   } else {
     memory_pool = &allocator->memory_pools.device_coarse[device_ordinal];
     memory_type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
@@ -575,19 +588,14 @@ iree_status_t iree_hal_amdgpu_allocator_create(
     }
 
     hsa_amd_memory_pool_t device_fine_pool = {0};
-    if (iree_status_is_ok(status)) {
-      status = iree_hal_amdgpu_find_fine_global_memory_pool(
-          libhsa, topology->gpu_agents[i], &device_fine_pool);
-      if (!iree_status_is_ok(status)) {
-        status = iree_status_annotate_f(
-            status,
-            "AMDGPU allocator requires fine-grained device-local memory for "
-            "host-coherent DEVICE_LOCAL|HOST_VISIBLE allocations on physical "
-            "device %" PRIhsz,
-            i);
-      }
+    if (iree_status_is_ok(status) &&
+        !logical_device->suppress_device_fine_memory) {
+      bool device_fine_pool_available = false;
+      status = iree_hal_amdgpu_query_fine_global_memory_pool(
+          libhsa, topology->gpu_agents[i], &device_fine_pool_available,
+          &device_fine_pool);
     }
-    if (iree_status_is_ok(status)) {
+    if (iree_status_is_ok(status) && device_fine_pool.handle) {
       status = iree_hal_amdgpu_allocator_query_pool_properties(
           libhsa, device_fine_pool, &allocator->memory_pools.device_fine[i]);
     }
@@ -648,13 +656,17 @@ static iree_device_size_t iree_hal_amdgpu_allocator_min_pool_limit(
   return lhs < rhs ? lhs : rhs;
 }
 
-static void iree_hal_amdgpu_allocator_query_pool_family_limits(
+static bool iree_hal_amdgpu_allocator_query_pool_family_limits(
     const iree_hal_amdgpu_allocator_memory_pool_t* pools,
     iree_host_size_t pool_count, iree_device_size_t* out_max_allocation_size,
     iree_device_size_t* out_min_alignment) {
+  *out_max_allocation_size = 0;
+  *out_min_alignment = 0;
+  if (!pools[0].memory_pool.handle) return false;
   iree_device_size_t max_allocation_size = pools[0].max_allocation_size;
   iree_device_size_t min_alignment = pools[0].allocation_alignment;
   for (iree_host_size_t i = 1; i < pool_count; ++i) {
+    if (!pools[i].memory_pool.handle) return false;
     max_allocation_size = iree_hal_amdgpu_allocator_min_pool_limit(
         max_allocation_size, pools[i].max_allocation_size);
     min_alignment = iree_hal_amdgpu_allocator_min_pool_limit(
@@ -662,6 +674,7 @@ static void iree_hal_amdgpu_allocator_query_pool_family_limits(
   }
   *out_max_allocation_size = max_allocation_size;
   *out_min_alignment = min_alignment;
+  return true;
 }
 
 static iree_status_t iree_hal_amdgpu_allocator_query_memory_heaps(
@@ -671,33 +684,29 @@ static iree_status_t iree_hal_amdgpu_allocator_query_memory_heaps(
     iree_host_size_t* IREE_RESTRICT out_count) {
   iree_hal_amdgpu_allocator_t* allocator =
       iree_hal_amdgpu_allocator_cast(base_allocator);
-  const iree_host_size_t heap_count = 3;
-  *out_count = heap_count;
-  if (capacity < heap_count) {
-    // NOTE: lightweight as this is hit in normal pre-sizing usage.
-    return iree_status_from_code(IREE_STATUS_OUT_OF_RANGE);
-  }
-
-  memset(heaps, 0, heap_count * sizeof(*heaps));
-
   iree_device_size_t device_coarse_max_allocation_size = 0;
   iree_device_size_t device_coarse_min_alignment = 0;
-  iree_hal_amdgpu_allocator_query_pool_family_limits(
-      allocator->memory_pools.device_coarse,
-      allocator->topology->gpu_agent_count, &device_coarse_max_allocation_size,
-      &device_coarse_min_alignment);
+  const bool device_coarse_available =
+      iree_hal_amdgpu_allocator_query_pool_family_limits(
+          allocator->memory_pools.device_coarse,
+          allocator->topology->gpu_agent_count,
+          &device_coarse_max_allocation_size, &device_coarse_min_alignment);
 
   iree_device_size_t device_fine_max_allocation_size = 0;
   iree_device_size_t device_fine_min_alignment = 0;
-  iree_hal_amdgpu_allocator_query_pool_family_limits(
-      allocator->memory_pools.device_fine, allocator->topology->gpu_agent_count,
-      &device_fine_max_allocation_size, &device_fine_min_alignment);
+  const bool device_fine_available =
+      iree_hal_amdgpu_allocator_query_pool_family_limits(
+          allocator->memory_pools.device_fine,
+          allocator->topology->gpu_agent_count,
+          &device_fine_max_allocation_size, &device_fine_min_alignment);
 
   iree_device_size_t host_fine_max_allocation_size = 0;
   iree_device_size_t host_fine_min_alignment = 0;
-  iree_hal_amdgpu_allocator_query_pool_family_limits(
-      allocator->memory_pools.host_fine, allocator->topology->gpu_agent_count,
-      &host_fine_max_allocation_size, &host_fine_min_alignment);
+  const bool host_fine_available =
+      iree_hal_amdgpu_allocator_query_pool_family_limits(
+          allocator->memory_pools.host_fine,
+          allocator->topology->gpu_agent_count, &host_fine_max_allocation_size,
+          &host_fine_min_alignment);
 
   // Sharing hints do not affect HSA pool selection.
   const iree_hal_buffer_usage_t sharing_usage =
@@ -712,27 +721,43 @@ static iree_status_t iree_hal_amdgpu_allocator_query_memory_heaps(
       IREE_HAL_BUFFER_USAGE_MAPPING_ACCESS_RANDOM |
       IREE_HAL_BUFFER_USAGE_MAPPING_ACCESS_SEQUENTIAL_WRITE;
 
-  // Heap 0: coarse-grained device-local memory.
-  heaps[0].type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
-  heaps[0].allowed_usage = IREE_HAL_BUFFER_USAGE_TRANSFER |
-                           IREE_HAL_BUFFER_USAGE_DISPATCH | sharing_usage;
-  heaps[0].max_allocation_size = device_coarse_max_allocation_size;
-  heaps[0].min_alignment = device_coarse_min_alignment;
+  iree_hal_allocator_memory_heap_t available_heaps[3] = {0};
+  iree_host_size_t heap_count = 0;
+  if (device_coarse_available) {
+    available_heaps[heap_count++] = (iree_hal_allocator_memory_heap_t){
+        .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+        .allowed_usage = IREE_HAL_BUFFER_USAGE_TRANSFER |
+                         IREE_HAL_BUFFER_USAGE_DISPATCH | sharing_usage,
+        .max_allocation_size = device_coarse_max_allocation_size,
+        .min_alignment = device_coarse_min_alignment,
+    };
+  }
+  if (device_fine_available) {
+    available_heaps[heap_count++] = (iree_hal_allocator_memory_heap_t){
+        .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+                IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                IREE_HAL_MEMORY_TYPE_HOST_COHERENT,
+        .allowed_usage = mappable_usage,
+        .max_allocation_size = device_fine_max_allocation_size,
+        .min_alignment = device_fine_min_alignment,
+    };
+  }
+  if (host_fine_available) {
+    available_heaps[heap_count++] = (iree_hal_allocator_memory_heap_t){
+        .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+        .allowed_usage = mappable_usage,
+        .max_allocation_size = host_fine_max_allocation_size,
+        .min_alignment = host_fine_min_alignment,
+    };
+  }
 
-  // Heap 1: fine-grained device-local memory for explicit host visibility.
-  heaps[1].type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
-                  IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
-                  IREE_HAL_MEMORY_TYPE_HOST_COHERENT;
-  heaps[1].allowed_usage = mappable_usage;
-  heaps[1].max_allocation_size = device_fine_max_allocation_size;
-  heaps[1].min_alignment = device_fine_min_alignment;
-
-  // Heap 2: fine-grained host-local memory visible to the device.
-  heaps[2].type =
-      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
-  heaps[2].allowed_usage = mappable_usage;
-  heaps[2].max_allocation_size = host_fine_max_allocation_size;
-  heaps[2].min_alignment = host_fine_min_alignment;
+  *out_count = heap_count;
+  if (capacity < heap_count) {
+    // NOTE: lightweight as this is hit in normal pre-sizing usage.
+    return iree_status_from_code(IREE_STATUS_OUT_OF_RANGE);
+  }
+  memcpy(heaps, available_heaps, heap_count * sizeof(*heaps));
 
   return iree_ok_status();
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
@@ -101,9 +101,17 @@ class AllocatorTest : public ::testing::Test {
                              iree_allocator_t host_allocator) {
       iree_hal_amdgpu_logical_device_options_t options;
       iree_hal_amdgpu_logical_device_options_initialize(&options);
+      return InitializeWithOptions(&options, libhsa, topology, host_allocator);
+    }
+
+    iree_status_t InitializeWithOptions(
+        const iree_hal_amdgpu_logical_device_options_t* options,
+        const iree_hal_amdgpu_libhsa_t* libhsa,
+        const iree_hal_amdgpu_topology_t* topology,
+        iree_allocator_t host_allocator) {
       IREE_RETURN_IF_ERROR(create_context_.Initialize(host_allocator));
       IREE_RETURN_IF_ERROR(iree_hal_amdgpu_logical_device_create(
-          IREE_SV("amdgpu"), &options, libhsa, topology,
+          IREE_SV("amdgpu"), options, libhsa, topology,
           create_context_.params(), host_allocator, &base_device_));
       return iree_hal_device_group_create_from_device(
           base_device_, create_context_.frontier_tracker(), host_allocator,
@@ -145,14 +153,17 @@ TEST_F(AllocatorTest, QueryMemoryHeapsReportsHsaLimits) {
                         iree_hal_allocator_query_memory_heaps(
                             test_device.allocator(),
                             /*capacity=*/0, /*heaps=*/NULL, &heap_count));
-  ASSERT_EQ(heap_count, 3u);
+  ASSERT_GE(heap_count, 2u);
+  ASSERT_LE(heap_count, 3u);
 
   std::array<iree_hal_allocator_memory_heap_t, 3> heaps;
   IREE_ASSERT_OK(iree_hal_allocator_query_memory_heaps(
       test_device.allocator(), heaps.size(), heaps.data(), &heap_count));
-  ASSERT_EQ(heap_count, heaps.size());
+  ASSERT_GE(heap_count, 2u);
+  ASSERT_LE(heap_count, heaps.size());
 
-  for (const auto& heap : heaps) {
+  for (iree_host_size_t i = 0; i < heap_count; ++i) {
+    const iree_hal_allocator_memory_heap_t& heap = heaps[i];
     EXPECT_NE(heap.max_allocation_size, 0u);
     EXPECT_NE(heap.max_allocation_size, ~(iree_device_size_t)0);
     EXPECT_NE(heap.min_alignment, 0u);
@@ -168,7 +179,8 @@ TEST_F(AllocatorTest, OversizedAllocationIsRejectedByCompatibility) {
   iree_host_size_t heap_count = 0;
   IREE_ASSERT_OK(iree_hal_allocator_query_memory_heaps(
       test_device.allocator(), heaps.size(), heaps.data(), &heap_count));
-  ASSERT_EQ(heap_count, heaps.size());
+  ASSERT_GE(heap_count, 2u);
+  ASSERT_LE(heap_count, heaps.size());
   ASSERT_LT(heaps[0].max_allocation_size, ~(iree_device_size_t)0);
 
   iree_device_size_t oversized_allocation_size = 0;
@@ -205,6 +217,10 @@ TEST_F(AllocatorTest, DeviceLocalHostVisibleMemoryIsLowPerformance) {
       iree_hal_allocator_query_buffer_compatibility(
           test_device.allocator(), params, /*allocation_size=*/4096,
           &resolved_params, &resolved_allocation_size);
+  if (!iree_all_bits_set(compatibility,
+                         IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE)) {
+    GTEST_SKIP() << "device-local host-visible memory is not available";
+  }
   EXPECT_TRUE(iree_all_bits_set(
       compatibility, IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE |
                          IREE_HAL_BUFFER_COMPATIBILITY_QUEUE_TRANSFER |
@@ -214,6 +230,90 @@ TEST_F(AllocatorTest, DeviceLocalHostVisibleMemoryIsLowPerformance) {
                                 IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
                                     IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
                                     IREE_HAL_MEMORY_TYPE_HOST_COHERENT));
+
+  iree_hal_buffer_params_t preferred_params = {0};
+  preferred_params.type = IREE_HAL_MEMORY_TYPE_OPTIMAL |
+                          IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                          IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+  preferred_params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER |
+                           IREE_HAL_BUFFER_USAGE_DISPATCH |
+                           IREE_HAL_BUFFER_USAGE_MAPPING_SCOPED;
+  iree_hal_buffer_params_t resolved_preferred_params = {0};
+  iree_device_size_t resolved_preferred_allocation_size = 0;
+  iree_hal_buffer_compatibility_t preferred_compatibility =
+      iree_hal_allocator_query_buffer_compatibility(
+          test_device.allocator(), preferred_params, /*allocation_size=*/4096,
+          &resolved_preferred_params, &resolved_preferred_allocation_size);
+  EXPECT_TRUE(
+      iree_all_bits_set(preferred_compatibility,
+                        IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE |
+                            IREE_HAL_BUFFER_COMPATIBILITY_QUEUE_TRANSFER |
+                            IREE_HAL_BUFFER_COMPATIBILITY_QUEUE_DISPATCH |
+                            IREE_HAL_BUFFER_COMPATIBILITY_LOW_PERFORMANCE));
+  EXPECT_TRUE(iree_all_bits_set(resolved_preferred_params.type,
+                                IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+                                    IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                                    IREE_HAL_MEMORY_TYPE_HOST_COHERENT));
+}
+
+TEST_F(AllocatorTest, SuppressDeviceFineMemoryRetainsMappedHostMemory) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.suppress_device_fine_memory = 1;
+
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.InitializeWithOptions(
+      &options, &libhsa_, &topology_, host_allocator_));
+
+  iree_hal_buffer_params_t device_visible_params = {0};
+  device_visible_params.type =
+      IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
+  device_visible_params.usage =
+      IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING;
+  iree_hal_buffer_params_t resolved_device_visible_params = {0};
+  iree_device_size_t resolved_device_visible_allocation_size = 0;
+  iree_hal_buffer_compatibility_t device_visible_compatibility =
+      iree_hal_allocator_query_buffer_compatibility(
+          test_device.allocator(), device_visible_params,
+          /*allocation_size=*/4096, &resolved_device_visible_params,
+          &resolved_device_visible_allocation_size);
+  EXPECT_EQ(device_visible_compatibility, IREE_HAL_BUFFER_COMPATIBILITY_NONE);
+
+  iree_hal_buffer_params_t host_visible_params = {0};
+  host_visible_params.type = IREE_HAL_MEMORY_TYPE_OPTIMAL |
+                             IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                             IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+  host_visible_params.usage =
+      IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING;
+  iree_hal_buffer_params_t resolved_host_visible_params = {0};
+  iree_device_size_t resolved_host_visible_allocation_size = 0;
+  iree_hal_buffer_compatibility_t host_visible_compatibility =
+      iree_hal_allocator_query_buffer_compatibility(
+          test_device.allocator(), host_visible_params,
+          /*allocation_size=*/4096, &resolved_host_visible_params,
+          &resolved_host_visible_allocation_size);
+  EXPECT_TRUE(
+      iree_all_bits_set(host_visible_compatibility,
+                        IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE |
+                            IREE_HAL_BUFFER_COMPATIBILITY_QUEUE_TRANSFER));
+  EXPECT_TRUE(iree_all_bits_set(
+      resolved_host_visible_params.type,
+      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE));
+  EXPECT_TRUE(iree_all_bits_set(resolved_host_visible_params.usage,
+                                IREE_HAL_BUFFER_USAGE_MAPPING));
+  EXPECT_FALSE(iree_all_bits_set(resolved_host_visible_params.type,
+                                 IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL));
+
+  iree_hal_buffer_t* buffer = NULL;
+  IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
+      test_device.allocator(), resolved_host_visible_params,
+      resolved_host_visible_allocation_size, &buffer));
+  EXPECT_TRUE(iree_all_bits_set(
+      iree_hal_buffer_memory_type(buffer),
+      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE));
+  EXPECT_FALSE(iree_all_bits_set(iree_hal_buffer_memory_type(buffer),
+                                 IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL));
+  iree_hal_buffer_release(buffer);
 }
 
 TEST_F(AllocatorTest, OverAlignedAllocationIsRejected) {
@@ -224,7 +324,8 @@ TEST_F(AllocatorTest, OverAlignedAllocationIsRejected) {
   iree_host_size_t heap_count = 0;
   IREE_ASSERT_OK(iree_hal_allocator_query_memory_heaps(
       test_device.allocator(), heaps.size(), heaps.data(), &heap_count));
-  ASSERT_EQ(heap_count, heaps.size());
+  ASSERT_GE(heap_count, 2u);
+  ASSERT_LE(heap_count, heaps.size());
 
   const iree_device_size_t over_alignment =
       ~(iree_device_size_t)0 ^ (~(iree_device_size_t)0 >> 1);

--- a/runtime/src/iree/hal/drivers/amdgpu/api.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/api.h
@@ -171,6 +171,12 @@ typedef struct iree_hal_amdgpu_logical_device_options_t {
   // selection remains limited to validated GPU ISAs when this is unset.
   uint64_t enable_experimental_pm4_command_buffers : 1;
 
+  // Suppresses fine-grained GPU-local memory pools even if the HSA agent
+  // reports them. This is a hardware bring-up and compatibility testing
+  // override for validating the coarse-grained device-local memory path used on
+  // GPUs that do not expose host-coherent VRAM.
+  uint64_t suppress_device_fine_memory : 1;
+
   // Reserved for future HSA active-wait tuning. Must be zero today because no
   // wait path consumes it yet.
   iree_duration_t wait_active_for_ns;

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue.c
@@ -209,6 +209,13 @@ static bool iree_hal_amdgpu_host_queue_has_error(
   return iree_atomic_load(&queue->error_status, iree_memory_order_acquire) != 0;
 }
 
+static iree_status_t iree_hal_amdgpu_host_queue_clone_error_status(
+    iree_hal_amdgpu_host_queue_t* queue) {
+  iree_status_t error = (iree_status_t)iree_atomic_load(
+      &queue->error_status, iree_memory_order_acquire);
+  return iree_status_is_ok(error) ? iree_ok_status() : iree_status_clone(error);
+}
+
 static bool iree_hal_amdgpu_host_queue_store_error(
     iree_hal_amdgpu_host_queue_t* queue, iree_status_t error) {
   intptr_t expected = 0;
@@ -227,6 +234,83 @@ static void iree_hal_amdgpu_host_queue_request_completion_thread_stop(
     iree_hsa_signal_store_screlease(IREE_LIBHSA(queue->libhsa),
                                     queue->completion.stop_signal, 1);
   }
+}
+
+iree_status_t iree_hal_amdgpu_host_queue_wait_for_setup_epoch(
+    iree_hal_amdgpu_host_queue_t* queue, uint64_t epoch) {
+  IREE_ASSERT_ARGUMENT(queue);
+  if (epoch == 0) return iree_ok_status();
+  if (!queue->hardware_queue || !queue->notification_ring.epoch.signal.handle) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "AMDGPU host queue cannot wait for epoch %" PRIu64
+                            " without an active hardware queue",
+                            epoch);
+  }
+  if (IREE_UNLIKELY(epoch > (uint64_t)IREE_HAL_AMDGPU_EPOCH_INITIAL_VALUE)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "AMDGPU host queue epoch %" PRIu64
+                            " exceeds representable HSA signal range",
+                            epoch);
+  }
+
+  hsa_signal_t epoch_signal =
+      iree_hal_amdgpu_notification_ring_epoch_signal(&queue->notification_ring);
+  hsa_signal_t stop_signal = queue->completion.stop_signal;
+  const hsa_signal_value_t target_signal_value =
+      (hsa_signal_value_t)(IREE_HAL_AMDGPU_EPOCH_INITIAL_VALUE - epoch);
+  const hsa_signal_value_t compare_value = target_signal_value + 1;
+
+  if (stop_signal.handle) {
+    enum {
+      IREE_HAL_AMDGPU_EPOCH_WAIT_EPOCH_SIGNAL = 0,
+      IREE_HAL_AMDGPU_EPOCH_WAIT_STOP_SIGNAL = 1,
+      IREE_HAL_AMDGPU_EPOCH_WAIT_SIGNAL_COUNT = 2,
+    };
+    hsa_signal_t signals[IREE_HAL_AMDGPU_EPOCH_WAIT_SIGNAL_COUNT] = {
+        epoch_signal,
+        stop_signal,
+    };
+    hsa_signal_condition_t conditions[IREE_HAL_AMDGPU_EPOCH_WAIT_SIGNAL_COUNT] =
+        {
+            HSA_SIGNAL_CONDITION_LT,
+            HSA_SIGNAL_CONDITION_NE,
+        };
+    hsa_signal_value_t values[IREE_HAL_AMDGPU_EPOCH_WAIT_SIGNAL_COUNT] = {
+        compare_value,
+        0,
+    };
+    const uint32_t signal_index = iree_hsa_amd_signal_wait_any(
+        IREE_LIBHSA(queue->libhsa), IREE_HAL_AMDGPU_EPOCH_WAIT_SIGNAL_COUNT,
+        signals, conditions, values, UINT64_MAX, HSA_WAIT_STATE_BLOCKED,
+        /*satisfying_value=*/NULL);
+    if (IREE_UNLIKELY(signal_index >=
+                      IREE_HAL_AMDGPU_EPOCH_WAIT_SIGNAL_COUNT)) {
+      iree_status_t error = iree_make_status(
+          IREE_STATUS_INTERNAL,
+          "hsa_amd_signal_wait_any returned invalid signal index %u while "
+          "waiting for AMDGPU host queue epoch %" PRIu64,
+          signal_index, epoch);
+      iree_hal_amdgpu_host_queue_store_error(queue, iree_status_clone(error));
+      iree_hal_amdgpu_host_queue_request_completion_thread_stop(queue);
+      return error;
+    } else if (signal_index == IREE_HAL_AMDGPU_EPOCH_WAIT_STOP_SIGNAL) {
+      iree_status_t error =
+          iree_hal_amdgpu_host_queue_clone_error_status(queue);
+      if (!iree_status_is_ok(error)) return error;
+      return iree_make_status(IREE_STATUS_CANCELLED,
+                              "AMDGPU host queue stopped while waiting for "
+                              "epoch %" PRIu64,
+                              epoch);
+    }
+  } else {
+    (void)iree_hsa_signal_wait_scacquire(
+        IREE_LIBHSA(queue->libhsa), epoch_signal, HSA_SIGNAL_CONDITION_LT,
+        compare_value, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
+  }
+
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_host_queue_clone_error_status(queue));
+  iree_hal_amdgpu_host_queue_drain_completions_for_waiter(queue);
+  return iree_hal_amdgpu_host_queue_clone_error_status(queue);
 }
 
 static hsa_signal_value_t iree_hal_amdgpu_host_queue_last_drained_signal_value(
@@ -421,7 +505,7 @@ iree_status_t iree_hal_amdgpu_host_queue_initialize(
     iree_hal_amdgpu_pm4_timestamp_strategy_t pm4_timestamp_strategy,
     iree_hal_amdgpu_epoch_signal_table_t* epoch_table,
     iree_arena_block_pool_t* block_pool,
-    iree_hal_amdgpu_block_pool_t* profiling_signal_block_pool,
+    iree_hal_amdgpu_host_queue_profiling_memory_t profiling_memory,
     const iree_hal_amdgpu_device_buffer_transfer_context_t* transfer_context,
     const iree_hal_pool_set_t* default_pool_set, iree_hal_pool_t* default_pool,
     iree_hal_amdgpu_transient_buffer_pool_t* transient_buffer_pool,
@@ -437,7 +521,6 @@ iree_status_t iree_hal_amdgpu_host_queue_initialize(
   IREE_ASSERT_ARGUMENT(frontier_tracker);
   IREE_ASSERT_ARGUMENT(epoch_table);
   IREE_ASSERT_ARGUMENT(block_pool);
-  IREE_ASSERT_ARGUMENT(profiling_signal_block_pool);
   IREE_ASSERT_ARGUMENT(transfer_context);
   IREE_ASSERT_ARGUMENT(default_pool_set);
   IREE_ASSERT_ARGUMENT(default_pool);
@@ -476,7 +559,7 @@ iree_status_t iree_hal_amdgpu_host_queue_initialize(
   iree_slim_mutex_initialize(&out_queue->locks.completion_drain_mutex);
   iree_slim_mutex_initialize(&out_queue->locks.post_drain_mutex);
   iree_slim_mutex_initialize(&out_queue->profiling.event_mutex);
-  out_queue->profiling.signals.block_pool = profiling_signal_block_pool;
+  out_queue->profiling.memory = profiling_memory;
   out_queue->axis = axis;
   out_queue->wait_barrier_strategy = wait_barrier_strategy;
   out_queue->vendor_packet_capabilities = vendor_packet_capabilities;

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue.h
@@ -76,6 +76,20 @@ typedef struct iree_hal_amdgpu_profile_queue_device_event_reservation_t {
 typedef struct iree_hal_amdgpu_host_queue_post_drain_action_t
     iree_hal_amdgpu_host_queue_post_drain_action_t;
 
+// Memory policy used for queue profiling records.
+typedef struct iree_hal_amdgpu_host_queue_profiling_memory_t {
+  // HSA memory pool used for device-owned raw completion-signal records.
+  hsa_amd_memory_pool_t signal_memory_pool;
+  // HSA memory pool used for host-readable, device-writable event records.
+  hsa_amd_memory_pool_t event_memory_pool;
+  // Agents granted explicit access to event records after allocation.
+  const hsa_agent_t* event_access_agents;
+  // Number of entries in |event_access_agents|.
+  iree_host_size_t event_access_agent_count;
+  // Publication required after CPU writes event metadata.
+  iree_hal_amdgpu_kernarg_ring_publication_t event_host_write_publication;
+} iree_hal_amdgpu_host_queue_profiling_memory_t;
+
 // Callback run after notification-ring drain has published completed entries
 // and reclaimed queue-owned ring state.
 typedef void(IREE_API_PTR* iree_hal_amdgpu_host_queue_post_drain_fn_t)(
@@ -313,26 +327,14 @@ typedef struct iree_hal_amdgpu_host_queue_t {
     uint32_t queue_device_events_enabled : 1;
     // True when selected dispatches may receive profile packet augmentation.
     uint32_t dispatch_profiling_enabled : 1;
+    // Memory pools and publication policy for queue-local profiling storage.
+    iree_hal_amdgpu_host_queue_profiling_memory_t memory;
     // Serializes profile event ring mutation and flush.
     iree_slim_mutex_t event_mutex;
-    // Raw completion-signal storage paired with dispatch event slots.
-    struct {
-      // Borrowed fine-grained GPU-agent block pool backing raw signal storage.
-      iree_hal_amdgpu_block_pool_t* block_pool;
-      // Host-side table of queue-owned GPU-agent raw signal blocks.
-      iree_hal_amdgpu_block_t** blocks;
-      // Number of entries in |blocks|.
-      uint32_t block_count;
-      // Number of iree_amd_signal_t records in each block.
-      uint32_t signals_per_block;
-    } signals;
-    // Shared device-visible allocation backing queue-local event rings.
-    struct {
-      // Allocation base returned by HSA memory pool allocation.
-      void* base;
-      // Byte length of |base|.
-      iree_host_size_t size;
-    } event_allocation;
+    // Queue-owned raw completion-signal records paired with dispatch slots.
+    iree_amd_signal_t* completion_signals;
+    // Shared host-readable, device-writable allocation backing event rings.
+    void* event_storage;
     // Device-visible dispatch event ring waiting for sink flush.
     struct {
       // Dispatch event record storage in the shared event allocation.
@@ -383,7 +385,7 @@ typedef struct iree_hal_amdgpu_host_queue_t {
       struct {
         // Host-side slot table pairing range banks with aqlprofile handles.
         iree_hal_amdgpu_profile_counter_range_slot_t* slots;
-        // Device-visible timing records for each range bank.
+        // Host-readable, device-written start/end ticks for each range bank.
         uint64_t* ticks;
         // Byte length of |ticks|.
         iree_host_size_t tick_storage_size;
@@ -614,10 +616,11 @@ void iree_hal_amdgpu_host_queue_enqueue_post_drain_action(
 // queue-device timestamp records. NONE disables profiling paths that need
 // queue-local timestamp ranges.
 //
-// |profiling_signal_block_pool| provides fine-grained GPU-agent memory used for
-// raw iree_amd_signal_t records. The host initializes these records once when
-// timestamp profiling begins; packets only use them for CP-written profiling
-// timestamps and never for host HSA waits or interrupts.
+// |profiling_memory| provides memory for queue-local profiling event rings and
+// raw iree_amd_signal_t records. Raw signals may use device-only memory because
+// packets only use them for CP-written timestamps and never for host HSA waits
+// or interrupts. Profile event records must be host-readable because the
+// profiling sink serializes them on the CPU.
 iree_status_t iree_hal_amdgpu_host_queue_initialize(
     const iree_hal_amdgpu_libhsa_t* libhsa, iree_hal_device_t* logical_device,
     iree_async_proactor_t* proactor, hsa_agent_t gpu_agent,
@@ -631,7 +634,7 @@ iree_status_t iree_hal_amdgpu_host_queue_initialize(
     iree_hal_amdgpu_pm4_timestamp_strategy_t pm4_timestamp_strategy,
     iree_hal_amdgpu_epoch_signal_table_t* epoch_table,
     iree_arena_block_pool_t* block_pool,
-    iree_hal_amdgpu_block_pool_t* profiling_signal_block_pool,
+    iree_hal_amdgpu_host_queue_profiling_memory_t profiling_memory,
     const iree_hal_amdgpu_device_buffer_transfer_context_t* transfer_context,
     const iree_hal_pool_set_t* default_pool_set, iree_hal_pool_t* default_pool,
     iree_hal_amdgpu_transient_buffer_pool_t* transient_buffer_pool,
@@ -666,6 +669,12 @@ iree_host_size_t iree_hal_amdgpu_host_queue_drain_completions(
 // affinity policy can be controlled.
 iree_host_size_t iree_hal_amdgpu_host_queue_drain_completions_for_waiter(
     iree_hal_amdgpu_host_queue_t* queue);
+
+// Waits until a queue-owned setup submission reaches |epoch|. Setup
+// submissions must not carry user-visible post-drain work; this direct waiter
+// drains only the completed notification entries it observes.
+iree_status_t iree_hal_amdgpu_host_queue_wait_for_setup_epoch(
+    iree_hal_amdgpu_host_queue_t* queue, uint64_t epoch);
 
 // Enables or disables HSA dispatch timestamp population for this queue.
 //

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_block.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_block.c
@@ -18,6 +18,7 @@
 #include "iree/hal/drivers/amdgpu/host_queue_command_buffer_scratch.h"
 #include "iree/hal/drivers/amdgpu/host_queue_policy.h"
 #include "iree/hal/drivers/amdgpu/host_queue_profile.h"
+#include "iree/hal/drivers/amdgpu/host_queue_profile_events.h"
 #include "iree/hal/drivers/amdgpu/host_queue_timestamp.h"
 #include "iree/hal/drivers/amdgpu/profile_counters.h"
 #include "iree/hal/drivers/amdgpu/profile_traces.h"
@@ -507,6 +508,10 @@ static uint64_t iree_hal_amdgpu_host_queue_finish_command_buffer_block(
   const uint64_t first_payload_packet_id =
       submission->first_packet_id + resolution->barrier_count +
       profile_queue_device_prefix_packet_count;
+  if (profile->dispatch_events.event_count != 0 ||
+      profile->queue_device_events.event_count != 0) {
+    iree_hal_amdgpu_host_queue_publish_profile_host_writes(queue);
+  }
   iree_hal_amdgpu_host_queue_publish_submission_kernargs(queue, submission);
   if (queue_device_event) {
     const uint64_t start_packet_id =

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_replay.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_replay.c
@@ -238,6 +238,7 @@ iree_hal_amdgpu_command_buffer_replay_submit_completion_packet(
       submission.reclaim_entry->queue_device_event_count =
           profile_queue_device_events.event_count;
       queue_device_event->submission_id = submission_id;
+      iree_hal_amdgpu_host_queue_publish_profile_host_writes(replay->queue);
     }
 
     if (queue_device_event) {

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_test.cc
@@ -136,8 +136,9 @@ static iree_status_t CreateHostVisibleTransferBuffer(
     iree_hal_allocator_t* allocator, iree_device_size_t buffer_size,
     iree_hal_buffer_t** out_buffer) {
   iree_hal_buffer_params_t params = {0};
-  params.type =
-      IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
+  params.type = IREE_HAL_MEMORY_TYPE_OPTIMAL |
+                IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING;
   return iree_hal_allocator_allocate_buffer(allocator, params, buffer_size,
                                             out_buffer);
@@ -147,8 +148,9 @@ static iree_status_t CreateHostVisibleDispatchBuffer(
     iree_hal_allocator_t* allocator, iree_device_size_t buffer_size,
     iree_hal_buffer_t** out_buffer) {
   iree_hal_buffer_params_t params = {0};
-  params.type =
-      IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
+  params.type = IREE_HAL_MEMORY_TYPE_OPTIMAL |
+                IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   params.access = IREE_HAL_MEMORY_ACCESS_ALL;
   params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
                  IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING;
@@ -160,8 +162,9 @@ static iree_status_t CreateHostVisibleIndirectParameterBuffer(
     iree_hal_allocator_t* allocator, iree_device_size_t buffer_size,
     iree_hal_buffer_t** out_buffer) {
   iree_hal_buffer_params_t params = {0};
-  params.type =
-      IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
+  params.type = IREE_HAL_MEMORY_TYPE_OPTIMAL |
+                IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   params.access = IREE_HAL_MEMORY_ACCESS_ALL;
   params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMETERS |
                  IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING;
@@ -1502,6 +1505,10 @@ TEST_F(HostQueueCommandBufferTest,
   ASSERT_GT(logical_device->physical_device_count, 0u);
   const iree_hal_amdgpu_aql_prepublished_kernarg_storage_t* storage =
       &logical_device->physical_devices[0]->prepublished_kernarg_storage;
+  if (storage->strategy ==
+      IREE_HAL_AMDGPU_AQL_PREPUBLISHED_KERNARG_STORAGE_STRATEGY_DISABLED) {
+    GTEST_SKIP() << "fine-grained GPU memory pool is not available";
+  }
 
   EXPECT_EQ(
       storage->strategy,
@@ -1525,6 +1532,16 @@ TEST_F(HostQueueCommandBufferTest, DirectDispatchUsesPrepublishedKernargs) {
   TestLogicalDevice test_device;
   IREE_ASSERT_OK(
       test_device.Initialize(&options, &libhsa_, &topology_, host_allocator_));
+
+  iree_hal_amdgpu_logical_device_t* logical_device =
+      test_device.logical_device();
+  ASSERT_GT(logical_device->physical_device_count, 0u);
+  const iree_hal_amdgpu_aql_prepublished_kernarg_storage_t* storage =
+      &logical_device->physical_devices[0]->prepublished_kernarg_storage;
+  if (storage->strategy ==
+      IREE_HAL_AMDGPU_AQL_PREPUBLISHED_KERNARG_STORAGE_STRATEGY_DISABLED) {
+    GTEST_SKIP() << "fine-grained GPU memory pool is not available";
+  }
 
   iree_hal_executable_cache_t* executable_cache = NULL;
   iree_hal_executable_t* executable = NULL;
@@ -2892,6 +2909,56 @@ TEST_F(HostQueueCommandBufferTest, SinklessProfilingBeginFails) {
                             test_device.base_device(), &profiling_options));
   IREE_EXPECT_OK(iree_hal_device_profiling_flush(test_device.base_device()));
   IREE_EXPECT_OK(iree_hal_device_profiling_end(test_device.base_device()));
+}
+
+TEST_F(HostQueueCommandBufferTest,
+       SuppressedDeviceFineMemoryAllowsDispatchProfiling) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.preallocate_pools = 0;
+  options.suppress_device_fine_memory = 1;
+
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(
+      test_device.Initialize(&options, &libhsa_, &topology_, host_allocator_));
+
+  ExpectQueueEventProfilingCanBeginAndEnd(&test_device);
+
+  CommandBufferProfileSink sink = {};
+  CommandBufferProfileSinkInitialize(&sink);
+  DeviceProfilingScope profiling(test_device.base_device());
+  IREE_ASSERT_OK(profiling.Begin(IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS,
+                                 CommandBufferProfileSinkAsBase(&sink)));
+  IREE_ASSERT_OK(profiling.End());
+  EXPECT_EQ(1, sink.begin_count);
+  EXPECT_EQ(1, sink.end_count);
+}
+
+TEST_F(HostQueueCommandBufferTest,
+       SuppressedDeviceFineMemoryAllowsQueueDeviceProfiling) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.preallocate_pools = 0;
+  options.suppress_device_fine_memory = 1;
+
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(
+      test_device.Initialize(&options, &libhsa_, &topology_, host_allocator_));
+
+  CommandBufferProfileSink sink = {};
+  CommandBufferProfileSinkInitialize(&sink);
+  DeviceProfilingScope profiling(test_device.base_device());
+  iree_status_t status =
+      profiling.Begin(IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS,
+                      CommandBufferProfileSinkAsBase(&sink));
+  if (IsQueueDeviceProfilingUnavailable(status)) {
+    iree_status_free(status);
+    GTEST_SKIP() << "queue-device profiling data family unsupported by backend";
+  }
+  IREE_ASSERT_OK(status);
+  IREE_ASSERT_OK(profiling.End());
+  EXPECT_EQ(1, sink.begin_count);
+  EXPECT_EQ(1, sink.end_count);
 }
 
 TEST_F(HostQueueCommandBufferTest, NestedProfilingBeginFails) {

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
@@ -879,6 +879,10 @@ static iree_status_t iree_hal_amdgpu_host_queue_submit_indirect_dispatch(
                 resolution->inline_acquire_scope),
             IREE_HSA_FENCE_SCOPE_SYSTEM));
   }
+  if (profile_events.event_count != 0 ||
+      profile_queue_device_events.event_count != 0) {
+    iree_hal_amdgpu_host_queue_publish_profile_host_writes(queue);
+  }
   iree_hal_amdgpu_host_queue_publish_submission_kernargs(queue, &submission);
   if (queue_device_event) {
     iree_hal_amdgpu_host_queue_commit_queue_device_start_packet(

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_pending_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_pending_test.cc
@@ -140,8 +140,9 @@ static iree_status_t CreateHostVisibleTransferBuffer(
     iree_hal_allocator_t* allocator, iree_device_size_t buffer_size,
     iree_hal_buffer_t** out_buffer) {
   iree_hal_buffer_params_t params = {0};
-  params.type =
-      IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
+  params.type = IREE_HAL_MEMORY_TYPE_OPTIMAL |
+                IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING;
   return iree_hal_allocator_allocate_buffer(allocator, params, buffer_size,
                                             out_buffer);

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_profile.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_profile.h
@@ -63,7 +63,8 @@ void iree_hal_amdgpu_host_queue_set_profile_flags(
     iree_hal_amdgpu_host_queue_t* queue,
     iree_hal_amdgpu_host_queue_profile_flags_t flags);
 
-// Initializes one reserved device-timestamped queue operation event.
+// Initializes one reserved device-timestamped queue operation event. Callers
+// must publish host writes before committing packets that reference the record.
 iree_hal_amdgpu_profile_queue_device_event_t*
 iree_hal_amdgpu_host_queue_initialize_profile_queue_device_event(
     iree_hal_amdgpu_host_queue_t* queue,

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_profile_events.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_profile_events.c
@@ -8,7 +8,9 @@
 
 #include <string.h>
 
+#include "iree/hal/drivers/amdgpu/device/blit.h"
 #include "iree/hal/drivers/amdgpu/host_queue_profile.h"
+#include "iree/hal/drivers/amdgpu/host_queue_submission.h"
 #include "iree/hal/drivers/amdgpu/profile_counters.h"
 #include "iree/hal/drivers/amdgpu/profile_traces.h"
 
@@ -34,93 +36,133 @@ static_assert(
 #define IREE_HAL_AMDGPU_HOST_QUEUE_PROFILE_QUEUE_DEVICE_EVENT_CAPACITY \
   (64 * 1024)
 
-static void iree_hal_amdgpu_host_queue_initialize_profiling_signal(
-    iree_amd_signal_t* signal) {
-  memset(signal, 0, sizeof(*signal));
-  signal->kind = IREE_AMD_SIGNAL_KIND_USER;
-  // Profiling completion signals are never waited on. Keep the value at
-  // all-bits-set so packet completion decrements never require host/device
-  // reset traffic; consumers read start_ts/end_ts after queue ordering proves
-  // the profiled packet completed.
-  signal->value = (iree_hsa_signal_value_t)-1;
+static iree_status_t
+iree_hal_amdgpu_host_queue_require_profiling_signal_memory_pool(
+    iree_hal_amdgpu_host_queue_t* queue) {
+  if (queue->profiling.memory.signal_memory_pool.handle) {
+    return iree_ok_status();
+  }
+  return iree_make_status(
+      IREE_STATUS_UNAVAILABLE,
+      "AMDGPU HSA timestamp profiling requires device-local signal memory");
+}
+
+static iree_status_t
+iree_hal_amdgpu_host_queue_require_profiling_event_memory_pool(
+    iree_hal_amdgpu_host_queue_t* queue) {
+  if (queue->profiling.memory.event_memory_pool.handle) return iree_ok_status();
+  return iree_make_status(
+      IREE_STATUS_UNAVAILABLE,
+      "AMDGPU profiling requires host-readable device-visible event memory");
+}
+
+void iree_hal_amdgpu_host_queue_publish_profile_host_writes(
+    const iree_hal_amdgpu_host_queue_t* queue) {
+  // CPU-visible device-coarse memory is not coherent until host writes are
+  // pushed through HDP. This only publishes CPU-authored event metadata; GPU
+  // timestamp writes become CPU-visible through the packet release scopes.
+  const iree_hal_amdgpu_kernarg_ring_publication_t publication =
+      queue->profiling.memory.event_host_write_publication;
+  if (publication.mode == IREE_HAL_AMDGPU_KERNARG_RING_PUBLICATION_MODE_NONE) {
+    return;
+  }
+  IREE_ASSERT(publication.mode ==
+              IREE_HAL_AMDGPU_KERNARG_RING_PUBLICATION_MODE_HDP_FLUSH);
+  IREE_ASSERT(publication.hdp_mem_flush_control);
+  iree_hal_amdgpu_kernarg_ring_host_write_fence();
+  *publication.hdp_mem_flush_control = 1u;
+  (void)*publication.hdp_mem_flush_control;
+}
+
+static iree_status_t
+iree_hal_amdgpu_host_queue_zero_profiling_completion_signals(
+    iree_hal_amdgpu_host_queue_t* queue, iree_amd_signal_t* signals,
+    iree_host_size_t signal_storage_size) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, signal_storage_size);
+
+  // Raw profiling signals are command-processor timestamp scratch records, not
+  // ROCR-created HSA synchronization objects. The command processor only needs
+  // the record address for timestamp writes/completion decrement and the device
+  // harvest kernel only reads the timestamp fields, so device-side zero-fill is
+  // sufficient initialization and keeps the storage device-local.
+  iree_hsa_kernel_dispatch_packet_t dispatch_packet;
+  memset(&dispatch_packet, 0, sizeof(dispatch_packet));
+  iree_hal_amdgpu_device_buffer_fill_kernargs_t kernargs;
+  memset(&kernargs, 0, sizeof(kernargs));
+  if (IREE_UNLIKELY(!iree_hal_amdgpu_device_buffer_fill_emplace(
+          queue->transfer_context, &dispatch_packet, signals,
+          signal_storage_size, /*pattern=*/0, /*pattern_length=*/1,
+          &kernargs))) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                             "unable to prepare profiling signal zero-fill "
+                             "dispatch for %" PRIhsz " bytes",
+                             signal_storage_size));
+  }
+
+  iree_hal_amdgpu_wait_resolution_t resolution;
+  bool ready = false;
+  uint64_t submission_epoch = 0;
+  iree_slim_mutex_lock(&queue->locks.submission_mutex);
+  iree_hal_amdgpu_host_queue_resolve_waits(
+      queue, iree_hal_semaphore_list_empty(), &resolution);
+  iree_status_t status = iree_hal_amdgpu_host_queue_submit_dispatch_packet(
+      queue, &resolution, iree_hal_semaphore_list_empty(), &dispatch_packet,
+      &kernargs, sizeof(kernargs), /*operation_resources=*/NULL,
+      /*operation_resource_count=*/0, /*profile_queue_event_info=*/NULL,
+      IREE_HAL_AMDGPU_HOST_QUEUE_SUBMISSION_FLAG_NONE, &ready,
+      &submission_epoch);
+  iree_slim_mutex_unlock(&queue->locks.submission_mutex);
+  if (iree_status_is_ok(status) && IREE_UNLIKELY(!ready)) {
+    status = iree_make_status(
+        IREE_STATUS_RESOURCE_EXHAUSTED,
+        "unable to reserve AQL/kernarg capacity for profiling signal "
+        "initialization; profiling must begin while the device is idle");
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_amdgpu_host_queue_wait_for_setup_epoch(queue,
+                                                             submission_epoch);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
 }
 
 static iree_status_t
 iree_hal_amdgpu_host_queue_allocate_profiling_completion_signals(
-    iree_hal_amdgpu_block_pool_t* signal_block_pool, uint32_t signal_count,
-    iree_allocator_t host_allocator, iree_hal_amdgpu_host_queue_t* out_queue) {
+    uint32_t signal_count, iree_hal_amdgpu_host_queue_t* queue) {
   IREE_TRACE_ZONE_BEGIN(z0);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, signal_count);
 
-  if (IREE_UNLIKELY(signal_block_pool->block_size < sizeof(iree_amd_signal_t) ||
-                    signal_block_pool->block_size % sizeof(iree_amd_signal_t) !=
-                        0)) {
-    IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                             "profiling signal block size %" PRIdsz
-                             " must hold whole iree_amd_signal_t records",
-                             signal_block_pool->block_size));
-  }
-  const iree_host_size_t signals_per_block =
-      signal_block_pool->block_size / sizeof(iree_amd_signal_t);
-  if (IREE_UNLIKELY(signals_per_block == 0 || signals_per_block > UINT32_MAX)) {
-    IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                             "profiling signal block size %" PRIu64
-                             " cannot hold a valid signal count",
-                             (uint64_t)signal_block_pool->block_size));
-  }
-  const iree_host_size_t signal_block_count =
-      iree_host_size_ceil_div(signal_count, signals_per_block);
-  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, signal_block_count);
-
-  iree_host_size_t signal_block_table_size = 0;
+  iree_host_size_t signal_storage_size = 0;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0,
-      IREE_STRUCT_LAYOUT(0, &signal_block_table_size,
-                         IREE_STRUCT_FIELD(signal_block_count,
-                                           iree_hal_amdgpu_block_t*, NULL)));
-  iree_hal_amdgpu_block_t** signal_blocks = NULL;
-  iree_status_t status = iree_allocator_malloc(
-      host_allocator, signal_block_table_size, (void**)&signal_blocks);
-  iree_host_size_t acquired_block_count = 0;
-  for (iree_host_size_t block_index = 0;
-       block_index < signal_block_count && iree_status_is_ok(status);
-       ++block_index) {
-    iree_hal_amdgpu_block_t* block = NULL;
-    status = iree_hal_amdgpu_block_pool_acquire(signal_block_pool, &block);
-    if (iree_status_is_ok(status)) {
-      signal_blocks[block_index] = block;
-      ++acquired_block_count;
-      if (IREE_UNLIKELY(
-              (uintptr_t)block->ptr % iree_alignof(iree_amd_signal_t) != 0)) {
-        status = iree_make_status(
-            IREE_STATUS_FAILED_PRECONDITION,
-            "profiling signal block is not aligned to %" PRIhsz " bytes",
-            (iree_host_size_t)iree_alignof(iree_amd_signal_t));
-      } else {
-        for (iree_host_size_t signal_index = 0;
-             signal_index < signals_per_block; ++signal_index) {
-          uint8_t* signal_ptr =
-              (uint8_t*)block->ptr + signal_index * sizeof(iree_amd_signal_t);
-          iree_hal_amdgpu_host_queue_initialize_profiling_signal(
-              (iree_amd_signal_t*)signal_ptr);
-        }
-      }
-    }
-  }
+      z0, IREE_STRUCT_LAYOUT(
+              0, &signal_storage_size,
+              IREE_STRUCT_FIELD(signal_count, iree_amd_signal_t, NULL)));
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, signal_storage_size);
 
+  iree_amd_signal_t* signals = NULL;
+  iree_status_t status = iree_hsa_amd_memory_pool_allocate(
+      IREE_LIBHSA(queue->libhsa), queue->profiling.memory.signal_memory_pool,
+      signal_storage_size, HSA_AMD_MEMORY_POOL_STANDARD_FLAG, (void**)&signals);
+  if (iree_status_is_ok(status) &&
+      IREE_UNLIKELY((uintptr_t)signals % iree_alignof(iree_amd_signal_t) !=
+                    0)) {
+    status = iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "profiling signal storage is not aligned to %" PRIhsz " bytes",
+        (iree_host_size_t)iree_alignof(iree_amd_signal_t));
+  }
   if (iree_status_is_ok(status)) {
-    out_queue->profiling.signals.block_pool = signal_block_pool;
-    out_queue->profiling.signals.blocks = signal_blocks;
-    out_queue->profiling.signals.block_count = (uint32_t)signal_block_count;
-    out_queue->profiling.signals.signals_per_block =
-        (uint32_t)signals_per_block;
-  } else {
-    for (iree_host_size_t i = 0; i < acquired_block_count; ++i) {
-      iree_hal_amdgpu_block_pool_release(signal_block_pool, signal_blocks[i]);
-    }
-    iree_allocator_free(host_allocator, signal_blocks);
+    status = iree_hal_amdgpu_host_queue_zero_profiling_completion_signals(
+        queue, signals, signal_storage_size);
+  }
+  if (iree_status_is_ok(status)) {
+    queue->profiling.completion_signals = signals;
+  } else if (signals) {
+    status = iree_status_join(status, iree_hsa_amd_memory_pool_free(
+                                          IREE_LIBHSA(queue->libhsa), signals));
   }
 
   IREE_TRACE_ZONE_END(z0);
@@ -129,35 +171,30 @@ iree_hal_amdgpu_host_queue_allocate_profiling_completion_signals(
 
 iree_status_t iree_hal_amdgpu_host_queue_ensure_profiling_completion_signals(
     iree_hal_amdgpu_host_queue_t* queue) {
-  if (queue->profiling.signals.blocks) return iree_ok_status();
+  if (queue->profiling.completion_signals) return iree_ok_status();
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_host_queue_require_profiling_signal_memory_pool(queue));
   return iree_hal_amdgpu_host_queue_allocate_profiling_completion_signals(
-      queue->profiling.signals.block_pool,
-      queue->profiling.dispatch_events.capacity, queue->host_allocator, queue);
+      queue->profiling.dispatch_events.capacity, queue);
 }
 
 void iree_hal_amdgpu_host_queue_deallocate_profiling_completion_signals(
     iree_hal_amdgpu_host_queue_t* queue) {
-  if (!queue->profiling.signals.blocks) {
-    return;
-  }
+  if (!queue->profiling.completion_signals) return;
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  for (uint32_t i = 0; i < queue->profiling.signals.block_count; ++i) {
-    iree_hal_amdgpu_block_pool_release(queue->profiling.signals.block_pool,
-                                       queue->profiling.signals.blocks[i]);
-  }
-  iree_allocator_free(queue->host_allocator, queue->profiling.signals.blocks);
-  queue->profiling.signals.block_pool = NULL;
-  queue->profiling.signals.blocks = NULL;
-  queue->profiling.signals.block_count = 0;
-  queue->profiling.signals.signals_per_block = 0;
+  iree_hal_amdgpu_hsa_cleanup_assert_success(iree_hsa_amd_memory_pool_free_raw(
+      queue->libhsa, queue->profiling.completion_signals));
+  queue->profiling.completion_signals = NULL;
 
   IREE_TRACE_ZONE_END(z0);
 }
 
 iree_status_t iree_hal_amdgpu_host_queue_ensure_profile_event_storage(
     iree_hal_amdgpu_host_queue_t* queue) {
-  if (queue->profiling.event_allocation.base) return iree_ok_status();
+  if (queue->profiling.event_storage) return iree_ok_status();
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_host_queue_require_profiling_event_memory_pool(queue));
 
   IREE_TRACE_ZONE_BEGIN(z0);
   const uint32_t dispatch_event_capacity =
@@ -167,6 +204,9 @@ iree_status_t iree_hal_amdgpu_host_queue_ensure_profile_event_storage(
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, dispatch_event_capacity);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, queue_device_event_capacity);
 
+  // Slots are initialized on reservation before any packet references their
+  // timestamp fields. The allocation itself intentionally starts with undefined
+  // contents so begin/clear do not perform bulk CPU writes to device memory.
   iree_host_size_t dispatch_events_offset = 0;
   iree_host_size_t queue_device_events_offset = 0;
   iree_host_size_t total_size = 0;
@@ -180,18 +220,30 @@ iree_status_t iree_hal_amdgpu_host_queue_ensure_profile_event_storage(
                                 iree_hal_amdgpu_profile_queue_device_event_t,
                                 &queue_device_events_offset)));
   void* event_storage = NULL;
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0,
-      iree_hsa_amd_memory_pool_allocate(
-          IREE_LIBHSA(queue->libhsa),
-          queue->profiling.signals.block_pool->memory_pool, total_size,
-          HSA_AMD_MEMORY_POOL_STANDARD_FLAG, &event_storage),
-      "allocating profile event rings of %" PRIhsz " bytes", total_size);
-  memset(event_storage, 0, total_size);
+  iree_status_t status = iree_hsa_amd_memory_pool_allocate(
+      IREE_LIBHSA(queue->libhsa), queue->profiling.memory.event_memory_pool,
+      total_size, HSA_AMD_MEMORY_POOL_STANDARD_FLAG, &event_storage);
+  if (iree_status_is_ok(status) &&
+      queue->profiling.memory.event_access_agent_count != 0) {
+    status = iree_hsa_amd_agents_allow_access(
+        IREE_LIBHSA(queue->libhsa),
+        (uint32_t)queue->profiling.memory.event_access_agent_count,
+        queue->profiling.memory.event_access_agents, /*flags=*/NULL,
+        event_storage);
+  }
+  if (!iree_status_is_ok(status)) {
+    if (event_storage) {
+      status = iree_status_join(
+          status, iree_hsa_amd_memory_pool_free(IREE_LIBHSA(queue->libhsa),
+                                                event_storage));
+    }
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, status, "allocating profile event rings of %" PRIhsz " bytes",
+        total_size);
+  }
 
   iree_slim_mutex_lock(&queue->profiling.event_mutex);
-  queue->profiling.event_allocation.base = event_storage;
-  queue->profiling.event_allocation.size = total_size;
+  queue->profiling.event_storage = event_storage;
   queue->profiling.dispatch_events.values =
       (iree_hal_amdgpu_profile_dispatch_event_t*)((uint8_t*)event_storage +
                                                   dispatch_events_offset);
@@ -227,21 +279,16 @@ void iree_hal_amdgpu_host_queue_clear_profile_events(
   queue->profiling.queue_device_events.ready_position = 0;
   queue->profiling.queue_device_events.write_position = 0;
   queue->profiling.queue_device_events.next_event_id = 1;
-  if (queue->profiling.event_allocation.base) {
-    memset(queue->profiling.event_allocation.base, 0,
-           queue->profiling.event_allocation.size);
-  }
   iree_slim_mutex_unlock(&queue->profiling.event_mutex);
 }
 
 void iree_hal_amdgpu_host_queue_deallocate_profile_events(
     iree_hal_amdgpu_host_queue_t* queue) {
-  if (!queue->profiling.event_allocation.base) return;
+  if (!queue->profiling.event_storage) return;
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_hal_amdgpu_hsa_cleanup_assert_success(iree_hsa_amd_memory_pool_free_raw(
-      queue->libhsa, queue->profiling.event_allocation.base));
-  queue->profiling.event_allocation.base = NULL;
-  queue->profiling.event_allocation.size = 0;
+      queue->libhsa, queue->profiling.event_storage));
+  queue->profiling.event_storage = NULL;
   queue->profiling.dispatch_events.values = NULL;
   queue->profiling.dispatch_events.capacity = 0;
   queue->profiling.dispatch_events.mask = 0;

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_profile_events.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_profile_events.h
@@ -13,12 +13,13 @@
 extern "C" {
 #endif  // __cplusplus
 
-// Allocates queue-local device-visible event rings used by dispatch and
-// queue-device timestamp profiling.
+// Allocates queue-local event rings. The CPU writes event metadata and the GPU
+// writes timestamp fields into each reserved record.
 iree_status_t iree_hal_amdgpu_host_queue_ensure_profile_event_storage(
     iree_hal_amdgpu_host_queue_t* queue);
 
-// Clears all event-ring cursors and records while preserving allocated storage.
+// Resets event-ring cursors while preserving allocated storage. Record contents
+// are initialized again when a slot is reserved.
 void iree_hal_amdgpu_host_queue_clear_profile_events(
     iree_hal_amdgpu_host_queue_t* queue);
 
@@ -26,13 +27,19 @@ void iree_hal_amdgpu_host_queue_clear_profile_events(
 void iree_hal_amdgpu_host_queue_deallocate_profile_events(
     iree_hal_amdgpu_host_queue_t* queue);
 
-// Allocates queue-local completion signals paired with dispatch event slots.
+// Allocates queue-local raw completion-signal scratch paired with dispatch
+// event slots and initializes it from the device.
 iree_status_t iree_hal_amdgpu_host_queue_ensure_profiling_completion_signals(
     iree_hal_amdgpu_host_queue_t* queue);
 
 // Releases queue-local profiling completion signals.
 void iree_hal_amdgpu_host_queue_deallocate_profiling_completion_signals(
     iree_hal_amdgpu_host_queue_t* queue);
+
+// Publishes host writes to queue-local event memory before packet headers that
+// reference the written records become visible to the command processor.
+void iree_hal_amdgpu_host_queue_publish_profile_host_writes(
+    const iree_hal_amdgpu_host_queue_t* queue);
 
 // Returns the configured dispatch event ring capacity.
 static inline uint32_t
@@ -51,23 +58,16 @@ static inline uint32_t iree_hal_amdgpu_host_queue_profile_dispatch_event_index(
 // dispatch event ring slot. The returned pointer references queue-owned
 // iree_amd_signal_t storage, not a ROCR-created HSA signal, and must never be
 // passed to host signal APIs except as an AQL packet completion_signal handle.
-// Valid only while HSA queue timestamp profiling is enabled.
+// The signal record is initialized as command-processor scratch; HSA signal
+// kind/value fields are not part of the profiling contract. Valid only while
+// HSA queue timestamp profiling is enabled.
 static inline iree_amd_signal_t*
 iree_hal_amdgpu_host_queue_profiling_completion_signal_ptr(
     const iree_hal_amdgpu_host_queue_t* queue, uint64_t event_position) {
   const uint32_t signal_index =
       iree_hal_amdgpu_host_queue_profile_dispatch_event_index(queue,
                                                               event_position);
-  const uint32_t block_index =
-      signal_index / queue->profiling.signals.signals_per_block;
-  const uint32_t block_signal_index =
-      signal_index - block_index * queue->profiling.signals.signals_per_block;
-  uint8_t* block_ptr =
-      (uint8_t*)queue->profiling.signals.blocks[block_index]->ptr;
-  iree_amd_signal_t* signal =
-      (iree_amd_signal_t*)(block_ptr +
-                           block_signal_index * sizeof(iree_amd_signal_t));
-  return signal;
+  return &queue->profiling.completion_signals[signal_index];
 }
 
 // Returns the raw profiling completion signal handle paired with

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_submission.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_submission.c
@@ -252,6 +252,35 @@ iree_hal_amdgpu_host_queue_final_pm4_ib_packet_control(
           queue, signal_semaphore_list));
 }
 
+// Returns the packet control for the final queue-device profiling packet. The
+// timestamp packet writes timestamp fields in host-read profile records, so the
+// queue epoch signal must publish those device writes at system scope.
+static iree_hal_amdgpu_aql_packet_control_t
+iree_hal_amdgpu_host_queue_final_profile_pm4_ib_packet_control(
+    iree_hal_amdgpu_host_queue_t* queue,
+    const iree_hal_amdgpu_wait_resolution_t* resolution,
+    const iree_hal_semaphore_list_t signal_semaphore_list) {
+  return iree_hal_amdgpu_aql_packet_control_barrier(
+      iree_hal_amdgpu_host_queue_max_fence_scope(
+          IREE_HSA_FENCE_SCOPE_AGENT, resolution->inline_acquire_scope),
+      iree_hal_amdgpu_host_queue_max_fence_scope(
+          IREE_HSA_FENCE_SCOPE_SYSTEM,
+          iree_hal_amdgpu_host_queue_signal_list_release_scope(
+              queue, signal_semaphore_list)));
+}
+
+static void iree_hal_amdgpu_host_queue_publish_submission_profile_host_writes(
+    const iree_hal_amdgpu_host_queue_t* queue,
+    iree_hal_amdgpu_profile_dispatch_event_reservation_t dispatch_events,
+    iree_hal_amdgpu_profile_queue_device_event_reservation_t
+        queue_device_events) {
+  if (dispatch_events.event_count == 0 &&
+      queue_device_events.event_count == 0) {
+    return;
+  }
+  iree_hal_amdgpu_host_queue_publish_profile_host_writes(queue);
+}
+
 // Returns the packet control for a non-final PM4-IB packet in a larger
 // submission. The final packet owns user-visible release and queue completion.
 static iree_hal_amdgpu_aql_packet_control_t
@@ -309,7 +338,7 @@ void iree_hal_amdgpu_host_queue_commit_queue_device_end_packet(
   const uint16_t header = iree_hal_amdgpu_aql_emit_pm4_ib(
       &packet->pm4_ib, pm4_ib_slot,
       iree_hal_amdgpu_pm4_ib_builder_dword_count(&builder),
-      iree_hal_amdgpu_host_queue_final_pm4_ib_packet_control(
+      iree_hal_amdgpu_host_queue_final_profile_pm4_ib_packet_control(
           queue, resolution, signal_semaphore_list),
       iree_hal_amdgpu_notification_ring_epoch_signal(&queue->notification_ring),
       &setup);
@@ -996,6 +1025,9 @@ uint64_t iree_hal_amdgpu_host_queue_finish_dispatch_submission(
       IREE_HSA_PACKET_TYPE_KERNEL_DISPATCH, dispatch_packet_control);
   const uint32_t profile_queue_device_prefix_packet_count =
       queue_device_event ? 1u : 0u;
+  iree_hal_amdgpu_host_queue_publish_submission_profile_host_writes(
+      queue, submission->profile_events,
+      submission->profile_queue_device_events);
   iree_hal_amdgpu_host_queue_publish_submission_kernargs(queue,
                                                          &submission->kernel);
   if (queue_device_event) {
@@ -1104,6 +1136,9 @@ iree_status_t iree_hal_amdgpu_host_queue_finish_pm4_ib_submission(
     submission->kernel.reclaim_entry->queue_device_event_count =
         submission->profile_queue_device_events.event_count;
     queue_device_event->submission_id = submission_epoch;
+    iree_hal_amdgpu_host_queue_publish_submission_profile_host_writes(
+        queue, (iree_hal_amdgpu_profile_dispatch_event_reservation_t){0},
+        submission->profile_queue_device_events);
     iree_hal_amdgpu_host_queue_commit_queue_device_start_packet(
         queue, resolution,
         submission->kernel.first_packet_id + resolution->barrier_count,
@@ -1450,6 +1485,8 @@ iree_status_t iree_hal_amdgpu_host_queue_submit_pm4_ib_with_binding_table_fixup(
         event->submission_id = submission_epoch;
       }
     }
+    iree_hal_amdgpu_host_queue_publish_submission_profile_host_writes(
+        queue, profile_events, profile_queue_device_events);
     iree_hal_amdgpu_host_queue_publish_submission_kernargs(queue, &submission);
     iree_hal_amdgpu_queue_upload_ring_publish_host_writes(
         &queue->queue_upload_ring);
@@ -1569,6 +1606,9 @@ uint64_t iree_hal_amdgpu_host_queue_finish_barrier_submission(
         submission->profile_queue_device_events.event_count;
     queue_device_event->submission_id = submission_epoch;
   }
+  iree_hal_amdgpu_host_queue_publish_submission_profile_host_writes(
+      queue, (iree_hal_amdgpu_profile_dispatch_event_reservation_t){0},
+      submission->profile_queue_device_events);
   if (post_commit_callback.fn) {
     post_commit_callback.fn(post_commit_callback.user_data,
                             iree_hal_amdgpu_host_queue_const_frontier(queue),
@@ -1589,7 +1629,7 @@ uint64_t iree_hal_amdgpu_host_queue_finish_barrier_submission(
     completion_header = iree_hal_amdgpu_aql_emit_pm4_ib(
         &completion_slot->pm4_ib, pm4_ib_slot,
         iree_hal_amdgpu_pm4_ib_builder_dword_count(&builder),
-        iree_hal_amdgpu_host_queue_final_pm4_ib_packet_control(
+        iree_hal_amdgpu_host_queue_final_profile_pm4_ib_packet_control(
             queue, resolution, signal_semaphore_list),
         iree_hal_amdgpu_notification_ring_epoch_signal(
             &queue->notification_ring),

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -1344,6 +1344,8 @@ static void iree_hal_amdgpu_logical_device_translate_physical_options(
   out_options->force_wait_barrier_defer = options->force_wait_barrier_defer;
   out_options->enable_experimental_pm4_command_buffers =
       options->enable_experimental_pm4_command_buffers;
+  out_options->suppress_device_fine_memory =
+      options->suppress_device_fine_memory;
 }
 
 static iree_status_t iree_hal_amdgpu_logical_device_verify_physical_options(
@@ -1549,6 +1551,8 @@ iree_status_t iree_hal_amdgpu_logical_device_create(
   logical_device->command_buffer_mode = options->command_buffer_mode;
   logical_device->pm4_command_buffer_publication_mode =
       options->pm4_command_buffer_publication_mode;
+  logical_device->suppress_device_fine_memory =
+      options->suppress_device_fine_memory;
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_logical_device_initialize_system_and_allocator(
         logical_device, options, libhsa, topology, host_allocator);
@@ -2097,18 +2101,19 @@ static iree_status_t iree_hal_amdgpu_query_physical_topology_edge(
     const iree_hal_amdgpu_physical_device_t* destination_physical_device,
     iree_hal_amdgpu_physical_topology_edge_t* out_physical_edge) {
   hsa_agent_t source_agent = source_physical_device->device_agent;
-  hsa_agent_t destination_agent = destination_physical_device->device_agent;
 
-  // Find both memory pool types on the destination agent. Not all devices
-  // expose both pool types; missing pools are treated as NEVER_ALLOWED for that
-  // pool kind, but an agent with no global pool at all is not a usable topology
-  // node.
-  hsa_amd_memory_pool_t dst_coarse_pool = {0};
-  bool has_coarse_pool = iree_hal_amdgpu_try_find_coarse_global_memory_pool(
-      libhsa, destination_agent, &dst_coarse_pool);
-  hsa_amd_memory_pool_t dst_fine_pool = {0};
-  bool has_fine_pool = iree_hal_amdgpu_try_find_fine_global_memory_pool(
-      libhsa, destination_agent, &dst_fine_pool);
+  // Use the memory pools exposed by the destination logical device instead of
+  // rediscovering raw HSA pools. Logical-device options can suppress optional
+  // fine-grained GPU-local memory, and topology refinement must describe the
+  // memory surface the device actually exposes.
+  hsa_amd_memory_pool_t dst_coarse_pool =
+      destination_physical_device->coarse_block_pools.large.memory_pool;
+  bool has_coarse_pool =
+      destination_physical_device->coarse_block_pools.large.is_initialized;
+  hsa_amd_memory_pool_t dst_fine_pool =
+      destination_physical_device->fine_block_pools.large.memory_pool;
+  bool has_fine_pool =
+      destination_physical_device->fine_block_pools.large.is_initialized;
   if (!has_coarse_pool && !has_fine_pool) {
     return iree_make_status(
         IREE_STATUS_UNAVAILABLE,

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.h
@@ -133,6 +133,9 @@ typedef struct iree_hal_amdgpu_logical_device_t {
   iree_hal_amdgpu_pm4_command_buffer_publication_mode_t
       pm4_command_buffer_publication_mode;
 
+  // True when GPU-local fine memory pools are suppressed for this device.
+  uint32_t suppress_device_fine_memory : 1;
+
   // Logical allocator.
   iree_hal_allocator_t* device_allocator;
 

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
@@ -456,18 +456,21 @@ static iree_status_t iree_hal_amdgpu_physical_device_initialize_host_pools(
 
 static iree_status_t iree_hal_amdgpu_physical_device_query_global_memory_pools(
     iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t device_agent,
+    bool suppress_device_fine_memory,
     hsa_amd_memory_pool_t* out_coarse_block_memory_pool,
     hsa_amd_memory_pool_t* out_fine_block_memory_pool) {
   iree_status_t status = iree_hal_amdgpu_find_coarse_global_memory_pool(
       libhsa, device_agent, out_coarse_block_memory_pool);
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_amdgpu_find_fine_global_memory_pool(
-        libhsa, device_agent, out_fine_block_memory_pool);
+  if (iree_status_is_ok(status) && !suppress_device_fine_memory) {
+    bool fine_block_memory_pool_available = false;
+    status = iree_hal_amdgpu_query_fine_global_memory_pool(
+        libhsa, device_agent, &fine_block_memory_pool_available,
+        out_fine_block_memory_pool);
   }
   if (!iree_status_is_ok(status)) {
     status = iree_status_annotate(
-        status, IREE_SV("AMDGPU physical device requires coarse and fine "
-                        "device-local global memory pools"));
+        status, IREE_SV("AMDGPU physical device requires a coarse-grained "
+                        "device-local global memory pool"));
   }
   return status;
 }
@@ -675,14 +678,6 @@ iree_hal_amdgpu_physical_device_initialize_device_block_pools_and_allocators(
       libhsa, options->device_block_pools.large, device_agent,
       coarse_block_memory_pool, "coarse-large-block", device_ordinal,
       host_allocator, &out_physical_device->coarse_block_pools.large));
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_physical_device_initialize_block_pool(
-      libhsa, options->device_block_pools.small, device_agent,
-      fine_block_memory_pool, "fine-small-block", device_ordinal,
-      host_allocator, &out_physical_device->fine_block_pools.small));
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_physical_device_initialize_block_pool(
-      libhsa, options->device_block_pools.large, device_agent,
-      fine_block_memory_pool, "fine-large-block", device_ordinal,
-      host_allocator, &out_physical_device->fine_block_pools.large));
 
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_block_allocator_initialize(
       &out_physical_device->coarse_block_pools.small,
@@ -692,6 +687,16 @@ iree_hal_amdgpu_physical_device_initialize_device_block_pools_and_allocators(
       &out_physical_device->coarse_block_pools.large,
       IREE_HAL_AMDGPU_PHYSICAL_DEVICE_COARSE_BLOCK_POOL_LARGE_PAGE_SIZE,
       &out_physical_device->coarse_block_allocators.large));
+  if (!fine_block_memory_pool.handle) return iree_ok_status();
+
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_physical_device_initialize_block_pool(
+      libhsa, options->device_block_pools.small, device_agent,
+      fine_block_memory_pool, "fine-small-block", device_ordinal,
+      host_allocator, &out_physical_device->fine_block_pools.small));
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_physical_device_initialize_block_pool(
+      libhsa, options->device_block_pools.large, device_agent,
+      fine_block_memory_pool, "fine-large-block", device_ordinal,
+      host_allocator, &out_physical_device->fine_block_pools.large));
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_block_allocator_initialize(
       &out_physical_device->fine_block_pools.small,
       IREE_HAL_AMDGPU_PHYSICAL_DEVICE_FINE_BLOCK_POOL_SMALL_PAGE_SIZE,
@@ -943,8 +948,8 @@ iree_status_t iree_hal_amdgpu_physical_device_initialize(
   hsa_amd_memory_pool_t fine_block_memory_pool = {0};
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_physical_device_query_global_memory_pools(
-        libhsa, device_agent, &coarse_block_memory_pool,
-        &fine_block_memory_pool);
+        libhsa, device_agent, options->suppress_device_fine_memory,
+        &coarse_block_memory_pool, &fine_block_memory_pool);
   }
   if (iree_status_is_ok(status)) {
     out_physical_device->prepublished_kernarg_storage =
@@ -1143,6 +1148,31 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
   iree_hal_amdgpu_physical_device_kernarg_ring_memory_t kernarg_ring_memory;
   iree_hal_amdgpu_physical_device_select_kernarg_ring_memory(
       physical_device, host_memory_pools, &kernarg_ring_memory);
+  iree_hal_amdgpu_host_queue_profiling_memory_t profiling_memory = {0};
+  // Raw profiling completion signals are command-processor scratch records
+  // initialized by a device fill, so they can live in coarse device memory.
+  if (physical_device->coarse_block_pools.small.is_initialized) {
+    profiling_memory.signal_memory_pool =
+        physical_device->coarse_block_pools.small.memory_pool;
+  }
+  // Event records are serialized by the CPU after the GPU writes timestamp
+  // fields. Prefer CPU-visible device-coarse memory when available so devices
+  // without fine-grained memory can still profile.
+  if (iree_hal_amdgpu_cpu_visible_device_coarse_memory_is_available(
+          &physical_device->cpu_visible_device_coarse_memory)) {
+    profiling_memory.event_memory_pool =
+        physical_device->cpu_visible_device_coarse_memory.memory_pool;
+    profiling_memory.event_access_agents =
+        physical_device->cpu_visible_device_coarse_memory.access_agents;
+    profiling_memory.event_access_agent_count =
+        physical_device->cpu_visible_device_coarse_memory.access_agent_count;
+    profiling_memory.event_host_write_publication =
+        physical_device->cpu_visible_device_coarse_memory
+            .host_write_publication;
+  } else if (physical_device->fine_block_pools.small.is_initialized) {
+    profiling_memory.event_memory_pool =
+        physical_device->fine_block_pools.small.memory_pool;
+  }
   for (iree_host_size_t queue_ordinal = 0;
        queue_ordinal < physical_device->host_queue_capacity &&
        iree_status_is_ok(status);
@@ -1167,8 +1197,7 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
         completion_thread_affinity, physical_device->wait_barrier_strategy,
         physical_device->vendor_packet_capabilities,
         physical_device->pm4_timestamp_strategy, epoch_signal_table,
-        &physical_device->fine_host_block_pool,
-        &physical_device->fine_block_pools.small,
+        &physical_device->fine_host_block_pool, profiling_memory,
         &physical_device->buffer_transfer_context,
         &physical_device->default_pool_set, physical_device->default_pool,
         &physical_device->transient_buffer_pool,

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device.h
@@ -159,6 +159,9 @@ typedef struct iree_hal_amdgpu_physical_device_options_t {
   // Enables PM4 dispatch command-buffer capabilities on unvalidated gfx9-gfx12
   // targets for hardware bring-up experiments.
   uint32_t enable_experimental_pm4_command_buffers : 1;
+
+  // Suppresses fine-grained GPU-local memory pools even if HSA reports them.
+  uint32_t suppress_device_fine_memory : 1;
 } iree_hal_amdgpu_physical_device_options_t;
 
 // Initializes |out_options| to its default values.
@@ -224,9 +227,9 @@ typedef struct iree_hal_amdgpu_physical_device_t {
   iree_hal_amdgpu_aql_prepublished_kernarg_storage_t
       prepublished_kernarg_storage;
 
-  // Fine-grained block pools for device memory blocks of various sizes.
+  // Optional fine-grained block pools for host-coherent device memory.
   iree_hal_amdgpu_block_pools_t fine_block_pools;
-  // Fine-grained block pool-based allocators for small transient allocations.
+  // Optional fine-grained block pool-based allocators for small transients.
   iree_hal_amdgpu_block_allocators_t fine_block_allocators;
   // Coarse-grained block pools for device memory blocks of various sizes.
   iree_hal_amdgpu_block_pools_t coarse_block_pools;

--- a/runtime/src/iree/hal/drivers/amdgpu/profile_counters.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/profile_counters.c
@@ -1123,6 +1123,14 @@ iree_status_t iree_hal_amdgpu_host_queue_enable_profile_counters(
         IREE_STATUS_FAILED_PRECONDITION,
         "AMDGPU counter range profiling requires PM4 timestamp range support");
   }
+  if (IREE_UNLIKELY(enable_queue_ranges &&
+                    !queue->profiling.memory.event_memory_pool.handle)) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(
+        IREE_STATUS_UNAVAILABLE,
+        "AMDGPU counter range profiling requires host-readable "
+        "device-visible timestamp memory");
+  }
   if (IREE_UNLIKELY(queue->profiling.counters.session)) {
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
@@ -1193,13 +1201,21 @@ iree_status_t iree_hal_amdgpu_host_queue_enable_profile_counters(
     }
     if (iree_status_is_ok(status)) {
       status = iree_hsa_amd_memory_pool_allocate(
-          IREE_LIBHSA(queue->libhsa),
-          queue->profiling.signals.block_pool->memory_pool,
+          IREE_LIBHSA(queue->libhsa), queue->profiling.memory.event_memory_pool,
           range_tick_storage_size, HSA_AMD_MEMORY_POOL_STANDARD_FLAG,
           (void**)&range_ticks);
     }
+    if (iree_status_is_ok(status) &&
+        queue->profiling.memory.event_access_agent_count != 0) {
+      status = iree_hsa_amd_agents_allow_access(
+          IREE_LIBHSA(queue->libhsa),
+          (uint32_t)queue->profiling.memory.event_access_agent_count,
+          queue->profiling.memory.event_access_agents, /*flags=*/NULL,
+          range_ticks);
+    }
     if (iree_status_is_ok(status)) {
-      memset(range_ticks, 0, range_tick_storage_size);
+      // Range ticks are pure device timestamp outputs. Start/flush packets
+      // overwrite both fields before the stopped bank is read by the CPU.
       for (iree_host_size_t i = 0;
            i < range_slot_count && iree_status_is_ok(status); ++i) {
         const uint32_t counter_set_ordinal =
@@ -1547,8 +1563,6 @@ static void iree_hal_amdgpu_host_queue_commit_profile_counter_range_start(
   }
   iree_hal_amdgpu_profile_counter_range_ticks_t* ticks =
       iree_hal_amdgpu_host_queue_profile_counter_range_ticks(queue, bank);
-  ticks->start_tick = 0;
-  ticks->end_tick = 0;
   iree_hal_amdgpu_host_queue_commit_timestamp_start(
       queue, first_packet_id + queue->profiling.counters.set_count,
       packet_control, &ticks->start_tick);

--- a/runtime/src/iree/hal/drivers/amdgpu/registration/driver_module.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/registration/driver_module.c
@@ -81,6 +81,11 @@ IREE_FLAG(bool, amdgpu_experimental_pm4_command_buffers, false,
           "targets. This is for hardware bring-up only; default automatic PM4 "
           "selection remains limited to validated GPU ISAs.");
 
+IREE_FLAG(bool, amdgpu_suppress_device_fine_memory, false,
+          "Suppresses fine-grained GPU-local memory pools even when reported "
+          "by HSA. This validates the coarse-grained device-local memory path "
+          "used on GPUs that do not expose host-coherent VRAM.");
+
 IREE_FLAG(int64_t, amdgpu_wait_active_for_ns, 0,
           "Reserved for future HSA active-wait tuning. Must be 0 today.");
 
@@ -261,6 +266,9 @@ static iree_status_t iree_hal_amdgpu_driver_factory_try_create(
 
   device_options->enable_experimental_pm4_command_buffers =
       FLAG_amdgpu_experimental_pm4_command_buffers;
+
+  device_options->suppress_device_fine_memory =
+      FLAG_amdgpu_suppress_device_fine_memory;
 
   if (FLAG_amdgpu_wait_active_for_ns < 0) {
     return iree_make_status(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/block_pool.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/block_pool.c
@@ -35,16 +35,6 @@ iree_status_t iree_hal_amdgpu_block_pool_initialize(
                              options.block_size));
   }
 
-  out_block_pool->libhsa = libhsa;
-  out_block_pool->host_allocator = host_allocator;
-  out_block_pool->agent = agent;
-  out_block_pool->memory_pool = memory_pool;
-  out_block_pool->block_size = options.block_size;
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_memory_trace_initialize_pool(
-              options.trace_name, IREE_HAL_AMDGPU_BLOCK_POOL_TRACE_ID,
-              host_allocator, &out_block_pool->trace));
-
   // Query the memory pool for its allocation granularity.
   // This is not the minimum allocation size
   // (HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_GRANULE) but the recommended size
@@ -60,6 +50,12 @@ iree_status_t iree_hal_amdgpu_block_pool_initialize(
       "querying HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE to "
       "determine blocks/allocation");
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, alloc_rec_granule);
+
+  out_block_pool->libhsa = libhsa;
+  out_block_pool->host_allocator = host_allocator;
+  out_block_pool->agent = agent;
+  out_block_pool->memory_pool = memory_pool;
+  out_block_pool->block_size = options.block_size;
 
   // If no min block count was provided we pick one as either the number that
   // will fit into the recommended allocation granule.
@@ -77,7 +73,12 @@ iree_status_t iree_hal_amdgpu_block_pool_initialize(
       (iree_host_size_t)(allocation_size / options.block_size);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, out_block_pool->blocks_per_allocation);
 
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hal_memory_trace_initialize_pool(
+              options.trace_name, IREE_HAL_AMDGPU_BLOCK_POOL_TRACE_ID,
+              host_allocator, &out_block_pool->trace));
   iree_slim_mutex_initialize(&out_block_pool->mutex);
+  out_block_pool->is_initialized = true;
   iree_slim_mutex_lock(&out_block_pool->mutex);
 
   // Preallocate as many allocations as required to hold the requested initial
@@ -101,7 +102,7 @@ iree_status_t iree_hal_amdgpu_block_pool_initialize(
 
 void iree_hal_amdgpu_block_pool_deinitialize(
     iree_hal_amdgpu_block_pool_t* block_pool) {
-  IREE_ASSERT_ARGUMENT(block_pool);
+  if (!block_pool || !block_pool->is_initialized) return;
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // Should have freed everything so we can just trim the pool to drop all
@@ -112,6 +113,7 @@ void iree_hal_amdgpu_block_pool_deinitialize(
 
   iree_slim_mutex_deinitialize(&block_pool->mutex);
   iree_hal_memory_trace_deinitialize(&block_pool->trace);
+  memset(block_pool, 0, sizeof(*block_pool));
 
   IREE_TRACE_ZONE_END(z0);
 }
@@ -173,6 +175,7 @@ static iree_status_t iree_hal_amdgpu_block_pool_grow(
 }
 
 void iree_hal_amdgpu_block_pool_trim(iree_hal_amdgpu_block_pool_t* block_pool) {
+  if (!block_pool || !block_pool->is_initialized) return;
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // NOTE: we could steal the whole list and free it outside of the lock but we
@@ -243,6 +246,7 @@ iree_status_t iree_hal_amdgpu_block_pool_acquire(
     iree_hal_amdgpu_block_t** out_block) {
   IREE_ASSERT_ARGUMENT(block_pool);
   IREE_ASSERT_ARGUMENT(out_block);
+  IREE_ASSERT(block_pool->is_initialized);
   IREE_TRACE_ZONE_BEGIN(z0);
   *out_block = NULL;
 
@@ -276,6 +280,7 @@ void iree_hal_amdgpu_block_pool_release(
     iree_hal_amdgpu_block_pool_t* block_pool, iree_hal_amdgpu_block_t* block) {
   IREE_ASSERT_ARGUMENT(block_pool);
   if (!block) return;
+  IREE_ASSERT(block_pool->is_initialized);
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_slim_mutex_lock(&block_pool->mutex);
@@ -295,6 +300,7 @@ void iree_hal_amdgpu_block_pool_release_list(
     iree_hal_amdgpu_block_t* block_head) {
   IREE_ASSERT_ARGUMENT(block_pool);
   if (!block_head) return;
+  IREE_ASSERT(block_pool->is_initialized);
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_slim_mutex_lock(&block_pool->mutex);
@@ -460,7 +466,7 @@ iree_status_t iree_hal_amdgpu_block_allocator_initialize(
 
 void iree_hal_amdgpu_block_allocator_deinitialize(
     iree_hal_amdgpu_block_allocator_t* allocator) {
-  if (!allocator) return;
+  if (!allocator || !allocator->block_pool) return;
 
   IREE_ASSERT_EQ(allocator->block_head, NULL);
   IREE_ASSERT_EQ(allocator->block_tail, NULL);

--- a/runtime/src/iree/hal/drivers/amdgpu/util/block_pool.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/block_pool.h
@@ -123,6 +123,8 @@ typedef struct iree_hal_amdgpu_block_pool_t {
   hsa_amd_memory_pool_t memory_pool;
   // Stable named-memory stream for HSA backing allocations in this pool.
   iree_hal_memory_trace_t trace;
+  // True after the pool trace and mutex fields are initialized.
+  uint32_t is_initialized : 1;
   // Size in bytes of a block on device.
   iree_device_size_t block_size;
   // Number of blocks in a single device allocation.

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem.c
@@ -52,13 +52,15 @@ static hsa_status_t iree_hal_amdgpu_find_global_memory_pool_iterator(
   return HSA_STATUS_SUCCESS;
 }
 
-iree_status_t iree_hal_amdgpu_find_global_memory_pool(
+static iree_status_t iree_hal_amdgpu_query_global_memory_pool(
     const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
-    hsa_amd_memory_pool_global_flag_t match_flags,
+    hsa_amd_memory_pool_global_flag_t match_flags, bool* out_available,
     hsa_amd_memory_pool_t* out_pool) {
   IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_available);
   IREE_ASSERT_ARGUMENT(out_pool);
   IREE_TRACE_ZONE_BEGIN(z0);
+  *out_available = false;
   memset(out_pool, 0, sizeof(*out_pool));
 
   iree_hal_amdgpu_find_global_memory_pool_state_t find_state = {
@@ -70,14 +72,34 @@ iree_status_t iree_hal_amdgpu_find_global_memory_pool(
       z0, iree_hsa_amd_agent_iterate_memory_pools(
               IREE_LIBHSA(libhsa), agent,
               iree_hal_amdgpu_find_global_memory_pool_iterator, &find_state));
-  if (!find_state.best_pool.handle) {
+  if (find_state.best_pool.handle) {
+    *out_available = true;
+    *out_pool = find_state.best_pool;
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_find_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    hsa_amd_memory_pool_global_flag_t match_flags,
+    hsa_amd_memory_pool_t* out_pool) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_pool);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  bool available = false;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hal_amdgpu_query_global_memory_pool(libhsa, agent, match_flags,
+                                                   &available, out_pool));
+  if (!available) {
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0, iree_make_status(IREE_STATUS_NOT_FOUND,
                              "no memory pool matching the required flags %u",
                              match_flags));
   }
 
-  *out_pool = find_state.best_pool;
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }
@@ -97,6 +119,16 @@ iree_status_t iree_hal_amdgpu_find_fine_global_memory_pool(
       HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED |
           HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED,
       out_pool);
+}
+
+iree_status_t iree_hal_amdgpu_query_fine_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    bool* out_available, hsa_amd_memory_pool_t* out_pool) {
+  return iree_hal_amdgpu_query_global_memory_pool(
+      libhsa, agent,
+      HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED |
+          HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED,
+      out_available, out_pool);
 }
 
 bool iree_hal_amdgpu_try_find_coarse_global_memory_pool(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem.h
@@ -71,6 +71,13 @@ iree_status_t iree_hal_amdgpu_find_fine_global_memory_pool(
     const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
     hsa_amd_memory_pool_t* out_pool);
 
+// Queries whether a fine-grained memory pool is available on the |agent|.
+// Returns errors from HSA enumeration, but reports a missing pool through
+// |out_available| instead of returning NOT_FOUND.
+iree_status_t iree_hal_amdgpu_query_fine_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    bool* out_available, hsa_amd_memory_pool_t* out_pool);
+
 // Tries to find a coarse-grained memory pool on the |agent|.
 // Returns true and populates |out_pool| if found, false otherwise.
 bool iree_hal_amdgpu_try_find_coarse_global_memory_pool(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem_test.cc
@@ -73,8 +73,12 @@ TEST_F(VMemTest, FindFineGlobalMemoryPool) {
   ASSERT_GE(topology.cpu_agent_count, 1);
 
   hsa_amd_memory_pool_t gpu_pool = {0};
-  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
-      &libhsa, topology.gpu_agents[0], &gpu_pool));
+  bool gpu_pool_available = false;
+  IREE_ASSERT_OK(iree_hal_amdgpu_query_fine_global_memory_pool(
+      &libhsa, topology.gpu_agents[0], &gpu_pool_available, &gpu_pool));
+  if (!gpu_pool_available) {
+    GTEST_SKIP() << "fine-grained GPU memory pool is not available";
+  }
   EXPECT_NE(gpu_pool.handle, 0);
 
   hsa_region_global_flag_t global_flags = (hsa_region_global_flag_t)0;
@@ -97,9 +101,13 @@ TEST_F(VMemTest, RingbufferLifetime) {
   ASSERT_GE(topology.gpu_agent_count, 1);
 
   hsa_agent_t gpu_agent = topology.gpu_agents[0];
-  hsa_amd_memory_pool_t memory_pool;
-  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
-      &libhsa, gpu_agent, &memory_pool));
+  hsa_amd_memory_pool_t memory_pool = {0};
+  bool memory_pool_available = false;
+  IREE_ASSERT_OK(iree_hal_amdgpu_query_fine_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool_available, &memory_pool));
+  if (!memory_pool_available) {
+    GTEST_SKIP() << "fine-grained GPU memory pool is not available";
+  }
 
   const iree_device_size_t min_capacity = 1 * 1024 * 1024;
   iree_hal_amdgpu_vmem_ringbuffer_t ringbuffer = {0};
@@ -122,9 +130,13 @@ TEST_F(VMemTest, RingbufferWrap) {
   ASSERT_GE(topology.gpu_agent_count, 1);
 
   hsa_agent_t gpu_agent = topology.gpu_agents[0];
-  hsa_amd_memory_pool_t memory_pool;
-  IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
-      &libhsa, gpu_agent, &memory_pool));
+  hsa_amd_memory_pool_t memory_pool = {0};
+  bool memory_pool_available = false;
+  IREE_ASSERT_OK(iree_hal_amdgpu_query_fine_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool_available, &memory_pool));
+  if (!memory_pool_available) {
+    GTEST_SKIP() << "fine-grained GPU memory pool is not available";
+  }
 
   const iree_device_size_t min_capacity = 1 * 1024 * 1024;
   iree_hal_amdgpu_vmem_ringbuffer_t ringbuffer = {0};


### PR DESCRIPTION
The runtime currently treats an allocatable fine-grained device-local HSA memory pool as part of the base AMDGPU HAL contract. The gfx1201 runner appears to expose coarse-grained device-local memory without a fine-grained device-local pool, so allocator/device construction fails before capabilities can report that DEVICE_LOCAL|HOST_VISIBLE|HOST_COHERENT memory is unavailable.

This changes the contract so coarse-grained device-local memory remains required, while fine-grained device-local memory is queried as an optional capability. Fine-memory-dependent paths stay unavailable when the pool is absent instead of silently falling back to host-local memory while claiming device-local semantics.

## Changes

- Add a status-returning optional fine-memory-pool query.
- Stop requiring a fine-grained device-local pool for AMDGPU physical-device and allocator construction.
- Add `suppress_device_fine_memory` / `--amdgpu_suppress_device_fine_memory` so tests and bring-up can exercise the coarse-only memory surface even on devices that report fine memory.
- Gate fine-device block pools, prepublished-kernarg/profiling storage, and fine-memory-dependent profiling modes on pool availability.
- Keep allocator semantics strict: explicit `DEVICE_LOCAL|HOST_VISIBLE` allocations remain unavailable without a matching fine-grained GPU pool, while `OPTIMAL|HOST_VISIBLE|DEVICE_VISIBLE` prefers device-fine and falls back to host-local/device-visible memory.
- Report only backed allocator heaps and update AMDGPU tests for optional fine GPU-local memory.
- Update HAL CTS helpers to initialize device-local buffers through queue fills instead of assuming device-local buffers are host-mappable.
- Make AMDGPU block-pool cleanup tolerate uninitialized optional pools.

Fixes #30.