### PR TITLE
[Loom] Preserve view alias proofs through movement analysis

### DIFF
--- a/loom/src/loom/analysis/kernel_async_legality.c
+++ b/loom/src/loom/analysis/kernel_async_legality.c
@@ -405,6 +405,8 @@ static void loom_kernel_async_legality_endpoint_region(
   *out_region = (loom_view_region_t){
       .view_value_id = endpoint->value_id,
       .root_value_id = endpoint->root_value_id,
+      .alias_scope_id = endpoint->alias_scope_id,
+      .nullability = endpoint->nullability,
       .begin_byte_offset = endpoint->begin_byte_offset,
       .byte_length = endpoint->byte_length,
       .end_byte_offset = endpoint->end_byte_offset,
@@ -429,10 +431,6 @@ static iree_status_t loom_kernel_async_legality_endpoints_overlap(
     *out_overlap = true;
     return iree_ok_status();
   }
-  if (pending_endpoint->root_value_id != access_region->root_value_id) {
-    return iree_ok_status();
-  }
-
   loom_view_region_t pending_region = {0};
   loom_kernel_async_legality_endpoint_region(pending_endpoint, &pending_region);
   bool no_overlap = false;

--- a/loom/src/loom/analysis/movement.c
+++ b/loom/src/loom/analysis/movement.c
@@ -35,6 +35,8 @@ static void loom_movement_endpoint_initialize_none(
       .kind = LOOM_MOVEMENT_ENDPOINT_NONE,
       .value_id = LOOM_VALUE_ID_INVALID,
       .root_value_id = LOOM_VALUE_ID_INVALID,
+      .alias_scope_id = LOOM_VALUE_FACT_ALIAS_SCOPE_ID_NONE,
+      .nullability = LOOM_VALUE_FACT_REFERENCE_NULLABILITY_UNKNOWN,
       .memory_space = LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN,
   };
 }
@@ -298,6 +300,8 @@ static iree_status_t loom_movement_endpoint_for_view(
       .type = loom_module_value_type(analysis->module, view_value_id),
       .memory_space = region->memory_space,
       .root_value_id = region->root_value_id,
+      .alias_scope_id = region->alias_scope_id,
+      .nullability = region->nullability,
       .begin_byte_offset = region->begin_byte_offset,
       .byte_length = region->byte_length,
       .end_byte_offset = region->end_byte_offset,
@@ -327,6 +331,8 @@ static void loom_movement_endpoint_for_register(
       .type = loom_module_value_type(module, value_id),
       .memory_space = LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN,
       .root_value_id = LOOM_VALUE_ID_INVALID,
+      .alias_scope_id = LOOM_VALUE_FACT_ALIAS_SCOPE_ID_NONE,
+      .nullability = LOOM_VALUE_FACT_REFERENCE_NULLABILITY_UNKNOWN,
   };
 }
 

--- a/loom/src/loom/analysis/movement.h
+++ b/loom/src/loom/analysis/movement.h
@@ -157,6 +157,12 @@ typedef struct loom_movement_endpoint_t {
   // Storage root identity for view endpoints.
   loom_value_id_t root_value_id;
 
+  // Comparable alias scope for disjointness proofs, or NONE.
+  loom_value_fact_alias_scope_id_t alias_scope_id;
+
+  // Known nullability of the storage root.
+  loom_value_fact_reference_nullability_t nullability;
+
   // Symbolic begin byte offset relative to root_value_id.
   loom_symbolic_expr_t begin_byte_offset;
 

--- a/loom/src/loom/analysis/view_regions.c
+++ b/loom/src/loom/analysis/view_regions.c
@@ -548,6 +548,8 @@ static iree_status_t loom_view_region_build_default(
       .view_value_id = value_id,
       .base_view_value_id = value_id,
       .root_value_id = reference.root_value_id,
+      .alias_scope_id = reference.alias_scope_id,
+      .nullability = reference.nullability,
       .begin_byte_offset = begin,
       .base_begin_byte_offset = begin,
       .projection_byte_offset = zero,
@@ -636,6 +638,8 @@ static iree_status_t loom_view_region_build_subview(
   IREE_RETURN_IF_ERROR(loom_view_region_expr_add(
       table, &source_region->begin_byte_offset, &additional_offset, &begin));
   out_region->root_value_id = source_region->root_value_id;
+  out_region->alias_scope_id = source_region->alias_scope_id;
+  out_region->nullability = source_region->nullability;
   out_region->base_view_value_id = source_region->base_view_value_id;
   out_region->base_begin_byte_offset = source_region->base_begin_byte_offset;
   IREE_RETURN_IF_ERROR(loom_view_region_expr_add(
@@ -668,6 +672,8 @@ static iree_status_t loom_view_region_build_refine(
       table, value_id, view_type, reference, out_region));
   if (!source_region) return iree_ok_status();
   out_region->root_value_id = source_region->root_value_id;
+  out_region->alias_scope_id = source_region->alias_scope_id;
+  out_region->nullability = source_region->nullability;
   out_region->base_view_value_id = source_region->base_view_value_id;
   out_region->base_begin_byte_offset = source_region->base_begin_byte_offset;
   out_region->projection_byte_offset = source_region->projection_byte_offset;
@@ -880,6 +886,20 @@ loom_view_access_flags_t loom_view_region_table_root_access_flags(
   return access_flags;
 }
 
+static bool loom_view_region_memory_spaces_are_disjoint(
+    loom_value_fact_memory_space_t left, loom_value_fact_memory_space_t right) {
+  if (left == right || left == LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN ||
+      right == LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN ||
+      left == LOOM_VALUE_FACT_MEMORY_SPACE_GENERIC ||
+      right == LOOM_VALUE_FACT_MEMORY_SPACE_GENERIC) {
+    return false;
+  }
+  return left == LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP ||
+         right == LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP ||
+         left == LOOM_VALUE_FACT_MEMORY_SPACE_PRIVATE ||
+         right == LOOM_VALUE_FACT_MEMORY_SPACE_PRIVATE;
+}
+
 iree_status_t loom_view_regions_prove_no_overlap(
     loom_view_region_table_t* table, const loom_view_region_t* left_region,
     const loom_view_region_t* right_region, bool* out_no_overlap) {
@@ -890,6 +910,13 @@ iree_status_t loom_view_regions_prove_no_overlap(
     return iree_ok_status();
   }
   if (left_region->root_value_id != right_region->root_value_id) {
+    if (loom_view_region_memory_spaces_are_disjoint(
+            left_region->memory_space, right_region->memory_space) ||
+        (left_region->alias_scope_id != LOOM_VALUE_FACT_ALIAS_SCOPE_ID_NONE &&
+         right_region->alias_scope_id != LOOM_VALUE_FACT_ALIAS_SCOPE_ID_NONE &&
+         left_region->alias_scope_id != right_region->alias_scope_id)) {
+      *out_no_overlap = true;
+    }
     return iree_ok_status();
   }
 

--- a/loom/src/loom/analysis/view_regions.h
+++ b/loom/src/loom/analysis/view_regions.h
@@ -75,6 +75,13 @@ typedef struct loom_view_region_t {
   // SSA value representing the storage root identity.
   loom_value_id_t root_value_id;
 
+  // Comparable alias scope for disjointness proofs, or NONE when distinct
+  // root identities are only addressing provenance.
+  loom_value_fact_alias_scope_id_t alias_scope_id;
+
+  // Known nullability of the underlying storage root.
+  loom_value_fact_reference_nullability_t nullability;
+
   // Symbolic byte offset of the view base relative to root_value_id.
   loom_symbolic_expr_t begin_byte_offset;
 
@@ -180,9 +187,10 @@ iree_status_t loom_view_region_table_analyze(loom_view_region_table_t* table);
 loom_view_access_flags_t loom_view_region_table_root_access_flags(
     const loom_view_region_table_t* table, loom_value_id_t root_value_id);
 
-// Attempts to prove that two same-root view regions cannot overlap. Different
-// root SSA values are conservative unknown until a separate root-disjoint fact
-// system exists.
+// Attempts to prove that two view regions cannot overlap. Same-root regions
+// use symbolic byte intervals. Distinct roots are disjoint when their concrete
+// memory spaces cannot alias or both carry comparable and different alias
+// scopes.
 iree_status_t loom_view_regions_prove_no_overlap(
     loom_view_region_table_t* table, const loom_view_region_t* left_region,
     const loom_view_region_t* right_region, bool* out_no_overlap);

--- a/loom/src/loom/analysis/view_regions_test.cc
+++ b/loom/src/loom/analysis/view_regions_test.cc
@@ -406,6 +406,55 @@ TEST_F(ViewRegionsTest, KeepsOverlappingAndDifferentRootViewsConservative) {
   EXPECT_FALSE(no_overlap);
 }
 
+TEST_F(ViewRegionsTest, ProvesDistinctComparableRootsDisjoint) {
+  loom_value_id_t first_buffer = DefineBufferArg();
+  loom_value_id_t second_buffer = DefineBufferArg();
+  loom_value_id_t buffers[] = {first_buffer, second_buffer};
+  loom_type_t buffer_types[] = {loom_type_buffer(), loom_type_buffer()};
+  loom_op_t* noalias_op = nullptr;
+  IREE_ASSERT_OK(loom_buffer_assume_noalias_build(
+      &builder_, buffers, IREE_ARRAYSIZE(buffers), buffer_types,
+      IREE_ARRAYSIZE(buffer_types), LOOM_LOCATION_UNKNOWN, &noalias_op));
+  loom_value_slice_t noalias_buffers =
+      loom_buffer_assume_noalias_results(noalias_op);
+  ASSERT_EQ(noalias_buffers.count, 2);
+
+  loom_value_id_t layout = BuildDenseLayout();
+  loom_value_id_t zero = loom_index_constant_result(BuildOffsetConstant(0));
+  loom_op_t* first_view_op = nullptr;
+  IREE_ASSERT_OK(loom_buffer_view_build(&builder_, noalias_buffers.values[0],
+                                        zero, ViewType1D(16, layout),
+                                        LOOM_LOCATION_UNKNOWN, &first_view_op));
+  loom_op_t* second_view_op = nullptr;
+  IREE_ASSERT_OK(loom_buffer_view_build(
+      &builder_, noalias_buffers.values[1], zero, ViewType1D(16, layout),
+      LOOM_LOCATION_UNKNOWN, &second_view_op));
+
+  loom_value_fact_table_t facts = {0};
+  ComputeFacts(&facts);
+  loom_view_region_table_t table = {0};
+  Analyze(&facts, &table);
+
+  const loom_view_region_t* first_region = nullptr;
+  IREE_ASSERT_OK(loom_view_region_table_get(
+      &table, loom_buffer_view_result(first_view_op), &first_region));
+  const loom_view_region_t* second_region = nullptr;
+  IREE_ASSERT_OK(loom_view_region_table_get(
+      &table, loom_buffer_view_result(second_view_op), &second_region));
+
+  ASSERT_NE(first_region, nullptr);
+  ASSERT_NE(second_region, nullptr);
+  EXPECT_EQ(first_region->root_value_id, first_buffer);
+  EXPECT_EQ(first_region->alias_scope_id, first_buffer);
+  EXPECT_EQ(second_region->root_value_id, second_buffer);
+  EXPECT_EQ(second_region->alias_scope_id, second_buffer);
+
+  bool no_overlap = false;
+  IREE_ASSERT_OK(loom_view_regions_prove_no_overlap(
+      &table, first_region, second_region, &no_overlap));
+  EXPECT_TRUE(no_overlap);
+}
+
 TEST_F(ViewRegionsTest, SubviewPreservesRootAndAddsLogicalOffset) {
   loom_value_id_t buffer = DefineBufferArg();
   loom_value_id_t base_offset = DefineOffsetArg();
@@ -434,6 +483,7 @@ TEST_F(ViewRegionsTest, SubviewPreservesRootAndAddsLogicalOffset) {
 
   ASSERT_NE(region, nullptr);
   EXPECT_EQ(region->root_value_id, buffer);
+  EXPECT_EQ(region->alias_scope_id, LOOM_VALUE_FACT_ALIAS_SCOPE_ID_NONE);
   EXPECT_TRUE(loom_symbolic_expr_is_linear(&region->begin_byte_offset));
   ASSERT_EQ(region->begin_byte_offset.term_count, 1);
   EXPECT_EQ(region->begin_byte_offset.terms[0].value_id, base_offset);

--- a/loom/src/loom/transforms/kernel/test/kernel_async_legality.loom-test
+++ b/loom/src/loom/transforms/kernel/test/kernel_async_legality.loom-test
@@ -291,6 +291,46 @@ func.def @rejects_source_overwrite_between_group_and_wait(%input: buffer) {
 
 // ====
 
+func.def @rejects_potentially_aliasing_source_write(%input: buffer, %other_input: buffer) {
+  %zero = index.constant 0 : offset
+  %bytes = index.constant 64 : offset
+  %global = buffer.assume.memory_space<global> %input : buffer
+  %other_global = buffer.assume.memory_space<global> %other_input : buffer
+  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %other = buffer.view %other_global[%zero] : buffer -> view<16xi8, #dense>
+  %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
+  %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
+  %value = scalar.constant 1 : i8
+  // ERROR@+1: LOWERING/037 {op_name="view.store", phase_name="kernel-async-legality"}
+  view.store %value, %other[0] : i8, view<16xi8, #dense>
+  kernel.async.wait %group {newer_groups = 0} : kernel.async.group
+  func.return
+}
+
+// ====
+
+func.def @allows_noalias_source_write(%input: buffer, %other_input: buffer) {
+  %input_unique, %other_unique = buffer.assume.noalias %input, %other_input : buffer, buffer
+  %zero = index.constant 0 : offset
+  %bytes = index.constant 64 : offset
+  %global = buffer.assume.memory_space<global> %input_unique : buffer
+  %other_global = buffer.assume.memory_space<global> %other_unique : buffer
+  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %other = buffer.view %other_global[%zero] : buffer -> view<16xi8, #dense>
+  %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
+  %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
+  %value = scalar.constant 1 : i8
+  view.store %value, %other[0] : i8, view<16xi8, #dense>
+  kernel.async.wait %group {newer_groups = 0} : kernel.async.group
+  func.return
+}
+
+// ====
+
 func.def @allows_disjoint_source_write_before_wait(%input: buffer) {
   %zero = index.constant 0 : offset
   %sixteen = index.constant 16 : offset

--- a/loom/src/loom/transforms/loop/licm.c
+++ b/loom/src/loom/transforms/loop/licm.c
@@ -23,7 +23,7 @@ LOOM_PASS_STATISTICS_DEFINE(loom_licm_statistics, loom_licm_statistics_t,
 
 static const loom_pass_info_t loom_licm_pass_info_storage = {
     .name = IREE_SVL("licm"),
-    .description = IREE_SVL("Hoist loop-invariant pure operations."),
+    .description = IREE_SVL("Hoist loop-invariant speculatable operations."),
     .kind = LOOM_PASS_FUNCTION,
     .statistic_layout = &loom_licm_statistics_layout,
 };
@@ -98,8 +98,11 @@ static iree_status_t loom_licm_op_is_hoistable(loom_licm_context_t* context,
                                                loom_op_t* loop_op,
                                                loom_op_t* candidate_op,
                                                bool* out_hoistable) {
-  return loom_motion_subtree_can_relocate_before(&context->motion, candidate_op,
-                                                 loop_op, out_hoistable);
+  // Moving before the loop may execute a candidate when the body never runs,
+  // and coalesces repeated body executions into one. Even an exact single-trip
+  // loop can move a potentially trapping op ahead of observable body work.
+  return loom_motion_subtree_can_speculate_before(
+      &context->motion, candidate_op, loop_op, out_hoistable);
 }
 
 static iree_status_t loom_licm_push_child_regions(

--- a/loom/src/loom/transforms/loop/test/licm.loom-test
+++ b/loom/src/loom/transforms/loop/test/licm.loom-test
@@ -1,29 +1,58 @@
 // RUN: pass licm
 
-// A chain of pure ops whose operands are all loop-invariant moves before the
-// loop in program order. The effectful sink stays in the loop body.
-func.def @hoists_invariant_chain(%n: index) {
+// A chain of speculatable ops whose operands are all loop-invariant moves
+// before the loop in program order. The effectful sink stays in the loop body.
+func.def @hoists_speculatable_invariant_chain(%n: index, %a: i32, %b: i32) {
   %zero = index.constant 0 : index
   %one = index.constant 1 : index
   scf.for %iv = [%zero to %n step %one] {
-    %a = test.constant 2 : i32
-    %b = test.constant 3 : i32
-    %sum = test.addi %a, %b : i32
-    test.use %sum : i32
+    %less = test.cmp lt, %a, %b : i32
+    %selected = scf.select %less, %a, %b : i32
+    test.use %selected : i32
     scf.yield
   }
   func.return
 }
 
 // ----
-func.def @hoists_invariant_chain(%n: index) {
+func.def @hoists_speculatable_invariant_chain(%n: index, %a: i32, %b: i32) {
   %zero = index.constant 0 : index
   %one = index.constant 1 : index
-  %a = test.constant 2 : i32
-  %b = test.constant 3 : i32
-  %sum = test.addi %a, %b : i32
+  %less = test.cmp lt, %a, %b : i32
+  %selected = scf.select %less, %a, %b : i32
   scf.for %iv = [%zero to %n step %one] {
-    test.use %sum : i32
+    test.use %selected : i32
+  }
+  func.return
+}
+
+// ====
+
+// PURE does not imply that an op can execute on a path where the loop body did
+// not run. test.addi intentionally lacks SAFE_TO_SPECULATE and stays inside a
+// loop whose trip count may be zero.
+func.def @keeps_non_speculatable_pure_op(%n: index, %value: i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  scf.for %iv = [%zero to %n step %one] {
+    %doubled = test.addi %value, %value : i32
+    test.use %doubled : i32
+  }
+  func.return
+}
+
+// ====
+
+// Even an exact single-trip loop does not make arbitrary PURE work safe to
+// move before the loop: the move can reorder a trap ahead of observable work
+// earlier in the body.
+func.def @keeps_non_speculatable_after_effect_in_single_trip(%value: i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  scf.for %iv = [%zero to %one step %one] {
+    test.use %value : i32
+    %doubled = test.addi %value, %value : i32
+    test.use %doubled : i32
   }
   func.return
 }
@@ -69,9 +98,9 @@ func.def @keeps_unknown_effects_inside_loop(%n: index, %value: i32) {
 
 // ====
 
-// A pure region op can move as a unit when its condition, branch computations,
-// yielded values, and result type references are all loop-invariant.
-func.def @hoists_pure_region_op(%cond: i1, %n: index, %a: i32, %b: i32) {
+// A PURE region op without a speculation contract stays under the loop
+// predicate even when all captures are loop-invariant.
+func.def @keeps_non_speculatable_region_op(%cond: i1, %n: index, %a: i32, %b: i32) {
   %zero = index.constant 0 : index
   %one = index.constant 1 : index
   scf.for %iv = [%zero to %n step %one] {
@@ -88,16 +117,16 @@ func.def @hoists_pure_region_op(%cond: i1, %n: index, %a: i32, %b: i32) {
 }
 
 // ----
-func.def @hoists_pure_region_op(%cond: i1, %n: index, %a: i32, %b: i32) {
+func.def @keeps_non_speculatable_region_op(%cond: i1, %n: index, %a: i32, %b: i32) {
   %zero = index.constant 0 : index
   %one = index.constant 1 : index
-  %selected = scf.if %cond -> (i32) {
-    %doubled = test.addi %a, %a : i32
-    scf.yield %doubled : i32
-  } else {
-    scf.yield %b : i32
-  }
   scf.for %iv = [%zero to %n step %one] {
+    %selected = scf.if %cond -> (i32) {
+      %doubled = test.addi %a, %a : i32
+      scf.yield %doubled : i32
+    } else {
+      scf.yield %b : i32
+    }
     test.use %selected : i32
   }
   func.return
@@ -105,15 +134,15 @@ func.def @hoists_pure_region_op(%cond: i1, %n: index, %a: i32, %b: i32) {
 
 // ====
 
-// Pure nested work can move out of the loop even when its parent region stays
-// in place because of nested effects.
-func.def @hoists_from_nested_pure_region(%cond: i1, %n: index, %value: i32) {
+// Speculatable nested work can cross both the conditional and loop predicates
+// even when its effectful parent region stays in place.
+func.def @hoists_from_nested_region(%cond: i1, %n: index, %a: i32, %b: i32) {
   %zero = index.constant 0 : index
   %one = index.constant 1 : index
   scf.for %iv = [%zero to %n step %one] {
     scf.if %cond {
-      %doubled = test.addi %value, %value : i32
-      test.use %doubled : i32
+      %less = test.cmp lt, %a, %b : i32
+      test.use %less : i1
       scf.yield
     } else {
       scf.yield
@@ -124,13 +153,13 @@ func.def @hoists_from_nested_pure_region(%cond: i1, %n: index, %value: i32) {
 }
 
 // ----
-func.def @hoists_from_nested_pure_region(%cond: i1, %n: index, %value: i32) {
+func.def @hoists_from_nested_region(%cond: i1, %n: index, %a: i32, %b: i32) {
   %zero = index.constant 0 : index
   %one = index.constant 1 : index
-  %doubled = test.addi %value, %value : i32
+  %less = test.cmp lt, %a, %b : i32
   scf.for %iv = [%zero to %n step %one] {
     scf.if %cond {
-      test.use %doubled : i32
+      test.use %less : i1
     } else {
     }
   }
@@ -167,26 +196,27 @@ func.def @keeps_type_ref_to_loop_local_layout(%buffer: buffer, %offset: offset, 
 
 // ====
 
-// scf.while uses the after region as its LoopLike body. Pure body ops whose
-// operands are available before the while op hoist in the same way as scf.for.
-func.def @hoists_from_while_after(%cond: i1, %init: i32) -> (i32) {
+// scf.while uses the after region as its LoopLike body. Speculatable body ops
+// whose operands are available before the while op hoist in the same way as
+// scf.for.
+func.def @hoists_from_while_after(%cond: i1, %init: i32, %limit: i32) -> (i32) {
   %result = scf.while(%before = %init : i32) -> (i32) {
     scf.condition %cond, %before : i1, i32
   } do(%body: i32) {
-    %sum = test.addi %init, %init : i32
-    test.use %sum : i32
+    %less = test.cmp lt, %init, %limit : i32
+    test.use %less : i1
     scf.yield %body : i32
   }
   func.return %result : i32
 }
 
 // ----
-func.def @hoists_from_while_after(%cond: i1, %init: i32) -> (i32) {
-  %sum = test.addi %init, %init : i32
+func.def @hoists_from_while_after(%cond: i1, %init: i32, %limit: i32) -> (i32) {
+  %less = test.cmp lt, %init, %limit : i32
   %result = scf.while(%before = %init : i32) -> (i32) {
     scf.condition %cond, %before : i1, i32
   } do(%body: i32) {
-    test.use %sum : i32
+    test.use %less : i1
     scf.yield %body : i32
   }
   func.return %result : i32


### PR DESCRIPTION
View-region and movement summaries now retain comparable alias scopes and nullability from value facts. Shared consumers can prove disjointness from same-root byte intervals, concrete non-aliasing memory spaces, or distinct explicit noalias scopes.

Async hazard validation previously treated any two different root SSA values as disjoint. External buffer arguments do not carry noalias by default, so two arguments that alias could bypass pending source or destination hazards. Every overlap query now delegates to the view-region proof: unknown external roots remain conservative, buffer.assume.noalias unlocks disjoint access, and global versus workgroup storage remains structurally disjoint.

The same proof surface is the foundation for loop-invariant read placement and keeps alias semantics out of individual transforms.