### PR TITLE
[Loom] Fix AMDGPU FP8 WMMA blocker paths

### DIFF
--- a/loom/py/loom/dialect/vector/defs.py
+++ b/loom/py/loom/dialect/vector/defs.py
@@ -1389,7 +1389,11 @@ vector_fragment_load = Op(
         "shape, view layout, and target legality; it is not an ordinary "
         "trailing-axis footprint of the view. The result carries fragment "
         "facts directly so vector.mma can consume it without a separate "
-        "vector.fragment wrapper."
+        "vector.fragment wrapper. When the view and result element types "
+        "differ, the operation represents a fragment-shaped numeric "
+        "conversion at the load boundary and target lowering must either "
+        "select that conversion explicitly or reject it with target "
+        "diagnostics."
     ),
     operands=[
         Operand("view", VIEW, doc="Typed source view holding logical matrix data."),
@@ -1402,7 +1406,6 @@ vector_fragment_load = Op(
         AttrDef("role", ATTR_TYPE_ENUM, enum_def=VectorFragmentRole),
         *_indexed_memory_attrs(),
     ],
-    constraints=[SameElementType("view", "result")],
     traits=[REFINABLE_RESULT_TYPE_REFS],
     effects=[Reads("view")],
     interfaces=[_memory_access_interface()],

--- a/loom/src/loom/ops/vector/ops.h
+++ b/loom/src/loom/ops/vector/ops.h
@@ -702,7 +702,7 @@ iree_status_t loom_vector_transform_verify(
     const loom_module_t* module, const loom_op_t* op,
     iree_diagnostic_emitter_t emitter);
 
-// LOOM_OP_VECTOR_FRAGMENT_LOAD: Load a target-shaped matrix fragment payload from a typed view at a full-rank logical origin. Unlike vector.load, the result vector shape is the physical fragment payload selected by role, logical matrix shape, view layout, and target legality; it is not an ordinary trailing-axis footprint of the view. The result carries fragment facts directly so vector.mma can consume it without a separate vector.fragment wrapper.
+// LOOM_OP_VECTOR_FRAGMENT_LOAD: Load a target-shaped matrix fragment payload from a typed view at a full-rank logical origin. Unlike vector.load, the result vector shape is the physical fragment payload selected by role, logical matrix shape, view layout, and target legality; it is not an ordinary trailing-axis footprint of the view. The result carries fragment facts directly so vector.mma can consume it without a separate vector.fragment wrapper. When the view and result element types differ, the operation represents a fragment-shaped numeric conversion at the load boundary and target lowering must either select that conversion explicitly or reject it with target diagnostics.
 // %lhs = vector.fragment.load<lhs> %a[%row, %k0] shape [%m, %k] : view<[%M]x[%K]xf16, %layout> -> vector<16xf16>
 LOOM_DEFINE_ISA(loom_vector_fragment_load_isa, LOOM_OP_VECTOR_FRAGMENT_LOAD)
 LOOM_DEFINE_OPERAND(loom_vector_fragment_load_view, 0)

--- a/loom/src/loom/ops/vector/test/verify.loom-test
+++ b/loom/src/loom/ops/vector/test/verify.loom-test
@@ -1030,12 +1030,11 @@ func.def @fragment_load_requires_full_rank_origin(%buffer: buffer, %offset: offs
 
 // ====
 
-// Dense fragment movement keeps the logical view element type on the physical
-// fragment payload.
-func.def @fragment_load_requires_matching_element_type(%buffer: buffer, %offset: offset, %row: index, %m: index, %k: index) {
+// Fragment loads may request a target-shaped element conversion at the load
+// boundary. Target legality owns selecting or rejecting the conversion.
+func.def @fragment_load_allows_load_boundary_conversion(%buffer: buffer, %offset: offset, %row: index, %m: index, %k: index) {
   %layout = encoding.layout.dense : encoding<layout>
   %view = buffer.view %buffer[%offset] : buffer -> view<16x16xf32, %layout>
-  // ERROR@+1: TYPE/002 "view" "result"
   %lhs = vector.fragment.load<lhs> %view[%row, 0] shape [%m, %k] : view<16x16xf32, %layout> -> vector<16xf16>
   func.return
 }

--- a/loom/src/loom/target/arch/amdgpu/legalization.c
+++ b/loom/src/loom/target/arch/amdgpu/legalization.c
@@ -1167,6 +1167,9 @@ static iree_status_t loom_amdgpu_fragment_store_plan_can_join_group(
     uint16_t register_count, loom_amdgpu_fragment_memory_plan_t* out_plan,
     bool* out_selected) {
   *out_selected = false;
+  if (!loom_vector_fragment_store_isa(op)) {
+    return iree_ok_status();
+  }
   bool selected = false;
   IREE_RETURN_IF_ERROR(loom_amdgpu_analyze_vector_fragment_memory_plan(
       context->module, context->fact_table, context->bundle,

--- a/loom/src/loom/target/arch/amdgpu/lower/emit.h
+++ b/loom/src/loom/target/arch/amdgpu/lower/emit.h
@@ -323,6 +323,12 @@ iree_status_t loom_amdgpu_emit_f32_to_bf16_lane(
     loom_value_id_t source_lane, loom_type_t lane_type,
     loom_value_id_t* out_lane);
 
+// Emits a software expansion from one FP8 storage byte to one f32 lane.
+iree_status_t loom_amdgpu_emit_fp8_to_f32_lane(
+    loom_low_lower_context_t* context, const loom_op_t* source_op,
+    loom_value_id_t source_byte, loom_scalar_type_t source_element_type,
+    loom_type_t lane_type, loom_value_id_t* out_lane);
+
 // Emits round-to-nearest-even conversion from two f32 lanes to one packed BF16
 // register. The low source becomes the low 16 bits of the result.
 iree_status_t loom_amdgpu_emit_f32_pair_to_packed_bf16(

--- a/loom/src/loom/target/arch/amdgpu/lower/matrix_fragment.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/matrix_fragment.c
@@ -60,6 +60,8 @@ typedef struct loom_amdgpu_fragment_memory_descriptor_table_t {
                  [LOOM_AMDGPU_FRAGMENT_MEMORY_MAX_PACKET_REGISTERS + 1u];
   // Descriptor ref for a scalar 16-bit load packet.
   loom_amdgpu_descriptor_ref_t load_b16_ref;
+  // Descriptor ref for a scalar 8-bit load packet.
+  loom_amdgpu_descriptor_ref_t load_i8_ref;
   // Descriptor ref for a scalar 16-bit store packet.
   loom_amdgpu_descriptor_ref_t store_b16_ref;
 } loom_amdgpu_fragment_memory_descriptor_table_t;
@@ -92,6 +94,7 @@ static const loom_amdgpu_fragment_memory_descriptor_table_t
                     },
                 .load_b16_ref =
                     LOOM_AMDGPU_DESCRIPTOR_REF_GLOBAL_LOAD_B16_D16_SADDR,
+                .load_i8_ref = LOOM_AMDGPU_DESCRIPTOR_REF_GLOBAL_LOAD_I8_SADDR,
                 .store_b16_ref =
                     LOOM_AMDGPU_DESCRIPTOR_REF_GLOBAL_STORE_B16_SADDR,
             },
@@ -117,6 +120,7 @@ static const loom_amdgpu_fragment_memory_descriptor_table_t
                             },
                     },
                 .load_b16_ref = LOOM_AMDGPU_DESCRIPTOR_REF_BUFFER_LOAD_B16_D16,
+                .load_i8_ref = LOOM_AMDGPU_DESCRIPTOR_REF_BUFFER_LOAD_I8,
                 .store_b16_ref = LOOM_AMDGPU_DESCRIPTOR_REF_BUFFER_STORE_B16,
             },
         [LOOM_AMDGPU_FRAGMENT_MEMORY_DOMAIN_WORKGROUP] =
@@ -141,6 +145,7 @@ static const loom_amdgpu_fragment_memory_descriptor_table_t
                             },
                     },
                 .load_b16_ref = LOOM_AMDGPU_DESCRIPTOR_REF_DS_READ_U16,
+                .load_i8_ref = LOOM_AMDGPU_DESCRIPTOR_REF_NONE,
                 .store_b16_ref = LOOM_AMDGPU_DESCRIPTOR_REF_DS_WRITE_B16,
             },
 };
@@ -335,6 +340,12 @@ static bool loom_amdgpu_fragment_memory_scalar_type_is_16bit_float(
          element_type == LOOM_SCALAR_TYPE_BF16;
 }
 
+static bool loom_amdgpu_fragment_memory_scalar_type_is_fp8(
+    loom_scalar_type_t element_type) {
+  return element_type == LOOM_SCALAR_TYPE_F8E4M3 ||
+         element_type == LOOM_SCALAR_TYPE_F8E5M2;
+}
+
 static bool loom_amdgpu_fragment_memory_can_load_packed_16bit_result(
     loom_amdgpu_memory_operation_kind_t operation_kind,
     loom_contract_operand_role_t role, loom_scalar_type_t expected_element_type,
@@ -346,6 +357,19 @@ static bool loom_amdgpu_fragment_memory_can_load_packed_16bit_result(
          payload_element_type == view_element_type &&
          loom_amdgpu_fragment_memory_scalar_type_is_16bit_float(
              payload_element_type);
+}
+
+static bool loom_amdgpu_fragment_memory_can_load_fp8_to_bf16(
+    loom_amdgpu_memory_operation_kind_t operation_kind,
+    loom_contract_operand_role_t role, loom_scalar_type_t expected_element_type,
+    loom_scalar_type_t payload_element_type,
+    loom_scalar_type_t view_element_type) {
+  return operation_kind == LOOM_AMDGPU_MEMORY_OPERATION_LOAD &&
+         (role == LOOM_CONTRACT_OPERAND_ROLE_LHS ||
+          role == LOOM_CONTRACT_OPERAND_ROLE_RHS) &&
+         expected_element_type == LOOM_SCALAR_TYPE_BF16 &&
+         payload_element_type == LOOM_SCALAR_TYPE_BF16 &&
+         loom_amdgpu_fragment_memory_scalar_type_is_fp8(view_element_type);
 }
 
 static bool loom_amdgpu_fragment_memory_payload_form_select(
@@ -364,6 +388,13 @@ static bool loom_amdgpu_fragment_memory_payload_form_select(
           view_element_type)) {
     *out_payload_form =
         LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_LOAD_PACKED_16BIT_RESULT;
+    return true;
+  }
+  if (loom_amdgpu_fragment_memory_can_load_fp8_to_bf16(
+          operation_kind, role, expected_element_type, payload_element_type,
+          view_element_type)) {
+    *out_payload_form =
+        LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_LOAD_FP8_TO_BF16;
     return true;
   }
   if ((payload_element_type == expected_element_type ||
@@ -407,6 +438,17 @@ static bool loom_amdgpu_fragment_memory_role_uses_packed_b16_elements(
              LOOM_AMDGPU_FRAGMENT_PACKED_B16_ELEMENT_BIT_COUNT &&
          role_layout->elements_per_register ==
              LOOM_AMDGPU_FRAGMENT_PACKED_B16_ELEMENT_COUNT;
+}
+
+static bool loom_amdgpu_fragment_memory_payload_uses_element_subindices(
+    const loom_amdgpu_fragment_memory_plan_t* plan,
+    const loom_amdgpu_matrix_fragment_role_layout_t* role_layout) {
+  if (loom_amdgpu_fragment_memory_role_uses_packed_b16_elements(role_layout)) {
+    return true;
+  }
+  return plan->payload_form ==
+             LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_LOAD_FP8_TO_BF16 &&
+         plan->elements_per_register > 1;
 }
 
 static bool loom_amdgpu_fragment_memory_role_uses_scalar_b16_packets(
@@ -788,10 +830,13 @@ static bool loom_amdgpu_fragment_memory_view_matches(
   const bool view_is_packed_16bit_result =
       payload_form ==
       LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_LOAD_PACKED_16BIT_RESULT;
+  const bool view_is_fp8_to_bf16 =
+      payload_form == LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_LOAD_FP8_TO_BF16;
   if (loom_type_is_vector(payload_type) &&
       payload_element_type != view_element_type &&
       !(view_is_narrowed && payload_element_type == expected_element_type) &&
-      !(view_is_extended && view_element_type == expected_element_type)) {
+      !(view_is_extended && view_element_type == expected_element_type) &&
+      !view_is_fp8_to_bf16) {
     return false;
   }
 
@@ -821,7 +866,7 @@ static bool loom_amdgpu_fragment_memory_view_matches(
       return false;
   }
   if (view_element_type != expected_element_type && !view_is_narrowed &&
-      !view_is_packed_16bit_result) {
+      !view_is_packed_16bit_result && !view_is_fp8_to_bf16) {
     return false;
   }
 
@@ -969,6 +1014,24 @@ static bool loom_amdgpu_fragment_memory_16bit_descriptor_ref(
   return true;
 }
 
+static bool loom_amdgpu_fragment_memory_8bit_load_descriptor_ref(
+    loom_value_fact_memory_space_t memory_space,
+    loom_amdgpu_descriptor_ref_t* out_descriptor_ref) {
+  *out_descriptor_ref = LOOM_AMDGPU_DESCRIPTOR_REF_NONE;
+  loom_amdgpu_fragment_memory_domain_t domain =
+      LOOM_AMDGPU_FRAGMENT_MEMORY_DOMAIN_COUNT_;
+  if (!loom_amdgpu_fragment_memory_domain_from_space(memory_space, &domain)) {
+    return false;
+  }
+  const loom_amdgpu_descriptor_ref_t descriptor_ref =
+      kFragmentMemoryDescriptorTables[domain].load_i8_ref;
+  if (descriptor_ref == LOOM_AMDGPU_DESCRIPTOR_REF_NONE) {
+    return false;
+  }
+  *out_descriptor_ref = descriptor_ref;
+  return true;
+}
+
 static bool loom_amdgpu_fragment_memory_narrowed_store_descriptor_ref(
     loom_value_fact_memory_space_t memory_space, uint16_t result_register_count,
     uint16_t* out_packet_register_count,
@@ -994,6 +1057,14 @@ static bool loom_amdgpu_fragment_memory_space_supports_access(
     loom_value_fact_memory_space_t memory_space,
     const loom_amdgpu_matrix_fragment_role_layout_t* role_layout,
     loom_amdgpu_fragment_memory_payload_form_t payload_form) {
+  if (payload_form ==
+      LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_LOAD_FP8_TO_BF16) {
+    loom_amdgpu_descriptor_ref_t descriptor_ref =
+        LOOM_AMDGPU_DESCRIPTOR_REF_NONE;
+    return loom_amdgpu_fragment_memory_8bit_load_descriptor_ref(
+        memory_space, &descriptor_ref);
+  }
+
   if (loom_amdgpu_fragment_memory_role_uses_scalar_b16_packets(role_layout)) {
     loom_amdgpu_descriptor_ref_t descriptor_ref =
         LOOM_AMDGPU_DESCRIPTOR_REF_NONE;
@@ -1039,6 +1110,34 @@ static bool loom_amdgpu_fragment_memory_space_supports_access(
   return false;
 }
 
+static bool loom_amdgpu_fragment_memory_fp8_to_bf16_descriptors_present(
+    const loom_low_descriptor_set_t* descriptor_set) {
+  static const loom_amdgpu_descriptor_ref_t kRequiredDescriptorRefs[] = {
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_MOV_B32,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_AND_B32_LIT,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_OR_B32,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_OR_B32_LIT,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_ADD_U32,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_ADD_U32_LIT,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_SUB_U32,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_LSHLREV_B32,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_LSHLREV_B32_LIT,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_LSHRREV_B32_LIT,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_EQ_I32,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_NE_I32,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_CNDMASK_B32,
+      LOOM_AMDGPU_DESCRIPTOR_REF_S_AND_B64,
+  };
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(kRequiredDescriptorRefs);
+       ++i) {
+    if (!loom_amdgpu_descriptor_set_has_ref(descriptor_set,
+                                            kRequiredDescriptorRefs[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 static bool loom_amdgpu_fragment_memory_payload_form_has_descriptors(
     const loom_low_descriptor_set_t* descriptor_set,
     loom_amdgpu_fragment_memory_payload_form_t payload_form) {
@@ -1050,6 +1149,9 @@ static bool loom_amdgpu_fragment_memory_payload_form_has_descriptors(
     case LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_STORE_EXTEND_F16_TO_F32:
       return loom_amdgpu_descriptor_set_has_ref(
           descriptor_set, LOOM_AMDGPU_DESCRIPTOR_REF_V_CVT_F32_F16);
+    case LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_LOAD_FP8_TO_BF16:
+      return loom_amdgpu_fragment_memory_fp8_to_bf16_descriptors_present(
+          descriptor_set);
   }
   return false;
 }
@@ -1275,7 +1377,9 @@ static bool loom_amdgpu_fragment_memory_analyze(
   if (!loom_amdgpu_fragment_memory_payload_form_has_descriptors(
           environment->descriptor_set, payload_form)) {
     return loom_amdgpu_fragment_memory_reject(
-        diagnostic, IREE_SV("fragment_memory.store_conversion"));
+        diagnostic, operation_kind == LOOM_AMDGPU_MEMORY_OPERATION_STORE
+                        ? IREE_SV("fragment_memory.store_conversion")
+                        : IREE_SV("fragment_memory.payload_form"));
   }
 
   if (source_access.memory_space == LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP) {
@@ -1317,6 +1421,7 @@ static bool loom_amdgpu_fragment_memory_analyze(
         .register_count = role_layout->register_count,
         .payload_register_count = payload_register_count,
         .elements_per_register = role_layout->elements_per_register,
+        .view_element_type = loom_type_element_type(view_type),
         .element_byte_count = (uint16_t)source_access.element_byte_count,
         .payload_form = payload_form,
         .narrowed_result_round_source = narrowed_result_round_source,
@@ -1738,6 +1843,26 @@ static bool loom_amdgpu_fragment_memory_select_packed_16bit_result_load_packet(
   return true;
 }
 
+static bool loom_amdgpu_fragment_memory_select_fp8_to_bf16_load_packet(
+    const loom_low_descriptor_set_t* descriptor_set,
+    const loom_amdgpu_fragment_memory_plan_t* plan, uint16_t register_index,
+    loom_amdgpu_fragment_memory_packet_plan_t* out_packet) {
+  *out_packet = (loom_amdgpu_fragment_memory_packet_plan_t){0};
+  loom_amdgpu_descriptor_ref_t descriptor_ref = LOOM_AMDGPU_DESCRIPTOR_REF_NONE;
+  if (!loom_amdgpu_fragment_memory_8bit_load_descriptor_ref(
+          plan->source.memory_space, &descriptor_ref) ||
+      !loom_amdgpu_descriptor_set_has_ref(descriptor_set, descriptor_ref)) {
+    return false;
+  }
+  *out_packet = (loom_amdgpu_fragment_memory_packet_plan_t){
+      .register_index = register_index,
+      .result_register_count = 1,
+      .packet_register_count = 1,
+      .descriptor_ref = descriptor_ref,
+  };
+  return true;
+}
+
 static bool loom_amdgpu_fragment_memory_can_use_packed_payload_slice(
     const loom_amdgpu_fragment_memory_plan_t* plan, uint16_t register_index,
     uint16_t result_register_count) {
@@ -1806,15 +1931,23 @@ static bool loom_amdgpu_fragment_memory_plan_packets(
   const loom_amdgpu_matrix_fragment_role_layout_t* role_layout =
       loom_amdgpu_matrix_fragment_role_layout(layout, plan->role);
   const bool scalar_b16_packets =
+      plan->payload_form !=
+          LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_LOAD_FP8_TO_BF16 &&
       loom_amdgpu_fragment_memory_role_uses_scalar_b16_packets(role_layout);
   const bool load_packed_16bit_result =
       plan->payload_form ==
       LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_LOAD_PACKED_16BIT_RESULT;
+  const bool load_fp8_to_bf16 =
+      plan->payload_form ==
+      LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_LOAD_FP8_TO_BF16;
   for (uint16_t register_index = 0; register_index < plan->register_count;) {
     loom_amdgpu_fragment_memory_packet_plan_t packet = {0};
     const bool selected =
         scalar_b16_packets
             ? loom_amdgpu_fragment_memory_select_low_subword_packet(
+                  descriptor_set, plan, register_index, &packet)
+        : load_fp8_to_bf16
+            ? loom_amdgpu_fragment_memory_select_fp8_to_bf16_load_packet(
                   descriptor_set, plan, register_index, &packet)
         : load_packed_16bit_result
             ? loom_amdgpu_fragment_memory_select_packed_16bit_result_load_packet(
@@ -1863,6 +1996,12 @@ iree_status_t loom_amdgpu_analyze_vector_fragment_memory_plan(
     loom_amdgpu_fragment_memory_plan_t* out_plan, bool* out_selected) {
   *out_plan = (loom_amdgpu_fragment_memory_plan_t){0};
   *out_selected = false;
+  if ((operation_kind == LOOM_AMDGPU_MEMORY_OPERATION_LOAD &&
+       !loom_vector_fragment_load_isa(source_op)) ||
+      (operation_kind == LOOM_AMDGPU_MEMORY_OPERATION_STORE &&
+       !loom_vector_fragment_store_isa(source_op))) {
+    return iree_ok_status();
+  }
   const loom_amdgpu_fragment_memory_environment_t environment = {
       .module = module,
       .fact_table = fact_table,
@@ -2275,9 +2414,9 @@ static iree_status_t loom_amdgpu_emit_fragment_memory_vaddr(
   if (element_index != 0) {
     const loom_amdgpu_matrix_fragment_role_layout_t* role_layout =
         loom_amdgpu_matrix_fragment_role_layout(layout, plan->role);
-    if (!loom_amdgpu_fragment_memory_role_uses_packed_b16_elements(
-            role_layout) ||
-        element_index >= role_layout->elements_per_register) {
+    if (!loom_amdgpu_fragment_memory_payload_uses_element_subindices(
+            plan, role_layout) ||
+        element_index >= plan->elements_per_register) {
       IREE_ASSERT_UNREACHABLE("selected AMDGPU fragment element map");
       IREE_BUILTIN_UNREACHABLE();
     }
@@ -2713,6 +2852,44 @@ static iree_status_t loom_amdgpu_emit_fragment_memory_packed_b16_load_packet(
       high_element, vgpr_type, out_low_packet);
 }
 
+static iree_status_t loom_amdgpu_emit_fragment_memory_fp8_to_bf16_load_packet(
+    loom_low_lower_context_t* context, const loom_op_t* source_op,
+    const loom_amdgpu_matrix_fragment_layout_t* layout,
+    const loom_amdgpu_fragment_memory_plan_t* plan,
+    const loom_amdgpu_fragment_memory_packet_plan_t* packet,
+    const loom_amdgpu_fragment_memory_address_accumulator_t* base_accumulator,
+    loom_value_id_t low_address_resource, loom_value_id_t low_packet_resource,
+    loom_type_t vgpr_type, loom_value_id_t low_soffset,
+    loom_value_id_t* out_low_packet) {
+  *out_low_packet = LOOM_VALUE_ID_INVALID;
+  if (plan->elements_per_register !=
+      LOOM_AMDGPU_FRAGMENT_PACKED_B16_ELEMENT_COUNT) {
+    IREE_ASSERT_UNREACHABLE("selected AMDGPU FP8 to BF16 fragment layout");
+    IREE_BUILTIN_UNREACHABLE();
+  }
+  loom_value_id_t f32_lanes[LOOM_AMDGPU_FRAGMENT_PACKED_B16_ELEMENT_COUNT] = {
+      0};
+  for (uint16_t element_index = 0; element_index < plan->elements_per_register;
+       ++element_index) {
+    loom_amdgpu_fragment_memory_address_t address;
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_fragment_memory_vaddr(
+        context, source_op, layout, plan, packet->register_index, element_index,
+        packet->descriptor_ref, base_accumulator, low_address_resource,
+        vgpr_type, &address));
+    loom_value_id_t low_byte = LOOM_VALUE_ID_INVALID;
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_fragment_load_packet(
+        context, source_op, layout, plan, packet, element_index,
+        /*vector_lane_count=*/1, vgpr_type, &address, low_packet_resource,
+        low_soffset, &low_byte));
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_fp8_to_f32_lane(
+        context, source_op, low_byte, plan->view_element_type, vgpr_type,
+        &f32_lanes[element_index]));
+  }
+  return loom_amdgpu_emit_f32_pair_to_packed_bf16(context, source_op,
+                                                  f32_lanes[0], f32_lanes[1],
+                                                  vgpr_type, out_low_packet);
+}
+
 static iree_status_t
 loom_amdgpu_emit_fragment_memory_packed_16bit_result_load_packet(
     loom_low_lower_context_t* context, const loom_op_t* source_op,
@@ -2893,6 +3070,9 @@ iree_status_t loom_amdgpu_lower_vector_fragment_load(
   const bool load_packed_16bit_result =
       plan->payload_form ==
       LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_LOAD_PACKED_16BIT_RESULT;
+  const bool load_fp8_to_bf16 =
+      plan->payload_form ==
+      LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_LOAD_FP8_TO_BF16;
 
   loom_value_id_t low_resource = LOOM_VALUE_ID_INVALID;
   loom_value_id_t low_packet_resource = LOOM_VALUE_ID_INVALID;
@@ -2918,6 +3098,14 @@ iree_status_t loom_amdgpu_lower_vector_fragment_load(
     if (load_packed_16bit_result) {
       IREE_RETURN_IF_ERROR(
           loom_amdgpu_emit_fragment_memory_packed_16bit_result_load_packet(
+              context, source_op, layout, plan, packet, &base_accumulator,
+              low_resource, low_packet_resource, vgpr_type, low_soffset,
+              &low_packets[packet_index]));
+      continue;
+    }
+    if (load_fp8_to_bf16) {
+      IREE_RETURN_IF_ERROR(
+          loom_amdgpu_emit_fragment_memory_fp8_to_bf16_load_packet(
               context, source_op, layout, plan, packet, &base_accumulator,
               low_resource, low_packet_resource, vgpr_type, low_soffset,
               &low_packets[packet_index]));

--- a/loom/src/loom/target/arch/amdgpu/lower/plan.h
+++ b/loom/src/loom/target/arch/amdgpu/lower/plan.h
@@ -1054,6 +1054,8 @@ typedef enum loom_amdgpu_fragment_memory_payload_form_e {
   LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_STORE_NARROW_F32_TO_BF16 = 2,
   // A f16 low-subword result fragment is widened to f32 lanes before store.
   LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_STORE_EXTEND_F16_TO_F32 = 3,
+  // FP8 memory lanes are expanded to BF16 fragment payload lanes on load.
+  LOOM_AMDGPU_FRAGMENT_MEMORY_PAYLOAD_FORM_LOAD_FP8_TO_BF16 = 4,
 } loom_amdgpu_fragment_memory_payload_form_t;
 
 typedef struct loom_amdgpu_fragment_memory_plan_t {
@@ -1077,6 +1079,8 @@ typedef struct loom_amdgpu_fragment_memory_plan_t {
   uint16_t payload_register_count;
   // Logical elements packed in each 32-bit fragment register.
   uint16_t elements_per_register;
+  // Scalar element type addressed in the source view.
+  loom_scalar_type_t view_element_type;
   // Byte count of one logical fragment element.
   uint16_t element_byte_count;
   // Direct memory packets emitted in increasing fragment-register order.

--- a/loom/src/loom/target/arch/amdgpu/lower/values.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/values.c
@@ -4994,6 +4994,365 @@ static iree_status_t loom_amdgpu_extract_f16_lane_as_low_bits(
       register_bit_offset, source_register, lane_type, out_lane);
 }
 
+typedef enum loom_amdgpu_fp8_special_policy_e {
+  LOOM_AMDGPU_FP8_SPECIAL_POLICY_IEEE = 0,
+  LOOM_AMDGPU_FP8_SPECIAL_POLICY_FINITE_NAN = 1,
+} loom_amdgpu_fp8_special_policy_t;
+
+typedef struct loom_amdgpu_fp8_decode_format_t {
+  // Number of encoded exponent bits.
+  uint8_t exponent_bits;
+  // Number of encoded mantissa bits.
+  uint8_t mantissa_bits;
+  // Exponent bias used by the FP8 format.
+  uint8_t exponent_bias;
+  // Top-exponent handling policy for infinities and NaNs.
+  loom_amdgpu_fp8_special_policy_t special_policy;
+} loom_amdgpu_fp8_decode_format_t;
+
+static bool loom_amdgpu_fp8_decode_format_from_type(
+    loom_scalar_type_t scalar_type,
+    loom_amdgpu_fp8_decode_format_t* out_format) {
+  switch (scalar_type) {
+    case LOOM_SCALAR_TYPE_F8E4M3:
+      *out_format = (loom_amdgpu_fp8_decode_format_t){
+          .exponent_bits = 4,
+          .mantissa_bits = 3,
+          .exponent_bias = 7,
+          .special_policy = LOOM_AMDGPU_FP8_SPECIAL_POLICY_FINITE_NAN,
+      };
+      return true;
+    case LOOM_SCALAR_TYPE_F8E5M2:
+      *out_format = (loom_amdgpu_fp8_decode_format_t){
+          .exponent_bits = 5,
+          .mantissa_bits = 2,
+          .exponent_bias = 15,
+          .special_policy = LOOM_AMDGPU_FP8_SPECIAL_POLICY_IEEE,
+      };
+      return true;
+    default:
+      return false;
+  }
+}
+
+static iree_status_t loom_amdgpu_emit_vgpr_compare_i32_immediate(
+    loom_low_lower_context_t* context, const loom_op_t* source_op,
+    loom_amdgpu_descriptor_ref_t compare_descriptor_ref,
+    loom_amdgpu_descriptor_ref_t inline_descriptor_ref, loom_value_id_t value,
+    uint32_t immediate, loom_type_t lane_type, loom_type_t mask_lane_type,
+    loom_value_id_t* out_condition) {
+  *out_condition = LOOM_VALUE_ID_INVALID;
+  const loom_low_descriptor_set_t* descriptor_set =
+      loom_low_lower_context_descriptor_set(context);
+  if (immediate <= 64 && loom_amdgpu_descriptor_set_has_ref(
+                             descriptor_set, inline_descriptor_ref)) {
+    loom_named_attr_t attrs[1] = {0};
+    iree_host_size_t attr_count = 0;
+    IREE_RETURN_IF_ERROR(
+        loom_amdgpu_append_i64_attr(context, IREE_SV("rhs"), immediate, attrs,
+                                    IREE_ARRAYSIZE(attrs), &attr_count));
+    const loom_value_id_t operands[] = {value};
+    loom_op_t* low_op = NULL;
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_low_op(
+        context, source_op, inline_descriptor_ref, operands,
+        IREE_ARRAYSIZE(operands), loom_make_named_attr_slice(attrs, attr_count),
+        &mask_lane_type, 1, &low_op));
+    *out_condition = loom_value_slice_get(loom_low_op_results(low_op), 0);
+    return iree_ok_status();
+  }
+
+  loom_value_id_t immediate_value = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_const_u32(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_MOV_B32, immediate,
+      lane_type, &immediate_value));
+  const loom_value_id_t operands[] = {value, immediate_value};
+  loom_op_t* low_op = NULL;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_low_op(
+      context, source_op, compare_descriptor_ref, operands,
+      IREE_ARRAYSIZE(operands), loom_make_named_attr_slice(NULL, 0),
+      &mask_lane_type, 1, &low_op));
+  *out_condition = loom_value_slice_get(loom_low_op_results(low_op), 0);
+  return iree_ok_status();
+}
+
+static iree_status_t loom_amdgpu_emit_vgpr_cndmask(
+    loom_low_lower_context_t* context, const loom_op_t* source_op,
+    loom_value_id_t false_value, loom_value_id_t true_value,
+    loom_value_id_t condition, loom_type_t lane_type,
+    loom_value_id_t* out_value) {
+  *out_value = LOOM_VALUE_ID_INVALID;
+  const loom_value_id_t operands[] = {false_value, true_value, condition};
+  loom_op_t* low_op = NULL;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_low_op(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_CNDMASK_B32, operands,
+      IREE_ARRAYSIZE(operands), loom_make_named_attr_slice(NULL, 0), &lane_type,
+      1, &low_op));
+  *out_value = loom_value_slice_get(loom_low_op_results(low_op), 0);
+  return iree_ok_status();
+}
+
+static iree_status_t loom_amdgpu_emit_vgpr_cndmask_true_immediate(
+    loom_low_lower_context_t* context, const loom_op_t* source_op,
+    loom_value_id_t false_value, uint32_t true_value, loom_value_id_t condition,
+    loom_type_t lane_type, loom_value_id_t* out_value) {
+  *out_value = LOOM_VALUE_ID_INVALID;
+  loom_low_lower_resolved_descriptor_t descriptor = {0};
+  bool descriptor_present = false;
+  if (true_value <= 64) {
+    IREE_RETURN_IF_ERROR(loom_amdgpu_resolve_descriptor_ref_if_present(
+        context, LOOM_AMDGPU_DESCRIPTOR_REF_V_CNDMASK_B32_SRC1_INLINE,
+        &descriptor, &descriptor_present));
+    if (descriptor_present) {
+      loom_named_attr_t attrs[1] = {0};
+      iree_host_size_t attr_count = 0;
+      IREE_RETURN_IF_ERROR(loom_amdgpu_append_i64_attr(
+          context, IREE_SV("true_value"), true_value, attrs,
+          IREE_ARRAYSIZE(attrs), &attr_count));
+      const loom_value_id_t operands[] = {false_value, condition};
+      loom_op_t* low_op = NULL;
+      IREE_RETURN_IF_ERROR(loom_low_lower_emit_resolved_descriptor_op(
+          context, &descriptor, operands, IREE_ARRAYSIZE(operands),
+          loom_make_named_attr_slice(attrs, attr_count), &lane_type, 1,
+          /*tied_results=*/NULL, /*tied_result_count=*/0, source_op->location,
+          &low_op));
+      *out_value = loom_value_slice_get(loom_low_op_results(low_op), 0);
+      return iree_ok_status();
+    }
+  }
+
+  IREE_RETURN_IF_ERROR(loom_amdgpu_resolve_descriptor_ref_if_present(
+      context, LOOM_AMDGPU_DESCRIPTOR_REF_V_CNDMASK_B32_SRC1_LIT, &descriptor,
+      &descriptor_present));
+  if (descriptor_present) {
+    loom_named_attr_t attrs[1] = {0};
+    iree_host_size_t attr_count = 0;
+    IREE_RETURN_IF_ERROR(
+        loom_amdgpu_append_i64_attr(context, IREE_SV("imm32"), true_value,
+                                    attrs, IREE_ARRAYSIZE(attrs), &attr_count));
+    const loom_value_id_t operands[] = {false_value, condition};
+    loom_op_t* low_op = NULL;
+    IREE_RETURN_IF_ERROR(loom_low_lower_emit_resolved_descriptor_op(
+        context, &descriptor, operands, IREE_ARRAYSIZE(operands),
+        loom_make_named_attr_slice(attrs, attr_count), &lane_type, 1,
+        /*tied_results=*/NULL, /*tied_result_count=*/0, source_op->location,
+        &low_op));
+    *out_value = loom_value_slice_get(loom_low_op_results(low_op), 0);
+    return iree_ok_status();
+  }
+
+  loom_value_id_t true_register = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_const_u32(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_MOV_B32, true_value,
+      lane_type, &true_register));
+  return loom_amdgpu_emit_vgpr_cndmask(context, source_op, false_value,
+                                       true_register, condition, lane_type,
+                                       out_value);
+}
+
+static iree_status_t loom_amdgpu_emit_fp8_leading_index(
+    loom_low_lower_context_t* context, const loom_op_t* source_op,
+    const loom_amdgpu_fp8_decode_format_t* format, loom_value_id_t mantissa,
+    loom_type_t lane_type, loom_type_t mask_lane_type,
+    loom_value_id_t* out_value) {
+  *out_value = LOOM_VALUE_ID_INVALID;
+  loom_value_id_t leading_index = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_const_u32(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_MOV_B32, 0, lane_type,
+      &leading_index));
+  for (uint8_t i = 1; i < format->mantissa_bits; ++i) {
+    loom_value_id_t mask = LOOM_VALUE_ID_INVALID;
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary_immediate(
+        context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_AND_B32_LIT, mantissa,
+        UINT32_C(1) << i, lane_type, &mask));
+    loom_value_id_t has_bit = LOOM_VALUE_ID_INVALID;
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_compare_i32_immediate(
+        context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_NE_I32,
+        LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_NE_I32_SRC1_INLINE, mask, 0, lane_type,
+        mask_lane_type, &has_bit));
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_cndmask_true_immediate(
+        context, source_op, leading_index, i, has_bit, lane_type,
+        &leading_index));
+  }
+  *out_value = leading_index;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_amdgpu_emit_fp8_subnormal_bits(
+    loom_low_lower_context_t* context, const loom_op_t* source_op,
+    const loom_amdgpu_fp8_decode_format_t* format, loom_value_id_t sign_bits,
+    loom_value_id_t mantissa, loom_type_t lane_type, loom_type_t mask_lane_type,
+    loom_value_id_t* out_value) {
+  *out_value = LOOM_VALUE_ID_INVALID;
+  loom_value_id_t leading_index = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_fp8_leading_index(
+      context, source_op, format, mantissa, lane_type, mask_lane_type,
+      &leading_index));
+  loom_value_id_t exponent_bits = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary_immediate(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_ADD_U32_LIT,
+      leading_index, 128u - format->exponent_bias - format->mantissa_bits,
+      lane_type, &exponent_bits));
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_shift(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_LSHLREV_B32_LIT, 23,
+      exponent_bits, lane_type, &exponent_bits));
+
+  loom_value_id_t f32_mantissa_shift = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_const_u32(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_MOV_B32, 23, lane_type,
+      &f32_mantissa_shift));
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_SUB_U32,
+      f32_mantissa_shift, leading_index, lane_type, &f32_mantissa_shift));
+  loom_value_id_t fraction_bits = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_LSHLREV_B32,
+      f32_mantissa_shift, mantissa, lane_type, &fraction_bits));
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary_immediate(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_AND_B32_LIT,
+      fraction_bits, UINT32_C(0x007FFFFF), lane_type, &fraction_bits));
+
+  loom_value_id_t nonzero_bits = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_OR_B32, sign_bits,
+      exponent_bits, lane_type, &nonzero_bits));
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_OR_B32, nonzero_bits,
+      fraction_bits, lane_type, &nonzero_bits));
+  loom_value_id_t is_zero = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_compare_i32_immediate(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_EQ_I32,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_EQ_I32_SRC1_INLINE, mantissa, 0,
+      lane_type, mask_lane_type, &is_zero));
+  return loom_amdgpu_emit_vgpr_cndmask(context, source_op, nonzero_bits,
+                                       sign_bits, is_zero, lane_type,
+                                       out_value);
+}
+
+iree_status_t loom_amdgpu_emit_fp8_to_f32_lane(
+    loom_low_lower_context_t* context, const loom_op_t* source_op,
+    loom_value_id_t source_byte, loom_scalar_type_t source_element_type,
+    loom_type_t lane_type, loom_value_id_t* out_lane) {
+  *out_lane = LOOM_VALUE_ID_INVALID;
+  loom_amdgpu_fp8_decode_format_t format = {0};
+  if (!loom_amdgpu_fp8_decode_format_from_type(source_element_type, &format)) {
+    IREE_ASSERT_UNREACHABLE("selected AMDGPU FP8 decode source type");
+    IREE_BUILTIN_UNREACHABLE();
+  }
+
+  IREE_RETURN_IF_ERROR(loom_amdgpu_materialize_low_vgpr_b32(
+      context, source_op, source_byte, &source_byte));
+  loom_type_t mask_lane_type = loom_type_none();
+  IREE_RETURN_IF_ERROR(
+      loom_amdgpu_make_sgpr_range_type(context, 2, &mask_lane_type));
+
+  const uint32_t sign_shift = format.exponent_bits + format.mantissa_bits;
+  const uint32_t sign_mask = UINT32_C(1) << sign_shift;
+  const uint32_t mantissa_mask = (UINT32_C(1) << format.mantissa_bits) - 1u;
+  const uint32_t exponent_mask = ((UINT32_C(1) << format.exponent_bits) - 1u)
+                                 << format.mantissa_bits;
+  const uint32_t exponent_all_ones = (UINT32_C(1) << format.exponent_bits) - 1u;
+
+  loom_value_id_t source_i32 = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary_immediate(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_AND_B32_LIT, source_byte,
+      UINT32_C(0xFF), lane_type, &source_i32));
+
+  loom_value_id_t sign_bits = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary_immediate(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_AND_B32_LIT, source_i32,
+      sign_mask, lane_type, &sign_bits));
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_shift(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_LSHLREV_B32_LIT,
+      31u - sign_shift, sign_bits, lane_type, &sign_bits));
+
+  loom_value_id_t exponent = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary_immediate(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_AND_B32_LIT, source_i32,
+      exponent_mask, lane_type, &exponent));
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_shift(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_LSHRREV_B32_LIT,
+      format.mantissa_bits, exponent, lane_type, &exponent));
+
+  loom_value_id_t mantissa = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary_immediate(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_AND_B32_LIT, source_i32,
+      mantissa_mask, lane_type, &mantissa));
+
+  loom_value_id_t normal_exponent = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary_immediate(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_ADD_U32_LIT, exponent,
+      127u - format.exponent_bias, lane_type, &normal_exponent));
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_shift(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_LSHLREV_B32_LIT, 23,
+      normal_exponent, lane_type, &normal_exponent));
+  loom_value_id_t normal_mantissa = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_shift(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_LSHLREV_B32_LIT,
+      23u - format.mantissa_bits, mantissa, lane_type, &normal_mantissa));
+  loom_value_id_t normal_bits = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_OR_B32, sign_bits,
+      normal_exponent, lane_type, &normal_bits));
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_OR_B32, normal_bits,
+      normal_mantissa, lane_type, &normal_bits));
+
+  loom_value_id_t subnormal_bits = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_fp8_subnormal_bits(
+      context, source_op, &format, sign_bits, mantissa, lane_type,
+      mask_lane_type, &subnormal_bits));
+  loom_value_id_t exponent_is_zero = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_compare_i32_immediate(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_EQ_I32,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_EQ_I32_SRC1_INLINE, exponent, 0,
+      lane_type, mask_lane_type, &exponent_is_zero));
+  loom_value_id_t finite_bits = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_cndmask(
+      context, source_op, normal_bits, subnormal_bits, exponent_is_zero,
+      lane_type, &finite_bits));
+
+  loom_value_id_t exponent_is_top = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_compare_i32_immediate(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_EQ_I32,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_EQ_I32_SRC1_INLINE, exponent,
+      exponent_all_ones, lane_type, mask_lane_type, &exponent_is_top));
+  if (format.special_policy == LOOM_AMDGPU_FP8_SPECIAL_POLICY_IEEE) {
+    loom_value_id_t infinity_bits = LOOM_VALUE_ID_INVALID;
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary_immediate(
+        context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_OR_B32_LIT, sign_bits,
+        UINT32_C(0x7F800000), lane_type, &infinity_bits));
+    loom_value_id_t mantissa_is_zero = LOOM_VALUE_ID_INVALID;
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_compare_i32_immediate(
+        context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_EQ_I32,
+        LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_EQ_I32_SRC1_INLINE, mantissa, 0,
+        lane_type, mask_lane_type, &mantissa_is_zero));
+    loom_value_id_t quiet_nan_bits = LOOM_VALUE_ID_INVALID;
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_const_u32(
+        context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_MOV_B32,
+        UINT32_C(0x7FC00000), lane_type, &quiet_nan_bits));
+    loom_value_id_t top_bits = LOOM_VALUE_ID_INVALID;
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_cndmask(
+        context, source_op, quiet_nan_bits, infinity_bits, mantissa_is_zero,
+        lane_type, &top_bits));
+    return loom_amdgpu_emit_vgpr_cndmask(context, source_op, finite_bits,
+                                         top_bits, exponent_is_top, lane_type,
+                                         out_lane);
+  }
+
+  loom_value_id_t mantissa_is_nan = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_compare_i32_immediate(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_EQ_I32,
+      LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_EQ_I32_SRC1_INLINE, mantissa,
+      mantissa_mask, lane_type, mask_lane_type, &mantissa_is_nan));
+  loom_value_id_t use_nan = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_sgpr_binary(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_S_AND_B64, exponent_is_top,
+      mantissa_is_nan, mask_lane_type, &use_nan));
+  return loom_amdgpu_emit_vgpr_cndmask_true_immediate(
+      context, source_op, finite_bits, UINT32_C(0x7FC00000), use_nan, lane_type,
+      out_lane);
+}
+
 iree_status_t loom_amdgpu_emit_f32_to_bf16_lane(
     loom_low_lower_context_t* context, const loom_op_t* source_op,
     loom_value_id_t source_lane, loom_type_t lane_type,

--- a/loom/src/loom/target/arch/amdgpu/planning/wait_plan.c
+++ b/loom/src/loom/target/arch/amdgpu/planning/wait_plan.c
@@ -49,6 +49,8 @@ typedef struct loom_amdgpu_wait_node_state_t {
   uint32_t workgroup_barrier_counter_mask;
   // Whether this structural node forwards wait dependencies to its users.
   bool forwards_dependencies;
+  // Whether the node has any wait-counter effect.
+  bool has_counter_effect;
   // Whether the node has a counter effect without a concrete counter id.
   bool has_generic_counter_effect;
   // Whether a memory read effect uses the target's default read counter.
@@ -262,6 +264,109 @@ static uint32_t loom_amdgpu_wait_counter_mask_from_slot(uint32_t slot) {
 
 static uint32_t loom_amdgpu_wait_counter_slot(uint16_t counter_id) {
   return counter_id - 1;
+}
+
+static uint32_t loom_amdgpu_wait_counter_mask_from_immediate_encoding_id(
+    uint16_t encoding_id) {
+  switch (encoding_id) {
+    case LOOM_AMDGPU_IMMEDIATE_ENCODING_ID_WAIT_COUNTER_VMEM:
+      return LOOM_AMDGPU_WAIT_COUNTER_MASK_VMEM;
+    case LOOM_AMDGPU_IMMEDIATE_ENCODING_ID_WAIT_COUNTER_LGKM:
+      return LOOM_AMDGPU_WAIT_COUNTER_MASK_LDS |
+             LOOM_AMDGPU_WAIT_COUNTER_MASK_SMEM;
+    case LOOM_AMDGPU_IMMEDIATE_ENCODING_ID_WAIT_COUNTER_VMEM_LOAD:
+      return LOOM_AMDGPU_WAIT_COUNTER_MASK_VMEM_LOAD;
+    case LOOM_AMDGPU_IMMEDIATE_ENCODING_ID_WAIT_COUNTER_VMEM_STORE:
+      return LOOM_AMDGPU_WAIT_COUNTER_MASK_VMEM_STORE;
+    case LOOM_AMDGPU_IMMEDIATE_ENCODING_ID_WAIT_COUNTER_LDS:
+      return LOOM_AMDGPU_WAIT_COUNTER_MASK_LDS;
+    case LOOM_AMDGPU_IMMEDIATE_ENCODING_ID_WAIT_COUNTER_SMEM:
+      return LOOM_AMDGPU_WAIT_COUNTER_MASK_SMEM;
+    case LOOM_AMDGPU_IMMEDIATE_ENCODING_ID_WAIT_COUNTER_ALU:
+      return LOOM_AMDGPU_WAIT_COUNTER_MASK_ALU;
+    default:
+      return 0;
+  }
+}
+
+static bool loom_amdgpu_wait_plan_immediate_has_default(
+    const loom_low_immediate_t* immediate) {
+  return iree_any_bit_set(immediate->flags,
+                          LOOM_LOW_IMMEDIATE_FLAG_DEFAULT_VALUE);
+}
+
+static const loom_named_attr_t* loom_amdgpu_wait_plan_find_attr(
+    loom_named_attr_slice_t attrs, loom_string_id_t name_id) {
+  for (iree_host_size_t i = 0; i < attrs.count; ++i) {
+    if (attrs.entries[i].name_id == name_id) return &attrs.entries[i];
+  }
+  return NULL;
+}
+
+static loom_named_attr_slice_t loom_amdgpu_wait_plan_node_attrs(
+    const loom_op_t* op) {
+  if (loom_low_op_isa(op)) return loom_low_op_attrs(op);
+  if (loom_low_const_isa(op)) return loom_low_const_attrs(op);
+  return loom_named_attr_slice_empty();
+}
+
+static int64_t loom_amdgpu_wait_plan_read_i64_immediate(
+    const loom_low_schedule_table_t* schedule,
+    const loom_low_immediate_t* immediate, const loom_op_t* op) {
+  const loom_low_descriptor_set_t* descriptor_set =
+      schedule->target.descriptor_set;
+  const iree_string_view_t immediate_name = loom_low_descriptor_set_string(
+      descriptor_set, immediate->field_name_string_offset);
+  const loom_string_id_t immediate_name_id =
+      loom_module_lookup_string(schedule->module, immediate_name);
+  if (immediate_name_id != LOOM_STRING_ID_INVALID) {
+    const loom_named_attr_t* attr = loom_amdgpu_wait_plan_find_attr(
+        loom_amdgpu_wait_plan_node_attrs(op), immediate_name_id);
+    if (attr != NULL) {
+      if (attr->value.kind != LOOM_ATTR_I64) {
+        IREE_ASSERT_UNREACHABLE("verified low wait immediate type");
+        IREE_BUILTIN_UNREACHABLE();
+      }
+      return loom_attr_as_i64(attr->value);
+    }
+  }
+  if (loom_amdgpu_wait_plan_immediate_has_default(immediate)) {
+    return immediate->default_value;
+  }
+  IREE_ASSERT_UNREACHABLE("verified low wait immediate presence");
+  IREE_BUILTIN_UNREACHABLE();
+}
+
+static void loom_amdgpu_wait_plan_counter_immediate_mask(
+    const loom_amdgpu_wait_plan_builder_t* builder, uint32_t node_index,
+    uint32_t* out_counter_mask, bool* out_has_counter_immediate) {
+  *out_counter_mask = 0;
+  *out_has_counter_immediate = false;
+  const loom_low_schedule_table_t* schedule = builder->schedule;
+  const loom_low_schedule_node_t* node = &schedule->nodes[node_index];
+  if (node->descriptor == NULL) return;
+
+  const loom_low_descriptor_set_t* descriptor_set =
+      schedule->target.descriptor_set;
+  const loom_amdgpu_wait_node_state_t* node_state =
+      &builder->node_states[node_index];
+  for (uint16_t i = 0; i < node->descriptor->immediate_count; ++i) {
+    const loom_low_immediate_t* immediate =
+        &descriptor_set->immediates[node->descriptor->immediate_start + i];
+    const uint32_t counter_mask =
+        loom_amdgpu_wait_counter_mask_from_immediate_encoding_id(
+            immediate->encoding_id) &
+        node_state->hazard_counter_mask;
+    if (counter_mask == 0) continue;
+    *out_has_counter_immediate = true;
+
+    const int64_t immediate_value =
+        loom_amdgpu_wait_plan_read_i64_immediate(schedule, immediate, node->op);
+    if (immediate_value >= 0 &&
+        (uint64_t)immediate_value < immediate->unsigned_max) {
+      *out_counter_mask |= counter_mask;
+    }
+  }
 }
 
 static uint32_t loom_amdgpu_wait_plan_saturating_add_u32(uint32_t lhs,
@@ -1050,6 +1155,7 @@ static iree_status_t loom_amdgpu_wait_plan_classify_effects(
         }
         break;
       case LOOM_LOW_EFFECT_KIND_COUNTER: {
+        node_state->has_counter_effect = true;
         if (effect->counter_id == LOOM_AMDGPU_WAIT_COUNTER_NONE) {
           node_state->has_generic_counter_effect = true;
           break;
@@ -1080,12 +1186,15 @@ static iree_status_t loom_amdgpu_wait_plan_finish_node_classification(
     if (node_state->has_generic_counter_effect) {
       node_state->explicit_wait_counter_mask |= node_state->hazard_counter_mask;
     }
-    if (node_state->has_generic_counter_effect &&
-        node_state->explicit_wait_counter_mask == 0) {
-      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "AMDGPU generic counter-effect node %zu has no "
-                              "wait-counter hazard rows",
-                              i);
+    if (node_state->has_counter_effect) {
+      uint32_t counter_immediate_mask = 0;
+      bool has_counter_immediate = false;
+      loom_amdgpu_wait_plan_counter_immediate_mask(builder, (uint32_t)i,
+                                                   &counter_immediate_mask,
+                                                   &has_counter_immediate);
+      if (has_counter_immediate) {
+        node_state->explicit_wait_counter_mask &= counter_immediate_mask;
+      }
     }
     if (node_state->explicit_wait_counter_mask != 0 &&
         node_state->hazard_counter_mask == 0) {

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma.loom-test
@@ -509,6 +509,722 @@ low.kernel.def target(@target) workgroup_size(32, 1, 1) @bf16_wmmar3_fragment_me
 
 amdgpu.target<gfx1100> @target
 
+kernel.def target(@target) @bf16_wmmar3_fp8_rhs_fragment_memory() {
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 32 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
+} launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %out_buffer: buffer) {
+  %base = index.constant 0 : offset
+  %m = index.constant 16 : index
+  %n = index.constant 16 : index
+  %k = index.constant 16 : index
+  %zero = vector.constant 0.0 : vector<8xf32>
+  %rhs_layout = encoding.layout.strided [1, 16] : encoding<layout>
+  %lhs_view = buffer.view %lhs_buffer[%base] : buffer -> view<16x16xbf16, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%base] : buffer -> view<16x16xf8E4M3, %rhs_layout>
+  %out_view = buffer.view %out_buffer[%base] : buffer -> view<16x16xbf16, #dense>
+  %lhs = vector.fragment.load<lhs> %lhs_view[0, 0] shape [%m, %k] : view<16x16xbf16, #dense> -> vector<16xbf16>
+  %rhs = vector.fragment.load<rhs> %rhs_view[0, 0] shape [%k, %n] : view<16x16xf8E4M3, %rhs_layout> -> vector<16xbf16>
+  %init = vector.fragment<init> %zero shape [%m, %n] : vector<8xf32>
+  %result = vector.mma %lhs, %rhs, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
+  vector.fragment.store<result> %result, %out_view[0, 0] shape [%m, %n] : vector<8xf32>, view<16x16xbf16, #dense>
+  kernel.return
+}
+
+// ----
+low.kernel.def target(@target) workgroup_size(32, 1, 1) @bf16_wmmar3_fp8_rhs_fragment_memory() asm<amdgpu.rdna3.core> {
+  %45 = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
+  %lhs_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 512} : reg<amdgpu.sgpr x2>
+  %rhs_view = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %out_view = resource<hal_binding> {index = 2, source_type = hal.buffer, extent = 512} : reg<amdgpu.sgpr x2>
+  %49 = v_mov_b32 0
+  %init = concat(%49, %49, %49, %49, %49, %49, %49, %49) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x8>
+  %58 = v_and_b32_src0_inline %45, 15
+  %60 = v_lshlrev_b32_src0_inline %58, 5
+  %61 = global_load_b128_saddr %60, %lhs_view
+  %62 = global_load_b128_saddr %60, %lhs_view {offset = 16}
+  %lhs = concat(%61, %62) : (reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>) -> reg<amdgpu.vgpr x8>
+  %66 = v_lshlrev_b32_src0_inline %58, 4
+  %67 = global_load_i8_saddr %66, %rhs_view
+  %68 = v_and_b32_lit %67, 255
+  %69 = v_and_b32_lit %68, 128
+  %70 = v_lshlrev_b32_src0_inline %69, 24
+  %71 = v_and_b32_lit %68, 120
+  %72 = v_lshrrev_b32_src0_inline %71, 3
+  %73 = v_and_b32_src0_inline %68, 7
+  %74 = v_add_u32_lit %72, 120
+  %75 = v_lshlrev_b32_src0_inline %74, 23
+  %76 = v_lshlrev_b32_src0_inline %73, 20
+  %77 = v_or_b32 %70, %75
+  %78 = v_or_b32 %77, %76
+  %80 = v_and_b32_src0_inline %73, 2
+  %81 = v_cmp_ne_i32_src1_inline %80 {rhs = 0}
+  %82 = v_cndmask_b32_src1_inline %49, %81 {true_value = 1}
+  %83 = v_and_b32_src0_inline %73, 4
+  %84 = v_cmp_ne_i32_src1_inline %83 {rhs = 0}
+  %85 = v_cndmask_b32_src1_inline %82, %84 {true_value = 2}
+  %86 = v_add_u32_lit %85, 118
+  %87 = v_lshlrev_b32_src0_inline %86, 23
+  %88 = v_mov_b32 23
+  %89 = v_sub_nc_u32 %88, %85
+  %90 = v_lshlrev_b32 %89, %73
+  %91 = v_and_b32_lit %90, 8388607
+  %92 = v_or_b32 %70, %87
+  %93 = v_or_b32 %92, %91
+  %94 = v_cmp_eq_i32_src1_inline %73 {rhs = 0}
+  %95 = v_cndmask_b32 %93, %70, %94
+  %96 = v_cmp_eq_i32_src1_inline %72 {rhs = 0}
+  %97 = v_cndmask_b32 %78, %95, %96
+  %98 = v_cmp_eq_i32_src1_inline %72 {rhs = 15}
+  %99 = v_cmp_eq_i32_src1_inline %73 {rhs = 7}
+  %100 = s_and_b64 %98, %99
+  %101 = v_cndmask_b32_src1_lit %97, %100, 2143289344
+  %102 = global_load_i8_saddr %66, %rhs_view {offset = 1}
+  %103 = v_and_b32_lit %102, 255
+  %104 = v_and_b32_lit %103, 128
+  %105 = v_lshlrev_b32_src0_inline %104, 24
+  %106 = v_and_b32_lit %103, 120
+  %107 = v_lshrrev_b32_src0_inline %106, 3
+  %108 = v_and_b32_src0_inline %103, 7
+  %109 = v_add_u32_lit %107, 120
+  %110 = v_lshlrev_b32_src0_inline %109, 23
+  %111 = v_lshlrev_b32_src0_inline %108, 20
+  %112 = v_or_b32 %105, %110
+  %113 = v_or_b32 %112, %111
+  %115 = v_and_b32_src0_inline %108, 2
+  %116 = v_cmp_ne_i32_src1_inline %115 {rhs = 0}
+  %117 = v_cndmask_b32_src1_inline %49, %116 {true_value = 1}
+  %118 = v_and_b32_src0_inline %108, 4
+  %119 = v_cmp_ne_i32_src1_inline %118 {rhs = 0}
+  %120 = v_cndmask_b32_src1_inline %117, %119 {true_value = 2}
+  %121 = v_add_u32_lit %120, 118
+  %122 = v_lshlrev_b32_src0_inline %121, 23
+  %124 = v_sub_nc_u32 %88, %120
+  %125 = v_lshlrev_b32 %124, %108
+  %126 = v_and_b32_lit %125, 8388607
+  %127 = v_or_b32 %105, %122
+  %128 = v_or_b32 %127, %126
+  %129 = v_cmp_eq_i32_src1_inline %108 {rhs = 0}
+  %130 = v_cndmask_b32 %128, %105, %129
+  %131 = v_cmp_eq_i32_src1_inline %107 {rhs = 0}
+  %132 = v_cndmask_b32 %113, %130, %131
+  %133 = v_cmp_eq_i32_src1_inline %107 {rhs = 15}
+  %134 = v_cmp_eq_i32_src1_inline %108 {rhs = 7}
+  %135 = s_and_b64 %133, %134
+  %136 = v_cndmask_b32_src1_lit %132, %135, 2143289344
+  %137 = v_lshrrev_b32_src0_inline %101, 16
+  %138 = v_and_b32_src0_inline %137, 1
+  %139 = v_add_u32_lit %138, 32767
+  %140 = v_add_u32 %101, %139
+  %141 = v_lshrrev_b32_src0_inline %140, 16
+  %142 = v_lshrrev_b32_src0_inline %136, 16
+  %143 = v_and_b32_src0_inline %142, 1
+  %144 = v_add_u32_lit %143, 32767
+  %145 = v_add_u32 %136, %144
+  %146 = v_lshrrev_b32_src0_inline %145, 16
+  %147 = v_cvt_pk_u16_u32 %141, %146
+  %148 = global_load_i8_saddr %66, %rhs_view {offset = 2}
+  %149 = v_and_b32_lit %148, 255
+  %150 = v_and_b32_lit %149, 128
+  %151 = v_lshlrev_b32_src0_inline %150, 24
+  %152 = v_and_b32_lit %149, 120
+  %153 = v_lshrrev_b32_src0_inline %152, 3
+  %154 = v_and_b32_src0_inline %149, 7
+  %155 = v_add_u32_lit %153, 120
+  %156 = v_lshlrev_b32_src0_inline %155, 23
+  %157 = v_lshlrev_b32_src0_inline %154, 20
+  %158 = v_or_b32 %151, %156
+  %159 = v_or_b32 %158, %157
+  %161 = v_and_b32_src0_inline %154, 2
+  %162 = v_cmp_ne_i32_src1_inline %161 {rhs = 0}
+  %163 = v_cndmask_b32_src1_inline %49, %162 {true_value = 1}
+  %164 = v_and_b32_src0_inline %154, 4
+  %165 = v_cmp_ne_i32_src1_inline %164 {rhs = 0}
+  %166 = v_cndmask_b32_src1_inline %163, %165 {true_value = 2}
+  %167 = v_add_u32_lit %166, 118
+  %168 = v_lshlrev_b32_src0_inline %167, 23
+  %170 = v_sub_nc_u32 %88, %166
+  %171 = v_lshlrev_b32 %170, %154
+  %172 = v_and_b32_lit %171, 8388607
+  %173 = v_or_b32 %151, %168
+  %174 = v_or_b32 %173, %172
+  %175 = v_cmp_eq_i32_src1_inline %154 {rhs = 0}
+  %176 = v_cndmask_b32 %174, %151, %175
+  %177 = v_cmp_eq_i32_src1_inline %153 {rhs = 0}
+  %178 = v_cndmask_b32 %159, %176, %177
+  %179 = v_cmp_eq_i32_src1_inline %153 {rhs = 15}
+  %180 = v_cmp_eq_i32_src1_inline %154 {rhs = 7}
+  %181 = s_and_b64 %179, %180
+  %182 = v_cndmask_b32_src1_lit %178, %181, 2143289344
+  %183 = global_load_i8_saddr %66, %rhs_view {offset = 3}
+  %184 = v_and_b32_lit %183, 255
+  %185 = v_and_b32_lit %184, 128
+  %186 = v_lshlrev_b32_src0_inline %185, 24
+  %187 = v_and_b32_lit %184, 120
+  %188 = v_lshrrev_b32_src0_inline %187, 3
+  %189 = v_and_b32_src0_inline %184, 7
+  %190 = v_add_u32_lit %188, 120
+  %191 = v_lshlrev_b32_src0_inline %190, 23
+  %192 = v_lshlrev_b32_src0_inline %189, 20
+  %193 = v_or_b32 %186, %191
+  %194 = v_or_b32 %193, %192
+  %196 = v_and_b32_src0_inline %189, 2
+  %197 = v_cmp_ne_i32_src1_inline %196 {rhs = 0}
+  %198 = v_cndmask_b32_src1_inline %49, %197 {true_value = 1}
+  %199 = v_and_b32_src0_inline %189, 4
+  %200 = v_cmp_ne_i32_src1_inline %199 {rhs = 0}
+  %201 = v_cndmask_b32_src1_inline %198, %200 {true_value = 2}
+  %202 = v_add_u32_lit %201, 118
+  %203 = v_lshlrev_b32_src0_inline %202, 23
+  %205 = v_sub_nc_u32 %88, %201
+  %206 = v_lshlrev_b32 %205, %189
+  %207 = v_and_b32_lit %206, 8388607
+  %208 = v_or_b32 %186, %203
+  %209 = v_or_b32 %208, %207
+  %210 = v_cmp_eq_i32_src1_inline %189 {rhs = 0}
+  %211 = v_cndmask_b32 %209, %186, %210
+  %212 = v_cmp_eq_i32_src1_inline %188 {rhs = 0}
+  %213 = v_cndmask_b32 %194, %211, %212
+  %214 = v_cmp_eq_i32_src1_inline %188 {rhs = 15}
+  %215 = v_cmp_eq_i32_src1_inline %189 {rhs = 7}
+  %216 = s_and_b64 %214, %215
+  %217 = v_cndmask_b32_src1_lit %213, %216, 2143289344
+  %218 = v_lshrrev_b32_src0_inline %182, 16
+  %219 = v_and_b32_src0_inline %218, 1
+  %220 = v_add_u32_lit %219, 32767
+  %221 = v_add_u32 %182, %220
+  %222 = v_lshrrev_b32_src0_inline %221, 16
+  %223 = v_lshrrev_b32_src0_inline %217, 16
+  %224 = v_and_b32_src0_inline %223, 1
+  %225 = v_add_u32_lit %224, 32767
+  %226 = v_add_u32 %217, %225
+  %227 = v_lshrrev_b32_src0_inline %226, 16
+  %228 = v_cvt_pk_u16_u32 %222, %227
+  %229 = global_load_i8_saddr %66, %rhs_view {offset = 4}
+  %230 = v_and_b32_lit %229, 255
+  %231 = v_and_b32_lit %230, 128
+  %232 = v_lshlrev_b32_src0_inline %231, 24
+  %233 = v_and_b32_lit %230, 120
+  %234 = v_lshrrev_b32_src0_inline %233, 3
+  %235 = v_and_b32_src0_inline %230, 7
+  %236 = v_add_u32_lit %234, 120
+  %237 = v_lshlrev_b32_src0_inline %236, 23
+  %238 = v_lshlrev_b32_src0_inline %235, 20
+  %239 = v_or_b32 %232, %237
+  %240 = v_or_b32 %239, %238
+  %242 = v_and_b32_src0_inline %235, 2
+  %243 = v_cmp_ne_i32_src1_inline %242 {rhs = 0}
+  %244 = v_cndmask_b32_src1_inline %49, %243 {true_value = 1}
+  %245 = v_and_b32_src0_inline %235, 4
+  %246 = v_cmp_ne_i32_src1_inline %245 {rhs = 0}
+  %247 = v_cndmask_b32_src1_inline %244, %246 {true_value = 2}
+  %248 = v_add_u32_lit %247, 118
+  %249 = v_lshlrev_b32_src0_inline %248, 23
+  %251 = v_sub_nc_u32 %88, %247
+  %252 = v_lshlrev_b32 %251, %235
+  %253 = v_and_b32_lit %252, 8388607
+  %254 = v_or_b32 %232, %249
+  %255 = v_or_b32 %254, %253
+  %256 = v_cmp_eq_i32_src1_inline %235 {rhs = 0}
+  %257 = v_cndmask_b32 %255, %232, %256
+  %258 = v_cmp_eq_i32_src1_inline %234 {rhs = 0}
+  %259 = v_cndmask_b32 %240, %257, %258
+  %260 = v_cmp_eq_i32_src1_inline %234 {rhs = 15}
+  %261 = v_cmp_eq_i32_src1_inline %235 {rhs = 7}
+  %262 = s_and_b64 %260, %261
+  %263 = v_cndmask_b32_src1_lit %259, %262, 2143289344
+  %264 = global_load_i8_saddr %66, %rhs_view {offset = 5}
+  %265 = v_and_b32_lit %264, 255
+  %266 = v_and_b32_lit %265, 128
+  %267 = v_lshlrev_b32_src0_inline %266, 24
+  %268 = v_and_b32_lit %265, 120
+  %269 = v_lshrrev_b32_src0_inline %268, 3
+  %270 = v_and_b32_src0_inline %265, 7
+  %271 = v_add_u32_lit %269, 120
+  %272 = v_lshlrev_b32_src0_inline %271, 23
+  %273 = v_lshlrev_b32_src0_inline %270, 20
+  %274 = v_or_b32 %267, %272
+  %275 = v_or_b32 %274, %273
+  %277 = v_and_b32_src0_inline %270, 2
+  %278 = v_cmp_ne_i32_src1_inline %277 {rhs = 0}
+  %279 = v_cndmask_b32_src1_inline %49, %278 {true_value = 1}
+  %280 = v_and_b32_src0_inline %270, 4
+  %281 = v_cmp_ne_i32_src1_inline %280 {rhs = 0}
+  %282 = v_cndmask_b32_src1_inline %279, %281 {true_value = 2}
+  %283 = v_add_u32_lit %282, 118
+  %284 = v_lshlrev_b32_src0_inline %283, 23
+  %286 = v_sub_nc_u32 %88, %282
+  %287 = v_lshlrev_b32 %286, %270
+  %288 = v_and_b32_lit %287, 8388607
+  %289 = v_or_b32 %267, %284
+  %290 = v_or_b32 %289, %288
+  %291 = v_cmp_eq_i32_src1_inline %270 {rhs = 0}
+  %292 = v_cndmask_b32 %290, %267, %291
+  %293 = v_cmp_eq_i32_src1_inline %269 {rhs = 0}
+  %294 = v_cndmask_b32 %275, %292, %293
+  %295 = v_cmp_eq_i32_src1_inline %269 {rhs = 15}
+  %296 = v_cmp_eq_i32_src1_inline %270 {rhs = 7}
+  %297 = s_and_b64 %295, %296
+  %298 = v_cndmask_b32_src1_lit %294, %297, 2143289344
+  %299 = v_lshrrev_b32_src0_inline %263, 16
+  %300 = v_and_b32_src0_inline %299, 1
+  %301 = v_add_u32_lit %300, 32767
+  %302 = v_add_u32 %263, %301
+  %303 = v_lshrrev_b32_src0_inline %302, 16
+  %304 = v_lshrrev_b32_src0_inline %298, 16
+  %305 = v_and_b32_src0_inline %304, 1
+  %306 = v_add_u32_lit %305, 32767
+  %307 = v_add_u32 %298, %306
+  %308 = v_lshrrev_b32_src0_inline %307, 16
+  %309 = v_cvt_pk_u16_u32 %303, %308
+  %310 = global_load_i8_saddr %66, %rhs_view {offset = 6}
+  %311 = v_and_b32_lit %310, 255
+  %312 = v_and_b32_lit %311, 128
+  %313 = v_lshlrev_b32_src0_inline %312, 24
+  %314 = v_and_b32_lit %311, 120
+  %315 = v_lshrrev_b32_src0_inline %314, 3
+  %316 = v_and_b32_src0_inline %311, 7
+  %317 = v_add_u32_lit %315, 120
+  %318 = v_lshlrev_b32_src0_inline %317, 23
+  %319 = v_lshlrev_b32_src0_inline %316, 20
+  %320 = v_or_b32 %313, %318
+  %321 = v_or_b32 %320, %319
+  %323 = v_and_b32_src0_inline %316, 2
+  %324 = v_cmp_ne_i32_src1_inline %323 {rhs = 0}
+  %325 = v_cndmask_b32_src1_inline %49, %324 {true_value = 1}
+  %326 = v_and_b32_src0_inline %316, 4
+  %327 = v_cmp_ne_i32_src1_inline %326 {rhs = 0}
+  %328 = v_cndmask_b32_src1_inline %325, %327 {true_value = 2}
+  %329 = v_add_u32_lit %328, 118
+  %330 = v_lshlrev_b32_src0_inline %329, 23
+  %332 = v_sub_nc_u32 %88, %328
+  %333 = v_lshlrev_b32 %332, %316
+  %334 = v_and_b32_lit %333, 8388607
+  %335 = v_or_b32 %313, %330
+  %336 = v_or_b32 %335, %334
+  %337 = v_cmp_eq_i32_src1_inline %316 {rhs = 0}
+  %338 = v_cndmask_b32 %336, %313, %337
+  %339 = v_cmp_eq_i32_src1_inline %315 {rhs = 0}
+  %340 = v_cndmask_b32 %321, %338, %339
+  %341 = v_cmp_eq_i32_src1_inline %315 {rhs = 15}
+  %342 = v_cmp_eq_i32_src1_inline %316 {rhs = 7}
+  %343 = s_and_b64 %341, %342
+  %344 = v_cndmask_b32_src1_lit %340, %343, 2143289344
+  %345 = global_load_i8_saddr %66, %rhs_view {offset = 7}
+  %346 = v_and_b32_lit %345, 255
+  %347 = v_and_b32_lit %346, 128
+  %348 = v_lshlrev_b32_src0_inline %347, 24
+  %349 = v_and_b32_lit %346, 120
+  %350 = v_lshrrev_b32_src0_inline %349, 3
+  %351 = v_and_b32_src0_inline %346, 7
+  %352 = v_add_u32_lit %350, 120
+  %353 = v_lshlrev_b32_src0_inline %352, 23
+  %354 = v_lshlrev_b32_src0_inline %351, 20
+  %355 = v_or_b32 %348, %353
+  %356 = v_or_b32 %355, %354
+  %358 = v_and_b32_src0_inline %351, 2
+  %359 = v_cmp_ne_i32_src1_inline %358 {rhs = 0}
+  %360 = v_cndmask_b32_src1_inline %49, %359 {true_value = 1}
+  %361 = v_and_b32_src0_inline %351, 4
+  %362 = v_cmp_ne_i32_src1_inline %361 {rhs = 0}
+  %363 = v_cndmask_b32_src1_inline %360, %362 {true_value = 2}
+  %364 = v_add_u32_lit %363, 118
+  %365 = v_lshlrev_b32_src0_inline %364, 23
+  %367 = v_sub_nc_u32 %88, %363
+  %368 = v_lshlrev_b32 %367, %351
+  %369 = v_and_b32_lit %368, 8388607
+  %370 = v_or_b32 %348, %365
+  %371 = v_or_b32 %370, %369
+  %372 = v_cmp_eq_i32_src1_inline %351 {rhs = 0}
+  %373 = v_cndmask_b32 %371, %348, %372
+  %374 = v_cmp_eq_i32_src1_inline %350 {rhs = 0}
+  %375 = v_cndmask_b32 %356, %373, %374
+  %376 = v_cmp_eq_i32_src1_inline %350 {rhs = 15}
+  %377 = v_cmp_eq_i32_src1_inline %351 {rhs = 7}
+  %378 = s_and_b64 %376, %377
+  %379 = v_cndmask_b32_src1_lit %375, %378, 2143289344
+  %380 = v_lshrrev_b32_src0_inline %344, 16
+  %381 = v_and_b32_src0_inline %380, 1
+  %382 = v_add_u32_lit %381, 32767
+  %383 = v_add_u32 %344, %382
+  %384 = v_lshrrev_b32_src0_inline %383, 16
+  %385 = v_lshrrev_b32_src0_inline %379, 16
+  %386 = v_and_b32_src0_inline %385, 1
+  %387 = v_add_u32_lit %386, 32767
+  %388 = v_add_u32 %379, %387
+  %389 = v_lshrrev_b32_src0_inline %388, 16
+  %390 = v_cvt_pk_u16_u32 %384, %389
+  %391 = global_load_i8_saddr %66, %rhs_view {offset = 8}
+  %392 = v_and_b32_lit %391, 255
+  %393 = v_and_b32_lit %392, 128
+  %394 = v_lshlrev_b32_src0_inline %393, 24
+  %395 = v_and_b32_lit %392, 120
+  %396 = v_lshrrev_b32_src0_inline %395, 3
+  %397 = v_and_b32_src0_inline %392, 7
+  %398 = v_add_u32_lit %396, 120
+  %399 = v_lshlrev_b32_src0_inline %398, 23
+  %400 = v_lshlrev_b32_src0_inline %397, 20
+  %401 = v_or_b32 %394, %399
+  %402 = v_or_b32 %401, %400
+  %404 = v_and_b32_src0_inline %397, 2
+  %405 = v_cmp_ne_i32_src1_inline %404 {rhs = 0}
+  %406 = v_cndmask_b32_src1_inline %49, %405 {true_value = 1}
+  %407 = v_and_b32_src0_inline %397, 4
+  %408 = v_cmp_ne_i32_src1_inline %407 {rhs = 0}
+  %409 = v_cndmask_b32_src1_inline %406, %408 {true_value = 2}
+  %410 = v_add_u32_lit %409, 118
+  %411 = v_lshlrev_b32_src0_inline %410, 23
+  %413 = v_sub_nc_u32 %88, %409
+  %414 = v_lshlrev_b32 %413, %397
+  %415 = v_and_b32_lit %414, 8388607
+  %416 = v_or_b32 %394, %411
+  %417 = v_or_b32 %416, %415
+  %418 = v_cmp_eq_i32_src1_inline %397 {rhs = 0}
+  %419 = v_cndmask_b32 %417, %394, %418
+  %420 = v_cmp_eq_i32_src1_inline %396 {rhs = 0}
+  %421 = v_cndmask_b32 %402, %419, %420
+  %422 = v_cmp_eq_i32_src1_inline %396 {rhs = 15}
+  %423 = v_cmp_eq_i32_src1_inline %397 {rhs = 7}
+  %424 = s_and_b64 %422, %423
+  %425 = v_cndmask_b32_src1_lit %421, %424, 2143289344
+  %426 = global_load_i8_saddr %66, %rhs_view {offset = 9}
+  %427 = v_and_b32_lit %426, 255
+  %428 = v_and_b32_lit %427, 128
+  %429 = v_lshlrev_b32_src0_inline %428, 24
+  %430 = v_and_b32_lit %427, 120
+  %431 = v_lshrrev_b32_src0_inline %430, 3
+  %432 = v_and_b32_src0_inline %427, 7
+  %433 = v_add_u32_lit %431, 120
+  %434 = v_lshlrev_b32_src0_inline %433, 23
+  %435 = v_lshlrev_b32_src0_inline %432, 20
+  %436 = v_or_b32 %429, %434
+  %437 = v_or_b32 %436, %435
+  %439 = v_and_b32_src0_inline %432, 2
+  %440 = v_cmp_ne_i32_src1_inline %439 {rhs = 0}
+  %441 = v_cndmask_b32_src1_inline %49, %440 {true_value = 1}
+  %442 = v_and_b32_src0_inline %432, 4
+  %443 = v_cmp_ne_i32_src1_inline %442 {rhs = 0}
+  %444 = v_cndmask_b32_src1_inline %441, %443 {true_value = 2}
+  %445 = v_add_u32_lit %444, 118
+  %446 = v_lshlrev_b32_src0_inline %445, 23
+  %448 = v_sub_nc_u32 %88, %444
+  %449 = v_lshlrev_b32 %448, %432
+  %450 = v_and_b32_lit %449, 8388607
+  %451 = v_or_b32 %429, %446
+  %452 = v_or_b32 %451, %450
+  %453 = v_cmp_eq_i32_src1_inline %432 {rhs = 0}
+  %454 = v_cndmask_b32 %452, %429, %453
+  %455 = v_cmp_eq_i32_src1_inline %431 {rhs = 0}
+  %456 = v_cndmask_b32 %437, %454, %455
+  %457 = v_cmp_eq_i32_src1_inline %431 {rhs = 15}
+  %458 = v_cmp_eq_i32_src1_inline %432 {rhs = 7}
+  %459 = s_and_b64 %457, %458
+  %460 = v_cndmask_b32_src1_lit %456, %459, 2143289344
+  %461 = v_lshrrev_b32_src0_inline %425, 16
+  %462 = v_and_b32_src0_inline %461, 1
+  %463 = v_add_u32_lit %462, 32767
+  %464 = v_add_u32 %425, %463
+  %465 = v_lshrrev_b32_src0_inline %464, 16
+  %466 = v_lshrrev_b32_src0_inline %460, 16
+  %467 = v_and_b32_src0_inline %466, 1
+  %468 = v_add_u32_lit %467, 32767
+  %469 = v_add_u32 %460, %468
+  %470 = v_lshrrev_b32_src0_inline %469, 16
+  %471 = v_cvt_pk_u16_u32 %465, %470
+  %472 = global_load_i8_saddr %66, %rhs_view {offset = 10}
+  %473 = v_and_b32_lit %472, 255
+  %474 = v_and_b32_lit %473, 128
+  %475 = v_lshlrev_b32_src0_inline %474, 24
+  %476 = v_and_b32_lit %473, 120
+  %477 = v_lshrrev_b32_src0_inline %476, 3
+  %478 = v_and_b32_src0_inline %473, 7
+  %479 = v_add_u32_lit %477, 120
+  %480 = v_lshlrev_b32_src0_inline %479, 23
+  %481 = v_lshlrev_b32_src0_inline %478, 20
+  %482 = v_or_b32 %475, %480
+  %483 = v_or_b32 %482, %481
+  %485 = v_and_b32_src0_inline %478, 2
+  %486 = v_cmp_ne_i32_src1_inline %485 {rhs = 0}
+  %487 = v_cndmask_b32_src1_inline %49, %486 {true_value = 1}
+  %488 = v_and_b32_src0_inline %478, 4
+  %489 = v_cmp_ne_i32_src1_inline %488 {rhs = 0}
+  %490 = v_cndmask_b32_src1_inline %487, %489 {true_value = 2}
+  %491 = v_add_u32_lit %490, 118
+  %492 = v_lshlrev_b32_src0_inline %491, 23
+  %494 = v_sub_nc_u32 %88, %490
+  %495 = v_lshlrev_b32 %494, %478
+  %496 = v_and_b32_lit %495, 8388607
+  %497 = v_or_b32 %475, %492
+  %498 = v_or_b32 %497, %496
+  %499 = v_cmp_eq_i32_src1_inline %478 {rhs = 0}
+  %500 = v_cndmask_b32 %498, %475, %499
+  %501 = v_cmp_eq_i32_src1_inline %477 {rhs = 0}
+  %502 = v_cndmask_b32 %483, %500, %501
+  %503 = v_cmp_eq_i32_src1_inline %477 {rhs = 15}
+  %504 = v_cmp_eq_i32_src1_inline %478 {rhs = 7}
+  %505 = s_and_b64 %503, %504
+  %506 = v_cndmask_b32_src1_lit %502, %505, 2143289344
+  %507 = global_load_i8_saddr %66, %rhs_view {offset = 11}
+  %508 = v_and_b32_lit %507, 255
+  %509 = v_and_b32_lit %508, 128
+  %510 = v_lshlrev_b32_src0_inline %509, 24
+  %511 = v_and_b32_lit %508, 120
+  %512 = v_lshrrev_b32_src0_inline %511, 3
+  %513 = v_and_b32_src0_inline %508, 7
+  %514 = v_add_u32_lit %512, 120
+  %515 = v_lshlrev_b32_src0_inline %514, 23
+  %516 = v_lshlrev_b32_src0_inline %513, 20
+  %517 = v_or_b32 %510, %515
+  %518 = v_or_b32 %517, %516
+  %520 = v_and_b32_src0_inline %513, 2
+  %521 = v_cmp_ne_i32_src1_inline %520 {rhs = 0}
+  %522 = v_cndmask_b32_src1_inline %49, %521 {true_value = 1}
+  %523 = v_and_b32_src0_inline %513, 4
+  %524 = v_cmp_ne_i32_src1_inline %523 {rhs = 0}
+  %525 = v_cndmask_b32_src1_inline %522, %524 {true_value = 2}
+  %526 = v_add_u32_lit %525, 118
+  %527 = v_lshlrev_b32_src0_inline %526, 23
+  %529 = v_sub_nc_u32 %88, %525
+  %530 = v_lshlrev_b32 %529, %513
+  %531 = v_and_b32_lit %530, 8388607
+  %532 = v_or_b32 %510, %527
+  %533 = v_or_b32 %532, %531
+  %534 = v_cmp_eq_i32_src1_inline %513 {rhs = 0}
+  %535 = v_cndmask_b32 %533, %510, %534
+  %536 = v_cmp_eq_i32_src1_inline %512 {rhs = 0}
+  %537 = v_cndmask_b32 %518, %535, %536
+  %538 = v_cmp_eq_i32_src1_inline %512 {rhs = 15}
+  %539 = v_cmp_eq_i32_src1_inline %513 {rhs = 7}
+  %540 = s_and_b64 %538, %539
+  %541 = v_cndmask_b32_src1_lit %537, %540, 2143289344
+  %542 = v_lshrrev_b32_src0_inline %506, 16
+  %543 = v_and_b32_src0_inline %542, 1
+  %544 = v_add_u32_lit %543, 32767
+  %545 = v_add_u32 %506, %544
+  %546 = v_lshrrev_b32_src0_inline %545, 16
+  %547 = v_lshrrev_b32_src0_inline %541, 16
+  %548 = v_and_b32_src0_inline %547, 1
+  %549 = v_add_u32_lit %548, 32767
+  %550 = v_add_u32 %541, %549
+  %551 = v_lshrrev_b32_src0_inline %550, 16
+  %552 = v_cvt_pk_u16_u32 %546, %551
+  %553 = global_load_i8_saddr %66, %rhs_view {offset = 12}
+  %554 = v_and_b32_lit %553, 255
+  %555 = v_and_b32_lit %554, 128
+  %556 = v_lshlrev_b32_src0_inline %555, 24
+  %557 = v_and_b32_lit %554, 120
+  %558 = v_lshrrev_b32_src0_inline %557, 3
+  %559 = v_and_b32_src0_inline %554, 7
+  %560 = v_add_u32_lit %558, 120
+  %561 = v_lshlrev_b32_src0_inline %560, 23
+  %562 = v_lshlrev_b32_src0_inline %559, 20
+  %563 = v_or_b32 %556, %561
+  %564 = v_or_b32 %563, %562
+  %566 = v_and_b32_src0_inline %559, 2
+  %567 = v_cmp_ne_i32_src1_inline %566 {rhs = 0}
+  %568 = v_cndmask_b32_src1_inline %49, %567 {true_value = 1}
+  %569 = v_and_b32_src0_inline %559, 4
+  %570 = v_cmp_ne_i32_src1_inline %569 {rhs = 0}
+  %571 = v_cndmask_b32_src1_inline %568, %570 {true_value = 2}
+  %572 = v_add_u32_lit %571, 118
+  %573 = v_lshlrev_b32_src0_inline %572, 23
+  %575 = v_sub_nc_u32 %88, %571
+  %576 = v_lshlrev_b32 %575, %559
+  %577 = v_and_b32_lit %576, 8388607
+  %578 = v_or_b32 %556, %573
+  %579 = v_or_b32 %578, %577
+  %580 = v_cmp_eq_i32_src1_inline %559 {rhs = 0}
+  %581 = v_cndmask_b32 %579, %556, %580
+  %582 = v_cmp_eq_i32_src1_inline %558 {rhs = 0}
+  %583 = v_cndmask_b32 %564, %581, %582
+  %584 = v_cmp_eq_i32_src1_inline %558 {rhs = 15}
+  %585 = v_cmp_eq_i32_src1_inline %559 {rhs = 7}
+  %586 = s_and_b64 %584, %585
+  %587 = v_cndmask_b32_src1_lit %583, %586, 2143289344
+  %588 = global_load_i8_saddr %66, %rhs_view {offset = 13}
+  %589 = v_and_b32_lit %588, 255
+  %590 = v_and_b32_lit %589, 128
+  %591 = v_lshlrev_b32_src0_inline %590, 24
+  %592 = v_and_b32_lit %589, 120
+  %593 = v_lshrrev_b32_src0_inline %592, 3
+  %594 = v_and_b32_src0_inline %589, 7
+  %595 = v_add_u32_lit %593, 120
+  %596 = v_lshlrev_b32_src0_inline %595, 23
+  %597 = v_lshlrev_b32_src0_inline %594, 20
+  %598 = v_or_b32 %591, %596
+  %599 = v_or_b32 %598, %597
+  %601 = v_and_b32_src0_inline %594, 2
+  %602 = v_cmp_ne_i32_src1_inline %601 {rhs = 0}
+  %603 = v_cndmask_b32_src1_inline %49, %602 {true_value = 1}
+  %604 = v_and_b32_src0_inline %594, 4
+  %605 = v_cmp_ne_i32_src1_inline %604 {rhs = 0}
+  %606 = v_cndmask_b32_src1_inline %603, %605 {true_value = 2}
+  %607 = v_add_u32_lit %606, 118
+  %608 = v_lshlrev_b32_src0_inline %607, 23
+  %610 = v_sub_nc_u32 %88, %606
+  %611 = v_lshlrev_b32 %610, %594
+  %612 = v_and_b32_lit %611, 8388607
+  %613 = v_or_b32 %591, %608
+  %614 = v_or_b32 %613, %612
+  %615 = v_cmp_eq_i32_src1_inline %594 {rhs = 0}
+  %616 = v_cndmask_b32 %614, %591, %615
+  %617 = v_cmp_eq_i32_src1_inline %593 {rhs = 0}
+  %618 = v_cndmask_b32 %599, %616, %617
+  %619 = v_cmp_eq_i32_src1_inline %593 {rhs = 15}
+  %620 = v_cmp_eq_i32_src1_inline %594 {rhs = 7}
+  %621 = s_and_b64 %619, %620
+  %622 = v_cndmask_b32_src1_lit %618, %621, 2143289344
+  %623 = v_lshrrev_b32_src0_inline %587, 16
+  %624 = v_and_b32_src0_inline %623, 1
+  %625 = v_add_u32_lit %624, 32767
+  %626 = v_add_u32 %587, %625
+  %627 = v_lshrrev_b32_src0_inline %626, 16
+  %628 = v_lshrrev_b32_src0_inline %622, 16
+  %629 = v_and_b32_src0_inline %628, 1
+  %630 = v_add_u32_lit %629, 32767
+  %631 = v_add_u32 %622, %630
+  %632 = v_lshrrev_b32_src0_inline %631, 16
+  %633 = v_cvt_pk_u16_u32 %627, %632
+  %634 = global_load_i8_saddr %66, %rhs_view {offset = 14}
+  %635 = v_and_b32_lit %634, 255
+  %636 = v_and_b32_lit %635, 128
+  %637 = v_lshlrev_b32_src0_inline %636, 24
+  %638 = v_and_b32_lit %635, 120
+  %639 = v_lshrrev_b32_src0_inline %638, 3
+  %640 = v_and_b32_src0_inline %635, 7
+  %641 = v_add_u32_lit %639, 120
+  %642 = v_lshlrev_b32_src0_inline %641, 23
+  %643 = v_lshlrev_b32_src0_inline %640, 20
+  %644 = v_or_b32 %637, %642
+  %645 = v_or_b32 %644, %643
+  %647 = v_and_b32_src0_inline %640, 2
+  %648 = v_cmp_ne_i32_src1_inline %647 {rhs = 0}
+  %649 = v_cndmask_b32_src1_inline %49, %648 {true_value = 1}
+  %650 = v_and_b32_src0_inline %640, 4
+  %651 = v_cmp_ne_i32_src1_inline %650 {rhs = 0}
+  %652 = v_cndmask_b32_src1_inline %649, %651 {true_value = 2}
+  %653 = v_add_u32_lit %652, 118
+  %654 = v_lshlrev_b32_src0_inline %653, 23
+  %656 = v_sub_nc_u32 %88, %652
+  %657 = v_lshlrev_b32 %656, %640
+  %658 = v_and_b32_lit %657, 8388607
+  %659 = v_or_b32 %637, %654
+  %660 = v_or_b32 %659, %658
+  %661 = v_cmp_eq_i32_src1_inline %640 {rhs = 0}
+  %662 = v_cndmask_b32 %660, %637, %661
+  %663 = v_cmp_eq_i32_src1_inline %639 {rhs = 0}
+  %664 = v_cndmask_b32 %645, %662, %663
+  %665 = v_cmp_eq_i32_src1_inline %639 {rhs = 15}
+  %666 = v_cmp_eq_i32_src1_inline %640 {rhs = 7}
+  %667 = s_and_b64 %665, %666
+  %668 = v_cndmask_b32_src1_lit %664, %667, 2143289344
+  %669 = global_load_i8_saddr %66, %rhs_view {offset = 15}
+  %670 = v_and_b32_lit %669, 255
+  %671 = v_and_b32_lit %670, 128
+  %672 = v_lshlrev_b32_src0_inline %671, 24
+  %673 = v_and_b32_lit %670, 120
+  %674 = v_lshrrev_b32_src0_inline %673, 3
+  %675 = v_and_b32_src0_inline %670, 7
+  %676 = v_add_u32_lit %674, 120
+  %677 = v_lshlrev_b32_src0_inline %676, 23
+  %678 = v_lshlrev_b32_src0_inline %675, 20
+  %679 = v_or_b32 %672, %677
+  %680 = v_or_b32 %679, %678
+  %682 = v_and_b32_src0_inline %675, 2
+  %683 = v_cmp_ne_i32_src1_inline %682 {rhs = 0}
+  %684 = v_cndmask_b32_src1_inline %49, %683 {true_value = 1}
+  %685 = v_and_b32_src0_inline %675, 4
+  %686 = v_cmp_ne_i32_src1_inline %685 {rhs = 0}
+  %687 = v_cndmask_b32_src1_inline %684, %686 {true_value = 2}
+  %688 = v_add_u32_lit %687, 118
+  %689 = v_lshlrev_b32_src0_inline %688, 23
+  %691 = v_sub_nc_u32 %88, %687
+  %692 = v_lshlrev_b32 %691, %675
+  %693 = v_and_b32_lit %692, 8388607
+  %694 = v_or_b32 %672, %689
+  %695 = v_or_b32 %694, %693
+  %696 = v_cmp_eq_i32_src1_inline %675 {rhs = 0}
+  %697 = v_cndmask_b32 %695, %672, %696
+  %698 = v_cmp_eq_i32_src1_inline %674 {rhs = 0}
+  %699 = v_cndmask_b32 %680, %697, %698
+  %700 = v_cmp_eq_i32_src1_inline %674 {rhs = 15}
+  %701 = v_cmp_eq_i32_src1_inline %675 {rhs = 7}
+  %702 = s_and_b64 %700, %701
+  %703 = v_cndmask_b32_src1_lit %699, %702, 2143289344
+  %704 = v_lshrrev_b32_src0_inline %668, 16
+  %705 = v_and_b32_src0_inline %704, 1
+  %706 = v_add_u32_lit %705, 32767
+  %707 = v_add_u32 %668, %706
+  %708 = v_lshrrev_b32_src0_inline %707, 16
+  %709 = v_lshrrev_b32_src0_inline %703, 16
+  %710 = v_and_b32_src0_inline %709, 1
+  %711 = v_add_u32_lit %710, 32767
+  %712 = v_add_u32 %703, %711
+  %713 = v_lshrrev_b32_src0_inline %712, 16
+  %714 = v_cvt_pk_u16_u32 %708, %713
+  %rhs = concat(%147, %228, %309, %390, %471, %552, %633, %714) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x8>
+  %716 = copy %init : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
+  %result = v_wmma_f32_16x16x16_bf16 %lhs, %rhs, %716
+  %718 = s_mov_b32 0
+  %719 = s_mov_b32 8
+  %720 = s_mov_b32 1
+  low.br ^_bb1(%718: reg<amdgpu.sgpr>)
+^_bb1(%44: reg<amdgpu.sgpr>):
+  %721 = s_cmp_lt_i32 %44, %719
+  low.cond_br %721, ^_bb2, ^_bb3 : reg<amdgpu.scc>
+^_bb2:
+  %722 = slice %result[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %723 = v_mov_b32_copy %44
+  %724 = v_mov_b32 1
+  %725 = v_cmp_eq_i32 %723, %724
+  %726 = slice %result[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %727 = v_cndmask_b32 %722, %726, %725
+  %728 = v_mov_b32 2
+  %729 = v_cmp_eq_i32 %723, %728
+  %730 = slice %result[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %731 = v_cndmask_b32 %727, %730, %729
+  %732 = v_mov_b32 3
+  %733 = v_cmp_eq_i32 %723, %732
+  %734 = slice %result[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %735 = v_cndmask_b32 %731, %734, %733
+  %736 = v_mov_b32 4
+  %737 = v_cmp_eq_i32 %723, %736
+  %738 = slice %result[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %739 = v_cndmask_b32 %735, %738, %737
+  %740 = v_mov_b32 5
+  %741 = v_cmp_eq_i32 %723, %740
+  %742 = slice %result[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %743 = v_cndmask_b32 %739, %742, %741
+  %744 = v_mov_b32 6
+  %745 = v_cmp_eq_i32 %723, %744
+  %746 = slice %result[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %747 = v_cndmask_b32 %743, %746, %745
+  %748 = v_mov_b32 7
+  %749 = v_cmp_eq_i32 %723, %748
+  %750 = slice %result[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %751 = v_cndmask_b32 %747, %750, %749
+  %752 = v_lshrrev_b32_lit %751, 16
+  %753 = v_and_b32_lit %752, 1
+  %754 = v_add_u32_lit %753, 32767
+  %755 = v_add_u32 %751, %754
+  %756 = v_lshrrev_b32_lit %755, 16
+  %758 = v_mov_b32 15
+  %759 = v_and_b32 %45, %758
+  %760 = v_lshrrev_b32_lit %45, 4
+  %761 = v_lshl_add_u32_shift_imm %44, %760, 1
+  %762 = v_lshl_add_u32_shift_imm %761, %759, 4
+  %763 = v_lshlrev_b32_src0_inline %762, 1
+  global_store_short_saddr %763, %756, %out_view
+  %764 = s_add_u32 %44, %720
+  low.br ^_bb1(%764: reg<amdgpu.sgpr>)
+^_bb3:
+  return
+}
+
+// ====
+
+amdgpu.target<gfx1100> @target
+
 kernel.def target(@target) @bf16_result_fragment_load_to_f32_epilogue() {
   %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_fragment_epilogue.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_fragment_epilogue.loom-test
@@ -29,6 +29,7 @@ kernel.def target(@target) @bf16_result_fragment_epilogue_two_tiles() {
   %scale = vector.constant 2.0 : vector<8xf32>
   %product0 = vector.mulf<reassoc|nnan|ninf|nsz|contract> %gate0, %scale : vector<8xf32>
   %product1 = vector.mulf<reassoc|nnan|ninf|nsz|contract> %gate1, %scale : vector<8xf32>
+  kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   vector.fragment.store<result> %product0, %output_view[%token_origin, %row_origin0] shape [%sixteen, %sixteen] : vector<8xf32>, view<64x64xbf16, #dense>
   vector.fragment.store<result> %product1, %output_view[%token_origin, %row_origin1] shape [%sixteen, %sixteen] : vector<8xf32>, view<64x64xbf16, #dense>
   kernel.return
@@ -39,6 +40,7 @@ low.kernel.def target(@target) workgroup_size(32, 1, 1) @bf16_result_fragment_ep
   %117 = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %gate_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 8192} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 8192} : reg<amdgpu.sgpr x2>
+  s_waitcnt {lgkmcnt = 0}
   %120 = s_mov_b32 0
   %121 = s_mov_b32 8
   %122 = s_mov_b32 1

--- a/loom/src/loom/target/emit/native/amdgpu/test/wait_plan.loom-test
+++ b/loom/src/loom/target/emit/native/amdgpu/test/wait_plan.loom-test
@@ -21,7 +21,22 @@ low.func.def target(@gfx11_target) @gfx11_explicit_smem_wait(%kernarg: reg<amdgp
 }
 
 // ----
-{"format":"loom.low.packet_hazard_plan.v1","function":"gfx11_explicit_smem_wait","target":"gfx11_target","descriptor_set":"amdgpu.rdna3.core","progress_count":4,"hazard_count":0,"progress":[{"index":0,"packet":0,"node":0,"block":0,"scheduled_ordinal":0,"class_id":4,"class_name":"amdgpu.smem","action":"advance","units":1},{"index":1,"packet":1,"node":1,"block":0,"scheduled_ordinal":1,"class_id":1,"class_name":"amdgpu.vmem_load","action":"reset","units":0},{"index":2,"packet":1,"node":1,"block":0,"scheduled_ordinal":1,"class_id":3,"class_name":"amdgpu.lds","action":"reset","units":0},{"index":3,"packet":1,"node":1,"block":0,"scheduled_ordinal":1,"class_id":4,"class_name":"amdgpu.smem","action":"reset","units":0}],"hazards":[]}
+{"format":"loom.low.packet_hazard_plan.v1","function":"gfx11_explicit_smem_wait","target":"gfx11_target","descriptor_set":"amdgpu.rdna3.core","progress_count":3,"hazard_count":0,"progress":[{"index":0,"packet":0,"node":0,"block":0,"scheduled_ordinal":0,"class_id":4,"class_name":"amdgpu.smem","action":"advance","units":1},{"index":1,"packet":1,"node":1,"block":0,"scheduled_ordinal":1,"class_id":3,"class_name":"amdgpu.lds","action":"reset","units":0},{"index":2,"packet":1,"node":1,"block":0,"scheduled_ordinal":1,"class_id":4,"class_name":"amdgpu.smem","action":"reset","units":0}],"hazards":[]}
+
+// ====
+
+// RUN: emit amdgpu-wait-counter-plan-json @gfx11_lgkm_wait_preserves_vmem_load strategy=source
+amdgpu.target<gfx1100> @gfx11_target
+low.func.def target(@gfx11_target) @gfx11_lgkm_wait_preserves_vmem_load(%resource: reg<amdgpu.sgpr x4>, %vaddr: reg<amdgpu.vgpr>, %soffset: reg<amdgpu.sgpr>, %lds_addr: reg<amdgpu.vgpr>) -> (reg<amdgpu.vgpr>) asm<amdgpu.rdna3.core> {
+  %global = buffer_load_dword %resource, %vaddr, %soffset
+  %local = ds_read_b32 %lds_addr
+  s_waitcnt {lgkmcnt = 0}
+  %sum = v_add_u32 %global, %local
+  return %sum
+}
+
+// ----
+{"format":"loom.low.packet_hazard_plan.v1","function":"gfx11_lgkm_wait_preserves_vmem_load","target":"gfx11_target","descriptor_set":"amdgpu.rdna3.core","progress_count":4,"hazard_count":2,"progress":[{"index":0,"packet":0,"node":0,"block":0,"scheduled_ordinal":0,"class_id":1,"class_name":"amdgpu.vmem_load","action":"advance","units":1},{"index":1,"packet":1,"node":1,"block":0,"scheduled_ordinal":1,"class_id":3,"class_name":"amdgpu.lds","action":"advance","units":1},{"index":2,"packet":2,"node":2,"block":0,"scheduled_ordinal":2,"class_id":3,"class_name":"amdgpu.lds","action":"reset","units":0},{"index":3,"packet":2,"node":2,"block":0,"scheduled_ordinal":2,"class_id":4,"class_name":"amdgpu.smem","action":"reset","units":0}],"hazards":[{"index":0,"kind":"action","action_id":1,"action_name":"amdgpu.wait_packet","reason_id":2,"reason_name":"amdgpu.ssa_use","producer_node":0,"producer_packet":0,"producer_scheduled_ordinal":0,"consumer_node":3,"insertion_packet":3,"block":0,"scheduled_ordinal":3,"progress_class_id":1,"progress_class_name":"amdgpu.vmem_load","required":1,"observed":0,"residual":1},{"index":1,"kind":"action","action_id":1,"action_name":"amdgpu.wait_packet","reason_id":5,"reason_name":"amdgpu.read_result_reuse","producer_node":0,"producer_packet":0,"producer_scheduled_ordinal":0,"consumer_node":4,"insertion_packet":4,"block":0,"scheduled_ordinal":4,"progress_class_id":1,"progress_class_name":"amdgpu.vmem_load","required":1,"observed":0,"residual":1}]}
 
 // ====
 


### PR DESCRIPTION
This closes two FP8/BF16 WMMA correctness gaps in the AMDGPU path: compact FP8 RHS storage can now feed BF16 WMMA operands directly, and workgroup barriers after WMMA no longer allow unrelated VMEM hazards to be treated as drained.

`vector.fragment.load` is now symmetric with `vector.fragment.store`: fragment movement is a target-shaped boundary, so the storage element type in the view and the physical payload element type may differ when target lowering explicitly selects the conversion. Ordinary vector memory operations still keep their same-element contract. The verifier coverage now documents this load-boundary conversion contract instead of rejecting it generically before the AMDGPU target can make a legality decision.

AMDGPU fragment lowering has a new FP8-to-BF16 load payload form for LHS/RHS matrix operands. The selected route uses scalar FP8 byte loads from global/buffer memory, expands each byte through the low-level arithmetic packet vocabulary, rounds pairs of f32 decode lanes into packed BF16 registers, and feeds the existing BF16 WMMA operand layout. This gives authors a direct compact-weight shape such as `vector.fragment.load<rhs> ... view<...xf8E4M3> -> vector<...xbf16>` without hand-authored staging through LDS or scalar unpack sludge.

The wait planner now interprets wait-counter immediate values before applying packet counter effects. A wait such as `s_waitcnt {lgkmcnt = 0}` resets LDS/SMEM progress without pretending that VMEM loads are complete. That preserves required VMEM waits across workgroup barriers and fixes the stale-input failure mode where FP8 scratch/WMMA kernels could produce NaNs after a post-MMA barrier.

The regression surface covers the IR contract, the selected AMDGPU source-to-low sequence, barrier-adjacent fragment epilogues, and the wait-plan JSON that proves lgkm-only waits leave VMEM hazards live.
