### PR TITLE
[HAL] Make executable globals usable

### DIFF
--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -1114,8 +1114,17 @@ iree_status_t iree_hal_streaming_module_function(
     iree_hal_streaming_module_t* module, const char* name,
     iree_hal_streaming_symbol_t** out_function);
 
-// Resolves a global symbol by name, lazily querying HAL executable globals.
-// Returned storage is owned by |module| and remains valid while it is live.
+// Tries to resolve a global symbol by name, lazily querying HAL executable
+// globals. Returned storage is owned by |module| and remains valid while it is
+// live.
+// Synchronization: module (global cache).
+iree_status_t iree_hal_streaming_module_try_lookup_global_symbol(
+    iree_hal_streaming_module_t* module, const char* name, bool* out_found,
+    iree_hal_streaming_symbol_t** out_global);
+
+// Resolves a required global symbol by name, lazily querying HAL executable
+// globals. Returned storage is owned by |module| and remains valid while it is
+// live.
 // Synchronization: module (global cache).
 iree_status_t iree_hal_streaming_module_global_symbol(
     iree_hal_streaming_module_t* module, const char* name,

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -542,7 +542,13 @@ typedef struct iree_hal_streaming_symbol_t {
   iree_hal_streaming_parameter_info_t parameters;
 
   // Global/data attributes (only valid for GLOBAL/DATA types).
+  // HAL executable global handle, when backed by an executable global.
+  iree_hal_executable_global_t global_handle;
+  // Cached streaming wrapper around the executable-owned global buffer.
+  iree_hal_streaming_buffer_t* global_buffer;
+  // HIP/CUDA-visible device pointer for the global storage.
   iree_hal_streaming_deviceptr_t device_address;
+  // Byte length of the global storage.
   iree_device_size_t size_bytes;
 } iree_hal_streaming_symbol_t;
 
@@ -560,6 +566,15 @@ typedef struct iree_hal_streaming_module_t {
   // Symbol metadata.
   iree_hal_streaming_symbol_t* symbols;
   iree_host_size_t symbol_count;
+
+  // Synchronizes lazy executable global resolution and cache access.
+  iree_slim_mutex_t global_mutex;
+  // Cached executable global symbols keyed by name.
+  iree_hal_streaming_symbol_t** globals;
+  // Number of cached executable global symbols.
+  iree_host_size_t global_count;
+  // Capacity of the cached executable global symbols array.
+  iree_host_size_t global_capacity;
 
   // File mapping if loaded from file.
   iree_io_file_mapping_t* file_mapping;
@@ -1099,7 +1114,14 @@ iree_status_t iree_hal_streaming_module_function(
     iree_hal_streaming_module_t* module, const char* name,
     iree_hal_streaming_symbol_t** out_function);
 
-// Synchronization: none (queries global metadata).
+// Resolves a global symbol by name, lazily querying HAL executable globals.
+// Returned storage is owned by |module| and remains valid while it is live.
+// Synchronization: module (global cache).
+iree_status_t iree_hal_streaming_module_global_symbol(
+    iree_hal_streaming_module_t* module, const char* name,
+    iree_hal_streaming_symbol_t** out_global);
+
+// Synchronization: module (global cache).
 iree_status_t iree_hal_streaming_module_global(
     iree_hal_streaming_module_t* module, const char* name,
     iree_hal_streaming_deviceptr_t* out_device_ptr,
@@ -1285,6 +1307,20 @@ iree_status_t iree_hal_streaming_memory_free_host(
 // Synchronization: none; called during context destruction after streams idle.
 void iree_hal_streaming_memory_release_pageable_staging(
     iree_hal_streaming_context_t* context);
+
+// Wraps an existing HAL buffer and registers it in the context pointer map.
+// The wrapper retains |buffer| for HRX interop, but callers must still ensure
+// the backing owner remains live for the duration required by the HAL API.
+// Synchronization: none (registers existing memory).
+iree_status_t iree_hal_streaming_memory_wrap_buffer(
+    iree_hal_streaming_context_t* context, iree_hal_buffer_t* buffer,
+    iree_hal_streaming_buffer_context_ownership_t context_ownership,
+    iree_hal_streaming_buffer_t** out_buffer);
+
+// Releases a wrapper created with iree_hal_streaming_memory_wrap_buffer.
+// Synchronization: none (unregisters existing memory).
+void iree_hal_streaming_memory_release_wrapped_buffer(
+    iree_hal_streaming_buffer_t* buffer);
 
 // Synchronization: none (registers existing memory).
 iree_status_t iree_hal_streaming_memory_register_host(

--- a/libhrx/src/binding/common/memory.c
+++ b/libhrx/src/binding/common/memory.c
@@ -196,6 +196,27 @@ static void iree_hal_streaming_buffer_free(
   IREE_TRACE_ZONE_END(z0);
 }
 
+iree_status_t iree_hal_streaming_memory_wrap_buffer(
+    iree_hal_streaming_context_t* context, iree_hal_buffer_t* buffer,
+    iree_hal_streaming_buffer_context_ownership_t context_ownership,
+    iree_hal_streaming_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(context);
+  IREE_ASSERT_ARGUMENT(buffer);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  *out_buffer = NULL;
+
+  return iree_hal_streaming_buffer_wrap(
+      context, buffer, (int)iree_hal_buffer_memory_type(buffer),
+      context_ownership, out_buffer);
+}
+
+void iree_hal_streaming_memory_release_wrapped_buffer(
+    iree_hal_streaming_buffer_t* buffer) {
+  if (!buffer) return;
+  hrx_buffer_table_remove(&buffer->context->buffer_table, buffer->device_ptr);
+  iree_hal_streaming_buffer_free(buffer);
+}
+
 static void iree_hal_streaming_temporary_host_buffer_free(
     iree_hal_streaming_context_t* context,
     iree_hal_streaming_buffer_t* buffer) {

--- a/libhrx/src/binding/common/module.c
+++ b/libhrx/src/binding/common/module.c
@@ -592,24 +592,12 @@ static iree_status_t iree_hal_streaming_module_grow_globals_locked(
     iree_hal_streaming_module_t* module, iree_host_size_t minimum_capacity) {
   if (minimum_capacity <= module->global_capacity) return iree_ok_status();
 
-  iree_host_size_t new_capacity =
-      module->global_capacity ? module->global_capacity : 4;
-  while (new_capacity < minimum_capacity) {
-    if (!iree_host_size_checked_mul(new_capacity, 2, &new_capacity)) {
-      return iree_make_status(
-          IREE_STATUS_OUT_OF_RANGE,
-          "module global cache capacity overflow growing to %" PRIhsz,
-          minimum_capacity);
-    }
-  }
-
-  void* new_globals = module->globals;
-  IREE_RETURN_IF_ERROR(
-      iree_allocator_realloc_array(module->host_allocator, new_capacity,
-                                   sizeof(*module->globals), &new_globals));
-  module->globals = (iree_hal_streaming_symbol_t**)new_globals;
-  module->global_capacity = new_capacity;
-  return iree_ok_status();
+  const iree_host_size_t minimum_allocated_capacity =
+      minimum_capacity < 4 ? 4 : minimum_capacity;
+  return iree_allocator_grow_array(
+      module->host_allocator, minimum_allocated_capacity,
+      sizeof(*module->globals), &module->global_capacity,
+      (void**)&module->globals);
 }
 
 static iree_status_t iree_hal_streaming_module_create_global_symbol_locked(
@@ -664,12 +652,14 @@ static iree_status_t iree_hal_streaming_module_create_global_symbol_locked(
   return status;
 }
 
-iree_status_t iree_hal_streaming_module_global_symbol(
-    iree_hal_streaming_module_t* module, const char* name,
+iree_status_t iree_hal_streaming_module_try_lookup_global_symbol(
+    iree_hal_streaming_module_t* module, const char* name, bool* out_found,
     iree_hal_streaming_symbol_t** out_global) {
   IREE_ASSERT_ARGUMENT(module);
   IREE_ASSERT_ARGUMENT(name);
+  IREE_ASSERT_ARGUMENT(out_found);
   IREE_ASSERT_ARGUMENT(out_global);
+  *out_found = false;
   *out_global = NULL;
 
   iree_string_view_t name_view =
@@ -681,6 +671,7 @@ iree_status_t iree_hal_streaming_module_global_symbol(
          symbol->type == IREE_HAL_STREAMING_SYMBOL_TYPE_DATA) &&
         iree_hal_streaming_module_symbol_name_matches(symbol->name,
                                                       name_view)) {
+      *out_found = true;
       *out_global = symbol;
       return iree_ok_status();
     }
@@ -692,6 +683,7 @@ iree_status_t iree_hal_streaming_module_global_symbol(
   iree_hal_streaming_symbol_t* cached_symbol =
       iree_hal_streaming_module_find_global_locked(module, name_view);
   if (cached_symbol) {
+    *out_found = true;
     *out_global = cached_symbol;
   } else {
     const iree_host_size_t executable_count =
@@ -710,17 +702,33 @@ iree_status_t iree_hal_streaming_module_global_symbol(
       if (!found) continue;
       status = iree_hal_streaming_module_create_global_symbol_locked(
           module, executable, global_handle, out_global);
+      if (iree_status_is_ok(status)) *out_found = true;
       break;
-    }
-    if (iree_status_is_ok(status) && !*out_global) {
-      status = iree_make_status(IREE_STATUS_NOT_FOUND,
-                                "global '%.*s' not found in module",
-                                (int)name_view.size, name_view.data);
     }
   }
 
   iree_slim_mutex_unlock(&module->global_mutex);
   return status;
+}
+
+iree_status_t iree_hal_streaming_module_global_symbol(
+    iree_hal_streaming_module_t* module, const char* name,
+    iree_hal_streaming_symbol_t** out_global) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_ASSERT_ARGUMENT(name);
+  IREE_ASSERT_ARGUMENT(out_global);
+  *out_global = NULL;
+
+  bool found = false;
+  IREE_RETURN_IF_ERROR(iree_hal_streaming_module_try_lookup_global_symbol(
+      module, name, &found, out_global));
+  if (found) return iree_ok_status();
+
+  iree_string_view_t name_view =
+      iree_string_view_trim(iree_make_cstring_view(name));
+  return iree_make_status(IREE_STATUS_NOT_FOUND,
+                          "global '%.*s' not found in module",
+                          (int)name_view.size, name_view.data);
 }
 
 iree_status_t iree_hal_streaming_module_global(

--- a/libhrx/src/binding/common/module.c
+++ b/libhrx/src/binding/common/module.c
@@ -319,6 +319,7 @@ iree_status_t iree_hal_streaming_module_create_from_memory(
       iree_allocator_malloc(host_allocator, sizeof(*module), (void**)&module));
   memset(module, 0, sizeof(*module));
   iree_atomic_ref_count_init(&module->ref_count);
+  iree_slim_mutex_initialize(&module->global_mutex);
   module->context = context;
   iree_hal_streaming_context_retain(context);
   module->host_allocator = host_allocator;
@@ -477,6 +478,16 @@ static void iree_hal_streaming_module_destroy(
   // Release symbol metadata.
   iree_allocator_free(module->host_allocator, module->symbols);
 
+  // Release cached executable globals while both the context pointer map and
+  // executable-owned global buffers are still live.
+  for (iree_host_size_t i = 0; i < module->global_count; ++i) {
+    iree_hal_streaming_memory_release_wrapped_buffer(
+        module->globals[i]->global_buffer);
+    iree_allocator_free(host_allocator, module->globals[i]);
+  }
+  iree_allocator_free(host_allocator, module->globals);
+  iree_slim_mutex_deinitialize(&module->global_mutex);
+
   // Release executable before the fat-binary extract: the HAL's code
   // object reader may still alias pointers into the (possibly owned)
   // backing store held by the extract until the executable drops.
@@ -516,6 +527,15 @@ void iree_hal_streaming_module_release(iree_hal_streaming_module_t* module) {
   }
 }
 
+static bool iree_hal_streaming_module_symbol_name_matches(
+    iree_string_view_t symbol_name, iree_string_view_t name) {
+  if (iree_string_view_equal(symbol_name, name)) return true;
+  iree_string_view_t stripped_name =
+      iree_string_view_strip_suffix(name, IREE_SV(".kd"));
+  return stripped_name.size != name.size &&
+         iree_string_view_equal(symbol_name, stripped_name);
+}
+
 iree_status_t iree_hal_streaming_module_symbol(
     iree_hal_streaming_module_t* module, const char* name,
     iree_hal_streaming_symbol_type_t expected_type,
@@ -527,12 +547,9 @@ iree_status_t iree_hal_streaming_module_symbol(
 
   iree_string_view_t name_view =
       iree_string_view_trim(iree_make_cstring_view(name));
-  iree_string_view_t stripped_name =
-      iree_string_view_strip_suffix(name_view, IREE_SV(".kd"));
   for (uint32_t i = 0; i < module->symbol_count; ++i) {
-    if (iree_string_view_equal(module->symbols[i].name, name_view) ||
-        (stripped_name.size != name_view.size &&
-         iree_string_view_equal(module->symbols[i].name, stripped_name))) {
+    if (iree_hal_streaming_module_symbol_name_matches(module->symbols[i].name,
+                                                      name_view)) {
       // Check if the symbol type matches expected type.
       if (module->symbols[i].type == expected_type) {
         // Return symbol info as pointer.
@@ -545,7 +562,6 @@ iree_status_t iree_hal_streaming_module_symbol(
             (int)name_view.size, name_view.data, expected_type,
             module->symbols[i].type);
       }
-      break;
     }
   }
   return iree_make_status(IREE_STATUS_NOT_FOUND,
@@ -560,6 +576,159 @@ iree_status_t iree_hal_streaming_module_function(
       module, name, IREE_HAL_STREAMING_SYMBOL_TYPE_FUNCTION, out_function);
 }
 
+static iree_hal_streaming_symbol_t*
+iree_hal_streaming_module_find_global_locked(
+    iree_hal_streaming_module_t* module, iree_string_view_t name) {
+  for (iree_host_size_t i = 0; i < module->global_count; ++i) {
+    iree_hal_streaming_symbol_t* symbol = module->globals[i];
+    if (iree_hal_streaming_module_symbol_name_matches(symbol->name, name)) {
+      return symbol;
+    }
+  }
+  return NULL;
+}
+
+static iree_status_t iree_hal_streaming_module_grow_globals_locked(
+    iree_hal_streaming_module_t* module, iree_host_size_t minimum_capacity) {
+  if (minimum_capacity <= module->global_capacity) return iree_ok_status();
+
+  iree_host_size_t new_capacity =
+      module->global_capacity ? module->global_capacity : 4;
+  while (new_capacity < minimum_capacity) {
+    if (!iree_host_size_checked_mul(new_capacity, 2, &new_capacity)) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "module global cache capacity overflow growing to %" PRIhsz,
+          minimum_capacity);
+    }
+  }
+
+  void* new_globals = module->globals;
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_realloc_array(module->host_allocator, new_capacity,
+                                   sizeof(*module->globals), &new_globals));
+  module->globals = (iree_hal_streaming_symbol_t**)new_globals;
+  module->global_capacity = new_capacity;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_module_create_global_symbol_locked(
+    iree_hal_streaming_module_t* module, iree_hal_executable_t* executable,
+    iree_hal_executable_global_t global_handle,
+    iree_hal_streaming_symbol_t** out_symbol) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_ASSERT_ARGUMENT(executable);
+  IREE_ASSERT_ARGUMENT(out_symbol);
+  *out_symbol = NULL;
+
+  iree_hal_executable_global_info_t global_info;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_executable_global_info(executable, global_handle, &global_info));
+
+  iree_hal_buffer_t* global_buffer = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_executable_global_buffer(
+      executable, global_handle, IREE_HAL_QUEUE_AFFINITY_ANY, &global_buffer));
+
+  iree_hal_streaming_buffer_t* streaming_buffer = NULL;
+  iree_status_t status = iree_hal_streaming_memory_wrap_buffer(
+      module->context, global_buffer,
+      IREE_HAL_STREAMING_BUFFER_CONTEXT_BORROWED, &streaming_buffer);
+
+  iree_hal_streaming_symbol_t* symbol = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_allocator_malloc(module->host_allocator, sizeof(*symbol),
+                                   (void**)&symbol);
+  }
+  if (iree_status_is_ok(status)) {
+    memset(symbol, 0, sizeof(*symbol));
+    symbol->module = module;
+    symbol->name = global_info.name;
+    symbol->type = IREE_HAL_STREAMING_SYMBOL_TYPE_GLOBAL;
+    symbol->executable = executable;
+    symbol->global_handle = global_handle;
+    symbol->global_buffer = streaming_buffer;
+    symbol->device_address =
+        iree_hal_streaming_buffer_device_pointer(streaming_buffer);
+    symbol->size_bytes = global_info.byte_length;
+    status = iree_hal_streaming_module_grow_globals_locked(
+        module, module->global_count + 1);
+  }
+
+  if (iree_status_is_ok(status)) {
+    module->globals[module->global_count++] = symbol;
+    *out_symbol = symbol;
+  } else {
+    iree_allocator_free(module->host_allocator, symbol);
+    iree_hal_streaming_memory_release_wrapped_buffer(streaming_buffer);
+  }
+  return status;
+}
+
+iree_status_t iree_hal_streaming_module_global_symbol(
+    iree_hal_streaming_module_t* module, const char* name,
+    iree_hal_streaming_symbol_t** out_global) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_ASSERT_ARGUMENT(name);
+  IREE_ASSERT_ARGUMENT(out_global);
+  *out_global = NULL;
+
+  iree_string_view_t name_view =
+      iree_string_view_trim(iree_make_cstring_view(name));
+
+  for (iree_host_size_t i = 0; i < module->symbol_count; ++i) {
+    iree_hal_streaming_symbol_t* symbol = &module->symbols[i];
+    if ((symbol->type == IREE_HAL_STREAMING_SYMBOL_TYPE_GLOBAL ||
+         symbol->type == IREE_HAL_STREAMING_SYMBOL_TYPE_DATA) &&
+        iree_hal_streaming_module_symbol_name_matches(symbol->name,
+                                                      name_view)) {
+      *out_global = symbol;
+      return iree_ok_status();
+    }
+  }
+
+  iree_status_t status = iree_ok_status();
+  iree_slim_mutex_lock(&module->global_mutex);
+
+  iree_hal_streaming_symbol_t* cached_symbol =
+      iree_hal_streaming_module_find_global_locked(module, name_view);
+  if (cached_symbol) {
+    *out_global = cached_symbol;
+  } else {
+    const iree_host_size_t executable_count =
+        module->executable_count ? module->executable_count : 1;
+    for (iree_host_size_t executable_ordinal = 0;
+         executable_ordinal < executable_count; ++executable_ordinal) {
+      iree_hal_executable_t* executable =
+          module->executables ? module->executables[executable_ordinal]
+                              : module->executable;
+      iree_hal_executable_global_t global_handle =
+          iree_hal_executable_global_invalid();
+      status = iree_hal_executable_lookup_global_by_name(executable, name_view,
+                                                         &global_handle);
+      if (iree_status_is_not_found(status)) {
+        // Merged HIP fat binaries are represented as several HAL executables.
+        // A miss in one entry is expected while probing for the entry that owns
+        // the global; the terminal miss below is the user-visible error.
+        iree_status_ignore(status);
+        status = iree_ok_status();
+        continue;
+      }
+      if (!iree_status_is_ok(status)) break;
+      status = iree_hal_streaming_module_create_global_symbol_locked(
+          module, executable, global_handle, out_global);
+      break;
+    }
+    if (iree_status_is_ok(status) && !*out_global) {
+      status = iree_make_status(IREE_STATUS_NOT_FOUND,
+                                "global '%.*s' not found in module",
+                                (int)name_view.size, name_view.data);
+    }
+  }
+
+  iree_slim_mutex_unlock(&module->global_mutex);
+  return status;
+}
+
 iree_status_t iree_hal_streaming_module_global(
     iree_hal_streaming_module_t* module, const char* name,
     iree_hal_streaming_deviceptr_t* out_device_ptr,
@@ -570,15 +739,9 @@ iree_status_t iree_hal_streaming_module_global(
   *out_device_ptr = 0;
   if (out_size) *out_size = 0;
 
-  // Module globals live entirely in the streaming layer: every exported
-  // global is discovered at module load time (see
-  // iree_hal_streaming_module_extract_metadata) and cached in
-  // module->symbols[]. We intentionally do NOT fall back to a HAL-level
-  // executable lookup; the IREE HAL does not expose a by-name global
-  // lookup and all supported lookups are resolved here.
   iree_hal_streaming_symbol_t* symbol = NULL;
-  IREE_RETURN_IF_ERROR(iree_hal_streaming_module_symbol(
-      module, name, IREE_HAL_STREAMING_SYMBOL_TYPE_GLOBAL, &symbol));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_streaming_module_global_symbol(module, name, &symbol));
 
   *out_device_ptr = symbol->device_address;
   if (out_size) *out_size = symbol->size_bytes;

--- a/libhrx/src/binding/common/module.c
+++ b/libhrx/src/binding/common/module.c
@@ -703,17 +703,11 @@ iree_status_t iree_hal_streaming_module_global_symbol(
                               : module->executable;
       iree_hal_executable_global_t global_handle =
           iree_hal_executable_global_invalid();
-      status = iree_hal_executable_lookup_global_by_name(executable, name_view,
-                                                         &global_handle);
-      if (iree_status_is_not_found(status)) {
-        // Merged HIP fat binaries are represented as several HAL executables.
-        // A miss in one entry is expected while probing for the entry that owns
-        // the global; the terminal miss below is the user-visible error.
-        iree_status_ignore(status);
-        status = iree_ok_status();
-        continue;
-      }
+      bool found = false;
+      status = iree_hal_executable_try_lookup_global_by_name(
+          executable, name_view, &found, &global_handle);
       if (!iree_status_is_ok(status)) break;
+      if (!found) continue;
       status = iree_hal_streaming_module_create_global_symbol_locked(
           module, executable, global_handle, out_global);
       break;

--- a/libhrx/src/binding/common/registry.c
+++ b/libhrx/src/binding/common/registry.c
@@ -580,6 +580,7 @@ static iree_status_t iree_hal_streaming_context_symbol_map_prepare_module(
 
       // Find the corresponding compiled symbol in the module by name.
       iree_hal_streaming_symbol_t* symbol = NULL;
+      bool found = false;
       switch (registration->symbols[i].type) {
         case IREE_HAL_STREAMING_SYMBOL_TYPE_FUNCTION:
           for (iree_host_size_t j = 0; j < entry->module->symbol_count; ++j) {
@@ -592,13 +593,9 @@ static iree_status_t iree_hal_streaming_context_symbol_map_prepare_module(
           break;
         case IREE_HAL_STREAMING_SYMBOL_TYPE_GLOBAL:
         case IREE_HAL_STREAMING_SYMBOL_TYPE_DATA:
-          status = iree_hal_streaming_module_global_symbol(
-              entry->module, registration->symbols[i].device_name, &symbol);
-          if (iree_status_is_not_found(status)) {
-            iree_status_ignore(status);
-            status = iree_ok_status();
-            symbol = NULL;
-          }
+          status = iree_hal_streaming_module_try_lookup_global_symbol(
+              entry->module, registration->symbols[i].device_name, &found,
+              &symbol);
           break;
         default:
           status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,

--- a/libhrx/src/binding/common/registry.c
+++ b/libhrx/src/binding/common/registry.c
@@ -571,7 +571,8 @@ static iree_status_t iree_hal_streaming_context_symbol_map_prepare_module(
   //         iree_status_is_ok(status) ? "OK" : "FAILED");
   if (iree_status_is_ok(status)) {
     // Insert all symbols from the module into the hash table.
-    for (iree_host_size_t i = 0; i < registration->symbol_count; ++i) {
+    for (iree_host_size_t i = 0;
+         iree_status_is_ok(status) && i < registration->symbol_count; ++i) {
       // Get the registered symbol's device name
       iree_string_view_t registered_name =
           iree_make_cstring_view(registration->symbols[i].device_name);
@@ -579,10 +580,44 @@ static iree_status_t iree_hal_streaming_context_symbol_map_prepare_module(
 
       // Find the corresponding compiled symbol in the module by name.
       iree_hal_streaming_symbol_t* symbol = NULL;
-      for (iree_host_size_t j = 0; j < entry->module->symbol_count; ++j) {
-        if (iree_string_view_equal(registered_name,
-                                   entry->module->symbols[j].name)) {
-          symbol = &entry->module->symbols[j];
+      switch (registration->symbols[i].type) {
+        case IREE_HAL_STREAMING_SYMBOL_TYPE_FUNCTION:
+          for (iree_host_size_t j = 0; j < entry->module->symbol_count; ++j) {
+            if (iree_string_view_equal(registered_name,
+                                       entry->module->symbols[j].name)) {
+              symbol = &entry->module->symbols[j];
+              break;
+            }
+          }
+          break;
+        case IREE_HAL_STREAMING_SYMBOL_TYPE_GLOBAL:
+        case IREE_HAL_STREAMING_SYMBOL_TYPE_DATA:
+          status = iree_hal_streaming_module_global_symbol(
+              entry->module, registration->symbols[i].device_name, &symbol);
+          if (iree_status_is_not_found(status)) {
+            iree_status_ignore(status);
+            status = iree_ok_status();
+            symbol = NULL;
+          }
+          break;
+        default:
+          status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                    "unsupported registered symbol type %d",
+                                    registration->symbols[i].type);
+          break;
+      }
+      if (!iree_status_is_ok(status)) {
+        break;
+      }
+      if (symbol && symbol->type != registration->symbols[i].type) {
+        if (!(registration->symbols[i].type ==
+                  IREE_HAL_STREAMING_SYMBOL_TYPE_DATA &&
+              symbol->type == IREE_HAL_STREAMING_SYMBOL_TYPE_GLOBAL)) {
+          status = iree_make_status(
+              IREE_STATUS_INVALID_ARGUMENT,
+              "registered symbol `%.*s` type mismatch (expected %d, got %d)",
+              (int)registered_name.size, registered_name.data,
+              registration->symbols[i].type, symbol->type);
           break;
         }
       }

--- a/runtime/src/iree/hal/cts/core/executable_test.cc
+++ b/runtime/src/iree/hal/cts/core/executable_test.cc
@@ -134,6 +134,16 @@ TEST_P(ExecutableTest, LookupExportByName) {
   EXPECT_EQ(ordinal.value, 0);
 }
 
+TEST_P(ExecutableTest, TryLookupGlobalByNameNotFound) {
+  bool found = true;
+  iree_hal_executable_global_t global =
+      iree_hal_executable_global_from_value(0);
+  IREE_ASSERT_OK(iree_hal_executable_try_lookup_global_by_name(
+      executable_, IREE_SV("NOT_FOUND"), &found, &global));
+  EXPECT_FALSE(found);
+  EXPECT_FALSE(iree_hal_executable_global_is_valid(global));
+}
+
 TEST_P(ExecutableTest, LookupGlobalByNameNotFound) {
   iree_hal_executable_global_t global = iree_hal_executable_global_invalid();
   EXPECT_THAT(Status(iree_hal_executable_lookup_global_by_name(

--- a/runtime/src/iree/hal/cts/core/executable_test.cc
+++ b/runtime/src/iree/hal/cts/core/executable_test.cc
@@ -134,14 +134,12 @@ TEST_P(ExecutableTest, LookupExportByName) {
   EXPECT_EQ(ordinal.value, 0);
 }
 
-TEST_P(ExecutableTest, LookupGlobalByNameNotFoundOrUnsupported) {
-  iree_hal_buffer_t* buffer = nullptr;
+TEST_P(ExecutableTest, LookupGlobalByNameNotFound) {
+  iree_hal_executable_global_t global = iree_hal_executable_global_invalid();
   EXPECT_THAT(Status(iree_hal_executable_lookup_global_by_name(
-                  executable_, IREE_SV("NOT_FOUND"),
-                  IREE_HAL_QUEUE_AFFINITY_ANY, &buffer)),
-              AnyOf(StatusIs(StatusCode::kNotFound),
-                    StatusIs(StatusCode::kUnimplemented)));
-  EXPECT_EQ(buffer, nullptr);
+                  executable_, IREE_SV("NOT_FOUND"), &global)),
+              StatusIs(StatusCode::kNotFound));
+  EXPECT_FALSE(iree_hal_executable_global_is_valid(global));
 }
 
 CTS_REGISTER_EXECUTABLE_TEST_SUITE(ExecutableTest);

--- a/runtime/src/iree/hal/cts/core/executable_test.cc
+++ b/runtime/src/iree/hal/cts/core/executable_test.cc
@@ -144,6 +144,41 @@ TEST_P(ExecutableTest, TryLookupGlobalByNameNotFound) {
   EXPECT_FALSE(iree_hal_executable_global_is_valid(global));
 }
 
+TEST_P(ExecutableTest, LookupGlobalByName) {
+  bool found = false;
+  iree_hal_executable_global_t global = iree_hal_executable_global_invalid();
+  IREE_ASSERT_OK(iree_hal_executable_try_lookup_global_by_name(
+      executable_, IREE_SV("executable_test_global"), &found, &global));
+  if (!found) GTEST_SKIP() << "executable testdata has no globals";
+  ASSERT_TRUE(iree_hal_executable_global_is_valid(global));
+
+  iree_hal_executable_global_info_t info;
+  IREE_ASSERT_OK(iree_hal_executable_global_info(executable_, global, &info));
+  EXPECT_EQ(std::string_view(info.name.data, info.name.size),
+            "executable_test_global");
+  ASSERT_EQ(info.byte_length, sizeof(uint64_t));
+
+  iree_hal_buffer_t* global_buffer = nullptr;
+  IREE_ASSERT_OK(iree_hal_executable_global_buffer(
+      executable_, global, IREE_HAL_QUEUE_AFFINITY_ANY, &global_buffer));
+  ASSERT_NE(global_buffer, nullptr);
+  EXPECT_EQ(iree_hal_buffer_byte_length(global_buffer), sizeof(uint64_t));
+
+  const uint64_t expected_value = 0xFEEDFACECAFEBEEFull;
+  SemaphoreList empty_wait;
+  SemaphoreList update_signal(device_, {0}, {1});
+  IREE_ASSERT_OK(iree_hal_device_queue_update(
+      device_, IREE_HAL_QUEUE_AFFINITY_ANY, empty_wait, update_signal,
+      &expected_value, /*source_offset=*/0, global_buffer, /*target_offset=*/0,
+      sizeof(expected_value), IREE_HAL_UPDATE_FLAG_NONE));
+  IREE_ASSERT_OK(iree_hal_semaphore_list_wait(
+      update_signal, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE));
+
+  std::vector<uint64_t> data = ReadBufferData<uint64_t>(global_buffer);
+  ASSERT_EQ(data.size(), 1u);
+  EXPECT_EQ(data[0], expected_value);
+}
+
 TEST_P(ExecutableTest, LookupGlobalByNameNotFound) {
   iree_hal_executable_global_t global = iree_hal_executable_global_invalid();
   EXPECT_THAT(Status(iree_hal_executable_lookup_global_by_name(

--- a/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
@@ -32,6 +32,21 @@ iree_runtime_cc_library(
 )
 
 iree_runtime_cc_library(
+    name = "buffer",
+    srcs = ["buffer.c"],
+    hdrs = ["buffer.h"],
+    deps = [
+        ":headers",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal",
+        "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/base/threading",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/drivers/amdgpu/util:libhsa",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "access_policy",
     srcs = ["access_policy.c"],
     hdrs = ["access_policy.h"],
@@ -110,8 +125,6 @@ iree_runtime_cc_library(
         "aql_program_builder.h",
         "aql_program_validation.c",
         "aql_program_validation.h",
-        "buffer.c",
-        "buffer.h",
         "driver.c",
         "driver.h",
         "executable.c",
@@ -194,6 +207,7 @@ iree_runtime_cc_library(
     ],
     deps = [
         ":access_policy",
+        ":buffer",
         ":executable_metadata",
         ":executable_metadata_hsaco",
         ":kernarg_layout",
@@ -218,6 +232,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/drivers/amdgpu/util:code_object_target",
         "//runtime/src/iree/hal/drivers/amdgpu/util:device_clock",
         "//runtime/src/iree/hal/drivers/amdgpu/util:device_library",
+        "//runtime/src/iree/hal/drivers/amdgpu/util:global_table",
         "//runtime/src/iree/hal/drivers/amdgpu/util:hsaco_metadata",
         "//runtime/src/iree/hal/drivers/amdgpu/util:info",
         "//runtime/src/iree/hal/drivers/amdgpu/util:kfd",
@@ -246,6 +261,7 @@ iree_runtime_cc_library(
 iree_runtime_cc_library(
     name = "headers",
     hdrs = [
+        "api.h",
         "aql_block_processor.h",
         "aql_block_processor_timestamp.h",
         "aql_command_buffer.h",

--- a/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
@@ -27,6 +27,26 @@ endif()
 if(IREE_HAL_DRIVER_AMDGPU)
 iree_cc_library(
   NAME
+    buffer
+  HDRS
+    "buffer.h"
+  SRCS
+    "buffer.c"
+  DEPS
+    ::headers
+    iree::base
+    iree::base::internal
+    iree::base::internal::arena
+    iree::base::threading
+    iree::hal
+    iree::hal::drivers::amdgpu::util::libhsa
+  PUBLIC
+)
+endif()
+
+if(IREE_HAL_DRIVER_AMDGPU)
+iree_cc_library(
+  NAME
     access_policy
   HDRS
     "access_policy.h"
@@ -132,8 +152,6 @@ iree_cc_library(
     "aql_program_builder.h"
     "aql_program_validation.c"
     "aql_program_validation.h"
-    "buffer.c"
-    "buffer.h"
     "driver.c"
     "driver.h"
     "executable.c"
@@ -212,6 +230,7 @@ iree_cc_library(
     "virtual_queue.h"
   DEPS
     ::access_policy
+    ::buffer
     ::executable_metadata
     ::executable_metadata_hsaco
     ::kernarg_layout
@@ -236,6 +255,7 @@ iree_cc_library(
     iree::hal::drivers::amdgpu::util::code_object_target
     iree::hal::drivers::amdgpu::util::device_clock
     iree::hal::drivers::amdgpu::util::device_library
+    iree::hal::drivers::amdgpu::util::global_table
     iree::hal::drivers::amdgpu::util::hsaco_metadata
     iree::hal::drivers::amdgpu::util::info
     iree::hal::drivers::amdgpu::util::kfd
@@ -265,6 +285,7 @@ iree_cc_library(
   NAME
     headers
   HDRS
+    "api.h"
     "aql_block_processor.h"
     "aql_block_processor_timestamp.h"
     "aql_command_buffer.h"

--- a/runtime/src/iree/hal/drivers/amdgpu/cts/testdata/executable_test.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/cts/testdata/executable_test.c
@@ -6,6 +6,9 @@
 
 #include "iree/hal/drivers/amdgpu/device/support/kernel.h"
 
+[[gnu::visibility("protected"), gnu::used]]
+uint64_t executable_test_global = 0x0123456789ABCDEFull;
+
 IREE_AMDGPU_ATTRIBUTE_KERNEL void export0(uint64_t* lhs, uint64_t* rhs,
                                           uint32_t c0, uint32_t c1) {
   if (c0 == c1) {

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -7,10 +7,10 @@
 #include "iree/hal/drivers/amdgpu/executable.h"
 
 #include "iree/base/internal/debugging.h"
-#include "iree/hal/drivers/amdgpu/buffer.h"
 #include "iree/hal/drivers/amdgpu/executable_metadata_hsaco.h"
 #include "iree/hal/drivers/amdgpu/queue_affinity.h"
 #include "iree/hal/drivers/amdgpu/util/code_object_target.h"
+#include "iree/hal/drivers/amdgpu/util/global_table.h"
 #include "iree/hal/drivers/amdgpu/util/hsaco_metadata.h"
 #include "iree/hal/drivers/amdgpu/util/kernarg_ring.h"
 #include "iree/hal/drivers/amdgpu/util/loaded_code_object.h"
@@ -628,29 +628,6 @@ static iree_status_t iree_hal_amdgpu_executable_get_raw_hsaco_symbol_by_name(
       libhsa, executable, symbol_name_storage, device_agent, out_symbol);
 }
 
-static iree_status_t iree_hal_amdgpu_executable_get_global_symbol_by_name(
-    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_executable_t executable,
-    iree_string_view_t symbol_name, hsa_agent_t device_agent,
-    hsa_executable_symbol_t* out_symbol) {
-  if (iree_string_view_is_empty(symbol_name)) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "executable global name is empty");
-  }
-  if (symbol_name.size > IREE_HAL_AMDGPU_MAX_STACK_SYMBOL_NAME_LENGTH) {
-    return iree_make_status(
-        IREE_STATUS_OUT_OF_RANGE,
-        "executable global name `%.*s` exceeds maximum length %" PRIhsz,
-        (int)symbol_name.size, symbol_name.data,
-        IREE_HAL_AMDGPU_MAX_STACK_SYMBOL_NAME_LENGTH);
-  }
-
-  char* symbol_name_storage = (char*)iree_alloca(symbol_name.size + 1);
-  memcpy(symbol_name_storage, symbol_name.data, symbol_name.size);
-  symbol_name_storage[symbol_name.size] = 0;
-  return iree_hal_amdgpu_executable_get_symbol_by_cstring(
-      libhsa, executable, symbol_name_storage, device_agent, out_symbol);
-}
-
 // Resolves the uniform kernel arguments that are the same on all GPU device
 // agents in the topology (since we assume all are the same device type).
 // All fields besides `kernel_object` will have valid values.
@@ -971,6 +948,8 @@ typedef struct iree_hal_amdgpu_executable_t {
   iree_host_size_t device_count;
   // HSA GPU agents indexed by physical device ordinal.
   hsa_agent_t* device_agents /*[device_count]*/;
+  // Executable global lookup and per-device buffer alias cache.
+  iree_hal_amdgpu_global_table_t global_table;
   // Table of kernel args stored in device memory, one copy per device.
   // Selected devices have an entire `kernel_count` set of args; unselected
   // devices remain NULL and fail lookup.
@@ -1440,6 +1419,20 @@ static iree_status_t iree_hal_amdgpu_executable_create_from_raw_hsaco(
         &executable->handle);
   }
   if (iree_status_is_ok(status)) {
+    const iree_hal_amdgpu_global_table_hsa_params_t global_table_params = {
+        .host_allocator = host_allocator,
+        .queue_affinity_domain = executable->queue_affinity_domain,
+        .loaded_physical_device_mask = executable->loaded_physical_device_mask,
+        .libhsa = libhsa,
+        .device = device,
+        .executable = executable->handle,
+        .device_agent_count = executable->device_count,
+        .device_agents = executable->device_agents,
+    };
+    status = iree_hal_amdgpu_global_table_initialize_hsa(
+        &global_table_params, &executable->global_table);
+  }
+  if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_executable_create_metadata_from_hsaco(
         libhsa, executable->handle, any_device_agent, &hsaco_metadata,
         host_allocator, &executable->metadata);
@@ -1619,6 +1612,7 @@ static void iree_hal_amdgpu_executable_destroy(
     }
   }
 
+  iree_hal_amdgpu_global_table_deinitialize(&executable->global_table);
   iree_hal_amdgpu_executable_metadata_free(executable->metadata);
   if (executable->handle.handle) {
     iree_hal_amdgpu_hsa_cleanup_assert_success(iree_hsa_executable_destroy_raw(
@@ -1818,75 +1812,31 @@ static iree_status_t iree_hal_amdgpu_executable_lookup_export_by_name(
                           (int)name.size, name.data);
 }
 
-static void iree_hal_amdgpu_executable_global_buffer_release(
-    void* user_data, iree_hal_buffer_t* buffer) {
-  (void)buffer;
-  iree_hal_executable_release((iree_hal_executable_t*)user_data);
-}
-
 static iree_status_t iree_hal_amdgpu_executable_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_executable_global_t* out_global) {
+  iree_hal_amdgpu_executable_t* executable =
+      iree_hal_amdgpu_executable_cast(base_executable);
+  return iree_hal_amdgpu_global_table_lookup(&executable->global_table, name,
+                                             out_global);
+}
+
+static iree_status_t iree_hal_amdgpu_executable_global_info(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
+  iree_hal_amdgpu_executable_t* executable =
+      iree_hal_amdgpu_executable_cast(base_executable);
+  return iree_hal_amdgpu_global_table_info(&executable->global_table, global,
+                                           out_info);
+}
+
+static iree_status_t iree_hal_amdgpu_executable_global_buffer(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
     iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
   iree_hal_amdgpu_executable_t* executable =
       iree_hal_amdgpu_executable_cast(base_executable);
-  *out_buffer = NULL;
-
-  iree_hal_queue_affinity_t requested_queue_affinity = queue_affinity;
-  if (iree_hal_queue_affinity_is_empty(requested_queue_affinity)) {
-    requested_queue_affinity = IREE_HAL_QUEUE_AFFINITY_ANY;
-  }
-
-  iree_hal_queue_affinity_t selected_queue_affinity = 0;
-  iree_host_size_t physical_device_ordinal = 0;
-  IREE_RETURN_IF_ERROR(
-      iree_hal_amdgpu_queue_affinity_normalize_for_physical_device(
-          executable->queue_affinity_domain, requested_queue_affinity,
-          &selected_queue_affinity, &physical_device_ordinal));
-
-  hsa_executable_symbol_t symbol = {0};
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_executable_get_global_symbol_by_name(
-      executable->libhsa, executable->handle, name,
-      executable->device_agents[physical_device_ordinal], &symbol));
-
-  hsa_symbol_kind_t symbol_kind = HSA_SYMBOL_KIND_KERNEL;
-  IREE_RETURN_IF_ERROR(iree_hsa_executable_symbol_get_info(
-      IREE_LIBHSA(executable->libhsa), symbol, HSA_EXECUTABLE_SYMBOL_INFO_TYPE,
-      &symbol_kind));
-  if (symbol_kind != HSA_SYMBOL_KIND_VARIABLE) {
-    return iree_make_status(IREE_STATUS_NOT_FOUND,
-                            "executable global `%.*s` not found",
-                            (int)name.size, name.data);
-  }
-
-  uint64_t variable_address = 0;
-  IREE_RETURN_IF_ERROR(iree_hsa_executable_symbol_get_info(
-      IREE_LIBHSA(executable->libhsa), symbol,
-      HSA_EXECUTABLE_SYMBOL_INFO_VARIABLE_ADDRESS, &variable_address));
-  uint32_t variable_size = 0;
-  IREE_RETURN_IF_ERROR(iree_hsa_executable_symbol_get_info(
-      IREE_LIBHSA(executable->libhsa), symbol,
-      HSA_EXECUTABLE_SYMBOL_INFO_VARIABLE_SIZE, &variable_size));
-
-  iree_hal_buffer_placement_t placement = {
-      .device = executable->device,
-      .queue_affinity = selected_queue_affinity,
-      .flags = IREE_HAL_BUFFER_PLACEMENT_FLAG_NONE,
-  };
-  iree_hal_buffer_release_callback_t release_callback = {
-      .fn = iree_hal_amdgpu_executable_global_buffer_release,
-      .user_data = base_executable,
-  };
-  iree_hal_executable_retain(base_executable);
-  iree_status_t status = iree_hal_amdgpu_buffer_create(
-      executable->libhsa, placement, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-      IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE,
-      IREE_HAL_BUFFER_USAGE_DEFAULT, variable_size, variable_size,
-      (void*)(uintptr_t)variable_address, release_callback,
-      executable->host_allocator, out_buffer);
-  if (!iree_status_is_ok(status)) {
-    iree_hal_executable_release(base_executable);
-  }
-  return status;
+  return iree_hal_amdgpu_global_table_buffer(&executable->global_table, global,
+                                             queue_affinity, out_buffer);
 }
 
 static const iree_hal_executable_vtable_t iree_hal_amdgpu_executable_vtable = {
@@ -1896,4 +1846,6 @@ static const iree_hal_executable_vtable_t iree_hal_amdgpu_executable_vtable = {
     .function_parameters = iree_hal_amdgpu_executable_export_parameters,
     .lookup_function_by_name = iree_hal_amdgpu_executable_lookup_export_by_name,
     .lookup_global_by_name = iree_hal_amdgpu_executable_lookup_global_by_name,
+    .global_info = iree_hal_amdgpu_executable_global_info,
+    .global_buffer = iree_hal_amdgpu_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -1812,13 +1812,13 @@ static iree_status_t iree_hal_amdgpu_executable_lookup_export_by_name(
                           (int)name.size, name.data);
 }
 
-static iree_status_t iree_hal_amdgpu_executable_lookup_global_by_name(
+static iree_status_t iree_hal_amdgpu_executable_try_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_executable_global_t* out_global) {
+    bool* out_found, iree_hal_executable_global_t* out_global) {
   iree_hal_amdgpu_executable_t* executable =
       iree_hal_amdgpu_executable_cast(base_executable);
-  return iree_hal_amdgpu_global_table_lookup(&executable->global_table, name,
-                                             out_global);
+  return iree_hal_amdgpu_global_table_try_lookup(&executable->global_table,
+                                                 name, out_found, out_global);
 }
 
 static iree_status_t iree_hal_amdgpu_executable_global_info(
@@ -1845,7 +1845,8 @@ static const iree_hal_executable_vtable_t iree_hal_amdgpu_executable_vtable = {
     .function_info = iree_hal_amdgpu_executable_export_info,
     .function_parameters = iree_hal_amdgpu_executable_export_parameters,
     .lookup_function_by_name = iree_hal_amdgpu_executable_lookup_export_by_name,
-    .lookup_global_by_name = iree_hal_amdgpu_executable_lookup_global_by_name,
+    .try_lookup_global_by_name =
+        iree_hal_amdgpu_executable_try_lookup_global_by_name,
     .global_info = iree_hal_amdgpu_executable_global_info,
     .global_buffer = iree_hal_amdgpu_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/drivers/amdgpu/util/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/BUILD.bazel
@@ -134,6 +134,52 @@ iree_runtime_cc_test(
     ],
 )
 
+iree_runtime_cc_library(
+    name = "global_table",
+    srcs = ["global_table.c"],
+    hdrs = ["global_table.h"],
+    deps = [
+        ":libhsa",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal",
+        "//runtime/src/iree/base/threading",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/drivers/amdgpu:buffer",
+        "//runtime/src/iree/hal/drivers/amdgpu:queue_affinity",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "global_table_test",
+    srcs = ["global_table_test.cc"],
+    deps = [
+        ":global_table",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/drivers/amdgpu",
+        "//runtime/src/iree/hal/drivers/amdgpu:queue_affinity",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_benchmark(
+    name = "global_table_benchmark",
+    srcs = ["global_table_benchmark.cc"],
+    tags = [
+        "benchmark",
+    ],
+    deps = [
+        ":global_table",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/drivers/amdgpu",
+        "//runtime/src/iree/hal/drivers/amdgpu:queue_affinity",
+        "//runtime/src/iree/testing:benchmark",
+        "//runtime/src/iree/testing:benchmark_main",
+    ],
+)
+
 iree_runtime_cc_fuzz(
     name = "hsaco_metadata_fuzz",
     srcs = ["hsaco_metadata_fuzz.cc"],
@@ -350,6 +396,7 @@ iree_runtime_cc_library(
         ":block_pool",
         ":device_library",
         ":device_library_target",
+        ":global_table",
         ":info",
         ":kfd",
         ":loaded_code_object",

--- a/runtime/src/iree/hal/drivers/amdgpu/util/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/CMakeLists.txt
@@ -163,6 +163,75 @@ iree_cc_test(
 endif()
 
 if(IREE_HAL_DRIVER_AMDGPU)
+iree_cc_library(
+  NAME
+    global_table
+  HDRS
+    "global_table.h"
+  SRCS
+    "global_table.c"
+  DEPS
+    ::libhsa
+    iree::base
+    iree::base::internal
+    iree::base::threading
+    iree::hal
+    iree::hal::drivers::amdgpu::buffer
+    iree::hal::drivers::amdgpu::queue_affinity
+  PUBLIC
+)
+endif()
+
+if(IREE_HAL_DRIVER_AMDGPU)
+iree_cc_test(
+  NAME
+    global_table_test
+  SRCS
+    "global_table_test.cc"
+  DEPS
+    ::global_table
+    iree::base
+    iree::hal
+    iree::hal::drivers::amdgpu
+    iree::hal::drivers::amdgpu::queue_affinity
+    iree::testing::gtest
+    iree::testing::gtest_main
+  LABELS
+    "iree-build-requirement=runtime.hal.amdgpu"
+    "iree-run-requirement=runtime.resource.amd_gpu"
+    "runtime-resource=amd-gpu"
+  RESOURCE_GROUP
+    iree-hal-drivers-amdgpu-tests
+)
+endif()
+
+if(IREE_HAL_DRIVER_AMDGPU)
+iree_cc_binary_benchmark(
+  NAME
+    global_table_benchmark
+  SRCS
+    "global_table_benchmark.cc"
+  DEPS
+    ::global_table
+    iree::base
+    iree::hal
+    iree::hal::drivers::amdgpu
+    iree::hal::drivers::amdgpu::queue_affinity
+    iree::testing::benchmark
+    iree::testing::benchmark_main
+    iree::third_party::google_benchmark
+  TESTONLY
+  LABELS
+    "benchmark"
+    "iree-build-requirement=runtime.hal.amdgpu"
+    "iree-run-requirement=runtime.resource.amd_gpu"
+    "runtime-resource=amd-gpu"
+  RESOURCE_GROUP
+    iree-hal-drivers-amdgpu-tests
+)
+endif()
+
+if(IREE_HAL_DRIVER_AMDGPU)
 iree_cc_fuzz(
   NAME
     hsaco_metadata_fuzz
@@ -460,6 +529,7 @@ iree_cc_library(
     ::block_pool
     ::device_library
     ::device_library_target
+    ::global_table
     ::info
     ::kfd
     ::loaded_code_object

--- a/runtime/src/iree/hal/drivers/amdgpu/util/global_table.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/global_table.c
@@ -1,0 +1,543 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/global_table.h"
+
+#include "iree/base/internal/math.h"
+#include "iree/hal/drivers/amdgpu/buffer.h"
+
+#define IREE_HAL_AMDGPU_MAX_STACK_GLOBAL_NAME_LENGTH \
+  ((iree_host_size_t)(4 * 1024))
+
+typedef struct iree_hal_amdgpu_global_table_entry_t {
+  // Executable-local handle value assigned when the entry is interned.
+  uint64_t handle_value;
+
+  // Persistent table-owned name storage.
+  iree_string_view_t name;
+
+  // Byte length verified from the first loaded physical device.
+  iree_device_size_t byte_length;
+
+  // One executable-owned buffer alias per physical device.
+  iree_hal_buffer_t** device_buffers;
+} iree_hal_amdgpu_global_table_entry_t;
+
+static iree_status_t iree_hal_amdgpu_global_table_validate_params(
+    const iree_hal_amdgpu_global_table_params_t* params) {
+  IREE_ASSERT_ARGUMENT(params);
+
+  if (IREE_UNLIKELY(params->physical_device_count == 0)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU global table requires at least one "
+                            "physical device");
+  }
+  if (IREE_UNLIKELY(params->physical_device_count > IREE_HAL_MAX_QUEUES)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "AMDGPU global table physical device count %" PRIhsz
+                            " exceeds queue affinity capacity %" PRIhsz,
+                            params->physical_device_count,
+                            (iree_host_size_t)IREE_HAL_MAX_QUEUES);
+  }
+  if (IREE_UNLIKELY(params->loaded_physical_device_mask == 0)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU global table requires a loaded device");
+  }
+
+  uint64_t valid_physical_device_mask = UINT64_MAX;
+  if (params->physical_device_count < 64) {
+    valid_physical_device_mask =
+        (((uint64_t)1) << params->physical_device_count) - 1;
+  }
+  if (IREE_UNLIKELY(params->loaded_physical_device_mask &
+                    ~valid_physical_device_mask)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "AMDGPU global table loaded device mask 0x%" PRIx64
+                            " exceeds physical device count %" PRIhsz,
+                            params->loaded_physical_device_mask,
+                            params->physical_device_count);
+  }
+
+  if (IREE_UNLIKELY(!params->resolver.verify ||
+                    !params->resolver.create_buffer)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU global table resolver is incomplete");
+  }
+
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_validate_hsa_params(
+    const iree_hal_amdgpu_global_table_hsa_params_t* params) {
+  IREE_ASSERT_ARGUMENT(params);
+
+  if (IREE_UNLIKELY(!params->libhsa)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU global table requires libhsa");
+  }
+  if (IREE_UNLIKELY(!params->device)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU global table requires a HAL device");
+  }
+  if (IREE_UNLIKELY(!params->executable.handle)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU global table requires an HSA executable");
+  }
+  if (IREE_UNLIKELY(params->device_agent_count == 0 ||
+                    !params->device_agents)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU global table requires device agents");
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_get_symbol_by_name(
+    const iree_hal_amdgpu_global_table_t* table, iree_string_view_t name,
+    hsa_agent_t device_agent, hsa_executable_symbol_t* out_symbol) {
+  if (iree_string_view_is_empty(name)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "executable global name is empty");
+  }
+  if (name.size > IREE_HAL_AMDGPU_MAX_STACK_GLOBAL_NAME_LENGTH) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "executable global name `%.*s` exceeds maximum length %" PRIhsz,
+        (int)name.size, name.data,
+        IREE_HAL_AMDGPU_MAX_STACK_GLOBAL_NAME_LENGTH);
+  }
+
+  char* name_storage = (char*)iree_alloca(name.size + 1);
+  memcpy(name_storage, name.data, name.size);
+  name_storage[name.size] = 0;
+  return iree_hsa_executable_get_symbol_by_name(
+      IREE_LIBHSA(table->hsa.libhsa), table->hsa.executable, name_storage,
+      &device_agent, out_symbol);
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_query_variable(
+    const iree_hal_amdgpu_global_table_t* table, hsa_executable_symbol_t symbol,
+    iree_string_view_t name, iree_host_size_t physical_device_ordinal,
+    iree_status_code_t wrong_kind_status_code, uint64_t* out_address,
+    iree_device_size_t* out_byte_length) {
+  hsa_symbol_kind_t symbol_kind = HSA_SYMBOL_KIND_KERNEL;
+  IREE_RETURN_IF_ERROR(iree_hsa_executable_symbol_get_info(
+      IREE_LIBHSA(table->hsa.libhsa), symbol, HSA_EXECUTABLE_SYMBOL_INFO_TYPE,
+      &symbol_kind));
+  if (symbol_kind != HSA_SYMBOL_KIND_VARIABLE) {
+    return iree_make_status(wrong_kind_status_code,
+                            "executable global `%.*s` is not a variable on "
+                            "physical device %" PRIhsz,
+                            (int)name.size, name.data, physical_device_ordinal);
+  }
+
+  if (out_address) {
+    IREE_RETURN_IF_ERROR(iree_hsa_executable_symbol_get_info(
+        IREE_LIBHSA(table->hsa.libhsa), symbol,
+        HSA_EXECUTABLE_SYMBOL_INFO_VARIABLE_ADDRESS, out_address));
+  }
+
+  uint32_t variable_size = 0;
+  IREE_RETURN_IF_ERROR(iree_hsa_executable_symbol_get_info(
+      IREE_LIBHSA(table->hsa.libhsa), symbol,
+      HSA_EXECUTABLE_SYMBOL_INFO_VARIABLE_SIZE, &variable_size));
+  *out_byte_length = variable_size;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_hsa_verify(
+    void* user_data, iree_string_view_t name,
+    iree_host_size_t verification_physical_device_ordinal,
+    iree_device_size_t* out_byte_length) {
+  iree_hal_amdgpu_global_table_t* table =
+      (iree_hal_amdgpu_global_table_t*)user_data;
+  *out_byte_length = 0;
+
+  if (IREE_UNLIKELY(verification_physical_device_ordinal >=
+                    table->hsa.device_agent_count)) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "global verification physical device ordinal %" PRIhsz
+        " exceeds device count %" PRIhsz,
+        verification_physical_device_ordinal, table->hsa.device_agent_count);
+  }
+
+  hsa_executable_symbol_t symbol = {0};
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_get_symbol_by_name(
+      table, name,
+      table->hsa.device_agents[verification_physical_device_ordinal], &symbol));
+
+  return iree_hal_amdgpu_global_table_query_variable(
+      table, symbol, name, verification_physical_device_ordinal,
+      IREE_STATUS_NOT_FOUND, /*out_address=*/NULL, out_byte_length);
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_hsa_create_buffer(
+    void* user_data, iree_string_view_t name,
+    iree_device_size_t expected_byte_length,
+    iree_hal_queue_affinity_t selected_queue_affinity,
+    iree_host_size_t physical_device_ordinal, iree_hal_buffer_t** out_buffer) {
+  iree_hal_amdgpu_global_table_t* table =
+      (iree_hal_amdgpu_global_table_t*)user_data;
+  *out_buffer = NULL;
+
+  if (IREE_UNLIKELY(physical_device_ordinal >= table->hsa.device_agent_count)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "global buffer physical device ordinal %" PRIhsz
+                            " exceeds device count %" PRIhsz,
+                            physical_device_ordinal,
+                            table->hsa.device_agent_count);
+  }
+
+  hsa_executable_symbol_t symbol = {0};
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_get_symbol_by_name(
+      table, name, table->hsa.device_agents[physical_device_ordinal], &symbol));
+
+  uint64_t variable_address = 0;
+  iree_device_size_t byte_length = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_query_variable(
+      table, symbol, name, physical_device_ordinal, IREE_STATUS_INTERNAL,
+      &variable_address, &byte_length));
+  if (IREE_UNLIKELY(byte_length != expected_byte_length)) {
+    return iree_make_status(
+        IREE_STATUS_INTERNAL,
+        "verified executable global `%.*s` changed size on physical device "
+        "%" PRIhsz " from %" PRIu64 " to %" PRIu64,
+        (int)name.size, name.data, physical_device_ordinal,
+        (uint64_t)expected_byte_length, (uint64_t)byte_length);
+  }
+
+  iree_hal_buffer_placement_t placement = {
+      .device = table->hsa.device,
+      .queue_affinity = selected_queue_affinity,
+      .flags = IREE_HAL_BUFFER_PLACEMENT_FLAG_NONE,
+  };
+  return iree_hal_amdgpu_buffer_create(
+      table->hsa.libhsa, placement, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+      IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE,
+      IREE_HAL_BUFFER_USAGE_DEFAULT, expected_byte_length, expected_byte_length,
+      (void*)(uintptr_t)variable_address,
+      iree_hal_buffer_release_callback_null(), table->host_allocator,
+      out_buffer);
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_first_loaded_device(
+    const iree_hal_amdgpu_global_table_t* table,
+    iree_host_size_t* out_physical_device_ordinal) {
+  if (IREE_UNLIKELY(table->loaded_physical_device_mask == 0)) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "AMDGPU global table has no loaded devices");
+  }
+  *out_physical_device_ordinal =
+      (iree_host_size_t)iree_math_count_trailing_zeros_u64(
+          table->loaded_physical_device_mask);
+  return iree_ok_status();
+}
+
+static iree_hal_amdgpu_global_table_entry_t*
+iree_hal_amdgpu_global_table_find_entry_locked(
+    iree_hal_amdgpu_global_table_t* table, iree_string_view_t name) {
+  for (iree_host_size_t i = 0; i < table->entry_count; ++i) {
+    iree_hal_amdgpu_global_table_entry_t* entry = table->entries[i];
+    if (iree_string_view_equal(entry->name, name)) return entry;
+  }
+  return NULL;
+}
+
+static iree_hal_amdgpu_global_table_entry_t*
+iree_hal_amdgpu_global_table_entry_from_handle_locked(
+    iree_hal_amdgpu_global_table_t* table,
+    iree_hal_executable_global_t global) {
+  if (!iree_hal_executable_global_is_valid(global)) return NULL;
+  if (global.value >= table->entry_count) return NULL;
+  return table->entries[global.value];
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_grow_entries_locked(
+    iree_hal_amdgpu_global_table_t* table, iree_host_size_t minimum_capacity) {
+  if (minimum_capacity <= table->entry_capacity) return iree_ok_status();
+
+  iree_host_size_t new_capacity =
+      table->entry_capacity ? table->entry_capacity : 4;
+  while (new_capacity < minimum_capacity) {
+    if (IREE_UNLIKELY(
+            !iree_host_size_checked_mul(new_capacity, 2, &new_capacity))) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "AMDGPU global table capacity overflow");
+    }
+  }
+
+  iree_hal_amdgpu_global_table_entry_t** entries = table->entries;
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_realloc_array(table->host_allocator, new_capacity,
+                                   sizeof(entries[0]), (void**)&entries));
+  memset(entries + table->entry_capacity, 0,
+         (new_capacity - table->entry_capacity) * sizeof(entries[0]));
+  table->entries = entries;
+  table->entry_capacity = new_capacity;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_entry_allocate(
+    iree_hal_amdgpu_global_table_t* table, iree_string_view_t name,
+    iree_device_size_t byte_length,
+    iree_hal_amdgpu_global_table_entry_t** out_entry) {
+  *out_entry = NULL;
+
+  iree_host_size_t name_storage_size = 0;
+  if (IREE_UNLIKELY(
+          !iree_host_size_checked_add(name.size, 1, &name_storage_size))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "AMDGPU global table name storage overflow");
+  }
+
+  iree_host_size_t total_size = 0;
+  iree_host_size_t device_buffers_offset = 0;
+  iree_host_size_t name_offset = 0;
+  IREE_RETURN_IF_ERROR(IREE_STRUCT_LAYOUT(
+      sizeof(iree_hal_amdgpu_global_table_entry_t), &total_size,
+      IREE_STRUCT_FIELD(table->physical_device_count, iree_hal_buffer_t*,
+                        &device_buffers_offset),
+      IREE_STRUCT_FIELD(name_storage_size, char, &name_offset)));
+
+  iree_hal_amdgpu_global_table_entry_t* entry = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(table->host_allocator, total_size, (void**)&entry));
+  memset(entry, 0, total_size);
+
+  entry->handle_value = IREE_HAL_EXECUTABLE_GLOBAL_INVALID_VALUE;
+  entry->byte_length = byte_length;
+  entry->device_buffers =
+      (iree_hal_buffer_t**)((uint8_t*)entry + device_buffers_offset);
+
+  char* name_storage = (char*)entry + name_offset;
+  memcpy(name_storage, name.data, name.size);
+  name_storage[name.size] = 0;
+  entry->name = iree_make_string_view(name_storage, name.size);
+
+  *out_entry = entry;
+  return iree_ok_status();
+}
+
+static void iree_hal_amdgpu_global_table_entry_free(
+    iree_hal_amdgpu_global_table_t* table,
+    iree_hal_amdgpu_global_table_entry_t* entry) {
+  if (!entry) return;
+  for (iree_host_size_t i = 0; i < table->physical_device_count; ++i) {
+    iree_hal_buffer_release(entry->device_buffers[i]);
+  }
+  iree_allocator_free(table->host_allocator, entry);
+}
+
+iree_status_t iree_hal_amdgpu_global_table_initialize(
+    const iree_hal_amdgpu_global_table_params_t* params,
+    iree_hal_amdgpu_global_table_t* out_table) {
+  IREE_ASSERT_ARGUMENT(out_table);
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_validate_params(params));
+
+  memset(out_table, 0, sizeof(*out_table));
+  out_table->initialized = true;
+  out_table->host_allocator = params->host_allocator;
+  out_table->queue_affinity_domain = params->queue_affinity_domain;
+  out_table->loaded_physical_device_mask = params->loaded_physical_device_mask;
+  out_table->physical_device_count = params->physical_device_count;
+  out_table->resolver = params->resolver;
+  iree_slim_mutex_initialize(&out_table->mutex);
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_global_table_initialize_hsa(
+    const iree_hal_amdgpu_global_table_hsa_params_t* params,
+    iree_hal_amdgpu_global_table_t* out_table) {
+  IREE_ASSERT_ARGUMENT(out_table);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_global_table_validate_hsa_params(params));
+
+  iree_hal_amdgpu_global_table_params_t table_params = {
+      .host_allocator = params->host_allocator,
+      .queue_affinity_domain = params->queue_affinity_domain,
+      .loaded_physical_device_mask = params->loaded_physical_device_mask,
+      .physical_device_count = params->device_agent_count,
+      .resolver =
+          {
+              .user_data = out_table,
+              .verify = iree_hal_amdgpu_global_table_hsa_verify,
+              .create_buffer = iree_hal_amdgpu_global_table_hsa_create_buffer,
+          },
+  };
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_global_table_initialize(&table_params, out_table));
+  out_table->hsa.libhsa = params->libhsa;
+  out_table->hsa.device = params->device;
+  out_table->hsa.executable = params->executable;
+  out_table->hsa.device_agent_count = params->device_agent_count;
+  out_table->hsa.device_agents = params->device_agents;
+  return iree_ok_status();
+}
+
+void iree_hal_amdgpu_global_table_deinitialize(
+    iree_hal_amdgpu_global_table_t* table) {
+  if (!table || !table->initialized) return;
+  for (iree_host_size_t i = 0; i < table->entry_count; ++i) {
+    iree_hal_amdgpu_global_table_entry_free(table, table->entries[i]);
+  }
+  iree_allocator_free(table->host_allocator, table->entries);
+  iree_slim_mutex_deinitialize(&table->mutex);
+  memset(table, 0, sizeof(*table));
+}
+
+iree_status_t iree_hal_amdgpu_global_table_lookup(
+    iree_hal_amdgpu_global_table_t* table, iree_string_view_t name,
+    iree_hal_executable_global_t* out_global) {
+  IREE_ASSERT_ARGUMENT(table);
+  IREE_ASSERT_ARGUMENT(out_global);
+  *out_global = iree_hal_executable_global_invalid();
+
+  if (iree_string_view_is_empty(name)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "executable global name is empty");
+  }
+
+  iree_slim_mutex_lock(&table->mutex);
+  iree_hal_amdgpu_global_table_entry_t* entry =
+      iree_hal_amdgpu_global_table_find_entry_locked(table, name);
+  if (entry) {
+    *out_global = iree_hal_executable_global_from_value(entry->handle_value);
+    iree_slim_mutex_unlock(&table->mutex);
+    return iree_ok_status();
+  }
+  iree_slim_mutex_unlock(&table->mutex);
+
+  iree_host_size_t verification_physical_device_ordinal = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_first_loaded_device(
+      table, &verification_physical_device_ordinal));
+
+  iree_device_size_t byte_length = 0;
+  IREE_RETURN_IF_ERROR(table->resolver.verify(
+      table->resolver.user_data, name, verification_physical_device_ordinal,
+      &byte_length));
+
+  iree_hal_amdgpu_global_table_entry_t* new_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_entry_allocate(
+      table, name, byte_length, &new_entry));
+
+  iree_slim_mutex_lock(&table->mutex);
+  entry = iree_hal_amdgpu_global_table_find_entry_locked(table, name);
+  if (entry) {
+    *out_global = iree_hal_executable_global_from_value(entry->handle_value);
+  } else {
+    const uint64_t handle_value = table->entry_count;
+    iree_status_t status = iree_hal_amdgpu_global_table_grow_entries_locked(
+        table, table->entry_count + 1);
+    if (iree_status_is_ok(status)) {
+      new_entry->handle_value = handle_value;
+      table->entries[table->entry_count++] = new_entry;
+      *out_global = iree_hal_executable_global_from_value(handle_value);
+      new_entry = NULL;
+    }
+    iree_slim_mutex_unlock(&table->mutex);
+    if (new_entry) {
+      iree_hal_amdgpu_global_table_entry_free(table, new_entry);
+    }
+    return status;
+  }
+  iree_slim_mutex_unlock(&table->mutex);
+
+  iree_hal_amdgpu_global_table_entry_free(table, new_entry);
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_global_table_info(
+    iree_hal_amdgpu_global_table_t* table, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
+  IREE_ASSERT_ARGUMENT(table);
+  IREE_ASSERT_ARGUMENT(out_info);
+  memset(out_info, 0, sizeof(*out_info));
+
+  iree_slim_mutex_lock(&table->mutex);
+  iree_hal_amdgpu_global_table_entry_t* entry =
+      iree_hal_amdgpu_global_table_entry_from_handle_locked(table, global);
+  if (!entry) {
+    iree_slim_mutex_unlock(&table->mutex);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid AMDGPU executable global handle");
+  }
+  out_info->name = entry->name;
+  out_info->byte_length = entry->byte_length;
+  iree_slim_mutex_unlock(&table->mutex);
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_global_table_buffer(
+    iree_hal_amdgpu_global_table_t* table, iree_hal_executable_global_t global,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(table);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  *out_buffer = NULL;
+
+  iree_hal_queue_affinity_t requested_queue_affinity = queue_affinity;
+  if (iree_hal_queue_affinity_is_empty(requested_queue_affinity)) {
+    requested_queue_affinity = IREE_HAL_QUEUE_AFFINITY_ANY;
+  }
+
+  iree_hal_queue_affinity_t selected_queue_affinity = 0;
+  iree_host_size_t physical_device_ordinal = 0;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_queue_affinity_normalize_for_physical_device(
+          table->queue_affinity_domain, requested_queue_affinity,
+          &selected_queue_affinity, &physical_device_ordinal));
+
+  if (IREE_UNLIKELY(((((uint64_t)1) << physical_device_ordinal) &
+                     table->loaded_physical_device_mask) == 0)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU executable global buffer requested on unloaded device %" PRIhsz,
+        physical_device_ordinal);
+  }
+
+  iree_slim_mutex_lock(&table->mutex);
+  iree_hal_amdgpu_global_table_entry_t* entry =
+      iree_hal_amdgpu_global_table_entry_from_handle_locked(table, global);
+  if (!entry) {
+    iree_slim_mutex_unlock(&table->mutex);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid AMDGPU executable global handle");
+  }
+  iree_hal_buffer_t* cached_buffer =
+      entry->device_buffers[physical_device_ordinal];
+  if (cached_buffer) {
+    *out_buffer = cached_buffer;
+    iree_slim_mutex_unlock(&table->mutex);
+    return iree_ok_status();
+  }
+  iree_string_view_t name = entry->name;
+  iree_device_size_t byte_length = entry->byte_length;
+  iree_slim_mutex_unlock(&table->mutex);
+
+  iree_hal_buffer_t* new_buffer = NULL;
+  IREE_RETURN_IF_ERROR(table->resolver.create_buffer(
+      table->resolver.user_data, name, byte_length, selected_queue_affinity,
+      physical_device_ordinal, &new_buffer));
+
+  iree_slim_mutex_lock(&table->mutex);
+  entry = iree_hal_amdgpu_global_table_entry_from_handle_locked(table, global);
+  if (!entry) {
+    iree_slim_mutex_unlock(&table->mutex);
+    iree_hal_buffer_release(new_buffer);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid AMDGPU executable global handle");
+  }
+  cached_buffer = entry->device_buffers[physical_device_ordinal];
+  if (cached_buffer) {
+    *out_buffer = cached_buffer;
+    iree_slim_mutex_unlock(&table->mutex);
+    iree_hal_buffer_release(new_buffer);
+  } else {
+    entry->device_buffers[physical_device_ordinal] = new_buffer;
+    *out_buffer = new_buffer;
+    iree_slim_mutex_unlock(&table->mutex);
+  }
+  return iree_ok_status();
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/util/global_table.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/global_table.c
@@ -207,6 +207,12 @@ static iree_status_t iree_hal_amdgpu_global_table_hsa_try_verify(
       table, symbol, /*out_address=*/NULL, out_found, out_byte_length);
 }
 
+static void iree_hal_amdgpu_global_table_borrowed_buffer_release(
+    void* user_data, iree_hal_buffer_t* buffer) {
+  (void)user_data;
+  (void)buffer;
+}
+
 static iree_status_t iree_hal_amdgpu_global_table_hsa_create_buffer(
     void* user_data, iree_string_view_t name,
     iree_device_size_t expected_byte_length,
@@ -255,13 +261,16 @@ static iree_status_t iree_hal_amdgpu_global_table_hsa_create_buffer(
       .queue_affinity = selected_queue_affinity,
       .flags = IREE_HAL_BUFFER_PLACEMENT_FLAG_NONE,
   };
+  iree_hal_buffer_release_callback_t release_callback = {
+      .fn = iree_hal_amdgpu_global_table_borrowed_buffer_release,
+      .user_data = NULL,
+  };
   return iree_hal_amdgpu_buffer_create(
       table->hsa.libhsa, placement, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
       IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE,
       IREE_HAL_BUFFER_USAGE_DEFAULT, expected_byte_length, expected_byte_length,
-      (void*)(uintptr_t)variable_address,
-      iree_hal_buffer_release_callback_null(), table->host_allocator,
-      out_buffer);
+      (void*)(uintptr_t)variable_address, release_callback,
+      table->host_allocator, out_buffer);
 }
 
 static iree_status_t iree_hal_amdgpu_global_table_first_loaded_device(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/global_table.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/global_table.c
@@ -61,7 +61,7 @@ static iree_status_t iree_hal_amdgpu_global_table_validate_params(
                             params->physical_device_count);
   }
 
-  if (IREE_UNLIKELY(!params->resolver.verify ||
+  if (IREE_UNLIKELY(!params->resolver.try_verify ||
                     !params->resolver.create_buffer)) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "AMDGPU global table resolver is incomplete");
@@ -94,9 +94,12 @@ static iree_status_t iree_hal_amdgpu_global_table_validate_hsa_params(
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_amdgpu_global_table_get_symbol_by_name(
+static iree_status_t iree_hal_amdgpu_global_table_try_get_symbol_by_name(
     const iree_hal_amdgpu_global_table_t* table, iree_string_view_t name,
-    hsa_agent_t device_agent, hsa_executable_symbol_t* out_symbol) {
+    hsa_agent_t device_agent, bool* out_found,
+    hsa_executable_symbol_t* out_symbol) {
+  *out_found = false;
+  memset(out_symbol, 0, sizeof(*out_symbol));
   if (iree_string_view_is_empty(name)) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "executable global name is empty");
@@ -112,25 +115,35 @@ static iree_status_t iree_hal_amdgpu_global_table_get_symbol_by_name(
   char* name_storage = (char*)iree_alloca(name.size + 1);
   memcpy(name_storage, name.data, name.size);
   name_storage[name.size] = 0;
-  return iree_hsa_executable_get_symbol_by_name(
-      IREE_LIBHSA(table->hsa.libhsa), table->hsa.executable, name_storage,
-      &device_agent, out_symbol);
+  hsa_status_t hsa_status = iree_hsa_executable_get_symbol_by_name_raw(
+      table->hsa.libhsa, table->hsa.executable, name_storage, &device_agent,
+      out_symbol);
+  if (hsa_status == HSA_STATUS_SUCCESS) {
+    *out_found = true;
+    return iree_ok_status();
+  }
+  if (hsa_status == HSA_STATUS_ERROR_INVALID_SYMBOL_NAME) {
+    return iree_ok_status();
+  }
+  return iree_status_from_hsa_status(
+      __FILE__, __LINE__, hsa_status, "hsa_executable_get_symbol_by_name",
+      "failed to resolve executable global symbol");
 }
 
-static iree_status_t iree_hal_amdgpu_global_table_query_variable(
+static iree_status_t iree_hal_amdgpu_global_table_try_query_variable(
     const iree_hal_amdgpu_global_table_t* table, hsa_executable_symbol_t symbol,
-    iree_string_view_t name, iree_host_size_t physical_device_ordinal,
-    iree_status_code_t wrong_kind_status_code, uint64_t* out_address,
+    uint64_t* out_address, bool* out_found,
     iree_device_size_t* out_byte_length) {
+  *out_found = false;
+  if (out_address) *out_address = 0;
+  *out_byte_length = 0;
+
   hsa_symbol_kind_t symbol_kind = HSA_SYMBOL_KIND_KERNEL;
   IREE_RETURN_IF_ERROR(iree_hsa_executable_symbol_get_info(
       IREE_LIBHSA(table->hsa.libhsa), symbol, HSA_EXECUTABLE_SYMBOL_INFO_TYPE,
       &symbol_kind));
   if (symbol_kind != HSA_SYMBOL_KIND_VARIABLE) {
-    return iree_make_status(wrong_kind_status_code,
-                            "executable global `%.*s` is not a variable on "
-                            "physical device %" PRIhsz,
-                            (int)name.size, name.data, physical_device_ordinal);
+    return iree_ok_status();
   }
 
   if (out_address) {
@@ -144,15 +157,34 @@ static iree_status_t iree_hal_amdgpu_global_table_query_variable(
       IREE_LIBHSA(table->hsa.libhsa), symbol,
       HSA_EXECUTABLE_SYMBOL_INFO_VARIABLE_SIZE, &variable_size));
   *out_byte_length = variable_size;
+  *out_found = true;
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_amdgpu_global_table_hsa_verify(
+static iree_status_t iree_hal_amdgpu_global_table_query_variable(
+    const iree_hal_amdgpu_global_table_t* table, hsa_executable_symbol_t symbol,
+    iree_string_view_t name, iree_host_size_t physical_device_ordinal,
+    iree_status_code_t wrong_kind_status_code, uint64_t* out_address,
+    iree_device_size_t* out_byte_length) {
+  bool found = false;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_try_query_variable(
+      table, symbol, out_address, &found, out_byte_length));
+  if (!found) {
+    return iree_make_status(wrong_kind_status_code,
+                            "executable global `%.*s` is not a variable on "
+                            "physical device %" PRIhsz,
+                            (int)name.size, name.data, physical_device_ordinal);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_hsa_try_verify(
     void* user_data, iree_string_view_t name,
-    iree_host_size_t verification_physical_device_ordinal,
+    iree_host_size_t verification_physical_device_ordinal, bool* out_found,
     iree_device_size_t* out_byte_length) {
   iree_hal_amdgpu_global_table_t* table =
       (iree_hal_amdgpu_global_table_t*)user_data;
+  *out_found = false;
   *out_byte_length = 0;
 
   if (IREE_UNLIKELY(verification_physical_device_ordinal >=
@@ -165,13 +197,14 @@ static iree_status_t iree_hal_amdgpu_global_table_hsa_verify(
   }
 
   hsa_executable_symbol_t symbol = {0};
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_get_symbol_by_name(
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_try_get_symbol_by_name(
       table, name,
-      table->hsa.device_agents[verification_physical_device_ordinal], &symbol));
+      table->hsa.device_agents[verification_physical_device_ordinal], out_found,
+      &symbol));
+  if (!*out_found) return iree_ok_status();
 
-  return iree_hal_amdgpu_global_table_query_variable(
-      table, symbol, name, verification_physical_device_ordinal,
-      IREE_STATUS_NOT_FOUND, /*out_address=*/NULL, out_byte_length);
+  return iree_hal_amdgpu_global_table_try_query_variable(
+      table, symbol, /*out_address=*/NULL, out_found, out_byte_length);
 }
 
 static iree_status_t iree_hal_amdgpu_global_table_hsa_create_buffer(
@@ -192,8 +225,16 @@ static iree_status_t iree_hal_amdgpu_global_table_hsa_create_buffer(
   }
 
   hsa_executable_symbol_t symbol = {0};
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_get_symbol_by_name(
-      table, name, table->hsa.device_agents[physical_device_ordinal], &symbol));
+  bool found = false;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_try_get_symbol_by_name(
+      table, name, table->hsa.device_agents[physical_device_ordinal], &found,
+      &symbol));
+  if (IREE_UNLIKELY(!found)) {
+    return iree_make_status(IREE_STATUS_INTERNAL,
+                            "verified executable global `%.*s` disappeared on "
+                            "physical device %" PRIhsz,
+                            (int)name.size, name.data, physical_device_ordinal);
+  }
 
   uint64_t variable_address = 0;
   iree_device_size_t byte_length = 0;
@@ -363,7 +404,7 @@ iree_status_t iree_hal_amdgpu_global_table_initialize_hsa(
       .resolver =
           {
               .user_data = out_table,
-              .verify = iree_hal_amdgpu_global_table_hsa_verify,
+              .try_verify = iree_hal_amdgpu_global_table_hsa_try_verify,
               .create_buffer = iree_hal_amdgpu_global_table_hsa_create_buffer,
           },
   };
@@ -388,11 +429,13 @@ void iree_hal_amdgpu_global_table_deinitialize(
   memset(table, 0, sizeof(*table));
 }
 
-iree_status_t iree_hal_amdgpu_global_table_lookup(
+iree_status_t iree_hal_amdgpu_global_table_try_lookup(
     iree_hal_amdgpu_global_table_t* table, iree_string_view_t name,
-    iree_hal_executable_global_t* out_global) {
+    bool* out_found, iree_hal_executable_global_t* out_global) {
   IREE_ASSERT_ARGUMENT(table);
+  IREE_ASSERT_ARGUMENT(out_found);
   IREE_ASSERT_ARGUMENT(out_global);
+  *out_found = false;
   *out_global = iree_hal_executable_global_invalid();
 
   if (iree_string_view_is_empty(name)) {
@@ -404,6 +447,7 @@ iree_status_t iree_hal_amdgpu_global_table_lookup(
   iree_hal_amdgpu_global_table_entry_t* entry =
       iree_hal_amdgpu_global_table_find_entry_locked(table, name);
   if (entry) {
+    *out_found = true;
     *out_global = iree_hal_executable_global_from_value(entry->handle_value);
     iree_slim_mutex_unlock(&table->mutex);
     return iree_ok_status();
@@ -415,9 +459,11 @@ iree_status_t iree_hal_amdgpu_global_table_lookup(
       table, &verification_physical_device_ordinal));
 
   iree_device_size_t byte_length = 0;
-  IREE_RETURN_IF_ERROR(table->resolver.verify(
+  bool resolved = false;
+  IREE_RETURN_IF_ERROR(table->resolver.try_verify(
       table->resolver.user_data, name, verification_physical_device_ordinal,
-      &byte_length));
+      &resolved, &byte_length));
+  if (!resolved) return iree_ok_status();
 
   iree_hal_amdgpu_global_table_entry_t* new_entry = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_entry_allocate(
@@ -426,6 +472,7 @@ iree_status_t iree_hal_amdgpu_global_table_lookup(
   iree_slim_mutex_lock(&table->mutex);
   entry = iree_hal_amdgpu_global_table_find_entry_locked(table, name);
   if (entry) {
+    *out_found = true;
     *out_global = iree_hal_executable_global_from_value(entry->handle_value);
   } else {
     const uint64_t handle_value = table->entry_count;
@@ -434,6 +481,7 @@ iree_status_t iree_hal_amdgpu_global_table_lookup(
     if (iree_status_is_ok(status)) {
       new_entry->handle_value = handle_value;
       table->entries[table->entry_count++] = new_entry;
+      *out_found = true;
       *out_global = iree_hal_executable_global_from_value(handle_value);
       new_entry = NULL;
     }
@@ -446,6 +494,20 @@ iree_status_t iree_hal_amdgpu_global_table_lookup(
   iree_slim_mutex_unlock(&table->mutex);
 
   iree_hal_amdgpu_global_table_entry_free(table, new_entry);
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_amdgpu_global_table_lookup(
+    iree_hal_amdgpu_global_table_t* table, iree_string_view_t name,
+    iree_hal_executable_global_t* out_global) {
+  bool found = false;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_global_table_try_lookup(table, name, &found, out_global));
+  if (!found) {
+    return iree_make_status(IREE_STATUS_NOT_FOUND,
+                            "executable global `%.*s` not found",
+                            (int)name.size, name.data);
+  }
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/util/global_table.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/global_table.h
@@ -1,0 +1,167 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_UTIL_GLOBAL_TABLE_H_
+#define IREE_HAL_DRIVERS_AMDGPU_UTIL_GLOBAL_TABLE_H_
+
+#include "iree/base/api.h"
+#include "iree/base/threading/mutex.h"
+#include "iree/hal/api.h"
+#include "iree/hal/drivers/amdgpu/queue_affinity.h"
+#include "iree/hal/drivers/amdgpu/util/libhsa.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct iree_hal_amdgpu_global_table_entry_t
+    iree_hal_amdgpu_global_table_entry_t;
+
+typedef struct iree_hal_amdgpu_global_table_resolver_t {
+  // Resolver-specific state passed to all callbacks.
+  void* user_data;
+
+  // Verifies that |name| resolves to an executable variable and returns its
+  // byte length. The table calls this on the first loaded physical device only.
+  iree_status_t (*verify)(void* user_data, iree_string_view_t name,
+                          iree_host_size_t verification_physical_device_ordinal,
+                          iree_device_size_t* out_byte_length);
+
+  // Creates an executable-owned buffer alias for |name| on one physical device.
+  iree_status_t (*create_buffer)(
+      void* user_data, iree_string_view_t name,
+      iree_device_size_t expected_byte_length,
+      iree_hal_queue_affinity_t selected_queue_affinity,
+      iree_host_size_t physical_device_ordinal, iree_hal_buffer_t** out_buffer);
+} iree_hal_amdgpu_global_table_resolver_t;
+
+typedef struct iree_hal_amdgpu_global_table_params_t {
+  // Host allocator used for table storage.
+  iree_allocator_t host_allocator;
+
+  // Queue affinity domain of the owning AMDGPU logical device.
+  iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain;
+
+  // Bitmask of physical device ordinals this executable was loaded on.
+  uint64_t loaded_physical_device_mask;
+
+  // Number of physical devices in the owning AMDGPU logical device.
+  iree_host_size_t physical_device_count;
+
+  // Backend resolver used for HSA symbol verification and buffer creation.
+  iree_hal_amdgpu_global_table_resolver_t resolver;
+} iree_hal_amdgpu_global_table_params_t;
+
+typedef struct iree_hal_amdgpu_global_table_hsa_params_t {
+  // Host allocator used for table storage and cached buffer wrappers.
+  iree_allocator_t host_allocator;
+
+  // Queue affinity domain of the owning AMDGPU logical device.
+  iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain;
+
+  // Bitmask of physical device ordinals this executable was loaded on.
+  uint64_t loaded_physical_device_mask;
+
+  // Borrowed HSA dynamic symbol table.
+  const iree_hal_amdgpu_libhsa_t* libhsa;
+
+  // Borrowed logical device used in global buffer placements.
+  iree_hal_device_t* device;
+
+  // Borrowed HSA executable containing variable symbols.
+  hsa_executable_t executable;
+
+  // Number of physical device agents in |device_agents|.
+  iree_host_size_t device_agent_count;
+
+  // Borrowed physical device agent table owned by the executable.
+  const hsa_agent_t* device_agents;
+} iree_hal_amdgpu_global_table_hsa_params_t;
+
+typedef struct iree_hal_amdgpu_global_table_t {
+  // True when the table has been initialized and must be deinitialized.
+  bool initialized;
+
+  // Host allocator used for all table-owned allocations.
+  iree_allocator_t host_allocator;
+
+  // Queue affinity domain of the owning logical device.
+  iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain;
+
+  // Bitmask of physical device ordinals with loaded code objects.
+  uint64_t loaded_physical_device_mask;
+
+  // Number of physical devices in the owning logical device.
+  iree_host_size_t physical_device_count;
+
+  // Backend resolver used for HSA symbol verification and buffer creation.
+  iree_hal_amdgpu_global_table_resolver_t resolver;
+
+  // HSA-backed resolver state used by the production AMDGPU executable path.
+  struct {
+    // Borrowed HSA dynamic symbol table.
+    const iree_hal_amdgpu_libhsa_t* libhsa;
+
+    // Borrowed logical device used in global buffer placements.
+    iree_hal_device_t* device;
+
+    // Borrowed HSA executable containing variable symbols.
+    hsa_executable_t executable;
+
+    // Number of physical device agents in |device_agents|.
+    iree_host_size_t device_agent_count;
+
+    // Borrowed physical device agent table owned by the executable.
+    const hsa_agent_t* device_agents;
+  } hsa;
+
+  // Guards entry publication and cached buffer publication.
+  iree_slim_mutex_t mutex;
+
+  // Dense table indexed by executable-local global handle value.
+  iree_hal_amdgpu_global_table_entry_t** entries;
+
+  // Number of populated entries.
+  iree_host_size_t entry_count;
+
+  // Capacity of |entries|.
+  iree_host_size_t entry_capacity;
+} iree_hal_amdgpu_global_table_t;
+
+// Initializes |out_table| for executable global resolution.
+iree_status_t iree_hal_amdgpu_global_table_initialize(
+    const iree_hal_amdgpu_global_table_params_t* params,
+    iree_hal_amdgpu_global_table_t* out_table);
+
+// Initializes |out_table| with the built-in HSA executable global resolver.
+iree_status_t iree_hal_amdgpu_global_table_initialize_hsa(
+    const iree_hal_amdgpu_global_table_hsa_params_t* params,
+    iree_hal_amdgpu_global_table_t* out_table);
+
+// Releases cached buffer aliases and table storage.
+void iree_hal_amdgpu_global_table_deinitialize(
+    iree_hal_amdgpu_global_table_t* table);
+
+// Finds a variable symbol by name and interns a global handle for it.
+iree_status_t iree_hal_amdgpu_global_table_lookup(
+    iree_hal_amdgpu_global_table_t* table, iree_string_view_t name,
+    iree_hal_executable_global_t* out_global);
+
+// Returns metadata for |global|. Returned string storage is table-owned.
+iree_status_t iree_hal_amdgpu_global_table_info(
+    iree_hal_amdgpu_global_table_t* table, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info);
+
+// Returns an executable-owned buffer alias for |global| on the selected device.
+iree_status_t iree_hal_amdgpu_global_table_buffer(
+    iree_hal_amdgpu_global_table_t* table, iree_hal_executable_global_t global,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_UTIL_GLOBAL_TABLE_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/util/global_table.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/global_table.h
@@ -24,11 +24,13 @@ typedef struct iree_hal_amdgpu_global_table_resolver_t {
   // Resolver-specific state passed to all callbacks.
   void* user_data;
 
-  // Verifies that |name| resolves to an executable variable and returns its
-  // byte length. The table calls this on the first loaded physical device only.
-  iree_status_t (*verify)(void* user_data, iree_string_view_t name,
-                          iree_host_size_t verification_physical_device_ordinal,
-                          iree_device_size_t* out_byte_length);
+  // Tries to verify that |name| resolves to an executable variable and returns
+  // its byte length when found. The table calls this on the first loaded
+  // physical device only.
+  iree_status_t (*try_verify)(
+      void* user_data, iree_string_view_t name,
+      iree_host_size_t verification_physical_device_ordinal, bool* out_found,
+      iree_device_size_t* out_byte_length);
 
   // Creates an executable-owned buffer alias for |name| on one physical device.
   iree_status_t (*create_buffer)(
@@ -144,6 +146,11 @@ iree_status_t iree_hal_amdgpu_global_table_initialize_hsa(
 // Releases cached buffer aliases and table storage.
 void iree_hal_amdgpu_global_table_deinitialize(
     iree_hal_amdgpu_global_table_t* table);
+
+// Tries to find a variable symbol by name and interns a global handle for it.
+iree_status_t iree_hal_amdgpu_global_table_try_lookup(
+    iree_hal_amdgpu_global_table_t* table, iree_string_view_t name,
+    bool* out_found, iree_hal_executable_global_t* out_global);
 
 // Finds a variable symbol by name and interns a global handle for it.
 iree_status_t iree_hal_amdgpu_global_table_lookup(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/global_table_benchmark.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/global_table_benchmark.cc
@@ -62,41 +62,46 @@ typedef struct iree_hal_amdgpu_global_table_benchmark_fixture_t {
   iree_hal_amdgpu_global_table_t table;
 } iree_hal_amdgpu_global_table_benchmark_fixture_t;
 
-static iree_status_t iree_hal_amdgpu_global_table_benchmark_parse_name(
+static bool iree_hal_amdgpu_global_table_benchmark_try_parse_name(
     iree_string_view_t name, iree_host_size_t global_count,
     iree_host_size_t* out_global_ordinal) {
   *out_global_ordinal = 0;
 
   static const iree_string_view_t prefix = IREE_SV("global_");
   if (!iree_string_view_starts_with(name, prefix)) {
-    return iree_make_status(IREE_STATUS_NOT_FOUND, "global not found");
+    return false;
   }
   iree_string_view_t ordinal_string =
       iree_string_view_strip_prefix(name, prefix);
   uint64_t global_ordinal = 0;
   if (!iree_string_view_atoi_uint64_base(ordinal_string, 10, &global_ordinal)) {
-    return iree_make_status(IREE_STATUS_NOT_FOUND, "global not found");
+    return false;
   }
   if (global_ordinal >= global_count) {
-    return iree_make_status(IREE_STATUS_NOT_FOUND, "global not found");
+    return false;
   }
 
   *out_global_ordinal = (iree_host_size_t)global_ordinal;
-  return iree_ok_status();
+  return true;
 }
 
-static iree_status_t iree_hal_amdgpu_global_table_benchmark_verify(
+static iree_status_t iree_hal_amdgpu_global_table_benchmark_try_verify(
     void* user_data, iree_string_view_t name,
-    iree_host_size_t verification_physical_device_ordinal,
+    iree_host_size_t verification_physical_device_ordinal, bool* out_found,
     iree_device_size_t* out_byte_length) {
   (void)verification_physical_device_ordinal;
+  *out_found = false;
+  *out_byte_length = 0;
 
   iree_hal_amdgpu_global_table_benchmark_resolver_t* resolver =
       (iree_hal_amdgpu_global_table_benchmark_resolver_t*)user_data;
   iree_host_size_t global_ordinal = 0;
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_benchmark_parse_name(
-      name, resolver->global_count, &global_ordinal));
+  if (!iree_hal_amdgpu_global_table_benchmark_try_parse_name(
+          name, resolver->global_count, &global_ordinal)) {
+    return iree_ok_status();
+  }
 
+  *out_found = true;
   *out_byte_length = 64;
   return iree_ok_status();
 }
@@ -113,8 +118,11 @@ static iree_status_t iree_hal_amdgpu_global_table_benchmark_create_buffer(
       (iree_hal_amdgpu_global_table_benchmark_resolver_t*)user_data;
 
   iree_host_size_t global_ordinal = 0;
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_benchmark_parse_name(
-      name, resolver->global_count, &global_ordinal));
+  if (!iree_hal_amdgpu_global_table_benchmark_try_parse_name(
+          name, resolver->global_count, &global_ordinal)) {
+    return iree_make_status(IREE_STATUS_INTERNAL,
+                            "verified benchmark global disappeared");
+  }
 
   iree_hal_buffer_retain(resolver->buffer);
   *out_buffer = resolver->buffer;
@@ -251,7 +259,7 @@ static iree_status_t iree_hal_amdgpu_global_table_benchmark_fixture_initialize(
       .resolver =
           {
               .user_data = &out_fixture->resolver,
-              .verify = iree_hal_amdgpu_global_table_benchmark_verify,
+              .try_verify = iree_hal_amdgpu_global_table_benchmark_try_verify,
               .create_buffer =
                   iree_hal_amdgpu_global_table_benchmark_create_buffer,
           },

--- a/runtime/src/iree/hal/drivers/amdgpu/util/global_table_benchmark.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/global_table_benchmark.cc
@@ -1,0 +1,412 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <stdio.h>
+
+#include "iree/hal/drivers/amdgpu/util/global_table.h"
+#include "iree/testing/benchmark.h"
+
+#define IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_NAME_CAPACITY 32
+
+typedef enum iree_hal_amdgpu_global_table_benchmark_mode_e {
+  IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_LOOKUP_FIRST = 0,
+  IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_LOOKUP_LAST,
+  IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_LOOKUP_CYCLE,
+  IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_BUFFER_CACHED,
+} iree_hal_amdgpu_global_table_benchmark_mode_t;
+
+typedef struct iree_hal_amdgpu_global_table_benchmark_config_t {
+  // Operation measured by this benchmark row.
+  iree_hal_amdgpu_global_table_benchmark_mode_t mode;
+
+  // Number of executable globals prepopulated into the table.
+  iree_host_size_t entry_count;
+} iree_hal_amdgpu_global_table_benchmark_config_t;
+
+typedef struct iree_hal_amdgpu_global_table_benchmark_name_table_t {
+  // Host allocator used for name table storage.
+  iree_allocator_t host_allocator;
+
+  // Number of names in |names|.
+  iree_host_size_t count;
+
+  // String views into |storage|.
+  iree_string_view_t* names;
+
+  // Fixed-width NUL-terminated string storage for all names.
+  char* storage;
+} iree_hal_amdgpu_global_table_benchmark_name_table_t;
+
+typedef struct iree_hal_amdgpu_global_table_benchmark_resolver_t {
+  // Number of names the resolver accepts.
+  iree_host_size_t global_count;
+
+  // Buffer returned for every accepted global.
+  iree_hal_buffer_t* buffer;
+} iree_hal_amdgpu_global_table_benchmark_resolver_t;
+
+typedef struct iree_hal_amdgpu_global_table_benchmark_fixture_t {
+  // Heap-backed fake buffer retained by cached table entries.
+  iree_hal_buffer_t* fake_buffer;
+
+  // Resolver state passed to the table.
+  iree_hal_amdgpu_global_table_benchmark_resolver_t resolver;
+
+  // Persistent benchmark names used by lookup calls.
+  iree_hal_amdgpu_global_table_benchmark_name_table_t name_table;
+
+  // Global table under benchmark.
+  iree_hal_amdgpu_global_table_t table;
+} iree_hal_amdgpu_global_table_benchmark_fixture_t;
+
+static iree_status_t iree_hal_amdgpu_global_table_benchmark_parse_name(
+    iree_string_view_t name, iree_host_size_t global_count,
+    iree_host_size_t* out_global_ordinal) {
+  *out_global_ordinal = 0;
+
+  static const iree_string_view_t prefix = IREE_SV("global_");
+  if (!iree_string_view_starts_with(name, prefix)) {
+    return iree_make_status(IREE_STATUS_NOT_FOUND, "global not found");
+  }
+  iree_string_view_t ordinal_string =
+      iree_string_view_strip_prefix(name, prefix);
+  uint64_t global_ordinal = 0;
+  if (!iree_string_view_atoi_uint64_base(ordinal_string, 10, &global_ordinal)) {
+    return iree_make_status(IREE_STATUS_NOT_FOUND, "global not found");
+  }
+  if (global_ordinal >= global_count) {
+    return iree_make_status(IREE_STATUS_NOT_FOUND, "global not found");
+  }
+
+  *out_global_ordinal = (iree_host_size_t)global_ordinal;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_benchmark_verify(
+    void* user_data, iree_string_view_t name,
+    iree_host_size_t verification_physical_device_ordinal,
+    iree_device_size_t* out_byte_length) {
+  (void)verification_physical_device_ordinal;
+
+  iree_hal_amdgpu_global_table_benchmark_resolver_t* resolver =
+      (iree_hal_amdgpu_global_table_benchmark_resolver_t*)user_data;
+  iree_host_size_t global_ordinal = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_benchmark_parse_name(
+      name, resolver->global_count, &global_ordinal));
+
+  *out_byte_length = 64;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_benchmark_create_buffer(
+    void* user_data, iree_string_view_t name,
+    iree_device_size_t expected_byte_length,
+    iree_hal_queue_affinity_t selected_queue_affinity,
+    iree_host_size_t physical_device_ordinal, iree_hal_buffer_t** out_buffer) {
+  (void)expected_byte_length;
+  (void)selected_queue_affinity;
+  (void)physical_device_ordinal;
+  iree_hal_amdgpu_global_table_benchmark_resolver_t* resolver =
+      (iree_hal_amdgpu_global_table_benchmark_resolver_t*)user_data;
+
+  iree_host_size_t global_ordinal = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_global_table_benchmark_parse_name(
+      name, resolver->global_count, &global_ordinal));
+
+  iree_hal_buffer_retain(resolver->buffer);
+  *out_buffer = resolver->buffer;
+  return iree_ok_status();
+}
+
+static iree_hal_amdgpu_queue_affinity_domain_t
+iree_hal_amdgpu_global_table_benchmark_domain(void) {
+  return (iree_hal_amdgpu_queue_affinity_domain_t){
+      .supported_affinity = 0x1ull,
+      .physical_device_count = 1,
+      .queue_count_per_physical_device = 1,
+  };
+}
+
+static void iree_hal_amdgpu_global_table_benchmark_buffer_release(
+    void* user_data, iree_hal_buffer_t* buffer) {
+  (void)buffer;
+  iree_allocator_free_aligned(iree_allocator_system(), user_data);
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_benchmark_create_heap_buffer(
+    iree_hal_buffer_t** out_buffer) {
+  *out_buffer = NULL;
+
+  void* storage = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc_aligned(
+      iree_allocator_system(), 64, IREE_HAL_HEAP_BUFFER_ALIGNMENT,
+      /*offset=*/0, &storage));
+
+  iree_hal_buffer_release_callback_t release_callback = {
+      .fn = iree_hal_amdgpu_global_table_benchmark_buffer_release,
+      .user_data = storage,
+  };
+  iree_status_t status = iree_hal_heap_buffer_wrap(
+      iree_hal_buffer_placement_undefined(), IREE_HAL_MEMORY_TYPE_HOST_LOCAL,
+      IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE,
+      IREE_HAL_BUFFER_USAGE_DEFAULT, 64, iree_make_byte_span(storage, 64),
+      release_callback, iree_allocator_system(), out_buffer);
+  if (!iree_status_is_ok(status)) {
+    iree_allocator_free_aligned(iree_allocator_system(), storage);
+  }
+  return status;
+}
+
+static void iree_hal_amdgpu_global_table_benchmark_name_table_deinitialize(
+    iree_hal_amdgpu_global_table_benchmark_name_table_t* name_table) {
+  iree_allocator_free(name_table->host_allocator, name_table->storage);
+  iree_allocator_free(name_table->host_allocator, name_table->names);
+  memset(name_table, 0, sizeof(*name_table));
+}
+
+static iree_status_t
+iree_hal_amdgpu_global_table_benchmark_name_table_initialize(
+    iree_host_size_t count, iree_allocator_t host_allocator,
+    iree_hal_amdgpu_global_table_benchmark_name_table_t* out_name_table) {
+  IREE_ASSERT_ARGUMENT(out_name_table);
+  memset(out_name_table, 0, sizeof(*out_name_table));
+  out_name_table->host_allocator = host_allocator;
+  out_name_table->count = count;
+
+  iree_status_t status = iree_allocator_malloc_array(
+      host_allocator, count, sizeof(out_name_table->names[0]),
+      (void**)&out_name_table->names);
+  if (iree_status_is_ok(status)) {
+    status = iree_allocator_malloc_array(
+        host_allocator, count,
+        IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_NAME_CAPACITY,
+        (void**)&out_name_table->storage);
+  }
+
+  for (iree_host_size_t i = 0; i < count && iree_status_is_ok(status); ++i) {
+    char* storage = out_name_table->storage +
+                    i * IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_NAME_CAPACITY;
+    int name_length =
+        snprintf(storage, IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_NAME_CAPACITY,
+                 "global_%04" PRIhsz, i);
+    if (name_length <= 0 ||
+        (iree_host_size_t)name_length >=
+            IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_NAME_CAPACITY) {
+      status = iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "benchmark global name for ordinal %" PRIhsz
+          " exceeds storage capacity %" PRIhsz,
+          i,
+          (iree_host_size_t)
+              IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_NAME_CAPACITY);
+    } else {
+      out_name_table->names[i] =
+          iree_make_string_view(storage, (iree_host_size_t)name_length);
+    }
+  }
+
+  if (!iree_status_is_ok(status)) {
+    iree_hal_amdgpu_global_table_benchmark_name_table_deinitialize(
+        out_name_table);
+  }
+  return status;
+}
+
+static void iree_hal_amdgpu_global_table_benchmark_fixture_deinitialize(
+    iree_hal_amdgpu_global_table_benchmark_fixture_t* fixture) {
+  iree_hal_amdgpu_global_table_deinitialize(&fixture->table);
+  iree_hal_amdgpu_global_table_benchmark_name_table_deinitialize(
+      &fixture->name_table);
+  iree_hal_buffer_release(fixture->fake_buffer);
+  memset(fixture, 0, sizeof(*fixture));
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_benchmark_fixture_initialize(
+    const iree_hal_amdgpu_global_table_benchmark_config_t* config,
+    iree_hal_amdgpu_global_table_benchmark_fixture_t* out_fixture) {
+  IREE_ASSERT_ARGUMENT(config);
+  IREE_ASSERT_ARGUMENT(out_fixture);
+  memset(out_fixture, 0, sizeof(*out_fixture));
+
+  iree_status_t status =
+      iree_hal_amdgpu_global_table_benchmark_create_heap_buffer(
+          &out_fixture->fake_buffer);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_amdgpu_global_table_benchmark_name_table_initialize(
+        config->entry_count, iree_allocator_system(), &out_fixture->name_table);
+  }
+  if (iree_status_is_ok(status)) {
+    out_fixture->resolver.global_count = config->entry_count;
+    out_fixture->resolver.buffer = out_fixture->fake_buffer;
+  }
+
+  const iree_hal_amdgpu_global_table_params_t params = {
+      .host_allocator = iree_allocator_system(),
+      .queue_affinity_domain = iree_hal_amdgpu_global_table_benchmark_domain(),
+      .loaded_physical_device_mask = 0x1ull,
+      .physical_device_count = 1,
+      .resolver =
+          {
+              .user_data = &out_fixture->resolver,
+              .verify = iree_hal_amdgpu_global_table_benchmark_verify,
+              .create_buffer =
+                  iree_hal_amdgpu_global_table_benchmark_create_buffer,
+          },
+  };
+  if (iree_status_is_ok(status)) {
+    status =
+        iree_hal_amdgpu_global_table_initialize(&params, &out_fixture->table);
+  }
+
+  for (iree_host_size_t i = 0;
+       i < out_fixture->name_table.count && iree_status_is_ok(status); ++i) {
+    iree_hal_executable_global_t global = iree_hal_executable_global_invalid();
+    status = iree_hal_amdgpu_global_table_lookup(
+        &out_fixture->table, out_fixture->name_table.names[i], &global);
+  }
+
+  if (!iree_status_is_ok(status)) {
+    iree_hal_amdgpu_global_table_benchmark_fixture_deinitialize(out_fixture);
+  }
+  return status;
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_benchmark_run_lookup(
+    iree_hal_amdgpu_global_table_benchmark_mode_t mode,
+    iree_hal_amdgpu_global_table_benchmark_fixture_t* fixture,
+    iree_benchmark_state_t* benchmark_state) {
+  iree_host_size_t global_ordinal = 0;
+  if (mode == IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_LOOKUP_LAST) {
+    global_ordinal = fixture->name_table.count - 1;
+  }
+
+  iree_status_t status = iree_ok_status();
+  while (iree_status_is_ok(status) &&
+         iree_benchmark_keep_running(benchmark_state, 1)) {
+    iree_hal_executable_global_t cached_global =
+        iree_hal_executable_global_invalid();
+    status = iree_hal_amdgpu_global_table_lookup(
+        &fixture->table, fixture->name_table.names[global_ordinal],
+        &cached_global);
+    iree_optimization_barrier(cached_global.value);
+
+    if (mode == IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_LOOKUP_CYCLE) {
+      ++global_ordinal;
+      if (global_ordinal == fixture->name_table.count) {
+        global_ordinal = 0;
+      }
+    }
+  }
+  return status;
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_benchmark_run_buffer(
+    iree_hal_executable_global_t global,
+    iree_hal_amdgpu_global_table_benchmark_fixture_t* fixture,
+    iree_benchmark_state_t* benchmark_state) {
+  iree_status_t status = iree_ok_status();
+  while (iree_status_is_ok(status) &&
+         iree_benchmark_keep_running(benchmark_state, 1)) {
+    iree_hal_buffer_t* cached_buffer = NULL;
+    status = iree_hal_amdgpu_global_table_buffer(
+        &fixture->table, global, IREE_HAL_QUEUE_AFFINITY_ANY, &cached_buffer);
+    iree_optimization_barrier(cached_buffer);
+  }
+  return status;
+}
+
+static iree_status_t iree_hal_amdgpu_global_table_benchmark_run(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  const iree_hal_amdgpu_global_table_benchmark_config_t* config =
+      (const iree_hal_amdgpu_global_table_benchmark_config_t*)
+          benchmark_def->user_data;
+
+  iree_hal_amdgpu_global_table_benchmark_fixture_t fixture;
+  iree_hal_executable_global_t buffer_global =
+      iree_hal_executable_global_invalid();
+
+  iree_status_t status =
+      iree_hal_amdgpu_global_table_benchmark_fixture_initialize(config,
+                                                                &fixture);
+  if (iree_status_is_ok(status) &&
+      config->mode == IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_BUFFER_CACHED) {
+    status = iree_hal_amdgpu_global_table_lookup(
+        &fixture.table, fixture.name_table.names[fixture.name_table.count - 1],
+        &buffer_global);
+  }
+  if (iree_status_is_ok(status) &&
+      config->mode == IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_BUFFER_CACHED) {
+    iree_hal_buffer_t* cached_buffer = NULL;
+    status = iree_hal_amdgpu_global_table_buffer(&fixture.table, buffer_global,
+                                                 IREE_HAL_QUEUE_AFFINITY_ANY,
+                                                 &cached_buffer);
+    iree_optimization_barrier(cached_buffer);
+  }
+
+  if (iree_status_is_ok(status)) {
+    switch (config->mode) {
+      case IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_LOOKUP_FIRST:
+      case IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_LOOKUP_LAST:
+      case IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_LOOKUP_CYCLE:
+        status = iree_hal_amdgpu_global_table_benchmark_run_lookup(
+            config->mode, &fixture, benchmark_state);
+        break;
+      case IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_BUFFER_CACHED:
+        status = iree_hal_amdgpu_global_table_benchmark_run_buffer(
+            buffer_global, &fixture, benchmark_state);
+        break;
+    }
+  }
+
+  iree_hal_amdgpu_global_table_benchmark_fixture_deinitialize(&fixture);
+  return status;
+}
+
+#define IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_REGISTER(               \
+    suffix, name, mode_value, entry_count_value)                       \
+  static const iree_hal_amdgpu_global_table_benchmark_config_t         \
+      iree_hal_amdgpu_global_table_benchmark_config_##suffix = {       \
+          .mode = mode_value,                                          \
+          .entry_count = entry_count_value,                            \
+  };                                                                   \
+  static const iree_benchmark_def_t                                    \
+      iree_hal_amdgpu_global_table_benchmark_def_##suffix = {          \
+          .time_unit = IREE_BENCHMARK_UNIT_NANOSECOND,                 \
+          .run = iree_hal_amdgpu_global_table_benchmark_run,           \
+          .user_data =                                                 \
+              &iree_hal_amdgpu_global_table_benchmark_config_##suffix, \
+  };                                                                   \
+  static const iree_benchmark_def_t*                                   \
+      iree_hal_amdgpu_global_table_benchmark_registration_##suffix     \
+          IREE_ATTRIBUTE_UNUSED = iree_benchmark_register(             \
+              iree_make_cstring_view(name),                            \
+              &iree_hal_amdgpu_global_table_benchmark_def_##suffix)
+
+#define IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_REGISTER_FOR_COUNT(suffix,      \
+                                                                  entry_count) \
+  IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_REGISTER(                             \
+      lookup_first_##suffix,                                                   \
+      "BM_GlobalTableLookupCachedFirst/entries:" #entry_count,                 \
+      IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_LOOKUP_FIRST, entry_count);       \
+  IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_REGISTER(                             \
+      lookup_last_##suffix,                                                    \
+      "BM_GlobalTableLookupCachedLast/entries:" #entry_count,                  \
+      IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_LOOKUP_LAST, entry_count);        \
+  IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_REGISTER(                             \
+      lookup_cycle_##suffix,                                                   \
+      "BM_GlobalTableLookupCachedCycle/entries:" #entry_count,                 \
+      IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_LOOKUP_CYCLE, entry_count);       \
+  IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_REGISTER(                             \
+      buffer_cached_##suffix,                                                  \
+      "BM_GlobalTableBufferCached/entries:" #entry_count,                      \
+      IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_BUFFER_CACHED, entry_count)
+
+IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_REGISTER_FOR_COUNT(1, 1);
+IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_REGISTER_FOR_COUNT(8, 8);
+IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_REGISTER_FOR_COUNT(64, 64);
+IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_REGISTER_FOR_COUNT(256, 256);
+IREE_HAL_AMDGPU_GLOBAL_TABLE_BENCHMARK_REGISTER_FOR_COUNT(1024, 1024);

--- a/runtime/src/iree/hal/drivers/amdgpu/util/global_table_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/global_table_test.cc
@@ -20,30 +20,30 @@ struct FakeResolver {
   iree_hal_queue_affinity_t last_create_queue_affinity = 0;
 };
 
-static iree_status_t LookupFakeGlobal(iree_string_view_t name,
-                                      iree_device_size_t* out_byte_length) {
+static bool TryLookupFakeGlobal(iree_string_view_t name,
+                                iree_device_size_t* out_byte_length) {
   if (iree_string_view_equal(name, IREE_SV("global_a"))) {
     *out_byte_length = 64;
-    return iree_ok_status();
+    return true;
   }
   if (iree_string_view_equal(name, IREE_SV("global_b"))) {
     *out_byte_length = 128;
-    return iree_ok_status();
+    return true;
   }
   *out_byte_length = 0;
-  return iree_make_status(IREE_STATUS_NOT_FOUND, "fake global `%.*s` not found",
-                          (int)name.size, name.data);
+  return false;
 }
 
-static iree_status_t FakeVerify(
+static iree_status_t FakeTryVerify(
     void* user_data, iree_string_view_t name,
-    iree_host_size_t verification_physical_device_ordinal,
+    iree_host_size_t verification_physical_device_ordinal, bool* out_found,
     iree_device_size_t* out_byte_length) {
   auto* resolver = static_cast<FakeResolver*>(user_data);
   ++resolver->verify_call_count;
   resolver->last_verify_physical_device_ordinal =
       verification_physical_device_ordinal;
-  return LookupFakeGlobal(name, out_byte_length);
+  *out_found = TryLookupFakeGlobal(name, out_byte_length);
+  return iree_ok_status();
 }
 
 static void FakeBufferRelease(void* user_data, iree_hal_buffer_t* buffer) {
@@ -63,7 +63,9 @@ static iree_status_t FakeCreateBuffer(
   *out_buffer = nullptr;
 
   iree_device_size_t byte_length = 0;
-  IREE_RETURN_IF_ERROR(LookupFakeGlobal(name, &byte_length));
+  if (!TryLookupFakeGlobal(name, &byte_length)) {
+    return iree_make_status(IREE_STATUS_INTERNAL, "fake global not verified");
+  }
   if (byte_length != expected_byte_length) {
     return iree_make_status(IREE_STATUS_INTERNAL, "fake global size mismatch");
   }
@@ -114,7 +116,7 @@ class GlobalTableTest : public ::testing::Test {
         .resolver =
             {
                 .user_data = &resolver_,
-                .verify = FakeVerify,
+                .try_verify = FakeTryVerify,
                 .create_buffer = FakeCreateBuffer,
             },
     };
@@ -227,7 +229,7 @@ TEST(GlobalTableStandaloneTest, BufferRejectsUnloadedPhysicalDevice) {
       .resolver =
           {
               .user_data = &resolver,
-              .verify = FakeVerify,
+              .try_verify = FakeTryVerify,
               .create_buffer = FakeCreateBuffer,
           },
   };

--- a/runtime/src/iree/hal/drivers/amdgpu/util/global_table_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/global_table_test.cc
@@ -1,0 +1,249 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/global_table.h"
+
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree::hal::amdgpu {
+namespace {
+
+struct FakeResolver {
+  iree_host_size_t verify_call_count = 0;
+  iree_host_size_t create_buffer_call_count = 0;
+  iree_host_size_t last_verify_physical_device_ordinal = IREE_HOST_SIZE_MAX;
+  iree_host_size_t last_create_physical_device_ordinal = IREE_HOST_SIZE_MAX;
+  iree_hal_queue_affinity_t last_create_queue_affinity = 0;
+};
+
+static iree_status_t LookupFakeGlobal(iree_string_view_t name,
+                                      iree_device_size_t* out_byte_length) {
+  if (iree_string_view_equal(name, IREE_SV("global_a"))) {
+    *out_byte_length = 64;
+    return iree_ok_status();
+  }
+  if (iree_string_view_equal(name, IREE_SV("global_b"))) {
+    *out_byte_length = 128;
+    return iree_ok_status();
+  }
+  *out_byte_length = 0;
+  return iree_make_status(IREE_STATUS_NOT_FOUND, "fake global `%.*s` not found",
+                          (int)name.size, name.data);
+}
+
+static iree_status_t FakeVerify(
+    void* user_data, iree_string_view_t name,
+    iree_host_size_t verification_physical_device_ordinal,
+    iree_device_size_t* out_byte_length) {
+  auto* resolver = static_cast<FakeResolver*>(user_data);
+  ++resolver->verify_call_count;
+  resolver->last_verify_physical_device_ordinal =
+      verification_physical_device_ordinal;
+  return LookupFakeGlobal(name, out_byte_length);
+}
+
+static void FakeBufferRelease(void* user_data, iree_hal_buffer_t* buffer) {
+  (void)buffer;
+  iree_allocator_free_aligned(iree_allocator_system(), user_data);
+}
+
+static iree_status_t FakeCreateBuffer(
+    void* user_data, iree_string_view_t name,
+    iree_device_size_t expected_byte_length,
+    iree_hal_queue_affinity_t selected_queue_affinity,
+    iree_host_size_t physical_device_ordinal, iree_hal_buffer_t** out_buffer) {
+  auto* resolver = static_cast<FakeResolver*>(user_data);
+  ++resolver->create_buffer_call_count;
+  resolver->last_create_physical_device_ordinal = physical_device_ordinal;
+  resolver->last_create_queue_affinity = selected_queue_affinity;
+  *out_buffer = nullptr;
+
+  iree_device_size_t byte_length = 0;
+  IREE_RETURN_IF_ERROR(LookupFakeGlobal(name, &byte_length));
+  if (byte_length != expected_byte_length) {
+    return iree_make_status(IREE_STATUS_INTERNAL, "fake global size mismatch");
+  }
+
+  void* storage = nullptr;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc_aligned(
+      iree_allocator_system(), expected_byte_length,
+      IREE_HAL_HEAP_BUFFER_ALIGNMENT, /*offset=*/0, &storage));
+  memset(storage, 0, expected_byte_length);
+
+  iree_hal_buffer_placement_t placement = {
+      .device = nullptr,
+      .queue_affinity = selected_queue_affinity,
+      .flags = IREE_HAL_BUFFER_PLACEMENT_FLAG_NONE,
+  };
+  iree_hal_buffer_release_callback_t release_callback = {
+      .fn = FakeBufferRelease,
+      .user_data = storage,
+  };
+  iree_status_t status = iree_hal_heap_buffer_wrap(
+      placement, IREE_HAL_MEMORY_TYPE_HOST_LOCAL,
+      IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE,
+      IREE_HAL_BUFFER_USAGE_DEFAULT, expected_byte_length,
+      iree_make_byte_span(storage, expected_byte_length), release_callback,
+      iree_allocator_system(), out_buffer);
+  if (!iree_status_is_ok(status)) {
+    iree_allocator_free_aligned(iree_allocator_system(), storage);
+  }
+  return status;
+}
+
+static iree_hal_amdgpu_queue_affinity_domain_t TwoDeviceDomain() {
+  return (iree_hal_amdgpu_queue_affinity_domain_t){
+      .supported_affinity = 0xFull,
+      .physical_device_count = 2,
+      .queue_count_per_physical_device = 2,
+  };
+}
+
+class GlobalTableTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const iree_hal_amdgpu_global_table_params_t params = {
+        .host_allocator = iree_allocator_system(),
+        .queue_affinity_domain = TwoDeviceDomain(),
+        .loaded_physical_device_mask = 0x3ull,
+        .physical_device_count = 2,
+        .resolver =
+            {
+                .user_data = &resolver_,
+                .verify = FakeVerify,
+                .create_buffer = FakeCreateBuffer,
+            },
+    };
+    IREE_ASSERT_OK(iree_hal_amdgpu_global_table_initialize(&params, &table_));
+  }
+
+  void TearDown() override {
+    iree_hal_amdgpu_global_table_deinitialize(&table_);
+  }
+
+  FakeResolver resolver_;
+  iree_hal_amdgpu_global_table_t table_;
+};
+
+TEST_F(GlobalTableTest, LookupInternsAndCachesByName) {
+  iree_hal_executable_global_t first_global =
+      iree_hal_executable_global_invalid();
+  IREE_ASSERT_OK(iree_hal_amdgpu_global_table_lookup(
+      &table_, IREE_SV("global_a"), &first_global));
+  EXPECT_TRUE(iree_hal_executable_global_is_valid(first_global));
+  EXPECT_EQ(resolver_.verify_call_count, 1u);
+  EXPECT_EQ(resolver_.last_verify_physical_device_ordinal, 0u);
+
+  iree_hal_executable_global_t second_global =
+      iree_hal_executable_global_invalid();
+  IREE_ASSERT_OK(iree_hal_amdgpu_global_table_lookup(
+      &table_, IREE_SV("global_a"), &second_global));
+  EXPECT_EQ(second_global.value, first_global.value);
+  EXPECT_EQ(resolver_.verify_call_count, 1u);
+}
+
+TEST_F(GlobalTableTest, LookupMissDoesNotIntern) {
+  iree_hal_executable_global_t global = iree_hal_executable_global_invalid();
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_NOT_FOUND,
+                        iree_hal_amdgpu_global_table_lookup(
+                            &table_, IREE_SV("missing"), &global));
+  EXPECT_FALSE(iree_hal_executable_global_is_valid(global));
+
+  iree_hal_executable_global_info_t info;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_global_table_info(&table_, global, &info));
+}
+
+TEST_F(GlobalTableTest, InfoReturnsBorrowedMetadata) {
+  iree_hal_executable_global_t global = iree_hal_executable_global_invalid();
+  IREE_ASSERT_OK(iree_hal_amdgpu_global_table_lookup(
+      &table_, IREE_SV("global_b"), &global));
+
+  iree_hal_executable_global_info_t info;
+  IREE_ASSERT_OK(iree_hal_amdgpu_global_table_info(&table_, global, &info));
+  EXPECT_TRUE(iree_string_view_equal(info.name, IREE_SV("global_b")));
+  EXPECT_EQ(info.byte_length, 128u);
+}
+
+TEST_F(GlobalTableTest, BufferCachesPerPhysicalDevice) {
+  iree_hal_executable_global_t global = iree_hal_executable_global_invalid();
+  IREE_ASSERT_OK(iree_hal_amdgpu_global_table_lookup(
+      &table_, IREE_SV("global_a"), &global));
+
+  iree_hal_buffer_t* first_device_buffer = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_global_table_buffer(
+      &table_, global, IREE_HAL_QUEUE_AFFINITY_ANY, &first_device_buffer));
+  ASSERT_NE(first_device_buffer, nullptr);
+  EXPECT_EQ(resolver_.create_buffer_call_count, 1u);
+  EXPECT_EQ(resolver_.last_create_physical_device_ordinal, 0u);
+  EXPECT_EQ(resolver_.last_create_queue_affinity, 0x3ull);
+
+  iree_hal_buffer_t* cached_first_device_buffer = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_global_table_buffer(
+      &table_, global, IREE_HAL_QUEUE_AFFINITY_ANY,
+      &cached_first_device_buffer));
+  EXPECT_EQ(cached_first_device_buffer, first_device_buffer);
+  EXPECT_EQ(resolver_.create_buffer_call_count, 1u);
+
+  iree_hal_buffer_t* second_device_buffer = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_global_table_buffer(&table_, global, 0xCull,
+                                                     &second_device_buffer));
+  ASSERT_NE(second_device_buffer, nullptr);
+  EXPECT_NE(second_device_buffer, first_device_buffer);
+  EXPECT_EQ(resolver_.create_buffer_call_count, 2u);
+  EXPECT_EQ(resolver_.last_create_physical_device_ordinal, 1u);
+  EXPECT_EQ(resolver_.last_create_queue_affinity, 0xCull);
+}
+
+TEST_F(GlobalTableTest, InvalidGlobalAccessRejected) {
+  iree_hal_executable_global_t global = iree_hal_executable_global_invalid();
+
+  iree_hal_executable_global_info_t info;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_global_table_info(&table_, global, &info));
+
+  iree_hal_buffer_t* buffer = nullptr;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_global_table_buffer(
+          &table_, global, IREE_HAL_QUEUE_AFFINITY_ANY, &buffer));
+  EXPECT_EQ(buffer, nullptr);
+}
+
+TEST(GlobalTableStandaloneTest, BufferRejectsUnloadedPhysicalDevice) {
+  FakeResolver resolver;
+  iree_hal_amdgpu_global_table_t table;
+  const iree_hal_amdgpu_global_table_params_t params = {
+      .host_allocator = iree_allocator_system(),
+      .queue_affinity_domain = TwoDeviceDomain(),
+      .loaded_physical_device_mask = 0x1ull,
+      .physical_device_count = 2,
+      .resolver =
+          {
+              .user_data = &resolver,
+              .verify = FakeVerify,
+              .create_buffer = FakeCreateBuffer,
+          },
+  };
+  IREE_ASSERT_OK(iree_hal_amdgpu_global_table_initialize(&params, &table));
+
+  iree_hal_executable_global_t global = iree_hal_executable_global_invalid();
+  IREE_ASSERT_OK(iree_hal_amdgpu_global_table_lookup(
+      &table, IREE_SV("global_a"), &global));
+  iree_hal_buffer_t* buffer = nullptr;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_global_table_buffer(&table, global, 0xCull, &buffer));
+  EXPECT_EQ(buffer, nullptr);
+
+  iree_hal_amdgpu_global_table_deinitialize(&table);
+}
+
+}  // namespace
+}  // namespace iree::hal::amdgpu

--- a/runtime/src/iree/hal/drivers/cuda/native_executable.c
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.c
@@ -674,9 +674,11 @@ static iree_status_t iree_hal_cuda_native_executable_lookup_export_by_name(
 #define IREE_HAL_CUDA_MAX_STACK_GLOBAL_NAME_LENGTH \
   ((iree_host_size_t)(4 * 1024))
 
-static iree_status_t iree_hal_cuda_native_executable_query_global(
+static iree_status_t iree_hal_cuda_native_executable_try_query_global(
     iree_hal_cuda_native_executable_t* executable, iree_string_view_t name,
-    CUdeviceptr* out_global_device_ptr, iree_device_size_t* out_byte_length) {
+    bool* out_found, CUdeviceptr* out_global_device_ptr,
+    iree_device_size_t* out_byte_length) {
+  *out_found = false;
   if (out_global_device_ptr) *out_global_device_ptr = 0;
   *out_byte_length = 0;
 
@@ -703,12 +705,9 @@ static iree_status_t iree_hal_cuda_native_executable_query_global(
           executable->symbols, terminal_result, __FILE__, __LINE__);
     }
   }
-  if (terminal_result != CUDA_SUCCESS) {
-    return iree_make_status(IREE_STATUS_NOT_FOUND,
-                            "executable global `%.*s` not found",
-                            (int)name.size, name.data);
-  }
+  if (terminal_result != CUDA_SUCCESS) return iree_ok_status();
 
+  *out_found = true;
   if (out_global_device_ptr) *out_global_device_ptr = global_device_ptr;
   *out_byte_length = (iree_device_size_t)global_size;
   return iree_ok_status();
@@ -729,11 +728,12 @@ static iree_status_t iree_hal_cuda_native_executable_validate_global_name(
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_cuda_native_executable_lookup_global_by_name(
+static iree_status_t iree_hal_cuda_native_executable_try_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_executable_global_t* out_global) {
+    bool* out_found, iree_hal_executable_global_t* out_global) {
   iree_hal_cuda_native_executable_t* executable =
       iree_hal_cuda_native_executable_cast(base_executable);
+  *out_found = false;
   *out_global = iree_hal_executable_global_invalid();
 
   IREE_RETURN_IF_ERROR(
@@ -743,6 +743,7 @@ static iree_status_t iree_hal_cuda_native_executable_lookup_global_by_name(
   iree_hal_cuda_native_executable_global_t* global =
       iree_hal_cuda_native_executable_find_global_locked(executable, name);
   if (global) {
+    *out_found = true;
     *out_global =
         iree_hal_executable_global_from_value((uint64_t)(uintptr_t)global);
     iree_slim_mutex_unlock(&executable->global_mutex);
@@ -751,8 +752,11 @@ static iree_status_t iree_hal_cuda_native_executable_lookup_global_by_name(
   iree_slim_mutex_unlock(&executable->global_mutex);
 
   iree_device_size_t byte_length = 0;
-  IREE_RETURN_IF_ERROR(iree_hal_cuda_native_executable_query_global(
-      executable, name, /*out_global_device_ptr=*/NULL, &byte_length));
+  bool query_found = false;
+  IREE_RETURN_IF_ERROR(iree_hal_cuda_native_executable_try_query_global(
+      executable, name, &query_found, /*out_global_device_ptr=*/NULL,
+      &byte_length));
+  if (!query_found) return iree_ok_status();
 
   iree_hal_cuda_native_executable_global_t* new_global = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_cuda_native_executable_global_allocate(
@@ -761,11 +765,13 @@ static iree_status_t iree_hal_cuda_native_executable_lookup_global_by_name(
   iree_slim_mutex_lock(&executable->global_mutex);
   global = iree_hal_cuda_native_executable_find_global_locked(executable, name);
   if (global) {
+    *out_found = true;
     *out_global =
         iree_hal_executable_global_from_value((uint64_t)(uintptr_t)global);
   } else {
     new_global->next = executable->global_list;
     executable->global_list = new_global;
+    *out_found = true;
     *out_global =
         iree_hal_executable_global_from_value((uint64_t)(uintptr_t)new_global);
     new_global = NULL;
@@ -825,8 +831,14 @@ static iree_status_t iree_hal_cuda_native_executable_global_buffer(
 
   CUdeviceptr global_device_ptr = 0;
   iree_device_size_t byte_length = 0;
-  IREE_RETURN_IF_ERROR(iree_hal_cuda_native_executable_query_global(
-      executable, name, &global_device_ptr, &byte_length));
+  bool found = false;
+  IREE_RETURN_IF_ERROR(iree_hal_cuda_native_executable_try_query_global(
+      executable, name, &found, &global_device_ptr, &byte_length));
+  if (IREE_UNLIKELY(!found)) {
+    return iree_make_status(IREE_STATUS_INTERNAL,
+                            "verified executable global `%.*s` disappeared",
+                            (int)name.size, name.data);
+  }
   if (IREE_UNLIKELY(byte_length != expected_byte_length)) {
     return iree_make_status(
         IREE_STATUS_INTERNAL,
@@ -882,8 +894,8 @@ static const iree_hal_executable_vtable_t
             iree_hal_cuda_native_executable_export_parameters,
         .lookup_function_by_name =
             iree_hal_cuda_native_executable_lookup_export_by_name,
-        .lookup_global_by_name =
-            iree_hal_cuda_native_executable_lookup_global_by_name,
+        .try_lookup_global_by_name =
+            iree_hal_cuda_native_executable_try_lookup_global_by_name,
         .global_info = iree_hal_cuda_native_executable_global_info,
         .global_buffer = iree_hal_cuda_native_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/drivers/cuda/native_executable.c
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.c
@@ -9,6 +9,7 @@
 #include <stddef.h>
 
 #include "iree/base/api.h"
+#include "iree/base/threading/mutex.h"
 #include "iree/hal/drivers/cuda/cuda_buffer.h"
 #include "iree/hal/drivers/cuda/cuda_dynamic_symbols.h"
 #include "iree/hal/drivers/cuda/cuda_status_util.h"
@@ -21,6 +22,20 @@
 #include "iree/schemas/cuda_executable_def_verifier.h"
 #include "iree/schemas/executable_debug_info_reader.h"
 #include "iree/schemas/executable_debug_info_verifier.h"
+
+typedef struct iree_hal_cuda_native_executable_global_t {
+  // Next executable-owned global entry.
+  struct iree_hal_cuda_native_executable_global_t* next;
+
+  // Persistent executable-owned global name.
+  iree_string_view_t name;
+
+  // Byte length verified against the loaded CUDA modules.
+  iree_device_size_t byte_length;
+
+  // Executable-owned buffer alias for this global.
+  iree_hal_buffer_t* buffer;
+} iree_hal_cuda_native_executable_global_t;
 
 typedef struct iree_hal_cuda_native_executable_t {
   // Abstract resource used for injecting reference counting and vtable;
@@ -41,6 +56,12 @@ typedef struct iree_hal_cuda_native_executable_t {
   iree_host_size_t module_count;
   // Loaded CUDA modules.
   CUmodule* modules;
+
+  // Guards executable-owned global entry and buffer publication.
+  iree_slim_mutex_t global_mutex;
+
+  // Executable-owned globals interned by name.
+  iree_hal_cuda_native_executable_global_t* global_list;
 
   // Number of exported kernels referencing the loaded modules.
   iree_host_size_t export_count;
@@ -343,6 +364,7 @@ iree_status_t iree_hal_cuda_native_executable_create(
   executable->module_count = module_count;
   executable->modules = (CUmodule*)((uint8_t*)executable + sizeof(*executable) +
                                     export_table_size);
+  iree_slim_mutex_initialize(&executable->global_mutex);
   executable->export_count = export_count;
   char* export_name_ptr = (char*)executable->modules + module_table_size;
   IREE_TRACE(uint8_t* export_info_ptr =
@@ -476,12 +498,93 @@ iree_status_t iree_hal_cuda_native_executable_create(
   return status;
 }
 
+static iree_hal_cuda_native_executable_global_t*
+iree_hal_cuda_native_executable_find_global_locked(
+    iree_hal_cuda_native_executable_t* executable, iree_string_view_t name) {
+  for (iree_hal_cuda_native_executable_global_t* global =
+           executable->global_list;
+       global; global = global->next) {
+    if (iree_string_view_equal(global->name, name)) return global;
+  }
+  return NULL;
+}
+
+static iree_hal_cuda_native_executable_global_t*
+iree_hal_cuda_native_executable_global_from_handle_locked(
+    iree_hal_cuda_native_executable_t* executable,
+    iree_hal_executable_global_t global) {
+  if (!iree_hal_executable_global_is_valid(global)) return NULL;
+  iree_hal_cuda_native_executable_global_t* expected_global =
+      (iree_hal_cuda_native_executable_global_t*)(uintptr_t)global.value;
+  for (iree_hal_cuda_native_executable_global_t* current_global =
+           executable->global_list;
+       current_global; current_global = current_global->next) {
+    if (current_global == expected_global) return current_global;
+  }
+  return NULL;
+}
+
+static iree_status_t iree_hal_cuda_native_executable_global_allocate(
+    iree_hal_cuda_native_executable_t* executable, iree_string_view_t name,
+    iree_device_size_t byte_length,
+    iree_hal_cuda_native_executable_global_t** out_global) {
+  *out_global = NULL;
+
+  iree_host_size_t name_storage_size = 0;
+  if (IREE_UNLIKELY(
+          !iree_host_size_checked_add(name.size, 1, &name_storage_size))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "CUDA executable global name storage overflow");
+  }
+
+  iree_host_size_t total_size = 0;
+  iree_host_size_t name_offset = 0;
+  IREE_RETURN_IF_ERROR(IREE_STRUCT_LAYOUT(
+      sizeof(iree_hal_cuda_native_executable_global_t), &total_size,
+      IREE_STRUCT_FIELD(name_storage_size, char, &name_offset)));
+
+  iree_hal_cuda_native_executable_global_t* global = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(executable->host_allocator,
+                                             total_size, (void**)&global));
+  memset(global, 0, total_size);
+
+  global->name = iree_make_string_view((char*)global + name_offset, name.size);
+  memcpy((void*)global->name.data, name.data, name.size);
+  ((char*)global->name.data)[name.size] = 0;
+  global->byte_length = byte_length;
+
+  *out_global = global;
+  return iree_ok_status();
+}
+
+static void iree_hal_cuda_native_executable_global_free(
+    iree_hal_cuda_native_executable_t* executable,
+    iree_hal_cuda_native_executable_global_t* global) {
+  if (!global) return;
+  iree_hal_buffer_release(global->buffer);
+  iree_allocator_free(executable->host_allocator, global);
+}
+
+static void iree_hal_cuda_native_executable_global_list_free(
+    iree_hal_cuda_native_executable_t* executable) {
+  iree_hal_cuda_native_executable_global_t* global = executable->global_list;
+  while (global) {
+    iree_hal_cuda_native_executable_global_t* next_global = global->next;
+    iree_hal_cuda_native_executable_global_free(executable, global);
+    global = next_global;
+  }
+  executable->global_list = NULL;
+}
+
 static void iree_hal_cuda_native_executable_destroy(
     iree_hal_executable_t* base_executable) {
   iree_hal_cuda_native_executable_t* executable =
       iree_hal_cuda_native_executable_cast(base_executable);
   iree_allocator_t host_allocator = executable->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_cuda_native_executable_global_list_free(executable);
+  iree_slim_mutex_deinitialize(&executable->global_mutex);
 
   for (iree_host_size_t i = 0; i < executable->module_count; ++i) {
     if (executable->modules[i]) {
@@ -571,29 +674,11 @@ static iree_status_t iree_hal_cuda_native_executable_lookup_export_by_name(
 #define IREE_HAL_CUDA_MAX_STACK_GLOBAL_NAME_LENGTH \
   ((iree_host_size_t)(4 * 1024))
 
-static void iree_hal_cuda_native_executable_global_buffer_release(
-    void* user_data, iree_hal_buffer_t* buffer) {
-  (void)buffer;
-  iree_hal_executable_release((iree_hal_executable_t*)user_data);
-}
-
-static iree_status_t iree_hal_cuda_native_executable_lookup_global_by_name(
-    iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
-  iree_hal_cuda_native_executable_t* executable =
-      iree_hal_cuda_native_executable_cast(base_executable);
-  *out_buffer = NULL;
-
-  if (iree_string_view_is_empty(name)) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "executable global name is empty");
-  }
-  if (name.size > IREE_HAL_CUDA_MAX_STACK_GLOBAL_NAME_LENGTH) {
-    return iree_make_status(
-        IREE_STATUS_OUT_OF_RANGE,
-        "executable global name `%.*s` exceeds maximum length %" PRIhsz,
-        (int)name.size, name.data, IREE_HAL_CUDA_MAX_STACK_GLOBAL_NAME_LENGTH);
-  }
+static iree_status_t iree_hal_cuda_native_executable_query_global(
+    iree_hal_cuda_native_executable_t* executable, iree_string_view_t name,
+    CUdeviceptr* out_global_device_ptr, iree_device_size_t* out_byte_length) {
+  if (out_global_device_ptr) *out_global_device_ptr = 0;
+  *out_byte_length = 0;
 
   IREE_RETURN_IF_ERROR(
       IREE_CURESULT_TO_STATUS(executable->symbols,
@@ -624,6 +709,133 @@ static iree_status_t iree_hal_cuda_native_executable_lookup_global_by_name(
                             (int)name.size, name.data);
   }
 
+  if (out_global_device_ptr) *out_global_device_ptr = global_device_ptr;
+  *out_byte_length = (iree_device_size_t)global_size;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_cuda_native_executable_validate_global_name(
+    iree_string_view_t name) {
+  if (iree_string_view_is_empty(name)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "executable global name is empty");
+  }
+  if (name.size > IREE_HAL_CUDA_MAX_STACK_GLOBAL_NAME_LENGTH) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "executable global name `%.*s` exceeds maximum length %" PRIhsz,
+        (int)name.size, name.data, IREE_HAL_CUDA_MAX_STACK_GLOBAL_NAME_LENGTH);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_cuda_native_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_executable_global_t* out_global) {
+  iree_hal_cuda_native_executable_t* executable =
+      iree_hal_cuda_native_executable_cast(base_executable);
+  *out_global = iree_hal_executable_global_invalid();
+
+  IREE_RETURN_IF_ERROR(
+      iree_hal_cuda_native_executable_validate_global_name(name));
+
+  iree_slim_mutex_lock(&executable->global_mutex);
+  iree_hal_cuda_native_executable_global_t* global =
+      iree_hal_cuda_native_executable_find_global_locked(executable, name);
+  if (global) {
+    *out_global =
+        iree_hal_executable_global_from_value((uint64_t)(uintptr_t)global);
+    iree_slim_mutex_unlock(&executable->global_mutex);
+    return iree_ok_status();
+  }
+  iree_slim_mutex_unlock(&executable->global_mutex);
+
+  iree_device_size_t byte_length = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_cuda_native_executable_query_global(
+      executable, name, /*out_global_device_ptr=*/NULL, &byte_length));
+
+  iree_hal_cuda_native_executable_global_t* new_global = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_cuda_native_executable_global_allocate(
+      executable, name, byte_length, &new_global));
+
+  iree_slim_mutex_lock(&executable->global_mutex);
+  global = iree_hal_cuda_native_executable_find_global_locked(executable, name);
+  if (global) {
+    *out_global =
+        iree_hal_executable_global_from_value((uint64_t)(uintptr_t)global);
+  } else {
+    new_global->next = executable->global_list;
+    executable->global_list = new_global;
+    *out_global =
+        iree_hal_executable_global_from_value((uint64_t)(uintptr_t)new_global);
+    new_global = NULL;
+  }
+  iree_slim_mutex_unlock(&executable->global_mutex);
+
+  iree_hal_cuda_native_executable_global_free(executable, new_global);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_cuda_native_executable_global_info(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
+  iree_hal_cuda_native_executable_t* executable =
+      iree_hal_cuda_native_executable_cast(base_executable);
+  memset(out_info, 0, sizeof(*out_info));
+
+  iree_slim_mutex_lock(&executable->global_mutex);
+  iree_hal_cuda_native_executable_global_t* global_entry =
+      iree_hal_cuda_native_executable_global_from_handle_locked(executable,
+                                                                global);
+  if (!global_entry) {
+    iree_slim_mutex_unlock(&executable->global_mutex);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid CUDA executable global handle");
+  }
+  out_info->name = global_entry->name;
+  out_info->byte_length = global_entry->byte_length;
+  iree_slim_mutex_unlock(&executable->global_mutex);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_cuda_native_executable_global_buffer(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  iree_hal_cuda_native_executable_t* executable =
+      iree_hal_cuda_native_executable_cast(base_executable);
+  *out_buffer = NULL;
+
+  iree_slim_mutex_lock(&executable->global_mutex);
+  iree_hal_cuda_native_executable_global_t* global_entry =
+      iree_hal_cuda_native_executable_global_from_handle_locked(executable,
+                                                                global);
+  if (!global_entry) {
+    iree_slim_mutex_unlock(&executable->global_mutex);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid CUDA executable global handle");
+  }
+  if (global_entry->buffer) {
+    *out_buffer = global_entry->buffer;
+    iree_slim_mutex_unlock(&executable->global_mutex);
+    return iree_ok_status();
+  }
+  iree_string_view_t name = global_entry->name;
+  iree_device_size_t expected_byte_length = global_entry->byte_length;
+  iree_slim_mutex_unlock(&executable->global_mutex);
+
+  CUdeviceptr global_device_ptr = 0;
+  iree_device_size_t byte_length = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_cuda_native_executable_query_global(
+      executable, name, &global_device_ptr, &byte_length));
+  if (IREE_UNLIKELY(byte_length != expected_byte_length)) {
+    return iree_make_status(
+        IREE_STATUS_INTERNAL,
+        "verified executable global `%.*s` changed size from %" PRIu64
+        " to %" PRIu64,
+        (int)name.size, name.data, (uint64_t)expected_byte_length,
+        (uint64_t)byte_length);
+  }
+
   iree_hal_buffer_placement_t placement = {
       .device = executable->device,
       .queue_affinity = iree_hal_queue_affinity_is_empty(queue_affinity)
@@ -631,22 +843,34 @@ static iree_status_t iree_hal_cuda_native_executable_lookup_global_by_name(
                             : queue_affinity,
       .flags = IREE_HAL_BUFFER_PLACEMENT_FLAG_NONE,
   };
-  iree_hal_buffer_release_callback_t release_callback = {
-      .fn = iree_hal_cuda_native_executable_global_buffer_release,
-      .user_data = base_executable,
-  };
-  iree_hal_executable_retain(base_executable);
-  iree_status_t status = iree_hal_cuda_buffer_wrap(
+  iree_hal_buffer_t* new_buffer = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_cuda_buffer_wrap(
       placement, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
       IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE,
-      IREE_HAL_BUFFER_USAGE_DEFAULT, global_size, /*byte_offset=*/0,
-      global_size, IREE_HAL_CUDA_BUFFER_TYPE_EXTERNAL, global_device_ptr,
-      /*host_ptr=*/NULL, release_callback, executable->host_allocator,
-      out_buffer);
-  if (!iree_status_is_ok(status)) {
-    iree_hal_executable_release(base_executable);
+      IREE_HAL_BUFFER_USAGE_DEFAULT, byte_length, /*byte_offset=*/0,
+      byte_length, IREE_HAL_CUDA_BUFFER_TYPE_EXTERNAL, global_device_ptr,
+      /*host_ptr=*/NULL, iree_hal_buffer_release_callback_null(),
+      executable->host_allocator, &new_buffer));
+
+  iree_slim_mutex_lock(&executable->global_mutex);
+  global_entry = iree_hal_cuda_native_executable_global_from_handle_locked(
+      executable, global);
+  if (!global_entry) {
+    iree_slim_mutex_unlock(&executable->global_mutex);
+    iree_hal_buffer_release(new_buffer);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid CUDA executable global handle");
   }
-  return status;
+  if (global_entry->buffer) {
+    *out_buffer = global_entry->buffer;
+    iree_slim_mutex_unlock(&executable->global_mutex);
+    iree_hal_buffer_release(new_buffer);
+  } else {
+    global_entry->buffer = new_buffer;
+    *out_buffer = new_buffer;
+    iree_slim_mutex_unlock(&executable->global_mutex);
+  }
+  return iree_ok_status();
 }
 
 static const iree_hal_executable_vtable_t
@@ -660,4 +884,6 @@ static const iree_hal_executable_vtable_t
             iree_hal_cuda_native_executable_lookup_export_by_name,
         .lookup_global_by_name =
             iree_hal_cuda_native_executable_lookup_global_by_name,
+        .global_info = iree_hal_cuda_native_executable_global_info,
+        .global_buffer = iree_hal_cuda_native_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/drivers/hip/native_executable.c
+++ b/runtime/src/iree/hal/drivers/hip/native_executable.c
@@ -833,10 +833,12 @@ static iree_status_t iree_hal_hip_native_executable_select_global_device(
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_hip_native_executable_query_global(
+static iree_status_t iree_hal_hip_native_executable_try_query_global(
     iree_hal_hip_native_executable_t* executable, iree_string_view_t name,
-    iree_host_size_t device_ordinal, hipDeviceptr_t* out_global_device_ptr,
+    iree_host_size_t device_ordinal, bool* out_found,
+    hipDeviceptr_t* out_global_device_ptr,
     iree_device_size_t* out_byte_length) {
+  *out_found = false;
   if (out_global_device_ptr) *out_global_device_ptr = 0;
   *out_byte_length = 0;
 
@@ -863,12 +865,9 @@ static iree_status_t iree_hal_hip_native_executable_query_global(
       return IREE_HIP_RESULT_TO_STATUS(executable->symbols, terminal_result);
     }
   }
-  if (terminal_result != hipSuccess) {
-    return iree_make_status(IREE_STATUS_NOT_FOUND,
-                            "executable global `%.*s` not found",
-                            (int)name.size, name.data);
-  }
+  if (terminal_result != hipSuccess) return iree_ok_status();
 
+  *out_found = true;
   if (out_global_device_ptr) *out_global_device_ptr = global_device_ptr;
   *out_byte_length = (iree_device_size_t)global_size;
   return iree_ok_status();
@@ -889,11 +888,12 @@ static iree_status_t iree_hal_hip_native_executable_validate_global_name(
   return iree_ok_status();
 }
 
-static iree_status_t iree_hal_hip_native_executable_lookup_global_by_name(
+static iree_status_t iree_hal_hip_native_executable_try_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_executable_global_t* out_global) {
+    bool* out_found, iree_hal_executable_global_t* out_global) {
   iree_hal_hip_native_executable_t* executable =
       iree_hal_hip_native_executable_cast(base_executable);
+  *out_found = false;
   *out_global = iree_hal_executable_global_invalid();
 
   IREE_RETURN_IF_ERROR(
@@ -903,6 +903,7 @@ static iree_status_t iree_hal_hip_native_executable_lookup_global_by_name(
   iree_hal_hip_native_executable_global_t* global =
       iree_hal_hip_native_executable_find_global_locked(executable, name);
   if (global) {
+    *out_found = true;
     *out_global =
         iree_hal_executable_global_from_value((uint64_t)(uintptr_t)global);
     iree_slim_mutex_unlock(&executable->global_mutex);
@@ -911,9 +912,11 @@ static iree_status_t iree_hal_hip_native_executable_lookup_global_by_name(
   iree_slim_mutex_unlock(&executable->global_mutex);
 
   iree_device_size_t byte_length = 0;
-  IREE_RETURN_IF_ERROR(iree_hal_hip_native_executable_query_global(
-      executable, name, /*device_ordinal=*/0, /*out_global_device_ptr=*/NULL,
-      &byte_length));
+  bool query_found = false;
+  IREE_RETURN_IF_ERROR(iree_hal_hip_native_executable_try_query_global(
+      executable, name, /*device_ordinal=*/0, &query_found,
+      /*out_global_device_ptr=*/NULL, &byte_length));
+  if (!query_found) return iree_ok_status();
 
   iree_hal_hip_native_executable_global_t* new_global = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_hip_native_executable_global_allocate(
@@ -922,11 +925,13 @@ static iree_status_t iree_hal_hip_native_executable_lookup_global_by_name(
   iree_slim_mutex_lock(&executable->global_mutex);
   global = iree_hal_hip_native_executable_find_global_locked(executable, name);
   if (global) {
+    *out_found = true;
     *out_global =
         iree_hal_executable_global_from_value((uint64_t)(uintptr_t)global);
   } else {
     new_global->next = executable->global_list;
     executable->global_list = new_global;
+    *out_found = true;
     *out_global =
         iree_hal_executable_global_from_value((uint64_t)(uintptr_t)new_global);
     new_global = NULL;
@@ -993,8 +998,16 @@ static iree_status_t iree_hal_hip_native_executable_global_buffer(
 
   hipDeviceptr_t global_device_ptr = 0;
   iree_device_size_t byte_length = 0;
-  IREE_RETURN_IF_ERROR(iree_hal_hip_native_executable_query_global(
-      executable, name, device_ordinal, &global_device_ptr, &byte_length));
+  bool found = false;
+  IREE_RETURN_IF_ERROR(iree_hal_hip_native_executable_try_query_global(
+      executable, name, device_ordinal, &found, &global_device_ptr,
+      &byte_length));
+  if (IREE_UNLIKELY(!found)) {
+    return iree_make_status(
+        IREE_STATUS_INTERNAL,
+        "verified executable global `%.*s` disappeared on HIP device %" PRIhsz,
+        (int)name.size, name.data, device_ordinal);
+  }
   if (IREE_UNLIKELY(byte_length != expected_byte_length)) {
     return iree_make_status(
         IREE_STATUS_INTERNAL,
@@ -1048,8 +1061,8 @@ static const iree_hal_executable_vtable_t
         .function_parameters = iree_hal_hip_native_executable_export_parameters,
         .lookup_function_by_name =
             iree_hal_hip_native_executable_lookup_export_by_name,
-        .lookup_global_by_name =
-            iree_hal_hip_native_executable_lookup_global_by_name,
+        .try_lookup_global_by_name =
+            iree_hal_hip_native_executable_try_lookup_global_by_name,
         .global_info = iree_hal_hip_native_executable_global_info,
         .global_buffer = iree_hal_hip_native_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/drivers/hip/native_executable.c
+++ b/runtime/src/iree/hal/drivers/hip/native_executable.c
@@ -10,6 +10,7 @@
 
 #include "iree/base/api.h"
 #include "iree/base/internal/math.h"
+#include "iree/base/threading/mutex.h"
 #include "iree/hal/drivers/hip/context_util.h"
 #include "iree/hal/drivers/hip/dynamic_symbols.h"
 #include "iree/hal/drivers/hip/hip_buffer.h"
@@ -39,6 +40,20 @@ typedef struct iree_hal_hip_native_executable_per_device_data_t {
   iree_hal_hip_kernel_params_t exports[];
 } iree_hal_hip_native_executable_per_device_data_t;
 
+typedef struct iree_hal_hip_native_executable_global_t {
+  // Next executable-owned global entry.
+  struct iree_hal_hip_native_executable_global_t* next;
+
+  // Persistent executable-owned global name.
+  iree_string_view_t name;
+
+  // Byte length verified against the first loaded HIP device.
+  iree_device_size_t byte_length;
+
+  // One executable-owned buffer alias per loaded HIP device.
+  iree_hal_buffer_t** device_buffers;
+} iree_hal_hip_native_executable_global_t;
+
 typedef struct iree_hal_hip_native_executable_t {
   // Abstract resource used for injecting reference counting and vtable;
   // must be at offset 0.
@@ -53,6 +68,13 @@ typedef struct iree_hal_hip_native_executable_t {
 
   // Number of HIP devices this executable was loaded onto.
   iree_host_size_t num_devices;
+
+  // Guards executable-owned global entry and buffer publication.
+  iree_slim_mutex_t global_mutex;
+
+  // Executable-owned globals interned by name.
+  iree_hal_hip_native_executable_global_t* global_list;
+
   // Per-device module and export tables.
   iree_hal_hip_native_executable_per_device_data_t* per_device_data[];
 } iree_hal_hip_native_executable_t;
@@ -400,6 +422,7 @@ iree_status_t iree_hal_hip_native_executable_create(
   executable->device = device;
   executable->symbols = symbols;
   executable->num_devices = topology.count;
+  iree_slim_mutex_initialize(&executable->global_mutex);
   const uint8_t* per_device_data_location =
       (uint8_t*)executable + sizeof(*executable);
 
@@ -570,12 +593,100 @@ iree_status_t iree_hal_hip_native_executable_create(
   return status;
 }
 
+static iree_hal_hip_native_executable_global_t*
+iree_hal_hip_native_executable_find_global_locked(
+    iree_hal_hip_native_executable_t* executable, iree_string_view_t name) {
+  for (iree_hal_hip_native_executable_global_t* global =
+           executable->global_list;
+       global; global = global->next) {
+    if (iree_string_view_equal(global->name, name)) return global;
+  }
+  return NULL;
+}
+
+static iree_hal_hip_native_executable_global_t*
+iree_hal_hip_native_executable_global_from_handle_locked(
+    iree_hal_hip_native_executable_t* executable,
+    iree_hal_executable_global_t global) {
+  if (!iree_hal_executable_global_is_valid(global)) return NULL;
+  iree_hal_hip_native_executable_global_t* expected_global =
+      (iree_hal_hip_native_executable_global_t*)(uintptr_t)global.value;
+  for (iree_hal_hip_native_executable_global_t* current_global =
+           executable->global_list;
+       current_global; current_global = current_global->next) {
+    if (current_global == expected_global) return current_global;
+  }
+  return NULL;
+}
+
+static iree_status_t iree_hal_hip_native_executable_global_allocate(
+    iree_hal_hip_native_executable_t* executable, iree_string_view_t name,
+    iree_device_size_t byte_length,
+    iree_hal_hip_native_executable_global_t** out_global) {
+  *out_global = NULL;
+
+  iree_host_size_t name_storage_size = 0;
+  if (IREE_UNLIKELY(
+          !iree_host_size_checked_add(name.size, 1, &name_storage_size))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "HIP executable global name storage overflow");
+  }
+
+  iree_host_size_t total_size = 0;
+  iree_host_size_t device_buffers_offset = 0;
+  iree_host_size_t name_offset = 0;
+  IREE_RETURN_IF_ERROR(IREE_STRUCT_LAYOUT(
+      sizeof(iree_hal_hip_native_executable_global_t), &total_size,
+      IREE_STRUCT_FIELD(executable->num_devices, iree_hal_buffer_t*,
+                        &device_buffers_offset),
+      IREE_STRUCT_FIELD(name_storage_size, char, &name_offset)));
+
+  iree_hal_hip_native_executable_global_t* global = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(executable->host_allocator,
+                                             total_size, (void**)&global));
+  memset(global, 0, total_size);
+
+  global->name = iree_make_string_view((char*)global + name_offset, name.size);
+  memcpy((void*)global->name.data, name.data, name.size);
+  ((char*)global->name.data)[name.size] = 0;
+  global->byte_length = byte_length;
+  global->device_buffers =
+      (iree_hal_buffer_t**)((uint8_t*)global + device_buffers_offset);
+
+  *out_global = global;
+  return iree_ok_status();
+}
+
+static void iree_hal_hip_native_executable_global_free(
+    iree_hal_hip_native_executable_t* executable,
+    iree_hal_hip_native_executable_global_t* global) {
+  if (!global) return;
+  for (iree_host_size_t i = 0; i < executable->num_devices; ++i) {
+    iree_hal_buffer_release(global->device_buffers[i]);
+  }
+  iree_allocator_free(executable->host_allocator, global);
+}
+
+static void iree_hal_hip_native_executable_global_list_free(
+    iree_hal_hip_native_executable_t* executable) {
+  iree_hal_hip_native_executable_global_t* global = executable->global_list;
+  while (global) {
+    iree_hal_hip_native_executable_global_t* next_global = global->next;
+    iree_hal_hip_native_executable_global_free(executable, global);
+    global = next_global;
+  }
+  executable->global_list = NULL;
+}
+
 static void iree_hal_hip_native_executable_destroy(
     iree_hal_executable_t* base_executable) {
   iree_hal_hip_native_executable_t* executable =
       iree_hal_hip_native_executable_cast(base_executable);
   iree_allocator_t host_allocator = executable->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_hip_native_executable_global_list_free(executable);
+  iree_slim_mutex_deinitialize(&executable->global_mutex);
 
   for (iree_host_size_t i = 0; i < executable->num_devices; ++i) {
     const iree_hal_hip_native_executable_per_device_data_t* data =
@@ -722,34 +833,12 @@ static iree_status_t iree_hal_hip_native_executable_select_global_device(
   return iree_ok_status();
 }
 
-static void iree_hal_hip_native_executable_global_buffer_release(
-    void* user_data, iree_hal_buffer_t* buffer) {
-  (void)buffer;
-  iree_hal_executable_release((iree_hal_executable_t*)user_data);
-}
-
-static iree_status_t iree_hal_hip_native_executable_lookup_global_by_name(
-    iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
-  iree_hal_hip_native_executable_t* executable =
-      iree_hal_hip_native_executable_cast(base_executable);
-  *out_buffer = NULL;
-
-  if (iree_string_view_is_empty(name)) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "executable global name is empty");
-  }
-  if (name.size > IREE_HAL_HIP_MAX_STACK_GLOBAL_NAME_LENGTH) {
-    return iree_make_status(
-        IREE_STATUS_OUT_OF_RANGE,
-        "executable global name `%.*s` exceeds maximum length %" PRIhsz,
-        (int)name.size, name.data, IREE_HAL_HIP_MAX_STACK_GLOBAL_NAME_LENGTH);
-  }
-
-  iree_host_size_t device_ordinal = 0;
-  iree_hal_queue_affinity_t selected_queue_affinity = 0;
-  IREE_RETURN_IF_ERROR(iree_hal_hip_native_executable_select_global_device(
-      executable, queue_affinity, &device_ordinal, &selected_queue_affinity));
+static iree_status_t iree_hal_hip_native_executable_query_global(
+    iree_hal_hip_native_executable_t* executable, iree_string_view_t name,
+    iree_host_size_t device_ordinal, hipDeviceptr_t* out_global_device_ptr,
+    iree_device_size_t* out_byte_length) {
+  if (out_global_device_ptr) *out_global_device_ptr = 0;
+  *out_byte_length = 0;
 
   const iree_hal_hip_native_executable_per_device_data_t* per_device_data =
       executable->per_device_data[device_ordinal];
@@ -780,27 +869,175 @@ static iree_status_t iree_hal_hip_native_executable_lookup_global_by_name(
                             (int)name.size, name.data);
   }
 
+  if (out_global_device_ptr) *out_global_device_ptr = global_device_ptr;
+  *out_byte_length = (iree_device_size_t)global_size;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_hip_native_executable_validate_global_name(
+    iree_string_view_t name) {
+  if (iree_string_view_is_empty(name)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "executable global name is empty");
+  }
+  if (name.size > IREE_HAL_HIP_MAX_STACK_GLOBAL_NAME_LENGTH) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "executable global name `%.*s` exceeds maximum length %" PRIhsz,
+        (int)name.size, name.data, IREE_HAL_HIP_MAX_STACK_GLOBAL_NAME_LENGTH);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_hip_native_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_executable_global_t* out_global) {
+  iree_hal_hip_native_executable_t* executable =
+      iree_hal_hip_native_executable_cast(base_executable);
+  *out_global = iree_hal_executable_global_invalid();
+
+  IREE_RETURN_IF_ERROR(
+      iree_hal_hip_native_executable_validate_global_name(name));
+
+  iree_slim_mutex_lock(&executable->global_mutex);
+  iree_hal_hip_native_executable_global_t* global =
+      iree_hal_hip_native_executable_find_global_locked(executable, name);
+  if (global) {
+    *out_global =
+        iree_hal_executable_global_from_value((uint64_t)(uintptr_t)global);
+    iree_slim_mutex_unlock(&executable->global_mutex);
+    return iree_ok_status();
+  }
+  iree_slim_mutex_unlock(&executable->global_mutex);
+
+  iree_device_size_t byte_length = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_hip_native_executable_query_global(
+      executable, name, /*device_ordinal=*/0, /*out_global_device_ptr=*/NULL,
+      &byte_length));
+
+  iree_hal_hip_native_executable_global_t* new_global = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_hip_native_executable_global_allocate(
+      executable, name, byte_length, &new_global));
+
+  iree_slim_mutex_lock(&executable->global_mutex);
+  global = iree_hal_hip_native_executable_find_global_locked(executable, name);
+  if (global) {
+    *out_global =
+        iree_hal_executable_global_from_value((uint64_t)(uintptr_t)global);
+  } else {
+    new_global->next = executable->global_list;
+    executable->global_list = new_global;
+    *out_global =
+        iree_hal_executable_global_from_value((uint64_t)(uintptr_t)new_global);
+    new_global = NULL;
+  }
+  iree_slim_mutex_unlock(&executable->global_mutex);
+
+  iree_hal_hip_native_executable_global_free(executable, new_global);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_hip_native_executable_global_info(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
+  iree_hal_hip_native_executable_t* executable =
+      iree_hal_hip_native_executable_cast(base_executable);
+  memset(out_info, 0, sizeof(*out_info));
+
+  iree_slim_mutex_lock(&executable->global_mutex);
+  iree_hal_hip_native_executable_global_t* global_entry =
+      iree_hal_hip_native_executable_global_from_handle_locked(executable,
+                                                               global);
+  if (!global_entry) {
+    iree_slim_mutex_unlock(&executable->global_mutex);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid HIP executable global handle");
+  }
+  out_info->name = global_entry->name;
+  out_info->byte_length = global_entry->byte_length;
+  iree_slim_mutex_unlock(&executable->global_mutex);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_hip_native_executable_global_buffer(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  iree_hal_hip_native_executable_t* executable =
+      iree_hal_hip_native_executable_cast(base_executable);
+  *out_buffer = NULL;
+
+  iree_host_size_t device_ordinal = 0;
+  iree_hal_queue_affinity_t selected_queue_affinity = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_hip_native_executable_select_global_device(
+      executable, queue_affinity, &device_ordinal, &selected_queue_affinity));
+
+  iree_slim_mutex_lock(&executable->global_mutex);
+  iree_hal_hip_native_executable_global_t* global_entry =
+      iree_hal_hip_native_executable_global_from_handle_locked(executable,
+                                                               global);
+  if (!global_entry) {
+    iree_slim_mutex_unlock(&executable->global_mutex);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid HIP executable global handle");
+  }
+  iree_hal_buffer_t* cached_buffer =
+      global_entry->device_buffers[device_ordinal];
+  if (cached_buffer) {
+    *out_buffer = cached_buffer;
+    iree_slim_mutex_unlock(&executable->global_mutex);
+    return iree_ok_status();
+  }
+  iree_string_view_t name = global_entry->name;
+  iree_device_size_t expected_byte_length = global_entry->byte_length;
+  iree_slim_mutex_unlock(&executable->global_mutex);
+
+  hipDeviceptr_t global_device_ptr = 0;
+  iree_device_size_t byte_length = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_hip_native_executable_query_global(
+      executable, name, device_ordinal, &global_device_ptr, &byte_length));
+  if (IREE_UNLIKELY(byte_length != expected_byte_length)) {
+    return iree_make_status(
+        IREE_STATUS_INTERNAL,
+        "verified executable global `%.*s` changed size on HIP device %" PRIhsz
+        " from %" PRIu64 " to %" PRIu64,
+        (int)name.size, name.data, device_ordinal,
+        (uint64_t)expected_byte_length, (uint64_t)byte_length);
+  }
+
   iree_hal_buffer_placement_t placement = {
       .device = executable->device,
       .queue_affinity = selected_queue_affinity,
       .flags = IREE_HAL_BUFFER_PLACEMENT_FLAG_NONE,
   };
-  iree_hal_buffer_release_callback_t release_callback = {
-      .fn = iree_hal_hip_native_executable_global_buffer_release,
-      .user_data = base_executable,
-  };
-  iree_hal_executable_retain(base_executable);
-  iree_status_t status = iree_hal_hip_buffer_wrap(
+  iree_hal_buffer_t* new_buffer = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_hip_buffer_wrap(
       placement, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
       IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE,
-      IREE_HAL_BUFFER_USAGE_DEFAULT, global_size, /*byte_offset=*/0,
-      global_size, IREE_HAL_HIP_BUFFER_TYPE_EXTERNAL, global_device_ptr,
-      /*host_ptr=*/NULL, release_callback, executable->host_allocator,
-      out_buffer);
-  if (!iree_status_is_ok(status)) {
-    iree_hal_executable_release(base_executable);
+      IREE_HAL_BUFFER_USAGE_DEFAULT, byte_length, /*byte_offset=*/0,
+      byte_length, IREE_HAL_HIP_BUFFER_TYPE_EXTERNAL, global_device_ptr,
+      /*host_ptr=*/NULL, iree_hal_buffer_release_callback_null(),
+      executable->host_allocator, &new_buffer));
+
+  iree_slim_mutex_lock(&executable->global_mutex);
+  global_entry = iree_hal_hip_native_executable_global_from_handle_locked(
+      executable, global);
+  if (!global_entry) {
+    iree_slim_mutex_unlock(&executable->global_mutex);
+    iree_hal_buffer_release(new_buffer);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid HIP executable global handle");
   }
-  return status;
+  cached_buffer = global_entry->device_buffers[device_ordinal];
+  if (cached_buffer) {
+    *out_buffer = cached_buffer;
+    iree_slim_mutex_unlock(&executable->global_mutex);
+    iree_hal_buffer_release(new_buffer);
+  } else {
+    global_entry->device_buffers[device_ordinal] = new_buffer;
+    *out_buffer = new_buffer;
+    iree_slim_mutex_unlock(&executable->global_mutex);
+  }
+  return iree_ok_status();
 }
 
 static const iree_hal_executable_vtable_t
@@ -813,4 +1050,6 @@ static const iree_hal_executable_vtable_t
             iree_hal_hip_native_executable_lookup_export_by_name,
         .lookup_global_by_name =
             iree_hal_hip_native_executable_lookup_global_by_name,
+        .global_info = iree_hal_hip_native_executable_global_info,
+        .global_buffer = iree_hal_hip_native_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/drivers/metal/executable.m
+++ b/runtime/src/iree/hal/drivers/metal/executable.m
@@ -569,6 +569,15 @@ static iree_status_t iree_hal_metal_executable_export_info(
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_metal_executable_export_parameters(
+    iree_hal_executable_t* base_executable, iree_hal_executable_function_t export_ordinal,
+    iree_host_size_t capacity, iree_hal_executable_function_parameter_t* out_parameters) {
+  iree_hal_metal_executable_t* executable = iree_hal_metal_executable_cast(base_executable);
+  (void)executable;
+  // TODO(metal): return export parameter information from kernel metadata.
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "parameter reflection not implemented");
+}
+
 static iree_status_t iree_hal_metal_executable_lookup_export_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
     iree_hal_executable_function_t* out_export_ordinal) {
@@ -585,22 +594,33 @@ static iree_status_t iree_hal_metal_executable_lookup_export_by_name(
 
 static iree_status_t iree_hal_metal_executable_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+    iree_hal_executable_global_t* out_global) {
   iree_hal_metal_executable_t* executable = iree_hal_metal_executable_cast(base_executable);
   (void)executable;
   (void)name;
-  (void)queue_affinity;
-  *out_buffer = NULL;
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "global lookup not implemented");
+  *out_global = iree_hal_executable_global_invalid();
+  return iree_make_status(IREE_STATUS_NOT_FOUND, "Metal executable has no globals");
 }
 
-static iree_status_t iree_hal_metal_executable_export_parameters(
-    iree_hal_executable_t* base_executable, iree_hal_executable_function_t export_ordinal,
-    iree_host_size_t capacity, iree_hal_executable_function_parameter_t* out_parameters) {
+static iree_status_t iree_hal_metal_executable_global_info(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
   iree_hal_metal_executable_t* executable = iree_hal_metal_executable_cast(base_executable);
   (void)executable;
-  // TODO(metal): return export parameter information from kernel metadata.
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED, "parameter reflection not implemented");
+  (void)global;
+  memset(out_info, 0, sizeof(*out_info));
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "invalid Metal executable global");
+}
+
+static iree_status_t iree_hal_metal_executable_global_buffer(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  iree_hal_metal_executable_t* executable = iree_hal_metal_executable_cast(base_executable);
+  (void)executable;
+  (void)global;
+  (void)queue_affinity;
+  *out_buffer = NULL;
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "invalid Metal executable global");
 }
 
 static const iree_hal_executable_vtable_t iree_hal_metal_executable_vtable = {
@@ -610,4 +630,6 @@ static const iree_hal_executable_vtable_t iree_hal_metal_executable_vtable = {
     .function_parameters = iree_hal_metal_executable_export_parameters,
     .lookup_function_by_name = iree_hal_metal_executable_lookup_export_by_name,
     .lookup_global_by_name = iree_hal_metal_executable_lookup_global_by_name,
+    .global_info = iree_hal_metal_executable_global_info,
+    .global_buffer = iree_hal_metal_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/drivers/metal/executable.m
+++ b/runtime/src/iree/hal/drivers/metal/executable.m
@@ -592,14 +592,15 @@ static iree_status_t iree_hal_metal_executable_lookup_export_by_name(
                           (int)name.size, name.data);
 }
 
-static iree_status_t iree_hal_metal_executable_lookup_global_by_name(
-    iree_hal_executable_t* base_executable, iree_string_view_t name,
+static iree_status_t iree_hal_metal_executable_try_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name, bool* out_found,
     iree_hal_executable_global_t* out_global) {
   iree_hal_metal_executable_t* executable = iree_hal_metal_executable_cast(base_executable);
   (void)executable;
   (void)name;
+  *out_found = false;
   *out_global = iree_hal_executable_global_invalid();
-  return iree_make_status(IREE_STATUS_NOT_FOUND, "Metal executable has no globals");
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_metal_executable_global_info(
@@ -629,7 +630,7 @@ static const iree_hal_executable_vtable_t iree_hal_metal_executable_vtable = {
     .function_info = iree_hal_metal_executable_export_info,
     .function_parameters = iree_hal_metal_executable_export_parameters,
     .lookup_function_by_name = iree_hal_metal_executable_lookup_export_by_name,
-    .lookup_global_by_name = iree_hal_metal_executable_lookup_global_by_name,
+    .try_lookup_global_by_name = iree_hal_metal_executable_try_lookup_global_by_name,
     .global_info = iree_hal_metal_executable_global_info,
     .global_buffer = iree_hal_metal_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/drivers/null/executable.c
+++ b/runtime/src/iree/hal/drivers/null/executable.c
@@ -131,15 +131,39 @@ static iree_status_t iree_hal_null_executable_lookup_export_by_name(
 
 static iree_status_t iree_hal_null_executable_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+    iree_hal_executable_global_t* out_global) {
   iree_hal_null_executable_t* executable =
       iree_hal_null_executable_cast(base_executable);
   (void)executable;
   (void)name;
+  *out_global = iree_hal_executable_global_invalid();
+  return iree_make_status(IREE_STATUS_NOT_FOUND,
+                          "null executable has no globals");
+}
+
+static iree_status_t iree_hal_null_executable_global_info(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
+  iree_hal_null_executable_t* executable =
+      iree_hal_null_executable_cast(base_executable);
+  (void)executable;
+  (void)global;
+  memset(out_info, 0, sizeof(*out_info));
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid null executable global");
+}
+
+static iree_status_t iree_hal_null_executable_global_buffer(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  iree_hal_null_executable_t* executable =
+      iree_hal_null_executable_cast(base_executable);
+  (void)executable;
+  (void)global;
   (void)queue_affinity;
   *out_buffer = NULL;
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "global lookup not implemented");
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid null executable global");
 }
 
 static const iree_hal_executable_vtable_t iree_hal_null_executable_vtable = {
@@ -149,4 +173,6 @@ static const iree_hal_executable_vtable_t iree_hal_null_executable_vtable = {
     .function_parameters = iree_hal_null_executable_export_parameters,
     .lookup_function_by_name = iree_hal_null_executable_lookup_export_by_name,
     .lookup_global_by_name = iree_hal_null_executable_lookup_global_by_name,
+    .global_info = iree_hal_null_executable_global_info,
+    .global_buffer = iree_hal_null_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/drivers/null/executable.c
+++ b/runtime/src/iree/hal/drivers/null/executable.c
@@ -129,16 +129,16 @@ static iree_status_t iree_hal_null_executable_lookup_export_by_name(
                           "reflection not implemented");
 }
 
-static iree_status_t iree_hal_null_executable_lookup_global_by_name(
+static iree_status_t iree_hal_null_executable_try_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_executable_global_t* out_global) {
+    bool* out_found, iree_hal_executable_global_t* out_global) {
   iree_hal_null_executable_t* executable =
       iree_hal_null_executable_cast(base_executable);
   (void)executable;
   (void)name;
+  *out_found = false;
   *out_global = iree_hal_executable_global_invalid();
-  return iree_make_status(IREE_STATUS_NOT_FOUND,
-                          "null executable has no globals");
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_null_executable_global_info(
@@ -172,7 +172,8 @@ static const iree_hal_executable_vtable_t iree_hal_null_executable_vtable = {
     .function_info = iree_hal_null_executable_export_info,
     .function_parameters = iree_hal_null_executable_export_parameters,
     .lookup_function_by_name = iree_hal_null_executable_lookup_export_by_name,
-    .lookup_global_by_name = iree_hal_null_executable_lookup_global_by_name,
+    .try_lookup_global_by_name =
+        iree_hal_null_executable_try_lookup_global_by_name,
     .global_info = iree_hal_null_executable_global_info,
     .global_buffer = iree_hal_null_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/drivers/vulkan/executable.c
+++ b/runtime/src/iree/hal/drivers/vulkan/executable.c
@@ -614,14 +614,14 @@ static iree_status_t iree_hal_vulkan_executable_lookup_export_by_name(
                           (int)name.size, name.data);
 }
 
-static iree_status_t iree_hal_vulkan_executable_lookup_global_by_name(
+static iree_status_t iree_hal_vulkan_executable_try_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_executable_global_t* out_global) {
+    bool* out_found, iree_hal_executable_global_t* out_global) {
   (void)base_executable;
   (void)name;
+  *out_found = false;
   *out_global = iree_hal_executable_global_invalid();
-  return iree_make_status(IREE_STATUS_NOT_FOUND,
-                          "Vulkan executable has no globals");
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_vulkan_executable_global_info(
@@ -651,7 +651,8 @@ static const iree_hal_executable_vtable_t iree_hal_vulkan_executable_vtable = {
     .function_info = iree_hal_vulkan_executable_export_info,
     .function_parameters = iree_hal_vulkan_executable_export_parameters,
     .lookup_function_by_name = iree_hal_vulkan_executable_lookup_export_by_name,
-    .lookup_global_by_name = iree_hal_vulkan_executable_lookup_global_by_name,
+    .try_lookup_global_by_name =
+        iree_hal_vulkan_executable_try_lookup_global_by_name,
     .global_info = iree_hal_vulkan_executable_global_info,
     .global_buffer = iree_hal_vulkan_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/drivers/vulkan/executable.c
+++ b/runtime/src/iree/hal/drivers/vulkan/executable.c
@@ -616,13 +616,33 @@ static iree_status_t iree_hal_vulkan_executable_lookup_export_by_name(
 
 static iree_status_t iree_hal_vulkan_executable_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+    iree_hal_executable_global_t* out_global) {
   (void)base_executable;
   (void)name;
+  *out_global = iree_hal_executable_global_invalid();
+  return iree_make_status(IREE_STATUS_NOT_FOUND,
+                          "Vulkan executable has no globals");
+}
+
+static iree_status_t iree_hal_vulkan_executable_global_info(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
+  (void)base_executable;
+  (void)global;
+  memset(out_info, 0, sizeof(*out_info));
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid Vulkan executable global");
+}
+
+static iree_status_t iree_hal_vulkan_executable_global_buffer(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  (void)base_executable;
+  (void)global;
   (void)queue_affinity;
   *out_buffer = NULL;
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "Vulkan executable global lookup not implemented");
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid Vulkan executable global");
 }
 
 static const iree_hal_executable_vtable_t iree_hal_vulkan_executable_vtable = {
@@ -632,4 +652,6 @@ static const iree_hal_executable_vtable_t iree_hal_vulkan_executable_vtable = {
     .function_parameters = iree_hal_vulkan_executable_export_parameters,
     .lookup_function_by_name = iree_hal_vulkan_executable_lookup_export_by_name,
     .lookup_global_by_name = iree_hal_vulkan_executable_lookup_global_by_name,
+    .global_info = iree_hal_vulkan_executable_global_info,
+    .global_buffer = iree_hal_vulkan_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/drivers/vulkan/logical_device.c
+++ b/runtime/src/iree/hal/drivers/vulkan/logical_device.c
@@ -1667,7 +1667,7 @@ static iree_status_t iree_hal_vulkan_logical_device_external_capture_end(
   return iree_hal_vulkan_unimplemented(IREE_SV("external capture"));
 }
 
-static iree_status_t iree_hal_vulkan_logical_device_allocate(
+static iree_status_t iree_hal_vulkan_logical_device_create(
     iree_string_view_t identifier, const iree_hal_vulkan_libvulkan_t* libvulkan,
     iree_allocator_t host_allocator,
     iree_hal_vulkan_logical_device_t** out_device) {
@@ -2024,8 +2024,8 @@ static iree_status_t iree_hal_vulkan_logical_device_create_from_selection(
 
   iree_hal_vulkan_logical_device_t* device = NULL;
   if (iree_status_is_ok(status)) {
-    status = iree_hal_vulkan_logical_device_allocate(identifier, libvulkan,
-                                                     host_allocator, &device);
+    status = iree_hal_vulkan_logical_device_create(identifier, libvulkan,
+                                                   host_allocator, &device);
   }
   if (iree_status_is_ok(status)) {
     device->instance = *instance;
@@ -2201,7 +2201,7 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_wrap_device(
 
   iree_hal_vulkan_logical_device_t* device = NULL;
   if (iree_status_is_ok(status)) {
-    status = iree_hal_vulkan_logical_device_allocate(
+    status = iree_hal_vulkan_logical_device_create(
         identifier, &instance_syms->libvulkan, host_allocator, &device);
   }
   if (iree_status_is_ok(status)) {

--- a/runtime/src/iree/hal/drivers/webgpu/webgpu_executable.c
+++ b/runtime/src/iree/hal/drivers/webgpu/webgpu_executable.c
@@ -388,14 +388,14 @@ static iree_status_t iree_hal_webgpu_executable_lookup_function_by_name(
                           (int)name.size, name.data);
 }
 
-static iree_status_t iree_hal_webgpu_executable_lookup_global_by_name(
+static iree_status_t iree_hal_webgpu_executable_try_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_executable_global_t* out_global) {
+    bool* out_found, iree_hal_executable_global_t* out_global) {
   (void)base_executable;
   (void)name;
+  *out_found = false;
   *out_global = iree_hal_executable_global_invalid();
-  return iree_make_status(IREE_STATUS_NOT_FOUND,
-                          "WebGPU executable has no globals");
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_webgpu_executable_global_info(
@@ -426,7 +426,8 @@ static const iree_hal_executable_vtable_t iree_hal_webgpu_executable_vtable = {
     .function_parameters = iree_hal_webgpu_executable_function_parameters,
     .lookup_function_by_name =
         iree_hal_webgpu_executable_lookup_function_by_name,
-    .lookup_global_by_name = iree_hal_webgpu_executable_lookup_global_by_name,
+    .try_lookup_global_by_name =
+        iree_hal_webgpu_executable_try_lookup_global_by_name,
     .global_info = iree_hal_webgpu_executable_global_info,
     .global_buffer = iree_hal_webgpu_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/drivers/webgpu/webgpu_executable.c
+++ b/runtime/src/iree/hal/drivers/webgpu/webgpu_executable.c
@@ -388,6 +388,37 @@ static iree_status_t iree_hal_webgpu_executable_lookup_function_by_name(
                           (int)name.size, name.data);
 }
 
+static iree_status_t iree_hal_webgpu_executable_lookup_global_by_name(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_hal_executable_global_t* out_global) {
+  (void)base_executable;
+  (void)name;
+  *out_global = iree_hal_executable_global_invalid();
+  return iree_make_status(IREE_STATUS_NOT_FOUND,
+                          "WebGPU executable has no globals");
+}
+
+static iree_status_t iree_hal_webgpu_executable_global_info(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
+  (void)base_executable;
+  (void)global;
+  memset(out_info, 0, sizeof(*out_info));
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid WebGPU executable global");
+}
+
+static iree_status_t iree_hal_webgpu_executable_global_buffer(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  (void)base_executable;
+  (void)global;
+  (void)queue_affinity;
+  *out_buffer = NULL;
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid WebGPU executable global");
+}
+
 static const iree_hal_executable_vtable_t iree_hal_webgpu_executable_vtable = {
     .destroy = iree_hal_webgpu_executable_destroy,
     .function_count = iree_hal_webgpu_executable_function_count,
@@ -395,4 +426,7 @@ static const iree_hal_executable_vtable_t iree_hal_webgpu_executable_vtable = {
     .function_parameters = iree_hal_webgpu_executable_function_parameters,
     .lookup_function_by_name =
         iree_hal_webgpu_executable_lookup_function_by_name,
+    .lookup_global_by_name = iree_hal_webgpu_executable_lookup_global_by_name,
+    .global_info = iree_hal_webgpu_executable_global_info,
+    .global_buffer = iree_hal_webgpu_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/executable.c
+++ b/runtime/src/iree/hal/executable.c
@@ -59,13 +59,33 @@ IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_function_by_name(
 
 IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_global_by_name(
     iree_hal_executable_t* executable, iree_string_view_t name,
+    iree_hal_executable_global_t* out_global) {
+  IREE_ASSERT_ARGUMENT(executable);
+  IREE_ASSERT_ARGUMENT(out_global);
+  *out_global = iree_hal_executable_global_invalid();
+  iree_status_t status = _VTABLE_DISPATCH(executable, lookup_global_by_name)(
+      executable, name, out_global);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_executable_global_info(
+    iree_hal_executable_t* executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
+  IREE_ASSERT_ARGUMENT(executable);
+  IREE_ASSERT_ARGUMENT(out_info);
+  memset(out_info, 0, sizeof(*out_info));
+  iree_status_t status =
+      _VTABLE_DISPATCH(executable, global_info)(executable, global, out_info);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_executable_global_buffer(
+    iree_hal_executable_t* executable, iree_hal_executable_global_t global,
     iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
   IREE_ASSERT_ARGUMENT(executable);
   IREE_ASSERT_ARGUMENT(out_buffer);
-  IREE_TRACE_ZONE_BEGIN(z0);
   *out_buffer = NULL;
-  iree_status_t status = _VTABLE_DISPATCH(executable, lookup_global_by_name)(
-      executable, name, queue_affinity, out_buffer);
-  IREE_TRACE_ZONE_END(z0);
+  iree_status_t status = _VTABLE_DISPATCH(executable, global_buffer)(
+      executable, global, queue_affinity, out_buffer);
   return status;
 }

--- a/runtime/src/iree/hal/executable.c
+++ b/runtime/src/iree/hal/executable.c
@@ -57,15 +57,32 @@ IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_function_by_name(
   return status;
 }
 
+IREE_API_EXPORT iree_status_t iree_hal_executable_try_lookup_global_by_name(
+    iree_hal_executable_t* executable, iree_string_view_t name, bool* out_found,
+    iree_hal_executable_global_t* out_global) {
+  IREE_ASSERT_ARGUMENT(executable);
+  IREE_ASSERT_ARGUMENT(out_found);
+  IREE_ASSERT_ARGUMENT(out_global);
+  *out_found = false;
+  *out_global = iree_hal_executable_global_invalid();
+  return _VTABLE_DISPATCH(executable, try_lookup_global_by_name)(
+      executable, name, out_found, out_global);
+}
+
 IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_global_by_name(
     iree_hal_executable_t* executable, iree_string_view_t name,
     iree_hal_executable_global_t* out_global) {
   IREE_ASSERT_ARGUMENT(executable);
   IREE_ASSERT_ARGUMENT(out_global);
-  *out_global = iree_hal_executable_global_invalid();
-  iree_status_t status = _VTABLE_DISPATCH(executable, lookup_global_by_name)(
-      executable, name, out_global);
-  return status;
+  bool found = false;
+  IREE_RETURN_IF_ERROR(iree_hal_executable_try_lookup_global_by_name(
+      executable, name, &found, out_global));
+  if (!found) {
+    return iree_make_status(IREE_STATUS_NOT_FOUND,
+                            "executable global `%.*s` not found",
+                            (int)name.size, name.data);
+  }
+  return iree_ok_status();
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_executable_global_info(

--- a/runtime/src/iree/hal/executable.h
+++ b/runtime/src/iree/hal/executable.h
@@ -79,6 +79,37 @@ static inline uint32_t iree_hal_executable_function_index(
   return (uint32_t)function.value;
 }
 
+// Executable global resolved within an executable.
+//
+// Global values are only meaningful with the executable that returned them.
+// They are not stable across executable loads, drivers, process runs, or
+// replacement artifacts. Stable cross-artifact identity is the global name.
+typedef struct iree_hal_executable_global_t {
+  // Executable-local global token.
+  uint64_t value;
+} iree_hal_executable_global_t;
+
+#define IREE_HAL_EXECUTABLE_GLOBAL_INVALID_VALUE UINT64_MAX
+
+// Returns an invalid executable global value.
+static inline iree_hal_executable_global_t iree_hal_executable_global_invalid(
+    void) {
+  return (iree_hal_executable_global_t){
+      IREE_HAL_EXECUTABLE_GLOBAL_INVALID_VALUE};
+}
+
+// Returns a global value for a raw executable-local token.
+static inline iree_hal_executable_global_t
+iree_hal_executable_global_from_value(uint64_t value) {
+  return (iree_hal_executable_global_t){value};
+}
+
+// Returns true if |global| contains a valid executable-local token.
+static inline bool iree_hal_executable_global_is_valid(
+    iree_hal_executable_global_t global) {
+  return global.value != IREE_HAL_EXECUTABLE_GLOBAL_INVALID_VALUE;
+}
+
 typedef struct iree_hal_occupancy_info_t {
   int reserved;
 } iree_hal_occupancy_info_t;
@@ -161,6 +192,14 @@ typedef struct iree_hal_executable_function_parameter_t {
   iree_string_view_t name;
 } iree_hal_executable_function_parameter_t;
 
+// Declares properties of an executable global variable.
+typedef struct iree_hal_executable_global_info_t {
+  // Executable-local global name if available, otherwise empty.
+  iree_string_view_t name;
+  // Total byte length of the global variable storage.
+  iree_device_size_t byte_length;
+} iree_hal_executable_global_info_t;
+
 // Handle to a loaded executable.
 // Loading of executables routes through an executable cache, allowing for
 // context-aware scoped caches. HAL implementations can use this to preserve
@@ -206,19 +245,32 @@ IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_function_by_name(
     iree_hal_executable_t* executable, iree_string_view_t name,
     iree_hal_executable_function_t* out_function);
 
-// Finds the executable global variable with the given |name| and returns a
-// device buffer aliasing its storage.
+// Finds the executable global variable with the given |name|.
+//
+// The returned global is an executable-local handle. It remains valid while the
+// executable remains live and must only be used with the executable that
+// returned it. Returns IREE_STATUS_NOT_FOUND when no such global variable
+// exists.
+IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_global_by_name(
+    iree_hal_executable_t* executable, iree_string_view_t name,
+    iree_hal_executable_global_t* out_global);
+
+// Returns information about the given |global|.
+//
+// Returned string storage is owned by the executable and remains valid while
+// the executable remains live.
+IREE_API_EXPORT iree_status_t iree_hal_executable_global_info(
+    iree_hal_executable_t* executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info);
+
+// Returns a device buffer aliasing |global| storage.
 //
 // |queue_affinity| selects the device instance for per-device globals. Empty or
 // any affinities select an implementation-defined valid device instance. The
-// returned buffer retains the executable storage it aliases and must be
-// released by the caller.
-//
-// Returns IREE_STATUS_NOT_FOUND when no such global variable exists and
-// IREE_STATUS_UNIMPLEMENTED when the executable format or backend cannot expose
-// globals.
-IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_global_by_name(
-    iree_hal_executable_t* executable, iree_string_view_t name,
+// returned buffer is owned by the executable and is borrowed by the caller.
+// Callers must ensure the executable outlives all uses of the returned buffer.
+IREE_API_EXPORT iree_status_t iree_hal_executable_global_buffer(
+    iree_hal_executable_t* executable, iree_hal_executable_global_t global,
     iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer);
 
 //===----------------------------------------------------------------------===//
@@ -247,6 +299,14 @@ typedef struct iree_hal_executable_vtable_t {
 
   iree_status_t(IREE_API_PTR* lookup_global_by_name)(
       iree_hal_executable_t* executable, iree_string_view_t name,
+      iree_hal_executable_global_t* out_global);
+
+  iree_status_t(IREE_API_PTR* global_info)(
+      iree_hal_executable_t* executable, iree_hal_executable_global_t global,
+      iree_hal_executable_global_info_t* out_info);
+
+  iree_status_t(IREE_API_PTR* global_buffer)(
+      iree_hal_executable_t* executable, iree_hal_executable_global_t global,
       iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer);
 } iree_hal_executable_vtable_t;
 IREE_HAL_ASSERT_VTABLE_LAYOUT(iree_hal_executable_vtable_t);

--- a/runtime/src/iree/hal/executable.h
+++ b/runtime/src/iree/hal/executable.h
@@ -249,8 +249,17 @@ IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_function_by_name(
 //
 // The returned global is an executable-local handle. It remains valid while the
 // executable remains live and must only be used with the executable that
-// returned it. Returns IREE_STATUS_NOT_FOUND when no such global variable
+// returned it. Returns OK with |out_found| false when no such global variable
 // exists.
+IREE_API_EXPORT iree_status_t iree_hal_executable_try_lookup_global_by_name(
+    iree_hal_executable_t* executable, iree_string_view_t name, bool* out_found,
+    iree_hal_executable_global_t* out_global);
+
+// Finds the executable global variable with the given |name|.
+//
+// The returned global follows the same lifetime rules as
+// iree_hal_executable_try_lookup_global_by_name. Returns IREE_STATUS_NOT_FOUND
+// when no such global variable exists.
 IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_global_by_name(
     iree_hal_executable_t* executable, iree_string_view_t name,
     iree_hal_executable_global_t* out_global);
@@ -297,9 +306,9 @@ typedef struct iree_hal_executable_vtable_t {
       iree_hal_executable_t* executable, iree_string_view_t name,
       iree_hal_executable_function_t* out_function);
 
-  iree_status_t(IREE_API_PTR* lookup_global_by_name)(
+  iree_status_t(IREE_API_PTR* try_lookup_global_by_name)(
       iree_hal_executable_t* executable, iree_string_view_t name,
-      iree_hal_executable_global_t* out_global);
+      bool* out_found, iree_hal_executable_global_t* out_global);
 
   iree_status_t(IREE_API_PTR* global_info)(
       iree_hal_executable_t* executable, iree_hal_executable_global_t global,

--- a/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
+++ b/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
@@ -261,13 +261,33 @@ static iree_status_t iree_hal_elf_executable_lookup_export_by_name(
 
 static iree_status_t iree_hal_elf_executable_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+    iree_hal_executable_global_t* out_global) {
   (void)base_executable;
   (void)name;
+  *out_global = iree_hal_executable_global_invalid();
+  return iree_make_status(IREE_STATUS_NOT_FOUND,
+                          "local ELF executable has no globals");
+}
+
+static iree_status_t iree_hal_elf_executable_global_info(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
+  (void)base_executable;
+  (void)global;
+  memset(out_info, 0, sizeof(*out_info));
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid local ELF executable global");
+}
+
+static iree_status_t iree_hal_elf_executable_global_buffer(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  (void)base_executable;
+  (void)global;
   (void)queue_affinity;
   *out_buffer = NULL;
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "local executable global lookup not implemented");
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid local ELF executable global");
 }
 
 static const iree_hal_local_executable_vtable_t iree_hal_elf_executable_vtable =
@@ -283,6 +303,8 @@ static const iree_hal_local_executable_vtable_t iree_hal_elf_executable_vtable =
                     iree_hal_elf_executable_lookup_export_by_name,
                 .lookup_global_by_name =
                     iree_hal_elf_executable_lookup_global_by_name,
+                .global_info = iree_hal_elf_executable_global_info,
+                .global_buffer = iree_hal_elf_executable_global_buffer,
             },
         .issue_call = iree_hal_elf_executable_issue_call,
 };

--- a/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
+++ b/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
@@ -259,14 +259,14 @@ static iree_status_t iree_hal_elf_executable_lookup_export_by_name(
       executable->library.v0, name, out_export_ordinal);
 }
 
-static iree_status_t iree_hal_elf_executable_lookup_global_by_name(
+static iree_status_t iree_hal_elf_executable_try_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_executable_global_t* out_global) {
+    bool* out_found, iree_hal_executable_global_t* out_global) {
   (void)base_executable;
   (void)name;
+  *out_found = false;
   *out_global = iree_hal_executable_global_invalid();
-  return iree_make_status(IREE_STATUS_NOT_FOUND,
-                          "local ELF executable has no globals");
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_elf_executable_global_info(
@@ -301,8 +301,8 @@ static const iree_hal_local_executable_vtable_t iree_hal_elf_executable_vtable =
                     iree_hal_elf_executable_export_parameters,
                 .lookup_function_by_name =
                     iree_hal_elf_executable_lookup_export_by_name,
-                .lookup_global_by_name =
-                    iree_hal_elf_executable_lookup_global_by_name,
+                .try_lookup_global_by_name =
+                    iree_hal_elf_executable_try_lookup_global_by_name,
                 .global_info = iree_hal_elf_executable_global_info,
                 .global_buffer = iree_hal_elf_executable_global_buffer,
             },

--- a/runtime/src/iree/hal/local/loaders/static_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/static_library_loader.c
@@ -196,13 +196,33 @@ static iree_status_t iree_hal_static_executable_lookup_export_by_name(
 
 static iree_status_t iree_hal_static_executable_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+    iree_hal_executable_global_t* out_global) {
   (void)base_executable;
   (void)name;
+  *out_global = iree_hal_executable_global_invalid();
+  return iree_make_status(IREE_STATUS_NOT_FOUND,
+                          "local static executable has no globals");
+}
+
+static iree_status_t iree_hal_static_executable_global_info(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
+  (void)base_executable;
+  (void)global;
+  memset(out_info, 0, sizeof(*out_info));
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid local static executable global");
+}
+
+static iree_status_t iree_hal_static_executable_global_buffer(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  (void)base_executable;
+  (void)global;
   (void)queue_affinity;
   *out_buffer = NULL;
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "local executable global lookup not implemented");
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid local static executable global");
 }
 
 static const iree_hal_local_executable_vtable_t
@@ -218,6 +238,8 @@ static const iree_hal_local_executable_vtable_t
                     iree_hal_static_executable_lookup_export_by_name,
                 .lookup_global_by_name =
                     iree_hal_static_executable_lookup_global_by_name,
+                .global_info = iree_hal_static_executable_global_info,
+                .global_buffer = iree_hal_static_executable_global_buffer,
             },
         .issue_call = iree_hal_static_executable_issue_call,
 };

--- a/runtime/src/iree/hal/local/loaders/static_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/static_library_loader.c
@@ -194,14 +194,14 @@ static iree_status_t iree_hal_static_executable_lookup_export_by_name(
       executable->library.v0, name, out_export_ordinal);
 }
 
-static iree_status_t iree_hal_static_executable_lookup_global_by_name(
+static iree_status_t iree_hal_static_executable_try_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_executable_global_t* out_global) {
+    bool* out_found, iree_hal_executable_global_t* out_global) {
   (void)base_executable;
   (void)name;
+  *out_found = false;
   *out_global = iree_hal_executable_global_invalid();
-  return iree_make_status(IREE_STATUS_NOT_FOUND,
-                          "local static executable has no globals");
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_static_executable_global_info(
@@ -236,8 +236,8 @@ static const iree_hal_local_executable_vtable_t
                     iree_hal_static_executable_export_parameters,
                 .lookup_function_by_name =
                     iree_hal_static_executable_lookup_export_by_name,
-                .lookup_global_by_name =
-                    iree_hal_static_executable_lookup_global_by_name,
+                .try_lookup_global_by_name =
+                    iree_hal_static_executable_try_lookup_global_by_name,
                 .global_info = iree_hal_static_executable_global_info,
                 .global_buffer = iree_hal_static_executable_global_buffer,
             },

--- a/runtime/src/iree/hal/local/loaders/system_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/system_library_loader.c
@@ -372,14 +372,14 @@ static iree_status_t iree_hal_system_executable_lookup_export_by_name(
       executable->library.v0, name, out_export_ordinal);
 }
 
-static iree_status_t iree_hal_system_executable_lookup_global_by_name(
+static iree_status_t iree_hal_system_executable_try_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_executable_global_t* out_global) {
+    bool* out_found, iree_hal_executable_global_t* out_global) {
   (void)base_executable;
   (void)name;
+  *out_found = false;
   *out_global = iree_hal_executable_global_invalid();
-  return iree_make_status(IREE_STATUS_NOT_FOUND,
-                          "local system executable has no globals");
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_system_executable_global_info(
@@ -414,8 +414,8 @@ static const iree_hal_local_executable_vtable_t
                     iree_hal_system_executable_export_parameters,
                 .lookup_function_by_name =
                     iree_hal_system_executable_lookup_export_by_name,
-                .lookup_global_by_name =
-                    iree_hal_system_executable_lookup_global_by_name,
+                .try_lookup_global_by_name =
+                    iree_hal_system_executable_try_lookup_global_by_name,
                 .global_info = iree_hal_system_executable_global_info,
                 .global_buffer = iree_hal_system_executable_global_buffer,
             },

--- a/runtime/src/iree/hal/local/loaders/system_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/system_library_loader.c
@@ -374,13 +374,33 @@ static iree_status_t iree_hal_system_executable_lookup_export_by_name(
 
 static iree_status_t iree_hal_system_executable_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+    iree_hal_executable_global_t* out_global) {
   (void)base_executable;
   (void)name;
+  *out_global = iree_hal_executable_global_invalid();
+  return iree_make_status(IREE_STATUS_NOT_FOUND,
+                          "local system executable has no globals");
+}
+
+static iree_status_t iree_hal_system_executable_global_info(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
+  (void)base_executable;
+  (void)global;
+  memset(out_info, 0, sizeof(*out_info));
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid local system executable global");
+}
+
+static iree_status_t iree_hal_system_executable_global_buffer(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  (void)base_executable;
+  (void)global;
   (void)queue_affinity;
   *out_buffer = NULL;
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "local executable global lookup not implemented");
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid local system executable global");
 }
 
 static const iree_hal_local_executable_vtable_t
@@ -396,6 +416,8 @@ static const iree_hal_local_executable_vtable_t
                     iree_hal_system_executable_lookup_export_by_name,
                 .lookup_global_by_name =
                     iree_hal_system_executable_lookup_global_by_name,
+                .global_info = iree_hal_system_executable_global_info,
+                .global_buffer = iree_hal_system_executable_global_buffer,
             },
         .issue_call = iree_hal_system_executable_issue_call,
 };

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -641,14 +641,14 @@ static iree_status_t iree_hal_vmvx_executable_lookup_export_by_name(
       (int)name.size, name.data);
 }
 
-static iree_status_t iree_hal_vmvx_executable_lookup_global_by_name(
+static iree_status_t iree_hal_vmvx_executable_try_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_executable_global_t* out_global) {
+    bool* out_found, iree_hal_executable_global_t* out_global) {
   (void)base_executable;
   (void)name;
+  *out_found = false;
   *out_global = iree_hal_executable_global_invalid();
-  return iree_make_status(IREE_STATUS_NOT_FOUND,
-                          "VMVX executable has no globals");
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_vmvx_executable_global_info(
@@ -683,8 +683,8 @@ static const iree_hal_local_executable_vtable_t
                     iree_hal_vmvx_executable_export_parameters,
                 .lookup_function_by_name =
                     iree_hal_vmvx_executable_lookup_export_by_name,
-                .lookup_global_by_name =
-                    iree_hal_vmvx_executable_lookup_global_by_name,
+                .try_lookup_global_by_name =
+                    iree_hal_vmvx_executable_try_lookup_global_by_name,
                 .global_info = iree_hal_vmvx_executable_global_info,
                 .global_buffer = iree_hal_vmvx_executable_global_buffer,
             },

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -643,13 +643,33 @@ static iree_status_t iree_hal_vmvx_executable_lookup_export_by_name(
 
 static iree_status_t iree_hal_vmvx_executable_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+    iree_hal_executable_global_t* out_global) {
   (void)base_executable;
   (void)name;
+  *out_global = iree_hal_executable_global_invalid();
+  return iree_make_status(IREE_STATUS_NOT_FOUND,
+                          "VMVX executable has no globals");
+}
+
+static iree_status_t iree_hal_vmvx_executable_global_info(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
+  (void)base_executable;
+  (void)global;
+  memset(out_info, 0, sizeof(*out_info));
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid VMVX executable global");
+}
+
+static iree_status_t iree_hal_vmvx_executable_global_buffer(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  (void)base_executable;
+  (void)global;
   (void)queue_affinity;
   *out_buffer = NULL;
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "VMVX executable global lookup not implemented");
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid VMVX executable global");
 }
 
 static const iree_hal_local_executable_vtable_t
@@ -665,6 +685,8 @@ static const iree_hal_local_executable_vtable_t
                     iree_hal_vmvx_executable_lookup_export_by_name,
                 .lookup_global_by_name =
                     iree_hal_vmvx_executable_lookup_global_by_name,
+                .global_info = iree_hal_vmvx_executable_global_info,
+                .global_buffer = iree_hal_vmvx_executable_global_buffer,
             },
         .issue_call = iree_hal_vmvx_executable_issue_call,
 };

--- a/runtime/src/iree/hal/replay/recorder_executable.c
+++ b/runtime/src/iree/hal/replay/recorder_executable.c
@@ -324,16 +324,17 @@ iree_hal_replay_recorder_executable_lookup_function_by_name(
                            executable->base_executable, name, out_function));
 }
 
-static iree_status_t iree_hal_replay_recorder_executable_lookup_global_by_name(
+static iree_status_t
+iree_hal_replay_recorder_executable_try_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_executable_global_t* out_global) {
+    bool* out_found, iree_hal_executable_global_t* out_global) {
   iree_hal_replay_recorder_executable_t* executable =
       iree_hal_replay_recorder_executable_cast(base_executable);
   (void)executable;
   (void)name;
+  *out_found = false;
   *out_global = iree_hal_executable_global_invalid();
-  return iree_make_status(IREE_STATUS_NOT_FOUND,
-                          "replay recorder executable does not expose globals");
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_replay_recorder_executable_global_info(
@@ -801,8 +802,8 @@ static const iree_hal_executable_vtable_t
             iree_hal_replay_recorder_executable_function_parameters,
         .lookup_function_by_name =
             iree_hal_replay_recorder_executable_lookup_function_by_name,
-        .lookup_global_by_name =
-            iree_hal_replay_recorder_executable_lookup_global_by_name,
+        .try_lookup_global_by_name =
+            iree_hal_replay_recorder_executable_try_lookup_global_by_name,
         .global_info = iree_hal_replay_recorder_executable_global_info,
         .global_buffer = iree_hal_replay_recorder_executable_global_buffer,
 };

--- a/runtime/src/iree/hal/replay/recorder_executable.c
+++ b/runtime/src/iree/hal/replay/recorder_executable.c
@@ -326,16 +326,39 @@ iree_hal_replay_recorder_executable_lookup_function_by_name(
 
 static iree_status_t iree_hal_replay_recorder_executable_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+    iree_hal_executable_global_t* out_global) {
   iree_hal_replay_recorder_executable_t* executable =
       iree_hal_replay_recorder_executable_cast(base_executable);
   (void)executable;
   (void)name;
+  *out_global = iree_hal_executable_global_invalid();
+  return iree_make_status(IREE_STATUS_NOT_FOUND,
+                          "replay recorder executable does not expose globals");
+}
+
+static iree_status_t iree_hal_replay_recorder_executable_global_info(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
+  iree_hal_replay_recorder_executable_t* executable =
+      iree_hal_replay_recorder_executable_cast(base_executable);
+  (void)executable;
+  (void)global;
+  memset(out_info, 0, sizeof(*out_info));
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid replay recorder executable global");
+}
+
+static iree_status_t iree_hal_replay_recorder_executable_global_buffer(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  iree_hal_replay_recorder_executable_t* executable =
+      iree_hal_replay_recorder_executable_cast(base_executable);
+  (void)executable;
+  (void)global;
   (void)queue_affinity;
   *out_buffer = NULL;
-  return iree_make_status(
-      IREE_STATUS_UNIMPLEMENTED,
-      "replay recording of executable global lookup is not implemented");
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "invalid replay recorder executable global");
 }
 
 //===----------------------------------------------------------------------===//
@@ -780,6 +803,8 @@ static const iree_hal_executable_vtable_t
             iree_hal_replay_recorder_executable_lookup_function_by_name,
         .lookup_global_by_name =
             iree_hal_replay_recorder_executable_lookup_global_by_name,
+        .global_info = iree_hal_replay_recorder_executable_global_info,
+        .global_buffer = iree_hal_replay_recorder_executable_global_buffer,
 };
 
 static const iree_hal_executable_cache_vtable_t

--- a/runtime/src/iree/hal/testing/mock_device.c
+++ b/runtime/src/iree/hal/testing/mock_device.c
@@ -215,12 +215,30 @@ static iree_status_t iree_hal_mock_executable_lookup_function_by_name(
 
 static iree_status_t iree_hal_mock_executable_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+    iree_hal_executable_global_t* out_global) {
   (void)base_executable;
   (void)name;
+  *out_global = iree_hal_executable_global_invalid();
+  return iree_make_status(IREE_STATUS_NOT_FOUND);
+}
+
+static iree_status_t iree_hal_mock_executable_global_info(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_executable_global_info_t* out_info) {
+  (void)base_executable;
+  (void)global;
+  memset(out_info, 0, sizeof(*out_info));
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT);
+}
+
+static iree_status_t iree_hal_mock_executable_global_buffer(
+    iree_hal_executable_t* base_executable, iree_hal_executable_global_t global,
+    iree_hal_queue_affinity_t queue_affinity, iree_hal_buffer_t** out_buffer) {
+  (void)base_executable;
+  (void)global;
   (void)queue_affinity;
   *out_buffer = NULL;
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT);
 }
 
 static const iree_hal_executable_vtable_t iree_hal_mock_executable_vtable = {
@@ -230,6 +248,8 @@ static const iree_hal_executable_vtable_t iree_hal_mock_executable_vtable = {
     .function_parameters = iree_hal_mock_executable_function_parameters,
     .lookup_function_by_name = iree_hal_mock_executable_lookup_function_by_name,
     .lookup_global_by_name = iree_hal_mock_executable_lookup_global_by_name,
+    .global_info = iree_hal_mock_executable_global_info,
+    .global_buffer = iree_hal_mock_executable_global_buffer,
 };
 
 typedef struct iree_hal_mock_executable_cache_t {

--- a/runtime/src/iree/hal/testing/mock_device.c
+++ b/runtime/src/iree/hal/testing/mock_device.c
@@ -213,13 +213,14 @@ static iree_status_t iree_hal_mock_executable_lookup_function_by_name(
   return iree_make_status(IREE_STATUS_NOT_FOUND);
 }
 
-static iree_status_t iree_hal_mock_executable_lookup_global_by_name(
+static iree_status_t iree_hal_mock_executable_try_lookup_global_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
-    iree_hal_executable_global_t* out_global) {
+    bool* out_found, iree_hal_executable_global_t* out_global) {
   (void)base_executable;
   (void)name;
+  *out_found = false;
   *out_global = iree_hal_executable_global_invalid();
-  return iree_make_status(IREE_STATUS_NOT_FOUND);
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_mock_executable_global_info(
@@ -247,7 +248,8 @@ static const iree_hal_executable_vtable_t iree_hal_mock_executable_vtable = {
     .function_info = iree_hal_mock_executable_function_info,
     .function_parameters = iree_hal_mock_executable_function_parameters,
     .lookup_function_by_name = iree_hal_mock_executable_lookup_function_by_name,
-    .lookup_global_by_name = iree_hal_mock_executable_lookup_global_by_name,
+    .try_lookup_global_by_name =
+        iree_hal_mock_executable_try_lookup_global_by_name,
     .global_info = iree_hal_mock_executable_global_info,
     .global_buffer = iree_hal_mock_executable_global_buffer,
 };


### PR DESCRIPTION
This adds a HAL executable-global abstraction for runtime-visible device variables and wires it through the backends that can expose globals today. The API is intentionally by-name: callers probe for a global using `iree_hal_executable_try_lookup_global_by_name`, receive an executable-local opaque handle, query stable metadata, and then request a HAL buffer alias for the selected queue/device affinity. The status-producing `iree_hal_executable_lookup_global_by_name` remains as the convenience wrapper for callers that require a global and want a `NOT_FOUND` diagnostic at the API boundary.

The AMDGPU implementation keeps the name-resolution and per-device buffer aliasing state in a dedicated global table. The table interns handles lazily, verifies symbols against the loaded HSA executable, caches aliases per physical device, and treats the returned buffers as borrowed views over loader-owned executable storage. That keeps the public HAL handle opaque while leaving room for the table internals to move from linear lookup to a denser index, sorted table, or generated lookup structure later.

HRX now resolves module globals through the HAL executable-global path instead of maintaining a parallel compatibility-only route. A logical HIP module may still be backed by multiple HAL executables from a fat binary, so HRX uses the non-error try-lookup path to scan that module namespace and only reports a terminal miss if no backing executable owns the requested name.

The CUDA and HIP native executable paths implement the same HAL contract around their driver symbol lookup APIs. Targets without executable-global support return a clean miss for lookup while preserving invalid-handle failures on metadata and buffer access. The CTS grows an optional positive global case so backends that provide the test symbol prove the full lookup, metadata, buffer-alias, write, and readback path through the public HAL APIs.