### PR TITLE
[Infra] Verify hooks against the pinned Lefthook CLI

### DIFF
--- a/build_tools/devtools/BUILD.bazel
+++ b/build_tools/devtools/BUILD.bazel
@@ -206,6 +206,7 @@ py_test(
         "aliases.py",
         "command_plan.py",
         "environment.py",
+        "hooks.py",
         "setup.py",
         "setup_test.py",
     ],

--- a/build_tools/devtools/cli_test.py
+++ b/build_tools/devtools/cli_test.py
@@ -16,7 +16,7 @@ from unittest import mock
 
 from build_tools.devtools import aliases, cli
 from build_tools.devtools import bazel as bazel_dev
-from build_tools.devtools.command_plan import WriteFileStep
+from build_tools.devtools.command_plan import CommandStep, WriteFileStep
 
 
 def normalized_plan_description(plan) -> str:
@@ -1188,6 +1188,17 @@ class CliTest(unittest.TestCase):
             "bazel precommit --profile ci --commit",
             step.content,
         )
+
+    def test_hook_verify_uses_supported_lefthook_file_option(self):
+        args = cli.parse_arguments(["bazel", "hook", "--verify"])
+
+        plan = args.handler(args)
+        step = plan.steps[-1]
+
+        self.assertIsInstance(step, CommandStep)
+        self.assertIn("--file", step.argv)
+        self.assertNotIn("--files", step.argv)
+        self.assertEqual(step.argv[step.argv.index("--file") + 1], "dev.py")
 
     def test_cmake_hook_defaults_to_default_profile(self):
         args = cli.parse_arguments(["cmake", "hook"])

--- a/build_tools/devtools/hooks.py
+++ b/build_tools/devtools/hooks.py
@@ -17,6 +17,27 @@ from build_tools.devtools.command_plan import (
 from build_tools.devtools.environment import REPO_ROOT, ToolEnvironment
 
 
+def lefthook_cli_compatibility_probe(tool_env: ToolEnvironment) -> CommandStep:
+    # Select a deliberately absent command so Lefthook parses the real
+    # invocation and repository config without executing presubmit work.
+    return CommandStep(
+        [
+            tool_env.tool("lefthook"),
+            "run",
+            "pre-commit",
+            "--file",
+            "dev.py",
+            "--command",
+            "__iree_cli_compatibility_probe__",
+            "--no-auto-install",
+            "--no-tty",
+        ],
+        cwd=REPO_ROOT,
+        env=tool_env.path_env(),
+        label="check Lefthook CLI compatibility",
+    )
+
+
 def hook_content(lane: str, profile: str, python_executable: str) -> str:
     if lane not in ("bazel", "cmake"):
         raise ValueError(f"unknown lane: {lane}")
@@ -86,7 +107,7 @@ def hook_plan(
     if verify:
         plan.add(
             CommandStep(
-                [tool_env.tool("lefthook"), "run", "pre-commit", "--files", "dev.py"],
+                [tool_env.tool("lefthook"), "run", "pre-commit", "--file", "dev.py"],
                 cwd=REPO_ROOT,
                 env=env,
                 label="verify selected hook policy",

--- a/build_tools/devtools/setup.py
+++ b/build_tools/devtools/setup.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from build_tools.devtools import hooks
 from build_tools.devtools.aliases import alias_steps
 from build_tools.devtools.command_plan import (
     CommandPlan,
@@ -59,6 +60,7 @@ def common_setup_plan(
             label="install Python developer tools",
         )
     )
+    plan.add(hooks.lefthook_cli_compatibility_probe(tool_env))
     platform_name = sys.platform if platform_name is None else platform_name
     if platform_name != "win32":
         plan.add(

--- a/build_tools/devtools/setup_test.py
+++ b/build_tools/devtools/setup_test.py
@@ -62,6 +62,24 @@ class SetupPlanTest(unittest.TestCase):
             self.assertTrue(
                 any("--group bazel" in step.describe() for step in commands)
             )
+            install_index = next(
+                index
+                for index, step in enumerate(commands)
+                if any(
+                    argument.endswith("requirements-dev.lock.txt")
+                    for argument in step.argv
+                )
+            )
+            probe_index, probe = next(
+                (index, step)
+                for index, step in enumerate(commands)
+                if step.label == "check Lefthook CLI compatibility"
+            )
+            self.assertLess(install_index, probe_index)
+            self.assertIn("--file", probe.argv)
+            self.assertNotIn("--files", probe.argv)
+            self.assertEqual(probe.argv[probe.argv.index("--file") + 1], "dev.py")
+            self.assertIn("__iree_cli_compatibility_probe__", probe.argv)
 
     def test_windows_venv_does_not_install_unusable_semgrep_package(self):
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
Hook verification now uses the singular `--file` option accepted by the repository-pinned Lefthook 2.1.9 binary.

Managed tool setup also runs the installed Lefthook against the real pre-commit configuration while selecting a deliberately absent command. This makes CLI or configuration drift fail during setup without executing presubmit work, and adds roughly a tenth of a second to setup.
