### PR TITLE
[Loom] Evaluate launch configs through loomc

### DIFF
--- a/loom/binding/c/BUILD.bazel
+++ b/loom/binding/c/BUILD.bazel
@@ -35,6 +35,7 @@ LOOMC_PUBLIC_HDRS = [
     "include/loomc/diagnostic.h",
     "include/loomc/emit.h",
     "include/loomc/iree.h",
+    "include/loomc/launch_config.h",
     "include/loomc/link.h",
     "include/loomc/link_index.h",
     "include/loomc/loomc.h",
@@ -116,6 +117,7 @@ loom_cc_library(
         "src/context.c",
         "src/diagnostic.c",
         "src/emit.c",
+        "src/launch_config.c",
         "src/link.c",
         "src/link_index.c",
         "src/module.c",
@@ -149,6 +151,7 @@ loom_cc_library(
         "src",
     ],
     deps = [
+        "//loom/src/loom/analysis:kernel_launch_config",
         "//loom/src/loom/codegen/low:target_binding",
         "//loom/src/loom/codegen/low:text_asm",
         "//loom/src/loom/codegen/low/pipeline:pass_environment",

--- a/loom/binding/c/CMakeLists.txt
+++ b/loom/binding/c/CMakeLists.txt
@@ -26,6 +26,7 @@ loom_cc_library(
     "include/loomc/diagnostic.h"
     "include/loomc/emit.h"
     "include/loomc/iree.h"
+    "include/loomc/launch_config.h"
     "include/loomc/link.h"
     "include/loomc/link_index.h"
     "include/loomc/loomc.h"
@@ -60,6 +61,7 @@ loom_cc_library(
     "src/context.c"
     "src/diagnostic.c"
     "src/emit.c"
+    "src/launch_config.c"
     "src/link.c"
     "src/link_index.c"
     "src/module.c"
@@ -78,6 +80,7 @@ loom_cc_library(
     iree::base::internal::arena
     iree::io::file_handle
     iree::io::stream
+    loom::analysis::kernel_launch_config
     loom::codegen::low::pipeline::pass_environment
     loom::codegen::low::target_binding
     loom::codegen::low::text_asm
@@ -143,6 +146,7 @@ loom_cc_library(
     "include/loomc/diagnostic.h"
     "include/loomc/emit.h"
     "include/loomc/iree.h"
+    "include/loomc/launch_config.h"
     "include/loomc/link.h"
     "include/loomc/link_index.h"
     "include/loomc/loomc.h"

--- a/loom/binding/c/include/loomc/base.h
+++ b/loom/binding/c/include/loomc/base.h
@@ -265,6 +265,12 @@ typedef enum loomc_structure_type_e {
 
   /// `loomc_sanitizer_options_t`.
   LOOMC_STRUCTURE_TYPE_SANITIZER_OPTIONS = 32,
+
+  /// `loomc_launch_config_eval_options_t`.
+  LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG_EVAL_OPTIONS = 33,
+
+  /// `loomc_launch_config_t`.
+  LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG = 34,
 } loomc_structure_type_t;
 
 /// One loose string option entry.

--- a/loom/binding/c/include/loomc/launch_config.h
+++ b/loom/binding/c/include/loomc/launch_config.h
@@ -1,0 +1,147 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef LOOMC_LAUNCH_CONFIG_H_
+#define LOOMC_LAUNCH_CONFIG_H_
+
+#include <stdint.h>
+
+#include "loomc/config.h"
+#include "loomc/module.h"
+
+/// @file
+/// Kernel launch configuration evaluation.
+///
+/// Launch configuration evaluation answers the host-side question "which launch
+/// parameters resolve to concrete values under this invocation config?" It is a
+/// cold-path convenience API for embedders that compile kernel shape sets and
+/// launch the resulting executable themselves. The result uses ordinary Loom C
+/// API versioned structs and presence flags; serialized launch config artifacts
+/// use a separate compact binary format.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Launch configuration fields that may be present after evaluation.
+typedef enum loomc_launch_config_field_flag_bits_e {
+  /// `loomc_launch_config_t::workgroup_count` is present.
+  LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT = 1u << 0,
+
+  /// `loomc_launch_config_t::workgroup_size` is present.
+  LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE = 1u << 1,
+
+  /// `loomc_launch_config_t::subgroup_size` is present.
+  LOOMC_LAUNCH_CONFIG_FIELD_FLAG_SUBGROUP_SIZE = 1u << 2,
+
+  /// `loomc_launch_config_t::workgroup_storage_bytes` is present.
+  LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_STORAGE_BYTES = 1u << 3,
+} loomc_launch_config_field_flag_bits_t;
+
+/// Bitmask of `loomc_launch_config_field_flag_bits_t` values.
+typedef uint32_t loomc_launch_config_field_flags_t;
+
+/// Evaluated launch configuration.
+///
+/// Callers zero-initialize this structure, set `type` to
+/// `LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG`, set `structure_size` to
+/// `sizeof(loomc_launch_config_t)`, and pass it to
+/// `loomc_module_evaluate_launch_config`. Fields are meaningful only
+/// when the corresponding `fields` bit is present.
+typedef struct loomc_launch_config_t {
+  /// Structure type. Must be `LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG` when
+  /// nonzero.
+  loomc_structure_type_t type;
+
+  /// Size of this structure in bytes.
+  loomc_host_size_t structure_size;
+
+  /// Extension chain for future launch configuration result payloads.
+  void* next;
+
+  /// Present evaluated fields.
+  loomc_launch_config_field_flags_t fields;
+
+  /// Optional concrete workgroup count.
+  loomc_dimension3_t workgroup_count;
+
+  /// Optional concrete local workgroup size.
+  loomc_dimension3_t workgroup_size;
+
+  /// Optional concrete subgroup size.
+  uint32_t subgroup_size;
+
+  /// Optional concrete workgroup-local storage byte count.
+  uint64_t workgroup_storage_bytes;
+} loomc_launch_config_t;
+
+/// Launch configuration evaluation options.
+///
+/// Callers zero-initialize this descriptor, set `type` to
+/// `LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG_EVAL_OPTIONS`, set
+/// `structure_size` to `sizeof(loomc_launch_config_eval_options_t)`,
+/// and fill the requested fields.
+typedef struct loomc_launch_config_eval_options_t {
+  /// Structure type. Must be
+  /// `LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG_EVAL_OPTIONS` when nonzero.
+  loomc_structure_type_t type;
+
+  /// Size of this structure in bytes.
+  loomc_host_size_t structure_size;
+
+  /// Extension chain for future launch configuration evaluation options.
+  const void* next;
+
+  /// Kernel function symbol to evaluate, with or without a leading `@`.
+  loomc_string_view_t function_symbol;
+
+  /// Per-invocation config dialect bindings and optional JSON object.
+  loomc_config_options_t config;
+
+  /// Workload argument values supplied as signed 64-bit integers.
+  ///
+  /// Values map positionally to the kernel launch-config region arguments.
+  /// Scalar index, offset, and integer arguments are seeded as exact value
+  /// facts. Unsupported argument types produce a failed result diagnostic.
+  const int64_t* workload_arguments;
+
+  /// Number of entries in `workload_arguments`.
+  loomc_host_size_t workload_argument_count;
+
+  /// Fields that must be present for the result to succeed.
+  ///
+  /// Missing required fields are reported as result diagnostics. Missing fields
+  /// that are not required are simply absent from
+  /// `loomc_launch_config_t::fields`.
+  loomc_launch_config_field_flags_t required_fields;
+} loomc_launch_config_eval_options_t;
+
+/// Evaluates a kernel's launch configuration under config bindings.
+///
+/// @param module Module containing the kernel. It is not mutated.
+/// @param workspace Scratch workspace used for the internal cloned module,
+/// config materialization, target fact storage, and value-fact analysis.
+/// @param options Evaluation options. `function_symbol` is required.
+/// @param allocator Host allocator used for returned result storage.
+/// @param out_config Receives evaluated launch config fields.
+/// @param out_result Receives a retained result for diagnostics.
+/// @return OK when evaluation ran to a result. Non-OK statuses represent API
+/// misuse or infrastructure failures before a result could be produced.
+///
+/// @ownership
+/// The caller owns `out_result` on an OK return and releases it with
+/// `loomc_result_release`.
+LOOMC_API_EXPORT loomc_status_t loomc_module_evaluate_launch_config(
+    const loomc_module_t* module, loomc_workspace_t* workspace,
+    const loomc_launch_config_eval_options_t* options,
+    loomc_allocator_t allocator, loomc_launch_config_t* out_config,
+    loomc_result_t** out_result);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOMC_LAUNCH_CONFIG_H_

--- a/loom/binding/c/include/loomc/loomc.h
+++ b/loom/binding/c/include/loomc/loomc.h
@@ -23,6 +23,7 @@
 #include "loomc/context.h"
 #include "loomc/diagnostic.h"
 #include "loomc/emit.h"
+#include "loomc/launch_config.h"
 #include "loomc/link.h"
 #include "loomc/link_index.h"
 #include "loomc/module.h"

--- a/loom/binding/c/include/loomc/module.h
+++ b/loom/binding/c/include/loomc/module.h
@@ -88,7 +88,7 @@ extern "C" {
 /// such as compiling a module require exclusive access to that module handle.
 typedef struct loomc_module_t loomc_module_t;
 
-/// Three-dimensional unsigned extent used by function metadata.
+/// Three-dimensional unsigned extent used by Loom C API structs.
 typedef struct loomc_dimension3_t {
   /// Extent along the x dimension.
   uint32_t x;
@@ -143,8 +143,8 @@ typedef uint32_t loomc_module_function_flags_t;
 /// Function metadata view written into caller-provided storage.
 ///
 /// This is the common identity record for every function kind. Function-kind
-/// specific payloads, such as kernel launch metadata, are queried with typed
-/// accessors instead of being mixed into this structure.
+/// specific payloads remain on the owning APIs instead of being mixed into this
+/// structure.
 ///
 /// @lifetime
 /// `symbol_name` borrows from the module that produced this view. The view and
@@ -188,39 +188,6 @@ typedef struct loomc_module_function_export_info_t {
   /// Optional artifact export symbol without a leading `@`.
   loomc_string_view_t export_symbol;
 } loomc_module_function_export_info_t;
-
-/// Kernel function metadata flag bits.
-typedef enum loomc_module_kernel_function_flag_bits_e {
-  /// `loomc_module_kernel_function_info_t::static_dispatch_workgroup_count` is
-  /// present.
-  LOOMC_MODULE_KERNEL_FUNCTION_FLAG_HAS_STATIC_DISPATCH_WORKGROUP_COUNT = 1u
-                                                                          << 0,
-
-  /// `loomc_module_kernel_function_info_t::static_workgroup_size` is present.
-  LOOMC_MODULE_KERNEL_FUNCTION_FLAG_HAS_STATIC_WORKGROUP_SIZE = 1u << 1,
-} loomc_module_kernel_function_flag_bits_t;
-
-/// Bitmask of `loomc_module_kernel_function_flag_bits_t` values.
-typedef uint32_t loomc_module_kernel_function_flags_t;
-
-/// Kernel-specific metadata view written into caller-provided storage.
-///
-/// Probe this view only for functions whose kind is
-/// `LOOMC_MODULE_FUNCTION_KIND_KERNEL` or
-/// `LOOMC_MODULE_FUNCTION_KIND_TARGET_KERNEL`. Fields whose presence depends
-/// on source metadata, lowering state, or analysis have corresponding `flags`
-/// bits. When a flag is absent, the related field is a zero value and should
-/// not be interpreted as a default chosen by Loom.
-typedef struct loomc_module_kernel_function_info_t {
-  /// Present kernel metadata flags.
-  loomc_module_kernel_function_flags_t flags;
-
-  /// Optional statically known dispatch workgroup count.
-  loomc_dimension3_t static_dispatch_workgroup_count;
-
-  /// Optional statically known workgroup size.
-  loomc_dimension3_t static_workgroup_size;
-} loomc_module_kernel_function_info_t;
 
 /// Module function query options.
 ///
@@ -467,10 +434,10 @@ LOOMC_API_EXPORT loomc_status_t loomc_module_clone(
 /// module operation is active.
 ///
 /// @par Example
-/// Find source kernels with a fully static launch grid:
+/// Enumerate exported source kernels:
 ///
 /// @code{.c}
-/// static loomc_status_t dispatch_static_kernels(loomc_module_t* module) {
+/// static loomc_status_t list_exported_kernels(loomc_module_t* module) {
 ///   loomc_allocator_t allocator = loomc_allocator_system();
 ///   loomc_module_function_query_options_t options = {
 ///       .type = LOOMC_STRUCTURE_TYPE_MODULE_FUNCTION_QUERY_OPTIONS,
@@ -499,15 +466,11 @@ LOOMC_API_EXPORT loomc_status_t loomc_module_clone(
 ///   if (loomc_status_is_ok(status) && result != NULL &&
 ///       loomc_result_succeeded(result)) {
 ///     for (loomc_host_size_t i = 0; i < function_count; ++i) {
-///       loomc_module_kernel_function_info_t kernel_info;
-///       bool has_static_grid =
-///           loomc_module_function_try_get_kernel_info_at(
-///               module, functions[i].function_ordinal, &kernel_info) &&
-///           (kernel_info.flags &
-///            LOOMC_MODULE_KERNEL_FUNCTION_FLAG_HAS_STATIC_DISPATCH_WORKGROUP_COUNT);
-///       if (has_static_grid) {
-///         dispatch(functions[i].symbol_name,
-///                  kernel_info.static_dispatch_workgroup_count);
+///       loomc_module_function_export_info_t export_info;
+///       if (loomc_module_function_try_get_export_info_at(
+///               module, functions[i].function_ordinal, &export_info)) {
+///         register_export(functions[i].symbol_name,
+///                         export_info.export_symbol);
 ///       }
 ///     }
 ///   }
@@ -737,52 +700,6 @@ LOOMC_API_EXPORT bool loomc_module_function_try_get_export_info(
 LOOMC_API_EXPORT loomc_status_t loomc_module_function_get_export_info(
     const loomc_module_t* module, const loomc_module_function_t* function,
     loomc_module_function_export_info_t* out_info);
-
-/// Tries to get kernel metadata by public function ordinal without allocating a
-/// status.
-///
-/// @param module Module to inspect.
-/// @param function_ordinal Ordinal in the module's unfiltered function metadata
-/// sequence.
-/// @param out_info Receives kernel metadata when the ordinal names a
-/// kernel-shaped function.
-/// @return True when `function_ordinal` names a kernel function.
-LOOMC_API_EXPORT bool loomc_module_function_try_get_kernel_info_at(
-    const loomc_module_t* module, loomc_host_size_t function_ordinal,
-    loomc_module_kernel_function_info_t* out_info);
-
-/// Gets kernel metadata by public function ordinal.
-///
-/// @param module Module to inspect.
-/// @param function_ordinal Ordinal in the module's unfiltered function metadata
-/// sequence.
-/// @param out_info Receives kernel metadata.
-/// @return OK when the ordinal names a kernel function, NOT_FOUND when it does
-/// not, or another non-OK status for API misuse.
-LOOMC_API_EXPORT loomc_status_t loomc_module_function_get_kernel_info_at(
-    const loomc_module_t* module, loomc_host_size_t function_ordinal,
-    loomc_module_kernel_function_info_t* out_info);
-
-/// Tries to get kernel metadata for a function without allocating a status.
-///
-/// @param module Module that produced `function`.
-/// @param function Function metadata from `module`.
-/// @param out_info Receives kernel metadata when `function` is kernel-shaped.
-/// @return True when `function` is a kernel function.
-LOOMC_API_EXPORT bool loomc_module_function_try_get_kernel_info(
-    const loomc_module_t* module, const loomc_module_function_t* function,
-    loomc_module_kernel_function_info_t* out_info);
-
-/// Gets kernel metadata for a function.
-///
-/// @param module Module that produced `function`.
-/// @param function Function metadata from `module`.
-/// @param out_info Receives kernel metadata.
-/// @return OK when `function` is kernel-shaped, NOT_FOUND when it is not, or
-/// another non-OK status for API misuse.
-LOOMC_API_EXPORT loomc_status_t loomc_module_function_get_kernel_info(
-    const loomc_module_t* module, const loomc_module_function_t* function,
-    loomc_module_kernel_function_info_t* out_info);
 
 /// Serializes a module into an immutable source handle.
 ///

--- a/loom/binding/c/src/launch_config.c
+++ b/loom/binding/c/src/launch_config.c
@@ -1,0 +1,405 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loomc/launch_config.h"
+
+#include <stdint.h>
+
+#include "config.h"
+#include "diagnostic.h"
+#include "iree/base/api.h"
+#include "loom/analysis/kernel_launch_config.h"
+#include "loomc/iree.h"
+#include "module.h"
+#include "result.h"
+#include "workspace.h"
+
+typedef struct loomc_launch_config_target_capture_t {
+  // Result receiving target contract diagnostics.
+  loomc_result_t* result;
+} loomc_launch_config_target_capture_t;
+
+typedef struct loomc_launch_config_resolved_options_t {
+  // Kernel function symbol to evaluate.
+  iree_string_view_t function_symbol;
+
+  // Requested config bindings.
+  const loomc_config_options_t* config;
+
+  // Workload argument values.
+  const int64_t* workload_arguments;
+
+  // Number of workload argument values.
+  loomc_host_size_t workload_argument_count;
+
+  // Fields that must be proven.
+  loomc_launch_config_field_flags_t required_fields;
+} loomc_launch_config_resolved_options_t;
+
+static iree_status_t loomc_launch_config_capture_diagnostic(
+    void* user_data, const loom_diagnostic_emission_t* emission) {
+  loomc_launch_config_target_capture_t* capture =
+      (loomc_launch_config_target_capture_t*)user_data;
+  return iree_status_from_loomc(loomc_result_add_loom_diagnostic_emission(
+      capture->result, /*source=*/NULL, LOOM_EMITTER_PASS, emission));
+}
+
+static bool loomc_launch_config_string_view_is_valid(
+    loomc_string_view_t value) {
+  return value.data != NULL || value.size == 0;
+}
+
+static bool loomc_launch_config_fields_are_valid(
+    loomc_launch_config_field_flags_t fields) {
+  const loomc_launch_config_field_flags_t known_fields =
+      LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
+      LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE |
+      LOOMC_LAUNCH_CONFIG_FIELD_FLAG_SUBGROUP_SIZE |
+      LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_STORAGE_BYTES;
+  return (fields & ~known_fields) == 0;
+}
+
+static loom_kernel_launch_config_field_flags_t
+loomc_launch_config_field_flags_to_kernel(
+    loomc_launch_config_field_flags_t fields) {
+  loom_kernel_launch_config_field_flags_t kernel_fields = 0;
+  if (iree_any_bit_set(fields,
+                       LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT)) {
+    kernel_fields |= LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT;
+  }
+  if (iree_any_bit_set(fields, LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE)) {
+    kernel_fields |= LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE;
+  }
+  if (iree_any_bit_set(fields, LOOMC_LAUNCH_CONFIG_FIELD_FLAG_SUBGROUP_SIZE)) {
+    kernel_fields |= LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_SUBGROUP_SIZE;
+  }
+  if (iree_any_bit_set(
+          fields, LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_STORAGE_BYTES)) {
+    kernel_fields |=
+        LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_STORAGE_BYTES;
+  }
+  return kernel_fields;
+}
+
+static loomc_launch_config_field_flags_t
+loomc_launch_config_field_flags_from_kernel(
+    loom_kernel_launch_config_field_flags_t fields) {
+  loomc_launch_config_field_flags_t public_fields = 0;
+  if (iree_any_bit_set(fields,
+                       LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT)) {
+    public_fields |= LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT;
+  }
+  if (iree_any_bit_set(fields,
+                       LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE)) {
+    public_fields |= LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE;
+  }
+  if (iree_any_bit_set(fields,
+                       LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_SUBGROUP_SIZE)) {
+    public_fields |= LOOMC_LAUNCH_CONFIG_FIELD_FLAG_SUBGROUP_SIZE;
+  }
+  if (iree_any_bit_set(
+          fields,
+          LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_STORAGE_BYTES)) {
+    public_fields |= LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_STORAGE_BYTES;
+  }
+  return public_fields;
+}
+
+static bool loomc_launch_config_options_have_specialization(
+    const loomc_launch_config_resolved_options_t* options) {
+  const loomc_config_options_t* config = options->config;
+  return options->workload_argument_count != 0 ||
+         (config != NULL && (config->binding_count != 0 ||
+                             !loomc_string_view_is_empty(config->json_object) ||
+                             config->flags != 0));
+}
+
+static loomc_status_t loomc_launch_config_validate_result(
+    const loomc_launch_config_t* config) {
+  if (config == NULL) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "out_config must not be NULL");
+  }
+  if (config->type != LOOMC_STRUCTURE_TYPE_NONE &&
+      config->type != LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "launch config has an unknown structure type");
+  }
+  if (config->structure_size != 0 && config->structure_size < sizeof(*config)) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "launch config structure_size is too small");
+  }
+  if (config->next != NULL) {
+    return loomc_make_status(
+        LOOMC_STATUS_UNIMPLEMENTED,
+        "launch config result extensions are not supported");
+  }
+  return loomc_ok_status();
+}
+
+static loomc_status_t loomc_launch_config_resolve_options(
+    const loomc_launch_config_eval_options_t* options,
+    loomc_launch_config_resolved_options_t* out_options) {
+  if (options == NULL) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "launch config eval options must not be NULL");
+  }
+  if (options->type != LOOMC_STRUCTURE_TYPE_NONE &&
+      options->type != LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG_EVAL_OPTIONS) {
+    return loomc_make_status(
+        LOOMC_STATUS_INVALID_ARGUMENT,
+        "launch config eval options have an unknown structure type");
+  }
+  if (options->structure_size != 0 &&
+      options->structure_size < sizeof(*options)) {
+    return loomc_make_status(
+        LOOMC_STATUS_INVALID_ARGUMENT,
+        "launch config eval options structure_size is too small");
+  }
+  if (options->next != NULL) {
+    return loomc_make_status(
+        LOOMC_STATUS_UNIMPLEMENTED,
+        "launch config eval option extensions are not supported");
+  }
+  if (!loomc_launch_config_string_view_is_valid(options->function_symbol)) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "function symbol has length but no data");
+  }
+  if (loomc_string_view_is_empty(options->function_symbol)) {
+    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                             "function symbol must not be empty");
+  }
+  if (options->workload_argument_count != 0 &&
+      options->workload_arguments == NULL) {
+    return loomc_make_status(
+        LOOMC_STATUS_INVALID_ARGUMENT,
+        "workload_argument_count is non-zero but workload_arguments is NULL");
+  }
+  if (!loomc_launch_config_fields_are_valid(options->required_fields)) {
+    return loomc_make_status(
+        LOOMC_STATUS_INVALID_ARGUMENT,
+        "launch config required_fields contains unknown bits");
+  }
+  LOOMC_RETURN_IF_ERROR(loomc_config_validate_options(&options->config));
+
+  *out_options = (loomc_launch_config_resolved_options_t){
+      .function_symbol = iree_string_view_from_loomc(options->function_symbol),
+      .config = &options->config,
+      .workload_arguments = options->workload_arguments,
+      .workload_argument_count = options->workload_argument_count,
+      .required_fields = options->required_fields,
+  };
+  return loomc_ok_status();
+}
+
+static loomc_status_t loomc_launch_config_fail_status(loomc_result_t* result,
+                                                      loomc_string_view_t code,
+                                                      loomc_status_t status) {
+  return loomc_result_fail_status_diagnostic_consume(
+      result, NULL, LOOMC_DIAGNOSTIC_SEVERITY_ERROR, code, status);
+}
+
+static loomc_status_t loomc_launch_config_fail_missing_required_field(
+    loomc_result_t* result, loomc_string_view_t code) {
+  return loomc_launch_config_fail_status(
+      result, code,
+      loomc_make_status(
+          LOOMC_STATUS_FAILED_PRECONDITION,
+          "required launch config field could not be resolved to a concrete "
+          "value"));
+}
+
+static loomc_status_t loomc_launch_config_report_failure(
+    loomc_result_t* result, loom_kernel_launch_config_failure_t failure) {
+  switch (failure) {
+    case LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_NONE:
+      return loomc_ok_status();
+    case LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_FUNCTION_NOT_FOUND:
+      return loomc_launch_config_fail_status(
+          result, loomc_make_cstring_view("LAUNCH_CONFIG/NOT_FOUND"),
+          loomc_make_status(LOOMC_STATUS_NOT_FOUND,
+                            "kernel function symbol was not found"));
+    case LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_NOT_KERNEL:
+      return loomc_launch_config_fail_status(
+          result, loomc_make_cstring_view("LAUNCH_CONFIG/NOT_KERNEL"),
+          loomc_make_status(
+              LOOMC_STATUS_INVALID_ARGUMENT,
+              "function is not a source kernel with launch config"));
+    case LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_WORKLOAD_ARGUMENT_COUNT:
+      return loomc_launch_config_fail_status(
+          result,
+          loomc_make_cstring_view("LAUNCH_CONFIG/WORKLOAD_ARGUMENT_COUNT"),
+          loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                            "workload argument count does not match launch "
+                            "config signature"));
+    case LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_WORKLOAD_ARGUMENT_TYPE:
+      return loomc_launch_config_fail_status(
+          result,
+          loomc_make_cstring_view("LAUNCH_CONFIG/WORKLOAD_ARGUMENT_TYPE"),
+          loomc_make_status(
+              LOOMC_STATUS_INVALID_ARGUMENT,
+              "workload argument type cannot be seeded from i64"));
+    case LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_TARGET_CONTRACT:
+      if (loomc_result_diagnostic_count(result) != 0) {
+        return loomc_result_set_state(result, LOOMC_RESULT_STATE_FAILED);
+      }
+      return loomc_launch_config_fail_status(
+          result, loomc_make_cstring_view("LAUNCH_CONFIG/TARGET_CONTRACT"),
+          loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
+                            "target contract could not be resolved"));
+    case LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_MISSING_WORKGROUP_COUNT:
+      return loomc_launch_config_fail_missing_required_field(
+          result,
+          loomc_make_cstring_view("LAUNCH_CONFIG/MISSING_WORKGROUP_COUNT"));
+    case LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_MISSING_WORKGROUP_SIZE:
+      return loomc_launch_config_fail_missing_required_field(
+          result,
+          loomc_make_cstring_view("LAUNCH_CONFIG/MISSING_WORKGROUP_SIZE"));
+    case LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_MISSING_SUBGROUP_SIZE:
+      return loomc_launch_config_fail_missing_required_field(
+          result,
+          loomc_make_cstring_view("LAUNCH_CONFIG/MISSING_SUBGROUP_SIZE"));
+    case LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_MISSING_WORKGROUP_STORAGE_BYTES:
+      return loomc_launch_config_fail_missing_required_field(
+          result, loomc_make_cstring_view(
+                      "LAUNCH_CONFIG/MISSING_WORKGROUP_STORAGE_BYTES"));
+  }
+  return loomc_launch_config_fail_status(
+      result, loomc_make_cstring_view("LAUNCH_CONFIG/UNKNOWN_FAILURE"),
+      loomc_make_status(
+          LOOMC_STATUS_INTERNAL,
+          "launch config evaluation returned an unknown failure"));
+}
+
+static void loomc_launch_config_copy_from_kernel(
+    const loom_kernel_launch_config_t* source, loomc_launch_config_t* target) {
+  target->fields = loomc_launch_config_field_flags_from_kernel(source->fields);
+  target->workgroup_count = (loomc_dimension3_t){
+      .x = source->workgroup_count.x,
+      .y = source->workgroup_count.y,
+      .z = source->workgroup_count.z,
+  };
+  target->workgroup_size = (loomc_dimension3_t){
+      .x = source->workgroup_size.x,
+      .y = source->workgroup_size.y,
+      .z = source->workgroup_size.z,
+  };
+  target->subgroup_size = source->subgroup_size;
+  target->workgroup_storage_bytes = source->workgroup_storage_bytes;
+}
+
+static loom_kernel_launch_config_options_t
+loomc_launch_config_make_kernel_options(
+    const loomc_launch_config_resolved_options_t* options,
+    iree_diagnostic_emitter_t emitter) {
+  return (loom_kernel_launch_config_options_t){
+      .function_symbol = options->function_symbol,
+      .workload_arguments = options->workload_arguments,
+      .workload_argument_count = options->workload_argument_count,
+      .required_fields =
+          loomc_launch_config_field_flags_to_kernel(options->required_fields),
+      .diagnostic_emitter = emitter,
+  };
+}
+
+loomc_status_t loomc_module_evaluate_launch_config(
+    const loomc_module_t* module, loomc_workspace_t* workspace,
+    const loomc_launch_config_eval_options_t* options,
+    loomc_allocator_t allocator, loomc_launch_config_t* out_config,
+    loomc_result_t** out_result) {
+  if (module == NULL || workspace == NULL || out_result == NULL) {
+    return loomc_make_status(
+        LOOMC_STATUS_INVALID_ARGUMENT,
+        "module, workspace, and out_result must not be NULL");
+  }
+  LOOMC_RETURN_IF_ERROR(loomc_launch_config_validate_result(out_config));
+  *out_config = (loomc_launch_config_t){
+      .type = LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG,
+      .structure_size = sizeof(*out_config),
+  };
+  *out_result = NULL;
+
+  loomc_launch_config_resolved_options_t resolved_options = {0};
+  LOOMC_RETURN_IF_ERROR(
+      loomc_launch_config_resolve_options(options, &resolved_options));
+
+  loomc_result_t* result = NULL;
+  LOOMC_RETURN_IF_ERROR(
+      loomc_result_create(LOOMC_RESULT_STATE_SUCCEEDED, allocator, &result));
+
+  const loom_module_t* source_internal_module =
+      loomc_module_const_loom_module(module);
+  if (source_internal_module != NULL &&
+      !loomc_launch_config_options_have_specialization(&resolved_options)) {
+    bool direct_evaluated = false;
+    loom_kernel_launch_config_t kernel_config = {0};
+    const loom_kernel_launch_config_options_t kernel_options =
+        loomc_launch_config_make_kernel_options(&resolved_options,
+                                                (iree_diagnostic_emitter_t){0});
+    loomc_status_t direct_status =
+        loomc_status_from_iree(loom_kernel_launch_config_try_evaluate_direct(
+            source_internal_module, loomc_workspace_block_pool(workspace),
+            &kernel_options, &kernel_config, &direct_evaluated));
+    if (!loomc_status_is_ok(direct_status)) {
+      loomc_result_release(result);
+      return direct_status;
+    }
+    if (direct_evaluated) {
+      loomc_launch_config_copy_from_kernel(&kernel_config, out_config);
+      *out_result = result;
+      return loomc_ok_status();
+    }
+  }
+
+  loomc_module_t* scratch_module = NULL;
+  loomc_status_t status =
+      loomc_module_clone(module, workspace, allocator, &scratch_module);
+  loom_module_t* internal_module =
+      loomc_status_is_ok(status) ? loomc_module_loom_module(scratch_module)
+                                 : NULL;
+  if (loomc_status_is_ok(status)) {
+    const loomc_config_apply_to_module_options_t config_options = {
+        .config = resolved_options.config,
+        .module = internal_module,
+        .result = result,
+        .diagnostic_code = loomc_make_cstring_view("CONFIG/INVALID"),
+        .block_pool = loomc_workspace_block_pool(workspace),
+        .allocator = allocator,
+    };
+    status = loomc_config_apply_to_module(&config_options);
+  }
+
+  loom_kernel_launch_config_t kernel_config = {0};
+  if (loomc_status_is_ok(status) && loomc_result_succeeded(result)) {
+    loomc_launch_config_target_capture_t capture = {
+        .result = result,
+    };
+    const iree_diagnostic_emitter_t emitter = {
+        .fn = loomc_launch_config_capture_diagnostic,
+        .user_data = &capture,
+    };
+    const loom_kernel_launch_config_options_t kernel_options =
+        loomc_launch_config_make_kernel_options(&resolved_options, emitter);
+    status = loomc_status_from_iree(loom_kernel_launch_config_evaluate(
+        internal_module, loomc_workspace_block_pool(workspace), &kernel_options,
+        &kernel_config));
+    if (loomc_status_is_ok(status)) {
+      loomc_launch_config_copy_from_kernel(&kernel_config, out_config);
+    }
+  }
+
+  if (loomc_status_is_ok(status) && loomc_result_succeeded(result)) {
+    status = loomc_launch_config_report_failure(result, kernel_config.failure);
+  }
+  if (loomc_status_is_ok(status)) {
+    *out_result = result;
+    result = NULL;
+  }
+
+  loomc_result_release(result);
+  loomc_module_release(scratch_module);
+  return status;
+}

--- a/loom/binding/c/src/module_function.c
+++ b/loom/binding/c/src/module_function.c
@@ -12,9 +12,7 @@
 #include "loom/ir/attribute.h"
 #include "loom/ir/module.h"
 #include "loom/ops/func/ops.h"
-#include "loom/ops/kernel/launch_config.h"
 #include "loom/ops/kernel/ops.h"
-#include "loom/ops/low/kernel.h"
 #include "loom/ops/low/ops.h"
 #include "loom/ops/op_defs.h"
 #include "loomc/iree.h"
@@ -129,24 +127,6 @@ static bool loomc_module_function_symbol_kind(
     return true;
   }
   return false;
-}
-
-static loomc_dimension3_t loomc_dimension3_from_workgroup_size(
-    loom_target_workgroup_size_t value) {
-  return (loomc_dimension3_t){
-      .x = value.x,
-      .y = value.y,
-      .z = value.z,
-  };
-}
-
-static loomc_dimension3_t loomc_dimension3_from_workgroup_count(
-    loom_target_dispatch_workgroup_count_t value) {
-  return (loomc_dimension3_t){
-      .x = value.x,
-      .y = value.y,
-      .z = value.z,
-  };
 }
 
 static iree_string_view_t loomc_module_function_symbol_name(
@@ -445,37 +425,6 @@ static bool loomc_module_function_populate_export_info(
   return out_info->flags != 0;
 }
 
-static void loomc_module_function_populate_source_kernel_info(
-    const loom_module_t* module, const loom_op_t* op,
-    loomc_module_kernel_function_info_t* out_info) {
-  loom_target_dispatch_workgroup_count_t workgroup_count = {0};
-  if (loom_kernel_def_static_workgroup_count(module, op, &workgroup_count)) {
-    out_info->static_dispatch_workgroup_count =
-        loomc_dimension3_from_workgroup_count(workgroup_count);
-    out_info->flags |=
-        LOOMC_MODULE_KERNEL_FUNCTION_FLAG_HAS_STATIC_DISPATCH_WORKGROUP_COUNT;
-  }
-
-  loom_target_workgroup_size_t workgroup_size = {0};
-  if (loom_kernel_def_static_workgroup_size(module, op, &workgroup_size)) {
-    out_info->static_workgroup_size =
-        loomc_dimension3_from_workgroup_size(workgroup_size);
-    out_info->flags |=
-        LOOMC_MODULE_KERNEL_FUNCTION_FLAG_HAS_STATIC_WORKGROUP_SIZE;
-  }
-}
-
-static void loomc_module_function_populate_target_kernel_info(
-    const loom_op_t* op, loomc_module_kernel_function_info_t* out_info) {
-  loom_target_workgroup_size_t workgroup_size = {0};
-  if (loom_low_kernel_def_static_workgroup_size(op, &workgroup_size)) {
-    out_info->static_workgroup_size =
-        loomc_dimension3_from_workgroup_size(workgroup_size);
-    out_info->flags |=
-        LOOMC_MODULE_KERNEL_FUNCTION_FLAG_HAS_STATIC_WORKGROUP_SIZE;
-  }
-}
-
 loomc_status_t loomc_module_query_functions(
     const loomc_module_t* module,
     const loomc_module_function_query_options_t* options,
@@ -702,117 +651,6 @@ loomc_status_t loomc_module_function_get_export_info(
                                                   out_info)) {
     return loomc_make_status(LOOMC_STATUS_NOT_FOUND,
                              "module function has no export metadata");
-  }
-  return loomc_ok_status();
-}
-
-bool loomc_module_function_try_get_kernel_info_at(
-    const loomc_module_t* module, loomc_host_size_t function_ordinal,
-    loomc_module_kernel_function_info_t* out_info) {
-  if (out_info == NULL) {
-    return false;
-  }
-  *out_info = (loomc_module_kernel_function_info_t){0};
-  const loom_module_t* internal_module = loomc_module_const_loom_module(module);
-  const loom_symbol_t* symbol = NULL;
-  loomc_module_function_kind_t kind = LOOMC_MODULE_FUNCTION_KIND_UNKNOWN;
-  if (!loomc_module_function_try_resolve_at(internal_module, function_ordinal,
-                                            &symbol, &kind) ||
-      !loomc_module_function_kind_is_kernel(kind)) {
-    return false;
-  }
-  if (kind == LOOMC_MODULE_FUNCTION_KIND_KERNEL) {
-    loomc_module_function_populate_source_kernel_info(
-        internal_module, symbol->defining_op, out_info);
-  } else {
-    loomc_module_function_populate_target_kernel_info(symbol->defining_op,
-                                                      out_info);
-  }
-  return true;
-}
-
-loomc_status_t loomc_module_function_get_kernel_info_at(
-    const loomc_module_t* module, loomc_host_size_t function_ordinal,
-    loomc_module_kernel_function_info_t* out_info) {
-  if (module == NULL || out_info == NULL) {
-    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
-                             "module and out_info must not be NULL");
-  }
-  *out_info = (loomc_module_kernel_function_info_t){0};
-  const loom_module_t* internal_module = loomc_module_const_loom_module(module);
-  if (internal_module == NULL) {
-    return loomc_make_status(LOOMC_STATUS_FAILED_PRECONDITION,
-                             "module does not contain internal IR");
-  }
-  const loom_symbol_t* symbol = NULL;
-  loomc_module_function_kind_t kind = LOOMC_MODULE_FUNCTION_KIND_UNKNOWN;
-  if (!loomc_module_function_try_resolve_at(internal_module, function_ordinal,
-                                            &symbol, &kind)) {
-    return loomc_make_status(LOOMC_STATUS_NOT_FOUND,
-                             "module function ordinal was not found");
-  }
-  if (!loomc_module_function_kind_is_kernel(kind)) {
-    return loomc_make_status(LOOMC_STATUS_NOT_FOUND,
-                             "module function is not a kernel");
-  }
-  if (kind == LOOMC_MODULE_FUNCTION_KIND_KERNEL) {
-    loomc_module_function_populate_source_kernel_info(
-        internal_module, symbol->defining_op, out_info);
-  } else {
-    loomc_module_function_populate_target_kernel_info(symbol->defining_op,
-                                                      out_info);
-  }
-  return loomc_ok_status();
-}
-
-bool loomc_module_function_try_get_kernel_info(
-    const loomc_module_t* module, const loomc_module_function_t* function,
-    loomc_module_kernel_function_info_t* out_info) {
-  if (out_info == NULL) {
-    return false;
-  }
-  *out_info = (loomc_module_kernel_function_info_t){0};
-  const loom_module_t* internal_module = NULL;
-  const loom_symbol_t* symbol = NULL;
-  loomc_module_function_kind_t kind = LOOMC_MODULE_FUNCTION_KIND_UNKNOWN;
-  if (!loomc_module_function_try_resolve(module, function, &internal_module,
-                                         &symbol, &kind) ||
-      !loomc_module_function_kind_is_kernel(kind)) {
-    return false;
-  }
-  if (kind == LOOMC_MODULE_FUNCTION_KIND_KERNEL) {
-    loomc_module_function_populate_source_kernel_info(
-        internal_module, symbol->defining_op, out_info);
-  } else {
-    loomc_module_function_populate_target_kernel_info(symbol->defining_op,
-                                                      out_info);
-  }
-  return true;
-}
-
-loomc_status_t loomc_module_function_get_kernel_info(
-    const loomc_module_t* module, const loomc_module_function_t* function,
-    loomc_module_kernel_function_info_t* out_info) {
-  if (out_info == NULL) {
-    return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
-                             "out_info must not be NULL");
-  }
-  *out_info = (loomc_module_kernel_function_info_t){0};
-  const loom_module_t* internal_module = NULL;
-  const loom_symbol_t* symbol = NULL;
-  loomc_module_function_kind_t kind = LOOMC_MODULE_FUNCTION_KIND_UNKNOWN;
-  LOOMC_RETURN_IF_ERROR(loomc_module_function_resolve(
-      module, function, &internal_module, &symbol, &kind));
-  if (!loomc_module_function_kind_is_kernel(kind)) {
-    return loomc_make_status(LOOMC_STATUS_NOT_FOUND,
-                             "module function is not a kernel");
-  }
-  if (kind == LOOMC_MODULE_FUNCTION_KIND_KERNEL) {
-    loomc_module_function_populate_source_kernel_info(
-        internal_module, symbol->defining_op, out_info);
-  } else {
-    loomc_module_function_populate_target_kernel_info(symbol->defining_op,
-                                                      out_info);
   }
   return loomc_ok_status();
 }

--- a/loom/binding/c/test/BUILD.bazel
+++ b/loom/binding/c/test/BUILD.bazel
@@ -137,6 +137,17 @@ loom_cc_test(
 )
 
 loom_cc_test(
+    name = "launch_config_test",
+    srcs = ["launch_config_test.cc"],
+    deps = [
+        ":test_util",
+        "//loom/binding/c:loomc",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+loom_cc_test(
     name = "module_test",
     srcs = ["module_test.cc"],
     deps = [

--- a/loom/binding/c/test/CMakeLists.txt
+++ b/loom/binding/c/test/CMakeLists.txt
@@ -133,6 +133,18 @@ loom_cc_test(
 
 loom_cc_test(
   NAME
+    launch_config_test
+  SRCS
+    "launch_config_test.cc"
+  DEPS
+    ::test_util
+    iree::testing::gtest
+    iree::testing::gtest_main
+    loom::binding::c::loomc
+)
+
+loom_cc_test(
+  NAME
     module_test
   SRCS
     "module_test.cc"

--- a/loom/binding/c/test/launch_config_test.cc
+++ b/loom/binding/c/test/launch_config_test.cc
@@ -1,0 +1,729 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loomc/launch_config.h"
+
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "iree/testing/gtest.h"
+#include "loomc/context.h"
+#include "loomc/diagnostic.h"
+#include "loomc/result.h"
+#include "loomc/source.h"
+#include "test/util.h"
+
+namespace {
+
+using loomc::testing::HandlePtr;
+
+using ContextPtr = HandlePtr<loomc_context_t, loomc_context_release>;
+
+using SourcePtr = HandlePtr<loomc_source_t, loomc_source_release>;
+
+using WorkspacePtr = HandlePtr<loomc_workspace_t, loomc_workspace_release>;
+
+using ModulePtr = HandlePtr<loomc_module_t, loomc_module_release>;
+
+using ResultPtr = HandlePtr<loomc_result_t, loomc_result_release>;
+
+ContextPtr CreateContext() {
+  loomc_context_t* context = nullptr;
+  LOOMC_EXPECT_OK(
+      loomc_context_create(nullptr, loomc_allocator_system(), &context));
+  return ContextPtr(context);
+}
+
+WorkspacePtr CreateWorkspace() {
+  loomc_workspace_t* workspace = nullptr;
+  LOOMC_EXPECT_OK(
+      loomc_workspace_create(nullptr, loomc_allocator_system(), &workspace));
+  return WorkspacePtr(workspace);
+}
+
+SourcePtr CreateTextSource(const char* identifier, const char* contents) {
+  loomc_source_options_t options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_SOURCE_OPTIONS,
+      /*.structure_size=*/sizeof(options),
+      /*.next=*/nullptr,
+      /*.format=*/LOOMC_SOURCE_FORMAT_TEXT,
+      /*.identifier=*/loomc_make_cstring_view(identifier),
+      /*.contents=*/loomc_make_byte_span(contents, strlen(contents)),
+      /*.storage=*/LOOMC_SOURCE_STORAGE_COPY,
+  };
+  loomc_source_t* source = nullptr;
+  LOOMC_EXPECT_OK(
+      loomc_source_create(&options, loomc_allocator_system(), &source));
+  return SourcePtr(source);
+}
+
+std::string ToString(loomc_string_view_t value) {
+  return value.data ? std::string(value.data, value.size) : std::string();
+}
+
+void ExpectSucceededResult(const loomc_result_t* result) {
+  ASSERT_NE(result, nullptr);
+  if (!loomc_result_succeeded(result) &&
+      loomc_result_diagnostic_count(result) != 0) {
+    const loomc_diagnostic_t* diagnostic =
+        loomc_result_diagnostic_at(result, 0);
+    ASSERT_NE(diagnostic, nullptr);
+    ADD_FAILURE() << ToString(diagnostic->code) << ": "
+                  << ToString(diagnostic->message);
+  }
+  EXPECT_TRUE(loomc_result_succeeded(result));
+}
+
+void ExpectFailedResultCode(const loomc_result_t* result, const char* code) {
+  ASSERT_NE(result, nullptr);
+  EXPECT_FALSE(loomc_result_succeeded(result));
+  bool found = false;
+  for (loomc_host_size_t i = 0; i < loomc_result_diagnostic_count(result);
+       ++i) {
+    const loomc_diagnostic_t* diagnostic =
+        loomc_result_diagnostic_at(result, i);
+    ASSERT_NE(diagnostic, nullptr);
+    found |= ToString(diagnostic->code) == code;
+  }
+  EXPECT_TRUE(found);
+}
+
+ModulePtr DeserializeModule(loomc_context_t* context,
+                            loomc_workspace_t* workspace, const char* text) {
+  SourcePtr source = CreateTextSource("launch_config.loom", text);
+  loomc_module_t* module = nullptr;
+  loomc_result_t* result = nullptr;
+  LOOMC_EXPECT_OK(loomc_module_deserialize_from_source(
+      context, workspace, source.get(), nullptr, loomc_allocator_system(),
+      &module, &result));
+  ResultPtr result_ptr(result);
+  ExpectSucceededResult(result_ptr.get());
+  return ModulePtr(module);
+}
+
+void Evaluate(loomc_module_t* module, loomc_workspace_t* workspace,
+              const loomc_launch_config_eval_options_t* options,
+              loomc_launch_config_t* out_config, ResultPtr* out_result) {
+  loomc_result_t* result = nullptr;
+  LOOMC_ASSERT_OK(loomc_module_evaluate_launch_config(
+      module, workspace, options, loomc_allocator_system(), out_config,
+      &result));
+  out_result->reset(result);
+}
+
+loomc_launch_config_eval_options_t EvalOptions(
+    const char* function_symbol,
+    loomc_launch_config_field_flags_t required_fields) {
+  loomc_launch_config_eval_options_t options = {};
+  options.type = LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG_EVAL_OPTIONS;
+  options.structure_size = sizeof(options);
+  options.function_symbol = loomc_make_cstring_view(function_symbol);
+  options.required_fields = required_fields;
+  return options;
+}
+
+loomc_launch_config_t EmptyResultConfig() {
+  loomc_launch_config_t config = {};
+  config.type = LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG;
+  config.structure_size = sizeof(config);
+  return config;
+}
+
+TEST(LaunchConfigTest, EvaluatesConstantLaunchConfig) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry() {
+  %c1 = index.constant 1 : index
+  %c2 = index.constant 2 : index
+  %c3 = index.constant 3 : index
+  %c4 = index.constant 4 : index
+  %c5 = index.constant 5 : index
+  %c6 = index.constant 6 : index
+  kernel.launch.config workgroups(%c2, %c3, %c4) workgroup_size(%c5, %c6, %c1) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("@entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
+                                LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE);
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectSucceededResult(result.get());
+  EXPECT_TRUE(config.fields & LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
+  EXPECT_EQ(config.workgroup_count.x, 2u);
+  EXPECT_EQ(config.workgroup_count.y, 3u);
+  EXPECT_EQ(config.workgroup_count.z, 4u);
+  EXPECT_TRUE(config.fields & LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE);
+  EXPECT_EQ(config.workgroup_size.x, 5u);
+  EXPECT_EQ(config.workgroup_size.y, 6u);
+  EXPECT_EQ(config.workgroup_size.z, 1u);
+}
+
+TEST(LaunchConfigTest, EvaluatesConfigBackedLaunchConfig) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+config.decl @shape.rows : index
+config.decl @shape.cols : index
+config.decl @tuning.workgroup_x : index
+
+kernel.def @entry() {
+  %one = index.constant 1 : index
+  %rows = config.get @shape.rows : index
+  %cols = config.get @shape.cols : index
+  %workgroup_x = config.get @tuning.workgroup_x : index
+  kernel.launch.config workgroups(%rows, %cols, %one) workgroup_size(%workgroup_x, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_config_binding_t bindings[] = {
+      {
+          /*.key=*/loomc_make_cstring_view("shape.rows"),
+          /*.value=*/loomc_make_cstring_view("7"),
+      },
+      {
+          /*.key=*/loomc_make_cstring_view("shape.cols"),
+          /*.value=*/loomc_make_cstring_view("8"),
+      },
+      {
+          /*.key=*/loomc_make_cstring_view("tuning.workgroup_x"),
+          /*.value=*/loomc_make_cstring_view("10"),
+      },
+  };
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
+                               LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE);
+  options.config.bindings = bindings;
+  options.config.binding_count = 3;
+  options.config.flags = LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
+                         LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED;
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectSucceededResult(result.get());
+  EXPECT_EQ(config.workgroup_count.x, 7u);
+  EXPECT_EQ(config.workgroup_count.y, 8u);
+  EXPECT_EQ(config.workgroup_count.z, 1u);
+  EXPECT_EQ(config.workgroup_size.x, 10u);
+  EXPECT_EQ(config.workgroup_size.y, 1u);
+  EXPECT_EQ(config.workgroup_size.z, 1u);
+}
+
+TEST(LaunchConfigTest, EvaluatesJsonConfigBackedLaunchConfig) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+config.decl @shape.rows : index
+config.decl @shape.cols : index
+
+kernel.def @entry() {
+  %one = index.constant 1 : index
+  %threads = index.constant 64 : index
+  %rows = config.get @shape.rows : index
+  %cols = config.get @shape.cols : index
+  kernel.launch.config workgroups(%rows, %cols, %one) workgroup_size(%threads, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
+                               LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE);
+  options.config.json_object = loomc_make_cstring_view(R"({
+        "shape": {
+          "rows": 13,
+          "cols": 17
+        }
+      })");
+  options.config.flags = LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
+                         LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED;
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectSucceededResult(result.get());
+  EXPECT_EQ(config.workgroup_count.x, 13u);
+  EXPECT_EQ(config.workgroup_count.y, 17u);
+  EXPECT_EQ(config.workgroup_count.z, 1u);
+  EXPECT_EQ(config.workgroup_size.x, 64u);
+  EXPECT_EQ(config.workgroup_size.y, 1u);
+  EXPECT_EQ(config.workgroup_size.z, 1u);
+}
+
+TEST(LaunchConfigTest, ReportsInvalidConfigBindingAsResultDiagnostic) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+config.decl @shape.rows : index
+
+kernel.def @entry() {
+  %one = index.constant 1 : index
+  %rows = config.get @shape.rows : index
+  kernel.launch.config workgroups(%rows, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_config_binding_t bindings[] = {{
+      /*.key=*/loomc_make_cstring_view("shape.cols"),
+      /*.value=*/loomc_make_cstring_view("7"),
+  }};
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
+  options.config.bindings = bindings;
+  options.config.binding_count = 1;
+  options.config.flags = LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN;
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectFailedResultCode(result.get(), "CONFIG/INVALID");
+}
+
+TEST(LaunchConfigTest, EvaluatesWorkloadArguments) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry(%rows: index, %cols: index) {
+  %one = index.constant 1 : index
+  %threads = index.constant 64 : index
+  kernel.launch.config workgroups(%rows, %cols, %one) workgroup_size(%threads, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  int64_t workload_arguments[] = {11, 12};
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
+                               LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE);
+  options.workload_arguments = workload_arguments;
+  options.workload_argument_count = 2;
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectSucceededResult(result.get());
+  EXPECT_EQ(config.workgroup_count.x, 11u);
+  EXPECT_EQ(config.workgroup_count.y, 12u);
+  EXPECT_EQ(config.workgroup_count.z, 1u);
+  EXPECT_EQ(config.workgroup_size.x, 64u);
+  EXPECT_EQ(config.workgroup_size.y, 1u);
+  EXPECT_EQ(config.workgroup_size.z, 1u);
+}
+
+TEST(LaunchConfigTest, EvaluatesWorkloadArgumentLaunchMath) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry(%rows: index) {
+  %one = index.constant 1 : index
+  %sixty_three = index.constant 63 : index
+  %sixty_four = index.constant 64 : index
+  %rounded_rows = index.add %rows, %sixty_three : index
+  %row_groups = index.div %rounded_rows, %sixty_four : index
+  kernel.launch.config workgroups(%row_groups, %one, %one) workgroup_size(%sixty_four, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  int64_t workload_arguments[] = {129};
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
+                               LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE);
+  options.workload_arguments = workload_arguments;
+  options.workload_argument_count = 1;
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectSucceededResult(result.get());
+  EXPECT_EQ(config.workgroup_count.x, 3u);
+  EXPECT_EQ(config.workgroup_count.y, 1u);
+  EXPECT_EQ(config.workgroup_count.z, 1u);
+  EXPECT_EQ(config.workgroup_size.x, 64u);
+  EXPECT_EQ(config.workgroup_size.y, 1u);
+  EXPECT_EQ(config.workgroup_size.z, 1u);
+}
+
+TEST(LaunchConfigTest, EvaluatesIntegerWorkloadArgumentsThroughIndexCast) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry(%rows_i32: i32, %cols_i64: i64) {
+  %one = index.constant 1 : index
+  %threads = index.constant 64 : index
+  %rows = index.cast %rows_i32 : i32 to index
+  %cols = index.cast %cols_i64 : i64 to index
+  kernel.launch.config workgroups(%rows, %cols, %one) workgroup_size(%threads, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  int64_t workload_arguments[] = {9, 10};
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
+                               LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE);
+  options.workload_arguments = workload_arguments;
+  options.workload_argument_count = 2;
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectSucceededResult(result.get());
+  EXPECT_EQ(config.workgroup_count.x, 9u);
+  EXPECT_EQ(config.workgroup_count.y, 10u);
+  EXPECT_EQ(config.workgroup_count.z, 1u);
+  EXPECT_EQ(config.workgroup_size.x, 64u);
+  EXPECT_EQ(config.workgroup_size.y, 1u);
+  EXPECT_EQ(config.workgroup_size.z, 1u);
+}
+
+TEST(LaunchConfigTest, AllowsPartialLaunchConfigResults) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry(%rows: index) {
+  %one = index.constant 1 : index
+  %threads = index.constant 64 : index
+  kernel.launch.config workgroups(%rows, %one, %one) workgroup_size(%threads, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE);
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectSucceededResult(result.get());
+  EXPECT_FALSE(config.fields & LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
+  EXPECT_TRUE(config.fields & LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE);
+  EXPECT_EQ(config.workgroup_size.x, 64u);
+  EXPECT_EQ(config.workgroup_size.y, 1u);
+  EXPECT_EQ(config.workgroup_size.z, 1u);
+}
+
+TEST(LaunchConfigTest, ReportsWorkloadArgumentsWithoutSignature) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  int64_t workload_arguments[] = {11};
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
+  options.workload_arguments = workload_arguments;
+  options.workload_argument_count = 1;
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectFailedResultCode(result.get(), "LAUNCH_CONFIG/WORKLOAD_ARGUMENT_COUNT");
+}
+
+TEST(LaunchConfigTest, ReportsWorkloadArgumentCountMismatch) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry(%rows: index, %cols: index) {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%rows, %cols, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  int64_t workload_arguments[] = {11};
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
+  options.workload_arguments = workload_arguments;
+  options.workload_argument_count = 1;
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectFailedResultCode(result.get(), "LAUNCH_CONFIG/WORKLOAD_ARGUMENT_COUNT");
+}
+
+TEST(LaunchConfigTest, ReportsUnsupportedWorkloadArgumentType) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry(%scale: f32) {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  int64_t workload_arguments[] = {1};
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
+  options.workload_arguments = workload_arguments;
+  options.workload_argument_count = 1;
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectFailedResultCode(result.get(), "LAUNCH_CONFIG/WORKLOAD_ARGUMENT_TYPE");
+}
+
+TEST(LaunchConfigTest, ReportsMissingFunctionSymbol) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("missing", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectFailedResultCode(result.get(), "LAUNCH_CONFIG/NOT_FOUND");
+}
+
+TEST(LaunchConfigTest, ReportsNonKernelFunctionSymbol) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+func.def @helper() {
+  func.return
+}
+
+kernel.def @entry() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("helper", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectFailedResultCode(result.get(), "LAUNCH_CONFIG/NOT_KERNEL");
+}
+
+TEST(LaunchConfigTest, ReportsMissingRequiredWorkgroupCount) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry(%rows: index) {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%rows, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectFailedResultCode(result.get(), "LAUNCH_CONFIG/MISSING_WORKGROUP_COUNT");
+}
+
+TEST(LaunchConfigTest, ReportsMissingRequiredSubgroupSize) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_SUBGROUP_SIZE);
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectFailedResultCode(result.get(), "LAUNCH_CONFIG/MISSING_SUBGROUP_SIZE");
+}
+
+TEST(LaunchConfigTest, ReportsMissingRequiredWorkgroupSize) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry(%threads: index) {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE);
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectFailedResultCode(result.get(), "LAUNCH_CONFIG/MISSING_WORKGROUP_SIZE");
+}
+
+TEST(LaunchConfigTest, ReportsMissingRequiredWorkgroupStorageBytes) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_launch_config_eval_options_t options = EvalOptions(
+      "entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_STORAGE_BYTES);
+  loomc_launch_config_t config = EmptyResultConfig();
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectFailedResultCode(result.get(),
+                         "LAUNCH_CONFIG/MISSING_WORKGROUP_STORAGE_BYTES");
+}
+
+TEST(LaunchConfigTest, AcceptsZeroInitializedApiStructs) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry() {
+  %one = index.constant 1 : index
+  %threads = index.constant 64 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_launch_config_eval_options_t options = {};
+  options.function_symbol = loomc_make_cstring_view("entry");
+  options.required_fields = LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
+                            LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE;
+  loomc_launch_config_t config = {};
+  ResultPtr result;
+  Evaluate(module.get(), workspace.get(), &options, &config, &result);
+
+  ExpectSucceededResult(result.get());
+  EXPECT_EQ(config.type, LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG);
+  EXPECT_EQ(config.structure_size, sizeof(config));
+  EXPECT_EQ(config.workgroup_count.x, 1u);
+  EXPECT_EQ(config.workgroup_size.x, 64u);
+}
+
+TEST(LaunchConfigTest, RejectsUnknownRequiredFieldBits) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_launch_config_eval_options_t options = EvalOptions(
+      "entry", static_cast<loomc_launch_config_field_flags_t>(1u << 31));
+  loomc_launch_config_t config = EmptyResultConfig();
+  loomc_result_t* raw_result = nullptr;
+  loomc_status_t status = loomc_module_evaluate_launch_config(
+      module.get(), workspace.get(), &options, loomc_allocator_system(),
+      &config, &raw_result);
+
+  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_INVALID_ARGUMENT, status);
+  EXPECT_EQ(raw_result, nullptr);
+}
+
+TEST(LaunchConfigTest, RejectsEmptyFunctionSymbolBeforeResult) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
+  loomc_launch_config_t config = EmptyResultConfig();
+  loomc_result_t* raw_result = nullptr;
+  loomc_status_t status = loomc_module_evaluate_launch_config(
+      module.get(), workspace.get(), &options, loomc_allocator_system(),
+      &config, &raw_result);
+
+  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_INVALID_ARGUMENT, status);
+  EXPECT_EQ(raw_result, nullptr);
+}
+
+TEST(LaunchConfigTest, RejectsMissingWorkloadArgumentPointerBeforeResult) {
+  ContextPtr context = CreateContext();
+  WorkspacePtr workspace = CreateWorkspace();
+  ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
+kernel.def @entry(%rows: index) {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%rows, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  loomc_launch_config_eval_options_t options =
+      EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
+  options.workload_argument_count = 1;
+  loomc_launch_config_t config = EmptyResultConfig();
+  loomc_result_t* raw_result = nullptr;
+  loomc_status_t status = loomc_module_evaluate_launch_config(
+      module.get(), workspace.get(), &options, loomc_allocator_system(),
+      &config, &raw_result);
+
+  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_INVALID_ARGUMENT, status);
+  EXPECT_EQ(raw_result, nullptr);
+}
+
+}  // namespace

--- a/loom/binding/c/test/module_test.cc
+++ b/loom/binding/c/test/module_test.cc
@@ -211,17 +211,6 @@ TEST(ModuleTest, QueriesFunctionsAndKernelSidecars) {
   EXPECT_EQ(helper->function_ordinal, 0u);
   EXPECT_EQ(helper->kind, LOOMC_MODULE_FUNCTION_KIND_FUNCTION);
   EXPECT_TRUE(helper->flags & LOOMC_MODULE_FUNCTION_FLAG_PUBLIC);
-  loomc_module_kernel_function_info_t kernel_info = {};
-  EXPECT_FALSE(loomc_module_function_try_get_kernel_info(module.get(), helper,
-                                                         &kernel_info));
-  EXPECT_FALSE(loomc_module_function_try_get_kernel_info_at(
-      module.get(), helper->function_ordinal, &kernel_info));
-  status =
-      loomc_module_function_get_kernel_info(module.get(), helper, &kernel_info);
-  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_NOT_FOUND, status);
-  status = loomc_module_function_get_kernel_info_at(
-      module.get(), helper->function_ordinal, &kernel_info);
-  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_NOT_FOUND, status);
   loomc_module_function_export_info_t export_info = {};
   EXPECT_FALSE(loomc_module_function_try_get_export_info_at(
       module.get(), helper->function_ordinal, &export_info));
@@ -234,21 +223,6 @@ TEST(ModuleTest, QueriesFunctionsAndKernelSidecars) {
   EXPECT_EQ(entry->function_ordinal, 1u);
   EXPECT_EQ(entry->kind, LOOMC_MODULE_FUNCTION_KIND_KERNEL);
   EXPECT_TRUE(entry->flags & LOOMC_MODULE_FUNCTION_FLAG_HAS_EXPORT_INFO);
-  ASSERT_TRUE(loomc_module_function_try_get_kernel_info(module.get(), entry,
-                                                        &kernel_info));
-  ASSERT_TRUE(loomc_module_function_try_get_kernel_info_at(
-      module.get(), entry->function_ordinal, &kernel_info));
-  EXPECT_TRUE(
-      kernel_info.flags &
-      LOOMC_MODULE_KERNEL_FUNCTION_FLAG_HAS_STATIC_DISPATCH_WORKGROUP_COUNT);
-  EXPECT_EQ(kernel_info.static_dispatch_workgroup_count.x, 2u);
-  EXPECT_EQ(kernel_info.static_dispatch_workgroup_count.y, 3u);
-  EXPECT_EQ(kernel_info.static_dispatch_workgroup_count.z, 4u);
-  EXPECT_TRUE(kernel_info.flags &
-              LOOMC_MODULE_KERNEL_FUNCTION_FLAG_HAS_STATIC_WORKGROUP_SIZE);
-  EXPECT_EQ(kernel_info.static_workgroup_size.x, 5u);
-  EXPECT_EQ(kernel_info.static_workgroup_size.y, 6u);
-  EXPECT_EQ(kernel_info.static_workgroup_size.z, 1u);
 
   export_info = {};
   ASSERT_TRUE(loomc_module_function_try_get_export_info(module.get(), entry,
@@ -372,13 +346,6 @@ TEST(ModuleTest, RejectsMalformedFunctionViewsWithoutCrashing) {
   LOOMC_ASSERT_OK(status);
   function.symbol_name =
       loomc_make_string_view(nullptr, function.symbol_name.size);
-
-  loomc_module_kernel_function_info_t kernel_info = {};
-  EXPECT_FALSE(loomc_module_function_try_get_kernel_info(
-      module.get(), &function, &kernel_info));
-  status = loomc_module_function_get_kernel_info(module.get(), &function,
-                                                 &kernel_info);
-  LOOMC_EXPECT_STATUS_IS(LOOMC_STATUS_INVALID_ARGUMENT, status);
 
   loomc_module_function_export_info_t export_info = {};
   EXPECT_FALSE(loomc_module_function_try_get_export_info(

--- a/loom/binding/c/test/target/iree_hal_execution.cc
+++ b/loom/binding/c/test/target/iree_hal_execution.cc
@@ -516,22 +516,37 @@ void RunIreeHalKernelExecutionTest(const IreeHalKernelExecutionTarget& target) {
   ASSERT_TRUE(ResultSucceeded(result.get(), "source deserialization"));
   result.reset();
 
-  loomc_module_function_t kernel_function = {};
-  LOOMC_ASSERT_OK(loomc_module_lookup_function(
-      module.get(), target.kernel_function_symbol, &kernel_function));
-  loomc_module_kernel_function_info_t kernel_info = {};
-  ASSERT_TRUE(loomc_module_function_try_get_kernel_info_at(
-      module.get(), kernel_function.function_ordinal, &kernel_info));
-  ASSERT_TRUE(
-      kernel_info.flags &
-      LOOMC_MODULE_KERNEL_FUNCTION_FLAG_HAS_STATIC_DISPATCH_WORKGROUP_COUNT);
-  ASSERT_TRUE(kernel_info.flags &
-              LOOMC_MODULE_KERNEL_FUNCTION_FLAG_HAS_STATIC_WORKGROUP_SIZE);
-  EXPECT_EQ(kernel_info.static_workgroup_size.x, 1u);
-  EXPECT_EQ(kernel_info.static_workgroup_size.y, 1u);
-  EXPECT_EQ(kernel_info.static_workgroup_size.z, 1u);
-  loomc_dimension3_t workgroup_count =
-      kernel_info.static_dispatch_workgroup_count;
+  loomc_launch_config_eval_options_t launch_config_options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG_EVAL_OPTIONS,
+      /*.structure_size=*/sizeof(launch_config_options),
+      /*.next=*/nullptr,
+      /*.function_symbol=*/target.kernel_function_symbol,
+      /*.config=*/{},
+      /*.workload_arguments=*/nullptr,
+      /*.workload_argument_count=*/0,
+      /*.required_fields=*/
+      LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
+          LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE,
+  };
+  loomc_launch_config_t launch_config = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG,
+      /*.structure_size=*/sizeof(launch_config),
+  };
+  loomc_result_t* launch_config_result = nullptr;
+  LOOMC_ASSERT_OK(loomc_module_evaluate_launch_config(
+      module.get(), workspace.get(), &launch_config_options,
+      loomc_allocator_system(), &launch_config, &launch_config_result));
+  result.reset(launch_config_result);
+  ASSERT_TRUE(ResultSucceeded(result.get(), "launch config evaluation"));
+  ASSERT_TRUE(launch_config.fields &
+              LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
+  ASSERT_TRUE(launch_config.fields &
+              LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE);
+  EXPECT_EQ(launch_config.workgroup_size.x, 1u);
+  EXPECT_EQ(launch_config.workgroup_size.y, 1u);
+  EXPECT_EQ(launch_config.workgroup_size.z, 1u);
+  loomc_dimension3_t workgroup_count = launch_config.workgroup_count;
+  result.reset();
 
   CompilerPtr compiler;
   loomc_compiler_t* compiler_handle = nullptr;

--- a/loom/src/loom/analysis/BUILD.bazel
+++ b/loom/src/loom/analysis/BUILD.bazel
@@ -234,6 +234,41 @@ loom_cc_library(
 )
 
 loom_cc_library(
+    name = "kernel_launch_config",
+    srcs = ["kernel_launch_config.c"],
+    hdrs = ["kernel_launch_config.h"],
+    deps = [
+        ":symbol_facts",
+        "//loom/src/loom/error:emitter",
+        "//loom/src/loom/ir",
+        "//loom/src/loom/ir:facts",
+        "//loom/src/loom/ops:func_symbol_facts",
+        "//loom/src/loom/ops/kernel",
+        "//loom/src/loom/pass:value_facts",
+        "//loom/src/loom/target:function_contract",
+        "//loom/src/loom/target:types",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal:arena",
+    ],
+)
+
+loom_cc_test(
+    name = "kernel_launch_config_test",
+    srcs = ["kernel_launch_config_test.cc"],
+    deps = [
+        ":kernel_launch_config",
+        "//loom/src/loom/format/text:parser",
+        "//loom/src/loom/ir",
+        "//loom/src/loom/testing:context",
+        "//loom/src/loom/testing:module_ptr",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+loom_cc_library(
     name = "vector_memory_footprint",
     srcs = ["vector_memory_footprint.c"],
     hdrs = ["vector_memory_footprint.h"],

--- a/loom/src/loom/analysis/CMakeLists.txt
+++ b/loom/src/loom/analysis/CMakeLists.txt
@@ -265,6 +265,45 @@ loom_cc_library(
 
 loom_cc_library(
   NAME
+    kernel_launch_config
+  HDRS
+    "kernel_launch_config.h"
+  SRCS
+    "kernel_launch_config.c"
+  DEPS
+    ::symbol_facts
+    iree::base
+    iree::base::internal::arena
+    loom::error::emitter
+    loom::ir
+    loom::ir::facts
+    loom::ops::func_symbol_facts
+    loom::ops::kernel
+    loom::pass::value_facts
+    loom::target::function_contract
+    loom::target::types
+  PUBLIC
+)
+
+loom_cc_test(
+  NAME
+    kernel_launch_config_test
+  SRCS
+    "kernel_launch_config_test.cc"
+  DEPS
+    ::kernel_launch_config
+    iree::base
+    iree::base::internal::arena
+    iree::testing::gtest
+    iree::testing::gtest_main
+    loom::format::text::parser
+    loom::ir
+    loom::testing::context
+    loom::testing::module_ptr
+)
+
+loom_cc_library(
+  NAME
     vector_memory_footprint
   HDRS
     "vector_memory_footprint.h"

--- a/loom/src/loom/analysis/kernel_launch_config.c
+++ b/loom/src/loom/analysis/kernel_launch_config.c
@@ -1,0 +1,331 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/analysis/kernel_launch_config.h"
+
+#include <string.h>
+
+#include "iree/base/internal/arena.h"
+#include "loom/analysis/symbol_facts.h"
+#include "loom/ir/facts.h"
+#include "loom/ir/types.h"
+#include "loom/ops/func_symbol_facts.h"
+#include "loom/ops/kernel/launch_config.h"
+#include "loom/ops/kernel/ops.h"
+#include "loom/pass/value_facts.h"
+#include "loom/target/function_contract.h"
+
+static iree_string_view_t loom_kernel_launch_config_normalize_symbol(
+    iree_string_view_t symbol) {
+  if (!iree_string_view_is_empty(symbol) && symbol.data[0] == '@') {
+    return iree_make_string_view(symbol.data + 1, symbol.size - 1);
+  }
+  return symbol;
+}
+
+bool loom_kernel_launch_config_fields_are_valid(
+    loom_kernel_launch_config_field_flags_t fields) {
+  const loom_kernel_launch_config_field_flags_t known_fields =
+      LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
+      LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE |
+      LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_SUBGROUP_SIZE |
+      LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_STORAGE_BYTES;
+  return (fields & ~known_fields) == 0;
+}
+
+static const loom_symbol_t* loom_kernel_launch_config_find_symbol(
+    const loom_module_t* module, iree_string_view_t symbol_name,
+    loom_symbol_id_t* out_symbol_id) {
+  *out_symbol_id = LOOM_SYMBOL_ID_INVALID;
+  loom_string_id_t name_id = loom_module_lookup_string(module, symbol_name);
+  if (name_id == LOOM_STRING_ID_INVALID) {
+    return NULL;
+  }
+  loom_symbol_id_t symbol_id = loom_module_find_symbol(module, name_id);
+  if (symbol_id == LOOM_SYMBOL_ID_INVALID) {
+    return NULL;
+  }
+  *out_symbol_id = symbol_id;
+  return &module->symbols.entries[symbol_id];
+}
+
+static iree_status_t loom_kernel_launch_config_symbol_has_target(
+    const loom_module_t* module, loom_symbol_id_t symbol_id,
+    iree_arena_block_pool_t* block_pool, bool* out_has_target) {
+  *out_has_target = false;
+
+  iree_arena_allocator_t arena;
+  iree_arena_initialize(block_pool, &arena);
+  loom_symbol_fact_table_t symbol_facts = {0};
+  loom_symbol_fact_table_initialize(&symbol_facts, &arena);
+  const loom_symbol_facts_base_t* base_facts = NULL;
+  iree_status_t status = loom_symbol_fact_table_lookup(&symbol_facts, module,
+                                                       symbol_id, &base_facts);
+  if (iree_status_is_ok(status)) {
+    const loom_func_symbol_facts_t* func_facts =
+        loom_func_symbol_facts_cast(base_facts);
+    *out_has_target =
+        func_facts && loom_symbol_ref_is_valid(func_facts->target_symbol);
+  }
+  iree_arena_deinitialize(&arena);
+  return status;
+}
+
+static iree_status_t loom_kernel_launch_config_resolve_target_bundle(
+    const loom_module_t* module, loom_symbol_id_t symbol_id,
+    iree_arena_allocator_t* arena, iree_diagnostic_emitter_t emitter,
+    bool* out_valid, loom_target_bundle_storage_t* out_storage,
+    const loom_target_bundle_t** out_bundle) {
+  *out_valid = true;
+  *out_storage = (loom_target_bundle_storage_t){0};
+  *out_bundle = NULL;
+
+  loom_symbol_fact_table_t symbol_facts = {0};
+  loom_symbol_fact_table_initialize(&symbol_facts, arena);
+  const loom_symbol_facts_base_t* base_facts = NULL;
+  IREE_RETURN_IF_ERROR(loom_symbol_fact_table_lookup(&symbol_facts, module,
+                                                     symbol_id, &base_facts));
+  const loom_func_symbol_facts_t* func_facts =
+      loom_func_symbol_facts_cast(base_facts);
+  if (!func_facts || !loom_symbol_ref_is_valid(func_facts->target_symbol)) {
+    return iree_ok_status();
+  }
+
+  bool contract_valid = false;
+  IREE_RETURN_IF_ERROR(loom_target_function_contract_resolve(
+      module, &symbol_facts, func_facts, emitter, &contract_valid,
+      out_storage));
+  *out_valid = contract_valid;
+  if (contract_valid) {
+    *out_bundle = &out_storage->bundle;
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_kernel_launch_config_define_workload_arguments(
+    const loom_kernel_launch_config_options_t* options,
+    const loom_module_t* module, loom_op_t* kernel_op,
+    loom_value_fact_table_t* fact_table,
+    loom_kernel_launch_config_t* out_config) {
+  if (options->workload_argument_count == 0) {
+    return iree_ok_status();
+  }
+  loom_region_t* config_region = loom_kernel_def_config(kernel_op);
+  if (!config_region || config_region->block_count == 0) {
+    out_config->failure =
+        LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_WORKLOAD_ARGUMENT_COUNT;
+    return iree_ok_status();
+  }
+  loom_block_t* entry_block = loom_region_entry_block(config_region);
+  if (!entry_block) {
+    out_config->failure =
+        LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_WORKLOAD_ARGUMENT_COUNT;
+    return iree_ok_status();
+  }
+  if (options->workload_argument_count != entry_block->arg_count) {
+    out_config->failure =
+        LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_WORKLOAD_ARGUMENT_COUNT;
+    return iree_ok_status();
+  }
+  for (iree_host_size_t i = 0; i < options->workload_argument_count; ++i) {
+    loom_value_id_t value_id = loom_block_arg_id(entry_block, (uint16_t)i);
+    loom_type_t type = loom_module_value_type(module, value_id);
+    if (!loom_type_is_scalar(type)) {
+      out_config->failure =
+          LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_WORKLOAD_ARGUMENT_TYPE;
+      return iree_ok_status();
+    }
+    const loom_scalar_type_t scalar_type = loom_type_element_type(type);
+    if (scalar_type != LOOM_SCALAR_TYPE_INDEX &&
+        scalar_type != LOOM_SCALAR_TYPE_OFFSET &&
+        !loom_scalar_type_is_integer(scalar_type)) {
+      out_config->failure =
+          LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_WORKLOAD_ARGUMENT_TYPE;
+      return iree_ok_status();
+    }
+    IREE_RETURN_IF_ERROR(loom_value_fact_table_define(
+        fact_table, value_id,
+        loom_value_facts_exact_i64(options->workload_arguments[i])));
+  }
+  return iree_ok_status();
+}
+
+static void loom_kernel_launch_config_fill_known_fields(
+    const loom_module_t* module, loom_op_t* kernel_op,
+    const loom_target_bundle_t* target_bundle,
+    const loom_value_fact_table_t* fact_table,
+    loom_kernel_launch_config_t* out_config) {
+  loom_target_dispatch_workgroup_count_t count = {0};
+  if (loom_kernel_def_static_workgroup_count_from_facts(module, kernel_op,
+                                                        fact_table, &count)) {
+    out_config->workgroup_count = count;
+    out_config->fields |= LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT;
+  }
+
+  loom_target_workgroup_size_t size = {0};
+  if (loom_kernel_def_static_workgroup_size_from_facts(module, kernel_op,
+                                                       fact_table, &size)) {
+    out_config->workgroup_size = size;
+    out_config->fields |= LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE;
+  }
+
+  if (target_bundle && target_bundle->snapshot &&
+      target_bundle->snapshot->subgroup_size != 0) {
+    out_config->subgroup_size = target_bundle->snapshot->subgroup_size;
+    out_config->fields |= LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_SUBGROUP_SIZE;
+  }
+}
+
+static void loom_kernel_launch_config_report_required_fields(
+    loom_kernel_launch_config_field_flags_t required_fields,
+    const loom_kernel_launch_config_t* config,
+    loom_kernel_launch_config_t* out_config) {
+  const loom_kernel_launch_config_field_flags_t missing =
+      required_fields & ~config->fields;
+  if (missing & LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT) {
+    out_config->failure =
+        LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_MISSING_WORKGROUP_COUNT;
+  } else if (missing & LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE) {
+    out_config->failure =
+        LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_MISSING_WORKGROUP_SIZE;
+  } else if (missing & LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_SUBGROUP_SIZE) {
+    out_config->failure =
+        LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_MISSING_SUBGROUP_SIZE;
+  } else if (missing &
+             LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_STORAGE_BYTES) {
+    out_config->failure =
+        LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_MISSING_WORKGROUP_STORAGE_BYTES;
+  }
+}
+
+iree_status_t loom_kernel_launch_config_try_evaluate_direct(
+    const loom_module_t* module, iree_arena_block_pool_t* block_pool,
+    const loom_kernel_launch_config_options_t* options,
+    loom_kernel_launch_config_t* out_config, bool* out_evaluated) {
+  if (!module || !block_pool || !options || !out_config || !out_evaluated) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "module, block_pool, options, out_config, and out_evaluated are "
+        "required");
+  }
+  if (!loom_kernel_launch_config_fields_are_valid(options->required_fields)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "required_fields contains unknown bits");
+  }
+
+  *out_config = (loom_kernel_launch_config_t){0};
+  *out_evaluated = false;
+  if (options->workload_argument_count != 0) {
+    return iree_ok_status();
+  }
+
+  const iree_string_view_t symbol_name =
+      loom_kernel_launch_config_normalize_symbol(options->function_symbol);
+  loom_symbol_id_t symbol_id = LOOM_SYMBOL_ID_INVALID;
+  const loom_symbol_t* symbol =
+      loom_kernel_launch_config_find_symbol(module, symbol_name, &symbol_id);
+  if (symbol == NULL || !loom_kernel_def_isa(symbol->defining_op)) {
+    return iree_ok_status();
+  }
+
+  bool has_target = false;
+  IREE_RETURN_IF_ERROR(loom_kernel_launch_config_symbol_has_target(
+      module, symbol_id, block_pool, &has_target));
+  if (has_target) {
+    return iree_ok_status();
+  }
+
+  loom_kernel_launch_config_fill_known_fields(module, symbol->defining_op,
+                                              /*target_bundle=*/NULL,
+                                              /*fact_table=*/NULL, out_config);
+  loom_kernel_launch_config_report_required_fields(options->required_fields,
+                                                   out_config, out_config);
+  if (!loom_kernel_launch_config_has_failure(out_config->failure)) {
+    *out_evaluated = true;
+  }
+  return iree_ok_status();
+}
+
+iree_status_t loom_kernel_launch_config_evaluate(
+    loom_module_t* module, iree_arena_block_pool_t* block_pool,
+    const loom_kernel_launch_config_options_t* options,
+    loom_kernel_launch_config_t* out_config) {
+  if (!module || !block_pool || !options || !out_config) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "module, block_pool, options, and out_config are required");
+  }
+  if (!loom_kernel_launch_config_fields_are_valid(options->required_fields)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "required_fields contains unknown bits");
+  }
+
+  *out_config = (loom_kernel_launch_config_t){0};
+  const iree_string_view_t symbol_name =
+      loom_kernel_launch_config_normalize_symbol(options->function_symbol);
+  loom_symbol_id_t symbol_id = LOOM_SYMBOL_ID_INVALID;
+  const loom_symbol_t* symbol =
+      loom_kernel_launch_config_find_symbol(module, symbol_name, &symbol_id);
+  if (symbol == NULL) {
+    out_config->failure = LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_FUNCTION_NOT_FOUND;
+    return iree_ok_status();
+  }
+  if (!loom_kernel_def_isa(symbol->defining_op)) {
+    out_config->failure = LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_NOT_KERNEL;
+    return iree_ok_status();
+  }
+
+  iree_arena_allocator_t target_arena;
+  iree_arena_initialize(block_pool, &target_arena);
+  loom_target_bundle_storage_t target_storage = {0};
+  const loom_target_bundle_t* target_bundle = NULL;
+  bool target_valid = true;
+  iree_status_t status = loom_kernel_launch_config_resolve_target_bundle(
+      module, symbol_id, &target_arena, options->diagnostic_emitter,
+      &target_valid, &target_storage, &target_bundle);
+  if (iree_status_is_ok(status) && !target_valid) {
+    out_config->failure = LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_TARGET_CONTRACT;
+  }
+
+  loom_pass_value_fact_owner_t fact_owner = {0};
+  loom_pass_value_fact_owner_initialize(block_pool, &fact_owner);
+  loom_value_fact_table_t* fact_table = NULL;
+  if (iree_status_is_ok(status) &&
+      !loom_kernel_launch_config_has_failure(out_config->failure)) {
+    loom_func_like_t function =
+        loom_func_like_cast(module, symbol->defining_op);
+    status = loom_pass_value_fact_owner_prepare(
+        &fact_owner, module,
+        loom_pass_value_fact_scope_region_for_target(
+            function, loom_kernel_def_config(symbol->defining_op),
+            symbol->defining_op, target_bundle),
+        &fact_table);
+  }
+  if (iree_status_is_ok(status) &&
+      !loom_kernel_launch_config_has_failure(out_config->failure)) {
+    status = loom_kernel_launch_config_define_workload_arguments(
+        options, module, symbol->defining_op, fact_table, out_config);
+  }
+  if (iree_status_is_ok(status) &&
+      !loom_kernel_launch_config_has_failure(out_config->failure)) {
+    loom_func_like_t function =
+        loom_func_like_cast(module, symbol->defining_op);
+    status = loom_value_fact_table_compute_region(
+        fact_table, module, function,
+        loom_kernel_def_config(symbol->defining_op), symbol->defining_op);
+  }
+  if (iree_status_is_ok(status) &&
+      !loom_kernel_launch_config_has_failure(out_config->failure)) {
+    loom_kernel_launch_config_fill_known_fields(
+        module, symbol->defining_op, target_bundle, fact_table, out_config);
+    loom_kernel_launch_config_report_required_fields(options->required_fields,
+                                                     out_config, out_config);
+  }
+
+  loom_pass_value_fact_owner_deinitialize(&fact_owner);
+  iree_arena_deinitialize(&target_arena);
+  return status;
+}

--- a/loom/src/loom/analysis/kernel_launch_config.h
+++ b/loom/src/loom/analysis/kernel_launch_config.h
@@ -1,0 +1,135 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Kernel launch configuration analysis.
+//
+// This layer evaluates launch configuration regions under caller-provided
+// workload arguments and target contracts. It sits above raw kernel dialect
+// helpers and below public API wrappers, tools, and artifact producers.
+
+#ifndef LOOM_KERNEL_LAUNCH_CONFIG_H_
+#define LOOM_KERNEL_LAUNCH_CONFIG_H_
+
+#include <stdint.h>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/arena.h"
+#include "loom/error/emitter.h"
+#include "loom/ir/module.h"
+#include "loom/target/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum loom_kernel_launch_config_field_flag_bits_e {
+  // workgroup_count is present.
+  LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT = 0x1u,
+
+  // workgroup_size is present.
+  LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE = 0x2u,
+
+  // subgroup_size is present.
+  LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_SUBGROUP_SIZE = 0x4u,
+
+  // workgroup_storage_bytes is present.
+  LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_STORAGE_BYTES = 0x8u,
+} loom_kernel_launch_config_field_flag_bits_t;
+
+typedef uint32_t loom_kernel_launch_config_field_flags_t;
+
+typedef enum loom_kernel_launch_config_failure_e {
+  // Evaluation succeeded.
+  LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_NONE = 0,
+
+  // The requested function symbol was not found.
+  LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_FUNCTION_NOT_FOUND = 1,
+
+  // The requested symbol is not a source kernel definition.
+  LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_NOT_KERNEL = 2,
+
+  // Workload argument count does not match the launch-config region signature.
+  LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_WORKLOAD_ARGUMENT_COUNT = 3,
+
+  // A workload argument cannot be represented from an i64 value.
+  LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_WORKLOAD_ARGUMENT_TYPE = 4,
+
+  // Target contract resolution emitted diagnostics.
+  LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_TARGET_CONTRACT = 5,
+
+  // Required workgroup count could not be resolved.
+  LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_MISSING_WORKGROUP_COUNT = 6,
+
+  // Required workgroup size could not be resolved.
+  LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_MISSING_WORKGROUP_SIZE = 7,
+
+  // Required subgroup size could not be resolved.
+  LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_MISSING_SUBGROUP_SIZE = 8,
+
+  // Required workgroup-local storage byte count could not be resolved.
+  LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_MISSING_WORKGROUP_STORAGE_BYTES = 9,
+} loom_kernel_launch_config_failure_t;
+
+static inline bool loom_kernel_launch_config_has_failure(
+    loom_kernel_launch_config_failure_t failure) {
+  return failure != LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_NONE;
+}
+
+typedef struct loom_kernel_launch_config_options_t {
+  // Kernel function symbol to evaluate, with or without a leading @.
+  iree_string_view_t function_symbol;
+
+  // Workload argument values supplied as signed 64-bit integers.
+  const int64_t* workload_arguments;
+
+  // Number of entries in workload_arguments.
+  iree_host_size_t workload_argument_count;
+
+  // Fields that must be present for evaluation to succeed.
+  loom_kernel_launch_config_field_flags_t required_fields;
+
+  // Structured diagnostic emitter for target-contract diagnostics.
+  iree_diagnostic_emitter_t diagnostic_emitter;
+} loom_kernel_launch_config_options_t;
+
+typedef struct loom_kernel_launch_config_t {
+  // Present evaluated fields.
+  loom_kernel_launch_config_field_flags_t fields;
+
+  // Optional concrete workgroup count.
+  loom_target_dispatch_workgroup_count_t workgroup_count;
+
+  // Optional concrete local workgroup size.
+  loom_target_workgroup_size_t workgroup_size;
+
+  // Optional concrete subgroup size.
+  uint32_t subgroup_size;
+
+  // Optional concrete workgroup-local storage byte count.
+  uint64_t workgroup_storage_bytes;
+
+  // Evaluation failure code, or NONE on success.
+  loom_kernel_launch_config_failure_t failure;
+} loom_kernel_launch_config_t;
+
+bool loom_kernel_launch_config_fields_are_valid(
+    loom_kernel_launch_config_field_flags_t fields);
+
+iree_status_t loom_kernel_launch_config_try_evaluate_direct(
+    const loom_module_t* module, iree_arena_block_pool_t* block_pool,
+    const loom_kernel_launch_config_options_t* options,
+    loom_kernel_launch_config_t* out_config, bool* out_evaluated);
+
+iree_status_t loom_kernel_launch_config_evaluate(
+    loom_module_t* module, iree_arena_block_pool_t* block_pool,
+    const loom_kernel_launch_config_options_t* options,
+    loom_kernel_launch_config_t* out_config);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // LOOM_KERNEL_LAUNCH_CONFIG_H_

--- a/loom/src/loom/analysis/kernel_launch_config_test.cc
+++ b/loom/src/loom/analysis/kernel_launch_config_test.cc
@@ -1,0 +1,180 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/analysis/kernel_launch_config.h"
+
+#include "iree/base/api.h"
+#include "iree/base/internal/arena.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+#include "loom/format/text/parser.h"
+#include "loom/ir/context.h"
+#include "loom/ir/module.h"
+#include "loom/testing/context.h"
+#include "loom/testing/module_ptr.h"
+
+namespace loom {
+namespace {
+
+using ModulePtr = ::loom::testing::ModulePtr;
+
+class KernelLaunchConfigTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    iree_arena_block_pool_initialize(4096, iree_allocator_system(),
+                                     &block_pool_);
+    loom_context_initialize(iree_allocator_system(), &context_);
+    IREE_ASSERT_OK(loom_testing_context_register_all_dialects(&context_));
+    IREE_ASSERT_OK(loom_context_finalize(&context_));
+  }
+
+  void TearDown() override {
+    loom_context_deinitialize(&context_);
+    iree_arena_block_pool_deinitialize(&block_pool_);
+  }
+
+  ModulePtr Parse(const char* source) {
+    loom_module_t* module = nullptr;
+    loom_text_parse_options_t options = {};
+    IREE_EXPECT_OK(loom_text_parse(iree_make_cstring_view(source),
+                                   IREE_SV("kernel_launch_config_test.loom"),
+                                   &context_, &block_pool_, &options, &module));
+    EXPECT_NE(module, nullptr);
+    return ModulePtr(module);
+  }
+
+  iree_arena_block_pool_t block_pool_;
+  loom_context_t context_;
+};
+
+TEST_F(KernelLaunchConfigTest, DirectlyEvaluatesTargetIndependentConstants) {
+  ModulePtr module = Parse(R"(
+kernel.def @entry() {
+  %one = index.constant 1 : index
+  %two = index.constant 2 : index
+  %three = index.constant 3 : index
+  %four = index.constant 4 : index
+  %five = index.constant 5 : index
+  %six = index.constant 6 : index
+  kernel.launch.config workgroups(%two, %three, %four) workgroup_size(%five, %six, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  const loom_kernel_launch_config_options_t options = {
+      /*.function_symbol=*/IREE_SV("@entry"),
+      /*.workload_arguments=*/nullptr,
+      /*.workload_argument_count=*/0,
+      /*.required_fields=*/
+      LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
+          LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE,
+      /*.diagnostic_emitter=*/{},
+  };
+  loom_kernel_launch_config_t config = {};
+  bool evaluated = false;
+  IREE_ASSERT_OK(loom_kernel_launch_config_try_evaluate_direct(
+      module.get(), &block_pool_, &options, &config, &evaluated));
+
+  EXPECT_TRUE(evaluated);
+  EXPECT_EQ(config.failure, LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_NONE);
+  EXPECT_TRUE(config.fields &
+              LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
+  EXPECT_EQ(config.workgroup_count.x, 2u);
+  EXPECT_EQ(config.workgroup_count.y, 3u);
+  EXPECT_EQ(config.workgroup_count.z, 4u);
+  EXPECT_TRUE(config.fields &
+              LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE);
+  EXPECT_EQ(config.workgroup_size.x, 5u);
+  EXPECT_EQ(config.workgroup_size.y, 6u);
+  EXPECT_EQ(config.workgroup_size.z, 1u);
+}
+
+TEST_F(KernelLaunchConfigTest, DirectPathSkipsTargetBoundKernels) {
+  ModulePtr module = Parse(R"(
+target.generic<reference> @gpu {
+  subgroup_size = 32
+}
+
+kernel.def target(@gpu) @entry() {
+  %one = index.constant 1 : index
+  %threads = index.constant 64 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  const loom_kernel_launch_config_options_t options = {
+      /*.function_symbol=*/IREE_SV("entry"),
+      /*.workload_arguments=*/nullptr,
+      /*.workload_argument_count=*/0,
+      /*.required_fields=*/
+      LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
+          LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE,
+      /*.diagnostic_emitter=*/{},
+  };
+  loom_kernel_launch_config_t config = {};
+  bool evaluated = true;
+  IREE_ASSERT_OK(loom_kernel_launch_config_try_evaluate_direct(
+      module.get(), &block_pool_, &options, &config, &evaluated));
+
+  EXPECT_FALSE(evaluated);
+  EXPECT_EQ(config.fields, 0u);
+  EXPECT_EQ(config.failure, LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_NONE);
+}
+
+TEST_F(KernelLaunchConfigTest, EvaluatesTargetAndWorkloadBackedFields) {
+  ModulePtr module = Parse(R"(
+target.generic<reference> @gpu {
+  subgroup_size = 32
+}
+
+kernel.def target(@gpu) @entry(%rows: index) {
+  %one = index.constant 1 : index
+  %sixty_three = index.constant 63 : index
+  %sixty_four = index.constant 64 : index
+  %rounded_rows = index.add %rows, %sixty_three : index
+  %row_groups = index.div %rounded_rows, %sixty_four : index
+  kernel.launch.config workgroups(%row_groups, %one, %one) workgroup_size(%sixty_four, %one, %one) : index
+} launch() {
+  kernel.return
+}
+)");
+
+  const int64_t workload_arguments[] = {129};
+  const loom_kernel_launch_config_options_t options = {
+      /*.function_symbol=*/IREE_SV("entry"),
+      /*.workload_arguments=*/workload_arguments,
+      /*.workload_argument_count=*/IREE_ARRAYSIZE(workload_arguments),
+      /*.required_fields=*/
+      LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
+          LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE |
+          LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_SUBGROUP_SIZE,
+      /*.diagnostic_emitter=*/{},
+  };
+  loom_kernel_launch_config_t config = {};
+  IREE_ASSERT_OK(loom_kernel_launch_config_evaluate(module.get(), &block_pool_,
+                                                    &options, &config));
+
+  EXPECT_EQ(config.failure, LOOM_KERNEL_LAUNCH_CONFIG_FAILURE_NONE);
+  EXPECT_TRUE(config.fields &
+              LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
+  EXPECT_EQ(config.workgroup_count.x, 3u);
+  EXPECT_EQ(config.workgroup_count.y, 1u);
+  EXPECT_EQ(config.workgroup_count.z, 1u);
+  EXPECT_TRUE(config.fields &
+              LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE);
+  EXPECT_EQ(config.workgroup_size.x, 64u);
+  EXPECT_EQ(config.workgroup_size.y, 1u);
+  EXPECT_EQ(config.workgroup_size.z, 1u);
+  EXPECT_TRUE(config.fields &
+              LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_SUBGROUP_SIZE);
+  EXPECT_EQ(config.subgroup_size, 32u);
+}
+
+}  // namespace
+}  // namespace loom


### PR DESCRIPTION
Adds launch configuration evaluation to `loomc` so embedders can ask Loom how to launch a specialized kernel without reimplementing the kernel's launch-shape math in their own runtime.

This is the first pragmatic bridge toward launch configuration artifacts and VM-backed launch helpers. A framework that JITs a fixed set of model shapes can now compile a Loom kernel, pass the same configuration/workload values it used for specialization, and receive concrete workgroup count, workgroup size, subgroup size, and workgroup-local storage values through a versioned C API. If any requested field cannot be proven concrete, the API returns a normal Loom result with structured diagnostics instead of forcing the host to guess.

**Authoring Model**

Kernel authors keep launch intent in the kernel source. Static values can be written directly, compile-time tuning/model values can flow through `config.decl`/`config.get`, and shape values that come from the host invocation can be represented as launch-config region arguments.

For a statically specialized kernel, the launch config can be driven by config symbols:

```mlir
config.decl @shape.rows : index
config.decl @shape.cols : index
config.decl @tuning.workgroup_x : index

kernel.def @matvec() {
  %one = index.constant 1 : index
  %rows = config.get @shape.rows : index
  %cols = config.get @shape.cols : index
  %workgroup_x = config.get @tuning.workgroup_x : index
  kernel.launch.config workgroups(%rows, %cols, %one) workgroup_size(%workgroup_x, %one, %one) : index
} launch() {
  kernel.return
}
```

A JIT or model runtime can bind those symbols to the selected model/tuning shape and request the concrete launch fields. JSON/JSONC config and explicit key/value bindings normalize into the same config map, with explicit bindings overriding JSON keys.

For dynamically shaped kernels, the launch config can take workload arguments:

```mlir
kernel.def @rows_kernel(%rows: index) {
  %one = index.constant 1 : index
  %sixty_three = index.constant 63 : index
  %sixty_four = index.constant 64 : index
  %rounded_rows = index.add %rows, %sixty_three : index
  %row_groups = index.div %rounded_rows, %sixty_four : index
  kernel.launch.config workgroups(%row_groups, %one, %one) workgroup_size(%sixty_four, %one, %one) : index
} launch() {
  kernel.return
}
```

The evaluator seeds workload arguments as exact value facts and then uses the existing target contracts/value-fact machinery to resolve the launch fields. Integer workload arguments can flow through casts into `index`, so hosts do not need to mirror Loom's internal index spelling just to ask for a launch shape.

Target facts remain part of the authored contract. When a kernel is targeted, target-provided fields such as subgroup size and local-memory requirements can be requested alongside the explicit `kernel.launch.config` fields:

```mlir
target.generic<reference> @gpu {
  subgroup_size = 32
}

kernel.def target(@gpu) @entry(%rows: index) {
  %one = index.constant 1 : index
  %threads = index.constant 64 : index
  kernel.launch.config workgroups(%rows, %one, %one) workgroup_size(%threads, %one, %one) : index
} launch() {
  kernel.return
}
```

**JIT Integration**

Embedders include `loomc/launch_config.h` and call `loomc_module_evaluate_launch_config` after loading/deserializing the module and before launching the compiled executable. The source module is not mutated; evaluation clones the needed state into workspace scratch storage, materializes config values, applies target contracts, runs value-fact analysis, and returns presence-flagged fields.

```c
loomc_config_binding_t bindings[] = {
    {
        .key = loomc_make_cstring_view("shape.rows"),
        .value = loomc_make_cstring_view("4096"),
    },
    {
        .key = loomc_make_cstring_view("shape.cols"),
        .value = loomc_make_cstring_view("32000"),
    },
    {
        .key = loomc_make_cstring_view("tuning.workgroup_x"),
        .value = loomc_make_cstring_view("64"),
    },
};

loomc_launch_config_eval_options_t options = {
    .type = LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG_EVAL_OPTIONS,
    .structure_size = sizeof(options),
    .function_symbol = loomc_make_cstring_view("matvec"),
    .config =
        {
            .bindings = bindings,
            .binding_count = sizeof(bindings) / sizeof(bindings[0]),
            .flags = LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
                     LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
        },
    .required_fields = LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
                       LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE,
};

loomc_launch_config_t launch_config = {
    .type = LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG,
    .structure_size = sizeof(launch_config),
};
loomc_result_t* result = NULL;
loomc_status_t status = loomc_module_evaluate_launch_config(
    module, workspace, &options, loomc_allocator_system(), &launch_config,
    &result);
```

The status return follows the normal `loomc` split: non-OK status means API misuse or infrastructure failure before a result could be produced. User IR/config problems are reported through `result`. A successful result may still omit fields that were not requested or not provably concrete unless those fields were listed in `required_fields`.

```c
if (!loomc_status_is_ok(status)) {
  // API/infrastructure failure.
}
if (!loomc_result_succeeded(result)) {
  // Read structured diagnostics from result.
}
if (launch_config.fields & LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT) {
  uint32_t x = launch_config.workgroup_count.x;
  uint32_t y = launch_config.workgroup_count.y;
  uint32_t z = launch_config.workgroup_count.z;
  // Dispatch with (x, y, z).
}
loomc_result_release(result);
```

Workload arguments use the same API:

```c
int64_t workload_arguments[] = {129};

loomc_launch_config_eval_options_t options = {
    .type = LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG_EVAL_OPTIONS,
    .structure_size = sizeof(options),
    .function_symbol = loomc_make_cstring_view("rows_kernel"),
    .workload_arguments = workload_arguments,
    .workload_argument_count =
        sizeof(workload_arguments) / sizeof(workload_arguments[0]),
    .required_fields = LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
                       LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE,
};
```

For the `rows_kernel` example above, `%rows = 129` evaluates to `workgroup_count = (3, 1, 1)` and `workgroup_size = (64, 1, 1)`.

**Implementation Shape**

The reusable evaluator lives in `loom/src/loom/analysis/kernel_launch_config.*`, below public APIs and tools but outside `tooling/`. The public `loomc` layer is a wrapper that handles C API versioning, config option plumbing, result ownership, and diagnostic conversion. This keeps launch-shape analysis available to future artifact producers and tools without tying the core evaluator to a CLI surface.

The old module kernel-info sidecar query is removed. That query could only expose author-visible static sidecars and encouraged callers to treat launch metadata as a passive property of a function. The new API evaluates a particular invocation: function symbol plus config bindings plus workload arguments plus target facts. That matches how model runtimes and JITs actually choose and launch specialized kernels.

This change intentionally does not add the compact binary launch-config sidecar yet. It establishes the programmatic evaluation contract that the sidecar producer and consumers can build on next.
