### PR TITLE
Fix topology storage max alignment

### DIFF
--- a/runtime/src/iree/hal/topology_builder.c
+++ b/runtime/src/iree/hal/topology_builder.c
@@ -63,7 +63,7 @@ static iree_status_t iree_hal_topology_storage_layout_calculate(
       &device_edges_offset));
   IREE_ASSERT_EQ(device_edges_offset,
                  offsetof(iree_hal_topology_t, device_edges));
-  total_size = iree_host_align(total_size, iree_alignof(iree_max_align_t));
+  total_size = iree_host_align(total_size, iree_max_align_t);
 
   iree_host_size_t nodes_offset = 0;
   IREE_RETURN_IF_ERROR(iree_hal_topology_storage_layout_append_array(


### PR DESCRIPTION
iree_max_align_t is already the numeric maximum host alignment value, not a type. Passing iree_alignof(iree_max_align_t) asks for the alignment of the expression produced by that value, which is conceptually the wrong operation even on compilers that accept it.

Pass iree_max_align_t directly to iree_host_align so the topology storage layout is padded to the intended maximum host alignment.

On MSVC the old expression expands to __alignof(16) and fails with: topology_builder.c(66): error C2059: syntax error: 'constant'.