### PR TITLE
[Infra] Fix clang-tidy GCC actions and extend queue transfer CTS

### DIFF
--- a/build_tools/clang_tidy/clang_tidy.bzl
+++ b/build_tools/clang_tidy/clang_tidy.bzl
@@ -17,6 +17,13 @@ load(
     "iree_cc_source_files",
 )
 
+# clang-tidy always parses through Clang even when Bazel's configured compile
+# action uses GCC. Keep target semantic flags intact but omit GCC driver flags
+# that Clang rejects before it can analyze the source.
+_CLANG_TIDY_UNSUPPORTED_COMPILE_ARGS = {
+    "-fno-canonical-system-headers": None,
+}
+
 IreeClangTidyInfo = provider(
     doc = "clang-tidy artifacts collected from configured C/C++ targets.",
     fields = {
@@ -125,7 +132,11 @@ def _run_clang_tidy_action(ctx, target, cc_toolchain, feature_configuration, sou
     else:
         args.add("--warnings-as-errors=%s" % ctx.attr._warnings_as_errors)
     args.add("--")
-    args.add_all(compile_command.compile_args)
+    args.add_all([
+        arg
+        for arg in compile_command.compile_args
+        if arg not in _CLANG_TIDY_UNSUPPORTED_COMPILE_ARGS
+    ])
 
     compilation_context = target[CcInfo].compilation_context
     inputs = depset(

--- a/runtime/src/iree/hal/cts/queue/queue_transfer_test.cc
+++ b/runtime/src/iree/hal/cts/queue/queue_transfer_test.cc
@@ -392,6 +392,7 @@ TEST_P(QueueTransferTest, UpdateSizeAndAlignmentClasses) {
       {/*.source_offset=*/5, /*.target_offset=*/4, /*.update_length=*/8},
       {/*.source_offset=*/1, /*.target_offset=*/1, /*.update_length=*/4},
       {/*.source_offset=*/0, /*.target_offset=*/0, /*.update_length=*/16},
+      {/*.source_offset=*/7, /*.target_offset=*/9, /*.update_length=*/528},
   };
 
   for (const UpdateCase& test_case : cases) {


### PR DESCRIPTION
Make clang-tidy analysis tolerate GCC-derived compile actions and extend direct HAL queue-transfer coverage to a non-power-of-two byte count.

Clang-tidy parses configured actions through Clang even when the selected target toolchain uses GCC. Filtering the GCC-only canonical-system-header driver flag at the analysis boundary prevents those actions from failing before checks run while preserving target-semantic options.

The queue-transfer matrix now includes a 528-byte operation with independent source and target offsets. Its existing expected-buffer comparison checks payload integrity and both guard regions through the normal direct queue API.