### PR TITLE
[Loom] Describe scalar view movement exactly

### DIFF
--- a/loom/src/loom/analysis/BUILD.bazel
+++ b/loom/src/loom/analysis/BUILD.bazel
@@ -537,6 +537,7 @@ loom_cc_test(
         "//loom/src/loom/ops/kernel",
         "//loom/src/loom/ops/test",
         "//loom/src/loom/ops/vector",
+        "//loom/src/loom/ops/view",
         "//loom/src/loom/util:fact_table",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:arena",

--- a/loom/src/loom/analysis/CMakeLists.txt
+++ b/loom/src/loom/analysis/CMakeLists.txt
@@ -629,6 +629,7 @@ loom_cc_test(
     loom::ops::kernel
     loom::ops::test
     loom::ops::vector
+    loom::ops::view
     loom::util::fact_table
 )
 

--- a/loom/src/loom/analysis/kernel_async_legality.c
+++ b/loom/src/loom/analysis/kernel_async_legality.c
@@ -400,23 +400,6 @@ static iree_status_t loom_kernel_async_legality_check_cluster_request(
   return iree_ok_status();
 }
 
-static void loom_kernel_async_legality_endpoint_region(
-    const loom_movement_endpoint_t* endpoint, loom_view_region_t* out_region) {
-  *out_region = (loom_view_region_t){
-      .view_value_id = endpoint->value_id,
-      .root_value_id = endpoint->root_value_id,
-      .alias_scope_id = endpoint->alias_scope_id,
-      .nullability = endpoint->nullability,
-      .begin_byte_offset = endpoint->begin_byte_offset,
-      .byte_length = endpoint->byte_length,
-      .end_byte_offset = endpoint->end_byte_offset,
-      .minimum_alignment = endpoint->minimum_alignment,
-      .root_minimum_alignment = endpoint->root_minimum_alignment,
-      .memory_space = endpoint->memory_space,
-      .precision_flags = endpoint->precision_flags,
-  };
-}
-
 static iree_status_t loom_kernel_async_legality_endpoints_overlap(
     loom_kernel_async_legality_state_t* state,
     const loom_movement_endpoint_t* pending_endpoint,
@@ -432,7 +415,11 @@ static iree_status_t loom_kernel_async_legality_endpoints_overlap(
     return iree_ok_status();
   }
   loom_view_region_t pending_region = {0};
-  loom_kernel_async_legality_endpoint_region(pending_endpoint, &pending_region);
+  if (!loom_movement_endpoint_as_view_region(pending_endpoint,
+                                             &pending_region)) {
+    *out_overlap = true;
+    return iree_ok_status();
+  }
   bool no_overlap = false;
   IREE_RETURN_IF_ERROR(loom_view_regions_prove_no_overlap(
       &state->movement_analysis.view_regions, &pending_region, access_region,
@@ -614,14 +601,21 @@ static iree_status_t loom_kernel_async_legality_append_transfer(
 
   if (request.source.kind == LOOM_MOVEMENT_ENDPOINT_VIEW) {
     loom_view_region_t source_region = {0};
-    loom_kernel_async_legality_endpoint_region(&request.source, &source_region);
+    if (!loom_movement_endpoint_as_view_region(&request.source,
+                                               &source_region)) {
+      return loom_kernel_async_legality_fail(state, producer_op,
+                                             LOOM_ERR_LOWERING_025);
+    }
     IREE_RETURN_IF_ERROR(loom_kernel_async_legality_check_pending_dest_hazard(
         state, stream, producer_op, &source_region, LOOM_OPERAND_READS));
     if (state->failed) return iree_ok_status();
   }
 
   loom_view_region_t dest_region = {0};
-  loom_kernel_async_legality_endpoint_region(&request.dest, &dest_region);
+  if (!loom_movement_endpoint_as_view_region(&request.dest, &dest_region)) {
+    return loom_kernel_async_legality_fail(state, producer_op,
+                                           LOOM_ERR_LOWERING_025);
+  }
   bool overlaps = false;
   IREE_RETURN_IF_ERROR(loom_kernel_async_legality_pending_dest_overlaps(
       state, stream, &dest_region, &overlaps));

--- a/loom/src/loom/analysis/movement.c
+++ b/loom/src/loom/analysis/movement.c
@@ -240,6 +240,29 @@ static void loom_movement_endpoint_refresh_static_bounds(
   }
 }
 
+static void loom_movement_endpoint_from_view_region(
+    const loom_module_t* module, loom_value_id_t view_value_id,
+    loom_movement_endpoint_flags_t access_flags,
+    const loom_view_region_t* region, loom_movement_endpoint_t* out_endpoint) {
+  *out_endpoint = (loom_movement_endpoint_t){
+      .kind = LOOM_MOVEMENT_ENDPOINT_VIEW,
+      .flags = access_flags,
+      .value_id = view_value_id,
+      .type = loom_module_value_type(module, view_value_id),
+      .memory_space = region->memory_space,
+      .root_value_id = region->root_value_id,
+      .alias_scope_id = region->alias_scope_id,
+      .nullability = region->nullability,
+      .begin_byte_offset = region->begin_byte_offset,
+      .byte_length = region->byte_length,
+      .end_byte_offset = region->end_byte_offset,
+      .minimum_alignment = region->minimum_alignment,
+      .root_minimum_alignment = region->root_minimum_alignment,
+      .precision_flags = region->precision_flags,
+  };
+  loom_movement_endpoint_refresh_static_bounds(out_endpoint);
+}
+
 static iree_status_t loom_movement_endpoint_apply_vector_footprint(
     loom_movement_analysis_t* analysis, const loom_symbolic_expr_t* origin,
     int64_t byte_length, loom_movement_endpoint_t* endpoint) {
@@ -293,30 +316,26 @@ static iree_status_t loom_movement_endpoint_for_view(
     return iree_ok_status();
   }
 
-  *out_endpoint = (loom_movement_endpoint_t){
-      .kind = LOOM_MOVEMENT_ENDPOINT_VIEW,
-      .flags = access_flags,
-      .value_id = view_value_id,
-      .type = loom_module_value_type(analysis->module, view_value_id),
-      .memory_space = region->memory_space,
-      .root_value_id = region->root_value_id,
-      .alias_scope_id = region->alias_scope_id,
-      .nullability = region->nullability,
-      .begin_byte_offset = region->begin_byte_offset,
-      .byte_length = region->byte_length,
-      .end_byte_offset = region->end_byte_offset,
-      .minimum_alignment = region->minimum_alignment,
-      .root_minimum_alignment = region->root_minimum_alignment,
-      .precision_flags = region->precision_flags,
-  };
-  if (loom_movement_exact_i64(region->begin_byte_offset,
-                              &out_endpoint->static_begin_byte_offset)) {
-    out_endpoint->flags |= LOOM_MOVEMENT_ENDPOINT_STATIC_BEGIN;
-  }
-  if (loom_movement_exact_i64(region->byte_length,
-                              &out_endpoint->static_byte_length)) {
-    out_endpoint->flags |= LOOM_MOVEMENT_ENDPOINT_STATIC_LENGTH;
-  }
+  loom_movement_endpoint_from_view_region(analysis->module, view_value_id,
+                                          access_flags, region, out_endpoint);
+  return iree_ok_status();
+}
+
+static iree_status_t loom_movement_endpoint_for_element_view(
+    loom_movement_analysis_t* analysis, loom_value_id_t view_value_id,
+    loom_attribute_t static_indices, loom_value_slice_t dynamic_indices,
+    loom_movement_endpoint_flags_t access_flags,
+    loom_movement_endpoint_t* out_endpoint) {
+  loom_movement_endpoint_initialize_none(out_endpoint);
+  loom_view_region_t element_region = {0};
+  bool derived = false;
+  IREE_RETURN_IF_ERROR(loom_view_region_table_derive_element_region(
+      &analysis->view_regions, view_value_id, static_indices, dynamic_indices,
+      &element_region, &derived));
+  if (!derived) return iree_ok_status();
+  loom_movement_endpoint_from_view_region(analysis->module, view_value_id,
+                                          access_flags, &element_region,
+                                          out_endpoint);
   return iree_ok_status();
 }
 
@@ -424,6 +443,91 @@ static bool loom_movement_cache_policy_from_attrs(
     return false;
   }
   return true;
+}
+
+static iree_status_t loom_movement_describe_scalar(
+    loom_movement_analysis_t* analysis, const loom_op_t* op,
+    loom_memory_access_t access, loom_movement_request_t* request,
+    loom_movement_diagnostic_t* diagnostic, bool* out_described) {
+  const loom_memory_access_operation_kind_t operation_kind =
+      loom_memory_access_operation_kind(access);
+  if (operation_kind != LOOM_MEMORY_ACCESS_OPERATION_LOAD &&
+      operation_kind != LOOM_MEMORY_ACCESS_OPERATION_STORE) {
+    diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_UNSUPPORTED_OP;
+    return loom_movement_describe_result(false, out_described);
+  }
+  if (loom_memory_access_mask(access) != LOOM_VALUE_ID_INVALID ||
+      loom_memory_access_passthrough(access) != LOOM_VALUE_ID_INVALID ||
+      loom_memory_access_offsets(access) != LOOM_VALUE_ID_INVALID) {
+    diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_UNSUPPORTED_OP;
+    return loom_movement_describe_result(false, out_described);
+  }
+
+  const loom_value_id_t view_value_id = loom_memory_access_view(access);
+  loom_value_id_t register_value_id = LOOM_VALUE_ID_INVALID;
+  if (operation_kind == LOOM_MEMORY_ACCESS_OPERATION_LOAD) {
+    if (op->result_count != 1) {
+      diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_ENDPOINT;
+      return loom_movement_describe_result(false, out_described);
+    }
+    register_value_id = loom_op_const_results(op)[0];
+    request->kind = LOOM_MOVEMENT_KIND_VIEW_LOAD;
+  } else {
+    register_value_id = loom_memory_access_value(access);
+    request->kind = LOOM_MOVEMENT_KIND_VIEW_STORE;
+  }
+  if (view_value_id == LOOM_VALUE_ID_INVALID ||
+      register_value_id == LOOM_VALUE_ID_INVALID ||
+      !loom_type_is_scalar(
+          loom_module_value_type(analysis->module, register_value_id))) {
+    diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_ENDPOINT;
+    return loom_movement_describe_result(false, out_described);
+  }
+
+  request->layout_kind = LOOM_MOVEMENT_LAYOUT_SCALAR_ELEMENT;
+  request->schema_kind = LOOM_MOVEMENT_SCHEMA_TYPED_ELEMENT;
+  if (!loom_movement_cache_policy_from_attrs(
+          loom_memory_access_cache_scope(access),
+          loom_memory_access_cache_temporal(access), &request->cache_policy,
+          diagnostic)) {
+    return loom_movement_describe_result(false, out_described);
+  }
+
+  const loom_attribute_t static_indices =
+      loom_memory_access_static_indices(access);
+  const loom_value_slice_t dynamic_indices =
+      loom_memory_access_dynamic_indices(access);
+  loom_movement_endpoint_t* view_endpoint = NULL;
+  if (operation_kind == LOOM_MEMORY_ACCESS_OPERATION_LOAD) {
+    IREE_RETURN_IF_ERROR(loom_movement_endpoint_for_element_view(
+        analysis, view_value_id, static_indices, dynamic_indices,
+        LOOM_MOVEMENT_ENDPOINT_READ, &request->source));
+    loom_movement_endpoint_for_register(analysis->module, register_value_id,
+                                        LOOM_MOVEMENT_ENDPOINT_WRITE,
+                                        &request->dest);
+    view_endpoint = &request->source;
+  } else {
+    loom_movement_endpoint_for_register(analysis->module, register_value_id,
+                                        LOOM_MOVEMENT_ENDPOINT_READ,
+                                        &request->source);
+    IREE_RETURN_IF_ERROR(loom_movement_endpoint_for_element_view(
+        analysis, view_value_id, static_indices, dynamic_indices,
+        LOOM_MOVEMENT_ENDPOINT_WRITE, &request->dest));
+    view_endpoint = &request->dest;
+  }
+  if (view_endpoint->kind != LOOM_MOVEMENT_ENDPOINT_VIEW) {
+    diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_ELEMENT_WIDTH |
+                                  LOOM_MOVEMENT_REJECTION_FOOTPRINT;
+    return loom_movement_describe_result(false, out_described);
+  }
+  if (!iree_any_bit_set(view_endpoint->flags,
+                        LOOM_MOVEMENT_ENDPOINT_STATIC_LENGTH)) {
+    diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_FOOTPRINT;
+    return loom_movement_describe_result(false, out_described);
+  }
+  request->flags |= LOOM_MOVEMENT_REQUEST_STATIC_TRANSFER;
+  request->transferred_byte_count = view_endpoint->static_byte_length;
+  return loom_movement_describe_result(true, out_described);
 }
 
 enum {
@@ -883,6 +987,41 @@ bool loom_movement_op_kind_is_async(loom_op_kind_t op_kind) {
   return loom_movement_async_descriptor_for(op_kind) != NULL;
 }
 
+bool loom_movement_endpoint_as_view_region(
+    const loom_movement_endpoint_t* endpoint, loom_view_region_t* out_region) {
+  *out_region = (loom_view_region_t){0};
+  if (!endpoint || endpoint->kind != LOOM_MOVEMENT_ENDPOINT_VIEW) {
+    return false;
+  }
+  loom_view_access_flags_t access_flags = 0;
+  if (iree_any_bit_set(endpoint->flags, LOOM_MOVEMENT_ENDPOINT_READ)) {
+    access_flags |= LOOM_VIEW_ACCESS_READ;
+  }
+  if (iree_any_bit_set(endpoint->flags, LOOM_MOVEMENT_ENDPOINT_WRITE)) {
+    access_flags |= LOOM_VIEW_ACCESS_WRITE;
+  }
+  *out_region = (loom_view_region_t){
+      .region_id = LOOM_VIEW_REGION_ID_INVALID,
+      .view_value_id = endpoint->value_id,
+      .base_view_value_id = endpoint->value_id,
+      .root_value_id = endpoint->root_value_id,
+      .alias_scope_id = endpoint->alias_scope_id,
+      .nullability = endpoint->nullability,
+      .begin_byte_offset = endpoint->begin_byte_offset,
+      .base_begin_byte_offset = endpoint->begin_byte_offset,
+      .begin_value_id = LOOM_VALUE_ID_INVALID,
+      .byte_length = endpoint->byte_length,
+      .end_byte_offset = endpoint->end_byte_offset,
+      .minimum_alignment = endpoint->minimum_alignment,
+      .root_minimum_alignment = endpoint->root_minimum_alignment,
+      .static_element_byte_count = -1,
+      .memory_space = endpoint->memory_space,
+      .access_flags = access_flags,
+      .precision_flags = endpoint->precision_flags,
+  };
+  return true;
+}
+
 uint64_t loom_movement_endpoint_minimum_byte_alignment(
     const loom_movement_endpoint_t* endpoint) {
   if (endpoint->kind != LOOM_MOVEMENT_ENDPOINT_VIEW ||
@@ -922,6 +1061,12 @@ iree_status_t loom_movement_request_describe_op(
     return loom_movement_describe_async(analysis, op, async_descriptor,
                                         out_request, out_diagnostic,
                                         out_described);
+  }
+
+  loom_memory_access_t access = loom_memory_access_cast(analysis->module, op);
+  if (loom_memory_access_isa(access)) {
+    return loom_movement_describe_scalar(analysis, op, access, out_request,
+                                         out_diagnostic, out_described);
   }
 
   out_diagnostic->rejection_bits |= LOOM_MOVEMENT_REJECTION_UNSUPPORTED_OP;

--- a/loom/src/loom/analysis/movement.h
+++ b/loom/src/loom/analysis/movement.h
@@ -49,6 +49,8 @@ typedef enum loom_movement_kind_e {
   LOOM_MOVEMENT_KIND_KERNEL_ASYNC_CLUSTER_GATHER_MASK = 16,
   LOOM_MOVEMENT_KIND_KERNEL_ASYNC_TENSOR_LOAD_TO_LDS = 17,
   LOOM_MOVEMENT_KIND_KERNEL_ASYNC_TENSOR_STORE_FROM_LDS = 18,
+  LOOM_MOVEMENT_KIND_VIEW_LOAD = 19,
+  LOOM_MOVEMENT_KIND_VIEW_STORE = 20,
 } loom_movement_kind_t;
 
 // Endpoint storage category.
@@ -69,6 +71,7 @@ typedef enum loom_movement_layout_kind_e {
   LOOM_MOVEMENT_LAYOUT_BYTE_RANGE = 6,
   LOOM_MOVEMENT_LAYOUT_CLUSTER_GATHER = 7,
   LOOM_MOVEMENT_LAYOUT_TENSOR_TILE = 8,
+  LOOM_MOVEMENT_LAYOUT_SCALAR_ELEMENT = 9,
 } loom_movement_layout_kind_t;
 
 // Relationship between byte movement and typed storage interpretation.
@@ -284,6 +287,11 @@ iree_status_t loom_movement_request_describe_op(
 // Non-memory endpoints or unknown alignment facts return 0.
 uint64_t loom_movement_endpoint_minimum_byte_alignment(
     const loom_movement_endpoint_t* endpoint);
+
+// Projects a view endpoint back into the common byte-region representation
+// used by alias and overlap proofs. Returns false for non-view endpoints.
+bool loom_movement_endpoint_as_view_region(
+    const loom_movement_endpoint_t* endpoint, loom_view_region_t* out_region);
 
 // Returns a diagnostic detail string for movement request rejection flags.
 iree_string_view_t loom_movement_rejection_detail(

--- a/loom/src/loom/analysis/movement_test.cc
+++ b/loom/src/loom/analysis/movement_test.cc
@@ -19,6 +19,7 @@
 #include "loom/ops/kernel/ops.h"
 #include "loom/ops/test/ops.h"
 #include "loom/ops/vector/ops.h"
+#include "loom/ops/view/ops.h"
 #include "loom/util/fact_table.h"
 
 namespace loom {
@@ -37,6 +38,7 @@ class MovementTest : public ::testing::Test {
     RegisterDialect(LOOM_DIALECT_KERNEL, loom_kernel_dialect_vtables);
     RegisterDialect(LOOM_DIALECT_TEST, loom_test_dialect_vtables);
     RegisterDialect(LOOM_DIALECT_VECTOR, loom_vector_dialect_vtables);
+    RegisterDialect(LOOM_DIALECT_VIEW, loom_view_dialect_vtables);
     IREE_ASSERT_OK(loom_context_finalize(&context_));
     IREE_ASSERT_OK(loom_module_allocate(&context_, IREE_SV("test"),
                                         &block_pool_, nullptr,
@@ -263,6 +265,65 @@ TEST_F(MovementTest, ClassifiesStaticDenseVectorLoadFootprint) {
   EXPECT_EQ(request.source.static_byte_length, 16);
   EXPECT_EQ(request.dest.kind, LOOM_MOVEMENT_ENDPOINT_REGISTER);
   EXPECT_EQ(diagnostic.rejection_bits, 0u);
+}
+
+TEST_F(MovementTest, ClassifiesStaticDenseScalarLoadFootprint) {
+  loom_value_id_t buffer = DefineBufferArg();
+  loom_value_id_t layout = BuildDenseLayout();
+  loom_value_id_t view =
+      BuildBufferView(buffer, 16, ViewType1D(LOOM_SCALAR_TYPE_F32, 32, layout));
+  int64_t static_indices[] = {3};
+  loom_op_t* op = nullptr;
+  IREE_ASSERT_OK(loom_view_load_build(
+      &builder_, 0, view, nullptr, 0, static_indices,
+      IREE_ARRAYSIZE(static_indices), 0, 0,
+      loom_type_scalar(LOOM_SCALAR_TYPE_F32), LOOM_LOCATION_UNKNOWN, &op));
+
+  loom_movement_analysis_t analysis = {};
+  InitializeAnalysis(&analysis);
+  loom_movement_request_t request = {};
+  loom_movement_diagnostic_t diagnostic = {};
+  ASSERT_TRUE(Describe(&analysis, op, &request, &diagnostic));
+  EXPECT_EQ(request.kind, LOOM_MOVEMENT_KIND_VIEW_LOAD);
+  EXPECT_EQ(request.layout_kind, LOOM_MOVEMENT_LAYOUT_SCALAR_ELEMENT);
+  EXPECT_EQ(request.schema_kind, LOOM_MOVEMENT_SCHEMA_TYPED_ELEMENT);
+  EXPECT_EQ(request.transferred_byte_count, 4);
+  EXPECT_EQ(request.source.kind, LOOM_MOVEMENT_ENDPOINT_VIEW);
+  EXPECT_EQ(request.source.root_value_id, buffer);
+  EXPECT_EQ(request.source.static_begin_byte_offset, 28);
+  EXPECT_EQ(request.source.static_byte_length, 4);
+  EXPECT_EQ(request.dest.kind, LOOM_MOVEMENT_ENDPOINT_REGISTER);
+  EXPECT_EQ(diagnostic.rejection_bits, 0u);
+}
+
+TEST_F(MovementTest, ClassifiesStaticStridedScalarStoreFootprint) {
+  loom_value_id_t buffer = DefineBufferArg();
+  loom_value_id_t value = DefineI32Arg();
+  loom_value_id_t layout = BuildStaticStridedLayout(8, 1);
+  loom_value_id_t view = BuildBufferView(
+      buffer, 8, ViewType2D(LOOM_SCALAR_TYPE_I32, 8, 8, layout));
+  int64_t static_indices[] = {1, 2};
+  loom_op_t* op = nullptr;
+  IREE_ASSERT_OK(loom_view_store_build(
+      &builder_, 0, value, view, nullptr, 0, static_indices,
+      IREE_ARRAYSIZE(static_indices), 0, 0, LOOM_LOCATION_UNKNOWN, &op));
+
+  loom_movement_analysis_t analysis = {};
+  InitializeAnalysis(&analysis);
+  loom_movement_request_t request = {};
+  loom_movement_diagnostic_t diagnostic = {};
+  ASSERT_TRUE(Describe(&analysis, op, &request, &diagnostic));
+  EXPECT_EQ(request.kind, LOOM_MOVEMENT_KIND_VIEW_STORE);
+  EXPECT_EQ(request.source.kind, LOOM_MOVEMENT_ENDPOINT_REGISTER);
+  EXPECT_EQ(request.dest.kind, LOOM_MOVEMENT_ENDPOINT_VIEW);
+  EXPECT_EQ(request.dest.root_value_id, buffer);
+  EXPECT_EQ(request.dest.static_begin_byte_offset, 48);
+  EXPECT_EQ(request.dest.static_byte_length, 4);
+
+  loom_view_region_t region = {};
+  ASSERT_TRUE(loom_movement_endpoint_as_view_region(&request.dest, &region));
+  EXPECT_EQ(region.root_value_id, buffer);
+  EXPECT_TRUE(iree_any_bit_set(region.access_flags, LOOM_VIEW_ACCESS_WRITE));
 }
 
 TEST_F(MovementTest, CarriesViewAlignmentFacts) {

--- a/loom/src/loom/analysis/view_regions.c
+++ b/loom/src/loom/analysis/view_regions.c
@@ -8,6 +8,7 @@
 
 #include <string.h>
 
+#include "iree/base/internal/math.h"
 #include "loom/ir/attribute.h"
 #include "loom/ir/context.h"
 #include "loom/ops/buffer/ops.h"
@@ -790,6 +791,70 @@ bool loom_view_region_table_try_lookup(const loom_view_region_table_t* table,
   }
   *out_region = &table->regions[region_id];
   return true;
+}
+
+iree_status_t loom_view_region_table_derive_element_region(
+    loom_view_region_table_t* table, loom_value_id_t view_value_id,
+    loom_attribute_t static_indices, loom_value_slice_t dynamic_indices,
+    loom_view_region_t* out_region, bool* out_derived) {
+  *out_region = (loom_view_region_t){0};
+  *out_derived = false;
+  if (!table || view_value_id >= table->module->values.count) {
+    return iree_ok_status();
+  }
+
+  const loom_view_region_t* source_region = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_view_region_table_get(table, view_value_id, &source_region));
+  if (!source_region || source_region->static_element_byte_count <= 0) {
+    return iree_ok_status();
+  }
+  const loom_type_t view_type =
+      loom_module_value_type(table->module, view_value_id);
+  if (static_indices.kind != LOOM_ATTR_I64_ARRAY ||
+      static_indices.count != loom_type_rank(view_type)) {
+    return iree_ok_status();
+  }
+  iree_host_size_t expected_dynamic_count = 0;
+  for (uint16_t i = 0; i < static_indices.count; ++i) {
+    expected_dynamic_count += static_indices.i64_array[i] == INT64_MIN;
+  }
+  if (dynamic_indices.count != expected_dynamic_count) {
+    return iree_ok_status();
+  }
+
+  loom_symbolic_expr_t additional_offset = {0};
+  IREE_RETURN_IF_ERROR(loom_view_region_additional_byte_offset_expr(
+      table, view_type, static_indices, dynamic_indices,
+      source_region->static_element_byte_count, &additional_offset));
+  loom_symbolic_expr_t begin = {0};
+  IREE_RETURN_IF_ERROR(loom_view_region_expr_add(
+      table, &source_region->begin_byte_offset, &additional_offset, &begin));
+  loom_symbolic_expr_t byte_length = {0};
+  loom_symbolic_expr_constant(source_region->static_element_byte_count,
+                              &byte_length);
+  loom_symbolic_expr_t end = {0};
+  IREE_RETURN_IF_ERROR(
+      loom_view_region_expr_add(table, &begin, &byte_length, &end));
+  loom_symbolic_expr_t projection = {0};
+  IREE_RETURN_IF_ERROR(
+      loom_view_region_expr_add(table, &source_region->projection_byte_offset,
+                                &additional_offset, &projection));
+
+  *out_region = *source_region;
+  out_region->region_id = LOOM_VIEW_REGION_ID_INVALID;
+  out_region->projection_byte_offset = projection;
+  out_region->begin_value_id = LOOM_VALUE_ID_INVALID;
+  out_region->begin_byte_offset = begin;
+  out_region->byte_length = byte_length;
+  out_region->end_byte_offset = end;
+  out_region->minimum_alignment =
+      iree_math_gcd_i64((int64_t)source_region->minimum_alignment,
+                        additional_offset.facts.known_divisor);
+  out_region->access_flags = 0;
+  loom_view_region_refresh_precision(out_region);
+  *out_derived = true;
+  return iree_ok_status();
 }
 
 //===----------------------------------------------------------------------===//

--- a/loom/src/loom/analysis/view_regions.h
+++ b/loom/src/loom/analysis/view_regions.h
@@ -178,6 +178,17 @@ bool loom_view_region_table_try_lookup(const loom_view_region_table_t* table,
                                        loom_value_id_t value_id,
                                        const loom_view_region_t** out_region);
 
+// Derives the exact one-element byte region addressed by |static_indices| and
+// |dynamic_indices| within |view_value_id|. The returned region preserves the
+// storage root, alias scope, nullability, and memory space of the source view.
+// Unsupported element widths or malformed index lists return OK with
+// |out_derived| false. Nonlinear but well-formed addresses remain derived with
+// conservative symbolic begin/end expressions.
+iree_status_t loom_view_region_table_derive_element_region(
+    loom_view_region_table_t* table, loom_value_id_t view_value_id,
+    loom_attribute_t static_indices, loom_value_slice_t dynamic_indices,
+    loom_view_region_t* out_region, bool* out_derived);
+
 // Walks the table's local value domain region, constructs summaries for view
 // values, and derives per-view access flags from memory-operand descriptors.
 iree_status_t loom_view_region_table_analyze(loom_view_region_table_t* table);

--- a/loom/src/loom/ops/scf/BUILD.bazel
+++ b/loom/src/loom/ops/scf/BUILD.bazel
@@ -33,7 +33,6 @@ loom_generated_cc_library(
     generator = "//loom/py/loom/gen/ops:c_tables_scf_generator",
     deps = [
         "//loom/src/loom/analysis:availability",
-        "//loom/src/loom/analysis:motion",
         "//loom/src/loom/error:emitter",
         "//loom/src/loom/error:error_defs",
         "//loom/src/loom/ir",

--- a/loom/src/loom/ops/scf/CMakeLists.txt
+++ b/loom/src/loom/ops/scf/CMakeLists.txt
@@ -32,7 +32,6 @@ loom_generated_cc_library(
   DEPS
     iree::base::internal
     loom::analysis::availability
-    loom::analysis::motion
     loom::error::emitter
     loom::error::error_defs
     loom::ir

--- a/loom/src/loom/transforms/scf/scf_unroll.c
+++ b/loom/src/loom/transforms/scf/scf_unroll.c
@@ -1351,21 +1351,6 @@ static bool loom_scf_unroll_effects_conflict(
                                                LOOM_SCF_UNROLL_EFFECT_WRITE);
 }
 
-static void loom_scf_unroll_endpoint_region(
-    const loom_movement_endpoint_t* endpoint, loom_view_region_t* out_region) {
-  *out_region = (loom_view_region_t){
-      .view_value_id = endpoint->value_id,
-      .root_value_id = endpoint->root_value_id,
-      .begin_byte_offset = endpoint->begin_byte_offset,
-      .byte_length = endpoint->byte_length,
-      .end_byte_offset = endpoint->end_byte_offset,
-      .minimum_alignment = endpoint->minimum_alignment,
-      .root_minimum_alignment = endpoint->root_minimum_alignment,
-      .memory_space = endpoint->memory_space,
-      .precision_flags = endpoint->precision_flags,
-  };
-}
-
 static bool loom_scf_unroll_symbolic_expr_contains_value(
     const loom_symbolic_expr_t* expression, loom_value_id_t value_id) {
   if (!loom_symbolic_expr_is_linear(expression)) return false;
@@ -1398,19 +1383,21 @@ static iree_status_t loom_scf_unroll_endpoints_no_overlap(
     return iree_ok_status();
   }
   if (left->root_value_id == LOOM_VALUE_ID_INVALID ||
-      right->root_value_id == LOOM_VALUE_ID_INVALID ||
-      left->root_value_id != right->root_value_id) {
+      right->root_value_id == LOOM_VALUE_ID_INVALID) {
     return iree_ok_status();
   }
-  if (varying_value_id != LOOM_VALUE_ID_INVALID &&
+  if (left->root_value_id == right->root_value_id &&
+      varying_value_id != LOOM_VALUE_ID_INVALID &&
       (loom_scf_unroll_endpoint_contains_value(left, varying_value_id) ||
        loom_scf_unroll_endpoint_contains_value(right, varying_value_id))) {
     return iree_ok_status();
   }
   loom_view_region_t left_region = {0};
-  loom_scf_unroll_endpoint_region(left, &left_region);
   loom_view_region_t right_region = {0};
-  loom_scf_unroll_endpoint_region(right, &right_region);
+  if (!loom_movement_endpoint_as_view_region(left, &left_region) ||
+      !loom_movement_endpoint_as_view_region(right, &right_region)) {
+    return iree_ok_status();
+  }
   return loom_view_regions_prove_no_overlap(&movement_analysis->view_regions,
                                             &left_region, &right_region,
                                             out_no_overlap);

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -272,6 +272,51 @@ func.def @interleaved_disjoint_vector_stores_commute(%buffer: buffer) {
 
 // ====
 
+func.def @interleaved_noalias_vector_stores_commute(%left: buffer, %right: buffer) {
+  %left_unique, %right_unique = buffer.assume.noalias %left, %right : buffer, buffer
+  %zero = index.constant 0 : offset
+  %value0 = scalar.constant 1 : i32
+  %value1 = scalar.constant 2 : i32
+  %vec0 = vector.splat %value0 : vector<4xi32>
+  %vec1 = vector.splat %value1 : vector<4xi32>
+  %layout = encoding.layout.dense : encoding<layout>
+  %left_view = buffer.view %left_unique[%zero] : buffer -> view<4xi32, %layout>
+  %right_view = buffer.view %right_unique[%zero] : buffer -> view<4xi32, %layout>
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  scf.for %i = [%start to %end step %step] unroll schedule(interleaved) {
+    vector.store %vec0, %left_view[0] : vector<4xi32>, view<4xi32, %layout>
+    vector.store %vec1, %right_view[0] : vector<4xi32>, view<4xi32, %layout>
+  }
+  func.return
+}
+
+// ----
+func.def @interleaved_noalias_vector_stores_commute(%left: buffer, %right: buffer) {
+  %left_unique, %right_unique = buffer.assume.noalias %left, %right : buffer, buffer
+  %zero = index.constant 0 : offset
+  %value0 = scalar.constant 1 : i32
+  %value1 = scalar.constant 2 : i32
+  %vec0 = vector.splat %value0 : vector<4xi32>
+  %vec1 = vector.splat %value1 : vector<4xi32>
+  %layout = encoding.layout.dense : encoding<layout>
+  %left_view = buffer.view %left_unique[%zero] : buffer -> view<4xi32, %layout>
+  %right_view = buffer.view %right_unique[%zero] : buffer -> view<4xi32, %layout>
+  %start = index.constant 0 : index
+  %end = index.constant 2 : index
+  %step = index.constant 1 : index
+  %i_0 = index.constant 0 : index
+  %i_1 = index.constant 1 : index
+  vector.store %vec0, %left_view[0] : vector<4xi32>, view<4xi32, %layout>
+  vector.store %vec0, %left_view[0] : vector<4xi32>, view<4xi32, %layout>
+  vector.store %vec1, %right_view[0] : vector<4xi32>, view<4xi32, %layout>
+  vector.store %vec1, %right_view[0] : vector<4xi32>, view<4xi32, %layout>
+  func.return
+}
+
+// ====
+
 func.def @interleaved_dynamic_base_vector_stores_commute(%buffer: buffer, %base: offset) {
   %value0 = scalar.constant 1 : i32
   %value1 = scalar.constant 2 : i32


### PR DESCRIPTION
Ordinary scalar view loads and stores now enter the target-neutral movement model as exact one-element byte transfers. Each endpoint retains its storage root, alias scope, nullability, memory space, symbolic byte interval, alignment, typed schema, and cache policy.

Async legality and configured interleaving consume one shared endpoint-to-region projection instead of reconstructing partial view summaries. Configured interleaving can therefore commute stores to explicitly disjoint noalias roots while preserving order for unrelated external roots and unresolved byte ranges.

The SCF dialect no longer carries its stale dependency on motion analysis, keeping the dependency graph acyclic as movement analysis becomes a shared legality substrate.