### PR TITLE
[HIP] Null the module out-handle before any failed-load error path

### DIFF
--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -10644,7 +10644,17 @@ HIPAPI hipError_t hipEventElapsedTime(float* ms, hipEvent_t start,
 // See also: hipModuleLoadData, hipModuleUnload, hipModuleGetFunction.
 HIPAPI hipError_t hipModuleLoad(hipModule_t* module, const char* fname) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  if (!module || !fname) {
+  if (!module) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+
+  // Establish the failure invariant before validating any other argument: every
+  // error path below (including the invalid-argument paths) leaves *module NULL
+  // so a caller that unconditionally unloads on a failed load cannot
+  // dereference an uninitialized handle. The success path overwrites it.
+  *module = NULL;
+  if (!fname) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
@@ -10764,7 +10774,17 @@ HIPAPI hipError_t hipModuleLoadDataEx(hipModule_t* module, const void* image,
       "[HIP_API] hipModuleLoadDataEx(module=%p, image=%p, numOptions=%u) "
       "ENTRY\n",
       (void*)module, image, numOptions);
-  if (!module || !image) {
+  if (!module) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+
+  // Establish the failure invariant before validating any other argument: every
+  // error path below (including the invalid-argument paths) leaves *module NULL
+  // so a caller that unconditionally unloads on a failed load cannot
+  // dereference an uninitialized handle. The success path overwrites it.
+  *module = NULL;
+  if (!image) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }

--- a/libhrx/src/binding/hip/hip_launch_validation_api_test.cc
+++ b/libhrx/src/binding/hip/hip_launch_validation_api_test.cc
@@ -54,6 +54,12 @@ using HipGraphKernelNodeGetParamsFn = hipError_t (*)(hipGraphNode_t node,
                                                      void* params);
 using HipGraphKernelNodeSetParamsFn = hipError_t (*)(hipGraphNode_t node,
                                                      const void* params);
+using HipModuleLoadDataExFn = hipError_t (*)(hipModule_t* module,
+                                             const void* image,
+                                             unsigned int num_options,
+                                             hipJitOption* options,
+                                             void** option_values);
+using HipModuleUnloadFn = hipError_t (*)(hipModule_t module);
 
 // Owns an RTLD_LOCAL HIP runtime instance and the entry points exercised by
 // this test. All calls use the loaded library instead of a link-time runtime.
@@ -364,6 +370,35 @@ TEST_F(HipLaunchValidationApiTest,
                                        &short_prepacked_params));
   EXPECT_EQ(reinterpret_cast<hipGraphNode_t>(uintptr_t{1}), rejected_node);
   EXPECT_EQ(hipSuccess, api_.graph_destroy(graph));
+}
+
+// A failed module load must leave the caller's out-handle NULL. Callers
+// commonly follow the HIP idiom of unconditionally calling hipModuleUnload
+// after a failed load; if hipModuleLoadDataEx returned an error without writing
+// *module, that unload would dereference an uninitialized handle. The
+// out-handle is seeded with a non-NULL sentinel here so the test proves the API
+// actively wrote NULL rather than leaving the sentinel untouched, and
+// hipModuleUnload(NULL) reports hipErrorInvalidResourceHandle instead of
+// succeeding, so the whole failed-load-then-unload sequence is well-defined.
+TEST_F(HipLaunchValidationApiTest, ModuleLoadFailureNullsOutHandleForUnload) {
+  auto module_load_data_ex = ResolveHipSymbol<HipModuleLoadDataExFn>(
+      api_.library, "hipModuleLoadDataEx");
+  auto module_unload =
+      ResolveHipSymbol<HipModuleUnloadFn>(api_.library, "hipModuleUnload");
+  ASSERT_NE(nullptr, module_load_data_ex);
+  ASSERT_NE(nullptr, module_unload);
+
+  // A small all-0xFF buffer carries no valid code-object magic, so the loader
+  // rejects it with an invalid-argument error before creating any module.
+  const uint8_t invalid_image[16] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                                     0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+                                     0xFF, 0xFF, 0xFF, 0xFF};
+  hipModule_t module = reinterpret_cast<hipModule_t>(uintptr_t{1});
+  EXPECT_NE(hipSuccess, module_load_data_ex(
+                            &module, invalid_image, /*num_options=*/0,
+                            /*options=*/nullptr, /*option_values=*/nullptr));
+  EXPECT_EQ(nullptr, module);
+  EXPECT_EQ(hipErrorInvalidResourceHandle, module_unload(module));
 }
 
 }  // namespace


### PR DESCRIPTION
## Problem
`hipModuleLoad` and `hipModuleLoadDataEx` take a `hipModule_t* module` out-parameter but, on a failed load, returned an error without writing `*module`. A caller that unconditionally unloads a module after a failed load (a common autotuning idiom) then passes an uninitialized handle to `hipModuleUnload`, which dereferences it — a crash on a garbage stack pointer.

## Fix
Restructure the argument guard in both functions so the order is: reject a NULL `module`, then set `*module = NULL`, then validate the remaining argument. Every error path now leaves `*module == NULL`, and the success path overwrites it. `hipModuleLoadData` inherits the fix by delegation.

## Test
Adds a regression test that seeds a non-NULL sentinel handle, drives a failed `hipModuleLoadDataEx`, and asserts the handle is left NULL and a following `hipModuleUnload` returns `hipErrorInvalidResourceHandle` safely.

## Notes
Opened as a draft for CI and early feedback. The added test is device-gated (it skips without an initializable HIP device); CI exercises the full path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
