### PR TITLE
[HAL/AMDGPU] Preserve grouped device frontier identity

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
@@ -39,6 +39,7 @@ iree_runtime_cc_library(
     srcs = ["queue_affinity.c"],
     hdrs = ["queue_affinity.h"],
     deps = [
+        "//runtime/src/iree/async",
         "//runtime/src/iree/base",
         "//runtime/src/iree/hal",
     ],

--- a/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
@@ -36,6 +36,7 @@ iree_cc_library(
   SRCS
     "queue_affinity.c"
   DEPS
+    iree::async
     iree::base
     iree::hal
   PUBLIC

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue.c
@@ -942,8 +942,7 @@ iree_status_t iree_hal_amdgpu_host_queue_initialize(
   // creates the epoch signal) and before any submissions.
   if (iree_status_is_ok(status)) {
     iree_hal_amdgpu_epoch_signal_table_register(
-        epoch_table, iree_async_axis_device_index(axis),
-        iree_async_axis_queue_index(axis),
+        epoch_table, iree_async_axis_queue_index(axis),
         iree_hal_amdgpu_notification_ring_epoch_signal(
             &out_queue->notification_ring));
     out_queue->epoch_table = epoch_table;
@@ -1038,8 +1037,7 @@ void iree_hal_amdgpu_host_queue_deinitialize(
   // handle partial initialization (init failed before registration).
   if (queue->epoch_table) {
     iree_hal_amdgpu_epoch_signal_table_deregister(
-        queue->epoch_table, iree_async_axis_device_index(queue->axis),
-        iree_async_axis_queue_index(queue->axis));
+        queue->epoch_table, iree_async_axis_queue_index(queue->axis));
     queue->epoch_table = NULL;
   }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue.h
@@ -437,9 +437,10 @@ typedef struct iree_hal_amdgpu_host_queue_t {
   // waits onto the software path instead of under-barriering.
   bool can_publish_frontier;
 
-  // This queue's axis in the causal graph. Constructed from the system's
-  // session epoch + machine index and this queue's device/queue ordinals.
-  // Used to identify this queue in frontier entries and epoch signal lookups.
+  // This queue's axis in the causal graph. The device index is assigned by the
+  // HAL device-group topology and the queue index is the flattened logical
+  // queue ordinal, preserving uniqueness for both separate logical devices and
+  // composite devices. Used in frontier entries and epoch signal lookups.
   // Immutable after initialization.
   iree_async_axis_t axis;
 
@@ -463,13 +464,12 @@ typedef struct iree_hal_amdgpu_host_queue_t {
   // Queue ordinal relative to |device_ordinal|.
   iree_host_size_t physical_queue_ordinal;
 
-  // Shared epoch signal table for cross-queue barrier emission (tier 2 wait
-  // resolution). Maps (device_index, queue_index) to hsa_signal_t for each
-  // queue's epoch signal. Used to look up peer queues' epoch signals when
-  // emitting AQL barrier-value packets for multi-axis dependencies (e.g.,
-  // TP collective joins needing barriers on 7 peer queues).
+  // Logical-device epoch signal table for cross-queue barrier emission (tier 2
+  // wait resolution). Maps flattened queue indices to hsa_signal_t values for
+  // queues in this logical device. Used to look up peer queues' epoch signals
+  // when emitting AQL barrier-value packets for multi-axis dependencies.
   //
-  // Borrowed from the device/system — valid for the lifetime of the queue.
+  // Borrowed from the logical device and valid for the lifetime of the queue.
   // This queue's own epoch signal is registered at init and deregistered at
   // deinit. Read-only during normal operation.
   iree_hal_amdgpu_epoch_signal_table_t* epoch_table;
@@ -615,13 +615,13 @@ void iree_hal_amdgpu_host_queue_enqueue_post_drain_action(
 // it, allocates a kernarg ring from |kernarg_memory|, creates the epoch signal
 // and notification ring, and starts the completion thread.
 //
-// |axis| is this queue's identity in the causal graph, constructed by the
-// caller from the system's session/machine identifiers and this queue's
-// device/queue ordinals via iree_async_axis_make_queue().
+// |axis| is this queue's identity in the causal graph. Its device index is the
+// topology-assigned HAL logical device index and its queue index is the
+// flattened logical queue ordinal within that device.
 //
-// |epoch_table| is the shared epoch signal table for cross-queue barrier
-// emission. This queue registers its epoch signal in the table at init and
-// deregisters at deinit. The table must outlive the queue.
+// |epoch_table| is the logical-device epoch signal table for cross-queue
+// barrier emission. This queue registers its epoch signal in the table at init
+// and deregisters at deinit. The table must outlive the queue.
 //
 // |feedback_state| is borrowed from the logical device. When enabled, queue
 // retirement drains the physical-device feedback channel before releasing

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer.c
@@ -180,7 +180,8 @@ iree_hal_amdgpu_host_queue_should_profile_all_pm4_command_buffer_dispatches(
   const uint32_t physical_device_ordinal = queue->device_ordinal <= UINT32_MAX
                                                ? (uint32_t)queue->device_ordinal
                                                : UINT32_MAX;
-  const uint32_t queue_ordinal = iree_async_axis_queue_index(queue->axis);
+  const uint32_t queue_ordinal =
+      iree_hal_amdgpu_host_queue_profile_queue_ordinal(queue);
   return iree_hal_profile_capture_filter_matches_location(
       filter, command_buffer_id, /*command_index=*/0, physical_device_ordinal,
       queue_ordinal);
@@ -193,7 +194,8 @@ iree_hal_amdgpu_host_queue_should_profile_pm4_command_buffer_dispatch(
   const uint32_t physical_device_ordinal = queue->device_ordinal <= UINT32_MAX
                                                ? (uint32_t)queue->device_ordinal
                                                : UINT32_MAX;
-  const uint32_t queue_ordinal = iree_async_axis_queue_index(queue->axis);
+  const uint32_t queue_ordinal =
+      iree_hal_amdgpu_host_queue_profile_queue_ordinal(queue);
   iree_hal_amdgpu_logical_device_t* logical_device =
       (iree_hal_amdgpu_logical_device_t*)queue->logical_device;
   return iree_hal_amdgpu_logical_device_should_profile_dispatch(

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profile.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profile.c
@@ -8,6 +8,7 @@
 
 #include <string.h>
 
+#include "iree/hal/drivers/amdgpu/host_queue_profile.h"
 #include "iree/hal/drivers/amdgpu/logical_device.h"
 #include "iree/hal/drivers/amdgpu/profile_traces.h"
 
@@ -36,7 +37,8 @@ iree_hal_amdgpu_host_queue_should_profile_all_command_buffer_dispatches(
   const uint32_t physical_device_ordinal = queue->device_ordinal <= UINT32_MAX
                                                ? (uint32_t)queue->device_ordinal
                                                : UINT32_MAX;
-  const uint32_t queue_ordinal = iree_async_axis_queue_index(queue->axis);
+  const uint32_t queue_ordinal =
+      iree_hal_amdgpu_host_queue_profile_queue_ordinal(queue);
   return iree_hal_profile_capture_filter_matches_location(
       filter, command_buffer_id, /*command_index=*/0, physical_device_ordinal,
       queue_ordinal);
@@ -51,7 +53,8 @@ iree_hal_amdgpu_host_queue_should_profile_command_buffer_dispatch_summary(
   const uint32_t physical_device_ordinal = queue->device_ordinal <= UINT32_MAX
                                                ? (uint32_t)queue->device_ordinal
                                                : UINT32_MAX;
-  const uint32_t queue_ordinal = iree_async_axis_queue_index(queue->axis);
+  const uint32_t queue_ordinal =
+      iree_hal_amdgpu_host_queue_profile_queue_ordinal(queue);
   iree_hal_amdgpu_logical_device_t* logical_device =
       (iree_hal_amdgpu_logical_device_t*)queue->logical_device;
   return iree_hal_amdgpu_logical_device_should_profile_dispatch(

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
@@ -562,7 +562,8 @@ static bool iree_hal_amdgpu_host_queue_should_profile_dispatch(
   const uint32_t physical_device_ordinal = queue->device_ordinal <= UINT32_MAX
                                                ? (uint32_t)queue->device_ordinal
                                                : UINT32_MAX;
-  const uint32_t queue_ordinal = iree_async_axis_queue_index(queue->axis);
+  const uint32_t queue_ordinal =
+      iree_hal_amdgpu_host_queue_profile_queue_ordinal(queue);
   return iree_hal_amdgpu_logical_device_should_profile_dispatch(
       logical_device, executable_id,
       iree_hal_executable_function_index(function),

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_policy.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_policy.c
@@ -67,7 +67,21 @@ iree_hsa_fence_scope_t iree_hal_amdgpu_host_queue_wait_acquire_scope(
 
 iree_hsa_fence_scope_t iree_hal_amdgpu_host_queue_axis_acquire_scope(
     const iree_hal_amdgpu_host_queue_t* queue, iree_async_axis_t axis) {
-  return iree_async_axis_device_index(axis) == queue->device_ordinal
+  // Session, machine, domain, and logical-device identity occupy the upper
+  // 32 bits of a queue axis. Queue indices are flattened across physical
+  // devices, with each physical device owning one contiguous range.
+  if ((axis >> 32) != (queue->axis >> 32)) {
+    return IREE_HSA_FENCE_SCOPE_SYSTEM;
+  }
+  const iree_hal_amdgpu_logical_device_t* logical_device =
+      (const iree_hal_amdgpu_logical_device_t*)queue->logical_device;
+  const iree_host_size_t first_physical_queue_ordinal =
+      queue->queue_ordinal - queue->physical_queue_ordinal;
+  const iree_host_size_t candidate_queue_ordinal =
+      iree_async_axis_queue_index(axis);
+  return candidate_queue_ordinal >= first_physical_queue_ordinal &&
+                 candidate_queue_ordinal - first_physical_queue_ordinal <
+                     logical_device->system->topology.gpu_agent_queue_count
              ? IREE_HSA_FENCE_SCOPE_AGENT
              : IREE_HSA_FENCE_SCOPE_SYSTEM;
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_profile.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_profile.c
@@ -17,7 +17,9 @@ uint32_t iree_hal_amdgpu_host_queue_profile_device_ordinal(
 
 uint32_t iree_hal_amdgpu_host_queue_profile_queue_ordinal(
     const iree_hal_amdgpu_host_queue_t* queue) {
-  return iree_async_axis_queue_index(queue->axis);
+  return queue->physical_queue_ordinal <= UINT32_MAX
+             ? (uint32_t)queue->physical_queue_ordinal
+             : UINT32_MAX;
 }
 
 uint64_t iree_hal_amdgpu_host_queue_profile_stream_id(

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_profile_events.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_profile_events.c
@@ -674,7 +674,8 @@ iree_status_t iree_hal_amdgpu_host_queue_write_profile_events(
     iree_hal_profile_chunk_metadata_t metadata =
         iree_hal_profile_chunk_metadata_default();
     const uint32_t physical_device_ordinal = (uint32_t)queue->device_ordinal;
-    const uint32_t queue_ordinal = iree_async_axis_queue_index(queue->axis);
+    const uint32_t queue_ordinal =
+        iree_hal_amdgpu_host_queue_profile_queue_ordinal(queue);
     metadata.content_type = IREE_HAL_PROFILE_CONTENT_TYPE_DISPATCH_EVENTS;
     metadata.name = iree_make_cstring_view("amdgpu.dispatch");
     metadata.session_id = session_id;

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_submission_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_submission_test.cc
@@ -11,6 +11,7 @@
 #include "iree/hal/api.h"
 #include "iree/hal/cts/util/test_base.h"
 #include "iree/hal/drivers/amdgpu/host_queue.h"
+#include "iree/hal/drivers/amdgpu/host_queue_policy.h"
 #include "iree/hal/drivers/amdgpu/host_queue_profile.h"
 #include "iree/hal/drivers/amdgpu/host_queue_profile_events.h"
 #include "iree/hal/drivers/amdgpu/host_queue_waits.h"
@@ -104,6 +105,125 @@ class TestLogicalDevice {
   // Device group that owns the topology assigned to |base_device_|.
   iree_hal_device_group_t* device_group_ = NULL;
 };
+
+// Two independently-created logical devices assigned to one causal topology.
+class TestLogicalDeviceGroup {
+ public:
+  ~TestLogicalDeviceGroup() {
+    // The group keeps each device and its topology live while the test-owned
+    // references are released. Releasing the group last lets it destroy the
+    // devices before destroying their borrowed topology.
+    for (iree_hal_device_t* device : devices_) {
+      iree_hal_device_release(device);
+    }
+    iree_hal_device_group_release(device_group_);
+  }
+
+  iree_status_t Initialize(
+      const iree_hal_amdgpu_logical_device_options_t* options,
+      const iree_hal_amdgpu_libhsa_t* libhsa,
+      const iree_hal_amdgpu_topology_t* topology,
+      iree_allocator_t host_allocator) {
+    iree_status_t status = create_context_.Initialize(host_allocator);
+    for (iree_host_size_t i = 0;
+         i < IREE_ARRAYSIZE(devices_) && iree_status_is_ok(status); ++i) {
+      status = iree_hal_amdgpu_logical_device_create(
+          IREE_SV("amdgpu"), options, libhsa, topology,
+          create_context_.params(), host_allocator, &devices_[i]);
+    }
+    if (!iree_status_is_ok(status)) return status;
+
+    iree_hal_device_group_builder_t builder;
+    iree_hal_device_group_builder_initialize(
+        &builder, create_context_.frontier_tracker());
+    for (iree_hal_device_t* device : devices_) {
+      if (!iree_status_is_ok(status)) break;
+      status = iree_hal_device_group_builder_add_device(&builder, device);
+    }
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_device_group_builder_finalize(&builder, host_allocator,
+                                                      &device_group_);
+    } else {
+      iree_hal_device_group_builder_deinitialize(&builder);
+    }
+    return status;
+  }
+
+  iree_hal_device_group_t* device_group() const { return device_group_; }
+
+  iree_hal_amdgpu_logical_device_t* logical_device(
+      iree_host_size_t index) const {
+    return (iree_hal_amdgpu_logical_device_t*)devices_[index];
+  }
+
+  iree_hal_amdgpu_host_queue_t* first_host_queue(iree_host_size_t index) const {
+    iree_hal_amdgpu_logical_device_t* logical_device =
+        this->logical_device(index);
+    if (logical_device->physical_device_count == 0) return NULL;
+    iree_hal_amdgpu_physical_device_t* physical_device =
+        logical_device->physical_devices[0];
+    if (physical_device->host_queue_count == 0) return NULL;
+    return &physical_device->host_queues[0];
+  }
+
+ private:
+  // Creation context supplying the group's shared causal frontier tracker.
+  iree::hal::cts::DeviceCreateContext create_context_;
+
+  // Test-owned device references released while the group still owns them.
+  iree_hal_device_t* devices_[2] = {NULL, NULL};
+
+  // Group owning the topology borrowed by both logical devices.
+  iree_hal_device_group_t* device_group_ = NULL;
+};
+
+TEST_F(HostQueueSubmissionTest, GroupedLogicalDeviceQueueFrontiersAreDistinct) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+
+  TestLogicalDeviceGroup test_group;
+  IREE_ASSERT_OK(
+      test_group.Initialize(&options, &libhsa_, &topology_, host_allocator_));
+  ASSERT_EQ(iree_hal_device_group_device_count(test_group.device_group()), 2u);
+
+  iree_hal_amdgpu_logical_device_t* logical_device_a =
+      test_group.logical_device(0);
+  iree_hal_amdgpu_logical_device_t* logical_device_b =
+      test_group.logical_device(1);
+  iree_hal_amdgpu_host_queue_t* queue_a = test_group.first_host_queue(0);
+  iree_hal_amdgpu_host_queue_t* queue_b = test_group.first_host_queue(1);
+  ASSERT_NE(queue_a, nullptr);
+  ASSERT_NE(queue_b, nullptr);
+
+  EXPECT_NE(queue_a->axis, queue_b->axis);
+  EXPECT_EQ(iree_async_axis_session(queue_a->axis),
+            iree_async_axis_session(queue_b->axis));
+  EXPECT_EQ(iree_async_axis_machine(queue_a->axis),
+            iree_async_axis_machine(queue_b->axis));
+  EXPECT_EQ(iree_async_axis_device_index(queue_a->axis), 0u);
+  EXPECT_EQ(iree_async_axis_device_index(queue_b->axis), 1u);
+  EXPECT_EQ(iree_async_axis_queue_index(queue_a->axis), 0u);
+  EXPECT_EQ(iree_async_axis_queue_index(queue_b->axis), 0u);
+
+  iree_hal_amdgpu_host_queue_epoch_wait_t wait_state;
+  ASSERT_TRUE(iree_hal_amdgpu_logical_device_lookup_host_queue_epoch_wait(
+      logical_device_a, queue_a->axis, &wait_state));
+  EXPECT_EQ(wait_state.host_queue, queue_a);
+  ASSERT_TRUE(iree_hal_amdgpu_logical_device_lookup_host_queue_epoch_wait(
+      logical_device_b, queue_b->axis, &wait_state));
+  EXPECT_EQ(wait_state.host_queue, queue_b);
+  EXPECT_FALSE(iree_hal_amdgpu_logical_device_lookup_host_queue_epoch_wait(
+      logical_device_a, queue_b->axis, &wait_state));
+  EXPECT_FALSE(iree_hal_amdgpu_logical_device_lookup_host_queue_epoch_wait(
+      logical_device_b, queue_a->axis, &wait_state));
+
+  EXPECT_EQ(
+      iree_hal_amdgpu_host_queue_axis_acquire_scope(queue_a, queue_a->axis),
+      IREE_HSA_FENCE_SCOPE_AGENT);
+  EXPECT_EQ(
+      iree_hal_amdgpu_host_queue_axis_acquire_scope(queue_a, queue_b->axis),
+      IREE_HSA_FENCE_SCOPE_SYSTEM);
+}
 
 class HostQueueHsaProfilingScope {
  public:

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -1560,21 +1560,31 @@ bool iree_hal_amdgpu_logical_device_lookup_host_queue_epoch_wait(
   memset(out_wait_state, 0, sizeof(*out_wait_state));
 
   if (!logical_device->host_queue_epoch_table) return false;
+  const iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain = {
+      .supported_affinity = logical_device->queue_affinity_mask,
+      .physical_device_count = logical_device->physical_device_count,
+      .queue_count_per_physical_device =
+          logical_device->system->topology.gpu_agent_queue_count,
+  };
+  iree_hal_amdgpu_queue_affinity_resolved_t resolved;
+  if (!iree_hal_amdgpu_queue_affinity_try_resolve_axis(
+          queue_affinity_domain, logical_device->axis, axis, &resolved)) {
+    return false;
+  }
   hsa_signal_t epoch_signal = {0};
   if (!iree_hal_amdgpu_epoch_signal_table_lookup(
           logical_device->host_queue_epoch_table, axis, &epoch_signal)) {
     return false;
   }
 
-  const uint8_t device_index = iree_async_axis_device_index(axis);
-  if (device_index >= logical_device->physical_device_count) return false;
   iree_hal_amdgpu_physical_device_t* physical_device =
-      logical_device->physical_devices[device_index];
+      logical_device->physical_devices[resolved.physical_device_ordinal];
 
-  const uint8_t queue_index = iree_async_axis_queue_index(axis);
-  if (queue_index >= physical_device->host_queue_count) return false;
+  if (resolved.physical_queue_ordinal >= physical_device->host_queue_count) {
+    return false;
+  }
   iree_hal_amdgpu_host_queue_t* queue =
-      &physical_device->host_queues[queue_index];
+      &physical_device->host_queues[resolved.physical_queue_ordinal];
 
   uint64_t wait_timeout_hint =
       logical_device->system->info.timestamp_frequency / 1000;
@@ -2506,19 +2516,32 @@ static iree_status_t iree_hal_amdgpu_logical_device_assign_topology_info(
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_hal_amdgpu_system_t* system = logical_device->system;
 
-  const uint8_t device_count = (uint8_t)system->topology.gpu_agent_count;
-  const uint8_t queue_stride = (uint8_t)system->topology.gpu_agent_queue_count;
-  const iree_host_size_t table_size =
-      iree_hal_amdgpu_epoch_signal_table_size(device_count, queue_stride);
-  iree_status_t status =
-      iree_allocator_malloc(logical_device->host_allocator, table_size,
-                            (void**)&logical_device->host_queue_epoch_table);
+  iree_host_size_t logical_queue_count = 0;
+  iree_status_t status = iree_ok_status();
+  if (!iree_host_size_checked_mul(system->topology.gpu_agent_count,
+                                  system->topology.gpu_agent_queue_count,
+                                  &logical_queue_count) ||
+      logical_queue_count > IREE_HAL_MAX_QUEUES) {
+    status = iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "AMDGPU logical queue count %" PRIhsz
+                              " exceeds queue affinity capacity %" PRIhsz,
+                              logical_queue_count,
+                              (iree_host_size_t)IREE_HAL_MAX_QUEUES);
+  }
+  if (iree_status_is_ok(status)) {
+    const iree_host_size_t table_size =
+        iree_hal_amdgpu_epoch_signal_table_size((uint16_t)logical_queue_count);
+    status =
+        iree_allocator_malloc(logical_device->host_allocator, table_size,
+                              (void**)&logical_device->host_queue_epoch_table);
+  }
   if (iree_status_is_ok(status)) {
     iree_hal_amdgpu_epoch_signal_table_initialize(
         logical_device->host_queue_epoch_table,
         iree_async_axis_session(topology_info->frontier.base_axis),
         iree_async_axis_machine(topology_info->frontier.base_axis),
-        device_count, queue_stride);
+        iree_async_axis_device_index(topology_info->frontier.base_axis),
+        (uint16_t)logical_queue_count);
   }
 
   for (iree_host_size_t device_ordinal = 0;

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
@@ -1186,8 +1186,6 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_hal_amdgpu_libhsa_t* libhsa = &system->libhsa;
-  const uint8_t session_epoch = iree_async_axis_session(base_axis);
-  const uint8_t machine_index = iree_async_axis_machine(base_axis);
   iree_status_t status = iree_hal_amdgpu_physical_device_create_default_pools(
       physical_device, epoch_signal_table, host_allocator);
   const iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain = {
@@ -1235,12 +1233,11 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
         physical_device->device_ordinal * physical_device->host_queue_capacity +
         queue_ordinal;
     iree_hal_amdgpu_queue_affinity_resolved_t resolved;
-    status = iree_hal_amdgpu_queue_affinity_resolve_ordinal(
-        queue_affinity_domain, logical_queue_ordinal, &resolved);
+    iree_async_axis_t queue_axis = 0;
+    status = iree_hal_amdgpu_queue_affinity_make_axis(
+        queue_affinity_domain, base_axis, logical_queue_ordinal, &resolved,
+        &queue_axis);
     if (!iree_status_is_ok(status)) break;
-    iree_async_axis_t queue_axis = iree_async_axis_make_queue(
-        session_epoch, machine_index, (uint8_t)physical_device->device_ordinal,
-        (uint8_t)queue_ordinal);
     iree_thread_affinity_t completion_thread_affinity;
     iree_thread_affinity_set_group_any(physical_device->host_numa_node,
                                        &completion_thread_affinity);

--- a/runtime/src/iree/hal/drivers/amdgpu/queue_affinity.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/queue_affinity.c
@@ -161,6 +161,48 @@ bool iree_hal_amdgpu_queue_affinity_try_resolve(
   return true;
 }
 
+iree_status_t iree_hal_amdgpu_queue_affinity_make_axis(
+    iree_hal_amdgpu_queue_affinity_domain_t domain, iree_async_axis_t base_axis,
+    iree_host_size_t queue_ordinal,
+    iree_hal_amdgpu_queue_affinity_resolved_t* out_resolved,
+    iree_async_axis_t* out_axis) {
+  *out_axis = 0;
+
+  if (IREE_UNLIKELY(iree_async_axis_domain(base_axis) !=
+                    IREE_ASYNC_CAUSAL_DOMAIN_QUEUE)) {
+    memset(out_resolved, 0, sizeof(*out_resolved));
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU base axis is not in the queue domain");
+  }
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_queue_affinity_resolve_ordinal(
+      domain, queue_ordinal, out_resolved));
+
+  *out_axis = iree_async_axis_make_queue(
+      iree_async_axis_session(base_axis), iree_async_axis_machine(base_axis),
+      iree_async_axis_device_index(base_axis), (uint8_t)queue_ordinal);
+  return iree_ok_status();
+}
+
+bool iree_hal_amdgpu_queue_affinity_try_resolve_axis(
+    iree_hal_amdgpu_queue_affinity_domain_t domain,
+    iree_async_axis_t local_axis, iree_async_axis_t candidate_axis,
+    iree_hal_amdgpu_queue_affinity_resolved_t* out_resolved) {
+  memset(out_resolved, 0, sizeof(*out_resolved));
+  if (iree_async_axis_domain(local_axis) != IREE_ASYNC_CAUSAL_DOMAIN_QUEUE ||
+      iree_async_axis_domain(candidate_axis) !=
+          IREE_ASYNC_CAUSAL_DOMAIN_QUEUE ||
+      iree_async_axis_session(local_axis) !=
+          iree_async_axis_session(candidate_axis) ||
+      iree_async_axis_machine(local_axis) !=
+          iree_async_axis_machine(candidate_axis) ||
+      iree_async_axis_device_index(local_axis) !=
+          iree_async_axis_device_index(candidate_axis)) {
+    return false;
+  }
+  return iree_hal_amdgpu_queue_affinity_try_resolve_ordinal(
+      domain, iree_async_axis_queue_index(candidate_axis), out_resolved);
+}
+
 iree_status_t iree_hal_amdgpu_queue_affinity_for_physical_device(
     iree_hal_amdgpu_queue_affinity_domain_t domain,
     iree_host_size_t physical_device_ordinal,

--- a/runtime/src/iree/hal/drivers/amdgpu/queue_affinity.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/queue_affinity.h
@@ -7,6 +7,7 @@
 #ifndef IREE_HAL_DRIVERS_AMDGPU_QUEUE_AFFINITY_H_
 #define IREE_HAL_DRIVERS_AMDGPU_QUEUE_AFFINITY_H_
 
+#include "iree/async/frontier.h"
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
 
@@ -85,6 +86,25 @@ iree_status_t iree_hal_amdgpu_queue_affinity_resolve(
 bool iree_hal_amdgpu_queue_affinity_try_resolve(
     iree_hal_amdgpu_queue_affinity_domain_t domain,
     iree_hal_queue_affinity_t requested_affinity,
+    iree_hal_amdgpu_queue_affinity_resolved_t* out_resolved);
+
+// Constructs the causal axis for |queue_ordinal| within one topology-assigned
+// HAL device. |base_axis| supplies the session, machine, and logical device
+// index; the flattened logical queue ordinal supplies the queue index. This
+// preserves distinct device-group identities while keeping every physical
+// queue in a composite logical device uniquely addressable.
+iree_status_t iree_hal_amdgpu_queue_affinity_make_axis(
+    iree_hal_amdgpu_queue_affinity_domain_t domain, iree_async_axis_t base_axis,
+    iree_host_size_t queue_ordinal,
+    iree_hal_amdgpu_queue_affinity_resolved_t* out_resolved,
+    iree_async_axis_t* out_axis);
+
+// Attempts to resolve |candidate_axis| as a queue in the same topology device
+// as |local_axis|. Returns false for axes from another session, machine,
+// logical device, or queue domain, and for queue indices outside |domain|.
+bool iree_hal_amdgpu_queue_affinity_try_resolve_axis(
+    iree_hal_amdgpu_queue_affinity_domain_t domain,
+    iree_async_axis_t local_axis, iree_async_axis_t candidate_axis,
     iree_hal_amdgpu_queue_affinity_resolved_t* out_resolved);
 
 // Builds the queue affinity mask for one physical device in |domain|.

--- a/runtime/src/iree/hal/drivers/amdgpu/queue_affinity_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/queue_affinity_test.cc
@@ -74,6 +74,38 @@ TEST(QueueAffinityTest, TryResolveReturnsFalseForInvalidAffinity) {
                                                           0x10ull, &resolved));
 }
 
+TEST(QueueAffinityTest, AxisPreservesLogicalDeviceAndMapsCompositeQueue) {
+  const iree_async_axis_t base_axis = iree_async_axis_make_queue(
+      /*session_epoch=*/3, /*machine_index=*/5, /*device_index=*/7,
+      /*queue_index=*/0);
+  iree_hal_amdgpu_queue_affinity_resolved_t resolved;
+  iree_async_axis_t axis = 0;
+  IREE_ASSERT_OK(iree_hal_amdgpu_queue_affinity_make_axis(
+      TwoDeviceDomain(), base_axis, /*queue_ordinal=*/3, &resolved, &axis));
+
+  EXPECT_EQ(iree_async_axis_session(axis), 3);
+  EXPECT_EQ(iree_async_axis_machine(axis), 5);
+  EXPECT_EQ(iree_async_axis_device_index(axis), 7);
+  EXPECT_EQ(iree_async_axis_queue_index(axis), 3);
+  EXPECT_EQ(resolved.physical_device_ordinal, 1);
+  EXPECT_EQ(resolved.physical_queue_ordinal, 1);
+
+  iree_hal_amdgpu_queue_affinity_resolved_t decoded;
+  ASSERT_TRUE(iree_hal_amdgpu_queue_affinity_try_resolve_axis(
+      TwoDeviceDomain(), base_axis, axis, &decoded));
+  EXPECT_EQ(decoded.queue_ordinal, resolved.queue_ordinal);
+  EXPECT_EQ(decoded.physical_device_ordinal, resolved.physical_device_ordinal);
+  EXPECT_EQ(decoded.physical_queue_ordinal, resolved.physical_queue_ordinal);
+}
+
+TEST(QueueAffinityTest, AxisResolutionRejectsForeignLogicalDevice) {
+  const iree_async_axis_t local_axis = iree_async_axis_make_queue(2, 4, 6, 0);
+  const iree_async_axis_t foreign_axis = iree_async_axis_make_queue(2, 4, 7, 0);
+  iree_hal_amdgpu_queue_affinity_resolved_t resolved;
+  EXPECT_FALSE(iree_hal_amdgpu_queue_affinity_try_resolve_axis(
+      TwoDeviceDomain(), local_axis, foreign_axis, &resolved));
+}
+
 TEST(QueueAffinityTest, PhysicalDeviceAffinityBuildsQueueRange) {
   iree_hal_queue_affinity_t queue_affinity = 0;
   IREE_ASSERT_OK(iree_hal_amdgpu_queue_affinity_for_physical_device(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/epoch_signal_table.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/epoch_signal_table.h
@@ -21,9 +21,9 @@ extern "C" {
 // iree_hal_amdgpu_epoch_signal_table_t
 //===----------------------------------------------------------------------===//
 
-// Flat lookup table mapping (device_index, queue_index) to the hsa_signal_t
-// epoch signal for that queue. Shared read-only across all queues on the same
-// machine during normal operation; mutated only during queue init/deinit.
+// Flat lookup table mapping one logical HAL device's queue indices to their
+// hsa_signal_t epoch signals. Shared read-only across all queues in the logical
+// device during normal operation; mutated only during queue init/deinit.
 //
 // The epoch signal is the single hsa_signal_t that the CP decrements on each
 // AQL packet completion. It is the mechanism by which tier 2 (device-side)
@@ -38,11 +38,11 @@ extern "C" {
 // can still require N lookups for N undominated peer axes discovered from the
 // semaphore frontier.
 //
-// The table is allocated once at device group init, sized from the topology
-// (device_count * queue_stride). Each queue registers its epoch signal during
-// init and deregisters during deinit. Lookup verifies the axis's session epoch
-// and machine index match this table's — axes from other sessions or machines
-// fail the lookup (tier 3 fallback).
+// The table is allocated once at logical-device topology assignment. Each queue
+// registers its epoch signal using its flattened logical queue index and
+// deregisters during deinit. Lookup verifies the axis's session, machine, and
+// topology-assigned logical device index. Axes from another identity fail the
+// lookup and use the tier 3 host-deferral path.
 typedef struct iree_hal_amdgpu_epoch_signal_table_t {
   // Session epoch from the axis encoding. Used to verify that a lookup axis
   // belongs to the same session as this table. Prevents cross-session aliasing
@@ -52,25 +52,25 @@ typedef struct iree_hal_amdgpu_epoch_signal_table_t {
   // belongs to the same machine. Cross-machine waits use tier 3 (host deferral)
   // since there is no shared HSA signal.
   uint8_t machine_index;
-  // Maximum queues per device (uniform across all devices in the topology).
-  // Columns in the 2D array: signals[device * queue_stride + queue].
-  uint8_t queue_stride;
-  // Number of devices in the table. Rows in the 2D array.
-  uint8_t device_count;
-  uint8_t reserved[4];
-  // Flat 2D array of epoch signals indexed by [device_index * queue_stride +
-  // queue_index]. Unregistered slots have handle == 0 (null signal). Registered
-  // slots contain the epoch signal from the queue's notification ring.
+  // Topology-assigned HAL logical device index encoded in every queue axis.
+  uint8_t device_index;
+  // Reserved for alignment and future identity dimensions.
+  uint8_t reserved0;
+  // Number of flattened logical queues addressable by |signals|.
+  uint16_t queue_count;
+  // Reserved for future table flags.
+  uint8_t reserved[2];
+  // Epoch signals indexed by flattened logical queue index. Unregistered slots
+  // have handle == 0 (null signal). Registered slots contain the epoch signal
+  // from the queue's notification ring.
   hsa_signal_t signals[];
 } iree_hal_amdgpu_epoch_signal_table_t;
 
-// Returns the total allocation size in bytes for an epoch signal table with
-// the given dimensions.
+// Returns the total allocation size in bytes for |queue_count| signals.
 static inline iree_host_size_t iree_hal_amdgpu_epoch_signal_table_size(
-    uint8_t device_count, uint8_t queue_stride) {
-  // uint8_t * uint8_t cannot overflow iree_host_size_t.
+    uint16_t queue_count) {
   return sizeof(iree_hal_amdgpu_epoch_signal_table_t) +
-         (iree_host_size_t)device_count * queue_stride * sizeof(hsa_signal_t);
+         (iree_host_size_t)queue_count * sizeof(hsa_signal_t);
 }
 
 // Initializes an epoch signal table in caller-provided memory. The caller
@@ -78,14 +78,15 @@ static inline iree_host_size_t iree_hal_amdgpu_epoch_signal_table_size(
 // bytes. All signal slots are zeroed (unregistered).
 static inline void iree_hal_amdgpu_epoch_signal_table_initialize(
     iree_hal_amdgpu_epoch_signal_table_t* table, uint8_t session_epoch,
-    uint8_t machine_index, uint8_t device_count, uint8_t queue_stride) {
+    uint8_t machine_index, uint8_t device_index, uint16_t queue_count) {
   table->session_epoch = session_epoch;
   table->machine_index = machine_index;
-  table->queue_stride = queue_stride;
-  table->device_count = device_count;
+  table->device_index = device_index;
+  table->reserved0 = 0;
+  table->queue_count = queue_count;
   memset(table->reserved, 0, sizeof(table->reserved));
   memset(table->signals, 0,
-         (iree_host_size_t)device_count * queue_stride * sizeof(hsa_signal_t));
+         (iree_host_size_t)queue_count * sizeof(hsa_signal_t));
 }
 
 // Registers a queue's epoch signal in the table. Called during queue init
@@ -93,62 +94,51 @@ static inline void iree_hal_amdgpu_epoch_signal_table_initialize(
 //
 // The slot must not already be registered (programming error if it is).
 static inline void iree_hal_amdgpu_epoch_signal_table_register(
-    iree_hal_amdgpu_epoch_signal_table_t* table, uint8_t device_index,
-    uint8_t queue_index, hsa_signal_t epoch_signal) {
-  IREE_ASSERT(device_index < table->device_count, "device_index out of range");
-  IREE_ASSERT(queue_index < table->queue_stride, "queue_index out of range");
-  iree_host_size_t slot =
-      (iree_host_size_t)device_index * table->queue_stride + queue_index;
-  IREE_ASSERT(table->signals[slot].handle == 0,
+    iree_hal_amdgpu_epoch_signal_table_t* table, uint8_t queue_index,
+    hsa_signal_t epoch_signal) {
+  IREE_ASSERT(queue_index < table->queue_count, "queue_index out of range");
+  IREE_ASSERT(table->signals[queue_index].handle == 0,
               "epoch signal slot already registered");
   IREE_ASSERT(epoch_signal.handle != 0, "cannot register null epoch signal");
-  table->signals[slot] = epoch_signal;
+  table->signals[queue_index] = epoch_signal;
 }
 
 // Deregisters a queue's epoch signal from the table. Called during queue
 // deinit before the notification ring (which owns the epoch signal) is
 // destroyed. The slot must currently be registered.
 static inline void iree_hal_amdgpu_epoch_signal_table_deregister(
-    iree_hal_amdgpu_epoch_signal_table_t* table, uint8_t device_index,
-    uint8_t queue_index) {
-  IREE_ASSERT(device_index < table->device_count, "device_index out of range");
-  IREE_ASSERT(queue_index < table->queue_stride, "queue_index out of range");
-  iree_host_size_t slot =
-      (iree_host_size_t)device_index * table->queue_stride + queue_index;
-  IREE_ASSERT(table->signals[slot].handle != 0,
+    iree_hal_amdgpu_epoch_signal_table_t* table, uint8_t queue_index) {
+  IREE_ASSERT(queue_index < table->queue_count, "queue_index out of range");
+  IREE_ASSERT(table->signals[queue_index].handle != 0,
               "epoch signal slot not registered");
-  table->signals[slot].handle = 0;
+  table->signals[queue_index].handle = 0;
 }
 
 // Looks up the epoch signal for the queue identified by |axis|. Returns true
 // and writes the signal to |out_signal| if the axis matches this table's
-// session/machine, is a QUEUE-domain axis, is within bounds, and the slot
-// is registered. Returns false otherwise (caller should fall back to tier 3).
+// session/machine/device identity, is a QUEUE-domain axis, is within bounds,
+// and the slot is registered. Returns false otherwise (caller should fall back
+// to tier 3).
 //
-// This is the hot-path lookup for tier 2 barrier emission. Two byte
-// comparisons (session + machine), one domain check, two bounds checks,
-// one array index. ~15 instructions.
+// This is the hot-path lookup for tier 2 barrier emission. Three byte
+// comparisons (session + machine + device), one domain check, one bounds
+// check, and one array index.
 static inline bool iree_hal_amdgpu_epoch_signal_table_lookup(
     const iree_hal_amdgpu_epoch_signal_table_t* table, iree_async_axis_t axis,
     hsa_signal_t* out_signal) {
-  // Verify this axis is from our session and machine.
-  if (iree_async_axis_session(axis) != table->session_epoch ||
-      iree_async_axis_machine(axis) != table->machine_index) {
-    return false;
-  }
-  // Must be a QUEUE-domain axis (not collective, host, etc.).
+  // Domain-specific fields are only defined for queue axes.
   if (iree_async_axis_domain(axis) != IREE_ASYNC_CAUSAL_DOMAIN_QUEUE) {
     return false;
   }
-  uint8_t device_index = iree_async_axis_device_index(axis);
-  uint8_t queue_index = iree_async_axis_queue_index(axis);
-  if (device_index >= table->device_count ||
-      queue_index >= table->queue_stride) {
+  // Verify this axis is from our session, machine, and logical HAL device.
+  if (iree_async_axis_session(axis) != table->session_epoch ||
+      iree_async_axis_machine(axis) != table->machine_index ||
+      iree_async_axis_device_index(axis) != table->device_index) {
     return false;
   }
-  hsa_signal_t signal =
-      table->signals[(iree_host_size_t)device_index * table->queue_stride +
-                     queue_index];
+  uint8_t queue_index = iree_async_axis_queue_index(axis);
+  if (queue_index >= table->queue_count) return false;
+  hsa_signal_t signal = table->signals[queue_index];
   if (signal.handle == 0) return false;  // Slot not registered.
   *out_signal = signal;
   return true;

--- a/runtime/src/iree/hal/drivers/amdgpu/util/epoch_signal_table_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/epoch_signal_table_test.cc
@@ -12,252 +12,90 @@
 
 namespace {
 
-// Helper to allocate and initialize a table with the given dimensions.
 class EpochSignalTable {
  public:
   EpochSignalTable(uint8_t session_epoch, uint8_t machine_index,
-                   uint8_t device_count, uint8_t queue_stride)
-      : device_count_(device_count), queue_stride_(queue_stride) {
-    iree_host_size_t size =
-        iree_hal_amdgpu_epoch_signal_table_size(device_count, queue_stride);
-    storage_.resize(size);
+                   uint8_t device_index, uint16_t queue_count) {
+    storage_.resize(iree_hal_amdgpu_epoch_signal_table_size(queue_count));
     table_ = reinterpret_cast<iree_hal_amdgpu_epoch_signal_table_t*>(
         storage_.data());
     iree_hal_amdgpu_epoch_signal_table_initialize(
-        table_, session_epoch, machine_index, device_count, queue_stride);
+        table_, session_epoch, machine_index, device_index, queue_count);
   }
 
   iree_hal_amdgpu_epoch_signal_table_t* get() { return table_; }
-  const iree_hal_amdgpu_epoch_signal_table_t* get() const { return table_; }
 
  private:
-  uint8_t device_count_;
-  uint8_t queue_stride_;
   std::vector<uint8_t> storage_;
   iree_hal_amdgpu_epoch_signal_table_t* table_;
 };
 
-// Makes a fake hsa_signal_t with the given handle value. No HSA runtime needed.
-static hsa_signal_t make_signal(uint64_t handle) {
+static hsa_signal_t MakeSignal(uint64_t handle) {
   hsa_signal_t signal;
   signal.handle = handle;
   return signal;
 }
 
-TEST(EpochSignalTable, SizeComputation) {
-  // 1 device, 1 queue: header + 1 signal.
-  EXPECT_EQ(
-      iree_hal_amdgpu_epoch_signal_table_size(1, 1),
-      sizeof(iree_hal_amdgpu_epoch_signal_table_t) + 1 * sizeof(hsa_signal_t));
-  // 8 devices, 4 queues: header + 32 signals.
-  EXPECT_EQ(
-      iree_hal_amdgpu_epoch_signal_table_size(8, 4),
-      sizeof(iree_hal_amdgpu_epoch_signal_table_t) + 32 * sizeof(hsa_signal_t));
-  // 0 devices: header only (degenerate but valid).
-  EXPECT_EQ(iree_hal_amdgpu_epoch_signal_table_size(0, 4),
-            sizeof(iree_hal_amdgpu_epoch_signal_table_t));
-}
+TEST(EpochSignalTable, ResolvesFlattenedLogicalQueues) {
+  EpochSignalTable table(/*session_epoch=*/5, /*machine_index=*/2,
+                         /*device_index=*/9, /*queue_count=*/4);
+  for (uint8_t queue = 0; queue < 4; ++queue) {
+    iree_hal_amdgpu_epoch_signal_table_register(table.get(), queue,
+                                                MakeSignal(100 + queue));
+  }
 
-TEST(EpochSignalTable, InitializationZerosAllSlots) {
-  EpochSignalTable table(/*session_epoch=*/1, /*machine_index=*/0,
-                         /*device_count=*/4, /*queue_stride=*/2);
-  // Every slot should be unregistered (handle == 0).
-  for (uint8_t device = 0; device < 4; ++device) {
-    for (uint8_t queue = 0; queue < 2; ++queue) {
-      iree_async_axis_t axis = iree_async_axis_make_queue(1, 0, device, queue);
-      hsa_signal_t signal;
-      EXPECT_FALSE(iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis,
-                                                             &signal));
-    }
+  for (uint8_t queue = 0; queue < 4; ++queue) {
+    const iree_async_axis_t axis = iree_async_axis_make_queue(5, 2, 9, queue);
+    hsa_signal_t signal;
+    ASSERT_TRUE(
+        iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
+    EXPECT_EQ(signal.handle, 100u + queue);
   }
 }
 
-TEST(EpochSignalTable, RegisterAndLookup) {
+TEST(EpochSignalTable, RejectsForeignAxes) {
   EpochSignalTable table(/*session_epoch=*/3, /*machine_index=*/7,
-                         /*device_count=*/2, /*queue_stride=*/2);
+                         /*device_index=*/5, /*queue_count=*/2);
+  iree_hal_amdgpu_epoch_signal_table_register(table.get(), 0, MakeSignal(100));
 
-  // Register device 0, queue 1.
-  iree_hal_amdgpu_epoch_signal_table_register(table.get(), 0, 1,
-                                              make_signal(42));
-
-  // Lookup should succeed with the correct signal.
-  iree_async_axis_t axis = iree_async_axis_make_queue(3, 7, 0, 1);
-  hsa_signal_t signal;
-  EXPECT_TRUE(
-      iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
-  EXPECT_EQ(signal.handle, 42u);
+  const iree_async_axis_t foreign_axes[] = {
+      iree_async_axis_make_queue(4, 7, 5, 0),
+      iree_async_axis_make_queue(3, 8, 5, 0),
+      iree_async_axis_make_queue(3, 7, 6, 0),
+      iree_async_axis_make(3, 7, IREE_ASYNC_CAUSAL_DOMAIN_COLLECTIVE, 0),
+      iree_async_axis_make(3, 7, IREE_ASYNC_CAUSAL_DOMAIN_HOST, 0),
+  };
+  for (iree_async_axis_t axis : foreign_axes) {
+    hsa_signal_t signal;
+    EXPECT_FALSE(
+        iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
+  }
 }
 
-TEST(EpochSignalTable, SessionMismatch) {
-  EpochSignalTable table(/*session_epoch=*/3, /*machine_index=*/7,
-                         /*device_count=*/2, /*queue_stride=*/2);
-  iree_hal_amdgpu_epoch_signal_table_register(table.get(), 0, 0,
-                                              make_signal(100));
-
-  // Same machine, different session.
-  iree_async_axis_t axis = iree_async_axis_make_queue(4, 7, 0, 0);
-  hsa_signal_t signal;
-  EXPECT_FALSE(
-      iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
-}
-
-TEST(EpochSignalTable, MachineMismatch) {
-  EpochSignalTable table(/*session_epoch=*/3, /*machine_index=*/7,
-                         /*device_count=*/2, /*queue_stride=*/2);
-  iree_hal_amdgpu_epoch_signal_table_register(table.get(), 0, 0,
-                                              make_signal(100));
-
-  // Same session, different machine.
-  iree_async_axis_t axis = iree_async_axis_make_queue(3, 8, 0, 0);
-  hsa_signal_t signal;
-  EXPECT_FALSE(
-      iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
-}
-
-TEST(EpochSignalTable, NonQueueDomainRejected) {
+TEST(EpochSignalTable, RejectsUnavailableQueues) {
   EpochSignalTable table(/*session_epoch=*/1, /*machine_index=*/0,
-                         /*device_count=*/4, /*queue_stride=*/4);
-  iree_hal_amdgpu_epoch_signal_table_register(table.get(), 0, 0,
-                                              make_signal(100));
+                         /*device_index=*/4, /*queue_count=*/2);
+  iree_hal_amdgpu_epoch_signal_table_register(table.get(), 0, MakeSignal(99));
 
-  // COLLECTIVE domain axis with the same ordinal bits.
-  iree_async_axis_t collective_axis =
-      iree_async_axis_make(1, 0, IREE_ASYNC_CAUSAL_DOMAIN_COLLECTIVE, 0);
   hsa_signal_t signal;
   EXPECT_FALSE(iree_hal_amdgpu_epoch_signal_table_lookup(
-      table.get(), collective_axis, &signal));
-
-  // HOST domain.
-  iree_async_axis_t host_axis =
-      iree_async_axis_make(1, 0, IREE_ASYNC_CAUSAL_DOMAIN_HOST, 0);
-  EXPECT_FALSE(iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), host_axis,
-                                                         &signal));
+      table.get(), iree_async_axis_make_queue(1, 0, 4, 1), &signal));
+  EXPECT_FALSE(iree_hal_amdgpu_epoch_signal_table_lookup(
+      table.get(), iree_async_axis_make_queue(1, 0, 4, 2), &signal));
 }
 
-TEST(EpochSignalTable, DeviceIndexOutOfBounds) {
+TEST(EpochSignalTable, DeregisterRemovesQueue) {
   EpochSignalTable table(/*session_epoch=*/1, /*machine_index=*/0,
-                         /*device_count=*/2, /*queue_stride=*/2);
-
-  // device_index 2 is out of bounds (only 0 and 1 exist).
-  iree_async_axis_t axis = iree_async_axis_make_queue(1, 0, 2, 0);
+                         /*device_index=*/4, /*queue_count=*/2);
+  iree_hal_amdgpu_epoch_signal_table_register(table.get(), 1, MakeSignal(77));
+  const iree_async_axis_t axis = iree_async_axis_make_queue(1, 0, 4, 1);
   hsa_signal_t signal;
+  ASSERT_TRUE(
+      iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
+
+  iree_hal_amdgpu_epoch_signal_table_deregister(table.get(), 1);
   EXPECT_FALSE(
       iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
-}
-
-TEST(EpochSignalTable, QueueIndexOutOfBounds) {
-  EpochSignalTable table(/*session_epoch=*/1, /*machine_index=*/0,
-                         /*device_count=*/2, /*queue_stride=*/2);
-
-  // queue_index 2 is out of bounds (stride is 2, so only 0 and 1).
-  iree_async_axis_t axis = iree_async_axis_make_queue(1, 0, 0, 2);
-  hsa_signal_t signal;
-  EXPECT_FALSE(
-      iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
-}
-
-TEST(EpochSignalTable, UnregisteredSlotReturnsFalse) {
-  EpochSignalTable table(/*session_epoch=*/1, /*machine_index=*/0,
-                         /*device_count=*/4, /*queue_stride=*/4);
-
-  // Register only slot (1, 2).
-  iree_hal_amdgpu_epoch_signal_table_register(table.get(), 1, 2,
-                                              make_signal(99));
-
-  // Adjacent unregistered slot (1, 3) should fail.
-  iree_async_axis_t axis = iree_async_axis_make_queue(1, 0, 1, 3);
-  hsa_signal_t signal;
-  EXPECT_FALSE(
-      iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
-
-  // Registered slot (1, 2) should succeed.
-  axis = iree_async_axis_make_queue(1, 0, 1, 2);
-  EXPECT_TRUE(
-      iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
-  EXPECT_EQ(signal.handle, 99u);
-}
-
-TEST(EpochSignalTable, Deregister) {
-  EpochSignalTable table(/*session_epoch=*/1, /*machine_index=*/0,
-                         /*device_count=*/2, /*queue_stride=*/2);
-  iree_hal_amdgpu_epoch_signal_table_register(table.get(), 1, 0,
-                                              make_signal(77));
-
-  // Verify registered.
-  iree_async_axis_t axis = iree_async_axis_make_queue(1, 0, 1, 0);
-  hsa_signal_t signal;
-  EXPECT_TRUE(
-      iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
-  EXPECT_EQ(signal.handle, 77u);
-
-  // Deregister.
-  iree_hal_amdgpu_epoch_signal_table_deregister(table.get(), 1, 0);
-
-  // Should no longer be found.
-  EXPECT_FALSE(
-      iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
-}
-
-TEST(EpochSignalTable, MultiSlotIndependence) {
-  // 4 devices × 2 queues = 8 slots. Register unique signals in each.
-  EpochSignalTable table(/*session_epoch=*/5, /*machine_index=*/2,
-                         /*device_count=*/4, /*queue_stride=*/2);
-
-  for (uint8_t device = 0; device < 4; ++device) {
-    for (uint8_t queue = 0; queue < 2; ++queue) {
-      uint64_t handle = (uint64_t)device * 100 + queue + 1;
-      iree_hal_amdgpu_epoch_signal_table_register(table.get(), device, queue,
-                                                  make_signal(handle));
-    }
-  }
-
-  // Verify each slot returns its unique signal.
-  for (uint8_t device = 0; device < 4; ++device) {
-    for (uint8_t queue = 0; queue < 2; ++queue) {
-      iree_async_axis_t axis = iree_async_axis_make_queue(5, 2, device, queue);
-      hsa_signal_t signal;
-      ASSERT_TRUE(iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis,
-                                                            &signal));
-      uint64_t expected_handle = (uint64_t)device * 100 + queue + 1;
-      EXPECT_EQ(signal.handle, expected_handle);
-    }
-  }
-}
-
-TEST(EpochSignalTable, TPCollectiveJoinPattern) {
-  // Simulates the 4-GPU TP collective join: Q0 needs to look up epoch signals
-  // for Q1, Q2, Q3 to emit barrier-value packets.
-  const uint8_t session = 1;
-  const uint8_t machine = 0;
-  const uint8_t device_count = 4;
-  const uint8_t queues_per_device = 1;
-
-  EpochSignalTable table(session, machine, device_count, queues_per_device);
-
-  // Each device has one queue with a unique epoch signal.
-  for (uint8_t device = 0; device < device_count; ++device) {
-    iree_hal_amdgpu_epoch_signal_table_register(table.get(), device, 0,
-                                                make_signal(1000 + device));
-  }
-
-  // Q0 (device 0) needs to wait on Q1, Q2, Q3. Look up their signals.
-  for (uint8_t peer = 1; peer < device_count; ++peer) {
-    iree_async_axis_t peer_axis =
-        iree_async_axis_make_queue(session, machine, peer, 0);
-    hsa_signal_t peer_signal;
-    ASSERT_TRUE(iree_hal_amdgpu_epoch_signal_table_lookup(
-        table.get(), peer_axis, &peer_signal));
-    EXPECT_EQ(peer_signal.handle, 1000u + peer);
-  }
-
-  // Q0's own signal should also be in the table (for other queues looking it
-  // up), though Q0 wouldn't barrier on itself.
-  iree_async_axis_t self_axis =
-      iree_async_axis_make_queue(session, machine, 0, 0);
-  hsa_signal_t self_signal;
-  ASSERT_TRUE(iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), self_axis,
-                                                        &self_signal));
-  EXPECT_EQ(self_signal.handle, 1000u);
 }
 
 }  // namespace

--- a/runtime/src/iree/hal/drivers/amdgpu/util/queue_benchmark.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/queue_benchmark.cc
@@ -466,20 +466,28 @@ class QueueBenchmark : public benchmark::Fixture {
 
     auto* logical_device =
         reinterpret_cast<iree_hal_amdgpu_logical_device_t*>(device_);
-    const uint8_t device_index = iree_async_axis_device_index(axis);
-    if (IREE_UNLIKELY(device_index >= logical_device->physical_device_count)) {
+    const iree_hal_amdgpu_queue_affinity_domain_t domain = {
+        /*.supported_affinity=*/logical_device->queue_affinity_mask,
+        /*.physical_device_count=*/logical_device->physical_device_count,
+        /*.queue_count_per_physical_device=*/
+        logical_device->system->topology.gpu_agent_queue_count,
+    };
+    iree_hal_amdgpu_queue_affinity_resolved_t resolved;
+    if (IREE_UNLIKELY(!iree_hal_amdgpu_queue_affinity_try_resolve_axis(
+            domain, logical_device->axis, axis, &resolved))) {
       return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                              "producer axis has no physical device");
+                              "producer axis is not local to this device");
     }
     iree_hal_amdgpu_physical_device_t* physical_device =
-        logical_device->physical_devices[device_index];
-    const uint8_t queue_index = iree_async_axis_queue_index(axis);
-    if (IREE_UNLIKELY(queue_index >= physical_device->host_queue_count)) {
+        logical_device->physical_devices[resolved.physical_device_ordinal];
+    if (IREE_UNLIKELY(resolved.physical_queue_ordinal >=
+                      physical_device->host_queue_count)) {
       return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                               "producer axis has no initialized host queue");
     }
 
-    *out_host_queue = &physical_device->host_queues[queue_index];
+    *out_host_queue =
+        &physical_device->host_queues[resolved.physical_queue_ordinal];
     return iree_ok_status();
   }
 


### PR DESCRIPTION
AMDGPU queue frontiers now use the device-group topology index and flattened logical queue ordinal as their canonical identity. Independent logical devices previously restarted physical device and queue ordinals at zero and could therefore alias when placed in one group, allowing a cross-device axis to resolve against the wrong local queue.

The epoch signal table is scoped to one logical device and indexed by flattened queue ordinal. Consumers that require physical coordinates decode through the queue-affinity domain, while profiling continues to expose physical queue ordinals. Fence-scope selection performs an inline identity and range check on the submission path.

The regression constructs two AMDGPU logical devices through the production device-group builder and proves that local epoch resolution succeeds, cross-device resolution fails, and fence scopes distinguish local from cross-device queues. Composite logical devices retain distinct axes for every physical queue.