### PR TITLE
Fix HRX HIP graph lifecycle query semantics

### DIFF
--- a/libhrx/src/binding/common/graph.c
+++ b/libhrx/src/binding/common/graph.c
@@ -46,7 +46,6 @@ iree_status_t iree_hal_streaming_graph_create(
   graph->flags = flags;
   graph->context = context;
   iree_hal_streaming_context_retain(context);
-  iree_slim_mutex_initialize(&graph->mutex);
   graph->host_allocator = host_allocator;
 
   *out_graph = graph;
@@ -64,9 +63,6 @@ static void iree_hal_streaming_graph_destroy(
 
   // Release context.
   iree_hal_streaming_context_release(graph->context);
-
-  // Deinitialize synchronization.
-  iree_slim_mutex_deinitialize(&graph->mutex);
 
   // Free graph memory itself (not allocated from arena).
   const iree_allocator_t host_allocator = graph->host_allocator;
@@ -166,8 +162,7 @@ static bool iree_hal_streaming_graph_remove_from_blocks(
 }
 
 static void iree_hal_streaming_graph_remove_dependency_refs(
-    iree_hal_streaming_graph_t* graph,
-    iree_hal_streaming_graph_node_t* node) {
+    iree_hal_streaming_graph_t* graph, iree_hal_streaming_graph_node_t* node) {
   for (iree_hal_streaming_node_block_t* block = graph->node_blocks; block;
        block = block->next) {
     for (iree_host_size_t i = 0; i < block->count; ++i) {
@@ -189,8 +184,7 @@ static void iree_hal_streaming_graph_remove_dependency_refs(
 }
 
 static void iree_hal_streaming_graph_remove_additional_edges(
-    iree_hal_streaming_graph_t* graph,
-    iree_hal_streaming_graph_node_t* node) {
+    iree_hal_streaming_graph_t* graph, iree_hal_streaming_graph_node_t* node) {
   iree_hal_streaming_graph_edge_t** next_edge = &graph->additional_edges;
   while (*next_edge) {
     iree_hal_streaming_graph_edge_t* edge = *next_edge;
@@ -585,11 +579,10 @@ iree_status_t iree_hal_streaming_graph_add_dependencies(
     if (!iree_hal_streaming_graph_node_is_active_in_graph(graph, from_node) ||
         !iree_hal_streaming_graph_node_is_active_in_graph(graph, to_node)) {
       IREE_TRACE_ZONE_END(z0);
-      return iree_make_status(
-          IREE_STATUS_INVALID_ARGUMENT,
-          "dependency node at index %" PRIhsz
-          " does not belong to the target graph",
-          i);
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "dependency node at index %" PRIhsz
+                              " does not belong to the target graph",
+                              i);
     }
     if (iree_hal_streaming_graph_dependency_exists(graph, from_node, to_node)) {
       IREE_TRACE_ZONE_END(z0);
@@ -638,8 +631,6 @@ iree_status_t iree_hal_streaming_graph_destroy_node(
   iree_hal_streaming_graph_t* graph = node->graph;
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_slim_mutex_lock(&graph->mutex);
-
   iree_hal_streaming_graph_remove_dependency_refs(graph, node);
   iree_hal_streaming_graph_remove_additional_edges(graph, node);
 
@@ -657,7 +648,6 @@ iree_status_t iree_hal_streaming_graph_destroy_node(
     node->dependency_count = 0;
   }
 
-  iree_slim_mutex_unlock(&graph->mutex);
   IREE_TRACE_ZONE_END(z0);
 
   if (!removed_from_nodes) {
@@ -686,15 +676,12 @@ iree_status_t iree_hal_streaming_graph_instantiate(
       z0, iree_hal_streaming_graph_exec_create(graph->context, graph, flags,
                                                graph->host_allocator, &exec));
 
-  // Mutex needed for instantiate per CUDA docs.
-  iree_slim_mutex_lock(&graph->mutex);
-
-  // Instantiate the graph exec on the given context and with our nodes.
-  // NOTE: this must happen under the graph lock (so nodes cannot change).
-  iree_status_t status = iree_hal_streaming_graph_exec_instantiate_locked(
-      exec, graph->node_blocks, graph->node_count);
-
-  iree_slim_mutex_unlock(&graph->mutex);
+  // Instantiate from the graph template. HIP/CUDA graph objects are not
+  // internally synchronized; callers must externally serialize access to a
+  // graph while it is being modified, queried, or instantiated.
+  iree_status_t status =
+      iree_hal_streaming_graph_exec_instantiate_from_template(
+          exec, graph->node_blocks, graph->node_count);
 
   if (iree_status_is_ok(status)) {
     *out_exec = exec;

--- a/libhrx/src/binding/common/graph.c
+++ b/libhrx/src/binding/common/graph.c
@@ -41,6 +41,8 @@ iree_status_t iree_hal_streaming_graph_create(
   graph->root_blocks = NULL;
   graph->current_root_block = NULL;
   graph->root_count = 0;
+  graph->additional_edges = NULL;
+  graph->additional_edge_count = 0;
   graph->flags = flags;
   graph->context = context;
   iree_hal_streaming_context_retain(context);
@@ -115,6 +117,92 @@ void iree_hal_streaming_graph_get_nodes(
   }
 }
 
+static void iree_hal_streaming_graph_renumber_nodes(
+    iree_hal_streaming_graph_t* graph) {
+  uint32_t node_index = 0;
+  for (iree_hal_streaming_node_block_t* block = graph->node_blocks; block;
+       block = block->next) {
+    for (iree_host_size_t i = 0; i < block->count; ++i) {
+      block->nodes[i]->node_index = node_index++;
+    }
+  }
+}
+
+static bool iree_hal_streaming_graph_node_is_active_in_graph(
+    const iree_hal_streaming_graph_t* graph,
+    const iree_hal_streaming_graph_node_t* node) {
+  return node && node->graph == graph;
+}
+
+static bool iree_hal_streaming_graph_dependency_exists(
+    const iree_hal_streaming_graph_t* graph,
+    const iree_hal_streaming_graph_node_t* from_node,
+    const iree_hal_streaming_graph_node_t* to_node) {
+  for (uint32_t i = 0; i < to_node->dependency_count; ++i) {
+    if (to_node->dependencies[i] == from_node) return true;
+  }
+  for (iree_hal_streaming_graph_edge_t* edge = graph->additional_edges; edge;
+       edge = edge->next) {
+    if (edge->from == from_node && edge->to == to_node) return true;
+  }
+  return false;
+}
+
+static bool iree_hal_streaming_graph_remove_from_blocks(
+    iree_hal_streaming_node_block_t* blocks,
+    iree_hal_streaming_graph_node_t* node) {
+  for (iree_hal_streaming_node_block_t* block = blocks; block;
+       block = block->next) {
+    for (iree_host_size_t i = 0; i < block->count; ++i) {
+      if (block->nodes[i] != node) continue;
+      for (iree_host_size_t j = i + 1; j < block->count; ++j) {
+        block->nodes[j - 1] = block->nodes[j];
+      }
+      --block->count;
+      return true;
+    }
+  }
+  return false;
+}
+
+static void iree_hal_streaming_graph_remove_dependency_refs(
+    iree_hal_streaming_graph_t* graph,
+    iree_hal_streaming_graph_node_t* node) {
+  for (iree_hal_streaming_node_block_t* block = graph->node_blocks; block;
+       block = block->next) {
+    for (iree_host_size_t i = 0; i < block->count; ++i) {
+      iree_hal_streaming_graph_node_t* existing_node = block->nodes[i];
+      uint32_t dependency_index = 0;
+      while (dependency_index < existing_node->dependency_count) {
+        if (existing_node->dependencies[dependency_index] != node) {
+          ++dependency_index;
+          continue;
+        }
+        for (uint32_t j = dependency_index + 1;
+             j < existing_node->dependency_count; ++j) {
+          existing_node->dependencies[j - 1] = existing_node->dependencies[j];
+        }
+        --existing_node->dependency_count;
+      }
+    }
+  }
+}
+
+static void iree_hal_streaming_graph_remove_additional_edges(
+    iree_hal_streaming_graph_t* graph,
+    iree_hal_streaming_graph_node_t* node) {
+  iree_hal_streaming_graph_edge_t** next_edge = &graph->additional_edges;
+  while (*next_edge) {
+    iree_hal_streaming_graph_edge_t* edge = *next_edge;
+    if (edge->from == node || edge->to == node) {
+      *next_edge = edge->next;
+      --graph->additional_edge_count;
+      continue;
+    }
+    next_edge = &edge->next;
+  }
+}
+
 // Helper to allocate a graph node with trailing dependencies and extra data.
 static iree_status_t iree_hal_streaming_graph_allocate_node(
     iree_allocator_t allocator, iree_host_size_t dependency_count,
@@ -180,6 +268,7 @@ static iree_status_t iree_hal_streaming_graph_add_node(
     iree_hal_streaming_graph_t* graph, iree_hal_streaming_graph_node_t* node) {
   // Assign unique index to the node that can be used to get the logical index
   // in the graph for use as dependency references.
+  node->graph = graph;
   node->node_index = (uint32_t)graph->node_count;
 
   // Add to node blocks.
@@ -472,18 +561,52 @@ iree_status_t iree_hal_streaming_graph_add_dependencies(
     iree_hal_streaming_graph_node_t** to_nodes, iree_host_size_t count) {
   IREE_ASSERT_ARGUMENT(graph);
   if (count == 0) return iree_ok_status();
-  IREE_ASSERT_ARGUMENT(from_nodes);
-  IREE_ASSERT_ARGUMENT(to_nodes);
+  if (!from_nodes || !to_nodes) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "dependency arrays must be provided");
+  }
   IREE_TRACE_ZONE_BEGIN(z0);
 
   for (iree_host_size_t i = 0; i < count; ++i) {
-    if (!from_nodes[i] || !to_nodes[i]) {
+    iree_hal_streaming_graph_node_t* from_node = from_nodes[i];
+    iree_hal_streaming_graph_node_t* to_node = to_nodes[i];
+    if (!from_node || !to_node) {
       IREE_TRACE_ZONE_END(z0);
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                               "null node in dependency list at index %" PRIhsz,
                               i);
     }
+    if (from_node == to_node) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "node cannot depend on itself at index %" PRIhsz,
+                              i);
+    }
+    if (!iree_hal_streaming_graph_node_is_active_in_graph(graph, from_node) ||
+        !iree_hal_streaming_graph_node_is_active_in_graph(graph, to_node)) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "dependency node at index %" PRIhsz
+          " does not belong to the target graph",
+          i);
+    }
+    if (iree_hal_streaming_graph_dependency_exists(graph, from_node, to_node)) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "duplicate dependency at index %" PRIhsz, i);
+    }
+    for (iree_host_size_t j = 0; j < i; ++j) {
+      if (from_nodes[j] == from_node && to_nodes[j] == to_node) {
+        IREE_TRACE_ZONE_END(z0);
+        return iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "duplicate dependency within request at index %" PRIhsz, i);
+      }
+    }
+  }
 
+  for (iree_host_size_t i = 0; i < count; ++i) {
     // Allocate edge from arena.
     iree_hal_streaming_graph_edge_t* edge = NULL;
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
@@ -503,6 +626,44 @@ iree_status_t iree_hal_streaming_graph_add_dependencies(
   }
 
   IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_streaming_graph_destroy_node(
+    iree_hal_streaming_graph_node_t* node) {
+  if (!node || !node->graph) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "node must belong to an active graph");
+  }
+  iree_hal_streaming_graph_t* graph = node->graph;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_slim_mutex_lock(&graph->mutex);
+
+  iree_hal_streaming_graph_remove_dependency_refs(graph, node);
+  iree_hal_streaming_graph_remove_additional_edges(graph, node);
+
+  const bool removed_from_nodes =
+      iree_hal_streaming_graph_remove_from_blocks(graph->node_blocks, node);
+  if (removed_from_nodes) {
+    --graph->node_count;
+  }
+  if (iree_hal_streaming_graph_remove_from_blocks(graph->root_blocks, node)) {
+    --graph->root_count;
+  }
+  if (removed_from_nodes) {
+    iree_hal_streaming_graph_renumber_nodes(graph);
+    node->graph = NULL;
+    node->dependency_count = 0;
+  }
+
+  iree_slim_mutex_unlock(&graph->mutex);
+  IREE_TRACE_ZONE_END(z0);
+
+  if (!removed_from_nodes) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "node not found in owning graph");
+  }
   return iree_ok_status();
 }
 

--- a/libhrx/src/binding/common/graph.h
+++ b/libhrx/src/binding/common/graph.h
@@ -58,9 +58,6 @@ typedef struct iree_hal_streaming_graph_t {
   uint32_t flags;
   iree_hal_streaming_context_t* context;
 
-  // Mutex only needed for instantiate/clone operations per CUDA docs.
-  iree_slim_mutex_t mutex;
-
   iree_allocator_t host_allocator;
 } iree_hal_streaming_graph_t;
 
@@ -99,7 +96,7 @@ iree_status_t iree_hal_streaming_graph_exec_create(
     iree_allocator_t host_allocator,
     iree_hal_streaming_graph_exec_t** out_exec);
 
-iree_status_t iree_hal_streaming_graph_exec_instantiate_locked(
+iree_status_t iree_hal_streaming_graph_exec_instantiate_from_template(
     iree_hal_streaming_graph_exec_t* exec,
     iree_hal_streaming_node_block_t* node_blocks, iree_host_size_t node_count);
 

--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -754,7 +754,7 @@ static iree_status_t iree_hal_streaming_graph_record_partition(
   return status;
 }
 
-iree_status_t iree_hal_streaming_graph_exec_instantiate_locked(
+iree_status_t iree_hal_streaming_graph_exec_instantiate_from_template(
     iree_hal_streaming_graph_exec_t* exec,
     iree_hal_streaming_node_block_t* node_blocks, iree_host_size_t node_count) {
   IREE_ASSERT_ARGUMENT(exec);

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -785,10 +785,13 @@ typedef struct iree_hal_streaming_graph_host_call_node_attrs_t {
 // [padding to iree_max_align_t]
 // [extra_data (e.g., packed kernel arguments)]
 typedef struct iree_hal_streaming_graph_node_t {
+  // Graph that owns the node while it remains part of a graph template.
+  iree_hal_streaming_graph_t* graph;
   // Type of the node indicating which attribute data is valid.
   iree_hal_streaming_graph_node_type_t type;
-  // Unique index assigned when added to graph.
+  // Dense index used by graph analysis while the node is active.
   uint32_t node_index;
+  // Number of embedded dependency pointers in |dependencies|.
   uint32_t dependency_count;
 
   // Node-specific data.
@@ -1434,6 +1437,9 @@ iree_status_t iree_hal_streaming_graph_add_host_call_node(
     iree_hal_streaming_graph_node_t** dependencies,
     iree_host_size_t dependency_count, void (*fn)(void*), void* user_data,
     iree_hal_streaming_graph_node_t** out_node);
+
+iree_status_t iree_hal_streaming_graph_destroy_node(
+    iree_hal_streaming_graph_node_t* node);
 
 // Synchronization: none (creates executable graph).
 iree_status_t iree_hal_streaming_graph_instantiate(

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -10875,12 +10875,18 @@ HIPAPI hipError_t hipGraphGetNodes(hipGraph_t graph, hipGraphNode_t* pNodes,
   // Get nodes from the graph (up to the requested count).
   if (pNodes != NULL) {
     const size_t requested_count = *numNodes;
+    const size_t copied_count =
+        total_count < requested_count ? total_count : requested_count;
     iree_hal_streaming_graph_get_nodes(
         stream_graph, requested_count,
         (iree_hal_streaming_graph_node_t**)pNodes);
+    for (size_t i = copied_count; i < requested_count; ++i) {
+      pNodes[i] = NULL;
+    }
+    *numNodes = copied_count;
+  } else {
+    *numNodes = total_count;
   }
-
-  *numNodes = total_count;
   IREE_TRACE_ZONE_END(z0);
   return hipSuccess;
 }
@@ -11058,18 +11064,46 @@ HIPAPI hipError_t hipGraphNodeGetDependentNodes(hipGraphNode_t node,
   return hipSuccess;
 }
 
+static hipGraphNodeType hip_graph_node_type_from_streaming_type(
+    iree_hal_streaming_graph_node_type_t type) {
+  switch (type) {
+    case IREE_HAL_STREAMING_GRAPH_NODE_TYPE_KERNEL:
+      return hipGraphNodeTypeKernel;
+    case IREE_HAL_STREAMING_GRAPH_NODE_TYPE_MEMCPY:
+      return hipGraphNodeTypeMemcpy;
+    case IREE_HAL_STREAMING_GRAPH_NODE_TYPE_MEMSET:
+      return hipGraphNodeTypeMemset;
+    case IREE_HAL_STREAMING_GRAPH_NODE_TYPE_HOST_CALL:
+      return hipGraphNodeTypeHost;
+    case IREE_HAL_STREAMING_GRAPH_NODE_TYPE_GRAPH:
+      return hipGraphNodeTypeGraph;
+    case IREE_HAL_STREAMING_GRAPH_NODE_TYPE_EMPTY:
+    default:
+      return hipGraphNodeTypeEmpty;
+  }
+}
+
 // Gets the type of a node.
 HIPAPI hipError_t hipGraphNodeGetType(hipGraphNode_t node,
                                       hipGraphNodeType* pType) {
-  (void)node;
-  if (pType) *pType = hipGraphNodeTypeEmpty;
+  if (!node || !pType) {
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+  iree_hal_streaming_graph_node_t* stream_node =
+      (iree_hal_streaming_graph_node_t*)node;
+  if (!stream_node->graph) {
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+  *pType = hip_graph_node_type_from_streaming_type(stream_node->type);
   return hipSuccess;
 }
 
 // Destroys a graph node.
 HIPAPI hipError_t hipGraphDestroyNode(hipGraphNode_t node) {
-  (void)node;
-  return hipSuccess;  // No-op since we don't track nodes individually
+  HIP_RETURN_STATUS(iree_hal_streaming_graph_destroy_node(
+                        (iree_hal_streaming_graph_node_t*)node),
+                    hipErrorInvalidValue);
+  return hipSuccess;
 }
 
 // Clones a graph.


### PR DESCRIPTION
HRX treated several HIP graph lifecycle APIs as shallow stubs: hipGraphNodeGetType always reported an empty node, hipGraphDestroyNode was a no-op, dependency insertion trusted caller-owned node handles, and hipGraphGetNodes always returned the total graph size even when the caller supplied a smaller output buffer. Those APIs expose graph-template structure directly, so the runtime needs to preserve node membership, liveness, dependency identity, and query counts consistently while the graph is being edited.

Track the owning graph on each template node while it is active, validate added dependency edges before mutating the graph, reject null/self/duplicate/cross-graph dependencies, and keep separately-added edges visible to duplicate detection. Implement node destruction by removing the node from graph/root node lists, dropping dependency references and extra edges that mention it, clearing its owning graph, and renumbering the remaining active nodes so query order stays dense.

Also map HRX internal node kinds back to HIP graph node types and make hipGraphGetNodes follow native small-buffer behavior: copy only the requested number of nodes, report the copied count, and clear the unused tail when the caller asks for more entries than exist. This makes graph lifecycle/query behavior deterministic and prevents destroyed or foreign nodes from remaining observable through later graph queries.