### PR TITLE
amdgpu: add unit tests for the kind-aware AQL doorbell

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/util/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/BUILD.bazel
@@ -464,6 +464,19 @@ iree_runtime_cc_test(
 )
 
 iree_runtime_cc_test(
+    name = "aql_ring_test",
+    srcs = ["aql_ring_test.cc"],
+    deps = [
+        ":libhsa",
+        ":queue_primitives",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal/drivers/amdgpu/abi",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_test(
     name = "queue_upload_ring_test",
     srcs = ["queue_upload_ring_test.cc"],
     deps = [

--- a/runtime/src/iree/hal/drivers/amdgpu/util/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/CMakeLists.txt
@@ -645,6 +645,28 @@ endif()
 if(IREE_HAL_DRIVER_AMDGPU)
 iree_cc_test(
   NAME
+    aql_ring_test
+  SRCS
+    "aql_ring_test.cc"
+  DEPS
+    ::libhsa
+    ::queue_primitives
+    iree::base
+    iree::hal::drivers::amdgpu::abi
+    iree::testing::gtest
+    iree::testing::gtest_main
+  LABELS
+    "iree-build-requirement=runtime.hal.amdgpu"
+    "iree-run-requirement=runtime.resource.amd_gpu"
+    "runtime-resource=amd-gpu"
+  RESOURCE_GROUP
+    iree-hal-drivers-amdgpu-tests
+)
+endif()
+
+if(IREE_HAL_DRIVER_AMDGPU)
+iree_cc_test(
+  NAME
     queue_upload_ring_test
   SRCS
     "queue_upload_ring_test.cc"

--- a/runtime/src/iree/hal/drivers/amdgpu/util/aql_ring_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/aql_ring_test.cc
@@ -1,0 +1,154 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/aql_ring.h"
+
+#include <cstdint>
+
+#include "iree/hal/drivers/amdgpu/util/libhsa.h"
+#include "iree/testing/gtest.h"
+
+namespace {
+
+// Fills the queue fields aql_ring_initialize reads: the packet ring base/size
+// and the doorbell signal handle. The dispatch-id fields are read by address
+// and left zero.
+static void ConfigureQueue(iree_hal_amdgpu_aql_packet_t* base, uint32_t size,
+                           const iree_amd_signal_t* doorbell_signal,
+                           iree_amd_queue_t* out_queue) {
+  out_queue->hsa_queue.base_address = base;
+  out_queue->hsa_queue.size = size;
+  out_queue->hsa_queue.doorbell_signal.handle = (uint64_t)doorbell_signal;
+}
+
+// A DOORBELL-kind signal exposes an MMIO register pointer in the union, so
+// initialize caches it for the inline fast path and records all hot pointers.
+TEST(AqlRingTest, InitializeResolvesMmioPointerForDoorbellKind) {
+  volatile int64_t doorbell_mmio = 0;
+  iree_amd_signal_t signal = {};
+  signal.kind = IREE_AMD_SIGNAL_KIND_DOORBELL;
+  signal.hardware_doorbell_ptr = (volatile uint64_t*)&doorbell_mmio;
+
+  iree_hal_amdgpu_aql_packet_t packets[4] = {};
+  iree_amd_queue_t queue = {};
+  ConfigureQueue(packets, IREE_ARRAYSIZE(packets), &signal, &queue);
+
+  iree_hal_amdgpu_libhsa_t libhsa = {};
+  iree_hal_amdgpu_aql_ring_t ring = {};
+  iree_hal_amdgpu_aql_ring_initialize(&libhsa, &queue, &ring);
+
+  // DOORBELL kind resolves to the MMIO pointer.
+  EXPECT_EQ((void*)ring.doorbell.ptr, (void*)&doorbell_mmio);
+  // The signal handle and libhsa are cached regardless of kind.
+  EXPECT_EQ(ring.doorbell.signal.handle, (uint64_t)&signal);
+  EXPECT_EQ(ring.libhsa, &libhsa);
+  // Remaining hot pointers come straight from the queue descriptor.
+  EXPECT_EQ(ring.base, packets);
+  EXPECT_EQ(ring.mask, IREE_ARRAYSIZE(packets) - 1);
+  EXPECT_EQ((void*)ring.write_dispatch_id, (void*)&queue.write_dispatch_id);
+  EXPECT_EQ((void*)ring.read_dispatch_id, (void*)&queue.read_dispatch_id);
+}
+
+// A USER-kind signal stores a value (not a pointer) in the same union slot, so
+// the fast-path pointer must stay NULL even when that value is non-zero.
+TEST(AqlRingTest, InitializeLeavesPointerNullForUserKind) {
+  iree_amd_signal_t signal = {};
+  signal.kind = IREE_AMD_SIGNAL_KIND_USER;
+  signal.value = 0x1234;  // a blind pointer read would yield a non-NULL ptr
+
+  iree_hal_amdgpu_aql_packet_t packets[4] = {};
+  iree_amd_queue_t queue = {};
+  ConfigureQueue(packets, IREE_ARRAYSIZE(packets), &signal, &queue);
+
+  iree_hal_amdgpu_libhsa_t libhsa = {};
+  iree_hal_amdgpu_aql_ring_t ring = {};
+  iree_hal_amdgpu_aql_ring_initialize(&libhsa, &queue, &ring);
+
+  EXPECT_EQ((void*)ring.doorbell.ptr, nullptr);
+  EXPECT_EQ(ring.doorbell.signal.handle, (uint64_t)&signal);
+  EXPECT_EQ(ring.libhsa, &libhsa);
+}
+
+// A null doorbell signal handle must not be dereferenced; the pointer stays
+// NULL and the (null) handle is still cached for the fallback path.
+TEST(AqlRingTest, InitializeLeavesPointerNullForNullSignal) {
+  iree_hal_amdgpu_aql_packet_t packets[4] = {};
+  iree_amd_queue_t queue = {};
+  ConfigureQueue(packets, IREE_ARRAYSIZE(packets), nullptr, &queue);
+
+  iree_hal_amdgpu_libhsa_t libhsa = {};
+  iree_hal_amdgpu_aql_ring_t ring = {};
+  iree_hal_amdgpu_aql_ring_initialize(&libhsa, &queue, &ring);
+
+  EXPECT_EQ((void*)ring.doorbell.ptr, nullptr);
+  EXPECT_EQ(ring.doorbell.signal.handle, 0u);
+}
+
+// The fallback is observed via a recording thunk in the libhsa function-pointer
+// table, which only exists in the default dynamic build; these two tests are
+// therefore dynamic-only.
+#if !IREE_HAL_AMDGPU_LIBHSA_STATIC
+
+// Captures the arguments of the most recent hsa_signal_store_screlease call.
+struct RecordedSignalStore {
+  hsa_signal_t signal;
+  hsa_signal_value_t value;
+  int count;
+};
+RecordedSignalStore g_recorded_signal_store;
+
+static void RecordSignalStore(hsa_signal_t signal, hsa_signal_value_t value) {
+  g_recorded_signal_store.signal = signal;
+  g_recorded_signal_store.value = value;
+  ++g_recorded_signal_store.count;
+}
+
+// A libhsa whose only populated thunk is the signal store used by the doorbell
+// fallback; every other entry stays NULL.
+static iree_hal_amdgpu_libhsa_t MakeRecordingLibhsa() {
+  iree_hal_amdgpu_libhsa_t libhsa = {};
+  libhsa.hsa_signal_store_screlease = RecordSignalStore;
+  return libhsa;
+}
+
+// With a resolved MMIO pointer the doorbell is a direct atomic store and never
+// routes through libhsa.
+TEST(AqlRingTest, DoorbellFastPathWritesMmioRegister) {
+  volatile int64_t doorbell_mmio = 0;
+  iree_hal_amdgpu_libhsa_t libhsa = MakeRecordingLibhsa();
+  g_recorded_signal_store = {};
+
+  iree_hal_amdgpu_aql_ring_t ring = {};
+  ring.libhsa = &libhsa;
+  ring.doorbell.ptr = &doorbell_mmio;
+
+  iree_hal_amdgpu_aql_ring_doorbell(&ring, 0x1234);
+
+  EXPECT_EQ(doorbell_mmio, int64_t{0x1234});
+  EXPECT_EQ(g_recorded_signal_store.count, 0);
+}
+
+// Without an MMIO pointer the doorbell falls back to the HSA signal store,
+// passing the cached signal handle and the packet ID as the value.
+TEST(AqlRingTest, DoorbellFallbackStoresSignalViaLibhsa) {
+  iree_hal_amdgpu_libhsa_t libhsa = MakeRecordingLibhsa();
+  g_recorded_signal_store = {};
+
+  iree_hal_amdgpu_aql_ring_t ring = {};
+  ring.libhsa = &libhsa;
+  ring.doorbell.ptr = nullptr;  // forces the fallback path
+  ring.doorbell.signal.handle = 0xABCD;
+
+  iree_hal_amdgpu_aql_ring_doorbell(&ring, 0x5678);
+
+  EXPECT_EQ(g_recorded_signal_store.count, 1);
+  EXPECT_EQ(g_recorded_signal_store.signal.handle, 0xABCDu);
+  EXPECT_EQ(g_recorded_signal_store.value, int64_t{0x5678});
+}
+
+#endif  // !IREE_HAL_AMDGPU_LIBHSA_STATIC
+
+}  // namespace


### PR DESCRIPTION
Covers iree_hal_amdgpu_aql_ring_initialize (DOORBELL-kind resolves the MMIO doorbell pointer; USER-kind and null doorbell signals leave it NULL and cache the signal handle + libhsa) and iree_hal_amdgpu_aql_ring_doorbell (direct MMIO store on the fast path vs HSA signal-store fallback). The fallback is observed with a recording libhsa thunk and is guarded to the dynamic build.

Wires aql_ring_test into the bazel and cmake builds.
