### PR TITLE
[Loom] Hoist invariant reads with byte proofs

### DIFF
--- a/loom/src/loom/analysis/BUILD.bazel
+++ b/loom/src/loom/analysis/BUILD.bazel
@@ -552,6 +552,8 @@ loom_cc_library(
     hdrs = ["motion.h"],
     deps = [
         ":availability",
+        ":loop_domain",
+        ":movement",
         "//loom/src/loom/ir",
         "//loom/src/loom/ops:op_defs",
         "//runtime/src/iree/base",

--- a/loom/src/loom/analysis/CMakeLists.txt
+++ b/loom/src/loom/analysis/CMakeLists.txt
@@ -642,6 +642,8 @@ loom_cc_library(
     "motion.c"
   DEPS
     ::availability
+    ::loop_domain
+    ::movement
     iree::base
     iree::base::internal::arena
     loom::ir

--- a/loom/src/loom/analysis/loop_domain.c
+++ b/loom/src/loom/analysis/loop_domain.c
@@ -34,3 +34,47 @@ bool loom_loop_domain_equal(const loom_value_fact_table_t* fact_table,
                                       rhs.upper_bound) &&
          loom_loop_domain_value_equal(fact_table, lhs.step, rhs.step);
 }
+
+static bool loom_loop_domain_lookup_range_facts(
+    const loom_value_fact_table_t* fact_table, loom_loop_domain_t domain,
+    loom_value_facts_t* out_lower_bound, loom_value_facts_t* out_upper_bound,
+    loom_value_facts_t* out_step) {
+  if (!fact_table || domain.lower_bound == LOOM_VALUE_ID_INVALID ||
+      domain.upper_bound == LOOM_VALUE_ID_INVALID ||
+      domain.step == LOOM_VALUE_ID_INVALID) {
+    return false;
+  }
+  *out_lower_bound =
+      loom_value_fact_table_lookup(fact_table, domain.lower_bound);
+  *out_upper_bound =
+      loom_value_fact_table_lookup(fact_table, domain.upper_bound);
+  *out_step = loom_value_fact_table_lookup(fact_table, domain.step);
+  return !loom_value_facts_is_float(*out_lower_bound) &&
+         !loom_value_facts_is_float(*out_upper_bound) &&
+         !loom_value_facts_is_float(*out_step) &&
+         loom_value_facts_is_positive(*out_step);
+}
+
+bool loom_loop_domain_proven_empty(const loom_value_fact_table_t* fact_table,
+                                   loom_loop_domain_t domain) {
+  loom_value_facts_t lower_bound = {0};
+  loom_value_facts_t upper_bound = {0};
+  loom_value_facts_t step = {0};
+  if (!loom_loop_domain_lookup_range_facts(fact_table, domain, &lower_bound,
+                                           &upper_bound, &step)) {
+    return false;
+  }
+  return lower_bound.range_lo >= upper_bound.range_hi;
+}
+
+bool loom_loop_domain_proven_nonempty(const loom_value_fact_table_t* fact_table,
+                                      loom_loop_domain_t domain) {
+  loom_value_facts_t lower_bound = {0};
+  loom_value_facts_t upper_bound = {0};
+  loom_value_facts_t step = {0};
+  if (!loom_loop_domain_lookup_range_facts(fact_table, domain, &lower_bound,
+                                           &upper_bound, &step)) {
+    return false;
+  }
+  return lower_bound.range_hi < upper_bound.range_lo;
+}

--- a/loom/src/loom/analysis/loop_domain.h
+++ b/loom/src/loom/analysis/loop_domain.h
@@ -37,6 +37,18 @@ typedef struct loom_loop_domain_t {
 bool loom_loop_domain_equal(const loom_value_fact_table_t* fact_table,
                             loom_loop_domain_t lhs, loom_loop_domain_t rhs);
 
+// Returns true when every value admitted by the domain facts produces zero
+// iterations. The proof requires a positive integer step and lower_bound >=
+// upper_bound for the complete fact ranges.
+bool loom_loop_domain_proven_empty(const loom_value_fact_table_t* fact_table,
+                                   loom_loop_domain_t domain);
+
+// Returns true when every value admitted by the domain facts produces at least
+// one iteration. The proof requires a positive integer step and lower_bound <
+// upper_bound for the complete fact ranges.
+bool loom_loop_domain_proven_nonempty(const loom_value_fact_table_t* fact_table,
+                                      loom_loop_domain_t domain);
+
 #ifdef __cplusplus
 }
 #endif

--- a/loom/src/loom/analysis/loop_domain_test.cc
+++ b/loom/src/loom/analysis/loop_domain_test.cc
@@ -122,5 +122,61 @@ TEST_F(LoopDomainTest, FloatFactsDoNotProveEquality) {
   EXPECT_FALSE(loom_loop_domain_equal(&fact_table_, lhs, rhs));
 }
 
+TEST_F(LoopDomainTest, RangeFactsProveNonemptyDomain) {
+  DefineFacts(1, loom_value_facts_make(0, 4, 1));
+  DefineFacts(2, loom_value_facts_make(8, 16, 1));
+  DefineFacts(3, loom_value_facts_make(1, 4, 1));
+  loom_loop_domain_t domain = {
+      /*.lower_bound=*/1,
+      /*.upper_bound=*/2,
+      /*.step=*/3,
+  };
+
+  EXPECT_TRUE(loom_loop_domain_proven_nonempty(&fact_table_, domain));
+  EXPECT_FALSE(loom_loop_domain_proven_empty(&fact_table_, domain));
+}
+
+TEST_F(LoopDomainTest, RangeFactsProveEmptyDomain) {
+  DefineFacts(1, loom_value_facts_make(16, 24, 1));
+  DefineFacts(2, loom_value_facts_make(0, 16, 1));
+  DefineFacts(3, loom_value_facts_exact_i64(1));
+  loom_loop_domain_t domain = {
+      /*.lower_bound=*/1,
+      /*.upper_bound=*/2,
+      /*.step=*/3,
+  };
+
+  EXPECT_TRUE(loom_loop_domain_proven_empty(&fact_table_, domain));
+  EXPECT_FALSE(loom_loop_domain_proven_nonempty(&fact_table_, domain));
+}
+
+TEST_F(LoopDomainTest, OverlappingBoundsProveNeitherDomainState) {
+  DefineFacts(1, loom_value_facts_make(0, 12, 1));
+  DefineFacts(2, loom_value_facts_make(8, 16, 1));
+  DefineFacts(3, loom_value_facts_exact_i64(1));
+  loom_loop_domain_t domain = {
+      /*.lower_bound=*/1,
+      /*.upper_bound=*/2,
+      /*.step=*/3,
+  };
+
+  EXPECT_FALSE(loom_loop_domain_proven_empty(&fact_table_, domain));
+  EXPECT_FALSE(loom_loop_domain_proven_nonempty(&fact_table_, domain));
+}
+
+TEST_F(LoopDomainTest, NonpositiveStepProvesNeitherDomainState) {
+  DefineFacts(1, loom_value_facts_exact_i64(0));
+  DefineFacts(2, loom_value_facts_exact_i64(16));
+  DefineFacts(3, loom_value_facts_exact_i64(0));
+  loom_loop_domain_t domain = {
+      /*.lower_bound=*/1,
+      /*.upper_bound=*/2,
+      /*.step=*/3,
+  };
+
+  EXPECT_FALSE(loom_loop_domain_proven_empty(&fact_table_, domain));
+  EXPECT_FALSE(loom_loop_domain_proven_nonempty(&fact_table_, domain));
+}
+
 }  // namespace
 }  // namespace loom

--- a/loom/src/loom/analysis/motion.c
+++ b/loom/src/loom/analysis/motion.c
@@ -6,6 +6,8 @@
 
 #include "loom/analysis/motion.h"
 
+#include "loom/analysis/loop_domain.h"
+#include "loom/ir/context.h"
 #include "loom/ir/module.h"
 
 //===----------------------------------------------------------------------===//
@@ -45,12 +47,22 @@ static loom_region_t* loom_motion_region_stack_pop(
 //===----------------------------------------------------------------------===//
 
 iree_status_t loom_motion_analysis_initialize(
-    const loom_module_t* module, iree_arena_allocator_t* arena,
-    loom_motion_analysis_t* out_analysis) {
-  out_analysis->module = module;
-  out_analysis->arena = arena;
+    const loom_module_t* module, loom_value_fact_table_t* fact_table,
+    const loom_local_value_domain_t* value_domain,
+    iree_arena_allocator_t* arena, loom_motion_analysis_t* out_analysis) {
+  *out_analysis = (loom_motion_analysis_t){
+      .module = module,
+      .arena = arena,
+      .fact_table = fact_table,
+      .value_domain = value_domain,
+  };
   IREE_RETURN_IF_ERROR(loom_availability_analysis_initialize(
       module, arena, &out_analysis->availability));
+  if (fact_table && value_domain) {
+    IREE_RETURN_IF_ERROR(loom_movement_analysis_initialize(
+        fact_table, value_domain, arena, &out_analysis->movement));
+    out_analysis->movement_initialized = true;
+  }
   return loom_motion_region_stack_initialize(arena,
                                              &out_analysis->region_stack);
 }
@@ -254,4 +266,305 @@ iree_status_t loom_motion_subtree_can_speculate_before(
   return loom_motion_subtree_can_move_before(analysis, candidate_op, before_op,
                                              LOOM_MOTION_POLICY_SPECULATION,
                                              out_can_speculate);
+}
+
+//===----------------------------------------------------------------------===//
+// Loop hoist evaluation
+//===----------------------------------------------------------------------===//
+
+static void loom_motion_loop_hoist_reject(
+    loom_motion_loop_hoist_result_t* result,
+    loom_motion_loop_hoist_rejection_flags_t rejection,
+    const loom_op_t* blocking_op) {
+  result->rejection_bits |= rejection;
+  if (!result->blocking_op) result->blocking_op = blocking_op;
+}
+
+static iree_status_t loom_motion_analysis_ensure_movement(
+    loom_motion_analysis_t* analysis, bool* out_available) {
+  *out_available = analysis->movement_initialized;
+  if (!*out_available || analysis->movement_analyzed) {
+    return iree_ok_status();
+  }
+  IREE_RETURN_IF_ERROR(loom_movement_analysis_analyze(&analysis->movement));
+  analysis->movement_analyzed = true;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_motion_evaluate_speculative_subtree(
+    loom_motion_analysis_t* analysis, const loom_op_t* candidate_op,
+    const loom_op_t* loop_op, loom_motion_loop_hoist_result_t* result) {
+  if (!loom_motion_op_can_speculate(analysis->module, candidate_op)) {
+    loom_motion_loop_hoist_reject(
+        result, LOOM_MOTION_LOOP_HOIST_REJECTION_CANDIDATE_SEMANTICS,
+        candidate_op);
+    return iree_ok_status();
+  }
+  bool captures_available = false;
+  IREE_RETURN_IF_ERROR(loom_availability_op_captures_are_available_before_op(
+      &analysis->availability, candidate_op, loop_op, candidate_op,
+      &captures_available));
+  if (!captures_available) {
+    loom_motion_loop_hoist_reject(
+        result, LOOM_MOTION_LOOP_HOIST_REJECTION_CAPTURE_UNAVAILABLE,
+        candidate_op);
+    return iree_ok_status();
+  }
+  bool can_speculate = false;
+  IREE_RETURN_IF_ERROR(loom_motion_subtree_can_speculate_before(
+      analysis, candidate_op, loop_op, &can_speculate));
+  if (!can_speculate) {
+    loom_motion_loop_hoist_reject(
+        result, LOOM_MOTION_LOOP_HOIST_REJECTION_CANDIDATE_SEMANTICS,
+        candidate_op);
+  }
+  return iree_ok_status();
+}
+
+static bool loom_motion_op_is_ordinary_load_candidate(
+    const loom_module_t* module, const loom_op_t* op) {
+  if (!module || !op || iree_any_bit_set(op->flags, LOOM_OP_FLAG_DEAD) ||
+      op->region_count != 0 || op->tied_result_count != 0) {
+    return false;
+  }
+  const loom_trait_flags_t traits = loom_op_effective_traits(module, op);
+  if (!loom_traits_may_read(traits) || loom_traits_may_write(traits) ||
+      iree_any_bit_set(
+          traits, LOOM_TRAIT_TERMINATOR | LOOM_TRAIT_HINT |
+                      LOOM_TRAIT_CONVERGENT | LOOM_TRAIT_UNIQUE_IDENTITY |
+                      LOOM_TRAIT_POISON_BOUNDARY | LOOM_TRAIT_MEMORY_FENCE |
+                      LOOM_TRAIT_NON_DETERMINISTIC |
+                      LOOM_TRAIT_UNKNOWN_EFFECTS)) {
+    return false;
+  }
+  const loom_memory_access_t access = loom_memory_access_cast(module, op);
+  return loom_memory_access_isa(access) &&
+         loom_memory_access_operation_kind(access) ==
+             LOOM_MEMORY_ACCESS_OPERATION_LOAD;
+}
+
+static bool loom_motion_request_is_ordinary_load(
+    const loom_movement_request_t* request) {
+  if (!request || request->source.kind != LOOM_MOVEMENT_ENDPOINT_VIEW) {
+    return false;
+  }
+  if (request->kind != LOOM_MOVEMENT_KIND_VIEW_LOAD &&
+      request->kind != LOOM_MOVEMENT_KIND_VECTOR_LOAD) {
+    return false;
+  }
+  return !iree_any_bit_set(request->flags,
+                           LOOM_MOVEMENT_REQUEST_MASKED |
+                               LOOM_MOVEMENT_REQUEST_ASYNC |
+                               LOOM_MOVEMENT_REQUEST_IRREGULAR_OFFSETS);
+}
+
+// Queries the conventional memory-space domain carried by a fence op. The
+// MemoryFence trait itself remains conservative: a fence with no precise
+// memory_space enum is treated as ordering every memory space. This keeps the
+// legality layer target-neutral without requiring it to recognize each
+// dialect's concrete fence operation.
+static bool loom_motion_memory_fence_space(
+    const loom_module_t* module, const loom_op_t* op,
+    loom_value_fact_memory_space_t* out_memory_space) {
+  *out_memory_space = LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN;
+  if (!module || !op ||
+      !loom_traits_order_memory(loom_op_effective_traits(module, op))) {
+    return false;
+  }
+  const loom_op_vtable_t* vtable = loom_op_vtable(module, op);
+  if (!vtable || !vtable->attr_descriptors) return false;
+  for (uint8_t i = 0; i < vtable->attribute_count && i < op->attribute_count;
+       ++i) {
+    const loom_attr_descriptor_t* descriptor = &vtable->attr_descriptors[i];
+    if (descriptor->attr_kind != LOOM_ATTR_ENUM ||
+        !iree_string_view_equal(loom_attr_descriptor_name(descriptor),
+                                IREE_SV("memory_space"))) {
+      continue;
+    }
+    const loom_attribute_t attr = loom_op_const_attrs(op)[i];
+    if (attr.kind != LOOM_ATTR_ENUM) return false;
+    const uint8_t value = loom_attr_as_enum(attr);
+    if (value > LOOM_VALUE_FACT_MEMORY_SPACE_GENERIC) return false;
+    *out_memory_space = (loom_value_fact_memory_space_t)value;
+    return true;
+  }
+  return false;
+}
+
+static iree_status_t loom_motion_loop_writes_are_disjoint(
+    loom_motion_analysis_t* analysis, loom_loop_like_t loop,
+    const loom_op_t* candidate_op,
+    const loom_movement_endpoint_t* read_endpoint,
+    loom_motion_loop_hoist_result_t* result) {
+  loom_view_region_t read_region = {0};
+  if (!loom_movement_endpoint_as_view_region(read_endpoint, &read_region)) {
+    loom_motion_loop_hoist_reject(
+        result, LOOM_MOTION_LOOP_HOIST_REJECTION_MOVEMENT_UNAVAILABLE,
+        candidate_op);
+    return iree_ok_status();
+  }
+
+  analysis->region_stack.count = 0;
+  IREE_RETURN_IF_ERROR(loom_motion_region_stack_push(
+      analysis->arena, &analysis->region_stack, loom_loop_like_body(loop)));
+  while (true) {
+    loom_region_t* region =
+        loom_motion_region_stack_pop(&analysis->region_stack);
+    if (!region) break;
+
+    loom_block_t* block = NULL;
+    loom_region_for_each_block(region, block) {
+      loom_op_t* op = NULL;
+      loom_block_for_each_op(block, op) {
+        if (op == candidate_op ||
+            iree_any_bit_set(op->flags, LOOM_OP_FLAG_DEAD)) {
+          continue;
+        }
+        const loom_trait_flags_t traits =
+            loom_op_effective_traits(analysis->module, op);
+        if (iree_any_bit_set(traits, LOOM_TRAIT_UNKNOWN_EFFECTS)) {
+          loom_motion_loop_hoist_reject(
+              result, LOOM_MOTION_LOOP_HOIST_REJECTION_UNKNOWN_INTERFERENCE,
+              op);
+          return iree_ok_status();
+        }
+        if (loom_traits_order_memory(traits)) {
+          loom_value_fact_memory_space_t fence_memory_space =
+              LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN;
+          if (!loom_motion_memory_fence_space(analysis->module, op,
+                                              &fence_memory_space) ||
+              !loom_view_memory_spaces_are_disjoint(read_region.memory_space,
+                                                    fence_memory_space)) {
+            loom_motion_loop_hoist_reject(
+                result, LOOM_MOTION_LOOP_HOIST_REJECTION_ORDERING_INTERFERENCE,
+                op);
+            return iree_ok_status();
+          }
+        }
+        if (iree_any_bit_set(traits, LOOM_TRAIT_WRITES_MEMORY)) {
+          loom_movement_request_t request = {0};
+          loom_movement_diagnostic_t diagnostic = {0};
+          bool described = false;
+          IREE_RETURN_IF_ERROR(loom_movement_request_describe_op(
+              &analysis->movement, op, &request, &diagnostic, &described));
+          if (!described || request.dest.kind != LOOM_MOVEMENT_ENDPOINT_VIEW ||
+              !iree_any_bit_set(request.dest.flags,
+                                LOOM_MOVEMENT_ENDPOINT_WRITE)) {
+            result->movement_rejection_bits |= diagnostic.rejection_bits;
+            loom_motion_loop_hoist_reject(
+                result, LOOM_MOTION_LOOP_HOIST_REJECTION_UNKNOWN_INTERFERENCE,
+                op);
+            return iree_ok_status();
+          }
+          loom_view_region_t write_region = {0};
+          if (!loom_movement_endpoint_as_view_region(&request.dest,
+                                                     &write_region)) {
+            loom_motion_loop_hoist_reject(
+                result, LOOM_MOTION_LOOP_HOIST_REJECTION_UNKNOWN_INTERFERENCE,
+                op);
+            return iree_ok_status();
+          }
+          bool no_overlap = false;
+          IREE_RETURN_IF_ERROR(loom_view_regions_prove_no_overlap(
+              &analysis->movement.view_regions, &read_region, &write_region,
+              &no_overlap));
+          if (!no_overlap) {
+            loom_motion_loop_hoist_reject(
+                result, LOOM_MOTION_LOOP_HOIST_REJECTION_OVERLAPPING_WRITE, op);
+            return iree_ok_status();
+          }
+        }
+
+        loom_region_t** child_regions = loom_op_regions(op);
+        for (uint8_t i = 0; i < op->region_count; ++i) {
+          IREE_RETURN_IF_ERROR(loom_motion_region_stack_push(
+              analysis->arena, &analysis->region_stack, child_regions[i]));
+        }
+      }
+    }
+  }
+  return iree_ok_status();
+}
+
+iree_status_t loom_motion_subtree_evaluate_hoist_before_loop(
+    loom_motion_analysis_t* analysis, loom_loop_like_t loop,
+    const loom_op_t* candidate_op,
+    loom_motion_loop_hoist_result_t* out_result) {
+  *out_result = (loom_motion_loop_hoist_result_t){0};
+  if (!analysis || !analysis->module || !loom_loop_like_isa(loop) ||
+      !candidate_op || !loop.op || candidate_op == loop.op ||
+      iree_any_bit_set(loop.op->flags, LOOM_OP_FLAG_DEAD)) {
+    loom_motion_loop_hoist_reject(
+        out_result, LOOM_MOTION_LOOP_HOIST_REJECTION_INVALID_REQUEST,
+        candidate_op);
+    return iree_ok_status();
+  }
+
+  if (!loom_motion_op_is_ordinary_load_candidate(analysis->module,
+                                                 candidate_op)) {
+    return loom_motion_evaluate_speculative_subtree(analysis, candidate_op,
+                                                    loop.op, out_result);
+  }
+
+  loom_region_t* loop_body = loom_loop_like_body(loop);
+  if (!loop_body || !candidate_op->parent_block ||
+      candidate_op->parent_block->parent_region != loop_body) {
+    loom_motion_loop_hoist_reject(
+        out_result, LOOM_MOTION_LOOP_HOIST_REJECTION_PREDICATE_CROSSING,
+        candidate_op);
+    return iree_ok_status();
+  }
+  if (!loom_loop_like_has_counted_range(loop)) {
+    loom_motion_loop_hoist_reject(
+        out_result, LOOM_MOTION_LOOP_HOIST_REJECTION_LOOP_MAY_NOT_EXECUTE,
+        loop.op);
+    return iree_ok_status();
+  }
+  const loom_loop_domain_t domain = {
+      .lower_bound = loom_loop_like_lower_bound(loop),
+      .upper_bound = loom_loop_like_upper_bound(loop),
+      .step = loom_loop_like_step(loop),
+  };
+  if (!loom_loop_domain_proven_nonempty(analysis->fact_table, domain)) {
+    loom_motion_loop_hoist_reject(
+        out_result, LOOM_MOTION_LOOP_HOIST_REJECTION_LOOP_MAY_NOT_EXECUTE,
+        loop.op);
+    return iree_ok_status();
+  }
+
+  bool captures_available = false;
+  IREE_RETURN_IF_ERROR(loom_availability_op_captures_are_available_before_op(
+      &analysis->availability, candidate_op, loop.op, candidate_op,
+      &captures_available));
+  if (!captures_available) {
+    loom_motion_loop_hoist_reject(
+        out_result, LOOM_MOTION_LOOP_HOIST_REJECTION_CAPTURE_UNAVAILABLE,
+        candidate_op);
+    return iree_ok_status();
+  }
+
+  bool movement_available = false;
+  IREE_RETURN_IF_ERROR(
+      loom_motion_analysis_ensure_movement(analysis, &movement_available));
+  if (!movement_available) {
+    loom_motion_loop_hoist_reject(
+        out_result, LOOM_MOTION_LOOP_HOIST_REJECTION_MOVEMENT_UNAVAILABLE,
+        candidate_op);
+    return iree_ok_status();
+  }
+
+  loom_movement_request_t request = {0};
+  loom_movement_diagnostic_t diagnostic = {0};
+  bool described = false;
+  IREE_RETURN_IF_ERROR(loom_movement_request_describe_op(
+      &analysis->movement, candidate_op, &request, &diagnostic, &described));
+  if (!described || !loom_motion_request_is_ordinary_load(&request)) {
+    out_result->movement_rejection_bits = diagnostic.rejection_bits;
+    loom_motion_loop_hoist_reject(
+        out_result, LOOM_MOTION_LOOP_HOIST_REJECTION_MOVEMENT_UNAVAILABLE,
+        candidate_op);
+    return iree_ok_status();
+  }
+  return loom_motion_loop_writes_are_disjoint(analysis, loop, candidate_op,
+                                              &request.source, out_result);
 }

--- a/loom/src/loom/analysis/motion.h
+++ b/loom/src/loom/analysis/motion.h
@@ -33,7 +33,9 @@
 #include "iree/base/api.h"
 #include "iree/base/internal/arena.h"
 #include "loom/analysis/availability.h"
+#include "loom/analysis/movement.h"
 #include "loom/ir/ir.h"
+#include "loom/ir/local_value_domain.h"
 #include "loom/ops/op_defs.h"
 
 #ifdef __cplusplus
@@ -58,17 +60,75 @@ typedef struct loom_motion_analysis_t {
   const loom_module_t* module;
   // Scratch arena used for temporary traversal stacks.
   iree_arena_allocator_t* arena;
+  // Function facts used for counted-loop and symbolic memory proofs.
+  loom_value_fact_table_t* fact_table;
+  // Active function-local value domain backing movement analysis.
+  const loom_local_value_domain_t* value_domain;
   // Value, type, and attribute capture availability queries.
   loom_availability_analysis_t availability;
+  // Lazily populated source memory movement analysis.
+  loom_movement_analysis_t movement;
+  // True when movement owns initialized analysis storage.
+  bool movement_initialized;
+  // True when the movement table has analyzed the local region tree.
+  bool movement_analyzed;
   // Reusable stack for subtree region walks.
   loom_motion_region_stack_t region_stack;
 } loom_motion_analysis_t;
 
-// Initializes shared motion analysis state. The caller owns |arena| and must
-// keep it live for the analysis object's lifetime.
+// Initializes shared motion analysis state. |fact_table| and |value_domain| may
+// both be NULL for effect-free relocation clients. Memory-aware loop placement
+// requires both. The caller owns all borrowed state and must keep it live for
+// the analysis object's lifetime.
 iree_status_t loom_motion_analysis_initialize(
-    const loom_module_t* module, iree_arena_allocator_t* arena,
-    loom_motion_analysis_t* out_analysis);
+    const loom_module_t* module, loom_value_fact_table_t* fact_table,
+    const loom_local_value_domain_t* value_domain,
+    iree_arena_allocator_t* arena, loom_motion_analysis_t* out_analysis);
+
+//===----------------------------------------------------------------------===//
+// Loop hoist evaluation
+//===----------------------------------------------------------------------===//
+
+typedef uint32_t loom_motion_loop_hoist_rejection_flags_t;
+
+#define LOOM_MOTION_LOOP_HOIST_REJECTION_INVALID_REQUEST ((uint32_t)1u << 0)
+#define LOOM_MOTION_LOOP_HOIST_REJECTION_CANDIDATE_SEMANTICS ((uint32_t)1u << 1)
+#define LOOM_MOTION_LOOP_HOIST_REJECTION_CAPTURE_UNAVAILABLE ((uint32_t)1u << 2)
+#define LOOM_MOTION_LOOP_HOIST_REJECTION_PREDICATE_CROSSING ((uint32_t)1u << 3)
+#define LOOM_MOTION_LOOP_HOIST_REJECTION_LOOP_MAY_NOT_EXECUTE \
+  ((uint32_t)1u << 4)
+#define LOOM_MOTION_LOOP_HOIST_REJECTION_MOVEMENT_UNAVAILABLE \
+  ((uint32_t)1u << 5)
+#define LOOM_MOTION_LOOP_HOIST_REJECTION_UNKNOWN_INTERFERENCE \
+  ((uint32_t)1u << 6)
+#define LOOM_MOTION_LOOP_HOIST_REJECTION_OVERLAPPING_WRITE ((uint32_t)1u << 7)
+#define LOOM_MOTION_LOOP_HOIST_REJECTION_ORDERING_INTERFERENCE \
+  ((uint32_t)1u << 8)
+
+// Stable legality result consumed by LICM and the placement planner.
+typedef struct loom_motion_loop_hoist_result_t {
+  // Bitset of loom_motion_loop_hoist_rejection_flags_t values. Zero means the
+  // motion is legal.
+  loom_motion_loop_hoist_rejection_flags_t rejection_bits;
+  // Movement classifier details when MOVEMENT_UNAVAILABLE is set.
+  loom_movement_rejection_flags_t movement_rejection_bits;
+  // First operation proving the rejection, or NULL when no op applies.
+  const loom_op_t* blocking_op;
+} loom_motion_loop_hoist_result_t;
+
+static inline bool loom_motion_loop_hoist_result_is_legal(
+    const loom_motion_loop_hoist_result_t* result) {
+  return result && result->rejection_bits == 0;
+}
+
+// Evaluates moving |candidate_op| immediately before |loop.op|. Effect-free
+// subtrees must be safe to speculate because the loop may execute zero times.
+// Ordinary unmasked view/vector loads may instead use a proven-nonempty loop
+// contract when every write in the loop is proven disjoint from the loaded byte
+// region. Loads nested under another predicate remain in place.
+iree_status_t loom_motion_subtree_evaluate_hoist_before_loop(
+    loom_motion_analysis_t* analysis, loom_loop_like_t loop,
+    const loom_op_t* candidate_op, loom_motion_loop_hoist_result_t* out_result);
 
 //===----------------------------------------------------------------------===//
 // Local classification

--- a/loom/src/loom/analysis/motion_test.cc
+++ b/loom/src/loom/analysis/motion_test.cc
@@ -90,8 +90,9 @@ class MotionTest : public ::testing::Test {
 
   void PrepareMotionAnalysis() {
     IREE_ASSERT_OK(loom_module_compute_uses(module_));
-    IREE_ASSERT_OK(
-        loom_motion_analysis_initialize(module_, &motion_arena_, &motion_));
+    IREE_ASSERT_OK(loom_motion_analysis_initialize(
+        module_, /*fact_table=*/nullptr, /*value_domain=*/nullptr,
+        &motion_arena_, &motion_));
   }
 
   iree_status_t QueryRelocateBefore(loom_op_t* candidate_op,

--- a/loom/src/loom/analysis/view_regions.c
+++ b/loom/src/loom/analysis/view_regions.c
@@ -951,7 +951,7 @@ loom_view_access_flags_t loom_view_region_table_root_access_flags(
   return access_flags;
 }
 
-static bool loom_view_region_memory_spaces_are_disjoint(
+bool loom_view_memory_spaces_are_disjoint(
     loom_value_fact_memory_space_t left, loom_value_fact_memory_space_t right) {
   if (left == right || left == LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN ||
       right == LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN ||
@@ -975,8 +975,8 @@ iree_status_t loom_view_regions_prove_no_overlap(
     return iree_ok_status();
   }
   if (left_region->root_value_id != right_region->root_value_id) {
-    if (loom_view_region_memory_spaces_are_disjoint(
-            left_region->memory_space, right_region->memory_space) ||
+    if (loom_view_memory_spaces_are_disjoint(left_region->memory_space,
+                                             right_region->memory_space) ||
         (left_region->alias_scope_id != LOOM_VALUE_FACT_ALIAS_SCOPE_ID_NONE &&
          right_region->alias_scope_id != LOOM_VALUE_FACT_ALIAS_SCOPE_ID_NONE &&
          left_region->alias_scope_id != right_region->alias_scope_id)) {

--- a/loom/src/loom/analysis/view_regions.h
+++ b/loom/src/loom/analysis/view_regions.h
@@ -198,6 +198,12 @@ iree_status_t loom_view_region_table_analyze(loom_view_region_table_t* table);
 loom_view_access_flags_t loom_view_region_table_root_access_flags(
     const loom_view_region_table_t* table, loom_value_id_t root_value_id);
 
+// Returns true when two concrete memory spaces cannot name the same storage.
+// Unknown and generic spaces remain conservative, as do distinct global-like
+// spaces whose target representations may overlap.
+bool loom_view_memory_spaces_are_disjoint(loom_value_fact_memory_space_t left,
+                                          loom_value_fact_memory_space_t right);
+
 // Attempts to prove that two view regions cannot overlap. Same-root regions
 // use symbolic byte intervals. Distinct roots are disjoint when their concrete
 // memory spaces cannot alias or both carry comparable and different alias

--- a/loom/src/loom/transforms/cfg/branch_sink.c
+++ b/loom/src/loom/transforms/cfg/branch_sink.c
@@ -444,8 +444,9 @@ iree_status_t loom_branch_sink_run(loom_pass_t* pass, loom_module_t* module,
   iree_status_t status = loom_branch_sink_region_stack_initialize(
       pass->arena, &context.region_stack);
   if (iree_status_is_ok(status)) {
-    status =
-        loom_motion_analysis_initialize(module, pass->arena, &context.motion);
+    status = loom_motion_analysis_initialize(module, /*fact_table=*/NULL,
+                                             /*value_domain=*/NULL, pass->arena,
+                                             &context.motion);
   }
 
   bool changed = true;

--- a/loom/src/loom/transforms/loop/BUILD.bazel
+++ b/loom/src/loom/transforms/loop/BUILD.bazel
@@ -21,6 +21,7 @@ loom_cc_library(
         "//loom/src/loom/ir",
         "//loom/src/loom/ops:op_defs",
         "//loom/src/loom/pass:types",
+        "//loom/src/loom/pass:value_facts",
         "//loom/src/loom/rewrite:rewriter",
         "//runtime/src/iree/base",
     ],

--- a/loom/src/loom/transforms/loop/CMakeLists.txt
+++ b/loom/src/loom/transforms/loop/CMakeLists.txt
@@ -22,6 +22,7 @@ loom_cc_library(
     loom::ir
     loom::ops::op_defs
     loom::pass::types
+    loom::pass::value_facts
     loom::rewrite::rewriter
   PUBLIC
 )

--- a/loom/src/loom/transforms/loop/licm.c
+++ b/loom/src/loom/transforms/loop/licm.c
@@ -8,8 +8,10 @@
 
 #include "loom/analysis/motion.h"
 #include "loom/ir/context.h"
+#include "loom/ir/local_value_domain.h"
 #include "loom/ir/module.h"
 #include "loom/ops/op_defs.h"
+#include "loom/pass/value_facts.h"
 #include "loom/rewrite/rewriter.h"
 
 #define LOOM_LICM_STATISTICS(V, statistics_type)     \
@@ -23,7 +25,8 @@ LOOM_PASS_STATISTICS_DEFINE(loom_licm_statistics, loom_licm_statistics_t,
 
 static const loom_pass_info_t loom_licm_pass_info_storage = {
     .name = IREE_SVL("licm"),
-    .description = IREE_SVL("Hoist loop-invariant speculatable operations."),
+    .description =
+        IREE_SVL("Hoist loop-invariant operations with proven legality."),
     .kind = LOOM_PASS_FUNCTION,
     .statistic_layout = &loom_licm_statistics_layout,
 };
@@ -84,6 +87,10 @@ typedef struct loom_licm_context_t {
   loom_rewriter_t* rewriter;
   // Shared motion legality analysis.
   loom_motion_analysis_t motion;
+  // Function-local value domain backing symbolic movement analysis.
+  loom_local_value_domain_t value_domain;
+  // Function facts used for counted-loop and alias proofs.
+  loom_value_fact_table_t* fact_table;
   // Region DFS stack for finding loop-like ops in the function.
   loom_licm_region_stack_t function_stack;
   // Region DFS stack for scanning one loop body for hoistable ops.
@@ -98,11 +105,12 @@ static iree_status_t loom_licm_op_is_hoistable(loom_licm_context_t* context,
                                                loom_op_t* loop_op,
                                                loom_op_t* candidate_op,
                                                bool* out_hoistable) {
-  // Moving before the loop may execute a candidate when the body never runs,
-  // and coalesces repeated body executions into one. Even an exact single-trip
-  // loop can move a potentially trapping op ahead of observable body work.
-  return loom_motion_subtree_can_speculate_before(
-      &context->motion, candidate_op, loop_op, out_hoistable);
+  const loom_loop_like_t loop = loom_loop_like_cast(context->module, loop_op);
+  loom_motion_loop_hoist_result_t result = {0};
+  IREE_RETURN_IF_ERROR(loom_motion_subtree_evaluate_hoist_before_loop(
+      &context->motion, loop, candidate_op, &result));
+  *out_hoistable = loom_motion_loop_hoist_result_is_legal(&result);
+  return iree_ok_status();
 }
 
 static iree_status_t loom_licm_push_child_regions(
@@ -223,8 +231,19 @@ iree_status_t loom_licm_run(loom_pass_t* pass, loom_module_t* module,
         loom_licm_region_stack_initialize(pass->arena, &context.loop_stack);
   }
   if (iree_status_is_ok(status)) {
-    status =
-        loom_motion_analysis_initialize(module, pass->arena, &context.motion);
+    status = loom_local_value_domain_acquire_for_region_tree(
+        module, loom_func_like_body(function), pass->arena,
+        &context.value_domain);
+  }
+  if (iree_status_is_ok(status)) {
+    status = loom_pass_value_facts_acquire(
+        pass, module, loom_pass_value_fact_scope_function(function),
+        &context.fact_table);
+  }
+  if (iree_status_is_ok(status)) {
+    status = loom_motion_analysis_initialize(module, context.fact_table,
+                                             &context.value_domain, pass->arena,
+                                             &context.motion);
   }
 
   bool changed = true;
@@ -238,6 +257,7 @@ iree_status_t loom_licm_run(loom_pass_t* pass, loom_module_t* module,
   if (iree_status_is_ok(status) && any_changed) {
     loom_pass_mark_changed(pass);
   }
+  loom_local_value_domain_release(&context.value_domain);
   loom_rewriter_deinitialize(&rewriter);
   return status;
 }

--- a/loom/src/loom/transforms/loop/test/licm.loom-test
+++ b/loom/src/loom/transforms/loop/test/licm.loom-test
@@ -249,3 +249,388 @@ func.def @keeps_while_effects_inside_after(%cond: i1, %init: i32) -> (i32) {
   }
   func.return %result : i32
 }
+
+// ====
+
+// A direct load in a proven-nonempty counted loop executes on every valid
+// source path. With no writes to its storage, it may be materialized once in
+// the loop preheader.
+func.def @hoists_immutable_scalar_load(%input: view<8xi32, #dense>, %initial: i32) -> (i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    %value = view.load %input[3] : view<8xi32, #dense> -> i32
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ----
+func.def @hoists_immutable_scalar_load(%input: view<8xi32, #dense>, %initial: i32) -> (i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %value = view.load %input[3] : view<8xi32, #dense> -> i32
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+// The address may remain symbolic as long as every captured value is
+// available at the preheader and the one-element footprint is representable.
+func.def @hoists_immutable_dynamic_scalar_load(%input: view<8xi32, #dense>, %index: index, %initial: i32) -> (i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    %value = view.load %input[%index] : view<8xi32, #dense> -> i32
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ----
+func.def @hoists_immutable_dynamic_scalar_load(%input: view<8xi32, #dense>, %index: index, %initial: i32) -> (i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %value = view.load %input[%index] : view<8xi32, #dense> -> i32
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+// An address derived from the induction variable is not available at the
+// preheader even when the loop is guaranteed to execute.
+func.def @keeps_loop_variant_scalar_load(%input: view<8xi32, #dense>, %initial: i32) -> (i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    %value = view.load %input[%iv] : view<8xi32, #dense> -> i32
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+// The same byte-region proof applies to ordinary unmasked vector loads.
+func.def @hoists_immutable_vector_load(%input: view<8xi32, #dense>, %initial: vector<4xi32>) -> (vector<4xi32>) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : vector<4xi32>) -> (vector<4xi32>) {
+    %value = vector.load %input[0] : view<8xi32, #dense> -> vector<4xi32>
+    scf.yield %value : vector<4xi32>
+  }
+  func.return %result : vector<4xi32>
+}
+
+// ----
+func.def @hoists_immutable_vector_load(%input: view<8xi32, #dense>, %initial: vector<4xi32>) -> (vector<4xi32>) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %value = vector.load %input[0] : view<8xi32, #dense> -> vector<4xi32>
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : vector<4xi32>) -> (vector<4xi32>) {
+    scf.yield %value : vector<4xi32>
+  }
+  func.return %result : vector<4xi32>
+}
+
+// ====
+
+// Subviews and refinements preserve the root-relative byte interval needed by
+// the motion proof.
+func.def @hoists_load_from_transformed_view(%input: buffer, %initial: i32) -> (i32) {
+  %offset = index.constant 0 : offset
+  %input_view = buffer.view %input[%offset] : buffer -> view<8xi32, #dense>
+  %input_subview = view.subview %input_view[2] : view<8xi32, #dense> -> view<4xi32, #dense>
+  %input_refined = view.refine %input_subview : view<4xi32, #dense> -> view<4xi32, #dense>
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    %value = view.load %input_refined[1] : view<4xi32, #dense> -> i32
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ----
+func.def @hoists_load_from_transformed_view(%input: buffer, %initial: i32) -> (i32) {
+  %offset = index.constant 0 : offset
+  %input_view = buffer.view %input[%offset] : buffer -> view<8xi32, #dense>
+  %input_subview = view.subview %input_view[2] : view<8xi32, #dense> -> view<4xi32, #dense>
+  %input_refined = view.refine %input_subview : view<4xi32, #dense> -> view<4xi32, #dense>
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %value = view.load %input_refined[1] : view<4xi32, #dense> -> i32
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+// A loop with an unknown trip count does not make the load address part of the
+// function's required valid-access domain, so the load remains guarded by the
+// loop predicate.
+func.def @keeps_load_in_maybe_empty_loop(%input: view<8xi32, #dense>, %n: index, %initial: i32) -> (i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %result = scf.for %iv = [%zero to %n step %one](%carry = %initial : i32) -> (i32) {
+    %value = view.load %input[3] : view<8xi32, #dense> -> i32
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+// A condition nested inside the loop adds another execution predicate. Even a
+// nonempty loop does not prove that the read executes.
+func.def @keeps_conditionally_executed_load(%input: view<8xi32, #dense>, %condition: i1, %initial: i32) -> (i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    %next = scf.if %condition -> (i32) {
+      %value = view.load %input[3] : view<8xi32, #dense> -> i32
+      scf.yield %value : i32
+    } else {
+      scf.yield %carry : i32
+    }
+    scf.yield %next : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+// Exact same-root byte regions allow a read to cross a disjoint write.
+func.def @hoists_load_across_disjoint_store(%storage: view<8xi32, #dense>, %replacement: i32, %initial: i32) -> (i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    %value = view.load %storage[0] : view<8xi32, #dense> -> i32
+    view.store %replacement, %storage[4] : i32, view<8xi32, #dense>
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ----
+func.def @hoists_load_across_disjoint_store(%storage: view<8xi32, #dense>, %replacement: i32, %initial: i32) -> (i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %value = view.load %storage[0] : view<8xi32, #dense> -> i32
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    view.store %replacement, %storage[4] : i32, view<8xi32, #dense>
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+// A write to the loaded byte region changes the value observed by later loop
+// iterations and blocks hoisting.
+func.def @keeps_load_with_overlapping_store(%storage: view<8xi32, #dense>, %replacement: i32, %initial: i32) -> (i32) {
+  %zero = index.constant 0 : index
+  %two = index.constant 2 : index
+  %one = index.constant 1 : index
+  %result = scf.for %iv = [%zero to %two step %one](%carry = %initial : i32) -> (i32) {
+    %value = view.load %storage[0] : view<8xi32, #dense> -> i32
+    view.store %replacement, %storage[0] : i32, view<8xi32, #dense>
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+// Writes nested under another structured predicate still participate in the
+// loop-wide interference proof.
+func.def @keeps_load_with_nested_overlapping_store(%storage: view<8xi32, #dense>, %replacement: i32, %condition: i1, %initial: i32) -> (i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    %value = view.load %storage[0] : view<8xi32, #dense> -> i32
+    scf.if %condition {
+      view.store %replacement, %storage[0] : i32, view<8xi32, #dense>
+    }
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+// Interference in a nested loop is part of the enclosing loop interval.
+func.def @keeps_load_with_nested_loop_write(%storage: view<8xi32, #dense>, %replacement: i32, %initial: i32) -> (i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %result = scf.for %outer = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    %value = view.load %storage[0] : view<8xi32, #dense> -> i32
+    scf.for %inner = [%zero to %one step %one] {
+      view.store %replacement, %storage[0] : i32, view<8xi32, #dense>
+    }
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+// Distinct external view arguments are addressing provenance, not an implicit
+// noalias contract.
+func.def @keeps_load_across_unproven_distinct_root(%input: view<8xi32, #dense>, %output: view<8xi32, #dense>, %replacement: i32, %initial: i32) -> (i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    %value = view.load %input[0] : view<8xi32, #dense> -> i32
+    view.store %replacement, %output[0] : i32, view<8xi32, #dense>
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+// Explicit noalias scopes make distinct external roots comparable.
+func.def @hoists_load_across_noalias_root(%input: buffer, %output: buffer, %replacement: i32, %initial: i32) -> (i32) {
+  %offset = index.constant 0 : offset
+  %input_unique, %output_unique = buffer.assume.noalias %input, %output : buffer, buffer
+  %input_view = buffer.view %input_unique[%offset] : buffer -> view<8xi32, #dense>
+  %output_view = buffer.view %output_unique[%offset] : buffer -> view<8xi32, #dense>
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    %value = view.load %input_view[0] : view<8xi32, #dense> -> i32
+    view.store %replacement, %output_view[0] : i32, view<8xi32, #dense>
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ----
+func.def @hoists_load_across_noalias_root(%input: buffer, %output: buffer, %replacement: i32, %initial: i32) -> (i32) {
+  %offset = index.constant 0 : offset
+  %input_unique, %output_unique = buffer.assume.noalias %input, %output : buffer, buffer
+  %input_view = buffer.view %input_unique[%offset] : buffer -> view<8xi32, #dense>
+  %output_view = buffer.view %output_unique[%offset] : buffer -> view<8xi32, #dense>
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %value = view.load %input_view[0] : view<8xi32, #dense> -> i32
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    view.store %replacement, %output_view[0] : i32, view<8xi32, #dense>
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+// Atomic accesses retain ordering and synchronization semantics that the
+// ordinary load/store movement model does not represent. They block motion
+// even when explicit noalias scopes prove their storage roots are disjoint.
+func.def @keeps_load_across_unmodeled_atomic(%input: buffer, %output: buffer, %replacement: i32, %initial: i32) -> (i32) {
+  %offset = index.constant 0 : offset
+  %input_unique, %output_unique = buffer.assume.noalias %input, %output : buffer, buffer
+  %input_view = buffer.view %input_unique[%offset] : buffer -> view<8xi32, #dense>
+  %output_view = buffer.view %output_unique[%offset] : buffer -> view<8xi32, #dense>
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    %value = view.load %input_view[0] : view<8xi32, #dense> -> i32
+    view.atomic.reduce<addi> %replacement, %output_view[0] {ordering = relaxed, scope = workgroup} : i32, view<8xi32, #dense>
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+// An operation with unknown effects may write storage that is not represented
+// by an SSA operand. Its presence in the loop therefore blocks read motion.
+func.def @keeps_load_across_unknown_effect(%input: view<8xi32, #dense>, %initial: i32) -> (i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    %value = view.load %input[0] : view<8xi32, #dense> -> i32
+    test.use %initial : i32
+    scf.yield %value : i32
+  }
+  func.return %result : i32
+}
+
+// ====
+
+// A memory fence orders accesses but does not invent a write to every storage
+// root. Immutable loads can cross it without weakening its convergence or
+// memory-ordering contract.
+kernel.def @hoists_immutable_load_across_barrier() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch(%input: buffer, %output: buffer) {
+  %offset = index.constant 0 : offset
+  %input_view = buffer.view %input[%offset] : buffer -> view<8xi32, #dense>
+  %output_view = buffer.view %output[%offset] : buffer -> view<8xi32, #dense>
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %initial = scalar.constant 0 : i32
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    %value = view.load %input_view[0] : view<8xi32, #dense> -> i32
+    kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
+    scf.yield %value : i32
+  }
+  view.store %result, %output_view[0] : i32, view<8xi32, #dense>
+  kernel.return
+}
+
+// ----
+kernel.def @hoists_immutable_load_across_barrier() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch(%input: buffer, %output: buffer) {
+  %offset = index.constant 0 : offset
+  %input_view = buffer.view %input[%offset] : buffer -> view<8xi32, #dense>
+  %output_view = buffer.view %output[%offset] : buffer -> view<8xi32, #dense>
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %initial = scalar.constant 0 : i32
+  %value = view.load %input_view[0] : view<8xi32, #dense> -> i32
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
+    scf.yield %value : i32
+  }
+  view.store %result, %output_view[0] : i32, view<8xi32, #dense>
+  kernel.return
+}
+
+// ====
+
+// A workgroup-memory barrier may publish another workitem's writes to the
+// loaded region. Moving the load before the loop would move it before that
+// matching fence even when the loop is known to execute exactly once.
+kernel.def @keeps_workgroup_load_after_matching_barrier() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch(%output: buffer) {
+  %zero_offset = index.constant 0 : offset
+  %bytes = index.constant 32 : offset
+  %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %scratch_view = buffer.view %scratch[%zero_offset] : buffer -> view<8xi32, #dense>
+  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xi32, #dense>
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %initial = scalar.constant 0 : i32
+  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+    kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
+    %value = view.load %scratch_view[0] : view<8xi32, #dense> -> i32
+    scf.yield %value : i32
+  }
+  view.store %result, %output_view[0] : i32, view<1xi32, #dense>
+  kernel.return
+}


### PR DESCRIPTION
LICM now evaluates every candidate through a stable loop-hoist legality result. Effect-free subtrees still require an explicit speculation contract; ordinary unmasked scalar and vector reads may instead move to a loop preheader when the loop is proven nonempty, every address capture is available there, and every represented write in the nested loop tree is proven disjoint from the loaded byte interval.

Possibly empty loops, nested predicates, loop-variant addresses, unresolved aliases, overlapping writes, and operations with unknown effects reject the move with classified reasons. Explicit memory fences preserve ordering but do not fabricate a write to every storage root, allowing immutable kernel inputs to be loaded once before a barrier-containing reduction loop.

The production LICM path acquires function value facts and a local value domain for the shared motion and movement analyses. Coverage uses loop results, function returns, kernel stores, scalar and vector loads, symbolic addresses, explicit noalias roots, exact same-root ranges, unknown effects, and a real `kernel.barrier` rather than test-only identity checks.