### PR TITLE
[Loom] Print AMDGPU zero-accumulator matrix packets

### DIFF
--- a/loom/src/loom/target/emit/native/amdgpu/assembly.c
+++ b/loom/src/loom/target/emit/native/amdgpu/assembly.c
@@ -77,6 +77,19 @@ static bool loom_amdgpu_assignments_match(
          lhs->location_count == rhs->location_count;
 }
 
+static bool loom_amdgpu_op_ties_result_to_operand(const loom_op_t* op,
+                                                  uint16_t result_index,
+                                                  uint16_t operand_index) {
+  const loom_tied_result_t* tied_results = loom_op_tied_results(op);
+  for (uint16_t i = 0; i < op->tied_result_count; ++i) {
+    if (tied_results[i].result_index == result_index &&
+        tied_results[i].operand_index == operand_index) {
+      return true;
+    }
+  }
+  return false;
+}
+
 static iree_status_t loom_amdgpu_append_register_range(
     const loom_native_assembly_packet_context_t* context, const char* prefix,
     const loom_low_allocation_assignment_t* assignment) {
@@ -2630,20 +2643,32 @@ static iree_status_t loom_amdgpu_append_storage_address_packet(
 
 static iree_status_t loom_amdgpu_append_matrix_packet(
     const loom_native_assembly_packet_context_t* context) {
+  const loom_low_descriptor_set_t* descriptor_set =
+      context->schedule->target.descriptor_set;
+  const loom_low_descriptor_t* descriptor = context->packet->descriptor;
   const loom_op_t* op = context->packet->node->op;
   uint16_t accumulator_operand_index = UINT16_MAX;
-  const loom_tied_result_t* tied_results = loom_op_tied_results(op);
-  for (uint16_t i = 0; i < op->tied_result_count; ++i) {
-    if (tied_results[i].result_index == 0) {
-      accumulator_operand_index = tied_results[i].operand_index;
+  for (uint16_t i = 0; i < op->operand_count; ++i) {
+    const uint16_t descriptor_operand_index =
+        loom_low_descriptor_packet_operand_descriptor_index(descriptor_set,
+                                                            descriptor, i);
+    IREE_ASSERT_NE(descriptor_operand_index, LOOM_LOW_ID_NONE);
+    if (descriptor_operand_index != LOOM_LOW_ID_NONE &&
+        loom_low_descriptor_operands_are_tied(descriptor_set, descriptor,
+                                              /*lhs_operand_index=*/0,
+                                              descriptor_operand_index)) {
+      accumulator_operand_index = i;
       break;
     }
   }
-  if (accumulator_operand_index == UINT16_MAX ||
-      accumulator_operand_index >= op->operand_count) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "AMDGPU matrix result must be tied to an accumulator operand");
+  if (accumulator_operand_index == UINT16_MAX) {
+    return loom_amdgpu_append_canonical_asm_form_packet(context);
+  }
+  if (!loom_amdgpu_op_ties_result_to_operand(op, /*result_index=*/0,
+                                             accumulator_operand_index)) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "AMDGPU matrix descriptor tie is missing from the "
+                            "scheduled low packet");
   }
   const loom_low_allocation_assignment_t* result_assignment =
       loom_amdgpu_map_assignment(context, loom_op_const_results(op)[0]);

--- a/loom/src/loom/target/emit/native/amdgpu/test/assembly_wmma.loom-test
+++ b/loom/src/loom/target/emit/native/amdgpu/test/assembly_wmma.loom-test
@@ -21,6 +21,19 @@ low.func.def target(@gfx11_target) @gfx11_wmma_base(%a8: reg<amdgpu.vgpr x8>, %b
 
 // ====
 
+// RUN: emit amdgpu-assembly @gfx11_wmma_zero_accumulator waits=none
+amdgpu.target<gfx1100> @gfx11_target
+low.func.def target(@gfx11_target) @gfx11_wmma_zero_accumulator(%a8: reg<amdgpu.vgpr x8>, %b8: reg<amdgpu.vgpr x8>) asm<amdgpu.rdna3.core> {
+  %f32_bf16 = v_wmma_f32_16x16x16_bf16_acc_zero %a8, %b8
+  return
+}
+
+// ----
+  v_wmma_f32_16x16x16_bf16 v[0:7], v[0:7], v[8:15], 0
+  s_endpgm
+
+// ====
+
 // RUN: emit amdgpu-assembly @gfx11_wmma_concat_resource_stall waits=none strategy=resource-stall
 amdgpu.target<gfx1100> @gfx11_target
 low.func.def target(@gfx11_target) @gfx11_wmma_concat_resource_stall(%lane: reg<amdgpu.vgpr>, %activation_view: reg<amdgpu.sgpr x2>, %weight_view: reg<amdgpu.sgpr x2>, %bias_view: reg<amdgpu.sgpr x2>, %output_view: reg<amdgpu.sgpr x2>) asm<amdgpu.rdna3.core> {


### PR DESCRIPTION
AMDGPU zero-accumulator WMMA descriptors are legitimate matrix packet forms: they encode the accumulator operand as the native literal `0` instead of consuming an explicit low operand tied to the result. Native assembly emission still treated every matrix packet as if it had a destructive accumulator/result tie, so reporting/listing paths could reject valid benchmark samples even though execution and lowering had already selected a correct zero-accumulator form.

This changes matrix native emission to ask the descriptor constraint table whether result 0 is tied to an explicit packet operand. Tied accumulator forms keep the existing safety checks: the scheduled low packet must carry the tie and the allocator must place result and accumulator in the same physical register range. Descriptors without that tie now use the canonical generated asm form, which prints the literal-zero operand supplied by the descriptor metadata.

The regression coverage lives in the AMDGPU WMMA assembly corpus and checks the actual product-facing assembly spelling:

```loom
%f32_bf16 = v_wmma_f32_16x16x16_bf16_acc_zero %a8, %b8
```

which now emits:

```asm
v_wmma_f32_16x16x16_bf16 v[0:7], v[0:7], v[8:15], 0
```

The practical user-visible effect is that benchmark/reporting paths can now emit native AMDGPU listings for BF16 WMMA kernels that start from zero accumulators, matching the lowering behavior that `iree-test-loom` was already able to execute.
