### PR TITLE
[Infra/AMDGPU] Use default AMDGPU counters and harden toolchains

### DIFF
--- a/build_tools/amdgpu/README.md
+++ b/build_tools/amdgpu/README.md
@@ -125,6 +125,11 @@ repository. It is inert by default. A real producer is selected with:
 Useful path overrides include `IREE_HAL_AMDGPU_DEVICE_TOOLCHAIN_ROCM_PATH`,
 `IREE_HAL_AMDGPU_DEVICE_TOOLCHAIN_LLVM_TOOLS_DIR`, `IREE_ROCM_PATH`, and
 per-tool overrides such as `IREE_HAL_AMDGPU_DEVICE_TOOLCHAIN_CLANG_BINARY`.
+ROCm distributions may expose `clang`/`amdclang` launcher shims that exec a
+versioned driver next to their observed `argv[0]` path. The repository resolves
+those shims to the matching versioned driver before exposing a Bazel executable
+target, because Bazel wraps local tools through generated symlinks and must not
+change the driver's sibling lookup behavior.
 When the toolchain repository is inert, selected source-built binaries are
 incompatible instead of referencing missing tool labels.
 

--- a/build_tools/bazel/amdgpu_device_toolchain_repo.bzl
+++ b/build_tools/bazel/amdgpu_device_toolchain_repo.bzl
@@ -321,6 +321,31 @@ def _clang_tool_candidates(repository_ctx, clang, names):
             ])
     return candidates
 
+def _detect_clang_resource_dir(repository_ctx, clang):
+    result = repository_ctx.execute([clang, "-print-resource-dir"], quiet = True)
+    if result.return_code != 0:
+        fail("Failed to query clang resource directory from {}:\n{}".format(
+            clang,
+            result.stderr,
+        ))
+    resource_dir = result.stdout.strip()
+    if not resource_dir:
+        fail("clang resource directory query returned an empty path from {}".format(clang))
+    return resource_dir
+
+def _select_invocable_clang(repository_ctx, clang):
+    resource_dir = _detect_clang_resource_dir(repository_ctx, clang)
+    resource_version = _basename(resource_dir)
+    if not resource_version:
+        return clang
+    clang_basename = _basename(clang)
+    if clang_basename.endswith("-" + resource_version):
+        return clang
+    versioned_clang = _join_path(_dirname(clang), clang_basename + "-" + resource_version)
+    if _is_executable(repository_ctx, versioned_clang):
+        return str(repository_ctx.path(versioned_clang))
+    return clang
+
 def _detect_clang_resource_include(repository_ctx, clang):
     explicit = repository_ctx.getenv("IREE_HAL_AMDGPU_DEVICE_TOOLCHAIN_CLANG_RESOURCE_INCLUDE")
     if not explicit:
@@ -331,19 +356,19 @@ def _detect_clang_resource_include(repository_ctx, clang):
             fail("Configured clang resource include directory does not exist: {}".format(explicit))
         return str(path)
 
-    result = repository_ctx.execute([clang, "-print-resource-dir"], quiet = True)
-    if result.return_code != 0:
-        fail("Failed to query clang resource directory from {}:\n{}".format(
-            clang,
-            result.stderr,
-        ))
-    include_dir = _join_path(result.stdout.strip(), "include")
+    include_dir = _join_path(_detect_clang_resource_dir(repository_ctx, clang), "include")
     path = repository_ctx.path(include_dir)
     if not path.exists:
         fail("clang resource include directory does not exist: {}".format(include_dir))
     return str(path)
 
+def _validate_clang_resource_include(repository_ctx, clang_resource_include):
+    marker = _join_path(clang_resource_include, "stddef.h")
+    if not repository_ctx.path(marker).exists:
+        fail("clang resource include marker does not exist: {}".format(marker))
+
 def _write_local_toolchain_repo(repository_ctx, tools, clang_resource_include):
+    _validate_clang_resource_include(repository_ctx, clang_resource_include)
     repository_ctx.file("prebuilt_tool.bzl", _PREBUILT_TOOL_BZL)
     repository_ctx.file("bin/.keep", "")
     for name, path in tools.items():
@@ -381,6 +406,7 @@ def _amdgpu_device_toolchain_repo_impl(repository_ctx):
         ["IREE_HAL_AMDGPU_DEVICE_TOOLCHAIN_CLANG_BINARY", "IREE_CLANG_BINARY", "CLANG"],
         "clang with AMDGPU support",
     )
+    clang = _select_invocable_clang(repository_ctx, clang)
     llvm_ar = _find_tool(
         repository_ctx,
         ["llvm-ar"],

--- a/build_tools/scripts/BUILD.bazel
+++ b/build_tools/scripts/BUILD.bazel
@@ -4,6 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@rules_python//python:defs.bzl", "py_test")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
@@ -12,3 +14,13 @@ package(
 exports_files([
     "amdgpu_device_binaries.py",
 ])
+
+py_test(
+    name = "amdgpu_device_binaries_test",
+    srcs = [
+        "amdgpu_device_binaries.py",
+        "amdgpu_device_binaries_test.py",
+    ],
+    data = ["//build_tools/amdgpu:target_map.py"],
+    main = "amdgpu_device_binaries_test.py",
+)

--- a/build_tools/scripts/amdgpu_device_binaries.py
+++ b/build_tools/scripts/amdgpu_device_binaries.py
@@ -283,6 +283,26 @@ def run_capture(args: Sequence[str]) -> str:
     return result.stdout.strip()
 
 
+def clang_resource_dir(clang: Path) -> Path:
+    resource_dir = Path(run_capture([str(clang), "-print-resource-dir"]))
+    if not resource_dir.name:
+        raise RuntimeError(
+            f"clang resource directory query returned an empty path: {clang}"
+        )
+    return resource_dir
+
+
+def select_invocable_clang(clang: Path) -> Path:
+    resource_version = clang_resource_dir(clang).name
+    if clang.name.endswith(f"-{resource_version}"):
+        return clang
+
+    versioned_clang = clang.with_name(f"{clang.name}-{resource_version}")
+    if executable := executable_path(versioned_clang):
+        return executable.resolve()
+    return clang
+
+
 def clang_tool_candidates(clang: Path, names: Sequence[str]) -> list[Path]:
     candidates: list[Path] = []
     for name in names:
@@ -310,10 +330,13 @@ def detect_clang_resource_include(clang: Path, explicit_path: str | None) -> Pat
     elif os.environ.get("IREE_CLANG_BUILTIN_HEADERS_PATH"):
         path = Path(os.environ["IREE_CLANG_BUILTIN_HEADERS_PATH"])
     else:
-        resource_dir = Path(run_capture([str(clang), "-print-resource-dir"]))
-        path = resource_dir / "include"
+        path = clang_resource_dir(clang) / "include"
     if not path.is_dir():
         raise RuntimeError(f"clang resource include directory not found: {path}")
+    if not (path / "stddef.h").is_file():
+        raise RuntimeError(
+            f"clang resource include marker not found: {path / 'stddef.h'}"
+        )
     return path.resolve()
 
 
@@ -330,6 +353,7 @@ def detect_toolchain(args: argparse.Namespace) -> Toolchain:
         tool_dirs=dirs,
         description="clang with AMDGPU support",
     )
+    clang = select_invocable_clang(clang)
     llvm_link = find_tool(
         explicit_path=args.llvm_link,
         env_vars=(

--- a/build_tools/scripts/amdgpu_device_binaries_test.py
+++ b/build_tools/scripts/amdgpu_device_binaries_test.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import amdgpu_device_binaries
+
+
+def write_executable(path: Path, contents: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)
+    path.chmod(0o755)
+
+
+class AmdgpuDeviceBinariesTest(unittest.TestCase):
+    def make_rocm_tree(self, root: Path) -> argparse.Namespace:
+        bin_dir = root / "llvm" / "bin"
+        resource_dir = root / "llvm" / "lib" / "clang" / "23"
+        include_dir = resource_dir / "include"
+        include_dir.mkdir(parents=True)
+        (include_dir / "stddef.h").write_text("/* fake resource header marker */\n")
+
+        clang_23 = bin_dir / "clang-23"
+        write_executable(
+            clang_23,
+            f"""#!/bin/sh
+if [ "$1" = "-print-resource-dir" ]; then
+  echo "{resource_dir}"
+  exit 0
+fi
+if [ "$1" = "--print-prog-name=llvm-link" ]; then
+  echo "{bin_dir / "llvm-link"}"
+  exit 0
+fi
+if [ "$1" = "--print-prog-name=lld" ]; then
+  echo "{bin_dir / "lld"}"
+  exit 0
+fi
+if [ "$1" = "--print-prog-name=ld.lld" ]; then
+  echo "{bin_dir / "lld"}"
+  exit 0
+fi
+if [ "$1" = "--print-prog-name=llvm-objcopy" ]; then
+  echo "{bin_dir / "llvm-objcopy"}"
+  exit 0
+fi
+exit 0
+""",
+        )
+        write_executable(
+            bin_dir / "clang",
+            """#!/bin/sh
+exec "$(dirname "$0")/clang-23" "$@"
+""",
+        )
+        write_executable(bin_dir / "llvm-link", "#!/bin/sh\nexit 0\n")
+        write_executable(bin_dir / "lld", "#!/bin/sh\nexit 0\n")
+        write_executable(bin_dir / "llvm-objcopy", "#!/bin/sh\nexit 0\n")
+
+        return argparse.Namespace(
+            clang=None,
+            clang_resource_include=None,
+            lld=None,
+            llvm_link=None,
+            llvm_objcopy=None,
+            rocm_path=[str(root)],
+            tool_dir=[],
+        )
+
+    def test_select_invocable_clang_prefers_versioned_rocm_driver(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = self.make_rocm_tree(Path(temp_dir))
+            clang = Path(args.rocm_path[0]) / "llvm" / "bin" / "clang"
+
+            selected = amdgpu_device_binaries.select_invocable_clang(clang)
+
+            self.assertEqual(selected.name, "clang-23")
+
+    def test_select_invocable_clang_keeps_versioned_driver(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = self.make_rocm_tree(Path(temp_dir))
+            clang = Path(args.rocm_path[0]) / "llvm" / "bin" / "clang-23"
+
+            selected = amdgpu_device_binaries.select_invocable_clang(clang)
+
+            self.assertEqual(selected, clang.resolve())
+
+    def test_detect_clang_resource_include_requires_marker_header(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            include_dir = Path(temp_dir) / "include"
+            include_dir.mkdir()
+
+            with self.assertRaisesRegex(RuntimeError, "stddef.h"):
+                amdgpu_device_binaries.detect_clang_resource_include(
+                    Path("/does/not/matter"),
+                    str(include_dir),
+                )
+
+    def test_detect_toolchain_selects_versioned_rocm_driver(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            args = self.make_rocm_tree(Path(temp_dir))
+
+            toolchain = amdgpu_device_binaries.detect_toolchain(args)
+
+            self.assertEqual(toolchain.clang.name, "clang-23")
+            self.assertEqual(toolchain.llvm_link.name, "llvm-link")
+            self.assertEqual(toolchain.lld.name, "lld")
+            self.assertEqual(toolchain.llvm_objcopy.name, "llvm-objcopy")
+            self.assertTrue((toolchain.clang_resource_include / "stddef.h").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/loom/src/loom/tooling/execution/hal/benchmark.c
+++ b/loom/src/loom/tooling/execution/hal/benchmark.c
@@ -170,6 +170,15 @@ static iree_status_t loom_run_hal_benchmark_options_validate(
   return iree_ok_status();
 }
 
+static bool loom_run_hal_benchmark_options_request_explicit_profile_counters(
+    const loom_run_hal_benchmark_options_t* options) {
+  if (!options->profile_counter_sets) return false;
+  for (iree_host_size_t i = 0; i < options->profile_counter_set_count; ++i) {
+    if (options->profile_counter_sets[i].counter_name_count != 0) return true;
+  }
+  return false;
+}
+
 typedef struct loom_run_hal_benchmark_batch_context_t {
   // HAL runtime that owns the device used for dispatch.
   const loom_run_hal_runtime_t* runtime;
@@ -399,7 +408,8 @@ static iree_status_t loom_run_hal_benchmark_run_profiled_batch(
                              .fn = loom_run_hal_profile_summary_capture_row,
                              .user_data = &context,
                          });
-  } else {
+  } else if (!loom_run_hal_benchmark_options_request_explicit_profile_counters(
+                 options)) {
     loom_run_hal_profile_summary_record_error(out_profile, status);
     iree_status_free(status);
     status = iree_ok_status();

--- a/loom/src/loom/tools/iree-benchmark-loom/options.c
+++ b/loom/src/loom/tools/iree-benchmark-loom/options.c
@@ -82,7 +82,8 @@ IREE_FLAG_LIST_NAMED(
     string, profile_counter, "profile-counter",
     "Implementation-specific hardware counter name to request during the final "
     "profiled batch. May be repeated and requires --profile-data to include "
-    "counters or counter-ranges.");
+    "counters or counter-ranges. If omitted, the target's default supported "
+    "counter set is selected.");
 IREE_FLAG_NAMED(
     string, profile_artifacts_dir, "profile-artifacts-dir", "",
     "Directory receiving raw IREE HAL profile bundles from final profiled "

--- a/runtime/src/iree/hal/device.c
+++ b/runtime/src/iree/hal/device.c
@@ -620,10 +620,14 @@ IREE_API_EXPORT iree_status_t iree_hal_device_profiling_begin(
     for (iree_host_size_t i = 0; i < options->counter_set_count; ++i) {
       const iree_hal_profile_counter_set_selection_t* counter_set =
           &options->counter_sets[i];
-      if (counter_set->counter_name_count == 0 || !counter_set->counter_names) {
+      if (counter_set->counter_name_count == 0) {
+        continue;
+      }
+      if (!counter_set->counter_names) {
         return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                 "hardware counter set %" PRIhsz
-                                " must request at least one counter name",
+                                " names counters but has no counter_names "
+                                "array",
                                 i);
       }
       for (iree_host_size_t j = 0; j < counter_set->counter_name_count; ++j) {
@@ -637,12 +641,6 @@ IREE_API_EXPORT iree_status_t iree_hal_device_profiling_begin(
         }
       }
     }
-  }
-  if (iree_hal_device_profiling_options_requests_counters(options) &&
-      options->counter_set_count == 0) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "counter profiling requires at least one counter set selection");
   }
 
   const bool data_requested =

--- a/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
@@ -356,6 +356,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/drivers/amdgpu/util:device_library",
         "//runtime/src/iree/hal/drivers/amdgpu/util:feedback_channel",
         "//runtime/src/iree/hal/drivers/amdgpu/util:info",
+        "//runtime/src/iree/hal/drivers/amdgpu/util:libaqlprofile",
         "//runtime/src/iree/hal/drivers/amdgpu/util:libhsa",
         "//runtime/src/iree/hal/drivers/amdgpu/util:packet",
         "//runtime/src/iree/hal/drivers/amdgpu/util:pm4_dispatch",
@@ -719,6 +720,19 @@ iree_runtime_cc_test(
 iree_runtime_cc_test(
     name = "physical_device_capabilities_test",
     srcs = ["physical_device_capabilities_test.cc"],
+    deps = [
+        ":amdgpu",
+        ":headers",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "profile_counters_test",
+    srcs = ["profile_counters_test.cc"],
     deps = [
         ":amdgpu",
         ":headers",

--- a/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
@@ -389,6 +389,7 @@ iree_cc_library(
     iree::hal::drivers::amdgpu::util::device_library
     iree::hal::drivers::amdgpu::util::feedback_channel
     iree::hal::drivers::amdgpu::util::info
+    iree::hal::drivers::amdgpu::util::libaqlprofile
     iree::hal::drivers::amdgpu::util::libhsa
     iree::hal::drivers::amdgpu::util::packet
     iree::hal::drivers::amdgpu::util::pm4_dispatch
@@ -933,6 +934,28 @@ iree_cc_test(
     physical_device_capabilities_test
   SRCS
     "physical_device_capabilities_test.cc"
+  DEPS
+    ::amdgpu
+    ::headers
+    iree::base
+    iree::hal
+    iree::testing::gtest
+    iree::testing::gtest_main
+  LABELS
+    "iree-build-requirement=runtime.hal.amdgpu"
+    "iree-run-requirement=runtime.resource.amd_gpu"
+    "runtime-resource=amd-gpu"
+  RESOURCE_GROUP
+    iree-hal-drivers-amdgpu-tests
+)
+endif()
+
+if(IREE_HAL_DRIVER_AMDGPU)
+iree_cc_test(
+  NAME
+    profile_counters_test
+  SRCS
+    "profile_counters_test.cc"
   DEPS
     ::amdgpu
     ::headers

--- a/runtime/src/iree/hal/drivers/amdgpu/device/binaries/README.md
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/binaries/README.md
@@ -48,6 +48,10 @@ host-tool directories such as
 For ROCm installs the script searches standard layouts such as `llvm/bin`,
 `lib/llvm/bin`, and `bin`; after finding `clang` or `amdclang` it also asks
 that compiler where its companion LLVM tools live with `--print-prog-name`.
+When the discovered compiler is a ROCm launcher shim with a matching versioned
+driver next to it, the generator uses the versioned driver. This matches the
+Bazel source-build path and avoids depending on shim-relative sibling lookup
+after another build system has wrapped or symlinked the executable.
 
 By default the generator keeps only the `.kd` kernel descriptor symbols in the
 regular symbol tables. `llvm-strip --strip-all` and

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profiling_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profiling_test.cc
@@ -92,6 +92,41 @@ TEST_F(HostQueueCommandBufferProfilingTest,
 }
 
 TEST_F(HostQueueCommandBufferProfilingTest,
+       DefaultHardwareCounterSelectionDoesNotFailWhenUnavailable) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(
+      test_device.Initialize(&options, &libhsa_, &topology_, host_allocator_));
+
+  CommandBufferProfileSink sink = {};
+  CommandBufferProfileSinkInitialize(&sink);
+  DeviceProfilingScope profiling(test_device.base_device());
+  IREE_ASSERT_OK(BeginDefaultHardwareCounterProfiling(&profiling, &sink));
+  IREE_ASSERT_OK(profiling.End());
+
+  EXPECT_EQ(1, sink.begin_count);
+  EXPECT_EQ(1, sink.end_count);
+}
+
+TEST_F(HostQueueCommandBufferProfilingTest,
+       ExplicitUnavailableHardwareCounterSelectionFails) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(
+      test_device.Initialize(&options, &libhsa_, &topology_, host_allocator_));
+
+  CommandBufferProfileSink sink = {};
+  CommandBufferProfileSinkInitialize(&sink);
+  DeviceProfilingScope profiling(test_device.base_device());
+  iree_status_t status =
+      BeginUnsupportedHardwareCounterProfiling(&profiling, &sink);
+  EXPECT_FALSE(iree_status_is_ok(status));
+  iree_status_free(status);
+}
+
+TEST_F(HostQueueCommandBufferProfilingTest,
        MultipleHardwareCounterSelectionEmitsLayoutWhenAvailable) {
   iree_hal_amdgpu_logical_device_options_t options;
   iree_hal_amdgpu_logical_device_options_initialize(&options);
@@ -102,7 +137,8 @@ TEST_F(HostQueueCommandBufferProfilingTest,
   CommandBufferProfileSink sink = {};
   CommandBufferProfileSinkInitialize(&sink);
   DeviceProfilingScope profiling(test_device.base_device());
-  iree_status_t profiling_status = BeginSqWaveWidthProfiling(&profiling, &sink);
+  iree_status_t profiling_status =
+      BeginMultipleSqCounterProfiling(&profiling, &sink);
   if (IsHardwareCounterProfilingUnavailable(
           iree_status_code(profiling_status))) {
     iree_status_free(profiling_status);
@@ -116,16 +152,15 @@ TEST_F(HostQueueCommandBufferProfilingTest,
   EXPECT_EQ(1, sink.counter_set_metadata_count);
   EXPECT_EQ(1, sink.counter_metadata_count);
   ASSERT_FALSE(sink.counter_set_records.empty());
-  ASSERT_EQ(sink.counter_set_records.size() * 4u, sink.counter_records.size());
+  ASSERT_EQ(sink.counter_set_records.size() * 3u, sink.counter_records.size());
   const iree_hal_profile_counter_unit_t expected_units[] = {
-      IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
       IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
       IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
       IREE_HAL_PROFILE_COUNTER_UNIT_CYCLES,
   };
   iree_host_size_t counter_record_index = 0;
   for (const auto& counter_set_record : sink.counter_set_records) {
-    ASSERT_EQ(4u, counter_set_record.counter_count);
+    ASSERT_EQ(3u, counter_set_record.counter_count);
     uint32_t sample_value_count = 0;
     for (uint32_t i = 0; i < counter_set_record.counter_count; ++i) {
       const auto& counter_record = sink.counter_records[counter_record_index++];

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profiling_test_util.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profiling_test_util.h
@@ -880,6 +880,16 @@ static iree_status_t BeginHardwareCounterProfiling(
   return profiling->Begin(&profiling_options);
 }
 
+static iree_status_t BeginDefaultHardwareCounterProfiling(
+    DeviceProfilingScope* profiling, CommandBufferProfileSink* sink) {
+  iree_hal_device_profiling_options_t profiling_options = {0};
+  profiling_options.data_families =
+      IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS |
+      IREE_HAL_DEVICE_PROFILING_DATA_COUNTER_SAMPLES;
+  profiling_options.sink = CommandBufferProfileSinkAsBase(sink);
+  return profiling->Begin(&profiling_options);
+}
+
 static iree_status_t BeginSqWavesProfiling(DeviceProfilingScope* profiling,
                                            CommandBufferProfileSink* sink) {
   iree_string_view_t counter_names[] = {
@@ -909,13 +919,21 @@ static iree_status_t BeginSqWavesCounterRangeProfiling(
   return profiling->Begin(&profiling_options);
 }
 
-static iree_status_t BeginSqWaveWidthProfiling(DeviceProfilingScope* profiling,
-                                               CommandBufferProfileSink* sink) {
+static iree_status_t BeginMultipleSqCounterProfiling(
+    DeviceProfilingScope* profiling, CommandBufferProfileSink* sink) {
   iree_string_view_t counter_names[] = {
       IREE_SV("SQ_WAVES"),
-      IREE_SV("SQ_WAVES_32"),
-      IREE_SV("SQ_WAVES_64"),
+      IREE_SV("SQ_INSTS_VALU"),
       IREE_SV("SQ_BUSY_CYCLES"),
+  };
+  return BeginHardwareCounterProfiling(
+      profiling, sink, IREE_ARRAYSIZE(counter_names), counter_names);
+}
+
+static iree_status_t BeginUnsupportedHardwareCounterProfiling(
+    DeviceProfilingScope* profiling, CommandBufferProfileSink* sink) {
+  iree_string_view_t counter_names[] = {
+      IREE_SV("NO_SUCH_COUNTER"),
   };
   return BeginHardwareCounterProfiling(
       profiling, sink, IREE_ARRAYSIZE(counter_names), counter_names);

--- a/runtime/src/iree/hal/drivers/amdgpu/profile_counters.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/profile_counters.c
@@ -32,6 +32,21 @@ enum { iree_hal_amdgpu_profile_counter_packets_per_set = 3u };
 enum { iree_hal_amdgpu_profile_counter_event_unsupported = UINT32_MAX };
 enum { iree_hal_amdgpu_profile_counter_range_bank_count = 2u };
 
+typedef enum iree_hal_amdgpu_profile_counter_family_e {
+  IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_UNSUPPORTED = 0,
+  // ROCProfiler `gfx9` base counter family.
+  IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9,
+  // ROCProfiler `gfx90a` counter family.
+  IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A,
+  // ROCProfiler `gfx940` counter family inherited by `gfx941` and `gfx942`.
+  IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940,
+  // ROCProfiler `gfx10` counter family.
+  IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10,
+  // ROCProfiler `gfx11` counter family.
+  IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11,
+  IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_COUNT,
+} iree_hal_amdgpu_profile_counter_family_t;
+
 typedef uint32_t iree_hal_amdgpu_profile_counter_session_flags_t;
 enum iree_hal_amdgpu_profile_counter_session_flag_bits_t {
   IREE_HAL_AMDGPU_PROFILE_COUNTER_SESSION_FLAG_NONE = 0u,
@@ -54,17 +69,13 @@ typedef struct iree_hal_amdgpu_profile_counter_descriptor_t {
   iree_hal_profile_counter_unit_t unit;
   // aqlprofile hardware block identifier for this counter.
   iree_hal_amdgpu_aqlprofile_block_name_t block_name_id;
-  // aqlprofile event id for gfx9 devices, or unsupported.
-  uint32_t gfx9_event_id;
-  // aqlprofile event id for gfx10 devices, or unsupported.
-  uint32_t gfx10_event_id;
-  // aqlprofile event id for gfx11 devices, or unsupported.
-  uint32_t gfx11_event_id;
-  // aqlprofile event id for gfx12 devices, or unsupported.
-  uint32_t gfx12_event_id;
+  // aqlprofile event ids indexed by iree_hal_amdgpu_profile_counter_family_t.
+  uint32_t event_ids[IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_COUNT];
 } iree_hal_amdgpu_profile_counter_descriptor_t;
 
 #define IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(value) {(value), sizeof(value) - 1}
+#define IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED \
+  iree_hal_amdgpu_profile_counter_event_unsupported
 
 static const iree_hal_amdgpu_profile_counter_descriptor_t
     iree_hal_amdgpu_profile_counter_descriptors[] = {
@@ -75,34 +86,33 @@ static const iree_hal_amdgpu_profile_counter_descriptor_t
                 "Raw SQ_WAVES values returned by aqlprofile."),
             .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
             .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_SQ,
-            .gfx9_event_id = 4,
-            .gfx10_event_id = 4,
-            .gfx11_event_id = 4,
-            .gfx12_event_id = 4,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] = 4,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 4,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 4,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] = 4,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] = 4,
+                },
         },
         {
-            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("SQ_WAVES_32"),
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("SQ_WAVES_EQ_64"),
             .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("SQ"),
-            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
-                "Raw SQ_WAVES_32 values returned by aqlprofile."),
+            .description =
+                IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("Wave64 waves sent to SQs."),
             .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
             .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_SQ,
-            .gfx9_event_id = iree_hal_amdgpu_profile_counter_event_unsupported,
-            .gfx10_event_id = 5,
-            .gfx11_event_id = 5,
-            .gfx12_event_id = 5,
-        },
-        {
-            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("SQ_WAVES_64"),
-            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("SQ"),
-            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
-                "Raw SQ_WAVES_64 values returned by aqlprofile."),
-            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
-            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_SQ,
-            .gfx9_event_id = iree_hal_amdgpu_profile_counter_event_unsupported,
-            .gfx10_event_id = 6,
-            .gfx11_event_id = 6,
-            .gfx12_event_id = 6,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 6,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 6,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
         },
         {
             .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("SQ_BUSY_CYCLES"),
@@ -111,14 +121,337 @@ static const iree_hal_amdgpu_profile_counter_descriptor_t
                 "Clock cycles with active waves in a shader engine."),
             .unit = IREE_HAL_PROFILE_COUNTER_UNIT_CYCLES,
             .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_SQ,
-            .gfx9_event_id = 3,
-            .gfx10_event_id = 3,
-            .gfx11_event_id = 3,
-            .gfx12_event_id = 3,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 3,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 3,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] = 3,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] = 3,
+                },
+        },
+        {
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("SQ_INSTS_VALU"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("SQ"),
+            .description =
+                IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("VALU instructions issued."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_SQ,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] = 26,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 26,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 26,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] = 64,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] = 62,
+                },
+        },
+        {
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("SQ_INSTS_VMEM_RD"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("SQ"),
+            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "VMEM read instructions issued, including FLAT."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_SQ,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] = 28,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 54,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 58,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
+        },
+        {
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("SQ_INSTS_VMEM_WR"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("SQ"),
+            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "VMEM write instructions issued, including FLAT."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_SQ,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] = 27,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 53,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 57,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
+        },
+        {
+            .name =
+                IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TA_BUFFER_READ_WAVEFRONTS"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TA"),
+            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "Buffer read wavefronts processed by TA."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TA,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 45,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 33,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
+        },
+        {
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "TA_BUFFER_WRITE_WAVEFRONTS"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TA"),
+            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "Buffer write wavefronts processed by TA."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TA,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 46,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 34,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
+        },
+        {
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCC_EA0_RDREQ"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCC"),
+            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "TCC/EA0 read requests, either 32-byte or 64-byte."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TCC,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 38,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 38,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
+        },
+        {
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCC_EA0_RDREQ_32B"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCC"),
+            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "32-byte TCC/EA0 read requests."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TCC,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 39,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 39,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
+        },
+        {
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCC_EA0_WRREQ"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCC"),
+            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "TCC/EA0 write requests, either 32-byte or 64-byte."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TCC,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 26,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 26,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
+        },
+        {
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCC_EA0_WRREQ_64B"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCC"),
+            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "64-byte TCC/EA0 write requests."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TCC,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 27,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 27,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
+        },
+        {
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCC_EA0_RDREQ_DRAM"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCC"),
+            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "TCC/EA0 read requests destined for DRAM."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TCC,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 102,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 102,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
+        },
+        {
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCC_EA0_WRREQ_DRAM"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCC"),
+            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "TCC/EA0 write requests destined for DRAM."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TCC,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 103,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 103,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
+        },
+        {
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCP_TOTAL_READ"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCP"),
+            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "Total read pixels/buffers from TA."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TCP,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 30,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 28,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
+        },
+        {
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCP_TOTAL_WRITE"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCP"),
+            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "Total local write pixels/buffers from TA."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TCP,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 32,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 30,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
+        },
+        {
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCP_TCC_READ_REQ"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCP"),
+            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "Read requests from TCP to all TCCs."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TCP,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 69,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 65,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
+        },
+        {
+            .name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCP_TCC_WRITE_REQ"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCP"),
+            .description = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV(
+                "Write requests from TCP to all TCCs."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_COUNT,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TCP,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 70,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 66,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
+        },
+        {
+            .name =
+                IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCP_TD_TCP_STALL_CYCLES"),
+            .block_name = IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TCP"),
+            .description =
+                IREE_HAL_AMDGPU_PROFILE_COUNTER_SV("TD stalls TCP cycles."),
+            .unit = IREE_HAL_PROFILE_COUNTER_UNIT_CYCLES,
+            .block_name_id = IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TCP,
+            .event_ids =
+                {
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A] = 7,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940] = 7,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                    [IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11] =
+                        IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED,
+                },
         },
 };
 
 #undef IREE_HAL_AMDGPU_PROFILE_COUNTER_SV
+#undef IREE_HAL_AMDGPU_PROFILE_COUNTER_UNSUPPORTED
+
+static const char iree_hal_amdgpu_profile_counter_supported_names_data[] =
+    "SQ_WAVES, SQ_WAVES_EQ_64, SQ_BUSY_CYCLES, SQ_INSTS_VALU, "
+    "SQ_INSTS_VMEM_RD, SQ_INSTS_VMEM_WR, "
+    "TA_BUFFER_READ_WAVEFRONTS, TA_BUFFER_WRITE_WAVEFRONTS, "
+    "TCC_EA0_RDREQ, TCC_EA0_RDREQ_32B, TCC_EA0_WRREQ, "
+    "TCC_EA0_WRREQ_64B, TCC_EA0_RDREQ_DRAM, "
+    "TCC_EA0_WRREQ_DRAM, TCP_TOTAL_READ, TCP_TOTAL_WRITE, "
+    "TCP_TCC_READ_REQ, TCP_TCC_WRITE_REQ, TCP_TD_TCP_STALL_CYCLES";
+
+static const iree_string_view_t
+    iree_hal_amdgpu_profile_counter_supported_names_storage = {
+        iree_hal_amdgpu_profile_counter_supported_names_data,
+        sizeof(iree_hal_amdgpu_profile_counter_supported_names_data) - 1,
+};
 
 // One resolved raw counter within a selected counter set.
 typedef struct iree_hal_amdgpu_profile_counter_t {
@@ -238,27 +571,88 @@ iree_hal_amdgpu_profile_counter_find_descriptor(iree_string_view_t name) {
   return NULL;
 }
 
+iree_string_view_t iree_hal_amdgpu_profile_counter_supported_names(void) {
+  return iree_hal_amdgpu_profile_counter_supported_names_storage;
+}
+
+static bool iree_hal_amdgpu_profile_counter_selection_is_default(
+    const iree_hal_profile_counter_set_selection_t* selection) {
+  return selection->counter_name_count == 0;
+}
+
+static bool iree_hal_amdgpu_profile_counter_options_request_explicit_names(
+    const iree_hal_device_profiling_options_t* options) {
+  if (!options->counter_sets) return false;
+  for (iree_host_size_t i = 0; i < options->counter_set_count; ++i) {
+    if (options->counter_sets[i].counter_name_count != 0) return true;
+  }
+  return false;
+}
+
+static bool iree_hal_amdgpu_profile_counter_status_allows_default_noop(
+    iree_status_code_t status_code) {
+  switch (status_code) {
+    case IREE_STATUS_NOT_FOUND:
+    case IREE_STATUS_UNAVAILABLE:
+    case IREE_STATUS_UNIMPLEMENTED:
+    case IREE_STATUS_FAILED_PRECONDITION:
+      return true;
+    default:
+      return false;
+  }
+}
+
+static iree_hal_amdgpu_profile_counter_family_t
+iree_hal_amdgpu_profile_counter_select_family(
+    iree_hal_amdgpu_gfxip_version_t gfxip_version) {
+  switch (gfxip_version.major) {
+    case 9:
+      if (gfxip_version.minor == 0 && gfxip_version.stepping == 10) {
+        return IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX90A;
+      }
+      if (gfxip_version.minor == 0) {
+        return IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX9;
+      }
+      if (gfxip_version.minor == 4 && gfxip_version.stepping <= 2) {
+        return IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX940;
+      }
+      return IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_UNSUPPORTED;
+    case 10:
+      if ((gfxip_version.minor == 1 && gfxip_version.stepping == 0) ||
+          (gfxip_version.minor == 3 && gfxip_version.stepping <= 2)) {
+        return IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX10;
+      }
+      return IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_UNSUPPORTED;
+    case 11:
+      if (gfxip_version.minor == 0 && gfxip_version.stepping <= 2) {
+        return IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_GFX11;
+      }
+      return IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_UNSUPPORTED;
+    default:
+      return IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_UNSUPPORTED;
+  }
+}
+
+static bool iree_hal_amdgpu_profile_counter_resolve_event_id(
+    const iree_hal_amdgpu_profile_counter_descriptor_t* descriptor,
+    iree_hal_amdgpu_gfxip_version_t gfxip_version, uint32_t* out_event_id) {
+  const iree_hal_amdgpu_profile_counter_family_t family =
+      iree_hal_amdgpu_profile_counter_select_family(gfxip_version);
+  if (family == IREE_HAL_AMDGPU_PROFILE_COUNTER_FAMILY_UNSUPPORTED) {
+    *out_event_id = iree_hal_amdgpu_profile_counter_event_unsupported;
+    return false;
+  }
+  *out_event_id = descriptor->event_ids[family];
+  return *out_event_id != iree_hal_amdgpu_profile_counter_event_unsupported;
+}
+
 static iree_status_t iree_hal_amdgpu_profile_counter_resolve_event(
     const iree_hal_amdgpu_profile_counter_descriptor_t* descriptor,
     iree_hal_amdgpu_gfxip_version_t gfxip_version,
     iree_hal_amdgpu_aqlprofile_pmc_event_t* out_event) {
   uint32_t event_id = iree_hal_amdgpu_profile_counter_event_unsupported;
-  switch (gfxip_version.major) {
-    case 9:
-      event_id = descriptor->gfx9_event_id;
-      break;
-    case 10:
-      event_id = descriptor->gfx10_event_id;
-      break;
-    case 11:
-      event_id = descriptor->gfx11_event_id;
-      break;
-    case 12:
-      event_id = descriptor->gfx12_event_id;
-      break;
-    default:
-      break;
-  }
+  iree_hal_amdgpu_profile_counter_resolve_event_id(descriptor, gfxip_version,
+                                                   &event_id);
   if (IREE_UNLIKELY(event_id ==
                     iree_hal_amdgpu_profile_counter_event_unsupported)) {
     return iree_make_status(
@@ -276,11 +670,71 @@ static iree_status_t iree_hal_amdgpu_profile_counter_resolve_event(
   return iree_ok_status();
 }
 
+iree_status_t iree_hal_amdgpu_profile_counter_resolve_named_event(
+    iree_string_view_t name, iree_hal_amdgpu_gfxip_version_t gfxip_version,
+    iree_hal_amdgpu_aqlprofile_pmc_event_t* out_event) {
+  IREE_ASSERT_ARGUMENT(out_event);
+  const iree_hal_amdgpu_profile_counter_descriptor_t* descriptor =
+      iree_hal_amdgpu_profile_counter_find_descriptor(name);
+  if (!descriptor) {
+    iree_string_view_t supported_names =
+        iree_hal_amdgpu_profile_counter_supported_names();
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "unsupported AMDGPU counter '%.*s'; supported counters: %.*s",
+        (int)name.size, name.data, (int)supported_names.size,
+        supported_names.data);
+  }
+  return iree_hal_amdgpu_profile_counter_resolve_event(
+      descriptor, gfxip_version, out_event);
+}
+
 static bool iree_hal_amdgpu_profile_counter_events_equal(
     iree_hal_amdgpu_aqlprofile_pmc_event_t lhs,
     iree_hal_amdgpu_aqlprofile_pmc_event_t rhs) {
   return lhs.block_index == rhs.block_index && lhs.event_id == rhs.event_id &&
          lhs.flags.raw == rhs.flags.raw && lhs.block_name == rhs.block_name;
+}
+
+static void iree_hal_amdgpu_profile_counter_select_default_descriptors(
+    const iree_hal_amdgpu_logical_device_t* logical_device,
+    const iree_hal_amdgpu_libaqlprofile_t* libaqlprofile,
+    const iree_hal_amdgpu_aqlprofile_agent_handle_t* agent_handles,
+    const iree_hal_amdgpu_profile_counter_descriptor_t** out_descriptors,
+    uint32_t* out_descriptor_count) {
+  uint32_t descriptor_count = 0;
+  for (iree_host_size_t i = 0;
+       i < IREE_ARRAYSIZE(iree_hal_amdgpu_profile_counter_descriptors); ++i) {
+    const iree_hal_amdgpu_profile_counter_descriptor_t* descriptor =
+        &iree_hal_amdgpu_profile_counter_descriptors[i];
+    bool supported_on_all_devices = true;
+    for (iree_host_size_t j = 0;
+         j < logical_device->physical_device_count && supported_on_all_devices;
+         ++j) {
+      const iree_hal_amdgpu_physical_device_t* physical_device =
+          logical_device->physical_devices[j];
+      uint32_t event_id = 0;
+      if (!iree_hal_amdgpu_profile_counter_resolve_event_id(
+              descriptor, physical_device->isa.target_id.version, &event_id)) {
+        supported_on_all_devices = false;
+        break;
+      }
+      iree_hal_amdgpu_aqlprofile_pmc_event_t event = {
+          .block_index = 0,
+          .event_id = event_id,
+          .block_name = descriptor->block_name_id,
+      };
+      bool valid = false;
+      const hsa_status_t hsa_status =
+          libaqlprofile->aqlprofile_validate_pmc_event(
+              agent_handles[physical_device->device_ordinal], &event, &valid);
+      supported_on_all_devices = hsa_status == HSA_STATUS_SUCCESS && valid;
+    }
+    if (supported_on_all_devices) {
+      out_descriptors[descriptor_count++] = descriptor;
+    }
+  }
+  *out_descriptor_count = descriptor_count;
 }
 
 static bool iree_hal_amdgpu_profile_counter_find_index_by_event(
@@ -345,6 +799,9 @@ static hsa_status_t iree_hal_amdgpu_profile_counter_collect_callback(
 static iree_status_t iree_hal_amdgpu_profile_counter_initialize_selection(
     const iree_hal_profile_counter_set_selection_t* selection,
     iree_hal_amdgpu_gfxip_version_t gfxip_version,
+    const iree_hal_amdgpu_profile_counter_descriptor_t* const*
+        default_descriptors,
+    uint32_t default_descriptor_count,
     iree_hal_amdgpu_profile_counter_set_t* counter_set) {
   if (IREE_UNLIKELY(selection->flags !=
                     IREE_HAL_PROFILE_COUNTER_SET_SELECTION_FLAG_NONE)) {
@@ -352,36 +809,42 @@ static iree_status_t iree_hal_amdgpu_profile_counter_initialize_selection(
                             "unsupported AMDGPU counter set flags 0x%x",
                             selection->flags);
   }
-  if (IREE_UNLIKELY(selection->counter_name_count == 0)) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "AMDGPU counter profiling requires at least one counter per set");
-  }
-  if (IREE_UNLIKELY(selection->counter_name_count > UINT32_MAX)) {
+  const bool default_selection =
+      iree_hal_amdgpu_profile_counter_selection_is_default(selection);
+  const iree_host_size_t requested_counter_count =
+      default_selection ? default_descriptor_count
+                        : selection->counter_name_count;
+  if (IREE_UNLIKELY(requested_counter_count > UINT32_MAX)) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "AMDGPU counter count exceeds uint32_t");
   }
 
-  for (iree_host_size_t i = 0; i < selection->counter_name_count; ++i) {
-    const iree_hal_amdgpu_profile_counter_descriptor_t* descriptor =
-        iree_hal_amdgpu_profile_counter_find_descriptor(
-            selection->counter_names[i]);
-    if (IREE_UNLIKELY(!descriptor)) {
-      return iree_make_status(
-          IREE_STATUS_UNIMPLEMENTED,
-          "unsupported AMDGPU counter '%.*s'; supported counters: "
-          "SQ_WAVES, SQ_WAVES_32, SQ_WAVES_64, SQ_BUSY_CYCLES",
-          (int)selection->counter_names[i].size,
-          selection->counter_names[i].data);
-    }
-    for (iree_host_size_t j = 0; j < i; ++j) {
-      if (iree_string_view_equal(selection->counter_names[i],
-                                 selection->counter_names[j])) {
+  for (iree_host_size_t i = 0; i < requested_counter_count; ++i) {
+    const iree_hal_amdgpu_profile_counter_descriptor_t* descriptor = NULL;
+    if (default_selection) {
+      descriptor = default_descriptors[i];
+    } else {
+      descriptor = iree_hal_amdgpu_profile_counter_find_descriptor(
+          selection->counter_names[i]);
+      if (IREE_UNLIKELY(!descriptor)) {
+        iree_string_view_t supported_names =
+            iree_hal_amdgpu_profile_counter_supported_names();
         return iree_make_status(
-            IREE_STATUS_INVALID_ARGUMENT,
-            "duplicate AMDGPU counter '%.*s' in one counter set",
+            IREE_STATUS_UNIMPLEMENTED,
+            "unsupported AMDGPU counter '%.*s'; supported counters: %.*s",
             (int)selection->counter_names[i].size,
-            selection->counter_names[i].data);
+            selection->counter_names[i].data, (int)supported_names.size,
+            supported_names.data);
+      }
+      for (iree_host_size_t j = 0; j < i; ++j) {
+        if (iree_string_view_equal(selection->counter_names[i],
+                                   selection->counter_names[j])) {
+          return iree_make_status(
+              IREE_STATUS_INVALID_ARGUMENT,
+              "duplicate AMDGPU counter '%.*s' in one counter set",
+              (int)selection->counter_names[i].size,
+              selection->counter_names[i].data);
+        }
       }
     }
 
@@ -396,7 +859,7 @@ static iree_status_t iree_hal_amdgpu_profile_counter_initialize_selection(
         .counter_ordinal = counter_ordinal,
     };
   }
-  counter_set->counter_count = (uint32_t)selection->counter_name_count;
+  counter_set->counter_count = (uint32_t)requested_counter_count;
   return iree_ok_status();
 }
 
@@ -490,17 +953,20 @@ static void iree_hal_amdgpu_profile_counter_destroy_packet_set(
 }
 
 static iree_status_t iree_hal_amdgpu_profile_counter_initialize_set(
-    const iree_hal_device_profiling_options_t* options,
+    const iree_hal_profile_counter_set_selection_t* selection,
     iree_hal_amdgpu_physical_device_t* physical_device,
     iree_host_size_t selection_ordinal,
+    const iree_hal_amdgpu_profile_counter_descriptor_t* const*
+        default_descriptors,
+    uint32_t default_descriptor_count,
     const iree_hal_amdgpu_libaqlprofile_t* libaqlprofile,
     iree_hal_amdgpu_profile_counter_session_t* session,
     iree_hal_amdgpu_profile_counter_t** inout_counter_storage,
     iree_hal_amdgpu_aqlprofile_pmc_event_t** inout_event_storage,
     char** inout_string_storage,
     iree_hal_amdgpu_profile_counter_set_t* out_counter_set) {
-  const iree_hal_profile_counter_set_selection_t* selection =
-      &options->counter_sets[selection_ordinal];
+  const bool default_selection =
+      iree_hal_amdgpu_profile_counter_selection_is_default(selection);
   iree_string_view_t set_name = selection->name;
   if (iree_string_view_is_empty(set_name)) {
     set_name = iree_hal_amdgpu_profile_counter_set_name();
@@ -522,9 +988,13 @@ static iree_status_t iree_hal_amdgpu_profile_counter_initialize_set(
       .name = iree_make_string_view(string_storage, set_name.size),
   };
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_profile_counter_initialize_selection(
-      selection, physical_device->isa.target_id.version, out_counter_set));
+      selection, physical_device->isa.target_id.version, default_descriptors,
+      default_descriptor_count, out_counter_set));
   *inout_counter_storage += out_counter_set->counter_count;
   *inout_event_storage += out_counter_set->counter_count;
+  if (out_counter_set->counter_count == 0) {
+    return iree_ok_status();
+  }
 
   for (uint32_t i = 0; i < out_counter_set->counter_count; ++i) {
     const iree_hal_amdgpu_profile_counter_t* counter =
@@ -564,6 +1034,12 @@ static iree_status_t iree_hal_amdgpu_profile_counter_initialize_set(
   }
   iree_hal_amdgpu_profile_counter_destroy_packets(libaqlprofile,
                                                   &metadata_handle);
+  if (!iree_status_is_ok(status) && default_selection) {
+    iree_status_free(status);
+    out_counter_set->counter_count = 0;
+    out_counter_set->sample_value_count = 0;
+    return iree_ok_status();
+  }
   return status;
 }
 
@@ -623,11 +1099,31 @@ iree_status_t iree_hal_amdgpu_profile_counter_session_allocate(
     IREE_TRACE_ZONE_END(z0);
     return iree_ok_status();
   }
+  const bool explicit_counter_names_requested =
+      iree_hal_amdgpu_profile_counter_options_request_explicit_names(options);
+  const iree_hal_profile_counter_set_selection_t default_selection = {
+      .flags = IREE_HAL_PROFILE_COUNTER_SET_SELECTION_FLAG_NONE,
+      .name = iree_hal_amdgpu_profile_counter_set_name(),
+      .counter_name_count = 0,
+      .counter_names = NULL,
+  };
+  const iree_host_size_t requested_counter_set_count =
+      options->counter_set_count;
+  const iree_host_size_t upper_counter_set_count =
+      requested_counter_set_count ? requested_counter_set_count : 1;
   if (IREE_UNLIKELY(!options->sink)) {
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
         "AMDGPU hardware counter profiling requires a profile sink");
+  }
+  if (IREE_UNLIKELY(requested_counter_set_count != 0 &&
+                    !options->counter_sets)) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU counter profiling requires counter_sets when "
+        "counter_set_count is nonzero");
   }
   if (IREE_UNLIKELY(options->counter_set_count > UINT32_MAX)) {
     IREE_TRACE_ZONE_END(z0);
@@ -639,13 +1135,25 @@ iree_status_t iree_hal_amdgpu_profile_counter_session_allocate(
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "AMDGPU physical device count exceeds uint32_t");
   }
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_amdgpu_profile_counter_validate_physical_device_support(
-              logical_device, session_flags));
+  iree_status_t status =
+      iree_hal_amdgpu_profile_counter_validate_physical_device_support(
+          logical_device, session_flags);
+  if (!iree_status_is_ok(status)) {
+    const iree_status_code_t status_code = iree_status_code(status);
+    if (!explicit_counter_names_requested &&
+        iree_hal_amdgpu_profile_counter_status_allows_default_noop(
+            status_code)) {
+      iree_status_free(status);
+      IREE_TRACE_ZONE_END(z0);
+      return iree_ok_status();
+    }
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
 
   iree_host_size_t counter_set_total_count = 0;
   if (IREE_UNLIKELY(!iree_host_size_checked_mul(
-          logical_device->physical_device_count, options->counter_set_count,
+          logical_device->physical_device_count, upper_counter_set_count,
           &counter_set_total_count))) {
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
@@ -653,18 +1161,18 @@ iree_status_t iree_hal_amdgpu_profile_counter_session_allocate(
   }
   iree_host_size_t counter_total_count = 0;
   iree_host_size_t string_storage_length = 0;
-  for (iree_host_size_t i = 0; i < options->counter_set_count; ++i) {
-    if (IREE_UNLIKELY(options->counter_sets[i].counter_name_count == 0)) {
-      IREE_TRACE_ZONE_END(z0);
-      return iree_make_status(
-          IREE_STATUS_INVALID_ARGUMENT,
-          "AMDGPU counter profiling requires at least one counter per set");
-    }
+  for (iree_host_size_t i = 0; i < upper_counter_set_count; ++i) {
+    const iree_hal_profile_counter_set_selection_t* selection =
+        requested_counter_set_count ? &options->counter_sets[i]
+                                    : &default_selection;
+    const iree_host_size_t selection_counter_count =
+        iree_hal_amdgpu_profile_counter_selection_is_default(selection)
+            ? IREE_ARRAYSIZE(iree_hal_amdgpu_profile_counter_descriptors)
+            : selection->counter_name_count;
     iree_host_size_t replicated_counter_count = 0;
     if (IREE_UNLIKELY(!iree_host_size_checked_mul(
                           logical_device->physical_device_count,
-                          options->counter_sets[i].counter_name_count,
-                          &replicated_counter_count) ||
+                          selection_counter_count, &replicated_counter_count) ||
                       !iree_host_size_checked_add(counter_total_count,
                                                   replicated_counter_count,
                                                   &counter_total_count))) {
@@ -673,7 +1181,7 @@ iree_status_t iree_hal_amdgpu_profile_counter_session_allocate(
                               "AMDGPU counter count overflow");
     }
 
-    iree_string_view_t set_name = options->counter_sets[i].name;
+    iree_string_view_t set_name = selection->name;
     if (iree_string_view_is_empty(set_name)) {
       set_name = iree_hal_amdgpu_profile_counter_set_name();
     }
@@ -723,7 +1231,7 @@ iree_status_t iree_hal_amdgpu_profile_counter_session_allocate(
   session->flags = session_flags;
   session->libhsa = &logical_device->system->libhsa;
   session->physical_device_count = logical_device->physical_device_count;
-  session->counter_set_count = (uint32_t)options->counter_set_count;
+  session->counter_set_count = 0;
   session->agent_handles =
       (iree_hal_amdgpu_aqlprofile_agent_handle_t*)((uint8_t*)session +
                                                    agent_handles_offset);
@@ -737,9 +1245,28 @@ iree_status_t iree_hal_amdgpu_profile_counter_session_allocate(
                                                 events_offset);
   iree_atomic_store(&session->next_sample_id, 1, iree_memory_order_relaxed);
 
-  iree_status_t status = iree_hal_amdgpu_libaqlprofile_initialize(
+  iree_host_size_t* normalized_selection_ordinals = NULL;
+  status = iree_allocator_malloc(
+      host_allocator, upper_counter_set_count * sizeof(iree_host_size_t),
+      (void**)&normalized_selection_ordinals);
+  if (!iree_status_is_ok(status)) {
+    iree_allocator_free(host_allocator, session);
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
+
+  status = iree_hal_amdgpu_libaqlprofile_initialize(
       session->libhsa, iree_string_view_list_empty(), host_allocator,
       &session->libaqlprofile);
+  if (!iree_status_is_ok(status) && !explicit_counter_names_requested &&
+      iree_hal_amdgpu_profile_counter_status_allows_default_noop(
+          iree_status_code(status))) {
+    iree_status_free(status);
+    iree_allocator_free(host_allocator, normalized_selection_ordinals);
+    iree_allocator_free(host_allocator, session);
+    IREE_TRACE_ZONE_END(z0);
+    return iree_ok_status();
+  }
   for (iree_host_size_t i = 0;
        i < logical_device->physical_device_count && iree_status_is_ok(status);
        ++i) {
@@ -749,6 +1276,39 @@ iree_status_t iree_hal_amdgpu_profile_counter_session_allocate(
         session->libhsa, &session->libaqlprofile, physical_device->device_agent,
         &session->agent_handles[physical_device->device_ordinal]);
   }
+  const iree_hal_amdgpu_profile_counter_descriptor_t*
+      default_descriptors[IREE_ARRAYSIZE(
+          iree_hal_amdgpu_profile_counter_descriptors)] = {0};
+  uint32_t default_descriptor_count = 0;
+  if (iree_status_is_ok(status)) {
+    iree_hal_amdgpu_profile_counter_select_default_descriptors(
+        logical_device, &session->libaqlprofile, session->agent_handles,
+        default_descriptors, &default_descriptor_count);
+  }
+  iree_host_size_t normalized_selection_count = 0;
+  for (iree_host_size_t i = 0;
+       i < upper_counter_set_count && iree_status_is_ok(status); ++i) {
+    const iree_hal_profile_counter_set_selection_t* selection =
+        requested_counter_set_count ? &options->counter_sets[i]
+                                    : &default_selection;
+    if (iree_hal_amdgpu_profile_counter_selection_is_default(selection) &&
+        default_descriptor_count == 0) {
+      continue;
+    }
+    normalized_selection_ordinals[normalized_selection_count++] = i;
+  }
+  if (iree_status_is_ok(status) && normalized_selection_count > UINT32_MAX) {
+    status = iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "AMDGPU counter set count exceeds uint32_t");
+  }
+  if (iree_status_is_ok(status) && normalized_selection_count == 0) {
+    iree_hal_amdgpu_libaqlprofile_deinitialize(&session->libaqlprofile);
+    iree_allocator_free(host_allocator, normalized_selection_ordinals);
+    iree_allocator_free(host_allocator, session);
+    IREE_TRACE_ZONE_END(z0);
+    return iree_ok_status();
+  }
+  session->counter_set_count = (uint32_t)normalized_selection_count;
   char* string_storage = (char*)session + string_storage_offset;
   for (iree_host_size_t i = 0;
        i < logical_device->physical_device_count && iree_status_is_ok(status);
@@ -756,13 +1316,37 @@ iree_status_t iree_hal_amdgpu_profile_counter_session_allocate(
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
     for (iree_host_size_t j = 0;
-         j < options->counter_set_count && iree_status_is_ok(status); ++j) {
+         j < normalized_selection_count && iree_status_is_ok(status); ++j) {
+      const iree_host_size_t selection_ordinal =
+          normalized_selection_ordinals[j];
+      const iree_hal_profile_counter_set_selection_t* selection =
+          requested_counter_set_count
+              ? &options->counter_sets[selection_ordinal]
+              : &default_selection;
       const iree_host_size_t counter_set_index =
-          physical_device->device_ordinal * options->counter_set_count + j;
+          physical_device->device_ordinal * normalized_selection_count + j;
       status = iree_hal_amdgpu_profile_counter_initialize_set(
-          options, physical_device, j, &session->libaqlprofile, session,
+          selection, physical_device, j, default_descriptors,
+          default_descriptor_count, &session->libaqlprofile, session,
           &counter_storage, &event_storage, &string_storage,
           &session->counter_sets[counter_set_index]);
+    }
+  }
+  bool empty_counter_set = false;
+  const iree_host_size_t initialized_counter_set_count =
+      logical_device->physical_device_count * normalized_selection_count;
+  for (iree_host_size_t i = 0;
+       i < initialized_counter_set_count && iree_status_is_ok(status); ++i) {
+    empty_counter_set |= session->counter_sets[i].counter_count == 0;
+  }
+  if (iree_status_is_ok(status) && empty_counter_set) {
+    if (!explicit_counter_names_requested) {
+      session->counter_set_count = 0;
+    } else {
+      status = iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "AMDGPU default counter selection did not produce a usable counter "
+          "set alongside explicit counter sets");
     }
   }
 
@@ -772,6 +1356,7 @@ iree_status_t iree_hal_amdgpu_profile_counter_session_allocate(
     iree_hal_amdgpu_libaqlprofile_deinitialize(&session->libaqlprofile);
     iree_allocator_free(host_allocator, session);
   }
+  iree_allocator_free(host_allocator, normalized_selection_ordinals);
 
   IREE_TRACE_ZONE_END(z0);
   return status;

--- a/runtime/src/iree/hal/drivers/amdgpu/profile_counters.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/profile_counters.h
@@ -10,6 +10,8 @@
 #include "iree/hal/device.h"
 #include "iree/hal/drivers/amdgpu/util/aql_emitter.h"
 #include "iree/hal/drivers/amdgpu/util/aql_ring.h"
+#include "iree/hal/drivers/amdgpu/util/libaqlprofile.h"
+#include "iree/hal/drivers/amdgpu/util/target_id.h"
 #include "iree/hal/profile_schema.h"
 #include "iree/hal/profile_sink.h"
 
@@ -28,6 +30,15 @@ typedef struct iree_hal_amdgpu_profile_counter_session_t
     iree_hal_amdgpu_profile_counter_session_t;
 typedef struct iree_hal_amdgpu_profile_dispatch_event_reservation_t
     iree_hal_amdgpu_profile_dispatch_event_reservation_t;
+
+// Returns a comma-separated list of supported counter names.
+iree_string_view_t iree_hal_amdgpu_profile_counter_supported_names(void);
+
+// Resolves a supported counter name to the aqlprofile event for
+// |gfxip_version|.
+iree_status_t iree_hal_amdgpu_profile_counter_resolve_named_event(
+    iree_string_view_t name, iree_hal_amdgpu_gfxip_version_t gfxip_version,
+    iree_hal_amdgpu_aqlprofile_pmc_event_t* out_event);
 
 // Flags selecting which counter resources to enable on a host queue.
 typedef uint32_t iree_hal_amdgpu_profile_counter_enable_flags_t;

--- a/runtime/src/iree/hal/drivers/amdgpu/profile_counters_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/profile_counters_test.cc
@@ -1,0 +1,122 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/profile_counters.h"
+
+#include <string>
+
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree::hal::amdgpu {
+namespace {
+
+static iree_hal_amdgpu_gfxip_version_t GfxIpFromProcessor(
+    iree_string_view_t processor) {
+  iree_hal_amdgpu_target_id_t target_id = {};
+  IREE_EXPECT_OK(iree_hal_amdgpu_target_id_parse(
+      processor, IREE_HAL_AMDGPU_TARGET_ID_PARSE_FLAG_ALLOW_ARCH_ONLY,
+      &target_id));
+  return target_id.version;
+}
+
+static iree_hal_amdgpu_aqlprofile_pmc_event_t ResolveCounter(
+    iree_string_view_t name, iree_string_view_t processor) {
+  iree_hal_amdgpu_aqlprofile_pmc_event_t event = {};
+  IREE_EXPECT_OK(iree_hal_amdgpu_profile_counter_resolve_named_event(
+      name, GfxIpFromProcessor(processor), &event));
+  return event;
+}
+
+static iree_status_code_t ResolveCounterStatus(iree_string_view_t name,
+                                               iree_string_view_t processor) {
+  iree_hal_amdgpu_aqlprofile_pmc_event_t event = {};
+  iree_status_t status = iree_hal_amdgpu_profile_counter_resolve_named_event(
+      name, GfxIpFromProcessor(processor), &event);
+  iree_status_code_t status_code = iree_status_code(status);
+  iree_status_free(status);
+  return status_code;
+}
+
+TEST(ProfileCountersTest, MapsGfx942ThroughGfx940CounterFamily) {
+  iree_hal_amdgpu_aqlprofile_pmc_event_t gfx940_event =
+      ResolveCounter(IREE_SV("SQ_INSTS_VMEM_RD"), IREE_SV("gfx940"));
+  iree_hal_amdgpu_aqlprofile_pmc_event_t gfx941_event =
+      ResolveCounter(IREE_SV("SQ_INSTS_VMEM_RD"), IREE_SV("gfx941"));
+  iree_hal_amdgpu_aqlprofile_pmc_event_t gfx942_event =
+      ResolveCounter(IREE_SV("SQ_INSTS_VMEM_RD"), IREE_SV("gfx942"));
+
+  EXPECT_EQ(gfx940_event.event_id, 58u);
+  EXPECT_EQ(gfx941_event.event_id, 58u);
+  EXPECT_EQ(gfx942_event.event_id, 58u);
+  EXPECT_EQ(gfx942_event.block_name, IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_SQ);
+
+  iree_hal_amdgpu_aqlprofile_pmc_event_t tcc_event =
+      ResolveCounter(IREE_SV("TCC_EA0_RDREQ_DRAM"), IREE_SV("gfx942"));
+  EXPECT_EQ(tcc_event.event_id, 102u);
+  EXPECT_EQ(tcc_event.block_name, IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TCC);
+}
+
+TEST(ProfileCountersTest, KeepsGfx90aAndGfx940Separate) {
+  iree_hal_amdgpu_aqlprofile_pmc_event_t gfx90a_vmem_read =
+      ResolveCounter(IREE_SV("SQ_INSTS_VMEM_RD"), IREE_SV("gfx90a"));
+  iree_hal_amdgpu_aqlprofile_pmc_event_t gfx940_vmem_read =
+      ResolveCounter(IREE_SV("SQ_INSTS_VMEM_RD"), IREE_SV("gfx940"));
+  iree_hal_amdgpu_aqlprofile_pmc_event_t gfx942_vmem_read =
+      ResolveCounter(IREE_SV("SQ_INSTS_VMEM_RD"), IREE_SV("gfx942"));
+
+  EXPECT_EQ(gfx90a_vmem_read.event_id, 54u);
+  EXPECT_EQ(gfx940_vmem_read.event_id, 58u);
+  EXPECT_EQ(gfx942_vmem_read.event_id, 58u);
+
+  iree_hal_amdgpu_aqlprofile_pmc_event_t gfx90a_tcp_read =
+      ResolveCounter(IREE_SV("TCP_TOTAL_READ"), IREE_SV("gfx90a"));
+  iree_hal_amdgpu_aqlprofile_pmc_event_t gfx940_tcp_read =
+      ResolveCounter(IREE_SV("TCP_TOTAL_READ"), IREE_SV("gfx940"));
+  iree_hal_amdgpu_aqlprofile_pmc_event_t gfx942_tcp_read =
+      ResolveCounter(IREE_SV("TCP_TOTAL_READ"), IREE_SV("gfx942"));
+
+  EXPECT_EQ(gfx90a_tcp_read.event_id, 30u);
+  EXPECT_EQ(gfx940_tcp_read.event_id, 28u);
+  EXPECT_EQ(gfx942_tcp_read.event_id, 28u);
+}
+
+TEST(ProfileCountersTest, UsesRocprofilerGfx10AndGfx11SqValuIds) {
+  iree_hal_amdgpu_aqlprofile_pmc_event_t gfx1010_event =
+      ResolveCounter(IREE_SV("SQ_INSTS_VALU"), IREE_SV("gfx1010"));
+  iree_hal_amdgpu_aqlprofile_pmc_event_t gfx1100_event =
+      ResolveCounter(IREE_SV("SQ_INSTS_VALU"), IREE_SV("gfx1100"));
+
+  EXPECT_EQ(gfx1010_event.event_id, 64u);
+  EXPECT_EQ(gfx1100_event.event_id, 62u);
+}
+
+TEST(ProfileCountersTest, RejectsUnsupportedExactTargets) {
+  EXPECT_EQ(ResolveCounterStatus(IREE_SV("SQ_WAVES"), IREE_SV("gfx950")),
+            IREE_STATUS_UNIMPLEMENTED);
+  EXPECT_EQ(ResolveCounterStatus(IREE_SV("SQ_WAVES"), IREE_SV("gfx1103")),
+            IREE_STATUS_UNIMPLEMENTED);
+  EXPECT_EQ(ResolveCounterStatus(IREE_SV("SQ_WAVES"), IREE_SV("gfx1200")),
+            IREE_STATUS_UNIMPLEMENTED);
+}
+
+TEST(ProfileCountersTest, RejectsUnsupportedCounterOnSupportedTarget) {
+  EXPECT_EQ(ResolveCounterStatus(IREE_SV("SQ_WAVES_EQ_64"), IREE_SV("gfx1100")),
+            IREE_STATUS_UNIMPLEMENTED);
+}
+
+TEST(ProfileCountersTest, SupportedNamesUseRocprofilerNames) {
+  std::string supported_names(
+      iree_hal_amdgpu_profile_counter_supported_names().data,
+      iree_hal_amdgpu_profile_counter_supported_names().size);
+
+  EXPECT_NE(supported_names.find("SQ_WAVES_EQ_64"), std::string::npos);
+  EXPECT_EQ(supported_names.find("SQ_WAVES_32"), std::string::npos);
+  EXPECT_EQ(supported_names.find("SQ_WAVES_64"), std::string::npos);
+}
+
+}  // namespace
+}  // namespace iree::hal::amdgpu

--- a/runtime/src/iree/hal/drivers/amdgpu/util/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/BUILD.bazel
@@ -59,6 +59,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base/internal:dynamic_library",
         "//runtime/src/iree/base/internal:path",
         "//runtime/src/iree/hal/drivers/amdgpu/abi",
+        "//third_party:aqlprofile_sdk_headers",
         "//third_party:hsa_runtime_headers",
     ],
 )

--- a/runtime/src/iree/hal/drivers/amdgpu/util/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_cc_library(
     iree::base::internal::dynamic_library
     iree::base::internal::path
     iree::hal::drivers::amdgpu::abi
+    iree::third_party::aqlprofile_sdk_headers
     iree::third_party::hsa_runtime_headers
   PUBLIC
 )

--- a/runtime/src/iree/hal/drivers/amdgpu/util/libaqlprofile.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/libaqlprofile.c
@@ -8,12 +8,6 @@
 
 #include <string.h>
 
-#if !defined(IREE_HAL_AMDGPU_ENABLE_AQLPROFILE)
-#define IREE_HAL_AMDGPU_ENABLE_AQLPROFILE 0
-#endif  // !IREE_HAL_AMDGPU_ENABLE_AQLPROFILE
-
-#if IREE_HAL_AMDGPU_ENABLE_AQLPROFILE
-
 // Some ROCm aqlprofile SDK headers define these C tag types without matching
 // typedefs, then use the untagged names in public prototypes.
 typedef struct aqlprofile_att_buffer_status_t aqlprofile_att_buffer_status_t;
@@ -481,56 +475,3 @@ iree_status_t iree_status_from_aqlprofile_status(
       "%s failed with hsa_status=0x%08X (%s)%s%s", symbol, (uint32_t)hsa_status,
       error_string, message ? ": " : "", message ? message : "");
 }
-
-#else  // IREE_HAL_AMDGPU_ENABLE_AQLPROFILE
-
-iree_status_t iree_hal_amdgpu_libaqlprofile_initialize(
-    const iree_hal_amdgpu_libhsa_t* libhsa,
-    iree_string_view_list_t search_paths, iree_allocator_t host_allocator,
-    iree_hal_amdgpu_libaqlprofile_t* out_libaqlprofile) {
-  IREE_ASSERT_ARGUMENT(libhsa);
-  IREE_ASSERT_ARGUMENT(out_libaqlprofile);
-  (void)libhsa;
-  (void)search_paths;
-  (void)host_allocator;
-  memset(out_libaqlprofile, 0, sizeof(*out_libaqlprofile));
-  return iree_make_status(
-      IREE_STATUS_UNIMPLEMENTED,
-      "AMDGPU aqlprofile support is disabled at build time");
-}
-
-void iree_hal_amdgpu_libaqlprofile_deinitialize(
-    iree_hal_amdgpu_libaqlprofile_t* libaqlprofile) {
-  IREE_ASSERT_ARGUMENT(libaqlprofile);
-  memset(libaqlprofile, 0, sizeof(*libaqlprofile));
-}
-
-bool iree_hal_amdgpu_libaqlprofile_has_att_support(
-    const iree_hal_amdgpu_libaqlprofile_t* libaqlprofile) {
-  (void)libaqlprofile;
-  return false;
-}
-
-iree_status_t iree_hal_amdgpu_libaqlprofile_require_att_support(
-    const iree_hal_amdgpu_libaqlprofile_t* libaqlprofile,
-    const char* context_message) {
-  (void)libaqlprofile;
-  return iree_make_status(
-      IREE_STATUS_UNIMPLEMENTED,
-      "AMDGPU aqlprofile support is disabled at build time%s%s",
-      context_message ? ": " : "", context_message ? context_message : "");
-}
-
-iree_status_t iree_status_from_aqlprofile_status(
-    const iree_hal_amdgpu_libaqlprofile_t* libaqlprofile, const char* file,
-    uint32_t line, hsa_status_t hsa_status, const char* symbol,
-    const char* message) {
-  (void)libaqlprofile;
-  if (hsa_status == HSA_STATUS_SUCCESS) return iree_ok_status();
-  return iree_make_status_with_location(
-      file, line, IREE_STATUS_INTERNAL,
-      "%s failed with hsa_status=0x%08X from AMDGPU aqlprofile%s%s", symbol,
-      (uint32_t)hsa_status, message ? ": " : "", message ? message : "");
-}
-
-#endif  // IREE_HAL_AMDGPU_ENABLE_AQLPROFILE

--- a/runtime/src/iree/hal/drivers/amdgpu/util/libaqlprofile.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/libaqlprofile.h
@@ -62,6 +62,9 @@ enum iree_hal_amdgpu_aqlprofile_parameter_name_e {
 typedef uint32_t iree_hal_amdgpu_aqlprofile_block_name_t;
 enum iree_hal_amdgpu_aqlprofile_block_name_e {
   IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_SQ = 6,
+  IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TA = 10,
+  IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TCC = 12,
+  IREE_HAL_AMDGPU_AQLPROFILE_BLOCK_NAME_TCP = 13,
 };
 
 typedef union iree_hal_amdgpu_aqlprofile_buffer_desc_flags_t {

--- a/runtime/src/iree/hal/profile_options.h
+++ b/runtime/src/iree/hal/profile_options.h
@@ -49,8 +49,9 @@ enum iree_hal_device_profiling_data_family_bits_t {
   // when they cannot retain complete selected events.
   IREE_HAL_DEVICE_PROFILING_DATA_DISPATCH_EVENTS = 1ull << 3,
 
-  // Explicitly selected hardware/software counter samples attributed to
-  // individual operations. Requested counters are described by |counter_sets|.
+  // Hardware/software counter samples attributed to individual operations.
+  // Empty |counter_sets| requests the target's default best-effort counter set;
+  // explicit counter names are strict.
   IREE_HAL_DEVICE_PROFILING_DATA_COUNTER_SAMPLES = 1ull << 4,
 
   // Executable/code-object/function metadata needed for offline analysis. Some
@@ -82,9 +83,10 @@ enum iree_hal_device_profiling_data_family_bits_t {
   // in dispatch or host-execution event families.
   IREE_HAL_DEVICE_PROFILING_DATA_COMMAND_REGION_EVENTS = 1ull << 9,
 
-  // Explicitly selected hardware/software counter ranges. Requested counters
-  // are described by |counter_sets| and are sampled over producer-defined time
-  // ranges without requiring operation attribution.
+  // Hardware/software counter ranges sampled over producer-defined time ranges
+  // without requiring operation attribution. Empty |counter_sets| requests the
+  // target's default best-effort counter set; explicit counter names are
+  // strict.
   IREE_HAL_DEVICE_PROFILING_DATA_COUNTER_RANGES = 1ull << 10,
 };
 
@@ -210,11 +212,14 @@ enum iree_hal_profile_counter_set_selection_flag_bits_t {
 // Caller-provided hardware counter set selection.
 //
 // The selection describes one named group of hardware counters requested for a
-// profiling session. All pointers are borrowed and must remain valid for the
-// duration of iree_hal_device_profiling_begin. A producer that supports the
-// selected counters emits one counter-set metadata record, one counter metadata
-// record per resolved counter, and counter-sample records using the same
-// |counter_set_id|.
+// profiling session. An empty counter name list asks the implementation to
+// choose the target's default best-effort counter set. A non-empty counter name
+// list is strict: producers must either capture every named counter or fail
+// iree_hal_device_profiling_begin. All pointers are borrowed and must remain
+// valid for the duration of iree_hal_device_profiling_begin. A producer that
+// supports the selected counters emits one counter-set metadata record, one
+// counter metadata record per resolved counter, and counter-sample records
+// using the same |counter_set_id|.
 typedef struct iree_hal_profile_counter_set_selection_t {
   // Flags controlling counter set selection behavior.
   iree_hal_profile_counter_set_selection_flags_t flags;
@@ -251,14 +256,14 @@ typedef struct iree_hal_device_profiling_options_t {
   // string views it contains before returning from profiling_begin.
   iree_hal_profile_capture_filter_t capture_filter;
 
-  // Number of explicitly requested hardware/software counter sets. Must be
-  // nonzero when requesting counter samples or counter ranges.
+  // Number of requested hardware/software counter sets. If zero when requesting
+  // counter samples or counter ranges, the implementation selects the target's
+  // default best-effort counter set.
   iree_host_size_t counter_set_count;
 
-  // Borrowed begin-call-only array of explicitly requested counter sets.
-  // Implementations must either capture every requested counter set exactly or
-  // fail profiling_begin; silently dropping counters would make the profile
-  // bundle misleading.
+  // Borrowed begin-call-only array of requested counter sets. Empty selections
+  // are target-default and best-effort; selections with explicit counter names
+  // are strict.
   const iree_hal_profile_counter_set_selection_t* counter_sets;
 } iree_hal_device_profiling_options_t;
 


### PR DESCRIPTION
Make AMDGPU profiling counters usable by default and harden the source-built device toolchain path used by AMDGPU execution tests.

The counter changes remove the hidden aqlprofile build switch from the AMDGPU HAL path: when AMDGPU support is enabled and the SDK headers are available, the aqlprofile wrapper is built, while the runtime library remains dynamically loaded only when profiling actually asks for counters. Default counter collection now means "use the supported counters for this target" rather than requiring users or agents to enumerate architecture-specific counters up front. Explicit counter lists remain strict, so a misspelled or unsupported counter still fails loudly.

The profiling counter table also moves from coarse gfx-major guesses to ROCProfiler-style target families. That keeps the default behavior conservative on targets where the available counters are not proven, while letting gfx940-family and gfx1100-family defaults work without making users encode per-machine knowledge.

The toolchain discovery change fixes the source-built AMDGPU executable path for ROCm/TheRock installs that expose a `clang` shim which execs a versioned sibling such as `clang-23`. Both the Bazel repository rule and the standalone device binary generator now derive the versioned driver from `-print-resource-dir` before exposing clang as a reusable tool, so generated/symlinked toolchains do not depend on the shim's original filesystem location.

Fixes #110.