### PR TITLE
[Loom] Expose pass mutation guards to Python builders

### DIFF
--- a/loom/py/loom/dialect/pass_/builders/__init__.pyi
+++ b/loom/py/loom/dialect/pass_/builders/__init__.pyi
@@ -73,3 +73,9 @@ class PassBuilder(DialectBuilder):
         *,
         location_id: int | None = ...,
     ) -> None: ...
+    def if_changed(
+        self,
+        *,
+        body: Region | None = ...,
+        location_id: int | None = ...,
+    ) -> None: ...


### PR DESCRIPTION
Expose `pass.if_changed` through the generated Python builder surface so programmatic pipeline authors can guard cleanup passes on the mutation state of the preceding pass. This keeps the typed Python API synchronized with the dialect definition and generated C builder.