### PR TITLE
[Loom] Report source memory lowering decisions

### DIFF
--- a/loom/build_tools/bazel/loom_check.bzl
+++ b/loom/build_tools/bazel/loom_check.bzl
@@ -44,8 +44,8 @@ def _loom_check_wrapper_content(ctx):
         "#!/usr/bin/env bash\n" +
         "set -euo pipefail\n" +
         "RUNFILES=\"${{RUNFILES_DIR:-$0.runfiles}}\"\n" +
-        "exec \"${{RUNFILES}}/{workspace}/{runner}\" " +
-        "\"$@\" \"${{RUNFILES}}/{workspace}/{fixture}\"\n"
+        "cd \"${{RUNFILES}}/{workspace}\"\n" +
+        "exec \"${{PWD}}/{runner}\" \"$@\" \"{fixture}\"\n"
     ).format(
         workspace = ctx.workspace_name,
         runner = ctx.executable.runner.short_path,

--- a/loom/build_tools/bazel/test/loom_check_fixture_runner.sh
+++ b/loom/build_tools/bazel/test/loom_check_fixture_runner.sh
@@ -14,7 +14,7 @@ fi
 
 fixture="$2"
 case "${fixture}" in
-  */loom/build_tools/bazel/test/roundtrip.loom-test) ;;
+  loom/build_tools/bazel/test/roundtrip.loom-test) ;;
   *)
     printf "unexpected fixture path: %s\n" "${fixture}" >&2
     exit 1

--- a/loom/py/loom/error/backend.py
+++ b/loom/py/loom/error/backend.py
@@ -911,6 +911,76 @@ ERR_BACKEND_039 = ErrorDef(
     ),
 )
 
+# ERR_BACKEND_040: Source memory cache-policy decision was recorded.
+ERR_BACKEND_040 = ErrorDef(
+    domain=ErrorDomain.BACKEND,
+    code=40,
+    severity=Severity.REMARK,
+    summary="Source memory cache-policy decision recorded.",
+    message=(
+        "target '{target_key}' export '{export_name}' config '{config_key}' "
+        "{decision} cache policy '{cache_scope}/{cache_temporal}' for "
+        "'@{function_name}' op '{op_name}' {operation_kind} in "
+        "{memory_space}: decision '{decision_key}', encoding "
+        "'{encoding_key}', scope_attr present {scope_attr_present} value "
+        "{scope_attr}, th_attr present {th_attr_present} value {th_attr}, "
+        "nt_attr present {nt_attr_present} value {nt_attr}"
+    ),
+    params=(
+        ErrorParam("target_key", ParamKind.STRING),
+        ErrorParam("export_name", ParamKind.STRING),
+        ErrorParam("config_key", ParamKind.STRING),
+        ErrorParam("function_name", ParamKind.STRING),
+        ErrorParam("op_name", ParamKind.STRING),
+        ErrorParam("memory_space", ParamKind.STRING),
+        ErrorParam("operation_kind", ParamKind.STRING),
+        ErrorParam("cache_scope", ParamKind.STRING),
+        ErrorParam("cache_temporal", ParamKind.STRING),
+        ErrorParam("decision_key", ParamKind.STRING),
+        ErrorParam("decision", ParamKind.STRING),
+        ErrorParam("encoding_key", ParamKind.STRING),
+        ErrorParam("scope_attr_present", ParamKind.BOOL),
+        ErrorParam("scope_attr", ParamKind.I64),
+        ErrorParam("th_attr_present", ParamKind.BOOL),
+        ErrorParam("th_attr", ParamKind.I64),
+        ErrorParam("nt_attr_present", ParamKind.BOOL),
+        ErrorParam("nt_attr", ParamKind.I64),
+    ),
+)
+
+# ERR_BACKEND_041: Source memory prefetch decision was recorded.
+ERR_BACKEND_041 = ErrorDef(
+    domain=ErrorDomain.BACKEND,
+    code=41,
+    severity=Severity.REMARK,
+    summary="Source memory prefetch decision recorded.",
+    message=(
+        "target '{target_key}' export '{export_name}' config '{config_key}' "
+        "{decision} prefetch '{prefetch_intent}/{prefetch_locality}' for "
+        "'@{function_name}' op '{op_name}' in {memory_space}: decision "
+        "'{decision_key}', packet '{packet_key}', immediate offset "
+        "{immediate_offset}, scalar byte offset {scalar_byte_offset}, dynamic "
+        "index '{dynamic_index_kind}', count {count}"
+    ),
+    params=(
+        ErrorParam("target_key", ParamKind.STRING),
+        ErrorParam("export_name", ParamKind.STRING),
+        ErrorParam("config_key", ParamKind.STRING),
+        ErrorParam("function_name", ParamKind.STRING),
+        ErrorParam("op_name", ParamKind.STRING),
+        ErrorParam("memory_space", ParamKind.STRING),
+        ErrorParam("prefetch_intent", ParamKind.STRING),
+        ErrorParam("prefetch_locality", ParamKind.STRING),
+        ErrorParam("decision_key", ParamKind.STRING),
+        ErrorParam("decision", ParamKind.STRING),
+        ErrorParam("packet_key", ParamKind.STRING),
+        ErrorParam("immediate_offset", ParamKind.I64),
+        ErrorParam("scalar_byte_offset", ParamKind.U32),
+        ErrorParam("dynamic_index_kind", ParamKind.STRING),
+        ErrorParam("count", ParamKind.U32),
+    ),
+)
+
 ALL_BACKEND_ERRORS: tuple[ErrorDef, ...] = (
     ERR_BACKEND_003,
     ERR_BACKEND_005,
@@ -945,4 +1015,6 @@ ALL_BACKEND_ERRORS: tuple[ErrorDef, ...] = (
     ERR_BACKEND_037,
     ERR_BACKEND_038,
     ERR_BACKEND_039,
+    ERR_BACKEND_040,
+    ERR_BACKEND_041,
 )

--- a/loom/src/loom/codegen/low/lower/lower.c
+++ b/loom/src/loom/codegen/low/lower/lower.c
@@ -375,6 +375,16 @@ static bool loom_low_lower_op_uses_policy(const loom_module_t* module,
          !loom_low_lower_op_is_source_metadata(op->kind);
 }
 
+static bool loom_low_lower_op_is_discardable_hint(const loom_module_t* module,
+                                                  const loom_op_t* op) {
+  if (op->result_count != 0 || op->region_count != 0 ||
+      op->tied_result_count != 0) {
+    return false;
+  }
+  const loom_trait_flags_t traits = loom_op_effective_traits(module, op);
+  return iree_any_bit_set(traits, LOOM_TRAIT_HINT);
+}
+
 static void loom_low_lower_mark_value_storage_required(
     loom_low_lower_context_t* context, loom_value_id_t source_value_id) {
   const loom_value_ordinal_t source_ordinal =
@@ -654,6 +664,10 @@ static void loom_low_lower_analyze_storage_demands(
   for (iree_host_size_t i = 0; i < context->lowering.selected_plan_count; ++i) {
     loom_low_lower_selected_plan_t* selected_plan =
         &context->lowering.selected_plans[i];
+    if (iree_any_bit_set(selected_plan->flags,
+                         LOOM_LOW_LOWER_SELECTED_PLAN_ELIDED)) {
+      continue;
+    }
     switch (selected_plan->kind) {
       case LOOM_LOW_LOWER_SELECTED_PLAN_RULE:
         loom_low_lower_mark_rule_storage_demands(context, selected_plan);
@@ -745,6 +759,22 @@ static void loom_low_lower_record_selected_plan(
                  context->lowering.selected_plan_capacity);
   context->lowering.selected_plans[context->lowering.selected_plan_count++] =
       selected_plan;
+}
+
+static void loom_low_lower_record_elided_hint_plan(
+    loom_low_lower_context_t* context, const loom_op_t* source_op) {
+  loom_low_lower_record_selected_plan(
+      context, (loom_low_lower_selected_plan_t){
+                   .source_op = source_op,
+                   .kind = LOOM_LOW_LOWER_SELECTED_PLAN_CALLBACK,
+                   .flags = LOOM_LOW_LOWER_SELECTED_PLAN_ELIDED,
+                   .rule_set_index = UINT16_MAX,
+                   .rule_index = UINT16_MAX,
+                   .rule_set = NULL,
+                   .rule = NULL,
+                   .resolved_emits = NULL,
+                   .plan = loom_low_lower_plan_empty(),
+               });
 }
 
 static iree_status_t loom_low_lower_record_selected_rule_plan(
@@ -1351,6 +1381,10 @@ static iree_status_t loom_low_lower_plan_op(loom_low_lower_context_t* context,
   if (failed_rule_set != NULL) {
     return loom_low_lower_rule_set_emit_selection_failure(
         context, failed_rule_set, source_op, failed_rule_selection);
+  }
+  if (loom_low_lower_op_is_discardable_hint(context->module, source_op)) {
+    loom_low_lower_record_elided_hint_plan(context, source_op);
+    return iree_ok_status();
   }
   return loom_low_lower_emit_no_target_contract(context, source_op);
 }

--- a/loom/src/loom/target/arch/amdgpu/lower/memory.h
+++ b/loom/src/loom/target/arch/amdgpu/lower/memory.h
@@ -178,6 +178,16 @@ iree_status_t loom_amdgpu_make_memory_attrs(
 bool loom_amdgpu_memory_cache_policy_is_present(
     const loom_vector_memory_cache_policy_t* policy);
 
+// Returns the stable diagnostic key for the selected descriptor-set cache
+// policy encoding.
+iree_string_view_t loom_amdgpu_memory_cache_policy_encoding_key(
+    const loom_low_descriptor_set_t* descriptor_set);
+
+// Returns the stable diagnostic decision key for a selected cache-policy
+// encoding.
+iree_string_view_t loom_amdgpu_memory_cache_policy_selected_key(
+    const loom_low_descriptor_set_t* descriptor_set);
+
 // Returns true when the selected descriptor set can encode the cache policy on
 // the memory access plan.
 bool loom_amdgpu_memory_cache_policy_can_lower(
@@ -234,6 +244,19 @@ iree_status_t loom_amdgpu_record_memory_access_diagnostic(
     const loom_amdgpu_memory_access_t* access,
     loom_amdgpu_memory_operation_kind_t kind);
 
+// Records optional cache-policy diagnostics for a selected memory access plan.
+iree_status_t loom_amdgpu_record_memory_cache_policy_diagnostic(
+    loom_target_low_legality_context_t* context, const loom_op_t* op,
+    const loom_low_descriptor_set_t* descriptor_set,
+    const loom_amdgpu_memory_access_t* access,
+    loom_amdgpu_memory_operation_kind_t kind);
+
+// Records optional cache-policy diagnostics for a rejected memory access plan.
+iree_status_t loom_amdgpu_record_memory_cache_policy_rejection_diagnostic(
+    loom_target_low_legality_context_t* context, const loom_op_t* op,
+    const loom_low_descriptor_set_t* descriptor_set,
+    const loom_amdgpu_memory_access_t* access);
+
 // Selects an AMDGPU source memory-load packet plan.
 iree_status_t loom_amdgpu_select_memory_load_plan(
     loom_low_lower_context_t* context, const loom_op_t* source_op,
@@ -274,6 +297,11 @@ iree_status_t loom_amdgpu_select_view_prefetch_plan(
 iree_status_t loom_amdgpu_lower_view_prefetch(
     loom_low_lower_context_t* context, const loom_op_t* source_op,
     const loom_amdgpu_prefetch_plan_t* plan);
+
+// Records optional prefetch diagnostics for source view.prefetch hints.
+iree_status_t loom_amdgpu_record_view_prefetch_diagnostic(
+    loom_target_low_legality_context_t* context, const loom_op_t* source_op,
+    const loom_low_descriptor_set_t* descriptor_set);
 
 // Verifies source memory legality for AMDGPU target-low selection.
 iree_status_t loom_amdgpu_low_legality_verify_memory(

--- a/loom/src/loom/target/arch/amdgpu/lower/memory_cache.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/memory_cache.c
@@ -153,6 +153,59 @@ loom_amdgpu_memory_cache_policy_encoding_row(
   return NULL;
 }
 
+static iree_string_view_t loom_amdgpu_memory_cache_policy_encoding_name(
+    loom_amdgpu_vector_memory_cache_policy_encoding_t encoding) {
+  switch (encoding) {
+    case LOOM_AMDGPU_VECTOR_MEMORY_CACHE_POLICY_ENCODING_NONE:
+      return IREE_SV("none");
+    case LOOM_AMDGPU_VECTOR_MEMORY_CACHE_POLICY_ENCODING_GFX9_11_GLC_SLC_DLC:
+      return IREE_SV("gfx9_11_glc_slc_dlc");
+    case LOOM_AMDGPU_VECTOR_MEMORY_CACHE_POLICY_ENCODING_GFX12_NV_SCOPE_TH:
+      return IREE_SV("gfx12_nv_scope_th");
+    case LOOM_AMDGPU_VECTOR_MEMORY_CACHE_POLICY_ENCODING_GFX950_NT_SC0_SC1:
+      return IREE_SV("gfx950_nt_sc0_sc1");
+  }
+  return IREE_SV("invalid");
+}
+
+static iree_string_view_t loom_amdgpu_memory_cache_policy_selected_name(
+    loom_amdgpu_vector_memory_cache_policy_encoding_t encoding) {
+  switch (encoding) {
+    case LOOM_AMDGPU_VECTOR_MEMORY_CACHE_POLICY_ENCODING_NONE:
+      return IREE_SV("memory_cache_policy.none");
+    case LOOM_AMDGPU_VECTOR_MEMORY_CACHE_POLICY_ENCODING_GFX9_11_GLC_SLC_DLC:
+      return IREE_SV("memory_cache_policy.gfx9_11_glc_slc_dlc");
+    case LOOM_AMDGPU_VECTOR_MEMORY_CACHE_POLICY_ENCODING_GFX12_NV_SCOPE_TH:
+      return IREE_SV("memory_cache_policy.gfx12_nv_scope_th");
+    case LOOM_AMDGPU_VECTOR_MEMORY_CACHE_POLICY_ENCODING_GFX950_NT_SC0_SC1:
+      return IREE_SV("memory_cache_policy.gfx950_nt_sc0_sc1");
+  }
+  return IREE_SV("memory_cache_policy.invalid");
+}
+
+static loom_amdgpu_vector_memory_cache_policy_encoding_t
+loom_amdgpu_memory_cache_policy_descriptor_encoding(
+    const loom_low_descriptor_set_t* descriptor_set) {
+  const loom_amdgpu_descriptor_set_info_t* descriptor_set_info =
+      loom_amdgpu_target_info_descriptor_set_at(
+          descriptor_set->descriptor_set_ordinal);
+  return descriptor_set_info
+             ? descriptor_set_info->vector_memory_cache_policy_encoding
+             : LOOM_AMDGPU_VECTOR_MEMORY_CACHE_POLICY_ENCODING_NONE;
+}
+
+iree_string_view_t loom_amdgpu_memory_cache_policy_encoding_key(
+    const loom_low_descriptor_set_t* descriptor_set) {
+  return loom_amdgpu_memory_cache_policy_encoding_name(
+      loom_amdgpu_memory_cache_policy_descriptor_encoding(descriptor_set));
+}
+
+iree_string_view_t loom_amdgpu_memory_cache_policy_selected_key(
+    const loom_low_descriptor_set_t* descriptor_set) {
+  return loom_amdgpu_memory_cache_policy_selected_name(
+      loom_amdgpu_memory_cache_policy_descriptor_encoding(descriptor_set));
+}
+
 static bool loom_amdgpu_memory_cache_policy_bits_contain(uint32_t bits,
                                                          uint8_t ordinal) {
   return ordinal < 32 && iree_any_bit_set(bits, (uint32_t)1u << ordinal);

--- a/loom/src/loom/target/arch/amdgpu/lower/memory_diagnostics.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/memory_diagnostics.c
@@ -68,6 +68,22 @@ static iree_string_view_t loom_amdgpu_memory_operation_name(
   return IREE_SV("invalid");
 }
 
+static iree_string_view_t loom_amdgpu_cache_policy_scope_param(
+    const loom_vector_memory_cache_policy_t* policy) {
+  return iree_all_bits_set(policy->build_flags,
+                           LOOM_VECTOR_MEMORY_CACHE_POLICY_BUILD_FLAG_SCOPE)
+             ? loom_amdgpu_cache_scope_name(policy->cache_scope)
+             : IREE_SV("<missing>");
+}
+
+static iree_string_view_t loom_amdgpu_cache_policy_temporal_param(
+    const loom_vector_memory_cache_policy_t* policy) {
+  return iree_all_bits_set(policy->build_flags,
+                           LOOM_VECTOR_MEMORY_CACHE_POLICY_BUILD_FLAG_TEMPORAL)
+             ? loom_amdgpu_cache_temporal_name(policy->cache_temporal)
+             : IREE_SV("<missing>");
+}
+
 static iree_string_view_t loom_amdgpu_source_memory_operation_name(
     loom_low_source_memory_operation_kind_t kind) {
   switch (kind) {
@@ -359,6 +375,79 @@ iree_status_t loom_amdgpu_record_memory_access_diagnostic(
           : 0,
       access->source.vector_lane_byte_stride, bank_summary.bank_stride_words,
       bank_summary.conflict_degree, bank_summary.conflict_kind);
+}
+
+static iree_status_t loom_amdgpu_record_memory_cache_policy(
+    loom_target_low_legality_context_t* context, const loom_op_t* op,
+    const loom_low_descriptor_set_t* descriptor_set,
+    const loom_amdgpu_memory_access_t* access,
+    loom_amdgpu_memory_operation_kind_t kind, iree_string_view_t decision_key,
+    iree_string_view_t decision,
+    const loom_amdgpu_memory_cache_policy_attrs_t* cache_attrs) {
+  const loom_vector_memory_cache_policy_t* policy =
+      &access->source.cache_policy;
+  const bool scope_attr_present =
+      cache_attrs &&
+      iree_any_bit_set(cache_attrs->flags,
+                       LOOM_AMDGPU_MEMORY_CACHE_POLICY_ATTR_SCOPE);
+  const bool th_attr_present =
+      cache_attrs && iree_any_bit_set(cache_attrs->flags,
+                                      LOOM_AMDGPU_MEMORY_CACHE_POLICY_ATTR_TH);
+  const bool nt_attr_present =
+      cache_attrs && iree_any_bit_set(cache_attrs->flags,
+                                      LOOM_AMDGPU_MEMORY_CACHE_POLICY_ATTR_NT);
+  return loom_target_low_legality_record_memory_cache_policy(
+      context, op, loom_amdgpu_memory_space_name(access->source.memory_space),
+      loom_amdgpu_memory_operation_name(kind),
+      loom_amdgpu_cache_policy_scope_param(policy),
+      loom_amdgpu_cache_policy_temporal_param(policy), decision_key, decision,
+      loom_amdgpu_memory_cache_policy_encoding_key(descriptor_set),
+      scope_attr_present, scope_attr_present ? cache_attrs->scope : 0,
+      th_attr_present, th_attr_present ? cache_attrs->th : 0, nt_attr_present,
+      nt_attr_present ? cache_attrs->nt : 0);
+}
+
+iree_status_t loom_amdgpu_record_memory_cache_policy_diagnostic(
+    loom_target_low_legality_context_t* context, const loom_op_t* op,
+    const loom_low_descriptor_set_t* descriptor_set,
+    const loom_amdgpu_memory_access_t* access,
+    loom_amdgpu_memory_operation_kind_t kind) {
+  if (!iree_any_bit_set(loom_target_low_legality_diagnostic_flags(context),
+                        LOOM_TARGET_LOW_LEGALITY_DIAGNOSTIC_MEMORY_ACCESS) ||
+      !loom_amdgpu_memory_cache_policy_is_present(
+          &access->source.cache_policy)) {
+    return iree_ok_status();
+  }
+
+  loom_amdgpu_memory_cache_policy_attrs_t cache_attrs = {0};
+  if (!loom_amdgpu_memory_cache_policy_encode(descriptor_set, access,
+                                              &cache_attrs)) {
+    return iree_ok_status();
+  }
+  return loom_amdgpu_record_memory_cache_policy(
+      context, op, descriptor_set, access, kind,
+      loom_amdgpu_memory_cache_policy_selected_key(descriptor_set),
+      IREE_SV("selected"), &cache_attrs);
+}
+
+iree_status_t loom_amdgpu_record_memory_cache_policy_rejection_diagnostic(
+    loom_target_low_legality_context_t* context, const loom_op_t* op,
+    const loom_low_descriptor_set_t* descriptor_set,
+    const loom_amdgpu_memory_access_t* access) {
+  if (!iree_any_bit_set(loom_target_low_legality_diagnostic_flags(context),
+                        LOOM_TARGET_LOW_LEGALITY_DIAGNOSTIC_MEMORY_ACCESS) ||
+      !loom_amdgpu_memory_cache_policy_is_present(
+          &access->source.cache_policy)) {
+    return iree_ok_status();
+  }
+
+  const loom_amdgpu_memory_operation_kind_t kind =
+      loom_amdgpu_memory_operation_kind_from_source(&access->source);
+  return loom_amdgpu_record_memory_cache_policy(
+      context, op, descriptor_set, access, kind,
+      loom_amdgpu_memory_cache_policy_rejection_key(
+          descriptor_set, access, &access->source.cache_policy),
+      IREE_SV("rejected"), /*cache_attrs=*/NULL);
 }
 
 iree_string_view_t loom_amdgpu_memory_access_rejection_key(

--- a/loom/src/loom/target/arch/amdgpu/lower/memory_legality.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/memory_legality.c
@@ -67,6 +67,11 @@ iree_status_t loom_amdgpu_low_legality_verify_memory(
   const loom_module_t* module = loom_target_low_legality_module(context);
   const loom_low_descriptor_set_t* descriptor_set =
       loom_target_low_legality_descriptor_set(context);
+  if (op->kind == LOOM_OP_VIEW_PREFETCH) {
+    IREE_RETURN_IF_ERROR(loom_amdgpu_record_view_prefetch_diagnostic(
+        context, op, descriptor_set));
+    return iree_ok_status();
+  }
   if (op->kind != LOOM_OP_VECTOR_LOAD && op->kind != LOOM_OP_VECTOR_STORE &&
       op->kind != LOOM_OP_VIEW_LOAD && op->kind != LOOM_OP_VIEW_STORE) {
     *out_handled = false;
@@ -103,6 +108,9 @@ iree_status_t loom_amdgpu_low_legality_verify_memory(
   for (uint32_t i = 0; i < plan.packet_count; ++i) {
     const loom_amdgpu_memory_access_t* access = &plan.packets[i].access;
     if (!loom_amdgpu_memory_cache_policy_can_lower(descriptor_set, access)) {
+      IREE_RETURN_IF_ERROR(
+          loom_amdgpu_record_memory_cache_policy_rejection_diagnostic(
+              context, op, descriptor_set, access));
       return loom_amdgpu_emit_memory_cache_policy_rejection(
           context, op, descriptor_set, access);
     }
@@ -111,6 +119,8 @@ iree_status_t loom_amdgpu_low_legality_verify_memory(
     const loom_amdgpu_memory_access_t* access = &plan.packets[i].access;
     const loom_amdgpu_memory_operation_kind_t kind =
         loom_amdgpu_memory_operation_kind_from_source(&access->source);
+    IREE_RETURN_IF_ERROR(loom_amdgpu_record_memory_cache_policy_diagnostic(
+        context, op, descriptor_set, access, kind));
     IREE_RETURN_IF_ERROR(loom_amdgpu_record_memory_access_diagnostic(
         context, op, descriptor_set, access, kind));
   }

--- a/loom/src/loom/target/arch/amdgpu/lower/plan.h
+++ b/loom/src/loom/target/arch/amdgpu/lower/plan.h
@@ -825,6 +825,8 @@ typedef struct loom_amdgpu_atomic_plan_t {
 typedef struct loom_amdgpu_prefetch_plan_t {
   // Descriptor row selected for the prefetch packet.
   loom_low_lower_resolved_descriptor_t descriptor;
+  // Descriptor ordinal selected from the active descriptor set.
+  uint32_t descriptor_ordinal;
   // Module string ID for the descriptor's offset attribute.
   loom_string_id_t offset_attr_name_id;
   // Module string ID for the descriptor's count attribute.

--- a/loom/src/loom/target/arch/amdgpu/lower/prefetch.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/prefetch.c
@@ -12,6 +12,47 @@
 #include "loom/target/arch/amdgpu/lower/types.h"
 #include "loom/target/arch/amdgpu/refs/target_refs.h"
 
+static iree_string_view_t loom_amdgpu_prefetch_intent_name(uint8_t intent) {
+  switch ((loom_view_prefetch_intent_t)intent) {
+    case LOOM_VIEW_PREFETCH_INTENT_READ:
+      return IREE_SV("read");
+    case LOOM_VIEW_PREFETCH_INTENT_WRITE:
+      return IREE_SV("write");
+    case LOOM_VIEW_PREFETCH_INTENT_COUNT_:
+      break;
+  }
+  return IREE_SV("invalid");
+}
+
+static iree_string_view_t loom_amdgpu_prefetch_locality_name(uint8_t locality) {
+  switch ((loom_view_prefetch_locality_t)locality) {
+    case LOOM_VIEW_PREFETCH_LOCALITY_NONE:
+      return IREE_SV("none");
+    case LOOM_VIEW_PREFETCH_LOCALITY_L1:
+      return IREE_SV("l1");
+    case LOOM_VIEW_PREFETCH_LOCALITY_L2:
+      return IREE_SV("l2");
+    case LOOM_VIEW_PREFETCH_LOCALITY_L3:
+      return IREE_SV("l3");
+    case LOOM_VIEW_PREFETCH_LOCALITY_COUNT_:
+      break;
+  }
+  return IREE_SV("invalid");
+}
+
+static iree_string_view_t loom_amdgpu_prefetch_dynamic_index_kind_name(
+    loom_amdgpu_memory_dynamic_index_kind_t kind) {
+  switch (kind) {
+    case LOOM_AMDGPU_MEMORY_DYNAMIC_INDEX_NONE:
+      return IREE_SV("none");
+    case LOOM_AMDGPU_MEMORY_DYNAMIC_INDEX_VADDR:
+      return IREE_SV("vaddr");
+    case LOOM_AMDGPU_MEMORY_DYNAMIC_INDEX_SOFFSET:
+      return IREE_SV("soffset");
+  }
+  return IREE_SV("invalid");
+}
+
 static bool loom_amdgpu_prefetch_static_offset_split(
     const loom_amdgpu_descriptor_offset_immediate_info_t* offset_info,
     loom_amdgpu_prefetch_plan_t* plan) {
@@ -110,24 +151,31 @@ static bool loom_amdgpu_prefetch_memory_space_is_buffer_backed(
   return false;
 }
 
-static iree_status_t loom_amdgpu_prefetch_select(
-    loom_low_lower_context_t* context, const loom_op_t* source_op,
-    loom_amdgpu_prefetch_plan_t* out_plan, bool* out_selected) {
-  *out_plan = (loom_amdgpu_prefetch_plan_t){0};
-  *out_selected = false;
+static bool loom_amdgpu_prefetch_select_source(
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    const loom_low_descriptor_set_t* descriptor_set,
+    const loom_view_region_table_t* view_regions, const loom_op_t* source_op,
+    loom_amdgpu_prefetch_plan_t* out_plan,
+    const loom_low_descriptor_t** out_descriptor,
+    iree_string_view_t* out_decision_key) {
+  *out_plan = (loom_amdgpu_prefetch_plan_t){
+      .descriptor_ordinal = LOOM_LOW_DESCRIPTOR_ORDINAL_NONE,
+  };
+  *out_descriptor = NULL;
+  *out_decision_key = IREE_SV("prefetch.unhandled");
   if (!loom_view_prefetch_isa(source_op)) {
-    return iree_ok_status();
+    return false;
   }
   if (loom_view_prefetch_intent(source_op) != LOOM_VIEW_PREFETCH_INTENT_READ) {
-    return iree_ok_status();
+    *out_decision_key = IREE_SV("prefetch.intent");
+    return false;
   }
 
-  const loom_low_descriptor_set_t* descriptor_set =
-      loom_low_lower_context_descriptor_set(context);
   const uint32_t descriptor_ordinal = loom_amdgpu_descriptor_ref_ordinal(
       descriptor_set, LOOM_AMDGPU_DESCRIPTOR_REF_S_BUFFER_PREFETCH_DATA);
   if (descriptor_ordinal == LOOM_LOW_DESCRIPTOR_ORDINAL_NONE) {
-    return iree_ok_status();
+    *out_decision_key = IREE_SV("prefetch.descriptor_missing");
+    return false;
   }
   const loom_low_descriptor_t* descriptor =
       loom_low_descriptor_set_descriptor_at(descriptor_set, descriptor_ordinal);
@@ -136,8 +184,49 @@ static iree_status_t loom_amdgpu_prefetch_select(
   if (!loom_amdgpu_descriptor_offset_immediate_info(
           descriptor_set, descriptor_ordinal, 1,
           LOOM_LOW_IMMEDIATE_KIND_UNSIGNED, &offset_info)) {
-    return iree_ok_status();
+    *out_decision_key = IREE_SV("prefetch.offset_immediate");
+    return false;
   }
+
+  loom_low_source_memory_access_diagnostic_t source_diagnostic = {0};
+  if (!loom_low_source_memory_access_plan_build(module, fact_table, source_op,
+                                                &out_plan->source,
+                                                &source_diagnostic)) {
+    *out_decision_key = source_diagnostic.rejection_bits != 0
+                            ? loom_low_source_memory_access_rejection_key(
+                                  source_diagnostic.rejection_bits)
+                            : IREE_SV("prefetch.source_memory_access");
+    return false;
+  }
+  if (!loom_amdgpu_prefetch_memory_space_is_buffer_backed(
+          out_plan->source.memory_space)) {
+    *out_decision_key = IREE_SV("prefetch.memory_space");
+    return false;
+  }
+  if (!loom_amdgpu_prefetch_select_dynamic_index(module, fact_table,
+                                                 view_regions, out_plan)) {
+    *out_decision_key = IREE_SV("prefetch.dynamic_index");
+    return false;
+  }
+  if (!loom_amdgpu_prefetch_static_offset_split(&offset_info, out_plan)) {
+    *out_decision_key = IREE_SV("prefetch.offset_range");
+    return false;
+  }
+  if (!loom_amdgpu_view_prefetch_count(source_op, &out_plan->count)) {
+    *out_decision_key = IREE_SV("prefetch.locality");
+    return false;
+  }
+
+  out_plan->descriptor_ordinal = descriptor_ordinal;
+  *out_descriptor = descriptor;
+  *out_decision_key = IREE_SV("prefetch.s_buffer_prefetch_data");
+  return true;
+}
+
+static iree_status_t loom_amdgpu_prefetch_select(
+    loom_low_lower_context_t* context, const loom_op_t* source_op,
+    loom_amdgpu_prefetch_plan_t* out_plan, bool* out_selected) {
+  *out_selected = false;
 
   const loom_module_t* module = loom_low_lower_context_module(context);
   const loom_value_fact_table_t* fact_table =
@@ -145,24 +234,13 @@ static iree_status_t loom_amdgpu_prefetch_select(
   const loom_view_region_table_t* view_regions = NULL;
   IREE_RETURN_IF_ERROR(
       loom_low_lower_context_view_regions(context, &view_regions));
-  loom_low_source_memory_access_diagnostic_t unused_diagnostic = {0};
-  if (!loom_low_source_memory_access_plan_build(module, fact_table, source_op,
-                                                &out_plan->source,
-                                                &unused_diagnostic)) {
-    return iree_ok_status();
-  }
-  if (!loom_amdgpu_prefetch_memory_space_is_buffer_backed(
-          out_plan->source.memory_space)) {
-    return iree_ok_status();
-  }
-  if (!loom_amdgpu_prefetch_select_dynamic_index(module, fact_table,
-                                                 view_regions, out_plan)) {
-    return iree_ok_status();
-  }
-  if (!loom_amdgpu_prefetch_static_offset_split(&offset_info, out_plan)) {
-    return iree_ok_status();
-  }
-  if (!loom_amdgpu_view_prefetch_count(source_op, &out_plan->count)) {
+  const loom_low_descriptor_set_t* descriptor_set =
+      loom_low_lower_context_descriptor_set(context);
+  const loom_low_descriptor_t* descriptor = NULL;
+  iree_string_view_t unused_decision_key = iree_string_view_empty();
+  if (!loom_amdgpu_prefetch_select_source(module, fact_table, descriptor_set,
+                                          view_regions, source_op, out_plan,
+                                          &descriptor, &unused_decision_key)) {
     return iree_ok_status();
   }
   IREE_RETURN_IF_ERROR(loom_low_lower_resolve_descriptor_row(
@@ -173,6 +251,41 @@ static iree_status_t loom_amdgpu_prefetch_select(
                                           &out_plan->count_attr_name_id));
   *out_selected = true;
   return iree_ok_status();
+}
+
+iree_status_t loom_amdgpu_record_view_prefetch_diagnostic(
+    loom_target_low_legality_context_t* context, const loom_op_t* source_op,
+    const loom_low_descriptor_set_t* descriptor_set) {
+  if (!iree_any_bit_set(loom_target_low_legality_diagnostic_flags(context),
+                        LOOM_TARGET_LOW_LEGALITY_DIAGNOSTIC_MEMORY_ACCESS) ||
+      !loom_view_prefetch_isa(source_op)) {
+    return iree_ok_status();
+  }
+
+  const loom_view_region_table_t* view_regions = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_target_low_legality_view_regions(context, &view_regions));
+  loom_amdgpu_prefetch_plan_t plan = {0};
+  const loom_low_descriptor_t* descriptor = NULL;
+  iree_string_view_t decision_key = iree_string_view_empty();
+  const bool selected = loom_amdgpu_prefetch_select_source(
+      loom_target_low_legality_module(context),
+      loom_target_low_legality_fact_table(context), descriptor_set,
+      view_regions, source_op, &plan, &descriptor, &decision_key);
+  const iree_string_view_t packet_key =
+      descriptor ? loom_low_descriptor_set_string(descriptor_set,
+                                                  descriptor->key_string_offset)
+                 : IREE_SV("<none>");
+  return loom_target_low_legality_record_memory_prefetch(
+      context, source_op,
+      loom_amdgpu_memory_space_name(plan.source.memory_space),
+      loom_amdgpu_prefetch_intent_name(loom_view_prefetch_intent(source_op)),
+      loom_amdgpu_prefetch_locality_name(
+          loom_view_prefetch_locality(source_op)),
+      decision_key, selected ? IREE_SV("selected") : IREE_SV("dropped"),
+      packet_key, plan.immediate_offset, plan.scalar_byte_offset,
+      loom_amdgpu_prefetch_dynamic_index_kind_name(plan.dynamic_term_kind),
+      plan.count);
 }
 
 iree_status_t loom_amdgpu_select_view_prefetch_plan(

--- a/loom/src/loom/target/arch/amdgpu/lower/registry_tables.inl
+++ b/loom/src/loom/target/arch/amdgpu/lower/registry_tables.inl
@@ -122,7 +122,8 @@ static const loom_amdgpu_lower_dispatch_row_t
         [LOOM_AMDGPU_OP_INDEX(LOOM_OP_VIEW_PREFETCH)] = LOOM_AMDGPU_DATA_ROW(
             LOOM_OP_VIEW_PREFETCH, loom_amdgpu_prefetch_plan_t,
             loom_amdgpu_select_view_prefetch_dispatch,
-            loom_amdgpu_emit_view_prefetch_dispatch, NULL),
+            loom_amdgpu_emit_view_prefetch_dispatch,
+            loom_amdgpu_low_legality_verify_memory),
 };
 
 static const loom_amdgpu_lower_dispatch_row_t

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cache_policy.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cache_policy.loom-test
@@ -1,5 +1,5 @@
 // TEMPLATE: loom/src/loom/test/corpus/source_low/memory_cache_policy_scopes.loom-test
-// RUN: emit source-low output=low
+// RUN: emit source-low diagnostics=memory output=low
 
 amdgpu.target<gfx1200> @target
 kernel.def target(@target) @cache_system_bypass_load_device_writeback_store() {
@@ -11,7 +11,9 @@ kernel.def target(@target) @cache_system_bypass_load_device_writeback_store() {
   %zero = index.constant 0 : offset
   %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
   %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  // REMARK@+1: BACKEND/040 "selected cache policy 'system/bypass'" "decision 'memory_cache_policy.gfx12_nv_scope_th'" "scope_attr present true value 3" "th_attr present true value 3"
   %loaded = vector.load %input_view[%tid, 0] {cache_scope = system, cache_temporal = bypass} : view<64x4xi32, #dense> -> vector<4xi32>
+  // REMARK@+1: BACKEND/040 "selected cache policy 'device/non_temporal_writeback'" "scope_attr present true value 2" "th_attr present true value 7" "nt_attr present false value 0"
   vector.store %loaded, %output_view[%tid, 0] {cache_scope = device, cache_temporal = non_temporal_writeback} : vector<4xi32>, view<64x4xi32, #dense>
   kernel.return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cache_policy_gfx950.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cache_policy_gfx950.loom-test
@@ -1,5 +1,5 @@
 // TEMPLATE: loom/src/loom/test/corpus/source_low/memory_cache_policy_non_temporal.loom-test
-// RUN: emit source-low output=low
+// RUN: emit source-low diagnostics=memory output=low
 
 amdgpu.target<gfx950> @target
 kernel.def target(@target) @cache_device_non_temporal_load_store() {
@@ -11,7 +11,9 @@ kernel.def target(@target) @cache_device_non_temporal_load_store() {
   %zero = index.constant 0 : offset
   %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
   %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  // REMARK@+1: BACKEND/040 "selected cache policy 'device/non_temporal'" "decision 'memory_cache_policy.gfx950_nt_sc0_sc1'" "scope_attr present false value 0" "nt_attr present true value 1"
   %loaded = vector.load %input_view[%tid, 0] {cache_scope = device, cache_temporal = non_temporal} : view<64x4xi32, #dense> -> vector<4xi32>
+  // REMARK@+1: BACKEND/040 "selected cache policy 'device/non_temporal'" "decision 'memory_cache_policy.gfx950_nt_sc0_sc1'" "th_attr present false value 0" "nt_attr present true value 1"
   vector.store %loaded, %output_view[%tid, 0] {cache_scope = device, cache_temporal = non_temporal} : vector<4xi32>, view<64x4xi32, #dense>
   kernel.return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_diagnostics.loom-test
@@ -284,6 +284,7 @@ kernel.def target(@target) @cache_policy_non_temporal_load_rejected() {
   %tid = index.assume %tid0 [range(%tid0, 0, 63)] : index
   %zero = index.constant 0 : offset
   %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
+  // REMARK@+2: BACKEND/040 "rejected cache policy 'device/non_temporal'" "decision 'memory_cache_policy.descriptor_encoding'" "encoding 'gfx9_11_glc_slc_dlc'"
   // ERROR@+1: AMDGPU/024 {constraint_key="memory_cache_policy.descriptor_encoding", memory_space="global", cache_scope="device", cache_temporal="non_temporal", descriptor_set_key="amdgpu.rdna3.core"}
   %loaded = vector.load %input_view[%tid, 0] {cache_scope = device, cache_temporal = non_temporal} : view<64x4xi32, #dense> -> vector<4xi32>
   kernel.return
@@ -304,6 +305,7 @@ kernel.def target(@target) @cache_policy_workgroup_store_rejected() {
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
   %one = vector.constant 1 : vector<4xi32>
+  // REMARK@+2: BACKEND/040 "rejected cache policy 'device/non_temporal'" "decision 'memory_cache_policy.workgroup'" "store in workgroup"
   // ERROR@+1: AMDGPU/024 {constraint_key="memory_cache_policy.workgroup", memory_space="workgroup", cache_scope="device", cache_temporal="non_temporal", descriptor_set_key="amdgpu.rdna3.core"}
   vector.store %one, %scratch_view[%tid, 0] {cache_scope = device, cache_temporal = non_temporal} : vector<4xi32>, view<64x4xi32, #dense>
   kernel.return

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_prefetch_gfx12.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_prefetch_gfx12.loom-test
@@ -1,10 +1,11 @@
 // TEMPLATE: loom/src/loom/test/corpus/source_low/memory_prefetch.loom-test
-// RUN: emit source-low output=low
+// RUN: emit source-low diagnostics=memory output=low
 
 amdgpu.target<gfx1200> @target
 func.def target(@target) @prefetch_static(%input: buffer) {
   %base = index.constant 16 : offset
   %input_view = buffer.view %input[%base] : buffer -> view<64xi32, #dense>
+  // REMARK@+1: BACKEND/041 "selected prefetch 'read/l1'" "decision 'prefetch.s_buffer_prefetch_data'" "immediate offset 32" "dynamic index 'none'"
   view.prefetch %input_view[4] {intent = read, locality = l1} : view<64xi32, #dense>
   func.return
 }
@@ -30,6 +31,7 @@ kernel.def target(@target) @prefetch_workgroup_id() {
   %bounded_gid = index.assume %gid [range(%gid, 0, 1024)] : index
   %zero = index.constant 0 : offset
   %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  // REMARK@+1: BACKEND/041 "selected prefetch 'read/l2'" "immediate offset 0" "dynamic index 'soffset'" "count 1"
   view.prefetch %input_view[%bounded_gid] {intent = read, locality = l2} : view<64xi32, #dense>
   kernel.return
 }
@@ -63,6 +65,7 @@ kernel.def target(@target) @prefetch_fixed_query_offset() {
   %offset = index.add %offset1, %subgroup_count : index
   %zero = index.constant 0 : offset
   %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  // REMARK@+1: BACKEND/041 "selected prefetch 'read/l1'" "immediate offset 180" "scalar byte offset 0" "dynamic index 'none'"
   view.prefetch %input_view[%offset] {intent = read, locality = l1} : view<64xi32, #dense>
   kernel.return
 }
@@ -74,4 +77,26 @@ low.kernel.def target(@target) workgroup_size(8, 4, 1) @prefetch_fixed_query_off
   %21 = low.op<amdgpu.hal.buffer_descriptor>(%input_view) {cache_swizzle_stride = 0, extent = 256} : (reg<amdgpu.sgpr x2>) -> reg<amdgpu.sgpr x4>
   low.op<amdgpu.s_buffer_prefetch_data>(%21, %20) {count = 1, offset = 180} : (reg<amdgpu.sgpr x4>, reg<amdgpu.sgpr>)
   low.return
+}
+
+// ====
+
+amdgpu.target<gfx1200> @target
+kernel.def target(@target) @prefetch_workitem_dropped() {
+  %c1 = index.constant 1 : index
+  %c64 = index.constant 64 : index
+  kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
+} launch(%input: buffer) {
+  %tid0 = kernel.workitem.id<x> : index
+  %tid = index.assume %tid0 [range(%tid0, 0, 63)] : index
+  %zero = index.constant 0 : offset
+  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  // REMARK@+1: BACKEND/041 "dropped prefetch 'read/l1'" "decision 'prefetch.dynamic_index'" "packet '<none>'" "count 0"
+  view.prefetch %input_view[%tid] {intent = read, locality = l1} : view<64xi32, #dense>
+  kernel.return
+}
+
+// ----
+low.kernel.def target(@target) workgroup_size(64, 1, 1) @prefetch_workitem_dropped() {
+  return
 }

--- a/loom/src/loom/target/low_legality.c
+++ b/loom/src/loom/target/low_legality.c
@@ -242,6 +242,72 @@ iree_status_t loom_target_low_legality_record_memory_access(
                                        params, IREE_ARRAYSIZE(params));
 }
 
+iree_status_t loom_target_low_legality_record_memory_cache_policy(
+    loom_target_low_legality_context_t* context, const loom_op_t* op,
+    iree_string_view_t memory_space, iree_string_view_t operation_kind,
+    iree_string_view_t cache_scope, iree_string_view_t cache_temporal,
+    iree_string_view_t decision_key, iree_string_view_t decision,
+    iree_string_view_t encoding_key, bool scope_attr_present,
+    int64_t scope_attr, bool th_attr_present, int64_t th_attr,
+    bool nt_attr_present, int64_t nt_attr) {
+  loom_diagnostic_param_t params[] = {
+      loom_param_string(
+          loom_target_low_legality_target_key(context->options->bundle)),
+      loom_param_string(
+          loom_target_low_legality_export_name(context->options->bundle)),
+      loom_param_string(
+          loom_target_low_legality_config_key(context->options->bundle)),
+      loom_param_string(loom_target_low_legality_function_name(context)),
+      loom_param_string(loom_op_name(context->module, op)),
+      loom_param_string(memory_space),
+      loom_param_string(operation_kind),
+      loom_param_string(cache_scope),
+      loom_param_string(cache_temporal),
+      loom_param_string(decision_key),
+      loom_param_string(decision),
+      loom_param_string(encoding_key),
+      loom_param_bool(scope_attr_present),
+      loom_param_i64(scope_attr),
+      loom_param_bool(th_attr_present),
+      loom_param_i64(th_attr),
+      loom_param_bool(nt_attr_present),
+      loom_param_i64(nt_attr),
+  };
+  return loom_target_low_legality_emit(context, op, LOOM_ERR_BACKEND_040,
+                                       params, IREE_ARRAYSIZE(params));
+}
+
+iree_status_t loom_target_low_legality_record_memory_prefetch(
+    loom_target_low_legality_context_t* context, const loom_op_t* op,
+    iree_string_view_t memory_space, iree_string_view_t prefetch_intent,
+    iree_string_view_t prefetch_locality, iree_string_view_t decision_key,
+    iree_string_view_t decision, iree_string_view_t packet_key,
+    int64_t immediate_offset, uint32_t scalar_byte_offset,
+    iree_string_view_t dynamic_index_kind, uint32_t count) {
+  loom_diagnostic_param_t params[] = {
+      loom_param_string(
+          loom_target_low_legality_target_key(context->options->bundle)),
+      loom_param_string(
+          loom_target_low_legality_export_name(context->options->bundle)),
+      loom_param_string(
+          loom_target_low_legality_config_key(context->options->bundle)),
+      loom_param_string(loom_target_low_legality_function_name(context)),
+      loom_param_string(loom_op_name(context->module, op)),
+      loom_param_string(memory_space),
+      loom_param_string(prefetch_intent),
+      loom_param_string(prefetch_locality),
+      loom_param_string(decision_key),
+      loom_param_string(decision),
+      loom_param_string(packet_key),
+      loom_param_i64(immediate_offset),
+      loom_param_u32(scalar_byte_offset),
+      loom_param_string(dynamic_index_kind),
+      loom_param_u32(count),
+  };
+  return loom_target_low_legality_emit(context, op, LOOM_ERR_BACKEND_041,
+                                       params, IREE_ARRAYSIZE(params));
+}
+
 const loom_module_t* loom_target_low_legality_module(
     const loom_target_low_legality_context_t* context) {
   return context->module;

--- a/loom/src/loom/target/low_legality.h
+++ b/loom/src/loom/target/low_legality.h
@@ -40,8 +40,8 @@ typedef struct loom_local_value_domain_t loom_local_value_domain_t;
 typedef struct loom_view_region_table_t loom_view_region_table_t;
 
 typedef enum loom_target_low_legality_diagnostic_flag_bits_e {
-  // Emit target memory-access selection remarks from providers that support
-  // them.
+  // Emit target source-memory decision remarks from providers that support
+  // them, including access, cache-policy, and prefetch selection.
   LOOM_TARGET_LOW_LEGALITY_DIAGNOSTIC_MEMORY_ACCESS = 1u << 0,
   // All target-low legality diagnostic flags known to this header.
   LOOM_TARGET_LOW_LEGALITY_DIAGNOSTIC_ALL =
@@ -241,6 +241,25 @@ iree_status_t loom_target_low_legality_record_memory_access(
     uint32_t dynamic_stride_bytes, uint32_t vector_lane_stride_bytes,
     uint32_t bank_stride_words, uint32_t bank_conflict_degree,
     iree_string_view_t bank_conflict_kind);
+
+// Emits ERR_BACKEND_040 for a source memory cache-policy decision.
+iree_status_t loom_target_low_legality_record_memory_cache_policy(
+    loom_target_low_legality_context_t* context, const loom_op_t* op,
+    iree_string_view_t memory_space, iree_string_view_t operation_kind,
+    iree_string_view_t cache_scope, iree_string_view_t cache_temporal,
+    iree_string_view_t decision_key, iree_string_view_t decision,
+    iree_string_view_t encoding_key, bool scope_attr_present,
+    int64_t scope_attr, bool th_attr_present, int64_t th_attr,
+    bool nt_attr_present, int64_t nt_attr);
+
+// Emits ERR_BACKEND_041 for a source memory prefetch decision.
+iree_status_t loom_target_low_legality_record_memory_prefetch(
+    loom_target_low_legality_context_t* context, const loom_op_t* op,
+    iree_string_view_t memory_space, iree_string_view_t prefetch_intent,
+    iree_string_view_t prefetch_locality, iree_string_view_t decision_key,
+    iree_string_view_t decision, iree_string_view_t packet_key,
+    int64_t immediate_offset, uint32_t scalar_byte_offset,
+    iree_string_view_t dynamic_index_kind, uint32_t count);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
Add structured backend remarks for source memory cache-policy and prefetch decisions at the target-low legality boundary. The shared legality helpers carry stable target/export/function/op fields plus target-owned decision keys and concrete encoding values, so diagnostics and jsonl reports can explain selected, rejected, and dropped outcomes without scraping lowered IR.

AMDGPU now records selected and rejected cache-policy encodings, selected prefetch packet choices, and dropped prefetch hints. Resultless hint ops that no target selects are represented as elided source-to-low plans, preserving the contract that view.prefetch is discardable while still letting diagnostics report why a backend declined to lower it.