### PR TITLE
[Runtime] Split native Windows file paths

### DIFF
--- a/runtime/src/iree/base/internal/path.c
+++ b/runtime/src/iree/base/internal/path.c
@@ -179,16 +179,26 @@ iree_status_t iree_file_path_join(iree_string_view_t lhs,
 void iree_file_path_split(iree_string_view_t path,
                           iree_string_view_t* out_dirname,
                           iree_string_view_t* out_basename) {
-  iree_host_size_t pos = iree_string_view_find_last_of(
-      path, iree_make_cstring_view("/"), IREE_STRING_VIEW_NPOS);
+#if defined(IREE_PLATFORM_WINDOWS)
+  const iree_string_view_t separators = IREE_SV("/\\");
+#else
+  const iree_string_view_t separators = IREE_SV("/");
+#endif  // IREE_PLATFORM_WINDOWS
+  iree_host_size_t pos =
+      iree_string_view_find_last_of(path, separators, IREE_STRING_VIEW_NPOS);
+  bool is_root_separator = pos == 0;
+#if defined(IREE_PLATFORM_WINDOWS)
+  is_root_separator |= pos == 2 && path.size >= 3 && path.data[1] == ':';
+#endif  // IREE_PLATFORM_WINDOWS
   if (pos == IREE_STRING_VIEW_NPOS) {
-    // No '/' in path.
+    // No platform path separator in |path|.
     *out_dirname = iree_string_view_empty();
     *out_basename = path;
-  } else if (pos == 0) {
-    // Single leading '/' in path.
-    *out_dirname = iree_string_view_substr(path, 0, 1);
-    *out_basename = iree_string_view_substr(path, 1, IREE_STRING_VIEW_NPOS);
+  } else if (is_root_separator) {
+    // Preserve a leading POSIX separator or Windows drive root.
+    *out_dirname = iree_string_view_substr(path, 0, pos + 1);
+    *out_basename =
+        iree_string_view_substr(path, pos + 1, IREE_STRING_VIEW_NPOS);
   } else {
     *out_dirname = iree_string_view_substr(path, 0, pos);
     *out_basename =

--- a/runtime/src/iree/base/internal/path.h
+++ b/runtime/src/iree/base/internal/path.h
@@ -44,16 +44,17 @@ iree_status_t iree_file_path_join(iree_string_view_t lhs,
                                   iree_string_view_t rhs,
                                   iree_allocator_t allocator, char** out_path);
 
-// Splits |path| into the dirname and basename at the final `/`.
+// Splits |path| into the dirname and basename at the final platform path
+// separator. Windows paths accept both `/` and `\`.
 void iree_file_path_split(iree_string_view_t path,
                           iree_string_view_t* out_dirname,
                           iree_string_view_t* out_basename);
 
 // Gets the directory name component of a file |path| (everything before the
-// final `/`).
+// final platform path separator).
 iree_string_view_t iree_file_path_dirname(iree_string_view_t path);
 
-// Returns the part of the |path| after the final `/`.
+// Returns the part of the |path| after the final platform path separator.
 iree_string_view_t iree_file_path_basename(iree_string_view_t path);
 
 // Returns the parts of the basename of path, split on the final `.`.

--- a/runtime/src/iree/base/internal/path_test.cc
+++ b/runtime/src/iree/base/internal/path_test.cc
@@ -140,6 +140,16 @@ TEST(FilePathTest, DirnameDoubleSlash) {
   EXPECT_SV_EQ(iree_file_path_dirname(_SV("foo//")), _SV("foo/"));
 }
 
+#if defined(IREE_PLATFORM_WINDOWS)
+TEST(FilePathTest, DirnameWindowsNative) {
+  EXPECT_SV_EQ(iree_file_path_dirname(_SV("\\")), _SV("\\"));
+  EXPECT_SV_EQ(iree_file_path_dirname(_SV("\\foo")), _SV("\\"));
+  EXPECT_SV_EQ(iree_file_path_dirname(_SV("foo\\bar")), _SV("foo"));
+  EXPECT_SV_EQ(iree_file_path_dirname(_SV("C:\\foo")), _SV("C:\\"));
+  EXPECT_SV_EQ(iree_file_path_dirname(_SV("C:\\foo\\bar")), _SV("C:\\foo"));
+}
+#endif  // IREE_PLATFORM_WINDOWS
+
 TEST(FilePathTest, BasenameEmpty) {
   EXPECT_SV_EQ(iree_file_path_basename(_SV("")), _SV(""));
 }
@@ -162,6 +172,16 @@ TEST(FilePathTest, BasenameRelative) {
 TEST(FilePathTest, BasenameDoubleSlash) {
   EXPECT_SV_EQ(iree_file_path_basename(_SV("foo//")), _SV(""));
 }
+
+#if defined(IREE_PLATFORM_WINDOWS)
+TEST(FilePathTest, BasenameWindowsNative) {
+  EXPECT_SV_EQ(iree_file_path_basename(_SV("\\")), _SV(""));
+  EXPECT_SV_EQ(iree_file_path_basename(_SV("\\foo")), _SV("foo"));
+  EXPECT_SV_EQ(iree_file_path_basename(_SV("foo\\bar")), _SV("bar"));
+  EXPECT_SV_EQ(iree_file_path_basename(_SV("C:\\foo")), _SV("foo"));
+  EXPECT_SV_EQ(iree_file_path_basename(_SV("C:\\foo\\bar")), _SV("bar"));
+}
+#endif  // IREE_PLATFORM_WINDOWS
 
 TEST(FilePathTest, Stem) {
   EXPECT_SV_EQ(iree_file_path_stem(_SV("")), _SV(""));


### PR DESCRIPTION
Windows file APIs produce native `\` separators, while the shared path
decomposition helpers only recognized `/`. This made a canonicalized Windows
path indivisible: basename calls returned the entire absolute path and dirname
calls returned empty.

Recognize both path separators on Windows and preserve drive roots during
splitting. POSIX behavior remains unchanged. Platform-specific tests cover
rooted, relative, and drive-qualified native paths.

This restores the composition contract between path canonicalization and
decomposition. In particular, relative assets such as safetensors shards remain
anchored to the directory containing a Windows-native manifest.
