### PR TITLE
[HRX] Make HIP result annotations compiler-portable

### DIFF
--- a/libhrx/src/binding/hip/BUILD.bazel
+++ b/libhrx/src/binding/hip/BUILD.bazel
@@ -30,9 +30,6 @@ hrx_cc_library(
         "api.h",
         "launch_params.h",
     ],
-    copts = [
-        "-Wno-attributes",
-    ],
     includes = [
         "../..",
         "../../../include",
@@ -58,7 +55,6 @@ hrx_cc_shared_library(
     additional_linker_inputs = ["amdhip64.map"],
     copts = [
         "-DIREE_HAL_STREAMING_HIP_EXPORTS",
-        "-Wno-attributes",
         "-Wno-unused-variable",
     ],
     includes = [
@@ -121,9 +117,6 @@ hrx_cc_test(
 hrx_cc_test(
     name = "hip_launch_validation_api_test",
     srcs = ["hip_launch_validation_api_test.cc"],
-    copts = [
-        "-Wno-attributes",
-    ],
     # The test loads the built runtime through its public ABI and supplies a
     # tagged function handle that reaches argument validation before dispatch.
     data = [":amdhip64"],
@@ -144,9 +137,6 @@ hrx_cc_test(
 hrx_cc_test(
     name = "launch_params_test",
     srcs = ["launch_params_test.cc"],
-    copts = [
-        "-Wno-attributes",
-    ],
     deps = [
         ":launch_params",
         "//runtime/src/iree/testing:gtest",

--- a/libhrx/src/binding/hip/CMakeLists.txt
+++ b/libhrx/src/binding/hip/CMakeLists.txt
@@ -12,8 +12,6 @@ iree_add_all_subdirs()
 iree_cc_library(
   NAME
     launch_params
-  COPTS
-    "-Wno-attributes"
   HDRS
     "api.h"
     "launch_params.h"
@@ -40,7 +38,6 @@ iree_cc_library(
     amdhip64
   COPTS
     "-DIREE_HAL_STREAMING_HIP_EXPORTS"
-    "-Wno-attributes"
     "-Wno-unused-variable"
   HDRS
     "api.h"
@@ -104,8 +101,6 @@ iree_cc_test(
     hip_launch_validation_api_test
   SRCS
     "hip_launch_validation_api_test.cc"
-  COPTS
-    "-Wno-attributes"
   DATA
     ::amdhip64
   DEPS
@@ -128,8 +123,6 @@ iree_cc_test(
     launch_params_test
   SRCS
     "launch_params_test.cc"
-  COPTS
-    "-Wno-attributes"
   DEPS
     ::launch_params
     iree::testing::gtest

--- a/libhrx/src/binding/hip/api.h
+++ b/libhrx/src/binding/hip/api.h
@@ -113,7 +113,15 @@ typedef struct hipExtent {
 #define hipMallocSignalMemory 0x2
 #define hipDeviceMallocUncached 0x3
 
-typedef enum __attribute__((annotate("HIP_nodiscard"))) hipError_t {
+// Warns C++17 callers when a HIP error result is discarded.
+#if defined(__cplusplus) && \
+    (__cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
+#define HRX_HIP_NODISCARD [[nodiscard]]
+#else
+#define HRX_HIP_NODISCARD
+#endif
+
+typedef enum HRX_HIP_NODISCARD hipError_t {
   hipSuccess = 0,
   hipErrorInvalidValue = 1,
   hipErrorOutOfMemory = 2,
@@ -191,6 +199,8 @@ typedef enum __attribute__((annotate("HIP_nodiscard"))) hipError_t {
   hipErrorRuntimeOther = 1053,
   hipErrorTbd = 9999  // Placeholder
 } hipError_t;
+
+#undef HRX_HIP_NODISCARD
 
 typedef enum hipDeviceAttribute_t {
   hipDeviceAttributeCudaCompatibleBegin = 0,


### PR DESCRIPTION
The public HIP compatibility header now expresses `hipError_t`'s discarded-result contract with the standard C++17 `[[nodiscard]]` attribute while remaining an ordinary enum declaration for C consumers. The feature check recognizes both the standard `__cplusplus` value and MSVC's `_MSVC_LANG`, preserving the same API behavior when native MSVC does not advertise its language mode through `__cplusplus`.

The annotation macro is private to the declaration and immediately undefined, so the header remains standalone and does not acquire an IREE dependency or leak compatibility machinery into consumers.

With the declaration portable at its source, the HIP launch helper, Linux shim, and their tests no longer suppress attribute diagnostics. This also removes the GNU-only `-Wno-attributes` option from the native-MSVC build surface instead of teaching each target about another compiler-specific exception.

The `amdhip64` shim itself remains intentionally Linux-only until its loader and symbol-export implementation is ported. This change makes the shared HIP API and launch-parameter code portable; it does not change the shim's platform support contract.

## Reviewer notes

The hand-written source change is confined to `api.h` and the Bazel target options. The CMake edit is generated from the Bazel metadata.
