### PR TITLE
[Infra] Check extent-value empty contracts

### DIFF
--- a/build_tools/clang_tidy/BUILD.bazel
+++ b/build_tools/clang_tidy/BUILD.bazel
@@ -51,6 +51,8 @@ py_binary(
 cc_binary(
     name = "IREEClangTidyPlugin.so",
     srcs = [
+        "iree/ExtentChecks.cc",
+        "iree/ExtentChecks.h",
         "iree/IreeTidyModule.cc",
         "iree/LifecycleChecks.cc",
         "iree/LifecycleChecks.h",
@@ -73,6 +75,28 @@ cc_binary(
     deps = [
         "@iree_clang_tidy_llvm//:llvm_headers",
     ],
+)
+
+py_test(
+    name = "extent_checks_test",
+    srcs = [
+        "test/clang_tidy_test.py",
+        "test/extent_checks_test.py",
+    ],
+    args = [
+        "--clang-tidy=$(location @iree_clang_tidy_llvm//:clang-tidy)",
+        "--plugin=$(location :IREEClangTidyPlugin.so)",
+    ],
+    data = [
+        "test/extent_checks.c",
+        "test/extent_checks.cc",
+        ":IREEClangTidyPlugin.so",
+        "@iree_clang_tidy_llvm//:clang-tidy",
+    ],
+    imports = ["test"],
+    main = "test/extent_checks_test.py",
+    tags = ["manual"],
+    target_compatible_with = CLANG_TIDY_LLVM_TARGET_COMPATIBLE_WITH,
 )
 
 py_test(

--- a/build_tools/clang_tidy/CMakeLists.txt
+++ b/build_tools/clang_tidy/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(LLVM REQUIRED CONFIG)
 find_package(Clang REQUIRED CONFIG)
 
 add_library(IREEClangTidyPlugin MODULE
+  iree/ExtentChecks.cc
   iree/IreeTidyModule.cc
   iree/LifecycleChecks.cc
   iree/RefCountChecks.cc
@@ -63,6 +64,15 @@ find_program(CLANG_TIDY_EXECUTABLE
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 enable_testing()
+add_test(
+  NAME iree-clang-tidy-extent-checks
+  COMMAND
+    Python3::Interpreter
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/extent_checks_test.py"
+    "--clang-tidy=${CLANG_TIDY_EXECUTABLE}"
+    "--plugin=$<TARGET_FILE:IREEClangTidyPlugin>"
+)
+
 add_test(
   NAME iree-clang-tidy-plugin-smoke
   COMMAND

--- a/build_tools/clang_tidy/README.md
+++ b/build_tools/clang_tidy/README.md
@@ -250,6 +250,45 @@ update the macro definition. For macro arguments, rewrite the argument at the
 callsite or use zero-initialization plus field assignment when the initializer
 is intentionally sparse.
 
+### `iree-extent-empty-initializer`
+
+`iree-extent-empty-initializer` diagnoses aggregate zero initialization of known
+IREE extent-value structs when a named empty constructor exists. These structs
+are small non-owning values that describe a bounded extent: string views, byte
+spans, span/list structs, semaphore lists, and buffer binding tables. The empty
+constructor is the canonical spelling for the empty value and avoids fragile
+field-order knowledge at call sites.
+
+Examples:
+
+```c
+iree_string_view_t name = iree_string_view_empty();
+iree_const_byte_span_t bytes = iree_const_byte_span_empty();
+iree_hal_semaphore_list_t semaphores = iree_hal_semaphore_list_empty();
+```
+
+### `iree-extent-empty-predicate`
+
+`iree-extent-empty-predicate` diagnoses hand-written empty tests that combine a
+data pointer check with a zero length check for known IREE extent values.
+Emptiness is defined only by the extent field (`size`, `data_length`, `count`,
+or `length`). A NULL pointer with a non-zero extent is malformed and should be
+rejected at API boundaries as validation, not treated as empty.
+Malformed-or-empty guards before access still spell both conditions explicitly;
+only pure empty predicates collapse to the named helper.
+
+Examples:
+
+```c
+if (iree_string_view_is_empty(name)) return iree_ok_status();
+if (iree_const_byte_span_is_empty(bytes)) return iree_ok_status();
+
+if (name.size > 0 && name.data == NULL) {
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "non-empty name has no storage");
+}
+```
+
 ### `iree-lifecycle-naming`
 
 `iree-lifecycle-naming` diagnoses caller-owned output records that use

--- a/build_tools/clang_tidy/iree/ExtentChecks.cc
+++ b/build_tools/clang_tidy/iree/ExtentChecks.cc
@@ -1,0 +1,464 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/ExtentChecks.h"
+
+#include <algorithm>
+#include <cctype>
+#include <optional>
+#include <string>
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/Stmt.h"
+#include "clang/AST/Type.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Lex/Lexer.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace clang::tidy::iree {
+namespace {
+
+struct ExtentValueContract {
+  const char* TypeName;
+  const char* EmptyFunction;
+  const char* IsEmptyFunction;
+  const char* PointerField;
+  const char* ExtentField;
+};
+
+constexpr ExtentValueContract kExtentValueContracts[] = {
+    {"iree_byte_span_t", "iree_byte_span_empty", "iree_byte_span_is_empty",
+     "data", "data_length"},
+    {"iree_const_byte_span_t", "iree_const_byte_span_empty",
+     "iree_const_byte_span_is_empty", "data", "data_length"},
+    {"iree_string_view_t", "iree_string_view_empty",
+     "iree_string_view_is_empty", "data", "size"},
+    {"iree_mutable_string_view_t", "iree_mutable_string_view_empty",
+     "iree_mutable_string_view_is_empty", "data", "size"},
+    {"iree_string_pair_list_t", "iree_string_pair_list_empty", nullptr, nullptr,
+     "count"},
+    {"iree_string_view_list_t", "iree_string_view_list_empty", nullptr, nullptr,
+     "count"},
+    {"iree_async_span_t", "iree_async_span_empty", "iree_async_span_is_empty",
+     nullptr, "length"},
+    {"iree_async_span_list_t", "iree_async_span_list_empty",
+     "iree_async_span_list_is_empty", nullptr, "count"},
+    {"iree_async_continuation_list_t", "iree_async_continuation_list_empty",
+     "iree_async_continuation_list_is_empty", nullptr, "count"},
+    {"iree_async_operation_list_t", "iree_async_operation_list_empty",
+     "iree_async_operation_list_is_empty", nullptr, "count"},
+    {"iree_hal_buffer_ref_list_t", "iree_hal_buffer_ref_list_empty", nullptr,
+     nullptr, "count"},
+    {"iree_hal_buffer_binding_table_t", "iree_hal_buffer_binding_table_empty",
+     "iree_hal_buffer_binding_table_is_empty", nullptr, "count"},
+    {"iree_hal_semaphore_list_t", "iree_hal_semaphore_list_empty",
+     "iree_hal_semaphore_list_is_empty", nullptr, "count"},
+};
+
+const Expr* IgnoreExpressionNoise(const Expr* Expr) {
+  if (!Expr) {
+    return nullptr;
+  }
+  return Expr->IgnoreParenImpCasts();
+}
+
+std::optional<std::string> SourceText(CharSourceRange Range,
+                                      const SourceManager& SourceManager,
+                                      const LangOptions& LangOptions) {
+  bool Invalid = false;
+  StringRef Text =
+      Lexer::getSourceText(Range, SourceManager, LangOptions, &Invalid);
+  if (Invalid || Text.empty()) {
+    return std::nullopt;
+  }
+  return Text.str();
+}
+
+std::optional<std::string> SourceText(const Expr* Expr,
+                                      const SourceManager& SourceManager,
+                                      const LangOptions& LangOptions) {
+  if (!Expr) {
+    return std::nullopt;
+  }
+  SourceLocation Begin = Expr->getBeginLoc();
+  SourceLocation End = Expr->getEndLoc();
+  if (Begin.isInvalid() || End.isInvalid() || Begin.isMacroID() ||
+      End.isMacroID()) {
+    return std::nullopt;
+  }
+  End = Lexer::getLocForEndOfToken(End, 0, SourceManager, LangOptions);
+  if (End.isInvalid()) {
+    return std::nullopt;
+  }
+  return SourceText(CharSourceRange::getCharRange(Begin, End), SourceManager,
+                    LangOptions);
+}
+
+std::optional<std::string> CompactSourceText(const Expr* Expr,
+                                             const SourceManager& SourceManager,
+                                             const LangOptions& LangOptions) {
+  std::optional<std::string> Text =
+      SourceText(Expr, SourceManager, LangOptions);
+  if (!Text) {
+    return std::nullopt;
+  }
+  Text->erase(std::remove_if(Text->begin(), Text->end(),
+                             [](unsigned char c) { return std::isspace(c); }),
+              Text->end());
+  return Text;
+}
+
+std::optional<CharSourceRange> ExprCharRange(const Expr* Expr,
+                                             const SourceManager& SourceManager,
+                                             const LangOptions& LangOptions) {
+  if (!Expr) {
+    return std::nullopt;
+  }
+  SourceLocation Begin = Expr->getBeginLoc();
+  SourceLocation End = Expr->getEndLoc();
+  if (Begin.isInvalid() || End.isInvalid() || Begin.isMacroID() ||
+      End.isMacroID()) {
+    return std::nullopt;
+  }
+  End = Lexer::getLocForEndOfToken(End, 0, SourceManager, LangOptions);
+  if (End.isInvalid()) {
+    return std::nullopt;
+  }
+  if (SourceManager.getFileID(Begin) != SourceManager.getFileID(End)) {
+    return std::nullopt;
+  }
+  return CharSourceRange::getCharRange(Begin, End);
+}
+
+std::optional<StringRef> TypedefName(QualType Qual) {
+  Qual = Qual.getUnqualifiedType();
+  const Type* TypePtr = Qual.getTypePtrOrNull();
+  if (!TypePtr) {
+    return std::nullopt;
+  }
+  const auto* Typedef = TypePtr->getAs<TypedefType>();
+  return Typedef ? std::optional<StringRef>(Typedef->getDecl()->getName())
+                 : std::nullopt;
+}
+
+const ExtentValueContract* ContractForValueType(QualType Qual) {
+  std::optional<StringRef> Name = TypedefName(Qual);
+  if (!Name) {
+    return nullptr;
+  }
+  for (const ExtentValueContract& Contract : kExtentValueContracts) {
+    if (*Name == Contract.TypeName) {
+      return &Contract;
+    }
+  }
+  return nullptr;
+}
+
+const InitListExpr* SourceInitializerList(const Expr* Init) {
+  const auto* List =
+      dyn_cast_or_null<InitListExpr>(IgnoreExpressionNoise(Init));
+  if (!List) {
+    return nullptr;
+  }
+  return List->getSyntacticForm() ? List->getSyntacticForm() : List;
+}
+
+bool IsZeroOrNullConstant(const Expr* Expr, ASTContext& Context) {
+  Expr = IgnoreExpressionNoise(Expr);
+  if (!Expr) {
+    return false;
+  }
+  if (Expr->isNullPointerConstant(Context, Expr::NPC_ValueDependentIsNotNull)) {
+    return true;
+  }
+  const auto* Integer = dyn_cast<IntegerLiteral>(Expr);
+  return Integer && Integer->getValue().isZero();
+}
+
+bool IsAggregateZeroInitializer(const InitListExpr* Init, ASTContext& Context) {
+  if (!Init) {
+    return false;
+  }
+  if (Init->getNumInits() == 0) {
+    return true;
+  }
+  for (const Expr* Child : Init->inits()) {
+    if (!IsZeroOrNullConstant(Child, Context)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool IsInsideOwnEmptyFunction(const VarDecl* Var,
+                              const ExtentValueContract& Contract) {
+  const auto* Function = dyn_cast_or_null<FunctionDecl>(Var->getDeclContext());
+  return Function && Function->getName() == Contract.EmptyFunction;
+}
+
+bool IsZeroIntegerConstant(const Expr* Expr) {
+  Expr = IgnoreExpressionNoise(Expr);
+  const auto* Integer = dyn_cast_or_null<IntegerLiteral>(Expr);
+  return Integer && Integer->getValue().isZero();
+}
+
+struct ExtentMemberUse {
+  const ExtentValueContract* Contract = nullptr;
+  const Expr* Base = nullptr;
+  std::string BaseText;
+  std::string CompactBaseText;
+};
+
+std::optional<ExtentMemberUse> ExtentMemberUseForField(
+    const Expr* Input, StringRef FieldName, const SourceManager& SourceManager,
+    const LangOptions& LangOptions) {
+  Input = IgnoreExpressionNoise(Input);
+  const auto* Member = dyn_cast_or_null<MemberExpr>(Input);
+  if (!Member || Member->isArrow()) {
+    return std::nullopt;
+  }
+  const auto* Field = dyn_cast_or_null<FieldDecl>(Member->getMemberDecl());
+  if (!Field || Field->getName() != FieldName) {
+    return std::nullopt;
+  }
+  const Expr* Base = Member->getBase();
+  const ExtentValueContract* Contract = ContractForValueType(Base->getType());
+  if (!Contract || !Contract->IsEmptyFunction) {
+    return std::nullopt;
+  }
+  std::optional<std::string> BaseText =
+      SourceText(Base, SourceManager, LangOptions);
+  std::optional<std::string> CompactBaseText =
+      CompactSourceText(Base, SourceManager, LangOptions);
+  if (!BaseText || !CompactBaseText) {
+    return std::nullopt;
+  }
+  return ExtentMemberUse{Contract, Base, *BaseText, *CompactBaseText};
+}
+
+std::optional<ExtentMemberUse> PointerNullPredicate(
+    const Expr* Input, ASTContext& Context, const SourceManager& SourceManager,
+    const LangOptions& LangOptions) {
+  Input = IgnoreExpressionNoise(Input);
+  if (!Input) {
+    return std::nullopt;
+  }
+  if (const auto* Unary = dyn_cast<UnaryOperator>(Input);
+      Unary && Unary->getOpcode() == UO_LNot) {
+    for (const ExtentValueContract& Contract : kExtentValueContracts) {
+      if (!Contract.PointerField) {
+        continue;
+      }
+      std::optional<ExtentMemberUse> Use =
+          ExtentMemberUseForField(Unary->getSubExpr(), Contract.PointerField,
+                                  SourceManager, LangOptions);
+      if (Use && Use->Contract == &Contract) {
+        return Use;
+      }
+    }
+    return std::nullopt;
+  }
+  const auto* Binary = dyn_cast<BinaryOperator>(Input);
+  if (!Binary || Binary->getOpcode() != BO_EQ) {
+    return std::nullopt;
+  }
+  const Expr* Lhs = IgnoreExpressionNoise(Binary->getLHS());
+  const Expr* Rhs = IgnoreExpressionNoise(Binary->getRHS());
+  const Expr* Candidate = nullptr;
+  if (Lhs &&
+      Lhs->isNullPointerConstant(Context, Expr::NPC_ValueDependentIsNotNull)) {
+    Candidate = Rhs;
+  } else if (Rhs && Rhs->isNullPointerConstant(
+                        Context, Expr::NPC_ValueDependentIsNotNull)) {
+    Candidate = Lhs;
+  }
+  if (!Candidate) {
+    return std::nullopt;
+  }
+  for (const ExtentValueContract& Contract : kExtentValueContracts) {
+    if (!Contract.PointerField) {
+      continue;
+    }
+    std::optional<ExtentMemberUse> Use = ExtentMemberUseForField(
+        Candidate, Contract.PointerField, SourceManager, LangOptions);
+    if (Use && Use->Contract == &Contract) {
+      return Use;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<ExtentMemberUse> ExtentZeroPredicate(
+    const Expr* Input, ASTContext& Context, const SourceManager& SourceManager,
+    const LangOptions& LangOptions) {
+  Input = IgnoreExpressionNoise(Input);
+  if (!Input) {
+    return std::nullopt;
+  }
+  if (const auto* Unary = dyn_cast<UnaryOperator>(Input);
+      Unary && Unary->getOpcode() == UO_LNot) {
+    for (const ExtentValueContract& Contract : kExtentValueContracts) {
+      std::optional<ExtentMemberUse> Use =
+          ExtentMemberUseForField(Unary->getSubExpr(), Contract.ExtentField,
+                                  SourceManager, LangOptions);
+      if (Use && Use->Contract == &Contract) {
+        return Use;
+      }
+    }
+    return std::nullopt;
+  }
+  const auto* Binary = dyn_cast<BinaryOperator>(Input);
+  if (!Binary || Binary->getOpcode() != BO_EQ) {
+    return std::nullopt;
+  }
+  const Expr* Lhs = IgnoreExpressionNoise(Binary->getLHS());
+  const Expr* Rhs = IgnoreExpressionNoise(Binary->getRHS());
+  const Expr* Candidate = nullptr;
+  if (IsZeroIntegerConstant(Lhs)) {
+    Candidate = Rhs;
+  } else if (IsZeroIntegerConstant(Rhs)) {
+    Candidate = Lhs;
+  }
+  if (!Candidate) {
+    return std::nullopt;
+  }
+  for (const ExtentValueContract& Contract : kExtentValueContracts) {
+    std::optional<ExtentMemberUse> Use = ExtentMemberUseForField(
+        Candidate, Contract.ExtentField, SourceManager, LangOptions);
+    if (Use && Use->Contract == &Contract) {
+      return Use;
+    }
+  }
+  return std::nullopt;
+}
+
+bool SameExtentBase(const ExtentMemberUse& Lhs, const ExtentMemberUse& Rhs) {
+  return Lhs.Contract == Rhs.Contract &&
+         Lhs.CompactBaseText == Rhs.CompactBaseText;
+}
+
+bool IsEmptyHelperFunction(const FunctionDecl* Function) {
+  return Function && Function->getName().ends_with("_is_empty");
+}
+
+}  // namespace
+
+ExtentEmptyInitializerCheck::ExtentEmptyInitializerCheck(
+    StringRef Name, ClangTidyContext* Context)
+    : ClangTidyCheck(Name, Context) {}
+
+void ExtentEmptyInitializerCheck::registerMatchers(
+    ast_matchers::MatchFinder* Finder) {
+  using namespace ast_matchers;
+  Finder->addMatcher(varDecl(unless(isExpansionInSystemHeader()),
+                             hasInitializer(initListExpr().bind("init")))
+                         .bind("var"),
+                     this);
+}
+
+void ExtentEmptyInitializerCheck::check(
+    const ast_matchers::MatchFinder::MatchResult& Result) {
+  const auto* Var = Result.Nodes.getNodeAs<VarDecl>("var");
+  const auto* Init = Result.Nodes.getNodeAs<InitListExpr>("init");
+  if (!Var || !Init || !Var->hasLocalStorage()) {
+    return;
+  }
+  const ExtentValueContract* Contract = ContractForValueType(Var->getType());
+  if (!Contract || IsInsideOwnEmptyFunction(Var, *Contract) ||
+      !IsAggregateZeroInitializer(SourceInitializerList(Init),
+                                  *Result.Context)) {
+    return;
+  }
+  const SourceManager& SourceManager = *Result.SourceManager;
+  if (Init->getBeginLoc().isMacroID()) {
+    return;
+  }
+  DiagnosticBuilder Diagnostic =
+      diag(SourceManager.getExpansionLoc(Init->getBeginLoc()),
+           "use %0() instead of aggregate zero initialization for empty %1 "
+           "values")
+      << Contract->EmptyFunction << Contract->TypeName;
+  std::optional<CharSourceRange> ReplacementRange =
+      ExprCharRange(Init, SourceManager, Result.Context->getLangOpts());
+  if (ReplacementRange) {
+    Diagnostic << FixItHint::CreateReplacement(
+        *ReplacementRange, (Twine(Contract->EmptyFunction) + "()").str());
+  }
+}
+
+ExtentEmptyPredicateCheck::ExtentEmptyPredicateCheck(StringRef Name,
+                                                     ClangTidyContext* Context)
+    : ClangTidyCheck(Name, Context) {}
+
+void ExtentEmptyPredicateCheck::registerMatchers(
+    ast_matchers::MatchFinder* Finder) {
+  using namespace ast_matchers;
+  Finder->addMatcher(
+      functionDecl(
+          forEachDescendant(binaryOperator(unless(isExpansionInSystemHeader()),
+                                           anyOf(hasOperatorName("||"),
+                                                 hasOperatorName("&&")))
+                                .bind("binary")))
+          .bind("function"),
+      this);
+}
+
+void ExtentEmptyPredicateCheck::check(
+    const ast_matchers::MatchFinder::MatchResult& Result) {
+  const auto* Binary = Result.Nodes.getNodeAs<BinaryOperator>("binary");
+  const auto* Function = Result.Nodes.getNodeAs<FunctionDecl>("function");
+  if (!Binary) {
+    return;
+  }
+  const SourceManager& SourceManager = *Result.SourceManager;
+  if (Binary->getOperatorLoc().isMacroID()) {
+    return;
+  }
+  ASTContext& Context = *Result.Context;
+  const LangOptions& LangOptions = Result.Context->getLangOpts();
+  std::optional<ExtentMemberUse> LhsPointer = PointerNullPredicate(
+      Binary->getLHS(), Context, SourceManager, LangOptions);
+  std::optional<ExtentMemberUse> RhsPointer = PointerNullPredicate(
+      Binary->getRHS(), Context, SourceManager, LangOptions);
+  std::optional<ExtentMemberUse> LhsExtent = ExtentZeroPredicate(
+      Binary->getLHS(), Context, SourceManager, LangOptions);
+  std::optional<ExtentMemberUse> RhsExtent = ExtentZeroPredicate(
+      Binary->getRHS(), Context, SourceManager, LangOptions);
+
+  std::optional<ExtentMemberUse> PointerUse;
+  if (LhsPointer && RhsExtent && SameExtentBase(*LhsPointer, *RhsExtent)) {
+    PointerUse = LhsPointer;
+  } else if (RhsPointer && LhsExtent &&
+             SameExtentBase(*RhsPointer, *LhsExtent)) {
+    PointerUse = RhsPointer;
+  } else {
+    return;
+  }
+  if (Binary->getOpcode() == BO_LOr && !IsEmptyHelperFunction(Function)) {
+    return;
+  }
+
+  DiagnosticBuilder Diagnostic =
+      diag(SourceManager.getExpansionLoc(Binary->getOperatorLoc()),
+           "test empty %0 values with %1(); pointer-null is malformedness, "
+           "not emptiness")
+      << PointerUse->Contract->TypeName
+      << PointerUse->Contract->IsEmptyFunction;
+  std::optional<CharSourceRange> ReplacementRange =
+      ExprCharRange(Binary, SourceManager, LangOptions);
+  if (ReplacementRange) {
+    Diagnostic << FixItHint::CreateReplacement(
+        *ReplacementRange, (Twine(PointerUse->Contract->IsEmptyFunction) + "(" +
+                            PointerUse->BaseText + ")")
+                               .str());
+  }
+}
+
+}  // namespace clang::tidy::iree

--- a/build_tools/clang_tidy/iree/ExtentChecks.h
+++ b/build_tools/clang_tidy/iree/ExtentChecks.h
@@ -1,0 +1,32 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BUILD_TOOLS_CLANG_TIDY_IREE_EXTENT_CHECKS_H_
+#define IREE_BUILD_TOOLS_CLANG_TIDY_IREE_EXTENT_CHECKS_H_
+
+#include "clang-tidy/ClangTidyCheck.h"
+
+namespace clang::tidy::iree {
+
+class ExtentEmptyInitializerCheck final : public ClangTidyCheck {
+ public:
+  ExtentEmptyInitializerCheck(StringRef Name, ClangTidyContext* Context);
+
+  void registerMatchers(ast_matchers::MatchFinder* Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult& Result) override;
+};
+
+class ExtentEmptyPredicateCheck final : public ClangTidyCheck {
+ public:
+  ExtentEmptyPredicateCheck(StringRef Name, ClangTidyContext* Context);
+
+  void registerMatchers(ast_matchers::MatchFinder* Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult& Result) override;
+};
+
+}  // namespace clang::tidy::iree
+
+#endif  // IREE_BUILD_TOOLS_CLANG_TIDY_IREE_EXTENT_CHECKS_H_

--- a/build_tools/clang_tidy/iree/IreeTidyModule.cc
+++ b/build_tools/clang_tidy/iree/IreeTidyModule.cc
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "clang-tidy/ClangTidyModule.h"
+#include "iree/ExtentChecks.h"
 #include "iree/LifecycleChecks.h"
 #include "iree/RefCountChecks.h"
 #include "iree/SmokeCheck.h"
@@ -28,6 +29,10 @@ class IreeTidyModule final : public ClangTidyModule {
     CheckFactories.registerCheck<DesignatedInitializerCheck>(
         "iree-cpp-designated-initializer");
     CheckFactories.registerCheck<DirectGotoCheck>("iree-direct-goto");
+    CheckFactories.registerCheck<ExtentEmptyInitializerCheck>(
+        "iree-extent-empty-initializer");
+    CheckFactories.registerCheck<ExtentEmptyPredicateCheck>(
+        "iree-extent-empty-predicate");
     CheckFactories.registerCheck<GuardedReleaseCheck>("iree-guarded-release");
     CheckFactories.registerCheck<LifecycleNamingCheck>("iree-lifecycle-naming");
     CheckFactories.registerCheck<RefCountLifecycleCheck>(

--- a/build_tools/clang_tidy/test/extent_checks.c
+++ b/build_tools/clang_tidy/test/extent_checks.c
@@ -1,0 +1,110 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif  // NULL
+
+typedef unsigned long iree_host_size_t;
+
+typedef struct {
+  unsigned char* data;
+  iree_host_size_t data_length;
+} iree_byte_span_t;
+static inline iree_byte_span_t iree_byte_span_empty(void) {
+  iree_byte_span_t span = {NULL, 0};
+  return span;
+}
+
+typedef struct {
+  const unsigned char* data;
+  iree_host_size_t data_length;
+} iree_const_byte_span_t;
+static inline iree_const_byte_span_t iree_const_byte_span_empty(void) {
+  iree_const_byte_span_t span = {NULL, 0};
+  return span;
+}
+
+typedef struct {
+  const char* data;
+  iree_host_size_t size;
+} iree_string_view_t;
+static inline iree_string_view_t iree_string_view_empty(void) {
+  iree_string_view_t view = {NULL, 0};
+  return view;
+}
+
+typedef struct {
+  char* data;
+  iree_host_size_t size;
+} iree_mutable_string_view_t;
+static inline iree_mutable_string_view_t iree_mutable_string_view_empty(void) {
+  iree_mutable_string_view_t view = {NULL, 0};
+  return view;
+}
+
+typedef struct {
+  iree_host_size_t count;
+  void** semaphores;
+  unsigned long* payload_values;
+} iree_hal_semaphore_list_t;
+static inline iree_hal_semaphore_list_t iree_hal_semaphore_list_empty(void) {
+  iree_hal_semaphore_list_t list = {0};
+  return list;
+}
+
+int iree_string_view_is_empty(iree_string_view_t view);
+int iree_const_byte_span_is_empty(iree_const_byte_span_t span);
+int iree_clang_tidy_extent_other_predicate(void);
+
+void iree_clang_tidy_extent_aggregate_zero_initializers(void) {
+  iree_byte_span_t byte_span = {0};
+  iree_const_byte_span_t const_byte_span = {NULL, 0};
+  iree_string_view_t string_view = {0};
+  iree_mutable_string_view_t mutable_string_view = {NULL, 0};
+  iree_hal_semaphore_list_t semaphore_list = {0};
+  (void)byte_span;
+  (void)const_byte_span;
+  (void)string_view;
+  (void)mutable_string_view;
+  (void)semaphore_list;
+}
+
+int iree_clang_tidy_extent_string_view_is_empty(iree_string_view_t view) {
+  if (view.data == NULL || view.size == 0) return 1;
+  return 0;
+}
+
+void iree_clang_tidy_extent_pointer_empty_predicates(
+    iree_string_view_t view, iree_const_byte_span_t span) {
+  if (!view.data && !view.size) return;
+  if (!span.data && !span.data_length) return;
+}
+
+void iree_clang_tidy_extent_allowed_predicates(iree_string_view_t view,
+                                               iree_const_byte_span_t span) {
+  if (!view.data || !view.size) return;
+  if (span.data == NULL || span.data_length == 0) return;
+  if (view.size > 0 && view.data == NULL) return;
+  if (span.data_length > 0 && !span.data) return;
+  if (iree_string_view_is_empty(view)) return;
+  if (iree_const_byte_span_is_empty(span)) return;
+  if (iree_clang_tidy_extent_other_predicate()) return;
+}
+
+void iree_clang_tidy_extent_allowed_initializers(void) {
+  iree_byte_span_t byte_span = iree_byte_span_empty();
+  iree_const_byte_span_t const_byte_span = iree_const_byte_span_empty();
+  iree_string_view_t string_view = iree_string_view_empty();
+  iree_mutable_string_view_t mutable_string_view =
+      iree_mutable_string_view_empty();
+  iree_hal_semaphore_list_t semaphore_list = iree_hal_semaphore_list_empty();
+  (void)byte_span;
+  (void)const_byte_span;
+  (void)string_view;
+  (void)mutable_string_view;
+  (void)semaphore_list;
+}

--- a/build_tools/clang_tidy/test/extent_checks.cc
+++ b/build_tools/clang_tidy/test/extent_checks.cc
@@ -1,0 +1,32 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+using iree_host_size_t = unsigned long;
+
+typedef struct {
+  const char* data;
+  iree_host_size_t size;
+} iree_string_view_t;
+static inline iree_string_view_t iree_string_view_empty(void) {
+  iree_string_view_t view = {nullptr, 0};
+  return view;
+}
+
+typedef struct {
+  const unsigned char* data;
+  iree_host_size_t data_length;
+} iree_const_byte_span_t;
+static inline iree_const_byte_span_t iree_const_byte_span_empty(void) {
+  iree_const_byte_span_t span = {nullptr, 0};
+  return span;
+}
+
+void iree_clang_tidy_extent_cpp_aggregate_zero_initializers(void) {
+  iree_string_view_t string_view = {};
+  iree_const_byte_span_t const_byte_span = {};
+  (void)string_view;
+  (void)const_byte_span;
+}

--- a/build_tools/clang_tidy/test/extent_checks_test.py
+++ b/build_tools/clang_tidy/test/extent_checks_test.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import unittest
+
+import clang_tidy_test
+
+_ARGS = clang_tidy_test.parse_arguments()
+
+
+class ExtentChecksTest(clang_tidy_test.ClangTidyAssertions):
+    def test_empty_initializers_are_diagnosed(self):
+        output = clang_tidy_test.run_clang_tidy(
+            clang_tidy=_ARGS.clang_tidy,
+            plugin=_ARGS.plugin,
+            checks="-*,iree-extent-empty-initializer",
+            source=clang_tidy_test.source_path(__file__, "extent_checks.c"),
+            compiler_args=["-std=gnu11"],
+        )
+        self.assertContainsAll(
+            output,
+            [
+                "use iree_byte_span_empty() instead of aggregate zero "
+                "initialization for empty iree_byte_span_t values",
+                "use iree_const_byte_span_empty() instead of aggregate zero "
+                "initialization for empty iree_const_byte_span_t values",
+                "use iree_string_view_empty() instead of aggregate zero "
+                "initialization for empty iree_string_view_t values",
+                "use iree_mutable_string_view_empty() instead of aggregate "
+                "zero initialization for empty iree_mutable_string_view_t values",
+                "use iree_hal_semaphore_list_empty() instead of aggregate "
+                "zero initialization for empty iree_hal_semaphore_list_t values",
+                "[iree-extent-empty-initializer]",
+            ],
+        )
+        self.assertContainsNone(
+            output,
+            [
+                "iree_clang_tidy_extent_allowed_initializers",
+            ],
+        )
+
+    def test_empty_initializers_are_fixed(self):
+        output, fixed_source = clang_tidy_test.run_clang_tidy_fix(
+            clang_tidy=_ARGS.clang_tidy,
+            plugin=_ARGS.plugin,
+            checks="-*,iree-extent-empty-initializer",
+            source=clang_tidy_test.source_path(__file__, "extent_checks.c"),
+            compiler_args=["-std=gnu11"],
+        )
+        self.assertContainsAll(output, ["[iree-extent-empty-initializer]"])
+        self.assertIn(
+            "iree_byte_span_t byte_span = iree_byte_span_empty();",
+            fixed_source,
+        )
+        self.assertIn(
+            "iree_const_byte_span_t const_byte_span = iree_const_byte_span_empty();",
+            fixed_source,
+        )
+        self.assertIn(
+            "iree_string_view_t string_view = iree_string_view_empty();",
+            fixed_source,
+        )
+        self.assertIn(
+            "iree_mutable_string_view_t mutable_string_view = "
+            "iree_mutable_string_view_empty();",
+            fixed_source,
+        )
+        self.assertIn(
+            "iree_hal_semaphore_list_t semaphore_list = "
+            "iree_hal_semaphore_list_empty();",
+            fixed_source,
+        )
+        self.assertNotIn("iree_byte_span_t byte_span = {0};", fixed_source)
+        self.assertNotIn(
+            "iree_const_byte_span_t const_byte_span = {NULL, 0};",
+            fixed_source,
+        )
+
+    def test_cpp_empty_initializers_are_diagnosed_and_fixed(self):
+        output, fixed_source = clang_tidy_test.run_clang_tidy_fix(
+            clang_tidy=_ARGS.clang_tidy,
+            plugin=_ARGS.plugin,
+            checks="-*,iree-extent-empty-initializer",
+            source=clang_tidy_test.source_path(__file__, "extent_checks.cc"),
+            compiler_args=["-std=c++17"],
+        )
+        self.assertContainsAll(
+            output,
+            [
+                "use iree_string_view_empty() instead of aggregate zero "
+                "initialization for empty iree_string_view_t values",
+                "use iree_const_byte_span_empty() instead of aggregate zero "
+                "initialization for empty iree_const_byte_span_t values",
+                "[iree-extent-empty-initializer]",
+            ],
+        )
+        self.assertIn(
+            "iree_string_view_t string_view = iree_string_view_empty();",
+            fixed_source,
+        )
+        self.assertIn(
+            "iree_const_byte_span_t const_byte_span = iree_const_byte_span_empty();",
+            fixed_source,
+        )
+        self.assertNotIn("iree_string_view_t string_view = {};", fixed_source)
+        self.assertNotIn(
+            "iree_const_byte_span_t const_byte_span = {};",
+            fixed_source,
+        )
+
+    def test_pointer_empty_predicates_are_diagnosed(self):
+        output = clang_tidy_test.run_clang_tidy(
+            clang_tidy=_ARGS.clang_tidy,
+            plugin=_ARGS.plugin,
+            checks="-*,iree-extent-empty-predicate",
+            source=clang_tidy_test.source_path(__file__, "extent_checks.c"),
+            compiler_args=["-std=gnu11"],
+        )
+        self.assertContainsAll(
+            output,
+            [
+                "test empty iree_string_view_t values with "
+                "iree_string_view_is_empty(); pointer-null is malformedness, "
+                "not emptiness",
+                "test empty iree_const_byte_span_t values with "
+                "iree_const_byte_span_is_empty(); pointer-null is "
+                "malformedness, not emptiness",
+                "[iree-extent-empty-predicate]",
+            ],
+        )
+        self.assertContainsNone(
+            output,
+            [
+                "iree_clang_tidy_extent_allowed_predicates",
+            ],
+        )
+
+    def test_pointer_empty_predicates_are_fixed(self):
+        output, fixed_source = clang_tidy_test.run_clang_tidy_fix(
+            clang_tidy=_ARGS.clang_tidy,
+            plugin=_ARGS.plugin,
+            checks="-*,iree-extent-empty-predicate",
+            source=clang_tidy_test.source_path(__file__, "extent_checks.c"),
+            compiler_args=["-std=gnu11"],
+        )
+        self.assertContainsAll(output, ["[iree-extent-empty-predicate]"])
+        self.assertIn(
+            "if (iree_string_view_is_empty(view)) return 1;",
+            fixed_source,
+        )
+        self.assertIn("if (!view.data || !view.size) return;", fixed_source)
+        self.assertIn(
+            "if (iree_const_byte_span_is_empty(span)) return;",
+            fixed_source,
+        )
+        self.assertIn(
+            "if (span.data == NULL || span.data_length == 0) return;",
+            fixed_source,
+        )
+        self.assertNotIn("view.data == NULL || view.size == 0", fixed_source)
+        self.assertNotIn("!view.data && !view.size", fixed_source)
+        self.assertNotIn("!span.data && !span.data_length", fixed_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/libhrx/src/libhrx/device.c
+++ b/libhrx/src/libhrx/device.c
@@ -128,7 +128,7 @@ hrx_status_t hrx_device_synchronize(hrx_device_t device) {
   }
   // Deprecated no-op compatibility shim. IREE requires callers to wait on
   // explicit semaphore payloads; an empty wait list returns immediately.
-  iree_hal_semaphore_list_t empty = {0};
+  iree_hal_semaphore_list_t empty = iree_hal_semaphore_list_empty();
   iree_status_t status = iree_hal_device_wait_semaphores(
       device->hal_device, IREE_ASYNC_WAIT_MODE_ALL, empty,
       iree_infinite_timeout(), /*flags=*/0);

--- a/libhrx/src/libhrx/queue_ops.c
+++ b/libhrx/src/libhrx/queue_ops.c
@@ -13,7 +13,7 @@
 static iree_hal_semaphore_list_t hrx_to_iree_semaphore_list(
     const hrx_semaphore_list_t* list, iree_hal_semaphore_t** hal_semaphores,
     uint64_t* values) {
-  iree_hal_semaphore_list_t result = {0};
+  iree_hal_semaphore_list_t result = iree_hal_semaphore_list_empty();
   if (!list || list->count == 0) return result;
   for (size_t i = 0; i < list->count; i++) {
     hal_semaphores[i] = list->semaphores[i]->hal_semaphore;
@@ -107,7 +107,7 @@ hrx_status_t hrx_queue_fill(hrx_device_t device, hrx_queue_affinity_t affinity,
   iree_hal_semaphore_list_t sig_list =
       hrx_to_iree_semaphore_list(signal_semaphores, sig_hal, sig_vals);
 
-  iree_hal_buffer_binding_table_t bt = {0};
+  iree_hal_buffer_binding_table_t bt = iree_hal_buffer_binding_table_empty();
   status = iree_hal_device_queue_execute(device->hal_device, queue_affinity,
                                          wait_list, sig_list, cb, bt,
                                          /*flags=*/0);
@@ -172,7 +172,7 @@ hrx_status_t hrx_queue_copy(hrx_device_t device, hrx_queue_affinity_t affinity,
   iree_hal_semaphore_list_t sig_list =
       hrx_to_iree_semaphore_list(signal_semaphores, sig_hal, sig_vals);
 
-  iree_hal_buffer_binding_table_t bt = {0};
+  iree_hal_buffer_binding_table_t bt = iree_hal_buffer_binding_table_empty();
   status = iree_hal_device_queue_execute(device->hal_device, queue_affinity,
                                          wait_list, sig_list, cb, bt,
                                          /*flags=*/0);

--- a/libhrx/src/libhrx/runtime.c
+++ b/libhrx/src/libhrx/runtime.c
@@ -503,7 +503,7 @@ static iree_status_t hrx_device_profile_end(hrx_device_s* device) {
     return iree_ok_status();
   }
 
-  iree_hal_semaphore_list_t empty = {0};
+  iree_hal_semaphore_list_t empty = iree_hal_semaphore_list_empty();
   iree_status_t status = iree_hal_device_wait_semaphores(
       device->hal_device, IREE_ASYNC_WAIT_MODE_ALL, empty,
       iree_infinite_timeout(), /*flags=*/0);

--- a/libhrx/src/libhrx/stream.c
+++ b/libhrx/src/libhrx/stream.c
@@ -136,7 +136,8 @@ hrx_status_t hrx_stream_flush(hrx_stream_t stream) {
       .payload_values = &signal_value,
   };
 
-  iree_hal_buffer_binding_table_t binding_table = {0};
+  iree_hal_buffer_binding_table_t binding_table =
+      iree_hal_buffer_binding_table_empty();
   status = iree_hal_device_queue_execute(
       stream->device->hal_device, IREE_HAL_QUEUE_AFFINITY_ANY, wait_list,
       signal_list, stream->pending_cb, binding_table, /*flags=*/0);

--- a/loom/src/loom/format/bytecode/reader.c
+++ b/loom/src/loom/format/bytecode/reader.c
@@ -417,7 +417,7 @@ static iree_status_t loom_bytecode_reader_read_comment_list(
           IREE_SV("comment_length"), length_offset,
           IREE_SV("comment_length_exceeds_maximum"));
     }
-    iree_const_byte_span_t span = {0};
+    iree_const_byte_span_t span = iree_const_byte_span_empty();
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_span(reader, cursor, length, &span));
     if (comments) {
@@ -561,7 +561,7 @@ static iree_status_t loom_bytecode_reader_read_string_table(
           reader, IREE_SV("string_length"), length,
           LOOM_BYTECODE_MAX_STRING_LENGTH, string_offset);
     }
-    iree_const_byte_span_t bytes = {0};
+    iree_const_byte_span_t bytes = iree_const_byte_span_empty();
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_span(reader, &cursor, length, &bytes));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -669,7 +669,7 @@ static iree_status_t loom_bytecode_reader_skip_predicate_list(
             loom_bytecode_reader_read_uvarint(reader, cursor, &encoded_value));
         if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
         if (value_args_are_strings) {
-          iree_string_view_t unused = {0};
+          iree_string_view_t unused = iree_string_view_empty();
           IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
               reader, encoded_value, IREE_SV("predicate_value_name"),
               value_offset, &unused));
@@ -711,7 +711,7 @@ static iree_status_t loom_bytecode_reader_skip_attr_value(
       IREE_RETURN_IF_ERROR(
           loom_bytecode_reader_read_uvarint(reader, cursor, &string_id));
       if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-      iree_string_view_t unused = {0};
+      iree_string_view_t unused = iree_string_view_empty();
       return loom_bytecode_reader_validate_string_ref(
           reader, string_id, IREE_SV("attribute_string"), offset, &unused);
     }
@@ -749,7 +749,7 @@ static iree_status_t loom_bytecode_reader_skip_attr_value(
       IREE_RETURN_IF_ERROR(
           loom_bytecode_reader_read_uvarint(reader, cursor, &byte_length));
       if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-      iree_const_byte_span_t unused = {0};
+      iree_const_byte_span_t unused = iree_const_byte_span_empty();
       return loom_bytecode_reader_read_span(reader, cursor, byte_length,
                                             &unused);
     }
@@ -759,7 +759,7 @@ static iree_status_t loom_bytecode_reader_skip_attr_value(
       IREE_RETURN_IF_ERROR(
           loom_bytecode_reader_read_uvarint(reader, cursor, &symbol_name_id));
       if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-      iree_string_view_t unused = {0};
+      iree_string_view_t unused = iree_string_view_empty();
       return loom_bytecode_reader_validate_string_ref(
           reader, symbol_name_id, IREE_SV("attribute_symbol"), offset, &unused);
     }
@@ -781,7 +781,7 @@ static iree_status_t loom_bytecode_reader_skip_attr_value(
       IREE_RETURN_IF_ERROR(
           loom_bytecode_reader_read_uvarint(reader, cursor, &entry_count));
       if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-      iree_string_view_t previous_key = {0};
+      iree_string_view_t previous_key = iree_string_view_empty();
       for (uint64_t entry_index = 0; entry_index < entry_count; ++entry_index) {
         uint64_t key_offset =
             loom_bytecode_reader_cursor_absolute_position(cursor);
@@ -789,7 +789,7 @@ static iree_status_t loom_bytecode_reader_skip_attr_value(
         IREE_RETURN_IF_ERROR(
             loom_bytecode_reader_read_uvarint(reader, cursor, &key_id));
         if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-        iree_string_view_t key = {0};
+        iree_string_view_t key = iree_string_view_empty();
         IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
             reader, key_id, IREE_SV("dict_key"), key_offset, &key));
         if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -906,7 +906,7 @@ static iree_status_t loom_bytecode_reader_read_predicate_list_attr(
               return iree_ok_status();
             predicate->args[arg_index] = (int64_t)value_id;
           } else {
-            iree_string_view_t unused = {0};
+            iree_string_view_t unused = iree_string_view_empty();
             IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
                 reader, encoded_value, IREE_SV("predicate_value_name"),
                 value_offset, &unused));
@@ -962,7 +962,7 @@ static iree_status_t loom_bytecode_reader_read_attr_value(
       IREE_RETURN_IF_ERROR(
           loom_bytecode_reader_read_uvarint(reader, cursor, &string_id));
       if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-      iree_string_view_t unused = {0};
+      iree_string_view_t unused = iree_string_view_empty();
       IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
           reader, string_id, IREE_SV("attribute_string"), string_offset,
           &unused));
@@ -1029,7 +1029,7 @@ static iree_status_t loom_bytecode_reader_read_attr_value(
             reader, IREE_SV("bytes_attribute"), byte_length, UINT32_MAX,
             byte_length_offset);
       }
-      iree_const_byte_span_t span = {0};
+      iree_const_byte_span_t span = iree_const_byte_span_empty();
       IREE_RETURN_IF_ERROR(
           loom_bytecode_reader_read_span(reader, cursor, byte_length, &span));
       if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -1049,7 +1049,7 @@ static iree_status_t loom_bytecode_reader_read_attr_value(
       IREE_RETURN_IF_ERROR(
           loom_bytecode_reader_read_uvarint(reader, cursor, &name_id));
       if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-      iree_string_view_t unused = {0};
+      iree_string_view_t unused = iree_string_view_empty();
       IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
           reader, name_id, IREE_SV("attribute_symbol"), name_offset, &unused));
       if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -1099,7 +1099,7 @@ static iree_status_t loom_bytecode_reader_read_attr_value(
             reader->arena, (iree_host_size_t)entry_count,
             sizeof(loom_named_attr_t), (void**)&entries));
       }
-      iree_string_view_t previous_key = {0};
+      iree_string_view_t previous_key = iree_string_view_empty();
       for (uint64_t entry_index = 0; entry_index < entry_count; ++entry_index) {
         uint64_t key_offset =
             loom_bytecode_reader_cursor_absolute_position(cursor);
@@ -1107,7 +1107,7 @@ static iree_status_t loom_bytecode_reader_read_attr_value(
         IREE_RETURN_IF_ERROR(
             loom_bytecode_reader_read_uvarint(reader, cursor, &key_id));
         if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-        iree_string_view_t key = {0};
+        iree_string_view_t key = iree_string_view_empty();
         IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
             reader, key_id, IREE_SV("dict_key"), key_offset, &key));
         if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -1205,7 +1205,7 @@ static iree_status_t loom_bytecode_reader_read_encodings(
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_uvarint(reader, &cursor, &name_id));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-    iree_string_view_t name = {0};
+    iree_string_view_t name = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
         reader, name_id, IREE_SV("encoding_family_name"), name_offset, &name));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -1264,7 +1264,7 @@ static iree_status_t loom_bytecode_reader_read_encodings(
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_uvarint(reader, &cursor, &param_count));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-    iree_string_view_t previous_param = {0};
+    iree_string_view_t previous_param = iree_string_view_empty();
     for (uint64_t param_index = 0; param_index < param_count; ++param_index) {
       uint64_t name_offset =
           loom_bytecode_reader_cursor_absolute_position(&cursor);
@@ -1272,7 +1272,7 @@ static iree_status_t loom_bytecode_reader_read_encodings(
       IREE_RETURN_IF_ERROR(
           loom_bytecode_reader_read_uvarint(reader, &cursor, &name_id));
       if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-      iree_string_view_t param_name = {0};
+      iree_string_view_t param_name = iree_string_view_empty();
       IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
           reader, name_id, IREE_SV("encoding_param_name"), name_offset,
           &param_name));
@@ -1379,7 +1379,7 @@ static iree_status_t loom_bytecode_reader_materialize_encodings(
       IREE_RETURN_IF_ERROR(
           loom_bytecode_reader_read_uvarint(reader, &cursor, &name_id));
       if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-      iree_string_view_t unused_name = {0};
+      iree_string_view_t unused_name = iree_string_view_empty();
       IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
           reader, name_id, IREE_SV("encoding_param_name"), name_offset,
           &unused_name));
@@ -1753,7 +1753,7 @@ static iree_status_t loom_bytecode_reader_read_types(
         IREE_RETURN_IF_ERROR(
             loom_bytecode_reader_read_uvarint(reader, &cursor, &param_count));
         if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-        iree_string_view_t unused_name = {0};
+        iree_string_view_t unused_name = iree_string_view_empty();
         IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
             reader, name_id, IREE_SV("dialect_type_name"), name_offset,
             &unused_name));
@@ -1911,7 +1911,7 @@ static iree_status_t loom_bytecode_reader_read_ops(
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_uvarint(reader, &cursor, &name_id));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-    iree_string_view_t op_name = {0};
+    iree_string_view_t op_name = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
         reader, name_id, IREE_SV("op_name"), name_offset, &op_name));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -2017,7 +2017,7 @@ static iree_status_t loom_bytecode_reader_read_locations(
         uint64_t data_length = 0;
         IREE_RETURN_IF_ERROR(
             loom_bytecode_reader_read_uvarint(reader, &cursor, &data_length));
-        iree_const_byte_span_t unused = {0};
+        iree_const_byte_span_t unused = iree_const_byte_span_empty();
         IREE_RETURN_IF_ERROR(loom_bytecode_reader_read_span(
             reader, &cursor, data_length, &unused));
         break;
@@ -2046,7 +2046,7 @@ static iree_status_t loom_bytecode_reader_read_locations(
         uint64_t data_length = 0;
         IREE_RETURN_IF_ERROR(
             loom_bytecode_reader_read_uvarint(reader, &cursor, &data_length));
-        iree_const_byte_span_t unused = {0};
+        iree_const_byte_span_t unused = iree_const_byte_span_empty();
         IREE_RETURN_IF_ERROR(loom_bytecode_reader_read_span(
             reader, &cursor, data_length, &unused));
         break;
@@ -2209,7 +2209,7 @@ static iree_status_t loom_bytecode_reader_materialize_locations(
               reader, IREE_SV("opaque_location_data"), data_length, UINT32_MAX,
               data_length_offset);
         }
-        iree_const_byte_span_t data_span = {0};
+        iree_const_byte_span_t data_span = iree_const_byte_span_empty();
         IREE_RETURN_IF_ERROR(loom_bytecode_reader_read_span(
             reader, &cursor, data_length, &data_span));
         if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -2258,7 +2258,7 @@ static iree_status_t loom_bytecode_reader_materialize_locations(
               reader, IREE_SV("tagged_location_data"), data_length, UINT32_MAX,
               data_length_offset);
         }
-        iree_const_byte_span_t data_span = {0};
+        iree_const_byte_span_t data_span = iree_const_byte_span_empty();
         IREE_RETURN_IF_ERROR(loom_bytecode_reader_read_span(
             reader, &cursor, data_length, &data_span));
         if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -2434,7 +2434,7 @@ static iree_status_t loom_bytecode_body_reader_define_value(
         IREE_SV("value_definition_was_not_reserved_before_decoding"));
   }
   if (name_id != 0) {
-    iree_string_view_t unused_name = {0};
+    iree_string_view_t unused_name = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
         body_reader->reader, name_id, IREE_SV("value_name"), name_offset,
         &unused_name));
@@ -2775,7 +2775,7 @@ static iree_status_t loom_bytecode_body_reader_read_op(
                                                            cursor, &key_id));
     if (loom_bytecode_reader_has_errors(body_reader->reader))
       return iree_ok_status();
-    iree_string_view_t key = {0};
+    iree_string_view_t key = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
         body_reader->reader, key_id, IREE_SV("attribute_key"), key_offset,
         &key));
@@ -2897,7 +2897,7 @@ static iree_status_t loom_bytecode_body_reader_read_block(
                                                            cursor, &label_id));
     if (loom_bytecode_reader_has_errors(body_reader->reader))
       return iree_ok_status();
-    iree_string_view_t unused_label = {0};
+    iree_string_view_t unused_label = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
         body_reader->reader, label_id, IREE_SV("block_label"), label_offset,
         &unused_label));
@@ -3281,7 +3281,7 @@ static iree_status_t loom_bytecode_reader_read_func_payload_attrs(
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_uvarint(reader, cursor, &key_id));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-    iree_string_view_t key = {0};
+    iree_string_view_t key = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
         reader, key_id, IREE_SV("function_attribute_key"), key_offset, &key));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -3351,7 +3351,7 @@ static iree_status_t loom_bytecode_reader_skip_func_payload_attrs(
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_uvarint(reader, cursor, &key_id));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-    iree_string_view_t key = {0};
+    iree_string_view_t key = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
         reader, key_id, IREE_SV("function_attribute_key"), key_offset, &key));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -3498,7 +3498,7 @@ static iree_status_t loom_bytecode_reader_skip_value_def(
       loom_bytecode_reader_read_uvarint(reader, cursor, &dim_binding_count));
   if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
   if (name_id != 0) {
-    iree_string_view_t unused_name = {0};
+    iree_string_view_t unused_name = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
         reader, name_id, IREE_SV("value_name"), name_offset, &unused_name));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -3594,7 +3594,7 @@ static iree_status_t loom_bytecode_reader_skip_global_payload(
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_uvarint(reader, cursor, &key_id));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-    iree_string_view_t key = {0};
+    iree_string_view_t key = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
         reader, key_id, IREE_SV("global_attribute_key"), key_offset, &key));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -3680,7 +3680,7 @@ static iree_status_t loom_bytecode_reader_skip_record_payload(
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_uvarint(reader, cursor, &key_id));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-    iree_string_view_t key = {0};
+    iree_string_view_t key = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
         reader, key_id, IREE_SV("record_attribute_key"), key_offset, &key));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -4070,7 +4070,7 @@ static iree_status_t loom_bytecode_reader_materialize_function_symbol(
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_uvarint(reader, cursor, &priority_value));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-    iree_string_view_t unused = {0};
+    iree_string_view_t unused = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
         reader, implements_string_id, IREE_SV("implements_op_name"),
         implements_offset, &unused));
@@ -4300,7 +4300,7 @@ static iree_status_t loom_bytecode_reader_materialize_global_symbol(
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_uvarint(reader, cursor, &key_id));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-    iree_string_view_t key = {0};
+    iree_string_view_t key = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
         reader, key_id, IREE_SV("global_attribute_key"), key_offset, &key));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -4422,7 +4422,7 @@ static iree_status_t loom_bytecode_reader_materialize_record_symbol(
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_uvarint(reader, cursor, &key_id));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-    iree_string_view_t key = {0};
+    iree_string_view_t key = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
         reader, key_id, IREE_SV("record_attribute_key"), key_offset, &key));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -4683,7 +4683,7 @@ static iree_status_t loom_bytecode_reader_read_symbols(
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_uvarint(reader, &cursor, &name_id));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
-    iree_string_view_t unused_name = {0};
+    iree_string_view_t unused_name = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
         reader, name_id, IREE_SV("symbol_name"), name_offset, &unused_name));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -4778,7 +4778,7 @@ static iree_status_t loom_bytecode_reader_read_symbols(
       uint64_t module_ref_id = 0;
       IREE_RETURN_IF_ERROR(
           loom_bytecode_reader_read_uvarint(reader, &cursor, &module_ref_id));
-      iree_string_view_t import_module = {0};
+      iree_string_view_t import_module = iree_string_view_empty();
       IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
           reader, module_ref_id, IREE_SV("source_module_id"), module_ref_offset,
           &import_module));
@@ -4788,7 +4788,7 @@ static iree_status_t loom_bytecode_reader_read_symbols(
       uint64_t symbol_ref_id = 0;
       IREE_RETURN_IF_ERROR(
           loom_bytecode_reader_read_uvarint(reader, &cursor, &symbol_ref_id));
-      iree_string_view_t import_symbol = {0};
+      iree_string_view_t import_symbol = iree_string_view_empty();
       IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
           reader, symbol_ref_id, IREE_SV("source_symbol_id"), symbol_ref_offset,
           &import_symbol));
@@ -4914,7 +4914,7 @@ static iree_status_t loom_bytecode_reader_read_symbols(
             reader, &cursor, &implements_string_id));
         IREE_RETURN_IF_ERROR(
             loom_bytecode_reader_read_uvarint(reader, &cursor, &priority));
-        iree_string_view_t implements_name = {0};
+        iree_string_view_t implements_name = iree_string_view_empty();
         IREE_RETURN_IF_ERROR(loom_bytecode_reader_validate_string_ref(
             reader, implements_string_id, IREE_SV("implements_op_name"),
             implements_offset, &implements_name));
@@ -5002,7 +5002,7 @@ static iree_status_t loom_bytecode_reader_validate_file_header(
   }
 
   uint8_t magic[LOOM_BYTECODE_MAGIC_LENGTH] = {0};
-  iree_const_byte_span_t magic_span = {0};
+  iree_const_byte_span_t magic_span = iree_const_byte_span_empty();
   IREE_RETURN_IF_ERROR(loom_bytecode_reader_read_span(
       reader, cursor, LOOM_BYTECODE_MAGIC_LENGTH, &magic_span));
   memcpy(magic, magic_span.data, sizeof(magic));
@@ -5174,7 +5174,7 @@ static iree_status_t loom_bytecode_reader_read_module_directory(
 static iree_status_t loom_bytecode_reader_read_file_string_pool(
     loom_bytecode_reader_state_t* reader, loom_bytecode_reader_cursor_t* cursor,
     uint64_t string_pool_length) {
-  iree_const_byte_span_t pool = {0};
+  iree_const_byte_span_t pool = iree_const_byte_span_empty();
   IREE_RETURN_IF_ERROR(loom_bytecode_reader_read_span(
       reader, cursor, string_pool_length, &pool));
   if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();

--- a/loom/src/loom/format/bytecode/varint_test.cc
+++ b/loom/src/loom/format/bytecode/varint_test.cc
@@ -203,7 +203,7 @@ TEST(UvarintEncode, BufferExactSize) {
 }
 
 TEST(UvarintEncode, ZeroLengthBuffer) {
-  iree_byte_span_t buffer = {NULL, 0};
+  iree_byte_span_t buffer = iree_byte_span_empty();
   iree_host_size_t length = 0;
   // Even value 0 needs 1 byte.
   IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED,
@@ -395,7 +395,7 @@ TEST(CursorReadSpan, Basic) {
   loom_bytecode_cursor_t cursor;
   loom_bytecode_cursor_initialize(data, sizeof(data), &cursor);
 
-  iree_const_byte_span_t span = {0};
+  iree_const_byte_span_t span = iree_const_byte_span_empty();
   IREE_ASSERT_OK(loom_bytecode_cursor_read_span(&cursor, 3, &span));
   EXPECT_EQ(span.data, data);
   EXPECT_EQ(span.data_length, 3u);
@@ -406,7 +406,7 @@ TEST(CursorReadSpan, PastEnd) {
   uint8_t data[] = {0x01};
   loom_bytecode_cursor_t cursor;
   loom_bytecode_cursor_initialize(data, sizeof(data), &cursor);
-  iree_const_byte_span_t span = {0};
+  iree_const_byte_span_t span = iree_const_byte_span_empty();
   IREE_EXPECT_STATUS_IS(IREE_STATUS_OUT_OF_RANGE,
                         loom_bytecode_cursor_read_span(&cursor, 2, &span));
   EXPECT_EQ(cursor.position, 0u);

--- a/loom/src/loom/format/bytecode/writer_test.cc
+++ b/loom/src/loom/format/bytecode/writer_test.cc
@@ -576,7 +576,7 @@ TEST_F(WriterTest, StringsSectionContainsModuleName) {
   uint64_t second_length = 0;
   IREE_ASSERT_OK(loom_uvarint_decode(&cursor, &second_length));
   EXPECT_EQ(second_length, 5u);
-  iree_const_byte_span_t span = {0};
+  iree_const_byte_span_t span = iree_const_byte_span_empty();
   IREE_ASSERT_OK(loom_bytecode_cursor_read_span(&cursor, 5, &span));
   EXPECT_EQ(memcmp(span.data, "hello", 5), 0);
 
@@ -712,7 +712,7 @@ TEST_F(WriterTest, FunctionSymbolKindUsesDenseWireEnum) {
   ASSERT_EQ(import_count, 0u);
   ASSERT_EQ(export_count, 1u);
 
-  iree_const_byte_span_t export_table = {};
+  iree_const_byte_span_t export_table = iree_const_byte_span_empty();
   IREE_ASSERT_OK(loom_bytecode_cursor_read_span(&cursor, 8, &export_table));
   EXPECT_EQ(export_table.data_length, 8u);
 

--- a/runtime/src/iree/async/cts/core/nop_test.cc
+++ b/runtime/src/iree/async/cts/core/nop_test.cc
@@ -95,7 +95,7 @@ TEST_P(NopTest, CallbackReceivesOperationPointer) {
 
 // Empty submit list: should succeed with no completions.
 TEST_P(NopTest, EmptySubmit) {
-  iree_async_operation_list_t empty_list = {nullptr, 0};
+  iree_async_operation_list_t empty_list = iree_async_operation_list_empty();
   IREE_ASSERT_OK(iree_async_proactor_submit(proactor_, empty_list));
 
   // Poll should return immediately with no completions (deadline exceeded).

--- a/runtime/src/iree/base/allocator.h
+++ b/runtime/src/iree/base/allocator.h
@@ -46,6 +46,10 @@ extern "C" {
 //===----------------------------------------------------------------------===//
 
 // A span of mutable bytes (ala std::span of uint8_t).
+//
+// Spans are empty when data_length is zero. Empty spans may have NULL or
+// non-NULL data pointers. A span with non-zero data_length and NULL data is
+// malformed and must be rejected at API boundaries before data is accessed.
 typedef struct iree_byte_span_t {
   uint8_t* data;
   iree_host_size_t data_length;
@@ -63,10 +67,14 @@ static inline iree_byte_span_t iree_byte_span_empty() {
 }
 
 static inline bool iree_byte_span_is_empty(iree_byte_span_t span) {
-  return span.data == NULL || span.data_length == 0;
+  return span.data_length == 0;
 }
 
 // A span of constant bytes (ala std::span of const uint8_t).
+//
+// Spans are empty when data_length is zero. Empty spans may have NULL or
+// non-NULL data pointers. A span with non-zero data_length and NULL data is
+// malformed and must be rejected at API boundaries before data is accessed.
 typedef struct iree_const_byte_span_t {
   const uint8_t* data;
   iree_host_size_t data_length;
@@ -84,7 +92,7 @@ static inline iree_const_byte_span_t iree_const_byte_span_empty() {
 }
 
 static inline bool iree_const_byte_span_is_empty(iree_const_byte_span_t span) {
-  return span.data == NULL || span.data_length == 0;
+  return span.data_length == 0;
 }
 
 static inline iree_const_byte_span_t iree_const_cast_byte_span(

--- a/runtime/src/iree/base/allocator_test.cc
+++ b/runtime/src/iree/base/allocator_test.cc
@@ -16,6 +16,26 @@ using ::iree::testing::status::IsOk;
 using ::iree::testing::status::StatusIs;
 
 //===----------------------------------------------------------------------===//
+// Byte span tests
+//===----------------------------------------------------------------------===//
+
+TEST(ByteSpanTest, Empty) {
+  uint8_t storage[1] = {0};
+  EXPECT_TRUE(iree_byte_span_is_empty(iree_byte_span_empty()));
+  EXPECT_TRUE(iree_byte_span_is_empty(iree_make_byte_span(storage, 0)));
+  EXPECT_FALSE(iree_byte_span_is_empty(iree_make_byte_span(NULL, 1)));
+}
+
+TEST(ConstByteSpanTest, Empty) {
+  const uint8_t storage[1] = {0};
+  EXPECT_TRUE(iree_const_byte_span_is_empty(iree_const_byte_span_empty()));
+  EXPECT_TRUE(
+      iree_const_byte_span_is_empty(iree_make_const_byte_span(storage, 0)));
+  EXPECT_FALSE(
+      iree_const_byte_span_is_empty(iree_make_const_byte_span(NULL, 1)));
+}
+
+//===----------------------------------------------------------------------===//
 // Checked arithmetic tests - iree_host_size_t
 //===----------------------------------------------------------------------===//
 

--- a/runtime/src/iree/base/string_view.h
+++ b/runtime/src/iree/base/string_view.h
@@ -25,6 +25,10 @@ typedef struct iree_status_handle_t* iree_status_t;
 #define IREE_STRING_VIEW_NPOS IREE_HOST_SIZE_MAX
 
 // A string view (ala std::string_view) into a non-NUL-terminated string.
+//
+// String views are empty when size is zero. Empty views may have NULL or
+// non-NULL data pointers. A view with non-zero size and NULL data is malformed
+// and must be rejected at API boundaries before data is accessed.
 typedef struct iree_string_view_t {
   const char* data;
   iree_host_size_t size;
@@ -37,7 +41,9 @@ static inline iree_string_view_t iree_string_view_empty(void) {
 }
 
 // Returns true if the given string view is the empty string.
-#define iree_string_view_is_empty(sv) (((sv).data == NULL) || ((sv).size == 0))
+static inline bool iree_string_view_is_empty(iree_string_view_t sv) {
+  return sv.size == 0;
+}
 
 static inline iree_string_view_t iree_make_string_view(
     const char* str, iree_host_size_t str_length) {
@@ -53,6 +59,10 @@ static inline iree_string_view_t iree_make_cstring_view(const char* str) {
 }
 
 // A mutable string view into a non-NUL-terminated char buffer.
+//
+// Mutable string views are empty when size is zero. Empty views may have NULL
+// or non-NULL data pointers. A view with non-zero size and NULL data is
+// malformed and must be rejected at API boundaries before data is accessed.
 // Unlike iree_string_view_t, the data pointer is non-const for writing.
 // Useful for output buffers where we track capacity and written length.
 typedef struct iree_mutable_string_view_t {
@@ -67,8 +77,10 @@ static inline iree_mutable_string_view_t iree_mutable_string_view_empty(void) {
 }
 
 // Returns true if the given mutable string view is empty.
-#define iree_mutable_string_view_is_empty(sv) \
-  (((sv).data == NULL) || ((sv).size == 0))
+static inline bool iree_mutable_string_view_is_empty(
+    iree_mutable_string_view_t sv) {
+  return sv.size == 0;
+}
 
 static inline iree_mutable_string_view_t iree_make_mutable_string_view(
     char* str, iree_host_size_t str_length) {

--- a/runtime/src/iree/base/string_view_test.cc
+++ b/runtime/src/iree/base/string_view_test.cc
@@ -24,6 +24,23 @@ static std::string ToString(iree_string_view_t value) {
   return std::string(value.data, value.size);
 }
 
+TEST(StringViewTest, Empty) {
+  const char storage[1] = {0};
+  EXPECT_TRUE(iree_string_view_is_empty(iree_string_view_empty()));
+  EXPECT_TRUE(iree_string_view_is_empty(iree_make_string_view(storage, 0)));
+  EXPECT_FALSE(iree_string_view_is_empty(iree_make_string_view(NULL, 1)));
+}
+
+TEST(MutableStringViewTest, Empty) {
+  char storage[1] = {0};
+  EXPECT_TRUE(
+      iree_mutable_string_view_is_empty(iree_mutable_string_view_empty()));
+  EXPECT_TRUE(iree_mutable_string_view_is_empty(
+      iree_make_mutable_string_view(storage, 0)));
+  EXPECT_FALSE(iree_mutable_string_view_is_empty(
+      iree_make_mutable_string_view(NULL, 1)));
+}
+
 TEST(StringViewTest, Equal) {
   auto equal = [](const char* lhs, const char* rhs) -> bool {
     return iree_string_view_equal(iree_make_cstring_view(lhs),
@@ -580,7 +597,7 @@ TEST(StringViewTest, ToCStringTruncate) {
 TEST(StringViewTest, AppendToBuffer) {
   char buffer[6] = {0, 1, 2, 3, 4, 5};
   iree_string_view_t source = iree_make_cstring_view("test");
-  iree_string_view_t target = {};
+  iree_string_view_t target = iree_string_view_empty();
   const iree_host_size_t size =
       iree_string_view_append_to_buffer(source, &target, buffer);
   EXPECT_EQ(size, source.size);
@@ -593,7 +610,7 @@ TEST(StringViewTest, AppendToBuffer) {
 TEST(StringViewTest, AppendToBufferEmptySource) {
   char buffer[4] = {0, 1, 2, 3};
   iree_string_view_t source = iree_make_string_view(nullptr, 0);
-  iree_string_view_t target = {};
+  iree_string_view_t target = iree_string_view_empty();
   const iree_host_size_t size =
       iree_string_view_append_to_buffer(source, &target, buffer);
   EXPECT_EQ(size, 0u);
@@ -605,7 +622,7 @@ TEST(StringViewTest, AppendToBufferEmptySource) {
 
 TEST(StringViewTest, AppendToBufferEmptySourceAndBuffer) {
   iree_string_view_t source = iree_make_string_view(nullptr, 0);
-  iree_string_view_t target = {};
+  iree_string_view_t target = iree_string_view_empty();
   const iree_host_size_t size =
       iree_string_view_append_to_buffer(source, &target, nullptr);
   EXPECT_EQ(size, 0u);

--- a/runtime/src/iree/hal/cts/sanitizer/asan_allocation_test.cc
+++ b/runtime/src/iree/hal/cts/sanitizer/asan_allocation_test.cc
@@ -90,10 +90,7 @@ static iree_status_t DispatchAsanAllocationRawAddress(
 
   SemaphoreList empty_wait;
   SemaphoreList dispatch_signal(device, {0}, {1});
-  iree_hal_buffer_ref_list_t empty_bindings = {
-      /*.count=*/0,
-      /*.values=*/nullptr,
-  };
+  iree_hal_buffer_ref_list_t empty_bindings = iree_hal_buffer_ref_list_empty();
   IREE_RETURN_IF_ERROR(iree_hal_device_queue_dispatch(
       device, IREE_HAL_QUEUE_AFFINITY_ANY, empty_wait, dispatch_signal,
       executable,

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor_test.cc
@@ -408,7 +408,8 @@ static iree_hal_amdgpu_aql_block_processor_t MakeProcessor(
     const iree_hal_amdgpu_device_buffer_transfer_context_t* transfer_context =
         nullptr,
     iree_hal_command_buffer_t* command_buffer = nullptr,
-    iree_hal_buffer_binding_table_t binding_table = {0, nullptr}) {
+    iree_hal_buffer_binding_table_t binding_table =
+        iree_hal_buffer_binding_table_empty()) {
   iree_hal_amdgpu_aql_block_processor_t processor = {};
   processor.transfer_context = transfer_context;
   processor.command_buffer = command_buffer;

--- a/runtime/src/iree/hal/drivers/amdgpu/cts/manual_asan_executable_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/cts/manual_asan_executable_test.cc
@@ -228,10 +228,7 @@ static iree_status_t DispatchManualAsanRawAddress(
 
   SemaphoreList empty_wait;
   SemaphoreList dispatch_signal(device, {0}, {1});
-  iree_hal_buffer_ref_list_t empty_bindings = {
-      /*.count=*/0,
-      /*.values=*/nullptr,
-  };
+  iree_hal_buffer_ref_list_t empty_bindings = iree_hal_buffer_ref_list_empty();
   IREE_RETURN_IF_ERROR(iree_hal_device_queue_dispatch(
       device, IREE_HAL_QUEUE_AFFINITY_ANY, empty_wait, dispatch_signal,
       executable,

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco_test.cc
@@ -79,7 +79,7 @@ static bool StringViewBelongsToCodeObjectData(
     iree_const_byte_span_t code_object_data, iree_string_view_t view) {
   const uintptr_t code_object_begin = (uintptr_t)code_object_data.data;
   const uintptr_t view_begin = (uintptr_t)view.data;
-  if (view.size == 0 && !view.data) return true;
+  if (iree_string_view_is_empty(view)) return true;
   if (!view.data || view_begin < code_object_begin) return false;
   const uintptr_t view_offset = view_begin - code_object_begin;
   return view_offset <= code_object_data.data_length &&

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profiling_test_util.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profiling_test_util.h
@@ -213,7 +213,7 @@ struct CommandBufferProfileSink {
   iree_status_code_t fail_begin_session_status_code = IREE_STATUS_OK;
 
   // Content type whose write callback should fail, or empty when disabled.
-  iree_string_view_t fail_write_content_type = {nullptr, 0};
+  iree_string_view_t fail_write_content_type = iree_string_view_empty();
 
   // Number of matching write callbacks that should fail.
   int fail_write_remaining = 0;

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_submission_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_submission_test.cc
@@ -260,7 +260,8 @@ static void ExpectDispatchSubmissionPlan(
     const DispatchSubmissionPlanCase& plan_case) {
   iree_hal_amdgpu_wait_resolution_t resolution = {0};
   resolution.barrier_count = plan_case.barrier_count;
-  const iree_hal_semaphore_list_t empty_signal_list = {0};
+  const iree_hal_semaphore_list_t empty_signal_list =
+      iree_hal_semaphore_list_empty();
   iree_hal_amdgpu_profile_dispatch_event_reservation_t profile_events = {0};
   iree_hal_amdgpu_host_queue_profile_event_info_t profile_queue_event_info = {
       /*.type=*/IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_DISPATCH,
@@ -363,7 +364,8 @@ static void ExpectPm4IbSubmissionPlan(
     const Pm4IbSubmissionPlanCase& plan_case) {
   iree_hal_amdgpu_wait_resolution_t resolution = {0};
   resolution.barrier_count = plan_case.barrier_count;
-  const iree_hal_semaphore_list_t empty_signal_list = {0};
+  const iree_hal_semaphore_list_t empty_signal_list =
+      iree_hal_semaphore_list_empty();
   iree_hal_amdgpu_host_queue_profile_event_info_t profile_queue_event_info = {
       /*.type=*/IREE_HAL_PROFILE_QUEUE_EVENT_TYPE_UPDATE,
       /*.flags=*/{},

--- a/runtime/src/iree/hal/drivers/vulkan/command_buffer_test.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/command_buffer_test.cc
@@ -172,7 +172,8 @@ TEST_F(VulkanCommandBufferTest, ReplaysDebugGroupsAsDebugUtilsLabels) {
   iree_hal_vulkan_debug_utils_t debug_utils;
   debug_utils.flags = IREE_HAL_VULKAN_DEBUG_UTILS_FLAG_COMMAND_LABELS;
   iree_hal_vulkan_builtins_t builtins = {};
-  iree_hal_buffer_binding_table_t binding_table = {};
+  iree_hal_buffer_binding_table_t binding_table =
+      iree_hal_buffer_binding_table_empty();
   VkDevice logical_device =
       reinterpret_cast<VkDevice>(static_cast<uintptr_t>(0x1234));
   VkCommandBuffer native_command_buffer =

--- a/runtime/src/iree/hal/drivers/vulkan/cts/bda_spirv_test.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/cts/bda_spirv_test.cc
@@ -432,7 +432,7 @@ TEST_P(BdaSpirvTest, QueueDispatchExecutesUnverifiedBdaNoop) {
           IREE_HAL_EXECUTABLE_CACHING_MODE_DISABLE_VERIFICATION,
       executable.out()));
 
-  iree_hal_buffer_ref_list_t bindings = {};
+  iree_hal_buffer_ref_list_t bindings = iree_hal_buffer_ref_list_empty();
   SemaphoreList dispatch_signal(device_, {0}, {1});
   IREE_ASSERT_OK(iree_hal_device_queue_dispatch(
       device_, IREE_HAL_QUEUE_AFFINITY_ANY, iree_hal_semaphore_list_empty(),

--- a/runtime/src/iree/tokenizer/vocab/vocab.c
+++ b/runtime/src/iree/tokenizer/vocab/vocab.c
@@ -83,7 +83,7 @@ iree_host_size_t iree_tokenizer_vocab_merge_count(
 iree_const_byte_span_t iree_tokenizer_vocab_string_table(
     const iree_tokenizer_vocab_t* vocab) {
   if (!vocab) {
-    iree_const_byte_span_t empty = {NULL, 0};
+    iree_const_byte_span_t empty = iree_const_byte_span_empty();
     return empty;
   }
   iree_const_byte_span_t span = {vocab->string_data, vocab->string_size};

--- a/runtime/src/iree/tokenizer/vocab/vocab_hash_test.cc
+++ b/runtime/src/iree/tokenizer/vocab/vocab_hash_test.cc
@@ -32,7 +32,7 @@ std::vector<uint8_t> BuildStringTable(
 
 TEST(VocabHashTest, EmptyVocab) {
   iree_tokenizer_vocab_hash_t* hash = nullptr;
-  iree_const_byte_span_t empty_table = {nullptr, 0};
+  iree_const_byte_span_t empty_table = iree_const_byte_span_empty();
   IREE_ASSERT_OK(iree_tokenizer_vocab_hash_build(
       nullptr, 0, empty_table, IREE_TOKENIZER_VOCAB_HASH_DEFAULT_LOAD_PERCENT,
       iree_allocator_system(), &hash));

--- a/runtime/src/iree/tokenizer/vocab/vocab_trie_test.cc
+++ b/runtime/src/iree/tokenizer/vocab/vocab_trie_test.cc
@@ -52,7 +52,7 @@ std::vector<std::pair<int32_t, size_t>> TraverseTrie(
 
 TEST(VocabTrieTest, EmptyVocab) {
   iree_tokenizer_vocab_trie_t* trie = nullptr;
-  iree_const_byte_span_t empty_table = {nullptr, 0};
+  iree_const_byte_span_t empty_table = iree_const_byte_span_empty();
   IREE_ASSERT_OK(iree_tokenizer_vocab_trie_build(
       nullptr, 0, empty_table, iree_allocator_system(), &trie));
   ASSERT_NE(trie, nullptr);

--- a/runtime/src/iree/vm/bytecode/assembler/source.c
+++ b/runtime/src/iree/vm/bytecode/assembler/source.c
@@ -9,7 +9,7 @@
 #include <ctype.h>
 
 bool iree_vm_bytecode_assembler_string_view_is_empty(iree_string_view_t value) {
-  return value.data == NULL || value.size == 0;
+  return iree_string_view_is_empty(value);
 }
 
 bool iree_vm_bytecode_assembler_string_view_equal_cstring(


### PR DESCRIPTION
Add clang-tidy checks for IREE extent-value empty contracts.

The initializer check normalizes aggregate zero initialization to named empty constructors for known span, string-view, and list value types.

The predicate check rejects pure empty tests that combine pointer nullness with a zero extent, while leaving explicit malformed-or-empty access guards intact. Empty is defined by the extent field; non-zero extent with NULL storage is malformed boundary input.

Update byte span and string view helpers so their empty predicates match that contract, and normalize existing call sites to the named empty constructors.