### PR TITLE
[Infra] Reflow long commit-message prose

### DIFF
--- a/build_tools/lefthook/README.md
+++ b/build_tools/lefthook/README.md
@@ -48,8 +48,22 @@ Git autosquash subjects such as `fixup! [Loom] ...`, `squash! [Loom] ...`,
 and `amend! [Loom] ...` are accepted. The hook strips the autosquash wrapper
 and validates the target subject with the same tag and subject-length policy.
 
-Subjects and prose body lines must stay at or below 72 characters. Long lines
-inside fenced code blocks are accepted so literal examples can remain faithful.
+Subjects and prose body lines must stay at or below 72 characters. This is a
+formatting policy for readable Git log output, not a request to shorten or
+fragment useful commit-message prose. Long fenced code blocks, indented
+examples, Markdown tables, URLs, and final Git trailers are preserved as
+structured text.
+
+When body prose is too long, the hook writes a reflowed suggestion under
+`.tmp/commit-msg/` and prints a `git commit -F ...` retry command. The
+suggestion reflows ordinary prose paragraphs only: subject lines, trailers,
+fenced blocks, indented examples, tables, URLs, block quotes, and list items are
+left untouched. The same formatter is available directly:
+
+```bash
+python build_tools/lefthook/commit_msg.py --format .git/COMMIT_EDITMSG
+```
+
 When a tag is missing, the hook ranks suggested tags from the staged paths and
 prints the paths used for the suggestion so the next edit is obvious.
 

--- a/build_tools/lefthook/commit_msg.py
+++ b/build_tools/lefthook/commit_msg.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import argparse
 import re
+import shlex
 import subprocess
 import sys
+import textwrap
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
@@ -33,6 +35,11 @@ SUBJECT_TAG_PATTERN = re.compile(
 )
 AUTOSQUASH_SUBJECT_PREFIX_PATTERN = re.compile(r"^(?P<prefix>fixup|squash|amend)!\s+")
 CODE_FENCE_PATTERN = re.compile(r"^\s*(```|~~~)")
+INDENTED_CODE_PATTERN = re.compile(r"^(?: {4,}|\t)")
+LIST_ITEM_PATTERN = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+")
+MARKDOWN_TABLE_PATTERN = re.compile(r"^\s*\|.*\|\s*$")
+URL_PATTERN = re.compile(r"\b(?:[a-z][a-z0-9+.-]*://|www\.)", re.IGNORECASE)
+TRAILER_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9-]*: .+")
 TAG_EXAMPLES = ("[Loom]", "[HRX]", "[HAL]", "[Runtime]", "[Infra]", "[CI]")
 
 
@@ -126,6 +133,8 @@ class CommitMessageDiagnostic:
     message: str
     text: str
     hint: str = ""
+    kind: str = "policy"
+    autofixable: bool = False
 
 
 def staged_commit_paths() -> list[str]:
@@ -151,6 +160,13 @@ def commit_message_text_lines(message_text: str) -> list[tuple[int, str]]:
             continue
         lines.append((line_number, line))
     return lines
+
+
+def commit_message_user_text(message_text: str) -> str:
+    """Returns the commit message text that Git would commit."""
+
+    lines = [line for _, line in commit_message_text_lines(message_text)]
+    return "\n".join(lines).rstrip() + "\n"
 
 
 def tag_suggestions_for_paths(paths: Sequence[str]) -> list[str]:
@@ -198,6 +214,118 @@ def unwrap_autosquash_subject(subject: str) -> tuple[str, bool]:
             return unwrapped_subject, is_autosquash_subject
         is_autosquash_subject = True
         unwrapped_subject = unwrapped_subject[prefix_match.end() :]
+
+
+def trailer_line_numbers(text_lines: Sequence[tuple[int, str]]) -> set[int]:
+    """Returns line numbers that are part of a final Git trailer block."""
+
+    trailer_lines: set[int] = set()
+    continuation_lines: list[int] = []
+    index = len(text_lines) - 1
+    while index >= 0 and text_lines[index][1] == "":
+        index -= 1
+
+    while index >= 0:
+        line_number, line = text_lines[index]
+        if line.startswith((" ", "\t")):
+            continuation_lines.append(line_number)
+            index -= 1
+            continue
+        if TRAILER_PATTERN.match(line):
+            trailer_lines.add(line_number)
+            trailer_lines.update(continuation_lines)
+            continuation_lines.clear()
+            index -= 1
+            continue
+        break
+    return trailer_lines
+
+
+def is_markdown_table_line(line: str) -> bool:
+    if MARKDOWN_TABLE_PATTERN.match(line):
+        return True
+    stripped = line.strip()
+    return stripped.startswith("|") and stripped.endswith("|")
+
+
+def is_line_length_exempt(line_number: int, line: str, trailer_lines: set[int]) -> bool:
+    """Returns whether line length should be preserved instead of checked."""
+
+    return (
+        line_number in trailer_lines
+        or INDENTED_CODE_PATTERN.match(line) is not None
+        or is_markdown_table_line(line)
+        or URL_PATTERN.search(line) is not None
+    )
+
+
+def is_reflowable_body_line(
+    line_number: int,
+    line: str,
+    trailer_lines: set[int],
+) -> bool:
+    """Returns whether a body line is ordinary prose safe to wrap."""
+
+    if not line:
+        return False
+    if is_line_length_exempt(line_number, line, trailer_lines):
+        return False
+    if LIST_ITEM_PATTERN.match(line):
+        return False
+    if line.lstrip().startswith(">"):
+        return False
+    return True
+
+
+def reflow_commit_message_text(message_text: str) -> str:
+    """Reflows ordinary prose paragraphs while preserving structured lines."""
+
+    text_lines = commit_message_text_lines(message_text)
+    if not text_lines:
+        return "\n"
+
+    subject_line_number = text_lines[0][0]
+    trailer_lines = trailer_line_numbers(text_lines)
+    output_lines: list[str] = []
+    paragraph_lines: list[str] = []
+    in_code_block = False
+
+    def flush_paragraph() -> None:
+        if not paragraph_lines:
+            return
+        paragraph_text = " ".join(line.strip() for line in paragraph_lines)
+        output_lines.extend(
+            textwrap.wrap(
+                paragraph_text,
+                width=LINE_LENGTH_LIMIT,
+                break_long_words=False,
+                break_on_hyphens=False,
+            )
+            or [""]
+        )
+        paragraph_lines.clear()
+
+    for line_number, line in text_lines:
+        is_code_fence = CODE_FENCE_PATTERN.match(line) is not None
+        if is_code_fence:
+            flush_paragraph()
+            output_lines.append(line)
+            in_code_block = not in_code_block
+            continue
+
+        if (
+            in_code_block
+            or line_number == subject_line_number
+            or not is_reflowable_body_line(line_number, line, trailer_lines)
+        ):
+            flush_paragraph()
+            output_lines.append(line)
+            continue
+
+        paragraph_lines.append(line)
+
+    flush_paragraph()
+    return "\n".join(output_lines).rstrip() + "\n"
 
 
 def validate_subject_line(
@@ -271,22 +399,41 @@ def validate_line_lengths(
 ) -> list[CommitMessageDiagnostic]:
     diagnostics: list[CommitMessageDiagnostic] = []
     in_code_block = False
+    trailer_lines = trailer_line_numbers(text_lines)
     for line_number, line in text_lines:
         if CODE_FENCE_PATTERN.match(line):
             in_code_block = not in_code_block
             continue
-        if in_code_block or line_number == subject_line_number or not line:
+        if (
+            in_code_block
+            or line_number == subject_line_number
+            or not line
+            or is_line_length_exempt(line_number, line, trailer_lines)
+        ):
             continue
         if len(line) > LINE_LENGTH_LIMIT:
+            is_autofixable = is_reflowable_body_line(line_number, line, trailer_lines)
+            hint = (
+                "Preserve the message content and reflow prose instead of "
+                "shortening, fragmenting, or rewriting it."
+            )
+            if not is_autofixable:
+                hint = (
+                    "Wrap this line manually. The prose reflow suggestion "
+                    "preserves structured lines such as lists, examples, and "
+                    "tables."
+                )
             diagnostics.append(
                 CommitMessageDiagnostic(
                     line_number=line_number,
                     message=(
-                        f"line is {len(line)} characters; keep commit message "
-                        f"body lines at or below {LINE_LENGTH_LIMIT}"
+                        f"commit message body line is {len(line)} characters; "
+                        f"wrap prose to {LINE_LENGTH_LIMIT} columns"
                     ),
                     text=line,
-                    hint="Wrap prose or put intentionally long examples in a fenced code block.",
+                    hint=hint,
+                    kind="line-length",
+                    autofixable=is_autofixable,
                 )
             )
     return diagnostics
@@ -356,8 +503,30 @@ def validate_commit_message_file(
     )
 
 
+def write_reflow_suggestion(message_file: Path, message_text: str) -> Path | None:
+    """Writes a reflowed message suggestion when it changes the user text."""
+
+    reflowed_text = reflow_commit_message_text(message_text)
+    if reflowed_text == commit_message_user_text(message_text):
+        return None
+
+    suggestion_directory = REPO_ROOT / ".tmp" / "commit-msg"
+    suggestion_directory.mkdir(parents=True, exist_ok=True)
+    suggestion_path = suggestion_directory / f"{message_file.name}.reflowed"
+    suggestion_path.write_text(reflowed_text, encoding="utf-8")
+    return suggestion_path
+
+
 def parse_arguments(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--format",
+        action="store_true",
+        help=(
+            "Print the commit message with ordinary prose paragraphs reflowed "
+            "to 72 columns. Structured lines are preserved."
+        ),
+    )
     parser.add_argument(
         "message_file",
         type=Path,
@@ -368,6 +537,11 @@ def parse_arguments(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str]) -> int:
     args = parse_arguments(argv)
+    message_text = args.message_file.read_text(encoding="utf-8")
+    if args.format:
+        print(reflow_commit_message_text(message_text), end="")
+        return 0
+
     diagnostics = validate_commit_message_file(
         args.message_file,
         changed_paths=staged_commit_paths(),
@@ -376,6 +550,31 @@ def main(argv: list[str]) -> int:
         return 0
 
     print("commit message policy failed:", file=sys.stderr)
+    if any(diagnostic.kind == "line-length" for diagnostic in diagnostics):
+        print("", file=sys.stderr)
+        print(
+            f"commit message body lines must be wrapped to {LINE_LENGTH_LIMIT} columns.",
+            file=sys.stderr,
+        )
+        print(
+            "Preserve the message content and reflow the prose instead of "
+            "shortening, fragmenting, or rewriting it.",
+            file=sys.stderr,
+        )
+        print("", file=sys.stderr)
+        print("Example:", file=sys.stderr)
+        print(
+            "  Before: This is a useful commit-message paragraph that is too "
+            "long for the Git log body width.",
+            file=sys.stderr,
+        )
+        print(
+            "  After:  This is a useful commit-message paragraph that is too",
+            file=sys.stderr,
+        )
+        print("          long for the Git log body width.", file=sys.stderr)
+        print("", file=sys.stderr)
+
     for diagnostic in diagnostics:
         print(
             f"  {args.message_file}:{diagnostic.line_number}: "
@@ -384,6 +583,37 @@ def main(argv: list[str]) -> int:
         )
         if diagnostic.hint:
             print(f"    hint: {diagnostic.hint}", file=sys.stderr)
+
+    if any(diagnostic.kind == "line-length" for diagnostic in diagnostics):
+        suggestion_path = write_reflow_suggestion(args.message_file, message_text)
+        if suggestion_path is not None:
+            relative_suggestion_path = suggestion_path.relative_to(REPO_ROOT)
+            print("", file=sys.stderr)
+            print(
+                f"Suggested prose-only reflow written to {relative_suggestion_path}.",
+                file=sys.stderr,
+            )
+            print("Retry a normal commit with:", file=sys.stderr)
+            print(
+                f"  git commit -F {shlex.quote(str(relative_suggestion_path))}",
+                file=sys.stderr,
+            )
+            if any(
+                diagnostic.kind == "line-length" and not diagnostic.autofixable
+                for diagnostic in diagnostics
+            ):
+                print(
+                    "Some long lines were preserved because they look "
+                    "structured; wrap those diagnostics manually before "
+                    "retrying.",
+                    file=sys.stderr,
+                )
+            print(
+                "For amend, squash, or fixup commits, rerun the same git "
+                "commit command and replace the message source with that -F "
+                "argument.",
+                file=sys.stderr,
+            )
     return 1
 
 

--- a/build_tools/lefthook/commit_msg_test.py
+++ b/build_tools/lefthook/commit_msg_test.py
@@ -172,13 +172,17 @@ class CommitMessageTest(unittest.TestCase):
         long_line = "This body line is intentionally too long for commit prose " + (
             "because it should be wrapped."
         )
+        diagnostics = commit_msg.validate_commit_message_text(
+            f"[Infra] Subject\n\n{long_line}\n"
+        )
         self.assertEqual(
-            self.diagnostic_messages(f"[Infra] Subject\n\n{long_line}\n"),
+            [diagnostic.message for diagnostic in diagnostics],
             [
-                f"line is {len(long_line)} characters; keep commit message "
-                "body lines at or below 72"
+                f"commit message body line is {len(long_line)} characters; "
+                "wrap prose to 72 columns"
             ],
         )
+        self.assertEqual([diagnostic.autofixable for diagnostic in diagnostics], [True])
 
     def test_allows_long_lines_inside_code_blocks(self):
         long_line = "x" * 120
@@ -188,6 +192,111 @@ class CommitMessageTest(unittest.TestCase):
             ),
             [],
         )
+
+    def test_allows_long_structured_body_lines(self):
+        long_url = "See https://example.com/" + "x" * 90
+        long_table = "| Column | " + "x" * 90 + " |"
+        long_code = "    git commit -m " + "x" * 90
+        long_trailer = "Co-authored-by: " + "x" * 90
+        long_trailer_continuation = " " + "x" * 90
+
+        self.assertEqual(
+            self.diagnostic_messages(
+                "[Infra] Subject\n"
+                "\n"
+                f"{long_url}\n"
+                f"{long_table}\n"
+                f"{long_code}\n"
+                "\n"
+                f"{long_trailer}\n"
+                f"{long_trailer_continuation}\n"
+            ),
+            [],
+        )
+
+    def test_rejects_long_bullet_body_lines(self):
+        long_bullet = (
+            "- This bullet list item is intentionally too long for the commit "
+            "message body width."
+        )
+        diagnostics = commit_msg.validate_commit_message_text(
+            f"[Infra] Subject\n\n{long_bullet}\n"
+        )
+        self.assertEqual(
+            [diagnostic.message for diagnostic in diagnostics],
+            [
+                f"commit message body line is {len(long_bullet)} characters; "
+                "wrap prose to 72 columns"
+            ],
+        )
+        self.assertEqual(
+            [diagnostic.autofixable for diagnostic in diagnostics], [False]
+        )
+
+    def test_reflows_ordinary_body_paragraphs(self):
+        self.assertEqual(
+            commit_msg.reflow_commit_message_text(
+                "[Infra] Subject\n"
+                "\n"
+                "This body paragraph is intentionally long enough to require "
+                "wrapping while preserving all words in the original order.\n"
+            ),
+            "[Infra] Subject\n"
+            "\n"
+            "This body paragraph is intentionally long enough to require wrapping\n"
+            "while preserving all words in the original order.\n",
+        )
+
+    def test_reflow_preserves_structured_body_lines(self):
+        long_bullet = (
+            "- This bullet list item is intentionally too long for automatic "
+            "reflow because list indentation needs human intent."
+        )
+        long_url = "See https://example.com/" + "x" * 90
+        long_code = "    git commit -m " + "x" * 90
+        long_trailer = "Change-Id: " + "x" * 90
+        message = (
+            "[Infra] Subject\n"
+            "\n"
+            f"{long_bullet}\n"
+            f"{long_url}\n"
+            "```text\n"
+            f"{'x' * 90}\n"
+            "```\n"
+            f"{long_code}\n"
+            "\n"
+            f"{long_trailer}\n"
+        )
+
+        self.assertEqual(commit_msg.reflow_commit_message_text(message), message)
+
+    def test_writes_reflow_suggestion(self):
+        message = (
+            "[Infra] Subject\n"
+            "\n"
+            "This body paragraph is intentionally long enough to require "
+            "wrapping while preserving all words in the original order.\n"
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            old_repo_root = commit_msg.REPO_ROOT
+            commit_msg.REPO_ROOT = Path(temporary_directory)
+            try:
+                suggestion_path = commit_msg.write_reflow_suggestion(
+                    Path("COMMIT_EDITMSG"),
+                    message,
+                )
+            finally:
+                commit_msg.REPO_ROOT = old_repo_root
+
+            self.assertIsNotNone(suggestion_path)
+            assert suggestion_path is not None
+            self.assertEqual(
+                suggestion_path.read_text(encoding="utf-8"),
+                "[Infra] Subject\n"
+                "\n"
+                "This body paragraph is intentionally long enough to require wrapping\n"
+                "while preserving all words in the original order.\n",
+            )
 
     def test_ranks_tag_suggestions_from_paths(self):
         self.assertEqual(


### PR DESCRIPTION
Teach the commit-message hook to distinguish ordinary prose from structured Markdown when reporting body line-length failures. The hook now frames long prose as a wrapping issue, preserves rich commit-message content, and writes a reflowed suggestion that authors can use with git commit -F.

The formatter is conservative: it wraps normal body paragraphs and leaves subjects, trailers, fenced code blocks, indented examples, URLs, tables, block quotes, and list items untouched. Mixed failures still point at the preserved structured lines so authors can wrap those cases deliberately instead of accepting a misleading automatic rewrite.