### PR TITLE
[HAL/AMDGPU] Deinitialize AQL programs

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor_test.cc
@@ -753,7 +753,7 @@ TEST(AqlBlockProcessorTest,
   EXPECT_EQ(second_block->terminator_opcode,
             IREE_HAL_AMDGPU_COMMAND_BUFFER_OPCODE_RETURN);
 
-  iree_hal_amdgpu_aql_program_release(&program);
+  iree_hal_amdgpu_aql_program_deinitialize(&program);
   iree_arena_block_pool_deinitialize(&block_pool);
 }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
@@ -287,7 +287,7 @@ static void iree_hal_amdgpu_aql_command_buffer_reset_resources(
 
 static void iree_hal_amdgpu_aql_command_buffer_discard_recording(
     iree_hal_amdgpu_aql_command_buffer_t* command_buffer) {
-  iree_hal_amdgpu_aql_program_release(&command_buffer->program);
+  iree_hal_amdgpu_aql_program_deinitialize(&command_buffer->program);
   iree_hal_amdgpu_aql_program_builder_deinitialize(&command_buffer->builder);
   iree_hal_amdgpu_aql_program_builder_initialize(
       command_buffer->block_pools.program, &command_buffer->builder);
@@ -850,7 +850,7 @@ static void iree_hal_amdgpu_aql_command_buffer_destroy(
   iree_allocator_t host_allocator = command_buffer->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_hal_amdgpu_aql_program_release(&command_buffer->program);
+  iree_hal_amdgpu_aql_program_deinitialize(&command_buffer->program);
   iree_hal_amdgpu_aql_program_builder_deinitialize(&command_buffer->builder);
   iree_hal_amdgpu_aql_command_buffer_reset_resources(command_buffer);
   iree_arena_deinitialize(&command_buffer->recording_arena);

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_program_builder.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_program_builder.c
@@ -81,9 +81,10 @@ iree_hal_amdgpu_aql_program_block_next(
 // Recording Output
 //===----------------------------------------------------------------------===//
 
-void iree_hal_amdgpu_aql_program_release(
+void iree_hal_amdgpu_aql_program_deinitialize(
     iree_hal_amdgpu_aql_program_t* program) {
   if (!program->first_block) {
+    memset(program, 0, sizeof(*program));
     return;
   }
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -134,7 +135,7 @@ void iree_hal_amdgpu_aql_program_builder_deinitialize(
         .block_pool = builder->block_pool,
         .first_block = builder->first_block,
     };
-    iree_hal_amdgpu_aql_program_release(&program);
+    iree_hal_amdgpu_aql_program_deinitialize(&program);
   }
 
   memset(builder, 0, sizeof(*builder));

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_program_builder.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_program_builder.h
@@ -51,8 +51,9 @@ typedef struct iree_hal_amdgpu_aql_program_t {
   uint32_t max_block_kernarg_length;
 } iree_hal_amdgpu_aql_program_t;
 
-// Releases all blocks in |program| back to its block pool.
-void iree_hal_amdgpu_aql_program_release(
+// Deinitializes |program|, returning all blocks to its block pool and clearing
+// it.
+void iree_hal_amdgpu_aql_program_deinitialize(
     iree_hal_amdgpu_aql_program_t* program);
 
 // Returns the block following |block| in program order.

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_program_builder_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_program_builder_test.cc
@@ -98,6 +98,24 @@ TEST(CommandBufferAbiTest, BuilderRejectsOversizedUsableBlockSize) {
   iree_arena_block_pool_deinitialize(&block_pool);
 }
 
+TEST_F(AqlProgramBuilderTest, DeinitializesEmptyProgram) {
+  iree_hal_amdgpu_aql_program_t program = {};
+  program.block_pool = block_pool();
+  program.block_count = 1;
+  program.command_count = 2;
+  program.max_block_aql_packet_count = 3;
+  program.max_block_kernarg_length = 4;
+
+  iree_hal_amdgpu_aql_program_deinitialize(&program);
+
+  EXPECT_EQ(program.block_pool, nullptr);
+  EXPECT_EQ(program.first_block, nullptr);
+  EXPECT_EQ(program.block_count, 0u);
+  EXPECT_EQ(program.command_count, 0u);
+  EXPECT_EQ(program.max_block_aql_packet_count, 0u);
+  EXPECT_EQ(program.max_block_kernarg_length, 0u);
+}
+
 TEST_F(AqlProgramBuilderTest, EmptyProgramRecordsReturnBlock) {
   iree_hal_amdgpu_aql_program_builder_t builder;
   iree_hal_amdgpu_aql_program_builder_initialize(block_pool(), &builder);
@@ -137,7 +155,7 @@ TEST_F(AqlProgramBuilderTest, EmptyProgramRecordsReturnBlock) {
 
   IREE_EXPECT_OK(iree_hal_amdgpu_aql_program_validate_metadata_only(&program));
 
-  iree_hal_amdgpu_aql_program_release(&program);
+  iree_hal_amdgpu_aql_program_deinitialize(&program);
 }
 
 TEST_F(AqlProgramBuilderTest, AppendsCommandAndBindingSources) {
@@ -207,7 +225,7 @@ TEST_F(AqlProgramBuilderTest, AppendsCommandAndBindingSources) {
   EXPECT_EQ(return_command->opcode,
             IREE_HAL_AMDGPU_COMMAND_BUFFER_OPCODE_RETURN);
 
-  iree_hal_amdgpu_aql_program_release(&program);
+  iree_hal_amdgpu_aql_program_deinitialize(&program);
 }
 
 TEST_F(AqlProgramBuilderTest, PatchesBarrierScopesAtRecordingTime) {
@@ -267,7 +285,7 @@ TEST_F(AqlProgramBuilderTest, PatchesBarrierScopesAtRecordingTime) {
                 second_dispatch->flags),
             IREE_HSA_FENCE_SCOPE_NONE);
 
-  iree_hal_amdgpu_aql_program_release(&program);
+  iree_hal_amdgpu_aql_program_deinitialize(&program);
 }
 
 TEST_F(AqlProgramBuilderTest, ForcedBarrierKeepsPendingAcquireScope) {
@@ -307,7 +325,7 @@ TEST_F(AqlProgramBuilderTest, ForcedBarrierKeepsPendingAcquireScope) {
                 dispatch->flags),
             IREE_HSA_FENCE_SCOPE_AGENT);
 
-  iree_hal_amdgpu_aql_program_release(&program);
+  iree_hal_amdgpu_aql_program_deinitialize(&program);
 }
 
 TEST_F(AqlProgramBuilderTest, SplitsBlocksWithBranchTerminator) {
@@ -353,7 +371,7 @@ TEST_F(AqlProgramBuilderTest, SplitsBlocksWithBranchTerminator) {
             IREE_HAL_AMDGPU_COMMAND_BUFFER_OPCODE_RETURN);
   EXPECT_EQ(second_block->terminator_target_block_ordinal, 0u);
 
-  iree_hal_amdgpu_aql_program_release(&program);
+  iree_hal_amdgpu_aql_program_deinitialize(&program);
 }
 
 TEST_F(AqlProgramBuilderTest, ValidatesSplitMetadataOnlyProgram) {
@@ -371,7 +389,7 @@ TEST_F(AqlProgramBuilderTest, ValidatesSplitMetadataOnlyProgram) {
   ASSERT_EQ(program.max_block_aql_packet_count, 0u);
   IREE_EXPECT_OK(iree_hal_amdgpu_aql_program_validate_metadata_only(&program));
 
-  iree_hal_amdgpu_aql_program_release(&program);
+  iree_hal_amdgpu_aql_program_deinitialize(&program);
 }
 
 TEST_F(AqlProgramBuilderTest, MetadataOnlyValidationRejectsPayloadBlocks) {
@@ -395,7 +413,7 @@ TEST_F(AqlProgramBuilderTest, MetadataOnlyValidationRejectsPayloadBlocks) {
       IREE_STATUS_INVALID_ARGUMENT,
       iree_hal_amdgpu_aql_program_validate_metadata_only(&program));
 
-  iree_hal_amdgpu_aql_program_release(&program);
+  iree_hal_amdgpu_aql_program_deinitialize(&program);
 }
 
 TEST_F(AqlProgramBuilderTest, MetadataOnlyValidationRejectsProfileMarkers) {
@@ -420,7 +438,7 @@ TEST_F(AqlProgramBuilderTest, MetadataOnlyValidationRejectsProfileMarkers) {
       IREE_STATUS_UNIMPLEMENTED,
       iree_hal_amdgpu_aql_program_validate_metadata_only(&program));
 
-  iree_hal_amdgpu_aql_program_release(&program);
+  iree_hal_amdgpu_aql_program_deinitialize(&program);
 }
 
 TEST_F(AqlProgramBuilderTest,
@@ -441,7 +459,7 @@ TEST_F(AqlProgramBuilderTest,
       IREE_STATUS_INVALID_ARGUMENT,
       iree_hal_amdgpu_aql_program_validate_metadata_only(&program));
 
-  iree_hal_amdgpu_aql_program_release(&program);
+  iree_hal_amdgpu_aql_program_deinitialize(&program);
 }
 
 TEST_F(AqlProgramBuilderTest, RejectsOversizedCommand) {


### PR DESCRIPTION
AQL programs are recording-output objects populated into caller-owned storage by the AQL program builder. Their teardown returns arena blocks to the owning block pool and clears that storage, so the lifecycle verb should be deinitialize rather than release.

This renames the helper and updates command-buffer and test callers. Empty program teardown now clears the record as well, keeping the deinitialize contract consistent even when no blocks were recorded.