### PR TITLE
[Infra] Harden IREE C contracts with clang-tidy

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,6 @@
+build
+.tmp
+.venv
+.notes
+.beads
+history

--- a/build_tools/clang_tidy/BUILD.bazel
+++ b/build_tools/clang_tidy/BUILD.bazel
@@ -97,6 +97,7 @@ py_test(
     ],
     data = [
         "test/status_checks.c",
+        "test/status_checks.cc",
         ":IREEClangTidyPlugin.so",
         "@iree_clang_tidy_llvm//:clang-tidy",
     ],

--- a/build_tools/clang_tidy/BUILD.bazel
+++ b/build_tools/clang_tidy/BUILD.bazel
@@ -53,6 +53,8 @@ cc_binary(
         "iree/SmokeCheck.h",
         "iree/StatusChecks.cc",
         "iree/StatusChecks.h",
+        "iree/TraceChecks.cc",
+        "iree/TraceChecks.h",
     ],
     copts = CLANG_TIDY_LLVM_COPTS,
     includes = ["."],
@@ -103,6 +105,27 @@ py_test(
     ],
     imports = ["test"],
     main = "test/status_checks_test.py",
+    tags = ["manual"],
+    target_compatible_with = CLANG_TIDY_LLVM_TARGET_COMPATIBLE_WITH,
+)
+
+py_test(
+    name = "trace_checks_test",
+    srcs = [
+        "test/clang_tidy_test.py",
+        "test/trace_checks_test.py",
+    ],
+    args = [
+        "--clang-tidy=$(location @iree_clang_tidy_llvm//:clang-tidy)",
+        "--plugin=$(location :IREEClangTidyPlugin.so)",
+    ],
+    data = [
+        "test/trace_checks.c",
+        ":IREEClangTidyPlugin.so",
+        "@iree_clang_tidy_llvm//:clang-tidy",
+    ],
+    imports = ["test"],
+    main = "test/trace_checks_test.py",
     tags = ["manual"],
     target_compatible_with = CLANG_TIDY_LLVM_TARGET_COMPATIBLE_WITH,
 )

--- a/build_tools/clang_tidy/CMakeLists.txt
+++ b/build_tools/clang_tidy/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(IREEClangTidyPlugin MODULE
   iree/IreeTidyModule.cc
   iree/SmokeCheck.cc
   iree/StatusChecks.cc
+  iree/TraceChecks.cc
 )
 
 target_include_directories(IREEClangTidyPlugin
@@ -73,6 +74,15 @@ add_test(
   COMMAND
     Python3::Interpreter
     "${CMAKE_CURRENT_SOURCE_DIR}/test/status_checks_test.py"
+    "--clang-tidy=${CLANG_TIDY_EXECUTABLE}"
+    "--plugin=$<TARGET_FILE:IREEClangTidyPlugin>"
+)
+
+add_test(
+  NAME iree-clang-tidy-trace-checks
+  COMMAND
+    Python3::Interpreter
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/trace_checks_test.py"
     "--clang-tidy=${CLANG_TIDY_EXECUTABLE}"
     "--plugin=$<TARGET_FILE:IREEClangTidyPlugin>"
 )

--- a/build_tools/clang_tidy/README.md
+++ b/build_tools/clang_tidy/README.md
@@ -31,7 +31,8 @@ file, and writes a per-source report:
 
 ```bash
 iree-bazel-test --repo_env=IREE_CLANG_TIDY_LLVM=auto \
-  //build_tools/clang_tidy:status_checks_test
+  //build_tools/clang_tidy:status_checks_test \
+  //build_tools/clang_tidy:trace_checks_test
 ```
 
 ## CMake
@@ -101,3 +102,32 @@ returns, `if` branches, status helper calls, C++ status wrappers, and known
 status-owning callback boundaries are checked directly. Loop-carried status
 variables and functions with `goto` cleanup paths are treated conservatively so
 diagnostics remain high signal.
+
+### `iree-trace-zone-balance`
+
+`iree-trace-zone-balance` treats trace zones as scoped C resources around
+status-return helper macros. A status-returning helper used inside an active
+zone must use the trace-zone-aware form so the failure path ends the zone:
+
+```c
+IREE_TRACE_ZONE_BEGIN(z0);
+IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, do_work());
+IREE_TRACE_ZONE_END(z0);
+return iree_ok_status();
+```
+
+Plain early-return helpers inside an active zone are diagnosed because their
+failure path skips the end macro:
+
+```c
+IREE_TRACE_ZONE_BEGIN(z0);
+IREE_RETURN_IF_ERROR(do_work());  // Use IREE_RETURN_AND_END_ZONE_IF_ERROR.
+IREE_TRACE_ZONE_END(z0);
+return iree_ok_status();
+```
+
+The check uses the preprocessor's macro expansion stream so disabled tracing,
+HRX wrapper macros, and multi-line helper invocations are modeled by the macro
+the developer wrote rather than by the helper's implementation detail. General
+proof of arbitrary `return` statements and block-local zone balance is handled
+conservatively to keep this check high signal.

--- a/build_tools/clang_tidy/README.md
+++ b/build_tools/clang_tidy/README.md
@@ -140,6 +140,41 @@ status-owning callback boundaries are checked directly. Loop-carried status
 variables and functions with `goto` cleanup paths are treated conservatively so
 diagnostics remain high signal.
 
+### `iree-status-transfer-order`
+
+`iree-status-transfer-order` diagnoses full expressions where the same local
+`iree_status_t` appears more than once and at least one occurrence transfers
+ownership:
+
+```c
+return iree_status_join(status, status);
+return iree_status_join(status, notify_failure(status));
+```
+
+C does not sequence function argument evaluation. In the second example, either
+argument can be evaluated first, so one path can consume or replace the status
+while the other path still tries to use the old owned value. The reliable shape
+is explicit sequencing through owned temporaries:
+
+```c
+iree_status_t notify_status = notify_failure(status);
+return iree_status_join(status, notify_status);
+```
+
+When two independent consumers intentionally need the same failure payload, clone
+first and give each owner one status value:
+
+```c
+iree_status_t cloned_status = iree_status_clone(status);
+iree_status_t notify_status = notify_failure(cloned_status);
+return iree_status_join(status, notify_status);
+```
+
+The check is local and syntactic by design. It models known status consumers,
+status transfer helpers, C++ status wrapper constructors, and status observer
+functions. Pure observer expressions such as multiple `iree_status_is_*` checks
+do not transfer ownership and are accepted.
+
 ### `iree-trace-zone-balance`
 
 `iree-trace-zone-balance` treats trace zones as scoped C resources around

--- a/build_tools/clang_tidy/README.md
+++ b/build_tools/clang_tidy/README.md
@@ -43,10 +43,12 @@ python dev.py cmake clang-tidy runtime/src/iree/base/status.c
 python dev.py cmake clang-tidy --base origin/main
 ```
 
-The CMake command builds the plugin in `.tmp/iree-clang-tidy-plugin` and runs
-`clang-tidy` against source files using the configured CMake
-`compile_commands.json`. Select the CMake build tree with
-`--cmake-build-dir` or `IREE_CMAKE_BUILD_DIR`.
+The CMake command builds the plugin in `.tmp/iree-clang-tidy-plugin`,
+materializes generated C/C++ compile inputs in the configured CMake build tree,
+and runs `run-clang-tidy` against source files using that build tree's
+`compile_commands.json`. Select the CMake build tree with `--cmake-build-dir`
+or `IREE_CMAKE_BUILD_DIR`. The runner defaults to a capped parallel job count
+and can be tuned with `IREE_CLANG_TIDY_JOBS`.
 
 Plugin-only CMake validation is also available:
 

--- a/build_tools/clang_tidy/README.md
+++ b/build_tools/clang_tidy/README.md
@@ -73,6 +73,43 @@ The status result must be returned, stored for later consumption, or explicitly
 consumed. The check intentionally does not reason about whether a callee is
 infallible; if the function returns `iree_status_t`, the caller owns that result.
 
+### `iree-status-borrowed-parameter`
+
+`iree-status-borrowed-parameter` diagnoses functions that take an
+`iree_status_t` parameter by value but only observe it:
+
+```c
+static bool is_unavailable(iree_status_t status) {
+  return iree_status_is_unavailable(status);
+}
+```
+
+A by-value `iree_status_t` parameter means the callee participates in ownership.
+The callee must return it, store it into an owning destination, consume it,
+clone it before fanout, or transfer it to another owning status API. Observer
+helpers should expose the non-owning representation they actually need:
+
+```c
+static bool is_unavailable(iree_status_code_t status_code) {
+  return status_code == IREE_STATUS_UNAVAILABLE;
+}
+
+static iree_status_t append_status(iree_string_builder_t* builder,
+                                   const iree_status_t* status) {
+  return iree_status_format_to(*status, append_chunk, builder)
+             ? iree_ok_status()
+             : iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                "failed to format status");
+}
+```
+
+The check intentionally keeps exceptions narrow. Status primitives that define
+the observer API, known status sinks, C++ `iree::Status` formatting internals,
+and documented borrowed callback boundaries are modeled explicitly. Ordinary
+debug/reporting helpers should use `iree_status_code_t`, `const iree_status_t*`,
+or `const iree_status_t&` instead of accepting a by-value status they do not
+own.
+
 ### `iree-status-lifetime`
 
 `iree-status-lifetime` treats local `iree_status_t` variables as owned linear

--- a/build_tools/clang_tidy/README.md
+++ b/build_tools/clang_tidy/README.md
@@ -58,6 +58,8 @@ ctest --test-dir .tmp/iree-clang-tidy-plugin --output-on-failure
 
 ## Checks
 
+### `iree-status-discarded`
+
 `iree-status-discarded` diagnoses calls returning `iree_status_t` when the call
 is used as a bare expression statement, including `(void)` casts:
 
@@ -69,3 +71,33 @@ some_status_returning_function();
 The status result must be returned, stored for later consumption, or explicitly
 consumed. The check intentionally does not reason about whether a callee is
 infallible; if the function returns `iree_status_t`, the caller owns that result.
+
+### `iree-status-lifetime`
+
+`iree-status-lifetime` treats local `iree_status_t` variables as owned linear
+values. The check diagnoses mechanically provable local lifetime errors:
+
+```c
+iree_status_t status = do_work();
+(void)status;  // Status leaves scope unconsumed.
+
+iree_status_t status = do_work();
+status = do_cleanup();  // Overwrites an owned status.
+
+iree_status_t status = do_work();
+iree_status_ignore(status);
+return status;  // Uses a consumed status value.
+```
+
+The accepted terminal actions mirror `runtime/src/iree/base/status.h`: return
+the status, store it into an owning destination, consume it with
+`iree_status_free`/`iree_status_ignore`/`iree_status_consume_code`, or transfer
+it through helpers such as `iree_status_join`, `iree_status_annotate`, and
+`iree_status_freeze` while continuing to own the returned status.
+
+The lifetime model focuses on local ownership states that can be proven from
+the AST with high confidence. Straight-line code, block scope, local transfers,
+returns, `if` branches, status helper calls, C++ status wrappers, and known
+status-owning callback boundaries are checked directly. Loop-carried status
+variables and functions with `goto` cleanup paths are treated conservatively so
+diagnostics remain high signal.

--- a/build_tools/clang_tidy/iree/IreeTidyModule.cc
+++ b/build_tools/clang_tidy/iree/IreeTidyModule.cc
@@ -16,6 +16,7 @@ class IreeTidyModule final : public ClangTidyModule {
   void addCheckFactories(ClangTidyCheckFactories& CheckFactories) override {
     CheckFactories.registerCheck<SmokeCheck>("iree-smoke");
     CheckFactories.registerCheck<DiscardedStatusCheck>("iree-status-discarded");
+    CheckFactories.registerCheck<StatusLifetimeCheck>("iree-status-lifetime");
   }
 };
 

--- a/build_tools/clang_tidy/iree/IreeTidyModule.cc
+++ b/build_tools/clang_tidy/iree/IreeTidyModule.cc
@@ -7,6 +7,7 @@
 #include "clang-tidy/ClangTidyModule.h"
 #include "iree/SmokeCheck.h"
 #include "iree/StatusChecks.h"
+#include "iree/TraceChecks.h"
 
 namespace clang::tidy::iree {
 namespace {
@@ -17,6 +18,7 @@ class IreeTidyModule final : public ClangTidyModule {
     CheckFactories.registerCheck<SmokeCheck>("iree-smoke");
     CheckFactories.registerCheck<DiscardedStatusCheck>("iree-status-discarded");
     CheckFactories.registerCheck<StatusLifetimeCheck>("iree-status-lifetime");
+    CheckFactories.registerCheck<TraceZoneCheck>("iree-trace-zone-balance");
   }
 };
 

--- a/build_tools/clang_tidy/iree/IreeTidyModule.cc
+++ b/build_tools/clang_tidy/iree/IreeTidyModule.cc
@@ -20,6 +20,8 @@ class IreeTidyModule final : public ClangTidyModule {
         "iree-status-borrowed-parameter");
     CheckFactories.registerCheck<DiscardedStatusCheck>("iree-status-discarded");
     CheckFactories.registerCheck<StatusLifetimeCheck>("iree-status-lifetime");
+    CheckFactories.registerCheck<StatusTransferOrderCheck>(
+        "iree-status-transfer-order");
     CheckFactories.registerCheck<TraceZoneCheck>("iree-trace-zone-balance");
   }
 };

--- a/build_tools/clang_tidy/iree/IreeTidyModule.cc
+++ b/build_tools/clang_tidy/iree/IreeTidyModule.cc
@@ -16,6 +16,8 @@ class IreeTidyModule final : public ClangTidyModule {
  public:
   void addCheckFactories(ClangTidyCheckFactories& CheckFactories) override {
     CheckFactories.registerCheck<SmokeCheck>("iree-smoke");
+    CheckFactories.registerCheck<BorrowedStatusParameterCheck>(
+        "iree-status-borrowed-parameter");
     CheckFactories.registerCheck<DiscardedStatusCheck>("iree-status-discarded");
     CheckFactories.registerCheck<StatusLifetimeCheck>("iree-status-lifetime");
     CheckFactories.registerCheck<TraceZoneCheck>("iree-trace-zone-balance");

--- a/build_tools/clang_tidy/iree/StatusChecks.cc
+++ b/build_tools/clang_tidy/iree/StatusChecks.cc
@@ -16,6 +16,7 @@
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace clang::tidy::iree {
 namespace {
@@ -705,6 +706,264 @@ class BorrowedStatusParameterAnalyzer {
   BorrowedStatusParameterCheck& Check_;
   llvm::DenseMap<const VarDecl*, StatusParameterUseState> State_;
   bool FunctionReturnsStatus_ = false;
+};
+
+struct StatusFullExpressionUse {
+  const VarDecl* Var = nullptr;
+  bool Transfers = false;
+  SourceLocation Location;
+};
+
+class StatusTransferOrderAnalyzer {
+ public:
+  explicit StatusTransferOrderAnalyzer(StatusTransferOrderCheck& Check)
+      : Check_(Check) {}
+
+  void analyzeFunction(const FunctionDecl* Function) {
+    if (!Function->hasBody()) {
+      return;
+    }
+    analyzeStatement(Function->getBody());
+  }
+
+ private:
+  void checkFullExpression(const Expr* Expr) {
+    SmallVector<StatusFullExpressionUse, 8> Uses;
+    collectExpressionUses(Expr, /*transferred=*/false, Uses);
+
+    llvm::DenseMap<const VarDecl*, unsigned> Counts;
+    llvm::DenseMap<const VarDecl*, SourceLocation> TransferLocations;
+    for (const StatusFullExpressionUse& Use : Uses) {
+      if (!Use.Var) {
+        continue;
+      }
+      const VarDecl* Var = Use.Var->getCanonicalDecl();
+      Counts[Var] += 1;
+      if (Use.Transfers && !TransferLocations[Var].isValid()) {
+        TransferLocations[Var] = Use.Location;
+      }
+    }
+
+    for (const auto& [Var, Count] : Counts) {
+      SourceLocation TransferLocation = TransferLocations[Var];
+      if (Count < 2 || !TransferLocation.isValid()) {
+        continue;
+      }
+      Check_.diag(TransferLocation,
+                  "iree_status_t %0 is used more than once in one full "
+                  "expression while ownership is transferred; sequence the "
+                  "operations through temporaries or clone before fanout")
+          << Var;
+    }
+  }
+
+  void recordUse(const VarDecl* Var, bool transferred, SourceLocation Location,
+                 SmallVectorImpl<StatusFullExpressionUse>& Uses) {
+    if (!Var) {
+      return;
+    }
+    Uses.push_back(StatusFullExpressionUse{
+        Var->getCanonicalDecl(),
+        transferred,
+        Location,
+    });
+  }
+
+  bool isStatusDestination(const Expr* Expr) const {
+    Expr = IgnoreExprNoise(Expr);
+    return Expr && IsStatusType(Expr->getType());
+  }
+
+  void checkSequencedExpression(const Expr* Expr) { checkFullExpression(Expr); }
+
+  void collectExpressionUses(const Expr* Expr, bool transferred,
+                             SmallVectorImpl<StatusFullExpressionUse>& Uses) {
+    Expr = IgnoreExprNoise(Expr);
+    if (!Expr) {
+      return;
+    }
+
+    if (const VarDecl* Var = ForwardedStatusLocal(Expr)) {
+      recordUse(Var, transferred, Expr->getExprLoc(), Uses);
+      return;
+    }
+    if (const VarDecl* Var = ReferencedStatusLocal(Expr)) {
+      recordUse(Var, transferred, Expr->getExprLoc(), Uses);
+      return;
+    }
+    if (const auto* Cast = dyn_cast<CastExpr>(Expr)) {
+      collectExpressionUses(Cast->getSubExpr(), transferred, Uses);
+      return;
+    }
+    if (const auto* Call = dyn_cast<CallExpr>(Expr)) {
+      collectCallUses(Call, transferred, Uses);
+      return;
+    }
+    if (const auto* Construct = dyn_cast<CXXConstructExpr>(Expr)) {
+      const CXXConstructorDecl* Constructor = Construct->getConstructor();
+      const bool IsStatusWrapper =
+          Constructor && Constructor->getParent() &&
+          (Constructor->getParent()->getName() == "Status" ||
+           Constructor->getParent()->getName() == "StatusOr");
+      for (unsigned I = 0; I < Construct->getNumArgs(); ++I) {
+        collectExpressionUses(Construct->getArg(I),
+                              /*transferred=*/IsStatusWrapper, Uses);
+      }
+      return;
+    }
+    if (const auto* Binary = dyn_cast<BinaryOperator>(Expr)) {
+      if (Binary->getOpcode() == BO_Comma || Binary->getOpcode() == BO_LAnd ||
+          Binary->getOpcode() == BO_LOr) {
+        checkSequencedExpression(Binary->getLHS());
+        checkSequencedExpression(Binary->getRHS());
+        return;
+      }
+      if (Binary->isAssignmentOp()) {
+        collectExpressionUses(
+            Binary->getRHS(),
+            /*transferred=*/isStatusDestination(Binary->getLHS()), Uses);
+        return;
+      }
+      collectExpressionUses(Binary->getLHS(), /*transferred=*/false, Uses);
+      collectExpressionUses(Binary->getRHS(), /*transferred=*/false, Uses);
+      return;
+    }
+    if (const auto* Unary = dyn_cast<UnaryOperator>(Expr)) {
+      collectExpressionUses(Unary->getSubExpr(), transferred, Uses);
+      return;
+    }
+    if (const auto* Conditional = dyn_cast<AbstractConditionalOperator>(Expr)) {
+      checkSequencedExpression(Conditional->getCond());
+      checkSequencedExpression(Conditional->getTrueExpr());
+      checkSequencedExpression(Conditional->getFalseExpr());
+      return;
+    }
+
+    for (const Stmt* Child : Expr->children()) {
+      if (const auto* ChildExpr = dyn_cast_or_null<clang::Expr>(Child)) {
+        collectExpressionUses(ChildExpr, transferred, Uses);
+      }
+    }
+  }
+
+  void collectCallUses(const CallExpr* Call, bool transferred,
+                       SmallVectorImpl<StatusFullExpressionUse>& Uses) {
+    StringRef Name = CalleeName(Call);
+    if (IsKnownStatusConsumer(Name) && Call->getNumArgs() >= 1) {
+      collectExpressionUses(Call->getArg(0), /*transferred=*/true, Uses);
+      for (unsigned I = 1; I < Call->getNumArgs(); ++I) {
+        collectExpressionUses(Call->getArg(I), /*transferred=*/false, Uses);
+      }
+      return;
+    }
+    if (IsKnownStatusTransferProducer(Name)) {
+      for (unsigned I = 0; I < Call->getNumArgs(); ++I) {
+        bool ConsumesArg = Name == "iree_status_join" ? I <= 1 : I == 0;
+        collectExpressionUses(Call->getArg(I), /*transferred=*/ConsumesArg,
+                              Uses);
+      }
+      return;
+    }
+    if (IsKnownStatusClone(Name)) {
+      for (const Expr* Arg : Call->arguments()) {
+        collectExpressionUses(Arg, /*transferred=*/false, Uses);
+      }
+      return;
+    }
+    if (std::optional<unsigned> SinkArg = KnownStatusSinkArgument(Name)) {
+      for (unsigned I = 0; I < Call->getNumArgs(); ++I) {
+        collectExpressionUses(Call->getArg(I), /*transferred=*/I == *SinkArg,
+                              Uses);
+      }
+      return;
+    }
+    if (IsStatusObserver(Name)) {
+      for (const Expr* Arg : Call->arguments()) {
+        collectExpressionUses(Arg, /*transferred=*/false, Uses);
+      }
+      return;
+    }
+
+    for (unsigned I = 0; I < Call->getNumArgs(); ++I) {
+      const Expr* Arg = Call->getArg(I);
+      QualType ParamType;
+      if (const FunctionDecl* Callee = Call->getDirectCallee();
+          Callee && I < Callee->getNumParams()) {
+        ParamType = Callee->getParamDecl(I)->getType();
+      }
+      const bool ArgIsStatus = IsStatusType(Arg->getType()) ||
+                               (!ParamType.isNull() && IsStatusType(ParamType));
+      collectExpressionUses(Arg, /*transferred=*/transferred || ArgIsStatus,
+                            Uses);
+    }
+  }
+
+  void analyzeStatement(const Stmt* Statement) {
+    if (!Statement) {
+      return;
+    }
+    if (const auto* Compound = dyn_cast<CompoundStmt>(Statement)) {
+      for (const Stmt* Child : Compound->body()) {
+        analyzeStatement(Child);
+      }
+      return;
+    }
+    if (const auto* DeclarationStatement = dyn_cast<DeclStmt>(Statement)) {
+      for (const Decl* D : DeclarationStatement->decls()) {
+        const auto* Var = dyn_cast<VarDecl>(D);
+        if (Var && Var->hasInit()) {
+          checkFullExpression(Var->getInit());
+        }
+      }
+      return;
+    }
+    if (const auto* Return = dyn_cast<ReturnStmt>(Statement)) {
+      checkFullExpression(Return->getRetValue());
+      return;
+    }
+    if (const auto* If = dyn_cast<IfStmt>(Statement)) {
+      analyzeStatement(If->getInit());
+      if (const DeclStmt* ConditionVariable =
+              If->getConditionVariableDeclStmt()) {
+        analyzeStatement(ConditionVariable);
+      }
+      checkFullExpression(If->getCond());
+      analyzeStatement(If->getThen());
+      analyzeStatement(If->getElse());
+      return;
+    }
+    if (const auto* For = dyn_cast<ForStmt>(Statement)) {
+      analyzeStatement(For->getInit());
+      checkFullExpression(For->getCond());
+      checkFullExpression(For->getInc());
+      analyzeStatement(For->getBody());
+      return;
+    }
+    if (const auto* While = dyn_cast<WhileStmt>(Statement)) {
+      checkFullExpression(While->getCond());
+      analyzeStatement(While->getBody());
+      return;
+    }
+    if (const auto* Do = dyn_cast<DoStmt>(Statement)) {
+      analyzeStatement(Do->getBody());
+      checkFullExpression(Do->getCond());
+      return;
+    }
+    if (const auto* Switch = dyn_cast<SwitchStmt>(Statement)) {
+      checkFullExpression(Switch->getCond());
+      analyzeStatement(Switch->getBody());
+      return;
+    }
+    if (const auto* ExprStatement = dyn_cast<Expr>(Statement)) {
+      checkFullExpression(ExprStatement);
+      return;
+    }
+    for (const Stmt* Child : Statement->children()) {
+      analyzeStatement(Child);
+    }
+  }
+
+  StatusTransferOrderCheck& Check_;
 };
 
 class StatusLifetimeAnalyzer {
@@ -1535,6 +1794,26 @@ void StatusLifetimeCheck::check(
     return;
   }
   StatusLifetimeAnalyzer Analyzer(*this, *Result.Context);
+  Analyzer.analyzeFunction(Function);
+}
+
+StatusTransferOrderCheck::StatusTransferOrderCheck(StringRef Name,
+                                                   ClangTidyContext* Context)
+    : ClangTidyCheck(Name, Context) {}
+
+void StatusTransferOrderCheck::registerMatchers(
+    ast_matchers::MatchFinder* Finder) {
+  using namespace ast_matchers;
+  Finder->addMatcher(functionDecl(isDefinition()).bind("function"), this);
+}
+
+void StatusTransferOrderCheck::check(
+    const ast_matchers::MatchFinder::MatchResult& Result) {
+  const auto* Function = Result.Nodes.getNodeAs<FunctionDecl>("function");
+  if (!Function || !Function->hasBody()) {
+    return;
+  }
+  StatusTransferOrderAnalyzer Analyzer(*this);
   Analyzer.analyzeFunction(Function);
 }
 

--- a/build_tools/clang_tidy/iree/StatusChecks.cc
+++ b/build_tools/clang_tidy/iree/StatusChecks.cc
@@ -6,21 +6,35 @@
 
 #include "iree/StatusChecks.h"
 
+#include <optional>
+
+#include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
+#include "clang/AST/Stmt.h"
 #include "clang/AST/Type.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallPtrSet.h"
 
 namespace clang::tidy::iree {
 namespace {
 
 bool IsNamedTypedef(QualType Type, StringRef Name) {
-  Type = Type.getLocalUnqualifiedType();
   if (Type.isNull()) {
     return false;
   }
+  Type = Type.getNonReferenceType();
+  if (Type.isNull() || Type->isDependentType()) {
+    return false;
+  }
+  Type = Type.getLocalUnqualifiedType();
   const auto* Typedef = Type->getAs<TypedefType>();
   return Typedef && Typedef->getDecl()->getName() == Name;
+}
+
+bool IsStatusType(QualType Type) {
+  return IsNamedTypedef(Type, "iree_status_t");
 }
 
 QualType ReturnTypeFromCalleeExpr(const Expr* Callee) {
@@ -67,6 +81,1062 @@ bool IsAllowedExplicitStatusConsumer(const CallExpr* Call) {
   return CalleeName(Call) == "iree_status_ignore";
 }
 
+bool IsMacroStatusTemporary(const VarDecl* Var) {
+  if (!Var) {
+    return false;
+  }
+  return Var->getName().starts_with("__status_") &&
+         Var->getLocation().isMacroID();
+}
+
+const Expr* IgnoreExprNoise(const Expr* Expr) {
+  while (Expr) {
+    Expr = Expr->IgnoreParenImpCasts();
+    if (const auto* Cleanups = dyn_cast<ExprWithCleanups>(Expr)) {
+      Expr = Cleanups->getSubExpr();
+      continue;
+    }
+    if (const auto* Materialized = dyn_cast<MaterializeTemporaryExpr>(Expr)) {
+      Expr = Materialized->getSubExpr();
+      continue;
+    }
+    break;
+  }
+  return Expr;
+}
+
+const VarDecl* ReferencedStatusLocal(const Expr* Expr) {
+  Expr = IgnoreExprNoise(Expr);
+  const auto* Ref = dyn_cast_or_null<DeclRefExpr>(Expr);
+  if (!Ref) {
+    return nullptr;
+  }
+  const auto* Var = dyn_cast<VarDecl>(Ref->getDecl());
+  if (!Var || !Var->hasLocalStorage() || IsMacroStatusTemporary(Var) ||
+      !IsStatusType(Var->getType())) {
+    return nullptr;
+  }
+  return Var->getCanonicalDecl();
+}
+
+const VarDecl* ReferencedStatusLocalThroughCasts(const Expr* Expr) {
+  Expr = IgnoreExprNoise(Expr);
+  while (const auto* Cast = dyn_cast_or_null<CastExpr>(Expr)) {
+    Expr = IgnoreExprNoise(Cast->getSubExpr());
+  }
+  return ReferencedStatusLocal(Expr);
+}
+
+const VarDecl* ForwardedStatusLocal(const Expr* Expr) {
+  if (const VarDecl* Var = ReferencedStatusLocal(Expr)) {
+    return Var;
+  }
+  Expr = IgnoreExprNoise(Expr);
+  if (const auto* Call = dyn_cast_or_null<CallExpr>(Expr);
+      Call && CalleeName(Call) == "move" && Call->getNumArgs() == 1) {
+    return ForwardedStatusLocal(Call->getArg(0));
+  }
+  return nullptr;
+}
+
+const VarDecl* ForwardedStatusLocalThroughCasts(const Expr* Expr) {
+  Expr = IgnoreExprNoise(Expr);
+  while (const auto* Cast = dyn_cast_or_null<CastExpr>(Expr)) {
+    Expr = IgnoreExprNoise(Cast->getSubExpr());
+  }
+  return ForwardedStatusLocal(Expr);
+}
+
+bool IsStatusObserver(StringRef Name) {
+  return Name == "iree_status_code" || Name == "iree_status_is_ok" ||
+         Name.starts_with("iree_status_is_") || Name == "iree_status_format" ||
+         Name == "iree_status_format_to" || Name == "iree_status_to_string" ||
+         Name == "iree_status_fprint" ||
+         Name == "iree_status_source_location" ||
+         Name == "iree_status_message" ||
+         Name == "iree_status_enumerate_payloads";
+}
+
+bool IsKnownStatusNoOwnerProducer(StringRef Name) {
+  return Name == "iree_ok_status" || Name == "iree_status_from_code" ||
+         Name == "iree_status_ignore" ||
+         Name == "iree_async_socket_query_failure";
+}
+
+bool IsKnownStatusConsumer(StringRef Name) {
+  return Name == "iree_status_free" || Name == "iree_status_ignore" ||
+         Name == "iree_status_consume_code" || Name == "iree_status_abort" ||
+         Name == "ConsumeForTest" || Name == "StatusToStringAndFree";
+}
+
+std::optional<unsigned> KnownStatusSinkArgument(StringRef Name) {
+  if (Name == "iree_async_proactor_io_uring_push_software_completion") {
+    return 2;
+  }
+  return std::nullopt;
+}
+
+bool IsKnownStatusTransferProducer(StringRef Name) {
+  return Name == "iree_status_annotate" || Name == "iree_status_annotate_f" ||
+         Name == "iree_status_freeze" || Name == "iree_status_join";
+}
+
+bool IsKnownStatusClone(StringRef Name) { return Name == "iree_status_clone"; }
+
+bool IsNoReturnStatusConsumer(StringRef Name) {
+  return Name == "iree_status_abort";
+}
+
+std::optional<std::pair<const VarDecl*, bool>> CompareExchangeStatusCondition(
+    const Expr* Condition) {
+  Condition = IgnoreExprNoise(Condition);
+  if (!Condition) {
+    return std::nullopt;
+  }
+  if (const auto* Unary = dyn_cast<UnaryOperator>(Condition);
+      Unary && Unary->getOpcode() == UO_LNot) {
+    if (auto Inner = CompareExchangeStatusCondition(Unary->getSubExpr())) {
+      return std::make_pair(Inner->first, !Inner->second);
+    }
+  }
+  if (const auto* Atomic = dyn_cast<AtomicExpr>(Condition);
+      Atomic && Atomic->isCmpXChg()) {
+    if (const VarDecl* Var =
+            ForwardedStatusLocalThroughCasts(Atomic->getVal2())) {
+      return std::make_pair(Var, true);
+    }
+  }
+  if (const auto* Call = dyn_cast<CallExpr>(Condition);
+      Call && Call->getNumArgs() >= 3 &&
+      CalleeName(Call).contains("compare_exchange")) {
+    if (const VarDecl* Var =
+            ForwardedStatusLocalThroughCasts(Call->getArg(2))) {
+      return std::make_pair(Var, true);
+    }
+  }
+  return std::nullopt;
+}
+
+bool IsNoReturnCall(const CallExpr* Call) {
+  if (const FunctionDecl* Callee = Call->getDirectCallee()) {
+    if (Callee->isNoReturn()) {
+      return true;
+    }
+  }
+  StringRef Name = CalleeName(Call);
+  return Name == "abort" || Name == "_Exit" || Name == "exit" ||
+         Name == "quick_exit" || Name == "__builtin_abort" ||
+         Name == "__builtin_trap" || Name == "iree_abort";
+}
+
+struct StatusValue {
+  bool IsStatus = false;
+  bool MayOwn = false;
+  bool Unknown = false;
+  SourceLocation Location;
+
+  static StatusValue NonStatus() { return StatusValue(); }
+
+  static StatusValue NoOwner(SourceLocation Location = SourceLocation()) {
+    StatusValue Value;
+    Value.IsStatus = true;
+    Value.Location = Location;
+    return Value;
+  }
+
+  static StatusValue Owned(SourceLocation Location) {
+    StatusValue Value;
+    Value.IsStatus = true;
+    Value.MayOwn = true;
+    Value.Location = Location;
+    return Value;
+  }
+
+  static StatusValue UnknownStatus(SourceLocation Location = SourceLocation()) {
+    StatusValue Value;
+    Value.IsStatus = true;
+    Value.Unknown = true;
+    Value.Location = Location;
+    return Value;
+  }
+};
+
+struct VariableState {
+  bool MayOwn = false;
+  bool MayBeConsumed = false;
+  bool Unknown = false;
+  SourceLocation OwnershipLocation;
+  SourceLocation ConsumeLocation;
+
+  static VariableState NoOwner() { return VariableState(); }
+
+  static VariableState Owned(SourceLocation Location) {
+    VariableState State;
+    State.MayOwn = true;
+    State.OwnershipLocation = Location;
+    return State;
+  }
+
+  static VariableState UnknownState() {
+    VariableState State;
+    State.Unknown = true;
+    return State;
+  }
+};
+
+struct AnalysisState {
+  llvm::DenseMap<const VarDecl*, VariableState> Variables;
+  bool Terminal = false;
+};
+
+VariableState MergeVariableState(const VariableState& Lhs,
+                                 const VariableState& Rhs) {
+  if (Lhs.Unknown || Rhs.Unknown) {
+    return VariableState::UnknownState();
+  }
+  VariableState Result;
+  Result.MayOwn = Lhs.MayOwn || Rhs.MayOwn;
+  Result.MayBeConsumed = Lhs.MayBeConsumed || Rhs.MayBeConsumed;
+  Result.OwnershipLocation = Lhs.OwnershipLocation.isValid()
+                                 ? Lhs.OwnershipLocation
+                                 : Rhs.OwnershipLocation;
+  Result.ConsumeLocation =
+      Lhs.ConsumeLocation.isValid() ? Lhs.ConsumeLocation : Rhs.ConsumeLocation;
+  return Result;
+}
+
+AnalysisState MergeStates(const AnalysisState& Lhs, const AnalysisState& Rhs) {
+  if (Lhs.Terminal) {
+    return Rhs;
+  }
+  if (Rhs.Terminal) {
+    return Lhs;
+  }
+  AnalysisState Result = Lhs;
+  for (const auto& [Var, RhsState] : Rhs.Variables) {
+    auto It = Result.Variables.find(Var);
+    if (It == Result.Variables.end()) {
+      Result.Variables[Var] = RhsState;
+    } else {
+      It->second = MergeVariableState(It->second, RhsState);
+    }
+  }
+  return Result;
+}
+
+class StatusRefCollector {
+ public:
+  void collect(const Stmt* Statement) {
+    if (!Statement) {
+      return;
+    }
+    if (const auto* ExprStatement = dyn_cast<Expr>(Statement)) {
+      if (const VarDecl* Var = ReferencedStatusLocal(ExprStatement)) {
+        Variables_.insert(Var);
+      }
+    }
+    for (const Stmt* Child : Statement->children()) {
+      collect(Child);
+    }
+  }
+
+  const llvm::SmallPtrSetImpl<const VarDecl*>& variables() const {
+    return Variables_;
+  }
+
+ private:
+  llvm::SmallPtrSet<const VarDecl*, 8> Variables_;
+};
+
+class GotoFinder {
+ public:
+  bool containsGoto(const Stmt* Statement) {
+    if (!Statement) {
+      return false;
+    }
+    if (isa<GotoStmt>(Statement) || isa<IndirectGotoStmt>(Statement)) {
+      return true;
+    }
+    for (const Stmt* Child : Statement->children()) {
+      if (containsGoto(Child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+};
+
+class StatusLifetimeAnalyzer {
+ public:
+  StatusLifetimeAnalyzer(StatusLifetimeCheck& Check, ASTContext& Context)
+      : Check_(Check), Context_(Context) {}
+
+  void analyzeFunction(const FunctionDecl* Function) {
+    const Stmt* Body = Function->getBody();
+    if (!Body) {
+      return;
+    }
+    GotoFinder Finder;
+    if (Finder.containsGoto(Body)) {
+      return;
+    }
+    AnalysisState State;
+    analyzeStatement(Body, State, /*is_function_body=*/true);
+  }
+
+ private:
+  void diagnoseUseAfterConsume(const VarDecl* Var, SourceLocation Location,
+                               const VariableState& State) {
+    if (State.ConsumeLocation.isValid()) {
+      Check_.diag(Location,
+                  "iree_status_t %0 is used after its ownership was consumed "
+                  "or transferred here")
+          << Var << State.ConsumeLocation;
+    } else {
+      Check_.diag(Location,
+                  "iree_status_t %0 is used after its ownership was consumed "
+                  "or transferred")
+          << Var;
+    }
+  }
+
+  void diagnoseDoubleConsume(const VarDecl* Var, SourceLocation Location,
+                             const VariableState& State) {
+    if (State.ConsumeLocation.isValid()) {
+      Check_.diag(Location,
+                  "iree_status_t %0 is consumed more than once; previous "
+                  "consume or transfer was here")
+          << Var << State.ConsumeLocation;
+    } else {
+      Check_.diag(Location, "iree_status_t %0 is consumed more than once")
+          << Var;
+    }
+  }
+
+  void diagnoseLeak(const VarDecl* Var, SourceLocation Location,
+                    const VariableState& State) {
+    if (!State.MayOwn || State.Unknown) {
+      return;
+    }
+    SourceLocation DiagnosticLocation =
+        Location.isValid() ? Location : State.OwnershipLocation;
+    if (State.OwnershipLocation.isValid() &&
+        State.OwnershipLocation != DiagnosticLocation) {
+      Check_.diag(DiagnosticLocation,
+                  "iree_status_t %0 may leave scope without being returned, "
+                  "stored, or consumed; ownership was acquired here")
+          << Var << State.OwnershipLocation;
+    } else {
+      Check_.diag(DiagnosticLocation,
+                  "iree_status_t %0 may leave scope without being returned, "
+                  "stored, or consumed")
+          << Var;
+    }
+  }
+
+  VariableState* findState(const VarDecl* Var, AnalysisState& State) {
+    if (!Var) {
+      return nullptr;
+    }
+    auto It = State.Variables.find(Var->getCanonicalDecl());
+    return It == State.Variables.end() ? nullptr : &It->second;
+  }
+
+  const VariableState* findState(const VarDecl* Var,
+                                 const AnalysisState& State) {
+    if (!Var) {
+      return nullptr;
+    }
+    auto It = State.Variables.find(Var->getCanonicalDecl());
+    return It == State.Variables.end() ? nullptr : &It->second;
+  }
+
+  void useVariable(const VarDecl* Var, SourceLocation Location,
+                   AnalysisState& State) {
+    VariableState* VarState = findState(Var, State);
+    if (!VarState || VarState->Unknown) {
+      return;
+    }
+    if (VarState->MayBeConsumed) {
+      diagnoseUseAfterConsume(Var, Location, *VarState);
+    }
+  }
+
+  void consumeVariable(const VarDecl* Var, SourceLocation Location,
+                       AnalysisState& State) {
+    VariableState* VarState = findState(Var, State);
+    if (!VarState || VarState->Unknown) {
+      return;
+    }
+    if (VarState->MayBeConsumed) {
+      diagnoseDoubleConsume(Var, Location, *VarState);
+    }
+    if (VarState->MayOwn) {
+      VarState->MayOwn = false;
+      VarState->MayBeConsumed = true;
+      VarState->ConsumeLocation = Location;
+    }
+  }
+
+  void storeVariable(const VarDecl* Var, SourceLocation Location,
+                     AnalysisState& State) {
+    consumeVariable(Var, Location, State);
+  }
+
+  StatusValue statusValueForVariable(const VarDecl* Var,
+                                     SourceLocation Location,
+                                     const AnalysisState& State) {
+    if (const VariableState* VarState = findState(Var, State)) {
+      if (VarState->Unknown) {
+        return StatusValue::UnknownStatus(Location);
+      }
+      return VarState->MayOwn ? StatusValue::Owned(Location)
+                              : StatusValue::NoOwner(Location);
+    }
+    return StatusValue::UnknownStatus(Location);
+  }
+
+  void setVariableFromStatusValue(const VarDecl* Var, const StatusValue& Value,
+                                  SourceLocation Location,
+                                  AnalysisState& State) {
+    if (!Var) {
+      return;
+    }
+    if (!Value.IsStatus) {
+      State.Variables[Var] = VariableState::UnknownState();
+      return;
+    }
+    if (Value.Unknown) {
+      State.Variables[Var] = VariableState::UnknownState();
+      return;
+    }
+    if (Value.MayOwn) {
+      State.Variables[Var] = VariableState::Owned(
+          Value.Location.isValid() ? Value.Location : Location);
+      return;
+    }
+    State.Variables[Var] = VariableState::NoOwner();
+  }
+
+  void diagnoseOutstandingStatus(AnalysisState& State,
+                                 SourceLocation Location) {
+    for (const auto& [Var, VarState] : State.Variables) {
+      diagnoseLeak(Var, Location, VarState);
+    }
+  }
+
+  void eraseVariables(ArrayRef<const VarDecl*> Vars, AnalysisState& State) {
+    for (const VarDecl* Var : Vars) {
+      State.Variables.erase(Var);
+    }
+  }
+
+  void markLoopTouchedVariablesUnknown(const Stmt* Statement,
+                                       AnalysisState& State) {
+    StatusRefCollector Collector;
+    Collector.collect(Statement);
+    for (const VarDecl* Var : Collector.variables()) {
+      if (findState(Var, State)) {
+        State.Variables[Var] = VariableState::UnknownState();
+      }
+    }
+  }
+
+  void analyzeStatement(const Stmt* Statement, AnalysisState& State,
+                        bool is_function_body = false) {
+    if (!Statement || State.Terminal) {
+      return;
+    }
+    if (const auto* Compound = dyn_cast<CompoundStmt>(Statement)) {
+      analyzeCompound(Compound, State, is_function_body);
+      return;
+    }
+    if (const auto* Decl = dyn_cast<DeclStmt>(Statement)) {
+      analyzeDeclStatement(Decl, State);
+      return;
+    }
+    if (const auto* Return = dyn_cast<ReturnStmt>(Statement)) {
+      analyzeReturn(Return, State);
+      return;
+    }
+    if (const auto* If = dyn_cast<IfStmt>(Statement)) {
+      analyzeIf(If, State);
+      return;
+    }
+    if (isa<BreakStmt>(Statement) || isa<ContinueStmt>(Statement)) {
+      State.Terminal = true;
+      return;
+    }
+    if (const auto* For = dyn_cast<ForStmt>(Statement)) {
+      analyzeFor(For, State);
+      return;
+    }
+    if (const auto* While = dyn_cast<WhileStmt>(Statement)) {
+      analyzeWhile(While, State);
+      return;
+    }
+    if (isa<DoStmt>(Statement) || isa<SwitchStmt>(Statement)) {
+      AnalysisState InnerState = State;
+      for (const Stmt* Child : Statement->children()) {
+        analyzeStatement(Child, InnerState);
+      }
+      markLoopTouchedVariablesUnknown(Statement, State);
+      return;
+    }
+    if (const auto* ExprStatement = dyn_cast<Expr>(Statement)) {
+      StatusValue Value = analyzeExpression(ExprStatement, State);
+      (void)Value;
+      return;
+    }
+    for (const Stmt* Child : Statement->children()) {
+      analyzeStatement(Child, State);
+    }
+  }
+
+  void analyzeCompound(const CompoundStmt* Compound, AnalysisState& State,
+                       bool is_function_body) {
+    SmallVector<const VarDecl*, 8> BlockVariables;
+    for (const Stmt* Child : Compound->body()) {
+      if (State.Terminal) {
+        break;
+      }
+      if (const auto* DeclarationStatement = dyn_cast<DeclStmt>(Child)) {
+        for (const Decl* D : DeclarationStatement->decls()) {
+          if (const auto* Var = dyn_cast<VarDecl>(D);
+              Var && Var->hasLocalStorage() && !IsMacroStatusTemporary(Var) &&
+              IsStatusType(Var->getType())) {
+            BlockVariables.push_back(Var->getCanonicalDecl());
+          }
+        }
+      }
+      analyzeStatement(Child, State);
+    }
+    if (!State.Terminal) {
+      if (is_function_body) {
+        diagnoseOutstandingStatus(State, Compound->getEndLoc());
+      } else {
+        for (const VarDecl* Var : BlockVariables) {
+          if (const VariableState* VarState = findState(Var, State)) {
+            diagnoseLeak(Var, Compound->getEndLoc(), *VarState);
+          }
+        }
+      }
+    }
+    if (!is_function_body) {
+      eraseVariables(BlockVariables, State);
+    }
+  }
+
+  void analyzeDeclStatement(const DeclStmt* DeclStatement,
+                            AnalysisState& State) {
+    for (const Decl* D : DeclStatement->decls()) {
+      const auto* Var = dyn_cast<VarDecl>(D);
+      if (!Var || !Var->hasLocalStorage()) {
+        continue;
+      }
+      if (!IsStatusType(Var->getType())) {
+        if (Var->hasInit()) {
+          analyzeExpression(Var->getInit(), State);
+        }
+        continue;
+      }
+      if (IsMacroStatusTemporary(Var)) {
+        if (Var->hasInit()) {
+          if (const VarDecl* InitVar = ForwardedStatusLocal(Var->getInit())) {
+            useVariable(InitVar, Var->getInit()->getExprLoc(), State);
+            markKnownOk(InitVar, State);
+          } else {
+            analyzeExpression(Var->getInit(), State);
+          }
+        }
+        continue;
+      }
+      const VarDecl* CanonicalVar = Var->getCanonicalDecl();
+      if (!Var->hasInit()) {
+        State.Variables[CanonicalVar] = VariableState::UnknownState();
+        continue;
+      }
+      StatusValue InitValue =
+          analyzeTransferredExpression(Var->getInit(), State);
+      setVariableFromStatusValue(CanonicalVar, InitValue, Var->getLocation(),
+                                 State);
+    }
+  }
+
+  void analyzeReturn(const ReturnStmt* Return, AnalysisState& State) {
+    if (const Expr* Value = Return->getRetValue()) {
+      StatusValue ReturnValue = analyzeTransferredExpression(Value, State);
+      (void)ReturnValue;
+    }
+    diagnoseOutstandingStatus(State, Return->getBeginLoc());
+    State.Terminal = true;
+  }
+
+  std::optional<std::pair<const VarDecl*, bool>> statusOkCondition(
+      const Expr* Condition) {
+    Condition = IgnoreExprNoise(Condition);
+    if (!Condition) {
+      return std::nullopt;
+    }
+    if (const auto* Unary = dyn_cast<UnaryOperator>(Condition);
+        Unary && Unary->getOpcode() == UO_LNot) {
+      if (auto Inner = statusOkCondition(Unary->getSubExpr())) {
+        return std::make_pair(Inner->first, !Inner->second);
+      }
+      if (const VarDecl* Var = ReferencedStatusLocal(Unary->getSubExpr())) {
+        return std::make_pair(Var, true);
+      }
+    }
+    if (const auto* Call = dyn_cast<CallExpr>(Condition);
+        Call && CalleeName(Call) == "iree_status_is_ok" &&
+        Call->getNumArgs() == 1) {
+      if (const VarDecl* Var = ReferencedStatusLocal(Call->getArg(0))) {
+        return std::make_pair(Var, true);
+      }
+    }
+    if (const auto* Call = dyn_cast<CallExpr>(Condition);
+        Call && CalleeName(Call) == "__builtin_expect" &&
+        Call->getNumArgs() >= 1) {
+      return statusOkCondition(Call->getArg(0));
+    }
+    if (const auto* Binary = dyn_cast<BinaryOperator>(Condition)) {
+      if (Binary->getOpcode() == BO_LAnd) {
+        if (auto LhsCondition = statusOkCondition(Binary->getLHS());
+            LhsCondition && LhsCondition->second) {
+          return LhsCondition;
+        }
+        if (auto RhsCondition = statusOkCondition(Binary->getRHS());
+            RhsCondition && RhsCondition->second) {
+          return RhsCondition;
+        }
+      }
+      if (Binary->getOpcode() == BO_LOr) {
+        if (auto LhsCondition = statusOkCondition(Binary->getLHS());
+            LhsCondition && !LhsCondition->second) {
+          return LhsCondition;
+        }
+        if (auto RhsCondition = statusOkCondition(Binary->getRHS());
+            RhsCondition && !RhsCondition->second) {
+          return RhsCondition;
+        }
+      }
+      if (Binary->getOpcode() == BO_EQ || Binary->getOpcode() == BO_NE) {
+        if (const VarDecl* Var =
+                ReferencedStatusLocalThroughCasts(Binary->getLHS())) {
+          if (isZeroConstant(Binary->getRHS())) {
+            return std::make_pair(Var, Binary->getOpcode() == BO_EQ);
+          }
+        }
+        if (const VarDecl* Var =
+                ReferencedStatusLocalThroughCasts(Binary->getRHS())) {
+          if (isZeroConstant(Binary->getLHS())) {
+            return std::make_pair(Var, Binary->getOpcode() == BO_EQ);
+          }
+        }
+      }
+    }
+    if (const VarDecl* Var = ReferencedStatusLocal(Condition)) {
+      return std::make_pair(Var, false);
+    }
+    return std::nullopt;
+  }
+
+  bool isZeroConstant(const Expr* Expr) {
+    Expr = IgnoreExprNoise(Expr);
+    if (!Expr) {
+      return false;
+    }
+    if (const auto* Literal = dyn_cast<IntegerLiteral>(Expr)) {
+      return Literal->getValue().isZero();
+    }
+    if (const auto* Ref = dyn_cast<DeclRefExpr>(Expr)) {
+      if (const auto* Constant = dyn_cast<EnumConstantDecl>(Ref->getDecl())) {
+        return Constant->getInitVal().isZero();
+      }
+    }
+    Expr::EvalResult Result;
+    if (!Expr->EvaluateAsInt(Result, Context_)) {
+      return false;
+    }
+    return Result.Val.getInt().isZero();
+  }
+
+  void markKnownOk(const VarDecl* Var, AnalysisState& State) {
+    VariableState* VarState = findState(Var, State);
+    if (!VarState || VarState->Unknown) {
+      return;
+    }
+    VarState->MayOwn = false;
+  }
+
+  void analyzeIf(const IfStmt* If, AnalysisState& State) {
+    if (const Stmt* Init = If->getInit()) {
+      analyzeStatement(Init, State);
+    }
+    if (const DeclStmt* ConditionVariable =
+            If->getConditionVariableDeclStmt()) {
+      analyzeDeclStatement(ConditionVariable, State);
+    }
+    analyzeExpression(If->getCond(), State);
+
+    AnalysisState ThenState = State;
+    AnalysisState ElseState = State;
+    if (auto Condition = statusOkCondition(If->getCond())) {
+      const VarDecl* Var = Condition->first;
+      bool TrueMeansOk = Condition->second;
+      if (TrueMeansOk) {
+        markKnownOk(Var, ThenState);
+      } else {
+        markKnownOk(Var, ElseState);
+      }
+    }
+    if (auto Condition = CompareExchangeStatusCondition(If->getCond())) {
+      const VarDecl* Var = Condition->first;
+      bool TrueTransfers = Condition->second;
+      if (TrueTransfers) {
+        consumeVariable(Var, If->getCond()->getExprLoc(), ThenState);
+      } else {
+        consumeVariable(Var, If->getCond()->getExprLoc(), ElseState);
+      }
+    }
+
+    analyzeStatement(If->getThen(), ThenState);
+    if (const Stmt* Else = If->getElse()) {
+      analyzeStatement(Else, ElseState);
+    }
+    State = MergeStates(ThenState, ElseState);
+  }
+
+  void markConditionTrueFacts(const Expr* Condition, AnalysisState& State) {
+    if (auto ConditionFact = statusOkCondition(Condition);
+        ConditionFact && ConditionFact->second) {
+      markKnownOk(ConditionFact->first, State);
+    }
+  }
+
+  void analyzeFor(const ForStmt* For, AnalysisState& State) {
+    AnalysisState InnerState = State;
+    analyzeStatement(For->getInit(), InnerState);
+    analyzeExpression(For->getCond(), InnerState);
+
+    AnalysisState BodyState = InnerState;
+    markConditionTrueFacts(For->getCond(), BodyState);
+    analyzeStatement(For->getBody(), BodyState);
+    analyzeExpression(For->getInc(), BodyState);
+
+    markLoopTouchedVariablesUnknown(For, State);
+  }
+
+  void analyzeWhile(const WhileStmt* While, AnalysisState& State) {
+    AnalysisState InnerState = State;
+    analyzeExpression(While->getCond(), InnerState);
+
+    AnalysisState BodyState = InnerState;
+    markConditionTrueFacts(While->getCond(), BodyState);
+    analyzeStatement(While->getBody(), BodyState);
+
+    markLoopTouchedVariablesUnknown(While, State);
+  }
+
+  StatusValue analyzeExpression(const Expr* Expr, AnalysisState& State) {
+    if (!Expr) {
+      return StatusValue::NonStatus();
+    }
+    Expr = IgnoreExprNoise(Expr);
+    if (!Expr) {
+      return StatusValue::NonStatus();
+    }
+
+    if (const VarDecl* Var = ReferencedStatusLocal(Expr)) {
+      useVariable(Var, Expr->getExprLoc(), State);
+      if (const VariableState* VarState = findState(Var, State)) {
+        if (VarState->Unknown) {
+          return StatusValue::UnknownStatus(Expr->getExprLoc());
+        }
+        return VarState->MayOwn ? StatusValue::Owned(Expr->getExprLoc())
+                                : StatusValue::NoOwner(Expr->getExprLoc());
+      }
+      return StatusValue::UnknownStatus(Expr->getExprLoc());
+    }
+
+    if (const auto* Cast = dyn_cast<CastExpr>(Expr);
+        Cast && Cast->getType()->isVoidType()) {
+      analyzeExpression(Cast->getSubExpr(), State);
+      return StatusValue::NonStatus();
+    }
+
+    if (const auto* Call = dyn_cast<CallExpr>(Expr)) {
+      return analyzeCall(Call, State);
+    }
+
+    if (const auto* Construct = dyn_cast<CXXConstructExpr>(Expr)) {
+      return analyzeCXXConstruct(Construct, State);
+    }
+
+    if (const auto* Binary = dyn_cast<BinaryOperator>(Expr)) {
+      if (Binary->isAssignmentOp()) {
+        return analyzeAssignment(Binary, State);
+      }
+      analyzeExpression(Binary->getLHS(), State);
+      analyzeExpression(Binary->getRHS(), State);
+      return IsStatusType(Binary->getType())
+                 ? StatusValue::UnknownStatus(Binary->getExprLoc())
+                 : StatusValue::NonStatus();
+    }
+
+    if (const auto* Unary = dyn_cast<UnaryOperator>(Expr)) {
+      analyzeExpression(Unary->getSubExpr(), State);
+      return IsStatusType(Unary->getType())
+                 ? StatusValue::UnknownStatus(Unary->getExprLoc())
+                 : StatusValue::NonStatus();
+    }
+
+    if (const auto* Conditional = dyn_cast<AbstractConditionalOperator>(Expr)) {
+      analyzeExpression(Conditional->getCond(), State);
+      AnalysisState TrueState = State;
+      AnalysisState FalseState = State;
+      StatusValue TrueValue =
+          analyzeExpression(Conditional->getTrueExpr(), TrueState);
+      StatusValue FalseValue =
+          analyzeExpression(Conditional->getFalseExpr(), FalseState);
+      State = MergeStates(TrueState, FalseState);
+      if (!TrueValue.IsStatus && !FalseValue.IsStatus) {
+        return StatusValue::NonStatus();
+      }
+      if (TrueValue.Unknown || FalseValue.Unknown) {
+        return StatusValue::UnknownStatus(Expr->getExprLoc());
+      }
+      return (TrueValue.MayOwn || FalseValue.MayOwn)
+                 ? StatusValue::Owned(Expr->getExprLoc())
+                 : StatusValue::NoOwner(Expr->getExprLoc());
+    }
+
+    for (const Stmt* Child : Expr->children()) {
+      if (const auto* ChildExpr =
+              Child ? dyn_cast<clang::Expr>(Child) : nullptr) {
+        analyzeExpression(ChildExpr, State);
+      } else {
+        analyzeStatement(Child, State);
+      }
+    }
+    return IsStatusType(Expr->getType())
+               ? StatusValue::UnknownStatus(Expr->getExprLoc())
+               : StatusValue::NonStatus();
+  }
+
+  StatusValue analyzeTransferredExpression(const Expr* Expr,
+                                           AnalysisState& State) {
+    if (!Expr) {
+      return StatusValue::NonStatus();
+    }
+    Expr = IgnoreExprNoise(Expr);
+    if (!Expr) {
+      return StatusValue::NonStatus();
+    }
+
+    if (const VarDecl* Var = ForwardedStatusLocal(Expr)) {
+      SourceLocation Location = Expr->getExprLoc();
+      useVariable(Var, Location, State);
+      StatusValue Value = statusValueForVariable(Var, Location, State);
+      consumeVariable(Var, Location, State);
+      return Value;
+    }
+
+    if (const auto* Conditional = dyn_cast<AbstractConditionalOperator>(Expr)) {
+      analyzeExpression(Conditional->getCond(), State);
+
+      AnalysisState TrueState = State;
+      AnalysisState FalseState = State;
+      if (auto Condition = statusOkCondition(Conditional->getCond())) {
+        const VarDecl* Var = Condition->first;
+        bool TrueMeansOk = Condition->second;
+        if (TrueMeansOk) {
+          markKnownOk(Var, TrueState);
+        } else {
+          markKnownOk(Var, FalseState);
+        }
+      }
+
+      StatusValue TrueValue =
+          analyzeTransferredExpression(Conditional->getTrueExpr(), TrueState);
+      StatusValue FalseValue =
+          analyzeTransferredExpression(Conditional->getFalseExpr(), FalseState);
+      State = MergeStates(TrueState, FalseState);
+      if (!TrueValue.IsStatus && !FalseValue.IsStatus) {
+        return StatusValue::NonStatus();
+      }
+      if (TrueValue.Unknown || FalseValue.Unknown) {
+        return StatusValue::UnknownStatus(Expr->getExprLoc());
+      }
+      return (TrueValue.MayOwn || FalseValue.MayOwn)
+                 ? StatusValue::Owned(Expr->getExprLoc())
+                 : StatusValue::NoOwner(Expr->getExprLoc());
+    }
+
+    return analyzeExpression(Expr, State);
+  }
+
+  StatusValue analyzeAssignment(const BinaryOperator* Binary,
+                                AnalysisState& State) {
+    const VarDecl* LhsVar = ReferencedStatusLocal(Binary->getLHS());
+    VariableState LhsBefore = LhsVar && findState(LhsVar, State)
+                                  ? *findState(LhsVar, State)
+                                  : VariableState::NoOwner();
+    StatusValue RhsValue =
+        analyzeTransferredExpression(Binary->getRHS(), State);
+    if (LhsVar) {
+      const VariableState* LhsAfterRhs = findState(LhsVar, State);
+      bool RhsConsumedLhs =
+          LhsAfterRhs && (!LhsBefore.MayOwn || !LhsAfterRhs->MayOwn ||
+                          LhsAfterRhs->MayBeConsumed || LhsAfterRhs->Unknown);
+      if (LhsBefore.MayOwn && !LhsBefore.Unknown && !RhsConsumedLhs) {
+        diagnoseLeak(LhsVar, Binary->getOperatorLoc(), LhsBefore);
+      }
+      setVariableFromStatusValue(LhsVar, RhsValue, Binary->getOperatorLoc(),
+                                 State);
+    }
+    return IsStatusType(Binary->getType())
+               ? StatusValue::UnknownStatus(Binary->getExprLoc())
+               : StatusValue::NonStatus();
+  }
+
+  StatusValue analyzeCall(const CallExpr* Call, AnalysisState& State) {
+    StringRef Name = CalleeName(Call);
+
+    if (Name == "iree_atomic_compare_exchange_strong" &&
+        Call->getNumArgs() >= 3) {
+      for (unsigned I = 0; I < Call->getNumArgs(); ++I) {
+        if (I == 2) {
+          if (const VarDecl* Var =
+                  ForwardedStatusLocalThroughCasts(Call->getArg(I))) {
+            useVariable(Var, Call->getArg(I)->getExprLoc(), State);
+            State.Variables[Var] = VariableState::UnknownState();
+            continue;
+          }
+        }
+        analyzeExpression(Call->getArg(I), State);
+      }
+      return StatusValue::NonStatus();
+    }
+
+    if (std::optional<unsigned> SinkArg = KnownStatusSinkArgument(Name)) {
+      for (unsigned I = 0; I < Call->getNumArgs(); ++I) {
+        if (I == *SinkArg) {
+          analyzeTransferredExpression(Call->getArg(I), State);
+        } else {
+          analyzeExpression(Call->getArg(I), State);
+        }
+      }
+      return StatusValue::NonStatus();
+    }
+
+    if (IsKnownStatusConsumer(Name) && Call->getNumArgs() >= 1) {
+      analyzeTransferredExpression(Call->getArg(0), State);
+      for (unsigned I = 1; I < Call->getNumArgs(); ++I) {
+        analyzeExpression(Call->getArg(I), State);
+      }
+      if (IsNoReturnStatusConsumer(Name)) {
+        diagnoseOutstandingStatus(State, Call->getExprLoc());
+        State.Terminal = true;
+      }
+      if (IsNamedTypedef(ReturnTypeFromCall(Call), "iree_status_t")) {
+        return StatusValue::NoOwner(Call->getExprLoc());
+      }
+      return StatusValue::NonStatus();
+    }
+
+    if (IsKnownStatusTransferProducer(Name)) {
+      bool ResultMayOwn = false;
+      bool ResultUnknown = false;
+      for (unsigned I = 0; I < Call->getNumArgs(); ++I) {
+        bool ConsumesArg = false;
+        if (Name == "iree_status_join") {
+          ConsumesArg = I == 0 || I == 1;
+        } else {
+          ConsumesArg = I == 0;
+        }
+        StatusValue ArgValue =
+            ConsumesArg ? analyzeTransferredExpression(Call->getArg(I), State)
+                        : analyzeExpression(Call->getArg(I), State);
+        if (ConsumesArg) {
+          ResultMayOwn = ResultMayOwn || ArgValue.MayOwn;
+          ResultUnknown = ResultUnknown || ArgValue.Unknown;
+        }
+      }
+      if (ResultUnknown) {
+        return StatusValue::UnknownStatus(Call->getExprLoc());
+      }
+      if (Name == "iree_status_annotate" || Name == "iree_status_annotate_f") {
+        ResultMayOwn = true;
+      }
+      return ResultMayOwn ? StatusValue::Owned(Call->getExprLoc())
+                          : StatusValue::NoOwner(Call->getExprLoc());
+    }
+
+    if (IsKnownStatusClone(Name)) {
+      for (unsigned I = 0; I < Call->getNumArgs(); ++I) {
+        analyzeExpression(Call->getArg(I), State);
+      }
+      return StatusValue::Owned(Call->getExprLoc());
+    }
+
+    bool HasUnknownStatusArgument = false;
+    for (unsigned I = 0; I < Call->getNumArgs(); ++I) {
+      StatusValue ArgValue = analyzeExpression(Call->getArg(I), State);
+      QualType ParamType;
+      if (const FunctionDecl* Callee = Call->getDirectCallee();
+          Callee && I < Callee->getNumParams()) {
+        ParamType = Callee->getParamDecl(I)->getType();
+      }
+      if (ParamType.isNull() ? ArgValue.IsStatus : IsStatusType(ParamType)) {
+        if (!IsStatusObserver(Name)) {
+          HasUnknownStatusArgument = true;
+          if (const VarDecl* Var = ForwardedStatusLocal(Call->getArg(I))) {
+            State.Variables[Var] = VariableState::UnknownState();
+          }
+        }
+      }
+    }
+
+    if (IsNoReturnCall(Call)) {
+      diagnoseOutstandingStatus(State, Call->getExprLoc());
+      State.Terminal = true;
+      return StatusValue::NonStatus();
+    }
+
+    if (!IsNamedTypedef(ReturnTypeFromCall(Call), "iree_status_t")) {
+      return StatusValue::NonStatus();
+    }
+    if (IsKnownStatusNoOwnerProducer(Name)) {
+      return StatusValue::NoOwner(Call->getExprLoc());
+    }
+    if (HasUnknownStatusArgument) {
+      return StatusValue::UnknownStatus(Call->getExprLoc());
+    }
+    return StatusValue::Owned(Call->getExprLoc());
+  }
+
+  StatusValue analyzeCXXConstruct(const CXXConstructExpr* Construct,
+                                  AnalysisState& State) {
+    const CXXConstructorDecl* Constructor = Construct->getConstructor();
+    const bool IsStatusConstructor =
+        Constructor && Constructor->getParent() &&
+        (Constructor->getParent()->getName() == "Status" ||
+         Constructor->getParent()->getName() == "StatusOr");
+    for (unsigned I = 0; I < Construct->getNumArgs(); ++I) {
+      StatusValue ArgValue =
+          IsStatusConstructor
+              ? analyzeTransferredExpression(Construct->getArg(I), State)
+              : analyzeExpression(Construct->getArg(I), State);
+      (void)ArgValue;
+    }
+    return StatusValue::NonStatus();
+  }
+
+  StatusLifetimeCheck& Check_;
+  ASTContext& Context_;
+};
+
 }  // namespace
 
 DiscardedStatusCheck::DiscardedStatusCheck(StringRef Name,
@@ -106,6 +1176,25 @@ void DiscardedStatusCheck::check(
   diag(Call->getExprLoc(),
        "iree_status_t result must be returned, stored for later consumption, "
        "or explicitly consumed");
+}
+
+StatusLifetimeCheck::StatusLifetimeCheck(StringRef Name,
+                                         ClangTidyContext* Context)
+    : ClangTidyCheck(Name, Context) {}
+
+void StatusLifetimeCheck::registerMatchers(ast_matchers::MatchFinder* Finder) {
+  using namespace ast_matchers;
+  Finder->addMatcher(functionDecl(isDefinition()).bind("function"), this);
+}
+
+void StatusLifetimeCheck::check(
+    const ast_matchers::MatchFinder::MatchResult& Result) {
+  const auto* Function = Result.Nodes.getNodeAs<FunctionDecl>("function");
+  if (!Function || !Function->hasBody()) {
+    return;
+  }
+  StatusLifetimeAnalyzer Analyzer(*this, *Result.Context);
+  Analyzer.analyzeFunction(Function);
 }
 
 }  // namespace clang::tidy::iree

--- a/build_tools/clang_tidy/iree/StatusChecks.cc
+++ b/build_tools/clang_tidy/iree/StatusChecks.cc
@@ -151,7 +151,8 @@ bool IsStatusObserver(StringRef Name) {
   return Name == "iree_status_code" || Name == "iree_status_is_ok" ||
          Name.starts_with("iree_status_is_") || Name == "iree_status_format" ||
          Name == "iree_status_format_to" || Name == "iree_status_to_string" ||
-         Name == "iree_status_fprint" ||
+         Name == "iree_status_fprint" || Name == "iree_status_format_message" ||
+         Name == "iree_status_format_message_to" ||
          Name == "iree_status_source_location" ||
          Name == "iree_status_message" ||
          Name == "iree_status_enumerate_payloads";
@@ -364,6 +365,346 @@ class GotoFinder {
     }
     return false;
   }
+};
+
+struct StatusParameterUseState {
+  bool Observed = false;
+  bool OwnsOrEscapes = false;
+  SourceLocation ObserveLocation;
+};
+
+const VarDecl* ReferencedStatusParameter(const Expr* Expr) {
+  Expr = IgnoreExprNoise(Expr);
+  const auto* Ref = dyn_cast_or_null<DeclRefExpr>(Expr);
+  if (!Ref) {
+    return nullptr;
+  }
+  const auto* Param = dyn_cast<ParmVarDecl>(Ref->getDecl());
+  if (!Param || !IsStatusType(Param->getType())) {
+    return nullptr;
+  }
+  return Param->getCanonicalDecl();
+}
+
+bool IsBorrowedStatusCheckExemptFunction(StringRef Name) {
+  return IsStatusObserver(Name) || IsKnownStatusConsumer(Name) ||
+         IsKnownStatusTransferProducer(Name) || IsKnownStatusClone(Name) ||
+         IsKnownStatusNoOwnerProducer(Name) ||
+         Name == "iree_async_proactor_io_uring_push_software_completion" ||
+         Name == "iree_hal_status_as_semaphore_failure" ||
+         Name == "iree_to_hrx_status";
+}
+
+bool IsStatusCppObserverMethod(const FunctionDecl* Function) {
+  const auto* Method = dyn_cast<CXXMethodDecl>(Function);
+  if (!Method || !Method->getIdentifier()) {
+    return false;
+  }
+  const CXXRecordDecl* Parent = Method->getParent();
+  return Parent && Parent->getName() == "Status" &&
+         Method->getName() == "ToString";
+}
+
+bool IsPointerToNamedTypedef(QualType Type, StringRef Name) {
+  Type = Type.getNonReferenceType();
+  Type = Type.getLocalUnqualifiedType();
+  const auto* Pointer = Type->getAs<PointerType>();
+  if (!Pointer) {
+    return false;
+  }
+  return IsNamedTypedef(Pointer->getPointeeType(), Name);
+}
+
+bool IsKnownBorrowedStatusCallbackDefinition(const FunctionDecl* Function) {
+  if (!Function->getReturnType()->isVoidType() ||
+      Function->getNumParams() != 3) {
+    return false;
+  }
+  return IsPointerToNamedTypedef(Function->getParamDecl(0)->getType(),
+                                 "iree_hal_amdgpu_reclaim_entry_t") &&
+         IsStatusType(Function->getParamDecl(2)->getType());
+}
+
+class BorrowedStatusParameterAnalyzer {
+ public:
+  explicit BorrowedStatusParameterAnalyzer(BorrowedStatusParameterCheck& Check)
+      : Check_(Check) {}
+
+  void analyzeFunction(const FunctionDecl* Function) {
+    if (!Function->hasBody()) {
+      return;
+    }
+    if (const auto* Identifier = Function->getIdentifier();
+        Identifier &&
+        IsBorrowedStatusCheckExemptFunction(Identifier->getName())) {
+      return;
+    }
+    if (IsStatusCppObserverMethod(Function) ||
+        IsKnownBorrowedStatusCallbackDefinition(Function)) {
+      return;
+    }
+    for (const ParmVarDecl* Param : Function->parameters()) {
+      if (!Param->getType()->isReferenceType() &&
+          IsStatusType(Param->getType())) {
+        State_[Param->getCanonicalDecl()] = StatusParameterUseState();
+      }
+    }
+    if (State_.empty()) {
+      return;
+    }
+    FunctionReturnsStatus_ = IsStatusType(Function->getReturnType());
+    analyzeStatement(Function->getBody());
+    for (const auto& [Param, State] : State_) {
+      if (!State.Observed || State.OwnsOrEscapes) {
+        continue;
+      }
+      Check_.diag(State.ObserveLocation.isValid() ? State.ObserveLocation
+                                                  : Param->getLocation(),
+                  "iree_status_t parameter %0 is only observed; use "
+                  "iree_status_code_t or another non-owning representation")
+          << Param;
+    }
+  }
+
+ private:
+  void markObserved(const VarDecl* Param, SourceLocation Location) {
+    auto It = State_.find(Param);
+    if (It == State_.end() || It->second.OwnsOrEscapes) {
+      return;
+    }
+    It->second.Observed = true;
+    if (!It->second.ObserveLocation.isValid()) {
+      It->second.ObserveLocation = Location;
+    }
+  }
+
+  void markOwnsOrEscapes(const VarDecl* Param) {
+    auto It = State_.find(Param);
+    if (It == State_.end()) {
+      return;
+    }
+    It->second.OwnsOrEscapes = true;
+  }
+
+  bool referencesTrackedStatusParameter(const Expr* Expr) {
+    Expr = IgnoreExprNoise(Expr);
+    if (!Expr) {
+      return false;
+    }
+    if (const VarDecl* Param = ReferencedStatusParameter(Expr);
+        Param && State_.contains(Param)) {
+      return true;
+    }
+    if (const auto* Lambda = dyn_cast<LambdaExpr>(Expr)) {
+      for (const LambdaCapture& Capture : Lambda->captures()) {
+        if (const auto* Param =
+                dyn_cast_or_null<ParmVarDecl>(Capture.getCapturedVar())) {
+          if (State_.contains(Param->getCanonicalDecl())) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+    for (const Stmt* Child : Expr->children()) {
+      if (const auto* ChildExpr = dyn_cast_or_null<clang::Expr>(Child);
+          ChildExpr && referencesTrackedStatusParameter(ChildExpr)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void markReferencedParametersOwnOrEscaped(const Expr* Expr) {
+    Expr = IgnoreExprNoise(Expr);
+    if (!Expr) {
+      return;
+    }
+    if (const VarDecl* Param = ReferencedStatusParameter(Expr);
+        Param && State_.contains(Param)) {
+      markOwnsOrEscapes(Param);
+      return;
+    }
+    for (const Stmt* Child : Expr->children()) {
+      if (const auto* ChildExpr = dyn_cast_or_null<clang::Expr>(Child)) {
+        markReferencedParametersOwnOrEscaped(ChildExpr);
+      }
+    }
+  }
+
+  bool isStatusDestination(const Expr* Expr) const {
+    Expr = IgnoreExprNoise(Expr);
+    return Expr && IsStatusType(Expr->getType());
+  }
+
+  void analyzeStatement(const Stmt* Statement) {
+    if (!Statement) {
+      return;
+    }
+    if (const auto* Lambda = dyn_cast<LambdaExpr>(Statement)) {
+      for (const LambdaCapture& Capture : Lambda->captures()) {
+        if (const auto* Param =
+                dyn_cast_or_null<ParmVarDecl>(Capture.getCapturedVar())) {
+          markOwnsOrEscapes(Param->getCanonicalDecl());
+        }
+      }
+      return;
+    }
+    if (const auto* Decl = dyn_cast<DeclStmt>(Statement)) {
+      analyzeDeclStatement(Decl);
+      return;
+    }
+    if (const auto* Return = dyn_cast<ReturnStmt>(Statement)) {
+      if (const Expr* Value = Return->getRetValue()) {
+        analyzeExpression(Value, /*transferred=*/FunctionReturnsStatus_);
+      }
+      return;
+    }
+    if (const auto* ExprStatement = dyn_cast<Expr>(Statement)) {
+      analyzeExpression(ExprStatement, /*transferred=*/false);
+      return;
+    }
+    for (const Stmt* Child : Statement->children()) {
+      analyzeStatement(Child);
+    }
+  }
+
+  void analyzeDeclStatement(const DeclStmt* DeclStatement) {
+    for (const Decl* D : DeclStatement->decls()) {
+      const auto* Var = dyn_cast<VarDecl>(D);
+      if (!Var || !Var->hasInit()) {
+        continue;
+      }
+      analyzeExpression(Var->getInit(),
+                        /*transferred=*/IsStatusType(Var->getType()));
+    }
+  }
+
+  void analyzeExpression(const Expr* Expr, bool transferred) {
+    Expr = IgnoreExprNoise(Expr);
+    if (!Expr) {
+      return;
+    }
+    if (const VarDecl* Param = ReferencedStatusParameter(Expr);
+        Param && State_.contains(Param)) {
+      if (transferred) {
+        markOwnsOrEscapes(Param);
+      } else {
+        markObserved(Param, Expr->getExprLoc());
+      }
+      return;
+    }
+    if (const auto* Cast = dyn_cast<CastExpr>(Expr)) {
+      analyzeExpression(Cast->getSubExpr(), transferred);
+      return;
+    }
+    if (const auto* Call = dyn_cast<CallExpr>(Expr)) {
+      analyzeCall(Call, transferred);
+      return;
+    }
+    if (const auto* Construct = dyn_cast<CXXConstructExpr>(Expr)) {
+      const CXXConstructorDecl* Constructor = Construct->getConstructor();
+      const bool IsStatusWrapper =
+          Constructor && Constructor->getParent() &&
+          (Constructor->getParent()->getName() == "Status" ||
+           Constructor->getParent()->getName() == "StatusOr");
+      for (unsigned I = 0; I < Construct->getNumArgs(); ++I) {
+        analyzeExpression(Construct->getArg(I), IsStatusWrapper);
+      }
+      return;
+    }
+    if (const auto* Binary = dyn_cast<BinaryOperator>(Expr)) {
+      if (Binary->isAssignmentOp()) {
+        analyzeExpression(Binary->getLHS(), /*transferred=*/false);
+        analyzeExpression(
+            Binary->getRHS(),
+            /*transferred=*/isStatusDestination(Binary->getLHS()));
+        return;
+      }
+      analyzeExpression(Binary->getLHS(), /*transferred=*/false);
+      analyzeExpression(Binary->getRHS(), /*transferred=*/false);
+      return;
+    }
+    if (const auto* Unary = dyn_cast<UnaryOperator>(Expr)) {
+      if (Unary->getOpcode() == UO_AddrOf) {
+        markReferencedParametersOwnOrEscaped(Unary->getSubExpr());
+      } else {
+        analyzeExpression(Unary->getSubExpr(), transferred);
+      }
+      return;
+    }
+    if (const auto* Conditional = dyn_cast<AbstractConditionalOperator>(Expr)) {
+      analyzeExpression(Conditional->getCond(), /*transferred=*/false);
+      analyzeExpression(Conditional->getTrueExpr(), transferred);
+      analyzeExpression(Conditional->getFalseExpr(), transferred);
+      return;
+    }
+    for (const Stmt* Child : Expr->children()) {
+      if (const auto* ChildExpr = dyn_cast_or_null<clang::Expr>(Child)) {
+        analyzeExpression(ChildExpr, transferred);
+      } else {
+        analyzeStatement(Child);
+      }
+    }
+  }
+
+  void analyzeCall(const CallExpr* Call, bool transferred) {
+    StringRef Name = CalleeName(Call);
+    if (IsKnownStatusConsumer(Name) && Call->getNumArgs() >= 1) {
+      analyzeExpression(Call->getArg(0), /*transferred=*/true);
+      for (unsigned I = 1; I < Call->getNumArgs(); ++I) {
+        analyzeExpression(Call->getArg(I), /*transferred=*/false);
+      }
+      return;
+    }
+    if (IsKnownStatusTransferProducer(Name)) {
+      for (unsigned I = 0; I < Call->getNumArgs(); ++I) {
+        bool ConsumesArg = Name == "iree_status_join" ? I <= 1 : I == 0;
+        analyzeExpression(Call->getArg(I), /*transferred=*/ConsumesArg);
+      }
+      return;
+    }
+    if (IsKnownStatusClone(Name)) {
+      for (unsigned I = 0; I < Call->getNumArgs(); ++I) {
+        analyzeExpression(Call->getArg(I), /*transferred=*/true);
+      }
+      return;
+    }
+    if (std::optional<unsigned> SinkArg = KnownStatusSinkArgument(Name)) {
+      for (unsigned I = 0; I < Call->getNumArgs(); ++I) {
+        analyzeExpression(Call->getArg(I), /*transferred=*/I == *SinkArg);
+      }
+      return;
+    }
+    if (IsStatusObserver(Name)) {
+      for (const Expr* Arg : Call->arguments()) {
+        analyzeExpression(Arg, /*transferred=*/false);
+      }
+      return;
+    }
+
+    for (unsigned I = 0; I < Call->getNumArgs(); ++I) {
+      const Expr* Arg = Call->getArg(I);
+      QualType ParamType;
+      if (const FunctionDecl* Callee = Call->getDirectCallee();
+          Callee && I < Callee->getNumParams()) {
+        ParamType = Callee->getParamDecl(I)->getType();
+      }
+      const bool ArgIsStatus = IsStatusType(Arg->getType()) ||
+                               (!ParamType.isNull() && IsStatusType(ParamType));
+      if (transferred || ArgIsStatus) {
+        markReferencedParametersOwnOrEscaped(Arg);
+      } else if (referencesTrackedStatusParameter(Arg)) {
+        analyzeExpression(Arg, /*transferred=*/false);
+      } else {
+        analyzeExpression(Arg, /*transferred=*/false);
+      }
+    }
+  }
+
+  BorrowedStatusParameterCheck& Check_;
+  llvm::DenseMap<const VarDecl*, StatusParameterUseState> State_;
+  bool FunctionReturnsStatus_ = false;
 };
 
 class StatusLifetimeAnalyzer {
@@ -1194,6 +1535,26 @@ void StatusLifetimeCheck::check(
     return;
   }
   StatusLifetimeAnalyzer Analyzer(*this, *Result.Context);
+  Analyzer.analyzeFunction(Function);
+}
+
+BorrowedStatusParameterCheck::BorrowedStatusParameterCheck(
+    StringRef Name, ClangTidyContext* Context)
+    : ClangTidyCheck(Name, Context) {}
+
+void BorrowedStatusParameterCheck::registerMatchers(
+    ast_matchers::MatchFinder* Finder) {
+  using namespace ast_matchers;
+  Finder->addMatcher(functionDecl(isDefinition()).bind("function"), this);
+}
+
+void BorrowedStatusParameterCheck::check(
+    const ast_matchers::MatchFinder::MatchResult& Result) {
+  const auto* Function = Result.Nodes.getNodeAs<FunctionDecl>("function");
+  if (!Function || !Function->hasBody()) {
+    return;
+  }
+  BorrowedStatusParameterAnalyzer Analyzer(*this);
   Analyzer.analyzeFunction(Function);
 }
 

--- a/build_tools/clang_tidy/iree/StatusChecks.h
+++ b/build_tools/clang_tidy/iree/StatusChecks.h
@@ -19,6 +19,14 @@ class DiscardedStatusCheck final : public ClangTidyCheck {
   void check(const ast_matchers::MatchFinder::MatchResult& Result) override;
 };
 
+class StatusLifetimeCheck final : public ClangTidyCheck {
+ public:
+  StatusLifetimeCheck(StringRef Name, ClangTidyContext* Context);
+
+  void registerMatchers(ast_matchers::MatchFinder* Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult& Result) override;
+};
+
 }  // namespace clang::tidy::iree
 
 #endif  // IREE_BUILD_TOOLS_CLANG_TIDY_IREE_STATUS_CHECKS_H_

--- a/build_tools/clang_tidy/iree/StatusChecks.h
+++ b/build_tools/clang_tidy/iree/StatusChecks.h
@@ -35,6 +35,14 @@ class BorrowedStatusParameterCheck final : public ClangTidyCheck {
   void check(const ast_matchers::MatchFinder::MatchResult& Result) override;
 };
 
+class StatusTransferOrderCheck final : public ClangTidyCheck {
+ public:
+  StatusTransferOrderCheck(StringRef Name, ClangTidyContext* Context);
+
+  void registerMatchers(ast_matchers::MatchFinder* Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult& Result) override;
+};
+
 }  // namespace clang::tidy::iree
 
 #endif  // IREE_BUILD_TOOLS_CLANG_TIDY_IREE_STATUS_CHECKS_H_

--- a/build_tools/clang_tidy/iree/StatusChecks.h
+++ b/build_tools/clang_tidy/iree/StatusChecks.h
@@ -27,6 +27,14 @@ class StatusLifetimeCheck final : public ClangTidyCheck {
   void check(const ast_matchers::MatchFinder::MatchResult& Result) override;
 };
 
+class BorrowedStatusParameterCheck final : public ClangTidyCheck {
+ public:
+  BorrowedStatusParameterCheck(StringRef Name, ClangTidyContext* Context);
+
+  void registerMatchers(ast_matchers::MatchFinder* Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult& Result) override;
+};
+
 }  // namespace clang::tidy::iree
 
 #endif  // IREE_BUILD_TOOLS_CLANG_TIDY_IREE_STATUS_CHECKS_H_

--- a/build_tools/clang_tidy/iree/TraceChecks.cc
+++ b/build_tools/clang_tidy/iree/TraceChecks.cc
@@ -1,0 +1,511 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/TraceChecks.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/Stmt.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/Lex/MacroArgs.h"
+#include "clang/Lex/PPCallbacks.h"
+#include "clang/Lex/Preprocessor.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace clang::tidy::iree {
+namespace {
+
+struct TraceMacro {
+  TraceMacroKind Kind = TraceMacroKind::kNone;
+  StringRef Name;
+  std::string ZoneId;
+};
+
+struct TraceZone {
+  std::string Id;
+  SourceLocation BeginLocation;
+};
+
+struct TraceState {
+  llvm::SmallVector<TraceZone, 8> Zones;
+  bool Terminal = false;
+  bool Unknown = false;
+};
+
+std::string Trim(std::string Text) {
+  StringRef Ref(Text);
+  Ref = Ref.trim();
+  return Ref.str();
+}
+
+TraceMacroKind TraceMacroKindForName(StringRef Name) {
+  if (Name == "IREE_TRACE_ZONE_BEGIN" ||
+      Name == "IREE_TRACE_ZONE_BEGIN_NAMED" ||
+      Name == "IREE_TRACE_ZONE_BEGIN_NAMED_DYNAMIC" ||
+      Name == "IREE_TRACE_ZONE_BEGIN_EXTERNAL" ||
+      Name == "HRX_TRACE_ZONE_BEGIN") {
+    return TraceMacroKind::kBegin;
+  }
+  if (Name == "IREE_TRACE_ZONE_END" || Name == "HRX_TRACE_ZONE_END") {
+    return TraceMacroKind::kEnd;
+  }
+  if (Name == "HIP_RETURN_ERROR") {
+    return TraceMacroKind::kReturn;
+  }
+  if (Name == "IREE_RETURN_IF_ERROR" || Name == "HRX_RETURN_IF_IREE_ERROR") {
+    return TraceMacroKind::kReturnIfError;
+  }
+  if (Name == "IREE_RETURN_AND_END_ZONE_IF_ERROR" ||
+      Name == "HRX_RETURN_AND_END_ZONE_IF_IREE_ERROR" ||
+      Name == "HIP_RETURN_STATUS_AND_END_ZONE_IF_ERROR" ||
+      Name == "HIP_RETURN_STATUS_AND_END_ZONE_IF_ERROR_2" ||
+      Name == "HIP_RETURN_STATUS_AND_END_ZONE_IF_ERROR_3") {
+    return TraceMacroKind::kReturnAndEndIfError;
+  }
+  if (Name == "IREE_RETURN_AND_END_ZONE" || Name == "HRX_RETURN_AND_END_ZONE" ||
+      Name == "HRX_RETURN_VOID_AND_END_ZONE") {
+    return TraceMacroKind::kReturnAndEnd;
+  }
+  return TraceMacroKind::kNone;
+}
+
+std::string FirstMacroArgument(const MacroArgs* Args, const Preprocessor& PP) {
+  if (!Args || Args->getNumMacroArguments() == 0) {
+    return "";
+  }
+  const Token* Arg = Args->getUnexpArgument(0);
+  if (!Arg || MacroArgs::getArgLength(Arg) == 0) {
+    return "";
+  }
+  bool Invalid = false;
+  std::string Spelling = PP.getSpelling(Arg[0], &Invalid);
+  return Invalid ? "" : Trim(std::move(Spelling));
+}
+
+class TraceMacroRecorder final : public PPCallbacks {
+ public:
+  TraceMacroRecorder(TraceZoneCheck& Check, Preprocessor& PP)
+      : Check_(Check), PP_(PP) {}
+
+  void MacroExpands(const Token& MacroNameTok, const MacroDefinition&,
+                    SourceRange Range, const MacroArgs* Args) override {
+    const IdentifierInfo* Identifier = MacroNameTok.getIdentifierInfo();
+    if (!Identifier) {
+      return;
+    }
+    StringRef Name = Identifier->getName();
+    TraceMacroKind Kind = TraceMacroKindForName(Name);
+    if (Kind == TraceMacroKind::kNone) {
+      return;
+    }
+    const SourceManager& SourceManager = PP_.getSourceManager();
+    if (SourceManager.isMacroBodyExpansion(MacroNameTok.getLocation())) {
+      return;
+    }
+    SourceLocation BeginLocation =
+        SourceManager.getExpansionLoc(Range.getBegin());
+    if (SourceManager.getExpansionLoc(MacroNameTok.getLocation()) !=
+        BeginLocation) {
+      return;
+    }
+    SourceLocation EndLocation = SourceManager.getExpansionLoc(Range.getEnd());
+    if (EndLocation.isInvalid()) {
+      EndLocation = BeginLocation;
+    }
+    Check_.addTraceMacroExpansion(Kind, Name, FirstMacroArgument(Args, PP_),
+                                  BeginLocation, EndLocation);
+  }
+
+ private:
+  TraceZoneCheck& Check_;
+  Preprocessor& PP_;
+};
+
+class TraceZoneAnalyzer {
+ public:
+  TraceZoneAnalyzer(TraceZoneCheck& Check, ASTContext& Context)
+      : Check_(Check), Context_(Context) {
+    ConsumedMacroExpansions_.resize(Check_.traceMacroExpansions().size(), 0);
+  }
+
+  void analyzeFunction(const FunctionDecl* Function) {
+    const Stmt* Body = Function->getBody();
+    if (!Body) {
+      return;
+    }
+    TraceState State;
+    analyzeStatement(Body, State);
+  }
+
+ private:
+  bool isTraceMacroContainer(const Stmt* Statement) const {
+    return isa<CompoundStmt>(Statement) || isa<IfStmt>(Statement) ||
+           isa<ForStmt>(Statement) || isa<WhileStmt>(Statement) ||
+           isa<SwitchStmt>(Statement) || isa<LabelStmt>(Statement);
+  }
+
+  SourceLocation expansionLocation(SourceLocation Location) const {
+    const SourceManager& SourceManager = Context_.getSourceManager();
+    return Location.isMacroID() ? SourceManager.getTopMacroCallerLoc(Location)
+                                : SourceManager.getExpansionLoc(Location);
+  }
+
+  bool rangesOverlap(SourceLocation LhsBegin, SourceLocation LhsEnd,
+                     SourceLocation RhsBegin, SourceLocation RhsEnd) const {
+    if (LhsBegin.isInvalid() || LhsEnd.isInvalid() || RhsBegin.isInvalid() ||
+        RhsEnd.isInvalid()) {
+      return false;
+    }
+    const SourceManager& SourceManager = Context_.getSourceManager();
+    if (SourceManager.isBeforeInTranslationUnit(LhsEnd, LhsBegin)) {
+      std::swap(LhsBegin, LhsEnd);
+    }
+    if (SourceManager.isBeforeInTranslationUnit(RhsEnd, RhsBegin)) {
+      std::swap(RhsBegin, RhsEnd);
+    }
+    return !SourceManager.isBeforeInTranslationUnit(LhsEnd, RhsBegin) &&
+           !SourceManager.isBeforeInTranslationUnit(RhsEnd, LhsBegin);
+  }
+
+  bool sameExpansionLine(SourceLocation Lhs, SourceLocation Rhs) const {
+    if (Lhs.isInvalid() || Rhs.isInvalid()) {
+      return false;
+    }
+    const SourceManager& SourceManager = Context_.getSourceManager();
+    Lhs = Lhs.isMacroID() ? SourceManager.getTopMacroCallerLoc(Lhs)
+                          : SourceManager.getExpansionLoc(Lhs);
+    Rhs = Rhs.isMacroID() ? SourceManager.getTopMacroCallerLoc(Rhs)
+                          : SourceManager.getExpansionLoc(Rhs);
+    if (SourceManager.getFileID(Lhs) != SourceManager.getFileID(Rhs)) {
+      return false;
+    }
+    return SourceManager.getExpansionLineNumber(Lhs) ==
+           SourceManager.getExpansionLineNumber(Rhs);
+  }
+
+  int traceMacroPriority(TraceMacroKind Kind) const {
+    switch (Kind) {
+      case TraceMacroKind::kNone:
+        return 0;
+      case TraceMacroKind::kReturnAndEnd:
+      case TraceMacroKind::kReturnAndEndIfError:
+        return 4;
+      case TraceMacroKind::kBegin:
+      case TraceMacroKind::kEnd:
+        return 3;
+      case TraceMacroKind::kReturnIfError:
+        return 2;
+      case TraceMacroKind::kReturn:
+        return 1;
+    }
+    return 0;
+  }
+
+  const TraceMacroExpansion* findTraceMacroExpansionForStatement(
+      const Stmt* Statement) {
+    if (!Statement || isTraceMacroContainer(Statement)) {
+      return nullptr;
+    }
+    SourceRange StatementRange = Statement->getSourceRange();
+    SourceLocation StatementBegin =
+        expansionLocation(StatementRange.getBegin());
+    SourceLocation StatementEnd = expansionLocation(StatementRange.getEnd());
+    if (StatementEnd.isInvalid()) {
+      StatementEnd = StatementBegin;
+    }
+    ArrayRef<TraceMacroExpansion> Expansions = Check_.traceMacroExpansions();
+    size_t BestIndex = Expansions.size();
+    int BestPriority = 0;
+    for (size_t I = 0; I < Expansions.size(); ++I) {
+      if (ConsumedMacroExpansions_[I]) {
+        continue;
+      }
+      const TraceMacroExpansion& Expansion = Expansions[I];
+      if (!rangesOverlap(StatementBegin, StatementEnd, Expansion.BeginLocation,
+                         Expansion.EndLocation) &&
+          !sameExpansionLine(StatementBegin, Expansion.BeginLocation)) {
+        continue;
+      }
+      int Priority = traceMacroPriority(Expansion.Kind);
+      if (Priority > BestPriority) {
+        BestIndex = I;
+        BestPriority = Priority;
+      }
+    }
+    if (BestIndex != Expansions.size()) {
+      ConsumedMacroExpansions_[BestIndex] = 1;
+      return &Expansions[BestIndex];
+    }
+    return nullptr;
+  }
+
+  TraceMacro traceMacroForStatement(const Stmt* Statement) {
+    const TraceMacroExpansion* Expansion =
+        findTraceMacroExpansionForStatement(Statement);
+    if (Expansion) {
+      return TraceMacro{Expansion->Kind, Expansion->Name, Expansion->ZoneId};
+    }
+    return TraceMacro{};
+  }
+
+  const TraceZone* activeZone(const TraceState& State) const {
+    return State.Zones.empty() ? nullptr : &State.Zones.back();
+  }
+
+  void diagnoseActiveReturn(SourceLocation Location, const TraceState& State,
+                            StringRef ReturnKind) {
+    const TraceZone* Zone = activeZone(State);
+    if (!Zone || State.Unknown) {
+      return;
+    }
+    if (Zone->BeginLocation.isValid()) {
+      Check_.diag(Location,
+                  "%0 exits with active trace zone %1; end the zone or use a "
+                  "trace-zone return helper")
+          << ReturnKind << Zone->Id << Zone->BeginLocation;
+    } else {
+      Check_.diag(Location,
+                  "%0 exits with active trace zone %1; end the zone or use a "
+                  "trace-zone return helper")
+          << ReturnKind << Zone->Id;
+    }
+  }
+
+  void beginZone(const TraceMacro& Macro, SourceLocation Location,
+                 TraceState& State) {
+    std::string ZoneId = Macro.ZoneId.empty() ? "<unknown>" : Macro.ZoneId;
+    State.Zones.push_back(TraceZone{std::move(ZoneId), Location});
+  }
+
+  void endZone(const TraceMacro& Macro, TraceState& State) {
+    if (State.Zones.empty() || State.Unknown) {
+      return;
+    }
+    if (Macro.ZoneId.empty()) {
+      State.Zones.pop_back();
+      return;
+    }
+    const TraceZone& Zone = State.Zones.back();
+    if (Zone.Id != "<unknown>" && Zone.Id != Macro.ZoneId) {
+      State.Unknown = true;
+      State.Zones.clear();
+      return;
+    }
+    State.Zones.pop_back();
+  }
+
+  bool sameZones(const TraceState& Lhs, const TraceState& Rhs) const {
+    if (Lhs.Zones.size() != Rhs.Zones.size()) {
+      return false;
+    }
+    for (size_t I = 0; I < Lhs.Zones.size(); ++I) {
+      if (Lhs.Zones[I].Id != Rhs.Zones[I].Id) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  TraceState mergeStates(const TraceState& EntryState,
+                         const TraceState& ThenState,
+                         const TraceState& ElseState) {
+    if (ThenState.Terminal && ElseState.Terminal) {
+      TraceState Terminal = EntryState;
+      Terminal.Terminal = true;
+      return Terminal;
+    }
+    if (ThenState.Terminal) {
+      return ElseState;
+    }
+    if (ElseState.Terminal) {
+      return ThenState;
+    }
+    if (ThenState.Unknown || ElseState.Unknown) {
+      TraceState Unknown = EntryState;
+      Unknown.Unknown = true;
+      Unknown.Zones.clear();
+      return Unknown;
+    }
+    if (!sameZones(ThenState, ElseState)) {
+      TraceState Unknown = EntryState;
+      Unknown.Unknown = true;
+      Unknown.Zones.clear();
+      return Unknown;
+    }
+    return ThenState;
+  }
+
+  void dropBlockLocalZones(const TraceState& EntryState, TraceState& State) {
+    if (!State.Terminal && !State.Unknown) {
+      State.Zones.resize(EntryState.Zones.size());
+    }
+  }
+
+  bool handleTraceMacro(const Stmt* Statement, TraceState& State) {
+    TraceMacro Macro = traceMacroForStatement(Statement);
+    switch (Macro.Kind) {
+      case TraceMacroKind::kNone:
+        return false;
+      case TraceMacroKind::kBegin:
+        beginZone(Macro, Statement->getBeginLoc(), State);
+        return true;
+      case TraceMacroKind::kEnd:
+        endZone(Macro, State);
+        return true;
+      case TraceMacroKind::kReturn:
+        State.Terminal = true;
+        return true;
+      case TraceMacroKind::kReturnIfError:
+        if (!State.Zones.empty()) {
+          diagnoseActiveReturn(Statement->getBeginLoc(), State, Macro.Name);
+        }
+        // The macro may continue on success, so active zones stay open.
+        return true;
+      case TraceMacroKind::kReturnAndEndIfError:
+        // The macro is a conditional failure path: it ends the zone only on
+        // failure and falls through with the zone still active on success.
+        return true;
+      case TraceMacroKind::kReturnAndEnd:
+        if (!State.Zones.empty()) {
+          endZone(Macro, State);
+        }
+        State.Terminal = true;
+        return true;
+    }
+    return false;
+  }
+
+  void analyzeStatement(const Stmt* Statement, TraceState& State) {
+    if (!Statement || State.Terminal) {
+      return;
+    }
+    if (handleTraceMacro(Statement, State)) {
+      return;
+    }
+    if (const auto* Compound = dyn_cast<CompoundStmt>(Statement)) {
+      analyzeCompound(Compound, State);
+      return;
+    }
+    if (isa<ReturnStmt>(Statement)) {
+      State.Terminal = true;
+      return;
+    }
+    if (const auto* If = dyn_cast<IfStmt>(Statement)) {
+      analyzeIf(If, State);
+      return;
+    }
+    if (const auto* Label = dyn_cast<LabelStmt>(Statement)) {
+      analyzeStatement(Label->getSubStmt(), State);
+      return;
+    }
+    if (isa<GotoStmt>(Statement) || isa<IndirectGotoStmt>(Statement)) {
+      return;
+    }
+    if (isa<BreakStmt>(Statement) || isa<ContinueStmt>(Statement)) {
+      return;
+    }
+    if (const auto* For = dyn_cast<ForStmt>(Statement)) {
+      analyzeLoopLike(For->getBody(), State);
+      return;
+    }
+    if (const auto* While = dyn_cast<WhileStmt>(Statement)) {
+      analyzeLoopLike(While->getBody(), State);
+      return;
+    }
+    if (const auto* Do = dyn_cast<DoStmt>(Statement)) {
+      analyzeLoopLike(Do->getBody(), State);
+      return;
+    }
+    if (const auto* Switch = dyn_cast<SwitchStmt>(Statement)) {
+      analyzeLoopLike(Switch->getBody(), State);
+      return;
+    }
+    for (const Stmt* Child : Statement->children()) {
+      analyzeStatement(Child, State);
+    }
+  }
+
+  void analyzeCompound(const CompoundStmt* Compound, TraceState& State) {
+    TraceState EntryState = State;
+    for (const Stmt* Child : Compound->body()) {
+      if (State.Terminal) {
+        break;
+      }
+      analyzeStatement(Child, State);
+    }
+    dropBlockLocalZones(EntryState, State);
+  }
+
+  void analyzeIf(const IfStmt* If, TraceState& State) {
+    TraceState EntryState = State;
+    TraceState ThenState = State;
+    analyzeStatement(If->getThen(), ThenState);
+
+    TraceState ElseState = State;
+    if (const Stmt* Else = If->getElse()) {
+      analyzeStatement(Else, ElseState);
+    }
+
+    State = mergeStates(EntryState, ThenState, ElseState);
+  }
+
+  void analyzeLoopLike(const Stmt* Body, TraceState& State) {
+    TraceState BodyState = State;
+    analyzeStatement(Body, BodyState);
+    // A loop or switch body may execute zero times or leave through break, so
+    // the outer state remains the entry state. Diagnostics inside the body
+    // still report active-zone status returns.
+  }
+
+  TraceZoneCheck& Check_;
+  ASTContext& Context_;
+  llvm::SmallVector<char, 256> ConsumedMacroExpansions_;
+};
+
+}  // namespace
+
+TraceZoneCheck::TraceZoneCheck(StringRef Name, ClangTidyContext* Context)
+    : ClangTidyCheck(Name, Context) {}
+
+void TraceZoneCheck::registerPPCallbacks(const SourceManager&, Preprocessor* PP,
+                                         Preprocessor*) {
+  if (!PP) {
+    return;
+  }
+  PP->addPPCallbacks(std::make_unique<TraceMacroRecorder>(*this, *PP));
+}
+
+void TraceZoneCheck::registerMatchers(ast_matchers::MatchFinder* Finder) {
+  using namespace ast_matchers;
+  Finder->addMatcher(functionDecl(isDefinition()).bind("function"), this);
+}
+
+void TraceZoneCheck::check(
+    const ast_matchers::MatchFinder::MatchResult& Result) {
+  const auto* Function = Result.Nodes.getNodeAs<FunctionDecl>("function");
+  if (!Function || !Function->hasBody()) {
+    return;
+  }
+  TraceZoneAnalyzer Analyzer(*this, *Result.Context);
+  Analyzer.analyzeFunction(Function);
+}
+
+void TraceZoneCheck::addTraceMacroExpansion(TraceMacroKind Kind, StringRef Name,
+                                            std::string ZoneId,
+                                            SourceLocation BeginLocation,
+                                            SourceLocation EndLocation) {
+  TraceMacroExpansions_.push_back(TraceMacroExpansion{
+      Kind, Name.str(), std::move(ZoneId), BeginLocation, EndLocation});
+}
+
+}  // namespace clang::tidy::iree

--- a/build_tools/clang_tidy/iree/TraceChecks.h
+++ b/build_tools/clang_tidy/iree/TraceChecks.h
@@ -1,0 +1,59 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BUILD_TOOLS_CLANG_TIDY_IREE_TRACE_CHECKS_H_
+#define IREE_BUILD_TOOLS_CLANG_TIDY_IREE_TRACE_CHECKS_H_
+
+#include <string>
+
+#include "clang-tidy/ClangTidyCheck.h"
+#include "clang/Basic/SourceLocation.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace clang::tidy::iree {
+
+enum class TraceMacroKind {
+  kNone,
+  kBegin,
+  kEnd,
+  kReturn,
+  kReturnIfError,
+  kReturnAndEndIfError,
+  kReturnAndEnd,
+};
+
+struct TraceMacroExpansion {
+  TraceMacroKind Kind = TraceMacroKind::kNone;
+  std::string Name;
+  std::string ZoneId;
+  SourceLocation BeginLocation;
+  SourceLocation EndLocation;
+};
+
+class TraceZoneCheck final : public ClangTidyCheck {
+ public:
+  TraceZoneCheck(StringRef Name, ClangTidyContext* Context);
+
+  void registerPPCallbacks(const SourceManager& SM, Preprocessor* PP,
+                           Preprocessor* ModuleExpanderPP) override;
+  void registerMatchers(ast_matchers::MatchFinder* Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult& Result) override;
+
+  void addTraceMacroExpansion(TraceMacroKind Kind, StringRef Name,
+                              std::string ZoneId, SourceLocation BeginLocation,
+                              SourceLocation EndLocation);
+  ArrayRef<TraceMacroExpansion> traceMacroExpansions() const {
+    return TraceMacroExpansions_;
+  }
+
+ private:
+  llvm::SmallVector<TraceMacroExpansion, 256> TraceMacroExpansions_;
+};
+
+}  // namespace clang::tidy::iree
+
+#endif  // IREE_BUILD_TOOLS_CLANG_TIDY_IREE_TRACE_CHECKS_H_

--- a/build_tools/clang_tidy/test/status_checks.c
+++ b/build_tools/clang_tidy/test/status_checks.c
@@ -4,15 +4,53 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-typedef struct iree_status_handle_t* iree_status_t;
+#include <stdint.h>
 
+typedef struct iree_status_handle_t* iree_status_t;
+typedef int iree_status_code_t;
+
+iree_status_t iree_ok_status(void);
+int iree_status_is_ok(iree_status_t status);
+void iree_status_free(iree_status_t status);
 iree_status_t iree_status_ignore(iree_status_t status);
+iree_status_t iree_status_join(iree_status_t base_status,
+                               iree_status_t new_status);
+iree_status_t iree_status_annotate(iree_status_t base_status,
+                                   const char* message);
+iree_status_code_t iree_status_consume_code(iree_status_t status);
+int iree_atomic_compare_exchange_strong(int* ptr, int* expected,
+                                        intptr_t desired, int success_order,
+                                        int failure_order);
+iree_status_t iree_async_socket_query_failure(void* socket);
+iree_status_t iree_status_clone(iree_status_t status);
+void iree_async_proactor_io_uring_push_software_completion(
+    void* proactor, void* operation, iree_status_t status);
+
 iree_status_t iree_clang_tidy_status_assigned_source(void);
+iree_status_t iree_clang_tidy_status_cleanup_source(void);
 iree_status_t iree_clang_tidy_status_dropped_source(void);
 iree_status_t iree_clang_tidy_status_ignored_source(void);
 iree_status_t iree_clang_tidy_status_named_call_source(void);
 iree_status_t iree_clang_tidy_status_returned_source(void);
 iree_status_t iree_clang_tidy_status_void_cast_source(void);
+
+#define IREE_LIKELY(x) (__builtin_expect(!!(x), 1))
+#define IREE_STATUS_OK 0
+#define IREE_STATUS_UNAVAILABLE 14
+#define IREE_STATUS_CODE_MASK 0x1Fu
+#define iree_status_code(value) \
+  ((iree_status_code_t)(((uintptr_t)(value)) & IREE_STATUS_CODE_MASK))
+#define iree_status_is_ok(value) \
+  IREE_LIKELY((uintptr_t)(value) == IREE_STATUS_OK)
+#define iree_status_is_unavailable(value) \
+  (iree_status_code(value) == IREE_STATUS_UNAVAILABLE)
+#define IREE_RETURN_IF_ERROR(expr)            \
+  do {                                        \
+    iree_status_t __status_macro = (expr);    \
+    if (!iree_status_is_ok(__status_macro)) { \
+      return __status_macro;                  \
+    }                                         \
+  } while (0)
 
 iree_status_t iree_clang_tidy_status_returned(void) {
   return iree_clang_tidy_status_returned_source();
@@ -37,4 +75,199 @@ void iree_clang_tidy_status_void_cast(void) {
 
 void iree_clang_tidy_status_named_call_dropped(void) {
   iree_clang_tidy_status_named_call_source();
+}
+
+void iree_clang_tidy_status_lifetime_leaked(void) {
+  iree_status_t leaked_status = iree_clang_tidy_status_assigned_source();
+  (void)leaked_status;
+}
+
+void iree_clang_tidy_status_lifetime_overwritten(void) {
+  iree_status_t overwritten_status = iree_clang_tidy_status_assigned_source();
+  overwritten_status = iree_clang_tidy_status_cleanup_source();
+  iree_status_ignore(overwritten_status);
+}
+
+void iree_clang_tidy_status_lifetime_double_consumed(void) {
+  iree_status_t double_consumed_status =
+      iree_clang_tidy_status_assigned_source();
+  iree_status_ignore(double_consumed_status);
+  iree_status_free(double_consumed_status);
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_used_after_consume(void) {
+  iree_status_t used_after_consume_status =
+      iree_clang_tidy_status_assigned_source();
+  iree_status_ignore(used_after_consume_status);
+  return used_after_consume_status;
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_used_after_transfer(void) {
+  iree_status_t used_after_transfer_status =
+      iree_clang_tidy_status_assigned_source();
+  iree_status_t transferred_status = used_after_transfer_status;
+  iree_status_ignore(transferred_status);
+  return used_after_transfer_status;
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_lost_on_return(void) {
+  iree_status_t lost_on_return_status =
+      iree_clang_tidy_status_assigned_source();
+  return iree_ok_status();
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_lost_on_code_predicate(void) {
+  iree_status_t code_predicate_status =
+      iree_clang_tidy_status_assigned_source();
+  if (iree_status_is_unavailable(code_predicate_status)) {
+    return iree_clang_tidy_status_cleanup_source();
+  }
+  return code_predicate_status;
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_returned(void) {
+  iree_status_t returned_status = iree_clang_tidy_status_assigned_source();
+  return returned_status;
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_return_if_error(void) {
+  iree_status_t return_if_error_status =
+      iree_clang_tidy_status_assigned_source();
+  if (!iree_status_is_ok(return_if_error_status)) {
+    return return_if_error_status;
+  }
+  return iree_ok_status();
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_return_if_error_macro(void) {
+  iree_status_t macro_return_status = iree_clang_tidy_status_assigned_source();
+  IREE_RETURN_IF_ERROR(macro_return_status);
+  return iree_ok_status();
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_return_if_error_fallthrough(
+    void) {
+  iree_status_t macro_fallthrough_status =
+      iree_clang_tidy_status_assigned_source();
+  IREE_RETURN_IF_ERROR(macro_fallthrough_status);
+  if (!iree_status_is_ok(macro_fallthrough_status)) {
+    return macro_fallthrough_status;
+  }
+  return iree_clang_tidy_status_cleanup_source();
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_transferred_local(void) {
+  iree_status_t transfer_source_status =
+      iree_clang_tidy_status_assigned_source();
+  iree_status_t transfer_target_status = transfer_source_status;
+  return transfer_target_status;
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_transferred_conditional(void) {
+  iree_status_t conditional_source_status =
+      iree_clang_tidy_status_assigned_source();
+  iree_status_t conditional_target_status =
+      iree_status_is_ok(conditional_source_status)
+          ? iree_clang_tidy_status_cleanup_source()
+          : conditional_source_status;
+  return conditional_target_status;
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_joined_secondary_error(void) {
+  iree_status_t joined_primary_status =
+      iree_clang_tidy_status_assigned_source();
+  iree_status_t joined_secondary_status =
+      iree_clang_tidy_status_cleanup_source();
+  if (!iree_status_is_ok(joined_secondary_status)) {
+    return iree_status_join(joined_primary_status, joined_secondary_status);
+  }
+  return joined_primary_status;
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_loop_break_overwrite(void) {
+  iree_status_t loop_break_status = iree_ok_status();
+  for (int i = 0; i < 4; ++i) {
+    loop_break_status = iree_clang_tidy_status_assigned_source();
+    if (!iree_status_is_ok(loop_break_status)) break;
+    loop_break_status = iree_clang_tidy_status_cleanup_source();
+    if (!iree_status_is_ok(loop_break_status)) break;
+  }
+  return loop_break_status;
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_ok_and_overwrite(int replace) {
+  iree_status_t ok_and_status = iree_clang_tidy_status_assigned_source();
+  if (iree_status_is_ok(ok_and_status) && replace) {
+    ok_and_status = iree_clang_tidy_status_cleanup_source();
+  }
+  return ok_and_status;
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_code_predicate_consumed(void) {
+  iree_status_t consumed_predicate_status =
+      iree_clang_tidy_status_assigned_source();
+  if (iree_status_is_unavailable(consumed_predicate_status)) {
+    iree_status_ignore(consumed_predicate_status);
+    return iree_clang_tidy_status_cleanup_source();
+  }
+  return consumed_predicate_status;
+}
+
+void iree_clang_tidy_status_lifetime_atomic_escape(int* ptr, int* expected) {
+  iree_status_t atomic_escape_status = iree_clang_tidy_status_assigned_source();
+  if (!iree_atomic_compare_exchange_strong(
+          ptr, expected, (intptr_t)atomic_escape_status, 0, 0)) {
+    iree_status_ignore(atomic_escape_status);
+  }
+}
+
+void iree_clang_tidy_status_lifetime_atomic_builtin_escape(
+    _Atomic(intptr_t)* ptr, intptr_t* expected) {
+  iree_status_t atomic_builtin_status =
+      iree_clang_tidy_status_assigned_source();
+  if (!__c11_atomic_compare_exchange_strong(
+          ptr, expected, (intptr_t)atomic_builtin_status, __ATOMIC_ACQ_REL,
+          __ATOMIC_RELAXED)) {
+    iree_status_ignore(atomic_builtin_status);
+  }
+}
+
+void iree_clang_tidy_status_lifetime_sink_argument(void* proactor,
+                                                   void* operation) {
+  iree_status_t sink_argument_status = iree_clang_tidy_status_assigned_source();
+  iree_async_proactor_io_uring_push_software_completion(proactor, operation,
+                                                        sink_argument_status);
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_borrowed_status(void* socket) {
+  iree_status_t borrowed_status = iree_async_socket_query_failure(socket);
+  if (!iree_status_is_ok(borrowed_status)) {
+    return iree_status_clone(borrowed_status);
+  }
+  return iree_ok_status();
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_joined(void) {
+  iree_status_t joined_status = iree_clang_tidy_status_assigned_source();
+  joined_status =
+      iree_status_join(joined_status, iree_clang_tidy_status_cleanup_source());
+  return joined_status;
+}
+
+iree_status_t iree_clang_tidy_status_lifetime_annotated(void) {
+  iree_status_t annotated_status = iree_clang_tidy_status_assigned_source();
+  if (annotated_status) {
+    return iree_status_annotate(annotated_status, "message");
+  }
+  return iree_ok_status();
+}
+
+void iree_clang_tidy_status_lifetime_stored(iree_status_t* out_status) {
+  iree_status_t stored_status = iree_clang_tidy_status_assigned_source();
+  *out_status = stored_status;
+}
+
+iree_status_code_t iree_clang_tidy_status_lifetime_consumed_code(void) {
+  iree_status_t consumed_code_status = iree_clang_tidy_status_assigned_source();
+  return iree_status_consume_code(consumed_code_status);
 }

--- a/build_tools/clang_tidy/test/status_checks.c
+++ b/build_tools/clang_tidy/test/status_checks.c
@@ -34,6 +34,7 @@ iree_status_t iree_clang_tidy_status_ignored_source(void);
 iree_status_t iree_clang_tidy_status_named_call_source(void);
 iree_status_t iree_clang_tidy_status_returned_source(void);
 iree_status_t iree_clang_tidy_status_void_cast_source(void);
+iree_status_t iree_clang_tidy_status_transfer_order_sink(iree_status_t status);
 
 #define IREE_LIKELY(x) (__builtin_expect(!!(x), 1))
 #define IREE_STATUS_OK 0
@@ -326,4 +327,43 @@ void iree_clang_tidy_status_borrowed_parameter_reclaim_callback(
   (void)entry;
   *(iree_status_code_t*)user_data =
       iree_status_code(reclaim_callback_parameter_status);
+}
+
+iree_status_t iree_clang_tidy_status_transfer_order_join_same(void) {
+  iree_status_t transfer_order_join_same_status =
+      iree_clang_tidy_status_assigned_source();
+  return iree_status_join(transfer_order_join_same_status,
+                          transfer_order_join_same_status);
+}
+
+iree_status_t iree_clang_tidy_status_transfer_order_join_callback(void) {
+  iree_status_t transfer_order_nested_status =
+      iree_clang_tidy_status_assigned_source();
+  return iree_status_join(
+      transfer_order_nested_status,
+      iree_clang_tidy_status_transfer_order_sink(transfer_order_nested_status));
+}
+
+iree_status_t iree_clang_tidy_status_transfer_order_explicit_sequence(void) {
+  iree_status_t explicit_sequence_status =
+      iree_clang_tidy_status_assigned_source();
+  iree_status_t cleanup_status = iree_clang_tidy_status_cleanup_source();
+  return iree_status_join(explicit_sequence_status, cleanup_status);
+}
+
+iree_status_t iree_clang_tidy_status_transfer_order_clone_before_fanout(void) {
+  iree_status_t clone_before_fanout_status =
+      iree_clang_tidy_status_assigned_source();
+  iree_status_t cloned_status = iree_status_clone(clone_before_fanout_status);
+  iree_status_t callback_status =
+      iree_clang_tidy_status_transfer_order_sink(cloned_status);
+  return iree_status_join(clone_before_fanout_status, callback_status);
+}
+
+int iree_clang_tidy_status_transfer_order_observer_only(void) {
+  iree_status_t observer_only_status = iree_clang_tidy_status_assigned_source();
+  int result = iree_status_is_ok(observer_only_status) ||
+               iree_status_is_unavailable(observer_only_status);
+  iree_status_ignore(observer_only_status);
+  return result;
 }

--- a/build_tools/clang_tidy/test/status_checks.c
+++ b/build_tools/clang_tidy/test/status_checks.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 typedef struct iree_status_handle_t* iree_status_t;
+typedef struct iree_hal_amdgpu_reclaim_entry_t iree_hal_amdgpu_reclaim_entry_t;
 typedef int iree_status_code_t;
 
 iree_status_t iree_ok_status(void);
@@ -270,4 +271,59 @@ void iree_clang_tidy_status_lifetime_stored(iree_status_t* out_status) {
 iree_status_code_t iree_clang_tidy_status_lifetime_consumed_code(void) {
   iree_status_t consumed_code_status = iree_clang_tidy_status_assigned_source();
   return iree_status_consume_code(consumed_code_status);
+}
+
+int iree_clang_tidy_status_borrowed_parameter(
+    iree_status_t borrowed_parameter_status) {
+  return iree_status_is_ok(borrowed_parameter_status);
+}
+
+int iree_clang_tidy_status_borrowed_parameter_code(
+    iree_status_code_t status_code) {
+  return status_code == IREE_STATUS_OK;
+}
+
+iree_status_t iree_clang_tidy_status_borrowed_parameter_returned(
+    iree_status_t returned_parameter_status) {
+  return returned_parameter_status;
+}
+
+void iree_clang_tidy_status_borrowed_parameter_consumed(
+    iree_status_t consumed_parameter_status) {
+  iree_status_free(consumed_parameter_status);
+}
+
+void iree_clang_tidy_status_borrowed_parameter_stored(
+    iree_status_t stored_parameter_status, iree_status_t* out_status) {
+  *out_status = stored_parameter_status;
+}
+
+iree_status_t iree_clang_tidy_status_borrowed_parameter_joined(
+    iree_status_t joined_parameter_status) {
+  return iree_status_join(joined_parameter_status,
+                          iree_clang_tidy_status_cleanup_source());
+}
+
+iree_status_t iree_clang_tidy_status_borrowed_parameter_annotated(
+    iree_status_t annotated_parameter_status) {
+  return iree_status_annotate(annotated_parameter_status, "message");
+}
+
+iree_status_t iree_clang_tidy_status_borrowed_parameter_cloned(
+    iree_status_t cloned_parameter_status) {
+  return iree_status_clone(cloned_parameter_status);
+}
+
+void iree_clang_tidy_status_borrowed_parameter_sink(
+    void* proactor, void* operation, iree_status_t sink_parameter_status) {
+  iree_async_proactor_io_uring_push_software_completion(proactor, operation,
+                                                        sink_parameter_status);
+}
+
+void iree_clang_tidy_status_borrowed_parameter_reclaim_callback(
+    iree_hal_amdgpu_reclaim_entry_t* entry, void* user_data,
+    iree_status_t reclaim_callback_parameter_status) {
+  (void)entry;
+  *(iree_status_code_t*)user_data =
+      iree_status_code(reclaim_callback_parameter_status);
 }

--- a/build_tools/clang_tidy/test/status_checks.cc
+++ b/build_tools/clang_tidy/test/status_checks.cc
@@ -13,6 +13,7 @@ class Status {
  public:
   Status() = default;
   Status(iree_status_t&& status);
+  const char* ToString(iree_status_t status) { return status ? "error" : "ok"; }
 };
 
 template <typename T>

--- a/build_tools/clang_tidy/test/status_checks.cc
+++ b/build_tools/clang_tidy/test/status_checks.cc
@@ -1,0 +1,88 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+typedef struct iree_status_handle_t* iree_status_t;
+
+iree_status_t iree_clang_tidy_status_cpp_source();
+
+namespace iree {
+class Status {
+ public:
+  Status() = default;
+  Status(iree_status_t&& status);
+};
+
+template <typename T>
+class StatusOr {
+ public:
+  StatusOr(iree_status_t&& status);
+  StatusOr(T value);
+};
+
+namespace internal {
+Status ConsumeForTest(iree_status_t& status);
+Status ConsumeForTest(iree_status_t&& status);
+}  // namespace internal
+}  // namespace iree
+
+namespace std {
+template <typename T>
+T&& move(T& value);
+}  // namespace std
+
+namespace {
+class String {};
+class AssertionResult {
+ public:
+  operator bool() const;
+};
+
+String StatusToStringAndFree(iree_status_t status);
+AssertionResult AssertOkPredicate(iree::Status status);
+
+void iree_clang_tidy_status_lifetime_consume_for_test() {
+  iree_status_t consume_for_test_status = iree_clang_tidy_status_cpp_source();
+  (void)::iree::internal::ConsumeForTest(consume_for_test_status);
+}
+
+void iree_clang_tidy_status_lifetime_consume_for_test_move() {
+  iree_status_t consume_for_test_move_status =
+      iree_clang_tidy_status_cpp_source();
+  (void)::iree::internal::ConsumeForTest(
+      std::move(consume_for_test_move_status));
+}
+
+void iree_clang_tidy_status_lifetime_string_to_free() {
+  iree_status_t string_to_free_status = iree_clang_tidy_status_cpp_source();
+  (void)StatusToStringAndFree(string_to_free_status);
+}
+
+void iree_clang_tidy_status_lifetime_gtest_condition_variable() {
+  iree_status_t gtest_condition_status = iree_clang_tidy_status_cpp_source();
+  if (AssertionResult assertion = AssertOkPredicate(
+          ::iree::internal::ConsumeForTest(gtest_condition_status))) {
+  } else {
+    return;
+  }
+}
+
+iree::Status iree_clang_tidy_status_lifetime_return_cpp_status_wrapper() {
+  iree_status_t cpp_status_wrapper_status = iree_clang_tidy_status_cpp_source();
+  return cpp_status_wrapper_status;
+}
+
+iree::Status iree_clang_tidy_status_lifetime_return_cpp_status_wrapper_move() {
+  iree_status_t cpp_status_wrapper_move_status =
+      iree_clang_tidy_status_cpp_source();
+  return std::move(cpp_status_wrapper_move_status);
+}
+
+iree::StatusOr<int> iree_clang_tidy_status_lifetime_return_cpp_status_or() {
+  iree_status_t cpp_status_or_status = iree_clang_tidy_status_cpp_source();
+  return cpp_status_or_status;
+}
+
+}  // namespace

--- a/build_tools/clang_tidy/test/status_checks_test.py
+++ b/build_tools/clang_tidy/test/status_checks_test.py
@@ -15,6 +15,50 @@ _ARGS = clang_tidy_test.parse_arguments()
 
 
 class StatusChecksTest(clang_tidy_test.ClangTidyAssertions):
+    def test_borrowed_status_parameter_is_diagnosed(self):
+        output = clang_tidy_test.run_clang_tidy(
+            clang_tidy=_ARGS.clang_tidy,
+            plugin=_ARGS.plugin,
+            checks="-*,iree-status-borrowed-parameter",
+            source=clang_tidy_test.source_path(__file__, "status_checks.c"),
+        )
+        self.assertContainsAll(
+            output,
+            [
+                "borrowed_parameter_status",
+                "[iree-status-borrowed-parameter]",
+            ],
+        )
+        self.assertContainsNone(
+            output,
+            [
+                "returned_parameter_status",
+                "consumed_parameter_status",
+                "stored_parameter_status",
+                "joined_parameter_status",
+                "annotated_parameter_status",
+                "cloned_parameter_status",
+                "sink_parameter_status",
+                "reclaim_callback_parameter_status",
+            ],
+        )
+
+    def test_borrowed_status_parameter_accepts_cpp_status_observer(self):
+        output = clang_tidy_test.run_clang_tidy(
+            clang_tidy=_ARGS.clang_tidy,
+            plugin=_ARGS.plugin,
+            checks="-*,iree-status-borrowed-parameter",
+            source=clang_tidy_test.source_path(__file__, "status_checks.cc"),
+            compiler_args=["-std=c++17"],
+        )
+        self.assertContainsNone(
+            output,
+            [
+                "ToString",
+                "[iree-status-borrowed-parameter]",
+            ],
+        )
+
     def test_discarded_status_result_is_diagnosed(self):
         output = clang_tidy_test.run_clang_tidy(
             clang_tidy=_ARGS.clang_tidy,

--- a/build_tools/clang_tidy/test/status_checks_test.py
+++ b/build_tools/clang_tidy/test/status_checks_test.py
@@ -153,6 +153,32 @@ class StatusChecksTest(clang_tidy_test.ClangTidyAssertions):
             ],
         )
 
+    def test_status_transfer_order_is_diagnosed(self):
+        output = clang_tidy_test.run_clang_tidy(
+            clang_tidy=_ARGS.clang_tidy,
+            plugin=_ARGS.plugin,
+            checks="-*,iree-status-transfer-order",
+            source=clang_tidy_test.source_path(__file__, "status_checks.c"),
+        )
+        self.assertContainsAll(
+            output,
+            [
+                "transfer_order_join_same_status",
+                "transfer_order_nested_status",
+                "[iree-status-transfer-order]",
+            ],
+        )
+        self.assertContainsNone(
+            output,
+            [
+                "explicit_sequence_status",
+                "clone_before_fanout_status",
+                "cloned_status",
+                "callback_status",
+                "observer_only_status",
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/build_tools/clang_tidy/test/status_checks_test.py
+++ b/build_tools/clang_tidy/test/status_checks_test.py
@@ -40,6 +40,75 @@ class StatusChecksTest(clang_tidy_test.ClangTidyAssertions):
             ],
         )
 
+    def test_status_lifetime_is_diagnosed(self):
+        output = clang_tidy_test.run_clang_tidy(
+            clang_tidy=_ARGS.clang_tidy,
+            plugin=_ARGS.plugin,
+            checks="-*,iree-status-lifetime",
+            source=clang_tidy_test.source_path(__file__, "status_checks.c"),
+        )
+        self.assertContainsAll(
+            output,
+            [
+                "leaked_status",
+                "overwritten_status",
+                "double_consumed_status",
+                "used_after_consume_status",
+                "used_after_transfer_status",
+                "lost_on_return_status",
+                "code_predicate_status",
+                "[iree-status-lifetime]",
+            ],
+        )
+        self.assertContainsNone(
+            output,
+            [
+                "returned_status",
+                "return_if_error_status",
+                "macro_return_status",
+                "macro_fallthrough_status",
+                "transfer_source_status",
+                "transfer_target_status",
+                "conditional_source_status",
+                "conditional_target_status",
+                "joined_primary_status",
+                "joined_secondary_status",
+                "loop_break_status",
+                "ok_and_status",
+                "consumed_predicate_status",
+                "atomic_escape_status",
+                "atomic_builtin_status",
+                "sink_argument_status",
+                "borrowed_status",
+                "joined_status",
+                "annotated_status",
+                "stored_status",
+                "consumed_code_status",
+            ],
+        )
+
+    def test_status_lifetime_accepts_cpp_test_consumers(self):
+        output = clang_tidy_test.run_clang_tidy(
+            clang_tidy=_ARGS.clang_tidy,
+            plugin=_ARGS.plugin,
+            checks="-*,iree-status-lifetime",
+            source=clang_tidy_test.source_path(__file__, "status_checks.cc"),
+            compiler_args=["-std=c++17"],
+        )
+        self.assertContainsNone(
+            output,
+            [
+                "consume_for_test_status",
+                "consume_for_test_move_status",
+                "string_to_free_status",
+                "gtest_condition_status",
+                "cpp_status_wrapper_status",
+                "cpp_status_wrapper_move_status",
+                "cpp_status_or_status",
+                "[iree-status-lifetime]",
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/build_tools/clang_tidy/test/trace_checks.c
+++ b/build_tools/clang_tidy/test/trace_checks.c
@@ -1,0 +1,145 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+typedef int iree_status_t;
+
+#define IREE_STATUS_OK 0
+
+iree_status_t iree_clang_tidy_trace_status_source(void);
+
+#define IREE_TRACE_ZONE_BEGIN(zone_id) int zone_id = 0
+#define IREE_TRACE_ZONE_BEGIN_NAMED(zone_id, name_literal) int zone_id = 0
+#define IREE_TRACE_ZONE_BEGIN_NAMED_DYNAMIC(zone_id, name, name_length) \
+  int zone_id = 0
+#define IREE_TRACE_ZONE_END(zone_id) (void)(zone_id)
+
+#define IREE_RETURN_IF_ERROR(expr)                           \
+  do {                                                       \
+    iree_status_t status_macro = (expr);                     \
+    if (status_macro != IREE_STATUS_OK) return status_macro; \
+  } while (0)
+
+#define IREE_RETURN_AND_END_ZONE_IF_ERROR(zone_id, expr) \
+  IREE_RETURN_IF_ERROR(expr)
+
+#define IREE_RETURN_AND_END_ZONE(zone_id, expr) return (expr)
+
+#define HRX_TRACE_ZONE_BEGIN(zone_id, name_literal) int zone_id = 0
+#define HRX_TRACE_ZONE_END(zone_id) (void)(zone_id)
+#define HRX_RETURN_IF_IREE_ERROR(expr)                       \
+  do {                                                       \
+    iree_status_t status_macro = (expr);                     \
+    if (status_macro != IREE_STATUS_OK) return status_macro; \
+  } while (0)
+#define HRX_RETURN_AND_END_ZONE_IF_IREE_ERROR(zone_id, expr) \
+  do {                                                       \
+    iree_status_t status_macro = (expr);                     \
+    if (status_macro != IREE_STATUS_OK) {                    \
+      HRX_TRACE_ZONE_END(zone_id);                           \
+      return status_macro;                                   \
+    }                                                        \
+  } while (0)
+#define HRX_RETURN_AND_END_ZONE(zone_id, expr) \
+  do {                                         \
+    HRX_TRACE_ZONE_END(zone_id);               \
+    return (expr);                             \
+  } while (0)
+
+#define HIP_RETURN_ERROR(error) \
+  do {                          \
+    int error_macro = (error);  \
+    return error_macro;         \
+  } while (0)
+
+iree_status_t iree_clang_tidy_trace_zone_balanced(void) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_END(z0);
+  return IREE_STATUS_OK;
+}
+
+iree_status_t iree_clang_tidy_trace_zone_nested_balanced(void) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_BEGIN_NAMED(z1, "inner");
+  IREE_TRACE_ZONE_END(z1);
+  IREE_TRACE_ZONE_END(z0);
+  return IREE_STATUS_OK;
+}
+
+iree_status_t iree_clang_tidy_trace_zone_cleanup_label(int fail) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = IREE_STATUS_OK;
+  if (fail) {
+    status = iree_clang_tidy_trace_status_source();
+    goto cleanup;
+  }
+cleanup:
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+iree_status_t iree_clang_tidy_trace_zone_branch_return_balanced(int fail) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  if (fail) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_clang_tidy_trace_status_source();
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return IREE_STATUS_OK;
+}
+
+int iree_clang_tidy_trace_zone_branch_macro_return_balanced(int fail) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  if (fail) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(1);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return 0;
+}
+
+iree_status_t iree_clang_tidy_trace_zone_branch_local_zone(int flag) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  if (flag) {
+    IREE_TRACE_ZONE_BEGIN(z1);
+    IREE_TRACE_ZONE_END(z1);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return IREE_STATUS_OK;
+}
+
+iree_status_t iree_clang_tidy_trace_zone_return_and_end_if_error(void) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, iree_clang_tidy_trace_status_source());
+  IREE_TRACE_ZONE_END(z0);
+  return IREE_STATUS_OK;
+}
+
+iree_status_t iree_clang_tidy_trace_zone_return_and_end(void) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_RETURN_AND_END_ZONE(z0, iree_clang_tidy_trace_status_source());
+}
+
+iree_status_t iree_clang_tidy_trace_zone_hrx_return_and_end_if_error(void) {
+  HRX_TRACE_ZONE_BEGIN(z0, "hrx");
+  HRX_RETURN_AND_END_ZONE_IF_IREE_ERROR(z0,
+                                        iree_clang_tidy_trace_status_source());
+  HRX_TRACE_ZONE_END(z0);
+  return IREE_STATUS_OK;
+}
+
+iree_status_t iree_clang_tidy_trace_zone_plain_return_if_error(void) {
+  IREE_TRACE_ZONE_BEGIN(plain_return_if_error_zone);
+  IREE_RETURN_IF_ERROR(iree_clang_tidy_trace_status_source());
+  IREE_TRACE_ZONE_END(plain_return_if_error_zone);
+  return IREE_STATUS_OK;
+}
+
+iree_status_t iree_clang_tidy_trace_zone_hrx_plain_return_if_error(void) {
+  HRX_TRACE_ZONE_BEGIN(hrx_plain_return_zone, "hrx");
+  HRX_RETURN_IF_IREE_ERROR(iree_clang_tidy_trace_status_source());
+  HRX_TRACE_ZONE_END(hrx_plain_return_zone);
+  return IREE_STATUS_OK;
+}

--- a/build_tools/clang_tidy/test/trace_checks_test.py
+++ b/build_tools/clang_tidy/test/trace_checks_test.py
@@ -1,0 +1,49 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import unittest
+
+import clang_tidy_test
+
+_ARGS = clang_tidy_test.parse_arguments()
+
+
+class TraceChecksTest(clang_tidy_test.ClangTidyAssertions):
+    def test_trace_zone_balance_is_diagnosed(self):
+        output = clang_tidy_test.run_clang_tidy(
+            clang_tidy=_ARGS.clang_tidy,
+            plugin=_ARGS.plugin,
+            checks="-*,iree-trace-zone-balance",
+            source=clang_tidy_test.source_path(__file__, "trace_checks.c"),
+        )
+        self.assertContainsAll(
+            output,
+            [
+                "plain_return_if_error_zone",
+                "hrx_plain_return_zone",
+                "[iree-trace-zone-balance]",
+            ],
+        )
+        self.assertContainsNone(
+            output,
+            [
+                "iree_clang_tidy_trace_zone_balanced",
+                "iree_clang_tidy_trace_zone_nested_balanced",
+                "iree_clang_tidy_trace_zone_cleanup_label",
+                "iree_clang_tidy_trace_zone_branch_return_balanced",
+                "iree_clang_tidy_trace_zone_branch_macro_return_balanced",
+                "iree_clang_tidy_trace_zone_branch_local_zone",
+                "iree_clang_tidy_trace_zone_return_and_end_if_error",
+                "iree_clang_tidy_trace_zone_return_and_end",
+                "iree_clang_tidy_trace_zone_hrx_return_and_end_if_error",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/cmake/iree_c_embed_data.cmake
+++ b/build_tools/cmake/iree_c_embed_data.cmake
@@ -103,6 +103,43 @@ function(iree_c_embed_data)
     COMMAND ${IREE_C_EMBED_DATA_TOOL_BINARY} ${_ARGS} ${_RESOLVED_SRCS}
     DEPENDS ${IREE_C_EMBED_DATA_TOOL_BINARY} ${_RESOLVED_SRCS}
   )
+  set(_REGISTER_COMPILE_INPUT TRUE)
+  foreach(_RESOLVED_SRC IN LISTS _RESOLVED_SRCS)
+    cmake_path(ABSOLUTE_PATH _RESOLVED_SRC NORMALIZE
+      OUTPUT_VARIABLE _RESOLVED_SRC_ABSOLUTE)
+    foreach(_BINARY_PREFIX
+        "${IREE_BINARY_DIR}"
+        "${PROJECT_BINARY_DIR}"
+        "${CMAKE_BINARY_DIR}"
+        "${CMAKE_CURRENT_BINARY_DIR}")
+      cmake_path(ABSOLUTE_PATH _BINARY_PREFIX NORMALIZE
+        OUTPUT_VARIABLE _BINARY_PREFIX_ABSOLUTE)
+      string(FIND "${_RESOLVED_SRC_ABSOLUTE}/" "${_BINARY_PREFIX_ABSOLUTE}/"
+        _BINARY_PREFIX_INDEX)
+      if(_BINARY_PREFIX_INDEX EQUAL 0)
+        set(_REGISTER_COMPILE_INPUT FALSE)
+      endif()
+    endforeach()
+  endforeach()
+  foreach(_SRC IN LISTS _RULE_SRCS)
+    if("${_SRC}" MATCHES "[.]vmfb$")
+      set(_REGISTER_COMPILE_INPUT TRUE)
+    endif()
+  endforeach()
+  if(_REGISTER_COMPILE_INPUT)
+    if(_RULE_PACKAGE)
+      string(REPLACE "::" "_" _PACKAGE_NAME "${_RULE_PACKAGE}")
+    else()
+      iree_package_name(_PACKAGE_NAME)
+    endif()
+    set(_GEN_TARGET "${_PACKAGE_NAME}_${_RULE_NAME}_c_embed_data_gen")
+    add_custom_target("${_GEN_TARGET}"
+      DEPENDS
+        "${_RULE_H_FILE_OUTPUT}"
+        "${_RULE_C_FILE_OUTPUT}"
+    )
+    iree_register_generated_compile_input("${_GEN_TARGET}")
+  endif()
 
   if(_RULE_TESTONLY)
     set(_TESTONLY_ARG "TESTONLY")
@@ -121,4 +158,13 @@ function(iree_c_embed_data)
     "${_PUBLIC_ARG}"
     "${_TESTONLY_ARG}"
   )
+  if(_REGISTER_COMPILE_INPUT)
+    set(_LIB_TARGET "${_PACKAGE_NAME}_${_RULE_NAME}")
+    if(TARGET "${_LIB_TARGET}")
+      add_dependencies("${_LIB_TARGET}" "${_GEN_TARGET}")
+    endif()
+    if(TARGET "${_LIB_TARGET}.objects")
+      add_dependencies("${_LIB_TARGET}.objects" "${_GEN_TARGET}")
+    endif()
+  endif()
 endfunction()

--- a/build_tools/cmake/iree_genrule.cmake
+++ b/build_tools/cmake/iree_genrule.cmake
@@ -88,4 +88,5 @@ function(iree_genrule)
   add_custom_target("${_RULE_NAME}"
     DEPENDS ${_RULE_OUTS}
   )
+  iree_register_generated_compile_input("${_RULE_NAME}")
 endfunction()

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -97,6 +97,24 @@ endif()
 # General utilities
 #-------------------------------------------------------------------------------
 
+if(NOT TARGET iree_generated_compile_inputs)
+  add_custom_target(iree_generated_compile_inputs)
+endif()
+
+# Registers a target that materializes generated C/C++ compile inputs.
+#
+# Compile-database consumers such as clang-tidy read compile_commands.json
+# without asking CMake to build the source target first. Generated headers and
+# sources therefore need a stable aggregate target that prepares the filesystem
+# view before external analysis starts.
+function(iree_register_generated_compile_input TARGET_NAME)
+  if(NOT TARGET "${TARGET_NAME}")
+    message(FATAL_ERROR
+      "Generated compile input target ${TARGET_NAME} was not found")
+  endif()
+  add_dependencies(iree_generated_compile_inputs "${TARGET_NAME}")
+endfunction()
+
 # iree_to_bool
 #
 # Sets `variable` to `ON` if `value` is true and `OFF` otherwise.

--- a/build_tools/devtools/help_text.py
+++ b/build_tools/devtools/help_text.py
@@ -274,9 +274,11 @@ fixes through Bazel, applies them outside Bazel, then re-runs the check.""",
 
 With no input option, this checks local staged, unstaged, and untracked files.
 Repo-relative paths and git scopes use the configured CMake compile database.
---fix applies fixes through run-clang-tidy, then re-runs the check. Run
-`python dev.py cmake configure` first. Select a build tree with
---cmake-build-dir or IREE_CMAKE_BUILD_DIR.""",
+The scan materializes generated compile inputs, then runs through
+run-clang-tidy with parallelism controlled by IREE_CLANG_TIDY_JOBS. --fix
+applies fixes through run-clang-tidy, then re-runs the check. Run
+`python dev.py cmake configure` first. Select a build tree with --cmake-build-dir
+or IREE_CMAKE_BUILD_DIR.""",
         )
     if command == "presubmit":
         return CommandHelp(
@@ -801,11 +803,12 @@ python dev.py cmake clang-tidy runtime/src/iree/base/status.c
 python dev.py --cmake-build-dir build/cmake-asan cmake clang-tidy runtime/src/iree/base/status.c
 ```
 
-The command builds the IREE clang-tidy plugin with CMake and runs `clang-tidy`
-against source files using the configured CMake `compile_commands.json`.
-`--fix` applies fixes through `run-clang-tidy`, then re-runs the normal check.
-Select the CMake build tree with `--cmake-build-dir` or
-`IREE_CMAKE_BUILD_DIR`."""
+The command builds the IREE clang-tidy plugin with CMake, materializes generated
+compile inputs, and runs `run-clang-tidy` against source files using the
+configured CMake `compile_commands.json`. The scan uses parallelism controlled
+by `IREE_CLANG_TIDY_JOBS`. `--fix` applies fixes through `run-clang-tidy`, then
+re-runs the normal check. Select the CMake build tree with `--cmake-build-dir`
+or `IREE_CMAKE_BUILD_DIR`."""
 
     if command == "configure":
         return """## iree-cmake-configure

--- a/build_tools/lefthook/presubmit.py
+++ b/build_tools/lefthook/presubmit.py
@@ -77,7 +77,10 @@ SEMGREP_PATH_PREFIXES = (
     "libhrx/",
 )
 SEMGREP_DEFAULT_MAX_JOBS = 14
+CLANG_TIDY_DEFAULT_CORE_DIVISOR = 2
+CLANG_TIDY_DEFAULT_MAX_JOBS = 96
 CLANG_TIDY_ASPECT = "//build_tools/clang_tidy:clang_tidy.bzl%collect_clang_tidy_aspect"
+CLANG_TIDY_CMAKE_GENERATED_INPUTS_TARGET = "iree_generated_compile_inputs"
 CLANG_TIDY_TRANSLATION_UNIT_EXTENSIONS = {
     ".c",
     ".cc",
@@ -975,6 +978,19 @@ def semgrep_jobs() -> int:
     return min(SEMGREP_DEFAULT_MAX_JOBS, max(1, int(cpu_count * 0.85)))
 
 
+def clang_tidy_jobs() -> int:
+    configured_jobs = os.environ.get("IREE_CLANG_TIDY_JOBS")
+    if configured_jobs:
+        try:
+            jobs = int(configured_jobs)
+        except ValueError:
+            return 1
+        return max(1, jobs)
+    cpu_count = os.cpu_count() or 1
+    default_jobs = max(1, (cpu_count + CLANG_TIDY_DEFAULT_CORE_DIVISOR - 1) // 2)
+    return min(cpu_count, CLANG_TIDY_DEFAULT_MAX_JOBS, default_jobs)
+
+
 def semgrep_scan_command(files: list[str]) -> list[str]:
     return [
         "semgrep",
@@ -1588,29 +1604,37 @@ def cmake_clang_tidy_plugin_path(build_dir: Path) -> Path | None:
 
 def cmake_clang_tidy_command(
     *,
+    run_clang_tidy: str,
     clang_tidy: str,
     plugin: Path,
     compile_commands_dir: Path,
     files: list[str],
-    fix: bool = False,
 ) -> list[str]:
-    command = [
+    return [
+        run_clang_tidy,
+        "-clang-tidy-binary",
         clang_tidy,
-        f"--load={plugin}",
-        f"--checks={CLANG_TIDY_CHECKS}",
-        f"-p={compile_commands_dir}",
-    ]
-    if fix:
-        command += [
-            "--fix-errors",
-            "--format-style=file",
-        ]
-    else:
-        command.append("--warnings-as-errors=*")
-    command += [
+        "-p",
+        str(compile_commands_dir),
+        f"-checks={CLANG_TIDY_CHECKS}",
+        f"-load={plugin}",
+        "-j",
+        str(clang_tidy_jobs()),
+        "-warnings-as-errors=*",
         *files,
     ]
-    return command
+
+
+def cmake_generated_compile_inputs_command(*, compile_commands_dir: Path) -> list[str]:
+    return [
+        "cmake",
+        "--build",
+        str(compile_commands_dir),
+        "--target",
+        CLANG_TIDY_CMAKE_GENERATED_INPUTS_TARGET,
+        "--parallel",
+        str(clang_tidy_jobs()),
+    ]
 
 
 def cmake_run_clang_tidy_fix_command(
@@ -1633,7 +1657,7 @@ def cmake_run_clang_tidy_fix_command(
         f"-checks={CLANG_TIDY_CHECKS}",
         f"-load={plugin}",
         "-j",
-        str(semgrep_jobs()),
+        str(clang_tidy_jobs()),
         "-fix",
         "-format",
         "-style=file",
@@ -1707,15 +1731,25 @@ def run_clang_tidy_cmake(
             return False
         return skip_step("clang-tidy", CLANG_TIDY_SETUP_HINT)
     llvm_config, clang_tidy, _ = tools
-    clang_apply_replacements = None
     run_clang_tidy = None
+    if candidate_files:
+        run_clang_tidy = clang_tidy_run_tool()
+        if not run_clang_tidy:
+            if clang_tidy_required(profile):
+                print(
+                    f"[fail] clang-tidy: {CLANG_TIDY_SETUP_HINT} with run-clang-tidy."
+                )
+                return False
+            return skip_step(
+                "clang-tidy", f"{CLANG_TIDY_SETUP_HINT} with run-clang-tidy"
+            )
+    clang_apply_replacements = None
     if fix:
         clang_apply_replacements = clang_tidy_apply_replacements_tool()
-        run_clang_tidy = clang_tidy_run_tool()
-        if not clang_apply_replacements or not run_clang_tidy:
+        if not clang_apply_replacements:
             print(
                 f"[fail] clang-tidy: {CLANG_TIDY_SETUP_HINT} with "
-                "clang-apply-replacements and run-clang-tidy for --fix."
+                "clang-apply-replacements for --fix."
             )
             return False
     if not require_tool("cmake", "clang-tidy CMake plugin"):
@@ -1785,6 +1819,19 @@ def run_clang_tidy_cmake(
         print("hint: run python dev.py cmake configure")
         return False
 
+    ok = (
+        run_command(
+            cmake_generated_compile_inputs_command(
+                compile_commands_dir=compile_commands_dir,
+            ),
+            "clang-tidy CMake generated compile inputs",
+            verbose,
+        )
+        and ok
+    )
+    if not ok:
+        return False
+
     if fix:
         ok = (
             run_command(
@@ -1805,6 +1852,7 @@ def run_clang_tidy_cmake(
             ok = (
                 run_command(
                     cmake_clang_tidy_command(
+                        run_clang_tidy=run_clang_tidy,
                         clang_tidy=clang_tidy,
                         plugin=plugin,
                         compile_commands_dir=compile_commands_dir,
@@ -1819,6 +1867,7 @@ def run_clang_tidy_cmake(
         ok = (
             run_command(
                 cmake_clang_tidy_command(
+                    run_clang_tidy=run_clang_tidy,
                     clang_tidy=clang_tidy,
                     plugin=plugin,
                     compile_commands_dir=compile_commands_dir,

--- a/build_tools/lefthook/presubmit_test.py
+++ b/build_tools/lefthook/presubmit_test.py
@@ -71,6 +71,27 @@ class PresubmitTest(unittest.TestCase):
         ):
             self.assertEqual(presubmit.semgrep_jobs(), 14)
 
+    def test_clang_tidy_default_jobs_are_capped_on_large_machines(self):
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(presubmit.os, "cpu_count", return_value=192),
+        ):
+            self.assertEqual(
+                presubmit.clang_tidy_jobs(),
+                presubmit.CLANG_TIDY_DEFAULT_MAX_JOBS,
+            )
+
+    def test_clang_tidy_default_jobs_use_half_machine(self):
+        with (
+            mock.patch.dict(os.environ, {}, clear=True),
+            mock.patch.object(presubmit.os, "cpu_count", return_value=64),
+        ):
+            self.assertEqual(presubmit.clang_tidy_jobs(), 32)
+
+    def test_clang_tidy_jobs_can_be_configured(self):
+        with mock.patch.dict(os.environ, {"IREE_CLANG_TIDY_JOBS": "48"}):
+            self.assertEqual(presubmit.clang_tidy_jobs(), 48)
+
     def test_clang_format_default_jobs_are_capped_on_large_machines(self):
         with (
             mock.patch.dict(os.environ, {}, clear=True),
@@ -230,35 +251,60 @@ class PresubmitTest(unittest.TestCase):
                 ["runtime/src/iree/base/status.c"],
             )
 
-    def test_cmake_clang_tidy_command_uses_compile_database(self):
-        command = presubmit.cmake_clang_tidy_command(
-            clang_tidy="clang-tidy",
-            plugin=Path(".tmp/plugin/libIREEClangTidyPlugin.so"),
-            compile_commands_dir=Path("build/cmake-debug"),
-            files=["runtime/src/iree/base/status.c"],
-        )
+    def test_cmake_clang_tidy_command_uses_parallel_driver(self):
+        with mock.patch.object(presubmit, "clang_tidy_jobs", return_value=17):
+            command = presubmit.cmake_clang_tidy_command(
+                run_clang_tidy="run-clang-tidy",
+                clang_tidy="clang-tidy",
+                plugin=Path(".tmp/plugin/libIREEClangTidyPlugin.so"),
+                compile_commands_dir=Path("build/cmake-debug"),
+                files=["runtime/src/iree/base/status.c"],
+            )
 
-        self.assertEqual(command[0], "clang-tidy")
-        self.assertIn("--load=.tmp/plugin/libIREEClangTidyPlugin.so", command)
-        self.assertIn(f"--checks={presubmit.CLANG_TIDY_CHECKS}", command)
-        self.assertIn("-p=build/cmake-debug", command)
+        self.assertEqual(command[0], "run-clang-tidy")
+        self.assertIn("-clang-tidy-binary", command)
+        self.assertIn("clang-tidy", command)
+        self.assertIn("-load=.tmp/plugin/libIREEClangTidyPlugin.so", command)
+        self.assertIn(f"-checks={presubmit.CLANG_TIDY_CHECKS}", command)
+        self.assertIn("-p", command)
+        self.assertIn("build/cmake-debug", command)
+        self.assertIn("-j", command)
+        self.assertIn("17", command)
+        self.assertIn("-warnings-as-errors=*", command)
         self.assertEqual(command[-1], "runtime/src/iree/base/status.c")
 
+    def test_cmake_generated_compile_inputs_command_uses_cmake_build(self):
+        with mock.patch.object(presubmit, "clang_tidy_jobs", return_value=23):
+            command = presubmit.cmake_generated_compile_inputs_command(
+                compile_commands_dir=Path("build/cmake-debug"),
+            )
+
+        self.assertEqual(command[0], "cmake")
+        self.assertIn("--build", command)
+        self.assertIn("build/cmake-debug", command)
+        self.assertIn("--target", command)
+        self.assertIn(presubmit.CLANG_TIDY_CMAKE_GENERATED_INPUTS_TARGET, command)
+        self.assertIn("--parallel", command)
+        self.assertIn("23", command)
+
     def test_cmake_clang_tidy_fix_command_uses_parallel_driver(self):
-        command = presubmit.cmake_run_clang_tidy_fix_command(
-            run_clang_tidy="run-clang-tidy",
-            clang_tidy="clang-tidy",
-            clang_apply_replacements="clang-apply-replacements",
-            plugin=Path(".tmp/plugin/libIREEClangTidyPlugin.so"),
-            compile_commands_dir=Path("build/cmake-debug"),
-            files=["runtime/src/iree/base/status.c"],
-        )
+        with mock.patch.object(presubmit, "clang_tidy_jobs", return_value=19):
+            command = presubmit.cmake_run_clang_tidy_fix_command(
+                run_clang_tidy="run-clang-tidy",
+                clang_tidy="clang-tidy",
+                clang_apply_replacements="clang-apply-replacements",
+                plugin=Path(".tmp/plugin/libIREEClangTidyPlugin.so"),
+                compile_commands_dir=Path("build/cmake-debug"),
+                files=["runtime/src/iree/base/status.c"],
+            )
 
         self.assertEqual(command[0], "run-clang-tidy")
         self.assertIn("-clang-tidy-binary", command)
         self.assertIn("clang-tidy", command)
         self.assertIn("-clang-apply-replacements-binary", command)
         self.assertIn("clang-apply-replacements", command)
+        self.assertIn("-j", command)
+        self.assertIn("19", command)
         self.assertIn("-fix", command)
         self.assertIn("-format", command)
         self.assertEqual(command[-1], "runtime/src/iree/base/status.c")

--- a/libhrx/src/binding/common/context.c
+++ b/libhrx/src/binding/common/context.c
@@ -106,7 +106,7 @@ iree_status_t iree_hal_streaming_context_create(
   // Initialize symbol map with global registry as the backing store.
   iree_hal_streaming_global_symbol_registry_t* registry =
       iree_hal_streaming_global_symbol_registry();
-  if (!registry) {
+  if (iree_status_is_ok(status) && !registry) {
     status = iree_make_status(IREE_STATUS_INTERNAL,
                               "global symbol registry failed to initialize");
   }

--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -494,10 +494,11 @@ static iree_status_t iree_hal_streaming_graph_create_dispatch_block(
     attrs->bindings.values = bindings_copy;
 
     // Add buffers to resource set.
-    IREE_RETURN_IF_ERROR(iree_hal_resource_set_insert_strided(
-        exec->resource_set, bindings.count, bindings.values,
-        offsetof(iree_hal_buffer_ref_t, buffer),
-        sizeof(iree_hal_buffer_ref_t)));
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_hal_resource_set_insert_strided(
+                exec->resource_set, bindings.count, bindings.values,
+                offsetof(iree_hal_buffer_ref_t, buffer),
+                sizeof(iree_hal_buffer_ref_t)));
   } else {
     attrs->bindings = iree_hal_buffer_ref_list_empty();
   }

--- a/libhrx/src/binding/common/init.c
+++ b/libhrx/src/binding/common/init.c
@@ -344,9 +344,9 @@ static iree_status_t iree_hal_streaming_query_p2p_capabilities(
   registry->p2p_link_count = registry->device_count * registry->device_count;
   const iree_host_size_t topology_size =
       registry->p2p_link_count * sizeof(iree_hal_streaming_p2p_link_t);
-  IREE_RETURN_IF_ERROR(iree_allocator_malloc(registry->host_allocator,
-                                             topology_size,
-                                             (void**)&registry->p2p_topology));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_allocator_malloc(registry->host_allocator, topology_size,
+                                (void**)&registry->p2p_topology));
   memset(registry->p2p_topology, 0, topology_size);
 
   // Populate P2P links for all device pairs.

--- a/libhrx/src/libhrx/runtime.c
+++ b/libhrx/src/libhrx/runtime.c
@@ -356,12 +356,12 @@ static void hrx_gpu_release_created_devices(int count) {
 }
 
 static void hrx_debug_print_iree_status(const char* label,
-                                        iree_status_t status) {
-  if (!hrx_gpu_debug_enabled() || iree_status_is_ok(status)) return;
+                                        const iree_status_t* status) {
+  if (!hrx_gpu_debug_enabled() || iree_status_is_ok(*status)) return;
   iree_allocator_t allocator = iree_allocator_system();
   char* message = NULL;
   iree_host_size_t message_length = 0;
-  if (iree_status_to_string(status, &allocator, &message, &message_length)) {
+  if (iree_status_to_string(*status, &allocator, &message, &message_length)) {
     fprintf(stderr, "hrx gpu debug: %s: %s\n", label,
             message ? message : "(no message)");
     iree_allocator_free(allocator, message);
@@ -379,7 +379,7 @@ static hrx_status_t hrx_create_iree_amdgpu_driver(
     iree_status_ignore(status);
     status = iree_ok_status();
   }
-  hrx_debug_print_iree_status("amdgpu driver module register", status);
+  hrx_debug_print_iree_status("amdgpu driver module register", &status);
   if (!iree_status_is_ok(status)) {
     return hrx_status_from_iree(status);
   }
@@ -388,7 +388,7 @@ static hrx_status_t hrx_create_iree_amdgpu_driver(
   status = iree_hal_driver_registry_try_create(
       iree_hal_driver_registry_default(), iree_make_cstring_view("amdgpu"),
       alloc, &driver);
-  hrx_debug_print_iree_status("amdgpu driver create", status);
+  hrx_debug_print_iree_status("amdgpu driver create", &status);
   if (!iree_status_is_ok(status)) {
     return hrx_status_from_iree(status);
   }
@@ -558,7 +558,7 @@ hrx_status_t hrx_gpu_initialize(uint32_t flags) {
   iree_hal_device_info_t* device_infos = NULL;
   iree_status = iree_hal_driver_query_available_devices(
       driver, alloc, &device_info_count, &device_infos);
-  hrx_debug_print_iree_status("query available devices", iree_status);
+  hrx_debug_print_iree_status("query available devices", &iree_status);
   if (!iree_status_is_ok(iree_status)) {
     iree_hal_driver_release(driver);
     hrx_release_shared_state();
@@ -604,7 +604,7 @@ hrx_status_t hrx_gpu_initialize(uint32_t flags) {
   if (profile_file_path) {
     iree_status =
         hrx_profile_file_sink_create(profile_file_path, alloc, &profile_sink);
-    hrx_debug_print_iree_status("create profile file sink", iree_status);
+    hrx_debug_print_iree_status("create profile file sink", &iree_status);
     if (!iree_status_is_ok(iree_status)) {
       iree_allocator_free(alloc, device_infos);
       iree_hal_driver_release(driver);
@@ -622,7 +622,7 @@ hrx_status_t hrx_gpu_initialize(uint32_t flags) {
     iree_status = iree_hal_driver_create_device_by_ordinal(
         driver, info_index, /*param_count=*/0, /*params=*/NULL, &create_params,
         alloc, &hal_device);
-    hrx_debug_print_iree_status("create device by ordinal", iree_status);
+    hrx_debug_print_iree_status("create device by ordinal", &iree_status);
     if (!iree_status_is_ok(iree_status)) {
       hrx_gpu_release_created_devices(created_count);
       iree_hal_profile_sink_release(profile_sink);
@@ -668,7 +668,7 @@ hrx_status_t hrx_gpu_initialize(uint32_t flags) {
     hrx_set_gpu_architecture_from_hal(hal_device, dev);
 
     iree_status = hrx_device_profile_begin(dev, profile_sink);
-    hrx_debug_print_iree_status("begin device profiling", iree_status);
+    hrx_debug_print_iree_status("begin device profiling", &iree_status);
     if (!iree_status_is_ok(iree_status)) {
       hrx_device_release(dev);
       hrx_gpu_release_created_devices(created_count);

--- a/loom/build_tools/cmake/loom_generated.cmake
+++ b/loom/build_tools/cmake/loom_generated.cmake
@@ -79,10 +79,12 @@ function(loom_generated_textual_header)
   )
 
   iree_package_name(_PACKAGE_NAME)
-  add_custom_target("${_PACKAGE_NAME}_${_RULE_NAME}"
+  set(_GEN_TARGET "${_PACKAGE_NAME}_${_RULE_NAME}")
+  add_custom_target("${_GEN_TARGET}"
     DEPENDS
       "${_OUTPUT}"
   )
+  iree_register_generated_compile_input("${_GEN_TARGET}")
 endfunction()
 
 function(loom_generated_cc_library)
@@ -198,10 +200,12 @@ function(loom_generated_cc_library)
   )
 
   iree_package_name(_PACKAGE_NAME)
-  add_custom_target("${_PACKAGE_NAME}_${_RULE_NAME}_gen"
+  set(_GEN_TARGET "${_PACKAGE_NAME}_${_RULE_NAME}_gen")
+  add_custom_target("${_GEN_TARGET}"
     DEPENDS
       ${_OUTPUTS}
   )
+  iree_register_generated_compile_input("${_GEN_TARGET}")
   if(_RULE_TESTONLY)
     set(_TESTONLY_ARG TESTONLY)
   else()

--- a/loom/build_tools/cmake/loom_low_descriptor.cmake
+++ b/loom/build_tools/cmake/loom_low_descriptor.cmake
@@ -113,10 +113,12 @@ function(loom_target_table_cc_library)
       message(FATAL_ERROR
         "loom_target_table_cc_library HEADER_ONLY target cannot generate outputs")
     endif()
-    add_custom_target("${_PACKAGE_NAME}_${_RULE_NAME}_gen"
+    set(_GEN_TARGET "${_PACKAGE_NAME}_${_RULE_NAME}_gen")
+    add_custom_target("${_GEN_TARGET}"
       DEPENDS
         "${_HEADER}"
     )
+    iree_register_generated_compile_input("${_GEN_TARGET}")
     loom_cc_library(
       NAME
         ${_RULE_NAME}
@@ -129,7 +131,7 @@ function(loom_target_table_cc_library)
     )
     add_dependencies(
       "${_PACKAGE_NAME}_${_RULE_NAME}"
-      "${_PACKAGE_NAME}_${_RULE_NAME}_gen"
+      "${_GEN_TARGET}"
     )
     return()
   endif()
@@ -161,12 +163,14 @@ function(loom_target_table_cc_library)
     VERBATIM
   )
 
-  add_custom_target("${_PACKAGE_NAME}_${_RULE_NAME}_gen"
+  set(_GEN_TARGET "${_PACKAGE_NAME}_${_RULE_NAME}_gen")
+  add_custom_target("${_GEN_TARGET}"
     DEPENDS
       "${_SOURCE}"
       "${_HEADER}"
       ${_GENERATED_HDRS}
   )
+  iree_register_generated_compile_input("${_GEN_TARGET}")
 
   loom_cc_library(
     NAME
@@ -218,6 +222,7 @@ function(loom_low_descriptor_cc_library)
 
   set(_HEADER "${CMAKE_CURRENT_BINARY_DIR}/${_RULE_HEADER}")
   iree_package_name(_PACKAGE_NAME)
+  set(_GEN_TARGET "${_PACKAGE_NAME}_${_RULE_NAME}_gen")
   loom_cc_library(
     NAME
       "${_RULE_NAME}_ids"
@@ -230,7 +235,7 @@ function(loom_low_descriptor_cc_library)
   )
   add_dependencies(
     "${_PACKAGE_NAME}_${_RULE_NAME}_ids"
-    "${_PACKAGE_NAME}_${_RULE_NAME}_gen"
+    "${_GEN_TARGET}"
   )
 endfunction()
 

--- a/loom/src/loom/format/text/parser/types.c
+++ b/loom/src/loom/format/text/parser/types.c
@@ -165,7 +165,7 @@ iree_status_t loom_parse_static_encoding(loom_parser_t* parser,
 
     uint32_t errors_before = parser->error_count;
     iree_status_t status = loom_parse_encoding_params(parser, params_scratch);
-    if (parser->error_count > errors_before) {
+    if (iree_status_is_ok(status) && parser->error_count > errors_before) {
       loom_parser_release_encoding_params(parser, params_scratch);
       return iree_ok_status();
     }

--- a/loom/src/loom/pass/interpreter.c
+++ b/loom/src/loom/pass/interpreter.c
@@ -355,14 +355,13 @@ static iree_status_t loom_pass_interpreter_invoke(
     invoke->descriptor->destroy(&pass);
   }
 
-  iree_status_t pass_status = status;
   iree_status_t report_status = iree_ok_status();
   loom_pass_interpreter_accumulate_diagnostics(state, &diagnostic_counter);
 
   if (state->options->report) {
     iree_duration_t duration_nanoseconds = iree_time_now() - start_time;
-    iree_status_code_t status_code = iree_status_code(pass_status);
-    if (iree_status_is_ok(pass_status) && diagnostic_counter.error_count != 0) {
+    iree_status_code_t status_code = iree_status_code(status);
+    if (iree_status_is_ok(status) && diagnostic_counter.error_count != 0) {
       status_code = IREE_STATUS_FAILED_PRECONDITION;
     }
     report_status = loom_pass_report_append_invocation(
@@ -382,17 +381,17 @@ static iree_status_t loom_pass_interpreter_invoke(
   }
 
   iree_arena_deinitialize(&instance_arena);
-  if (!iree_status_is_ok(pass_status)) {
+  if (!iree_status_is_ok(status)) {
     if (diagnostic_counter.emission_count == 0) {
-      pass_status = iree_status_join(
-          pass_status, loom_pass_interpreter_emit_failure_diagnostic(
-                           state, frame, instruction));
+      status = iree_status_join(
+          status, loom_pass_interpreter_emit_failure_diagnostic(state, frame,
+                                                                instruction));
     }
-    pass_status = iree_status_join(pass_status, report_status);
+    status = iree_status_join(status, report_status);
     iree_string_view_t symbol_name =
         loom_pass_interpreter_symbol_name(state, frame);
     return iree_status_annotate_f(
-        pass_status, "while executing pass '%.*s' at %s anchor on @%.*s",
+        status, "while executing pass '%.*s' at %s anchor on @%.*s",
         (int)invoke->descriptor->key.size, invoke->descriptor->key.data,
         loom_pass_interpreter_anchor_name(frame->kind), (int)symbol_name.size,
         symbol_name.data);

--- a/loom/src/loom/target/compile_report.c
+++ b/loom/src/loom/target/compile_report.c
@@ -71,8 +71,8 @@ void loom_target_compile_report_initialize_if_empty(
 }
 
 void loom_target_compile_report_record_status(
-    loom_target_compile_report_t* report, iree_status_t status) {
-  report->status_code = iree_status_code(status);
+    loom_target_compile_report_t* report, iree_status_code_t status_code) {
+  report->status_code = status_code;
 }
 
 void loom_target_compile_report_record_target_bundle(

--- a/loom/src/loom/target/compile_report.h
+++ b/loom/src/loom/target/compile_report.h
@@ -503,7 +503,7 @@ void loom_target_compile_report_initialize_if_empty(
 
 // Records a terminal status code in |report|.
 void loom_target_compile_report_record_status(
-    loom_target_compile_report_t* report, iree_status_t status);
+    loom_target_compile_report_t* report, iree_status_code_t status_code);
 
 // Records the target bundle selected for compilation.
 void loom_target_compile_report_record_target_bundle(

--- a/loom/src/loom/target/emit/ireevm/archive_emitter.c
+++ b/loom/src/loom/target/emit/ireevm/archive_emitter.c
@@ -597,7 +597,8 @@ iree_status_t loom_ireevm_emit_module_archive_from_ir(
     loom_ireevm_module_archive_deinitialize(out_archive, allocator);
   }
   if (state.report != NULL) {
-    loom_target_compile_report_record_status(state.report, status);
+    loom_target_compile_report_record_status(state.report,
+                                             iree_status_code(status));
   }
   if (state.initialized) {
     loom_ireevm_archive_emit_state_deinitialize(&state);

--- a/loom/src/loom/target/emit/ireevm/function_bytecode.c
+++ b/loom/src/loom/target/emit/ireevm/function_bytecode.c
@@ -363,8 +363,18 @@ static iree_status_t loom_ireevm_register_assignment_metadata(
       assignment->descriptor_reg_class_id, &layout);
   if (!iree_status_is_ok(status)) {
     iree_string_view_t register_class = iree_string_view_empty();
-    IREE_RETURN_IF_ERROR(loom_low_allocation_assignment_register_class_name(
-        allocation, assignment, &register_class));
+    iree_status_t name_status =
+        loom_low_allocation_assignment_register_class_name(
+            allocation, assignment, &register_class);
+    if (!iree_status_is_ok(name_status)) {
+      return iree_status_join(
+          iree_status_annotate_f(status,
+                                 "while emitting VM bytecode value %u "
+                                 "allocated to invalid register class %u",
+                                 (unsigned)assignment->value_id,
+                                 (unsigned)assignment->descriptor_reg_class_id),
+          name_status);
+    }
     return iree_status_annotate_f(status,
                                   "while emitting VM bytecode value %u "
                                   "allocated to register class '%.*s'",

--- a/loom/src/loom/target/emit/native/amdgpu/hal_kernel_library.c
+++ b/loom/src/loom/target/emit/native/amdgpu/hal_kernel_library.c
@@ -802,7 +802,7 @@ iree_status_t loom_amdgpu_emit_hal_kernel_library(
     loom_amdgpu_hal_kernel_library_deinitialize(out_library, allocator);
   }
   if (report != NULL) {
-    loom_target_compile_report_record_status(report, status);
+    loom_target_compile_report_record_status(report, iree_status_code(status));
   }
   iree_arena_deinitialize(&table_arena);
   iree_arena_block_pool_deinitialize(&block_pool);

--- a/loom/src/loom/tooling/execution/hal/benchmark.c
+++ b/loom/src/loom/tooling/execution/hal/benchmark.c
@@ -192,11 +192,11 @@ static iree_status_t loom_run_hal_benchmark_execute_batch(void* user_data) {
 }
 
 static void loom_run_hal_profile_summary_record_error(
-    loom_run_hal_profile_summary_t* profile, iree_status_t status) {
+    loom_run_hal_profile_summary_t* profile, const iree_status_t* status) {
   profile->has_error = true;
-  profile->error_code = iree_status_code(status);
+  profile->error_code = iree_status_code(*status);
   iree_host_size_t required_length = 0;
-  if (iree_status_format(status, sizeof(profile->error_message),
+  if (iree_status_format(*status, sizeof(profile->error_message),
                          profile->error_message, &required_length)) {
     profile->error_message_length = required_length;
     if (profile->error_message_length >= sizeof(profile->error_message)) {
@@ -214,7 +214,6 @@ static void loom_run_hal_profile_summary_record_error(
     profile->error_message[index] = '\0';
     profile->error_message_length = index;
   }
-  iree_status_free(status);
 }
 
 static void loom_run_hal_profile_summary_copy_artifact_path(
@@ -401,7 +400,8 @@ static iree_status_t loom_run_hal_benchmark_run_profiled_batch(
                              .user_data = &context,
                          });
   } else {
-    loom_run_hal_profile_summary_record_error(out_profile, status);
+    loom_run_hal_profile_summary_record_error(out_profile, &status);
+    iree_status_ignore(status);
     status = iree_ok_status();
   }
 
@@ -448,7 +448,8 @@ static iree_status_t loom_run_hal_benchmark_profile_final_batch(
     status = loom_run_hal_benchmark_run_profiled_batch(
         runtime, &profile_batch, options, allocator, out_profile);
   } else {
-    loom_run_hal_profile_summary_record_error(out_profile, status);
+    loom_run_hal_profile_summary_record_error(out_profile, &status);
+    iree_status_ignore(status);
     status = iree_ok_status();
   }
   loom_run_hal_dispatch_batch_deinitialize(&profile_batch);
@@ -491,7 +492,8 @@ static iree_status_t loom_run_hal_benchmark_profile_final_sequence_batch(
     status = loom_run_hal_benchmark_run_profiled_batch(
         runtime, &profile_batch, options, allocator, out_profile);
   } else {
-    loom_run_hal_profile_summary_record_error(out_profile, status);
+    loom_run_hal_profile_summary_record_error(out_profile, &status);
+    iree_status_ignore(status);
     status = iree_ok_status();
   }
   loom_run_hal_dispatch_batch_deinitialize(&profile_batch);

--- a/loom/src/loom/tooling/execution/hal/benchmark.c
+++ b/loom/src/loom/tooling/execution/hal/benchmark.c
@@ -377,14 +377,11 @@ static iree_status_t loom_run_hal_benchmark_run_profiled_batch(
     status =
         iree_hal_device_profiling_begin(runtime->device, &profiling_options);
   }
-  const bool profiling_began = iree_status_is_ok(status);
-  if (profiling_began) {
-    status = loom_run_hal_dispatch_batch_execute(runtime, batch);
-  }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_device_profiling_flush(runtime->device);
-  }
-  if (profiling_began) {
+    status = loom_run_hal_dispatch_batch_execute(runtime, batch);
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_device_profiling_flush(runtime->device);
+    }
     status = iree_status_join(status,
                               iree_hal_device_profiling_end(runtime->device));
   }

--- a/loom/src/loom/tooling/execution/hal/candidate.c
+++ b/loom/src/loom/tooling/execution/hal/candidate.c
@@ -39,7 +39,7 @@ static void loom_run_hal_candidate_initialize(
 
 static void loom_run_hal_candidate_record_report_status(
     const loom_run_candidate_compile_options_t* options,
-    loom_run_hal_candidate_t* candidate, iree_status_t status) {
+    loom_run_hal_candidate_t* candidate, iree_status_code_t status_code) {
   loom_target_compile_report_t* report =
       options->report != NULL ? &candidate->compile_report : NULL;
   if (report == NULL) {
@@ -55,7 +55,7 @@ static void loom_run_hal_candidate_record_report_status(
     loom_target_compile_report_record_artifact_size(
         report, candidate->artifact.executable_data.data_length);
   }
-  loom_target_compile_report_record_status(report, status);
+  loom_target_compile_report_record_status(report, status_code);
 }
 
 static iree_status_t loom_run_hal_candidate_emit_selected_target(
@@ -109,7 +109,8 @@ iree_status_t loom_run_hal_candidate_compile(
     status = loom_run_hal_candidate_emit_selected_target(
         provider, run_module, options, allocator, out_candidate);
   }
-  loom_run_hal_candidate_record_report_status(options, out_candidate, status);
+  loom_run_hal_candidate_record_report_status(options, out_candidate,
+                                              iree_status_code(status));
   loom_run_hal_candidate_publish_compile_report(options, out_candidate);
   if (!iree_status_is_ok(status)) {
     loom_run_hal_candidate_deinitialize(out_candidate);
@@ -126,7 +127,8 @@ iree_status_t loom_run_hal_candidate_emit_module_target(
                                     out_candidate);
   iree_status_t status = loom_run_hal_candidate_emit_selected_target(
       provider, run_module, options, allocator, out_candidate);
-  loom_run_hal_candidate_record_report_status(options, out_candidate, status);
+  loom_run_hal_candidate_record_report_status(options, out_candidate,
+                                              iree_status_code(status));
   loom_run_hal_candidate_publish_compile_report(options, out_candidate);
   if (!iree_status_is_ok(status)) {
     loom_run_hal_candidate_deinitialize(out_candidate);

--- a/loom/src/loom/tooling/execution/measurement.c
+++ b/loom/src/loom/tooling/execution/measurement.c
@@ -126,7 +126,8 @@ iree_status_t loom_run_measurement_scope_begin(
 }
 
 iree_status_t loom_run_measurement_scope_end(
-    loom_run_measurement_scope_t* scope, iree_status_t operation_status) {
+    loom_run_measurement_scope_t* scope,
+    iree_status_code_t operation_status_code) {
   if (!scope->is_recording) {
     return iree_ok_status();
   }
@@ -136,7 +137,7 @@ iree_status_t loom_run_measurement_scope_end(
   sample->duration_ns = end_time_ns >= scope->start_time_ns
                             ? end_time_ns - scope->start_time_ns
                             : 0;
-  sample->status_code = iree_status_code(operation_status);
+  sample->status_code = operation_status_code;
   *scope = (loom_run_measurement_scope_t){0};
   return iree_ok_status();
 }
@@ -150,6 +151,7 @@ iree_status_t loom_run_measurement_run_step(
   IREE_RETURN_IF_ERROR(
       loom_run_measurement_scope_begin(options, boundary, result, &scope));
   iree_status_t status = callback.fn(callback.user_data);
-  iree_status_t scope_status = loom_run_measurement_scope_end(&scope, status);
+  iree_status_t scope_status =
+      loom_run_measurement_scope_end(&scope, iree_status_code(status));
   return iree_status_join(status, scope_status);
 }

--- a/loom/src/loom/tooling/execution/measurement.c
+++ b/loom/src/loom/tooling/execution/measurement.c
@@ -150,6 +150,6 @@ iree_status_t loom_run_measurement_run_step(
   IREE_RETURN_IF_ERROR(
       loom_run_measurement_scope_begin(options, boundary, result, &scope));
   iree_status_t status = callback.fn(callback.user_data);
-  return iree_status_join(status,
-                          loom_run_measurement_scope_end(&scope, status));
+  iree_status_t scope_status = loom_run_measurement_scope_end(&scope, status);
+  return iree_status_join(status, scope_status);
 }

--- a/loom/src/loom/tooling/execution/measurement.h
+++ b/loom/src/loom/tooling/execution/measurement.h
@@ -129,9 +129,10 @@ iree_status_t loom_run_measurement_scope_begin(
     loom_run_measurement_result_t* result,
     loom_run_measurement_scope_t* out_scope);
 
-// Ends |scope| and records |operation_status|'s status code in the sample.
+// Ends |scope| and records |operation_status_code| in the sample.
 iree_status_t loom_run_measurement_scope_end(
-    loom_run_measurement_scope_t* scope, iree_status_t operation_status);
+    loom_run_measurement_scope_t* scope,
+    iree_status_code_t operation_status_code);
 
 // Invokes |callback| inside a measured boundary and always closes the scope.
 iree_status_t loom_run_measurement_run_step(

--- a/loom/src/loom/tooling/target/spirv/artifact_provider.c
+++ b/loom/src/loom/tooling/target/spirv/artifact_provider.c
@@ -228,7 +228,7 @@ static iree_status_t loom_spirv_hal_artifact_provider_emit_artifact(
         &low_registry, &arena, allocator, out_emitted, out_artifact);
   }
   if (report != NULL) {
-    loom_target_compile_report_record_status(report, status);
+    loom_target_compile_report_record_status(report, iree_status_code(status));
   }
 
   iree_arena_deinitialize(&arena);

--- a/loom/src/loom/tools/iree-benchmark-loom/profile_report.c
+++ b/loom/src/loom/tools/iree-benchmark-loom/profile_report.c
@@ -87,13 +87,14 @@ static iree_status_t iree_benchmark_loom_read_file_into_builder(
   return iree_ok_status();
 }
 
-static void iree_benchmark_loom_consume_status_json_error(
-    iree_status_t status, iree_benchmark_loom_status_json_error_t* out_error) {
-  out_error->code = iree_status_code(status);
+static void iree_benchmark_loom_format_status_json_error(
+    const iree_status_t* status,
+    iree_benchmark_loom_status_json_error_t* out_error) {
+  out_error->code = iree_status_code(*status);
   memset(out_error->message, 0, sizeof(out_error->message));
   iree_host_size_t required_length = 0;
-  if (iree_status_format(status, sizeof(out_error->message), out_error->message,
-                         &required_length)) {
+  if (iree_status_format(*status, sizeof(out_error->message),
+                         out_error->message, &required_length)) {
     out_error->message_length = required_length;
     if (out_error->message_length >= sizeof(out_error->message)) {
       out_error->message_length = sizeof(out_error->message) - 1;
@@ -109,7 +110,6 @@ static void iree_benchmark_loom_consume_status_json_error(
     out_error->message[index] = '\0';
     out_error->message_length = index;
   }
-  iree_status_free(status);
 }
 
 static iree_status_t iree_benchmark_loom_write_profile_artifact_identity_json(
@@ -475,12 +475,16 @@ iree_benchmark_loom_append_profile_summary_status_from_error(
     iree_string_view_t status, iree_string_view_t reason,
     iree_status_t error_status, iree_string_builder_t* profile_output) {
   iree_benchmark_loom_status_json_error_t error = {0};
-  iree_benchmark_loom_consume_status_json_error(error_status, &error);
-  return iree_benchmark_loom_append_profile_summary_status_row(
-      run, candidate, work_item_index, module, benchmark_plan, case_plan,
-      policy, benchmark_result, /*decode_summary=*/NULL, status, reason,
-      error.code, iree_make_string_view(error.message, error.message_length),
-      profile_output);
+  iree_benchmark_loom_format_status_json_error(&error_status, &error);
+  iree_status_t append_status =
+      iree_benchmark_loom_append_profile_summary_status_row(
+          run, candidate, work_item_index, module, benchmark_plan, case_plan,
+          policy, benchmark_result, /*decode_summary=*/NULL, status, reason,
+          error.code,
+          iree_make_string_view(error.message, error.message_length),
+          profile_output);
+  iree_status_free(error_status);
+  return append_status;
 }
 
 static iree_status_t iree_benchmark_loom_append_profile_summary_payload_row(
@@ -667,12 +671,16 @@ iree_benchmark_loom_append_profile_counter_status_from_error(
     iree_string_view_t status, iree_string_view_t reason,
     iree_status_t error_status, iree_string_builder_t* profile_output) {
   iree_benchmark_loom_status_json_error_t error = {0};
-  iree_benchmark_loom_consume_status_json_error(error_status, &error);
-  return iree_benchmark_loom_append_profile_counter_status_row(
-      run, candidate, work_item_index, module, benchmark_plan, case_plan,
-      policy, benchmark_result, /*decode_summary=*/NULL, status, reason,
-      error.code, iree_make_string_view(error.message, error.message_length),
-      profile_output);
+  iree_benchmark_loom_format_status_json_error(&error_status, &error);
+  iree_status_t append_status =
+      iree_benchmark_loom_append_profile_counter_status_row(
+          run, candidate, work_item_index, module, benchmark_plan, case_plan,
+          policy, benchmark_result, /*decode_summary=*/NULL, status, reason,
+          error.code,
+          iree_make_string_view(error.message, error.message_length),
+          profile_output);
+  iree_status_free(error_status);
+  return append_status;
 }
 
 static iree_status_t iree_benchmark_loom_append_profile_counter_payload_row(

--- a/loom/src/loom/tools/iree-benchmark-loom/report.c
+++ b/loom/src/loom/tools/iree-benchmark-loom/report.c
@@ -71,12 +71,12 @@ static iree_status_t iree_benchmark_loom_write_optional_i64_query_json(
     iree_hal_device_t* device, iree_string_view_t category,
     iree_string_view_t key, const char* field_name,
     loom_output_stream_t* stream) {
-  int64_t value = 0;
-  iree_status_t status =
-      iree_hal_device_query_i64(device, category, key, &value);
   IREE_RETURN_IF_ERROR(loom_output_stream_write_cstring(stream, ","));
   IREE_RETURN_IF_ERROR(loom_json_write_escaped_cstring(stream, field_name));
   IREE_RETURN_IF_ERROR(loom_output_stream_write_cstring(stream, ":"));
+  int64_t value = 0;
+  iree_status_t status =
+      iree_hal_device_query_i64(device, category, key, &value);
   if (iree_status_is_ok(status)) {
     return loom_output_stream_write_format(stream, "%" PRIi64, value);
   }
@@ -430,11 +430,11 @@ iree_status_t iree_benchmark_loom_write_hal_context_identity_fields_json(
         IREE_SV("concurrency"), "hal_dispatch_concurrency", stream));
     IREE_RETURN_IF_ERROR(loom_output_stream_write_cstring(stream, "}"));
 
+    IREE_RETURN_IF_ERROR(
+        loom_output_stream_write_cstring(stream, ",\"capabilities\":"));
     iree_hal_device_capabilities_t capabilities = {0};
     iree_status_t capabilities_status = iree_hal_device_query_capabilities(
         context->execution.runtime.device, &capabilities);
-    IREE_RETURN_IF_ERROR(
-        loom_output_stream_write_cstring(stream, ",\"capabilities\":"));
     if (iree_status_is_ok(capabilities_status)) {
       IREE_RETURN_IF_ERROR(loom_output_stream_write_format(
           stream,

--- a/loom/src/loom/tools/iree-benchmark-loom/report.c
+++ b/loom/src/loom/tools/iree-benchmark-loom/report.c
@@ -34,11 +34,12 @@ static iree_string_view_t iree_benchmark_loom_selected_device_uri(
 }
 
 iree_status_t iree_benchmark_loom_write_status_object_json(
-    iree_status_t status, loom_output_stream_t* stream) {
-  const iree_status_code_t code = iree_status_code(status);
+    const iree_status_t* status, loom_output_stream_t* stream) {
+  const iree_status_code_t code = iree_status_code(*status);
   char message[512];
   iree_host_size_t required_length = 0;
-  if (!iree_status_format(status, sizeof(message), message, &required_length)) {
+  if (!iree_status_format(*status, sizeof(message), message,
+                          &required_length)) {
     const char* status_string = iree_status_code_string(code);
     iree_host_size_t index = 0;
     for (; status_string[index] != '\0' && index + 1 < sizeof(message);
@@ -81,7 +82,7 @@ static iree_status_t iree_benchmark_loom_write_optional_i64_query_json(
     return loom_output_stream_write_format(stream, "%" PRIi64, value);
   }
   iree_status_t write_status =
-      iree_benchmark_loom_write_status_object_json(status, stream);
+      iree_benchmark_loom_write_status_object_json(&status, stream);
   iree_status_free(status);
   return write_status;
 }
@@ -455,7 +456,7 @@ iree_status_t iree_benchmark_loom_write_hal_context_identity_fields_json(
       IREE_RETURN_IF_ERROR(loom_output_stream_write_cstring(stream, "}"));
     } else {
       iree_status_t write_status = iree_benchmark_loom_write_status_object_json(
-          capabilities_status, stream);
+          &capabilities_status, stream);
       iree_status_free(capabilities_status);
       IREE_RETURN_IF_ERROR(write_status);
     }

--- a/loom/src/loom/tools/iree-benchmark-loom/report.h
+++ b/loom/src/loom/tools/iree-benchmark-loom/report.h
@@ -21,7 +21,7 @@ extern "C" {
 
 // Writes a borrowed status as a structured JSON object.
 iree_status_t iree_benchmark_loom_write_status_object_json(
-    iree_status_t status, loom_output_stream_t* stream);
+    const iree_status_t* status, loom_output_stream_t* stream);
 
 // Writes the run identifier field shared by every JSONL row.
 iree_status_t iree_benchmark_loom_write_run_id_field_json(

--- a/loom/src/loom/tools/loom-check/emit.c
+++ b/loom/src/loom/tools/loom-check/emit.c
@@ -771,7 +771,8 @@ static iree_status_t loom_check_emit_finish_status_failure(
       "emit target '%.*s' failed: ", (int)emit_target_name.size,
       emit_target_name.data);
   if (iree_status_is_ok(status)) {
-    status = iree_string_builder_append_status(&result->detail, failure_status);
+    status =
+        iree_string_builder_append_status(&result->detail, &failure_status);
   }
   if (iree_status_is_ok(status)) {
     status = iree_string_builder_append_cstring(&result->detail, "\n");

--- a/loom/src/loom/tools/loom-check/execute.c
+++ b/loom/src/loom/tools/loom-check/execute.c
@@ -345,7 +345,8 @@ static iree_status_t loom_check_execute_finish_status_failure(
       &result->detail, "%.*s returned status: ", (int)operation_name.size,
       operation_name.data);
   if (iree_status_is_ok(status)) {
-    status = iree_string_builder_append_status(&result->detail, failure_status);
+    status =
+        iree_string_builder_append_status(&result->detail, &failure_status);
   }
   if (iree_status_is_ok(status)) {
     status = iree_string_builder_append_cstring(&result->detail, "\n");

--- a/loom/src/loom/tools/loom-check/execute.c
+++ b/loom/src/loom/tools/loom-check/execute.c
@@ -466,7 +466,8 @@ static iree_status_t loom_check_execute_pass_with_output(
   loom_target_compile_report_t compile_report = {0};
   loom_target_compile_report_t* compile_report_ref = NULL;
   loom_target_compile_report_row_storage_t compile_report_row_storage = {0};
-  if (output_kind == LOOM_CHECK_PASS_OUTPUT_COMPILE_REPORT) {
+  if (iree_status_is_ok(status) &&
+      output_kind == LOOM_CHECK_PASS_OUTPUT_COMPILE_REPORT) {
     status = loom_check_compile_report_row_storage_initialize(
         &diagnostic_arena, &compile_report_row_storage);
     if (iree_status_is_ok(status)) {
@@ -504,7 +505,8 @@ static iree_status_t loom_check_execute_pass_with_output(
                                                            &predicate_storage);
     const loom_pass_registry_t* pass_registry = loom_pass_builtin_registry();
     loom_pass_registry_storage_t pass_registry_storage = {0};
-    if (environment != NULL && environment->pass_registry != NULL) {
+    if (iree_status_is_ok(status) && environment != NULL &&
+        environment->pass_registry != NULL) {
       const loom_pass_registry_t* pass_registries[] = {
           loom_pass_builtin_registry(),
           environment->pass_registry,

--- a/loom/src/loom/tools/loom-check/requirements.c
+++ b/loom/src/loom/tools/loom-check/requirements.c
@@ -134,8 +134,8 @@ static iree_status_t loom_check_skip_unavailable_requirement(
     status = iree_string_builder_append_cstring(&result->detail, ": ");
   }
   if (iree_status_is_ok(status)) {
-    status =
-        iree_string_builder_append_status(&result->detail, availability_status);
+    status = iree_string_builder_append_status(&result->detail,
+                                               &availability_status);
   }
   if (iree_status_is_ok(status)) {
     status = iree_string_builder_append_cstring(&result->detail, "\n");

--- a/loom/src/loom/tools/loom-compile/loom-compile.c
+++ b/loom/src/loom/tools/loom-compile/loom-compile.c
@@ -575,8 +575,7 @@ int main(int argc, char** argv) {
     exit_code = 1;
   }
 
-  const bool had_error = !iree_status_is_ok(status);
-  if (had_error) {
+  if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_free(status);
     exit_code = 1;

--- a/loom/src/loom/tools/loom-format/loom-format.c
+++ b/loom/src/loom/tools/loom-format/loom-format.c
@@ -118,10 +118,11 @@ int main(int argc, char** argv) {
                                       &output, allocator);
   }
 
-  bool had_error = !iree_status_is_ok(status);
-  if (had_error) {
+  int exit_code = 0;
+  if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_free(status);
+    exit_code = 1;
   }
 
   loom_format_output_deinitialize(&output, allocator);
@@ -130,5 +131,5 @@ int main(int argc, char** argv) {
     loom_context_deinitialize(&context);
   }
   iree_arena_block_pool_deinitialize(&block_pool);
-  return had_error ? 1 : 0;
+  return exit_code;
 }

--- a/loom/src/loom/tools/loom-link/loom-link.c
+++ b/loom/src/loom/tools/loom-link/loom-link.c
@@ -1328,10 +1328,11 @@ int main(int argc, char** argv) {
     }
   }
 
-  const bool had_error = !iree_status_is_ok(status);
-  if (had_error) {
+  int exit_code = 0;
+  if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_free(status);
+    exit_code = 1;
   }
 
   iree_allocator_free(allocator, source_entries);
@@ -1344,5 +1345,5 @@ int main(int argc, char** argv) {
     loom_context_deinitialize(&context);
   }
   iree_arena_block_pool_deinitialize(&block_pool);
-  return had_error ? 1 : 0;
+  return exit_code;
 }

--- a/loom/src/loom/tools/loom-opt/loom-opt.c
+++ b/loom/src/loom/tools/loom-opt/loom-opt.c
@@ -1145,11 +1145,11 @@ int main(int argc, char** argv) {
         diagnostic_sink);
     if (!iree_status_is_ok(status) && pass_execution_started &&
         iree_status_is_ok(pass_pipeline_status)) {
+      iree_status_code_t status_code = iree_status_code(status);
       status = iree_status_join(
-          status,
-          loom_opt_write_pass_reproducer(
-              iree_make_cstring_view(FLAG_pass_reproducer), filename, source,
-              pass_registry, iree_status_code(status), allocator));
+          status, loom_opt_write_pass_reproducer(
+                      iree_make_cstring_view(FLAG_pass_reproducer), filename,
+                      source, pass_registry, status_code, allocator));
     }
   }
   if (iree_status_is_ok(status) && pass_run_result.error_count == 0 &&
@@ -1170,11 +1170,11 @@ int main(int argc, char** argv) {
     }
   }
 
-  bool had_status_error = !iree_status_is_ok(status);
-  bool had_error = had_status_error || pass_run_result.error_count != 0;
-  if (had_status_error) {
+  bool had_error = pass_run_result.error_count != 0;
+  if (!iree_status_is_ok(status)) {
     iree_status_fprint(stderr, status);
     iree_status_free(status);
+    had_error = true;
   }
 
   if (pass_report_initialized) {

--- a/runtime/build_tools/cmake/flatbuffer_c_library.cmake
+++ b/runtime/build_tools/cmake/flatbuffer_c_library.cmake
@@ -117,6 +117,7 @@ function(flatbuffer_c_library)
     DEPENDS
       ${_OUTS}
   )
+  iree_register_generated_compile_input(${_GEN_TARGET})
 
   add_library(${_NAME} INTERFACE)
   add_dependencies(${_NAME} ${_GEN_TARGET})

--- a/runtime/src/iree/async/cts/buffer/registration_test.cc
+++ b/runtime/src/iree/async/cts/buffer/registration_test.cc
@@ -61,8 +61,8 @@ static StatusOr<AsyncSlabPtr> CreateSlab(
   iree_status_t status =
       iree_async_slab_create(slab_options, iree_allocator_system(), &slab);
   if (!iree_status_is_ok(status)) {
-    return iree::Status(static_cast<iree::StatusCode>(iree_status_code(status)),
-                        "slab creation failed");
+    return iree::Status(iree_status_annotate(
+        status, iree_make_cstring_view("slab creation failed")));
   }
   return AsyncSlabPtr(slab);
 }
@@ -85,8 +85,8 @@ static StatusOr<AsyncRegionPtr> RegisterSlab(
                         "(RLIMIT_MEMLOCK); skipping test");
   }
   if (!iree_status_is_ok(status)) {
-    return iree::Status(static_cast<iree::StatusCode>(iree_status_code(status)),
-                        "slab registration failed");
+    return iree::Status(iree_status_annotate(
+        status, iree_make_cstring_view("slab registration failed")));
   }
   return AsyncRegionPtr(region);
 }

--- a/runtime/src/iree/async/cts/socket/send_flags_test.cc
+++ b/runtime/src/iree/async/cts/socket/send_flags_test.cc
@@ -1033,11 +1033,12 @@ TEST_P(SendFlagsTest, ZeroCopySendMultipleSlabs) {
   iree_async_buffer_pool_t* pool_b = nullptr;
   iree_status_t status = iree_async_proactor_register_slab(
       proactor_, slab_b, IREE_ASYNC_BUFFER_ACCESS_FLAG_READ, &region_b);
-  bool has_two_slabs = iree_status_is_ok(status);
-  if (!has_two_slabs) {
+  bool has_two_slabs = false;
+  if (!iree_status_is_ok(status)) {
     iree_status_ignore(status);
     // Fall back to testing with just one slab (acquire multiple buffers).
   } else {
+    has_two_slabs = true;
     IREE_ASSERT_OK(iree_async_buffer_pool_allocate(
         region_b, iree_allocator_system(), &pool_b));
   }

--- a/runtime/src/iree/async/cts/socket/socket_benchmark.cc
+++ b/runtime/src/iree/async/cts/socket/socket_benchmark.cc
@@ -308,11 +308,9 @@ static LoopbackContext* CreateLoopbackContext(
     iree_host_size_t count = 0;
     status = iree_async_proactor_poll(ctx->proactor, iree_make_timeout_ms(100),
                                       &count);
-    if (!iree_status_is_ok(status) &&
-        !iree_status_is_deadline_exceeded(status)) {
+    if (!iree_status_is_ok(status)) {
       iree_status_ignore(status);
     }
-    iree_status_ignore(status);
     completions += (int)count;
   }
 

--- a/runtime/src/iree/async/cts/socket/tcp_transfer_test.cc
+++ b/runtime/src/iree/async/cts/socket/tcp_transfer_test.cc
@@ -70,9 +70,9 @@ class LargeTransferTest : public SocketTestBase<> {
       iree_status_t status =
           iree_async_proactor_submit_one(proactor_, &send_op.base);
       if (!iree_status_is_ok(status)) {
+        iree::Status submit_status(std::move(status));
         ADD_FAILURE() << "SendAll: submit_one failed at offset " << total_sent
-                      << "/" << total_size << ": "
-                      << iree::Status(std::move(status)).ToString();
+                      << "/" << total_size << ": " << submit_status.ToString();
         return 0;
       }
 
@@ -114,9 +114,10 @@ class LargeTransferTest : public SocketTestBase<> {
       iree_status_t status =
           iree_async_proactor_submit_one(proactor_, &recv_op.base);
       if (!iree_status_is_ok(status)) {
+        iree::Status submit_status(std::move(status));
         ADD_FAILURE() << "RecvAll: submit_one failed at offset "
                       << total_received << "/" << total_size << ": "
-                      << iree::Status(std::move(status)).ToString();
+                      << submit_status.ToString();
         return 0;
       }
 

--- a/runtime/src/iree/async/cts/sync/relay_benchmark.cc
+++ b/runtime/src/iree/async/cts/sync/relay_benchmark.cc
@@ -237,8 +237,8 @@ static StatusOr<std::unique_ptr<RelayChannel>> CreateRelayChannel(
   iree_status_t status = iree_async_notification_create(
       proactor, IREE_ASYNC_NOTIFICATION_FLAG_NONE, &channel->source);
   if (!iree_status_is_ok(status)) {
-    return iree::Status(static_cast<iree::StatusCode>(iree_status_code(status)),
-                        "Source notification creation failed");
+    return iree::Status(iree_status_annotate(
+        status, iree_make_cstring_view("source notification creation failed")));
   }
 
   status = iree_async_notification_create(
@@ -246,8 +246,8 @@ static StatusOr<std::unique_ptr<RelayChannel>> CreateRelayChannel(
   if (!iree_status_is_ok(status)) {
     iree_async_notification_release(channel->source);
     channel->source = nullptr;
-    return iree::Status(static_cast<iree::StatusCode>(iree_status_code(status)),
-                        "Sink notification creation failed");
+    return iree::Status(iree_status_annotate(
+        status, iree_make_cstring_view("sink notification creation failed")));
   }
 
   iree_async_relay_source_t source_desc =
@@ -262,8 +262,8 @@ static StatusOr<std::unique_ptr<RelayChannel>> CreateRelayChannel(
     iree_async_notification_release(channel->source);
     channel->sink = nullptr;
     channel->source = nullptr;
-    return iree::Status(static_cast<iree::StatusCode>(iree_status_code(status)),
-                        "Relay registration failed");
+    return iree::Status(iree_status_annotate(
+        status, iree_make_cstring_view("relay registration failed")));
   }
 
   return channel;

--- a/runtime/src/iree/async/frontier_benchmark.cc
+++ b/runtime/src/iree/async/frontier_benchmark.cc
@@ -630,7 +630,7 @@ static void BM_Validate(benchmark::State& state) {
   for (auto _ : state) {
     iree_status_t status = iree_async_frontier_validate(storage.frontier());
     benchmark::DoNotOptimize(status);
-    // status is ok_status (NULL pointer), no free needed.
+    IREE_CHECK_OK(status);
   }
   state.SetItemsProcessed(state.iterations());
 }

--- a/runtime/src/iree/async/frontier_tracker_benchmark.cc
+++ b/runtime/src/iree/async/frontier_tracker_benchmark.cc
@@ -398,6 +398,7 @@ static void BM_Wait_ImmediatelySatisfied(benchmark::State& state) {
         fixture.tracker(), frontier_storage.frontier(), MinimalCallback,
         nullptr, &waiter);
     benchmark::DoNotOptimize(status);
+    IREE_CHECK_OK(status);
   }
   state.SetItemsProcessed(state.iterations());
 }
@@ -419,6 +420,7 @@ static void BM_Wait_Pending(benchmark::State& state) {
         fixture.tracker(), frontier_storage.frontier(), MinimalCallback,
         nullptr, &waiter);
     benchmark::DoNotOptimize(status);
+    IREE_CHECK_OK(status);
 
     state.PauseTiming();
     iree_async_frontier_tracker_cancel_wait(fixture.tracker(), &waiter);
@@ -451,6 +453,7 @@ static void BM_Wait_MultiEntrySatisfied(benchmark::State& state) {
         fixture.tracker(), frontier_storage.frontier(), MinimalCallback,
         nullptr, &waiter);
     benchmark::DoNotOptimize(status);
+    IREE_CHECK_OK(status);
   }
   state.SetItemsProcessed(state.iterations());
 }

--- a/runtime/src/iree/async/platform/io_uring/proactor.c
+++ b/runtime/src/iree/async/platform/io_uring/proactor.c
@@ -1247,7 +1247,7 @@ static iree_host_size_t iree_async_proactor_io_uring_process_cqe(
     iree_async_socket_t* socket =
         iree_async_proactor_io_uring_socket_from_io_operation(operation);
     if (socket) {
-      iree_async_socket_set_failure(socket, status);
+      iree_async_socket_set_failure(socket, iree_status_code(status));
     }
   }
 

--- a/runtime/src/iree/async/platform/io_uring/proactor.h
+++ b/runtime/src/iree/async/platform/io_uring/proactor.h
@@ -370,6 +370,7 @@ void iree_async_proactor_io_uring_submit_continuation_chain(
 
 // Pushes a completed software operation to the MPSC queue for callback
 // delivery on the poll thread (in proactor.c, used by proactor_submit.c).
+// Takes ownership of |status| and carries it with |operation|.
 void iree_async_proactor_io_uring_push_software_completion(
     iree_async_proactor_io_uring_t* proactor, iree_async_operation_t* operation,
     iree_status_t status);

--- a/runtime/src/iree/async/platform/io_uring/proactor_registration.c
+++ b/runtime/src/iree/async/platform/io_uring/proactor_registration.c
@@ -745,8 +745,12 @@ iree_status_t iree_async_proactor_io_uring_register_slab(
       // This is a programming error if it fails (we just registered these
       // slots moments ago with no I/O in-flight), so hard-abort.
       if (slab_region->registered_fixed_buffers) {
-        IREE_CHECK_OK(iree_async_io_uring_slab_region_unregister_fixed_buffers(
-            slab_region, proactor));
+        iree_status_t unregister_status =
+            iree_async_io_uring_slab_region_unregister_fixed_buffers(
+                slab_region, proactor);
+        if (!iree_status_is_ok(unregister_status)) {
+          iree_status_abort(iree_status_join(status, unregister_status));
+        }
       }
       iree_allocator_free(base_proactor->allocator, slab_region);
       IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/async/platform/io_uring/proactor_submit.c
+++ b/runtime/src/iree/async/platform/io_uring/proactor_submit.c
@@ -1157,6 +1157,22 @@ void iree_async_proactor_io_uring_dispatch_continuation_chain(
           proactor, op, &deferred);
     }
 
+    // Extract next in chain before push (push repurposes linked_next for the
+    // completion status).
+    iree_async_operation_t* next = op->linked_next;
+    op->linked_next = NULL;
+
+    if (!iree_status_is_ok(op_status)) {
+      // Software op failed. Cancel remaining chain via MPSC.
+      iree_async_proactor_io_uring_push_software_completion(proactor, op,
+                                                            op_status);
+      if (next) {
+        iree_async_proactor_io_uring_cancel_continuation_chain_to_mpsc(proactor,
+                                                                       next);
+      }
+      return;
+    }
+
     if (deferred) {
       // Tracker holds the continuation chain (transferred from linked_next
       // by execute_semaphore_wait). The WAIT completion arrives later via
@@ -1167,23 +1183,9 @@ void iree_async_proactor_io_uring_dispatch_continuation_chain(
       return;
     }
 
-    // Extract next in chain before push (push repurposes linked_next for the
-    // completion status).
-    iree_async_operation_t* next = op->linked_next;
-    op->linked_next = NULL;
-
     // Push this op's completion to MPSC.
     iree_async_proactor_io_uring_push_software_completion(proactor, op,
                                                           op_status);
-
-    if (!iree_status_is_ok(op_status)) {
-      // Software op failed. Cancel remaining chain via MPSC.
-      if (next) {
-        iree_async_proactor_io_uring_cancel_continuation_chain_to_mpsc(proactor,
-                                                                       next);
-      }
-      return;
-    }
 
     op = next;
   }
@@ -1860,17 +1862,27 @@ iree_status_t iree_async_proactor_io_uring_submit(
           proactor, operation, &deferred);
     }
 
+    // Extract continuation before pushing completion (push repurposes
+    // linked_next to carry the completion status through the MPSC queue).
+    iree_async_operation_t* continuation = operation->linked_next;
+    operation->linked_next = NULL;
+
+    if (!iree_status_is_ok(op_status)) {
+      iree_async_proactor_io_uring_push_software_completion(proactor, operation,
+                                                            op_status);
+      if (continuation) {
+        iree_async_proactor_io_uring_cancel_continuation_chain_to_mpsc(
+            proactor, continuation);
+      }
+      continue;
+    }
+
     if (deferred) {
       // Timepoints registered. Completion arrives later via
       // pending_semaphore_waits. The tracker holds the continuation chain
       // (transferred from linked_next in execute_semaphore_wait).
       continue;
     }
-
-    // Extract continuation before pushing completion (push repurposes
-    // linked_next to carry the completion status through the MPSC queue).
-    iree_async_operation_t* continuation = operation->linked_next;
-    operation->linked_next = NULL;
 
     // Push this op's completion to MPSC BEFORE dispatching its continuation.
     // This preserves callback ordering: trigger fires first, then
@@ -1880,13 +1892,8 @@ iree_status_t iree_async_proactor_io_uring_submit(
 
     // Dispatch linked continuation chain (if any).
     if (continuation) {
-      if (iree_status_is_ok(op_status)) {
-        iree_async_proactor_io_uring_dispatch_continuation_chain(proactor,
-                                                                 continuation);
-      } else {
-        iree_async_proactor_io_uring_cancel_continuation_chain_to_mpsc(
-            proactor, continuation);
-      }
+      iree_async_proactor_io_uring_dispatch_continuation_chain(proactor,
+                                                               continuation);
     }
   }
 

--- a/runtime/src/iree/async/platform/iocp/proactor.c
+++ b/runtime/src/iree/async/platform/iocp/proactor.c
@@ -253,7 +253,7 @@ static void iree_async_proactor_iocp_dispatch_completion(
     iree_async_socket_t* socket =
         iree_async_proactor_iocp_socket_from_io_operation(operation);
     if (socket) {
-      iree_async_socket_set_failure(socket, status);
+      iree_async_socket_set_failure(socket, iree_status_code(status));
     }
   }
   if (!iree_any_bit_set(flags, IREE_ASYNC_COMPLETION_FLAG_MORE)) {

--- a/runtime/src/iree/async/platform/js/proactor.c
+++ b/runtime/src/iree/async/platform/js/proactor.c
@@ -76,14 +76,14 @@ static void iree_async_proactor_js_cancel_continuation_chain(
 // On failure: cancels the entire chain with CANCELLED callbacks.
 static void iree_async_proactor_js_dispatch_linked_continuation(
     iree_async_proactor_js_t* proactor, iree_async_operation_t* operation,
-    iree_status_t trigger_status) {
+    iree_status_code_t trigger_status_code) {
   iree_async_operation_t* continuation = operation->linked_next;
   if (!continuation) return;
 
   // Detach the chain before potentially recursive submit.
   operation->linked_next = NULL;
 
-  if (iree_status_is_ok(trigger_status)) {
+  if (trigger_status_code == IREE_STATUS_OK) {
     // Success: submit the continuation (which may itself have linked_next).
     iree_status_t status =
         iree_async_proactor_js_submit_one(proactor, continuation);
@@ -116,7 +116,7 @@ static void iree_async_proactor_js_complete(
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_async_operation_release_resources(operation);
   iree_async_proactor_js_dispatch_linked_continuation(proactor, operation,
-                                                      status);
+                                                      iree_status_code(status));
   operation->completion_fn(operation->user_data, operation, status, flags);
   IREE_TRACE_ZONE_END(z0);
 }

--- a/runtime/src/iree/async/platform/posix/proactor.c
+++ b/runtime/src/iree/async/platform/posix/proactor.c
@@ -54,7 +54,7 @@ typedef enum {
 static const iree_async_proactor_vtable_t iree_async_proactor_posix_vtable;
 static iree_host_size_t iree_async_proactor_posix_dispatch_linked_continuation(
     iree_async_proactor_posix_t* proactor, iree_async_operation_t* operation,
-    iree_status_t trigger_status);
+    iree_status_code_t trigger_status_code);
 static void iree_async_proactor_posix_process_notification_waits(
     iree_async_proactor_posix_t* proactor,
     iree_async_notification_t* notification);
@@ -726,7 +726,7 @@ static void iree_async_proactor_posix_drain_pending_queue(
         iree_status_ignore(push_status);
         iree_async_operation_release_resources(operation);
         iree_async_proactor_posix_dispatch_linked_continuation(
-            proactor, operation, iree_status_from_code(IREE_STATUS_CANCELLED));
+            proactor, operation, IREE_STATUS_CANCELLED);
         iree_async_proactor_complete_operation(
             operation, iree_status_from_code(IREE_STATUS_CANCELLED),
             IREE_ASYNC_COMPLETION_FLAG_NONE);
@@ -809,7 +809,7 @@ static void iree_async_proactor_posix_drain_pending_queue(
         iree_status_ignore(push_status);
         iree_async_operation_release_resources(operation);
         iree_async_proactor_posix_dispatch_linked_continuation(
-            proactor, operation, status);
+            proactor, operation, iree_status_code(status));
         iree_async_proactor_complete_operation(operation, status,
                                                IREE_ASYNC_COMPLETION_FLAG_NONE);
       }
@@ -1278,7 +1278,7 @@ static iree_status_t iree_async_proactor_posix_submit_message(
     // Fire-and-forget: no source completion callback. Dispatch linked
     // continuation directly with the send status.
     iree_async_proactor_posix_dispatch_linked_continuation(
-        proactor, &message->base, send_status);
+        proactor, &message->base, iree_status_code(send_status));
     iree_status_ignore(send_status);
     return iree_ok_status();
   }
@@ -1366,7 +1366,8 @@ static iree_status_t iree_async_proactor_posix_submit_operation(
         return iree_ok_status();
       }
       if (!iree_status_is_ok(send_status)) {
-        iree_async_socket_set_failure(send_op->socket, send_status);
+        iree_async_socket_set_failure(send_op->socket,
+                                      iree_status_code(send_status));
       }
       return iree_async_proactor_posix_complete_on_submit(
           proactor, operation, send_status, IREE_ASYNC_COMPLETION_FLAG_NONE);
@@ -1404,7 +1405,8 @@ static iree_status_t iree_async_proactor_posix_submit_operation(
         return iree_ok_status();
       }
       if (!iree_status_is_ok(sendto_status)) {
-        iree_async_socket_set_failure(sendto_op->socket, sendto_status);
+        iree_async_socket_set_failure(sendto_op->socket,
+                                      iree_status_code(sendto_status));
       }
       return iree_async_proactor_posix_complete_on_submit(
           proactor, operation, sendto_status, IREE_ASYNC_COMPLETION_FLAG_NONE);
@@ -1593,14 +1595,14 @@ static void iree_async_proactor_posix_submit_continuation_chain(
 // Returns the number of directly-invoked callbacks (for completion counting).
 static iree_host_size_t iree_async_proactor_posix_dispatch_linked_continuation(
     iree_async_proactor_posix_t* proactor, iree_async_operation_t* operation,
-    iree_status_t trigger_status) {
+    iree_status_code_t trigger_status_code) {
   iree_async_operation_t* continuation = operation->linked_next;
   if (!continuation) return 0;
 
   // Detach the chain before potentially recursive submit.
   operation->linked_next = NULL;
 
-  if (iree_status_is_ok(trigger_status)) {
+  if (trigger_status_code == IREE_STATUS_OK) {
     iree_async_proactor_posix_submit_continuation_chain(proactor, continuation);
     return 0;  // Submitted ops produce completions counted by the drain loop.
   } else {
@@ -1695,7 +1697,7 @@ static iree_host_size_t iree_async_proactor_posix_process_expired_timers(
     } else {
       // Pool exhausted — dispatch directly (same as drain_completion_queue).
       iree_async_proactor_posix_dispatch_linked_continuation(
-          proactor, &timer->base, status);
+          proactor, &timer->base, iree_status_code(status));
       iree_async_operation_release_resources(&timer->base);
       iree_async_proactor_complete_operation(&timer->base, status,
                                              IREE_ASYNC_COMPLETION_FLAG_NONE);
@@ -1775,7 +1777,7 @@ static iree_host_size_t iree_async_proactor_posix_drain_completion_queue(
     // count is added directly here.
     if (operation) {
       count += iree_async_proactor_posix_dispatch_linked_continuation(
-          proactor, operation, status);
+          proactor, operation, iree_status_code(status));
     }
 
     // Release resources retained during submission for final completions.
@@ -2400,7 +2402,7 @@ static void iree_async_proactor_posix_process_operation_chain(
         iree_status_ignore(push_status);
         iree_async_operation_release_resources(current);
         iree_async_proactor_posix_dispatch_linked_continuation(
-            proactor, current, iree_status_from_code(IREE_STATUS_CANCELLED));
+            proactor, current, IREE_STATUS_CANCELLED);
         iree_async_proactor_complete_operation(
             current, iree_status_from_code(IREE_STATUS_CANCELLED),
             IREE_ASYNC_COMPLETION_FLAG_NONE);
@@ -2429,7 +2431,7 @@ static void iree_async_proactor_posix_process_operation_chain(
       iree_async_socket_t* socket =
           iree_async_proactor_posix_socket_from_io_operation(current);
       if (socket) {
-        iree_async_socket_set_failure(socket, op_status);
+        iree_async_socket_set_failure(socket, iree_status_code(op_status));
       }
     }
 
@@ -2493,8 +2495,8 @@ static void iree_async_proactor_posix_process_operation_chain(
                              &completion->slist_entry);
     } else {
       // Pool exhausted — dispatch directly (same pattern as cancel fallback).
-      iree_async_proactor_posix_dispatch_linked_continuation(proactor, current,
-                                                             op_status);
+      iree_async_proactor_posix_dispatch_linked_continuation(
+          proactor, current, iree_status_code(op_status));
       iree_async_operation_release_resources(current);
       iree_async_proactor_complete_operation(current, op_status,
                                              completion_flags);
@@ -2603,7 +2605,7 @@ static void iree_async_proactor_posix_process_notification_waits(
         // Pool exhausted — release resources and dispatch directly.
         iree_async_operation_release_resources(&wait->base);
         iree_async_proactor_posix_dispatch_linked_continuation(
-            proactor, &wait->base, status);
+            proactor, &wait->base, iree_status_code(status));
         iree_async_proactor_complete_operation(&wait->base, status,
                                                IREE_ASYNC_COMPLETION_FLAG_NONE);
       }
@@ -2665,7 +2667,7 @@ static void iree_async_proactor_posix_drain_pending_timer_cancellations(
     } else {
       // Pool exhausted — dispatch directly (same as drain_completion_queue).
       iree_async_proactor_posix_dispatch_linked_continuation(
-          proactor, &timer->base, iree_status_from_code(IREE_STATUS_CANCELLED));
+          proactor, &timer->base, IREE_STATUS_CANCELLED);
       iree_async_operation_release_resources(&timer->base);
       iree_async_proactor_complete_operation(
           &timer->base, iree_status_from_code(IREE_STATUS_CANCELLED),
@@ -2769,7 +2771,7 @@ static void iree_async_proactor_posix_drain_pending_fd_cancellations(
           iree_status_ignore(push_status);
           iree_async_operation_release_resources(op);
           iree_async_proactor_posix_dispatch_linked_continuation(
-              proactor, op, iree_status_from_code(IREE_STATUS_CANCELLED));
+              proactor, op, IREE_STATUS_CANCELLED);
           iree_async_proactor_complete_operation(
               op, iree_status_from_code(IREE_STATUS_CANCELLED),
               IREE_ASYNC_COMPLETION_FLAG_NONE);

--- a/runtime/src/iree/async/socket.h
+++ b/runtime/src/iree/async/socket.h
@@ -263,17 +263,16 @@ static inline iree_status_t iree_async_socket_query_failure(
 
 // Sets the socket's sticky failure status if not already failed.
 // Uses atomic compare-exchange so the first error wins: if the socket already
-// has a failure, |status| is discarded and the original failure preserved.
+// has a failure, |status_code| is discarded and the original failure preserved.
 //
 // Only the status code is stored (no storage allocation). The full error
 // context is delivered to the caller via the operation's completion callback;
 // the sticky failure is a persistent "is this socket still usable?" indicator
 // that supports peek semantics in iree_async_socket_query_failure().
-static inline void iree_async_socket_set_failure(iree_async_socket_t* socket,
-                                                 iree_status_t status) {
-  if (iree_status_is_ok(status)) return;
-  intptr_t failure_code =
-      (intptr_t)iree_status_from_code(iree_status_code(status));
+static inline void iree_async_socket_set_failure(
+    iree_async_socket_t* socket, iree_status_code_t status_code) {
+  if (status_code == IREE_STATUS_OK) return;
+  intptr_t failure_code = (intptr_t)iree_status_from_code(status_code);
   intptr_t expected = (intptr_t)iree_ok_status();
   iree_atomic_compare_exchange_strong(&socket->failure_status, &expected,
                                       failure_code, iree_memory_order_acq_rel,

--- a/runtime/src/iree/async/util/continuation.c
+++ b/runtime/src/iree/async/util/continuation.c
@@ -8,11 +8,10 @@
 
 iree_host_size_t iree_async_continuation_dispatch(
     iree_async_continuation_submit_fn_t submit_fn, void* submit_context,
-    iree_async_continuation_list_t* continuations, iree_status_t status) {
+    iree_async_continuation_list_t* continuations,
+    iree_status_code_t status_code) {
   iree_host_size_t continuation_count = continuations->count;
   if (continuation_count == 0) {
-    // No continuations - caller still owns the status for their callback.
-    // Do not consume it here.
     return 0;
   }
 
@@ -24,7 +23,7 @@ iree_host_size_t iree_async_continuation_dispatch(
   // re-enter this function.
   continuations->count = 0;
 
-  if (iree_status_is_ok(status)) {
+  if (status_code == IREE_STATUS_OK) {
     // Triggering operation succeeded - submit continuations.
     iree_async_operation_list_t continuation_list = {
         .values = continuation_operations + continuation_start,
@@ -44,7 +43,7 @@ iree_host_size_t iree_async_continuation_dispatch(
           ++invoked;
         }
       }
-      iree_status_ignore(submit_status);
+      iree_status_free(submit_status);
       return invoked;
     }
     // Operations submitted - completions will be counted via CQEs.
@@ -56,9 +55,6 @@ iree_host_size_t iree_async_continuation_dispatch(
     // We don't submit-then-cancel because some operations (like NOP) complete
     // immediately in the kernel before cancel can take effect. Invoking
     // callbacks directly ensures continuations consistently receive CANCELLED.
-    //
-    // Note: We do NOT consume the incoming status here - the caller still
-    // owns it and will use it for the triggering operation's callback.
     iree_host_size_t invoked = 0;
     for (iree_host_size_t i = 0; i < continuation_count; ++i) {
       iree_async_operation_t* operation =

--- a/runtime/src/iree/async/util/continuation.h
+++ b/runtime/src/iree/async/util/continuation.h
@@ -85,21 +85,23 @@ typedef iree_status_t (*iree_async_continuation_submit_fn_t)(
 // Dispatches continuation operations based on the triggering operation's
 // result.
 //
-// On success (|status| is OK):
+// On success (|status_code| is OK):
 //   Submits continuation operations via |submit_fn|. If submit fails, invokes
 //   callbacks directly with the submit error.
 //
-// On failure (|status| is not OK):
+// On failure (|status_code| is not OK):
 //   Invokes all continuation callbacks directly with CANCELLED.
 //
-// IMPORTANT: This function does NOT consume |status|. The caller retains
-// ownership and must pass it to the triggering operation's completion callback.
-// Continuations receive fresh CANCELLED statuses, not the original error.
+// The triggering operation's status is intentionally represented as a status
+// code because dispatch only needs to branch on success/failure. The caller
+// retains ownership of any original status and passes it to the triggering
+// operation's completion callback. Continuations receive fresh CANCELLED
+// statuses, not the original error.
 //
 // |submit_fn|: Backend's submit function.
 // |submit_context|: Context for submit_fn (typically proactor pointer).
 // |continuations|: List of continuations (count cleared before dispatch).
-// |status|: Result of the triggering operation (not consumed).
+// |status_code|: Result code of the triggering operation.
 //
 // Returns the number of callbacks invoked directly (not via CQE). This is used
 // for completion counting on backends that track completions.
@@ -107,7 +109,8 @@ typedef iree_status_t (*iree_async_continuation_submit_fn_t)(
 // Thread-safety: Must be called from the proactor's poll thread.
 iree_host_size_t iree_async_continuation_dispatch(
     iree_async_continuation_submit_fn_t submit_fn, void* submit_context,
-    iree_async_continuation_list_t* continuations, iree_status_t status);
+    iree_async_continuation_list_t* continuations,
+    iree_status_code_t status_code);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/async/util/continuation_test.cc
+++ b/runtime/src/iree/async/util/continuation_test.cc
@@ -94,7 +94,7 @@ TEST_F(ContinuationTest, EmptyListReturnsZero) {
       iree_async_continuation_list_empty();
 
   iree_host_size_t invoked = iree_async_continuation_dispatch(
-      MockSubmit, &context_, &continuations, iree_ok_status());
+      MockSubmit, &context_, &continuations, IREE_STATUS_OK);
 
   EXPECT_EQ(invoked, 0u);
   EXPECT_TRUE(context_.submitted_operations.empty());
@@ -106,21 +106,16 @@ TEST_F(ContinuationTest, EmptyListDoesNotConsumeStatus) {
       iree_async_continuation_list_empty();
 
   // Create a status with storage (error status).
-  // We own this status until we pass it to a callback or ignore it.
+  // We own this status until we pass it to a callback or free it.
   iree_status_t status = iree_make_status(IREE_STATUS_CANCELLED, "test error");
 
   iree_host_size_t invoked = iree_async_continuation_dispatch(
-      MockSubmit, &context_, &continuations, status);
+      MockSubmit, &context_, &continuations, iree_status_code(status));
 
   EXPECT_EQ(invoked, 0u);
 
-  // CRITICAL: dispatch does NOT consume status. Caller still owns it and
-  // would pass it to the triggering operation's completion callback.
-  // For this test, we just verify it's still valid then clean up.
   EXPECT_EQ(iree_status_code(status), IREE_STATUS_CANCELLED);
-
-  // We still own it, so we must clean up.
-  iree_status_ignore(status);
+  iree_status_free(status);
 }
 
 //===----------------------------------------------------------------------===//
@@ -134,7 +129,7 @@ TEST_F(ContinuationTest, SuccessSubmitsContinuations) {
       iree_async_make_continuation_list(operation_ptrs, 0, 3);
 
   iree_host_size_t invoked = iree_async_continuation_dispatch(
-      MockSubmit, &context_, &continuations, iree_ok_status());
+      MockSubmit, &context_, &continuations, IREE_STATUS_OK);
 
   // All operations should be submitted, none invoked directly.
   EXPECT_EQ(invoked, 0u);
@@ -156,7 +151,7 @@ TEST_F(ContinuationTest, SuccessWithStartOffset) {
                                         /*count=*/2);
 
   iree_host_size_t invoked = iree_async_continuation_dispatch(
-      MockSubmit, &context_, &continuations, iree_ok_status());
+      MockSubmit, &context_, &continuations, IREE_STATUS_OK);
 
   EXPECT_EQ(invoked, 0u);
   ASSERT_EQ(context_.submitted_operations.size(), 2u);
@@ -174,7 +169,7 @@ TEST_F(ContinuationTest, SuccessSubmitFailsInvokesCallbacksWithError) {
       iree_async_make_continuation_list(operation_ptrs, 0, 2);
 
   iree_host_size_t invoked = iree_async_continuation_dispatch(
-      MockSubmit, &context_, &continuations, iree_ok_status());
+      MockSubmit, &context_, &continuations, IREE_STATUS_OK);
 
   // Submit was attempted, then callbacks invoked directly with the error.
   // Each callback receives a CLONE of the submit error (ownership transfer).
@@ -203,12 +198,14 @@ TEST_F(ContinuationTest, FailureInvokesCancelledCallbacks) {
       iree_make_status(IREE_STATUS_INTERNAL, "something failed");
 
   iree_host_size_t invoked = iree_async_continuation_dispatch(
-      MockSubmit, &context_, &continuations, trigger_status);
+      MockSubmit, &context_, &continuations, iree_status_code(trigger_status));
 
   // All callbacks invoked directly with fresh CANCELLED statuses.
   // The original trigger_status is NOT passed to continuations.
   EXPECT_EQ(invoked, 3u);
   EXPECT_TRUE(context_.submitted_operations.empty());
+  EXPECT_EQ(iree_status_code(trigger_status), IREE_STATUS_INTERNAL);
+  iree_status_free(trigger_status);
   ASSERT_EQ(context_.completions.size(), 3u);
   for (int i = 0; i < 3; ++i) {
     EXPECT_EQ(context_.completions[i].operation, &operations_[i]);
@@ -218,13 +215,6 @@ TEST_F(ContinuationTest, FailureInvokesCancelledCallbacks) {
 
   // Count should be cleared.
   EXPECT_EQ(continuations.count, 0u);
-
-  // CRITICAL: dispatch does NOT consume trigger_status. The caller retains
-  // ownership to pass it to the triggering operation's completion callback.
-  EXPECT_EQ(iree_status_code(trigger_status), IREE_STATUS_INTERNAL);
-
-  // We still own it, so we must clean up.
-  iree_status_ignore(trigger_status);
 }
 
 TEST_F(ContinuationTest, FailureStatusNotConsumed) {
@@ -238,18 +228,14 @@ TEST_F(ContinuationTest, FailureStatusNotConsumed) {
       "this is a longer error message that will allocate storage");
 
   iree_async_continuation_dispatch(MockSubmit, &context_, &continuations,
-                                   status);
+                                   iree_status_code(status));
+
+  EXPECT_EQ(iree_status_code(status), IREE_STATUS_DATA_LOSS);
+  iree_status_free(status);
 
   // Verify the continuation got CANCELLED, not the original error.
   ASSERT_EQ(context_.completions.size(), 1u);
   EXPECT_EQ(context_.completions[0].status_code, IREE_STATUS_CANCELLED);
-
-  // Status should still be valid - caller retains ownership.
-  // This would be passed to the triggering operation's callback.
-  EXPECT_EQ(iree_status_code(status), IREE_STATUS_DATA_LOSS);
-
-  // We still own it, so clean up.
-  iree_status_ignore(status);
 }
 
 //===----------------------------------------------------------------------===//
@@ -269,16 +255,14 @@ TEST_F(ContinuationTest, NullCallbackSkipped) {
       iree_make_status(IREE_STATUS_CANCELLED, "cancelled");
 
   iree_host_size_t invoked = iree_async_continuation_dispatch(
-      MockSubmit, &context_, &continuations, trigger_status);
+      MockSubmit, &context_, &continuations, iree_status_code(trigger_status));
+  iree_status_free(trigger_status);
 
   // Only 2 callbacks invoked (the one with null is skipped).
   EXPECT_EQ(invoked, 2u);
   ASSERT_EQ(context_.completions.size(), 2u);
   EXPECT_EQ(context_.completions[0].operation, &operations_[0]);
   EXPECT_EQ(context_.completions[1].operation, &operations_[2]);
-
-  // Clean up - we still own trigger_status.
-  iree_status_ignore(trigger_status);
 }
 
 }  // namespace

--- a/runtime/src/iree/async/util/operation_pool_test.cc
+++ b/runtime/src/iree/async/util/operation_pool_test.cc
@@ -232,7 +232,7 @@ TEST_F(OperationPoolTest, ConcurrentAcquireRelease) {
         iree_async_operation_t* operation = nullptr;
         iree_status_t status = iree_async_operation_pool_acquire(
             pool_, sizeof(iree_async_operation_t), &operation);
-        ASSERT_TRUE(iree_status_is_ok(status));
+        IREE_ASSERT_OK(status);
         ASSERT_NE(operation, nullptr);
 
         // Simulate some work.
@@ -265,7 +265,7 @@ TEST_F(OperationPoolTest, ConcurrentMixedSizes) {
         iree_async_operation_t* operation = nullptr;
         iree_status_t status =
             iree_async_operation_pool_acquire(pool_, size, &operation);
-        ASSERT_TRUE(iree_status_is_ok(status));
+        IREE_ASSERT_OK(status);
         ASSERT_NE(operation, nullptr);
 
         iree_async_operation_pool_release(pool_, operation);

--- a/runtime/src/iree/base/internal/json.c
+++ b/runtime/src/iree/base/internal/json.c
@@ -1442,9 +1442,9 @@ iree_status_t iree_json_parse_codepoint(iree_string_view_t value,
   iree_host_size_t unescaped_length = 0;
   iree_status_t status =
       iree_json_unescape_string(value, 0, NULL, &unescaped_length);
-  if (!iree_status_is_ok(status) &&
-      !iree_status_is_resource_exhausted(status)) {
-    return status;
+  if (!iree_status_is_ok(status)) {
+    if (!iree_status_is_resource_exhausted(status)) return status;
+    iree_status_ignore(status);
   }
 
   // Allocate a small stack buffer for the unescaped character.

--- a/runtime/src/iree/base/status.h
+++ b/runtime/src/iree/base/status.h
@@ -194,6 +194,17 @@ typedef enum iree_status_code_e {
 // leave ownership unchanged. A status that was only checked still needs to be
 // returned, stored, or consumed on every non-OK path.
 //
+// A function parameter typed as iree_status_t by value participates in that
+// ownership protocol. Callbacks and helpers that accept a by-value status must
+// return it, store it into an owning destination, consume it, clone it before
+// fanout, or transfer it to another owning status API. If a callee only needs
+// to test success/failure or record a scalar result, pass iree_status_code_t
+// instead. If a C callee needs to inspect the full formatted status without
+// consuming it, pass const iree_status_t* and document that the pointer is
+// borrowed. In C++ helpers, pass const iree_status_t& for the same borrowed
+// full-status case. These non-owning signatures make it visible that the caller
+// still owns the original status after the call returns.
+//
 // iree_status_free and iree_status_ignore both consume ownership, but they
 // communicate different intent. Use iree_status_free when the failure has been
 // handled, reported, propagated through another channel, or otherwise accounted
@@ -261,8 +272,9 @@ typedef enum iree_status_code_e {
 //
 // The repo-owned clang-tidy checks enforce the mechanically provable part of
 // this contract: status-returning call results are not silently discarded,
-// local status owners are not overwritten or left unconsumed, and consumed
-// status variables are not reused.
+// local status owners are not overwritten or left unconsumed, consumed status
+// variables are not reused, and by-value status parameters are not merely
+// observed as borrowed values.
 //
 // Opaque status structure containing an iree_status_code_t and optional status
 // object with more detailed information and payloads.

--- a/runtime/src/iree/base/status.h
+++ b/runtime/src/iree/base/status.h
@@ -163,6 +163,107 @@ typedef enum iree_status_code_e {
   IREE_STATUS_CODE_MASK = 0x1Fu,
 } iree_status_code_t;
 
+// Status ownership and lifetime contract.
+//
+// iree_status_t is an owned, linear C value. A status value is returned by
+// value, copied by ordinary C assignment, and not automatically destroyed when
+// it leaves scope. Any operation that produces an iree_status_t transfers
+// ownership of that status to the caller. The owner must eventually transfer
+// that ownership again or consume it exactly once.
+//
+// Assigning one local iree_status_t variable to another local transfers
+// ownership to the destination. The source variable must not be read, returned,
+// or consumed again unless it is first reset to a fresh value.
+//
+// Valid terminal ownership actions are:
+//
+// * return the status from the current status-returning function;
+// * store it into an owning field, callback argument, or output slot whose
+//   contract says it now owns the status;
+// * consume it with iree_status_free, iree_status_ignore,
+//   iree_status_consume_code, or iree_status_abort;
+// * pass it to a status transfer helper such as iree_status_join,
+//   iree_status_annotate, iree_status_annotate_f, or iree_status_freeze and
+//   then return, store, or consume the helper's returned status; or
+// * in C++ code, wrap it in iree::Status or pass it to a test helper such as
+//   IREE_EXPECT_OK/IREE_ASSERT_OK that takes ownership.
+//
+// Reading a status is not a terminal ownership action. Predicates and accessors
+// such as iree_status_is_ok, iree_status_code, iree_status_message,
+// iree_status_source_location, and formatting functions observe the status but
+// leave ownership unchanged. A status that was only checked still needs to be
+// returned, stored, or consumed on every non-OK path.
+//
+// iree_status_free and iree_status_ignore both consume ownership, but they
+// communicate different intent. Use iree_status_free when the failure has been
+// handled, reported, propagated through another channel, or otherwise accounted
+// for. Use iree_status_ignore only when the failure is deliberately unhandled
+// and the code is explicitly choosing to discard it.
+//
+// Consuming a status does not mutate the caller's local variable. These APIs
+// take the status by value; after iree_status_free(status) or
+// iree_status_ignore(status), the local |status| variable still contains the
+// old bits and must not be read, returned, or consumed again unless it is first
+// reset to a fresh value such as iree_ok_status(). A common reset pattern for
+// stored statuses is:
+//
+//   stored_status = iree_status_ignore(stored_status);
+//
+// iree_status_join consumes both of its arguments and returns the status that
+// remains owned by the caller. This is the normal way to preserve a primary
+// failure while still reporting cleanup failures:
+//
+//   iree_status_t status = do_work();
+//   status = iree_status_join(status, do_cleanup());
+//   return status;
+//
+// iree_status_annotate, iree_status_annotate_f, and iree_status_freeze consume
+// their input status and return the replacement status. The returned value is
+// the new owned value:
+//
+//   if (!iree_status_is_ok(status)) {
+//     return iree_status_annotate_f(status, "while opening '%.*s'",
+//                                   (int)path.size, path.data);
+//   }
+//
+// iree_status_clone is different: it observes the input status and returns a
+// second owned status. Both the original and the clone then require independent
+// ownership handling.
+//
+// OK statuses and code-only statuses may not have heap storage, but they still
+// participate in the same ownership protocol. That uniformity keeps callers
+// independent of IREE_STATUS_MODE and lets debug builds attach source
+// locations, annotations, payloads, and stack traces without changing call-site
+// control flow.
+//
+// iree_make_status and the allocation/annotation helpers may allocate and may
+// capture source locations, annotations, payloads, or stack traces. They
+// represent real operation failures, not ordinary non-error control flow,
+// retry state, or parser lookahead. Expected alternatives are usually modeled
+// with enums, booleans, optionals, or ordinary result values instead of by
+// manufacturing and discarding statuses.
+//
+// For simple propagation with no local cleanup:
+//
+//   IREE_RETURN_IF_ERROR(do_work());
+//   return iree_ok_status();
+//
+// For local cleanup or output publication, keep one terminal status value and
+// gate success-only effects on iree_status_is_ok(status):
+//
+//   iree_status_t status = create_resource(&resource);
+//   if (iree_status_is_ok(status)) {
+//     *out_resource = resource;
+//   } else {
+//     destroy_resource(resource);
+//   }
+//   return status;
+//
+// The repo-owned clang-tidy checks enforce the mechanically provable part of
+// this contract: status-returning call results are not silently discarded,
+// local status owners are not overwritten or left unconsumed, and consumed
+// status variables are not reused.
+//
 // Opaque status structure containing an iree_status_code_t and optional status
 // object with more detailed information and payloads.
 //

--- a/runtime/src/iree/base/status.h
+++ b/runtime/src/iree/base/status.h
@@ -228,6 +228,13 @@ typedef enum iree_status_code_e {
 //   status = iree_status_join(status, do_cleanup());
 //   return status;
 //
+// A single full expression should mention an owned status at most once when any
+// mention transfers ownership. C does not sequence function argument
+// evaluation, so expressions like iree_status_join(status, callback(status))
+// have no portable ownership order. Sequence the operations through temporary
+// locals, and clone first when two independent consumers need equivalent status
+// payloads.
+//
 // iree_status_annotate, iree_status_annotate_f, and iree_status_freeze consume
 // their input status and return the replacement status. The returned value is
 // the new owned value:
@@ -273,8 +280,9 @@ typedef enum iree_status_code_e {
 // The repo-owned clang-tidy checks enforce the mechanically provable part of
 // this contract: status-returning call results are not silently discarded,
 // local status owners are not overwritten or left unconsumed, consumed status
-// variables are not reused, and by-value status parameters are not merely
-// observed as borrowed values.
+// variables are not reused, a single full expression does not combine a
+// transfer with another use of the same local status, and by-value status
+// parameters are not merely observed as borrowed values.
 //
 // Opaque status structure containing an iree_status_code_t and optional status
 // object with more detailed information and payloads.

--- a/runtime/src/iree/base/status_test.cc
+++ b/runtime/src/iree/base/status_test.cc
@@ -124,7 +124,7 @@ TEST(StatusJoin, FailedBaseKeepsPrimaryAndPreservesSecondary) {
 }
 
 // Helper: collects iree_status_format_to output into a std::string.
-static std::string FormatStatusTo(iree_status_t status) {
+static std::string FormatStatusTo(const iree_status_t& status) {
   std::string result;
   iree_status_format_to(
       status,
@@ -138,7 +138,7 @@ static std::string FormatStatusTo(iree_status_t status) {
 }
 
 // Helper: collects iree_status_format output into a std::string.
-static std::string FormatStatusBuffer(iree_status_t status) {
+static std::string FormatStatusBuffer(const iree_status_t& status) {
   iree_host_size_t buffer_length = 0;
   if (!iree_status_format(status, 0, NULL, &buffer_length)) return "<!>";
   std::vector<char> buffer(buffer_length + 1, '\0');
@@ -150,7 +150,7 @@ static std::string FormatStatusBuffer(iree_status_t status) {
   return std::string(buffer.data(), actual_length);
 }
 
-static void ExpectStatusFormatTruncated(iree_status_t status,
+static void ExpectStatusFormatTruncated(const iree_status_t& status,
                                         iree_host_size_t buffer_capacity) {
   iree_host_size_t required_length = 0;
   EXPECT_TRUE(iree_status_format(status, 0, NULL, &required_length));
@@ -168,7 +168,7 @@ static void ExpectStatusFormatTruncated(iree_status_t status,
 }
 
 static void ExpectStatusFormatTruncatedAtAllSmallerCapacities(
-    iree_status_t status) {
+    const iree_status_t& status) {
   iree_host_size_t required_length = 0;
   ASSERT_TRUE(iree_status_format(status, 0, NULL, &required_length));
   ASSERT_GT(required_length, 0u);
@@ -178,14 +178,14 @@ static void ExpectStatusFormatTruncatedAtAllSmallerCapacities(
   }
 }
 
-static void ExpectStatusFormatRequiresTerminator(iree_status_t status) {
+static void ExpectStatusFormatRequiresTerminator(const iree_status_t& status) {
   iree_host_size_t required_length = 0;
   ASSERT_TRUE(iree_status_format(status, 0, NULL, &required_length));
   ASSERT_GT(required_length, 0u);
   ExpectStatusFormatTruncated(status, required_length);
 }
 
-static void ExpectStatusFormatFitsExactly(iree_status_t status) {
+static void ExpectStatusFormatFitsExactly(const iree_status_t& status) {
   std::string expected = FormatStatusTo(status);
   ASSERT_FALSE(expected.empty());
 

--- a/runtime/src/iree/base/status_test.cc
+++ b/runtime/src/iree/base/status_test.cc
@@ -389,8 +389,10 @@ TEST(StatusToString, SinglePass) {
   iree_allocator_t allocator = iree_allocator_system();
   char* buffer = NULL;
   iree_host_size_t buffer_length = 0;
-  ASSERT_TRUE(
-      iree_status_to_string(status, &allocator, &buffer, &buffer_length));
+  const bool converted =
+      iree_status_to_string(status, &allocator, &buffer, &buffer_length);
+  iree_status_free(status);
+  ASSERT_TRUE(converted);
   std::string result(buffer, buffer_length);
   EXPECT_THAT(result, HasSubstr("INTERNAL"));
   EXPECT_THAT(result, HasSubstr("error 42"));
@@ -398,7 +400,6 @@ TEST(StatusToString, SinglePass) {
   // Verify NUL termination.
   EXPECT_EQ(buffer[buffer_length], '\0');
   iree_allocator_free(allocator, buffer);
-  iree_status_free(status);
 }
 
 #endif  // has IREE_STATUS_FEATURE_ANNOTATIONS

--- a/runtime/src/iree/base/string_builder.c
+++ b/runtime/src/iree/base/string_builder.c
@@ -247,8 +247,8 @@ static bool iree_string_builder_append_status_output(iree_string_view_t chunk,
 }
 
 IREE_API_EXPORT iree_status_t iree_string_builder_append_status(
-    iree_string_builder_t* builder, iree_status_t status) {
-  if (!iree_status_format_to(status, iree_string_builder_append_status_output,
+    iree_string_builder_t* builder, const iree_status_t* status) {
+  if (!iree_status_format_to(*status, iree_string_builder_append_status_output,
                              builder)) {
     return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                             "failed to append formatted status to builder");

--- a/runtime/src/iree/base/string_builder.h
+++ b/runtime/src/iree/base/string_builder.h
@@ -163,7 +163,7 @@ IREE_API_EXPORT IREE_PRINTF_ATTRIBUTE(2, 3) iree_status_t
 // source location, message, and all payload annotations).
 // Does not consume or free |status|.
 IREE_API_EXPORT iree_status_t iree_string_builder_append_status(
-    iree_string_builder_t* builder, iree_status_t status);
+    iree_string_builder_t* builder, const iree_status_t* status);
 
 // Lightweight builder for lists of iree_string_pair_t.
 // Includes a side pool for keeping dynamically allocated strings, since it is

--- a/runtime/src/iree/base/tooling/flags.c
+++ b/runtime/src/iree/base/tooling/flags.c
@@ -481,6 +481,7 @@ void iree_flags_parse_checked(iree_flags_parse_mode_t mode, int* argc,
   fprintf(stderr, "\x1b[31mFLAGS ERROR: (╯°□°)╯︵👻\x1b[0m\n");
   iree_status_fprint(stderr, status);
   fflush(stderr);
+  iree_status_free(status);
 
   exit(EXIT_FAILURE);
 }

--- a/runtime/src/iree/hal/buffer_view_util.c
+++ b/runtime/src/iree/hal/buffer_view_util.c
@@ -401,13 +401,14 @@ static iree_status_t iree_hal_buffer_view_parse_impl(
   if (!iree_status_is_ok(shape_result) &&
       !iree_status_is_out_of_range(shape_result)) {
     return shape_result;
-  } else if (shape_rank > 128) {
+  }
+  iree_status_free(shape_result);
+  if (shape_rank > 128) {
     return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                             "a shape rank of %" PRIhsz
                             " is just a little bit excessive, eh?",
                             shape_rank);
   }
-  shape_result = iree_status_ignore(shape_result);
   iree_hal_dim_t* shape =
       (iree_hal_dim_t*)iree_alloca(shape_rank * sizeof(iree_hal_dim_t));
   IREE_RETURN_IF_ERROR(
@@ -485,7 +486,7 @@ static iree_status_t iree_hal_buffer_view_format_impl(
         buffer ? buffer + buffer_length : NULL, &shape_length);
     buffer_length += shape_length;
     if (iree_status_is_out_of_range(status)) {
-      status = iree_status_ignore(status);
+      iree_status_free(status);
       buffer = NULL;
     } else if (!iree_status_is_ok(status)) {
       return status;
@@ -503,7 +504,7 @@ static iree_status_t iree_hal_buffer_view_format_impl(
       buffer ? buffer + buffer_length : NULL, &element_type_length);
   buffer_length += element_type_length;
   if (iree_status_is_out_of_range(status)) {
-    status = iree_status_ignore(status);
+    iree_status_free(status);
     buffer = NULL;
   } else if (!iree_status_is_ok(status)) {
     return status;
@@ -532,7 +533,7 @@ static iree_status_t iree_hal_buffer_view_format_impl(
   status =
       iree_status_join(status, iree_hal_buffer_unmap_range(&buffer_mapping));
   if (iree_status_is_out_of_range(status)) {
-    status = iree_status_ignore(status);
+    iree_status_free(status);
     buffer = NULL;
   } else if (!iree_status_is_ok(status)) {
     return status;
@@ -574,6 +575,7 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_view_fprint(
     IREE_TRACE_ZONE_END(z0);
     return status;
   }
+  iree_status_free(status);
 
   // Allocate scratch space to format in to.
   // We should be streaming.
@@ -611,6 +613,7 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_view_append_to_builder(
       buffer_view, max_element_count, /*buffer_capacity=*/0, /*buffer=*/NULL,
       &required_length);
   if (!iree_status_is_out_of_range(status)) return status;
+  iree_status_free(status);
   char* buffer = NULL;
   IREE_RETURN_IF_ERROR(
       iree_string_builder_append_inline(builder, required_length, &buffer));

--- a/runtime/src/iree/hal/cts/command_buffer/dispatch_reuse_test.cc
+++ b/runtime/src/iree/hal/cts/command_buffer/dispatch_reuse_test.cc
@@ -245,7 +245,7 @@ TEST_P(DispatchReuseTest, DispatchProfilingRecordsCommandBufferDispatch) {
   iree_status_t profiling_status =
       profiling.Begin(IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS,
                       TestProfileSinkAsBase(&sink));
-  if (IsProfilingUnsupported(profiling_status)) {
+  if (IsProfilingUnsupported(iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "device dispatch profiling unsupported by backend";
   }
@@ -663,7 +663,7 @@ TEST_P(DispatchReuseTest, MultiDispatchProfilingFiltersCommandIndex) {
 
   DeviceProfilingScope profiling(device_);
   iree_status_t profiling_status = profiling.Begin(&profiling_options);
-  if (IsProfilingUnsupported(profiling_status)) {
+  if (IsProfilingUnsupported(iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "device dispatch profiling unsupported by backend";
   }

--- a/runtime/src/iree/hal/cts/queue/queue_dispatch_test.cc
+++ b/runtime/src/iree/hal/cts/queue/queue_dispatch_test.cc
@@ -144,7 +144,7 @@ TEST_P(QueueDispatchTest, DispatchWithConstantsAndBindingsWhileProfiling) {
   iree_status_t profiling_status =
       profiling.Begin(IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS,
                       TestProfileSinkAsBase(&sink));
-  if (IsProfilingUnsupported(profiling_status)) {
+  if (IsProfilingUnsupported(iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "device profiling data family unsupported by backend";
   }
@@ -234,7 +234,7 @@ TEST_P(QueueDispatchTest, DispatchHostQueueEventProfiling) {
       profiling.Begin(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS |
                           IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS,
                       TestProfileSinkAsBase(&sink));
-  if (IsProfilingUnsupported(profiling_status)) {
+  if (IsProfilingUnsupported(iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "host queue profiling unsupported by backend";
   }
@@ -320,7 +320,7 @@ TEST_P(QueueDispatchTest, DispatchDeviceQueueEventProfiling) {
   iree_status_t profiling_status =
       profiling.Begin(IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS,
                       TestProfileSinkAsBase(&sink));
-  if (IsProfilingUnsupported(profiling_status)) {
+  if (IsProfilingUnsupported(iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "device queue profiling unsupported by backend";
   }
@@ -378,7 +378,7 @@ TEST_P(QueueDispatchTest, DispatchProfileFilterCanSkipDirectDispatchEvents) {
       IREE_SV("iree-hal-cts-never-matches-*");
   DeviceProfilingScope profiling(device_);
   iree_status_t profiling_status = profiling.Begin(&profiling_options);
-  if (IsProfilingUnsupported(profiling_status)) {
+  if (IsProfilingUnsupported(iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "device profiling data family unsupported by backend";
   }
@@ -671,7 +671,7 @@ class QueueDispatchIndirectParametersTest : public CtsTestBase<> {
         profiling.Begin(IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS |
                             IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS,
                         TestProfileSinkAsBase(&sink));
-    if (IsProfilingUnsupported(profiling_status)) {
+    if (IsProfilingUnsupported(iree_status_code(profiling_status))) {
       iree_status_free(profiling_status);
       GTEST_SKIP() << "device profiling data family unsupported by backend";
     }

--- a/runtime/src/iree/hal/cts/queue/queue_transfer_test.cc
+++ b/runtime/src/iree/hal/cts/queue/queue_transfer_test.cc
@@ -603,7 +603,7 @@ TEST_P(QueueTransferTest, FillAndCopyHostQueueEventProfiling) {
       profiling.Begin(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS |
                           IREE_HAL_DEVICE_PROFILING_DATA_HOST_EXECUTION_EVENTS,
                       TestProfileSinkAsBase(&sink));
-  if (IsProfilingUnsupported(profiling_status)) {
+  if (IsProfilingUnsupported(iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "host queue profiling unsupported by backend";
   }

--- a/runtime/src/iree/hal/cts/util/profile_test_util.cc
+++ b/runtime/src/iree/hal/cts/util/profile_test_util.cc
@@ -475,9 +475,9 @@ iree_hal_profile_sink_t* TestProfileSinkAsBase(TestProfileSink* sink) {
   return reinterpret_cast<iree_hal_profile_sink_t*>(sink);
 }
 
-bool IsProfilingUnsupported(iree_status_t status) {
-  return iree_status_is_unimplemented(status) ||
-         iree_status_is_invalid_argument(status);
+bool IsProfilingUnsupported(iree_status_code_t status_code) {
+  return status_code == IREE_STATUS_UNIMPLEMENTED ||
+         status_code == IREE_STATUS_INVALID_ARGUMENT;
 }
 
 static bool HasInvalidDeviceTickAlignment(const TestProfileSink& sink,

--- a/runtime/src/iree/hal/cts/util/profile_test_util.h
+++ b/runtime/src/iree/hal/cts/util/profile_test_util.h
@@ -155,9 +155,9 @@ void TestProfileSinkInitialize(TestProfileSink* sink);
 // Casts |sink| to its HAL profile sink base pointer.
 iree_hal_profile_sink_t* TestProfileSinkAsBase(TestProfileSink* sink);
 
-// Returns true when |status| means a backend does not support the requested
-// profiling mode in a cross-backend CTS test.
-bool IsProfilingUnsupported(iree_status_t status);
+// Returns true when |status_code| means a backend does not support the
+// requested profiling mode in a cross-backend CTS test.
+bool IsProfilingUnsupported(iree_status_code_t status_code);
 
 // Verifies all dispatch events have clock correlation records for their
 // physical device.

--- a/runtime/src/iree/hal/device.c
+++ b/runtime/src/iree/hal/device.c
@@ -77,7 +77,8 @@ IREE_API_EXPORT iree_status_t iree_hal_device_query_capabilities(
   IREE_ASSERT_ARGUMENT(device);
   IREE_ASSERT_ARGUMENT(out_capabilities);
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_RETURN_IF_ERROR(
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
       _VTABLE_DISPATCH(device, query_capabilities)(device, out_capabilities));
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer.c
@@ -91,7 +91,7 @@ static void iree_hal_amdgpu_host_queue_retire_pm4_publication_reference(
     iree_status_t status) {
   (void)entry;
   iree_hal_amdgpu_pm4_command_buffer_retire_publication_reference(
-      (iree_hal_command_buffer_t*)user_data, status);
+      (iree_hal_command_buffer_t*)user_data, iree_status_code(status));
 }
 
 static iree_hal_amdgpu_reclaim_action_t

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profiling_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profiling_test.cc
@@ -77,7 +77,8 @@ TEST_F(HostQueueCommandBufferProfilingTest,
   CommandBufferProfileSinkInitialize(&sink);
   DeviceProfilingScope profiling(test_device.base_device());
   iree_status_t profiling_status = BeginSqWavesProfiling(&profiling, &sink);
-  if (IsHardwareCounterProfilingUnavailable(profiling_status)) {
+  if (IsHardwareCounterProfilingUnavailable(
+          iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "AMDGPU hardware counter profiling unavailable";
   }
@@ -102,7 +103,8 @@ TEST_F(HostQueueCommandBufferProfilingTest,
   CommandBufferProfileSinkInitialize(&sink);
   DeviceProfilingScope profiling(test_device.base_device());
   iree_status_t profiling_status = BeginSqWaveWidthProfiling(&profiling, &sink);
-  if (IsHardwareCounterProfilingUnavailable(profiling_status)) {
+  if (IsHardwareCounterProfilingUnavailable(
+          iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "AMDGPU hardware counter profiling unavailable";
   }
@@ -265,7 +267,7 @@ TEST_F(HostQueueCommandBufferProfilingTest,
       profiling.Begin(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS |
                           IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS,
                       CommandBufferProfileSinkAsBase(&sink));
-  if (IsQueueDeviceProfilingUnavailable(profiling_status)) {
+  if (IsQueueDeviceProfilingUnavailable(iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "queue-device profiling data family unsupported by backend";
   }
@@ -377,7 +379,7 @@ TEST_F(HostQueueCommandBufferProfilingTest,
   iree_status_t profiling_status =
       profiling.Begin(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS,
                       CommandBufferProfileSinkAsBase(&sink));
-  if (IsProfilingUnsupported(profiling_status)) {
+  if (IsProfilingUnsupported(iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "device profiling data family unsupported by backend";
   }
@@ -574,7 +576,7 @@ TEST_F(HostQueueCommandBufferProfilingTest,
   iree_status_t status =
       profiling.Begin(IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS,
                       CommandBufferProfileSinkAsBase(&sink));
-  if (IsQueueDeviceProfilingUnavailable(status)) {
+  if (IsQueueDeviceProfilingUnavailable(iree_status_code(status))) {
     iree_status_free(status);
     GTEST_SKIP() << "queue-device profiling data family unsupported by backend";
   }
@@ -1044,7 +1046,7 @@ TEST_F(HostQueueCommandBufferProfilingTest,
                           IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS |
                           IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS,
                       CommandBufferProfileSinkAsBase(&sink));
-  if (IsQueueDeviceProfilingUnavailable(profiling_status)) {
+  if (IsQueueDeviceProfilingUnavailable(iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "queue-device profiling data family unsupported by backend";
   }
@@ -1154,7 +1156,8 @@ TEST_F(HostQueueCommandBufferProfilingTest,
   CommandBufferProfileSinkInitialize(&sink);
   DeviceProfilingScope profiling(test_device.base_device());
   iree_status_t profiling_status = BeginSqWavesProfiling(&profiling, &sink);
-  if (IsHardwareCounterProfilingUnavailable(profiling_status)) {
+  if (IsHardwareCounterProfilingUnavailable(
+          iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "AMDGPU hardware counter profiling unavailable";
   }
@@ -1244,7 +1247,8 @@ TEST_F(HostQueueCommandBufferProfilingTest,
   DeviceProfilingScope profiling(test_device.base_device());
   iree_status_t profiling_status =
       BeginSqWavesCounterRangeProfiling(&profiling, &sink);
-  if (IsHardwareCounterProfilingUnavailable(profiling_status)) {
+  if (IsHardwareCounterProfilingUnavailable(
+          iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "AMDGPU hardware counter range profiling unavailable";
   }
@@ -1300,7 +1304,8 @@ TEST_F(HostQueueCommandBufferProfilingTest,
   CommandBufferProfileSinkInitialize(&sink);
   DeviceProfilingScope profiling(test_device.base_device());
   iree_status_t profiling_status = BeginSqWavesProfiling(&profiling, &sink);
-  if (IsHardwareCounterProfilingUnavailable(profiling_status)) {
+  if (IsHardwareCounterProfilingUnavailable(
+          iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "AMDGPU hardware counter profiling unavailable";
   }
@@ -1508,7 +1513,7 @@ TEST_F(HostQueueCommandBufferProfilingTest,
   iree_status_t profiling_status =
       profiling.Begin(IREE_HAL_DEVICE_PROFILING_DATA_DEVICE_QUEUE_EVENTS,
                       CommandBufferProfileSinkAsBase(&sink));
-  if (IsQueueDeviceProfilingUnavailable(profiling_status)) {
+  if (IsQueueDeviceProfilingUnavailable(iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
     GTEST_SKIP() << "queue-device profiling data family unsupported by backend";
   }

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profiling_test_util.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profiling_test_util.h
@@ -18,9 +18,9 @@
 
 namespace iree::hal::amdgpu::test {
 
-static bool IsProfilingUnsupported(iree_status_t status) {
-  return iree_status_is_unimplemented(status) ||
-         iree_status_is_invalid_argument(status);
+static bool IsProfilingUnsupported(iree_status_code_t status_code) {
+  return status_code == IREE_STATUS_UNIMPLEMENTED ||
+         status_code == IREE_STATUS_INVALID_ARGUMENT;
 }
 
 static iree_status_t SubmitProfiledQueueFill(TestLogicalDevice* test_device) {
@@ -849,14 +849,16 @@ static uint32_t SumQueueEventOperationCounts(
   return operation_count;
 }
 
-static bool IsHardwareCounterProfilingUnavailable(iree_status_t status) {
-  return IsProfilingUnsupported(status) || iree_status_is_not_found(status) ||
-         iree_status_is_failed_precondition(status);
+static bool IsHardwareCounterProfilingUnavailable(
+    iree_status_code_t status_code) {
+  return IsProfilingUnsupported(status_code) ||
+         status_code == IREE_STATUS_NOT_FOUND ||
+         status_code == IREE_STATUS_FAILED_PRECONDITION;
 }
 
-static bool IsQueueDeviceProfilingUnavailable(iree_status_t status) {
-  return IsProfilingUnsupported(status) ||
-         iree_status_is_failed_precondition(status);
+static bool IsQueueDeviceProfilingUnavailable(iree_status_code_t status_code) {
+  return IsProfilingUnsupported(status_code) ||
+         status_code == IREE_STATUS_FAILED_PRECONDITION;
 }
 
 static iree_status_t BeginHardwareCounterProfiling(

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -3025,9 +3025,9 @@ static iree_status_t iree_hal_amdgpu_logical_device_profiling_begin(
                       logical_device, false));
     }
     if (sink_session_begun) {
-      status = iree_status_join(
-          status, iree_hal_profile_sink_end_session(sink, &metadata,
-                                                    iree_status_code(status)));
+      iree_status_code_t status_code = iree_status_code(status);
+      status = iree_status_join(status, iree_hal_profile_sink_end_session(
+                                            sink, &metadata, status_code));
     }
     logical_device->profiling.next_clock_correlation_sample_id = 0;
     memset(&logical_device->profiling.metadata_cursor, 0,
@@ -3139,9 +3139,9 @@ static iree_status_t iree_hal_amdgpu_logical_device_profiling_end(
         status, iree_hal_amdgpu_logical_device_set_hsa_profiling_enabled(
                     logical_device, false));
   }
-  status =
-      iree_status_join(status, iree_hal_profile_sink_end_session(
-                                   sink, &metadata, iree_status_code(status)));
+  iree_status_code_t status_code = iree_status_code(status);
+  status = iree_status_join(
+      status, iree_hal_profile_sink_end_session(sink, &metadata, status_code));
 
   iree_hal_amdgpu_logical_device_reset_profile_options(logical_device);
   logical_device->profiling.session_id = 0;

--- a/runtime/src/iree/hal/drivers/amdgpu/pm4_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/pm4_command_buffer.c
@@ -3602,7 +3602,8 @@ void iree_hal_amdgpu_pm4_command_buffer_cancel_publication_reference(
 }
 
 void iree_hal_amdgpu_pm4_command_buffer_retire_publication_reference(
-    iree_hal_command_buffer_t* base_command_buffer, iree_status_t status) {
+    iree_hal_command_buffer_t* base_command_buffer,
+    iree_status_code_t status_code) {
   iree_hal_amdgpu_pm4_command_buffer_t* command_buffer =
       iree_hal_amdgpu_pm4_command_buffer_cast(base_command_buffer);
   iree_slim_mutex_lock(&command_buffer->publication_mutex);
@@ -3611,7 +3612,7 @@ void iree_hal_amdgpu_pm4_command_buffer_retire_publication_reference(
               "matching acquire");
   --command_buffer->publication_reference_count;
   if (command_buffer->publication_reference_count == 0 &&
-      iree_status_is_ok(status) &&
+      status_code == IREE_STATUS_OK &&
       !iree_hsa_signal_is_null(command_buffer->publication_signal)) {
     iree_hal_amdgpu_pm4_command_buffer_release_publication_resources_locked(
         command_buffer);

--- a/runtime/src/iree/hal/drivers/amdgpu/pm4_command_buffer.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/pm4_command_buffer.h
@@ -244,7 +244,7 @@ void iree_hal_amdgpu_pm4_command_buffer_cancel_publication_reference(
 // Retires one acquired publication reference after a queue submission that
 // waited on the publication signal has retired.
 void iree_hal_amdgpu_pm4_command_buffer_retire_publication_reference(
-    iree_hal_command_buffer_t* command_buffer, iree_status_t status);
+    iree_hal_command_buffer_t* command_buffer, iree_status_code_t status_code);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/amdgpu/util/libaqlprofile.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/libaqlprofile.c
@@ -222,7 +222,7 @@ static iree_status_t iree_hal_amdgpu_libaqlprofile_try_load_library_from_file(
     status = iree_string_builder_append_format(
         error_builder, "\n  Tried: %s\n    ", file_path);
     if (iree_status_is_ok(status)) {
-      status = iree_string_builder_append_status(error_builder, load_status);
+      status = iree_string_builder_append_status(error_builder, &load_status);
     }
     iree_status_free(load_status);
   }

--- a/runtime/src/iree/hal/drivers/amdgpu/util/libhsa.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/libhsa.c
@@ -267,7 +267,7 @@ static iree_status_t iree_hal_amdgpu_libhsa_try_load_library_from_file(
     status = iree_string_builder_append_format(
         error_builder, "\n  Tried: %s\n    ", file_path);
     if (iree_status_is_ok(status)) {
-      status = iree_string_builder_append_status(error_builder, load_status);
+      status = iree_string_builder_append_status(error_builder, &load_status);
     }
     iree_status_free(load_status);
   }

--- a/runtime/src/iree/hal/drivers/hip/cleanup_thread.c
+++ b/runtime/src/iree/hal/drivers/hip/cleanup_thread.c
@@ -72,9 +72,10 @@ static int iree_hal_hip_cleanup_thread_main(void* param) {
             hipEventSynchronize(iree_hal_hip_event_handle(callback.event)));
       }
 
-      status = iree_status_join(
-          status, callback.callback(callback.user_data, callback.event,
-                                    iree_status_clone(status)));
+      iree_status_t callback_input_status = iree_status_clone(status);
+      iree_status_t callback_status = callback.callback(
+          callback.user_data, callback.event, callback_input_status);
+      status = iree_status_join(status, callback_status);
       iree_slim_mutex_lock(&thread->mutex);
       if (!iree_status_is_ok(status)) {
         iree_status_ignore(thread->failure_status);

--- a/runtime/src/iree/hal/drivers/hip/dynamic_symbols.c
+++ b/runtime/src/iree/hal/drivers/hip/dynamic_symbols.c
@@ -63,7 +63,7 @@ static bool iree_hal_hip_try_load_dylib(const char* file_path,
 
   IREE_IGNORE_ERROR(iree_string_builder_append_format(
       error_builder, "\n  Tried: %s\n    ", file_path));
-  IREE_IGNORE_ERROR(iree_string_builder_append_status(error_builder, status));
+  IREE_IGNORE_ERROR(iree_string_builder_append_status(error_builder, &status));
 
   iree_status_ignore(status);
   return false;

--- a/runtime/src/iree/hal/drivers/hip/hip_allocator_test.cc
+++ b/runtime/src/iree/hal/drivers/hip/hip_allocator_test.cc
@@ -244,9 +244,8 @@ TEST_F(HipAllocatorTest, DeviceLocalMappingPromotesToHostVisible) {
   iree_hal_buffer_t* buffer = nullptr;
   iree_status_t status =
       iree_hal_allocator_allocate_buffer(allocator, params, kSize, &buffer);
-  ASSERT_TRUE(iree_status_is_ok(status))
-      << "DEVICE_LOCAL + MAPPING allocation should succeed after promotion; "
-      << iree_status_code_string(iree_status_code(status));
+  IREE_ASSERT_OK(status)
+      << "DEVICE_LOCAL + MAPPING allocation should succeed after promotion";
   ASSERT_NE(nullptr, buffer);
 
   // The buffer must be mappable.
@@ -254,10 +253,11 @@ TEST_F(HipAllocatorTest, DeviceLocalMappingPromotesToHostVisible) {
   status = iree_hal_buffer_map_range(buffer, IREE_HAL_MAPPING_MODE_SCOPED,
                                      IREE_HAL_MEMORY_ACCESS_READ, 0, kSize,
                                      &mapping);
-  EXPECT_TRUE(iree_status_is_ok(status))
-      << "Promoted buffer should be mappable";
   if (iree_status_is_ok(status)) {
+    iree_status_free(status);
     IREE_ASSERT_OK(iree_hal_buffer_unmap_range(&mapping));
+  } else {
+    IREE_EXPECT_OK(status) << "Promoted buffer should be mappable";
   }
 
   iree_hal_buffer_release(buffer);

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -364,7 +364,8 @@ static iree_status_t iree_hal_hip_device_initialize_internal(
           device->identifier, device->params.stream_tracing,
           &device->block_pool, host_allocator,
           &device->devices[i].tracing_context);
-      status = IREE_HIP_CALL_TO_STATUS(symbols, hipCtxPopCurrent(NULL));
+      status = iree_status_join(
+          status, IREE_HIP_CALL_TO_STATUS(symbols, hipCtxPopCurrent(NULL)));
       if (!iree_status_is_ok(status)) {
         break;
       }
@@ -2340,30 +2341,33 @@ static iree_status_t iree_hal_hip_device_make_queue_read_callback_data(
       (void*)((uint8_t*)callback_data + sizeof(*callback_data)),
       &callback_data->base);
 
-  if (iree_status_is_ok(status)) {
-    uint64_t* chunk_base =
-        (void*)((uint8_t*)callback_data + sizeof(*callback_data) +
-                additional_data_for_base);
-    iree_hal_command_buffer_t** command_buffer_base =
-        (iree_hal_command_buffer_t**)((uint8_t*)chunk_base +
-                                      sizeof(*callback_data->read_chunk_sizes) *
-                                          chunk_count);
-    callback_data->source_file = source_file;
-    callback_data->source_offset = source_offset;
-    callback_data->target_buffer = target_buffer;
-    iree_hal_resource_retain(target_buffer);
-    iree_hal_file_retain(source_file);
-    callback_data->target_offset = target_offset;
-    callback_data->length = length;
-    callback_data->flags = flags;
-    callback_data->read_chunks_completed = 0;
-    callback_data->num_read_chunks = chunk_count;
-    callback_data->read_chunk_sizes = chunk_base;
-    callback_data->command_buffers = command_buffer_base;
+  if (!iree_status_is_ok(status)) {
+    iree_allocator_free(host_allocator, callback_data);
+    IREE_TRACE_ZONE_END(z0);
+    return status;
   }
+  uint64_t* chunk_base =
+      (void*)((uint8_t*)callback_data + sizeof(*callback_data) +
+              additional_data_for_base);
+  iree_hal_command_buffer_t** command_buffer_base =
+      (iree_hal_command_buffer_t**)((uint8_t*)chunk_base +
+                                    sizeof(*callback_data->read_chunk_sizes) *
+                                        chunk_count);
+  callback_data->source_file = source_file;
+  callback_data->source_offset = source_offset;
+  callback_data->target_buffer = target_buffer;
+  iree_hal_resource_retain(target_buffer);
+  iree_hal_file_retain(source_file);
+  callback_data->target_offset = target_offset;
+  callback_data->length = length;
+  callback_data->flags = flags;
+  callback_data->read_chunks_completed = 0;
+  callback_data->num_read_chunks = chunk_count;
+  callback_data->read_chunk_sizes = chunk_base;
+  callback_data->command_buffers = command_buffer_base;
   *out_data = callback_data;
   IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
+  return status;
 }
 
 static iree_status_t iree_hal_hip_device_queue_read(

--- a/runtime/src/iree/hal/drivers/hip/hip_driver.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_driver.c
@@ -258,9 +258,9 @@ static iree_status_t iree_hal_hip_driver_dump_device_info(
   if (iree_status_is_ok(status)) {
     status = iree_string_builder_append_format(
         builder, "\n- amdhip64_dylib_path: %s", path_builder.buffer);
-    iree_string_builder_deinitialize(&path_builder);
-    IREE_RETURN_IF_ERROR(status);
   }
+  iree_string_builder_deinitialize(&path_builder);
+  IREE_RETURN_IF_ERROR(status);
 
   hipDevice_t device = IREE_DEVICE_ID_TO_HIPDEVICE(device_id);
 

--- a/runtime/src/iree/hal/drivers/hip/stream_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/hip/stream_command_buffer.c
@@ -270,8 +270,8 @@ static iree_status_t iree_hal_hip_stream_command_buffer_execution_barrier(
   }
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  IREE_RETURN_IF_ERROR(
-      iree_hal_hip_stream_command_buffer_flush_collectives(command_buffer));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hal_hip_stream_command_buffer_flush_collectives(command_buffer));
 
   // Nothing to do for barriers between memory operations or dispatches--HIP
   // stream semantics guarantees execution and memory visibility in program

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -716,7 +716,7 @@ static void iree_hal_sync_device_profile_operation_record_begin(
 static void iree_hal_sync_device_profile_operation_record_end(
     iree_hal_sync_device_t* device,
     const iree_hal_sync_device_profile_operation_t* operation,
-    iree_status_t operation_status) {
+    iree_status_code_t operation_status_code) {
   iree_hal_local_profile_recorder_t* recorder = device->profile_recorder;
   if (IREE_UNLIKELY(!recorder || operation->submission_id == 0)) {
     return;
@@ -730,7 +730,7 @@ static void iree_hal_sync_device_profile_operation_record_end(
       iree_hal_local_profile_host_execution_event_info_default();
   event_info.type = operation->type;
   event_info.flags = operation->host_flags;
-  event_info.status_code = iree_status_code(operation_status);
+  event_info.status_code = operation_status_code;
   event_info.scope = operation->scope;
   event_info.submission_id = operation->submission_id;
   event_info.command_buffer_id = operation->command_buffer_id;
@@ -804,8 +804,8 @@ static iree_status_t iree_hal_sync_device_profiled_queue_op_end(
     const iree_hal_semaphore_list_t signal_semaphore_list,
     const iree_hal_sync_device_profile_operation_t* operation,
     iree_status_t operation_status) {
-  iree_hal_sync_device_profile_operation_record_end(device, operation,
-                                                    operation_status);
+  iree_hal_sync_device_profile_operation_record_end(
+      device, operation, iree_status_code(operation_status));
   return iree_hal_sync_device_queue_op_end(device, signal_semaphore_list,
                                            operation_status);
 }
@@ -1446,7 +1446,7 @@ static iree_status_t iree_hal_sync_device_queue_host_call_profiled(
 
   if (is_nonblocking || call_status_code == IREE_STATUS_DEFERRED) {
     iree_hal_sync_device_profile_operation_record_end(
-        device, &profile_operation, iree_status_from_code(call_status_code));
+        device, &profile_operation, call_status_code);
     // Dependencies have already been signaled by contract; the callback status
     // cannot be represented on the queue timeline. Deferred callbacks will
     // signal in the future or are fire-and-forget.
@@ -1458,7 +1458,7 @@ static iree_status_t iree_hal_sync_device_queue_host_call_profiled(
         device, signal_semaphore_list, &profile_operation, call_status);
   } else {
     iree_hal_sync_device_profile_operation_record_end(
-        device, &profile_operation, call_status);
+        device, &profile_operation, iree_status_code(call_status));
     iree_async_frontier_tracker_fail_axis(
         device->frontier_tracker, device->axis,
         iree_status_from_code(iree_status_code(call_status)));

--- a/runtime/src/iree/hal/drivers/local_task/block_processor.c
+++ b/runtime/src/iree/hal/drivers/local_task/block_processor.c
@@ -869,7 +869,7 @@ static bool iree_hal_cmd_transfer_claim_tile(iree_atomic_int64_t* tile_index,
 
 static void iree_hal_cmd_block_processor_profile_accumulate_dispatch(
     iree_hal_cmd_block_processor_context_t* context,
-    const iree_hal_cmd_dispatch_t* dispatch, iree_status_t status,
+    const iree_hal_cmd_dispatch_t* dispatch, iree_status_code_t status_code,
     iree_time_t start_host_time_ns, iree_time_t end_host_time_ns,
     uint32_t tile_count) {
   iree_hal_cmd_block_processor_profile_dispatch_t* dispatch_profile =
@@ -883,7 +883,6 @@ static void iree_hal_cmd_block_processor_profile_accumulate_dispatch(
   iree_atomic_fetch_add(&dispatch_profile->tile_duration_sum_ns,
                         (int64_t)(end_host_time_ns - start_host_time_ns),
                         iree_memory_order_relaxed);
-  const iree_status_code_t status_code = iree_status_code(status);
   if (status_code != IREE_STATUS_OK) {
     int32_t expected_status_code = IREE_STATUS_OK;
     iree_atomic_compare_exchange_strong(
@@ -989,8 +988,8 @@ static iree_status_t iree_hal_cmd_execute_dispatch_tiles_profiled(
                                                !iree_status_is_ok(status)))) {
     if (aggregate_host_execution) {
       iree_hal_cmd_block_processor_profile_accumulate_dispatch(
-          context, dispatch, status, start_host_time_ns, end_host_time_ns,
-          *out_tiles_completed);
+          context, dispatch, iree_status_code(status), start_host_time_ns,
+          end_host_time_ns, *out_tiles_completed);
     } else {
       iree_hal_cmd_block_processor_profile_append_dispatch_event(
           context, dispatch, binding_ptrs, *out_tiles_completed,

--- a/runtime/src/iree/hal/drivers/local_task/task_queue.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_queue.c
@@ -61,8 +61,8 @@ static void iree_hal_task_queue_debug_record_fail(
 
 static void iree_hal_task_queue_debug_record_destroy(
     iree_hal_task_queue_t* queue, const iree_hal_task_queue_op_t* operation,
-    iree_status_t failure_status) {
-  if (iree_status_is_ok(failure_status)) {
+    iree_status_code_t failure_status_code) {
+  if (failure_status_code == IREE_STATUS_OK) {
     iree_atomic_fetch_add(&queue->debug.destroyed_ok_operation_count, 1,
                           iree_memory_order_relaxed);
   } else {
@@ -94,10 +94,10 @@ static void iree_hal_task_queue_debug_record_fail(
 
 static void iree_hal_task_queue_debug_record_destroy(
     iree_hal_task_queue_t* queue, const iree_hal_task_queue_op_t* operation,
-    iree_status_t failure_status) {
+    iree_status_code_t failure_status_code) {
   (void)queue;
   (void)operation;
-  (void)failure_status;
+  (void)failure_status_code;
 }
 #endif  // !defined(NDEBUG)
 
@@ -560,7 +560,8 @@ static void iree_hal_task_queue_profile_start_host_execution(
 }
 
 static void iree_hal_task_queue_profile_finish_host_execution(
-    iree_hal_task_queue_op_t* operation, iree_status_t operation_status) {
+    iree_hal_task_queue_op_t* operation,
+    iree_status_code_t operation_status_code) {
   iree_hal_task_queue_profile_operation_t* profile_operation =
       iree_hal_task_queue_profile_operation(operation);
   if (!profile_operation) return;
@@ -577,7 +578,7 @@ static void iree_hal_task_queue_profile_finish_host_execution(
       iree_hal_local_profile_host_execution_event_info_default();
   event_info.type = profile_operation->type;
   event_info.flags = profile_operation->host_flags;
-  event_info.status_code = iree_status_code(operation_status);
+  event_info.status_code = operation_status_code;
   event_info.scope = profile_operation->scope;
   event_info.submission_id = profile_operation->submission_id;
   event_info.command_buffer_id = profile_operation->command_buffer_id;
@@ -641,8 +642,9 @@ static iree_status_t iree_hal_task_queue_op_unmap_binding_mappings(
 static void iree_hal_task_queue_op_destroy(iree_hal_task_queue_op_t* operation,
                                            iree_status_t failure_status) {
   iree_hal_task_queue_debug_record_destroy(operation->queue, operation,
-                                           failure_status);
-  iree_hal_task_queue_profile_finish_host_execution(operation, failure_status);
+                                           iree_status_code(failure_status));
+  iree_hal_task_queue_profile_finish_host_execution(
+      operation, iree_status_code(failure_status));
 
   // Failure/early-destroy backstop: success completion finalizes mappings
   // before signaling, but issue failures can destroy the operation directly.
@@ -714,7 +716,8 @@ static void iree_hal_task_queue_op_complete_with_epoch(
   if (iree_status_is_ok(status)) {
     // Publish profiling before user-visible completion. Waiters may flush and
     // end profiling immediately after signal semaphores are reached.
-    iree_hal_task_queue_profile_finish_host_execution(operation, status);
+    iree_hal_task_queue_profile_finish_host_execution(operation,
+                                                      iree_status_code(status));
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_semaphore_list_signal(operation->signal_semaphores,
@@ -738,7 +741,8 @@ static void iree_hal_task_queue_op_complete(
   if (iree_status_is_ok(status)) {
     // Publish profiling before user-visible completion. Waiters may flush and
     // end profiling immediately after signal semaphores are reached.
-    iree_hal_task_queue_profile_finish_host_execution(operation, status);
+    iree_hal_task_queue_profile_finish_host_execution(operation,
+                                                      iree_status_code(status));
   }
   if (iree_status_is_ok(status)) {
     // Signal all semaphores to their new values.

--- a/runtime/src/iree/hal/drivers/vulkan/api.c
+++ b/runtime/src/iree/hal/drivers/vulkan/api.c
@@ -137,9 +137,7 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_query_extensibility_set(
   if (set == (target_set)) {                                             \
     iree_status_t add_status = iree_hal_vulkan_add_extensibility_string( \
         (value), string_capacity, out_string_count, out_string_values);  \
-    if (!iree_status_is_ok(add_status) && iree_status_is_ok(status)) {   \
-      status = add_status;                                               \
-    }                                                                    \
+    status = iree_status_join(status, add_status);                       \
   }
 
   switch (set) {

--- a/runtime/src/iree/hal/drivers/vulkan/cts/bda_raw_spirv_test.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/cts/bda_raw_spirv_test.cc
@@ -1172,7 +1172,7 @@ TEST_P(BdaRawSpirvTest, CommandBufferProfilingBypassesCachedNativeReplay) {
   iree_status_t status =
       profiling.Begin(IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS,
                       TestProfileSinkAsBase(&sink));
-  if (IsProfilingUnsupported(status)) {
+  if (IsProfilingUnsupported(iree_status_code(status))) {
     iree_status_ignore(status);
     GTEST_SKIP() << "Vulkan dispatch profiling is unavailable";
   }

--- a/runtime/src/iree/hal/drivers/vulkan/queue.c
+++ b/runtime/src/iree/hal/drivers/vulkan/queue.c
@@ -8713,19 +8713,19 @@ static iree_status_t iree_hal_vulkan_queue_record_dispatch_bda_native(
     iree_hal_vulkan_queue_pending_submission_t* submission,
     const iree_hal_vulkan_pipeline_t* pipeline) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status = iree_ok_status();
-  status = iree_hal_vulkan_queue_allocate_native_command_buffer_under_lock(
-      queue, submission);
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_vulkan_queue_profile_prepare_native_timestamps_under_lock(
-        queue, submission);
-  }
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hal_vulkan_queue_allocate_native_command_buffer_under_lock(
+              queue, submission));
+  iree_status_t status =
+      iree_hal_vulkan_queue_profile_prepare_native_timestamps_under_lock(
+          queue, submission);
 
   const iree_host_size_t binding_count =
       pipeline->bda.binding_count_known ? pipeline->binding_count
                                         : submission->dispatch.binding_count;
   iree_device_size_t binding_table_length = 0;
-  if (!iree_device_size_checked_mul((iree_device_size_t)binding_count,
+  if (iree_status_is_ok(status) &&
+      !iree_device_size_checked_mul((iree_device_size_t)binding_count,
                                     pipeline->bda.binding_table_entry_length,
                                     &binding_table_length)) {
     IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/hal/drivers/vulkan/util/libvulkan.c
+++ b/runtime/src/iree/hal/drivers/vulkan/util/libvulkan.c
@@ -537,7 +537,7 @@ static iree_status_t iree_hal_vulkan_libvulkan_try_load_library_from_file(
     status = iree_string_builder_append_format(
         error_builder, "\n  Tried: %s\n    ", file_path);
     if (iree_status_is_ok(status)) {
-      status = iree_string_builder_append_status(error_builder, load_status);
+      status = iree_string_builder_append_status(error_builder, &load_status);
     }
     iree_status_free(load_status);
   }

--- a/runtime/src/iree/hal/drivers/webgpu/webgpu_driver.c
+++ b/runtime/src/iree/hal/drivers/webgpu/webgpu_driver.c
@@ -140,11 +140,15 @@ static iree_status_t iree_hal_webgpu_poll_until_complete(
   while (!request->completed) {
     iree_status_t poll_status =
         iree_async_proactor_poll(proactor, iree_infinite_timeout(), NULL);
-    // DEADLINE_EXCEEDED means poll found nothing this iteration — retry.
-    if (!iree_status_is_ok(poll_status) &&
-        !iree_status_is_deadline_exceeded(poll_status)) {
-      return poll_status;
+    if (iree_status_is_ok(poll_status)) {
+      continue;
     }
+    // DEADLINE_EXCEEDED means poll found nothing this iteration — retry.
+    if (iree_status_is_deadline_exceeded(poll_status)) {
+      iree_status_free(poll_status);
+      continue;
+    }
+    return poll_status;
   }
   return request->result_status;
 }

--- a/runtime/src/iree/hal/local/profile.c
+++ b/runtime/src/iree/hal/local/profile.c
@@ -548,9 +548,10 @@ iree_status_t iree_hal_local_profile_recorder_create(
       iree_hal_profile_chunk_metadata_t metadata =
           iree_hal_local_profile_recorder_metadata(
               recorder, IREE_HAL_PROFILE_CONTENT_TYPE_SESSION);
-      status = iree_status_join(status, iree_hal_profile_sink_end_session(
-                                            recorder->options.sink, &metadata,
-                                            iree_status_code(status)));
+      iree_status_code_t status_code = iree_status_code(status);
+      status = iree_status_join(
+          status, iree_hal_profile_sink_end_session(recorder->options.sink,
+                                                    &metadata, status_code));
     }
     iree_hal_local_profile_recorder_destroy(recorder);
   }
@@ -1680,9 +1681,10 @@ iree_status_t iree_hal_local_profile_recorder_end(
   iree_hal_profile_chunk_metadata_t metadata =
       iree_hal_local_profile_recorder_metadata(
           recorder, IREE_HAL_PROFILE_CONTENT_TYPE_SESSION);
+  iree_status_code_t status_code = iree_status_code(status);
   status = iree_status_join(
-      status, iree_hal_profile_sink_end_session(
-                  recorder->options.sink, &metadata, iree_status_code(status)));
+      status, iree_hal_profile_sink_end_session(recorder->options.sink,
+                                                &metadata, status_code));
   recorder->active = false;
   return status;
 }

--- a/runtime/src/iree/hal/pool_set.c
+++ b/runtime/src/iree/hal/pool_set.c
@@ -82,12 +82,12 @@ iree_status_t iree_hal_pool_set_register(iree_hal_pool_set_t* pool_set,
   if (pool_set->entry_count >= pool_set->entry_capacity) {
     IREE_TRACE_ZONE_BEGIN(z0);
     IREE_TRACE_ZONE_APPEND_TEXT(z0, "grow");
-    iree_status_t status = iree_allocator_grow_array(
-        pool_set->host_allocator, pool_set->entry_count + 1,
-        sizeof(iree_hal_pool_set_entry_t), &pool_set->entry_capacity,
-        (void**)&pool_set->entries);
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_allocator_grow_array(
+                pool_set->host_allocator, pool_set->entry_count + 1,
+                sizeof(iree_hal_pool_set_entry_t), &pool_set->entry_capacity,
+                (void**)&pool_set->entries));
     IREE_TRACE_ZONE_END(z0);
-    IREE_RETURN_IF_ERROR(status);
   }
 
   iree_host_size_t insert_index = 0;

--- a/runtime/src/iree/hal/replay/recorder.c
+++ b/runtime/src/iree/hal/replay/recorder.c
@@ -104,25 +104,23 @@ static iree_status_t iree_hal_replay_recorder_check_open_locked(
 }
 
 static void iree_hal_replay_recorder_fail_locked(
-    iree_hal_replay_recorder_t* recorder, iree_status_t status) {
+    iree_hal_replay_recorder_t* recorder, iree_status_code_t status_code) {
   IREE_ASSERT_ARGUMENT(recorder);
-  if (IREE_UNLIKELY(!iree_status_is_ok(status) &&
+  if (IREE_UNLIKELY(status_code != IREE_STATUS_OK &&
                     recorder->terminal_status_code == IREE_STATUS_OK)) {
-    recorder->terminal_status_code = iree_status_code(status);
+    recorder->terminal_status_code = status_code;
   }
 }
 
 void iree_hal_replay_recorder_fail(iree_hal_replay_recorder_t* recorder,
-                                   iree_status_t status) {
+                                   iree_status_code_t status_code) {
   IREE_ASSERT_ARGUMENT(recorder);
-  if (iree_status_is_ok(status)) return;
-  iree_status_code_t status_code = iree_status_code(status);
+  if (status_code == IREE_STATUS_OK) return;
   iree_slim_mutex_lock(&recorder->mutex);
   if (recorder->terminal_status_code == IREE_STATUS_OK) {
     recorder->terminal_status_code = status_code;
   }
   iree_slim_mutex_unlock(&recorder->mutex);
-  iree_status_free(status);
 }
 
 static iree_status_t iree_hal_replay_recorder_append_record_locked(
@@ -135,7 +133,7 @@ static iree_status_t iree_hal_replay_recorder_append_record_locked(
   metadata.thread_id = iree_hal_replay_current_thread_id();
   iree_status_t status = iree_hal_replay_file_writer_append_record(
       recorder->writer, &metadata, iovec_count, iovecs, out_payload_range);
-  iree_hal_replay_recorder_fail_locked(recorder, status);
+  iree_hal_replay_recorder_fail_locked(recorder, iree_status_code(status));
   return status;
 }
 
@@ -351,7 +349,8 @@ iree_status_t iree_hal_replay_recorder_end_operation_with_payload(
       (uint32_t)iree_status_code(operation_status);
   iree_status_t record_status = iree_hal_replay_file_writer_append_record(
       recorder->writer, &pending_record->metadata, iovec_count, iovecs, NULL);
-  iree_hal_replay_recorder_fail_locked(recorder, record_status);
+  iree_hal_replay_recorder_fail_locked(recorder,
+                                       iree_status_code(record_status));
   iree_slim_mutex_unlock(&recorder->mutex);
   return iree_status_join(record_status, operation_status);
 }
@@ -384,7 +383,8 @@ iree_status_t iree_hal_replay_recorder_end_creation_operation(
         created_object_type, object_payload_type, object_iovec_count,
         object_iovecs);
   }
-  iree_hal_replay_recorder_fail_locked(recorder, record_status);
+  iree_hal_replay_recorder_fail_locked(recorder,
+                                       iree_status_code(record_status));
   iree_slim_mutex_unlock(&recorder->mutex);
   return iree_status_join(record_status, operation_status);
 }
@@ -506,7 +506,7 @@ iree_hal_replay_recorder_close(iree_hal_replay_recorder_t* recorder) {
     if (iree_status_is_ok(status)) {
       recorder->closed = true;
     } else {
-      iree_hal_replay_recorder_fail_locked(recorder, status);
+      iree_hal_replay_recorder_fail_locked(recorder, iree_status_code(status));
     }
   }
   iree_slim_mutex_unlock(&recorder->mutex);
@@ -661,7 +661,8 @@ static void iree_hal_replay_replace_device_allocator(
       device->recorder, device->device_id, base_device, new_allocator,
       device->host_allocator, &new_replay_allocator);
   if (!iree_status_is_ok(status)) {
-    iree_hal_replay_recorder_fail(device->recorder, status);
+    iree_hal_replay_recorder_fail(device->recorder, iree_status_code(status));
+    iree_status_ignore(status);
     return;
   }
   iree_hal_device_replace_allocator(device->base_device, new_allocator);

--- a/runtime/src/iree/hal/replay/recorder.c
+++ b/runtime/src/iree/hal/replay/recorder.c
@@ -1667,7 +1667,7 @@ static iree_status_t iree_hal_replay_device_queue_dispatch(
         device->recorder, signal_semaphore_list, device->host_allocator,
         &signal_payloads, &signal_payloads_size);
   }
-  if (bindings.count) {
+  if (iree_status_is_ok(status) && bindings.count) {
     iree_host_size_t binding_storage_size = 0;
     iree_host_size_t temporary_buffers_size = 0;
     if (IREE_UNLIKELY(!iree_host_size_checked_mul(bindings.count,
@@ -1788,7 +1788,7 @@ static iree_status_t iree_hal_replay_device_queue_execute(
         device->recorder, signal_semaphore_list, device->host_allocator,
         &signal_payloads, &signal_payloads_size);
   }
-  if (binding_table.count) {
+  if (iree_status_is_ok(status) && binding_table.count) {
     iree_host_size_t binding_storage_size = 0;
     iree_host_size_t temporary_buffers_size = 0;
     if (IREE_UNLIKELY(!iree_host_size_checked_mul(binding_table.count,

--- a/runtime/src/iree/hal/replay/recorder_buffer.c
+++ b/runtime/src/iree/hal/replay/recorder_buffer.c
@@ -528,7 +528,7 @@ static iree_status_t iree_hal_replay_recorder_buffer_flush_range(
       &pending_record);
   if (!iree_status_is_ok(begin_status)) {
     iree_allocator_free(buffer->host_allocator, data_snapshot);
-    return begin_status;
+    return iree_status_join(begin_status, status);
   }
   if (iree_status_is_ok(status)) {
     status = IREE_HAL_REPLAY_VTABLE_DISPATCH(buffer->base_buffer,

--- a/runtime/src/iree/hal/replay/recorder_executable.c
+++ b/runtime/src/iree/hal/replay/recorder_executable.c
@@ -270,7 +270,9 @@ static iree_host_size_t iree_hal_replay_recorder_executable_function_count(
                                                     iree_ok_status());
   }
   if (!iree_status_is_ok(status)) {
-    iree_hal_replay_recorder_fail(executable->recorder, status);
+    iree_hal_replay_recorder_fail(executable->recorder,
+                                  iree_status_code(status));
+    iree_status_ignore(status);
   }
   return count;
 }

--- a/runtime/src/iree/hal/replay/recorder_record.h
+++ b/runtime/src/iree/hal/replay/recorder_record.h
@@ -24,9 +24,9 @@ typedef struct iree_hal_replay_pending_record_t {
   iree_hal_replay_file_record_metadata_t metadata;
 } iree_hal_replay_pending_record_t;
 
-// Records |status| as the recorder's terminal failure and frees it.
+// Records |status_code| as the recorder's terminal failure.
 void iree_hal_replay_recorder_fail(iree_hal_replay_recorder_t* recorder,
-                                   iree_status_t status);
+                                   iree_status_code_t status_code);
 
 iree_status_t iree_hal_replay_recorder_reserve_object_id(
     iree_hal_replay_recorder_t* recorder,

--- a/runtime/src/iree/hal/string_util.c
+++ b/runtime/src/iree/hal/string_util.c
@@ -778,6 +778,7 @@ static iree_status_t iree_hal_format_buffer_elements_recursive(
           buffer ? buffer + buffer_length : NULL, &actual_length);
       buffer_length += actual_length;
       if (iree_status_is_out_of_range(status)) {
+        iree_status_free(status);
         buffer = NULL;
       } else if (!iree_status_is_ok(status)) {
         return status;
@@ -810,6 +811,7 @@ static iree_status_t iree_hal_format_buffer_elements_recursive(
       subdata.data += element_stride;
       buffer_length += actual_length;
       if (iree_status_is_out_of_range(status)) {
+        iree_status_free(status);
         buffer = NULL;
       } else if (!iree_status_is_ok(status)) {
         return status;

--- a/runtime/src/iree/hal/utils/caching_allocator.c
+++ b/runtime/src/iree/hal/utils/caching_allocator.c
@@ -366,8 +366,9 @@ iree_status_t iree_hal_caching_allocator_create_unbounded(
   // Query heaps from the underlying allocator.
   iree_hal_allocator_memory_heap_t heaps[8];
   iree_host_size_t heap_count = 0;
-  IREE_RETURN_IF_ERROR(iree_hal_allocator_query_memory_heaps(
-      device_allocator, IREE_ARRAYSIZE(heaps), heaps, &heap_count));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hal_allocator_query_memory_heaps(
+              device_allocator, IREE_ARRAYSIZE(heaps), heaps, &heap_count));
 
   // Setup pool parameters for each heap.
   iree_hal_caching_allocator_pool_params_t* heap_pool_params =

--- a/runtime/src/iree/hal/utils/deferred_work_queue.c
+++ b/runtime/src/iree/hal/utils/deferred_work_queue.c
@@ -263,8 +263,9 @@ static void iree_hal_deferred_work_queue_ready_action_list_initialize(
 
 // Ready action entry struct.
 typedef struct iree_hal_deferred_work_queue_completion_list_node_t {
-  // The callback and user data for that callback. To be called
-  // when the associated event has completed.
+  // The callback and user data for that callback. To be called when the
+  // associated event has completed. The status passed to the callback is
+  // borrowed and must not be consumed by the callback.
   iree_status_t (*callback)(iree_status_t, void* user_data);
   void* user_data;
   // The event to wait for on the completion thread.
@@ -554,6 +555,7 @@ iree_status_t iree_hal_deferred_work_queue_create(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_allocator_malloc(host_allocator, sizeof(*actions),
                                 (void**)&actions));
+  memset(actions, 0, sizeof(*actions));
   actions->host_allocator = host_allocator;
   actions->block_pool = block_pool;
   actions->device_interface = device_interface;
@@ -596,7 +598,7 @@ iree_status_t iree_hal_deferred_work_queue_create(
   }
 
   IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
+  return status;
 }
 
 static iree_hal_deferred_work_queue_t* iree_hal_deferred_work_queue_cast(
@@ -681,8 +683,6 @@ static void iree_hal_deferred_work_queue_action_destroy(
   iree_hal_resource_set_free(action->resource_set);
 
   iree_hal_deferred_work_queue_action_clear_events(action);
-
-  iree_hal_resource_release(actions);
 
   iree_allocator_free(host_allocator, action);
 
@@ -1392,9 +1392,6 @@ iree_status_t iree_hal_deferred_work_queue_issue(
               "exceeded maximum queue action wait event limit");
           action->device_interface->vtable->release_wait_event(
               action->device_interface, wait_event);
-          if (iree_status_is_ok(actions->status)) {
-            actions->status = status;
-          }
           iree_hal_deferred_work_queue_action_fail_locked(action, status);
           break;
         }
@@ -1607,8 +1604,8 @@ static void iree_hal_deferred_work_queue_worker_process_completion(
     }
 
     if (entry->callback) {
-      status =
-          iree_status_join(status, entry->callback(status, entry->user_data));
+      iree_status_t callback_status = entry->callback(status, entry->user_data);
+      status = iree_status_join(status, callback_status);
     }
 
     if (IREE_UNLIKELY(entry->created_event)) {

--- a/runtime/src/iree/hal/utils/queue_host_call_emulation.c
+++ b/runtime/src/iree/hal/utils/queue_host_call_emulation.c
@@ -106,7 +106,7 @@ static int iree_hal_emulated_host_call_main(void* entry_arg) {
   // progress after this point regardless of how long the host call takes.
   const bool is_nonblocking =
       iree_any_bit_set(state->flags, IREE_HAL_HOST_CALL_FLAG_NON_BLOCKING);
-  if (is_nonblocking) {
+  if (iree_status_is_ok(status) && is_nonblocking) {
     // NOTE: the signals can fail in which case we never perform the call.
     // That's ok as failure to signal is considered a device-loss/death
     // situation as there's no telling what has gone wrong.

--- a/runtime/src/iree/io/file_contents.c
+++ b/runtime/src/iree/io/file_contents.c
@@ -267,7 +267,7 @@ IREE_API_EXPORT iree_status_t iree_io_file_contents_read(
   // Attempt to read the file into memory, chunking into ~2GB segments.
   // Several implementations of read have limits at ~2GB even on 64-bit systems.
   iree_host_size_t bytes_read = 0;
-  while (bytes_read < file_size) {
+  while (iree_status_is_ok(status) && bytes_read < file_size) {
     const iree_host_size_t chunk_size =
         iree_min(file_size - bytes_read, INT_MAX);
     if (fread(contents->buffer.data + bytes_read, 1, chunk_size, file) !=

--- a/runtime/src/iree/io/file_contents.c
+++ b/runtime/src/iree/io/file_contents.c
@@ -69,14 +69,15 @@ IREE_API_EXPORT iree_status_t iree_io_file_contents_read_stdin(
   iree_host_size_t capacity = 4096;
   iree_host_size_t total_size = 0;
   iree_host_size_t data_offset = 0;
-  IREE_RETURN_IF_ERROR(IREE_STRUCT_LAYOUT(
-      sizeof(iree_io_file_contents_t), &total_size,
-      IREE_STRUCT_FIELD_ALIGNED(capacity, uint8_t,
-                                IREE_IO_FILE_CONTENTS_BASE_ALIGNMENT,
-                                &data_offset)));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, IREE_STRUCT_LAYOUT(
+              sizeof(iree_io_file_contents_t), &total_size,
+              IREE_STRUCT_FIELD_ALIGNED(capacity, uint8_t,
+                                        IREE_IO_FILE_CONTENTS_BASE_ALIGNMENT,
+                                        &data_offset)));
   iree_io_file_contents_t* contents = NULL;
-  IREE_RETURN_IF_ERROR(
-      iree_allocator_malloc(host_allocator, total_size, (void**)&contents));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_allocator_malloc(host_allocator, total_size, (void**)&contents));
   contents->buffer.data = (void*)((uint8_t*)contents + data_offset);
 
   iree_host_size_t size = 0;

--- a/runtime/src/iree/modules/hal/debugging.c
+++ b/runtime/src/iree/modules/hal/debugging.c
@@ -39,6 +39,7 @@ static iree_status_t iree_hal_module_buffer_view_trace_stdio(
     if (!iree_status_is_out_of_range(status)) {
       return status;
     }
+    iree_status_free(status);
     ++result_length;  // include NUL
 
     // Allocate scratch heap memory to contain the result and format into it.

--- a/runtime/src/iree/modules/hal/module.c
+++ b/runtime/src/iree/modules/hal/module.c
@@ -1786,7 +1786,6 @@ IREE_VM_ABI_EXPORT(iree_hal_module_fence_query,  //
 
   iree_status_t query_status = iree_hal_fence_query(fence);
   rets->i0 = iree_status_consume_code(query_status);
-  iree_status_ignore(query_status);
 
   return iree_ok_status();
 }

--- a/runtime/src/iree/modules/hal/module.c
+++ b/runtime/src/iree/modules/hal/module.c
@@ -2112,7 +2112,8 @@ IREE_API_EXPORT iree_status_t iree_hal_module_create(
   iree_host_size_t total_size =
       iree_vm_native_module_size() + sizeof(iree_hal_module_t);
   iree_vm_module_t* base_module = NULL;
-  IREE_RETURN_IF_ERROR(
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
       iree_allocator_malloc(host_allocator, total_size, (void**)&base_module));
   memset(base_module, 0, total_size);
   iree_status_t status =

--- a/runtime/src/iree/testing/benchmark_full.cc
+++ b/runtime/src/iree/testing/benchmark_full.cc
@@ -81,7 +81,7 @@ void iree_benchmark_set_items_processed(iree_benchmark_state_t* state,
 // iree_benchmark_def_t
 //===----------------------------------------------------------------------===//
 
-static std::string StatusToString(iree_status_t status) {
+static std::string StatusToString(const iree_status_t& status) {
   if (iree_status_is_ok(status)) {
     return "OK";
   }

--- a/runtime/src/iree/testing/gbenchmark_harness_demo.cc
+++ b/runtime/src/iree/testing/gbenchmark_harness_demo.cc
@@ -31,6 +31,7 @@ static void BM_StatusCreation(benchmark::State& state) {
   for (auto _ : state) {
     iree_status_t status = iree_make_status(IREE_STATUS_OK);
     benchmark::DoNotOptimize(status);
+    IREE_CHECK_OK(status);
   }
 }
 BENCHMARK(BM_StatusCreation);

--- a/runtime/src/iree/tokenizer/decoder/sequence_test.cc
+++ b/runtime/src/iree/tokenizer/decoder/sequence_test.cc
@@ -51,10 +51,7 @@ class SequenceDecoderTest : public ::testing::Test {
     iree_status_t status = iree_tokenizer_decoder_sequence_allocate(
         raw_children.data(), raw_children.size(), iree_allocator_system(),
         &raw_decoder);
-    if (!iree_status_is_ok(status)) {
-      // Children are cleaned up when vector goes out of scope.
-      return ScopedDecoder(nullptr);
-    }
+    IREE_CHECK_OK(status);
 
     // Success: release all children to sequence ownership.
     for (auto& child : children) {

--- a/runtime/src/iree/tokenizer/normalizer/sequence_test.cc
+++ b/runtime/src/iree/tokenizer/normalizer/sequence_test.cc
@@ -41,9 +41,7 @@ class SequenceNormalizerTest : public ::testing::Test {
     iree_status_t status = iree_tokenizer_normalizer_sequence_allocate(
         raw_children.data(), raw_children.size(), iree_allocator_system(),
         &raw_normalizer);
-    if (!iree_status_is_ok(status)) {
-      return ScopedNormalizer(nullptr);
-    }
+    IREE_CHECK_OK(status);
 
     // Success: release all children to sequence ownership.
     for (auto& child : children) {
@@ -57,9 +55,7 @@ class SequenceNormalizerTest : public ::testing::Test {
     iree_tokenizer_normalizer_t* raw = nullptr;
     iree_status_t status = iree_tokenizer_normalizer_passthrough_allocate(
         iree_allocator_system(), &raw);
-    if (!iree_status_is_ok(status)) {
-      return ScopedNormalizer(nullptr);
-    }
+    IREE_CHECK_OK(status);
     return ScopedNormalizer(raw);
   }
 
@@ -68,9 +64,7 @@ class SequenceNormalizerTest : public ::testing::Test {
     iree_tokenizer_normalizer_t* raw = nullptr;
     iree_status_t status = iree_tokenizer_normalizer_deferred_allocate(
         iree_allocator_system(), &raw);
-    if (!iree_status_is_ok(status)) {
-      return ScopedNormalizer(nullptr);
-    }
+    IREE_CHECK_OK(status);
     return ScopedNormalizer(raw);
   }
 
@@ -79,9 +73,7 @@ class SequenceNormalizerTest : public ::testing::Test {
     iree_tokenizer_normalizer_t* raw = nullptr;
     iree_status_t status = iree_tokenizer_normalizer_strip_allocate(
         left, right, iree_allocator_system(), &raw);
-    if (!iree_status_is_ok(status)) {
-      return ScopedNormalizer(nullptr);
-    }
+    IREE_CHECK_OK(status);
     return ScopedNormalizer(raw);
   }
 
@@ -91,9 +83,7 @@ class SequenceNormalizerTest : public ::testing::Test {
     // U+2581 LOWER ONE EIGHTH BLOCK = 0xE2 0x96 0x81 in UTF-8.
     iree_status_t status = iree_tokenizer_normalizer_replace_allocate(
         IREE_SV(" "), IREE_SV("\xE2\x96\x81"), iree_allocator_system(), &raw);
-    if (!iree_status_is_ok(status)) {
-      return ScopedNormalizer(nullptr);
-    }
+    IREE_CHECK_OK(status);
     return ScopedNormalizer(raw);
   }
 
@@ -103,9 +93,7 @@ class SequenceNormalizerTest : public ::testing::Test {
     iree_status_t status = iree_tokenizer_normalizer_prepend_allocate(
         IREE_SV("\xE2\x96\x81"), skip_if_prefix_matches,
         iree_allocator_system(), &raw);
-    if (!iree_status_is_ok(status)) {
-      return ScopedNormalizer(nullptr);
-    }
+    IREE_CHECK_OK(status);
     return ScopedNormalizer(raw);
   }
 };

--- a/runtime/src/iree/tokenizer/segmenter/sequence_test.cc
+++ b/runtime/src/iree/tokenizer/segmenter/sequence_test.cc
@@ -44,9 +44,7 @@ class SequenceSegmenterTest : public ::testing::Test {
     iree_status_t status = iree_tokenizer_segmenter_sequence_allocate(
         raw_children.data(), raw_children.size(), iree_allocator_system(),
         &raw_segmenter);
-    if (!iree_status_is_ok(status)) {
-      return ScopedSegmenter(nullptr);
-    }
+    IREE_CHECK_OK(status);
 
     // Success: release all children to sequence ownership.
     for (auto& child : children) {
@@ -60,9 +58,7 @@ class SequenceSegmenterTest : public ::testing::Test {
     iree_tokenizer_segmenter_t* raw = nullptr;
     iree_status_t status = iree_tokenizer_segmenter_metaspace_allocate(
         0, /*split_enabled=*/true, iree_allocator_system(), &raw);
-    if (!iree_status_is_ok(status)) {
-      return ScopedSegmenter(nullptr);
-    }
+    IREE_CHECK_OK(status);
     return ScopedSegmenter(raw);
   }
 
@@ -71,9 +67,7 @@ class SequenceSegmenterTest : public ::testing::Test {
     iree_tokenizer_segmenter_t* raw = nullptr;
     iree_status_t status = iree_tokenizer_segmenter_whitespace_allocate(
         iree_allocator_system(), &raw);
-    if (!iree_status_is_ok(status)) {
-      return ScopedSegmenter(nullptr);
-    }
+    IREE_CHECK_OK(status);
     return ScopedSegmenter(raw);
   }
 
@@ -87,10 +81,7 @@ class SequenceSegmenterTest : public ::testing::Test {
     iree_tokenizer_segmenter_t* raw = nullptr;
     iree_status_t status = iree_tokenizer_segmenter_punctuation_allocate(
         behavior, iree_allocator_system(), &raw);
-    if (!iree_status_is_ok(status)) {
-      iree_status_ignore(status);
-      return ScopedSegmenter(nullptr);
-    }
+    IREE_CHECK_OK(status);
     return ScopedSegmenter(raw);
   }
 
@@ -105,10 +96,7 @@ class SequenceSegmenterTest : public ::testing::Test {
         iree_make_cstring_view(pattern),
         IREE_TOKENIZER_UTIL_REGEX_COMPILE_FLAG_NONE, iree_allocator_system(),
         &dfa, &dfa_storage, &error);
-    if (!iree_status_is_ok(status)) {
-      iree_status_ignore(status);
-      return ScopedSegmenter(nullptr);
-    }
+    IREE_CHECK_OK(status);
 
     iree_tokenizer_segmenter_t* raw = nullptr;
     status = iree_tokenizer_segmenter_split_allocate(
@@ -116,8 +104,7 @@ class SequenceSegmenterTest : public ::testing::Test {
         &raw);
     if (!iree_status_is_ok(status)) {
       iree_allocator_free(iree_allocator_system(), dfa_storage);
-      iree_status_ignore(status);
-      return ScopedSegmenter(nullptr);
+      IREE_CHECK_OK(status);
     }
     // Ownership of dfa_storage transferred to segmenter.
     return ScopedSegmenter(raw);

--- a/runtime/src/iree/tokenizer/tokenizer.c
+++ b/runtime/src/iree/tokenizer/tokenizer.c
@@ -1227,7 +1227,8 @@ iree_status_t iree_tokenizer_decode(const iree_tokenizer_t* tokenizer,
     //    buffer is full (no room for Stage 2 to consume tokens).
     // The pump loop's made_progress flag handles all internal "needs more
     // pumping" cases, so 0/0 at this level is always genuine exhaustion.
-    if (tokens_consumed == 0 && text_written == 0) {
+    if (iree_status_is_ok(status) && tokens_consumed == 0 &&
+        text_written == 0) {
       status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                                 "decode output buffer full");
     }
@@ -1555,7 +1556,8 @@ iree_status_t iree_tokenizer_decode_batch(
       tokens.values += tokens_consumed;
       tokens.count -= tokens_consumed;
       // Zero progress = output buffer exhausted (see one-shot decode comment).
-      if (tokens_consumed == 0 && text_written == 0) {
+      if (iree_status_is_ok(status) && tokens_consumed == 0 &&
+          text_written == 0) {
         status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                                   "decode output buffer full");
       }

--- a/runtime/src/iree/tokenizer/tokenizer_encode_test.cc
+++ b/runtime/src/iree/tokenizer/tokenizer_encode_test.cc
@@ -119,9 +119,7 @@ iree_tokenizer_segmenter_t* CreateSplitSegmenter(const char* pattern) {
       iree_make_cstring_view(pattern),
       IREE_TOKENIZER_UTIL_REGEX_COMPILE_FLAG_NONE, iree_allocator_system(),
       &dfa, &dfa_storage, &error);
-  if (!iree_status_is_ok(status)) {
-    return nullptr;
-  }
+  IREE_CHECK_OK(status);
 
   iree_tokenizer_segmenter_t* segmenter = nullptr;
   status = iree_tokenizer_segmenter_split_allocate(
@@ -129,7 +127,7 @@ iree_tokenizer_segmenter_t* CreateSplitSegmenter(const char* pattern) {
       iree_allocator_system(), &segmenter);
   if (!iree_status_is_ok(status)) {
     iree_allocator_free(iree_allocator_system(), dfa_storage);
-    return nullptr;
+    IREE_CHECK_OK(status);
   }
 
   return segmenter;
@@ -1144,6 +1142,7 @@ TEST_F(TokenizerStreamingTest, LargeCJKTextWithCappedBuffer) {
 
     if (!iree_status_is_ok(status)) {
       iree_status_fprint(stderr, status);
+      iree_status_free(status);
       FAIL() << "Streaming encode failed at byte "
              << (cjk_text.length() - remaining.size);
     }
@@ -1225,6 +1224,7 @@ TEST_F(TokenizerStreamingTest, ChunkedEncodeWithUTF8BoundarySplits) {
       std::cerr << "Chunk at offset " << offset << " (length " << length
                 << ") failed:\n";
       iree_status_fprint(stderr, status);
+      iree_status_free(status);
       FAIL() << "One-shot encode should handle chunks with split UTF-8";
     }
     total_tokens += token_count;
@@ -2566,16 +2566,14 @@ static iree_tokenizer_segmenter_t* CreateSplitSegmenterWithBehavior(
       iree_make_cstring_view(pattern),
       IREE_TOKENIZER_UTIL_REGEX_COMPILE_FLAG_NONE, iree_allocator_system(),
       &dfa, &dfa_storage, &error);
-  if (!iree_status_is_ok(status)) {
-    return nullptr;
-  }
+  IREE_CHECK_OK(status);
 
   iree_tokenizer_segmenter_t* segmenter = nullptr;
   status = iree_tokenizer_segmenter_split_allocate(
       dfa, dfa_storage, behavior, false, iree_allocator_system(), &segmenter);
   if (!iree_status_is_ok(status)) {
     iree_allocator_free(iree_allocator_system(), dfa_storage);
-    return nullptr;
+    IREE_CHECK_OK(status);
   }
 
   return segmenter;

--- a/runtime/src/iree/tooling/function_io.c
+++ b/runtime/src/iree/tooling/function_io.c
@@ -672,8 +672,9 @@ static iree_status_t iree_tooling_parse_variants_into(
   // List of opened streams used for allowing multiple arguments to source from
   // the same file sequentially.
   iree_io_stream_list_t* stream_list = NULL;
-  IREE_RETURN_IF_ERROR(iree_io_stream_list_allocate(
-      IREE_IO_STDIO_STREAM_MODE_READ, host_allocator, &stream_list));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_io_stream_list_allocate(IREE_IO_STDIO_STREAM_MODE_READ,
+                                       host_allocator, &stream_list));
 
   // Parse each variant string. Note that some strings may expand to zero or
   // more variants and so we need to consume the cconv based on how many were

--- a/runtime/src/iree/tooling/numpy_io_test.cc
+++ b/runtime/src/iree/tooling/numpy_io_test.cc
@@ -46,6 +46,7 @@ class NumpyIOTest : public ::testing::Test {
       iree_status_free(status);
       GTEST_SKIP();
     }
+    IREE_ASSERT_OK(status);
     device_allocator_ = iree_hal_device_allocator(device_);
   }
 

--- a/runtime/src/iree/vm/invocation.c
+++ b/runtime/src/iree/vm/invocation.c
@@ -318,6 +318,8 @@ IREE_API_EXPORT iree_status_t iree_vm_invoke(
   iree_status_t status = iree_vm_begin_invoke(&state, context, function, flags,
                                               policy, inputs, host_allocator);
   while (iree_status_is_deferred(status)) {
+    status = iree_status_ignore(status);
+
     // Grab the wait frame from the stack holding the wait parameters.
     // This is optional: if an invocation yields for cooperative scheduling
     // purposes there will not be a wait frame on the stack and we'll just
@@ -841,6 +843,7 @@ static iree_status_t iree_vm_async_begin_invoke(void* user_data,
       iree_vm_invoke_fiber_leave(state->invocation_id, state->base.stack);
     });
     // Deferred until a wait completes or the next tick.
+    iree_status_ignore(status);
     status = iree_vm_async_tick_invoke(state, loop);
   } else if (iree_status_is_ok(status)) {
     // Completed synchronously. This is the happy path and lets us complete the
@@ -884,6 +887,7 @@ static iree_status_t iree_vm_async_resume_invoke(void* user_data,
       iree_vm_invoke_fiber_leave(state->invocation_id, state->base.stack);
     });
     // Deferred on a wait or yield. Enqueue waits/a resume.
+    iree_status_ignore(status);
     status = iree_vm_async_tick_invoke(state, loop);
   } else if (iree_status_is_ok(status)) {
     // Completed synchronously.

--- a/runtime/src/iree/vm/stack.c
+++ b/runtime/src/iree/vm/stack.c
@@ -678,6 +678,7 @@ IREE_API_EXPORT iree_status_t iree_vm_stack_format_backtrace(
           &source_location, IREE_VM_SOURCE_LOCATION_FORMAT_FLAG_NONE, builder);
     }
     if (iree_status_is_unavailable(status)) {
+      iree_status_ignore(status);
       // TODO(benvanik): if this is an import/export we can get that name.
       IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(builder, "-"));
     } else if (!iree_status_is_ok(status)) {

--- a/runtime/src/iree/vm/testing/test_runner.h
+++ b/runtime/src/iree/vm/testing/test_runner.h
@@ -214,8 +214,10 @@ class VMTestRunner : public BaseType,
       if (params.expects_failure) {                                         \
         iree_status_ignore(status);                                         \
       } else {                                                              \
+        iree::Status wrapped_status(std::move(status));                     \
+        std::string status_string = wrapped_status.ToString();              \
         GTEST_FAIL() << "Function expected success but failed with error: " \
-                     << iree::Status(std::move(status)).ToString();         \
+                     << status_string;                                      \
       }                                                                     \
     }                                                                       \
   }


### PR DESCRIPTION
This adds the first repo-owned clang-tidy contract checks for IREE C code and makes them a native part of the existing presubmit/static-analysis workflow. The checks focus on status ownership and trace-zone cleanup, two C patterns where the codebase relies on disciplined resource handling rather than language-level RAII.

`iree_status_t` is now treated as an owning resource in the analysis layer. The new checks diagnose statuses that are produced without being consumed, APIs that borrow an owning status object when they only need a status code, and transfer ordering hazards where a status is moved or consumed before later use. Existing sites that only needed to inspect a status have been reshaped to make the ownership boundary explicit.

The trace-zone check enforces the status-return helper forms that preserve zone balance on early error exits. This keeps traced functions from accidentally returning around `IREE_TRACE_ZONE_END` and establishes the base for broader scoped-resource checking around tracing macros.

The clang-tidy runner is integrated through both Bazel and CMake. Bazel runs the checks as actions using the existing configured graph. CMake builds the same plugin, materializes generated compile inputs through a small aggregate target, and uses LLVM's parallel `run-clang-tidy` driver over the configured compile database. Local build and scratch directories are excluded from Bazel wildcard package discovery so CMake output trees do not contaminate `//...` builds.

The result is a presubmit-visible static-analysis layer that codifies core IREE C contracts while remaining fast enough to run routinely on the full configured runtime, Loom, and HRX source tree.
