### PR TITLE
hip: device-side timestamps for hipEventElapsedTime

### DIFF
--- a/libhrx/src/binding/common/BUILD.bazel
+++ b/libhrx/src/binding/common/BUILD.bazel
@@ -101,6 +101,20 @@ hrx_cc_test(
     ],
 )
 
+# Drives the streaming event timing host path on a host (local-task) device,
+# so it is GPU-free and runnable without an accelerator.
+hrx_cc_test(
+    name = "event_test",
+    srcs = ["event_test.cc"],
+    deps = [
+        ":common",
+        "//libhrx/src/libhrx:hrx_static",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
 hrx_cc_benchmark(
     name = "buffer_table_benchmark",
     srcs = ["buffer_table_benchmark.cc"],

--- a/libhrx/src/binding/common/CMakeLists.txt
+++ b/libhrx/src/binding/common/CMakeLists.txt
@@ -92,6 +92,20 @@ iree_cc_test(
     libhrx_defs
 )
 
+iree_cc_test(
+  NAME
+    event_test
+  SRCS
+    "event_test.cc"
+  DEPS
+    ::common
+    iree::base
+    iree::testing::gtest
+    iree::testing::gtest_main
+    libhrx::src::libhrx::hrx
+    libhrx_defs
+)
+
 iree_cc_binary_benchmark(
   NAME
     buffer_table_benchmark

--- a/libhrx/src/binding/common/event.c
+++ b/libhrx/src/binding/common/event.c
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 static void iree_hal_streaming_event_destroy(iree_hal_streaming_event_t* event);
+static iree_status_t iree_hal_streaming_event_enable_device_timing(
+    iree_hal_streaming_event_t* event, iree_hal_streaming_context_t* context);
 
 iree_status_t iree_hal_streaming_event_create(
     iree_hal_streaming_context_t* context,
@@ -34,6 +36,9 @@ iree_status_t iree_hal_streaming_event_create(
   event->context = context;
   iree_hal_streaming_context_retain(context);
   event->record_time_ns = 0;
+  event->timestamp_buffer = NULL;
+  event->timestamp_frequency_hz = 0;
+  event->device_tick_valid = false;
   event->ipc_handle = NULL;
   event->capture_graph = NULL;
   event->capture_dependencies = NULL;
@@ -46,6 +51,15 @@ iree_status_t iree_hal_streaming_event_create(
   iree_status_t status = iree_hal_semaphore_create(
       context->device, IREE_HAL_QUEUE_AFFINITY_ANY, 0ULL,
       IREE_HAL_SEMAPHORE_FLAG_NONE, &event->semaphore);
+
+  // Enable device-side timing when the device advertises a device timestamp
+  // domain. Devices without one stay host-timed; a capable device that cannot
+  // allocate its tick buffer fails creation rather than silently using
+  // (wrong) host timing.
+  if (iree_status_is_ok(status) &&
+      !iree_all_bits_set(flags, IREE_HAL_STREAMING_EVENT_FLAG_DISABLE_TIMING)) {
+    status = iree_hal_streaming_event_enable_device_timing(event, context);
+  }
 
   if (iree_status_is_ok(status)) {
     *out_event = event;
@@ -63,6 +77,9 @@ static void iree_hal_streaming_event_destroy(
   // Release semaphore.
   iree_hal_semaphore_release(event->semaphore);
 
+  // Release device timestamp buffer.
+  iree_hal_buffer_release(event->timestamp_buffer);
+
   // Release recording stream reference.
   iree_hal_streaming_stream_release(event->recording_stream);
 
@@ -77,6 +94,47 @@ static void iree_hal_streaming_event_destroy(
   iree_allocator_free(host_allocator, event);
 
   IREE_TRACE_ZONE_END(z0);
+}
+
+// Enables device-side timestamping for |event| when the device advertises a
+// device timestamp domain, allocating the per-event tick buffer. Returns OK and
+// leaves the event host-timed (timestamp_buffer == NULL) when the device does
+// not advertise the capability. Returns a failure status when the device DOES
+// advertise it but the tick buffer cannot be allocated: dropping to host timing
+// there would report wrong (host-enqueue) durations on a device that can
+// measure real ones.
+static iree_status_t iree_hal_streaming_event_enable_device_timing(
+    iree_hal_streaming_event_t* event, iree_hal_streaming_context_t* context) {
+  const iree_hal_device_spec_t* spec = iree_hal_device_spec(context->device);
+  if (!spec) return iree_ok_status();
+  // iree_hal_device_spec_timing returns &spec->timing, so it is non-NULL once
+  // spec is.
+  const iree_hal_device_timing_spec_t* timing =
+      iree_hal_device_spec_timing(spec);
+  if (!iree_all_bits_set(timing->flags,
+                         IREE_HAL_DEVICE_TIMING_SPEC_FLAG_DEVICE_TIMESTAMPS) ||
+      timing->timestamp_frequency_hz == 0) {
+    // Device does not advertise device-side timestamps; the event stays
+    // host-timed.
+    return iree_ok_status();
+  }
+  iree_hal_buffer_params_t params = {0};
+  // Host-visible host-pool buffer; adding DEVICE_LOCAL would require a
+  // fine-grained device pool that only large-BAR / APU GPUs expose. The host
+  // pool is device-visible, so the device still writes the tick here and the
+  // host maps it to read it back.
+  params.type = IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
+  params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING;
+  params.access = IREE_HAL_MEMORY_ACCESS_ALL;
+  params.queue_affinity = IREE_HAL_QUEUE_AFFINITY_ANY;
+  iree_hal_buffer_t* buffer = NULL;
+  // The device advertised the capability, so a failed allocation is a real
+  // error rather than a reason to fall back to (wrong) host timing.
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
+      context->device_allocator, params, sizeof(uint64_t), &buffer));
+  event->timestamp_buffer = buffer;
+  event->timestamp_frequency_hz = timing->timestamp_frequency_hz;
+  return iree_ok_status();
 }
 
 void iree_hal_streaming_event_retain(iree_hal_streaming_event_t* event) {
@@ -114,6 +172,10 @@ iree_status_t iree_hal_streaming_event_record(
   IREE_ASSERT_ARGUMENT(event);
   IREE_ASSERT_ARGUMENT(stream);
   IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Reset per-record: only a successful device-tick write below sets this true,
+  // so capture- and graph-recorded events remain host-timed.
+  event->device_tick_valid = false;
 
   // Check if we're capturing to a graph.
   if (stream->capture_status == IREE_HAL_STREAMING_CAPTURE_STATUS_ACTIVE) {
@@ -182,9 +244,20 @@ iree_status_t iree_hal_streaming_event_record(
       .payload_values = signal_values,
   };
 
-  iree_status_t status = iree_hal_device_queue_barrier(
-      stream->context->device, stream->queue_affinity, wait_semaphores,
-      signal_semaphores, IREE_HAL_EXECUTE_FLAG_NONE);
+  // Device-timed events write a device GPU-clock tick at this queue point; the
+  // timestamp op signals the same semaphores a barrier would. Host-timed events
+  // use a plain barrier (record_time_ns above is the timestamp).
+  iree_status_t status;
+  if (event->timestamp_buffer) {
+    status = iree_hal_device_queue_timestamp(
+        stream->context->device, stream->queue_affinity, wait_semaphores,
+        signal_semaphores, event->timestamp_buffer,
+        /*target_offset=*/0, IREE_HAL_TIMESTAMP_FLAG_NONE);
+  } else {
+    status = iree_hal_device_queue_barrier(
+        stream->context->device, stream->queue_affinity, wait_semaphores,
+        signal_semaphores, IREE_HAL_EXECUTE_FLAG_NONE);
+  }
   if (iree_status_is_ok(status)) {
     status = iree_hal_device_queue_flush(stream->context->device,
                                          stream->queue_affinity);
@@ -192,6 +265,9 @@ iree_status_t iree_hal_streaming_event_record(
   if (iree_status_is_ok(status)) {
     stream->pending_value = event->signal_value;
     stream->submitted_value = event->signal_value;
+    // A device tick was submitted for this record iff the timestamp path was
+    // taken; mark it valid only after the whole record submission succeeded.
+    event->device_tick_valid = event->timestamp_buffer != NULL;
   }
   iree_slim_mutex_unlock(&stream->mutex);
   IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, status);
@@ -212,6 +288,15 @@ iree_status_t iree_hal_streaming_event_synchronize(
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
+}
+
+float iree_hal_streaming_event_ticks_to_ms(uint64_t start_tick,
+                                           uint64_t stop_tick,
+                                           uint64_t frequency_hz) {
+  // Signed delta so a stop-before-start yields a negative duration rather than
+  // an unsigned wrap.
+  const int64_t delta_ticks = (int64_t)stop_tick - (int64_t)start_tick;
+  return (float)((double)delta_ticks * 1000.0 / (double)frequency_hz);
 }
 
 iree_status_t iree_hal_streaming_event_elapsed_time(
@@ -250,7 +335,32 @@ iree_status_t iree_hal_streaming_event_elapsed_time(
                             "stop event has not completed");
   }
 
-  // Calculate elapsed time in milliseconds.
+  // Device-side timestamps: read both GPU-clock ticks and convert using the
+  // device tick frequency. The ticks must come from one device clock, so both
+  // events must be on the same device (as hipEventElapsedTime requires); ticks
+  // are then valid across streams on that device. Same device means stop shares
+  // start's nonzero frequency, so the start->timestamp_frequency_hz guard and
+  // conversion below cover both events. Events on different devices fall
+  // through to the host-observed path below.
+  if (start->device_tick_valid && stop->device_tick_valid &&
+      start->timestamp_frequency_hz != 0 &&
+      start->context->device == stop->context->device) {
+    uint64_t start_tick = 0;
+    uint64_t stop_tick = 0;
+    IREE_RETURN_IF_ERROR(iree_hal_buffer_map_read(
+        start->timestamp_buffer, 0, &start_tick, sizeof(start_tick)));
+    IREE_RETURN_IF_ERROR(iree_hal_buffer_map_read(
+        stop->timestamp_buffer, 0, &stop_tick, sizeof(stop_tick)));
+    // Full 64-bit counter: the amdgpu device timestamp domain reports a
+    // full-width clock, so the signed subtraction cannot wrap. A device that
+    // advertised a narrower counter (timestamp_valid_bits < 64, from
+    // iree_hal_device_spec_timing) is not currently supported here.
+    *ms = iree_hal_streaming_event_ticks_to_ms(start_tick, stop_tick,
+                                               start->timestamp_frequency_hz);
+    return iree_ok_status();
+  }
+
+  // Host-observed fallback (devices without a device timestamp domain).
   int64_t elapsed_ns = stop->record_time_ns - start->record_time_ns;
   *ms = (float)elapsed_ns / 1000000.0f;  // Convert nanoseconds to milliseconds.
 

--- a/libhrx/src/binding/common/event_test.cc
+++ b/libhrx/src/binding/common/event_test.cc
@@ -1,0 +1,251 @@
+// Copyright 2026 The HRX Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Unit tests for streaming event timing (iree_hal_streaming_event_*).
+//
+// These tests deliberately exercise the HOST-timing path: a host (local-task)
+// device does not advertise a device timestamp domain, so events created on it
+// stay host-timed (timestamp_buffer == NULL) and elapsed_time is computed from
+// record_time_ns. The device-timestamp path requires an accelerator that
+// advertises a device timestamp domain, so this host path is the realistically
+// GPU-free-testable behavior of the timing change.
+//
+// The test brings up a host device via the public hrx CPU lifecycle and wraps
+// it in a minimal iree_hal_streaming_device_t so it can drive the internal
+// streaming context/stream/event APIs directly.
+// iree_hal_streaming_context_create only reads hal_device + ordinal from the
+// entry (and the device allocator), and the create/record/elapsed/release
+// lifecycle never touches the unset fields when no pageable staging buffer is
+// allocated.
+
+#include <string.h>
+
+#include "common/internal.h"
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+using ::iree::testing::status::StatusIs;
+
+// Fixture that owns a host (local-task) device and a streaming context built on
+// top of it. The hrx CPU accelerator is a process-global singleton, so the
+// fixture reference-counts init/shutdown to stay robust if gtest ever runs the
+// suite alongside other hrx consumers in the same binary.
+class EventTimingTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Bring up the host accelerator. ALREADY_EXISTS means another fixture (or
+    // test) already initialized it; treat that as success and skip our matching
+    // shutdown in TearDown.
+    hrx_status_t cpu_status = hrx_cpu_initialize(0);
+    if (hrx_status_is_ok(cpu_status)) {
+      owns_cpu_ = true;
+    } else if (hrx_status_code(cpu_status) == HRX_STATUS_ALREADY_EXISTS) {
+      hrx_status_ignore(cpu_status);
+    } else {
+      IREE_ASSERT_OK(hrx_to_iree_status(cpu_status));
+    }
+
+    hrx_device_t hrx_device = NULL;
+    IREE_ASSERT_OK(hrx_to_iree_status(hrx_cpu_device_get(0, &hrx_device)));
+    ASSERT_NE(hrx_device, nullptr);
+
+    // Minimal device entry: the streaming context only needs the HAL device and
+    // an ordinal. Everything else stays zeroed and is never dereferenced for
+    // the create/record/elapsed/release lifecycle exercised here.
+    memset(&device_entry_, 0, sizeof(device_entry_));
+    device_entry_.ordinal = 0;
+    device_entry_.hal_device = hrx_device_hal(hrx_device);
+    ASSERT_NE(device_entry_.hal_device, nullptr);
+
+    iree_hal_streaming_context_flags_t flags;
+    memset(&flags, 0, sizeof(flags));
+    IREE_ASSERT_OK(iree_hal_streaming_context_create(
+        &device_entry_, flags, iree_allocator_system(), &context_));
+
+    IREE_ASSERT_OK(iree_hal_streaming_stream_create(
+        context_, IREE_HAL_STREAMING_STREAM_FLAG_NONE, /*priority=*/0,
+        iree_allocator_system(), &stream_));
+  }
+
+  void TearDown() override {
+    iree_hal_streaming_stream_release(stream_);
+    iree_hal_streaming_context_release(context_);
+    if (owns_cpu_) {
+      hrx_status_ignore(hrx_cpu_shutdown());
+    }
+  }
+
+  // Creates an event and records it on the fixture stream.
+  iree_hal_streaming_event_t* CreateAndRecord(
+      iree_hal_streaming_event_flags_t flags) {
+    iree_hal_streaming_event_t* event = NULL;
+    IREE_CHECK_OK(iree_hal_streaming_event_create(
+        context_, flags, iree_allocator_system(), &event));
+    // This fixture's host device does not advertise a device timestamp domain,
+    // so events stay host-timed (no device tick buffer) and elapsed_time uses
+    // record_time_ns. Pin that here so the suite fails loudly rather than
+    // silently changing paths if the host device ever advertises the domain.
+    EXPECT_EQ(event->timestamp_buffer, nullptr);
+    IREE_CHECK_OK(iree_hal_streaming_event_record(event, stream_));
+    return event;
+  }
+
+  bool owns_cpu_ = false;
+  iree_hal_streaming_device_t device_entry_;
+  iree_hal_streaming_context_t* context_ = NULL;
+  iree_hal_streaming_stream_t* stream_ = NULL;
+};
+
+// Records two events in program order, synchronizes, and asserts the
+// host-timing path produces a finite, non-negative duration. The two records
+// sample a monotonic host clock (record_time_ns via iree_time_now) in program
+// order, so start <= stop; the delta can legitimately be 0ms on a fast host,
+// and only a negative or non-finite result is wrong.
+TEST_F(EventTimingTest, HostElapsedTimeIsNonNegative) {
+  iree_hal_streaming_event_t* start =
+      CreateAndRecord(IREE_HAL_STREAMING_EVENT_FLAG_NONE);
+
+  // This flush enqueues no ordered device work between the records:
+  // event_record submits its barrier directly and there is no pending command
+  // buffer. The record ordering comes solely from the monotonic host clock
+  // sampled in each event_record.
+  IREE_ASSERT_OK(iree_hal_streaming_stream_flush(stream_));
+
+  iree_hal_streaming_event_t* stop =
+      CreateAndRecord(IREE_HAL_STREAMING_EVENT_FLAG_NONE);
+
+  IREE_ASSERT_OK(iree_hal_streaming_event_synchronize(start));
+  IREE_ASSERT_OK(iree_hal_streaming_event_synchronize(stop));
+
+  float ms = -1.0f;
+  IREE_ASSERT_OK(iree_hal_streaming_event_elapsed_time(&ms, start, stop));
+  EXPECT_GE(ms, 0.0f);
+  EXPECT_TRUE(ms == ms);           // not NaN
+  EXPECT_LT(ms, 60.0f * 1000.0f);  // sane upper bound (< 60s)
+
+  iree_hal_streaming_event_release(start);
+  iree_hal_streaming_event_release(stop);
+}
+
+// Elapsed time across events recorded on the same stream must be monotonic:
+// (start -> stop) is non-negative and (stop -> start) is its negation, matching
+// CUDA/HIP signed-duration semantics on the host-timing path.
+TEST_F(EventTimingTest, HostElapsedTimeIsSignedAndConsistent) {
+  iree_hal_streaming_event_t* first =
+      CreateAndRecord(IREE_HAL_STREAMING_EVENT_FLAG_NONE);
+  IREE_ASSERT_OK(iree_hal_streaming_stream_flush(stream_));
+  iree_hal_streaming_event_t* second =
+      CreateAndRecord(IREE_HAL_STREAMING_EVENT_FLAG_NONE);
+
+  IREE_ASSERT_OK(iree_hal_streaming_event_synchronize(first));
+  IREE_ASSERT_OK(iree_hal_streaming_event_synchronize(second));
+
+  float forward = 0.0f;
+  float backward = 0.0f;
+  IREE_ASSERT_OK(
+      iree_hal_streaming_event_elapsed_time(&forward, first, second));
+  IREE_ASSERT_OK(
+      iree_hal_streaming_event_elapsed_time(&backward, second, first));
+
+  EXPECT_GE(forward, 0.0f);
+  EXPECT_FLOAT_EQ(backward, -forward);
+
+  iree_hal_streaming_event_release(first);
+  iree_hal_streaming_event_release(second);
+}
+
+// Elapsed time converts the host record-time delta from ns to ms exactly and is
+// signed. record_time_ns is set to known values (white-box) so the scale and
+// sign are verified deterministically, independent of wall-clock timing.
+TEST_F(EventTimingTest, HostElapsedTimeScaleAndSignAreExact) {
+  iree_hal_streaming_event_t* start =
+      CreateAndRecord(IREE_HAL_STREAMING_EVENT_FLAG_NONE);
+  iree_hal_streaming_event_t* stop =
+      CreateAndRecord(IREE_HAL_STREAMING_EVENT_FLAG_NONE);
+  IREE_ASSERT_OK(iree_hal_streaming_event_synchronize(start));
+  IREE_ASSERT_OK(iree_hal_streaming_event_synchronize(stop));
+
+  // 5,000,000 ns == 5.0 ms (both nonzero so the "recorded" guard passes).
+  start->record_time_ns = 1000000;
+  stop->record_time_ns = 6000000;
+
+  float ms = 0.0f;
+  IREE_ASSERT_OK(iree_hal_streaming_event_elapsed_time(&ms, start, stop));
+  EXPECT_FLOAT_EQ(ms, 5.0f);
+  IREE_ASSERT_OK(iree_hal_streaming_event_elapsed_time(&ms, stop, start));
+  EXPECT_FLOAT_EQ(ms, -5.0f);
+
+  iree_hal_streaming_event_release(start);
+  iree_hal_streaming_event_release(stop);
+}
+
+// An event created with DISABLE_TIMING has no usable timestamp; measuring
+// elapsed time with it on either side must be rejected with INVALID_ARGUMENT.
+TEST_F(EventTimingTest, DisableTimingRejectsElapsedTime) {
+  iree_hal_streaming_event_t* timed =
+      CreateAndRecord(IREE_HAL_STREAMING_EVENT_FLAG_NONE);
+  iree_hal_streaming_event_t* untimed =
+      CreateAndRecord(IREE_HAL_STREAMING_EVENT_FLAG_DISABLE_TIMING);
+
+  IREE_ASSERT_OK(iree_hal_streaming_event_synchronize(timed));
+  IREE_ASSERT_OK(iree_hal_streaming_event_synchronize(untimed));
+
+  float ms = 0.0f;
+  EXPECT_THAT(
+      iree::Status(iree_hal_streaming_event_elapsed_time(&ms, untimed, timed)),
+      StatusIs(iree::StatusCode::kInvalidArgument));
+  EXPECT_THAT(
+      iree::Status(iree_hal_streaming_event_elapsed_time(&ms, timed, untimed)),
+      StatusIs(iree::StatusCode::kInvalidArgument));
+
+  iree_hal_streaming_event_release(timed);
+  iree_hal_streaming_event_release(untimed);
+}
+
+// Events that have never been recorded have no timestamp; elapsed time must be
+// rejected with INVALID_ARGUMENT rather than reporting a bogus duration.
+TEST_F(EventTimingTest, UnrecordedEventRejectsElapsedTime) {
+  iree_hal_streaming_event_t* recorded =
+      CreateAndRecord(IREE_HAL_STREAMING_EVENT_FLAG_NONE);
+
+  iree_hal_streaming_event_t* unrecorded = NULL;
+  IREE_ASSERT_OK(iree_hal_streaming_event_create(
+      context_, IREE_HAL_STREAMING_EVENT_FLAG_NONE, iree_allocator_system(),
+      &unrecorded));
+
+  IREE_ASSERT_OK(iree_hal_streaming_event_synchronize(recorded));
+
+  float ms = 0.0f;
+  // Stop event never recorded.
+  EXPECT_THAT(iree::Status(iree_hal_streaming_event_elapsed_time(&ms, recorded,
+                                                                 unrecorded)),
+              StatusIs(iree::StatusCode::kInvalidArgument));
+  // Start event never recorded.
+  EXPECT_THAT(iree::Status(iree_hal_streaming_event_elapsed_time(
+                  &ms, unrecorded, recorded)),
+              StatusIs(iree::StatusCode::kInvalidArgument));
+
+  iree_hal_streaming_event_release(recorded);
+  iree_hal_streaming_event_release(unrecorded);
+}
+
+// Directly covers the device tick->ms conversion math (the device record path
+// itself needs an accelerator advertising the timestamp domain, which this
+// GPU-free suite cannot provide).
+TEST(EventTickConversionTest, TicksToMilliseconds) {
+  // 1 GHz: 1 tick == 1 ns, so 5,000,000 ticks == 5 ms.
+  EXPECT_FLOAT_EQ(
+      iree_hal_streaming_event_ticks_to_ms(1000, 5001000, 1000000000ull), 5.0f);
+  // Signed: stop before start is negative.
+  EXPECT_FLOAT_EQ(
+      iree_hal_streaming_event_ticks_to_ms(5001000, 1000, 1000000000ull),
+      -5.0f);
+  // 2 GHz: 10,000,000 ticks == 5 ms.
+  EXPECT_FLOAT_EQ(
+      iree_hal_streaming_event_ticks_to_ms(0, 10000000, 2000000000ull), 5.0f);
+}
+
+}  // namespace

--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -2151,6 +2151,9 @@ static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
       }
       if (iree_status_is_ok(status)) {
         event->record_time_ns = iree_time_now();
+        // A graph-replayed record writes no device tick; elapsed time uses the
+        // host record-time delta.
+        event->device_tick_valid = false;
         ++event->signal_value;
         signal_sems[signal_count] = event->semaphore;
         signal_vals[signal_count] = event->signal_value;

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -732,6 +732,19 @@ typedef struct iree_hal_streaming_event_t {
   // Timing information.
   iree_time_t record_time_ns;
 
+  // Owned 8-byte device-visible buffer holding the GPU clock tick written at
+  // record time, or NULL when the event is host-timed. Released in
+  // iree_hal_streaming_event_destroy.
+  iree_hal_buffer_t* timestamp_buffer;
+  // Device timestamp domain frequency in ticks per second, used to convert a
+  // tick delta to milliseconds. Zero when the event is host-timed.
+  uint64_t timestamp_frequency_hz;
+  // Whether |timestamp_buffer| currently holds a device tick written by the
+  // most recent record. Only the direct (non-capture) record path writes a
+  // tick; capture- and graph-recorded events leave this false and fall back to
+  // host timing in iree_hal_streaming_event_elapsed_time.
+  bool device_tick_valid;
+
   // Platform-specific IPC handle, if the event is IPC enabled.
   void* ipc_handle;
 
@@ -1713,6 +1726,14 @@ iree_status_t iree_hal_streaming_event_synchronize(
 iree_status_t iree_hal_streaming_event_elapsed_time(
     float* ms, iree_hal_streaming_event_t* start,
     iree_hal_streaming_event_t* stop);
+
+// Converts a device timestamp tick delta to milliseconds using the device tick
+// frequency (ticks/second), which must be nonzero. Signed: a stop tick recorded
+// before the start tick yields a negative duration (matching CUDA/HIP), not an
+// unsigned wrap.
+float iree_hal_streaming_event_ticks_to_ms(uint64_t start_tick,
+                                           uint64_t stop_tick,
+                                           uint64_t frequency_hz);
 
 //===----------------------------------------------------------------------===//
 // Memory management


### PR DESCRIPTION
## Notice

This is a Pull against the temp dev branch, and requires #142 to land before opening on main.

## Contents

Wires the HIP streaming-event binding's `hipEventElapsedTime` to the device-side GPU timestamp seam (`iree_hal_device_queue_timestamp` / `iree_hal_device_spec_timing`) that this base branch already carries. When the device advertises a device timestamp domain, an event allocates an 8-byte tick buffer and records a device GPU-clock tick at its queue point; elapsed time reads both ticks after completion and converts the signed delta with the device tick frequency. Devices without a device timestamp domain keep the host-side `record_time_ns` path; a device that advertises the domain but cannot allocate the tick buffer fails event creation rather than silently reporting wrong host-enqueue durations.

This replaces host-enqueue spacing (which measured ~0 ms for back-to-back records and broke MIOpen's auto-tuner) with real GPU-reach timing, and makes cross-stream measurement valid since both ticks share one monotonic device clock.

Events recorded through stream capture or graph replay emit no device tick (the graph `EVENT_RECORD` path submits a barrier), so a per-event `device_tick_valid` flag keeps those events on the host-timed path and `hipEventElapsedTime` never reads an unwritten tick buffer. Extending device-precision timing to graph-recorded events (emitting the tick during graph replay) is a follow-up.

## Scope

Targets `users/awoloszyn/dev`, which already carries the HAL + amdgpu device-timestamp seam; the diff here is only the HIP consumer under `libhrx/src/binding/common` (`event.c`, `event_test.cc`, `internal.h`, plus the `event_test` build wiring).

## Testing

`bazelisk test //libhrx/src/binding/common:event_test` passes (host path, GPU-free, clean under ASAN). Host-path unit tests cover non-negative host elapsed time, signed/consistent forward-vs-backward durations, the exact ns→ms scale and sign from known record times, the tick→ms conversion helper directly, and `INVALID_ARGUMENT` rejection for `DISABLE_TIMING` and never-recorded events. The device-tick record path itself needs an accelerator that advertises the domain and is verified on MI300X via the HIP CTS `event_timing_test`.
