### PR TITLE
[HIP] Resolve device pointers for pre-packed extra kernarg buffers

### DIFF
--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -11123,6 +11123,9 @@ HIPAPI hipError_t hipModuleLaunchKernel(
     HIP_RETURN_ERROR(init_result);
   }
 
+  // Untag the function pointer if it was tagged by hipModuleGetFunction.
+  iree_hal_streaming_symbol_t* symbol = iree_hal_streaming_symbol_untag(f);
+
   // Extract params pointer and size from HIP's parameter format.
   void* params_ptr = NULL;
   size_t params_size = 0;
@@ -11141,17 +11144,26 @@ HIPAPI hipError_t hipModuleLaunchKernel(
         params_size = *(size_t*)extra[i + 1];
       }
     }
-    // The extra format provides a pre-packed buffer in the kernel's native ABI.
-    // Mark it as pre-packed so the streaming layer passes it through directly.
-    dispatch_flags |= IREE_HAL_STREAMING_DISPATCH_FLAG_PRE_PACKED;
+    // The extra buffer is laid out in the kernel's native kernarg ABI. When the
+    // kernel has reflected pointer-binding metadata, that buffer holds HIP
+    // device pointers that must be resolved to HAL bindings - the exact same
+    // resolution the static hipLaunchKernelGGL path performs. Marking it
+    // pre-packed would instead pass those raw pointers straight through
+    // (CUSTOM_DIRECT_ARGUMENTS), skipping both pointer resolution and the
+    // HSACO-driven hidden-kernarg synthesis, so the kernel would write through
+    // unresolved pointers and its output would never reach the caller's buffer.
+    // Only pass the buffer through verbatim for kernels WITHOUT binding metadata
+    // (opaque/native kernels such as hipBLASLt), where it is already a complete
+    // native kernarg pack. Kernels with bindings fall through to the streaming
+    // layer's metadata unpack path (dispatch flags NONE).
+    if (!symbol || symbol->parameters.binding_count == 0) {
+      dispatch_flags |= IREE_HAL_STREAMING_DISPATCH_FLAG_PRE_PACKED;
+    }
   } else if (kernelParams) {
     // kernelParams is an array of pointers to the actual parameters.
     params_ptr = kernelParams;
     dispatch_flags |= IREE_HAL_STREAMING_DISPATCH_FLAG_ARGS_ARRAY;
   }
-
-  // Untag the function pointer if it was tagged by hipModuleGetFunction.
-  iree_hal_streaming_symbol_t* symbol = iree_hal_streaming_symbol_untag(f);
 
   const iree_hal_streaming_dispatch_params_t params = {
       .grid_dim = {gridDimX, gridDimY, gridDimZ},
@@ -14055,6 +14067,21 @@ HIPAPI hipError_t hipGraphAddKernelNode(hipGraphNode_t* pGraphNode,
           ? (iree_hal_streaming_graph_node_t**)pDependencies
           : NULL;
 
+  // Resolve the kernel symbol first so the extra-buffer handling below can key
+  // off its reflected parameter metadata.
+  iree_hal_streaming_symbol_t* symbol = NULL;
+  hipError_t symbol_result = iree_hip_resolve_function_symbol(
+      stream_graph->context, params->func, &symbol);
+  if (symbol_result != hipSuccess) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(symbol_result);
+  }
+  if (!params->kernelParams && !params->extra &&
+      !iree_hip_symbol_accepts_empty_kernel_params(symbol)) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+
   // Create dispatch params from kernel node params.
   // Extract params pointer from HIP's parameter format.
   void* params_ptr = NULL;
@@ -14074,7 +14101,15 @@ HIPAPI hipError_t hipGraphAddKernelNode(hipGraphNode_t* pGraphNode,
         params_size = *(size_t*)params->extra[i + 1];
       }
     }
-    dispatch_flags |= IREE_HAL_STREAMING_DISPATCH_FLAG_PRE_PACKED;
+    // Same reasoning as hipModuleLaunchKernel: the extra buffer is in the
+    // kernel's native kernarg ABI, but for kernels with reflected pointer
+    // bindings it still holds HIP device pointers that must be resolved to HAL
+    // bindings. Only pass it through pre-packed for kernels WITHOUT binding
+    // metadata (opaque/native kernels); metadata kernels fall through to the
+    // graph node's metadata unpack path so their pointers resolve.
+    if (!symbol || symbol->parameters.binding_count == 0) {
+      dispatch_flags |= IREE_HAL_STREAMING_DISPATCH_FLAG_PRE_PACKED;
+    }
   } else if (params->kernelParams) {
     // kernelParams is an array of pointers to the actual parameters.
     params_ptr = params->kernelParams;
@@ -14089,19 +14124,6 @@ HIPAPI hipError_t hipGraphAddKernelNode(hipGraphNode_t* pGraphNode,
       .buffer_size = params_size,
       .flags = dispatch_flags,
   };
-
-  iree_hal_streaming_symbol_t* symbol = NULL;
-  hipError_t symbol_result = iree_hip_resolve_function_symbol(
-      stream_graph->context, params->func, &symbol);
-  if (symbol_result != hipSuccess) {
-    IREE_TRACE_ZONE_END(z0);
-    HIP_RETURN_ERROR(symbol_result);
-  }
-  if (!params->kernelParams && !params->extra &&
-      !iree_hip_symbol_accepts_empty_kernel_params(symbol)) {
-    IREE_TRACE_ZONE_END(z0);
-    HIP_RETURN_ERROR(hipErrorInvalidValue);
-  }
 
   // Add kernel node to graph.
   iree_hal_streaming_graph_node_t* node = NULL;
@@ -18606,6 +18628,20 @@ HIPAPI hipError_t hipGraphKernelNodeSetParams(hipGraphNode_t node,
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
   const hipKernelNodeParams* params = (const hipKernelNodeParams*)pNodeParams;
+
+  // Resolve the kernel symbol first so the extra-buffer handling below can key
+  // off its reflected parameter metadata.
+  iree_hal_streaming_symbol_t* symbol = NULL;
+  hipError_t result = iree_hip_resolve_function_symbol(
+      stream_node->graph->context, params->func, &symbol);
+  if (result != hipSuccess) {
+    HIP_RETURN_ERROR(result);
+  }
+  if (!params->kernelParams && !params->extra &&
+      !iree_hip_symbol_accepts_empty_kernel_params(symbol)) {
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+
   void* params_ptr = NULL;
   size_t params_size = 0;
   iree_hal_streaming_dispatch_flags_t dispatch_flags =
@@ -18618,7 +18654,12 @@ HIPAPI hipError_t hipGraphKernelNodeSetParams(hipGraphNode_t node,
         params_size = *(size_t*)params->extra[i + 1];
       }
     }
-    dispatch_flags |= IREE_HAL_STREAMING_DISPATCH_FLAG_PRE_PACKED;
+    // Same reasoning as hipModuleLaunchKernel / hipGraphAddKernelNode: only pass
+    // the extra buffer through pre-packed for kernels WITHOUT binding metadata;
+    // metadata kernels must be unpacked so their device pointers resolve.
+    if (!symbol || symbol->parameters.binding_count == 0) {
+      dispatch_flags |= IREE_HAL_STREAMING_DISPATCH_FLAG_PRE_PACKED;
+    }
   } else if (params->kernelParams) {
     params_ptr = params->kernelParams;
     dispatch_flags |= IREE_HAL_STREAMING_DISPATCH_FLAG_ARGS_ARRAY;
@@ -18632,17 +18673,6 @@ HIPAPI hipError_t hipGraphKernelNodeSetParams(hipGraphNode_t node,
       .buffer_size = params_size,
       .flags = dispatch_flags,
   };
-
-  iree_hal_streaming_symbol_t* symbol = NULL;
-  hipError_t result = iree_hip_resolve_function_symbol(
-      stream_node->graph->context, params->func, &symbol);
-  if (result != hipSuccess) {
-    HIP_RETURN_ERROR(result);
-  }
-  if (!params->kernelParams && !params->extra &&
-      !iree_hip_symbol_accepts_empty_kernel_params(symbol)) {
-    HIP_RETURN_ERROR(hipErrorInvalidValue);
-  }
   HIP_RETURN_STATUS(iree_hal_streaming_graph_set_kernel_node_params(
                         stream_node, symbol, &dispatch_params),
                     hipErrorInvalidValue);

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -11123,8 +11123,19 @@ HIPAPI hipError_t hipModuleLaunchKernel(
     HIP_RETURN_ERROR(init_result);
   }
 
-  // Untag the function pointer if it was tagged by hipModuleGetFunction.
+  // Validate the function handle before untagging it. An untagged or
+  // non-function handle is rejected here (as the other driver-style entry
+  // points do) so the extra-buffer handling below can safely dereference
+  // symbol->parameters.
+  if (!iree_hal_streaming_symbol_has_tag(f)) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(hipErrorInvalidHandle);
+  }
   iree_hal_streaming_symbol_t* symbol = iree_hal_streaming_symbol_untag(f);
+  if (!symbol || symbol->type != IREE_HAL_STREAMING_SYMBOL_TYPE_FUNCTION) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(hipErrorInvalidHandle);
+  }
 
   // Extract params pointer and size from HIP's parameter format.
   void* params_ptr = NULL;
@@ -11152,11 +11163,15 @@ HIPAPI hipError_t hipModuleLaunchKernel(
     // (CUSTOM_DIRECT_ARGUMENTS), skipping both pointer resolution and the
     // HSACO-driven hidden-kernarg synthesis, so the kernel would write through
     // unresolved pointers and its output would never reach the caller's buffer.
-    // Only pass the buffer through verbatim for kernels WITHOUT binding
-    // metadata (opaque/native kernels such as hipBLASLt), where it is already a
-    // complete native kernarg pack. Kernels with bindings fall through to the
-    // streaming layer's metadata unpack path (dispatch flags NONE).
-    if (!symbol || symbol->parameters.binding_count == 0) {
+    // Only pass the buffer through verbatim for kernels WITHOUT binding or
+    // copy metadata (opaque/native kernels such as hipBLASLt), where it is
+    // already a complete native kernarg pack. This matches the streaming
+    // layer's is_native_kernel definition (binding_count == 0 &&
+    // copy_count == 0); scalar-only kernels with copy operations still carry
+    // metadata and must fall through to the metadata unpack path (dispatch
+    // flags NONE) so their pointers resolve.
+    if (!symbol || (symbol->parameters.binding_count == 0 &&
+                    symbol->parameters.copy_count == 0)) {
       dispatch_flags |= IREE_HAL_STREAMING_DISPATCH_FLAG_PRE_PACKED;
     }
   } else if (kernelParams) {
@@ -14104,10 +14119,14 @@ HIPAPI hipError_t hipGraphAddKernelNode(hipGraphNode_t* pGraphNode,
     // Same reasoning as hipModuleLaunchKernel: the extra buffer is in the
     // kernel's native kernarg ABI, but for kernels with reflected pointer
     // bindings it still holds HIP device pointers that must be resolved to HAL
-    // bindings. Only pass it through pre-packed for kernels WITHOUT binding
-    // metadata (opaque/native kernels); metadata kernels fall through to the
-    // graph node's metadata unpack path so their pointers resolve.
-    if (!symbol || symbol->parameters.binding_count == 0) {
+    // bindings. Only pass it through pre-packed for kernels WITHOUT binding or
+    // copy metadata (opaque/native kernels), matching the streaming layer's
+    // is_native_kernel definition (binding_count == 0 && copy_count == 0);
+    // metadata kernels (including scalar-only kernels with copy operations)
+    // fall through to the graph node's metadata unpack path so their pointers
+    // resolve.
+    if (!symbol || (symbol->parameters.binding_count == 0 &&
+                    symbol->parameters.copy_count == 0)) {
       dispatch_flags |= IREE_HAL_STREAMING_DISPATCH_FLAG_PRE_PACKED;
     }
   } else if (params->kernelParams) {
@@ -18655,10 +18674,13 @@ HIPAPI hipError_t hipGraphKernelNodeSetParams(hipGraphNode_t node,
       }
     }
     // Same reasoning as hipModuleLaunchKernel / hipGraphAddKernelNode: only
-    // pass the extra buffer through pre-packed for kernels WITHOUT binding
-    // metadata; metadata kernels must be unpacked so their device pointers
-    // resolve.
-    if (!symbol || symbol->parameters.binding_count == 0) {
+    // pass the extra buffer through pre-packed for kernels WITHOUT binding or
+    // copy metadata, matching the streaming layer's is_native_kernel
+    // definition (binding_count == 0 && copy_count == 0); metadata kernels
+    // (including scalar-only kernels with copy operations) must be unpacked so
+    // their device pointers resolve.
+    if (!symbol || (symbol->parameters.binding_count == 0 &&
+                    symbol->parameters.copy_count == 0)) {
       dispatch_flags |= IREE_HAL_STREAMING_DISPATCH_FLAG_PRE_PACKED;
     }
   } else if (params->kernelParams) {

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -11152,10 +11152,10 @@ HIPAPI hipError_t hipModuleLaunchKernel(
     // (CUSTOM_DIRECT_ARGUMENTS), skipping both pointer resolution and the
     // HSACO-driven hidden-kernarg synthesis, so the kernel would write through
     // unresolved pointers and its output would never reach the caller's buffer.
-    // Only pass the buffer through verbatim for kernels WITHOUT binding metadata
-    // (opaque/native kernels such as hipBLASLt), where it is already a complete
-    // native kernarg pack. Kernels with bindings fall through to the streaming
-    // layer's metadata unpack path (dispatch flags NONE).
+    // Only pass the buffer through verbatim for kernels WITHOUT binding
+    // metadata (opaque/native kernels such as hipBLASLt), where it is already a
+    // complete native kernarg pack. Kernels with bindings fall through to the
+    // streaming layer's metadata unpack path (dispatch flags NONE).
     if (!symbol || symbol->parameters.binding_count == 0) {
       dispatch_flags |= IREE_HAL_STREAMING_DISPATCH_FLAG_PRE_PACKED;
     }
@@ -18654,9 +18654,10 @@ HIPAPI hipError_t hipGraphKernelNodeSetParams(hipGraphNode_t node,
         params_size = *(size_t*)params->extra[i + 1];
       }
     }
-    // Same reasoning as hipModuleLaunchKernel / hipGraphAddKernelNode: only pass
-    // the extra buffer through pre-packed for kernels WITHOUT binding metadata;
-    // metadata kernels must be unpacked so their device pointers resolve.
+    // Same reasoning as hipModuleLaunchKernel / hipGraphAddKernelNode: only
+    // pass the extra buffer through pre-packed for kernels WITHOUT binding
+    // metadata; metadata kernels must be unpacked so their device pointers
+    // resolve.
     if (!symbol || symbol->parameters.binding_count == 0) {
       dispatch_flags |= IREE_HAL_STREAMING_DISPATCH_FLAG_PRE_PACKED;
     }


### PR DESCRIPTION
## Summary

Fixes the `OUTPUT_NOT_WRITTEN` class of bugs in #156 for every HIP entry point that consumes the `HIP_LAUNCH_PARAM_*` (`extra`) pre-packed kernarg buffer.

All of these entry points unconditionally tagged the `extra` buffer with `IREE_HAL_STREAMING_DISPATCH_FLAG_PRE_PACKED`:

- `hipModuleLaunchKernel`
- `hipExtModuleLaunchKernel` (pure delegate to the above)
- `hipGraphAddKernelNode`
- `hipGraphKernelNodeSetParams`
- `hipGraphExecKernelNodeSetParams` (delegates to `hipGraphKernelNodeSetParams`)

`PRE_PACKED` tells the streaming layer to treat the buffer as a finished native kernarg pack and pass it straight through (`CUSTOM_DIRECT_ARGUMENTS`). But for a normal `hipcc`-compiled kernel that carries reflected **pointer-binding metadata**, the `extra` buffer still holds the app's *HIP device pointers*, which must be resolved to HAL bindings before dispatch — plus the hidden kernargs (grid/block/dispatch info) have to be synthesized. Passing the buffer through verbatim skips both steps, so the kernel dereferences unresolved pointers: it runs, writes somewhere that isn't the caller's `out_d`, and the output never surfaces. Every HIP call still returns `hipSuccess`.

This is the exact resolution the **static** `hipLaunchKernelGGL` path already performs (fixed for that path in #120). This PR brings the `extra`/module and graph paths in line.

## The fix

Gate `PRE_PACKED` on the kernel having **no** reflected bindings, and let metadata kernels fall through to the existing metadata-unpack path (dispatch flags `NONE`) that resolves their pointers:

```c
if (!symbol || symbol->parameters.binding_count == 0) {
  dispatch_flags |= IREE_HAL_STREAMING_DISPATCH_FLAG_PRE_PACKED;
}
```

- **Kernels with bindings** (ordinary HIP kernels): fall through to metadata unpack → device pointers resolved to HAL bindings, hidden kernargs synthesized → correct output. ✅
- **Kernels without bindings** (opaque/native, e.g. hipBLASLt): still pass through pre-packed exactly as before → no behavior change. ✅

For the two graph entry points, the kernel-symbol resolution (`iree_hip_resolve_function_symbol`) is reordered to run *before* the flag decision so `binding_count` is available at that point. No functional change to the resolution itself — just moved earlier.

`libhrx/src/binding/hip/api.c`, +62/−32, one call per site.

## How it resolves the issues

Verified under HRX on MI300X / gfx942 with single-purpose repros (attached in #156). Each fails `0`/`OUTPUT_NOT_WRITTEN` before this change and returns `107`/`FULLY_WORKS` after:

| Path (via `extra`) | Before | After |
| --- | --- | --- |
| `hipModuleLaunchKernel` | `0` OUTPUT_NOT_WRITTEN | `107` FULLY_WORKS |
| `hipGraphAddKernelNode` | `0` OUTPUT_NOT_WRITTEN | `107` FULLY_WORKS |
| `hipGraphKernelNodeSetParams` | `0` OUTPUT_NOT_WRITTEN | `107` FULLY_WORKS |
| `hipGraphExecKernelNodeSetParams` | `0` OUTPUT_NOT_WRITTEN | `107` FULLY_WORKS |
| static `hipLaunchKernelGGL` (regression) | `107` (from #120) | `107` FULLY_WORKS |

No new lint. Full local regression (`hrx_probe`, `hrx_probe_module`, the three graph probes, and the `square`/`square_module` samples) passes under HRX.

## Why Option A (and the alternatives considered)

**Option A — gate `PRE_PACKED` at each HIP API site on `binding_count` (this PR).**
- *Pros:* Minimal, localized, and already verified end-to-end. Reuses the exact pointer-resolution the static path relies on, so there's high confidence it's correct. Zero behavior change for native/opaque kernels.
- *Cons:* The rule is repeated at each API call site (currently 3 physical sites; `hipExt*`/exec paths inherit it via delegation). If a *future* entry point learns to accept `extra`, it would need the same guard.

**Option B — push the gate down into the streaming layer, where `is_native_kernel` is already computed.** Decide "pre-packed vs unpack" once, centrally, so every current and future caller inherits it.
- *Pros:* One rule, one place; every entry point (module launch, graph nodes, anything added later) is covered automatically. See the code-flow note below for why this is attractive here specifically.
- *Cons:* More delicate — `PRE_PACKED` also drives the `CUSTOM_DIRECT_ARGUMENTS` vs `NONE` dispatch-flag selection, so that coupling must be adjusted in lockstep, on a hotter/more-shared path. Larger blast radius, more regression surface.

**Option C — treat `PRE_PACKED` as advisory everywhere; make "does the kernel have resolvable bindings?" the single source of truth.** (Option B taken to its conclusion.)
- *Pros:* Cleanest long-term model; no flag/behavior mismatch possible.
- *Cons:* Biggest behavioral change; needs the most regression testing across GEMM/hipBLASLt and graph-capture paths.

**Option D — keep raw pass-through, but separately (1) make referenced buffers resident and (2) synthesize hidden kernargs.**
- *Pros:* Most surgical to the literal failure; smallest change to dispatch behavior.
- *Cons:* Re-derives pointer residency + hidden-arg logic the unpack path already does for free; highest risk of subtle bugs. Only worth it if there's a perf reason to avoid the unpack path.

**Recommendation:** land **Option A** now as the low-risk, verified fix, and consider **Option B** as a follow-up consolidation.

## `hipExtModuleLaunchKernel` and graph kernel-node code flow — where Option B helps

The reason Option A needs touching multiple sites (and Option B is appealing as a follow-up) is how these paths funnel together:

- `hipExtModuleLaunchKernel` → **delegates to** `hipModuleLaunchKernel`, so it's fixed for free here. But that's a delegation coincidence, not a structural guarantee.
- `hipGraphExecKernelNodeSetParams` → **delegates to** `hipGraphKernelNodeSetParams`, likewise fixed transitively.
- `hipGraphAddKernelNode` / `hipGraphKernelNodeSetParams` build the `dispatch_params` at the **API layer**, then hand them to `iree_hal_streaming_graph_*` in `graph.c`; the module path hands them to `iree_hal_streaming_launch_kernel` in `stream.c`. Both lower-level functions take the `is_pre_packed` branch based on the flag they're *given* — i.e. the decision is currently made above them, per entry point.

So the same "pre-packed vs unpack" decision is re-expressed at each API entry today. **Option B** would move the `binding_count` gate down into `stream.c` / `graph.c` (right where `is_native_kernel` is already computed), making it the single decision point that both the launch and graph paths pass through — at which point the per-site guards in this PR become redundant and any future `extra`-consuming entry point is covered automatically. The trade-off is the flag/dispatch-mode coupling noted above.

## @AWoloszyn — one question before considering B/C over A

The gate assumes: *if a kernel has reflected bindings, its `extra` buffer must be unpacked/resolved rather than passed through.* Is there any kernel in the HRX corpus that **deliberately** relies on `PRE_PACKED` pass-through **despite** having binding metadata — e.g. a hand-packed buffer with padding/alignment that intentionally doesn't match the reflected offsets? I couldn't find one, and the layer already falls back to raw pass-through if metadata resolution fails, so Option A looks safe — but you'd know the kernel corpus best. If no such kernel exists, Option B/C become clean consolidations; if one does, the gate needs an explicit opt-out. Would appreciate your read on this before we invest in B/C.

Refs #156.
