### PR TITLE
[AMDGPU] Emplace implicit kernargs per field to support unaligned/partial hidden blocks

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.c
@@ -42,31 +42,6 @@ void iree_hal_amdgpu_device_dispatch_emplace_packet(
 // Dispatch kernarg emission
 //===----------------------------------------------------------------------===//
 
-void iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
-    const iree_hal_amdgpu_device_kernel_args_t* IREE_AMDGPU_RESTRICT
-        kernel_args,
-    const uint32_t workgroup_count[3], uint32_t dynamic_workgroup_local_memory,
-    const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* IREE_AMDGPU_RESTRICT
-        layout,
-    void* IREE_AMDGPU_RESTRICT kernarg_ptr) {
-  if (!layout->has_implicit_args) return;
-
-  iree_amdgpu_kernel_implicit_args_t* IREE_AMDGPU_RESTRICT implicit_args =
-      (iree_amdgpu_kernel_implicit_args_t*)((uint8_t*)kernarg_ptr +
-                                            layout->implicit_args_offset);
-  iree_amdgpu_memset(implicit_args, 0, IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE);
-  implicit_args->block_count[0] = workgroup_count[0];
-  implicit_args->block_count[1] = workgroup_count[1];
-  implicit_args->block_count[2] = workgroup_count[2];
-  implicit_args->group_size[0] = kernel_args->workgroup_size[0];
-  implicit_args->group_size[1] = kernel_args->workgroup_size[1];
-  implicit_args->group_size[2] = kernel_args->workgroup_size[2];
-  implicit_args->grid_dims = 3;
-  implicit_args->printf_buffer = NULL;
-  implicit_args->hostcall_buffer = NULL;
-  implicit_args->dynamic_lds_size = dynamic_workgroup_local_memory;
-}
-
 void iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
     const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* IREE_AMDGPU_RESTRICT
         layout,

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch.h
@@ -115,25 +115,6 @@ void iree_hal_amdgpu_device_dispatch_emplace_packet(
     iree_hsa_kernel_dispatch_packet_t* IREE_AMDGPU_RESTRICT dispatch_packet,
     void* IREE_AMDGPU_RESTRICT kernarg_ptr);
 
-// Populates the HIP/OpenCL implicit args suffix in already-reserved storage.
-//
-// This must be called after explicit HAL/custom kernargs have been populated
-// whenever |layout->has_implicit_args| is true.
-//
-// Preconditions:
-//   - |kernel_args|, |workgroup_count|, |layout|, and |kernarg_ptr| are
-//     non-NULL.
-//   - |layout| describes a reservation with an implicit suffix.
-//   - |kernarg_ptr| points to at least |layout->total_kernarg_size| bytes of
-//     writable storage.
-void iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
-    const iree_hal_amdgpu_device_kernel_args_t* IREE_AMDGPU_RESTRICT
-        kernel_args,
-    const uint32_t workgroup_count[3], uint32_t dynamic_workgroup_local_memory,
-    const iree_hal_amdgpu_device_dispatch_kernarg_layout_t* IREE_AMDGPU_RESTRICT
-        layout,
-    void* IREE_AMDGPU_RESTRICT kernarg_ptr);
-
 // Populates custom direct explicit kernargs in already-reserved storage.
 //
 // |custom_kernarg_ptr| provides caller-supplied bytes in the final kernel ABI

--- a/runtime/src/iree/hal/drivers/amdgpu/device/dispatch_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/dispatch_test.cc
@@ -61,54 +61,6 @@ TEST(DispatchTest, EmplacePacketPreservesZeroWorkgroupCounts) {
   EXPECT_EQ(packet.completion_signal.handle, iree_hsa_signal_null().handle);
 }
 
-TEST(DispatchTest, EmplaceImplicitArgsWritesSuffix) {
-  iree_hal_amdgpu_device_kernel_args_t kernel_args = MakeKernelArgs(
-      /*kernel_object=*/0x1234u,
-      /*kernarg_size=*/32 + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE,
-      /*kernarg_alignment=*/16);
-  iree_hal_amdgpu_device_dispatch_kernarg_layout_t layout = {
-      /*.explicit_kernarg_size=*/32,
-      /*.implicit_args_offset=*/32,
-      /*.total_kernarg_size=*/32 + IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE,
-      /*.has_implicit_args=*/true,
-  };
-  const uint32_t workgroup_count[3] = {7, 8, 9};
-  alignas(16) std::array<uint8_t, 256> kernargs = {};
-  kernargs.fill(0xFD);
-
-  iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
-      &kernel_args, workgroup_count, /*dynamic_workgroup_local_memory=*/13,
-      &layout, kernargs.data());
-
-  EXPECT_EQ(kernargs[31], 0xFDu);
-
-  const auto* implicit_args =
-      reinterpret_cast<const iree_amdgpu_kernel_implicit_args_t*>(
-          kernargs.data() + layout.implicit_args_offset);
-  EXPECT_EQ(implicit_args->block_count[0], 7u);
-  EXPECT_EQ(implicit_args->block_count[1], 8u);
-  EXPECT_EQ(implicit_args->block_count[2], 9u);
-  EXPECT_EQ(implicit_args->group_size[0], 4u);
-  EXPECT_EQ(implicit_args->group_size[1], 5u);
-  EXPECT_EQ(implicit_args->group_size[2], 6u);
-  EXPECT_EQ(implicit_args->remainder[0], 0u);
-  EXPECT_EQ(implicit_args->remainder[1], 0u);
-  EXPECT_EQ(implicit_args->remainder[2], 0u);
-  EXPECT_EQ(implicit_args->reserved0, 0u);
-  EXPECT_EQ(implicit_args->reserved1, 0u);
-  EXPECT_EQ(implicit_args->global_offset[0], 0u);
-  EXPECT_EQ(implicit_args->global_offset[1], 0u);
-  EXPECT_EQ(implicit_args->global_offset[2], 0u);
-  EXPECT_EQ(implicit_args->grid_dims, 3u);
-  EXPECT_EQ(implicit_args->printf_buffer, nullptr);
-  EXPECT_EQ(implicit_args->hostcall_buffer, nullptr);
-  EXPECT_EQ(implicit_args->deprecated_multigrid_sync_arg, 0u);
-  EXPECT_EQ(implicit_args->unused_heap_v1, 0u);
-  EXPECT_EQ(implicit_args->unused_default_queue, 0u);
-  EXPECT_EQ(implicit_args->unused_completion_action, 0u);
-  EXPECT_EQ(implicit_args->dynamic_lds_size, 13u);
-}
-
 TEST(DispatchTest, EmplaceCustomKernargsCopiesRawBlob) {
   iree_hal_amdgpu_device_dispatch_kernarg_layout_t layout = {};
   const std::array<uint8_t, 20> custom_kernargs = {

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco.c
@@ -26,9 +26,11 @@ typedef struct iree_hal_amdgpu_hsaco_kernel_load_plan_t {
   iree_host_size_t constant_byte_length;
   // Total native kernarg byte length reserved for dispatch.
   iree_host_size_t kernarg_byte_length;
-  // Native byte offset of the implicit-argument suffix, or
+  // Native byte offset where the implicit-argument region begins, or
   // IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE.
   iree_host_size_t implicit_args_byte_offset;
+  // Per-field native offsets of the synthesized implicit arguments.
+  iree_hal_amdgpu_kernarg_implicit_args_t implicit_args;
   // Byte length required for the immutable native kernarg layout record.
   iree_host_size_t layout_byte_length;
 } iree_hal_amdgpu_hsaco_kernel_load_plan_t;
@@ -112,6 +114,65 @@ static bool iree_hal_amdgpu_hsaco_metadata_arg_kind_is_hidden(
          kind == IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN_NONE;
 }
 
+// Records the native offset of a synthesized implicit ("hidden") argument by
+// matching its metadata `.value_kind`. Only the fields the runtime writes at
+// dispatch time are recorded; every other hidden argument (global offset,
+// printf/hostcall buffers, remainder, hidden_none padding) is left zero.
+// Returns an error if a recognized field declares an unexpected byte size.
+static iree_status_t iree_hal_amdgpu_hsaco_record_implicit_field(
+    iree_string_view_t symbol_name,
+    const iree_hal_amdgpu_hsaco_metadata_arg_t* arg,
+    iree_hal_amdgpu_kernarg_implicit_args_t* out_implicit_args) {
+  uint16_t* target_offset = NULL;
+  uint32_t expected_size = 0;
+  if (iree_string_view_equal(arg->value_kind,
+                             IREE_SV("hidden_block_count_x"))) {
+    target_offset = &out_implicit_args->block_count_offset[0];
+    expected_size = sizeof(uint32_t);
+  } else if (iree_string_view_equal(arg->value_kind,
+                                    IREE_SV("hidden_block_count_y"))) {
+    target_offset = &out_implicit_args->block_count_offset[1];
+    expected_size = sizeof(uint32_t);
+  } else if (iree_string_view_equal(arg->value_kind,
+                                    IREE_SV("hidden_block_count_z"))) {
+    target_offset = &out_implicit_args->block_count_offset[2];
+    expected_size = sizeof(uint32_t);
+  } else if (iree_string_view_equal(arg->value_kind,
+                                    IREE_SV("hidden_group_size_x"))) {
+    target_offset = &out_implicit_args->group_size_offset[0];
+    expected_size = sizeof(uint16_t);
+  } else if (iree_string_view_equal(arg->value_kind,
+                                    IREE_SV("hidden_group_size_y"))) {
+    target_offset = &out_implicit_args->group_size_offset[1];
+    expected_size = sizeof(uint16_t);
+  } else if (iree_string_view_equal(arg->value_kind,
+                                    IREE_SV("hidden_group_size_z"))) {
+    target_offset = &out_implicit_args->group_size_offset[2];
+    expected_size = sizeof(uint16_t);
+  } else if (iree_string_view_equal(arg->value_kind,
+                                    IREE_SV("hidden_grid_dims"))) {
+    target_offset = &out_implicit_args->grid_dims_offset;
+    expected_size = sizeof(uint16_t);
+  } else if (iree_string_view_equal(arg->value_kind,
+                                    IREE_SV("hidden_dynamic_lds_size"))) {
+    target_offset = &out_implicit_args->dynamic_lds_size_offset;
+    expected_size = sizeof(uint32_t);
+  } else {
+    // Hidden argument the runtime does not synthesize; leave it zero.
+    return iree_ok_status();
+  }
+  if (IREE_UNLIKELY(arg->size != expected_size)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU kernel `%.*s` implicit argument `%.*s` has unexpected size %u "
+        "(expected %u)",
+        (int)symbol_name.size, symbol_name.data, (int)arg->value_kind.size,
+        arg->value_kind.data, arg->size, expected_size);
+  }
+  *target_offset = (uint16_t)arg->offset;
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_amdgpu_hsaco_load_plan_check_u16(
     iree_string_view_t symbol_name, iree_string_view_t field_name,
     iree_host_size_t value) {
@@ -132,6 +193,16 @@ static iree_status_t iree_hal_amdgpu_hsaco_load_plan_analyze_kernel(
   IREE_ASSERT_ARGUMENT(out_load_plan);
   memset(out_load_plan, 0, sizeof(*out_load_plan));
   out_load_plan->implicit_args_byte_offset =
+      IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE;
+  for (iree_host_size_t i = 0; i < 3; ++i) {
+    out_load_plan->implicit_args.block_count_offset[i] =
+        IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE;
+    out_load_plan->implicit_args.group_size_offset[i] =
+        IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE;
+  }
+  out_load_plan->implicit_args.grid_dims_offset =
+      IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE;
+  out_load_plan->implicit_args.dynamic_lds_size_offset =
       IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE;
 
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_load_plan_check_u16(
@@ -165,6 +236,8 @@ static iree_status_t iree_hal_amdgpu_hsaco_load_plan_analyze_kernel(
     if (iree_hal_amdgpu_hsaco_metadata_arg_kind_is_hidden(arg->kind)) {
       hidden_args_offset =
           iree_min(hidden_args_offset, (iree_host_size_t)arg->offset);
+      IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_record_implicit_field(
+          kernel->symbol_name, arg, &out_load_plan->implicit_args));
       continue;
     }
 
@@ -243,6 +316,10 @@ static iree_status_t iree_hal_amdgpu_hsaco_load_plan_analyze_kernel(
       kernel->symbol_name, IREE_SV("constant span count"),
       out_load_plan->constant_span_count));
 
+  // The native kernarg length is exactly the code object's kernarg segment
+  // size. Implicit arguments are written in place at their own metadata offsets
+  // (validated per-argument above to fall within the segment) rather than as a
+  // fixed-size suffix reserved past the segment.
   out_load_plan->kernarg_byte_length = kernel->kernarg_segment_size;
   if (hidden_args_offset != IREE_HOST_SIZE_MAX) {
     if (IREE_UNLIKELY(explicit_kernarg_end > hidden_args_offset)) {
@@ -252,22 +329,7 @@ static iree_status_t iree_hal_amdgpu_hsaco_load_plan_analyze_kernel(
           "implicit kernargs",
           (int)kernel->symbol_name.size, kernel->symbol_name.data);
     }
-    iree_host_size_t implicit_args_end = 0;
-    if (IREE_UNLIKELY(!iree_host_size_checked_add(
-            hidden_args_offset,
-            (iree_host_size_t)IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE,
-            &implicit_args_end))) {
-      return iree_make_status(
-          IREE_STATUS_OUT_OF_RANGE,
-          "AMDGPU kernel `%.*s` implicit kernarg suffix overflows",
-          (int)kernel->symbol_name.size, kernel->symbol_name.data);
-    }
-    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_load_plan_check_u16(
-        kernel->symbol_name, IREE_SV("implicit kernarg suffix end"),
-        implicit_args_end));
     out_load_plan->implicit_args_byte_offset = hidden_args_offset;
-    out_load_plan->kernarg_byte_length =
-        iree_max(out_load_plan->kernarg_byte_length, implicit_args_end);
   }
 
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_kernarg_layout_storage_size(
@@ -382,6 +444,7 @@ static iree_status_t iree_hal_amdgpu_hsaco_load_plan_populate_layout_tables(
       .kernarg_alignment = kernel->kernarg_segment_alignment,
       .constant_byte_length = load_plan->constant_byte_length,
       .implicit_args_byte_offset = load_plan->implicit_args_byte_offset,
+      .implicit_args = load_plan->implicit_args,
       .binding_count = load_plan->binding_count,
       .binding_slots = binding_slots,
       .constant_span_count = load_plan->constant_span_count,

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco_test.cc
@@ -341,6 +341,85 @@ TEST(ExecutableMetadataHsacoTest, PopulatesImplicitArgsSuffixLayout) {
   iree_hal_amdgpu_executable_metadata_free(metadata);
 }
 
+// Regression gate against a transposed implicit-field mapping: a kernel
+// declaring the full hidden block must record each hidden arg's native offset
+// in the matching per-field slot of the layout. Every field uses a distinct
+// offset, so any value_kind-to-field transposition in record_implicit_field
+// would surface here rather than passing every coarse existing check.
+TEST(ExecutableMetadataHsacoTest, RecordsPerFieldImplicitOffsets) {
+  const iree_const_byte_span_t source_code_object_data = SourceCodeObjectData();
+  std::vector<uint8_t> loaded_code_object_storage = MakeLoadedCodeObjectData();
+  const iree_const_byte_span_t loaded_code_object_data =
+      LoadedCodeObjectData(loaded_code_object_storage);
+  // Explicit args must belong to the code object so their names rebase; hidden
+  // args are skipped by rebasing, so their value_kind literals drive the
+  // per-field recording under test.
+  std::vector<iree_hal_amdgpu_hsaco_metadata_arg_t> args = {
+      MakeArg(ViewFromCodeObjectData(source_code_object_data, "buffer"), 0, 8,
+              IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_GLOBAL_BUFFER,
+              ViewFromCodeObjectData(source_code_object_data, "global_buffer")),
+      MakeArg(ViewFromCodeObjectData(source_code_object_data, "value"), 8, 4,
+              IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_BY_VALUE,
+              ViewFromCodeObjectData(source_code_object_data, "by_value")),
+      MakeArg(IREE_SV("bcx"), 16, 4,
+              IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+              IREE_SV("hidden_block_count_x")),
+      MakeArg(IREE_SV("bcy"), 20, 4,
+              IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+              IREE_SV("hidden_block_count_y")),
+      MakeArg(IREE_SV("bcz"), 24, 4,
+              IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+              IREE_SV("hidden_block_count_z")),
+      MakeArg(IREE_SV("gsx"), 28, 2,
+              IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+              IREE_SV("hidden_group_size_x")),
+      MakeArg(IREE_SV("gsy"), 30, 2,
+              IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+              IREE_SV("hidden_group_size_y")),
+      MakeArg(IREE_SV("gsz"), 32, 2,
+              IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+              IREE_SV("hidden_group_size_z")),
+      MakeArg(IREE_SV("gd"), 34, 2,
+              IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+              IREE_SV("hidden_grid_dims")),
+      MakeArg(IREE_SV("lds"), 36, 4,
+              IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+              IREE_SV("hidden_dynamic_lds_size")),
+  };
+  iree_hal_amdgpu_hsaco_metadata_kernel_t kernel =
+      MakeKernel(ViewFromCodeObjectData(source_code_object_data, "implicit"),
+                 ViewFromCodeObjectData(source_code_object_data, "implicit.kd"),
+                 /*kernarg_segment_size=*/40, args);
+  iree_hal_amdgpu_hsaco_metadata_t hsaco_metadata = {
+      /*.host_allocator=*/{},
+      /*.elf_data=*/source_code_object_data,
+      /*.message_pack_data=*/{},
+      /*.target=*/{},
+      /*.reflection_name_storage_size=*/{},
+      /*.arg_name_storage_size=*/{},
+      /*.kernel_count=*/1,
+      /*.kernels=*/&kernel,
+  };
+
+  iree_hal_amdgpu_executable_metadata_t* metadata =
+      AllocateAndPopulate(&hsaco_metadata, loaded_code_object_data);
+  const iree_hal_amdgpu_kernarg_layout_t* layout = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_executable_metadata_resolve_layout(
+      metadata, metadata->exports[0].kernarg_layout, &layout));
+
+  EXPECT_EQ(layout->implicit_args_byte_offset, 16);
+  EXPECT_EQ(layout->implicit_args.block_count_offset[0], 16);
+  EXPECT_EQ(layout->implicit_args.block_count_offset[1], 20);
+  EXPECT_EQ(layout->implicit_args.block_count_offset[2], 24);
+  EXPECT_EQ(layout->implicit_args.group_size_offset[0], 28);
+  EXPECT_EQ(layout->implicit_args.group_size_offset[1], 30);
+  EXPECT_EQ(layout->implicit_args.group_size_offset[2], 32);
+  EXPECT_EQ(layout->implicit_args.grid_dims_offset, 34);
+  EXPECT_EQ(layout->implicit_args.dynamic_lds_size_offset, 36);
+
+  iree_hal_amdgpu_executable_metadata_free(metadata);
+}
+
 TEST(ExecutableMetadataHsacoTest, PopulatesElfOnlyCustomDirectExport) {
   const iree_const_byte_span_t source_code_object_data = SourceCodeObjectData();
   std::vector<uint8_t> loaded_code_object_storage = MakeLoadedCodeObjectData();
@@ -483,6 +562,38 @@ TEST(ExecutableMetadataHsacoTest, RejectsHiddenArgsBeforeVisibleArgsEnd) {
   };
   iree_hal_amdgpu_hsaco_metadata_kernel_t kernel =
       MakeKernel(IREE_SV("bad"), IREE_SV("bad.kd"), 24, args);
+  iree_hal_amdgpu_hsaco_metadata_t hsaco_metadata = {
+      /*.host_allocator=*/{},
+      /*.elf_data=*/{},
+      /*.message_pack_data=*/{},
+      /*.target=*/{},
+      /*.reflection_name_storage_size=*/{},
+      /*.arg_name_storage_size=*/{},
+      /*.kernel_count=*/1,
+      /*.kernels=*/&kernel,
+  };
+  iree_hal_amdgpu_executable_metadata_counts_t counts;
+
+  EXPECT_THAT(Status(iree_hal_amdgpu_executable_metadata_calculate_hsaco_counts(
+                  &hsaco_metadata, &counts)),
+              StatusIs(StatusCode::kInvalidArgument));
+}
+
+// A recognized hidden field whose declared byte size does not match the ABI
+// (here hidden_block_count_x as 8 bytes instead of uint32) must be rejected by
+// record_implicit_field, so a mistyped code object cannot silently mispatch the
+// synthesized implicit arguments.
+TEST(ExecutableMetadataHsacoTest, RejectsImplicitFieldWithUnexpectedSize) {
+  std::vector<iree_hal_amdgpu_hsaco_metadata_arg_t> args = {
+      MakeArg(IREE_SV("buffer"), 0, 8,
+              IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_GLOBAL_BUFFER,
+              IREE_SV("global_buffer")),
+      MakeArg(IREE_SV("bcx"), 8, 8,
+              IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_HIDDEN,
+              IREE_SV("hidden_block_count_x")),
+  };
+  iree_hal_amdgpu_hsaco_metadata_kernel_t kernel =
+      MakeKernel(IREE_SV("bad"), IREE_SV("bad.kd"), 16, args);
   iree_hal_amdgpu_hsaco_metadata_t hsaco_metadata = {
       /*.host_allocator=*/{},
       /*.elf_data=*/{},

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_dispatch.c
@@ -497,37 +497,31 @@ static void iree_hal_amdgpu_host_queue_initialize_dispatch_event(
   event->workgroup_size[2] = plan->kernel_args->workgroup_size[2];
 }
 
+// Returns a pointer positioned so the device indirect-parameter patch's
+// contiguous block_count[3] store lands on the kernel's declared
+// hidden_block_count_x/y/z fields, or NULL when there is no block_count to
+// patch (no implicit args, an ELF-only custom-direct export with no native
+// layout, or a kernel that does not declare block_count). |layout| is the
+// native metadata layout shared by native and custom-direct dispatches and is
+// the same source the host emplace uses to write block_count, so the patch
+// overwrites exactly those bytes. Layout construction validates block_count as
+// a contiguous uint32[3], so anchoring the fixed-struct store at the x-field
+// offset covers all three fields in-bounds.
 static iree_amdgpu_kernel_implicit_args_t*
-iree_hal_amdgpu_host_queue_native_implicit_args(
+iree_hal_amdgpu_host_queue_indirect_block_count_args(
     const iree_hal_amdgpu_kernarg_layout_t* layout, void* kernarg_data) {
-  if (!iree_any_bit_set(layout->flags,
+  if (!layout ||
+      !iree_any_bit_set(layout->flags,
                         IREE_HAL_AMDGPU_KERNARG_LAYOUT_FLAG_IMPLICIT_ARGS)) {
     return NULL;
   }
-  return (
-      iree_amdgpu_kernel_implicit_args_t*)((uint8_t*)kernarg_data +
-                                           layout->implicit_args_byte_offset);
-}
-
-static void iree_hal_amdgpu_host_queue_emplace_native_implicit_args(
-    const iree_hal_amdgpu_device_kernel_args_t* kernel_args,
-    const uint32_t workgroup_count[3], uint32_t dynamic_workgroup_local_memory,
-    const iree_hal_amdgpu_kernarg_layout_t* layout, void* kernarg_data) {
-  iree_amdgpu_kernel_implicit_args_t* implicit_args =
-      iree_hal_amdgpu_host_queue_native_implicit_args(layout, kernarg_data);
-  if (!implicit_args) return;
-
-  memset(implicit_args, 0, IREE_AMDGPU_KERNEL_IMPLICIT_ARGS_SIZE);
-  implicit_args->block_count[0] = workgroup_count[0];
-  implicit_args->block_count[1] = workgroup_count[1];
-  implicit_args->block_count[2] = workgroup_count[2];
-  implicit_args->group_size[0] = kernel_args->workgroup_size[0];
-  implicit_args->group_size[1] = kernel_args->workgroup_size[1];
-  implicit_args->group_size[2] = kernel_args->workgroup_size[2];
-  implicit_args->grid_dims = 3;
-  implicit_args->printf_buffer = NULL;
-  implicit_args->hostcall_buffer = NULL;
-  implicit_args->dynamic_lds_size = dynamic_workgroup_local_memory;
+  const uint16_t block_count_offset =
+      layout->implicit_args.block_count_offset[0];
+  if (block_count_offset == IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE) {
+    return NULL;
+  }
+  return (iree_amdgpu_kernel_implicit_args_t*)((uint8_t*)kernarg_data +
+                                               block_count_offset);
 }
 
 static void iree_hal_amdgpu_host_queue_emplace_dispatch_kernargs(
@@ -539,17 +533,22 @@ static void iree_hal_amdgpu_host_queue_emplace_dispatch_kernargs(
     iree_hal_amdgpu_device_dispatch_emplace_custom_kernargs(
         plan->custom_layout, constants.data, constants.data_length,
         kernarg_data);
-    iree_hal_amdgpu_device_dispatch_emplace_implicit_args(
-        plan->kernel_args, workgroup_count, dynamic_workgroup_local_memory,
-        plan->custom_layout, kernarg_data);
+    // Custom-direct dispatches still synthesize the HIP/OpenCL implicit args.
+    // The native metadata layout carries the per-field implicit offsets; it is
+    // present for reflected kernels and NULL for ELF-only custom-direct exports
+    // (which declare no implicit args, so this is a no-op for them).
+    iree_hal_amdgpu_kernarg_layout_emplace_implicit_args(
+        plan->descriptor->kernarg_layout, workgroup_count,
+        plan->kernel_args->workgroup_size, dynamic_workgroup_local_memory,
+        kernarg_data);
     return;
   }
 
   iree_hal_amdgpu_kernarg_layout_emplace_explicit_args(
       plan->kernarg_layout, binding_ptrs, constants, kernarg_data);
-  iree_hal_amdgpu_host_queue_emplace_native_implicit_args(
-      plan->kernel_args, workgroup_count, dynamic_workgroup_local_memory,
-      plan->kernarg_layout, kernarg_data);
+  iree_hal_amdgpu_kernarg_layout_emplace_implicit_args(
+      plan->kernarg_layout, workgroup_count, plan->kernel_args->workgroup_size,
+      dynamic_workgroup_local_memory, kernarg_data);
 }
 
 static bool iree_hal_amdgpu_host_queue_should_profile_dispatch(
@@ -777,15 +776,13 @@ static iree_status_t iree_hal_amdgpu_host_queue_submit_dispatch_packets(
         iree_hal_amdgpu_host_queue_profiling_completion_signal(
             queue, profile_events.first_event_position);
   }
+  // Both native and custom-direct dispatches synthesize implicit args from the
+  // native metadata layout, so the indirect block_count patch is anchored there
+  // regardless of the argument path. This overwrites the same block_count bytes
+  // the host emplace populated with the placeholder workgroup count.
   iree_amdgpu_kernel_implicit_args_t* implicit_args =
-      uses_custom_direct_arguments
-          ? (plan->custom_layout->has_implicit_args
-                 ? (iree_amdgpu_kernel_implicit_args_t*)(dispatch_kernarg_data +
-                                                         plan->custom_layout
-                                                             ->implicit_args_offset)
-                 : NULL)
-          : iree_hal_amdgpu_host_queue_native_implicit_args(
-                plan->kernarg_layout, dispatch_kernarg_data);
+      iree_hal_amdgpu_host_queue_indirect_block_count_args(
+          plan->descriptor->kernarg_layout, dispatch_kernarg_data);
   const iree_hsa_fence_scope_t dispatch_acquire_scope =
       iree_hal_amdgpu_host_queue_kernarg_acquire_scope(
           IREE_HSA_FENCE_SCOPE_AGENT);

--- a/runtime/src/iree/hal/drivers/amdgpu/kernarg_layout.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/kernarg_layout.c
@@ -176,6 +176,95 @@ static iree_status_t iree_hal_amdgpu_kernarg_layout_validate_no_source_overlap(
   return iree_ok_status();
 }
 
+// Validates that a synthesized implicit-argument field lies within the kernarg
+// segment. A NONE offset means the kernel did not declare the field.
+static iree_status_t iree_hal_amdgpu_kernarg_layout_validate_implicit_field(
+    iree_host_size_t kernarg_byte_length, uint16_t field_offset,
+    iree_host_size_t field_size) {
+  if (field_offset == IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE) {
+    return iree_ok_status();
+  }
+  iree_host_size_t field_end = 0;
+  if (IREE_UNLIKELY(
+          !iree_host_size_checked_add(field_offset, field_size, &field_end)) ||
+      IREE_UNLIKELY(field_end > kernarg_byte_length)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "implicit argument field at offset %u size %" PRIhsz
+                            " exceeds kernarg byte length %" PRIhsz,
+                            field_offset, field_size, kernarg_byte_length);
+  }
+  return iree_ok_status();
+}
+
+// Validates every synthesized implicit-argument field against the kernarg
+// segment bounds and enforces that hidden_block_count_x/y/z are declared as a
+// contiguous uint32[3] block (or omitted), which the device indirect-parameter
+// patch relies on.
+static iree_status_t iree_hal_amdgpu_kernarg_layout_validate_implicit_args(
+    iree_host_size_t kernarg_byte_length,
+    const iree_hal_amdgpu_kernarg_implicit_args_t* implicit_args) {
+  for (iree_host_size_t i = 0; i < 3; ++i) {
+    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_kernarg_layout_validate_implicit_field(
+        kernarg_byte_length, implicit_args->block_count_offset[i],
+        sizeof(uint32_t)));
+    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_kernarg_layout_validate_implicit_field(
+        kernarg_byte_length, implicit_args->group_size_offset[i],
+        sizeof(uint16_t)));
+  }
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_kernarg_layout_validate_implicit_field(
+      kernarg_byte_length, implicit_args->grid_dims_offset, sizeof(uint16_t)));
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_kernarg_layout_validate_implicit_field(
+      kernarg_byte_length, implicit_args->dynamic_lds_size_offset,
+      sizeof(uint32_t)));
+
+  // The device indirect-parameter patch rewrites hidden_block_count_x/y/z as a
+  // contiguous uint32[3] (three uint32 dword stores) anchored at the x field,
+  // matching the AMD code object ABI, which packs block_count as one uint32[3]
+  // object. Require the three fields to be either all omitted or all declared
+  // contiguously so those stores land exactly on the declared fields and stay
+  // within the per-field bounds validated above. Real code objects always
+  // satisfy this; rejecting anything else keeps the device writes in-bounds.
+  const uint16_t block_count_x = implicit_args->block_count_offset[0];
+  const uint16_t block_count_y = implicit_args->block_count_offset[1];
+  const uint16_t block_count_z = implicit_args->block_count_offset[2];
+  const bool block_count_absent =
+      block_count_x == IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE &&
+      block_count_y == IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE &&
+      block_count_z == IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE;
+  const bool block_count_contiguous =
+      block_count_x != IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE &&
+      block_count_y != IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE &&
+      block_count_z != IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE &&
+      (iree_host_size_t)block_count_y ==
+          (iree_host_size_t)block_count_x + sizeof(uint32_t) &&
+      (iree_host_size_t)block_count_z ==
+          (iree_host_size_t)block_count_x + 2 * sizeof(uint32_t);
+  if (IREE_UNLIKELY(!block_count_absent && !block_count_contiguous)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "hidden block_count fields must be declared as a contiguous uint32[3] "
+        "block or omitted entirely (got offsets %u, %u, %u)",
+        block_count_x, block_count_y, block_count_z);
+  }
+
+  // The device patch stores block_count as uint32 dwords, so the anchor field
+  // block_count_x (and thus the contiguous y/z that follow it) must be 4-byte
+  // aligned. This replaces the removed 8-byte base-alignment reject: alignment
+  // is now required only where the device performs aligned dword stores, not on
+  // the region base, which may be unaligned for a partial hidden block. When
+  // block_count is absent there is nothing to align.
+  if (IREE_UNLIKELY(
+          !block_count_absent &&
+          !iree_host_size_has_alignment(block_count_x, sizeof(uint32_t)))) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "hidden block_count_x offset %u must be 4-byte aligned for the device "
+        "uint32 dword store",
+        block_count_x);
+  }
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_amdgpu_kernarg_layout_validate_params(
     const iree_hal_amdgpu_kernarg_layout_params_t* params) {
   if (IREE_UNLIKELY(params->kernarg_byte_length >
@@ -225,13 +314,14 @@ static iree_status_t iree_hal_amdgpu_kernarg_layout_validate_params(
                               params->implicit_args_byte_offset,
                               params->kernarg_byte_length);
     }
-    if (IREE_UNLIKELY(!iree_host_size_has_alignment(
-            params->implicit_args_byte_offset, sizeof(uint64_t)))) {
-      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "implicit args offset %" PRIhsz
-                              " must be 8-byte aligned",
-                              params->implicit_args_byte_offset);
-    }
+    // The AMD ABI does not require the implicit-argument region to begin at an
+    // 8-byte-aligned offset: hand-written assembly kernels (e.g. MIOpen
+    // Winograd) begin the region with sub-8-byte hidden_none padding so the
+    // lowest hidden offset can be unaligned. Each synthesized field is written
+    // at its own metadata offset instead, so validate every declared field
+    // lies within the kernarg segment rather than constraining the base.
+    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_kernarg_layout_validate_implicit_args(
+        params->kernarg_byte_length, &params->implicit_args));
   }
   for (iree_host_size_t i = 0; i < params->binding_count; ++i) {
     const iree_hal_amdgpu_kernarg_byte_range_t range =
@@ -364,6 +454,7 @@ iree_status_t iree_hal_amdgpu_kernarg_layout_initialize(
   out_layout->implicit_args_byte_offset =
       (uint16_t)params->implicit_args_byte_offset;
   out_layout->flags = flags;
+  out_layout->implicit_args = params->implicit_args;
 
   if (params->binding_count > 0) {
     memmove(out_layout->binding_slots, params->binding_slots,
@@ -409,5 +500,61 @@ void iree_hal_amdgpu_kernarg_layout_emplace_explicit_args(
     const iree_hal_amdgpu_kernarg_constant_span_t span = constant_spans[i];
     memcpy(target + span.target_byte_offset,
            constants.data + span.source_byte_offset, span.byte_length);
+  }
+}
+
+void iree_hal_amdgpu_kernarg_layout_emplace_implicit_args(
+    const iree_hal_amdgpu_kernarg_layout_t* layout,
+    const uint32_t workgroup_count[3], const uint16_t workgroup_size[3],
+    uint32_t dynamic_workgroup_local_memory, void* kernarg_ptr) {
+  if (!layout ||
+      !iree_any_bit_set(layout->flags,
+                        IREE_HAL_AMDGPU_KERNARG_LAYOUT_FLAG_IMPLICIT_ARGS)) {
+    return;
+  }
+  uint8_t* target = (uint8_t*)kernarg_ptr;
+
+  // Zero the implicit region so undeclared fields (global offset, printf and
+  // hostcall buffers, remainder, and hidden_none padding) are zero/NULL, which
+  // matches the HIP defaults. The runtime owns the whole implicit region
+  // [implicit_args_byte_offset, kernarg_byte_length). On the native path the
+  // code object metadata analysis rejects kernels whose explicit kernargs reach
+  // into this region, so explicit args sit strictly below the region start and
+  // this zero never touches them. On the custom-direct path the caller supplies
+  // only the pre-packed explicit prefix; the runtime synthesizes the implicit
+  // args and zero-fills this region regardless, so it does not depend on (and
+  // deliberately overwrites) any caller bytes inside it. The zero is
+  // unconditional because kernarg storage is pooled and may hold stale bytes
+  // from a prior dispatch that must not leak into this one.
+  const uint16_t region_begin = layout->implicit_args_byte_offset;
+  memset(target + region_begin, 0, layout->kernarg_byte_length - region_begin);
+
+  // Write only the fields the code object metadata declared, each at its own
+  // native offset (ROCr walks and writes hidden args individually rather than
+  // splatting a fixed struct at one base offset).
+  const iree_hal_amdgpu_kernarg_implicit_args_t* implicit_args =
+      &layout->implicit_args;
+  for (iree_host_size_t i = 0; i < 3; ++i) {
+    if (implicit_args->block_count_offset[i] !=
+        IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE) {
+      memcpy(target + implicit_args->block_count_offset[i], &workgroup_count[i],
+             sizeof(uint32_t));
+    }
+    if (implicit_args->group_size_offset[i] !=
+        IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE) {
+      memcpy(target + implicit_args->group_size_offset[i], &workgroup_size[i],
+             sizeof(uint16_t));
+    }
+  }
+  if (implicit_args->grid_dims_offset !=
+      IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE) {
+    const uint16_t grid_dims = 3;
+    memcpy(target + implicit_args->grid_dims_offset, &grid_dims,
+           sizeof(uint16_t));
+  }
+  if (implicit_args->dynamic_lds_size_offset !=
+      IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE) {
+    memcpy(target + implicit_args->dynamic_lds_size_offset,
+           &dynamic_workgroup_local_memory, sizeof(uint32_t));
   }
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/kernarg_layout.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/kernarg_layout.h
@@ -59,6 +59,29 @@ typedef struct iree_hal_amdgpu_kernarg_constant_span_t {
   uint16_t byte_length;
 } iree_hal_amdgpu_kernarg_constant_span_t;
 
+// Native kernarg byte offsets of the HIP/OpenCL implicit ("hidden") argument
+// fields the runtime synthesizes per dispatch.
+//
+// Each offset is the code object metadata's per-argument `.offset` for that
+// hidden field, or IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE when the
+// kernel does not declare the field (in which case it is left zero, matching
+// the HIP default). This mirrors ROCr's per-field implicit-argument write
+// (clr rocclr device/rocm/rocvirtual.cpp) rather than assuming a single fixed
+// implicit-args struct at one base offset, which is invalid for hand-written
+// assembly kernels (e.g. MIOpen Winograd) that declare only a partial hidden
+// block. Undeclared fields (global offset, printf/hostcall buffers, remainder,
+// and hidden_none padding) remain zero via the layout's zero-fill.
+typedef struct iree_hal_amdgpu_kernarg_implicit_args_t {
+  // Byte offset of hidden_block_count_x/y/z (uint32 each), or NONE.
+  uint16_t block_count_offset[3];
+  // Byte offset of hidden_group_size_x/y/z (uint16 each), or NONE.
+  uint16_t group_size_offset[3];
+  // Byte offset of hidden_grid_dims (uint16), or NONE.
+  uint16_t grid_dims_offset;
+  // Byte offset of hidden_dynamic_lds_size (uint32), or NONE.
+  uint16_t dynamic_lds_size_offset;
+} iree_hal_amdgpu_kernarg_implicit_args_t;
+
 // Parameters used to build an immutable native kernarg layout.
 typedef struct iree_hal_amdgpu_kernarg_layout_params_t {
   // Total native kernarg byte length reserved for dispatch.
@@ -67,8 +90,10 @@ typedef struct iree_hal_amdgpu_kernarg_layout_params_t {
   iree_host_size_t kernarg_alignment;
   // Number of bytes consumed from the HAL dispatch constant stream.
   iree_host_size_t constant_byte_length;
-  // Native byte offset of the implicit-argument suffix, or
-  // IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE.
+  // Native byte offset where the implicit-argument region begins (the lowest
+  // hidden argument offset), or
+  // IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE when the kernel has no
+  // implicit arguments.
   iree_host_size_t implicit_args_byte_offset;
   // Number of entries in binding_slots.
   iree_host_size_t binding_count;
@@ -78,6 +103,12 @@ typedef struct iree_hal_amdgpu_kernarg_layout_params_t {
   iree_host_size_t constant_span_count;
   // Dense dispatch-constant stream to native kernarg byte mappings.
   const iree_hal_amdgpu_kernarg_constant_span_t* constant_spans;
+  // Per-field native offsets of the synthesized implicit arguments. Only
+  // meaningful when implicit_args_byte_offset != IMPLICIT_ARGS_NONE. The
+  // producer must set every field the kernel does not declare to
+  // IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE; a zero-initialized field
+  // is interpreted as offset 0, not as absent.
+  iree_hal_amdgpu_kernarg_implicit_args_t implicit_args;
 } iree_hal_amdgpu_kernarg_layout_params_t;
 
 // Immutable native kernarg layout for one executable export.
@@ -96,11 +127,17 @@ typedef struct iree_hal_amdgpu_kernarg_layout_t {
   uint16_t constant_span_count;
   // Number of bytes consumed from the HAL dispatch constant stream.
   uint16_t constant_byte_length;
-  // Native byte offset of the implicit-argument suffix, or
-  // IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE.
+  // Native byte offset where the implicit-argument region begins (the lowest
+  // hidden argument offset), or
+  // IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE when the kernel has no
+  // implicit arguments. Used as the start of the region zeroed before per-field
+  // implicit emplacement.
   uint16_t implicit_args_byte_offset;
   // Feature flags derived at layout construction time.
   iree_hal_amdgpu_kernarg_layout_flags_t flags;
+  // Per-field native offsets of the synthesized implicit arguments. Only
+  // meaningful when the IMPLICIT_ARGS flag is set.
+  iree_hal_amdgpu_kernarg_implicit_args_t implicit_args;
   // Dense binding ordinal to native qword target mapping table.
   iree_hal_amdgpu_kernarg_binding_slot_t binding_slots[];
 } iree_hal_amdgpu_kernarg_layout_t;
@@ -147,6 +184,23 @@ void iree_hal_amdgpu_kernarg_layout_emplace_explicit_args(
     const iree_hal_amdgpu_kernarg_layout_t* layout,
     const uint64_t* binding_ptrs, iree_const_byte_span_t constants,
     void* kernarg_ptr);
+
+// Populates the HIP/OpenCL implicit ("hidden") kernargs in already-reserved
+// storage, writing each declared implicit field at its own native offset.
+//
+// This zeroes the implicit region beginning at
+// |layout|->implicit_args_byte_offset and then writes only the fields the code
+// object metadata declared: hidden_block_count from |workgroup_count|,
+// hidden_group_size from |workgroup_size|, hidden_grid_dims as 3, and
+// hidden_dynamic_lds_size from |dynamic_workgroup_local_memory|. Undeclared
+// fields (global offset, printf/hostcall buffers, remainder, padding) remain
+// zero. Does nothing when |layout| is NULL or has no implicit arguments.
+// |kernarg_ptr| must point to at least |layout|->kernarg_byte_length writable
+// bytes.
+void iree_hal_amdgpu_kernarg_layout_emplace_implicit_args(
+    const iree_hal_amdgpu_kernarg_layout_t* layout,
+    const uint32_t workgroup_count[3], const uint16_t workgroup_size[3],
+    uint32_t dynamic_workgroup_local_memory, void* kernarg_ptr);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/amdgpu/kernarg_layout_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/kernarg_layout_test.cc
@@ -134,6 +134,7 @@ TEST(KernargLayoutTest, MarksImplicitArgsLayoutForZeroFill) {
   iree_hal_amdgpu_kernarg_layout_t* layout =
       reinterpret_cast<iree_hal_amdgpu_kernarg_layout_t*>(storage.data());
 
+  const uint16_t kNone = IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE;
   iree_hal_amdgpu_kernarg_layout_params_t params = {
       /*.kernarg_byte_length=*/272,
       /*.kernarg_alignment=*/8,
@@ -141,6 +142,15 @@ TEST(KernargLayoutTest, MarksImplicitArgsLayoutForZeroFill) {
       /*.implicit_args_byte_offset=*/16,
       /*.binding_count=*/IREE_ARRAYSIZE(binding_slots),
       /*.binding_slots=*/binding_slots,
+      /*.constant_span_count=*/0,
+      /*.constant_spans=*/nullptr,
+      /*.implicit_args=*/
+      {
+          /*.block_count_offset=*/{16, 20, 24},
+          /*.group_size_offset=*/{kNone, kNone, kNone},
+          /*.grid_dims_offset=*/kNone,
+          /*.dynamic_lds_size_offset=*/kNone,
+      },
   };
   IREE_ASSERT_OK(iree_hal_amdgpu_kernarg_layout_initialize(
       &params, storage.size(), layout));
@@ -342,6 +352,202 @@ TEST(KernargLayoutTest, RejectsTooLittleStorage) {
           &params, sizeof(storage),
           reinterpret_cast<iree_hal_amdgpu_kernarg_layout_t*>(storage))),
       StatusIs(StatusCode::kResourceExhausted));
+}
+
+// Regression gate: a standard kernel declaring the complete implicit block at
+// the fixed AMD ABI offsets must have block_count/group_size/grid_dims/
+// dynamic_lds written at those offsets and every other implicit byte (global
+// offset, printf/hostcall, remainder, padding) left zero -- matching the
+// previous fixed-struct splat.
+TEST(KernargLayoutTest, EmplacesFullImplicitArgsAtAbiOffsets) {
+  std::vector<uint8_t> storage = AllocateStorage(0, 0);
+  auto* layout =
+      reinterpret_cast<iree_hal_amdgpu_kernarg_layout_t*>(storage.data());
+  iree_hal_amdgpu_kernarg_layout_params_t params = {
+      /*.kernarg_byte_length=*/128,
+      /*.kernarg_alignment=*/8,
+      /*.constant_byte_length=*/0,
+      /*.implicit_args_byte_offset=*/0,
+      /*.binding_count=*/0,
+      /*.binding_slots=*/nullptr,
+      /*.constant_span_count=*/0,
+      /*.constant_spans=*/nullptr,
+      /*.implicit_args=*/
+      {
+          /*.block_count_offset=*/{0, 4, 8},
+          /*.group_size_offset=*/{12, 14, 16},
+          /*.grid_dims_offset=*/64,
+          /*.dynamic_lds_size_offset=*/120,
+      },
+  };
+  IREE_ASSERT_OK(iree_hal_amdgpu_kernarg_layout_initialize(
+      &params, storage.size(), layout));
+
+  uint8_t kernargs[128];
+  memset(kernargs, 0xCD, sizeof(kernargs));
+  const uint32_t workgroup_count[3] = {11u, 22u, 33u};
+  const uint16_t workgroup_size[3] = {4u, 5u, 6u};
+  iree_hal_amdgpu_kernarg_layout_emplace_implicit_args(
+      layout, workgroup_count, workgroup_size,
+      /*dynamic_workgroup_local_memory=*/777u, kernargs);
+
+  uint8_t expected[128] = {0};
+  memcpy(expected + 0, &workgroup_count[0], sizeof(uint32_t));
+  memcpy(expected + 4, &workgroup_count[1], sizeof(uint32_t));
+  memcpy(expected + 8, &workgroup_count[2], sizeof(uint32_t));
+  memcpy(expected + 12, &workgroup_size[0], sizeof(uint16_t));
+  memcpy(expected + 14, &workgroup_size[1], sizeof(uint16_t));
+  memcpy(expected + 16, &workgroup_size[2], sizeof(uint16_t));
+  const uint16_t grid_dims = 3u;
+  memcpy(expected + 64, &grid_dims, sizeof(uint16_t));
+  const uint32_t dynamic_lds = 777u;
+  memcpy(expected + 120, &dynamic_lds, sizeof(uint32_t));
+  EXPECT_EQ(memcmp(kernargs, expected, sizeof(expected)), 0);
+
+  // Global offset (bytes 40..64) must stay zero, not garbage.
+  for (int i = 40; i < 64; ++i) EXPECT_EQ(kernargs[i], 0) << "byte " << i;
+}
+
+// A hand-written assembly kernel (e.g. MIOpen Winograd) declares only a partial
+// hidden block, so the region begins at an unaligned offset and none of the
+// synthesized fields are present. Initialization must accept the unaligned
+// region (no 8-byte-alignment rejection) and emplacement must zero the region
+// (leaving global offset 0) without writing any field that would corrupt the
+// kernel or the explicit arguments below the region.
+TEST(KernargLayoutTest, EmplacesPartialImplicitArgsAndAcceptsUnalignedRegion) {
+  std::vector<uint8_t> storage = AllocateStorage(0, 0);
+  auto* layout =
+      reinterpret_cast<iree_hal_amdgpu_kernarg_layout_t*>(storage.data());
+  const uint16_t kNone = IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE;
+  iree_hal_amdgpu_kernarg_layout_params_t params = {
+      /*.kernarg_byte_length=*/248,
+      /*.kernarg_alignment=*/8,
+      /*.constant_byte_length=*/0,
+      /*.implicit_args_byte_offset=*/201,
+      /*.binding_count=*/0,
+      /*.binding_slots=*/nullptr,
+      /*.constant_span_count=*/0,
+      /*.constant_spans=*/nullptr,
+      /*.implicit_args=*/
+      {
+          /*.block_count_offset=*/{kNone, kNone, kNone},
+          /*.group_size_offset=*/{kNone, kNone, kNone},
+          /*.grid_dims_offset=*/kNone,
+          /*.dynamic_lds_size_offset=*/kNone,
+      },
+  };
+  IREE_ASSERT_OK(iree_hal_amdgpu_kernarg_layout_initialize(
+      &params, storage.size(), layout));
+
+  uint8_t kernargs[248];
+  memset(kernargs, 0xCD, sizeof(kernargs));
+  const uint32_t workgroup_count[3] = {7u, 8u, 9u};
+  const uint16_t workgroup_size[3] = {1u, 1u, 1u};
+  iree_hal_amdgpu_kernarg_layout_emplace_implicit_args(
+      layout, workgroup_count, workgroup_size,
+      /*dynamic_workgroup_local_memory=*/42u, kernargs);
+
+  for (int i = 0; i < 201; ++i) {
+    EXPECT_EQ(kernargs[i], 0xCD) << "explicit byte " << i;
+  }
+  for (int i = 201; i < 248; ++i) {
+    EXPECT_EQ(kernargs[i], 0) << "implicit byte " << i;
+  }
+}
+
+// A declared implicit field whose [offset, offset+size) exceeds the kernarg
+// segment must be rejected (the base-alignment check was removed in favor of
+// per-field bounds validation).
+TEST(KernargLayoutTest, RejectsImplicitFieldBeyondKernargSegment) {
+  std::vector<uint8_t> storage = AllocateStorage(0, 0);
+  auto* layout =
+      reinterpret_cast<iree_hal_amdgpu_kernarg_layout_t*>(storage.data());
+  const uint16_t kNone = IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE;
+  iree_hal_amdgpu_kernarg_layout_params_t params = {
+      /*.kernarg_byte_length=*/128,
+      /*.kernarg_alignment=*/8,
+      /*.constant_byte_length=*/0,
+      /*.implicit_args_byte_offset=*/64,
+      /*.binding_count=*/0,
+      /*.binding_slots=*/nullptr,
+      /*.constant_span_count=*/0,
+      /*.constant_spans=*/nullptr,
+      /*.implicit_args=*/
+      {
+          /*.block_count_offset=*/{126, kNone, kNone},  // 126 + 4 > 128
+          /*.group_size_offset=*/{kNone, kNone, kNone},
+          /*.grid_dims_offset=*/kNone,
+          /*.dynamic_lds_size_offset=*/kNone,
+      },
+  };
+  EXPECT_THAT(Status(iree_hal_amdgpu_kernarg_layout_initialize(
+                  &params, storage.size(), layout)),
+              StatusIs(StatusCode::kOutOfRange));
+}
+
+// The device indirect-parameter patch writes hidden_block_count_x/y/z as a
+// contiguous uint32[3] anchored at the x field, so a kernel declaring the three
+// block_count fields at non-contiguous offsets (even when each is individually
+// in bounds) must be rejected at layout construction rather than silently
+// mispatched on device.
+TEST(KernargLayoutTest, RejectsNonContiguousBlockCount) {
+  std::vector<uint8_t> storage = AllocateStorage(0, 0);
+  auto* layout =
+      reinterpret_cast<iree_hal_amdgpu_kernarg_layout_t*>(storage.data());
+  const uint16_t kNone = IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE;
+  iree_hal_amdgpu_kernarg_layout_params_t params = {
+      /*.kernarg_byte_length=*/128,
+      /*.kernarg_alignment=*/8,
+      /*.constant_byte_length=*/0,
+      /*.implicit_args_byte_offset=*/0,
+      /*.binding_count=*/0,
+      /*.binding_slots=*/nullptr,
+      /*.constant_span_count=*/0,
+      /*.constant_spans=*/nullptr,
+      /*.implicit_args=*/
+      {
+          /*.block_count_offset=*/{0, 4, 16},  // z not contiguous with x/y
+          /*.group_size_offset=*/{kNone, kNone, kNone},
+          /*.grid_dims_offset=*/kNone,
+          /*.dynamic_lds_size_offset=*/kNone,
+      },
+  };
+  EXPECT_THAT(Status(iree_hal_amdgpu_kernarg_layout_initialize(
+                  &params, storage.size(), layout)),
+              StatusIs(StatusCode::kInvalidArgument));
+}
+
+// The device patch stores block_count as uint32 dwords, so block_count_x must
+// be 4-byte aligned. A kernel declaring contiguous, in-bounds block_count
+// fields anchored at a non-dword-aligned offset must be rejected at layout
+// construction (this is the alignment guarantee the removed 8-byte base-align
+// reject used to provide, now scoped to where the device actually stores).
+TEST(KernargLayoutTest, RejectsMisalignedBlockCount) {
+  std::vector<uint8_t> storage = AllocateStorage(0, 0);
+  auto* layout =
+      reinterpret_cast<iree_hal_amdgpu_kernarg_layout_t*>(storage.data());
+  const uint16_t kNone = IREE_HAL_AMDGPU_KERNARG_LAYOUT_IMPLICIT_ARGS_NONE;
+  iree_hal_amdgpu_kernarg_layout_params_t params = {
+      /*.kernarg_byte_length=*/128,
+      /*.kernarg_alignment=*/8,
+      /*.constant_byte_length=*/0,
+      /*.implicit_args_byte_offset=*/2,
+      /*.binding_count=*/0,
+      /*.binding_slots=*/nullptr,
+      /*.constant_span_count=*/0,
+      /*.constant_spans=*/nullptr,
+      /*.implicit_args=*/
+      {
+          // Contiguous and in bounds, but x is not 4-byte aligned.
+          /*.block_count_offset=*/{2, 6, 10},
+          /*.group_size_offset=*/{kNone, kNone, kNone},
+          /*.grid_dims_offset=*/kNone,
+          /*.dynamic_lds_size_offset=*/kNone,
+      },
+  };
+  EXPECT_THAT(Status(iree_hal_amdgpu_kernarg_layout_initialize(
+                  &params, storage.size(), layout)),
+              StatusIs(StatusCode::kInvalidArgument));
 }
 
 }  // namespace


### PR DESCRIPTION
## Problem
Hand-written GCN assembly kernels (for example MIOpen Winograd convolution) start their AMD hidden/implicit kernarg block at an unaligned base offset (observed at byte 201) and may declare only a partial subset of hidden fields. The AMDGPU kernarg layout rejected any implicit base that was not 8-byte aligned and wrote a fixed full implicit struct at the base offset, so these kernels failed to load — and the failed load surfaced downstream as a crash.

## Fix
Record each declared implicit field's own native offset during code-object analysis; validate every declared field's bounds; require hidden `block_count` to be either omitted or a contiguous `uint32[3]` with a 4-byte-aligned anchor (the device performs `uint32` dword stores); and emplace only the declared fields at their own offsets, zeroing the region first. The host dispatch path is rerouted so both the native and custom-direct paths source the native layout and anchor the indirect `block_count` write at the declared offset, skipping it when `block_count` is undeclared. Removes a device implicit-emplace helper left with no caller by the reroute.

## Test
Adds unit coverage for per-field offset recording (catching a transposed mapping), unexpected-size rejection, and the out-of-bounds, non-contiguous, and misaligned `block_count` rejections, plus full and partial/unaligned emplacement.

## Notes
Composes on top of the native-argument packing already on main. Opened as a draft: the amdgpu package builds under a pinned-ROCm-header configuration, and CI validates the full driver build and GPU dispatch path — a recommended gate before this leaves draft, as it was rebased across a recent rewrite of the dispatch-packet construction it interacts with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
