### PR TITLE
Add `gfx1100` runners to CI

### DIFF
--- a/.github/workflows/ci_core_linux.yml
+++ b/.github/workflows/ci_core_linux.yml
@@ -90,7 +90,7 @@ jobs:
       ctest_exclude_regex: ${{ matrix.ctest_exclude_regex }}
       ctest_label_exclude_regex: "runtime-resource=|manual"
       cmake_options: |
-        -DIREE_HAL_AMDGPU_TARGETS=gfx942;gfx1151;gfx1201
+        -DIREE_HAL_AMDGPU_TARGETS=gfx942;gfx1100;gfx1201
       package: ${{ matrix.package }}
 
   gpu_linux:
@@ -104,6 +104,11 @@ jobs:
           - name: Linux / CMake / GPU gfx942
             chip: gfx942
             runner_label: linux-gfx942-1gpu-core42-ossci-rocm
+            ctest_exclude_regex: ""
+            experimental: false
+          - name: Linux / CMake / GPU gfx1100
+            chip: gfx1100
+            runner_label: linux-gfx110X-gpu-rocm
             ctest_exclude_regex: ""
             experimental: false
           - name: Linux / CMake / GPU gfx1201

--- a/.github/workflows/release_core_linux.yml
+++ b/.github/workflows/release_core_linux.yml
@@ -44,7 +44,7 @@ jobs:
       test_gpu: false
       ctest_label_exclude_regex: "runtime-resource=|manual"
       cmake_options: |
-        -DIREE_HAL_AMDGPU_TARGETS=gfx942;gfx1151;gfx1201
+        -DIREE_HAL_AMDGPU_TARGETS=gfx942;gfx1100;gfx1151;gfx1201
       package: true
       package_suffix: ${{ github.ref_name }}
 

--- a/.github/workflows/test_core_linux_gpu.yml
+++ b/.github/workflows/test_core_linux_gpu.yml
@@ -114,6 +114,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
       - name: Adjust git config
         run: git config --global --add safe.directory "$PWD"
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ python dev.py cmake configure \
   -DCMAKE_MODULE_LINKER_FLAGS="-fuse-ld=lld" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DIREE_HAL_DRIVER_AMDGPU=ON \
-  -DIREE_HAL_AMDGPU_TARGETS='gfx942;gfx1151;gfx1201'
+  -DIREE_HAL_AMDGPU_TARGETS='gfx942;gfx1100;gfx1151;gfx1201'
 
 python dev.py cmake build
 cmake --install build/cmake --prefix build/hrx-install \
@@ -81,7 +81,7 @@ cmake -S . -B build/hrx-system -GNinja \
   -DCMAKE_MODULE_LINKER_FLAGS="-fuse-ld=lld" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DIREE_HAL_DRIVER_AMDGPU=ON \
-  -DIREE_HAL_AMDGPU_TARGETS='gfx942;gfx1151;gfx1201'
+  -DIREE_HAL_AMDGPU_TARGETS='gfx942;gfx1100;gfx1151;gfx1201'
 
 cmake --build build/hrx-system
 cmake --install build/hrx-system --prefix build/hrx-install \


### PR DESCRIPTION
## Motivation

CI currently runs built artifacts on `gfx942` and `gfx1201` runners, this PR updates to additionally fan out to `gfx1100`.

## Technical Details

- Updates `.github/workflows/ci_core_linux.yml` to additionally run on  `gfx1100`.

