### PR TITLE
[hip] Track HIP stream and primary context state

### DIFF
--- a/libhrx/src/binding/common/device.c
+++ b/libhrx/src/binding/common/device.c
@@ -223,11 +223,12 @@ iree_status_t iree_hal_streaming_device_set_primary_context_flags(
                          "invalid device ordinal %" PRIhsz, device_ordinal));
   }
 
-  // Update the primary context flags.
+  iree_slim_mutex_lock(&device->primary_context_mutex);
   device->primary_context_flags = *flags;
-
-  // If the primary context exists, we might need to update it.
-  // For now, we just store the flags for new contexts.
+  if (device->primary_context) {
+    device->primary_context->flags = *flags;
+  }
+  iree_slim_mutex_unlock(&device->primary_context_mutex);
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -247,16 +248,16 @@ iree_status_t iree_hal_streaming_device_primary_context_state(
                          "invalid device ordinal %" PRIhsz, device_ordinal));
   }
 
+  iree_slim_mutex_lock(&device->primary_context_mutex);
   if (out_flags) {
-    *out_flags = device->primary_context_flags;
+    *out_flags =
+        device->primary_context ? device->primary_context->flags
+                                : device->primary_context_flags;
   }
-
-  // Context is active if reference count > 0.
   if (out_active) {
-    iree_slim_mutex_lock(&device->primary_context_mutex);
-    *out_active = (device->primary_context_ref_count > 0);
-    iree_slim_mutex_unlock(&device->primary_context_mutex);
+    *out_active = device->primary_context != NULL;
   }
+  iree_slim_mutex_unlock(&device->primary_context_mutex);
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();

--- a/libhrx/src/binding/common/device.c
+++ b/libhrx/src/binding/common/device.c
@@ -250,9 +250,8 @@ iree_status_t iree_hal_streaming_device_primary_context_state(
 
   iree_slim_mutex_lock(&device->primary_context_mutex);
   if (out_flags) {
-    *out_flags =
-        device->primary_context ? device->primary_context->flags
-                                : device->primary_context_flags;
+    *out_flags = device->primary_context ? device->primary_context->flags
+                                         : device->primary_context_flags;
   }
   if (out_active) {
     *out_active = device->primary_context != NULL;

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -436,6 +436,13 @@ typedef enum iree_hal_streaming_stream_flag_bits_e {
   IREE_HAL_STREAMING_STREAM_FLAG_NON_BLOCKING = 1ull << 0,
 } iree_hal_streaming_stream_flags_t;
 
+typedef enum iree_hal_streaming_synchronization_policy_e {
+  IREE_HAL_STREAMING_SYNCHRONIZATION_POLICY_AUTO = 1,
+  IREE_HAL_STREAMING_SYNCHRONIZATION_POLICY_SPIN = 2,
+  IREE_HAL_STREAMING_SYNCHRONIZATION_POLICY_YIELD = 3,
+  IREE_HAL_STREAMING_SYNCHRONIZATION_POLICY_BLOCKING_SYNC = 4,
+} iree_hal_streaming_synchronization_policy_t;
+
 // Stream capture status enum.
 typedef enum iree_hal_streaming_capture_status_e {
   IREE_HAL_STREAMING_CAPTURE_STATUS_NONE = 0,
@@ -466,9 +473,16 @@ typedef struct iree_hal_streaming_stream_t {
   // Parent context, unowned (to avoid cycles).
   iree_hal_streaming_context_t* context;
 
-  // Stream properties.
+  // HIP stream creation flags.
   iree_hal_streaming_stream_flags_t flags;
+  // HIP synchronization policy value for stream attribute queries.
+  iree_hal_streaming_synchronization_policy_t synchronization_policy;
+  // HIP stream scheduling priority hint.
   int priority;
+  // Number of 32-bit entries in |cu_mask|.
+  iree_host_size_t cu_mask_count;
+  // Optional HIP CU mask owned by this stream; NULL means default device mask.
+  uint32_t* cu_mask;
   // Stable HIP stream identifier, unique within this context.
   unsigned long long stream_id;
 

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -479,9 +479,12 @@ typedef struct iree_hal_streaming_stream_t {
   iree_hal_streaming_synchronization_policy_t synchronization_policy;
   // HIP stream scheduling priority hint.
   int priority;
-  // Number of 32-bit entries in |cu_mask|.
+  // Number of 32-bit entries in |cu_mask|; zero until CU-mask APIs attach
+  // state.
   iree_host_size_t cu_mask_count;
   // Optional HIP CU mask owned by this stream; NULL means default device mask.
+  // The stream CU-mask API follow-up will populate/query this value; command
+  // scheduling in this layer does not consume it.
   uint32_t* cu_mask;
   // Stable HIP stream identifier, unique within this context.
   unsigned long long stream_id;

--- a/libhrx/src/binding/common/stream.c
+++ b/libhrx/src/binding/common/stream.c
@@ -200,7 +200,11 @@ iree_status_t iree_hal_streaming_stream_create(
   iree_atomic_ref_count_init(&stream->ref_count);
   stream->context = context;
   stream->flags = flags;
+  stream->synchronization_policy =
+      IREE_HAL_STREAMING_SYNCHRONIZATION_POLICY_AUTO;
   stream->priority = priority;
+  stream->cu_mask_count = 0;
+  stream->cu_mask = NULL;
   stream->stream_id = 0;
   stream->command_buffer = NULL;
   stream->pending_launch_count = 0;
@@ -272,6 +276,8 @@ static void iree_hal_streaming_stream_destroy(
 
   // Release command buffer.
   iree_hal_command_buffer_release(stream->command_buffer);
+
+  iree_allocator_free(stream->host_allocator, stream->cu_mask);
 
   if (stream->capture_graph_owned) {
     iree_hal_streaming_graph_release(stream->capture_graph);

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -2937,7 +2937,7 @@ HIPAPI hipError_t hipDevicePrimaryCtxSetFlags(hipDevice_t dev,
 // State information:
 // - flags: Current context creation flags.
 // - active: 1 if context is active, 0 if inactive.
-// - Context is active if reference count > 0.
+// - Context is active while the device owns a live primary context.
 //
 // Multi-GPU: Queries state of specified device's primary context.
 //


### PR DESCRIPTION
Store stream synchronization policy and CU-mask state on streaming streams, release owned CU-mask storage during stream teardown, and update primary context flags under the primary-context lock.

Report primary-context active state from the live context handle so implicit contexts and retained contexts share the same state contract.