### PR TITLE
[Infra] Extending clang-tidy refcount checks

### DIFF
--- a/build_tools/clang_tidy/README.md
+++ b/build_tools/clang_tidy/README.md
@@ -247,16 +247,26 @@ iree_hal_buffer_release(buffer);
 iree_hal_buffer_release(buffer);
 ```
 
-This rule is intentionally local. It does not yet merge release state across
-branch exits, and assignment resets the handle state:
+This rule is intentionally local. It merges the narrow branch shape where both
+arms directly release the same handle, and assignment resets the handle state:
 
 ```c
+if (condition) {
+  iree_hal_buffer_release(buffer);
+} else {
+  iree_hal_buffer_release(buffer);
+}
+buffer->data = NULL;  // The handle was released on every branch.
+
 iree_hal_buffer_release(buffer);
 buffer = NULL;
 
 iree_hal_buffer_release(buffer);
 buffer = replacement_buffer;
 ```
+
+Partial branch releases do not poison the outer handle state because the local
+checker only reports state it can prove on every path through that statement.
 
 If a release drops one retained edge while another owner keeps the object alive,
 the code should still avoid reading through the released handle spelling. Take

--- a/build_tools/clang_tidy/iree/RefCountChecks.cc
+++ b/build_tools/clang_tidy/iree/RefCountChecks.cc
@@ -308,25 +308,26 @@ bool HasIgnoredRefCountDecrement(StringRef NormalizedBody) {
   }
 }
 
-bool RefCountDecrementReferencesParameter(StringRef NormalizedBody,
-                                          StringRef ParameterName) {
-  static constexpr StringRef RefCountDec = "iree_atomic_ref_count_dec";
+bool RefCountMutationReferencesParameter(StringRef NormalizedBody,
+                                         StringRef MutationName,
+                                         StringRef ParameterName) {
   size_t SearchPosition = 0;
   while (true) {
-    size_t DecPosition = NormalizedBody.find(RefCountDec, SearchPosition);
-    if (DecPosition == StringRef::npos) {
+    size_t MutationPosition = NormalizedBody.find(MutationName, SearchPosition);
+    if (MutationPosition == StringRef::npos) {
       return false;
     }
-    size_t StatementEnd = NormalizedBody.find(';', DecPosition);
+    size_t StatementEnd = NormalizedBody.find(';', MutationPosition);
     if (StatementEnd == StringRef::npos) {
       StatementEnd = NormalizedBody.size();
     }
     if (SourceContainsIdentifier(
-            NormalizedBody.substr(DecPosition, StatementEnd - DecPosition),
+            NormalizedBody.substr(MutationPosition,
+                                  StatementEnd - MutationPosition),
             ParameterName)) {
       return true;
     }
-    SearchPosition = DecPosition + RefCountDec.size();
+    SearchPosition = MutationPosition + MutationName.size();
   }
 }
 
@@ -386,6 +387,47 @@ bool HasArgumentAssert(StringRef NormalizedBody, StringRef ParameterName) {
   return false;
 }
 
+bool IsInsideOpenBlock(StringRef NormalizedBody, size_t BlockPosition,
+                       size_t TargetPosition) {
+  int Depth = 0;
+  for (size_t I = BlockPosition; I < TargetPosition; ++I) {
+    if (NormalizedBody[I] == '{') {
+      ++Depth;
+    } else if (NormalizedBody[I] == '}') {
+      --Depth;
+    }
+  }
+  return Depth > 0;
+}
+
+bool HasGuardedRefCountIncrement(StringRef NormalizedBody,
+                                 StringRef ParameterName) {
+  static constexpr StringRef RefCountInc = "iree_atomic_ref_count_inc";
+  size_t SearchPosition = 0;
+  while (true) {
+    size_t IncPosition = NormalizedBody.find(RefCountInc, SearchPosition);
+    if (IncPosition == StringRef::npos) {
+      return false;
+    }
+    StringRef Prefix = NormalizedBody.substr(0, IncPosition);
+    size_t IfPosition = Prefix.rfind("if(");
+    if (IfPosition != StringRef::npos) {
+      size_t BlockPosition = NormalizedBody.find('{', IfPosition);
+      bool IncrementIsInsideThenBlock =
+          BlockPosition != StringRef::npos && BlockPosition < IncPosition &&
+          IsInsideOpenBlock(NormalizedBody, BlockPosition, IncPosition);
+      if (IncrementIsInsideThenBlock) {
+        StringRef Condition = NormalizedBody.substr(
+            IfPosition + 3, BlockPosition - IfPosition - 3);
+        if (SourceContainsIdentifier(Condition, ParameterName)) {
+          return true;
+        }
+      }
+    }
+    SearchPosition = IncPosition + RefCountInc.size();
+  }
+}
+
 bool IsRefCountReleaseNullSafe(const FunctionDecl* Function,
                                StringRef NormalizedBody) {
   if (Function->getNumParams() != 1) {
@@ -397,7 +439,8 @@ bool IsRefCountReleaseNullSafe(const FunctionDecl* Function,
   }
   StringRef ParameterName = Parameter->getName();
   if (ParameterName.empty() ||
-      !RefCountDecrementReferencesParameter(NormalizedBody, ParameterName)) {
+      !RefCountMutationReferencesParameter(
+          NormalizedBody, "iree_atomic_ref_count_dec", ParameterName)) {
     return true;
   }
   if (HasArgumentAssert(NormalizedBody, ParameterName)) {
@@ -405,6 +448,28 @@ bool IsRefCountReleaseNullSafe(const FunctionDecl* Function,
   }
   return HasEarlyNullReturn(NormalizedBody, ParameterName) ||
          HasGuardedRefCountDecrement(NormalizedBody, ParameterName);
+}
+
+bool IsRefCountRetainNullSafe(const FunctionDecl* Function,
+                              StringRef NormalizedBody) {
+  if (Function->getNumParams() != 1) {
+    return true;
+  }
+  const ParmVarDecl* Parameter = Function->getParamDecl(0);
+  if (!Parameter->getType()->isAnyPointerType()) {
+    return true;
+  }
+  StringRef ParameterName = Parameter->getName();
+  if (ParameterName.empty() ||
+      !RefCountMutationReferencesParameter(
+          NormalizedBody, "iree_atomic_ref_count_inc", ParameterName)) {
+    return true;
+  }
+  if (HasArgumentAssert(NormalizedBody, ParameterName)) {
+    return false;
+  }
+  return HasEarlyNullReturn(NormalizedBody, ParameterName) ||
+         HasGuardedRefCountIncrement(NormalizedBody, ParameterName);
 }
 
 const Expr* IgnoreExprNoise(const Expr* Expression) {
@@ -868,6 +933,14 @@ void RefCountLifecycleCheck::check(
       !IsRefCountReleaseNullSafe(Function, NormalizedBody)) {
     diag(SourceManager.getExpansionLoc(Function->getLocation()),
          "refcounted release function %0 must be null-safe")
+        << FunctionName;
+    return;
+  }
+  if (Function->getReturnType()->isVoidType() &&
+      FunctionName.ends_with("_retain") &&
+      !IsRefCountRetainNullSafe(Function, NormalizedBody)) {
+    diag(SourceManager.getExpansionLoc(Function->getLocation()),
+         "refcounted retain function %0 must be null-safe")
         << FunctionName;
     return;
   }

--- a/build_tools/clang_tidy/iree/RefCountChecks.cc
+++ b/build_tools/clang_tidy/iree/RefCountChecks.cc
@@ -432,6 +432,58 @@ const VarDecl* ReferencedVariableThroughIndirection(const Expr* Expression) {
   return nullptr;
 }
 
+bool IsNullPointerConstant(const Expr* Expression, ASTContext& Context) {
+  Expression = IgnoreExprNoise(Expression);
+  return Expression && Expression->isNullPointerConstant(
+                           Context, Expr::NPC_ValueDependentIsNotNull);
+}
+
+const VarDecl* PositivePointerGuardVariable(const Expr* Condition,
+                                            ASTContext& Context) {
+  Condition = IgnoreExprNoise(Condition);
+  if (const VarDecl* Variable = ReferencedVariable(Condition)) {
+    return Variable->getType()->isAnyPointerType() ? Variable : nullptr;
+  }
+
+  const auto* Binary = dyn_cast_or_null<BinaryOperator>(Condition);
+  if (!Binary || Binary->getOpcode() != BO_NE) {
+    return nullptr;
+  }
+  const VarDecl* LeftVariable = ReferencedVariable(Binary->getLHS());
+  const VarDecl* RightVariable = ReferencedVariable(Binary->getRHS());
+  if (LeftVariable && !RightVariable &&
+      IsNullPointerConstant(Binary->getRHS(), Context)) {
+    return LeftVariable->getType()->isAnyPointerType() ? LeftVariable : nullptr;
+  }
+  if (RightVariable && !LeftVariable &&
+      IsNullPointerConstant(Binary->getLHS(), Context)) {
+    return RightVariable->getType()->isAnyPointerType() ? RightVariable
+                                                        : nullptr;
+  }
+  return nullptr;
+}
+
+const Stmt* SingleStatementBody(const Stmt* Body) {
+  if (!Body) {
+    return nullptr;
+  }
+  const auto* Compound = dyn_cast<CompoundStmt>(Body);
+  if (!Compound) {
+    return Body;
+  }
+  const Stmt* OnlyStatement = nullptr;
+  for (const Stmt* Statement : Compound->body()) {
+    if (!Statement) {
+      continue;
+    }
+    if (OnlyStatement) {
+      return nullptr;
+    }
+    OnlyStatement = Statement;
+  }
+  return OnlyStatement;
+}
+
 struct DirectRefCountOperation {
   const VarDecl* Variable = nullptr;
   const FunctionDecl* Function = nullptr;
@@ -478,6 +530,24 @@ std::optional<DirectRefCountOperation> DirectReleaseStatement(
 std::optional<DirectRefCountOperation> DirectRetainStatement(
     const Stmt* Statement) {
   return DirectRefCountOperationStatement(Statement, IsRetainFunctionName);
+}
+
+std::optional<DirectRefCountOperation> GuardedReleaseStatement(
+    const IfStmt* Statement, ASTContext& Context) {
+  if (!Statement || Statement->getElse()) {
+    return std::nullopt;
+  }
+  const VarDecl* GuardedVariable =
+      PositivePointerGuardVariable(Statement->getCond(), Context);
+  if (!GuardedVariable) {
+    return std::nullopt;
+  }
+  std::optional<DirectRefCountOperation> Release =
+      DirectReleaseStatement(SingleStatementBody(Statement->getThen()));
+  if (!Release || Release->Variable != GuardedVariable) {
+    return std::nullopt;
+  }
+  return Release;
 }
 
 const VarDecl* DirectVariableAssignment(const Stmt* Statement) {
@@ -710,6 +780,9 @@ void RefCountLifecycleCheck::registerMatchers(
   Finder->addMatcher(
       fieldDecl(unless(isExpansionInSystemHeader())).bind("refcount-field"),
       this);
+  Finder->addMatcher(
+      ifStmt(unless(isExpansionInSystemHeader())).bind("guarded-release-if"),
+      this);
 }
 
 void RefCountLifecycleCheck::check(
@@ -734,6 +807,23 @@ void RefCountLifecycleCheck::check(
              "in a refcounted object");
         return;
     }
+  }
+
+  if (const auto* If = Result.Nodes.getNodeAs<IfStmt>("guarded-release-if")) {
+    const SourceManager& SourceManager = *Result.SourceManager;
+    if (IsExternalMacroBody(If->getIfLoc(), SourceManager)) {
+      return;
+    }
+    std::optional<DirectRefCountOperation> Release =
+        GuardedReleaseStatement(If, *Result.Context);
+    if (!Release || IsExternalMacroBody(Release->Location, SourceManager)) {
+      return;
+    }
+    diag(SourceManager.getExpansionLoc(If->getIfLoc()),
+         "%0 is null-guarded before %1, but release functions must be "
+         "null-safe")
+        << Release->Variable->getName() << Release->Function->getName();
+    return;
   }
 
   const auto* Function = Result.Nodes.getNodeAs<FunctionDecl>("function");

--- a/build_tools/clang_tidy/iree/RefCountChecks.cc
+++ b/build_tools/clang_tidy/iree/RefCountChecks.cc
@@ -252,16 +252,29 @@ bool IsRefCountAnchoredRecord(const RecordDecl* Record,
   return IsRefCountAnchorField(FirstField(Record), SourceManager);
 }
 
-bool ShouldDiagnoseRefCountField(const FieldDecl* Field,
-                                 const SourceManager& SourceManager) {
+enum class RefCountFieldDiagnostic {
+  kNone,
+  kMisusedCounter,
+  kRefCountNotFirst,
+};
+
+RefCountFieldDiagnostic DiagnoseRefCountField(
+    const FieldDecl* Field, const SourceManager& SourceManager) {
   if (!IsRefCountField(Field)) {
-    return false;
+    return RefCountFieldDiagnostic::kNone;
   }
   const RecordDecl* Record = EnclosingRecord(Field);
   if (Field == FirstField(Record)) {
-    return !IsAllowedRefCountFieldName(Field, SourceManager);
+    return IsAllowedRefCountFieldName(Field, SourceManager)
+               ? RefCountFieldDiagnostic::kNone
+               : RefCountFieldDiagnostic::kMisusedCounter;
   }
-  return IsRefCountAnchoredRecord(Record, SourceManager);
+  if (Field->getName() == "ref_count") {
+    return RefCountFieldDiagnostic::kRefCountNotFirst;
+  }
+  return IsRefCountAnchoredRecord(Record, SourceManager)
+             ? RefCountFieldDiagnostic::kMisusedCounter
+             : RefCountFieldDiagnostic::kNone;
 }
 
 bool BodyContainsRefCountMutation(StringRef BodyText) {
@@ -706,14 +719,21 @@ void RefCountLifecycleCheck::check(
     if (IsExternalMacroBody(Field->getLocation(), SourceManager)) {
       return;
     }
-    if (!ShouldDiagnoseRefCountField(Field, SourceManager)) {
-      return;
+    switch (DiagnoseRefCountField(Field, SourceManager)) {
+      case RefCountFieldDiagnostic::kNone:
+        return;
+      case RefCountFieldDiagnostic::kMisusedCounter:
+        diag(SourceManager.getExpansionLoc(Field->getLocation()),
+             "iree_atomic_ref_count_t field %0 must model object lifetime; "
+             "use an explicit atomic integer type for counters")
+            << Field->getName();
+        return;
+      case RefCountFieldDiagnostic::kRefCountNotFirst:
+        diag(SourceManager.getExpansionLoc(Field->getLocation()),
+             "iree_atomic_ref_count_t field ref_count must be the first field "
+             "in a refcounted object");
+        return;
     }
-    diag(SourceManager.getExpansionLoc(Field->getLocation()),
-         "iree_atomic_ref_count_t field %0 must model object lifetime; use an "
-         "explicit atomic integer type for counters")
-        << Field->getName();
-    return;
   }
 
   const auto* Function = Result.Nodes.getNodeAs<FunctionDecl>("function");

--- a/build_tools/clang_tidy/iree/RefCountChecks.cc
+++ b/build_tools/clang_tidy/iree/RefCountChecks.cc
@@ -736,7 +736,14 @@ class ReleaseFlowAnalyzer final
         }
       } else if (std::optional<DirectRefCountOperation> Retain =
                      DirectRetainStatement(Child)) {
-        if (!Released.contains(Retain->Variable)) {
+        auto It = Released.find(Retain->Variable);
+        if (It != Released.end() &&
+            !IsExternalMacroBody(Retain->Location, SourceManager)) {
+          Check.diag(SourceManager.getExpansionLoc(Retain->Location),
+                     "%0 is retained by %1 after %2 already released it")
+              << Retain->Variable->getName() << Retain->Function->getName()
+              << It->second.Function->getName();
+        } else {
           unsigned& ReferenceCount = ReferenceCounts[Retain->Variable];
           if (ReferenceCount == 0) {
             ReferenceCount = 1;

--- a/build_tools/clang_tidy/iree/RefCountChecks.cc
+++ b/build_tools/clang_tidy/iree/RefCountChecks.cc
@@ -615,6 +615,27 @@ std::optional<DirectRefCountOperation> GuardedReleaseStatement(
   return Release;
 }
 
+std::optional<DirectRefCountOperation> IfElseMergedReleaseStatement(
+    const IfStmt* Statement) {
+  if (!Statement || !Statement->getElse()) {
+    return std::nullopt;
+  }
+  std::optional<DirectRefCountOperation> ThenRelease =
+      DirectReleaseStatement(SingleStatementBody(Statement->getThen()));
+  std::optional<DirectRefCountOperation> ElseRelease =
+      DirectReleaseStatement(SingleStatementBody(Statement->getElse()));
+  if (!ThenRelease || !ElseRelease ||
+      ThenRelease->Variable != ElseRelease->Variable ||
+      ThenRelease->Function != ElseRelease->Function) {
+    return std::nullopt;
+  }
+  return DirectRefCountOperation{
+      .Variable = ThenRelease->Variable,
+      .Function = ThenRelease->Function,
+      .Location = Statement->getIfLoc(),
+  };
+}
+
 const VarDecl* DirectVariableAssignment(const Stmt* Statement) {
   if (!Statement) {
     return nullptr;
@@ -781,24 +802,11 @@ class ReleaseFlowAnalyzer final
       UseVisitor.Visit(Child);
       if (std::optional<DirectRefCountOperation> Release =
               DirectReleaseStatement(Child)) {
-        auto It = Released.find(Release->Variable);
-        if (It != Released.end() &&
-            !IsExternalMacroBody(Release->Location, SourceManager)) {
-          Check.diag(SourceManager.getExpansionLoc(Release->Location),
-                     "%0 is released by %1 after %2 already released it")
-              << Release->Variable->getName() << Release->Function->getName()
-              << It->second.Function->getName();
-        } else {
-          unsigned& ReferenceCount = ReferenceCounts[Release->Variable];
-          if (ReferenceCount == 0) {
-            ReferenceCount = 1;
-          }
-          --ReferenceCount;
-          if (ReferenceCount == 0) {
-            Released[Release->Variable] = ReleaseInfo{
-                .Function = Release->Function, .Location = Release->Location};
-          }
-        }
+        ConsumeRelease(*Release, Released, ReferenceCounts);
+      } else if (const auto* If = dyn_cast<IfStmt>(Child);
+                 std::optional<DirectRefCountOperation> Release =
+                     IfElseMergedReleaseStatement(If)) {
+        ConsumeRelease(*Release, Released, ReferenceCounts);
       } else if (std::optional<DirectRefCountOperation> Retain =
                      DirectRetainStatement(Child)) {
         auto It = Released.find(Retain->Variable);
@@ -824,6 +832,29 @@ class ReleaseFlowAnalyzer final
   }
 
  private:
+  void ConsumeRelease(
+      const DirectRefCountOperation& Release, ReleasedVariables& Released,
+      llvm::DenseMap<const VarDecl*, unsigned>& ReferenceCounts) {
+    auto It = Released.find(Release.Variable);
+    if (It != Released.end() &&
+        !IsExternalMacroBody(Release.Location, SourceManager)) {
+      Check.diag(SourceManager.getExpansionLoc(Release.Location),
+                 "%0 is released by %1 after %2 already released it")
+          << Release.Variable->getName() << Release.Function->getName()
+          << It->second.Function->getName();
+      return;
+    }
+    unsigned& ReferenceCount = ReferenceCounts[Release.Variable];
+    if (ReferenceCount == 0) {
+      ReferenceCount = 1;
+    }
+    --ReferenceCount;
+    if (ReferenceCount == 0) {
+      Released[Release.Variable] = ReleaseInfo{.Function = Release.Function,
+                                               .Location = Release.Location};
+    }
+  }
+
   void VisitChildren(const Stmt* Statement) {
     for (const Stmt* Child : Statement->children()) {
       if (Child) {

--- a/build_tools/clang_tidy/test/refcount_checks.c
+++ b/build_tools/clang_tidy/test/refcount_checks.c
@@ -62,6 +62,28 @@ iree_status_t iree_clang_tidy_refcount_status_release(
 
 void iree_clang_tidy_refcount_void_retain(
     iree_clang_tidy_refcounted_t* resource) {
+  if (!resource) {
+    return;
+  }
+  iree_atomic_ref_count_inc(&resource->ref_count);
+}
+
+void iree_clang_tidy_refcount_inline_null_retain(
+    iree_clang_tidy_refcounted_t* resource) {
+  if (resource) {
+    iree_atomic_ref_count_inc(&resource->ref_count);
+  }
+}
+
+void iree_clang_tidy_refcount_likely_null_retain(
+    iree_clang_tidy_refcounted_t* resource) {
+  if (IREE_LIKELY(resource)) {
+    iree_atomic_ref_count_inc(&resource->ref_count);
+  }
+}
+
+void iree_clang_tidy_refcount_unguarded_retain(
+    iree_clang_tidy_refcounted_t* resource) {
   iree_atomic_ref_count_inc(&resource->ref_count);
 }
 

--- a/build_tools/clang_tidy/test/refcount_checks.c
+++ b/build_tools/clang_tidy/test/refcount_checks.c
@@ -142,6 +142,12 @@ void iree_clang_tidy_refcount_release_then_release(
   iree_clang_tidy_refcount_void_release(resource);
 }
 
+void iree_clang_tidy_refcount_release_then_retain(
+    iree_clang_tidy_refcounted_t* retained_resource) {
+  iree_clang_tidy_refcount_void_release(retained_resource);
+  iree_clang_tidy_refcount_void_retain(retained_resource);
+}
+
 void iree_clang_tidy_refcount_release_then_call(
     iree_clang_tidy_refcounted_t* resource) {
   iree_clang_tidy_refcount_void_release(resource);

--- a/build_tools/clang_tidy/test/refcount_checks.c
+++ b/build_tools/clang_tidy/test/refcount_checks.c
@@ -269,6 +269,37 @@ void iree_clang_tidy_refcount_release_in_branch_then_use(
   resource->ref_count = 0;
 }
 
+void iree_clang_tidy_refcount_if_else_release_then_use(
+    iree_clang_tidy_refcounted_t* merged_resource, int condition) {
+  if (condition) {
+    iree_clang_tidy_refcount_void_release(merged_resource);
+  } else {
+    iree_clang_tidy_refcount_void_release(merged_resource);
+  }
+  merged_resource->ref_count = 0;
+}
+
+void iree_clang_tidy_refcount_if_else_release_then_release(
+    iree_clang_tidy_refcounted_t* merged_released_resource, int condition) {
+  if (condition) {
+    iree_clang_tidy_refcount_void_release(merged_released_resource);
+  } else {
+    iree_clang_tidy_refcount_void_release(merged_released_resource);
+  }
+  iree_clang_tidy_refcount_void_release(merged_released_resource);
+}
+
+void iree_clang_tidy_refcount_if_else_release_after_retain_then_use(
+    iree_clang_tidy_refcounted_t* retained_merged_resource, int condition) {
+  iree_clang_tidy_refcount_void_retain(retained_merged_resource);
+  if (condition) {
+    iree_clang_tidy_refcount_void_release(retained_merged_resource);
+  } else {
+    iree_clang_tidy_refcount_void_release(retained_merged_resource);
+  }
+  retained_merged_resource->ref_count = 0;
+}
+
 void iree_clang_tidy_refcount_local_counter_release(
     iree_clang_tidy_refcounted_t* resource) {
   iree_atomic_ref_count_t* ref_count = &resource->ref_count;

--- a/build_tools/clang_tidy/test/refcount_checks.c
+++ b/build_tools/clang_tidy/test/refcount_checks.c
@@ -23,6 +23,11 @@ typedef struct iree_clang_tidy_refcounted_t {
   iree_atomic_ref_count_t ref_count;
 } iree_clang_tidy_refcounted_t;
 
+typedef struct iree_clang_tidy_refcounted_misaligned_t {
+  int state;
+  iree_atomic_ref_count_t ref_count;
+} iree_clang_tidy_refcounted_misaligned_t;
+
 typedef struct iree_clang_tidy_refcount_misused_counter_t {
   iree_atomic_ref_count_t pending_submissions;
 } iree_clang_tidy_refcount_misused_counter_t;

--- a/build_tools/clang_tidy/test/refcount_checks.c
+++ b/build_tools/clang_tidy/test/refcount_checks.c
@@ -204,6 +204,35 @@ void iree_clang_tidy_refcount_release_then_replace(
   resource->ref_count = 0;
 }
 
+void iree_clang_tidy_refcount_guarded_release(
+    iree_clang_tidy_refcounted_t* guarded_resource) {
+  if (guarded_resource) {
+    iree_clang_tidy_refcount_void_release(guarded_resource);
+  }
+}
+
+void iree_clang_tidy_refcount_guarded_release_null_comparison(
+    iree_clang_tidy_refcounted_t* null_compared_resource) {
+  if (null_compared_resource != NULL) {
+    iree_clang_tidy_refcount_void_release(null_compared_resource);
+  }
+}
+
+void iree_clang_tidy_refcount_guarded_release_reversed_null_comparison(
+    iree_clang_tidy_refcounted_t* reversed_null_compared_resource) {
+  if (NULL != reversed_null_compared_resource) {
+    iree_clang_tidy_refcount_void_release(reversed_null_compared_resource);
+  }
+}
+
+void iree_clang_tidy_refcount_conditional_release(
+    iree_clang_tidy_refcounted_t* conditionally_released_resource,
+    int condition) {
+  if (condition) {
+    iree_clang_tidy_refcount_void_release(conditionally_released_resource);
+  }
+}
+
 void iree_clang_tidy_refcount_release_in_branch_then_use(
     iree_clang_tidy_refcounted_t* resource, int condition) {
   if (condition) {
@@ -234,4 +263,12 @@ void iree_clang_tidy_refcount_status_release_then_use(
     iree_clang_tidy_refcounted_t* status_released_resource) {
   (void)iree_clang_tidy_virtual_memory_release(status_released_resource);
   iree_clang_tidy_refcount_observe(status_released_resource);
+}
+
+void iree_clang_tidy_refcount_guarded_status_release(
+    iree_clang_tidy_refcounted_t* guarded_status_released_resource) {
+  if (guarded_status_released_resource) {
+    (void)iree_clang_tidy_virtual_memory_release(
+        guarded_status_released_resource);
+  }
 }

--- a/build_tools/clang_tidy/test/refcount_checks_test.py
+++ b/build_tools/clang_tidy/test/refcount_checks_test.py
@@ -72,6 +72,11 @@ class RefCountChecksTest(clang_tidy_test.ClangTidyAssertions):
                 "iree_clang_tidy_refcount_void_release",
                 "reversed_null_compared_resource is null-guarded before "
                 "iree_clang_tidy_refcount_void_release",
+                "merged_resource is dereferenced after "
+                "iree_clang_tidy_refcount_void_release releases it",
+                "merged_released_resource is released by "
+                "iree_clang_tidy_refcount_void_release after "
+                "iree_clang_tidy_refcount_void_release already released it",
                 "[iree-refcount-lifecycle]",
             ],
         )
@@ -92,6 +97,7 @@ class RefCountChecksTest(clang_tidy_test.ClangTidyAssertions):
                 "iree_clang_tidy_refcount_release_then_replace",
                 "conditionally_released_resource",
                 "iree_clang_tidy_refcount_release_in_branch_then_use",
+                "retained_merged_resource",
                 "iree_clang_tidy_refcount_local_counter_release",
                 "iree_clang_tidy_refcount_lookup_retain",
                 "iree_clang_tidy_virtual_memory_release",

--- a/build_tools/clang_tidy/test/refcount_checks_test.py
+++ b/build_tools/clang_tidy/test/refcount_checks_test.py
@@ -37,6 +37,8 @@ class RefCountChecksTest(clang_tidy_test.ClangTidyAssertions):
                 "iree_clang_tidy_refcount_asserting_release "
                 "must be null-safe",
                 "iree_atomic_ref_count_dec return value must be checked",
+                "iree_atomic_ref_count_t field ref_count must be the first "
+                "field in a refcounted object",
                 "iree_atomic_ref_count_t field pending_submissions must model "
                 "object lifetime",
                 "iree_atomic_ref_count_t field queued_callbacks must model "

--- a/build_tools/clang_tidy/test/refcount_checks_test.py
+++ b/build_tools/clang_tidy/test/refcount_checks_test.py
@@ -60,6 +60,12 @@ class RefCountChecksTest(clang_tidy_test.ClangTidyAssertions):
                 "iree_clang_tidy_refcount_void_release releases it",
                 "returned_resource is used after "
                 "iree_clang_tidy_refcount_void_release releases it",
+                "guarded_resource is null-guarded before "
+                "iree_clang_tidy_refcount_void_release",
+                "null_compared_resource is null-guarded before "
+                "iree_clang_tidy_refcount_void_release",
+                "reversed_null_compared_resource is null-guarded before "
+                "iree_clang_tidy_refcount_void_release",
                 "[iree-refcount-lifecycle]",
             ],
         )
@@ -75,11 +81,13 @@ class RefCountChecksTest(clang_tidy_test.ClangTidyAssertions):
                 "iree_clang_tidy_refcount_retain_then_double_release",
                 "iree_clang_tidy_refcount_release_then_clear",
                 "iree_clang_tidy_refcount_release_then_replace",
+                "conditionally_released_resource",
                 "iree_clang_tidy_refcount_release_in_branch_then_use",
                 "iree_clang_tidy_refcount_local_counter_release",
                 "iree_clang_tidy_refcount_lookup_retain",
                 "iree_clang_tidy_virtual_memory_release",
                 "status_released_resource",
+                "guarded_status_released_resource",
                 "side_counter",
             ],
         )

--- a/build_tools/clang_tidy/test/refcount_checks_test.py
+++ b/build_tools/clang_tidy/test/refcount_checks_test.py
@@ -36,6 +36,9 @@ class RefCountChecksTest(clang_tidy_test.ClangTidyAssertions):
                 "refcounted release function "
                 "iree_clang_tidy_refcount_asserting_release "
                 "must be null-safe",
+                "refcounted retain function "
+                "iree_clang_tidy_refcount_unguarded_retain "
+                "must be null-safe",
                 "iree_atomic_ref_count_dec return value must be checked",
                 "iree_atomic_ref_count_t field ref_count must be the first "
                 "field in a refcounted object",
@@ -79,6 +82,8 @@ class RefCountChecksTest(clang_tidy_test.ClangTidyAssertions):
                 "iree_clang_tidy_refcount_void_retain",
                 "refcounted retain/release function "
                 "iree_clang_tidy_refcount_void_release",
+                "iree_clang_tidy_refcount_inline_null_retain",
+                "iree_clang_tidy_refcount_likely_null_retain",
                 "iree_clang_tidy_refcount_early_null_release",
                 "iree_clang_tidy_refcount_inline_null_release",
                 "iree_clang_tidy_refcount_likely_null_release",

--- a/build_tools/clang_tidy/test/refcount_checks_test.py
+++ b/build_tools/clang_tidy/test/refcount_checks_test.py
@@ -50,6 +50,9 @@ class RefCountChecksTest(clang_tidy_test.ClangTidyAssertions):
                 "resource is released by "
                 "iree_clang_tidy_refcount_void_release after "
                 "iree_clang_tidy_refcount_void_release already released it",
+                "retained_resource is retained by "
+                "iree_clang_tidy_refcount_void_retain after "
+                "iree_clang_tidy_refcount_void_release already released it",
                 "resource is used after "
                 "iree_clang_tidy_refcount_void_release releases it",
                 "cast_resource is used after "
@@ -72,6 +75,7 @@ class RefCountChecksTest(clang_tidy_test.ClangTidyAssertions):
         self.assertContainsNone(
             output,
             [
+                "refcounted retain/release function "
                 "iree_clang_tidy_refcount_void_retain",
                 "refcounted retain/release function "
                 "iree_clang_tidy_refcount_void_release",

--- a/libhrx/src/libhrx/allocator.c
+++ b/libhrx/src/libhrx/allocator.c
@@ -10,6 +10,7 @@ hrx_allocator_t hrx_device_allocator(hrx_device_t device) {
 }
 
 void hrx_allocator_retain(hrx_allocator_t allocator) {
+  if (!allocator) return;
   iree_hal_allocator_retain(allocator->hal_allocator);
   hrx_device_retain(allocator->device);
 }

--- a/libhrx/src/libhrx/buffer.c
+++ b/libhrx/src/libhrx/buffer.c
@@ -112,6 +112,7 @@ hrx_status_t hrx_buffer_allocate(hrx_stream_t stream, size_t size,
 }
 
 void hrx_buffer_retain(hrx_buffer_t buffer) {
+  if (!buffer) return;
   iree_hal_buffer_retain(buffer->hal_buffer);
   iree_hal_pool_retain(buffer->hal_pool);
   hrx_device_retain(buffer->device);

--- a/libhrx/src/libhrx/buffer_view.c
+++ b/libhrx/src/libhrx/buffer_view.c
@@ -71,6 +71,7 @@ hrx_status_t hrx_buffer_view_create(hrx_buffer_t buffer, size_t shape_rank,
 }
 
 void hrx_buffer_view_retain(hrx_buffer_view_t buffer_view) {
+  if (!buffer_view) return;
   iree_hal_buffer_view_retain(buffer_view->hal_buffer_view);
   iree_atomic_ref_count_inc(&buffer_view->ref_count);
 }

--- a/libhrx/src/libhrx/device.c
+++ b/libhrx/src/libhrx/device.c
@@ -89,6 +89,7 @@ hrx_status_t hrx_device_get_type(hrx_device_t device,
 }
 
 void hrx_device_retain(hrx_device_t device) {
+  if (!device) return;
   iree_hal_device_retain(device->hal_device);
   iree_hal_device_group_retain(device->hal_device_group);
   iree_atomic_ref_count_inc(&device->ref_count);

--- a/libhrx/src/libhrx/fence.c
+++ b/libhrx/src/libhrx/fence.c
@@ -57,6 +57,7 @@ hrx_status_t hrx_fence_create_at(hrx_semaphore_t semaphore, uint64_t value,
 }
 
 void hrx_fence_retain(hrx_fence_t fence) {
+  if (!fence) return;
   iree_hal_fence_retain(fence->hal_fence);
   iree_atomic_ref_count_inc(&fence->ref_count);
 }

--- a/libhrx/src/libhrx/module.c
+++ b/libhrx/src/libhrx/module.c
@@ -106,6 +106,7 @@ hrx_status_t hrx_module_load_vmfb(hrx_device_t device, const void* vmfb_data,
 }
 
 void hrx_module_retain(hrx_module_t module) {
+  if (!module) return;
   iree_vm_context_retain(module->context);
   iree_vm_module_retain(module->hal_module);
   iree_vm_module_retain(module->bytecode_module);
@@ -161,6 +162,7 @@ hrx_status_t hrx_module_lookup_function(hrx_module_t module, const char* name,
 }
 
 void hrx_function_retain(hrx_function_t function) {
+  if (!function) return;
   hrx_module_retain(function->module);
   iree_atomic_ref_count_inc(&function->ref_count);
 }

--- a/libhrx/src/libhrx/semaphore.c
+++ b/libhrx/src/libhrx/semaphore.c
@@ -36,6 +36,7 @@ hrx_status_t hrx_semaphore_create(hrx_device_t device, uint64_t initial_value,
 }
 
 void hrx_semaphore_retain(hrx_semaphore_t semaphore) {
+  if (!semaphore) return;
   iree_hal_semaphore_retain(semaphore->hal_semaphore);
   hrx_device_retain(semaphore->device);
   iree_atomic_ref_count_inc(&semaphore->ref_count);

--- a/libhrx/src/libhrx/stream.c
+++ b/libhrx/src/libhrx/stream.c
@@ -76,6 +76,7 @@ hrx_status_t hrx_stream_create(hrx_device_t device, uint32_t flags,
 }
 
 void hrx_stream_retain(hrx_stream_t stream) {
+  if (!stream) return;
   hrx_device_retain(stream->device);
   hrx_semaphore_retain(stream->semaphore);
   iree_atomic_ref_count_inc(&stream->ref_count);

--- a/libhrx/src/libhrx/value_list.c
+++ b/libhrx/src/libhrx/value_list.c
@@ -31,6 +31,7 @@ hrx_status_t hrx_value_list_create(size_t capacity, hrx_value_list_t* list) {
 }
 
 void hrx_value_list_retain(hrx_value_list_t list) {
+  if (!list) return;
   iree_vm_list_retain(list->vm_list);
   iree_atomic_ref_count_inc(&list->ref_count);
 }

--- a/runtime/src/iree/async/notification.c
+++ b/runtime/src/iree/async/notification.c
@@ -39,7 +39,9 @@ IREE_API_EXPORT iree_status_t iree_async_notification_create_shared(
 
 IREE_API_EXPORT void iree_async_notification_retain(
     iree_async_notification_t* notification) {
-  iree_atomic_ref_count_inc(&notification->ref_count);
+  if (notification) {
+    iree_atomic_ref_count_inc(&notification->ref_count);
+  }
 }
 
 IREE_API_EXPORT void iree_async_notification_release(

--- a/runtime/src/iree/async/proactor.h
+++ b/runtime/src/iree/async/proactor.h
@@ -723,7 +723,9 @@ iree_async_proactor_run_progress(iree_async_proactor_t* proactor);
 
 // Retains a reference to the proactor.
 static inline void iree_async_proactor_retain(iree_async_proactor_t* proactor) {
-  iree_atomic_ref_count_inc(&proactor->ref_count);
+  if (proactor) {
+    iree_atomic_ref_count_inc(&proactor->ref_count);
+  }
 }
 
 // Releases a reference to the proactor. Destroys when count reaches zero.

--- a/runtime/src/iree/async/region.h
+++ b/runtime/src/iree/async/region.h
@@ -209,7 +209,9 @@ void iree_async_region_destroy(iree_async_region_t* region);
 
 // Retains a reference to the region.
 static inline void iree_async_region_retain(iree_async_region_t* region) {
-  iree_atomic_ref_count_inc(&region->ref_count);
+  if (region) {
+    iree_atomic_ref_count_inc(&region->ref_count);
+  }
 }
 
 // Releases a reference to the region. When the last reference is released,

--- a/runtime/src/iree/async/slab.h
+++ b/runtime/src/iree/async/slab.h
@@ -204,7 +204,9 @@ iree_status_t iree_async_slab_import_dmabuf(int dmabuf_fd, uint64_t offset,
 
 // Retains a reference to the slab.
 static inline void iree_async_slab_retain(iree_async_slab_t* slab) {
-  iree_atomic_ref_count_inc(&slab->ref_count);
+  if (slab) {
+    iree_atomic_ref_count_inc(&slab->ref_count);
+  }
 }
 
 // Releases a reference to the slab. When the last reference is released,

--- a/runtime/src/iree/hal/drivers/cuda/event_pool.c
+++ b/runtime/src/iree/hal/drivers/cuda/event_pool.c
@@ -92,6 +92,9 @@ static inline iree_status_t iree_hal_cuda_event_create(
 }
 
 void iree_hal_cuda_event_retain(iree_hal_cuda_event_t* event) {
+  if (!event) {
+    return;
+  }
   iree_atomic_ref_count_inc(&event->ref_count);
 }
 
@@ -205,6 +208,9 @@ static void iree_hal_cuda_event_pool_free(
 }
 
 void iree_hal_cuda_event_pool_retain(iree_hal_cuda_event_pool_t* event_pool) {
+  if (!event_pool) {
+    return;
+  }
   iree_atomic_ref_count_inc(&event_pool->ref_count);
 }
 

--- a/runtime/src/iree/hal/drivers/hip/event_pool.c
+++ b/runtime/src/iree/hal/drivers/hip/event_pool.c
@@ -114,6 +114,9 @@ static inline iree_status_t iree_hal_hip_event_create(
 }
 
 void iree_hal_hip_event_retain(iree_hal_hip_event_t* event) {
+  if (!event) {
+    return;
+  }
   iree_atomic_ref_count_inc(&event->ref_count);
 }
 
@@ -253,6 +256,9 @@ static void iree_hal_hip_event_pool_free(
 }
 
 void iree_hal_hip_event_pool_retain(iree_hal_hip_event_pool_t* event_pool) {
+  if (!event_pool) {
+    return;
+  }
   iree_atomic_ref_count_inc(&event_pool->ref_count);
 }
 

--- a/runtime/src/iree/hal/drivers/hip/event_semaphore.h
+++ b/runtime/src/iree/hal/drivers/hip/event_semaphore.h
@@ -49,15 +49,7 @@ iree_status_t iree_hal_hip_semaphore_notify_work(
 iree_status_t iree_hal_hip_semaphore_notify_forward_progress_to(
     iree_hal_semaphore_t* base_semaphore, uint64_t value);
 
-// Returns the hip event that needs to be signaled in order
-// for the semaphore to reach a given value.
-// This event *must* have been previously notified for
-// forward progress by iree_hal_hip_semaphore_notify_forward_progress_to.
-// If the return status is iree_ok_status(), and the out_hip_event is NULL,
-// it is because the event has already been signaled, and the result
-// is visible on the host.
-// The refcount for the event is incremented here, and the caller
-// must decrement when no longer needed.
+// Records waits on |stream| for HIP events required to observe |value|.
 iree_status_t iree_hal_hip_semaphore_wait_hip_events(
     iree_hal_semaphore_t* base_semaphore, uint64_t value, hipStream_t stream);
 

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -1496,28 +1496,9 @@ static iree_status_t iree_hal_hip_device_stream_wait_for_semaphores(
        i < wait_semaphore_list.count && iree_status_is_ok(status); ++i) {
     IREE_TRACE_ZONE_BEGIN_NAMED(
         z1, "iree_hal_hip_device_stream_wait_for_semaphores_get_hip_event");
-    iree_hal_hip_event_t* event = NULL;
     status = iree_hal_hip_semaphore_wait_hip_events(
         wait_semaphore_list.semaphores[i],
         wait_semaphore_list.payload_values[i], stream);
-    if (!iree_status_is_ok(status)) {
-      IREE_TRACE_ZONE_END(z1);
-      break;
-    }
-    // If we don't have an event, then we don't have to wait for it since it
-    // has already been signaled on the host.
-    if (!event) {
-      IREE_TRACE_ZONE_END(z1);
-      continue;
-    }
-
-    IREE_TRACE_ZONE_BEGIN_NAMED(
-        z3, "iree_hal_hip_device_stream_wait_for_semaphores_wait_hip_event");
-    status = IREE_HIP_CALL_TO_STATUS(
-        device->hip_symbols,
-        hipStreamWaitEvent(stream, iree_hal_hip_event_handle(event), 0));
-    iree_hal_hip_event_release(event);
-    IREE_TRACE_ZONE_END(z3);
     IREE_TRACE_ZONE_END(z1);
   }
 

--- a/runtime/src/iree/hal/drivers/hip/native_executable.c
+++ b/runtime/src/iree/hal/drivers/hip/native_executable.c
@@ -325,8 +325,9 @@ iree_status_t iree_hal_hip_native_executable_create(
             flatbuffers_string_len(
                 iree_hal_hip_ExportDef_kernel_name_get(export_def)),
             &total_export_name_length))) {
-      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                              "export name storage size overflow");
+      IREE_RETURN_AND_END_ZONE_IF_ERROR(
+          z0, iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                               "export name storage size overflow"));
     }
     IREE_TRACE({
       total_export_info_length += iree_hal_debug_calculate_export_info_size(
@@ -359,13 +360,15 @@ iree_status_t iree_hal_hip_native_executable_create(
           !iree_host_size_checked_add(native_executable_device_info_size,
                                       total_export_info_length,
                                       &native_executable_device_info_size))) {
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "executable storage size overflow");
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                             "executable storage size overflow"));
   }
   if (IREE_UNLIKELY(native_executable_device_info_size >
                     IREE_HOST_SIZE_MAX - iree_max_align_t)) {
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "executable storage size overflow");
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                             "executable storage size overflow"));
   }
   native_executable_device_info_size =
       iree_host_align(native_executable_device_info_size, iree_max_align_t);
@@ -383,8 +386,9 @@ iree_status_t iree_hal_hip_native_executable_create(
                                       &total_size) ||
           !iree_host_size_checked_add(
               total_size, native_executable_device_infos_size, &total_size))) {
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "executable storage size overflow");
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                             "executable storage size overflow"));
   }
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0,

--- a/runtime/src/iree/hal/drivers/hip/stream_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/hip/stream_command_buffer.c
@@ -493,7 +493,6 @@ static iree_status_t iree_hal_hip_stream_command_buffer_dispatch(
     iree_hal_buffer_ref_list_t bindings, iree_hal_dispatch_flags_t flags) {
   iree_hal_hip_stream_command_buffer_t* command_buffer =
       iree_hal_hip_stream_command_buffer_cast(base_command_buffer);
-  IREE_TRACE_ZONE_BEGIN(z0);
 
   // TODO: we can support CUSTOM_DIRECT_ARGUMENTS quite easily here.
   // Static indirect arguments and parameters are also easy (as we can
@@ -509,6 +508,8 @@ static iree_status_t iree_hal_hip_stream_command_buffer_dispatch(
         IREE_STATUS_UNIMPLEMENTED,
         "indirect parameters are not supported in CUDA streams");
   }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
 
   // If any of the workgroup counts are zero, we can skip execution
   // of the kernel. This prevents a 'hipErrorInvalidConfiguration' error when

--- a/runtime/src/iree/vm/module.h
+++ b/runtime/src/iree/vm/module.h
@@ -367,8 +367,11 @@ typedef enum iree_vm_signal_e {
 typedef struct iree_vm_module_t {
   IREE_API_UNSTABLE
 
-  void* self;
+  // Reference count used to manage module lifetime.
   iree_atomic_ref_count_t ref_count;
+
+  // User-defined pointer passed to all module interface functions.
+  void* self;
 
   // Destroys |self| when all references to the module have been released.
   void(IREE_API_PTR* destroy)(void* self);


### PR DESCRIPTION
This expands the repo-owned clang-tidy checks from status lifetime into the IREE C refcount contract. The goal is to make the ownership rules around `iree_atomic_ref_count_t`, `*_retain`, and `*_release` visible to tooling so the common C footguns become presubmit failures instead of review nits or ASAN-only discoveries.

The core position is that `iree_atomic_ref_count_t` is an object-lifetime primitive, not a generic atomic counter. A concrete refcounted object is now expected to anchor its lifetime state with an offset-zero `iree_atomic_ref_count_t ref_count` field, with the VM type-erased reference counter as the existing explicit exception. Additional refcount primitive fields inside refcounted records are treated as synchronization-model drift: queue depths, pending callback counts, and latch state should use explicit atomic integer types that describe the real coordination contract.

The lifecycle API shape is also part of the hard gate. Retain and release helpers that directly mutate an object's refcount return `void`, and both sides of the pair are null-safe. That gives cleanup code one consistent shape: release can be called unconditionally, retain can mirror release at optional ownership boundaries, and local code no longer needs noisy `if (ptr)` wrappers around release calls. The checker rejects those wrappers for direct release statements because they hide the contract in every caller instead of keeping it on the release API.

The largest new behavior is the local release-flow model. A direct one-argument void `*_release(handle)` statement consumes that handle spelling until it is reassigned or until an explicit direct retain edge remains. The check now diagnoses direct dereference, call-argument use, explicit-cast call use, assignment/copy, alias initialization, return, repeated release, and direct retain after the modeled final release. It also merges the narrow branch shape where both arms of an `if/else` directly release the same handle through the same release function. Partial branch releases stay branch-local, which keeps the rule in the zero-noise lane while catching the cleanup shapes that are provably bad in local code.

The branch deliberately stops short of same-function leak inference for create/allocate/retain acquisition paths. IREE has many valid ownership transfers into object fields, operation payloads, wrapper objects, callback state, and VM/HAL container APIs. Without explicit ownership annotations or an interprocedural ownership model, a rule that tries to require every local acquire to release in the same function would confuse legitimate transfer with leak. That work belongs in the next ownership-annotation or whole-program analysis layer rather than in this lexical clang-tidy gate.

The codebase cleanup is the proof that these contracts are enforceable today. `iree_vm_module_t` now places `ref_count` first, matching the concrete-object layout rule instead of relying on the unrelated `IREE_API_UNSTABLE` marker or the `self` pointer location. HRX, async, HIP, and CUDA retain helpers are made null-safe to match their release partners. Existing direct-release flow in the tree was already clean enough that the new local use-after-release and double-release diagnostics land as regression guards rather than a large churn pass.

Running the full configured static-analysis surface with HIP enabled also exposed a few trace-zone issues in the HIP driver. Those fixes are included so the branch keeps the active HIP backend clean under the same clang-tidy presubmit profile: unsupported dispatch validation happens before opening the trace zone, overflow exits inside active zones use the trace-aware return helper, and a stale local HIP event wait path was removed now that the semaphore helper records the stream waits itself. The adjacent HIP semaphore comment now describes the current API instead of the old retained-event handoff.

### Reviewer Notes

- The highest-value review surface is `build_tools/clang_tidy/iree/RefCountChecks.cc`, especially the distinction between structural refcount evidence, suffix-based retain/release contracts, and the intentionally narrow local release-flow model.
- The fixture expansion in `build_tools/clang_tidy/test/refcount_checks.c` defines the intended signal boundary. The positive cases should read as actual ownership mistakes, and the negative cases should stay accepted because they either model an explicit retained edge, a partial branch, reassignment, or a status-returning non-object release API.
- The HRX and async changes are API-contract normalization: retain now mirrors release's null-safety rather than making every caller carry optional-handle guards.
- The HIP trace-zone cleanup is orthogonal to refcounting but belongs in this PR because enabling the active HIP surface under the clang-tidy profile made those existing control-flow hazards visible.
- Lifecycle naming checks for create/destroy, allocate/free, and initialize/deinitialize remain separate work. This PR finishes the refcount ownership layer; naming classification can now proceed without being tangled with the retain/release hard gate.