### PR TITLE
[Loom] Support stripmine tails and stricter fact/config contracts

### DIFF
--- a/loom/binding/c/include/loomc/config.h
+++ b/loom/binding/c/include/loomc/config.h
@@ -57,7 +57,9 @@ typedef struct loomc_config_binding_t {
 
 /// Configuration validation and resolution policy bit values.
 typedef enum loomc_config_policy_flag_bits_e {
-  /// Reject config bindings that do not match any known config symbol.
+  /// Reject config bindings outside the current operation's known config
+  /// declaration set. Link operations validate this before final pruning so
+  /// declared-but-unused bindings may be accepted and ignored.
   LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN = 1u << 0,
 
   /// Require all final operation config values to be resolved.

--- a/loom/binding/c/src/config.c
+++ b/loom/binding/c/src/config.c
@@ -113,6 +113,21 @@ static loom_tooling_config_materialize_flags_t loomc_config_materialize_flags(
   return result;
 }
 
+static iree_status_t loomc_config_validate_known_keys(
+    const loom_tooling_config_set_t* config_set,
+    loomc_config_known_key_fn_t is_known_key, void* known_key_user_data) {
+  if (!config_set || !is_known_key) return iree_ok_status();
+  for (iree_host_size_t i = 0; i < config_set->binding_count; ++i) {
+    const loom_tooling_config_binding_t* binding = &config_set->bindings[i];
+    if (is_known_key(known_key_user_data, binding->key)) {
+      continue;
+    }
+    return iree_make_status(IREE_STATUS_NOT_FOUND, "unknown config '%.*s'",
+                            (int)binding->key.size, binding->key.data);
+  }
+  return iree_ok_status();
+}
+
 loomc_status_t loomc_config_apply_to_module(
     const loomc_config_apply_to_module_options_t* options) {
   if (options == NULL || options->module == NULL || options->result == NULL ||
@@ -133,11 +148,21 @@ loomc_status_t loomc_config_apply_to_module(
   loomc_status_t status = loomc_status_from_iree(
       loomc_config_populate_set(options->config, host_allocator, &config_set));
   loom_tooling_config_materialize_result_t materialize_result = {0};
+  if (loomc_status_is_ok(status) && options->is_known_key &&
+      iree_any_bit_set(options->config->flags,
+                       LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN)) {
+    status = loomc_status_from_iree(loomc_config_validate_known_keys(
+        &config_set, options->is_known_key, options->known_key_user_data));
+  }
   if (loomc_status_is_ok(status)) {
     loom_tooling_config_materialize_options_t materialize_options;
     loom_tooling_config_materialize_options_initialize(&materialize_options);
     materialize_options.flags =
         loomc_config_materialize_flags(options->config->flags);
+    if (options->is_known_key) {
+      materialize_options.flags &=
+          ~LOOM_TOOLING_CONFIG_MATERIALIZE_REQUIRE_MATCHES;
+    }
     materialize_options.config_set = &config_set;
     status = loomc_status_from_iree(loom_tooling_config_materialize_module(
         options->module, &materialize_options, options->block_pool,

--- a/loom/binding/c/src/config.h
+++ b/loom/binding/c/src/config.h
@@ -18,6 +18,11 @@
 extern "C" {
 #endif
 
+// Returns true when |key| names a config symbol known to the enclosing
+// invocation before final pruning.
+typedef bool (*loomc_config_known_key_fn_t)(void* user_data,
+                                            iree_string_view_t key);
+
 // Module config application options.
 typedef struct loomc_config_apply_to_module_options_t {
   // Public per-invocation config options to materialize.
@@ -31,6 +36,15 @@ typedef struct loomc_config_apply_to_module_options_t {
 
   // Diagnostic code used when config-domain statuses become result diagnostics.
   loomc_string_view_t diagnostic_code;
+
+  // Optional config-key membership query used for REJECT_UNKNOWN. When set,
+  // unknown bindings are rejected against this query before materialization,
+  // and bindings known by the invocation but pruned from |module| are ignored
+  // by final materialization.
+  loomc_config_known_key_fn_t is_known_key;
+
+  // User data passed to |is_known_key|.
+  void* known_key_user_data;
 
   // Block pool for transient config materialization storage.
   iree_arena_block_pool_t* block_pool;

--- a/loom/binding/c/src/link.c
+++ b/loom/binding/c/src/link.c
@@ -68,6 +68,15 @@ typedef struct loomc_link_diagnostic_capture_t {
   const loomc_source_t* source;
 } loomc_link_diagnostic_capture_t;
 
+typedef struct loomc_link_config_known_key_query_t {
+  // Frozen index that supplied the link plan.
+  const loom_link_module_index_t* index;
+  // Module ordinals selected by the link plan.
+  const uint8_t* selected_modules;
+  // Number of entries in |selected_modules|.
+  iree_host_size_t selected_module_count;
+} loomc_link_config_known_key_query_t;
+
 static iree_allocator_t loomc_link_iree_allocator(loomc_allocator_t allocator) {
   return iree_allocator_from_loomc(allocator);
 }
@@ -75,6 +84,12 @@ static iree_allocator_t loomc_link_iree_allocator(loomc_allocator_t allocator) {
 static bool loomc_link_any_flag_set(loomc_link_flags_t flags,
                                     loomc_link_flags_t bits) {
   return (flags & bits) != 0;
+}
+
+static bool loomc_link_config_options_have_bindings(
+    const loomc_config_options_t* config) {
+  return config && (config->binding_count != 0 ||
+                    !loomc_string_view_is_empty(config->json_object));
 }
 
 static loomc_status_t loomc_link_validate_linker_options(
@@ -385,6 +400,68 @@ static iree_status_t loomc_link_plan_build_roots(
   return iree_ok_status();
 }
 
+static iree_status_t loomc_link_plan_build_module_bitmap(
+    const loom_link_plan_t* plan, iree_arena_allocator_t* arena,
+    const uint8_t** out_selected_modules,
+    iree_host_size_t* out_selected_module_count) {
+  *out_selected_modules = NULL;
+  *out_selected_module_count = 0;
+  const loom_link_module_index_t* index = loom_link_plan_index(plan);
+  const iree_host_size_t module_count =
+      loom_link_module_index_module_count(index);
+  if (module_count == 0) {
+    return iree_ok_status();
+  }
+
+  uint8_t* selected_modules = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(arena, module_count,
+                                                 sizeof(*selected_modules),
+                                                 (void**)&selected_modules));
+  memset(selected_modules, 0, module_count * sizeof(*selected_modules));
+
+  const iree_host_size_t plan_symbol_count = loom_link_plan_symbol_count(plan);
+  for (iree_host_size_t i = 0; i < plan_symbol_count; ++i) {
+    const loom_link_plan_symbol_t* planned = loom_link_plan_symbol_at(plan, i);
+    const loom_link_module_index_symbol_t* symbol =
+        loom_link_module_index_symbol_at(index, planned->symbol_ordinal);
+    const loom_link_module_index_module_t* module =
+        loom_link_module_index_symbol_module(index, symbol);
+    if (module == NULL || module->ordinal >= module_count) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "link plan referenced a stale module");
+    }
+    selected_modules[module->ordinal] = 1;
+  }
+
+  *out_selected_modules = selected_modules;
+  *out_selected_module_count = module_count;
+  return iree_ok_status();
+}
+
+static bool loomc_link_config_key_known(void* user_data,
+                                        iree_string_view_t key) {
+  const loomc_link_config_known_key_query_t* query =
+      (const loomc_link_config_known_key_query_t*)user_data;
+  if (!query || !query->index || !query->selected_modules) {
+    return false;
+  }
+  const iree_host_size_t symbol_count =
+      loom_link_module_index_symbol_count(query->index);
+  for (iree_host_size_t i = 0; i < symbol_count; ++i) {
+    const loom_link_module_index_symbol_t* symbol =
+        loom_link_module_index_symbol_at(query->index, i);
+    if (!symbol || symbol->module_ordinal >= query->selected_module_count ||
+        !query->selected_modules[symbol->module_ordinal] ||
+        !iree_any_bit_set(symbol->flags, LOOM_LINK_SYMBOL_FLAG_CONFIG)) {
+      continue;
+    }
+    if (iree_string_view_equal(symbol->name, key)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 static iree_status_t loomc_link_add_planned_modules(
     loomc_link_materialization_cache_t* cache, const loom_link_plan_t* plan,
     bool selective, iree_arena_allocator_t* arena, loom_linker_t* linker) {
@@ -541,6 +618,9 @@ loomc_status_t loomc_link_module(loomc_linker_t* linker,
   loomc_module_t* module = NULL;
   loom_linker_t* internal_linker = NULL;
   loom_module_t* linked_module = NULL;
+  const uint8_t* config_selected_modules = NULL;
+  iree_host_size_t config_selected_module_count = 0;
+  loomc_link_config_known_key_query_t config_known_key_query = {0};
 
   loomc_status_t status = loomc_link_materialization_cache_initialize(
       linker, workspace, options->link_index, result, &cache);
@@ -620,11 +700,28 @@ loomc_status_t loomc_link_module(loomc_linker_t* linker,
         operation_status);
   }
   if (loomc_status_is_ok(status) && loomc_result_succeeded(result)) {
+    if (iree_any_bit_set(options->config.flags,
+                         LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN) &&
+        loomc_link_config_options_have_bindings(&options->config)) {
+      status = loomc_status_from_iree(loomc_link_plan_build_module_bitmap(
+          plan, &arena, &config_selected_modules,
+          &config_selected_module_count));
+      config_known_key_query = (loomc_link_config_known_key_query_t){
+          .index = cache.module_index,
+          .selected_modules = config_selected_modules,
+          .selected_module_count = config_selected_module_count,
+      };
+    }
+  }
+  if (loomc_status_is_ok(status) && loomc_result_succeeded(result)) {
     loomc_config_apply_to_module_options_t config_apply_options = {
         .config = &options->config,
         .module = linked_module,
         .result = result,
         .diagnostic_code = loomc_make_cstring_view("CONFIG/INVALID"),
+        .is_known_key =
+            config_selected_modules ? loomc_link_config_key_known : NULL,
+        .known_key_user_data = &config_known_key_query,
         .block_pool = loomc_workspace_block_pool(workspace),
         .allocator = linker->allocator,
     };

--- a/loom/binding/c/test/link_test.cc
+++ b/loom/binding/c/test/link_test.cc
@@ -1196,6 +1196,135 @@ func.def public @from_bytecode() -> (index) {
             std::string::npos);
 }
 
+TEST(LinkTest, LinkModuleAcceptsDeclaredUnusedConfigFromBytecodeIndex) {
+  std::vector<uint8_t> bytecode = WriteBytecodeModule(R"(
+config.decl @id4.vae.conv3x3_bias.output_channel_count : %value: index where [range(%value, 1, 8192)]
+
+func.def public @generic() -> (index) {
+  %channels = config.get @id4.vae.conv3x3_bias.output_channel_count : index
+  func.return %channels : index
+}
+
+func.def public @specialized_rgb() -> (index) {
+  %channels = index.constant 3 : index
+  func.return %channels : index
+}
+)");
+  ContextPtr context = CreateContext();
+  BuilderPtr builder = CreateBuilder(context.get());
+  SourcePtr source = CreateSource(LOOMC_SOURCE_FORMAT_BYTECODE, "module.loombc",
+                                  bytecode.data(), bytecode.size());
+  AddSource(builder.get(), source.get(), "bytecode",
+            LOOMC_LINK_PROVIDER_ROLE_INPUT);
+
+  LinkIndexPtr link_index;
+  FinishIndex(builder.get(), &link_index);
+  source.reset();
+  bytecode.clear();
+
+  LinkerPtr linker = CreateLinker(context.get());
+  WorkspacePtr workspace = CreateWorkspace();
+  const loomc_string_view_t roots[] = {
+      loomc_make_cstring_view("@specialized_rgb"),
+  };
+  loomc_config_binding_t bindings[] = {
+      {
+          /*.key=*/
+          loomc_make_cstring_view("@id4.vae.conv3x3_bias.output_channel_count"),
+          /*.value=*/loomc_make_cstring_view("3"),
+      },
+  };
+  loomc_link_options_t options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_NONE,
+      /*.structure_size=*/0,
+      /*.next=*/nullptr,
+      /*.link_index=*/nullptr,
+      /*.module_name=*/loomc_string_view_empty(),
+      /*.root_symbols=*/roots,
+      /*.root_symbol_count=*/1,
+      /*.flags=*/0,
+      /*.config=*/
+      {
+          /*.bindings=*/bindings,
+          /*.binding_count=*/1,
+          /*.json_object=*/loomc_string_view_empty(),
+          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
+              LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+      },
+  };
+  ResultPtr result;
+  ModulePtr module = LinkIndex(linker.get(), workspace.get(), link_index.get(),
+                               &options, &result);
+
+  ASSERT_TRUE(loomc_result_succeeded(result.get()));
+  ASSERT_NE(module.get(), nullptr);
+  std::string text = SerializeModuleToText(module.get());
+  EXPECT_NE(text.find("func.def public @specialized_rgb"), std::string::npos);
+  EXPECT_EQ(text.find("func.def public @generic"), std::string::npos);
+  EXPECT_EQ(text.find("id4.vae.conv3x3_bias.output_channel_count"),
+            std::string::npos);
+}
+
+TEST(LinkTest, LinkModuleRejectsConfigDeclaredOnlyByUnselectedProvider) {
+  ContextPtr context = CreateContext();
+  BuilderPtr builder = CreateBuilder(context.get());
+  SourcePtr selected_source = CreateTextSource("selected.loom", R"(
+func.def public @selected() -> (index) {
+  %value = index.constant 1 : index
+  func.return %value : index
+}
+)");
+  AddSource(builder.get(), selected_source.get(), "selected",
+            LOOMC_LINK_PROVIDER_ROLE_INPUT);
+  SourcePtr unused_source = CreateTextSource("unused.loom", R"(
+config.decl @unused.operation.tile_count : index
+
+func.def public @unused() -> (index) {
+  %tiles = config.get @unused.operation.tile_count : index
+  func.return %tiles : index
+}
+)");
+  AddSource(builder.get(), unused_source.get(), "unused",
+            LOOMC_LINK_PROVIDER_ROLE_LIBRARY);
+
+  LinkIndexPtr link_index;
+  FinishIndex(builder.get(), &link_index);
+  LinkerPtr linker = CreateLinker(context.get());
+  WorkspacePtr workspace = CreateWorkspace();
+  const loomc_string_view_t roots[] = {
+      loomc_make_cstring_view("@selected"),
+  };
+  loomc_config_binding_t bindings[] = {
+      {
+          /*.key=*/loomc_make_cstring_view("@unused.operation.tile_count"),
+          /*.value=*/loomc_make_cstring_view("4"),
+      },
+  };
+  loomc_link_options_t options = {
+      /*.type=*/LOOMC_STRUCTURE_TYPE_NONE,
+      /*.structure_size=*/0,
+      /*.next=*/nullptr,
+      /*.link_index=*/nullptr,
+      /*.module_name=*/loomc_string_view_empty(),
+      /*.root_symbols=*/roots,
+      /*.root_symbol_count=*/1,
+      /*.flags=*/0,
+      /*.config=*/
+      {
+          /*.bindings=*/bindings,
+          /*.binding_count=*/1,
+          /*.json_object=*/loomc_string_view_empty(),
+          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN,
+      },
+  };
+  ResultPtr result;
+  ModulePtr module = LinkIndex(linker.get(), workspace.get(), link_index.get(),
+                               &options, &result);
+
+  EXPECT_EQ(module.get(), nullptr);
+  ExpectFailedResultCode(result.get(), "CONFIG/INVALID");
+}
+
 TEST(LinkTest, LinkModuleReportsUnknownConfigAsResultDiagnostic) {
   ContextPtr context = CreateContext();
   BuilderPtr builder = CreateBuilder(context.get());

--- a/loom/py/loom/dialect/scf/defs.py
+++ b/loom/py/loom/dialect/scf/defs.py
@@ -384,6 +384,8 @@ scf_for = Op(
     examples=[
         "scf.for %iv = [%c0 to %n step %c1] {\n  scf.yield\n}",
         "%result = scf.for %iv = [%c0 to %n step %c1](%acc = %init : f32) -> (f32) {\n  %next = scalar.addf %acc, %acc : f32\n  scf.yield %next : f32\n}",
+        "scf.for %iv = [%c0 to %n step %c1] unroll(%factor) {\n  scf.yield\n}",
+        "scf.for %iv = [%c0 to %n step %c1] unroll(%factor) schedule(interleaved) {\n  scf.yield\n}",
     ],
 )
 

--- a/loom/py/loom/error/target.py
+++ b/loom/py/loom/error/target.py
@@ -1028,6 +1028,82 @@ ERR_TARGET_058 = ErrorDef(
     ),
 )
 
+# ERR_TARGET_059: Assume predicate contradicts known value range.
+ERR_TARGET_059 = ErrorDef(
+    domain=ErrorDomain.TARGET,
+    code=59,
+    severity=Severity.ERROR,
+    summary="Assume predicate contradicts known value range.",
+    message=(
+        "target '{target_key}' export '{export_name}' config '{config_key}' "
+        "rejected '{op_name}' in '@{function_name}': predicate "
+        "'{predicate_name}' on '{value_name}' requires range "
+        "[{required_min}, {required_max}] but known facts prove range "
+        "[{known_min}, {known_max}]"
+    ),
+    params=(
+        *_TARGET_CONTEXT_PARAMS,
+        ErrorParam("predicate_name", ParamKind.STRING),
+        ErrorParam("value_name", ParamKind.STRING),
+        ErrorParam("required_min", ParamKind.I64),
+        ErrorParam("required_max", ParamKind.I64),
+        ErrorParam("known_min", ParamKind.I64),
+        ErrorParam("known_max", ParamKind.I64),
+    ),
+    fix_hint=(
+        "Remove the impossible assume, widen the predicate, or guard the "
+        "assume so only values satisfying the predicate can reach it."
+    ),
+)
+
+# ERR_TARGET_060: Assume predicate contradicts exact integer facts.
+ERR_TARGET_060 = ErrorDef(
+    domain=ErrorDomain.TARGET,
+    code=60,
+    severity=Severity.ERROR,
+    summary="Assume predicate contradicts exact integer facts.",
+    message=(
+        "target '{target_key}' export '{export_name}' config '{config_key}' "
+        "rejected '{op_name}' in '@{function_name}': predicate "
+        "'{predicate_name}' on '{value_name}' cannot be satisfied by exact "
+        "integer value {known_value}"
+    ),
+    params=(
+        *_TARGET_CONTEXT_PARAMS,
+        ErrorParam("predicate_name", ParamKind.STRING),
+        ErrorParam("value_name", ParamKind.STRING),
+        ErrorParam("known_value", ParamKind.I64),
+    ),
+    fix_hint=(
+        "Remove the impossible assume, change the exact value, or guard the "
+        "assume so only values satisfying the predicate can reach it."
+    ),
+)
+
+# ERR_TARGET_061: Assume predicate contradicts exact floating-point facts.
+ERR_TARGET_061 = ErrorDef(
+    domain=ErrorDomain.TARGET,
+    code=61,
+    severity=Severity.ERROR,
+    summary="Assume predicate contradicts exact floating-point facts.",
+    message=(
+        "target '{target_key}' export '{export_name}' config '{config_key}' "
+        "rejected '{op_name}' in '@{function_name}': predicate "
+        "'{predicate_name}' on '{value_name}' cannot be satisfied by exact "
+        "floating-point class '{value_class}'"
+    ),
+    params=(
+        *_TARGET_CONTEXT_PARAMS,
+        ErrorParam("predicate_name", ParamKind.STRING),
+        ErrorParam("value_name", ParamKind.STRING),
+        ErrorParam("value_class", ParamKind.STRING),
+    ),
+    fix_hint=(
+        "Remove the impossible assume, change the exact value, or guard the "
+        "assume so only values satisfying the predicate can reach it."
+    ),
+)
+
 ALL_TARGET_ERRORS = (
     ERR_TARGET_001,
     ERR_TARGET_002,
@@ -1079,4 +1155,7 @@ ALL_TARGET_ERRORS = (
     ERR_TARGET_056,
     ERR_TARGET_057,
     ERR_TARGET_058,
+    ERR_TARGET_059,
+    ERR_TARGET_060,
+    ERR_TARGET_061,
 )

--- a/loom/src/loom/codegen/low/transforms/pipeline/target_legalize.c
+++ b/loom/src/loom/codegen/low/transforms/pipeline/target_legalize.c
@@ -427,6 +427,17 @@ static iree_string_view_t loom_low_target_legalize_nonempty(
   return iree_string_view_is_empty(value) ? placeholder : value;
 }
 
+static iree_string_view_t loom_low_target_legalize_value_name(
+    const loom_module_t* module, loom_value_id_t value_id) {
+  if (value_id >= module->values.count) return IREE_SV("<unknown>");
+  const loom_value_t* value = loom_module_value(module, value_id);
+  if (value->name_id == LOOM_STRING_ID_INVALID ||
+      value->name_id >= module->strings.count) {
+    return IREE_SV("<unnamed>");
+  }
+  return module->strings.entries[value->name_id];
+}
+
 static bool loom_low_target_legalize_should_stop_preflight(
     const loom_low_target_legalize_function_state_t* state) {
   return state->pass_state->max_errors != 0 &&
@@ -563,35 +574,38 @@ static bool loom_low_target_legalize_lookup_assume_operand_facts(
   return false;
 }
 
+static void loom_low_target_legalize_context_params(
+    loom_low_target_legalize_function_state_t* state, const loom_op_t* op,
+    loom_diagnostic_param_t* params) {
+  const loom_target_bundle_t* bundle = state->selection->target_bundle;
+  const loom_target_config_t* config = bundle ? bundle->config : NULL;
+  const loom_target_export_plan_t* export_plan =
+      bundle ? bundle->export_plan : NULL;
+  params[0] = loom_param_string(loom_low_target_legalize_nonempty(
+      bundle ? bundle->name : iree_string_view_empty(), IREE_SV("<empty>")));
+  params[1] = loom_param_string(loom_low_target_legalize_nonempty(
+      export_plan ? export_plan->name : iree_string_view_empty(),
+      IREE_SV("<empty>")));
+  params[2] = loom_param_string(loom_low_target_legalize_nonempty(
+      config ? config->name : iree_string_view_empty(), IREE_SV("<empty>")));
+  params[3] = loom_param_string(loom_low_target_legalize_nonempty(
+      loom_low_target_legalize_function_name(state), IREE_SV("<module>")));
+  params[4] = loom_param_string(loom_op_name(state->module, op));
+}
+
 static iree_status_t loom_low_target_legalize_emit_topology_assume_error(
     loom_low_target_legalize_function_state_t* state, const loom_op_t* op,
     iree_string_view_t value_kind, iree_string_view_t axis,
     int64_t required_minimum, int64_t required_maximum, int64_t assumed_minimum,
     int64_t assumed_maximum) {
-  const loom_target_bundle_t* bundle = state->selection->target_bundle;
-  const loom_target_config_t* config = bundle ? bundle->config : NULL;
-  const loom_target_export_plan_t* export_plan =
-      bundle ? bundle->export_plan : NULL;
-  const loom_diagnostic_param_t params[] = {
-      loom_param_string(loom_low_target_legalize_nonempty(
-          bundle ? bundle->name : iree_string_view_empty(),
-          IREE_SV("<empty>"))),
-      loom_param_string(loom_low_target_legalize_nonempty(
-          export_plan ? export_plan->name : iree_string_view_empty(),
-          IREE_SV("<empty>"))),
-      loom_param_string(loom_low_target_legalize_nonempty(
-          config ? config->name : iree_string_view_empty(),
-          IREE_SV("<empty>"))),
-      loom_param_string(loom_low_target_legalize_nonempty(
-          loom_low_target_legalize_function_name(state), IREE_SV("<module>"))),
-      loom_param_string(loom_op_name(state->module, op)),
-      loom_param_string(value_kind),
-      loom_param_string(axis),
-      loom_param_i64(required_minimum),
-      loom_param_i64(required_maximum),
-      loom_param_i64(assumed_minimum),
-      loom_param_i64(assumed_maximum),
-  };
+  loom_diagnostic_param_t params[11];
+  loom_low_target_legalize_context_params(state, op, params);
+  params[5] = loom_param_string(value_kind);
+  params[6] = loom_param_string(axis);
+  params[7] = loom_param_i64(required_minimum);
+  params[8] = loom_param_i64(required_maximum);
+  params[9] = loom_param_i64(assumed_minimum);
+  params[10] = loom_param_i64(assumed_maximum);
   const loom_diagnostic_emission_t emission = {
       .op = op,
       .error = LOOM_ERR_TARGET_058,
@@ -601,6 +615,147 @@ static iree_status_t loom_low_target_legalize_emit_topology_assume_error(
   IREE_RETURN_IF_ERROR(
       iree_diagnostic_emit(state->pass->diagnostic_emitter, &emission));
   ++state->preflight_error_count;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_low_target_legalize_emit_assume_range_conflict_error(
+    loom_low_target_legalize_function_state_t* state, const loom_op_t* op,
+    const loom_predicate_t* predicate, loom_value_id_t value_id,
+    loom_value_fact_predicate_conflict_t conflict) {
+  const char* predicate_name = loom_predicate_kind_name(predicate->kind);
+  loom_diagnostic_param_t params[11];
+  loom_low_target_legalize_context_params(state, op, params);
+  params[5] =
+      loom_param_string(predicate_name ? iree_make_cstring_view(predicate_name)
+                                       : IREE_SV("<unknown>"));
+  params[6] = loom_param_string(
+      loom_low_target_legalize_value_name(state->module, value_id));
+  params[7] = loom_param_i64(conflict.required_minimum);
+  params[8] = loom_param_i64(conflict.required_maximum);
+  params[9] = loom_param_i64(conflict.known_minimum);
+  params[10] = loom_param_i64(conflict.known_maximum);
+  const loom_diagnostic_emission_t emission = {
+      .op = op,
+      .error = LOOM_ERR_TARGET_059,
+      .params = params,
+      .param_count = IREE_ARRAYSIZE(params),
+  };
+  IREE_RETURN_IF_ERROR(
+      iree_diagnostic_emit(state->pass->diagnostic_emitter, &emission));
+  ++state->preflight_error_count;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_low_target_legalize_emit_assume_exact_i64_error(
+    loom_low_target_legalize_function_state_t* state, const loom_op_t* op,
+    const loom_predicate_t* predicate, loom_value_id_t value_id,
+    loom_value_fact_predicate_conflict_t conflict) {
+  const char* predicate_name = loom_predicate_kind_name(predicate->kind);
+  loom_diagnostic_param_t params[8];
+  loom_low_target_legalize_context_params(state, op, params);
+  params[5] =
+      loom_param_string(predicate_name ? iree_make_cstring_view(predicate_name)
+                                       : IREE_SV("<unknown>"));
+  params[6] = loom_param_string(
+      loom_low_target_legalize_value_name(state->module, value_id));
+  params[7] = loom_param_i64(conflict.known_value);
+  const loom_diagnostic_emission_t emission = {
+      .op = op,
+      .error = LOOM_ERR_TARGET_060,
+      .params = params,
+      .param_count = IREE_ARRAYSIZE(params),
+  };
+  IREE_RETURN_IF_ERROR(
+      iree_diagnostic_emit(state->pass->diagnostic_emitter, &emission));
+  ++state->preflight_error_count;
+  return iree_ok_status();
+}
+
+static iree_string_view_t loom_low_target_legalize_float_class_name(
+    loom_value_fact_predicate_conflict_float_class_t float_class) {
+  switch (float_class) {
+    case LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_NAN:
+      return IREE_SV("nan");
+    case LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_INFINITY:
+      return IREE_SV("infinity");
+    case LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_NONE:
+      return IREE_SV("<unknown>");
+  }
+  return IREE_SV("<unknown>");
+}
+
+static iree_status_t loom_low_target_legalize_emit_assume_exact_f64_error(
+    loom_low_target_legalize_function_state_t* state, const loom_op_t* op,
+    const loom_predicate_t* predicate, loom_value_id_t value_id,
+    loom_value_fact_predicate_conflict_t conflict) {
+  const char* predicate_name = loom_predicate_kind_name(predicate->kind);
+  loom_diagnostic_param_t params[8];
+  loom_low_target_legalize_context_params(state, op, params);
+  params[5] =
+      loom_param_string(predicate_name ? iree_make_cstring_view(predicate_name)
+                                       : IREE_SV("<unknown>"));
+  params[6] = loom_param_string(
+      loom_low_target_legalize_value_name(state->module, value_id));
+  params[7] = loom_param_string(
+      loom_low_target_legalize_float_class_name(conflict.known_float_class));
+  const loom_diagnostic_emission_t emission = {
+      .op = op,
+      .error = LOOM_ERR_TARGET_061,
+      .params = params,
+      .param_count = IREE_ARRAYSIZE(params),
+  };
+  IREE_RETURN_IF_ERROR(
+      iree_diagnostic_emit(state->pass->diagnostic_emitter, &emission));
+  ++state->preflight_error_count;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_low_target_legalize_emit_assume_conflict_error(
+    loom_low_target_legalize_function_state_t* state, const loom_op_t* op,
+    const loom_predicate_t* predicate, loom_value_id_t value_id,
+    loom_value_fact_predicate_conflict_t conflict) {
+  switch (conflict.kind) {
+    case LOOM_VALUE_FACT_PREDICATE_CONFLICT_RANGE:
+      return loom_low_target_legalize_emit_assume_range_conflict_error(
+          state, op, predicate, value_id, conflict);
+    case LOOM_VALUE_FACT_PREDICATE_CONFLICT_EXACT_I64:
+      return loom_low_target_legalize_emit_assume_exact_i64_error(
+          state, op, predicate, value_id, conflict);
+    case LOOM_VALUE_FACT_PREDICATE_CONFLICT_EXACT_F64:
+      return loom_low_target_legalize_emit_assume_exact_f64_error(
+          state, op, predicate, value_id, conflict);
+    case LOOM_VALUE_FACT_PREDICATE_CONFLICT_NONE:
+      return iree_ok_status();
+  }
+  return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                          "unknown assume predicate conflict kind %d",
+                          (int)conflict.kind);
+}
+
+static iree_status_t loom_low_target_legalize_check_assume_predicate_conflicts(
+    loom_low_target_legalize_function_state_t* state, const loom_op_t* op,
+    const loom_value_fact_table_t* fact_table, loom_value_slice_t values,
+    const loom_predicate_t* predicates, uint16_t predicate_count) {
+  if (loom_low_target_legalize_should_stop_preflight(state)) {
+    return iree_ok_status();
+  }
+  for (uint16_t i = 0; i < predicate_count &&
+                       !loom_low_target_legalize_should_stop_preflight(state);
+       ++i) {
+    loom_value_facts_t facts = loom_value_facts_unknown();
+    if (!loom_low_target_legalize_lookup_assume_operand_facts(
+            fact_table, values, &predicates[i], &facts)) {
+      continue;
+    }
+    loom_value_fact_predicate_conflict_t conflict = {0};
+    if (!loom_value_facts_predicate_conflict(facts, &predicates[i],
+                                             &conflict)) {
+      continue;
+    }
+    IREE_RETURN_IF_ERROR(loom_low_target_legalize_emit_assume_conflict_error(
+        state, op, &predicates[i], (loom_value_id_t)predicates[i].args[0],
+        conflict));
+  }
   return iree_ok_status();
 }
 
@@ -642,23 +797,31 @@ static iree_status_t loom_low_target_legalize_check_assume_topology_domain(
   return iree_ok_status();
 }
 
-static iree_status_t loom_low_target_legalize_check_assume_topology_domains(
+static iree_status_t loom_low_target_legalize_check_assume_predicates(
     loom_low_target_legalize_function_state_t* state, const loom_op_t* op,
     const loom_value_fact_table_t* fact_table) {
-  // Entry-block assumes are launch-wide author contracts. Assumes in nested
-  // regions or non-entry CFG blocks are path-sensitive facts from the control
-  // flow that reached them.
-  if (!loom_low_target_legalize_op_is_in_function_entry_block(state, op)) {
-    return iree_ok_status();
-  }
   if (loom_index_assume_isa(op)) {
     loom_attribute_t predicate_attr = loom_index_assume_predicates(op);
+    IREE_RETURN_IF_ERROR(
+        loom_low_target_legalize_check_assume_predicate_conflicts(
+            state, op, fact_table, loom_index_assume_values(op),
+            predicate_attr.predicate_list, predicate_attr.count));
+    if (!loom_low_target_legalize_op_is_in_function_entry_block(state, op)) {
+      return iree_ok_status();
+    }
     return loom_low_target_legalize_check_assume_topology_domain(
         state, op, fact_table, loom_index_assume_values(op),
         predicate_attr.predicate_list, predicate_attr.count);
   }
   if (loom_scalar_assume_isa(op)) {
     loom_attribute_t predicate_attr = loom_scalar_assume_predicates(op);
+    IREE_RETURN_IF_ERROR(
+        loom_low_target_legalize_check_assume_predicate_conflicts(
+            state, op, fact_table, loom_scalar_assume_values(op),
+            predicate_attr.predicate_list, predicate_attr.count));
+    if (!loom_low_target_legalize_op_is_in_function_entry_block(state, op)) {
+      return iree_ok_status();
+    }
     return loom_low_target_legalize_check_assume_topology_domain(
         state, op, fact_table, loom_scalar_assume_values(op),
         predicate_attr.predicate_list, predicate_attr.count);
@@ -1143,7 +1306,7 @@ static iree_status_t loom_low_target_legalize_rewrite_op(
   if (state->preflight_error_count != 0) {
     return iree_ok_status();
   }
-  IREE_RETURN_IF_ERROR(loom_low_target_legalize_check_assume_topology_domains(
+  IREE_RETURN_IF_ERROR(loom_low_target_legalize_check_assume_predicates(
       state, op, driver->latest_facts));
   if (state->preflight_error_count != 0) {
     return iree_ok_status();

--- a/loom/src/loom/codegen/low/transforms/test/target_legalize_diagnostics.loom-test
+++ b/loom/src/loom/codegen/low/transforms/test/target_legalize_diagnostics.loom-test
@@ -69,6 +69,42 @@ func.def target(@test_target) @require_native_rejects_reduce_axes_reference_fall
 
 test.target<low_core> @test_target
 
+func.def target(@test_target) @rejects_assume_range_contradicting_exact_facts() -> (index) {
+  %exact = index.constant 64 : index
+  // ERROR@+1: TARGET/059 {predicate_name="range", value_name="exact", required_min="128", required_max="255", known_min="64", known_max="64"}
+  %assumed = index.assume %exact [range(%exact, 128, 255)] : index
+  func.return %assumed : index
+}
+
+// ====
+// RUN: pass target-legalize
+
+test.target<low_core> @test_target
+
+func.def target(@test_target) @rejects_assume_ne_contradicting_exact_facts() -> (index) {
+  %exact = index.constant 64 : index
+  // ERROR@+1: TARGET/060 {predicate_name="ne", value_name="exact", known_value="64"}
+  %assumed = index.assume %exact [ne(%exact, 64)] : index
+  func.return %assumed : index
+}
+
+// ====
+// RUN: pass target-legalize
+
+test.target<low_core> @test_target
+
+func.def target(@test_target) @rejects_assume_divisibility_contradicting_exact_facts() -> (index) {
+  %exact = index.constant 66 : index
+  // ERROR@+1: TARGET/060 {predicate_name="mul", value_name="exact", known_value="66"}
+  %assumed = index.assume %exact [mul(%exact, 64)] : index
+  func.return %assumed : index
+}
+
+// ====
+// RUN: pass target-legalize
+
+test.target<low_core> @test_target
+
 kernel.def target(@test_target) @rejects_workitem_id_assume_excluding_static_workgroup() {
   %c1 = index.constant 1 : index
   %c64 = index.constant 64 : index

--- a/loom/src/loom/ir/facts.c
+++ b/loom/src/loom/ir/facts.c
@@ -296,6 +296,219 @@ void loom_value_facts_recompute_flags(loom_value_facts_t* facts) {
 // Predicate application
 //===----------------------------------------------------------------------===//
 
+static bool loom_value_facts_predicate_const_arg(
+    const loom_predicate_t* predicate, uint8_t index, int64_t* out_value) {
+  if (predicate->arg_count <= index ||
+      predicate->arg_tags[index] != LOOM_PRED_ARG_CONST) {
+    return false;
+  }
+  *out_value = predicate->args[index];
+  return true;
+}
+
+static bool loom_value_facts_predicate_value_first_arg(
+    const loom_predicate_t* predicate) {
+  return predicate->arg_count >= 1 &&
+         predicate->arg_tags[0] == LOOM_PRED_ARG_VALUE;
+}
+
+static bool loom_value_facts_predicate_required_range(
+    const loom_predicate_t* predicate, int64_t* out_minimum,
+    int64_t* out_maximum) {
+  *out_minimum = INT64_MIN;
+  *out_maximum = INT64_MAX;
+  if (!loom_value_facts_predicate_value_first_arg(predicate)) return false;
+
+  int64_t constant = 0;
+  switch ((loom_predicate_kind_t)predicate->kind) {
+    case LOOM_PREDICATE_EQ:
+      if (!loom_value_facts_predicate_const_arg(predicate, 1, &constant)) {
+        return false;
+      }
+      *out_minimum = constant;
+      *out_maximum = constant;
+      return true;
+    case LOOM_PREDICATE_LT:
+      if (!loom_value_facts_predicate_const_arg(predicate, 1, &constant)) {
+        return false;
+      }
+      if (constant == INT64_MIN) {
+        *out_minimum = INT64_MAX;
+        *out_maximum = INT64_MIN;
+        return true;
+      }
+      *out_maximum = constant - 1;
+      return true;
+    case LOOM_PREDICATE_LE:
+    case LOOM_PREDICATE_MAX:
+      if (!loom_value_facts_predicate_const_arg(predicate, 1, &constant)) {
+        return false;
+      }
+      *out_maximum = constant;
+      return true;
+    case LOOM_PREDICATE_GT:
+      if (!loom_value_facts_predicate_const_arg(predicate, 1, &constant)) {
+        return false;
+      }
+      if (constant == INT64_MAX) {
+        *out_minimum = INT64_MAX;
+        *out_maximum = INT64_MIN;
+        return true;
+      }
+      *out_minimum = constant + 1;
+      return true;
+    case LOOM_PREDICATE_GE:
+    case LOOM_PREDICATE_MIN:
+      if (!loom_value_facts_predicate_const_arg(predicate, 1, &constant)) {
+        return false;
+      }
+      *out_minimum = constant;
+      return true;
+    case LOOM_PREDICATE_RANGE:
+      if (!loom_value_facts_predicate_const_arg(predicate, 1, out_minimum) ||
+          !loom_value_facts_predicate_const_arg(predicate, 2, out_maximum)) {
+        return false;
+      }
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool loom_value_facts_predicate_range_conflict(
+    loom_value_facts_t facts, const loom_predicate_t* predicate,
+    loom_value_fact_predicate_conflict_t* out_conflict) {
+  int64_t required_minimum = INT64_MIN;
+  int64_t required_maximum = INT64_MAX;
+  if (!loom_value_facts_predicate_required_range(predicate, &required_minimum,
+                                                 &required_maximum)) {
+    return false;
+  }
+  if (required_minimum <= required_maximum &&
+      required_maximum >= facts.range_lo &&
+      required_minimum <= facts.range_hi) {
+    return false;
+  }
+  if (out_conflict != NULL) {
+    *out_conflict = (loom_value_fact_predicate_conflict_t){
+        .kind = LOOM_VALUE_FACT_PREDICATE_CONFLICT_RANGE,
+        .known_minimum = facts.range_lo,
+        .known_maximum = facts.range_hi,
+        .required_minimum = required_minimum,
+        .required_maximum = required_maximum,
+    };
+  }
+  return true;
+}
+
+static bool loom_value_facts_predicate_exact_i64_conflict(
+    loom_value_facts_t facts, const loom_predicate_t* predicate,
+    loom_value_fact_predicate_conflict_t* out_conflict) {
+  int64_t known_value = 0;
+  if (!loom_value_facts_as_exact_i64(facts, &known_value) ||
+      !loom_value_facts_predicate_value_first_arg(predicate)) {
+    return false;
+  }
+
+  int64_t predicate_value = 0;
+  bool conflicts = false;
+  switch ((loom_predicate_kind_t)predicate->kind) {
+    case LOOM_PREDICATE_NE:
+      conflicts = loom_value_facts_predicate_const_arg(predicate, 1,
+                                                       &predicate_value) &&
+                  known_value == predicate_value;
+      break;
+    case LOOM_PREDICATE_MUL:
+      conflicts = loom_value_facts_predicate_const_arg(predicate, 1,
+                                                       &predicate_value) &&
+                  predicate_value > 0 && known_value % predicate_value != 0;
+      break;
+    case LOOM_PREDICATE_POW2:
+      conflicts = known_value <= 0 || (known_value & (known_value - 1)) != 0;
+      break;
+    default:
+      return false;
+  }
+  if (!conflicts) return false;
+
+  if (out_conflict != NULL) {
+    *out_conflict = (loom_value_fact_predicate_conflict_t){
+        .kind = LOOM_VALUE_FACT_PREDICATE_CONFLICT_EXACT_I64,
+        .known_minimum = facts.range_lo,
+        .known_maximum = facts.range_hi,
+        .known_value = known_value,
+        .predicate_value = predicate_value,
+    };
+  }
+  return true;
+}
+
+static bool loom_value_facts_predicate_exact_f64_conflict(
+    loom_value_facts_t facts, const loom_predicate_t* predicate,
+    loom_value_fact_predicate_conflict_t* out_conflict) {
+  if (!loom_value_facts_is_exact(facts) ||
+      !loom_value_facts_predicate_value_first_arg(predicate)) {
+    return false;
+  }
+
+  const double known_value = loom_value_facts_as_f64(facts);
+  loom_value_fact_predicate_conflict_float_class_t float_class =
+      LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_NONE;
+  switch ((loom_predicate_kind_t)predicate->kind) {
+    case LOOM_PREDICATE_NOT_NAN:
+      if (isnan(known_value)) {
+        float_class = LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_NAN;
+      }
+      break;
+    case LOOM_PREDICATE_NOT_INF:
+      if (isinf(known_value)) {
+        float_class = LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_INFINITY;
+      }
+      break;
+    case LOOM_PREDICATE_FINITE:
+      if (isnan(known_value)) {
+        float_class = LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_NAN;
+      } else if (isinf(known_value)) {
+        float_class = LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_INFINITY;
+      }
+      break;
+    default:
+      return false;
+  }
+  if (float_class == LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_NONE) {
+    return false;
+  }
+
+  if (out_conflict != NULL) {
+    *out_conflict = (loom_value_fact_predicate_conflict_t){
+        .kind = LOOM_VALUE_FACT_PREDICATE_CONFLICT_EXACT_F64,
+        .known_float_class = float_class,
+    };
+  }
+  return true;
+}
+
+bool loom_value_facts_predicate_conflict(
+    loom_value_facts_t facts, const loom_predicate_t* predicate,
+    loom_value_fact_predicate_conflict_t* out_conflict) {
+  if (out_conflict != NULL) {
+    *out_conflict = (loom_value_fact_predicate_conflict_t){
+        .kind = LOOM_VALUE_FACT_PREDICATE_CONFLICT_NONE,
+    };
+  }
+  if (predicate == NULL) {
+    return false;
+  }
+  if (loom_value_facts_is_float(facts)) {
+    return loom_value_facts_predicate_exact_f64_conflict(facts, predicate,
+                                                         out_conflict);
+  }
+  return loom_value_facts_predicate_range_conflict(facts, predicate,
+                                                   out_conflict) ||
+         loom_value_facts_predicate_exact_i64_conflict(facts, predicate,
+                                                       out_conflict);
+}
+
 void loom_value_facts_apply_predicate(loom_value_facts_t* facts,
                                       const loom_predicate_t* predicate) {
   // This scalar fact lattice can consume predicates with literal bounds. Value

--- a/loom/src/loom/ir/facts.h
+++ b/loom/src/loom/ir/facts.h
@@ -504,10 +504,57 @@ static inline void loom_value_facts_meet(
 // Predicate application
 //===----------------------------------------------------------------------===//
 
+typedef enum loom_value_fact_predicate_conflict_kind_e {
+  LOOM_VALUE_FACT_PREDICATE_CONFLICT_NONE = 0,
+  LOOM_VALUE_FACT_PREDICATE_CONFLICT_RANGE = 1,
+  LOOM_VALUE_FACT_PREDICATE_CONFLICT_EXACT_I64 = 2,
+  LOOM_VALUE_FACT_PREDICATE_CONFLICT_EXACT_F64 = 3,
+} loom_value_fact_predicate_conflict_kind_t;
+
+typedef enum loom_value_fact_predicate_conflict_float_class_e {
+  LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_NONE = 0,
+  LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_NAN = 1,
+  LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_INFINITY = 2,
+} loom_value_fact_predicate_conflict_float_class_t;
+
+typedef struct loom_value_fact_predicate_conflict_t {
+  // Kind of contradiction proven by the fact lattice.
+  loom_value_fact_predicate_conflict_kind_t kind;
+
+  // Minimum known value from the incoming fact range.
+  int64_t known_minimum;
+
+  // Maximum known value from the incoming fact range.
+  int64_t known_maximum;
+
+  // Minimum value required by the predicate range.
+  int64_t required_minimum;
+
+  // Maximum value required by the predicate range.
+  int64_t required_maximum;
+
+  // Exact integer value proven by incoming facts.
+  int64_t known_value;
+
+  // Integer predicate parameter that conflicts with |known_value|.
+  int64_t predicate_value;
+
+  // Exact floating-point class that conflicts with a float predicate.
+  loom_value_fact_predicate_conflict_float_class_t known_float_class;
+} loom_value_fact_predicate_conflict_t;
+
 // Recomputes the cached flags from range_lo, range_hi, and known_divisor.
 // Preserves facts that are not derived from the integer range, such as
 // predicate, floating-point type, and execution distribution flags.
 void loom_value_facts_recompute_flags(loom_value_facts_t* facts);
+
+// Returns true when |predicate| is statically impossible for |facts|. This is a
+// validation query, not a transfer function: callers that accept user assumes
+// should diagnose true results before applying the predicate to avoid turning
+// provably empty facts into ordinary unknown facts.
+bool loom_value_facts_predicate_conflict(
+    loom_value_facts_t facts, const loom_predicate_t* predicate,
+    loom_value_fact_predicate_conflict_t* out_conflict);
 
 // Tightens facts using a single predicate constraint. Modifies the facts in
 // place and recomputes flags afterward. The caller is responsible for enforcing

--- a/loom/src/loom/ir/facts_test.cc
+++ b/loom/src/loom/ir/facts_test.cc
@@ -402,12 +402,125 @@ static loom_predicate_t make_predicate_not_nan(void) {
   return pred;
 }
 
+static loom_predicate_t make_predicate_not_inf(void) {
+  loom_predicate_t pred = {0};
+  pred.kind = (uint8_t)LOOM_PREDICATE_NOT_INF;
+  pred.arg_count = 1;
+  pred.arg_tags[0] = LOOM_PRED_ARG_VALUE;
+  return pred;
+}
+
 static loom_predicate_t make_predicate_finite(void) {
   loom_predicate_t pred = {0};
   pred.kind = (uint8_t)LOOM_PREDICATE_FINITE;
   pred.arg_count = 1;
   pred.arg_tags[0] = LOOM_PRED_ARG_VALUE;
   return pred;
+}
+
+TEST(FactsPredicateConflict, RangeDisjointFromKnownRange) {
+  loom_value_facts_t f = loom_value_facts_make(0, 63, 1);
+  loom_predicate_t pred = make_predicate_range(128, 255);
+  loom_value_fact_predicate_conflict_t conflict = {};
+  ASSERT_TRUE(loom_value_facts_predicate_conflict(f, &pred, &conflict));
+  EXPECT_EQ(conflict.kind, LOOM_VALUE_FACT_PREDICATE_CONFLICT_RANGE);
+  EXPECT_EQ(conflict.known_minimum, 0);
+  EXPECT_EQ(conflict.known_maximum, 63);
+  EXPECT_EQ(conflict.required_minimum, 128);
+  EXPECT_EQ(conflict.required_maximum, 255);
+}
+
+TEST(FactsPredicateConflict, RangeOverlappingKnownRangeIsSatisfiable) {
+  loom_value_facts_t f = loom_value_facts_make(0, 255, 1);
+  loom_predicate_t pred = make_predicate_range(128, 511);
+  EXPECT_FALSE(loom_value_facts_predicate_conflict(f, &pred, NULL));
+}
+
+TEST(FactsPredicateConflict, EmptyPredicateRangeAlwaysConflicts) {
+  loom_value_facts_t f = loom_value_facts_unknown();
+  loom_predicate_t pred = make_predicate_1(LOOM_PREDICATE_LT, INT64_MIN);
+  loom_value_fact_predicate_conflict_t conflict = {};
+  ASSERT_TRUE(loom_value_facts_predicate_conflict(f, &pred, &conflict));
+  EXPECT_EQ(conflict.kind, LOOM_VALUE_FACT_PREDICATE_CONFLICT_RANGE);
+  EXPECT_GT(conflict.required_minimum, conflict.required_maximum);
+}
+
+TEST(FactsPredicateConflict, NotEqualExcludesExactKnownValue) {
+  loom_value_facts_t f = loom_value_facts_exact_i64(64);
+  loom_predicate_t pred = make_predicate_1(LOOM_PREDICATE_NE, 64);
+  loom_value_fact_predicate_conflict_t conflict = {};
+  ASSERT_TRUE(loom_value_facts_predicate_conflict(f, &pred, &conflict));
+  EXPECT_EQ(conflict.kind, LOOM_VALUE_FACT_PREDICATE_CONFLICT_EXACT_I64);
+  EXPECT_EQ(conflict.known_value, 64);
+  EXPECT_EQ(conflict.predicate_value, 64);
+}
+
+TEST(FactsPredicateConflict, DivisibilityRejectsExactNonMultiple) {
+  loom_value_facts_t f = loom_value_facts_exact_i64(66);
+  loom_predicate_t pred = make_predicate_1(LOOM_PREDICATE_MUL, 64);
+  loom_value_fact_predicate_conflict_t conflict = {};
+  ASSERT_TRUE(loom_value_facts_predicate_conflict(f, &pred, &conflict));
+  EXPECT_EQ(conflict.kind, LOOM_VALUE_FACT_PREDICATE_CONFLICT_EXACT_I64);
+  EXPECT_EQ(conflict.known_value, 66);
+  EXPECT_EQ(conflict.predicate_value, 64);
+}
+
+TEST(FactsPredicateConflict, PowerOfTwoRejectsExactNonPower) {
+  loom_value_facts_t f = loom_value_facts_exact_i64(66);
+  loom_predicate_t pred = make_predicate_pow2();
+  loom_value_fact_predicate_conflict_t conflict = {};
+  ASSERT_TRUE(loom_value_facts_predicate_conflict(f, &pred, &conflict));
+  EXPECT_EQ(conflict.kind, LOOM_VALUE_FACT_PREDICATE_CONFLICT_EXACT_I64);
+  EXPECT_EQ(conflict.known_value, 66);
+}
+
+TEST(FactsPredicateConflict, NotNanRejectsExactNan) {
+  loom_value_facts_t f =
+      loom_value_facts_exact_f64(std::numeric_limits<double>::quiet_NaN());
+  loom_predicate_t pred = make_predicate_not_nan();
+  loom_value_fact_predicate_conflict_t conflict = {};
+  ASSERT_TRUE(loom_value_facts_predicate_conflict(f, &pred, &conflict));
+  EXPECT_EQ(conflict.kind, LOOM_VALUE_FACT_PREDICATE_CONFLICT_EXACT_F64);
+  EXPECT_EQ(conflict.known_float_class,
+            LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_NAN);
+}
+
+TEST(FactsPredicateConflict, NotInfRejectsExactInfinity) {
+  loom_value_facts_t f =
+      loom_value_facts_exact_f64(std::numeric_limits<double>::infinity());
+  loom_predicate_t pred = make_predicate_not_inf();
+  loom_value_fact_predicate_conflict_t conflict = {};
+  ASSERT_TRUE(loom_value_facts_predicate_conflict(f, &pred, &conflict));
+  EXPECT_EQ(conflict.kind, LOOM_VALUE_FACT_PREDICATE_CONFLICT_EXACT_F64);
+  EXPECT_EQ(conflict.known_float_class,
+            LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_INFINITY);
+}
+
+TEST(FactsPredicateConflict, FiniteRejectsExactNanAndInfinity) {
+  loom_predicate_t pred = make_predicate_finite();
+
+  loom_value_fact_predicate_conflict_t nan_conflict = {};
+  ASSERT_TRUE(loom_value_facts_predicate_conflict(
+      loom_value_facts_exact_f64(std::numeric_limits<double>::quiet_NaN()),
+      &pred, &nan_conflict));
+  EXPECT_EQ(nan_conflict.kind, LOOM_VALUE_FACT_PREDICATE_CONFLICT_EXACT_F64);
+  EXPECT_EQ(nan_conflict.known_float_class,
+            LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_NAN);
+
+  loom_value_fact_predicate_conflict_t infinity_conflict = {};
+  ASSERT_TRUE(loom_value_facts_predicate_conflict(
+      loom_value_facts_exact_f64(-std::numeric_limits<double>::infinity()),
+      &pred, &infinity_conflict));
+  EXPECT_EQ(infinity_conflict.kind,
+            LOOM_VALUE_FACT_PREDICATE_CONFLICT_EXACT_F64);
+  EXPECT_EQ(infinity_conflict.known_float_class,
+            LOOM_VALUE_FACT_PREDICATE_CONFLICT_FLOAT_CLASS_INFINITY);
+}
+
+TEST(FactsPredicateConflict, FiniteAcceptsExactFiniteFloat) {
+  loom_value_facts_t f = loom_value_facts_exact_f64(1.5);
+  loom_predicate_t pred = make_predicate_finite();
+  EXPECT_FALSE(loom_value_facts_predicate_conflict(f, &pred, NULL));
 }
 
 TEST(FactsApplyPredicate, Eq) {

--- a/loom/src/loom/ops/vector/facts.c
+++ b/loom/src/loom/ops/vector/facts.c
@@ -595,6 +595,10 @@ iree_status_t loom_vector_fragment_facts(
   loom_vector_fragment_copy_present_auxiliary(parameters.auxiliary,
                                               &fact.auxiliary);
 
+  if (loom_vector_fragment_role(op) == LOOM_VECTOR_ROLE_INIT) {
+    fact.flags |= LOOM_VECTOR_FRAGMENT_FACT_FLAG_HAS_NATIVE_STORAGE;
+  }
+
   if (parameters.has_schema) {
     fact.flags |= LOOM_VECTOR_FRAGMENT_FACT_FLAG_HAS_SCHEMA;
     fact.schema_value_id = parameters.schema_value_id;

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma.loom-test
@@ -835,6 +835,84 @@ low.kernel.def target(@target) workgroup_size(64, 1, 1) @f16_wmmar3_wave64_half_
 
 amdgpu.target<gfx1100> @target {subgroup_size = 64}
 
+kernel.def target(@target) @f16_wmmar3_wave64_half_acc_loop_f32_fragment_memory() {
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 64 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
+} launch(%out_buffer: buffer) {
+  %base = index.constant 0 : offset
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %two = index.constant 2 : index
+  %sixteen = index.constant 16 : index
+  %sixty_four = index.constant 64 : index
+  %m = index.constant 16 : index
+  %n = index.constant 16 : index
+  %k = index.constant 16 : index
+  %layout = encoding.layout.strided [1, %sixty_four] : encoding<layout>
+  %out_global = buffer.assume.memory_space<global> %out_buffer : buffer
+  %out_aligned = buffer.assume.alignment %out_global {minimum_alignment = 16} : buffer
+  %out_view = buffer.view %out_aligned[%base] : buffer -> view<64x64xf32, %layout>
+  %lhs_values = vector.constant 0.0 : vector<16xf16>
+  %rhs_values = vector.constant 0.0 : vector<16xf16>
+  %init_values = vector.constant 1.0 : vector<8xf16>
+  %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xf16>
+  %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xf16>
+  %init = vector.fragment<init> %init_values shape [%m, %n] : vector<8xf16>
+  %result = scf.for %i = [%zero to %two step %one](%acc = %init : vector<8xf16>) -> (vector<8xf16>) {
+    %next = vector.mma %lhs, %rhs, %acc : vector<16xf16>, vector<16xf16>, vector<8xf16>
+    scf.yield %next : vector<8xf16>
+  }
+  vector.fragment.store<result> %result, %out_view[%zero, %sixteen] shape [%m, %n] : vector<8xf16>, view<64x64xf32, %layout>
+  kernel.return
+}
+
+// ----
+low.kernel.def target(@target) workgroup_size(64, 1, 1) @f16_wmmar3_wave64_half_acc_loop_f32_fragment_memory() asm<amdgpu.rdna3.core> {
+  %34 = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
+  %out_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %zero = s_mov_b32 0
+  %one = s_mov_b32 1
+  %two = s_mov_b32 2
+  %39 = v_mov_b32 0
+  %rhs = concat(%39, %39, %39, %39, %39, %39, %39, %39) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x8>
+  %48 = v_mov_b32 1006648320
+  %init = concat(%48, %48, %48, %48) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x4>
+  low.br ^_bb1(%zero: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x4>)
+^_bb1(%i: reg<amdgpu.sgpr>, %acc: reg<amdgpu.vgpr x4>):
+  %53 = s_cmp_lt_i32 %i, %two
+  low.cond_br %53, ^_bb2, ^_bb3 : reg<amdgpu.scc>
+^_bb2:
+  %54 = copy %acc : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr x4>
+  %next = v_wmma_f16_16x16x16_f16_w64 %rhs, %rhs, %54
+  %56 = s_add_u32 %i, %one
+  low.br ^_bb1(%56: reg<amdgpu.sgpr>, %next: reg<amdgpu.vgpr x4>)
+^_bb3:
+  %57 = v_and_b32_src0_inline %34, 15
+  %58 = v_lshrrev_b32_src0_inline %34, 4
+  %59 = v_lshlrev_b32_src0_inline %58, 2
+  %60 = v_lshlrev_b32_src0_inline %57, 8
+  %61 = v_add_u32 %59, %60
+  %62 = slice %acc[0] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
+  %63 = v_cvt_f32_f16 %62
+  %64 = v_add_u32_lit %61, 4096
+  global_store_b32_saddr %64, %63, %out_view
+  %65 = slice %acc[1] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
+  %66 = v_cvt_f32_f16 %65
+  global_store_b32_saddr %64, %66, %out_view {offset = 16}
+  %68 = slice %acc[2] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
+  %69 = v_cvt_f32_f16 %68
+  global_store_b32_saddr %64, %69, %out_view {offset = 32}
+  %71 = slice %acc[3] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
+  %72 = v_cvt_f32_f16 %71
+  global_store_b32_saddr %64, %72, %out_view {offset = 48}
+  return
+}
+
+// ====
+
+amdgpu.target<gfx1100> @target {subgroup_size = 64}
+
 kernel.def target(@target) @f16_wmmar3_wave64_half_acc_f32_epilogue_fragment_memory() {
   %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index

--- a/loom/src/loom/tools/loom-opt/loom-opt.test.json
+++ b/loom/src/loom/tools/loom-opt/loom-opt.test.json
@@ -449,6 +449,79 @@
       ]
     },
     {
+      "name": "reports exact linear stripmine with guarded tail",
+      "run": {
+        "tool": "loom-opt",
+        "args": [
+          "--pass=unroll-scf-for",
+          "--pass-report=json",
+          "--output={tmp}/linear-exact-stripmine-tail.loom"
+        ],
+        "stdin": {
+          "text": "func.def @linear_exact_stripmine_tail() {\n  %start = index.constant 0 : index\n  %end = index.constant 5 : index\n  %step = index.constant 1 : index\n  %factor = index.constant 2 : index\n  scf.for %i = [%start to %end step %step] unroll(%factor) {\n    test.use %i : index\n  }\n  func.return\n}\n"
+        }
+      },
+      "stderr": {
+        "contains": [
+          "\"pass\":\"unroll-scf-for\"",
+          "\"category\":\"scf-unroll\"",
+          "\"outcome\":\"stripmined\"",
+          "\"policy\":\"factor\"",
+          "\"schedule\":\"linear\"",
+          "\"unroll_factor\":2",
+          "\"step\":1",
+          "\"tail_strategy\":\"guarded_lanes\"",
+          "\"trip_count_state\":\"exact\"",
+          "\"trip_count\":5",
+          "\"lower_bound_kind\":\"static\"",
+          "\"lower\":0"
+        ]
+      },
+      "files": [
+        {
+          "path": "{tmp}/linear-exact-stripmine-tail.loom",
+          "contains": ["scf.if"]
+        }
+      ]
+    },
+    {
+      "name": "reports exact interleaved stripmine with dynamic lower",
+      "run": {
+        "tool": "loom-opt",
+        "args": [
+          "--pass=unroll-scf-for",
+          "--pass-report=json",
+          "--output={tmp}/interleaved-dynamic-lower-stripmine-tail.loom"
+        ],
+        "stdin": {
+          "text": "func.def @interleaved_dynamic_lower_stripmine_tail(%lane0: index) {\n  %lane = index.assume %lane0 [range(%lane0, 0, 63)] : index\n  %end = index.constant 192 : index\n  %step = index.constant 64 : index\n  %factor = index.constant 2 : index\n  scf.for %column = [%lane to %end step %step] unroll(%factor) schedule(interleaved) {\n    test.use %column : index\n  }\n  func.return\n}\n"
+        }
+      },
+      "stderr": {
+        "contains": [
+          "\"pass\":\"unroll-scf-for\"",
+          "\"category\":\"scf-unroll\"",
+          "\"outcome\":\"stripmined\"",
+          "\"policy\":\"factor\"",
+          "\"schedule\":\"interleaved\"",
+          "\"unroll_factor\":2",
+          "\"step\":64",
+          "\"tail_strategy\":\"tail_loop\"",
+          "\"trip_count_state\":\"exact\"",
+          "\"trip_count\":3",
+          "\"lower_bound_kind\":\"dynamic\"",
+          "\"lower_range_min\":0",
+          "\"lower_range_max\":63"
+        ]
+      },
+      "files": [
+        {
+          "path": "{tmp}/interleaved-dynamic-lower-stripmine-tail.loom",
+          "contains": ["scf.for %column"]
+        }
+      ]
+    },
+    {
       "name": "prints full target register types in text diagnostics",
       "run": {
         "tool": "loom-opt",

--- a/loom/src/loom/tools/loom-opt/loom-opt.test.json
+++ b/loom/src/loom/tools/loom-opt/loom-opt.test.json
@@ -353,6 +353,41 @@
       ]
     },
     {
+      "name": "reports dynamic lower full unroll",
+      "run": {
+        "tool": "loom-opt",
+        "args": [
+          "--pass=unroll-scf-for",
+          "--pass-report=json",
+          "--output={tmp}/dynamic-lower-full-unroll.loom"
+        ],
+        "stdin": {
+          "text": "func.def @dynamic_lower_full_unroll(%slot0: index) {\n  %slot = index.assume %slot0 [range(%slot0, 0, 7)] : index\n  %end = index.constant 16 : index\n  %step = index.constant 8 : index\n  scf.for %i = [%slot to %end step %step] unroll {\n    test.use %i : index\n  }\n  func.return\n}\n"
+        }
+      },
+      "stderr": {
+        "contains": [
+          "\"pass\":\"unroll-scf-for\"",
+          "\"category\":\"scf-unroll\"",
+          "\"outcome\":\"unrolled\"",
+          "\"op\":\"scf.for\"",
+          "\"policy\":\"bare\"",
+          "\"schedule\":\"linear\"",
+          "\"trip_count\":2",
+          "\"step\":8",
+          "\"lower_bound_kind\":\"dynamic\"",
+          "\"lower_range_min\":0",
+          "\"lower_range_max\":7"
+        ]
+      },
+      "files": [
+        {
+          "path": "{tmp}/dynamic-lower-full-unroll.loom",
+          "not_contains": ["scf.for"]
+        }
+      ]
+    },
+    {
       "name": "reports no-op unroll factor policy clearing",
       "run": {
         "tool": "loom-opt",

--- a/loom/src/loom/tools/loom-opt/loom-opt.test.json
+++ b/loom/src/loom/tools/loom-opt/loom-opt.test.json
@@ -319,6 +319,38 @@
       ]
     },
     {
+      "name": "reports no-op unroll factor policy clearing",
+      "run": {
+        "tool": "loom-opt",
+        "args": [
+          "--pass=unroll-scf-for",
+          "--pass-report=json",
+          "--output={tmp}/cleared-unroll-factor.loom"
+        ],
+        "stdin": {
+          "text": "func.def @clear_noop_factor() {\n  %start = index.constant 0 : index\n  %end = index.constant 4 : index\n  %step = index.constant 1 : index\n  %factor = index.constant 1 : index\n  scf.for %i = [%start to %end step %step] unroll(%factor) schedule(interleaved) {\n    test.use %i : index\n  }\n  func.return\n}\n"
+        }
+      },
+      "stderr": {
+        "contains": [
+          "\"pass\":\"unroll-scf-for\"",
+          "\"category\":\"scf-unroll\"",
+          "\"outcome\":\"cleared\"",
+          "\"policy\":\"factor\"",
+          "\"schedule\":\"interleaved\"",
+          "\"unroll_factor\":1",
+          "\"clear_reason\":\"factor_le_one\""
+        ]
+      },
+      "files": [
+        {
+          "path": "{tmp}/cleared-unroll-factor.loom",
+          "contains": ["scf.for %i"],
+          "not_contains": ["unroll(%factor)", "schedule(interleaved)"]
+        }
+      ]
+    },
+    {
       "name": "reports dynamic linear stripmine with guarded tail",
       "run": {
         "tool": "loom-opt",
@@ -339,8 +371,7 @@
           "\"policy\":\"factor\"",
           "\"schedule\":\"linear\"",
           "\"unroll_factor\":2",
-          "\"tail_guards\":true",
-          "\"tail_loop\":false",
+          "\"tail_strategy\":\"guarded_lanes\"",
           "\"trip_count_state\":\"unresolved\""
         ]
       },
@@ -372,8 +403,7 @@
           "\"policy\":\"factor\"",
           "\"schedule\":\"interleaved\"",
           "\"unroll_factor\":2",
-          "\"tail_guards\":false",
-          "\"tail_loop\":true",
+          "\"tail_strategy\":\"tail_loop\"",
           "\"trip_count_state\":\"unresolved\""
         ]
       },

--- a/loom/src/loom/tools/loom-opt/loom-opt.test.json
+++ b/loom/src/loom/tools/loom-opt/loom-opt.test.json
@@ -319,6 +319,72 @@
       ]
     },
     {
+      "name": "reports dynamic linear stripmine with guarded tail",
+      "run": {
+        "tool": "loom-opt",
+        "args": [
+          "--pass=unroll-scf-for",
+          "--pass-report=json",
+          "--output={tmp}/linear-stripmine-tail.loom"
+        ],
+        "stdin": {
+          "text": "func.def @linear_stripmine_tail(%end: index) {\n  %start = index.constant 0 : index\n  %step = index.constant 1 : index\n  %factor = index.constant 2 : index\n  scf.for %i = [%start to %end step %step] unroll(%factor) {\n    test.use %i : index\n  }\n  func.return\n}\n"
+        }
+      },
+      "stderr": {
+        "contains": [
+          "\"pass\":\"unroll-scf-for\"",
+          "\"category\":\"scf-unroll\"",
+          "\"outcome\":\"stripmined\"",
+          "\"policy\":\"factor\"",
+          "\"schedule\":\"linear\"",
+          "\"unroll_factor\":2",
+          "\"tail_guards\":true",
+          "\"tail_loop\":false",
+          "\"trip_count_state\":\"unresolved\""
+        ]
+      },
+      "files": [
+        {
+          "path": "{tmp}/linear-stripmine-tail.loom",
+          "contains": ["scf.if"]
+        }
+      ]
+    },
+    {
+      "name": "reports dynamic interleaved stripmine with tail loop",
+      "run": {
+        "tool": "loom-opt",
+        "args": [
+          "--pass=unroll-scf-for",
+          "--pass-report=json",
+          "--output={tmp}/interleaved-stripmine-tail.loom"
+        ],
+        "stdin": {
+          "text": "func.def @interleaved_stripmine_tail(%end: index) {\n  %start = index.constant 0 : index\n  %step = index.constant 1 : index\n  %factor = index.constant 2 : index\n  scf.for %i = [%start to %end step %step] unroll(%factor) schedule(interleaved) {\n    test.use %i : index\n  }\n  func.return\n}\n"
+        }
+      },
+      "stderr": {
+        "contains": [
+          "\"pass\":\"unroll-scf-for\"",
+          "\"category\":\"scf-unroll\"",
+          "\"outcome\":\"stripmined\"",
+          "\"policy\":\"factor\"",
+          "\"schedule\":\"interleaved\"",
+          "\"unroll_factor\":2",
+          "\"tail_guards\":false",
+          "\"tail_loop\":true",
+          "\"trip_count_state\":\"unresolved\""
+        ]
+      },
+      "files": [
+        {
+          "path": "{tmp}/interleaved-stripmine-tail.loom",
+          "contains": ["scf.for %i"]
+        }
+      ]
+    },
+    {
       "name": "prints full target register types in text diagnostics",
       "run": {
         "tool": "loom-opt",

--- a/loom/src/loom/tools/loom-opt/loom-opt.test.json
+++ b/loom/src/loom/tools/loom-opt/loom-opt.test.json
@@ -319,6 +319,40 @@
       ]
     },
     {
+      "name": "reports config-specialized sequence loop trip count",
+      "run": {
+        "tool": "loom-opt",
+        "args": [
+          "--pass=unroll-scf-for",
+          "--pass-report=json",
+          "--output={tmp}/structured-sequence-loop.loom"
+        ],
+        "stdin": {
+          "text": "config.def @runtime.sequence_width = 128 : index\nconfig.def @runtime.workgroup_size = 64 : index\n\nfunc.def @structured_sequence_loop(%lane0: index) {\n  %lane = index.assume %lane0 [range(%lane0, 0, 63)] : index\n  %sequence_width = config.get @runtime.sequence_width : index\n  %workgroup_size = config.get @runtime.workgroup_size : index\n  scf.for %column = [%lane to %sequence_width step %workgroup_size] {\n    test.use %column : index\n  }\n  func.return\n}\n"
+        }
+      },
+      "stderr": {
+        "contains": [
+          "\"pass\":\"unroll-scf-for\"",
+          "\"category\":\"scf-unroll\"",
+          "\"outcome\":\"structured\"",
+          "\"policy\":\"absent\"",
+          "\"trip_count_state\":\"exact\"",
+          "\"trip_count\":2",
+          "\"step\":64",
+          "\"lower_bound_kind\":\"dynamic\"",
+          "\"lower_range_min\":0",
+          "\"lower_range_max\":63"
+        ]
+      },
+      "files": [
+        {
+          "path": "{tmp}/structured-sequence-loop.loom",
+          "contains": ["scf.for %column"]
+        }
+      ]
+    },
+    {
       "name": "reports no-op unroll factor policy clearing",
       "run": {
         "tool": "loom-opt",

--- a/loom/src/loom/transforms/scf/scf_unroll.c
+++ b/loom/src/loom/transforms/scf/scf_unroll.c
@@ -356,6 +356,17 @@ static iree_string_view_t loom_scf_unroll_schedule_name(
   return IREE_SV("unknown");
 }
 
+static iree_string_view_t loom_scf_unroll_tail_strategy_name(
+    loom_scf_unroll_partial_unroll_flags_t flags) {
+  if (iree_any_bit_set(flags, LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_GUARD_TAIL)) {
+    return IREE_SV("guarded_lanes");
+  }
+  if (iree_any_bit_set(flags, LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_TAIL_LOOP)) {
+    return IREE_SV("tail_loop");
+  }
+  return IREE_SV("none");
+}
+
 static iree_status_t loom_scf_unroll_append_report_detail(
     const loom_scf_unroll_context_t* context, loom_op_t* op,
     iree_string_view_t policy, loom_scf_for_unroll_schedule_t schedule,
@@ -413,7 +424,7 @@ static iree_status_t loom_scf_unroll_append_partial_report_detail(
     return iree_ok_status();
   }
 
-  loom_pass_report_detail_field_t fields[11];
+  loom_pass_report_detail_field_t fields[10];
   uint16_t field_count = 0;
   fields[field_count++] = loom_pass_report_detail_string_field(
       IREE_SV("outcome"), IREE_SV("stripmined"));
@@ -427,12 +438,8 @@ static iree_status_t loom_scf_unroll_append_partial_report_detail(
       IREE_SV("unroll_factor"), unroll_factor);
   fields[field_count++] =
       loom_pass_report_detail_int64_field(IREE_SV("step"), step);
-  fields[field_count++] = loom_pass_report_detail_bool_field(
-      IREE_SV("tail_guards"),
-      iree_any_bit_set(flags, LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_GUARD_TAIL));
-  fields[field_count++] = loom_pass_report_detail_bool_field(
-      IREE_SV("tail_loop"),
-      iree_any_bit_set(flags, LOOM_SCF_UNROLL_PARTIAL_UNROLL_FLAG_TAIL_LOOP));
+  fields[field_count++] = loom_pass_report_detail_string_field(
+      IREE_SV("tail_strategy"), loom_scf_unroll_tail_strategy_name(flags));
   fields[field_count++] = loom_pass_report_detail_string_field(
       IREE_SV("trip_count_state"),
       loom_scf_unroll_trip_count_state_name(trip_count_state));
@@ -493,6 +500,31 @@ static iree_status_t loom_scf_unroll_append_policy_absent_report_detail(
           IREE_SV("lower_range_max"), trip_count.lower_range_max);
       break;
   }
+  return loom_pass_report_append_detail(context->pass, IREE_SV("scf-unroll"),
+                                        fields, field_count);
+}
+
+static iree_status_t loom_scf_unroll_append_clear_report_detail(
+    const loom_scf_unroll_context_t* context, loom_op_t* op,
+    int64_t unroll_factor, loom_scf_for_unroll_schedule_t schedule) {
+  if (!context->reports_enabled) {
+    return iree_ok_status();
+  }
+
+  loom_pass_report_detail_field_t fields[6];
+  uint16_t field_count = 0;
+  fields[field_count++] = loom_pass_report_detail_string_field(
+      IREE_SV("outcome"), IREE_SV("cleared"));
+  fields[field_count++] = loom_pass_report_detail_string_field(
+      IREE_SV("op"), loom_op_name(context->module, op));
+  fields[field_count++] = loom_pass_report_detail_string_field(
+      IREE_SV("policy"), IREE_SV("factor"));
+  fields[field_count++] = loom_pass_report_detail_string_field(
+      IREE_SV("schedule"), loom_scf_unroll_schedule_name(schedule));
+  fields[field_count++] = loom_pass_report_detail_int64_field(
+      IREE_SV("unroll_factor"), unroll_factor);
+  fields[field_count++] = loom_pass_report_detail_string_field(
+      IREE_SV("clear_reason"), IREE_SV("factor_le_one"));
   return loom_pass_report_append_detail(context->pass, IREE_SV("scf-unroll"),
                                         fields, field_count);
 }
@@ -825,8 +857,12 @@ static iree_status_t loom_scf_unroll_adjust_tied_results_for_policy_clear(
 
 static iree_status_t loom_scf_unroll_clear_policy(
     loom_scf_unroll_context_t* context, loom_op_t* op, loom_op_t* yield,
+    int64_t unroll_factor, loom_scf_for_unroll_schedule_t schedule,
     bool* out_changed) {
   *out_changed = false;
+  IREE_RETURN_IF_ERROR(loom_scf_unroll_append_clear_report_detail(
+      context, op, unroll_factor, schedule));
+
   loom_value_slice_t iter_args = loom_scf_for_iter_args(op);
   loom_value_slice_t yielded_values = loom_scf_yield_values(yield);
   loom_type_t* result_types = NULL;
@@ -2102,10 +2138,15 @@ static iree_status_t loom_scf_unroll_build_dynamic_interleaved_main_upper(
     trip_count = loom_index_div_result(trip_count_op);
   }
 
+  loom_op_t* factor_op = NULL;
+  IREE_RETURN_IF_ERROR(loom_index_constant_build(
+      &context->rewriter->builder, loom_attr_i64(unroll_factor), index_type,
+      op->location, &factor_op));
   loom_op_t* tile_count_op = NULL;
-  IREE_RETURN_IF_ERROR(loom_index_div_build(
-      &context->rewriter->builder, trip_count, loom_scf_for_unroll_factor(op),
-      index_type, op->location, &tile_count_op));
+  IREE_RETURN_IF_ERROR(
+      loom_index_div_build(&context->rewriter->builder, trip_count,
+                           loom_index_constant_result(factor_op), index_type,
+                           op->location, &tile_count_op));
   loom_op_t* main_span_op = NULL;
   IREE_RETURN_IF_ERROR(loom_index_mul_build(
       &context->rewriter->builder, loom_index_div_result(tile_count_op),
@@ -2341,7 +2382,8 @@ static iree_status_t loom_scf_unroll_try_unroll(
           IREE_SV("nonnegative unroll factor"));
     }
     if (unroll_factor <= 1) {
-      return loom_scf_unroll_clear_policy(context, op, yield, out_changed);
+      return loom_scf_unroll_clear_policy(context, op, yield, unroll_factor,
+                                          unroll_schedule, out_changed);
     }
     if (unroll_factor > UINT32_MAX) {
       return loom_scf_unroll_emit_policy_error(

--- a/loom/src/loom/transforms/scf/scf_unroll.c
+++ b/loom/src/loom/transforms/scf/scf_unroll.c
@@ -683,6 +683,18 @@ static iree_status_t loom_scf_unroll_build_strided_iteration_index(
       iree_make_string_view(suffix, (iree_host_size_t)suffix_length));
 }
 
+static iree_status_t loom_scf_unroll_build_index_constant(
+    loom_scf_unroll_context_t* context, loom_op_t* op, int64_t value,
+    loom_type_t index_type, loom_value_id_t* out_value) {
+  *out_value = LOOM_VALUE_ID_INVALID;
+  loom_op_t* constant_op = NULL;
+  IREE_RETURN_IF_ERROR(loom_index_constant_build(
+      &context->rewriter->builder, loom_attr_i64(value), index_type,
+      op->location, &constant_op));
+  *out_value = loom_index_constant_result(constant_op);
+  return iree_ok_status();
+}
+
 static iree_status_t loom_scf_unroll_clone_iteration(
     loom_scf_unroll_context_t* context, const loom_block_t* body_block,
     loom_op_t* yield, loom_value_id_t iteration_index, uint32_t ordinal,
@@ -927,12 +939,8 @@ static iree_status_t loom_scf_unroll_build_scaled_step(
         context, op, IREE_SV("unroll_factor"), unroll_factor,
         IREE_SV("step * unroll factor representable as i64"));
   }
-  loom_op_t* step_op = NULL;
-  IREE_RETURN_IF_ERROR(loom_index_constant_build(
-      &context->rewriter->builder, loom_attr_i64(scaled_step), index_type,
-      op->location, &step_op));
-  *out_scaled_step = loom_index_constant_result(step_op);
-  return iree_ok_status();
+  return loom_scf_unroll_build_index_constant(context, op, scaled_step,
+                                              index_type, out_scaled_step);
 }
 
 static iree_status_t loom_scf_unroll_build_in_bounds_condition(
@@ -2113,31 +2121,30 @@ static iree_status_t loom_scf_unroll_build_dynamic_interleaved_main_upper(
       index_type, op->location, &non_negative_span_op));
   loom_value_id_t trip_count = loom_index_max_result(non_negative_span_op);
   if (step != 1) {
-    loom_op_t* step_minus_one_op = NULL;
-    IREE_RETURN_IF_ERROR(loom_index_constant_build(
-        &context->rewriter->builder, loom_attr_i64(step - 1), index_type,
-        op->location, &step_minus_one_op));
+    loom_value_id_t step_minus_one = LOOM_VALUE_ID_INVALID;
+    IREE_RETURN_IF_ERROR(loom_scf_unroll_build_index_constant(
+        context, op, step - 1, index_type, &step_minus_one));
     loom_op_t* padded_span_op = NULL;
-    IREE_RETURN_IF_ERROR(
-        loom_index_add_build(&context->rewriter->builder, trip_count,
-                             loom_index_constant_result(step_minus_one_op),
-                             index_type, op->location, &padded_span_op));
+    IREE_RETURN_IF_ERROR(loom_index_add_build(
+        &context->rewriter->builder, trip_count, step_minus_one, index_type,
+        op->location, &padded_span_op));
+    loom_value_id_t step_value = LOOM_VALUE_ID_INVALID;
+    IREE_RETURN_IF_ERROR(loom_scf_unroll_build_index_constant(
+        context, op, step, index_type, &step_value));
     loom_op_t* trip_count_op = NULL;
     IREE_RETURN_IF_ERROR(loom_index_div_build(
         &context->rewriter->builder, loom_index_add_result(padded_span_op),
-        loom_scf_for_step(op), index_type, op->location, &trip_count_op));
+        step_value, index_type, op->location, &trip_count_op));
     trip_count = loom_index_div_result(trip_count_op);
   }
 
-  loom_op_t* factor_op = NULL;
-  IREE_RETURN_IF_ERROR(loom_index_constant_build(
-      &context->rewriter->builder, loom_attr_i64(unroll_factor), index_type,
-      op->location, &factor_op));
+  loom_value_id_t factor_value = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_scf_unroll_build_index_constant(
+      context, op, unroll_factor, index_type, &factor_value));
   loom_op_t* tile_count_op = NULL;
-  IREE_RETURN_IF_ERROR(
-      loom_index_div_build(&context->rewriter->builder, trip_count,
-                           loom_index_constant_result(factor_op), index_type,
-                           op->location, &tile_count_op));
+  IREE_RETURN_IF_ERROR(loom_index_div_build(
+      &context->rewriter->builder, trip_count, factor_value, index_type,
+      op->location, &tile_count_op));
   loom_op_t* main_span_op = NULL;
   IREE_RETURN_IF_ERROR(loom_index_mul_build(
       &context->rewriter->builder, loom_index_div_result(tile_count_op),
@@ -2270,14 +2277,18 @@ static iree_status_t loom_scf_unroll_partial_unroll_interleaved_with_arena(
     if (op->result_count > 0) {
       tail_iter_args = loom_scf_for_results(main_loop);
     }
+    loom_value_id_t tail_step = loom_scf_for_step(op);
+    if (step != 1) {
+      IREE_RETURN_IF_ERROR(loom_scf_unroll_build_index_constant(
+          context, op, step, index_type, &tail_step));
+    }
     loom_op_t* tail_loop = NULL;
     IREE_RETURN_IF_ERROR(loom_scf_for_build(
         &context->rewriter->builder, /*build_flags=*/0, main_upper,
-        loom_scf_for_upper_bound(op), loom_scf_for_step(op),
-        tail_iter_args.values, tail_iter_args.count, result_types,
-        op->result_count, tied_results, tied_result_count,
-        LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0, /*unroll_schedule=*/0,
-        op->location, &tail_loop));
+        loom_scf_for_upper_bound(op), tail_step, tail_iter_args.values,
+        tail_iter_args.count, result_types, op->result_count, tied_results,
+        tied_result_count, LOOM_VALUE_ID_INVALID, /*unroll_policy=*/0,
+        /*unroll_schedule=*/0, op->location, &tail_loop));
     loom_region_t* tail_body = loom_scf_for_body(tail_loop);
     saved_ip = loom_builder_enter_region(&context->rewriter->builder, tail_loop,
                                          tail_body);

--- a/loom/src/loom/transforms/scf/scf_unroll.c
+++ b/loom/src/loom/transforms/scf/scf_unroll.c
@@ -367,6 +367,28 @@ static iree_string_view_t loom_scf_unroll_tail_strategy_name(
   return IREE_SV("none");
 }
 
+static void loom_scf_unroll_append_lower_bound_report_fields(
+    loom_pass_report_detail_field_t* fields, uint16_t* field_count,
+    const loom_scf_unroll_trip_count_t* trip_count) {
+  fields[(*field_count)++] = loom_pass_report_detail_string_field(
+      IREE_SV("lower_bound_kind"),
+      loom_scf_unroll_lower_bound_kind_name(trip_count->lower_kind));
+  switch (trip_count->lower_kind) {
+    case LOOM_SCF_UNROLL_LOWER_BOUND_STATIC:
+      fields[(*field_count)++] = loom_pass_report_detail_int64_field(
+          IREE_SV("lower"), trip_count->lower_i64);
+      break;
+    case LOOM_SCF_UNROLL_LOWER_BOUND_DYNAMIC:
+      fields[(*field_count)++] = loom_pass_report_detail_uint64_field(
+          IREE_SV("lower_value_id"), trip_count->lower_value);
+      fields[(*field_count)++] = loom_pass_report_detail_int64_field(
+          IREE_SV("lower_range_min"), trip_count->lower_range_min);
+      fields[(*field_count)++] = loom_pass_report_detail_int64_field(
+          IREE_SV("lower_range_max"), trip_count->lower_range_max);
+      break;
+  }
+}
+
 static iree_status_t loom_scf_unroll_append_report_detail(
     const loom_scf_unroll_context_t* context, loom_op_t* op,
     iree_string_view_t policy, loom_scf_for_unroll_schedule_t schedule,
@@ -389,27 +411,12 @@ static iree_status_t loom_scf_unroll_append_report_detail(
       IREE_SV("trip_count"), trip_count->count);
   fields[field_count++] =
       loom_pass_report_detail_int64_field(IREE_SV("step"), trip_count->step);
-  fields[field_count++] = loom_pass_report_detail_string_field(
-      IREE_SV("lower_bound_kind"),
-      loom_scf_unroll_lower_bound_kind_name(trip_count->lower_kind));
   if (unroll_factor >= 0) {
     fields[field_count++] = loom_pass_report_detail_int64_field(
         IREE_SV("unroll_factor"), unroll_factor);
   }
-  switch (trip_count->lower_kind) {
-    case LOOM_SCF_UNROLL_LOWER_BOUND_STATIC:
-      fields[field_count++] = loom_pass_report_detail_int64_field(
-          IREE_SV("lower"), trip_count->lower_i64);
-      break;
-    case LOOM_SCF_UNROLL_LOWER_BOUND_DYNAMIC:
-      fields[field_count++] = loom_pass_report_detail_uint64_field(
-          IREE_SV("lower_value_id"), trip_count->lower_value);
-      fields[field_count++] = loom_pass_report_detail_int64_field(
-          IREE_SV("lower_range_min"), trip_count->lower_range_min);
-      fields[field_count++] = loom_pass_report_detail_int64_field(
-          IREE_SV("lower_range_max"), trip_count->lower_range_max);
-      break;
-  }
+  loom_scf_unroll_append_lower_bound_report_fields(fields, &field_count,
+                                                   trip_count);
   return loom_pass_report_append_detail(context->pass, IREE_SV("scf-unroll"),
                                         fields, field_count);
 }
@@ -424,7 +431,7 @@ static iree_status_t loom_scf_unroll_append_partial_report_detail(
     return iree_ok_status();
   }
 
-  loom_pass_report_detail_field_t fields[10];
+  loom_pass_report_detail_field_t fields[13];
   uint16_t field_count = 0;
   fields[field_count++] = loom_pass_report_detail_string_field(
       IREE_SV("outcome"), IREE_SV("stripmined"));
@@ -446,9 +453,8 @@ static iree_status_t loom_scf_unroll_append_partial_report_detail(
   if (trip_count_state == LOOM_SCF_UNROLL_TRIP_COUNT_EXACT) {
     fields[field_count++] = loom_pass_report_detail_uint64_field(
         IREE_SV("trip_count"), trip_count->count);
-    fields[field_count++] = loom_pass_report_detail_string_field(
-        IREE_SV("lower_bound_kind"),
-        loom_scf_unroll_lower_bound_kind_name(trip_count->lower_kind));
+    loom_scf_unroll_append_lower_bound_report_fields(fields, &field_count,
+                                                     trip_count);
   }
   return loom_pass_report_append_detail(context->pass, IREE_SV("scf-unroll"),
                                         fields, field_count);
@@ -483,23 +489,8 @@ static iree_status_t loom_scf_unroll_append_policy_absent_report_detail(
       IREE_SV("trip_count"), trip_count.count);
   fields[field_count++] =
       loom_pass_report_detail_int64_field(IREE_SV("step"), trip_count.step);
-  fields[field_count++] = loom_pass_report_detail_string_field(
-      IREE_SV("lower_bound_kind"),
-      loom_scf_unroll_lower_bound_kind_name(trip_count.lower_kind));
-  switch (trip_count.lower_kind) {
-    case LOOM_SCF_UNROLL_LOWER_BOUND_STATIC:
-      fields[field_count++] = loom_pass_report_detail_int64_field(
-          IREE_SV("lower"), trip_count.lower_i64);
-      break;
-    case LOOM_SCF_UNROLL_LOWER_BOUND_DYNAMIC:
-      fields[field_count++] = loom_pass_report_detail_uint64_field(
-          IREE_SV("lower_value_id"), trip_count.lower_value);
-      fields[field_count++] = loom_pass_report_detail_int64_field(
-          IREE_SV("lower_range_min"), trip_count.lower_range_min);
-      fields[field_count++] = loom_pass_report_detail_int64_field(
-          IREE_SV("lower_range_max"), trip_count.lower_range_max);
-      break;
-  }
+  loom_scf_unroll_append_lower_bound_report_fields(fields, &field_count,
+                                                   &trip_count);
   return loom_pass_report_append_detail(context->pass, IREE_SV("scf-unroll"),
                                         fields, field_count);
 }

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -767,16 +767,58 @@ func.def @interleaved_partial_factor_dynamic_tail_loop(%end: index) {
   %6 = index.constant 0 : index
   %7 = index.sub %end, %start : index
   %8 = index.max %7, %6 : index
-  %9 = index.div %8, %factor : index
-  %10 = index.mul %9, %5 : index
-  %11 = index.add %start, %10 : index
-  scf.for %i = [%start to %11 step %5] {
-    %13 = index.constant 1 : index
-    %i_1 = index.add %i, %13 : index
+  %9 = index.constant 2 : index
+  %10 = index.div %8, %9 : index
+  %11 = index.mul %10, %5 : index
+  %12 = index.add %start, %11 : index
+  scf.for %i = [%start to %12 step %5] {
+    %14 = index.constant 1 : index
+    %i_1 = index.add %i, %14 : index
     test.use %i : index
     test.use %i_1 : index
   }
-  scf.for %i = [%11 to %end step %step] {
+  scf.for %i = [%12 to %end step %step] {
+    test.use %i : index
+  }
+  func.return
+}
+
+// ====
+
+config.def @runtime.unroll_factor = 2 : index
+
+func.def @interleaved_partial_config_factor_dynamic_tail_loop(%end: index) {
+  %start = index.constant 0 : index
+  %step = index.constant 1 : index
+  %factor = config.get @runtime.unroll_factor : index
+  scf.for %i = [%start to %end step %step] unroll(%factor) schedule(interleaved) {
+    test.use %i : index
+  }
+  func.return
+}
+
+// ----
+config.def @runtime.unroll_factor = 2 : index
+
+func.def @interleaved_partial_config_factor_dynamic_tail_loop(%end: index) {
+  %start = index.constant 0 : index
+  %step = index.constant 1 : index
+  %factor = config.get @runtime.unroll_factor : index
+  %6 = index.constant 2 : index
+  %7 = index.constant 0 : index
+  %8 = index.sub %end, %start : index
+  %9 = index.max %8, %7 : index
+  %10 = index.constant 2 : index
+  %11 = index.div %9, %10 : index
+  %12 = index.mul %11, %6 : index
+  %13 = index.add %start, %12 : index
+  scf.for %i = [%start to %13 step %6] {
+    %15 = index.constant 1 : index
+    %i_1 = index.add %i, %15 : index
+    test.use %i : index
+    test.use %i_1 : index
+  }
+  scf.for %i = [%13 to %end step %step] {
     test.use %i : index
   }
   func.return
@@ -806,16 +848,17 @@ func.def @interleaved_partial_factor_dynamic_tail_step_two(%end: index) {
   %9 = index.constant 1 : index
   %10 = index.add %8, %9 : index
   %11 = index.div %10, %step : index
-  %12 = index.div %11, %factor : index
-  %13 = index.mul %12, %5 : index
-  %14 = index.add %start, %13 : index
-  scf.for %i = [%start to %14 step %5] {
-    %16 = index.constant 2 : index
-    %i_2 = index.add %i, %16 : index
+  %12 = index.constant 2 : index
+  %13 = index.div %11, %12 : index
+  %14 = index.mul %13, %5 : index
+  %15 = index.add %start, %14 : index
+  scf.for %i = [%start to %15 step %5] {
+    %17 = index.constant 2 : index
+    %i_2 = index.add %i, %17 : index
     test.use %i : index
     test.use %i_2 : index
   }
-  scf.for %i = [%14 to %end step %step] {
+  scf.for %i = [%15 to %end step %step] {
     test.use %i : index
   }
   func.return

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -625,6 +625,66 @@ func.def @partial_factor_divisible_trip_count_omits_tail_guard() {
 
 // ====
 
+func.def @partial_factor_dynamic_tail_guard(%end: index) {
+  %start = index.constant 0 : index
+  %step = index.constant 1 : index
+  %factor = index.constant 2 : index
+  scf.for %i = [%start to %end step %step] unroll(%factor) {
+    test.use %i : index
+  }
+  func.return
+}
+
+// ----
+func.def @partial_factor_dynamic_tail_guard(%end: index) {
+  %start = index.constant 0 : index
+  %step = index.constant 1 : index
+  %factor = index.constant 2 : index
+  %5 = index.constant 2 : index
+  scf.for %i = [%start to %end step %5] {
+    test.use %i : index
+    %7 = index.constant 1 : index
+    %i_1 = index.add %i, %7 : index
+    %9 = index.cmp slt, %i_1, %end : index
+    scf.if %9 {
+      test.use %i_1 : index
+    }
+  }
+  func.return
+}
+
+// ====
+
+func.def @partial_factor_dynamic_tail_guard_step_two(%end: index) {
+  %start = index.constant 0 : index
+  %step = index.constant 2 : index
+  %factor = index.constant 2 : index
+  scf.for %i = [%start to %end step %step] unroll(%factor) {
+    test.use %i : index
+  }
+  func.return
+}
+
+// ----
+func.def @partial_factor_dynamic_tail_guard_step_two(%end: index) {
+  %start = index.constant 0 : index
+  %step = index.constant 2 : index
+  %factor = index.constant 2 : index
+  %5 = index.constant 4 : index
+  scf.for %i = [%start to %end step %5] {
+    test.use %i : index
+    %7 = index.constant 2 : index
+    %i_2 = index.add %i, %7 : index
+    %9 = index.cmp slt, %i_2, %end : index
+    scf.if %9 {
+      test.use %i_2 : index
+    }
+  }
+  func.return
+}
+
+// ====
+
 func.def @interleaved_partial_factor_divisible_trip_count() {
   %start = index.constant 0 : index
   %end = index.constant 4 : index

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -1094,6 +1094,37 @@ func.def @bare_unroll_dynamic_lower_static_trip_count(%slot0: index) {
 
 // ====
 
+config.def @runtime.sequence_width = 128 : index
+config.def @runtime.workgroup_size = 64 : index
+
+func.def @bare_unroll_config_specialized_sequence_width(%lane0: index) {
+  %lane = index.assume %lane0 [range(%lane0, 0, 63)] : index
+  %sequence_width = config.get @runtime.sequence_width : index
+  %workgroup_size = config.get @runtime.workgroup_size : index
+  scf.for %column = [%lane to %sequence_width step %workgroup_size] unroll {
+    test.use %column : index
+  }
+  func.return
+}
+
+// ----
+config.def @runtime.sequence_width = 128 : index
+
+config.def @runtime.workgroup_size = 64 : index
+
+func.def @bare_unroll_config_specialized_sequence_width(%lane0: index) {
+  %lane = index.assume %lane0 [range(%lane0, 0, 63)] : index
+  %sequence_width = config.get @runtime.sequence_width : index
+  %workgroup_size = config.get @runtime.workgroup_size : index
+  test.use %lane : index
+  %7 = index.constant 64 : index
+  %column_64 = index.add %lane, %7 : index
+  test.use %column_64 : index
+  func.return
+}
+
+// ====
+
 func.def @bare_unroll_range_dependent_dynamic_lower_rejected(%slot0: index) {
   %slot = index.assume %slot0 [range(%slot0, 0, 8)] : index
   %end = index.constant 16 : index

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -858,6 +858,52 @@ func.def @interleaved_partial_config_factor_dynamic_tail_loop(%end: index) {
 
 // ====
 
+config.def @runtime.unroll_step = 2 : index
+
+func.def @interleaved_partial_config_step_dynamic_tail_loop(%end: index) {
+  %start = index.constant 0 : index
+  %step = config.get @runtime.unroll_step : index
+  %factor = index.constant 2 : index
+  scf.for %i = [%start to %end step %step] unroll(%factor) schedule(interleaved) {
+    test.use %i : index
+  }
+  func.return
+}
+
+// ----
+config.def @runtime.unroll_step = 2 : index
+
+func.def @interleaved_partial_config_step_dynamic_tail_loop(%end: index) {
+  %start = index.constant 0 : index
+  %step = config.get @runtime.unroll_step : index
+  %factor = index.constant 2 : index
+  %6 = index.constant 4 : index
+  %7 = index.constant 0 : index
+  %8 = index.sub %end, %start : index
+  %9 = index.max %8, %7 : index
+  %10 = index.constant 1 : index
+  %11 = index.add %9, %10 : index
+  %12 = index.constant 2 : index
+  %13 = index.div %11, %12 : index
+  %14 = index.constant 2 : index
+  %15 = index.div %13, %14 : index
+  %16 = index.mul %15, %6 : index
+  %17 = index.add %start, %16 : index
+  scf.for %i = [%start to %17 step %6] {
+    %19 = index.constant 2 : index
+    %i_2 = index.add %i, %19 : index
+    test.use %i : index
+    test.use %i_2 : index
+  }
+  %21 = index.constant 2 : index
+  scf.for %i = [%17 to %end step %21] {
+    test.use %i : index
+  }
+  func.return
+}
+
+// ====
+
 func.def @interleaved_partial_factor_dynamic_tail_step_two(%end: index) {
   %start = index.constant 0 : index
   %step = index.constant 2 : index
@@ -879,18 +925,20 @@ func.def @interleaved_partial_factor_dynamic_tail_step_two(%end: index) {
   %8 = index.max %7, %6 : index
   %9 = index.constant 1 : index
   %10 = index.add %8, %9 : index
-  %11 = index.div %10, %step : index
-  %12 = index.constant 2 : index
-  %13 = index.div %11, %12 : index
-  %14 = index.mul %13, %5 : index
-  %15 = index.add %start, %14 : index
-  scf.for %i = [%start to %15 step %5] {
-    %17 = index.constant 2 : index
-    %i_2 = index.add %i, %17 : index
+  %11 = index.constant 2 : index
+  %12 = index.div %10, %11 : index
+  %13 = index.constant 2 : index
+  %14 = index.div %12, %13 : index
+  %15 = index.mul %14, %5 : index
+  %16 = index.add %start, %15 : index
+  scf.for %i = [%start to %16 step %5] {
+    %18 = index.constant 2 : index
+    %i_2 = index.add %i, %18 : index
     test.use %i : index
     test.use %i_2 : index
   }
-  scf.for %i = [%15 to %end step %step] {
+  %20 = index.constant 2 : index
+  scf.for %i = [%16 to %end step %20] {
     test.use %i : index
   }
   func.return

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -685,6 +685,38 @@ func.def @partial_factor_dynamic_tail_guard_step_two(%end: index) {
 
 // ====
 
+func.def @partial_factor_dynamic_lower_static_tail_guard(%lane0: index) {
+  %lane = index.assume %lane0 [range(%lane0, 0, 63)] : index
+  %end = index.constant 192 : index
+  %step = index.constant 64 : index
+  %factor = index.constant 2 : index
+  scf.for %column = [%lane to %end step %step] unroll(%factor) {
+    test.use %column : index
+  }
+  func.return
+}
+
+// ----
+func.def @partial_factor_dynamic_lower_static_tail_guard(%lane0: index) {
+  %lane = index.assume %lane0 [range(%lane0, 0, 63)] : index
+  %end = index.constant 192 : index
+  %step = index.constant 64 : index
+  %factor = index.constant 2 : index
+  %6 = index.constant 128 : index
+  scf.for %column = [%lane to %end step %6] {
+    test.use %column : index
+    %8 = index.constant 64 : index
+    %column_64 = index.add %column, %8 : index
+    %10 = index.cmp slt, %column_64, %end : index
+    scf.if %10 {
+      test.use %column_64 : index
+    }
+  }
+  func.return
+}
+
+// ====
+
 func.def @interleaved_partial_factor_divisible_trip_count() {
   %start = index.constant 0 : index
   %end = index.constant 4 : index


### PR DESCRIPTION
This builds on the interleaved `scf.for` scheduling work in #141 by making the surrounding authoring path solid for real JIT kernels: dynamic stripmine tails lower explicitly, config-specialized loop shapes feed exact unroll decisions, native fragment storage facts survive init-fragment loops, impossible assumes become structured diagnostics, and strict C API config binding policy no longer rejects operation-level bindings that are declared by the selected source closure but pruned from the final root.

The SCF unroller now handles partial unrolls with dynamic tails instead of requiring authors to spell a target-specific static shape up front. Non-interleaved partial unrolls guard the extra lanes when the end is dynamic; interleaved partial unrolls split the exact full-width prefix from the dynamic tail loop. The exact-factor/step path also consumes config-materialized values, so authoring patterns such as a config-driven sequence width or workgroup step can still become ordinary compile-time unrolled IR once the JIT supplies those facts.

The result is that authors can keep writing dynamic kernels while still asking for a useful schedule:

```mlir
scf.for %i = [%c0 to %dynamic_count step %runtime_step] unroll(%runtime_factor) schedule(interleaved) {
  ...
}
```

When `%runtime_step` and `%runtime_factor` specialize to exact compile-time values, the unroller uses them for the full-width prefix and leaves the dynamic tail explicit. That is the shape we want for dynamic model kernels: no hardcoded launch sizes in source IR, no silent scalar fallback when the schedule can be proven, and structured report rows explaining the exact stripmine/tail proof that was used.

The branch also strengthens the feedback loop around facts. `vector.fragment<init>` now preserves native fragment-storage facts through loop-carried accumulator paths, which keeps AMDGPU WMMA fragment memory lowering on the same native-storage path as loaded and MMA-produced fragments. Target legalization now rejects assumes that contradict facts already proven for the operand, including disjoint ranges, exact integer contradictions such as `ne`, `mul`, and `pow2`, and exact floating-point class contradictions for `not_nan`, `not_inf`, and `finite`. These are structured diagnostics with typed fields rather than prose-only failures.

The C binding link path now validates strict config bindings against the link plan's selected source modules before final pruning. That preserves typo detection for truly unknown config keys while allowing stable operation-level config maps to be passed to selective JIT roots even when a particular root no longer consumes every declared config after specialization or DCE. `REQUIRE_RESOLVED` remains focused on live reachable config declarations in the final linked module.

The main review surfaces are `scf_unroll.c` for the tail splitting/proof logic, `facts.{h,c}` plus target legalization for impossible-assume diagnostics, and `loom/binding/c/src/{config,link}.c` for the config policy split. The tests are intentionally split along those contracts: SCF IR-to-IR cases for authored loop shapes, target diagnostics for impossible assumes, AMDGPU source-low coverage for native fragment-storage preservation, and C binding link tests for declared-but-unused config bindings.
