### PR TITLE
[CI] Run Loom Vulkan execution by resource label

### DIFF
--- a/.github/workflows/ci_iree_bazel.yml
+++ b/.github/workflows/ci_iree_bazel.yml
@@ -164,8 +164,8 @@ jobs:
 
       - name: Run IREE Bazel CI
         run: |
-          echo "python3 build_tools/devtools/ci.py ${{ matrix.command }} --target //runtime/... --keep-going"
-          python3 build_tools/devtools/ci.py ${{ matrix.command }} --target //runtime/... --keep-going
+          echo "python3 build_tools/devtools/ci.py ${{ matrix.command }} --keep-going"
+          python3 build_tools/devtools/ci.py ${{ matrix.command }} --keep-going
 
   linux_bazel_amdgpu:
     name: ${{ matrix.name }}

--- a/build_tools/bazel/test/cc_benchmark_rules_test.bzl
+++ b/build_tools/bazel/test/cc_benchmark_rules_test.bzl
@@ -59,7 +59,7 @@ def _test_cc_benchmark_smoke_test_args_and_tags(name, **kwargs):
         resource_group = "gpu",
         srcs = [name + "_subject.cc"],
         tags = [
-            "driver=vulkan",
+            "requires-gpu-vulkan",
             "manual",
         ],
     )
@@ -82,7 +82,7 @@ def _test_cc_benchmark_smoke_test_args_and_tags_impl(env, target):
     if attrs.args != expected_args:
         env.fail("expected smoke test args %r, got %r" % (expected_args, attrs.args))
     for expected_tag in [
-        "driver=vulkan",
+        "requires-gpu-vulkan",
         "exclusive-if-local",
         "resource_group:gpu",
     ]:

--- a/build_tools/bazel/test/cc_fuzz_rules_test.bzl
+++ b/build_tools/bazel/test/cc_fuzz_rules_test.bzl
@@ -17,7 +17,7 @@ def _test_cc_fuzz_adds_fuzzer_contract(name, **kwargs):
         defines = ["USER_DEFINE"],
         linkopts = ["-Wl,--user-linkopt"],
         srcs = [name + "_subject.cc"],
-        tags = ["driver=vulkan"],
+        tags = ["requires-gpu-vulkan"],
     )
     analysis_test(
         name = name,
@@ -44,7 +44,7 @@ def _test_cc_fuzz_adds_fuzzer_contract_impl(env, target):
         if expected_linkopt not in attrs.linkopts:
             env.fail("expected %r in fuzz linkopts %r" % (expected_linkopt, attrs.linkopts))
     for expected_tag in [
-        "driver=vulkan",
+        "requires-gpu-vulkan",
         "fuzz",
         "manual",
     ]:

--- a/build_tools/bazel/test/cc_rules_test.bzl
+++ b/build_tools/bazel/test/cc_rules_test.bzl
@@ -189,7 +189,7 @@ def _test_cc_test_applies_resource_group_tags(name, **kwargs):
         srcs = [name + "_subject.cc"],
         resource_group = "gpu",
         tags = [
-            "driver=vulkan",
+            "requires-gpu-vulkan",
             "manual",
         ],
     )
@@ -206,7 +206,7 @@ def _test_cc_test_applies_resource_group_tags(name, **kwargs):
 def _test_cc_test_applies_resource_group_tags_impl(env, target):
     tags = target[TestingAspectInfo].attrs.tags
     for expected_tag in [
-        "driver=vulkan",
+        "requires-gpu-vulkan",
         "exclusive-if-local",
         "resource_group:gpu",
     ]:

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -243,6 +243,12 @@ function(iree_cc_test)
   list(APPEND _RULE_LABELS "${_PACKAGE_PATH}")
   set_property(TEST ${_NAME_PATH} PROPERTY LABELS "${_RULE_LABELS}")
   set_property(TEST ${_NAME_PATH} PROPERTY TIMEOUT ${_RULE_TIMEOUT})
+  iree_register_test_resource_build_target(
+    TEST_BUILD_TARGET
+      "${_NAME}"
+    LABELS
+      ${_RULE_LABELS}
+  )
 
   if(_RULE_RESOURCE_GROUP)
     set_property(TEST ${_NAME_PATH} PROPERTY RESOURCE_LOCK "${_RULE_RESOURCE_GROUP}")

--- a/build_tools/cmake/iree_configure_testing.cmake
+++ b/build_tools/cmake/iree_configure_testing.cmake
@@ -12,6 +12,62 @@ enable_testing(iree)
 # A property is apparently the only way to get an uncached global variable.
 set_property(GLOBAL PROPERTY IREE_TEST_TMPDIRS "")
 set(IREE_TEST_TMPDIR_ROOT "${IREE_BINARY_DIR}/test_tmpdir")
+set(IREE_RUNTIME_RESOURCE_LABEL_PREFIX "runtime-resource=")
+
+# iree_register_test_resource_build_target
+#
+# Adds TEST_BUILD_TARGET to aggregate build targets keyed by runtime resource
+# labels. This lets CI build all tests for a resource class before selecting
+# them with CTest labels without keeping a central inventory of test packages.
+#
+# Parameters:
+#   TEST_BUILD_TARGET: CMake target that must be built before running the test.
+#   LABELS: labels assigned to the test.
+function(iree_register_test_resource_build_target)
+  cmake_parse_arguments(
+    _RULE
+    ""
+    "TEST_BUILD_TARGET"
+    "LABELS"
+    ${ARGN}
+  )
+
+  if(NOT _RULE_TEST_BUILD_TARGET OR NOT TARGET "${_RULE_TEST_BUILD_TARGET}")
+    return()
+  endif()
+
+  get_target_property(
+    _IREE_TEST_RESOURCE_IMPORTED
+    "${_RULE_TEST_BUILD_TARGET}"
+    IMPORTED
+  )
+  if(_IREE_TEST_RESOURCE_IMPORTED)
+    return()
+  endif()
+
+  foreach(_LABEL IN LISTS _RULE_LABELS)
+    if(NOT _LABEL MATCHES "^${IREE_RUNTIME_RESOURCE_LABEL_PREFIX}(.+)$")
+      continue()
+    endif()
+    set(_RESOURCE_NAME "${CMAKE_MATCH_1}")
+    string(
+      REGEX REPLACE "[^A-Za-z0-9_.+-]" "-"
+      _RESOURCE_TARGET_SUFFIX "${_RESOURCE_NAME}"
+    )
+    set(_RESOURCE_TARGET "iree-test-resource-${_RESOURCE_TARGET_SUFFIX}")
+    if(NOT TARGET "${_RESOURCE_TARGET}")
+      add_custom_target("${_RESOURCE_TARGET}"
+        COMMENT
+          "Building IREE tests requiring ${IREE_RUNTIME_RESOURCE_LABEL_PREFIX}${_RESOURCE_NAME}"
+      )
+      set_property(
+        TARGET "${_RESOURCE_TARGET}"
+        PROPERTY FOLDER ${IREE_IDE_FOLDER}/test
+      )
+    endif()
+    add_dependencies("${_RESOURCE_TARGET}" "${_RULE_TEST_BUILD_TARGET}")
+  endforeach()
+endfunction()
 
 # iree_configure_test
 #

--- a/build_tools/cmake/iree_execution_test_suite.cmake
+++ b/build_tools/cmake/iree_execution_test_suite.cmake
@@ -127,6 +127,12 @@ function(iree_execution_test_suite)
   set_property(TEST ${_TEST_NAME} PROPERTY LABELS "${_RULE_LABELS}")
   set_property(TEST ${_TEST_NAME} PROPERTY TIMEOUT "${_RULE_TIMEOUT}")
   set_property(TEST ${_TEST_NAME} PROPERTY REQUIRED_FILES "${_REQUIRED_FILES}")
+  iree_register_test_resource_build_target(
+    TEST_BUILD_TARGET
+      "${_TEST_TARGET_NAME}"
+    LABELS
+      ${_RULE_LABELS}
+  )
   set(_ENVIRONMENT_VARS "PYTHONDONTWRITEBYTECODE=1")
   if(_RULE_SANITIZER_SUPPRESSIONS)
     iree_append_sanitizer_suppression_environment(

--- a/build_tools/cmake/iree_native_test.cmake
+++ b/build_tools/cmake/iree_native_test.cmake
@@ -12,9 +12,7 @@
 #
 # Parameters:
 # NAME: name of target
-# DRIVER: If specified, will pass --device=DRIVER to the test binary and adds
-#     a driver label to the test.
-#     TODO(scotttodd): Remove automatic args/labels, push those up a level
+# DRIVER: If specified, will pass --device=DRIVER to the test binary.
 # DATA: Additional input files needed by the test binary. When running tests on
 #     a separate device (e.g. Android), these files will be pushed to the
 #     device. TEST_INPUT_FILE_ARG is automatically added if specified.
@@ -74,11 +72,9 @@ function(iree_native_test)
   set(_TEST_NAME "${_PACKAGE_PATH}/${_RULE_NAME}")
   set(_IREE_TEST_CAN_REGISTER OFF)
 
-  # If driver was specified, add the corresponding test arg and label.
+  # If driver was specified, add the corresponding test arg.
   if(DEFINED _RULE_DRIVER)
     list(APPEND _RULE_ARGS "--device=${_RULE_DRIVER}")
-    list(APPEND _RULE_LABELS "driver=${_RULE_DRIVER}")
-
   endif()
 
   set(_TEST_ENVIRONMENT_VARS)
@@ -192,6 +188,13 @@ function(iree_native_test)
   set_property(TEST ${_TEST_NAME} PROPERTY LABELS "${_RULE_LABELS}")
   set_property(TEST "${_TEST_NAME}" PROPERTY REQUIRED_FILES "${_RULE_DATA}")
   set_property(TEST ${_TEST_NAME} PROPERTY TIMEOUT ${_RULE_TIMEOUT})
+  iree_package_target_name(_TEST_BUILD_TARGET "${_RULE_SRC}")
+  iree_register_test_resource_build_target(
+    TEST_BUILD_TARGET
+      "${_TEST_BUILD_TARGET}"
+    LABELS
+      ${_RULE_LABELS}
+  )
   if(_RULE_RESOURCE_GROUP)
     set_property(TEST ${_TEST_NAME} PROPERTY RESOURCE_LOCK "${_RULE_RESOURCE_GROUP}")
   endif()

--- a/build_tools/devtools/ci.py
+++ b/build_tools/devtools/ci.py
@@ -238,6 +238,17 @@ def cmake_build_step(
     )
 
 
+def cmake_runtime_resource_build_target(resource_label: str) -> str:
+    prefix = ci_config.RUNTIME_CTEST_RESOURCE_LABEL_PREFIX
+    if not resource_label.startswith(prefix):
+        raise ValueError(f"expected CTest runtime resource label: {resource_label}")
+    resource_name = resource_label.removeprefix(prefix)
+    resource_target_suffix = "".join(
+        c if c.isalnum() or c in "_.+-" else "-" for c in resource_name
+    )
+    return "iree-test-resource-" + resource_target_suffix
+
+
 def combine_ctest_regex(*regexes: str) -> str:
     return "|".join(f"({regex})" for regex in regexes if regex)
 
@@ -432,15 +443,40 @@ def amdgpu_config_steps(targets: tuple[str, ...], config: str) -> list[CiStep]:
     raise ValueError(f"unknown Bazel AMDGPU sanitizer config: {config}")
 
 
-def vulkan_test_steps(config: str | None = None) -> list[CiStep]:
+def vulkan_test_steps(
+    targets: tuple[str, ...],
+    config: str | None = None,
+) -> list[CiStep]:
     config_name = f" with {config.upper()}" if config is not None else ""
-    return [
+    steps = [
         bazel_test_step(
-            f"Test IREE Vulkan tests{config_name}",
-            ci_config.VULKAN_BAZEL_DRIVER_TARGETS,
+            f"Test IREE Vulkan package tests{config_name}",
+            ci_config.VULKAN_BAZEL_DRIVER_TARGETS + ci_config.VULKAN_XFAIL_TARGETS,
             config=config,
         ),
     ]
+    for (
+        slice_name,
+        target_prefix,
+        default_target,
+        resource_tag,
+    ) in ci_config.VULKAN_BAZEL_RESOURCE_SLICES:
+        slice_targets = resource_slice_targets(
+            targets,
+            target_prefix=target_prefix,
+            default_target=default_target,
+        )
+        if not slice_targets:
+            continue
+        steps.append(
+            bazel_test_step(
+                f"Test IREE Vulkan {slice_name} resources{config_name}",
+                slice_targets,
+                config=config,
+                test_tag_filters=(resource_tag,),
+            )
+        )
+    return steps
 
 
 def vulkan_steps(targets: tuple[str, ...]) -> list[CiStep]:
@@ -450,7 +486,7 @@ def vulkan_steps(targets: tuple[str, ...]) -> list[CiStep]:
             "Build IREE with Vulkan",
             ci_config.VULKAN_BAZEL_DRIVER_TARGETS,
         ),
-        *vulkan_test_steps(),
+        *vulkan_test_steps(targets),
     ]
 
 
@@ -464,8 +500,17 @@ def vulkan_sanitizer_steps(targets: tuple[str, ...]) -> list[CiStep]:
 
 
 def vulkan_config_steps(targets: tuple[str, ...], config: str) -> list[CiStep]:
+    # Vulkan hardware tests execute the system loader and ICD in-process. Keep
+    # sanitizer coverage to compile-time checks here; the unsanitized Vulkan
+    # lane owns execution on real devices.
     if config in ci_config.SANITIZER_TEST_CONFIGS:
-        return vulkan_test_steps(config=config)
+        return [
+            bazel_build_step(
+                f"Build IREE with Vulkan and {config.upper()}",
+                ci_config.VULKAN_BAZEL_DRIVER_TARGETS,
+                config=config,
+            )
+        ]
     if config in ci_config.SANITIZER_BUILD_CONFIGS:
         return [
             bazel_build_step(
@@ -515,11 +560,13 @@ def cmake_amdgpu_steps(command_name: str, sanitizer: str | None) -> list[CiStep]
         xfail_regex = ci_config.AMDGPU_SANITIZERS_CTEST_EXCLUDE_REGEX
     else:
         xfail_regex = ci_config.AMDGPU_CTEST_EXCLUDE_REGEX
-    build_targets = (
-        ci_config.AMDGPU_CMAKE_TEST_BUILD_TARGETS
-        if tests_enabled
-        else ci_config.AMDGPU_CMAKE_DRIVER_TARGETS
-    )
+    build_targets = ci_config.AMDGPU_CMAKE_DRIVER_TARGETS
+    if tests_enabled:
+        build_targets += (
+            cmake_runtime_resource_build_target(
+                ci_config.AMDGPU_CTEST_RESOURCE_LABEL_REGEX
+            ),
+        )
     steps = [
         cmake_configure_step(
             command_name,
@@ -584,6 +631,13 @@ def cmake_loom_amdgpu_steps(command_name: str) -> list[CiStep]:
 def cmake_vulkan_steps(command_name: str, sanitizer: str | None) -> list[CiStep]:
     sanitizer_name = f" with {sanitizer.upper()}" if sanitizer is not None else ""
     tests_enabled = cmake_tests_enabled(sanitizer)
+    build_targets = ci_config.VULKAN_CMAKE_DRIVER_TARGETS
+    if tests_enabled:
+        build_targets += (
+            cmake_runtime_resource_build_target(
+                ci_config.VULKAN_CTEST_RESOURCE_LABEL_REGEX
+            ),
+        )
     steps = [
         cmake_configure_step(
             command_name,
@@ -593,15 +647,24 @@ def cmake_vulkan_steps(command_name: str, sanitizer: str | None) -> list[CiStep]
         cmake_build_step(
             command_name,
             f"Build IREE CMake Vulkan{sanitizer_name}",
-            ci_config.VULKAN_CMAKE_DRIVER_TARGETS,
+            build_targets,
         ),
     ]
     if tests_enabled:
         steps.append(
             cmake_test_step(
                 command_name,
-                f"Test IREE CMake Vulkan tests{sanitizer_name}",
+                f"Test IREE CMake Vulkan package tests{sanitizer_name}",
                 regex=ci_config.VULKAN_CTEST_REGEX,
+                env=sanitizer_env(sanitizer),
+            )
+        )
+        steps.append(
+            cmake_test_step(
+                command_name,
+                f"Test IREE CMake Vulkan resource tests{sanitizer_name}",
+                label_regex=ci_config.VULKAN_CTEST_RESOURCE_LABEL_REGEX,
+                exclude_regex=ci_config.VULKAN_CTEST_REGEX,
                 env=sanitizer_env(sanitizer),
             )
         )

--- a/build_tools/devtools/ci_config.py
+++ b/build_tools/devtools/ci_config.py
@@ -11,6 +11,11 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+# This file is the CI policy map. Entries here should describe workflow
+# boundaries: package roots, target patterns, requirement labels, resource
+# slices, and named xfail groups. Individual test targets belong near the test;
+# hardware execution joins CI through run-requirement tags and CTest labels.
+
 IREE_TARGET_DIRECTORIES = ("runtime", "loom")
 
 # ASAN, UBSAN, and TSAN run tests. MSAN builds stay useful, but running tests
@@ -129,12 +134,6 @@ NON_CPU_HAL_DRIVER_CTEST_REGEX = (
 
 AMDGPU_BAZEL_DRIVER_TARGETS = ("//runtime/src/iree/hal/drivers/amdgpu/...",)
 AMDGPU_CMAKE_DRIVER_TARGETS = ("runtime/src/iree/hal/drivers/amdgpu/all",)
-AMDGPU_CMAKE_RESOURCE_TEST_BUILD_TARGETS = (
-    "loom_tools_iree-test-loom_amdgpu_execution_test_test_deps",
-)
-AMDGPU_CMAKE_TEST_BUILD_TARGETS = (
-    AMDGPU_CMAKE_DRIVER_TARGETS + AMDGPU_CMAKE_RESOURCE_TEST_BUILD_TARGETS
-)
 AMDGPU_TARGET_SELECTOR = "gfx942"
 RUNTIME_AMDGPU_RESOURCE_TAG = "iree-run-requirement=runtime.resource.amd_gpu"
 AMDGPU_BAZEL_RESOURCE_SLICES = (
@@ -224,5 +223,50 @@ AMDGPU_TSAN_SANITIZERS_CTEST_EXCLUDE_REGEX = ctest_exclude_regex(
 )
 
 VULKAN_BAZEL_DRIVER_TARGETS = ("//runtime/src/iree/hal/drivers/vulkan/...",)
+RUNTIME_VULKAN_RESOURCE_TAG = "iree-run-requirement=runtime.resource.vulkan_device"
+VULKAN_BAZEL_RESOURCE_SLICES = (
+    ("loom", "//loom", "//loom/...", RUNTIME_VULKAN_RESOURCE_TAG),
+)
 VULKAN_CMAKE_DRIVER_TARGETS = ("runtime/src/iree/hal/drivers/vulkan/all",)
 VULKAN_CTEST_REGEX = r"^iree/hal/drivers/vulkan/"
+VULKAN_CTEST_RESOURCE_LABEL_REGEX = "runtime-resource=vulkan-device"
+VULKAN_XFAILS = (
+    # These generic executable CTS binaries still bind the empty compatibility
+    # testdata registration instead of real SPIR-V payloads.
+    bazel_xfail("//runtime/src/iree/hal/drivers/vulkan/cts:profiling_tests"),
+    bazel_xfail(
+        "//runtime/src/iree/hal/drivers/vulkan/cts:command_buffer_dispatch_tests"
+    ),
+    bazel_xfail(
+        "//runtime/src/iree/hal/drivers/vulkan/cts:command_buffer_dispatch_pipeline_tests"
+    ),
+    bazel_xfail(
+        "//runtime/src/iree/hal/drivers/vulkan/cts:command_buffer_dispatch_reuse_tests"
+    ),
+    bazel_xfail(
+        "//runtime/src/iree/hal/drivers/vulkan/cts:command_buffer_dispatch_constants_bindings_tests"
+    ),
+    bazel_xfail(
+        "//runtime/src/iree/hal/drivers/vulkan/cts:command_buffer_dispatch_constants_tests"
+    ),
+    bazel_xfail(
+        "//runtime/src/iree/hal/drivers/vulkan/cts:command_buffer_dispatch_indirect_parameters_tests"
+    ),
+    bazel_xfail(
+        "//runtime/src/iree/hal/drivers/vulkan/cts:command_buffer_dispatch_multi_entrypoint_tests"
+    ),
+    bazel_xfail(
+        "//runtime/src/iree/hal/drivers/vulkan/cts:command_buffer_dispatch_multi_workgroup_tests"
+    ),
+    bazel_xfail("//runtime/src/iree/hal/drivers/vulkan/cts:executable_tests"),
+    bazel_xfail(
+        "//runtime/src/iree/hal/drivers/vulkan/cts:queue_dispatch_direct_tests"
+    ),
+    bazel_xfail(
+        "//runtime/src/iree/hal/drivers/vulkan/cts:queue_dispatch_indirect_parameters_tests"
+    ),
+    bazel_xfail(
+        "//runtime/src/iree/hal/drivers/vulkan/cts:queue_descriptor_cache_tests"
+    ),
+)
+VULKAN_XFAIL_TARGETS = bazel_xfail_targets(VULKAN_XFAILS)

--- a/build_tools/devtools/ci_test.py
+++ b/build_tools/devtools/ci_test.py
@@ -420,13 +420,36 @@ class CiTest(unittest.TestCase):
                 for line in command_lines
             )
         )
-        host_test = next(
-            step for step in steps if step.name == "Test IREE Vulkan tests"
+        package_test = next(
+            step for step in steps if step.name == "Test IREE Vulkan package tests"
         )
-        self.assertIn(ci_config.VULKAN_BAZEL_DRIVER_TARGETS[0], host_test.argv)
-        self.assertFalse(any("--test_tag_filters" in arg for arg in host_test.argv))
+        self.assertIn(ci_config.VULKAN_BAZEL_DRIVER_TARGETS[0], package_test.argv)
+        for xfail_target in ci_config.VULKAN_XFAIL_TARGETS:
+            self.assertIn(xfail_target, package_test.argv)
+        self.assertFalse(any("--test_tag_filters" in arg for arg in package_test.argv))
+        self.assertFalse(
+            any(step.name == "Test IREE Vulkan loom resources" for step in steps)
+        )
 
-    def test_bazel_vulkan_single_sanitizer_command_runs_one_configuration(self):
+    def test_vulkan_command_runs_resource_slices_by_requirement_label(self):
+        args = ci.parse_arguments(["iree-bazel-vulkan"])
+
+        steps = ci.steps_from_args(args)
+        resource_test = next(
+            step for step in steps if step.name == "Test IREE Vulkan loom resources"
+        )
+        command_line = resource_test.command_line()
+
+        self.assertIn("//loom/...", resource_test.argv)
+        self.assertIn(
+            "--test_tag_filters=" + ci_config.RUNTIME_VULKAN_RESOURCE_TAG,
+            resource_test.argv,
+        )
+        self.assertNotIn(":spirv_vulkan_execution_test", command_line)
+        self.assertNotIn(":emit_spirv_vulkan_test", command_line)
+        self.assertNotIn(":emit_spirv_iree_hal_test", command_line)
+
+    def test_bazel_vulkan_single_sanitizer_command_builds_one_configuration(self):
         args = ci.parse_arguments(
             [
                 "iree-bazel-vulkan-asan",
@@ -439,13 +462,16 @@ class CiTest(unittest.TestCase):
         command_lines = [step.command_line() for step in steps]
 
         self.assertTrue(
+            any("bazel build --config=asan" in line for line in command_lines)
+        )
+        self.assertFalse(
             any("bazel test --config=asan" in line for line in command_lines)
         )
         self.assertFalse(any("--config=ubsan" in line for line in command_lines))
         self.assertFalse(any("--config=tsan" in line for line in command_lines))
         self.assertFalse(any("--config=msan" in line for line in command_lines))
 
-    def test_bazel_vulkan_sanitizers_use_generic_clang_configs(self):
+    def test_bazel_vulkan_sanitizers_build_with_generic_clang_configs(self):
         args = ci.parse_arguments(
             [
                 "iree-bazel-vulkan-sanitizers",
@@ -458,17 +484,18 @@ class CiTest(unittest.TestCase):
         command_lines = [step.command_line() for step in steps]
 
         self.assertTrue(
-            any("bazel test --config=asan" in line for line in command_lines)
+            any("bazel build --config=asan" in line for line in command_lines)
         )
         self.assertTrue(
-            any("bazel test --config=tsan" in line for line in command_lines)
+            any("bazel build --config=tsan" in line for line in command_lines)
         )
         self.assertTrue(
-            any("bazel test --config=ubsan" in line for line in command_lines)
+            any("bazel build --config=ubsan" in line for line in command_lines)
         )
         self.assertTrue(
             any("bazel build --config=msan" in line for line in command_lines)
         )
+        self.assertFalse(any("bazel test --config=" in line for line in command_lines))
 
     def test_vulkan_workflows_require_hardware_preflight(self):
         for path, job_name in (
@@ -761,8 +788,17 @@ class CiTest(unittest.TestCase):
         build_steps = [step for step in steps if step.name.startswith("Build IREE")]
         for target in ci_config.AMDGPU_CMAKE_DRIVER_TARGETS:
             self.assertTrue(any(target in step.argv for step in build_steps))
-        for target in ci_config.AMDGPU_CMAKE_RESOURCE_TEST_BUILD_TARGETS:
-            self.assertTrue(any(target in step.argv for step in build_steps))
+        resource_target = ci.cmake_runtime_resource_build_target(
+            ci_config.AMDGPU_CTEST_RESOURCE_LABEL_REGEX
+        )
+        self.assertTrue(any(resource_target in step.argv for step in build_steps))
+        self.assertFalse(
+            any(
+                "loom_tools_iree-test-loom_amdgpu_execution_test" in arg
+                for step in build_steps
+                for arg in step.argv
+            )
+        )
         self.assertTrue(
             any("-R '^iree/hal/drivers/amdgpu/'" in line for line in command_lines)
         )
@@ -837,8 +873,10 @@ class CiTest(unittest.TestCase):
         build_steps = [step for step in steps if step.name.startswith("Build IREE")]
         for target in ci_config.AMDGPU_CMAKE_DRIVER_TARGETS:
             self.assertTrue(any(target in step.argv for step in build_steps))
-        for target in ci_config.AMDGPU_CMAKE_RESOURCE_TEST_BUILD_TARGETS:
-            self.assertFalse(any(target in step.argv for step in build_steps))
+        resource_target = ci.cmake_runtime_resource_build_target(
+            ci_config.AMDGPU_CTEST_RESOURCE_LABEL_REGEX
+        )
+        self.assertFalse(any(resource_target in step.argv for step in build_steps))
         self.assertFalse(any("Test IREE CMake AMDGPU" in step.name for step in steps))
 
     def test_cmake_loom_amdgpu_command_runs_compile_coverage_without_driver(self):
@@ -889,10 +927,34 @@ class CiTest(unittest.TestCase):
             any("-DIREE_HAL_DRIVER_AMDGPU=OFF" in line for line in command_lines)
         )
         build_steps = [step for step in steps if step.name.startswith("Build IREE")]
-        for target in ci_config.VULKAN_CMAKE_DRIVER_TARGETS:
+        resource_target = ci.cmake_runtime_resource_build_target(
+            ci_config.VULKAN_CTEST_RESOURCE_LABEL_REGEX
+        )
+        for target in ci_config.VULKAN_CMAKE_DRIVER_TARGETS + (resource_target,):
             self.assertTrue(any(target in step.argv for step in build_steps))
+        for target in (
+            "loom/src/loom/tools/iree-test-loom/all",
+            "loom/binding/c/example/all",
+            "loom/binding/c/test/target/spirv/all",
+        ):
+            self.assertFalse(any(target in step.argv for step in build_steps))
+        package_test = next(
+            step
+            for step in steps
+            if step.name == "Test IREE CMake Vulkan package tests"
+        )
         self.assertTrue(
-            any(ci_config.VULKAN_CTEST_REGEX in line for line in command_lines)
+            any(ci_config.VULKAN_CTEST_REGEX in arg for arg in package_test.argv)
+        )
+        resource_test = next(
+            step
+            for step in steps
+            if step.name == "Test IREE CMake Vulkan resource tests"
+        )
+        self.assertIn(ci_config.VULKAN_CTEST_RESOURCE_LABEL_REGEX, resource_test.argv)
+        self.assertIn(ci_config.VULKAN_CTEST_REGEX, resource_test.argv)
+        self.assertFalse(
+            any("emit_spirv_vulkan_test" in arg for arg in resource_test.argv)
         )
         self.assertFalse(any("-fuse-ld=lld" in line for line in command_lines))
 

--- a/loom/binding/c/example/BUILD.bazel
+++ b/loom/binding/c/example/BUILD.bazel
@@ -105,9 +105,6 @@ loom_cc_test(
     name = "emit_spirv_vulkan_test",
     srcs = ["emit_spirv_vulkan.c"],
     sanitizer_suppressions = vulkan_suppressions,
-    tags = [
-        "driver=vulkan",
-    ],
     target_compatible_with = LOOMC_TARGET_SPIRV_VULKAN_COMPATIBLE_WITH,
     deps = [
         "//build_tools:dl",
@@ -120,9 +117,6 @@ loom_cc_test(
 loom_cc_test(
     name = "emit_spirv_iree_hal_test",
     srcs = ["emit_spirv_iree_hal.c"],
-    tags = [
-        "driver=vulkan",
-    ],
     target_compatible_with = LOOMC_TARGET_SPIRV_VULKAN_COMPATIBLE_WITH,
     deps = [
         "//loom/binding/c:loomc",

--- a/loom/binding/c/example/CMakeLists.txt
+++ b/loom/binding/c/example/CMakeLists.txt
@@ -106,7 +106,6 @@ loom_cc_test(
     loom::binding::c::target::spirv
     loom::binding::c::target::spirv::vulkan
   LABELS
-    "driver=vulkan"
     "iree-run-requirement=runtime.resource.vulkan_device"
     "runtime-resource=vulkan-device"
   RESOURCE_GROUP
@@ -134,7 +133,6 @@ loom_cc_test(
     loom::binding::c::target::spirv
     loom::binding::c::target::spirv::iree_hal
   LABELS
-    "driver=vulkan"
     "iree-run-requirement=runtime.resource.vulkan_device"
     "runtime-resource=vulkan-device"
   RESOURCE_GROUP

--- a/loom/binding/c/test/target/spirv/BUILD.bazel
+++ b/loom/binding/c/test/target/spirv/BUILD.bazel
@@ -87,7 +87,8 @@ loom_cc_test(
     name = "iree_hal_execution_test",
     srcs = ["iree_hal_execution_test.cc"],
     tags = [
-        "driver=vulkan",
+        "iree-run-requirement=runtime.resource.vulkan_device",
+        "runtime-resource=vulkan-device",
     ],
     target_compatible_with = LOOMC_TARGET_SPIRV_VULKAN_COMPATIBLE_WITH,
     deps = [

--- a/loom/binding/c/test/target/spirv/CMakeLists.txt
+++ b/loom/binding/c/test/target/spirv/CMakeLists.txt
@@ -108,7 +108,8 @@ loom_cc_test(
     loom::binding::c::target::spirv::iree_hal
     loom::binding::c::test::target::iree_hal_execution_test_util
   LABELS
-    "driver=vulkan"
+    "iree-run-requirement=runtime.resource.vulkan_device"
+    "runtime-resource=vulkan-device"
     "iree-build-requirement=loom.target.arch.spirv"
     "iree-build-requirement=loom.emit.spirv"
 )

--- a/loom/src/loom/target/emit/native/amdgpu/BUILD.bazel
+++ b/loom/src/loom/target/emit/native/amdgpu/BUILD.bazel
@@ -418,7 +418,6 @@ loom_cc_test(
     name = "hsaco_hsa_test",
     srcs = ["hsaco_hsa_test.cc"],
     tags = [
-        "driver=amdgpu",
         "nodocker",
         "requires-gpu-amd",
     ],

--- a/loom/src/loom/target/emit/native/amdgpu/CMakeLists.txt
+++ b/loom/src/loom/target/emit/native/amdgpu/CMakeLists.txt
@@ -573,7 +573,6 @@ loom_cc_test(
     loom::target::arch::amdgpu::target_info
     loom::target::low_descriptor_registry
   LABELS
-    "driver=amdgpu"
     "nodocker"
     "requires-gpu-amd"
     "iree-build-requirement=loom.target.arch.amdgpu"

--- a/loom/src/loom/test/corpus/authoring/BUILD.bazel
+++ b/loom/src/loom/test/corpus/authoring/BUILD.bazel
@@ -87,7 +87,6 @@ iree_executable_test(
         "ffn_gate_up_swiglu_q6q8.loom",
     ],
     tags = [
-        "driver=amdgpu",
         "manual",
         "requires-gpu-amd",
     ],
@@ -113,7 +112,6 @@ iree_executable_test(
         "memset_i8.loom",
     ],
     tags = [
-        "driver=amdgpu",
         "manual",
         "requires-gpu-amd",
     ],
@@ -139,7 +137,6 @@ iree_executable_test(
         "mlp_down_projection_residual_bf16.loom",
     ],
     tags = [
-        "driver=amdgpu",
         "manual",
         "requires-gpu-amd",
     ],

--- a/loom/src/loom/test/corpus/authoring/CMakeLists.txt
+++ b/loom/src/loom/test/corpus/authoring/CMakeLists.txt
@@ -68,7 +68,6 @@ iree_native_test(
   SRC
     loom::tools::iree-benchmark-loom
   LABELS
-    "driver=amdgpu"
     "manual"
     "requires-gpu-amd"
 )
@@ -92,7 +91,6 @@ iree_native_test(
   SRC
     loom::tools::iree-benchmark-loom
   LABELS
-    "driver=amdgpu"
     "manual"
     "requires-gpu-amd"
 )
@@ -116,7 +114,6 @@ iree_native_test(
   SRC
     loom::tools::iree-benchmark-loom
   LABELS
-    "driver=amdgpu"
     "manual"
     "requires-gpu-amd"
 )

--- a/loom/src/loom/tools/iree-benchmark-loom/BUILD.bazel
+++ b/loom/src/loom/tools/iree-benchmark-loom/BUILD.bazel
@@ -289,7 +289,6 @@ iree_execution_test_suite(
     ],
     manifests = ["iree-benchmark-loom_amdgpu.test.json"],
     tags = [
-        "driver=amdgpu",
         "manual",
         "requires-gpu-amd",
     ],
@@ -310,7 +309,6 @@ iree_execution_test_suite(
     manifests = ["iree-benchmark-loom_spirv_vulkan.test.json"],
     sanitizer_suppressions = vulkan_suppressions,
     tags = [
-        "driver=vulkan",
         "manual",
         "requires-gpu-vulkan",
     ],

--- a/loom/src/loom/tools/iree-benchmark-loom/CMakeLists.txt
+++ b/loom/src/loom/tools/iree-benchmark-loom/CMakeLists.txt
@@ -247,7 +247,6 @@ iree_execution_test_suite(
   DATA
     "${PROJECT_SOURCE_DIR}/loom/src/loom/tools/iree-test-loom/testdata/amdgpu_hal_actual.loom"
   LABELS
-    "driver=amdgpu"
     "manual"
     "requires-gpu-amd"
 )
@@ -270,7 +269,6 @@ iree_execution_test_suite(
     lsan
     vulkan
   LABELS
-    "driver=vulkan"
     "manual"
     "requires-gpu-vulkan"
 )

--- a/loom/src/loom/tools/iree-test-loom/BUILD.bazel
+++ b/loom/src/loom/tools/iree-test-loom/BUILD.bazel
@@ -138,7 +138,6 @@ iree_execution_test_suite(
     ],
     manifests = ["iree-test-loom_amdgpu.test.json"],
     tags = [
-        "driver=amdgpu",
         "iree-run-requirement=runtime.resource.amd_gpu",
         "requires-gpu-amd",
         "runtime-resource=amd-gpu",
@@ -160,7 +159,6 @@ iree_execution_test_suite(
     manifests = ["iree-test-loom_spirv_vulkan.test.json"],
     sanitizer_suppressions = vulkan_suppressions,
     tags = [
-        "driver=vulkan",
         "iree-run-requirement=runtime.resource.vulkan_device",
         "requires-gpu-vulkan",
         "runtime-resource=vulkan-device",

--- a/loom/src/loom/tools/iree-test-loom/CMakeLists.txt
+++ b/loom/src/loom/tools/iree-test-loom/CMakeLists.txt
@@ -96,7 +96,6 @@ iree_execution_test_suite(
   DATA
     "testdata/amdgpu_hal_actual.loom"
   LABELS
-    "driver=amdgpu"
     "iree-run-requirement=runtime.resource.amd_gpu"
     "requires-gpu-amd"
     "runtime-resource=amd-gpu"
@@ -120,7 +119,6 @@ iree_execution_test_suite(
     lsan
     vulkan
   LABELS
-    "driver=vulkan"
     "iree-run-requirement=runtime.resource.vulkan_device"
     "requires-gpu-vulkan"
     "runtime-resource=vulkan-device"

--- a/runtime/build_tools/bazel/test/cc_benchmark_rules_test.bzl
+++ b/runtime/build_tools/bazel/test/cc_benchmark_rules_test.bzl
@@ -55,7 +55,7 @@ def _test_runtime_benchmark_smoke_test_applies_resource_group_tags(name, **kwarg
         resource_group = "gpu",
         srcs = [name + "_subject.cc"],
         tags = [
-            "driver=amdgpu",
+            "requires-gpu-amd",
             "manual",
         ],
     )
@@ -72,7 +72,7 @@ def _test_runtime_benchmark_smoke_test_applies_resource_group_tags(name, **kwarg
 def _test_runtime_benchmark_smoke_test_applies_resource_group_tags_impl(env, target):
     tags = target[TestingAspectInfo].attrs.tags
     for expected_tag in [
-        "driver=amdgpu",
+        "requires-gpu-amd",
         "exclusive-if-local",
         "resource_group:gpu",
     ]:

--- a/runtime/build_tools/bazel/test/cc_fuzz_rules_test.bzl
+++ b/runtime/build_tools/bazel/test/cc_fuzz_rules_test.bzl
@@ -32,7 +32,7 @@ def _test_runtime_fuzz_adds_runtime_include_root(name, **kwargs):
         iree_runtime_cc_fuzz,
         name = name + "_subject",
         srcs = [name + "_subject.cc"],
-        tags = ["driver=amdgpu"],
+        tags = ["requires-gpu-amd"],
     )
     analysis_test(
         name = name,
@@ -49,7 +49,7 @@ def _test_runtime_fuzz_adds_runtime_include_root_impl(env, target):
     _expect_path_suffix(env, paths, "runtime/src")
     tags = target[TestingAspectInfo].attrs.tags
     for expected_tag in [
-        "driver=amdgpu",
+        "requires-gpu-amd",
         "fuzz",
         "manual",
     ]:

--- a/runtime/build_tools/bazel/test/cc_rules_test.bzl
+++ b/runtime/build_tools/bazel/test/cc_rules_test.bzl
@@ -172,7 +172,7 @@ def _test_runtime_test_adds_runtime_include_root(name, **kwargs):
         srcs = [name + "_subject.cc"],
         resource_group = "gpu",
         tags = [
-            "driver=amdgpu",
+            "requires-gpu-amd",
             "manual",
         ],
     )
@@ -191,7 +191,7 @@ def _test_runtime_test_adds_runtime_include_root_impl(env, target):
     _expect_path_suffix(env, paths, "runtime/src")
     tags = target[TestingAspectInfo].attrs.tags
     for expected_tag in [
-        "driver=amdgpu",
+        "requires-gpu-amd",
         "exclusive-if-local",
         "resource_group:gpu",
     ]:

--- a/runtime/build_tools/bazel/test/hal_cts/hal_cts_rules_test.bzl
+++ b/runtime/build_tools/bazel/test/hal_cts/hal_cts_rules_test.bzl
@@ -36,7 +36,7 @@ def _test_non_executable_suite_generates_wrapped_test(name, **kwargs):
         resource_group = "gpu",
         size = "medium",
         tags = [
-            "driver=fixture",
+            "fixture-driver",
             "manual",
         ],
     )
@@ -60,7 +60,7 @@ def _test_non_executable_suite_generates_wrapped_test_impl(env, target):
 
     attrs = target[TestingAspectInfo].attrs
     _expect_value(env, attrs.args, "--cts_fixture_flag=true")
-    _expect_value(env, attrs.tags, "driver=fixture")
+    _expect_value(env, attrs.tags, "fixture-driver")
     _expect_value(env, attrs.tags, "exclusive-if-local")
     _expect_value(env, attrs.tags, "resource_group:gpu")
     env.expect.that_bool(attrs.local).equals(True)

--- a/runtime/src/iree/hal/drivers/metal/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/metal/cts/CMakeLists.txt
@@ -42,6 +42,4 @@ iree_hal_cts_test_suite(
     ::backends
   TESTDATA_LIBS
     ::testdata_metal_spirv_lib
-  LABELS
-    "driver=metal"
 )

--- a/runtime/src/iree/hal/drivers/vulkan/logical_device.c
+++ b/runtime/src/iree/hal/drivers/vulkan/logical_device.c
@@ -2053,7 +2053,7 @@ static iree_status_t iree_hal_vulkan_logical_device_create_from_selection(
 
   if (iree_status_is_ok(status)) {
     *out_device = (iree_hal_device_t*)device;
-  } else if (device) {
+  } else {
     iree_hal_device_release((iree_hal_device_t*)device);
   }
   IREE_TRACE_ZONE_END(z0);
@@ -2215,7 +2215,7 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_wrap_device(
   }
   if (iree_status_is_ok(status)) {
     *out_device = (iree_hal_device_t*)device;
-  } else if (device) {
+  } else {
     iree_hal_device_release((iree_hal_device_t*)device);
   }
 

--- a/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.c
+++ b/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.c
@@ -14,11 +14,7 @@ IREE_FLAG_LIST(string, vulkan_libvulkan_search_path,
                "Search path (directory or file) for the Vulkan loader library "
                "(`libvulkan.so`, `vulkan-1.dll`, etc).");
 
-#ifndef NDEBUG
-#define IREE_HAL_VULKAN_DEBUG_FLAG_DEFAULT true
-#else
 #define IREE_HAL_VULKAN_DEBUG_FLAG_DEFAULT false
-#endif  // !NDEBUG
 
 IREE_FLAG(bool, vulkan_validation_layers, IREE_HAL_VULKAN_DEBUG_FLAG_DEFAULT,
           "Requests Vulkan validation layers.");


### PR DESCRIPTION
Extend the Vulkan CI lanes so Loom SPIR-V/Vulkan execution coverage is selected by the same semantic resource contract as runtime Vulkan tests. Bazel now keeps the runtime Vulkan package test step and adds resource-sliced Loom tests using the runtime.resource.vulkan_device tag. CMake builds package-level Loom targets and runs non-runtime Vulkan-resource tests through the runtime-resource=vulkan-device CTest label.

Keep root CI configuration as policy instead of an inventory of individual tests. The config now records package roots, target patterns, resource labels, and build slices; new tests join hardware lanes by carrying the right run-requirement tags near the test definition.

Make Vulkan validation and debug utils explicit opt-ins instead of debug-build defaults. Public examples and embedding tests can create Vulkan HAL devices without needing test-only flag parsing or validation-layer suppression arguments.