### PR TITLE
[Loom] Project source pressure into residency tiers

### DIFF
--- a/loom/src/loom/codegen/low/lower/BUILD.bazel
+++ b/loom/src/loom/codegen/low/lower/BUILD.bazel
@@ -74,6 +74,7 @@ loom_cc_library(
         "//loom/src/loom/target:low_descriptor_registry",
         "//loom/src/loom/target:low_legality",
         "//loom/src/loom/target:registers",
+        "//loom/src/loom/target:residency",
         "//loom/src/loom/target:types",
         "//loom/src/loom/util:cfg_graph",
         "//loom/src/loom/util:fact_table",
@@ -104,6 +105,42 @@ loom_cc_library(
         "//loom/src/loom/target:types",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:arena",
+    ],
+)
+
+loom_cc_library(
+    name = "source_pressure",
+    srcs = ["source_pressure.c"],
+    hdrs = ["source_pressure.h"],
+    visibility = [
+        "//loom/src/loom/codegen/low/transforms/pipeline:__pkg__",
+        "//loom/src/loom/transforms/loop:__pkg__",
+    ],
+    deps = [
+        ":lower",
+        "//loom/src/loom/analysis:liveness",
+        "//loom/src/loom/analysis:view_regions",
+        "//loom/src/loom/ir",
+        "//loom/src/loom/util:adaptive_sort",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal:arena",
+    ],
+)
+
+loom_cc_test(
+    name = "source_pressure_test",
+    srcs = ["source_pressure_test.cc"],
+    deps = [
+        ":source_pressure",
+        "//loom/src/loom/format/text:parser",
+        "//loom/src/loom/ir",
+        "//loom/src/loom/ops/func",
+        "//loom/src/loom/ops/scalar",
+        "//loom/src/loom/ops/scf",
+        "//loom/src/loom/testing:module_ptr",
+        "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
     ],
 )
 

--- a/loom/src/loom/codegen/low/lower/CMakeLists.txt
+++ b/loom/src/loom/codegen/low/lower/CMakeLists.txt
@@ -58,6 +58,7 @@ loom_cc_library(
     loom::target::low_descriptor_registry
     loom::target::low_legality
     loom::target::registers
+    loom::target::residency
     loom::target::types
     loom::util::cfg_graph
     loom::util::fact_table
@@ -85,6 +86,42 @@ loom_cc_library(
     loom::target::function_contract
     loom::target::types
   PUBLIC
+)
+
+loom_cc_library(
+  NAME
+    source_pressure
+  HDRS
+    "source_pressure.h"
+  SRCS
+    "source_pressure.c"
+  DEPS
+    ::lower
+    iree::base
+    iree::base::internal::arena
+    loom::analysis::liveness
+    loom::analysis::view_regions
+    loom::ir
+    loom::util::adaptive_sort
+  PUBLIC
+)
+
+loom_cc_test(
+  NAME
+    source_pressure_test
+  SRCS
+    "source_pressure_test.cc"
+  DEPS
+    ::source_pressure
+    iree::base::internal::arena
+    iree::testing::gtest
+    iree::testing::gtest_main
+    loom::format::text::parser
+    loom::ir
+    loom::ops::func
+    loom::ops::scalar
+    loom::ops::scf
+    loom::testing::module_ptr
 )
 
 loom_cc_test(

--- a/loom/src/loom/codegen/low/lower/lower.h
+++ b/loom/src/loom/codegen/low/lower/lower.h
@@ -27,6 +27,7 @@
 #include "loom/ops/op_defs.h"
 #include "loom/sanitizer/options.h"
 #include "loom/target/low_legality.h"
+#include "loom/target/residency.h"
 #include "loom/target/types.h"
 #include "loom/util/fact_table.h"
 
@@ -132,6 +133,22 @@ typedef struct loom_low_lower_map_contract_value_callback_t {
   // Caller-owned payload passed to |fn|.
   void* user_data;
 } loom_low_lower_map_contract_value_callback_t;
+
+typedef const loom_target_residency_model_t* (
+    *loom_low_lower_residency_model_fn_t)(
+    void* user_data,
+    const loom_target_contract_query_environment_t* environment);
+
+typedef struct loom_low_lower_residency_model_callback_t {
+  // Optional callback returning the immutable residency model selected by a
+  // target contract. Missing or a null result means residency is unavailable.
+  // Direct resource IDs in the returned model are descriptor register-class
+  // IDs so read-only source value mappings can contribute allocation units
+  // without target-specific type tests in generic placement code.
+  loom_low_lower_residency_model_fn_t fn;
+  // Caller-owned payload passed to |fn|.
+  void* user_data;
+} loom_low_lower_residency_model_callback_t;
 
 typedef enum loom_low_lower_abi_argument_kind_e {
   // Source argument is passed as a low function block argument.
@@ -608,6 +625,9 @@ typedef struct loom_low_lower_policy_t {
   // for read-only target contract queries. Missing means table guards that need
   // register mapping cannot match.
   loom_low_lower_map_contract_value_callback_t map_contract_value;
+  // Optionally returns the residency model for read-only source pressure and
+  // final target-low allocation queries.
+  loom_low_lower_residency_model_callback_t residency_model;
   // Optionally maps source function arguments to non-direct ABI imports.
   loom_low_lower_map_argument_callback_t map_argument;
   // Optionally emits target live-ins or other structural preamble packets.

--- a/loom/src/loom/codegen/low/lower/source_pressure.c
+++ b/loom/src/loom/codegen/low/lower/source_pressure.c
@@ -1,0 +1,570 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/codegen/low/lower/source_pressure.h"
+
+#include <string.h>
+
+#include "loom/analysis/liveness.h"
+#include "loom/analysis/view_regions.h"
+#include "loom/ir/local_value_domain.h"
+#include "loom/ir/module.h"
+#include "loom/util/adaptive_sort.h"
+
+typedef struct loom_low_source_pressure_query_state_record_t {
+  // Target-owned stable state key.
+  const void* key;
+  // Byte length of |data|.
+  iree_host_size_t data_length;
+  // Zero-initialized target-owned state payload.
+  void* data;
+} loom_low_source_pressure_query_state_record_t;
+
+typedef struct loom_low_source_pressure_query_state_t {
+  // Arena owning records and target state payloads.
+  iree_arena_allocator_t* arena;
+  // Target-owned query state records.
+  loom_low_source_pressure_query_state_record_t* records;
+  // Number of populated entries in |records|.
+  iree_host_size_t record_count;
+  // Allocated capacity of |records|.
+  iree_host_size_t record_capacity;
+} loom_low_source_pressure_query_state_t;
+
+static iree_status_t loom_low_source_pressure_get_or_allocate_query_state(
+    void* user_data, const void* key, iree_host_size_t data_length,
+    void** out_data) {
+  loom_low_source_pressure_query_state_t* state =
+      (loom_low_source_pressure_query_state_t*)user_data;
+  *out_data = NULL;
+  if (key == NULL || data_length == 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "target query state requires a key and storage");
+  }
+  for (iree_host_size_t i = 0; i < state->record_count; ++i) {
+    loom_low_source_pressure_query_state_record_t* record = &state->records[i];
+    if (record->key != key) continue;
+    if (record->data_length != data_length) {
+      return iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "target query state key requested with inconsistent storage size");
+    }
+    *out_data = record->data;
+    return iree_ok_status();
+  }
+
+  if (state->record_count == state->record_capacity) {
+    iree_host_size_t minimum_capacity = 0;
+    if (!iree_host_size_checked_add(state->record_count, 1,
+                                    &minimum_capacity)) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "target query state capacity overflow");
+    }
+    IREE_RETURN_IF_ERROR(iree_arena_grow_array(
+        state->arena, state->record_count, minimum_capacity,
+        sizeof(*state->records), &state->record_capacity,
+        (void**)&state->records));
+  }
+
+  void* data = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate(state->arena, data_length, &data));
+  memset(data, 0, data_length);
+  loom_low_source_pressure_query_state_record_t* record =
+      &state->records[state->record_count++];
+  *record = (loom_low_source_pressure_query_state_record_t){
+      .key = key,
+      .data_length = data_length,
+      .data = data,
+  };
+  *out_data = data;
+  return iree_ok_status();
+}
+
+typedef struct loom_low_source_pressure_event_t {
+  // Structured liveness program point where pressure changes.
+  uint32_t point;
+  // Residency direct resource receiving the unit delta.
+  uint16_t direct_resource_id;
+  // Target allocation units entering or leaving the live set.
+  uint32_t units;
+  // Negative for a segment end and positive for a segment start.
+  int8_t direction;
+  // Source value used for deterministic event ordering.
+  loom_value_id_t value_id;
+} loom_low_source_pressure_event_t;
+
+static bool loom_low_source_pressure_event_less(
+    const loom_low_source_pressure_event_t* lhs,
+    const loom_low_source_pressure_event_t* rhs) {
+  if (lhs->point != rhs->point) return lhs->point < rhs->point;
+  if (lhs->direction != rhs->direction) {
+    return lhs->direction < rhs->direction;
+  }
+  if (lhs->direct_resource_id != rhs->direct_resource_id) {
+    return lhs->direct_resource_id < rhs->direct_resource_id;
+  }
+  return lhs->value_id < rhs->value_id;
+}
+
+LOOM_DEFINE_ADAPTIVE_SORT(loom_low_source_pressure_event_sort,
+                          loom_low_source_pressure_event_t,
+                          loom_low_source_pressure_event_less)
+
+static iree_status_t loom_low_source_pressure_copy_reserves(
+    const loom_low_source_pressure_options_t* options,
+    iree_host_size_t direct_resource_count, iree_arena_allocator_t* arena,
+    loom_low_source_pressure_reserve_t** out_reserves,
+    uint64_t** out_reserved_units) {
+  *out_reserves = NULL;
+  *out_reserved_units = NULL;
+  if (direct_resource_count != 0) {
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(arena, direct_resource_count,
+                                                   sizeof(**out_reserved_units),
+                                                   (void**)out_reserved_units));
+    memset(*out_reserved_units, 0,
+           direct_resource_count * sizeof(**out_reserved_units));
+  }
+  if (options->reserve_count == 0) return iree_ok_status();
+  if (options->reserves == NULL) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "source pressure has a null non-empty reserve contributor list");
+  }
+
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(arena, options->reserve_count,
+                                                 sizeof(**out_reserves),
+                                                 (void**)out_reserves));
+  for (iree_host_size_t i = 0; i < options->reserve_count; ++i) {
+    const loom_low_source_pressure_reserve_t* source = &options->reserves[i];
+    if (iree_string_view_is_empty(source->name)) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "source pressure reserve %zu has no name", i);
+    }
+    if (source->direct_resource_count != direct_resource_count ||
+        (direct_resource_count != 0 && source->direct_resource_units == NULL)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "source pressure reserve '%.*s' has %zu resource values; model "
+          "requires %zu",
+          (int)source->name.size, source->name.data,
+          source->direct_resource_count, direct_resource_count);
+    }
+    uint64_t* copied_units = NULL;
+    if (direct_resource_count != 0) {
+      IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+          arena, direct_resource_count, sizeof(*copied_units),
+          (void**)&copied_units));
+      memcpy(copied_units, source->direct_resource_units,
+             direct_resource_count * sizeof(*copied_units));
+    }
+    (*out_reserves)[i] = (loom_low_source_pressure_reserve_t){
+        .name = source->name,
+        .direct_resource_units = copied_units,
+        .direct_resource_count = direct_resource_count,
+    };
+    for (iree_host_size_t resource_id = 0; resource_id < direct_resource_count;
+         ++resource_id) {
+      uint64_t* total = &(*out_reserved_units)[resource_id];
+      if (*total > UINT64_MAX - copied_units[resource_id]) {
+        return iree_make_status(
+            IREE_STATUS_OUT_OF_RANGE,
+            "source pressure reserves overflow direct resource %zu",
+            resource_id);
+      }
+      *total += copied_units[resource_id];
+    }
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_low_source_pressure_collect_events(
+    const loom_target_contract_query_environment_t* environment,
+    const loom_low_lower_policy_t* policy,
+    const loom_target_residency_model_t* model,
+    const loom_liveness_analysis_t* liveness, iree_arena_allocator_t* arena,
+    loom_low_source_pressure_event_t** out_events,
+    iree_host_size_t* out_event_count, iree_host_size_t* out_mapped_value_count,
+    iree_host_size_t* out_non_register_value_count,
+    iree_host_size_t* out_live_segment_count,
+    iree_host_size_t* out_transient_segment_count) {
+  *out_events = NULL;
+  *out_event_count = 0;
+  *out_mapped_value_count = 0;
+  *out_non_register_value_count = 0;
+  *out_live_segment_count = 0;
+  *out_transient_segment_count = 0;
+  iree_host_size_t segment_capacity = 0;
+  if (!iree_host_size_checked_add(liveness->segment_count,
+                                  liveness->value_count, &segment_capacity) ||
+      segment_capacity > IREE_HOST_SIZE_MAX / 2u) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "source pressure event count exceeds host size");
+  }
+  const iree_host_size_t event_capacity = segment_capacity * 2u;
+  loom_low_source_pressure_event_t* events = NULL;
+  if (event_capacity != 0) {
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        arena, event_capacity, sizeof(*events), (void**)&events));
+  }
+
+  iree_host_size_t event_count = 0;
+  for (loom_value_ordinal_t value_ordinal = 0;
+       value_ordinal < liveness->value_count; ++value_ordinal) {
+    const loom_liveness_segment_range_t segment_range =
+        loom_liveness_segment_range_for_value_ordinal(liveness, value_ordinal);
+    const loom_value_id_t value_id = liveness->value_ids[value_ordinal];
+    const loom_value_t* value =
+        loom_module_value(environment->module, value_id);
+    const bool is_block_argument = loom_value_is_block_arg(value);
+    const loom_op_t* source_op =
+        is_block_argument ? environment->function.op : loom_value_def_op(value);
+    const bool has_leaf_result_issue =
+        !is_block_argument && source_op != NULL && source_op->region_count == 0;
+    if (segment_range.count == 0 && !has_leaf_result_issue) continue;
+    loom_low_lower_rule_mapped_value_t mapped_value =
+        loom_low_lower_rule_mapped_value_none();
+    IREE_RETURN_IF_ERROR(policy->map_contract_value.fn(
+        policy->map_contract_value.user_data, environment, source_op, value_id,
+        &mapped_value));
+    if (!mapped_value.is_register) {
+      ++*out_non_register_value_count;
+      continue;
+    }
+    if (mapped_value.register_unit_count == 0 ||
+        mapped_value.descriptor_register_class_id >=
+            model->direct_resources.resource_count) {
+      return iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "source value %u maps to invalid residency resource %u with %u "
+          "unit(s)",
+          value_id, (unsigned)mapped_value.descriptor_register_class_id,
+          (unsigned)mapped_value.register_unit_count);
+    }
+    ++*out_mapped_value_count;
+    for (uint32_t i = 0; i < segment_range.count; ++i) {
+      const loom_liveness_segment_t segment =
+          liveness->segments[segment_range.start + i];
+      if (segment.start_point >= segment.end_point) {
+        return iree_make_status(
+            IREE_STATUS_FAILED_PRECONDITION,
+            "source value %u has an empty pressure liveness segment", value_id);
+      }
+      events[event_count++] = (loom_low_source_pressure_event_t){
+          .point = segment.end_point,
+          .direct_resource_id = mapped_value.descriptor_register_class_id,
+          .units = mapped_value.register_unit_count,
+          .direction = -1,
+          .value_id = value_id,
+      };
+      events[event_count++] = (loom_low_source_pressure_event_t){
+          .point = segment.start_point,
+          .direct_resource_id = mapped_value.descriptor_register_class_id,
+          .units = mapped_value.register_unit_count,
+          .direction = 1,
+          .value_id = value_id,
+      };
+      ++*out_live_segment_count;
+    }
+    if (has_leaf_result_issue) {
+      uint32_t issue_point = 0;
+      IREE_RETURN_IF_ERROR(loom_liveness_op_program_point(
+          liveness, loom_liveness_order_empty(), source_op, &issue_point));
+      bool live_at_issue = false;
+      for (uint32_t i = 0; i < segment_range.count; ++i) {
+        const loom_liveness_segment_t segment =
+            liveness->segments[segment_range.start + i];
+        if (segment.start_point <= issue_point &&
+            issue_point < segment.end_point) {
+          live_at_issue = true;
+          break;
+        }
+      }
+      if (!live_at_issue) {
+        if (issue_point == UINT32_MAX) {
+          return iree_make_status(
+              IREE_STATUS_OUT_OF_RANGE,
+              "source pressure issue segment exceeds program-point range");
+        }
+        events[event_count++] = (loom_low_source_pressure_event_t){
+            .point = issue_point + 1u,
+            .direct_resource_id = mapped_value.descriptor_register_class_id,
+            .units = mapped_value.register_unit_count,
+            .direction = -1,
+            .value_id = value_id,
+        };
+        events[event_count++] = (loom_low_source_pressure_event_t){
+            .point = issue_point,
+            .direct_resource_id = mapped_value.descriptor_register_class_id,
+            .units = mapped_value.register_unit_count,
+            .direction = 1,
+            .value_id = value_id,
+        };
+        ++*out_live_segment_count;
+        ++*out_transient_segment_count;
+      }
+    }
+  }
+  IREE_ASSERT_LE(event_count, event_capacity);
+  loom_low_source_pressure_event_sort(events, event_count);
+  *out_events = events;
+  *out_event_count = event_count;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_low_source_pressure_apply_event(
+    const loom_low_source_pressure_event_t* event, uint64_t* current_units) {
+  uint64_t* units = &current_units[event->direct_resource_id];
+  if (event->direction < 0) {
+    if (*units < event->units) {
+      return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                              "source pressure liveness sweep underflow");
+    }
+    *units -= event->units;
+    return iree_ok_status();
+  }
+  if (*units > UINT64_MAX - event->units) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "source pressure liveness sweep overflow");
+  }
+  *units += event->units;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_low_source_pressure_sweep(
+    const loom_target_residency_model_t* model,
+    const loom_target_residency_evaluator_t* evaluator,
+    const loom_low_source_pressure_event_t* events,
+    iree_host_size_t event_count, const uint64_t* reserved_units,
+    iree_arena_allocator_t* arena, uint32_t* out_minimum_tier,
+    uint32_t* out_minimum_tier_point, uint64_t** out_peak_units,
+    uint64_t** out_minimum_tier_units) {
+  const iree_host_size_t direct_resource_count =
+      model->direct_resources.resource_count;
+  uint64_t* current_units = NULL;
+  uint64_t* peak_units = NULL;
+  uint64_t* minimum_tier_units = NULL;
+  if (direct_resource_count != 0) {
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(arena, direct_resource_count,
+                                                   sizeof(*current_units),
+                                                   (void**)&current_units));
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(arena, direct_resource_count,
+                                                   sizeof(*peak_units),
+                                                   (void**)&peak_units));
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        arena, direct_resource_count, sizeof(*minimum_tier_units),
+        (void**)&minimum_tier_units));
+    memcpy(current_units, reserved_units,
+           direct_resource_count * sizeof(*current_units));
+    memcpy(peak_units, reserved_units,
+           direct_resource_count * sizeof(*peak_units));
+    memcpy(minimum_tier_units, reserved_units,
+           direct_resource_count * sizeof(*minimum_tier_units));
+  }
+
+  uint32_t minimum_tier = 0;
+  IREE_RETURN_IF_ERROR(loom_target_residency_evaluator_evaluate_tier(
+      evaluator, current_units, direct_resource_count, &minimum_tier));
+  uint32_t minimum_tier_point = 0;
+  for (iree_host_size_t i = 0; i < event_count;) {
+    const uint32_t point = events[i].point;
+    do {
+      IREE_RETURN_IF_ERROR(
+          loom_low_source_pressure_apply_event(&events[i], current_units));
+      ++i;
+    } while (i < event_count && events[i].point == point);
+    for (iree_host_size_t resource_id = 0; resource_id < direct_resource_count;
+         ++resource_id) {
+      peak_units[resource_id] =
+          iree_max(peak_units[resource_id], current_units[resource_id]);
+    }
+    uint32_t tier = 0;
+    IREE_RETURN_IF_ERROR(loom_target_residency_evaluator_evaluate_tier(
+        evaluator, current_units, direct_resource_count, &tier));
+    if (tier < minimum_tier) {
+      minimum_tier = tier;
+      minimum_tier_point = point;
+      if (direct_resource_count != 0) {
+        memcpy(minimum_tier_units, current_units,
+               direct_resource_count * sizeof(*minimum_tier_units));
+      }
+    }
+  }
+
+  *out_minimum_tier = minimum_tier;
+  *out_minimum_tier_point = minimum_tier_point;
+  *out_peak_units = peak_units;
+  *out_minimum_tier_units = minimum_tier_units;
+  return iree_ok_status();
+}
+
+iree_status_t loom_low_source_pressure_analyze(
+    const loom_target_contract_query_environment_t* environment,
+    const loom_low_lower_policy_t* policy,
+    const loom_low_source_pressure_options_t* options,
+    iree_arena_allocator_t* arena, loom_low_source_pressure_t* out_pressure) {
+  if (environment == NULL || policy == NULL || arena == NULL ||
+      out_pressure == NULL) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "source pressure requires an environment, policy, arena, and output");
+  }
+  *out_pressure = (loom_low_source_pressure_t){0};
+  if (environment->module == NULL || environment->function.op == NULL ||
+      environment->descriptor_set == NULL) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "source pressure environment requires a function and descriptor set");
+  }
+  const loom_low_source_pressure_options_t empty_options =
+      loom_low_source_pressure_options_empty();
+  if (options == NULL) options = &empty_options;
+
+  const loom_target_residency_model_t* model = NULL;
+  if (policy->residency_model.fn != NULL) {
+    model = policy->residency_model.fn(policy->residency_model.user_data,
+                                       environment);
+  }
+  if (model == NULL) {
+    if (options->reserve_count != 0) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "source pressure reserves require an available residency model");
+    }
+    return iree_ok_status();
+  }
+  if (policy->map_contract_value.fn == NULL) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "lowering policy '%.*s' has a residency model but no source value "
+        "mapping",
+        (int)policy->name.size, policy->name.data);
+  }
+  if (model->direct_resources.resource_count !=
+      environment->descriptor_set->reg_class_count) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "lowering policy '%.*s' residency model has %u direct resources; "
+        "descriptor set has %u register classes",
+        (int)policy->name.size, policy->name.data,
+        (unsigned)model->direct_resources.resource_count,
+        (unsigned)environment->descriptor_set->reg_class_count);
+  }
+
+  loom_low_source_pressure_reserve_t* reserves = NULL;
+  uint64_t* reserved_units = NULL;
+  IREE_RETURN_IF_ERROR(loom_low_source_pressure_copy_reserves(
+      options, model->direct_resources.resource_count, arena, &reserves,
+      &reserved_units));
+
+  loom_target_residency_evaluator_t residency_evaluator;
+  IREE_RETURN_IF_ERROR(
+      loom_target_residency_evaluator_initialize(model, &residency_evaluator));
+
+  loom_local_value_domain_t owned_value_domain = {0};
+  const loom_local_value_domain_t* value_domain = environment->value_domain;
+  bool owns_value_domain = false;
+  iree_status_t status = iree_ok_status();
+  const loom_region_t* body = loom_func_like_body(environment->function);
+  if (value_domain == NULL) {
+    status = loom_local_value_domain_acquire_for_region_tree(
+        (loom_module_t*)environment->module, body, arena, &owned_value_domain);
+    if (iree_status_is_ok(status)) {
+      value_domain = &owned_value_domain;
+      owns_value_domain = true;
+    }
+  } else if (!loom_local_value_domain_is_acquired(value_domain) ||
+             value_domain->region != body ||
+             !iree_any_bit_set(value_domain->flags,
+                               LOOM_LOCAL_VALUE_DOMAIN_FLAG_REGION_TREE)) {
+    status = iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "source pressure requires a region-tree value domain for the function");
+  }
+
+  loom_target_contract_query_environment_t query_environment = *environment;
+  loom_view_region_table_t owned_view_regions = {0};
+  loom_low_source_pressure_query_state_t query_state = {
+      .arena = arena,
+  };
+  if (iree_status_is_ok(status)) {
+    query_environment.value_domain = value_domain;
+    query_environment.arena = arena;
+    if (query_environment.view_regions == NULL) {
+      status = loom_view_region_table_initialize(
+          (loom_value_fact_table_t*)query_environment.fact_table, value_domain,
+          arena, &owned_view_regions);
+      if (iree_status_is_ok(status)) {
+        status = loom_view_region_table_analyze(&owned_view_regions);
+      }
+      if (iree_status_is_ok(status)) {
+        query_environment.view_regions = &owned_view_regions;
+      }
+    }
+    if (query_environment.target_state_allocator.fn == NULL) {
+      query_environment.target_state_allocator =
+          (loom_target_contract_query_state_allocator_t){
+              .fn = loom_low_source_pressure_get_or_allocate_query_state,
+              .user_data = &query_state,
+          };
+    }
+  }
+
+  loom_liveness_analysis_t liveness = {0};
+  if (iree_status_is_ok(status)) {
+    status = loom_liveness_analyze_local_value_domain(
+        value_domain, loom_liveness_order_empty(), arena, &liveness);
+  }
+  loom_low_source_pressure_event_t* events = NULL;
+  iree_host_size_t event_count = 0;
+  iree_host_size_t mapped_value_count = 0;
+  iree_host_size_t non_register_value_count = 0;
+  iree_host_size_t live_segment_count = 0;
+  iree_host_size_t transient_segment_count = 0;
+  if (iree_status_is_ok(status)) {
+    status = loom_low_source_pressure_collect_events(
+        &query_environment, policy, model, &liveness, arena, &events,
+        &event_count, &mapped_value_count, &non_register_value_count,
+        &live_segment_count, &transient_segment_count);
+  }
+
+  uint32_t minimum_tier = 0;
+  uint32_t minimum_tier_point = 0;
+  uint64_t* peak_units = NULL;
+  uint64_t* minimum_tier_units = NULL;
+  if (iree_status_is_ok(status)) {
+    status = loom_low_source_pressure_sweep(
+        model, &residency_evaluator, events, event_count, reserved_units, arena,
+        &minimum_tier, &minimum_tier_point, &peak_units, &minimum_tier_units);
+  }
+  if (iree_status_is_ok(status)) {
+    loom_low_source_pressure_flags_t flags =
+        LOOM_LOW_SOURCE_PRESSURE_FLAG_MODEL_AVAILABLE;
+    if (iree_any_bit_set(
+            options->flags,
+            LOOM_LOW_SOURCE_PRESSURE_OPTION_FLAG_RESERVES_COMPLETE)) {
+      flags |= LOOM_LOW_SOURCE_PRESSURE_FLAG_PROJECTION_COMPLETE;
+    }
+    *out_pressure = (loom_low_source_pressure_t){
+        .flags = flags,
+        .minimum_tier = minimum_tier,
+        .minimum_tier_point = minimum_tier_point,
+        .peak_direct_resource_units = peak_units,
+        .minimum_tier_direct_resource_units = minimum_tier_units,
+        .reserved_direct_resource_units = reserved_units,
+        .direct_resource_count = model->direct_resources.resource_count,
+        .reserves = reserves,
+        .reserve_count = options->reserve_count,
+        .mapped_value_count = mapped_value_count,
+        .non_register_value_count = non_register_value_count,
+        .live_segment_count = live_segment_count,
+        .transient_segment_count = transient_segment_count,
+    };
+  }
+  if (owns_value_domain) {
+    loom_local_value_domain_release(&owned_value_domain);
+  }
+  return status;
+}

--- a/loom/src/loom/codegen/low/lower/source_pressure.h
+++ b/loom/src/loom/codegen/low/lower/source_pressure.h
@@ -1,0 +1,123 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Target-resource pressure projected from structured source IR.
+
+#ifndef LOOM_CODEGEN_LOW_LOWER_SOURCE_PRESSURE_H_
+#define LOOM_CODEGEN_LOW_LOWER_SOURCE_PRESSURE_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/arena.h"
+#include "loom/codegen/low/lower/lower.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// One named conservative contribution not represented by source SSA values.
+typedef struct loom_low_source_pressure_reserve_t {
+  // Stable contributor name used by structured reports.
+  iree_string_view_t name;
+  // Resource units dense by residency-model direct resource ID.
+  const uint64_t* direct_resource_units;
+  // Number of entries in |direct_resource_units|.
+  iree_host_size_t direct_resource_count;
+} loom_low_source_pressure_reserve_t;
+
+typedef uint16_t loom_low_source_pressure_option_flags_t;
+enum loom_low_source_pressure_option_flag_bits_e {
+  // The supplied contributors bound all non-source target storage pressure.
+  LOOM_LOW_SOURCE_PRESSURE_OPTION_FLAG_RESERVES_COMPLETE = 1u << 0,
+};
+
+// Options controlling one source pressure projection.
+typedef struct loom_low_source_pressure_options_t {
+  // Named target or lowering reserve contributors.
+  const loom_low_source_pressure_reserve_t* reserves;
+  // Number of entries in |reserves|.
+  iree_host_size_t reserve_count;
+  // Completeness claims for the supplied projection inputs.
+  loom_low_source_pressure_option_flags_t flags;
+} loom_low_source_pressure_options_t;
+
+static inline loom_low_source_pressure_options_t
+loom_low_source_pressure_options_empty(void) {
+  return (loom_low_source_pressure_options_t){0};
+}
+
+typedef uint16_t loom_low_source_pressure_flags_t;
+enum loom_low_source_pressure_flag_bits_e {
+  // The selected lowering policy supplied a target residency model.
+  LOOM_LOW_SOURCE_PRESSURE_FLAG_MODEL_AVAILABLE = 1u << 0,
+  // Source values and named reserves form a complete pressure projection.
+  LOOM_LOW_SOURCE_PRESSURE_FLAG_PROJECTION_COMPLETE = 1u << 1,
+};
+
+// Whole-function target pressure envelope over structured source liveness.
+//
+// Arrays and copied reserve records are owned by the analysis arena. Direct
+// resource IDs match descriptor register-class IDs by lowering-policy contract.
+typedef struct loom_low_source_pressure_t {
+  // Model availability and projection completeness bits.
+  loom_low_source_pressure_flags_t flags;
+  // Worst residency tier reached at any feasible structured program point.
+  uint32_t minimum_tier;
+  // Earliest program point attaining |minimum_tier|.
+  uint32_t minimum_tier_point;
+  // Maximum units observed independently for each direct resource.
+  const uint64_t* peak_direct_resource_units;
+  // Simultaneously live resource vector at |minimum_tier_point|.
+  const uint64_t* minimum_tier_direct_resource_units;
+  // Sum of all named reserves applied at every program point.
+  const uint64_t* reserved_direct_resource_units;
+  // Number of entries in each direct-resource vector.
+  iree_host_size_t direct_resource_count;
+  // Arena-owned copy of named reserve contributors.
+  const loom_low_source_pressure_reserve_t* reserves;
+  // Number of entries in |reserves|.
+  iree_host_size_t reserve_count;
+  // Source values mapped to target register resources.
+  iree_host_size_t mapped_value_count;
+  // Live source values explicitly mapped to no target register.
+  iree_host_size_t non_register_value_count;
+  // Mapped sparse liveness segments swept by the analysis.
+  iree_host_size_t live_segment_count;
+  // Leaf-operation result issue segments included in |live_segment_count|.
+  iree_host_size_t transient_segment_count;
+} loom_low_source_pressure_t;
+
+static inline bool loom_low_source_pressure_model_available(
+    const loom_low_source_pressure_t* pressure) {
+  return pressure != NULL &&
+         iree_any_bit_set(pressure->flags,
+                          LOOM_LOW_SOURCE_PRESSURE_FLAG_MODEL_AVAILABLE);
+}
+
+static inline bool loom_low_source_pressure_projection_complete(
+    const loom_low_source_pressure_t* pressure) {
+  return pressure != NULL &&
+         iree_any_bit_set(pressure->flags,
+                          LOOM_LOW_SOURCE_PRESSURE_FLAG_PROJECTION_COMPLETE);
+}
+
+// Projects structured source liveness into the selected target's residency
+// resources.
+//
+// |environment| must identify one source function and descriptor set. The
+// analysis reuses an active region-tree value domain and view-region table when
+// supplied, otherwise it builds scoped instances. Mutating the source module
+// invalidates the returned envelope.
+iree_status_t loom_low_source_pressure_analyze(
+    const loom_target_contract_query_environment_t* environment,
+    const loom_low_lower_policy_t* policy,
+    const loom_low_source_pressure_options_t* options,
+    iree_arena_allocator_t* arena, loom_low_source_pressure_t* out_pressure);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_CODEGEN_LOW_LOWER_SOURCE_PRESSURE_H_

--- a/loom/src/loom/codegen/low/lower/source_pressure_test.cc
+++ b/loom/src/loom/codegen/low/lower/source_pressure_test.cc
@@ -1,0 +1,322 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/codegen/low/lower/source_pressure.h"
+
+#include "iree/base/internal/arena.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+#include "loom/format/text/parser.h"
+#include "loom/ir/context.h"
+#include "loom/ir/module.h"
+#include "loom/ops/func/ops.h"
+#include "loom/ops/scalar/ops.h"
+#include "loom/ops/scf/ops.h"
+#include "loom/testing/module_ptr.h"
+
+namespace loom {
+namespace {
+
+using ModulePtr = ::loom::testing::ModulePtr;
+
+static const iree_string_view_t kDirectResourceNames[] = {
+    IREE_SVL("integer_registers"),
+    IREE_SVL("float_registers"),
+};
+
+static const loom_target_residency_cliff_range_t kDirectCliffRanges[] = {
+    {/*.start=*/0, /*.count=*/0},
+    {/*.start=*/0, /*.count=*/0},
+};
+
+static const loom_target_residency_derived_member_t kDerivedMembers[] = {
+    {
+        /*.resource_id=*/0,
+        /*.direct_resource_id=*/0,
+        /*.contribution_granularity=*/1,
+    },
+    {
+        /*.resource_id=*/0,
+        /*.direct_resource_id=*/1,
+        /*.contribution_granularity=*/1,
+    },
+};
+
+static const loom_target_residency_cliff_t kDerivedCliffs[] = {
+    {
+        /*.resource_id=*/0,
+        /*.cliff_units=*/6,
+        /*.tier_before=*/4,
+        /*.tier_after=*/2,
+    },
+};
+
+static const loom_target_residency_derived_resource_t kDerivedResources[] = {
+    {
+        /*.name=*/IREE_SVL("shared_register_pool"),
+        /*.pool_units=*/64,
+        /*.allocation_granularity=*/1,
+        /*.member_start=*/0,
+        /*.member_count=*/2,
+        /*.cliff_start=*/0,
+        /*.cliff_count=*/1,
+    },
+};
+
+static const loom_target_residency_model_t kResidencyModel = {
+    /*.best_tier=*/4,
+    /*.direct_resources=*/
+    {
+        /*.names=*/kDirectResourceNames,
+        /*.cliffs=*/nullptr,
+        /*.cliff_count=*/0,
+        /*.cliff_ranges=*/kDirectCliffRanges,
+        /*.resource_count=*/IREE_ARRAYSIZE(kDirectResourceNames),
+    },
+    /*.derived_resources=*/
+    {
+        /*.resources=*/kDerivedResources,
+        /*.resource_count=*/IREE_ARRAYSIZE(kDerivedResources),
+        /*.members=*/kDerivedMembers,
+        /*.member_count=*/IREE_ARRAYSIZE(kDerivedMembers),
+        /*.cliffs=*/kDerivedCliffs,
+        /*.cliff_count=*/IREE_ARRAYSIZE(kDerivedCliffs),
+    },
+};
+
+static iree_status_t MapContractValue(
+    void* user_data,
+    const loom_target_contract_query_environment_t* environment,
+    const loom_op_t* source_op, loom_value_id_t source_value_id,
+    loom_low_lower_rule_mapped_value_t* out_mapped_value) {
+  (void)user_data;
+  (void)source_op;
+  *out_mapped_value = loom_low_lower_rule_mapped_value_none();
+  const loom_type_t type =
+      loom_module_value_type(environment->module, source_value_id);
+  if (!loom_type_is_scalar(type)) return iree_ok_status();
+  if (loom_type_element_type(type) == LOOM_SCALAR_TYPE_I32) {
+    *out_mapped_value = loom_low_lower_rule_mapped_value_register(0, 1);
+  } else if (loom_type_element_type(type) == LOOM_SCALAR_TYPE_F32) {
+    *out_mapped_value = loom_low_lower_rule_mapped_value_register(1, 1);
+  }
+  return iree_ok_status();
+}
+
+static const loom_target_residency_model_t* ResidencyModel(
+    void* user_data,
+    const loom_target_contract_query_environment_t* environment) {
+  (void)user_data;
+  (void)environment;
+  return &kResidencyModel;
+}
+
+static const loom_low_lower_policy_t kPolicy = {
+    /*.name=*/IREE_SVL("source-pressure-test"),
+    /*.error_catalog=*/{},
+    /*.map_type=*/{},
+    /*.source_type_supported=*/{},
+    /*.map_value=*/{},
+    /*.map_contract_value=*/{/*.fn=*/MapContractValue, /*.user_data=*/nullptr},
+    /*.residency_model=*/{/*.fn=*/ResidencyModel, /*.user_data=*/nullptr},
+};
+
+class SourcePressureTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    iree_arena_block_pool_initialize(4096, iree_allocator_system(),
+                                     &block_pool_);
+    loom_context_initialize(iree_allocator_system(), &context_);
+    RegisterDialect(LOOM_DIALECT_FUNC, loom_func_dialect_vtables);
+    RegisterDialect(LOOM_DIALECT_SCALAR, loom_scalar_dialect_vtables);
+    RegisterDialect(LOOM_DIALECT_SCF, loom_scf_dialect_vtables);
+    IREE_ASSERT_OK(loom_context_finalize(&context_));
+    iree_arena_initialize(&block_pool_, &analysis_arena_);
+    descriptor_set_.reg_class_count = 2;
+  }
+
+  void TearDown() override {
+    iree_arena_deinitialize(&analysis_arena_);
+    loom_context_deinitialize(&context_);
+    iree_arena_block_pool_deinitialize(&block_pool_);
+  }
+
+  using DialectVtablesFn =
+      const loom_op_vtable_t* const* (*)(iree_host_size_t*);
+
+  void RegisterDialect(uint8_t dialect_id,
+                       DialectVtablesFn dialect_vtables_fn) {
+    iree_host_size_t count = 0;
+    const loom_op_vtable_t* const* vtables = dialect_vtables_fn(&count);
+    IREE_ASSERT_OK(loom_context_register_dialect(&context_, dialect_id, vtables,
+                                                 (uint16_t)count));
+  }
+
+  ModulePtr ParseModule(const char* source) {
+    loom_module_t* module = nullptr;
+    loom_text_parse_options_t options = {};
+    IREE_CHECK_OK(loom_text_parse(iree_make_cstring_view(source),
+                                  IREE_SV("source_pressure_test.loom"),
+                                  &context_, &block_pool_, &options, &module));
+    return ModulePtr(module);
+  }
+
+  loom_func_like_t FindFunction(loom_module_t* module,
+                                iree_string_view_t name) {
+    const loom_string_id_t name_id = loom_module_lookup_string(module, name);
+    IREE_ASSERT_NE(name_id, LOOM_STRING_ID_INVALID);
+    const loom_symbol_id_t symbol_id = loom_module_find_symbol(module, name_id);
+    IREE_ASSERT_NE(symbol_id, LOOM_SYMBOL_ID_INVALID);
+    loom_func_like_t function = loom_func_like_cast(
+        module, module->symbols.entries[symbol_id].defining_op);
+    IREE_ASSERT_NE(function.op, nullptr);
+    return function;
+  }
+
+  loom_low_source_pressure_t Analyze(
+      loom_module_t* module, iree_string_view_t function_name,
+      const loom_low_source_pressure_options_t* options = nullptr) {
+    const loom_target_contract_query_environment_t environment = {
+        /*.module=*/module,
+        /*.function=*/FindFunction(module, function_name),
+        /*.bundle=*/{},
+        /*.target_data=*/{},
+        /*.target_ref=*/{},
+        /*.descriptor_set=*/&descriptor_set_,
+    };
+    loom_low_source_pressure_t pressure;
+    IREE_CHECK_OK(loom_low_source_pressure_analyze(
+        &environment, &kPolicy, options, &analysis_arena_, &pressure));
+    return pressure;
+  }
+
+  iree_arena_block_pool_t block_pool_;
+  loom_context_t context_;
+  iree_arena_allocator_t analysis_arena_;
+  loom_low_descriptor_set_t descriptor_set_ = {};
+};
+
+TEST_F(SourcePressureTest, AlternativeBranchesUseFeasiblePathMaximum) {
+  ModulePtr module = ParseModule(R"(
+func.def @branches(%condition: i1) {
+  scf.if %condition {
+    %i0 = scalar.constant 1 : i32
+    %i1 = scalar.constant 2 : i32
+    %ir0 = scalar.addi %i0, %i1 : i32
+    %ir1 = scalar.addi %i0, %i1 : i32
+    %ir2 = scalar.addi %i0, %i1 : i32
+    %is0 = scalar.addi %ir0, %ir1 : i32
+    %is1 = scalar.addi %is0, %ir2 : i32
+    scf.yield
+  } else {
+    %f0 = scalar.constant 1.0 : f32
+    %f1 = scalar.constant 2.0 : f32
+    %fr0 = scalar.addf %f0, %f1 : f32
+    %fr1 = scalar.addf %f0, %f1 : f32
+    %fr2 = scalar.addf %f0, %f1 : f32
+    %fs0 = scalar.addf %fr0, %fr1 : f32
+    %fs1 = scalar.addf %fs0, %fr2 : f32
+    scf.yield
+  }
+  func.return
+}
+)");
+  const loom_low_source_pressure_options_t options = {
+      /*.reserves=*/{},
+      /*.reserve_count=*/{},
+      /*.flags=*/LOOM_LOW_SOURCE_PRESSURE_OPTION_FLAG_RESERVES_COMPLETE,
+  };
+  const loom_low_source_pressure_t pressure =
+      Analyze(module.get(), IREE_SV("branches"), &options);
+
+  ASSERT_TRUE(loom_low_source_pressure_projection_complete(&pressure));
+  ASSERT_EQ(pressure.direct_resource_count, 2u);
+  EXPECT_EQ(pressure.peak_direct_resource_units[0], 5u);
+  EXPECT_EQ(pressure.peak_direct_resource_units[1], 5u);
+  EXPECT_EQ(pressure.minimum_tier, 4u);
+}
+
+TEST_F(SourcePressureTest, SimultaneousClassesCrossDerivedResourceCliff) {
+  ModulePtr module = ParseModule(R"(
+func.def @overlap(%i0: i32, %i1: i32, %f0: f32, %f1: f32) -> (i32, f32) {
+  %ir0 = scalar.addi %i0, %i1 : i32
+  %ir1 = scalar.addi %i0, %i1 : i32
+  %is = scalar.addi %ir0, %ir1 : i32
+  %fr0 = scalar.addf %f0, %f1 : f32
+  %fr1 = scalar.addf %f0, %f1 : f32
+  %fs = scalar.addf %fr0, %fr1 : f32
+  func.return %is, %fs : i32, f32
+}
+)");
+  const loom_low_source_pressure_options_t options = {
+      /*.reserves=*/{},
+      /*.reserve_count=*/{},
+      /*.flags=*/LOOM_LOW_SOURCE_PRESSURE_OPTION_FLAG_RESERVES_COMPLETE,
+  };
+  const loom_low_source_pressure_t pressure =
+      Analyze(module.get(), IREE_SV("overlap"), &options);
+
+  ASSERT_EQ(pressure.minimum_tier, 2u);
+  ASSERT_NE(pressure.minimum_tier_direct_resource_units, nullptr);
+  EXPECT_GE(pressure.minimum_tier_direct_resource_units[0] +
+                pressure.minimum_tier_direct_resource_units[1],
+            4u);
+}
+
+TEST_F(SourcePressureTest, LoopCarriedAndLiveThroughValuesContribute) {
+  ModulePtr module = ParseModule(R"(
+func.def @loop(%start: index, %end: index, %step: index, %seed: i32, %live: i32) -> (i32) {
+  %result = scf.for %iv = [%start to %end step %step](%acc = %seed : i32) -> (i32) {
+    %next = scalar.addi %acc, %live : i32
+    scf.yield %next : i32
+  }
+  func.return %result : i32
+}
+)");
+  const loom_low_source_pressure_t pressure =
+      Analyze(module.get(), IREE_SV("loop"));
+
+  ASSERT_EQ(pressure.direct_resource_count, 2u);
+  EXPECT_GE(pressure.peak_direct_resource_units[0], 2u);
+  EXPECT_EQ(pressure.mapped_value_count, 5u);
+  EXPECT_EQ(pressure.live_segment_count, 6u);
+  EXPECT_EQ(pressure.transient_segment_count, 1u);
+}
+
+TEST_F(SourcePressureTest, NamedReservesApplyAtEveryProgramPoint) {
+  ModulePtr module = ParseModule(R"(
+func.def @empty() {
+  func.return
+}
+)");
+  const uint64_t abi_units[] = {2, 4};
+  const loom_low_source_pressure_reserve_t reserves[] = {
+      {
+          /*.name=*/IREE_SVL("target_abi"),
+          /*.direct_resource_units=*/abi_units,
+          /*.direct_resource_count=*/IREE_ARRAYSIZE(abi_units),
+      },
+  };
+  const loom_low_source_pressure_options_t options = {
+      /*.reserves=*/reserves,
+      /*.reserve_count=*/IREE_ARRAYSIZE(reserves),
+      /*.flags=*/LOOM_LOW_SOURCE_PRESSURE_OPTION_FLAG_RESERVES_COMPLETE,
+  };
+  const loom_low_source_pressure_t pressure =
+      Analyze(module.get(), IREE_SV("empty"), &options);
+
+  EXPECT_TRUE(loom_low_source_pressure_projection_complete(&pressure));
+  EXPECT_EQ(pressure.minimum_tier, 2u);
+  EXPECT_EQ(pressure.minimum_tier_point, 0u);
+  ASSERT_EQ(pressure.reserve_count, 1u);
+  EXPECT_TRUE(
+      iree_string_view_equal(pressure.reserves[0].name, IREE_SV("target_abi")));
+  EXPECT_EQ(pressure.reserved_direct_resource_units[0], 2u);
+  EXPECT_EQ(pressure.reserved_direct_resource_units[1], 4u);
+}
+
+}  // namespace
+}  // namespace loom

--- a/loom/src/loom/target/arch/amdgpu/lower/BUILD.bazel
+++ b/loom/src/loom/target/arch/amdgpu/lower/BUILD.bazel
@@ -337,6 +337,7 @@ loom_cc_library(
         "//loom/src/loom/target/arch/amdgpu/lower/candidates:compare_candidates",
         "//loom/src/loom/target/arch/amdgpu/matrix:contract",
         "//loom/src/loom/target/arch/amdgpu/matrix:projection",
+        "//loom/src/loom/target/arch/amdgpu/planning:occupancy_model",
         "//loom/src/loom/target/arch/amdgpu/planning:wait_counters",
         "//loom/src/loom/target/arch/amdgpu/planning:wait_packets",
         "//loom/src/loom/target/arch/amdgpu/planning:wait_plan",

--- a/loom/src/loom/target/arch/amdgpu/lower/CMakeLists.txt
+++ b/loom/src/loom/target/arch/amdgpu/lower/CMakeLists.txt
@@ -372,6 +372,7 @@ loom_cc_library(
     loom::target::arch::amdgpu::lower::candidates::compare_candidates
     loom::target::arch::amdgpu::matrix::contract
     loom::target::arch::amdgpu::matrix::projection
+    loom::target::arch::amdgpu::planning::occupancy_model
     loom::target::arch::amdgpu::planning::wait_counters
     loom::target::arch::amdgpu::planning::wait_packets
     loom::target::arch::amdgpu::planning::wait_plan

--- a/loom/src/loom/target/arch/amdgpu/lower/registry.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/registry.c
@@ -69,6 +69,7 @@
 #include "loom/target/arch/amdgpu/lower/value/vector_construct.h"
 #include "loom/target/arch/amdgpu/lower/value/vector_conversion.h"
 #include "loom/target/arch/amdgpu/lower/workgroup.h"
+#include "loom/target/arch/amdgpu/planning/occupancy_model.h"
 
 typedef struct loom_amdgpu_lower_dispatch_row_t
     loom_amdgpu_lower_dispatch_row_t;
@@ -1547,6 +1548,16 @@ static_assert(IREE_ARRAYSIZE(kAmdgpuRuleSets) ==
                   LOOM_AMDGPU_RULE_SET_INDEX_COUNT_,
               "AMDGPU rule-set index enum must match the rule-set table");
 
+static const loom_target_residency_model_t* loom_amdgpu_residency_model(
+    void* user_data,
+    const loom_target_contract_query_environment_t* environment) {
+  (void)user_data;
+  const loom_amdgpu_occupancy_model_t* occupancy_model =
+      loom_amdgpu_occupancy_model_for_descriptor_set_ordinal(
+          environment->descriptor_set->descriptor_set_ordinal);
+  return occupancy_model == NULL ? NULL : &occupancy_model->residency_model;
+}
+
 static const loom_low_lower_policy_t kAmdgpuLowLowerPolicy = {
     .name = IREE_SVL("amdgpu-register-lower"),
     .error_catalog = &loom_amdgpu_error_catalog,
@@ -1554,6 +1565,7 @@ static const loom_low_lower_policy_t kAmdgpuLowLowerPolicy = {
     .map_value = {.fn = loom_amdgpu_map_value, .user_data = NULL},
     .map_contract_value = {.fn = loom_amdgpu_map_contract_value,
                            .user_data = NULL},
+    .residency_model = {.fn = loom_amdgpu_residency_model, .user_data = NULL},
     .map_argument = {.fn = loom_amdgpu_map_argument, .user_data = NULL},
     .map_abi_layout = {.fn = loom_amdgpu_map_abi_layout, .user_data = NULL},
     .emit_preamble = {.fn = loom_amdgpu_emit_preamble, .user_data = NULL},

--- a/loom/src/loom/target/arch/amdgpu/planning/BUILD.bazel
+++ b/loom/src/loom/target/arch/amdgpu/planning/BUILD.bazel
@@ -500,7 +500,7 @@ loom_generated_cc_library(
     hdrs = ["occupancy_model.h"],
     generator = _AMDGPU_OCCUPANCY_TABLE_GENERATOR,
     source = "occupancy_model_tables.c",
-    visibility = _AMDGPU_ROOT_VISIBILITY,
+    visibility = _AMDGPU_ROOT_VISIBILITY + _AMDGPU_LOWER_VISIBILITY,
     deps = [
         "//loom/src/loom/target:residency",
         "//loom/src/loom/target/arch/amdgpu:target_info",

--- a/loom/src/loom/target/residency.c
+++ b/loom/src/loom/target/residency.c
@@ -337,6 +337,130 @@ static iree_status_t loom_target_residency_validate_model(
   return loom_target_residency_validate_derived_resources(model);
 }
 
+static iree_status_t loom_target_residency_validate_query_inputs(
+    const loom_target_residency_model_t* model,
+    const uint64_t* direct_resource_units,
+    iree_host_size_t direct_resource_unit_count) {
+  if (model == NULL) {
+    if (direct_resource_unit_count != 0) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "an unavailable residency model cannot consume direct resources");
+    }
+    return iree_ok_status();
+  }
+  IREE_RETURN_IF_ERROR(loom_target_residency_validate_model(model));
+  if (direct_resource_unit_count != model->direct_resources.resource_count) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "residency query has %zu direct resource values; model requires %u",
+        direct_resource_unit_count,
+        (unsigned)model->direct_resources.resource_count);
+  }
+  if (direct_resource_unit_count != 0 && direct_resource_units == NULL) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "residency query has a null non-empty direct resource vector");
+  }
+  return iree_ok_status();
+}
+
+iree_status_t loom_target_residency_evaluator_initialize(
+    const loom_target_residency_model_t* model,
+    loom_target_residency_evaluator_t* out_evaluator) {
+  if (out_evaluator == NULL) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "residency evaluator output must be non-null");
+  }
+  *out_evaluator = (loom_target_residency_evaluator_t){0};
+  if (model == NULL) return iree_ok_status();
+  IREE_RETURN_IF_ERROR(loom_target_residency_validate_model(model));
+  *out_evaluator = (loom_target_residency_evaluator_t){
+      .model = model,
+      .direct_resource_count = model->direct_resources.resource_count,
+  };
+  return iree_ok_status();
+}
+
+iree_status_t loom_target_residency_evaluator_evaluate_tier(
+    const loom_target_residency_evaluator_t* evaluator,
+    const uint64_t* direct_resource_units,
+    iree_host_size_t direct_resource_unit_count, uint32_t* out_tier) {
+  if (evaluator == NULL || out_tier == NULL) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "residency evaluator and tier output must be "
+                            "non-null");
+  }
+  *out_tier = 0;
+  if (direct_resource_unit_count != evaluator->direct_resource_count) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "residency evaluator has %zu direct resource values; query supplies "
+        "%zu",
+        evaluator->direct_resource_count, direct_resource_unit_count);
+  }
+  if (direct_resource_unit_count != 0 && direct_resource_units == NULL) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "residency evaluator has a null non-empty direct resource vector");
+  }
+  const loom_target_residency_model_t* model = evaluator->model;
+  if (model == NULL) return iree_ok_status();
+
+  uint32_t tier = model->best_tier;
+  for (uint16_t resource_id = 0;
+       resource_id < model->direct_resources.resource_count; ++resource_id) {
+    const loom_target_residency_cliff_range_t range =
+        model->direct_resources.cliff_ranges[resource_id];
+    const loom_target_residency_cliff_t* cliffs =
+        range.count == 0 ? NULL : &model->direct_resources.cliffs[range.start];
+    loom_target_residency_cliff_evaluation_t evaluation;
+    loom_target_residency_evaluate_cliffs(cliffs, range.count, model->best_tier,
+                                          direct_resource_units[resource_id],
+                                          &evaluation);
+    tier = iree_min(tier, evaluation.tier);
+  }
+
+  for (uint16_t resource_id = 0;
+       resource_id < model->derived_resources.resource_count; ++resource_id) {
+    const loom_target_residency_derived_resource_t* resource =
+        &model->derived_resources.resources[resource_id];
+    uint64_t resource_units = 0;
+    for (uint16_t i = 0; i < resource->member_count; ++i) {
+      const loom_target_residency_derived_member_t* member =
+          &model->derived_resources.members[resource->member_start + i];
+      const uint64_t contribution = loom_target_residency_round_resource_units(
+          direct_resource_units[member->direct_resource_id],
+          member->contribution_granularity);
+      resource_units =
+          iree_math_saturating_add_u64(resource_units, contribution);
+    }
+    const loom_target_residency_cliff_t* cliffs =
+        resource->cliff_count == 0
+            ? NULL
+            : &model->derived_resources.cliffs[resource->cliff_start];
+    loom_target_residency_cliff_evaluation_t evaluation;
+    loom_target_residency_evaluate_cliffs(cliffs, resource->cliff_count,
+                                          model->best_tier, resource_units,
+                                          &evaluation);
+    tier = iree_min(tier, evaluation.tier);
+  }
+
+  *out_tier = tier;
+  return iree_ok_status();
+}
+
+iree_status_t loom_target_residency_evaluate_tier(
+    const loom_target_residency_model_t* model,
+    const uint64_t* direct_resource_units,
+    iree_host_size_t direct_resource_unit_count, uint32_t* out_tier) {
+  loom_target_residency_evaluator_t evaluator;
+  IREE_RETURN_IF_ERROR(
+      loom_target_residency_evaluator_initialize(model, &evaluator));
+  return loom_target_residency_evaluator_evaluate_tier(
+      &evaluator, direct_resource_units, direct_resource_unit_count, out_tier);
+}
+
 static void loom_target_residency_resource_cliffs(
     const loom_target_residency_model_t* model,
     const loom_target_residency_resource_evaluation_t* resource_evaluation,
@@ -394,26 +518,12 @@ iree_status_t loom_target_residency_query(
   }
   *out_query = (loom_target_residency_query_t){0};
   if (model == NULL) {
-    if (direct_resource_unit_count != 0) {
-      return iree_make_status(
-          IREE_STATUS_INVALID_ARGUMENT,
-          "an unavailable residency model cannot consume direct resources");
-    }
+    IREE_RETURN_IF_ERROR(loom_target_residency_validate_query_inputs(
+        model, direct_resource_units, direct_resource_unit_count));
     return iree_ok_status();
   }
-  IREE_RETURN_IF_ERROR(loom_target_residency_validate_model(model));
-  if (direct_resource_unit_count != model->direct_resources.resource_count) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "residency query has %zu direct resource values; model requires %u",
-        direct_resource_unit_count,
-        (unsigned)model->direct_resources.resource_count);
-  }
-  if (direct_resource_unit_count != 0 && direct_resource_units == NULL) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "residency query has a null non-empty direct resource vector");
-  }
+  IREE_RETURN_IF_ERROR(loom_target_residency_validate_query_inputs(
+      model, direct_resource_units, direct_resource_unit_count));
 
   const iree_host_size_t resource_count =
       direct_resource_unit_count + model->derived_resources.resource_count;

--- a/loom/src/loom/target/residency.h
+++ b/loom/src/loom/target/residency.h
@@ -220,6 +220,14 @@ typedef struct loom_target_residency_query_t {
   iree_host_size_t limiting_resource_count;
 } loom_target_residency_query_t;
 
+// Validated whole-model tier evaluator for repeated pressure queries.
+typedef struct loom_target_residency_evaluator_t {
+  // Immutable validated model, or NULL when residency is unavailable.
+  const loom_target_residency_model_t* model;
+  // Direct resource vector length required by |model|.
+  iree_host_size_t direct_resource_count;
+} loom_target_residency_evaluator_t;
+
 // Returns true when |table| contains no direct resources and no cliffs.
 static inline bool loom_target_residency_direct_resource_table_is_empty(
     const loom_target_residency_direct_resource_table_t* table) {
@@ -274,6 +282,35 @@ void loom_target_residency_evaluate_cliffs(
     const loom_target_residency_cliff_t* cliffs, iree_host_size_t cliff_count,
     uint32_t initial_tier, uint64_t units,
     loom_target_residency_cliff_evaluation_t* out_evaluation);
+
+// Validates |model| once and prepares a repeated whole-tier evaluator.
+//
+// A null model succeeds and creates an unavailable evaluator whose tier is
+// always zero.
+iree_status_t loom_target_residency_evaluator_initialize(
+    const loom_target_residency_model_t* model,
+    loom_target_residency_evaluator_t* out_evaluator);
+
+// Evaluates one direct-resource vector with a prepared evaluator.
+//
+// This performs no allocation and does not revalidate immutable model tables.
+// |direct_resource_units| must have exactly the count captured by initialize.
+iree_status_t loom_target_residency_evaluator_evaluate_tier(
+    const loom_target_residency_evaluator_t* evaluator,
+    const uint64_t* direct_resource_units,
+    iree_host_size_t direct_resource_unit_count, uint32_t* out_tier);
+
+// Evaluates only the whole-model residency tier without allocating storage.
+//
+// |direct_resource_units| is dense by direct resource ID and must exactly
+// match the model's direct resource count. A null model succeeds with tier zero
+// when no direct resource values are supplied. This is the hot-path query for
+// pressure sweeps; use |loom_target_residency_query| when transition distances
+// and limiting-resource diagnostics are required.
+iree_status_t loom_target_residency_evaluate_tier(
+    const loom_target_residency_model_t* model,
+    const uint64_t* direct_resource_units,
+    iree_host_size_t direct_resource_unit_count, uint32_t* out_tier);
 
 // Evaluates all resources and the resulting whole-model residency tier.
 //

--- a/loom/src/loom/target/residency_test.cc
+++ b/loom/src/loom/target/residency_test.cc
@@ -184,6 +184,38 @@ TEST_F(ResidencyTest, CliffEvaluationUsesExactBoundaries) {
       LOOM_TARGET_RESIDENCY_CLIFF_EVALUATION_FLAG_HAS_WORSE_TIER));
 }
 
+TEST_F(ResidencyTest, TierEvaluationRequiresNoDiagnosticStorage) {
+  struct TestCase {
+    uint64_t vector_units;
+    uint64_t scalar_units;
+    uint32_t expected_tier;
+  };
+  const TestCase test_cases[] = {
+      {/*.vector_units=*/0, /*.scalar_units=*/0, /*.expected_tier=*/4},
+      {/*.vector_units=*/4, /*.scalar_units=*/2, /*.expected_tier=*/4},
+      // The derived shared resource crosses its first cliff even though neither
+      // direct resource does.
+      {/*.vector_units=*/4, /*.scalar_units=*/5, /*.expected_tier=*/2},
+      {/*.vector_units=*/5, /*.scalar_units=*/0, /*.expected_tier=*/2},
+      {/*.vector_units=*/9, /*.scalar_units=*/11, /*.expected_tier=*/0},
+  };
+  for (const TestCase& test_case : test_cases) {
+    const uint64_t direct_units[] = {test_case.vector_units,
+                                     test_case.scalar_units};
+    uint32_t tier = UINT32_MAX;
+    IREE_ASSERT_OK(loom_target_residency_evaluate_tier(
+        &kModel, direct_units, IREE_ARRAYSIZE(direct_units), &tier));
+    EXPECT_EQ(tier, test_case.expected_tier);
+  }
+}
+
+TEST_F(ResidencyTest, TierEvaluationMakesUnavailableModelExplicit) {
+  uint32_t tier = UINT32_MAX;
+  IREE_ASSERT_OK(
+      loom_target_residency_evaluate_tier(nullptr, nullptr, 0, &tier));
+  EXPECT_EQ(tier, 0u);
+}
+
 TEST_F(ResidencyTest, UnavailableModelIsExplicit) {
   loom_target_residency_query_t query;
   IREE_ASSERT_OK(


### PR DESCRIPTION
Loom can now project structured source SSA liveness into the same ordered target-residency model used to reason about physical resource allocation. Source transforms no longer need to approximate a scheduling decision with a target-independent value count, and target-low validation does not need a second definition of the cliffs that matter. Both stages consume one immutable model over direct and derived resource vectors.

## Target residency evaluation

The residency layer now provides a prepared evaluator for repeated whole-model tier queries. Initialization validates the immutable target tables once; each subsequent query evaluates a dense direct-resource vector without allocating diagnostic storage or revalidating the model. This is the query shape needed by a pressure sweep or placement search that may evaluate many program points.

Direct resources contribute through their own ordered cliff tables. Derived resources combine one or more direct resources using target-defined allocation granularities before applying shared cliffs, allowing a target to describe coupled pools and aggregate limits without teaching the compiler what those resources mean. The effective residency tier is the most restrictive tier produced by any direct or derived resource. Saturating arithmetic keeps malformed or extreme inputs from wrapping into a falsely favorable result.

The existing diagnostic query remains the richer interface for explaining a selected vector: it identifies limiting resources, the next worse cliff, and the reductions needed to recover a better tier. The prepared evaluator and diagnostic query share the same validated model and cliff semantics, so a fast planning decision and its later explanation cannot drift.

Model absence is explicit. An unavailable model accepts no resource vector and produces tier zero; it is not interpreted as unlimited capacity. Callers can therefore distinguish a target that has no residency contract from one whose resource usage genuinely occupies the best tier.

## Structured source-pressure projection

The new source-pressure analysis maps source SSA values through the selected lowering policy into target-authored direct resource units. Resource identities are the descriptor register-class IDs already used by lowering, so the source projection and physical allocation speak the same target contract without generic code testing source types for AMDGPU-specific classes.

The analysis acquires or reuses the function's region-tree value domain, view-region facts, target query state, and structured liveness. Each mapped liveness segment becomes a pair of deterministic pressure events. Segment ends are applied before starts at the same program point, preventing adjacent non-overlapping lifetimes from being counted together. Leaf-operation results that have no ordinary live interval still receive a one-point issue segment, preserving the transient destination pressure required to execute the operation rather than treating an unused result as free.

Sweeping those events produces two deliberately different forms of evidence:

- Per-resource peaks report the maximum observed units for each direct resource independently.
- The vector captured at the earliest worst-tier program point reports resources that were simultaneously live when residency was actually constrained.

That distinction matters for derived resources. Combining independent SGPR-like and VGPR-like peaks from different branches or program points could invent a shared-pool cliff that no feasible execution reaches. Evaluating the simultaneous vector at every structured program point preserves branch exclusivity while still accounting for join-live values, loop-carried values, values live through nested regions, and transient results. The projection therefore composes alternative paths by their feasible maximum rather than summing mutually exclusive pressure.

Named reserve contributors account for target state that is not represented by source SSA values, such as fixed ABI state or bounded lower-level temporaries. Each reserve carries a stable name and a complete direct-resource vector, is copied into analysis-owned storage, and is applied at every program point. A separate completeness bit records whether those contributors bound all non-source pressure. Consumers can use an incomplete envelope as evidence without mistaking it for a proof that a residency floor will survive physical allocation.

The resulting arena-owned envelope records model availability, projection completeness, the worst tier and its earliest program point, independent resource peaks, the simultaneous worst-tier vector, the aggregate and per-contributor reserves, and counts for mapped values, non-register values, liveness segments, and transient issue segments. Invalid resource IDs, zero-sized register mappings, descriptor/model mismatches, malformed reserve vectors, liveness underflow, and arithmetic overflow fail loudly instead of silently weakening the estimate.

## Target integration and impact

Lowering policies gain one optional callback that selects the immutable residency model for a target contract. AMDGPU implements it by returning the existing occupancy model associated with the selected descriptor set. The generic evaluator and source analysis contain no SGPR, VGPR, AGPR, wave, or occupancy branches; another target can define different resource classes, coupled pools, or throughput tiers behind the same interface.

This gives placement and scheduling transforms a target-aware but target-neutral question: for the values simultaneously live at this source placement, which ordered residency tier does the selected target model predict? The answer can be compared across legal alternatives before unrolling and structural lowering, while final physical allocation can be checked against the same cliff tables afterward. A projection miss is therefore measurable disagreement between conservative source evidence and exact allocation, not disagreement between two independently implemented cost models.

Coverage exercises exact tier boundaries, direct and derived resource interaction, explicit model absence, mutually exclusive branch pressure, simultaneous cross-class pressure, loop-carried and live-through values, transient issue pressure, and named reserves that constrain even an otherwise empty function. Both Bazel and CMake build and test the analysis as a compiler library with visibility restricted to the low pipeline and loop transforms.
