### PR TITLE
[Infra] Optimize PR clang-tidy presubmit

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Adjust git config
         run: git config --global --add safe.directory "$PWD"
@@ -58,4 +60,14 @@ jobs:
           test -d "${HRX_ROCM_ROOT}/lib/llvm/include"
 
       - name: Run presubmit
-        run: python3 dev.py bazel presubmit --profile ci --no-project-tests
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            python3 dev.py bazel presubmit \
+              --profile ci \
+              --no-project-tests \
+              --base "${{ github.event.pull_request.base.sha }}"
+          else
+            python3 dev.py bazel presubmit \
+              --profile ci \
+              --no-project-tests
+          fi

--- a/build_tools/clang_tidy/clang_tidy.bzl
+++ b/build_tools/clang_tidy/clang_tidy.bzl
@@ -21,6 +21,8 @@ IreeClangTidyInfo = provider(
     doc = "clang-tidy artifacts collected from configured C/C++ targets.",
     fields = {
         "fixes": "depset of per-translation-unit clang-tidy replacement YAML files.",
+        "local_fixes": "depset of direct per-translation-unit clang-tidy replacement YAML files.",
+        "local_reports": "depset of direct per-translation-unit clang-tidy report files.",
         "reports": "depset of per-translation-unit clang-tidy report files.",
     },
 )
@@ -186,9 +188,16 @@ def _collect_clang_tidy_aspect_impl(target, ctx):
     fixes = depset(local_fixes, transitive = transitive_fixes)
     reports = depset(local_reports, transitive = transitive_reports)
     return [
-        IreeClangTidyInfo(fixes = fixes, reports = reports),
+        IreeClangTidyInfo(
+            fixes = fixes,
+            local_fixes = depset(local_fixes),
+            local_reports = depset(local_reports),
+            reports = reports,
+        ),
         OutputGroupInfo(
             iree_clang_tidy_fixes = fixes,
+            iree_clang_tidy_local_fixes = depset(local_fixes),
+            iree_clang_tidy_local_reports = depset(local_reports),
             iree_clang_tidy_reports = reports,
         ),
     ]
@@ -237,18 +246,31 @@ collect_clang_tidy_aspect = aspect(
 
 def _iree_clang_tidy_impl(ctx):
     transitive_fixes = []
+    transitive_local_fixes = []
+    transitive_local_reports = []
     transitive_reports = []
     for target in ctx.attr.targets:
         if IreeClangTidyInfo in target:
             transitive_fixes.append(target[IreeClangTidyInfo].fixes)
+            transitive_local_fixes.append(target[IreeClangTidyInfo].local_fixes)
+            transitive_local_reports.append(target[IreeClangTidyInfo].local_reports)
             transitive_reports.append(target[IreeClangTidyInfo].reports)
     fixes = depset(transitive = transitive_fixes)
+    local_fixes = depset(transitive = transitive_local_fixes)
+    local_reports = depset(transitive = transitive_local_reports)
     reports = depset(transitive = transitive_reports)
     return [
         DefaultInfo(files = reports),
-        IreeClangTidyInfo(fixes = fixes, reports = reports),
+        IreeClangTidyInfo(
+            fixes = fixes,
+            local_fixes = local_fixes,
+            local_reports = local_reports,
+            reports = reports,
+        ),
         OutputGroupInfo(
             iree_clang_tidy_fixes = fixes,
+            iree_clang_tidy_local_fixes = local_fixes,
+            iree_clang_tidy_local_reports = local_reports,
             iree_clang_tidy_reports = reports,
         ),
     ]

--- a/build_tools/devtools/cli.py
+++ b/build_tools/devtools/cli.py
@@ -855,6 +855,12 @@ def add_lane_commands(subparsers: argparse._SubParsersAction, lane: str) -> None
     )
     add_argument(
         presubmit_parser,
+        "--base",
+        metavar="GIT_REF",
+        help="Run presubmit over branch changes since GIT_REF plus local changes.",
+    )
+    add_argument(
+        presubmit_parser,
         "--no-project-tests",
         dest="project_tests",
         action="store_false",
@@ -1209,6 +1215,7 @@ def handle_presubmit(args: argparse.Namespace) -> CommandPlan:
         args.lane,
         existing_or_system_environment(args),
         args.profile,
+        base=args.base,
         cmake_build_dir=configured_cmake_build_dir(args)
         if args.lane == "cmake"
         else None,

--- a/build_tools/devtools/cli_test.py
+++ b/build_tools/devtools/cli_test.py
@@ -971,6 +971,16 @@ class CliTest(unittest.TestCase):
         self.assertIn("--profile default", description)
         self.assertIn("--all", description)
 
+    def test_bazel_presubmit_can_use_base_ref(self):
+        args = cli.parse_arguments(["bazel", "presubmit", "--base", "origin/main"])
+
+        plan = args.handler(args)
+        description = plan.describe()
+
+        self.assertIn("--lane bazel", description)
+        self.assertIn("--base origin/main", description)
+        self.assertNotIn("--all", description)
+
     def test_bazel_presubmit_can_skip_project_tests(self):
         args = cli.parse_arguments(["bazel", "presubmit", "--no_project_tests"])
 
@@ -1051,6 +1061,7 @@ class CliTest(unittest.TestCase):
 
         self.assertIn("The default profile is ci", output)
         self.assertIn("full-tree", output)
+        self.assertIn("--base", output)
         self.assertIn("precommit", output)
 
     def test_bazel_clang_tidy_help_explains_modes(self):

--- a/build_tools/devtools/help_text.py
+++ b/build_tools/devtools/help_text.py
@@ -284,6 +284,7 @@ Repo-relative paths and git scopes use the configured CMake compile database.
             epilog=f"""Examples:
   python dev.py {lane} presubmit
   python dev.py {lane} presubmit --profile paranoid
+  python dev.py {lane} presubmit --base origin/main
   python dev.py {lane} presubmit --no-project-tests
   python dev.py {lane} presubmit --verbose
 
@@ -295,6 +296,8 @@ Profiles:
 The default profile is ci. This is intentionally the expensive full-tree check
 that approximates the project test workflows a developer can run locally. Use
 --no-project-tests only for CI jobs that have separate project test workflows.
+`--base` runs the same presubmit profile on the branch diff and lets static
+analysis providers conservatively escalate when a change affects wider state.
 Use `python dev.py {lane} precommit` for local changes only.""",
         )
     if command == "precommit":

--- a/build_tools/devtools/presubmit.py
+++ b/build_tools/devtools/presubmit.py
@@ -52,6 +52,7 @@ def presubmit_plan(
     lane: str,
     tool_env: ToolEnvironment,
     profile: str,
+    base: str | None = None,
     cmake_build_dir: Path | None = None,
     verbose: bool = False,
     project_tests: bool = True,
@@ -70,8 +71,8 @@ def presubmit_plan(
             "--profile",
             profile,
             "--check",
-            "--all",
         ]
+        command += ["--base", base] if base is not None else ["--all"]
         if verbose:
             command.append("--verbose")
         if not project_tests:
@@ -93,8 +94,8 @@ def presubmit_plan(
             "--profile",
             profile,
             "--check",
-            "--all",
         ]
+        command += ["--base", base] if base is not None else ["--all"]
         if verbose:
             command.append("--verbose")
         if not project_tests:

--- a/build_tools/lefthook/presubmit.py
+++ b/build_tools/lefthook/presubmit.py
@@ -61,10 +61,16 @@ C_FORMAT_EXTENSIONS = {
     ".m",
     ".mm",
 }
+C_INCLUDE_FRAGMENT_EXTENSIONS = {
+    ".def",
+    ".inc",
+    ".inl",
+}
+C_ANALYSIS_EXTENSIONS = C_FORMAT_EXTENSIONS | C_INCLUDE_FRAGMENT_EXTENSIONS
 C_FORMAT_BATCH_SIZE = 64
 C_FORMAT_DEFAULT_MAX_JOBS = 16
 SEMGREP_CONFIG = "build_tools/static_analysis/semgrep/iree.yml"
-SEMGREP_EXTENSIONS = C_FORMAT_EXTENSIONS
+SEMGREP_EXTENSIONS = C_ANALYSIS_EXTENSIONS
 SEMGREP_PATH_PREFIXES = (
     "runtime/src/iree/",
     "loom/src/loom/",
@@ -72,18 +78,25 @@ SEMGREP_PATH_PREFIXES = (
 )
 SEMGREP_DEFAULT_MAX_JOBS = 14
 CLANG_TIDY_ASPECT = "//build_tools/clang_tidy:clang_tidy.bzl%collect_clang_tidy_aspect"
-CLANG_TIDY_EXTENSIONS = {
+CLANG_TIDY_TRANSLATION_UNIT_EXTENSIONS = {
     ".c",
     ".cc",
     ".cpp",
     ".cxx",
+}
+CLANG_TIDY_HEADER_EXTENSIONS = {
     ".h",
     ".hh",
     ".hpp",
     ".hxx",
-}
+} | C_INCLUDE_FRAGMENT_EXTENSIONS
+CLANG_TIDY_EXTENSIONS = (
+    CLANG_TIDY_TRANSLATION_UNIT_EXTENSIONS | CLANG_TIDY_HEADER_EXTENSIONS
+)
 CLANG_TIDY_INFRA_PREFIX = "build_tools/clang_tidy/"
 CLANG_TIDY_FIXES_OUTPUT_GROUP = "iree_clang_tidy_fixes"
+CLANG_TIDY_LOCAL_FIXES_OUTPUT_GROUP = "iree_clang_tidy_local_fixes"
+CLANG_TIDY_LOCAL_OUTPUT_GROUP = "iree_clang_tidy_local_reports"
 CLANG_TIDY_OUTPUT_GROUP = "iree_clang_tidy_reports"
 CLANG_TIDY_PATH_PREFIXES = SEMGREP_PATH_PREFIXES
 CLANG_TIDY_REPO_ENV = "--repo_env=IREE_CLANG_TIDY_LLVM=auto"
@@ -174,13 +187,45 @@ ROOT_DEVTOOLS_TRIGGERS = (
     "build_tools/devtools/",
     "build_tools/lefthook/",
 )
+CLANG_TIDY_FULL_SCOPE_EXACT_PATHS = {
+    ".bazelrc",
+    ".bazelversion",
+    ".github/workflows/presubmit.yml",
+    "MODULE.bazel",
+    "MODULE.bazel.lock",
+    "WORKSPACE",
+    "WORKSPACE.bazel",
+    "WORKSPACE.bzlmod",
+    "dev.py",
+}
+CLANG_TIDY_FULL_SCOPE_PREFIXES = (
+    "build_tools/bazel/",
+    "build_tools/devtools/",
+    "build_tools/lefthook/",
+    CLANG_TIDY_INFRA_PREFIX,
+)
+
+
+@dataclass(frozen=True)
+class PresubmitInputs:
+    mode: str
+    selected_paths: list[str]
+    changed_paths: list[str]
+    tracked_paths: list[str] | None = None
+    base: str | None = None
+
+    def all_paths(self) -> list[str]:
+        tracked_paths = self.tracked_paths
+        if tracked_paths is None:
+            tracked_paths = git_list(["ls-files", "-z"])
+        return unique_paths([*tracked_paths, *self.changed_paths])
 
 
 @dataclass(frozen=True)
 class StaticAnalysisProvider:
     name: str
     profiles: frozenset[str]
-    runner: Callable[[list[str], str, str, bool], bool]
+    runner: Callable[[PresubmitInputs, str, str, bool], bool]
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -623,19 +668,50 @@ def commit_files() -> list[str]:
     )
 
 
-def selected_files(args: argparse.Namespace) -> list[str]:
+def tracked_files() -> list[str]:
+    return git_list(["ls-files", "-z"])
+
+
+def presubmit_inputs(args: argparse.Namespace) -> PresubmitInputs:
     if args.paths:
-        return args.paths
+        return PresubmitInputs(
+            mode="explicit",
+            selected_paths=args.paths,
+            changed_paths=args.paths,
+        )
     if args.changed:
-        return changed_files()
+        paths = changed_files()
+        return PresubmitInputs(
+            mode="changed",
+            selected_paths=paths,
+            changed_paths=paths,
+        )
     if args.staged:
-        return git_list(["diff", "--cached", "--name-only", "-z", "--diff-filter=ACMR"])
+        paths = git_list(
+            ["diff", "--cached", "--name-only", "-z", "--diff-filter=ACMR"]
+        )
+        return PresubmitInputs(
+            mode="staged",
+            selected_paths=paths,
+            changed_paths=paths,
+        )
     if args.commit:
-        return commit_files()
+        paths = commit_files()
+        return PresubmitInputs(
+            mode="commit",
+            selected_paths=paths,
+            changed_paths=paths,
+        )
     if args.all:
-        return git_list(["ls-files", "-z"])
+        paths = tracked_files()
+        return PresubmitInputs(
+            mode="all",
+            selected_paths=paths,
+            changed_paths=paths,
+            tracked_paths=paths,
+        )
     if args.base:
-        return unique_paths(
+        paths = unique_paths(
             [
                 *git_list(
                     [
@@ -650,12 +726,33 @@ def selected_files(args: argparse.Namespace) -> list[str]:
                 *changed_files(),
             ]
         )
+        return PresubmitInputs(
+            mode="base",
+            selected_paths=paths,
+            changed_paths=paths,
+            tracked_paths=tracked_files(),
+            base=args.base,
+        )
     if args.files_from:
         with open(args.files_from, encoding="utf-8") as file_list:
-            return [line.strip() for line in file_list if line.strip()]
-    return git_list(
+            paths = [line.strip() for line in file_list if line.strip()]
+        return PresubmitInputs(
+            mode="files-from",
+            selected_paths=paths,
+            changed_paths=paths,
+        )
+    paths = git_list(
         ["diff", "--name-only", "-z", "--diff-filter=ACMR", args.since, "--"]
     )
+    return PresubmitInputs(
+        mode="since",
+        selected_paths=paths,
+        changed_paths=paths,
+    )
+
+
+def selected_files(args: argparse.Namespace) -> list[str]:
+    return presubmit_inputs(args).selected_paths
 
 
 def existing_files(paths: list[str]) -> list[str]:
@@ -711,6 +808,37 @@ def is_clang_tidy_candidate_file(path: str) -> bool:
 
 def is_clang_tidy_infra_file(path: str) -> bool:
     return path.startswith(CLANG_TIDY_INFRA_PREFIX)
+
+
+def is_bazel_graph_file(path: str) -> bool:
+    file_path = Path(path)
+    return (
+        path in CLANG_TIDY_FULL_SCOPE_EXACT_PATHS
+        or file_path.name in BUILDIFIER_NAMES
+        or file_path.suffix in BUILDIFIER_EXTENSIONS
+    )
+
+
+def is_clang_tidy_full_scope_trigger(path: str) -> bool:
+    if is_bazel_graph_file(path):
+        return True
+    if any(path.startswith(prefix) for prefix in CLANG_TIDY_FULL_SCOPE_PREFIXES):
+        return True
+    return path.startswith(CLANG_TIDY_PATH_PREFIXES) and (
+        Path(path).suffix in CLANG_TIDY_HEADER_EXTENSIONS
+    )
+
+
+def clang_tidy_uses_full_scope(inputs: PresubmitInputs) -> bool:
+    return inputs.mode == "base" and any(
+        is_clang_tidy_full_scope_trigger(path) for path in inputs.changed_paths
+    )
+
+
+def clang_tidy_analysis_paths(inputs: PresubmitInputs) -> list[str]:
+    if clang_tidy_uses_full_scope(inputs):
+        return inputs.all_paths()
+    return inputs.selected_paths
 
 
 def is_executable_path(path: str) -> bool:
@@ -1252,7 +1380,8 @@ def is_root_devtools_trigger(path: str) -> bool:
     )
 
 
-def run_semgrep(paths: list[str], profile: str, verbose: bool) -> bool:
+def run_semgrep(inputs: PresubmitInputs, profile: str, verbose: bool) -> bool:
+    paths = inputs.selected_paths
     files = existing_files([path for path in paths if is_semgrep_candidate_file(path)])
     validate_config = SEMGREP_CONFIG in paths
     if not files and not validate_config:
@@ -1279,6 +1408,7 @@ def clang_tidy_bazel_command(
     *,
     build_events_path: Path | None = None,
     emit_fixes: bool = False,
+    local_outputs: bool = False,
 ) -> list[str]:
     command = [
         "bazel",
@@ -1286,9 +1416,15 @@ def clang_tidy_bazel_command(
     ]
     if keep_going:
         command.append("--keep_going")
-    output_groups = [CLANG_TIDY_OUTPUT_GROUP]
+    output_groups = [
+        CLANG_TIDY_LOCAL_OUTPUT_GROUP if local_outputs else CLANG_TIDY_OUTPUT_GROUP
+    ]
     if emit_fixes:
-        output_groups.append(CLANG_TIDY_FIXES_OUTPUT_GROUP)
+        output_groups.append(
+            CLANG_TIDY_LOCAL_FIXES_OUTPUT_GROUP
+            if local_outputs
+            else CLANG_TIDY_FIXES_OUTPUT_GROUP
+        )
     command += [
         CLANG_TIDY_REPO_ENV,
         f"--aspects={CLANG_TIDY_ASPECT}",
@@ -1554,11 +1690,12 @@ def clang_apply_replacements_command(
 
 
 def run_clang_tidy_cmake(
-    paths: list[str], profile: str, verbose: bool, fix: bool = False
+    inputs: PresubmitInputs, profile: str, verbose: bool, fix: bool = False
 ) -> bool:
+    paths = clang_tidy_analysis_paths(inputs)
     candidate_files = cmake_clang_tidy_candidate_files(paths)
     infra_files = existing_files(
-        [path for path in paths if is_clang_tidy_infra_file(path)]
+        [path for path in inputs.changed_paths if is_clang_tidy_infra_file(path)]
     )
     if not candidate_files and not infra_files:
         return skip_step("clang-tidy", "no C/C++ runtime inputs")
@@ -1701,6 +1838,7 @@ def run_clang_tidy_bazel_fix(
     package_targets: list[str],
     profile: str,
     verbose: bool,
+    local_outputs: bool,
 ) -> bool:
     clang_apply_replacements = clang_tidy_apply_replacements_tool()
     if not clang_apply_replacements:
@@ -1722,6 +1860,7 @@ def run_clang_tidy_bazel_fix(
                 keep_going=True,
                 build_events_path=build_events_path,
                 emit_fixes=True,
+                local_outputs=local_outputs,
             ),
             "clang-tidy Bazel fix export",
             verbose,
@@ -1731,7 +1870,9 @@ def run_clang_tidy_bazel_fix(
 
         fix_paths = bazel_output_paths_from_bep(
             build_events_path,
-            output_group=CLANG_TIDY_FIXES_OUTPUT_GROUP,
+            output_group=CLANG_TIDY_LOCAL_FIXES_OUTPUT_GROUP
+            if local_outputs
+            else CLANG_TIDY_FIXES_OUTPUT_GROUP,
             suffix=".clang_tidy_fixes.yaml",
         )
         if not fix_paths:
@@ -1751,6 +1892,7 @@ def run_clang_tidy_bazel_fix(
                     clang_tidy_bazel_command(
                         package_targets,
                         keep_going=profile == "ci",
+                        local_outputs=local_outputs,
                     ),
                     "clang-tidy Bazel actions after fixes",
                     verbose,
@@ -1774,6 +1916,7 @@ def run_clang_tidy_bazel_fix(
             clang_tidy_bazel_command(
                 package_targets,
                 keep_going=profile == "ci",
+                local_outputs=local_outputs,
             ),
             "clang-tidy Bazel actions after fixes",
             verbose,
@@ -1783,22 +1926,23 @@ def run_clang_tidy_bazel_fix(
 
 
 def run_clang_tidy(
-    paths: list[str],
+    inputs: PresubmitInputs,
     profile: str,
     lane: str,
     verbose: bool,
     fix: bool = False,
 ) -> bool:
     if lane == "cmake":
-        return run_clang_tidy_cmake(paths, profile, verbose, fix=fix)
+        return run_clang_tidy_cmake(inputs, profile, verbose, fix=fix)
     if lane != "bazel":
         return skip_step("clang-tidy", "unknown build-system lane")
 
+    paths = clang_tidy_analysis_paths(inputs)
     candidate_files = existing_files(
         [path for path in paths if is_clang_tidy_candidate_file(path)]
     )
     infra_files = existing_files(
-        [path for path in paths if is_clang_tidy_infra_file(path)]
+        [path for path in inputs.changed_paths if is_clang_tidy_infra_file(path)]
     )
     if not candidate_files and not infra_files:
         return skip_step("clang-tidy", "no C/C++ runtime inputs")
@@ -1850,6 +1994,7 @@ def run_clang_tidy(
         ]
     )
     if package_targets:
+        local_outputs = True
         if fix:
             ok = (
                 run_clang_tidy_bazel_fix(
@@ -1857,6 +2002,7 @@ def run_clang_tidy(
                     package_targets=package_targets,
                     profile=profile,
                     verbose=verbose,
+                    local_outputs=local_outputs,
                 )
                 and ok
             )
@@ -1866,6 +2012,7 @@ def run_clang_tidy(
                     clang_tidy_bazel_command(
                         package_targets,
                         keep_going=profile == "ci",
+                        local_outputs=local_outputs,
                     ),
                     "clang-tidy Bazel actions",
                     verbose,
@@ -1881,8 +2028,8 @@ STATIC_ANALYSIS_PROVIDERS = (
     StaticAnalysisProvider(
         name="Semgrep",
         profiles=frozenset(("paranoid", "ci")),
-        runner=lambda paths, profile, lane, verbose: run_semgrep(
-            paths, profile, verbose
+        runner=lambda inputs, profile, lane, verbose: run_semgrep(
+            inputs, profile, verbose
         ),
     ),
     StaticAnalysisProvider(
@@ -1894,9 +2041,9 @@ STATIC_ANALYSIS_PROVIDERS = (
 
 
 def run_static_analysis(
-    paths: list[str], profile: str, lane: str, verbose: bool
+    inputs: PresubmitInputs, profile: str, lane: str, verbose: bool
 ) -> bool:
-    if not paths:
+    if not inputs.selected_paths:
         return True
     ok = True
     selected_providers = [
@@ -1907,13 +2054,14 @@ def run_static_analysis(
     if not selected_providers:
         return skip_step("Static analysis", f"no providers for {profile} profile")
     for provider in selected_providers:
-        ok = provider.runner(paths, profile, lane, verbose) and ok
+        ok = provider.runner(inputs, profile, lane, verbose) and ok
     return ok
 
 
 def print_plan(
-    args: argparse.Namespace, paths: list[str], projects: list[Project]
+    args: argparse.Namespace, inputs: PresubmitInputs, projects: list[Project]
 ) -> None:
+    paths = inputs.selected_paths
     mutation = "fix" if args.fix else "check"
     if args.paths:
         input_mode = "explicit paths"
@@ -2018,10 +2166,11 @@ def print_suggested_actions(args: argparse.Namespace, ok: bool) -> None:
 
 
 def run_presubmit(
-    args: argparse.Namespace, paths: list[str], projects: list[Project]
+    args: argparse.Namespace, inputs: PresubmitInputs, projects: list[Project]
 ) -> int:
+    paths = inputs.selected_paths
     if args.print_plan:
-        print_plan(args, paths, projects)
+        print_plan(args, inputs, projects)
 
     ok = True
     if args.hygiene:
@@ -2051,7 +2200,7 @@ def run_presubmit(
         print_section("Static Analysis")
         ok = (
             run_static_analysis(
-                paths, profile=args.profile, lane=args.lane, verbose=args.verbose
+                inputs, profile=args.profile, lane=args.lane, verbose=args.verbose
             )
             and ok
         )
@@ -2059,7 +2208,7 @@ def run_presubmit(
         print_section("clang-tidy")
         ok = (
             run_clang_tidy(
-                paths,
+                inputs,
                 profile=args.profile,
                 lane=args.lane,
                 verbose=args.verbose,
@@ -2072,12 +2221,12 @@ def run_presubmit(
 
 
 def run_presubmit_with_source_guard(
-    args: argparse.Namespace, paths: list[str], projects: list[Project]
+    args: argparse.Namespace, inputs: PresubmitInputs, projects: list[Project]
 ) -> int:
     snapshot = NonEmptyTrackedFileSnapshot.capture_tracked_package_initializers(
         REPO_ROOT
     )
-    result = run_presubmit(args, paths, projects)
+    result = run_presubmit(args, inputs, projects)
     if not snapshot.verify(REPO_ROOT):
         result = 1
     return result
@@ -2085,12 +2234,12 @@ def run_presubmit_with_source_guard(
 
 def main() -> int:
     args = parse_arguments()
-    paths = selected_files(args)
-    projects = projects_for_paths(paths)
+    inputs = presubmit_inputs(args)
+    projects = projects_for_paths(inputs.selected_paths)
     if args.fix:
         with source_mutation_lock(REPO_ROOT, "root-presubmit-fix"):
-            return run_presubmit_with_source_guard(args, paths, projects)
-    return run_presubmit_with_source_guard(args, paths, projects)
+            return run_presubmit_with_source_guard(args, inputs, projects)
+    return run_presubmit_with_source_guard(args, inputs, projects)
 
 
 if __name__ == "__main__":

--- a/build_tools/lefthook/presubmit_test.py
+++ b/build_tools/lefthook/presubmit_test.py
@@ -25,6 +25,21 @@ sys.modules[PRESUBMIT_SPEC.name] = presubmit
 PRESUBMIT_SPEC.loader.exec_module(presubmit)
 
 
+def input_scope(
+    paths: list[str],
+    *,
+    mode: str = "explicit",
+    changed_paths: list[str] | None = None,
+    tracked_paths: list[str] | None = None,
+) -> presubmit.PresubmitInputs:
+    return presubmit.PresubmitInputs(
+        mode=mode,
+        selected_paths=paths,
+        changed_paths=changed_paths if changed_paths is not None else paths,
+        tracked_paths=tracked_paths,
+    )
+
+
 class PresubmitTest(unittest.TestCase):
     def test_semgrep_candidates_require_configured_prefix_and_extension(self):
         with (
@@ -121,13 +136,16 @@ class PresubmitTest(unittest.TestCase):
     def test_clang_tidy_candidates_require_configured_prefix_and_extension(self):
         with (
             mock.patch.object(presubmit, "CLANG_TIDY_PATH_PREFIXES", ("project/src/",)),
-            mock.patch.object(presubmit, "CLANG_TIDY_EXTENSIONS", {".c", ".h"}),
+            mock.patch.object(presubmit, "CLANG_TIDY_EXTENSIONS", {".c", ".h", ".inl"}),
         ):
             self.assertTrue(
                 presubmit.is_clang_tidy_candidate_file("project/src/file.c")
             )
             self.assertTrue(
                 presubmit.is_clang_tidy_candidate_file("project/src/file.h")
+            )
+            self.assertTrue(
+                presubmit.is_clang_tidy_candidate_file("project/src/file.inl")
             )
             self.assertFalse(
                 presubmit.is_clang_tidy_candidate_file("project/src/file.py")
@@ -165,6 +183,19 @@ class PresubmitTest(unittest.TestCase):
             command,
         )
         self.assertIn("--build_event_json_file=.tmp/fixes/build_events.json", command)
+
+    def test_clang_tidy_bazel_command_can_use_local_output_groups(self):
+        command = presubmit.clang_tidy_bazel_command(
+            ["//runtime/src/iree/base:all"],
+            emit_fixes=True,
+            local_outputs=True,
+        )
+
+        self.assertIn("--aspects_parameters=emit_fixes=true", command)
+        self.assertIn(
+            "--output_groups=iree_clang_tidy_local_reports,iree_clang_tidy_local_fixes",
+            command,
+        )
 
     def test_clang_tidy_fix_paths_filter_to_selected_translation_units(self):
         fix_paths = [
@@ -269,7 +300,7 @@ class PresubmitTest(unittest.TestCase):
             ),
         ):
             ok = presubmit.run_clang_tidy(
-                ["runtime/src/iree/base/status.c"],
+                input_scope(["runtime/src/iree/base/status.c"]),
                 profile="paranoid",
                 lane="bazel",
                 verbose=False,
@@ -291,7 +322,7 @@ class PresubmitTest(unittest.TestCase):
             ),
         ):
             ok = presubmit.run_clang_tidy(
-                ["runtime/src/iree/base/status.c"],
+                input_scope(["runtime/src/iree/base/status.c"]),
                 profile="ci",
                 lane="bazel",
                 verbose=False,
@@ -313,7 +344,9 @@ class PresubmitTest(unittest.TestCase):
             ) as run_command,
         ):
             ok = presubmit.run_clang_tidy(
-                ["build_tools/bazel/test/cc_benchmark_smoke_test_fixture.c"],
+                input_scope(
+                    ["build_tools/bazel/test/cc_benchmark_smoke_test_fixture.c"]
+                ),
                 profile="paranoid",
                 lane="bazel",
                 verbose=False,
@@ -322,6 +355,9 @@ class PresubmitTest(unittest.TestCase):
         self.assertTrue(ok)
         command = run_command.call_args.args[0]
         self.assertNotIn("--keep_going", command)
+        self.assertIn(
+            f"--output_groups={presubmit.CLANG_TIDY_LOCAL_OUTPUT_GROUP}", command
+        )
         self.assertIn("//build_tools/bazel/test:all", command)
 
     def test_clang_tidy_ci_runs_bazel_packages_keep_going(self):
@@ -337,7 +373,9 @@ class PresubmitTest(unittest.TestCase):
             ) as run_command,
         ):
             ok = presubmit.run_clang_tidy(
-                ["build_tools/bazel/test/cc_benchmark_smoke_test_fixture.c"],
+                input_scope(
+                    ["build_tools/bazel/test/cc_benchmark_smoke_test_fixture.c"]
+                ),
                 profile="ci",
                 lane="bazel",
                 verbose=False,
@@ -346,7 +384,93 @@ class PresubmitTest(unittest.TestCase):
         self.assertTrue(ok)
         command = run_command.call_args.args[0]
         self.assertIn("--keep_going", command)
+        self.assertIn(
+            f"--output_groups={presubmit.CLANG_TIDY_LOCAL_OUTPUT_GROUP}", command
+        )
         self.assertIn("//build_tools/bazel/test:all", command)
+
+    def test_clang_tidy_base_implementation_scope_stays_bounded(self):
+        inputs = input_scope(
+            ["runtime/src/iree/base/status.c"],
+            mode="base",
+            tracked_paths=[
+                "runtime/src/iree/base/status.c",
+                "runtime/src/iree/base/allocator.c",
+            ],
+        )
+
+        self.assertEqual(
+            presubmit.clang_tidy_analysis_paths(inputs),
+            ["runtime/src/iree/base/status.c"],
+        )
+
+    def test_clang_tidy_base_header_scope_escalates_to_full(self):
+        inputs = input_scope(
+            ["runtime/src/iree/base/status.h"],
+            mode="base",
+            tracked_paths=[
+                "runtime/src/iree/base/status.c",
+                "runtime/src/iree/base/status.h",
+                "runtime/src/iree/base/allocator.c",
+            ],
+        )
+
+        self.assertEqual(
+            presubmit.clang_tidy_analysis_paths(inputs),
+            [
+                "runtime/src/iree/base/status.c",
+                "runtime/src/iree/base/status.h",
+                "runtime/src/iree/base/allocator.c",
+            ],
+        )
+
+    def test_clang_tidy_base_inl_scope_escalates_to_full(self):
+        inputs = input_scope(
+            ["runtime/src/iree/base/table.inl"],
+            mode="base",
+            tracked_paths=[
+                "runtime/src/iree/base/status.c",
+                "runtime/src/iree/base/table.inl",
+            ],
+        )
+
+        self.assertEqual(
+            presubmit.clang_tidy_analysis_paths(inputs),
+            [
+                "runtime/src/iree/base/status.c",
+                "runtime/src/iree/base/table.inl",
+            ],
+        )
+
+    def test_clang_tidy_base_infra_scope_escalates_and_runs_plugin_tests(self):
+        inputs = input_scope(
+            ["build_tools/clang_tidy/iree/IreeTidyModule.cc"],
+            mode="base",
+            tracked_paths=[
+                "runtime/src/iree/base/status.c",
+                "build_tools/clang_tidy/iree/IreeTidyModule.cc",
+            ],
+        )
+        with (
+            mock.patch.object(
+                presubmit, "clang_tidy_llvm_available", return_value=True
+            ),
+            mock.patch.object(
+                presubmit, "run_command", return_value=True
+            ) as run_command,
+        ):
+            ok = presubmit.run_clang_tidy(
+                inputs,
+                profile="paranoid",
+                lane="bazel",
+                verbose=False,
+            )
+
+        self.assertTrue(ok)
+        plugin_test_command = run_command.call_args_list[0].args[0]
+        self.assertIn("//build_tools/clang_tidy:plugin_smoke_test", plugin_test_command)
+        clang_tidy_command = run_command.call_args_list[-1].args[0]
+        self.assertIn("//runtime/src/iree/base:all", clang_tidy_command)
 
     def test_clang_tidy_infra_runs_plugin_tests(self):
         with (
@@ -358,7 +482,7 @@ class PresubmitTest(unittest.TestCase):
             ) as run_command,
         ):
             ok = presubmit.run_clang_tidy(
-                ["build_tools/clang_tidy/iree/IreeTidyModule.cc"],
+                input_scope(["build_tools/clang_tidy/iree/IreeTidyModule.cc"]),
                 profile="paranoid",
                 lane="bazel",
                 verbose=False,
@@ -373,7 +497,7 @@ class PresubmitTest(unittest.TestCase):
 
     def test_default_profile_has_no_static_analysis_provider(self):
         ok = presubmit.run_static_analysis(
-            ["runtime/src/iree/base/status.c"],
+            input_scope(["runtime/src/iree/base/status.c"]),
             profile="default",
             lane="bazel",
             verbose=False,


### PR DESCRIPTION
Optimizes the clang-tidy presubmit path by separating PR changed paths from the analysis scope and by adding local Bazel clang-tidy output groups.

Pull request CI now passes the PR base SHA into dev.py presubmit. Static-analysis providers receive structured input with selected paths, changed paths, and the tracked tree available separately, so tools can choose changed-scope execution, conservative full-scope escalation, or skip behavior without each tool owning Git diff plumbing.

clang-tidy now keeps implementation-only base-mode runs bounded to selected owning packages, while base-mode changes to Bazel/build/tooling inputs, clang-tidy infra, or header-like runtime inputs including .inl/.inc/.def still escalate to full analysis. Provider-selected Bazel runs request local report/fix output groups, avoiding transitive dependency report materialization while preserving the existing transitive behavior for explicit Bazel target-pattern clang-tidy commands.