### PR TITLE
[Loom] Analyze final native artifacts before publication

### DIFF
--- a/loom/py/loom/error/amdgpu.py
+++ b/loom/py/loom/error/amdgpu.py
@@ -1027,6 +1027,49 @@ ERR_AMDGPU_044 = ErrorDef(
     ),
 )
 
+# ERR_AMDGPU_045: AMDGPU final artifact has an insufficient wait.
+ERR_AMDGPU_045 = ErrorDef(
+    domain=ErrorDomain.AMDGPU,
+    code=45,
+    severity=Severity.ERROR,
+    summary="AMDGPU final artifact has an insufficient wait.",
+    message=(
+        "AMDGPU final-artifact wait hazard '{diagnostic_code}' for kernel "
+        "'{kernel_name}' (present={has_kernel}, entry .text+{kernel_entry_offset}) "
+        "at {section_name}+{consumer_section_offset} "
+        "(file+{consumer_file_offset}): instruction '{consumer_instruction}' "
+        "has {access_kind} conflict on "
+        "{register_class}[{register_index}:{register_width}] with producer at "
+        "section+{producer_section_offset} (file+{producer_file_offset}) "
+        "instruction '{producer_instruction}'; counter {counter_name} requires "
+        "count {required_count}: {explanation}"
+    ),
+    params=(
+        ErrorParam("diagnostic_code", ParamKind.STRING),
+        ErrorParam("has_kernel", ParamKind.BOOL),
+        ErrorParam("kernel_name", ParamKind.STRING),
+        ErrorParam("kernel_entry_offset", ParamKind.U64),
+        ErrorParam("counter_name", ParamKind.STRING),
+        ErrorParam("access_kind", ParamKind.STRING),
+        ErrorParam("register_class", ParamKind.STRING),
+        ErrorParam("register_index", ParamKind.U32),
+        ErrorParam("register_width", ParamKind.U32),
+        ErrorParam("section_name", ParamKind.STRING),
+        ErrorParam("consumer_section_offset", ParamKind.U64),
+        ErrorParam("consumer_file_offset", ParamKind.U64),
+        ErrorParam("consumer_instruction", ParamKind.STRING),
+        ErrorParam("producer_section_offset", ParamKind.U64),
+        ErrorParam("producer_file_offset", ParamKind.U64),
+        ErrorParam("producer_instruction", ParamKind.STRING),
+        ErrorParam("required_count", ParamKind.U32),
+        ErrorParam("explanation", ParamKind.STRING),
+    ),
+    fix_hint=(
+        "Strengthen or insert the required AMDGPU wait before the reported "
+        "consumer instruction"
+    ),
+)
+
 ALL_AMDGPU_ERRORS = (
     ERR_AMDGPU_001,
     ERR_AMDGPU_003,
@@ -1071,4 +1114,5 @@ ALL_AMDGPU_ERRORS = (
     ERR_AMDGPU_042,
     ERR_AMDGPU_043,
     ERR_AMDGPU_044,
+    ERR_AMDGPU_045,
 )

--- a/loom/src/loom/target/arch/amdgpu/BUILD.bazel
+++ b/loom/src/loom/target/arch/amdgpu/BUILD.bazel
@@ -25,6 +25,8 @@ package(
 
 _AMDGPU_CHECK_VISIBILITY = ["//loom/src/loom/target/arch/amdgpu/check:__pkg__"]
 
+_AMDGPU_DIAGNOSTICS_VISIBILITY = ["//loom/src/loom/target/arch/amdgpu/diagnostics:__pkg__"]
+
 _AMDGPU_ENCODING_VISIBILITY = ["//loom/src/loom/target/arch/amdgpu/encoding:__pkg__"]
 
 _AMDGPU_HAL_VISIBILITY = ["//loom/src/loom/target/arch/amdgpu/hal:__pkg__"]
@@ -77,6 +79,7 @@ loom_generated_cc_library(
     generator = "//loom/py/loom/gen/error:c_errors",
     source = "error_catalog.c",
     visibility = (
+        _AMDGPU_DIAGNOSTICS_VISIBILITY +
         _AMDGPU_HAL_VISIBILITY +
         _AMDGPU_LOWER_VISIBILITY +
         _AMDGPU_NATIVE_VISIBILITY +

--- a/loom/src/loom/target/arch/amdgpu/diagnostics/BUILD.bazel
+++ b/loom/src/loom/target/arch/amdgpu/diagnostics/BUILD.bazel
@@ -7,6 +7,7 @@
 load(
     "//loom/build_tools/bazel:build_defs.bzl",
     "loom_cc_library",
+    "loom_cc_test",
 )
 
 package(
@@ -25,5 +26,30 @@ loom_cc_library(
         "//loom/src/loom/target:low_packet_diagnostics",
         "//loom/src/loom/target/arch/amdgpu/refs:target_refs",
         "//runtime/src/iree/base",
+    ],
+)
+
+loom_cc_library(
+    name = "wait_hazard",
+    srcs = ["wait_hazard.c"],
+    hdrs = ["wait_hazard.h"],
+    visibility = ["//loom/src/loom/tooling/target/amdgpu:__subpackages__"],
+    deps = [
+        "//loom/src/loom/error:diagnostic",
+        "//loom/src/loom/target/arch/amdgpu:error_defs",
+        "//runtime/src/iree/base",
+    ],
+)
+
+loom_cc_test(
+    name = "wait_hazard_test",
+    srcs = ["wait_hazard_test.cc"],
+    deps = [
+        ":wait_hazard",
+        "//loom/src/loom/error:json_sink",
+        "//loom/src/loom/util:stream",
+        "//runtime/src/iree/base/internal:json",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
     ],
 )

--- a/loom/src/loom/target/arch/amdgpu/diagnostics/CMakeLists.txt
+++ b/loom/src/loom/target/arch/amdgpu/diagnostics/CMakeLists.txt
@@ -26,4 +26,38 @@ loom_cc_library(
 )
 endif()
 
+if(LOOM_TARGET_ARCH_AMDGPU)
+loom_cc_library(
+  NAME
+    wait_hazard
+  HDRS
+    "wait_hazard.h"
+  SRCS
+    "wait_hazard.c"
+  DEPS
+    iree::base
+    loom::error::diagnostic
+    loom::target::arch::amdgpu::error_defs
+  PUBLIC
+)
+endif()
+
+if(LOOM_TARGET_ARCH_AMDGPU)
+loom_cc_test(
+  NAME
+    wait_hazard_test
+  SRCS
+    "wait_hazard_test.cc"
+  DEPS
+    ::wait_hazard
+    iree::base::internal::json
+    iree::testing::gtest
+    iree::testing::gtest_main
+    loom::error::json_sink
+    loom::util::stream
+  LABELS
+    "iree-build-requirement=loom.target.arch.amdgpu"
+)
+endif()
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/loom/src/loom/target/arch/amdgpu/diagnostics/wait_hazard.c
+++ b/loom/src/loom/target/arch/amdgpu/diagnostics/wait_hazard.c
@@ -1,0 +1,53 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/target/arch/amdgpu/diagnostics/wait_hazard.h"
+
+#include "loom/target/arch/amdgpu/error_catalog.h"
+
+iree_status_t loom_amdgpu_wait_hazard_emit(
+    const loom_amdgpu_wait_hazard_t* hazard,
+    const loom_diagnostic_sink_t* sink) {
+  if (hazard == NULL) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU wait hazard is required");
+  }
+  const loom_diagnostic_param_t params[] = {
+      loom_param_string(hazard->diagnostic_code),
+      loom_param_bool(hazard->has_kernel),
+      loom_param_string(hazard->kernel_name),
+      loom_param_u64(hazard->kernel_entry_offset),
+      loom_param_string(hazard->counter_name),
+      loom_param_string(hazard->access_kind),
+      loom_param_string(hazard->register_class),
+      loom_param_u32(hazard->register_index),
+      loom_param_u32(hazard->register_width),
+      loom_param_string(hazard->section_name),
+      loom_param_u64(hazard->consumer_section_offset),
+      loom_param_u64(hazard->consumer_file_offset),
+      loom_param_string(hazard->consumer_instruction),
+      loom_param_u64(hazard->producer_section_offset),
+      loom_param_u64(hazard->producer_file_offset),
+      loom_param_string(hazard->producer_instruction),
+      loom_param_u32(hazard->required_count),
+      loom_param_string(hazard->explanation),
+  };
+  const loom_source_range_t location = {
+      .provenance = LOOM_SOURCE_PROVENANCE_UNAVAILABLE_SOURCE,
+      .filename =
+          hazard->has_kernel ? hazard->kernel_name : hazard->section_name,
+  };
+  const loom_diagnostic_t diagnostic = {
+      .severity = LOOM_ERR_AMDGPU_045->severity,
+      .error = LOOM_ERR_AMDGPU_045,
+      .params = params,
+      .param_count = IREE_ARRAYSIZE(params),
+      .emitter = LOOM_EMITTER_PASS,
+      .origin = location,
+      .source_location = location,
+  };
+  return loom_diagnostic_emit(sink, &diagnostic);
+}

--- a/loom/src/loom/target/arch/amdgpu/diagnostics/wait_hazard.h
+++ b/loom/src/loom/target/arch/amdgpu/diagnostics/wait_hazard.h
@@ -1,0 +1,72 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Structured diagnostics for final-artifact AMDGPU wait hazards.
+
+#ifndef LOOM_TARGET_ARCH_AMDGPU_DIAGNOSTICS_WAIT_HAZARD_H_
+#define LOOM_TARGET_ARCH_AMDGPU_DIAGNOSTICS_WAIT_HAZARD_H_
+
+#include "iree/base/api.h"
+#include "loom/error/diagnostic.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// One producer/consumer wait hazard decoded from a final AMDGPU artifact.
+//
+// String views are borrowed only for a synchronous diagnostic emission. Sinks
+// must copy any diagnostic fields they retain, as required by
+// loom_diagnostic_sink_t.
+typedef struct loom_amdgpu_wait_hazard_t {
+  // Stable machine-readable hazard classification.
+  iree_string_view_t diagnostic_code;
+  // True when the analyzer attributed this hazard to a kernel descriptor.
+  bool has_kernel;
+  // Kernel symbol name, or empty when no kernel identity is available.
+  iree_string_view_t kernel_name;
+  // Kernel entry-point byte offset in the artifact .text section.
+  uint64_t kernel_entry_offset;
+  // Stable hardware wait-counter name.
+  iree_string_view_t counter_name;
+  // Stable consumer access kind.
+  iree_string_view_t access_kind;
+  // Stable ISA register-file name.
+  iree_string_view_t register_class;
+  // First 32-bit register lane implicated in the hazard.
+  uint32_t register_index;
+  // Number of contiguous 32-bit register lanes implicated in the hazard.
+  uint32_t register_width;
+  // Artifact section containing the consumer instruction.
+  iree_string_view_t section_name;
+  // Consumer instruction byte offset within |section_name|.
+  uint64_t consumer_section_offset;
+  // Consumer instruction byte offset within the artifact file.
+  uint64_t consumer_file_offset;
+  // Decoded consumer instruction text.
+  iree_string_view_t consumer_instruction;
+  // Producer instruction byte offset within |section_name|.
+  uint64_t producer_section_offset;
+  // Producer instruction byte offset within the artifact file.
+  uint64_t producer_file_offset;
+  // Decoded producer instruction text.
+  iree_string_view_t producer_instruction;
+  // Wait count required before the consumer instruction.
+  uint32_t required_count;
+  // Analyzer-provided explanation of the hazard.
+  iree_string_view_t explanation;
+} loom_amdgpu_wait_hazard_t;
+
+// Emits |hazard| through |sink| as the canonical AMDGPU wait diagnostic.
+iree_status_t loom_amdgpu_wait_hazard_emit(
+    const loom_amdgpu_wait_hazard_t* hazard,
+    const loom_diagnostic_sink_t* sink);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_TARGET_ARCH_AMDGPU_DIAGNOSTICS_WAIT_HAZARD_H_

--- a/loom/src/loom/target/arch/amdgpu/diagnostics/wait_hazard_test.cc
+++ b/loom/src/loom/target/arch/amdgpu/diagnostics/wait_hazard_test.cc
@@ -1,0 +1,169 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/target/arch/amdgpu/diagnostics/wait_hazard.h"
+
+#include <cstring>
+
+#include "iree/base/internal/json.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+#include "loom/error/json_sink.h"
+#include "loom/util/stream.h"
+
+namespace loom {
+namespace {
+
+static iree_string_view_t ParseJsonDocument(iree_string_view_t json) {
+  iree_string_view_t cursor = json;
+  iree_string_view_t value = iree_string_view_empty();
+  IREE_EXPECT_OK(iree_json_consume_value(&cursor, &value));
+  IREE_EXPECT_OK(iree_json_consume_insignificant(&cursor));
+  EXPECT_TRUE(iree_string_view_is_empty(cursor));
+  return value;
+}
+
+static iree_string_view_t LookupObject(iree_string_view_t object,
+                                       iree_string_view_t key) {
+  iree_string_view_t value = iree_string_view_empty();
+  IREE_EXPECT_OK(iree_json_lookup_object_value(object, key, &value));
+  return value;
+}
+
+static void ExpectObjectValueEquals(iree_string_view_t object,
+                                    iree_string_view_t key,
+                                    iree_string_view_t expected) {
+  EXPECT_TRUE(iree_string_view_equal(LookupObject(object, key), expected));
+}
+
+struct TextSinkState {
+  loom_output_stream_t stream;
+};
+
+static iree_status_t FormatTextSink(void* user_data,
+                                    const loom_diagnostic_t* diagnostic) {
+  TextSinkState* state = static_cast<TextSinkState*>(user_data);
+  return loom_diagnostic_format(diagnostic, &state->stream);
+}
+
+static loom_amdgpu_wait_hazard_t MakeWaitHazard(
+    iree_string_view_t explanation) {
+  return loom_amdgpu_wait_hazard_t{
+      /*.diagnostic_code=*/IREE_SVL("wait_counter"),
+      /*.has_kernel=*/true,
+      /*.kernel_name=*/IREE_SVL("main"),
+      /*.kernel_entry_offset=*/32,
+      /*.counter_name=*/IREE_SVL("xcnt"),
+      /*.access_kind=*/IREE_SVL("def"),
+      /*.register_class=*/IREE_SVL("vgpr"),
+      /*.register_index=*/16,
+      /*.register_width=*/8,
+      /*.section_name=*/IREE_SVL(".text"),
+      /*.consumer_section_offset=*/144,
+      /*.consumer_file_offset=*/400,
+      /*.consumer_instruction=*/
+      IREE_SVL("v_wmma_f32_16x16x16_bf16 v[0:7], v[8:15], v[16:23]"),
+      /*.producer_section_offset=*/96,
+      /*.producer_file_offset=*/352,
+      /*.producer_instruction=*/
+      IREE_SVL("buffer_load_dwordx4 v[16:19], off, s[0:3], 0"),
+      /*.required_count=*/0,
+      /*.explanation=*/explanation,
+  };
+}
+
+TEST(AmdgpuWaitHazardTest, EmitsEveryStructuredFieldAsJson) {
+  char explanation[] = "missing s_waitcnt_depctr";
+  const loom_amdgpu_wait_hazard_t hazard =
+      MakeWaitHazard(iree_make_cstring_view(explanation));
+
+  iree_string_builder_t builder;
+  iree_string_builder_initialize(iree_allocator_system(), &builder);
+  loom_output_stream_t stream;
+  loom_output_stream_for_builder(&builder, &stream);
+  loom_json_sink_options_t json_options = {
+      /*.stream=*/&stream,
+  };
+  const loom_diagnostic_sink_t sink = {
+      /*.fn=*/loom_diagnostic_json_sink,
+      /*.user_data=*/&json_options,
+  };
+  IREE_ASSERT_OK(loom_amdgpu_wait_hazard_emit(&hazard, &sink));
+  std::memset(explanation, 'x', sizeof(explanation) - 1);
+
+  const iree_string_view_t root =
+      ParseJsonDocument(iree_string_builder_view(&builder));
+  ExpectObjectValueEquals(root, IREE_SV("error_id"), IREE_SV("ERR_AMDGPU_045"));
+  ExpectObjectValueEquals(root, IREE_SV("emitter"), IREE_SV("pass"));
+  const iree_string_view_t params = LookupObject(root, IREE_SV("params"));
+  ExpectObjectValueEquals(params, IREE_SV("diagnostic_code"),
+                          IREE_SV("wait_counter"));
+  ExpectObjectValueEquals(params, IREE_SV("has_kernel"), IREE_SV("true"));
+  ExpectObjectValueEquals(params, IREE_SV("kernel_name"), IREE_SV("main"));
+  ExpectObjectValueEquals(params, IREE_SV("kernel_entry_offset"),
+                          IREE_SV("32"));
+  ExpectObjectValueEquals(params, IREE_SV("counter_name"), IREE_SV("xcnt"));
+  ExpectObjectValueEquals(params, IREE_SV("access_kind"), IREE_SV("def"));
+  ExpectObjectValueEquals(params, IREE_SV("register_class"), IREE_SV("vgpr"));
+  ExpectObjectValueEquals(params, IREE_SV("register_index"), IREE_SV("16"));
+  ExpectObjectValueEquals(params, IREE_SV("register_width"), IREE_SV("8"));
+  ExpectObjectValueEquals(params, IREE_SV("section_name"), IREE_SV(".text"));
+  ExpectObjectValueEquals(params, IREE_SV("consumer_section_offset"),
+                          IREE_SV("144"));
+  ExpectObjectValueEquals(params, IREE_SV("consumer_file_offset"),
+                          IREE_SV("400"));
+  ExpectObjectValueEquals(
+      params, IREE_SV("consumer_instruction"),
+      IREE_SV("v_wmma_f32_16x16x16_bf16 v[0:7], v[8:15], v[16:23]"));
+  ExpectObjectValueEquals(params, IREE_SV("producer_section_offset"),
+                          IREE_SV("96"));
+  ExpectObjectValueEquals(params, IREE_SV("producer_file_offset"),
+                          IREE_SV("352"));
+  ExpectObjectValueEquals(
+      params, IREE_SV("producer_instruction"),
+      IREE_SV("buffer_load_dwordx4 v[16:19], off, s[0:3], 0"));
+  ExpectObjectValueEquals(params, IREE_SV("required_count"), IREE_SV("0"));
+  ExpectObjectValueEquals(params, IREE_SV("explanation"),
+                          IREE_SV("missing s_waitcnt_depctr"));
+  iree_string_builder_deinitialize(&builder);
+}
+
+TEST(AmdgpuWaitHazardTest, FormatsEveryStructuredFieldAsText) {
+  const loom_amdgpu_wait_hazard_t hazard =
+      MakeWaitHazard(IREE_SV("missing s_waitcnt_depctr"));
+  iree_string_builder_t builder;
+  iree_string_builder_initialize(iree_allocator_system(), &builder);
+  TextSinkState state;
+  loom_output_stream_for_builder(&builder, &state.stream);
+  const loom_diagnostic_sink_t sink = {
+      /*.fn=*/FormatTextSink,
+      /*.user_data=*/&state,
+  };
+  IREE_ASSERT_OK(loom_amdgpu_wait_hazard_emit(&hazard, &sink));
+  const iree_string_view_t text = iree_string_builder_view(&builder);
+  EXPECT_NE(
+      iree_string_view_find(
+          text,
+          IREE_SV(
+              "AMDGPU final-artifact wait hazard 'wait_counter' for kernel "
+              "'main' (present=true, entry .text+32) at .text+144 (file+400): "
+              "instruction 'v_wmma_f32_16x16x16_bf16 v[0:7], v[8:15], "
+              "v[16:23]' has def conflict on vgpr[16:8] with producer at "
+              "section+96 (file+352) instruction 'buffer_load_dwordx4 "
+              "v[16:19], off, s[0:3], 0'; counter xcnt requires count 0: "
+              "missing s_waitcnt_depctr"),
+          0),
+      IREE_STRING_VIEW_NPOS);
+  iree_string_builder_deinitialize(&builder);
+}
+
+TEST(AmdgpuWaitHazardTest, RejectsMissingHazard) {
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        loom_amdgpu_wait_hazard_emit(nullptr, nullptr));
+}
+
+}  // namespace
+}  // namespace loom

--- a/loom/src/loom/target/reporting/format_json.c
+++ b/loom/src/loom/target/reporting/format_json.c
@@ -47,6 +47,45 @@ iree_status_t loom_target_compile_report_json_write_optional_u32_field(
   return loom_json_object_write_uint32_field(object, name, value);
 }
 
+static iree_status_t loom_target_compile_report_format_artifact_analysis_json(
+    const loom_target_compile_report_artifact_analysis_t* analysis,
+    loom_output_stream_t* stream) {
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
+      &object, IREE_SV("analyzer"), analysis->analyzer_name));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("abi_version"), analysis->analyzer_abi_version));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
+      &object, IREE_SV("outcome"),
+      loom_target_compile_report_artifact_analysis_outcome_name(
+          analysis->outcome)));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
+      &object, IREE_SV("artifact_target"), analysis->artifact_target));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("instructions_analyzed"), analysis->instruction_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("memory_events_tracked"), analysis->memory_event_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("functions_discovered"), analysis->function_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("functions_analyzed"),
+      analysis->analyzed_function_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("findings_observed"), analysis->finding_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("findings_reported"), analysis->reported_finding_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_bool_field(
+      &object, IREE_SV("findings_truncated"), analysis->findings_truncated));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_bool_field(
+      &object, IREE_SV("stopped_early"), analysis->stopped_early));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_bool_field(
+      &object, IREE_SV("complete"), analysis->complete));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_bool_field(
+      &object, IREE_SV("passed"), analysis->passed));
+  return loom_json_object_end(&object);
+}
+
 static iree_status_t loom_target_compile_report_format_schedule_json(
     const loom_target_compile_report_t* report, loom_output_stream_t* stream) {
   loom_json_object_writer_t object;
@@ -1437,6 +1476,14 @@ iree_status_t loom_target_compile_report_format_json(
                        LOOM_TARGET_COMPILE_REPORT_DETAIL_ARTIFACT_SIZE)) {
     IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
         &object, IREE_SV("artifact_size"), report->artifact_size));
+  }
+  if (iree_any_bit_set(report->detail_flags,
+                       LOOM_TARGET_COMPILE_REPORT_DETAIL_ARTIFACT_ANALYSIS)) {
+    IREE_RETURN_IF_ERROR(
+        loom_json_object_begin_field(&object, IREE_SV("artifact_analysis")));
+    IREE_RETURN_IF_ERROR(
+        loom_target_compile_report_format_artifact_analysis_json(
+            &report->artifact_analysis, stream));
   }
   IREE_RETURN_IF_ERROR(
       loom_json_object_begin_field(&object, IREE_SV("entries")));

--- a/loom/src/loom/target/reporting/format_test.cc
+++ b/loom/src/loom/target/reporting/format_test.cc
@@ -214,6 +214,111 @@ TEST(CompileReportFormatTest, FormatsCoreReport) {
   loom_target_compile_report_deinitialize(&report);
 }
 
+TEST(CompileReportFormatTest, ClonesAndFormatsArtifactAnalysis) {
+  loom_target_compile_report_t report = {};
+  loom_target_compile_report_initialize(&report, iree_allocator_system());
+  const loom_target_compile_report_artifact_analysis_t analysis = {
+      /*.analyzer_name=*/IREE_SVL("rocjitsu-waitcheck"),
+      /*.analyzer_abi_version=*/1,
+      /*.outcome=*/
+      LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_REJECTED,
+      /*.artifact_target=*/IREE_SVL("gfx1250"),
+      /*.instruction_count=*/354,
+      /*.memory_event_count=*/61,
+      /*.function_count=*/3,
+      /*.analyzed_function_count=*/2,
+      /*.finding_count=*/7,
+      /*.reported_finding_count=*/4,
+      /*.findings_truncated=*/true,
+      /*.stopped_early=*/true,
+      /*.complete=*/false,
+      /*.passed=*/false,
+  };
+  loom_target_compile_report_record_artifact_analysis(&report, &analysis);
+
+  loom_target_compile_report_t clone = {};
+  IREE_ASSERT_OK(loom_target_compile_report_clone(
+      &report, iree_allocator_system(), &clone));
+  loom_target_compile_report_deinitialize(&report);
+  EXPECT_TRUE(iree_any_bit_set(
+      clone.detail_flags, LOOM_TARGET_COMPILE_REPORT_DETAIL_ARTIFACT_ANALYSIS));
+  EXPECT_TRUE(iree_string_view_equal(clone.artifact_analysis.analyzer_name,
+                                     IREE_SV("rocjitsu-waitcheck")));
+  EXPECT_EQ(clone.artifact_analysis.analyzer_abi_version, 1u);
+  EXPECT_EQ(clone.artifact_analysis.outcome,
+            LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_REJECTED);
+  EXPECT_TRUE(iree_string_view_equal(clone.artifact_analysis.artifact_target,
+                                     IREE_SV("gfx1250")));
+  EXPECT_EQ(clone.artifact_analysis.instruction_count, 354u);
+  EXPECT_EQ(clone.artifact_analysis.memory_event_count, 61u);
+  EXPECT_EQ(clone.artifact_analysis.function_count, 3u);
+  EXPECT_EQ(clone.artifact_analysis.analyzed_function_count, 2u);
+  EXPECT_EQ(clone.artifact_analysis.finding_count, 7u);
+  EXPECT_EQ(clone.artifact_analysis.reported_finding_count, 4u);
+  EXPECT_TRUE(clone.artifact_analysis.findings_truncated);
+  EXPECT_TRUE(clone.artifact_analysis.stopped_early);
+  EXPECT_FALSE(clone.artifact_analysis.complete);
+  EXPECT_FALSE(clone.artifact_analysis.passed);
+
+  const loom_target_compile_report_format_options_t options = {
+      /*.mode=*/LOOM_TARGET_COMPILE_REPORT_FORMAT_MODE_SUMMARY,
+  };
+  iree_string_builder_t builder;
+  iree_string_builder_initialize(iree_allocator_system(), &builder);
+  IREE_ASSERT_OK(
+      loom_target_compile_report_format_text(&clone, &options, &builder));
+  const iree_string_view_t text = iree_string_builder_view(&builder);
+  EXPECT_NE(
+      iree_string_view_find(
+          text,
+          IREE_SV("artifact_analysis analyzer=rocjitsu-waitcheck "
+                  "abi_version=1 outcome=rejected artifact_target=gfx1250 "
+                  "instructions_analyzed=354 memory_events_tracked=61 "
+                  "functions_discovered=3 functions_analyzed=2 "
+                  "findings_observed=7 findings_reported=4 "
+                  "findings_truncated=true stopped_early=true "
+                  "complete=false passed=false"),
+          0),
+      IREE_STRING_VIEW_NPOS);
+  iree_string_builder_deinitialize(&builder);
+
+  iree_string_builder_initialize(iree_allocator_system(), &builder);
+  loom_output_stream_t stream;
+  loom_output_stream_for_builder(&builder, &stream);
+  IREE_ASSERT_OK(
+      loom_target_compile_report_format_json(&clone, &options, &stream));
+  const iree_string_view_t root =
+      ParseJsonDocument(iree_string_builder_view(&builder));
+  const iree_string_view_t artifact_analysis =
+      LookupObject(root, IREE_SV("artifact_analysis"));
+  ExpectObjectValueEquals(artifact_analysis, IREE_SV("analyzer"),
+                          IREE_SV("rocjitsu-waitcheck"));
+  ExpectObjectUint64Equals(artifact_analysis, IREE_SV("abi_version"), 1);
+  ExpectObjectValueEquals(artifact_analysis, IREE_SV("outcome"),
+                          IREE_SV("rejected"));
+  ExpectObjectValueEquals(artifact_analysis, IREE_SV("artifact_target"),
+                          IREE_SV("gfx1250"));
+  ExpectObjectUint64Equals(artifact_analysis, IREE_SV("instructions_analyzed"),
+                           354);
+  ExpectObjectUint64Equals(artifact_analysis, IREE_SV("memory_events_tracked"),
+                           61);
+  ExpectObjectUint64Equals(artifact_analysis, IREE_SV("functions_discovered"),
+                           3);
+  ExpectObjectUint64Equals(artifact_analysis, IREE_SV("functions_analyzed"), 2);
+  ExpectObjectUint64Equals(artifact_analysis, IREE_SV("findings_observed"), 7);
+  ExpectObjectUint64Equals(artifact_analysis, IREE_SV("findings_reported"), 4);
+  ExpectObjectValueEquals(artifact_analysis, IREE_SV("findings_truncated"),
+                          IREE_SV("true"));
+  ExpectObjectValueEquals(artifact_analysis, IREE_SV("stopped_early"),
+                          IREE_SV("true"));
+  ExpectObjectValueEquals(artifact_analysis, IREE_SV("complete"),
+                          IREE_SV("false"));
+  ExpectObjectValueEquals(artifact_analysis, IREE_SV("passed"),
+                          IREE_SV("false"));
+  iree_string_builder_deinitialize(&builder);
+  loom_target_compile_report_deinitialize(&clone);
+}
+
 TEST(CompileReportFormatTest, FormatsEntryReportsAndTargetCapabilities) {
   loom_target_compile_report_t report = {};
   loom_target_compile_report_initialize(&report, iree_allocator_system());

--- a/loom/src/loom/target/reporting/format_text.c
+++ b/loom/src/loom/target/reporting/format_text.c
@@ -316,6 +316,36 @@ static iree_status_t loom_target_compile_report_format_summary(
       iree_string_builder_append_string(builder, IREE_SV("\n")));
 
   if (iree_any_bit_set(report->detail_flags,
+                       LOOM_TARGET_COMPILE_REPORT_DETAIL_ARTIFACT_ANALYSIS)) {
+    const loom_target_compile_report_artifact_analysis_t* analysis =
+        &report->artifact_analysis;
+    const iree_string_view_t analyzer =
+        loom_target_compile_report_text_non_empty(analysis->analyzer_name);
+    const iree_string_view_t outcome =
+        loom_target_compile_report_artifact_analysis_outcome_name(
+            analysis->outcome);
+    const iree_string_view_t target =
+        loom_target_compile_report_text_non_empty(analysis->artifact_target);
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+        builder,
+        "COMPILE-REPORT: artifact_analysis analyzer=%.*s abi_version=%" PRIu32
+        " outcome=%.*s artifact_target=%.*s instructions_analyzed=%" PRIu64
+        " memory_events_tracked=%" PRIu64 " functions_discovered=%" PRIu64
+        " functions_analyzed=%" PRIu64 " findings_observed=%" PRIu64
+        " findings_reported=%" PRIu64
+        " findings_truncated=%s stopped_early=%s complete=%s passed=%s\n",
+        (int)analyzer.size, analyzer.data, analysis->analyzer_abi_version,
+        (int)outcome.size, outcome.data, (int)target.size, target.data,
+        analysis->instruction_count, analysis->memory_event_count,
+        analysis->function_count, analysis->analyzed_function_count,
+        analysis->finding_count, analysis->reported_finding_count,
+        analysis->findings_truncated ? "true" : "false",
+        analysis->stopped_early ? "true" : "false",
+        analysis->complete ? "true" : "false",
+        analysis->passed ? "true" : "false"));
+  }
+
+  if (iree_any_bit_set(report->detail_flags,
                        LOOM_TARGET_COMPILE_REPORT_DETAIL_SCHEDULE)) {
     IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
         builder,

--- a/loom/src/loom/target/reporting/report.c
+++ b/loom/src/loom/target/reporting/report.c
@@ -381,6 +381,13 @@ void loom_target_compile_report_record_artifact_size(
   report->artifact_size = artifact_size;
 }
 
+void loom_target_compile_report_record_artifact_analysis(
+    loom_target_compile_report_t* report,
+    const loom_target_compile_report_artifact_analysis_t* analysis) {
+  report->artifact_analysis = *analysis;
+  report->detail_flags |= LOOM_TARGET_COMPILE_REPORT_DETAIL_ARTIFACT_ANALYSIS;
+}
+
 void loom_target_compile_report_record_schedule(
     loom_target_compile_report_t* report, uint64_t node_count,
     uint64_t scheduled_node_count, uint64_t dependency_count,

--- a/loom/src/loom/target/reporting/report.h
+++ b/loom/src/loom/target/reporting/report.h
@@ -31,6 +31,18 @@ typedef enum loom_target_compile_artifact_kind_e {
   LOOM_TARGET_COMPILE_ARTIFACT_KIND_TARGET_ARTIFACT = 4,
 } loom_target_compile_artifact_kind_t;
 
+// Terminal outcome of final target-artifact analysis.
+typedef enum loom_target_compile_report_artifact_analysis_outcome_e {
+  // No artifact analysis was requested or completed.
+  LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_NONE = 0,
+  // Analysis completed over the full artifact and found no hazards.
+  LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_CLEAN = 1,
+  // Analysis completed and rejected the artifact due to one or more findings.
+  LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_REJECTED = 2,
+  // Analysis could not produce an authoritative verdict.
+  LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_ERROR = 3,
+} loom_target_compile_report_artifact_analysis_outcome_t;
+
 typedef uint32_t loom_target_compile_report_detail_flags_t;
 enum {
   // No optional report details are populated.
@@ -87,7 +99,46 @@ enum {
   LOOM_TARGET_COMPILE_REPORT_DETAIL_LOW_PLANNING = 1u << 24,
   // Target-inserted native packet rows were recorded or counted.
   LOOM_TARGET_COMPILE_REPORT_DETAIL_TARGET_INSERTION_ROWS = 1u << 25,
+  // Final target-artifact analysis summary was recorded.
+  LOOM_TARGET_COMPILE_REPORT_DETAIL_ARTIFACT_ANALYSIS = 1u << 26,
 };
+
+// Target-neutral summary of one final target-artifact analysis.
+//
+// |analyzer_name| and |artifact_target| borrow storage with the same lifetime
+// as the report's other string views. Analyzer adapters must map callback-only
+// strings to Loom-owned stable names before recording this summary.
+typedef struct loom_target_compile_report_artifact_analysis_t {
+  // Stable Loom-facing analyzer identity.
+  iree_string_view_t analyzer_name;
+  // Analyzer ABI version used for this analysis.
+  uint32_t analyzer_abi_version;
+  // Terminal analysis outcome.
+  loom_target_compile_report_artifact_analysis_outcome_t outcome;
+  // Target identity independently inferred from the final artifact.
+  iree_string_view_t artifact_target;
+  // Final native instructions decoded and analyzed.
+  uint64_t instruction_count;
+  // Memory events tracked while analyzing decoded instructions.
+  uint64_t memory_event_count;
+  // Artifact functions or kernels discovered.
+  uint64_t function_count;
+  // Discovered functions or kernels analyzed.
+  uint64_t analyzed_function_count;
+  // Findings observed regardless of reporting limits.
+  uint64_t finding_count;
+  // Findings published through the analyzer diagnostic callback.
+  uint64_t reported_finding_count;
+  // True when |finding_count| is only a lower bound because reporting was
+  // disabled, limited, or stopped early.
+  bool findings_truncated;
+  // True when analysis intentionally stopped after an observed finding.
+  bool stopped_early;
+  // True when the entire artifact received an authoritative analysis.
+  bool complete;
+  // Analyzer pass state reported for the artifact.
+  bool passed;
+} loom_target_compile_report_artifact_analysis_t;
 
 typedef enum loom_target_compile_report_move_cause_e {
   // No residual target move cause was recorded.
@@ -1637,6 +1688,8 @@ typedef struct loom_target_compile_report_t {
   iree_string_view_t artifact_format;
   // Number of bytes in the produced artifact.
   uint64_t artifact_size;
+  // Final target-artifact analysis summary.
+  loom_target_compile_report_artifact_analysis_t artifact_analysis;
   // Number of low schedule nodes before target emission.
   uint64_t schedule_node_count;
   // Number of low schedule nodes in scheduled order.
@@ -1838,6 +1891,11 @@ void loom_target_compile_report_record_target_bundle(
 // Records the produced artifact byte size in |report|.
 void loom_target_compile_report_record_artifact_size(
     loom_target_compile_report_t* report, uint64_t artifact_size);
+
+// Records a final target-artifact analysis summary in |report|.
+void loom_target_compile_report_record_artifact_analysis(
+    loom_target_compile_report_t* report,
+    const loom_target_compile_report_artifact_analysis_t* analysis);
 
 // Records target-low schedule summary counts in |report|.
 void loom_target_compile_report_record_schedule(

--- a/loom/src/loom/target/reporting/schema.c
+++ b/loom/src/loom/target/reporting/schema.c
@@ -29,6 +29,21 @@ iree_string_view_t loom_target_compile_report_artifact_kind_name(
   }
 }
 
+iree_string_view_t loom_target_compile_report_artifact_analysis_outcome_name(
+    loom_target_compile_report_artifact_analysis_outcome_t outcome) {
+  switch (outcome) {
+    case LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_CLEAN:
+      return IREE_SV("clean");
+    case LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_REJECTED:
+      return IREE_SV("rejected");
+    case LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_ERROR:
+      return IREE_SV("error");
+    case LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_NONE:
+    default:
+      return IREE_SV("none");
+  }
+}
+
 iree_string_view_t loom_target_compile_report_source_low_selection_name(
     loom_target_compile_report_source_low_selection_kind_t kind) {
   switch (kind) {

--- a/loom/src/loom/target/reporting/schema.h
+++ b/loom/src/loom/target/reporting/schema.h
@@ -53,6 +53,8 @@ extern const loom_target_compile_report_move_cause_descriptor_t
 
 iree_string_view_t loom_target_compile_report_artifact_kind_name(
     loom_target_compile_artifact_kind_t kind);
+iree_string_view_t loom_target_compile_report_artifact_analysis_outcome_name(
+    loom_target_compile_report_artifact_analysis_outcome_t outcome);
 iree_string_view_t loom_target_compile_report_source_low_selection_name(
     loom_target_compile_report_source_low_selection_kind_t kind);
 

--- a/loom/src/loom/tooling/execution/BUILD.bazel
+++ b/loom/src/loom/tooling/execution/BUILD.bazel
@@ -26,10 +26,23 @@ loom_cc_library(
 )
 
 loom_cc_library(
+    name = "artifact_analyzer",
+    srcs = ["artifact_analyzer.c"],
+    hdrs = ["artifact_analyzer.h"],
+    deps = [
+        "//loom/src/loom/error:diagnostic",
+        "//loom/src/loom/target:types",
+        "//loom/src/loom/target/reporting:report",
+        "//runtime/src/iree/base",
+    ],
+)
+
+loom_cc_library(
     name = "compile_options",
     srcs = ["compile_options.c"],
     hdrs = ["compile_options.h"],
     deps = [
+        ":artifact_analyzer",
         "//loom/src/loom/error:diagnostic",
         "//loom/src/loom/target:pipeline_options",
         "//loom/src/loom/target/reporting:artifact_manifest",

--- a/loom/src/loom/tooling/execution/CMakeLists.txt
+++ b/loom/src/loom/tooling/execution/CMakeLists.txt
@@ -23,12 +23,28 @@ loom_cc_library(
 
 loom_cc_library(
   NAME
+    artifact_analyzer
+  HDRS
+    "artifact_analyzer.h"
+  SRCS
+    "artifact_analyzer.c"
+  DEPS
+    iree::base
+    loom::error::diagnostic
+    loom::target::reporting::report
+    loom::target::types
+  PUBLIC
+)
+
+loom_cc_library(
+  NAME
     compile_options
   HDRS
     "compile_options.h"
   SRCS
     "compile_options.c"
   DEPS
+    ::artifact_analyzer
     iree::base
     loom::error::diagnostic
     loom::target::pipeline_options

--- a/loom/src/loom/tooling/execution/artifact_analyzer.c
+++ b/loom/src/loom/tooling/execution/artifact_analyzer.c
@@ -1,0 +1,21 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/tooling/execution/artifact_analyzer.h"
+
+iree_status_t loom_run_artifact_analyzer_analyze(
+    const loom_run_artifact_analyzer_t* analyzer,
+    const loom_run_artifact_analysis_request_t* request) {
+  if (analyzer == NULL || analyzer->fn == NULL) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "artifact analyzer requires a callback");
+  }
+  if (request == NULL) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "artifact analyzer requires a request");
+  }
+  return analyzer->fn(analyzer->user_data, request);
+}

--- a/loom/src/loom/tooling/execution/artifact_analyzer.h
+++ b/loom/src/loom/tooling/execution/artifact_analyzer.h
@@ -1,0 +1,70 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Target-neutral analysis of final compiler artifact bytes.
+
+#ifndef LOOM_TOOLING_EXECUTION_ARTIFACT_ANALYZER_H_
+#define LOOM_TOOLING_EXECUTION_ARTIFACT_ANALYZER_H_
+
+#include "iree/base/api.h"
+#include "loom/error/diagnostic.h"
+#include "loom/target/reporting/report.h"
+#include "loom/target/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Immutable final-artifact state borrowed for one synchronous analysis call.
+typedef struct loom_run_artifact_analysis_request_t {
+  // Target-native format of |artifact_data|.
+  loom_target_artifact_format_t artifact_format;
+
+  // Final target-native bytes produced by the selected artifact provider.
+  iree_const_byte_span_t artifact_data;
+
+  // Provider-owned target key used to emit |artifact_data|.
+  iree_string_view_t target_key;
+
+  // Target-neutral bundle resolved for the artifact, when available.
+  const loom_target_bundle_t* target_bundle;
+
+  // Sink receiving analyzer diagnostics. A NULL callback may count findings
+  // internally but cannot publish rendered diagnostics.
+  loom_diagnostic_sink_t diagnostic_sink;
+
+  // Maximum diagnostics the analyzer may publish before rejecting analysis.
+  // Zero requests the analyzer's conservative default.
+  uint32_t max_errors;
+
+  // Optional candidate-owned compile report receiving structured analysis.
+  loom_target_compile_report_t* report;
+} loom_run_artifact_analysis_request_t;
+
+// Synchronously analyzes |request|. The callback must not retain any request
+// field after returning.
+typedef iree_status_t (*loom_run_artifact_analyze_fn_t)(
+    void* user_data, const loom_run_artifact_analysis_request_t* request);
+
+// Borrowed final-artifact analyzer selected by a compiler embedding.
+typedef struct loom_run_artifact_analyzer_t {
+  // Synchronous analysis callback.
+  loom_run_artifact_analyze_fn_t fn;
+
+  // Caller-owned payload forwarded to |fn|.
+  void* user_data;
+} loom_run_artifact_analyzer_t;
+
+// Invokes |analyzer| synchronously over |request|.
+iree_status_t loom_run_artifact_analyzer_analyze(
+    const loom_run_artifact_analyzer_t* analyzer,
+    const loom_run_artifact_analysis_request_t* request);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_TOOLING_EXECUTION_ARTIFACT_ANALYZER_H_

--- a/loom/src/loom/tooling/execution/compile_options.h
+++ b/loom/src/loom/tooling/execution/compile_options.h
@@ -13,6 +13,7 @@
 #include "loom/target/pipeline_options.h"
 #include "loom/target/reporting/artifact_manifest.h"
 #include "loom/target/reporting/report.h"
+#include "loom/tooling/execution/artifact_analyzer.h"
 #include "loom/verify/verify.h"
 
 #ifdef __cplusplus
@@ -59,6 +60,9 @@ typedef struct loom_run_candidate_compile_options_t {
   uint32_t max_errors;
   // Optional caller-owned structured compile report to populate.
   loom_target_compile_report_t* report;
+  // Optional borrowed analyzer for final target-native artifact bytes.
+  // Analysis is synchronous and completes before the candidate is published.
+  const loom_run_artifact_analyzer_t* artifact_analyzer;
   // Optional one-shot report capture receiving emitted diagnostics for report
   // output adapters.
   loom_run_compile_report_capture_t* report_capture;

--- a/loom/src/loom/tooling/execution/hal/BUILD.bazel
+++ b/loom/src/loom/tooling/execution/hal/BUILD.bazel
@@ -57,6 +57,7 @@ loom_cc_library(
         ":artifact",
         ":runtime",
         "//loom/src/loom/target/reporting:report",
+        "//loom/src/loom/tooling/execution:artifact_analyzer",
         "//loom/src/loom/tooling/execution:compile_options",
         "//loom/src/loom/tooling/execution:session",
         "//loom/src/loom/verify",

--- a/loom/src/loom/tooling/execution/hal/CMakeLists.txt
+++ b/loom/src/loom/tooling/execution/hal/CMakeLists.txt
@@ -60,6 +60,7 @@ loom_cc_library(
     ::runtime
     iree::base
     loom::target::reporting::report
+    loom::tooling::execution::artifact_analyzer
     loom::tooling::execution::compile_options
     loom::tooling::execution::session
     loom::verify

--- a/loom/src/loom/tooling/execution/hal/candidate.c
+++ b/loom/src/loom/tooling/execution/hal/candidate.c
@@ -90,6 +90,20 @@ static iree_status_t loom_run_hal_candidate_emit_selected_target(
       candidate->artifact.target_bundle == NULL) {
     candidate->artifact.target_bundle = candidate->device_target.target_bundle;
   }
+  if (iree_status_is_ok(status) && candidate->compiled &&
+      options->artifact_analyzer != NULL) {
+    const loom_run_artifact_analysis_request_t request = {
+        .artifact_format = candidate->artifact.target_artifact_format,
+        .artifact_data = candidate->artifact.target_artifact_data,
+        .target_key = candidate->artifact.target_key,
+        .target_bundle = candidate->artifact.target_bundle,
+        .diagnostic_sink = options->diagnostic_sink,
+        .max_errors = options->max_errors,
+        .report = report,
+    };
+    status = loom_run_artifact_analyzer_analyze(options->artifact_analyzer,
+                                                &request);
+  }
   return status;
 }
 

--- a/loom/src/loom/tooling/execution/hal/candidate_test.cc
+++ b/loom/src/loom/tooling/execution/hal/candidate_test.cc
@@ -48,6 +48,14 @@ bool g_fake_hal_expect_module_target = false;
 loom_target_compile_report_t* g_fake_hal_emit_report = nullptr;
 const loom_target_pipeline_options_t* g_fake_hal_emit_target_pipeline_options =
     nullptr;
+enum class FakeHalEmitOutcome {
+  kArtifact,
+  kNoArtifact,
+  kFailure,
+};
+FakeHalEmitOutcome g_fake_hal_emit_outcome = FakeHalEmitOutcome::kArtifact;
+int g_fake_hal_deinitialize_target_count = 0;
+int g_fake_hal_deinitialize_artifact_count = 0;
 const uint8_t kFakeHalExecutableData[] = {0x7F, 'E', 'L', 'F'};
 const uint8_t kFakeHalTargetArtifactData[] = {'h', 's', 'a', 'c', 'o'};
 static const loom_target_snapshot_t kFakeSnapshot = {
@@ -63,6 +71,68 @@ static const loom_target_bundle_t kFakeTargetBundle = {
     /*.snapshot=*/&kFakeSnapshot,
     /*.export_plan=*/&kFakeExportPlan,
 };
+
+struct FakeArtifactAnalyzerState {
+  int call_count = 0;
+  bool reject = false;
+  loom_target_artifact_format_t artifact_format =
+      LOOM_TARGET_ARTIFACT_FORMAT_UNKNOWN;
+  iree_const_byte_span_t artifact_data = {};
+  iree_string_view_t target_key = {};
+  const loom_target_bundle_t* target_bundle = nullptr;
+  loom_diagnostic_sink_t diagnostic_sink = {};
+  uint32_t max_errors = 0;
+  bool report_present = false;
+};
+
+iree_status_t FakeAnalyzeArtifact(
+    void* user_data, const loom_run_artifact_analysis_request_t* request) {
+  auto* state = static_cast<FakeArtifactAnalyzerState*>(user_data);
+  ++state->call_count;
+  state->artifact_format = request->artifact_format;
+  state->artifact_data = request->artifact_data;
+  state->target_key = request->target_key;
+  state->target_bundle = request->target_bundle;
+  state->diagnostic_sink = request->diagnostic_sink;
+  state->max_errors = request->max_errors;
+  state->report_present = request->report != nullptr;
+  if (request->report != nullptr) {
+    const loom_target_compile_report_artifact_analysis_t analysis = {
+        /*.analyzer_name=*/IREE_SVL("fake-artifact-analyzer"),
+        /*.analyzer_abi_version=*/7,
+        /*.outcome=*/
+        state->reject
+            ? LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_REJECTED
+            : LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_CLEAN,
+        /*.artifact_target=*/request->target_key,
+        /*.instruction_count=*/5,
+        /*.memory_event_count=*/2,
+        /*.function_count=*/1,
+        /*.analyzed_function_count=*/1,
+        /*.finding_count=*/state->reject ? 1u : 0u,
+        /*.reported_finding_count=*/state->reject ? 1u : 0u,
+        /*.findings_truncated=*/false,
+        /*.stopped_early=*/false,
+        /*.complete=*/true,
+        /*.passed=*/!state->reject,
+    };
+    loom_target_compile_report_record_artifact_analysis(request->report,
+                                                        &analysis);
+  }
+  if (state->reject) {
+    return iree_make_status(IREE_STATUS_ABORTED,
+                            "fake final-artifact rejection");
+  }
+  return iree_ok_status();
+}
+
+loom_run_artifact_analyzer_t FakeArtifactAnalyzer(
+    FakeArtifactAnalyzerState* state) {
+  return (loom_run_artifact_analyzer_t){
+      /*.fn=*/FakeAnalyzeArtifact,
+      /*.user_data=*/state,
+  };
+}
 
 const loom_run_hal_runtime_t* FakeHalRuntime() {
   return reinterpret_cast<const loom_run_hal_runtime_t*>(&kFakeHalRuntime);
@@ -83,6 +153,15 @@ iree_status_t FakeHalSelectDeviceTarget(
       /*.target_key=*/IREE_SVL("fake-hal"),
   };
   return iree_ok_status();
+}
+
+void FakeHalDeinitializeDeviceTarget(
+    const loom_run_hal_artifact_provider_t* provider,
+    loom_run_hal_device_target_t* target, iree_allocator_t allocator) {
+  (void)provider;
+  (void)allocator;
+  ++g_fake_hal_deinitialize_target_count;
+  *target = {};
 }
 
 iree_status_t FakeHalEmitArtifact(
@@ -115,6 +194,13 @@ iree_status_t FakeHalEmitArtifact(
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "unexpected fake HAL target payload");
   }
+  if (g_fake_hal_emit_outcome == FakeHalEmitOutcome::kFailure) {
+    return iree_make_status(IREE_STATUS_ABORTED,
+                            "fake HAL provider emission failure");
+  }
+  if (g_fake_hal_emit_outcome == FakeHalEmitOutcome::kNoArtifact) {
+    return iree_ok_status();
+  }
   *out_artifact = (loom_run_hal_artifact_t){
       /*.hal_target=*/nullptr,
       /*.target_key=*/IREE_SVL("fake-hal-target"),
@@ -141,6 +227,7 @@ void FakeHalDeinitializeArtifact(
     loom_run_hal_artifact_t* artifact, iree_allocator_t allocator) {
   (void)provider;
   (void)allocator;
+  ++g_fake_hal_deinitialize_artifact_count;
   *artifact = {};
 }
 
@@ -151,7 +238,7 @@ const loom_run_hal_artifact_provider_t kFakeHalArtifactProvider = {
     /*.default_pipeline_options=*/{},
     /*.select_device_target=*/FakeHalSelectDeviceTarget,
     /*.select_target_key=*/{},
-    /*.deinitialize_device_target=*/{},
+    /*.deinitialize_device_target=*/FakeHalDeinitializeDeviceTarget,
     /*.emit_artifact=*/FakeHalEmitArtifact,
     /*.deinitialize_artifact=*/FakeHalDeinitializeArtifact,
 };
@@ -163,6 +250,9 @@ class HalCandidateTest : public ::testing::Test {
     g_fake_hal_expect_module_target = false;
     g_fake_hal_emit_report = nullptr;
     g_fake_hal_emit_target_pipeline_options = nullptr;
+    g_fake_hal_emit_outcome = FakeHalEmitOutcome::kArtifact;
+    g_fake_hal_deinitialize_target_count = 0;
+    g_fake_hal_deinitialize_artifact_count = 0;
     loom_run_session_options_t options = {};
     loom_run_session_options_initialize(&options);
     options.register_context = (loom_run_register_context_callback_t){
@@ -204,6 +294,10 @@ TEST_F(HalCandidateTest, CompileHalExecutableCandidate) {
   InitializeCompileOptions(&run_module, &options);
   loom_target_compile_report_t report = {};
   options.report = &report;
+  FakeArtifactAnalyzerState analyzer_state;
+  const loom_run_artifact_analyzer_t analyzer =
+      FakeArtifactAnalyzer(&analyzer_state);
+  options.artifact_analyzer = &analyzer;
 
   loom_run_hal_candidate_t candidate = {};
   g_fake_hal_emit_was_called = false;
@@ -231,6 +325,19 @@ TEST_F(HalCandidateTest, CompileHalExecutableCandidate) {
   EXPECT_EQ(candidate.artifact.executable_data.data, kFakeHalExecutableData);
   EXPECT_EQ(candidate.artifact.executable_data.data_length,
             sizeof(kFakeHalExecutableData));
+  EXPECT_EQ(analyzer_state.call_count, 1);
+  EXPECT_EQ(analyzer_state.artifact_format, LOOM_TARGET_ARTIFACT_FORMAT_ELF);
+  EXPECT_EQ(analyzer_state.artifact_data.data, kFakeHalTargetArtifactData);
+  EXPECT_EQ(analyzer_state.artifact_data.data_length,
+            sizeof(kFakeHalTargetArtifactData));
+  EXPECT_TRUE(iree_string_view_equal(analyzer_state.target_key,
+                                     IREE_SV("fake-hal-target")));
+  EXPECT_EQ(analyzer_state.target_bundle, &kFakeTargetBundle);
+  EXPECT_EQ(analyzer_state.diagnostic_sink.fn, options.diagnostic_sink.fn);
+  EXPECT_EQ(analyzer_state.diagnostic_sink.user_data,
+            options.diagnostic_sink.user_data);
+  EXPECT_EQ(analyzer_state.max_errors, options.max_errors);
+  EXPECT_TRUE(analyzer_state.report_present);
   EXPECT_EQ(candidate.compile_report.artifact_kind,
             LOOM_TARGET_COMPILE_ARTIFACT_KIND_HAL_EXECUTABLE);
   EXPECT_EQ(candidate.compile_report.status_code, IREE_STATUS_OK);
@@ -243,9 +350,30 @@ TEST_F(HalCandidateTest, CompileHalExecutableCandidate) {
   EXPECT_EQ(candidate.compile_report.artifact_size,
             sizeof(kFakeHalExecutableData));
   EXPECT_EQ(report.artifact_size, candidate.compile_report.artifact_size);
+  EXPECT_TRUE(
+      iree_any_bit_set(report.detail_flags,
+                       LOOM_TARGET_COMPILE_REPORT_DETAIL_ARTIFACT_ANALYSIS));
+  EXPECT_TRUE(iree_string_view_equal(report.artifact_analysis.analyzer_name,
+                                     IREE_SV("fake-artifact-analyzer")));
+  EXPECT_EQ(report.artifact_analysis.analyzer_abi_version, 7u);
+  EXPECT_EQ(report.artifact_analysis.outcome,
+            LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_CLEAN);
+  EXPECT_TRUE(iree_string_view_equal(report.artifact_analysis.artifact_target,
+                                     IREE_SV("fake-hal-target")));
+  EXPECT_EQ(report.artifact_analysis.instruction_count, 5u);
+  EXPECT_EQ(report.artifact_analysis.memory_event_count, 2u);
+  EXPECT_EQ(report.artifact_analysis.function_count, 1u);
+  EXPECT_EQ(report.artifact_analysis.analyzed_function_count, 1u);
+  EXPECT_EQ(report.artifact_analysis.finding_count, 0u);
+  EXPECT_EQ(report.artifact_analysis.reported_finding_count, 0u);
+  EXPECT_TRUE(report.artifact_analysis.complete);
+  EXPECT_TRUE(report.artifact_analysis.passed);
 
   loom_run_hal_candidate_deinitialize(&candidate);
   EXPECT_EQ(candidate.provider, nullptr);
+  EXPECT_EQ(report.artifact_analysis.outcome,
+            LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_CLEAN);
+  loom_target_compile_report_deinitialize(&report);
   loom_run_module_deinitialize(&run_module);
 }
 
@@ -281,6 +409,10 @@ TEST_F(HalCandidateTest, EmitsModuleTargetCandidate) {
   InitializeCompileOptions(&run_module, &options);
   loom_target_compile_report_t report = {};
   options.report = &report;
+  FakeArtifactAnalyzerState analyzer_state;
+  const loom_run_artifact_analyzer_t analyzer =
+      FakeArtifactAnalyzer(&analyzer_state);
+  options.artifact_analyzer = &analyzer;
 
   loom_run_hal_candidate_t candidate = {};
   g_fake_hal_emit_was_called = false;
@@ -295,6 +427,10 @@ TEST_F(HalCandidateTest, EmitsModuleTargetCandidate) {
   EXPECT_EQ(candidate.device_target.data, nullptr);
   EXPECT_EQ(candidate.device_target.target_bundle, nullptr);
   EXPECT_EQ(candidate.artifact.target_bundle, nullptr);
+  EXPECT_EQ(analyzer_state.call_count, 1);
+  EXPECT_EQ(analyzer_state.artifact_data.data, kFakeHalTargetArtifactData);
+  EXPECT_EQ(analyzer_state.target_bundle, nullptr);
+  EXPECT_TRUE(analyzer_state.report_present);
   EXPECT_TRUE(iree_string_view_equal(candidate.artifact.target_key,
                                      IREE_SV("fake-hal-target")));
   EXPECT_TRUE(iree_string_view_is_empty(candidate.compile_report.target_key));
@@ -304,6 +440,168 @@ TEST_F(HalCandidateTest, EmitsModuleTargetCandidate) {
 
   g_fake_hal_expect_module_target = false;
   loom_run_hal_candidate_deinitialize(&candidate);
+  loom_target_compile_report_deinitialize(&report);
+  loom_run_module_deinitialize(&run_module);
+}
+
+TEST_F(HalCandidateTest, EmitsExplicitTargetCandidate) {
+  loom_run_module_t run_module = {};
+  IREE_ASSERT_OK(Parse(IREE_SV(kHalSource), &run_module));
+
+  loom_run_candidate_compile_options_t options = {};
+  InitializeCompileOptions(&run_module, &options);
+  FakeArtifactAnalyzerState analyzer_state;
+  const loom_run_hal_device_target_t target = {
+      /*.hal_target=*/nullptr,
+      /*.data=*/&kFakeHalTarget,
+      /*.target_storage=*/{},
+      /*.target_bundle=*/&kFakeTargetBundle,
+      /*.target_key=*/IREE_SVL("explicit-fake-hal"),
+  };
+
+  loom_run_hal_candidate_t candidate = {};
+  {
+    const loom_run_artifact_analyzer_t analyzer =
+        FakeArtifactAnalyzer(&analyzer_state);
+    options.artifact_analyzer = &analyzer;
+    IREE_ASSERT_OK(loom_run_hal_candidate_emit_target(
+        &kFakeHalArtifactProvider, &target, &run_module, &options,
+        iree_allocator_system(), &candidate));
+    EXPECT_TRUE(g_fake_hal_emit_was_called);
+    EXPECT_FALSE(candidate.owns_device_target);
+    EXPECT_EQ(candidate.artifact.target_bundle, &kFakeTargetBundle);
+    EXPECT_EQ(analyzer_state.call_count, 1);
+    EXPECT_EQ(analyzer_state.artifact_format, LOOM_TARGET_ARTIFACT_FORMAT_ELF);
+    EXPECT_EQ(analyzer_state.artifact_data.data, kFakeHalTargetArtifactData);
+    EXPECT_EQ(analyzer_state.target_bundle, &kFakeTargetBundle);
+    EXPECT_FALSE(analyzer_state.report_present);
+  }
+
+  loom_run_hal_candidate_deinitialize(&candidate);
+  EXPECT_EQ(analyzer_state.call_count, 1);
+  EXPECT_EQ(g_fake_hal_deinitialize_target_count, 0);
+  EXPECT_EQ(g_fake_hal_deinitialize_artifact_count, 1);
+  loom_run_module_deinitialize(&run_module);
+}
+
+TEST_F(HalCandidateTest, SkipsAnalyzerWhenProviderEmitsNoArtifact) {
+  loom_run_module_t run_module = {};
+  IREE_ASSERT_OK(Parse(IREE_SV(kHalSource), &run_module));
+
+  loom_run_candidate_compile_options_t options = {};
+  InitializeCompileOptions(&run_module, &options);
+  FakeArtifactAnalyzerState analyzer_state;
+  const loom_run_artifact_analyzer_t analyzer =
+      FakeArtifactAnalyzer(&analyzer_state);
+  options.artifact_analyzer = &analyzer;
+  g_fake_hal_emit_outcome = FakeHalEmitOutcome::kNoArtifact;
+
+  loom_run_hal_candidate_t candidate = {};
+  IREE_ASSERT_OK(loom_run_hal_candidate_compile(
+      &kFakeHalArtifactProvider, FakeHalRuntime(), &run_module, &options,
+      iree_allocator_system(), &candidate));
+  EXPECT_TRUE(g_fake_hal_emit_was_called);
+  EXPECT_FALSE(candidate.compiled);
+  EXPECT_EQ(analyzer_state.call_count, 0);
+
+  loom_run_hal_candidate_deinitialize(&candidate);
+  loom_run_module_deinitialize(&run_module);
+}
+
+TEST_F(HalCandidateTest, SkipsAnalyzerWhenProviderFails) {
+  loom_run_module_t run_module = {};
+  IREE_ASSERT_OK(Parse(IREE_SV(kHalSource), &run_module));
+
+  loom_run_candidate_compile_options_t options = {};
+  InitializeCompileOptions(&run_module, &options);
+  loom_target_compile_report_t report = {};
+  options.report = &report;
+  FakeArtifactAnalyzerState analyzer_state;
+  const loom_run_artifact_analyzer_t analyzer =
+      FakeArtifactAnalyzer(&analyzer_state);
+  options.artifact_analyzer = &analyzer;
+  g_fake_hal_emit_outcome = FakeHalEmitOutcome::kFailure;
+
+  loom_run_hal_candidate_t candidate = {};
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_ABORTED,
+      loom_run_hal_candidate_compile(&kFakeHalArtifactProvider,
+                                     FakeHalRuntime(), &run_module, &options,
+                                     iree_allocator_system(), &candidate));
+  EXPECT_EQ(analyzer_state.call_count, 0);
+  EXPECT_EQ(candidate.provider, nullptr);
+  EXPECT_EQ(report.status_code, IREE_STATUS_ABORTED);
+  EXPECT_EQ(g_fake_hal_deinitialize_target_count, 1);
+  EXPECT_EQ(g_fake_hal_deinitialize_artifact_count, 1);
+
+  loom_target_compile_report_deinitialize(&report);
+  loom_run_module_deinitialize(&run_module);
+}
+
+TEST_F(HalCandidateTest, AnalyzerRejectionDiscardsCandidate) {
+  loom_run_module_t run_module = {};
+  IREE_ASSERT_OK(Parse(IREE_SV(kHalSource), &run_module));
+
+  loom_run_candidate_compile_options_t options = {};
+  InitializeCompileOptions(&run_module, &options);
+  loom_target_compile_report_t report = {};
+  options.report = &report;
+  FakeArtifactAnalyzerState analyzer_state;
+  analyzer_state.reject = true;
+  const loom_run_artifact_analyzer_t analyzer =
+      FakeArtifactAnalyzer(&analyzer_state);
+  options.artifact_analyzer = &analyzer;
+
+  loom_run_hal_candidate_t candidate = {};
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_ABORTED,
+      loom_run_hal_candidate_compile(&kFakeHalArtifactProvider,
+                                     FakeHalRuntime(), &run_module, &options,
+                                     iree_allocator_system(), &candidate));
+  EXPECT_EQ(analyzer_state.call_count, 1);
+  EXPECT_EQ(analyzer_state.artifact_data.data, kFakeHalTargetArtifactData);
+  EXPECT_EQ(analyzer_state.target_bundle, &kFakeTargetBundle);
+  EXPECT_TRUE(analyzer_state.report_present);
+  EXPECT_EQ(candidate.provider, nullptr);
+  EXPECT_FALSE(candidate.compiled);
+  EXPECT_EQ(candidate.artifact.storage, nullptr);
+  EXPECT_EQ(report.status_code, IREE_STATUS_ABORTED);
+  EXPECT_EQ(report.artifact_size, sizeof(kFakeHalExecutableData));
+  EXPECT_TRUE(
+      iree_any_bit_set(report.detail_flags,
+                       LOOM_TARGET_COMPILE_REPORT_DETAIL_ARTIFACT_ANALYSIS));
+  EXPECT_EQ(report.artifact_analysis.outcome,
+            LOOM_TARGET_COMPILE_REPORT_ARTIFACT_ANALYSIS_OUTCOME_REJECTED);
+  EXPECT_EQ(report.artifact_analysis.finding_count, 1u);
+  EXPECT_EQ(report.artifact_analysis.reported_finding_count, 1u);
+  EXPECT_TRUE(report.artifact_analysis.complete);
+  EXPECT_FALSE(report.artifact_analysis.passed);
+  EXPECT_EQ(g_fake_hal_deinitialize_target_count, 1);
+  EXPECT_EQ(g_fake_hal_deinitialize_artifact_count, 1);
+
+  loom_target_compile_report_deinitialize(&report);
+  loom_run_module_deinitialize(&run_module);
+}
+
+TEST_F(HalCandidateTest, RejectsAnalyzerWithoutCallback) {
+  loom_run_module_t run_module = {};
+  IREE_ASSERT_OK(Parse(IREE_SV(kHalSource), &run_module));
+
+  loom_run_candidate_compile_options_t options = {};
+  InitializeCompileOptions(&run_module, &options);
+  const loom_run_artifact_analyzer_t analyzer = {};
+  options.artifact_analyzer = &analyzer;
+
+  loom_run_hal_candidate_t candidate = {};
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      loom_run_hal_candidate_compile(&kFakeHalArtifactProvider,
+                                     FakeHalRuntime(), &run_module, &options,
+                                     iree_allocator_system(), &candidate));
+  EXPECT_EQ(candidate.provider, nullptr);
+  EXPECT_EQ(g_fake_hal_deinitialize_target_count, 1);
+  EXPECT_EQ(g_fake_hal_deinitialize_artifact_count, 1);
+
   loom_run_module_deinitialize(&run_module);
 }
 


### PR DESCRIPTION
Make final native bytes an explicit compiler transaction point. A compiler embedding can synchronously analyze the exact artifact produced by the selected target provider, publish structured results into the compile report, and reject the candidate before any executable artifact becomes observable.

## Analyzer contract

The target-neutral callback borrows the final byte span, artifact format, target key and bundle, diagnostic sink, reporting limit, and candidate-owned compile report for one synchronous call. The borrow lasts for that call; candidate preparation retains ownership of request storage and compiler state.

Candidate preparation invokes analysis only after native emission succeeds and before publication. Analyzer failure leaves the candidate unpublished. Candidate teardown remains the single owner of targets, artifact bytes, and report storage, and analyzer-written report data remains valid through teardown for both clean and rejected outcomes.

## Structured results

Compile reports distinguish no analysis, a complete clean result, a complete rejection, and an analysis error. Text and JSON include analyzer identity and ABI version, independently observed artifact target, decoded instruction and memory-event counts, discovered and analyzed functions, findings observed and reported, truncation, early termination, completeness, and the final verdict.

AMDGPU wait hazards have a typed diagnostic bridge carrying the stable hazard code, kernel attribution, section and file offsets, producer and consumer instructions, register class and span, counter identity, required progress, and explanation. Final-byte analyzers therefore use Loom's normal diagnostic and report surfaces while preserving machine-readable finding data alongside human explanations.

## Embedding model

The compiler embedding owns analyzer discovery, dynamic-library loading, ABI negotiation, selection policy, and required-versus-advisory behavior. The core compiler owns callback invocation and the structured result schema. Target providers own native artifact production. These boundaries let analyzer implementations and loading policy evolve independently of candidate ownership and target emission.

## Reviewer Notes

The highest-value review surfaces are transactional ordering in `hal/candidate.c`, request and report lifetime ownership, rejection before publication, and the stability of the target-neutral report and typed-hazard schemas.
