### PR TITLE
Propagate AMDGPU kernel resource metadata

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
@@ -1726,7 +1726,17 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_write_dispatch_tail(
     uint8_t* tail_payload) {
   switch (kernarg_storage_mode) {
     case IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STORAGE_MODE_CUSTOM_DIRECT: {
-      const iree_host_size_t explicit_bytes = layout->explicit_kernarg_size;
+      iree_host_size_t explicit_bytes = layout->explicit_kernarg_size;
+      if (explicit_bytes == 0) {
+        // Zero means dynamic explicit bytes; with an implicit suffix, user
+        // kernargs end where the runtime-owned hidden args begin.
+        explicit_bytes = layout->has_implicit_args
+                             ? layout->implicit_args_offset
+                             : layout->total_kernarg_size;
+        if (explicit_bytes == 0) {
+          explicit_bytes = constants.data_length;
+        }
+      }
       const iree_host_size_t copy_bytes = constants.data_length < explicit_bytes
                                               ? constants.data_length
                                               : explicit_bytes;

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
@@ -1729,7 +1729,10 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_write_dispatch_tail(
       iree_host_size_t explicit_bytes = layout->explicit_kernarg_size;
       if (explicit_bytes == 0) {
         // Zero means dynamic explicit bytes; with an implicit suffix, user
-        // kernargs end where the runtime-owned hidden args begin.
+        // kernargs end where the runtime-owned hidden args begin. Executable
+        // loading rejects metadata where visible args resume after that suffix,
+        // and plan construction reserves enough bytes for the explicit prefix
+        // and any suffix written below.
         explicit_bytes = layout->has_implicit_args
                              ? layout->implicit_args_offset
                              : layout->total_kernarg_size;

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
@@ -1726,20 +1726,9 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_write_dispatch_tail(
     uint8_t* tail_payload) {
   switch (kernarg_storage_mode) {
     case IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STORAGE_MODE_CUSTOM_DIRECT: {
-      iree_host_size_t explicit_bytes = layout->explicit_kernarg_size;
-      if (explicit_bytes == 0) {
-        // Zero means dynamic explicit bytes; with an implicit suffix, user
-        // kernargs end where the runtime-owned hidden args begin. Executable
-        // loading rejects metadata where visible args resume after that suffix,
-        // and plan construction reserves enough bytes for the explicit prefix
-        // and any suffix written below.
-        explicit_bytes = layout->has_implicit_args
-                             ? layout->implicit_args_offset
-                             : layout->total_kernarg_size;
-        if (explicit_bytes == 0) {
-          explicit_bytes = constants.data_length;
-        }
-      }
+      const iree_host_size_t explicit_bytes =
+          iree_hal_amdgpu_device_dispatch_explicit_kernarg_size(
+              layout, constants.data_length);
       const iree_host_size_t copy_bytes = constants.data_length < explicit_bytes
                                               ? constants.data_length
                                               : explicit_bytes;
@@ -2236,16 +2225,17 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_prepare_dispatch_plan(
     //
     // Validate after 8-byte ABI padding so we accept missing tail padding while
     // still rejecting truly short pre-packed HIP argument buffers.
-    const uint32_t required_explicit_bytes =
-        (uint32_t)
-            out_plan->descriptor->custom_kernarg_layout.explicit_kernarg_size;
+    const iree_host_size_t required_explicit_bytes =
+        iree_hal_amdgpu_device_dispatch_explicit_kernarg_size(
+            &out_plan->descriptor->custom_kernarg_layout,
+            /*custom_kernarg_length=*/0);
     const iree_host_size_t padded_constant_length =
         iree_host_align(inputs->constants.data_length, /*alignment=*/8);
     if (IREE_UNLIKELY(padded_constant_length < required_explicit_bytes)) {
       return iree_make_status(
           IREE_STATUS_INVALID_ARGUMENT,
-          "custom dispatch argument length too short; expected at least %u "
-          "but got %" PRIhsz " (padded to %" PRIhsz ")",
+          "custom dispatch argument length too short; expected at least "
+          "%" PRIhsz " but got %" PRIhsz " (padded to %" PRIhsz ")",
           required_explicit_bytes, inputs->constants.data_length,
           padded_constant_length);
     }

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.c
@@ -77,9 +77,9 @@ void iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
                                         : custom_kernarg_length;
   if (total_kernarg_size > 0) {
     iree_amdgpu_memset(kernarg_ptr, 0, total_kernarg_size);
-    const size_t explicit_bytes = layout->explicit_kernarg_size
-                                      ? layout->explicit_kernarg_size
-                                      : total_kernarg_size;
+    const size_t explicit_bytes =
+        iree_hal_amdgpu_device_dispatch_explicit_kernarg_size(
+            layout, custom_kernarg_length);
     const size_t copy_bytes = custom_kernarg_length < explicit_bytes
                                   ? custom_kernarg_length
                                   : explicit_bytes;

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
@@ -28,11 +28,17 @@ extern "C" {
 // packet/kernarg storage. Host recording/submission code must validate kernel
 // metadata and user-provided arguments before passing a layout here.
 typedef struct iree_hal_amdgpu_device_dispatch_kernarg_layout_t {
-  // Size in bytes of the explicitly provided dispatch arguments.
+  // Size in bytes of the caller-provided native ABI argument prefix. Zero means
+  // the dispatch recording path determines the explicit byte count.
   size_t explicit_kernarg_size;
-  // Offset in bytes of the implicit HIP/OpenCL suffix, if present.
+  // Offset in bytes of the implicit HIP/OpenCL suffix, if present. Metadata-
+  // derived fixed layouts require all visible arguments to end at or before
+  // this offset; interleaved visible/hidden/visible layouts are rejected while
+  // loading the executable.
   size_t implicit_args_offset;
-  // Total kernarg reservation size in bytes required for this dispatch.
+  // Total kernarg reservation size in bytes required for this dispatch. Fixed
+  // layouts cover the explicit prefix and any implicit suffix; zero means the
+  // caller-provided byte count determines the reservation size.
   size_t total_kernarg_size;
   // True if a HIP/OpenCL implicit args suffix is appended at
   // |implicit_args_offset| and must be populated during emplace.

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
@@ -28,8 +28,9 @@ extern "C" {
 // packet/kernarg storage. Host recording/submission code must validate kernel
 // metadata and user-provided arguments before passing a layout here.
 typedef struct iree_hal_amdgpu_device_dispatch_kernarg_layout_t {
-  // Size in bytes of the caller-provided native ABI argument prefix. Zero means
-  // the dispatch recording path determines the explicit byte count.
+  // Size in bytes of the caller-provided native ABI argument prefix. Zero
+  // derives the prefix size from the implicit suffix offset, fixed total size,
+  // or caller-provided length.
   size_t explicit_kernarg_size;
   // Offset in bytes of the implicit HIP/OpenCL suffix, if present. Metadata-
   // derived fixed layouts require all visible arguments to end at or before
@@ -44,6 +45,22 @@ typedef struct iree_hal_amdgpu_device_dispatch_kernarg_layout_t {
   // |implicit_args_offset| and must be populated during emplace.
   bool has_implicit_args;
 } iree_hal_amdgpu_device_dispatch_kernarg_layout_t;
+
+// Returns the caller-owned explicit prefix byte count to validate and copy.
+static inline size_t iree_hal_amdgpu_device_dispatch_explicit_kernarg_size(
+    const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* layout,
+    size_t custom_kernarg_length) {
+  if (layout->explicit_kernarg_size != 0) {
+    return layout->explicit_kernarg_size;
+  }
+  if (layout->has_implicit_args) {
+    return layout->implicit_args_offset;
+  }
+  if (layout->total_kernarg_size != 0) {
+    return layout->total_kernarg_size;
+  }
+  return custom_kernarg_length;
+}
 
 //===----------------------------------------------------------------------===//
 // Dispatch Packet/Kernarg Emission
@@ -124,9 +141,10 @@ void iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
 
 // Populates custom direct explicit kernargs in already-reserved storage.
 //
-// |custom_kernarg_ptr| provides up to |layout->total_kernarg_size| bytes in the
-// final kernel ABI shape expected by the target kernel. Missing trailing
-// padding bytes remain zeroed.
+// |custom_kernarg_ptr| provides the caller-owned explicit ABI prefix expected
+// by the target kernel. Missing trailing padding bytes remain zeroed. Implicit
+// HIP/OpenCL suffix bytes are runtime-owned and must be populated by
+// iree_hal_amdgpu_device_dispatch_emplace_implicit_args().
 //
 // Preconditions:
 //   - |layout| and |kernarg_ptr| are non-NULL.

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch_test.cc
@@ -129,5 +129,52 @@ TEST(DispatchTest, EmplaceCustomKernargsCopiesRawBlob) {
   }
 }
 
+TEST(DispatchTest, ExplicitKernargSizeUsesImplicitPrefixOffset) {
+  iree_hal_amdgpu_device_dispatch_kernarg_layout_t layout = {
+      /*.explicit_kernarg_size=*/0,
+      /*.implicit_args_offset=*/16,
+      /*.total_kernarg_size=*/16 + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE,
+      /*.has_implicit_args=*/true,
+  };
+
+  EXPECT_EQ(iree_hal_amdgpu_device_dispatch_explicit_kernarg_size(
+                &layout, /*custom_kernarg_length=*/64),
+            16u);
+
+  layout.implicit_args_offset = 0;
+  EXPECT_EQ(iree_hal_amdgpu_device_dispatch_explicit_kernarg_size(
+                &layout, /*custom_kernarg_length=*/64),
+            0u);
+
+  layout = {};
+  EXPECT_EQ(iree_hal_amdgpu_device_dispatch_explicit_kernarg_size(
+                &layout, /*custom_kernarg_length=*/64),
+            64u);
+}
+
+TEST(DispatchTest, EmplaceCustomKernargsDoesNotCopyImplicitSuffix) {
+  const size_t total_kernarg_size = IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE + 8;
+  iree_hal_amdgpu_device_dispatch_kernarg_layout_t layout = {
+      /*.explicit_kernarg_size=*/0,
+      /*.implicit_args_offset=*/0,
+      /*.total_kernarg_size=*/total_kernarg_size,
+      /*.has_implicit_args=*/true,
+  };
+  std::array<uint8_t, 64> custom_kernargs = {};
+  custom_kernargs.fill(0xAB);
+  alignas(16) std::array<uint8_t, 256> kernargs = {};
+  kernargs.fill(0xFD);
+
+  iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
+      &layout, custom_kernargs.data(), custom_kernargs.size(), kernargs.data());
+
+  for (size_t i = 0; i < total_kernarg_size; ++i) {
+    EXPECT_EQ(kernargs[i], 0u);
+  }
+  for (size_t i = total_kernarg_size; i < kernargs.size(); ++i) {
+    EXPECT_EQ(kernargs[i], 0xFD);
+  }
+}
+
 }  // namespace
 }  // namespace iree::hal::amdgpu

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -1785,6 +1785,9 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_export_infos(
     const bool custom_direct_only = iree_any_bit_set(
         metadata_export->flags,
         IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_CUSTOM_DIRECT_ONLY);
+    const bool uniform_workgroup_size = iree_any_bit_set(
+        metadata_export->flags,
+        IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_UNIFORM_WORKGROUP_SIZE);
 
     const iree_hal_amdgpu_kernarg_layout_t* layout = NULL;
     if (!custom_direct_only) {
@@ -1797,18 +1800,52 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_export_infos(
       IREE_RETURN_IF_ERROR(iree_hal_amdgpu_executable_validate_workgroup_size(
           reflection->symbol_name, metadata_export->workgroup_size, limits));
     }
+    const uint32_t max_workgroup_size =
+        metadata_export->max_workgroup_size != 0
+            ? metadata_export->max_workgroup_size
+            : limits->max_workgroup_size;
+    if (IREE_UNLIKELY(max_workgroup_size > limits->max_workgroup_size)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "AMDGPU kernel `%.*s` max workgroup size %u exceeds device maximum "
+          "%u",
+          (int)reflection->symbol_name.size, reflection->symbol_name.data,
+          max_workgroup_size, limits->max_workgroup_size);
+    }
+    if (!requires_dispatch_workgroup_size &&
+        metadata_export->max_workgroup_size != 0) {
+      const uint64_t fixed_workgroup_size =
+          (uint64_t)metadata_export->workgroup_size[0] *
+          metadata_export->workgroup_size[1] * metadata_export->workgroup_size[2];
+      if (IREE_UNLIKELY(fixed_workgroup_size > max_workgroup_size)) {
+        return iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "AMDGPU kernel `%.*s` workgroup size total %" PRIu64
+            " exceeds kernel maximum %u",
+            (int)reflection->symbol_name.size, reflection->symbol_name.data,
+            fixed_workgroup_size, max_workgroup_size);
+      }
+    }
 
     executable->custom_direct_only_exports[i] = custom_direct_only;
     executable->export_parameter_offsets[i] = reflection->parameter_offset;
 
     memset(info, 0, sizeof(*info));
     info->name = reflection->name;
-    info->flags = requires_dispatch_workgroup_size
-                      ? IREE_HAL_EXECUTABLE_FUNCTION_FLAG_WORKGROUP_SIZE_DYNAMIC
-                      : IREE_HAL_EXECUTABLE_FUNCTION_FLAG_NONE;
+    info->flags = IREE_HAL_EXECUTABLE_FUNCTION_FLAG_NONE;
+    if (requires_dispatch_workgroup_size) {
+      info->flags |= IREE_HAL_EXECUTABLE_FUNCTION_FLAG_WORKGROUP_SIZE_DYNAMIC;
+    }
+    if (uniform_workgroup_size) {
+      info->flags |= IREE_HAL_EXECUTABLE_FUNCTION_FLAG_UNIFORM_WORKGROUP_SIZE;
+    }
     info->constant_byte_length = layout ? layout->constant_byte_length : 0;
     info->binding_count = layout ? layout->binding_count : 0;
     info->parameter_count = reflection->parameter_count;
+    info->max_workgroup_size = max_workgroup_size;
+    info->workgroup_local_memory_size =
+        metadata_export->fixed_group_segment_size;
+    info->private_memory_size = metadata_export->fixed_private_segment_size;
     if (requires_dispatch_workgroup_size) {
       info->workgroup_size[0] = 1;
       info->workgroup_size[1] = 1;

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -1816,7 +1816,8 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_export_infos(
         metadata_export->max_workgroup_size != 0) {
       const uint64_t fixed_workgroup_size =
           (uint64_t)metadata_export->workgroup_size[0] *
-          metadata_export->workgroup_size[1] * metadata_export->workgroup_size[2];
+          metadata_export->workgroup_size[1] *
+          metadata_export->workgroup_size[2];
       if (IREE_UNLIKELY(fixed_workgroup_size > max_workgroup_size)) {
         return iree_make_status(
             IREE_STATUS_INVALID_ARGUMENT,

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -864,10 +864,10 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_dispatch_descriptor(
           .explicit_kernarg_size = custom_explicit_kernarg_size,
       };
   if (custom_implicit_args_offset != UINT16_MAX) {
-    // Custom-direct callers own every visible native kernarg byte. Hidden
-    // metadata marks the implicit suffix location, but visible args may appear
-    // after the first hidden record in some code objects, so validate/copy the
-    // full visible extent instead of truncating at the suffix offset.
+    // Custom-direct callers provide the visible native kernarg prefix. Metadata
+    // planning rejects visible arguments that cross the implicit suffix offset,
+    // so the runtime can reserve the full kernarg block and populate the hidden
+    // suffix after copying the caller-provided prefix.
     out_descriptor->custom_kernarg_layout.implicit_args_offset =
         custom_implicit_args_offset;
     out_descriptor->custom_kernarg_layout.total_kernarg_size =

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata.h
@@ -40,6 +40,8 @@ typedef enum iree_hal_amdgpu_executable_export_flag_bits_e {
       1u << 0,
   // Export can only be launched with caller-provided native kernargs.
   IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_CUSTOM_DIRECT_ONLY = 1u << 1,
+  // OpenCL/HIP kernel requires every workgroup to have the same size.
+  IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_UNIFORM_WORKGROUP_SIZE = 1u << 2,
 } iree_hal_amdgpu_executable_export_flag_bits_t;
 typedef uint32_t iree_hal_amdgpu_executable_export_flags_t;
 
@@ -96,6 +98,8 @@ typedef struct iree_hal_amdgpu_executable_export_t {
   uint32_t fixed_group_segment_size;
   // Fixed private segment byte size reported by executable metadata.
   uint32_t fixed_private_segment_size;
+  // Maximum total work-items per workgroup accepted by this export.
+  uint32_t max_workgroup_size;
   // Maximum dynamic group-memory byte count accepted for this export.
   uint32_t max_dynamic_workgroup_local_memory;
   // Native kernarg layout record for normal metadata-described dispatch.

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco.c
@@ -524,8 +524,13 @@ iree_status_t iree_hal_amdgpu_executable_metadata_populate_from_hsaco(
     export_info->fixed_group_segment_size = kernel->group_segment_fixed_size;
     export_info->fixed_private_segment_size =
         kernel->private_segment_fixed_size;
+    export_info->max_workgroup_size = kernel->max_flat_workgroup_size;
     export_info->max_dynamic_workgroup_local_memory =
         UINT32_MAX - kernel->group_segment_fixed_size;
+    if (kernel->uniform_workgroup_size) {
+      export_info->flags |=
+          IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_UNIFORM_WORKGROUP_SIZE;
+    }
     iree_hal_amdgpu_hsaco_load_plan_populate_workgroup_size(kernel,
                                                             export_info);
 

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco_test.cc
@@ -122,8 +122,10 @@ static iree_hal_amdgpu_hsaco_metadata_kernel_t MakeKernel(
       /*.kernarg_segment_alignment=*/8,
       /*.group_segment_fixed_size=*/16,
       /*.private_segment_fixed_size=*/32,
+      /*.max_flat_workgroup_size=*/256,
       /*.required_workgroup_size=*/{},
       /*.has_required_workgroup_size=*/{},
+      /*.uniform_workgroup_size=*/false,
       /*.arg_count=*/args.size(),
       /*.args=*/args.data(),
   };

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
@@ -241,17 +241,19 @@ static iree_status_t iree_hal_amdgpu_host_queue_validate_dispatch_kernargs(
 
   iree_host_size_t operation_resource_count = 1;
   if (iree_any_bit_set(flags, IREE_HAL_DISPATCH_FLAG_CUSTOM_DIRECT_ARGUMENTS)) {
-    const uint32_t required_explicit_bytes =
-        (uint32_t)descriptor->custom_kernarg_layout.explicit_kernarg_size;
+    const iree_host_size_t required_explicit_bytes =
+        iree_hal_amdgpu_device_dispatch_explicit_kernarg_size(
+            &descriptor->custom_kernarg_layout,
+            /*custom_kernarg_length=*/0);
     const iree_host_size_t padded_constant_length =
         iree_host_align(constants.data_length, /*alignment=*/8);
     if (IREE_UNLIKELY(padded_constant_length < required_explicit_bytes)) {
-      return iree_make_status(
-          IREE_STATUS_INVALID_ARGUMENT,
-          "custom dispatch argument length too short; expected at least %u "
-          "but got %" PRIhsz " (padded to %" PRIhsz ")",
-          required_explicit_bytes, constants.data_length,
-          padded_constant_length);
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "custom dispatch argument length too short; "
+                              "expected at least %" PRIhsz " but got %" PRIhsz
+                              " (padded to %" PRIhsz ")",
+                              required_explicit_bytes, constants.data_length,
+                              padded_constant_length);
     }
     if (IREE_UNLIKELY(constants.data_length > 0 && !constants.data)) {
       return iree_make_status(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -629,7 +629,9 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_kernel_fields_t {
   bool has_kernarg_segment_alignment;
   bool has_group_segment_fixed_size;
   bool has_private_segment_fixed_size;
+  bool has_max_flat_workgroup_size;
   bool has_required_workgroup_size;
+  bool has_uniform_workgroup_size;
   bool has_args;
 } iree_hal_amdgpu_hsaco_metadata_kernel_fields_t;
 
@@ -994,6 +996,14 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_parse_kernel(
       IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_read_uint32(
           reader, &out_kernel->private_segment_fixed_size));
       fields.has_private_segment_fixed_size = true;
+    } else if (iree_string_view_equal(key,
+                                      IREE_SV(".max_flat_workgroup_size"))) {
+      if (fields.has_max_flat_workgroup_size) {
+        return iree_hal_amdgpu_hsaco_metadata_duplicate_field_status(key);
+      }
+      IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_read_uint32(
+          reader, &out_kernel->max_flat_workgroup_size));
+      fields.has_max_flat_workgroup_size = true;
     } else if (iree_string_view_equal(key, IREE_SV(".reqd_workgroup_size"))) {
       if (fields.has_required_workgroup_size) {
         return iree_hal_amdgpu_hsaco_metadata_duplicate_field_status(key);
@@ -1002,6 +1012,20 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_parse_kernel(
           reader, out_kernel->required_workgroup_size));
       out_kernel->has_required_workgroup_size = true;
       fields.has_required_workgroup_size = true;
+    } else if (iree_string_view_equal(key,
+                                      IREE_SV(".uniform_work_group_size"))) {
+      if (fields.has_uniform_workgroup_size) {
+        return iree_hal_amdgpu_hsaco_metadata_duplicate_field_status(key);
+      }
+      uint32_t uniform_workgroup_size = 0;
+      IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_read_uint32(
+          reader, &uniform_workgroup_size));
+      if (uniform_workgroup_size > 1) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "AMDGPU uniform_work_group_size must be 0 or 1");
+      }
+      out_kernel->uniform_workgroup_size = uniform_workgroup_size != 0;
+      fields.has_uniform_workgroup_size = true;
     } else if (iree_string_view_equal(key, IREE_SV(".args"))) {
       if (fields.has_args) {
         return iree_hal_amdgpu_hsaco_metadata_duplicate_field_status(key);

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -1018,11 +1018,12 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_parse_kernel(
         return iree_hal_amdgpu_hsaco_metadata_duplicate_field_status(key);
       }
       uint32_t uniform_workgroup_size = 0;
-      IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_read_uint32(
-          reader, &uniform_workgroup_size));
+      IREE_RETURN_IF_ERROR(
+          iree_hal_amdgpu_msgpack_read_uint32(reader, &uniform_workgroup_size));
       if (uniform_workgroup_size > 1) {
-        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                                "AMDGPU uniform_work_group_size must be 0 or 1");
+        return iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "AMDGPU uniform_work_group_size must be 0 or 1");
       }
       out_kernel->uniform_workgroup_size = uniform_workgroup_size != 0;
       fields.has_uniform_workgroup_size = true;

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
@@ -82,10 +82,14 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_kernel_t {
   uint32_t group_segment_fixed_size;
   // Fixed private segment size from `.private_segment_fixed_size`.
   uint32_t private_segment_fixed_size;
+  // Maximum total work-items per workgroup from `.max_flat_workgroup_size`.
+  uint32_t max_flat_workgroup_size;
   // Required workgroup size from `.reqd_workgroup_size`, if present.
   uint32_t required_workgroup_size[3];
   // True when |required_workgroup_size| was present.
   bool has_required_workgroup_size;
+  // True when `.uniform_work_group_size` is present and non-zero.
+  bool uniform_workgroup_size;
   // Number of argument records in |args|.
   iree_host_size_t arg_count;
   // Argument records borrowed from the owning metadata object.

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
@@ -142,13 +142,14 @@ static std::vector<uint8_t> BuildKernelMetadata(
 
   AppendMsgPackString(&output, IREE_SV("amdhsa.kernels"));
   AppendMsgPackArray(&output, 1);
-  AppendMsgPackMap(&output, 8);
+  AppendMsgPackMap(&output, 9);
   AppendStringField(&output, IREE_SV(".name"), IREE_SV("vector_add"));
   AppendStringField(&output, IREE_SV(".symbol"), IREE_SV("vector_add.kd"));
   AppendUintField(&output, IREE_SV(".kernarg_segment_size"), 24);
   AppendUintField(&output, IREE_SV(".kernarg_segment_align"), 8);
   AppendUintField(&output, IREE_SV(".group_segment_fixed_size"), 1024);
   AppendUintField(&output, IREE_SV(".private_segment_fixed_size"), 64);
+  AppendUintField(&output, IREE_SV(".max_flat_workgroup_size"), 256);
   AppendMsgPackString(&output, IREE_SV(".reqd_workgroup_size"));
   AppendMsgPackArray(&output, 3);
   AppendMsgPackUint(&output, 16);
@@ -426,6 +427,7 @@ TEST(HsacoMetadataTest, ParsesValidMetadata) {
   EXPECT_EQ(kernel.kernarg_segment_alignment, 8);
   EXPECT_EQ(kernel.group_segment_fixed_size, 1024);
   EXPECT_EQ(kernel.private_segment_fixed_size, 64);
+  EXPECT_EQ(kernel.max_flat_workgroup_size, 256);
   ASSERT_TRUE(kernel.has_required_workgroup_size);
   EXPECT_EQ(kernel.required_workgroup_size[0], 16);
   EXPECT_EQ(kernel.required_workgroup_size[1], 4);

--- a/runtime/src/iree/hal/executable.h
+++ b/runtime/src/iree/hal/executable.h
@@ -125,6 +125,9 @@ enum iree_hal_executable_function_flag_bits_e {
   // The workgroup size specified on the function info is the minimum size and
   // granularity and any dynamic workgroup size chosen must be a multiple.
   IREE_HAL_EXECUTABLE_FUNCTION_FLAG_WORKGROUP_SIZE_DYNAMIC = 1ull << 1,
+  // OpenCL/HIP uniform-workgroup-size metadata requires global work sizes to
+  // divide evenly by local workgroup sizes.
+  IREE_HAL_EXECUTABLE_FUNCTION_FLAG_UNIFORM_WORKGROUP_SIZE = 1ull << 2,
 };
 typedef uint64_t iree_hal_executable_function_flags_t;
 
@@ -145,6 +148,12 @@ typedef struct iree_hal_executable_function_info_t {
   // If IREE_HAL_EXECUTABLE_FUNCTION_FLAG_WORKGROUP_SIZE_DYNAMIC is set then
   // any dynamic workgroup size must be a multiple of this value.
   uint32_t workgroup_size[3];
+  // Maximum total work-items per workgroup accepted by this function.
+  uint32_t max_workgroup_size;
+  // Fixed workgroup-local memory required by the function, in bytes.
+  uint32_t workgroup_local_memory_size;
+  // Fixed private memory required per work-item, in bytes.
+  uint32_t private_memory_size;
   // Occupancy information hinting at how this function should be scheduled.
   iree_hal_occupancy_info_t occupancy_info;
 } iree_hal_executable_function_info_t;


### PR DESCRIPTION
Carry max workgroup size, fixed local/private memory usage, and uniform-workgroup metadata from HSACO messagepack into executable export info. Preserve custom-direct kernarg layouts with implicit argument offsets so launch paths can separate caller-provided payload from runtime-owned hidden arguments.