### PR TITLE
[hip] Fix hipGetProcAddress symbol resolution under RTLD_LOCAL

### DIFF
--- a/libhrx/src/binding/hip/BUILD.bazel
+++ b/libhrx/src/binding/hip/BUILD.bazel
@@ -52,10 +52,17 @@ hrx_cc_shared_library(
 hrx_cc_test(
     name = "hip_get_proc_address_test",
     srcs = ["hip_get_proc_address_test.cc"],
-    # The test dlopen()s the built shared object with RTLD_LOCAL to reproduce
-    # the consumer scenario (e.g. Triton), so it needs the artifact at runtime.
-    data = [":amdhip64"],
+    # The test dlopen()s the built libamdhip64 with RTLD_LOCAL to reproduce the
+    # consumer scenario (e.g. Triton). Under CMake the exact artifact path is
+    # injected via the HRX_TEST_LIBAMDHIP64_PATH compile definition and its
+    # build dependency (see CMakeLists.txt below the preserve marker). Under
+    # Bazel, point the test at the artifact with HRX_TEST_LIBAMDHIP64, e.g.
+    # `bazel test --test_env=HRX_TEST_LIBAMDHIP64=$(bazel cquery ...)`; without
+    # it the test skips (GTEST_SKIP) rather than failing.
     deps = [
+        # The test itself calls dlopen()/dlsym()/dlclose(); link libdl so the
+        # executable resolves them (glibc that ships dl separately, ld.lld).
+        "//build_tools:dl",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",
     ],

--- a/libhrx/src/binding/hip/BUILD.bazel
+++ b/libhrx/src/binding/hip/BUILD.bazel
@@ -7,6 +7,7 @@
 load(
     "//libhrx/build_tools/bazel:cc.bzl",
     "hrx_cc_shared_library",
+    "hrx_cc_test",
 )
 
 package(
@@ -42,5 +43,17 @@ hrx_cc_shared_library(
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/threading",
         "//runtime/src/iree/hal",
+    ],
+)
+
+hrx_cc_test(
+    name = "hip_get_proc_address_test",
+    srcs = ["hip_get_proc_address_test.cc"],
+    # The test dlopen()s the built shared object with RTLD_LOCAL to reproduce
+    # the consumer scenario (e.g. Triton), so it needs the artifact at runtime.
+    data = [":amdhip64"],
+    deps = [
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
     ],
 )

--- a/libhrx/src/binding/hip/BUILD.bazel
+++ b/libhrx/src/binding/hip/BUILD.bazel
@@ -22,7 +22,10 @@ hrx_cc_shared_library(
         "abi_stubs.c",
         "api.c",
     ],
-    hdrs = ["api.h"],
+    hdrs = [
+        "api.h",
+        "binding_internal.h",
+    ],
     additional_linker_inputs = ["amdhip64.map"],
     copts = [
         "-DIREE_HAL_STREAMING_HIP_EXPORTS",

--- a/libhrx/src/binding/hip/CMakeLists.txt
+++ b/libhrx/src/binding/hip/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_cc_library(
     "-Wno-unused-variable"
   HDRS
     "api.h"
+    "binding_internal.h"
   SRCS
     "abi_stubs.c"
     "api.c"

--- a/libhrx/src/binding/hip/CMakeLists.txt
+++ b/libhrx/src/binding/hip/CMakeLists.txt
@@ -41,7 +41,30 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_test(
+  NAME
+    hip_get_proc_address_test
+  SRCS
+    "hip_get_proc_address_test.cc"
+  DATA
+    ::amdhip64
+  DEPS
+    iree::testing::gtest
+    iree::testing::gtest_main
+    libhrx_defs
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
+
+# Point hip_get_proc_address_test at the shared object built in this tree so it
+# can dlopen() the exact artifact under test. Guarded because the test target
+# only exists when tests are enabled.
+if(TARGET libhrx_src_binding_hip_hip_get_proc_address_test)
+  target_compile_definitions(libhrx_src_binding_hip_hip_get_proc_address_test
+    PRIVATE
+      "HRX_TEST_LIBAMDHIP64_PATH=\"$<TARGET_FILE:libhrx_src_binding_hip_amdhip64>\""
+  )
+endif()
 
 # The symbol version script and --undefined-version are applied through the
 # generated LINKOPTS above (from linkopts in BUILD.bazel). Keep them out of

--- a/libhrx/src/binding/hip/CMakeLists.txt
+++ b/libhrx/src/binding/hip/CMakeLists.txt
@@ -47,9 +47,8 @@ iree_cc_test(
     hip_get_proc_address_test
   SRCS
     "hip_get_proc_address_test.cc"
-  DATA
-    ::amdhip64
   DEPS
+    ${CMAKE_DL_LIBS}
     iree::testing::gtest
     iree::testing::gtest_main
     libhrx_defs
@@ -58,12 +57,18 @@ iree_cc_test(
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
 
 # Point hip_get_proc_address_test at the shared object built in this tree so it
-# can dlopen() the exact artifact under test. Guarded because the test target
-# only exists when tests are enabled.
+# can dlopen() the exact artifact under test, and make sure that artifact is
+# built first. Guarded because the test target only exists when tests are
+# enabled. (The library is passed by absolute path rather than as a test DATA
+# edge because DATA installs into the relocatable test tree, and the shim's
+# build-tree path is only valid for the in-tree ctest run.)
 if(TARGET libhrx_src_binding_hip_hip_get_proc_address_test)
   target_compile_definitions(libhrx_src_binding_hip_hip_get_proc_address_test
     PRIVATE
       "HRX_TEST_LIBAMDHIP64_PATH=\"$<TARGET_FILE:libhrx_src_binding_hip_amdhip64>\""
+  )
+  add_dependencies(libhrx_src_binding_hip_hip_get_proc_address_test
+    libhrx_src_binding_hip_amdhip64
   )
 endif()
 

--- a/libhrx/src/binding/hip/abi_stubs.c
+++ b/libhrx/src/binding/hip/abi_stubs.c
@@ -15,6 +15,7 @@
 #include <string.h>
 
 #include "libhrx/src/binding/hip/api.h"
+#include "libhrx/src/binding/hip/binding_internal.h"
 
 // Local compatibility declarations for unsupported ABI entries. These symbols
 // only need type-correct call boundaries here; their implementations below
@@ -167,8 +168,17 @@ static hipError_t hrx_hip_spt_lookup(const char* symbol, void** function,
                                      void* symbol_status) {
   if (!symbol || !function) return hipErrorInvalidValue;
 
-  void* process = dlopen(NULL, RTLD_LAZY);
-  if (!process) {
+  // Resolve against this library, not the process-global scope; see
+  // iree_hip_self_dl_handle(). Like hipGetProcAddress(), a consumer may dlopen
+  // us with RTLD_LOCAL, so a dlsym(dlopen(NULL), ...) lookup would spuriously
+  // fail. Fall back to the global scope only if the self-handle is unavailable.
+  void* handle = iree_hip_self_dl_handle();
+  bool close_handle = false;
+  if (!handle) {
+    handle = dlopen(NULL, RTLD_LAZY);
+    close_handle = handle != NULL;
+  }
+  if (!handle) {
     *function = NULL;
     if (symbol_status) *(int*)symbol_status = 1;
     return hipErrorSharedObjectInitFailed;
@@ -181,9 +191,10 @@ static hipError_t hrx_hip_spt_lookup(const char* symbol, void** function,
       (symbol_length < 4 || strcmp(symbol + symbol_length - 4, "_spt") != 0)) {
     snprintf(stream_per_thread_symbol, sizeof(stream_per_thread_symbol),
              "%s_spt", symbol);
-    found = dlsym(process, stream_per_thread_symbol);
+    found = dlsym(handle, stream_per_thread_symbol);
   }
-  if (!found) found = dlsym(process, symbol);
+  if (!found) found = dlsym(handle, symbol);
+  if (close_handle) dlclose(handle);
 
   *function = found;
   if (symbol_status) *(int*)symbol_status = found ? 0 : 1;

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #endif
 
+#include "binding/hip/binding_internal.h"
 #include "common/graph.h"
 #include "common/internal.h"
 #include "common/tls.h"
@@ -21456,8 +21457,9 @@ HIPAPI const char* hipGetErrorName(hipError_t error) {
 }
 
 // Handle scoped to THIS shared object (the HIP shim), resolved once. See the
-// note on hipGetProcAddress() for why the process-global scope is insufficient.
-static void* iree_hip_self_dl_handle = NULL;
+// declaration in binding_internal.h and the note on hipGetProcAddress() for why
+// the process-global scope is insufficient.
+static void* iree_hip_self_dl_handle_cached = NULL;
 static iree_once_flag iree_hip_self_dl_handle_once = IREE_ONCE_FLAG_INIT;
 static void iree_hip_init_self_dl_handle(void) {
   Dl_info info;
@@ -21465,8 +21467,14 @@ static void iree_hip_init_self_dl_handle(void) {
   // it with RTLD_NOLOAD returns a handle to the already-resident module (the
   // extra reference intentionally pins the always-loaded HIP runtime).
   if (dladdr((void*)&hipGetProcAddress, &info) != 0 && info.dli_fname) {
-    iree_hip_self_dl_handle = dlopen(info.dli_fname, RTLD_LAZY | RTLD_NOLOAD);
+    iree_hip_self_dl_handle_cached =
+        dlopen(info.dli_fname, RTLD_LAZY | RTLD_NOLOAD);
   }
+}
+
+void* iree_hip_self_dl_handle(void) {
+  iree_call_once(&iree_hip_self_dl_handle_once, iree_hip_init_self_dl_handle);
+  return iree_hip_self_dl_handle_cached;
 }
 
 HIPAPI hipError_t hipGetProcAddress(const char* symbol, void** pfn,
@@ -21484,8 +21492,7 @@ HIPAPI hipError_t hipGetProcAddress(const char* symbol, void** pfn,
   // dlsym(dlopen(NULL), ...) lookup would spuriously fail with
   // hipErrorNotFound. Fall back to the global scope only if the self-handle
   // could not be established.
-  iree_call_once(&iree_hip_self_dl_handle_once, iree_hip_init_self_dl_handle);
-  void* handle = iree_hip_self_dl_handle;
+  void* handle = iree_hip_self_dl_handle();
   bool close_handle = false;
   if (!handle) {
     handle = dlopen(NULL, RTLD_LAZY);

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -4,6 +4,14 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// _GNU_SOURCE must be defined before any system header so that <dlfcn.h>
+// exposes the GNU extensions dladdr()/Dl_info and the RTLD_NOLOAD flag, which
+// hipGetProcAddress() uses to resolve symbols against this shared object
+// itself rather than the process-global scope.
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include "binding/hip/api.h"
 
 #include <dlfcn.h>
@@ -21447,6 +21455,20 @@ HIPAPI const char* hipGetErrorName(hipError_t error) {
   return hipGetErrorString(error);
 }
 
+// Handle scoped to THIS shared object (the HIP shim), resolved once. See the
+// note on hipGetProcAddress() for why the process-global scope is insufficient.
+static void* iree_hip_self_dl_handle = NULL;
+static iree_once_flag iree_hip_self_dl_handle_once = IREE_ONCE_FLAG_INIT;
+static void iree_hip_init_self_dl_handle(void) {
+  Dl_info info;
+  // dladdr() on a symbol we define yields the path to this library; reopening
+  // it with RTLD_NOLOAD returns a handle to the already-resident module (the
+  // extra reference intentionally pins the always-loaded HIP runtime).
+  if (dladdr((void*)&hipGetProcAddress, &info) != 0 && info.dli_fname) {
+    iree_hip_self_dl_handle = dlopen(info.dli_fname, RTLD_LAZY | RTLD_NOLOAD);
+  }
+}
+
 HIPAPI hipError_t hipGetProcAddress(const char* symbol, void** pfn,
                                     int hipVersion, uint64_t flags,
                                     void* symbolStatus) {
@@ -21456,13 +21478,26 @@ HIPAPI hipError_t hipGetProcAddress(const char* symbol, void** pfn,
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
 
-  void* process = dlopen(NULL, RTLD_LAZY);
-  if (!process) {
+  // Resolve symbols against this library, not the process-global scope. A
+  // consumer may dlopen us with RTLD_LOCAL (Triton's AMD backend does exactly
+  // this), so our symbols never enter the global namespace and a
+  // dlsym(dlopen(NULL), ...) lookup would spuriously fail with
+  // hipErrorNotFound. Fall back to the global scope only if the self-handle
+  // could not be established.
+  iree_call_once(&iree_hip_self_dl_handle_once, iree_hip_init_self_dl_handle);
+  void* handle = iree_hip_self_dl_handle;
+  bool close_handle = false;
+  if (!handle) {
+    handle = dlopen(NULL, RTLD_LAZY);
+    close_handle = handle != NULL;
+  }
+  if (!handle) {
     *pfn = NULL;
     if (symbolStatus) *(int*)symbolStatus = 1;
     HIP_RETURN_ERROR(hipErrorSharedObjectInitFailed);
   }
-  *pfn = dlsym(process, symbol);
+  *pfn = dlsym(handle, symbol);
+  if (close_handle) dlclose(handle);
   if (symbolStatus) *(int*)symbolStatus = *pfn ? 0 : 1;
   HIP_RETURN_ERROR(*pfn ? hipSuccess : hipErrorNotFound);
 }

--- a/libhrx/src/binding/hip/binding_internal.h
+++ b/libhrx/src/binding/hip/binding_internal.h
@@ -9,4 +9,18 @@
 
 #include "common/internal.h"
 
+// Returns a dlopen handle scoped to THIS shared object (the HIP shim), or NULL
+// if it could not be established. The handle is resolved once and cached for
+// the process lifetime; callers must NOT dlclose() it.
+//
+// This is the single source of truth for the "resolve HIP symbols against our
+// own library" behavior shared by hipGetProcAddress() and the _spt lookup
+// (hipGetProcAddress_spt/hipGetDriverEntryPoint_spt). It exists because a
+// consumer may dlopen the HIP runtime with RTLD_LOCAL (Triton's AMD backend
+// does exactly this), which keeps our symbols out of the process-global scope;
+// a dlsym(dlopen(NULL), ...) lookup would then spuriously fail. Callers should
+// dlsym() against this handle and fall back to the global scope only if it is
+// NULL. Defined in api.c (which enables the GNU extensions it needs).
+void* iree_hip_self_dl_handle(void);
+
 #endif  // HRX_BINDING_HIP_BINDING_INTERNAL_H_

--- a/libhrx/src/binding/hip/hip_get_proc_address_test.cc
+++ b/libhrx/src/binding/hip/hip_get_proc_address_test.cc
@@ -1,17 +1,21 @@
 // Copyright 2026 The HRX Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Regression test for hipGetProcAddress() symbol resolution scope.
+// Regression test for hipGetProcAddress()-family symbol resolution scope.
 //
 // hipGetProcAddress() must resolve symbols against the HIP runtime library
 // that defines them, NOT the process-global symbol scope. Consumers such as
 // Triton's AMD backend dlopen() libamdhip64 with RTLD_LOCAL and then resolve
-// the whole HIP API through hipGetProcAddress(). When hipGetProcAddress() was
-// implemented as dlsym(dlopen(NULL), symbol) it searched only the global
+// the whole HIP API through hipGetProcAddress(). When these entry points were
+// implemented as dlsym(dlopen(NULL), symbol) they searched only the global
 // scope, so an RTLD_LOCAL load left our symbols invisible and every lookup
 // (starting with the very first, hipGetLastError) failed with
 // hipErrorNotFound -- taking down Triton at driver-init time. See issue for
 // details.
+//
+// The same lookup backs the stream-per-thread variants
+// (hipGetProcAddress_spt / hipGetDriverEntryPoint_spt via hrx_hip_spt_lookup),
+// so those had the identical bug and are exercised here too.
 //
 // The library under test is located via, in order: the HRX_TEST_LIBAMDHIP64
 // environment variable (an explicit override), then the
@@ -49,32 +53,44 @@ const char* CandidateLibPath() {
 #endif
 }
 
+// Resolves `entry_point` from the RTLD_LOCAL-loaded library and asserts it can
+// look up a core HIP symbol (hipGetLastError, the first thing Triton needs).
 // Opening RTLD_LOCAL is the whole point: it mirrors how Triton loads the HIP
 // runtime and is the condition that exposed the bug.
-TEST(HipGetProcAddressTest, ResolvesOwnSymbolWhenLoadedRtldLocal) {
+void ExpectResolvesUnderRtldLocal(const char* entry_point) {
   const char* path = CandidateLibPath();
   void* lib = dlopen(path, RTLD_LAZY | RTLD_LOCAL);
   if (lib == nullptr) {
     GTEST_SKIP() << "cannot dlopen " << path << ": " << dlerror();
   }
 
-  auto hip_get_proc_address =
-      reinterpret_cast<hipGetProcAddressFn>(dlsym(lib, "hipGetProcAddress"));
-  ASSERT_NE(hip_get_proc_address, nullptr)
-      << "hipGetProcAddress not exported by " << path;
+  auto get_proc_address =
+      reinterpret_cast<hipGetProcAddressFn>(dlsym(lib, entry_point));
+  ASSERT_NE(get_proc_address, nullptr)
+      << entry_point << " not exported by " << path;
 
   void* pfn = nullptr;
   int symbol_status = -1;
   // hipVersion 60000000 == major 6; matches the minimum Triton requires.
-  int rc = hip_get_proc_address("hipGetLastError", &pfn, 60000000,
-                                /*flags=*/0, &symbol_status);
+  int rc = get_proc_address("hipGetLastError", &pfn, 60000000,
+                            /*flags=*/0, &symbol_status);
 
   EXPECT_EQ(rc, kHipSuccess)
-      << "hipGetProcAddress must resolve own symbols under RTLD_LOCAL";
+      << entry_point << " must resolve own symbols under RTLD_LOCAL";
   EXPECT_NE(pfn, nullptr) << "resolved function pointer must be non-null";
   EXPECT_EQ(symbol_status, 0) << "symbolStatus must report success";
 
   dlclose(lib);
+}
+
+TEST(HipGetProcAddressTest, ResolvesOwnSymbolWhenLoadedRtldLocal) {
+  ExpectResolvesUnderRtldLocal("hipGetProcAddress");
+}
+
+// The stream-per-thread entry point shares the same underlying lookup
+// (hrx_hip_spt_lookup) and had the identical process-global-scope bug.
+TEST(HipGetProcAddressTest, SptEntryPointResolvesOwnSymbolWhenLoadedRtldLocal) {
+  ExpectResolvesUnderRtldLocal("hipGetProcAddress_spt");
 }
 
 }  // namespace

--- a/libhrx/src/binding/hip/hip_get_proc_address_test.cc
+++ b/libhrx/src/binding/hip/hip_get_proc_address_test.cc
@@ -1,0 +1,80 @@
+// Copyright 2026 The HRX Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression test for hipGetProcAddress() symbol resolution scope.
+//
+// hipGetProcAddress() must resolve symbols against the HIP runtime library
+// that defines them, NOT the process-global symbol scope. Consumers such as
+// Triton's AMD backend dlopen() libamdhip64 with RTLD_LOCAL and then resolve
+// the whole HIP API through hipGetProcAddress(). When hipGetProcAddress() was
+// implemented as dlsym(dlopen(NULL), symbol) it searched only the global
+// scope, so an RTLD_LOCAL load left our symbols invisible and every lookup
+// (starting with the very first, hipGetLastError) failed with
+// hipErrorNotFound -- taking down Triton at driver-init time. See issue for
+// details.
+//
+// The library under test is located via, in order: the HRX_TEST_LIBAMDHIP64
+// environment variable (an explicit override), then the
+// HRX_TEST_LIBAMDHIP64_PATH compile definition (set by CMake to the freshly
+// built artifact), then the bare soname "libamdhip64.so" (resolved through the
+// loader search path). If none can be opened the test is skipped rather than
+// failed, so it is inert in build configurations that do not produce the
+// shared object.
+
+#include <dlfcn.h>
+
+#include <cstdint>
+#include <cstdlib>
+
+#include "iree/testing/gtest.h"
+
+namespace {
+
+// hipSuccess is 0 in the HIP ABI.
+constexpr int kHipSuccess = 0;
+
+using hipGetProcAddressFn = int (*)(const char* symbol, void** pfn,
+                                    int hipVersion, uint64_t flags,
+                                    void* symbolStatus);
+
+const char* CandidateLibPath() {
+  if (const char* env = std::getenv("HRX_TEST_LIBAMDHIP64");
+      env && *env != '\0') {
+    return env;
+  }
+#ifdef HRX_TEST_LIBAMDHIP64_PATH
+  return HRX_TEST_LIBAMDHIP64_PATH;
+#else
+  return "libamdhip64.so";
+#endif
+}
+
+// Opening RTLD_LOCAL is the whole point: it mirrors how Triton loads the HIP
+// runtime and is the condition that exposed the bug.
+TEST(HipGetProcAddressTest, ResolvesOwnSymbolWhenLoadedRtldLocal) {
+  const char* path = CandidateLibPath();
+  void* lib = dlopen(path, RTLD_LAZY | RTLD_LOCAL);
+  if (lib == nullptr) {
+    GTEST_SKIP() << "cannot dlopen " << path << ": " << dlerror();
+  }
+
+  auto hip_get_proc_address =
+      reinterpret_cast<hipGetProcAddressFn>(dlsym(lib, "hipGetProcAddress"));
+  ASSERT_NE(hip_get_proc_address, nullptr)
+      << "hipGetProcAddress not exported by " << path;
+
+  void* pfn = nullptr;
+  int symbol_status = -1;
+  // hipVersion 60000000 == major 6; matches the minimum Triton requires.
+  int rc = hip_get_proc_address("hipGetLastError", &pfn, 60000000,
+                                /*flags=*/0, &symbol_status);
+
+  EXPECT_EQ(rc, kHipSuccess)
+      << "hipGetProcAddress must resolve own symbols under RTLD_LOCAL";
+  EXPECT_NE(pfn, nullptr) << "resolved function pointer must be non-null";
+  EXPECT_EQ(symbol_status, 0) << "symbolStatus must report success";
+
+  dlclose(lib);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

`hipGetProcAddress()` resolved symbols against the **process-global** symbol
scope (`dlsym(dlopen(NULL), symbol)`) instead of against the HIP runtime library
that defines them. Any consumer that `dlopen`s `libamdhip64.so` with
`RTLD_LOCAL` therefore cannot resolve **any** HIP entry point through
`hipGetProcAddress()` — an `RTLD_LOCAL` library never exports its symbols into
the global scope.

This breaks **Triton**: its AMD backend does
`dlopen(libamdhip64.so, RTLD_LAZY | RTLD_LOCAL)` and then binds the whole HIP API
via `hipGetProcAddress`. The first required symbol (`hipGetLastError`) fails, so
Triton dies at driver-init with:

```
RuntimeError: cannot get address for 'hipGetLastError' from libamdhip64.so
```

This is a pre-existing bug on `main` (independent of any in-flight work).

Fixes #162.

## Fix

Resolve against **this** module: `dladdr()` on an owned symbol yields our own
path, which is reopened once with `RTLD_NOLOAD` to get a handle scoped to the
HIP runtime library (resolved lazily via `iree_call_once`). Falls back to the
global scope only if the self-handle cannot be established. `_GNU_SOURCE` is
defined for `dladdr`/`Dl_info`/`RTLD_NOLOAD`.

## Test

Adds `hip_get_proc_address_test` (`hrx_cc_test`): `dlopen(..., RTLD_LOCAL)` then
asserts `hipGetProcAddress("hipGetLastError", ...)` returns `hipSuccess` with a
non-null pointer, reproducing the consumer (Triton) scenario. It **fails** on
the old implementation and **passes** with the fix. The generated
`CMakeLists.txt` was regenerated with `bazel_to_cmake` and is in sync with
`BUILD.bazel`.

## Verification

- GPU-free C reproducer: `RTLD_LOCAL` goes `FAIL` (hipErrorNotFound) → `OK`
  after the fix; `RTLD_GLOBAL` stays `OK`.
- New gtest passes.
- Both Triton workloads (`triton_add.py`, minimal `add.py`) go from failing at
  `hipGetProcAddress` to `VERDICT=FULLY_WORKS` end-to-end through HRX.

Made with [Cursor](https://cursor.com)