### PR TITLE
[HAL/AMDGPU] Deinitialize PM4 programs without status

### DIFF
--- a/build_tools/devtools/cli_test.py
+++ b/build_tools/devtools/cli_test.py
@@ -893,7 +893,11 @@ class CliTest(unittest.TestCase):
 
         self.assertEqual(len(plan.steps), 2)
         self.assertIn("--fix", plan.steps[0].argv)
+        self.assertIn("--hygiene", plan.steps[0].argv)
         self.assertIn("--check", plan.steps[1].argv)
+        self.assertNotIn("--hygiene", plan.steps[1].argv)
+        self.assertIn("--tests", plan.steps[1].argv)
+        self.assertIn("--static-analysis", plan.steps[1].argv)
         self.assertIn("--commit", description)
         self.assertNotIn("--changed", description)
 
@@ -905,7 +909,11 @@ class CliTest(unittest.TestCase):
 
         self.assertEqual(len(plan.steps), 2)
         self.assertIn("--fix", plan.steps[0].argv)
+        self.assertIn("--hygiene", plan.steps[0].argv)
         self.assertIn("--check", plan.steps[1].argv)
+        self.assertNotIn("--hygiene", plan.steps[1].argv)
+        self.assertIn("--tests", plan.steps[1].argv)
+        self.assertIn("--static-analysis", plan.steps[1].argv)
         self.assertIn("--staged", description)
         self.assertNotIn("--changed", description)
 
@@ -917,7 +925,11 @@ class CliTest(unittest.TestCase):
 
         self.assertEqual(len(plan.steps), 2)
         self.assertIn("--fix", plan.steps[0].argv)
+        self.assertIn("--hygiene", plan.steps[0].argv)
         self.assertIn("--check", plan.steps[1].argv)
+        self.assertNotIn("--hygiene", plan.steps[1].argv)
+        self.assertIn("--tests", plan.steps[1].argv)
+        self.assertIn("--static-analysis", plan.steps[1].argv)
         self.assertIn("README.md dev.py", description)
         self.assertNotIn("--changed", description)
         self.assertNotIn("--staged", description)

--- a/build_tools/devtools/presubmit.py
+++ b/build_tools/devtools/presubmit.py
@@ -144,13 +144,15 @@ def precommit_plan(
         input_args.append("--changed")
 
     plan = CommandPlan()
-    if precommit_should_autofix(profile, commit, staged, paths):
+    should_autofix = precommit_should_autofix(profile, commit, staged, paths)
+    if should_autofix:
         command = [
             tool_env.python,
             str(REPO_ROOT / "build_tools/lefthook/presubmit.py"),
             "--lane",
             lane,
             "--fix",
+            "--hygiene",
             *input_args,
             "--profile",
             profile,
@@ -176,6 +178,8 @@ def precommit_plan(
         "--profile",
         profile,
     ]
+    if should_autofix:
+        command += ["--tests", "--static-analysis"]
     if verbose:
         command.append("--verbose")
     plan.add(

--- a/build_tools/lefthook/README.md
+++ b/build_tools/lefthook/README.md
@@ -20,10 +20,12 @@ python dev.py <lane> precommit --profile <profile> --commit
 ```
 
 This fix-then-check path is used for `paranoid` and `ci` when the input is the
-generated hook's commit scope or an explicit `--staged` precommit, because those
-profiles run affected tests after any mutation. Broader local-change precommit
-runs stay check-only. The `default` profile remains check-only. Local fixups are
-also available through explicit commands:
+generated hook's commit scope or an explicit `--staged` precommit. The mutating
+pass is limited to hygiene fixers and is also the hygiene validation boundary:
+unfixable diagnostics fail there. The validation pass then runs affected tests
+and static analysis once against the post-fix tree. Broader local-change
+precommit runs stay check-only. The `default` profile remains check-only. Local
+fixups are also available through explicit commands:
 
 ```bash
 python dev.py bazel fix

--- a/runtime/src/iree/hal/drivers/amdgpu/pm4_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/pm4_command_buffer.c
@@ -3488,11 +3488,7 @@ static void iree_hal_amdgpu_pm4_command_buffer_destroy(
     command_buffer->resident_allocation = NULL;
     memset(&command_buffer->program, 0, sizeof(command_buffer->program));
   } else {
-    iree_status_t release_status =
-        iree_hal_amdgpu_pm4_program_release(&command_buffer->program);
-    IREE_ASSERT(iree_status_is_ok(release_status),
-                "PM4 command-buffer program release failed");
-    iree_status_free(release_status);
+    iree_hal_amdgpu_pm4_program_deinitialize(&command_buffer->program);
   }
   iree_hal_amdgpu_pm4_command_buffer_fixup_reset(command_buffer);
   if (command_buffer->recording_state ==

--- a/runtime/src/iree/hal/drivers/amdgpu/util/pm4_dispatch_live_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/pm4_dispatch_live_test.cc
@@ -608,7 +608,7 @@ TEST_F(PM4DispatchLiveTest, AqlAndAqlPm4IbLaunchMixedKernels) {
   WaitForCompletionWord(&memory->completion, /*value=*/1);
   EXPECT_EQ(memory->outputs[0], kPm4ValueA);
   EXPECT_EQ(memory->outputs[1], kPm4ValueB + 0x100u);
-  IREE_ASSERT_OK(iree_hal_amdgpu_pm4_program_release(&pm4_program));
+  iree_hal_amdgpu_pm4_program_deinitialize(&pm4_program);
 
   memset(memory, 0, sizeof(*memory));
   pm4_dword_count = 0;
@@ -660,7 +660,7 @@ TEST_F(PM4DispatchLiveTest, AqlAndAqlPm4IbLaunchMixedKernels) {
   WaitForCompletionWord(&memory->completion, /*value=*/2);
   EXPECT_EQ(memory->scratch[0], kPm4BarrierValue);
   EXPECT_EQ(memory->outputs[2], kPm4BarrierValue + kPm4BarrierAdd);
-  IREE_ASSERT_OK(iree_hal_amdgpu_pm4_program_release(&pm4_program));
+  iree_hal_amdgpu_pm4_program_deinitialize(&pm4_program);
 
   memset(memory, 0, sizeof(*memory));
   memory->store_kernargs[2] = {.target = &memory->outputs[3],
@@ -760,13 +760,12 @@ TEST_F(PM4DispatchLiveTest, AqlAndAqlPm4IbLaunchMixedKernels) {
   WaitForCompletionWord(&memory->completion, /*value=*/3);
   EXPECT_EQ(memory->outputs[2], kPm4PatchValue + 0x100u);
   EXPECT_EQ(memory->outputs[3], 0u);
-  IREE_ASSERT_OK(iree_hal_amdgpu_pm4_program_release(&pm4_program));
-  IREE_ASSERT_OK(iree_hal_amdgpu_pm4_program_release(&target_pm4_program));
+  iree_hal_amdgpu_pm4_program_deinitialize(&pm4_program);
+  iree_hal_amdgpu_pm4_program_deinitialize(&target_pm4_program);
   EXPECT_EQ(queue_error.callback_count.load(std::memory_order_relaxed), 0u);
   EXPECT_EQ(queue_error.status.load(std::memory_order_relaxed),
             static_cast<uint32_t>(HSA_STATUS_SUCCESS));
 
-  IREE_ASSERT_OK(iree_hal_amdgpu_pm4_program_release(&pm4_program));
   IREE_ASSERT_OK(
       iree_hsa_signal_destroy(IREE_LIBHSA(&libhsa), completion_signal));
   IREE_ASSERT_OK(iree_hsa_queue_destroy(IREE_LIBHSA(&libhsa), queue));

--- a/runtime/src/iree/hal/drivers/amdgpu/util/pm4_program.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/pm4_program.c
@@ -96,16 +96,17 @@ iree_status_t iree_hal_amdgpu_pm4_program_initialize_with_stats(
   return status;
 }
 
-iree_status_t iree_hal_amdgpu_pm4_program_release(
+void iree_hal_amdgpu_pm4_program_deinitialize(
     iree_hal_amdgpu_pm4_program_t* program) {
-  if (!program || !program->dwords) return iree_ok_status();
+  if (!program) return;
+  if (!program->dwords) {
+    memset(program, 0, sizeof(*program));
+    return;
+  }
   IREE_TRACE_ZONE_BEGIN(z0);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, program->byte_length);
-  iree_status_t status = iree_hsa_amd_memory_pool_free(
-      IREE_LIBHSA(program->libhsa), program->dwords);
-  if (iree_status_is_ok(status)) {
-    memset(program, 0, sizeof(*program));
-  }
+  iree_status_ignore(iree_hsa_amd_memory_pool_free(IREE_LIBHSA(program->libhsa),
+                                                   program->dwords));
+  memset(program, 0, sizeof(*program));
   IREE_TRACE_ZONE_END(z0);
-  return status;
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/util/pm4_program.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/pm4_program.h
@@ -60,8 +60,8 @@ iree_status_t iree_hal_amdgpu_pm4_program_initialize_with_stats(
     iree_hal_amdgpu_pm4_program_publish_stats_t* out_stats,
     iree_hal_amdgpu_pm4_program_t* out_program);
 
-// Releases the executable storage backing |program| and clears it on success.
-iree_status_t iree_hal_amdgpu_pm4_program_release(
+// Deinitializes the executable storage backing |program| and clears it.
+void iree_hal_amdgpu_pm4_program_deinitialize(
     iree_hal_amdgpu_pm4_program_t* program);
 
 #ifdef __cplusplus

--- a/runtime/src/iree/hal/drivers/amdgpu/util/pm4_program_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/pm4_program_test.cc
@@ -101,7 +101,7 @@ TEST_F(PM4ProgramTest, InitializePersistentProgram) {
   EXPECT_EQ(packet.ib_jump_cmd[3], program.dword_count | (1u << 23));
   EXPECT_EQ(packet.dw_cnt_remain, 0xAu);
 
-  IREE_ASSERT_OK(iree_hal_amdgpu_pm4_program_release(&program));
+  iree_hal_amdgpu_pm4_program_deinitialize(&program);
   EXPECT_EQ(program.dwords, nullptr);
   EXPECT_EQ(program.dword_count, 0u);
   EXPECT_EQ(program.byte_length, 0u);


### PR DESCRIPTION
Rename the in-place PM4 program teardown API from release to deinitialize so it matches the initialize side of the contract. The object owns executable HSA memory in caller-provided storage, and command-buffer destruction has no status channel that can reliably propagate a ROCR free failure.

Ignore the ROCR free wrapper status at the no-status cleanup boundary and clear the program record unconditionally. Update command-buffer destruction and PM4 tests to call the deinitializer directly instead of asserting a status and freeing it.