### PR TITLE
Make the gfx1201 tests non experimental.

### DIFF
--- a/.github/workflows/ci_core_linux.yml
+++ b/.github/workflows/ci_core_linux.yml
@@ -118,7 +118,7 @@ jobs:
             chip: gfx1201
             runner_label: gpu_navi4x
             ctest_exclude_regex: ""
-            experimental: true
+            experimental: false
     uses: ./.github/workflows/test_core_linux_gpu.yml
     permissions:
       actions: read

--- a/.github/workflows/ci_core_linux.yml
+++ b/.github/workflows/ci_core_linux.yml
@@ -114,7 +114,7 @@ jobs:
             runner_label: linux-gfx942-1gpu-core42-ossci-rocm
             ctest_exclude_regex: "(^iree/hal/drivers/amdgpu/allocator_test$)|(^iree/hal/drivers/amdgpu/host_queue_command_buffer_test$)|(^iree/hal/drivers/amdgpu/pm4_command_buffer_benchmark_test$)"
             experimental: false
-          - name: Linux / CMake / GPU gfx1201 (experimental)
+          - name: Linux / CMake / GPU gfx1201
             chip: gfx1201
             runner_label: gpu_navi4x
             ctest_exclude_regex: ""


### PR DESCRIPTION
With #43, all tests now pass on gfx1201 and its memory configuration.
