### PR TITLE
[Loom] Add interleaved scf.for scheduling

### DIFF
--- a/loom/py/loom/dialect/scf/defs.py
+++ b/loom/py/loom/dialect/scf/defs.py
@@ -98,6 +98,19 @@ ScfForUnrollPolicy = EnumDef(
     doc="Local scf.for unroll policy.",
 )
 
+ScfForUnrollSchedule = EnumDef(
+    "ScfForUnrollSchedule",
+    [
+        EnumCase("linear", 0, doc="Materialize unrolled iterations in source order."),
+        EnumCase(
+            "interleaved",
+            1,
+            doc="Materialize corresponding body positions across unrolled iterations when dependencies allow.",
+        ),
+    ],
+    doc="Local scf.for unroll body ordering.",
+)
+
 # ============================================================================
 # scf.yield — variadic region terminator
 # ============================================================================
@@ -302,6 +315,13 @@ scf_for = Op(
             optional=True,
             doc="Optional bare unroll policy for required full unroll.",
         ),
+        AttrDef(
+            "unroll_schedule",
+            ATTR_TYPE_ENUM,
+            enum_def=ScfForUnrollSchedule,
+            optional=True,
+            doc="Optional schedule used when materializing unrolled loop body copies.",
+        ),
     ],
     results=[Result("results", ANY, variadic=True)],
     regions=[
@@ -354,6 +374,10 @@ scf_for = Op(
         OptionalGroup(
             [Attr("unroll_policy")],
             anchor="unroll_policy",
+        ),
+        OptionalGroup(
+            [Clause("schedule", Attr("unroll_schedule"))],
+            anchor="unroll_schedule",
         ),
         Region("body"),
     ],

--- a/loom/src/loom/analysis/movement.c
+++ b/loom/src/loom/analysis/movement.c
@@ -142,18 +142,125 @@ static bool loom_movement_vector_footprint_byte_length(
                               out_byte_length);
 }
 
-static bool loom_movement_vector_static_begin_byte_offset(
-    const loom_vector_memory_access_t* access, loom_attribute_t static_indices,
-    int64_t* out_byte_offset) {
-  *out_byte_offset = 0;
+static iree_status_t loom_movement_origin_index_expr(
+    loom_movement_analysis_t* analysis, loom_attribute_t static_indices,
+    loom_value_slice_t dynamic_indices, uint8_t axis,
+    loom_symbolic_expr_t* out_expression, bool* out_known) {
+  *out_known = false;
   if (static_indices.kind != LOOM_ATTR_I64_ARRAY ||
-      static_indices.count != access->view_rank) {
-    return false;
+      axis >= static_indices.count) {
+    return iree_ok_status();
   }
-  int64_t lane_indices[LOOM_ENCODING_ADDRESS_LAYOUT_MAX_RANK] = {0};
-  return loom_vector_memory_access_static_lane_byte_offset(
-      access, static_indices, lane_indices, access->vector_rank,
-      out_byte_offset);
+
+  uint16_t dynamic_ordinal = 0;
+  for (uint8_t i = 0; i <= axis; ++i) {
+    int64_t static_index = static_indices.i64_array[i];
+    if (static_index != INT64_MIN) {
+      if (i == axis) {
+        loom_symbolic_expr_constant(static_index, out_expression);
+        *out_known = true;
+        return iree_ok_status();
+      }
+      continue;
+    }
+    if (i == axis) {
+      if (dynamic_ordinal >= dynamic_indices.count) {
+        return iree_ok_status();
+      }
+      IREE_RETURN_IF_ERROR(loom_symbolic_expr_from_value(
+          &analysis->view_regions.expression_context,
+          dynamic_indices.values[dynamic_ordinal], out_expression));
+      *out_known = true;
+      return iree_ok_status();
+    }
+    ++dynamic_ordinal;
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_movement_vector_origin_byte_offset_expr(
+    loom_movement_analysis_t* analysis,
+    const loom_vector_memory_access_t* access, loom_attribute_t static_indices,
+    loom_value_slice_t dynamic_indices, loom_symbolic_expr_t* out_expression,
+    bool* out_known) {
+  *out_known = false;
+  if (access->static_element_byte_count <= 0 ||
+      static_indices.kind != LOOM_ATTR_I64_ARRAY ||
+      static_indices.count != access->view_rank) {
+    return iree_ok_status();
+  }
+
+  loom_symbolic_expr_t element_offset = {0};
+  loom_symbolic_expr_constant(0, &element_offset);
+  for (uint8_t view_axis = 0; view_axis < access->view_rank; ++view_axis) {
+    int64_t stride = 0;
+    if (!loom_vector_memory_access_static_axis_stride(access, view_axis,
+                                                      &stride)) {
+      return iree_ok_status();
+    }
+    if (stride == 0) continue;
+
+    loom_symbolic_expr_t origin = {0};
+    bool origin_known = false;
+    IREE_RETURN_IF_ERROR(loom_movement_origin_index_expr(
+        analysis, static_indices, dynamic_indices, view_axis, &origin,
+        &origin_known));
+    if (!origin_known) return iree_ok_status();
+
+    loom_symbolic_expr_t contribution = {0};
+    IREE_RETURN_IF_ERROR(
+        loom_symbolic_expr_mul_i64(&analysis->view_regions.expression_context,
+                                   &origin, stride, &contribution));
+    IREE_RETURN_IF_ERROR(loom_symbolic_expr_add(
+        &analysis->view_regions.expression_context, &element_offset,
+        &contribution, &element_offset));
+  }
+
+  IREE_RETURN_IF_ERROR(loom_symbolic_expr_mul_i64(
+      &analysis->view_regions.expression_context, &element_offset,
+      access->static_element_byte_count, out_expression));
+  *out_known = true;
+  return iree_ok_status();
+}
+
+static void loom_movement_endpoint_refresh_static_bounds(
+    loom_movement_endpoint_t* endpoint) {
+  endpoint->flags &= ~(LOOM_MOVEMENT_ENDPOINT_STATIC_BEGIN |
+                       LOOM_MOVEMENT_ENDPOINT_STATIC_LENGTH);
+  endpoint->static_begin_byte_offset = 0;
+  endpoint->static_byte_length = 0;
+  if (loom_movement_exact_i64(endpoint->begin_byte_offset,
+                              &endpoint->static_begin_byte_offset)) {
+    endpoint->flags |= LOOM_MOVEMENT_ENDPOINT_STATIC_BEGIN;
+  }
+  if (loom_movement_exact_i64(endpoint->byte_length,
+                              &endpoint->static_byte_length)) {
+    endpoint->flags |= LOOM_MOVEMENT_ENDPOINT_STATIC_LENGTH;
+  }
+}
+
+static iree_status_t loom_movement_endpoint_apply_vector_footprint(
+    loom_movement_analysis_t* analysis, const loom_symbolic_expr_t* origin,
+    int64_t byte_length, loom_movement_endpoint_t* endpoint) {
+  if (endpoint->kind != LOOM_MOVEMENT_ENDPOINT_VIEW) {
+    return iree_ok_status();
+  }
+
+  loom_symbolic_expr_t begin = {0};
+  IREE_RETURN_IF_ERROR(
+      loom_symbolic_expr_add(&analysis->view_regions.expression_context,
+                             &endpoint->begin_byte_offset, origin, &begin));
+  loom_symbolic_expr_t length = {0};
+  loom_symbolic_expr_constant(byte_length, &length);
+  loom_symbolic_expr_t end = {0};
+  IREE_RETURN_IF_ERROR(loom_symbolic_expr_add(
+      &analysis->view_regions.expression_context, &begin, &length, &end));
+
+  endpoint->begin_byte_offset = begin;
+  endpoint->byte_length = length;
+  endpoint->end_byte_offset = end;
+  loom_movement_endpoint_refresh_static_bounds(endpoint);
+  return iree_ok_status();
 }
 
 static loom_movement_layout_kind_t loom_movement_direct_layout_kind(
@@ -224,11 +331,14 @@ static void loom_movement_endpoint_for_register(
   };
 }
 
-static bool loom_movement_apply_vector_access(
+static iree_status_t loom_movement_apply_vector_access(
     loom_movement_analysis_t* analysis, loom_value_id_t view_value_id,
     loom_type_t vector_type, loom_attribute_t static_indices,
+    loom_value_slice_t dynamic_indices,
     loom_movement_layout_kind_t fallback_layout_kind,
-    loom_movement_request_t* request, loom_movement_diagnostic_t* diagnostic) {
+    loom_movement_request_t* request, loom_movement_diagnostic_t* diagnostic,
+    bool* out_applied) {
+  *out_applied = false;
   const loom_type_t view_type =
       loom_module_value_type(analysis->module, view_value_id);
   const loom_fact_context_t* fact_context =
@@ -237,23 +347,23 @@ static bool loom_movement_apply_vector_access(
                                           view_type, vector_type,
                                           &request->vector_access)) {
     diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_VECTOR_ACCESS;
-    return false;
+    return iree_ok_status();
   }
 
   if (request->vector_access.layout_kind == LOOM_VECTOR_MEMORY_LAYOUT_UNKNOWN) {
     diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_LAYOUT;
-    return false;
+    return iree_ok_status();
   }
   if (request->vector_access.static_element_byte_count <= 0) {
     diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_ELEMENT_WIDTH;
-    return false;
+    return iree_ok_status();
   }
 
   int64_t transferred_byte_count = 0;
   if (!loom_movement_vector_transfer_byte_count(&request->vector_access,
                                                 &transferred_byte_count)) {
     diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_LANE_COUNT;
-    return false;
+    return iree_ok_status();
   }
   request->flags |= LOOM_MOVEMENT_REQUEST_STATIC_TRANSFER;
   request->transferred_byte_count = transferred_byte_count;
@@ -276,54 +386,27 @@ static bool loom_movement_apply_vector_access(
     request->dest.static_byte_length = endpoint_byte_length;
   }
 
-  int64_t static_begin = 0;
-  if (loom_movement_vector_static_begin_byte_offset(
-          &request->vector_access, static_indices, &static_begin)) {
-    if (request->source.kind == LOOM_MOVEMENT_ENDPOINT_VIEW &&
-        iree_all_bits_set(request->source.flags,
-                          LOOM_MOVEMENT_ENDPOINT_STATIC_BEGIN |
-                              LOOM_MOVEMENT_ENDPOINT_STATIC_LENGTH)) {
-      if (!iree_checked_add_i64(request->source.static_begin_byte_offset,
-                                static_begin,
-                                &request->source.static_begin_byte_offset)) {
-        diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_FOOTPRINT;
-        return false;
-      }
-      int64_t static_end = 0;
-      if (!iree_checked_add_i64(request->source.static_begin_byte_offset,
-                                request->source.static_byte_length,
-                                &static_end)) {
-        diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_FOOTPRINT;
-        return false;
-      }
-      loom_symbolic_expr_constant(request->source.static_begin_byte_offset,
-                                  &request->source.begin_byte_offset);
-      loom_symbolic_expr_constant(static_end, &request->source.end_byte_offset);
-    }
-    if (request->dest.kind == LOOM_MOVEMENT_ENDPOINT_VIEW &&
-        iree_all_bits_set(request->dest.flags,
-                          LOOM_MOVEMENT_ENDPOINT_STATIC_BEGIN |
-                              LOOM_MOVEMENT_ENDPOINT_STATIC_LENGTH)) {
-      if (!iree_checked_add_i64(request->dest.static_begin_byte_offset,
-                                static_begin,
-                                &request->dest.static_begin_byte_offset)) {
-        diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_FOOTPRINT;
-        return false;
-      }
-      int64_t static_end = 0;
-      if (!iree_checked_add_i64(request->dest.static_begin_byte_offset,
-                                request->dest.static_byte_length,
-                                &static_end)) {
-        diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_FOOTPRINT;
-        return false;
-      }
-      loom_symbolic_expr_constant(request->dest.static_begin_byte_offset,
-                                  &request->dest.begin_byte_offset);
-      loom_symbolic_expr_constant(static_end, &request->dest.end_byte_offset);
-    }
+  if (endpoint_byte_length == 0 ||
+      iree_any_bit_set(request->flags,
+                       LOOM_MOVEMENT_REQUEST_IRREGULAR_OFFSETS)) {
+    *out_applied = true;
+    return iree_ok_status();
   }
 
-  return true;
+  loom_symbolic_expr_t origin = {0};
+  bool origin_known = false;
+  IREE_RETURN_IF_ERROR(loom_movement_vector_origin_byte_offset_expr(
+      analysis, &request->vector_access, static_indices, dynamic_indices,
+      &origin, &origin_known));
+  if (origin_known) {
+    IREE_RETURN_IF_ERROR(loom_movement_endpoint_apply_vector_footprint(
+        analysis, &origin, endpoint_byte_length, &request->source));
+    IREE_RETURN_IF_ERROR(loom_movement_endpoint_apply_vector_footprint(
+        analysis, &origin, endpoint_byte_length, &request->dest));
+  }
+
+  *out_applied = true;
+  return iree_ok_status();
 }
 
 static bool loom_movement_cache_policy_from_attrs(
@@ -516,11 +599,15 @@ static iree_status_t loom_movement_describe_vector(
                                         &request->dest);
   }
 
-  if (!loom_movement_apply_vector_access(
-          analysis, view_value_id,
-          loom_module_value_type(analysis->module, register_value_id),
-          loom_op_const_attrs(op)[2], descriptor->layout_kind, request,
-          diagnostic)) {
+  loom_memory_access_t access = loom_memory_access_cast(analysis->module, op);
+  bool applied = false;
+  IREE_RETURN_IF_ERROR(loom_movement_apply_vector_access(
+      analysis, view_value_id,
+      loom_module_value_type(analysis->module, register_value_id),
+      loom_memory_access_static_indices(access),
+      loom_memory_access_dynamic_indices(access), descriptor->layout_kind,
+      request, diagnostic, &applied));
+  if (!applied) {
     return loom_movement_describe_result(false, out_described);
   }
   return loom_movement_describe_result(true, out_described);

--- a/loom/src/loom/ops/interface_test.cc
+++ b/loom/src/loom/ops/interface_test.cc
@@ -228,7 +228,7 @@ TEST_F(InterfaceTest, LoopLikeCastReturnsValidForScfFor) {
   IREE_ASSERT_OK(loom_scf_for_build(
       &builder_, /*build_flags=*/0, lower_id, upper_id, step_id, nullptr, 0,
       nullptr, 0, nullptr, 0, LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0,
-      LOOM_LOCATION_UNKNOWN, &for_op));
+      /*unroll_schedule=*/0, LOOM_LOCATION_UNKNOWN, &for_op));
 
   loom_loop_like_t loop = loom_loop_like_cast(module_, for_op);
   EXPECT_TRUE(loom_loop_like_isa(loop));
@@ -274,7 +274,7 @@ TEST_F(InterfaceTest, LoopLikeAccessorsForScfFor) {
   IREE_ASSERT_OK(loom_scf_for_build(
       &builder_, /*build_flags=*/0, lower_id, upper_id, step_id, nullptr, 0,
       nullptr, 0, nullptr, 0, LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0,
-      LOOM_LOCATION_UNKNOWN, &for_op));
+      /*unroll_schedule=*/0, LOOM_LOCATION_UNKNOWN, &for_op));
 
   loom_loop_like_t loop = loom_loop_like_cast(module_, for_op);
   ASSERT_TRUE(loom_loop_like_isa(loop));
@@ -308,7 +308,7 @@ TEST_F(InterfaceTest, LoopLikeIterArgsEmpty) {
       &builder_, /*build_flags=*/0, loom_op_results(lower)[0],
       loom_op_results(upper)[0], loom_op_results(step)[0], nullptr, 0, nullptr,
       0, nullptr, 0, LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0,
-      LOOM_LOCATION_UNKNOWN, &for_op));
+      /*unroll_schedule=*/0, LOOM_LOCATION_UNKNOWN, &for_op));
 
   loom_loop_like_t loop = loom_loop_like_cast(module_, for_op);
   loom_value_slice_t iter_args = loom_loop_like_iter_args(loop);
@@ -333,7 +333,8 @@ TEST_F(InterfaceTest, LoopLikeIterArgsNonEmpty) {
                          loom_op_results(lower)[0], loom_op_results(upper)[0],
                          loom_op_results(step)[0], init_ids, 2, result_types, 2,
                          nullptr, 0, loom_op_results(factor)[0],
-                         /*unroll_policy=*/0, LOOM_LOCATION_UNKNOWN, &for_op));
+                         /*unroll_policy=*/0, /*unroll_schedule=*/0,
+                         LOOM_LOCATION_UNKNOWN, &for_op));
 
   loom_loop_like_t loop = loom_loop_like_cast(module_, for_op);
   loom_value_slice_t iter_args = loom_loop_like_iter_args(loop);
@@ -383,7 +384,7 @@ TEST_F(InterfaceTest, RegionBranchCastReturnsNullForScfFor) {
       &builder_, /*build_flags=*/0, loom_op_results(lower)[0],
       loom_op_results(upper)[0], loom_op_results(step)[0], nullptr, 0, nullptr,
       0, nullptr, 0, LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0,
-      LOOM_LOCATION_UNKNOWN, &for_op));
+      /*unroll_schedule=*/0, LOOM_LOCATION_UNKNOWN, &for_op));
 
   loom_region_branch_t branch = loom_region_branch_cast(module_, for_op);
   EXPECT_FALSE(loom_region_branch_isa(branch));

--- a/loom/src/loom/ops/scf/canonicalize.c
+++ b/loom/src/loom/ops/scf/canonicalize.c
@@ -1631,6 +1631,12 @@ static iree_status_t loom_scf_for_forward_loop_carried_results(
     build_flags |= LOOM_SCF_FOR_BUILD_FLAG_HAS_UNROLL_POLICY;
     unroll_policy = loom_scf_for_unroll_policy(op);
   }
+  loom_scf_for_unroll_schedule_t unroll_schedule = 0;
+  if (!loom_attr_is_absent(
+          loom_op_attrs(op)[loom_scf_for_unroll_schedule_ATTR_INDEX])) {
+    build_flags |= LOOM_SCF_FOR_BUILD_FLAG_HAS_UNROLL_SCHEDULE;
+    unroll_schedule = loom_scf_for_unroll_schedule(op);
+  }
   uint16_t old_iter_arg_offset =
       (uint16_t)(iter_args.values - loom_op_const_operands(op));
   uint16_t new_iter_arg_offset = 3;
@@ -1708,8 +1714,8 @@ static iree_status_t loom_scf_for_forward_loop_carried_results(
       &rewriter->builder, build_flags, loom_scf_for_lower_bound(op),
       loom_scf_for_upper_bound(op), loom_scf_for_step(op), kept_iter_args,
       kept_count, kept_result_types, kept_count, tied_results,
-      tied_result_count, unroll_factor, unroll_policy, op->location,
-      &new_loop));
+      tied_result_count, unroll_factor, unroll_policy, unroll_schedule,
+      op->location, &new_loop));
 
   loom_region_t* new_body = loom_scf_for_body(new_loop);
   loom_builder_ip_t saved_ip =

--- a/loom/src/loom/ops/scf/ops.h
+++ b/loom/src/loom/ops/scf/ops.h
@@ -36,6 +36,13 @@ typedef enum loom_scf_for_unroll_policy_e {
   LOOM_SCF_FOR_UNROLL_POLICY_COUNT_ = 2,
 } loom_scf_for_unroll_policy_t;
 
+// Local scf.for unroll body ordering.
+typedef enum loom_scf_for_unroll_schedule_e {
+  LOOM_SCF_FOR_UNROLL_SCHEDULE_LINEAR = 0,
+  LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED = 1,
+  LOOM_SCF_FOR_UNROLL_SCHEDULE_COUNT_ = 2,
+} loom_scf_for_unroll_schedule_t;
+
 // LOOM_OP_SCF_FOR: Bounded counted loop with optional loop-carried state.
 // scf.for %iv = [%c0 to %n step %c1] {
 //   scf.yield
@@ -48,10 +55,12 @@ LOOM_DEFINE_SEGMENTED_OPERANDS(loom_scf_for_iter_args, 3)
 LOOM_DEFINE_SEGMENTED_OPTIONAL_OPERAND(loom_scf_for_unroll_factor, 4)
 LOOM_DEFINE_VARIADIC_RESULTS(loom_scf_for_results, 0)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_scf_for_unroll_policy, 0, loom_scf_for_unroll_policy_t)
+LOOM_DEFINE_ATTR_ENUM_TYPED(loom_scf_for_unroll_schedule, 1, loom_scf_for_unroll_schedule_t)
 LOOM_DEFINE_REGION(loom_scf_for_body, 0)
 enum loom_scf_for_build_flag_bits_e {
   LOOM_SCF_FOR_BUILD_FLAG_HAS_UNROLL_FACTOR = 1u << 0,
   LOOM_SCF_FOR_BUILD_FLAG_HAS_UNROLL_POLICY = 1u << 1,
+  LOOM_SCF_FOR_BUILD_FLAG_HAS_UNROLL_SCHEDULE = 1u << 2,
 };
 typedef uint32_t loom_scf_for_build_flags_t;
 iree_status_t loom_scf_for_build(
@@ -68,6 +77,7 @@ iree_status_t loom_scf_for_build(
     iree_host_size_t tied_result_count,
     loom_optional loom_may_consume loom_value_id_t unroll_factor,
     loom_optional uint8_t unroll_policy,
+    loom_optional uint8_t unroll_schedule,
     loom_location_id_t location,
     loom_op_t** out_op);
 iree_status_t loom_scf_for_canonicalize(loom_op_t* op, loom_rewriter_t* rewriter);

--- a/loom/src/loom/ops/scf/test/roundtrip.loom-test
+++ b/loom/src/loom/ops/scf/test/roundtrip.loom-test
@@ -64,6 +64,26 @@ func.def @dynamic_unroll_policy(%lo: index, %hi: index, %step: index, %factor: i
 
 // ====
 
+// scf.for with an explicit unroll materialization schedule.
+func.def @dynamic_unroll_interleaved_schedule(%lo: index, %hi: index, %step: index, %factor: index, %init: f32) -> (f32) {
+  %result = scf.for %iv = [%lo to %hi step %step](%acc = %init : f32) -> (f32) unroll(%factor) schedule(interleaved) {
+    scf.yield %acc : f32
+  }
+  func.return %result : f32
+}
+
+// ====
+
+// scf.for with an explicit linear schedule prints the requested schedule rather
+// than relying on the absent-attribute default.
+func.def @dynamic_unroll_linear_schedule(%lo: index, %hi: index, %step: index, %factor: index) {
+  scf.for %iv = [%lo to %hi step %step] unroll(%factor) schedule(linear) {
+  }
+  func.return
+}
+
+// ====
+
 // scf.for also accepts grouped iter_arg type lists, then prints the canonical
 // per-binding type form.
 func.def @multi_vector_iter_grouped_types(%lo: index, %hi: index, %step: index, %gate_zero: vector<1xf32>, %up_zero: vector<1xf32>) -> (vector<1xf32>, vector<1xf32>) {

--- a/loom/src/loom/ops/scf/test/verify.loom-test
+++ b/loom/src/loom/ops/scf/test/verify.loom-test
@@ -64,6 +64,16 @@ func.def @for_unroll_policy_is_exclusive(%lo: index, %hi: index, %step: index, %
 
 // ====
 
+// An unroll schedule only has meaning when an unroll directive is present.
+func.def @for_unroll_schedule_requires_unroll(%lo: index, %hi: index, %step: index) {
+  // ERROR@+1: STRUCTURE/014 {attr_name="schedule", expected_constraint="paired with bare unroll or unroll factor"}
+  scf.for %iv = [%lo to %hi step %step] schedule(interleaved) {
+  }
+  func.return
+}
+
+// ====
+
 // Yield/result type matching remaps parent result references to the values
 // yielded by each region. This keeps co-result-shaped types valid without
 // forcing branch-local layouts to escape their region.

--- a/loom/src/loom/ops/scf/verify.c
+++ b/loom/src/loom/ops/scf/verify.c
@@ -196,12 +196,19 @@ iree_status_t loom_scf_for_verify(const loom_module_t* module,
   bool has_unroll_factor = loom_scf_for_unroll_factor_is_present(op);
   bool has_unroll_policy = !loom_attr_is_absent(
       loom_op_attrs(op)[loom_scf_for_unroll_policy_ATTR_INDEX]);
-  if (!has_unroll_factor || !has_unroll_policy) {
-    return iree_ok_status();
+  bool has_unroll_schedule = !loom_attr_is_absent(
+      loom_op_attrs(op)[loom_scf_for_unroll_schedule_ATTR_INDEX]);
+  if (has_unroll_factor && has_unroll_policy) {
+    return loom_scf_emit_attribute_value_constraint(
+        emitter, op, IREE_SV("unroll"), 2,
+        IREE_SV("either bare unroll or unroll factor, not both"));
   }
-  return loom_scf_emit_attribute_value_constraint(
-      emitter, op, IREE_SV("unroll"), 2,
-      IREE_SV("either bare unroll or unroll factor, not both"));
+  if (has_unroll_schedule && !has_unroll_factor && !has_unroll_policy) {
+    return loom_scf_emit_attribute_value_constraint(
+        emitter, op, IREE_SV("schedule"), 0,
+        IREE_SV("paired with bare unroll or unroll factor"));
+  }
+  return iree_ok_status();
 }
 
 iree_status_t loom_scf_while_verify(const loom_module_t* module,

--- a/loom/src/loom/transforms/loop/loop_fusion.c
+++ b/loom/src/loom/transforms/loop/loop_fusion.c
@@ -678,7 +678,8 @@ static iree_status_t loom_loop_fusion_fuse_pair(
       builder, /*build_flags=*/0, first->domain.lower_bound,
       first->domain.upper_bound, first->domain.step, iter_args, iter_arg_count,
       result_types, result_count, NULL, 0, LOOM_VALUE_ID_INVALID,
-      /*unroll_policy=*/0, first->op->location, &fused_loop);
+      /*unroll_policy=*/0, /*unroll_schedule=*/0, first->op->location,
+      &fused_loop);
   if (iree_status_is_ok(status)) {
     status = loom_loop_fusion_copy_result_names(context->module, first, second,
                                                 fused_loop);

--- a/loom/src/loom/transforms/scf/BUILD.bazel
+++ b/loom/src/loom/transforms/scf/BUILD.bazel
@@ -37,6 +37,7 @@ loom_cc_library(
     srcs = ["scf_unroll.c"],
     hdrs = ["scf_unroll.h"],
     deps = [
+        "//loom/src/loom/analysis:movement",
         "//loom/src/loom/error:emitter",
         "//loom/src/loom/error:error_defs",
         "//loom/src/loom/ir",

--- a/loom/src/loom/transforms/scf/CMakeLists.txt
+++ b/loom/src/loom/transforms/scf/CMakeLists.txt
@@ -41,6 +41,7 @@ loom_cc_library(
     "scf_unroll.c"
   DEPS
     iree::base
+    loom::analysis::movement
     loom::error::emitter
     loom::error::error_defs
     loom::ir

--- a/loom/src/loom/transforms/scf/scf_unroll.c
+++ b/loom/src/loom/transforms/scf/scf_unroll.c
@@ -1035,6 +1035,14 @@ typedef struct loom_scf_unroll_body_op_list_t {
   uint32_t count;
 } loom_scf_unroll_body_op_list_t;
 
+typedef uint8_t loom_scf_unroll_effect_flags_t;
+
+enum loom_scf_unroll_effect_flag_bits_e {
+  LOOM_SCF_UNROLL_EFFECT_READ = 1u << 0,
+  LOOM_SCF_UNROLL_EFFECT_WRITE = 1u << 1,
+  LOOM_SCF_UNROLL_EFFECT_ORDERED = 1u << 2,
+};
+
 typedef struct loom_scf_unroll_payload_readiness_t {
   const loom_scf_unroll_context_t* context;
   const loom_block_t* body_block;
@@ -1221,6 +1229,120 @@ static iree_status_t loom_scf_unroll_collect_interleavable_body_ops(
   return iree_ok_status();
 }
 
+static loom_scf_unroll_effect_flags_t loom_scf_unroll_op_effect_flags(
+    const loom_scf_unroll_context_t* context, const loom_op_t* op) {
+  loom_trait_flags_t traits = loom_op_effective_traits(context->module, op);
+  loom_scf_unroll_effect_flags_t flags = 0;
+  if (loom_traits_may_read(traits)) {
+    flags |= LOOM_SCF_UNROLL_EFFECT_READ;
+  }
+  if (loom_traits_may_write(traits)) {
+    flags |= LOOM_SCF_UNROLL_EFFECT_WRITE;
+  }
+  if (iree_any_bit_set(
+          traits, LOOM_TRAIT_NON_DETERMINISTIC | LOOM_TRAIT_UNKNOWN_EFFECTS |
+                      LOOM_TRAIT_HINT | LOOM_TRAIT_POISON_BOUNDARY |
+                      LOOM_TRAIT_CONVERGENT)) {
+    flags |= LOOM_SCF_UNROLL_EFFECT_ORDERED;
+  }
+  return flags;
+}
+
+static bool loom_scf_unroll_effects_conflict(
+    loom_scf_unroll_effect_flags_t prior_flags,
+    loom_scf_unroll_effect_flags_t candidate_flags) {
+  if ((prior_flags | candidate_flags) == 0) return false;
+  if (iree_any_bit_set(prior_flags | candidate_flags,
+                       LOOM_SCF_UNROLL_EFFECT_ORDERED)) {
+    return true;
+  }
+  if (!iree_any_bit_set(prior_flags | candidate_flags,
+                        LOOM_SCF_UNROLL_EFFECT_WRITE)) {
+    return false;
+  }
+  return iree_any_bit_set(prior_flags, LOOM_SCF_UNROLL_EFFECT_READ |
+                                           LOOM_SCF_UNROLL_EFFECT_WRITE) &&
+         iree_any_bit_set(candidate_flags, LOOM_SCF_UNROLL_EFFECT_READ |
+                                               LOOM_SCF_UNROLL_EFFECT_WRITE);
+}
+
+static iree_status_t loom_scf_unroll_collect_effect_flags(
+    const loom_scf_unroll_context_t* context,
+    const loom_scf_unroll_body_op_list_t* body_ops,
+    loom_scf_unroll_effect_flags_t** out_effect_flags) {
+  *out_effect_flags = NULL;
+  if (body_ops->count == 0) return iree_ok_status();
+  loom_scf_unroll_effect_flags_t* effect_flags = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_arena_allocate_array(context->pass->arena, body_ops->count,
+                                sizeof(*effect_flags), (void**)&effect_flags));
+  for (uint32_t i = 0; i < body_ops->count; ++i) {
+    effect_flags[i] =
+        loom_scf_unroll_op_effect_flags(context, body_ops->ops[i]);
+  }
+  *out_effect_flags = effect_flags;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_scf_unroll_initialize_effect_dependencies(
+    const loom_scf_unroll_context_t* context,
+    const loom_scf_unroll_body_op_list_t* body_ops,
+    const loom_scf_unroll_effect_flags_t* effect_flags, uint32_t unroll_count,
+    iree_host_size_t clone_slot_count, iree_host_size_t** out_pending_counts) {
+  *out_pending_counts = NULL;
+  if (clone_slot_count == 0) return iree_ok_status();
+  bool has_effects = false;
+  for (uint32_t i = 0; i < body_ops->count; ++i) {
+    has_effects = has_effects || effect_flags[i] != 0;
+  }
+  if (!has_effects) return iree_ok_status();
+
+  iree_host_size_t* pending_counts = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      context->pass->arena, clone_slot_count, sizeof(*pending_counts),
+      (void**)&pending_counts));
+  memset(pending_counts, 0, clone_slot_count * sizeof(*pending_counts));
+
+  for (uint32_t ordinal = 0; ordinal < unroll_count; ++ordinal) {
+    for (uint32_t op_index = 0; op_index < body_ops->count; ++op_index) {
+      const iree_host_size_t slot =
+          (iree_host_size_t)ordinal * body_ops->count + op_index;
+      const loom_scf_unroll_effect_flags_t candidate_flags =
+          effect_flags[op_index];
+      for (iree_host_size_t prior_slot = 0; prior_slot < slot; ++prior_slot) {
+        const uint32_t prior_op_index =
+            (uint32_t)(prior_slot % body_ops->count);
+        if (loom_scf_unroll_effects_conflict(effect_flags[prior_op_index],
+                                             candidate_flags)) {
+          ++pending_counts[slot];
+        }
+      }
+    }
+  }
+
+  *out_pending_counts = pending_counts;
+  return iree_ok_status();
+}
+
+static void loom_scf_unroll_release_effect_dependencies(
+    const loom_scf_unroll_body_op_list_t* body_ops,
+    const loom_scf_unroll_effect_flags_t* effect_flags,
+    iree_host_size_t clone_slot_count, iree_host_size_t cloned_slot,
+    iree_host_size_t* pending_counts) {
+  if (!pending_counts || body_ops->count == 0) return;
+  const uint32_t cloned_op_index = (uint32_t)(cloned_slot % body_ops->count);
+  const loom_scf_unroll_effect_flags_t cloned_flags =
+      effect_flags[cloned_op_index];
+  for (iree_host_size_t slot = cloned_slot + 1; slot < clone_slot_count;
+       ++slot) {
+    const uint32_t op_index = (uint32_t)(slot % body_ops->count);
+    if (pending_counts[slot] > 0 && loom_scf_unroll_effects_conflict(
+                                        cloned_flags, effect_flags[op_index])) {
+      --pending_counts[slot];
+    }
+  }
+}
+
 static iree_status_t loom_scf_unroll_body_op_payload_is_ready(
     const loom_scf_unroll_context_t* context, const loom_block_t* body_block,
     const loom_op_t* source_op, const loom_ir_remap_t* remap, bool* out_ready) {
@@ -1332,6 +1454,9 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved(
   loom_value_slice_t iter_args = loom_scf_for_iter_args(op);
   const uint32_t unroll_count = trip_count->count;
   const uint16_t carried_count = op->result_count;
+  loom_scf_unroll_effect_flags_t* effect_flags = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_scf_unroll_collect_effect_flags(context, &body_ops, &effect_flags));
   if (unroll_count == 0) {
     if (carried_count > 0) {
       IREE_RETURN_IF_ERROR(loom_rewriter_preserve_result_names_on_new_values(
@@ -1378,6 +1503,10 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved(
                                   sizeof(*cloned), (void**)&cloned));
     memset(cloned, 0, clone_slot_count * sizeof(*cloned));
   }
+  iree_host_size_t* pending_effect_dependency_counts = NULL;
+  IREE_RETURN_IF_ERROR(loom_scf_unroll_initialize_effect_dependencies(
+      context, &body_ops, effect_flags, unroll_count, clone_slot_count,
+      &pending_effect_dependency_counts));
 
   loom_value_id_t induction_variable = body_block->arg_ids[0];
   for (uint32_t ordinal = 0; ordinal < unroll_count; ++ordinal) {
@@ -1427,9 +1556,14 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved(
     for (uint32_t op_index = 0; op_index < body_ops.count; ++op_index) {
       const loom_op_t* source_op = body_ops.ops[op_index];
       for (uint32_t ordinal = 0; ordinal < unroll_count; ++ordinal) {
-        bool* cloned_slot =
-            &cloned[(iree_host_size_t)ordinal * body_ops.count + op_index];
+        const iree_host_size_t slot =
+            (iree_host_size_t)ordinal * body_ops.count + op_index;
+        bool* cloned_slot = &cloned[slot];
         if (*cloned_slot) continue;
+        if (pending_effect_dependency_counts &&
+            pending_effect_dependency_counts[slot] != 0) {
+          continue;
+        }
         bool payload_ready = false;
         IREE_RETURN_IF_ERROR(loom_scf_unroll_body_op_payload_is_ready(
             context, body_block, source_op, &remaps[ordinal], &payload_ready));
@@ -1443,6 +1577,9 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved(
         IREE_RETURN_IF_ERROR(loom_scf_unroll_rename_cloned_op_results(
             context, source_op, cloned_op, ordinal));
         *cloned_slot = true;
+        loom_scf_unroll_release_effect_dependencies(
+            &body_ops, effect_flags, clone_slot_count, slot,
+            pending_effect_dependency_counts);
         ++cloned_counts[ordinal];
         --remaining;
         made_progress = true;

--- a/loom/src/loom/transforms/scf/scf_unroll.c
+++ b/loom/src/loom/transforms/scf/scf_unroll.c
@@ -1297,10 +1297,32 @@ static void loom_scf_unroll_endpoint_region(
   };
 }
 
+static bool loom_scf_unroll_symbolic_expr_contains_value(
+    const loom_symbolic_expr_t* expression, loom_value_id_t value_id) {
+  if (!loom_symbolic_expr_is_linear(expression)) return false;
+  for (iree_host_size_t i = 0; i < expression->term_count; ++i) {
+    const loom_symbolic_term_t term = expression->terms[i];
+    if (term.value_id == value_id || term.relation_value_id == value_id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool loom_scf_unroll_endpoint_contains_value(
+    const loom_movement_endpoint_t* endpoint, loom_value_id_t value_id) {
+  return loom_scf_unroll_symbolic_expr_contains_value(
+             &endpoint->begin_byte_offset, value_id) ||
+         loom_scf_unroll_symbolic_expr_contains_value(&endpoint->byte_length,
+                                                      value_id) ||
+         loom_scf_unroll_symbolic_expr_contains_value(
+             &endpoint->end_byte_offset, value_id);
+}
+
 static iree_status_t loom_scf_unroll_endpoints_no_overlap(
     loom_movement_analysis_t* movement_analysis,
     const loom_movement_endpoint_t* left, const loom_movement_endpoint_t* right,
-    bool* out_no_overlap) {
+    loom_value_id_t varying_value_id, bool* out_no_overlap) {
   *out_no_overlap = false;
   if (left->kind != LOOM_MOVEMENT_ENDPOINT_VIEW ||
       right->kind != LOOM_MOVEMENT_ENDPOINT_VIEW) {
@@ -1309,6 +1331,11 @@ static iree_status_t loom_scf_unroll_endpoints_no_overlap(
   if (left->root_value_id == LOOM_VALUE_ID_INVALID ||
       right->root_value_id == LOOM_VALUE_ID_INVALID ||
       left->root_value_id != right->root_value_id) {
+    return iree_ok_status();
+  }
+  if (varying_value_id != LOOM_VALUE_ID_INVALID &&
+      (loom_scf_unroll_endpoint_contains_value(left, varying_value_id) ||
+       loom_scf_unroll_endpoint_contains_value(right, varying_value_id))) {
     return iree_ok_status();
   }
   loom_view_region_t left_region = {0};
@@ -1345,7 +1372,8 @@ static iree_status_t loom_scf_unroll_movement_requests_conflict(
     const loom_movement_request_t* prior_request,
     loom_scf_unroll_effect_flags_t prior_flags,
     const loom_movement_request_t* candidate_request,
-    loom_scf_unroll_effect_flags_t candidate_flags, bool* out_conflict) {
+    loom_scf_unroll_effect_flags_t candidate_flags,
+    loom_value_id_t varying_value_id, bool* out_conflict) {
   *out_conflict = true;
   const loom_movement_endpoint_t* prior_write = NULL;
   const loom_movement_endpoint_t* prior_read = NULL;
@@ -1380,7 +1408,7 @@ static iree_status_t loom_scf_unroll_movement_requests_conflict(
 
   bool no_overlap = false;
   IREE_RETURN_IF_ERROR(loom_scf_unroll_endpoints_no_overlap(
-      movement_analysis, left, right, &no_overlap));
+      movement_analysis, left, right, varying_value_id, &no_overlap));
   *out_conflict = !no_overlap;
   return iree_ok_status();
 }
@@ -1426,7 +1454,7 @@ static iree_status_t loom_scf_unroll_effects_conflict_with_movement(
     const loom_scf_unroll_effect_dependency_plan_t* plan,
     const loom_scf_unroll_effect_flags_t* effect_flags,
     uint32_t prior_effect_index, uint32_t candidate_effect_index,
-    bool* out_conflict) {
+    loom_value_id_t varying_value_id, bool* out_conflict) {
   const uint32_t prior_op_index = plan->body_op_indices[prior_effect_index];
   const uint32_t candidate_op_index =
       plan->body_op_indices[candidate_effect_index];
@@ -1448,7 +1476,7 @@ static iree_status_t loom_scf_unroll_effects_conflict_with_movement(
   return loom_scf_unroll_movement_requests_conflict(
       movement_analysis, &movement_requests[prior_effect_index], prior_flags,
       &movement_requests[candidate_effect_index], candidate_flags,
-      out_conflict);
+      varying_value_id, out_conflict);
 }
 
 static bool loom_scf_unroll_effects_conflict_is_refinable(
@@ -1610,7 +1638,7 @@ static iree_status_t loom_scf_unroll_build_effect_dependency_plan(
         status = loom_scf_unroll_effects_conflict_with_movement(
             &movement_analysis, movement_requests, described_movements, &plan,
             effect_flags, prior_effect_index, candidate_effect_index,
-            &conflicts[matrix_index]);
+            body_block->arg_ids[0], &conflicts[matrix_index]);
         if (!iree_status_is_ok(status)) break;
       }
     }

--- a/loom/src/loom/transforms/scf/scf_unroll.c
+++ b/loom/src/loom/transforms/scf/scf_unroll.c
@@ -1207,20 +1207,6 @@ static iree_status_t loom_scf_unroll_collect_interleavable_body_ops(
           LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
           IREE_SV("body operations without nested regions or successors"));
     }
-    if (op->result_count != 0) {
-      loom_trait_flags_t traits =
-          loom_op_effective_traits(context->module, body_op);
-      if (body_op->tied_result_count != 0 ||
-          !iree_any_bit_set(traits, LOOM_TRAIT_PURE) ||
-          iree_any_bit_set(traits, LOOM_TRAIT_HINT | LOOM_TRAIT_CONVERGENT) ||
-          loom_traits_may_read(traits) || loom_traits_may_write(traits)) {
-        return loom_scf_unroll_emit_policy_error(
-            context, op, IREE_SV("schedule"),
-            LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
-            IREE_SV("effect-free body operations when interleaving "
-                    "loop-carried values"));
-      }
-    }
     if (count == UINT32_MAX) {
       return loom_scf_unroll_emit_policy_error(
           context, op, IREE_SV("schedule"), count,

--- a/loom/src/loom/transforms/scf/scf_unroll.c
+++ b/loom/src/loom/transforms/scf/scf_unroll.c
@@ -9,12 +9,14 @@
 #include <inttypes.h>
 #include <stdint.h>
 
+#include "loom/analysis/movement.h"
 #include "loom/error/emitter.h"
 #include "loom/error/error_catalog.h"
 #include "loom/ir/attribute.h"
 #include "loom/ir/context.h"
 #include "loom/ir/encoding.h"
 #include "loom/ir/facts.h"
+#include "loom/ir/local_value_domain.h"
 #include "loom/ir/module.h"
 #include "loom/ir/types.h"
 #include "loom/ops/index/ops.h"
@@ -1037,6 +1039,19 @@ typedef struct loom_scf_unroll_body_op_list_t {
 
 typedef uint8_t loom_scf_unroll_effect_flags_t;
 
+#define LOOM_SCF_UNROLL_EFFECT_INDEX_INVALID UINT32_MAX
+#define LOOM_SCF_UNROLL_INTERLEAVED_EFFECT_OP_LIMIT 64
+
+typedef struct loom_scf_unroll_effect_dependency_plan_t {
+  const bool* conflicts;
+  const uint32_t* body_op_indices;
+  const uint32_t* body_to_effect_indices;
+  bool* cloned_ordinals;
+  uint32_t* completed_ordinals;
+  uint32_t effect_count;
+  uint32_t unroll_count;
+} loom_scf_unroll_effect_dependency_plan_t;
+
 enum loom_scf_unroll_effect_flag_bits_e {
   LOOM_SCF_UNROLL_EFFECT_READ = 1u << 0,
   LOOM_SCF_UNROLL_EFFECT_WRITE = 1u << 1,
@@ -1174,6 +1189,7 @@ static iree_status_t loom_scf_unroll_attr_refs_are_ready(
 static iree_status_t loom_scf_unroll_collect_interleavable_body_ops(
     const loom_scf_unroll_context_t* context, loom_op_t* op,
     const loom_block_t* body_block, const loom_op_t* yield,
+    iree_arena_allocator_t* scratch_arena,
     loom_scf_unroll_body_op_list_t* out_body_ops) {
   *out_body_ops = (loom_scf_unroll_body_op_list_t){0};
 
@@ -1214,7 +1230,7 @@ static iree_status_t loom_scf_unroll_collect_interleavable_body_ops(
   }
 
   const loom_op_t** ops = NULL;
-  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(context->pass->arena, count,
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(scratch_arena, count,
                                                  sizeof(*ops), (void**)&ops));
   uint32_t index = 0;
   for (const loom_op_t* body_op = body_block->first_op;
@@ -1266,16 +1282,120 @@ static bool loom_scf_unroll_effects_conflict(
                                                LOOM_SCF_UNROLL_EFFECT_WRITE);
 }
 
+static void loom_scf_unroll_endpoint_region(
+    const loom_movement_endpoint_t* endpoint, loom_view_region_t* out_region) {
+  *out_region = (loom_view_region_t){
+      .view_value_id = endpoint->value_id,
+      .root_value_id = endpoint->root_value_id,
+      .begin_byte_offset = endpoint->begin_byte_offset,
+      .byte_length = endpoint->byte_length,
+      .end_byte_offset = endpoint->end_byte_offset,
+      .minimum_alignment = endpoint->minimum_alignment,
+      .root_minimum_alignment = endpoint->root_minimum_alignment,
+      .memory_space = endpoint->memory_space,
+      .precision_flags = endpoint->precision_flags,
+  };
+}
+
+static iree_status_t loom_scf_unroll_endpoints_no_overlap(
+    loom_movement_analysis_t* movement_analysis,
+    const loom_movement_endpoint_t* left, const loom_movement_endpoint_t* right,
+    bool* out_no_overlap) {
+  *out_no_overlap = false;
+  if (left->kind != LOOM_MOVEMENT_ENDPOINT_VIEW ||
+      right->kind != LOOM_MOVEMENT_ENDPOINT_VIEW) {
+    return iree_ok_status();
+  }
+  if (left->root_value_id == LOOM_VALUE_ID_INVALID ||
+      right->root_value_id == LOOM_VALUE_ID_INVALID ||
+      left->root_value_id != right->root_value_id) {
+    return iree_ok_status();
+  }
+  loom_view_region_t left_region = {0};
+  loom_scf_unroll_endpoint_region(left, &left_region);
+  loom_view_region_t right_region = {0};
+  loom_scf_unroll_endpoint_region(right, &right_region);
+  return loom_view_regions_prove_no_overlap(&movement_analysis->view_regions,
+                                            &left_region, &right_region,
+                                            out_no_overlap);
+}
+
+static bool loom_scf_unroll_request_access_endpoint(
+    const loom_movement_request_t* request,
+    loom_scf_unroll_effect_flags_t flags,
+    loom_scf_unroll_effect_flags_t access_kind,
+    const loom_movement_endpoint_t** out_endpoint) {
+  *out_endpoint = NULL;
+  if (!iree_any_bit_set(flags, access_kind)) return false;
+  if (access_kind == LOOM_SCF_UNROLL_EFFECT_WRITE &&
+      request->dest.kind == LOOM_MOVEMENT_ENDPOINT_VIEW) {
+    *out_endpoint = &request->dest;
+    return true;
+  }
+  if (access_kind == LOOM_SCF_UNROLL_EFFECT_READ &&
+      request->source.kind == LOOM_MOVEMENT_ENDPOINT_VIEW) {
+    *out_endpoint = &request->source;
+    return true;
+  }
+  return false;
+}
+
+static iree_status_t loom_scf_unroll_movement_requests_conflict(
+    loom_movement_analysis_t* movement_analysis,
+    const loom_movement_request_t* prior_request,
+    loom_scf_unroll_effect_flags_t prior_flags,
+    const loom_movement_request_t* candidate_request,
+    loom_scf_unroll_effect_flags_t candidate_flags, bool* out_conflict) {
+  *out_conflict = true;
+  const loom_movement_endpoint_t* prior_write = NULL;
+  const loom_movement_endpoint_t* prior_read = NULL;
+  const loom_movement_endpoint_t* candidate_write = NULL;
+  const loom_movement_endpoint_t* candidate_read = NULL;
+  (void)loom_scf_unroll_request_access_endpoint(
+      prior_request, prior_flags, LOOM_SCF_UNROLL_EFFECT_WRITE, &prior_write);
+  (void)loom_scf_unroll_request_access_endpoint(
+      prior_request, prior_flags, LOOM_SCF_UNROLL_EFFECT_READ, &prior_read);
+  (void)loom_scf_unroll_request_access_endpoint(
+      candidate_request, candidate_flags, LOOM_SCF_UNROLL_EFFECT_WRITE,
+      &candidate_write);
+  (void)loom_scf_unroll_request_access_endpoint(
+      candidate_request, candidate_flags, LOOM_SCF_UNROLL_EFFECT_READ,
+      &candidate_read);
+
+  const loom_movement_endpoint_t* left = NULL;
+  const loom_movement_endpoint_t* right = NULL;
+  if (prior_write && candidate_write) {
+    left = prior_write;
+    right = candidate_write;
+  } else if (prior_write && candidate_read) {
+    left = prior_write;
+    right = candidate_read;
+  } else if (prior_read && candidate_write) {
+    left = prior_read;
+    right = candidate_write;
+  } else {
+    *out_conflict = false;
+    return iree_ok_status();
+  }
+
+  bool no_overlap = false;
+  IREE_RETURN_IF_ERROR(loom_scf_unroll_endpoints_no_overlap(
+      movement_analysis, left, right, &no_overlap));
+  *out_conflict = !no_overlap;
+  return iree_ok_status();
+}
+
 static iree_status_t loom_scf_unroll_collect_effect_flags(
     const loom_scf_unroll_context_t* context,
     const loom_scf_unroll_body_op_list_t* body_ops,
+    iree_arena_allocator_t* scratch_arena,
     loom_scf_unroll_effect_flags_t** out_effect_flags) {
   *out_effect_flags = NULL;
   if (body_ops->count == 0) return iree_ok_status();
   loom_scf_unroll_effect_flags_t* effect_flags = NULL;
-  IREE_RETURN_IF_ERROR(
-      iree_arena_allocate_array(context->pass->arena, body_ops->count,
-                                sizeof(*effect_flags), (void**)&effect_flags));
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(scratch_arena, body_ops->count,
+                                                 sizeof(*effect_flags),
+                                                 (void**)&effect_flags));
   for (uint32_t i = 0; i < body_ops->count; ++i) {
     effect_flags[i] =
         loom_scf_unroll_op_effect_flags(context, body_ops->ops[i]);
@@ -1284,63 +1404,293 @@ static iree_status_t loom_scf_unroll_collect_effect_flags(
   return iree_ok_status();
 }
 
-static iree_status_t loom_scf_unroll_initialize_effect_dependencies(
-    const loom_scf_unroll_context_t* context,
+static iree_status_t loom_scf_unroll_describe_movement_requests(
+    loom_movement_analysis_t* movement_analysis,
+    const loom_scf_unroll_body_op_list_t* body_ops,
+    const loom_scf_unroll_effect_dependency_plan_t* plan,
+    loom_movement_request_t* requests, bool* described) {
+  for (uint32_t i = 0; i < plan->effect_count; ++i) {
+    const uint32_t body_op_index = plan->body_op_indices[i];
+    loom_movement_diagnostic_t diagnostic = {0};
+    IREE_RETURN_IF_ERROR(loom_movement_request_describe_op(
+        movement_analysis, body_ops->ops[body_op_index], &requests[i],
+        &diagnostic, &described[i]));
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_scf_unroll_effects_conflict_with_movement(
+    loom_movement_analysis_t* movement_analysis,
+    const loom_movement_request_t* movement_requests,
+    const bool* described_movements,
+    const loom_scf_unroll_effect_dependency_plan_t* plan,
+    const loom_scf_unroll_effect_flags_t* effect_flags,
+    uint32_t prior_effect_index, uint32_t candidate_effect_index,
+    bool* out_conflict) {
+  const uint32_t prior_op_index = plan->body_op_indices[prior_effect_index];
+  const uint32_t candidate_op_index =
+      plan->body_op_indices[candidate_effect_index];
+  const loom_scf_unroll_effect_flags_t prior_flags =
+      effect_flags[prior_op_index];
+  const loom_scf_unroll_effect_flags_t candidate_flags =
+      effect_flags[candidate_op_index];
+  *out_conflict =
+      loom_scf_unroll_effects_conflict(prior_flags, candidate_flags);
+  if (!*out_conflict) return iree_ok_status();
+  if (iree_any_bit_set(prior_flags | candidate_flags,
+                       LOOM_SCF_UNROLL_EFFECT_ORDERED)) {
+    return iree_ok_status();
+  }
+  if (!described_movements[prior_effect_index] ||
+      !described_movements[candidate_effect_index]) {
+    return iree_ok_status();
+  }
+  return loom_scf_unroll_movement_requests_conflict(
+      movement_analysis, &movement_requests[prior_effect_index], prior_flags,
+      &movement_requests[candidate_effect_index], candidate_flags,
+      out_conflict);
+}
+
+static bool loom_scf_unroll_effects_conflict_is_refinable(
+    loom_scf_unroll_effect_flags_t prior_flags,
+    loom_scf_unroll_effect_flags_t candidate_flags) {
+  return loom_scf_unroll_effects_conflict(prior_flags, candidate_flags) &&
+         !iree_any_bit_set(prior_flags | candidate_flags,
+                           LOOM_SCF_UNROLL_EFFECT_ORDERED);
+}
+
+static iree_status_t loom_scf_unroll_build_effect_dependency_plan(
+    const loom_scf_unroll_context_t* context, loom_op_t* op,
+    const loom_block_t* body_block,
     const loom_scf_unroll_body_op_list_t* body_ops,
     const loom_scf_unroll_effect_flags_t* effect_flags, uint32_t unroll_count,
-    iree_host_size_t clone_slot_count, iree_host_size_t** out_pending_counts) {
-  *out_pending_counts = NULL;
-  if (clone_slot_count == 0) return iree_ok_status();
-  bool has_effects = false;
+    iree_arena_allocator_t* scratch_arena,
+    loom_scf_unroll_effect_dependency_plan_t* out_plan) {
+  *out_plan = (loom_scf_unroll_effect_dependency_plan_t){0};
+  if (body_ops->count == 0) return iree_ok_status();
+
+  uint32_t effect_count = 0;
   for (uint32_t i = 0; i < body_ops->count; ++i) {
-    has_effects = has_effects || effect_flags[i] != 0;
+    if (effect_flags[i] != 0) ++effect_count;
   }
-  if (!has_effects) return iree_ok_status();
+  if (effect_count == 0) return iree_ok_status();
 
-  iree_host_size_t* pending_counts = NULL;
+  uint32_t* body_to_effect_indices = NULL;
   IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-      context->pass->arena, clone_slot_count, sizeof(*pending_counts),
-      (void**)&pending_counts));
-  memset(pending_counts, 0, clone_slot_count * sizeof(*pending_counts));
+      scratch_arena, body_ops->count, sizeof(*body_to_effect_indices),
+      (void**)&body_to_effect_indices));
+  for (uint32_t i = 0; i < body_ops->count; ++i) {
+    body_to_effect_indices[i] = LOOM_SCF_UNROLL_EFFECT_INDEX_INVALID;
+  }
 
-  for (uint32_t ordinal = 0; ordinal < unroll_count; ++ordinal) {
-    for (uint32_t op_index = 0; op_index < body_ops->count; ++op_index) {
-      const iree_host_size_t slot =
-          (iree_host_size_t)ordinal * body_ops->count + op_index;
+  uint32_t* body_op_indices = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(scratch_arena, effect_count,
+                                                 sizeof(*body_op_indices),
+                                                 (void**)&body_op_indices));
+  uint32_t effect_index = 0;
+  for (uint32_t i = 0; i < body_ops->count; ++i) {
+    if (effect_flags[i] == 0) continue;
+    body_to_effect_indices[i] = effect_index;
+    body_op_indices[effect_index++] = i;
+  }
+
+  bool has_conflicts = false;
+  bool has_refinable_conflicts = false;
+  for (uint32_t prior_effect_index = 0; prior_effect_index < effect_count;
+       ++prior_effect_index) {
+    const uint32_t prior_op_index = body_op_indices[prior_effect_index];
+    for (uint32_t candidate_effect_index = 0;
+         candidate_effect_index < effect_count; ++candidate_effect_index) {
+      const uint32_t candidate_op_index =
+          body_op_indices[candidate_effect_index];
+      const loom_scf_unroll_effect_flags_t prior_flags =
+          effect_flags[prior_op_index];
       const loom_scf_unroll_effect_flags_t candidate_flags =
-          effect_flags[op_index];
-      for (iree_host_size_t prior_slot = 0; prior_slot < slot; ++prior_slot) {
-        const uint32_t prior_op_index =
-            (uint32_t)(prior_slot % body_ops->count);
-        if (loom_scf_unroll_effects_conflict(effect_flags[prior_op_index],
-                                             candidate_flags)) {
-          ++pending_counts[slot];
+          effect_flags[candidate_op_index];
+      const bool conflict =
+          loom_scf_unroll_effects_conflict(prior_flags, candidate_flags);
+      has_conflicts = has_conflicts || conflict;
+      has_refinable_conflicts = has_refinable_conflicts ||
+                                loom_scf_unroll_effects_conflict_is_refinable(
+                                    prior_flags, candidate_flags);
+    }
+  }
+  if (!has_conflicts) return iree_ok_status();
+  if (effect_count > LOOM_SCF_UNROLL_INTERLEAVED_EFFECT_OP_LIMIT) {
+    return loom_scf_unroll_emit_policy_error(
+        context, op, IREE_SV("schedule"), effect_count,
+        IREE_SV("effectful body operation count within interleaved scheduler "
+                "limit"));
+  }
+
+  iree_host_size_t matrix_count = 0;
+  if (!iree_host_size_checked_mul((iree_host_size_t)effect_count, effect_count,
+                                  &matrix_count)) {
+    return loom_scf_unroll_emit_policy_error(
+        context, op, IREE_SV("schedule"),
+        LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
+        IREE_SV("effect conflict matrix representable"));
+  }
+  bool* conflicts = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      scratch_arena, matrix_count, sizeof(*conflicts), (void**)&conflicts));
+  memset(conflicts, 0, matrix_count * sizeof(*conflicts));
+  for (uint32_t prior_effect_index = 0; prior_effect_index < effect_count;
+       ++prior_effect_index) {
+    const uint32_t prior_op_index = body_op_indices[prior_effect_index];
+    for (uint32_t candidate_effect_index = 0;
+         candidate_effect_index < effect_count; ++candidate_effect_index) {
+      const uint32_t candidate_op_index =
+          body_op_indices[candidate_effect_index];
+      const iree_host_size_t matrix_index =
+          (iree_host_size_t)prior_effect_index * effect_count +
+          candidate_effect_index;
+      conflicts[matrix_index] = loom_scf_unroll_effects_conflict(
+          effect_flags[prior_op_index], effect_flags[candidate_op_index]);
+    }
+  }
+
+  loom_local_value_domain_t value_domain = {0};
+  loom_movement_analysis_t movement_analysis = {0};
+  loom_movement_request_t* movement_requests = NULL;
+  bool* described_movements = NULL;
+  iree_status_t status = iree_ok_status();
+  loom_scf_unroll_effect_dependency_plan_t plan = {
+      .conflicts = conflicts,
+      .body_op_indices = body_op_indices,
+      .body_to_effect_indices = body_to_effect_indices,
+      .effect_count = effect_count,
+      .unroll_count = unroll_count,
+  };
+  if (has_refinable_conflicts) {
+    status = loom_local_value_domain_acquire_for_region(
+        context->module, body_block->parent_region, scratch_arena,
+        &value_domain);
+    if (iree_status_is_ok(status)) {
+      status =
+          loom_movement_analysis_initialize(context->fact_table, &value_domain,
+                                            scratch_arena, &movement_analysis);
+    }
+    if (iree_status_is_ok(status)) {
+      status = loom_movement_analysis_analyze(&movement_analysis);
+    }
+    if (iree_status_is_ok(status)) {
+      status = iree_arena_allocate_array(scratch_arena, effect_count,
+                                         sizeof(*movement_requests),
+                                         (void**)&movement_requests);
+    }
+    if (iree_status_is_ok(status)) {
+      status = iree_arena_allocate_array(scratch_arena, effect_count,
+                                         sizeof(*described_movements),
+                                         (void**)&described_movements);
+    }
+    if (iree_status_is_ok(status)) {
+      memset(described_movements, 0,
+             (iree_host_size_t)effect_count * sizeof(*described_movements));
+      status = loom_scf_unroll_describe_movement_requests(
+          &movement_analysis, body_ops, &plan, movement_requests,
+          described_movements);
+    }
+    for (uint32_t prior_effect_index = 0;
+         iree_status_is_ok(status) && prior_effect_index < effect_count;
+         ++prior_effect_index) {
+      const uint32_t prior_op_index = body_op_indices[prior_effect_index];
+      for (uint32_t candidate_effect_index = 0;
+           candidate_effect_index < effect_count; ++candidate_effect_index) {
+        const uint32_t candidate_op_index =
+            body_op_indices[candidate_effect_index];
+        if (!loom_scf_unroll_effects_conflict_is_refinable(
+                effect_flags[prior_op_index],
+                effect_flags[candidate_op_index])) {
+          continue;
         }
+        const iree_host_size_t matrix_index =
+            (iree_host_size_t)prior_effect_index * effect_count +
+            candidate_effect_index;
+        status = loom_scf_unroll_effects_conflict_with_movement(
+            &movement_analysis, movement_requests, described_movements, &plan,
+            effect_flags, prior_effect_index, candidate_effect_index,
+            &conflicts[matrix_index]);
+        if (!iree_status_is_ok(status)) break;
       }
     }
   }
 
-  *out_pending_counts = pending_counts;
+  loom_local_value_domain_release(&value_domain);
+  IREE_RETURN_IF_ERROR(status);
+
+  bool has_remaining_conflicts = false;
+  for (iree_host_size_t i = 0; i < matrix_count; ++i) {
+    has_remaining_conflicts = has_remaining_conflicts || conflicts[i];
+  }
+  if (!has_remaining_conflicts) return iree_ok_status();
+
+  iree_host_size_t cloned_ordinal_count = 0;
+  if (!iree_host_size_checked_mul((iree_host_size_t)effect_count, unroll_count,
+                                  &cloned_ordinal_count)) {
+    return loom_scf_unroll_emit_policy_error(
+        context, op, IREE_SV("schedule"),
+        LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
+        IREE_SV("effect dependency state representable"));
+  }
+  bool* cloned_ordinals = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      scratch_arena, cloned_ordinal_count, sizeof(*cloned_ordinals),
+      (void**)&cloned_ordinals));
+  memset(cloned_ordinals, 0, cloned_ordinal_count * sizeof(*cloned_ordinals));
+  uint32_t* completed_ordinals = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(scratch_arena, effect_count,
+                                                 sizeof(*completed_ordinals),
+                                                 (void**)&completed_ordinals));
+  memset(completed_ordinals, 0,
+         (iree_host_size_t)effect_count * sizeof(*completed_ordinals));
+
+  plan.cloned_ordinals = cloned_ordinals;
+  plan.completed_ordinals = completed_ordinals;
+  *out_plan = plan;
   return iree_ok_status();
 }
 
-static void loom_scf_unroll_release_effect_dependencies(
-    const loom_scf_unroll_body_op_list_t* body_ops,
-    const loom_scf_unroll_effect_flags_t* effect_flags,
-    iree_host_size_t clone_slot_count, iree_host_size_t cloned_slot,
-    iree_host_size_t* pending_counts) {
-  if (!pending_counts || body_ops->count == 0) return;
-  const uint32_t cloned_op_index = (uint32_t)(cloned_slot % body_ops->count);
-  const loom_scf_unroll_effect_flags_t cloned_flags =
-      effect_flags[cloned_op_index];
-  for (iree_host_size_t slot = cloned_slot + 1; slot < clone_slot_count;
-       ++slot) {
-    const uint32_t op_index = (uint32_t)(slot % body_ops->count);
-    if (pending_counts[slot] > 0 && loom_scf_unroll_effects_conflict(
-                                        cloned_flags, effect_flags[op_index])) {
-      --pending_counts[slot];
+static bool loom_scf_unroll_effect_dependencies_are_ready(
+    const loom_scf_unroll_effect_dependency_plan_t* plan, uint32_t op_index,
+    uint32_t ordinal) {
+  if (!plan->conflicts) return true;
+  const uint32_t effect_index = plan->body_to_effect_indices[op_index];
+  if (effect_index == LOOM_SCF_UNROLL_EFFECT_INDEX_INVALID) return true;
+  for (uint32_t prior_effect_index = 0; prior_effect_index < plan->effect_count;
+       ++prior_effect_index) {
+    const iree_host_size_t matrix_index =
+        (iree_host_size_t)prior_effect_index * plan->effect_count +
+        effect_index;
+    if (!plan->conflicts[matrix_index]) continue;
+    const uint32_t prior_op_index = plan->body_op_indices[prior_effect_index];
+    const uint32_t required_completed_ordinal =
+        ordinal + (prior_op_index < op_index ? 1u : 0u);
+    if (plan->completed_ordinals[prior_effect_index] <
+        required_completed_ordinal) {
+      return false;
     }
   }
+  return true;
+}
+
+static void loom_scf_unroll_release_effect_dependencies(
+    loom_scf_unroll_effect_dependency_plan_t* plan, uint32_t op_index,
+    uint32_t ordinal) {
+  if (!plan->conflicts) return;
+  const uint32_t effect_index = plan->body_to_effect_indices[op_index];
+  if (effect_index == LOOM_SCF_UNROLL_EFFECT_INDEX_INVALID) return;
+  const iree_host_size_t ordinal_index =
+      (iree_host_size_t)effect_index * plan->unroll_count + ordinal;
+  plan->cloned_ordinals[ordinal_index] = true;
+  uint32_t completed_ordinal = plan->completed_ordinals[effect_index];
+  while (completed_ordinal < plan->unroll_count &&
+         plan->cloned_ordinals[(iree_host_size_t)effect_index *
+                                   plan->unroll_count +
+                               completed_ordinal]) {
+    ++completed_ordinal;
+  }
+  plan->completed_ordinals[effect_index] = completed_ordinal;
 }
 
 static iree_status_t loom_scf_unroll_body_op_payload_is_ready(
@@ -1412,6 +1762,7 @@ static iree_status_t loom_scf_unroll_mark_iteration_complete(
     loom_scf_unroll_context_t* context, const loom_block_t* body_block,
     const loom_op_t* yield, uint32_t ordinal, uint32_t trip_count,
     uint16_t carried_count, loom_ir_remap_t* remaps,
+    iree_arena_allocator_t* scratch_arena,
     loom_value_id_t* final_carried_values) {
   if (carried_count == 0) return iree_ok_status();
 
@@ -1419,9 +1770,9 @@ static iree_status_t loom_scf_unroll_mark_iteration_complete(
   loom_value_id_t* resolved_values = final_carried_values;
   if (ordinal + 1 < trip_count) {
     resolved_values = NULL;
-    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-        context->pass->arena, carried_count, sizeof(*resolved_values),
-        (void**)&resolved_values));
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(scratch_arena, carried_count,
+                                                   sizeof(*resolved_values),
+                                                   (void**)&resolved_values));
   }
   for (uint16_t i = 0; i < carried_count; ++i) {
     IREE_RETURN_IF_ERROR(loom_ir_remap_resolve_value(
@@ -1437,16 +1788,17 @@ static iree_status_t loom_scf_unroll_mark_iteration_complete(
   return iree_ok_status();
 }
 
-static iree_status_t loom_scf_unroll_full_unroll_interleaved(
+static iree_status_t loom_scf_unroll_full_unroll_interleaved_with_arena(
     loom_scf_unroll_context_t* context, loom_op_t* op, loom_op_t* yield,
-    const loom_scf_unroll_trip_count_t* trip_count, bool* out_changed) {
+    const loom_scf_unroll_trip_count_t* trip_count,
+    iree_arena_allocator_t* scratch_arena, bool* out_changed) {
   *out_changed = false;
 
   loom_region_t* body = loom_scf_for_body(op);
   loom_block_t* body_block = loom_region_entry_block(body);
   loom_scf_unroll_body_op_list_t body_ops = {0};
   IREE_RETURN_IF_ERROR(loom_scf_unroll_collect_interleavable_body_ops(
-      context, op, body_block, yield, &body_ops));
+      context, op, body_block, yield, scratch_arena, &body_ops));
 
   loom_builder_set_before(&context->rewriter->builder, op);
   loom_value_id_t value_checkpoint =
@@ -1455,8 +1807,8 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved(
   const uint32_t unroll_count = trip_count->count;
   const uint16_t carried_count = op->result_count;
   loom_scf_unroll_effect_flags_t* effect_flags = NULL;
-  IREE_RETURN_IF_ERROR(
-      loom_scf_unroll_collect_effect_flags(context, &body_ops, &effect_flags));
+  IREE_RETURN_IF_ERROR(loom_scf_unroll_collect_effect_flags(
+      context, &body_ops, scratch_arena, &effect_flags));
   if (unroll_count == 0) {
     if (carried_count > 0) {
       IREE_RETURN_IF_ERROR(loom_rewriter_preserve_result_names_on_new_values(
@@ -1474,17 +1826,17 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved(
 
   loom_ir_remap_t* remaps = NULL;
   IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-      context->pass->arena, unroll_count, sizeof(*remaps), (void**)&remaps));
+      scratch_arena, unroll_count, sizeof(*remaps), (void**)&remaps));
   bool* completed_iterations = NULL;
   IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-      context->pass->arena, unroll_count, sizeof(*completed_iterations),
+      scratch_arena, unroll_count, sizeof(*completed_iterations),
       (void**)&completed_iterations));
   memset(completed_iterations, 0,
          (iree_host_size_t)unroll_count * sizeof(*completed_iterations));
   uint32_t* cloned_counts = NULL;
-  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-      context->pass->arena, unroll_count, sizeof(*cloned_counts),
-      (void**)&cloned_counts));
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(scratch_arena, unroll_count,
+                                                 sizeof(*cloned_counts),
+                                                 (void**)&cloned_counts));
   memset(cloned_counts, 0,
          (iree_host_size_t)unroll_count * sizeof(*cloned_counts));
 
@@ -1498,20 +1850,19 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved(
         IREE_SV("unroll count * body operation count representable"));
   }
   if (clone_slot_count != 0) {
-    IREE_RETURN_IF_ERROR(
-        iree_arena_allocate_array(context->pass->arena, clone_slot_count,
-                                  sizeof(*cloned), (void**)&cloned));
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        scratch_arena, clone_slot_count, sizeof(*cloned), (void**)&cloned));
     memset(cloned, 0, clone_slot_count * sizeof(*cloned));
   }
-  iree_host_size_t* pending_effect_dependency_counts = NULL;
-  IREE_RETURN_IF_ERROR(loom_scf_unroll_initialize_effect_dependencies(
-      context, &body_ops, effect_flags, unroll_count, clone_slot_count,
-      &pending_effect_dependency_counts));
+  loom_scf_unroll_effect_dependency_plan_t effect_dependency_plan = {0};
+  IREE_RETURN_IF_ERROR(loom_scf_unroll_build_effect_dependency_plan(
+      context, op, body_block, &body_ops, effect_flags, unroll_count,
+      scratch_arena, &effect_dependency_plan));
 
   loom_value_id_t induction_variable = body_block->arg_ids[0];
   for (uint32_t ordinal = 0; ordinal < unroll_count; ++ordinal) {
     IREE_RETURN_IF_ERROR(loom_ir_remap_initialize(
-        context->module, context->module, context->pass->arena,
+        context->module, context->module, scratch_arena,
         &(loom_ir_remap_options_t){
             .allow_unmapped_values = true,
             .remap_symbol = loom_ir_remap_symbol_callback_empty(),
@@ -1538,7 +1889,7 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved(
   loom_value_id_t* final_carried_values = NULL;
   if (carried_count > 0) {
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-        context->pass->arena, carried_count, sizeof(*final_carried_values),
+        scratch_arena, carried_count, sizeof(*final_carried_values),
         (void**)&final_carried_values));
   }
 
@@ -1546,7 +1897,7 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved(
     for (uint32_t ordinal = 0; ordinal < unroll_count; ++ordinal) {
       IREE_RETURN_IF_ERROR(loom_scf_unroll_mark_iteration_complete(
           context, body_block, yield, ordinal, unroll_count, carried_count,
-          remaps, final_carried_values));
+          remaps, scratch_arena, final_carried_values));
     }
   }
 
@@ -1560,8 +1911,8 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved(
             (iree_host_size_t)ordinal * body_ops.count + op_index;
         bool* cloned_slot = &cloned[slot];
         if (*cloned_slot) continue;
-        if (pending_effect_dependency_counts &&
-            pending_effect_dependency_counts[slot] != 0) {
+        if (!loom_scf_unroll_effect_dependencies_are_ready(
+                &effect_dependency_plan, op_index, ordinal)) {
           continue;
         }
         bool payload_ready = false;
@@ -1577,9 +1928,8 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved(
         IREE_RETURN_IF_ERROR(loom_scf_unroll_rename_cloned_op_results(
             context, source_op, cloned_op, ordinal));
         *cloned_slot = true;
-        loom_scf_unroll_release_effect_dependencies(
-            &body_ops, effect_flags, clone_slot_count, slot,
-            pending_effect_dependency_counts);
+        loom_scf_unroll_release_effect_dependencies(&effect_dependency_plan,
+                                                    op_index, ordinal);
         ++cloned_counts[ordinal];
         --remaining;
         made_progress = true;
@@ -1587,7 +1937,7 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved(
             !completed_iterations[ordinal]) {
           IREE_RETURN_IF_ERROR(loom_scf_unroll_mark_iteration_complete(
               context, body_block, yield, ordinal, unroll_count, carried_count,
-              remaps, final_carried_values));
+              remaps, scratch_arena, final_carried_values));
           completed_iterations[ordinal] = true;
         }
       }
@@ -1614,6 +1964,17 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved(
   context->statistics->iterations_materialized += unroll_count;
   *out_changed = true;
   return iree_ok_status();
+}
+
+static iree_status_t loom_scf_unroll_full_unroll_interleaved(
+    loom_scf_unroll_context_t* context, loom_op_t* op, loom_op_t* yield,
+    const loom_scf_unroll_trip_count_t* trip_count, bool* out_changed) {
+  iree_arena_allocator_t scratch_arena;
+  iree_arena_initialize(context->pass->arena->block_pool, &scratch_arena);
+  iree_status_t status = loom_scf_unroll_full_unroll_interleaved_with_arena(
+      context, op, yield, trip_count, &scratch_arena, out_changed);
+  iree_arena_deinitialize(&scratch_arena);
+  return status;
 }
 
 static iree_status_t loom_scf_unroll_try_unroll(

--- a/loom/src/loom/transforms/scf/scf_unroll.c
+++ b/loom/src/loom/transforms/scf/scf_unroll.c
@@ -1179,6 +1179,20 @@ static iree_status_t loom_scf_unroll_collect_interleavable_body_ops(
           LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
           IREE_SV("body operations without nested regions or successors"));
     }
+    if (op->result_count != 0) {
+      loom_trait_flags_t traits =
+          loom_op_effective_traits(context->module, body_op);
+      if (body_op->tied_result_count != 0 ||
+          !iree_any_bit_set(traits, LOOM_TRAIT_PURE) ||
+          iree_any_bit_set(traits, LOOM_TRAIT_HINT | LOOM_TRAIT_CONVERGENT) ||
+          loom_traits_may_read(traits) || loom_traits_may_write(traits)) {
+        return loom_scf_unroll_emit_policy_error(
+            context, op, IREE_SV("schedule"),
+            LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
+            IREE_SV("effect-free body operations when interleaving "
+                    "loop-carried values"));
+      }
+    }
     if (count == UINT32_MAX) {
       return loom_scf_unroll_emit_policy_error(
           context, op, IREE_SV("schedule"), count,

--- a/loom/src/loom/transforms/scf/scf_unroll.c
+++ b/loom/src/loom/transforms/scf/scf_unroll.c
@@ -158,6 +158,7 @@ typedef enum loom_scf_unroll_lower_bound_kind_e {
 
 typedef enum loom_scf_unroll_partial_unroll_flag_bits_e {
   LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_GUARD_TAIL = 1u << 0,
+  LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_TAIL_LOOP = 1u << 1,
 } loom_scf_unroll_partial_unroll_flag_bits_t;
 typedef uint32_t loom_scf_unroll_partial_unroll_flags_t;
 
@@ -363,7 +364,7 @@ static iree_status_t loom_scf_unroll_append_report_detail(
     return iree_ok_status();
   }
 
-  loom_pass_report_detail_field_t fields[12];
+  loom_pass_report_detail_field_t fields[11];
   uint16_t field_count = 0;
   fields[field_count++] = loom_pass_report_detail_string_field(
       IREE_SV("outcome"), IREE_SV("unrolled"));
@@ -412,7 +413,7 @@ static iree_status_t loom_scf_unroll_append_partial_report_detail(
     return iree_ok_status();
   }
 
-  loom_pass_report_detail_field_t fields[12];
+  loom_pass_report_detail_field_t fields[11];
   uint16_t field_count = 0;
   fields[field_count++] = loom_pass_report_detail_string_field(
       IREE_SV("outcome"), IREE_SV("stripmined"));
@@ -429,6 +430,9 @@ static iree_status_t loom_scf_unroll_append_partial_report_detail(
   fields[field_count++] = loom_pass_report_detail_bool_field(
       IREE_SV("tail_guards"),
       iree_any_bit_set(flags, LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_GUARD_TAIL));
+  fields[field_count++] = loom_pass_report_detail_bool_field(
+      IREE_SV("tail_loop"),
+      iree_any_bit_set(flags, LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_TAIL_LOOP));
   fields[field_count++] = loom_pass_report_detail_string_field(
       IREE_SV("trip_count_state"),
       loom_scf_unroll_trip_count_state_name(trip_count_state));
@@ -1816,39 +1820,26 @@ static iree_status_t loom_scf_unroll_mark_iteration_complete(
   return iree_ok_status();
 }
 
-static iree_status_t loom_scf_unroll_full_unroll_interleaved_with_arena(
-    loom_scf_unroll_context_t* context, loom_op_t* op, loom_op_t* yield,
+static iree_status_t loom_scf_unroll_emit_interleaved_tile(
+    loom_scf_unroll_context_t* context, loom_op_t* op,
+    const loom_block_t* body_block, loom_op_t* yield,
     const loom_scf_unroll_trip_count_t* trip_count,
-    iree_arena_allocator_t* scratch_arena, bool* out_changed) {
-  *out_changed = false;
-
-  loom_region_t* body = loom_scf_for_body(op);
-  loom_block_t* body_block = loom_region_entry_block(body);
+    const loom_value_id_t* initial_carried_values, uint16_t carried_count,
+    iree_arena_allocator_t* scratch_arena,
+    loom_value_id_t* final_carried_values) {
   loom_scf_unroll_body_op_list_t body_ops = {0};
   IREE_RETURN_IF_ERROR(loom_scf_unroll_collect_interleavable_body_ops(
       context, op, body_block, yield, scratch_arena, &body_ops));
 
-  loom_builder_set_before(&context->rewriter->builder, op);
-  loom_value_id_t value_checkpoint =
-      loom_rewriter_value_checkpoint(context->rewriter);
-  loom_value_slice_t iter_args = loom_scf_for_iter_args(op);
   const uint32_t unroll_count = trip_count->count;
-  const uint16_t carried_count = op->result_count;
   loom_scf_unroll_effect_flags_t* effect_flags = NULL;
   IREE_RETURN_IF_ERROR(loom_scf_unroll_collect_effect_flags(
       context, &body_ops, scratch_arena, &effect_flags));
   if (unroll_count == 0) {
     if (carried_count > 0) {
-      IREE_RETURN_IF_ERROR(loom_rewriter_preserve_result_names_on_new_values(
-          context->rewriter, op, iter_args.values, carried_count,
-          value_checkpoint));
-      IREE_RETURN_IF_ERROR(loom_rewriter_replace_all_uses_and_erase(
-          context->rewriter, op, iter_args.values, carried_count));
-    } else {
-      IREE_RETURN_IF_ERROR(loom_rewriter_erase(context->rewriter, op));
+      memcpy(final_carried_values, initial_carried_values,
+             (iree_host_size_t)carried_count * sizeof(*final_carried_values));
     }
-    ++context->statistics->loops_unrolled;
-    *out_changed = true;
     return iree_ok_status();
   }
 
@@ -1911,14 +1902,7 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved_with_arena(
 
   for (uint16_t i = 0; i < carried_count; ++i) {
     IREE_RETURN_IF_ERROR(loom_ir_remap_map_value(
-        &remaps[0], body_block->arg_ids[1 + i], iter_args.values[i]));
-  }
-
-  loom_value_id_t* final_carried_values = NULL;
-  if (carried_count > 0) {
-    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-        scratch_arena, carried_count, sizeof(*final_carried_values),
-        (void**)&final_carried_values));
+        &remaps[0], body_block->arg_ids[1 + i], initial_carried_values[i]));
   }
 
   if (body_ops.count == 0) {
@@ -1978,6 +1962,33 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved_with_arena(
     }
   }
 
+  return iree_ok_status();
+}
+
+static iree_status_t loom_scf_unroll_full_unroll_interleaved_with_arena(
+    loom_scf_unroll_context_t* context, loom_op_t* op, loom_op_t* yield,
+    const loom_scf_unroll_trip_count_t* trip_count,
+    iree_arena_allocator_t* scratch_arena, bool* out_changed) {
+  *out_changed = false;
+
+  loom_region_t* body = loom_scf_for_body(op);
+  loom_block_t* body_block = loom_region_entry_block(body);
+  loom_value_slice_t iter_args = loom_scf_for_iter_args(op);
+  const uint16_t carried_count = op->result_count;
+  loom_value_id_t* final_carried_values = NULL;
+  if (carried_count > 0) {
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        scratch_arena, carried_count, sizeof(*final_carried_values),
+        (void**)&final_carried_values));
+  }
+
+  loom_builder_set_before(&context->rewriter->builder, op);
+  loom_value_id_t value_checkpoint =
+      loom_rewriter_value_checkpoint(context->rewriter);
+  IREE_RETURN_IF_ERROR(loom_scf_unroll_emit_interleaved_tile(
+      context, op, body_block, yield, trip_count, iter_args.values,
+      carried_count, scratch_arena, final_carried_values));
+
   if (carried_count > 0) {
     IREE_RETURN_IF_ERROR(loom_rewriter_preserve_result_names_on_new_values(
         context->rewriter, op, final_carried_values, carried_count,
@@ -1989,7 +2000,7 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved_with_arena(
   }
 
   ++context->statistics->loops_unrolled;
-  context->statistics->iterations_materialized += unroll_count;
+  context->statistics->iterations_materialized += trip_count->count;
   *out_changed = true;
   return iree_ok_status();
 }
@@ -2001,6 +2012,291 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved(
   iree_arena_initialize(context->pass->arena->block_pool, &scratch_arena);
   iree_status_t status = loom_scf_unroll_full_unroll_interleaved_with_arena(
       context, op, yield, trip_count, &scratch_arena, out_changed);
+  iree_arena_deinitialize(&scratch_arena);
+  return status;
+}
+
+static iree_status_t loom_scf_unroll_build_exact_interleaved_main_upper(
+    loom_scf_unroll_context_t* context, loom_op_t* op,
+    const loom_scf_unroll_trip_count_t* trip_count, uint32_t unroll_factor,
+    loom_type_t index_type, loom_value_id_t* out_scaled_step,
+    loom_value_id_t* out_main_upper) {
+  *out_scaled_step = LOOM_VALUE_ID_INVALID;
+  *out_main_upper = LOOM_VALUE_ID_INVALID;
+
+  IREE_RETURN_IF_ERROR(loom_scf_unroll_build_scaled_step(
+      context, op, trip_count->step, unroll_factor, index_type,
+      out_scaled_step));
+
+  const uint32_t main_iteration_count =
+      (trip_count->count / unroll_factor) * unroll_factor;
+  int64_t main_span = 0;
+  if (!iree_checked_mul_i64((int64_t)main_iteration_count, trip_count->step,
+                            &main_span)) {
+    return loom_scf_unroll_emit_policy_error(
+        context, op, IREE_SV("schedule"), main_iteration_count,
+        IREE_SV("main interleaved iteration span representable as i64"));
+  }
+
+  switch (trip_count->lower_kind) {
+    case LOOM_SCF_UNROLL_LOWER_BOUND_STATIC: {
+      int64_t main_upper = 0;
+      if (!iree_checked_add_i64(trip_count->lower_i64, main_span,
+                                &main_upper)) {
+        return loom_scf_unroll_emit_policy_error(
+            context, op, IREE_SV("schedule"), main_span,
+            IREE_SV("main interleaved upper bound representable as i64"));
+      }
+      loom_op_t* upper_op = NULL;
+      IREE_RETURN_IF_ERROR(loom_index_constant_build(
+          &context->rewriter->builder, loom_attr_i64(main_upper), index_type,
+          op->location, &upper_op));
+      *out_main_upper = loom_index_constant_result(upper_op);
+      return iree_ok_status();
+    }
+    case LOOM_SCF_UNROLL_LOWER_BOUND_DYNAMIC:
+      if (main_span == 0) {
+        *out_main_upper = trip_count->lower_value;
+        return iree_ok_status();
+      }
+      loom_op_t* span_op = NULL;
+      IREE_RETURN_IF_ERROR(loom_index_constant_build(
+          &context->rewriter->builder, loom_attr_i64(main_span), index_type,
+          op->location, &span_op));
+      loom_op_t* upper_op = NULL;
+      IREE_RETURN_IF_ERROR(loom_index_add_build(
+          &context->rewriter->builder, trip_count->lower_value,
+          loom_index_constant_result(span_op), index_type, op->location,
+          &upper_op));
+      *out_main_upper = loom_index_add_result(upper_op);
+      return iree_ok_status();
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_scf_unroll_build_dynamic_interleaved_main_upper(
+    loom_scf_unroll_context_t* context, loom_op_t* op, int64_t step,
+    uint32_t unroll_factor, loom_type_t index_type,
+    loom_value_id_t* out_scaled_step, loom_value_id_t* out_main_upper) {
+  *out_scaled_step = LOOM_VALUE_ID_INVALID;
+  *out_main_upper = LOOM_VALUE_ID_INVALID;
+
+  IREE_RETURN_IF_ERROR(loom_scf_unroll_build_scaled_step(
+      context, op, step, unroll_factor, index_type, out_scaled_step));
+
+  loom_op_t* zero_op = NULL;
+  IREE_RETURN_IF_ERROR(loom_index_constant_build(&context->rewriter->builder,
+                                                 loom_attr_i64(0), index_type,
+                                                 op->location, &zero_op));
+  const loom_value_id_t zero = loom_index_constant_result(zero_op);
+
+  loom_op_t* span_op = NULL;
+  IREE_RETURN_IF_ERROR(loom_index_sub_build(
+      &context->rewriter->builder, loom_scf_for_upper_bound(op),
+      loom_scf_for_lower_bound(op), index_type, op->location, &span_op));
+  loom_op_t* non_negative_span_op = NULL;
+  IREE_RETURN_IF_ERROR(loom_index_max_build(
+      &context->rewriter->builder, loom_index_sub_result(span_op), zero,
+      index_type, op->location, &non_negative_span_op));
+  loom_value_id_t trip_count = loom_index_max_result(non_negative_span_op);
+  if (step != 1) {
+    loom_op_t* step_minus_one_op = NULL;
+    IREE_RETURN_IF_ERROR(loom_index_constant_build(
+        &context->rewriter->builder, loom_attr_i64(step - 1), index_type,
+        op->location, &step_minus_one_op));
+    loom_op_t* padded_span_op = NULL;
+    IREE_RETURN_IF_ERROR(
+        loom_index_add_build(&context->rewriter->builder, trip_count,
+                             loom_index_constant_result(step_minus_one_op),
+                             index_type, op->location, &padded_span_op));
+    loom_op_t* trip_count_op = NULL;
+    IREE_RETURN_IF_ERROR(loom_index_div_build(
+        &context->rewriter->builder, loom_index_add_result(padded_span_op),
+        loom_scf_for_step(op), index_type, op->location, &trip_count_op));
+    trip_count = loom_index_div_result(trip_count_op);
+  }
+
+  loom_op_t* tile_count_op = NULL;
+  IREE_RETURN_IF_ERROR(loom_index_div_build(
+      &context->rewriter->builder, trip_count, loom_scf_for_unroll_factor(op),
+      index_type, op->location, &tile_count_op));
+  loom_op_t* main_span_op = NULL;
+  IREE_RETURN_IF_ERROR(loom_index_mul_build(
+      &context->rewriter->builder, loom_index_div_result(tile_count_op),
+      *out_scaled_step, index_type, op->location, &main_span_op));
+  loom_op_t* main_upper_op = NULL;
+  IREE_RETURN_IF_ERROR(loom_index_add_build(
+      &context->rewriter->builder, loom_scf_for_lower_bound(op),
+      loom_index_mul_result(main_span_op), index_type, op->location,
+      &main_upper_op));
+  *out_main_upper = loom_index_add_result(main_upper_op);
+  return iree_ok_status();
+}
+
+static iree_status_t loom_scf_unroll_clone_loop_body(
+    loom_scf_unroll_context_t* context, const loom_block_t* source_block,
+    loom_block_t* target_block, iree_arena_allocator_t* scratch_arena) {
+  loom_ir_remap_t remap = {0};
+  IREE_RETURN_IF_ERROR(loom_ir_remap_initialize(
+      context->module, context->module, scratch_arena,
+      &(loom_ir_remap_options_t){
+          .allow_unmapped_values = true,
+          .remap_symbol = loom_ir_remap_symbol_callback_empty(),
+      },
+      &remap));
+  for (uint16_t i = 0; i < source_block->arg_count; ++i) {
+    IREE_RETURN_IF_ERROR(loom_rewriter_copy_value_name(
+        context->rewriter, loom_block_arg_id(source_block, i),
+        loom_block_arg_id(target_block, i)));
+    IREE_RETURN_IF_ERROR(
+        loom_ir_remap_map_value(&remap, loom_block_arg_id(source_block, i),
+                                loom_block_arg_id(target_block, i)));
+  }
+  return loom_ir_clone_block_ops(&context->rewriter->builder, source_block,
+                                 &remap, NULL);
+}
+
+static iree_status_t loom_scf_unroll_partial_unroll_interleaved_with_arena(
+    loom_scf_unroll_context_t* context, loom_op_t* op, loom_op_t* yield,
+    int64_t step, uint32_t unroll_factor,
+    const loom_scf_unroll_trip_count_t* trip_count, bool tail_loop_required,
+    iree_arena_allocator_t* scratch_arena, bool* out_changed) {
+  *out_changed = false;
+
+  loom_type_t* result_types = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_scf_unroll_copy_result_types(context, op, &result_types));
+
+  loom_value_slice_t iter_args = loom_scf_for_iter_args(op);
+  loom_tied_result_t* tied_results = NULL;
+  uint16_t tied_result_count = 0;
+  IREE_RETURN_IF_ERROR(loom_scf_unroll_adjust_tied_results_for_policy_clear(
+      context, op, iter_args, &tied_results, &tied_result_count));
+
+  loom_builder_set_before(&context->rewriter->builder, op);
+  loom_value_id_t value_checkpoint =
+      loom_rewriter_value_checkpoint(context->rewriter);
+  loom_type_t index_type =
+      loom_module_value_type(context->module, loom_scf_for_lower_bound(op));
+
+  loom_value_id_t scaled_step = LOOM_VALUE_ID_INVALID;
+  loom_value_id_t main_upper = LOOM_VALUE_ID_INVALID;
+  if (trip_count) {
+    IREE_RETURN_IF_ERROR(loom_scf_unroll_build_exact_interleaved_main_upper(
+        context, op, trip_count, unroll_factor, index_type, &scaled_step,
+        &main_upper));
+  } else {
+    IREE_RETURN_IF_ERROR(loom_scf_unroll_build_dynamic_interleaved_main_upper(
+        context, op, step, unroll_factor, index_type, &scaled_step,
+        &main_upper));
+  }
+
+  loom_op_t* main_loop = NULL;
+  IREE_RETURN_IF_ERROR(loom_scf_for_build(
+      &context->rewriter->builder, /*build_flags=*/0,
+      loom_scf_for_lower_bound(op), main_upper, scaled_step, iter_args.values,
+      iter_args.count, result_types, op->result_count, tied_results,
+      tied_result_count, LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0,
+      /*unroll_schedule=*/0, op->location, &main_loop));
+
+  loom_region_t* old_body = loom_scf_for_body(op);
+  loom_block_t* old_block = loom_region_entry_block(old_body);
+  loom_region_t* main_body = loom_scf_for_body(main_loop);
+  loom_builder_ip_t saved_ip = loom_builder_enter_region(
+      &context->rewriter->builder, main_loop, main_body);
+  loom_block_t* main_block = loom_region_entry_block(main_body);
+  for (uint16_t i = 0; i < old_block->arg_count; ++i) {
+    IREE_RETURN_IF_ERROR(loom_rewriter_copy_value_name(
+        context->rewriter, loom_block_arg_id(old_block, i),
+        loom_block_arg_id(main_block, i)));
+  }
+
+  loom_value_id_t* main_carried_values = NULL;
+  loom_value_id_t* final_main_carried_values = NULL;
+  if (op->result_count > 0) {
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        scratch_arena, op->result_count, sizeof(*main_carried_values),
+        (void**)&main_carried_values));
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        scratch_arena, op->result_count, sizeof(*final_main_carried_values),
+        (void**)&final_main_carried_values));
+    for (uint16_t i = 0; i < op->result_count; ++i) {
+      main_carried_values[i] = loom_block_arg_id(main_block, (uint16_t)(1 + i));
+    }
+  }
+
+  loom_scf_unroll_trip_count_t tile_trip_count = {
+      .count = unroll_factor,
+      .step = step,
+      .lower_kind = LOOM_SCF_UNROLL_LOWER_BOUND_DYNAMIC,
+      .lower_value = loom_block_arg_id(main_block, 0),
+      .lower_range_min = 0,
+      .lower_range_max = 0,
+  };
+  IREE_RETURN_IF_ERROR(loom_scf_unroll_emit_interleaved_tile(
+      context, op, old_block, yield, &tile_trip_count, main_carried_values,
+      op->result_count, scratch_arena, final_main_carried_values));
+  loom_op_t* main_yield = NULL;
+  IREE_RETURN_IF_ERROR(loom_scf_yield_build(
+      &context->rewriter->builder, final_main_carried_values, op->result_count,
+      op->location, &main_yield));
+  loom_builder_restore(&context->rewriter->builder, saved_ip);
+
+  const loom_value_id_t* replacement_values = NULL;
+  if (op->result_count > 0) {
+    replacement_values = loom_scf_for_results(main_loop).values;
+  }
+
+  if (tail_loop_required) {
+    loom_value_slice_t tail_iter_args = {0};
+    if (op->result_count > 0) {
+      tail_iter_args = loom_scf_for_results(main_loop);
+    }
+    loom_op_t* tail_loop = NULL;
+    IREE_RETURN_IF_ERROR(loom_scf_for_build(
+        &context->rewriter->builder, /*build_flags=*/0, main_upper,
+        loom_scf_for_upper_bound(op), loom_scf_for_step(op),
+        tail_iter_args.values, tail_iter_args.count, result_types,
+        op->result_count, tied_results, tied_result_count,
+        LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, /*unroll_schedule=*/0,
+        op->location, &tail_loop));
+    loom_region_t* tail_body = loom_scf_for_body(tail_loop);
+    saved_ip = loom_builder_enter_region(&context->rewriter->builder, tail_loop,
+                                         tail_body);
+    IREE_RETURN_IF_ERROR(loom_scf_unroll_clone_loop_body(
+        context, old_block, loom_region_entry_block(tail_body), scratch_arena));
+    loom_builder_restore(&context->rewriter->builder, saved_ip);
+    if (op->result_count > 0) {
+      replacement_values = loom_scf_for_results(tail_loop).values;
+    }
+  }
+
+  if (op->result_count > 0) {
+    IREE_RETURN_IF_ERROR(loom_rewriter_preserve_result_names_on_new_values(
+        context->rewriter, op, replacement_values, op->result_count,
+        value_checkpoint));
+    IREE_RETURN_IF_ERROR(loom_rewriter_replace_all_uses_and_erase(
+        context->rewriter, op, replacement_values, op->result_count));
+  } else {
+    IREE_RETURN_IF_ERROR(loom_rewriter_erase(context->rewriter, op));
+  }
+
+  ++context->statistics->loops_unrolled;
+  context->statistics->iterations_materialized += unroll_factor;
+  *out_changed = true;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_scf_unroll_partial_unroll_interleaved(
+    loom_scf_unroll_context_t* context, loom_op_t* op, loom_op_t* yield,
+    int64_t step, uint32_t unroll_factor,
+    const loom_scf_unroll_trip_count_t* trip_count, bool tail_loop_required,
+    bool* out_changed) {
+  iree_arena_allocator_t scratch_arena;
+  iree_arena_initialize(context->pass->arena->block_pool, &scratch_arena);
+  iree_status_t status = loom_scf_unroll_partial_unroll_interleaved_with_arena(
+      context, op, yield, step, unroll_factor, trip_count, tail_loop_required,
+      &scratch_arena, out_changed);
   iree_arena_deinitialize(&scratch_arena);
   return status;
 }
@@ -2089,15 +2385,17 @@ static iree_status_t loom_scf_unroll_try_unroll(
           context, op, IREE_SV("step"), step,
           IREE_SV("positive exact static step"));
     }
+    if (unroll_schedule == LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED) {
+      IREE_RETURN_IF_ERROR(loom_scf_unroll_append_partial_report_detail(
+          context, op, unroll_factor, unroll_schedule, step, trip_count_state,
+          &trip_count, LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_TAIL_LOOP));
+      return loom_scf_unroll_partial_unroll_interleaved(
+          context, op, yield, step, unroll_factor_u32,
+          /*trip_count=*/NULL, /*tail_loop_required=*/true, out_changed);
+    }
     IREE_RETURN_IF_ERROR(loom_scf_unroll_append_partial_report_detail(
         context, op, unroll_factor, unroll_schedule, step, trip_count_state,
         &trip_count, LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_GUARD_TAIL));
-    if (unroll_schedule == LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED) {
-      return loom_scf_unroll_emit_policy_error(
-          context, op, IREE_SV("schedule"),
-          LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
-          IREE_SV("exact full unroll without generated tail guards"));
-    }
     return loom_scf_unroll_partial_unroll(
         context, op, yield, step, unroll_factor_u32,
         LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_GUARD_TAIL, out_changed);
@@ -2107,15 +2405,22 @@ static iree_status_t loom_scf_unroll_try_unroll(
         trip_count.count % unroll_factor_u32 == 0
             ? 0
             : LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_GUARD_TAIL;
+    if (unroll_schedule == LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED) {
+      partial_flags = trip_count.count % unroll_factor_u32 == 0
+                          ? 0
+                          : LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_TAIL_LOOP;
+      IREE_RETURN_IF_ERROR(loom_scf_unroll_append_partial_report_detail(
+          context, op, unroll_factor, unroll_schedule, trip_count.step,
+          trip_count_state, &trip_count, partial_flags));
+      return loom_scf_unroll_partial_unroll_interleaved(
+          context, op, yield, trip_count.step, unroll_factor_u32, &trip_count,
+          iree_any_bit_set(partial_flags,
+                           LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_TAIL_LOOP),
+          out_changed);
+    }
     IREE_RETURN_IF_ERROR(loom_scf_unroll_append_partial_report_detail(
         context, op, unroll_factor, unroll_schedule, trip_count.step,
         trip_count_state, &trip_count, partial_flags));
-    if (unroll_schedule == LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED) {
-      return loom_scf_unroll_emit_policy_error(
-          context, op, IREE_SV("schedule"),
-          LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
-          IREE_SV("exact full unroll without stripmining"));
-    }
     return loom_scf_unroll_partial_unroll(context, op, yield, trip_count.step,
                                           unroll_factor_u32, partial_flags,
                                           out_changed);

--- a/loom/src/loom/transforms/scf/scf_unroll.c
+++ b/loom/src/loom/transforms/scf/scf_unroll.c
@@ -13,8 +13,10 @@
 #include "loom/error/error_catalog.h"
 #include "loom/ir/attribute.h"
 #include "loom/ir/context.h"
+#include "loom/ir/encoding.h"
 #include "loom/ir/facts.h"
 #include "loom/ir/module.h"
+#include "loom/ir/types.h"
 #include "loom/ops/index/ops.h"
 #include "loom/ops/op_defs.h"
 #include "loom/ops/scf/ops.h"
@@ -338,10 +340,23 @@ static iree_string_view_t loom_scf_unroll_trip_count_state_name(
   return IREE_SV("unknown");
 }
 
+static iree_string_view_t loom_scf_unroll_schedule_name(
+    loom_scf_for_unroll_schedule_t schedule) {
+  switch (schedule) {
+    case LOOM_SCF_FOR_UNROLL_SCHEDULE_LINEAR:
+      return IREE_SV("linear");
+    case LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED:
+      return IREE_SV("interleaved");
+    case LOOM_SCF_FOR_UNROLL_SCHEDULE_COUNT_:
+      break;
+  }
+  return IREE_SV("unknown");
+}
+
 static iree_status_t loom_scf_unroll_append_report_detail(
     const loom_scf_unroll_context_t* context, loom_op_t* op,
-    iree_string_view_t policy, int64_t unroll_factor,
-    const loom_scf_unroll_trip_count_t* trip_count) {
+    iree_string_view_t policy, loom_scf_for_unroll_schedule_t schedule,
+    int64_t unroll_factor, const loom_scf_unroll_trip_count_t* trip_count) {
   if (!context->reports_enabled) {
     return iree_ok_status();
   }
@@ -354,6 +369,8 @@ static iree_status_t loom_scf_unroll_append_report_detail(
       IREE_SV("op"), loom_op_name(context->module, op));
   fields[field_count++] =
       loom_pass_report_detail_string_field(IREE_SV("policy"), policy);
+  fields[field_count++] = loom_pass_report_detail_string_field(
+      IREE_SV("schedule"), loom_scf_unroll_schedule_name(schedule));
   fields[field_count++] = loom_pass_report_detail_uint64_field(
       IREE_SV("trip_count"), trip_count->count);
   fields[field_count++] =
@@ -385,8 +402,8 @@ static iree_status_t loom_scf_unroll_append_report_detail(
 
 static iree_status_t loom_scf_unroll_append_partial_report_detail(
     const loom_scf_unroll_context_t* context, loom_op_t* op,
-    int64_t unroll_factor, int64_t step,
-    loom_scf_unroll_trip_count_state_t trip_count_state,
+    int64_t unroll_factor, loom_scf_for_unroll_schedule_t schedule,
+    int64_t step, loom_scf_unroll_trip_count_state_t trip_count_state,
     const loom_scf_unroll_trip_count_t* trip_count,
     loom_scf_unroll_partial_unroll_flags_t flags) {
   if (!context->reports_enabled) {
@@ -401,6 +418,8 @@ static iree_status_t loom_scf_unroll_append_partial_report_detail(
       IREE_SV("op"), loom_op_name(context->module, op));
   fields[field_count++] = loom_pass_report_detail_string_field(
       IREE_SV("policy"), IREE_SV("factor"));
+  fields[field_count++] = loom_pass_report_detail_string_field(
+      IREE_SV("schedule"), loom_scf_unroll_schedule_name(schedule));
   fields[field_count++] = loom_pass_report_detail_int64_field(
       IREE_SV("unroll_factor"), unroll_factor);
   fields[field_count++] =
@@ -505,7 +524,9 @@ static iree_status_t loom_scf_unroll_emit_trip_count_error(
 static bool loom_scf_unroll_policy_present(loom_op_t* op) {
   return loom_scf_for_unroll_factor_is_present(op) ||
          !loom_attr_is_absent(
-             loom_op_attrs(op)[loom_scf_for_unroll_policy_ATTR_INDEX]);
+             loom_op_attrs(op)[loom_scf_for_unroll_policy_ATTR_INDEX]) ||
+         !loom_attr_is_absent(
+             loom_op_attrs(op)[loom_scf_for_unroll_schedule_ATTR_INDEX]);
 }
 
 static bool loom_scf_unroll_shape_is_supported(loom_op_t* op,
@@ -820,7 +841,7 @@ static iree_status_t loom_scf_unroll_clear_policy(
       loom_scf_for_lower_bound(op), loom_scf_for_upper_bound(op),
       loom_scf_for_step(op), iter_args.values, iter_args.count, result_types,
       op->result_count, tied_results, tied_result_count, LOOM_VALUE_ID_INVALID,
-      /*unroll_policy=*/0, op->location, &new_loop));
+      /*unroll_policy=*/0, /*unroll_schedule=*/0, op->location, &new_loop));
 
   loom_region_t* old_body = loom_scf_for_body(op);
   loom_block_t* old_block = loom_region_entry_block(old_body);
@@ -926,7 +947,7 @@ static iree_status_t loom_scf_unroll_partial_unroll(
       loom_scf_for_lower_bound(op), loom_scf_for_upper_bound(op), scaled_step,
       iter_args.values, iter_args.count, result_types, op->result_count,
       tied_results, tied_result_count, LOOM_VALUE_ID_INVALID,
-      /*unroll_policy=*/0, op->location, &new_loop));
+      /*unroll_policy=*/0, /*unroll_schedule=*/0, op->location, &new_loop));
 
   loom_region_t* old_body = loom_scf_for_body(op);
   loom_block_t* old_block = loom_region_entry_block(old_body);
@@ -1009,6 +1030,441 @@ static iree_status_t loom_scf_unroll_partial_unroll(
   return iree_ok_status();
 }
 
+typedef struct loom_scf_unroll_body_op_list_t {
+  const loom_op_t** ops;
+  uint32_t count;
+} loom_scf_unroll_body_op_list_t;
+
+typedef struct loom_scf_unroll_payload_readiness_t {
+  const loom_scf_unroll_context_t* context;
+  const loom_block_t* body_block;
+  const loom_op_t* source_op;
+  const loom_ir_remap_t* remap;
+  bool ready;
+} loom_scf_unroll_payload_readiness_t;
+
+static bool loom_scf_unroll_value_ref_is_ready(
+    const loom_scf_unroll_payload_readiness_t* query,
+    loom_value_id_t value_id) {
+  const loom_value_t* value =
+      loom_module_value(query->context->module, value_id);
+  if (loom_value_is_block_arg(value)) {
+    if (loom_value_def_block(value) != query->body_block) return true;
+  } else {
+    const loom_op_t* def_op = loom_value_def_op(value);
+    if (!def_op || def_op->parent_block != query->body_block) return true;
+    if (def_op == query->source_op) return true;
+  }
+
+  loom_value_id_t mapped_value = LOOM_VALUE_ID_INVALID;
+  return loom_ir_remap_try_lookup_value(query->remap, value_id, &mapped_value);
+}
+
+static iree_status_t loom_scf_unroll_check_type_ref_is_ready(
+    loom_value_id_t value_id, void* user_data) {
+  loom_scf_unroll_payload_readiness_t* query =
+      (loom_scf_unroll_payload_readiness_t*)user_data;
+  if (!loom_scf_unroll_value_ref_is_ready(query, value_id)) {
+    query->ready = false;
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_scf_unroll_type_refs_are_ready(
+    loom_scf_unroll_payload_readiness_t* query, loom_type_t type,
+    bool* out_ready) {
+  query->ready = true;
+  IREE_RETURN_IF_ERROR(loom_type_walk_value_refs(
+      type, loom_scf_unroll_check_type_ref_is_ready, query));
+  *out_ready = query->ready;
+  return iree_ok_status();
+}
+
+static bool loom_scf_unroll_predicate_refs_are_ready(
+    const loom_scf_unroll_payload_readiness_t* query,
+    const loom_predicate_t* predicate) {
+  for (uint8_t i = 0; i < IREE_ARRAYSIZE(predicate->arg_tags); ++i) {
+    if (predicate->arg_tags[i] != LOOM_PRED_ARG_VALUE) continue;
+    if (predicate->args[i] < 0) return false;
+    if (!loom_scf_unroll_value_ref_is_ready(
+            query, (loom_value_id_t)predicate->args[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static iree_status_t loom_scf_unroll_attr_refs_are_ready(
+    loom_scf_unroll_payload_readiness_t* query, const loom_attribute_t* attr,
+    uint8_t depth, bool* out_ready) {
+  *out_ready = false;
+  if (!attr || depth > LOOM_ATTR_DICT_MAX_NESTING_DEPTH) {
+    return iree_ok_status();
+  }
+  switch ((loom_attr_kind_t)attr->kind) {
+    case LOOM_ATTR_ABSENT:
+    case LOOM_ATTR_I64:
+    case LOOM_ATTR_F64:
+    case LOOM_ATTR_STRING:
+    case LOOM_ATTR_BOOL:
+    case LOOM_ATTR_ENUM:
+    case LOOM_ATTR_I64_ARRAY:
+    case LOOM_ATTR_SYMBOL:
+    case LOOM_ATTR_BYTES:
+      *out_ready = true;
+      return iree_ok_status();
+    case LOOM_ATTR_TYPE:
+      if (attr->type_id == LOOM_TYPE_ID_INVALID ||
+          attr->type_id >= query->context->module->types.count) {
+        return iree_ok_status();
+      }
+      return loom_scf_unroll_type_refs_are_ready(
+          query, query->context->module->types.entries[attr->type_id],
+          out_ready);
+    case LOOM_ATTR_PREDICATE_LIST:
+      if (attr->count > 0 && !attr->predicate_list) return iree_ok_status();
+      for (uint16_t i = 0; i < attr->count; ++i) {
+        if (!loom_scf_unroll_predicate_refs_are_ready(
+                query, &attr->predicate_list[i])) {
+          return iree_ok_status();
+        }
+      }
+      *out_ready = true;
+      return iree_ok_status();
+    case LOOM_ATTR_DICT:
+      if (attr->count > 0 && !attr->dict_entries) return iree_ok_status();
+      for (uint16_t i = 0; i < attr->count; ++i) {
+        IREE_RETURN_IF_ERROR(loom_scf_unroll_attr_refs_are_ready(
+            query, &attr->dict_entries[i].value, (uint8_t)(depth + 1),
+            out_ready));
+        if (!*out_ready) return iree_ok_status();
+      }
+      *out_ready = true;
+      return iree_ok_status();
+    case LOOM_ATTR_ENCODING: {
+      if (attr->encoding_id > UINT16_MAX) return iree_ok_status();
+      const loom_encoding_t* encoding = loom_module_encoding(
+          query->context->module, (uint16_t)attr->encoding_id);
+      if (!encoding) return iree_ok_status();
+      if (encoding->attribute_count > 0 && !encoding->attributes) {
+        return iree_ok_status();
+      }
+      for (uint8_t i = 0; i < encoding->attribute_count; ++i) {
+        IREE_RETURN_IF_ERROR(loom_scf_unroll_attr_refs_are_ready(
+            query, &encoding->attributes[i].value, (uint8_t)(depth + 1),
+            out_ready));
+        if (!*out_ready) return iree_ok_status();
+      }
+      *out_ready = true;
+      return iree_ok_status();
+    }
+    default:
+      return iree_ok_status();
+  }
+}
+
+static iree_status_t loom_scf_unroll_collect_interleavable_body_ops(
+    const loom_scf_unroll_context_t* context, loom_op_t* op,
+    const loom_block_t* body_block, const loom_op_t* yield,
+    loom_scf_unroll_body_op_list_t* out_body_ops) {
+  *out_body_ops = (loom_scf_unroll_body_op_list_t){0};
+
+  uint32_t count = 0;
+  for (const loom_op_t* body_op = body_block->first_op;
+       body_op && body_op != yield; body_op = body_op->next_op) {
+    if (iree_any_bit_set(body_op->flags, LOOM_OP_FLAG_DEAD)) continue;
+    if (body_op->region_count != 0 || body_op->successor_count != 0) {
+      return loom_scf_unroll_emit_policy_error(
+          context, op, IREE_SV("schedule"),
+          LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
+          IREE_SV("body operations without nested regions or successors"));
+    }
+    if (count == UINT32_MAX) {
+      return loom_scf_unroll_emit_policy_error(
+          context, op, IREE_SV("schedule"), count,
+          IREE_SV("body operation count representable as uint32"));
+    }
+    ++count;
+  }
+
+  if (count == 0) {
+    return iree_ok_status();
+  }
+
+  const loom_op_t** ops = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(context->pass->arena, count,
+                                                 sizeof(*ops), (void**)&ops));
+  uint32_t index = 0;
+  for (const loom_op_t* body_op = body_block->first_op;
+       body_op && body_op != yield; body_op = body_op->next_op) {
+    if (iree_any_bit_set(body_op->flags, LOOM_OP_FLAG_DEAD)) continue;
+    ops[index++] = body_op;
+  }
+  *out_body_ops = (loom_scf_unroll_body_op_list_t){
+      .ops = ops,
+      .count = count,
+  };
+  return iree_ok_status();
+}
+
+static iree_status_t loom_scf_unroll_body_op_payload_is_ready(
+    const loom_scf_unroll_context_t* context, const loom_block_t* body_block,
+    const loom_op_t* source_op, const loom_ir_remap_t* remap, bool* out_ready) {
+  *out_ready = false;
+  loom_scf_unroll_payload_readiness_t query = {
+      .context = context,
+      .body_block = body_block,
+      .source_op = source_op,
+      .remap = remap,
+      .ready = true,
+  };
+  const loom_value_id_t* operands = loom_op_const_operands(source_op);
+  for (uint16_t i = 0; i < source_op->operand_count; ++i) {
+    if (!loom_scf_unroll_value_ref_is_ready(&query, operands[i])) {
+      return iree_ok_status();
+    }
+  }
+  const loom_value_id_t* results = loom_op_const_results(source_op);
+  for (uint16_t i = 0; i < source_op->result_count; ++i) {
+    bool ready = false;
+    IREE_RETURN_IF_ERROR(loom_scf_unroll_type_refs_are_ready(
+        &query, loom_module_value_type(context->module, results[i]), &ready));
+    if (!ready) return iree_ok_status();
+  }
+  const loom_attribute_t* attrs = loom_op_const_attrs(source_op);
+  for (uint8_t i = 0; i < source_op->attribute_count; ++i) {
+    bool ready = false;
+    IREE_RETURN_IF_ERROR(
+        loom_scf_unroll_attr_refs_are_ready(&query, &attrs[i], 0, &ready));
+    if (!ready) {
+      return iree_ok_status();
+    }
+  }
+  *out_ready = true;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_scf_unroll_rename_cloned_op_results(
+    loom_scf_unroll_context_t* context, const loom_op_t* source_op,
+    loom_op_t* cloned_op, uint32_t ordinal) {
+  if (ordinal == 0 ||
+      !iree_any_bit_set(context->rewriter->name_policy,
+                        LOOM_REWRITER_NAME_POLICY_DERIVE_DEBUG_NAMES)) {
+    return iree_ok_status();
+  }
+
+  char suffix[32] = {0};
+  int suffix_length =
+      iree_snprintf(suffix, sizeof(suffix), "%" PRIu32, ordinal);
+  if (suffix_length <= 0 || (iree_host_size_t)suffix_length >= sizeof(suffix)) {
+    return iree_ok_status();
+  }
+  iree_string_view_t suffix_view =
+      iree_make_string_view(suffix, (iree_host_size_t)suffix_length);
+  const loom_value_id_t* source_results = loom_op_const_results(source_op);
+  const loom_value_id_t* cloned_results = loom_op_const_results(cloned_op);
+  for (uint16_t i = 0; i < source_op->result_count; ++i) {
+    IREE_RETURN_IF_ERROR(
+        loom_rewriter_clear_value_name(context->rewriter, cloned_results[i]));
+    IREE_RETURN_IF_ERROR(loom_rewriter_try_set_derived_value_name(
+        context->rewriter, source_results[i], cloned_results[i], suffix_view));
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_scf_unroll_mark_iteration_complete(
+    loom_scf_unroll_context_t* context, const loom_block_t* body_block,
+    const loom_op_t* yield, uint32_t ordinal, uint32_t trip_count,
+    uint16_t carried_count, loom_ir_remap_t* remaps,
+    loom_value_id_t* final_carried_values) {
+  if (carried_count == 0) return iree_ok_status();
+
+  loom_value_slice_t yielded_values = loom_scf_yield_values(yield);
+  loom_value_id_t* resolved_values = final_carried_values;
+  if (ordinal + 1 < trip_count) {
+    resolved_values = NULL;
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        context->pass->arena, carried_count, sizeof(*resolved_values),
+        (void**)&resolved_values));
+  }
+  for (uint16_t i = 0; i < carried_count; ++i) {
+    IREE_RETURN_IF_ERROR(loom_ir_remap_resolve_value(
+        &remaps[ordinal], yielded_values.values[i], &resolved_values[i]));
+  }
+  if (ordinal + 1 < trip_count) {
+    for (uint16_t i = 0; i < carried_count; ++i) {
+      IREE_RETURN_IF_ERROR(loom_ir_remap_map_value(&remaps[ordinal + 1],
+                                                   body_block->arg_ids[1 + i],
+                                                   resolved_values[i]));
+    }
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_scf_unroll_full_unroll_interleaved(
+    loom_scf_unroll_context_t* context, loom_op_t* op, loom_op_t* yield,
+    const loom_scf_unroll_trip_count_t* trip_count, bool* out_changed) {
+  *out_changed = false;
+
+  loom_region_t* body = loom_scf_for_body(op);
+  loom_block_t* body_block = loom_region_entry_block(body);
+  loom_scf_unroll_body_op_list_t body_ops = {0};
+  IREE_RETURN_IF_ERROR(loom_scf_unroll_collect_interleavable_body_ops(
+      context, op, body_block, yield, &body_ops));
+
+  loom_builder_set_before(&context->rewriter->builder, op);
+  loom_value_id_t value_checkpoint =
+      loom_rewriter_value_checkpoint(context->rewriter);
+  loom_value_slice_t iter_args = loom_scf_for_iter_args(op);
+  const uint32_t unroll_count = trip_count->count;
+  const uint16_t carried_count = op->result_count;
+  if (unroll_count == 0) {
+    if (carried_count > 0) {
+      IREE_RETURN_IF_ERROR(loom_rewriter_preserve_result_names_on_new_values(
+          context->rewriter, op, iter_args.values, carried_count,
+          value_checkpoint));
+      IREE_RETURN_IF_ERROR(loom_rewriter_replace_all_uses_and_erase(
+          context->rewriter, op, iter_args.values, carried_count));
+    } else {
+      IREE_RETURN_IF_ERROR(loom_rewriter_erase(context->rewriter, op));
+    }
+    ++context->statistics->loops_unrolled;
+    *out_changed = true;
+    return iree_ok_status();
+  }
+
+  loom_ir_remap_t* remaps = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      context->pass->arena, unroll_count, sizeof(*remaps), (void**)&remaps));
+  bool* completed_iterations = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      context->pass->arena, unroll_count, sizeof(*completed_iterations),
+      (void**)&completed_iterations));
+  memset(completed_iterations, 0,
+         (iree_host_size_t)unroll_count * sizeof(*completed_iterations));
+  uint32_t* cloned_counts = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      context->pass->arena, unroll_count, sizeof(*cloned_counts),
+      (void**)&cloned_counts));
+  memset(cloned_counts, 0,
+         (iree_host_size_t)unroll_count * sizeof(*cloned_counts));
+
+  bool* cloned = NULL;
+  iree_host_size_t clone_slot_count = 0;
+  if (!iree_host_size_checked_mul((iree_host_size_t)unroll_count,
+                                  body_ops.count, &clone_slot_count)) {
+    return loom_scf_unroll_emit_policy_error(
+        context, op, IREE_SV("schedule"),
+        LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
+        IREE_SV("unroll count * body operation count representable"));
+  }
+  if (clone_slot_count != 0) {
+    IREE_RETURN_IF_ERROR(
+        iree_arena_allocate_array(context->pass->arena, clone_slot_count,
+                                  sizeof(*cloned), (void**)&cloned));
+    memset(cloned, 0, clone_slot_count * sizeof(*cloned));
+  }
+
+  loom_value_id_t induction_variable = body_block->arg_ids[0];
+  for (uint32_t ordinal = 0; ordinal < unroll_count; ++ordinal) {
+    IREE_RETURN_IF_ERROR(loom_ir_remap_initialize(
+        context->module, context->module, context->pass->arena,
+        &(loom_ir_remap_options_t){
+            .allow_unmapped_values = true,
+            .remap_symbol = loom_ir_remap_symbol_callback_empty(),
+        },
+        &remaps[ordinal]));
+    loom_value_id_t iteration_index = LOOM_VALUE_ID_INVALID;
+    IREE_RETURN_IF_ERROR(loom_scf_unroll_build_iteration_index(
+        context, op, induction_variable, trip_count, ordinal,
+        &iteration_index));
+    if (iteration_index == LOOM_VALUE_ID_INVALID) {
+      return loom_scf_unroll_emit_policy_error(
+          context, op, IREE_SV("schedule"), ordinal,
+          IREE_SV("iteration index representable as i64"));
+    }
+    IREE_RETURN_IF_ERROR(loom_ir_remap_map_value(
+        &remaps[ordinal], induction_variable, iteration_index));
+  }
+
+  for (uint16_t i = 0; i < carried_count; ++i) {
+    IREE_RETURN_IF_ERROR(loom_ir_remap_map_value(
+        &remaps[0], body_block->arg_ids[1 + i], iter_args.values[i]));
+  }
+
+  loom_value_id_t* final_carried_values = NULL;
+  if (carried_count > 0) {
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        context->pass->arena, carried_count, sizeof(*final_carried_values),
+        (void**)&final_carried_values));
+  }
+
+  if (body_ops.count == 0) {
+    for (uint32_t ordinal = 0; ordinal < unroll_count; ++ordinal) {
+      IREE_RETURN_IF_ERROR(loom_scf_unroll_mark_iteration_complete(
+          context, body_block, yield, ordinal, unroll_count, carried_count,
+          remaps, final_carried_values));
+    }
+  }
+
+  iree_host_size_t remaining = clone_slot_count;
+  while (remaining > 0) {
+    bool made_progress = false;
+    for (uint32_t op_index = 0; op_index < body_ops.count; ++op_index) {
+      const loom_op_t* source_op = body_ops.ops[op_index];
+      for (uint32_t ordinal = 0; ordinal < unroll_count; ++ordinal) {
+        bool* cloned_slot =
+            &cloned[(iree_host_size_t)ordinal * body_ops.count + op_index];
+        if (*cloned_slot) continue;
+        bool payload_ready = false;
+        IREE_RETURN_IF_ERROR(loom_scf_unroll_body_op_payload_is_ready(
+            context, body_block, source_op, &remaps[ordinal], &payload_ready));
+        if (!payload_ready) {
+          continue;
+        }
+        loom_op_t* cloned_op = NULL;
+        IREE_RETURN_IF_ERROR(loom_ir_clone_op(&context->rewriter->builder,
+                                              source_op, &remaps[ordinal],
+                                              &cloned_op));
+        IREE_RETURN_IF_ERROR(loom_scf_unroll_rename_cloned_op_results(
+            context, source_op, cloned_op, ordinal));
+        *cloned_slot = true;
+        ++cloned_counts[ordinal];
+        --remaining;
+        made_progress = true;
+        if (cloned_counts[ordinal] == body_ops.count &&
+            !completed_iterations[ordinal]) {
+          IREE_RETURN_IF_ERROR(loom_scf_unroll_mark_iteration_complete(
+              context, body_block, yield, ordinal, unroll_count, carried_count,
+              remaps, final_carried_values));
+          completed_iterations[ordinal] = true;
+        }
+      }
+    }
+    if (!made_progress) {
+      return loom_scf_unroll_emit_policy_error(
+          context, op, IREE_SV("schedule"),
+          LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
+          IREE_SV("acyclic body-local SSA dependencies"));
+    }
+  }
+
+  if (carried_count > 0) {
+    IREE_RETURN_IF_ERROR(loom_rewriter_preserve_result_names_on_new_values(
+        context->rewriter, op, final_carried_values, carried_count,
+        value_checkpoint));
+    IREE_RETURN_IF_ERROR(loom_rewriter_replace_all_uses_and_erase(
+        context->rewriter, op, final_carried_values, carried_count));
+  } else {
+    IREE_RETURN_IF_ERROR(loom_rewriter_erase(context->rewriter, op));
+  }
+
+  ++context->statistics->loops_unrolled;
+  context->statistics->iterations_materialized += unroll_count;
+  *out_changed = true;
+  return iree_ok_status();
+}
+
 static iree_status_t loom_scf_unroll_try_unroll(
     loom_scf_unroll_context_t* context, loom_op_t* op, bool* out_changed) {
   *out_changed = false;
@@ -1022,10 +1478,22 @@ static iree_status_t loom_scf_unroll_try_unroll(
   bool has_unroll_factor = loom_scf_for_unroll_factor_is_present(op);
   bool has_unroll_policy = !loom_attr_is_absent(
       loom_op_attrs(op)[loom_scf_for_unroll_policy_ATTR_INDEX]);
+  bool has_unroll_schedule = !loom_attr_is_absent(
+      loom_op_attrs(op)[loom_scf_for_unroll_schedule_ATTR_INDEX]);
   if (has_unroll_factor && has_unroll_policy) {
     return loom_scf_unroll_emit_policy_error(
         context, op, IREE_SV("unroll"), 2,
         IREE_SV("either bare unroll or unroll factor, not both"));
+  }
+  if (has_unroll_schedule && !has_unroll_factor && !has_unroll_policy) {
+    return loom_scf_unroll_emit_policy_error(
+        context, op, IREE_SV("schedule"), 0,
+        IREE_SV("paired with bare unroll or unroll factor"));
+  }
+  loom_scf_for_unroll_schedule_t unroll_schedule =
+      LOOM_SCF_FOR_UNROLL_SCHEDULE_LINEAR;
+  if (has_unroll_schedule) {
+    unroll_schedule = loom_scf_for_unroll_schedule(op);
   }
 
   loom_op_t* yield = NULL;
@@ -1082,8 +1550,14 @@ static iree_status_t loom_scf_unroll_try_unroll(
           IREE_SV("positive exact static step"));
     }
     IREE_RETURN_IF_ERROR(loom_scf_unroll_append_partial_report_detail(
-        context, op, unroll_factor, step, trip_count_state, &trip_count,
-        LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_GUARD_TAIL));
+        context, op, unroll_factor, unroll_schedule, step, trip_count_state,
+        &trip_count, LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_GUARD_TAIL));
+    if (unroll_schedule == LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED) {
+      return loom_scf_unroll_emit_policy_error(
+          context, op, IREE_SV("schedule"),
+          LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
+          IREE_SV("exact full unroll without generated tail guards"));
+    }
     return loom_scf_unroll_partial_unroll(
         context, op, yield, step, unroll_factor_u32,
         LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_GUARD_TAIL, out_changed);
@@ -1094,15 +1568,26 @@ static iree_status_t loom_scf_unroll_try_unroll(
             ? 0
             : LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_GUARD_TAIL;
     IREE_RETURN_IF_ERROR(loom_scf_unroll_append_partial_report_detail(
-        context, op, unroll_factor, trip_count.step, trip_count_state,
-        &trip_count, partial_flags));
+        context, op, unroll_factor, unroll_schedule, trip_count.step,
+        trip_count_state, &trip_count, partial_flags));
+    if (unroll_schedule == LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED) {
+      return loom_scf_unroll_emit_policy_error(
+          context, op, IREE_SV("schedule"),
+          LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
+          IREE_SV("exact full unroll without stripmining"));
+    }
     return loom_scf_unroll_partial_unroll(context, op, yield, trip_count.step,
                                           unroll_factor_u32, partial_flags,
                                           out_changed);
   }
   IREE_RETURN_IF_ERROR(loom_scf_unroll_append_report_detail(
       context, op, has_unroll_factor ? IREE_SV("factor") : IREE_SV("bare"),
-      has_unroll_factor ? unroll_factor : -1, &trip_count));
+      unroll_schedule, has_unroll_factor ? unroll_factor : -1, &trip_count));
+
+  if (unroll_schedule == LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED) {
+    return loom_scf_unroll_full_unroll_interleaved(context, op, yield,
+                                                   &trip_count, out_changed);
+  }
 
   loom_region_t* body = loom_scf_for_body(op);
   loom_block_t* body_block = loom_region_entry_block(body);

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -272,6 +272,86 @@ func.def @interleaved_disjoint_vector_stores_commute(%buffer: buffer) {
 
 // ====
 
+func.def @interleaved_dynamic_base_vector_stores_commute(%buffer: buffer, %base: offset) {
+  %value0 = scalar.constant 1 : i32
+  %value1 = scalar.constant 2 : i32
+  %vec0 = vector.splat %value0 : vector<4xi32>
+  %vec1 = vector.splat %value1 : vector<4xi32>
+  %layout = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<8xi32, %layout>
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  scf.for %i = [%start to %end step %step] unroll schedule(interleaved) {
+    vector.store %vec0, %view[0] : vector<4xi32>, view<8xi32, %layout>
+    vector.store %vec1, %view[4] : vector<4xi32>, view<8xi32, %layout>
+  }
+  func.return
+}
+
+// ----
+func.def @interleaved_dynamic_base_vector_stores_commute(%buffer: buffer, %base: offset) {
+  %value0 = scalar.constant 1 : i32
+  %value1 = scalar.constant 2 : i32
+  %vec0 = vector.splat %value0 : vector<4xi32>
+  %vec1 = vector.splat %value1 : vector<4xi32>
+  %layout = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<8xi32, %layout>
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  vector.store %vec0, %view[0] : vector<4xi32>, view<8xi32, %layout>
+  vector.store %vec0, %view[0] : vector<4xi32>, view<8xi32, %layout>
+  vector.store %vec1, %view[4] : vector<4xi32>, view<8xi32, %layout>
+  vector.store %vec1, %view[4] : vector<4xi32>, view<8xi32, %layout>
+  func.return
+}
+
+// ====
+
+func.def @interleaved_dynamic_index_vector_stores_commute(%buffer: buffer, %row: index) {
+  %zero = index.constant 0 : offset
+  %value0 = scalar.constant 1 : i32
+  %value1 = scalar.constant 2 : i32
+  %vec0 = vector.splat %value0 : vector<4xi32>
+  %vec1 = vector.splat %value1 : vector<4xi32>
+  %layout = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%zero] : buffer -> view<4x8xi32, %layout>
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  scf.for %i = [%start to %end step %step] unroll schedule(interleaved) {
+    vector.store %vec0, %view[%row, 0] : vector<4xi32>, view<4x8xi32, %layout>
+    vector.store %vec1, %view[%row, 4] : vector<4xi32>, view<4x8xi32, %layout>
+  }
+  func.return
+}
+
+// ----
+func.def @interleaved_dynamic_index_vector_stores_commute(%buffer: buffer, %row: index) {
+  %zero = index.constant 0 : offset
+  %value0 = scalar.constant 1 : i32
+  %value1 = scalar.constant 2 : i32
+  %vec0 = vector.splat %value0 : vector<4xi32>
+  %vec1 = vector.splat %value1 : vector<4xi32>
+  %layout = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%zero] : buffer -> view<4x8xi32, %layout>
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  vector.store %vec0, %view[%row, 0] : vector<4xi32>, view<4x8xi32, %layout>
+  vector.store %vec0, %view[%row, 0] : vector<4xi32>, view<4x8xi32, %layout>
+  vector.store %vec1, %view[%row, 4] : vector<4xi32>, view<4x8xi32, %layout>
+  vector.store %vec1, %view[%row, 4] : vector<4xi32>, view<4x8xi32, %layout>
+  func.return
+}
+
+// ====
+
 func.def @interleaved_overlapping_vector_stores_preserve_order(%buffer: buffer) {
   %zero = index.constant 0 : offset
   %value0 = scalar.constant 1 : i32
@@ -308,6 +388,52 @@ func.def @interleaved_overlapping_vector_stores_preserve_order(%buffer: buffer) 
   vector.store %vec1, %view[0] : vector<4xi32>, view<4xi32, %layout>
   vector.store %vec0, %view[0] : vector<4xi32>, view<4xi32, %layout>
   vector.store %vec1, %view[0] : vector<4xi32>, view<4xi32, %layout>
+  func.return
+}
+
+// ====
+
+func.def @interleaved_induction_vector_stores_preserve_order(%buffer: buffer) {
+  %zero = index.constant 0 : offset
+  %one = index.constant 1 : index
+  %value0 = scalar.constant 1 : i32
+  %value1 = scalar.constant 2 : i32
+  %vec0 = vector.splat %value0 : vector<1xi32>
+  %vec1 = vector.splat %value1 : vector<1xi32>
+  %layout = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%zero] : buffer -> view<4xi32, %layout>
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  scf.for %i = [%start to %end step %step] unroll schedule(interleaved) {
+    %next = index.add %i, %one : index
+    vector.store %vec0, %view[%i] : vector<1xi32>, view<4xi32, %layout>
+    vector.store %vec1, %view[%next] : vector<1xi32>, view<4xi32, %layout>
+  }
+  func.return
+}
+
+// ----
+func.def @interleaved_induction_vector_stores_preserve_order(%buffer: buffer) {
+  %zero = index.constant 0 : offset
+  %one = index.constant 1 : index
+  %value0 = scalar.constant 1 : i32
+  %value1 = scalar.constant 2 : i32
+  %vec0 = vector.splat %value0 : vector<1xi32>
+  %vec1 = vector.splat %value1 : vector<1xi32>
+  %layout = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%zero] : buffer -> view<4xi32, %layout>
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  %next = index.add %i_0, %one : index
+  %next_1 = index.add %i_1, %one : index
+  vector.store %vec0, %view[%i_0] : vector<1xi32>, view<4xi32, %layout>
+  vector.store %vec1, %view[%next] : vector<1xi32>, view<4xi32, %layout>
+  vector.store %vec0, %view[%i_1] : vector<1xi32>, view<4xi32, %layout>
+  vector.store %vec1, %view[%next_1] : vector<1xi32>, view<4xi32, %layout>
   func.return
 }
 

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -76,6 +76,113 @@ func.def @bare_unroll_result_loop(%input: i32) -> (i32) {
 
 // ====
 
+func.def @interleaved_unroll_resultless_loop(%input: i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
+  scf.for %i = [%start to %end step %step] unroll schedule(interleaved) {
+    test.use %i : index
+    %first = test.addi %input, %input : i32
+    %second = test.addi %first, %input : i32
+    test.use %second : i32
+  }
+  func.return
+}
+
+// ----
+func.def @interleaved_unroll_resultless_loop(%input: i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  %i_2 = index.constant 2 : index
+  test.use %i_0 : index
+  test.use %i_1 : index
+  test.use %i_2 : index
+  %first = test.addi %input, %input : i32
+  %first_1 = test.addi %input, %input : i32
+  %first_2 = test.addi %input, %input : i32
+  %second = test.addi %first, %input : i32
+  %second_1 = test.addi %first_1, %input : i32
+  %second_2 = test.addi %first_2, %input : i32
+  test.use %second : i32
+  test.use %second_1 : i32
+  test.use %second_2 : i32
+  func.return
+}
+
+// ====
+
+func.def @interleaved_unroll_result_loop(%input: i32) -> (i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
+  %result = scf.for %i = [%start to %end step %step](%acc = %input : i32) -> (i32) unroll schedule(interleaved) {
+    %first = test.addi %input, %input : i32
+    %second = test.addi %first, %input : i32
+    %next = test.addi %acc, %second : i32
+    scf.yield %next : i32
+  }
+  func.return %result : i32
+}
+
+// ----
+func.def @interleaved_unroll_result_loop(%input: i32) -> (i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  %i_2 = index.constant 2 : index
+  %first = test.addi %input, %input : i32
+  %first_1 = test.addi %input, %input : i32
+  %first_2 = test.addi %input, %input : i32
+  %second = test.addi %first, %input : i32
+  %second_1 = test.addi %first_1, %input : i32
+  %second_2 = test.addi %first_2, %input : i32
+  %next = test.addi %input, %second : i32
+  %next_1 = test.addi %next, %second_1 : i32
+  %next_2 = test.addi %next_1, %second_2 : i32
+  func.return %next_2 : i32
+}
+
+// ====
+
+func.def @interleaved_unroll_preserves_type_ref_order(%buffer: buffer, %offset: offset) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
+  scf.for %i = [%start to %end step %step] unroll schedule(interleaved) {
+    %layout = encoding.layout.dense : encoding<layout>
+    %view = buffer.view %buffer[%offset] : buffer -> view<4xf32, %layout>
+    test.use %view : view<4xf32, %layout>
+  }
+  func.return
+}
+
+// ----
+func.def @interleaved_unroll_preserves_type_ref_order(%buffer: buffer, %offset: offset) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  %i_2 = index.constant 2 : index
+  %layout = encoding.layout.dense : encoding<layout>
+  %layout_1 = encoding.layout.dense : encoding<layout>
+  %layout_2 = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%offset] : buffer -> view<4xf32, %layout>
+  %view_1 = buffer.view %buffer[%offset] : buffer -> view<4xf32, %layout_1>
+  %view_2 = buffer.view %buffer[%offset] : buffer -> view<4xf32, %layout_2>
+  test.use %view : view<4xf32, %layout>
+  test.use %view_1 : view<4xf32, %layout_1>
+  test.use %view_2 : view<4xf32, %layout_2>
+  func.return
+}
+
+// ====
+
 func.def @bare_unroll_zero_trip_result_loop(%input: i32) -> (i32) {
   %start = index.constant 0 : index
   %end = index.constant 0 : index
@@ -256,6 +363,20 @@ func.def @partial_factor_divisible_trip_count_omits_tail_guard() {
     %7 = index.constant 1 : index
     %i_1 = index.add %i, %7 : index
     test.use %i_1 : index
+  }
+  func.return
+}
+
+// ====
+
+func.def @interleaved_partial_factor_requires_exact_full_unroll() {
+  %start = index.constant 0 : index
+  %end = index.constant 4 : index
+  %step = index.constant 1 : index
+  %factor = index.constant 2 : index
+  // ERROR@+1: STRUCTURE/014 {attr_name="schedule", expected_constraint="exact full unroll without stripmining"}
+  scf.for %i = [%start to %end step %step] unroll(%factor) schedule(interleaved) {
+    test.use %i : index
   }
   func.return
 }

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -162,13 +162,13 @@ func.def @interleaved_unroll_preserves_type_ref_order(%buffer: buffer, %offset: 
   %i_1 = index.constant 1 : index
   %i_2 = index.constant 2 : index
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%offset] : buffer -> view<4xf32, %layout>
-  test.use %view : view<4xf32, %layout>
   %layout_1 = encoding.layout.dense : encoding<layout>
-  %view_1 = buffer.view %buffer[%offset] : buffer -> view<4xf32, %layout_1>
-  test.use %view_1 : view<4xf32, %layout_1>
   %layout_2 = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%offset] : buffer -> view<4xf32, %layout>
+  %view_1 = buffer.view %buffer[%offset] : buffer -> view<4xf32, %layout_1>
   %view_2 = buffer.view %buffer[%offset] : buffer -> view<4xf32, %layout_2>
+  test.use %view : view<4xf32, %layout>
+  test.use %view_1 : view<4xf32, %layout_1>
   test.use %view_2 : view<4xf32, %layout_2>
   func.return
 }
@@ -226,6 +226,88 @@ func.def @interleaved_write_read_hazard_preserves_order(%pool: pool<16>, %input:
   test.write_resource %pool, %input : pool<16>, i32
   %value_1 = test.read_resource %pool : pool<16> -> i32
   test.use %value_1 : i32
+  func.return
+}
+
+// ====
+
+func.def @interleaved_disjoint_vector_stores_commute(%buffer: buffer) {
+  %zero = index.constant 0 : offset
+  %value0 = scalar.constant 1 : i32
+  %value1 = scalar.constant 2 : i32
+  %vec0 = vector.splat %value0 : vector<4xi32>
+  %vec1 = vector.splat %value1 : vector<4xi32>
+  %layout = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%zero] : buffer -> view<8xi32, %layout>
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  scf.for %i = [%start to %end step %step] unroll schedule(interleaved) {
+    vector.store %vec0, %view[0] : vector<4xi32>, view<8xi32, %layout>
+    vector.store %vec1, %view[4] : vector<4xi32>, view<8xi32, %layout>
+  }
+  func.return
+}
+
+// ----
+func.def @interleaved_disjoint_vector_stores_commute(%buffer: buffer) {
+  %zero = index.constant 0 : offset
+  %value0 = scalar.constant 1 : i32
+  %value1 = scalar.constant 2 : i32
+  %vec0 = vector.splat %value0 : vector<4xi32>
+  %vec1 = vector.splat %value1 : vector<4xi32>
+  %layout = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%zero] : buffer -> view<8xi32, %layout>
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  vector.store %vec0, %view[0] : vector<4xi32>, view<8xi32, %layout>
+  vector.store %vec0, %view[0] : vector<4xi32>, view<8xi32, %layout>
+  vector.store %vec1, %view[4] : vector<4xi32>, view<8xi32, %layout>
+  vector.store %vec1, %view[4] : vector<4xi32>, view<8xi32, %layout>
+  func.return
+}
+
+// ====
+
+func.def @interleaved_overlapping_vector_stores_preserve_order(%buffer: buffer) {
+  %zero = index.constant 0 : offset
+  %value0 = scalar.constant 1 : i32
+  %value1 = scalar.constant 2 : i32
+  %vec0 = vector.splat %value0 : vector<4xi32>
+  %vec1 = vector.splat %value1 : vector<4xi32>
+  %layout = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%zero] : buffer -> view<4xi32, %layout>
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  scf.for %i = [%start to %end step %step] unroll schedule(interleaved) {
+    vector.store %vec0, %view[0] : vector<4xi32>, view<4xi32, %layout>
+    vector.store %vec1, %view[0] : vector<4xi32>, view<4xi32, %layout>
+  }
+  func.return
+}
+
+// ----
+func.def @interleaved_overlapping_vector_stores_preserve_order(%buffer: buffer) {
+  %zero = index.constant 0 : offset
+  %value0 = scalar.constant 1 : i32
+  %value1 = scalar.constant 2 : i32
+  %vec0 = vector.splat %value0 : vector<4xi32>
+  %vec1 = vector.splat %value1 : vector<4xi32>
+  %layout = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%zero] : buffer -> view<4xi32, %layout>
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  vector.store %vec0, %view[0] : vector<4xi32>, view<4xi32, %layout>
+  vector.store %vec1, %view[0] : vector<4xi32>, view<4xi32, %layout>
+  vector.store %vec0, %view[0] : vector<4xi32>, view<4xi32, %layout>
+  vector.store %vec1, %view[0] : vector<4xi32>, view<4xi32, %layout>
   func.return
 }
 

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -795,11 +795,10 @@ func.def @interleaved_partial_factor_carried_loop(%input: i32) -> (i32) {
 
 // ====
 
-func.def @interleaved_carried_loop_rejects_read_effect(%pool: pool<16>, %input: i32) -> (i32) {
+func.def @interleaved_carried_loop_reads_before_carried_updates(%pool: pool<16>, %input: i32) -> (i32) {
   %start = index.constant 0 : index
   %end = index.constant 3 : index
   %step = index.constant 1 : index
-  // ERROR@+1: STRUCTURE/014 {attr_name="schedule", expected_constraint="effect-free body operations when interleaving loop-carried values"}
   %result = scf.for %i = [%start to %end step %step](%acc = %input : i32) -> (i32) unroll schedule(interleaved) {
     %tile = test.read_resource %pool : pool<16> -> i32
     %next = test.addi %acc, %tile : i32
@@ -808,16 +807,67 @@ func.def @interleaved_carried_loop_rejects_read_effect(%pool: pool<16>, %input: 
   func.return %result : i32
 }
 
-// ====
-
-func.def @interleaved_carried_loop_rejects_write_effect(%pool: pool<16>, %input: i32) -> (i32) {
+// ----
+func.def @interleaved_carried_loop_reads_before_carried_updates(%pool: pool<16>, %input: i32) -> (i32) {
   %start = index.constant 0 : index
   %end = index.constant 3 : index
   %step = index.constant 1 : index
-  // ERROR@+1: STRUCTURE/014 {attr_name="schedule", expected_constraint="effect-free body operations when interleaving loop-carried values"}
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  %i_2 = index.constant 2 : index
+  %tile = test.read_resource %pool : pool<16> -> i32
+  %tile_1 = test.read_resource %pool : pool<16> -> i32
+  %tile_2 = test.read_resource %pool : pool<16> -> i32
+  %next = test.addi %input, %tile : i32
+  %next_1 = test.addi %next, %tile_1 : i32
+  %next_2 = test.addi %next_1, %tile_2 : i32
+  func.return %next_2 : i32
+}
+
+// ====
+
+func.def @interleaved_carried_loop_preserves_write_effect_order(%pool: pool<16>, %input: i32) -> (i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
   %result = scf.for %i = [%start to %end step %step](%acc = %input : i32) -> (i32) unroll schedule(interleaved) {
     %next = test.addi %acc, %acc : i32
     test.write_resource %pool, %next : pool<16>, i32
+    scf.yield %next : i32
+  }
+  func.return %result : i32
+}
+
+// ----
+func.def @interleaved_carried_loop_preserves_write_effect_order(%pool: pool<16>, %input: i32) -> (i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  %i_2 = index.constant 2 : index
+  %next = test.addi %input, %input : i32
+  test.write_resource %pool, %next : pool<16>, i32
+  %next_1 = test.addi %next, %next : i32
+  test.write_resource %pool, %next_1 : pool<16>, i32
+  %next_2 = test.addi %next_1, %next_1 : i32
+  test.write_resource %pool, %next_2 : pool<16>, i32
+  func.return %next_2 : i32
+}
+
+// ====
+
+func.def @interleaved_carried_loop_rejects_nested_region(%input: i32) -> (i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
+  // ERROR@+1: STRUCTURE/014 {attr_name="schedule", expected_constraint="body operations without nested regions or successors"}
+  %result = scf.for %i = [%start to %end step %step](%acc = %input : i32) -> (i32) unroll schedule(interleaved) {
+    %cond = index.cmp eq, %i, %start : index
+    scf.if %cond {
+      test.use %acc : i32
+    }
+    %next = test.addi %acc, %input : i32
     scf.yield %next : i32
   }
   func.return %result : i32

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -81,10 +81,8 @@ func.def @interleaved_unroll_resultless_loop(%input: i32) {
   %end = index.constant 3 : index
   %step = index.constant 1 : index
   scf.for %i = [%start to %end step %step] unroll schedule(interleaved) {
-    test.use %i : index
     %first = test.addi %input, %input : i32
     %second = test.addi %first, %input : i32
-    test.use %second : i32
   }
   func.return
 }
@@ -97,18 +95,12 @@ func.def @interleaved_unroll_resultless_loop(%input: i32) {
   %i_0 = index.constant 0 : index
   %i_1 = index.constant 1 : index
   %i_2 = index.constant 2 : index
-  test.use %i_0 : index
-  test.use %i_1 : index
-  test.use %i_2 : index
   %first = test.addi %input, %input : i32
   %first_1 = test.addi %input, %input : i32
   %first_2 = test.addi %input, %input : i32
   %second = test.addi %first, %input : i32
   %second_1 = test.addi %first_1, %input : i32
   %second_2 = test.addi %first_2, %input : i32
-  test.use %second : i32
-  test.use %second_1 : i32
-  test.use %second_2 : i32
   func.return
 }
 
@@ -170,14 +162,70 @@ func.def @interleaved_unroll_preserves_type_ref_order(%buffer: buffer, %offset: 
   %i_1 = index.constant 1 : index
   %i_2 = index.constant 2 : index
   %layout = encoding.layout.dense : encoding<layout>
-  %layout_1 = encoding.layout.dense : encoding<layout>
-  %layout_2 = encoding.layout.dense : encoding<layout>
   %view = buffer.view %buffer[%offset] : buffer -> view<4xf32, %layout>
-  %view_1 = buffer.view %buffer[%offset] : buffer -> view<4xf32, %layout_1>
-  %view_2 = buffer.view %buffer[%offset] : buffer -> view<4xf32, %layout_2>
   test.use %view : view<4xf32, %layout>
+  %layout_1 = encoding.layout.dense : encoding<layout>
+  %view_1 = buffer.view %buffer[%offset] : buffer -> view<4xf32, %layout_1>
   test.use %view_1 : view<4xf32, %layout_1>
+  %layout_2 = encoding.layout.dense : encoding<layout>
+  %view_2 = buffer.view %buffer[%offset] : buffer -> view<4xf32, %layout_2>
   test.use %view_2 : view<4xf32, %layout_2>
+  func.return
+}
+
+// ====
+
+func.def @interleaved_read_effects_commute(%pool: pool<16>) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
+  scf.for %i = [%start to %end step %step] unroll schedule(interleaved) {
+    %value = test.read_resource %pool : pool<16> -> i32
+  }
+  func.return
+}
+
+// ----
+func.def @interleaved_read_effects_commute(%pool: pool<16>) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  %i_2 = index.constant 2 : index
+  %value = test.read_resource %pool : pool<16> -> i32
+  %value_1 = test.read_resource %pool : pool<16> -> i32
+  %value_2 = test.read_resource %pool : pool<16> -> i32
+  func.return
+}
+
+// ====
+
+func.def @interleaved_write_read_hazard_preserves_order(%pool: pool<16>, %input: i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  scf.for %i = [%start to %end step %step] unroll schedule(interleaved) {
+    test.write_resource %pool, %input : pool<16>, i32
+    %value = test.read_resource %pool : pool<16> -> i32
+    test.use %value : i32
+  }
+  func.return
+}
+
+// ----
+func.def @interleaved_write_read_hazard_preserves_order(%pool: pool<16>, %input: i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  test.write_resource %pool, %input : pool<16>, i32
+  %value = test.read_resource %pool : pool<16> -> i32
+  test.use %value : i32
+  test.write_resource %pool, %input : pool<16>, i32
+  %value_1 = test.read_resource %pool : pool<16> -> i32
+  test.use %value_1 : i32
   func.return
 }
 

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -625,16 +625,172 @@ func.def @partial_factor_divisible_trip_count_omits_tail_guard() {
 
 // ====
 
-func.def @interleaved_partial_factor_requires_exact_full_unroll() {
+func.def @interleaved_partial_factor_divisible_trip_count() {
   %start = index.constant 0 : index
   %end = index.constant 4 : index
   %step = index.constant 1 : index
   %factor = index.constant 2 : index
-  // ERROR@+1: STRUCTURE/014 {attr_name="schedule", expected_constraint="exact full unroll without stripmining"}
   scf.for %i = [%start to %end step %step] unroll(%factor) schedule(interleaved) {
     test.use %i : index
   }
   func.return
+}
+
+// ----
+func.def @interleaved_partial_factor_divisible_trip_count() {
+  %start = index.constant 0 : index
+  %end = index.constant 4 : index
+  %step = index.constant 1 : index
+  %factor = index.constant 2 : index
+  %5 = index.constant 2 : index
+  %6 = index.constant 4 : index
+  scf.for %i = [%start to %6 step %5] {
+    %8 = index.constant 1 : index
+    %i_1 = index.add %i, %8 : index
+    test.use %i : index
+    test.use %i_1 : index
+  }
+  func.return
+}
+
+// ====
+
+func.def @interleaved_partial_factor_static_tail_loop() {
+  %start = index.constant 0 : index
+  %end = index.constant 5 : index
+  %step = index.constant 1 : index
+  %factor = index.constant 2 : index
+  scf.for %i = [%start to %end step %step] unroll(%factor) schedule(interleaved) {
+    test.use %i : index
+  }
+  func.return
+}
+
+// ----
+func.def @interleaved_partial_factor_static_tail_loop() {
+  %start = index.constant 0 : index
+  %end = index.constant 5 : index
+  %step = index.constant 1 : index
+  %factor = index.constant 2 : index
+  %5 = index.constant 2 : index
+  %6 = index.constant 4 : index
+  scf.for %i = [%start to %6 step %5] {
+    %8 = index.constant 1 : index
+    %i_1 = index.add %i, %8 : index
+    test.use %i : index
+    test.use %i_1 : index
+  }
+  scf.for %i = [%6 to %end step %step] {
+    test.use %i : index
+  }
+  func.return
+}
+
+// ====
+
+func.def @interleaved_partial_factor_dynamic_tail_loop(%end: index) {
+  %start = index.constant 0 : index
+  %step = index.constant 1 : index
+  %factor = index.constant 2 : index
+  scf.for %i = [%start to %end step %step] unroll(%factor) schedule(interleaved) {
+    test.use %i : index
+  }
+  func.return
+}
+
+// ----
+func.def @interleaved_partial_factor_dynamic_tail_loop(%end: index) {
+  %start = index.constant 0 : index
+  %step = index.constant 1 : index
+  %factor = index.constant 2 : index
+  %5 = index.constant 2 : index
+  %6 = index.constant 0 : index
+  %7 = index.sub %end, %start : index
+  %8 = index.max %7, %6 : index
+  %9 = index.div %8, %factor : index
+  %10 = index.mul %9, %5 : index
+  %11 = index.add %start, %10 : index
+  scf.for %i = [%start to %11 step %5] {
+    %13 = index.constant 1 : index
+    %i_1 = index.add %i, %13 : index
+    test.use %i : index
+    test.use %i_1 : index
+  }
+  scf.for %i = [%11 to %end step %step] {
+    test.use %i : index
+  }
+  func.return
+}
+
+// ====
+
+func.def @interleaved_partial_factor_dynamic_tail_step_two(%end: index) {
+  %start = index.constant 0 : index
+  %step = index.constant 2 : index
+  %factor = index.constant 2 : index
+  scf.for %i = [%start to %end step %step] unroll(%factor) schedule(interleaved) {
+    test.use %i : index
+  }
+  func.return
+}
+
+// ----
+func.def @interleaved_partial_factor_dynamic_tail_step_two(%end: index) {
+  %start = index.constant 0 : index
+  %step = index.constant 2 : index
+  %factor = index.constant 2 : index
+  %5 = index.constant 4 : index
+  %6 = index.constant 0 : index
+  %7 = index.sub %end, %start : index
+  %8 = index.max %7, %6 : index
+  %9 = index.constant 1 : index
+  %10 = index.add %8, %9 : index
+  %11 = index.div %10, %step : index
+  %12 = index.div %11, %factor : index
+  %13 = index.mul %12, %5 : index
+  %14 = index.add %start, %13 : index
+  scf.for %i = [%start to %14 step %5] {
+    %16 = index.constant 2 : index
+    %i_2 = index.add %i, %16 : index
+    test.use %i : index
+    test.use %i_2 : index
+  }
+  scf.for %i = [%14 to %end step %step] {
+    test.use %i : index
+  }
+  func.return
+}
+
+// ====
+
+func.def @interleaved_partial_factor_carried_loop(%input: i32) -> (i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 4 : index
+  %step = index.constant 1 : index
+  %factor = index.constant 2 : index
+  %result = scf.for %i = [%start to %end step %step](%acc = %input : i32) -> (i32) unroll(%factor) schedule(interleaved) {
+    %next = test.addi %acc, %input : i32
+    scf.yield %next : i32
+  }
+  func.return %result : i32
+}
+
+// ----
+func.def @interleaved_partial_factor_carried_loop(%input: i32) -> (i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 4 : index
+  %step = index.constant 1 : index
+  %factor = index.constant 2 : index
+  %10 = index.constant 2 : index
+  %11 = index.constant 4 : index
+  %result = scf.for %i = [%start to %11 step %10](%acc = %input : i32) -> (i32) {
+    %15 = index.constant 1 : index
+    %i_1 = index.add %i, %15 : index
+    %next = test.addi %acc, %input : i32
+    %next_1 = test.addi %next, %input : i32
+    scf.yield %next_1 : i32
+  }
+  func.return %result : i32
 }
 
 // ====

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -383,6 +383,36 @@ func.def @interleaved_partial_factor_requires_exact_full_unroll() {
 
 // ====
 
+func.def @interleaved_carried_loop_rejects_read_effect(%pool: pool<16>, %input: i32) -> (i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
+  // ERROR@+1: STRUCTURE/014 {attr_name="schedule", expected_constraint="effect-free body operations when interleaving loop-carried values"}
+  %result = scf.for %i = [%start to %end step %step](%acc = %input : i32) -> (i32) unroll schedule(interleaved) {
+    %tile = test.read_resource %pool : pool<16> -> i32
+    %next = test.addi %acc, %tile : i32
+    scf.yield %next : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+func.def @interleaved_carried_loop_rejects_write_effect(%pool: pool<16>, %input: i32) -> (i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
+  // ERROR@+1: STRUCTURE/014 {attr_name="schedule", expected_constraint="effect-free body operations when interleaving loop-carried values"}
+  %result = scf.for %i = [%start to %end step %step](%acc = %input : i32) -> (i32) unroll schedule(interleaved) {
+    %next = test.addi %acc, %acc : i32
+    test.write_resource %pool, %next : pool<16>, i32
+    scf.yield %next : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
 func.def @dynamic_bound_factor_stripmines(%end: index) {
   %start = index.constant 0 : index
   %step = index.constant 1 : index

--- a/loom/src/loom/transforms/vector/to_scalar_aggregates.c
+++ b/loom/src/loom/transforms/vector/to_scalar_aggregates.c
@@ -79,7 +79,8 @@ static iree_status_t loom_vector_to_scalar_aggregate_loop_axis(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, &current_aggregate, 1, &state->vector_type, 1, NULL, 0,
-      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, state->location, &loop));
+      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, /*unroll_schedule=*/0,
+      state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(
@@ -213,7 +214,8 @@ static iree_status_t loom_vector_to_scalar_splat_loop_axis(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, &current_aggregate, 1, &state->vector_type, 1, NULL, 0,
-      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, state->location, &loop));
+      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, /*unroll_schedule=*/0,
+      state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(

--- a/loom/src/loom/transforms/vector/to_scalar_memory.c
+++ b/loom/src/loom/transforms/vector/to_scalar_memory.c
@@ -253,7 +253,7 @@ static iree_status_t loom_vector_to_scalar_build_dynamic_active_prefix(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, lane_index,
       step, &lower_bound, 1, &index_type, 1, NULL, 0, LOOM_VALUE_ID_INVALID,
-      /*unroll_policy=*/0, state->location, &loop));
+      /*unroll_policy=*/0, /*unroll_schedule=*/0, state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(
@@ -646,7 +646,7 @@ static iree_status_t loom_vector_to_scalar_lower_memory_store_loop_axis(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, NULL, 0, NULL, 0, NULL, 0, LOOM_VALUE_ID_INVALID,
-      /*unroll_policy=*/0, state->location, &loop));
+      /*unroll_policy=*/0, /*unroll_schedule=*/0, state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(
@@ -861,7 +861,7 @@ static iree_status_t loom_vector_to_scalar_lower_fragment_store_columns(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, NULL, 0, NULL, 0, NULL, 0, LOOM_VALUE_ID_INVALID,
-      /*unroll_policy=*/0, state->location, &loop));
+      /*unroll_policy=*/0, /*unroll_schedule=*/0, state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(
@@ -902,7 +902,7 @@ iree_status_t loom_vector_to_scalar_lower_fragment_store(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, NULL, 0, NULL, 0, NULL, 0, LOOM_VALUE_ID_INVALID,
-      /*unroll_policy=*/0, state->location, &loop));
+      /*unroll_policy=*/0, /*unroll_schedule=*/0, state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(
@@ -1108,7 +1108,7 @@ loom_vector_fragment_store_to_scalar_physical_result_loop_rewrite_ops(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &rewriter->builder, /*build_flags=*/0, zero, upper_bound, step, NULL, 0,
       NULL, 0, NULL, 0, LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0,
-      first_op->location, &loop));
+      /*unroll_schedule=*/0, first_op->location, &loop));
   loom_vector_to_scalar_record_loop_created(&state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(&rewriter->builder, loop,
@@ -1190,7 +1190,7 @@ static iree_status_t loom_vector_to_scalar_lower_dynamic_store_compress(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, NULL, 0, NULL, 0, NULL, 0, LOOM_VALUE_ID_INVALID,
-      /*unroll_policy=*/0, state->location, &loop));
+      /*unroll_policy=*/0, /*unroll_schedule=*/0, state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(
@@ -1375,7 +1375,7 @@ static iree_status_t loom_vector_to_scalar_lower_atomic_reduce_loop_axis(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, NULL, 0, NULL, 0, NULL, 0, LOOM_VALUE_ID_INVALID,
-      /*unroll_policy=*/0, state->location, &loop));
+      /*unroll_policy=*/0, /*unroll_schedule=*/0, state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(
@@ -1618,7 +1618,8 @@ static iree_status_t loom_vector_to_scalar_atomic_rmw_loop_axis(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, &current_aggregate, 1, &state->vector_type, 1, NULL, 0,
-      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, state->location, &loop));
+      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, /*unroll_schedule=*/0,
+      state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(
@@ -1777,7 +1778,8 @@ static iree_status_t loom_vector_to_scalar_atomic_cmpxchg_loop_axis(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, &current_aggregate, 1, &state->vector_type, 1, NULL, 0,
-      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, state->location, &loop));
+      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, /*unroll_schedule=*/0,
+      state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(

--- a/loom/src/loom/transforms/vector/to_scalar_mma.c
+++ b/loom/src/loom/transforms/vector/to_scalar_mma.c
@@ -872,7 +872,7 @@ static iree_status_t loom_vector_to_scalar_mma_accumulator_loop(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, &init_lane, 1, &accumulator_type, 1, NULL, 0, LOOM_VALUE_ID_INVALID,
-      /*unroll_policy=*/0, state->location, &loop));
+      /*unroll_policy=*/0, /*unroll_schedule=*/0, state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(
@@ -930,7 +930,8 @@ static iree_status_t loom_vector_to_scalar_mma_column_loop(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, &current_aggregate, 1, &init->type, 1, NULL, 0,
-      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, state->location, &loop));
+      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, /*unroll_schedule=*/0,
+      state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(
@@ -973,7 +974,7 @@ static iree_status_t loom_vector_to_scalar_mma_row_loop(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, &init->payload, 1, &init->type, 1, NULL, 0, LOOM_VALUE_ID_INVALID,
-      /*unroll_policy=*/0, state->location, &loop));
+      /*unroll_policy=*/0, /*unroll_schedule=*/0, state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(

--- a/loom/src/loom/transforms/vector/to_scalar_quantized.c
+++ b/loom/src/loom/transforms/vector/to_scalar_quantized.c
@@ -689,7 +689,8 @@ static iree_status_t loom_vector_to_scalar_build_bitpack_bitstream_lane(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, &initial_accumulator, 1, &storage_work_type, 1, NULL, 0,
-      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, state->location, &loop));
+      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, /*unroll_schedule=*/0,
+      state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(
@@ -981,7 +982,8 @@ static iree_status_t loom_vector_to_scalar_build_bitunpack_bitstream_lane(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, &initial_accumulator, 1, &result_work_type, 1, NULL, 0,
-      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, state->location, &loop));
+      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, /*unroll_schedule=*/0,
+      state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(

--- a/loom/src/loom/transforms/vector/to_scalar_reductions.c
+++ b/loom/src/loom/transforms/vector/to_scalar_reductions.c
@@ -313,7 +313,8 @@ static iree_status_t loom_vector_to_scalar_accumulator_loop_axis(
       &state->lane_state.rewriter->builder, /*build_flags=*/0, lower_bound,
       upper_bound, step, &current_accumulator, 1,
       &state->lane_state.result_scalar_type, 1, NULL, 0, LOOM_VALUE_ID_INVALID,
-      /*unroll_policy=*/0, state->lane_state.location, &loop));
+      /*unroll_policy=*/0, /*unroll_schedule=*/0, state->lane_state.location,
+      &loop));
   loom_vector_to_scalar_record_loop_created(&state->lane_state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(
@@ -551,7 +552,8 @@ static iree_status_t loom_vector_to_scalar_reduce_axes_axis(
       &state->lane_state.rewriter->builder, /*build_flags=*/0, lower_bound,
       upper_bound, step, &current_accumulator, 1,
       &state->lane_state.result_scalar_type, 1, NULL, 0, LOOM_VALUE_ID_INVALID,
-      /*unroll_policy=*/0, state->lane_state.location, &loop));
+      /*unroll_policy=*/0, /*unroll_schedule=*/0, state->lane_state.location,
+      &loop));
   loom_vector_to_scalar_record_loop_created(&state->lane_state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(
@@ -762,8 +764,8 @@ static iree_status_t loom_vector_to_scalar_reduce_axes_result_loop_axis(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->lane_state.rewriter->builder, /*build_flags=*/0, lower_bound,
       upper_bound, step, &current_aggregate, 1, &state->result_type, 1, NULL, 0,
-      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, state->lane_state.location,
-      &loop));
+      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, /*unroll_schedule=*/0,
+      state->lane_state.location, &loop));
   loom_vector_to_scalar_record_loop_created(&state->lane_state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(

--- a/loom/src/loom/transforms/vector/to_scalar_structural.c
+++ b/loom/src/loom/transforms/vector/to_scalar_structural.c
@@ -617,7 +617,8 @@ loom_vector_to_scalar_build_dynamic_shape_changing_bitcast_lane(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, &initial_accumulator, 1, &result_integer_type, 1, NULL, 0,
-      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, state->location, &loop));
+      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, /*unroll_schedule=*/0,
+      state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(

--- a/loom/src/loom/transforms/vector/to_scalar_tables.c
+++ b/loom/src/loom/transforms/vector/to_scalar_tables.c
@@ -173,7 +173,8 @@ static iree_status_t loom_vector_to_scalar_build_table_quantize_dynamic_lane(
   IREE_RETURN_IF_ERROR(loom_scf_for_build(
       &state->rewriter->builder, /*build_flags=*/0, lower_bound, upper_bound,
       step, &initial_accumulator, 1, &state->result_scalar_type, 1, NULL, 0,
-      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, state->location, &loop));
+      LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, /*unroll_schedule=*/0,
+      state->location, &loop));
   loom_vector_to_scalar_record_loop_created(state);
 
   loom_builder_ip_t saved = loom_builder_enter_region(


### PR DESCRIPTION
This PR makes `scf.for ... schedule(interleaved)` a real authoring tool for latency-hiding loop shapes instead of a narrow full-unroll experiment. Authors can now ask Loom to materialize corresponding body positions across unrolled iterations while the transform preserves SSA dependences, loop-carried state, dynamic tails, and memory ordering.

The new spelling is intentionally compact:

```mlir
scf.for %i = [%start to %end step %step] unroll schedule(interleaved) {
  %a = ...
  %b = ... %a ...
}
```

For a fixed trip count this produces the shape authors usually want when trying to expose independent work:

```mlir
%a0 = ...
%a1 = ...
%a2 = ...
%b0 = ... %a0 ...
%b1 = ... %a1 ...
%b2 = ... %a2 ...
```

The same schedule works with explicit unroll factors and dynamic tails:

```mlir
scf.for %i = [%start to %end step %step] unroll(%factor) schedule(interleaved) {
  ...
}
```

When the trip count may not be divisible by the factor, Loom now splits the loop into an interleaved main loop and an ordinary tail loop. That gives authors the useful fixed-width channel lane shape without forcing them to write unsafe static bounds or discard dynamic kernels. The main loop advances by `step * factor`, and the tail loop preserves the original source order for remaining iterations.

Loop-carried values are supported too. This is still an ordinary sequential recurrence, not a reduction contract, so the compiler preserves the carried chain while interleaving independent work around it:

```mlir
%result = scf.for %i = [%start to %end step %step](%acc = %input : i32) -> (i32) unroll schedule(interleaved) {
  %tile = view.load ...
  %next = scalar.addi %acc, %tile : i32
  scf.yield %next : i32
}
```

That can become:

```mlir
%tile0 = view.load ...
%tile1 = view.load ...
%tile2 = view.load ...
%next0 = scalar.addi %input, %tile0 : i32
%next1 = scalar.addi %next0, %tile1 : i32
%next2 = scalar.addi %next1, %tile2 : i32
```

Memory effects participate in the same dependence-aware scheduling. Read-only effects can commute. Disjoint vector stores can commute when movement analysis proves the footprints cannot overlap. Write/read hazards and overlapping stores stay ordered. This keeps the feature useful for real kernels with staging, packetized loads, vector stores, and tail handling, while still making `schedule(interleaved)` a request that is constrained by semantics rather than a directive that punches through them.

The implementation stays target-independent. The SCF transform does not learn about AMDGPU, scalar, vector, or future tile ops. It asks shared movement and footprint analysis whether operations can move, and it schedules an operation for an unrolled ordinal only when the remapped operands, types, attributes, and effect dependencies are available. Unsupported body shapes still fail with structured schedule diagnostics; nested-region bodies remain rejected because this pass does not yet have a dependence model for cloning and interleaving nested control flow.

This is the first useful layer for author-directed scheduling. The obvious next step is explicit reduction semantics for `scf.for` carried values: authors should eventually be able to say that a carried result is a reassociable reduction contribution instead of an ordinary sequential recurrence. That is deliberately not folded into this PR. This branch gives us the dependence-aware interleaving substrate first, so the reduction design can build on a scheduler that already understands dynamic tails, carried values, and effects.
