### PR TITLE
Fix libamdhip64 link: stage version script via additional_linker_inputs

### DIFF
--- a/build_tools/bazel/cc.bzl
+++ b/build_tools/bazel/cc.bzl
@@ -141,6 +141,10 @@ iree_cc_binary = macro(
         cc_attrs.binary_source,
         cc_attrs.link,
         {
+            "additional_linker_inputs": attr.label_list(
+                allow_files = True,
+                doc = "Extra files made available to the link action, such as linker version scripts referenced from linkopts.",
+            ),
             "args": attr.string_list(
                 doc = "Command-line arguments used when this binary is run by Bazel.",
             ),

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -382,7 +382,7 @@ class BuildFileFunctions(object):
         return deps_block, var_block
 
     def _convert_platform_select_strings(
-        self, name, block_name, values, quote=True, sort=False
+        self, name, block_name, values, quote=True, sort=False, expand_locations=False
     ):
         """Handles string lists that may contain ConditionSelect entries.
 
@@ -390,12 +390,21 @@ class BuildFileFunctions(object):
         MixedDeps or ConditionSelect, emits a CMake list variable with
         if/elseif/else blocks before the target and returns the normal argument
         block with an additional variable reference.
+
+        When expand_locations is set, $(location ...) make-variables in each
+        string are expanded so flags such as
+        -Wl,--version-script=$(location :foo.map) resolve under CMake. A
+        same-package source file resolves to ${CMAKE_CURRENT_SOURCE_DIR}/<name>,
+        which is correct even when the target lives in a CMake sub-project whose
+        PROJECT_SOURCE_DIR is not the repo root.
         """
         if values is None:
             return self._convert_string_list_block(block_name, None), ""
         if isinstance(values, ConditionSelect):
             values = MixedDeps(unconditional=[], selects=[values])
         if not isinstance(values, MixedDeps):
+            if expand_locations:
+                values = self._convert_linkopt_location_args(values)
             return self._convert_string_list_block(
                 block_name, values, quote=quote, sort=sort
             ), ""
@@ -420,6 +429,10 @@ class BuildFileFunctions(object):
                 var_block += f"{keyword}({cond})\n"
                 if sort:
                     selected_values = sorted(selected_values)
+                if expand_locations:
+                    selected_values = self._convert_linkopt_location_args(
+                        selected_values
+                    )
                 for value in selected_values:
                     var_block += append_value(value)
                 first = False
@@ -428,6 +441,8 @@ class BuildFileFunctions(object):
                 var_block += "else()\n"
                 if sort:
                     default_values = sorted(default_values)
+                if expand_locations:
+                    default_values = self._convert_linkopt_location_args(default_values)
                 for value in default_values:
                     var_block += append_value(value)
             var_block += "endif()\n"
@@ -435,6 +450,8 @@ class BuildFileFunctions(object):
         unconditional = values.unconditional
         if sort:
             unconditional = sorted(unconditional)
+        if expand_locations:
+            unconditional = self._convert_linkopt_location_args(unconditional)
         string_block = self._convert_string_list_block(
             block_name, unconditional, quote=quote, sort=False
         )
@@ -575,6 +592,30 @@ class BuildFileFunctions(object):
         converted_args = []
         for arg in args:
             converted_args.extend(self._convert_location_arg(arg))
+        return converted_args
+
+    def _convert_linkopt_location_arg(self, arg):
+        # Linkopts such as -Wl,--version-script=$(location :foo.map) must resolve
+        # to a path the linker can open at link time. A same-package source file
+        # maps to ${CMAKE_CURRENT_SOURCE_DIR}/<name>, which is correct regardless
+        # of the enclosing CMake project root -- unlike ${PROJECT_SOURCE_DIR},
+        # which is the repo root only for the top-level project and not for
+        # sub-projects such as libhrx.
+        def replace_location(match):
+            label = match.group(2)
+            package, name = self._split_location_label(label)
+            if package == self._current_package():
+                return f"${{CMAKE_CURRENT_SOURCE_DIR}}/{name}"
+            return " ".join(self._cmake_location_paths(label))
+
+        return [_LOCATION_PATTERN.sub(replace_location, arg)]
+
+    def _convert_linkopt_location_args(self, args):
+        if args is None:
+            return None
+        converted_args = []
+        for arg in args:
+            converted_args.extend(self._convert_linkopt_location_arg(arg))
         return converted_args
 
     def _convert_native_test_location_arg(self, arg):
@@ -1520,7 +1561,7 @@ class BuildFileFunctions(object):
         alwayslink_block = self._convert_option_block("ALWAYSLINK", alwayslink)
         shared_block = self._convert_option_block("SHARED", shared)
         linkopts_block, platform_linkopts_block = self._convert_platform_select_strings(
-            name, "LINKOPTS", linkopts
+            name, "LINKOPTS", linkopts, expand_locations=True
         )
         includes_block = self._convert_includes_block(includes)
         system_includes_block = self._convert_string_list_block(
@@ -1679,7 +1720,7 @@ class BuildFileFunctions(object):
             name, "DEFINES", defines
         )
         linkopts_block, platform_linkopts_block = self._convert_platform_select_strings(
-            name, "LINKOPTS", linkopts
+            name, "LINKOPTS", linkopts, expand_locations=True
         )
         srcs_block = self._convert_srcs_block(srcs)
         data_block = self._convert_target_list_block("DATA", data)
@@ -1757,7 +1798,7 @@ class BuildFileFunctions(object):
             name, "DEFINES", defines
         )
         linkopts_block, platform_linkopts_block = self._convert_platform_select_strings(
-            name, "LINKOPTS", linkopts
+            name, "LINKOPTS", linkopts, expand_locations=True
         )
         labels_block = self._convert_string_list_block("LABELS", tags)
 

--- a/build_tools/bazel_to_cmake/config_test.py
+++ b/build_tools/bazel_to_cmake/config_test.py
@@ -238,6 +238,35 @@ class ConfigTest(unittest.TestCase):
         self.assertIn("  TESTONLY\n", converter.body)
         self.assertIn("iree::hal::local::executable_library", converter.body)
 
+    def test_cc_library_linkopts_expand_location_make_variables(self):
+        converter = SimpleNamespace(body="")
+        functions = bazel_to_cmake_converter.BuildFileFunctions(
+            converter=converter,
+            targets=bazel_to_cmake_targets.TargetConverter(repo_map={"@iree": ""}),
+            build_dir="libhrx/src/binding/hip",
+        )
+
+        functions.cc_library(
+            name="amdhip64",
+            srcs=["api.c"],
+            linkopts=[
+                "-Wl,--undefined-version",
+                "-Wl,--version-script=$(location :amdhip64.map)",
+            ],
+            shared=True,
+        )
+
+        self.assertIn("  LINKOPTS\n", converter.body)
+        self.assertIn("-Wl,--undefined-version", converter.body)
+        # A same-package $(location ...) resolves to a current-source-dir path
+        # (correct even in a CMake sub-project), not a literal make-variable nor
+        # a ${PROJECT_SOURCE_DIR} path relative to the repo root.
+        self.assertNotIn("$(location", converter.body)
+        self.assertIn(
+            "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/amdhip64.map",
+            converter.body,
+        )
+
     def test_c_embed_data_srcs_can_reference_generated_targets(self):
         repo_root = Path(__file__).resolve().parents[2]
         converter = SimpleNamespace(body="")

--- a/libhrx/src/binding/hip/BUILD.bazel
+++ b/libhrx/src/binding/hip/BUILD.bazel
@@ -19,6 +19,7 @@ hrx_cc_shared_library(
         "api.c",
     ],
     hdrs = ["api.h"],
+    additional_linker_inputs = ["amdhip64.map"],
     copts = [
         "-DIREE_HAL_STREAMING_HIP_EXPORTS",
         "-Wno-attributes",
@@ -29,14 +30,13 @@ hrx_cc_shared_library(
         "../../../include",
         "../../libhrx",
     ],
+    linkopts = [
+        "-Wl,--undefined-version",
+        "-Wl,--version-script=$(location :amdhip64.map)",
+    ],
     deps = [
         "//libhrx/src/binding/common",
         "//runtime/src/iree/base",
         "//runtime/src/iree/hal",
-    ],
-    data = ["amdhip64.map"],
-    linkopts = [
-        "-Wl,--undefined-version",
-        "-Wl,--version-script=$(location :amdhip64.map)",
     ],
 )

--- a/libhrx/src/binding/hip/CMakeLists.txt
+++ b/libhrx/src/binding/hip/CMakeLists.txt
@@ -27,6 +27,9 @@ iree_cc_library(
     libhrx::src::binding::common
     libhrx_defs
   SHARED
+  LINKOPTS
+    "-Wl,--undefined-version"
+    "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/amdhip64.map"
   INCLUDES
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>"
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../..>"
@@ -39,13 +42,15 @@ iree_cc_library(
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
 
+# The symbol version script and --undefined-version are applied through the
+# generated LINKOPTS above (from linkopts in BUILD.bazel). Keep them out of
+# LINK_FLAGS here so the version script is not applied twice.
 set_target_properties(libhrx_src_binding_hip_amdhip64 PROPERTIES
   OUTPUT_NAME amdhip64
   VERSION 7.9999.0
   SOVERSION 7
   POSITION_INDEPENDENT_CODE ON
   INSTALL_RPATH "$ORIGIN"
-  LINK_FLAGS "-Wl,--undefined-version -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/amdhip64.map"
 )
 
 install(TARGETS libhrx_src_binding_hip_amdhip64


### PR DESCRIPTION
## Problem

The `Linux / AMDGPU Build + Host Tests` job on #86 fails at **Build libhrx** when linking `libamdhip64.so`:

```
ld.lld: error: cannot find version script libhrx/src/binding/hip/amdhip64.map
clang-23: error: linker command failed with exit code 1
```

(Failing run: https://github.com/ROCm/hrx-system/actions/runs/27438641025/job/81106895407)

## Fix 1 — Bazel link (`additional_linker_inputs`)

The version script was wired through `data`, which only populates **runfiles** and is not an input to the link action. Under the sandbox the `CppLink` action never sees `amdhip64.map`, so `ld.lld` can't open it (`$(location ...)` still resolves the path, which is why the flag is correct but the file is absent).

Stage it through `additional_linker_inputs` instead. The `iree_cc_binary` symbolic macro didn't expose that attribute (its link-attr group is only `linkopts` + `linkstatic`), so this adds it to the macro schema; it forwards through `**kwargs` → rules_cc `cc_binary`, which stages it into the link.

## Fix 2 — `bazel_to_cmake` so the generated CMake matches (addresses review)

`bazel_to_cmake` mirrored `linkopts` verbatim, so the generated CMake `LINKOPTS` kept the Bazel `$(location :amdhip64.map)` make-variable, which CMake can't expand. The hand-written `LINK_FLAGS` worked around it, leaving the autogen block out of sync (the `[fail] Bazel-to-CMake` presubmit).

The converter now expands `$(location ...)` in `linkopts`: a same-package source file resolves to `${CMAKE_CURRENT_SOURCE_DIR}/<name>`, which is correct regardless of the enclosing CMake project root. (The general location machinery uses `${PROJECT_SOURCE_DIR}/<repo-package>`, which is the repo root only for the top-level project — for the `libhrx` **sub-project** `PROJECT_SOURCE_DIR` is `<repo>/libhrx`, so that form would double the path.) `libhrx/src/binding/hip/CMakeLists.txt` is regenerated so the autogen `LINKOPTS` carries `${CMAKE_CURRENT_SOURCE_DIR}/amdhip64.map`, and the now-redundant hand-written `LINK_FLAGS` is dropped so the version script isn't applied twice. Added a converter unit test.

## Verification

- `bazel query` loads the target and all `//libhrx/...` cc targets (macro accepts the new attribute; no sibling breakage).
- Converter unit tests pass (incl. the new one); `ruff` clean; repo-wide `bazel_to_cmake.py --check` reports 0 files to update (blast radius limited to the hip target).
- The generated `LINKOPTS` path is byte-identical to the version-script flag that already builds today — applied via `target_link_options` instead of `LINK_FLAGS`. CI's CMake jobs validate the regenerated link end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
