### PR TITLE
[HIP] Record kernel attributes on module symbols

### DIFF
--- a/libhrx/include/hrx_runtime.h
+++ b/libhrx/include/hrx_runtime.h
@@ -190,6 +190,7 @@ typedef enum hrx_device_property_t {
   HRX_DEVICE_PROPERTY_MAX_SHARED_MEMORY,
   HRX_DEVICE_PROPERTY_CLOCK_RATE,
   HRX_DEVICE_PROPERTY_PCI_BUS_ID,
+  HRX_DEVICE_PROPERTY_HOST_NATIVE_ATOMIC_SUPPORTED,
 } hrx_device_property_t;
 
 // Memory type bitfield. Values match iree_hal_memory_type_t.

--- a/libhrx/src/binding/common/BUILD.bazel
+++ b/libhrx/src/binding/common/BUILD.bazel
@@ -32,8 +32,10 @@ hrx_cc_library(
         "mem_pool.c",
         "memory.c",
         "module.c",
+        "module_runtime_metadata.c",
         "peer.c",
         "registry.c",
+        "rocm_hostcall.c",
         "stream.c",
         "tls.c",
     ],
@@ -43,6 +45,7 @@ hrx_cc_library(
         "hrx_bridge.h",
         "internal.h",
         "kernel_arguments.h",
+        "printf_format.h",
         "tls.h",
     ],
     includes = [
@@ -103,6 +106,17 @@ hrx_cc_test(
 hrx_cc_test(
     name = "fat_binary_test",
     srcs = ["fat_binary_test.cc"],
+    deps = [
+        ":common",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+hrx_cc_test(
+    name = "rocm_hostcall_test",
+    srcs = ["rocm_hostcall_test.cc"],
     deps = [
         ":common",
         "//runtime/src/iree/base",

--- a/libhrx/src/binding/common/CMakeLists.txt
+++ b/libhrx/src/binding/common/CMakeLists.txt
@@ -13,6 +13,7 @@ iree_cc_library(
     "hrx_bridge.h"
     "internal.h"
     "kernel_arguments.h"
+    "printf_format.h"
     "tls.h"
   SRCS
     "context.c"
@@ -27,8 +28,10 @@ iree_cc_library(
     "mem_pool.c"
     "memory.c"
     "module.c"
+    "module_runtime_metadata.c"
     "peer.c"
     "registry.c"
+    "rocm_hostcall.c"
     "stream.c"
     "tls.c"
   DEPS
@@ -97,6 +100,19 @@ iree_cc_test(
     fat_binary_test
   SRCS
     "fat_binary_test.cc"
+  DEPS
+    ::common
+    iree::base
+    iree::testing::gtest
+    iree::testing::gtest_main
+    libhrx_defs
+)
+
+iree_cc_test(
+  NAME
+    rocm_hostcall_test
+  SRCS
+    "rocm_hostcall_test.cc"
   DEPS
     ::common
     iree::base

--- a/libhrx/src/binding/common/context.c
+++ b/libhrx/src/binding/common/context.c
@@ -7,6 +7,188 @@
 #include <string.h>
 
 #include "common/internal.h"
+#include "iree/hal/buffer_transfer.h"
+
+//===----------------------------------------------------------------------===//
+// ROCm device runtime state
+//===----------------------------------------------------------------------===//
+
+// ROCm device libraries expect hidden_heap_v1 to point at a heap header with
+// fixed recordable-kind slots and an initial slab window. Streaming owns that
+// HIP runtime policy; HAL drivers only expose the metadata slot and patch the
+// supplied bytes into native launch arguments.
+#define IREE_HAL_STREAMING_ROCM_MALLOC_HEAP_SIZE (128 * 1024)
+#define IREE_HAL_STREAMING_ROCM_MALLOC_KIND_COUNT 16
+#define IREE_HAL_STREAMING_ROCM_MALLOC_NUM_SDATA 256
+#define IREE_HAL_STREAMING_ROCM_MALLOC_RECORDABLE_OFFSET 4096
+#define IREE_HAL_STREAMING_ROCM_MALLOC_RECORDABLE_STRIDE 128
+#define IREE_HAL_STREAMING_ROCM_MALLOC_INITIAL_SLABS_OFFSET 108544
+#define IREE_HAL_STREAMING_ROCM_MALLOC_INITIAL_SLAB_SIZE (2 * 1024 * 1024)
+static_assert(IREE_HAL_STREAMING_ROCM_MALLOC_RECORDABLE_OFFSET +
+                      IREE_HAL_STREAMING_ROCM_MALLOC_KIND_COUNT *
+                          IREE_HAL_STREAMING_ROCM_MALLOC_RECORDABLE_STRIDE <=
+                  IREE_HAL_STREAMING_ROCM_MALLOC_HEAP_SIZE,
+              "device malloc recordable table must fit in heap header");
+static_assert(IREE_HAL_STREAMING_ROCM_MALLOC_INITIAL_SLABS_OFFSET +
+                      3 * sizeof(uint64_t) <=
+                  IREE_HAL_STREAMING_ROCM_MALLOC_HEAP_SIZE,
+              "device malloc initial slab table must fit in heap header");
+
+static void iree_hal_streaming_rocm_store_u32(uint8_t* storage,
+                                              iree_host_size_t offset,
+                                              uint32_t value) {
+  memcpy(storage + offset, &value, sizeof(value));
+}
+
+static void iree_hal_streaming_rocm_store_u64(uint8_t* storage,
+                                              iree_host_size_t offset,
+                                              uint64_t value) {
+  memcpy(storage + offset, &value, sizeof(value));
+}
+
+static iree_status_t iree_hal_streaming_rocm_populate_malloc_heap_header(
+    void* heap_storage, uint64_t initial_slabs_device_ptr,
+    iree_device_size_t initial_slab_bytes) {
+  if (IREE_UNLIKELY(initial_slab_bytes >
+                    UINT64_MAX - initial_slabs_device_ptr)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "ROCm device malloc initial slab range overflow");
+  }
+
+  uint8_t* heap = (uint8_t*)heap_storage;
+  memset(heap, 0, IREE_HAL_STREAMING_ROCM_MALLOC_HEAP_SIZE);
+
+  for (uint32_t i = 0; i < IREE_HAL_STREAMING_ROCM_MALLOC_KIND_COUNT; ++i) {
+    const iree_host_size_t offset =
+        IREE_HAL_STREAMING_ROCM_MALLOC_RECORDABLE_OFFSET +
+        (iree_host_size_t)i * IREE_HAL_STREAMING_ROCM_MALLOC_RECORDABLE_STRIDE;
+    iree_hal_streaming_rocm_store_u32(heap, offset,
+                                      IREE_HAL_STREAMING_ROCM_MALLOC_NUM_SDATA);
+  }
+
+  const uint64_t initial_slabs_start = initial_slabs_device_ptr;
+  const uint64_t initial_slabs_end =
+      initial_slabs_start + (uint64_t)initial_slab_bytes;
+  iree_hal_streaming_rocm_store_u64(
+      heap, IREE_HAL_STREAMING_ROCM_MALLOC_INITIAL_SLABS_OFFSET,
+      initial_slabs_start);
+  iree_hal_streaming_rocm_store_u64(
+      heap,
+      IREE_HAL_STREAMING_ROCM_MALLOC_INITIAL_SLABS_OFFSET + sizeof(uint64_t),
+      initial_slabs_end);
+  iree_hal_streaming_rocm_store_u64(
+      heap,
+      IREE_HAL_STREAMING_ROCM_MALLOC_INITIAL_SLABS_OFFSET +
+          2 * sizeof(uint64_t),
+      initial_slabs_start);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_rocm_allocate_device_buffer(
+    iree_hal_streaming_context_t* context, iree_hal_buffer_usage_t usage,
+    iree_device_size_t allocation_size, iree_hal_buffer_t** out_buffer,
+    uint64_t* out_device_ptr) {
+  *out_buffer = NULL;
+  *out_device_ptr = 0;
+
+  iree_hal_buffer_params_t params = {
+      .usage = usage | IREE_HAL_BUFFER_USAGE_SHARING_EXPORT,
+      .access = IREE_HAL_MEMORY_ACCESS_ALL,
+      .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+      .queue_affinity = context->queue_affinity,
+  };
+
+  iree_hal_buffer_t* buffer = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
+      context->device_allocator, params, allocation_size, &buffer));
+
+  iree_hal_external_buffer_t external_buffer;
+  iree_status_t status = iree_hal_allocator_export_buffer(
+      context->device_allocator, buffer,
+      IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION,
+      IREE_HAL_EXTERNAL_BUFFER_FLAG_NONE, &external_buffer);
+  if (iree_status_is_ok(status)) {
+    *out_buffer = buffer;
+    *out_device_ptr = external_buffer.handle.device_allocation.ptr;
+  } else {
+    iree_hal_buffer_release(buffer);
+  }
+  return status;
+}
+
+static iree_status_t
+iree_hal_streaming_context_initialize_rocm_device_runtime_locked(
+    iree_hal_streaming_context_t* context) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  const iree_device_size_t requested_heap_size =
+      (iree_device_size_t)context->limits.malloc_heap_size;
+  const iree_device_size_t initial_slab_count = iree_device_size_ceil_div(
+      iree_max(
+          requested_heap_size,
+          (iree_device_size_t)IREE_HAL_STREAMING_ROCM_MALLOC_INITIAL_SLAB_SIZE),
+      IREE_HAL_STREAMING_ROCM_MALLOC_INITIAL_SLAB_SIZE);
+  iree_device_size_t initial_slab_bytes = 0;
+  if (IREE_UNLIKELY(!iree_device_size_checked_mul(
+          initial_slab_count,
+          (iree_device_size_t)IREE_HAL_STREAMING_ROCM_MALLOC_INITIAL_SLAB_SIZE,
+          &initial_slab_bytes))) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "ROCm device malloc heap size overflow");
+  }
+
+  iree_hal_buffer_t* heap_buffer = NULL;
+  iree_hal_buffer_t* initial_slabs_buffer = NULL;
+  uint64_t heap_device_ptr = 0;
+  uint64_t initial_slabs_device_ptr = 0;
+  uint8_t* heap_header = NULL;
+
+  iree_status_t status = iree_hal_streaming_rocm_allocate_device_buffer(
+      context,
+      IREE_HAL_BUFFER_USAGE_TRANSFER_TARGET |
+          IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE,
+      IREE_HAL_STREAMING_ROCM_MALLOC_HEAP_SIZE, &heap_buffer, &heap_device_ptr);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_rocm_allocate_device_buffer(
+        context, IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE, initial_slab_bytes,
+        &initial_slabs_buffer, &initial_slabs_device_ptr);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_allocator_malloc(context->host_allocator,
+                                   IREE_HAL_STREAMING_ROCM_MALLOC_HEAP_SIZE,
+                                   (void**)&heap_header);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_rocm_populate_malloc_heap_header(
+        heap_header, initial_slabs_device_ptr, initial_slab_bytes);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_slim_mutex_lock(&context->direct_transfer_mutex);
+    status = iree_hal_device_transfer_h2d(
+        context->device, heap_header, heap_buffer, /*target_offset=*/0,
+        IREE_HAL_STREAMING_ROCM_MALLOC_HEAP_SIZE,
+        IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout());
+    iree_slim_mutex_unlock(&context->direct_transfer_mutex);
+  }
+
+  if (iree_status_is_ok(status)) {
+    context->rocm_device_runtime.malloc_heap_buffer = heap_buffer;
+    context->rocm_device_runtime.malloc_initial_slabs_buffer =
+        initial_slabs_buffer;
+    iree_atomic_store(&context->rocm_device_runtime.malloc_heap_device_ptr,
+                      heap_device_ptr, iree_memory_order_release);
+    heap_buffer = NULL;
+    initial_slabs_buffer = NULL;
+  }
+
+  iree_allocator_free(context->host_allocator, heap_header);
+  iree_hal_buffer_release(initial_slabs_buffer);
+  iree_hal_buffer_release(heap_buffer);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
 
 //===----------------------------------------------------------------------===//
 // Global state
@@ -80,10 +262,16 @@ iree_status_t iree_hal_streaming_context_create(
   memset(&context->buffer_table, 0, sizeof(context->buffer_table));
   context->pageable_h2d_staging_buffer = NULL;
   context->pageable_h2d_staging_size = 0;
+  memset(&context->rocm_device_runtime, 0,
+         sizeof(context->rocm_device_runtime));
+  context->rocm_device_runtime.malloc_heap_device_ptr = IREE_ATOMIC_VAR_INIT(0);
+  context->rocm_device_runtime.hostcall_buffer_device_ptr =
+      IREE_ATOMIC_VAR_INIT(0);
   iree_atomic_store(&context->capture_stream_count, 0,
                     iree_memory_order_relaxed);
   context->host_allocator = host_allocator;
   iree_slim_mutex_initialize(&context->mutex);
+  iree_slim_mutex_initialize(&context->direct_transfer_mutex);
 
   // Initialize global list pointers.
   context->context_list_entry.next = NULL;
@@ -96,10 +284,10 @@ iree_status_t iree_hal_streaming_context_create(
       8;  // Pre-allocate for default stream + user streams.
   context->streams = NULL;
 
-  // Initialize default limits.
-  // These are typical defaults matching CUDA/HIP behavior.
+  // Initialize default limits. Buffered printf uses a per-dispatch FIFO sized
+  // for the ROCm device-library workitem debug record window.
   context->limits.stack_size = 1024;                        // 1KB default
-  context->limits.printf_fifo_size = 1024 * 1024;           // 1MB
+  context->limits.printf_fifo_size = 4 * 1024 * 1024;       // 4MB
   context->limits.malloc_heap_size = 8 * 1024 * 1024;       // 8MB
   context->limits.dev_runtime_sync_depth = 128;             // 128 levels
   context->limits.dev_runtime_pending_launch_count = 2048;  // 2048 launches
@@ -170,6 +358,10 @@ static void iree_hal_streaming_context_destroy(
   iree_status_ignore(iree_hal_streaming_context_synchronize(context));
 
   iree_hal_streaming_memory_release_pageable_staging(context);
+  iree_hal_streaming_context_deinitialize_rocm_hostcall_service(context);
+  iree_hal_buffer_release(
+      context->rocm_device_runtime.malloc_initial_slabs_buffer);
+  iree_hal_buffer_release(context->rocm_device_runtime.malloc_heap_buffer);
 
   // Deinitialize symbol map and unload any statically-registered modules that
   // were on-demand loaded for this context.
@@ -210,6 +402,7 @@ static void iree_hal_streaming_context_destroy(
   iree_hal_device_release(context->device);
 
   // Deinitialize synchronization.
+  iree_slim_mutex_deinitialize(&context->direct_transfer_mutex);
   iree_slim_mutex_deinitialize(&context->mutex);
 
   // Free context memory.
@@ -435,7 +628,14 @@ iree_status_t iree_hal_streaming_context_set_limit(
       context->limits.printf_fifo_size = value;
       break;
     case IREE_HAL_STREAMING_CONTEXT_LIMIT_MALLOC_HEAP_SIZE:
-      context->limits.malloc_heap_size = value;
+      if (context->rocm_device_runtime.malloc_heap_buffer &&
+          context->limits.malloc_heap_size != value) {
+        status =
+            iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                             "device malloc heap has already been initialized");
+      } else {
+        context->limits.malloc_heap_size = value;
+      }
       break;
     case IREE_HAL_STREAMING_CONTEXT_LIMIT_DEV_RUNTIME_SYNC_DEPTH:
       context->limits.dev_runtime_sync_depth = value;
@@ -457,7 +657,36 @@ iree_status_t iree_hal_streaming_context_set_limit(
   iree_slim_mutex_unlock(&context->mutex);
 
   IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
+  return status;
+}
+
+iree_status_t iree_hal_streaming_context_rocm_device_malloc_heap(
+    iree_hal_streaming_context_t* context, uint64_t* out_heap_device_ptr) {
+  IREE_ASSERT_ARGUMENT(context);
+  IREE_ASSERT_ARGUMENT(out_heap_device_ptr);
+  *out_heap_device_ptr = 0;
+  const uint64_t cached_heap_device_ptr =
+      iree_hal_streaming_context_cached_rocm_malloc_heap(context);
+  if (cached_heap_device_ptr != 0) {
+    *out_heap_device_ptr = cached_heap_device_ptr;
+    return iree_ok_status();
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_slim_mutex_lock(&context->mutex);
+  iree_status_t status = iree_ok_status();
+  if (!context->rocm_device_runtime.malloc_heap_buffer) {
+    status = iree_hal_streaming_context_initialize_rocm_device_runtime_locked(
+        context);
+  }
+  if (iree_status_is_ok(status)) {
+    *out_heap_device_ptr =
+        iree_hal_streaming_context_cached_rocm_malloc_heap(context);
+  }
+  iree_slim_mutex_unlock(&context->mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
 }
 
 iree_status_t iree_hal_streaming_context_enable_peer_access(

--- a/libhrx/src/binding/common/graph.c
+++ b/libhrx/src/binding/common/graph.c
@@ -166,9 +166,8 @@ iree_status_t iree_hal_streaming_graph_allocate_host_staging(
 
   iree_hal_streaming_buffer_t* buffer = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_streaming_memory_allocate_host(
-              graph->context, size,
-              IREE_HAL_STREAMING_HOST_REGISTER_FLAG_DEFAULT, &buffer));
+      z0, iree_hal_streaming_memory_allocate_host_staging(graph->context, size,
+                                                          &buffer));
 
   iree_hal_streaming_graph_owned_host_allocation_t* owned_allocation = NULL;
   iree_status_t status = iree_arena_allocate(

--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -36,6 +36,27 @@ typedef enum iree_hal_streaming_graph_block_type_e {
 
 typedef void (*iree_hal_streaming_host_callback_t)(void* user_data);
 
+// HIP graph command order also orders memory side effects. The AMDGPU HAL
+// lowers these access scopes into AQL acquire/release fences between payloads.
+static iree_status_t iree_hal_streaming_graph_record_ordering_barrier(
+    iree_hal_command_buffer_t* command_buffer) {
+  static const iree_hal_memory_barrier_t memory_barrier = {
+      .source_scope = IREE_HAL_ACCESS_SCOPE_DISPATCH_READ |
+                      IREE_HAL_ACCESS_SCOPE_DISPATCH_WRITE |
+                      IREE_HAL_ACCESS_SCOPE_TRANSFER_READ |
+                      IREE_HAL_ACCESS_SCOPE_TRANSFER_WRITE,
+      .target_scope = IREE_HAL_ACCESS_SCOPE_DISPATCH_READ |
+                      IREE_HAL_ACCESS_SCOPE_DISPATCH_WRITE |
+                      IREE_HAL_ACCESS_SCOPE_TRANSFER_READ |
+                      IREE_HAL_ACCESS_SCOPE_TRANSFER_WRITE,
+  };
+  return iree_hal_command_buffer_execution_barrier(
+      command_buffer,
+      IREE_HAL_EXECUTION_STAGE_DISPATCH | IREE_HAL_EXECUTION_STAGE_TRANSFER,
+      IREE_HAL_EXECUTION_STAGE_DISPATCH | IREE_HAL_EXECUTION_STAGE_TRANSFER,
+      IREE_HAL_EXECUTION_BARRIER_FLAG_NONE, 1, &memory_barrier, 0, NULL);
+}
+
 // IREE_HAL_STREAMING_GRAPH_BLOCK_TYPE_QUEUE_BARRIER
 typedef struct iree_hal_streaming_graph_barrier_block_attrs_t {
   iree_hal_execute_flags_t flags;
@@ -665,14 +686,18 @@ iree_status_t iree_hal_streaming_graph_exec_create(
   iree_status_t status = iree_hal_resource_set_allocate(
       &context->device_entry->block_pool, &exec->resource_set);
   if (iree_status_is_ok(status) && exec->node_disabled_state_count > 0) {
-    status = iree_allocator_malloc(
-        host_allocator,
-        exec->node_disabled_state_count * sizeof(*exec->node_disabled_states),
-        (void**)&exec->node_disabled_states);
+    iree_host_size_t node_disabled_states_size = 0;
+    if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+            exec->node_disabled_state_count,
+            sizeof(*exec->node_disabled_states), &node_disabled_states_size))) {
+      status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                "node disabled-state size overflow");
+    } else {
+      status = iree_allocator_malloc(host_allocator, node_disabled_states_size,
+                                     (void**)&exec->node_disabled_states);
+    }
     if (iree_status_is_ok(status)) {
-      memset(exec->node_disabled_states, 0,
-             exec->node_disabled_state_count *
-                 sizeof(*exec->node_disabled_states));
+      memset(exec->node_disabled_states, 0, node_disabled_states_size);
     }
   }
   if (iree_status_is_ok(status)) {
@@ -880,18 +905,20 @@ iree_hal_streaming_graph_exec_flags(iree_hal_streaming_graph_exec_t* exec) {
 bool iree_hal_streaming_graph_exec_owns_node(
     iree_hal_streaming_graph_exec_t* exec,
     iree_hal_streaming_graph_node_t* node) {
-  return exec && node && node->graph == exec->graph &&
+  return exec && !exec->is_destroyed && node && node->graph == exec->graph &&
          node->node_index < exec->instantiated_node_count;
 }
 
 bool iree_hal_streaming_graph_exec_node_is_enabled(
     iree_hal_streaming_graph_exec_t* exec,
     iree_hal_streaming_graph_node_t* node) {
-  if (!iree_hal_streaming_graph_exec_owns_node(exec, node) ||
-      node->node_index >= exec->node_disabled_state_count) {
-    return false;
-  }
-  return exec->node_disabled_states[node->node_index] == 0;
+  if (!exec) return false;
+  iree_slim_mutex_lock(&exec->mutex);
+  const bool is_enabled = iree_hal_streaming_graph_exec_owns_node(exec, node) &&
+                          node->node_index < exec->node_disabled_state_count &&
+                          exec->node_disabled_states[node->node_index] == 0;
+  iree_slim_mutex_unlock(&exec->mutex);
+  return is_enabled;
 }
 
 iree_status_t iree_hal_streaming_graph_exec_set_node_enabled(
@@ -1357,10 +1384,8 @@ static iree_status_t iree_hal_streaming_graph_create_execute_block(
   // destruction waits for active streams, and stream-ordered destruction queues
   // the release after prior work.
   //
-  // TODO: limit queue affinity to the device being instantiated on, if scoped
-  // to a queue. Currently we are assuming we are targeting a single
-  // iree_hal_device_t but it should really be a pair of (iree_hal_device_t,
-  // queue_affinity_mask).
+  // Graph executables are bound to the context device. Queue affinity is
+  // selected when the executable is submitted to a stream.
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_command_buffer_create(
               exec->context->device, IREE_HAL_COMMAND_BUFFER_MODE_UNRETAINED,
@@ -1439,8 +1464,8 @@ static bool iree_hal_streaming_node_index_set_test_hazard(
 }
 
 // Inserts |value| into the |set|.
-// If the set has reached capacity it is set to invalid and all future tests
-// will return a hazard.
+// If the set has reached capacity it is set to invalid and all later membership
+// queries conservatively report a hazard.
 static void iree_hal_streaming_node_index_set_insert(
     iree_hal_streaming_node_index_set_t* set, uint32_t value) {
   if (set->count >= IREE_ARRAYSIZE(set->values)) {
@@ -1498,8 +1523,8 @@ static iree_status_t iree_hal_streaming_graph_record_partition(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_command_buffer_begin(command_buffer));
 
-  // Scope the partition into a debug group.
-  // TODO: propagate graph information (name, origin, etc).
+  // Scope the partition into a debug group. Node-level debug labels carry
+  // operation detail.
   const iree_string_view_t label_name = iree_make_cstring_view("tbd_partition");
   const iree_hal_label_location_t* location = NULL;
   const iree_hal_label_color_t label_color = iree_hal_label_color_unspecified();
@@ -1534,10 +1559,8 @@ static iree_status_t iree_hal_streaming_graph_record_partition(
               node, additional_edges, node_index_map, &barrier_index_set);
       if (preserve_sorted_order || has_dependency_hazard) {
         IREE_RETURN_AND_END_ZONE_IF_ERROR(
-            z0, iree_hal_command_buffer_execution_barrier(
-                    command_buffer, IREE_HAL_EXECUTION_STAGE_COMMAND_RETIRE,
-                    IREE_HAL_EXECUTION_STAGE_COMMAND_ISSUE,
-                    IREE_HAL_EXECUTION_BARRIER_FLAG_NONE, 0, NULL, 0, NULL));
+            z0,
+            iree_hal_streaming_graph_record_ordering_barrier(command_buffer));
         iree_hal_streaming_node_index_set_reset(&barrier_index_set);
       }
     }
@@ -1547,7 +1570,7 @@ static iree_status_t iree_hal_streaming_graph_record_partition(
         const iree_hal_streaming_graph_kernel_node_attrs_t* attrs =
             &node->attrs.kernel;
         iree_hal_streaming_symbol_t* symbol = attrs->symbol;
-        const iree_hal_dispatch_config_t config = {
+        iree_hal_dispatch_config_t config = {
             .workgroup_size =
                 {
                     attrs->block_dim[0],
@@ -1562,10 +1585,30 @@ static iree_status_t iree_hal_streaming_graph_record_partition(
                 },
             .dynamic_workgroup_local_memory = attrs->shared_memory_bytes,
         };
+        iree_hal_dispatch_runtime_parameter_list_t runtime_parameters;
         const iree_hal_dispatch_flags_t flags =
             attrs->bindings.count
                 ? IREE_HAL_DISPATCH_FLAG_NONE
                 : IREE_HAL_DISPATCH_FLAG_CUSTOM_DIRECT_ARGUMENTS;
+        // Graph executables record one reusable command buffer and may run
+        // concurrently. Buffered printf requires a distinct FIFO that remains
+        // live through each launch and is drained after that launch completes;
+        // recording a shared FIFO here would race, while omitting it passes a
+        // null pointer to device code.
+        if (symbol->runtime_services.printf_buffer.present) {
+          status = iree_make_status(
+              IREE_STATUS_UNIMPLEMENTED,
+              "graph kernel dispatch does not support buffered printf");
+          break;
+        }
+        if (iree_hal_streaming_symbol_uses_runtime_services(
+                symbol, /*enable_printf=*/false)) {
+          status = iree_hal_streaming_symbol_prepare_runtime_dispatch_config(
+              symbol, exec->context, /*enable_printf=*/false,
+              &runtime_parameters, &config,
+              /*out_printf_buffer=*/NULL);
+        }
+        if (!iree_status_is_ok(status)) break;
         status = iree_hal_command_buffer_dispatch(
             command_buffer, symbol->executable,
             iree_hal_executable_function_from_index(symbol->export_ordinal),
@@ -1662,9 +1705,8 @@ iree_status_t iree_hal_streaming_graph_exec_instantiate_from_template(
   // We need semaphores at partition boundaries for synchronization.
   // Multi-stream partitions need join semaphores.
   //
-  // This currently allocates semaphores per block boundary. A future
-  // optimization can reduce this to the maximum layer size by advancing
-  // timeline values between partitions.
+  // Allocate semaphores per block boundary. Each boundary needs a stable
+  // timeline edge for the lifetime of the executable.
   uint32_t semaphore_count = 0;
   if (schedule.partition_count > 1) {
     for (iree_host_size_t i = 0; i < schedule.partition_count - 1; i++) {

--- a/libhrx/src/binding/common/init.c
+++ b/libhrx/src/binding/common/init.c
@@ -48,6 +48,24 @@ static uint32_t iree_hal_streaming_u32_or_default(uint64_t value,
   return (uint32_t)value;
 }
 
+static iree_status_t iree_hal_streaming_query_host_native_atomic_supported(
+    hrx_device_t hrx_device, bool* out_supported) {
+  *out_supported = false;
+  bool supported = false;
+  hrx_status_t status = hrx_device_get_property(
+      hrx_device, HRX_DEVICE_PROPERTY_HOST_NATIVE_ATOMIC_SUPPORTED, &supported,
+      sizeof(supported));
+  if (hrx_status_is_ok(status)) {
+    *out_supported = supported;
+    return iree_ok_status();
+  }
+  if (hrx_status_code(status) == HRX_STATUS_UNAVAILABLE) {
+    hrx_status_ignore(status);
+    return iree_ok_status();
+  }
+  return hrx_to_iree_status(status);
+}
+
 // Queries device info and populates device properties.
 static iree_status_t iree_hal_streaming_query_device_info(
     iree_hal_streaming_device_t* device) {
@@ -129,6 +147,11 @@ static iree_status_t iree_hal_streaming_query_device_info(
   // TODO: Query from actual device properties.
   // Cooperative launch requires Pascal (SM 6.0) or newer.
   device->supports_cooperative_launch = (device->compute_capability_major >= 6);
+  bool host_native_atomic_supported = false;
+  status = iree_hal_streaming_query_host_native_atomic_supported(
+      device->hrx_device, &host_native_atomic_supported);
+  if (!iree_status_is_ok(status)) return status;
+  device->host_native_atomic_supported = host_native_atomic_supported;
 
   device->max_threads_per_block = iree_hal_streaming_u32_or_default(
       launch ? launch->maximum_workgroup_invocations : 0, 1024);
@@ -149,8 +172,9 @@ static iree_status_t iree_hal_streaming_query_device_info(
     device->warp_size = 32;
   }
 
-  uint32_t multiprocessor_count = iree_hal_streaming_u32_or_default(
-      execution ? execution->unit_count : 0, 80);
+  device->raw_compute_unit_count = execution ? execution->unit_count : 0;
+  uint32_t multiprocessor_count =
+      iree_hal_streaming_u32_or_default(device->raw_compute_unit_count, 80);
   // IREE/HSA reports raw compute units, while HIP reports RDNA devices in
   // WGP-like units. Keep this HIP-compatible because rocBLAS/hipBLASLt query
   // the physical multiprocessor count when selecting GEMM solutions.
@@ -159,6 +183,9 @@ static iree_status_t iree_hal_streaming_query_device_info(
     multiprocessor_count /= 2;
   }
   device->multiprocessor_count = multiprocessor_count;
+
+  device->maximum_resident_subgroup_count =
+      execution ? execution->maximum_resident_subgroup_count : 0;
 
   device->max_threads_per_multiprocessor = iree_hal_streaming_u32_or_default(
       execution ? execution->maximum_resident_invocation_count : 0, 2048);

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -134,6 +134,20 @@ typedef struct iree_hal_streaming_limits_t {
   size_t persisting_l2_cache_size;          // Persistent L2 cache size.
 } iree_hal_streaming_limits_t;
 
+// Per-context device-runtime storage for ROCm device libraries.
+typedef struct iree_hal_streaming_rocm_device_runtime_t {
+  // Device-local heap header buffer passed through hidden_heap_v1.
+  iree_hal_buffer_t* malloc_heap_buffer;
+  // Device-local initial slab storage referenced by the heap header.
+  iree_hal_buffer_t* malloc_initial_slabs_buffer;
+  // Non-zero after the immutable malloc heap and header are fully initialized.
+  iree_atomic_uint64_t malloc_heap_device_ptr;
+  // Lazily-created hostcall listener and queue-visible service buffer.
+  struct iree_hal_streaming_rocm_hostcall_service_t* hostcall_service;
+  // Non-zero after the hostcall listener and service buffer are ready.
+  iree_atomic_uint64_t hostcall_buffer_device_ptr;
+} iree_hal_streaming_rocm_device_runtime_t;
+
 // Tracks a module loaded into a context symbol map.
 typedef struct iree_hal_streaming_context_module_entry_t {
   // Module registration from the global registry (for identification).
@@ -147,8 +161,11 @@ typedef struct iree_hal_streaming_context_module_entry_t {
 typedef struct iree_hal_streaming_context_symbol_entry_t {
   // Host pointer key used by generated HIP registration code.
   void* key;
-  // Compiled symbol associated with the registration key.
+  // Context-local symbol resolved from the registered module.
   iree_hal_streaming_symbol_t* symbol;
+  // True when |symbol| backs managed host storage that must be refreshed after
+  // synchronization.
+  bool synchronize_managed_data_to_host;
 } iree_hal_streaming_context_symbol_entry_t;
 
 // Per-context cache of compiled symbols.
@@ -231,8 +248,13 @@ struct iree_hal_streaming_context_t {
   // Context resource limits.
   iree_hal_streaming_limits_t limits;
 
+  // Lazily-created ROCm device-runtime state used by loaded HIP modules.
+  iree_hal_streaming_rocm_device_runtime_t rocm_device_runtime;
+
   // Synchronization.
   iree_slim_mutex_t mutex;
+  // Serializes direct HAL device transfer calls issued outside command buffers.
+  iree_slim_mutex_t direct_transfer_mutex;
 
   // Host allocator.
   iree_allocator_t host_allocator;
@@ -264,6 +286,23 @@ static inline bool iree_hal_streaming_context_has_capture_streams(
     const iree_hal_streaming_context_t* context) {
   return iree_atomic_load(&context->capture_stream_count,
                           iree_memory_order_acquire) > 0;
+}
+
+// Returns the ready device-runtime heap address, or 0 while it is
+// uninitialized.
+static inline uint64_t iree_hal_streaming_context_cached_rocm_malloc_heap(
+    const iree_hal_streaming_context_t* context) {
+  return (uint64_t)iree_atomic_load(
+      &context->rocm_device_runtime.malloc_heap_device_ptr,
+      iree_memory_order_acquire);
+}
+
+// Returns the ready hostcall service-buffer address, or 0 while it is absent.
+static inline uint64_t iree_hal_streaming_context_cached_rocm_hostcall_buffer(
+    const iree_hal_streaming_context_t* context) {
+  return (uint64_t)iree_atomic_load(
+      &context->rocm_device_runtime.hostcall_buffer_device_ptr,
+      iree_memory_order_acquire);
 }
 
 static inline void iree_hal_streaming_context_enter_capture(
@@ -325,11 +364,17 @@ typedef struct iree_hal_streaming_device_t {
   iree_device_size_t free_memory;
   // True when cooperative launches are supported by the device.
   bool supports_cooperative_launch;
+  // True when host/device links support native system-scope atomics.
+  bool host_native_atomic_supported;
 
   // GCN architecture name (e.g., "gfx942:sramecc+:xnack-").
   char gcn_arch_name[64];
 
   // Device properties cache.
+  // Physical compute-unit count from the execution specification.
+  uint32_t raw_compute_unit_count;
+  // Maximum waves that can reside on one physical compute unit.
+  uint32_t maximum_resident_subgroup_count;
   uint32_t max_threads_per_block;
   uint32_t max_block_dim[3];
   uint32_t max_grid_dim[3];
@@ -612,6 +657,34 @@ static inline bool iree_hal_streaming_parameter_info_is_empty(
          parameters->copy_count == 0;
 }
 
+// Backend-native hidden runtime parameter slot.
+typedef struct iree_hal_streaming_runtime_parameter_slot_t {
+  // Byte offset in the backend-native launch argument storage.
+  uint32_t offset;
+  // Byte length of the runtime parameter storage.
+  uint32_t length;
+  // True when this slot was declared by executable metadata.
+  bool present;
+} iree_hal_streaming_runtime_parameter_slot_t;
+
+// Runtime service slots declared by one function symbol.
+typedef struct iree_hal_streaming_symbol_runtime_services_t {
+  // Hidden buffered-printf service slot.
+  iree_hal_streaming_runtime_parameter_slot_t printf_buffer;
+  // Hidden hostcall service slot.
+  iree_hal_streaming_runtime_parameter_slot_t hostcall_buffer;
+  // Hidden device-runtime heap slot.
+  iree_hal_streaming_runtime_parameter_slot_t heap_v1;
+} iree_hal_streaming_symbol_runtime_services_t;
+
+// Parsed printf format metadata retained at module scope.
+typedef struct iree_hal_streaming_printf_format_t {
+  // Lower 64 bits of the MD5 hash emitted in `amdhsa.printf`.
+  uint64_t hash;
+  // Format string borrowed from executable metadata storage.
+  iree_string_view_t format;
+} iree_hal_streaming_printf_format_t;
+
 // Symbol metadata structure.
 typedef struct iree_hal_streaming_symbol_t {
   // Parent module. Unowned.
@@ -633,6 +706,8 @@ typedef struct iree_hal_streaming_symbol_t {
 
   // Function parameter information used for argument packing and unpacking.
   iree_hal_streaming_parameter_info_t parameters;
+  // Hidden runtime services declared by function metadata.
+  iree_hal_streaming_symbol_runtime_services_t runtime_services;
 
   // Global/data attributes (only valid for GLOBAL/DATA types).
   // HAL executable global handle, when backed by an executable global.
@@ -644,6 +719,14 @@ typedef struct iree_hal_streaming_symbol_t {
   // Byte length of the global storage.
   iree_device_size_t size_bytes;
 } iree_hal_streaming_symbol_t;
+
+// Returns true when a dispatch must populate a backend-native runtime service.
+static inline bool iree_hal_streaming_symbol_uses_runtime_services(
+    const iree_hal_streaming_symbol_t* symbol, bool enable_printf) {
+  return (enable_printf && symbol->runtime_services.printf_buffer.present) ||
+         symbol->runtime_services.hostcall_buffer.present ||
+         symbol->runtime_services.heap_v1.present;
+}
 
 // Module containing compiled kernels.
 typedef struct iree_hal_streaming_module_t {
@@ -667,6 +750,10 @@ typedef struct iree_hal_streaming_module_t {
   iree_host_size_t global_count;
   // Capacity of the cached executable global symbols array.
   iree_host_size_t global_capacity;
+  // Number of parsed printf format records.
+  iree_host_size_t printf_format_count;
+  // Parsed printf format records keyed by metadata hash.
+  iree_hal_streaming_printf_format_t* printf_formats;
 
   // Context that loaded this module.
   iree_hal_streaming_context_t* context;
@@ -1432,6 +1519,21 @@ iree_status_t iree_hal_streaming_context_set_limit(
     iree_hal_streaming_context_t* context,
     iree_hal_streaming_context_limit_t limit, size_t value);
 
+// Returns a device pointer to the per-context ROCm device malloc heap.
+// Synchronization: the first request initializes under the context lock.
+iree_status_t iree_hal_streaming_context_rocm_device_malloc_heap(
+    iree_hal_streaming_context_t* context, uint64_t* out_heap_device_ptr);
+// Returns a context-owned ROCm hostcall service buffer device pointer.
+// Synchronization: the first request initializes under the context lock.
+iree_status_t iree_hal_streaming_context_rocm_hostcall_buffer(
+    iree_hal_streaming_context_t* context, uint64_t* out_buffer_device_ptr);
+// Calculates the power-of-two packet capacity required for one host queue.
+iree_status_t iree_hal_streaming_rocm_hostcall_calculate_packet_count(
+    const iree_hal_streaming_device_t* device, uint32_t* out_packet_count);
+// Shuts down any lazily-created ROCm hostcall service for |context|.
+void iree_hal_streaming_context_deinitialize_rocm_hostcall_service(
+    iree_hal_streaming_context_t* context);
+
 // Synchronization: none (configures peer access).
 iree_status_t iree_hal_streaming_context_enable_peer_access(
     iree_hal_streaming_context_t* context,
@@ -1516,6 +1618,30 @@ iree_status_t iree_hal_streaming_module_create_from_memory(
     iree_hal_streaming_context_t* context,
     iree_hal_executable_load_flags_t load_flags, iree_const_byte_span_t image,
     iree_allocator_t host_allocator, iree_hal_streaming_module_t** out_module);
+
+// Initializes hidden runtime service and executable-level runtime metadata.
+iree_status_t iree_hal_streaming_module_initialize_runtime_metadata(
+    iree_hal_streaming_module_t* module);
+// Allocates and initializes a transient buffered-printf FIFO for one dispatch.
+iree_status_t iree_hal_streaming_symbol_create_printf_buffer(
+    iree_hal_streaming_symbol_t* symbol,
+    iree_hal_streaming_buffer_t** out_buffer);
+// Adds hidden runtime service pointers required by |symbol| to |config|.
+// |runtime_parameters| is caller-owned dispatch storage that must remain live
+// through command recording; |config| references it when it has patches.
+// When |enable_printf| is true, returns a transient printf FIFO in
+// |out_printf_buffer| that must be drained or released by the caller.
+iree_status_t iree_hal_streaming_symbol_prepare_runtime_dispatch_config(
+    iree_hal_streaming_symbol_t* symbol, iree_hal_streaming_context_t* context,
+    bool enable_printf,
+    iree_hal_dispatch_runtime_parameter_list_t* runtime_parameters,
+    iree_hal_dispatch_config_t* config,
+    iree_hal_streaming_buffer_t** out_printf_buffer);
+// Enqueues a stream-ordered drain and release for a transient printf buffer.
+// Takes ownership of |buffer| regardless of success.
+iree_status_t iree_hal_streaming_symbol_queue_printf_drain(
+    iree_hal_streaming_symbol_t* symbol, iree_hal_streaming_stream_t* stream,
+    iree_hal_streaming_buffer_t* buffer);
 
 // Loads module from a file at the given path.
 // Synchronization: none (creates new module).
@@ -1654,6 +1780,12 @@ iree_status_t iree_hal_streaming_launch_kernel(
 iree_status_t iree_hal_streaming_launch_host_function(
     iree_hal_streaming_stream_t* stream, void (*fn)(void*), void* user_data);
 
+// Enqueues a HAL host call at the current stream timeline point.
+// Synchronization: stream flush (flushes stream before enqueue).
+iree_status_t iree_hal_streaming_queue_host_call(
+    iree_hal_streaming_stream_t* stream, iree_hal_host_call_t call,
+    const uint64_t args[4], iree_hal_host_call_flags_t flags);
+
 //===----------------------------------------------------------------------===//
 // Event management
 //===----------------------------------------------------------------------===//
@@ -1762,6 +1894,20 @@ iree_status_t iree_hal_streaming_memory_allocate_host(
     iree_hal_streaming_host_register_flags_t flags,
     iree_hal_streaming_buffer_t** out_buffer);
 
+// Synchronization: none (allocates queue-visible host staging memory).
+iree_status_t iree_hal_streaming_memory_allocate_host_staging(
+    iree_hal_streaming_context_t* context, iree_host_size_t size,
+    iree_hal_streaming_buffer_t** out_buffer);
+
+// Synchronization: none (allocates host-visible device-runtime storage).
+iree_status_t iree_hal_streaming_memory_allocate_runtime_host(
+    iree_hal_streaming_context_t* context, iree_host_size_t size,
+    iree_hal_streaming_buffer_t** out_buffer);
+// Synchronization: none (allocates context-owned host-visible runtime storage).
+iree_status_t iree_hal_streaming_memory_allocate_context_runtime_host(
+    iree_hal_streaming_context_t* context, iree_host_size_t size,
+    iree_hal_streaming_buffer_t** out_buffer);
+
 // Synchronization: none (allocates host-visible device memory).
 iree_status_t iree_hal_streaming_memory_allocate_managed(
     iree_hal_streaming_context_t* context, iree_host_size_t size,
@@ -1787,6 +1933,11 @@ iree_status_t iree_hal_streaming_memory_wrap_buffer(
 // Releases a wrapper created with iree_hal_streaming_memory_wrap_buffer.
 // Synchronization: none (unregisters existing memory).
 void iree_hal_streaming_memory_release_wrapped_buffer(
+    iree_hal_streaming_buffer_t* buffer);
+
+// Releases a transient buffer whose stream-ordered users have completed.
+// Synchronization: caller-provided stream ordering.
+void iree_hal_streaming_memory_release_transient_buffer(
     iree_hal_streaming_buffer_t* buffer);
 
 // Synchronization: none (registers existing memory).
@@ -2145,8 +2296,12 @@ typedef struct iree_hal_streaming_symbol_registration_t {
     } function;
     // Variable-specific metadata (only valid if type == GLOBAL/DATA).
     struct {
+      // Registered variable size in bytes.
       size_t size;
+      // Required variable alignment in bytes.
       uint32_t alignment;
+      // Host storage used to initialize a managed variable, or NULL.
+      void* managed_initial_value;
     } variable;
   } params;
 } iree_hal_streaming_symbol_registration_t;
@@ -2225,7 +2380,8 @@ iree_status_t iree_hal_streaming_global_symbol_registry_insert_variable(
 iree_status_t iree_hal_streaming_global_symbol_registry_insert_managed_variable(
     iree_hal_streaming_global_symbol_registry_t* registry,
     iree_hal_streaming_module_registration_t* module, void* host_variable,
-    const char* device_name, size_t size, uint32_t alignment);
+    const char* device_name, size_t size, uint32_t alignment,
+    void* managed_initial_value);
 
 // Looks up the registration type for a host-side variable pointer.
 bool iree_hal_streaming_global_symbol_registry_query_variable(
@@ -2254,6 +2410,11 @@ void iree_hal_streaming_context_symbol_map_deinitialize(
 iree_status_t iree_hal_streaming_context_symbol_map_lookup(
     iree_hal_streaming_context_symbol_map_t* map, void* host_pointer,
     iree_hal_streaming_symbol_t** out_symbol);
+
+// Refreshes host storage for managed DATA symbols whose device backing storage
+// has been resolved in this context.
+iree_status_t iree_hal_streaming_context_symbol_map_synchronize_managed_data(
+    iree_hal_streaming_context_symbol_map_t* map);
 
 #ifdef __cplusplus
 }

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -689,20 +689,35 @@ typedef struct iree_hal_streaming_printf_format_t {
 typedef struct iree_hal_streaming_symbol_t {
   // Parent module. Unowned.
   iree_hal_streaming_module_t* module;
+  // HIP-visible symbol name. Aliases executable/module-owned string storage.
   iree_string_view_t name;
+  // Symbol kind determining which metadata fields are active.
   iree_hal_streaming_symbol_type_t type;
+  // HAL executable containing this function export, if this is a function.
   iree_hal_executable_t* executable;
+  // HAL executable export ordinal for function dispatch and metadata queries.
   iree_hal_executable_export_ordinal_t export_ordinal;
 
-  // Function attributes (only valid for FUNCTION type).
+  // Occupancy scheduling hints for function dispatch.
   iree_hal_occupancy_info_t occupancy_info;
   // Maximum workgroup size reported by executable metadata, or the device
   // limit when metadata does not specify one.
   uint32_t max_threads_per_block;
+  // Fixed workgroup-local memory required by the function, in bytes.
   uint32_t shared_size_bytes;
+  // Fixed private memory required per work-item, in bytes.
   uint32_t local_size_bytes;
+  // Registers used per work-item, or 0 when executable metadata omits it.
   uint32_t num_regs;
+  // Maximum dynamic shared memory accepted by this function, in bytes.
   uint32_t max_dynamic_shared_size_bytes;
+  // Preferred shared-memory carveout percentage reported through HIP function
+  // attribute queries.
+  int32_t preferred_shared_memory_carveout;
+  // Cache mode flag reported through HIP function attribute queries.
+  uint32_t cache_mode_ca;
+  // True when OpenCL/HIP metadata requires uniform workgroup sizes.
+  bool uniform_workgroup_size;
 
   // Function parameter information used for argument packing and unpacking.
   iree_hal_streaming_parameter_info_t parameters;

--- a/libhrx/src/binding/common/memory.c
+++ b/libhrx/src/binding/common/memory.c
@@ -43,6 +43,102 @@ static void iree_hal_streaming_host_memcpy_callback(void* user_data) {
   memcpy(callback_data->dst, callback_data->src, callback_data->count);
 }
 
+typedef struct iree_hal_streaming_d2h_transfer_t {
+  // Context retained while the host call performs the direct D2H transfer.
+  iree_hal_streaming_context_t* context;
+  // Source HAL buffer retained until the host call finishes reading it.
+  iree_hal_buffer_t* src_buffer;
+  // Byte offset into |src_buffer|.
+  iree_device_size_t src_offset;
+  // Ordinary CPU staging memory used as the HAL direct-transfer destination.
+  void* staging;
+  // User host destination pointer.
+  void* dst;
+  // Number of bytes to copy.
+  iree_device_size_t size;
+} iree_hal_streaming_d2h_transfer_t;
+
+static void iree_hal_streaming_d2h_transfer_release(
+    iree_hal_streaming_d2h_transfer_t* transfer) {
+  if (!transfer) return;
+  iree_allocator_free(iree_allocator_system(), transfer->staging);
+  if (transfer->src_buffer) iree_hal_buffer_release(transfer->src_buffer);
+  if (transfer->context) iree_hal_streaming_context_release(transfer->context);
+  iree_allocator_free(iree_allocator_system(), transfer);
+}
+
+static iree_status_t iree_hal_streaming_d2h_transfer_host_call(
+    void* user_data, const uint64_t args[4],
+    iree_hal_host_call_context_t* call_context) {
+  (void)args;
+  (void)call_context;
+  iree_hal_streaming_d2h_transfer_t* transfer =
+      (iree_hal_streaming_d2h_transfer_t*)user_data;
+
+  const iree_device_size_t d2h_chunk_size = 4 * 1024 * 1024;
+  uint8_t* staging_ptr = (uint8_t*)transfer->staging;
+  iree_device_size_t remaining = transfer->size;
+  iree_device_size_t chunk_offset = 0;
+  iree_status_t status = iree_ok_status();
+  iree_slim_mutex_lock(&transfer->context->direct_transfer_mutex);
+  while (remaining > 0 && iree_status_is_ok(status)) {
+    iree_device_size_t this_chunk =
+        remaining < d2h_chunk_size ? remaining : d2h_chunk_size;
+    status = iree_hal_device_transfer_d2h(
+        transfer->context->device, transfer->src_buffer,
+        transfer->src_offset + chunk_offset, staging_ptr + chunk_offset,
+        this_chunk, IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT,
+        iree_infinite_timeout());
+    chunk_offset += this_chunk;
+    remaining -= this_chunk;
+  }
+  iree_slim_mutex_unlock(&transfer->context->direct_transfer_mutex);
+  if (iree_status_is_ok(status)) {
+    memcpy(transfer->dst, transfer->staging, transfer->size);
+  }
+
+  iree_hal_streaming_d2h_transfer_release(transfer);
+  return status;
+}
+
+static iree_status_t iree_hal_streaming_enqueue_d2h_transfer(
+    iree_hal_streaming_context_t* context, iree_hal_streaming_stream_t* stream,
+    iree_hal_streaming_buffer_ref_t src_ref, void* dst,
+    iree_device_size_t size) {
+  if (IREE_UNLIKELY(size > IREE_HOST_SIZE_MAX)) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "D2H transfer size overflows host size");
+  }
+
+  iree_hal_streaming_d2h_transfer_t* transfer = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+      iree_allocator_system(), sizeof(*transfer), (void**)&transfer));
+  memset(transfer, 0, sizeof(*transfer));
+  iree_status_t status = iree_allocator_malloc(
+      iree_allocator_system(), (iree_host_size_t)size, &transfer->staging);
+  if (!iree_status_is_ok(status)) {
+    iree_allocator_free(iree_allocator_system(), transfer);
+    return status;
+  }
+  transfer->context = context;
+  transfer->src_buffer = src_ref.buffer->buffer;
+  transfer->src_offset = src_ref.offset;
+  transfer->dst = dst;
+  transfer->size = size;
+  iree_hal_streaming_context_retain(context);
+  iree_hal_buffer_retain(transfer->src_buffer);
+
+  uint64_t args[4] = {0, 0, 0, 0};
+  iree_hal_host_call_t call = iree_hal_make_host_call(
+      iree_hal_streaming_d2h_transfer_host_call, transfer);
+  iree_status_t queue_status = iree_hal_streaming_queue_host_call(
+      stream, call, args, IREE_HAL_HOST_CALL_FLAG_NONE);
+  if (!iree_status_is_ok(queue_status)) {
+    iree_hal_streaming_d2h_transfer_release(transfer);
+  }
+  return queue_status;
+}
+
 static void iree_hal_streaming_buffer_free(iree_hal_streaming_buffer_t* buffer);
 
 static void iree_hal_streaming_memory_account_device_free(
@@ -338,6 +434,13 @@ iree_status_t iree_hal_streaming_memory_wrap_buffer(
 }
 
 void iree_hal_streaming_memory_release_wrapped_buffer(
+    iree_hal_streaming_buffer_t* buffer) {
+  if (!buffer) return;
+  hrx_buffer_table_remove(&buffer->context->buffer_table, buffer->device_ptr);
+  iree_hal_streaming_buffer_free(buffer);
+}
+
+void iree_hal_streaming_memory_release_transient_buffer(
     iree_hal_streaming_buffer_t* buffer) {
   if (!buffer) return;
   hrx_buffer_table_remove(&buffer->context->buffer_table, buffer->device_ptr);
@@ -924,6 +1027,9 @@ static iree_status_t iree_hal_streaming_memory_allocate_host_with_context_mode(
         IREE_STATUS_UNAVAILABLE,
         "host allocation did not export a host-visible pointer");
   }
+  if (iree_status_is_ok(status)) {
+    memset(wrapper->host_ptr, 0, allocation_size);
+  }
 
   if (iree_status_is_ok(status)) {
     wrapper->imported_host_allocation = false;
@@ -939,13 +1045,115 @@ static iree_status_t iree_hal_streaming_memory_allocate_host_with_context_mode(
   return status;
 }
 
+static iree_status_t
+iree_hal_streaming_memory_allocate_owned_host_import_with_context_mode(
+    iree_hal_streaming_context_t* context, iree_host_size_t size,
+    iree_hal_streaming_host_register_flags_t flags,
+    iree_hal_buffer_usage_t usage, iree_device_size_t min_alignment,
+    iree_hal_streaming_buffer_context_ownership_t context_ownership,
+    iree_hal_streaming_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(context);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  *out_buffer = NULL;
+
+  const iree_host_size_t allocation_size = iree_max(size, (iree_host_size_t)8);
+  const iree_host_size_t host_alignment =
+      iree_max((iree_host_size_t)min_alignment, (iree_host_size_t)4096);
+  void* host_ptr = NULL;
+  iree_status_t status = iree_allocator_malloc_aligned(
+      context->host_allocator, allocation_size, host_alignment,
+      /*offset=*/0, &host_ptr);
+  if (iree_status_is_ok(status)) {
+    memset(host_ptr, 0, allocation_size);
+  }
+
+  iree_hal_buffer_t* buffer = NULL;
+  if (iree_status_is_ok(status)) {
+    iree_hal_buffer_params_t params = {
+        .usage = usage,
+        .access = IREE_HAL_MEMORY_ACCESS_ALL,
+        .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+        .queue_affinity = IREE_HAL_QUEUE_AFFINITY_ANY,
+        .min_alignment = host_alignment,
+    };
+    iree_hal_external_buffer_t external_buffer = {
+        .type = IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION,
+        .flags = IREE_HAL_EXTERNAL_BUFFER_FLAG_NONE,
+        .size = allocation_size,
+        .handle.host_allocation.ptr = host_ptr,
+    };
+    status = iree_hal_allocator_import_buffer(
+        context->device_allocator, params, &external_buffer,
+        iree_hal_buffer_release_callback_null(), &buffer);
+  }
+
+  iree_hal_streaming_buffer_t* wrapper = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_buffer_wrap(
+        context, buffer,
+        (int)(IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+              IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE),
+        host_ptr, /*allocation_pool=*/NULL, context_ownership, &wrapper);
+  }
+  iree_hal_buffer_release(buffer);
+
+  if (iree_status_is_ok(status)) {
+    wrapper->owns_host_ptr = true;
+    wrapper->imported_host_allocation = false;
+    wrapper->host_register_flags = flags;
+    *out_buffer = wrapper;
+    host_ptr = NULL;
+  } else {
+    if (wrapper) {
+      hrx_buffer_table_remove(&context->buffer_table, wrapper->device_ptr);
+      iree_hal_streaming_buffer_free(wrapper);
+    }
+  }
+  iree_allocator_free_aligned(context->host_allocator, host_ptr);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 iree_status_t iree_hal_streaming_memory_allocate_host(
     iree_hal_streaming_context_t* context, iree_host_size_t size,
     iree_hal_streaming_host_register_flags_t flags,
     iree_hal_streaming_buffer_t** out_buffer) {
-  return iree_hal_streaming_memory_allocate_host_with_context_mode(
+  return iree_hal_streaming_memory_allocate_owned_host_import_with_context_mode(
       context, size, flags, IREE_HAL_BUFFER_USAGE_DEFAULT,
       /*min_alignment=*/64, IREE_HAL_STREAMING_BUFFER_CONTEXT_RETAINED,
+      out_buffer);
+}
+
+iree_status_t iree_hal_streaming_memory_allocate_host_staging(
+    iree_hal_streaming_context_t* context, iree_host_size_t size,
+    iree_hal_streaming_buffer_t** out_buffer) {
+  return iree_hal_streaming_memory_allocate_host_with_context_mode(
+      context, size, IREE_HAL_STREAMING_HOST_REGISTER_FLAG_DEFAULT,
+      IREE_HAL_BUFFER_USAGE_DEFAULT,
+      /*min_alignment=*/64, IREE_HAL_STREAMING_BUFFER_CONTEXT_RETAINED,
+      out_buffer);
+}
+
+iree_status_t iree_hal_streaming_memory_allocate_runtime_host(
+    iree_hal_streaming_context_t* context, iree_host_size_t size,
+    iree_hal_streaming_buffer_t** out_buffer) {
+  return iree_hal_streaming_memory_allocate_host_with_context_mode(
+      context, size, IREE_HAL_STREAMING_HOST_REGISTER_FLAG_DEFAULT,
+      IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE | IREE_HAL_BUFFER_USAGE_TRANSFER,
+      /*min_alignment=*/64, IREE_HAL_STREAMING_BUFFER_CONTEXT_RETAINED,
+      out_buffer);
+}
+
+iree_status_t iree_hal_streaming_memory_allocate_context_runtime_host(
+    iree_hal_streaming_context_t* context, iree_host_size_t size,
+    iree_hal_streaming_buffer_t** out_buffer) {
+  return iree_hal_streaming_memory_allocate_host_with_context_mode(
+      context, size, IREE_HAL_STREAMING_HOST_REGISTER_FLAG_DEFAULT,
+      IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE | IREE_HAL_BUFFER_USAGE_TRANSFER,
+      /*min_alignment=*/64, IREE_HAL_STREAMING_BUFFER_CONTEXT_BORROWED,
       out_buffer);
 }
 
@@ -1024,12 +1232,13 @@ iree_status_t iree_hal_streaming_memory_allocate_managed(
   const iree_host_size_t allocation_size = iree_max(size, (iree_host_size_t)8);
   iree_hal_streaming_buffer_t* buffer = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_streaming_memory_allocate_host_with_context_mode(
-              context, allocation_size,
-              (iree_hal_streaming_host_register_flags_t)allocation_flags,
-              IREE_HAL_BUFFER_USAGE_DEFAULT,
-              /*min_alignment=*/4096,
-              IREE_HAL_STREAMING_BUFFER_CONTEXT_RETAINED, &buffer));
+      z0,
+      iree_hal_streaming_memory_allocate_owned_host_import_with_context_mode(
+          context, allocation_size,
+          (iree_hal_streaming_host_register_flags_t)allocation_flags,
+          IREE_HAL_BUFFER_USAGE_DEFAULT,
+          /*min_alignment=*/4096, IREE_HAL_STREAMING_BUFFER_CONTEXT_RETAINED,
+          &buffer));
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
     buffer->is_managed = true;
@@ -1538,6 +1747,48 @@ static iree_status_t iree_hal_streaming_enqueue_buffer_copy(
   return status;
 }
 
+static iree_status_t iree_hal_streaming_enqueue_host_update(
+    iree_hal_streaming_stream_t* stream, const void* src,
+    iree_hal_streaming_buffer_ref_t dst_ref, iree_device_size_t size) {
+  IREE_ASSERT_ARGUMENT(stream);
+  IREE_ASSERT_ARGUMENT(src);
+  if (!dst_ref.buffer || !dst_ref.buffer->buffer) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "host update destination is not a device buffer");
+  }
+  iree_device_size_t range_end = 0;
+  if (IREE_UNLIKELY(
+          !iree_device_size_checked_add(dst_ref.offset, size, &range_end) ||
+          range_end > dst_ref.buffer->size)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "host update exceeds destination buffer range");
+  }
+
+  const uint8_t* src_ptr = (const uint8_t*)src;
+  iree_device_size_t remaining = size;
+  iree_device_size_t chunk_offset = 0;
+  iree_slim_mutex_lock(&stream->mutex);
+  iree_status_t status = iree_hal_streaming_stream_begin_locked(stream);
+  while (remaining > 0 && iree_status_is_ok(status)) {
+    const iree_device_size_t this_chunk =
+        remaining < IREE_HAL_COMMAND_BUFFER_MAX_UPDATE_SIZE
+            ? remaining
+            : IREE_HAL_COMMAND_BUFFER_MAX_UPDATE_SIZE;
+    const iree_hal_buffer_ref_t target_ref = iree_hal_make_buffer_ref(
+        dst_ref.buffer->buffer, dst_ref.offset + chunk_offset, this_chunk);
+    status = iree_hal_command_buffer_update_buffer(
+        stream->command_buffer, src_ptr + chunk_offset, 0, target_ref,
+        IREE_HAL_UPDATE_FLAG_NONE);
+    chunk_offset += this_chunk;
+    remaining -= this_chunk;
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_command_buffer_barrier(stream->command_buffer);
+  }
+  iree_slim_mutex_unlock(&stream->mutex);
+  return status;
+}
+
 //===----------------------------------------------------------------------===//
 // Memory copy helper functions
 //===----------------------------------------------------------------------===//
@@ -1615,6 +1866,7 @@ iree_status_t iree_hal_streaming_memcpy_host_to_device(
     return iree_ok_status();
   }
 
+  const iree_device_size_t staging_threshold = 256 * 1024;
   if (stream) {
     iree_hal_streaming_buffer_ref_t src_ref;
     iree_status_t src_status = iree_hal_streaming_memory_lookup(
@@ -1631,11 +1883,16 @@ iree_status_t iree_hal_streaming_memcpy_host_to_device(
       return queue_status;
     }
     iree_status_ignore(src_status);
+    if (size <= staging_threshold) {
+      iree_status_t queue_status =
+          iree_hal_streaming_enqueue_host_update(stream, src, dst_ref, size);
+      IREE_TRACE_ZONE_END(z0);
+      return queue_status;
+    }
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0, iree_hal_streaming_stream_synchronize(stream));
   }
 
-  const iree_device_size_t staging_threshold = 256 * 1024;
   if (size >= staging_threshold) {
     iree_hal_streaming_stream_t* copy_stream =
         stream ? stream : context->default_stream;
@@ -1681,17 +1938,20 @@ iree_status_t iree_hal_streaming_memcpy_host_to_device(
     const uint8_t* src_ptr = (const uint8_t*)src;
     iree_device_size_t remaining = size;
     iree_device_size_t chunk_offset = 0;
-    while (remaining > 0) {
+    iree_status_t direct_status = iree_ok_status();
+    iree_slim_mutex_lock(&context->direct_transfer_mutex);
+    while (remaining > 0 && iree_status_is_ok(direct_status)) {
       iree_device_size_t this_chunk =
           remaining < h2d_chunk_size ? remaining : h2d_chunk_size;
-      iree_status_t chunk_status = iree_hal_device_transfer_h2d(
+      direct_status = iree_hal_device_transfer_h2d(
           context->device, src_ptr + chunk_offset, dst_ref.buffer->buffer,
           dst_ref.offset + chunk_offset, this_chunk,
           IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout());
-      IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, chunk_status);
       chunk_offset += this_chunk;
       remaining -= this_chunk;
     }
+    iree_slim_mutex_unlock(&context->direct_transfer_mutex);
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, direct_status);
   }
 
   IREE_TRACE_ZONE_END(z0);
@@ -1783,8 +2043,11 @@ iree_status_t iree_hal_streaming_memcpy_device_to_host(
             IREE_STATUS_INVALID_ARGUMENT,
             "device-to-host destination is not host memory");
       }
-      iree_status_t queue_status = iree_hal_streaming_enqueue_buffer_copy(
-          stream, src_ref, dst_ref, size);
+      iree_status_t queue_status =
+          dst_ref.buffer->buffer ? iree_hal_streaming_enqueue_buffer_copy(
+                                       stream, src_ref, dst_ref, size)
+                                 : iree_hal_streaming_enqueue_d2h_transfer(
+                                       context, stream, src_ref, dst, size);
       IREE_TRACE_ZONE_END(z0);
       return queue_status;
     }
@@ -1798,6 +2061,7 @@ iree_status_t iree_hal_streaming_memcpy_device_to_host(
   iree_device_size_t remaining = size;
   iree_device_size_t chunk_offset = 0;
   iree_status_t direct_status = iree_ok_status();
+  iree_slim_mutex_lock(&context->direct_transfer_mutex);
   while (remaining > 0 && iree_status_is_ok(direct_status)) {
     iree_device_size_t this_chunk =
         remaining < d2h_chunk_size ? remaining : d2h_chunk_size;
@@ -1808,6 +2072,7 @@ iree_status_t iree_hal_streaming_memcpy_device_to_host(
     chunk_offset += this_chunk;
     remaining -= this_chunk;
   }
+  iree_slim_mutex_unlock(&context->direct_transfer_mutex);
   if (iree_status_is_ok(direct_status)) {
     IREE_TRACE_ZONE_END(z0);
     return iree_ok_status();

--- a/libhrx/src/binding/common/module.c
+++ b/libhrx/src/binding/common/module.c
@@ -204,7 +204,15 @@ static iree_status_t iree_hal_streaming_module_extract_metadata(
     iree_hal_executable_t* executable =
         module->executables ? module->executables[executable_ordinal]
                             : module->executable;
-    module->symbol_count += iree_hal_executable_export_count(executable);
+    iree_host_size_t new_symbol_count = 0;
+    if (IREE_UNLIKELY(!iree_host_size_checked_add(
+            module->symbol_count, iree_hal_executable_export_count(executable),
+            &new_symbol_count))) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                              "module symbol count overflow");
+    }
+    module->symbol_count = new_symbol_count;
   }
   if (module->symbol_count == 0) {
     IREE_TRACE_ZONE_END(z0);
@@ -220,23 +228,39 @@ static iree_status_t iree_hal_streaming_module_extract_metadata(
     uint16_t copy_count;
     uint16_t resolve_count;
   } op_counts_t;
-  const iree_host_size_t export_infos_size =
-      module->symbol_count * sizeof(iree_hal_executable_export_info_t);
-  const iree_host_size_t export_executables_size =
-      module->symbol_count * sizeof(iree_hal_executable_t*);
-  const iree_host_size_t export_ordinals_size =
-      module->symbol_count * sizeof(iree_hal_executable_export_ordinal_t);
-  const iree_host_size_t op_counts_size =
-      module->symbol_count * sizeof(op_counts_t);
+  iree_host_size_t export_infos_size = 0;
+  iree_host_size_t export_executables_size = 0;
+  iree_host_size_t export_ordinals_size = 0;
+  iree_host_size_t op_counts_size = 0;
+  iree_host_size_t total_temp_size = 0;
+  if (IREE_UNLIKELY(
+          !iree_host_size_checked_mul(module->symbol_count,
+                                      sizeof(iree_hal_executable_export_info_t),
+                                      &export_infos_size) ||
+          !iree_host_size_checked_mul(module->symbol_count,
+                                      sizeof(iree_hal_executable_t*),
+                                      &export_executables_size) ||
+          !iree_host_size_checked_mul(
+              module->symbol_count,
+              sizeof(iree_hal_executable_export_ordinal_t),
+              &export_ordinals_size) ||
+          !iree_host_size_checked_mul(module->symbol_count, sizeof(op_counts_t),
+                                      &op_counts_size) ||
+          !iree_host_size_checked_add(
+              export_infos_size, export_executables_size, &total_temp_size) ||
+          !iree_host_size_checked_add(total_temp_size, export_ordinals_size,
+                                      &total_temp_size) ||
+          !iree_host_size_checked_add(total_temp_size, op_counts_size,
+                                      &total_temp_size))) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "module export metadata size overflow");
+  }
   uint8_t* temp_buffer = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_allocator_malloc(module->host_allocator,
-                                export_infos_size + export_executables_size +
-                                    export_ordinals_size + op_counts_size,
+      z0, iree_allocator_malloc(module->host_allocator, total_temp_size,
                                 (void**)&temp_buffer));
-  memset(temp_buffer, 0,
-         export_infos_size + export_executables_size + export_ordinals_size +
-             op_counts_size);
+  memset(temp_buffer, 0, total_temp_size);
   iree_hal_executable_export_info_t* export_infos =
       (iree_hal_executable_export_info_t*)temp_buffer;
   iree_hal_executable_t** export_executables =
@@ -269,7 +293,13 @@ static iree_status_t iree_hal_streaming_module_extract_metadata(
                                                export_ordinals[symbol_index],
                                                &export_infos[symbol_index]);
       if (!iree_status_is_ok(status)) break;
-      total_parameter_count += export_infos[symbol_index].parameter_count;
+      if (IREE_UNLIKELY(!iree_host_size_checked_add(
+              total_parameter_count, export_infos[symbol_index].parameter_count,
+              &total_parameter_count))) {
+        status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                  "module parameter count overflow");
+        break;
+      }
       ++symbol_index;
     }
   }
@@ -277,9 +307,15 @@ static iree_status_t iree_hal_streaming_module_extract_metadata(
   // Allocate the scratch space for querying parameter info.
   iree_hal_executable_export_parameter_t* parameters = NULL;
   if (iree_status_is_ok(status) && total_parameter_count > 0) {
-    status = iree_allocator_malloc(module->host_allocator,
-                                   total_parameter_count * sizeof(*parameters),
-                                   (void**)&parameters);
+    iree_host_size_t parameters_size = 0;
+    if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+            total_parameter_count, sizeof(*parameters), &parameters_size))) {
+      status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                "module parameter metadata size overflow");
+    } else {
+      status = iree_allocator_malloc(module->host_allocator, parameters_size,
+                                     (void**)&parameters);
+    }
   }
 
   // Analyze each export to determine operation counts.
@@ -311,19 +347,32 @@ static iree_status_t iree_hal_streaming_module_extract_metadata(
 
   // Allocate all permanent storage in a single block.
   // Memory layout: [Symbol Array][Symbol0 ops][Symbol1 ops]...
-  const iree_host_size_t symbols_size =
-      module->symbol_count * sizeof(iree_hal_streaming_symbol_t);
-  const iree_host_size_t ops_size =
-      total_ops * sizeof(iree_hal_streaming_parameter_op_t);
-  const iree_host_size_t total_size = symbols_size + ops_size;
+  iree_host_size_t symbols_size = 0;
+  iree_host_size_t ops_size = 0;
+  iree_host_size_t total_size = 0;
+  if (iree_status_is_ok(status) &&
+      IREE_UNLIKELY(
+          !iree_host_size_checked_mul(module->symbol_count,
+                                      sizeof(iree_hal_streaming_symbol_t),
+                                      &symbols_size) ||
+          !iree_host_size_checked_mul(total_ops,
+                                      sizeof(iree_hal_streaming_parameter_op_t),
+                                      &ops_size) ||
+          !iree_host_size_checked_add(symbols_size, ops_size, &total_size))) {
+    status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                              "module symbol storage size overflow");
+  }
   uint8_t* buffer = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_allocator_malloc(module->host_allocator, total_size,
                                    (void**)&buffer);
   }
-  module->symbols = (iree_hal_streaming_symbol_t*)buffer;
-  iree_hal_streaming_parameter_op_t* ops_base =
-      (iree_hal_streaming_parameter_op_t*)(buffer + symbols_size);
+  iree_hal_streaming_parameter_op_t* ops_base = NULL;
+  if (iree_status_is_ok(status)) {
+    memset(buffer, 0, total_size);
+    module->symbols = (iree_hal_streaming_symbol_t*)buffer;
+    ops_base = (iree_hal_streaming_parameter_op_t*)(buffer + symbols_size);
+  }
 
   iree_hal_streaming_parameter_op_t* current_ops = ops_base;
   for (iree_host_size_t i = 0, parameter_base = 0;
@@ -336,14 +385,28 @@ static iree_status_t iree_hal_streaming_module_extract_metadata(
     symbol->executable = export_executables[i];
     symbol->export_ordinal = export_ordinals[i];
 
-    // Function attributes - TODO: Query from export metadata when available.
-    // TODO(benvanik): populate from occupancy_info when available.
+    // Function attributes are sourced from executable metadata when present and
+    // fall back to conservative device-level defaults otherwise.
     symbol->occupancy_info = export_infos[i].occupancy_info;
-    symbol->max_threads_per_block = 1024;       // TODO: from metadata.
-    symbol->shared_size_bytes = 0;              // TODO: from metadata.
-    symbol->local_size_bytes = 0;               // TODO: from metadata.
-    symbol->num_regs = 32;                      // TODO: from metadata.
-    symbol->max_dynamic_shared_size_bytes = 0;  // TODO: from metadata.
+    symbol->max_threads_per_block = export_infos[i].max_workgroup_size;
+    if (symbol->max_threads_per_block == 0 && module->context &&
+        module->context->device_entry) {
+      symbol->max_threads_per_block =
+          module->context->device_entry->max_threads_per_block;
+    }
+    if (symbol->max_threads_per_block == 0) {
+      symbol->max_threads_per_block = 1024;
+    }
+    symbol->shared_size_bytes = export_infos[i].workgroup_local_memory_size;
+    symbol->local_size_bytes = export_infos[i].private_memory_size;
+    // Register usage is not currently exposed by the executable metadata.
+    symbol->num_regs = 0;
+    symbol->max_dynamic_shared_size_bytes = 0;
+    symbol->preferred_shared_memory_carveout = 0;
+    symbol->cache_mode_ca = 0;
+    symbol->uniform_workgroup_size = iree_any_bit_set(
+        export_infos[i].flags,
+        IREE_HAL_EXECUTABLE_FUNCTION_FLAG_UNIFORM_WORKGROUP_SIZE);
 
     // Initialize parameter info.
     iree_hal_streaming_parameter_info_t* parameter_info = &symbol->parameters;

--- a/libhrx/src/binding/common/module.c
+++ b/libhrx/src/binding/common/module.c
@@ -9,7 +9,109 @@
 
 #include "common/fat_binary.h"
 #include "common/internal.h"
+#include "iree/hal/buffer_transfer.h"
 #include "iree/io/file_handle.h"
+
+//===----------------------------------------------------------------------===//
+// AMDGPU ELF symbol scanning
+//===----------------------------------------------------------------------===//
+
+#define HRX_MODULE_ELF_MAGIC_INT 0x464c457fu  // 0x7f 'E' 'L' 'F'
+#define HRX_MODULE_ELFCLASS64 2
+#define HRX_MODULE_ELFDATA2LSB 1
+#define HRX_MODULE_SHT_SYMTAB 2
+#define HRX_MODULE_SHT_DYNSYM 11
+#define HRX_MODULE_STB_GLOBAL 1
+#define HRX_MODULE_STB_WEAK 2
+#define HRX_MODULE_STT_OBJECT 1
+#define HRX_MODULE_SHN_UNDEF 0
+
+typedef struct hrx_module_elf64_header_t {
+  // ELF ident bytes.
+  uint8_t magic[4];
+  // ELF class; HRX only accepts ELFCLASS64 here.
+  uint8_t elf_class;
+  // ELF data encoding; HRX only accepts little-endian here.
+  uint8_t elf_data;
+  // ELF ident version byte.
+  uint8_t elf_version;
+  // ELF OS ABI byte.
+  uint8_t osabi;
+  // ELF ABI version byte.
+  uint8_t abiversion;
+  // Remaining ELF ident padding.
+  uint8_t padding[7];
+  // ELF object type.
+  uint16_t type;
+  // ELF target machine.
+  uint16_t machine;
+  // ELF object version.
+  uint32_t version;
+  // Entry point address.
+  uint64_t entry;
+  // Program header table file offset.
+  uint64_t phoff;
+  // Section header table file offset.
+  uint64_t shoff;
+  // Target-specific ELF flags.
+  uint32_t flags;
+  // ELF header byte size.
+  uint16_t ehsize;
+  // Program header entry byte size.
+  uint16_t phentsize;
+  // Program header entry count.
+  uint16_t phnum;
+  // Section header entry byte size.
+  uint16_t shentsize;
+  // Section header entry count.
+  uint16_t shnum;
+  // Section-name string table section index.
+  uint16_t shstrndx;
+} hrx_module_elf64_header_t;
+static_assert(sizeof(hrx_module_elf64_header_t) == 64,
+              "ELF64 header must be 64 bytes");
+
+typedef struct hrx_module_elf64_section_header_t {
+  // Section name string-table offset.
+  uint32_t name;
+  // Section type.
+  uint32_t type;
+  // Section flags.
+  uint64_t flags;
+  // Section virtual address.
+  uint64_t address;
+  // Section file offset.
+  uint64_t offset;
+  // Section byte length.
+  uint64_t size;
+  // Section-specific linked section index.
+  uint32_t link;
+  // Section-specific extra info.
+  uint32_t info;
+  // Section alignment.
+  uint64_t address_alignment;
+  // Entry byte size for table sections.
+  uint64_t entry_size;
+} hrx_module_elf64_section_header_t;
+static_assert(sizeof(hrx_module_elf64_section_header_t) == 64,
+              "ELF64 section header must be 64 bytes");
+
+typedef struct hrx_module_elf64_symbol_t {
+  // Symbol name string-table offset.
+  uint32_t name;
+  // Symbol binding/type byte.
+  uint8_t info;
+  // Symbol visibility byte.
+  uint8_t other;
+  // Defining section index.
+  uint16_t section_index;
+  // Symbol value.
+  uint64_t value;
+  // Symbol byte size.
+  uint64_t size;
+} hrx_module_elf64_symbol_t;
+static_assert(sizeof(hrx_module_elf64_symbol_t) == 24,
+              "ELF64 symbol must be 24 bytes");
 
 //===----------------------------------------------------------------------===//
 // Module management
@@ -415,6 +517,9 @@ static iree_status_t iree_hal_streaming_module_extract_metadata(
 
 static void iree_hal_streaming_module_destroy(
     iree_hal_streaming_module_t* module);
+static iree_status_t iree_hal_streaming_module_initialize_managed_globals(
+    iree_hal_streaming_module_t* module,
+    const iree_hal_streaming_fat_binary_extract_t* fat_extract);
 
 static iree_status_t iree_hal_streaming_module_load_executable(
     iree_hal_streaming_context_t* context,
@@ -511,7 +616,17 @@ iree_status_t iree_hal_streaming_module_create_from_memory(
     status = iree_hal_streaming_module_extract_metadata(module);
   }
 
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_module_initialize_runtime_metadata(module);
+  }
+
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_module_initialize_managed_globals(module,
+                                                                  &fat_extract);
+  }
+
   iree_hal_streaming_fat_binary_extract_reset(&fat_extract);
+
   if (iree_status_is_ok(status)) {
     *out_module = module;
   } else {
@@ -572,6 +687,7 @@ static void iree_hal_streaming_module_destroy(
 
   // Release symbol metadata.
   iree_allocator_free(module->host_allocator, module->symbols);
+  iree_allocator_free(module->host_allocator, module->printf_formats);
 
   // Release cached executable globals while both the context pointer map and
   // executable-owned global buffers are still live.
@@ -675,6 +791,20 @@ iree_hal_streaming_module_find_global_locked(
   return NULL;
 }
 
+static iree_hal_streaming_symbol_t*
+iree_hal_streaming_module_find_global_for_executable_locked(
+    iree_hal_streaming_module_t* module, iree_hal_executable_t* executable,
+    iree_string_view_t name) {
+  for (iree_host_size_t i = 0; i < module->global_count; ++i) {
+    iree_hal_streaming_symbol_t* symbol = module->globals[i];
+    if (symbol->executable == executable &&
+        iree_hal_streaming_module_symbol_name_matches(symbol->name, name)) {
+      return symbol;
+    }
+  }
+  return NULL;
+}
+
 static iree_status_t iree_hal_streaming_module_grow_globals_locked(
     iree_hal_streaming_module_t* module, iree_host_size_t minimum_capacity) {
   if (minimum_capacity <= module->global_capacity) return iree_ok_status();
@@ -736,6 +866,44 @@ static iree_status_t iree_hal_streaming_module_create_global_symbol_locked(
     iree_allocator_free(module->host_allocator, symbol);
     iree_hal_streaming_memory_release_wrapped_buffer(streaming_buffer);
   }
+  return status;
+}
+
+static iree_status_t
+iree_hal_streaming_module_try_lookup_global_symbol_for_executable(
+    iree_hal_streaming_module_t* module, iree_hal_executable_t* executable,
+    iree_string_view_t name, bool* out_found,
+    iree_hal_streaming_symbol_t** out_global) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_ASSERT_ARGUMENT(executable);
+  IREE_ASSERT_ARGUMENT(out_found);
+  IREE_ASSERT_ARGUMENT(out_global);
+  *out_found = false;
+  *out_global = NULL;
+
+  iree_status_t status = iree_ok_status();
+  iree_slim_mutex_lock(&module->global_mutex);
+
+  iree_hal_streaming_symbol_t* cached_symbol =
+      iree_hal_streaming_module_find_global_for_executable_locked(
+          module, executable, name);
+  if (cached_symbol) {
+    *out_found = true;
+    *out_global = cached_symbol;
+  } else {
+    iree_hal_executable_global_t global_handle =
+        iree_hal_executable_global_invalid();
+    bool found = false;
+    status = iree_hal_executable_try_lookup_global_by_name(
+        executable, name, &found, &global_handle);
+    if (iree_status_is_ok(status) && found) {
+      status = iree_hal_streaming_module_create_global_symbol_locked(
+          module, executable, global_handle, out_global);
+      if (iree_status_is_ok(status)) *out_found = true;
+    }
+  }
+
+  iree_slim_mutex_unlock(&module->global_mutex);
   return status;
 }
 
@@ -818,6 +986,311 @@ iree_status_t iree_hal_streaming_module_global_symbol(
                           (int)name_view.size, name_view.data);
 }
 
+static iree_status_t iree_hal_streaming_module_managed_device_name(
+    iree_hal_streaming_module_t* module, const char* device_name,
+    char** out_managed_device_name) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_ASSERT_ARGUMENT(device_name);
+  IREE_ASSERT_ARGUMENT(out_managed_device_name);
+  *out_managed_device_name = NULL;
+
+  static const char suffix[] = ".managed";
+  const iree_host_size_t name_length = (iree_host_size_t)strlen(device_name);
+  iree_host_size_t name_size = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_add(name_length, sizeof(suffix),
+                                                &name_size))) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "managed symbol name size overflow");
+  }
+
+  char* managed_device_name = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(module->host_allocator, name_size,
+                                             (void**)&managed_device_name));
+  memcpy(managed_device_name, device_name, name_length);
+  memcpy(managed_device_name + name_length, suffix, sizeof(suffix));
+  *out_managed_device_name = managed_device_name;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_module_initialize_managed_pointer(
+    iree_hal_streaming_module_t* module,
+    iree_hal_streaming_symbol_t* pointer_symbol,
+    iree_hal_streaming_symbol_t* storage_symbol, const char* device_name) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_ASSERT_ARGUMENT(pointer_symbol);
+  IREE_ASSERT_ARGUMENT(storage_symbol);
+  IREE_ASSERT_ARGUMENT(device_name);
+
+  if (!pointer_symbol->global_buffer ||
+      !pointer_symbol->global_buffer->buffer) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "managed pointer `%s` has no HAL buffer",
+                            device_name);
+  }
+  if (pointer_symbol->size_bytes < sizeof(storage_symbol->device_address)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "managed pointer `%s` is too small (%" PRIu64
+                            " bytes)",
+                            device_name, (uint64_t)pointer_symbol->size_bytes);
+  }
+
+  const iree_hal_streaming_deviceptr_t storage_device_address =
+      storage_symbol->device_address;
+  return iree_hal_device_transfer_h2d(
+      module->context->device, &storage_device_address,
+      pointer_symbol->global_buffer->buffer, /*target_offset=*/0,
+      sizeof(storage_device_address), IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT,
+      iree_infinite_timeout());
+}
+
+static iree_status_t iree_hal_streaming_module_elf_subspan(
+    iree_const_byte_span_t elf, uint64_t offset64, uint64_t size64,
+    const char* kind, iree_const_byte_span_t* out_span) {
+  IREE_ASSERT_ARGUMENT(kind);
+  IREE_ASSERT_ARGUMENT(out_span);
+  memset(out_span, 0, sizeof(*out_span));
+
+  if (offset64 > IREE_HOST_SIZE_MAX || size64 > IREE_HOST_SIZE_MAX) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "ELF %s range is too large", kind);
+  }
+  const iree_host_size_t offset = (iree_host_size_t)offset64;
+  const iree_host_size_t size = (iree_host_size_t)size64;
+  if (offset > elf.data_length || size > elf.data_length - offset) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "ELF %s range is out of bounds", kind);
+  }
+  *out_span = iree_make_const_byte_span(elf.data + offset, size);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_module_elf_cstring_view(
+    iree_const_byte_span_t string_table, uint32_t offset,
+    iree_string_view_t* out_string) {
+  IREE_ASSERT_ARGUMENT(out_string);
+  *out_string = iree_string_view_empty();
+
+  if (offset >= string_table.data_length) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "ELF string-table offset is out of bounds");
+  }
+  const char* data = (const char*)string_table.data + offset;
+  const iree_host_size_t capacity = string_table.data_length - offset;
+  for (iree_host_size_t i = 0; i < capacity; ++i) {
+    if (data[i] == '\0') {
+      *out_string = iree_make_string_view(data, i);
+      return iree_ok_status();
+    }
+  }
+  return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                          "ELF string-table entry is unterminated");
+}
+
+static bool iree_hal_streaming_module_split_managed_name(
+    iree_string_view_t name, iree_string_view_t* out_base_name) {
+  IREE_ASSERT_ARGUMENT(out_base_name);
+  *out_base_name = iree_string_view_empty();
+
+  static const iree_string_view_t suffix = IREE_SVL(".managed");
+  if (!iree_string_view_ends_with(name, suffix) || name.size == suffix.size) {
+    return false;
+  }
+  *out_base_name = iree_make_string_view(name.data, name.size - suffix.size);
+  return true;
+}
+
+static iree_status_t iree_hal_streaming_module_copy_cstring(
+    iree_hal_streaming_module_t* module, iree_string_view_t value,
+    char** out_string) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_ASSERT_ARGUMENT(out_string);
+  *out_string = NULL;
+
+  iree_host_size_t size = 0;
+  if (!iree_host_size_checked_add(value.size, 1, &size)) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "managed symbol name size overflow");
+  }
+
+  char* string = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(module->host_allocator, size, (void**)&string));
+  memcpy(string, value.data, value.size);
+  string[value.size] = '\0';
+  *out_string = string;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_module_initialize_managed_symbol_pair(
+    iree_hal_streaming_module_t* module, iree_hal_executable_t* executable,
+    iree_string_view_t pointer_name, iree_string_view_t storage_name) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_ASSERT_ARGUMENT(executable);
+
+  bool pointer_found = false;
+  iree_hal_streaming_symbol_t* pointer_symbol = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_streaming_module_try_lookup_global_symbol_for_executable(
+          module, executable, pointer_name, &pointer_found, &pointer_symbol));
+  if (!pointer_found || !pointer_symbol) return iree_ok_status();
+
+  bool storage_found = false;
+  iree_hal_streaming_symbol_t* storage_symbol = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_streaming_module_try_lookup_global_symbol_for_executable(
+          module, executable, storage_name, &storage_found, &storage_symbol));
+  if (!storage_found || !storage_symbol) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "managed storage `%.*s` was declared but not "
+                            "resolved by the executable",
+                            (int)storage_name.size, storage_name.data);
+  }
+
+  char* pointer_name_string = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_streaming_module_copy_cstring(
+      module, pointer_name, &pointer_name_string));
+  iree_status_t status = iree_hal_streaming_module_initialize_managed_pointer(
+      module, pointer_symbol, storage_symbol, pointer_name_string);
+  iree_allocator_free(module->host_allocator, pointer_name_string);
+  return status;
+}
+
+static iree_status_t
+iree_hal_streaming_module_initialize_managed_globals_from_elf(
+    iree_hal_streaming_module_t* module, iree_hal_executable_t* executable,
+    iree_const_byte_span_t elf) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_ASSERT_ARGUMENT(executable);
+
+  if (elf.data_length < sizeof(hrx_module_elf64_header_t)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "ELF data too small for managed-symbol scan");
+  }
+
+  hrx_module_elf64_header_t header;
+  memcpy(&header, elf.data, sizeof(header));
+  uint32_t magic = 0;
+  memcpy(&magic, header.magic, sizeof(magic));
+  if (magic != HRX_MODULE_ELF_MAGIC_INT ||
+      header.elf_class != HRX_MODULE_ELFCLASS64 ||
+      header.elf_data != HRX_MODULE_ELFDATA2LSB) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "unsupported ELF for managed-symbol scan");
+  }
+  if (header.shentsize != sizeof(hrx_module_elf64_section_header_t)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "unexpected ELF section-header size for managed-symbol scan");
+  }
+
+  iree_host_size_t section_headers_size = 0;
+  if (!iree_host_size_checked_mul((iree_host_size_t)header.shentsize,
+                                  (iree_host_size_t)header.shnum,
+                                  &section_headers_size)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "ELF section-header table size overflow");
+  }
+
+  iree_const_byte_span_t section_headers_span;
+  IREE_RETURN_IF_ERROR(iree_hal_streaming_module_elf_subspan(
+      elf, header.shoff, section_headers_size, "section-header table",
+      &section_headers_span));
+  const hrx_module_elf64_section_header_t* section_headers =
+      (const hrx_module_elf64_section_header_t*)section_headers_span.data;
+
+  for (uint16_t section_index = 0; section_index < header.shnum;
+       ++section_index) {
+    const hrx_module_elf64_section_header_t* symbol_table =
+        &section_headers[section_index];
+    if (symbol_table->type != HRX_MODULE_SHT_SYMTAB &&
+        symbol_table->type != HRX_MODULE_SHT_DYNSYM) {
+      continue;
+    }
+    if (symbol_table->entry_size != sizeof(hrx_module_elf64_symbol_t)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "unexpected ELF symbol-table entry size for managed-symbol scan");
+    }
+    if (symbol_table->size % symbol_table->entry_size != 0) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "ELF symbol-table size is not a multiple of entry size");
+    }
+    if (symbol_table->link >= header.shnum) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "ELF symbol-table string-table link is invalid");
+    }
+
+    iree_const_byte_span_t symbol_table_span;
+    IREE_RETURN_IF_ERROR(iree_hal_streaming_module_elf_subspan(
+        elf, symbol_table->offset, symbol_table->size, "symbol table",
+        &symbol_table_span));
+    const hrx_module_elf64_symbol_t* symbols =
+        (const hrx_module_elf64_symbol_t*)symbol_table_span.data;
+
+    const hrx_module_elf64_section_header_t* string_table =
+        &section_headers[symbol_table->link];
+    iree_const_byte_span_t string_table_span;
+    IREE_RETURN_IF_ERROR(iree_hal_streaming_module_elf_subspan(
+        elf, string_table->offset, string_table->size, "string table",
+        &string_table_span));
+
+    const iree_host_size_t symbol_count =
+        (iree_host_size_t)(symbol_table->size / symbol_table->entry_size);
+    for (iree_host_size_t i = 0; i < symbol_count; ++i) {
+      const hrx_module_elf64_symbol_t* symbol = &symbols[i];
+      const uint8_t binding = symbol->info >> 4;
+      const uint8_t type = symbol->info & 0x0F;
+      if ((binding != HRX_MODULE_STB_GLOBAL &&
+           binding != HRX_MODULE_STB_WEAK) ||
+          type != HRX_MODULE_STT_OBJECT ||
+          symbol->section_index == HRX_MODULE_SHN_UNDEF) {
+        continue;
+      }
+
+      iree_string_view_t storage_name = iree_string_view_empty();
+      IREE_RETURN_IF_ERROR(iree_hal_streaming_module_elf_cstring_view(
+          string_table_span, symbol->name, &storage_name));
+      iree_string_view_t pointer_name = iree_string_view_empty();
+      if (!iree_hal_streaming_module_split_managed_name(storage_name,
+                                                        &pointer_name)) {
+        continue;
+      }
+
+      IREE_RETURN_IF_ERROR(
+          iree_hal_streaming_module_initialize_managed_symbol_pair(
+              module, executable, pointer_name, storage_name));
+    }
+  }
+
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_module_initialize_managed_globals(
+    iree_hal_streaming_module_t* module,
+    const iree_hal_streaming_fat_binary_extract_t* fat_extract) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_ASSERT_ARGUMENT(fat_extract);
+
+  if (fat_extract->match_count == 0) return iree_ok_status();
+  if (module->executables &&
+      module->executable_count != fat_extract->match_count) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "module executable count does not match extracted ELF count");
+  }
+
+  for (iree_host_size_t i = 0; i < fat_extract->match_count; ++i) {
+    iree_hal_executable_t* executable =
+        module->executables ? module->executables[i] : module->executable;
+    IREE_RETURN_IF_ERROR(
+        iree_hal_streaming_module_initialize_managed_globals_from_elf(
+            module, executable, fat_extract->matches[i].data));
+  }
+
+  return iree_ok_status();
+}
+
 iree_status_t iree_hal_streaming_module_global(
     iree_hal_streaming_module_t* module, const char* name,
     iree_hal_streaming_deviceptr_t* out_device_ptr,
@@ -828,9 +1301,36 @@ iree_status_t iree_hal_streaming_module_global(
   *out_device_ptr = 0;
   if (out_size) *out_size = 0;
 
+  bool found = false;
   iree_hal_streaming_symbol_t* symbol = NULL;
-  IREE_RETURN_IF_ERROR(
-      iree_hal_streaming_module_global_symbol(module, name, &symbol));
+  IREE_RETURN_IF_ERROR(iree_hal_streaming_module_try_lookup_global_symbol(
+      module, name, &found, &symbol));
+
+  char* managed_device_name = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_streaming_module_managed_device_name(
+      module, name, &managed_device_name));
+  bool managed_found = false;
+  iree_hal_streaming_symbol_t* managed_symbol = NULL;
+  iree_status_t status = iree_hal_streaming_module_try_lookup_global_symbol(
+      module, managed_device_name, &managed_found, &managed_symbol);
+  iree_allocator_free(module->host_allocator, managed_device_name);
+  IREE_RETURN_IF_ERROR(status);
+
+  if (managed_found && managed_symbol) {
+    if (found && symbol) {
+      IREE_RETURN_IF_ERROR(iree_hal_streaming_module_initialize_managed_pointer(
+          module, symbol, managed_symbol, name));
+    }
+    symbol = managed_symbol;
+    found = true;
+  }
+  if (!found || !symbol) {
+    iree_string_view_t name_view =
+        iree_string_view_trim(iree_make_cstring_view(name));
+    return iree_make_status(IREE_STATUS_NOT_FOUND,
+                            "global '%.*s' not found in module",
+                            (int)name_view.size, name_view.data);
+  }
 
   *out_device_ptr = symbol->device_address;
   if (out_size) *out_size = symbol->size_bytes;

--- a/libhrx/src/binding/common/module_runtime_metadata.c
+++ b/libhrx/src/binding/common/module_runtime_metadata.c
@@ -1,0 +1,992 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <wchar.h>
+
+#include "common/internal.h"
+#include "common/printf_format.h"
+
+#define IREE_HAL_STREAMING_PRINTF_BUFFER_HEADER_SIZE (2 * sizeof(uint32_t))
+#define IREE_HAL_STREAMING_PRINTF_RECORD_FLAG_STDERR 1u
+#define IREE_HAL_STREAMING_PRINTF_RECORD_FLAG_CONSTANT_FORMAT 2u
+
+//===----------------------------------------------------------------------===//
+// Runtime Parameter Slots
+//===----------------------------------------------------------------------===//
+
+static iree_status_t iree_hal_streaming_module_set_runtime_service_slot(
+    iree_string_view_t name,
+    iree_hal_executable_function_runtime_parameter_info_t parameter_info,
+    iree_hal_streaming_runtime_parameter_slot_t* out_slot) {
+  if (parameter_info.length != sizeof(uint64_t)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "runtime parameter `%.*s` has unsupported size %" PRIu32,
+        (int)name.size, name.data, parameter_info.length);
+  }
+  if (IREE_UNLIKELY(out_slot->present)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "runtime parameter `%.*s` is declared more than "
+                            "once",
+                            (int)name.size, name.data);
+  }
+
+  *out_slot = (iree_hal_streaming_runtime_parameter_slot_t){
+      .offset = parameter_info.offset,
+      .length = parameter_info.length,
+      .present = true,
+  };
+  return iree_ok_status();
+}
+
+static uint16_t iree_hal_streaming_implicit_runtime_parameter_length(
+    iree_string_view_t name) {
+  // The backend initializes the complete implicit launch block, including
+  // fields a given kernel does not read. Streaming only supplies the runtime
+  // services that are external to that block.
+  if (iree_string_view_equal(name, IREE_SV("hidden_block_count_x")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_block_count_y")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_block_count_z")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_dynamic_lds_size")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_private_base")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_shared_base"))) {
+    return sizeof(uint32_t);
+  }
+  if (iree_string_view_equal(name, IREE_SV("hidden_group_size_x")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_group_size_y")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_group_size_z")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_remainder_x")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_remainder_y")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_remainder_z")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_grid_dims"))) {
+    return sizeof(uint16_t);
+  }
+  if (iree_string_view_equal(name, IREE_SV("hidden_tool_correlation_id")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_global_offset_x")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_global_offset_y")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_global_offset_z")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_multigrid_sync_arg")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_default_queue")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_completion_action")) ||
+      iree_string_view_equal(name, IREE_SV("hidden_queue_ptr"))) {
+    return sizeof(uint64_t);
+  }
+  return 0;
+}
+
+static iree_status_t iree_hal_streaming_module_initialize_runtime_parameter(
+    iree_hal_streaming_symbol_t* symbol,
+    iree_hal_executable_function_runtime_parameter_info_t parameter_info) {
+  const iree_string_view_t name = parameter_info.name;
+  if (iree_string_view_equal(name, IREE_SV("hidden_printf_buffer"))) {
+    return iree_hal_streaming_module_set_runtime_service_slot(
+        name, parameter_info, &symbol->runtime_services.printf_buffer);
+  }
+  if (iree_string_view_equal(name, IREE_SV("hidden_hostcall_buffer"))) {
+    return iree_hal_streaming_module_set_runtime_service_slot(
+        name, parameter_info, &symbol->runtime_services.hostcall_buffer);
+  }
+  if (iree_string_view_equal(name, IREE_SV("hidden_heap_v1"))) {
+    return iree_hal_streaming_module_set_runtime_service_slot(
+        name, parameter_info, &symbol->runtime_services.heap_v1);
+  }
+  const uint16_t implicit_parameter_length =
+      iree_hal_streaming_implicit_runtime_parameter_length(name);
+  if (implicit_parameter_length != 0) {
+    if (parameter_info.length != implicit_parameter_length) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "implicit runtime parameter `%.*s` has size "
+                              "%" PRIu32 "; expected %" PRIu16,
+                              (int)name.size, name.data, parameter_info.length,
+                              implicit_parameter_length);
+    }
+    return iree_ok_status();
+  }
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "runtime parameter `%.*s` has no streaming provider",
+                          (int)name.size, name.data);
+}
+
+static iree_status_t iree_hal_streaming_module_validate_runtime_service_slots(
+    const iree_hal_streaming_symbol_t* symbol) {
+  typedef struct iree_hal_streaming_runtime_service_slot_info_t {
+    // Runtime parameter name for diagnostics.
+    iree_string_view_t name;
+    // Slot populated by the runtime service.
+    const iree_hal_streaming_runtime_parameter_slot_t* slot;
+  } iree_hal_streaming_runtime_service_slot_info_t;
+  const iree_hal_streaming_runtime_service_slot_info_t slots[] = {
+      {
+          .name = IREE_SV("hidden_printf_buffer"),
+          .slot = &symbol->runtime_services.printf_buffer,
+      },
+      {
+          .name = IREE_SV("hidden_hostcall_buffer"),
+          .slot = &symbol->runtime_services.hostcall_buffer,
+      },
+      {
+          .name = IREE_SV("hidden_heap_v1"),
+          .slot = &symbol->runtime_services.heap_v1,
+      },
+  };
+  iree_host_size_t present_count = 0;
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(slots); ++i) {
+    if (!slots[i].slot->present) continue;
+    ++present_count;
+    const uint64_t slot_begin = slots[i].slot->offset;
+    const uint64_t slot_end = slot_begin + slots[i].slot->length;
+    for (iree_host_size_t j = 0; j < i; ++j) {
+      if (!slots[j].slot->present) continue;
+      const uint64_t prior_begin = slots[j].slot->offset;
+      const uint64_t prior_end = prior_begin + slots[j].slot->length;
+      if (prior_begin < slot_end && slot_begin < prior_end) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "runtime parameters `%.*s` and `%.*s` overlap",
+                                (int)slots[j].name.size, slots[j].name.data,
+                                (int)slots[i].name.size, slots[i].name.data);
+      }
+    }
+  }
+  if (IREE_UNLIKELY(present_count >
+                    IREE_HAL_DISPATCH_MAX_RUNTIME_PARAMETER_PATCHES)) {
+    return iree_make_status(
+        IREE_STATUS_RESOURCE_EXHAUSTED,
+        "runtime parameter patch capacity %u is smaller than %" PRIhsz
+        " declared runtime services",
+        IREE_HAL_DISPATCH_MAX_RUNTIME_PARAMETER_PATCHES, present_count);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_module_initialize_symbol_runtime_slots(
+    iree_hal_streaming_module_t* module) {
+  iree_status_t status = iree_ok_status();
+  for (iree_host_size_t i = 0;
+       iree_status_is_ok(status) && i < module->symbol_count; ++i) {
+    iree_hal_streaming_symbol_t* symbol = &module->symbols[i];
+    if (symbol->type != IREE_HAL_STREAMING_SYMBOL_TYPE_FUNCTION) continue;
+
+    const iree_hal_executable_function_t function =
+        iree_hal_executable_function_from_index(symbol->export_ordinal);
+    iree_hal_executable_function_info_t function_info;
+    status = iree_hal_executable_function_info(symbol->executable, function,
+                                               &function_info);
+    iree_hal_executable_function_runtime_parameter_info_t* parameters = NULL;
+    if (iree_status_is_ok(status) && function_info.runtime_parameter_count) {
+      status = iree_allocator_malloc_array(
+          module->host_allocator, function_info.runtime_parameter_count,
+          sizeof(*parameters), (void**)&parameters);
+    }
+    if (iree_status_is_ok(status) && function_info.runtime_parameter_count) {
+      status = iree_hal_executable_function_runtime_parameters(
+          symbol->executable, function, function_info.runtime_parameter_count,
+          parameters);
+    }
+    for (iree_host_size_t j = 0;
+         iree_status_is_ok(status) && j < function_info.runtime_parameter_count;
+         ++j) {
+      status = iree_hal_streaming_module_initialize_runtime_parameter(
+          symbol, parameters[j]);
+    }
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_streaming_module_validate_runtime_service_slots(symbol);
+    }
+    iree_allocator_free(module->host_allocator, parameters);
+  }
+  return status;
+}
+
+//===----------------------------------------------------------------------===//
+// Buffered Printf Runtime
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_hal_streaming_printf_drain_state_t {
+  // Module retained while the host call needs the printf format table.
+  iree_hal_streaming_module_t* module;
+  // Transient host-visible printf FIFO owned by the host call.
+  iree_hal_streaming_buffer_t* buffer;
+} iree_hal_streaming_printf_drain_state_t;
+
+static iree_host_size_t iree_hal_streaming_printf_strnlen(
+    const char* data, iree_host_size_t data_length) {
+  iree_host_size_t length = 0;
+  while (length < data_length && data[length] != '\0') ++length;
+  return length;
+}
+
+static iree_host_size_t iree_hal_streaming_printf_align8(
+    iree_host_size_t value) {
+  return (value + 7u) & ~(iree_host_size_t)7u;
+}
+
+static iree_status_t iree_hal_streaming_printf_find_format(
+    iree_hal_streaming_module_t* module, uint64_t hash,
+    iree_string_view_t* out_format) {
+  *out_format = iree_string_view_empty();
+  for (iree_host_size_t i = 0; i < module->printf_format_count; ++i) {
+    const iree_hal_streaming_printf_format_t* record =
+        &module->printf_formats[i];
+    if (record->hash == hash) {
+      *out_format = record->format;
+      return iree_ok_status();
+    }
+  }
+  return iree_make_status(
+      IREE_STATUS_NOT_FOUND,
+      "buffered printf record references unknown format hash 0x%016" PRIx64,
+      hash);
+}
+
+static bool iree_hal_streaming_printf_write(FILE* stream, int* out_count,
+                                            const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  const int result = vfprintf(stream, format, args);
+  va_end(args);
+  if (result < 0) {
+    *out_count = result;
+    return false;
+  }
+  if (*out_count <= INT_MAX - result) {
+    *out_count += result;
+  } else {
+    *out_count = INT_MAX;
+  }
+  return true;
+}
+
+static bool iree_hal_streaming_printf_write_bytes(FILE* stream, int* out_count,
+                                                  const char* data,
+                                                  iree_host_size_t length) {
+  if (length == 0) return true;
+  if (IREE_UNLIKELY(length > (iree_host_size_t)INT_MAX)) {
+    *out_count = -1;
+    return false;
+  }
+  if (fwrite(data, 1, length, stream) != length) {
+    *out_count = -1;
+    return false;
+  }
+  if (*out_count <= INT_MAX - (int)length) {
+    *out_count += (int)length;
+  } else {
+    *out_count = INT_MAX;
+  }
+  return true;
+}
+
+static const uint8_t* iree_hal_streaming_printf_read_u64(
+    const uint8_t* argument, const uint8_t* argument_end, uint64_t* out_value) {
+  if (IREE_UNLIKELY((iree_host_size_t)(argument_end - argument) <
+                    sizeof(*out_value))) {
+    return NULL;
+  }
+  memcpy(out_value, argument, sizeof(*out_value));
+  return argument + sizeof(*out_value);
+}
+
+static const uint8_t* iree_hal_streaming_printf_process_spec(
+    FILE* stream, int* out_count, const char* spec_begin,
+    iree_host_size_t spec_length, const uint8_t* argument,
+    const uint8_t* argument_end) {
+  if (IREE_UNLIKELY(spec_length >= 128)) return NULL;
+  char spec[128];
+  memcpy(spec, spec_begin, spec_length);
+  spec[spec_length] = '\0';
+  iree_hal_streaming_printf_spec_t parsed_spec;
+  if (IREE_UNLIKELY(!iree_hal_streaming_printf_parse_spec(spec, spec_length,
+                                                          &parsed_spec))) {
+    return NULL;
+  }
+
+  const int star_count = parsed_spec.star_count;
+  int star0 = 0;
+  int star1 = 0;
+  uint64_t raw_value = 0;
+  if (star_count >= 1) {
+    argument =
+        iree_hal_streaming_printf_read_u64(argument, argument_end, &raw_value);
+    if (!argument) return NULL;
+    star0 = (int)raw_value;
+  }
+  if (star_count >= 2) {
+    argument =
+        iree_hal_streaming_printf_read_u64(argument, argument_end, &raw_value);
+    if (!argument) return NULL;
+    star1 = (int)raw_value;
+  }
+
+  const char conversion = parsed_spec.conversion;
+
+#define IREE_HAL_STREAMING_PRINTF_CALL(value)                                 \
+  do {                                                                        \
+    if (star_count == 0) {                                                    \
+      iree_hal_streaming_printf_write(stream, out_count, spec, value);        \
+    } else if (star_count == 1) {                                             \
+      iree_hal_streaming_printf_write(stream, out_count, spec, star0, value); \
+    } else {                                                                  \
+      iree_hal_streaming_printf_write(stream, out_count, spec, star0, star1,  \
+                                      value);                                 \
+    }                                                                         \
+  } while (0)
+
+  switch (conversion) {
+    case 'd':
+    case 'i':
+    case 'o':
+    case 'u':
+    case 'x':
+    case 'X': {
+      argument = iree_hal_streaming_printf_read_u64(argument, argument_end,
+                                                    &raw_value);
+      if (!argument) return NULL;
+      if (parsed_spec.is_signed_integer) {
+        switch (parsed_spec.length_modifier) {
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_DEFAULT:
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_H:
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_HH: {
+            const int value = (int)raw_value;
+            IREE_HAL_STREAMING_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_L: {
+            const long value = (long)raw_value;
+            IREE_HAL_STREAMING_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_LL: {
+            const long long value = (long long)raw_value;
+            IREE_HAL_STREAMING_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_J: {
+            const intmax_t value = (intmax_t)raw_value;
+            IREE_HAL_STREAMING_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_Z: {
+            const iree_hal_streaming_printf_signed_size_t value =
+                (iree_hal_streaming_printf_signed_size_t)raw_value;
+            IREE_HAL_STREAMING_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_T: {
+            const ptrdiff_t value = (ptrdiff_t)raw_value;
+            IREE_HAL_STREAMING_PRINTF_CALL(value);
+            break;
+          }
+        }
+      } else {
+        switch (parsed_spec.length_modifier) {
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_DEFAULT:
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_H:
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_HH: {
+            const unsigned int value = (unsigned int)raw_value;
+            IREE_HAL_STREAMING_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_L: {
+            const unsigned long value = (unsigned long)raw_value;
+            IREE_HAL_STREAMING_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_LL: {
+            const unsigned long long value = (unsigned long long)raw_value;
+            IREE_HAL_STREAMING_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_J: {
+            const uintmax_t value = (uintmax_t)raw_value;
+            IREE_HAL_STREAMING_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_Z: {
+            const size_t value = (size_t)raw_value;
+            IREE_HAL_STREAMING_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_T: {
+            const iree_hal_streaming_printf_unsigned_ptrdiff_t value =
+                (iree_hal_streaming_printf_unsigned_ptrdiff_t)raw_value;
+            IREE_HAL_STREAMING_PRINTF_CALL(value);
+            break;
+          }
+        }
+      }
+      break;
+    }
+    case 'c': {
+      argument = iree_hal_streaming_printf_read_u64(argument, argument_end,
+                                                    &raw_value);
+      if (!argument) return NULL;
+      if (parsed_spec.is_wide_character) {
+        const wint_t value = (wint_t)raw_value;
+        IREE_HAL_STREAMING_PRINTF_CALL(value);
+      } else {
+        const int value = (int)raw_value;
+        IREE_HAL_STREAMING_PRINTF_CALL(value);
+      }
+      break;
+    }
+    case 'f':
+    case 'F':
+    case 'e':
+    case 'E':
+    case 'g':
+    case 'G':
+    case 'a':
+    case 'A': {
+      argument = iree_hal_streaming_printf_read_u64(argument, argument_end,
+                                                    &raw_value);
+      if (!argument) return NULL;
+      double value = 0;
+      memcpy(&value, &raw_value, sizeof(value));
+      IREE_HAL_STREAMING_PRINTF_CALL(value);
+      break;
+    }
+    case 's': {
+      const iree_host_size_t available_bytes =
+          (iree_host_size_t)(argument_end - argument);
+      const iree_host_size_t string_length = iree_hal_streaming_printf_strnlen(
+          (const char*)argument, available_bytes);
+      if (IREE_UNLIKELY(string_length == available_bytes)) return NULL;
+      const char* value = (const char*)argument;
+      IREE_HAL_STREAMING_PRINTF_CALL(value);
+      argument += iree_hal_streaming_printf_align8(string_length + 1);
+      if (IREE_UNLIKELY(argument > argument_end)) return NULL;
+      break;
+    }
+    case 'p': {
+      argument = iree_hal_streaming_printf_read_u64(argument, argument_end,
+                                                    &raw_value);
+      if (!argument) return NULL;
+      void* value = (void*)(uintptr_t)raw_value;
+      IREE_HAL_STREAMING_PRINTF_CALL(value);
+      break;
+    }
+    default:
+      return NULL;
+  }
+
+#undef IREE_HAL_STREAMING_PRINTF_CALL
+
+  return argument;
+}
+
+static iree_status_t iree_hal_streaming_printf_write_formatted(
+    FILE* stream, iree_string_view_t format, const uint8_t* arguments,
+    iree_host_size_t argument_length) {
+  const uint8_t* argument = arguments;
+  const uint8_t* argument_end = arguments + argument_length;
+  int out_count = 0;
+  iree_host_size_t cursor = 0;
+  while (cursor < format.size) {
+    const char* percent =
+        memchr(format.data + cursor, '%', format.size - cursor);
+    if (!percent) {
+      if (!iree_hal_streaming_printf_write_bytes(
+              stream, &out_count, format.data + cursor, format.size - cursor)) {
+        return iree_make_status(IREE_STATUS_UNKNOWN,
+                                "buffered printf output write failed");
+      }
+      return iree_ok_status();
+    }
+
+    const iree_host_size_t percent_offset =
+        (iree_host_size_t)(percent - format.data);
+    if (!iree_hal_streaming_printf_write_bytes(stream, &out_count,
+                                               format.data + cursor,
+                                               percent_offset - cursor)) {
+      return iree_make_status(IREE_STATUS_UNKNOWN,
+                              "buffered printf output write failed");
+    }
+
+    iree_host_size_t spec_end = percent_offset + 1;
+    if (spec_end < format.size && format.data[spec_end] == '%') {
+      if (!iree_hal_streaming_printf_write_bytes(stream, &out_count, "%", 1)) {
+        return iree_make_status(IREE_STATUS_UNKNOWN,
+                                "buffered printf output write failed");
+      }
+      cursor = spec_end + 1;
+      continue;
+    }
+
+    static const char kConversionSpecifiers[] = "diouxXfFeEgGaAcspn";
+    while (spec_end < format.size &&
+           !strchr(kConversionSpecifiers, format.data[spec_end])) {
+      ++spec_end;
+    }
+    if (IREE_UNLIKELY(spec_end == format.size)) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "buffered printf format is unterminated");
+    }
+    ++spec_end;
+
+    argument = iree_hal_streaming_printf_process_spec(
+        stream, &out_count, percent, spec_end - percent_offset, argument,
+        argument_end);
+    if (IREE_UNLIKELY(out_count < 0 || !argument)) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "buffered printf arguments are malformed");
+    }
+    cursor = spec_end;
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_printf_drain_constant_record(
+    iree_hal_streaming_module_t* module, FILE* stream, const uint8_t* payload,
+    iree_host_size_t payload_length) {
+  if (IREE_UNLIKELY(payload_length < sizeof(uint64_t))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "buffered printf constant record is truncated");
+  }
+  uint64_t hash = 0;
+  memcpy(&hash, payload, sizeof(hash));
+
+  iree_string_view_t format = iree_string_view_empty();
+  IREE_RETURN_IF_ERROR(
+      iree_hal_streaming_printf_find_format(module, hash, &format));
+  return iree_hal_streaming_printf_write_formatted(
+      stream, format, payload + sizeof(uint64_t),
+      payload_length - sizeof(uint64_t));
+}
+
+static iree_status_t iree_hal_streaming_printf_drain_inline_record(
+    FILE* stream, const uint8_t* payload, iree_host_size_t payload_length) {
+  const iree_host_size_t format_length =
+      iree_hal_streaming_printf_strnlen((const char*)payload, payload_length);
+  if (IREE_UNLIKELY(format_length == payload_length)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "buffered printf inline format is unterminated");
+  }
+  const iree_host_size_t argument_offset =
+      iree_hal_streaming_printf_align8(format_length + 1);
+  if (IREE_UNLIKELY(argument_offset > payload_length)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "buffered printf inline record is malformed");
+  }
+  const iree_string_view_t format =
+      iree_make_string_view((const char*)payload, format_length);
+  return iree_hal_streaming_printf_write_formatted(
+      stream, format, payload + argument_offset,
+      payload_length - argument_offset);
+}
+
+static iree_status_t iree_hal_streaming_printf_drain(
+    iree_hal_streaming_module_t* module, iree_hal_streaming_buffer_t* buffer) {
+  if (IREE_UNLIKELY(!buffer->host_ptr)) {
+    return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                            "buffered printf FIFO is not host-visible");
+  }
+  if (IREE_UNLIKELY(buffer->size <
+                    IREE_HAL_STREAMING_PRINTF_BUFFER_HEADER_SIZE)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "buffered printf FIFO is smaller than its header");
+  }
+
+  const uint8_t* data = (const uint8_t*)buffer->host_ptr;
+  uint32_t used_bytes = 0;
+  uint32_t capacity_bytes = 0;
+  memcpy(&used_bytes, data, sizeof(used_bytes));
+  memcpy(&capacity_bytes, data + sizeof(used_bytes), sizeof(capacity_bytes));
+
+  const iree_host_size_t storage_capacity =
+      (iree_host_size_t)buffer->size -
+      IREE_HAL_STREAMING_PRINTF_BUFFER_HEADER_SIZE;
+  if (IREE_UNLIKELY(capacity_bytes > storage_capacity ||
+                    used_bytes > capacity_bytes)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "buffered printf FIFO header is out of range");
+  }
+
+  const uint8_t* cursor = data + IREE_HAL_STREAMING_PRINTF_BUFFER_HEADER_SIZE;
+  iree_host_size_t remaining = used_bytes;
+  iree_status_t status = iree_ok_status();
+  while (iree_status_is_ok(status) && remaining > 0) {
+    if (IREE_UNLIKELY(remaining < sizeof(uint32_t))) {
+      status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "buffered printf record is truncated");
+      break;
+    }
+
+    uint32_t control = 0;
+    memcpy(&control, cursor, sizeof(control));
+    const iree_host_size_t record_length = control >> 2;
+    if (IREE_UNLIKELY(record_length < sizeof(uint32_t) ||
+                      record_length > remaining)) {
+      status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "buffered printf record length is invalid");
+      break;
+    }
+
+    FILE* stream = (control & IREE_HAL_STREAMING_PRINTF_RECORD_FLAG_STDERR)
+                       ? stderr
+                       : stdout;
+    const uint8_t* payload = cursor + sizeof(uint32_t);
+    const iree_host_size_t payload_length = record_length - sizeof(uint32_t);
+    if (control & IREE_HAL_STREAMING_PRINTF_RECORD_FLAG_CONSTANT_FORMAT) {
+      status = iree_hal_streaming_printf_drain_constant_record(
+          module, stream, payload, payload_length);
+    } else {
+      status = iree_hal_streaming_printf_drain_inline_record(stream, payload,
+                                                             payload_length);
+    }
+
+    cursor += record_length;
+    remaining -= record_length;
+  }
+
+  fflush(stdout);
+  fflush(stderr);
+  return status;
+}
+
+static iree_status_t iree_hal_streaming_printf_drain_host_call(
+    void* user_data, const uint64_t args[4],
+    iree_hal_host_call_context_t* call_context) {
+  (void)args;
+  (void)call_context;
+  iree_hal_streaming_printf_drain_state_t* state =
+      (iree_hal_streaming_printf_drain_state_t*)user_data;
+  iree_status_t status =
+      iree_hal_streaming_printf_drain(state->module, state->buffer);
+  iree_hal_streaming_memory_release_transient_buffer(state->buffer);
+  iree_hal_streaming_module_release(state->module);
+  iree_allocator_free(iree_allocator_system(), state);
+  return status;
+}
+
+iree_status_t iree_hal_streaming_symbol_create_printf_buffer(
+    iree_hal_streaming_symbol_t* symbol,
+    iree_hal_streaming_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(symbol);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  *out_buffer = NULL;
+  if (!symbol->runtime_services.printf_buffer.present) return iree_ok_status();
+
+  size_t buffer_size = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_streaming_context_limit(
+      symbol->module->context,
+      IREE_HAL_STREAMING_CONTEXT_LIMIT_PRINTF_FIFO_SIZE, &buffer_size));
+  if (IREE_UNLIKELY(buffer_size <
+                    IREE_HAL_STREAMING_PRINTF_BUFFER_HEADER_SIZE)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "buffered printf FIFO size is too small");
+  }
+  if (IREE_UNLIKELY(buffer_size >
+                    (size_t)UINT32_MAX +
+                        IREE_HAL_STREAMING_PRINTF_BUFFER_HEADER_SIZE)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "buffered printf FIFO size exceeds ABI limit");
+  }
+
+  iree_hal_streaming_buffer_t* buffer = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_streaming_memory_allocate_runtime_host(
+      symbol->module->context, (iree_host_size_t)buffer_size, &buffer));
+
+  uint32_t used_bytes = 0;
+  uint32_t capacity_bytes =
+      (uint32_t)(buffer_size - IREE_HAL_STREAMING_PRINTF_BUFFER_HEADER_SIZE);
+  memcpy(buffer->host_ptr, &used_bytes, sizeof(used_bytes));
+  memcpy((uint8_t*)buffer->host_ptr + sizeof(used_bytes), &capacity_bytes,
+         sizeof(capacity_bytes));
+  *out_buffer = buffer;
+  return iree_ok_status();
+}
+
+// Module initialization validates the fixed service slots for overlap and
+// runtime-parameter-list capacity before dispatches can reach this hot path.
+static inline void
+iree_hal_streaming_dispatch_config_append_validated_runtime_pointer(
+    iree_hal_dispatch_runtime_parameter_list_t* runtime_parameters,
+    const iree_hal_streaming_runtime_parameter_slot_t* slot,
+    uint64_t device_ptr) {
+  iree_hal_dispatch_runtime_parameter_patch_t* patch =
+      &runtime_parameters->patches[runtime_parameters->count++];
+  patch->offset = slot->offset;
+  patch->length = (uint16_t)slot->length;
+  patch->reserved = 0;
+  memcpy(patch->data, &device_ptr, sizeof(device_ptr));
+}
+
+iree_status_t iree_hal_streaming_symbol_prepare_runtime_dispatch_config(
+    iree_hal_streaming_symbol_t* symbol, iree_hal_streaming_context_t* context,
+    bool enable_printf,
+    iree_hal_dispatch_runtime_parameter_list_t* runtime_parameters,
+    iree_hal_dispatch_config_t* config,
+    iree_hal_streaming_buffer_t** out_printf_buffer) {
+  IREE_ASSERT_ARGUMENT(symbol);
+  IREE_ASSERT_ARGUMENT(context);
+  IREE_ASSERT_ARGUMENT(runtime_parameters);
+  IREE_ASSERT_ARGUMENT(config);
+  if (out_printf_buffer) *out_printf_buffer = NULL;
+  *runtime_parameters = (iree_hal_dispatch_runtime_parameter_list_t){0};
+  config->runtime_parameters = NULL;
+
+  iree_hal_streaming_buffer_t* printf_buffer = NULL;
+  iree_status_t status = iree_ok_status();
+  if (enable_printf && symbol->runtime_services.printf_buffer.present) {
+    if (IREE_UNLIKELY(!out_printf_buffer)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "printf runtime buffer requested without an output owner");
+    }
+    status =
+        iree_hal_streaming_symbol_create_printf_buffer(symbol, &printf_buffer);
+    if (iree_status_is_ok(status)) {
+      iree_hal_streaming_dispatch_config_append_validated_runtime_pointer(
+          runtime_parameters, &symbol->runtime_services.printf_buffer,
+          printf_buffer->device_ptr);
+    }
+  }
+
+  if (iree_status_is_ok(status) &&
+      symbol->runtime_services.hostcall_buffer.present) {
+    uint64_t hostcall_buffer_device_ptr =
+        iree_hal_streaming_context_cached_rocm_hostcall_buffer(context);
+    if (hostcall_buffer_device_ptr == 0) {
+      status = iree_hal_streaming_context_rocm_hostcall_buffer(
+          context, &hostcall_buffer_device_ptr);
+    }
+    if (iree_status_is_ok(status)) {
+      iree_hal_streaming_dispatch_config_append_validated_runtime_pointer(
+          runtime_parameters, &symbol->runtime_services.hostcall_buffer,
+          hostcall_buffer_device_ptr);
+    }
+  }
+
+  if (iree_status_is_ok(status) && symbol->runtime_services.heap_v1.present) {
+    uint64_t heap_device_ptr =
+        iree_hal_streaming_context_cached_rocm_malloc_heap(context);
+    if (heap_device_ptr == 0) {
+      status = iree_hal_streaming_context_rocm_device_malloc_heap(
+          context, &heap_device_ptr);
+    }
+    if (iree_status_is_ok(status)) {
+      iree_hal_streaming_dispatch_config_append_validated_runtime_pointer(
+          runtime_parameters, &symbol->runtime_services.heap_v1,
+          heap_device_ptr);
+    }
+  }
+
+  if (!iree_status_is_ok(status)) {
+    if (printf_buffer) {
+      iree_hal_streaming_memory_release_transient_buffer(printf_buffer);
+    }
+    return status;
+  }
+  if (runtime_parameters->count != 0) {
+    config->runtime_parameters = runtime_parameters;
+  }
+  if (out_printf_buffer) {
+    *out_printf_buffer = printf_buffer;
+  } else if (printf_buffer) {
+    iree_hal_streaming_memory_release_transient_buffer(printf_buffer);
+  }
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_streaming_symbol_queue_printf_drain(
+    iree_hal_streaming_symbol_t* symbol, iree_hal_streaming_stream_t* stream,
+    iree_hal_streaming_buffer_t* buffer) {
+  IREE_ASSERT_ARGUMENT(symbol);
+  IREE_ASSERT_ARGUMENT(stream);
+  if (!buffer) return iree_ok_status();
+
+  iree_hal_streaming_printf_drain_state_t* state = NULL;
+  iree_status_t status = iree_allocator_malloc(iree_allocator_system(),
+                                               sizeof(*state), (void**)&state);
+  if (!iree_status_is_ok(status)) {
+    iree_hal_streaming_memory_release_transient_buffer(buffer);
+    return status;
+  }
+  state->module = symbol->module;
+  iree_hal_streaming_module_retain(state->module);
+  state->buffer = buffer;
+
+  const uint64_t args[4] = {0, 0, 0, 0};
+  iree_hal_host_call_t call =
+      iree_hal_make_host_call(iree_hal_streaming_printf_drain_host_call, state);
+  status = iree_hal_streaming_queue_host_call(stream, call, args,
+                                              IREE_HAL_HOST_CALL_FLAG_NONE);
+  if (!iree_status_is_ok(status)) {
+    iree_hal_streaming_memory_release_transient_buffer(buffer);
+    iree_hal_streaming_module_release(state->module);
+    iree_allocator_free(iree_allocator_system(), state);
+  }
+  return status;
+}
+
+//===----------------------------------------------------------------------===//
+// Printf Metadata
+//===----------------------------------------------------------------------===//
+
+static iree_host_size_t iree_hal_streaming_module_executable_count(
+    const iree_hal_streaming_module_t* module) {
+  return module->executables ? module->executable_count : 1;
+}
+
+static iree_hal_executable_t* iree_hal_streaming_module_executable_at(
+    const iree_hal_streaming_module_t* module, iree_host_size_t index) {
+  return module->executables ? module->executables[index] : module->executable;
+}
+
+static iree_status_t iree_hal_streaming_parse_printf_metadata_record(
+    iree_string_view_t record, uint64_t* out_hash,
+    iree_string_view_t* out_format) {
+  *out_hash = 0;
+  *out_format = iree_string_view_empty();
+
+  if (!iree_string_view_consume_prefix(&record, IREE_SV("0:0:"))) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "printf metadata record must start with fixed `0:0:` fields");
+  }
+  iree_host_size_t comma = iree_string_view_find_char(record, ',', 0);
+  if (comma == IREE_STRING_VIEW_NPOS || comma == 0) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "printf metadata record is missing hash/format delimiter");
+  }
+  iree_string_view_t hash_text = iree_string_view_substr(record, 0, comma);
+  if (hash_text.size > 16) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "printf metadata hash exceeds 64 bits");
+  }
+  uint64_t hash = 0;
+  if (!iree_string_view_atoi_uint64_base(hash_text, 16, &hash)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "printf metadata hash is not hexadecimal");
+  }
+
+  *out_hash = hash;
+  *out_format =
+      iree_string_view_substr(record, comma + 1, IREE_STRING_VIEW_NPOS);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_module_append_printf_format(
+    iree_hal_streaming_module_t* module, uint64_t hash,
+    iree_string_view_t format) {
+  for (iree_host_size_t i = 0; i < module->printf_format_count; ++i) {
+    iree_hal_streaming_printf_format_t* existing = &module->printf_formats[i];
+    if (existing->hash != hash) continue;
+    if (iree_string_view_equal(existing->format, format))
+      return iree_ok_status();
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "printf metadata hash collision for hash 0x%016" PRIx64, hash);
+  }
+  module->printf_formats[module->printf_format_count++] =
+      (iree_hal_streaming_printf_format_t){
+          .hash = hash,
+          .format = format,
+      };
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_module_initialize_printf_metadata(
+    iree_hal_streaming_module_t* module) {
+  iree_status_t status = iree_ok_status();
+
+  iree_host_size_t total_record_count = 0;
+  const iree_host_size_t executable_count =
+      iree_hal_streaming_module_executable_count(module);
+  for (iree_host_size_t i = 0;
+       iree_status_is_ok(status) && i < executable_count; ++i) {
+    iree_host_size_t record_count = 0;
+    status = iree_hal_executable_runtime_metadata_count(
+        iree_hal_streaming_module_executable_at(module, i),
+        IREE_SV("amdhsa.printf"), &record_count);
+    if (!iree_status_is_ok(status)) break;
+    if (!iree_host_size_checked_add(total_record_count, record_count,
+                                    &total_record_count)) {
+      status = iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                                "printf metadata record count overflow");
+    }
+  }
+  if (!iree_status_is_ok(status) || total_record_count == 0) return status;
+
+  iree_host_size_t format_storage_size = 0;
+  if (!iree_host_size_checked_mul(total_record_count,
+                                  sizeof(module->printf_formats[0]),
+                                  &format_storage_size)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "printf metadata table size overflow");
+  }
+  status = iree_allocator_malloc(module->host_allocator, format_storage_size,
+                                 (void**)&module->printf_formats);
+  if (iree_status_is_ok(status)) {
+    memset(module->printf_formats, 0, format_storage_size);
+  }
+
+  iree_hal_executable_runtime_metadata_record_t* records = NULL;
+  for (iree_host_size_t i = 0;
+       iree_status_is_ok(status) && i < executable_count; ++i) {
+    iree_hal_executable_t* executable =
+        iree_hal_streaming_module_executable_at(module, i);
+    iree_host_size_t record_count = 0;
+    status = iree_hal_executable_runtime_metadata_count(
+        executable, IREE_SV("amdhsa.printf"), &record_count);
+    if (!iree_status_is_ok(status) || record_count == 0) continue;
+
+    iree_host_size_t records_size = 0;
+    if (!iree_host_size_checked_mul(record_count, sizeof(records[0]),
+                                    &records_size)) {
+      status = iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                                "printf metadata record storage overflow");
+      break;
+    }
+    status = iree_allocator_malloc(module->host_allocator, records_size,
+                                   (void**)&records);
+    if (!iree_status_is_ok(status)) break;
+    memset(records, 0, records_size);
+
+    status = iree_hal_executable_runtime_metadata_records(
+        executable, IREE_SV("amdhsa.printf"), record_count, records);
+    for (iree_host_size_t j = 0; iree_status_is_ok(status) && j < record_count;
+         ++j) {
+      uint64_t hash = 0;
+      iree_string_view_t format = iree_string_view_empty();
+      status = iree_hal_streaming_parse_printf_metadata_record(records[j].value,
+                                                               &hash, &format);
+      if (iree_status_is_ok(status)) {
+        status = iree_hal_streaming_module_append_printf_format(module, hash,
+                                                                format);
+      }
+    }
+
+    iree_allocator_free(module->host_allocator, records);
+    records = NULL;
+  }
+  if (records) iree_allocator_free(module->host_allocator, records);
+  return status;
+}
+
+//===----------------------------------------------------------------------===//
+// Module Runtime Metadata
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_hal_streaming_module_initialize_runtime_metadata(
+    iree_hal_streaming_module_t* module) {
+  IREE_ASSERT_ARGUMENT(module);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status =
+      iree_hal_streaming_module_initialize_symbol_runtime_slots(module);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_module_initialize_printf_metadata(module);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}

--- a/libhrx/src/binding/common/printf_format.h
+++ b/libhrx/src/binding/common/printf_format.h
@@ -1,0 +1,189 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_STREAMING_PRINTF_FORMAT_H_
+#define IREE_HAL_STREAMING_PRINTF_FORMAT_H_
+
+#include <limits.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "iree/base/api.h"
+
+// Length modifier carried by one supported printf conversion.
+typedef enum iree_hal_streaming_printf_length_modifier_e {
+  IREE_HAL_STREAMING_PRINTF_LENGTH_DEFAULT = 0,
+  IREE_HAL_STREAMING_PRINTF_LENGTH_HH,
+  IREE_HAL_STREAMING_PRINTF_LENGTH_H,
+  IREE_HAL_STREAMING_PRINTF_LENGTH_L,
+  IREE_HAL_STREAMING_PRINTF_LENGTH_LL,
+  IREE_HAL_STREAMING_PRINTF_LENGTH_J,
+  IREE_HAL_STREAMING_PRINTF_LENGTH_Z,
+  IREE_HAL_STREAMING_PRINTF_LENGTH_T,
+} iree_hal_streaming_printf_length_modifier_t;
+
+// Parsed printf conversion that can be safely materialized from a device ABI
+// scalar slot and passed to vfprintf.
+typedef struct iree_hal_streaming_printf_spec_t {
+  // Terminal conversion character, such as d, s, or f.
+  char conversion;
+  // Parsed length modifier affecting the host vararg type.
+  iree_hal_streaming_printf_length_modifier_t length_modifier;
+  // Number of width and precision arguments supplied with *.
+  uint8_t star_count;
+  // True when the conversion consumes a signed integer argument.
+  bool is_signed_integer;
+  // True when the conversion consumes a wide character argument.
+  bool is_wide_character;
+} iree_hal_streaming_printf_spec_t;
+
+static inline bool iree_hal_streaming_printf_is_flag(char c) {
+  switch (c) {
+    case '#':
+    case '0':
+    case '-':
+    case ' ':
+    case '+':
+    case '\'':
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Parses the supported C printf grammar. Device-side scalar values are carried
+// in eight-byte slots, so long double, wide strings, and %n cannot be mapped to
+// a safe host-side vararg representation.
+static inline bool iree_hal_streaming_printf_parse_spec(
+    const char* spec, iree_host_size_t spec_length,
+    iree_hal_streaming_printf_spec_t* out_spec) {
+  if (!spec || !out_spec || spec_length < 2 || spec[0] != '%') return false;
+
+  *out_spec = (iree_hal_streaming_printf_spec_t){0};
+  const iree_host_size_t conversion_index = spec_length - 1;
+  out_spec->conversion = spec[conversion_index];
+
+  iree_host_size_t index = 1;
+  while (index < conversion_index &&
+         iree_hal_streaming_printf_is_flag(spec[index])) {
+    ++index;
+  }
+  if (index < conversion_index && spec[index] == '*') {
+    ++out_spec->star_count;
+    ++index;
+  } else {
+    while (index < conversion_index && spec[index] >= '0' &&
+           spec[index] <= '9') {
+      ++index;
+    }
+  }
+  if (index < conversion_index && spec[index] == '.') {
+    ++index;
+    if (index < conversion_index && spec[index] == '*') {
+      ++out_spec->star_count;
+      ++index;
+    } else {
+      while (index < conversion_index && spec[index] >= '0' &&
+             spec[index] <= '9') {
+        ++index;
+      }
+    }
+  }
+
+  if (index < conversion_index) {
+    switch (spec[index++]) {
+      case 'h':
+        if (index < conversion_index && spec[index] == 'h') {
+          ++index;
+          out_spec->length_modifier = IREE_HAL_STREAMING_PRINTF_LENGTH_HH;
+        } else {
+          out_spec->length_modifier = IREE_HAL_STREAMING_PRINTF_LENGTH_H;
+        }
+        break;
+      case 'l':
+        if (index < conversion_index && spec[index] == 'l') {
+          ++index;
+          out_spec->length_modifier = IREE_HAL_STREAMING_PRINTF_LENGTH_LL;
+        } else {
+          out_spec->length_modifier = IREE_HAL_STREAMING_PRINTF_LENGTH_L;
+        }
+        break;
+      case 'j':
+        out_spec->length_modifier = IREE_HAL_STREAMING_PRINTF_LENGTH_J;
+        break;
+      case 'z':
+        out_spec->length_modifier = IREE_HAL_STREAMING_PRINTF_LENGTH_Z;
+        break;
+      case 't':
+        out_spec->length_modifier = IREE_HAL_STREAMING_PRINTF_LENGTH_T;
+        break;
+      case 'L':
+        return false;
+      default:
+        return false;
+    }
+  }
+  if (index != conversion_index) return false;
+
+  switch (out_spec->conversion) {
+    case 'd':
+    case 'i':
+      out_spec->is_signed_integer = true;
+      return true;
+    case 'o':
+    case 'u':
+    case 'x':
+    case 'X':
+      return true;
+    case 'c':
+      if (out_spec->length_modifier == IREE_HAL_STREAMING_PRINTF_LENGTH_L) {
+        out_spec->is_wide_character = true;
+        return true;
+      }
+      return out_spec->length_modifier ==
+             IREE_HAL_STREAMING_PRINTF_LENGTH_DEFAULT;
+    case 'f':
+    case 'F':
+    case 'e':
+    case 'E':
+    case 'g':
+    case 'G':
+    case 'a':
+    case 'A':
+      return out_spec->length_modifier ==
+                 IREE_HAL_STREAMING_PRINTF_LENGTH_DEFAULT ||
+             out_spec->length_modifier == IREE_HAL_STREAMING_PRINTF_LENGTH_L;
+    case 's':
+    case 'p':
+      return out_spec->length_modifier ==
+             IREE_HAL_STREAMING_PRINTF_LENGTH_DEFAULT;
+    default:
+      return false;
+  }
+}
+
+#if SIZE_MAX == UINT_MAX
+typedef int iree_hal_streaming_printf_signed_size_t;
+#elif SIZE_MAX == ULONG_MAX
+typedef long iree_hal_streaming_printf_signed_size_t;
+#elif SIZE_MAX == ULLONG_MAX
+typedef long long iree_hal_streaming_printf_signed_size_t;
+#else
+#error "unsupported size_t representation for printf formatting"
+#endif
+
+#if PTRDIFF_MAX == INT_MAX
+typedef unsigned int iree_hal_streaming_printf_unsigned_ptrdiff_t;
+#elif PTRDIFF_MAX == LONG_MAX
+typedef unsigned long iree_hal_streaming_printf_unsigned_ptrdiff_t;
+#elif PTRDIFF_MAX == LLONG_MAX
+typedef unsigned long long iree_hal_streaming_printf_unsigned_ptrdiff_t;
+#else
+#error "unsupported ptrdiff_t representation for printf formatting"
+#endif
+
+#endif  // IREE_HAL_STREAMING_PRINTF_FORMAT_H_

--- a/libhrx/src/binding/common/registry.c
+++ b/libhrx/src/binding/common/registry.c
@@ -12,6 +12,7 @@
 #include "iree/base/internal/math.h"
 #include "iree/base/threading/call_once.h"
 #include "iree/base/threading/mutex.h"
+#include "iree/hal/buffer_transfer.h"
 
 static void iree_hal_streaming_context_symbol_map_expunge_module(
     iree_hal_streaming_context_symbol_map_t* map,
@@ -37,7 +38,6 @@ static inline bool iree_hal_streaming_symbol_map_is_valid_key(void* key) {
 // Hash function for host pointers. This is a MurmurHash3-style finalizer that
 // mixes aligned function pointer bits well enough for the open-addressed table.
 static inline uint64_t iree_hal_streaming_symbol_pointer_hash(void* ptr) {
-  // Simple hash for pointers - mix bits.
   uint64_t hash = (uint64_t)ptr;
   hash ^= hash >> 33;
   hash *= 0xff51afd7ed558ccdull;
@@ -45,6 +45,125 @@ static inline uint64_t iree_hal_streaming_symbol_pointer_hash(void* ptr) {
   hash *= 0xc4ceb9fe1a85ec53ull;
   hash ^= hash >> 33;
   return hash;
+}
+
+static iree_status_t iree_hal_streaming_registry_checked_array_size(
+    iree_host_size_t count, iree_host_size_t element_size, const char* kind,
+    iree_host_size_t* out_size) {
+  IREE_ASSERT_ARGUMENT(kind);
+  IREE_ASSERT_ARGUMENT(out_size);
+  if (IREE_UNLIKELY(
+          !iree_host_size_checked_mul(count, element_size, out_size))) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "%s allocation size overflow", kind);
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_managed_device_name(
+    iree_allocator_t host_allocator, const char* device_name,
+    char** out_managed_device_name) {
+  IREE_ASSERT_ARGUMENT(device_name);
+  IREE_ASSERT_ARGUMENT(out_managed_device_name);
+  *out_managed_device_name = NULL;
+
+  static const char suffix[] = ".managed";
+  const iree_host_size_t name_length = (iree_host_size_t)strlen(device_name);
+  iree_host_size_t name_size = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_add(name_length, sizeof(suffix),
+                                                &name_size))) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "managed symbol name size overflow");
+  }
+
+  char* managed_device_name = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(host_allocator, name_size,
+                                             (void**)&managed_device_name));
+  memcpy(managed_device_name, device_name, name_length);
+  memcpy(managed_device_name + name_length, suffix, sizeof(suffix));
+  *out_managed_device_name = managed_device_name;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_initialize_managed_global(
+    iree_hal_streaming_context_symbol_map_t* map,
+    const iree_hal_streaming_symbol_registration_t* registration,
+    iree_hal_streaming_symbol_t* pointer_symbol,
+    iree_hal_streaming_symbol_t* storage_symbol) {
+  IREE_ASSERT_ARGUMENT(map);
+  IREE_ASSERT_ARGUMENT(registration);
+  IREE_ASSERT_ARGUMENT(storage_symbol);
+
+  if (!storage_symbol->global_buffer ||
+      !storage_symbol->global_buffer->buffer) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "managed storage `%s` has no HAL buffer",
+                            registration->device_name);
+  }
+  if (registration->params.variable.size > (size_t)storage_symbol->size_bytes) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "managed storage `%s` is too small (%zu requested, %" PRIu64
+        " available)",
+        registration->device_name, registration->params.variable.size,
+        (uint64_t)storage_symbol->size_bytes);
+  }
+
+  iree_status_t status = iree_ok_status();
+  if (registration->params.variable.managed_initial_value &&
+      registration->params.variable.size > 0) {
+    status = iree_hal_device_transfer_h2d(
+        map->context->device,
+        registration->params.variable.managed_initial_value,
+        storage_symbol->global_buffer->buffer, /*target_offset=*/0,
+        registration->params.variable.size,
+        IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout());
+  }
+  if (!iree_status_is_ok(status) || !pointer_symbol) return status;
+
+  if (!pointer_symbol->global_buffer ||
+      !pointer_symbol->global_buffer->buffer) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "managed pointer `%s` has no HAL buffer",
+                            registration->device_name);
+  }
+  if (pointer_symbol->size_bytes < sizeof(storage_symbol->device_address)) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "managed pointer `%s` is too small (%" PRIu64 " bytes)",
+        registration->device_name, (uint64_t)pointer_symbol->size_bytes);
+  }
+
+  const iree_hal_streaming_deviceptr_t storage_device_address =
+      storage_symbol->device_address;
+  return iree_hal_device_transfer_h2d(
+      map->context->device, &storage_device_address,
+      pointer_symbol->global_buffer->buffer, /*target_offset=*/0,
+      sizeof(storage_device_address), IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT,
+      iree_infinite_timeout());
+}
+
+static bool iree_hal_streaming_context_symbol_map_find_entry(
+    iree_hal_streaming_context_symbol_map_t* map, void* host_pointer,
+    iree_hal_streaming_context_symbol_entry_t** out_entry) {
+  IREE_ASSERT_ARGUMENT(map);
+  IREE_ASSERT_ARGUMENT(out_entry);
+  *out_entry = NULL;
+  if (!iree_hal_streaming_symbol_map_is_valid_key(host_pointer)) return false;
+
+  const uint64_t hash = iree_hal_streaming_symbol_pointer_hash(host_pointer);
+  uint32_t index = hash & (map->capacity - 1);
+  for (iree_host_size_t i = 0; i < map->capacity; ++i) {
+    if (map->entries[index].key == host_pointer) {
+      *out_entry = &map->entries[index];
+      return true;
+    }
+    if (map->entries[index].key == IREE_HAL_STREAMING_SYMBOL_MAP_EMPTY_KEY) {
+      return false;
+    }
+    index = (index + 1) & (map->capacity - 1);
+  }
+  return false;
 }
 
 //===----------------------------------------------------------------------===//
@@ -86,14 +205,20 @@ iree_status_t iree_hal_streaming_global_symbol_registry_allocate(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_allocator_malloc(host_allocator, sizeof(*registry),
                                 (void**)&registry));
+  memset(registry, 0, sizeof(*registry));
   registry->host_allocator = host_allocator;
   iree_slim_mutex_initialize(&registry->mutex);
 
   // Allocate initial module pointer array.
   registry->module_capacity = 16;
-  iree_status_t status = iree_allocator_malloc(
-      host_allocator, registry->module_capacity * sizeof(registry->modules[0]),
-      (void**)&registry->modules);
+  iree_host_size_t modules_size = 0;
+  iree_status_t status = iree_hal_streaming_registry_checked_array_size(
+      registry->module_capacity, sizeof(registry->modules[0]),
+      "module registry", &modules_size);
+  if (iree_status_is_ok(status)) {
+    status = iree_allocator_malloc(host_allocator, modules_size,
+                                   (void**)&registry->modules);
+  }
 
   if (iree_status_is_ok(status)) {
     *out_registry = registry;
@@ -132,9 +257,13 @@ static iree_status_t iree_hal_streaming_global_symbol_registry_grow_unsafe(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_hal_streaming_module_registration_t** new_modules = NULL;
+  iree_host_size_t new_modules_size = 0;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_allocator_malloc(registry->host_allocator,
-                                new_capacity * sizeof(new_modules[0]),
+      z0, iree_hal_streaming_registry_checked_array_size(
+              new_capacity, sizeof(new_modules[0]), "module registry",
+              &new_modules_size));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_allocator_malloc(registry->host_allocator, new_modules_size,
                                 (void**)&new_modules));
   memcpy(new_modules, registry->modules,
          registry->module_count * sizeof(new_modules[0]));
@@ -161,10 +290,15 @@ iree_status_t iree_hal_streaming_global_symbol_registry_register_module(
   // Grow the module table if needed.
   iree_status_t status = iree_ok_status();
   if (registry->module_count >= registry->module_capacity) {
-    const iree_host_size_t new_capacity =
-        iree_max(registry->module_capacity + 1, registry->module_capacity * 2);
-    status = iree_hal_streaming_global_symbol_registry_grow_unsafe(
-        registry, new_capacity);
+    iree_host_size_t new_capacity = 0;
+    if (IREE_UNLIKELY(!iree_host_size_checked_mul(registry->module_capacity, 2,
+                                                  &new_capacity))) {
+      status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                "module registry capacity overflow");
+    } else {
+      status = iree_hal_streaming_global_symbol_registry_grow_unsafe(
+          registry, new_capacity);
+    }
   }
 
   // Allocate a new module registration dynamically.
@@ -175,14 +309,19 @@ iree_status_t iree_hal_streaming_global_symbol_registry_register_module(
   }
 
   if (iree_status_is_ok(status)) {
+    memset(module, 0, sizeof(*module));
     module->module_binary = module_binary;
 
     // Allocate initial symbols array.
     module->symbol_capacity = 32;
-    status = iree_allocator_malloc(
-        registry->host_allocator,
-        module->symbol_capacity * sizeof(module->symbols[0]),
-        (void**)&module->symbols);
+    iree_host_size_t symbols_size = 0;
+    status = iree_hal_streaming_registry_checked_array_size(
+        module->symbol_capacity, sizeof(module->symbols[0]), "module symbols",
+        &symbols_size);
+    if (iree_status_is_ok(status)) {
+      status = iree_allocator_malloc(registry->host_allocator, symbols_size,
+                                     (void**)&module->symbols);
+    }
   }
 
   if (iree_status_is_ok(status)) {
@@ -255,9 +394,13 @@ static iree_status_t iree_hal_streaming_module_registration_grow_unsafe(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_hal_streaming_symbol_registration_t* new_symbols = NULL;
+  iree_host_size_t new_symbols_size = 0;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_allocator_malloc(host_allocator,
-                                new_capacity * sizeof(new_symbols[0]),
+      z0, iree_hal_streaming_registry_checked_array_size(
+              new_capacity, sizeof(new_symbols[0]), "module symbols",
+              &new_symbols_size));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_allocator_malloc(host_allocator, new_symbols_size,
                                 (void**)&new_symbols));
   memcpy(new_symbols, module->symbols,
          module->symbol_count * sizeof(module->symbols[0]));
@@ -285,10 +428,15 @@ iree_status_t iree_hal_streaming_global_symbol_registry_insert_function(
   // Check if we need to grow the module's symbols array.
   iree_status_t status = iree_ok_status();
   if (module->symbol_count >= module->symbol_capacity) {
-    const iree_host_size_t new_capacity =
-        iree_max(module->symbol_capacity + 1, module->symbol_capacity * 2);
-    status = iree_hal_streaming_module_registration_grow_unsafe(
-        module, new_capacity, registry->host_allocator);
+    iree_host_size_t new_capacity = 0;
+    if (IREE_UNLIKELY(!iree_host_size_checked_mul(module->symbol_capacity, 2,
+                                                  &new_capacity))) {
+      status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                "module symbol capacity overflow");
+    } else {
+      status = iree_hal_streaming_module_registration_grow_unsafe(
+          module, new_capacity, registry->host_allocator);
+    }
   }
 
   if (iree_status_is_ok(status)) {
@@ -315,7 +463,7 @@ iree_hal_streaming_global_symbol_registry_insert_variable_with_type(
     iree_hal_streaming_global_symbol_registry_t* registry,
     iree_hal_streaming_module_registration_t* module, void* host_variable,
     const char* device_name, size_t size, uint32_t alignment,
-    iree_hal_streaming_symbol_type_t symbol_type) {
+    iree_hal_streaming_symbol_type_t symbol_type, void* managed_initial_value) {
   IREE_ASSERT_ARGUMENT(registry);
   IREE_ASSERT_ARGUMENT(module);
   IREE_ASSERT_ARGUMENT(host_variable);
@@ -347,6 +495,7 @@ iree_hal_streaming_global_symbol_registry_insert_variable_with_type(
     symbol->module = module;
     symbol->params.variable.size = size;
     symbol->params.variable.alignment = alignment;
+    symbol->params.variable.managed_initial_value = managed_initial_value;
   }
 
   iree_slim_mutex_unlock(&registry->mutex);
@@ -360,16 +509,17 @@ iree_status_t iree_hal_streaming_global_symbol_registry_insert_variable(
     const char* device_name, size_t size, uint32_t alignment) {
   return iree_hal_streaming_global_symbol_registry_insert_variable_with_type(
       registry, module, host_variable, device_name, size, alignment,
-      IREE_HAL_STREAMING_SYMBOL_TYPE_GLOBAL);
+      IREE_HAL_STREAMING_SYMBOL_TYPE_GLOBAL, /*managed_initial_value=*/NULL);
 }
 
 iree_status_t iree_hal_streaming_global_symbol_registry_insert_managed_variable(
     iree_hal_streaming_global_symbol_registry_t* registry,
     iree_hal_streaming_module_registration_t* module, void* host_variable,
-    const char* device_name, size_t size, uint32_t alignment) {
+    const char* device_name, size_t size, uint32_t alignment,
+    void* managed_initial_value) {
   return iree_hal_streaming_global_symbol_registry_insert_variable_with_type(
       registry, module, host_variable, device_name, size, alignment,
-      IREE_HAL_STREAMING_SYMBOL_TYPE_DATA);
+      IREE_HAL_STREAMING_SYMBOL_TYPE_DATA, managed_initial_value);
 }
 
 bool iree_hal_streaming_global_symbol_registry_query_variable(
@@ -457,10 +607,20 @@ iree_status_t iree_hal_streaming_context_symbol_map_initialize(
   // Round capacity up to the next power of 2 (if not already).
   out_map->capacity =
       (iree_host_size_t)iree_math_round_up_to_pow2_u64(initial_capacity);
+  if (IREE_UNLIKELY(out_map->capacity == 0)) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "symbol map capacity overflow");
+  }
+  iree_host_size_t entries_size = 0;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_allocator_malloc(host_allocator,
-                                out_map->capacity * sizeof(out_map->entries[0]),
+      z0, iree_hal_streaming_registry_checked_array_size(
+              out_map->capacity, sizeof(out_map->entries[0]), "symbol map",
+              &entries_size));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_allocator_malloc(host_allocator, entries_size,
                                 (void**)&out_map->entries));
+  memset(out_map->entries, 0, entries_size);
 
   // Register with the global registry (so we can listen for notifications).
   iree_slim_mutex_lock(&registry->mutex);
@@ -523,17 +683,31 @@ static iree_status_t iree_hal_streaming_context_symbol_map_grow(
   // Round up to the next power of 2 for optimal hash distribution.
   iree_host_size_t new_capacity =
       (iree_host_size_t)iree_math_round_up_to_pow2_u64(new_min_capacity);
+  if (IREE_UNLIKELY(new_capacity == 0)) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "symbol map capacity overflow");
+  }
   if (new_capacity <= map->capacity) {
-    new_capacity = map->capacity * 2;
+    if (IREE_UNLIKELY(
+            !iree_host_size_checked_mul(map->capacity, 2, &new_capacity))) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                              "symbol map capacity overflow");
+    }
   }
 
   // Allocate the new table.
   iree_hal_streaming_context_symbol_entry_t* new_entries = NULL;
+  iree_host_size_t new_entries_size = 0;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_allocator_malloc(map->host_allocator,
-                                new_capacity * sizeof(new_entries[0]),
+      z0, iree_hal_streaming_registry_checked_array_size(
+              new_capacity, sizeof(new_entries[0]), "symbol map",
+              &new_entries_size));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_allocator_malloc(map->host_allocator, new_entries_size,
                                 (void**)&new_entries));
-  memset(new_entries, 0, new_capacity * sizeof(new_entries[0]));
+  memset(new_entries, 0, new_entries_size);
 
   // Rehash all existing entries into the new table.
   for (iree_host_size_t i = 0; i < map->capacity; ++i) {
@@ -549,6 +723,8 @@ static iree_status_t iree_hal_streaming_context_symbol_map_grow(
       if (new_entries[index].key == IREE_HAL_STREAMING_SYMBOL_MAP_EMPTY_KEY) {
         new_entries[index].key = key;
         new_entries[index].symbol = map->entries[i].symbol;
+        new_entries[index].synchronize_managed_data_to_host =
+            map->entries[i].synchronize_managed_data_to_host;
         break;
       }
       index = (index + 1) & (new_capacity - 1);
@@ -589,11 +765,25 @@ static iree_status_t iree_hal_streaming_context_symbol_map_prepare_module(
   }
 
   // Grow the hash table to fit our new total count, if needed.
-  const iree_host_size_t new_count = map->count + registration->symbol_count;
-  if (new_count > map->capacity * 3 / 4) {
+  iree_host_size_t new_count = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_add(
+          map->count, registration->symbol_count, &new_count))) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "symbol map entry count overflow");
+  }
+  if (new_count > map->capacity - map->capacity / 4) {
     // Need to resize the hash table to maintain good load factor.
     // We want to keep the load factor below 75% for good performance.
-    iree_host_size_t new_min_capacity = (new_count * 4) / 3;
+    iree_host_size_t scaled_count = 0;
+    if (IREE_UNLIKELY(
+            !iree_host_size_checked_mul(new_count, 4, &scaled_count))) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                              "symbol map capacity overflow");
+    }
+    iree_host_size_t new_min_capacity = scaled_count / 3;
+    if (scaled_count % 3 != 0) ++new_min_capacity;
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0, iree_hal_streaming_context_symbol_map_grow(map, new_min_capacity));
   }
@@ -618,8 +808,6 @@ static iree_status_t iree_hal_streaming_context_symbol_map_prepare_module(
   iree_status_t status = iree_hal_streaming_module_create_from_memory(
       map->context, load_flags, module_data, map->host_allocator,
       &entry->module);
-  // fprintf(stderr, "[REGISTRY] module load %s\n",
-  //         iree_status_is_ok(status) ? "OK" : "FAILED");
   if (iree_status_is_ok(status)) {
     // Insert all symbols from the module into the hash table.
     for (iree_host_size_t i = 0;
@@ -628,6 +816,7 @@ static iree_status_t iree_hal_streaming_context_symbol_map_prepare_module(
       iree_string_view_t registered_name =
           iree_make_cstring_view(registration->symbols[i].device_name);
       void* symbol_host_ptr = registration->symbols[i].host_pointer;
+      bool synchronize_managed_data_to_host = false;
 
       // Find the corresponding compiled symbol in the module by name.
       iree_hal_streaming_symbol_t* symbol = NULL;
@@ -643,11 +832,40 @@ static iree_status_t iree_hal_streaming_context_symbol_map_prepare_module(
           }
           break;
         case IREE_HAL_STREAMING_SYMBOL_TYPE_GLOBAL:
-        case IREE_HAL_STREAMING_SYMBOL_TYPE_DATA:
           status = iree_hal_streaming_module_try_lookup_global_symbol(
               entry->module, registration->symbols[i].device_name, &found,
               &symbol);
           break;
+        case IREE_HAL_STREAMING_SYMBOL_TYPE_DATA: {
+          status = iree_hal_streaming_module_try_lookup_global_symbol(
+              entry->module, registration->symbols[i].device_name, &found,
+              &symbol);
+          if (!iree_status_is_ok(status)) break;
+
+          bool storage_found = false;
+          iree_hal_streaming_symbol_t* storage_symbol = NULL;
+          char* managed_device_name = NULL;
+          status = iree_hal_streaming_managed_device_name(
+              map->host_allocator, registration->symbols[i].device_name,
+              &managed_device_name);
+          if (iree_status_is_ok(status)) {
+            status = iree_hal_streaming_module_try_lookup_global_symbol(
+                entry->module, managed_device_name, &storage_found,
+                &storage_symbol);
+          }
+          iree_allocator_free(map->host_allocator, managed_device_name);
+          if (!iree_status_is_ok(status)) break;
+
+          if (storage_found && storage_symbol) {
+            status = iree_hal_streaming_initialize_managed_global(
+                map, &registration->symbols[i], symbol, storage_symbol);
+            if (!iree_status_is_ok(status)) break;
+            found = true;
+            symbol = storage_symbol;
+            synchronize_managed_data_to_host = true;
+          }
+          break;
+        }
         default:
           status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                     "unsupported registered symbol type %d",
@@ -670,9 +888,8 @@ static iree_status_t iree_hal_streaming_context_symbol_map_prepare_module(
         }
       }
       if (!symbol) {
-        // Registered symbol not found - log a warning but don't fail.
-        // Some PyTorch modules may register functions that aren't in the fat
-        // binary.
+        // Registration tables may name symbols that are not present in a
+        // particular loaded image.
         fprintf(stderr,
                 "[WARN] registered symbol `%.*s` not found in module with %zu "
                 "symbols\n",
@@ -682,15 +899,6 @@ static iree_status_t iree_hal_streaming_context_symbol_map_prepare_module(
         continue;
       }
 
-      // Debug: print symbol metadata when inserting
-#if 0
-      if (strstr(registered_name.data, "indexSelect")) {
-        fprintf(stderr, "[DEBUG] Inserting symbol '%.*s' copy=%u bind=%u const=%u\n",
-                (int)registered_name.size, registered_name.data,
-                symbol->parameters.copy_count, symbol->parameters.binding_count,
-                (unsigned)symbol->parameters.constant_bytes);
-      }
-#endif
       // Insert into hash table.
       const uint64_t hash =
           iree_hal_streaming_symbol_pointer_hash(symbol_host_ptr);
@@ -701,6 +909,8 @@ static iree_status_t iree_hal_streaming_context_symbol_map_prepare_module(
                 IREE_HAL_STREAMING_SYMBOL_MAP_TOMBSTONE_KEY) {
           map->entries[idx].key = symbol_host_ptr;
           map->entries[idx].symbol = symbol;
+          map->entries[idx].synchronize_managed_data_to_host =
+              synchronize_managed_data_to_host;
           ++map->count;
           break;
         }
@@ -764,6 +974,7 @@ static void iree_hal_streaming_context_symbol_map_expunge_module(
         // Found it - replace with tombstone.
         map->entries[index].key = IREE_HAL_STREAMING_SYMBOL_MAP_TOMBSTONE_KEY;
         map->entries[index].symbol = NULL;
+        map->entries[index].synchronize_managed_data_to_host = false;
         --map->count;
         break;
       } else if (map->entries[index].key ==
@@ -779,6 +990,57 @@ static void iree_hal_streaming_context_symbol_map_expunge_module(
   iree_allocator_free(map->host_allocator, module_entry);
 
   IREE_TRACE_ZONE_END(z0);
+}
+
+iree_status_t iree_hal_streaming_context_symbol_map_synchronize_managed_data(
+    iree_hal_streaming_context_symbol_map_t* map) {
+  IREE_ASSERT_ARGUMENT(map);
+
+  for (iree_hal_streaming_context_module_entry_t* module_entry = map->modules;
+       module_entry; module_entry = module_entry->next) {
+    iree_hal_streaming_module_registration_t* registration =
+        module_entry->registration;
+    for (iree_host_size_t i = 0; i < registration->symbol_count; ++i) {
+      iree_hal_streaming_symbol_registration_t* symbol_registration =
+          &registration->symbols[i];
+      if (symbol_registration->type != IREE_HAL_STREAMING_SYMBOL_TYPE_DATA) {
+        continue;
+      }
+
+      void* host_target =
+          symbol_registration->params.variable.managed_initial_value;
+      const size_t byte_length = symbol_registration->params.variable.size;
+      if (!host_target || byte_length == 0) continue;
+
+      iree_hal_streaming_context_symbol_entry_t* entry = NULL;
+      if (!iree_hal_streaming_context_symbol_map_find_entry(
+              map, symbol_registration->host_pointer, &entry) ||
+          !entry->synchronize_managed_data_to_host) {
+        continue;
+      }
+
+      iree_hal_streaming_symbol_t* symbol = entry->symbol;
+      if (!symbol || !symbol->global_buffer || !symbol->global_buffer->buffer) {
+        return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                                "managed symbol `%s` has no HAL buffer",
+                                symbol_registration->device_name);
+      }
+      if (byte_length > (size_t)symbol->size_bytes) {
+        return iree_make_status(
+            IREE_STATUS_OUT_OF_RANGE,
+            "managed symbol `%s` is too small (%zu requested, %" PRIu64
+            " available)",
+            symbol_registration->device_name, byte_length,
+            (uint64_t)symbol->size_bytes);
+      }
+
+      IREE_RETURN_IF_ERROR(iree_hal_device_transfer_d2h(
+          map->context->device, symbol->global_buffer->buffer,
+          /*source_offset=*/0, host_target, byte_length,
+          IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout()));
+    }
+  }
+  return iree_ok_status();
 }
 
 iree_status_t iree_hal_streaming_context_symbol_map_lookup(
@@ -802,16 +1064,6 @@ iree_status_t iree_hal_streaming_context_symbol_map_lookup(
     const void* entry_key = map->entries[index].key;
     if (entry_key == host_pointer) {
       *out_symbol = map->entries[index].symbol;  // hit
-#if 0
-      // Debug: check if this is an indexSelect kernel by looking at name
-      if ((*out_symbol)->name.data && strstr((*out_symbol)->name.data, "indexSelect")) {
-        fprintf(stderr, "[DEBUG_FAST] Found indexSelect: copy=%u bind=%u const=%u name=%.*s\n",
-                (*out_symbol)->parameters.copy_count, (*out_symbol)->parameters.binding_count,
-                (unsigned)(*out_symbol)->parameters.constant_bytes,
-                (int)((*out_symbol)->name.size > 80 ? 80 : (*out_symbol)->name.size),
-                (*out_symbol)->name.data);
-      }
-#endif
       return iree_ok_status();
     } else if (entry_key == IREE_HAL_STREAMING_SYMBOL_MAP_EMPTY_KEY) {
       break;  // not found in local map
@@ -847,13 +1099,6 @@ iree_status_t iree_hal_streaming_context_symbol_map_lookup(
     const void* entry_key = map->entries[index].key;
     if (entry_key == host_pointer) {
       *out_symbol = map->entries[index].symbol;  // hit
-#if 0
-      if (strstr(registration->device_name, "indexSelect")) {
-        fprintf(stderr, "[DEBUG] Found indexSelect in hash: copy=%u bind=%u const=%u\n",
-                (*out_symbol)->parameters.copy_count, (*out_symbol)->parameters.binding_count,
-                (unsigned)(*out_symbol)->parameters.constant_bytes);
-      }
-#endif
       return iree_ok_status();
     } else if (entry_key == IREE_HAL_STREAMING_SYMBOL_MAP_EMPTY_KEY) {
       break;  // still not found (shouldn't happen)

--- a/libhrx/src/binding/common/rocm_hostcall.c
+++ b/libhrx/src/binding/common/rocm_hostcall.c
@@ -1,0 +1,889 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <limits.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <wchar.h>
+
+#include "common/internal.h"
+#include "common/printf_format.h"
+#include "iree/base/internal/atomics.h"
+#include "iree/base/threading/thread.h"
+
+#define IREE_HAL_STREAMING_HOSTCALL_SERVICE_FUNCTION_CALL 1u
+#define IREE_HAL_STREAMING_HOSTCALL_SERVICE_PRINTF 2u
+#define IREE_HAL_STREAMING_HOSTCALL_SERVICE_DEVMEM 3u
+#define IREE_HAL_STREAMING_HOSTCALL_SERVICE_SANITIZER 4u
+
+typedef struct iree_hal_streaming_hostcall_packet_header_t {
+  // Tagged pointer to the next packet in the intrusive stack.
+  uint64_t next;
+  // Bitmask of active lanes whose payload slots are valid.
+  uint64_t activemask;
+  // Device-library service identifier requested by the wave.
+  uint32_t service;
+  // Bit 0 is the ready flag. The device waits until the host clears it.
+  iree_atomic_uint32_t control;
+} iree_hal_streaming_hostcall_packet_header_t;
+
+typedef struct iree_hal_streaming_hostcall_payload_t {
+  // One eight-qword argument/return slot for each possible wave lane.
+  uint64_t slots[64][8];
+} iree_hal_streaming_hostcall_payload_t;
+
+typedef struct iree_hal_streaming_hostcall_buffer_header_t {
+  // Device address of the packet header array.
+  uint64_t headers;
+  // Device address of the packet payload array.
+  uint64_t payloads;
+  // HSA signal handle used by the device to notify the listener.
+  uint64_t doorbell;
+  // Tagged stack of packets available to device waves.
+  uint64_t free_stack;
+  // Tagged stack of packets awaiting host processing.
+  iree_atomic_uint64_t ready_stack;
+  // Mask used to extract packet indexes from tagged stack pointers.
+  uint64_t index_mask;
+} iree_hal_streaming_hostcall_buffer_header_t;
+
+typedef struct iree_hal_streaming_hostcall_message_t {
+  // Accumulated qword payload for one in-flight device-library message.
+  uint64_t* data;
+  // Number of qwords currently accumulated in |data|.
+  iree_host_size_t count;
+  // Capacity of |data| in qwords.
+  iree_host_size_t capacity;
+  // True while this message ID is active.
+  bool live;
+} iree_hal_streaming_hostcall_message_t;
+
+typedef struct iree_hal_streaming_hostcall_message_table_t {
+  // Indexed message table. Device descriptors carry the table index.
+  iree_hal_streaming_hostcall_message_t* messages;
+  // Number of entries in |messages|.
+  iree_host_size_t count;
+  // Capacity of |messages|.
+  iree_host_size_t capacity;
+  // Allocator used for table and message payload storage.
+  iree_allocator_t host_allocator;
+} iree_hal_streaming_hostcall_message_table_t;
+
+typedef struct iree_hal_streaming_rocm_hostcall_service_t {
+  // Driver-owned notification used to wake the hostcall listener.
+  iree_hal_host_notification_t* notification;
+  // Queue-visible hostcall buffer.
+  iree_hal_streaming_buffer_t* buffer;
+  // Host view of |buffer|'s ABI header.
+  iree_hal_streaming_hostcall_buffer_header_t* hostcall_buffer;
+  // Host view of the packet header array.
+  iree_hal_streaming_hostcall_packet_header_t* packet_headers;
+  // Host view of the packet payload array.
+  iree_hal_streaming_hostcall_payload_t* packet_payloads;
+  // Listener thread that processes packets while kernels are running.
+  iree_thread_t* listener_thread;
+  // Non-zero after shutdown requests the listener to exit.
+  iree_atomic_int32_t stop_requested;
+  // Accumulated device-library printf messages.
+  iree_hal_streaming_hostcall_message_table_t messages;
+  // Host allocator used for the service object and dynamic message storage.
+  iree_allocator_t host_allocator;
+} iree_hal_streaming_rocm_hostcall_service_t;
+
+static_assert(sizeof(iree_atomic_uint32_t) == sizeof(uint32_t),
+              "hostcall control field must remain a 32-bit ABI field");
+static_assert(sizeof(iree_atomic_uint64_t) == sizeof(uint64_t),
+              "hostcall ready stack field must remain a 64-bit ABI field");
+
+static iree_host_size_t iree_hal_streaming_hostcall_align(
+    iree_host_size_t value, iree_host_size_t alignment) {
+  return (value + alignment - 1) & ~(alignment - 1);
+}
+
+iree_status_t iree_hal_streaming_rocm_hostcall_calculate_packet_count(
+    const iree_hal_streaming_device_t* device, uint32_t* out_packet_count) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_ASSERT_ARGUMENT(out_packet_count);
+  *out_packet_count = 0;
+
+  if (IREE_UNLIKELY(device->raw_compute_unit_count == 0 ||
+                    device->maximum_resident_subgroup_count == 0)) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "hostcall sizing requires physical compute-unit and resident-wave "
+        "limits");
+  }
+
+  // One packet is required for every wave that can be resident on the queue.
+  // The raw execution properties deliberately remain separate from HIP's
+  // compatibility-adjusted public device attributes.
+  const uint64_t minimum_packet_count =
+      (uint64_t)device->raw_compute_unit_count *
+      device->maximum_resident_subgroup_count;
+  if (IREE_UNLIKELY(minimum_packet_count > UINT32_MAX)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "hostcall packet count exceeds ABI range");
+  }
+
+  // Tagged stack pointers encode the packet index with a bitmask. Round up so
+  // the allocated table covers every representable index selected by that mask.
+  uint32_t packet_count = 2;
+  while (packet_count < minimum_packet_count) {
+    if (IREE_UNLIKELY(packet_count > UINT32_MAX / 2)) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "hostcall packet count exceeds ABI range");
+    }
+    packet_count *= 2;
+  }
+
+  *out_packet_count = packet_count;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_hostcall_buffer_layout(
+    uint32_t packet_count, iree_host_size_t* out_headers_offset,
+    iree_host_size_t* out_payloads_offset, iree_host_size_t* out_total_size) {
+  if (IREE_UNLIKELY(packet_count == 0 ||
+                    (packet_count & (packet_count - 1)) != 0)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "hostcall packet count must be a non-zero power of two");
+  }
+
+  iree_host_size_t headers_offset = iree_hal_streaming_hostcall_align(
+      sizeof(iree_hal_streaming_hostcall_buffer_header_t),
+      iree_alignof(iree_hal_streaming_hostcall_packet_header_t));
+  iree_host_size_t headers_size = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+          packet_count, sizeof(iree_hal_streaming_hostcall_packet_header_t),
+          &headers_size))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "hostcall packet header table size overflow");
+  }
+  iree_host_size_t headers_end = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_add(headers_offset, headers_size,
+                                                &headers_end))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "hostcall packet header table range overflow");
+  }
+
+  iree_host_size_t payloads_offset = iree_hal_streaming_hostcall_align(
+      headers_end, iree_alignof(iree_hal_streaming_hostcall_payload_t));
+  iree_host_size_t payloads_size = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+          packet_count, sizeof(iree_hal_streaming_hostcall_payload_t),
+          &payloads_size))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "hostcall packet payload table size overflow");
+  }
+  iree_host_size_t total_size = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_add(payloads_offset, payloads_size,
+                                                &total_size))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "hostcall buffer size overflow");
+  }
+
+  *out_headers_offset = headers_offset;
+  *out_payloads_offset = payloads_offset;
+  *out_total_size = total_size;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_hostcall_message_table_initialize(
+    iree_allocator_t host_allocator,
+    iree_hal_streaming_hostcall_message_table_t* out_table) {
+  memset(out_table, 0, sizeof(*out_table));
+  out_table->host_allocator = host_allocator;
+  return iree_ok_status();
+}
+
+static void iree_hal_streaming_hostcall_message_table_deinitialize(
+    iree_hal_streaming_hostcall_message_table_t* table) {
+  for (iree_host_size_t i = 0; i < table->count; ++i) {
+    iree_allocator_free(table->host_allocator, table->messages[i].data);
+  }
+  iree_allocator_free(table->host_allocator, table->messages);
+  memset(table, 0, sizeof(*table));
+}
+
+static iree_status_t iree_hal_streaming_hostcall_message_table_grow(
+    iree_hal_streaming_hostcall_message_table_t* table,
+    iree_host_size_t minimum_capacity) {
+  if (table->capacity >= minimum_capacity) return iree_ok_status();
+  iree_host_size_t new_capacity = table->capacity ? table->capacity * 2 : 16;
+  while (new_capacity < minimum_capacity) new_capacity *= 2;
+  iree_host_size_t allocation_size = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+          new_capacity, sizeof(table->messages[0]), &allocation_size))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "hostcall message table size overflow");
+  }
+  const iree_host_size_t old_capacity = table->capacity;
+  IREE_RETURN_IF_ERROR(iree_allocator_realloc(
+      table->host_allocator, allocation_size, (void**)&table->messages));
+  memset(table->messages + old_capacity, 0,
+         (new_capacity - old_capacity) * sizeof(table->messages[0]));
+  table->capacity = new_capacity;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_hostcall_message_allocate(
+    iree_hal_streaming_hostcall_message_table_t* table,
+    uint64_t* out_message_id,
+    iree_hal_streaming_hostcall_message_t** out_message) {
+  for (iree_host_size_t i = 0; i < table->count; ++i) {
+    iree_hal_streaming_hostcall_message_t* message = &table->messages[i];
+    if (message->live) continue;
+    message->count = 0;
+    message->live = true;
+    *out_message_id = i;
+    *out_message = message;
+    return iree_ok_status();
+  }
+
+  IREE_RETURN_IF_ERROR(
+      iree_hal_streaming_hostcall_message_table_grow(table, table->count + 1));
+  iree_hal_streaming_hostcall_message_t* message =
+      &table->messages[table->count];
+  message->count = 0;
+  message->live = true;
+  *out_message_id = table->count++;
+  *out_message = message;
+  return iree_ok_status();
+}
+
+static iree_hal_streaming_hostcall_message_t*
+iree_hal_streaming_hostcall_message_lookup(
+    iree_hal_streaming_hostcall_message_table_t* table, uint64_t message_id) {
+  if (message_id >= table->count) return NULL;
+  iree_hal_streaming_hostcall_message_t* message = &table->messages[message_id];
+  return message->live ? message : NULL;
+}
+
+static iree_status_t iree_hal_streaming_hostcall_message_append(
+    iree_hal_streaming_hostcall_message_table_t* table,
+    iree_hal_streaming_hostcall_message_t* message, const uint64_t* data,
+    iree_host_size_t count) {
+  if (count == 0) return iree_ok_status();
+  iree_host_size_t required_count = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_add(message->count, count,
+                                                &required_count))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "hostcall message length overflow");
+  }
+  if (message->capacity < required_count) {
+    iree_host_size_t new_capacity =
+        message->capacity ? message->capacity * 2 : 16;
+    while (new_capacity < required_count) new_capacity *= 2;
+    iree_host_size_t allocation_size = 0;
+    if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+            new_capacity, sizeof(message->data[0]), &allocation_size))) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "hostcall message storage size overflow");
+    }
+    IREE_RETURN_IF_ERROR(iree_allocator_realloc(
+        table->host_allocator, allocation_size, (void**)&message->data));
+    message->capacity = new_capacity;
+  }
+  memcpy(message->data + message->count, data, count * sizeof(data[0]));
+  message->count = required_count;
+  return iree_ok_status();
+}
+
+static void iree_hal_streaming_hostcall_message_discard(
+    iree_hal_streaming_hostcall_message_t* message) {
+  message->count = 0;
+  message->live = false;
+}
+
+static uint64_t iree_hal_streaming_hostcall_descriptor_field(uint64_t value,
+                                                             uint32_t offset,
+                                                             uint32_t width) {
+  return (value >> offset) & ((1ull << width) - 1);
+}
+
+static uint64_t iree_hal_streaming_hostcall_descriptor_set_field(
+    uint64_t descriptor, uint64_t value, uint32_t offset, uint32_t width) {
+  const uint64_t reset_mask = ~(((1ull << width) - 1) << offset);
+  return (descriptor & reset_mask) | (value << offset);
+}
+
+static iree_host_size_t iree_hal_streaming_hostcall_strnlen(
+    const char* data, iree_host_size_t data_length) {
+  iree_host_size_t length = 0;
+  while (length < data_length && data[length] != '\0') ++length;
+  return length;
+}
+
+static bool iree_hal_streaming_hostcall_printf_write(FILE* stream,
+                                                     int* out_count,
+                                                     const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  const int result = vfprintf(stream, format, args);
+  va_end(args);
+  if (result < 0) {
+    *out_count = result;
+    return false;
+  }
+  if (*out_count <= INT32_MAX - result) {
+    *out_count += result;
+  } else {
+    *out_count = INT32_MAX;
+  }
+  return true;
+}
+
+static bool iree_hal_streaming_hostcall_printf_write_bytes(
+    FILE* stream, int* out_count, const char* data, iree_host_size_t length) {
+  if (length == 0) return true;
+  if (IREE_UNLIKELY(length > (iree_host_size_t)INT32_MAX)) {
+    *out_count = -1;
+    return false;
+  }
+  if (fwrite(data, 1, length, stream) != length) {
+    *out_count = -1;
+    return false;
+  }
+  if (*out_count <= INT32_MAX - (int)length) {
+    *out_count += (int)length;
+  } else {
+    *out_count = INT32_MAX;
+  }
+  return true;
+}
+
+static const uint64_t* iree_hal_streaming_hostcall_printf_process_spec(
+    FILE* stream, int* out_count, const char* spec_begin,
+    iree_host_size_t spec_length, const uint64_t* argument,
+    const uint64_t* argument_end) {
+  if (IREE_UNLIKELY(spec_length >= 128)) return NULL;
+  char spec[128];
+  memcpy(spec, spec_begin, spec_length);
+  spec[spec_length] = '\0';
+
+  iree_hal_streaming_printf_spec_t parsed_spec;
+  if (IREE_UNLIKELY(!iree_hal_streaming_printf_parse_spec(spec, spec_length,
+                                                          &parsed_spec))) {
+    return NULL;
+  }
+  const int star_count = parsed_spec.star_count;
+  if (IREE_UNLIKELY(argument_end - argument < star_count)) return NULL;
+  int star0 = 0;
+  int star1 = 0;
+  if (star_count >= 1) star0 = (int)*argument++;
+  if (star_count >= 2) star1 = (int)*argument++;
+
+  if (argument == argument_end) return NULL;
+
+#define IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value)                         \
+  do {                                                                         \
+    if (star_count == 0) {                                                     \
+      iree_hal_streaming_hostcall_printf_write(stream, out_count, spec,        \
+                                               value);                         \
+    } else if (star_count == 1) {                                              \
+      iree_hal_streaming_hostcall_printf_write(stream, out_count, spec, star0, \
+                                               value);                         \
+    } else {                                                                   \
+      iree_hal_streaming_hostcall_printf_write(stream, out_count, spec, star0, \
+                                               star1, value);                  \
+    }                                                                          \
+  } while (0)
+
+  switch (parsed_spec.conversion) {
+    case 'd':
+    case 'i':
+    case 'o':
+    case 'u':
+    case 'x':
+    case 'X': {
+      const uint64_t raw_value = *argument++;
+      if (parsed_spec.is_signed_integer) {
+        switch (parsed_spec.length_modifier) {
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_DEFAULT:
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_H:
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_HH: {
+            const int value = (int)raw_value;
+            IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_L: {
+            const long value = (long)raw_value;
+            IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_LL: {
+            const long long value = (long long)raw_value;
+            IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_J: {
+            const intmax_t value = (intmax_t)raw_value;
+            IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_Z: {
+            const iree_hal_streaming_printf_signed_size_t value =
+                (iree_hal_streaming_printf_signed_size_t)raw_value;
+            IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_T: {
+            const ptrdiff_t value = (ptrdiff_t)raw_value;
+            IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+            break;
+          }
+        }
+      } else {
+        switch (parsed_spec.length_modifier) {
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_DEFAULT:
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_H:
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_HH: {
+            const unsigned int value = (unsigned int)raw_value;
+            IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_L: {
+            const unsigned long value = (unsigned long)raw_value;
+            IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_LL: {
+            const unsigned long long value = (unsigned long long)raw_value;
+            IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_J: {
+            const uintmax_t value = (uintmax_t)raw_value;
+            IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_Z: {
+            const size_t value = (size_t)raw_value;
+            IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+            break;
+          }
+          case IREE_HAL_STREAMING_PRINTF_LENGTH_T: {
+            const iree_hal_streaming_printf_unsigned_ptrdiff_t value =
+                (iree_hal_streaming_printf_unsigned_ptrdiff_t)raw_value;
+            IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+            break;
+          }
+        }
+      }
+      break;
+    }
+    case 'c': {
+      if (parsed_spec.is_wide_character) {
+        const wint_t value = (wint_t)*argument++;
+        IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+      } else {
+        const int value = (int)*argument++;
+        IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+      }
+      break;
+    }
+    case 'f':
+    case 'F':
+    case 'e':
+    case 'E':
+    case 'g':
+    case 'G':
+    case 'a':
+    case 'A': {
+      double value = 0;
+      memcpy(&value, argument, sizeof(value));
+      ++argument;
+      IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+      break;
+    }
+    case 's': {
+      const char* value = (const char*)argument;
+      const iree_host_size_t available_bytes =
+          (iree_host_size_t)(argument_end - argument) * sizeof(uint64_t);
+      const iree_host_size_t string_length =
+          iree_hal_streaming_hostcall_strnlen(value, available_bytes);
+      if (IREE_UNLIKELY(string_length == available_bytes)) return NULL;
+      IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+      argument += (string_length + 1 + 7) / 8;
+      break;
+    }
+    case 'p': {
+      void* value = (void*)(uintptr_t)*argument++;
+      IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL(value);
+      break;
+    }
+    default:
+      return NULL;
+  }
+
+#undef IREE_HAL_STREAMING_HOSTCALL_PRINTF_CALL
+
+  return argument;
+}
+
+static int iree_hal_streaming_hostcall_printf_format(FILE* stream,
+                                                     const uint64_t* begin,
+                                                     const uint64_t* end) {
+  if (begin >= end) return -1;
+  const char* format = (const char*)begin;
+  const iree_host_size_t available_bytes =
+      (iree_host_size_t)(end - begin) * sizeof(uint64_t);
+  const iree_host_size_t format_length =
+      iree_hal_streaming_hostcall_strnlen(format, available_bytes);
+  if (format_length == available_bytes) return -1;
+
+  const uint64_t* argument = begin + ((format_length + 1 + 7) / 8);
+  int out_count = 0;
+  iree_host_size_t cursor = 0;
+  while (cursor < format_length) {
+    const char* percent = memchr(format + cursor, '%', format_length - cursor);
+    if (!percent) {
+      iree_hal_streaming_hostcall_printf_write_bytes(
+          stream, &out_count, format + cursor, format_length - cursor);
+      break;
+    }
+
+    const iree_host_size_t percent_offset =
+        (iree_host_size_t)(percent - format);
+    if (!iree_hal_streaming_hostcall_printf_write_bytes(
+            stream, &out_count, format + cursor, percent_offset - cursor)) {
+      break;
+    }
+
+    iree_host_size_t spec_end = percent_offset + 1;
+    if (spec_end < format_length && format[spec_end] == '%') {
+      if (!iree_hal_streaming_hostcall_printf_write_bytes(stream, &out_count,
+                                                          "%", 1)) {
+        break;
+      }
+      cursor = spec_end + 1;
+      continue;
+    }
+
+    static const char kConversionSpecifiers[] = "diouxXfFeEgGaAcspn";
+    while (spec_end < format_length &&
+           !strchr(kConversionSpecifiers, format[spec_end])) {
+      ++spec_end;
+    }
+    if (spec_end == format_length) break;
+    ++spec_end;
+
+    argument = iree_hal_streaming_hostcall_printf_process_spec(
+        stream, &out_count, percent, spec_end - percent_offset, argument, end);
+    if (out_count < 0 || !argument) break;
+    cursor = spec_end;
+  }
+  return out_count;
+}
+
+static bool iree_hal_streaming_hostcall_handle_printf(
+    iree_hal_streaming_hostcall_message_table_t* table, uint64_t* payload) {
+  enum {
+    kDescriptorOffsetBegin = 0,
+    kDescriptorOffsetEnd = 1,
+    kDescriptorOffsetReserved = 2,
+    kDescriptorOffsetLength = 5,
+    kDescriptorOffsetId = 8,
+  };
+
+  uint64_t descriptor = payload[0];
+  const bool begin = iree_hal_streaming_hostcall_descriptor_field(
+                         descriptor, kDescriptorOffsetBegin, 1) != 0;
+  const bool end = iree_hal_streaming_hostcall_descriptor_field(
+                       descriptor, kDescriptorOffsetEnd, 1) != 0;
+  const uint64_t reserved = iree_hal_streaming_hostcall_descriptor_field(
+      descriptor, kDescriptorOffsetReserved, 3);
+  const uint64_t length = iree_hal_streaming_hostcall_descriptor_field(
+      descriptor, kDescriptorOffsetLength, 3);
+  if (IREE_UNLIKELY(reserved != 0)) {
+    payload[0] = (uint64_t)-1;
+    return false;
+  }
+
+  iree_hal_streaming_hostcall_message_t* message = NULL;
+  if (begin) {
+    uint64_t message_id = 0;
+    if (!iree_status_is_ok(iree_hal_streaming_hostcall_message_allocate(
+            table, &message_id, &message))) {
+      payload[0] = (uint64_t)-1;
+      return false;
+    }
+    descriptor &= ~(1ull << kDescriptorOffsetBegin);
+    descriptor = iree_hal_streaming_hostcall_descriptor_set_field(
+        descriptor, message_id, kDescriptorOffsetId, 56);
+    payload[0] = descriptor;
+  } else {
+    const uint64_t message_id = iree_hal_streaming_hostcall_descriptor_field(
+        descriptor, kDescriptorOffsetId, 56);
+    message = iree_hal_streaming_hostcall_message_lookup(table, message_id);
+    if (!message) {
+      payload[0] = (uint64_t)-1;
+      return false;
+    }
+  }
+
+  if (!iree_status_is_ok(iree_hal_streaming_hostcall_message_append(
+          table, message, payload + 1, (iree_host_size_t)length))) {
+    payload[0] = (uint64_t)-1;
+    return false;
+  }
+
+  if (!end) return true;
+
+  if (message->count == 0) {
+    payload[0] = (uint64_t)-1;
+    iree_hal_streaming_hostcall_message_discard(message);
+    return false;
+  }
+
+  const uint64_t control = message->data[0];
+  FILE* stream = (control & 1u) ? stderr : stdout;
+  if (control & ~1ull) {
+    payload[0] = (uint64_t)-1;
+    iree_hal_streaming_hostcall_message_discard(message);
+    return false;
+  }
+  const int result = iree_hal_streaming_hostcall_printf_format(
+      stream, message->data + 1, message->data + message->count);
+  fflush(stream);
+  payload[0] = (uint64_t)(int64_t)result;
+  payload[1] = 0;
+  iree_hal_streaming_hostcall_message_discard(message);
+  return result >= 0;
+}
+
+static void iree_hal_streaming_hostcall_complete_unsupported(
+    uint32_t service, uint64_t* payload) {
+  switch (service) {
+    case IREE_HAL_STREAMING_HOSTCALL_SERVICE_FUNCTION_CALL:
+    case IREE_HAL_STREAMING_HOSTCALL_SERVICE_DEVMEM:
+    case IREE_HAL_STREAMING_HOSTCALL_SERVICE_SANITIZER:
+      payload[0] = 0;
+      payload[1] = 0;
+      return;
+    default:
+      payload[0] = (uint64_t)-1;
+      payload[1] = 0;
+      return;
+  }
+}
+
+static void iree_hal_streaming_hostcall_process_payload(
+    iree_hal_streaming_rocm_hostcall_service_t* service, uint32_t service_id,
+    uint64_t* payload) {
+  if (service_id == IREE_HAL_STREAMING_HOSTCALL_SERVICE_PRINTF) {
+    (void)iree_hal_streaming_hostcall_handle_printf(&service->messages,
+                                                    payload);
+    return;
+  }
+  iree_hal_streaming_hostcall_complete_unsupported(service_id, payload);
+}
+
+static void iree_hal_streaming_hostcall_process_packets(
+    iree_hal_streaming_rocm_hostcall_service_t* service) {
+  uint64_t ready_stack = iree_atomic_exchange(
+      &service->hostcall_buffer->ready_stack, 0, iree_memory_order_acquire);
+  for (uint64_t iter = ready_stack, next = 0; iter != 0; iter = next) {
+    const uint64_t packet_index = iter & service->hostcall_buffer->index_mask;
+    iree_hal_streaming_hostcall_packet_header_t* header =
+        &service->packet_headers[packet_index];
+    next = header->next;
+
+    uint64_t activemask = header->activemask;
+    while (activemask != 0) {
+      const int lane = __builtin_ctzll(activemask);
+      activemask &= ~(1ull << lane);
+      iree_hal_streaming_hostcall_process_payload(
+          service, header->service,
+          service->packet_payloads[packet_index].slots[lane]);
+    }
+
+    const uint32_t control =
+        iree_atomic_load(&header->control, iree_memory_order_relaxed);
+    iree_atomic_store(&header->control, control & ~1u,
+                      iree_memory_order_release);
+  }
+}
+
+static int iree_hal_streaming_hostcall_listener_main(void* user_data) {
+  iree_hal_streaming_rocm_hostcall_service_t* service =
+      (iree_hal_streaming_rocm_hostcall_service_t*)user_data;
+  uint64_t signal_value = IREE_HAL_HOST_NOTIFICATION_INITIAL_VALUE;
+  while (
+      !iree_atomic_load(&service->stop_requested, iree_memory_order_acquire)) {
+    const uint64_t new_value =
+        iree_hal_host_notification_wait(service->notification, signal_value);
+    if (iree_atomic_load(&service->stop_requested, iree_memory_order_acquire)) {
+      break;
+    }
+    if (new_value == signal_value) continue;
+    signal_value = new_value;
+    iree_hal_streaming_hostcall_process_packets(service);
+  }
+  return 0;
+}
+
+static void iree_hal_streaming_hostcall_buffer_initialize(
+    iree_hal_streaming_buffer_t* buffer, uint64_t doorbell_token,
+    uint32_t packet_count, iree_host_size_t headers_offset,
+    iree_host_size_t payloads_offset,
+    iree_hal_streaming_rocm_hostcall_service_t* service) {
+  service->hostcall_buffer =
+      (iree_hal_streaming_hostcall_buffer_header_t*)buffer->host_ptr;
+  service->packet_headers =
+      (iree_hal_streaming_hostcall_packet_header_t*)((uint8_t*)
+                                                         buffer->host_ptr +
+                                                     headers_offset);
+  service->packet_payloads =
+      (iree_hal_streaming_hostcall_payload_t*)((uint8_t*)buffer->host_ptr +
+                                               payloads_offset);
+
+  service->hostcall_buffer->headers = buffer->device_ptr + headers_offset;
+  service->hostcall_buffer->payloads = buffer->device_ptr + payloads_offset;
+  service->hostcall_buffer->doorbell = doorbell_token;
+  service->hostcall_buffer->index_mask = packet_count - 1;
+  iree_atomic_store(&service->hostcall_buffer->ready_stack, 0,
+                    iree_memory_order_relaxed);
+
+  uint64_t next = service->hostcall_buffer->index_mask + 1;
+  service->packet_headers[0].next = 0;
+  for (uint32_t i = 1; i < packet_count; ++i) {
+    service->packet_headers[i].next = next;
+    next = i;
+  }
+  service->hostcall_buffer->free_stack = next;
+}
+
+static void iree_hal_streaming_rocm_hostcall_service_destroy(
+    iree_hal_streaming_rocm_hostcall_service_t* service) {
+  if (!service) return;
+  if (service->listener_thread) {
+    iree_atomic_store(&service->stop_requested, 1, iree_memory_order_release);
+    iree_hal_host_notification_wake(service->notification);
+    iree_thread_join(service->listener_thread);
+    iree_thread_release(service->listener_thread);
+  }
+  iree_hal_host_notification_release(service->notification);
+  iree_hal_streaming_memory_release_transient_buffer(service->buffer);
+  iree_hal_streaming_hostcall_message_table_deinitialize(&service->messages);
+  iree_allocator_free(service->host_allocator, service);
+}
+
+static iree_status_t iree_hal_streaming_rocm_hostcall_service_create(
+    iree_hal_streaming_context_t* context,
+    iree_hal_streaming_rocm_hostcall_service_t** out_service) {
+  *out_service = NULL;
+
+  iree_hal_streaming_rocm_hostcall_service_t* service = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+      context->host_allocator, sizeof(*service), (void**)&service));
+  memset(service, 0, sizeof(*service));
+  service->host_allocator = context->host_allocator;
+  iree_atomic_store(&service->stop_requested, 0, iree_memory_order_relaxed);
+  iree_status_t status = iree_hal_streaming_hostcall_message_table_initialize(
+      context->host_allocator, &service->messages);
+
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_host_notification_create(context->device,
+                                               &service->notification);
+  }
+
+  iree_host_size_t headers_offset = 0;
+  iree_host_size_t payloads_offset = 0;
+  iree_host_size_t buffer_size = 0;
+  uint32_t packet_count = 0;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_rocm_hostcall_calculate_packet_count(
+        context->device_entry, &packet_count);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_hostcall_buffer_layout(
+        packet_count, &headers_offset, &payloads_offset, &buffer_size);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_memory_allocate_context_runtime_host(
+        context, buffer_size, &service->buffer);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_hal_streaming_hostcall_buffer_initialize(
+        service->buffer,
+        iree_hal_host_notification_device_token(service->notification),
+        packet_count, headers_offset, payloads_offset, service);
+  }
+
+  if (iree_status_is_ok(status)) {
+    // Hostcall is a live rendezvous: device-library code can wait inside the
+    // dispatch until the host clears packet ready bits. A stream callback
+    // queued after the dispatch would run too late, so the listener must exist
+    // before kernels receive the hidden hostcall buffer pointer.
+    const iree_thread_create_params_t thread_params = {
+        .name = IREE_SV("hrx-hostcall"),
+        .priority_class = IREE_THREAD_PRIORITY_CLASS_HIGH,
+    };
+    status = iree_thread_create(iree_hal_streaming_hostcall_listener_main,
+                                service, thread_params, context->host_allocator,
+                                &service->listener_thread);
+  }
+
+  if (iree_status_is_ok(status)) {
+    *out_service = service;
+  } else {
+    iree_hal_streaming_rocm_hostcall_service_destroy(service);
+  }
+  return status;
+}
+
+iree_status_t iree_hal_streaming_context_rocm_hostcall_buffer(
+    iree_hal_streaming_context_t* context, uint64_t* out_buffer_device_ptr) {
+  IREE_ASSERT_ARGUMENT(context);
+  IREE_ASSERT_ARGUMENT(out_buffer_device_ptr);
+  *out_buffer_device_ptr = 0;
+
+  if (IREE_UNLIKELY(!context->device_entry->host_native_atomic_supported)) {
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "ROCm hostcall requires native host/device atomic support");
+  }
+
+  const uint64_t cached_buffer_device_ptr =
+      iree_hal_streaming_context_cached_rocm_hostcall_buffer(context);
+  if (cached_buffer_device_ptr != 0) {
+    *out_buffer_device_ptr = cached_buffer_device_ptr;
+    return iree_ok_status();
+  }
+
+  iree_slim_mutex_lock(&context->mutex);
+  iree_status_t status = iree_ok_status();
+  if (!context->rocm_device_runtime.hostcall_service) {
+    status = iree_hal_streaming_rocm_hostcall_service_create(
+        context, &context->rocm_device_runtime.hostcall_service);
+  }
+  if (iree_status_is_ok(status)) {
+    *out_buffer_device_ptr =
+        context->rocm_device_runtime.hostcall_service->buffer->device_ptr;
+    iree_atomic_store(&context->rocm_device_runtime.hostcall_buffer_device_ptr,
+                      *out_buffer_device_ptr, iree_memory_order_release);
+  }
+  iree_slim_mutex_unlock(&context->mutex);
+  return status;
+}
+
+void iree_hal_streaming_context_deinitialize_rocm_hostcall_service(
+    iree_hal_streaming_context_t* context) {
+  IREE_ASSERT_ARGUMENT(context);
+  iree_slim_mutex_lock(&context->mutex);
+  iree_hal_streaming_rocm_hostcall_service_t* service =
+      context->rocm_device_runtime.hostcall_service;
+  context->rocm_device_runtime.hostcall_service = NULL;
+  iree_atomic_store(&context->rocm_device_runtime.hostcall_buffer_device_ptr, 0,
+                    iree_memory_order_release);
+  iree_slim_mutex_unlock(&context->mutex);
+  iree_hal_streaming_rocm_hostcall_service_destroy(service);
+}

--- a/libhrx/src/binding/common/rocm_hostcall_test.cc
+++ b/libhrx/src/binding/common/rocm_hostcall_test.cc
@@ -1,0 +1,75 @@
+// Copyright 2026 The HRX Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+
+#include "common/internal.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+TEST(RocmHostcallTest, RoundsResidentWavesToPowerOfTwo) {
+  iree_hal_streaming_device_t device = {};
+  device.raw_compute_unit_count = 304;
+  device.maximum_resident_subgroup_count = 32;
+
+  uint32_t packet_count = 0;
+  IREE_ASSERT_OK(iree_hal_streaming_rocm_hostcall_calculate_packet_count(
+      &device, &packet_count));
+  EXPECT_EQ(16384u, packet_count);
+}
+
+TEST(RocmHostcallTest, UsesUnadjustedPhysicalProperties) {
+  iree_hal_streaming_device_t device = {};
+  device.raw_compute_unit_count = 60;
+  device.maximum_resident_subgroup_count = 64;
+  device.multiprocessor_count = 30;
+  device.warp_size = 32;
+
+  uint32_t packet_count = 0;
+  IREE_ASSERT_OK(iree_hal_streaming_rocm_hostcall_calculate_packet_count(
+      &device, &packet_count));
+  EXPECT_EQ(4096u, packet_count);
+}
+
+TEST(RocmHostcallTest, RejectsIncompletePhysicalProperties) {
+  iree_hal_streaming_device_t device = {};
+  uint32_t packet_count = 123;
+
+  iree_status_t status =
+      iree_hal_streaming_rocm_hostcall_calculate_packet_count(&device,
+                                                              &packet_count);
+  EXPECT_EQ(IREE_STATUS_FAILED_PRECONDITION, iree_status_code(status));
+  iree_status_ignore(status);
+  EXPECT_EQ(0u, packet_count);
+}
+
+TEST(RocmHostcallTest, RejectsUnsupportedHostAtomicsBeforeServiceCreation) {
+  iree_hal_streaming_device_t device = {};
+  iree_hal_streaming_context_t context = {};
+  context.device_entry = &device;
+
+  uint64_t buffer_device_ptr = UINT64_C(1);
+  iree_status_t status = iree_hal_streaming_context_rocm_hostcall_buffer(
+      &context, &buffer_device_ptr);
+  EXPECT_EQ(IREE_STATUS_UNIMPLEMENTED, iree_status_code(status));
+  iree_status_ignore(status);
+  EXPECT_EQ(0u, buffer_device_ptr);
+}
+
+TEST(RocmHostcallTest, ReturnsPublishedServiceBufferWithoutContextLock) {
+  iree_hal_streaming_device_t device = {};
+  device.host_native_atomic_supported = true;
+  iree_hal_streaming_context_t context = {};
+  context.device_entry = &device;
+  iree_atomic_store(&context.rocm_device_runtime.hostcall_buffer_device_ptr,
+                    UINT64_C(0x123456789ABCDEF0), iree_memory_order_release);
+
+  uint64_t buffer_device_ptr = 0;
+  IREE_ASSERT_OK(iree_hal_streaming_context_rocm_hostcall_buffer(
+      &context, &buffer_device_ptr));
+  EXPECT_EQ(UINT64_C(0x123456789ABCDEF0), buffer_device_ptr);
+}
+
+}  // namespace

--- a/libhrx/src/binding/common/stream.c
+++ b/libhrx/src/binding/common/stream.c
@@ -452,12 +452,17 @@ iree_status_t iree_hal_streaming_stream_query(
   }
   IREE_RETURN_IF_ERROR(query_status);
 
-  if (current_value >= stream->pending_value) {
+  iree_slim_mutex_lock(&stream->mutex);
+  const uint64_t pending_value = stream->pending_value;
+  if (current_value >= pending_value) {
     *status = 0;  // Complete
-    stream->completed_value = current_value;
+    if (stream->completed_value < current_value) {
+      stream->completed_value = current_value;
+    }
   } else {
     *status = 1;  // Not complete
   }
+  iree_slim_mutex_unlock(&stream->mutex);
 
   return iree_ok_status();
 }
@@ -487,6 +492,8 @@ static iree_status_t iree_hal_streaming_stream_synchronize_impl(
     IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, flush_status);
   }
 
+  uint64_t target_value = 0;
+  uint64_t completed_value = 0;
   timing_step_ns = timing_enabled ? hrx_launch_timing_now_ns() : 0;
   uint64_t current_value = 0;
   iree_status_t query_status =
@@ -494,25 +501,28 @@ static iree_status_t iree_hal_streaming_stream_synchronize_impl(
   if (iree_status_is_unavailable(query_status)) {
     iree_status_ignore(query_status);
     query_status = iree_ok_status();
-  } else if (iree_status_is_ok(query_status)) {
-    if (current_value >= stream->pending_value) {
-      stream->completed_value = current_value;
-    }
   }
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, query_status);
+  iree_slim_mutex_lock(&stream->mutex);
+  target_value = stream->pending_value;
+  if (current_value > stream->completed_value) {
+    stream->completed_value = current_value;
+  }
+  completed_value = stream->completed_value;
+  iree_slim_mutex_unlock(&stream->mutex);
   if (timing_enabled) {
     timing_query_ns += hrx_launch_timing_now_ns() - timing_step_ns;
   }
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, query_status);
 
   // Wait for timeline semaphore to reach pending value.
-  if (stream->pending_value > stream->completed_value) {
+  if (target_value > completed_value) {
     // fprintf(stderr, "[STREAM] sync: waiting for semaphore pending=%"PRIu64"
     // completed=%"PRIu64"\n",
     //         stream->pending_value, stream->completed_value);
     timing_step_ns = timing_enabled ? hrx_launch_timing_now_ns() : 0;
     iree_status_t wait_status = iree_hal_semaphore_wait(
-        stream->timeline_semaphore, stream->pending_value,
-        iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
+        stream->timeline_semaphore, target_value, iree_infinite_timeout(),
+        IREE_ASYNC_WAIT_FLAG_NONE);
     if (timing_enabled) {
       timing_wait_ns += hrx_launch_timing_now_ns() - timing_step_ns;
     }
@@ -521,7 +531,11 @@ static iree_status_t iree_hal_streaming_stream_synchronize_impl(
       return wait_status;
     }
     // fprintf(stderr, "[STREAM] sync: wait OK\n");
-    stream->completed_value = stream->pending_value;
+    iree_slim_mutex_lock(&stream->mutex);
+    if (stream->completed_value < target_value) {
+      stream->completed_value = target_value;
+    }
+    iree_slim_mutex_unlock(&stream->mutex);
   }
 
   if (timing_enabled) {
@@ -1294,7 +1308,7 @@ iree_status_t iree_hal_streaming_launch_kernel(
   }
 
   // Create IREE dispatch config.
-  const iree_hal_dispatch_config_t config = {
+  iree_hal_dispatch_config_t config = {
       .workgroup_size =
           {
               params->block_dim[0],
@@ -1309,6 +1323,7 @@ iree_status_t iree_hal_streaming_launch_kernel(
           },
       .dynamic_workgroup_local_memory = params->shared_memory_bytes,
   };
+  iree_hal_dispatch_runtime_parameter_list_t runtime_parameters;
 
   // HIP launches use native kernarg bytes. The AMDGPU queue code still
   // populates the dispatch implicit arguments for CUSTOM_DIRECT_ARGUMENTS; this
@@ -1318,103 +1333,129 @@ iree_status_t iree_hal_streaming_launch_kernel(
           ? IREE_HAL_DISPATCH_FLAG_CUSTOM_DIRECT_ARGUMENTS
           : IREE_HAL_DISPATCH_FLAG_NONE;
 
-  uint64_t timing_step_ns = timing_enabled ? hrx_launch_timing_now_ns() : 0;
+  iree_hal_streaming_buffer_t* printf_buffer = NULL;
   iree_status_t status = iree_ok_status();
+  if (iree_hal_streaming_symbol_uses_runtime_services(symbol,
+                                                      /*enable_printf=*/true)) {
+    status = iree_hal_streaming_symbol_prepare_runtime_dispatch_config(
+        symbol, stream->context, /*enable_printf=*/true, &runtime_parameters,
+        &config, &printf_buffer);
+  }
+  if (!iree_status_is_ok(status)) {
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
+
+  uint64_t timing_step_ns = timing_enabled ? hrx_launch_timing_now_ns() : 0;
   bool should_flush = false;
-  iree_slim_mutex_lock(&stream->mutex);
-  if (dispatch_directly) {
-    uint64_t wait_value = stream->pending_value;
-    uint64_t signal_value = wait_value + 1;
-    const iree_hal_semaphore_list_t wait_semaphores = {
-        .count = wait_value > 0 ? 1 : 0,
-        .semaphores = &stream->timeline_semaphore,
-        .payload_values = &wait_value,
-    };
-    const iree_hal_semaphore_list_t signal_semaphores = {
-        .count = 1,
-        .semaphores = &stream->timeline_semaphore,
-        .payload_values = &signal_value,
-    };
-    status = iree_hal_device_queue_dispatch(
-        stream->context->device, stream->queue_affinity, wait_semaphores,
-        signal_semaphores, symbol->executable,
-        iree_hal_executable_function_from_index(symbol->export_ordinal), config,
-        iree_make_const_byte_span(constants, constants_size), binding_list,
-        flags);
-    if (iree_status_is_ok(status)) {
-      status = iree_hal_device_queue_flush(stream->context->device,
-                                           stream->queue_affinity);
-    }
-    if (iree_status_is_ok(status)) {
-      stream->pending_value = signal_value;
-      stream->submitted_value = signal_value;
-    }
-  } else {
-    uint64_t timing_begin_step_ns =
-        timing_enabled ? hrx_launch_timing_now_ns() : 0;
-    status = iree_hal_streaming_stream_begin_locked(stream);
-    if (timing_enabled) {
-      timing_begin_ns += hrx_launch_timing_now_ns() - timing_begin_step_ns;
-    }
-    if (iree_status_is_ok(status)) {
-      status = iree_hal_command_buffer_dispatch(
-          stream->command_buffer, symbol->executable,
+  if (iree_status_is_ok(status)) {
+    iree_slim_mutex_lock(&stream->mutex);
+    if (dispatch_directly) {
+      uint64_t wait_value = stream->pending_value;
+      uint64_t signal_value = wait_value + 1;
+      const iree_hal_semaphore_list_t wait_semaphores = {
+          .count = wait_value > 0 ? 1 : 0,
+          .semaphores = &stream->timeline_semaphore,
+          .payload_values = &wait_value,
+      };
+      const iree_hal_semaphore_list_t signal_semaphores = {
+          .count = 1,
+          .semaphores = &stream->timeline_semaphore,
+          .payload_values = &signal_value,
+      };
+      status = iree_hal_device_queue_dispatch(
+          stream->context->device, stream->queue_affinity, wait_semaphores,
+          signal_semaphores, symbol->executable,
           iree_hal_executable_function_from_index(symbol->export_ordinal),
           config, iree_make_const_byte_span(constants, constants_size),
           binding_list, flags);
-    }
-
-    // Insert an execution + memory barrier after each dispatch to enforce
-    // serial ordering within the command buffer, emulating HIP stream
-    // semantics. This allows batching multiple dispatches per CB submission
-    // while maintaining correctness. Inter-CB ordering is handled by timeline
-    // semaphore chaining in iree_hal_streaming_stream_flush.
-    //
-    // The memory barrier with non-host (DISPATCH/TRANSFER) access scopes is
-    // important: under the AMDGPU HAL backend it resolves to an AGENT-scoped
-    // AQL release+acquire fence between this dispatch and the next, which
-    // flushes the GPU L1/L2 caches so the next dispatch sees this dispatch's
-    // writes. A bare execution barrier with no memory barriers does not publish
-    // dispatch memory side effects under backends that preserve empty barrier
-    // scopes, so later dispatches can observe stale device cache contents.
-    if (iree_status_is_ok(status) && !hrx_disable_dispatch_barrier_enabled()) {
-      static const iree_hal_memory_barrier_t memory_barrier = {
-          .source_scope = IREE_HAL_ACCESS_SCOPE_DISPATCH_READ |
-                          IREE_HAL_ACCESS_SCOPE_DISPATCH_WRITE |
-                          IREE_HAL_ACCESS_SCOPE_TRANSFER_READ |
-                          IREE_HAL_ACCESS_SCOPE_TRANSFER_WRITE,
-          .target_scope = IREE_HAL_ACCESS_SCOPE_DISPATCH_READ |
-                          IREE_HAL_ACCESS_SCOPE_DISPATCH_WRITE |
-                          IREE_HAL_ACCESS_SCOPE_TRANSFER_READ |
-                          IREE_HAL_ACCESS_SCOPE_TRANSFER_WRITE,
-      };
-      uint64_t timing_barrier_step_ns =
+      if (iree_status_is_ok(status)) {
+        status = iree_hal_device_queue_flush(stream->context->device,
+                                             stream->queue_affinity);
+      }
+      if (iree_status_is_ok(status)) {
+        stream->pending_value = signal_value;
+        stream->submitted_value = signal_value;
+      }
+    } else {
+      uint64_t timing_begin_step_ns =
           timing_enabled ? hrx_launch_timing_now_ns() : 0;
-      status = iree_hal_command_buffer_execution_barrier(
-          stream->command_buffer,
-          IREE_HAL_EXECUTION_STAGE_DISPATCH | IREE_HAL_EXECUTION_STAGE_TRANSFER,
-          IREE_HAL_EXECUTION_STAGE_DISPATCH | IREE_HAL_EXECUTION_STAGE_TRANSFER,
-          IREE_HAL_EXECUTION_BARRIER_FLAG_NONE, 1, &memory_barrier, 0, NULL);
+      status = iree_hal_streaming_stream_begin_locked(stream);
       if (timing_enabled) {
-        timing_barrier_ns +=
-            hrx_launch_timing_now_ns() - timing_barrier_step_ns;
+        timing_begin_ns += hrx_launch_timing_now_ns() - timing_begin_step_ns;
+      }
+      if (iree_status_is_ok(status)) {
+        status = iree_hal_command_buffer_dispatch(
+            stream->command_buffer, symbol->executable,
+            iree_hal_executable_function_from_index(symbol->export_ordinal),
+            config, iree_make_const_byte_span(constants, constants_size),
+            binding_list, flags);
+      }
+
+      // Insert an execution + memory barrier after each dispatch to enforce
+      // serial ordering within the command buffer, emulating HIP stream
+      // semantics. This allows batching multiple dispatches per CB submission
+      // while maintaining correctness. Inter-CB ordering is handled by timeline
+      // semaphore chaining in iree_hal_streaming_stream_flush.
+      //
+      // The memory barrier with non-host (DISPATCH/TRANSFER) access scopes is
+      // important: under the AMDGPU HAL backend it resolves to an AGENT-scoped
+      // AQL release+acquire fence between this dispatch and the next, which
+      // flushes the GPU L1/L2 caches so the next dispatch sees this dispatch's
+      // writes. A bare execution barrier with no memory barriers does not
+      // publish dispatch memory side effects under backends that preserve empty
+      // barrier scopes, so later dispatches can observe stale device cache
+      // contents.
+      if (iree_status_is_ok(status) &&
+          !hrx_disable_dispatch_barrier_enabled()) {
+        static const iree_hal_memory_barrier_t memory_barrier = {
+            .source_scope = IREE_HAL_ACCESS_SCOPE_DISPATCH_READ |
+                            IREE_HAL_ACCESS_SCOPE_DISPATCH_WRITE |
+                            IREE_HAL_ACCESS_SCOPE_TRANSFER_READ |
+                            IREE_HAL_ACCESS_SCOPE_TRANSFER_WRITE,
+            .target_scope = IREE_HAL_ACCESS_SCOPE_DISPATCH_READ |
+                            IREE_HAL_ACCESS_SCOPE_DISPATCH_WRITE |
+                            IREE_HAL_ACCESS_SCOPE_TRANSFER_READ |
+                            IREE_HAL_ACCESS_SCOPE_TRANSFER_WRITE,
+        };
+        uint64_t timing_barrier_step_ns =
+            timing_enabled ? hrx_launch_timing_now_ns() : 0;
+        status = iree_hal_command_buffer_execution_barrier(
+            stream->command_buffer,
+            IREE_HAL_EXECUTION_STAGE_DISPATCH |
+                IREE_HAL_EXECUTION_STAGE_TRANSFER,
+            IREE_HAL_EXECUTION_STAGE_DISPATCH |
+                IREE_HAL_EXECUTION_STAGE_TRANSFER,
+            IREE_HAL_EXECUTION_BARRIER_FLAG_NONE, 1, &memory_barrier, 0, NULL);
+        if (timing_enabled) {
+          timing_barrier_ns +=
+              hrx_launch_timing_now_ns() - timing_barrier_step_ns;
+        }
+      }
+
+      if (iree_status_is_ok(status)) {
+        ++stream->pending_launch_count;
+        const int flush_interval = hrx_flush_interval();
+        should_flush = hrx_flush_each_launch_enabled() ||
+                       (flush_interval > 0 && stream->pending_launch_count >=
+                                                  (uint32_t)flush_interval);
       }
     }
-
-    if (iree_status_is_ok(status)) {
-      ++stream->pending_launch_count;
-      const int flush_interval = hrx_flush_interval();
-      should_flush = hrx_flush_each_launch_enabled() ||
-                     (flush_interval > 0 &&
-                      stream->pending_launch_count >= (uint32_t)flush_interval);
-    }
+    iree_slim_mutex_unlock(&stream->mutex);
   }
-  iree_slim_mutex_unlock(&stream->mutex);
   if (timing_enabled) {
     timing_dispatch_ns += hrx_launch_timing_now_ns() - timing_step_ns;
   }
   if (!dispatch_directly && iree_status_is_ok(status) && should_flush) {
     status = iree_hal_streaming_stream_flush(stream);
+  }
+  if (iree_status_is_ok(status) && printf_buffer) {
+    status = iree_hal_streaming_symbol_queue_printf_drain(symbol, stream,
+                                                          printf_buffer);
+    printf_buffer = NULL;
+  }
+  if (printf_buffer) {
+    iree_hal_streaming_memory_release_transient_buffer(printf_buffer);
   }
   if (timing_enabled) {
     ++g_hrx_launch_timing.launch_count;
@@ -1446,6 +1487,49 @@ static iree_status_t iree_hal_streaming_host_callback_thunk(
   return iree_ok_status();
 }
 
+iree_status_t iree_hal_streaming_queue_host_call(
+    iree_hal_streaming_stream_t* stream, iree_hal_host_call_t call,
+    const uint64_t args[4], iree_hal_host_call_flags_t flags) {
+  IREE_ASSERT_ARGUMENT(stream);
+  IREE_ASSERT_ARGUMENT(call.fn);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(z0,
+                                    iree_hal_streaming_stream_flush(stream));
+
+  iree_slim_mutex_lock(&stream->mutex);
+  uint64_t wait_value = stream->pending_value;
+  if (IREE_UNLIKELY(wait_value == UINT64_MAX)) {
+    iree_slim_mutex_unlock(&stream->mutex);
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "stream timeline value overflow");
+  }
+  uint64_t signal_value = wait_value + 1;
+  iree_hal_semaphore_list_t wait_semaphores = {
+      .count = wait_value > 0 ? 1 : 0,
+      .semaphores = &stream->timeline_semaphore,
+      .payload_values = &wait_value,
+  };
+  iree_hal_semaphore_list_t signal_semaphores = {
+      .count = 1,
+      .semaphores = &stream->timeline_semaphore,
+      .payload_values = &signal_value,
+  };
+
+  iree_status_t status = iree_hal_device_queue_host_call(
+      stream->context->device, stream->queue_affinity, wait_semaphores,
+      signal_semaphores, call, args, flags);
+  if (iree_status_is_ok(status)) {
+    stream->pending_value = signal_value;
+    stream->submitted_value = signal_value;
+  }
+  iree_slim_mutex_unlock(&stream->mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 iree_status_t iree_hal_streaming_launch_host_function(
     iree_hal_streaming_stream_t* stream, void (*fn)(void*), void* user_data) {
   IREE_ASSERT_ARGUMENT(stream);
@@ -1466,11 +1550,6 @@ iree_status_t iree_hal_streaming_launch_host_function(
     return iree_ok_status();
   }
 
-  // Flush any pending command-buffer work so the host call can sit at a
-  // concrete point on the stream timeline.
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(z0,
-                                    iree_hal_streaming_stream_flush(stream));
-
   // Allocate a wrapper structure to hold the callback and user data.
   iree_hal_streaming_host_callback_t* callback = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
@@ -1483,29 +1562,8 @@ iree_status_t iree_hal_streaming_launch_host_function(
   iree_hal_host_call_t call =
       iree_hal_make_host_call(iree_hal_streaming_host_callback_thunk, callback);
 
-  iree_slim_mutex_lock(&stream->mutex);
-  uint64_t wait_value = stream->pending_value;
-  uint64_t signal_value = wait_value + 1;
-  iree_hal_semaphore_list_t wait_semaphores = {
-      .count = wait_value > 0 ? 1 : 0,
-      .semaphores = &stream->timeline_semaphore,
-      .payload_values = &wait_value,
-  };
-  iree_hal_semaphore_list_t signal_semaphores = {
-      .count = 1,
-      .semaphores = &stream->timeline_semaphore,
-      .payload_values = &signal_value,
-  };
-
-  iree_status_t status = iree_hal_device_queue_host_call(
-      stream->context->device, stream->queue_affinity, wait_semaphores,
-      signal_semaphores, call, args, /*flags=*/0);
-  if (iree_status_is_ok(status)) {
-    stream->pending_value = signal_value;
-    stream->submitted_value = signal_value;
-  }
-  iree_slim_mutex_unlock(&stream->mutex);
-
+  iree_status_t status = iree_hal_streaming_queue_host_call(
+      stream, call, args, IREE_HAL_HOST_CALL_FLAG_NONE);
   if (!iree_status_is_ok(status)) {
     iree_allocator_free(iree_allocator_system(), callback);
     IREE_TRACE_ZONE_END(z0);

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -614,6 +614,10 @@ static hipError_t iree_hip_get_per_thread_stream_state(
   return hipSuccess;
 }
 
+// HIP reports a successful zero-size malloc by returning NULL. Keep just enough
+// thread-local state for hipMemPtrGetInfo(NULL, &size) to report that result.
+static IREE_THREAD_LOCAL bool iree_hip_zero_size_allocation_pending = false;
+
 static void iree_hip_thread_error_set(hipError_t error, bool sticky) {
   iree_hip_thread_error.last_error = error;
   iree_hip_thread_error.sticky = sticky;
@@ -1772,7 +1776,8 @@ HIPAPI hipError_t hipGetDeviceProperties(hipDeviceProp_t* prop, int device) {
   prop->maxBlocksPerMultiProcessor = device_obj->max_blocks_per_multiprocessor;
   prop->accessPolicyMaxWindowSize = 0;
   prop->reservedSharedMemPerBlock = 0;
-  prop->hostNativeAtomicSupported = is_gfx1100 ? 1 : 0;
+  prop->hostNativeAtomicSupported =
+      device_obj->host_native_atomic_supported ? 1 : 0;
   prop->memoryPoolsSupported = is_gfx1100 ? 1 : 0;
   prop->hostRegisterSupported = 1;
   prop->hostRegisterReadOnlySupported = 1;
@@ -1947,6 +1952,9 @@ HIPAPI hipError_t hipDeviceGetAttribute(int* value, hipDeviceAttribute_t attr,
       break;
     case hipDeviceAttributeManagedMemory:
       *value = 1;
+      break;
+    case hipDeviceAttributeHostNativeAtomicSupported:
+      *value = device_obj->host_native_atomic_supported ? 1 : 0;
       break;
     case hipDeviceAttributeHostRegisterSupported:
       *value = 1;
@@ -2631,6 +2639,10 @@ HIPAPI hipError_t hipDeviceSynchronize(void) {
   }
 
   iree_status_t status = iree_hal_streaming_context_synchronize(context);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_context_symbol_map_synchronize_managed_data(
+        &context->symbol_map);
+  }
   hipError_t result = iree_status_to_hip_result(status);
   HIP_DEBUG_LOG(
       "[HIP_API] hipDeviceSynchronize() returned %d (sync_count=%d)\n", result,
@@ -4325,6 +4337,7 @@ HIPAPI hipError_t hipMalloc(void** ptr, size_t size) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
+  iree_hip_zero_size_allocation_pending = false;
 
   // Ensure initialization and get context.
   iree_hal_streaming_context_t* context = NULL;
@@ -4342,6 +4355,7 @@ HIPAPI hipError_t hipMalloc(void** ptr, size_t size) {
 
   if (size == 0) {
     *ptr = NULL;
+    iree_hip_zero_size_allocation_pending = true;
     IREE_TRACE_ZONE_END(z0);
     return hipSuccess;
   }
@@ -4491,6 +4505,11 @@ HIPAPI hipError_t hipMallocPitch(void** devPtr, size_t* pitch, size_t width,
 HIPAPI hipError_t hipFree(void* ptr) {
   HIP_DEBUG_LOG("[HIP_API] hipFree(%p)\n", ptr);
   IREE_TRACE_ZONE_BEGIN(z0);
+  if (!ptr) {
+    iree_hip_zero_size_allocation_pending = false;
+    IREE_TRACE_ZONE_END(z0);
+    return hipSuccess;
+  }
 
   // Ensure initialization and get context.
   iree_hal_streaming_context_t* context = NULL;
@@ -4635,6 +4654,11 @@ HIPAPI hipError_t hipMallocHost(void** ptr, size_t size) {
 // See also: hipMalloc, hipFreeHost, hipFreeAsync.
 HIPAPI hipError_t hipFreeHost(void* ptr) {
   IREE_TRACE_ZONE_BEGIN(z0);
+  if (!ptr) {
+    IREE_TRACE_ZONE_END(z0);
+    return hipSuccess;
+  }
+
   // Ensure initialization and get context.
   iree_hal_streaming_context_t* context = NULL;
   hipError_t init_result = iree_hip_ensure_context(&context);
@@ -5277,7 +5301,17 @@ HIPAPI hipError_t hipHostGetFlags(unsigned int* flagsPtr, void* hostPtr) {
 HIPAPI hipError_t hipMemPtrGetInfo(void* ptr, size_t* size) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  if (!ptr || !size) {
+  if (!size) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+  if (!ptr) {
+    if (iree_hip_zero_size_allocation_pending) {
+      iree_hip_zero_size_allocation_pending = false;
+      *size = 0;
+      IREE_TRACE_ZONE_END(z0);
+      return hipSuccess;
+    }
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
@@ -9970,6 +10004,10 @@ HIPAPI hipError_t hipStreamSynchronize(hipStream_t stream) {
 
     iree_status_t status =
         iree_hal_streaming_context_synchronize_legacy_default(context);
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_streaming_context_symbol_map_synchronize_managed_data(
+          &context->symbol_map);
+    }
     hipError_t result = iree_status_to_hip_result(status);
     IREE_TRACE_ZONE_END(z0);
     return result;
@@ -9983,6 +10021,10 @@ HIPAPI hipError_t hipStreamSynchronize(hipStream_t stream) {
 
   iree_status_t status =
       iree_hal_streaming_stream_synchronize(streaming_stream);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_context_symbol_map_synchronize_managed_data(
+        &streaming_stream->context->symbol_map);
+  }
   hipError_t result = iree_status_to_hip_result(status);
   IREE_TRACE_ZONE_END(z0);
   return result;
@@ -10471,6 +10513,10 @@ HIPAPI hipError_t hipEventSynchronize(hipEvent_t event) {
   }
 
   iree_status_t status = iree_hal_streaming_event_synchronize(streaming_event);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_context_symbol_map_synchronize_managed_data(
+        &streaming_event->context->symbol_map);
+  }
   hipError_t result = iree_status_to_hip_result(status);
   IREE_TRACE_ZONE_END(z0);
   return result;
@@ -13362,11 +13408,41 @@ HIPAPI hipError_t hipDrvPointerGetAttributes(unsigned int numAttributes,
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
+
+  iree_hal_streaming_context_t* context = NULL;
+  hipError_t init_result = iree_hip_ensure_context(&context);
+  if (init_result != hipSuccess) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(init_result);
+  }
+  if (!ptr) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+
   // Query each attribute individually using hipPointerGetAttribute.
   hipError_t result = hipSuccess;
   for (unsigned int i = 0; i < numAttributes; i++) {
-    hipError_t attr_result =
-        hipPointerGetAttribute(data[i], attributes[i], (hipDeviceptr_t)ptr);
+    hipError_t attr_result = hipSuccess;
+    if (!data[i]) {
+      attr_result = hipErrorInvalidValue;
+    } else if (attributes[i] == HIP_POINTER_ATTRIBUTE_HOST_POINTER) {
+      iree_hal_streaming_buffer_ref_t buffer_ref;
+      iree_hal_streaming_context_t* owner_context = NULL;
+      attr_result = iree_hip_lookup_streaming_range_with_owner(
+          context, ptr, 1, &owner_context, &buffer_ref);
+      if (attr_result == hipSuccess) {
+        *(void**)data[i] =
+            buffer_ref.buffer->host_ptr
+                ? (void*)((iree_host_size_t)buffer_ref.buffer->host_ptr +
+                          buffer_ref.offset)
+                : NULL;
+        iree_hal_streaming_context_release(owner_context);
+      }
+    } else {
+      attr_result =
+          hipPointerGetAttribute(data[i], attributes[i], (hipDeviceptr_t)ptr);
+    }
     if (attr_result != hipSuccess) {
       // Return the first error encountered.
       if (result == hipSuccess) {
@@ -21726,12 +21802,13 @@ HIPAPI hipError_t hipFreeAsync(void* ptr, hipStream_t stream) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(resolve_result);
   }
+  if (!ptr) {
+    iree_hip_zero_size_allocation_pending = false;
+    IREE_TRACE_ZONE_END(z0);
+    return hipSuccess;
+  }
 
   if (stream_obj->capture_status == IREE_HAL_STREAMING_CAPTURE_STATUS_ACTIVE) {
-    if (!ptr) {
-      IREE_TRACE_ZONE_END(z0);
-      return hipSuccess;
-    }
     hipGraphNode_t node = NULL;
     hipError_t result = hipGraphAddMemFreeNode(
         &node, (hipGraph_t)stream_obj->capture_graph,
@@ -22556,11 +22633,12 @@ HIPAPI void __hipRegisterManagedVar(void* hipModule, void** pointer,
   iree_status_t status =
       iree_hal_streaming_global_symbol_registry_insert_managed_variable(
           registry, (iree_hal_streaming_module_registration_t*)hipModule,
-          managed_pointer ? managed_pointer : pointer, name, size, align);
+          managed_pointer ? managed_pointer : pointer, name, size, align,
+          managed_pointer);
   if (iree_status_is_ok(status) && (void*)pointer != managed_pointer) {
     status = iree_hal_streaming_global_symbol_registry_insert_managed_variable(
         registry, (iree_hal_streaming_module_registration_t*)hipModule, pointer,
-        name, size, align);
+        name, size, align, managed_pointer);
   }
   iree_status_ignore(status);
 }

--- a/libhrx/src/libhrx/BUILD.bazel
+++ b/libhrx/src/libhrx/BUILD.bazel
@@ -79,6 +79,7 @@ HRX_DEPS = [
     "//runtime/src/iree/vm/bytecode:module",
 ] + iree_select({
     "//runtime/config/hal:driver_amdgpu": [
+        "//runtime/src/iree/hal/drivers/amdgpu:device_spec",
         "//runtime/src/iree/hal/drivers/amdgpu/registration",
     ],
     "//conditions:default": [],

--- a/libhrx/src/libhrx/CMakeLists.txt
+++ b/libhrx/src/libhrx/CMakeLists.txt
@@ -15,6 +15,7 @@ if(IREE_HAL_DRIVER_AMDGPU)
 endif()
 set(_hrx_static_platform_deps "")
 if(IREE_HAL_DRIVER_AMDGPU)
+  list(APPEND _hrx_static_platform_deps iree::hal::drivers::amdgpu::device_spec)
   list(APPEND _hrx_static_platform_deps iree::hal::drivers::amdgpu::registration)
 endif()
 iree_cc_library(
@@ -86,6 +87,7 @@ iree_cc_library(
 
 set(_hrx_platform_deps "")
 if(IREE_HAL_DRIVER_AMDGPU)
+  list(APPEND _hrx_platform_deps iree::hal::drivers::amdgpu::device_spec)
   list(APPEND _hrx_platform_deps iree::hal::drivers::amdgpu::registration)
 endif()
 iree_cc_library(
@@ -173,6 +175,7 @@ iree_cc_test(
 if(IREE_HAL_DRIVER_AMDGPU)
   target_link_libraries(libhrx_src_libhrx_hrx PRIVATE
     iree::hal::drivers::amdgpu::registration
+    iree::hal::drivers::amdgpu::device_spec
   )
   target_compile_definitions(libhrx_src_libhrx_hrx.objects PRIVATE
     HRX_HAS_IREE_AMDGPU_DRIVER

--- a/libhrx/src/libhrx/device.c
+++ b/libhrx/src/libhrx/device.c
@@ -8,6 +8,33 @@
 
 #include "hrx_internal.h"
 
+#ifdef HRX_HAS_IREE_AMDGPU_DRIVER
+#include "iree/hal/drivers/amdgpu/device_spec.h"
+#endif  // HRX_HAS_IREE_AMDGPU_DRIVER
+
+#ifdef HRX_HAS_IREE_AMDGPU_DRIVER
+static hrx_status_t hrx_device_query_amdgpu_host_native_atomic_supported(
+    hrx_device_t device, bool* out_supported) {
+  *out_supported = false;
+  const iree_hal_device_spec_facet_t* facet =
+      iree_hal_amdgpu_device_spec_find_facet(
+          iree_hal_device_spec(device->hal_device));
+  if (!facet) {
+    return hrx_make_status(
+        HRX_STATUS_UNAVAILABLE,
+        "AMDGPU HAL device spec did not provide an AMDGPU facet");
+  }
+
+  iree_hal_amdgpu_device_spec_t amdgpu_spec;
+  iree_status_t status =
+      iree_hal_amdgpu_device_spec_decode_facet(facet, &amdgpu_spec);
+  if (!iree_status_is_ok(status)) return hrx_status_from_iree(status);
+  *out_supported = iree_all_bits_set(
+      amdgpu_spec.flags, IREE_HAL_AMDGPU_DEVICE_SPEC_FLAG_HOST_NATIVE_ATOMICS);
+  return hrx_ok_status();
+}
+#endif  // HRX_HAS_IREE_AMDGPU_DRIVER
+
 hrx_status_t hrx_device_query_total_memory_from_spec(
     hrx_device_t device, bool* out_known, iree_device_size_t* out_total) {
   if (!device || !out_known || !out_total) {
@@ -115,6 +142,19 @@ hrx_status_t hrx_device_get_property(hrx_device_t device,
       }
       *(uint32_t*)value = 0;  // Not available from local-task driver.
       return hrx_ok_status();
+    }
+    case HRX_DEVICE_PROPERTY_HOST_NATIVE_ATOMIC_SUPPORTED: {
+      if (value_size < sizeof(bool)) {
+        return hrx_make_status(HRX_STATUS_OUT_OF_RANGE,
+                               "buffer too small for bool");
+      }
+#ifdef HRX_HAS_IREE_AMDGPU_DRIVER
+      return hrx_device_query_amdgpu_host_native_atomic_supported(device,
+                                                                  (bool*)value);
+#else
+      return hrx_make_status(HRX_STATUS_UNAVAILABLE,
+                             "host native atomic support is unavailable");
+#endif  // HRX_HAS_IREE_AMDGPU_DRIVER
     }
     default:
       return hrx_make_status(HRX_STATUS_INVALID_ARGUMENT,

--- a/runtime/src/iree/hal/BUILD.bazel
+++ b/runtime/src/iree/hal/BUILD.bazel
@@ -65,6 +65,7 @@ iree_runtime_cc_library(
         "executable.c",
         "fence.c",
         "file.c",
+        "host_notification.c",
         "pool.c",
         "pool_set.c",
         "profile_metrics.c",
@@ -95,6 +96,7 @@ iree_runtime_cc_library(
         "executable.h",
         "fence.h",
         "file.h",
+        "host_notification.h",
         "pool.h",
         "pool_set.h",
         "profile_metrics.h",
@@ -127,6 +129,18 @@ iree_runtime_cc_library(
 iree_runtime_cc_test(
     name = "device_test",
     srcs = ["device_test.cc"],
+    deps = [
+        ":hal",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal/testing:mock_device",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "host_notification_test",
+    srcs = ["host_notification_test.cc"],
     deps = [
         ":hal",
         "//runtime/src/iree/base",

--- a/runtime/src/iree/hal/CMakeLists.txt
+++ b/runtime/src/iree/hal/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_cc_library(
     "executable.h"
     "fence.h"
     "file.h"
+    "host_notification.h"
     "pool.h"
     "pool_set.h"
     "profile_metrics.h"
@@ -73,6 +74,7 @@ iree_cc_library(
     "executable.c"
     "fence.c"
     "file.c"
+    "host_notification.c"
     "pool.c"
     "pool_set.c"
     "profile_metrics.c"
@@ -100,6 +102,19 @@ iree_cc_test(
     device_test
   SRCS
     "device_test.cc"
+  DEPS
+    ::hal
+    iree::base
+    iree::hal::testing::mock_device
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
+iree_cc_test(
+  NAME
+    host_notification_test
+  SRCS
+    "host_notification_test.cc"
   DEPS
     ::hal
     iree::base

--- a/runtime/src/iree/hal/command_buffer.h
+++ b/runtime/src/iree/hal/command_buffer.h
@@ -460,6 +460,36 @@ IREE_API_EXPORT iree_string_view_t iree_hal_collective_op_format(
 IREE_API_EXPORT iree_device_size_t iree_hal_collective_element_byte_count(
     iree_hal_collective_element_type_t element_type);
 
+// Maximum backend-native runtime argument patches carried by one dispatch.
+#define IREE_HAL_DISPATCH_MAX_RUNTIME_PARAMETER_PATCHES 4
+
+// Maximum byte length of one backend-native runtime argument patch.
+#define IREE_HAL_DISPATCH_MAX_RUNTIME_PARAMETER_LENGTH 16
+
+// Backend-native launch argument patch applied after the normal HAL ABI has
+// materialized a dispatch's kernarg storage.
+typedef struct iree_hal_dispatch_runtime_parameter_patch_t {
+  // Byte offset in backend-native launch argument storage.
+  uint32_t offset;
+  // Byte length copied from |data|.
+  uint16_t length;
+  // Reserved for alignment and future flags. Must be zero.
+  uint16_t reserved;
+  // Runtime parameter bytes copied into launch argument storage.
+  uint8_t data[IREE_HAL_DISPATCH_MAX_RUNTIME_PARAMETER_LENGTH];
+} iree_hal_dispatch_runtime_parameter_patch_t;
+
+// Bounded per-dispatch backend-native runtime argument patch list.
+typedef struct iree_hal_dispatch_runtime_parameter_list_t {
+  // Number of valid entries in |patches|.
+  uint8_t count;
+  // Reserved for alignment and future flags. Must be zero.
+  uint8_t reserved[3];
+  // Dispatch-local runtime argument patches.
+  iree_hal_dispatch_runtime_parameter_patch_t
+      patches[IREE_HAL_DISPATCH_MAX_RUNTIME_PARAMETER_PATCHES];
+} iree_hal_dispatch_runtime_parameter_list_t;
+
 // Configuration defining how a dispatch is performed.
 typedef struct iree_hal_dispatch_config_t {
   // Optional workgroup size for targets that have workgroup sizes specified by
@@ -489,7 +519,32 @@ typedef struct iree_hal_dispatch_config_t {
   // This is added on top of the static workgroup local memory declared by the
   // function metadata.
   uint32_t dynamic_workgroup_local_memory;
+  // Optional backend-native runtime parameter patches for this dispatch. The
+  // list is borrowed for the duration of the dispatch call.
+  // Command buffers and queues that retain dispatches must clone the list into
+  // their own command storage before returning.
+  const iree_hal_dispatch_runtime_parameter_list_t* runtime_parameters;
 } iree_hal_dispatch_config_t;
+
+// Returns true when |config| carries backend-native runtime parameter state.
+static inline bool iree_hal_dispatch_config_has_runtime_parameters(
+    iree_hal_dispatch_config_t config) {
+  return config.runtime_parameters && config.runtime_parameters->count != 0;
+}
+
+// Clones |source| and, when present, its borrowed runtime parameter list into
+// |runtime_parameter_storage|. Use this at command and queue boundaries that
+// retain a dispatch beyond the call that supplied its configuration.
+static inline void iree_hal_dispatch_config_clone(
+    iree_hal_dispatch_config_t source,
+    iree_hal_dispatch_runtime_parameter_list_t* runtime_parameter_storage,
+    iree_hal_dispatch_config_t* out_config) {
+  *out_config = source;
+  if (source.runtime_parameters) {
+    *runtime_parameter_storage = *source.runtime_parameters;
+    out_config->runtime_parameters = runtime_parameter_storage;
+  }
+}
 
 // Creates a default dispatch config with the given static workgroup count.
 static inline iree_hal_dispatch_config_t iree_hal_make_static_dispatch_config(

--- a/runtime/src/iree/hal/device.h
+++ b/runtime/src/iree/hal/device.h
@@ -22,6 +22,7 @@
 #include "iree/hal/event.h"
 #include "iree/hal/fence.h"
 #include "iree/hal/file.h"
+#include "iree/hal/host_notification.h"
 #include "iree/hal/memory/asan.h"
 #include "iree/hal/pool.h"
 #include "iree/hal/profile_options.h"
@@ -1130,6 +1131,13 @@ typedef struct iree_hal_device_vtable_t {
   iree_status_t(IREE_API_PTR* create_event)(
       iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
       iree_hal_event_flags_t flags, iree_hal_event_t** out_event);
+
+  // Device-writable, host-waitable notification constructor.
+  // Drivers without support assign
+  // iree_hal_host_notification_create_unimplemented.
+  iree_status_t(IREE_API_PTR* create_host_notification)(
+      iree_hal_device_t* device,
+      iree_hal_host_notification_t** out_notification);
 
   iree_status_t(IREE_API_PTR* load_executable)(
       iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,

--- a/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
@@ -22,10 +22,21 @@ iree_amdgpu_target_selectors_flag(
 )
 
 iree_runtime_cc_library(
+    name = "device_spec",
+    srcs = ["device_spec.c"],
+    hdrs = ["device_spec.h"],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "device_spec_builder",
     srcs = ["device_spec_builder.c"],
     hdrs = ["device_spec_builder.h"],
     deps = [
+        ":device_spec",
         "//runtime/src/iree/base",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/executable/amdgpu:executable_target",
@@ -173,6 +184,8 @@ iree_runtime_cc_library(
         "executable.h",
         "feedback_state.c",
         "feedback_state.h",
+        "host_notification.c",
+        "host_notification.h",
         "host_queue.c",
         "host_queue.h",
         "host_queue_blit.c",
@@ -326,6 +339,7 @@ iree_runtime_cc_library(
         "driver.h",
         "executable.h",
         "feedback_state.h",
+        "host_notification.h",
         "host_queue.h",
         "host_queue_blit.h",
         "host_queue_command_buffer.h",
@@ -397,6 +411,7 @@ iree_runtime_cc_test(
     name = "device_spec_test",
     srcs = ["device_spec_test.cc"],
     deps = [
+        ":device_spec",
         ":device_spec_builder",
         "//runtime/src/iree/base",
         "//runtime/src/iree/hal",

--- a/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
@@ -12,12 +12,28 @@ iree_add_all_subdirs()
 if(IREE_HAL_DRIVER_AMDGPU)
 iree_cc_library(
   NAME
+    device_spec
+  HDRS
+    "device_spec.h"
+  SRCS
+    "device_spec.c"
+  DEPS
+    iree::base
+    iree::hal
+  PUBLIC
+)
+endif()
+
+if(IREE_HAL_DRIVER_AMDGPU)
+iree_cc_library(
+  NAME
     device_spec_builder
   HDRS
     "device_spec_builder.h"
   SRCS
     "device_spec_builder.c"
   DEPS
+    ::device_spec
     iree::base
     iree::hal
     iree::hal::executable::amdgpu::executable_target
@@ -215,6 +231,8 @@ iree_cc_library(
     "executable.h"
     "feedback_state.c"
     "feedback_state.h"
+    "host_notification.c"
+    "host_notification.h"
     "host_queue.c"
     "host_queue.h"
     "host_queue_blit.c"
@@ -365,6 +383,7 @@ iree_cc_library(
     "driver.h"
     "executable.h"
     "feedback_state.h"
+    "host_notification.h"
     "host_queue.h"
     "host_queue_blit.h"
     "host_queue_command_buffer.h"
@@ -439,6 +458,7 @@ iree_cc_test(
   SRCS
     "device_spec_test.cc"
   DEPS
+    ::device_spec
     ::device_spec_builder
     iree::base
     iree::hal

--- a/runtime/src/iree/hal/drivers/amdgpu/abi/kernel_args.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/abi/kernel_args.h
@@ -71,24 +71,19 @@ IREE_AMDGPU_STATIC_ASSERT(
 // OpenCL/HIP: (`amd::KernelParameterDescriptor`...)
 // https://github.com/ROCm/clr/blob/5da72f9d524420c43fe3eee44b11ac875d884e0f/rocclr/device/rocm/rocvirtual.cpp#L3197
 //
-// This complex construction was required once upon a time. The LLVM code
-// producing the kernargs layout and metadata handles these cases much more
-// simply by only ever truncating the implicit args at the last used field:
+// Earlier code-object metadata could describe a truncated implicit-argument
+// region ending at the last field the compiler proved was required:
 // https://github.com/llvm/llvm-project/blob/7f1b465c6ae476e59dc90652d58fc648932d23b1/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp#L389
 //
-// Then at some point in time someone was like "meh, who cares about optimizing"
-// and decided to include all of them always 🤦:
+// Newer compiler behavior may emit the full implicit-argument block whenever
+// any implicit argument is required:
 // https://github.com/llvm/llvm-project/blob/7f1b465c6ae476e59dc90652d58fc648932d23b1/llvm/lib/Target/AMDGPU/AMDGPUSubtarget.cpp#L299
 //
-// What this means in practice is that if any implicit arg is used then all will
-// be included and declared in the metadata even if only one is actually read by
-// the kernel -- there's no way for us to know. In the ideal case none of them
-// are read and the kernel function gets the `amdgpu-no-implicitarg-ptr` attr
-// so that all of them can be skipped. Otherwise we reserve the 256 bytes and
-// just splat them all in. This at least keeps our code simple relative to all
-// the implementations that enumerate the metadata and write args one at a time.
-// We really should try to force `amdgpu-no-implicitarg-ptr` when we generate
-// code, though.
+// In practice, metadata can declare the full block even when the kernel only
+// reads one field. The loader cannot infer which declared fields are live, so
+// any kernel with implicit arguments receives the full block. Kernels that do
+// not read implicit arguments should be compiled with
+// `amdgpu-no-implicitarg-ptr` so the block can be omitted entirely.
 //
 // For our bare-metal C runtime device code we have total freedom and don't use
 // any OpenCL/HIP-related things that would emit the implicit args.
@@ -152,7 +147,7 @@ typedef struct IREE_AMDGPU_ALIGNAS(8) iree_amdgpu_kernel_implicit_args_t {
   uint16_t grid_dims;  // + 64
 
   // Fixed-size buffer for `-mprintf-kind=buffered` support.
-  // By default LLVM uses `hostcall` but that's a mess and we avoid it.
+  // LLVM defaults to hostcall printf; buffered printf uses this slot instead.
   // `__printf_alloc` in the device library is used to grab this pointer, the
   // header DWORDs are manipulated, and the contents are written to the buffer.
   //
@@ -162,15 +157,12 @@ typedef struct IREE_AMDGPU_ALIGNAS(8) iree_amdgpu_kernel_implicit_args_t {
   //   uint8_t data[size];
   // } printf_buffer_t;
   //
-  // One of many disappointing parts of this scheme is that constant string
-  // values are interned, MD5 hashed, and stored *externally* in the amdhsa data
-  // blob. In order to print with any constant format string this data blob
-  // needs to be parsed, retained, and referenced every time a printf packet is
-  // processed. It would have been significantly better to embed the table in
-  // the ELF as a global constant instead as then we could reference it on both
-  // host and device and not need to parse the amdhsa blob.
+  // Constant format strings are interned, MD5 hashed, and stored externally in
+  // the amdhsa metadata blob. Host-side printf processing must retain the
+  // parsed metadata table for as long as queued printf packets may reference
+  // those format-string hashes.
   //
-  // The contents of the data buffer are best defined by the janky parser code:
+  // The contents of the data buffer are defined by the runtime parser:
   // https://github.com/ROCm/clr/blob/a2550e0a9ecaa8f371cb14d08904c51874c37cbe/rocclr/device/rocm/rocprintf.cpp#L454
   // Each printf consists of a control DWORD followed by 8-byte aligned
   // contents. Effectively:
@@ -196,30 +188,22 @@ typedef struct IREE_AMDGPU_ALIGNAS(8) iree_amdgpu_kernel_implicit_args_t {
   // Note that the documentation is incorrect about there being a version prefix
   // and it expects the first uint64_t to contain the format string bytes.
   //
-  // Note that in another disappointing display of rube-goldbergian development
-  // this implementation for some reason uses uint64_t for its data elements
-  // but never aligns it - meaning that consumer code must use unaligned loads
-  // in order to read the data. The CLR just copies it out each time. One could
-  // think that was for streaming (release the buffer contents early back to
-  // dispatches) but since they fully halt the world and synchronize after every
-  // dispatch containing a print none of that matters and it's just poor
-  // engineering.
+  // Packet data is logically organized as uint64_t elements, but the records
+  // may not be naturally aligned in the byte stream. Consumers must copy or
+  // otherwise perform unaligned-safe reads before interpreting argument words.
   //
   // The compiler emits strings in the delimited form of
   // `"0:0:<format_string_hash>,<actual_format_string>"`. Note that the first
   // two values should always be 0 and are delimited by `:` while the MD5 hash
-  // is delimited from the format string itself by `,`. There's some special
-  // handling in the CLR for `:` being in the format string because whoever
-  // wrote it did a find from the end instead of a prefix consume - there's
-  // special handling of \72 (`:`) and other weird things that I'm not sure is
-  // needed. Example from LLVM: `"0:0:8addc4c0362218ac,Hello World!:\n"`.
+  // is delimited from the format string itself by `,`. Format strings can
+  // contain escaped `:` characters; parsers should treat the two leading fields
+  // as fixed prefixes rather than searching for a final delimiter. Example
+  // from LLVM: `"0:0:8addc4c0362218ac,Hello World!:\n"`.
   //
-  // The hash is the lower 64 bits of the MD5 hash in hex but we don't care as
-  // it's just a semi-unique value we use to lookup the string formats. On load
-  // we sort and do a binary search instead of creating an std::map for every
-  // single print invocation like the CLR does. Just... wow.
+  // The hash is the lower 64 bits of the MD5 hash in hex. It is only used as
+  // the lookup key for the retained format-string table.
   //
-  // Handling the contents is also overtly complicated and poorly documented:
+  // Host-side formatting behavior is defined by:
   // https://github.com/ROCm/clr/blob/a2550e0a9ecaa8f371cb14d08904c51874c37cbe/rocclr/device/devhcprintf.cpp#L168
   //
   // See:
@@ -227,9 +211,8 @@ typedef struct IREE_AMDGPU_ALIGNAS(8) iree_amdgpu_kernel_implicit_args_t {
   // https://github.com/ROCm/llvm-project/blob/997363823fcc5ccc7b0cc572aad05ba08714bf5f/amd/device-libs/ockl/src/cprintf.cl#L17
   // https://github.com/ROCm/clr/blob/a2550e0a9ecaa8f371cb14d08904c51874c37cbe/rocclr/device/rocm/rocprintf.cpp#L393
   //
-  // Note that having a printf in a kernel causes the kernel to dispatch
-  // synchronously :facepalm:. We can't do the same and would need to emit
-  // flush packets (or something) into the control queue. What a mess.
+  // Host consumption of printf packets requires a stream-ordered drain point
+  // after any dispatch that may write this buffer.
   // https://github.com/ROCm/clr/blob/a2550e0a9ecaa8f371cb14d08904c51874c37cbe/rocclr/device/rocm/rocvirtual.cpp#L3644
   // https://github.com/ROCm/clr/blob/a2550e0a9ecaa8f371cb14d08904c51874c37cbe/rocclr/device/rocm/rocprintf.cpp#L428-L429
   //
@@ -237,12 +220,11 @@ typedef struct IREE_AMDGPU_ALIGNAS(8) iree_amdgpu_kernel_implicit_args_t {
   //   hidden_printf_buffer
   void* printf_buffer;  // + 72
 
-  // Used for ASAN, printf, and more modern device memory allocations.
-  // It's bizarre and only "documented" in code and I really hope we don't have
-  // to touch it. Note that due to some LLVM bug sometimes this will be included
-  // in the offset table for a kernel even if it is not used (the
-  // `amdgpu-no-hostcall-ptr` attribute is set). At this point I'm quite sure no
-  // one has ever actually inspected the files produced by the LLVM backend.
+  // Hostcall service buffer used by sanitizer, printf, and device-runtime
+  // services. Metadata can declare this slot even when the generated kernel
+  // does not read it, such as when `amdgpu-no-hostcall-ptr` is present; the
+  // slot's presence alone is not a reliable indication that dispatch requires a
+  // live hostcall service.
   //
   // Represented in metadata as:
   //   hidden_hostcall_buffer
@@ -255,11 +237,10 @@ typedef struct IREE_AMDGPU_ALIGNAS(8) iree_amdgpu_kernel_implicit_args_t {
   //   hidden_multigrid_sync_arg
   uint64_t deprecated_multigrid_sync_arg;
 
-  // Device memory heap pointer for device malloc/free.
-  // We don't support kernels using this as it requires too much goo for little
-  // payoff. The kernels we run shouldn't be malloc/freeing internally. If they
-  // do we will need to implement the heap API via hostcalls and other silly
-  // things that add a tremendous amount of complexity.
+  // Device-runtime heap pointer used by kernels that declare a
+  // hidden_heap_v1 metadata slot. This struct preserves the ABI position;
+  // language/runtime layers may patch a backend-specific heap pointer when
+  // they load an executable that needs one.
   //
   // See:
   // https://github.com/ROCm/llvm-project/blob/97753eeaa4c79c2db2dcd9f37b7989596a8d4f15/amd/device-libs/ockl/src/dm.cl#L192

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator.c
@@ -515,6 +515,7 @@ static bool iree_hal_amdgpu_allocator_resolve_placement(
   iree_hal_memory_type_t memory_type = 0;
   // Sharing hints do not affect HSA pool selection.
   const iree_hal_buffer_usage_t sharing_usage =
+      IREE_HAL_BUFFER_USAGE_SHARING_EXPORT |
       IREE_HAL_BUFFER_USAGE_SHARING_REPLICATE |
       IREE_HAL_BUFFER_USAGE_SHARING_CONCURRENT |
       IREE_HAL_BUFFER_USAGE_SHARING_IMMUTABLE;
@@ -743,6 +744,7 @@ static iree_status_t iree_hal_amdgpu_allocator_query_memory_heaps(
 
   // Sharing hints do not affect HSA pool selection.
   const iree_hal_buffer_usage_t sharing_usage =
+      IREE_HAL_BUFFER_USAGE_SHARING_EXPORT |
       IREE_HAL_BUFFER_USAGE_SHARING_REPLICATE |
       IREE_HAL_BUFFER_USAGE_SHARING_CONCURRENT |
       IREE_HAL_BUFFER_USAGE_SHARING_IMMUTABLE;

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
@@ -1766,6 +1766,7 @@ static void iree_hal_amdgpu_aql_command_buffer_write_implicit_args(
     const iree_hal_amdgpu_device_kernel_args_t* kernel_args,
     const iree_hal_dispatch_config_t config,
     iree_amdgpu_kernel_implicit_args_t* implicit_args) {
+  memset(implicit_args, 0, IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE);
   implicit_args->block_count[0] = config.workgroup_count[0];
   implicit_args->block_count[1] = config.workgroup_count[1];
   implicit_args->block_count[2] = config.workgroup_count[2];
@@ -1802,6 +1803,17 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_write_dispatch_tail(
                                                   layout->implicit_args_offset);
         iree_hal_amdgpu_aql_command_buffer_write_implicit_args(
             kernel_args, config, implicit_args);
+        const iree_host_size_t implicit_args_end =
+            layout->implicit_args_offset +
+            IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE;
+        if (layout->total_kernarg_size > implicit_args_end) {
+          memset(tail_payload + implicit_args_end, 0,
+                 layout->total_kernarg_size - implicit_args_end);
+        }
+      }
+      if (config.runtime_parameters) {
+        iree_hal_amdgpu_executable_apply_runtime_parameter_patches(
+            config, tail_payload);
       }
       return iree_ok_status();
     }
@@ -1862,6 +1874,10 @@ iree_hal_amdgpu_aql_command_buffer_record_prepublished_dispatch_kernargs(
         iree_hal_amdgpu_aql_command_buffer_write_implicit_args(
             kernel_args, config, implicit_args);
       }
+      if (config.runtime_parameters) {
+        iree_hal_amdgpu_executable_apply_runtime_parameter_patches(
+            config, kernarg_data);
+      }
     }
   }
   if (iree_status_is_ok(status)) {
@@ -1917,6 +1933,10 @@ iree_hal_amdgpu_aql_command_buffer_write_inline_dispatch_kernargs(
                                                     ->implicit_args_byte_offset);
       iree_hal_amdgpu_aql_command_buffer_write_implicit_args(
           kernel_args, config, implicit_args);
+    }
+    if (config.runtime_parameters) {
+      iree_hal_amdgpu_executable_apply_runtime_parameter_patches(config,
+                                                                 kernarg_data);
     }
   }
   return status;
@@ -2091,6 +2111,10 @@ iree_hal_amdgpu_aql_command_buffer_record_queue_kernel_objects(
     status = iree_hal_amdgpu_executable_lookup_dispatch_descriptor_for_queue(
         inputs->executable, inputs->export_ordinal, queue_affinity,
         &descriptor);
+    if (iree_status_is_ok(status) && inputs->config.runtime_parameters) {
+      status = iree_hal_amdgpu_executable_validate_dispatch_runtime_parameters(
+          descriptor, inputs->config);
+    }
     if (iree_status_is_ok(status)) {
       queue_kernel_objects[physical_queue_ordinal] =
           descriptor->kernel_args.kernel_object;
@@ -2205,6 +2229,11 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_prepare_dispatch_plan(
         iree_hal_amdgpu_executable_lookup_dispatch_descriptor_for_device(
             inputs->executable, inputs->export_ordinal,
             command_buffer->device_ordinal, &out_plan->descriptor));
+    if (inputs->config.runtime_parameters) {
+      IREE_RETURN_IF_ERROR(
+          iree_hal_amdgpu_executable_validate_dispatch_runtime_parameters(
+              out_plan->descriptor, inputs->config));
+    }
   }
 
   IREE_RETURN_IF_ERROR(

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
@@ -31,9 +31,14 @@ typedef struct iree_hal_amdgpu_device_dispatch_kernarg_layout_t {
   // Fixed size in bytes of explicitly provided dispatch arguments, or zero
   // when the caller-provided byte count is dynamic.
   size_t explicit_kernarg_size;
-  // Offset in bytes of the implicit HIP/OpenCL suffix, if present.
+  // Offset in bytes of the implicit HIP/OpenCL suffix, if present. Metadata-
+  // derived fixed layouts require all visible arguments to end at or before
+  // this offset; interleaved visible/hidden/visible layouts are rejected while
+  // loading the executable.
   size_t implicit_args_offset;
-  // Total kernarg reservation size in bytes required for this dispatch.
+  // Total kernarg reservation size in bytes required for this dispatch. Fixed
+  // layouts cover the explicit prefix and any implicit suffix; zero means the
+  // caller-provided byte count determines the reservation size.
   size_t total_kernarg_size;
   // True if a HIP/OpenCL implicit args suffix is appended at
   // |implicit_args_offset| and must be populated during emplace.

--- a/runtime/src/iree/hal/drivers/amdgpu/device_spec.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/device_spec.c
@@ -1,0 +1,47 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/device_spec.h"
+
+#include <string.h>
+
+IREE_API_EXPORT const iree_hal_device_spec_facet_t*
+iree_hal_amdgpu_device_spec_find_facet(
+    const iree_hal_device_spec_t* device_spec) {
+  IREE_ASSERT_ARGUMENT(device_spec);
+  return iree_hal_device_spec_find_facet(
+      device_spec,
+      iree_make_cstring_view(IREE_HAL_AMDGPU_DEVICE_SPEC_SCHEMA_ID));
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_amdgpu_device_spec_decode_facet(
+    const iree_hal_device_spec_facet_t* facet,
+    iree_hal_amdgpu_device_spec_t* out_spec) {
+  IREE_ASSERT_ARGUMENT(facet);
+  IREE_ASSERT_ARGUMENT(out_spec);
+  if (!iree_string_view_equal(
+          facet->schema_id,
+          iree_make_cstring_view(IREE_HAL_AMDGPU_DEVICE_SPEC_SCHEMA_ID))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "facet is not an AMDGPU device spec");
+  }
+  if (facet->schema_version != IREE_HAL_AMDGPU_DEVICE_SPEC_SCHEMA_VERSION) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU device spec facet version %u is not supported",
+        facet->schema_version);
+  }
+  memset(out_spec, 0, sizeof(*out_spec));
+  if (facet->payload.data_length != sizeof(*out_spec)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU device spec payload must be exactly %" PRIhsz
+        " bytes; got %" PRIhsz,
+        sizeof(*out_spec), facet->payload.data_length);
+  }
+  memcpy(out_spec, facet->payload.data, sizeof(*out_spec));
+  return iree_ok_status();
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/device_spec.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device_spec.h
@@ -1,0 +1,52 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_DEVICE_SPEC_H_
+#define IREE_HAL_DRIVERS_AMDGPU_DEVICE_SPEC_H_
+
+#include <stdint.h>
+
+#include "iree/base/api.h"
+#include "iree/hal/device_spec.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+#define IREE_HAL_AMDGPU_DEVICE_SPEC_SCHEMA_ID "iree.hal.drivers.amdgpu.device"
+#define IREE_HAL_AMDGPU_DEVICE_SPEC_SCHEMA_VERSION 1u
+
+// Stable AMDGPU device spec flags.
+typedef uint32_t iree_hal_amdgpu_device_spec_flags_t;
+typedef enum iree_hal_amdgpu_device_spec_flag_bits_e {
+  // No AMDGPU device spec flags are present.
+  IREE_HAL_AMDGPU_DEVICE_SPEC_FLAG_NONE = 0u,
+  // The GPU link to the nearest host fine-grained memory pool supports native
+  // atomic transactions.
+  IREE_HAL_AMDGPU_DEVICE_SPEC_FLAG_HOST_NATIVE_ATOMICS = 1u << 0,
+} iree_hal_amdgpu_device_spec_flag_bits_t;
+
+// Pointer-free AMDGPU device facts preserved in a driver-local facet.
+typedef struct iree_hal_amdgpu_device_spec_t {
+  // Stable AMDGPU device spec flags.
+  iree_hal_amdgpu_device_spec_flags_t flags;
+} iree_hal_amdgpu_device_spec_t;
+
+// Finds the AMDGPU device spec facet in |device_spec| or NULL.
+IREE_API_EXPORT const iree_hal_device_spec_facet_t*
+iree_hal_amdgpu_device_spec_find_facet(
+    const iree_hal_device_spec_t* device_spec);
+
+// Decodes an AMDGPU device spec |facet| into |out_spec|.
+IREE_API_EXPORT iree_status_t iree_hal_amdgpu_device_spec_decode_facet(
+    const iree_hal_device_spec_facet_t* facet,
+    iree_hal_amdgpu_device_spec_t* out_spec);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_DEVICE_SPEC_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/device_spec_builder.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/device_spec_builder.c
@@ -457,6 +457,30 @@ static iree_status_t iree_hal_amdgpu_device_spec_populate_sanitizer(
                                                     &params->sanitizer);
 }
 
+static iree_status_t iree_hal_amdgpu_device_spec_populate_facet(
+    const iree_hal_amdgpu_device_spec_params_t* params,
+    iree_hal_device_spec_builder_t* builder) {
+  bool host_native_atomics_supported = true;
+  for (iree_host_size_t i = 0; i < params->physical_device_count; ++i) {
+    if (!params->physical_devices[i].host_native_atomic_supported) {
+      host_native_atomics_supported = false;
+      break;
+    }
+  }
+
+  iree_hal_amdgpu_device_spec_t amdgpu_spec = {
+      .flags = host_native_atomics_supported
+                   ? IREE_HAL_AMDGPU_DEVICE_SPEC_FLAG_HOST_NATIVE_ATOMICS
+                   : IREE_HAL_AMDGPU_DEVICE_SPEC_FLAG_NONE,
+  };
+  iree_hal_device_spec_facet_t facet = {
+      .schema_id = IREE_SV(IREE_HAL_AMDGPU_DEVICE_SPEC_SCHEMA_ID),
+      .schema_version = IREE_HAL_AMDGPU_DEVICE_SPEC_SCHEMA_VERSION,
+      .payload = iree_make_const_byte_span(&amdgpu_spec, sizeof(amdgpu_spec)),
+  };
+  return iree_hal_device_spec_builder_add_facet(builder, &facet);
+}
+
 IREE_API_EXPORT iree_status_t iree_hal_amdgpu_device_spec_create(
     const iree_hal_amdgpu_device_spec_params_t* params,
     iree_allocator_t host_allocator, iree_hal_device_spec_t** out_spec) {
@@ -485,6 +509,9 @@ IREE_API_EXPORT iree_status_t iree_hal_amdgpu_device_spec_create(
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_device_spec_populate_sanitizer(params, &builder);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_amdgpu_device_spec_populate_facet(params, &builder);
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_device_spec_builder_finalize(&builder, out_spec);

--- a/runtime/src/iree/hal/drivers/amdgpu/device_spec_builder.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device_spec_builder.h
@@ -9,6 +9,7 @@
 
 #include "iree/base/api.h"
 #include "iree/hal/allocator.h"
+#include "iree/hal/drivers/amdgpu/device_spec.h"
 #include "iree/hal/executable/amdgpu/target_id.h"
 #include "iree/hal/utils/device_spec_builder.h"
 
@@ -49,6 +50,9 @@ typedef struct iree_hal_amdgpu_device_spec_physical_device_params_t {
   uint32_t maximum_waves_per_compute_unit;
   // Maximum workgroup local-memory byte length.
   uint32_t maximum_workgroup_local_memory_size;
+  // True when the GPU link to nearest host fine-grained memory supports native
+  // atomic transactions.
+  uint32_t host_native_atomic_supported : 1;
   // Optional physical-device parameter flags.
   iree_hal_amdgpu_device_spec_physical_device_flags_t flags;
 } iree_hal_amdgpu_device_spec_physical_device_params_t;

--- a/runtime/src/iree/hal/drivers/amdgpu/device_spec_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/device_spec_test.cc
@@ -30,6 +30,7 @@ static void CreateDeviceSpecForProcessor(
       /*.wavefront_size=*/wavefront_size,
       /*.maximum_waves_per_compute_unit=*/64,
       /*.maximum_workgroup_local_memory_size=*/64 * 1024,
+      /*.host_native_atomic_supported=*/true,
       /*.flags=*/IREE_HAL_AMDGPU_DEVICE_SPEC_PHYSICAL_DEVICE_FLAG_UUID |
           IREE_HAL_AMDGPU_DEVICE_SPEC_PHYSICAL_DEVICE_FLAG_PCI_ADDRESS,
   };
@@ -99,6 +100,14 @@ TEST(DeviceSpecTest, CreatesSpecFromParams) {
             64ull * 1024ull * 1024ull * 1024ull);
   EXPECT_FALSE(iree_all_bits_set(
       memory->heaps[0].flags, IREE_HAL_MEMORY_HEAP_SPEC_FLAG_CAPACITY_UNKNOWN));
+
+  const iree_hal_device_spec_facet_t* facet =
+      iree_hal_amdgpu_device_spec_find_facet(device_spec);
+  ASSERT_NE(facet, nullptr);
+  iree_hal_amdgpu_device_spec_t amdgpu_spec;
+  IREE_ASSERT_OK(iree_hal_amdgpu_device_spec_decode_facet(facet, &amdgpu_spec));
+  EXPECT_TRUE(iree_all_bits_set(
+      amdgpu_spec.flags, IREE_HAL_AMDGPU_DEVICE_SPEC_FLAG_HOST_NATIVE_ATOMICS));
 
   const iree_hal_device_executable_spec_t* executables =
       iree_hal_device_spec_executables(device_spec);

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -1184,6 +1184,102 @@ iree_hal_amdgpu_executable_primary_variant(
   return &executable->load_variants[0];
 }
 
+static iree_host_size_t iree_hal_amdgpu_executable_dispatch_kernarg_size(
+    const iree_hal_amdgpu_executable_dispatch_descriptor_t* descriptor) {
+  const iree_host_size_t metadata_kernarg_size =
+      descriptor->kernarg_layout
+          ? descriptor->kernarg_layout->kernarg_byte_length
+          : 0;
+  const iree_host_size_t custom_kernarg_size =
+      descriptor->custom_kernarg_layout.total_kernarg_size;
+  return iree_max((iree_host_size_t)descriptor->kernel_args.kernarg_size,
+                  iree_max(metadata_kernarg_size, custom_kernarg_size));
+}
+
+void iree_hal_amdgpu_executable_apply_runtime_parameter_patches(
+    const iree_hal_dispatch_config_t config, void* kernarg_data) {
+  const iree_hal_dispatch_runtime_parameter_list_t* runtime_parameters =
+      config.runtime_parameters;
+  if (!runtime_parameters) return;
+  for (uint8_t i = 0; i < runtime_parameters->count; ++i) {
+    const iree_hal_dispatch_runtime_parameter_patch_t* patch =
+        &runtime_parameters->patches[i];
+    memcpy((uint8_t*)kernarg_data + patch->offset, patch->data, patch->length);
+  }
+}
+
+iree_status_t iree_hal_amdgpu_executable_validate_dispatch_runtime_parameters(
+    const iree_hal_amdgpu_executable_dispatch_descriptor_t* descriptor,
+    const iree_hal_dispatch_config_t config) {
+  const iree_hal_dispatch_runtime_parameter_list_t* runtime_parameters =
+      config.runtime_parameters;
+  if (!runtime_parameters) return iree_ok_status();
+  if (IREE_UNLIKELY(runtime_parameters->reserved[0] != 0 ||
+                    runtime_parameters->reserved[1] != 0 ||
+                    runtime_parameters->reserved[2] != 0)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU dispatch runtime parameter list has non-zero reserved bits");
+  }
+  if (IREE_UNLIKELY(runtime_parameters->count >
+                    IREE_HAL_DISPATCH_MAX_RUNTIME_PARAMETER_PATCHES)) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "AMDGPU dispatch runtime parameter patch count %u exceeds %u",
+        runtime_parameters->count,
+        IREE_HAL_DISPATCH_MAX_RUNTIME_PARAMETER_PATCHES);
+  }
+  const iree_host_size_t kernarg_size =
+      iree_hal_amdgpu_executable_dispatch_kernarg_size(descriptor);
+  for (uint8_t i = 0; i < runtime_parameters->count; ++i) {
+    const iree_hal_dispatch_runtime_parameter_patch_t* patch =
+        &runtime_parameters->patches[i];
+    if (IREE_UNLIKELY(patch->reserved != 0)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "AMDGPU dispatch runtime parameter patch[%u] has non-zero reserved "
+          "bits",
+          i);
+    }
+    if (IREE_UNLIKELY(patch->length == 0)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "AMDGPU dispatch runtime parameter patch[%u] has zero length", i);
+    }
+    if (IREE_UNLIKELY(patch->length >
+                      IREE_HAL_DISPATCH_MAX_RUNTIME_PARAMETER_LENGTH)) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "AMDGPU dispatch runtime parameter patch[%u] length %u exceeds %u", i,
+          patch->length, IREE_HAL_DISPATCH_MAX_RUNTIME_PARAMETER_LENGTH);
+    }
+    const iree_host_size_t patch_end =
+        (iree_host_size_t)patch->offset + patch->length;
+    if (IREE_UNLIKELY(patch_end < patch->offset || patch_end > kernarg_size)) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "AMDGPU dispatch runtime parameter patch[%u] range [%" PRIu32
+          ", %" PRIhsz ") exceeds kernarg size %" PRIhsz,
+          i, patch->offset, patch_end, kernarg_size);
+    }
+    for (uint8_t j = 0; j < i; ++j) {
+      const iree_hal_dispatch_runtime_parameter_patch_t* prior_patch =
+          &runtime_parameters->patches[j];
+      const iree_host_size_t prior_patch_end =
+          (iree_host_size_t)prior_patch->offset + prior_patch->length;
+      if (IREE_UNLIKELY(prior_patch->offset < patch_end &&
+                        patch->offset < prior_patch_end)) {
+        return iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "AMDGPU dispatch runtime parameter patch[%u] overlaps patch[%u]", i,
+            j);
+      }
+    }
+  }
+
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_amdgpu_executable_select_queue_scope(
     const iree_hal_amdgpu_executable_t* executable,
     iree_hal_queue_affinity_t queue_affinity,
@@ -1573,19 +1669,39 @@ iree_hal_amdgpu_executable_initialize_dispatch_descriptors_for_device(
         custom_explicit_kernarg_sizes
             ? custom_explicit_kernarg_sizes[kernel_ordinal]
             : executable->host_kernel_args[kernel_ordinal].kernarg_size;
-    const uint16_t custom_implicit_args_offset =
+    uint16_t custom_implicit_args_offset =
         custom_implicit_args_offsets
             ? custom_implicit_args_offsets[kernel_ordinal]
             : UINT16_MAX;
     const iree_hal_amdgpu_kernarg_layout_t* kernarg_layout = NULL;
-    if (!executable->custom_direct_only_exports[kernel_ordinal]) {
+    const iree_hal_amdgpu_kernarg_layout_t* metadata_kernarg_layout = NULL;
+    const iree_hal_amdgpu_executable_export_t* metadata_export =
+        &dispatch_metadata->exports[kernel_ordinal];
+    if (executable->custom_direct_only_exports[kernel_ordinal]) {
+      if (iree_hal_amdgpu_kernarg_layout_ref_is_valid(
+              metadata_export->kernarg_layout)) {
+        IREE_RETURN_IF_ERROR(
+            iree_hal_amdgpu_executable_metadata_resolve_layout(
+                dispatch_metadata, metadata_export->kernarg_layout,
+                &metadata_kernarg_layout),
+            "resolving dispatch kernarg layout for export %" PRIhsz,
+            kernel_ordinal);
+        if (custom_implicit_args_offset == UINT16_MAX &&
+            iree_any_bit_set(
+                metadata_kernarg_layout->flags,
+                IREE_HAL_AMDGPU_KERNARG_LAYOUT_FLAG_IMPLICIT_ARGS)) {
+          custom_implicit_args_offset =
+              metadata_kernarg_layout->implicit_args_byte_offset;
+        }
+      }
+    } else {
       IREE_RETURN_IF_ERROR(
           iree_hal_amdgpu_executable_metadata_resolve_layout(
-              dispatch_metadata,
-              dispatch_metadata->exports[kernel_ordinal].kernarg_layout,
-              &kernarg_layout),
+              dispatch_metadata, metadata_export->kernarg_layout,
+              &metadata_kernarg_layout),
           "resolving dispatch kernarg layout for export %" PRIhsz,
           kernel_ordinal);
+      kernarg_layout = metadata_kernarg_layout;
     }
     IREE_RETURN_IF_ERROR(
         iree_hal_amdgpu_executable_initialize_dispatch_descriptor(
@@ -1802,6 +1918,9 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_export_infos(
     const bool custom_direct_only = iree_any_bit_set(
         metadata_export->flags,
         IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_CUSTOM_DIRECT_ONLY);
+    const bool uniform_workgroup_size = iree_any_bit_set(
+        metadata_export->flags,
+        IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_UNIFORM_WORKGROUP_SIZE);
 
     const iree_hal_amdgpu_kernarg_layout_t* layout = NULL;
     if (!custom_direct_only) {
@@ -1814,18 +1933,62 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_export_infos(
       IREE_RETURN_IF_ERROR(iree_hal_amdgpu_executable_validate_workgroup_size(
           reflection->symbol_name, metadata_export->workgroup_size, limits));
     }
+    const uint32_t max_workgroup_size =
+        metadata_export->max_workgroup_size != 0
+            ? metadata_export->max_workgroup_size
+            : limits->max_workgroup_size;
+    if (IREE_UNLIKELY(max_workgroup_size > limits->max_workgroup_size)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "AMDGPU kernel `%.*s` max workgroup size %u exceeds device maximum "
+          "%u",
+          (int)reflection->symbol_name.size, reflection->symbol_name.data,
+          max_workgroup_size, limits->max_workgroup_size);
+    }
+    if (!requires_dispatch_workgroup_size &&
+        metadata_export->max_workgroup_size != 0) {
+      const uint64_t fixed_workgroup_size =
+          (uint64_t)metadata_export->workgroup_size[0] *
+          metadata_export->workgroup_size[1] *
+          metadata_export->workgroup_size[2];
+      if (IREE_UNLIKELY(fixed_workgroup_size > max_workgroup_size)) {
+        return iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "AMDGPU kernel `%.*s` workgroup size total %" PRIu64
+            " exceeds kernel maximum %u",
+            (int)reflection->symbol_name.size, reflection->symbol_name.data,
+            fixed_workgroup_size, max_workgroup_size);
+      }
+    }
+    if (IREE_UNLIKELY(metadata_export->runtime_parameter_count > UINT16_MAX)) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "AMDGPU kernel `%.*s` has %u runtime parameters; max is %u",
+          (int)reflection->symbol_name.size, reflection->symbol_name.data,
+          metadata_export->runtime_parameter_count, UINT16_MAX);
+    }
 
     executable->custom_direct_only_exports[i] = custom_direct_only;
     executable->export_parameter_offsets[i] = reflection->parameter_offset;
 
     memset(info, 0, sizeof(*info));
     info->name = reflection->name;
-    info->flags = requires_dispatch_workgroup_size
-                      ? IREE_HAL_EXECUTABLE_FUNCTION_FLAG_WORKGROUP_SIZE_DYNAMIC
-                      : IREE_HAL_EXECUTABLE_FUNCTION_FLAG_NONE;
+    info->flags = IREE_HAL_EXECUTABLE_FUNCTION_FLAG_NONE;
+    if (requires_dispatch_workgroup_size) {
+      info->flags |= IREE_HAL_EXECUTABLE_FUNCTION_FLAG_WORKGROUP_SIZE_DYNAMIC;
+    }
+    if (uniform_workgroup_size) {
+      info->flags |= IREE_HAL_EXECUTABLE_FUNCTION_FLAG_UNIFORM_WORKGROUP_SIZE;
+    }
     info->constant_byte_length = layout ? layout->constant_byte_length : 0;
     info->binding_count = layout ? layout->binding_count : 0;
     info->parameter_count = reflection->parameter_count;
+    info->runtime_parameter_count =
+        (uint16_t)metadata_export->runtime_parameter_count;
+    info->max_workgroup_size = max_workgroup_size;
+    info->workgroup_local_memory_size =
+        metadata_export->fixed_group_segment_size;
+    info->private_memory_size = metadata_export->fixed_private_segment_size;
     if (requires_dispatch_workgroup_size) {
       info->workgroup_size[0] = 1;
       info->workgroup_size[1] = 1;
@@ -2590,6 +2753,71 @@ static iree_status_t iree_hal_amdgpu_executable_export_parameters(
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_amdgpu_executable_export_runtime_parameters(
+    iree_hal_executable_t* base_executable,
+    iree_hal_executable_function_t function, iree_host_size_t capacity,
+    iree_hal_executable_function_runtime_parameter_info_t* out_parameters) {
+  IREE_ASSERT_ARGUMENT(out_parameters || capacity == 0);
+  iree_hal_amdgpu_executable_t* executable =
+      iree_hal_amdgpu_executable_cast(base_executable);
+  if (IREE_UNLIKELY(!iree_hal_executable_function_is_index_in_range(
+          function, executable->kernel_count))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "function id %" PRIu64
+                            " out of range; executable has %" PRIhsz " exports",
+                            function.value, executable->kernel_count);
+  }
+  const uint32_t export_ordinal = iree_hal_executable_function_index(function);
+  const iree_hal_amdgpu_executable_export_t* export_info =
+      &executable->metadata->exports[export_ordinal];
+  const iree_host_size_t parameter_begin =
+      export_info->runtime_parameter_offset;
+  const iree_host_size_t parameter_count = export_info->runtime_parameter_count;
+  const iree_host_size_t copy_count = iree_min(capacity, parameter_count);
+  for (iree_host_size_t i = 0; i < copy_count; ++i) {
+    const iree_hal_amdgpu_executable_runtime_parameter_t* parameter =
+        &executable->metadata->runtime_parameters[parameter_begin + i];
+    out_parameters[i] = (iree_hal_executable_function_runtime_parameter_info_t){
+        .name = parameter->name,
+        .offset = parameter->offset,
+        .length = parameter->length,
+    };
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_executable_runtime_metadata_count(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_host_size_t* out_count) {
+  iree_hal_amdgpu_executable_t* executable =
+      iree_hal_amdgpu_executable_cast(base_executable);
+  *out_count = 0;
+  if (iree_string_view_equal(name, IREE_SV("amdhsa.printf"))) {
+    *out_count = executable->metadata->printf_record_count;
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_executable_runtime_metadata_records(
+    iree_hal_executable_t* base_executable, iree_string_view_t name,
+    iree_host_size_t capacity,
+    iree_hal_executable_runtime_metadata_record_t* out_records) {
+  iree_hal_amdgpu_executable_t* executable =
+      iree_hal_amdgpu_executable_cast(base_executable);
+  if (!iree_string_view_equal(name, IREE_SV("amdhsa.printf"))) {
+    return iree_ok_status();
+  }
+  const iree_host_size_t copy_count =
+      iree_min(capacity, executable->metadata->printf_record_count);
+  for (iree_host_size_t i = 0; i < copy_count; ++i) {
+    out_records[i] = (iree_hal_executable_runtime_metadata_record_t){
+        .name = name,
+        .value = executable->metadata->printf_records[i],
+    };
+  }
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_amdgpu_executable_lookup_export_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
     iree_hal_executable_function_t* out_export_ordinal) {
@@ -2667,6 +2895,11 @@ static const iree_hal_executable_vtable_t iree_hal_amdgpu_executable_vtable = {
     .function_count = iree_hal_amdgpu_executable_export_count,
     .function_info = iree_hal_amdgpu_executable_export_info,
     .function_parameters = iree_hal_amdgpu_executable_export_parameters,
+    .function_runtime_parameters =
+        iree_hal_amdgpu_executable_export_runtime_parameters,
+    .runtime_metadata_count = iree_hal_amdgpu_executable_runtime_metadata_count,
+    .runtime_metadata_records =
+        iree_hal_amdgpu_executable_runtime_metadata_records,
     .lookup_function_by_name = iree_hal_amdgpu_executable_lookup_export_by_name,
     .try_lookup_global_by_name =
         iree_hal_amdgpu_executable_try_lookup_global_by_name,

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.h
@@ -64,10 +64,9 @@ iree_status_t iree_hal_amdgpu_executable_target_supported(
 // Host-resident dispatch metadata precomputed for one executable export on one
 // physical device.
 //
-// Descriptors are immutable after executable creation and remain valid for the
-// lifetime of the executable. They intentionally duplicate the device-visible
-// kernel argument table in ordinary host memory so queue submission does not
-// read per-dispatch metadata from memory allocated for GPU visibility.
+// Descriptors remain valid for the lifetime of the executable. They contain
+// immutable launch metadata and validate the structural shape of runtime
+// parameter patches supplied by embedding runtimes.
 typedef struct iree_hal_amdgpu_executable_dispatch_descriptor_t {
   // Device-specific kernel arguments with a valid kernel_object for dispatch.
   iree_hal_amdgpu_device_kernel_args_t kernel_args;
@@ -102,7 +101,15 @@ typedef struct iree_hal_amdgpu_executable_dispatch_descriptor_t {
   bool pm4_launch_state_valid;
 } iree_hal_amdgpu_executable_dispatch_descriptor_t;
 
-// Creates an AMDGPU executable from a binary in memory. Each executable may
+void iree_hal_amdgpu_executable_apply_runtime_parameter_patches(
+    const iree_hal_dispatch_config_t config, void* kernarg_data);
+
+// Validates the structural bounds of runtime parameter patches in |config|.
+iree_status_t iree_hal_amdgpu_executable_validate_dispatch_runtime_parameters(
+    const iree_hal_amdgpu_executable_dispatch_descriptor_t* descriptor,
+    const iree_hal_dispatch_config_t config);
+
+// Creates a AMDGPU executable from a binary in memory. Each executable may
 // contain multiple entry points and be composed of several modules presented to
 // the HAL as a single instance. See iree_hal_executable_load_params_t for more
 // information about the lifetime of the resources referenced within.

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata.c
@@ -25,6 +25,9 @@ iree_status_t iree_hal_amdgpu_executable_metadata_storage_size(
                         iree_hal_amdgpu_executable_reflection_t, NULL),
       IREE_STRUCT_FIELD(counts->parameter_count,
                         iree_hal_executable_function_parameter_t, NULL),
+      IREE_STRUCT_FIELD(counts->runtime_parameter_count,
+                        iree_hal_amdgpu_executable_runtime_parameter_t, NULL),
+      IREE_STRUCT_FIELD(counts->printf_record_count, iree_string_view_t, NULL),
       IREE_STRUCT_FIELD_ALIGNED(counts->layout_blob_byte_length, uint8_t,
                                 iree_alignof(iree_hal_amdgpu_kernarg_layout_t),
                                 NULL));
@@ -43,6 +46,8 @@ iree_status_t iree_hal_amdgpu_executable_metadata_allocate(
   iree_host_size_t exports_offset = 0;
   iree_host_size_t reflection_offset = 0;
   iree_host_size_t parameters_offset = 0;
+  iree_host_size_t runtime_parameters_offset = 0;
+  iree_host_size_t printf_records_offset = 0;
   iree_host_size_t layout_blob_offset = 0;
   iree_host_size_t total_size = 0;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
@@ -57,6 +62,11 @@ iree_status_t iree_hal_amdgpu_executable_metadata_allocate(
               IREE_STRUCT_FIELD(counts->parameter_count,
                                 iree_hal_executable_function_parameter_t,
                                 &parameters_offset),
+              IREE_STRUCT_FIELD(counts->runtime_parameter_count,
+                                iree_hal_amdgpu_executable_runtime_parameter_t,
+                                &runtime_parameters_offset),
+              IREE_STRUCT_FIELD(counts->printf_record_count, iree_string_view_t,
+                                &printf_records_offset),
               IREE_STRUCT_FIELD_ALIGNED(
                   counts->layout_blob_byte_length, uint8_t,
                   iree_alignof(iree_hal_amdgpu_kernarg_layout_t),
@@ -86,6 +96,17 @@ iree_status_t iree_hal_amdgpu_executable_metadata_allocate(
         counts->parameter_count
             ? (iree_hal_executable_function_parameter_t*)(storage_base +
                                                           parameters_offset)
+            : NULL;
+    metadata->runtime_parameter_count = counts->runtime_parameter_count;
+    metadata->runtime_parameters =
+        counts->runtime_parameter_count
+            ? (iree_hal_amdgpu_executable_runtime_parameter_t*)(storage_base +
+                                                                runtime_parameters_offset)
+            : NULL;
+    metadata->printf_record_count = counts->printf_record_count;
+    metadata->printf_records =
+        counts->printf_record_count
+            ? (iree_string_view_t*)(storage_base + printf_records_offset)
             : NULL;
     metadata->layout_blob_capacity = counts->layout_blob_byte_length;
     metadata->layout_blob = counts->layout_blob_byte_length

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata.h
@@ -40,6 +40,8 @@ typedef enum iree_hal_amdgpu_executable_export_flag_bits_e {
       1u << 0,
   // Export can only be launched with caller-provided native kernargs.
   IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_CUSTOM_DIRECT_ONLY = 1u << 1,
+  // OpenCL/HIP kernel requires every workgroup to have the same size.
+  IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_UNIFORM_WORKGROUP_SIZE = 1u << 2,
 } iree_hal_amdgpu_executable_export_flag_bits_t;
 typedef uint32_t iree_hal_amdgpu_executable_export_flags_t;
 
@@ -70,6 +72,10 @@ typedef struct iree_hal_amdgpu_executable_metadata_counts_t {
   iree_host_size_t export_count;
   // Number of reflected HAL parameter records.
   iree_host_size_t parameter_count;
+  // Number of hidden runtime parameter records.
+  iree_host_size_t runtime_parameter_count;
+  // Number of raw `amdhsa.printf` metadata records.
+  iree_host_size_t printf_record_count;
   // Total byte capacity required for immutable kernarg layout records.
   iree_host_size_t layout_blob_byte_length;
 } iree_hal_amdgpu_executable_metadata_counts_t;
@@ -86,6 +92,16 @@ typedef struct iree_hal_amdgpu_executable_reflection_t {
   uint32_t parameter_count;
 } iree_hal_amdgpu_executable_reflection_t;
 
+// Hidden runtime parameter declared by executable metadata.
+typedef struct iree_hal_amdgpu_executable_runtime_parameter_t {
+  // Runtime parameter name from native executable metadata.
+  iree_string_view_t name;
+  // Native byte offset in the kernarg segment.
+  uint16_t offset;
+  // Byte length of the runtime parameter storage.
+  uint16_t length;
+} iree_hal_amdgpu_executable_runtime_parameter_t;
+
 // Hot provider-neutral metadata for one executable export.
 typedef struct iree_hal_amdgpu_executable_export_t {
   // Export dispatch/layout feature flags.
@@ -100,10 +116,16 @@ typedef struct iree_hal_amdgpu_executable_export_t {
   uint32_t fixed_group_segment_size;
   // Fixed private segment byte size reported by executable metadata.
   uint32_t fixed_private_segment_size;
+  // Maximum total work-items per workgroup accepted by this export.
+  uint32_t max_workgroup_size;
   // Maximum dynamic group-memory byte count accepted for this export.
   uint32_t max_dynamic_workgroup_local_memory;
   // Native kernarg layout record for normal metadata-described dispatch.
   iree_hal_amdgpu_kernarg_layout_ref_t kernarg_layout;
+  // First runtime parameter record for this export.
+  uint32_t runtime_parameter_offset;
+  // Number of runtime parameter records for this export.
+  uint32_t runtime_parameter_count;
 } iree_hal_amdgpu_executable_export_t;
 
 // Provider-neutral executable metadata populated during executable load.
@@ -126,6 +148,14 @@ typedef struct iree_hal_amdgpu_executable_metadata_t {
   iree_host_size_t parameter_count;
   // Reflected HAL parameter records for all exports.
   iree_hal_executable_function_parameter_t* parameters;
+  // Number of hidden runtime parameter records.
+  iree_host_size_t runtime_parameter_count;
+  // Hidden runtime parameter records for all exports.
+  iree_hal_amdgpu_executable_runtime_parameter_t* runtime_parameters;
+  // Number of raw `amdhsa.printf` metadata records.
+  iree_host_size_t printf_record_count;
+  // Raw `amdhsa.printf` metadata records.
+  iree_string_view_t* printf_records;
   // Total byte capacity of layout_blob.
   iree_host_size_t layout_blob_capacity;
   // Number of bytes already allocated from layout_blob.

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco.c
@@ -16,8 +16,12 @@
 //===----------------------------------------------------------------------===//
 
 typedef struct iree_hal_amdgpu_hsaco_kernel_load_plan_t {
+  // Export flags derived while scanning kernel metadata.
+  iree_hal_amdgpu_executable_export_flags_t export_flags;
   // Number of reflected HAL-visible parameter records.
   iree_host_size_t parameter_count;
+  // Number of hidden runtime parameter records.
+  iree_host_size_t runtime_parameter_count;
   // Number of HAL binding pointers consumed by the native layout.
   iree_host_size_t binding_count;
   // Number of HAL dispatch-constant spans consumed by the native layout.
@@ -112,6 +116,11 @@ static bool iree_hal_amdgpu_hsaco_metadata_arg_kind_is_hidden(
          kind == IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN_NONE;
 }
 
+static bool iree_hal_amdgpu_hsaco_metadata_arg_kind_is_runtime_parameter(
+    iree_hal_amdgpu_hsaco_metadata_arg_kind_t kind) {
+  return kind == IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN;
+}
+
 static iree_status_t iree_hal_amdgpu_hsaco_load_plan_check_u16(
     iree_string_view_t symbol_name, iree_string_view_t field_name,
     iree_host_size_t value) {
@@ -163,6 +172,10 @@ static iree_status_t iree_hal_amdgpu_hsaco_load_plan_analyze_kernel(
     }
 
     if (iree_hal_amdgpu_hsaco_metadata_arg_kind_is_hidden(arg->kind)) {
+      if (iree_hal_amdgpu_hsaco_metadata_arg_kind_is_runtime_parameter(
+              arg->kind)) {
+        ++out_load_plan->runtime_parameter_count;
+      }
       hidden_args_offset =
           iree_min(hidden_args_offset, (iree_host_size_t)arg->offset);
       continue;
@@ -307,6 +320,7 @@ iree_status_t iree_hal_amdgpu_executable_metadata_calculate_hsaco_counts(
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "AMDGPU metadata export count overflow");
   }
+  out_counts->printf_record_count = hsaco_metadata->printf_record_count;
 
   for (iree_host_size_t i = 0; i < hsaco_metadata->kernel_count; ++i) {
     iree_hal_amdgpu_hsaco_kernel_load_plan_t load_plan;
@@ -325,6 +339,20 @@ iree_status_t iree_hal_amdgpu_executable_metadata_calculate_hsaco_counts(
       return iree_make_status(
           IREE_STATUS_OUT_OF_RANGE,
           "AMDGPU metadata parameter count exceeds reflection offset range");
+    }
+    if (IREE_UNLIKELY(!iree_host_size_checked_add(
+            out_counts->runtime_parameter_count,
+            load_plan.runtime_parameter_count,
+            &out_counts->runtime_parameter_count))) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "AMDGPU metadata runtime parameter count overflow");
+    }
+    if (IREE_UNLIKELY(out_counts->runtime_parameter_count > UINT32_MAX)) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "AMDGPU metadata runtime parameter count exceeds reflection offset "
+          "range");
     }
     IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_load_plan_add_layout_capacity(
         load_plan.layout_byte_length, &out_counts->layout_blob_byte_length));
@@ -389,6 +417,48 @@ static iree_status_t iree_hal_amdgpu_hsaco_load_plan_populate_layout_tables(
   };
   return iree_hal_amdgpu_kernarg_layout_initialize(
       &params, layout_storage_capacity, layout);
+}
+
+static iree_status_t
+iree_hal_amdgpu_hsaco_load_plan_populate_runtime_parameters(
+    const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel,
+    const iree_hal_amdgpu_hsaco_loaded_code_object_rebase_t* rebase,
+    iree_host_size_t capacity,
+    iree_hal_amdgpu_executable_runtime_parameter_t* out_runtime_parameters) {
+  iree_host_size_t runtime_parameter_count = 0;
+  for (iree_host_size_t i = 0; i < kernel->arg_count; ++i) {
+    const iree_hal_amdgpu_hsaco_metadata_arg_t* arg = &kernel->args[i];
+    if (!iree_hal_amdgpu_hsaco_metadata_arg_kind_is_runtime_parameter(
+            arg->kind)) {
+      continue;
+    }
+    if (IREE_UNLIKELY(runtime_parameter_count >= capacity)) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "AMDGPU runtime parameter population exceeded planned capacity");
+    }
+    if (IREE_UNLIKELY(arg->offset > UINT16_MAX || arg->size > UINT16_MAX)) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "AMDGPU runtime parameter `%.*s` exceeds supported offset/length "
+          "range",
+          (int)arg->value_kind.size, arg->value_kind.data);
+    }
+    iree_hal_amdgpu_executable_runtime_parameter_t* runtime_parameter =
+        &out_runtime_parameters[runtime_parameter_count++];
+    IREE_RETURN_IF_ERROR(
+        iree_hal_amdgpu_hsaco_loaded_code_object_rebase_string_view(
+            rebase, "runtime parameter name", arg->value_kind,
+            &runtime_parameter->name));
+    runtime_parameter->offset = (uint16_t)arg->offset;
+    runtime_parameter->length = (uint16_t)arg->size;
+  }
+  if (IREE_UNLIKELY(runtime_parameter_count != capacity)) {
+    return iree_make_status(
+        IREE_STATUS_INTERNAL,
+        "AMDGPU runtime parameter population count changed");
+  }
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_amdgpu_hsaco_load_plan_populate_parameters(
@@ -479,10 +549,12 @@ iree_status_t iree_hal_amdgpu_executable_metadata_populate_from_hsaco(
   IREE_RETURN_IF_ERROR(
       iree_hal_amdgpu_executable_metadata_calculate_hsaco_counts(hsaco_metadata,
                                                                  &counts));
-  if (IREE_UNLIKELY(metadata->export_count != counts.export_count ||
-                    metadata->parameter_count < counts.parameter_count ||
-                    metadata->layout_blob_capacity <
-                        counts.layout_blob_byte_length)) {
+  if (IREE_UNLIKELY(
+          metadata->export_count != counts.export_count ||
+          metadata->parameter_count < counts.parameter_count ||
+          metadata->runtime_parameter_count < counts.runtime_parameter_count ||
+          metadata->printf_record_count < counts.printf_record_count ||
+          metadata->layout_blob_capacity < counts.layout_blob_byte_length)) {
     return iree_make_status(
         IREE_STATUS_RESOURCE_EXHAUSTED,
         "AMDGPU executable metadata storage does not match HSACO counts");
@@ -506,8 +578,15 @@ iree_status_t iree_hal_amdgpu_executable_metadata_populate_from_hsaco(
       iree_hal_amdgpu_hsaco_loaded_code_object_rebase_string_view(
           &rebase, "target", hsaco_metadata->target, &metadata->target));
   metadata->code_object_data = loaded_code_object_data;
+  for (iree_host_size_t i = 0; i < hsaco_metadata->printf_record_count; ++i) {
+    IREE_RETURN_IF_ERROR(
+        iree_hal_amdgpu_hsaco_loaded_code_object_rebase_string_view(
+            &rebase, "printf record", hsaco_metadata->printf_records[i].value,
+            &metadata->printf_records[i]));
+  }
 
   iree_host_size_t parameter_offset = 0;
+  iree_host_size_t runtime_parameter_offset = 0;
   for (iree_host_size_t i = 0; i < hsaco_metadata->kernel_count; ++i) {
     const iree_hal_amdgpu_hsaco_metadata_kernel_t* kernel =
         &hsaco_metadata->kernels[i];
@@ -531,12 +610,20 @@ iree_status_t iree_hal_amdgpu_executable_metadata_populate_from_hsaco(
     reflection->parameter_count = (uint32_t)load_plan.parameter_count;
 
     iree_hal_amdgpu_executable_export_t* export_info = &metadata->exports[i];
-    export_info->flags = IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_NONE;
+    export_info->flags = load_plan.export_flags;
+    export_info->runtime_parameter_offset = (uint32_t)runtime_parameter_offset;
+    export_info->runtime_parameter_count =
+        (uint32_t)load_plan.runtime_parameter_count;
     export_info->fixed_group_segment_size = kernel->group_segment_fixed_size;
     export_info->fixed_private_segment_size =
         kernel->private_segment_fixed_size;
+    export_info->max_workgroup_size = kernel->max_flat_workgroup_size;
     export_info->max_dynamic_workgroup_local_memory =
         UINT32_MAX - kernel->group_segment_fixed_size;
+    if (kernel->uniform_workgroup_size) {
+      export_info->flags |=
+          IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_UNIFORM_WORKGROUP_SIZE;
+    }
     iree_hal_amdgpu_hsaco_load_plan_populate_workgroup_size(kernel,
                                                             export_info);
     iree_hal_amdgpu_hsaco_load_plan_populate_workgroup_cluster_size(
@@ -561,7 +648,16 @@ iree_status_t iree_hal_amdgpu_executable_metadata_populate_from_hsaco(
                                       : NULL),
         "populating reflected parameters for kernel `%.*s`",
         (int)kernel->symbol_name.size, kernel->symbol_name.data);
+    IREE_RETURN_IF_ERROR(
+        iree_hal_amdgpu_hsaco_load_plan_populate_runtime_parameters(
+            kernel, &rebase, load_plan.runtime_parameter_count,
+            load_plan.runtime_parameter_count
+                ? &metadata->runtime_parameters[runtime_parameter_offset]
+                : NULL),
+        "populating runtime parameters for kernel `%.*s`",
+        (int)kernel->symbol_name.size, kernel->symbol_name.data);
     parameter_offset += load_plan.parameter_count;
+    runtime_parameter_offset += load_plan.runtime_parameter_count;
   }
 
   for (iree_host_size_t i = 0; i < hsaco_metadata->elf_kernel_symbol_count;
@@ -586,6 +682,12 @@ iree_status_t iree_hal_amdgpu_executable_metadata_populate_from_hsaco(
     return iree_make_status(
         IREE_STATUS_INTERNAL,
         "AMDGPU metadata parameter population count changed");
+  }
+  if (IREE_UNLIKELY(runtime_parameter_offset !=
+                    counts.runtime_parameter_count)) {
+    return iree_make_status(
+        IREE_STATUS_INTERNAL,
+        "AMDGPU metadata runtime parameter population count changed");
   }
   return iree_ok_status();
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco_test.cc
@@ -6,6 +6,7 @@
 
 #include "iree/hal/drivers/amdgpu/executable_metadata_hsaco.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <vector>
@@ -32,11 +33,19 @@ static const uint8_t kSourceCodeObjectData[] =
     "buffer\0"
     "value\0"
     "grid_x\0"
+    "printf\0"
+    "hostcall\0"
+    "heap\0"
     "direct\0"
     "direct.kd\0"
     "global_buffer\0"
     "by_value\0"
-    "hidden_global_offset_x\0";
+    "hidden_global_offset_x\0"
+    "hidden_printf_buffer\0"
+    "hidden_hostcall_buffer\0"
+    "hidden_heap_v1\0"
+    "0:0:8addc4c0362218ac,Hello World!\\n\0"
+    "0:0:1122334455667788,value=%d\\n\0";
 
 static iree_const_byte_span_t SourceCodeObjectData() {
   return iree_make_const_byte_span(kSourceCodeObjectData,
@@ -122,10 +131,12 @@ static iree_hal_amdgpu_hsaco_metadata_kernel_t MakeKernel(
       /*.kernarg_segment_alignment=*/8,
       /*.group_segment_fixed_size=*/16,
       /*.private_segment_fixed_size=*/32,
+      /*.max_flat_workgroup_size=*/256,
       /*.required_workgroup_size=*/{},
       /*.has_required_workgroup_size=*/{},
       /*.workgroup_cluster_size=*/{},
       /*.has_workgroup_cluster_size=*/{},
+      /*.uniform_workgroup_size=*/false,
       /*.arg_count=*/args.size(),
       /*.args=*/args.data(),
   };
@@ -176,6 +187,14 @@ TEST(ExecutableMetadataHsacoTest, PopulatesSparseInterleavedKernelLayout) {
   kernel.workgroup_cluster_size[0] = 1;
   kernel.workgroup_cluster_size[1] = 2;
   kernel.workgroup_cluster_size[2] = 1;
+  iree_hal_amdgpu_hsaco_metadata_printf_record_t printf_records[] = {
+      {/*.value=*/
+       ViewFromCodeObjectData(source_code_object_data,
+                              "0:0:8addc4c0362218ac,Hello World!\\n")},
+      {/*.value=*/
+       ViewFromCodeObjectData(source_code_object_data,
+                              "0:0:1122334455667788,value=%d\\n")},
+  };
   iree_hal_amdgpu_hsaco_metadata_t hsaco_metadata = {
       /*.host_allocator=*/{},
       /*.elf_data=*/source_code_object_data,
@@ -187,6 +206,10 @@ TEST(ExecutableMetadataHsacoTest, PopulatesSparseInterleavedKernelLayout) {
       /*.arg_name_storage_size=*/{},
       /*.kernel_count=*/1,
       /*.kernels=*/&kernel,
+      /*.elf_kernel_symbol_count=*/{},
+      /*.elf_kernel_symbols=*/{},
+      /*.printf_record_count=*/IREE_ARRAYSIZE(printf_records),
+      /*.printf_records=*/printf_records,
   };
 
   iree_hal_amdgpu_executable_metadata_counts_t counts;
@@ -194,6 +217,7 @@ TEST(ExecutableMetadataHsacoTest, PopulatesSparseInterleavedKernelLayout) {
       &hsaco_metadata, &counts));
   EXPECT_EQ(counts.export_count, 1);
   EXPECT_EQ(counts.parameter_count, 4);
+  EXPECT_EQ(counts.printf_record_count, 2);
   EXPECT_GT(counts.layout_blob_byte_length, 0);
 
   iree_hal_amdgpu_executable_metadata_t* metadata =
@@ -206,6 +230,11 @@ TEST(ExecutableMetadataHsacoTest, PopulatesSparseInterleavedKernelLayout) {
   EXPECT_EQ(metadata->code_object_data.data, loaded_code_object_data.data);
   EXPECT_EQ(metadata->code_object_data.data_length,
             loaded_code_object_data.data_length);
+  ASSERT_EQ(metadata->printf_record_count, 2);
+  ExpectRebasedView(loaded_code_object_data, printf_records[0].value,
+                    metadata->printf_records[0]);
+  ExpectRebasedView(loaded_code_object_data, printf_records[1].value,
+                    metadata->printf_records[1]);
 
   const iree_hal_amdgpu_executable_export_t& export_info = metadata->exports[0];
   EXPECT_EQ(export_info.flags, IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_NONE);
@@ -305,6 +334,91 @@ TEST(ExecutableMetadataHsacoTest, PopulatesImplicitArgsSuffixLayout) {
               IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
               ViewFromCodeObjectData(source_code_object_data,
                                      "hidden_global_offset_x")),
+      MakeArg(ViewFromCodeObjectData(source_code_object_data, "printf"),
+              16 + offsetof(iree_amdgpu_kernel_implicit_args_t, printf_buffer),
+              8, IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+              ViewFromCodeObjectData(source_code_object_data,
+                                     "hidden_printf_buffer")),
+      MakeArg(
+          ViewFromCodeObjectData(source_code_object_data, "hostcall"),
+          16 + offsetof(iree_amdgpu_kernel_implicit_args_t, hostcall_buffer), 8,
+          IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+          ViewFromCodeObjectData(source_code_object_data,
+                                 "hidden_hostcall_buffer")),
+  };
+  iree_hal_amdgpu_hsaco_metadata_kernel_t kernel =
+      MakeKernel(ViewFromCodeObjectData(source_code_object_data, "implicit"),
+                 ViewFromCodeObjectData(source_code_object_data, "implicit.kd"),
+                 16 + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE, args);
+  iree_hal_amdgpu_hsaco_metadata_t hsaco_metadata = {
+      /*.host_allocator=*/{},
+      /*.elf_data=*/source_code_object_data,
+      /*.message_pack_data=*/{},
+      /*.target=*/{},
+      /*.reflection_name_storage_size=*/{},
+      /*.arg_name_storage_size=*/{},
+      /*.kernel_count=*/1,
+      /*.kernels=*/&kernel,
+  };
+
+  iree_hal_amdgpu_executable_metadata_counts_t counts;
+  IREE_ASSERT_OK(iree_hal_amdgpu_executable_metadata_calculate_hsaco_counts(
+      &hsaco_metadata, &counts));
+  EXPECT_EQ(counts.parameter_count, 2);
+  EXPECT_EQ(counts.runtime_parameter_count, 3);
+
+  iree_hal_amdgpu_executable_metadata_t* metadata =
+      AllocateAndPopulate(&hsaco_metadata, loaded_code_object_data);
+  EXPECT_EQ(
+      metadata->exports[0].flags,
+      IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_REQUIRES_DISPATCH_WORKGROUP_SIZE);
+  EXPECT_EQ(metadata->runtime_parameter_count, 3);
+  EXPECT_EQ(metadata->exports[0].runtime_parameter_offset, 0);
+  EXPECT_EQ(metadata->exports[0].runtime_parameter_count, 3);
+  ExpectRebasedView(loaded_code_object_data, args[2].value_kind,
+                    metadata->runtime_parameters[0].name);
+  EXPECT_EQ(metadata->runtime_parameters[0].offset, 16);
+  ExpectRebasedView(loaded_code_object_data, args[3].value_kind,
+                    metadata->runtime_parameters[1].name);
+  EXPECT_EQ(metadata->runtime_parameters[1].offset,
+            16 + offsetof(iree_amdgpu_kernel_implicit_args_t, printf_buffer));
+  ExpectRebasedView(loaded_code_object_data, args[4].value_kind,
+                    metadata->runtime_parameters[2].name);
+  EXPECT_EQ(metadata->runtime_parameters[2].offset,
+            16 + offsetof(iree_amdgpu_kernel_implicit_args_t, hostcall_buffer));
+
+  const iree_hal_amdgpu_kernarg_layout_t* layout = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_executable_metadata_resolve_layout(
+      metadata, metadata->exports[0].kernarg_layout, &layout));
+  EXPECT_EQ(layout->implicit_args_byte_offset, 16);
+  EXPECT_TRUE(iree_all_bits_set(
+      layout->flags,
+      IREE_HAL_AMDGPU_KERNARG_LAYOUT_FLAG_IMPLICIT_ARGS |
+          IREE_HAL_AMDGPU_KERNARG_LAYOUT_FLAG_REQUIRES_ZERO_FILL));
+  EXPECT_EQ(layout->binding_count, 1);
+  EXPECT_EQ(layout->constant_byte_length, 4);
+
+  iree_hal_amdgpu_executable_metadata_free(metadata);
+}
+
+TEST(ExecutableMetadataHsacoTest,
+     PreservesRuntimeParametersWithoutServiceClassification) {
+  const iree_const_byte_span_t source_code_object_data = SourceCodeObjectData();
+  std::vector<uint8_t> loaded_code_object_storage = MakeLoadedCodeObjectData();
+  const iree_const_byte_span_t loaded_code_object_data =
+      LoadedCodeObjectData(loaded_code_object_storage);
+  std::vector<iree_hal_amdgpu_hsaco_metadata_arg_t> args = {
+      MakeArg(
+          ViewFromCodeObjectData(source_code_object_data, "hostcall"),
+          16 + offsetof(iree_amdgpu_kernel_implicit_args_t, hostcall_buffer), 8,
+          IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+          ViewFromCodeObjectData(source_code_object_data,
+                                 "hidden_hostcall_buffer")),
+      MakeArg(
+          ViewFromCodeObjectData(source_code_object_data, "heap"),
+          16 + offsetof(iree_amdgpu_kernel_implicit_args_t, unused_heap_v1), 8,
+          IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+          ViewFromCodeObjectData(source_code_object_data, "hidden_heap_v1")),
   };
   iree_hal_amdgpu_hsaco_metadata_kernel_t kernel =
       MakeKernel(ViewFromCodeObjectData(source_code_object_data, "implicit"),
@@ -323,20 +437,20 @@ TEST(ExecutableMetadataHsacoTest, PopulatesImplicitArgsSuffixLayout) {
 
   iree_hal_amdgpu_executable_metadata_t* metadata =
       AllocateAndPopulate(&hsaco_metadata, loaded_code_object_data);
-  EXPECT_TRUE(iree_any_bit_set(
+  EXPECT_EQ(
       metadata->exports[0].flags,
-      IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_REQUIRES_DISPATCH_WORKGROUP_SIZE));
-
-  const iree_hal_amdgpu_kernarg_layout_t* layout = nullptr;
-  IREE_ASSERT_OK(iree_hal_amdgpu_executable_metadata_resolve_layout(
-      metadata, metadata->exports[0].kernarg_layout, &layout));
-  EXPECT_EQ(layout->implicit_args_byte_offset, 16);
-  EXPECT_TRUE(iree_all_bits_set(
-      layout->flags,
-      IREE_HAL_AMDGPU_KERNARG_LAYOUT_FLAG_IMPLICIT_ARGS |
-          IREE_HAL_AMDGPU_KERNARG_LAYOUT_FLAG_REQUIRES_ZERO_FILL));
-  EXPECT_EQ(layout->binding_count, 1);
-  EXPECT_EQ(layout->constant_byte_length, 4);
+      IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_REQUIRES_DISPATCH_WORKGROUP_SIZE);
+  EXPECT_EQ(metadata->runtime_parameter_count, 2);
+  EXPECT_EQ(metadata->exports[0].runtime_parameter_offset, 0);
+  EXPECT_EQ(metadata->exports[0].runtime_parameter_count, 2);
+  ExpectRebasedView(loaded_code_object_data, args[0].value_kind,
+                    metadata->runtime_parameters[0].name);
+  EXPECT_EQ(metadata->runtime_parameters[0].offset,
+            16 + offsetof(iree_amdgpu_kernel_implicit_args_t, hostcall_buffer));
+  ExpectRebasedView(loaded_code_object_data, args[1].value_kind,
+                    metadata->runtime_parameters[1].name);
+  EXPECT_EQ(metadata->runtime_parameters[1].offset,
+            16 + offsetof(iree_amdgpu_kernel_implicit_args_t, unused_heap_v1));
 
   iree_hal_amdgpu_executable_metadata_free(metadata);
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_test.cc
@@ -18,6 +18,8 @@ TEST(ExecutableMetadataTest, AllocatesHotAndColdTables) {
   iree_hal_amdgpu_executable_metadata_counts_t counts = {
       /*.export_count=*/2,
       /*.parameter_count=*/3,
+      /*.runtime_parameter_count=*/1,
+      /*.printf_record_count=*/2,
       /*.layout_blob_byte_length=*/128,
   };
 
@@ -30,6 +32,10 @@ TEST(ExecutableMetadataTest, AllocatesHotAndColdTables) {
   EXPECT_NE(metadata->reflection, nullptr);
   EXPECT_EQ(metadata->parameter_count, 3);
   EXPECT_NE(metadata->parameters, nullptr);
+  EXPECT_EQ(metadata->runtime_parameter_count, 1);
+  EXPECT_NE(metadata->runtime_parameters, nullptr);
+  EXPECT_EQ(metadata->printf_record_count, 2);
+  EXPECT_NE(metadata->printf_records, nullptr);
   EXPECT_EQ(metadata->layout_blob_capacity, 128);
   EXPECT_EQ(metadata->layout_blob_used, 0);
   EXPECT_NE(metadata->layout_blob, nullptr);
@@ -48,6 +54,8 @@ TEST(ExecutableMetadataTest, AppendsAndResolvesLayout) {
   iree_hal_amdgpu_executable_metadata_counts_t counts = {
       /*.export_count=*/1,
       /*.parameter_count=*/{},
+      /*.runtime_parameter_count=*/{},
+      /*.printf_record_count=*/{},
       /*.layout_blob_byte_length=*/layout_byte_length,
   };
   iree_hal_amdgpu_executable_metadata_t* metadata = nullptr;
@@ -103,6 +111,8 @@ TEST(ExecutableMetadataTest, RejectsLayoutBlobOverflow) {
   iree_hal_amdgpu_executable_metadata_counts_t counts = {
       /*.export_count=*/1,
       /*.parameter_count=*/{},
+      /*.runtime_parameter_count=*/{},
+      /*.printf_record_count=*/{},
       /*.layout_blob_byte_length=*/8,
   };
   iree_hal_amdgpu_executable_metadata_t* metadata = nullptr;
@@ -126,6 +136,8 @@ TEST(ExecutableMetadataTest, RejectsInvalidLayoutReference) {
   iree_hal_amdgpu_executable_metadata_counts_t counts = {
       /*.export_count=*/1,
       /*.parameter_count=*/{},
+      /*.runtime_parameter_count=*/{},
+      /*.printf_record_count=*/{},
       /*.layout_blob_byte_length=*/16,
   };
   iree_hal_amdgpu_executable_metadata_t* metadata = nullptr;

--- a/runtime/src/iree/hal/drivers/amdgpu/host_notification.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_notification.c
@@ -1,0 +1,127 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/host_notification.h"
+
+#include <string.h>
+
+#include "iree/hal/detail.h"
+#include "iree/hal/drivers/amdgpu/logical_device.h"
+#include "iree/hal/drivers/amdgpu/system.h"
+#include "iree/hal/drivers/amdgpu/util/libhsa.h"
+
+typedef struct iree_hal_amdgpu_host_notification_t {
+  // Base resource interface.
+  iree_hal_resource_t resource;
+  // Allocator used to free the notification.
+  iree_allocator_t host_allocator;
+  // Retained HSA API table used for native signal operations.
+  iree_hal_amdgpu_libhsa_t libhsa;
+  // Signal shared by device requesters and the host listener.
+  hsa_signal_t signal;
+} iree_hal_amdgpu_host_notification_t;
+
+static const iree_hal_host_notification_vtable_t
+    iree_hal_amdgpu_host_notification_vtable;
+
+static iree_hal_amdgpu_host_notification_t*
+iree_hal_amdgpu_host_notification_cast(
+    iree_hal_host_notification_t* base_notification) {
+  IREE_HAL_ASSERT_TYPE(base_notification,
+                       &iree_hal_amdgpu_host_notification_vtable);
+  return (iree_hal_amdgpu_host_notification_t*)base_notification;
+}
+
+static void iree_hal_amdgpu_host_notification_destroy(
+    iree_hal_host_notification_t* base_notification) {
+  iree_hal_amdgpu_host_notification_t* notification =
+      iree_hal_amdgpu_host_notification_cast(base_notification);
+  iree_allocator_t host_allocator = notification->host_allocator;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  if (notification->signal.handle) {
+    iree_hal_amdgpu_hsa_cleanup_assert_success(iree_hsa_signal_destroy_raw(
+        &notification->libhsa, notification->signal));
+  }
+  iree_hal_amdgpu_libhsa_deinitialize(&notification->libhsa);
+  iree_allocator_free(host_allocator, notification);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static uint64_t iree_hal_amdgpu_host_notification_device_token(
+    iree_hal_host_notification_t* base_notification) {
+  iree_hal_amdgpu_host_notification_t* notification =
+      iree_hal_amdgpu_host_notification_cast(base_notification);
+  return notification->signal.handle;
+}
+
+static uint64_t iree_hal_amdgpu_host_notification_wait(
+    iree_hal_host_notification_t* base_notification, uint64_t observed_value) {
+  iree_hal_amdgpu_host_notification_t* notification =
+      iree_hal_amdgpu_host_notification_cast(base_notification);
+  return (uint64_t)iree_hsa_signal_wait_scacquire(
+      IREE_LIBHSA(&notification->libhsa), notification->signal,
+      HSA_SIGNAL_CONDITION_NE, (hsa_signal_value_t)observed_value, UINT64_MAX,
+      HSA_WAIT_STATE_BLOCKED);
+}
+
+static void iree_hal_amdgpu_host_notification_wake(
+    iree_hal_host_notification_t* base_notification) {
+  iree_hal_amdgpu_host_notification_t* notification =
+      iree_hal_amdgpu_host_notification_cast(base_notification);
+  iree_hsa_signal_store_screlease(IREE_LIBHSA(&notification->libhsa),
+                                  notification->signal, 0);
+}
+
+static const iree_hal_host_notification_vtable_t
+    iree_hal_amdgpu_host_notification_vtable = {
+        .destroy = iree_hal_amdgpu_host_notification_destroy,
+        .device_token = iree_hal_amdgpu_host_notification_device_token,
+        .wait = iree_hal_amdgpu_host_notification_wait,
+        .wake = iree_hal_amdgpu_host_notification_wake,
+};
+
+iree_status_t iree_hal_amdgpu_host_notification_create(
+    iree_hal_amdgpu_logical_device_t* device,
+    iree_hal_host_notification_t** out_notification) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_ASSERT_ARGUMENT(out_notification);
+  *out_notification = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_amdgpu_host_notification_t* notification = NULL;
+  iree_status_t status = iree_allocator_malloc(
+      device->host_allocator, sizeof(*notification), (void**)&notification);
+  if (iree_status_is_ok(status)) {
+    memset(notification, 0, sizeof(*notification));
+    notification->host_allocator = device->host_allocator;
+    status = iree_hal_amdgpu_libhsa_copy(&device->system->libhsa,
+                                         &notification->libhsa);
+  }
+  if (iree_status_is_ok(status)) {
+    status =
+        iree_hsa_amd_signal_create(IREE_LIBHSA(&notification->libhsa),
+                                   IREE_HAL_HOST_NOTIFICATION_INITIAL_VALUE,
+                                   /*num_consumers=*/0, /*consumers=*/NULL,
+                                   /*attributes=*/0, &notification->signal);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_hal_resource_initialize(&iree_hal_amdgpu_host_notification_vtable,
+                                 &notification->resource);
+    *out_notification = (iree_hal_host_notification_t*)notification;
+  } else if (notification) {
+    if (notification->signal.handle) {
+      iree_hal_amdgpu_hsa_cleanup_assert_success(iree_hsa_signal_destroy_raw(
+          &notification->libhsa, notification->signal));
+    }
+    iree_hal_amdgpu_libhsa_deinitialize(&notification->libhsa);
+    iree_allocator_free(notification->host_allocator, notification);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/host_notification.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_notification.h
@@ -1,0 +1,32 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_HOST_NOTIFICATION_H_
+#define IREE_HAL_DRIVERS_AMDGPU_HOST_NOTIFICATION_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/host_notification.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct iree_hal_amdgpu_logical_device_t
+    iree_hal_amdgpu_logical_device_t;
+
+// Creates an AMDGPU-backed host notification.
+//
+// The notification retains the driver HSA library independently, allowing it
+// to remain valid until its final release without exposing HSA to callers.
+iree_status_t iree_hal_amdgpu_host_notification_create(
+    iree_hal_amdgpu_logical_device_t* device,
+    iree_hal_host_notification_t** out_notification);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_HOST_NOTIFICATION_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
@@ -383,6 +383,11 @@ static iree_status_t iree_hal_amdgpu_host_queue_prepare_dispatch_plan(
 
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_host_queue_lookup_dispatch_descriptor(
       queue, executable, export_ordinal, &out_plan->descriptor));
+  if (config.runtime_parameters) {
+    IREE_RETURN_IF_ERROR(
+        iree_hal_amdgpu_executable_validate_dispatch_runtime_parameters(
+            out_plan->descriptor, config));
+  }
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_host_queue_select_dispatch_kernel_args(
       out_plan->descriptor, config, &out_plan->override_kernel_args,
       &out_plan->kernel_args));
@@ -533,8 +538,9 @@ static void iree_hal_amdgpu_host_queue_emplace_native_implicit_args(
 static void iree_hal_amdgpu_host_queue_emplace_dispatch_kernargs(
     const iree_hal_amdgpu_host_queue_dispatch_plan_t* plan,
     const uint32_t workgroup_count[3], uint32_t dynamic_workgroup_local_memory,
-    iree_const_byte_span_t constants, const uint64_t* binding_ptrs,
-    bool uses_custom_direct_arguments, void* kernarg_data) {
+    const iree_hal_dispatch_config_t config, iree_const_byte_span_t constants,
+    const uint64_t* binding_ptrs, bool uses_custom_direct_arguments,
+    void* kernarg_data) {
   if (uses_custom_direct_arguments) {
     iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
         plan->custom_layout, constants.data, constants.data_length,
@@ -542,6 +548,10 @@ static void iree_hal_amdgpu_host_queue_emplace_dispatch_kernargs(
     iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
         plan->kernel_args, workgroup_count, dynamic_workgroup_local_memory,
         plan->custom_layout, kernarg_data);
+    if (config.runtime_parameters) {
+      iree_hal_amdgpu_executable_apply_runtime_parameter_patches(config,
+                                                                 kernarg_data);
+    }
     return;
   }
 
@@ -550,6 +560,10 @@ static void iree_hal_amdgpu_host_queue_emplace_dispatch_kernargs(
   iree_hal_amdgpu_host_queue_emplace_native_implicit_args(
       plan->kernel_args, workgroup_count, dynamic_workgroup_local_memory,
       plan->kernarg_layout, kernarg_data);
+  if (config.runtime_parameters) {
+    iree_hal_amdgpu_executable_apply_runtime_parameter_patches(config,
+                                                               kernarg_data);
+  }
 }
 
 static bool iree_hal_amdgpu_host_queue_should_profile_dispatch(
@@ -765,7 +779,7 @@ static iree_status_t iree_hal_amdgpu_host_queue_submit_dispatch_packets(
                                                : config.workgroup_count;
   iree_hal_amdgpu_host_queue_emplace_dispatch_kernargs(
       plan, target_workgroup_count, config.dynamic_workgroup_local_memory,
-      constants, binding_ptrs, uses_custom_direct_arguments,
+      config, constants, binding_ptrs, uses_custom_direct_arguments,
       dispatch_kernarg_data);
   iree_hsa_signal_t dispatch_completion_signal =
       profile_queue_device_event

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_pending_operation.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_pending_operation.h
@@ -154,6 +154,8 @@ struct iree_hal_amdgpu_pending_op_t {
       iree_hal_executable_function_t export_ordinal;
       // Dispatch workgroup configuration captured from queue_dispatch.
       iree_hal_dispatch_config_t config;
+      // Runtime parameter list owned by this deferred operation when present.
+      iree_hal_dispatch_runtime_parameter_list_t runtime_parameters;
       // Arena-owned copy of dispatch constants.
       iree_const_byte_span_t constants;
       // Arena-owned copy of dispatch buffer references.

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_pending_payload.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_pending_payload.c
@@ -449,7 +449,8 @@ iree_status_t iree_hal_amdgpu_host_queue_defer_dispatch(
   }
   op->dispatch.executable = executable;
   op->dispatch.export_ordinal = export_ordinal;
-  op->dispatch.config = config;
+  iree_hal_dispatch_config_clone(config, &op->dispatch.runtime_parameters,
+                                 &op->dispatch.config);
   op->dispatch.flags = flags;
 
   iree_status_t status = iree_ok_status();

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -17,6 +17,7 @@
 #include "iree/hal/drivers/amdgpu/device_spec_builder.h"
 #include "iree/hal/drivers/amdgpu/executable.h"
 #include "iree/hal/drivers/amdgpu/feedback_state.h"
+#include "iree/hal/drivers/amdgpu/host_notification.h"
 #include "iree/hal/drivers/amdgpu/host_queue_profile.h"
 #include "iree/hal/drivers/amdgpu/host_queue_profile_events.h"
 #include "iree/hal/drivers/amdgpu/physical_device.h"
@@ -1911,6 +1912,8 @@ static iree_status_t iree_hal_amdgpu_logical_device_create_device_spec(
         physical_device->maximum_waves_per_compute_unit;
     physical_params->maximum_workgroup_local_memory_size =
         physical_device->group_segment_max_size;
+    physical_params->host_native_atomic_supported =
+        physical_device->host_native_atomic_supported;
   }
 
   uint64_t device_memory_capacity_bytes = 0;
@@ -3033,6 +3036,17 @@ static iree_status_t iree_hal_amdgpu_logical_device_queue_host_call(
                                   signal_semaphore_list, call, args, flags);
 }
 
+static iree_status_t iree_hal_amdgpu_logical_device_create_host_notification(
+    iree_hal_device_t* base_device,
+    iree_hal_host_notification_t** out_notification) {
+  iree_hal_amdgpu_logical_device_t* logical_device =
+      iree_hal_amdgpu_logical_device_cast(base_device);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_logical_device_check_failure(logical_device));
+  return iree_hal_amdgpu_host_notification_create(logical_device,
+                                                  out_notification);
+}
+
 static iree_status_t iree_hal_amdgpu_logical_device_queue_dispatch(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
@@ -3461,6 +3475,8 @@ static const iree_hal_device_vtable_t iree_hal_amdgpu_logical_device_vtable = {
     .create_command_buffer =
         iree_hal_amdgpu_logical_device_create_command_buffer,
     .create_event = iree_hal_amdgpu_logical_device_create_event,
+    .create_host_notification =
+        iree_hal_amdgpu_logical_device_create_host_notification,
     .load_executable = iree_hal_amdgpu_logical_device_load_executable,
     .import_file = iree_hal_amdgpu_logical_device_import_file,
     .create_semaphore = iree_hal_amdgpu_logical_device_create_semaphore,

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
@@ -7,6 +7,7 @@
 #include "iree/hal/drivers/amdgpu/physical_device.h"
 
 #include <stdio.h>
+#include <string.h>
 
 #include "iree/async/frontier_tracker.h"
 #include "iree/async/notification.h"
@@ -48,6 +49,8 @@
 static_assert(IREE_HAL_AMDGPU_PHYSICAL_DEVICE_GROUP_SEGMENT_MAX_SIZE_DEFAULT !=
                   0,
               "group segment max size default must be non-zero");
+
+#define IREE_HAL_AMDGPU_PHYSICAL_DEVICE_MAX_HOST_LINK_HOPS 16
 
 typedef struct iree_hal_amdgpu_agent_first_isa_t {
   // Number of ISAs seen during iteration.
@@ -416,6 +419,7 @@ static iree_status_t iree_hal_amdgpu_physical_device_initialize_identity(
   // Zeroing allows deinitialization to run after any partial initialization
   // failure below.
   memset(out_physical_device, 0, sizeof(*out_physical_device));
+  out_physical_device->libhsa = libhsa;
   out_physical_device->device_agent = device_agent;
   out_physical_device->device_ordinal = device_ordinal;
   out_physical_device->host_memory_pools = *host_memory_pools;
@@ -550,6 +554,58 @@ iree_hal_amdgpu_physical_device_query_svm_direct_host_access(
       IREE_LIBHSA(libhsa), device_agent,
       (hsa_agent_info_t)HSA_AMD_AGENT_INFO_SVM_DIRECT_HOST_ACCESS,
       out_direct_host_access);
+}
+
+static iree_status_t
+iree_hal_amdgpu_physical_device_query_host_native_atomic_support(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t device_agent,
+    hsa_amd_memory_pool_t host_fine_memory_pool,
+    bool* out_host_native_atomic_supported) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_host_native_atomic_supported);
+  *out_host_native_atomic_supported = false;
+  if (!host_fine_memory_pool.handle) return iree_ok_status();
+
+  // Host-native atomics are an optional host/device link property. If the HSA
+  // runtime cannot report link information for the nearest host fine-grained
+  // pool, leave the capability disabled instead of failing device creation.
+  uint32_t hop_count = 0;
+  hsa_status_t hsa_status = iree_hsa_amd_agent_memory_pool_get_info_raw(
+      libhsa, device_agent, host_fine_memory_pool,
+      HSA_AMD_AGENT_MEMORY_POOL_INFO_NUM_LINK_HOPS, &hop_count);
+  if (hsa_status != HSA_STATUS_SUCCESS) return iree_ok_status();
+  if (hop_count == 0) {
+    *out_host_native_atomic_supported = true;
+    return iree_ok_status();
+  }
+  if (IREE_UNLIKELY(hop_count >
+                    IREE_HAL_AMDGPU_PHYSICAL_DEVICE_MAX_HOST_LINK_HOPS)) {
+    // LINK_INFO writes hop_count entries into a caller-sized array with no
+    // separate byte-count argument, so overly large topologies cannot be
+    // queried by this bounded cold probe.
+    return iree_ok_status();
+  }
+
+  hsa_amd_memory_pool_link_info_t
+      link_hops[IREE_HAL_AMDGPU_PHYSICAL_DEVICE_MAX_HOST_LINK_HOPS];
+  memset(link_hops, 0, sizeof(link_hops[0]) * hop_count);
+  hsa_status = iree_hsa_amd_agent_memory_pool_get_info_raw(
+      libhsa, device_agent, host_fine_memory_pool,
+      HSA_AMD_AGENT_MEMORY_POOL_INFO_LINK_INFO, link_hops);
+  if (hsa_status != HSA_STATUS_SUCCESS) return iree_ok_status();
+  // HIP exposes native host atomics as a single device property, not as
+  // per-hop or per-width capabilities. Only advertise it when the whole
+  // reported host path supports both 32-bit and 64-bit atomic transactions.
+  bool host_native_atomic_supported = true;
+  for (uint32_t i = 0; i < hop_count; ++i) {
+    if (!link_hops[i].atomic_support_32bit ||
+        !link_hops[i].atomic_support_64bit) {
+      host_native_atomic_supported = false;
+      break;
+    }
+  }
+  *out_host_native_atomic_supported = host_native_atomic_supported;
+  return iree_ok_status();
 }
 
 static iree_status_t
@@ -997,6 +1053,14 @@ iree_status_t iree_hal_amdgpu_physical_device_initialize(
     status = iree_hal_amdgpu_physical_device_query_global_memory_pools(
         libhsa, device_agent, options->suppress_device_fine_memory,
         &coarse_block_memory_pool, &fine_block_memory_pool);
+  }
+  if (iree_status_is_ok(status)) {
+    bool host_native_atomic_supported = false;
+    status = iree_hal_amdgpu_physical_device_query_host_native_atomic_support(
+        libhsa, device_agent, host_memory_pools->fine_pool,
+        &host_native_atomic_supported);
+    out_physical_device->host_native_atomic_supported =
+        host_native_atomic_supported ? 1u : 0u;
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_physical_device_preallocate_host_pool(

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device.h
@@ -187,6 +187,8 @@ iree_status_t iree_hal_amdgpu_physical_device_options_verify(
 // A physical device representing an HSA GPU agent.
 // May contain one or more HAL queues that map to HSA queues on the agent.
 typedef struct iree_hal_amdgpu_physical_device_t {
+  // HSA API handle used for physical-device-owned raw HSA allocations.
+  const iree_hal_amdgpu_libhsa_t* libhsa;
   // GPU agent.
   hsa_agent_t device_agent;
   // Ordinal of the GPU agent within the topology.
@@ -232,6 +234,9 @@ typedef struct iree_hal_amdgpu_physical_device_t {
   iree_hal_amdgpu_memory_system_capabilities_t memory_system;
   // Clustered-dispatch limits reported for this GPU agent.
   iree_hal_amdgpu_workgroup_cluster_capabilities_t workgroup_cluster;
+  // True when this GPU's link to nearest host fine-grained memory supports
+  // native atomic transactions.
+  uint32_t host_native_atomic_supported : 1;
   // CPU-visible coarse-grained device-memory capability for this GPU.
   iree_hal_amdgpu_cpu_visible_device_coarse_memory_t
       cpu_visible_device_coarse_memory;

--- a/runtime/src/iree/hal/drivers/amdgpu/pm4_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/pm4_command_buffer.c
@@ -72,6 +72,8 @@ typedef struct iree_hal_amdgpu_pm4_dispatch_record_t {
   uint64_t executable_id;
   // Dispatch workgroup counts.
   uint32_t workgroup_count[3];
+  // Dispatch-local native runtime parameters retained until materialization.
+  iree_hal_dispatch_runtime_parameter_list_t runtime_parameters;
   // DISPATCH_DIRECT thread dimensions.
   uint32_t dispatch_thread_count[3];
   // HAL command ordinal within this command buffer.
@@ -2154,7 +2156,7 @@ static void iree_hal_amdgpu_pm4_command_buffer_write_implicit_args(
     const iree_hal_amdgpu_device_kernel_args_t* kernel_args,
     const iree_hal_dispatch_config_t config,
     iree_amdgpu_kernel_implicit_args_t* implicit_args) {
-  memset(implicit_args, 0, sizeof(*implicit_args));
+  memset(implicit_args, 0, IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE);
   implicit_args->block_count[0] = config.workgroup_count[0];
   implicit_args->block_count[1] = config.workgroup_count[1];
   implicit_args->block_count[2] = config.workgroup_count[2];
@@ -2256,6 +2258,10 @@ static iree_status_t iree_hal_amdgpu_pm4_command_buffer_write_template(
                                                   ->implicit_args_byte_offset);
     iree_hal_amdgpu_pm4_command_buffer_write_implicit_args(kernel_args, config,
                                                            implicit_args);
+  }
+  if (config.runtime_parameters) {
+    iree_hal_amdgpu_executable_apply_runtime_parameter_patches(config,
+                                                               template_bytes);
   }
   return iree_ok_status();
 }
@@ -2638,6 +2644,9 @@ static iree_status_t iree_hal_amdgpu_pm4_command_buffer_append_dispatch_record(
   record->workgroup_count[0] = config.workgroup_count[0];
   record->workgroup_count[1] = config.workgroup_count[1];
   record->workgroup_count[2] = config.workgroup_count[2];
+  if (config.runtime_parameters) {
+    record->runtime_parameters = *config.runtime_parameters;
+  }
   record->dispatch_thread_count[0] = dispatch_thread_count[0];
   record->dispatch_thread_count[1] = dispatch_thread_count[1];
   record->dispatch_thread_count[2] = dispatch_thread_count[2];
@@ -2719,6 +2728,8 @@ static iree_status_t iree_hal_amdgpu_pm4_command_buffer_materialize_dispatch(
       .workgroup_count = {record->workgroup_count[0],
                           record->workgroup_count[1],
                           record->workgroup_count[2]},
+      .runtime_parameters =
+          record->runtime_parameters.count ? &record->runtime_parameters : NULL,
   };
 
   if (iree_any_bit_set(
@@ -3252,6 +3263,11 @@ static iree_status_t iree_hal_amdgpu_pm4_command_buffer_record_dispatch(
     return iree_make_status(
         IREE_STATUS_UNIMPLEMENTED,
         "clustered AMDGPU dispatch requires an AQL command buffer");
+  }
+  if (config.runtime_parameters) {
+    IREE_RETURN_IF_ERROR(
+        iree_hal_amdgpu_executable_validate_dispatch_runtime_parameters(
+            descriptor, config));
   }
   if (IREE_UNLIKELY(!descriptor->pm4_launch_state_valid)) {
     return iree_make_status(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -619,8 +619,12 @@ static iree_status_t iree_hal_amdgpu_msgpack_skip(
 //===----------------------------------------------------------------------===//
 
 typedef struct iree_hal_amdgpu_hsaco_metadata_count_t {
+  // Number of decoded kernel records.
   iree_host_size_t kernel_count;
+  // Number of decoded kernel argument records.
   iree_host_size_t arg_count;
+  // Number of raw `amdhsa.printf` records.
+  iree_host_size_t printf_record_count;
 } iree_hal_amdgpu_hsaco_metadata_count_t;
 
 typedef struct iree_hal_amdgpu_hsaco_metadata_kernel_fields_t {
@@ -630,8 +634,10 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_kernel_fields_t {
   bool has_kernarg_segment_alignment;
   bool has_group_segment_fixed_size;
   bool has_private_segment_fixed_size;
+  bool has_max_flat_workgroup_size;
   bool has_required_workgroup_size;
   bool has_workgroup_cluster_size;
+  bool has_uniform_workgroup_size;
   bool has_args;
 } iree_hal_amdgpu_hsaco_metadata_kernel_fields_t;
 
@@ -736,6 +742,7 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_count_message_pack(
   IREE_RETURN_IF_ERROR(
       iree_hal_amdgpu_msgpack_read_map_count(&reader, &root_field_count));
   bool has_kernels = false;
+  bool has_printf = false;
   for (uint32_t i = 0; i < root_field_count; ++i) {
     iree_string_view_t key = iree_string_view_empty();
     IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_read_string(&reader, &key));
@@ -752,6 +759,19 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_count_message_pack(
       for (uint32_t j = 0; j < kernel_count; ++j) {
         IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_metadata_count_kernel_args(
             &reader, &out_count->arg_count));
+      }
+    } else if (iree_string_view_equal(key, IREE_SV("amdhsa.printf"))) {
+      if (has_printf) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "AMDGPU metadata repeats `amdhsa.printf`");
+      }
+      has_printf = true;
+      uint32_t printf_record_count = 0;
+      IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_read_array_count(
+          &reader, &printf_record_count));
+      out_count->printf_record_count = printf_record_count;
+      for (uint32_t j = 0; j < printf_record_count; ++j) {
+        IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_skip(&reader, 0));
       }
     } else {
       IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_skip(&reader, 0));
@@ -1027,6 +1047,14 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_parse_kernel(
       IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_read_uint32(
           reader, &out_kernel->private_segment_fixed_size));
       fields.has_private_segment_fixed_size = true;
+    } else if (iree_string_view_equal(key,
+                                      IREE_SV(".max_flat_workgroup_size"))) {
+      if (fields.has_max_flat_workgroup_size) {
+        return iree_hal_amdgpu_hsaco_metadata_duplicate_field_status(key);
+      }
+      IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_read_uint32(
+          reader, &out_kernel->max_flat_workgroup_size));
+      fields.has_max_flat_workgroup_size = true;
     } else if (iree_string_view_equal(key, IREE_SV(".reqd_workgroup_size"))) {
       if (fields.has_required_workgroup_size) {
         return iree_hal_amdgpu_hsaco_metadata_duplicate_field_status(key);
@@ -1044,6 +1072,21 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_parse_kernel(
               reader, out_kernel->workgroup_cluster_size));
       out_kernel->has_workgroup_cluster_size = true;
       fields.has_workgroup_cluster_size = true;
+    } else if (iree_string_view_equal(key,
+                                      IREE_SV(".uniform_work_group_size"))) {
+      if (fields.has_uniform_workgroup_size) {
+        return iree_hal_amdgpu_hsaco_metadata_duplicate_field_status(key);
+      }
+      uint32_t uniform_workgroup_size = 0;
+      IREE_RETURN_IF_ERROR(
+          iree_hal_amdgpu_msgpack_read_uint32(reader, &uniform_workgroup_size));
+      if (uniform_workgroup_size > 1) {
+        return iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "AMDGPU uniform_work_group_size must be 0 or 1");
+      }
+      out_kernel->uniform_workgroup_size = uniform_workgroup_size != 0;
+      fields.has_uniform_workgroup_size = true;
     } else if (iree_string_view_equal(key, IREE_SV(".args"))) {
       if (fields.has_args) {
         return iree_hal_amdgpu_hsaco_metadata_duplicate_field_status(key);
@@ -1100,6 +1143,7 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_parse_message_pack(
       iree_hal_amdgpu_msgpack_read_map_count(&reader, &root_field_count));
   bool has_target = false;
   bool has_kernels = false;
+  bool has_printf = false;
   iree_host_size_t arg_index = 0;
   for (uint32_t i = 0; i < root_field_count; ++i) {
     iree_string_view_t key = iree_string_view_empty();
@@ -1130,6 +1174,24 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_parse_message_pack(
         IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_metadata_parse_kernel(
             &reader, metadata, &arg_index, &metadata->kernels[j]));
       }
+    } else if (iree_string_view_equal(key, IREE_SV("amdhsa.printf"))) {
+      if (has_printf) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "AMDGPU metadata repeats `amdhsa.printf`");
+      }
+      has_printf = true;
+      uint32_t printf_record_count = 0;
+      IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_read_array_count(
+          &reader, &printf_record_count));
+      if (printf_record_count != metadata->printf_record_count) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                                "AMDGPU metadata printf record count changed "
+                                "between parse passes");
+      }
+      for (uint32_t j = 0; j < printf_record_count; ++j) {
+        IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_read_string(
+            &reader, &metadata->printf_records[j].value));
+      }
     } else {
       IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_skip(&reader, 0));
     }
@@ -1156,16 +1218,21 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_allocate_storage(
     iree_hal_amdgpu_hsaco_metadata_t* metadata) {
   metadata->kernel_count = count.kernel_count;
   metadata->arg_count = count.arg_count;
-  if (count.kernel_count == 0 && count.arg_count == 0) {
+  metadata->printf_record_count = count.printf_record_count;
+  if (count.kernel_count == 0 && count.arg_count == 0 &&
+      count.printf_record_count == 0) {
     return iree_ok_status();
   }
   IREE_TRACE_ZONE_BEGIN(z0);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, count.kernel_count);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, count.arg_count);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, count.printf_record_count);
 
   iree_host_size_t kernels_size = 0;
   iree_host_size_t args_offset = 0;
   iree_host_size_t args_size = 0;
+  iree_host_size_t printf_records_offset = 0;
+  iree_host_size_t printf_records_size = 0;
   iree_host_size_t total_size = 0;
   if (!iree_host_size_checked_mul(
           count.kernel_count, sizeof(metadata->kernels[0]), &kernels_size) ||
@@ -1174,7 +1241,16 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_allocate_storage(
           &args_offset) ||
       !iree_host_size_checked_mul(count.arg_count, sizeof(metadata->args[0]),
                                   &args_size) ||
-      !iree_host_size_checked_add(args_offset, args_size, &total_size)) {
+      !iree_host_size_checked_add(args_offset, args_size, &total_size) ||
+      !iree_host_size_checked_align(
+          total_size,
+          iree_alignof(iree_hal_amdgpu_hsaco_metadata_printf_record_t),
+          &printf_records_offset) ||
+      !iree_host_size_checked_mul(count.printf_record_count,
+                                  sizeof(metadata->printf_records[0]),
+                                  &printf_records_size) ||
+      !iree_host_size_checked_add(printf_records_offset, printf_records_size,
+                                  &total_size)) {
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0, iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                              "AMDGPU metadata storage size overflow"));
@@ -1189,6 +1265,11 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_allocate_storage(
   metadata->args =
       count.arg_count
           ? (iree_hal_amdgpu_hsaco_metadata_arg_t*)(storage + args_offset)
+          : NULL;
+  metadata->printf_records =
+      count.printf_record_count
+          ? (iree_hal_amdgpu_hsaco_metadata_printf_record_t*)(storage +
+                                                              printf_records_offset)
           : NULL;
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
@@ -82,6 +82,8 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_kernel_t {
   uint32_t group_segment_fixed_size;
   // Fixed private segment size from `.private_segment_fixed_size`.
   uint32_t private_segment_fixed_size;
+  // Maximum total work-items per workgroup from `.max_flat_workgroup_size`.
+  uint32_t max_flat_workgroup_size;
   // Required workgroup size from `.reqd_workgroup_size`, if present.
   uint32_t required_workgroup_size[3];
   // True when |required_workgroup_size| was present.
@@ -91,6 +93,8 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_kernel_t {
   uint8_t workgroup_cluster_size[3];
   // True when |workgroup_cluster_size| was present.
   bool has_workgroup_cluster_size;
+  // True when `.uniform_work_group_size` is present and non-zero.
+  bool uniform_workgroup_size;
   // Number of argument records in |args|.
   iree_host_size_t arg_count;
   // Argument records borrowed from the owning metadata object.
@@ -104,6 +108,12 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_elf_kernel_symbol_t {
   // Kernel descriptor symbol name used to resolve the HSA kernel object.
   iree_string_view_t symbol_name;
 } iree_hal_amdgpu_hsaco_metadata_elf_kernel_symbol_t;
+
+// Raw `amdhsa.printf` metadata record.
+typedef struct iree_hal_amdgpu_hsaco_metadata_printf_record_t {
+  // Record payload borrowed from the metadata blob.
+  iree_string_view_t value;
+} iree_hal_amdgpu_hsaco_metadata_printf_record_t;
 
 // Decoded AMDGPU code object metadata.
 //
@@ -131,6 +141,10 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_t {
   // ELF-only kernel symbols. These are not reflected metadata and must only be
   // used by custom-direct native kernarg launch paths.
   iree_hal_amdgpu_hsaco_metadata_elf_kernel_symbol_t* elf_kernel_symbols;
+  // Number of raw `amdhsa.printf` metadata records.
+  iree_host_size_t printf_record_count;
+  // Raw `amdhsa.printf` metadata records.
+  iree_hal_amdgpu_hsaco_metadata_printf_record_t* printf_records;
   // Total number of decoded argument records.
   iree_host_size_t arg_count;
   // Contiguous argument storage referenced by |kernels|.

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
@@ -131,6 +131,7 @@ enum BuildKernelMetadataFlagBits : uint32_t {
   kBuildKernelMetadataOutOfRangeArg = 1u << 0,
   kBuildKernelMetadataUnknownValueKind = 1u << 1,
   kBuildKernelMetadataClusterDimensions = 1u << 2,
+  kBuildKernelMetadataPrintf = 1u << 3,
 };
 
 static std::vector<uint8_t> BuildKernelMetadata(
@@ -141,8 +142,9 @@ static std::vector<uint8_t> BuildKernelMetadata(
       (flags & kBuildKernelMetadataUnknownValueKind) != 0;
   const bool has_cluster_dimensions =
       (flags & kBuildKernelMetadataClusterDimensions) != 0;
+  const bool include_printf = (flags & kBuildKernelMetadataPrintf) != 0;
   std::vector<uint8_t> output;
-  AppendMsgPackMap(&output, 3);
+  AppendMsgPackMap(&output, include_printf ? 4 : 3);
 
   AppendMsgPackString(&output, IREE_SV("amdhsa.version"));
   AppendMsgPackArray(&output, 2);
@@ -156,13 +158,14 @@ static std::vector<uint8_t> BuildKernelMetadata(
 
   AppendMsgPackString(&output, IREE_SV("amdhsa.kernels"));
   AppendMsgPackArray(&output, 1);
-  AppendMsgPackMap(&output, 8 + (has_cluster_dimensions ? 1 : 0));
+  AppendMsgPackMap(&output, 9 + (has_cluster_dimensions ? 1 : 0));
   AppendStringField(&output, IREE_SV(".name"), IREE_SV("vector_add"));
   AppendStringField(&output, IREE_SV(".symbol"), IREE_SV("vector_add.kd"));
   AppendUintField(&output, IREE_SV(".kernarg_segment_size"), 24);
   AppendUintField(&output, IREE_SV(".kernarg_segment_align"), 8);
   AppendUintField(&output, IREE_SV(".group_segment_fixed_size"), 1024);
   AppendUintField(&output, IREE_SV(".private_segment_fixed_size"), 64);
+  AppendUintField(&output, IREE_SV(".max_flat_workgroup_size"), 256);
   AppendMsgPackString(&output, IREE_SV(".reqd_workgroup_size"));
   AppendMsgPackArray(&output, 3);
   AppendMsgPackUint(&output, 16);
@@ -214,6 +217,14 @@ static std::vector<uint8_t> BuildKernelMetadata(
   AppendUintField(&output, IREE_SV(".size"), out_of_range_arg ? 8 : 4);
   AppendStringField(&output, IREE_SV(".value_kind"), IREE_SV("by_value"));
   AppendUintField(&output, IREE_SV(".align"), 4);
+
+  if (include_printf) {
+    AppendMsgPackString(&output, IREE_SV("amdhsa.printf"));
+    AppendMsgPackArray(&output, 2);
+    AppendMsgPackString(&output,
+                        IREE_SV("0:0:8addc4c0362218ac,Hello World!\\n"));
+    AppendMsgPackString(&output, IREE_SV("0:0:1122334455667788,value=%d\\n"));
+  }
 
   return output;
 }
@@ -504,6 +515,7 @@ TEST(HsacoMetadataTest, ParsesValidMetadata) {
   EXPECT_EQ(kernel.kernarg_segment_alignment, 8);
   EXPECT_EQ(kernel.group_segment_fixed_size, 1024);
   EXPECT_EQ(kernel.private_segment_fixed_size, 64);
+  EXPECT_EQ(kernel.max_flat_workgroup_size, 256);
   ASSERT_TRUE(kernel.has_required_workgroup_size);
   EXPECT_EQ(kernel.required_workgroup_size[0], 16);
   EXPECT_EQ(kernel.required_workgroup_size[1], 4);
@@ -541,6 +553,24 @@ TEST(HsacoMetadataTest, ParsesValidMetadata) {
   EXPECT_EQ(kernel.args[3].size, 4);
   EXPECT_EQ(kernel.args[3].kind,
             IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_BY_VALUE);
+
+  iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
+}
+
+TEST(HsacoMetadataTest, ParsesPrintfMetadata) {
+  std::vector<uint8_t> elf =
+      BuildElfWithMetadata(BuildKernelMetadata(kBuildKernelMetadataPrintf));
+
+  iree_hal_amdgpu_hsaco_metadata_t metadata;
+  IREE_ASSERT_OK(iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
+      ByteSpan(elf), iree_allocator_system(), &metadata));
+
+  ASSERT_EQ(metadata.printf_record_count, 2);
+  ASSERT_NE(metadata.printf_records, nullptr);
+  EXPECT_EQ(ToString(metadata.printf_records[0].value),
+            "0:0:8addc4c0362218ac,Hello World!\\n");
+  EXPECT_EQ(ToString(metadata.printf_records[1].value),
+            "0:0:1122334455667788,value=%d\\n");
 
   iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
 }

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -1256,6 +1256,7 @@ static const iree_hal_device_vtable_t iree_hal_cuda_device_vtable = {
     .create_channel = iree_hal_cuda_device_create_channel,
     .create_command_buffer = iree_hal_cuda_device_create_command_buffer,
     .create_event = iree_hal_cuda_device_create_event,
+    .create_host_notification = iree_hal_host_notification_create_unimplemented,
     .load_executable = iree_hal_cuda_device_load_executable,
     .import_file = iree_hal_cuda_device_import_file,
     .create_semaphore = iree_hal_cuda_device_create_semaphore,

--- a/runtime/src/iree/hal/drivers/hip/hip_device.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_device.c
@@ -3113,6 +3113,7 @@ static const iree_hal_device_vtable_t iree_hal_hip_device_vtable = {
     .create_channel = iree_hal_hip_device_create_channel,
     .create_command_buffer = iree_hal_hip_device_create_command_buffer,
     .create_event = iree_hal_hip_device_create_event,
+    .create_host_notification = iree_hal_host_notification_create_unimplemented,
     .load_executable = iree_hal_hip_device_load_executable,
     .import_file = iree_hal_hip_device_import_file,
     .create_semaphore = iree_hal_hip_device_create_semaphore,

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -1804,6 +1804,7 @@ static const iree_hal_device_vtable_t iree_hal_sync_device_vtable = {
     .create_channel = iree_hal_sync_device_create_channel,
     .create_command_buffer = iree_hal_sync_device_create_command_buffer,
     .create_event = iree_hal_sync_device_create_event,
+    .create_host_notification = iree_hal_host_notification_create_unimplemented,
     .load_executable = iree_hal_sync_device_load_executable,
     .import_file = iree_hal_sync_device_import_file,
     .create_semaphore = iree_hal_sync_device_create_semaphore,

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -1219,6 +1219,7 @@ static const iree_hal_device_vtable_t iree_hal_task_device_vtable = {
     .create_channel = iree_hal_task_device_create_channel,
     .create_command_buffer = iree_hal_task_device_create_command_buffer,
     .create_event = iree_hal_task_device_create_event,
+    .create_host_notification = iree_hal_host_notification_create_unimplemented,
     .load_executable = iree_hal_task_device_load_executable,
     .import_file = iree_hal_task_device_import_file,
     .create_semaphore = iree_hal_task_device_create_semaphore,

--- a/runtime/src/iree/hal/drivers/metal/metal_device.m
+++ b/runtime/src/iree/hal/drivers/metal/metal_device.m
@@ -807,6 +807,7 @@ static const iree_hal_device_vtable_t iree_hal_metal_device_vtable = {
     .create_channel = iree_hal_metal_device_create_channel,
     .create_command_buffer = iree_hal_metal_device_create_command_buffer,
     .create_event = iree_hal_metal_device_create_event,
+    .create_host_notification = iree_hal_host_notification_create_unimplemented,
     .load_executable = iree_hal_metal_device_load_executable,
     .import_file = iree_hal_metal_device_import_file,
     .create_semaphore = iree_hal_metal_device_create_semaphore,

--- a/runtime/src/iree/hal/drivers/null/device.c
+++ b/runtime/src/iree/hal/drivers/null/device.c
@@ -707,6 +707,7 @@ static const iree_hal_device_vtable_t iree_hal_null_device_vtable = {
     .create_channel = iree_hal_null_device_create_channel,
     .create_command_buffer = iree_hal_null_device_create_command_buffer,
     .create_event = iree_hal_null_device_create_event,
+    .create_host_notification = iree_hal_host_notification_create_unimplemented,
     .load_executable = iree_hal_null_device_load_executable,
     .import_file = iree_hal_null_device_import_file,
     .create_semaphore = iree_hal_null_device_create_semaphore,

--- a/runtime/src/iree/hal/drivers/vulkan/logical_device.c
+++ b/runtime/src/iree/hal/drivers/vulkan/logical_device.c
@@ -2272,6 +2272,7 @@ static const iree_hal_device_vtable_t iree_hal_vulkan_logical_device_vtable = {
     .create_command_buffer =
         iree_hal_vulkan_logical_device_create_command_buffer,
     .create_event = iree_hal_vulkan_logical_device_create_event,
+    .create_host_notification = iree_hal_host_notification_create_unimplemented,
     .load_executable = iree_hal_vulkan_logical_device_load_executable,
     .import_file = iree_hal_vulkan_logical_device_import_file,
     .create_semaphore = iree_hal_vulkan_logical_device_create_semaphore,

--- a/runtime/src/iree/hal/drivers/webgpu/webgpu_device.c
+++ b/runtime/src/iree/hal/drivers/webgpu/webgpu_device.c
@@ -606,6 +606,7 @@ static const iree_hal_device_vtable_t iree_hal_webgpu_device_vtable = {
     .create_channel = iree_hal_webgpu_device_create_channel,
     .create_command_buffer = iree_hal_webgpu_device_create_command_buffer,
     .create_event = iree_hal_webgpu_device_create_event,
+    .create_host_notification = iree_hal_host_notification_create_unimplemented,
     .load_executable = iree_hal_webgpu_device_load_executable,
     .import_file = iree_hal_webgpu_device_import_file,
     .create_semaphore = iree_hal_webgpu_device_create_semaphore,

--- a/runtime/src/iree/hal/executable.c
+++ b/runtime/src/iree/hal/executable.c
@@ -54,6 +54,59 @@ IREE_API_EXPORT iree_status_t iree_hal_executable_function_parameters(
   return status;
 }
 
+IREE_API_EXPORT iree_status_t iree_hal_executable_function_runtime_parameters(
+    iree_hal_executable_t* executable, iree_hal_executable_function_t function,
+    iree_host_size_t capacity,
+    iree_hal_executable_function_runtime_parameter_info_t* out_parameters) {
+  IREE_ASSERT_ARGUMENT(executable);
+  IREE_ASSERT_ARGUMENT(out_parameters || capacity == 0);
+  if (!_VTABLE_DISPATCH(executable, function_runtime_parameters)) {
+    if (capacity != 0) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "executable does not expose runtime parameters");
+    }
+    return iree_ok_status();
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status =
+      _VTABLE_DISPATCH(executable, function_runtime_parameters)(
+          executable, function, capacity, out_parameters);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_executable_runtime_metadata_count(
+    iree_hal_executable_t* executable, iree_string_view_t name,
+    iree_host_size_t* out_count) {
+  IREE_ASSERT_ARGUMENT(executable);
+  IREE_ASSERT_ARGUMENT(out_count);
+  *out_count = 0;
+  if (!_VTABLE_DISPATCH(executable, runtime_metadata_count)) {
+    return iree_ok_status();
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = _VTABLE_DISPATCH(executable, runtime_metadata_count)(
+      executable, name, out_count);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_executable_runtime_metadata_records(
+    iree_hal_executable_t* executable, iree_string_view_t name,
+    iree_host_size_t capacity,
+    iree_hal_executable_runtime_metadata_record_t* out_records) {
+  IREE_ASSERT_ARGUMENT(executable);
+  IREE_ASSERT_ARGUMENT(out_records || capacity == 0);
+  if (!_VTABLE_DISPATCH(executable, runtime_metadata_records)) {
+    return iree_ok_status();
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = _VTABLE_DISPATCH(executable, runtime_metadata_records)(
+      executable, name, capacity, out_records);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_function_by_name(
     iree_hal_executable_t* executable, iree_string_view_t name,
     iree_hal_executable_function_t* out_function) {

--- a/runtime/src/iree/hal/executable.h
+++ b/runtime/src/iree/hal/executable.h
@@ -163,6 +163,9 @@ enum iree_hal_executable_function_flag_bits_e {
   // The workgroup size specified on the function info is the minimum size and
   // granularity and any dynamic workgroup size chosen must be a multiple.
   IREE_HAL_EXECUTABLE_FUNCTION_FLAG_WORKGROUP_SIZE_DYNAMIC = 1ull << 1,
+  // OpenCL/HIP uniform-workgroup-size metadata requires global work sizes to
+  // divide evenly by local workgroup sizes.
+  IREE_HAL_EXECUTABLE_FUNCTION_FLAG_UNIFORM_WORKGROUP_SIZE = 1ull << 2,
 };
 typedef uint64_t iree_hal_executable_function_flags_t;
 
@@ -179,10 +182,18 @@ typedef struct iree_hal_executable_function_info_t {
   uint16_t binding_count;
   // Total number of logical parameters.
   uint16_t parameter_count;
+  // Total number of backend-native runtime parameters.
+  uint16_t runtime_parameter_count;
   // Static or minimum workgroup size of the function.
   // If IREE_HAL_EXECUTABLE_FUNCTION_FLAG_WORKGROUP_SIZE_DYNAMIC is set then
   // any dynamic workgroup size must be a multiple of this value.
   uint32_t workgroup_size[3];
+  // Maximum total work-items per workgroup accepted by this function.
+  uint32_t max_workgroup_size;
+  // Fixed workgroup-local memory required by the function, in bytes.
+  uint32_t workgroup_local_memory_size;
+  // Fixed private memory required per work-item, in bytes.
+  uint32_t private_memory_size;
   // Occupancy information hinting at how this function should be scheduled.
   iree_hal_occupancy_info_t occupancy_info;
 } iree_hal_executable_function_info_t;
@@ -239,6 +250,28 @@ typedef struct iree_hal_executable_function_parameter_t {
   iree_string_view_t name;
 } iree_hal_executable_function_parameter_t;
 
+// Reflected information about an executable runtime parameter.
+//
+// Runtime parameters are backend-defined launch ABI values that are not part
+// of the user-visible function parameter list. They are declared by executable
+// metadata and supplied by an embedding runtime before dispatch.
+typedef struct iree_hal_executable_function_runtime_parameter_info_t {
+  // Runtime parameter name from executable metadata.
+  iree_string_view_t name;
+  // Byte offset in the backend-native launch argument storage.
+  uint32_t offset;
+  // Byte length of the runtime parameter storage.
+  uint32_t length;
+} iree_hal_executable_function_runtime_parameter_info_t;
+
+// Backend-defined executable-level runtime metadata record.
+typedef struct iree_hal_executable_runtime_metadata_record_t {
+  // Metadata collection name.
+  iree_string_view_t name;
+  // Record payload owned by the executable.
+  iree_string_view_t value;
+} iree_hal_executable_runtime_metadata_record_t;
+
 // Declares properties of an executable global variable.
 typedef struct iree_hal_executable_global_info_t {
   // Executable-local global name if available, otherwise empty.
@@ -282,6 +315,34 @@ IREE_API_EXPORT iree_status_t iree_hal_executable_function_parameters(
     iree_hal_executable_t* executable, iree_hal_executable_function_t function,
     iree_host_size_t capacity,
     iree_hal_executable_function_parameter_t* out_parameters);
+
+// Populates |out_parameters| with up to |capacity| backend-native runtime
+// parameters. Callers should allocate based on runtime_parameter_count in the
+// function info. Returned string storage is owned by |executable| and remains
+// valid while the executable remains live.
+IREE_API_EXPORT iree_status_t iree_hal_executable_function_runtime_parameters(
+    iree_hal_executable_t* executable, iree_hal_executable_function_t function,
+    iree_host_size_t capacity,
+    iree_hal_executable_function_runtime_parameter_info_t* out_parameters);
+
+// Returns the number of executable-level runtime metadata records named |name|.
+//
+// Returned records are backend-defined data decoded from executable metadata.
+// This is executable-level metadata; function-specific launch ABI slots are
+// exposed through iree_hal_executable_function_runtime_parameters.
+IREE_API_EXPORT iree_status_t iree_hal_executable_runtime_metadata_count(
+    iree_hal_executable_t* executable, iree_string_view_t name,
+    iree_host_size_t* out_count);
+
+// Populates |out_records| with up to |capacity| runtime metadata records.
+//
+// Callers should size |out_records| from
+// iree_hal_executable_runtime_metadata_count. Returned string storage is owned
+// by |executable| and remains valid while the executable remains live.
+IREE_API_EXPORT iree_status_t iree_hal_executable_runtime_metadata_records(
+    iree_hal_executable_t* executable, iree_string_view_t name,
+    iree_host_size_t capacity,
+    iree_hal_executable_runtime_metadata_record_t* out_records);
 
 // Finds the function with the given |name|.
 IREE_API_EXPORT iree_status_t iree_hal_executable_lookup_function_by_name(
@@ -344,6 +405,23 @@ typedef struct iree_hal_executable_vtable_t {
       iree_hal_executable_t* executable,
       iree_hal_executable_function_t function, iree_host_size_t capacity,
       iree_hal_executable_function_parameter_t* out_parameters);
+
+  iree_status_t(IREE_API_PTR* function_runtime_parameters)(
+      iree_hal_executable_t* executable,
+      iree_hal_executable_function_t function, iree_host_size_t capacity,
+      iree_hal_executable_function_runtime_parameter_info_t* out_parameters);
+
+  // Returns the number of executable-level runtime metadata records named
+  // |name|.
+  iree_status_t(IREE_API_PTR* runtime_metadata_count)(
+      iree_hal_executable_t* executable, iree_string_view_t name,
+      iree_host_size_t* out_count);
+
+  // Populates executable-level runtime metadata records named |name|.
+  iree_status_t(IREE_API_PTR* runtime_metadata_records)(
+      iree_hal_executable_t* executable, iree_string_view_t name,
+      iree_host_size_t capacity,
+      iree_hal_executable_runtime_metadata_record_t* out_records);
 
   iree_status_t(IREE_API_PTR* lookup_function_by_name)(
       iree_hal_executable_t* executable, iree_string_view_t name,

--- a/runtime/src/iree/hal/host_notification.c
+++ b/runtime/src/iree/hal/host_notification.c
@@ -1,0 +1,62 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/host_notification.h"
+
+#include "iree/hal/detail.h"
+#include "iree/hal/device.h"
+
+#define _VTABLE_DISPATCH(notification, method_name)                  \
+  IREE_HAL_VTABLE_DISPATCH(notification, iree_hal_host_notification, \
+                           method_name)
+
+IREE_HAL_API_RETAIN_RELEASE(host_notification);
+
+IREE_API_EXPORT iree_status_t iree_hal_host_notification_create(
+    iree_hal_device_t* device,
+    iree_hal_host_notification_t** out_notification) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_ASSERT_ARGUMENT(out_notification);
+  *out_notification = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = IREE_HAL_VTABLE_DISPATCH(
+      device, iree_hal_device, create_host_notification)(device,
+                                                         out_notification);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_host_notification_create_unimplemented(
+    iree_hal_device_t* device,
+    iree_hal_host_notification_t** out_notification) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_ASSERT_ARGUMENT(out_notification);
+  *out_notification = NULL;
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "device does not support host notifications");
+}
+
+IREE_API_EXPORT uint64_t iree_hal_host_notification_device_token(
+    iree_hal_host_notification_t* notification) {
+  IREE_ASSERT_ARGUMENT(notification);
+  return _VTABLE_DISPATCH(notification, device_token)(notification);
+}
+
+IREE_API_EXPORT uint64_t iree_hal_host_notification_wait(
+    iree_hal_host_notification_t* notification, uint64_t observed_value) {
+  IREE_ASSERT_ARGUMENT(notification);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  uint64_t value =
+      _VTABLE_DISPATCH(notification, wait)(notification, observed_value);
+  IREE_TRACE_ZONE_END(z0);
+  return value;
+}
+
+IREE_API_EXPORT void iree_hal_host_notification_wake(
+    iree_hal_host_notification_t* notification) {
+  IREE_ASSERT_ARGUMENT(notification);
+  _VTABLE_DISPATCH(notification, wake)(notification);
+}

--- a/runtime/src/iree/hal/host_notification.h
+++ b/runtime/src/iree/hal/host_notification.h
@@ -1,0 +1,96 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_HOST_NOTIFICATION_H_
+#define IREE_HAL_HOST_NOTIFICATION_H_
+
+#include <stdint.h>
+
+#include "iree/base/api.h"
+#include "iree/hal/resource.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct iree_hal_device_t iree_hal_device_t;
+
+//===----------------------------------------------------------------------===//
+// iree_hal_host_notification_t
+//===----------------------------------------------------------------------===//
+
+// An opaque device signal that a host thread can wait on.
+//
+// Device-runtime ABIs may serialize |device_token| into device-visible memory
+// without interpreting it. The driver owns the token's representation and all
+// native synchronization needed to wait on it.
+typedef struct iree_hal_host_notification_t iree_hal_host_notification_t;
+
+// Initial value observed by a newly-created notification.
+#define IREE_HAL_HOST_NOTIFICATION_INITIAL_VALUE UINT64_C(1)
+
+// Creates a host notification for device-runtime communication.
+IREE_API_EXPORT iree_status_t iree_hal_host_notification_create(
+    iree_hal_device_t* device, iree_hal_host_notification_t** out_notification);
+
+// Generic vtable implementation for devices that do not support host
+// notifications. Device vtables must assign this function instead of NULL.
+IREE_API_EXPORT iree_status_t iree_hal_host_notification_create_unimplemented(
+    iree_hal_device_t* device, iree_hal_host_notification_t** out_notification);
+
+// Retains |notification| for the caller.
+IREE_API_EXPORT void iree_hal_host_notification_retain(
+    iree_hal_host_notification_t* notification);
+
+// Releases |notification| from the caller.
+IREE_API_EXPORT void iree_hal_host_notification_release(
+    iree_hal_host_notification_t* notification);
+
+// Returns the opaque device ABI token for |notification|.
+//
+// The token is only valid while the notification remains retained. Callers may
+// copy it into a backend-specific device-runtime ABI but must not inspect or
+// modify it.
+IREE_API_EXPORT uint64_t iree_hal_host_notification_device_token(
+    iree_hal_host_notification_t* notification);
+
+// Waits until the notification's value differs from |observed_value|.
+//
+// This is an unbounded wait. Callers that need to stop a listener must arrange
+// an independent stop condition and call iree_hal_host_notification_wake.
+IREE_API_EXPORT uint64_t iree_hal_host_notification_wait(
+    iree_hal_host_notification_t* notification, uint64_t observed_value);
+
+// Wakes host threads blocked in iree_hal_host_notification_wait.
+//
+// This is intended for listener shutdown. It must not be used to provide
+// device-runtime responses, which are carried by the caller's shared memory
+// protocol.
+IREE_API_EXPORT void iree_hal_host_notification_wake(
+    iree_hal_host_notification_t* notification);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_host_notification_t implementation details
+//===----------------------------------------------------------------------===//
+
+typedef struct iree_hal_host_notification_vtable_t {
+  void(IREE_API_PTR* destroy)(iree_hal_host_notification_t* notification);
+  uint64_t(IREE_API_PTR* device_token)(
+      iree_hal_host_notification_t* notification);
+  uint64_t(IREE_API_PTR* wait)(iree_hal_host_notification_t* notification,
+                               uint64_t observed_value);
+  void(IREE_API_PTR* wake)(iree_hal_host_notification_t* notification);
+} iree_hal_host_notification_vtable_t;
+IREE_HAL_ASSERT_VTABLE_LAYOUT(iree_hal_host_notification_vtable_t);
+
+IREE_API_EXPORT void iree_hal_host_notification_destroy(
+    iree_hal_host_notification_t* notification);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_HOST_NOTIFICATION_H_

--- a/runtime/src/iree/hal/host_notification_test.cc
+++ b/runtime/src/iree/hal/host_notification_test.cc
@@ -1,0 +1,33 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/host_notification.h"
+
+#include "iree/hal/testing/mock_device.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+TEST(HostNotificationTest, RejectsUnsupportedDevice) {
+  iree_hal_mock_device_options_t options;
+  iree_hal_mock_device_options_initialize(&options);
+
+  iree_hal_device_t* device = NULL;
+  IREE_ASSERT_OK(
+      iree_hal_mock_device_create(&options, iree_allocator_system(), &device));
+
+  iree_hal_host_notification_t* notification = NULL;
+  iree_status_t status =
+      iree_hal_host_notification_create(device, &notification);
+  EXPECT_EQ(IREE_STATUS_UNIMPLEMENTED, iree_status_code(status));
+  iree_status_ignore(status);
+  EXPECT_EQ(NULL, notification);
+
+  iree_hal_device_release(device);
+}
+
+}  // namespace

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -559,6 +559,7 @@ static iree_status_t iree_hal_vmvx_executable_export_info(
     iree_hal_executable_t* base_executable,
     iree_hal_executable_function_t function,
     iree_hal_executable_function_info_t* out_info) {
+  memset(out_info, 0, sizeof(*out_info));
   iree_hal_vmvx_executable_t* executable =
       (iree_hal_vmvx_executable_t*)base_executable;
   if (!iree_hal_executable_function_is_index_in_range(

--- a/runtime/src/iree/hal/local/profile_test.cc
+++ b/runtime/src/iree/hal/local/profile_test.cc
@@ -433,14 +433,15 @@ static iree_status_t FakeLocalExecutableIssueCall(
 }
 
 static const iree_hal_local_executable_vtable_t kFakeLocalExecutableVTable = {
-    {
-        FakeLocalExecutableDestroy,
-        FakeLocalExecutableFunctionCount,
-        FakeLocalExecutableFunctionInfo,
-        FakeLocalExecutableFunctionParameters,
-        FakeLocalExecutableLookupFunctionByName,
-    },
-    FakeLocalExecutableIssueCall,
+    .base =
+        {
+            .destroy = FakeLocalExecutableDestroy,
+            .function_count = FakeLocalExecutableFunctionCount,
+            .function_info = FakeLocalExecutableFunctionInfo,
+            .function_parameters = FakeLocalExecutableFunctionParameters,
+            .lookup_function_by_name = FakeLocalExecutableLookupFunctionByName,
+        },
+    .issue_call = FakeLocalExecutableIssueCall,
 };
 
 class LocalProfileRecorderTest : public ::testing::Test {

--- a/runtime/src/iree/hal/replay/BUILD.bazel
+++ b/runtime/src/iree/hal/replay/BUILD.bazel
@@ -20,6 +20,7 @@ iree_runtime_cc_library(
     hdrs = ["format.h"],
     deps = [
         "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
     ],
 )
 
@@ -148,6 +149,7 @@ iree_runtime_cc_test(
     deps = [
         ":execute",
         ":file_reader",
+        ":file_writer",
         ":recorder",
         "//runtime/src/iree/async",
         "//runtime/src/iree/async/util:proactor_pool",

--- a/runtime/src/iree/hal/replay/CMakeLists.txt
+++ b/runtime/src/iree/hal/replay/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_cc_library(
     "format.c"
   DEPS
     iree::base
+    iree::hal
   PUBLIC
 )
 
@@ -162,6 +163,7 @@ iree_cc_test(
   DEPS
     ::execute
     ::file_reader
+    ::file_writer
     ::recorder
     iree::async
     iree::async::util::proactor_pool

--- a/runtime/src/iree/hal/replay/dump.c
+++ b/runtime/src/iree/hal/replay/dump.c
@@ -401,19 +401,16 @@ static iree_status_t iree_hal_replay_dump_read_executable_metadata_header(
   }
   memcpy(out_header, record->payload.data + ranges->metadata_offset,
          sizeof(*out_header));
-  if (out_header->reserved1 != 0) {
-    return iree_make_status(IREE_STATUS_DATA_LOSS,
-                            "replay executable metadata reserved fields must "
-                            "be zero");
-  }
   if (out_header->function_count > IREE_HOST_SIZE_MAX ||
       out_header->parameter_count > IREE_HOST_SIZE_MAX ||
-      out_header->function_name_storage_length > IREE_HOST_SIZE_MAX) {
+      out_header->runtime_parameter_count > IREE_HOST_SIZE_MAX ||
+      out_header->name_storage_length > IREE_HOST_SIZE_MAX) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "replay executable metadata count overflow");
   }
   iree_host_size_t function_metadata_size = 0;
   iree_host_size_t parameter_metadata_size = 0;
+  iree_host_size_t runtime_parameter_metadata_size = 0;
   iree_host_size_t expected_length = 0;
   if (!iree_host_size_checked_mul(
           (iree_host_size_t)out_header->function_count,
@@ -423,14 +420,19 @@ static iree_status_t iree_hal_replay_dump_read_executable_metadata_header(
           (iree_host_size_t)out_header->parameter_count,
           sizeof(iree_hal_replay_executable_parameter_metadata_t),
           &parameter_metadata_size) ||
+      !iree_host_size_checked_mul(
+          (iree_host_size_t)out_header->runtime_parameter_count,
+          sizeof(iree_hal_replay_executable_runtime_parameter_metadata_t),
+          &runtime_parameter_metadata_size) ||
       !iree_host_size_checked_add(
           sizeof(iree_hal_replay_executable_metadata_header_t),
           function_metadata_size, &expected_length) ||
       !iree_host_size_checked_add(expected_length, parameter_metadata_size,
                                   &expected_length) ||
       !iree_host_size_checked_add(
-          expected_length,
-          (iree_host_size_t)out_header->function_name_storage_length,
+          expected_length, runtime_parameter_metadata_size, &expected_length) ||
+      !iree_host_size_checked_add(
+          expected_length, (iree_host_size_t)out_header->name_storage_length,
           &expected_length) ||
       expected_length != payload->executable_metadata_length) {
     return iree_make_status(IREE_STATUS_DATA_LOSS,
@@ -1025,9 +1027,11 @@ static iree_status_t iree_hal_replay_dump_append_text_payload(
         IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
             builder,
             " metadata_functions=%" PRIu64 " metadata_parameters=%" PRIu64
-            " metadata_function_name_storage_length=%" PRIu64,
+            " metadata_runtime_parameters=%" PRIu64
+            " metadata_name_storage_length=%" PRIu64,
             metadata_header.function_count, metadata_header.parameter_count,
-            metadata_header.function_name_storage_length));
+            metadata_header.runtime_parameter_count,
+            metadata_header.name_storage_length));
       }
       return iree_ok_status();
     }
@@ -1110,15 +1114,16 @@ static iree_status_t iree_hal_replay_dump_append_text_payload(
           " function_ordinal=%" PRIu32 " flags=0x%08" PRIx32
           " workgroup_count=[%" PRIu32 ",%" PRIu32 ",%" PRIu32
           "] workgroup_size=[%" PRIu32 ",%" PRIu32 ",%" PRIu32
-          "] wait_count=%" PRIu64 " signal_count=%" PRIu64
+          "] runtime_parameter_count=%u"
+          " wait_count=%" PRIu64 " signal_count=%" PRIu64
           " constants_range=[%" PRIu64 ", +%" PRIu64
           "] bindings_range=[%" PRIu64 ", +%" PRIhsz "]",
           payload.executable_id, payload.queue_affinity,
           payload.function_ordinal, payload.flags, payload.workgroup_count[0],
           payload.workgroup_count[1], payload.workgroup_count[2],
           payload.workgroup_size[0], payload.workgroup_size[1],
-          payload.workgroup_size[2], payload.wait_semaphore_count,
-          payload.signal_semaphore_count,
+          payload.workgroup_size[2], payload.runtime_parameters.count,
+          payload.wait_semaphore_count, payload.signal_semaphore_count,
           payload_range->offset + constants_offset, payload.constants_length,
           payload_range->offset + bindings_offset, bindings_size));
       return iree_hal_replay_dump_append_text_buffer_ref(
@@ -1734,9 +1739,11 @@ static iree_status_t iree_hal_replay_dump_append_json_payload(
             builder,
             ",\"metadata_function_count\":%" PRIu64
             ",\"metadata_parameter_count\":%" PRIu64
-            ",\"metadata_function_name_storage_length\":%" PRIu64,
+            ",\"metadata_runtime_parameter_count\":%" PRIu64
+            ",\"metadata_name_storage_length\":%" PRIu64,
             metadata_header.function_count, metadata_header.parameter_count,
-            metadata_header.function_name_storage_length));
+            metadata_header.runtime_parameter_count,
+            metadata_header.name_storage_length));
       }
       return iree_string_builder_append_cstring(builder, "}");
     }
@@ -1831,6 +1838,7 @@ static iree_status_t iree_hal_replay_dump_append_json_payload(
           ",\"flags\":%" PRIu32 ",\"workgroup_count\":[%" PRIu32 ",%" PRIu32
           ",%" PRIu32 "],\"workgroup_size\":[%" PRIu32 ",%" PRIu32 ",%" PRIu32
           "],\"dynamic_workgroup_local_memory\":%" PRIu32
+          ",\"runtime_parameter_count\":%u"
           ",\"wait_semaphore_count\":%" PRIu64
           ",\"signal_semaphore_count\":%" PRIu64
           ",\"constants_length\":%" PRIu64 ",\"binding_count\":%" PRIu64,
@@ -1839,8 +1847,9 @@ static iree_status_t iree_hal_replay_dump_append_json_payload(
           payload.workgroup_count[1], payload.workgroup_count[2],
           payload.workgroup_size[0], payload.workgroup_size[1],
           payload.workgroup_size[2], payload.dynamic_workgroup_local_memory,
-          payload.wait_semaphore_count, payload.signal_semaphore_count,
-          payload.constants_length, payload.binding_count));
+          payload.runtime_parameters.count, payload.wait_semaphore_count,
+          payload.signal_semaphore_count, payload.constants_length,
+          payload.binding_count));
       IREE_RETURN_IF_ERROR(iree_hal_replay_dump_append_json_buffer_ref(
           builder, "workgroup_count_ref", &payload.workgroup_count_ref));
       iree_hal_replay_file_range_t wait_range =

--- a/runtime/src/iree/hal/replay/dump_test.cc
+++ b/runtime/src/iree/hal/replay/dump_test.cc
@@ -152,7 +152,7 @@ static std::vector<uint8_t> MakeExecutableLoadReplayFileStorage() {
   iree_hal_replay_executable_metadata_header_t metadata_header = {};
   metadata_header.function_count = 1;
   const char function_name[] = "main";
-  metadata_header.function_name_storage_length = sizeof(function_name) - 1;
+  metadata_header.name_storage_length = sizeof(function_name) - 1;
   iree_hal_replay_executable_function_metadata_t function_metadata = {};
   function_metadata.binding_count = 2;
   function_metadata.workgroup_size[0] = 3;
@@ -282,6 +282,7 @@ TEST(ReplayDumpTest, EmitsExecutableMetadataRanges) {
   EXPECT_THAT(text_output, HasSubstr("metadata_range=["));
   EXPECT_THAT(text_output, HasSubstr("metadata_functions=1"));
   EXPECT_THAT(text_output, HasSubstr("metadata_parameters=0"));
+  EXPECT_THAT(text_output, HasSubstr("metadata_runtime_parameters=0"));
 
   options.format = IREE_HAL_REPLAY_DUMP_FORMAT_JSONL;
   std::string jsonl_output;
@@ -292,6 +293,8 @@ TEST(ReplayDumpTest, EmitsExecutableMetadataRanges) {
   EXPECT_THAT(jsonl_output, HasSubstr("\"metadata_range\""));
   EXPECT_THAT(jsonl_output, HasSubstr("\"metadata_function_count\":1"));
   EXPECT_THAT(jsonl_output, HasSubstr("\"metadata_parameter_count\":0"));
+  EXPECT_THAT(jsonl_output,
+              HasSubstr("\"metadata_runtime_parameter_count\":0"));
 }
 
 TEST(ReplayDumpTest, EmitsBufferRangeDataRanges) {

--- a/runtime/src/iree/hal/replay/execute.c
+++ b/runtime/src/iree/hal/replay/execute.c
@@ -98,6 +98,8 @@ typedef struct iree_hal_replay_plan_command_buffer_dispatch_t {
   uint32_t function_ordinal;
   // Dispatch grid and indirect-count configuration.
   iree_hal_dispatch_config_t config;
+  // Runtime parameter list retained for |config| during plan execution.
+  iree_hal_dispatch_runtime_parameter_list_t runtime_parameters;
   // Serialized indirect workgroup count buffer reference.
   iree_hal_replay_buffer_ref_payload_t workgroup_count_ref;
   // Inline constant bytes borrowed from the replay file.
@@ -772,15 +774,11 @@ static iree_status_t iree_hal_replay_executor_make_function_map_from_metadata(
   }
   iree_hal_replay_executable_metadata_header_t header;
   memcpy(&header, executable_metadata.data, sizeof(header));
-  if (IREE_UNLIKELY(header.reserved1 != 0)) {
-    return iree_make_status(IREE_STATUS_DATA_LOSS,
-                            "replay executable metadata reserved fields must "
-                            "be zero");
-  }
   if (IREE_UNLIKELY(header.function_count > IREE_HOST_SIZE_MAX ||
                     header.function_count > UINT32_MAX ||
                     header.parameter_count > IREE_HOST_SIZE_MAX ||
-                    header.function_name_storage_length > IREE_HOST_SIZE_MAX)) {
+                    header.runtime_parameter_count > IREE_HOST_SIZE_MAX ||
+                    header.name_storage_length > IREE_HOST_SIZE_MAX)) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "replay executable metadata count overflow");
   }
@@ -788,30 +786,40 @@ static iree_status_t iree_hal_replay_executor_make_function_map_from_metadata(
       (iree_host_size_t)header.function_count;
   const iree_host_size_t captured_parameter_count =
       (iree_host_size_t)header.parameter_count;
+  const iree_host_size_t captured_runtime_parameter_count =
+      (iree_host_size_t)header.runtime_parameter_count;
   const iree_host_size_t captured_name_storage_length =
-      (iree_host_size_t)header.function_name_storage_length;
+      (iree_host_size_t)header.name_storage_length;
 
   iree_host_size_t function_metadata_size = 0;
   iree_host_size_t parameter_metadata_size = 0;
+  iree_host_size_t runtime_parameter_metadata_size = 0;
   iree_host_size_t expected_length = 0;
-  if (IREE_UNLIKELY(!iree_host_size_checked_mul(
-                        captured_function_count,
-                        sizeof(iree_hal_replay_executable_function_metadata_t),
-                        &function_metadata_size) ||
-                    !iree_host_size_checked_mul(
-                        captured_parameter_count,
-                        sizeof(iree_hal_replay_executable_parameter_metadata_t),
-                        &parameter_metadata_size) ||
-                    !iree_host_size_checked_add(
-                        sizeof(iree_hal_replay_executable_metadata_header_t),
-                        function_metadata_size, &expected_length) ||
-                    !iree_host_size_checked_add(expected_length,
-                                                parameter_metadata_size,
-                                                &expected_length) ||
-                    !iree_host_size_checked_add(expected_length,
-                                                captured_name_storage_length,
-                                                &expected_length) ||
-                    expected_length != executable_metadata.data_length)) {
+  if (IREE_UNLIKELY(
+          !iree_host_size_checked_mul(
+              captured_function_count,
+              sizeof(iree_hal_replay_executable_function_metadata_t),
+              &function_metadata_size) ||
+          !iree_host_size_checked_mul(
+              captured_parameter_count,
+              sizeof(iree_hal_replay_executable_parameter_metadata_t),
+              &parameter_metadata_size) ||
+          !iree_host_size_checked_mul(
+              captured_runtime_parameter_count,
+              sizeof(iree_hal_replay_executable_runtime_parameter_metadata_t),
+              &runtime_parameter_metadata_size) ||
+          !iree_host_size_checked_add(
+              sizeof(iree_hal_replay_executable_metadata_header_t),
+              function_metadata_size, &expected_length) ||
+          !iree_host_size_checked_add(expected_length, parameter_metadata_size,
+                                      &expected_length) ||
+          !iree_host_size_checked_add(expected_length,
+                                      runtime_parameter_metadata_size,
+                                      &expected_length) ||
+          !iree_host_size_checked_add(expected_length,
+                                      captured_name_storage_length,
+                                      &expected_length) ||
+          expected_length != executable_metadata.data_length)) {
     return iree_make_status(IREE_STATUS_DATA_LOSS,
                             "replay executable metadata length mismatch");
   }
@@ -821,20 +829,27 @@ static iree_status_t iree_hal_replay_executor_make_function_map_from_metadata(
       sizeof(iree_hal_replay_executable_metadata_header_t);
   const uint8_t* parameter_metadata_data =
       function_metadata_data + function_metadata_size;
+  const uint8_t* runtime_parameter_metadata_data =
+      parameter_metadata_data + parameter_metadata_size;
   const iree_hal_replay_executable_function_metadata_t* function_metadata =
       (const iree_hal_replay_executable_function_metadata_t*)
           function_metadata_data;
   const iree_hal_replay_executable_parameter_metadata_t* parameter_metadata =
       (const iree_hal_replay_executable_parameter_metadata_t*)
           parameter_metadata_data;
-  const char* name_storage =
-      (const char*)(parameter_metadata_data + parameter_metadata_size);
+  const iree_hal_replay_executable_runtime_parameter_metadata_t*
+      runtime_parameter_metadata =
+          (const iree_hal_replay_executable_runtime_parameter_metadata_t*)
+              runtime_parameter_metadata_data;
+  const char* name_storage = (const char*)(runtime_parameter_metadata_data +
+                                           runtime_parameter_metadata_size);
 
   iree_hal_executable_function_t* function_map = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_replay_executor_allocate_function_map(
       executor, captured_function_count, &function_map));
 
   iree_host_size_t parameter_index = 0;
+  iree_host_size_t runtime_parameter_index = 0;
   iree_host_size_t name_offset = 0;
   iree_status_t status = iree_ok_status();
   for (iree_host_size_t i = 0;
@@ -843,6 +858,9 @@ static iree_status_t iree_hal_replay_executor_make_function_map_from_metadata(
         &function_metadata[i];
     if (IREE_UNLIKELY(captured->parameter_count >
                           captured_parameter_count - parameter_index ||
+                      captured->runtime_parameter_count >
+                          captured_runtime_parameter_count -
+                              runtime_parameter_index ||
                       captured->name_length >
                           captured_name_storage_length - name_offset)) {
       status = iree_make_status(IREE_STATUS_DATA_LOSS,
@@ -921,6 +939,15 @@ static iree_status_t iree_hal_replay_executor_make_function_map_from_metadata(
           (uint32_t)loaded_info.parameter_count, loaded_info.workgroup_size[0],
           loaded_info.workgroup_size[1], loaded_info.workgroup_size[2]);
     }
+    if (iree_status_is_ok(status) && captured->runtime_parameter_count !=
+                                         loaded_info.runtime_parameter_count) {
+      status = iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "replay executable %" PRIu64 " function %" PRIhsz
+          " runtime parameter count mismatch: captured=%u loaded=%u",
+          executable_id, i, (uint32_t)captured->runtime_parameter_count,
+          (uint32_t)loaded_info.runtime_parameter_count);
+    }
 
     iree_hal_executable_function_parameter_t* loaded_parameters = NULL;
     if (iree_status_is_ok(status) && captured->parameter_count != 0) {
@@ -982,12 +1009,84 @@ static iree_status_t iree_hal_replay_executor_make_function_map_from_metadata(
     }
     parameter_index += captured->parameter_count;
     iree_allocator_free(executor->host_allocator, loaded_parameters);
+
+    iree_hal_executable_function_runtime_parameter_info_t*
+        loaded_runtime_parameters = NULL;
+    if (iree_status_is_ok(status) && captured->runtime_parameter_count != 0) {
+      iree_host_size_t runtime_parameter_size = 0;
+      if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+              captured->runtime_parameter_count,
+              sizeof(iree_hal_executable_function_runtime_parameter_info_t),
+              &runtime_parameter_size))) {
+        status = iree_make_status(
+            IREE_STATUS_OUT_OF_RANGE,
+            "executable runtime parameter metadata is too large");
+      }
+      if (iree_status_is_ok(status)) {
+        status = iree_allocator_malloc(executor->host_allocator,
+                                       runtime_parameter_size,
+                                       (void**)&loaded_runtime_parameters);
+      }
+      if (iree_status_is_ok(status)) {
+        status = iree_hal_executable_function_runtime_parameters(
+            executable, function, captured->runtime_parameter_count,
+            loaded_runtime_parameters);
+      }
+    }
+    for (iree_host_size_t j = 0;
+         j < captured->runtime_parameter_count && iree_status_is_ok(status);
+         ++j) {
+      const iree_hal_replay_executable_runtime_parameter_metadata_t*
+          captured_parameter =
+              &runtime_parameter_metadata[runtime_parameter_index + j];
+      if (IREE_UNLIKELY(captured_parameter->reserved0 != 0)) {
+        status = iree_make_status(
+            IREE_STATUS_DATA_LOSS,
+            "replay executable runtime parameter metadata reserved fields must "
+            "be zero");
+        break;
+      }
+      if (IREE_UNLIKELY(captured_parameter->name_length == 0 ||
+                        captured_parameter->name_length >
+                            captured_name_storage_length - name_offset)) {
+        status = iree_make_status(
+            IREE_STATUS_DATA_LOSS,
+            "replay executable runtime parameter metadata name is invalid");
+        break;
+      }
+      const iree_string_view_t captured_parameter_name = iree_make_string_view(
+          name_storage + name_offset, captured_parameter->name_length);
+      name_offset += captured_parameter->name_length;
+      const iree_hal_executable_function_runtime_parameter_info_t*
+          loaded_parameter = &loaded_runtime_parameters[j];
+      if (!iree_string_view_equal(captured_parameter_name,
+                                  loaded_parameter->name) ||
+          captured_parameter->offset != loaded_parameter->offset ||
+          captured_parameter->length != loaded_parameter->length) {
+        status = iree_make_status(
+            IREE_STATUS_FAILED_PRECONDITION,
+            "replay executable %" PRIu64 " function %" PRIhsz
+            " runtime parameter %" PRIhsz
+            " ABI mismatch: captured=(name='%.*s' offset=%u length=%u) "
+            "loaded=(name='%.*s' offset=%u length=%u)",
+            executable_id, i, j, (int)captured_parameter_name.size,
+            captured_parameter_name.data, (uint32_t)captured_parameter->offset,
+            (uint32_t)captured_parameter->length,
+            (int)loaded_parameter->name.size, loaded_parameter->name.data,
+            (uint32_t)loaded_parameter->offset,
+            (uint32_t)loaded_parameter->length);
+      }
+    }
+    runtime_parameter_index += captured->runtime_parameter_count;
+    iree_allocator_free(executor->host_allocator, loaded_runtime_parameters);
     if (iree_status_is_ok(status)) {
       function_map[i] = function;
     }
   }
   if (iree_status_is_ok(status) &&
       IREE_UNLIKELY(parameter_index != captured_parameter_count ||
+                    runtime_parameter_index !=
+                        captured_runtime_parameter_count ||
                     name_offset != captured_name_storage_length)) {
     status = iree_make_status(IREE_STATUS_DATA_LOSS,
                               "replay executable metadata count mismatch");
@@ -2501,6 +2600,17 @@ static iree_status_t iree_hal_replay_executor_dispatch_layout(
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_replay_executor_check_runtime_parameters(
+    const iree_hal_replay_dispatch_payload_t* payload) {
+  if (payload->runtime_parameters.count != 0) {
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "replay dispatch has backend-native runtime parameters without a "
+        "portable provider");
+  }
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_replay_plan_prepare_scope(
     const iree_hal_replay_file_record_t* record,
     iree_hal_replay_scope_event_type_t event_type,
@@ -2587,6 +2697,8 @@ static iree_status_t iree_hal_replay_plan_prepare_command_buffer_dispatch(
       sizeof(iree_hal_replay_dispatch_payload_t)));
   iree_hal_replay_dispatch_payload_t payload;
   memcpy(&payload, record->payload.data, sizeof(payload));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_replay_executor_check_runtime_parameters(&payload));
   if (payload.wait_semaphore_count != 0 ||
       payload.signal_semaphore_count != 0) {
     return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
@@ -2618,6 +2730,8 @@ static iree_status_t iree_hal_replay_plan_prepare_command_buffer_dispatch(
          sizeof(out_dispatch->config.workgroup_count));
   out_dispatch->config.dynamic_workgroup_local_memory =
       payload.dynamic_workgroup_local_memory;
+  out_dispatch->runtime_parameters = payload.runtime_parameters;
+  out_dispatch->config.runtime_parameters = &out_dispatch->runtime_parameters;
   out_dispatch->workgroup_count_ref = payload.workgroup_count_ref;
   out_dispatch->constants =
       iree_make_const_byte_span(record->payload.data + constants_offset,
@@ -2831,6 +2945,8 @@ static iree_status_t iree_hal_replay_executor_command_buffer_dispatch(
       sizeof(iree_hal_replay_dispatch_payload_t)));
   iree_hal_replay_dispatch_payload_t payload;
   memcpy(&payload, record->payload.data, sizeof(payload));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_replay_executor_check_runtime_parameters(&payload));
   if (payload.wait_semaphore_count != 0 ||
       payload.signal_semaphore_count != 0) {
     return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
@@ -2883,6 +2999,7 @@ static iree_status_t iree_hal_replay_executor_command_buffer_dispatch(
            sizeof(config.workgroup_count));
     config.dynamic_workgroup_local_memory =
         payload.dynamic_workgroup_local_memory;
+    config.runtime_parameters = &payload.runtime_parameters;
     iree_hal_executable_function_t function =
         iree_hal_executable_function_invalid();
     status = iree_hal_replay_executor_make_buffer_ref(
@@ -2912,6 +3029,8 @@ static iree_status_t iree_hal_replay_executor_queue_dispatch(
       sizeof(iree_hal_replay_dispatch_payload_t)));
   iree_hal_replay_dispatch_payload_t payload;
   memcpy(&payload, record->payload.data, sizeof(payload));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_replay_executor_check_runtime_parameters(&payload));
   iree_host_size_t wait_offset = 0;
   iree_host_size_t wait_size = 0;
   iree_host_size_t signal_offset = 0;
@@ -2972,6 +3091,7 @@ static iree_status_t iree_hal_replay_executor_queue_dispatch(
            sizeof(config.workgroup_count));
     config.dynamic_workgroup_local_memory =
         payload.dynamic_workgroup_local_memory;
+    config.runtime_parameters = &payload.runtime_parameters;
     iree_hal_executable_function_t function =
         iree_hal_executable_function_invalid();
     status = iree_hal_replay_executor_make_buffer_ref(
@@ -3484,6 +3604,7 @@ static iree_status_t iree_hal_replay_executor_replay_operation(
     case IREE_HAL_REPLAY_OPERATION_CODE_EXECUTABLE_FUNCTION_INFO:
     case IREE_HAL_REPLAY_OPERATION_CODE_EXECUTABLE_FUNCTION_PARAMETERS:
     case IREE_HAL_REPLAY_OPERATION_CODE_EXECUTABLE_LOOKUP_FUNCTION_BY_NAME:
+    case IREE_HAL_REPLAY_OPERATION_CODE_EXECUTABLE_FUNCTION_RUNTIME_PARAMETERS:
     case IREE_HAL_REPLAY_OPERATION_CODE_BUFFER_MAP_RANGE:
       return iree_ok_status();
     case IREE_HAL_REPLAY_OPERATION_CODE_DEVICE_LOAD_EXECUTABLE:

--- a/runtime/src/iree/hal/replay/execute_test.cc
+++ b/runtime/src/iree/hal/replay/execute_test.cc
@@ -18,6 +18,7 @@
 #include "iree/async/util/proactor_pool.h"
 #include "iree/hal/drivers/local_sync/sync_device.h"
 #include "iree/hal/replay/file_reader.h"
+#include "iree/hal/replay/file_writer.h"
 #include "iree/hal/replay/recorder.h"
 #include "iree/hal/testing/mock_device.h"
 #include "iree/io/file_contents.h"
@@ -180,22 +181,49 @@ typedef struct MockExecutableFunctionRecord {
   uint8_t native_abi_offset;
   // Native ABI byte size for the optional reflected buffer binding.
   uint16_t parameter_size;
+  // Number of runtime parameter records for the function.
+  uint8_t runtime_parameter_count;
+  // Reserved byte; must be zero.
+  uint8_t reserved;
 } MockExecutableFunctionRecord;
 
-static_assert(sizeof(MockExecutableFunctionRecord) == 10);
+static_assert(sizeof(MockExecutableFunctionRecord) == 12);
+
+typedef struct MockExecutableRuntimeParameter {
+  const char* name;
+  uint8_t offset;
+  uint8_t length;
+} MockExecutableRuntimeParameter;
+
+typedef struct MockExecutableRuntimeParameterRecord {
+  uint8_t offset;
+  uint8_t length;
+  uint8_t name_length;
+  uint8_t reserved;
+} MockExecutableRuntimeParameterRecord;
+
+static_assert(sizeof(MockExecutableRuntimeParameterRecord) == 4);
 
 static std::vector<uint8_t> MakeMockExecutableData(
     uint8_t constant_count, uint8_t binding_count, uint8_t workgroup_size_x,
-    uint8_t native_abi_offset = 0, uint16_t parameter_size = 0) {
+    uint8_t native_abi_offset, uint16_t parameter_size,
+    std::initializer_list<MockExecutableRuntimeParameter> runtime_parameters) {
   const char name[] = "main";
+  if (runtime_parameters.size() > UINT8_MAX) {
+    ADD_FAILURE() << "too many mock runtime parameters";
+    return {};
+  }
   if (native_abi_offset != 0 && parameter_size == 0) {
     parameter_size = sizeof(void*);
   }
   std::vector<uint8_t> data(
-      4 + sizeof(MockExecutableFunctionRecord) + sizeof(name) - 1, 0);
+      4 + sizeof(MockExecutableFunctionRecord) +
+          runtime_parameters.size() *
+              sizeof(MockExecutableRuntimeParameterRecord),
+      0);
   const uint32_t function_count = 1;
   std::memcpy(data.data(), &function_count, sizeof(function_count));
-  const MockExecutableFunctionRecord record = {
+  const MockExecutableFunctionRecord function_record = {
       /*.constant_count=*/constant_count,
       /*.binding_count=*/binding_count,
       /*.flags=*/0,
@@ -203,10 +231,51 @@ static std::vector<uint8_t> MakeMockExecutableData(
       /*.name_length=*/sizeof(name) - 1,
       /*.native_abi_offset=*/native_abi_offset,
       /*.parameter_size=*/parameter_size,
+      /*.runtime_parameter_count=*/(uint8_t)runtime_parameters.size(),
+      /*.reserved=*/0,
   };
-  std::memcpy(data.data() + 4, &record, sizeof(record));
-  std::memcpy(data.data() + 4 + sizeof(record), name, sizeof(name) - 1);
+  std::memcpy(data.data() + sizeof(function_count), &function_record,
+              sizeof(function_record));
+  for (size_t i = 0; i < runtime_parameters.size(); ++i) {
+    const MockExecutableRuntimeParameter& parameter =
+        *(runtime_parameters.begin() + i);
+    const size_t parameter_name_length = strlen(parameter.name);
+    if (parameter_name_length > UINT8_MAX) {
+      ADD_FAILURE() << "mock runtime parameter name too long";
+      return {};
+    }
+    const MockExecutableRuntimeParameterRecord parameter_record = {
+        /*.offset=*/parameter.offset,
+        /*.length=*/parameter.length,
+        /*.name_length=*/(uint8_t)parameter_name_length,
+        /*.reserved=*/0,
+    };
+    std::memcpy(data.data() + sizeof(function_count) + sizeof(function_record) +
+                    i * sizeof(parameter_record),
+                &parameter_record, sizeof(parameter_record));
+  }
+  data.insert(data.end(), name, name + sizeof(name) - 1);
+  for (const MockExecutableRuntimeParameter& parameter : runtime_parameters) {
+    const size_t parameter_name_length = strlen(parameter.name);
+    data.insert(data.end(), parameter.name,
+                parameter.name + parameter_name_length);
+  }
   return data;
+}
+
+static std::vector<uint8_t> MakeMockExecutableData(
+    uint8_t constant_count, uint8_t binding_count, uint8_t workgroup_size_x,
+    uint8_t native_abi_offset = 0, uint16_t parameter_size = 0) {
+  return MakeMockExecutableData(constant_count, binding_count, workgroup_size_x,
+                                native_abi_offset, parameter_size, {});
+}
+
+static std::vector<uint8_t> MakeMockExecutableData(
+    uint8_t constant_count, uint8_t binding_count, uint8_t workgroup_size_x,
+    std::initializer_list<MockExecutableRuntimeParameter> runtime_parameters) {
+  return MakeMockExecutableData(constant_count, binding_count, workgroup_size_x,
+                                /*native_abi_offset=*/0,
+                                /*parameter_size=*/0, runtime_parameters);
 }
 
 typedef struct MockExecutableFunction {
@@ -245,6 +314,8 @@ static std::vector<uint8_t> MakeNamedMockExecutableData(
         /*.name_length=*/(uint8_t)name_length,
         /*.native_abi_offset=*/0,
         /*.parameter_size=*/0,
+        /*.runtime_parameter_count=*/0,
+        /*.reserved=*/0,
     };
     std::memcpy(data.data() + 4 + function_ordinal * sizeof(record), &record,
                 sizeof(record));
@@ -296,6 +367,52 @@ static void CaptureMockExecutableLoad(iree_const_byte_span_t executable_data,
   iree_hal_device_group_release(wrapped_group);
   iree_hal_device_group_release(source_group);
   iree_hal_replay_recorder_release(recorder);
+}
+
+static std::vector<uint8_t> MakeRawRuntimeParameterDispatchReplayFile() {
+  std::vector<uint8_t> storage(4096, 0);
+  iree_io_file_handle_t* file_handle = nullptr;
+  IREE_CHECK_OK(iree_io_file_handle_wrap_host_allocation(
+      IREE_IO_FILE_ACCESS_READ | IREE_IO_FILE_ACCESS_WRITE,
+      iree_make_byte_span(storage.data(), storage.size()),
+      iree_io_file_handle_release_callback_null(), iree_allocator_system(),
+      &file_handle));
+  iree_hal_replay_file_writer_t* writer = nullptr;
+  IREE_CHECK_OK(iree_hal_replay_file_writer_create(
+      file_handle, iree_allocator_system(), &writer));
+  iree_io_file_handle_release(file_handle);
+
+  iree_hal_replay_file_record_metadata_t session_metadata = {};
+  session_metadata.sequence_ordinal = 0;
+  session_metadata.record_type = IREE_HAL_REPLAY_FILE_RECORD_TYPE_SESSION;
+  IREE_CHECK_OK(iree_hal_replay_file_writer_append_record(
+      writer, &session_metadata, 0, nullptr, nullptr));
+
+  iree_hal_replay_dispatch_payload_t payload = {};
+  payload.runtime_parameters.count = 1;
+  payload.runtime_parameters.patches[0].offset = 16;
+  payload.runtime_parameters.patches[0].length = sizeof(uint64_t);
+  const uint64_t raw_device_address = UINT64_C(0x0123456789ABCDEF);
+  memcpy(payload.runtime_parameters.patches[0].data, &raw_device_address,
+         sizeof(raw_device_address));
+  iree_const_byte_span_t payload_span =
+      iree_make_const_byte_span(&payload, sizeof(payload));
+  iree_hal_replay_file_record_metadata_t dispatch_metadata = {};
+  dispatch_metadata.sequence_ordinal = 1;
+  dispatch_metadata.device_id = 1;
+  dispatch_metadata.object_id = 1;
+  dispatch_metadata.related_object_id = 2;
+  dispatch_metadata.record_type = IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION;
+  dispatch_metadata.payload_type = IREE_HAL_REPLAY_PAYLOAD_TYPE_DISPATCH;
+  dispatch_metadata.object_type = IREE_HAL_REPLAY_OBJECT_TYPE_DEVICE;
+  dispatch_metadata.operation_code =
+      IREE_HAL_REPLAY_OPERATION_CODE_DEVICE_QUEUE_DISPATCH;
+  IREE_CHECK_OK(iree_hal_replay_file_writer_append_record(
+      writer, &dispatch_metadata, 1, &payload_span, nullptr));
+
+  IREE_CHECK_OK(iree_hal_replay_file_writer_close(writer));
+  iree_hal_replay_file_writer_free(writer);
+  return storage;
 }
 
 static void CorruptFirstCapturedExecutableData(std::vector<uint8_t>* storage) {
@@ -520,6 +637,86 @@ TEST(ReplayExecuteTest, UsesRecordedExecutableMetadataForSubstitution) {
   IREE_EXPECT_OK(iree_hal_replay_execute_file(GetCapturedFileContents(storage),
                                               replay_group, &options,
                                               iree_allocator_system()));
+  EXPECT_EQ(substitution_state.invocation_count, 1u);
+  iree_hal_device_group_release(replay_group);
+}
+
+TEST(ReplayExecuteTest, RejectsRawRuntimeParameterDispatchPayload) {
+  std::vector<uint8_t> storage = MakeRawRuntimeParameterDispatchReplayFile();
+  iree_hal_device_group_t* replay_group = CreateSyncDeviceGroup();
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_UNIMPLEMENTED,
+                        iree_hal_replay_execute_file(
+                            GetCapturedFileContents(storage), replay_group,
+                            nullptr, iree_allocator_system()));
+  iree_hal_device_group_release(replay_group);
+}
+
+TEST(ReplayExecuteTest, SubstitutesRecordedExecutableRuntimeParameterMetadata) {
+  std::vector<uint8_t> captured_data = MakeMockExecutableData(
+      /*constant_count=*/2, /*binding_count=*/3, /*workgroup_size_x=*/4,
+      {{/*name=*/"runtime_state", /*offset=*/16, /*length=*/8}});
+  std::vector<uint8_t> replacement_data = MakeMockExecutableData(
+      /*constant_count=*/2, /*binding_count=*/3, /*workgroup_size_x=*/4,
+      {{/*name=*/"runtime_state", /*offset=*/16, /*length=*/8}});
+  std::vector<uint8_t> storage(32768, 0);
+  CaptureMockExecutableLoad(
+      iree_make_const_byte_span(captured_data.data(), captured_data.size()),
+      &storage);
+
+  TestExecutableSubstitutionState substitution_state = {
+      /*.source=*/iree_make_cstring_view("replacement.mock"),
+      /*.executable_data=*/
+      iree_make_const_byte_span(replacement_data.data(),
+                                replacement_data.size()),
+      /*.invocation_count=*/0,
+      /*.executable_id=*/IREE_HAL_REPLAY_OBJECT_ID_NONE,
+  };
+  iree_hal_replay_execute_options_t options =
+      iree_hal_replay_execute_options_default();
+  options.executable_substitution_callback.fn =
+      TestExecutableSubstitutionCallback;
+  options.executable_substitution_callback.user_data = &substitution_state;
+
+  iree_hal_device_group_t* replay_group = CreateMockExecutableDeviceGroup();
+  IREE_EXPECT_OK(iree_hal_replay_execute_file(GetCapturedFileContents(storage),
+                                              replay_group, &options,
+                                              iree_allocator_system()));
+  EXPECT_EQ(substitution_state.invocation_count, 1u);
+  iree_hal_device_group_release(replay_group);
+}
+
+TEST(ReplayExecuteTest,
+     RejectsExecutableSubstitutionRuntimeParameterAbiMismatch) {
+  std::vector<uint8_t> captured_data = MakeMockExecutableData(
+      /*constant_count=*/2, /*binding_count=*/3, /*workgroup_size_x=*/4,
+      {{/*name=*/"runtime_state", /*offset=*/16, /*length=*/8}});
+  std::vector<uint8_t> replacement_data = MakeMockExecutableData(
+      /*constant_count=*/2, /*binding_count=*/3, /*workgroup_size_x=*/4,
+      {{/*name=*/"runtime_state", /*offset=*/24, /*length=*/8}});
+  std::vector<uint8_t> storage(32768, 0);
+  CaptureMockExecutableLoad(
+      iree_make_const_byte_span(captured_data.data(), captured_data.size()),
+      &storage);
+
+  TestExecutableSubstitutionState substitution_state = {
+      /*.source=*/iree_make_cstring_view("replacement.mock"),
+      /*.executable_data=*/
+      iree_make_const_byte_span(replacement_data.data(),
+                                replacement_data.size()),
+      /*.invocation_count=*/0,
+      /*.executable_id=*/IREE_HAL_REPLAY_OBJECT_ID_NONE,
+  };
+  iree_hal_replay_execute_options_t options =
+      iree_hal_replay_execute_options_default();
+  options.executable_substitution_callback.fn =
+      TestExecutableSubstitutionCallback;
+  options.executable_substitution_callback.user_data = &substitution_state;
+
+  iree_hal_device_group_t* replay_group = CreateMockExecutableDeviceGroup();
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION,
+                        iree_hal_replay_execute_file(
+                            GetCapturedFileContents(storage), replay_group,
+                            &options, iree_allocator_system()));
   EXPECT_EQ(substitution_state.invocation_count, 1u);
   iree_hal_device_group_release(replay_group);
 }

--- a/runtime/src/iree/hal/replay/format.c
+++ b/runtime/src/iree/hal/replay/format.c
@@ -191,6 +191,8 @@ IREE_API_EXPORT const char* iree_hal_replay_operation_code_string(
       return "executable.function_parameters";
     case IREE_HAL_REPLAY_OPERATION_CODE_EXECUTABLE_LOOKUP_FUNCTION_BY_NAME:
       return "executable.lookup_function_by_name";
+    case IREE_HAL_REPLAY_OPERATION_CODE_EXECUTABLE_FUNCTION_RUNTIME_PARAMETERS:
+      return "executable.function_runtime_parameters";
     default:
       return "unknown";
   }

--- a/runtime/src/iree/hal/replay/format.h
+++ b/runtime/src/iree/hal/replay/format.h
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "iree/base/api.h"
+#include "iree/hal/command_buffer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -149,6 +150,7 @@ enum iree_hal_replay_operation_code_e {
   IREE_HAL_REPLAY_OPERATION_CODE_EXECUTABLE_FUNCTION_INFO = 501u,
   IREE_HAL_REPLAY_OPERATION_CODE_EXECUTABLE_FUNCTION_PARAMETERS = 502u,
   IREE_HAL_REPLAY_OPERATION_CODE_EXECUTABLE_LOOKUP_FUNCTION_BY_NAME = 503u,
+  IREE_HAL_REPLAY_OPERATION_CODE_EXECUTABLE_FUNCTION_RUNTIME_PARAMETERS = 504u,
 };
 
 // Producer-defined payload schema stored in record headers.
@@ -361,10 +363,10 @@ typedef struct iree_hal_replay_executable_metadata_header_t {
   uint64_t function_count;
   // Total number of parameter metadata records after all function records.
   uint64_t parameter_count;
-  // Total byte length of function names following all parameter records.
-  uint64_t function_name_storage_length;
-  // Reserved for future executable metadata; must be zero.
-  uint64_t reserved1;
+  // Total byte length of function and runtime parameter names after records.
+  uint64_t name_storage_length;
+  // Total number of runtime parameter metadata records after parameters.
+  uint64_t runtime_parameter_count;
 } iree_hal_replay_executable_metadata_header_t;
 
 // Captured executable function reflection used to validate substitutions.
@@ -381,6 +383,8 @@ typedef struct iree_hal_replay_executable_function_metadata_t {
   uint16_t parameter_count;
   // Byte length of this function's name in the trailing name storage.
   uint16_t name_length;
+  // Number of runtime parameter metadata records for this function.
+  uint16_t runtime_parameter_count;
 } iree_hal_replay_executable_function_metadata_t;
 
 // Captured executable function parameter reflection.
@@ -398,6 +402,18 @@ typedef struct iree_hal_replay_executable_parameter_metadata_t {
   // Reserved for future parameter metadata; must be zero.
   uint8_t reserved0;
 } iree_hal_replay_executable_parameter_metadata_t;
+
+// Captured backend-native runtime parameter ABI metadata.
+typedef struct iree_hal_replay_executable_runtime_parameter_metadata_t {
+  // Byte offset in backend-native launch argument storage.
+  uint32_t offset;
+  // Byte length of the runtime parameter.
+  uint32_t length;
+  // Byte length of the parameter name in the trailing name storage.
+  uint16_t name_length;
+  // Reserved for future metadata; must be zero.
+  uint16_t reserved0;
+} iree_hal_replay_executable_runtime_parameter_metadata_t;
 
 // Payload describing a captured semaphore object.
 typedef struct iree_hal_replay_semaphore_object_payload_t {
@@ -568,8 +584,9 @@ typedef struct iree_hal_replay_dispatch_payload_t {
   iree_hal_replay_buffer_ref_payload_t workgroup_count_ref;
   // Dynamic workgroup-local memory size in bytes.
   uint32_t dynamic_workgroup_local_memory;
-  // Reserved for future dispatch metadata; must be zero.
-  uint32_t reserved0;
+  // Value copy of dispatch-local native runtime parameter patches and
+  // requirements.
+  iree_hal_dispatch_runtime_parameter_list_t runtime_parameters;
   // Number of wait semaphore timepoints following this header.
   uint64_t wait_semaphore_count;
   // Number of signal semaphore timepoints following the wait timepoints.

--- a/runtime/src/iree/hal/replay/recorder.c
+++ b/runtime/src/iree/hal/replay/recorder.c
@@ -1677,6 +1677,11 @@ static iree_status_t iree_hal_replay_device_queue_dispatch(
         IREE_HAL_REPLAY_PAYLOAD_TYPE_DISPATCH, &pending_record);
   }
   if (iree_status_is_ok(status)) {
+    if (iree_hal_dispatch_config_has_runtime_parameters(config)) {
+      // Backend-native parameters can contain live device addresses without an
+      // object reference that a replay executor can resolve in a new context.
+      iree_hal_replay_recorder_mark_unsupported(&pending_record);
+    }
     status = iree_hal_replay_recorder_end_operation_with_payload(
         &pending_record,
         iree_hal_device_queue_dispatch(
@@ -2011,6 +2016,7 @@ static const iree_hal_device_vtable_t iree_hal_replay_device_vtable = {
     .create_channel = iree_hal_replay_device_create_channel,
     .create_command_buffer = iree_hal_replay_device_create_command_buffer,
     .create_event = iree_hal_replay_device_create_event,
+    .create_host_notification = iree_hal_host_notification_create_unimplemented,
     .load_executable = iree_hal_replay_device_load_executable,
     .import_file = iree_hal_replay_device_import_file,
     .create_semaphore = iree_hal_replay_device_create_semaphore,

--- a/runtime/src/iree/hal/replay/recorder_command_buffer.c
+++ b/runtime/src/iree/hal/replay/recorder_command_buffer.c
@@ -882,6 +882,11 @@ static iree_status_t iree_hal_replay_recorder_command_buffer_dispatch(
         IREE_HAL_REPLAY_PAYLOAD_TYPE_DISPATCH, &pending_record);
   }
   if (iree_status_is_ok(status)) {
+    if (iree_hal_dispatch_config_has_runtime_parameters(config)) {
+      // Backend-native parameters can contain live device addresses without an
+      // object reference that a replay executor can resolve in a new context.
+      iree_hal_replay_recorder_mark_unsupported(&pending_record);
+    }
     status = iree_hal_replay_recorder_end_operation_with_payload(
         &pending_record,
         iree_hal_command_buffer_dispatch(

--- a/runtime/src/iree/hal/replay/recorder_executable.c
+++ b/runtime/src/iree/hal/replay/recorder_executable.c
@@ -309,6 +309,24 @@ static iree_status_t iree_hal_replay_recorder_executable_function_parameters(
 }
 
 static iree_status_t
+iree_hal_replay_recorder_executable_function_runtime_parameters(
+    iree_hal_executable_t* base_executable,
+    iree_hal_executable_function_t function, iree_host_size_t capacity,
+    iree_hal_executable_function_runtime_parameter_info_t* out_parameters) {
+  iree_hal_replay_recorder_executable_t* executable =
+      iree_hal_replay_recorder_executable_cast(base_executable);
+  iree_hal_replay_pending_record_t pending_record;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_recorder_executable_begin_operation(
+      executable,
+      IREE_HAL_REPLAY_OPERATION_CODE_EXECUTABLE_FUNCTION_RUNTIME_PARAMETERS,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_NONE, &pending_record));
+  return iree_hal_replay_recorder_end_operation(
+      &pending_record,
+      iree_hal_executable_function_runtime_parameters(
+          executable->base_executable, function, capacity, out_parameters));
+}
+
+static iree_status_t
 iree_hal_replay_recorder_executable_lookup_function_by_name(
     iree_hal_executable_t* base_executable, iree_string_view_t name,
     iree_hal_executable_function_t* out_function) {
@@ -444,7 +462,8 @@ static iree_status_t iree_hal_replay_recorder_capture_executable_metadata(
   }
   iree_status_t status = iree_ok_status();
   iree_host_size_t parameter_count = 0;
-  iree_host_size_t function_name_storage_size = 0;
+  iree_host_size_t runtime_parameter_count = 0;
+  iree_host_size_t name_storage_size = 0;
   for (iree_host_size_t i = 0; i < function_count && iree_status_is_ok(status);
        ++i) {
     status = iree_hal_executable_function_info(
@@ -486,11 +505,20 @@ static iree_status_t iree_hal_replay_recorder_capture_executable_metadata(
     }
     if (iree_status_is_ok(status)) {
       if (IREE_UNLIKELY(!iree_host_size_checked_add(
-              function_name_storage_size, function_infos[i].name.size,
-              &function_name_storage_size))) {
-        status =
-            iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                             "executable function name storage size overflow");
+              runtime_parameter_count,
+              function_infos[i].runtime_parameter_count,
+              &runtime_parameter_count))) {
+        status = iree_make_status(
+            IREE_STATUS_OUT_OF_RANGE,
+            "executable runtime parameter metadata count overflow");
+      }
+    }
+    if (iree_status_is_ok(status)) {
+      if (IREE_UNLIKELY(!iree_host_size_checked_add(name_storage_size,
+                                                    function_infos[i].name.size,
+                                                    &name_storage_size))) {
+        status = iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                                  "executable name storage size overflow");
       }
     }
   }
@@ -534,9 +562,82 @@ static iree_status_t iree_hal_replay_recorder_capture_executable_metadata(
     return status;
   }
 
+  iree_hal_executable_function_runtime_parameter_info_t* runtime_parameters =
+      NULL;
+  iree_host_size_t runtime_parameter_info_size = 0;
+  if (runtime_parameter_count > 0) {
+    if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+            runtime_parameter_count, sizeof(*runtime_parameters),
+            &runtime_parameter_info_size))) {
+      iree_allocator_free(host_allocator, parameters);
+      iree_allocator_free(host_allocator, function_infos);
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "executable runtime parameter metadata size overflow");
+    }
+    status = iree_allocator_malloc(host_allocator, runtime_parameter_info_size,
+                                   (void**)&runtime_parameters);
+    if (!iree_status_is_ok(status)) {
+      iree_allocator_free(host_allocator, parameters);
+      iree_allocator_free(host_allocator, function_infos);
+      return status;
+    }
+  }
+
+  iree_host_size_t runtime_parameter_index = 0;
+  for (iree_host_size_t i = 0; i < function_count && iree_status_is_ok(status);
+       ++i) {
+    const iree_host_size_t function_runtime_parameter_count =
+        function_infos[i].runtime_parameter_count;
+    if (function_runtime_parameter_count == 0) continue;
+    status = iree_hal_executable_function_runtime_parameters(
+        executable, iree_hal_executable_function_from_index((uint32_t)i),
+        function_runtime_parameter_count,
+        runtime_parameters + runtime_parameter_index);
+    for (iree_host_size_t j = 0;
+         j < function_runtime_parameter_count && iree_status_is_ok(status);
+         ++j) {
+      const iree_hal_executable_function_runtime_parameter_info_t* parameter =
+          &runtime_parameters[runtime_parameter_index + j];
+      if (IREE_UNLIKELY(iree_string_view_is_empty(parameter->name))) {
+        status = iree_make_status(
+            IREE_STATUS_FAILED_PRECONDITION,
+            "replay recording requires a name for runtime parameter %" PRIhsz
+            " of executable function %" PRIhsz,
+            j, i);
+      }
+      if (iree_status_is_ok(status) &&
+          IREE_UNLIKELY(parameter->name.size > UINT16_MAX)) {
+        status = iree_make_status(
+            IREE_STATUS_OUT_OF_RANGE,
+            "executable runtime parameter name length overflow");
+      }
+      if (iree_status_is_ok(status) &&
+          IREE_UNLIKELY(!iree_host_size_checked_add(
+              name_storage_size, parameter->name.size, &name_storage_size))) {
+        status = iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                                  "executable name storage size overflow");
+      }
+    }
+    runtime_parameter_index += function_runtime_parameter_count;
+  }
+  if (iree_status_is_ok(status) &&
+      IREE_UNLIKELY(runtime_parameter_index != runtime_parameter_count)) {
+    status = iree_make_status(
+        IREE_STATUS_INTERNAL,
+        "executable runtime parameter reflection count changed during capture");
+  }
+  if (!iree_status_is_ok(status)) {
+    iree_allocator_free(host_allocator, runtime_parameters);
+    iree_allocator_free(host_allocator, parameters);
+    iree_allocator_free(host_allocator, function_infos);
+    return status;
+  }
+
   iree_host_size_t metadata_size = 0;
   iree_host_size_t function_metadata_size = 0;
   iree_host_size_t parameter_metadata_size = 0;
+  iree_host_size_t runtime_parameter_metadata_size = 0;
   if (IREE_UNLIKELY(
           !iree_host_size_checked_mul(
               function_count,
@@ -546,13 +647,20 @@ static iree_status_t iree_hal_replay_recorder_capture_executable_metadata(
               parameter_count,
               sizeof(iree_hal_replay_executable_parameter_metadata_t),
               &parameter_metadata_size) ||
+          !iree_host_size_checked_mul(
+              runtime_parameter_count,
+              sizeof(iree_hal_replay_executable_runtime_parameter_metadata_t),
+              &runtime_parameter_metadata_size) ||
           !iree_host_size_checked_add(
               sizeof(iree_hal_replay_executable_metadata_header_t),
               function_metadata_size, &metadata_size) ||
           !iree_host_size_checked_add(metadata_size, parameter_metadata_size,
                                       &metadata_size) ||
-          !iree_host_size_checked_add(metadata_size, function_name_storage_size,
+          !iree_host_size_checked_add(
+              metadata_size, runtime_parameter_metadata_size, &metadata_size) ||
+          !iree_host_size_checked_add(metadata_size, name_storage_size,
                                       &metadata_size))) {
+    iree_allocator_free(host_allocator, runtime_parameters);
     iree_allocator_free(host_allocator, parameters);
     iree_allocator_free(host_allocator, function_infos);
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
@@ -568,7 +676,8 @@ static iree_status_t iree_hal_replay_recorder_capture_executable_metadata(
         (iree_hal_replay_executable_metadata_header_t*)metadata_storage;
     header->function_count = function_count;
     header->parameter_count = parameter_count;
-    header->function_name_storage_length = function_name_storage_size;
+    header->name_storage_length = name_storage_size;
+    header->runtime_parameter_count = runtime_parameter_count;
     iree_hal_replay_executable_function_metadata_t* function_metadata =
         (iree_hal_replay_executable_function_metadata_t*)(metadata_storage +
                                                           sizeof(*header));
@@ -576,12 +685,19 @@ static iree_status_t iree_hal_replay_recorder_capture_executable_metadata(
         (iree_hal_replay_executable_parameter_metadata_t*)(metadata_storage +
                                                            sizeof(*header) +
                                                            function_metadata_size);
-    uint8_t* function_name_storage = metadata_storage + sizeof(*header) +
-                                     function_metadata_size +
-                                     parameter_metadata_size;
+    iree_hal_replay_executable_runtime_parameter_metadata_t* runtime_parameter_metadata =
+        (iree_hal_replay_executable_runtime_parameter_metadata_t*)(metadata_storage +
+                                                                   sizeof(
+                                                                       *header) +
+                                                                   function_metadata_size +
+                                                                   parameter_metadata_size);
+    uint8_t* name_storage = metadata_storage + sizeof(*header) +
+                            function_metadata_size + parameter_metadata_size +
+                            runtime_parameter_metadata_size;
 
     parameter_index = 0;
-    iree_host_size_t function_name_offset = 0;
+    runtime_parameter_index = 0;
+    iree_host_size_t name_offset = 0;
     for (iree_host_size_t i = 0; i < function_count; ++i) {
       function_metadata[i].flags = function_infos[i].flags;
       function_metadata[i].workgroup_size[0] =
@@ -595,10 +711,12 @@ static iree_status_t iree_hal_replay_recorder_capture_executable_metadata(
       function_metadata[i].binding_count = function_infos[i].binding_count;
       function_metadata[i].parameter_count = function_infos[i].parameter_count;
       function_metadata[i].name_length = (uint16_t)function_infos[i].name.size;
+      function_metadata[i].runtime_parameter_count =
+          function_infos[i].runtime_parameter_count;
       if (!iree_string_view_is_empty(function_infos[i].name)) {
-        memcpy(function_name_storage + function_name_offset,
-               function_infos[i].name.data, function_infos[i].name.size);
-        function_name_offset += function_infos[i].name.size;
+        memcpy(name_storage + name_offset, function_infos[i].name.data,
+               function_infos[i].name.size);
+        name_offset += function_infos[i].name.size;
       }
       for (iree_host_size_t j = 0; j < function_infos[i].parameter_count; ++j) {
         const iree_hal_executable_function_parameter_t* parameter =
@@ -615,10 +733,24 @@ static iree_status_t iree_hal_replay_recorder_capture_executable_metadata(
         parameter_metadata->size = parameter->size;
         ++parameter_metadata;
       }
+      for (iree_host_size_t j = 0;
+           j < function_infos[i].runtime_parameter_count; ++j) {
+        const iree_hal_executable_function_runtime_parameter_info_t* parameter =
+            &runtime_parameters[runtime_parameter_index++];
+        runtime_parameter_metadata->offset = parameter->offset;
+        runtime_parameter_metadata->length = parameter->length;
+        runtime_parameter_metadata->name_length =
+            (uint16_t)parameter->name.size;
+        memcpy(name_storage + name_offset, parameter->name.data,
+               parameter->name.size);
+        name_offset += parameter->name.size;
+        ++runtime_parameter_metadata;
+      }
     }
     *out_storage = iree_make_byte_span(metadata_storage, metadata_size);
     *out_metadata = iree_make_const_byte_span(metadata_storage, metadata_size);
   }
+  iree_allocator_free(host_allocator, runtime_parameters);
   iree_allocator_free(host_allocator, parameters);
   iree_allocator_free(host_allocator, function_infos);
   return status;
@@ -697,6 +829,8 @@ static const iree_hal_executable_vtable_t
         .function_info = iree_hal_replay_recorder_executable_function_info,
         .function_parameters =
             iree_hal_replay_recorder_executable_function_parameters,
+        .function_runtime_parameters =
+            iree_hal_replay_recorder_executable_function_runtime_parameters,
         .lookup_function_by_name =
             iree_hal_replay_recorder_executable_lookup_function_by_name,
         .try_lookup_global_by_name =

--- a/runtime/src/iree/hal/replay/recorder_test.cc
+++ b/runtime/src/iree/hal/replay/recorder_test.cc
@@ -65,6 +65,21 @@ static iree_hal_device_group_t* CreateMockDeviceGroup() {
   return group;
 }
 
+static iree_hal_device_group_t* CreateMockExecutableDeviceGroup() {
+  iree_hal_mock_device_options_t options;
+  iree_hal_mock_device_options_initialize(&options);
+  options.identifier = iree_make_cstring_view("mock-executable");
+  options.executable_loading_enabled = true;
+
+  iree_hal_device_t* device = nullptr;
+  IREE_CHECK_OK(
+      iree_hal_mock_device_create(&options, iree_allocator_system(), &device));
+  iree_hal_device_t* devices[] = {device};
+  iree_hal_device_group_t* group = CreateDeviceGroup(1, devices);
+  iree_hal_device_release(device);
+  return group;
+}
+
 static iree_hal_device_t* CreateSyncDevice(const char* identifier) {
   iree_async_proactor_pool_t* proactor_pool = nullptr;
   IREE_CHECK_OK(iree_async_proactor_pool_create(
@@ -118,6 +133,55 @@ static iree_hal_replay_recorder_t* CreateHostAllocationRecorder(
   return recorder;
 }
 
+static iree_hal_executable_t* PrepareMockExecutable(iree_hal_device_t* device) {
+  static const uint8_t kExecutableData[] = {
+      1,
+      0,
+      0,
+      0,  // Function count.
+      // Constant count, binding count, flags, workgroup size, name length,
+      // native ABI offset, parameter size, runtime parameter count, reserved.
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      4,
+      0,
+      0,
+      0,
+      0,
+      0,
+      'm',
+      'a',
+      'i',
+      'n',
+  };
+  const iree_hal_executable_target_selection_t target_selection = {
+      /*.family=*/IREE_SV(IREE_HAL_MOCK_EXECUTABLE_TARGET_FAMILY),
+      /*.target_key=*/IREE_SV(IREE_HAL_MOCK_EXECUTABLE_TARGET_KEY),
+      /*.kind_flags=*/IREE_HAL_EXECUTABLE_TARGET_KIND_FLAG_VIRTUAL,
+      /*.physical_device_affinity=*/1,
+  };
+  const iree_hal_executable_target_selection_result_t target_result =
+      iree_hal_device_spec_select_executable_target(
+          iree_hal_device_spec(device), &target_selection);
+  IREE_ASSERT_EQ(target_result.outcome,
+                 IREE_HAL_EXECUTABLE_TARGET_SELECTION_OUTCOME_SELECTED);
+
+  iree_hal_executable_load_params_t load_params;
+  iree_hal_executable_load_params_initialize(&load_params);
+  load_params.executable_data =
+      iree_make_const_byte_span(kExecutableData, sizeof(kExecutableData));
+
+  iree_hal_executable_t* executable = nullptr;
+  IREE_CHECK_OK(iree_hal_device_load_executable(
+      device, IREE_HAL_QUEUE_AFFINITY_ANY, target_result.target, &load_params,
+      &executable));
+  return executable;
+}
+
 #if IREE_FILE_IO_ENABLE && \
     (defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_LINUX))
 iree::testing::TempFilePath WriteTempFile(iree_const_byte_span_t contents) {
@@ -160,6 +224,7 @@ struct ReplayRecordSummary {
   iree_host_size_t unsupported_import_buffer_record_count = 0;
   iree_host_size_t unsupported_export_buffer_record_count = 0;
   iree_host_size_t unsupported_host_call_record_count = 0;
+  iree_host_size_t unsupported_queue_dispatch_record_count = 0;
   iree_host_size_t buffer_range_data_payload_count = 0;
   iree_host_size_t import_buffer_payload_count = 0;
   uint64_t import_buffer_captured_data_length = 0;
@@ -307,7 +372,8 @@ static ReplayRecordSummary ParseReplayRecordSummary(
         }
         EXPECT_EQ((uint32_t)IREE_STATUS_OK, record.header.status_code);
         break;
-      case IREE_HAL_REPLAY_FILE_RECORD_TYPE_UNSUPPORTED:
+      case IREE_HAL_REPLAY_FILE_RECORD_TYPE_UNSUPPORTED: {
+        bool queue_dispatch = false;
         if (record.header.operation_code ==
             IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_IMPORT_BUFFER) {
           ++summary.unsupported_import_buffer_record_count;
@@ -317,15 +383,55 @@ static ReplayRecordSummary ParseReplayRecordSummary(
         } else if (record.header.operation_code ==
                    IREE_HAL_REPLAY_OPERATION_CODE_DEVICE_QUEUE_HOST_CALL) {
           ++summary.unsupported_host_call_record_count;
+        } else if (record.header.operation_code ==
+                   IREE_HAL_REPLAY_OPERATION_CODE_DEVICE_QUEUE_DISPATCH) {
+          ++summary.unsupported_queue_dispatch_record_count;
+          queue_dispatch = true;
         }
-        EXPECT_EQ((uint32_t)IREE_STATUS_OK, record.header.status_code);
+        if (queue_dispatch) {
+          EXPECT_EQ((uint32_t)IREE_STATUS_UNIMPLEMENTED,
+                    record.header.status_code);
+        } else {
+          EXPECT_EQ((uint32_t)IREE_STATUS_OK, record.header.status_code);
+        }
         break;
+      }
       default:
         break;
     }
   }
 
   return summary;
+}
+
+static bool FindCapturedQueueDispatchPayload(
+    const std::vector<uint8_t>& storage,
+    iree_hal_replay_dispatch_payload_t* out_payload) {
+  iree_hal_replay_file_header_t file_header;
+  iree_host_size_t offset = 0;
+  IREE_CHECK_OK(iree_hal_replay_file_parse_header(
+      iree_make_const_byte_span(storage.data(), storage.size()), &file_header,
+      &offset));
+  const iree_const_byte_span_t file_contents = iree_make_const_byte_span(
+      storage.data(), (iree_host_size_t)file_header.file_length);
+  while (offset < file_contents.data_length) {
+    iree_hal_replay_file_record_t record;
+    IREE_CHECK_OK(iree_hal_replay_file_parse_record(file_contents, offset,
+                                                    &record, &offset));
+    if (record.header.operation_code !=
+            IREE_HAL_REPLAY_OPERATION_CODE_DEVICE_QUEUE_DISPATCH ||
+        record.header.payload_type != IREE_HAL_REPLAY_PAYLOAD_TYPE_DISPATCH) {
+      continue;
+    }
+    if (record.payload.data_length < sizeof(*out_payload)) {
+      ADD_FAILURE() << "captured dispatch payload is short";
+      return false;
+    }
+    memcpy(out_payload, record.payload.data, sizeof(*out_payload));
+    return true;
+  }
+  ADD_FAILURE() << "expected a captured queue dispatch";
+  return false;
 }
 
 static iree_status_t CountHostCall(void* user_data, const uint64_t args[4],
@@ -410,6 +516,57 @@ TEST(ReplayRecorderTest, WrappedDeviceRecordsHostCallAsUnsupported) {
 
   ReplayRecordSummary summary = ParseReplayRecordSummary(storage);
   EXPECT_EQ(1u, summary.unsupported_host_call_record_count);
+}
+
+TEST(ReplayRecorderTest, MarksQueueDispatchRuntimeParametersUnsupported) {
+  std::vector<uint8_t> storage(32768, 0);
+  iree_hal_replay_recorder_t* recorder = CreateHostAllocationRecorder(&storage);
+
+  iree_hal_device_group_t* source_group = CreateMockExecutableDeviceGroup();
+  iree_hal_device_group_t* wrapped_group = nullptr;
+  IREE_ASSERT_OK(iree_hal_replay_wrap_device_group(
+      recorder, source_group, iree_allocator_system(), &wrapped_group));
+  iree_hal_device_t* wrapped_device =
+      iree_hal_device_group_device_at(wrapped_group, 0);
+  iree_hal_executable_t* executable = PrepareMockExecutable(wrapped_device);
+
+  iree_hal_dispatch_runtime_parameter_list_t runtime_parameters = {};
+  runtime_parameters.count = 2;
+  runtime_parameters.patches[0].offset = 16;
+  runtime_parameters.patches[0].length = sizeof(uint64_t);
+  const uint64_t first_value = UINT64_C(0x0123456789ABCDEF);
+  memcpy(runtime_parameters.patches[0].data, &first_value, sizeof(first_value));
+  runtime_parameters.patches[1].offset = 40;
+  runtime_parameters.patches[1].length = sizeof(uint32_t);
+  const uint32_t second_value = UINT32_C(0x76543210);
+  memcpy(runtime_parameters.patches[1].data, &second_value,
+         sizeof(second_value));
+  const iree_hal_dispatch_config_t config = {
+      .workgroup_count = {1, 1, 1},
+      .runtime_parameters = &runtime_parameters,
+  };
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_UNIMPLEMENTED,
+      iree_hal_device_queue_dispatch(
+          wrapped_device, IREE_HAL_QUEUE_AFFINITY_ANY,
+          iree_hal_semaphore_list_empty(), iree_hal_semaphore_list_empty(),
+          executable, iree_hal_executable_function_from_index(0), config,
+          iree_const_byte_span_empty(), iree_hal_buffer_ref_list_empty(),
+          IREE_HAL_DISPATCH_FLAG_NONE));
+
+  iree_hal_executable_release(executable);
+  IREE_ASSERT_OK(iree_hal_replay_recorder_close(recorder));
+  iree_hal_replay_recorder_release(recorder);
+  iree_hal_device_group_release(wrapped_group);
+  iree_hal_device_group_release(source_group);
+
+  iree_hal_replay_dispatch_payload_t payload = {};
+  ASSERT_TRUE(FindCapturedQueueDispatchPayload(storage, &payload));
+  ReplayRecordSummary summary = ParseReplayRecordSummary(storage);
+  EXPECT_EQ(1u, summary.unsupported_queue_dispatch_record_count);
+  const iree_hal_dispatch_runtime_parameter_list_t empty_parameters = {};
+  EXPECT_EQ(0, memcmp(&payload.runtime_parameters, &empty_parameters,
+                      sizeof(empty_parameters)));
 }
 
 TEST(ReplayRecorderTest,

--- a/runtime/src/iree/hal/testing/mock_device.c
+++ b/runtime/src/iree/hal/testing/mock_device.c
@@ -29,9 +29,13 @@ typedef struct iree_hal_mock_executable_function_record_t {
   uint8_t native_abi_offset;
   // Native ABI byte size for the optional reflected buffer binding.
   uint16_t parameter_size;
+  // Number of runtime parameter records for this function.
+  uint8_t runtime_parameter_count;
+  // Reserved byte; must be zero.
+  uint8_t reserved;
 } iree_hal_mock_executable_function_record_t;
 
-static_assert(sizeof(iree_hal_mock_executable_function_record_t) == 10,
+static_assert(sizeof(iree_hal_mock_executable_function_record_t) == 12,
               "mock executable metadata must have a stable byte layout");
 
 typedef struct iree_hal_mock_executable_parameter_metadata_t {
@@ -41,22 +45,33 @@ typedef struct iree_hal_mock_executable_parameter_metadata_t {
   uint16_t size;
 } iree_hal_mock_executable_parameter_metadata_t;
 
-typedef struct iree_hal_mock_executable_t {
-  iree_hal_resource_t resource;
-  iree_allocator_t host_allocator;
-  iree_host_size_t function_count;
-  // Function metadata records indexed by executable function ordinal.
-  iree_hal_executable_function_info_t functions[];
-} iree_hal_mock_executable_t;
+typedef struct iree_hal_mock_executable_runtime_parameter_record_t {
+  // Byte offset in the mock backend-native argument storage.
+  uint8_t offset;
+  // Byte length of the runtime parameter.
+  uint8_t length;
+  // Byte length of the parameter name in the trailing name storage.
+  uint8_t name_length;
+  // Reserved byte; must be zero.
+  uint8_t reserved;
+} iree_hal_mock_executable_runtime_parameter_record_t;
 
-static iree_hal_mock_executable_parameter_metadata_t*
-iree_hal_mock_executable_parameter_metadata(
-    iree_hal_mock_executable_t* executable) {
-  return (
-      iree_hal_mock_executable_parameter_metadata_t*)(executable->functions +
-                                                      executable
-                                                          ->function_count);
-}
+typedef struct iree_hal_mock_executable_t {
+  // HAL resource header.
+  iree_hal_resource_t resource;
+  // Allocator used for this executable's contiguous storage.
+  iree_allocator_t host_allocator;
+  // Number of functions in |functions|.
+  iree_host_size_t function_count;
+  // Per-function records reflected by function_info.
+  iree_hal_executable_function_info_t* functions;
+  // Native binding parameter metadata indexed by executable function ordinal.
+  iree_hal_mock_executable_parameter_metadata_t* parameter_metadata;
+  // Function-indexed offsets into |runtime_parameters|.
+  iree_host_size_t* runtime_parameter_offsets;
+  // Runtime parameter records grouped by function.
+  iree_hal_executable_function_runtime_parameter_info_t* runtime_parameters;
+} iree_hal_mock_executable_t;
 
 static const iree_hal_executable_vtable_t iree_hal_mock_executable_vtable;
 
@@ -94,16 +109,32 @@ static iree_status_t iree_hal_mock_executable_create(
         IREE_STATUS_INVALID_ARGUMENT,
         "mock executable function metadata length mismatch");
   }
-  iree_const_byte_span_t name_storage = iree_make_const_byte_span(
-      function_data.data + function_record_data_length,
-      function_data.data_length - function_record_data_length);
-
   const iree_hal_mock_executable_function_record_t* function_records =
       (const iree_hal_mock_executable_function_record_t*)function_data.data;
+  iree_host_size_t runtime_parameter_count = 0;
+  iree_host_size_t function_name_storage_length = 0;
   iree_host_size_t expected_name_storage_length = 0;
   for (iree_host_size_t i = 0; i < function_count; ++i) {
     const iree_hal_mock_executable_function_record_t* record =
         &function_records[i];
+    if (IREE_UNLIKELY(record->reserved != 0)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "mock executable function metadata reserved byte must be zero");
+    }
+    if (IREE_UNLIKELY(!iree_host_size_checked_add(
+            runtime_parameter_count, record->runtime_parameter_count,
+            &runtime_parameter_count))) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "mock executable runtime parameter count "
+                              "overflow");
+    }
+    if (IREE_UNLIKELY(!iree_host_size_checked_add(
+            function_name_storage_length, record->name_length,
+            &function_name_storage_length))) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "mock executable function name storage overflow");
+    }
     if (IREE_UNLIKELY(!iree_host_size_checked_add(
             expected_name_storage_length, record->name_length,
             &expected_name_storage_length))) {
@@ -111,13 +142,54 @@ static iree_status_t iree_hal_mock_executable_create(
                               "mock executable function name storage overflow");
     }
   }
+  iree_host_size_t runtime_parameter_record_data_length = 0;
+  if (IREE_UNLIKELY(
+          !iree_host_size_checked_mul(
+              runtime_parameter_count,
+              sizeof(iree_hal_mock_executable_runtime_parameter_record_t),
+              &runtime_parameter_record_data_length) ||
+          runtime_parameter_record_data_length >
+              function_data.data_length - function_record_data_length)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "mock executable runtime parameter metadata length mismatch");
+  }
+  const iree_hal_mock_executable_runtime_parameter_record_t* runtime_parameter_records =
+      (const iree_hal_mock_executable_runtime_parameter_record_t*)(function_data
+                                                                       .data +
+                                                                   function_record_data_length);
+  iree_const_byte_span_t name_storage = iree_make_const_byte_span(
+      function_data.data + function_record_data_length +
+          runtime_parameter_record_data_length,
+      function_data.data_length - function_record_data_length -
+          runtime_parameter_record_data_length);
+  for (iree_host_size_t i = 0; i < runtime_parameter_count; ++i) {
+    const iree_hal_mock_executable_runtime_parameter_record_t* record =
+        &runtime_parameter_records[i];
+    if (IREE_UNLIKELY(record->reserved != 0)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "mock executable runtime parameter metadata reserved byte must be "
+          "zero");
+    }
+    if (IREE_UNLIKELY(!iree_host_size_checked_add(
+            expected_name_storage_length, record->name_length,
+            &expected_name_storage_length))) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "mock executable runtime parameter name storage overflow");
+    }
+  }
   if (IREE_UNLIKELY(expected_name_storage_length != name_storage.data_length)) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "mock executable function name length mismatch");
+                            "mock executable name storage length mismatch");
   }
 
   iree_host_size_t function_info_size = 0;
   iree_host_size_t parameter_metadata_size = 0;
+  iree_host_size_t runtime_parameter_offset_count = 0;
+  iree_host_size_t runtime_parameter_offset_size = 0;
+  iree_host_size_t runtime_parameter_info_size = 0;
   iree_host_size_t total_size = 0;
   if (IREE_UNLIKELY(
           !iree_host_size_checked_mul(
@@ -127,8 +199,21 @@ static iree_status_t iree_hal_mock_executable_create(
               function_count,
               sizeof(iree_hal_mock_executable_parameter_metadata_t),
               &parameter_metadata_size) ||
+          !iree_host_size_checked_add(function_count, 1,
+                                      &runtime_parameter_offset_count) ||
+          !iree_host_size_checked_mul(runtime_parameter_offset_count,
+                                      sizeof(iree_host_size_t),
+                                      &runtime_parameter_offset_size) ||
+          !iree_host_size_checked_mul(
+              runtime_parameter_count,
+              sizeof(iree_hal_executable_function_runtime_parameter_info_t),
+              &runtime_parameter_info_size) ||
           !iree_host_size_checked_add(sizeof(iree_hal_mock_executable_t),
                                       function_info_size, &total_size) ||
+          !iree_host_size_checked_add(total_size, runtime_parameter_offset_size,
+                                      &total_size) ||
+          !iree_host_size_checked_add(total_size, runtime_parameter_info_size,
+                                      &total_size) ||
           !iree_host_size_checked_add(total_size, parameter_metadata_size,
                                       &total_size) ||
           !iree_host_size_checked_add(total_size, name_storage.data_length,
@@ -145,13 +230,27 @@ static iree_status_t iree_hal_mock_executable_create(
   executable->host_allocator = host_allocator;
   executable->function_count = function_count;
 
-  char* executable_name_storage = (char*)executable + sizeof(*executable) +
-                                  function_info_size + parameter_metadata_size;
+  uint8_t* executable_storage = (uint8_t*)executable + sizeof(*executable);
+  executable->functions =
+      (iree_hal_executable_function_info_t*)executable_storage;
+  executable_storage += function_info_size;
+  executable->runtime_parameter_offsets = (iree_host_size_t*)executable_storage;
+  executable_storage += runtime_parameter_offset_size;
+  executable->runtime_parameters =
+      (iree_hal_executable_function_runtime_parameter_info_t*)
+          executable_storage;
+  executable_storage += runtime_parameter_info_size;
+  executable->parameter_metadata =
+      (iree_hal_mock_executable_parameter_metadata_t*)executable_storage;
+  executable_storage += parameter_metadata_size;
+  char* executable_name_storage = (char*)executable_storage;
   if (name_storage.data_length != 0) {
     memcpy(executable_name_storage, name_storage.data,
            name_storage.data_length);
   }
   iree_host_size_t name_offset = 0;
+  iree_host_size_t runtime_parameter_name_offset = function_name_storage_length;
+  iree_host_size_t runtime_parameter_index = 0;
   for (iree_host_size_t i = 0; i < function_count; ++i) {
     const iree_hal_mock_executable_function_record_t* record =
         &function_records[i];
@@ -163,15 +262,33 @@ static iree_status_t iree_hal_mock_executable_create(
         record->constant_count * sizeof(uint32_t);
     executable->functions[i].binding_count = record->binding_count;
     executable->functions[i].parameter_count = record->parameter_size ? 1 : 0;
+    executable->functions[i].runtime_parameter_count =
+        record->runtime_parameter_count;
     executable->functions[i].workgroup_size[0] = record->workgroup_size[0];
     executable->functions[i].workgroup_size[1] = record->workgroup_size[1];
     executable->functions[i].workgroup_size[2] = record->workgroup_size[2];
-    iree_hal_mock_executable_parameter_metadata(executable)[i] =
+    executable->parameter_metadata[i] =
         (iree_hal_mock_executable_parameter_metadata_t){
             .native_abi_offset = record->native_abi_offset,
             .size = record->parameter_size,
         };
+    executable->runtime_parameter_offsets[i] = runtime_parameter_index;
+    for (iree_host_size_t j = 0; j < record->runtime_parameter_count; ++j) {
+      const iree_hal_mock_executable_runtime_parameter_record_t*
+          runtime_parameter_record =
+              &runtime_parameter_records[runtime_parameter_index];
+      iree_hal_executable_function_runtime_parameter_info_t* runtime_parameter =
+          &executable->runtime_parameters[runtime_parameter_index++];
+      runtime_parameter->name = iree_make_string_view(
+          executable_name_storage + runtime_parameter_name_offset,
+          runtime_parameter_record->name_length);
+      runtime_parameter_name_offset += runtime_parameter_record->name_length;
+      runtime_parameter->offset = runtime_parameter_record->offset;
+      runtime_parameter->length = runtime_parameter_record->length;
+    }
   }
+  executable->runtime_parameter_offsets[function_count] =
+      runtime_parameter_index;
 
   *out_executable = (iree_hal_executable_t*)executable;
   return iree_ok_status();
@@ -221,8 +338,7 @@ static iree_status_t iree_hal_mock_executable_function_parameters(
   const uint32_t function_ordinal =
       iree_hal_executable_function_index(function);
   const iree_hal_mock_executable_parameter_metadata_t* parameter_metadata =
-      &iree_hal_mock_executable_parameter_metadata(
-          executable)[function_ordinal];
+      &executable->parameter_metadata[function_ordinal];
   if (!parameter_metadata->size) return iree_ok_status();
   if (capacity < 1 || !out_parameters) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
@@ -236,6 +352,32 @@ static iree_status_t iree_hal_mock_executable_function_parameters(
       .native_abi_offset = parameter_metadata->native_abi_offset,
       .name = iree_string_view_empty(),
   };
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_mock_executable_function_runtime_parameters(
+    iree_hal_executable_t* base_executable,
+    iree_hal_executable_function_t function, iree_host_size_t capacity,
+    iree_hal_executable_function_runtime_parameter_info_t* out_parameters) {
+  IREE_ASSERT_ARGUMENT(out_parameters || capacity == 0);
+  iree_hal_mock_executable_t* executable =
+      iree_hal_mock_executable_cast(base_executable);
+  if (!iree_hal_executable_function_is_index_in_range(
+          function, executable->function_count)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE);
+  }
+  const uint32_t function_ordinal =
+      iree_hal_executable_function_index(function);
+  const iree_host_size_t parameter_begin =
+      executable->runtime_parameter_offsets[function_ordinal];
+  const iree_host_size_t parameter_count =
+      executable->runtime_parameter_offsets[function_ordinal + 1] -
+      parameter_begin;
+  const iree_host_size_t copy_count = iree_min(capacity, parameter_count);
+  if (copy_count > 0) {
+    memcpy(out_parameters, executable->runtime_parameters + parameter_begin,
+           copy_count * sizeof(*out_parameters));
+  }
   return iree_ok_status();
 }
 
@@ -288,6 +430,8 @@ static const iree_hal_executable_vtable_t iree_hal_mock_executable_vtable = {
     .function_count = iree_hal_mock_executable_function_count,
     .function_info = iree_hal_mock_executable_function_info,
     .function_parameters = iree_hal_mock_executable_function_parameters,
+    .function_runtime_parameters =
+        iree_hal_mock_executable_function_runtime_parameters,
     .lookup_function_by_name = iree_hal_mock_executable_lookup_function_by_name,
     .try_lookup_global_by_name =
         iree_hal_mock_executable_try_lookup_global_by_name,
@@ -736,6 +880,7 @@ static const iree_hal_device_vtable_t iree_hal_mock_device_vtable = {
     .create_channel = iree_hal_mock_device_create_channel,
     .create_command_buffer = iree_hal_mock_device_create_command_buffer,
     .create_event = iree_hal_mock_device_create_event,
+    .create_host_notification = iree_hal_host_notification_create_unimplemented,
     .load_executable = iree_hal_mock_device_load_executable,
     .import_file = iree_hal_mock_device_import_file,
     .create_semaphore = iree_hal_mock_device_create_semaphore,

--- a/runtime/src/iree/hal/utils/deferred_command_buffer.c
+++ b/runtime/src/iree/hal/utils/deferred_command_buffer.c
@@ -688,6 +688,8 @@ typedef struct iree_hal_cmd_dispatch_t {
   iree_hal_executable_t* executable;
   iree_hal_executable_function_t export_ordinal;
   iree_hal_dispatch_config_t config;
+  // Runtime parameter list retained by this deferred dispatch.
+  iree_hal_dispatch_runtime_parameter_list_t runtime_parameters;
   iree_const_byte_span_t constants;
   iree_hal_buffer_ref_list_t bindings;
   iree_hal_dispatch_flags_t flags;
@@ -729,7 +731,8 @@ static iree_status_t iree_hal_deferred_command_buffer_dispatch(
       (void**)&cmd));
   cmd->executable = executable;
   cmd->export_ordinal = export_ordinal;
-  memcpy(&cmd->config, &config, sizeof(cmd->config));
+  iree_hal_dispatch_config_clone(config, &cmd->runtime_parameters,
+                                 &cmd->config);
   cmd->flags = flags;
 
   uint8_t* cmd_base = (uint8_t*)cmd;


### PR DESCRIPTION
Populate streaming module symbols from executable metadata, including workgroup limits, fixed memory requirements, cache/carveout state, and uniform-workgroup requirements.

Keep parameter unpack metadata bounded with checked allocation and field-width validation so launch argument layouts fail cleanly when reflected metadata exceeds the stored representation.