### PR TITLE
[Infra] Harden refcount clang-tidy checks

### DIFF
--- a/build_tools/clang_tidy/iree/RefCountChecks.cc
+++ b/build_tools/clang_tidy/iree/RefCountChecks.cc
@@ -395,7 +395,7 @@ bool IsRefCountReleaseNullSafe(const FunctionDecl* Function,
 }
 
 const Expr* IgnoreExprNoise(const Expr* Expression) {
-  return Expression ? Expression->IgnoreParenImpCasts() : nullptr;
+  return Expression ? Expression->IgnoreParenCasts() : nullptr;
 }
 
 const VarDecl* ReferencedVariable(const Expr* Expression) {
@@ -442,7 +442,8 @@ std::optional<DirectRefCountOperation> DirectRefCountOperationStatement(
     return std::nullopt;
   }
   const FunctionDecl* Callee = Call->getDirectCallee();
-  if (!Callee || !FunctionNamePredicate(Callee->getName())) {
+  if (!Callee || !Callee->getReturnType()->isVoidType() ||
+      !FunctionNamePredicate(Callee->getName())) {
     return std::nullopt;
   }
   const VarDecl* Variable = ReferencedVariable(Call->getArg(0));
@@ -524,6 +525,52 @@ class ReleasedUseVisitor final
     VisitChildren(Expression);
   }
 
+  void VisitBinaryOperator(const BinaryOperator* Expression) {
+    if (Expression->isAssignmentOp()) {
+      if (const VarDecl* Variable = ReferencedVariable(Expression->getRHS())) {
+        DiagnoseUse(Variable, Expression->getRHS()->getBeginLoc());
+      }
+    }
+    VisitChildren(Expression);
+  }
+
+  void VisitCallExpr(const CallExpr* Expression) {
+    const FunctionDecl* Callee = Expression->getDirectCallee();
+    if (Callee && (IsReleaseFunctionName(Callee->getName()) ||
+                   IsRetainFunctionName(Callee->getName()))) {
+      VisitChildren(Expression);
+      return;
+    }
+    for (const Expr* Argument : Expression->arguments()) {
+      if (const VarDecl* Variable = ReferencedVariable(Argument)) {
+        DiagnoseUse(Variable, Argument->getBeginLoc());
+      }
+    }
+    VisitChildren(Expression);
+  }
+
+  void VisitDeclStmt(const DeclStmt* Statement) {
+    for (const Decl* Declaration : Statement->decls()) {
+      const auto* Variable = dyn_cast<VarDecl>(Declaration);
+      if (!Variable || !Variable->hasInit()) {
+        continue;
+      }
+      if (const VarDecl* Referenced = ReferencedVariable(Variable->getInit())) {
+        DiagnoseUse(Referenced, Variable->getInit()->getBeginLoc());
+      }
+    }
+    VisitChildren(Statement);
+  }
+
+  void VisitReturnStmt(const ReturnStmt* Statement) {
+    if (const Expr* ReturnValue = Statement->getRetValue()) {
+      if (const VarDecl* Variable = ReferencedVariable(ReturnValue)) {
+        DiagnoseUse(Variable, ReturnValue->getBeginLoc());
+      }
+    }
+    VisitChildren(Statement);
+  }
+
  private:
   void VisitChildren(const Stmt* Statement) {
     for (const Stmt* Child : Statement->children()) {
@@ -544,6 +591,20 @@ class ReleasedUseVisitor final
     Diagnosed.insert(Variable);
     Check.diag(SourceManager.getExpansionLoc(Location),
                "%0 is dereferenced after %1 releases it")
+        << Variable->getName() << It->second.Function->getName();
+  }
+
+  void DiagnoseUse(const VarDecl* Variable, SourceLocation Location) {
+    auto It = Released.find(Variable);
+    if (It == Released.end() || Diagnosed.contains(Variable)) {
+      return;
+    }
+    if (IsExternalMacroBody(Location, SourceManager)) {
+      return;
+    }
+    Diagnosed.insert(Variable);
+    Check.diag(SourceManager.getExpansionLoc(Location),
+               "%0 is used after %1 releases it")
         << Variable->getName() << It->second.Function->getName();
   }
 

--- a/build_tools/clang_tidy/test/refcount_checks.c
+++ b/build_tools/clang_tidy/test/refcount_checks.c
@@ -69,6 +69,10 @@ void iree_clang_tidy_refcount_void_release(
   }
 }
 
+void iree_clang_tidy_refcount_observe(iree_clang_tidy_refcounted_t* resource) {
+  (void)resource;
+}
+
 void iree_clang_tidy_refcount_unguarded_release(
     iree_clang_tidy_refcounted_t* resource) {
   if (iree_atomic_ref_count_dec(&resource->ref_count) == 1) {
@@ -133,6 +137,39 @@ void iree_clang_tidy_refcount_release_then_release(
   iree_clang_tidy_refcount_void_release(resource);
 }
 
+void iree_clang_tidy_refcount_release_then_call(
+    iree_clang_tidy_refcounted_t* resource) {
+  iree_clang_tidy_refcount_void_release(resource);
+  iree_clang_tidy_refcount_observe(resource);
+}
+
+void iree_clang_tidy_refcount_release_then_cast_call(
+    iree_clang_tidy_refcounted_t* cast_resource) {
+  iree_clang_tidy_refcount_void_release(cast_resource);
+  iree_clang_tidy_refcount_observe(
+      (iree_clang_tidy_refcounted_t*)cast_resource);
+}
+
+void iree_clang_tidy_refcount_release_then_assign(
+    iree_clang_tidy_refcounted_t* assigned_resource,
+    iree_clang_tidy_refcounted_t** out_resource) {
+  iree_clang_tidy_refcount_void_release(assigned_resource);
+  *out_resource = assigned_resource;
+}
+
+void iree_clang_tidy_refcount_release_then_alias(
+    iree_clang_tidy_refcounted_t* aliased_resource) {
+  iree_clang_tidy_refcount_void_release(aliased_resource);
+  iree_clang_tidy_refcounted_t* alias = aliased_resource;
+  (void)alias;
+}
+
+iree_clang_tidy_refcounted_t* iree_clang_tidy_refcount_release_then_return(
+    iree_clang_tidy_refcounted_t* returned_resource) {
+  iree_clang_tidy_refcount_void_release(returned_resource);
+  return returned_resource;
+}
+
 void iree_clang_tidy_refcount_retain_then_double_release(
     iree_clang_tidy_refcounted_t* resource) {
   iree_clang_tidy_refcount_void_retain(resource);
@@ -186,4 +223,10 @@ iree_status_t iree_clang_tidy_refcount_lookup_retain(
 iree_status_t iree_clang_tidy_virtual_memory_release(void* memory) {
   (void)memory;
   return iree_ok_status();
+}
+
+void iree_clang_tidy_refcount_status_release_then_use(
+    iree_clang_tidy_refcounted_t* status_released_resource) {
+  (void)iree_clang_tidy_virtual_memory_release(status_released_resource);
+  iree_clang_tidy_refcount_observe(status_released_resource);
 }

--- a/build_tools/clang_tidy/test/refcount_checks_test.py
+++ b/build_tools/clang_tidy/test/refcount_checks_test.py
@@ -48,6 +48,16 @@ class RefCountChecksTest(clang_tidy_test.ClangTidyAssertions):
                 "resource is released by "
                 "iree_clang_tidy_refcount_void_release after "
                 "iree_clang_tidy_refcount_void_release already released it",
+                "resource is used after "
+                "iree_clang_tidy_refcount_void_release releases it",
+                "cast_resource is used after "
+                "iree_clang_tidy_refcount_void_release releases it",
+                "assigned_resource is used after "
+                "iree_clang_tidy_refcount_void_release releases it",
+                "aliased_resource is used after "
+                "iree_clang_tidy_refcount_void_release releases it",
+                "returned_resource is used after "
+                "iree_clang_tidy_refcount_void_release releases it",
                 "[iree-refcount-lifecycle]",
             ],
         )
@@ -67,6 +77,7 @@ class RefCountChecksTest(clang_tidy_test.ClangTidyAssertions):
                 "iree_clang_tidy_refcount_local_counter_release",
                 "iree_clang_tidy_refcount_lookup_retain",
                 "iree_clang_tidy_virtual_memory_release",
+                "status_released_resource",
                 "side_counter",
             ],
         )

--- a/build_tools/lefthook/presubmit.py
+++ b/build_tools/lefthook/presubmit.py
@@ -2012,6 +2012,7 @@ def run_clang_tidy(
                     "--config=presubmit",
                     CLANG_TIDY_REPO_ENV,
                     "//build_tools/clang_tidy:plugin_smoke_test",
+                    "//build_tools/clang_tidy:refcount_checks_test",
                     "//build_tools/clang_tidy:status_checks_test",
                     "//build_tools/clang_tidy:style_checks_test",
                     "//build_tools/clang_tidy:trace_checks_test",

--- a/build_tools/lefthook/presubmit_test.py
+++ b/build_tools/lefthook/presubmit_test.py
@@ -538,6 +538,9 @@ class PresubmitTest(unittest.TestCase):
         plugin_test_command = run_command.call_args_list[0].args[0]
         self.assertIn("//build_tools/clang_tidy:plugin_smoke_test", plugin_test_command)
         self.assertIn(
+            "//build_tools/clang_tidy:refcount_checks_test", plugin_test_command
+        )
+        self.assertIn(
             "//build_tools/clang_tidy:status_checks_test", plugin_test_command
         )
         self.assertIn("//build_tools/clang_tidy:style_checks_test", plugin_test_command)


### PR DESCRIPTION
The IREE refcount clang-tidy check now treats direct void object release calls as consuming the released handle spelling until the local flow reassigns it or models an explicit retain edge. That widens the existing post-release dereference and double-release coverage to catch direct call-argument use, explicit-cast call use, assignment or copy into another storage location, local alias initialization, and returning the released handle.

The model remains intentionally local and conservative. It only creates ownership edges for void retain/release APIs, so status-returning release operations such as allocator virtual-memory release are not treated as refcount object releases. It also stays on direct handle expressions rather than trying to solve branch merges, output parameters, comparisons, missing releases, or whole-function ownership proofs in this slice.

This also fixes the clang-tidy infrastructure test set so refcount_checks_test runs whenever plugin sources change. Refcount diagnostics now have the same plugin-change coverage as the status, style, and trace check categories.