### PR TITLE
[Loom] Qualify configured gfx1250 fragment banks

### DIFF
--- a/loom/src/loom/tools/loom-compile/BUILD.bazel
+++ b/loom/src/loom/tools/loom-compile/BUILD.bazel
@@ -139,6 +139,7 @@ iree_execution_test_suite(
 iree_execution_test_suite(
     name = "amdgpu_execution_test",
     data = [
+        "gfx1250_configured_fragment_bank.loom",
         "gfx1250_extended_vgpr.loom",
         "gfx1250_tied_accumulators.loom",
         "gfx12_wmma_bf16_f32.loom",

--- a/loom/src/loom/tools/loom-compile/CMakeLists.txt
+++ b/loom/src/loom/tools/loom-compile/CMakeLists.txt
@@ -103,6 +103,7 @@ iree_execution_test_suite(
     "loom-compile=::loom-compile"
   DATA
     "${PROJECT_SOURCE_DIR}/loom/src/loom/tools/iree-test-loom/testdata/amdgpu_unused_kernargs.loom"
+    "gfx1250_configured_fragment_bank.loom"
     "gfx1250_extended_vgpr.loom"
     "gfx1250_tied_accumulators.loom"
     "gfx12_wmma_bf16_f32.loom"

--- a/loom/src/loom/tools/loom-compile/gfx1250_configured_fragment_bank.loom
+++ b/loom/src/loom/tools/loom-compile/gfx1250_configured_fragment_bank.loom
@@ -1,0 +1,76 @@
+config.decl @test.fragment_bank.m_fragments : %value: index where [range(%value, 1, 8)]
+
+config.decl @test.fragment_bank.n_fragments : %value: index where [range(%value, 1, 8)]
+
+config.decl @test.fragment_bank.k_fragments : %value: index where [range(%value, 1, 8)]
+
+config.decl @test.fragment_bank.workgroup_size : %value: index where [range(%value, 1, 2048)]
+
+config.decl @test.fragment_bank.scratch_elements : %value: index where [range(%value, 1, 100000)]
+
+amdgpu.target<gfx1250> @target
+
+kernel.def target(@target) export("configured_fragment_bank") @configured_fragment_bank() {
+  %one = index.constant 1 : index
+  %workgroup_size = config.get @test.fragment_bank.workgroup_size : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+} launch(%output: buffer) {
+  %base = index.constant 0 : offset
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %two = index.constant 2 : index
+  %four = index.constant 4 : index
+  %c16 = index.constant 16 : index
+  %matrix_m = index.constant 16 : index
+  %matrix_n = index.constant 16 : index
+  %matrix_k = index.constant 32 : index
+  %m_fragments = config.get @test.fragment_bank.m_fragments : index
+  %n_fragments = config.get @test.fragment_bank.n_fragments : index
+  %k_fragments = config.get @test.fragment_bank.k_fragments : index
+  %scratch_elements = config.get @test.fragment_bank.scratch_elements : index
+  %m_extent = index.mul %m_fragments, %c16 : index
+  %n_extent = index.mul %n_fragments, %c16 : index
+  %scratch_bytes_index = index.mul %scratch_elements, %four : index
+  %scratch_bytes = index.cast %scratch_bytes_index : index to offset
+  %lane = kernel.workitem.id<x> : index
+  %output_global = buffer.assume.memory_space<global> %output : buffer
+  %output_view = buffer.view %output_global[%base] : buffer -> view<[%m_extent]x[%n_extent]xf32, #dense>
+  %scratch = buffer.alloca %scratch_bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %scratch_view = buffer.view %scratch[%base] : buffer -> view<[%scratch_elements]xi32, #dense>
+  %marker = vector.constant 0 : vector<1xi32>
+  vector.store %marker, %scratch_view[%lane] : vector<1xi32>, view<[%scratch_elements]xi32, #dense>
+  kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
+  %lhs_payload = vector.constant 1.0 : vector<16xbf16>
+  %rhs_payload = vector.constant 1.0 : vector<16xbf16>
+  %lhs = vector.fragment<lhs> %lhs_payload shape [%matrix_m, %matrix_k] : vector<16xbf16>
+  %rhs = vector.fragment<rhs> %rhs_payload shape [%matrix_k, %matrix_n] : vector<16xbf16>
+  %zero_payload = vector.constant 0.0 : vector<8xf32>
+  %zero_fragment = vector.fragment<init> %zero_payload shape [%matrix_m, %matrix_n] : vector<8xf32>
+  %initial_bank = vector.broadcast %zero_fragment : vector<8xf32> -> vector<[%m_fragments]x[%n_fragments]x8xf32>
+  %result_bank = scf.for %stage = [%zero to %two step %one](%stage_bank = %initial_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) {
+    %after_k = scf.for %k_fragment = [%zero to %k_fragments step %one](%k_bank = %stage_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) unroll {
+      %after_m = scf.for %m_fragment = [%zero to %m_fragments step %one](%m_bank = %k_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) unroll {
+        %after_n = scf.for %n_fragment = [%zero to %n_fragments step %one](%n_bank = %m_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) unroll {
+          %accumulator_payload = vector.extract %n_bank[%m_fragment, %n_fragment] : vector<[%m_fragments]x[%n_fragments]x8xf32> -> vector<8xf32>
+          %accumulator = vector.fragment<init> %accumulator_payload shape [%matrix_m, %matrix_n] : vector<8xf32>
+          %next_accumulator = vector.mma %lhs, %rhs, %accumulator : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
+          %next_bank = vector.insert %next_accumulator into %n_bank[%m_fragment, %n_fragment] : vector<8xf32>, vector<[%m_fragments]x[%n_fragments]x8xf32>
+          scf.yield %next_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>
+        }
+        scf.yield %after_n : vector<[%m_fragments]x[%n_fragments]x8xf32>
+      }
+      scf.yield %after_m : vector<[%m_fragments]x[%n_fragments]x8xf32>
+    }
+    scf.yield %after_k : vector<[%m_fragments]x[%n_fragments]x8xf32>
+  }
+  scf.for %store_m = [%zero to %m_fragments step %one] unroll {
+    %store_m_offset = index.mul %store_m, %c16 : index
+    scf.for %store_n = [%zero to %n_fragments step %one] unroll {
+      %store_n_offset = index.mul %store_n, %c16 : index
+      %store_payload = vector.extract %result_bank[%store_m, %store_n] : vector<[%m_fragments]x[%n_fragments]x8xf32> -> vector<8xf32>
+      %store_fragment = vector.fragment<result> %store_payload shape [%matrix_m, %matrix_n] : vector<8xf32>
+      vector.fragment.store<result> %store_fragment, %output_view[%store_m_offset, %store_n_offset] shape [%matrix_m, %matrix_n] : vector<8xf32>, view<[%m_extent]x[%n_extent]xf32, #dense>
+    }
+  }
+  kernel.return
+}

--- a/loom/src/loom/tools/loom-compile/loom-compile-amdgpu.test.json
+++ b/loom/src/loom/tools/loom-compile/loom-compile-amdgpu.test.json
@@ -78,6 +78,219 @@
       ]
     },
     {
+      "name": "specializes configured fragment banks before gfx1250 lowering",
+      "steps": [
+        {
+          "name": "compile-1x1x1",
+          "run": {
+            "tool": "loom-compile",
+            "args": [
+              "{srcdir}/gfx1250_configured_fragment_bank.loom",
+              "--backend=amdgpu-hal",
+              "--target=gfx1250",
+              "--config=test.fragment_bank.m_fragments=1",
+              "--config=test.fragment_bank.n_fragments=1",
+              "--config=test.fragment_bank.k_fragments=1",
+              "--config=test.fragment_bank.workgroup_size=32",
+              "--config=test.fragment_bank.scratch_elements=32",
+              "--output={tmp}/configured_fragment_bank_1x1x1.hal",
+              "--emit-target-artifact={tmp}/configured_fragment_bank_1x1x1.hsaco",
+              "--compile-report=details",
+              "--compile-report-output=-"
+            ]
+          },
+          "stdout": {
+            "contains": {
+              "unordered": [
+                "\"key\":\"test.fragment_bank.m_fragments\",\"value\":\"1\"",
+                "\"key\":\"test.fragment_bank.n_fragments\",\"value\":\"1\"",
+                "\"key\":\"test.fragment_bank.k_fragments\",\"value\":\"1\"",
+                "\"wmma_count\":1",
+                "\"wmma_count\":2",
+                "\"private_memory_bytes\":0",
+                "\"allocation_spill_count\":0"
+              ]
+            }
+          },
+          "files": [
+            {
+              "path": "{tmp}/configured_fragment_bank_1x1x1.hsaco",
+              "non_empty": true
+            }
+          ]
+        },
+        {
+          "name": "compile-2x1x2",
+          "run": {
+            "tool": "loom-compile",
+            "args": [
+              "{srcdir}/gfx1250_configured_fragment_bank.loom",
+              "--backend=amdgpu-hal",
+              "--target=gfx1250",
+              "--config=test.fragment_bank.m_fragments=2",
+              "--config=test.fragment_bank.n_fragments=1",
+              "--config=test.fragment_bank.k_fragments=2",
+              "--config=test.fragment_bank.workgroup_size=32",
+              "--config=test.fragment_bank.scratch_elements=32",
+              "--output={tmp}/configured_fragment_bank_2x1x2.hal",
+              "--emit-target-artifact={tmp}/configured_fragment_bank_2x1x2.hsaco",
+              "--compile-report=details",
+              "--compile-report-output=-"
+            ]
+          },
+          "stdout": {
+            "contains": {
+              "unordered": [
+                "\"key\":\"test.fragment_bank.m_fragments\",\"value\":\"2\"",
+                "\"key\":\"test.fragment_bank.n_fragments\",\"value\":\"1\"",
+                "\"key\":\"test.fragment_bank.k_fragments\",\"value\":\"2\"",
+                "\"wmma_count\":4",
+                "\"wmma_count\":8",
+                "\"private_memory_bytes\":0",
+                "\"allocation_spill_count\":0"
+              ]
+            }
+          },
+          "files": [
+            {
+              "path": "{tmp}/configured_fragment_bank_2x1x2.hsaco",
+              "non_empty": true
+            }
+          ]
+        },
+        {
+          "name": "compile-8x4x2",
+          "run": {
+            "tool": "loom-compile",
+            "args": [
+              "{srcdir}/gfx1250_configured_fragment_bank.loom",
+              "--backend=amdgpu-hal",
+              "--target=gfx1250",
+              "--config=test.fragment_bank.m_fragments=8",
+              "--config=test.fragment_bank.n_fragments=4",
+              "--config=test.fragment_bank.k_fragments=2",
+              "--config=test.fragment_bank.workgroup_size=32",
+              "--config=test.fragment_bank.scratch_elements=32",
+              "--output={tmp}/configured_fragment_bank_8x4x2.hal",
+              "--emit-target-artifact={tmp}/configured_fragment_bank_8x4x2.hsaco",
+              "--compile-report=details",
+              "--compile-report-output=-"
+            ]
+          },
+          "stdout": {
+            "contains": {
+              "unordered": [
+                "\"key\":\"test.fragment_bank.m_fragments\",\"value\":\"8\"",
+                "\"key\":\"test.fragment_bank.n_fragments\",\"value\":\"4\"",
+                "\"key\":\"test.fragment_bank.k_fragments\",\"value\":\"2\"",
+                "\"wmma_count\":64",
+                "\"wmma_count\":128",
+                "\"private_memory_bytes\":0",
+                "\"allocation_spill_count\":0"
+              ]
+            }
+          },
+          "files": [
+            {
+              "path": "{tmp}/configured_fragment_bank_8x4x2.hsaco",
+              "non_empty": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "rejects invalid configured gfx1250 launch and storage contracts",
+      "steps": [
+        {
+          "name": "reject-scratch-smaller-than-workgroup",
+          "run": {
+            "tool": "loom-compile",
+            "args": [
+              "{srcdir}/gfx1250_configured_fragment_bank.loom",
+              "--backend=amdgpu-hal",
+              "--target=gfx1250",
+              "--config=test.fragment_bank.m_fragments=1",
+              "--config=test.fragment_bank.n_fragments=1",
+              "--config=test.fragment_bank.k_fragments=1",
+              "--config=test.fragment_bank.workgroup_size=64",
+              "--config=test.fragment_bank.scratch_elements=32",
+              "--output={tmp}/unused.hal"
+            ]
+          },
+          "exit": {
+            "nonzero": true
+          },
+          "stderr": {
+            "contains": {
+              "unordered": [
+                "error [SUBRANGE/011]",
+                "origin + 1 <= view_bound",
+                "view_bound is 32"
+              ]
+            }
+          }
+        },
+        {
+          "name": "reject-oversized-workgroup",
+          "run": {
+            "tool": "loom-compile",
+            "args": [
+              "{srcdir}/gfx1250_configured_fragment_bank.loom",
+              "--backend=amdgpu-hal",
+              "--target=gfx1250",
+              "--config=test.fragment_bank.m_fragments=1",
+              "--config=test.fragment_bank.n_fragments=1",
+              "--config=test.fragment_bank.k_fragments=1",
+              "--config=test.fragment_bank.workgroup_size=2048",
+              "--config=test.fragment_bank.scratch_elements=2048",
+              "--output={tmp}/unused.hal"
+            ]
+          },
+          "exit": {
+            "nonzero": true
+          },
+          "stderr": {
+            "contains": {
+              "unordered": [
+                "error [TARGET/024]",
+                "workgroup x size 2048 exceeds target limit 1024"
+              ]
+            }
+          }
+        },
+        {
+          "name": "reject-oversized-workgroup-storage",
+          "run": {
+            "tool": "loom-compile",
+            "args": [
+              "{srcdir}/gfx1250_configured_fragment_bank.loom",
+              "--backend=amdgpu-hal",
+              "--target=gfx1250",
+              "--config=test.fragment_bank.m_fragments=1",
+              "--config=test.fragment_bank.n_fragments=1",
+              "--config=test.fragment_bank.k_fragments=1",
+              "--config=test.fragment_bank.workgroup_size=32",
+              "--config=test.fragment_bank.scratch_elements=100000",
+              "--output={tmp}/unused.hal"
+            ]
+          },
+          "exit": {
+            "nonzero": true
+          },
+          "stderr": {
+            "contains": {
+              "unordered": [
+                "error [TARGET/051]",
+                "reserves 400000 byte(s) of workgroup storage",
+                "target limit 327680"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "reports gfx125x target-inserted address-state economics",
       "steps": [
         {


### PR DESCRIPTION
Configured fragment-bank dimensions now specialize before schedule-loop unrolling and bank scalar replacement, allowing one Loom source to produce multiple gfx1250 WMMA schedules without exposing authoring aggregates to target lowering.

Production `loom-compile` coverage exercises 1x1x1, 2x1x2, and the 8x4x2 accumulator shape used by the large PGR2 schedule. It checks the corresponding native WMMA counts and zero spill/private-memory results. The 8x4 bank is larger than the target's ordinary vector-width contract, so successful final HSACO emission proves that structural scalar replacement occurs end to end.

The same source binds launch geometry and workgroup storage. Invalid bindings exercise cross-knob bounds, the gfx1250 workgroup-size limit, and the 320 KiB LDS limit through production diagnostics.
