### PR TITLE
Make core HRX build helpers Windows-safe

### DIFF
--- a/build_tools/bazel_to_cmake/config_test.py
+++ b/build_tools/bazel_to_cmake/config_test.py
@@ -371,6 +371,35 @@ class ConfigTest(unittest.TestCase):
                 deps=[],
             )
 
+    def test_runtime_generated_files_use_discovered_python_interpreter(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        runtime = bazel_to_cmake_config.include_project(
+            str(repo_root / ".bazel_to_cmake.cfg.py"),
+            "runtime/.bazel_to_cmake.cfg.py",
+        )
+        converter = SimpleNamespace(body="")
+        functions = runtime.build_file_functions(
+            converter=converter,
+            targets=bazel_to_cmake_targets.TargetConverter(repo_map={"@iree": ""}),
+            build_dir=str(repo_root / "runtime/src/iree/vm/bytecode/isa"),
+            repo_root=str(repo_root),
+        )
+
+        functions.iree_generated_files(
+            name="op_table_gen",
+            srcs=["isa.json"],
+            outs=["op_table.h"],
+            args=["--schema", "$(location isa.json)"],
+            output_args={"op_table.h": "--op-table"},
+            tool=":generate_vm_isa",
+        )
+
+        self.assertIn(
+            "${Python3_EXECUTABLE} $(rootpath generate_vm_isa.py)",
+            converter.body,
+        )
+        self.assertNotIn("python3 $(rootpath generate_vm_isa.py)", converter.body)
+
     def test_requirement_policy_loads_cross_project_requirement_defs(self):
         repo_root = Path(__file__).resolve().parents[2]
         policy = bazel_to_cmake_requirements.load_project_policy(

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -402,8 +402,6 @@ iree_select_compiler_opts(IREE_DEFAULT_LINKOPTS
   CLANG_OR_GCC
     ${_IREE_MATH_LINKOPTS}
     ${_IREE_LOGGING_LINKOPTS}
-  MSVC
-    "-natvis:${IREE_ROOT_DIR}/runtime/iree.natvis"
 )
 
 if(EMSCRIPTEN AND IREE_EXTERNAL_WEBGPU_HAL_DRIVER_FOUND)

--- a/libhrx/cts/core/hrx_loader.cpp
+++ b/libhrx/cts/core/hrx_loader.cpp
@@ -55,8 +55,7 @@ void HrxLoader::load(const std::string& path) {
 #define LOAD(name) name = (decltype(name))loadSymbol("hrx_" #name)
 #define LOAD_FULL(field, sym) field = (decltype(field))loadSymbol(#sym)
 
-  host_allocator_system_ptr =
-      (hrx_host_allocator_t*)loadSymbol("hrx_host_allocator_system_value");
+  LOAD_FULL(host_allocator_system_fn, hrx_host_allocator_system);
 
   LOAD(host_allocator_malloc);
   LOAD(host_allocator_malloc_uninitialized);

--- a/libhrx/cts/core/hrx_loader.hpp
+++ b/libhrx/cts/core/hrx_loader.hpp
@@ -22,10 +22,10 @@ class HrxLoader {
   static HrxLoader& instance();
   static void setLibraryPath(const std::string& path);
 
-  // Host allocator. system_value is a data symbol loaded via dlsym.
-  hrx_host_allocator_t* host_allocator_system_ptr;
+  // Host allocator.
+  decltype(&hrx_host_allocator_system) host_allocator_system_fn;
   hrx_host_allocator_t host_allocator_system() {
-    return *host_allocator_system_ptr;
+    return host_allocator_system_fn();
   }
 
   decltype(&hrx_host_allocator_malloc) host_allocator_malloc;

--- a/libhrx/include/hrx_runtime.h
+++ b/libhrx/include/hrx_runtime.h
@@ -16,7 +16,11 @@ extern "C" {
 // Export macros
 //===----------------------------------------------------------------------===//
 
-#if defined(HRX_BUILDING_SHARED)
+#if defined(_WIN32) && defined(HRX_BUILDING_SHARED)
+#define HRX_API __declspec(dllexport)
+#elif defined(_WIN32) && !defined(HRX_STATIC)
+#define HRX_API __declspec(dllimport)
+#elif defined(HRX_BUILDING_SHARED)
 #define HRX_API __attribute__((visibility("default")))
 #elif defined(HRX_STATIC)
 #define HRX_API
@@ -38,14 +42,9 @@ typedef struct hrx_host_allocator_t {
   void* ctl;
 } hrx_host_allocator_t;
 
-// Pre-initialized system allocator. Valid as soon as libhrx.so is loaded
-// (no hrx_*_initialize() required). On ELF this is a direct data export;
-// Windows will need __declspec(dllimport) when we get there.
-HRX_API extern hrx_host_allocator_t hrx_host_allocator_system_value;
-
-static inline hrx_host_allocator_t hrx_host_allocator_system(void) {
-  return hrx_host_allocator_system_value;
-}
+// Returns the process-wide system allocator. Valid as soon as libhrx is loaded
+// (no hrx_*_initialize() required).
+HRX_API hrx_host_allocator_t hrx_host_allocator_system(void);
 
 //===----------------------------------------------------------------------===//
 // Version

--- a/libhrx/src/libhrx/CMakeLists.txt
+++ b/libhrx/src/libhrx/CMakeLists.txt
@@ -104,10 +104,14 @@ set_target_properties(libhrx_src_libhrx_hrx PROPERTIES
   VERSION ${PROJECT_VERSION}
   SOVERSION 0
   EXPORT_NAME hrx
-  C_VISIBILITY_PRESET hidden
   POSITION_INDEPENDENT_CODE ON
-  LINK_FLAGS "-Wl,--version-script=${LIBHRX_SOURCE_DIR}/cmake/hrx_exports.lds"
 )
+if(NOT WIN32)
+  set_target_properties(libhrx_src_libhrx_hrx PROPERTIES
+    C_VISIBILITY_PRESET hidden
+    LINK_FLAGS "-Wl,--version-script=${LIBHRX_SOURCE_DIR}/cmake/hrx_exports.lds"
+  )
+endif()
 set_property(TARGET libhrx_src_libhrx_hrx PROPERTY
   INTERFACE_LINK_LIBRARIES ""
 )

--- a/libhrx/src/libhrx/host_allocator.c
+++ b/libhrx/src/libhrx/host_allocator.c
@@ -10,21 +10,22 @@ _Static_assert(sizeof(hrx_host_allocator_t) == sizeof(iree_allocator_t),
 _Static_assert(_Alignof(hrx_host_allocator_t) == _Alignof(iree_allocator_t),
                "host allocator alignment mismatch");
 
-// Initialized before main() via constructor. iree_allocator_system() is
-// safe to call at load time (it's an inline returning two constants).
-hrx_host_allocator_t hrx_host_allocator_system_value;
-
-__attribute__((constructor)) static void hrx_host_allocator_init(void) {
-  iree_allocator_t sys = iree_allocator_system();
-  hrx_host_allocator_system_value.self = sys.self;
-  hrx_host_allocator_system_value.ctl = (void*)sys.ctl;
+// Type-pun allocator values. Both are two-word structs {self, ctl} with
+// identical layout, but HRX keeps the control pointer opaque in the public API.
+static inline hrx_host_allocator_t iree_to_hrx_allocator(iree_allocator_t a) {
+  hrx_host_allocator_t v;
+  memcpy(&v, &a, sizeof(v));
+  return v;
 }
 
-// Type-pun hrx_host_allocator_t to iree_allocator_t.
 static inline iree_allocator_t hrx_to_iree_allocator(hrx_host_allocator_t a) {
   iree_allocator_t v;
   memcpy(&v, &a, sizeof(v));
   return v;
+}
+
+hrx_host_allocator_t hrx_host_allocator_system(void) {
+  return iree_to_hrx_allocator(iree_allocator_system());
 }
 
 //===----------------------------------------------------------------------===//

--- a/runtime/.bazel_to_cmake.cfg.py
+++ b/runtime/.bazel_to_cmake.cfg.py
@@ -111,7 +111,7 @@ class RuntimeBuildFileFunctions(bazel_to_cmake_converter.BuildFileFunctions):
     def iree_generated_files(self, name, srcs, outs, args, output_args, tool, **kwargs):
         if tool != ":generate_vm_isa":
             raise NotImplementedError(f"iree_generated_files tool: {tool}")
-        cmd_parts = ["python3 $(rootpath generate_vm_isa.py)"]
+        cmd_parts = ["${Python3_EXECUTABLE} $(rootpath generate_vm_isa.py)"]
         cmd_parts.extend(arg.replace("$(location ", "$(rootpath ") for arg in args)
         for out in outs:
             cmd_parts.extend([output_args[out], f"$(execpath {out})"])

--- a/runtime/src/iree/vm/bytecode/isa/CMakeLists.txt
+++ b/runtime/src/iree/vm/bytecode/isa/CMakeLists.txt
@@ -18,7 +18,7 @@ iree_genrule(
   OUTS
     op_table.h
   CMD
-    "python3 $(rootpath generate_vm_isa.py) --schema $(rootpath isa.json) --op-table $(execpath op_table.h)"
+    "${Python3_EXECUTABLE} $(rootpath generate_vm_isa.py) --schema $(rootpath isa.json) --op-table $(execpath op_table.h)"
 )
 
 iree_genrule(
@@ -31,7 +31,7 @@ iree_genrule(
     encoding_table.c
     encoding_table.h
   CMD
-    "python3 $(rootpath generate_vm_isa.py) --schema $(rootpath isa.json) --encoding-table-source $(execpath encoding_table.c) --encoding-table-header $(execpath encoding_table.h)"
+    "${Python3_EXECUTABLE} $(rootpath generate_vm_isa.py) --schema $(rootpath isa.json) --encoding-table-source $(execpath encoding_table.c) --encoding-table-header $(execpath encoding_table.h)"
 )
 
 iree_cc_library(


### PR DESCRIPTION
Submits parts of https://github.com/ROCm/hrx-system/pull/37 needed to enable a Windows build.

Changes:

- Export HRX public API symbols with `__declspec(dllexport/dllimport)` on Windows while preserving `HRX_STATIC` for static builds.
- Replace the exported `hrx_host_allocator_system_value` data symbol with a `hrx_host_allocator_system()` function. This avoids Windows DLL data import/export pitfalls and removes the GCC-only constructor.
- Update the CTS dynamic loader to resolve `hrx_host_allocator_system` as a function instead of looking up the old allocator data symbol.
- Apply ELF hidden-visibility and `-Wl,--version-script` link flags only on non-Windows platforms, since MSVC/link.exe does not support them.
- Remove the MSVC natvis link option as `runtime/iree.natvis` doesn't exist, so reduced/embedded HRX layouts do not reference a missing debugger file.
- Use CMake's discovered `${Python3_EXECUTABLE}` in VM bytecode ISA genrules instead of assuming a `python3` executable is on Windows `PATH`.