### PR TITLE
[Loom] Model memory fences explicitly

### DIFF
--- a/loom/py/loom/dialect/kernel/defs.py
+++ b/loom/py/loom/dialect/kernel/defs.py
@@ -47,6 +47,7 @@ from loom.dsl import (
     INDEX,
     INTEGER,
     ISOLATED_FROM_ABOVE,
+    MEMORY_FENCE,
     PURE,
     SCALAR,
     SYMBOL_DEFINE,
@@ -1294,7 +1295,7 @@ kernel_barrier = Op(
             doc="Execution scope synchronized by the barrier.",
         ),
     ],
-    traits=[UNKNOWN_EFFECTS, CONVERGENT],
+    traits=[MEMORY_FENCE, CONVERGENT],
     verify="loom_kernel_barrier_verify",
     format=[TemplateParam("memory_space"), AttrDict()],
     examples=[

--- a/loom/py/loom/dsl.py
+++ b/loom/py/loom/dsl.py
@@ -128,6 +128,7 @@ __all__ = [
     "ISOLATED_FROM_ABOVE",
     "NON_DETERMINISTIC",
     "UNKNOWN_EFFECTS",
+    "MEMORY_FENCE",
     "CONVERGENT",
     "HINT",
     "SAFE_TO_SPECULATE",
@@ -889,6 +890,11 @@ NON_DETERMINISTIC = Trait("NonDeterministic")
 # Effects depend on runtime state (e.g., func.call depends on the callee).
 # Passes treat this conservatively as both READS_MEMORY and WRITES_MEMORY.
 UNKNOWN_EFFECTS = Trait("UnknownEffects")
+# Op orders memory accesses without directly reading or writing a resource.
+# Fences are observable side effects but do not alias every memory operand;
+# analyses preserve their ordering contract independently from footprint
+# interference.
+MEMORY_FENCE = Trait("MemoryFence")
 # Execution depends on the dynamic set of participating invocations. This is
 # independent of memory effects: a convergent op may still be pure, read/write
 # memory, or have unknown effects, but generic optimizers must not erase,
@@ -3228,6 +3234,11 @@ def _validate_no_effect_conflicts(
             f"Op '{op_name}': declares both PURE and UNKNOWN_EFFECTS. "
             f"A pure op has no effects."
         )
+    if "Pure" in trait_names and "MemoryFence" in trait_names:
+        raise ValueError(
+            f"Op '{op_name}': declares both PURE and MEMORY_FENCE. "
+            f"A memory fence is an observable ordering effect."
+        )
     if "Pure" in trait_names and "UniqueIdentity" in trait_names:
         raise ValueError(
             f"Op '{op_name}': declares both PURE and UNIQUE_IDENTITY. "
@@ -3243,6 +3254,11 @@ def _validate_no_effect_conflicts(
         raise ValueError(
             f"Op '{op_name}': declares both HINT and UNKNOWN_EFFECTS. "
             f"Hints are not semantic effects."
+        )
+    if "Hint" in trait_names and "MemoryFence" in trait_names:
+        raise ValueError(
+            f"Op '{op_name}': declares both HINT and MEMORY_FENCE. "
+            f"A memory fence is semantic, not a compiler hint."
         )
     if "Hint" in trait_names and "NonDeterministic" in trait_names:
         raise ValueError(
@@ -3264,6 +3280,11 @@ def _validate_no_effect_conflicts(
         raise ValueError(
             f"Op '{op_name}': declares both SAFE_TO_SPECULATE and UNKNOWN_EFFECTS. "
             f"Unknown effects cannot be executed on additional control paths."
+        )
+    if "SafeToSpeculate" in trait_names and "MemoryFence" in trait_names:
+        raise ValueError(
+            f"Op '{op_name}': declares both SAFE_TO_SPECULATE and MEMORY_FENCE. "
+            f"Speculation must not add memory-ordering effects."
         )
     if "SafeToSpeculate" in trait_names and "NonDeterministic" in trait_names:
         raise ValueError(
@@ -4029,7 +4050,8 @@ class Op:
 
         An op is pure if it explicitly declares traits=[PURE], or if it
         has no effects, no ownership effects, no ALLOCATES results, and no HINT,
-        NON_DETERMINISTIC, UNKNOWN_EFFECTS, or UNIQUE_IDENTITY traits.
+        NON_DETERMINISTIC, UNKNOWN_EFFECTS, MEMORY_FENCE, or UNIQUE_IDENTITY
+        traits.
         """
         if self.has_trait("Pure"):
             return True
@@ -4043,7 +4065,11 @@ class Op:
             return False
         if self.has_trait("Hint"):
             return False
-        if self.has_trait("NonDeterministic") or self.has_trait("UnknownEffects"):
+        if (
+            self.has_trait("NonDeterministic")
+            or self.has_trait("UnknownEffects")
+            or self.has_trait("MemoryFence")
+        ):
             return False
         return True
 

--- a/loom/py/loom/dsl_test.py
+++ b/loom/py/loom/dsl_test.py
@@ -51,6 +51,7 @@ from loom.dsl import (
     INTEGER,
     INTEGER_ELEMENT,
     INVOLUTION,
+    MEMORY_FENCE,
     NON_DETERMINISTIC,
     OFFSET,
     POOL,
@@ -1909,6 +1910,22 @@ class TestEffects:
     def test_convergent_can_be_pure(self) -> None:
         op = Op("test.convergent", traits=[PURE, CONVERGENT])
         assert op.is_pure
+
+    def test_memory_fence_can_be_convergent(self) -> None:
+        op = Op("test.barrier", traits=[MEMORY_FENCE, CONVERGENT])
+        assert not op.is_pure
+
+    def test_memory_fence_conflicts_with_pure(self) -> None:
+        with _raises(ValueError, match="PURE.*MEMORY_FENCE"):
+            Op("test.bad", traits=[PURE, MEMORY_FENCE])
+
+    def test_memory_fence_conflicts_with_hint(self) -> None:
+        with _raises(ValueError, match="HINT.*MEMORY_FENCE"):
+            Op("test.bad", traits=[HINT, MEMORY_FENCE])
+
+    def test_memory_fence_conflicts_with_safe_to_speculate(self) -> None:
+        with _raises(ValueError, match="SAFE_TO_SPECULATE.*MEMORY_FENCE"):
+            Op("test.bad", traits=[SAFE_TO_SPECULATE, MEMORY_FENCE])
 
     def test_safe_to_speculate_conflicts_with_hint(self) -> None:
         with _raises(ValueError, match="SAFE_TO_SPECULATE.*HINT"):

--- a/loom/py/loom/gen/ops/c_enums.py
+++ b/loom/py/loom/gen/ops/c_enums.py
@@ -132,6 +132,7 @@ TRAIT_MAP: dict[str, str] = {
     "IsolatedFromAbove": "LOOM_TRAIT_ISOLATED_FROM_ABOVE",
     "NonDeterministic": "LOOM_TRAIT_NON_DETERMINISTIC",
     "UnknownEffects": "LOOM_TRAIT_UNKNOWN_EFFECTS",
+    "MemoryFence": "LOOM_TRAIT_MEMORY_FENCE",
     "Convergent": "LOOM_TRAIT_CONVERGENT",
     "UniqueIdentity": "LOOM_TRAIT_UNIQUE_IDENTITY",
     "Hint": "LOOM_TRAIT_HINT",

--- a/loom/py/loom/gen/ops/c_traits.py
+++ b/loom/py/loom/gen/ops/c_traits.py
@@ -144,6 +144,7 @@ def trait_flags(op: Op) -> str:
     explicit_pure = any(trait.name == "Pure" for trait in op.traits)
     has_non_deterministic = any(trait.name == "NonDeterministic" for trait in op.traits)
     has_unknown_effects = any(trait.name == "UnknownEffects" for trait in op.traits)
+    has_memory_fence = any(trait.name == "MemoryFence" for trait in op.traits)
     has_hint = any(trait.name == "Hint" for trait in op.traits)
     if (
         not explicit_pure
@@ -151,6 +152,7 @@ def trait_flags(op: Op) -> str:
         and not op.ownership_effects
         and not has_non_deterministic
         and not has_unknown_effects
+        and not has_memory_fence
         and not has_hint
         and not has_allocating_result
         and not has_explicit_unique_identity

--- a/loom/src/loom/analysis/kernel_async_legality.c
+++ b/loom/src/loom/analysis/kernel_async_legality.c
@@ -405,6 +405,8 @@ static void loom_kernel_async_legality_endpoint_region(
   *out_region = (loom_view_region_t){
       .view_value_id = endpoint->value_id,
       .root_value_id = endpoint->root_value_id,
+      .alias_scope_id = endpoint->alias_scope_id,
+      .nullability = endpoint->nullability,
       .begin_byte_offset = endpoint->begin_byte_offset,
       .byte_length = endpoint->byte_length,
       .end_byte_offset = endpoint->end_byte_offset,
@@ -429,10 +431,6 @@ static iree_status_t loom_kernel_async_legality_endpoints_overlap(
     *out_overlap = true;
     return iree_ok_status();
   }
-  if (pending_endpoint->root_value_id != access_region->root_value_id) {
-    return iree_ok_status();
-  }
-
   loom_view_region_t pending_region = {0};
   loom_kernel_async_legality_endpoint_region(pending_endpoint, &pending_region);
   bool no_overlap = false;

--- a/loom/src/loom/analysis/movement.c
+++ b/loom/src/loom/analysis/movement.c
@@ -35,6 +35,8 @@ static void loom_movement_endpoint_initialize_none(
       .kind = LOOM_MOVEMENT_ENDPOINT_NONE,
       .value_id = LOOM_VALUE_ID_INVALID,
       .root_value_id = LOOM_VALUE_ID_INVALID,
+      .alias_scope_id = LOOM_VALUE_FACT_ALIAS_SCOPE_ID_NONE,
+      .nullability = LOOM_VALUE_FACT_REFERENCE_NULLABILITY_UNKNOWN,
       .memory_space = LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN,
   };
 }
@@ -298,6 +300,8 @@ static iree_status_t loom_movement_endpoint_for_view(
       .type = loom_module_value_type(analysis->module, view_value_id),
       .memory_space = region->memory_space,
       .root_value_id = region->root_value_id,
+      .alias_scope_id = region->alias_scope_id,
+      .nullability = region->nullability,
       .begin_byte_offset = region->begin_byte_offset,
       .byte_length = region->byte_length,
       .end_byte_offset = region->end_byte_offset,
@@ -327,6 +331,8 @@ static void loom_movement_endpoint_for_register(
       .type = loom_module_value_type(module, value_id),
       .memory_space = LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN,
       .root_value_id = LOOM_VALUE_ID_INVALID,
+      .alias_scope_id = LOOM_VALUE_FACT_ALIAS_SCOPE_ID_NONE,
+      .nullability = LOOM_VALUE_FACT_REFERENCE_NULLABILITY_UNKNOWN,
   };
 }
 

--- a/loom/src/loom/analysis/movement.h
+++ b/loom/src/loom/analysis/movement.h
@@ -157,6 +157,12 @@ typedef struct loom_movement_endpoint_t {
   // Storage root identity for view endpoints.
   loom_value_id_t root_value_id;
 
+  // Comparable alias scope for disjointness proofs, or NONE.
+  loom_value_fact_alias_scope_id_t alias_scope_id;
+
+  // Known nullability of the storage root.
+  loom_value_fact_reference_nullability_t nullability;
+
   // Symbolic begin byte offset relative to root_value_id.
   loom_symbolic_expr_t begin_byte_offset;
 

--- a/loom/src/loom/analysis/view_regions.c
+++ b/loom/src/loom/analysis/view_regions.c
@@ -548,6 +548,8 @@ static iree_status_t loom_view_region_build_default(
       .view_value_id = value_id,
       .base_view_value_id = value_id,
       .root_value_id = reference.root_value_id,
+      .alias_scope_id = reference.alias_scope_id,
+      .nullability = reference.nullability,
       .begin_byte_offset = begin,
       .base_begin_byte_offset = begin,
       .projection_byte_offset = zero,
@@ -636,6 +638,8 @@ static iree_status_t loom_view_region_build_subview(
   IREE_RETURN_IF_ERROR(loom_view_region_expr_add(
       table, &source_region->begin_byte_offset, &additional_offset, &begin));
   out_region->root_value_id = source_region->root_value_id;
+  out_region->alias_scope_id = source_region->alias_scope_id;
+  out_region->nullability = source_region->nullability;
   out_region->base_view_value_id = source_region->base_view_value_id;
   out_region->base_begin_byte_offset = source_region->base_begin_byte_offset;
   IREE_RETURN_IF_ERROR(loom_view_region_expr_add(
@@ -668,6 +672,8 @@ static iree_status_t loom_view_region_build_refine(
       table, value_id, view_type, reference, out_region));
   if (!source_region) return iree_ok_status();
   out_region->root_value_id = source_region->root_value_id;
+  out_region->alias_scope_id = source_region->alias_scope_id;
+  out_region->nullability = source_region->nullability;
   out_region->base_view_value_id = source_region->base_view_value_id;
   out_region->base_begin_byte_offset = source_region->base_begin_byte_offset;
   out_region->projection_byte_offset = source_region->projection_byte_offset;
@@ -880,6 +886,20 @@ loom_view_access_flags_t loom_view_region_table_root_access_flags(
   return access_flags;
 }
 
+static bool loom_view_region_memory_spaces_are_disjoint(
+    loom_value_fact_memory_space_t left, loom_value_fact_memory_space_t right) {
+  if (left == right || left == LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN ||
+      right == LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN ||
+      left == LOOM_VALUE_FACT_MEMORY_SPACE_GENERIC ||
+      right == LOOM_VALUE_FACT_MEMORY_SPACE_GENERIC) {
+    return false;
+  }
+  return left == LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP ||
+         right == LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP ||
+         left == LOOM_VALUE_FACT_MEMORY_SPACE_PRIVATE ||
+         right == LOOM_VALUE_FACT_MEMORY_SPACE_PRIVATE;
+}
+
 iree_status_t loom_view_regions_prove_no_overlap(
     loom_view_region_table_t* table, const loom_view_region_t* left_region,
     const loom_view_region_t* right_region, bool* out_no_overlap) {
@@ -890,6 +910,13 @@ iree_status_t loom_view_regions_prove_no_overlap(
     return iree_ok_status();
   }
   if (left_region->root_value_id != right_region->root_value_id) {
+    if (loom_view_region_memory_spaces_are_disjoint(
+            left_region->memory_space, right_region->memory_space) ||
+        (left_region->alias_scope_id != LOOM_VALUE_FACT_ALIAS_SCOPE_ID_NONE &&
+         right_region->alias_scope_id != LOOM_VALUE_FACT_ALIAS_SCOPE_ID_NONE &&
+         left_region->alias_scope_id != right_region->alias_scope_id)) {
+      *out_no_overlap = true;
+    }
     return iree_ok_status();
   }
 

--- a/loom/src/loom/analysis/view_regions.h
+++ b/loom/src/loom/analysis/view_regions.h
@@ -75,6 +75,13 @@ typedef struct loom_view_region_t {
   // SSA value representing the storage root identity.
   loom_value_id_t root_value_id;
 
+  // Comparable alias scope for disjointness proofs, or NONE when distinct
+  // root identities are only addressing provenance.
+  loom_value_fact_alias_scope_id_t alias_scope_id;
+
+  // Known nullability of the underlying storage root.
+  loom_value_fact_reference_nullability_t nullability;
+
   // Symbolic byte offset of the view base relative to root_value_id.
   loom_symbolic_expr_t begin_byte_offset;
 
@@ -180,9 +187,10 @@ iree_status_t loom_view_region_table_analyze(loom_view_region_table_t* table);
 loom_view_access_flags_t loom_view_region_table_root_access_flags(
     const loom_view_region_table_t* table, loom_value_id_t root_value_id);
 
-// Attempts to prove that two same-root view regions cannot overlap. Different
-// root SSA values are conservative unknown until a separate root-disjoint fact
-// system exists.
+// Attempts to prove that two view regions cannot overlap. Same-root regions
+// use symbolic byte intervals. Distinct roots are disjoint when their concrete
+// memory spaces cannot alias or both carry comparable and different alias
+// scopes.
 iree_status_t loom_view_regions_prove_no_overlap(
     loom_view_region_table_t* table, const loom_view_region_t* left_region,
     const loom_view_region_t* right_region, bool* out_no_overlap);

--- a/loom/src/loom/analysis/view_regions_test.cc
+++ b/loom/src/loom/analysis/view_regions_test.cc
@@ -406,6 +406,55 @@ TEST_F(ViewRegionsTest, KeepsOverlappingAndDifferentRootViewsConservative) {
   EXPECT_FALSE(no_overlap);
 }
 
+TEST_F(ViewRegionsTest, ProvesDistinctComparableRootsDisjoint) {
+  loom_value_id_t first_buffer = DefineBufferArg();
+  loom_value_id_t second_buffer = DefineBufferArg();
+  loom_value_id_t buffers[] = {first_buffer, second_buffer};
+  loom_type_t buffer_types[] = {loom_type_buffer(), loom_type_buffer()};
+  loom_op_t* noalias_op = nullptr;
+  IREE_ASSERT_OK(loom_buffer_assume_noalias_build(
+      &builder_, buffers, IREE_ARRAYSIZE(buffers), buffer_types,
+      IREE_ARRAYSIZE(buffer_types), LOOM_LOCATION_UNKNOWN, &noalias_op));
+  loom_value_slice_t noalias_buffers =
+      loom_buffer_assume_noalias_results(noalias_op);
+  ASSERT_EQ(noalias_buffers.count, 2);
+
+  loom_value_id_t layout = BuildDenseLayout();
+  loom_value_id_t zero = loom_index_constant_result(BuildOffsetConstant(0));
+  loom_op_t* first_view_op = nullptr;
+  IREE_ASSERT_OK(loom_buffer_view_build(&builder_, noalias_buffers.values[0],
+                                        zero, ViewType1D(16, layout),
+                                        LOOM_LOCATION_UNKNOWN, &first_view_op));
+  loom_op_t* second_view_op = nullptr;
+  IREE_ASSERT_OK(loom_buffer_view_build(
+      &builder_, noalias_buffers.values[1], zero, ViewType1D(16, layout),
+      LOOM_LOCATION_UNKNOWN, &second_view_op));
+
+  loom_value_fact_table_t facts = {0};
+  ComputeFacts(&facts);
+  loom_view_region_table_t table = {0};
+  Analyze(&facts, &table);
+
+  const loom_view_region_t* first_region = nullptr;
+  IREE_ASSERT_OK(loom_view_region_table_get(
+      &table, loom_buffer_view_result(first_view_op), &first_region));
+  const loom_view_region_t* second_region = nullptr;
+  IREE_ASSERT_OK(loom_view_region_table_get(
+      &table, loom_buffer_view_result(second_view_op), &second_region));
+
+  ASSERT_NE(first_region, nullptr);
+  ASSERT_NE(second_region, nullptr);
+  EXPECT_EQ(first_region->root_value_id, first_buffer);
+  EXPECT_EQ(first_region->alias_scope_id, first_buffer);
+  EXPECT_EQ(second_region->root_value_id, second_buffer);
+  EXPECT_EQ(second_region->alias_scope_id, second_buffer);
+
+  bool no_overlap = false;
+  IREE_ASSERT_OK(loom_view_regions_prove_no_overlap(
+      &table, first_region, second_region, &no_overlap));
+  EXPECT_TRUE(no_overlap);
+}
+
 TEST_F(ViewRegionsTest, SubviewPreservesRootAndAddsLogicalOffset) {
   loom_value_id_t buffer = DefineBufferArg();
   loom_value_id_t base_offset = DefineOffsetArg();
@@ -434,6 +483,7 @@ TEST_F(ViewRegionsTest, SubviewPreservesRootAndAddsLogicalOffset) {
 
   ASSERT_NE(region, nullptr);
   EXPECT_EQ(region->root_value_id, buffer);
+  EXPECT_EQ(region->alias_scope_id, LOOM_VALUE_FACT_ALIAS_SCOPE_ID_NONE);
   EXPECT_TRUE(loom_symbolic_expr_is_linear(&region->begin_byte_offset));
   ASSERT_EQ(region->begin_byte_offset.term_count, 1);
   EXPECT_EQ(region->begin_byte_offset.terms[0].value_id, base_offset);

--- a/loom/src/loom/ir/ir.h
+++ b/loom/src/loom/ir/ir.h
@@ -709,31 +709,45 @@ enum loom_trait_bits_e {
   // hot-path guard before asking a dialect-owned helper for exact source/result
   // ranges.
   LOOM_TRAIT_STORAGE_RELATION = 1u << 23,
+  // Op orders memory accesses without directly reading or writing a resource.
+  // Generic effect queries treat fences as read/write barriers so existing
+  // transforms preserve their ordering. Exact memory analyses may distinguish
+  // the ordering effect from storage-root interference.
+  LOOM_TRAIT_MEMORY_FENCE = 1u << 24,
 };
 typedef uint32_t loom_trait_flags_t;
 
-// Returns true if the trait flags indicate the op may write to memory
-// or has unknown effects. Works on raw bitfields to avoid redundant
+// Returns true if the trait flags indicate the op may write to memory, order
+// memory, or has unknown effects. Works on raw bitfields to avoid redundant
 // vtable lookups when the vtable is already resolved.
 static inline bool loom_traits_may_write(loom_trait_flags_t traits) {
-  return (traits & (LOOM_TRAIT_WRITES_MEMORY | LOOM_TRAIT_UNKNOWN_EFFECTS)) !=
-         0;
+  return (traits & (LOOM_TRAIT_WRITES_MEMORY | LOOM_TRAIT_UNKNOWN_EFFECTS |
+                    LOOM_TRAIT_MEMORY_FENCE)) != 0;
 }
 
 // Returns true if the trait flags indicate the op may observe memory or
 // external state in a way that prevents pure/deterministic reasoning.
 // NON_DETERMINISTIC is counted with read-like effects because CSE and purity
 // checks must treat it as an observation even when it does not read memory.
+// MEMORY_FENCE is counted so generic transforms preserve memory ordering.
 static inline bool loom_traits_may_read(loom_trait_flags_t traits) {
   return (traits & (LOOM_TRAIT_READS_MEMORY | LOOM_TRAIT_UNKNOWN_EFFECTS |
-                    LOOM_TRAIT_NON_DETERMINISTIC)) != 0;
+                    LOOM_TRAIT_NON_DETERMINISTIC | LOOM_TRAIT_MEMORY_FENCE)) !=
+         0;
 }
 
 // Returns true if the trait flags indicate the op may produce different
-// results for identical inputs, writes memory, or has unknown effects.
+// results for identical inputs, write memory, order memory, or have unknown
+// effects.
 static inline bool loom_traits_has_side_effects(loom_trait_flags_t traits) {
   return (traits & (LOOM_TRAIT_WRITES_MEMORY | LOOM_TRAIT_UNKNOWN_EFFECTS |
-                    LOOM_TRAIT_NON_DETERMINISTIC)) != 0;
+                    LOOM_TRAIT_NON_DETERMINISTIC | LOOM_TRAIT_MEMORY_FENCE)) !=
+         0;
+}
+
+// Returns true when the op carries an explicit memory ordering effect.
+static inline bool loom_traits_order_memory(loom_trait_flags_t traits) {
+  return (traits & LOOM_TRAIT_MEMORY_FENCE) != 0;
 }
 
 // Returns true if the trait flags indicate the op's regions cannot

--- a/loom/src/loom/pass/predicate.c
+++ b/loom/src/loom/pass/predicate.c
@@ -40,6 +40,8 @@ static const loom_pass_trait_name_t kLoomPassTraitNames[] = {
     {IREE_SVL("non-deterministic"), LOOM_TRAIT_NON_DETERMINISTIC},
     {IREE_SVL("UnknownEffects"), LOOM_TRAIT_UNKNOWN_EFFECTS},
     {IREE_SVL("unknown-effects"), LOOM_TRAIT_UNKNOWN_EFFECTS},
+    {IREE_SVL("MemoryFence"), LOOM_TRAIT_MEMORY_FENCE},
+    {IREE_SVL("memory-fence"), LOOM_TRAIT_MEMORY_FENCE},
     {IREE_SVL("IsolatedFromAbove"), LOOM_TRAIT_ISOLATED_FROM_ABOVE},
     {IREE_SVL("isolated-from-above"), LOOM_TRAIT_ISOLATED_FROM_ABOVE},
     {IREE_SVL("UniqueIdentity"), LOOM_TRAIT_UNIQUE_IDENTITY},

--- a/loom/src/loom/transforms/kernel/test/kernel_async_legality.loom-test
+++ b/loom/src/loom/transforms/kernel/test/kernel_async_legality.loom-test
@@ -291,6 +291,46 @@ func.def @rejects_source_overwrite_between_group_and_wait(%input: buffer) {
 
 // ====
 
+func.def @rejects_potentially_aliasing_source_write(%input: buffer, %other_input: buffer) {
+  %zero = index.constant 0 : offset
+  %bytes = index.constant 64 : offset
+  %global = buffer.assume.memory_space<global> %input : buffer
+  %other_global = buffer.assume.memory_space<global> %other_input : buffer
+  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %other = buffer.view %other_global[%zero] : buffer -> view<16xi8, #dense>
+  %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
+  %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
+  %value = scalar.constant 1 : i8
+  // ERROR@+1: LOWERING/037 {op_name="view.store", phase_name="kernel-async-legality"}
+  view.store %value, %other[0] : i8, view<16xi8, #dense>
+  kernel.async.wait %group {newer_groups = 0} : kernel.async.group
+  func.return
+}
+
+// ====
+
+func.def @allows_noalias_source_write(%input: buffer, %other_input: buffer) {
+  %input_unique, %other_unique = buffer.assume.noalias %input, %other_input : buffer, buffer
+  %zero = index.constant 0 : offset
+  %bytes = index.constant 64 : offset
+  %global = buffer.assume.memory_space<global> %input_unique : buffer
+  %other_global = buffer.assume.memory_space<global> %other_unique : buffer
+  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %other = buffer.view %other_global[%zero] : buffer -> view<16xi8, #dense>
+  %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
+  %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
+  %value = scalar.constant 1 : i8
+  view.store %value, %other[0] : i8, view<16xi8, #dense>
+  kernel.async.wait %group {newer_groups = 0} : kernel.async.group
+  func.return
+}
+
+// ====
+
 func.def @allows_disjoint_source_write_before_wait(%input: buffer) {
   %zero = index.constant 0 : offset
   %sixteen = index.constant 16 : offset

--- a/loom/src/loom/transforms/loop/licm.c
+++ b/loom/src/loom/transforms/loop/licm.c
@@ -23,7 +23,7 @@ LOOM_PASS_STATISTICS_DEFINE(loom_licm_statistics, loom_licm_statistics_t,
 
 static const loom_pass_info_t loom_licm_pass_info_storage = {
     .name = IREE_SVL("licm"),
-    .description = IREE_SVL("Hoist loop-invariant pure operations."),
+    .description = IREE_SVL("Hoist loop-invariant speculatable operations."),
     .kind = LOOM_PASS_FUNCTION,
     .statistic_layout = &loom_licm_statistics_layout,
 };
@@ -98,8 +98,11 @@ static iree_status_t loom_licm_op_is_hoistable(loom_licm_context_t* context,
                                                loom_op_t* loop_op,
                                                loom_op_t* candidate_op,
                                                bool* out_hoistable) {
-  return loom_motion_subtree_can_relocate_before(&context->motion, candidate_op,
-                                                 loop_op, out_hoistable);
+  // Moving before the loop may execute a candidate when the body never runs,
+  // and coalesces repeated body executions into one. Even an exact single-trip
+  // loop can move a potentially trapping op ahead of observable body work.
+  return loom_motion_subtree_can_speculate_before(
+      &context->motion, candidate_op, loop_op, out_hoistable);
 }
 
 static iree_status_t loom_licm_push_child_regions(

--- a/loom/src/loom/transforms/loop/test/licm.loom-test
+++ b/loom/src/loom/transforms/loop/test/licm.loom-test
@@ -1,29 +1,58 @@
 // RUN: pass licm
 
-// A chain of pure ops whose operands are all loop-invariant moves before the
-// loop in program order. The effectful sink stays in the loop body.
-func.def @hoists_invariant_chain(%n: index) {
+// A chain of speculatable ops whose operands are all loop-invariant moves
+// before the loop in program order. The effectful sink stays in the loop body.
+func.def @hoists_speculatable_invariant_chain(%n: index, %a: i32, %b: i32) {
   %zero = index.constant 0 : index
   %one = index.constant 1 : index
   scf.for %iv = [%zero to %n step %one] {
-    %a = test.constant 2 : i32
-    %b = test.constant 3 : i32
-    %sum = test.addi %a, %b : i32
-    test.use %sum : i32
+    %less = test.cmp lt, %a, %b : i32
+    %selected = scf.select %less, %a, %b : i32
+    test.use %selected : i32
     scf.yield
   }
   func.return
 }
 
 // ----
-func.def @hoists_invariant_chain(%n: index) {
+func.def @hoists_speculatable_invariant_chain(%n: index, %a: i32, %b: i32) {
   %zero = index.constant 0 : index
   %one = index.constant 1 : index
-  %a = test.constant 2 : i32
-  %b = test.constant 3 : i32
-  %sum = test.addi %a, %b : i32
+  %less = test.cmp lt, %a, %b : i32
+  %selected = scf.select %less, %a, %b : i32
   scf.for %iv = [%zero to %n step %one] {
-    test.use %sum : i32
+    test.use %selected : i32
+  }
+  func.return
+}
+
+// ====
+
+// PURE does not imply that an op can execute on a path where the loop body did
+// not run. test.addi intentionally lacks SAFE_TO_SPECULATE and stays inside a
+// loop whose trip count may be zero.
+func.def @keeps_non_speculatable_pure_op(%n: index, %value: i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  scf.for %iv = [%zero to %n step %one] {
+    %doubled = test.addi %value, %value : i32
+    test.use %doubled : i32
+  }
+  func.return
+}
+
+// ====
+
+// Even an exact single-trip loop does not make arbitrary PURE work safe to
+// move before the loop: the move can reorder a trap ahead of observable work
+// earlier in the body.
+func.def @keeps_non_speculatable_after_effect_in_single_trip(%value: i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  scf.for %iv = [%zero to %one step %one] {
+    test.use %value : i32
+    %doubled = test.addi %value, %value : i32
+    test.use %doubled : i32
   }
   func.return
 }
@@ -69,9 +98,9 @@ func.def @keeps_unknown_effects_inside_loop(%n: index, %value: i32) {
 
 // ====
 
-// A pure region op can move as a unit when its condition, branch computations,
-// yielded values, and result type references are all loop-invariant.
-func.def @hoists_pure_region_op(%cond: i1, %n: index, %a: i32, %b: i32) {
+// A PURE region op without a speculation contract stays under the loop
+// predicate even when all captures are loop-invariant.
+func.def @keeps_non_speculatable_region_op(%cond: i1, %n: index, %a: i32, %b: i32) {
   %zero = index.constant 0 : index
   %one = index.constant 1 : index
   scf.for %iv = [%zero to %n step %one] {
@@ -88,16 +117,16 @@ func.def @hoists_pure_region_op(%cond: i1, %n: index, %a: i32, %b: i32) {
 }
 
 // ----
-func.def @hoists_pure_region_op(%cond: i1, %n: index, %a: i32, %b: i32) {
+func.def @keeps_non_speculatable_region_op(%cond: i1, %n: index, %a: i32, %b: i32) {
   %zero = index.constant 0 : index
   %one = index.constant 1 : index
-  %selected = scf.if %cond -> (i32) {
-    %doubled = test.addi %a, %a : i32
-    scf.yield %doubled : i32
-  } else {
-    scf.yield %b : i32
-  }
   scf.for %iv = [%zero to %n step %one] {
+    %selected = scf.if %cond -> (i32) {
+      %doubled = test.addi %a, %a : i32
+      scf.yield %doubled : i32
+    } else {
+      scf.yield %b : i32
+    }
     test.use %selected : i32
   }
   func.return
@@ -105,15 +134,15 @@ func.def @hoists_pure_region_op(%cond: i1, %n: index, %a: i32, %b: i32) {
 
 // ====
 
-// Pure nested work can move out of the loop even when its parent region stays
-// in place because of nested effects.
-func.def @hoists_from_nested_pure_region(%cond: i1, %n: index, %value: i32) {
+// Speculatable nested work can cross both the conditional and loop predicates
+// even when its effectful parent region stays in place.
+func.def @hoists_from_nested_region(%cond: i1, %n: index, %a: i32, %b: i32) {
   %zero = index.constant 0 : index
   %one = index.constant 1 : index
   scf.for %iv = [%zero to %n step %one] {
     scf.if %cond {
-      %doubled = test.addi %value, %value : i32
-      test.use %doubled : i32
+      %less = test.cmp lt, %a, %b : i32
+      test.use %less : i1
       scf.yield
     } else {
       scf.yield
@@ -124,13 +153,13 @@ func.def @hoists_from_nested_pure_region(%cond: i1, %n: index, %value: i32) {
 }
 
 // ----
-func.def @hoists_from_nested_pure_region(%cond: i1, %n: index, %value: i32) {
+func.def @hoists_from_nested_region(%cond: i1, %n: index, %a: i32, %b: i32) {
   %zero = index.constant 0 : index
   %one = index.constant 1 : index
-  %doubled = test.addi %value, %value : i32
+  %less = test.cmp lt, %a, %b : i32
   scf.for %iv = [%zero to %n step %one] {
     scf.if %cond {
-      test.use %doubled : i32
+      test.use %less : i1
     } else {
     }
   }
@@ -167,26 +196,27 @@ func.def @keeps_type_ref_to_loop_local_layout(%buffer: buffer, %offset: offset, 
 
 // ====
 
-// scf.while uses the after region as its LoopLike body. Pure body ops whose
-// operands are available before the while op hoist in the same way as scf.for.
-func.def @hoists_from_while_after(%cond: i1, %init: i32) -> (i32) {
+// scf.while uses the after region as its LoopLike body. Speculatable body ops
+// whose operands are available before the while op hoist in the same way as
+// scf.for.
+func.def @hoists_from_while_after(%cond: i1, %init: i32, %limit: i32) -> (i32) {
   %result = scf.while(%before = %init : i32) -> (i32) {
     scf.condition %cond, %before : i1, i32
   } do(%body: i32) {
-    %sum = test.addi %init, %init : i32
-    test.use %sum : i32
+    %less = test.cmp lt, %init, %limit : i32
+    test.use %less : i1
     scf.yield %body : i32
   }
   func.return %result : i32
 }
 
 // ----
-func.def @hoists_from_while_after(%cond: i1, %init: i32) -> (i32) {
-  %sum = test.addi %init, %init : i32
+func.def @hoists_from_while_after(%cond: i1, %init: i32, %limit: i32) -> (i32) {
+  %less = test.cmp lt, %init, %limit : i32
   %result = scf.while(%before = %init : i32) -> (i32) {
     scf.condition %cond, %before : i1, i32
   } do(%body: i32) {
-    test.use %sum : i32
+    test.use %less : i1
     scf.yield %body : i32
   }
   func.return %result : i32

--- a/loom/src/loom/verify/verify_structure.c
+++ b/loom/src/loom/verify/verify_structure.c
@@ -127,6 +127,11 @@ static bool loom_verify_trait_conflict(loom_trait_flags_t traits,
     *out_trait_b = IREE_SV("UNKNOWN_EFFECTS");
     return true;
   }
+  if (iree_all_bits_set(traits, LOOM_TRAIT_HINT | LOOM_TRAIT_MEMORY_FENCE)) {
+    *out_trait_a = IREE_SV("HINT");
+    *out_trait_b = IREE_SV("MEMORY_FENCE");
+    return true;
+  }
   if (iree_all_bits_set(traits,
                         LOOM_TRAIT_HINT | LOOM_TRAIT_NON_DETERMINISTIC)) {
     *out_trait_a = IREE_SV("HINT");
@@ -157,6 +162,11 @@ static bool loom_verify_trait_conflict(loom_trait_flags_t traits,
   if (iree_all_bits_set(traits, LOOM_TRAIT_PURE | LOOM_TRAIT_UNKNOWN_EFFECTS)) {
     *out_trait_a = IREE_SV("PURE");
     *out_trait_b = IREE_SV("UNKNOWN_EFFECTS");
+    return true;
+  }
+  if (iree_all_bits_set(traits, LOOM_TRAIT_PURE | LOOM_TRAIT_MEMORY_FENCE)) {
+    *out_trait_a = IREE_SV("PURE");
+    *out_trait_b = IREE_SV("MEMORY_FENCE");
     return true;
   }
   if (iree_all_bits_set(traits, LOOM_TRAIT_PURE | LOOM_TRAIT_UNIQUE_IDENTITY)) {
@@ -190,6 +200,12 @@ static bool loom_verify_trait_conflict(loom_trait_flags_t traits,
           traits, LOOM_TRAIT_SAFE_TO_SPECULATE | LOOM_TRAIT_UNKNOWN_EFFECTS)) {
     *out_trait_a = IREE_SV("SAFE_TO_SPECULATE");
     *out_trait_b = IREE_SV("UNKNOWN_EFFECTS");
+    return true;
+  }
+  if (iree_all_bits_set(
+          traits, LOOM_TRAIT_SAFE_TO_SPECULATE | LOOM_TRAIT_MEMORY_FENCE)) {
+    *out_trait_a = IREE_SV("SAFE_TO_SPECULATE");
+    *out_trait_b = IREE_SV("MEMORY_FENCE");
     return true;
   }
   if (iree_all_bits_set(traits, LOOM_TRAIT_SAFE_TO_SPECULATE |

--- a/loom/src/loom/verify/verify_test.cc
+++ b/loom/src/loom/verify/verify_test.cc
@@ -525,6 +525,39 @@ TEST(VerifyTraitConsistencyTest, RejectsDeclaredSpeculatableConvergentTraits) {
                            "SAFE_TO_SPECULATE", "CONVERGENT");
 }
 
+TEST(VerifyTraitConsistencyTest, RejectsDeclaredPureMemoryFenceTraits) {
+  static const uint8_t kBadFenceName[] = {
+      9, 3, 'b', 'a', 'd', '.', 'f', 'e', 'n', 'c', 'e', '\0',
+  };
+  static const loom_op_vtable_t kBadFenceVtable = {
+      /*.traits=*/LOOM_TRAIT_PURE | LOOM_TRAIT_MEMORY_FENCE,
+      /*.fixed_operand_count=*/{},
+      /*.fixed_result_count=*/{},
+      /*.attribute_count=*/{},
+      /*.region_count=*/{},
+      /*.vtable_flags=*/{},
+      /*.symbol_kind=*/{},
+      /*.constraint_count=*/{},
+      /*.operand_descriptor_count=*/{},
+      /*.control_flow_flags=*/{},
+      /*.control_flow_reserved=*/{},
+      /*.successor_selector_operand_index=*/{},
+      /*.canonicalize=*/{},
+      /*.infer_facts=*/{},
+      /*.effective_traits=*/{},
+      /*.attr_descriptors=*/{},
+      /*.operand_descriptors=*/{},
+      /*.type_transfer=*/{},
+      /*.result_descriptors=*/{},
+      /*.region_descriptors=*/{},
+      /*.constraints=*/{},
+      /*.verify=*/{},
+      /*.name=*/kBadFenceName,
+  };
+  ExpectBadTraitDiagnostic(&kBadFenceVtable, "bad.fence", "PURE",
+                           "MEMORY_FENCE");
+}
+
 //===----------------------------------------------------------------------===//
 // Structural checks
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Memory-ordering operations now carry an explicit `MemoryFence` trait, allowing exact memory analyses to distinguish ordering from storage-root interference while keeping generic transforms conservative.

`kernel.barrier` uses this contract instead of `UnknownEffects`. Generic read/write effect queries still treat a fence as a full ordering barrier, so CSE, scheduling, region effect propagation, and other existing consumers cannot move memory through it accidentally.

The trait is wired through DSL validation, generated C tables, pass predicates, purity inference, and runtime trait consistency checks. This creates the semantic hook required for loop-invariant immutable reads to cross barriers only when a dedicated alias analysis proves that no storage interference exists.