### PR TITLE
[Infra] Improve clang-tidy lifecycle naming checks

### DIFF
--- a/build_tools/clang_tidy/BUILD.bazel
+++ b/build_tools/clang_tidy/BUILD.bazel
@@ -52,6 +52,8 @@ cc_binary(
     name = "IREEClangTidyPlugin.so",
     srcs = [
         "iree/IreeTidyModule.cc",
+        "iree/LifecycleChecks.cc",
+        "iree/LifecycleChecks.h",
         "iree/RefCountChecks.cc",
         "iree/RefCountChecks.h",
         "iree/SmokeCheck.cc",
@@ -112,6 +114,27 @@ py_test(
     ],
     imports = ["test"],
     main = "test/status_checks_test.py",
+    tags = ["manual"],
+    target_compatible_with = CLANG_TIDY_LLVM_TARGET_COMPATIBLE_WITH,
+)
+
+py_test(
+    name = "lifecycle_checks_test",
+    srcs = [
+        "test/clang_tidy_test.py",
+        "test/lifecycle_checks_test.py",
+    ],
+    args = [
+        "--clang-tidy=$(location @iree_clang_tidy_llvm//:clang-tidy)",
+        "--plugin=$(location :IREEClangTidyPlugin.so)",
+    ],
+    data = [
+        "test/lifecycle_checks.c",
+        ":IREEClangTidyPlugin.so",
+        "@iree_clang_tidy_llvm//:clang-tidy",
+    ],
+    imports = ["test"],
+    main = "test/lifecycle_checks_test.py",
     tags = ["manual"],
     target_compatible_with = CLANG_TIDY_LLVM_TARGET_COMPATIBLE_WITH,
 )

--- a/build_tools/clang_tidy/CMakeLists.txt
+++ b/build_tools/clang_tidy/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(Clang REQUIRED CONFIG)
 
 add_library(IREEClangTidyPlugin MODULE
   iree/IreeTidyModule.cc
+  iree/LifecycleChecks.cc
   iree/RefCountChecks.cc
   iree/SmokeCheck.cc
   iree/StatusChecks.cc
@@ -76,6 +77,15 @@ add_test(
   COMMAND
     Python3::Interpreter
     "${CMAKE_CURRENT_SOURCE_DIR}/test/status_checks_test.py"
+    "--clang-tidy=${CLANG_TIDY_EXECUTABLE}"
+    "--plugin=$<TARGET_FILE:IREEClangTidyPlugin>"
+)
+
+add_test(
+  NAME iree-clang-tidy-lifecycle-checks
+  COMMAND
+    Python3::Interpreter
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/lifecycle_checks_test.py"
     "--clang-tidy=${CLANG_TIDY_EXECUTABLE}"
     "--plugin=$<TARGET_FILE:IREEClangTidyPlugin>"
 )

--- a/build_tools/clang_tidy/README.md
+++ b/build_tools/clang_tidy/README.md
@@ -199,6 +199,46 @@ status transfer helpers, C++ status wrapper constructors, and status observer
 functions. Pure observer expressions such as multiple `iree_status_is_*` checks
 do not transfer ownership and are accepted.
 
+### `iree-lifecycle-naming`
+
+`iree-lifecycle-naming` diagnoses caller-owned output records that use
+`allocate` naming but have a matching `deinitialize` cleanup function:
+
+```c
+iree_status_t iree_tool_temp_file_allocate(
+    iree_string_view_t stem, iree_tool_temp_file_t* out_file);
+void iree_tool_temp_file_deinitialize(iree_tool_temp_file_t* file);
+```
+
+The paired cleanup contract says the caller owns the record storage and the
+function initializes that storage. The acquisition side should use
+`initialize` naming even when initialization creates external resources or
+allocates backing storage:
+
+```c
+iree_status_t iree_tool_temp_file_initialize(
+    iree_string_view_t stem, iree_tool_temp_file_t* out_file);
+void iree_tool_temp_file_deinitialize(iree_tool_temp_file_t* file);
+```
+
+`allocate/free` naming remains the storage-oriented shape for APIs that publish
+heap or pool objects through pointer-to-pointer outputs, allocator operations
+such as buffer allocation, and arena helpers that allocate backing storage into
+descriptors without owning a deinitialize contract.
+
+`initialize` functions that publish a pointer-to-pointer output must name the
+caller-owned storage backing that typed view:
+
+```c
+iree_status_t iree_vm_stack_initialize(
+    iree_byte_span_t storage, iree_vm_invocation_flags_t flags,
+    iree_vm_stack_t** out_stack);
+```
+
+Without an explicit `storage` or `*_storage` parameter, a pointer-to-pointer
+output reads like a callee-owned object factory and should use
+`create/destroy/retain/release` or `allocate/free` naming instead.
+
 ### `iree-refcount-lifecycle`
 
 `iree-refcount-lifecycle` treats `iree_atomic_ref_count_t` as an object

--- a/build_tools/clang_tidy/README.md
+++ b/build_tools/clang_tidy/README.md
@@ -217,6 +217,20 @@ void iree_hal_buffer_retain(iree_hal_buffer_t* buffer);
 void iree_hal_buffer_release(iree_hal_buffer_t* buffer);
 ```
 
+Factories that publish refcounted objects through `out_*` pointer-to-pointer
+parameters use create naming, even when the implementation allocates heap
+storage internally:
+
+```c
+iree_status_t iree_hal_buffer_view_create(
+    iree_hal_buffer_t* buffer,
+    iree_hal_buffer_view_t** out_buffer_view);
+```
+
+`allocate/free` naming is reserved for storage-oriented resources that are not
+themselves refcounted objects, and `initialize/deinitialize` naming is reserved
+for caller-owned storage passed as a single pointer.
+
 Retain and release operations that mutate the reference count return `void`.
 Release functions are null-safe so cleanup code can call them unconditionally
 without adding noisy guards:

--- a/build_tools/clang_tidy/iree/IreeTidyModule.cc
+++ b/build_tools/clang_tidy/iree/IreeTidyModule.cc
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "clang-tidy/ClangTidyModule.h"
+#include "iree/LifecycleChecks.h"
 #include "iree/RefCountChecks.h"
 #include "iree/SmokeCheck.h"
 #include "iree/StatusChecks.h"
@@ -26,6 +27,7 @@ class IreeTidyModule final : public ClangTidyModule {
         "iree-status-transfer-order");
     CheckFactories.registerCheck<DirectGotoCheck>("iree-direct-goto");
     CheckFactories.registerCheck<GuardedReleaseCheck>("iree-guarded-release");
+    CheckFactories.registerCheck<LifecycleNamingCheck>("iree-lifecycle-naming");
     CheckFactories.registerCheck<RefCountLifecycleCheck>(
         "iree-refcount-lifecycle");
     CheckFactories.registerCheck<TestStatusMacroCheck>(

--- a/build_tools/clang_tidy/iree/LifecycleChecks.cc
+++ b/build_tools/clang_tidy/iree/LifecycleChecks.cc
@@ -1,0 +1,219 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/LifecycleChecks.h"
+
+#include <optional>
+#include <string>
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/Type.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace clang::tidy::iree {
+namespace {
+
+bool IsExternalMacroBody(SourceLocation Location,
+                         const SourceManager& SourceManager) {
+  if (!Location.isMacroID()) {
+    return false;
+  }
+  SourceLocation SpellingLocation = SourceManager.getSpellingLoc(Location);
+  if (SourceManager.isInSystemHeader(SpellingLocation)) {
+    return true;
+  }
+  llvm::StringRef Filename = SourceManager.getFilename(SpellingLocation);
+  return Filename.contains("/external/") || Filename.starts_with("external/");
+}
+
+const RecordDecl* RecordDefinition(const RecordDecl* Record) {
+  if (!Record) {
+    return nullptr;
+  }
+  return Record->getDefinition() ? Record->getDefinition() : Record;
+}
+
+const RecordDecl* RecordFromType(QualType Type) {
+  Type = Type.getCanonicalType().getUnqualifiedType();
+  const auto* Record = Type->getAs<RecordType>();
+  return RecordDefinition(Record ? Record->getDecl() : nullptr);
+}
+
+const RecordDecl* CallerOwnedOutParameterRecord(const ParmVarDecl* Parameter) {
+  if (!Parameter || !Parameter->getName().starts_with("out_")) {
+    return nullptr;
+  }
+  QualType Type = Parameter->getType().getCanonicalType().getUnqualifiedType();
+  if (!Type->isPointerType()) {
+    return nullptr;
+  }
+  QualType PointeeType =
+      Type->getPointeeType().getCanonicalType().getUnqualifiedType();
+  if (PointeeType->isPointerType()) {
+    return nullptr;
+  }
+  return RecordFromType(PointeeType);
+}
+
+const RecordDecl* PublishedOutParameterRecord(const ParmVarDecl* Parameter) {
+  if (!Parameter || !Parameter->getName().starts_with("out_")) {
+    return nullptr;
+  }
+  QualType Type = Parameter->getType().getCanonicalType().getUnqualifiedType();
+  if (!Type->isPointerType()) {
+    return nullptr;
+  }
+  QualType PointeeType =
+      Type->getPointeeType().getCanonicalType().getUnqualifiedType();
+  if (!PointeeType->isPointerType()) {
+    return nullptr;
+  }
+  return RecordFromType(PointeeType->getPointeeType());
+}
+
+bool IsStorageParameterName(StringRef Name) {
+  return Name == "storage" || Name.ends_with("_storage");
+}
+
+bool HasStorageParameter(const FunctionDecl* Function) {
+  for (const ParmVarDecl* Parameter : Function->parameters()) {
+    if (IsStorageParameterName(Parameter->getName())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool FirstParameterHasRecordType(const FunctionDecl* Function,
+                                 const RecordDecl* Record) {
+  if (!Function || Function->getNumParams() < 1) {
+    return false;
+  }
+  QualType Type = Function->getParamDecl(0)
+                      ->getType()
+                      .getCanonicalType()
+                      .getUnqualifiedType();
+  if (!Type->isPointerType()) {
+    return false;
+  }
+  const RecordDecl* ParameterRecord = RecordFromType(Type->getPointeeType());
+  return ParameterRecord && ParameterRecord == RecordDefinition(Record);
+}
+
+const FunctionDecl* MatchingDeinitializeFunction(const FunctionDecl* Function,
+                                                 const RecordDecl* Record) {
+  if (!Function || !Record || !Function->getName().ends_with("_allocate")) {
+    return nullptr;
+  }
+  std::string DeinitializeName =
+      (Function->getName().drop_back(StringRef("_allocate").size()) +
+       "_deinitialize")
+          .str();
+  for (const Decl* Declaration : Function->getDeclContext()->decls()) {
+    const auto* Candidate = dyn_cast<FunctionDecl>(Declaration);
+    if (!Candidate || Candidate->getName() != DeinitializeName ||
+        !Candidate->getReturnType()->isVoidType()) {
+      continue;
+    }
+    if (FirstParameterHasRecordType(Candidate, Record)) {
+      return Candidate;
+    }
+  }
+  return nullptr;
+}
+
+struct CallerOwnedAllocateOutParameter {
+  const ParmVarDecl* Parameter = nullptr;
+  const FunctionDecl* DeinitializeFunction = nullptr;
+};
+
+std::optional<CallerOwnedAllocateOutParameter>
+CallerOwnedAllocateOutParameterFor(const FunctionDecl* Function) {
+  if (!Function || !Function->getName().ends_with("_allocate")) {
+    return std::nullopt;
+  }
+  for (const ParmVarDecl* Parameter : Function->parameters()) {
+    const RecordDecl* Record = CallerOwnedOutParameterRecord(Parameter);
+    const FunctionDecl* DeinitializeFunction =
+        MatchingDeinitializeFunction(Function, Record);
+    if (DeinitializeFunction) {
+      return CallerOwnedAllocateOutParameter{
+          .Parameter = Parameter,
+          .DeinitializeFunction = DeinitializeFunction,
+      };
+    }
+  }
+  return std::nullopt;
+}
+
+const ParmVarDecl* InitializePublishedOutParameterWithoutStorage(
+    const FunctionDecl* Function) {
+  if (!Function || !Function->getName().ends_with("_initialize") ||
+      HasStorageParameter(Function)) {
+    return nullptr;
+  }
+  for (const ParmVarDecl* Parameter : Function->parameters()) {
+    if (PublishedOutParameterRecord(Parameter)) {
+      return Parameter;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+LifecycleNamingCheck::LifecycleNamingCheck(StringRef Name,
+                                           ClangTidyContext* Context)
+    : ClangTidyCheck(Name, Context) {}
+
+void LifecycleNamingCheck::registerMatchers(ast_matchers::MatchFinder* Finder) {
+  using namespace ast_matchers;
+  Finder->addMatcher(
+      functionDecl(isDefinition(), unless(isExpansionInSystemHeader()))
+          .bind("function"),
+      this);
+}
+
+void LifecycleNamingCheck::check(
+    const ast_matchers::MatchFinder::MatchResult& Result) {
+  const auto* Function = Result.Nodes.getNodeAs<FunctionDecl>("function");
+  if (!Function) {
+    return;
+  }
+  const SourceManager& SourceManager = *Result.SourceManager;
+  if (IsExternalMacroBody(Function->getLocation(), SourceManager)) {
+    return;
+  }
+  std::optional<CallerOwnedAllocateOutParameter> OutParameter =
+      CallerOwnedAllocateOutParameterFor(Function);
+  if (OutParameter) {
+    SourceLocation Location =
+        SourceManager.getExpansionLoc(OutParameter->Parameter->getLocation());
+    diag(Location,
+         "caller-owned output %0 from %1 uses allocate naming but is cleaned "
+         "up by %2; use initialize/deinitialize naming")
+        << OutParameter->Parameter->getName() << Function->getName()
+        << OutParameter->DeinitializeFunction->getName();
+    return;
+  }
+
+  const ParmVarDecl* PublishedOutParameter =
+      InitializePublishedOutParameterWithoutStorage(Function);
+  if (!PublishedOutParameter) {
+    return;
+  }
+  SourceLocation Location =
+      SourceManager.getExpansionLoc(PublishedOutParameter->getLocation());
+  diag(Location,
+       "pointer-to-pointer output %0 from %1 uses initialize naming without "
+       "an explicit storage parameter")
+      << PublishedOutParameter->getName() << Function->getName();
+}
+
+}  // namespace clang::tidy::iree

--- a/build_tools/clang_tidy/iree/LifecycleChecks.h
+++ b/build_tools/clang_tidy/iree/LifecycleChecks.h
@@ -1,0 +1,24 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BUILD_TOOLS_CLANG_TIDY_IREE_LIFECYCLE_CHECKS_H_
+#define IREE_BUILD_TOOLS_CLANG_TIDY_IREE_LIFECYCLE_CHECKS_H_
+
+#include "clang-tidy/ClangTidyCheck.h"
+
+namespace clang::tidy::iree {
+
+class LifecycleNamingCheck final : public ClangTidyCheck {
+ public:
+  LifecycleNamingCheck(StringRef Name, ClangTidyContext* Context);
+
+  void registerMatchers(ast_matchers::MatchFinder* Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult& Result) override;
+};
+
+}  // namespace clang::tidy::iree
+
+#endif  // IREE_BUILD_TOOLS_CLANG_TIDY_IREE_LIFECYCLE_CHECKS_H_

--- a/build_tools/clang_tidy/iree/RefCountChecks.cc
+++ b/build_tools/clang_tidy/iree/RefCountChecks.cc
@@ -187,6 +187,10 @@ bool IsRefCountLifecycleFunctionName(StringRef FunctionName) {
          FunctionName.ends_with("_release");
 }
 
+bool IsAllocateFunctionName(StringRef FunctionName) {
+  return FunctionName.ends_with("_allocate");
+}
+
 bool IsReleaseFunctionName(StringRef FunctionName) {
   return FunctionName.ends_with("_release");
 }
@@ -250,6 +254,74 @@ bool IsRefCountAnchorField(const FieldDecl* Field,
 bool IsRefCountAnchoredRecord(const RecordDecl* Record,
                               const SourceManager& SourceManager) {
   return IsRefCountAnchorField(FirstField(Record), SourceManager);
+}
+
+const RecordDecl* RecordDefinition(const RecordDecl* Record) {
+  if (!Record) {
+    return nullptr;
+  }
+  return Record->getDefinition() ? Record->getDefinition() : Record;
+}
+
+const RecordDecl* RecordFromType(QualType Type) {
+  Type = Type.getCanonicalType().getUnqualifiedType();
+  const auto* Record = Type->getAs<RecordType>();
+  return RecordDefinition(Record ? Record->getDecl() : nullptr);
+}
+
+bool IsRefCountAnchoredRecordOrBase(
+    const RecordDecl* Record, const SourceManager& SourceManager,
+    llvm::SmallPtrSetImpl<const RecordDecl*>& VisitedRecords) {
+  Record = RecordDefinition(Record);
+  if (!Record || !VisitedRecords.insert(Record).second) {
+    return false;
+  }
+  const FieldDecl* First = FirstField(Record);
+  if (!First) {
+    return false;
+  }
+  if (IsRefCountAnchorField(First, SourceManager)) {
+    return true;
+  }
+  const RecordDecl* BaseRecord = RecordFromType(First->getType());
+  return BaseRecord && IsRefCountAnchoredRecordOrBase(BaseRecord, SourceManager,
+                                                      VisitedRecords);
+}
+
+bool IsRefCountAnchoredRecordOrBase(const RecordDecl* Record,
+                                    const SourceManager& SourceManager) {
+  llvm::SmallPtrSet<const RecordDecl*, 4> VisitedRecords;
+  return IsRefCountAnchoredRecordOrBase(Record, SourceManager, VisitedRecords);
+}
+
+const RecordDecl* OutParameterPointeeRecord(const ParmVarDecl* Parameter) {
+  if (!Parameter || !Parameter->getName().starts_with("out_")) {
+    return nullptr;
+  }
+  QualType Type = Parameter->getType().getCanonicalType().getUnqualifiedType();
+  if (!Type->isPointerType()) {
+    return nullptr;
+  }
+  QualType PointeeType =
+      Type->getPointeeType().getCanonicalType().getUnqualifiedType();
+  if (!PointeeType->isPointerType()) {
+    return nullptr;
+  }
+  return RecordFromType(PointeeType->getPointeeType());
+}
+
+const ParmVarDecl* RefCountedAllocateOutParameter(
+    const FunctionDecl* Function, const SourceManager& SourceManager) {
+  if (!Function || !IsAllocateFunctionName(Function->getName())) {
+    return nullptr;
+  }
+  for (const ParmVarDecl* Parameter : Function->parameters()) {
+    const RecordDecl* Record = OutParameterPointeeRecord(Parameter);
+    if (Record && IsRefCountAnchoredRecordOrBase(Record, SourceManager)) {
+      return Parameter;
+    }
+  }
+  return nullptr;
 }
 
 enum class RefCountFieldDiagnostic {
@@ -935,6 +1007,14 @@ void RefCountLifecycleCheck::check(
   }
   const SourceManager& SourceManager = *Result.SourceManager;
   if (IsExternalMacroBody(Function->getLocation(), SourceManager)) {
+    return;
+  }
+  if (const ParmVarDecl* Parameter =
+          RefCountedAllocateOutParameter(Function, SourceManager)) {
+    diag(SourceManager.getExpansionLoc(Parameter->getLocation()),
+         "refcounted object factory %0 publishes %1 through allocate naming; "
+         "use create/destroy/retain/release naming")
+        << Function->getName() << Parameter->getName();
     return;
   }
   const Stmt* Body = Function->getBody();

--- a/build_tools/clang_tidy/test/lifecycle_checks.c
+++ b/build_tools/clang_tidy/test/lifecycle_checks.c
@@ -1,0 +1,77 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+typedef int iree_status_t;
+
+typedef struct iree_clang_tidy_in_place_resource_t {
+  int value;
+} iree_clang_tidy_in_place_resource_t;
+
+typedef struct iree_clang_tidy_heap_resource_t {
+  int value;
+} iree_clang_tidy_heap_resource_t;
+
+iree_status_t iree_ok_status(void);
+
+iree_status_t iree_clang_tidy_in_place_resource_allocate(
+    int value, iree_clang_tidy_in_place_resource_t* out_resource) {
+  out_resource->value = value;
+  return iree_ok_status();
+}
+
+void iree_clang_tidy_in_place_resource_deinitialize(
+    iree_clang_tidy_in_place_resource_t* resource) {
+  resource->value = 0;
+}
+
+iree_status_t iree_clang_tidy_in_place_resource_initialize(
+    int value, iree_clang_tidy_in_place_resource_t* out_resource) {
+  out_resource->value = value;
+  return iree_ok_status();
+}
+
+iree_status_t iree_clang_tidy_heap_resource_allocate(
+    iree_clang_tidy_heap_resource_t** out_resource) {
+  (void)out_resource;
+  return iree_ok_status();
+}
+
+void iree_clang_tidy_heap_resource_free(
+    iree_clang_tidy_heap_resource_t* resource) {
+  (void)resource;
+}
+
+iree_status_t iree_clang_tidy_arena_bitset_allocate(
+    int word_count, iree_clang_tidy_in_place_resource_t* out_bitset) {
+  out_bitset->value = word_count;
+  return iree_ok_status();
+}
+
+void iree_clang_tidy_other_resource_deinitialize(
+    iree_clang_tidy_heap_resource_t* resource) {
+  (void)resource;
+}
+
+iree_status_t iree_clang_tidy_view_initialize(
+    iree_clang_tidy_heap_resource_t** out_resource) {
+  (void)out_resource;
+  return iree_ok_status();
+}
+
+iree_status_t iree_clang_tidy_view_with_storage_initialize(
+    void* storage, iree_clang_tidy_heap_resource_t** out_resource) {
+  (void)storage;
+  (void)out_resource;
+  return iree_ok_status();
+}
+
+iree_status_t iree_clang_tidy_view_with_named_storage_initialize(
+    iree_clang_tidy_in_place_resource_t* out_storage,
+    iree_clang_tidy_heap_resource_t** out_resource) {
+  (void)out_storage;
+  (void)out_resource;
+  return iree_ok_status();
+}

--- a/build_tools/clang_tidy/test/lifecycle_checks_test.py
+++ b/build_tools/clang_tidy/test/lifecycle_checks_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import unittest
+
+import clang_tidy_test
+
+_ARGS = clang_tidy_test.parse_arguments()
+
+
+class LifecycleChecksTest(clang_tidy_test.ClangTidyAssertions):
+    def test_lifecycle_naming_classifies_caller_owned_storage(self):
+        output = clang_tidy_test.run_clang_tidy(
+            clang_tidy=_ARGS.clang_tidy,
+            plugin=_ARGS.plugin,
+            checks="-*,iree-lifecycle-naming",
+            source=clang_tidy_test.source_path(__file__, "lifecycle_checks.c"),
+            compiler_args=["-std=gnu11"],
+        )
+        self.assertContainsAll(
+            output,
+            [
+                "caller-owned output out_resource from "
+                "iree_clang_tidy_in_place_resource_allocate uses allocate "
+                "naming but is cleaned up by "
+                "iree_clang_tidy_in_place_resource_deinitialize",
+                "pointer-to-pointer output out_resource from "
+                "iree_clang_tidy_view_initialize uses initialize naming "
+                "without an explicit storage parameter",
+                "[iree-lifecycle-naming]",
+            ],
+        )
+        self.assertContainsNone(
+            output,
+            [
+                "iree_clang_tidy_in_place_resource_initialize",
+                "iree_clang_tidy_heap_resource_allocate",
+                "iree_clang_tidy_arena_bitset_allocate",
+                "iree_clang_tidy_other_resource_deinitialize",
+                "iree_clang_tidy_view_with_storage_initialize",
+                "iree_clang_tidy_view_with_named_storage_initialize",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build_tools/clang_tidy/test/refcount_checks.c
+++ b/build_tools/clang_tidy/test/refcount_checks.c
@@ -23,6 +23,20 @@ typedef struct iree_clang_tidy_refcounted_t {
   iree_atomic_ref_count_t ref_count;
 } iree_clang_tidy_refcounted_t;
 
+typedef struct iree_clang_tidy_refcounted_base_t {
+  iree_atomic_ref_count_t ref_count;
+  const void* vtable;
+} iree_clang_tidy_refcounted_base_t;
+
+typedef struct iree_clang_tidy_refcounted_with_base_t {
+  iree_clang_tidy_refcounted_base_t resource;
+  int payload;
+} iree_clang_tidy_refcounted_with_base_t;
+
+typedef struct iree_clang_tidy_plain_allocated_t {
+  int payload;
+} iree_clang_tidy_plain_allocated_t;
+
 typedef struct iree_clang_tidy_refcounted_misaligned_t {
   int state;
   iree_atomic_ref_count_t ref_count;
@@ -45,6 +59,42 @@ typedef struct iree_clang_tidy_not_refcount_anchored_t {
 void iree_atomic_ref_count_inc(iree_atomic_ref_count_t* ref_count);
 int iree_atomic_ref_count_dec(iree_atomic_ref_count_t* ref_count);
 iree_status_t iree_ok_status(void);
+
+iree_status_t iree_clang_tidy_refcounted_create(
+    iree_clang_tidy_refcounted_t** out_resource) {
+  (void)out_resource;
+  return iree_ok_status();
+}
+
+iree_status_t iree_clang_tidy_refcounted_allocate(
+    iree_clang_tidy_refcounted_t** out_resource) {
+  (void)out_resource;
+  return iree_ok_status();
+}
+
+iree_status_t iree_clang_tidy_refcounted_with_base_allocate(
+    iree_clang_tidy_refcounted_with_base_t** out_resource) {
+  (void)out_resource;
+  return iree_ok_status();
+}
+
+iree_status_t iree_clang_tidy_plain_allocate(
+    iree_clang_tidy_plain_allocated_t** out_resource) {
+  (void)out_resource;
+  return iree_ok_status();
+}
+
+iree_status_t iree_clang_tidy_refcounted_output_name_ignored_allocate(
+    iree_clang_tidy_refcounted_t** resource) {
+  (void)resource;
+  return iree_ok_status();
+}
+
+iree_status_t iree_clang_tidy_refcounted_initialize(
+    iree_clang_tidy_refcounted_t* out_resource) {
+  (void)out_resource;
+  return iree_ok_status();
+}
 
 iree_status_t iree_clang_tidy_refcount_status_retain(
     iree_clang_tidy_refcounted_t* resource) {

--- a/build_tools/clang_tidy/test/refcount_checks_test.py
+++ b/build_tools/clang_tidy/test/refcount_checks_test.py
@@ -46,6 +46,12 @@ class RefCountChecksTest(clang_tidy_test.ClangTidyAssertions):
                 "object lifetime",
                 "iree_atomic_ref_count_t field queued_callbacks must model "
                 "object lifetime",
+                "refcounted object factory "
+                "iree_clang_tidy_refcounted_allocate publishes "
+                "out_resource through allocate naming",
+                "refcounted object factory "
+                "iree_clang_tidy_refcounted_with_base_allocate publishes "
+                "out_resource through allocate naming",
                 "resource is dereferenced after "
                 "iree_clang_tidy_refcount_void_release releases it",
                 "resources is dereferenced after "
@@ -100,6 +106,10 @@ class RefCountChecksTest(clang_tidy_test.ClangTidyAssertions):
                 "retained_merged_resource",
                 "iree_clang_tidy_refcount_local_counter_release",
                 "iree_clang_tidy_refcount_lookup_retain",
+                "iree_clang_tidy_refcounted_create",
+                "iree_clang_tidy_plain_allocate",
+                "iree_clang_tidy_refcounted_output_name_ignored_allocate",
+                "iree_clang_tidy_refcounted_initialize",
                 "iree_clang_tidy_virtual_memory_release",
                 "status_released_resource",
                 "guarded_status_released_resource",

--- a/loom/src/loom/target/tool/llvm.c
+++ b/loom/src/loom/target/tool/llvm.c
@@ -396,7 +396,7 @@ typedef struct loom_llvm_temp_file_t {
   char path[MAX_PATH];
 } loom_llvm_temp_file_t;
 
-static iree_status_t loom_llvm_temp_file_allocate(
+static iree_status_t loom_llvm_temp_file_initialize(
     const char* prefix, loom_llvm_temp_file_t* out_file) {
   memset(out_file, 0, sizeof(*out_file));
   char temp_directory[MAX_PATH] = {0};
@@ -664,7 +664,7 @@ typedef struct loom_llvm_temp_file_t {
   char path[4096];
 } loom_llvm_temp_file_t;
 
-static iree_status_t loom_llvm_temp_file_allocate(
+static iree_status_t loom_llvm_temp_file_initialize(
     const char* stem, loom_llvm_temp_file_t* out_file) {
   memset(out_file, 0, sizeof(*out_file));
   int length =
@@ -801,7 +801,7 @@ typedef struct loom_llvm_temp_file_t {
   uint8_t unused;
 } loom_llvm_temp_file_t;
 
-static iree_status_t loom_llvm_temp_file_allocate(
+static iree_status_t loom_llvm_temp_file_initialize(
     const char* stem, loom_llvm_temp_file_t* out_file) {
   (void)stem;
   (void)out_file;
@@ -948,7 +948,7 @@ iree_status_t loom_llvm_tool_disassemble_bitcode(
   *out_text = (loom_llvm_tool_output_t){0};
 
   loom_llvm_temp_file_t input_file;
-  iree_status_t status = loom_llvm_temp_file_allocate("bc", &input_file);
+  iree_status_t status = loom_llvm_temp_file_initialize("bc", &input_file);
   if (iree_status_is_ok(status)) {
     status = iree_io_file_contents_write(loom_llvm_temp_file_path(&input_file),
                                          bitcode, allocator);
@@ -1053,9 +1053,9 @@ static iree_status_t loom_llvm_tool_run_bytes_to_file_output(
   loom_llvm_temp_file_t input_file = {0};
   loom_llvm_temp_file_t output_file = {0};
   iree_status_t status =
-      loom_llvm_temp_file_allocate(input_suffix, &input_file);
+      loom_llvm_temp_file_initialize(input_suffix, &input_file);
   if (iree_status_is_ok(status)) {
-    status = loom_llvm_temp_file_allocate(output_suffix, &output_file);
+    status = loom_llvm_temp_file_initialize(output_suffix, &output_file);
   }
   if (iree_status_is_ok(status)) {
     status = iree_io_file_contents_write(loom_llvm_temp_file_path(&input_file),
@@ -1174,7 +1174,7 @@ iree_status_t loom_llvm_tool_disassemble_object(
   *out_text = (loom_llvm_tool_output_t){0};
 
   loom_llvm_temp_file_t input_file = {0};
-  iree_status_t status = loom_llvm_temp_file_allocate("obj", &input_file);
+  iree_status_t status = loom_llvm_temp_file_initialize("obj", &input_file);
   if (iree_status_is_ok(status)) {
     status = iree_io_file_contents_write(loom_llvm_temp_file_path(&input_file),
                                          object, allocator);

--- a/loom/src/loom/target/tool/process.c
+++ b/loom/src/loom/target/tool/process.c
@@ -669,8 +669,8 @@ iree_string_view_t loom_tool_temp_file_path(const loom_tool_temp_file_t* file) {
 
 #if defined(IREE_PLATFORM_WINDOWS)
 
-iree_status_t loom_tool_temp_file_allocate(iree_string_view_t stem,
-                                           loom_tool_temp_file_t* out_file) {
+iree_status_t loom_tool_temp_file_initialize(iree_string_view_t stem,
+                                             loom_tool_temp_file_t* out_file) {
   memset(out_file, 0, sizeof(*out_file));
 
   char stem_buffer[32] = {0};
@@ -706,8 +706,8 @@ void loom_tool_temp_file_deinitialize(loom_tool_temp_file_t* file) {
 
 #elif LOOM_TOOL_PROCESS_POSIX
 
-iree_status_t loom_tool_temp_file_allocate(iree_string_view_t stem,
-                                           loom_tool_temp_file_t* out_file) {
+iree_status_t loom_tool_temp_file_initialize(iree_string_view_t stem,
+                                             loom_tool_temp_file_t* out_file) {
   memset(out_file, 0, sizeof(*out_file));
 
   char stem_buffer[32] = {0};
@@ -751,8 +751,8 @@ void loom_tool_temp_file_deinitialize(loom_tool_temp_file_t* file) {
 
 #else
 
-iree_status_t loom_tool_temp_file_allocate(iree_string_view_t stem,
-                                           loom_tool_temp_file_t* out_file) {
+iree_status_t loom_tool_temp_file_initialize(iree_string_view_t stem,
+                                             loom_tool_temp_file_t* out_file) {
   (void)stem;
   memset(out_file, 0, sizeof(*out_file));
   return iree_make_status(

--- a/loom/src/loom/target/tool/process.h
+++ b/loom/src/loom/target/tool/process.h
@@ -68,10 +68,10 @@ iree_status_t loom_tool_process_run(iree_string_view_t executable_path,
                                     iree_allocator_t allocator,
                                     loom_tool_process_result_t* out_result);
 
-// Allocates a temporary filesystem path and creates an empty file there. The
+// Initializes a temporary filesystem path and creates an empty file there. The
 // caller may rewrite the file before passing the path to a tool.
-iree_status_t loom_tool_temp_file_allocate(iree_string_view_t stem,
-                                           loom_tool_temp_file_t* out_file);
+iree_status_t loom_tool_temp_file_initialize(iree_string_view_t stem,
+                                             loom_tool_temp_file_t* out_file);
 
 // Returns the current filesystem path for |file|.
 iree_string_view_t loom_tool_temp_file_path(const loom_tool_temp_file_t* file);

--- a/loom/src/loom/target/tool/spirv.c
+++ b/loom/src/loom/target/tool/spirv.c
@@ -188,7 +188,7 @@ static iree_status_t loom_spirv_tool_write_temp_binary(
     iree_const_byte_span_t binary, iree_allocator_t allocator,
     loom_tool_temp_file_t* out_file) {
   IREE_RETURN_IF_ERROR(
-      loom_tool_temp_file_allocate(IREE_SV("loom-spirv"), out_file));
+      loom_tool_temp_file_initialize(IREE_SV("loom-spirv"), out_file));
   iree_status_t status = iree_io_file_contents_write(
       loom_tool_temp_file_path(out_file), binary, allocator);
   if (!iree_status_is_ok(status)) {

--- a/loom/src/loom/target/tool/wasm.c
+++ b/loom/src/loom/target/tool/wasm.c
@@ -167,7 +167,7 @@ static iree_status_t loom_wasm_tool_write_temp_binary(
     iree_const_byte_span_t binary, iree_allocator_t allocator,
     loom_tool_temp_file_t* out_file) {
   IREE_RETURN_IF_ERROR(
-      loom_tool_temp_file_allocate(IREE_SV("loom-wasm"), out_file));
+      loom_tool_temp_file_initialize(IREE_SV("loom-wasm"), out_file));
   iree_status_t status = iree_io_file_contents_write(
       loom_tool_temp_file_path(out_file), binary, allocator);
   if (!iree_status_is_ok(status)) {

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -992,7 +992,7 @@ iree_hal_amdgpu_executable_const_cast(const iree_hal_executable_t* base_value) {
   return (const iree_hal_amdgpu_executable_t*)base_value;
 }
 
-static iree_status_t iree_hal_amdgpu_executable_allocate(
+static iree_status_t iree_hal_amdgpu_executable_create_empty(
     iree_hal_device_t* device, const iree_hal_amdgpu_libhsa_t* libhsa,
     const iree_hal_amdgpu_topology_t* topology,
     const iree_hal_amdgpu_queue_affinity_physical_device_set_t*
@@ -1424,7 +1424,7 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
 
   iree_hal_amdgpu_executable_t* executable = NULL;
   if (iree_status_is_ok(status)) {
-    status = iree_hal_amdgpu_executable_allocate(
+    status = iree_hal_amdgpu_executable_create_empty(
         device, libhsa, topology, physical_devices,
         metadata_counts.export_count, host_allocator, &executable);
   }

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -606,7 +606,7 @@ iree_status_t iree_hal_cuda_device_create(
 
   iree_hal_cuda_event_pool_t* device_event_pool = NULL;
   if (iree_status_is_ok(status)) {
-    status = iree_hal_cuda_event_pool_allocate(
+    status = iree_hal_cuda_event_pool_create(
         cuda_symbols, params->event_pool_capacity, host_allocator,
         &device_event_pool);
   }

--- a/runtime/src/iree/hal/drivers/cuda/event_pool.c
+++ b/runtime/src/iree/hal/drivers/cuda/event_pool.c
@@ -148,7 +148,7 @@ struct iree_hal_cuda_event_pool_t {
 static void iree_hal_cuda_event_pool_free(
     iree_hal_cuda_event_pool_t* event_pool);
 
-iree_status_t iree_hal_cuda_event_pool_allocate(
+iree_status_t iree_hal_cuda_event_pool_create(
     const iree_hal_cuda_dynamic_symbols_t* symbols,
     iree_host_size_t available_capacity, iree_allocator_t host_allocator,
     iree_hal_cuda_event_pool_t** out_event_pool) {

--- a/runtime/src/iree/hal/drivers/cuda/event_pool.h
+++ b/runtime/src/iree/hal/drivers/cuda/event_pool.h
@@ -47,11 +47,11 @@ void iree_hal_cuda_event_release(iree_hal_cuda_event_t* event);
 // Thread-safe; multiple threads may acquire and release events from the pool.
 typedef struct iree_hal_cuda_event_pool_t iree_hal_cuda_event_pool_t;
 
-// Allocates a new event pool with up to |available_capacity| events.
+// Creates a new event pool with up to |available_capacity| events.
 //
 // Extra events requested beyond the capability are directly created and
 // destroyed without pooling.
-iree_status_t iree_hal_cuda_event_pool_allocate(
+iree_status_t iree_hal_cuda_event_pool_create(
     const iree_hal_cuda_dynamic_symbols_t* symbols,
     iree_host_size_t available_capacity, iree_allocator_t host_allocator,
     iree_hal_cuda_event_pool_t** out_event_pool);

--- a/runtime/src/iree/hal/drivers/hip/cleanup_thread.c
+++ b/runtime/src/iree/hal/drivers/hip/cleanup_thread.c
@@ -92,7 +92,7 @@ static int iree_hal_hip_cleanup_thread_main(void* param) {
   return 0;
 }
 
-iree_status_t iree_hal_hip_cleanup_thread_initialize(
+iree_status_t iree_hal_hip_cleanup_thread_allocate(
     const iree_hal_hip_dynamic_symbols_t* symbols,
     iree_allocator_t host_allocator,
     iree_hal_hip_cleanup_thread_t** out_thread) {
@@ -129,8 +129,7 @@ iree_status_t iree_hal_hip_cleanup_thread_initialize(
   return status;
 }
 
-void iree_hal_hip_cleanup_thread_deinitialize(
-    iree_hal_hip_cleanup_thread_t* thread) {
+void iree_hal_hip_cleanup_thread_free(iree_hal_hip_cleanup_thread_t* thread) {
   if (!thread) return;
   IREE_TRACE_ZONE_BEGIN(z0);
 

--- a/runtime/src/iree/hal/drivers/hip/cleanup_thread.h
+++ b/runtime/src/iree/hal/drivers/hip/cleanup_thread.h
@@ -17,15 +17,14 @@ typedef struct iree_hal_hip_event_t iree_hal_hip_event_t;
 typedef iree_status_t (*iree_hal_hip_cleanup_callback_t)(
     void* user_data, iree_hal_hip_event_t* event, iree_status_t status);
 
-// Initializes the cleanup thread for HIP driver.
-iree_status_t iree_hal_hip_cleanup_thread_initialize(
+// Allocates the cleanup thread for HIP driver.
+iree_status_t iree_hal_hip_cleanup_thread_allocate(
     const iree_hal_hip_dynamic_symbols_t* symbols,
     iree_allocator_t host_allocator,
     iree_hal_hip_cleanup_thread_t** out_thread);
 
-// Deinitializes the cleanup thread for HIP driver.
-void iree_hal_hip_cleanup_thread_deinitialize(
-    iree_hal_hip_cleanup_thread_t* thread);
+// Frees the cleanup thread for HIP driver.
+void iree_hal_hip_cleanup_thread_free(iree_hal_hip_cleanup_thread_t* thread);
 
 // Adds a pending cleanup to the thread.
 //

--- a/runtime/src/iree/hal/drivers/hip/dispatch_thread.c
+++ b/runtime/src/iree/hal/drivers/hip/dispatch_thread.c
@@ -85,7 +85,7 @@ static int iree_hal_hip_dispatch_thread_main(void* param) {
   return 0;
 }
 
-iree_status_t iree_hal_hip_dispatch_thread_initialize(
+iree_status_t iree_hal_hip_dispatch_thread_allocate(
     iree_allocator_t host_allocator,
     iree_hal_hip_dispatch_thread_t** out_thread) {
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -121,8 +121,7 @@ iree_status_t iree_hal_hip_dispatch_thread_initialize(
   return status;
 }
 
-void iree_hal_hip_dispatch_thread_deinitialize(
-    iree_hal_hip_dispatch_thread_t* thread) {
+void iree_hal_hip_dispatch_thread_free(iree_hal_hip_dispatch_thread_t* thread) {
   if (!thread) {
     return;
   }

--- a/runtime/src/iree/hal/drivers/hip/dispatch_thread.h
+++ b/runtime/src/iree/hal/drivers/hip/dispatch_thread.h
@@ -34,14 +34,13 @@ typedef struct iree_hal_hip_event_t iree_hal_hip_event_t;
 typedef iree_status_t (*iree_hal_hip_dispatch_callback_t)(void* user_data,
                                                           iree_status_t status);
 
-// Initializes the dispatch thread for HIP driver.
-iree_status_t iree_hal_hip_dispatch_thread_initialize(
+// Allocates the dispatch thread for HIP driver.
+iree_status_t iree_hal_hip_dispatch_thread_allocate(
     iree_allocator_t host_allocator,
     iree_hal_hip_dispatch_thread_t** out_thread);
 
-// Deinitializes the dispatch thread for HIP driver.
-void iree_hal_hip_dispatch_thread_deinitialize(
-    iree_hal_hip_dispatch_thread_t* thread);
+// Frees the dispatch thread for HIP driver.
+void iree_hal_hip_dispatch_thread_free(iree_hal_hip_dispatch_thread_t* thread);
 
 // Adds a dispatch to the thread, which will be executed
 // in order.

--- a/runtime/src/iree/hal/drivers/hip/event_pool.c
+++ b/runtime/src/iree/hal/drivers/hip/event_pool.c
@@ -180,7 +180,7 @@ struct iree_hal_hip_event_pool_t {
 
 static void iree_hal_hip_event_pool_free(iree_hal_hip_event_pool_t* event_pool);
 
-iree_status_t iree_hal_hip_event_pool_allocate(
+iree_status_t iree_hal_hip_event_pool_create(
     const iree_hal_hip_dynamic_symbols_t* symbols,
     iree_host_size_t available_capacity, iree_allocator_t host_allocator,
     hipCtx_t device_context, iree_hal_hip_event_pool_t** out_event_pool) {

--- a/runtime/src/iree/hal/drivers/hip/event_pool.h
+++ b/runtime/src/iree/hal/drivers/hip/event_pool.h
@@ -47,11 +47,11 @@ iree_status_t iree_hal_hip_event_export(iree_hal_hip_event_t* event);
 // Thread-safe; multiple threads may acquire and release events from the pool.
 typedef struct iree_hal_hip_event_pool_t iree_hal_hip_event_pool_t;
 
-// Allocates a new event pool with up to |available_capacity| events.
+// Creates a new event pool with up to |available_capacity| events.
 //
 // Extra events requested beyond the capability are directly created and
 // destroyed without pooling.
-iree_status_t iree_hal_hip_event_pool_allocate(
+iree_status_t iree_hal_hip_event_pool_create(
     const iree_hal_hip_dynamic_symbols_t* symbols,
     iree_host_size_t available_capacity, iree_allocator_t host_allocator,
     hipCtx_t device_context, iree_hal_hip_event_pool_t** out_event_pool);

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -404,18 +404,18 @@ static iree_status_t iree_hal_hip_device_initialize_internal(
       host_allocator, &device->device_allocator);
 
   if (iree_status_is_ok(status)) {
-    status = iree_hal_hip_cleanup_thread_initialize(symbols, host_allocator,
-                                                    &device->cleanup_thread);
+    status = iree_hal_hip_cleanup_thread_allocate(symbols, host_allocator,
+                                                  &device->cleanup_thread);
   }
 
   if (iree_status_is_ok(status)) {
-    status = iree_hal_hip_cleanup_thread_initialize(
-        symbols, host_allocator, &device->buffer_free_thread);
+    status = iree_hal_hip_cleanup_thread_allocate(symbols, host_allocator,
+                                                  &device->buffer_free_thread);
   }
 
   if (iree_status_is_ok(status)) {
     for (iree_host_size_t i = 0; i < device->device_count; ++i) {
-      status = iree_hal_hip_dispatch_thread_initialize(
+      status = iree_hal_hip_dispatch_thread_allocate(
           host_allocator, &device->devices[i].dispatch_thread);
       if (!iree_status_is_ok(status)) {
         break;
@@ -583,7 +583,7 @@ iree_status_t iree_hal_hip_device_create(
 
   for (iree_host_size_t i = 0; i < device_count && iree_status_is_ok(status);
        ++i) {
-    status = iree_hal_hip_event_pool_allocate(
+    status = iree_hal_hip_event_pool_create(
         symbols, params->event_pool_capacity, host_allocator,
         device->devices[i].hip_context, &device->devices[i].device_event_pool);
   }
@@ -627,16 +627,15 @@ static void iree_hal_hip_device_destroy(iree_hal_device_t* base_device) {
   const iree_hal_hip_dynamic_symbols_t* symbols = device->hip_symbols;
 
   for (iree_host_size_t i = 0; i < device->device_count; ++i) {
-    iree_hal_hip_dispatch_thread_deinitialize(
-        device->devices[i].dispatch_thread);
+    iree_hal_hip_dispatch_thread_free(device->devices[i].dispatch_thread);
   }
 
   iree_hal_hip_device_clear_topology_info(device);
 
   // Join with the threads and clear them so that subsequent resource
   // cleanup does not get scheduled on these threads.
-  iree_hal_hip_cleanup_thread_deinitialize(device->cleanup_thread);
-  iree_hal_hip_cleanup_thread_deinitialize(device->buffer_free_thread);
+  iree_hal_hip_cleanup_thread_free(device->cleanup_thread);
+  iree_hal_hip_cleanup_thread_free(device->buffer_free_thread);
   device->cleanup_thread = NULL;
   device->buffer_free_thread = NULL;
 


### PR DESCRIPTION
This extends the repo-owned clang-tidy contract checks from refcount mechanics into lifecycle naming. The new checks codify the IREE C distinction between refcounted object factories, allocator-domain storage operations, and caller-owned in-place initialization so drift becomes a presubmit-visible diagnostic instead of a review-time style argument.

The refcounted factory rule now rejects `*_allocate` APIs that publish an `out_*` pointer-to-pointer to a concrete refcounted object. The structural anchor is the object being returned: either a direct offset-zero `iree_atomic_ref_count_t ref_count` field or an offset-zero base/header record whose first field is that refcount. This avoids body-shape guesses such as looking for allocator calls, since a factory may allocate through helpers and an allocator-domain function may legitimately allocate storage without being an object constructor.

The lifecycle naming rule covers the caller-owned side of the contract. If a function named `*_allocate` publishes caller-owned storage and the matching teardown operation is `*_deinitialize`, the pair should be spelled `initialize/deinitialize`. The check also rejects `*_initialize` functions that return a pointer-to-pointer unless the signature has an explicit `storage` parameter, preserving the narrow placement-in-storage pattern used by existing view initializers without making generic `T**` initialization look normal.

The codebase cleanup is deliberately small and tied to the diagnostics. HIP and CUDA event pools now use `*_create` because they publish refcounted pool objects. The AMDGPU executable shell helper is renamed to `*_create_empty` because it constructs a refcounted HAL resource even though the caller fills in metadata afterward. Loom temporary file helpers now use `*_initialize` because the caller owns the storage and the helper initializes/deinitializes it in place. HIP cleanup and dispatch thread helpers remain `allocate/free` because they publish heap-owned, non-refcounted thread objects.

Allocator-domain APIs are intentionally out of scope for this hard gate. Names such as `iree_hal_allocator_allocate_buffer`, `hrx_allocator_allocate_buffer`, and `hrx_buffer_allocate` describe memory-allocation operations rather than generic object construction, even when they return handle wrappers. The checker stays on exact lifecycle suffixes instead of treating every name containing `allocate` as suspect; broader public API output-name normalization can happen separately with explicit domain exceptions.