### PR TITLE
Fix Windows MSVC build-tree blockers

### DIFF
--- a/libhrx/src/binding/common/BUILD.bazel
+++ b/libhrx/src/binding/common/BUILD.bazel
@@ -43,9 +43,6 @@ hrx_cc_library(
         "internal.h",
         "tls.h",
     ],
-    copts = [
-        "-Wno-unused-variable",
-    ],
     includes = [
         "..",
         "../../../include",

--- a/libhrx/src/binding/common/CMakeLists.txt
+++ b/libhrx/src/binding/common/CMakeLists.txt
@@ -7,8 +7,6 @@ iree_add_all_subdirs()
 iree_cc_library(
   NAME
     common
-  COPTS
-    "-Wno-unused-variable"
   HDRS
     "fat_binary.h"
     "graph.h"
@@ -105,6 +103,16 @@ iree_cc_binary_benchmark(
     libhrx_defs
   TESTONLY
 )
+
+if(WIN32)
+  set_tests_properties(
+    "libhrx/src/binding/common/buffer_table_test"
+    "libhrx/src/binding/common/buffer_table_benchmark_test"
+    PROPERTIES
+      ENVIRONMENT_MODIFICATION
+        "PATH=path_list_prepend:$<TARGET_FILE_DIR:libhrx_src_libhrx_hrx>"
+  )
+endif()
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
 

--- a/libhrx/src/binding/common/buffer_table_benchmark.cc
+++ b/libhrx/src/binding/common/buffer_table_benchmark.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
+#include <numeric>
 #include <random>
 #include <vector>
 

--- a/libhrx/src/binding/common/memory.c
+++ b/libhrx/src/binding/common/memory.c
@@ -4,8 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <stdatomic.h>
-
 #include "common/graph.h"
 #include "common/internal.h"
 #include "iree/hal/buffer_transfer.h"
@@ -206,7 +204,8 @@ static iree_status_t iree_hal_streaming_buffer_wrap_hrx_buffer(
         IREE_STATUS_UNAVAILABLE,
         "registered host allocation did not export a device-visible pointer");
   } else if (!have_device_ptr) {
-    static atomic_uintptr_t g_next_synthetic = 0xDEAD000000000000ULL;
+    static iree_atomic_uint64_t g_next_synthetic =
+        IREE_ATOMIC_VAR_INIT(0xDEAD000000000000ULL);
     iree_device_size_t aligned_size = 0;
     if (IREE_UNLIKELY(!iree_device_size_checked_mul_add(wrapper->size, 1, 255,
                                                         &aligned_size))) {
@@ -214,7 +213,8 @@ static iree_status_t iree_hal_streaming_buffer_wrap_hrx_buffer(
                                 "buffer size overflows synthetic alignment");
     } else {
       aligned_size &= ~(iree_device_size_t)255;
-      uintptr_t synthetic = atomic_fetch_add(&g_next_synthetic, aligned_size);
+      uint64_t synthetic = iree_atomic_fetch_add(
+          &g_next_synthetic, aligned_size, iree_memory_order_relaxed);
       wrapper->device_ptr = (iree_hal_streaming_deviceptr_t)synthetic;
       have_device_ptr = true;
     }

--- a/runtime/src/iree/base/internal/mpsc_queue_test.cc
+++ b/runtime/src/iree/base/internal/mpsc_queue_test.cc
@@ -628,7 +628,7 @@ TEST_F(MpscQueueTest, ConcurrentProducers) {
 
   std::vector<std::thread> producers;
   for (int p = 0; p < producer_count; ++p) {
-    producers.emplace_back([&queue, p]() {
+    producers.emplace_back([&queue, p, messages_per_producer]() {
       for (int i = 0; i < messages_per_producer; ++i) {
         TaggedMessage msg = {(uint32_t)p, (uint32_t)i};
         while (!iree_mpsc_queue_write(&queue, &msg, sizeof(msg))) {
@@ -685,7 +685,7 @@ TEST_F(MpscQueueTest, ConcurrentBeginWriteCommit) {
 
   std::vector<std::thread> producers;
   for (int p = 0; p < producer_count; ++p) {
-    producers.emplace_back([&queue, p]() {
+    producers.emplace_back([&queue, p, messages_per_producer]() {
       for (int i = 0; i < messages_per_producer; ++i) {
         iree_mpsc_queue_reservation_t reservation;
         void* payload;
@@ -738,7 +738,7 @@ TEST_F(MpscQueueTest, ConcurrentVariableSizeStress) {
 
   std::vector<std::thread> producers;
   for (int p = 0; p < producer_count; ++p) {
-    producers.emplace_back([&queue, p]() {
+    producers.emplace_back([&queue, p, messages_per_producer]() {
       for (int i = 0; i < messages_per_producer; ++i) {
         // Variable payload: 8 bytes header + 0-120 bytes of fill.
         // Header is (producer_id, sequence).
@@ -805,7 +805,7 @@ TEST_F(MpscQueueTest, ConcurrentCancelStress) {
 
   std::vector<std::thread> producers;
   for (int p = 0; p < producer_count; ++p) {
-    producers.emplace_back([&queue, p]() {
+    producers.emplace_back([&queue, p, messages_per_producer]() {
       uint32_t committed = 0;
       for (int i = 0; committed < (uint32_t)messages_per_producer; ++i) {
         iree_mpsc_queue_reservation_t reservation;


### PR DESCRIPTION
Prelanding some MSVC build blockers for: https://github.com/ROCm/hrx-system/pull/161

Use portable IREE atomics and MSVC-safe test code.

Make libhrx buffer-table CTest find hrx.dll on Windows.
