### PR TITLE
[Loom/AMDGPU] Report and qualify residency planning

### DIFF
--- a/loom/src/loom/target/reporting/format.h
+++ b/loom/src/loom/target/reporting/format.h
@@ -17,6 +17,9 @@
 extern "C" {
 #endif
 
+// Version of the structured compile-report JSON schema.
+#define LOOM_TARGET_COMPILE_REPORT_JSON_SCHEMA_VERSION 1u
+
 typedef enum loom_target_compile_report_format_mode_e {
   // Does not format a compile report.
   LOOM_TARGET_COMPILE_REPORT_FORMAT_MODE_NONE = 0,
@@ -53,7 +56,9 @@ iree_status_t loom_target_compile_report_format_text(
     const loom_target_compile_report_format_options_t* options,
     iree_string_builder_t* builder);
 
-// Formats |report| as one structured JSON object into |stream|.
+// Formats |report| as one structured JSON object into |stream|. Every emitted
+// object begins with schema_version so consumers can reject incompatible
+// layouts before interpreting optional detail sections.
 //
 // SUMMARY mode emits stable summary fields, row counts, and the entry index.
 // DETAILS mode additionally emits copied row arrays such as pressure, spill,

--- a/loom/src/loom/target/reporting/format_json.c
+++ b/loom/src/loom/target/reporting/format_json.c
@@ -709,6 +709,62 @@ static iree_status_t loom_target_compile_report_format_target_resources_json(
   return loom_json_object_end(&object);
 }
 
+static iree_status_t loom_target_compile_report_format_exact_residency_json(
+    const loom_target_compile_report_exact_residency_t* residency,
+    loom_output_stream_t* stream) {
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("contract_count"), residency->contract_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("evaluated_contract_count"),
+      residency->evaluated_contract_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("unevaluated_contract_count"),
+      residency->unevaluated_contract_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("minimum_contract_count"),
+      residency->minimum_contract_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("preserve_contract_count"),
+      residency->preserve_contract_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("satisfied_contract_count"),
+      residency->satisfied_contract_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("unsatisfied_contract_count"),
+      residency->unsatisfied_contract_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("repaired_contract_count"),
+      residency->repaired_contract_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("projection_miss_count"),
+      residency->projection_miss_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("candidate_count"), residency->candidate_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("attempted_candidate_count"),
+      residency->attempted_candidate_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("repair_count"), residency->repair_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("maximum_required_tier"),
+      residency->maximum_required_tier));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("maximum_minimum_tier"),
+      residency->maximum_minimum_tier));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("maximum_projected_baseline_tier"),
+      residency->maximum_projected_baseline_tier));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("minimum_allocated_tier"),
+      residency->minimum_allocated_tier));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("maximum_tier_shortfall"),
+      residency->maximum_tier_shortfall));
+  return loom_json_object_end(&object);
+}
+
 static iree_status_t loom_target_compile_report_format_dimension3_json(
     uint32_t x, uint32_t y, uint32_t z, uint64_t flat, bool include_flat,
     loom_output_stream_t* stream) {
@@ -1270,6 +1326,13 @@ static iree_status_t loom_target_compile_report_format_entry_json(
         loom_target_compile_report_format_target_resources_json(
             &row->target_resources, stream));
   }
+  if (iree_any_bit_set(row->detail_flags,
+                       LOOM_TARGET_COMPILE_REPORT_DETAIL_EXACT_RESIDENCY)) {
+    IREE_RETURN_IF_ERROR(
+        loom_json_object_begin_field(&object, IREE_SV("exact_residency")));
+    IREE_RETURN_IF_ERROR(loom_target_compile_report_format_exact_residency_json(
+        &row->exact_residency, stream));
+  }
   if (iree_any_bit_set(
           row->detail_flags,
           LOOM_TARGET_COMPILE_REPORT_DETAIL_STATIC_INSTRUCTION_MIX)) {
@@ -1380,6 +1443,9 @@ iree_status_t loom_target_compile_report_format_json(
   }
   loom_json_object_writer_t object;
   IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("schema_version"),
+      LOOM_TARGET_COMPILE_REPORT_JSON_SCHEMA_VERSION));
   IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
       &object, IREE_SV("artifact_kind"),
       loom_target_compile_report_artifact_kind_name(report->artifact_kind)));
@@ -1561,6 +1627,13 @@ iree_status_t loom_target_compile_report_format_json(
     IREE_RETURN_IF_ERROR(
         loom_target_compile_report_format_target_resources_json(
             &report->target_resources, stream));
+  }
+  if (iree_any_bit_set(report->detail_flags,
+                       LOOM_TARGET_COMPILE_REPORT_DETAIL_EXACT_RESIDENCY)) {
+    IREE_RETURN_IF_ERROR(
+        loom_json_object_begin_field(&object, IREE_SV("exact_residency")));
+    IREE_RETURN_IF_ERROR(loom_target_compile_report_format_exact_residency_json(
+        &report->exact_residency, stream));
   }
   IREE_RETURN_IF_ERROR(loom_target_compile_report_format_json_planning_details(
       report, options->mode, &object, stream));

--- a/loom/src/loom/target/reporting/format_json_lowering.c
+++ b/loom/src/loom/target/reporting/format_json_lowering.c
@@ -329,6 +329,297 @@ loom_target_compile_report_format_source_low_transforms_json(
   return loom_json_object_end(&object);
 }
 
+static iree_status_t
+loom_target_compile_report_format_source_low_residency_row_json(
+    const loom_target_compile_report_source_low_residency_row_t* row,
+    iree_host_size_t row_index, loom_output_stream_t* stream) {
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(
+      &object, IREE_SV("index"), row_index));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("function"), row->function_name));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("source_op"), row->source_op_name));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("source_op_kind"), row->source_op_kind));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("policy"), row->policy));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("outcome"), row->outcome));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("reason"), row->reason));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("baseline_tier"), row->baseline_tier));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("selected_tier"), row->selected_tier));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("required_tier"), row->required_tier));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("candidate_count"), row->candidate_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("selected_count"), row->selected_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("rejected_count"), row->rejected_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("reserve_count"), row->reserve_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_bool_field(
+      &object, IREE_SV("projection_complete"), row->projection_complete));
+  return loom_json_object_end(&object);
+}
+
+static iree_status_t
+loom_target_compile_report_format_source_low_residency_json(
+    const loom_target_compile_report_t* report,
+    loom_target_compile_report_format_mode_t mode,
+    loom_output_stream_t* stream) {
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(
+      &object, IREE_SV("count"), report->source_low_residency_rows.count));
+  if (mode != LOOM_TARGET_COMPILE_REPORT_FORMAT_MODE_DETAILS) {
+    return loom_json_object_end(&object);
+  }
+  IREE_RETURN_IF_ERROR(loom_json_object_begin_field(&object, IREE_SV("rows")));
+  loom_json_array_writer_t array;
+  IREE_RETURN_IF_ERROR(loom_json_array_begin(stream, &array));
+  iree_host_size_t row_index = 0;
+  for (const loom_target_compile_report_vec_t* vec =
+           report->source_low_residency_rows.head;
+       vec != NULL; vec = vec->next) {
+    const loom_target_compile_report_source_low_residency_row_t* rows =
+        (const loom_target_compile_report_source_low_residency_row_t*)
+            loom_target_compile_report_vec_const_rows(vec);
+    for (iree_host_size_t i = 0; i < vec->count; ++i, ++row_index) {
+      IREE_RETURN_IF_ERROR(loom_json_array_begin_element(&array));
+      IREE_RETURN_IF_ERROR(
+          loom_target_compile_report_format_source_low_residency_row_json(
+              &rows[i], row_index, stream));
+    }
+  }
+  IREE_RETURN_IF_ERROR(loom_json_array_end(&array));
+  return loom_json_object_end(&object);
+}
+
+static iree_status_t
+loom_target_compile_report_format_source_low_residency_resource_row_json(
+    const loom_target_compile_report_source_low_residency_resource_row_t* row,
+    iree_host_size_t row_index, loom_output_stream_t* stream) {
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(
+      &object, IREE_SV("index"), row_index));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("function"), row->function_name));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("source_op"), row->source_op_name));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("source_op_kind"), row->source_op_kind));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("phase"), row->phase));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("program_point"), row->program_point));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("resource"), row->resource_name));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("resource_kind"), row->resource_kind));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("resource_id"), row->resource_id));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("units"), row->units));
+  IREE_RETURN_IF_ERROR(
+      loom_json_object_write_uint32_field(&object, IREE_SV("tier"), row->tier));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("next_better_tier"), row->next_better_tier));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("next_worse_tier"), row->next_worse_tier));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("next_worse_cliff_units"), row->next_worse_cliff_units));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("additional_units_to_next_worse_tier"),
+      row->additional_units_to_next_worse_tier));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("reduction_units_to_next_better_tier"),
+      row->reduction_units_to_next_better_tier));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_bool_field(
+      &object, IREE_SV("limiting"), row->limiting));
+  return loom_json_object_end(&object);
+}
+
+static iree_status_t
+loom_target_compile_report_format_source_low_residency_resources_json(
+    const loom_target_compile_report_t* report,
+    loom_target_compile_report_format_mode_t mode,
+    loom_output_stream_t* stream) {
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(
+      &object, IREE_SV("count"),
+      report->source_low_residency_resource_rows.count));
+  if (mode != LOOM_TARGET_COMPILE_REPORT_FORMAT_MODE_DETAILS) {
+    return loom_json_object_end(&object);
+  }
+  IREE_RETURN_IF_ERROR(loom_json_object_begin_field(&object, IREE_SV("rows")));
+  loom_json_array_writer_t array;
+  IREE_RETURN_IF_ERROR(loom_json_array_begin(stream, &array));
+  iree_host_size_t row_index = 0;
+  for (const loom_target_compile_report_vec_t* vec =
+           report->source_low_residency_resource_rows.head;
+       vec != NULL; vec = vec->next) {
+    const loom_target_compile_report_source_low_residency_resource_row_t* rows =
+        (const loom_target_compile_report_source_low_residency_resource_row_t*)
+            loom_target_compile_report_vec_const_rows(vec);
+    for (iree_host_size_t i = 0; i < vec->count; ++i, ++row_index) {
+      IREE_RETURN_IF_ERROR(loom_json_array_begin_element(&array));
+      IREE_RETURN_IF_ERROR(
+          loom_target_compile_report_format_source_low_residency_resource_row_json(
+              &rows[i], row_index, stream));
+    }
+  }
+  IREE_RETURN_IF_ERROR(loom_json_array_end(&array));
+  return loom_json_object_end(&object);
+}
+
+static iree_status_t
+loom_target_compile_report_format_source_low_residency_reserve_row_json(
+    const loom_target_compile_report_source_low_residency_reserve_row_t* row,
+    iree_host_size_t row_index, loom_output_stream_t* stream) {
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(
+      &object, IREE_SV("index"), row_index));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("function"), row->function_name));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("reserve"), row->reserve_name));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("resource"), row->resource_name));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("resource_id"), row->resource_id));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("units"), row->units));
+  return loom_json_object_end(&object);
+}
+
+static iree_status_t
+loom_target_compile_report_format_source_low_residency_reserves_json(
+    const loom_target_compile_report_t* report,
+    loom_target_compile_report_format_mode_t mode,
+    loom_output_stream_t* stream) {
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(
+      &object, IREE_SV("count"),
+      report->source_low_residency_reserve_rows.count));
+  if (mode != LOOM_TARGET_COMPILE_REPORT_FORMAT_MODE_DETAILS) {
+    return loom_json_object_end(&object);
+  }
+  IREE_RETURN_IF_ERROR(loom_json_object_begin_field(&object, IREE_SV("rows")));
+  loom_json_array_writer_t array;
+  IREE_RETURN_IF_ERROR(loom_json_array_begin(stream, &array));
+  iree_host_size_t row_index = 0;
+  for (const loom_target_compile_report_vec_t* vec =
+           report->source_low_residency_reserve_rows.head;
+       vec != NULL; vec = vec->next) {
+    const loom_target_compile_report_source_low_residency_reserve_row_t* rows =
+        (const loom_target_compile_report_source_low_residency_reserve_row_t*)
+            loom_target_compile_report_vec_const_rows(vec);
+    for (iree_host_size_t i = 0; i < vec->count; ++i, ++row_index) {
+      IREE_RETURN_IF_ERROR(loom_json_array_begin_element(&array));
+      IREE_RETURN_IF_ERROR(
+          loom_target_compile_report_format_source_low_residency_reserve_row_json(
+              &rows[i], row_index, stream));
+    }
+  }
+  IREE_RETURN_IF_ERROR(loom_json_array_end(&array));
+  return loom_json_object_end(&object);
+}
+
+static iree_status_t
+loom_target_compile_report_format_residency_candidate_row_json(
+    const loom_target_compile_report_residency_candidate_row_t* row,
+    iree_host_size_t row_index, loom_output_stream_t* stream) {
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(
+      &object, IREE_SV("index"), row_index));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("function"), row->function_name));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("source_op"), row->source_op_name));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("source_op_kind"), row->source_op_kind));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("candidate_id"), row->candidate_id));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("stage"), row->stage));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("outcome"), row->outcome));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("projected_recompute_cost"),
+      row->projected_recompute_cost));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("exact_use_count"), row->exact_use_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("cloned_packet_count"), row->cloned_packet_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("rewritten_operand_count"),
+      row->rewritten_operand_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_bool_field(
+      &object, IREE_SV("preserves_baseline"), row->preserves_baseline));
+  return loom_json_object_end(&object);
+}
+
+static iree_status_t
+loom_target_compile_report_format_residency_candidates_json(
+    const loom_target_compile_report_t* report,
+    loom_target_compile_report_format_mode_t mode,
+    loom_output_stream_t* stream) {
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(
+      &object, IREE_SV("count"), report->residency_candidate_rows.count));
+  if (mode != LOOM_TARGET_COMPILE_REPORT_FORMAT_MODE_DETAILS) {
+    return loom_json_object_end(&object);
+  }
+  IREE_RETURN_IF_ERROR(loom_json_object_begin_field(&object, IREE_SV("rows")));
+  loom_json_array_writer_t array;
+  IREE_RETURN_IF_ERROR(loom_json_array_begin(stream, &array));
+  iree_host_size_t row_index = 0;
+  for (const loom_target_compile_report_vec_t* vec =
+           report->residency_candidate_rows.head;
+       vec != NULL; vec = vec->next) {
+    const loom_target_compile_report_residency_candidate_row_t* rows =
+        (const loom_target_compile_report_residency_candidate_row_t*)
+            loom_target_compile_report_vec_const_rows(vec);
+    for (iree_host_size_t i = 0; i < vec->count; ++i, ++row_index) {
+      IREE_RETURN_IF_ERROR(loom_json_array_begin_element(&array));
+      IREE_RETURN_IF_ERROR(
+          loom_target_compile_report_format_residency_candidate_row_json(
+              &rows[i], row_index, stream));
+    }
+  }
+  IREE_RETURN_IF_ERROR(loom_json_array_end(&array));
+  return loom_json_object_end(&object);
+}
+
 static iree_status_t loom_target_compile_report_format_memory_interval_json(
     const loom_target_compile_report_memory_interval_t* interval,
     loom_json_object_writer_t* object) {
@@ -1100,6 +1391,34 @@ static iree_status_t loom_target_compile_report_format_source_low_json(
         loom_json_object_begin_field(&object, IREE_SV("transforms")));
     IREE_RETURN_IF_ERROR(
         loom_target_compile_report_format_source_low_transforms_json(
+            report, mode, stream));
+  }
+  if (report->source_low_residency_rows.count != 0) {
+    IREE_RETURN_IF_ERROR(
+        loom_json_object_begin_field(&object, IREE_SV("residency_placements")));
+    IREE_RETURN_IF_ERROR(
+        loom_target_compile_report_format_source_low_residency_json(
+            report, mode, stream));
+  }
+  if (report->source_low_residency_resource_rows.count != 0) {
+    IREE_RETURN_IF_ERROR(
+        loom_json_object_begin_field(&object, IREE_SV("residency_resources")));
+    IREE_RETURN_IF_ERROR(
+        loom_target_compile_report_format_source_low_residency_resources_json(
+            report, mode, stream));
+  }
+  if (report->source_low_residency_reserve_rows.count != 0) {
+    IREE_RETURN_IF_ERROR(
+        loom_json_object_begin_field(&object, IREE_SV("residency_reserves")));
+    IREE_RETURN_IF_ERROR(
+        loom_target_compile_report_format_source_low_residency_reserves_json(
+            report, mode, stream));
+  }
+  if (report->residency_candidate_rows.count != 0) {
+    IREE_RETURN_IF_ERROR(
+        loom_json_object_begin_field(&object, IREE_SV("residency_candidates")));
+    IREE_RETURN_IF_ERROR(
+        loom_target_compile_report_format_residency_candidates_json(
             report, mode, stream));
   }
   IREE_RETURN_IF_ERROR(

--- a/loom/src/loom/target/reporting/format_json_test.cc
+++ b/loom/src/loom/target/reporting/format_json_test.cc
@@ -316,6 +316,178 @@ TEST(CompileReportFormatTest, FormatsSourceLowTransformRowsJson) {
   loom_target_compile_report_deinitialize(&report);
 }
 
+TEST(CompileReportFormatTest, FormatsSourceLowResidencyRowsJson) {
+  loom_target_compile_report_t report = {};
+  loom_target_compile_report_initialize(&report, iree_allocator_system());
+  report.requested_detail_flags =
+      LOOM_TARGET_COMPILE_REPORT_DETAIL_SOURCE_LOW_ROWS;
+  loom_target_compile_report_source_low_residency_row_t row = {};
+  row.function_name = IREE_SVL("kernel");
+  row.source_op_name = IREE_SVL("scf.for");
+  row.source_op_kind = 42;
+  row.policy = IREE_SVL("preserve");
+  row.outcome = IREE_SVL("selected");
+  row.reason = IREE_SVL("residency_cliff");
+  row.baseline_tier = 4;
+  row.selected_tier = 4;
+  row.required_tier = 4;
+  row.candidate_count = 3;
+  row.selected_count = 2;
+  row.rejected_count = 1;
+  row.reserve_count = 2;
+  row.projection_complete = true;
+  IREE_ASSERT_OK(loom_target_compile_report_record_source_low_residency_row(
+      &report, &row));
+  loom_target_compile_report_source_low_residency_resource_row_t resource = {};
+  resource.function_name = IREE_SVL("kernel");
+  resource.source_op_name = IREE_SVL("scf.for");
+  resource.source_op_kind = 42;
+  resource.phase = IREE_SVL("selected");
+  resource.program_point = 17;
+  resource.resource_name = IREE_SVL("vgpr");
+  resource.resource_kind = IREE_SVL("direct");
+  resource.resource_id = 1;
+  resource.units = 112;
+  resource.tier = 4;
+  resource.next_better_tier = 0;
+  resource.next_worse_tier = 3;
+  resource.next_worse_cliff_units = 128;
+  resource.additional_units_to_next_worse_tier = 16;
+  resource.reduction_units_to_next_better_tier = 0;
+  resource.limiting = false;
+  IREE_ASSERT_OK(
+      loom_target_compile_report_record_source_low_residency_resource_row(
+          &report, &resource));
+  loom_target_compile_report_source_low_residency_reserve_row_t reserve = {};
+  reserve.function_name = IREE_SVL("kernel");
+  reserve.reserve_name = IREE_SVL("target_abi");
+  reserve.resource_name = IREE_SVL("sgpr");
+  reserve.resource_id = 0;
+  reserve.units = 8;
+  IREE_ASSERT_OK(
+      loom_target_compile_report_record_source_low_residency_reserve_row(
+          &report, &reserve));
+  loom_target_compile_report_residency_candidate_row_t candidate = {};
+  candidate.function_name = IREE_SVL("kernel");
+  candidate.source_op_name = IREE_SVL("scalar.addf");
+  candidate.source_op_kind = 43;
+  candidate.candidate_id = 7;
+  candidate.stage = IREE_SVL("exact");
+  candidate.outcome = IREE_SVL("restored");
+  candidate.projected_recompute_cost = 2;
+  candidate.exact_use_count = 3;
+  candidate.cloned_packet_count = 1;
+  candidate.rewritten_operand_count = 3;
+  candidate.preserves_baseline = true;
+  IREE_ASSERT_OK(loom_target_compile_report_record_residency_candidate_row(
+      &report, &candidate));
+
+  iree_string_builder_t builder;
+  iree_string_builder_initialize(iree_allocator_system(), &builder);
+  loom_output_stream_t stream;
+  loom_output_stream_for_builder(&builder, &stream);
+  const loom_target_compile_report_format_options_t summary_options = {
+      /*.mode=*/LOOM_TARGET_COMPILE_REPORT_FORMAT_MODE_SUMMARY,
+  };
+  IREE_ASSERT_OK(loom_target_compile_report_format_json(
+      &report, &summary_options, &stream));
+  iree_string_view_t root =
+      ParseJsonDocument(iree_string_builder_view(&builder));
+  iree_string_view_t source_low = LookupObject(root, IREE_SV("source_low"));
+  iree_string_view_t placements =
+      LookupObject(source_low, IREE_SV("residency_placements"));
+  ExpectObjectUint64Equals(placements, IREE_SV("count"), 1);
+  EXPECT_TRUE(
+      iree_string_view_is_empty(TryLookupObject(placements, IREE_SV("rows"))));
+  const iree_string_view_t candidate_summary =
+      LookupObject(source_low, IREE_SV("residency_candidates"));
+  ExpectObjectUint64Equals(candidate_summary, IREE_SV("count"), 1);
+  EXPECT_TRUE(iree_string_view_is_empty(
+      TryLookupObject(candidate_summary, IREE_SV("rows"))));
+  const iree_string_view_t resource_summary =
+      LookupObject(source_low, IREE_SV("residency_resources"));
+  ExpectObjectUint64Equals(resource_summary, IREE_SV("count"), 1);
+  const iree_string_view_t reserve_summary =
+      LookupObject(source_low, IREE_SV("residency_reserves"));
+  ExpectObjectUint64Equals(reserve_summary, IREE_SV("count"), 1);
+  iree_string_builder_deinitialize(&builder);
+
+  iree_string_builder_initialize(iree_allocator_system(), &builder);
+  loom_output_stream_for_builder(&builder, &stream);
+  const loom_target_compile_report_format_options_t details_options = {
+      /*.mode=*/LOOM_TARGET_COMPILE_REPORT_FORMAT_MODE_DETAILS,
+  };
+  IREE_ASSERT_OK(loom_target_compile_report_format_json(
+      &report, &details_options, &stream));
+  root = ParseJsonDocument(iree_string_builder_view(&builder));
+  source_low = LookupObject(root, IREE_SV("source_low"));
+  placements = LookupObject(source_low, IREE_SV("residency_placements"));
+  const iree_string_view_t placement =
+      LookupArrayElement(LookupObject(placements, IREE_SV("rows")), 0);
+  ExpectObjectValueEquals(placement, IREE_SV("function"), IREE_SV("kernel"));
+  ExpectObjectValueEquals(placement, IREE_SV("source_op"), IREE_SV("scf.for"));
+  ExpectObjectUint64Equals(placement, IREE_SV("source_op_kind"), 42);
+  ExpectObjectValueEquals(placement, IREE_SV("policy"), IREE_SV("preserve"));
+  ExpectObjectValueEquals(placement, IREE_SV("outcome"), IREE_SV("selected"));
+  ExpectObjectValueEquals(placement, IREE_SV("reason"),
+                          IREE_SV("residency_cliff"));
+  ExpectObjectUint64Equals(placement, IREE_SV("baseline_tier"), 4);
+  ExpectObjectUint64Equals(placement, IREE_SV("selected_tier"), 4);
+  ExpectObjectUint64Equals(placement, IREE_SV("required_tier"), 4);
+  ExpectObjectUint64Equals(placement, IREE_SV("candidate_count"), 3);
+  ExpectObjectUint64Equals(placement, IREE_SV("selected_count"), 2);
+  ExpectObjectUint64Equals(placement, IREE_SV("rejected_count"), 1);
+  ExpectObjectUint64Equals(placement, IREE_SV("reserve_count"), 2);
+  ExpectObjectValueEquals(placement, IREE_SV("projection_complete"),
+                          IREE_SV("true"));
+  const iree_string_view_t candidates =
+      LookupObject(source_low, IREE_SV("residency_candidates"));
+  const iree_string_view_t candidate_row =
+      LookupArrayElement(LookupObject(candidates, IREE_SV("rows")), 0);
+  ExpectObjectValueEquals(candidate_row, IREE_SV("function"),
+                          IREE_SV("kernel"));
+  ExpectObjectValueEquals(candidate_row, IREE_SV("source_op"),
+                          IREE_SV("scalar.addf"));
+  ExpectObjectUint64Equals(candidate_row, IREE_SV("candidate_id"), 7);
+  ExpectObjectValueEquals(candidate_row, IREE_SV("stage"), IREE_SV("exact"));
+  ExpectObjectValueEquals(candidate_row, IREE_SV("outcome"),
+                          IREE_SV("restored"));
+  ExpectObjectUint64Equals(candidate_row, IREE_SV("projected_recompute_cost"),
+                           2);
+  ExpectObjectUint64Equals(candidate_row, IREE_SV("exact_use_count"), 3);
+  ExpectObjectUint64Equals(candidate_row, IREE_SV("cloned_packet_count"), 1);
+  ExpectObjectUint64Equals(candidate_row, IREE_SV("rewritten_operand_count"),
+                           3);
+  ExpectObjectValueEquals(candidate_row, IREE_SV("preserves_baseline"),
+                          IREE_SV("true"));
+  const iree_string_view_t resources =
+      LookupObject(source_low, IREE_SV("residency_resources"));
+  const iree_string_view_t resource_row =
+      LookupArrayElement(LookupObject(resources, IREE_SV("rows")), 0);
+  ExpectObjectValueEquals(resource_row, IREE_SV("phase"), IREE_SV("selected"));
+  ExpectObjectUint64Equals(resource_row, IREE_SV("program_point"), 17);
+  ExpectObjectValueEquals(resource_row, IREE_SV("resource"), IREE_SV("vgpr"));
+  ExpectObjectValueEquals(resource_row, IREE_SV("resource_kind"),
+                          IREE_SV("direct"));
+  ExpectObjectUint64Equals(resource_row, IREE_SV("units"), 112);
+  ExpectObjectUint64Equals(resource_row, IREE_SV("next_worse_tier"), 3);
+  ExpectObjectUint64Equals(resource_row, IREE_SV("next_worse_cliff_units"),
+                           128);
+  ExpectObjectUint64Equals(resource_row,
+                           IREE_SV("additional_units_to_next_worse_tier"), 16);
+  const iree_string_view_t reserves =
+      LookupObject(source_low, IREE_SV("residency_reserves"));
+  const iree_string_view_t reserve_row =
+      LookupArrayElement(LookupObject(reserves, IREE_SV("rows")), 0);
+  ExpectObjectValueEquals(reserve_row, IREE_SV("reserve"),
+                          IREE_SV("target_abi"));
+  ExpectObjectValueEquals(reserve_row, IREE_SV("resource"), IREE_SV("sgpr"));
+  ExpectObjectUint64Equals(reserve_row, IREE_SV("units"), 8);
+  iree_string_builder_deinitialize(&builder);
+
+  loom_target_compile_report_deinitialize(&report);
+}
+
 TEST(CompileReportFormatTest, FormatsAndAggregatesLowPlanningStatistics) {
   loom_target_compile_report_t report;
   loom_target_compile_report_initialize(&report, iree_allocator_system());
@@ -330,12 +502,40 @@ TEST(CompileReportFormatTest, FormatsAndAggregatesLowPlanningStatistics) {
     planning->allocation_run_count = i + 1;
     planning->repair.iteration_count = i + 2;
     planning->repair.diagnostic_replay_count = i + 3;
+    planning->residency.contract_count = i;
+    planning->residency.candidate_count = i + 4;
+    planning->residency.maximum_projected_required_tier = i + 1;
+    planning->residency.validation_count = i + 5;
+    planning->residency.minimum_observed_allocated_tier = 5 - i;
+    planning->residency.maximum_observed_tier_shortfall = i - 1;
+    planning->residency.repair_attempt_count = i + 6;
+    planning->residency.repair_count = i + 7;
+    planning->residency.failure_count = i - 1;
     planning->memory.frame_arena.used_bytes_high_water = i * 100;
     planning->memory.frame_arena.owned_bytes_high_water = i * 200;
     planning->memory.block_system_allocation_count = i;
     planning->memory.block_system_allocation_bytes = i * 32768;
     planning->memory.oversized_allocation_count = i + 4;
     planning->memory.oversized_allocation_bytes = i * 4096;
+    const bool satisfied = i == 1;
+    loom_target_compile_report_exact_residency_t exact_residency = {};
+    exact_residency.contract_count = 1;
+    exact_residency.evaluated_contract_count = 1;
+    exact_residency.minimum_contract_count = i == 2 ? 1u : 0u;
+    exact_residency.preserve_contract_count = i == 1 ? 1u : 0u;
+    exact_residency.satisfied_contract_count = satisfied ? 1u : 0u;
+    exact_residency.unsatisfied_contract_count = satisfied ? 0u : 1u;
+    exact_residency.repaired_contract_count = satisfied ? 1u : 0u;
+    exact_residency.projection_miss_count = i == 1 ? 1u : 0u;
+    exact_residency.candidate_count = i + 1;
+    exact_residency.attempted_candidate_count = i;
+    exact_residency.repair_count = satisfied ? 1u : 0u;
+    exact_residency.maximum_required_tier = (uint32_t)(i + 2);
+    exact_residency.maximum_minimum_tier = i == 2 ? 4u : 0u;
+    exact_residency.maximum_projected_baseline_tier = i == 1 ? 4u : 0u;
+    exact_residency.minimum_allocated_tier = satisfied ? 4u : 2u;
+    exact_residency.maximum_tier_shortfall = satisfied ? 0u : 2u;
+    loom_target_compile_report_record_exact_residency(&entry, &exact_residency);
     IREE_ASSERT_OK(
         loom_target_compile_report_record_entry_report(&report, &entry));
     loom_target_compile_report_deinitialize(&entry);
@@ -344,25 +544,63 @@ TEST(CompileReportFormatTest, FormatsAndAggregatesLowPlanningStatistics) {
   EXPECT_EQ(report.low_planning.frame_build_count, 3u);
   EXPECT_EQ(report.low_planning.allocation_run_count, 5u);
   EXPECT_EQ(report.low_planning.repair.iteration_count, 7u);
+  EXPECT_EQ(report.low_planning.residency.contract_count, 3u);
+  EXPECT_EQ(report.low_planning.residency.candidate_count, 11u);
+  EXPECT_EQ(report.low_planning.residency.maximum_projected_required_tier, 3u);
+  EXPECT_EQ(report.low_planning.residency.minimum_observed_allocated_tier, 3u);
+  EXPECT_EQ(report.low_planning.residency.maximum_observed_tier_shortfall, 1u);
   EXPECT_EQ(report.low_planning.memory.frame_arena.used_bytes_high_water, 200u);
   EXPECT_EQ(report.low_planning.memory.block_system_allocation_count, 3u);
+  EXPECT_EQ(report.exact_residency.contract_count, 2u);
+  EXPECT_EQ(report.exact_residency.evaluated_contract_count, 2u);
+  EXPECT_EQ(report.exact_residency.unevaluated_contract_count, 0u);
+  EXPECT_EQ(report.exact_residency.minimum_contract_count, 1u);
+  EXPECT_EQ(report.exact_residency.preserve_contract_count, 1u);
+  EXPECT_EQ(report.exact_residency.satisfied_contract_count, 1u);
+  EXPECT_EQ(report.exact_residency.unsatisfied_contract_count, 1u);
+  EXPECT_EQ(report.exact_residency.repaired_contract_count, 1u);
+  EXPECT_EQ(report.exact_residency.projection_miss_count, 1u);
+  EXPECT_EQ(report.exact_residency.candidate_count, 5u);
+  EXPECT_EQ(report.exact_residency.attempted_candidate_count, 3u);
+  EXPECT_EQ(report.exact_residency.repair_count, 1u);
+  EXPECT_EQ(report.exact_residency.maximum_required_tier, 4u);
+  EXPECT_EQ(report.exact_residency.maximum_minimum_tier, 4u);
+  EXPECT_EQ(report.exact_residency.maximum_projected_baseline_tier, 4u);
+  EXPECT_EQ(report.exact_residency.minimum_allocated_tier, 2u);
+  EXPECT_EQ(report.exact_residency.maximum_tier_shortfall, 2u);
 
   iree_string_builder_t builder;
   iree_string_builder_initialize(iree_allocator_system(), &builder);
   loom_output_stream_t stream;
   loom_output_stream_for_builder(&builder, &stream);
   const loom_target_compile_report_format_options_t options = {
-      /*.mode=*/LOOM_TARGET_COMPILE_REPORT_FORMAT_MODE_SUMMARY,
+      /*.mode=*/LOOM_TARGET_COMPILE_REPORT_FORMAT_MODE_DETAILS,
   };
   IREE_ASSERT_OK(
       loom_target_compile_report_format_json(&report, &options, &stream));
   const iree_string_view_t root =
       ParseJsonDocument(iree_string_builder_view(&builder));
+  ExpectObjectUint64Equals(root, IREE_SV("schema_version"),
+                           LOOM_TARGET_COMPILE_REPORT_JSON_SCHEMA_VERSION);
   const iree_string_view_t planning = LookupObject(root, IREE_SV("planning"));
   ExpectObjectUint64Equals(planning, IREE_SV("frame_build_count"), 3);
   ExpectObjectUint64Equals(planning, IREE_SV("allocation_run_count"), 5);
   const iree_string_view_t repair = LookupObject(planning, IREE_SV("repair"));
   ExpectObjectUint64Equals(repair, IREE_SV("iteration_count"), 7);
+  const iree_string_view_t residency =
+      LookupObject(planning, IREE_SV("residency"));
+  ExpectObjectUint64Equals(residency, IREE_SV("contract_count"), 3);
+  ExpectObjectUint64Equals(residency, IREE_SV("candidate_count"), 11);
+  ExpectObjectUint64Equals(residency,
+                           IREE_SV("maximum_projected_required_tier"), 3);
+  ExpectObjectUint64Equals(residency, IREE_SV("validation_count"), 13);
+  ExpectObjectUint64Equals(residency,
+                           IREE_SV("minimum_observed_allocated_tier"), 3);
+  ExpectObjectUint64Equals(residency,
+                           IREE_SV("maximum_observed_tier_shortfall"), 1);
+  ExpectObjectUint64Equals(residency, IREE_SV("repair_attempt_count"), 15);
+  ExpectObjectUint64Equals(residency, IREE_SV("repair_count"), 17);
+  ExpectObjectUint64Equals(residency, IREE_SV("failure_count"), 1);
   const iree_string_view_t memory = LookupObject(planning, IREE_SV("memory"));
   const iree_string_view_t frame_arena =
       LookupObject(memory, IREE_SV("frame_arena"));
@@ -375,6 +613,44 @@ TEST(CompileReportFormatTest, FormatsAndAggregatesLowPlanningStatistics) {
   ExpectObjectUint64Equals(system_allocations, IREE_SV("oversized_count"), 11);
   ExpectObjectUint64Equals(system_allocations, IREE_SV("oversized_bytes"),
                            12288);
+  const iree_string_view_t exact_residency =
+      LookupObject(root, IREE_SV("exact_residency"));
+  ExpectObjectUint64Equals(exact_residency, IREE_SV("contract_count"), 2);
+  ExpectObjectUint64Equals(exact_residency, IREE_SV("evaluated_contract_count"),
+                           2);
+  ExpectObjectUint64Equals(exact_residency,
+                           IREE_SV("unevaluated_contract_count"), 0);
+  ExpectObjectUint64Equals(exact_residency, IREE_SV("minimum_contract_count"),
+                           1);
+  ExpectObjectUint64Equals(exact_residency, IREE_SV("preserve_contract_count"),
+                           1);
+  ExpectObjectUint64Equals(exact_residency, IREE_SV("satisfied_contract_count"),
+                           1);
+  ExpectObjectUint64Equals(exact_residency,
+                           IREE_SV("unsatisfied_contract_count"), 1);
+  ExpectObjectUint64Equals(exact_residency, IREE_SV("maximum_required_tier"),
+                           4);
+  ExpectObjectUint64Equals(exact_residency, IREE_SV("maximum_minimum_tier"), 4);
+  ExpectObjectUint64Equals(exact_residency,
+                           IREE_SV("maximum_projected_baseline_tier"), 4);
+  ExpectObjectUint64Equals(exact_residency, IREE_SV("minimum_allocated_tier"),
+                           2);
+  const iree_string_view_t entries = LookupObject(root, IREE_SV("entries"));
+  const iree_string_view_t entry_rows = LookupObject(entries, IREE_SV("rows"));
+  const iree_string_view_t first_entry = LookupArrayElement(entry_rows, 0);
+  const iree_string_view_t first_exact_residency =
+      LookupObject(first_entry, IREE_SV("exact_residency"));
+  ExpectObjectUint64Equals(first_exact_residency,
+                           IREE_SV("minimum_allocated_tier"), 4);
+  ExpectObjectUint64Equals(first_exact_residency,
+                           IREE_SV("repaired_contract_count"), 1);
+  const iree_string_view_t second_entry = LookupArrayElement(entry_rows, 1);
+  const iree_string_view_t second_exact_residency =
+      LookupObject(second_entry, IREE_SV("exact_residency"));
+  ExpectObjectUint64Equals(second_exact_residency,
+                           IREE_SV("minimum_allocated_tier"), 2);
+  ExpectObjectUint64Equals(second_exact_residency,
+                           IREE_SV("unsatisfied_contract_count"), 1);
 
   iree_string_builder_deinitialize(&builder);
   loom_target_compile_report_deinitialize(&report);

--- a/loom/src/loom/target/reporting/format_planning.c
+++ b/loom/src/loom/target/reporting/format_planning.c
@@ -14,6 +14,8 @@ iree_status_t loom_target_compile_report_append_low_planning_text_fields(
     const loom_low_planning_statistics_t* statistics,
     iree_string_builder_t* builder) {
   const loom_low_planning_repair_statistics_t* repair = &statistics->repair;
+  const loom_low_planning_residency_statistics_t* residency =
+      &statistics->residency;
   const loom_low_planning_memory_statistics_t* memory = &statistics->memory;
   IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
       builder,
@@ -23,10 +25,16 @@ iree_status_t loom_target_compile_report_append_low_planning_text_fields(
       " live_range_split_operands=%" PRIu64
       " pair_replication_attempts=%" PRIu64 " pair_replication_edits=%" PRIu64
       " pair_replication_rejections=%" PRIu64
-      " spill_materialization_batches=%" PRIu64
-      " frame_arena_used_peak=%" PRIu64 " frame_arena_owned_peak=%" PRIu64
-      " repair_arena_used_peak=%" PRIu64 " repair_arena_owned_peak=%" PRIu64
-      " scratch_arena_used_peak=%" PRIu64 " scratch_arena_owned_peak=%" PRIu64,
+      " spill_materialization_batches=%" PRIu64 " residency_contracts=%" PRIu64
+      " residency_candidates=%" PRIu64 " residency_validations=%" PRIu64
+      " residency_projected_required_tier_max=%" PRIu32
+      " residency_observed_allocated_tier_min=%" PRIu32
+      " residency_observed_tier_shortfall_max=%" PRIu32
+      " residency_repair_attempts=%" PRIu64 " residency_repairs=%" PRIu64
+      " residency_failures=%" PRIu64 " frame_arena_used_peak=%" PRIu64
+      " frame_arena_owned_peak=%" PRIu64 " repair_arena_used_peak=%" PRIu64
+      " repair_arena_owned_peak=%" PRIu64 " scratch_arena_used_peak=%" PRIu64
+      " scratch_arena_owned_peak=%" PRIu64,
       statistics->frame_build_count, statistics->allocation_run_count,
       repair->iteration_count, repair->diagnostic_replay_count,
       repair->spill_traffic_lowering_count,
@@ -35,8 +43,13 @@ iree_status_t loom_target_compile_report_append_low_planning_text_fields(
       repair->pair_replication_attempt_count,
       repair->pair_replication_edit_count,
       repair->pair_replication_rejection_count,
-      repair->spill_materialization_batch_count,
-      memory->frame_arena.used_bytes_high_water,
+      repair->spill_materialization_batch_count, residency->contract_count,
+      residency->candidate_count, residency->validation_count,
+      residency->maximum_projected_required_tier,
+      residency->minimum_observed_allocated_tier,
+      residency->maximum_observed_tier_shortfall,
+      residency->repair_attempt_count, residency->repair_count,
+      residency->failure_count, memory->frame_arena.used_bytes_high_water,
       memory->frame_arena.owned_bytes_high_water,
       memory->repair_arena.used_bytes_high_water,
       memory->repair_arena.owned_bytes_high_water,
@@ -79,6 +92,8 @@ iree_status_t loom_target_compile_report_format_low_planning_json(
     const loom_low_planning_statistics_t* statistics,
     loom_output_stream_t* stream) {
   const loom_low_planning_repair_statistics_t* repair = &statistics->repair;
+  const loom_low_planning_residency_statistics_t* residency =
+      &statistics->residency;
   const loom_low_planning_memory_statistics_t* memory = &statistics->memory;
   loom_json_object_writer_t root;
   IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &root));
@@ -118,6 +133,36 @@ iree_status_t loom_target_compile_report_format_low_planning_json(
       &repair_object, IREE_SV("spill_materialization_batch_count"),
       repair->spill_materialization_batch_count));
   IREE_RETURN_IF_ERROR(loom_json_object_end(&repair_object));
+
+  IREE_RETURN_IF_ERROR(
+      loom_json_object_begin_field(&root, IREE_SV("residency")));
+  loom_json_object_writer_t residency_object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &residency_object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &residency_object, IREE_SV("contract_count"), residency->contract_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &residency_object, IREE_SV("candidate_count"),
+      residency->candidate_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &residency_object, IREE_SV("maximum_projected_required_tier"),
+      residency->maximum_projected_required_tier));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &residency_object, IREE_SV("validation_count"),
+      residency->validation_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &residency_object, IREE_SV("minimum_observed_allocated_tier"),
+      residency->minimum_observed_allocated_tier));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &residency_object, IREE_SV("maximum_observed_tier_shortfall"),
+      residency->maximum_observed_tier_shortfall));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &residency_object, IREE_SV("repair_attempt_count"),
+      residency->repair_attempt_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &residency_object, IREE_SV("repair_count"), residency->repair_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &residency_object, IREE_SV("failure_count"), residency->failure_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_end(&residency_object));
 
   IREE_RETURN_IF_ERROR(loom_json_object_begin_field(&root, IREE_SV("memory")));
   loom_json_object_writer_t memory_object;

--- a/loom/src/loom/target/reporting/format_test.cc
+++ b/loom/src/loom/target/reporting/format_test.cc
@@ -52,6 +52,48 @@ static iree_string_view_t LookupArrayElement(iree_string_view_t array,
   return value;
 }
 
+TEST(CompileReportFormatTest, FormatsResidencyCandidateRowsText) {
+  loom_target_compile_report_t report = {};
+  loom_target_compile_report_initialize(&report, iree_allocator_system());
+  report.requested_detail_flags =
+      LOOM_TARGET_COMPILE_REPORT_DETAIL_SOURCE_LOW_ROWS;
+  loom_target_compile_report_residency_candidate_row_t row = {};
+  row.function_name = IREE_SVL("kernel");
+  row.source_op_name = IREE_SVL("scalar.addf");
+  row.source_op_kind = 43;
+  row.candidate_id = 7;
+  row.stage = IREE_SVL("exact");
+  row.outcome = IREE_SVL("restored");
+  row.projected_recompute_cost = 2;
+  row.exact_use_count = 3;
+  row.cloned_packet_count = 1;
+  row.rewritten_operand_count = 3;
+  row.preserves_baseline = true;
+  IREE_ASSERT_OK(
+      loom_target_compile_report_record_residency_candidate_row(&report, &row));
+
+  const loom_target_compile_report_format_options_t options = {
+      /*.mode=*/LOOM_TARGET_COMPILE_REPORT_FORMAT_MODE_DETAILS,
+  };
+  iree_string_builder_t builder;
+  iree_string_builder_initialize(iree_allocator_system(), &builder);
+  IREE_ASSERT_OK(
+      loom_target_compile_report_format_text(&report, &options, &builder));
+  const iree_string_view_t text = iree_string_builder_view(&builder);
+  EXPECT_NE(iree_string_view_find(
+                text,
+                IREE_SV("residency_candidate[0] function=kernel "
+                        "source_op=scalar.addf candidate_id=7 stage=exact "
+                        "outcome=restored projected_cost=2 exact_uses=3 "
+                        "cloned_packets=1 rewritten_operands=3 "
+                        "preserves_baseline=true"),
+                0),
+            IREE_HOST_SIZE_MAX);
+
+  iree_string_builder_deinitialize(&builder);
+  loom_target_compile_report_deinitialize(&report);
+}
+
 TEST(CompileReportFormatTest, FormatsCoreReport) {
   loom_target_compile_report_t report = {};
   loom_target_compile_report_initialize(&report, iree_allocator_system());
@@ -137,6 +179,22 @@ TEST(CompileReportFormatTest, FormatsCoreReport) {
   resources.occupancy_percent = 50;
   resources.limiting_resource = IREE_SVL("amdgpu.vgpr");
   loom_target_compile_report_record_target_resources(&report, &resources);
+  loom_target_compile_report_exact_residency_t exact_residency = {};
+  exact_residency.contract_count = 1;
+  exact_residency.evaluated_contract_count = 1;
+  exact_residency.minimum_contract_count = 1;
+  exact_residency.preserve_contract_count = 1;
+  exact_residency.satisfied_contract_count = 1;
+  exact_residency.repaired_contract_count = 1;
+  exact_residency.projection_miss_count = 1;
+  exact_residency.candidate_count = 3;
+  exact_residency.attempted_candidate_count = 2;
+  exact_residency.repair_count = 1;
+  exact_residency.maximum_required_tier = 4;
+  exact_residency.maximum_minimum_tier = 3;
+  exact_residency.maximum_projected_baseline_tier = 5;
+  exact_residency.minimum_allocated_tier = 4;
+  loom_target_compile_report_record_exact_residency(&report, &exact_residency);
 
   iree_string_builder_t builder;
   iree_string_builder_initialize(iree_allocator_system(), &builder);
@@ -159,6 +217,19 @@ TEST(CompileReportFormatTest, FormatsCoreReport) {
           text, IREE_SV("target_resources scalar_register_class=amdgpu.sgpr"),
           0),
       IREE_STRING_VIEW_NPOS);
+  EXPECT_NE(iree_string_view_find(
+                text,
+                IREE_SV("exact_residency contracts=1 evaluated_contracts=1 "
+                        "unevaluated_contracts=0 minimum_contracts=1 "
+                        "preserve_contracts=1 satisfied=1 unsatisfied=0 "
+                        "repaired_contracts=1 projection_misses=1 candidates=3 "
+                        "attempted_candidates=2 repairs=1 "
+                        "maximum_required_tier=4 maximum_minimum_tier=3 "
+                        "maximum_projected_baseline_tier=5 "
+                        "minimum_allocated_tier=4 "
+                        "maximum_tier_shortfall=0"),
+                0),
+            IREE_STRING_VIEW_NPOS);
   EXPECT_NE(
       iree_string_view_find(
           text, IREE_SV("economics memory per_workitem_issued_read_bytes=24"),
@@ -180,6 +251,17 @@ TEST(CompileReportFormatTest, FormatsCoreReport) {
   const iree_string_view_t schedule = LookupObject(root, IREE_SV("schedule"));
   ExpectObjectUint64Equals(schedule, IREE_SV("node_count"), 5);
   ExpectObjectUint64Equals(schedule, IREE_SV("resource_use_count"), 2);
+  const iree_string_view_t exact_residency_json =
+      LookupObject(root, IREE_SV("exact_residency"));
+  ExpectObjectUint64Equals(exact_residency_json, IREE_SV("contract_count"), 1);
+  ExpectObjectUint64Equals(exact_residency_json,
+                           IREE_SV("evaluated_contract_count"), 1);
+  ExpectObjectUint64Equals(exact_residency_json,
+                           IREE_SV("satisfied_contract_count"), 1);
+  ExpectObjectUint64Equals(exact_residency_json,
+                           IREE_SV("attempted_candidate_count"), 2);
+  ExpectObjectUint64Equals(exact_residency_json,
+                           IREE_SV("minimum_allocated_tier"), 4);
   const iree_string_view_t workload_json =
       LookupObject(root, IREE_SV("workload"));
   const iree_string_view_t workgroup_size =

--- a/loom/src/loom/target/reporting/format_text.c
+++ b/loom/src/loom/target/reporting/format_text.c
@@ -282,6 +282,31 @@ static iree_status_t loom_target_compile_report_append_target_resources_fields(
       limiting_resource.data);
 }
 
+static iree_status_t loom_target_compile_report_append_exact_residency_fields(
+    const loom_target_compile_report_exact_residency_t* residency,
+    iree_string_builder_t* builder) {
+  return iree_string_builder_append_format(
+      builder,
+      " contracts=%" PRIu64 " evaluated_contracts=%" PRIu64
+      " unevaluated_contracts=%" PRIu64 " minimum_contracts=%" PRIu64
+      " preserve_contracts=%" PRIu64 " satisfied=%" PRIu64
+      " unsatisfied=%" PRIu64 " repaired_contracts=%" PRIu64
+      " projection_misses=%" PRIu64 " candidates=%" PRIu64
+      " attempted_candidates=%" PRIu64 " repairs=%" PRIu64
+      " maximum_required_tier=%" PRIu32 " maximum_minimum_tier=%" PRIu32
+      " maximum_projected_baseline_tier=%" PRIu32
+      " minimum_allocated_tier=%" PRIu32 " maximum_tier_shortfall=%" PRIu32,
+      residency->contract_count, residency->evaluated_contract_count,
+      residency->unevaluated_contract_count, residency->minimum_contract_count,
+      residency->preserve_contract_count, residency->satisfied_contract_count,
+      residency->unsatisfied_contract_count, residency->repaired_contract_count,
+      residency->projection_miss_count, residency->candidate_count,
+      residency->attempted_candidate_count, residency->repair_count,
+      residency->maximum_required_tier, residency->maximum_minimum_tier,
+      residency->maximum_projected_baseline_tier,
+      residency->minimum_allocated_tier, residency->maximum_tier_shortfall);
+}
+
 static iree_status_t loom_target_compile_report_format_summary(
     const loom_target_compile_report_t* report,
     const loom_target_compile_report_format_options_t* options,
@@ -337,6 +362,17 @@ static iree_status_t loom_target_compile_report_format_summary(
     IREE_RETURN_IF_ERROR(
         loom_target_compile_report_append_low_planning_text_fields(
             &report->low_planning, builder));
+    IREE_RETURN_IF_ERROR(
+        iree_string_builder_append_string(builder, IREE_SV("\n")));
+  }
+
+  if (iree_any_bit_set(report->detail_flags,
+                       LOOM_TARGET_COMPILE_REPORT_DETAIL_EXACT_RESIDENCY)) {
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_string(
+        builder, IREE_SV("COMPILE-REPORT: exact_residency")));
+    IREE_RETURN_IF_ERROR(
+        loom_target_compile_report_append_exact_residency_fields(
+            &report->exact_residency, builder));
     IREE_RETURN_IF_ERROR(
         iree_string_builder_append_string(builder, IREE_SV("\n")));
   }
@@ -758,6 +794,17 @@ static iree_status_t loom_target_compile_report_format_entry_rows(
         IREE_RETURN_IF_ERROR(
             loom_target_compile_report_append_low_planning_text_fields(
                 &row->low_planning, builder));
+        IREE_RETURN_IF_ERROR(
+            iree_string_builder_append_string(builder, IREE_SV("\n")));
+      }
+      if (iree_any_bit_set(row->detail_flags,
+                           LOOM_TARGET_COMPILE_REPORT_DETAIL_EXACT_RESIDENCY)) {
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+            builder, "COMPILE-REPORT: entry[%" PRIhsz "].exact_residency",
+            row_index));
+        IREE_RETURN_IF_ERROR(
+            loom_target_compile_report_append_exact_residency_fields(
+                &row->exact_residency, builder));
         IREE_RETURN_IF_ERROR(
             iree_string_builder_append_string(builder, IREE_SV("\n")));
       }

--- a/loom/src/loom/target/reporting/format_text_lowering.c
+++ b/loom/src/loom/target/reporting/format_text_lowering.c
@@ -524,6 +524,192 @@ loom_target_compile_report_format_source_low_transform_rows(
   return iree_ok_status();
 }
 
+static iree_status_t
+loom_target_compile_report_format_source_low_residency_rows(
+    const loom_target_compile_report_t* report,
+    iree_string_builder_t* builder) {
+  if (report->source_low_residency_rows.count == 0) {
+    return iree_ok_status();
+  }
+  IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+      builder, "COMPILE-REPORT: source_low_residency rows=%" PRIhsz "\n",
+      report->source_low_residency_rows.count));
+  iree_host_size_t row_index = 0;
+  for (const loom_target_compile_report_vec_t* vec =
+           report->source_low_residency_rows.head;
+       vec != NULL; vec = vec->next) {
+    const loom_target_compile_report_source_low_residency_row_t* rows =
+        (const loom_target_compile_report_source_low_residency_row_t*)
+            loom_target_compile_report_vec_const_rows(vec);
+    for (iree_host_size_t i = 0; i < vec->count; ++i, ++row_index) {
+      const loom_target_compile_report_source_low_residency_row_t* row =
+          &rows[i];
+      const iree_string_view_t function_name =
+          loom_target_compile_report_text_non_empty(row->function_name);
+      const iree_string_view_t source_op_name =
+          loom_target_compile_report_text_non_empty(row->source_op_name);
+      const iree_string_view_t policy =
+          loom_target_compile_report_text_non_empty(row->policy);
+      const iree_string_view_t outcome =
+          loom_target_compile_report_text_non_empty(row->outcome);
+      const iree_string_view_t reason =
+          loom_target_compile_report_text_non_empty(row->reason);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          builder,
+          "COMPILE-REPORT: source_low_residency[%" PRIhsz
+          "] function=%.*s source_op=%.*s policy=%.*s outcome=%.*s "
+          "reason=%.*s baseline_tier=%u selected_tier=%u required_tier=%u "
+          "candidates=%u selected=%u rejected=%u reserves=%u "
+          "projection_complete=%s\n",
+          row_index, (int)function_name.size, function_name.data,
+          (int)source_op_name.size, source_op_name.data, (int)policy.size,
+          policy.data, (int)outcome.size, outcome.data, (int)reason.size,
+          reason.data, row->baseline_tier, row->selected_tier,
+          row->required_tier, row->candidate_count, row->selected_count,
+          row->rejected_count, row->reserve_count,
+          row->projection_complete ? "true" : "false"));
+    }
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t
+loom_target_compile_report_format_source_low_residency_resource_rows(
+    const loom_target_compile_report_t* report,
+    iree_string_builder_t* builder) {
+  if (report->source_low_residency_resource_rows.count == 0) {
+    return iree_ok_status();
+  }
+  IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+      builder,
+      "COMPILE-REPORT: source_low_residency_resources rows=%" PRIhsz "\n",
+      report->source_low_residency_resource_rows.count));
+  iree_host_size_t row_index = 0;
+  for (const loom_target_compile_report_vec_t* vec =
+           report->source_low_residency_resource_rows.head;
+       vec != NULL; vec = vec->next) {
+    const loom_target_compile_report_source_low_residency_resource_row_t* rows =
+        (const loom_target_compile_report_source_low_residency_resource_row_t*)
+            loom_target_compile_report_vec_const_rows(vec);
+    for (iree_host_size_t i = 0; i < vec->count; ++i, ++row_index) {
+      const loom_target_compile_report_source_low_residency_resource_row_t*
+          row = &rows[i];
+      const iree_string_view_t function_name =
+          loom_target_compile_report_text_non_empty(row->function_name);
+      const iree_string_view_t source_op_name =
+          loom_target_compile_report_text_non_empty(row->source_op_name);
+      const iree_string_view_t phase =
+          loom_target_compile_report_text_non_empty(row->phase);
+      const iree_string_view_t resource_name =
+          loom_target_compile_report_text_non_empty(row->resource_name);
+      const iree_string_view_t resource_kind =
+          loom_target_compile_report_text_non_empty(row->resource_kind);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          builder,
+          "COMPILE-REPORT: source_low_residency_resource[%" PRIhsz
+          "] function=%.*s source_op=%.*s phase=%.*s point=%u resource=%.*s "
+          "kind=%.*s resource_id=%u units=%" PRIu64
+          " tier=%u next_better_tier=%u next_worse_tier=%u "
+          "next_worse_cliff=%u units_to_worse=%" PRIu64
+          " units_to_better=%" PRIu64 " limiting=%s\n",
+          row_index, (int)function_name.size, function_name.data,
+          (int)source_op_name.size, source_op_name.data, (int)phase.size,
+          phase.data, row->program_point, (int)resource_name.size,
+          resource_name.data, (int)resource_kind.size, resource_kind.data,
+          row->resource_id, row->units, row->tier, row->next_better_tier,
+          row->next_worse_tier, row->next_worse_cliff_units,
+          row->additional_units_to_next_worse_tier,
+          row->reduction_units_to_next_better_tier,
+          row->limiting ? "true" : "false"));
+    }
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t
+loom_target_compile_report_format_source_low_residency_reserve_rows(
+    const loom_target_compile_report_t* report,
+    iree_string_builder_t* builder) {
+  if (report->source_low_residency_reserve_rows.count == 0) {
+    return iree_ok_status();
+  }
+  IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+      builder,
+      "COMPILE-REPORT: source_low_residency_reserves rows=%" PRIhsz "\n",
+      report->source_low_residency_reserve_rows.count));
+  iree_host_size_t row_index = 0;
+  for (const loom_target_compile_report_vec_t* vec =
+           report->source_low_residency_reserve_rows.head;
+       vec != NULL; vec = vec->next) {
+    const loom_target_compile_report_source_low_residency_reserve_row_t* rows =
+        (const loom_target_compile_report_source_low_residency_reserve_row_t*)
+            loom_target_compile_report_vec_const_rows(vec);
+    for (iree_host_size_t i = 0; i < vec->count; ++i, ++row_index) {
+      const loom_target_compile_report_source_low_residency_reserve_row_t* row =
+          &rows[i];
+      const iree_string_view_t function_name =
+          loom_target_compile_report_text_non_empty(row->function_name);
+      const iree_string_view_t reserve_name =
+          loom_target_compile_report_text_non_empty(row->reserve_name);
+      const iree_string_view_t resource_name =
+          loom_target_compile_report_text_non_empty(row->resource_name);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          builder,
+          "COMPILE-REPORT: source_low_residency_reserve[%" PRIhsz
+          "] function=%.*s reserve=%.*s resource=%.*s resource_id=%u "
+          "units=%" PRIu64 "\n",
+          row_index, (int)function_name.size, function_name.data,
+          (int)reserve_name.size, reserve_name.data, (int)resource_name.size,
+          resource_name.data, row->resource_id, row->units));
+    }
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_target_compile_report_format_residency_candidate_rows(
+    const loom_target_compile_report_t* report,
+    iree_string_builder_t* builder) {
+  if (report->residency_candidate_rows.count == 0) {
+    return iree_ok_status();
+  }
+  IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+      builder, "COMPILE-REPORT: residency_candidates rows=%" PRIhsz "\n",
+      report->residency_candidate_rows.count));
+  iree_host_size_t row_index = 0;
+  for (const loom_target_compile_report_vec_t* vec =
+           report->residency_candidate_rows.head;
+       vec != NULL; vec = vec->next) {
+    const loom_target_compile_report_residency_candidate_row_t* rows =
+        (const loom_target_compile_report_residency_candidate_row_t*)
+            loom_target_compile_report_vec_const_rows(vec);
+    for (iree_host_size_t i = 0; i < vec->count; ++i, ++row_index) {
+      const loom_target_compile_report_residency_candidate_row_t* row =
+          &rows[i];
+      const iree_string_view_t function_name =
+          loom_target_compile_report_text_non_empty(row->function_name);
+      const iree_string_view_t source_op_name =
+          loom_target_compile_report_text_non_empty(row->source_op_name);
+      const iree_string_view_t stage =
+          loom_target_compile_report_text_non_empty(row->stage);
+      const iree_string_view_t outcome =
+          loom_target_compile_report_text_non_empty(row->outcome);
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          builder,
+          "COMPILE-REPORT: residency_candidate[%" PRIhsz
+          "] function=%.*s source_op=%.*s candidate_id=%u stage=%.*s "
+          "outcome=%.*s projected_cost=%u exact_uses=%u cloned_packets=%u "
+          "rewritten_operands=%u preserves_baseline=%s\n",
+          row_index, (int)function_name.size, function_name.data,
+          (int)source_op_name.size, source_op_name.data, row->candidate_id,
+          (int)stage.size, stage.data, (int)outcome.size, outcome.data,
+          row->projected_recompute_cost, row->exact_use_count,
+          row->cloned_packet_count, row->rewritten_operand_count,
+          row->preserves_baseline ? "true" : "false"));
+    }
+  }
+  return iree_ok_status();
+}
+
 static iree_status_t loom_target_compile_report_format_source_low_memory_rows(
     const loom_target_compile_report_t* report,
     iree_string_builder_t* builder) {
@@ -968,6 +1154,18 @@ iree_status_t loom_target_compile_report_format_text_lowering_details(
   IREE_RETURN_IF_ERROR(
       loom_target_compile_report_format_source_low_transform_rows(report,
                                                                   builder));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_format_source_low_residency_rows(report,
+                                                                  builder));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_format_source_low_residency_resource_rows(
+          report, builder));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_format_source_low_residency_reserve_rows(
+          report, builder));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_format_residency_candidate_rows(report,
+                                                                 builder));
   IREE_RETURN_IF_ERROR(loom_target_compile_report_format_source_low_memory_rows(
       report, builder));
   IREE_RETURN_IF_ERROR(

--- a/loom/src/loom/tooling/execution/compile_report_capture_test.cc
+++ b/loom/src/loom/tooling/execution/compile_report_capture_test.cc
@@ -293,9 +293,10 @@ TEST(CompileReportCaptureTest, AppendsConfiguredJsonOutput) {
       loom_run_compile_report_capture_append_output(&capture, &builder));
 
   iree_string_view_t output = iree_string_builder_view(&builder);
-  EXPECT_NE(
-      iree_string_view_find(output, IREE_SV("output\n{\"artifact_kind\""), 0),
-      IREE_STRING_VIEW_NPOS);
+  EXPECT_NE(iree_string_view_find(
+                output,
+                IREE_SV("output\n{\"schema_version\":1,\"artifact_kind\""), 0),
+            IREE_STRING_VIEW_NPOS);
   EXPECT_NE(iree_string_view_find(
                 output, IREE_SV("\"artifact_kind\":\"vm-archive\""), 0),
             IREE_STRING_VIEW_NPOS);

--- a/loom/src/loom/tools/loom-compile/BUILD.bazel
+++ b/loom/src/loom/tools/loom-compile/BUILD.bazel
@@ -151,6 +151,7 @@ iree_execution_test_suite(
         "report_materialized_fragment_spills_amdgpu.loom",
         "report_private_memory_mix_amdgpu.loom",
         "report_target_insertions_uncountable_amdgpu.loom",
+        "residency_cross_target_amdgpu.loom",
         "selected_root_amdgpu.loom",
         "target_family_template_provider_amdgpu.loom",
         "//loom/src/loom/tools/iree-test-loom:testdata/amdgpu_unused_kernargs.loom",

--- a/loom/src/loom/tools/loom-compile/CMakeLists.txt
+++ b/loom/src/loom/tools/loom-compile/CMakeLists.txt
@@ -115,6 +115,7 @@ iree_execution_test_suite(
     "report_materialized_fragment_spills_amdgpu.loom"
     "report_private_memory_mix_amdgpu.loom"
     "report_target_insertions_uncountable_amdgpu.loom"
+    "residency_cross_target_amdgpu.loom"
     "selected_root_amdgpu.loom"
     "target_family_template_provider_amdgpu.loom"
   LABELS

--- a/loom/src/loom/tools/loom-compile/gfx1250_configured_fragment_bank.loom
+++ b/loom/src/loom/tools/loom-compile/gfx1250_configured_fragment_bank.loom
@@ -14,7 +14,7 @@ kernel.def target(@target) export("configured_fragment_bank") @configured_fragme
   %one = index.constant 1 : index
   %workgroup_size = config.get @test.fragment_bank.workgroup_size : index
   kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
-} launch(%output: buffer) {
+} launch(%scale_buffer: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %zero = index.constant 0 : index
   %one = index.constant 1 : index
@@ -33,21 +33,25 @@ kernel.def target(@target) export("configured_fragment_bank") @configured_fragme
   %scratch_bytes_index = index.mul %scratch_elements, %four : index
   %scratch_bytes = index.cast %scratch_bytes_index : index to offset
   %lane = kernel.workitem.id<x> : index
+  %scale_global = buffer.assume.memory_space<global> %scale_buffer : buffer
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%base] : buffer -> view<[%m_extent]x[%n_extent]xf32, #dense>
+  %scale_noalias, %output_noalias = buffer.assume.noalias %scale_global, %output_global : buffer, buffer
+  %scale_view = buffer.view %scale_noalias[%base] : buffer -> view<16xf32, #dense>
+  %output_view = buffer.view %output_noalias[%base] : buffer -> view<[%m_extent]x[%n_extent]xf32, #dense>
   %scratch = buffer.alloca %scratch_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch_view = buffer.view %scratch[%base] : buffer -> view<[%scratch_elements]xi32, #dense>
   %marker = vector.constant 0 : vector<1xi32>
   vector.store %marker, %scratch_view[%lane] : vector<1xi32>, view<[%scratch_elements]xi32, #dense>
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
-  %lhs_payload = vector.constant 1.0 : vector<16xbf16>
-  %rhs_payload = vector.constant 1.0 : vector<16xbf16>
-  %lhs = vector.fragment<lhs> %lhs_payload shape [%matrix_m, %matrix_k] : vector<16xbf16>
-  %rhs = vector.fragment<rhs> %rhs_payload shape [%matrix_k, %matrix_n] : vector<16xbf16>
   %zero_payload = vector.constant 0.0 : vector<8xf32>
   %zero_fragment = vector.fragment<init> %zero_payload shape [%matrix_m, %matrix_n] : vector<8xf32>
   %initial_bank = vector.broadcast %zero_fragment : vector<8xf32> -> vector<[%m_fragments]x[%n_fragments]x8xf32>
-  %result_bank = scf.for %stage = [%zero to %two step %one](%stage_bank = %initial_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) {
+  %result_bank = scf.for %stage = [%zero to %two step %one](%stage_bank = %initial_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) residency(preserve) {
+    %lhs_wide = vector.load %scale_view[0] : view<16xf32, #dense> -> vector<16xf32>
+    %lhs_payload = vector.fptrunc %lhs_wide : vector<16xf32> to vector<16xbf16>
+    %rhs_payload = vector.constant 1.0 : vector<16xbf16>
+    %lhs = vector.fragment<lhs> %lhs_payload shape [%matrix_m, %matrix_k] : vector<16xbf16>
+    %rhs = vector.fragment<rhs> %rhs_payload shape [%matrix_k, %matrix_n] : vector<16xbf16>
     %after_k = scf.for %k_fragment = [%zero to %k_fragments step %one](%k_bank = %stage_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) unroll {
       %after_m = scf.for %m_fragment = [%zero to %m_fragments step %one](%m_bank = %k_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) unroll {
         %after_n = scf.for %n_fragment = [%zero to %n_fragments step %one](%n_bank = %m_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) unroll {

--- a/loom/src/loom/tools/loom-compile/loom-compile-amdgpu.test.json
+++ b/loom/src/loom/tools/loom-compile/loom-compile-amdgpu.test.json
@@ -180,19 +180,145 @@
           "stdout": {
             "contains": {
               "unordered": [
+                "\"schema_version\":1",
                 "\"key\":\"test.fragment_bank.m_fragments\",\"value\":\"8\"",
                 "\"key\":\"test.fragment_bank.n_fragments\",\"value\":\"4\"",
                 "\"key\":\"test.fragment_bank.k_fragments\",\"value\":\"2\"",
                 "\"wmma_count\":64",
                 "\"wmma_count\":128",
                 "\"private_memory_bytes\":0",
-                "\"allocation_spill_count\":0"
+                "\"allocation_spill_count\":0",
+                "\"policy\":\"preserve\"",
+                "\"stage\":\"exact\",\"outcome\":\"restored\"",
+                "\"projection_miss_count\":1",
+                "\"maximum_projected_required_tier\":16",
+                "\"minimum_observed_allocated_tier\":3",
+                "\"maximum_observed_tier_shortfall\":13",
+                "\"maximum_required_tier\":3",
+                "\"resource\":\"amdgpu.vgpr\",\"resource_kind\":\"direct\",\"resource_id\":1,\"units\":288,\"tier\":3",
+                "\"reduction_units_to_next_better_tier\":32,\"limiting\":true",
+                "\"occupancy_percent\":18"
               ]
             }
           },
           "files": [
             {
               "path": "{tmp}/configured_fragment_bank_8x4x2.hsaco",
+              "non_empty": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "plans one targetless residency contract across distinct AMDGPU models",
+      "steps": [
+        {
+          "name": "compile-gfx942",
+          "run": {
+            "tool": "loom-compile",
+            "args": [
+              "{srcdir}/residency_cross_target_amdgpu.loom",
+              "--backend=amdgpu-hal",
+              "--target=gfx942",
+              "--output={tmp}/residency_cross_target_gfx942.hal",
+              "--emit-target-artifact={tmp}/residency_cross_target_gfx942.hsaco",
+              "--compile-report=details",
+              "--compile-report-output=-"
+            ]
+          },
+          "stdout": {
+            "contains": {
+              "unordered": [
+                "\"target_key\":\"gfx942\"",
+                "\"policy\":\"preserve\",\"outcome\":\"selected\",\"reason\":\"dynamic_work_removed\"",
+                "\"residency_resources\":{\"count\":24",
+                "\"resource\":\"amdgpu.agpr\"",
+                "\"resource\":\"amdgpu.vgpr_agpr\",\"resource_kind\":\"derived\"",
+                "\"source_op\":\"vector.load\"",
+                "\"stage\":\"exact\",\"outcome\":\"not_attempted\"",
+                "\"projection_miss_count\":0",
+                "\"minimum_allocated_tier\":10",
+                "\"subgroup_size\":64",
+                "\"occupancy_percent\":62"
+              ]
+            }
+          },
+          "files": [
+            {
+              "path": "{tmp}/residency_cross_target_gfx942.hsaco",
+              "non_empty": true
+            }
+          ]
+        },
+        {
+          "name": "compile-gfx1100",
+          "run": {
+            "tool": "loom-compile",
+            "args": [
+              "{srcdir}/residency_cross_target_amdgpu.loom",
+              "--backend=amdgpu-hal",
+              "--target=gfx1100",
+              "--output={tmp}/residency_cross_target_gfx1100.hal",
+              "--emit-target-artifact={tmp}/residency_cross_target_gfx1100.hsaco",
+              "--compile-report=details",
+              "--compile-report-output=-"
+            ]
+          },
+          "stdout": {
+            "contains": {
+              "unordered": [
+                "\"target_key\":\"gfx1100\"",
+                "\"policy\":\"preserve\",\"outcome\":\"selected\",\"reason\":\"dynamic_work_removed\"",
+                "\"residency_resources\":{\"count\":18",
+                "\"source_op\":\"vector.load\"",
+                "\"stage\":\"exact\",\"outcome\":\"not_attempted\"",
+                "\"projection_miss_count\":0",
+                "\"minimum_allocated_tier\":16"
+              ]
+            },
+            "not_contains": [
+              "\"resource\":\"amdgpu.mode\""
+            ]
+          },
+          "files": [
+            {
+              "path": "{tmp}/residency_cross_target_gfx1100.hsaco",
+              "non_empty": true
+            }
+          ]
+        },
+        {
+          "name": "compile-gfx1250",
+          "run": {
+            "tool": "loom-compile",
+            "args": [
+              "{srcdir}/residency_cross_target_amdgpu.loom",
+              "--backend=amdgpu-hal",
+              "--target=gfx1250",
+              "--output={tmp}/residency_cross_target_gfx1250.hal",
+              "--emit-target-artifact={tmp}/residency_cross_target_gfx1250.hsaco",
+              "--compile-report=details",
+              "--compile-report-output=-"
+            ]
+          },
+          "stdout": {
+            "contains": {
+              "unordered": [
+                "\"target_key\":\"gfx1250\"",
+                "\"policy\":\"preserve\",\"outcome\":\"selected\",\"reason\":\"dynamic_work_removed\"",
+                "\"residency_resources\":{\"count\":21",
+                "\"resource\":\"amdgpu.mode\"",
+                "\"source_op\":\"vector.load\"",
+                "\"stage\":\"exact\",\"outcome\":\"not_attempted\"",
+                "\"projection_miss_count\":0",
+                "\"minimum_allocated_tier\":16"
+              ]
+            }
+          },
+          "files": [
+            {
+              "path": "{tmp}/residency_cross_target_gfx1250.hsaco",
               "non_empty": true
             }
           ]

--- a/loom/src/loom/tools/loom-compile/residency_cross_target_amdgpu.loom
+++ b/loom/src/loom/tools/loom-compile/residency_cross_target_amdgpu.loom
@@ -1,0 +1,25 @@
+// A targetless residency-policy kernel compiled against distinct AMDGPU target
+// models by the execution manifest.
+kernel.def export("residency_cross_target") @residency_cross_target() {
+  %one = index.constant 1 : index
+  %workgroup_size = index.constant 32 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+} launch(%input: buffer, %output: buffer) {
+  %base = index.constant 0 : offset
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %two = index.constant 2 : index
+  %input_global = buffer.assume.memory_space<global> %input : buffer
+  %output_global = buffer.assume.memory_space<global> %output : buffer
+  %input_noalias, %output_noalias = buffer.assume.noalias %input_global, %output_global : buffer, buffer
+  %input_view = buffer.view %input_noalias[%base] : buffer -> view<16xf32, #dense>
+  %output_view = buffer.view %output_noalias[%base] : buffer -> view<16xf32, #dense>
+  %initial = vector.constant 0.0 : vector<16xf32>
+  %result = scf.for %stage = [%zero to %two step %one](%acc = %initial : vector<16xf32>) -> (vector<16xf32>) residency(preserve) {
+    %invariant = vector.load %input_view[0] : view<16xf32, #dense> -> vector<16xf32>
+    %next = vector.addf %acc, %invariant : vector<16xf32>
+    scf.yield %next : vector<16xf32>
+  }
+  vector.store %result, %output_view[0] : vector<16xf32>, view<16xf32, #dense>
+  kernel.return
+}


### PR DESCRIPTION
Expose residency planning and exact physical outcomes through a versioned compile-report schema, then qualify the complete production pipeline against distinct AMDGPU target models and a configured gfx1250 fragment-bank kernel. Source decisions, direct and derived cliff witnesses, named reserves, stable candidate identities, exact resources, projection misses, repairs, and terminal shortfalls are now observable without parsing diagnostics.

One targetless preserve-policy kernel compiles through the normal pipeline for gfx942, gfx1100, and gfx1250. The resulting artifacts demonstrate target-specific resource domains from identical source: gfx942 reports AGPR and derived VGPR+AGPR pressure with a 64-lane subgroup and 62% modeled occupancy, while gfx1100 and gfx1250 resolve through different resource sets at tier 16 and gfx1250 additionally reports its mode resource.

The configured gfx1250 8x4x2 fragment-bank kernel exercises the optimistic-projection path with real WMMA lowering. Source planning projects tier 16; provisional physical allocation reaches tier 3 at 288 VGPRs and 18% modeled occupancy; one finite restoration recovers the exact authored baseline; and the terminal report records zero shortfall plus the 32-VGPR reduction needed to reach tier 4. Both qualification paths emit non-empty HSACO artifacts, proving that reporting observes shipping compilation rather than a test-only analyzer.

### Review surface

- Summary reports retain stable aggregate counts while detail reports emit typed source, candidate, repair, and exact-resource rows.
- Planning history and terminal exact state use separate fields so a successful repair cannot hide the provisional allocation that triggered it.
- The compile-tool manifest checks production pipeline selection, cross-target model differences, finite repair, terminal satisfaction, occupancy, and emitted HSACO artifacts.
