### PR TITLE
[Loom] Preserve wide LDS loads through scalar consumers

### DIFF
--- a/loom/src/loom/ops/vector/canonicalize.c
+++ b/loom/src/loom/ops/vector/canonicalize.c
@@ -136,6 +136,18 @@ static bool loom_vector_value_is_all_bool(const loom_rewriter_t* rewriter,
                                             expected ? 1 : 0);
 }
 
+static bool loom_vector_value_is_workgroup_view(const loom_rewriter_t* rewriter,
+                                                loom_value_id_t value_id) {
+  if (!rewriter->fact_table) return false;
+  loom_value_fact_view_reference_t reference = {0};
+  if (!loom_value_facts_query_view_reference(
+          &rewriter->fact_table->context,
+          loom_rewriter_value_facts(rewriter, value_id), &reference)) {
+    return false;
+  }
+  return reference.memory_space == LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP;
+}
+
 static bool loom_vector_facts_to_constant_attr(loom_value_facts_t facts,
                                                loom_scalar_type_t element_type,
                                                loom_attribute_t* out_attr) {
@@ -718,6 +730,10 @@ static iree_status_t loom_vector_canonicalize_extract_from_load(
   }
 
   const loom_value_id_t view = loom_vector_load_view(source_def_op);
+  if (loom_vector_value_is_workgroup_view(rewriter, view)) {
+    return iree_ok_status();
+  }
+
   const loom_type_t view_type = loom_module_value_type(rewriter->module, view);
   const loom_fact_context_t* fact_context =
       rewriter->fact_table ? &rewriter->fact_table->context : NULL;

--- a/loom/src/loom/ops/vector/test/canonicalize.loom-test
+++ b/loom/src/loom/ops/vector/test/canonicalize.loom-test
@@ -177,6 +177,27 @@ func.def @extract_single_use_load_to_view_load(%input: buffer, %offset: offset) 
 
 // ====
 
+// Workgroup vector loads preserve their footprint even when only one scalar
+// lane is consumed. Backends use the vector memory operation as a scheduling
+// contract for LDS packet selection.
+kernel.def @extract_single_use_workgroup_load_keeps_wide_load() {
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
+} launch() {
+  %zero = index.constant 0 : offset
+  %bytes = index.constant 64 : offset
+  %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %view = buffer.view %scratch[%zero] : buffer -> view<4xi32, #dense>
+  %seed = vector.constant 1 : vector<4xi32>
+  vector.store %seed, %view[0] : vector<4xi32>, view<4xi32, #dense>
+  %wide = vector.load %view[0] : view<4xi32, #dense> -> vector<4xi32>
+  %lane2 = vector.extract %wide[2] : vector<4xi32> -> i32
+  view.store %lane2, %view[0] : i32, view<4xi32, #dense>
+  kernel.return
+}
+
+// ====
+
 // When multiple scalar lanes are extracted, the wide vector load is still the
 // better canonical form: target lowering can select one coalesced memory op and
 // slice registers instead of scalarizing into several smaller loads.

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_workgroup_b128.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_workgroup_b128.loom-test
@@ -38,6 +38,45 @@ low.kernel.def target(@target) workgroup_size(64, 1, 1) @lds_b128_roundtrip() as
 // ====
 
 amdgpu.target<gfx1100> @target
+kernel.def target(@target) @lds_b128_single_lane_extract() {
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 64 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
+} launch(%input: buffer, %output: buffer) {
+  %lane = kernel.workitem.id<x> : index
+  %zero = index.constant 0 : offset
+  %bytes = index.constant 1024 : offset
+  %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
+  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
+  vector.store %loaded, %scratch_view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
+  %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
+  %lane2 = vector.extract %roundtrip[2] : vector<4xi32> -> i32
+  view.store %lane2, %output_view[%lane] : i32, view<64xi32, #dense>
+  kernel.return
+}
+
+// ----
+low.kernel.def target(@target) workgroup_size(64, 1, 1) @lds_b128_single_lane_extract() asm<amdgpu.rdna3.core> {
+  %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
+  %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
+  %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
+  %33 = storage {byte_alignment = 16, byte_length = 1024} : low.storage<workgroup>
+  %35 = v_lshlrev_b32_src0_inline %lane, 4
+  %loaded = global_load_b128_saddr %35, %input_view
+  ds_write_b128 %35, %loaded
+  %roundtrip = ds_read_b128 %35
+  %lane2 = slice %roundtrip[2] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
+  %41 = v_lshlrev_b32_src0_inline %lane, 2
+  global_store_b32_saddr %41, %lane2, %output_view
+  return
+}
+
+// ====
+
+amdgpu.target<gfx1100> @target
 kernel.def target(@target) @lds_b128_xor_swizzle_roundtrip() {
   %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index

--- a/loom/src/loom/test/corpus/source_low/memory_workgroup_b128.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_workgroup_b128.loom-test
@@ -21,6 +21,28 @@ kernel.def @lds_b128_roundtrip() {
 
 // ====
 
+kernel.def @lds_b128_single_lane_extract() {
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 64 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
+} launch(%input: buffer, %output: buffer) {
+  %lane = kernel.workitem.id<x> : index
+  %zero = index.constant 0 : offset
+  %bytes = index.constant 1024 : offset
+  %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
+  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
+  vector.store %loaded, %scratch_view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
+  %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
+  %lane2 = vector.extract %roundtrip[2] : vector<4xi32> -> i32
+  view.store %lane2, %output_view[%lane] : i32, view<64xi32, #dense>
+  kernel.return
+}
+
+// ====
+
 kernel.def @lds_b128_xor_swizzle_roundtrip() {
   %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index


### PR DESCRIPTION
Preserves the vector footprint of workgroup memory loads when a scalar extract is the immediate consumer. The vector canonicalizer previously treated single-use `vector.load` plus `vector.extract` as a scalarization opportunity in every memory space. That is profitable for ordinary scalar consumers, but it erases the access width before AMDGPU memory selection can see that an LDS load was authored as `vector<4xi32>`, forcing scalar `ds_read_b32` packets where the hardware has a wide `ds_read_b128` packet.

This change teaches the canonicalizer to consult value facts for the loaded view and keep workgroup-space vector loads intact. The scalar lane still materializes through `vector.extract`, so later lowering can select a wide LDS packet and slice the requested lane from the loaded register group. The shared source-low corpus now includes the authorable pattern, and the AMDGPU projection locks the expected `ds_write_b128`/`ds_read_b128` lowering.

This is intentionally a narrow compiler-contract change: it does not try to infer global performance intent from every vector load, and it keeps the decision rooted in memory-space facts so non-workgroup scalarization behavior stays unchanged.
