### PR TITLE
[Loom] Add AMDGPU packed-dot schedule guardrails

### DIFF
--- a/loom/src/loom/target/arch/amdgpu/BUILD.bazel
+++ b/loom/src/loom/target/arch/amdgpu/BUILD.bazel
@@ -432,6 +432,7 @@ loom_check_test_suite(
         "//loom/src/loom/test/corpus/source_low:packed_dot_float8.loom-test",
         "//loom/src/loom/test/corpus/source_low:packed_dot_i4_mixed.loom-test",
         "//loom/src/loom/test/corpus/source_low:packed_dot_integer.loom-test",
+        "//loom/src/loom/test/corpus/source_low:packed_dot_wide.loom-test",
         "//loom/src/loom/test/corpus/source_low:packed_payload_offsets.loom-test",
         "//loom/src/loom/test/corpus/source_low:packed_q8_dequant_dot.loom-test",
         "//loom/src/loom/test/corpus/source_low:sync_barrier.loom-test",

--- a/loom/src/loom/target/arch/amdgpu/CMakeLists.txt
+++ b/loom/src/loom/target/arch/amdgpu/CMakeLists.txt
@@ -450,6 +450,7 @@ loom_check_test_suite(
     "${PROJECT_SOURCE_DIR}/loom/src/loom/test/corpus/source_low/packed_dot_float8.loom-test"
     "${PROJECT_SOURCE_DIR}/loom/src/loom/test/corpus/source_low/packed_dot_i4_mixed.loom-test"
     "${PROJECT_SOURCE_DIR}/loom/src/loom/test/corpus/source_low/packed_dot_integer.loom-test"
+    "${PROJECT_SOURCE_DIR}/loom/src/loom/test/corpus/source_low/packed_dot_wide.loom-test"
     "${PROJECT_SOURCE_DIR}/loom/src/loom/test/corpus/source_low/packed_payload_offsets.loom-test"
     "${PROJECT_SOURCE_DIR}/loom/src/loom/test/corpus/source_low/packed_q8_dequant_dot.loom-test"
     "${PROJECT_SOURCE_DIR}/loom/src/loom/test/corpus/source_low/sync_barrier.loom-test"

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_report.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_report.loom-test
@@ -66,3 +66,46 @@ COMPILE-REPORT: source_low[8] function=report_lds_read2_write2_bank_fields sourc
 COMPILE-REPORT: source_low[9] function=report_lds_read2_write2_bank_fields source_op=vector.store selection=plan plan=3606 descriptor=0 emitted_ops=2
 COMPILE-REPORT: source_low_memory[0] function=report_lds_read2_write2_bank_fields source_op=vector.store memory_space=workgroup operation=store packet=amdgpu.ds_write2_b32 descriptor=2245861438422952198 element_bytes=4 vector_lanes=2 dynamic_stride_bytes=32 vector_lane_stride_bytes=8 bank_stride_words=8 bank_conflict_degree=8 bank_conflict_kind=bank-conflict-risk
 COMPILE-REPORT: source_low_memory[1] function=report_lds_read2_write2_bank_fields source_op=vector.load memory_space=workgroup operation=load packet=amdgpu.ds_read2_b32 descriptor=211090682926363697 element_bytes=4 vector_lanes=2 dynamic_stride_bytes=32 vector_lane_stride_bytes=8 bank_stride_words=8 bank_conflict_degree=8 bank_conflict_kind=bank-conflict-risk
+
+// ====
+
+amdgpu.target<gfx1100> @target
+
+kernel.def target(@target) @report_lds_b128_single_lane_extract() {
+  %c1 = index.constant 1 : index
+  %c64 = index.constant 64 : index
+  kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
+} launch(%input: buffer, %output: buffer) {
+  %tid = kernel.workitem.id<x> : index
+  %zero = index.constant 0 : offset
+  %bytes = index.constant 1024 : offset
+  %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
+  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %loaded = vector.load %input_view[%tid, 0] : view<64x4xi32, #dense> -> vector<4xi32>
+  vector.store %loaded, %scratch_view[%tid, 0] : vector<4xi32>, view<64x4xi32, #dense>
+  %roundtrip = vector.load %scratch_view[%tid, 0] : view<64x4xi32, #dense> -> vector<4xi32>
+  %lane2 = vector.extract %roundtrip[2] : vector<4xi32> -> i32
+  view.store %lane2, %output_view[%tid] : i32, view<64xi32, #dense>
+  kernel.return
+}
+
+// ----
+COMPILE-REPORT: summary artifact=none status=OK function=- backend=- bundle=- export=- export_symbol=- config=- lowered=-
+COMPILE-REPORT: source_low selected_ops=12 emitted_ops=11 rows=12
+COMPILE-REPORT: source_low_memory rows=2
+COMPILE-REPORT: source_low[0] function=report_lds_b128_single_lane_extract source_op=kernel.workitem.id selection=plan plan=4112 descriptor=0 emitted_ops=0
+COMPILE-REPORT: source_low[1] function=report_lds_b128_single_lane_extract source_op=index.constant selection=plan plan=3840 descriptor=0 emitted_ops=0
+COMPILE-REPORT: source_low[2] function=report_lds_b128_single_lane_extract source_op=index.constant selection=plan plan=3840 descriptor=0 emitted_ops=0
+COMPILE-REPORT: source_low[3] function=report_lds_b128_single_lane_extract source_op=buffer.alloca selection=plan plan=3072 descriptor=0 emitted_ops=2
+COMPILE-REPORT: source_low[4] function=report_lds_b128_single_lane_extract source_op=buffer.view selection=rule rule_set=1 rule=0 descriptor=0 emitted_ops=0
+COMPILE-REPORT: source_low[5] function=report_lds_b128_single_lane_extract source_op=buffer.view selection=rule rule_set=1 rule=0 descriptor=0 emitted_ops=0
+COMPILE-REPORT: source_low[6] function=report_lds_b128_single_lane_extract source_op=buffer.view selection=rule rule_set=1 rule=0 descriptor=0 emitted_ops=0
+COMPILE-REPORT: source_low[7] function=report_lds_b128_single_lane_extract source_op=vector.load selection=plan plan=3605 descriptor=0 emitted_ops=2
+COMPILE-REPORT: source_low[8] function=report_lds_b128_single_lane_extract source_op=vector.store selection=plan plan=3606 descriptor=0 emitted_ops=2
+COMPILE-REPORT: source_low[9] function=report_lds_b128_single_lane_extract source_op=vector.load selection=plan plan=3605 descriptor=0 emitted_ops=2
+COMPILE-REPORT: source_low[10] function=report_lds_b128_single_lane_extract source_op=vector.extract selection=plan plan=3592 descriptor=0 emitted_ops=1
+COMPILE-REPORT: source_low[11] function=report_lds_b128_single_lane_extract source_op=view.store selection=plan plan=3331 descriptor=0 emitted_ops=2
+COMPILE-REPORT: source_low_memory[0] function=report_lds_b128_single_lane_extract source_op=vector.store memory_space=workgroup operation=store packet=amdgpu.ds_write_b128 descriptor=135153244011467798 element_bytes=4 vector_lanes=4 dynamic_stride_bytes=16 vector_lane_stride_bytes=4 bank_stride_words=4 bank_conflict_degree=4 bank_conflict_kind=bank-conflict-risk
+COMPILE-REPORT: source_low_memory[1] function=report_lds_b128_single_lane_extract source_op=vector.load memory_space=workgroup operation=load packet=amdgpu.ds_read_b128 descriptor=8908758602290675705 element_bytes=4 vector_lanes=4 dynamic_stride_bytes=16 vector_lane_stride_bytes=4 bank_stride_words=4 bank_conflict_degree=4 bank_conflict_kind=bank-conflict-risk

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_ml_contraction.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_ml_contraction.loom-test
@@ -198,6 +198,62 @@ low.func.def target(@target) abi(hal_kernel) @i4_dot8_two_k_blocks(%lhs0: reg<am
 // ====
 
 amdgpu.target<gfx1100> @target
+kernel.def target(@target) @workgroup_cached_dot4i_u8s8_tile() {
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 64 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
+} launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output_buffer: buffer) {
+  %lane = kernel.workitem.id<x> : index
+  %zero = index.constant 0 : offset
+  %bytes = index.constant 1024 : offset
+  %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64x16xi8, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64x16xi8, #dense>
+  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x16xi8, #dense>
+  %output_view = buffer.view %output_buffer[%zero] : buffer -> view<64x4xi32, #dense>
+  %lhs = vector.load %lhs_view[%lane, 0] : view<64x16xi8, #dense> -> vector<16xi8>
+  vector.store %lhs, %scratch_view[%lane, 0] : vector<16xi8>, view<64x16xi8, #dense>
+  %lhs_cached = vector.load %scratch_view[%lane, 0] : view<64x16xi8, #dense> -> vector<16xi8>
+  %rhs = vector.load %rhs_view[%lane, 0] : view<64x16xi8, #dense> -> vector<16xi8>
+  %acc = vector.constant 0 : vector<4xi32>
+  %dot = vector.dot4i<u8s8> %lhs_cached, %rhs, %acc : vector<16xi8>, vector<16xi8>, vector<4xi32>
+  vector.store %dot, %output_view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
+  kernel.return
+}
+
+// ----
+low.kernel.def target(@target) workgroup_size(64, 1, 1) @workgroup_cached_dot4i_u8s8_tile() asm<amdgpu.rdna3.core> {
+  %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
+  %lhs_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
+  %rhs_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
+  %output_view = resource<hal_binding> {index = 2, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
+  %49 = storage {byte_alignment = 16, byte_length = 1024} : low.storage<workgroup>
+  %51 = v_lshlrev_b32_src0_inline %lane, 4
+  %lhs = global_load_b128_saddr %51, %lhs_view
+  ds_write_b128 %51, %lhs
+  %lhs_cached = ds_read_b128 %51
+  %rhs = global_load_b128_saddr %51, %rhs_view
+  %58 = v_mov_b32 0
+  %63 = slice %lhs_cached[0] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
+  %64 = slice %rhs[0] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
+  %66 = v_dot4_i32_iu8_u8s8 %63, %64, %58
+  %67 = slice %lhs_cached[1] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
+  %68 = slice %rhs[1] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
+  %70 = v_dot4_i32_iu8_u8s8 %67, %68, %58
+  %71 = slice %lhs_cached[2] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
+  %72 = slice %rhs[2] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
+  %74 = v_dot4_i32_iu8_u8s8 %71, %72, %58
+  %75 = slice %lhs_cached[3] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
+  %76 = slice %rhs[3] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
+  %78 = v_dot4_i32_iu8_u8s8 %75, %76, %58
+  %dot = concat(%66, %70, %74, %78) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x4>
+  global_store_b128_saddr %51, %dot, %output_view
+  return
+}
+
+// ====
+
+amdgpu.target<gfx1100> @target
 func.def target(@target) @tail_selected_f32_dot(%lhs: vector<4xf32>, %rhs: vector<4xf32>, %acc: f32, %lane: i32, %limit: i32) -> (f32) {
   %dot = vector.dotf %lhs, %rhs, %acc : vector<4xf32>, vector<4xf32>, f32
   %inside = scalar.cmpi slt, %lane, %limit : i32

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_packed_dot_wide.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_packed_dot_wide.loom-test
@@ -1,0 +1,139 @@
+// TEMPLATE: loom/src/loom/test/corpus/source_low/packed_dot_wide.loom-test
+// RUN: emit source-low output=low
+
+amdgpu.target<gfx1100> @target
+func.def target(@target) @bf16_dot2_256(%lhs: vector<16xbf16>, %rhs: vector<16xbf16>, %acc: vector<8xf32>) -> (vector<8xf32>) {
+  %dot = vector.dot2f %lhs, %rhs, %acc : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
+  func.return %dot : vector<8xf32>
+}
+
+// ----
+low.func.def target(@target) abi(hal_kernel) @bf16_dot2_256(%lhs: reg<amdgpu.vgpr x8>, %rhs: reg<amdgpu.vgpr x8>, %acc: reg<amdgpu.vgpr x8>) -> (reg<amdgpu.vgpr x8>) asm<amdgpu.rdna3.core> {
+  %9 = copy %acc : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
+  %10 = slice %lhs[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %11 = slice %rhs[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %12 = slice %9[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %13 = v_dot2_f32_bf16 %10, %11, %12
+  %14 = slice %lhs[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %15 = slice %rhs[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %16 = slice %9[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %17 = v_dot2_f32_bf16 %14, %15, %16
+  %18 = slice %lhs[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %19 = slice %rhs[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %20 = slice %9[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %21 = v_dot2_f32_bf16 %18, %19, %20
+  %22 = slice %lhs[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %23 = slice %rhs[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %24 = slice %9[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %25 = v_dot2_f32_bf16 %22, %23, %24
+  %26 = slice %lhs[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %27 = slice %rhs[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %28 = slice %9[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %29 = v_dot2_f32_bf16 %26, %27, %28
+  %30 = slice %lhs[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %31 = slice %rhs[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %32 = slice %9[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %33 = v_dot2_f32_bf16 %30, %31, %32
+  %34 = slice %lhs[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %35 = slice %rhs[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %36 = slice %9[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %37 = v_dot2_f32_bf16 %34, %35, %36
+  %38 = slice %lhs[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %39 = slice %rhs[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %40 = slice %9[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %41 = v_dot2_f32_bf16 %38, %39, %40
+  %dot = concat(%13, %17, %21, %25, %29, %33, %37, %41) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x8>
+  return %dot
+}
+
+// ====
+
+amdgpu.target<gfx1100> @target
+func.def target(@target) @dot4i_u8s8_256(%lhs: vector<32xi8>, %rhs: vector<32xi8>, %acc: vector<8xi32>) -> (vector<8xi32>) {
+  %dot = vector.dot4i<u8s8> %lhs, %rhs, %acc : vector<32xi8>, vector<32xi8>, vector<8xi32>
+  func.return %dot : vector<8xi32>
+}
+
+// ----
+low.func.def target(@target) abi(hal_kernel) @dot4i_u8s8_256(%lhs: reg<amdgpu.vgpr x8>, %rhs: reg<amdgpu.vgpr x8>, %acc: reg<amdgpu.vgpr x8>) -> (reg<amdgpu.vgpr x8>) asm<amdgpu.rdna3.core> {
+  %9 = slice %lhs[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %10 = slice %rhs[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %11 = slice %acc[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %12 = v_dot4_i32_iu8_u8s8 %9, %10, %11
+  %13 = slice %lhs[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %14 = slice %rhs[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %15 = slice %acc[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %16 = v_dot4_i32_iu8_u8s8 %13, %14, %15
+  %17 = slice %lhs[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %18 = slice %rhs[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %19 = slice %acc[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %20 = v_dot4_i32_iu8_u8s8 %17, %18, %19
+  %21 = slice %lhs[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %22 = slice %rhs[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %23 = slice %acc[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %24 = v_dot4_i32_iu8_u8s8 %21, %22, %23
+  %25 = slice %lhs[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %26 = slice %rhs[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %27 = slice %acc[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %28 = v_dot4_i32_iu8_u8s8 %25, %26, %27
+  %29 = slice %lhs[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %30 = slice %rhs[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %31 = slice %acc[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %32 = v_dot4_i32_iu8_u8s8 %29, %30, %31
+  %33 = slice %lhs[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %34 = slice %rhs[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %35 = slice %acc[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %36 = v_dot4_i32_iu8_u8s8 %33, %34, %35
+  %37 = slice %lhs[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %38 = slice %rhs[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %39 = slice %acc[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %40 = v_dot4_i32_iu8_u8s8 %37, %38, %39
+  %dot = concat(%12, %16, %20, %24, %28, %32, %36, %40) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x8>
+  return %dot
+}
+
+// ====
+
+amdgpu.target<gfx1100> @target
+func.def target(@target) @dot4i_s8s8_256(%lhs: vector<32xi8>, %rhs: vector<32xi8>, %acc: vector<8xi32>) -> (vector<8xi32>) {
+  %dot = vector.dot4i<s8s8> %lhs, %rhs, %acc : vector<32xi8>, vector<32xi8>, vector<8xi32>
+  func.return %dot : vector<8xi32>
+}
+
+// ----
+low.func.def target(@target) abi(hal_kernel) @dot4i_s8s8_256(%lhs: reg<amdgpu.vgpr x8>, %rhs: reg<amdgpu.vgpr x8>, %acc: reg<amdgpu.vgpr x8>) -> (reg<amdgpu.vgpr x8>) asm<amdgpu.rdna3.core> {
+  %9 = slice %lhs[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %10 = slice %rhs[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %11 = slice %acc[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %12 = v_dot4_i32_i8 %9, %10, %11
+  %13 = slice %lhs[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %14 = slice %rhs[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %15 = slice %acc[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %16 = v_dot4_i32_i8 %13, %14, %15
+  %17 = slice %lhs[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %18 = slice %rhs[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %19 = slice %acc[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %20 = v_dot4_i32_i8 %17, %18, %19
+  %21 = slice %lhs[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %22 = slice %rhs[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %23 = slice %acc[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %24 = v_dot4_i32_i8 %21, %22, %23
+  %25 = slice %lhs[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %26 = slice %rhs[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %27 = slice %acc[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %28 = v_dot4_i32_i8 %25, %26, %27
+  %29 = slice %lhs[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %30 = slice %rhs[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %31 = slice %acc[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %32 = v_dot4_i32_i8 %29, %30, %31
+  %33 = slice %lhs[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %34 = slice %rhs[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %35 = slice %acc[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %36 = v_dot4_i32_i8 %33, %34, %35
+  %37 = slice %lhs[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %38 = slice %rhs[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %39 = slice %acc[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %40 = v_dot4_i32_i8 %37, %38, %39
+  %dot = concat(%12, %16, %20, %24, %28, %32, %36, %40) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x8>
+  return %dot
+}

--- a/loom/src/loom/test/corpus/source_low/ml_contraction.loom-test
+++ b/loom/src/loom/test/corpus/source_low/ml_contraction.loom-test
@@ -55,6 +55,31 @@ func.def @i4_dot8_two_k_blocks(%lhs0: vector<2xi32>, %rhs0: vector<2xi32>, %lhs1
 
 // ====
 
+kernel.def @workgroup_cached_dot4i_u8s8_tile() {
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 64 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
+} launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output_buffer: buffer) {
+  %lane = kernel.workitem.id<x> : index
+  %zero = index.constant 0 : offset
+  %bytes = index.constant 1024 : offset
+  %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64x16xi8, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64x16xi8, #dense>
+  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x16xi8, #dense>
+  %output_view = buffer.view %output_buffer[%zero] : buffer -> view<64x4xi32, #dense>
+  %lhs = vector.load %lhs_view[%lane, 0] : view<64x16xi8, #dense> -> vector<16xi8>
+  vector.store %lhs, %scratch_view[%lane, 0] : vector<16xi8>, view<64x16xi8, #dense>
+  %lhs_cached = vector.load %scratch_view[%lane, 0] : view<64x16xi8, #dense> -> vector<16xi8>
+  %rhs = vector.load %rhs_view[%lane, 0] : view<64x16xi8, #dense> -> vector<16xi8>
+  %acc = vector.constant 0 : vector<4xi32>
+  %dot = vector.dot4i<u8s8> %lhs_cached, %rhs, %acc : vector<16xi8>, vector<16xi8>, vector<4xi32>
+  vector.store %dot, %output_view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
+  kernel.return
+}
+
+// ====
+
 func.def @tail_selected_f32_dot(%lhs: vector<4xf32>, %rhs: vector<4xf32>, %acc: f32, %lane: i32, %limit: i32) -> (f32) {
   %dot = vector.dotf %lhs, %rhs, %acc : vector<4xf32>, vector<4xf32>, f32
   %inside = scalar.cmpi slt, %lane, %limit : i32


### PR DESCRIPTION
Adds durable guardrails for the packed-dot and LDS schedule class exposed by the recent AMDGPU oracle comparisons. The goal is not to check in a product- or quantization-specific kernel; it is to make the compiler’s reusable building blocks visible in the shared corpus and in AMDGPU projections so agents can author this family of kernels with confidence.

The AMDGPU source-low suite now projects the shared wide packed-dot corpus. That locks the target contract that authored wide `vector.dot4i` and `vector.dot2f` operations select native per-register dot instructions instead of falling back through scalar arithmetic.

The source-low memory report suite also records the structured packet shape for a workgroup `b128` store/load pair feeding a scalar lane extract. That makes the important facts visible in compiler output: selected packet name, vector lane count, lane stride, dynamic stride, and bank-conflict classification. Humans and agents should be able to compare packet shape through reports instead of scraping ISA listings.

Finally, the shared ML contraction corpus gains a compact workgroup-cached packed-dot motif. The AMDGPU projection proves that the generic motif lowers to the desirable unit schedule: `b128` global and LDS transfers feeding four native `v_dot4_i32_iu8_u8s8` operations. This gives authors a small, reusable pattern for the LDS-backed packed-dot schedule family without giving the checked-in test suite a model-specific identity.
