### PR TITLE
hip: capture GPU-reach timestamps in hipEventElapsedTime

### DIFF
--- a/libhrx/src/binding/common/event.c
+++ b/libhrx/src/binding/common/event.c
@@ -106,6 +106,17 @@ iree_status_t iree_hal_streaming_event_query(iree_hal_streaming_event_t* event,
   return iree_ok_status();
 }
 
+// Captures the host wall-clock time when the GPU *reaches* this point in the
+// stream (invoked as a stream-ordered host callback). Recording the time here —
+// rather than when hipEventRecord is called on the host — is what makes
+// hipEventElapsedTime reflect real GPU progress instead of host enqueue latency
+// (which is ~0 and breaks consumers like MIOpen's kernel auto-tuner, which
+// rejects non-positive elapsed times).
+static void iree_hal_streaming_event_capture_timestamp(void *user_data) {
+  iree_hal_streaming_event_t *event = (iree_hal_streaming_event_t *)user_data;
+  event->record_time_ns = iree_time_now();
+}
+
 iree_status_t iree_hal_streaming_event_record(
     iree_hal_streaming_event_t* event, iree_hal_streaming_stream_t* stream) {
   IREE_ASSERT_ARGUMENT(event);
@@ -122,7 +133,17 @@ iree_status_t iree_hal_streaming_event_record(
         "event record during graph capture not yet implemented");
   }
 
-  event->record_time_ns = iree_time_now();
+  // Capture the timestamp via a stream-ordered host callback so it reflects when
+  // the GPU reaches this point, not host enqueue time. The callback advances the
+  // stream timeline, so the completion barrier below waits for it — meaning
+  // hipEventQuery/Synchronize observe completion only after record_time_ns is
+  // set (no race). Timing-disabled events skip this and keep the cheapest record.
+  event->record_time_ns = 0;
+  if (!(event->flags & IREE_HAL_STREAMING_EVENT_FLAG_DISABLE_TIMING)) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_hal_streaming_launch_host_function(
+                stream, iree_hal_streaming_event_capture_timestamp, event));
+  }
 
   // Set recording stream so we can track when we cross streams in a signal/wait
   // sequence.
@@ -218,8 +239,22 @@ iree_status_t iree_hal_streaming_event_elapsed_time(
                             "stop event has not completed");
   }
 
-  // Calculate elapsed time in milliseconds.
+  // Elapsed time in ms. Both timestamps come from the same monotonic clock
+  // when the GPU reaches each event, so on a single recording stream
+  // stop >= start. A negative delta means the events were recorded on
+  // independent streams (whose host-callback timelines have no mutual order);
+  // returning a bogus negative value would reintroduce the non-positive-elapsed
+  // failure this fixes, so reject it. NOTE: this is coarse host-observed
+  // GPU-reach timing (a stream-ordered callback samples iree_time_now), not a
+  // device timestamp; cross-stream and concurrent re-record are out of scope
+  // (see the review notes) but sufficient for the MIOpen unblock.
   int64_t elapsed_ns = stop->record_time_ns - start->record_time_ns;
+  if (elapsed_ns < 0) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "stop event precedes start event (events recorded on different streams "
+        "are not supported for elapsed-time measurement)");
+  }
   *ms = (float)elapsed_ns / 1000000.0f;  // Convert nanoseconds to milliseconds.
 
   return iree_ok_status();

--- a/libhrx/src/binding/common/event.c
+++ b/libhrx/src/binding/common/event.c
@@ -112,8 +112,8 @@ iree_status_t iree_hal_streaming_event_query(iree_hal_streaming_event_t* event,
 // hipEventElapsedTime reflect real GPU progress instead of host enqueue latency
 // (which is ~0 and breaks consumers like MIOpen's kernel auto-tuner, which
 // rejects non-positive elapsed times).
-static void iree_hal_streaming_event_capture_timestamp(void *user_data) {
-  iree_hal_streaming_event_t *event = (iree_hal_streaming_event_t *)user_data;
+static void iree_hal_streaming_event_capture_timestamp(void* user_data) {
+  iree_hal_streaming_event_t* event = (iree_hal_streaming_event_t*)user_data;
   event->record_time_ns = iree_time_now();
 }
 
@@ -133,11 +133,12 @@ iree_status_t iree_hal_streaming_event_record(
         "event record during graph capture not yet implemented");
   }
 
-  // Capture the timestamp via a stream-ordered host callback so it reflects when
-  // the GPU reaches this point, not host enqueue time. The callback advances the
-  // stream timeline, so the completion barrier below waits for it — meaning
-  // hipEventQuery/Synchronize observe completion only after record_time_ns is
-  // set (no race). Timing-disabled events skip this and keep the cheapest record.
+  // Capture the timestamp via a stream-ordered host callback so it reflects
+  // when the GPU reaches this point, not host enqueue time. The callback
+  // advances the stream timeline, so the completion barrier below waits for it
+  // — meaning hipEventQuery/Synchronize observe completion only after
+  // record_time_ns is set (no race). Timing-disabled events skip this and keep
+  // the cheapest record.
   event->record_time_ns = 0;
   if (!(event->flags & IREE_HAL_STREAMING_EVENT_FLAG_DISABLE_TIMING)) {
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
@@ -246,8 +247,9 @@ iree_status_t iree_hal_streaming_event_elapsed_time(
   // returning a bogus negative value would reintroduce the non-positive-elapsed
   // failure this fixes, so reject it. NOTE: this is coarse host-observed
   // GPU-reach timing (a stream-ordered callback samples iree_time_now), not a
-  // device timestamp; cross-stream and concurrent re-record are out of scope
-  // (see the review notes) but sufficient for the MIOpen unblock.
+  // device timestamp; cross-stream measurement and concurrent re-record are
+  // unsupported, but this is sufficient for per-launch kernel timing such as
+  // library auto-tuners.
   int64_t elapsed_ns = stop->record_time_ns - start->record_time_ns;
   if (elapsed_ns < 0) {
     return iree_make_status(


### PR DESCRIPTION
## Summary
`hipEventElapsedTime` measured host enqueue spacing, so back-to-back records around a kernel reported ~0 ms; MIOpen's auto-tuner rejects non-positive elapsed, breaking conv tuning. Sample a monotonic timestamp inside a stream-ordered host callback (when the GPU reaches the event). Also reject a negative delta (events on independent streams) rather than returning a bogus negative value.

## Review
Agent review: the host-callback approach is coarse host-observed GPU-reach timing (documented in-code), sufficient for the auto-tuner unblock. Bounded fix applied (the negative-delta guard); device-side timestamps and the re-record error-code refinement are documented follow-ups.

## Test
Paired hip-cts: `iree-org/hip-cts` `users/zjgarvey/hip-event-elapsed-time-test` (elapsed > 0 around GPU work + disable-timing rejected). Verified on MI300X (30 assertions, 2 cases).

Peeled from the nightly bring-up branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)