### PR TITLE
[HAL/AMDGPU] Fix ASAN pinned-host pool selection

### DIFF
--- a/.github/workflows/ci_core_linux.yml
+++ b/.github/workflows/ci_core_linux.yml
@@ -118,7 +118,7 @@ jobs:
             chip: gfx1201
             runner_label: gpu_navi4x
             ctest_exclude_regex: ""
-            experimental: true
+            experimental: false
     uses: ./.github/workflows/test_core_linux_gpu.yml
     permissions:
       actions: read

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -417,6 +417,19 @@ static hipError_t iree_status_to_fixed_hip_result(iree_status_t status,
   return error;
 }
 
+static hipError_t iree_module_status_to_hip_result(iree_status_t status) {
+  if (iree_status_is_ok(status)) {
+    return hipSuccess;
+  }
+
+  const iree_status_code_t code = iree_status_code(status);
+  if (code == IREE_STATUS_INCOMPATIBLE) {
+    iree_status_free(status);
+    return hipErrorNoBinaryForGpu;
+  }
+  return iree_status_to_hip_result(status);
+}
+
 static hipError_t hrx_status_to_hip_result(hrx_status_t status) {
   if (hrx_status_is_ok(status)) {
     return hipSuccess;
@@ -6747,6 +6760,7 @@ HIPAPI hipError_t hipEventElapsedTime(float* ms, hipEvent_t start,
 //  - hipErrorInvalidContext: No active HIP context.
 //  - hipErrorFileNotFound: Module file does not exist.
 //  - hipErrorInvalidImage: File is not a valid module format.
+//  - hipErrorNoBinaryForGpu: Module has no binary for the current device.
 //  - hipErrorNotInitialized: HIP runtime not initialized.
 //  - hipErrorOutOfMemory: Insufficient memory to load module.
 //
@@ -6794,7 +6808,7 @@ HIPAPI hipError_t hipModuleLoad(hipModule_t* module, const char* fname) {
     *module = (hipModule_t)stream_module;
   }
 
-  hipError_t result = iree_status_to_hip_result(status);
+  hipError_t result = iree_module_status_to_hip_result(status);
   IREE_TRACE_ZONE_END(z0);
   return result;
 }
@@ -6810,6 +6824,7 @@ HIPAPI hipError_t hipModuleLoad(hipModule_t* module, const char* fname) {
 //  - hipErrorInvalidValue: module or image is NULL.
 //  - hipErrorInvalidContext: No active HIP context.
 //  - hipErrorInvalidImage: Data is not a valid module format.
+//  - hipErrorNoBinaryForGpu: Module has no binary for the current device.
 //  - hipErrorNotInitialized: HIP runtime not initialized.
 //  - hipErrorOutOfMemory: Insufficient memory to load module.
 //
@@ -6988,7 +7003,7 @@ HIPAPI hipError_t hipModuleLoadDataEx(hipModule_t* module, const void* image,
     fflush(stderr);
   }
 
-  hipError_t result = iree_status_to_hip_result(status);
+  hipError_t result = iree_module_status_to_hip_result(status);
   IREE_TRACE_ZONE_END(z0);
   return result;
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
@@ -86,6 +86,24 @@ static iree_hal_device_asan_spec_t QueryAsanSpec(iree_hal_device_t* device) {
   return sanitizer->asan;
 }
 
+static iree_hal_amdgpu_shadow_map_slab_t* FindShadowMapSlab(
+    iree_hal_amdgpu_shadow_map_t* shadow_map, uint64_t slab_index) {
+  for (iree_host_size_t i = 0; i < shadow_map->slab_count; ++i) {
+    if (shadow_map->slabs[i].index == slab_index) {
+      return &shadow_map->slabs[i];
+    }
+  }
+  return nullptr;
+}
+
+static iree_device_size_t OversizedAllocationSize(
+    const iree_hal_amdgpu_logical_device_t* logical_device) {
+  const iree_device_size_t tlsf_range_length =
+      logical_device->physical_devices[0]
+          ->default_pool_options.tlsf_options.range_length;
+  return tlsf_range_length + 1;
+}
+
 class AllocatorTest : public ::testing::Test {
  protected:
   class HsaAllocation {
@@ -300,16 +318,20 @@ TEST_F(AllocatorTest, AsanHostLocalShadowBackingMapsPinnedHostSlabs) {
   EXPECT_EQ(shadow_map->hsa.memory_pool.handle,
             test_device.logical_device()
                 ->physical_devices[0]
-                ->host_memory_pools.fine_pool.handle);
+                ->coarse_block_pools.large.memory_pool.handle);
 
+  const iree_host_size_t initial_slab_count = shadow_map->slab_count;
   IREE_ASSERT_OK(iree_hal_amdgpu_shadow_map_map_slab(shadow_map, 0));
-  ASSERT_EQ(shadow_map->slab_count, 1u);
-  EXPECT_EQ(shadow_map->slabs[0].index, 0u);
+  ASSERT_GE(shadow_map->slab_count, initial_slab_count);
+
+  iree_hal_amdgpu_shadow_map_slab_t* shadow_slab =
+      FindShadowMapSlab(shadow_map, 0);
+  ASSERT_NE(shadow_slab, nullptr);
 
   constexpr uint8_t kHeapRedzoneShadowValue = 0xFAu;
   uint8_t shadow_byte = 0;
   IREE_ASSERT_OK(iree_hsa_memory_copy(IREE_LIBHSA(&libhsa_), &shadow_byte,
-                                      shadow_map->slabs[0].base_ptr,
+                                      shadow_slab->base_ptr,
                                       sizeof(shadow_byte)));
   EXPECT_EQ(shadow_byte, kHeapRedzoneShadowValue);
 }
@@ -384,6 +406,7 @@ TEST_F(AllocatorTest, AsanDiagnosticsExposeDefaultQuarantineRetention) {
   iree_hal_amdgpu_logical_device_options_t options;
   iree_hal_amdgpu_logical_device_options_initialize(&options);
   options.asan.enabled = 1;
+  options.default_pool.range_length = 4096;
 
   TestLogicalDevice test_device;
   IREE_ASSERT_OK(test_device.InitializeWithOptions(
@@ -398,8 +421,9 @@ TEST_F(AllocatorTest, AsanDiagnosticsExposeDefaultQuarantineRetention) {
       QueryAsanObservation(test_device.device());
   EXPECT_EQ(asan.quarantine_size, 0u);
   EXPECT_EQ(asan.quarantine_eviction_count, 0u);
-  EXPECT_EQ(asan.shadow_mapped_slab_count, 0u);
-  EXPECT_EQ(asan.shadow_committed_size, 0u);
+  const uint64_t initial_shadow_mapped_slab_count =
+      asan.shadow_mapped_slab_count;
+  const uint64_t initial_shadow_committed_size = asan.shadow_committed_size;
 
   iree_hal_buffer_params_t params = {0};
   params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
@@ -409,16 +433,17 @@ TEST_F(AllocatorTest, AsanDiagnosticsExposeDefaultQuarantineRetention) {
 
   iree_hal_buffer_t* buffer = nullptr;
   uint64_t ptr = 0;
-  IREE_ASSERT_OK(AllocateAndExportDevicePointer(test_device.allocator(), params,
-                                                /*allocation_size=*/4096,
-                                                &buffer, &ptr));
+  const iree_device_size_t allocation_size =
+      OversizedAllocationSize(test_device.logical_device());
+  IREE_ASSERT_OK(AllocateAndExportDevicePointer(
+      test_device.allocator(), params, allocation_size, &buffer, &ptr));
   iree_hal_buffer_release(buffer);
 
   asan = QueryAsanObservation(test_device.device());
   EXPECT_GT(asan.quarantine_size, 0u);
   EXPECT_EQ(asan.quarantine_eviction_count, 0u);
-  EXPECT_GT(asan.shadow_mapped_slab_count, 0u);
-  EXPECT_GT(asan.shadow_committed_size, 0u);
+  EXPECT_GE(asan.shadow_mapped_slab_count, initial_shadow_mapped_slab_count);
+  EXPECT_GE(asan.shadow_committed_size, initial_shadow_committed_size);
 }
 
 TEST_F(AllocatorTest, AsanDiagnosticsExposeZeroQuarantineRelease) {
@@ -426,6 +451,7 @@ TEST_F(AllocatorTest, AsanDiagnosticsExposeZeroQuarantineRelease) {
   iree_hal_amdgpu_logical_device_options_initialize(&options);
   options.asan.enabled = 1;
   options.asan.quarantine_size = 0;
+  options.default_pool.range_length = 4096;
 
   TestLogicalDevice test_device;
   IREE_ASSERT_OK(test_device.InitializeWithOptions(
@@ -434,6 +460,14 @@ TEST_F(AllocatorTest, AsanDiagnosticsExposeZeroQuarantineRelease) {
       QueryAsanSpec(test_device.device());
   EXPECT_EQ(asan_spec.pool_options.quarantine_size, 0u);
 
+  iree_hal_device_asan_observation_t asan =
+      QueryAsanObservation(test_device.device());
+  const uint64_t initial_quarantine_eviction_count =
+      asan.quarantine_eviction_count;
+  const uint64_t initial_shadow_mapped_slab_count =
+      asan.shadow_mapped_slab_count;
+  const uint64_t initial_shadow_committed_size = asan.shadow_committed_size;
+
   iree_hal_buffer_params_t params = {0};
   params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
   params.usage =
@@ -442,17 +476,18 @@ TEST_F(AllocatorTest, AsanDiagnosticsExposeZeroQuarantineRelease) {
 
   iree_hal_buffer_t* buffer = nullptr;
   uint64_t ptr = 0;
-  IREE_ASSERT_OK(AllocateAndExportDevicePointer(test_device.allocator(), params,
-                                                /*allocation_size=*/4096,
-                                                &buffer, &ptr));
+  const iree_device_size_t allocation_size =
+      OversizedAllocationSize(test_device.logical_device());
+  IREE_ASSERT_OK(AllocateAndExportDevicePointer(
+      test_device.allocator(), params, allocation_size, &buffer, &ptr));
   iree_hal_buffer_release(buffer);
 
-  const iree_hal_device_asan_observation_t asan =
-      QueryAsanObservation(test_device.device());
+  asan = QueryAsanObservation(test_device.device());
   EXPECT_EQ(asan.quarantine_size, 0u);
-  EXPECT_EQ(asan.quarantine_eviction_count, 1u);
-  EXPECT_GT(asan.shadow_mapped_slab_count, 0u);
-  EXPECT_GT(asan.shadow_committed_size, 0u);
+  EXPECT_EQ(asan.quarantine_eviction_count,
+            initial_quarantine_eviction_count + 1);
+  EXPECT_GE(asan.shadow_mapped_slab_count, initial_shadow_mapped_slab_count);
+  EXPECT_GE(asan.shadow_committed_size, initial_shadow_committed_size);
 }
 
 TEST_F(AllocatorTest, QueryMemoryHeapsReportsHsaLimits) {

--- a/runtime/src/iree/hal/drivers/amdgpu/api.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/api.h
@@ -118,10 +118,10 @@ typedef enum iree_hal_amdgpu_asan_shadow_backing_e {
   // device. This keeps instrumented shadow reads local to the GPU and is the
   // default production policy.
   IREE_HAL_AMDGPU_ASAN_SHADOW_BACKING_DEVICE_LOCAL = 0,
-  // Back shadow slabs with nearest-CPU fine-grained host memory mapped for the
-  // logical-device topology. Host-local shadow updates must happen before
-  // queue submissions whose dispatches read them, or after waited work retires
-  // before release poisoning mutates them.
+  // Back shadow slabs with pinned host memory mapped for the logical-device
+  // topology. Host-local shadow updates must happen before queue submissions
+  // whose dispatches read them, or after waited work retires before release
+  // poisoning mutates them.
   IREE_HAL_AMDGPU_ASAN_SHADOW_BACKING_HOST_LOCAL = 1,
 } iree_hal_amdgpu_asan_shadow_backing_t;
 

--- a/runtime/src/iree/hal/drivers/amdgpu/asan_state.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/asan_state.c
@@ -211,14 +211,15 @@ static iree_status_t iree_hal_amdgpu_asan_state_select_shadow_backing(
       }
       return iree_ok_status();
     case IREE_HAL_AMDGPU_ASAN_SHADOW_BACKING_HOST_LOCAL:
-      out_selection->memory_pool = physical_device->host_memory_pools.fine_pool;
+      out_selection->memory_pool =
+          physical_device->coarse_block_pools.large.memory_pool;
       out_selection->memory_type = IREE_HAL_AMDGPU_VMEM_MEMORY_TYPE_PINNED_HOST;
       out_selection->name = "host-local";
       if (IREE_UNLIKELY(!out_selection->memory_pool.handle)) {
         return iree_make_status(
             IREE_STATUS_FAILED_PRECONDITION,
-            "AMDGPU ASAN host-local shadow backing requires a fine-grained "
-            "host memory pool");
+            "AMDGPU ASAN host-local shadow backing requires a "
+            "coarse-grained device-local memory pool");
       }
       return iree_ok_status();
     default:

--- a/runtime/src/iree/hal/drivers/amdgpu/feedback_state.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/feedback_state.c
@@ -355,11 +355,12 @@ static iree_status_t iree_hal_amdgpu_feedback_state_initialize_device(
   }
 
   hsa_amd_memory_pool_t ring_memory_pool =
-      physical_device->fine_block_pools.large.memory_pool;
+      physical_device->coarse_block_pools.large.memory_pool;
   if (IREE_UNLIKELY(!ring_memory_pool.handle)) {
     return iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,
-        "AMDGPU feedback requires a device fine-grained ring memory pool");
+        "AMDGPU feedback requires a coarse-grained device-local ring memory "
+        "pool");
   }
 
   out_device_state->parent = state;

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
@@ -1079,6 +1079,7 @@ static iree_status_t iree_hal_amdgpu_physical_device_create_pool_pair(
             oversized_pool_trace_name,
             IREE_ARRAYSIZE(oversized_pool_trace_name), oversized_pool_name,
             physical_device->device_ordinal),
+        .asan = pool_options.asan,
     };
     status = iree_hal_passthrough_pool_create(
         oversized_pool_options, slab_provider,

--- a/runtime/src/iree/hal/drivers/amdgpu/util/feedback_channel.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/feedback_channel.h
@@ -26,7 +26,7 @@ typedef struct iree_hal_amdgpu_feedback_channel_params_t {
   hsa_agent_t device_agent;
   // CPU fine-grained memory pool used for the control block.
   hsa_amd_memory_pool_t control_memory_pool;
-  // Device fine-grained memory pool used for the pinned VMM packet ring.
+  // GPU global memory pool used to create the pinned VMM packet ring.
   hsa_amd_memory_pool_t ring_memory_pool;
   // Topology used to grant ring access to CPU and GPU agents.
   const iree_hal_amdgpu_topology_t* topology;
@@ -44,7 +44,7 @@ typedef struct iree_hal_amdgpu_feedback_channel_t {
   hsa_signal_t notify_signal;
   // Device-visible control block allocated from host fine-grained memory.
   iree_hal_amdgpu_feedback_channel_header_t* control;
-  // Mirrored VMM packet ring allocated from pinned device-visible memory.
+  // Mirrored VMM packet ring allocated from pinned host memory.
   iree_hal_amdgpu_vmem_ringbuffer_t ringbuffer;
 } iree_hal_amdgpu_feedback_channel_t;
 

--- a/runtime/src/iree/hal/drivers/amdgpu/util/feedback_channel_live_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/feedback_channel_live_test.cc
@@ -299,12 +299,8 @@ TEST_F(FeedbackChannelLiveTest, DeviceProducerSignalsHost) {
   IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
       &libhsa, cpu_agent, &control_memory_pool));
   hsa_amd_memory_pool_t ring_memory_pool = {};
-  bool ring_memory_pool_available = false;
-  IREE_ASSERT_OK(iree_hal_amdgpu_query_fine_global_memory_pool(
-      &libhsa, gpu_agent, &ring_memory_pool_available, &ring_memory_pool));
-  if (!ring_memory_pool_available) {
-    GTEST_SKIP() << "fine-grained GPU memory pool is not available";
-  }
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_coarse_global_memory_pool(
+      &libhsa, gpu_agent, &ring_memory_pool));
 
   iree_hal_amdgpu_feedback_channel_t channel = {};
   iree_hal_amdgpu_feedback_channel_params_t channel_params = {};

--- a/runtime/src/iree/hal/drivers/amdgpu/util/feedback_channel_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/feedback_channel_test.cc
@@ -81,13 +81,8 @@ class FeedbackChannelTest : public ::testing::Test {
   void SetUp() override {
     IREE_ASSERT_OK(iree_hal_amdgpu_find_fine_global_memory_pool(
         &libhsa, topology.cpu_agents[0], &control_memory_pool_));
-    bool ring_memory_pool_available = false;
-    IREE_ASSERT_OK(iree_hal_amdgpu_query_fine_global_memory_pool(
-        &libhsa, topology.gpu_agents[0], &ring_memory_pool_available,
-        &ring_memory_pool_));
-    if (!ring_memory_pool_available) {
-      GTEST_SKIP() << "fine-grained GPU memory pool is not available";
-    }
+    IREE_ASSERT_OK(iree_hal_amdgpu_find_coarse_global_memory_pool(
+        &libhsa, topology.gpu_agents[0], &ring_memory_pool_));
 
     iree_hal_amdgpu_feedback_channel_params_t params = {};
     params.libhsa = &libhsa;
@@ -109,7 +104,7 @@ class FeedbackChannelTest : public ::testing::Test {
   static iree_hal_amdgpu_topology_t topology;
   // CPU fine-grained pool used for the channel control block.
   hsa_amd_memory_pool_t control_memory_pool_ = {};
-  // Device fine-grained pool used for the pinned VMM packet ring.
+  // GPU global memory pool used to create the pinned VMM packet ring.
   hsa_amd_memory_pool_t ring_memory_pool_ = {};
   // Feedback channel under test.
   iree_hal_amdgpu_feedback_channel_t channel_ = {};

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem_test.cc
@@ -160,5 +160,30 @@ TEST_F(VMemTest, RingbufferWrap) {
   iree_hal_amdgpu_vmem_ringbuffer_deinitialize(&libhsa, &ringbuffer);
 }
 
+TEST_F(VMemTest, RingbufferPinnedHostWithCoarseDevicePool) {
+  IREE_TRACE_SCOPE();
+  ASSERT_GE(topology.gpu_agent_count, 1);
+
+  hsa_agent_t gpu_agent = topology.gpu_agents[0];
+  hsa_amd_memory_pool_t memory_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_coarse_global_memory_pool(
+      &libhsa, gpu_agent, &memory_pool));
+
+  const iree_device_size_t min_capacity = 1 * 1024 * 1024;
+  iree_hal_amdgpu_vmem_ringbuffer_t ringbuffer = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_vmem_ringbuffer_initialize_with_topology(
+      &libhsa, gpu_agent, memory_pool,
+      IREE_HAL_AMDGPU_VMEM_MEMORY_TYPE_PINNED_HOST, min_capacity, &topology,
+      IREE_HAL_AMDGPU_ACCESS_MODE_SHARED, &ringbuffer));
+
+  EXPECT_GE(ringbuffer.capacity, min_capacity);
+  EXPECT_EQ(ringbuffer.ring_base_ptr,
+            (uint8_t*)ringbuffer.va_base_ptr + ringbuffer.capacity);
+  EXPECT_TRUE(iree_device_size_has_alignment(
+      (iree_device_size_t)ringbuffer.ring_base_ptr, 64));
+
+  iree_hal_amdgpu_vmem_ringbuffer_deinitialize(&libhsa, &ringbuffer);
+}
+
 }  // namespace
 }  // namespace iree::hal::amdgpu


### PR DESCRIPTION
AMDGPU ASAN and feedback setup were requiring fine-grained GPU memory for paths that only need pinned host VMM backing. ROCR still needs a GPU global memory pool handle for pinned VMM handle creation, but that handle can come from the coarse device pool. This routes feedback rings and host-local ASAN shadow backing through the coarse pool while preserving CPU fine-grained memory for the feedback control block.

The default pool pair now carries ASAN policy into the oversized pass-through pool as well as TLSF, so large allocations keep redzones, shadow publication, and quarantine behavior instead of silently bypassing ASAN. The allocator tests now distinguish TLSF suballocation behavior from provider-level ASAN observation counters and explicitly probe pinned-host VMM ringbuffer creation with a coarse device pool.

HRX module loading now maps a HAL incompatible code-object result to hipErrorNoBinaryForGpu so HIP-style callers can distinguish a structurally valid image with no binary for the current device from an invalid image.

gfx1201 GPU CI is now required instead of experimental, so regressions on the Navi4x runner fail the PR visibly.

Fixes #106