### PR TITLE
[Loom] Harden dynamic source lowering

### DIFF
--- a/loom/py/loom/dialect/index/defs.py
+++ b/loom/py/loom/dialect/index/defs.py
@@ -406,6 +406,7 @@ index_rotli = binary_op(
     doc="Left rotate over logical coordinate values. Offsets are physical byte counts and cannot use this op.",
     canonicalize="loom_index_rotli_canonicalize",
     facts="loom_index_rotli_facts",
+    traits=[DISTRIBUTION_TRANSFER],
     examples=["%r = index.rotli %lhs, %rhs : index"],
 )
 
@@ -417,6 +418,7 @@ index_rotri = binary_op(
     doc="Right rotate over logical coordinate values. Offsets are physical byte counts and cannot use this op.",
     canonicalize="loom_index_rotri_canonicalize",
     facts="loom_index_rotri_facts",
+    traits=[DISTRIBUTION_TRANSFER],
     examples=["%r = index.rotri %lhs, %rhs : index"],
 )
 

--- a/loom/src/loom/analysis/view_regions.c
+++ b/loom/src/loom/analysis/view_regions.c
@@ -547,6 +547,7 @@ static iree_status_t loom_view_region_build_default(
       .view_value_id = value_id,
       .root_value_id = reference.root_value_id,
       .begin_byte_offset = begin,
+      .begin_value_id = LOOM_VALUE_ID_INVALID,
       .byte_length = length,
       .end_byte_offset = end,
       .minimum_alignment = reference.minimum_alignment,
@@ -593,6 +594,7 @@ static iree_status_t loom_view_region_build_buffer_view(
   IREE_RETURN_IF_ERROR(loom_view_region_build_default(
       table, value_id, view_type, reference, out_region));
   out_region->root_value_id = reference.root_value_id;
+  out_region->begin_value_id = loom_buffer_view_byte_offset(op);
   IREE_RETURN_IF_ERROR(loom_symbolic_expr_from_value(
       &table->expression_context, loom_buffer_view_byte_offset(op),
       &out_region->begin_byte_offset));
@@ -627,6 +629,9 @@ static iree_status_t loom_view_region_build_subview(
   IREE_RETURN_IF_ERROR(loom_view_region_expr_add(
       table, &source_region->begin_byte_offset, &additional_offset, &begin));
   out_region->root_value_id = source_region->root_value_id;
+  if (loom_symbolic_expr_is_constant(&additional_offset)) {
+    out_region->begin_value_id = source_region->begin_value_id;
+  }
   out_region->begin_byte_offset = begin;
   loom_view_region_expression_refine_facts(&out_region->begin_byte_offset,
                                            reference.base_byte_offset);
@@ -648,6 +653,7 @@ static iree_status_t loom_view_region_build_refine(
       table, value_id, view_type, reference, out_region));
   if (!source_region) return iree_ok_status();
   out_region->root_value_id = source_region->root_value_id;
+  out_region->begin_value_id = source_region->begin_value_id;
   out_region->begin_byte_offset = source_region->begin_byte_offset;
   loom_view_region_expression_refine_facts(&out_region->begin_byte_offset,
                                            reference.base_byte_offset);
@@ -738,6 +744,28 @@ iree_status_t loom_view_region_table_get(
         LOOM_VIEW_REGION_VALUE_EMPTY;
   }
   return status;
+}
+
+bool loom_view_region_table_try_lookup(const loom_view_region_table_t* table,
+                                       loom_value_id_t value_id,
+                                       const loom_view_region_t** out_region) {
+  *out_region = NULL;
+  if (!table || value_id >= table->module->values.count) return false;
+  const loom_value_ordinal_t value_ordinal =
+      loom_local_value_domain_try_ordinal(table->value_domain, value_id);
+  if (value_ordinal == LOOM_VALUE_ORDINAL_INVALID) return false;
+  if (table->states_by_value_ordinal[value_ordinal] !=
+      LOOM_VIEW_REGION_VALUE_READY) {
+    return false;
+  }
+  const loom_view_region_id_t region_id =
+      table->region_ids_by_value_ordinal[value_ordinal];
+  if (region_id == LOOM_VIEW_REGION_ID_INVALID ||
+      region_id >= table->region_count) {
+    return false;
+  }
+  *out_region = &table->regions[region_id];
+  return true;
 }
 
 //===----------------------------------------------------------------------===//

--- a/loom/src/loom/analysis/view_regions.h
+++ b/loom/src/loom/analysis/view_regions.h
@@ -75,6 +75,10 @@ typedef struct loom_view_region_t {
   // Symbolic byte offset of the view base relative to root_value_id.
   loom_symbolic_expr_t begin_byte_offset;
 
+  // Existing SSA value that materializes begin_byte_offset, or invalid when
+  // the begin offset only exists as a symbolic expression.
+  loom_value_id_t begin_value_id;
+
   // Symbolic byte length of the conservative footprint envelope.
   loom_symbolic_expr_t byte_length;
 
@@ -150,6 +154,13 @@ iree_status_t loom_view_region_table_initialize(
 iree_status_t loom_view_region_table_get(loom_view_region_table_t* table,
                                          loom_value_id_t value_id,
                                          const loom_view_region_t** out_region);
+
+// Looks up an already constructed region summary without allocating or
+// recursively constructing missing producers. Returns false when |value_id| is
+// outside the analyzed local domain or when the summary is not ready.
+bool loom_view_region_table_try_lookup(const loom_view_region_table_t* table,
+                                       loom_value_id_t value_id,
+                                       const loom_view_region_t** out_region);
 
 // Walks the table's local value domain region, constructs summaries for view
 // values, and derives per-view access flags from memory-operand descriptors.

--- a/loom/src/loom/codegen/low/BUILD.bazel
+++ b/loom/src/loom/codegen/low/BUILD.bazel
@@ -514,6 +514,7 @@ loom_cc_library(
     deps = [
         ":memory_access",
         "//loom/src/loom/analysis:symbolic_expr",
+        "//loom/src/loom/analysis:view_regions",
         "//loom/src/loom/ir",
         "//loom/src/loom/ir:facts",
         "//loom/src/loom/ops/buffer",

--- a/loom/src/loom/codegen/low/CMakeLists.txt
+++ b/loom/src/loom/codegen/low/CMakeLists.txt
@@ -560,6 +560,7 @@ loom_cc_library(
     ::memory_access
     iree::base
     loom::analysis::symbolic_expr
+    loom::analysis::view_regions
     loom::ir
     loom::ir::facts
     loom::ops::buffer

--- a/loom/src/loom/codegen/low/lower/lower.h
+++ b/loom/src/loom/codegen/low/lower/lower.h
@@ -832,6 +832,10 @@ loom_func_like_t loom_low_lower_context_source_function(
 const loom_low_lower_abi_argument_t* loom_low_lower_context_argument_map(
     const loom_low_lower_context_t* context, uint16_t* out_argument_count);
 
+// Returns the active function-local source value domain for this lowering run.
+const loom_local_value_domain_t* loom_low_lower_context_value_domain(
+    const loom_low_lower_context_t* context);
+
 // Returns the source function name used in source-to-low diagnostics.
 iree_string_view_t loom_low_lower_context_function_name(
     const loom_low_lower_context_t* context);

--- a/loom/src/loom/codegen/low/lower/lower_context.c
+++ b/loom/src/loom/codegen/low/lower/lower_context.c
@@ -201,6 +201,11 @@ const loom_low_lower_abi_argument_t* loom_low_lower_context_argument_map(
   return context->lowering.argument_map;
 }
 
+const loom_local_value_domain_t* loom_low_lower_context_value_domain(
+    const loom_low_lower_context_t* context) {
+  return &context->lowering.value_domain;
+}
+
 loom_op_t* loom_low_lower_context_low_function(
     const loom_low_lower_context_t* context) {
   return context->low_func_op;

--- a/loom/src/loom/codegen/low/source_memory_plan.c
+++ b/loom/src/loom/codegen/low/source_memory_plan.c
@@ -10,6 +10,7 @@
 
 #include "iree/base/api.h"
 #include "loom/analysis/symbolic_expr.h"
+#include "loom/analysis/view_regions.h"
 #include "loom/codegen/low/memory_access.h"
 #include "loom/ir/facts.h"
 #include "loom/ir/module.h"
@@ -863,9 +864,125 @@ static bool loom_low_source_memory_access_add_dynamic_view_base_byte_offset(
   return true;
 }
 
+static bool loom_low_source_memory_facts_are_stronger(
+    loom_value_facts_t candidate, loom_value_facts_t baseline) {
+  if (loom_value_facts_is_float(candidate) !=
+      loom_value_facts_is_float(baseline)) {
+    return false;
+  }
+  const bool range_no_weaker = candidate.range_lo >= baseline.range_lo &&
+                               candidate.range_hi <= baseline.range_hi;
+  const bool range_stronger = candidate.range_lo > baseline.range_lo ||
+                              candidate.range_hi < baseline.range_hi;
+  const bool divisor_no_weaker =
+      baseline.known_divisor <= 1 ||
+      (candidate.known_divisor >= baseline.known_divisor &&
+       (candidate.known_divisor % baseline.known_divisor) == 0);
+  const bool divisor_stronger =
+      divisor_no_weaker && candidate.known_divisor > baseline.known_divisor;
+  return range_no_weaker && divisor_no_weaker &&
+         (range_stronger || divisor_stronger);
+}
+
+static loom_value_id_t loom_low_source_memory_symbolic_term_materialized_value(
+    const loom_value_fact_table_t* fact_table,
+    const loom_symbolic_term_t* expression_term) {
+  if (!fact_table ||
+      expression_term->relation_value_id == LOOM_VALUE_ID_INVALID ||
+      expression_term->relation_value_id == expression_term->value_id ||
+      !loom_value_fact_table_has_entry(fact_table,
+                                       expression_term->relation_value_id) ||
+      !loom_value_fact_table_has_entry(fact_table, expression_term->value_id)) {
+    return expression_term->value_id;
+  }
+  return loom_low_source_memory_facts_are_stronger(
+             loom_value_fact_table_lookup(fact_table,
+                                          expression_term->relation_value_id),
+             loom_value_fact_table_lookup(fact_table,
+                                          expression_term->value_id))
+             ? expression_term->relation_value_id
+             : expression_term->value_id;
+}
+
+static bool loom_low_source_memory_access_add_view_region_byte_offset(
+    const loom_value_fact_table_t* fact_table,
+    const loom_view_region_t* view_region,
+    loom_low_source_memory_access_plan_t* plan,
+    loom_low_source_memory_access_diagnostic_t* diagnostic,
+    int64_t* inout_static_byte_offset) {
+  if (!view_region ||
+      !loom_symbolic_expr_is_linear(&view_region->begin_byte_offset)) {
+    diagnostic->rejection_bits |=
+        LOOM_LOW_SOURCE_MEMORY_ACCESS_REJECTION_VIEW_BASE;
+    return false;
+  }
+  int64_t static_byte_offset = 0;
+  if (!loom_checked_add_i64(*inout_static_byte_offset,
+                            view_region->begin_byte_offset.constant,
+                            &static_byte_offset)) {
+    diagnostic->rejection_bits |=
+        LOOM_LOW_SOURCE_MEMORY_ACCESS_REJECTION_VIEW_BASE_OVERFLOW;
+    return false;
+  }
+  plan->static_view_base_byte_offset = view_region->begin_byte_offset.constant;
+  *inout_static_byte_offset = static_byte_offset;
+
+  const iree_host_size_t dynamic_view_base_begin = plan->dynamic_term_count;
+  for (iree_host_size_t i = 0; i < view_region->begin_byte_offset.term_count;
+       ++i) {
+    const loom_symbolic_term_t* expression_term =
+        &view_region->begin_byte_offset.terms[i];
+    if (expression_term->coefficient <= 0) {
+      diagnostic->rejection_bits |=
+          LOOM_LOW_SOURCE_MEMORY_ACCESS_REJECTION_VIEW_BASE;
+      return false;
+    }
+    loom_value_id_t materialized_value =
+        loom_low_source_memory_symbolic_term_materialized_value(
+            fact_table, expression_term);
+    if (view_region->begin_byte_offset.term_count == 1 &&
+        expression_term->coefficient == 1 &&
+        view_region->begin_value_id != LOOM_VALUE_ID_INVALID) {
+      materialized_value = view_region->begin_value_id;
+    }
+    loom_low_source_memory_dynamic_term_t term = {
+        .index = materialized_value,
+        .axis = LOOM_LOW_SOURCE_MEMORY_DYNAMIC_TERM_AXIS_NONE,
+        .byte_stride = expression_term->coefficient,
+        .byte_shift = LOOM_LOW_SOURCE_MEMORY_ACCESS_BYTE_SHIFT_NONE,
+    };
+    loom_low_source_memory_access_dynamic_index_source(
+        fact_table, materialized_value, &term.source, &term.dimension);
+    (void)loom_low_source_memory_access_power_of_two_shift(term.byte_stride,
+                                                           &term.byte_shift);
+    loom_low_source_memory_dynamic_term_compute_scaled_byte_facts(
+        fact_table, materialized_value, term.byte_stride, NULL, 0,
+        &term.byte_facts);
+    if (!loom_low_source_memory_access_append_dynamic_term(plan, &term,
+                                                           diagnostic)) {
+      return false;
+    }
+  }
+  const iree_host_size_t dynamic_view_base_count =
+      plan->dynamic_term_count - dynamic_view_base_begin;
+  if (dynamic_view_base_count > UINT8_MAX) {
+    diagnostic->rejection_bits |=
+        LOOM_LOW_SOURCE_MEMORY_ACCESS_REJECTION_DYNAMIC_INDEX_COUNT;
+    return false;
+  }
+  plan->dynamic_view_base_term_count = (uint8_t)dynamic_view_base_count;
+  if (dynamic_view_base_count == 1 &&
+      view_region->begin_byte_offset.terms[0].coefficient == 1) {
+    plan->dynamic_view_base_value_id =
+        plan->dynamic_terms[dynamic_view_base_begin].index;
+  }
+  return true;
+}
+
 static bool loom_low_source_memory_access_add_view_base_byte_offset(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
-    loom_value_id_t view_value_id, loom_low_source_memory_access_plan_t* plan,
+    const loom_view_region_table_t* view_regions, loom_value_id_t view_value_id,
+    loom_low_source_memory_access_plan_t* plan,
     loom_low_source_memory_access_diagnostic_t* diagnostic,
     int64_t* inout_static_byte_offset) {
   loom_value_fact_view_reference_t view_reference = {0};
@@ -878,22 +995,32 @@ static bool loom_low_source_memory_access_add_view_base_byte_offset(
     return false;
   }
 
-  int64_t view_base_byte_offset = 0;
-  if (loom_low_source_memory_access_exact_i64(view_reference.base_byte_offset,
-                                              &view_base_byte_offset)) {
-    int64_t static_byte_offset = 0;
-    if (!iree_checked_add_i64(*inout_static_byte_offset, view_base_byte_offset,
-                              &static_byte_offset)) {
-      diagnostic->rejection_bits |=
-          LOOM_LOW_SOURCE_MEMORY_ACCESS_REJECTION_VIEW_BASE_OVERFLOW;
+  const loom_view_region_t* view_region = NULL;
+  if (view_regions && loom_view_region_table_try_lookup(
+                          view_regions, view_value_id, &view_region)) {
+    if (!loom_low_source_memory_access_add_view_region_byte_offset(
+            fact_table, view_region, plan, diagnostic,
+            inout_static_byte_offset)) {
       return false;
     }
-    plan->static_view_base_byte_offset = view_base_byte_offset;
-    *inout_static_byte_offset = static_byte_offset;
-  } else if (!loom_low_source_memory_access_add_dynamic_view_base_byte_offset(
-                 module, fact_table, view_value_id, plan, diagnostic,
-                 inout_static_byte_offset)) {
-    return false;
+  } else {
+    int64_t view_base_byte_offset = 0;
+    if (loom_low_source_memory_access_exact_i64(view_reference.base_byte_offset,
+                                                &view_base_byte_offset)) {
+      int64_t static_byte_offset = 0;
+      if (!iree_checked_add_i64(*inout_static_byte_offset,
+                                view_base_byte_offset, &static_byte_offset)) {
+        diagnostic->rejection_bits |=
+            LOOM_LOW_SOURCE_MEMORY_ACCESS_REJECTION_VIEW_BASE_OVERFLOW;
+        return false;
+      }
+      plan->static_view_base_byte_offset = view_base_byte_offset;
+      *inout_static_byte_offset = static_byte_offset;
+    } else if (!loom_low_source_memory_access_add_dynamic_view_base_byte_offset(
+                   module, fact_table, view_value_id, plan, diagnostic,
+                   inout_static_byte_offset)) {
+      return false;
+    }
   }
 
   plan->memory_space = view_reference.memory_space;
@@ -1074,6 +1201,7 @@ static loom_type_t loom_low_source_memory_access_payload_vector_type(
 
 static bool loom_low_source_memory_access_plan_from_components(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    const loom_view_region_table_t* view_regions,
     loom_low_source_memory_operation_kind_t operation_kind,
     loom_value_id_t view_value_id, loom_value_slice_t dynamic_indices,
     loom_attribute_t static_indices, loom_type_t view_type,
@@ -1170,8 +1298,8 @@ static bool loom_low_source_memory_access_plan_from_components(
     return false;
   }
   if (!loom_low_source_memory_access_add_view_base_byte_offset(
-          module, fact_table, view_value_id, out_plan, out_diagnostic,
-          &static_byte_offset)) {
+          module, fact_table, view_regions, view_value_id, out_plan,
+          out_diagnostic, &static_byte_offset)) {
     return false;
   }
 
@@ -1318,6 +1446,15 @@ bool loom_low_source_memory_access_plan_build(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
     const loom_op_t* source_op, loom_low_source_memory_access_plan_t* out_plan,
     loom_low_source_memory_access_diagnostic_t* out_diagnostic) {
+  return loom_low_source_memory_access_plan_build_with_view_regions(
+      module, fact_table, NULL, source_op, out_plan, out_diagnostic);
+}
+
+bool loom_low_source_memory_access_plan_build_with_view_regions(
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    const loom_view_region_table_t* view_regions, const loom_op_t* source_op,
+    loom_low_source_memory_access_plan_t* out_plan,
+    loom_low_source_memory_access_diagnostic_t* out_diagnostic) {
   *out_plan = (loom_low_source_memory_access_plan_t){0};
   *out_diagnostic = (loom_low_source_memory_access_diagnostic_t){0};
 
@@ -1356,11 +1493,12 @@ bool loom_low_source_memory_access_plan_build(
   const loom_type_t vector_type =
       loom_low_source_memory_access_payload_vector_type(module, source_op,
                                                         access, view_type);
-  const bool built = loom_low_source_memory_access_plan_build_indexed(
-      module, fact_table, operation_kind, view_value_id,
-      loom_memory_access_dynamic_indices(access),
-      loom_memory_access_static_indices(access), vector_type, cache_policy,
-      out_plan, out_diagnostic);
+  const bool built =
+      loom_low_source_memory_access_plan_build_indexed_with_view_regions(
+          module, fact_table, view_regions, operation_kind, view_value_id,
+          loom_memory_access_dynamic_indices(access),
+          loom_memory_access_static_indices(access), vector_type, cache_policy,
+          out_plan, out_diagnostic);
   if (built) {
     out_plan->vector_offset_kind =
         loom_low_source_memory_access_vector_offset_kind(
@@ -1377,6 +1515,20 @@ bool loom_low_source_memory_access_plan_build_indexed(
     loom_vector_memory_cache_policy_t cache_policy,
     loom_low_source_memory_access_plan_t* out_plan,
     loom_low_source_memory_access_diagnostic_t* out_diagnostic) {
+  return loom_low_source_memory_access_plan_build_indexed_with_view_regions(
+      module, fact_table, NULL, operation_kind, view_value_id, dynamic_indices,
+      static_indices, vector_type, cache_policy, out_plan, out_diagnostic);
+}
+
+bool loom_low_source_memory_access_plan_build_indexed_with_view_regions(
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    const loom_view_region_table_t* view_regions,
+    loom_low_source_memory_operation_kind_t operation_kind,
+    loom_value_id_t view_value_id, loom_value_slice_t dynamic_indices,
+    loom_attribute_t static_indices, loom_type_t vector_type,
+    loom_vector_memory_cache_policy_t cache_policy,
+    loom_low_source_memory_access_plan_t* out_plan,
+    loom_low_source_memory_access_diagnostic_t* out_diagnostic) {
   *out_plan = (loom_low_source_memory_access_plan_t){0};
   *out_diagnostic = (loom_low_source_memory_access_diagnostic_t){0};
   if (view_value_id >= module->values.count) {
@@ -1386,13 +1538,26 @@ bool loom_low_source_memory_access_plan_build_indexed(
   }
   const loom_type_t view_type = loom_module_value_type(module, view_value_id);
   return loom_low_source_memory_access_plan_from_components(
-      module, fact_table, operation_kind, view_value_id, dynamic_indices,
-      static_indices, view_type, vector_type, cache_policy, out_plan,
-      out_diagnostic);
+      module, fact_table, view_regions, operation_kind, view_value_id,
+      dynamic_indices, static_indices, view_type, vector_type, cache_policy,
+      out_plan, out_diagnostic);
 }
 
 bool loom_low_source_memory_access_plan_build_view(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    loom_low_source_memory_operation_kind_t operation_kind,
+    loom_value_id_t view_value_id,
+    loom_vector_memory_cache_policy_t cache_policy,
+    loom_low_source_memory_access_plan_t* out_plan,
+    loom_low_source_memory_access_diagnostic_t* out_diagnostic) {
+  return loom_low_source_memory_access_plan_build_view_with_view_regions(
+      module, fact_table, NULL, operation_kind, view_value_id, cache_policy,
+      out_plan, out_diagnostic);
+}
+
+bool loom_low_source_memory_access_plan_build_view_with_view_regions(
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    const loom_view_region_table_t* view_regions,
     loom_low_source_memory_operation_kind_t operation_kind,
     loom_value_id_t view_value_id,
     loom_vector_memory_cache_policy_t cache_policy,
@@ -1419,6 +1584,13 @@ bool loom_low_source_memory_access_plan_build_view(
   int64_t zero_indices[LOOM_ENCODING_ADDRESS_LAYOUT_MAX_RANK] = {0};
   loom_attribute_t static_indices =
       loom_attr_i64_array(zero_indices, loom_type_rank(result_view_type));
+
+  if (view_regions) {
+    return loom_low_source_memory_access_plan_build_indexed_with_view_regions(
+        module, fact_table, view_regions, operation_kind, view_value_id,
+        dynamic_indices, static_indices, vector_type, cache_policy, out_plan,
+        out_diagnostic);
+  }
 
   loom_value_id_t projection_view_id = view_value_id;
   const loom_value_t* view_value = loom_module_value(module, view_value_id);

--- a/loom/src/loom/codegen/low/source_memory_plan.h
+++ b/loom/src/loom/codegen/low/source_memory_plan.h
@@ -29,6 +29,8 @@
 extern "C" {
 #endif
 
+typedef struct loom_view_region_table_t loom_view_region_table_t;
+
 #define LOOM_LOW_SOURCE_MEMORY_ACCESS_BYTE_SHIFT_NONE UINT32_MAX
 
 typedef enum loom_low_source_memory_operation_kind_e {
@@ -220,6 +222,18 @@ bool loom_low_source_memory_access_plan_build(
     const loom_op_t* source_op, loom_low_source_memory_access_plan_t* out_plan,
     loom_low_source_memory_access_diagnostic_t* out_diagnostic);
 
+// Builds a source memory plan with optional precomputed view-region summaries.
+//
+// When present, |view_regions| is only queried with a non-mutating lookup and
+// must already have been analyzed by the caller. This lets lowering reuse its
+// function-local analysis without turning each memory access into a fresh
+// producer walk or analysis construction site.
+bool loom_low_source_memory_access_plan_build_with_view_regions(
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    const loom_view_region_table_t* view_regions, const loom_op_t* source_op,
+    loom_low_source_memory_access_plan_t* out_plan,
+    loom_low_source_memory_access_diagnostic_t* out_diagnostic);
+
 // Builds a target-independent source memory plan for an indexed view access.
 //
 // This is the component-level sibling of vector.load/store planning for source
@@ -227,6 +241,18 @@ bool loom_low_source_memory_access_plan_build(
 // element or vector footprint, such as sanitizer access assertions.
 bool loom_low_source_memory_access_plan_build_indexed(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    loom_low_source_memory_operation_kind_t operation_kind,
+    loom_value_id_t view_value_id, loom_value_slice_t dynamic_indices,
+    loom_attribute_t static_indices, loom_type_t vector_type,
+    loom_vector_memory_cache_policy_t cache_policy,
+    loom_low_source_memory_access_plan_t* out_plan,
+    loom_low_source_memory_access_diagnostic_t* out_diagnostic);
+
+// Builds an indexed source memory plan with optional precomputed view-region
+// summaries. See loom_low_source_memory_access_plan_build_with_view_regions.
+bool loom_low_source_memory_access_plan_build_indexed_with_view_regions(
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    const loom_view_region_table_t* view_regions,
     loom_low_source_memory_operation_kind_t operation_kind,
     loom_value_id_t view_value_id, loom_value_slice_t dynamic_indices,
     loom_attribute_t static_indices, loom_type_t vector_type,
@@ -244,6 +270,17 @@ bool loom_low_source_memory_access_plan_build_indexed(
 // names a view projection rather than an indexed vector load.
 bool loom_low_source_memory_access_plan_build_view(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    loom_low_source_memory_operation_kind_t operation_kind,
+    loom_value_id_t view_value_id,
+    loom_vector_memory_cache_policy_t cache_policy,
+    loom_low_source_memory_access_plan_t* out_plan,
+    loom_low_source_memory_access_diagnostic_t* out_diagnostic);
+
+// Builds a whole-view source memory plan with optional precomputed view-region
+// summaries. See loom_low_source_memory_access_plan_build_with_view_regions.
+bool loom_low_source_memory_access_plan_build_view_with_view_regions(
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    const loom_view_region_table_t* view_regions,
     loom_low_source_memory_operation_kind_t operation_kind,
     loom_value_id_t view_value_id,
     loom_vector_memory_cache_policy_t cache_policy,

--- a/loom/src/loom/target/arch/amdgpu/lower/async.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/async.c
@@ -138,16 +138,17 @@ static bool loom_amdgpu_async_gather_select_descriptor(
 static bool loom_amdgpu_async_gather_select_source(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
     const loom_low_descriptor_set_t* descriptor_set,
-    loom_value_id_t source_view, loom_vector_memory_cache_policy_t cache_policy,
+    const loom_view_region_table_t* view_regions, loom_value_id_t source_view,
+    loom_vector_memory_cache_policy_t cache_policy,
     loom_amdgpu_async_gather_selection_t* selection,
     loom_amdgpu_async_gather_diagnostic_t* diagnostic,
     uint32_t* out_descriptor_ordinal) {
   *out_descriptor_ordinal = LOOM_LOW_DESCRIPTOR_ORDINAL_NONE;
 
-  if (!loom_low_source_memory_access_plan_build_view(
-          module, fact_table, LOOM_LOW_SOURCE_MEMORY_OPERATION_LOAD,
-          source_view, cache_policy, &selection->source,
-          &diagnostic->source_diagnostic)) {
+  if (!loom_low_source_memory_access_plan_build_view_with_view_regions(
+          module, fact_table, view_regions,
+          LOOM_LOW_SOURCE_MEMORY_OPERATION_LOAD, source_view, cache_policy,
+          &selection->source, &diagnostic->source_diagnostic)) {
     diagnostic->rejection_bits |=
         LOOM_AMDGPU_ASYNC_GATHER_REJECTION_SOURCE_PLAN;
     return false;
@@ -253,6 +254,7 @@ static bool loom_amdgpu_async_gather_select_dest(
 static bool loom_amdgpu_async_gather_select(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
     const loom_low_descriptor_set_t* descriptor_set,
+    const loom_view_region_table_t* view_regions,
     loom_func_like_t source_function, const loom_op_t* source_op,
     loom_amdgpu_async_gather_selection_t* out_selection,
     loom_amdgpu_async_gather_diagnostic_t* out_diagnostic) {
@@ -277,8 +279,9 @@ static bool loom_amdgpu_async_gather_select(
   out_selection->dest_view = loom_kernel_async_gather_dest(source_op);
   uint32_t descriptor_ordinal = LOOM_LOW_DESCRIPTOR_ORDINAL_NONE;
   if (!loom_amdgpu_async_gather_select_source(
-          module, fact_table, descriptor_set, out_selection->source_view,
-          cache_policy, out_selection, out_diagnostic, &descriptor_ordinal) ||
+          module, fact_table, descriptor_set, view_regions,
+          out_selection->source_view, cache_policy, out_selection,
+          out_diagnostic, &descriptor_ordinal) ||
       !loom_amdgpu_async_gather_select_dest(fact_table, source_function,
                                             out_selection->dest_view,
                                             out_selection, out_diagnostic)) {
@@ -358,10 +361,13 @@ iree_status_t loom_amdgpu_select_kernel_async_gather_plan(
   *out_selected = false;
   loom_amdgpu_async_gather_diagnostic_t diagnostic = {0};
   loom_amdgpu_async_gather_selection_t selection = {0};
+  const loom_view_region_table_t* view_regions = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_low_lower_context_view_regions(context, &view_regions));
   if (!loom_amdgpu_async_gather_select(
           loom_low_lower_context_module(context),
           loom_low_lower_context_fact_table(context),
-          loom_low_lower_context_descriptor_set(context),
+          loom_low_lower_context_descriptor_set(context), view_regions,
           loom_low_lower_context_source_function(context), source_op,
           &selection, &diagnostic)) {
     return iree_ok_status();
@@ -708,10 +714,13 @@ static iree_status_t loom_amdgpu_low_legality_verify_kernel_async_gather(
     loom_target_low_legality_context_t* context, const loom_op_t* op) {
   loom_amdgpu_async_gather_selection_t selection = {0};
   loom_amdgpu_async_gather_diagnostic_t diagnostic = {0};
+  const loom_view_region_table_t* view_regions = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_target_low_legality_view_regions(context, &view_regions));
   if (loom_amdgpu_async_gather_select(
           loom_target_low_legality_module(context),
           loom_target_low_legality_fact_table(context),
-          loom_target_low_legality_descriptor_set(context),
+          loom_target_low_legality_descriptor_set(context), view_regions,
           loom_target_low_legality_function(context), op, &selection,
           &diagnostic)) {
     return iree_ok_status();

--- a/loom/src/loom/target/arch/amdgpu/lower/atomic.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/atomic.c
@@ -1026,7 +1026,8 @@ static void loom_amdgpu_atomic_select_packet_attrs(
 
 static iree_status_t loom_amdgpu_atomic_select(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
-    const loom_low_descriptor_set_t* descriptor_set, const loom_op_t* source_op,
+    const loom_low_descriptor_set_t* descriptor_set,
+    const loom_view_region_table_t* view_regions, const loom_op_t* source_op,
     loom_amdgpu_atomic_selection_t* out_selection,
     loom_low_source_memory_access_diagnostic_t* source_diagnostic,
     loom_amdgpu_memory_access_diagnostic_t* memory_diagnostic,
@@ -1043,9 +1044,9 @@ static iree_status_t loom_amdgpu_atomic_select(
     return iree_ok_status();
   }
 
-  if (!loom_low_source_memory_access_plan_build(module, fact_table, source_op,
-                                                &out_selection->source,
-                                                source_diagnostic)) {
+  if (!loom_low_source_memory_access_plan_build_with_view_regions(
+          module, fact_table, view_regions, source_op, &out_selection->source,
+          source_diagnostic)) {
     return iree_ok_status();
   }
   switch (out_selection->source.operation_kind) {
@@ -1250,12 +1251,16 @@ iree_status_t loom_amdgpu_select_atomic_plan(
   loom_amdgpu_memory_access_diagnostic_t memory_diagnostic = {0};
   loom_amdgpu_atomic_diagnostic_t diagnostic = {0};
   loom_amdgpu_atomic_selection_t selection = {0};
+  const loom_view_region_table_t* view_regions = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_low_lower_context_view_regions(context, &view_regions));
   bool selected = false;
   IREE_RETURN_IF_ERROR(loom_amdgpu_atomic_select(
       loom_low_lower_context_module(context),
       loom_low_lower_context_fact_table(context),
-      loom_low_lower_context_descriptor_set(context), source_op, &selection,
-      &source_diagnostic, &memory_diagnostic, &diagnostic, &selected));
+      loom_low_lower_context_descriptor_set(context), view_regions, source_op,
+      &selection, &source_diagnostic, &memory_diagnostic, &diagnostic,
+      &selected));
   if (!selected) {
     return iree_ok_status();
   }
@@ -1638,11 +1643,15 @@ iree_status_t loom_amdgpu_low_legality_verify_atomic(
   loom_amdgpu_memory_access_diagnostic_t memory_diagnostic = {0};
   loom_amdgpu_atomic_diagnostic_t diagnostic = {0};
   const loom_module_t* module = loom_target_low_legality_module(context);
+  const loom_view_region_table_t* view_regions = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_target_low_legality_view_regions(context, &view_regions));
   bool selected = false;
   IREE_RETURN_IF_ERROR(loom_amdgpu_atomic_select(
       module, loom_target_low_legality_fact_table(context),
-      loom_target_low_legality_descriptor_set(context), op, &selection,
-      &source_diagnostic, &memory_diagnostic, &diagnostic, &selected));
+      loom_target_low_legality_descriptor_set(context), view_regions, op,
+      &selection, &source_diagnostic, &memory_diagnostic, &diagnostic,
+      &selected));
   if (selected) {
     return iree_ok_status();
   }

--- a/loom/src/loom/target/arch/amdgpu/lower/memory.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/memory.c
@@ -2624,8 +2624,9 @@ bool loom_amdgpu_memory_access_plan_select(
   *out_source_diagnostic = (loom_low_source_memory_access_diagnostic_t){0};
   *out_diagnostic = (loom_amdgpu_memory_access_diagnostic_t){0};
 
-  if (!loom_low_source_memory_access_plan_build(
-          module, fact_table, source_op, out_source, out_source_diagnostic)) {
+  if (!loom_low_source_memory_access_plan_build_with_view_regions(
+          module, fact_table, view_regions, source_op, out_source,
+          out_source_diagnostic)) {
     return false;
   }
 

--- a/loom/src/loom/target/arch/amdgpu/lower/prefetch.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/prefetch.c
@@ -189,9 +189,9 @@ static bool loom_amdgpu_prefetch_select_source(
   }
 
   loom_low_source_memory_access_diagnostic_t source_diagnostic = {0};
-  if (!loom_low_source_memory_access_plan_build(module, fact_table, source_op,
-                                                &out_plan->source,
-                                                &source_diagnostic)) {
+  if (!loom_low_source_memory_access_plan_build_with_view_regions(
+          module, fact_table, view_regions, source_op, &out_plan->source,
+          &source_diagnostic)) {
     *out_decision_key = source_diagnostic.rejection_bits != 0
                             ? loom_low_source_memory_access_rejection_key(
                                   source_diagnostic.rejection_bits)

--- a/loom/src/loom/target/arch/amdgpu/lower/sanitizer.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/sanitizer.c
@@ -609,7 +609,8 @@ static bool loom_amdgpu_sanitizer_access_byte_stride(
 
 static bool loom_amdgpu_sanitizer_assert_access_plan_build(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
-    const loom_op_t* op, loom_amdgpu_sanitizer_access_plan_t* out_plan,
+    const loom_view_region_table_t* view_regions, const loom_op_t* op,
+    loom_amdgpu_sanitizer_access_plan_t* out_plan,
     loom_amdgpu_sanitizer_access_diagnostic_t* out_diagnostic) {
   *out_plan = (loom_amdgpu_sanitizer_access_plan_t){
       .site_id = LOOM_SANITIZER_SITE_ID_INVALID,
@@ -686,8 +687,8 @@ static bool loom_amdgpu_sanitizer_assert_access_plan_build(
 
   loom_low_source_memory_access_plan_t source = {0};
   loom_vector_memory_cache_policy_t cache_policy = {0};
-  if (!loom_low_source_memory_access_plan_build_indexed(
-          module, fact_table, source_kind, view_value_id, indices,
+  if (!loom_low_source_memory_access_plan_build_indexed_with_view_regions(
+          module, fact_table, view_regions, source_kind, view_value_id, indices,
           static_indices, base_vector_type, cache_policy, &source,
           &out_diagnostic->source)) {
     return false;
@@ -748,10 +749,13 @@ iree_status_t loom_amdgpu_select_sanitizer_assert_access_plan(
   }
 
   loom_amdgpu_sanitizer_access_diagnostic_t diagnostic = {0};
+  const loom_view_region_table_t* view_regions = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_low_lower_context_view_regions(context, &view_regions));
   if (!loom_amdgpu_sanitizer_assert_access_plan_build(
           loom_low_lower_context_module(context),
-          loom_low_lower_context_fact_table(context), source_op, out_plan,
-          &diagnostic)) {
+          loom_low_lower_context_fact_table(context), view_regions, source_op,
+          out_plan, &diagnostic)) {
     return iree_ok_status();
   }
   const loom_sanitizer_reporting_mode_t reporting_mode =
@@ -779,9 +783,12 @@ iree_status_t loom_amdgpu_low_legality_verify_sanitizer_assert_access(
 
   loom_amdgpu_sanitizer_access_plan_t plan = {0};
   loom_amdgpu_sanitizer_access_diagnostic_t diagnostic = {0};
+  const loom_view_region_table_t* view_regions = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_target_low_legality_view_regions(context, &view_regions));
   if (!loom_amdgpu_sanitizer_assert_access_plan_build(
           loom_target_low_legality_module(context),
-          loom_target_low_legality_fact_table(context), op, &plan,
+          loom_target_low_legality_fact_table(context), view_regions, op, &plan,
           &diagnostic)) {
     return loom_amdgpu_sanitizer_assert_access_reject(context, op, &plan,
                                                       &diagnostic);

--- a/loom/src/loom/target/arch/amdgpu/lower/sanitizer_race.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/sanitizer_race.c
@@ -1618,8 +1618,8 @@ static bool loom_amdgpu_sanitizer_race_access_plan_build(
 
   loom_low_source_memory_access_plan_t source = {0};
   loom_vector_memory_cache_policy_t cache_policy = {0};
-  if (!loom_low_source_memory_access_plan_build_indexed(
-          module, fact_table, source_kind, view_value_id,
+  if (!loom_low_source_memory_access_plan_build_indexed_with_view_regions(
+          module, fact_table, view_regions, source_kind, view_value_id,
           loom_sanitizer_race_access_indices(op),
           loom_sanitizer_race_access_static_indices(op), vector_type,
           cache_policy, &source, out_source_diagnostic)) {

--- a/loom/src/loom/target/arch/amdgpu/lower/support.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/support.c
@@ -999,8 +999,8 @@ static bool loom_amdgpu_source_memory_access_prefers_vgpr(
   }
   loom_low_source_memory_access_plan_t plan = {0};
   loom_low_source_memory_access_diagnostic_t diagnostic = {0};
-  if (!loom_low_source_memory_access_plan_build(module, fact_table, source_op,
-                                                &plan, &diagnostic)) {
+  if (!loom_low_source_memory_access_plan_build_with_view_regions(
+          module, fact_table, view_regions, source_op, &plan, &diagnostic)) {
     return true;
   }
   if (plan.operation_kind != LOOM_LOW_SOURCE_MEMORY_OPERATION_LOAD ||

--- a/loom/src/loom/target/arch/amdgpu/lower/support.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/support.c
@@ -1141,75 +1141,27 @@ static bool loom_amdgpu_scalar_conversion_result_follows_operand_vgpr(
   }
 }
 
-static bool loom_amdgpu_scalar_integer_binary_result_follows_operand_vgpr(
+static bool
+loom_amdgpu_distribution_transfer_binary_result_follows_operand_vgpr(
     const loom_module_t* module, loom_value_id_t source_value_id,
     const loom_op_t* defining_op, loom_value_id_t* out_lhs,
     loom_value_id_t* out_rhs) {
   *out_lhs = LOOM_VALUE_ID_INVALID;
   *out_rhs = LOOM_VALUE_ID_INVALID;
   if (loom_value_def_index(loom_module_value(module, source_value_id)) != 0 ||
+      defining_op->operand_count != 2 || defining_op->result_count != 1 ||
+      !loom_traits_have_distribution_transfer(
+          loom_op_effective_traits(module, defining_op)) ||
       (!loom_amdgpu_type_is_i32(
            loom_module_value_type(module, source_value_id)) &&
        !loom_amdgpu_type_is_i64(
            loom_module_value_type(module, source_value_id)))) {
     return false;
   }
-  switch (defining_op->kind) {
-    case LOOM_OP_SCALAR_ADDI:
-      *out_lhs = loom_scalar_addi_lhs(defining_op);
-      *out_rhs = loom_scalar_addi_rhs(defining_op);
-      return true;
-    case LOOM_OP_SCALAR_SUBI:
-      *out_lhs = loom_scalar_subi_lhs(defining_op);
-      *out_rhs = loom_scalar_subi_rhs(defining_op);
-      return true;
-    case LOOM_OP_SCALAR_MULI:
-      *out_lhs = loom_scalar_muli_lhs(defining_op);
-      *out_rhs = loom_scalar_muli_rhs(defining_op);
-      return true;
-    case LOOM_OP_SCALAR_SHLI:
-      *out_lhs = loom_scalar_shli_lhs(defining_op);
-      *out_rhs = loom_scalar_shli_rhs(defining_op);
-      return true;
-    case LOOM_OP_SCALAR_SHRSI:
-      *out_lhs = loom_scalar_shrsi_lhs(defining_op);
-      *out_rhs = loom_scalar_shrsi_rhs(defining_op);
-      return true;
-    case LOOM_OP_SCALAR_SHRUI:
-      *out_lhs = loom_scalar_shrui_lhs(defining_op);
-      *out_rhs = loom_scalar_shrui_rhs(defining_op);
-      return true;
-    case LOOM_OP_SCALAR_ANDI:
-      *out_lhs = loom_scalar_andi_lhs(defining_op);
-      *out_rhs = loom_scalar_andi_rhs(defining_op);
-      return true;
-    case LOOM_OP_SCALAR_ORI:
-      *out_lhs = loom_scalar_ori_lhs(defining_op);
-      *out_rhs = loom_scalar_ori_rhs(defining_op);
-      return true;
-    case LOOM_OP_SCALAR_XORI:
-      *out_lhs = loom_scalar_xori_lhs(defining_op);
-      *out_rhs = loom_scalar_xori_rhs(defining_op);
-      return true;
-    case LOOM_OP_SCALAR_MINSI:
-      *out_lhs = loom_scalar_minsi_lhs(defining_op);
-      *out_rhs = loom_scalar_minsi_rhs(defining_op);
-      return true;
-    case LOOM_OP_SCALAR_MAXSI:
-      *out_lhs = loom_scalar_maxsi_lhs(defining_op);
-      *out_rhs = loom_scalar_maxsi_rhs(defining_op);
-      return true;
-    case LOOM_OP_SCALAR_MINUI:
-      *out_lhs = loom_scalar_minui_lhs(defining_op);
-      *out_rhs = loom_scalar_minui_rhs(defining_op);
-      return true;
-    case LOOM_OP_SCALAR_MAXUI:
-      *out_lhs = loom_scalar_maxui_lhs(defining_op);
-      *out_rhs = loom_scalar_maxui_rhs(defining_op);
-      return true;
-    default:
-      return false;
-  }
+  const loom_value_id_t* operands = loom_op_const_operands(defining_op);
+  *out_lhs = operands[0];
+  *out_rhs = operands[1];
+  return true;
 }
 
 static bool loom_amdgpu_source_value_facts_are_native_i1_mask(
@@ -1358,7 +1310,7 @@ static bool loom_amdgpu_source_value_directly_prefers_vgpr(
       default: {
         loom_value_id_t lhs = LOOM_VALUE_ID_INVALID;
         loom_value_id_t rhs = LOOM_VALUE_ID_INVALID;
-        if (loom_amdgpu_scalar_integer_binary_result_follows_operand_vgpr(
+        if (loom_amdgpu_distribution_transfer_binary_result_follows_operand_vgpr(
                 module, source_value_id, defining_op, &lhs, &rhs)) {
           return loom_amdgpu_source_value_directly_prefers_vgpr(
                      module, lhs, source_value_id) ||
@@ -2212,54 +2164,6 @@ static bool loom_amdgpu_scf_select_result_requires_vgpr(
       module, fact_table, view_regions, condition, source_value_id);
 }
 
-static bool loom_amdgpu_index_arithmetic_result_follows_operand_vgpr(
-    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
-    const loom_view_region_table_t* view_regions,
-    loom_value_id_t source_value_id, const loom_op_t* defining_op) {
-  if (loom_value_def_index(loom_module_value(module, source_value_id)) != 0) {
-    return false;
-  }
-
-  uint16_t operand_count = 0;
-  switch (defining_op->kind) {
-    case LOOM_OP_INDEX_ADD:
-    case LOOM_OP_INDEX_SUB:
-    case LOOM_OP_INDEX_MUL:
-    case LOOM_OP_INDEX_SCALE:
-    case LOOM_OP_INDEX_DIV:
-    case LOOM_OP_INDEX_REM:
-    case LOOM_OP_INDEX_MIN:
-    case LOOM_OP_INDEX_MAX:
-    case LOOM_OP_INDEX_ANDI:
-    case LOOM_OP_INDEX_ORI:
-    case LOOM_OP_INDEX_XORI:
-    case LOOM_OP_INDEX_SHLI:
-    case LOOM_OP_INDEX_SHRSI:
-    case LOOM_OP_INDEX_SHRUI:
-    case LOOM_OP_INDEX_ROTLI:
-    case LOOM_OP_INDEX_ROTRI:
-      operand_count = 2;
-      break;
-    case LOOM_OP_INDEX_MADD:
-      operand_count = 3;
-      break;
-    default:
-      return false;
-  }
-  if (operand_count > defining_op->operand_count) {
-    return false;
-  }
-  const loom_value_id_t* operands = loom_op_const_operands(defining_op);
-  for (uint16_t i = 0; i < operand_count; ++i) {
-    if (operands[i] != source_value_id &&
-        loom_amdgpu_source_value_prefers_vgpr(module, fact_table, view_regions,
-                                              operands[i])) {
-      return true;
-    }
-  }
-  return false;
-}
-
 static bool loom_amdgpu_source_value_has_vgpr_payload_use(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
     const loom_view_region_table_t* view_regions,
@@ -2357,11 +2261,6 @@ bool loom_amdgpu_source_value_prefers_vgpr(
     }
   }
 
-  if (loom_amdgpu_index_arithmetic_result_follows_operand_vgpr(
-          module, fact_table, view_regions, source_value_id, defining_op)) {
-    return true;
-  }
-
   if (loom_scalar_bitcast_isa(defining_op)) {
     const loom_value_id_t input_value_id =
         loom_scalar_bitcast_input(defining_op);
@@ -2435,7 +2334,7 @@ bool loom_amdgpu_source_value_prefers_vgpr(
     default: {
       loom_value_id_t lhs = LOOM_VALUE_ID_INVALID;
       loom_value_id_t rhs = LOOM_VALUE_ID_INVALID;
-      if (loom_amdgpu_scalar_integer_binary_result_follows_operand_vgpr(
+      if (loom_amdgpu_distribution_transfer_binary_result_follows_operand_vgpr(
               module, source_value_id, defining_op, &lhs, &rhs)) {
         return loom_amdgpu_source_value_prefers_vgpr(module, fact_table,
                                                      view_regions, lhs) ||

--- a/loom/src/loom/target/arch/amdgpu/lower/support.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/support.c
@@ -805,6 +805,143 @@ static bool loom_amdgpu_scalar_type_fallback_result_prefers_vgpr(
       LOOM_AMDGPU_SCALAR_VALUE_REGISTER_FLAG_FALLBACK_RESULT_PREFERS_VGPR);
 }
 
+typedef uint8_t loom_amdgpu_source_value_analysis_bits_t;
+
+enum loom_amdgpu_source_value_analysis_bit_e {
+  LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_PREFERS_VGPR = 1u << 0,
+  LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_NATIVE_I1_MASK = 1u << 1,
+  LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_DURABLE_I1_BOOL = 1u << 2,
+  LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_REGISTER_SHAPE = 1u << 3,
+};
+
+typedef struct loom_amdgpu_source_value_analysis_record_t {
+  // Analysis bits whose values have been computed for this source value.
+  loom_amdgpu_source_value_analysis_bits_t known_bits;
+  // Computed true/false values keyed by known_bits.
+  loom_amdgpu_source_value_analysis_bits_t value_bits;
+  // Cached register shape used when the REGISTER_SHAPE value bit is set.
+  loom_amdgpu_register_shape_t register_shape;
+} loom_amdgpu_source_value_analysis_record_t;
+
+typedef struct loom_amdgpu_source_value_analysis_t {
+  // Dense source value domain owned by the current source-to-low lowering run.
+  const loom_local_value_domain_t* value_domain;
+  // Cached analysis records indexed by function-local source value ordinal.
+  loom_amdgpu_source_value_analysis_record_t* records;
+  // Number of initialized records.
+  iree_host_size_t record_count;
+} loom_amdgpu_source_value_analysis_t;
+
+static int loom_amdgpu_source_value_analysis_state_key;
+
+static iree_status_t loom_amdgpu_source_value_analysis_for_context(
+    loom_low_lower_context_t* context,
+    loom_amdgpu_source_value_analysis_t** out_analysis) {
+  *out_analysis = NULL;
+  loom_amdgpu_source_value_analysis_t* analysis = NULL;
+  IREE_RETURN_IF_ERROR(loom_low_lower_get_or_allocate_target_state(
+      context, &loom_amdgpu_source_value_analysis_state_key, sizeof(*analysis),
+      (void**)&analysis));
+  const loom_local_value_domain_t* value_domain =
+      loom_low_lower_context_value_domain(context);
+  if (analysis->value_domain != value_domain ||
+      analysis->record_count < value_domain->value_count) {
+    analysis->value_domain = value_domain;
+    analysis->record_count = value_domain->value_count;
+    IREE_RETURN_IF_ERROR(loom_low_lower_allocate_scratch_array(
+        context, analysis->record_count, sizeof(*analysis->records),
+        (void**)&analysis->records));
+    memset(analysis->records, 0,
+           analysis->record_count * sizeof(*analysis->records));
+  }
+  *out_analysis = analysis;
+  return iree_ok_status();
+}
+
+static loom_amdgpu_source_value_analysis_record_t*
+loom_amdgpu_source_value_analysis_lookup(
+    loom_amdgpu_source_value_analysis_t* analysis,
+    loom_value_id_t source_value_id) {
+  if (analysis == NULL || analysis->value_domain == NULL ||
+      !loom_local_value_domain_is_acquired(analysis->value_domain)) {
+    return NULL;
+  }
+  const loom_value_ordinal_t value_ordinal =
+      loom_local_value_domain_try_ordinal(analysis->value_domain,
+                                          source_value_id);
+  if (value_ordinal == LOOM_VALUE_ORDINAL_INVALID ||
+      value_ordinal >= analysis->record_count) {
+    return NULL;
+  }
+  return &analysis->records[value_ordinal];
+}
+
+static bool loom_amdgpu_source_value_analysis_cached_bit(
+    loom_amdgpu_source_value_analysis_t* analysis,
+    loom_value_id_t source_value_id,
+    loom_amdgpu_source_value_analysis_bits_t bit, bool* out_value) {
+  *out_value = false;
+  loom_amdgpu_source_value_analysis_record_t* record =
+      loom_amdgpu_source_value_analysis_lookup(analysis, source_value_id);
+  if (record == NULL || !iree_any_bit_set(record->known_bits, bit)) {
+    return false;
+  }
+  *out_value = iree_any_bit_set(record->value_bits, bit);
+  return true;
+}
+
+static void loom_amdgpu_source_value_analysis_record_bit(
+    loom_amdgpu_source_value_analysis_t* analysis,
+    loom_value_id_t source_value_id,
+    loom_amdgpu_source_value_analysis_bits_t bit, bool value) {
+  loom_amdgpu_source_value_analysis_record_t* record =
+      loom_amdgpu_source_value_analysis_lookup(analysis, source_value_id);
+  if (record == NULL) return;
+  record->known_bits |= bit;
+  if (value) {
+    record->value_bits |= bit;
+  } else {
+    record->value_bits &= (loom_amdgpu_source_value_analysis_bits_t)~bit;
+  }
+}
+
+static bool loom_amdgpu_source_value_analysis_cached_register_shape(
+    loom_amdgpu_source_value_analysis_t* analysis,
+    loom_value_id_t source_value_id, bool* out_has_shape,
+    loom_amdgpu_register_shape_t* out_shape) {
+  *out_has_shape = false;
+  *out_shape = (loom_amdgpu_register_shape_t){0};
+  loom_amdgpu_source_value_analysis_record_t* record =
+      loom_amdgpu_source_value_analysis_lookup(analysis, source_value_id);
+  if (record == NULL ||
+      !iree_any_bit_set(record->known_bits,
+                        LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_REGISTER_SHAPE)) {
+    return false;
+  }
+  *out_shape = record->register_shape;
+  *out_has_shape = iree_any_bit_set(
+      record->value_bits, LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_REGISTER_SHAPE);
+  return true;
+}
+
+static void loom_amdgpu_source_value_analysis_record_register_shape(
+    loom_amdgpu_source_value_analysis_t* analysis,
+    loom_value_id_t source_value_id, const loom_amdgpu_register_shape_t* shape,
+    bool valid) {
+  loom_amdgpu_source_value_analysis_record_t* record =
+      loom_amdgpu_source_value_analysis_lookup(analysis, source_value_id);
+  if (record == NULL) return;
+  record->known_bits |= LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_REGISTER_SHAPE;
+  if (valid) {
+    record->value_bits |= LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_REGISTER_SHAPE;
+    record->register_shape = *shape;
+  } else {
+    record->value_bits &=
+        (loom_amdgpu_source_value_analysis_bits_t)~LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_REGISTER_SHAPE;
+    record->register_shape = (loom_amdgpu_register_shape_t){0};
+  }
+}
+
 static bool loom_amdgpu_source_memory_root_is_read_only(
     const loom_low_source_memory_access_plan_t* plan,
     const loom_view_region_table_t* view_regions) {
@@ -2320,15 +2457,75 @@ bool loom_amdgpu_source_value_prefers_vgpr(
   }
 }
 
+static bool loom_amdgpu_analyzed_source_value_prefers_vgpr(
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    const loom_view_region_table_t* view_regions,
+    loom_amdgpu_source_value_analysis_t* analysis,
+    loom_value_id_t source_value_id) {
+  bool value = false;
+  if (loom_amdgpu_source_value_analysis_cached_bit(
+          analysis, source_value_id,
+          LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_PREFERS_VGPR, &value)) {
+    return value;
+  }
+  value = loom_amdgpu_source_value_prefers_vgpr(module, fact_table,
+                                                view_regions, source_value_id);
+  loom_amdgpu_source_value_analysis_record_bit(
+      analysis, source_value_id, LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_PREFERS_VGPR,
+      value);
+  return value;
+}
+
+static bool loom_amdgpu_analyzed_source_value_is_native_i1_mask(
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    const loom_view_region_table_t* view_regions,
+    loom_amdgpu_source_value_analysis_t* analysis,
+    loom_value_id_t source_value_id) {
+  bool value = false;
+  if (loom_amdgpu_source_value_analysis_cached_bit(
+          analysis, source_value_id,
+          LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_NATIVE_I1_MASK, &value)) {
+    return value;
+  }
+  value = loom_amdgpu_source_value_is_native_i1_mask(
+      module, fact_table, view_regions, source_value_id);
+  loom_amdgpu_source_value_analysis_record_bit(
+      analysis, source_value_id,
+      LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_NATIVE_I1_MASK, value);
+  return value;
+}
+
+static bool loom_amdgpu_analyzed_source_value_is_durable_i1_bool(
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    const loom_view_region_table_t* view_regions,
+    loom_amdgpu_source_value_analysis_t* analysis,
+    loom_value_id_t source_value_id) {
+  bool value = false;
+  if (loom_amdgpu_source_value_analysis_cached_bit(
+          analysis, source_value_id,
+          LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_DURABLE_I1_BOOL, &value)) {
+    return value;
+  }
+  value = loom_amdgpu_source_value_is_durable_i1_bool(
+      module, fact_table, view_regions, source_value_id);
+  loom_amdgpu_source_value_analysis_record_bit(
+      analysis, source_value_id,
+      LOOM_AMDGPU_SOURCE_VALUE_ANALYSIS_DURABLE_I1_BOOL, value);
+  return value;
+}
+
 iree_status_t loom_amdgpu_context_value_prefers_vgpr(
     loom_low_lower_context_t* context, loom_value_id_t source_value_id,
     bool* out_prefers_vgpr) {
   const loom_view_region_table_t* view_regions = NULL;
   IREE_RETURN_IF_ERROR(
       loom_low_lower_context_view_regions(context, &view_regions));
-  *out_prefers_vgpr = loom_amdgpu_source_value_prefers_vgpr(
+  loom_amdgpu_source_value_analysis_t* analysis = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_amdgpu_source_value_analysis_for_context(context, &analysis));
+  *out_prefers_vgpr = loom_amdgpu_analyzed_source_value_prefers_vgpr(
       loom_low_lower_context_module(context),
-      loom_low_lower_context_fact_table(context), view_regions,
+      loom_low_lower_context_fact_table(context), view_regions, analysis,
       source_value_id);
   return iree_ok_status();
 }
@@ -2339,9 +2536,12 @@ iree_status_t loom_amdgpu_context_value_is_native_i1_mask(
   const loom_view_region_table_t* view_regions = NULL;
   IREE_RETURN_IF_ERROR(
       loom_low_lower_context_view_regions(context, &view_regions));
-  *out_is_native_mask = loom_amdgpu_source_value_is_native_i1_mask(
+  loom_amdgpu_source_value_analysis_t* analysis = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_amdgpu_source_value_analysis_for_context(context, &analysis));
+  *out_is_native_mask = loom_amdgpu_analyzed_source_value_is_native_i1_mask(
       loom_low_lower_context_module(context),
-      loom_low_lower_context_fact_table(context), view_regions,
+      loom_low_lower_context_fact_table(context), view_regions, analysis,
       source_value_id);
   return iree_ok_status();
 }
@@ -2349,6 +2549,7 @@ iree_status_t loom_amdgpu_context_value_is_native_i1_mask(
 static bool loom_amdgpu_source_scalar_value_register_shape(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
     const loom_view_region_table_t* view_regions,
+    loom_amdgpu_source_value_analysis_t* analysis,
     loom_value_id_t source_value_id, loom_type_t source_type,
     loom_amdgpu_register_shape_t* out_shape) {
   const loom_amdgpu_scalar_value_register_mapping_t* mapping =
@@ -2362,25 +2563,26 @@ static bool loom_amdgpu_source_scalar_value_register_shape(
     case LOOM_AMDGPU_SCALAR_VALUE_REGISTER_POLICY_FIXED:
       return true;
     case LOOM_AMDGPU_SCALAR_VALUE_REGISTER_POLICY_I1:
-      if (loom_amdgpu_source_value_is_native_i1_mask(
-              module, fact_table, view_regions, source_value_id)) {
+      if (loom_amdgpu_analyzed_source_value_is_native_i1_mask(
+              module, fact_table, view_regions, analysis, source_value_id)) {
         *out_shape =
             loom_amdgpu_register_shape(LOOM_AMDGPU_REG_CLASS_ID_SGPR, 2);
-      } else if (loom_amdgpu_source_value_is_durable_i1_bool(
-                     module, fact_table, view_regions, source_value_id)) {
+      } else if (loom_amdgpu_analyzed_source_value_is_durable_i1_bool(
+                     module, fact_table, view_regions, analysis,
+                     source_value_id)) {
         *out_shape =
             loom_amdgpu_register_shape(LOOM_AMDGPU_REG_CLASS_ID_SGPR, 1);
       }
       return true;
     case LOOM_AMDGPU_SCALAR_VALUE_REGISTER_POLICY_PREFERRED_BANK:
-      if (loom_amdgpu_source_value_prefers_vgpr(
-              module, fact_table, view_regions, source_value_id)) {
+      if (loom_amdgpu_analyzed_source_value_prefers_vgpr(
+              module, fact_table, view_regions, analysis, source_value_id)) {
         out_shape->class_id = LOOM_AMDGPU_REG_CLASS_ID_VGPR;
       }
       return true;
     case LOOM_AMDGPU_SCALAR_VALUE_REGISTER_POLICY_OFFSET_WIDTH:
-      if (loom_amdgpu_source_value_prefers_vgpr(
-              module, fact_table, view_regions, source_value_id)) {
+      if (loom_amdgpu_analyzed_source_value_prefers_vgpr(
+              module, fact_table, view_regions, analysis, source_value_id)) {
         out_shape->class_id = LOOM_AMDGPU_REG_CLASS_ID_VGPR;
       }
       if (loom_amdgpu_source_address_value_needs_64bit(
@@ -2397,6 +2599,7 @@ static bool loom_amdgpu_source_scalar_value_register_shape(
 static bool loom_amdgpu_source_vector_value_register_shape(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
     const loom_view_region_table_t* view_regions,
+    loom_amdgpu_source_value_analysis_t* analysis,
     loom_value_id_t source_value_id, loom_type_t source_type,
     loom_amdgpu_register_shape_t* out_shape) {
   loom_amdgpu_vector_storage_t vector_storage = {0};
@@ -2411,8 +2614,8 @@ static bool loom_amdgpu_source_vector_value_register_shape(
     case LOOM_AMDGPU_VECTOR_STORAGE_KIND_FULL_32BIT:
     case LOOM_AMDGPU_VECTOR_STORAGE_KIND_FULL_64BIT:
       *out_shape = loom_amdgpu_register_shape(
-          loom_amdgpu_source_value_prefers_vgpr(module, fact_table,
-                                                view_regions, source_value_id)
+          loom_amdgpu_analyzed_source_value_prefers_vgpr(
+              module, fact_table, view_regions, analysis, source_value_id)
               ? LOOM_AMDGPU_REG_CLASS_ID_VGPR
               : LOOM_AMDGPU_REG_CLASS_ID_SGPR,
           vector_storage.register_count);
@@ -2459,14 +2662,15 @@ static bool loom_amdgpu_source_value_register_shape_needs_analysis(
 static bool loom_amdgpu_source_value_register_shape(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
     const loom_view_region_table_t* view_regions,
+    loom_amdgpu_source_value_analysis_t* analysis,
     loom_value_id_t source_value_id, loom_type_t source_type,
     loom_amdgpu_register_shape_t* out_shape) {
   return loom_amdgpu_source_scalar_value_register_shape(
-             module, fact_table, view_regions, source_value_id, source_type,
-             out_shape) ||
+             module, fact_table, view_regions, analysis, source_value_id,
+             source_type, out_shape) ||
          loom_amdgpu_source_vector_value_register_shape(
-             module, fact_table, view_regions, source_value_id, source_type,
-             out_shape);
+             module, fact_table, view_regions, analysis, source_value_id,
+             source_type, out_shape);
 }
 
 iree_status_t loom_amdgpu_map_type(void* user_data,
@@ -2502,15 +2706,25 @@ iree_status_t loom_amdgpu_map_value(void* user_data,
                                     loom_type_t* out_low_type) {
   (void)user_data;
   const loom_view_region_table_t* view_regions = NULL;
+  loom_amdgpu_source_value_analysis_t* analysis = NULL;
   if (loom_amdgpu_source_value_register_shape_needs_analysis(source_type)) {
     IREE_RETURN_IF_ERROR(
         loom_low_lower_context_view_regions(context, &view_regions));
+    IREE_RETURN_IF_ERROR(
+        loom_amdgpu_source_value_analysis_for_context(context, &analysis));
   }
   loom_amdgpu_register_shape_t shape = {0};
-  if (loom_amdgpu_source_value_register_shape(
-          loom_low_lower_context_module(context),
-          loom_low_lower_context_fact_table(context), view_regions,
-          source_value_id, source_type, &shape)) {
+  bool has_shape = false;
+  if (!loom_amdgpu_source_value_analysis_cached_register_shape(
+          analysis, source_value_id, &has_shape, &shape)) {
+    has_shape = loom_amdgpu_source_value_register_shape(
+        loom_low_lower_context_module(context),
+        loom_low_lower_context_fact_table(context), view_regions, analysis,
+        source_value_id, source_type, &shape);
+    loom_amdgpu_source_value_analysis_record_register_shape(
+        analysis, source_value_id, &shape, has_shape);
+  }
+  if (has_shape) {
     return loom_amdgpu_make_register_type(context, shape.class_id,
                                           shape.unit_count, out_low_type);
   }
@@ -2547,7 +2761,8 @@ iree_status_t loom_amdgpu_map_contract_value(
   loom_amdgpu_register_shape_t shape = {0};
   if (loom_amdgpu_source_value_register_shape(
           environment->module, environment->fact_table,
-          environment->view_regions, source_value_id, source_type, &shape)) {
+          environment->view_regions, /*analysis=*/NULL, source_value_id,
+          source_type, &shape)) {
     return loom_amdgpu_map_contract_register(
         environment, shape.class_id, shape.unit_count, out_mapped_value);
   }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global.loom-test
@@ -810,6 +810,38 @@ low.func.def target(@target) abi(hal_kernel) @descriptor_dynamic_base_static_ext
 // ====
 
 amdgpu.target<gfx1100> @target
+func.def target(@target) @descriptor_dynamic_projected_base_static_extent_load_i32(%input: buffer, %base_i32: i32) -> (i32) {
+  %base0 = index.cast %base_i32 : i32 to offset
+  %base = index.assume %base0 [range(%base0, 0, 4092), mul(%base0, 4)] : offset
+  %input_descriptor = buffer.assume.memory_space<descriptor> %input : buffer
+  %input_view = buffer.view %input_descriptor[%base] : buffer -> view<8xi32, #dense>
+  %input_subview = view.subview %input_view[1] : view<8xi32, #dense> -> view<4xi32, #dense>
+  %input_refined = view.refine %input_subview : view<4xi32, #dense> -> view<4xi32, #dense>
+  %loaded = view.load %input_refined[2] : view<4xi32, #dense> -> i32
+  func.return %loaded : i32
+}
+
+// ----
+low.func.def target(@target) abi(hal_kernel) @descriptor_dynamic_projected_base_static_extent_load_i32(%base: reg<amdgpu.sgpr>) -> (reg<amdgpu.vgpr>) asm<amdgpu.rdna3.core> {
+  %input_refined = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %13 = v_mov_b32 0
+  %14 = s_mov_b32 16
+  %15 = s_add_u32 %base, %14
+  %16 = s_add_u32_rhs_inline %15, 4
+  %19 = slice %input_refined[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %20 = slice %input_refined[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %21 = s_mov_b32 65535
+  %22 = s_and_b32 %20, %21
+  %23 = concat(%19, %22) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %24 = s_mov_b32 822243328
+  %25 = concat(%23, %16, %24) : (reg<amdgpu.sgpr x2>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x4>
+  %loaded = buffer_load_dword %25, %13, %base {offset = 12}
+  return %loaded
+}
+
+// ====
+
+amdgpu.target<gfx1100> @target
 func.def target(@target) @descriptor_dynamic_extent_load_f32(%input: buffer, %element_count_i32: i32, %element_i32: i32) -> (f32) {
   %base = index.constant 0 : offset
   %input_descriptor = buffer.assume.memory_space<descriptor> %input : buffer

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_ml_attention.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_ml_attention.loom-test
@@ -134,26 +134,25 @@ func.def target(@target) @paged_kv_cache_block_load(%page_table: buffer, %page_p
 low.func.def target(@target) abi(hal_kernel) @paged_kv_cache_block_load(%sequence: reg<amdgpu.sgpr>, %block: reg<amdgpu.sgpr>, %lane: reg<amdgpu.sgpr>) -> (reg<amdgpu.vgpr>, reg<amdgpu.vgpr x2>) asm<amdgpu.rdna3.core> {
   %page_entry_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
   %kv_view = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
-  %page_entry_byte_stride = s_mov_b32 4
-  %page_table_row_byte_stride = s_mov_b32 512
-  %lane_byte_stride = s_mov_b32 8
-  %row_base = s_mul_i32 %sequence, %page_table_row_byte_stride
-  %block_entry_offset = s_mul_i32 %block, %page_entry_byte_stride
-  %page_entry_offset = s_add_u32 %row_base, %block_entry_offset
   %42 = v_mov_b32 0
-  %43 = slice %page_entry_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
-  %44 = slice %page_entry_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
-  %45 = s_mov_b32 0
-  %46 = s_add_u32 %43, %page_entry_offset
-  %47 = s_addc_u32 %44, %45
-  %48 = concat(%46, %47) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %page = global_load_b32_saddr %42, %48
-  %50 = v_mov_b32 4096
-  %page_base = v_mul_lo_u32 %page, %50
-  %lane_offset = s_mul_i32 %lane, %lane_byte_stride
-  %53 = v_mov_b32_copy %lane_offset
-  %kv_offset = v_add_u32 %page_base, %53
-  %key_values = global_load_b64_saddr %kv_offset, %kv_view
+  %43 = s_lshl_b32_rhs_inline %sequence, 9
+  %44 = s_lshl_b32_rhs_inline %block, 2
+  %45 = s_add_u32 %43, %44
+  %46 = slice %page_entry_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %47 = slice %page_entry_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %48 = s_mov_b32 0
+  %49 = s_add_u32 %46, %45
+  %50 = s_addc_u32 %47, %48
+  %51 = concat(%49, %50) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %page = global_load_b32_saddr %42, %51
+  %58 = v_lshlrev_b32_src0_inline %page, 12
+  %59 = s_lshl_b32_rhs_inline %lane, 3
+  %60 = slice %kv_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %61 = slice %kv_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %63 = s_add_u32 %60, %59
+  %64 = s_addc_u32 %61, %48
+  %65 = concat(%63, %64) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %key_values = global_load_b64_saddr %58, %65
   return %page, %key_values
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_packed_payload_offsets.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_packed_payload_offsets.loom-test
@@ -21,21 +21,17 @@ func.def target(@target) @packed4_payload_word_offset(%weights: buffer, %block0:
 // ----
 low.func.def target(@target) abi(hal_kernel) @packed4_payload_word_offset(%block: reg<amdgpu.sgpr>, %word: reg<amdgpu.sgpr>) -> (reg<amdgpu.vgpr>) asm<amdgpu.rdna3.core> {
   %word_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
-  %block_byte_stride = s_mov_b32 18
-  %payload_header_offset = s_mov_b32 2
-  %word_byte_stride = s_mov_b32 4
-  %block_base = s_mul_i32 %block, %block_byte_stride
-  %payload_base = s_add_u32 %block_base, %payload_header_offset
-  %word_byte_offset = s_mul_i32 %word, %word_byte_stride
-  %byte_offset = s_add_u32 %payload_base, %word_byte_offset
   %27 = v_mov_b32 0
-  %28 = slice %word_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
-  %29 = slice %word_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
-  %30 = s_mov_b32 0
-  %31 = s_add_u32 %28, %byte_offset
-  %32 = s_addc_u32 %29, %30
-  %33 = concat(%31, %32) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %packed_word = global_load_b32_saddr %27, %33
+  %28 = s_mul_i32_rhs_inline %block, 18
+  %29 = s_lshl_b32_rhs_inline %word, 2
+  %30 = s_add_u32 %28, %29
+  %31 = slice %word_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %32 = slice %word_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %33 = s_mov_b32 0
+  %34 = s_add_u32 %31, %30
+  %35 = s_addc_u32 %32, %33
+  %36 = concat(%34, %35) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %packed_word = global_load_b32_saddr %27, %36 {offset = 2}
   return %packed_word
 }
 
@@ -65,13 +61,6 @@ func.def target(@target) @packed5_split_payload_offsets(%weights: buffer, %block
 // ----
 low.func.def target(@target) abi(hal_kernel) @packed5_split_payload_offsets(%block: reg<amdgpu.sgpr>, %word: reg<amdgpu.sgpr>) -> (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) asm<amdgpu.rdna3.core> {
   %low_bits_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
-  %block_byte_stride = s_mov_b32 22
-  %low_bits_header_offset = s_mov_b32 6
-  %word_byte_stride = s_mov_b32 4
-  %block_base = s_mul_i32 %block, %block_byte_stride
-  %low_bits_base = s_add_u32 %block_base, %low_bits_header_offset
-  %low_word_byte_offset = s_mul_i32 %word, %word_byte_stride
-  %low_bits_byte_offset = s_add_u32 %low_bits_base, %low_word_byte_offset
   %35 = v_mov_b32 0
   %36 = s_mul_i32_rhs_inline %block, 22
   %37 = slice %low_bits_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
@@ -81,10 +70,12 @@ low.func.def target(@target) abi(hal_kernel) @packed5_split_payload_offsets(%blo
   %41 = s_addc_u32 %38, %39
   %42 = concat(%40, %41) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
   %side_bits_word = global_load_b32_saddr %35, %42 {offset = 2}
-  %48 = s_add_u32 %37, %low_bits_byte_offset
-  %49 = s_addc_u32 %38, %39
-  %50 = concat(%48, %49) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %low_bits_word = global_load_b32_saddr %35, %50
+  %46 = s_lshl_b32_rhs_inline %word, 2
+  %47 = s_add_u32 %36, %46
+  %51 = s_add_u32 %37, %47
+  %52 = s_addc_u32 %38, %39
+  %53 = concat(%51, %52) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %low_bits_word = global_load_b32_saddr %35, %53 {offset = 6}
   return %side_bits_word, %low_bits_word
 }
 
@@ -125,35 +116,29 @@ func.def target(@target) @packed6_split_payload_offsets(%weights: buffer, %block
 // ----
 low.func.def target(@target) abi(hal_kernel) @packed6_split_payload_offsets(%block: reg<amdgpu.sgpr>, %low_word: reg<amdgpu.sgpr>, %high_word: reg<amdgpu.sgpr>, %scale: reg<amdgpu.sgpr>) -> (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) asm<amdgpu.rdna3.core> {
   %scale_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
-  %block_byte_stride = s_mov_b32 210
-  %high_bits_header_offset = s_mov_b32 128
-  %scale_header_offset = s_mov_b32 192
-  %word_byte_stride = s_mov_b32 4
-  %half_byte_stride = s_mov_b32 2
-  %block_base = s_mul_i32 %block, %block_byte_stride
-  %high_bits_base = s_add_u32 %block_base, %high_bits_header_offset
-  %scale_base = s_add_u32 %block_base, %scale_header_offset
-  %low_word_byte_offset = s_mul_i32 %low_word, %word_byte_stride
-  %high_word_byte_offset = s_mul_i32 %high_word, %word_byte_stride
-  %scale_element_byte_offset = s_mul_i32 %scale, %half_byte_stride
-  %low_bits_byte_offset = s_add_u32 %block_base, %low_word_byte_offset
-  %high_bits_byte_offset = s_add_u32 %high_bits_base, %high_word_byte_offset
-  %scale_byte_offset = s_add_u32 %scale_base, %scale_element_byte_offset
   %57 = v_mov_b32 0
-  %58 = slice %scale_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
-  %59 = slice %scale_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
-  %60 = s_mov_b32 0
-  %61 = s_add_u32 %58, %low_bits_byte_offset
-  %62 = s_addc_u32 %59, %60
-  %63 = concat(%61, %62) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %low_bits_word = global_load_b32_saddr %57, %63
-  %69 = s_add_u32 %58, %high_bits_byte_offset
-  %70 = s_addc_u32 %59, %60
-  %71 = concat(%69, %70) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %high_bits_word = global_load_b32_saddr %57, %71
-  %77 = s_add_u32 %58, %scale_byte_offset
-  %78 = s_addc_u32 %59, %60
+  %58 = s_mov_b32 210
+  %59 = s_mul_i32 %block, %58
+  %60 = s_lshl_b32_rhs_inline %low_word, 2
+  %61 = s_add_u32 %59, %60
+  %62 = slice %scale_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %63 = slice %scale_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %64 = s_mov_b32 0
+  %65 = s_add_u32 %62, %61
+  %66 = s_addc_u32 %63, %64
+  %67 = concat(%65, %66) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %low_bits_word = global_load_b32_saddr %57, %67
+  %72 = s_lshl_b32_rhs_inline %high_word, 2
+  %73 = s_add_u32 %59, %72
+  %77 = s_add_u32 %62, %73
+  %78 = s_addc_u32 %63, %64
   %79 = concat(%77, %78) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %scale_value = global_load_u16_saddr %57, %79
+  %high_bits_word = global_load_b32_saddr %57, %79 {offset = 128}
+  %84 = s_lshl_b32_rhs_inline %scale, 1
+  %85 = s_add_u32 %59, %84
+  %89 = s_add_u32 %62, %85
+  %90 = s_addc_u32 %63, %64
+  %91 = concat(%89, %90) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %scale_value = global_load_u16_saddr %57, %91 {offset = 192}
   return %low_bits_word, %high_bits_word, %scale_value
 }

--- a/loom/src/loom/test/corpus/source_low/memory_global.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_global.loom-test
@@ -231,6 +231,19 @@ func.def @descriptor_dynamic_base_static_extent_load_i32(%input: buffer, %base_i
 
 // ====
 
+func.def @descriptor_dynamic_projected_base_static_extent_load_i32(%input: buffer, %base_i32: i32) -> (i32) {
+  %base0 = index.cast %base_i32 : i32 to offset
+  %base = index.assume %base0 [range(%base0, 0, 4092), mul(%base0, 4)] : offset
+  %input_descriptor = buffer.assume.memory_space<descriptor> %input : buffer
+  %input_view = buffer.view %input_descriptor[%base] : buffer -> view<8xi32, #dense>
+  %input_subview = view.subview %input_view[1] : view<8xi32, #dense> -> view<4xi32, #dense>
+  %input_refined = view.refine %input_subview : view<4xi32, #dense> -> view<4xi32, #dense>
+  %loaded = view.load %input_refined[2] : view<4xi32, #dense> -> i32
+  func.return %loaded : i32
+}
+
+// ====
+
 func.def @descriptor_dynamic_extent_load_f32(%input: buffer, %element_count_i32: i32, %element_i32: i32) -> (f32) {
   %base = index.constant 0 : offset
   %input_descriptor = buffer.assume.memory_space<descriptor> %input : buffer

--- a/loom/src/loom/transforms/scf/scf_unroll.c
+++ b/loom/src/loom/transforms/scf/scf_unroll.c
@@ -1076,6 +1076,13 @@ typedef struct loom_scf_unroll_body_op_list_t {
   uint32_t count;
 } loom_scf_unroll_body_op_list_t;
 
+static bool loom_scf_unroll_body_op_has_nested_control_flow(
+    const loom_scf_unroll_context_t* context, const loom_op_t* op) {
+  const loom_op_vtable_t* vtable = loom_op_vtable(context->module, op);
+  return op->region_count != 0 || op->successor_count != 0 ||
+         (vtable && vtable->region_count != 0);
+}
+
 typedef uint8_t loom_scf_unroll_effect_flags_t;
 
 #define LOOM_SCF_UNROLL_EFFECT_INDEX_INVALID UINT32_MAX
@@ -1099,11 +1106,22 @@ enum loom_scf_unroll_effect_flag_bits_e {
 
 typedef struct loom_scf_unroll_payload_readiness_t {
   const loom_scf_unroll_context_t* context;
+  const loom_region_t* body_region;
   const loom_block_t* body_block;
   const loom_op_t* source_op;
   const loom_ir_remap_t* remap;
   bool ready;
 } loom_scf_unroll_payload_readiness_t;
+
+static bool loom_scf_unroll_op_is_inside_region(const loom_op_t* op,
+                                                const loom_region_t* region) {
+  for (const loom_op_t* current = op; current; current = current->parent_op) {
+    const loom_region_t* parent_region =
+        current->parent_block ? current->parent_block->parent_region : NULL;
+    if (parent_region == region) return true;
+  }
+  return false;
+}
 
 static bool loom_scf_unroll_value_ref_is_ready(
     const loom_scf_unroll_payload_readiness_t* query,
@@ -1114,12 +1132,35 @@ static bool loom_scf_unroll_value_ref_is_ready(
     if (loom_value_def_block(value) != query->body_block) return true;
   } else {
     const loom_op_t* def_op = loom_value_def_op(value);
-    if (!def_op || def_op->parent_block != query->body_block) return true;
+    if (!def_op) return true;
+    if (!def_op->parent_block) {
+      loom_value_id_t mapped_value = LOOM_VALUE_ID_INVALID;
+      return loom_ir_remap_try_lookup_value(query->remap, value_id,
+                                            &mapped_value);
+    }
+    if (!loom_scf_unroll_op_is_inside_region(def_op, query->body_region)) {
+      return true;
+    }
     if (def_op == query->source_op) return true;
   }
 
   loom_value_id_t mapped_value = LOOM_VALUE_ID_INVALID;
-  return loom_ir_remap_try_lookup_value(query->remap, value_id, &mapped_value);
+  return loom_ir_remap_try_lookup_value(query->remap, value_id,
+                                        &mapped_value) &&
+         mapped_value != value_id;
+}
+
+static bool loom_scf_unroll_yielded_value_can_remain_unmapped(
+    const loom_scf_unroll_context_t* context, const loom_region_t* body_region,
+    const loom_block_t* body_block, loom_value_id_t value_id) {
+  const loom_value_t* value = loom_module_value(context->module, value_id);
+  if (loom_value_is_block_arg(value)) {
+    return loom_value_def_block(value) != body_block;
+  }
+  const loom_op_t* def_op = loom_value_def_op(value);
+  if (!def_op) return false;
+  if (!def_op->parent_block) return false;
+  return !loom_scf_unroll_op_is_inside_region(def_op, body_region);
 }
 
 static iree_status_t loom_scf_unroll_check_type_ref_is_ready(
@@ -1236,7 +1277,7 @@ static iree_status_t loom_scf_unroll_collect_interleavable_body_ops(
   for (const loom_op_t* body_op = body_block->first_op;
        body_op && body_op != yield; body_op = body_op->next_op) {
     if (iree_any_bit_set(body_op->flags, LOOM_OP_FLAG_DEAD)) continue;
-    if (body_op->region_count != 0 || body_op->successor_count != 0) {
+    if (loom_scf_unroll_body_op_has_nested_control_flow(context, body_op)) {
       return loom_scf_unroll_emit_policy_error(
           context, op, IREE_SV("schedule"),
           LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
@@ -1458,15 +1499,6 @@ static iree_status_t loom_scf_unroll_collect_effect_flags(
   }
   *out_effect_flags = effect_flags;
   return iree_ok_status();
-}
-
-static bool loom_scf_unroll_has_effectful_body_op(
-    const loom_scf_unroll_body_op_list_t* body_ops,
-    const loom_scf_unroll_effect_flags_t* effect_flags) {
-  for (uint32_t i = 0; i < body_ops->count; ++i) {
-    if (effect_flags[i] != 0) return true;
-  }
-  return false;
 }
 
 static iree_status_t loom_scf_unroll_describe_movement_requests(
@@ -1759,11 +1791,13 @@ static void loom_scf_unroll_release_effect_dependencies(
 }
 
 static iree_status_t loom_scf_unroll_body_op_payload_is_ready(
-    const loom_scf_unroll_context_t* context, const loom_block_t* body_block,
-    const loom_op_t* source_op, const loom_ir_remap_t* remap, bool* out_ready) {
+    const loom_scf_unroll_context_t* context, const loom_region_t* body_region,
+    const loom_block_t* body_block, const loom_op_t* source_op,
+    const loom_ir_remap_t* remap, bool* out_ready) {
   *out_ready = false;
   loom_scf_unroll_payload_readiness_t query = {
       .context = context,
+      .body_region = body_region,
       .body_block = body_block,
       .source_op = source_op,
       .remap = remap,
@@ -1795,6 +1829,27 @@ static iree_status_t loom_scf_unroll_body_op_payload_is_ready(
   return iree_ok_status();
 }
 
+static bool loom_scf_unroll_yield_payload_is_ready(
+    const loom_scf_unroll_context_t* context, const loom_region_t* body_region,
+    const loom_block_t* body_block, const loom_op_t* yield,
+    const loom_ir_remap_t* remap) {
+  loom_scf_unroll_payload_readiness_t query = {
+      .context = context,
+      .body_region = body_region,
+      .body_block = body_block,
+      .source_op = yield,
+      .remap = remap,
+      .ready = true,
+  };
+  loom_value_slice_t yielded_values = loom_scf_yield_values(yield);
+  for (uint16_t i = 0; i < yielded_values.count; ++i) {
+    if (!loom_scf_unroll_value_ref_is_ready(&query, yielded_values.values[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 static iree_status_t loom_scf_unroll_rename_cloned_op_results(
     loom_scf_unroll_context_t* context, const loom_op_t* source_op,
     loom_op_t* cloned_op, uint32_t ordinal) {
@@ -1824,7 +1879,8 @@ static iree_status_t loom_scf_unroll_rename_cloned_op_results(
 }
 
 static iree_status_t loom_scf_unroll_mark_iteration_complete(
-    loom_scf_unroll_context_t* context, const loom_block_t* body_block,
+    loom_scf_unroll_context_t* context, loom_op_t* op,
+    loom_region_t* body_region, const loom_block_t* body_block,
     const loom_op_t* yield, uint32_t ordinal, uint32_t trip_count,
     uint16_t carried_count, loom_ir_remap_t* remaps,
     iree_arena_allocator_t* scratch_arena,
@@ -1840,8 +1896,22 @@ static iree_status_t loom_scf_unroll_mark_iteration_complete(
                                                    (void**)&resolved_values));
   }
   for (uint16_t i = 0; i < carried_count; ++i) {
-    IREE_RETURN_IF_ERROR(loom_ir_remap_resolve_value(
-        &remaps[ordinal], yielded_values.values[i], &resolved_values[i]));
+    bool can_remain_unmapped =
+        loom_scf_unroll_yielded_value_can_remain_unmapped(
+            context, body_region, body_block, yielded_values.values[i]);
+    if (!loom_ir_remap_try_lookup_value(
+            &remaps[ordinal], yielded_values.values[i], &resolved_values[i]) ||
+        (!can_remain_unmapped &&
+         resolved_values[i] == yielded_values.values[i])) {
+      if (can_remain_unmapped) {
+        resolved_values[i] = yielded_values.values[i];
+      } else {
+        return loom_scf_unroll_emit_policy_error(
+            context, op, IREE_SV("schedule"),
+            LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
+            IREE_SV("acyclic loop-carried dependencies"));
+      }
+    }
   }
   if (ordinal + 1 < trip_count) {
     for (uint16_t i = 0; i < carried_count; ++i) {
@@ -1860,9 +1930,11 @@ static iree_status_t loom_scf_unroll_emit_interleaved_tile(
     const loom_value_id_t* initial_carried_values, uint16_t carried_count,
     iree_arena_allocator_t* scratch_arena,
     loom_value_id_t* final_carried_values) {
+  loom_region_t* body_region = loom_scf_for_body(op);
   loom_scf_unroll_body_op_list_t body_ops = {0};
   IREE_RETURN_IF_ERROR(loom_scf_unroll_collect_interleavable_body_ops(
       context, op, body_block, yield, scratch_arena, &body_ops));
+  if (loom_pass_has_error_diagnostics(context->pass)) return iree_ok_status();
 
   const uint32_t unroll_count = trip_count->count;
   loom_scf_unroll_effect_flags_t* effect_flags = NULL;
@@ -1874,14 +1946,6 @@ static iree_status_t loom_scf_unroll_emit_interleaved_tile(
              (iree_host_size_t)carried_count * sizeof(*final_carried_values));
     }
     return iree_ok_status();
-  }
-  if (carried_count > 0 &&
-      loom_scf_unroll_has_effectful_body_op(&body_ops, effect_flags)) {
-    return loom_scf_unroll_emit_policy_error(
-        context, op, IREE_SV("schedule"),
-        LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
-        IREE_SV("effect-free body operations when interleaving loop-carried "
-                "values"));
   }
 
   loom_ir_remap_t* remaps = NULL;
@@ -1948,9 +2012,16 @@ static iree_status_t loom_scf_unroll_emit_interleaved_tile(
 
   if (body_ops.count == 0) {
     for (uint32_t ordinal = 0; ordinal < unroll_count; ++ordinal) {
+      if (!loom_scf_unroll_yield_payload_is_ready(
+              context, body_region, body_block, yield, &remaps[ordinal])) {
+        continue;
+      }
       IREE_RETURN_IF_ERROR(loom_scf_unroll_mark_iteration_complete(
-          context, body_block, yield, ordinal, unroll_count, carried_count,
-          remaps, scratch_arena, final_carried_values));
+          context, op, body_region, body_block, yield, ordinal, unroll_count,
+          carried_count, remaps, scratch_arena, final_carried_values));
+      if (loom_pass_has_error_diagnostics(context->pass))
+        return iree_ok_status();
+      completed_iterations[ordinal] = true;
     }
   }
 
@@ -1970,7 +2041,8 @@ static iree_status_t loom_scf_unroll_emit_interleaved_tile(
         }
         bool payload_ready = false;
         IREE_RETURN_IF_ERROR(loom_scf_unroll_body_op_payload_is_ready(
-            context, body_block, source_op, &remaps[ordinal], &payload_ready));
+            context, body_region, body_block, source_op, &remaps[ordinal],
+            &payload_ready));
         if (!payload_ready) {
           continue;
         }
@@ -1987,10 +2059,16 @@ static iree_status_t loom_scf_unroll_emit_interleaved_tile(
         --remaining;
         made_progress = true;
         if (cloned_counts[ordinal] == body_ops.count &&
-            !completed_iterations[ordinal]) {
+            !completed_iterations[ordinal] &&
+            loom_scf_unroll_yield_payload_is_ready(
+                context, body_region, body_block, yield, &remaps[ordinal])) {
           IREE_RETURN_IF_ERROR(loom_scf_unroll_mark_iteration_complete(
-              context, body_block, yield, ordinal, unroll_count, carried_count,
-              remaps, scratch_arena, final_carried_values));
+              context, op, body_region, body_block, yield, ordinal,
+              unroll_count, carried_count, remaps, scratch_arena,
+              final_carried_values));
+          if (loom_pass_has_error_diagnostics(context->pass)) {
+            return iree_ok_status();
+          }
           completed_iterations[ordinal] = true;
         }
       }
@@ -2001,6 +2079,13 @@ static iree_status_t loom_scf_unroll_emit_interleaved_tile(
           LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
           IREE_SV("acyclic body-local SSA dependencies"));
     }
+  }
+  for (uint32_t ordinal = 0; ordinal < unroll_count; ++ordinal) {
+    if (completed_iterations[ordinal]) continue;
+    return loom_scf_unroll_emit_policy_error(
+        context, op, IREE_SV("schedule"),
+        LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
+        IREE_SV("acyclic loop-carried dependencies"));
   }
 
   return iree_ok_status();
@@ -2032,8 +2117,16 @@ static iree_status_t loom_scf_unroll_full_unroll_interleaved_with_arena(
       carried_count, scratch_arena, final_carried_values);
   loom_builder_restore(&context->rewriter->builder, saved_ip);
   IREE_RETURN_IF_ERROR(status);
+  if (loom_pass_has_error_diagnostics(context->pass)) return iree_ok_status();
 
   if (carried_count > 0) {
+    for (uint16_t i = 0; i < carried_count; ++i) {
+      if (final_carried_values[i] < context->module->values.count) continue;
+      return loom_scf_unroll_emit_policy_error(
+          context, op, IREE_SV("schedule"),
+          LOOM_SCF_FOR_UNROLL_SCHEDULE_INTERLEAVED,
+          IREE_SV("acyclic loop-carried dependencies"));
+    }
     IREE_RETURN_IF_ERROR(loom_rewriter_preserve_result_names_on_new_values(
         context->rewriter, op, final_carried_values, carried_count,
         value_checkpoint));

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -352,6 +352,51 @@ func.def @interleaved_dynamic_index_vector_stores_commute(%buffer: buffer, %row:
 
 // ====
 
+func.def @interleaved_carried_disjoint_vector_stores_commute(%buffer: buffer, %input: i32) -> (i32) {
+  %zero = index.constant 0 : offset
+  %value0 = scalar.constant 1 : i32
+  %value1 = scalar.constant 2 : i32
+  %vec0 = vector.splat %value0 : vector<4xi32>
+  %vec1 = vector.splat %value1 : vector<4xi32>
+  %layout = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%zero] : buffer -> view<8xi32, %layout>
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  %result = scf.for %i = [%start to %end step %step](%acc = %input : i32) -> (i32) unroll schedule(interleaved) {
+    %next = test.addi %acc, %input : i32
+    vector.store %vec0, %view[0] : vector<4xi32>, view<8xi32, %layout>
+    vector.store %vec1, %view[4] : vector<4xi32>, view<8xi32, %layout>
+    scf.yield %next : i32
+  }
+  func.return %result : i32
+}
+
+// ----
+func.def @interleaved_carried_disjoint_vector_stores_commute(%buffer: buffer, %input: i32) -> (i32) {
+  %zero = index.constant 0 : offset
+  %value0 = scalar.constant 1 : i32
+  %value1 = scalar.constant 2 : i32
+  %vec0 = vector.splat %value0 : vector<4xi32>
+  %vec1 = vector.splat %value1 : vector<4xi32>
+  %layout = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%zero] : buffer -> view<8xi32, %layout>
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  %next = test.addi %input, %input : i32
+  vector.store %vec0, %view[0] : vector<4xi32>, view<8xi32, %layout>
+  vector.store %vec0, %view[0] : vector<4xi32>, view<8xi32, %layout>
+  vector.store %vec1, %view[4] : vector<4xi32>, view<8xi32, %layout>
+  vector.store %vec1, %view[4] : vector<4xi32>, view<8xi32, %layout>
+  %next_1 = test.addi %next, %input : i32
+  func.return %next_1 : i32
+}
+
+// ====
+
 func.def @interleaved_overlapping_vector_stores_preserve_order(%buffer: buffer) {
   %zero = index.constant 0 : offset
   %value0 = scalar.constant 1 : i32
@@ -978,14 +1023,13 @@ func.def @interleaved_partial_factor_carried_loop(%input: i32) -> (i32) {
 
 // ====
 
-func.def @interleaved_carried_loop_rejects_vector_read(%buffer: buffer, %input: vector<4xi32>) -> (vector<4xi32>) {
+func.def @interleaved_carried_loop_with_vector_read(%buffer: buffer, %input: vector<4xi32>) -> (vector<4xi32>) {
   %zero_offset = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %view = buffer.view %buffer[%zero_offset] : buffer -> view<4xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 3 : index
   %step = index.constant 1 : index
-  // ERROR@+1: STRUCTURE/014 {attr_name="schedule", expected_constraint="effect-free body operations when interleaving loop-carried values"}
   %result = scf.for %i = [%start to %end step %step](%acc = %input : vector<4xi32>) -> (vector<4xi32>) unroll schedule(interleaved) {
     %loaded = vector.load %view[%i] : view<4xi32, %layout> -> vector<4xi32>
     %next = vector.addi %acc, %loaded : vector<4xi32>
@@ -994,19 +1038,55 @@ func.def @interleaved_carried_loop_rejects_vector_read(%buffer: buffer, %input: 
   func.return %result : vector<4xi32>
 }
 
-// ====
-
-func.def @interleaved_carried_loop_rejects_resource_write(%pool: pool<16>, %input: i32) -> (i32) {
+// ----
+func.def @interleaved_carried_loop_with_vector_read(%buffer: buffer, %input: vector<4xi32>) -> (vector<4xi32>) {
+  %zero_offset = index.constant 0 : offset
+  %layout = encoding.layout.dense : encoding<layout>
+  %view = buffer.view %buffer[%zero_offset] : buffer -> view<4xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 3 : index
   %step = index.constant 1 : index
-  // ERROR@+1: STRUCTURE/014 {attr_name="schedule", expected_constraint="effect-free body operations when interleaving loop-carried values"}
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  %i_2 = index.constant 2 : index
+  %loaded = vector.load %view[%i_0] : view<4xi32, %layout> -> vector<4xi32>
+  %loaded_1 = vector.load %view[%i_1] : view<4xi32, %layout> -> vector<4xi32>
+  %loaded_2 = vector.load %view[%i_2] : view<4xi32, %layout> -> vector<4xi32>
+  %next = vector.addi %input, %loaded : vector<4xi32>
+  %next_1 = vector.addi %next, %loaded_1 : vector<4xi32>
+  %next_2 = vector.addi %next_1, %loaded_2 : vector<4xi32>
+  func.return %next_2 : vector<4xi32>
+}
+
+// ====
+
+func.def @interleaved_carried_loop_preserves_ordered_writes(%pool: pool<16>, %input: i32) -> (i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
   %result = scf.for %i = [%start to %end step %step](%acc = %input : i32) -> (i32) unroll schedule(interleaved) {
     %next = test.addi %acc, %acc : i32
     test.write_resource %pool, %next : pool<16>, i32
     scf.yield %next : i32
   }
   func.return %result : i32
+}
+
+// ----
+func.def @interleaved_carried_loop_preserves_ordered_writes(%pool: pool<16>, %input: i32) -> (i32) {
+  %start = index.constant 0 : index
+  %end = index.constant 3 : index
+  %step = index.constant 1 : index
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  %i_2 = index.constant 2 : index
+  %next = test.addi %input, %input : i32
+  test.write_resource %pool, %next : pool<16>, i32
+  %next_1 = test.addi %next, %next : i32
+  test.write_resource %pool, %next_1 : pool<16>, i32
+  %next_2 = test.addi %next_1, %next_1 : i32
+  test.write_resource %pool, %next_2 : pool<16>, i32
+  func.return %next_2 : i32
 }
 
 // ====


### PR DESCRIPTION
This tightens two pieces of Loom’s dynamic-kernel path that authors are starting to rely on heavily: `scf.for schedule(interleaved)` can now handle more realistic memory-carrying loop bodies, and AMDGPU source-to-low lowering has a stronger fact-backed view of source values and memory access plans.

The SCF unroller now reasons about memory effects before deciding whether an interleaved schedule is safe. Independent vector stores may commute even when the loop also carries SSA state, so authors can use interleaved unrolling for small repeated store motifs without manually reshaping the loop body. The same analysis keeps overlapping or induction-dependent vector stores in original iteration order, which preserves the safety boundary for effectful schedules instead of rejecting every carried loop or blindly interleaving writes.

For AMDGPU source lowering, value placement now has a function-local cache for the common source-value questions reached while mapping source IR into low registers: preferred VGPR placement, native i1 mask materialization, durable boolean storage, and final register shape. That avoids repeatedly walking the same source values and use lists through the map-value hot path, and it gives future placement work one compact analysis surface instead of a pile of recomputed recursive helpers.

Source memory planning now consumes view-region analysis when AMDGPU lowering asks for a plan. `buffer.view`, `view.refine`, and statically-offset `view.subview` regions preserve their materialized byte bases, so descriptor selection can distinguish a dynamic root buffer base from a static projected view offset. That lets dense projected views keep stronger static offsets and cleaner addressing in the generated low IR, while preserving the existing diagnostic path for accesses that still cannot be planned.

The branch also removes duplicated target-local operation lists from AMDGPU placement. Scalar integer binary placement now uses the generated `DistributionTransfer` trait plus operand/result shape checks instead of a hand-maintained scalar op switch. Index arithmetic placement falls through the same shared trait path, and index rotates now carry the distribution-transfer trait in the Python op source of truth instead of relying on an AMDGPU-only exception.

An author-facing example of the SCF change is:

```mlir
scf.for %i = [%start to %end step %step](%acc = %input : i32) -> (i32) unroll schedule(interleaved) {
  %next = test.addi %acc, %input : i32
  vector.store %vec0, %view[0] : vector<4xi32>, view<8xi32, %layout>
  vector.store %vec1, %view[4] : vector<4xi32>, view<8xi32, %layout>
  scf.yield %next : i32
}
```

The unroller can now interleave the disjoint vector stores while keeping the carried SSA recurrence in the only legal order. If the vector footprints overlap, depend on the induction value, or cannot be proven independent, the pass preserves ordered iteration behavior instead.

The review surface is mostly in `scf_unroll.c`, `source_memory_plan.c`, `view_regions.c`, and AMDGPU `lower/support.c`. The important invariants are that schedule interleaving must never reorder dependent memory effects, source-memory planning must keep diagnostics user-facing rather than turning planning failures into infrastructure statuses, and AMDGPU placement should continue moving toward generated traits/facts instead of target-private op-family lists.
