### PR TITLE
[CI] Gate GPU tests on rocminfo health

### DIFF
--- a/.github/scripts/check_rocm_environment.sh
+++ b/.github/scripts/check_rocm_environment.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -euo pipefail
+
+if ! command -v rocminfo >/dev/null 2>&1; then
+  echo "::error::ROCm environment on this runner is broken; rocminfo was not found."
+  exit 1
+fi
+
+echo "rocminfo path: $(command -v rocminfo)"
+if ! rocminfo; then
+  echo "::error::ROCm environment on this runner is broken; rocminfo failed before GPU tests."
+  exit 1
+fi

--- a/.github/workflows/ci_core_linux.yml
+++ b/.github/workflows/ci_core_linux.yml
@@ -118,7 +118,7 @@ jobs:
             chip: gfx1201
             runner_label: gpu_navi4x
             ctest_exclude_regex: ""
-            experimental: false
+            experimental: true
     uses: ./.github/workflows/test_core_linux_gpu.yml
     permissions:
       actions: read

--- a/.github/workflows/ci_iree_bazel.yml
+++ b/.github/workflows/ci_iree_bazel.yml
@@ -202,9 +202,7 @@ jobs:
           test -d "${HRX_ROCM_ROOT}/include"
 
       - name: Report ROCm environment
-        run: |
-          echo "rocminfo path: $(command -v rocminfo)"
-          rocminfo
+        run: bash .github/scripts/check_rocm_environment.sh
 
       - name: Run IREE Bazel CI
         run: |

--- a/.github/workflows/ci_iree_cmake.yml
+++ b/.github/workflows/ci_iree_cmake.yml
@@ -197,6 +197,9 @@ jobs:
           "$CC" --version
           test -d "${HRX_ROCM_ROOT}/include"
 
+      - name: Report ROCm environment
+        run: bash .github/scripts/check_rocm_environment.sh
+
       - name: Run IREE CMake CI
         run: |
           echo "python3 build_tools/devtools/ci.py ${{ matrix.command }} --keep-going"

--- a/.github/workflows/test_core_linux_gpu.yml
+++ b/.github/workflows/test_core_linux_gpu.yml
@@ -151,13 +151,15 @@ jobs:
           "${HRX_PYTHON}" build_tools/ci_core_linux.py extract-packages
 
       - name: Report ROCm environment
+        id: rocm_environment
+        continue-on-error: ${{ inputs.experimental }}
         run: |
           export PATH="${HRX_PUBLIC_DEPS_DIR}/bin:${PATH}"
           export LD_LIBRARY_PATH="${HRX_PUBLIC_DEPS_DIR}/lib:${HRX_PUBLIC_DEPS_DIR}/lib/rocm_sysdeps/lib:${LD_LIBRARY_PATH:-}"
-          echo "rocminfo path: $(command -v rocminfo)"
-          rocminfo || echo "::warning::rocminfo failed; continuing to installed GPU tests"
+          bash .github/scripts/check_rocm_environment.sh
 
       - name: Run installed GPU tests
+        if: ${{ steps.rocm_environment.outcome == 'success' }}
         continue-on-error: ${{ inputs.experimental }}
         run: |
           "${HRX_PYTHON}" build_tools/ci_core_linux.py test


### PR DESCRIPTION
Treat rocminfo as the fast ROCm environment health check for GPU jobs. If it fails, emit an explicit broken-runner error instead of continuing into package, Bazel, or CMake test suites and reporting cascading failures.

Share the ROCm environment probe across the packaged GPU workflow and the IREE Bazel/CMake AMDGPU workflows so all ROCm-backed GPU lanes fail at the same sentinel.

Allow the gfx1201 packaged runner to remain live as an experimental lane while it is unhealthy. Experimental packaged GPU jobs tolerate the rocminfo probe failure and skip installed tests, while non-experimental GPU jobs fail immediately on a broken ROCm environment.