### PR TITLE
Fix HIP graph launch sequencing

### DIFF
--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -1009,21 +1009,39 @@ iree_status_t iree_hal_streaming_graph_exec_launch(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(z0,
                                     iree_hal_streaming_stream_flush(stream));
 
-  // Query current values of internal semaphores for delta encoding.
-  // Strategy A: Reuse semaphores - query current values.
-  for (uint32_t i = 0; i < exec->semaphore_count; i++) {
-    IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_hal_semaphore_query(exec->semaphores[i],
-                                     &exec->semaphore_base_values[i]));
-  }
-
-  // Mutex needed for launch per CUDA docs.
+  // Mutex needed for launch per CUDA docs. It also protects the executable
+  // semaphore base values below, which are reused and advanced across launches
+  // of the same executable graph.
   iree_slim_mutex_lock(&exec->mutex);
 
-  // Save the stream's initial state.
-  uint64_t stream_wait_value = stream->completed_value;
-  ++stream->pending_value;
-  uint64_t stream_signal_value = stream->pending_value;
+  // Each graph block stores semaphore payload offsets relative to these base
+  // values. Refresh the bases from the device, but never move them backward.
+  // Back-to-back graph launches can submit a later launch before an earlier one
+  // has completed; in that case the queried device value may still be behind
+  // the last payload value this exec submitted.
+  for (uint32_t i = 0; i < exec->semaphore_count; i++) {
+    uint64_t current_value = 0;
+    iree_status_t status =
+        iree_hal_semaphore_query(exec->semaphores[i], &current_value);
+    if (!iree_status_is_ok(status)) {
+      iree_slim_mutex_unlock(&exec->mutex);
+      IREE_TRACE_ZONE_END(z0);
+      return status;
+    }
+    exec->semaphore_base_values[i] =
+        iree_max(exec->semaphore_base_values[i], current_value);
+  }
+
+  iree_slim_mutex_lock(&stream->mutex);
+
+  // Reserve the next stream timeline value while holding the stream lock so
+  // concurrent host threads cannot submit same-stream work with the same wait
+  // or signal value. The graph waits on the current stream tail, not the last
+  // completion observed by the host; HIP stream ordering requires repeated
+  // graph launches on the same stream to execute FIFO even when the caller does
+  // not synchronize between launches.
+  uint64_t stream_wait_value = stream->pending_value;
+  uint64_t stream_signal_value = stream_wait_value + 1;
 
   // Submit all blocks. They will synchronize with each other via internal
   // semaphores. This allows concurrent execution of independent blocks.
@@ -1194,7 +1212,12 @@ iree_status_t iree_hal_streaming_graph_exec_launch(
     memcpy(exec->semaphore_base_values, new_base_values,
            exec->semaphore_count * sizeof(uint64_t));
   }
+  if (iree_status_is_ok(status)) {
+    stream->pending_value = stream_signal_value;
+    stream->submitted_value = stream_signal_value;
+  }
 
+  iree_slim_mutex_unlock(&stream->mutex);
   iree_slim_mutex_unlock(&exec->mutex);
   IREE_TRACE_ZONE_END(z0);
   return status;

--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -1009,9 +1009,9 @@ iree_status_t iree_hal_streaming_graph_exec_launch(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(z0,
                                     iree_hal_streaming_stream_flush(stream));
 
-  // Mutex needed for launch per CUDA docs. It also protects the executable
-  // semaphore base values below, which are reused and advanced across launches
-  // of the same executable graph.
+  // Mutex needed for launch as multiple threads can submit at once.
+  // It also protects the executable semaphore base values below, which
+  // are reused and advanced across launches of the same executable graph.
   iree_slim_mutex_lock(&exec->mutex);
 
   // Each graph block stores semaphore payload offsets relative to these base

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -421,7 +421,7 @@ typedef struct iree_hal_streaming_stream_t {
 
   // Semaphore chain for synchronization.
   iree_hal_semaphore_t* timeline_semaphore;
-  uint64_t pending_value;    // Next value to be used for signaling
+  uint64_t pending_value;    // Last stream timeline value reserved.
   uint64_t submitted_value;  // Last value that was actually submitted (for
                              // wait_submitted)
   uint64_t completed_value;  // Last value we've verified as completed

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -10547,45 +10547,6 @@ HIPAPI hipError_t hipGraphAddMemcpyNode1D(hipGraphNode_t* pGraphNode,
 // Warning: Destination address captured at creation.
 // Ensure memory remains valid for all graph launches.
 //
-// Callback data for host-based memset in graph nodes.
-typedef struct iree_hip_graph_memset_callback_data_t {
-  void* dst;
-  int value;
-  size_t elementSize;
-  size_t count;
-  iree_hal_streaming_context_t* context;
-} iree_hip_graph_memset_callback_data_t;
-
-// Host callback function for memset operations.
-// Uses host-to-device transfer with a pattern buffer for synchronous memset.
-static void iree_hip_graph_memset_callback(void* user_data) {
-  iree_hip_graph_memset_callback_data_t* data =
-      (iree_hip_graph_memset_callback_data_t*)user_data;
-
-  // Create a host buffer with the pattern and use H2D transfer.
-  // This works because iree_hal_streaming_memcpy_host_to_device with NULL
-  // stream uses synchronous transfer via iree_hal_device_transfer_h2d.
-  size_t total_size = data->count * data->elementSize;
-
-  // Allocate a temporary host buffer with the pattern using standard malloc.
-  void* pattern_buffer = malloc(total_size);
-  if (!pattern_buffer) {
-    return;
-  }
-
-  // Fill the pattern buffer.
-  uint8_t pattern_byte = (uint8_t)data->value;
-  memset(pattern_buffer, pattern_byte, total_size);
-
-  // Copy to device using synchronous H2D transfer.
-  iree_status_t status = iree_hal_streaming_memcpy_host_to_device(
-      data->context, (iree_hal_streaming_deviceptr_t)data->dst, pattern_buffer,
-      total_size, NULL);
-  iree_status_ignore(status);
-
-  free(pattern_buffer);
-}
-
 // See also: hipGraphAddMemcpyNode, hipGraphAddKernelNode,
 //           hipMemsetAsync, hipGraphMemsetNodeSetParams.
 HIPAPI hipError_t hipGraphAddMemsetNode(hipGraphNode_t* pGraphNode,
@@ -10611,31 +10572,12 @@ HIPAPI hipError_t hipGraphAddMemsetNode(hipGraphNode_t* pGraphNode,
 
   iree_hal_streaming_graph_node_t* node = NULL;
 
-  // Use host callback approach for memset nodes.
-  // This avoids issues with buffer table lookups and works reliably.
-  // Allocate callback data in the graph's arena.
-  iree_hip_graph_memset_callback_data_t* callback_data = NULL;
-  iree_status_t alloc_status = iree_arena_allocate(
-      &stream_graph->arena, sizeof(iree_hip_graph_memset_callback_data_t),
-      (void**)&callback_data);
-  if (!iree_status_is_ok(alloc_status)) {
-    iree_status_ignore(alloc_status);
-    IREE_TRACE_ZONE_END(z0);
-    HIP_RETURN_ERROR(hipErrorOutOfMemory);
-  }
-
-  callback_data->dst = (void*)params->dst;
-  callback_data->value = params->value;
-  callback_data->elementSize = params->elementSize;
-  callback_data->count = params->width * params->height;
-  callback_data->context = stream_graph->context;
-
-  // Create a host callback node that performs the memset.
   HIP_RETURN_STATUS_AND_END_ZONE_IF_ERROR(
       z0,
-      iree_hal_streaming_graph_add_host_call_node(
-          stream_graph, deps, numDependencies, iree_hip_graph_memset_callback,
-          callback_data, &node),
+      iree_hal_streaming_graph_add_memset_node(
+          stream_graph, deps, numDependencies,
+          (iree_hal_streaming_deviceptr_t)params->dst, params->value,
+          params->elementSize, params->width * params->height, &node),
       hipErrorInvalidValue);
 
   *pGraphNode = (hipGraphNode_t)node;


### PR DESCRIPTION
Graph launches could hang or mis-order repeated launches because stream sequencing was based on completed values instead of the last submitted stream work, and graph memset nodes were represented as host callbacks.

This changes graph launch submission to chain from the stream pending value and keep graph semaphore bases monotonic across repeated launches. It also records HIP graph memset nodes as native graph memset nodes, avoiding a host callback in the execution path.
