### PR TITLE
[HIP] Anchor event records to the timeline that carries them

### DIFF
--- a/libhrx/cts/BUILD.bazel
+++ b/libhrx/cts/BUILD.bazel
@@ -143,6 +143,24 @@ hrx_cts_test(
 )
 
 hrx_cc_test(
+    name = "hip_event_test",
+    srcs = ["tests/hip/event_test.cpp"],
+    data = ["//libhrx/src/binding/hip:amdhip64"],
+    env = {
+        "HRX_TEST_LIBAMDHIP64": "$(location //libhrx/src/binding/hip:amdhip64)",
+    },
+    sanitizer_suppressions = hsa_suppressions,
+    tags = AMD_GPU_CTS_TAGS,
+    target_compatible_with = _LINUX_COMPATIBILITY,
+    deps = [
+        "//build_tools:dl",
+        "//libhrx/src/binding/hip:launch_params",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+hrx_cc_test(
     name = "hip_module_execution_test",
     srcs = [
         "core/amdgpu_executable_test_data.hpp",

--- a/libhrx/cts/CMakeLists.txt
+++ b/libhrx/cts/CMakeLists.txt
@@ -260,6 +260,30 @@ hrx_cc_test(
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 iree_cc_test(
   NAME
+    hip_event_test
+  SRCS
+    "tests/hip/event_test.cpp"
+  DATA
+    libhrx::src::binding::hip::amdhip64
+  DEPS
+    ${CMAKE_DL_LIBS}
+    iree::testing::gtest
+    iree::testing::gtest_main
+    libhrx::src::binding::hip::launch_params
+    libhrx_defs
+  ENV
+    "HRX_TEST_LIBAMDHIP64=$<TARGET_FILE:libhrx::src::binding::hip::amdhip64>"
+  LABELS
+    "runtime-resource=amd-gpu"
+  SANITIZER_SUPPRESSIONS
+    lsan
+    hsa
+)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+iree_cc_test(
+  NAME
     hip_module_execution_test
   SRCS
     "core/amdgpu_executable_test_data.hpp"

--- a/libhrx/cts/tests/hip/event_test.cpp
+++ b/libhrx/cts/tests/hip/event_test.cpp
@@ -70,17 +70,13 @@ using HipGraphLaunchFn = hipError_t (*)(hipGraphExec_t graph_exec,
 using HipGraphExecDestroyFn = hipError_t (*)(hipGraphExec_t graph_exec);
 
 // Host callback that parks a stream timeline until the test thread releases it.
-// Every wait in these tests is a readiness contract on these flags, so no step
-// depends on wall-clock time or on how fast the device drains.
 struct StreamGate {
-  // Set by the callback once the queue thread running host callbacks has
-  // entered it.
+  // Set by the callback once it has started running.
   std::atomic<bool> entered{false};
   // Set by the test thread to let the callback return.
   std::atomic<bool> released{false};
-  // Set by the callback as its final store before it returns. The callback
-  // writes through a pointer into the frame that enqueued it, so that frame
-  // must not be left until this is set.
+  // Set by the callback as its final store. The callback writes through a
+  // pointer into the frame that enqueued it, so that frame must outlive this.
   std::atomic<bool> finished{false};
 };
 
@@ -94,16 +90,14 @@ void GateHostFunction(void* user_data) {
 }
 
 // Host callback that samples whether a gate callback had already finished when
-// it ran, which is how work enqueued behind a timeline point observes that the
-// work in front of that point really did drain first.
+// it ran.
 struct StreamMarker {
-  // Gate sampled by the callback. Borrowed from the frame that enqueues the
-  // callback and set before the enqueue.
+  // Gate sampled by the callback, borrowed from the enqueuing frame.
   const StreamGate* gate = nullptr;
   // Whether |gate| had finished when the callback sampled it. Only meaningful
   // once |finished| is set.
   std::atomic<bool> saw_gate_finished{false};
-  // Set by the callback as its final store before it returns. See StreamGate.
+  // Set by the callback as its final store. See StreamGate.
   std::atomic<bool> finished{false};
 };
 
@@ -115,9 +109,7 @@ void MarkerHostFunction(void* user_data) {
   marker->finished.store(true, std::memory_order_release);
 }
 
-// Host callback that only records that it ran, for nodes that exist to put
-// something behind another node rather than to observe ordering. |user_data| is
-// the flag to set and is the callback's final store, as with the others here.
+// Host callback whose only action is to store true through |user_data|.
 void RanHostFunction(void* user_data) {
   static_cast<std::atomic<bool>*>(user_data)->store(true,
                                                     std::memory_order_release);
@@ -125,13 +117,7 @@ void RanHostFunction(void* user_data) {
 
 // Keeps the enclosing frame alive until every host callback registered with it
 // has returned, releasing the registered gate first so a parked callback can
-// get there. Host callbacks run on a queue thread and write through pointers
-// into the frame that enqueued them, so releasing the gate is not enough: the
-// callback is still inside its stores when the test thread observes the
-// release, and a test body that returns early (a failed assertion, most of all)
-// would leave those stores aimed at a dead frame. Callbacks are registered
-// immediately after their enqueue succeeds, so a callback that never reached a
-// queue is never awaited.
+// get there. Callbacks are registered only once their enqueue has succeeded.
 class ScopedHostCallbacks {
  public:
   ScopedHostCallbacks() = default;
@@ -147,9 +133,7 @@ class ScopedHostCallbacks {
   }
 
   // Registers a parked gate callback whose enqueue has succeeded. Only one gate
-  // may be registered: a second registration would displace the first, leaving
-  // nothing able to release it, and the destructor would then spin forever
-  // waiting for a callback that can never return.
+  // may be registered; nothing could release a displaced one.
   void AddGate(StreamGate* gate) {
     ASSERT_EQ(nullptr, gate_) << "a gate is already registered";
     gate_ = gate;
@@ -169,22 +153,16 @@ class ScopedHostCallbacks {
   }
 
  private:
-  // Gate released before the destructor waits, or null when none is
-  // registered. Borrowed from the enclosing frame.
+  // Gate released before the destructor waits, or null when none is registered.
+  // Borrowed from the enclosing frame.
   StreamGate* gate_ = nullptr;
-  // Completion flags of the callbacks registered so far, all borrowed from the
-  // enclosing frame.
+  // Completion flags of the registered callbacks, borrowed from that frame.
   std::vector<const std::atomic<bool>*> pending_;
 };
 
 class HipEventTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    // The shim under test is a build artifact this test declares a dependency
-    // on and it names no ROCm library at link time, so it loads on a machine
-    // with no device just as well as on one with a device. A load failure is
-    // therefore a regression in the shim rather than a property of the machine,
-    // which is why it fails here instead of skipping.
     library_ = dlopen(CandidateLibPath(), RTLD_NOW | RTLD_LOCAL);
     ASSERT_NE(nullptr, library_)
         << "cannot dlopen " << CandidateLibPath() << ": " << dlerror();
@@ -256,8 +234,6 @@ class HipEventTest : public ::testing::Test {
     ASSERT_NE(nullptr, graph_launch_);
     ASSERT_NE(nullptr, graph_exec_destroy_);
 
-    // Only the absence of a device is a reason to skip: any other failure is a
-    // shim regression, and skipping on it would report this file as passing.
     const hipError_t init_result = init_(/*flags=*/0);
     if (init_result == hipErrorNoDevice) {
       GTEST_SKIP() << "no HIP device available";
@@ -266,12 +242,8 @@ class HipEventTest : public ::testing::Test {
   }
 
   // Destroys the handles the body created, in reverse order of the dependencies
-  // between handle kinds. Destroying here rather than at the end of each body
-  // is what keeps a failed assertion - which leaves its body immediately - from
-  // adding leak-checker noise on top of the failure it is already reporting.
-  // The body's own scope guards have joined every host callback by the time
-  // this runs, so no stream is destroyed while a callback is still parked on
-  // it.
+  // between handle kinds, so a body that left early on a failed assertion does
+  // not also report leaks.
   void TearDown() override {
     for (auto it = graph_execs_.rbegin(); it != graph_execs_.rend(); ++it) {
       EXPECT_EQ(hipSuccess, graph_exec_destroy_(*it));
@@ -295,8 +267,7 @@ class HipEventTest : public ::testing::Test {
     return stream;
   }
 
-  // Destroys a stream created through CreateStream ahead of TearDown, dropping
-  // it from the fixture's list so it is not destroyed twice.
+  // Destroys a stream the fixture owns ahead of TearDown.
   void DestroyStream(hipStream_t stream) {
     streams_.erase(std::remove(streams_.begin(), streams_.end(), stream),
                    streams_.end());
@@ -320,15 +291,12 @@ class HipEventTest : public ::testing::Test {
   }
 
   // Hands a graph the body obtained some other way - ending a stream capture,
-  // for one - to the fixture so TearDown destroys it. Ignores null so a caller
-  // can hand over the result of a call that failed and let its own assertion
-  // report the failure.
+  // for one - to the fixture so TearDown destroys it. Ignores null.
   void TrackGraph(hipGraph_t graph) {
     if (graph) graphs_.push_back(graph);
   }
 
-  // Destroys a graph the fixture owns ahead of TearDown, dropping it from the
-  // fixture's list so it is not destroyed twice.
+  // Destroys a graph the fixture owns ahead of TearDown.
   void DestroyGraph(hipGraph_t graph) {
     graphs_.erase(std::remove(graphs_.begin(), graphs_.end(), graph),
                   graphs_.end());
@@ -345,8 +313,7 @@ class HipEventTest : public ::testing::Test {
     return graph_exec;
   }
 
-  // Destroys an executable created through InstantiateGraph ahead of TearDown,
-  // dropping it from the fixture's list so it is not destroyed twice.
+  // Destroys an executable the fixture owns ahead of TearDown.
   void DestroyGraphExec(hipGraphExec_t graph_exec) {
     graph_execs_.erase(
         std::remove(graph_execs_.begin(), graph_execs_.end(), graph_exec),
@@ -364,9 +331,8 @@ class HipEventTest : public ::testing::Test {
     ASSERT_EQ(hipSuccess, stream_synchronize_(stream));
   }
 
-  // Enqueues |gate| on |stream|, registers it with |callbacks| so it can never
-  // outlive the caller's frame, and returns once the callback is running, at
-  // which point the stream provably holds unfinished work.
+  // Enqueues |gate| on |stream|, registers it with |callbacks|, and returns
+  // once the callback is running and the stream provably holds unfinished work.
   void EnqueueGateAndWaitUntilEntered(hipStream_t stream, StreamGate* gate,
                                       ScopedHostCallbacks* callbacks) {
     ASSERT_EQ(hipSuccess, launch_host_func_(stream, &GateHostFunction, gate));
@@ -437,9 +403,7 @@ class HipEventTest : public ::testing::Test {
 
 // A record marks a point on the recording stream's timeline, so re-recording an
 // event on a stream whose timeline is behind still names a point that stream
-// has not reached. Deriving the target from a timeline the event carries across
-// streams instead lets a record name a value that is already in the past, which
-// reports work as complete before any of it has run.
+// has not reached.
 TEST_F(HipEventTest, CrossStreamRerecordDoesNotReportStaleCompletion) {
   hipStream_t stream_a = CreateStream();
   ASSERT_NE(nullptr, stream_a);
@@ -469,18 +433,9 @@ TEST_F(HipEventTest, CrossStreamRerecordDoesNotReportStaleCompletion) {
 }
 
 // Recording a shared event on a second stream must not make that stream wait
-// for the first one. Nothing was submitted between the two records, so the
-// streams are independent, and the second one drains while the first is still
-// parked in its gate.
-//
-// Any implementation in which both records signal one timeline the event
-// carries across streams chains the second stream behind the first, whether it
-// orders the two records explicitly or the queue holds the later submission
-// because an earlier one is already due to signal a higher value on the same
-// timeline. Either way this test blocks in hipStreamSynchronize until the outer
-// harness kills it: the gate is deliberately still held at that point, so there
-// is no wall-clock threshold here that a slow machine could turn into a false
-// pass.
+// for the first one: nothing was submitted between the two records, so the
+// second stream drains while the first is still parked in its gate. A stream
+// chained to the other one hangs in hipStreamSynchronize.
 TEST_F(HipEventTest, CrossStreamRerecordDoesNotChainTheNewStreamToTheOldOne) {
   hipStream_t stream_a = CreateStream();
   ASSERT_NE(nullptr, stream_a);
@@ -498,9 +453,8 @@ TEST_F(HipEventTest, CrossStreamRerecordDoesNotChainTheNewStreamToTheOldOne) {
   ASSERT_EQ(hipSuccess, event_record_(event, stream_b));
 
   EXPECT_EQ(hipSuccess, stream_synchronize_(stream_b));
-  // The event names the last record, which is the one on the stream that just
-  // drained, so waiting on the event must not reach back to the parked stream
-  // either.
+  // The event names the last record, on the stream that just drained, so
+  // waiting on it must not reach back to the parked stream either.
   EXPECT_EQ(hipSuccess, event_query_(event));
   EXPECT_EQ(hipSuccess, event_synchronize_(event));
   EXPECT_FALSE(gate.finished.load(std::memory_order_acquire))
@@ -512,16 +466,8 @@ TEST_F(HipEventTest, CrossStreamRerecordDoesNotChainTheNewStreamToTheOldOne) {
 
 // Destroying the stream an event was recorded on has to leave the event
 // queryable, and re-recording it elsewhere has to let go of what it was
-// holding. The leak checker and AddressSanitizer are what watch the second
-// half: a reference kept too long shows up as a leak, and one dropped too early
-// as a use after free.
-//
-// The stream object outlives hipStreamDestroy here, because the event holds it
-// for the capture state a wait on a captured event picks up. What this pins is
-// therefore the handle-level contract and the lifetime of that reference - the
-// re-record below releases a stream whose handle is already gone - rather than
-// the event's reference to the timeline itself. The graph executable case is
-// where that reference is the only thing holding the timeline up.
+// holding. This pins the handle-level contract; the event's reference to the
+// timeline itself is what the graph executable case below covers.
 TEST_F(HipEventTest, EventStaysUsableAfterItsRecordingStreamHandleIsDestroyed) {
   hipStream_t stream_a = CreateStream();
   ASSERT_NE(nullptr, stream_a);
@@ -540,20 +486,18 @@ TEST_F(HipEventTest, EventStaysUsableAfterItsRecordingStreamHandleIsDestroyed) {
 }
 
 // A record node in the middle of a graph marks a point on a timeline the graph
-// executable owns and the caller never sees, and a graph launch deliberately
-// does not adopt the launching stream. Nothing but the event's own reference to
-// that timeline is left once the executable is destroyed, which is what this
-// pins: the event has to stay queryable afterwards, and re-recording it
-// elsewhere has to let the timeline go.
+// executable owns, and the event's own reference is all that is left once the
+// executable is destroyed: the event has to stay queryable afterwards, and
+// re-recording it elsewhere has to let the timeline go.
 TEST_F(HipEventTest, EventStaysUsableAfterTheRecordingGraphExecutableIsGone) {
   hipStream_t stream = CreateStream();
   ASSERT_NE(nullptr, stream);
   hipEvent_t event = CreateEvent();
   ASSERT_NE(nullptr, event);
 
-  // The node behind the record node is what puts the record in a partition of
-  // its own; without it the record would land in the final partition and name
-  // the stream timeline, which outlives the executable on its own.
+  // The node behind the record node puts the record in a partition of its own;
+  // otherwise it would land in the final partition and name the stream
+  // timeline, which outlives the executable.
   hipGraph_t graph = CreateGraph();
   ASSERT_NE(nullptr, graph);
   hipGraphNode_t record_node = nullptr;
@@ -589,15 +533,9 @@ TEST_F(HipEventTest, EventStaysUsableAfterTheRecordingGraphExecutableIsGone) {
 }
 
 // A cross-stream re-record must leave the event usable as a dependency for
-// another stream: the point the record names has to be one the recording stream
-// actually reaches, and work gated on it through hipStreamWaitEvent has to run
-// only after that stream drains. A record naming a point nothing will ever
-// reach shows up here as the stream_c synchronize never returning.
-//
-// This is a contract check on correct behavior rather than a discriminator for
-// the stale-target defect the first test covers. With a stale target the gated
-// callback still could not run early, because both callbacks execute on the one
-// queue thread that the parked gate is occupying.
+// another stream: work gated on it through hipStreamWaitEvent has to run only
+// after the recording stream drains. This is a contract check, not a
+// discriminator - the gated callback shares a queue thread with the gate.
 TEST_F(HipEventTest, CrossStreamRerecordStaysUsableAsStreamWaitDependency) {
   hipStream_t stream_a = CreateStream();
   ASSERT_NE(nullptr, stream_a);
@@ -634,18 +572,10 @@ TEST_F(HipEventTest, CrossStreamRerecordStaysUsableAsStreamWaitDependency) {
          "recorded the event drained";
 }
 
-// Waiting on an event does not release a stream from its own ordering. The wait
-// is submitted behind work that is still parked and its completion advances the
-// stream timeline, so a wait that does not also wait for the work in front of
-// it would let the stream report itself drained while that work is still
-// running.
-//
-// This is a contract check rather than a discriminator for the missing wait on
-// its own: the queue independently holds a submission that signals a timeline
-// value behind an earlier submission signaling a lower value on the same
-// timeline, which covers for the missing dependency here. It fails if either
-// mechanism regresses, and it is the only thing standing behind the ordering if
-// the queue ever stops serializing signals it does not have to.
+// Waiting on an event does not release a stream from its own ordering: the wait
+// advances the stream timeline, so it must complete only once the work in front
+// of it has run. This is a contract check, not a discriminator - the queue also
+// serializes signals on one timeline, which covers the same ordering.
 TEST_F(HipEventTest, StreamWaitEventStaysOrderedBehindPriorStreamWork) {
   hipStream_t stream_a = CreateStream();
   ASSERT_NE(nullptr, stream_a);
@@ -673,12 +603,9 @@ TEST_F(HipEventTest, StreamWaitEventStaysOrderedBehindPriorStreamWork) {
 }
 
 // Both halves of a stream event wait can be absent at once: a stream that has
-// never submitted has nothing behind it to stay ordered against, and an event
-// with no submitted record has no point to wait for. The barrier that carries
-// the wait goes out with an empty wait list and still has to be accepted and
-// still has to signal the stream, which is what the synchronize proves - a
-// barrier that was never submitted leaves the stream naming a value nothing
-// will reach, and the synchronize would not return.
+// never submitted has nothing behind it, and an event with no submitted record
+// has no point to wait for. The barrier goes out with an empty wait list and
+// still has to be accepted and still has to signal the stream.
 TEST_F(HipEventTest, StreamWaitOnANeverRecordedEventDropsBothWaits) {
   hipStream_t stream = CreateStream();
   ASSERT_NE(nullptr, stream);
@@ -701,9 +628,7 @@ TEST_F(HipEventTest, StreamWaitOnANeverRecordedEventDropsBothWaits) {
 
 // A graph event wait node on an event with no submitted record has nothing to
 // wait for, so the wait is dropped and the block goes out with whatever waits
-// the schedule gave it. The node behind it still has to run: a block that
-// instead waited on value zero of a timeline it never got would either never be
-// submitted or never be satisfied, and the synchronize below would not return.
+// the schedule gave it. The node behind it still has to run.
 TEST_F(HipEventTest, GraphEventWaitNodeOnANeverRecordedEventDropsTheWait) {
   hipStream_t stream = CreateStream();
   ASSERT_NE(nullptr, stream);
@@ -737,25 +662,15 @@ TEST_F(HipEventTest, GraphEventWaitNodeOnANeverRecordedEventDropsTheWait) {
 }
 
 // A graph whose only node records an event marks the point the launch itself
-// reaches. Launching it onto a parked stream cannot get there, so the event has
-// to read as not ready until the stream drains; a launch that left the event
-// naming a point one of its earlier records already reached would read as
-// complete here, and one that named a point the launch never signals would hang
-// in the synchronize below.
-//
-// What no test in this file reaches is what the event does when a block fails
-// to submit. Everything a block is submitted with comes from the graph and the
-// stream rather than from the caller, so nothing reachable through the HIP
-// surface makes the queue reject one; covering the rollback needs a HAL device
-// that can be told to fail, which is a seam below this layer.
+// reaches, so launching it onto a parked stream leaves the event not ready
+// until that stream drains.
 TEST_F(HipEventTest, GraphRecordNodeAtTheEndOfAGraphMarksTheLaunchPoint) {
   hipStream_t stream = CreateStream();
   ASSERT_NE(nullptr, stream);
   hipEvent_t event = CreateEvent();
   ASSERT_NE(nullptr, event);
 
-  // Stream records and graph records have to interleave on one event: the point
-  // a stream record leaves behind must not confuse the graph record after it.
+  // Stream records and graph records have to interleave on one event.
   ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream, /*count=*/2));
 
   hipGraph_t graph = CreateGraph();
@@ -793,11 +708,9 @@ TEST_F(HipEventTest, GraphRecordNodeAtTheEndOfAGraphMarksTheLaunchPoint) {
 }
 
 // A record node with a node after it marks the point that node reaches rather
-// than the point the whole launch reaches, and those are different timelines in
-// the implementation: the launch signals the stream, while a node in the middle
-// signals one of the executable's internal semaphores. The event still must not
-// read as complete while the launch is parked, and the node after the record
-// node still has to run behind everything in front of the launch.
+// than the point the whole launch reaches: the launch signals the stream, while
+// a node in the middle signals one of the executable's internal semaphores. The
+// event still must not read as complete while the launch is parked.
 TEST_F(HipEventTest, GraphRecordNodeInsideAGraphMarksTheNodePoint) {
   hipStream_t stream = CreateStream();
   ASSERT_NE(nullptr, stream);
@@ -845,10 +758,8 @@ TEST_F(HipEventTest, GraphRecordNodeInsideAGraphMarksTheNodePoint) {
 }
 
 // Elapsed time reads the timestamp a record leaves behind, which is adopted
-// with the recorded point and only once the submission carrying it has been
-// accepted. An event with no submitted record therefore has no timestamp and no
-// interval to report, and two that do have one span a non-negative interval,
-// since the stop event is recorded after the start event returns.
+// only once the submission carrying it has been accepted, so an event with no
+// submitted record has no interval to report.
 TEST_F(HipEventTest, ElapsedTimeNeedsBothEventsRecorded) {
   hipStream_t stream = CreateStream();
   ASSERT_NE(nullptr, stream);
@@ -871,8 +782,7 @@ TEST_F(HipEventTest, ElapsedTimeNeedsBothEventsRecorded) {
 }
 
 // Both events have to have completed before an interval means anything, so a
-// stop event whose record is still parked behind work on its stream reports as
-// not ready rather than reporting the interval up to the point it was issued.
+// stop event whose record is still parked reports as not ready.
 TEST_F(HipEventTest, ElapsedTimeIsNotReadyWhileAnEventIsOutstanding) {
   hipStream_t stream_a = CreateStream();
   ASSERT_NE(nullptr, stream_a);
@@ -903,11 +813,7 @@ TEST_F(HipEventTest, ElapsedTimeIsNotReadyWhileAnEventIsOutstanding) {
 
 // A record issued while its stream is capturing produces neither a submission
 // nor a graph node, only a snapshot of the capture frontier, so it leaves the
-// event with no point and no timestamp. There is no moment for a timestamp to
-// describe: the graph the capture builds has not run and may never run. Elapsed
-// time over such an event is therefore rejected the same way it rejects an
-// event that was never recorded, rather than reporting the host-side gap
-// between two calls made while building a graph.
+// event with no timestamp and no interval to report.
 TEST_F(HipEventTest, ElapsedTimeRejectsEventsRecordedOnlyDuringCapture) {
   hipStream_t stream = CreateStream();
   ASSERT_NE(nullptr, stream);

--- a/libhrx/cts/tests/hip/event_test.cpp
+++ b/libhrx/cts/tests/hip/event_test.cpp
@@ -41,6 +41,8 @@ using HipStreamBeginCaptureFn = hipError_t (*)(hipStream_t stream,
 using HipStreamEndCaptureFn = hipError_t (*)(hipStream_t stream,
                                              hipGraph_t* graph);
 using HipEventCreateFn = hipError_t (*)(hipEvent_t* event);
+using HipEventCreateWithFlagsFn = hipError_t (*)(hipEvent_t* event,
+                                                 unsigned int flags);
 using HipEventDestroyFn = hipError_t (*)(hipEvent_t event);
 using HipEventRecordFn = hipError_t (*)(hipEvent_t event, hipStream_t stream);
 using HipEventQueryFn = hipError_t (*)(hipEvent_t event);
@@ -187,6 +189,8 @@ class HipEventTest : public ::testing::Test {
         library_, "hipStreamEndCapture");
     hip_.event_create =
         ResolveHipSymbol<HipEventCreateFn>(library_, "hipEventCreate");
+    hip_.event_create_with_flags = ResolveHipSymbol<HipEventCreateWithFlagsFn>(
+        library_, "hipEventCreateWithFlags");
     hip_.event_destroy =
         ResolveHipSymbol<HipEventDestroyFn>(library_, "hipEventDestroy");
     hip_.event_record =
@@ -230,6 +234,7 @@ class HipEventTest : public ::testing::Test {
     ASSERT_NE(nullptr, hip_.stream_begin_capture);
     ASSERT_NE(nullptr, hip_.stream_end_capture);
     ASSERT_NE(nullptr, hip_.event_create);
+    ASSERT_NE(nullptr, hip_.event_create_with_flags);
     ASSERT_NE(nullptr, hip_.event_destroy);
     ASSERT_NE(nullptr, hip_.event_record);
     ASSERT_NE(nullptr, hip_.event_query);
@@ -291,6 +296,14 @@ class HipEventTest : public ::testing::Test {
   hipEvent_t CreateEvent() {
     hipEvent_t event = nullptr;
     EXPECT_EQ(hipSuccess, hip_.event_create(&event));
+    if (event) events_.push_back(event);
+    return event;
+  }
+
+  // Creates an event carrying |flags|, owned by the fixture.
+  hipEvent_t CreateEventWithFlags(unsigned int flags) {
+    hipEvent_t event = nullptr;
+    EXPECT_EQ(hipSuccess, hip_.event_create_with_flags(&event, flags));
     if (event) events_.push_back(event);
     return event;
   }
@@ -414,6 +427,7 @@ class HipEventTest : public ::testing::Test {
     HipStreamBeginCaptureFn stream_begin_capture;
     HipStreamEndCaptureFn stream_end_capture;
     HipEventCreateFn event_create;
+    HipEventCreateWithFlagsFn event_create_with_flags;
     HipEventDestroyFn event_destroy;
     HipEventRecordFn event_record;
     HipEventQueryFn event_query;
@@ -840,6 +854,45 @@ TEST_F(HipEventTest, ElapsedTimeRejectsEventsRecordedOnlyDuringCapture) {
   float ms = -1.0f;
   EXPECT_EQ(hipErrorInvalidHandle, hip_.event_elapsed_time(&ms, start, stop))
       << "an interval was reported for records that were never submitted";
+}
+
+TEST_F(HipEventTest, ElapsedTimeNeedsTimingEnabledOnBothEvents) {
+  hipStream_t stream = CreateStream();
+  ASSERT_NE(nullptr, stream);
+  hipEvent_t timed_start = CreateEvent();
+  ASSERT_NE(nullptr, timed_start);
+  hipEvent_t timed_stop = CreateEvent();
+  ASSERT_NE(nullptr, timed_stop);
+  hipEvent_t untimed_start = CreateEventWithFlags(hipEventDisableTiming);
+  ASSERT_NE(nullptr, untimed_start);
+  hipEvent_t untimed_stop = CreateEventWithFlags(hipEventDisableTiming);
+  ASSERT_NE(nullptr, untimed_stop);
+
+  // Every event is left with a submitted record that has been reached, and the
+  // pairs below are drawn from that one ordered run, so the timing flag is the
+  // only thing separating a measured interval from a rejected one.
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(timed_start, stream,
+                                               /*count=*/1));
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(untimed_start, stream,
+                                               /*count=*/1));
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(untimed_stop, stream,
+                                               /*count=*/1));
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(timed_stop, stream,
+                                               /*count=*/1));
+
+  float ms = -1.0f;
+  EXPECT_EQ(hipSuccess, hip_.event_elapsed_time(&ms, timed_start, timed_stop));
+  EXPECT_GE(ms, 0.0f);
+
+  EXPECT_EQ(hipErrorInvalidHandle,
+            hip_.event_elapsed_time(&ms, untimed_start, untimed_stop))
+      << "an interval was reported for two events with timing disabled";
+  EXPECT_EQ(hipErrorInvalidHandle,
+            hip_.event_elapsed_time(&ms, untimed_start, timed_stop))
+      << "an interval was reported for a start with timing disabled";
+  EXPECT_EQ(hipErrorInvalidHandle,
+            hip_.event_elapsed_time(&ms, timed_start, untimed_stop))
+      << "an interval was reported for a stop with timing disabled";
 }
 
 // Bytes taken from the default pool by the reuse tests below. A pending free is

--- a/libhrx/cts/tests/hip/event_test.cpp
+++ b/libhrx/cts/tests/hip/event_test.cpp
@@ -6,7 +6,9 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstddef>
 #include <cstdlib>
+#include <thread>
 #include <vector>
 
 #include "binding/hip/api.h"
@@ -47,6 +49,9 @@ using HipEventElapsedTimeFn = hipError_t (*)(float* ms, hipEvent_t start,
                                              hipEvent_t stop);
 using HipLaunchHostFuncFn = hipError_t (*)(hipStream_t stream, hipHostFn_t fn,
                                            void* user_data);
+using HipMallocAsyncFn = hipError_t (*)(void** device_ptr, size_t size,
+                                        hipStream_t stream);
+using HipFreeAsyncFn = hipError_t (*)(void* device_ptr, hipStream_t stream);
 using HipGraphCreateFn = hipError_t (*)(hipGraph_t* graph, unsigned int flags);
 using HipGraphDestroyFn = hipError_t (*)(hipGraph_t graph);
 using HipGraphAddEventRecordNodeFn = hipError_t (*)(
@@ -194,6 +199,10 @@ class HipEventTest : public ::testing::Test {
         library_, "hipEventElapsedTime");
     hip_.launch_host_func =
         ResolveHipSymbol<HipLaunchHostFuncFn>(library_, "hipLaunchHostFunc");
+    hip_.malloc_async =
+        ResolveHipSymbol<HipMallocAsyncFn>(library_, "hipMallocAsync");
+    hip_.free_async =
+        ResolveHipSymbol<HipFreeAsyncFn>(library_, "hipFreeAsync");
     hip_.graph_create =
         ResolveHipSymbol<HipGraphCreateFn>(library_, "hipGraphCreate");
     hip_.graph_destroy =
@@ -227,6 +236,8 @@ class HipEventTest : public ::testing::Test {
     ASSERT_NE(nullptr, hip_.event_synchronize);
     ASSERT_NE(nullptr, hip_.event_elapsed_time);
     ASSERT_NE(nullptr, hip_.launch_host_func);
+    ASSERT_NE(nullptr, hip_.malloc_async);
+    ASSERT_NE(nullptr, hip_.free_async);
     ASSERT_NE(nullptr, hip_.graph_create);
     ASSERT_NE(nullptr, hip_.graph_destroy);
     ASSERT_NE(nullptr, hip_.graph_add_event_record_node);
@@ -333,6 +344,49 @@ class HipEventTest : public ::testing::Test {
     ASSERT_EQ(hipSuccess, hip_.stream_synchronize(stream));
   }
 
+  // Instantiates a graph whose only node records |event|, so the record is the
+  // launch's last block and its point lands on the launching stream timeline.
+  hipGraphExec_t InstantiateGraphRecordingAtTheEnd(hipEvent_t event) {
+    hipGraph_t graph = CreateGraph();
+    EXPECT_NE(nullptr, graph);
+    if (!graph) return nullptr;
+    hipGraphNode_t record_node = nullptr;
+    EXPECT_EQ(hipSuccess, hip_.graph_add_event_record_node(
+                              &record_node, graph, /*dependencies=*/nullptr,
+                              /*dependency_count=*/0, event));
+    return InstantiateGraph(graph);
+  }
+
+  // Instantiates a graph that records |event| and then runs a host node, which
+  // puts the record in a partition of its own so its point lands on a timeline
+  // internal to the launch. The host node stores |host_node_ran|, which must
+  // outlive every launch of the returned executable.
+  hipGraphExec_t InstantiateGraphRecordingBeforeAHostNode(
+      hipEvent_t event, std::atomic<bool>* host_node_ran) {
+    hipGraph_t graph = CreateGraph();
+    EXPECT_NE(nullptr, graph);
+    if (!graph) return nullptr;
+    hipGraphNode_t record_node = nullptr;
+    EXPECT_EQ(hipSuccess, hip_.graph_add_event_record_node(
+                              &record_node, graph, /*dependencies=*/nullptr,
+                              /*dependency_count=*/0, event));
+    hipHostNodeParams host_params = {};
+    host_params.fn = &RanHostFunction;
+    host_params.userData = host_node_ran;
+    hipGraphNode_t host_node = nullptr;
+    EXPECT_EQ(hipSuccess,
+              hip_.graph_add_host_node(&host_node, graph, &record_node,
+                                       /*dependency_count=*/1, &host_params));
+    return InstantiateGraph(graph);
+  }
+
+  // Allocates |size| bytes from the device's default pool on |stream|.
+  void* AllocateAsync(hipStream_t stream, size_t size) {
+    void* device_ptr = nullptr;
+    EXPECT_EQ(hipSuccess, hip_.malloc_async(&device_ptr, size, stream));
+    return device_ptr;
+  }
+
   // Enqueues |gate| on |stream|, registers it with |callbacks|, and returns
   // once the callback is running and the stream provably holds unfinished work.
   void EnqueueGateAndWaitUntilEntered(hipStream_t stream, StreamGate* gate,
@@ -366,6 +420,8 @@ class HipEventTest : public ::testing::Test {
     HipEventSynchronizeFn event_synchronize;
     HipEventElapsedTimeFn event_elapsed_time;
     HipLaunchHostFuncFn launch_host_func;
+    HipMallocAsyncFn malloc_async;
+    HipFreeAsyncFn free_async;
     HipGraphCreateFn graph_create;
     HipGraphDestroyFn graph_destroy;
     HipGraphAddEventRecordNodeFn graph_add_event_record_node;
@@ -784,6 +840,333 @@ TEST_F(HipEventTest, ElapsedTimeRejectsEventsRecordedOnlyDuringCapture) {
   float ms = -1.0f;
   EXPECT_EQ(hipErrorInvalidHandle, hip_.event_elapsed_time(&ms, start, stop))
       << "an interval was reported for records that were never submitted";
+}
+
+// Bytes taken from the default pool by the reuse tests below. A pending free is
+// only reused for a request of exactly its own size, so every one of them uses
+// this constant on both sides of the free.
+constexpr size_t kReuseAllocationSize = 4096;
+
+// A stream that waits on an event is ordered behind the stream timeline point
+// that reaching the event's recorded point implies, and a pending free on that
+// stream up to that point may be handed to it. A record inside a graph launch
+// implies nothing about the stream that last recorded the event through the
+// stream API, so a free queued on that stream stays unavailable.
+TEST_F(HipEventTest, GraphInternalRecordDeniesReuseFromTheLastStreamRecorder) {
+  hipStream_t producer = CreateStream();
+  ASSERT_NE(nullptr, producer);
+  hipStream_t launch_stream = CreateStream();
+  ASSERT_NE(nullptr, launch_stream);
+  hipStream_t consumer = CreateStream();
+  ASSERT_NE(nullptr, consumer);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+
+  std::atomic<bool> host_node_ran{false};
+  hipGraphExec_t graph_exec =
+      InstantiateGraphRecordingBeforeAHostNode(event, &host_node_ran);
+  ASSERT_NE(nullptr, graph_exec);
+
+  // Makes the producer the event's last stream recorder while leaving its
+  // timeline far behind the launch timeline the record node goes on to name.
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, producer, /*count=*/1));
+  for (int i = 0; i < 8; ++i) {
+    ASSERT_EQ(hipSuccess, hip_.graph_launch(graph_exec, launch_stream));
+  }
+  ASSERT_EQ(hipSuccess, hip_.stream_synchronize(launch_stream));
+  ASSERT_TRUE(host_node_ran.load(std::memory_order_acquire));
+
+  // The gate parks the producer ahead of the free, so the free's host callback
+  // provably has not run and only an event dependency could release its
+  // allocation.
+  StreamGate gate;
+  ScopedHostCallbacks callbacks;
+  ASSERT_NO_FATAL_FAILURE(
+      EnqueueGateAndWaitUntilEntered(producer, &gate, &callbacks));
+
+  void* freed = AllocateAsync(producer, kReuseAllocationSize);
+  ASSERT_NE(nullptr, freed);
+  ASSERT_EQ(hipSuccess, hip_.free_async(freed, producer));
+
+  ASSERT_EQ(hipSuccess, hip_.stream_wait_event(consumer, event, /*flags=*/0));
+  void* reallocated = AllocateAsync(consumer, kReuseAllocationSize);
+  ASSERT_NE(nullptr, reallocated);
+  EXPECT_NE(freed, reallocated)
+      << "an allocation still queued for free on the producer was handed to a "
+         "stream that only waited on a record made inside a graph launch";
+
+  EXPECT_EQ(hipSuccess, hip_.free_async(reallocated, consumer));
+  callbacks.ReleaseGate();
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(producer));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(consumer));
+}
+
+// The case the reuse policy exists for: the event's last record is a stream
+// record on the producer, behind the free, so waiting on it does order the
+// consumer after the free.
+TEST_F(HipEventTest, StreamRecordBehindAFreeGrantsReuseToTheWaitingStream) {
+  hipStream_t producer = CreateStream();
+  ASSERT_NE(nullptr, producer);
+  hipStream_t launch_stream = CreateStream();
+  ASSERT_NE(nullptr, launch_stream);
+  hipStream_t consumer = CreateStream();
+  ASSERT_NE(nullptr, consumer);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+
+  std::atomic<bool> host_node_ran{false};
+  hipGraphExec_t graph_exec =
+      InstantiateGraphRecordingBeforeAHostNode(event, &host_node_ran);
+  ASSERT_NE(nullptr, graph_exec);
+
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, producer, /*count=*/1));
+  for (int i = 0; i < 8; ++i) {
+    ASSERT_EQ(hipSuccess, hip_.graph_launch(graph_exec, launch_stream));
+  }
+  ASSERT_EQ(hipSuccess, hip_.stream_synchronize(launch_stream));
+  ASSERT_TRUE(host_node_ran.load(std::memory_order_acquire));
+
+  StreamGate gate;
+  ScopedHostCallbacks callbacks;
+  ASSERT_NO_FATAL_FAILURE(
+      EnqueueGateAndWaitUntilEntered(producer, &gate, &callbacks));
+
+  void* freed = AllocateAsync(producer, kReuseAllocationSize);
+  ASSERT_NE(nullptr, freed);
+  ASSERT_EQ(hipSuccess, hip_.free_async(freed, producer));
+  ASSERT_EQ(hipSuccess, hip_.event_record(event, producer));
+
+  ASSERT_EQ(hipSuccess, hip_.stream_wait_event(consumer, event, /*flags=*/0));
+  void* reallocated = AllocateAsync(consumer, kReuseAllocationSize);
+  ASSERT_NE(nullptr, reallocated);
+  EXPECT_EQ(freed, reallocated)
+      << "a stream ordered behind the free by an event wait was denied the "
+         "freed allocation";
+
+  EXPECT_EQ(hipSuccess, hip_.free_async(reallocated, consumer));
+  callbacks.ReleaseGate();
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(producer));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(consumer));
+}
+
+// A stream record names the timeline value it reserved and nothing later. A
+// free queued on that same stream after the record lands past that value, so
+// waiting on the record does not order the waiter behind the free and the
+// allocation stays unavailable.
+TEST_F(HipEventTest, StreamRecordAheadOfAFreeDeniesReuseToTheWaitingStream) {
+  hipStream_t producer = CreateStream();
+  ASSERT_NE(nullptr, producer);
+  hipStream_t consumer = CreateStream();
+  ASSERT_NE(nullptr, consumer);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+
+  StreamGate gate;
+  ScopedHostCallbacks callbacks;
+  ASSERT_NO_FATAL_FAILURE(
+      EnqueueGateAndWaitUntilEntered(producer, &gate, &callbacks));
+
+  ASSERT_EQ(hipSuccess, hip_.event_record(event, producer));
+
+  // Queued behind the record, so the free lands on the producer timeline past
+  // the value the record named.
+  void* freed = AllocateAsync(producer, kReuseAllocationSize);
+  ASSERT_NE(nullptr, freed);
+  ASSERT_EQ(hipSuccess, hip_.free_async(freed, producer));
+
+  ASSERT_EQ(hipSuccess, hip_.stream_wait_event(consumer, event, /*flags=*/0));
+  void* reallocated = AllocateAsync(consumer, kReuseAllocationSize);
+  ASSERT_NE(nullptr, reallocated);
+  EXPECT_NE(freed, reallocated)
+      << "an allocation freed past the value the record named was handed to a "
+         "stream that only waited on that record";
+
+  EXPECT_EQ(hipSuccess, hip_.free_async(reallocated, consumer));
+  callbacks.ReleaseGate();
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(producer));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(consumer));
+}
+
+// A record that is the launch's last block names a point on the launching
+// stream's own timeline, which is a stream point regardless of which stream
+// last recorded the event through the stream API.
+TEST_F(HipEventTest, GraphRecordEndingALaunchGrantsReuseOfTheLaunchingStream) {
+  hipStream_t producer = CreateStream();
+  ASSERT_NE(nullptr, producer);
+  hipStream_t other_recorder = CreateStream();
+  ASSERT_NE(nullptr, other_recorder);
+  hipStream_t consumer = CreateStream();
+  ASSERT_NE(nullptr, consumer);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+
+  hipGraphExec_t graph_exec = InstantiateGraphRecordingAtTheEnd(event);
+  ASSERT_NE(nullptr, graph_exec);
+
+  StreamGate gate;
+  ScopedHostCallbacks callbacks;
+  ASSERT_NO_FATAL_FAILURE(
+      EnqueueGateAndWaitUntilEntered(producer, &gate, &callbacks));
+
+  void* freed = AllocateAsync(producer, kReuseAllocationSize);
+  ASSERT_NE(nullptr, freed);
+  ASSERT_EQ(hipSuccess, hip_.free_async(freed, producer));
+
+  // The stream record leaves a recorder that has nothing to do with the launch
+  // that follows it.
+  ASSERT_EQ(hipSuccess, hip_.event_record(event, other_recorder));
+  ASSERT_EQ(hipSuccess, hip_.graph_launch(graph_exec, producer));
+
+  ASSERT_EQ(hipSuccess, hip_.stream_wait_event(consumer, event, /*flags=*/0));
+  void* reallocated = AllocateAsync(consumer, kReuseAllocationSize);
+  ASSERT_NE(nullptr, reallocated);
+  EXPECT_EQ(freed, reallocated)
+      << "a stream ordered behind the free by a graph record on the producer "
+         "was denied the freed allocation";
+
+  EXPECT_EQ(hipSuccess, hip_.free_async(reallocated, consumer));
+  callbacks.ReleaseGate();
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(producer));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(other_recorder));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(consumer));
+}
+
+// A record internal to a launch names no stream timeline value, but every block
+// of the launch is chained behind the tail the launch waited on, so the free
+// queued ahead of the launch is still covered.
+TEST_F(HipEventTest, GraphInternalRecordGrantsReuseBehindTheLaunchTail) {
+  hipStream_t producer = CreateStream();
+  ASSERT_NE(nullptr, producer);
+  hipStream_t other_recorder = CreateStream();
+  ASSERT_NE(nullptr, other_recorder);
+  hipStream_t consumer = CreateStream();
+  ASSERT_NE(nullptr, consumer);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+
+  std::atomic<bool> host_node_ran{false};
+  hipGraphExec_t graph_exec =
+      InstantiateGraphRecordingBeforeAHostNode(event, &host_node_ran);
+  ASSERT_NE(nullptr, graph_exec);
+
+  StreamGate gate;
+  ScopedHostCallbacks callbacks;
+  ASSERT_NO_FATAL_FAILURE(
+      EnqueueGateAndWaitUntilEntered(producer, &gate, &callbacks));
+
+  void* freed = AllocateAsync(producer, kReuseAllocationSize);
+  ASSERT_NE(nullptr, freed);
+  ASSERT_EQ(hipSuccess, hip_.free_async(freed, producer));
+
+  ASSERT_EQ(hipSuccess, hip_.event_record(event, other_recorder));
+  ASSERT_EQ(hipSuccess, hip_.graph_launch(graph_exec, producer));
+  callbacks.Add(host_node_ran);
+
+  ASSERT_EQ(hipSuccess, hip_.stream_wait_event(consumer, event, /*flags=*/0));
+  void* reallocated = AllocateAsync(consumer, kReuseAllocationSize);
+  ASSERT_NE(nullptr, reallocated);
+  EXPECT_EQ(freed, reallocated)
+      << "a stream ordered behind the free by the tail the launch waited on "
+         "was denied the freed allocation";
+
+  EXPECT_EQ(hipSuccess, hip_.free_async(reallocated, consumer));
+  callbacks.ReleaseGate();
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(producer));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(other_recorder));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(consumer));
+}
+
+// The tail a launch waited on is a lower bound on the stream ordering a record
+// inside the launch implies, never the point itself. A free queued on the
+// launching stream after the launch completes past that tail, so waiting on the
+// record does not order the waiter behind it and the allocation stays
+// unavailable.
+TEST_F(HipEventTest, GraphInternalRecordDeniesReuseAheadOfTheLaunchTail) {
+  hipStream_t producer = CreateStream();
+  ASSERT_NE(nullptr, producer);
+  hipStream_t consumer = CreateStream();
+  ASSERT_NE(nullptr, consumer);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+
+  std::atomic<bool> host_node_ran{false};
+  hipGraphExec_t graph_exec =
+      InstantiateGraphRecordingBeforeAHostNode(event, &host_node_ran);
+  ASSERT_NE(nullptr, graph_exec);
+
+  StreamGate gate;
+  ScopedHostCallbacks callbacks;
+  ASSERT_NO_FATAL_FAILURE(
+      EnqueueGateAndWaitUntilEntered(producer, &gate, &callbacks));
+
+  ASSERT_EQ(hipSuccess, hip_.graph_launch(graph_exec, producer));
+  callbacks.Add(host_node_ran);
+
+  // Queued behind the launch, so the free lands on the producer timeline past
+  // the tail the launch waited on.
+  void* freed = AllocateAsync(producer, kReuseAllocationSize);
+  ASSERT_NE(nullptr, freed);
+  ASSERT_EQ(hipSuccess, hip_.free_async(freed, producer));
+
+  ASSERT_EQ(hipSuccess, hip_.stream_wait_event(consumer, event, /*flags=*/0));
+  void* reallocated = AllocateAsync(consumer, kReuseAllocationSize);
+  ASSERT_NE(nullptr, reallocated);
+  EXPECT_NE(freed, reallocated)
+      << "an allocation freed past the tail the launch waited on was handed to "
+         "a stream that only waited on a record made inside that launch";
+
+  EXPECT_EQ(hipSuccess, hip_.free_async(reallocated, consumer));
+  callbacks.ReleaseGate();
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(producer));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(consumer));
+}
+
+// A record landing between a waiter's read of the event and its submission has
+// to leave the waiter waiting on the point it read. The interleaving is
+// unordered by contract, so there is nothing to assert about which record wins;
+// unaided this pins only that every call succeeds and every stream drains. It
+// is also a manual race detector probe: no configured job runs it under one, so
+// checking that the concurrent reads are synchronized means running it under
+// one by hand.
+TEST_F(HipEventTest, ConcurrentRecordsDoNotDisturbAConcurrentStreamWait) {
+  hipStream_t stream_a = CreateStream();
+  ASSERT_NE(nullptr, stream_a);
+  hipStream_t stream_b = CreateStream();
+  ASSERT_NE(nullptr, stream_b);
+  hipStream_t consumer = CreateStream();
+  ASSERT_NE(nullptr, consumer);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+
+  // Gives the event a submitted record before either loop starts so the waiter
+  // exercises a populated point from its first iteration.
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream_a, /*count=*/1));
+
+  constexpr int kIterationCount = 100;
+  std::atomic<hipError_t> record_result{hipSuccess};
+  std::thread recorder([&] {
+    for (int i = 0; i < kIterationCount; ++i) {
+      const hipError_t result =
+          hip_.event_record(event, (i % 2 == 0) ? stream_a : stream_b);
+      if (result != hipSuccess) {
+        record_result.store(result, std::memory_order_release);
+        return;
+      }
+    }
+  });
+
+  hipError_t wait_result = hipSuccess;
+  for (int i = 0; i < kIterationCount && wait_result == hipSuccess; ++i) {
+    wait_result = hip_.stream_wait_event(consumer, event, /*flags=*/0);
+  }
+  recorder.join();
+
+  EXPECT_EQ(hipSuccess, record_result.load(std::memory_order_acquire));
+  EXPECT_EQ(hipSuccess, wait_result);
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream_a));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream_b));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(consumer));
+  EXPECT_EQ(hipSuccess, hip_.event_synchronize(event));
 }
 
 }  // namespace

--- a/libhrx/cts/tests/hip/event_test.cpp
+++ b/libhrx/cts/tests/hip/event_test.cpp
@@ -387,9 +387,6 @@ class HipEventTest : public ::testing::Test {
   std::vector<hipGraphExec_t> graph_execs_;
 };
 
-// A record marks a point on the recording stream's timeline, so re-recording an
-// event on a stream whose timeline is behind still names a point that stream
-// has not reached.
 TEST_F(HipEventTest, CrossStreamRerecordDoesNotReportStaleCompletion) {
   hipStream_t stream_a = CreateStream();
   ASSERT_NE(nullptr, stream_a);
@@ -418,10 +415,7 @@ TEST_F(HipEventTest, CrossStreamRerecordDoesNotReportStaleCompletion) {
   EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream_b));
 }
 
-// Recording a shared event on a second stream must not make that stream wait
-// for the first one: nothing was submitted between the two records, so the
-// second stream drains while the first is still parked in its gate. A stream
-// chained to the other one hangs in hipStreamSynchronize.
+// A chained stream hangs in hipStreamSynchronize rather than failing here.
 TEST_F(HipEventTest, CrossStreamRerecordDoesNotChainTheNewStreamToTheOldOne) {
   hipStream_t stream_a = CreateStream();
   ASSERT_NE(nullptr, stream_a);
@@ -450,10 +444,8 @@ TEST_F(HipEventTest, CrossStreamRerecordDoesNotChainTheNewStreamToTheOldOne) {
   EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream_a));
 }
 
-// Destroying the stream an event was recorded on has to leave the event
-// queryable, and re-recording it elsewhere has to let go of what it was
-// holding. This pins the handle-level contract; the event's reference to the
-// timeline itself is what the graph executable case below covers.
+// Pins the handle-level contract only - the event keeps the stream object alive
+// for its capture state, so the timeline reference is the case below.
 TEST_F(HipEventTest, EventStaysUsableAfterItsRecordingStreamHandleIsDestroyed) {
   hipStream_t stream_a = CreateStream();
   ASSERT_NE(nullptr, stream_a);
@@ -471,10 +463,8 @@ TEST_F(HipEventTest, EventStaysUsableAfterItsRecordingStreamHandleIsDestroyed) {
   EXPECT_EQ(hipSuccess, hip_.event_query(event));
 }
 
-// A record node in the middle of a graph marks a point on a timeline the graph
-// executable owns, and the event's own reference is all that is left once the
-// executable is destroyed: the event has to stay queryable afterwards, and
-// re-recording it elsewhere has to let the timeline go.
+// The one case where the event's own reference is all that keeps the timeline
+// alive; without it the query below is a use after free.
 TEST_F(HipEventTest, EventStaysUsableAfterTheRecordingGraphExecutableIsGone) {
   hipStream_t stream = CreateStream();
   ASSERT_NE(nullptr, stream);
@@ -518,10 +508,8 @@ TEST_F(HipEventTest, EventStaysUsableAfterTheRecordingGraphExecutableIsGone) {
   EXPECT_EQ(hipSuccess, hip_.event_query(event));
 }
 
-// A cross-stream re-record must leave the event usable as a dependency for
-// another stream: work gated on it through hipStreamWaitEvent has to run only
-// after the recording stream drains. This is a contract check, not a
-// discriminator - the gated callback shares a queue thread with the gate.
+// This is a contract check, not a discriminator - the gated callback shares a
+// queue thread with the gate.
 TEST_F(HipEventTest, CrossStreamRerecordStaysUsableAsStreamWaitDependency) {
   hipStream_t stream_a = CreateStream();
   ASSERT_NE(nullptr, stream_a);
@@ -558,10 +546,8 @@ TEST_F(HipEventTest, CrossStreamRerecordStaysUsableAsStreamWaitDependency) {
          "recorded the event drained";
 }
 
-// Waiting on an event does not release a stream from its own ordering: the wait
-// advances the stream timeline, so it must complete only once the work in front
-// of it has run. This is a contract check, not a discriminator - the queue also
-// serializes signals on one timeline, which covers the same ordering.
+// This is a contract check, not a discriminator - the queue also serializes
+// signals on one timeline, which covers the same ordering.
 TEST_F(HipEventTest, StreamWaitEventStaysOrderedBehindPriorStreamWork) {
   hipStream_t stream_a = CreateStream();
   ASSERT_NE(nullptr, stream_a);
@@ -588,10 +574,6 @@ TEST_F(HipEventTest, StreamWaitEventStaysOrderedBehindPriorStreamWork) {
          "event wait was still running";
 }
 
-// Both halves of a stream event wait can be absent at once: a stream that has
-// never submitted has nothing behind it, and an event with no submitted record
-// has no point to wait for. The barrier goes out with an empty wait list and
-// still has to be accepted and still has to signal the stream.
 TEST_F(HipEventTest, StreamWaitOnANeverRecordedEventDropsBothWaits) {
   hipStream_t stream = CreateStream();
   ASSERT_NE(nullptr, stream);
@@ -612,9 +594,6 @@ TEST_F(HipEventTest, StreamWaitOnANeverRecordedEventDropsBothWaits) {
   EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream));
 }
 
-// A graph event wait node on an event with no submitted record has nothing to
-// wait for, so the wait is dropped and the block goes out with whatever waits
-// the schedule gave it. The node behind it still has to run.
 TEST_F(HipEventTest, GraphEventWaitNodeOnANeverRecordedEventDropsTheWait) {
   hipStream_t stream = CreateStream();
   ASSERT_NE(nullptr, stream);
@@ -647,9 +626,6 @@ TEST_F(HipEventTest, GraphEventWaitNodeOnANeverRecordedEventDropsTheWait) {
       << "the node behind a dropped event wait never ran";
 }
 
-// A graph whose only node records an event marks the point the launch itself
-// reaches, so launching it onto a parked stream leaves the event not ready
-// until that stream drains.
 TEST_F(HipEventTest, GraphRecordNodeAtTheEndOfAGraphMarksTheLaunchPoint) {
   hipStream_t stream = CreateStream();
   ASSERT_NE(nullptr, stream);
@@ -693,10 +669,6 @@ TEST_F(HipEventTest, GraphRecordNodeAtTheEndOfAGraphMarksTheLaunchPoint) {
   ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream, /*count=*/1));
 }
 
-// A record node with a node after it marks the point that node reaches rather
-// than the point the whole launch reaches: the launch signals the stream, while
-// a node in the middle signals one of the executable's internal semaphores. The
-// event still must not read as complete while the launch is parked.
 TEST_F(HipEventTest, GraphRecordNodeInsideAGraphMarksTheNodePoint) {
   hipStream_t stream = CreateStream();
   ASSERT_NE(nullptr, stream);
@@ -743,9 +715,6 @@ TEST_F(HipEventTest, GraphRecordNodeInsideAGraphMarksTheNodePoint) {
          "launch drained";
 }
 
-// Elapsed time reads the timestamp a record leaves behind, which is adopted
-// only once the submission carrying it has been accepted, so an event with no
-// submitted record has no interval to report.
 TEST_F(HipEventTest, ElapsedTimeNeedsBothEventsRecorded) {
   hipStream_t stream = CreateStream();
   ASSERT_NE(nullptr, stream);
@@ -767,8 +736,6 @@ TEST_F(HipEventTest, ElapsedTimeNeedsBothEventsRecorded) {
   EXPECT_GE(ms, 0.0f);
 }
 
-// Both events have to have completed before an interval means anything, so a
-// stop event whose record is still parked reports as not ready.
 TEST_F(HipEventTest, ElapsedTimeIsNotReadyWhileAnEventIsOutstanding) {
   hipStream_t stream_a = CreateStream();
   ASSERT_NE(nullptr, stream_a);
@@ -797,9 +764,6 @@ TEST_F(HipEventTest, ElapsedTimeIsNotReadyWhileAnEventIsOutstanding) {
   EXPECT_GE(ms, 0.0f);
 }
 
-// A record issued while its stream is capturing produces neither a submission
-// nor a graph node, only a snapshot of the capture frontier, so it leaves the
-// event with no timestamp and no interval to report.
 TEST_F(HipEventTest, ElapsedTimeRejectsEventsRecordedOnlyDuringCapture) {
   hipStream_t stream = CreateStream();
   ASSERT_NE(nullptr, stream);

--- a/libhrx/cts/tests/hip/event_test.cpp
+++ b/libhrx/cts/tests/hip/event_test.cpp
@@ -1,0 +1,933 @@
+// Copyright 2026 The HRX Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <dlfcn.h>
+#include <sched.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdlib>
+#include <vector>
+
+#include "binding/hip/api.h"
+#include "iree/testing/gtest.h"
+
+namespace {
+
+const char* CandidateLibPath() {
+  if (const char* environment_path = std::getenv("HRX_TEST_LIBAMDHIP64");
+      environment_path && *environment_path != '\0') {
+    return environment_path;
+  }
+  return "libamdhip64.so";
+}
+
+template <typename T>
+T ResolveHipSymbol(void* library, const char* name) {
+  return reinterpret_cast<T>(dlsym(library, name));
+}
+
+using HipInitFn = hipError_t (*)(unsigned int flags);
+using HipStreamCreateFn = hipError_t (*)(hipStream_t* stream);
+using HipStreamDestroyFn = hipError_t (*)(hipStream_t stream);
+using HipStreamSynchronizeFn = hipError_t (*)(hipStream_t stream);
+using HipStreamWaitEventFn = hipError_t (*)(hipStream_t stream,
+                                            hipEvent_t event,
+                                            unsigned int flags);
+using HipStreamBeginCaptureFn = hipError_t (*)(hipStream_t stream,
+                                               hipStreamCaptureMode mode);
+using HipStreamEndCaptureFn = hipError_t (*)(hipStream_t stream,
+                                             hipGraph_t* graph);
+using HipEventCreateFn = hipError_t (*)(hipEvent_t* event);
+using HipEventDestroyFn = hipError_t (*)(hipEvent_t event);
+using HipEventRecordFn = hipError_t (*)(hipEvent_t event, hipStream_t stream);
+using HipEventQueryFn = hipError_t (*)(hipEvent_t event);
+using HipEventSynchronizeFn = hipError_t (*)(hipEvent_t event);
+using HipEventElapsedTimeFn = hipError_t (*)(float* ms, hipEvent_t start,
+                                             hipEvent_t stop);
+using HipLaunchHostFuncFn = hipError_t (*)(hipStream_t stream, hipHostFn_t fn,
+                                           void* user_data);
+using HipGraphCreateFn = hipError_t (*)(hipGraph_t* graph, unsigned int flags);
+using HipGraphDestroyFn = hipError_t (*)(hipGraph_t graph);
+using HipGraphAddEventRecordNodeFn = hipError_t (*)(
+    hipGraphNode_t* node, hipGraph_t graph, const hipGraphNode_t* dependencies,
+    size_t dependency_count, hipEvent_t event);
+using HipGraphAddEventWaitNodeFn = hipError_t (*)(
+    hipGraphNode_t* node, hipGraph_t graph, const hipGraphNode_t* dependencies,
+    size_t dependency_count, hipEvent_t event);
+using HipGraphAddHostNodeFn = hipError_t (*)(hipGraphNode_t* node,
+                                             hipGraph_t graph,
+                                             const hipGraphNode_t* dependencies,
+                                             size_t dependency_count,
+                                             const void* node_params);
+using HipGraphInstantiateFn = hipError_t (*)(hipGraphExec_t* graph_exec,
+                                             hipGraph_t graph,
+                                             hipGraphNode_t* error_node,
+                                             char* log_buffer,
+                                             size_t buffer_size);
+using HipGraphLaunchFn = hipError_t (*)(hipGraphExec_t graph_exec,
+                                        hipStream_t stream);
+using HipGraphExecDestroyFn = hipError_t (*)(hipGraphExec_t graph_exec);
+
+// Host callback that parks a stream timeline until the test thread releases it.
+// Every wait in these tests is a readiness contract on these flags, so no step
+// depends on wall-clock time or on how fast the device drains.
+struct StreamGate {
+  // Set by the callback once the queue thread running host callbacks has
+  // entered it.
+  std::atomic<bool> entered{false};
+  // Set by the test thread to let the callback return.
+  std::atomic<bool> released{false};
+  // Set by the callback as its final store before it returns. The callback
+  // writes through a pointer into the frame that enqueued it, so that frame
+  // must not be left until this is set.
+  std::atomic<bool> finished{false};
+};
+
+void GateHostFunction(void* user_data) {
+  auto* gate = static_cast<StreamGate*>(user_data);
+  gate->entered.store(true, std::memory_order_release);
+  while (!gate->released.load(std::memory_order_acquire)) {
+    sched_yield();
+  }
+  gate->finished.store(true, std::memory_order_release);
+}
+
+// Host callback that samples whether a gate callback had already finished when
+// it ran, which is how work enqueued behind a timeline point observes that the
+// work in front of that point really did drain first.
+struct StreamMarker {
+  // Gate sampled by the callback. Borrowed from the frame that enqueues the
+  // callback and set before the enqueue.
+  const StreamGate* gate = nullptr;
+  // Whether |gate| had finished when the callback sampled it. Only meaningful
+  // once |finished| is set.
+  std::atomic<bool> saw_gate_finished{false};
+  // Set by the callback as its final store before it returns. See StreamGate.
+  std::atomic<bool> finished{false};
+};
+
+void MarkerHostFunction(void* user_data) {
+  auto* marker = static_cast<StreamMarker*>(user_data);
+  marker->saw_gate_finished.store(
+      marker->gate->finished.load(std::memory_order_acquire),
+      std::memory_order_release);
+  marker->finished.store(true, std::memory_order_release);
+}
+
+// Host callback that only records that it ran, for nodes that exist to put
+// something behind another node rather than to observe ordering. |user_data| is
+// the flag to set and is the callback's final store, as with the others here.
+void RanHostFunction(void* user_data) {
+  static_cast<std::atomic<bool>*>(user_data)->store(true,
+                                                    std::memory_order_release);
+}
+
+// Keeps the enclosing frame alive until every host callback registered with it
+// has returned, releasing the registered gate first so a parked callback can
+// get there. Host callbacks run on a queue thread and write through pointers
+// into the frame that enqueued them, so releasing the gate is not enough: the
+// callback is still inside its stores when the test thread observes the
+// release, and a test body that returns early (a failed assertion, most of all)
+// would leave those stores aimed at a dead frame. Callbacks are registered
+// immediately after their enqueue succeeds, so a callback that never reached a
+// queue is never awaited.
+class ScopedHostCallbacks {
+ public:
+  ScopedHostCallbacks() = default;
+  ScopedHostCallbacks(const ScopedHostCallbacks&) = delete;
+  ScopedHostCallbacks& operator=(const ScopedHostCallbacks&) = delete;
+  ~ScopedHostCallbacks() {
+    ReleaseGate();
+    for (const std::atomic<bool>* finished : pending_) {
+      while (!finished->load(std::memory_order_acquire)) {
+        sched_yield();
+      }
+    }
+  }
+
+  // Registers a parked gate callback whose enqueue has succeeded. Only one gate
+  // may be registered: a second registration would displace the first, leaving
+  // nothing able to release it, and the destructor would then spin forever
+  // waiting for a callback that can never return.
+  void AddGate(StreamGate* gate) {
+    ASSERT_EQ(nullptr, gate_) << "a gate is already registered";
+    gate_ = gate;
+    Add(gate->finished);
+  }
+
+  // Registers a callback whose enqueue has succeeded and that stores
+  // |finished| as its final action.
+  void Add(const std::atomic<bool>& finished) { pending_.push_back(&finished); }
+
+  // Lets the registered gate callback return. Idempotent: the destructor
+  // repeats it for the exit paths that never get here.
+  void ReleaseGate() {
+    if (gate_) {
+      gate_->released.store(true, std::memory_order_release);
+    }
+  }
+
+ private:
+  // Gate released before the destructor waits, or null when none is
+  // registered. Borrowed from the enclosing frame.
+  StreamGate* gate_ = nullptr;
+  // Completion flags of the callbacks registered so far, all borrowed from the
+  // enclosing frame.
+  std::vector<const std::atomic<bool>*> pending_;
+};
+
+class HipEventTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // The shim under test is a build artifact this test declares a dependency
+    // on and it names no ROCm library at link time, so it loads on a machine
+    // with no device just as well as on one with a device. A load failure is
+    // therefore a regression in the shim rather than a property of the machine,
+    // which is why it fails here instead of skipping.
+    library_ = dlopen(CandidateLibPath(), RTLD_NOW | RTLD_LOCAL);
+    ASSERT_NE(nullptr, library_)
+        << "cannot dlopen " << CandidateLibPath() << ": " << dlerror();
+
+    init_ = ResolveHipSymbol<HipInitFn>(library_, "hipInit");
+    stream_create_ =
+        ResolveHipSymbol<HipStreamCreateFn>(library_, "hipStreamCreate");
+    stream_destroy_ =
+        ResolveHipSymbol<HipStreamDestroyFn>(library_, "hipStreamDestroy");
+    stream_synchronize_ = ResolveHipSymbol<HipStreamSynchronizeFn>(
+        library_, "hipStreamSynchronize");
+    stream_wait_event_ =
+        ResolveHipSymbol<HipStreamWaitEventFn>(library_, "hipStreamWaitEvent");
+    stream_begin_capture_ = ResolveHipSymbol<HipStreamBeginCaptureFn>(
+        library_, "hipStreamBeginCapture");
+    stream_end_capture_ = ResolveHipSymbol<HipStreamEndCaptureFn>(
+        library_, "hipStreamEndCapture");
+    event_create_ =
+        ResolveHipSymbol<HipEventCreateFn>(library_, "hipEventCreate");
+    event_destroy_ =
+        ResolveHipSymbol<HipEventDestroyFn>(library_, "hipEventDestroy");
+    event_record_ =
+        ResolveHipSymbol<HipEventRecordFn>(library_, "hipEventRecord");
+    event_query_ = ResolveHipSymbol<HipEventQueryFn>(library_, "hipEventQuery");
+    event_synchronize_ = ResolveHipSymbol<HipEventSynchronizeFn>(
+        library_, "hipEventSynchronize");
+    event_elapsed_time_ = ResolveHipSymbol<HipEventElapsedTimeFn>(
+        library_, "hipEventElapsedTime");
+    launch_host_func_ =
+        ResolveHipSymbol<HipLaunchHostFuncFn>(library_, "hipLaunchHostFunc");
+    graph_create_ =
+        ResolveHipSymbol<HipGraphCreateFn>(library_, "hipGraphCreate");
+    graph_destroy_ =
+        ResolveHipSymbol<HipGraphDestroyFn>(library_, "hipGraphDestroy");
+    graph_add_event_record_node_ =
+        ResolveHipSymbol<HipGraphAddEventRecordNodeFn>(
+            library_, "hipGraphAddEventRecordNode");
+    graph_add_event_wait_node_ = ResolveHipSymbol<HipGraphAddEventWaitNodeFn>(
+        library_, "hipGraphAddEventWaitNode");
+    graph_add_host_node_ = ResolveHipSymbol<HipGraphAddHostNodeFn>(
+        library_, "hipGraphAddHostNode");
+    graph_instantiate_ = ResolveHipSymbol<HipGraphInstantiateFn>(
+        library_, "hipGraphInstantiate");
+    graph_launch_ =
+        ResolveHipSymbol<HipGraphLaunchFn>(library_, "hipGraphLaunch");
+    graph_exec_destroy_ = ResolveHipSymbol<HipGraphExecDestroyFn>(
+        library_, "hipGraphExecDestroy");
+
+    ASSERT_NE(nullptr, init_);
+    ASSERT_NE(nullptr, stream_create_);
+    ASSERT_NE(nullptr, stream_destroy_);
+    ASSERT_NE(nullptr, stream_synchronize_);
+    ASSERT_NE(nullptr, stream_wait_event_);
+    ASSERT_NE(nullptr, stream_begin_capture_);
+    ASSERT_NE(nullptr, stream_end_capture_);
+    ASSERT_NE(nullptr, event_create_);
+    ASSERT_NE(nullptr, event_destroy_);
+    ASSERT_NE(nullptr, event_record_);
+    ASSERT_NE(nullptr, event_query_);
+    ASSERT_NE(nullptr, event_synchronize_);
+    ASSERT_NE(nullptr, event_elapsed_time_);
+    ASSERT_NE(nullptr, launch_host_func_);
+    ASSERT_NE(nullptr, graph_create_);
+    ASSERT_NE(nullptr, graph_destroy_);
+    ASSERT_NE(nullptr, graph_add_event_record_node_);
+    ASSERT_NE(nullptr, graph_add_event_wait_node_);
+    ASSERT_NE(nullptr, graph_add_host_node_);
+    ASSERT_NE(nullptr, graph_instantiate_);
+    ASSERT_NE(nullptr, graph_launch_);
+    ASSERT_NE(nullptr, graph_exec_destroy_);
+
+    // Only the absence of a device is a reason to skip: any other failure is a
+    // shim regression, and skipping on it would report this file as passing.
+    const hipError_t init_result = init_(/*flags=*/0);
+    if (init_result == hipErrorNoDevice) {
+      GTEST_SKIP() << "no HIP device available";
+    }
+    ASSERT_EQ(hipSuccess, init_result) << "hipInit failed";
+  }
+
+  // Destroys the handles the body created, in reverse order of the dependencies
+  // between handle kinds. Destroying here rather than at the end of each body
+  // is what keeps a failed assertion - which leaves its body immediately - from
+  // adding leak-checker noise on top of the failure it is already reporting.
+  // The body's own scope guards have joined every host callback by the time
+  // this runs, so no stream is destroyed while a callback is still parked on
+  // it.
+  void TearDown() override {
+    for (auto it = graph_execs_.rbegin(); it != graph_execs_.rend(); ++it) {
+      EXPECT_EQ(hipSuccess, graph_exec_destroy_(*it));
+    }
+    for (auto it = graphs_.rbegin(); it != graphs_.rend(); ++it) {
+      EXPECT_EQ(hipSuccess, graph_destroy_(*it));
+    }
+    for (auto it = events_.rbegin(); it != events_.rend(); ++it) {
+      EXPECT_EQ(hipSuccess, event_destroy_(*it));
+    }
+    for (auto it = streams_.rbegin(); it != streams_.rend(); ++it) {
+      EXPECT_EQ(hipSuccess, stream_destroy_(*it));
+    }
+  }
+
+  // Creates a stream owned by the fixture.
+  hipStream_t CreateStream() {
+    hipStream_t stream = nullptr;
+    EXPECT_EQ(hipSuccess, stream_create_(&stream));
+    if (stream) streams_.push_back(stream);
+    return stream;
+  }
+
+  // Destroys a stream created through CreateStream ahead of TearDown, dropping
+  // it from the fixture's list so it is not destroyed twice.
+  void DestroyStream(hipStream_t stream) {
+    streams_.erase(std::remove(streams_.begin(), streams_.end(), stream),
+                   streams_.end());
+    EXPECT_EQ(hipSuccess, stream_destroy_(stream));
+  }
+
+  // Creates an event owned by the fixture.
+  hipEvent_t CreateEvent() {
+    hipEvent_t event = nullptr;
+    EXPECT_EQ(hipSuccess, event_create_(&event));
+    if (event) events_.push_back(event);
+    return event;
+  }
+
+  // Creates an empty graph owned by the fixture.
+  hipGraph_t CreateGraph() {
+    hipGraph_t graph = nullptr;
+    EXPECT_EQ(hipSuccess, graph_create_(&graph, /*flags=*/0));
+    TrackGraph(graph);
+    return graph;
+  }
+
+  // Hands a graph the body obtained some other way - ending a stream capture,
+  // for one - to the fixture so TearDown destroys it. Ignores null so a caller
+  // can hand over the result of a call that failed and let its own assertion
+  // report the failure.
+  void TrackGraph(hipGraph_t graph) {
+    if (graph) graphs_.push_back(graph);
+  }
+
+  // Destroys a graph the fixture owns ahead of TearDown, dropping it from the
+  // fixture's list so it is not destroyed twice.
+  void DestroyGraph(hipGraph_t graph) {
+    graphs_.erase(std::remove(graphs_.begin(), graphs_.end(), graph),
+                  graphs_.end());
+    EXPECT_EQ(hipSuccess, graph_destroy_(graph));
+  }
+
+  // Instantiates |graph| into an executable owned by the fixture.
+  hipGraphExec_t InstantiateGraph(hipGraph_t graph) {
+    hipGraphExec_t graph_exec = nullptr;
+    EXPECT_EQ(hipSuccess,
+              graph_instantiate_(&graph_exec, graph, /*error_node=*/nullptr,
+                                 /*log_buffer=*/nullptr, /*buffer_size=*/0));
+    if (graph_exec) graph_execs_.push_back(graph_exec);
+    return graph_exec;
+  }
+
+  // Destroys an executable created through InstantiateGraph ahead of TearDown,
+  // dropping it from the fixture's list so it is not destroyed twice.
+  void DestroyGraphExec(hipGraphExec_t graph_exec) {
+    graph_execs_.erase(
+        std::remove(graph_execs_.begin(), graph_execs_.end(), graph_exec),
+        graph_execs_.end());
+    EXPECT_EQ(hipSuccess, graph_exec_destroy_(graph_exec));
+  }
+
+  // Records |event| on |stream| and waits for it |count| times, leaving both
+  // the stream and the event drained.
+  void AdvanceEventOnStream(hipEvent_t event, hipStream_t stream, int count) {
+    for (int i = 0; i < count; ++i) {
+      ASSERT_EQ(hipSuccess, event_record_(event, stream));
+      ASSERT_EQ(hipSuccess, event_synchronize_(event));
+    }
+    ASSERT_EQ(hipSuccess, stream_synchronize_(stream));
+  }
+
+  // Enqueues |gate| on |stream|, registers it with |callbacks| so it can never
+  // outlive the caller's frame, and returns once the callback is running, at
+  // which point the stream provably holds unfinished work.
+  void EnqueueGateAndWaitUntilEntered(hipStream_t stream, StreamGate* gate,
+                                      ScopedHostCallbacks* callbacks) {
+    ASSERT_EQ(hipSuccess, launch_host_func_(stream, &GateHostFunction, gate));
+    ASSERT_NO_FATAL_FAILURE(callbacks->AddGate(gate));
+    while (!gate->entered.load(std::memory_order_acquire)) {
+      sched_yield();
+    }
+  }
+
+  // HIP shim under test. Intentionally never dlclose()d: the shim owns
+  // process-global device state shared by every test in this file.
+  void* library_ = nullptr;
+  // Resolved hipInit.
+  HipInitFn init_ = nullptr;
+  // Resolved hipStreamCreate.
+  HipStreamCreateFn stream_create_ = nullptr;
+  // Resolved hipStreamDestroy.
+  HipStreamDestroyFn stream_destroy_ = nullptr;
+  // Resolved hipStreamSynchronize.
+  HipStreamSynchronizeFn stream_synchronize_ = nullptr;
+  // Resolved hipStreamWaitEvent.
+  HipStreamWaitEventFn stream_wait_event_ = nullptr;
+  // Resolved hipStreamBeginCapture.
+  HipStreamBeginCaptureFn stream_begin_capture_ = nullptr;
+  // Resolved hipStreamEndCapture.
+  HipStreamEndCaptureFn stream_end_capture_ = nullptr;
+  // Resolved hipEventCreate.
+  HipEventCreateFn event_create_ = nullptr;
+  // Resolved hipEventDestroy.
+  HipEventDestroyFn event_destroy_ = nullptr;
+  // Resolved hipEventRecord.
+  HipEventRecordFn event_record_ = nullptr;
+  // Resolved hipEventQuery.
+  HipEventQueryFn event_query_ = nullptr;
+  // Resolved hipEventSynchronize.
+  HipEventSynchronizeFn event_synchronize_ = nullptr;
+  // Resolved hipEventElapsedTime.
+  HipEventElapsedTimeFn event_elapsed_time_ = nullptr;
+  // Resolved hipLaunchHostFunc.
+  HipLaunchHostFuncFn launch_host_func_ = nullptr;
+  // Resolved hipGraphCreate.
+  HipGraphCreateFn graph_create_ = nullptr;
+  // Resolved hipGraphDestroy.
+  HipGraphDestroyFn graph_destroy_ = nullptr;
+  // Resolved hipGraphAddEventRecordNode.
+  HipGraphAddEventRecordNodeFn graph_add_event_record_node_ = nullptr;
+  // Resolved hipGraphAddEventWaitNode.
+  HipGraphAddEventWaitNodeFn graph_add_event_wait_node_ = nullptr;
+  // Resolved hipGraphAddHostNode.
+  HipGraphAddHostNodeFn graph_add_host_node_ = nullptr;
+  // Resolved hipGraphInstantiate.
+  HipGraphInstantiateFn graph_instantiate_ = nullptr;
+  // Resolved hipGraphLaunch.
+  HipGraphLaunchFn graph_launch_ = nullptr;
+  // Resolved hipGraphExecDestroy.
+  HipGraphExecDestroyFn graph_exec_destroy_ = nullptr;
+
+ private:
+  // Streams created through CreateStream, destroyed by TearDown.
+  std::vector<hipStream_t> streams_;
+  // Events created through CreateEvent, destroyed by TearDown.
+  std::vector<hipEvent_t> events_;
+  // Graphs created through CreateGraph, destroyed by TearDown.
+  std::vector<hipGraph_t> graphs_;
+  // Executables created through InstantiateGraph, destroyed by TearDown.
+  std::vector<hipGraphExec_t> graph_execs_;
+};
+
+// A record marks a point on the recording stream's timeline, so re-recording an
+// event on a stream whose timeline is behind still names a point that stream
+// has not reached. Deriving the target from a timeline the event carries across
+// streams instead lets a record name a value that is already in the past, which
+// reports work as complete before any of it has run.
+TEST_F(HipEventTest, CrossStreamRerecordDoesNotReportStaleCompletion) {
+  hipStream_t stream_a = CreateStream();
+  ASSERT_NE(nullptr, stream_a);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream_a, /*count=*/3));
+
+  // A fresh stream starts its timeline at zero, behind the stream that has been
+  // recording the event.
+  hipStream_t stream_b = CreateStream();
+  ASSERT_NE(nullptr, stream_b);
+
+  StreamGate gate;
+  ScopedHostCallbacks callbacks;
+  ASSERT_NO_FATAL_FAILURE(
+      EnqueueGateAndWaitUntilEntered(stream_b, &gate, &callbacks));
+
+  ASSERT_EQ(hipSuccess, event_record_(event, stream_b));
+  EXPECT_EQ(hipErrorNotReady, event_query_(event))
+      << "event completed while the gate callback holding its recording stream "
+         "is still running";
+
+  callbacks.ReleaseGate();
+  EXPECT_EQ(hipSuccess, event_synchronize_(event));
+  EXPECT_EQ(hipSuccess, event_query_(event));
+  EXPECT_EQ(hipSuccess, stream_synchronize_(stream_b));
+}
+
+// Recording a shared event on a second stream must not make that stream wait
+// for the first one. Nothing was submitted between the two records, so the
+// streams are independent, and the second one drains while the first is still
+// parked in its gate.
+//
+// Any implementation in which both records signal one timeline the event
+// carries across streams chains the second stream behind the first, whether it
+// orders the two records explicitly or the queue holds the later submission
+// because an earlier one is already due to signal a higher value on the same
+// timeline. Either way this test blocks in hipStreamSynchronize until the outer
+// harness kills it: the gate is deliberately still held at that point, so there
+// is no wall-clock threshold here that a slow machine could turn into a false
+// pass.
+TEST_F(HipEventTest, CrossStreamRerecordDoesNotChainTheNewStreamToTheOldOne) {
+  hipStream_t stream_a = CreateStream();
+  ASSERT_NE(nullptr, stream_a);
+  hipStream_t stream_b = CreateStream();
+  ASSERT_NE(nullptr, stream_b);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+
+  StreamGate gate;
+  ScopedHostCallbacks callbacks;
+  ASSERT_NO_FATAL_FAILURE(
+      EnqueueGateAndWaitUntilEntered(stream_a, &gate, &callbacks));
+
+  ASSERT_EQ(hipSuccess, event_record_(event, stream_a));
+  ASSERT_EQ(hipSuccess, event_record_(event, stream_b));
+
+  EXPECT_EQ(hipSuccess, stream_synchronize_(stream_b));
+  // The event names the last record, which is the one on the stream that just
+  // drained, so waiting on the event must not reach back to the parked stream
+  // either.
+  EXPECT_EQ(hipSuccess, event_query_(event));
+  EXPECT_EQ(hipSuccess, event_synchronize_(event));
+  EXPECT_FALSE(gate.finished.load(std::memory_order_acquire))
+      << "the gate was released before the independent stream was observed";
+
+  callbacks.ReleaseGate();
+  EXPECT_EQ(hipSuccess, stream_synchronize_(stream_a));
+}
+
+// Destroying the stream an event was recorded on has to leave the event
+// queryable, and re-recording it elsewhere has to let go of what it was
+// holding. The leak checker and AddressSanitizer are what watch the second
+// half: a reference kept too long shows up as a leak, and one dropped too early
+// as a use after free.
+//
+// The stream object outlives hipStreamDestroy here, because the event holds it
+// for the capture state a wait on a captured event picks up. What this pins is
+// therefore the handle-level contract and the lifetime of that reference - the
+// re-record below releases a stream whose handle is already gone - rather than
+// the event's reference to the timeline itself. The graph executable case is
+// where that reference is the only thing holding the timeline up.
+TEST_F(HipEventTest, EventStaysUsableAfterItsRecordingStreamHandleIsDestroyed) {
+  hipStream_t stream_a = CreateStream();
+  ASSERT_NE(nullptr, stream_a);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream_a, /*count=*/2));
+
+  ASSERT_NO_FATAL_FAILURE(DestroyStream(stream_a));
+  EXPECT_EQ(hipSuccess, event_query_(event));
+  EXPECT_EQ(hipSuccess, event_synchronize_(event));
+
+  hipStream_t stream_b = CreateStream();
+  ASSERT_NE(nullptr, stream_b);
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream_b, /*count=*/1));
+  EXPECT_EQ(hipSuccess, event_query_(event));
+}
+
+// A record node in the middle of a graph marks a point on a timeline the graph
+// executable owns and the caller never sees, and a graph launch deliberately
+// does not adopt the launching stream. Nothing but the event's own reference to
+// that timeline is left once the executable is destroyed, which is what this
+// pins: the event has to stay queryable afterwards, and re-recording it
+// elsewhere has to let the timeline go.
+TEST_F(HipEventTest, EventStaysUsableAfterTheRecordingGraphExecutableIsGone) {
+  hipStream_t stream = CreateStream();
+  ASSERT_NE(nullptr, stream);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+
+  // The node behind the record node is what puts the record in a partition of
+  // its own; without it the record would land in the final partition and name
+  // the stream timeline, which outlives the executable on its own.
+  hipGraph_t graph = CreateGraph();
+  ASSERT_NE(nullptr, graph);
+  hipGraphNode_t record_node = nullptr;
+  ASSERT_EQ(hipSuccess, graph_add_event_record_node_(
+                            &record_node, graph, /*dependencies=*/nullptr,
+                            /*dependency_count=*/0, event));
+  std::atomic<bool> host_node_ran{false};
+  hipHostNodeParams host_params = {};
+  host_params.fn = &RanHostFunction;
+  host_params.userData = &host_node_ran;
+  hipGraphNode_t host_node = nullptr;
+  ASSERT_EQ(hipSuccess,
+            graph_add_host_node_(&host_node, graph, &record_node,
+                                 /*dependency_count=*/1, &host_params));
+  hipGraphExec_t graph_exec = InstantiateGraph(graph);
+  ASSERT_NE(nullptr, graph_exec);
+
+  ScopedHostCallbacks callbacks;
+  ASSERT_EQ(hipSuccess, graph_launch_(graph_exec, stream));
+  callbacks.Add(host_node_ran);
+  ASSERT_EQ(hipSuccess, stream_synchronize_(stream));
+
+  ASSERT_NO_FATAL_FAILURE(DestroyGraphExec(graph_exec));
+  ASSERT_NO_FATAL_FAILURE(DestroyGraph(graph));
+
+  EXPECT_EQ(hipSuccess, event_query_(event));
+  EXPECT_EQ(hipSuccess, event_synchronize_(event));
+
+  hipStream_t stream_b = CreateStream();
+  ASSERT_NE(nullptr, stream_b);
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream_b, /*count=*/1));
+  EXPECT_EQ(hipSuccess, event_query_(event));
+}
+
+// A cross-stream re-record must leave the event usable as a dependency for
+// another stream: the point the record names has to be one the recording stream
+// actually reaches, and work gated on it through hipStreamWaitEvent has to run
+// only after that stream drains. A record naming a point nothing will ever
+// reach shows up here as the stream_c synchronize never returning.
+//
+// This is a contract check on correct behavior rather than a discriminator for
+// the stale-target defect the first test covers. With a stale target the gated
+// callback still could not run early, because both callbacks execute on the one
+// queue thread that the parked gate is occupying.
+TEST_F(HipEventTest, CrossStreamRerecordStaysUsableAsStreamWaitDependency) {
+  hipStream_t stream_a = CreateStream();
+  ASSERT_NE(nullptr, stream_a);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream_a, /*count=*/3));
+
+  hipStream_t stream_b = CreateStream();
+  ASSERT_NE(nullptr, stream_b);
+  hipStream_t stream_c = CreateStream();
+  ASSERT_NE(nullptr, stream_c);
+
+  StreamGate gate;
+  StreamMarker marker;
+  marker.gate = &gate;
+  ScopedHostCallbacks callbacks;
+  ASSERT_NO_FATAL_FAILURE(
+      EnqueueGateAndWaitUntilEntered(stream_b, &gate, &callbacks));
+
+  ASSERT_EQ(hipSuccess, event_record_(event, stream_b));
+  ASSERT_EQ(hipSuccess, stream_wait_event_(stream_c, event, /*flags=*/0));
+  ASSERT_EQ(hipSuccess,
+            launch_host_func_(stream_c, &MarkerHostFunction, &marker));
+  callbacks.Add(marker.finished);
+
+  callbacks.ReleaseGate();
+  EXPECT_EQ(hipSuccess, stream_synchronize_(stream_c));
+  EXPECT_EQ(hipSuccess, stream_synchronize_(stream_b));
+
+  EXPECT_TRUE(marker.finished.load(std::memory_order_acquire))
+      << "work gated on the re-recorded event never ran";
+  EXPECT_TRUE(marker.saw_gate_finished.load(std::memory_order_acquire))
+      << "work gated on the re-recorded event ran before the stream that "
+         "recorded the event drained";
+}
+
+// Waiting on an event does not release a stream from its own ordering. The wait
+// is submitted behind work that is still parked and its completion advances the
+// stream timeline, so a wait that does not also wait for the work in front of
+// it would let the stream report itself drained while that work is still
+// running.
+//
+// This is a contract check rather than a discriminator for the missing wait on
+// its own: the queue independently holds a submission that signals a timeline
+// value behind an earlier submission signaling a lower value on the same
+// timeline, which covers for the missing dependency here. It fails if either
+// mechanism regresses, and it is the only thing standing behind the ordering if
+// the queue ever stops serializing signals it does not have to.
+TEST_F(HipEventTest, StreamWaitEventStaysOrderedBehindPriorStreamWork) {
+  hipStream_t stream_a = CreateStream();
+  ASSERT_NE(nullptr, stream_a);
+  hipStream_t stream_b = CreateStream();
+  ASSERT_NE(nullptr, stream_b);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+
+  // The event is complete before the wait is submitted, so nothing but the
+  // stream's own ordering can hold the wait back.
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream_a, /*count=*/1));
+
+  StreamGate gate;
+  ScopedHostCallbacks callbacks;
+  ASSERT_NO_FATAL_FAILURE(
+      EnqueueGateAndWaitUntilEntered(stream_b, &gate, &callbacks));
+
+  ASSERT_EQ(hipSuccess, stream_wait_event_(stream_b, event, /*flags=*/0));
+
+  callbacks.ReleaseGate();
+  EXPECT_EQ(hipSuccess, stream_synchronize_(stream_b));
+  EXPECT_TRUE(gate.finished.load(std::memory_order_acquire))
+      << "the stream reported itself drained while work submitted before the "
+         "event wait was still running";
+}
+
+// Both halves of a stream event wait can be absent at once: a stream that has
+// never submitted has nothing behind it to stay ordered against, and an event
+// with no submitted record has no point to wait for. The barrier that carries
+// the wait goes out with an empty wait list and still has to be accepted and
+// still has to signal the stream, which is what the synchronize proves - a
+// barrier that was never submitted leaves the stream naming a value nothing
+// will reach, and the synchronize would not return.
+TEST_F(HipEventTest, StreamWaitOnANeverRecordedEventDropsBothWaits) {
+  hipStream_t stream = CreateStream();
+  ASSERT_NE(nullptr, stream);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+
+  ASSERT_EQ(hipSuccess, stream_wait_event_(stream, event, /*flags=*/0));
+  EXPECT_EQ(hipSuccess, stream_synchronize_(stream));
+
+  // The stream has now submitted, so the same wait keeps the stream half and
+  // drops only the event half.
+  ASSERT_EQ(hipSuccess, stream_wait_event_(stream, event, /*flags=*/0));
+  EXPECT_EQ(hipSuccess, stream_synchronize_(stream));
+
+  // And once the event has a record the wait carries both halves again.
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream, /*count=*/1));
+  ASSERT_EQ(hipSuccess, stream_wait_event_(stream, event, /*flags=*/0));
+  EXPECT_EQ(hipSuccess, stream_synchronize_(stream));
+}
+
+// A graph event wait node on an event with no submitted record has nothing to
+// wait for, so the wait is dropped and the block goes out with whatever waits
+// the schedule gave it. The node behind it still has to run: a block that
+// instead waited on value zero of a timeline it never got would either never be
+// submitted or never be satisfied, and the synchronize below would not return.
+TEST_F(HipEventTest, GraphEventWaitNodeOnANeverRecordedEventDropsTheWait) {
+  hipStream_t stream = CreateStream();
+  ASSERT_NE(nullptr, stream);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+
+  hipGraph_t graph = CreateGraph();
+  ASSERT_NE(nullptr, graph);
+  hipGraphNode_t wait_node = nullptr;
+  ASSERT_EQ(hipSuccess,
+            graph_add_event_wait_node_(&wait_node, graph,
+                                       /*dependencies=*/nullptr,
+                                       /*dependency_count=*/0, event));
+  std::atomic<bool> host_node_ran{false};
+  hipHostNodeParams host_params = {};
+  host_params.fn = &RanHostFunction;
+  host_params.userData = &host_node_ran;
+  hipGraphNode_t host_node = nullptr;
+  ASSERT_EQ(hipSuccess,
+            graph_add_host_node_(&host_node, graph, &wait_node,
+                                 /*dependency_count=*/1, &host_params));
+  hipGraphExec_t graph_exec = InstantiateGraph(graph);
+  ASSERT_NE(nullptr, graph_exec);
+
+  ScopedHostCallbacks callbacks;
+  ASSERT_EQ(hipSuccess, graph_launch_(graph_exec, stream));
+  callbacks.Add(host_node_ran);
+  EXPECT_EQ(hipSuccess, stream_synchronize_(stream));
+  EXPECT_TRUE(host_node_ran.load(std::memory_order_acquire))
+      << "the node behind a dropped event wait never ran";
+}
+
+// A graph whose only node records an event marks the point the launch itself
+// reaches. Launching it onto a parked stream cannot get there, so the event has
+// to read as not ready until the stream drains; a launch that left the event
+// naming a point one of its earlier records already reached would read as
+// complete here, and one that named a point the launch never signals would hang
+// in the synchronize below.
+//
+// What no test in this file reaches is what the event does when a block fails
+// to submit. Everything a block is submitted with comes from the graph and the
+// stream rather than from the caller, so nothing reachable through the HIP
+// surface makes the queue reject one; covering the rollback needs a HAL device
+// that can be told to fail, which is a seam below this layer.
+TEST_F(HipEventTest, GraphRecordNodeAtTheEndOfAGraphMarksTheLaunchPoint) {
+  hipStream_t stream = CreateStream();
+  ASSERT_NE(nullptr, stream);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+
+  // Stream records and graph records have to interleave on one event: the point
+  // a stream record leaves behind must not confuse the graph record after it.
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream, /*count=*/2));
+
+  hipGraph_t graph = CreateGraph();
+  ASSERT_NE(nullptr, graph);
+  hipGraphNode_t node = nullptr;
+  ASSERT_EQ(hipSuccess,
+            graph_add_event_record_node_(&node, graph, /*dependencies=*/nullptr,
+                                         /*dependency_count=*/0, event));
+  hipGraphExec_t graph_exec = InstantiateGraph(graph);
+  ASSERT_NE(nullptr, graph_exec);
+
+  StreamGate gate;
+  ScopedHostCallbacks callbacks;
+  ASSERT_NO_FATAL_FAILURE(
+      EnqueueGateAndWaitUntilEntered(stream, &gate, &callbacks));
+
+  ASSERT_EQ(hipSuccess, graph_launch_(graph_exec, stream));
+  EXPECT_EQ(hipErrorNotReady, event_query_(event))
+      << "event completed while the gate callback holding the stream the graph "
+         "launched onto is still running";
+
+  callbacks.ReleaseGate();
+  EXPECT_EQ(hipSuccess, event_synchronize_(event));
+  EXPECT_EQ(hipSuccess, event_query_(event));
+
+  // Repeated launches keep naming a fresh point, and stream records keep
+  // working on an event a graph has been recording.
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_EQ(hipSuccess, graph_launch_(graph_exec, stream));
+    EXPECT_EQ(hipSuccess, event_synchronize_(event));
+    EXPECT_EQ(hipSuccess, event_query_(event));
+  }
+  EXPECT_EQ(hipSuccess, stream_synchronize_(stream));
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream, /*count=*/1));
+}
+
+// A record node with a node after it marks the point that node reaches rather
+// than the point the whole launch reaches, and those are different timelines in
+// the implementation: the launch signals the stream, while a node in the middle
+// signals one of the executable's internal semaphores. The event still must not
+// read as complete while the launch is parked, and the node after the record
+// node still has to run behind everything in front of the launch.
+TEST_F(HipEventTest, GraphRecordNodeInsideAGraphMarksTheNodePoint) {
+  hipStream_t stream = CreateStream();
+  ASSERT_NE(nullptr, stream);
+  hipEvent_t event = CreateEvent();
+  ASSERT_NE(nullptr, event);
+
+  hipGraph_t graph = CreateGraph();
+  ASSERT_NE(nullptr, graph);
+  hipGraphNode_t record_node = nullptr;
+  ASSERT_EQ(hipSuccess, graph_add_event_record_node_(
+                            &record_node, graph, /*dependencies=*/nullptr,
+                            /*dependency_count=*/0, event));
+
+  StreamGate gate;
+  StreamMarker marker;
+  marker.gate = &gate;
+  hipHostNodeParams host_params = {};
+  host_params.fn = &MarkerHostFunction;
+  host_params.userData = &marker;
+  hipGraphNode_t host_node = nullptr;
+  ASSERT_EQ(hipSuccess,
+            graph_add_host_node_(&host_node, graph, &record_node,
+                                 /*dependency_count=*/1, &host_params));
+
+  hipGraphExec_t graph_exec = InstantiateGraph(graph);
+  ASSERT_NE(nullptr, graph_exec);
+
+  ScopedHostCallbacks callbacks;
+  ASSERT_NO_FATAL_FAILURE(
+      EnqueueGateAndWaitUntilEntered(stream, &gate, &callbacks));
+
+  ASSERT_EQ(hipSuccess, graph_launch_(graph_exec, stream));
+  callbacks.Add(marker.finished);
+  EXPECT_EQ(hipErrorNotReady, event_query_(event))
+      << "event completed while the gate callback holding the stream the graph "
+         "launched onto is still running";
+
+  callbacks.ReleaseGate();
+  EXPECT_EQ(hipSuccess, event_synchronize_(event));
+  EXPECT_EQ(hipSuccess, event_query_(event));
+  EXPECT_EQ(hipSuccess, stream_synchronize_(stream));
+  EXPECT_TRUE(marker.saw_gate_finished.load(std::memory_order_acquire))
+      << "the node after the record node ran before the work in front of the "
+         "launch drained";
+}
+
+// Elapsed time reads the timestamp a record leaves behind, which is adopted
+// with the recorded point and only once the submission carrying it has been
+// accepted. An event with no submitted record therefore has no timestamp and no
+// interval to report, and two that do have one span a non-negative interval,
+// since the stop event is recorded after the start event returns.
+TEST_F(HipEventTest, ElapsedTimeNeedsBothEventsRecorded) {
+  hipStream_t stream = CreateStream();
+  ASSERT_NE(nullptr, stream);
+  hipEvent_t start = CreateEvent();
+  ASSERT_NE(nullptr, start);
+  hipEvent_t stop = CreateEvent();
+  ASSERT_NE(nullptr, stop);
+
+  float ms = -1.0f;
+  EXPECT_EQ(hipErrorInvalidHandle, event_elapsed_time_(&ms, start, stop));
+
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(start, stream, /*count=*/1));
+  EXPECT_EQ(hipErrorInvalidHandle, event_elapsed_time_(&ms, start, stop))
+      << "an interval was reported for an event that was never recorded";
+
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(stop, stream, /*count=*/1));
+  ms = -1.0f;
+  EXPECT_EQ(hipSuccess, event_elapsed_time_(&ms, start, stop));
+  EXPECT_GE(ms, 0.0f);
+}
+
+// Both events have to have completed before an interval means anything, so a
+// stop event whose record is still parked behind work on its stream reports as
+// not ready rather than reporting the interval up to the point it was issued.
+TEST_F(HipEventTest, ElapsedTimeIsNotReadyWhileAnEventIsOutstanding) {
+  hipStream_t stream_a = CreateStream();
+  ASSERT_NE(nullptr, stream_a);
+  hipStream_t stream_b = CreateStream();
+  ASSERT_NE(nullptr, stream_b);
+  hipEvent_t start = CreateEvent();
+  ASSERT_NE(nullptr, start);
+  hipEvent_t stop = CreateEvent();
+  ASSERT_NE(nullptr, stop);
+
+  ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(start, stream_a, /*count=*/1));
+
+  StreamGate gate;
+  ScopedHostCallbacks callbacks;
+  ASSERT_NO_FATAL_FAILURE(
+      EnqueueGateAndWaitUntilEntered(stream_b, &gate, &callbacks));
+  ASSERT_EQ(hipSuccess, event_record_(stop, stream_b));
+
+  float ms = -1.0f;
+  EXPECT_EQ(hipErrorNotReady, event_elapsed_time_(&ms, start, stop));
+
+  callbacks.ReleaseGate();
+  ASSERT_EQ(hipSuccess, event_synchronize_(stop));
+  ms = -1.0f;
+  EXPECT_EQ(hipSuccess, event_elapsed_time_(&ms, start, stop));
+  EXPECT_GE(ms, 0.0f);
+}
+
+// A record issued while its stream is capturing produces neither a submission
+// nor a graph node, only a snapshot of the capture frontier, so it leaves the
+// event with no point and no timestamp. There is no moment for a timestamp to
+// describe: the graph the capture builds has not run and may never run. Elapsed
+// time over such an event is therefore rejected the same way it rejects an
+// event that was never recorded, rather than reporting the host-side gap
+// between two calls made while building a graph.
+TEST_F(HipEventTest, ElapsedTimeRejectsEventsRecordedOnlyDuringCapture) {
+  hipStream_t stream = CreateStream();
+  ASSERT_NE(nullptr, stream);
+  hipEvent_t start = CreateEvent();
+  ASSERT_NE(nullptr, start);
+  hipEvent_t stop = CreateEvent();
+  ASSERT_NE(nullptr, stop);
+
+  ASSERT_EQ(hipSuccess,
+            stream_begin_capture_(stream, hipStreamCaptureModeGlobal));
+  ASSERT_EQ(hipSuccess, event_record_(start, stream));
+  ASSERT_EQ(hipSuccess, event_record_(stop, stream));
+  hipGraph_t graph = nullptr;
+  ASSERT_EQ(hipSuccess, stream_end_capture_(stream, &graph));
+  TrackGraph(graph);
+  ASSERT_NE(nullptr, graph);
+
+  float ms = -1.0f;
+  EXPECT_EQ(hipErrorInvalidHandle, event_elapsed_time_(&ms, start, stop))
+      << "an interval was reported for records that were never submitted";
+}
+
+}  // namespace

--- a/libhrx/cts/tests/hip/event_test.cpp
+++ b/libhrx/cts/tests/hip/event_test.cpp
@@ -167,74 +167,76 @@ class HipEventTest : public ::testing::Test {
     ASSERT_NE(nullptr, library_)
         << "cannot dlopen " << CandidateLibPath() << ": " << dlerror();
 
-    init_ = ResolveHipSymbol<HipInitFn>(library_, "hipInit");
-    stream_create_ =
+    hip_.init = ResolveHipSymbol<HipInitFn>(library_, "hipInit");
+    hip_.stream_create =
         ResolveHipSymbol<HipStreamCreateFn>(library_, "hipStreamCreate");
-    stream_destroy_ =
+    hip_.stream_destroy =
         ResolveHipSymbol<HipStreamDestroyFn>(library_, "hipStreamDestroy");
-    stream_synchronize_ = ResolveHipSymbol<HipStreamSynchronizeFn>(
+    hip_.stream_synchronize = ResolveHipSymbol<HipStreamSynchronizeFn>(
         library_, "hipStreamSynchronize");
-    stream_wait_event_ =
+    hip_.stream_wait_event =
         ResolveHipSymbol<HipStreamWaitEventFn>(library_, "hipStreamWaitEvent");
-    stream_begin_capture_ = ResolveHipSymbol<HipStreamBeginCaptureFn>(
+    hip_.stream_begin_capture = ResolveHipSymbol<HipStreamBeginCaptureFn>(
         library_, "hipStreamBeginCapture");
-    stream_end_capture_ = ResolveHipSymbol<HipStreamEndCaptureFn>(
+    hip_.stream_end_capture = ResolveHipSymbol<HipStreamEndCaptureFn>(
         library_, "hipStreamEndCapture");
-    event_create_ =
+    hip_.event_create =
         ResolveHipSymbol<HipEventCreateFn>(library_, "hipEventCreate");
-    event_destroy_ =
+    hip_.event_destroy =
         ResolveHipSymbol<HipEventDestroyFn>(library_, "hipEventDestroy");
-    event_record_ =
+    hip_.event_record =
         ResolveHipSymbol<HipEventRecordFn>(library_, "hipEventRecord");
-    event_query_ = ResolveHipSymbol<HipEventQueryFn>(library_, "hipEventQuery");
-    event_synchronize_ = ResolveHipSymbol<HipEventSynchronizeFn>(
+    hip_.event_query =
+        ResolveHipSymbol<HipEventQueryFn>(library_, "hipEventQuery");
+    hip_.event_synchronize = ResolveHipSymbol<HipEventSynchronizeFn>(
         library_, "hipEventSynchronize");
-    event_elapsed_time_ = ResolveHipSymbol<HipEventElapsedTimeFn>(
+    hip_.event_elapsed_time = ResolveHipSymbol<HipEventElapsedTimeFn>(
         library_, "hipEventElapsedTime");
-    launch_host_func_ =
+    hip_.launch_host_func =
         ResolveHipSymbol<HipLaunchHostFuncFn>(library_, "hipLaunchHostFunc");
-    graph_create_ =
+    hip_.graph_create =
         ResolveHipSymbol<HipGraphCreateFn>(library_, "hipGraphCreate");
-    graph_destroy_ =
+    hip_.graph_destroy =
         ResolveHipSymbol<HipGraphDestroyFn>(library_, "hipGraphDestroy");
-    graph_add_event_record_node_ =
+    hip_.graph_add_event_record_node =
         ResolveHipSymbol<HipGraphAddEventRecordNodeFn>(
             library_, "hipGraphAddEventRecordNode");
-    graph_add_event_wait_node_ = ResolveHipSymbol<HipGraphAddEventWaitNodeFn>(
-        library_, "hipGraphAddEventWaitNode");
-    graph_add_host_node_ = ResolveHipSymbol<HipGraphAddHostNodeFn>(
+    hip_.graph_add_event_wait_node =
+        ResolveHipSymbol<HipGraphAddEventWaitNodeFn>(
+            library_, "hipGraphAddEventWaitNode");
+    hip_.graph_add_host_node = ResolveHipSymbol<HipGraphAddHostNodeFn>(
         library_, "hipGraphAddHostNode");
-    graph_instantiate_ = ResolveHipSymbol<HipGraphInstantiateFn>(
+    hip_.graph_instantiate = ResolveHipSymbol<HipGraphInstantiateFn>(
         library_, "hipGraphInstantiate");
-    graph_launch_ =
+    hip_.graph_launch =
         ResolveHipSymbol<HipGraphLaunchFn>(library_, "hipGraphLaunch");
-    graph_exec_destroy_ = ResolveHipSymbol<HipGraphExecDestroyFn>(
+    hip_.graph_exec_destroy = ResolveHipSymbol<HipGraphExecDestroyFn>(
         library_, "hipGraphExecDestroy");
 
-    ASSERT_NE(nullptr, init_);
-    ASSERT_NE(nullptr, stream_create_);
-    ASSERT_NE(nullptr, stream_destroy_);
-    ASSERT_NE(nullptr, stream_synchronize_);
-    ASSERT_NE(nullptr, stream_wait_event_);
-    ASSERT_NE(nullptr, stream_begin_capture_);
-    ASSERT_NE(nullptr, stream_end_capture_);
-    ASSERT_NE(nullptr, event_create_);
-    ASSERT_NE(nullptr, event_destroy_);
-    ASSERT_NE(nullptr, event_record_);
-    ASSERT_NE(nullptr, event_query_);
-    ASSERT_NE(nullptr, event_synchronize_);
-    ASSERT_NE(nullptr, event_elapsed_time_);
-    ASSERT_NE(nullptr, launch_host_func_);
-    ASSERT_NE(nullptr, graph_create_);
-    ASSERT_NE(nullptr, graph_destroy_);
-    ASSERT_NE(nullptr, graph_add_event_record_node_);
-    ASSERT_NE(nullptr, graph_add_event_wait_node_);
-    ASSERT_NE(nullptr, graph_add_host_node_);
-    ASSERT_NE(nullptr, graph_instantiate_);
-    ASSERT_NE(nullptr, graph_launch_);
-    ASSERT_NE(nullptr, graph_exec_destroy_);
+    ASSERT_NE(nullptr, hip_.init);
+    ASSERT_NE(nullptr, hip_.stream_create);
+    ASSERT_NE(nullptr, hip_.stream_destroy);
+    ASSERT_NE(nullptr, hip_.stream_synchronize);
+    ASSERT_NE(nullptr, hip_.stream_wait_event);
+    ASSERT_NE(nullptr, hip_.stream_begin_capture);
+    ASSERT_NE(nullptr, hip_.stream_end_capture);
+    ASSERT_NE(nullptr, hip_.event_create);
+    ASSERT_NE(nullptr, hip_.event_destroy);
+    ASSERT_NE(nullptr, hip_.event_record);
+    ASSERT_NE(nullptr, hip_.event_query);
+    ASSERT_NE(nullptr, hip_.event_synchronize);
+    ASSERT_NE(nullptr, hip_.event_elapsed_time);
+    ASSERT_NE(nullptr, hip_.launch_host_func);
+    ASSERT_NE(nullptr, hip_.graph_create);
+    ASSERT_NE(nullptr, hip_.graph_destroy);
+    ASSERT_NE(nullptr, hip_.graph_add_event_record_node);
+    ASSERT_NE(nullptr, hip_.graph_add_event_wait_node);
+    ASSERT_NE(nullptr, hip_.graph_add_host_node);
+    ASSERT_NE(nullptr, hip_.graph_instantiate);
+    ASSERT_NE(nullptr, hip_.graph_launch);
+    ASSERT_NE(nullptr, hip_.graph_exec_destroy);
 
-    const hipError_t init_result = init_(/*flags=*/0);
+    const hipError_t init_result = hip_.init(/*flags=*/0);
     if (init_result == hipErrorNoDevice) {
       GTEST_SKIP() << "no HIP device available";
     }
@@ -246,23 +248,23 @@ class HipEventTest : public ::testing::Test {
   // not also report leaks.
   void TearDown() override {
     for (auto it = graph_execs_.rbegin(); it != graph_execs_.rend(); ++it) {
-      EXPECT_EQ(hipSuccess, graph_exec_destroy_(*it));
+      EXPECT_EQ(hipSuccess, hip_.graph_exec_destroy(*it));
     }
     for (auto it = graphs_.rbegin(); it != graphs_.rend(); ++it) {
-      EXPECT_EQ(hipSuccess, graph_destroy_(*it));
+      EXPECT_EQ(hipSuccess, hip_.graph_destroy(*it));
     }
     for (auto it = events_.rbegin(); it != events_.rend(); ++it) {
-      EXPECT_EQ(hipSuccess, event_destroy_(*it));
+      EXPECT_EQ(hipSuccess, hip_.event_destroy(*it));
     }
     for (auto it = streams_.rbegin(); it != streams_.rend(); ++it) {
-      EXPECT_EQ(hipSuccess, stream_destroy_(*it));
+      EXPECT_EQ(hipSuccess, hip_.stream_destroy(*it));
     }
   }
 
   // Creates a stream owned by the fixture.
   hipStream_t CreateStream() {
     hipStream_t stream = nullptr;
-    EXPECT_EQ(hipSuccess, stream_create_(&stream));
+    EXPECT_EQ(hipSuccess, hip_.stream_create(&stream));
     if (stream) streams_.push_back(stream);
     return stream;
   }
@@ -271,13 +273,13 @@ class HipEventTest : public ::testing::Test {
   void DestroyStream(hipStream_t stream) {
     streams_.erase(std::remove(streams_.begin(), streams_.end(), stream),
                    streams_.end());
-    EXPECT_EQ(hipSuccess, stream_destroy_(stream));
+    EXPECT_EQ(hipSuccess, hip_.stream_destroy(stream));
   }
 
   // Creates an event owned by the fixture.
   hipEvent_t CreateEvent() {
     hipEvent_t event = nullptr;
-    EXPECT_EQ(hipSuccess, event_create_(&event));
+    EXPECT_EQ(hipSuccess, hip_.event_create(&event));
     if (event) events_.push_back(event);
     return event;
   }
@@ -285,7 +287,7 @@ class HipEventTest : public ::testing::Test {
   // Creates an empty graph owned by the fixture.
   hipGraph_t CreateGraph() {
     hipGraph_t graph = nullptr;
-    EXPECT_EQ(hipSuccess, graph_create_(&graph, /*flags=*/0));
+    EXPECT_EQ(hipSuccess, hip_.graph_create(&graph, /*flags=*/0));
     TrackGraph(graph);
     return graph;
   }
@@ -300,15 +302,15 @@ class HipEventTest : public ::testing::Test {
   void DestroyGraph(hipGraph_t graph) {
     graphs_.erase(std::remove(graphs_.begin(), graphs_.end(), graph),
                   graphs_.end());
-    EXPECT_EQ(hipSuccess, graph_destroy_(graph));
+    EXPECT_EQ(hipSuccess, hip_.graph_destroy(graph));
   }
 
   // Instantiates |graph| into an executable owned by the fixture.
   hipGraphExec_t InstantiateGraph(hipGraph_t graph) {
     hipGraphExec_t graph_exec = nullptr;
-    EXPECT_EQ(hipSuccess,
-              graph_instantiate_(&graph_exec, graph, /*error_node=*/nullptr,
-                                 /*log_buffer=*/nullptr, /*buffer_size=*/0));
+    EXPECT_EQ(hipSuccess, hip_.graph_instantiate(
+                              &graph_exec, graph, /*error_node=*/nullptr,
+                              /*log_buffer=*/nullptr, /*buffer_size=*/0));
     if (graph_exec) graph_execs_.push_back(graph_exec);
     return graph_exec;
   }
@@ -318,24 +320,25 @@ class HipEventTest : public ::testing::Test {
     graph_execs_.erase(
         std::remove(graph_execs_.begin(), graph_execs_.end(), graph_exec),
         graph_execs_.end());
-    EXPECT_EQ(hipSuccess, graph_exec_destroy_(graph_exec));
+    EXPECT_EQ(hipSuccess, hip_.graph_exec_destroy(graph_exec));
   }
 
   // Records |event| on |stream| and waits for it |count| times, leaving both
   // the stream and the event drained.
   void AdvanceEventOnStream(hipEvent_t event, hipStream_t stream, int count) {
     for (int i = 0; i < count; ++i) {
-      ASSERT_EQ(hipSuccess, event_record_(event, stream));
-      ASSERT_EQ(hipSuccess, event_synchronize_(event));
+      ASSERT_EQ(hipSuccess, hip_.event_record(event, stream));
+      ASSERT_EQ(hipSuccess, hip_.event_synchronize(event));
     }
-    ASSERT_EQ(hipSuccess, stream_synchronize_(stream));
+    ASSERT_EQ(hipSuccess, hip_.stream_synchronize(stream));
   }
 
   // Enqueues |gate| on |stream|, registers it with |callbacks|, and returns
   // once the callback is running and the stream provably holds unfinished work.
   void EnqueueGateAndWaitUntilEntered(hipStream_t stream, StreamGate* gate,
                                       ScopedHostCallbacks* callbacks) {
-    ASSERT_EQ(hipSuccess, launch_host_func_(stream, &GateHostFunction, gate));
+    ASSERT_EQ(hipSuccess,
+              hip_.launch_host_func(stream, &GateHostFunction, gate));
     ASSERT_NO_FATAL_FAILURE(callbacks->AddGate(gate));
     while (!gate->entered.load(std::memory_order_acquire)) {
       sched_yield();
@@ -345,50 +348,33 @@ class HipEventTest : public ::testing::Test {
   // HIP shim under test. Intentionally never dlclose()d: the shim owns
   // process-global device state shared by every test in this file.
   void* library_ = nullptr;
-  // Resolved hipInit.
-  HipInitFn init_ = nullptr;
-  // Resolved hipStreamCreate.
-  HipStreamCreateFn stream_create_ = nullptr;
-  // Resolved hipStreamDestroy.
-  HipStreamDestroyFn stream_destroy_ = nullptr;
-  // Resolved hipStreamSynchronize.
-  HipStreamSynchronizeFn stream_synchronize_ = nullptr;
-  // Resolved hipStreamWaitEvent.
-  HipStreamWaitEventFn stream_wait_event_ = nullptr;
-  // Resolved hipStreamBeginCapture.
-  HipStreamBeginCaptureFn stream_begin_capture_ = nullptr;
-  // Resolved hipStreamEndCapture.
-  HipStreamEndCaptureFn stream_end_capture_ = nullptr;
-  // Resolved hipEventCreate.
-  HipEventCreateFn event_create_ = nullptr;
-  // Resolved hipEventDestroy.
-  HipEventDestroyFn event_destroy_ = nullptr;
-  // Resolved hipEventRecord.
-  HipEventRecordFn event_record_ = nullptr;
-  // Resolved hipEventQuery.
-  HipEventQueryFn event_query_ = nullptr;
-  // Resolved hipEventSynchronize.
-  HipEventSynchronizeFn event_synchronize_ = nullptr;
-  // Resolved hipEventElapsedTime.
-  HipEventElapsedTimeFn event_elapsed_time_ = nullptr;
-  // Resolved hipLaunchHostFunc.
-  HipLaunchHostFuncFn launch_host_func_ = nullptr;
-  // Resolved hipGraphCreate.
-  HipGraphCreateFn graph_create_ = nullptr;
-  // Resolved hipGraphDestroy.
-  HipGraphDestroyFn graph_destroy_ = nullptr;
-  // Resolved hipGraphAddEventRecordNode.
-  HipGraphAddEventRecordNodeFn graph_add_event_record_node_ = nullptr;
-  // Resolved hipGraphAddEventWaitNode.
-  HipGraphAddEventWaitNodeFn graph_add_event_wait_node_ = nullptr;
-  // Resolved hipGraphAddHostNode.
-  HipGraphAddHostNodeFn graph_add_host_node_ = nullptr;
-  // Resolved hipGraphInstantiate.
-  HipGraphInstantiateFn graph_instantiate_ = nullptr;
-  // Resolved hipGraphLaunch.
-  HipGraphLaunchFn graph_launch_ = nullptr;
-  // Resolved hipGraphExecDestroy.
-  HipGraphExecDestroyFn graph_exec_destroy_ = nullptr;
+  // Entry points resolved from |library_| by SetUp, each named for the hip*
+  // symbol it was resolved from. SetUp fails if any is unresolved, so every
+  // one is non-null for the duration of a test body.
+  struct {
+    HipInitFn init;
+    HipStreamCreateFn stream_create;
+    HipStreamDestroyFn stream_destroy;
+    HipStreamSynchronizeFn stream_synchronize;
+    HipStreamWaitEventFn stream_wait_event;
+    HipStreamBeginCaptureFn stream_begin_capture;
+    HipStreamEndCaptureFn stream_end_capture;
+    HipEventCreateFn event_create;
+    HipEventDestroyFn event_destroy;
+    HipEventRecordFn event_record;
+    HipEventQueryFn event_query;
+    HipEventSynchronizeFn event_synchronize;
+    HipEventElapsedTimeFn event_elapsed_time;
+    HipLaunchHostFuncFn launch_host_func;
+    HipGraphCreateFn graph_create;
+    HipGraphDestroyFn graph_destroy;
+    HipGraphAddEventRecordNodeFn graph_add_event_record_node;
+    HipGraphAddEventWaitNodeFn graph_add_event_wait_node;
+    HipGraphAddHostNodeFn graph_add_host_node;
+    HipGraphInstantiateFn graph_instantiate;
+    HipGraphLaunchFn graph_launch;
+    HipGraphExecDestroyFn graph_exec_destroy;
+  } hip_ = {};
 
  private:
   // Streams created through CreateStream, destroyed by TearDown.
@@ -421,15 +407,15 @@ TEST_F(HipEventTest, CrossStreamRerecordDoesNotReportStaleCompletion) {
   ASSERT_NO_FATAL_FAILURE(
       EnqueueGateAndWaitUntilEntered(stream_b, &gate, &callbacks));
 
-  ASSERT_EQ(hipSuccess, event_record_(event, stream_b));
-  EXPECT_EQ(hipErrorNotReady, event_query_(event))
+  ASSERT_EQ(hipSuccess, hip_.event_record(event, stream_b));
+  EXPECT_EQ(hipErrorNotReady, hip_.event_query(event))
       << "event completed while the gate callback holding its recording stream "
          "is still running";
 
   callbacks.ReleaseGate();
-  EXPECT_EQ(hipSuccess, event_synchronize_(event));
-  EXPECT_EQ(hipSuccess, event_query_(event));
-  EXPECT_EQ(hipSuccess, stream_synchronize_(stream_b));
+  EXPECT_EQ(hipSuccess, hip_.event_synchronize(event));
+  EXPECT_EQ(hipSuccess, hip_.event_query(event));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream_b));
 }
 
 // Recording a shared event on a second stream must not make that stream wait
@@ -449,19 +435,19 @@ TEST_F(HipEventTest, CrossStreamRerecordDoesNotChainTheNewStreamToTheOldOne) {
   ASSERT_NO_FATAL_FAILURE(
       EnqueueGateAndWaitUntilEntered(stream_a, &gate, &callbacks));
 
-  ASSERT_EQ(hipSuccess, event_record_(event, stream_a));
-  ASSERT_EQ(hipSuccess, event_record_(event, stream_b));
+  ASSERT_EQ(hipSuccess, hip_.event_record(event, stream_a));
+  ASSERT_EQ(hipSuccess, hip_.event_record(event, stream_b));
 
-  EXPECT_EQ(hipSuccess, stream_synchronize_(stream_b));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream_b));
   // The event names the last record, on the stream that just drained, so
   // waiting on it must not reach back to the parked stream either.
-  EXPECT_EQ(hipSuccess, event_query_(event));
-  EXPECT_EQ(hipSuccess, event_synchronize_(event));
+  EXPECT_EQ(hipSuccess, hip_.event_query(event));
+  EXPECT_EQ(hipSuccess, hip_.event_synchronize(event));
   EXPECT_FALSE(gate.finished.load(std::memory_order_acquire))
       << "the gate was released before the independent stream was observed";
 
   callbacks.ReleaseGate();
-  EXPECT_EQ(hipSuccess, stream_synchronize_(stream_a));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream_a));
 }
 
 // Destroying the stream an event was recorded on has to leave the event
@@ -476,13 +462,13 @@ TEST_F(HipEventTest, EventStaysUsableAfterItsRecordingStreamHandleIsDestroyed) {
   ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream_a, /*count=*/2));
 
   ASSERT_NO_FATAL_FAILURE(DestroyStream(stream_a));
-  EXPECT_EQ(hipSuccess, event_query_(event));
-  EXPECT_EQ(hipSuccess, event_synchronize_(event));
+  EXPECT_EQ(hipSuccess, hip_.event_query(event));
+  EXPECT_EQ(hipSuccess, hip_.event_synchronize(event));
 
   hipStream_t stream_b = CreateStream();
   ASSERT_NE(nullptr, stream_b);
   ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream_b, /*count=*/1));
-  EXPECT_EQ(hipSuccess, event_query_(event));
+  EXPECT_EQ(hipSuccess, hip_.event_query(event));
 }
 
 // A record node in the middle of a graph marks a point on a timeline the graph
@@ -501,7 +487,7 @@ TEST_F(HipEventTest, EventStaysUsableAfterTheRecordingGraphExecutableIsGone) {
   hipGraph_t graph = CreateGraph();
   ASSERT_NE(nullptr, graph);
   hipGraphNode_t record_node = nullptr;
-  ASSERT_EQ(hipSuccess, graph_add_event_record_node_(
+  ASSERT_EQ(hipSuccess, hip_.graph_add_event_record_node(
                             &record_node, graph, /*dependencies=*/nullptr,
                             /*dependency_count=*/0, event));
   std::atomic<bool> host_node_ran{false};
@@ -510,26 +496,26 @@ TEST_F(HipEventTest, EventStaysUsableAfterTheRecordingGraphExecutableIsGone) {
   host_params.userData = &host_node_ran;
   hipGraphNode_t host_node = nullptr;
   ASSERT_EQ(hipSuccess,
-            graph_add_host_node_(&host_node, graph, &record_node,
-                                 /*dependency_count=*/1, &host_params));
+            hip_.graph_add_host_node(&host_node, graph, &record_node,
+                                     /*dependency_count=*/1, &host_params));
   hipGraphExec_t graph_exec = InstantiateGraph(graph);
   ASSERT_NE(nullptr, graph_exec);
 
   ScopedHostCallbacks callbacks;
-  ASSERT_EQ(hipSuccess, graph_launch_(graph_exec, stream));
+  ASSERT_EQ(hipSuccess, hip_.graph_launch(graph_exec, stream));
   callbacks.Add(host_node_ran);
-  ASSERT_EQ(hipSuccess, stream_synchronize_(stream));
+  ASSERT_EQ(hipSuccess, hip_.stream_synchronize(stream));
 
   ASSERT_NO_FATAL_FAILURE(DestroyGraphExec(graph_exec));
   ASSERT_NO_FATAL_FAILURE(DestroyGraph(graph));
 
-  EXPECT_EQ(hipSuccess, event_query_(event));
-  EXPECT_EQ(hipSuccess, event_synchronize_(event));
+  EXPECT_EQ(hipSuccess, hip_.event_query(event));
+  EXPECT_EQ(hipSuccess, hip_.event_synchronize(event));
 
   hipStream_t stream_b = CreateStream();
   ASSERT_NE(nullptr, stream_b);
   ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream_b, /*count=*/1));
-  EXPECT_EQ(hipSuccess, event_query_(event));
+  EXPECT_EQ(hipSuccess, hip_.event_query(event));
 }
 
 // A cross-stream re-record must leave the event usable as a dependency for
@@ -555,15 +541,15 @@ TEST_F(HipEventTest, CrossStreamRerecordStaysUsableAsStreamWaitDependency) {
   ASSERT_NO_FATAL_FAILURE(
       EnqueueGateAndWaitUntilEntered(stream_b, &gate, &callbacks));
 
-  ASSERT_EQ(hipSuccess, event_record_(event, stream_b));
-  ASSERT_EQ(hipSuccess, stream_wait_event_(stream_c, event, /*flags=*/0));
+  ASSERT_EQ(hipSuccess, hip_.event_record(event, stream_b));
+  ASSERT_EQ(hipSuccess, hip_.stream_wait_event(stream_c, event, /*flags=*/0));
   ASSERT_EQ(hipSuccess,
-            launch_host_func_(stream_c, &MarkerHostFunction, &marker));
+            hip_.launch_host_func(stream_c, &MarkerHostFunction, &marker));
   callbacks.Add(marker.finished);
 
   callbacks.ReleaseGate();
-  EXPECT_EQ(hipSuccess, stream_synchronize_(stream_c));
-  EXPECT_EQ(hipSuccess, stream_synchronize_(stream_b));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream_c));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream_b));
 
   EXPECT_TRUE(marker.finished.load(std::memory_order_acquire))
       << "work gated on the re-recorded event never ran";
@@ -593,10 +579,10 @@ TEST_F(HipEventTest, StreamWaitEventStaysOrderedBehindPriorStreamWork) {
   ASSERT_NO_FATAL_FAILURE(
       EnqueueGateAndWaitUntilEntered(stream_b, &gate, &callbacks));
 
-  ASSERT_EQ(hipSuccess, stream_wait_event_(stream_b, event, /*flags=*/0));
+  ASSERT_EQ(hipSuccess, hip_.stream_wait_event(stream_b, event, /*flags=*/0));
 
   callbacks.ReleaseGate();
-  EXPECT_EQ(hipSuccess, stream_synchronize_(stream_b));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream_b));
   EXPECT_TRUE(gate.finished.load(std::memory_order_acquire))
       << "the stream reported itself drained while work submitted before the "
          "event wait was still running";
@@ -612,18 +598,18 @@ TEST_F(HipEventTest, StreamWaitOnANeverRecordedEventDropsBothWaits) {
   hipEvent_t event = CreateEvent();
   ASSERT_NE(nullptr, event);
 
-  ASSERT_EQ(hipSuccess, stream_wait_event_(stream, event, /*flags=*/0));
-  EXPECT_EQ(hipSuccess, stream_synchronize_(stream));
+  ASSERT_EQ(hipSuccess, hip_.stream_wait_event(stream, event, /*flags=*/0));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream));
 
   // The stream has now submitted, so the same wait keeps the stream half and
   // drops only the event half.
-  ASSERT_EQ(hipSuccess, stream_wait_event_(stream, event, /*flags=*/0));
-  EXPECT_EQ(hipSuccess, stream_synchronize_(stream));
+  ASSERT_EQ(hipSuccess, hip_.stream_wait_event(stream, event, /*flags=*/0));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream));
 
   // And once the event has a record the wait carries both halves again.
   ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream, /*count=*/1));
-  ASSERT_EQ(hipSuccess, stream_wait_event_(stream, event, /*flags=*/0));
-  EXPECT_EQ(hipSuccess, stream_synchronize_(stream));
+  ASSERT_EQ(hipSuccess, hip_.stream_wait_event(stream, event, /*flags=*/0));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream));
 }
 
 // A graph event wait node on an event with no submitted record has nothing to
@@ -639,24 +625,24 @@ TEST_F(HipEventTest, GraphEventWaitNodeOnANeverRecordedEventDropsTheWait) {
   ASSERT_NE(nullptr, graph);
   hipGraphNode_t wait_node = nullptr;
   ASSERT_EQ(hipSuccess,
-            graph_add_event_wait_node_(&wait_node, graph,
-                                       /*dependencies=*/nullptr,
-                                       /*dependency_count=*/0, event));
+            hip_.graph_add_event_wait_node(&wait_node, graph,
+                                           /*dependencies=*/nullptr,
+                                           /*dependency_count=*/0, event));
   std::atomic<bool> host_node_ran{false};
   hipHostNodeParams host_params = {};
   host_params.fn = &RanHostFunction;
   host_params.userData = &host_node_ran;
   hipGraphNode_t host_node = nullptr;
   ASSERT_EQ(hipSuccess,
-            graph_add_host_node_(&host_node, graph, &wait_node,
-                                 /*dependency_count=*/1, &host_params));
+            hip_.graph_add_host_node(&host_node, graph, &wait_node,
+                                     /*dependency_count=*/1, &host_params));
   hipGraphExec_t graph_exec = InstantiateGraph(graph);
   ASSERT_NE(nullptr, graph_exec);
 
   ScopedHostCallbacks callbacks;
-  ASSERT_EQ(hipSuccess, graph_launch_(graph_exec, stream));
+  ASSERT_EQ(hipSuccess, hip_.graph_launch(graph_exec, stream));
   callbacks.Add(host_node_ran);
-  EXPECT_EQ(hipSuccess, stream_synchronize_(stream));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream));
   EXPECT_TRUE(host_node_ran.load(std::memory_order_acquire))
       << "the node behind a dropped event wait never ran";
 }
@@ -676,9 +662,9 @@ TEST_F(HipEventTest, GraphRecordNodeAtTheEndOfAGraphMarksTheLaunchPoint) {
   hipGraph_t graph = CreateGraph();
   ASSERT_NE(nullptr, graph);
   hipGraphNode_t node = nullptr;
-  ASSERT_EQ(hipSuccess,
-            graph_add_event_record_node_(&node, graph, /*dependencies=*/nullptr,
-                                         /*dependency_count=*/0, event));
+  ASSERT_EQ(hipSuccess, hip_.graph_add_event_record_node(
+                            &node, graph, /*dependencies=*/nullptr,
+                            /*dependency_count=*/0, event));
   hipGraphExec_t graph_exec = InstantiateGraph(graph);
   ASSERT_NE(nullptr, graph_exec);
 
@@ -687,23 +673,23 @@ TEST_F(HipEventTest, GraphRecordNodeAtTheEndOfAGraphMarksTheLaunchPoint) {
   ASSERT_NO_FATAL_FAILURE(
       EnqueueGateAndWaitUntilEntered(stream, &gate, &callbacks));
 
-  ASSERT_EQ(hipSuccess, graph_launch_(graph_exec, stream));
-  EXPECT_EQ(hipErrorNotReady, event_query_(event))
+  ASSERT_EQ(hipSuccess, hip_.graph_launch(graph_exec, stream));
+  EXPECT_EQ(hipErrorNotReady, hip_.event_query(event))
       << "event completed while the gate callback holding the stream the graph "
          "launched onto is still running";
 
   callbacks.ReleaseGate();
-  EXPECT_EQ(hipSuccess, event_synchronize_(event));
-  EXPECT_EQ(hipSuccess, event_query_(event));
+  EXPECT_EQ(hipSuccess, hip_.event_synchronize(event));
+  EXPECT_EQ(hipSuccess, hip_.event_query(event));
 
   // Repeated launches keep naming a fresh point, and stream records keep
   // working on an event a graph has been recording.
   for (int i = 0; i < 3; ++i) {
-    ASSERT_EQ(hipSuccess, graph_launch_(graph_exec, stream));
-    EXPECT_EQ(hipSuccess, event_synchronize_(event));
-    EXPECT_EQ(hipSuccess, event_query_(event));
+    ASSERT_EQ(hipSuccess, hip_.graph_launch(graph_exec, stream));
+    EXPECT_EQ(hipSuccess, hip_.event_synchronize(event));
+    EXPECT_EQ(hipSuccess, hip_.event_query(event));
   }
-  EXPECT_EQ(hipSuccess, stream_synchronize_(stream));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream));
   ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(event, stream, /*count=*/1));
 }
 
@@ -720,7 +706,7 @@ TEST_F(HipEventTest, GraphRecordNodeInsideAGraphMarksTheNodePoint) {
   hipGraph_t graph = CreateGraph();
   ASSERT_NE(nullptr, graph);
   hipGraphNode_t record_node = nullptr;
-  ASSERT_EQ(hipSuccess, graph_add_event_record_node_(
+  ASSERT_EQ(hipSuccess, hip_.graph_add_event_record_node(
                             &record_node, graph, /*dependencies=*/nullptr,
                             /*dependency_count=*/0, event));
 
@@ -732,8 +718,8 @@ TEST_F(HipEventTest, GraphRecordNodeInsideAGraphMarksTheNodePoint) {
   host_params.userData = &marker;
   hipGraphNode_t host_node = nullptr;
   ASSERT_EQ(hipSuccess,
-            graph_add_host_node_(&host_node, graph, &record_node,
-                                 /*dependency_count=*/1, &host_params));
+            hip_.graph_add_host_node(&host_node, graph, &record_node,
+                                     /*dependency_count=*/1, &host_params));
 
   hipGraphExec_t graph_exec = InstantiateGraph(graph);
   ASSERT_NE(nullptr, graph_exec);
@@ -742,16 +728,16 @@ TEST_F(HipEventTest, GraphRecordNodeInsideAGraphMarksTheNodePoint) {
   ASSERT_NO_FATAL_FAILURE(
       EnqueueGateAndWaitUntilEntered(stream, &gate, &callbacks));
 
-  ASSERT_EQ(hipSuccess, graph_launch_(graph_exec, stream));
+  ASSERT_EQ(hipSuccess, hip_.graph_launch(graph_exec, stream));
   callbacks.Add(marker.finished);
-  EXPECT_EQ(hipErrorNotReady, event_query_(event))
+  EXPECT_EQ(hipErrorNotReady, hip_.event_query(event))
       << "event completed while the gate callback holding the stream the graph "
          "launched onto is still running";
 
   callbacks.ReleaseGate();
-  EXPECT_EQ(hipSuccess, event_synchronize_(event));
-  EXPECT_EQ(hipSuccess, event_query_(event));
-  EXPECT_EQ(hipSuccess, stream_synchronize_(stream));
+  EXPECT_EQ(hipSuccess, hip_.event_synchronize(event));
+  EXPECT_EQ(hipSuccess, hip_.event_query(event));
+  EXPECT_EQ(hipSuccess, hip_.stream_synchronize(stream));
   EXPECT_TRUE(marker.saw_gate_finished.load(std::memory_order_acquire))
       << "the node after the record node ran before the work in front of the "
          "launch drained";
@@ -769,15 +755,15 @@ TEST_F(HipEventTest, ElapsedTimeNeedsBothEventsRecorded) {
   ASSERT_NE(nullptr, stop);
 
   float ms = -1.0f;
-  EXPECT_EQ(hipErrorInvalidHandle, event_elapsed_time_(&ms, start, stop));
+  EXPECT_EQ(hipErrorInvalidHandle, hip_.event_elapsed_time(&ms, start, stop));
 
   ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(start, stream, /*count=*/1));
-  EXPECT_EQ(hipErrorInvalidHandle, event_elapsed_time_(&ms, start, stop))
+  EXPECT_EQ(hipErrorInvalidHandle, hip_.event_elapsed_time(&ms, start, stop))
       << "an interval was reported for an event that was never recorded";
 
   ASSERT_NO_FATAL_FAILURE(AdvanceEventOnStream(stop, stream, /*count=*/1));
   ms = -1.0f;
-  EXPECT_EQ(hipSuccess, event_elapsed_time_(&ms, start, stop));
+  EXPECT_EQ(hipSuccess, hip_.event_elapsed_time(&ms, start, stop));
   EXPECT_GE(ms, 0.0f);
 }
 
@@ -799,15 +785,15 @@ TEST_F(HipEventTest, ElapsedTimeIsNotReadyWhileAnEventIsOutstanding) {
   ScopedHostCallbacks callbacks;
   ASSERT_NO_FATAL_FAILURE(
       EnqueueGateAndWaitUntilEntered(stream_b, &gate, &callbacks));
-  ASSERT_EQ(hipSuccess, event_record_(stop, stream_b));
+  ASSERT_EQ(hipSuccess, hip_.event_record(stop, stream_b));
 
   float ms = -1.0f;
-  EXPECT_EQ(hipErrorNotReady, event_elapsed_time_(&ms, start, stop));
+  EXPECT_EQ(hipErrorNotReady, hip_.event_elapsed_time(&ms, start, stop));
 
   callbacks.ReleaseGate();
-  ASSERT_EQ(hipSuccess, event_synchronize_(stop));
+  ASSERT_EQ(hipSuccess, hip_.event_synchronize(stop));
   ms = -1.0f;
-  EXPECT_EQ(hipSuccess, event_elapsed_time_(&ms, start, stop));
+  EXPECT_EQ(hipSuccess, hip_.event_elapsed_time(&ms, start, stop));
   EXPECT_GE(ms, 0.0f);
 }
 
@@ -823,16 +809,16 @@ TEST_F(HipEventTest, ElapsedTimeRejectsEventsRecordedOnlyDuringCapture) {
   ASSERT_NE(nullptr, stop);
 
   ASSERT_EQ(hipSuccess,
-            stream_begin_capture_(stream, hipStreamCaptureModeGlobal));
-  ASSERT_EQ(hipSuccess, event_record_(start, stream));
-  ASSERT_EQ(hipSuccess, event_record_(stop, stream));
+            hip_.stream_begin_capture(stream, hipStreamCaptureModeGlobal));
+  ASSERT_EQ(hipSuccess, hip_.event_record(start, stream));
+  ASSERT_EQ(hipSuccess, hip_.event_record(stop, stream));
   hipGraph_t graph = nullptr;
-  ASSERT_EQ(hipSuccess, stream_end_capture_(stream, &graph));
+  ASSERT_EQ(hipSuccess, hip_.stream_end_capture(stream, &graph));
   TrackGraph(graph);
   ASSERT_NE(nullptr, graph);
 
   float ms = -1.0f;
-  EXPECT_EQ(hipErrorInvalidHandle, event_elapsed_time_(&ms, start, stop))
+  EXPECT_EQ(hipErrorInvalidHandle, hip_.event_elapsed_time(&ms, start, stop))
       << "an interval was reported for records that were never submitted";
 }
 

--- a/libhrx/src/binding/common/event.c
+++ b/libhrx/src/binding/common/event.c
@@ -10,8 +10,6 @@
 // Event management
 //===----------------------------------------------------------------------===//
 
-static void iree_hal_streaming_event_destroy(iree_hal_streaming_event_t* event);
-
 iree_status_t iree_hal_streaming_event_create(
     iree_hal_streaming_context_t* context,
     iree_hal_streaming_event_flags_t flags, iree_allocator_t host_allocator,
@@ -26,9 +24,12 @@ iree_status_t iree_hal_streaming_event_create(
       z0,
       iree_allocator_malloc(host_allocator, sizeof(*event), (void**)&event));
 
-  // Initialize event.
+  // Initialize event. An event holds no timeline of its own; it starts with no
+  // recorded point and takes a reference to one when a record is submitted.
   iree_atomic_ref_count_init(&event->ref_count);
   event->flags = flags;
+  iree_slim_mutex_initialize(&event->mutex);
+  event->signal_semaphore = NULL;
   event->signal_value = 0;
   event->recording_stream = NULL;
   event->context = context;
@@ -39,29 +40,20 @@ iree_status_t iree_hal_streaming_event_create(
   event->capture_dependencies = NULL;
   event->capture_dependency_count = 0;
   event->capture_dependency_capacity = 0;
-  event->semaphore = NULL;
   event->host_allocator = host_allocator;
 
-  // Create HAL semaphore for synchronization.
-  iree_status_t status = iree_hal_semaphore_create(
-      context->device, IREE_HAL_QUEUE_AFFINITY_ANY, 0ULL,
-      IREE_HAL_SEMAPHORE_FLAG_NONE, &event->semaphore);
-
-  if (iree_status_is_ok(status)) {
-    *out_event = event;
-  } else {
-    iree_hal_streaming_event_destroy(event);
-  }
+  *out_event = event;
   IREE_TRACE_ZONE_END(z0);
-  return status;
+  return iree_ok_status();
 }
 
 static void iree_hal_streaming_event_destroy(
     iree_hal_streaming_event_t* event) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  // Release semaphore.
-  iree_hal_semaphore_release(event->semaphore);
+  // Release the recorded point. The semaphore belongs to the stream or graph
+  // executable that carried the record, both of which may already be gone.
+  iree_hal_semaphore_release(event->signal_semaphore);
 
   // Release recording stream reference.
   iree_hal_streaming_stream_release(event->recording_stream);
@@ -73,6 +65,7 @@ static void iree_hal_streaming_event_destroy(
   iree_allocator_free(event->host_allocator, event->capture_dependencies);
 
   // Free event memory.
+  iree_slim_mutex_deinitialize(&event->mutex);
   iree_allocator_t host_allocator = event->host_allocator;
   iree_allocator_free(host_allocator, event);
 
@@ -91,19 +84,77 @@ void iree_hal_streaming_event_release(iree_hal_streaming_event_t* event) {
   }
 }
 
+void iree_hal_streaming_event_acquire_recorded_point(
+    iree_hal_streaming_event_t* event, iree_hal_semaphore_t** out_semaphore,
+    uint64_t* out_value) {
+  iree_slim_mutex_lock(&event->mutex);
+  *out_semaphore = event->signal_semaphore;
+  *out_value = event->signal_value;
+  iree_hal_semaphore_retain(*out_semaphore);
+  iree_slim_mutex_unlock(&event->mutex);
+}
+
+void iree_hal_streaming_event_commit_recorded_point(
+    iree_hal_streaming_event_t* event, iree_hal_semaphore_t* semaphore,
+    uint64_t value, iree_time_t record_time_ns) {
+  iree_hal_semaphore_retain(semaphore);
+  iree_slim_mutex_lock(&event->mutex);
+  iree_hal_semaphore_t* previous_semaphore = event->signal_semaphore;
+  event->signal_semaphore = semaphore;
+  event->signal_value = value;
+  event->record_time_ns = record_time_ns;
+  iree_slim_mutex_unlock(&event->mutex);
+  iree_hal_semaphore_release(previous_semaphore);
+}
+
+iree_hal_streaming_stream_t* iree_hal_streaming_event_exchange_recording_stream(
+    iree_hal_streaming_event_t* event, iree_hal_streaming_stream_t* stream) {
+  iree_slim_mutex_lock(&event->mutex);
+  iree_hal_streaming_stream_t* previous_stream = event->recording_stream;
+  if (previous_stream != stream) {
+    iree_hal_streaming_stream_retain(stream);
+    event->recording_stream = stream;
+  } else {
+    previous_stream = NULL;
+  }
+  iree_slim_mutex_unlock(&event->mutex);
+  return previous_stream;
+}
+
+iree_time_t iree_hal_streaming_event_record_time_ns(
+    iree_hal_streaming_event_t* event) {
+  iree_slim_mutex_lock(&event->mutex);
+  const iree_time_t record_time_ns = event->record_time_ns;
+  iree_slim_mutex_unlock(&event->mutex);
+  return record_time_ns;
+}
+
 iree_status_t iree_hal_streaming_event_query(iree_hal_streaming_event_t* event,
                                              int* status) {
   IREE_ASSERT_ARGUMENT(event);
   IREE_ASSERT_ARGUMENT(status);
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  uint64_t current_value = 0;
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_semaphore_query(event->semaphore, &current_value));
+  iree_hal_semaphore_t* semaphore = NULL;
+  uint64_t signal_value = 0;
+  iree_hal_streaming_event_acquire_recorded_point(event, &semaphore,
+                                                  &signal_value);
+  if (!semaphore) {
+    // Nothing has been submitted for this event, so there is nothing to wait
+    // for and the event reads as complete.
+    *status = 0;
+    IREE_TRACE_ZONE_END(z0);
+    return iree_ok_status();
+  }
 
-  *status = (current_value >= event->signal_value)
-                ? 0
-                : 1;  // 0=complete, 1=not complete
+  uint64_t current_value = 0;
+  iree_status_t query_status =
+      iree_hal_semaphore_query(semaphore, &current_value);
+  iree_hal_semaphore_release(semaphore);
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, query_status);
+
+  *status =
+      (current_value >= signal_value) ? 0 : 1;  // 0=complete, 1=not complete
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -117,12 +168,6 @@ iree_status_t iree_hal_streaming_event_record(
 
   // Check if we're capturing to a graph.
   if (stream->capture_status == IREE_HAL_STREAMING_CAPTURE_STATUS_ACTIVE) {
-    event->record_time_ns = iree_time_now();
-    if (event->recording_stream != stream) {
-      iree_hal_streaming_stream_release(event->recording_stream);
-      event->recording_stream = stream;
-      iree_hal_streaming_stream_retain(stream);
-    }
     if (event->capture_dependency_capacity < stream->capture_dependency_count) {
       IREE_RETURN_AND_END_ZONE_IF_ERROR(
           z0, iree_allocator_realloc(event->host_allocator,
@@ -142,19 +187,23 @@ iree_status_t iree_hal_streaming_event_record(
       event->capture_graph = stream->capture_graph;
       iree_hal_streaming_graph_retain(event->capture_graph);
     }
+    // A captured record produces neither a submission nor a graph node, only
+    // the frontier snapshot above, so there is no point for it to name and no
+    // moment for a timestamp to describe: both the recorded point and the
+    // record time are left naming the last submitted record. An event whose
+    // only record was captured therefore reads as never recorded, and elapsed
+    // time over it is rejected rather than reporting the host-side gap between
+    // two capture calls. The stream is adopted because a later wait on this
+    // event has to pick the capture up from the stream that captured it.
+    iree_hal_streaming_stream_release(
+        iree_hal_streaming_event_exchange_recording_stream(event, stream));
     IREE_TRACE_ZONE_END(z0);
     return iree_ok_status();
   }
 
-  event->record_time_ns = iree_time_now();
-
-  // Set recording stream so we can track when we cross streams in a signal/wait
-  // sequence.
-  if (event->recording_stream != stream) {
-    iree_hal_streaming_stream_release(event->recording_stream);
-    event->recording_stream = stream;
-    iree_hal_streaming_stream_retain(stream);
-  }
+  // Sampled before the submission so the timestamp reflects when the caller
+  // issued the record, and adopted only once that submission is accepted.
+  const iree_time_t record_time_ns = iree_time_now();
 
   // Flush the stream to ensure all prior operations are submitted.
   IREE_RETURN_AND_END_ZONE_IF_ERROR(z0,
@@ -162,26 +211,36 @@ iree_status_t iree_hal_streaming_event_record(
 
   iree_slim_mutex_lock(&stream->mutex);
 
-  // Use stream's current pending value as wait value and increment for signal.
-  uint64_t wait_value = stream->pending_value;
-  event->signal_value = wait_value + 1;
+  // The record marks a point on the recording stream's timeline: the barrier
+  // reserves the stream's next value under the stream mutex and signals it once
+  // everything already on the stream has completed. Every value on a stream
+  // timeline is reserved exactly once and only ever increases, so a record can
+  // never select a value that timeline has already passed no matter which
+  // stream recorded the event before, and two streams recording the same event
+  // at once draw from different timelines under different mutexes.
+  uint64_t stream_wait_value = stream->pending_value;
+  if (IREE_UNLIKELY(stream_wait_value == UINT64_MAX)) {
+    iree_slim_mutex_unlock(&stream->mutex);
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "stream timeline value overflow");
+  }
+  uint64_t stream_signal_value = stream_wait_value + 1;
 
-  // Create a queue barrier to signal the event semaphore.
-  // This waits for the stream's last submission to complete before signaling.
+  // The wait is dropped when the stream has never submitted, matching the other
+  // submission paths on the stream; nothing can be behind value zero.
   iree_hal_semaphore_list_t wait_semaphores = {
+      .count = stream_wait_value > 0 ? 1 : 0,
+      .semaphores = &stream->timeline_semaphore,
+      .payload_values = &stream_wait_value,
+  };
+  iree_hal_semaphore_list_t signal_semaphores = {
       .count = 1,
       .semaphores = &stream->timeline_semaphore,
-      .payload_values = &wait_value,
-  };
-  iree_hal_semaphore_t* semaphores[] = {stream->timeline_semaphore,
-                                        event->semaphore};
-  uint64_t signal_values[] = {event->signal_value, event->signal_value};
-  iree_hal_semaphore_list_t signal_semaphores = {
-      .count = 2,
-      .semaphores = semaphores,
-      .payload_values = signal_values,
+      .payload_values = &stream_signal_value,
   };
 
+  iree_hal_streaming_stream_t* previous_stream = NULL;
   iree_status_t status = iree_hal_device_queue_barrier(
       stream->context->device, stream->queue_affinity, wait_semaphores,
       signal_semaphores, IREE_HAL_EXECUTE_FLAG_NONE);
@@ -190,10 +249,21 @@ iree_status_t iree_hal_streaming_event_record(
                                          stream->queue_affinity);
   }
   if (iree_status_is_ok(status)) {
-    stream->pending_value = event->signal_value;
-    stream->submitted_value = event->signal_value;
+    stream->pending_value = stream_signal_value;
+    stream->submitted_value = stream_signal_value;
+    // A rejected submission signals nothing, so the event keeps its previous
+    // point instead of naming one that will never be reached.
+    iree_hal_streaming_event_commit_recorded_point(
+        event, stream->timeline_semaphore, stream_signal_value, record_time_ns);
+    previous_stream =
+        iree_hal_streaming_event_exchange_recording_stream(event, stream);
   }
   iree_slim_mutex_unlock(&stream->mutex);
+  // Dropping the last reference to the previously recording stream runs its
+  // teardown, which re-enters the streaming layer to synchronize the stream and
+  // unregister it from its context, so the reference is dropped only after this
+  // stream's mutex is released.
+  iree_hal_streaming_stream_release(previous_stream);
   IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, status);
 
   IREE_TRACE_ZONE_END(z0);
@@ -205,10 +275,25 @@ iree_status_t iree_hal_streaming_event_synchronize(
   IREE_ASSERT_ARGUMENT(event);
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_semaphore_wait(event->semaphore, event->signal_value,
-                                  iree_infinite_timeout(),
-                                  IREE_ASYNC_WAIT_FLAG_NONE));
+  iree_hal_semaphore_t* semaphore = NULL;
+  uint64_t signal_value = 0;
+  iree_hal_streaming_event_acquire_recorded_point(event, &semaphore,
+                                                  &signal_value);
+  if (!semaphore) {
+    // Nothing has been submitted for this event, so there is nothing to wait
+    // for.
+    IREE_TRACE_ZONE_END(z0);
+    return iree_ok_status();
+  }
+
+  // Waiting outside the event mutex leaves the event recordable while a wait on
+  // it is outstanding; the retained reference keeps the timeline alive across a
+  // concurrent re-record onto another one.
+  iree_status_t status =
+      iree_hal_semaphore_wait(semaphore, signal_value, iree_infinite_timeout(),
+                              IREE_ASYNC_WAIT_FLAG_NONE);
+  iree_hal_semaphore_release(semaphore);
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, status);
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -228,8 +313,14 @@ iree_status_t iree_hal_streaming_event_elapsed_time(
                             "cannot measure elapsed time with timing disabled");
   }
 
-  // Ensure both events have been recorded.
-  if (start->record_time_ns == 0 || stop->record_time_ns == 0) {
+  // Ensure both events have been recorded. A record that failed to submit
+  // leaves no timestamp, so this also rejects events whose only record never
+  // reached the device.
+  const iree_time_t start_time_ns =
+      iree_hal_streaming_event_record_time_ns(start);
+  const iree_time_t stop_time_ns =
+      iree_hal_streaming_event_record_time_ns(stop);
+  if (start_time_ns == 0 || stop_time_ns == 0) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
         "events must be recorded before measuring elapsed time");
@@ -251,7 +342,7 @@ iree_status_t iree_hal_streaming_event_elapsed_time(
   }
 
   // Calculate elapsed time in milliseconds.
-  int64_t elapsed_ns = stop->record_time_ns - start->record_time_ns;
+  int64_t elapsed_ns = stop_time_ns - start_time_ns;
   *ms = (float)elapsed_ns / 1000000.0f;  // Convert nanoseconds to milliseconds.
 
   return iree_ok_status();

--- a/libhrx/src/binding/common/event.c
+++ b/libhrx/src/binding/common/event.c
@@ -32,7 +32,6 @@ iree_status_t iree_hal_streaming_event_create(
   event->recording_stream = NULL;
   event->context = context;
   iree_hal_streaming_context_retain(context);
-  event->record_time_ns = 0;
   event->ipc_handle = NULL;
   event->capture_graph = NULL;
   event->capture_dependencies = NULL;
@@ -92,12 +91,11 @@ void iree_hal_streaming_event_acquire_recorded_point(
 
 void iree_hal_streaming_event_commit_recorded_point(
     iree_hal_streaming_event_t* event,
-    iree_hal_streaming_recorded_point_t point, iree_time_t record_time_ns) {
+    iree_hal_streaming_recorded_point_t point) {
   iree_hal_semaphore_retain(point.semaphore);
   iree_slim_mutex_lock(&event->mutex);
   iree_hal_semaphore_t* previous_semaphore = event->recorded_point.semaphore;
   event->recorded_point = point;
-  event->record_time_ns = record_time_ns;
   iree_slim_mutex_unlock(&event->mutex);
   iree_hal_semaphore_release(previous_semaphore);
 }
@@ -116,12 +114,18 @@ iree_hal_streaming_stream_t* iree_hal_streaming_event_exchange_recording_stream(
   return previous_stream;
 }
 
-iree_time_t iree_hal_streaming_event_record_time_ns(
-    iree_hal_streaming_event_t* event) {
-  iree_slim_mutex_lock(&event->mutex);
-  const iree_time_t record_time_ns = event->record_time_ns;
-  iree_slim_mutex_unlock(&event->mutex);
-  return record_time_ns;
+// Returns whether |point| has been reached. A point naming no timeline has no
+// submitted record and reads as reached. Borrows |point|: the reference taken
+// when the point was acquired stays with the acquirer, which releases it.
+static iree_status_t iree_hal_streaming_recorded_point_query(
+    const iree_hal_streaming_recorded_point_t* point, bool* out_reached) {
+  *out_reached = true;
+  if (!point->semaphore) return iree_ok_status();
+  uint64_t current_value = 0;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_semaphore_query(point->semaphore, &current_value));
+  *out_reached = current_value >= point->value;
+  return iree_ok_status();
 }
 
 iree_status_t iree_hal_streaming_event_query(iree_hal_streaming_event_t* event,
@@ -132,21 +136,14 @@ iree_status_t iree_hal_streaming_event_query(iree_hal_streaming_event_t* event,
 
   iree_hal_streaming_recorded_point_t recorded_point;
   iree_hal_streaming_event_acquire_recorded_point(event, &recorded_point);
-  if (!recorded_point.semaphore) {
-    // An event with no submitted record reads as complete.
-    *status = 0;
-    IREE_TRACE_ZONE_END(z0);
-    return iree_ok_status();
-  }
-
-  uint64_t current_value = 0;
+  bool reached = false;
   iree_status_t query_status =
-      iree_hal_semaphore_query(recorded_point.semaphore, &current_value);
+      iree_hal_streaming_recorded_point_query(&recorded_point, &reached);
   iree_hal_semaphore_release(recorded_point.semaphore);
   IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, query_status);
 
   // 0=complete, 1=not complete.
-  *status = (current_value >= recorded_point.value) ? 0 : 1;
+  *status = reached ? 0 : 1;
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -180,8 +177,8 @@ iree_status_t iree_hal_streaming_event_record(
       iree_hal_streaming_graph_retain(event->capture_graph);
     }
     // A captured record produces no submission, so it leaves the recorded point
-    // and the record time alone; only the stream is adopted, for the later wait
-    // that picks the capture up from the stream that captured it.
+    // alone; only the stream is adopted, for the later wait that picks the
+    // capture up from the stream that captured it.
     iree_hal_streaming_stream_release(
         iree_hal_streaming_event_exchange_recording_stream(event, stream));
     IREE_TRACE_ZONE_END(z0);
@@ -238,10 +235,10 @@ iree_status_t iree_hal_streaming_event_record(
         .value = stream_signal_value,
         .ordered_after_stream_id = stream->stream_id,
         .ordered_after_stream_value = stream_signal_value,
+        .record_time_ns = record_time_ns,
     };
     // A rejected submission signals nothing, so the event keeps its old point.
-    iree_hal_streaming_event_commit_recorded_point(event, recorded_point,
-                                                   record_time_ns);
+    iree_hal_streaming_event_commit_recorded_point(event, recorded_point);
     previous_stream =
         iree_hal_streaming_event_exchange_recording_stream(event, stream);
     status = iree_hal_device_queue_flush(stream->context->device,
@@ -282,47 +279,52 @@ iree_status_t iree_hal_streaming_event_synchronize(
 
 iree_status_t iree_hal_streaming_event_elapsed_time(
     float* ms, iree_hal_streaming_event_t* start,
-    iree_hal_streaming_event_t* stop) {
+    iree_hal_streaming_event_t* stop,
+    iree_hal_streaming_event_timing_t* out_timing) {
   IREE_ASSERT_ARGUMENT(ms);
   IREE_ASSERT_ARGUMENT(start);
   IREE_ASSERT_ARGUMENT(stop);
+  IREE_ASSERT_ARGUMENT(out_timing);
+  *out_timing = IREE_HAL_STREAMING_EVENT_TIMING_UNTIMED;
 
-  // Check if either event has timing disabled.
+  // An event with timing disabled never carries a timestamp to measure from.
   if ((start->flags & IREE_HAL_STREAMING_EVENT_FLAG_DISABLE_TIMING) ||
       (stop->flags & IREE_HAL_STREAMING_EVENT_FLAG_DISABLE_TIMING)) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "cannot measure elapsed time with timing disabled");
+    return iree_ok_status();
   }
 
-  // Ensure both events have been recorded.
-  const iree_time_t start_time_ns =
-      iree_hal_streaming_event_record_time_ns(start);
-  const iree_time_t stop_time_ns =
-      iree_hal_streaming_event_record_time_ns(stop);
-  if (start_time_ns == 0 || stop_time_ns == 0) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "events must be recorded before measuring elapsed time");
+  // Each record is taken once and the interval is measured between exactly the
+  // two records queried below, so a record landing on either event concurrently
+  // cannot pair one record's timestamp with another record's point.
+  iree_hal_streaming_recorded_point_t start_point;
+  iree_hal_streaming_recorded_point_t stop_point;
+  iree_hal_streaming_event_acquire_recorded_point(start, &start_point);
+  iree_hal_streaming_event_acquire_recorded_point(stop, &stop_point);
+
+  // Both records must carry a timestamp and both must have been reached before
+  // the interval between them exists. The stop record is only queried once the
+  // start record is known to have been reached, so an outstanding start reports
+  // the interval as incomplete without touching the stop timeline.
+  iree_status_t status = iree_ok_status();
+  if (start_point.record_time_ns != 0 && stop_point.record_time_ns != 0) {
+    bool reached = false;
+    status = iree_hal_streaming_recorded_point_query(&start_point, &reached);
+    if (iree_status_is_ok(status) && reached) {
+      status = iree_hal_streaming_recorded_point_query(&stop_point, &reached);
+    }
+    if (iree_status_is_ok(status)) {
+      if (reached) {
+        const int64_t elapsed_ns =
+            stop_point.record_time_ns - start_point.record_time_ns;
+        *ms = (float)elapsed_ns / 1000000.0f;
+        *out_timing = IREE_HAL_STREAMING_EVENT_TIMING_MEASURED;
+      } else {
+        *out_timing = IREE_HAL_STREAMING_EVENT_TIMING_INCOMPLETE;
+      }
+    }
   }
 
-  // Ensure both events have completed.
-  int start_status = 0;
-  IREE_RETURN_IF_ERROR(iree_hal_streaming_event_query(start, &start_status));
-  if (start_status != 0) {
-    return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                            "start event has not completed");
-  }
-
-  int stop_status = 0;
-  IREE_RETURN_IF_ERROR(iree_hal_streaming_event_query(stop, &stop_status));
-  if (stop_status != 0) {
-    return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                            "stop event has not completed");
-  }
-
-  // Calculate elapsed time in milliseconds.
-  int64_t elapsed_ns = stop_time_ns - start_time_ns;
-  *ms = (float)elapsed_ns / 1000000.0f;  // Convert nanoseconds to milliseconds.
-
-  return iree_ok_status();
+  iree_hal_semaphore_release(start_point.semaphore);
+  iree_hal_semaphore_release(stop_point.semaphore);
+  return status;
 }

--- a/libhrx/src/binding/common/event.c
+++ b/libhrx/src/binding/common/event.c
@@ -228,12 +228,9 @@ iree_status_t iree_hal_streaming_event_record(
       stream->context->device, stream->queue_affinity, wait_semaphores,
       signal_semaphores, IREE_HAL_EXECUTE_FLAG_NONE);
   if (iree_status_is_ok(status)) {
-    status = iree_hal_device_queue_flush(stream->context->device,
-                                         stream->queue_affinity);
-  }
-  if (iree_status_is_ok(status)) {
+    // The accepted barrier owns the value it signals, so the timeline advances
+    // here and stays advanced even when the flush below fails.
     stream->pending_value = stream_signal_value;
-    stream->submitted_value = stream_signal_value;
     // The barrier signals the stream's own timeline, so reaching the point is
     // exactly the stream reaching that value.
     const iree_hal_streaming_recorded_point_t recorded_point = {
@@ -247,6 +244,8 @@ iree_status_t iree_hal_streaming_event_record(
                                                    record_time_ns);
     previous_stream =
         iree_hal_streaming_event_exchange_recording_stream(event, stream);
+    status = iree_hal_device_queue_flush(stream->context->device,
+                                         stream->queue_affinity);
   }
   iree_slim_mutex_unlock(&stream->mutex);
   // Stream teardown re-enters the streaming layer, so the displaced reference

--- a/libhrx/src/binding/common/event.c
+++ b/libhrx/src/binding/common/event.c
@@ -28,8 +28,7 @@ iree_status_t iree_hal_streaming_event_create(
   iree_atomic_ref_count_init(&event->ref_count);
   event->flags = flags;
   iree_slim_mutex_initialize(&event->mutex);
-  event->signal_semaphore = NULL;
-  event->signal_value = 0;
+  event->recorded_point = (iree_hal_streaming_recorded_point_t){0};
   event->recording_stream = NULL;
   event->context = context;
   iree_hal_streaming_context_retain(context);
@@ -51,7 +50,7 @@ static void iree_hal_streaming_event_destroy(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // Release the recorded point.
-  iree_hal_semaphore_release(event->signal_semaphore);
+  iree_hal_semaphore_release(event->recorded_point.semaphore);
 
   // Release recording stream reference.
   iree_hal_streaming_stream_release(event->recording_stream);
@@ -83,23 +82,21 @@ void iree_hal_streaming_event_release(iree_hal_streaming_event_t* event) {
 }
 
 void iree_hal_streaming_event_acquire_recorded_point(
-    iree_hal_streaming_event_t* event, iree_hal_semaphore_t** out_semaphore,
-    uint64_t* out_value) {
+    iree_hal_streaming_event_t* event,
+    iree_hal_streaming_recorded_point_t* out_point) {
   iree_slim_mutex_lock(&event->mutex);
-  *out_semaphore = event->signal_semaphore;
-  *out_value = event->signal_value;
-  iree_hal_semaphore_retain(*out_semaphore);
+  *out_point = event->recorded_point;
+  iree_hal_semaphore_retain(out_point->semaphore);
   iree_slim_mutex_unlock(&event->mutex);
 }
 
 void iree_hal_streaming_event_commit_recorded_point(
-    iree_hal_streaming_event_t* event, iree_hal_semaphore_t* semaphore,
-    uint64_t value, iree_time_t record_time_ns) {
-  iree_hal_semaphore_retain(semaphore);
+    iree_hal_streaming_event_t* event,
+    iree_hal_streaming_recorded_point_t point, iree_time_t record_time_ns) {
+  iree_hal_semaphore_retain(point.semaphore);
   iree_slim_mutex_lock(&event->mutex);
-  iree_hal_semaphore_t* previous_semaphore = event->signal_semaphore;
-  event->signal_semaphore = semaphore;
-  event->signal_value = value;
+  iree_hal_semaphore_t* previous_semaphore = event->recorded_point.semaphore;
+  event->recorded_point = point;
   event->record_time_ns = record_time_ns;
   iree_slim_mutex_unlock(&event->mutex);
   iree_hal_semaphore_release(previous_semaphore);
@@ -133,11 +130,9 @@ iree_status_t iree_hal_streaming_event_query(iree_hal_streaming_event_t* event,
   IREE_ASSERT_ARGUMENT(status);
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_hal_semaphore_t* semaphore = NULL;
-  uint64_t signal_value = 0;
-  iree_hal_streaming_event_acquire_recorded_point(event, &semaphore,
-                                                  &signal_value);
-  if (!semaphore) {
+  iree_hal_streaming_recorded_point_t recorded_point;
+  iree_hal_streaming_event_acquire_recorded_point(event, &recorded_point);
+  if (!recorded_point.semaphore) {
     // An event with no submitted record reads as complete.
     *status = 0;
     IREE_TRACE_ZONE_END(z0);
@@ -146,12 +141,12 @@ iree_status_t iree_hal_streaming_event_query(iree_hal_streaming_event_t* event,
 
   uint64_t current_value = 0;
   iree_status_t query_status =
-      iree_hal_semaphore_query(semaphore, &current_value);
-  iree_hal_semaphore_release(semaphore);
+      iree_hal_semaphore_query(recorded_point.semaphore, &current_value);
+  iree_hal_semaphore_release(recorded_point.semaphore);
   IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, query_status);
 
-  *status =
-      (current_value >= signal_value) ? 0 : 1;  // 0=complete, 1=not complete
+  // 0=complete, 1=not complete.
+  *status = (current_value >= recorded_point.value) ? 0 : 1;
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -239,9 +234,17 @@ iree_status_t iree_hal_streaming_event_record(
   if (iree_status_is_ok(status)) {
     stream->pending_value = stream_signal_value;
     stream->submitted_value = stream_signal_value;
+    // The barrier signals the stream's own timeline, so reaching the point is
+    // exactly the stream reaching that value.
+    const iree_hal_streaming_recorded_point_t recorded_point = {
+        .semaphore = stream->timeline_semaphore,
+        .value = stream_signal_value,
+        .ordered_after_stream_id = stream->stream_id,
+        .ordered_after_stream_value = stream_signal_value,
+    };
     // A rejected submission signals nothing, so the event keeps its old point.
-    iree_hal_streaming_event_commit_recorded_point(
-        event, stream->timeline_semaphore, stream_signal_value, record_time_ns);
+    iree_hal_streaming_event_commit_recorded_point(event, recorded_point,
+                                                   record_time_ns);
     previous_stream =
         iree_hal_streaming_event_exchange_recording_stream(event, stream);
   }
@@ -260,20 +263,18 @@ iree_status_t iree_hal_streaming_event_synchronize(
   IREE_ASSERT_ARGUMENT(event);
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_hal_semaphore_t* semaphore = NULL;
-  uint64_t signal_value = 0;
-  iree_hal_streaming_event_acquire_recorded_point(event, &semaphore,
-                                                  &signal_value);
-  if (!semaphore) {
+  iree_hal_streaming_recorded_point_t recorded_point;
+  iree_hal_streaming_event_acquire_recorded_point(event, &recorded_point);
+  if (!recorded_point.semaphore) {
     // An event with no submitted record has nothing to wait for.
     IREE_TRACE_ZONE_END(z0);
     return iree_ok_status();
   }
 
-  iree_status_t status =
-      iree_hal_semaphore_wait(semaphore, signal_value, iree_infinite_timeout(),
-                              IREE_ASYNC_WAIT_FLAG_NONE);
-  iree_hal_semaphore_release(semaphore);
+  iree_status_t status = iree_hal_semaphore_wait(
+      recorded_point.semaphore, recorded_point.value, iree_infinite_timeout(),
+      IREE_ASYNC_WAIT_FLAG_NONE);
+  iree_hal_semaphore_release(recorded_point.semaphore);
   IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, status);
 
   IREE_TRACE_ZONE_END(z0);

--- a/libhrx/src/binding/common/event.c
+++ b/libhrx/src/binding/common/event.c
@@ -24,8 +24,7 @@ iree_status_t iree_hal_streaming_event_create(
       z0,
       iree_allocator_malloc(host_allocator, sizeof(*event), (void**)&event));
 
-  // Initialize event. An event holds no timeline of its own; it starts with no
-  // recorded point and takes a reference to one when a record is submitted.
+  // Initialize event.
   iree_atomic_ref_count_init(&event->ref_count);
   event->flags = flags;
   iree_slim_mutex_initialize(&event->mutex);
@@ -51,8 +50,7 @@ static void iree_hal_streaming_event_destroy(
     iree_hal_streaming_event_t* event) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  // Release the recorded point. The semaphore belongs to the stream or graph
-  // executable that carried the record, both of which may already be gone.
+  // Release the recorded point.
   iree_hal_semaphore_release(event->signal_semaphore);
 
   // Release recording stream reference.
@@ -140,8 +138,7 @@ iree_status_t iree_hal_streaming_event_query(iree_hal_streaming_event_t* event,
   iree_hal_streaming_event_acquire_recorded_point(event, &semaphore,
                                                   &signal_value);
   if (!semaphore) {
-    // Nothing has been submitted for this event, so there is nothing to wait
-    // for and the event reads as complete.
+    // An event with no submitted record reads as complete.
     *status = 0;
     IREE_TRACE_ZONE_END(z0);
     return iree_ok_status();
@@ -187,14 +184,9 @@ iree_status_t iree_hal_streaming_event_record(
       event->capture_graph = stream->capture_graph;
       iree_hal_streaming_graph_retain(event->capture_graph);
     }
-    // A captured record produces neither a submission nor a graph node, only
-    // the frontier snapshot above, so there is no point for it to name and no
-    // moment for a timestamp to describe: both the recorded point and the
-    // record time are left naming the last submitted record. An event whose
-    // only record was captured therefore reads as never recorded, and elapsed
-    // time over it is rejected rather than reporting the host-side gap between
-    // two capture calls. The stream is adopted because a later wait on this
-    // event has to pick the capture up from the stream that captured it.
+    // A captured record produces no submission, so it leaves the recorded point
+    // and the record time alone; only the stream is adopted, for the later wait
+    // that picks the capture up from the stream that captured it.
     iree_hal_streaming_stream_release(
         iree_hal_streaming_event_exchange_recording_stream(event, stream));
     IREE_TRACE_ZONE_END(z0);
@@ -202,7 +194,7 @@ iree_status_t iree_hal_streaming_event_record(
   }
 
   // Sampled before the submission so the timestamp reflects when the caller
-  // issued the record, and adopted only once that submission is accepted.
+  // issued the record.
   const iree_time_t record_time_ns = iree_time_now();
 
   // Flush the stream to ensure all prior operations are submitted.
@@ -212,12 +204,8 @@ iree_status_t iree_hal_streaming_event_record(
   iree_slim_mutex_lock(&stream->mutex);
 
   // The record marks a point on the recording stream's timeline: the barrier
-  // takes the stream's next value under the stream mutex and signals it once
-  // everything already on the stream has completed. Every value on a stream
-  // timeline is reserved exactly once and only ever increases, so a record can
-  // never select a value that timeline has already passed no matter which
-  // stream recorded the event before, and two streams recording the same event
-  // at once draw from different timelines under different mutexes.
+  // takes the stream's next value and signals it once everything already on the
+  // stream has completed.
   uint64_t stream_wait_value = 0;
   uint64_t stream_signal_value = 0;
   iree_status_t status = iree_hal_streaming_stream_reserve_next_value_locked(
@@ -228,8 +216,7 @@ iree_status_t iree_hal_streaming_event_record(
     return status;
   }
 
-  // The wait is dropped when the stream has never submitted, matching the other
-  // submission paths on the stream; nothing can be behind value zero.
+  // A stream that has never submitted has nothing behind it to wait on.
   iree_hal_semaphore_list_t wait_semaphores = {
       .count = stream_wait_value > 0 ? 1 : 0,
       .semaphores = &stream->timeline_semaphore,
@@ -252,18 +239,15 @@ iree_status_t iree_hal_streaming_event_record(
   if (iree_status_is_ok(status)) {
     stream->pending_value = stream_signal_value;
     stream->submitted_value = stream_signal_value;
-    // A rejected submission signals nothing, so the event keeps its previous
-    // point instead of naming one that will never be reached.
+    // A rejected submission signals nothing, so the event keeps its old point.
     iree_hal_streaming_event_commit_recorded_point(
         event, stream->timeline_semaphore, stream_signal_value, record_time_ns);
     previous_stream =
         iree_hal_streaming_event_exchange_recording_stream(event, stream);
   }
   iree_slim_mutex_unlock(&stream->mutex);
-  // Dropping the last reference to the previously recording stream runs its
-  // teardown, which re-enters the streaming layer to synchronize the stream and
-  // unregister it from its context, so the reference is dropped only after this
-  // stream's mutex is released.
+  // Stream teardown re-enters the streaming layer, so the displaced reference
+  // is dropped outside this stream's mutex.
   iree_hal_streaming_stream_release(previous_stream);
   IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, status);
 
@@ -281,15 +265,11 @@ iree_status_t iree_hal_streaming_event_synchronize(
   iree_hal_streaming_event_acquire_recorded_point(event, &semaphore,
                                                   &signal_value);
   if (!semaphore) {
-    // Nothing has been submitted for this event, so there is nothing to wait
-    // for.
+    // An event with no submitted record has nothing to wait for.
     IREE_TRACE_ZONE_END(z0);
     return iree_ok_status();
   }
 
-  // Waiting outside the event mutex leaves the event recordable while a wait on
-  // it is outstanding; the retained reference keeps the timeline alive across a
-  // concurrent re-record onto another one.
   iree_status_t status =
       iree_hal_semaphore_wait(semaphore, signal_value, iree_infinite_timeout(),
                               IREE_ASYNC_WAIT_FLAG_NONE);
@@ -314,9 +294,7 @@ iree_status_t iree_hal_streaming_event_elapsed_time(
                             "cannot measure elapsed time with timing disabled");
   }
 
-  // Ensure both events have been recorded. A record that failed to submit
-  // leaves no timestamp, so this also rejects events whose only record never
-  // reached the device.
+  // Ensure both events have been recorded.
   const iree_time_t start_time_ns =
       iree_hal_streaming_event_record_time_ns(start);
   const iree_time_t stop_time_ns =

--- a/libhrx/src/binding/common/event.c
+++ b/libhrx/src/binding/common/event.c
@@ -212,20 +212,21 @@ iree_status_t iree_hal_streaming_event_record(
   iree_slim_mutex_lock(&stream->mutex);
 
   // The record marks a point on the recording stream's timeline: the barrier
-  // reserves the stream's next value under the stream mutex and signals it once
+  // takes the stream's next value under the stream mutex and signals it once
   // everything already on the stream has completed. Every value on a stream
   // timeline is reserved exactly once and only ever increases, so a record can
   // never select a value that timeline has already passed no matter which
   // stream recorded the event before, and two streams recording the same event
   // at once draw from different timelines under different mutexes.
-  uint64_t stream_wait_value = stream->pending_value;
-  if (IREE_UNLIKELY(stream_wait_value == UINT64_MAX)) {
+  uint64_t stream_wait_value = 0;
+  uint64_t stream_signal_value = 0;
+  iree_status_t status = iree_hal_streaming_stream_reserve_next_value_locked(
+      stream, &stream_wait_value, &stream_signal_value);
+  if (!iree_status_is_ok(status)) {
     iree_slim_mutex_unlock(&stream->mutex);
     IREE_TRACE_ZONE_END(z0);
-    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
-                            "stream timeline value overflow");
+    return status;
   }
-  uint64_t stream_signal_value = stream_wait_value + 1;
 
   // The wait is dropped when the stream has never submitted, matching the other
   // submission paths on the stream; nothing can be behind value zero.
@@ -241,7 +242,7 @@ iree_status_t iree_hal_streaming_event_record(
   };
 
   iree_hal_streaming_stream_t* previous_stream = NULL;
-  iree_status_t status = iree_hal_device_queue_barrier(
+  status = iree_hal_device_queue_barrier(
       stream->context->device, stream->queue_affinity, wait_semaphores,
       signal_semaphores, IREE_HAL_EXECUTE_FLAG_NONE);
   if (iree_status_is_ok(status)) {

--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -1909,6 +1909,7 @@ iree_status_t iree_hal_streaming_graph_exec_instantiate_from_template(
 
 static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
     iree_hal_streaming_graph_exec_t* exec, iree_hal_streaming_stream_t* stream,
+    uint64_t launch_stream_tail_value,
     iree_hal_semaphore_list_t external_wait_semaphores,
     iree_hal_semaphore_list_t external_signal_semaphores);
 
@@ -1929,7 +1930,7 @@ static iree_status_t iree_hal_streaming_graph_host_callback(
 static iree_status_t iree_hal_streaming_graph_submit_block(
     iree_hal_streaming_graph_block_t* block,
     const iree_hal_streaming_graph_block_ptrs_t* ptrs,
-    iree_hal_streaming_stream_t* stream,
+    iree_hal_streaming_stream_t* stream, uint64_t launch_stream_tail_value,
     iree_hal_semaphore_list_t wait_semaphores,
     iree_hal_semaphore_list_t signal_semaphores) {
   switch (block->type) {
@@ -1994,8 +1995,13 @@ static iree_status_t iree_hal_streaming_graph_submit_block(
     case IREE_HAL_STREAMING_GRAPH_BLOCK_TYPE_CHILD_GRAPH: {
       iree_hal_streaming_graph_exec_t* child_exec =
           ptrs->attrs->child_graph.exec;
+      // Only the child's block 0 carries this block's waits, which are
+      // themselves behind the launch tail; a record inside the child sits in a
+      // single-block partition that either is block 0 or chains back to it, so
+      // the tail carries down unchanged.
       return iree_hal_streaming_graph_exec_submit_blocks_locked(
-          child_exec, stream, wait_semaphores, signal_semaphores);
+          child_exec, stream, launch_stream_tail_value, wait_semaphores,
+          signal_semaphores);
     }
     default:
       return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
@@ -2003,8 +2009,16 @@ static iree_status_t iree_hal_streaming_graph_submit_block(
   }
 }
 
+// |launch_stream_tail_value| is the value on |stream|'s timeline that the whole
+// launch waits behind, or 0 when the stream had never submitted. Only block 0
+// carries the launch's external waits, and the extra workstream blocks of the
+// first partition wait on nothing, so a block is behind the tail only when it
+// chains back to block 0. An event record node is never recordable and so gets
+// a partition of its own holding a single block, which either is block 0 or
+// waits on every signal of the partition ahead of it, back to block 0.
 static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
     iree_hal_streaming_graph_exec_t* exec, iree_hal_streaming_stream_t* stream,
+    uint64_t launch_stream_tail_value,
     iree_hal_semaphore_list_t external_wait_semaphores,
     iree_hal_semaphore_list_t external_signal_semaphores) {
   enum {
@@ -2145,16 +2159,19 @@ static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
       ++wait_count;
     }
     // Retained across the submission so a concurrent record of the same event
-    // cannot drop the last reference to the timeline this block names.
-    iree_hal_semaphore_t* event_wait_semaphore = NULL;
+    // cannot drop the last reference to the timeline this block names. Unlike
+    // iree_hal_streaming_stream_wait_event, the point's stream ordering is not
+    // filed in |stream|'s memory reuse ledger; a missing entry only withholds
+    // allocations from reuse, so the omission costs reuse and can never grant
+    // it.
+    iree_hal_streaming_recorded_point_t event_wait_point = {0};
     if (block_waits_event) {
-      uint64_t event_wait_value = 0;
-      iree_hal_streaming_event_acquire_recorded_point(
-          ptrs.attrs->event.event, &event_wait_semaphore, &event_wait_value);
+      iree_hal_streaming_event_acquire_recorded_point(ptrs.attrs->event.event,
+                                                      &event_wait_point);
       // A wait on an event with no submitted record has nothing to wait for.
-      if (event_wait_semaphore) {
-        wait_sems[wait_count] = event_wait_semaphore;
-        wait_vals[wait_count] = event_wait_value;
+      if (event_wait_point.semaphore) {
+        wait_sems[wait_count] = event_wait_point.semaphore;
+        wait_vals[wait_count] = event_wait_point.value;
         ++wait_count;
       }
     }
@@ -2204,18 +2221,32 @@ static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
       const iree_time_t record_time_ns =
           block_records_event ? iree_time_now() : 0;
       status = iree_hal_streaming_graph_submit_block(
-          block, &ptrs, stream, wait_semaphores, signal_semaphores);
+          block, &ptrs, stream, launch_stream_tail_value, wait_semaphores,
+          signal_semaphores);
       // A rejected block signals nothing, so the event keeps its old point. The
       // commit stays inside this iteration because later blocks in the same
       // launch wait on the committed point. The recording stream is left alone:
       // it carries capture state and a launch is not a capture.
       if (block_records_event && iree_status_is_ok(status)) {
+        // The block's first signal is the point the record names. When that
+        // signal is the launching stream's own timeline the point is exactly a
+        // stream point; otherwise it is internal to the launch and all that is
+        // known about the stream is that the launch waited behind its tail.
+        const bool signals_launch_stream_timeline =
+            signal_sems[0] == stream->timeline_semaphore;
+        const iree_hal_streaming_recorded_point_t recorded_point = {
+            .semaphore = signal_sems[0],
+            .value = signal_vals[0],
+            .ordered_after_stream_id = stream->stream_id,
+            .ordered_after_stream_value = signals_launch_stream_timeline
+                                              ? signal_vals[0]
+                                              : launch_stream_tail_value,
+        };
         iree_hal_streaming_event_commit_recorded_point(
-            ptrs.attrs->event.event, signal_sems[0], signal_vals[0],
-            record_time_ns);
+            ptrs.attrs->event.event, recorded_point, record_time_ns);
       }
     }
-    iree_hal_semaphore_release(event_wait_semaphore);
+    iree_hal_semaphore_release(event_wait_point.semaphore);
     if (free_value_array) {
       iree_allocator_free(exec->host_allocator, value_array);
     }
@@ -2340,7 +2371,7 @@ iree_status_t iree_hal_streaming_graph_exec_launch(
   };
   if (iree_status_is_ok(status)) {
     status = iree_hal_streaming_graph_exec_submit_blocks_locked(
-        exec, stream, wait_semaphores, signal_semaphores);
+        exec, stream, stream_wait_value, wait_semaphores, signal_semaphores);
   }
 
   if (iree_status_is_ok(status)) {

--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -2059,10 +2059,9 @@ static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
         (block_index == 0 ? external_wait_semaphores.count : 0) +
         (block_waits_event ? 1 : 0);
     const iree_host_size_t total_signal_count =
-        block->signal_semaphore_count +
-        (block_index == exec->block_count - 1 ? external_signal_semaphores.count
-                                              : 0) +
-        (block_records_event ? 1 : 0);
+        block->signal_semaphore_count + (block_index == exec->block_count - 1
+                                             ? external_signal_semaphores.count
+                                             : 0);
     iree_host_size_t total_semaphores = 0;
     if (IREE_UNLIKELY(!iree_host_size_checked_add(
             total_wait_count, total_signal_count, &total_semaphores))) {
@@ -2134,11 +2133,20 @@ static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
           exec->semaphore_base_values[semaphore_index] + delta;
       ++wait_count;
     }
+    // Point the block waits on when it waits for an event, retained across the
+    // submission so a concurrent record of the same event cannot drop the last
+    // reference to a timeline this block is about to name.
+    iree_hal_semaphore_t* event_wait_semaphore = NULL;
     if (block_waits_event) {
-      iree_hal_streaming_event_t* event = ptrs.attrs->event.event;
-      wait_sems[wait_count] = event->semaphore;
-      wait_vals[wait_count] = event->signal_value;
-      ++wait_count;
+      uint64_t event_wait_value = 0;
+      iree_hal_streaming_event_acquire_recorded_point(
+          ptrs.attrs->event.event, &event_wait_semaphore, &event_wait_value);
+      // A wait on an event with no submitted record has nothing to wait for.
+      if (event_wait_semaphore) {
+        wait_sems[wait_count] = event_wait_semaphore;
+        wait_vals[wait_count] = event_wait_value;
+        ++wait_count;
+      }
     }
 
     iree_host_size_t signal_count = 0;
@@ -2159,23 +2167,25 @@ static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
         ++signal_count;
       }
     }
-    if (block_records_event) {
-      iree_hal_streaming_event_t* event = ptrs.attrs->event.event;
-      if (IREE_UNLIKELY(event->signal_value == UINT64_MAX)) {
-        status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
-                                  "event signal value overflow");
-      } else if (event->recording_stream != stream) {
-        iree_hal_streaming_stream_retain(stream);
-        iree_hal_streaming_stream_release(event->recording_stream);
-        event->recording_stream = stream;
-      }
-      if (iree_status_is_ok(status)) {
-        event->record_time_ns = iree_time_now();
-        ++event->signal_value;
-        signal_sems[signal_count] = event->semaphore;
-        signal_vals[signal_count] = event->signal_value;
-        ++signal_count;
-      }
+
+    // A record node marks the point its own block reaches, which is the first
+    // value the block signals: a record node always occupies a partition of its
+    // own, so that value is signaled exactly when the node's dependencies have
+    // completed and by nothing else. Reusing the block's existing signal rather
+    // than adding one of its own is what keeps the event off any timeline it
+    // would have to reserve values on, and the timeline it names is advanced
+    // only by launches that reach this block, all of which run under one
+    // executable mutex: a top-level launch holds its own, while a child graph's
+    // blocks are submitted under the parent's, which is the only mutex that can
+    // reach them because each instantiation of a parent owns a private child
+    // executable.
+    //
+    // Every partition but the last signals at least one of the executable's
+    // internal semaphores, and the last partition's block carries the launch's
+    // external signals, so a record block always has a value to name.
+    if (block_records_event && IREE_UNLIKELY(signal_count == 0)) {
+      status = iree_make_status(IREE_STATUS_INTERNAL,
+                                "event record block signals no timeline value");
     }
 
     iree_hal_semaphore_list_t wait_semaphores = {
@@ -2189,9 +2199,30 @@ static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
         .payload_values = signal_vals,
     };
     if (iree_status_is_ok(status)) {
+      // Sampled before the submission so the timestamp reflects when the launch
+      // issued the record.
+      const iree_time_t record_time_ns =
+          block_records_event ? iree_time_now() : 0;
       status = iree_hal_streaming_graph_submit_block(
           block, &ptrs, stream, wait_semaphores, signal_semaphores);
+      // A rejected block signals nothing, so the event keeps its previous point
+      // rather than naming one that will never be reached. Later blocks in this
+      // launch that wait on the event read the committed point, so the commit
+      // stays inside the iteration that submitted it.
+      //
+      // The event's recording stream is left alone: it carries the capture
+      // state a stream wait picks up from the stream that captured the event,
+      // and a graph launch is not a capture. Exchanging it here would also drop
+      // a reference to another stream while this stream's mutex is held, and
+      // stream teardown re-enters the streaming layer to synchronize that
+      // stream and unregister it from its context.
+      if (block_records_event && iree_status_is_ok(status)) {
+        iree_hal_streaming_event_commit_recorded_point(
+            ptrs.attrs->event.event, signal_sems[0], signal_vals[0],
+            record_time_ns);
+      }
     }
+    iree_hal_semaphore_release(event_wait_semaphore);
     if (free_value_array) {
       iree_allocator_free(exec->host_allocator, value_array);
     }

--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -2344,8 +2344,10 @@ iree_status_t iree_hal_streaming_graph_exec_launch(
   // completion observed by the host; HIP stream ordering requires repeated
   // graph launches on the same stream to execute FIFO even when the caller does
   // not synchronize between launches.
-  uint64_t stream_wait_value = stream->pending_value;
-  uint64_t stream_signal_value = stream_wait_value + 1;
+  uint64_t stream_wait_value = 0;
+  uint64_t stream_signal_value = 0;
+  iree_status_t status = iree_hal_streaming_stream_reserve_next_value_locked(
+      stream, &stream_wait_value, &stream_signal_value);
 
   iree_hal_semaphore_t* wait_semaphore = stream->timeline_semaphore;
   uint64_t wait_payload_value = stream_wait_value;
@@ -2361,8 +2363,10 @@ iree_status_t iree_hal_streaming_graph_exec_launch(
       .semaphores = &signal_semaphore,
       .payload_values = &signal_payload_value,
   };
-  iree_status_t status = iree_hal_streaming_graph_exec_submit_blocks_locked(
-      exec, stream, wait_semaphores, signal_semaphores);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_graph_exec_submit_blocks_locked(
+        exec, stream, wait_semaphores, signal_semaphores);
+  }
 
   if (iree_status_is_ok(status)) {
     stream->pending_value = stream_signal_value;

--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -1716,12 +1716,8 @@ iree_status_t iree_hal_streaming_graph_exec_instantiate_from_template(
            exec->semaphore_count * sizeof(*exec->semaphore_base_values));
 
     // Create the internal semaphores that carry values between partitions. The
-    // resource set is their only owner: every use of exec->semaphores happens
-    // under a launch of this executable, and anything that has to outlive the
-    // executable - an event recorded by a node in the middle of the graph, for
-    // one - takes a reference of its own. Each semaphore is handed to the set
-    // and let go of as it is created, so a failure part way through leaves the
-    // ones already made owned by the set rather than by nobody.
+    // resource set is their sole owner; exec->semaphores are borrowed pointers
+    // and anything outliving the executable takes its own reference.
     iree_status_t status = iree_ok_status();
     for (uint32_t i = 0; i < exec->semaphore_count && iree_status_is_ok(status);
          i++) {
@@ -2148,9 +2144,8 @@ static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
           exec->semaphore_base_values[semaphore_index] + delta;
       ++wait_count;
     }
-    // Point the block waits on when it waits for an event, retained across the
-    // submission so a concurrent record of the same event cannot drop the last
-    // reference to a timeline this block is about to name.
+    // Retained across the submission so a concurrent record of the same event
+    // cannot drop the last reference to the timeline this block names.
     iree_hal_semaphore_t* event_wait_semaphore = NULL;
     if (block_waits_event) {
       uint64_t event_wait_value = 0;
@@ -2183,21 +2178,11 @@ static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
       }
     }
 
-    // A record node marks the point its own block reaches, which is the first
-    // value the block signals: a record node always occupies a partition of its
-    // own, so that value is signaled exactly when the node's dependencies have
-    // completed and by nothing else. Reusing the block's existing signal rather
-    // than adding one of its own is what keeps the event off any timeline it
-    // would have to reserve values on, and the timeline it names is advanced
-    // only by launches that reach this block, all of which run under one
-    // executable mutex: a top-level launch holds its own, while a child graph's
-    // blocks are submitted under the parent's, which is the only mutex that can
-    // reach them because each instantiation of a parent owns a private child
-    // executable.
-    //
-    // Every partition but the last signals at least one of the executable's
-    // internal semaphores, and the last partition's block carries the launch's
-    // external signals, so a record block always has a value to name.
+    // A record node marks the point its own block reaches, which is the block's
+    // first signal value: the partitioner gives a record node a partition of
+    // its own, so that value is signaled exactly when the node's dependencies
+    // complete. Every block signals either an internal semaphore or the
+    // launch's external signals, so a record block always has a value to name.
     if (block_records_event && IREE_UNLIKELY(signal_count == 0)) {
       status = iree_make_status(IREE_STATUS_INTERNAL,
                                 "event record block signals no timeline value");
@@ -2220,17 +2205,10 @@ static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
           block_records_event ? iree_time_now() : 0;
       status = iree_hal_streaming_graph_submit_block(
           block, &ptrs, stream, wait_semaphores, signal_semaphores);
-      // A rejected block signals nothing, so the event keeps its previous point
-      // rather than naming one that will never be reached. Later blocks in this
-      // launch that wait on the event read the committed point, so the commit
-      // stays inside the iteration that submitted it.
-      //
-      // The event's recording stream is left alone: it carries the capture
-      // state a stream wait picks up from the stream that captured the event,
-      // and a graph launch is not a capture. Exchanging it here would also drop
-      // a reference to another stream while this stream's mutex is held, and
-      // stream teardown re-enters the streaming layer to synchronize that
-      // stream and unregister it from its context.
+      // A rejected block signals nothing, so the event keeps its old point. The
+      // commit stays inside this iteration because later blocks in the same
+      // launch wait on the committed point. The recording stream is left alone:
+      // it carries capture state and a launch is not a capture.
       if (block_records_event && iree_status_is_ok(status)) {
         iree_hal_streaming_event_commit_recorded_point(
             ptrs.attrs->event.event, signal_sems[0], signal_vals[0],
@@ -2246,13 +2224,10 @@ static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
     }
   }
 
-  // The base values advance even when a block failed to submit. Blocks that did
+  // The base values advance even when a block failed to submit: blocks that did
   // submit have already signaled their new values, and a timeline value may be
-  // signaled only once; a launch that rewound the bases would make the next
-  // launch signal those values a second time and fail the semaphores for good.
-  // Entries for blocks that never submitted are unchanged, and the block that
-  // waits on such an entry is rebased by the same amount as the block that
-  // signals it, so skipping a value is invisible to both.
+  // signaled only once, so rewinding the bases would make the next launch
+  // signal those values again and fail the semaphores for good.
   if (exec->semaphore_count > 0) {
     memcpy(exec->semaphore_base_values, new_base_values,
            exec->semaphore_count * sizeof(uint64_t));

--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -2241,9 +2241,10 @@ static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
             .ordered_after_stream_value = signals_launch_stream_timeline
                                               ? signal_vals[0]
                                               : launch_stream_tail_value,
+            .record_time_ns = record_time_ns,
         };
-        iree_hal_streaming_event_commit_recorded_point(
-            ptrs.attrs->event.event, recorded_point, record_time_ns);
+        iree_hal_streaming_event_commit_recorded_point(ptrs.attrs->event.event,
+                                                       recorded_point);
       }
     }
     iree_hal_semaphore_release(event_wait_point.semaphore);

--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -2231,7 +2231,14 @@ static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
     }
   }
 
-  if (iree_status_is_ok(status) && exec->semaphore_count > 0) {
+  // The base values advance even when a block failed to submit. Blocks that did
+  // submit have already signaled their new values, and a timeline value may be
+  // signaled only once; a launch that rewound the bases would make the next
+  // launch signal those values a second time and fail the semaphores for good.
+  // Entries for blocks that never submitted are unchanged, and the block that
+  // waits on such an entry is rebased by the same amount as the block that
+  // signals it, so skipping a value is invisible to both.
+  if (exec->semaphore_count > 0) {
     memcpy(exec->semaphore_base_values, new_base_values,
            exec->semaphore_count * sizeof(uint64_t));
   }

--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -1705,25 +1705,40 @@ iree_status_t iree_hal_streaming_graph_exec_instantiate_from_template(
         iree_arena_allocate(&exec->arena_allocator,
                             exec->semaphore_count * sizeof(*exec->semaphores),
                             (void**)&exec->semaphores));
+    memset(exec->semaphores, 0,
+           exec->semaphore_count * sizeof(*exec->semaphores));
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0, iree_arena_allocate(
                 &exec->arena_allocator,
                 exec->semaphore_count * sizeof(*exec->semaphore_base_values),
                 (void**)&exec->semaphore_base_values));
+    memset(exec->semaphore_base_values, 0,
+           exec->semaphore_count * sizeof(*exec->semaphore_base_values));
 
-    // Create internal semaphores.
-    for (uint32_t i = 0; i < exec->semaphore_count; i++) {
-      IREE_RETURN_AND_END_ZONE_IF_ERROR(
-          z0, iree_hal_semaphore_create(
-                  exec->context->device, exec->context->queue_affinity, 0ull,
-                  IREE_HAL_SEMAPHORE_FLAG_NONE, &exec->semaphores[i]));
-      exec->semaphore_base_values[i] = 0;
+    // Create the internal semaphores that carry values between partitions. The
+    // resource set is their only owner: every use of exec->semaphores happens
+    // under a launch of this executable, and anything that has to outlive the
+    // executable - an event recorded by a node in the middle of the graph, for
+    // one - takes a reference of its own. Each semaphore is handed to the set
+    // and let go of as it is created, so a failure part way through leaves the
+    // ones already made owned by the set rather than by nobody.
+    iree_status_t status = iree_ok_status();
+    for (uint32_t i = 0; i < exec->semaphore_count && iree_status_is_ok(status);
+         i++) {
+      iree_hal_semaphore_t* semaphore = NULL;
+      status = iree_hal_semaphore_create(
+          exec->context->device, exec->context->queue_affinity, 0ull,
+          IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore);
+      if (iree_status_is_ok(status)) {
+        status =
+            iree_hal_resource_set_insert(exec->resource_set, 1, &semaphore);
+        iree_hal_semaphore_release(semaphore);
+      }
+      if (iree_status_is_ok(status)) {
+        exec->semaphores[i] = semaphore;
+      }
     }
-
-    // Add semaphores to the resource set for automatic cleanup.
-    IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_hal_resource_set_insert(
-                exec->resource_set, exec->semaphore_count, exec->semaphores));
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, status);
   }
 
   // Create blocks from partitions.

--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -2256,9 +2256,11 @@ static iree_status_t iree_hal_streaming_graph_exec_submit_blocks_locked(
   }
 
   // The base values advance even when a block failed to submit: blocks that did
-  // submit have already signaled their new values, and a timeline value may be
-  // signaled only once, so rewinding the bases would make the next launch
-  // signal those values again and fail the semaphores for good.
+  // submit have already signaled their new values, and a value must name
+  // exactly one submission. Nothing rejects a duplicate signal, so rewinding
+  // the bases would make the next launch re-signal those values silently, and
+  // its blocks would find their waits already satisfied and run ahead of the
+  // work they were ordered behind.
   if (exec->semaphore_count > 0) {
     memcpy(exec->semaphore_base_values, new_base_values,
            exec->semaphore_count * sizeof(uint64_t));
@@ -2376,7 +2378,6 @@ iree_status_t iree_hal_streaming_graph_exec_launch(
 
   if (iree_status_is_ok(status)) {
     stream->pending_value = stream_signal_value;
-    stream->submitted_value = stream_signal_value;
     if (exec->uses_graph_memory_nodes) {
       iree_hal_streaming_stream_release(
           exec->graph_memory_active_launch_stream);

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -722,15 +722,63 @@ typedef struct iree_hal_streaming_event_t {
   // Event properties.
   iree_hal_streaming_event_flags_t flags;
 
-  // HAL semaphore.
-  iree_hal_semaphore_t* semaphore;
+  // Guards the recorded point: |signal_semaphore|, |signal_value| and
+  // |record_time_ns|. An event is shared state that any thread may record,
+  // query, or wait on, and the semaphore and value must be read together or a
+  // reader can pair one record's semaphore with another record's value. Held
+  // after the recording stream's mutex and, on the graph path, after the graph
+  // executable's mutex; no path takes a stream or executable mutex while
+  // holding this one. Readers copy the pair and retain the semaphore under this
+  // mutex rather than waiting under it, so a record never blocks behind an
+  // unbounded wait on the same event.
+  iree_slim_mutex_t mutex;
+  // Timeline semaphore the last submitted record signals, retained by the
+  // event, or NULL when no record has been submitted yet. The event never owns
+  // a timeline of its own: a record marks a point on the timeline of whichever
+  // submission carries it, so the value below is always reserved and signaled
+  // by that submission's owner. A stream record marks the recording stream's
+  // timeline; a graph record node marks the timeline its block signals, which
+  // is the graph executable's internal semaphore for the partition holding the
+  // node or, for a node in the final partition, the timeline the launch itself
+  // signals. Being a reference rather than an owned semaphore is what lets a
+  // submitted record stay queryable after the stream or graph executable that
+  // carried it is gone.
+  //
+  // A record issued while the recording stream was capturing to a graph never
+  // becomes a submitted record: it produces no submission and no graph node,
+  // only the capture state below. That state is never cleared once set, so from
+  // then on a query or a synchronize on the event is answered with a
+  // captured-event error instead of reading the point here.
+  iree_hal_semaphore_t* signal_semaphore;
+  // Value on |signal_semaphore| that the last submitted record signals, or 0
+  // when |signal_semaphore| is NULL. Both fields are adopted only after that
+  // submission succeeds, so the event never names a point nothing will reach.
+  // Because every timeline is advanced only by its own owner under its own
+  // mutex, no two records can select the same value and no record can select a
+  // value its timeline has already passed. A record issued while the recording
+  // stream is capturing to a graph stores capture state instead and leaves both
+  // fields naming whatever the last submitted record set.
   uint64_t signal_value;
 
-  // Recording stream and context.
+  // Stream that last recorded this event through the stream API, retained, or
+  // NULL before any such record. Its only consumer is stream capture: a wait on
+  // a captured event picks the capture mode, id and owning thread up from here.
+  // A graph launch that runs a record node leaves it alone, as a launch is not
+  // a capture and has no capture state to hand over. Exchanged under |mutex| so
+  // two concurrent records cannot both release the stream they displaced; the
+  // capture paths that consume it read it without the mutex, which is sound
+  // only because a capture sequence is driven by one thread.
   iree_hal_streaming_stream_t* recording_stream;
+  // Context that created the event, retained.
   iree_hal_streaming_context_t* context;
 
-  // Timing information.
+  // Host time the last submitted record was issued at, or 0 when no record has
+  // been submitted. Guarded by |mutex| and adopted with the recorded point, so
+  // a record that never reached the queue leaves no timestamp for a point that
+  // will never be reached: a rejected submission and a record issued while the
+  // recording stream is capturing both leave whatever the last submitted record
+  // set. Elapsed time reads this as the test for whether an event has been
+  // recorded, which is why the two must move together.
   iree_time_t record_time_ns;
 
   // Platform-specific IPC handle, if the event is IPC enabled.
@@ -1707,6 +1755,43 @@ void iree_hal_streaming_event_release(iree_hal_streaming_event_t* event);
 // Synchronization: none (queries event status, non-blocking).
 iree_status_t iree_hal_streaming_event_query(iree_hal_streaming_event_t* event,
                                              int* status);
+
+// Takes a reference to the timeline point |event| was last recorded at.
+// |*out_semaphore| is left NULL when no record has been submitted, in which
+// case there is nothing to wait for and |*out_value| is 0. Callers release
+// |*out_semaphore|.
+// Synchronization: event (event mutex held while copying the point).
+void iree_hal_streaming_event_acquire_recorded_point(
+    iree_hal_streaming_event_t* event, iree_hal_semaphore_t** out_semaphore,
+    uint64_t* out_value);
+
+// Adopts |semaphore| at |value| as the point |event| is recorded at, taking a
+// reference to |semaphore| and dropping the reference to the previous point.
+// Called only once the submission that signals the point has been accepted.
+// Synchronization: event (event mutex held while replacing the point).
+void iree_hal_streaming_event_commit_recorded_point(
+    iree_hal_streaming_event_t* event, iree_hal_semaphore_t* semaphore,
+    uint64_t value, iree_time_t record_time_ns);
+
+// Makes |stream| the stream whose capture state |event| belongs to, taking a
+// reference to it, and returns the stream the event referenced before with its
+// reference transferred to the caller. Returns NULL when |stream| was already
+// the recording stream and no reference changed hands.
+//
+// Releasing the returned stream can destroy it, and stream teardown re-enters
+// the streaming layer to synchronize the stream and unregister it from its
+// context, so callers holding a stream mutex drop the returned reference after
+// unlocking rather than under the lock.
+// Synchronization: event (event mutex held while exchanging), so two concurrent
+// records can never both be handed the same reference to release.
+iree_hal_streaming_stream_t* iree_hal_streaming_event_exchange_recording_stream(
+    iree_hal_streaming_event_t* event, iree_hal_streaming_stream_t* stream);
+
+// Returns the host time the last submitted record of |event| was issued at, or
+// 0 when no record has been submitted.
+// Synchronization: event (event mutex held while reading).
+iree_time_t iree_hal_streaming_event_record_time_ns(
+    iree_hal_streaming_event_t* event);
 
 // Synchronization: stream flush (flushes stream before recording).
 iree_status_t iree_hal_streaming_event_record(

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -736,8 +736,9 @@ typedef enum iree_hal_streaming_event_flag_bits_e {
 } iree_hal_streaming_event_flags_t;
 
 // The timeline point a submitted event record names, together with the stream
-// timeline point that reaching it implies. Published and read as one value so
-// no reader can pair one record's semaphore with another record's value.
+// timeline point that reaching it implies and the host time the record was
+// issued at. Published and read as one value so no reader can pair one record's
+// semaphore, value or timestamp with another record's.
 typedef struct iree_hal_streaming_recorded_point_t {
   // Timeline semaphore the record's submission signals, or NULL when no record
   // has been submitted. Retained by whoever holds the point.
@@ -754,6 +755,11 @@ typedef struct iree_hal_streaming_recorded_point_t {
   // inside a graph launch is ordered after the tail the launch waited on,
   // which is earlier than anything the launch signals.
   uint64_t ordered_after_stream_value;
+  // Host time in nanoseconds the record was issued at, or 0 when no record has
+  // been submitted. Sampled before the submission, so it marks when the caller
+  // issued the record, not when the point is reached; elapsed time reads 0 here
+  // as "never recorded".
+  iree_time_t record_time_ns;
 } iree_hal_streaming_recorded_point_t;
 
 // Event for synchronization.
@@ -764,8 +770,9 @@ typedef struct iree_hal_streaming_event_t {
   // Event properties.
   iree_hal_streaming_event_flags_t flags;
 
-  // Guards |recorded_point| and |record_time_ns|, which must be read together
-  // or a reader pairs one record's point with another record's timestamp.
+  // Guards |recorded_point|, which carries the record's point and timestamp as
+  // one value so no reader can pair one record's point with another record's
+  // timestamp.
   // Acquired after the recording stream's mutex and after the graph
   // executable's mutex; no path takes either while holding this one.
   // Waits happen outside it: readers copy and retain the point under it.
@@ -786,11 +793,6 @@ typedef struct iree_hal_streaming_event_t {
   // Context that created the event, retained.
   iree_hal_streaming_context_t* context;
 
-  // Host time in nanoseconds the last submitted record was issued at, or 0 when
-  // no record has been submitted. Guarded by |mutex| and adopted with the
-  // recorded point; elapsed time reads 0 here as "never recorded".
-  iree_time_t record_time_ns;
-
   // Platform-specific IPC handle, if the event is IPC enabled.
   void* ipc_handle;
 
@@ -806,6 +808,20 @@ typedef struct iree_hal_streaming_event_t {
   // Host allocator.
   iree_allocator_t host_allocator;
 } iree_hal_streaming_event_t;
+
+// Outcome of measuring the interval between two event records. Carried out of
+// band from the status because a failed timeline propagates its own status
+// verbatim, and that status can carry any code, including whichever one a
+// measurement outcome would otherwise have used.
+typedef enum iree_hal_streaming_event_timing_e {
+  // Both records were reached and the interval between them was measured.
+  IREE_HAL_STREAMING_EVENT_TIMING_MEASURED = 0,
+  // At least one of the events carries no timestamp, because timing is disabled
+  // on it or because no record of it has been submitted.
+  IREE_HAL_STREAMING_EVENT_TIMING_UNTIMED,
+  // Both events carry a timestamp but at least one record has not been reached.
+  IREE_HAL_STREAMING_EVENT_TIMING_INCOMPLETE,
+} iree_hal_streaming_event_timing_t;
 
 //===----------------------------------------------------------------------===//
 // Memory types
@@ -1780,7 +1796,7 @@ void iree_hal_streaming_event_acquire_recorded_point(
 // Synchronization: event (event mutex held while replacing the point).
 void iree_hal_streaming_event_commit_recorded_point(
     iree_hal_streaming_event_t* event,
-    iree_hal_streaming_recorded_point_t point, iree_time_t record_time_ns);
+    iree_hal_streaming_recorded_point_t point);
 
 // Makes |stream| the stream whose capture state |event| belongs to, taking a
 // reference to it, and transfers the previously referenced stream to the
@@ -1793,12 +1809,6 @@ void iree_hal_streaming_event_commit_recorded_point(
 iree_hal_streaming_stream_t* iree_hal_streaming_event_exchange_recording_stream(
     iree_hal_streaming_event_t* event, iree_hal_streaming_stream_t* stream);
 
-// Returns the host time the last submitted record of |event| was issued at, or
-// 0 when no record has been submitted.
-// Synchronization: event (event mutex held while reading).
-iree_time_t iree_hal_streaming_event_record_time_ns(
-    iree_hal_streaming_event_t* event);
-
 // Synchronization: stream flush (flushes stream before recording).
 iree_status_t iree_hal_streaming_event_record(
     iree_hal_streaming_event_t* event, iree_hal_streaming_stream_t* stream);
@@ -1807,10 +1817,20 @@ iree_status_t iree_hal_streaming_event_record(
 iree_status_t iree_hal_streaming_event_synchronize(
     iree_hal_streaming_event_t* event);
 
-// Synchronization: both events (waits for both events to complete).
+// Measures the interval between the records |start| and |stop| name and stores
+// it in milliseconds in |*ms|. Writes |*ms| only when |*out_timing| is
+// MEASURED; every other outcome leaves it untouched.
+//
+// |*out_timing| says why no interval was produced and is meaningful only when
+// this returns ok. A non-ok status comes from querying a timeline and belongs
+// to whatever failed the device, not to the events.
+//
+// Synchronization: both events (each event's mutex held while its record is
+// copied; no waiting).
 iree_status_t iree_hal_streaming_event_elapsed_time(
     float* ms, iree_hal_streaming_event_t* start,
-    iree_hal_streaming_event_t* stop);
+    iree_hal_streaming_event_t* stop,
+    iree_hal_streaming_event_timing_t* out_timing);
 
 //===----------------------------------------------------------------------===//
 // Memory management

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -730,6 +730,27 @@ typedef enum iree_hal_streaming_event_flag_bits_e {
   IREE_HAL_STREAMING_EVENT_FLAG_INTERPROCESS = 1ull << 2,
 } iree_hal_streaming_event_flags_t;
 
+// The timeline point a submitted event record names, together with the stream
+// timeline point that reaching it implies. Published and read as one value so
+// no reader can pair one record's semaphore with another record's value.
+typedef struct iree_hal_streaming_recorded_point_t {
+  // Timeline semaphore the record's submission signals, or NULL when no record
+  // has been submitted. Retained by whoever holds the point.
+  iree_hal_semaphore_t* semaphore;
+  // Value |semaphore| reaches once the recorded work completes, or 0 when
+  // |semaphore| is NULL.
+  uint64_t value;
+  // Stream whose timeline this point is ordered after, or 0 when the point
+  // follows no stream timeline point. Identifies the timeline a cross-stream
+  // wait on this point can claim ordering against.
+  unsigned long long ordered_after_stream_id;
+  // Value on |ordered_after_stream_id|'s timeline this point is ordered after,
+  // or 0 when there is none. A lower bound, not the point itself: a record
+  // inside a graph launch is ordered after the tail the launch waited on,
+  // which is earlier than anything the launch signals.
+  uint64_t ordered_after_stream_value;
+} iree_hal_streaming_recorded_point_t;
+
 // Event for synchronization.
 typedef struct iree_hal_streaming_event_t {
   // Reference counting.
@@ -738,23 +759,18 @@ typedef struct iree_hal_streaming_event_t {
   // Event properties.
   iree_hal_streaming_event_flags_t flags;
 
-  // Guards |signal_semaphore|, |signal_value| and |record_time_ns|, which must
-  // be read together or a reader pairs one record's semaphore with another
-  // record's value. Acquired after the recording stream's mutex and after the
-  // graph executable's mutex; no path takes either while holding this one.
+  // Guards |recorded_point| and |record_time_ns|, which must be read together
+  // or a reader pairs one record's point with another record's timestamp.
+  // Acquired after the recording stream's mutex and after the graph
+  // executable's mutex; no path takes either while holding this one.
   // Waits happen outside it: readers copy and retain the point under it.
   iree_slim_mutex_t mutex;
-  // Timeline semaphore the last submitted record signals, retained, or NULL
-  // when no record has been submitted. The event owns no timeline: a record
-  // names a point on the timeline of whichever submission carries it, and the
-  // retained reference is what keeps a submitted record queryable after the
-  // stream or graph executable that carried it is gone.
-  iree_hal_semaphore_t* signal_semaphore;
-  // Value on |signal_semaphore| that the last submitted record signals, or 0
-  // when |signal_semaphore| is NULL. Adopted with |signal_semaphore| only once
-  // the submission that signals it has been accepted, so the event never names
-  // a point nothing will reach.
-  uint64_t signal_value;
+  // Point the last submitted record names, or a zeroed point when no record
+  // has been submitted. The event owns no timeline: a record names a point on
+  // the timeline of whichever submission carries it, and the retained
+  // reference in |recorded_point.semaphore| is what keeps a submitted record
+  // queryable after the stream or graph executable that carried it is gone.
+  iree_hal_streaming_recorded_point_t recorded_point;
 
   // Stream that last recorded this event through the stream API, retained, or
   // NULL before any such record. Consumed only by stream capture, which picks
@@ -1745,21 +1761,21 @@ void iree_hal_streaming_event_release(iree_hal_streaming_event_t* event);
 iree_status_t iree_hal_streaming_event_query(iree_hal_streaming_event_t* event,
                                              int* status);
 
-// Takes a reference to the timeline point |event| was last recorded at, or
-// leaves |*out_semaphore| NULL and |*out_value| 0 when no record has been
-// submitted. Callers release |*out_semaphore|.
+// Takes a reference to the point |event| was last recorded at, or a zeroed
+// point when no record has been submitted. Callers release
+// |out_point->semaphore|.
 // Synchronization: event (event mutex held while copying the point).
 void iree_hal_streaming_event_acquire_recorded_point(
-    iree_hal_streaming_event_t* event, iree_hal_semaphore_t** out_semaphore,
-    uint64_t* out_value);
+    iree_hal_streaming_event_t* event,
+    iree_hal_streaming_recorded_point_t* out_point);
 
-// Adopts |semaphore| at |value| as the point |event| is recorded at, taking a
-// reference to |semaphore| and dropping the reference to the previous point.
-// Called only once the submission that signals the point has been accepted.
+// Adopts |point| as the point |event| is recorded at, taking a reference to
+// |point.semaphore| and dropping the reference to the previous point. Called
+// only once the submission that signals the point has been accepted.
 // Synchronization: event (event mutex held while replacing the point).
 void iree_hal_streaming_event_commit_recorded_point(
-    iree_hal_streaming_event_t* event, iree_hal_semaphore_t* semaphore,
-    uint64_t value, iree_time_t record_time_ns);
+    iree_hal_streaming_event_t* event,
+    iree_hal_streaming_recorded_point_t point, iree_time_t record_time_ns);
 
 // Makes |stream| the stream whose capture state |event| belongs to, taking a
 // reference to it, and transfers the previously referenced stream to the

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -515,11 +515,6 @@ typedef struct iree_hal_streaming_stream_t {
   // Queue affinity.
   iree_hal_queue_affinity_t queue_affinity;
 
-  // Recorded events on this stream.
-  iree_hal_streaming_event_t** recorded_events;
-  iree_host_size_t event_count;
-  iree_host_size_t event_capacity;
-
   // Event dependencies that establish safe cross-stream allocation reuse.
   iree_hal_streaming_memory_reuse_dependency_t* memory_reuse_dependencies;
   // Number of valid entries in |memory_reuse_dependencies|.

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -547,6 +547,34 @@ typedef struct iree_hal_streaming_stream_t {
   iree_allocator_t host_allocator;
 } iree_hal_streaming_stream_t;
 
+// Reserves the next value on |stream|'s timeline for one submission and returns
+// the pair of values that submission names. Callers must hold |stream->mutex|,
+// which is what keeps two submissions on the same stream from selecting the
+// same value, and must publish |*out_signal_value| to |stream->pending_value|
+// themselves so a reservation the queue never accepted leaves the timeline
+// where it was.
+//
+// |*out_wait_value| is the value already reserved on the timeline that the
+// submission has to wait on to stay behind the work in front of it. It is zero
+// when the stream has never submitted, in which case there is nothing behind
+// the reservation and callers drop the wait rather than waiting on value zero.
+//
+// This is the only place a stream timeline value is reserved. Every submission
+// path on a stream goes through it, so the check that the timeline has values
+// left has exactly one owner.
+static inline iree_status_t iree_hal_streaming_stream_reserve_next_value_locked(
+    iree_hal_streaming_stream_t* stream, uint64_t* out_wait_value,
+    uint64_t* out_signal_value) {
+  const uint64_t wait_value = stream->pending_value;
+  if (IREE_UNLIKELY(wait_value == UINT64_MAX)) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "stream timeline value overflow");
+  }
+  *out_wait_value = wait_value;
+  *out_signal_value = wait_value + 1;
+  return iree_ok_status();
+}
+
 // Updates capture status while keeping the owning context's capture-stream
 // count in sync. Callers serialize access to the stream capture fields.
 static inline void iree_hal_streaming_stream_set_capture_status(

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -507,9 +507,7 @@ typedef struct iree_hal_streaming_stream_t {
 
   // Semaphore chain for synchronization.
   iree_hal_semaphore_t* timeline_semaphore;
-  uint64_t pending_value;    // Last stream timeline value reserved.
-  uint64_t submitted_value;  // Last value that was actually submitted (for
-                             // wait_submitted)
+  uint64_t pending_value;    // Last value a submission has been accepted for.
   uint64_t completed_value;  // Last value we've verified as completed
 
   // Queue affinity.
@@ -550,7 +548,14 @@ typedef struct iree_hal_streaming_stream_t {
 // Reserves the next value on |stream|'s timeline for one submission. Callers
 // must hold |stream->mutex| and publish |*out_signal_value| to
 // |stream->pending_value| only once the submission is accepted, so a rejected
-// submission leaves the timeline where it was.
+// submission leaves the timeline where it was and hands the value out again.
+//
+// A value must name exactly one submission, and nothing catches a violation:
+// queues publish their completions with a duplicate-tolerant advance, so the
+// second submission's signal is a silent no-op and the timeline reaches the
+// value when the first submission completes. Every reader treats the timeline
+// reaching a value as "the submission that signals it has completed", so all of
+// them report completion while the second submission is still running.
 //
 // |*out_wait_value| is the value the submission must wait on to stay behind the
 // work in front of it, or 0 when the stream has never submitted, in which case

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -547,21 +547,14 @@ typedef struct iree_hal_streaming_stream_t {
   iree_allocator_t host_allocator;
 } iree_hal_streaming_stream_t;
 
-// Reserves the next value on |stream|'s timeline for one submission and returns
-// the pair of values that submission names. Callers must hold |stream->mutex|,
-// which is what keeps two submissions on the same stream from selecting the
-// same value, and must publish |*out_signal_value| to |stream->pending_value|
-// themselves so a reservation the queue never accepted leaves the timeline
-// where it was.
+// Reserves the next value on |stream|'s timeline for one submission. Callers
+// must hold |stream->mutex| and publish |*out_signal_value| to
+// |stream->pending_value| only once the submission is accepted, so a rejected
+// submission leaves the timeline where it was.
 //
-// |*out_wait_value| is the value already reserved on the timeline that the
-// submission has to wait on to stay behind the work in front of it. It is zero
-// when the stream has never submitted, in which case there is nothing behind
-// the reservation and callers drop the wait rather than waiting on value zero.
-//
-// This is the only place a stream timeline value is reserved. Every submission
-// path on a stream goes through it, so the check that the timeline has values
-// left has exactly one owner.
+// |*out_wait_value| is the value the submission must wait on to stay behind the
+// work in front of it, or 0 when the stream has never submitted, in which case
+// callers drop the wait rather than waiting on value zero.
 static inline iree_status_t iree_hal_streaming_stream_reserve_next_value_locked(
     iree_hal_streaming_stream_t* stream, uint64_t* out_wait_value,
     uint64_t* out_signal_value) {
@@ -745,63 +738,36 @@ typedef struct iree_hal_streaming_event_t {
   // Event properties.
   iree_hal_streaming_event_flags_t flags;
 
-  // Guards the recorded point: |signal_semaphore|, |signal_value| and
-  // |record_time_ns|. An event is shared state that any thread may record,
-  // query, or wait on, and the semaphore and value must be read together or a
-  // reader can pair one record's semaphore with another record's value. Held
-  // after the recording stream's mutex and, on the graph path, after the graph
-  // executable's mutex; no path takes a stream or executable mutex while
-  // holding this one. Readers copy the pair and retain the semaphore under this
-  // mutex rather than waiting under it, so a record never blocks behind an
-  // unbounded wait on the same event.
+  // Guards |signal_semaphore|, |signal_value| and |record_time_ns|, which must
+  // be read together or a reader pairs one record's semaphore with another
+  // record's value. Acquired after the recording stream's mutex and after the
+  // graph executable's mutex; no path takes either while holding this one.
+  // Waits happen outside it: readers copy and retain the point under it.
   iree_slim_mutex_t mutex;
-  // Timeline semaphore the last submitted record signals, retained by the
-  // event, or NULL when no record has been submitted yet. The event never owns
-  // a timeline of its own: a record marks a point on the timeline of whichever
-  // submission carries it, so the value below is always reserved and signaled
-  // by that submission's owner. A stream record marks the recording stream's
-  // timeline; a graph record node marks the timeline its block signals, which
-  // is the graph executable's internal semaphore for the partition holding the
-  // node or, for a node in the final partition, the timeline the launch itself
-  // signals. Being a reference rather than an owned semaphore is what lets a
-  // submitted record stay queryable after the stream or graph executable that
-  // carried it is gone.
-  //
-  // A record issued while the recording stream was capturing to a graph never
-  // becomes a submitted record: it produces no submission and no graph node,
-  // only the capture state below. That state is never cleared once set, so from
-  // then on a query or a synchronize on the event is answered with a
-  // captured-event error instead of reading the point here.
+  // Timeline semaphore the last submitted record signals, retained, or NULL
+  // when no record has been submitted. The event owns no timeline: a record
+  // names a point on the timeline of whichever submission carries it, and the
+  // retained reference is what keeps a submitted record queryable after the
+  // stream or graph executable that carried it is gone.
   iree_hal_semaphore_t* signal_semaphore;
   // Value on |signal_semaphore| that the last submitted record signals, or 0
-  // when |signal_semaphore| is NULL. Both fields are adopted only after that
-  // submission succeeds, so the event never names a point nothing will reach.
-  // Because every timeline is advanced only by its own owner under its own
-  // mutex, no two records can select the same value and no record can select a
-  // value its timeline has already passed. A record issued while the recording
-  // stream is capturing to a graph stores capture state instead and leaves both
-  // fields naming whatever the last submitted record set.
+  // when |signal_semaphore| is NULL. Adopted with |signal_semaphore| only once
+  // the submission that signals it has been accepted, so the event never names
+  // a point nothing will reach.
   uint64_t signal_value;
 
   // Stream that last recorded this event through the stream API, retained, or
-  // NULL before any such record. Its only consumer is stream capture: a wait on
-  // a captured event picks the capture mode, id and owning thread up from here.
-  // A graph launch that runs a record node leaves it alone, as a launch is not
-  // a capture and has no capture state to hand over. Exchanged under |mutex| so
-  // two concurrent records cannot both release the stream they displaced; the
-  // capture paths that consume it read it without the mutex, which is sound
-  // only because a capture sequence is driven by one thread.
+  // NULL before any such record. Consumed only by stream capture, which picks
+  // the capture mode, id and owning thread up from here; a graph launch leaves
+  // it alone. Exchanged under |mutex| but read by the capture paths without it,
+  // which is sound only because a capture sequence is driven by one thread.
   iree_hal_streaming_stream_t* recording_stream;
   // Context that created the event, retained.
   iree_hal_streaming_context_t* context;
 
-  // Host time the last submitted record was issued at, or 0 when no record has
-  // been submitted. Guarded by |mutex| and adopted with the recorded point, so
-  // a record that never reached the queue leaves no timestamp for a point that
-  // will never be reached: a rejected submission and a record issued while the
-  // recording stream is capturing both leave whatever the last submitted record
-  // set. Elapsed time reads this as the test for whether an event has been
-  // recorded, which is why the two must move together.
+  // Host time in nanoseconds the last submitted record was issued at, or 0 when
+  // no record has been submitted. Guarded by |mutex| and adopted with the
+  // recorded point; elapsed time reads 0 here as "never recorded".
   iree_time_t record_time_ns;
 
   // Platform-specific IPC handle, if the event is IPC enabled.
@@ -1779,10 +1745,9 @@ void iree_hal_streaming_event_release(iree_hal_streaming_event_t* event);
 iree_status_t iree_hal_streaming_event_query(iree_hal_streaming_event_t* event,
                                              int* status);
 
-// Takes a reference to the timeline point |event| was last recorded at.
-// |*out_semaphore| is left NULL when no record has been submitted, in which
-// case there is nothing to wait for and |*out_value| is 0. Callers release
-// |*out_semaphore|.
+// Takes a reference to the timeline point |event| was last recorded at, or
+// leaves |*out_semaphore| NULL and |*out_value| 0 when no record has been
+// submitted. Callers release |*out_semaphore|.
 // Synchronization: event (event mutex held while copying the point).
 void iree_hal_streaming_event_acquire_recorded_point(
     iree_hal_streaming_event_t* event, iree_hal_semaphore_t** out_semaphore,
@@ -1797,16 +1762,13 @@ void iree_hal_streaming_event_commit_recorded_point(
     uint64_t value, iree_time_t record_time_ns);
 
 // Makes |stream| the stream whose capture state |event| belongs to, taking a
-// reference to it, and returns the stream the event referenced before with its
-// reference transferred to the caller. Returns NULL when |stream| was already
-// the recording stream and no reference changed hands.
+// reference to it, and transfers the previously referenced stream to the
+// caller. Returns NULL when |stream| was already the recording stream.
 //
-// Releasing the returned stream can destroy it, and stream teardown re-enters
-// the streaming layer to synchronize the stream and unregister it from its
-// context, so callers holding a stream mutex drop the returned reference after
-// unlocking rather than under the lock.
-// Synchronization: event (event mutex held while exchanging), so two concurrent
-// records can never both be handed the same reference to release.
+// Releasing the returned stream can run its teardown, which re-enters the
+// streaming layer to synchronize and unregister the stream, so callers holding
+// a stream mutex must drop the reference after unlocking.
+// Synchronization: event (event mutex held while exchanging).
 iree_hal_streaming_stream_t* iree_hal_streaming_event_exchange_recording_stream(
     iree_hal_streaming_event_t* event, iree_hal_streaming_stream_t* stream);
 

--- a/libhrx/src/binding/common/stream.c
+++ b/libhrx/src/binding/common/stream.c
@@ -315,9 +315,6 @@ iree_status_t iree_hal_streaming_stream_create(
   stream->submitted_value = 0;
   stream->completed_value = 0;
   stream->queue_affinity = IREE_HAL_QUEUE_AFFINITY_ANY;
-  stream->recorded_events = NULL;
-  stream->event_count = 0;
-  stream->event_capacity = 0;
   stream->memory_reuse_dependencies = NULL;
   stream->memory_reuse_dependency_count = 0;
   stream->memory_reuse_dependency_capacity = 0;
@@ -371,13 +368,6 @@ static void iree_hal_streaming_stream_destroy(
     iree_hal_streaming_context_unregister_stream(context, stream);
   }
 
-  // Clean up recorded events.
-  if (stream->recorded_events) {
-    for (iree_host_size_t i = 0; i < stream->event_count; ++i) {
-      iree_hal_streaming_event_release(stream->recorded_events[i]);
-    }
-    iree_allocator_free(stream->host_allocator, stream->recorded_events);
-  }
   iree_allocator_free(stream->host_allocator,
                       stream->memory_reuse_dependencies);
 

--- a/libhrx/src/binding/common/stream.c
+++ b/libhrx/src/binding/common/stream.c
@@ -783,20 +783,40 @@ iree_status_t iree_hal_streaming_stream_wait_event(
   // Reserve the next stream timeline value and submit a barrier that completes
   // only after the event is signaled. The value is submitted, not completed;
   // query/synchronize advance completed_value after observing the semaphore.
-  uint64_t signal_value = stream->pending_value + 1;
+  uint64_t wait_value = stream->pending_value;
+  uint64_t signal_value = wait_value + 1;
 
+  // The barrier waits on the point the event was recorded at and on everything
+  // already on this stream. Both waits are needed: dropping the stream wait
+  // would let this barrier signal the next stream value before the value below
+  // it, which both breaks the ordering every later operation on the stream
+  // relies on and signals the stream timeline out of order. The stream wait is
+  // dropped when the stream has never submitted, and the event wait when the
+  // event has never had a record submitted, as neither has a point to wait for.
   // The recorded point is copied out under the event's own mutex; reading the
   // event's fields in place would read them under this stream's mutex, which is
-  // not the mutex a record of this event takes. An event with no submitted
-  // record has no point to wait for.
+  // not the mutex a record of this event takes.
   iree_hal_semaphore_t* event_semaphore = NULL;
   uint64_t event_signal_value = 0;
   iree_hal_streaming_event_acquire_recorded_point(event, &event_semaphore,
                                                   &event_signal_value);
+  iree_hal_semaphore_t* wait_semaphore_storage[2];
+  uint64_t wait_value_storage[2];
+  iree_host_size_t wait_count = 0;
+  if (wait_value > 0) {
+    wait_semaphore_storage[wait_count] = stream->timeline_semaphore;
+    wait_value_storage[wait_count] = wait_value;
+    ++wait_count;
+  }
+  if (event_semaphore) {
+    wait_semaphore_storage[wait_count] = event_semaphore;
+    wait_value_storage[wait_count] = event_signal_value;
+    ++wait_count;
+  }
   iree_hal_semaphore_list_t wait_semaphores = {
-      .count = event_semaphore ? 1 : 0,
-      .semaphores = &event_semaphore,
-      .payload_values = &event_signal_value,
+      .count = wait_count,
+      .semaphores = wait_semaphore_storage,
+      .payload_values = wait_value_storage,
   };
   iree_hal_semaphore_list_t signal_semaphores = {
       .count = 1,

--- a/libhrx/src/binding/common/stream.c
+++ b/libhrx/src/binding/common/stream.c
@@ -544,12 +544,6 @@ iree_status_t iree_hal_streaming_stream_query(
 
   IREE_RETURN_IF_ERROR(iree_hal_streaming_stream_flush(stream));
 
-  // A timeline query fails only when the timeline itself has failed, which is
-  // permanent: there is no transient answer to distinguish from an incomplete
-  // one, since a value below the one being waited for is reported as a value
-  // and not as an error. Reporting that failure as merely incomplete would turn
-  // a dead timeline into a poll loop that never ends, so it propagates, which
-  // is also how an event query classifies it.
   uint64_t current_value = 0;
   IREE_RETURN_IF_ERROR(
       iree_hal_semaphore_query(stream->timeline_semaphore, &current_value));
@@ -600,9 +594,6 @@ static iree_status_t iree_hal_streaming_stream_synchronize_impl(
   uint64_t completed_value = stream->completed_value;
   iree_slim_mutex_unlock(&stream->mutex);
 
-  // A failing query means the timeline has failed for good, which the wait
-  // below would also report; propagating it here keeps the message the failure
-  // was raised with instead of the bare code a wait carries.
   timing_step_ns = timing_enabled ? hrx_launch_timing_now_ns() : 0;
   uint64_t current_value = 0;
   iree_status_t query_status =
@@ -787,15 +778,9 @@ iree_status_t iree_hal_streaming_stream_wait_event(
   }
 
   // The barrier waits on the point the event was recorded at and on everything
-  // already on this stream. Both waits are needed: dropping the stream wait
-  // would let this barrier signal the next stream value before the value below
-  // it, which both breaks the ordering every later operation on the stream
-  // relies on and signals the stream timeline out of order. The stream wait is
-  // dropped when the stream has never submitted, and the event wait when the
-  // event has never had a record submitted, as neither has a point to wait for.
-  // The recorded point is copied out under the event's own mutex; reading the
-  // event's fields in place would read them under this stream's mutex, which is
-  // not the mutex a record of this event takes.
+  // already on this stream, so the value it signals stays behind the value
+  // below it. Either wait is dropped when there is nothing behind it: a stream
+  // that has never submitted, or an event with no submitted record.
   iree_hal_semaphore_t* event_semaphore = NULL;
   uint64_t event_signal_value = 0;
   iree_hal_streaming_event_acquire_recorded_point(event, &event_semaphore,

--- a/libhrx/src/binding/common/stream.c
+++ b/libhrx/src/binding/common/stream.c
@@ -466,12 +466,19 @@ iree_status_t iree_hal_streaming_stream_flush(
       return status;
     }
 
-    // Wait for the previous submission (pending_value before increment).
-    // This chains each flush after the one before it, so that operations
-    // split across multiple command buffers (e.g. by an intervening
-    // hipMemcpy) still execute in order.
-    uint64_t wait_value = stream->pending_value;
-    stream->pending_value++;
+    // Wait for the previous submission. This chains each flush after the one
+    // before it, so that operations split across multiple command buffers
+    // (e.g. by an intervening hipMemcpy) still execute in order.
+    uint64_t wait_value = 0;
+    uint64_t signal_value = 0;
+    status = iree_hal_streaming_stream_reserve_next_value_locked(
+        stream, &wait_value, &signal_value);
+    if (!iree_status_is_ok(status)) {
+      iree_slim_mutex_unlock(&stream->mutex);
+      IREE_TRACE_ZONE_END(z0);
+      return status;
+    }
+    stream->pending_value = signal_value;
 
     // Submit to device queue with timeline semaphore.
     // Wait for the previous submission to complete before executing.
@@ -486,7 +493,7 @@ iree_status_t iree_hal_streaming_stream_flush(
     iree_hal_semaphore_list_t signal_semaphores = {
         .count = 1,
         .semaphores = &stream->timeline_semaphore,
-        .payload_values = &stream->pending_value,
+        .payload_values = &signal_value,
     };
 
     timing_step_ns = timing_enabled ? hrx_launch_timing_now_ns() : 0;
@@ -502,13 +509,9 @@ iree_status_t iree_hal_streaming_stream_flush(
       timing_execute_ns += hrx_launch_timing_now_ns() - timing_step_ns;
     }
 
-    if (!iree_status_is_ok(status)) {
-      // Error will propagate via iree_status_t return.
-    }
-
     // Track the submitted value for wait_submitted.
     if (iree_status_is_ok(status)) {
-      stream->submitted_value = stream->pending_value;
+      stream->submitted_value = signal_value;
     }
 
     // Release command buffer (we're done with it).
@@ -773,8 +776,15 @@ iree_status_t iree_hal_streaming_stream_wait_event(
   // Reserve the next stream timeline value and submit a barrier that completes
   // only after the event is signaled. The value is submitted, not completed;
   // query/synchronize advance completed_value after observing the semaphore.
-  uint64_t wait_value = stream->pending_value;
-  uint64_t signal_value = wait_value + 1;
+  uint64_t wait_value = 0;
+  uint64_t signal_value = 0;
+  iree_status_t status = iree_hal_streaming_stream_reserve_next_value_locked(
+      stream, &wait_value, &signal_value);
+  if (!iree_status_is_ok(status)) {
+    iree_slim_mutex_unlock(&stream->mutex);
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
 
   // The barrier waits on the point the event was recorded at and on everything
   // already on this stream. Both waits are needed: dropping the stream wait
@@ -814,7 +824,7 @@ iree_status_t iree_hal_streaming_stream_wait_event(
       .payload_values = &signal_value,
   };
 
-  iree_status_t status = iree_hal_device_queue_barrier(
+  status = iree_hal_device_queue_barrier(
       stream->context->device, stream->queue_affinity, wait_semaphores,
       signal_semaphores, IREE_HAL_EXECUTE_FLAG_NONE);
   if (iree_status_is_ok(status)) {
@@ -1489,8 +1499,10 @@ iree_status_t iree_hal_streaming_launch_kernel(
   bool should_flush = false;
   iree_slim_mutex_lock(&stream->mutex);
   if (dispatch_directly) {
-    uint64_t wait_value = stream->pending_value;
-    uint64_t signal_value = wait_value + 1;
+    uint64_t wait_value = 0;
+    uint64_t signal_value = 0;
+    status = iree_hal_streaming_stream_reserve_next_value_locked(
+        stream, &wait_value, &signal_value);
     const iree_hal_semaphore_list_t wait_semaphores = {
         .count = wait_value > 0 ? 1 : 0,
         .semaphores = &stream->timeline_semaphore,
@@ -1501,12 +1513,14 @@ iree_status_t iree_hal_streaming_launch_kernel(
         .semaphores = &stream->timeline_semaphore,
         .payload_values = &signal_value,
     };
-    status = iree_hal_device_queue_dispatch(
-        stream->context->device, stream->queue_affinity, wait_semaphores,
-        signal_semaphores, symbol->executable,
-        iree_hal_executable_function_from_index(symbol->export_ordinal), config,
-        iree_make_const_byte_span(constants, constants_size), binding_list,
-        flags);
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_device_queue_dispatch(
+          stream->context->device, stream->queue_affinity, wait_semaphores,
+          signal_semaphores, symbol->executable,
+          iree_hal_executable_function_from_index(symbol->export_ordinal),
+          config, iree_make_const_byte_span(constants, constants_size),
+          binding_list, flags);
+    }
     if (iree_status_is_ok(status)) {
       status = iree_hal_device_queue_flush(stream->context->device,
                                            stream->queue_affinity);
@@ -1623,14 +1637,15 @@ iree_status_t iree_hal_streaming_queue_host_call(
                                     iree_hal_streaming_stream_flush(stream));
 
   iree_slim_mutex_lock(&stream->mutex);
-  uint64_t wait_value = stream->pending_value;
-  if (IREE_UNLIKELY(wait_value == UINT64_MAX)) {
+  uint64_t wait_value = 0;
+  uint64_t signal_value = 0;
+  iree_status_t status = iree_hal_streaming_stream_reserve_next_value_locked(
+      stream, &wait_value, &signal_value);
+  if (!iree_status_is_ok(status)) {
     iree_slim_mutex_unlock(&stream->mutex);
     IREE_TRACE_ZONE_END(z0);
-    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
-                            "stream timeline value overflow");
+    return status;
   }
-  uint64_t signal_value = wait_value + 1;
   iree_hal_semaphore_list_t wait_semaphores = {
       .count = wait_value > 0 ? 1 : 0,
       .semaphores = &stream->timeline_semaphore,
@@ -1642,7 +1657,7 @@ iree_status_t iree_hal_streaming_queue_host_call(
       .payload_values = &signal_value,
   };
 
-  iree_status_t status = iree_hal_device_queue_host_call(
+  status = iree_hal_device_queue_host_call(
       stream->context->device, stream->queue_affinity, wait_semaphores,
       signal_semaphores, call, args, flags);
   if (iree_status_is_ok(status)) {

--- a/libhrx/src/binding/common/stream.c
+++ b/libhrx/src/binding/common/stream.c
@@ -544,15 +544,15 @@ iree_status_t iree_hal_streaming_stream_query(
 
   IREE_RETURN_IF_ERROR(iree_hal_streaming_stream_flush(stream));
 
+  // A timeline query fails only when the timeline itself has failed, which is
+  // permanent: there is no transient answer to distinguish from an incomplete
+  // one, since a value below the one being waited for is reported as a value
+  // and not as an error. Reporting that failure as merely incomplete would turn
+  // a dead timeline into a poll loop that never ends, so it propagates, which
+  // is also how an event query classifies it.
   uint64_t current_value = 0;
-  iree_status_t query_status =
-      iree_hal_semaphore_query(stream->timeline_semaphore, &current_value);
-  if (iree_status_is_unavailable(query_status)) {
-    iree_status_ignore(query_status);
-    *status = 1;  // Not complete
-    return iree_ok_status();
-  }
-  IREE_RETURN_IF_ERROR(query_status);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_semaphore_query(stream->timeline_semaphore, &current_value));
 
   iree_slim_mutex_lock(&stream->mutex);
   const uint64_t pending_value = stream->pending_value;
@@ -600,14 +600,14 @@ static iree_status_t iree_hal_streaming_stream_synchronize_impl(
   uint64_t completed_value = stream->completed_value;
   iree_slim_mutex_unlock(&stream->mutex);
 
+  // A failing query means the timeline has failed for good, which the wait
+  // below would also report; propagating it here keeps the message the failure
+  // was raised with instead of the bare code a wait carries.
   timing_step_ns = timing_enabled ? hrx_launch_timing_now_ns() : 0;
   uint64_t current_value = 0;
   iree_status_t query_status =
       iree_hal_semaphore_query(stream->timeline_semaphore, &current_value);
-  if (iree_status_is_unavailable(query_status)) {
-    iree_status_ignore(query_status);
-    query_status = iree_ok_status();
-  } else if (iree_status_is_ok(query_status)) {
+  if (iree_status_is_ok(query_status)) {
     if (current_value > completed_value) {
       completed_value = current_value;
     }

--- a/libhrx/src/binding/common/stream.c
+++ b/libhrx/src/binding/common/stream.c
@@ -312,7 +312,6 @@ iree_status_t iree_hal_streaming_stream_create(
   stream->pending_launch_count = 0;
   stream->timeline_semaphore = NULL;
   stream->pending_value = 0;
-  stream->submitted_value = 0;
   stream->completed_value = 0;
   stream->queue_affinity = IREE_HAL_QUEUE_AFFINITY_ANY;
   stream->memory_reuse_dependencies = NULL;
@@ -478,7 +477,6 @@ iree_status_t iree_hal_streaming_stream_flush(
       IREE_TRACE_ZONE_END(z0);
       return status;
     }
-    stream->pending_value = signal_value;
 
     // Submit to device queue with timeline semaphore.
     // Wait for the previous submission to complete before executing.
@@ -502,16 +500,14 @@ iree_status_t iree_hal_streaming_stream_flush(
         signal_semaphores, stream->command_buffer,
         iree_hal_buffer_binding_table_empty(), IREE_HAL_EXECUTE_FLAG_NONE);
     if (iree_status_is_ok(status)) {
+      // The accepted submission owns the value it signals, so the timeline
+      // advances here and stays advanced even when the flush below fails.
+      stream->pending_value = signal_value;
       status =
           iree_hal_device_queue_flush(stream->context->device, queue_affinity);
     }
     if (timing_enabled) {
       timing_execute_ns += hrx_launch_timing_now_ns() - timing_step_ns;
-    }
-
-    // Track the submitted value for wait_submitted.
-    if (iree_status_is_ok(status)) {
-      stream->submitted_value = signal_value;
     }
 
     // Release command buffer (we're done with it).
@@ -661,14 +657,14 @@ iree_status_t iree_hal_streaming_stream_wait_submitted(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // Wait for already-submitted work to complete WITHOUT flushing.
-  // Snapshot the last submitted value under the stream lock. New submissions
+  // Snapshot the tail of accepted work under the stream lock. New submissions
   // after this point are outside this wait operation.
   iree_slim_mutex_lock(&stream->mutex);
-  const uint64_t submitted_value = stream->submitted_value;
+  const uint64_t pending_value = stream->pending_value;
   iree_slim_mutex_unlock(&stream->mutex);
-  if (submitted_value > 0) {
+  if (pending_value > 0) {
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_hal_semaphore_wait(stream->timeline_semaphore, submitted_value,
+        z0, iree_hal_semaphore_wait(stream->timeline_semaphore, pending_value,
                                     iree_infinite_timeout(),
                                     IREE_ASYNC_WAIT_FLAG_NONE));
   }
@@ -768,6 +764,8 @@ iree_status_t iree_hal_streaming_stream_wait_event(
       source_stream_id != 0 && source_stream_id != stream->stream_id &&
       source_timeline_value != 0;
   bool added_memory_reuse_dependency = false;
+  // True once the queue has accepted the barrier that establishes the ordering.
+  bool submitted = false;
   iree_status_t status = iree_ok_status();
   if (files_memory_reuse_dependency) {
     status = iree_hal_streaming_stream_reserve_memory_reuse_dependency(
@@ -824,12 +822,12 @@ iree_status_t iree_hal_streaming_stream_wait_event(
           stream->context->device, stream->queue_affinity, wait_semaphores,
           signal_semaphores, IREE_HAL_EXECUTE_FLAG_NONE);
       if (iree_status_is_ok(status)) {
+        // The accepted barrier owns the value it signals, so the timeline
+        // advances here and stays advanced even when the flush below fails.
+        submitted = true;
+        stream->pending_value = signal_value;
         status = iree_hal_device_queue_flush(stream->context->device,
                                              stream->queue_affinity);
-      }
-      if (iree_status_is_ok(status)) {
-        stream->pending_value = signal_value;
-        stream->submitted_value = signal_value;
       }
     }
 
@@ -843,7 +841,7 @@ iree_status_t iree_hal_streaming_stream_wait_event(
   // carries no value until the submission that establishes the ordering is
   // accepted, and is withdrawn when that submission is not.
   if (files_memory_reuse_dependency) {
-    if (iree_status_is_ok(status)) {
+    if (submitted) {
       iree_hal_streaming_stream_record_memory_reuse_dependency(
           stream, source_stream_id, source_timeline_value);
     } else if (added_memory_reuse_dependency) {
@@ -1526,12 +1524,11 @@ iree_status_t iree_hal_streaming_launch_kernel(
           binding_list, flags);
     }
     if (iree_status_is_ok(status)) {
+      // The accepted dispatch owns the value it signals, so the timeline
+      // advances here and stays advanced even when the flush below fails.
+      stream->pending_value = signal_value;
       status = iree_hal_device_queue_flush(stream->context->device,
                                            stream->queue_affinity);
-    }
-    if (iree_status_is_ok(status)) {
-      stream->pending_value = signal_value;
-      stream->submitted_value = signal_value;
     }
   } else {
     uint64_t timing_begin_step_ns =
@@ -1666,7 +1663,6 @@ iree_status_t iree_hal_streaming_queue_host_call(
       signal_semaphores, call, args, flags);
   if (iree_status_is_ok(status)) {
     stream->pending_value = signal_value;
-    stream->submitted_value = signal_value;
   }
   iree_slim_mutex_unlock(&stream->mutex);
 

--- a/libhrx/src/binding/common/stream.c
+++ b/libhrx/src/binding/common/stream.c
@@ -784,10 +784,19 @@ iree_status_t iree_hal_streaming_stream_wait_event(
   // only after the event is signaled. The value is submitted, not completed;
   // query/synchronize advance completed_value after observing the semaphore.
   uint64_t signal_value = stream->pending_value + 1;
+
+  // The recorded point is copied out under the event's own mutex; reading the
+  // event's fields in place would read them under this stream's mutex, which is
+  // not the mutex a record of this event takes. An event with no submitted
+  // record has no point to wait for.
+  iree_hal_semaphore_t* event_semaphore = NULL;
+  uint64_t event_signal_value = 0;
+  iree_hal_streaming_event_acquire_recorded_point(event, &event_semaphore,
+                                                  &event_signal_value);
   iree_hal_semaphore_list_t wait_semaphores = {
-      .count = 1,
-      .semaphores = &event->semaphore,
-      .payload_values = &event->signal_value,
+      .count = event_semaphore ? 1 : 0,
+      .semaphores = &event_semaphore,
+      .payload_values = &event_signal_value,
   };
   iree_hal_semaphore_list_t signal_semaphores = {
       .count = 1,
@@ -808,6 +817,7 @@ iree_status_t iree_hal_streaming_stream_wait_event(
   }
 
   iree_slim_mutex_unlock(&stream->mutex);
+  iree_hal_semaphore_release(event_semaphore);
   if (!iree_status_is_ok(status) && added_memory_reuse_dependency) {
     iree_hal_streaming_stream_remove_uncommitted_memory_reuse_dependency(
         stream, source_stream_id);

--- a/libhrx/src/binding/common/stream.c
+++ b/libhrx/src/binding/common/stream.c
@@ -747,92 +747,111 @@ iree_status_t iree_hal_streaming_stream_wait_event(
     return iree_ok_status();
   }
 
+  // Read the point once. The barrier below waits on exactly the point whose
+  // stream ordering is filed as a reuse dependency, so a record landing on this
+  // event concurrently cannot make the filed dependency describe a point other
+  // than the one waited on.
+  iree_hal_streaming_recorded_point_t recorded_point;
+  iree_hal_streaming_event_acquire_recorded_point(event, &recorded_point);
+
+  // Waiting on the point orders every later submission on this stream behind
+  // it, and therefore behind the stream timeline point it follows. That is the
+  // ordering a deferred free on that stream needs before its allocation may be
+  // reused here. A point that follows no stream timeline point files nothing:
+  // there is no ordering to claim. A point on this stream's own timeline files
+  // nothing either, because same-stream ordering already covers it.
   const unsigned long long source_stream_id =
-      event->recording_stream ? event->recording_stream->stream_id : 0;
-  const uint64_t source_timeline_value = event->signal_value;
+      recorded_point.ordered_after_stream_id;
+  const uint64_t source_timeline_value =
+      recorded_point.ordered_after_stream_value;
+  const bool files_memory_reuse_dependency =
+      source_stream_id != 0 && source_stream_id != stream->stream_id &&
+      source_timeline_value != 0;
   bool added_memory_reuse_dependency = false;
-  if (source_stream_id != 0 && source_stream_id != stream->stream_id &&
-      source_timeline_value != 0) {
-    IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_hal_streaming_stream_reserve_memory_reuse_dependency(
-                stream, source_stream_id, &added_memory_reuse_dependency));
+  iree_status_t status = iree_ok_status();
+  if (files_memory_reuse_dependency) {
+    status = iree_hal_streaming_stream_reserve_memory_reuse_dependency(
+        stream, source_stream_id, &added_memory_reuse_dependency);
   }
 
   // Flush the stream to ensure all prior operations are submitted.
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(z0,
-                                    iree_hal_streaming_stream_flush(stream));
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_stream_flush(stream);
+  }
 
-  iree_slim_mutex_lock(&stream->mutex);
+  if (iree_status_is_ok(status)) {
+    iree_slim_mutex_lock(&stream->mutex);
 
-  // Reserve the next stream timeline value and submit a barrier that completes
-  // only after the event is signaled. The value is submitted, not completed;
-  // query/synchronize advance completed_value after observing the semaphore.
-  uint64_t wait_value = 0;
-  uint64_t signal_value = 0;
-  iree_status_t status = iree_hal_streaming_stream_reserve_next_value_locked(
-      stream, &wait_value, &signal_value);
-  if (!iree_status_is_ok(status)) {
+    // Reserve the next stream timeline value and submit a barrier that
+    // completes only after the event is signaled. The value is submitted, not
+    // completed; query/synchronize advance completed_value after observing the
+    // semaphore.
+    uint64_t wait_value = 0;
+    uint64_t signal_value = 0;
+    status = iree_hal_streaming_stream_reserve_next_value_locked(
+        stream, &wait_value, &signal_value);
+    if (iree_status_is_ok(status)) {
+      // The barrier waits on the point the event was recorded at and on
+      // everything already on this stream, so the value it signals stays behind
+      // the value below it. Either wait is dropped when there is nothing behind
+      // it: a stream that has never submitted, or an event with no submitted
+      // record.
+      iree_hal_semaphore_t* wait_semaphore_storage[2];
+      uint64_t wait_value_storage[2];
+      iree_host_size_t wait_count = 0;
+      if (wait_value > 0) {
+        wait_semaphore_storage[wait_count] = stream->timeline_semaphore;
+        wait_value_storage[wait_count] = wait_value;
+        ++wait_count;
+      }
+      if (recorded_point.semaphore) {
+        wait_semaphore_storage[wait_count] = recorded_point.semaphore;
+        wait_value_storage[wait_count] = recorded_point.value;
+        ++wait_count;
+      }
+      iree_hal_semaphore_list_t wait_semaphores = {
+          .count = wait_count,
+          .semaphores = wait_semaphore_storage,
+          .payload_values = wait_value_storage,
+      };
+      iree_hal_semaphore_list_t signal_semaphores = {
+          .count = 1,
+          .semaphores = &stream->timeline_semaphore,
+          .payload_values = &signal_value,
+      };
+
+      status = iree_hal_device_queue_barrier(
+          stream->context->device, stream->queue_affinity, wait_semaphores,
+          signal_semaphores, IREE_HAL_EXECUTE_FLAG_NONE);
+      if (iree_status_is_ok(status)) {
+        status = iree_hal_device_queue_flush(stream->context->device,
+                                             stream->queue_affinity);
+      }
+      if (iree_status_is_ok(status)) {
+        stream->pending_value = signal_value;
+        stream->submitted_value = signal_value;
+      }
+    }
+
     iree_slim_mutex_unlock(&stream->mutex);
-    IREE_TRACE_ZONE_END(z0);
-    return status;
   }
 
-  // The barrier waits on the point the event was recorded at and on everything
-  // already on this stream, so the value it signals stays behind the value
-  // below it. Either wait is dropped when there is nothing behind it: a stream
-  // that has never submitted, or an event with no submitted record.
-  iree_hal_semaphore_t* event_semaphore = NULL;
-  uint64_t event_signal_value = 0;
-  iree_hal_streaming_event_acquire_recorded_point(event, &event_semaphore,
-                                                  &event_signal_value);
-  iree_hal_semaphore_t* wait_semaphore_storage[2];
-  uint64_t wait_value_storage[2];
-  iree_host_size_t wait_count = 0;
-  if (wait_value > 0) {
-    wait_semaphore_storage[wait_count] = stream->timeline_semaphore;
-    wait_value_storage[wait_count] = wait_value;
-    ++wait_count;
-  }
-  if (event_semaphore) {
-    wait_semaphore_storage[wait_count] = event_semaphore;
-    wait_value_storage[wait_count] = event_signal_value;
-    ++wait_count;
-  }
-  iree_hal_semaphore_list_t wait_semaphores = {
-      .count = wait_count,
-      .semaphores = wait_semaphore_storage,
-      .payload_values = wait_value_storage,
-  };
-  iree_hal_semaphore_list_t signal_semaphores = {
-      .count = 1,
-      .semaphores = &stream->timeline_semaphore,
-      .payload_values = &signal_value,
-  };
+  iree_hal_semaphore_release(recorded_point.semaphore);
 
-  status = iree_hal_device_queue_barrier(
-      stream->context->device, stream->queue_affinity, wait_semaphores,
-      signal_semaphores, IREE_HAL_EXECUTE_FLAG_NONE);
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_device_queue_flush(stream->context->device,
-                                         stream->queue_affinity);
-  }
-  if (iree_status_is_ok(status)) {
-    stream->pending_value = signal_value;
-    stream->submitted_value = signal_value;
-  }
-
-  iree_slim_mutex_unlock(&stream->mutex);
-  iree_hal_semaphore_release(event_semaphore);
-  if (!iree_status_is_ok(status) && added_memory_reuse_dependency) {
-    iree_hal_streaming_stream_remove_uncommitted_memory_reuse_dependency(
-        stream, source_stream_id);
+  // The reservation holds the dependency slot from before the submission so a
+  // concurrent reservation for the same source stream cannot displace it. It
+  // carries no value until the submission that establishes the ordering is
+  // accepted, and is withdrawn when that submission is not.
+  if (files_memory_reuse_dependency) {
+    if (iree_status_is_ok(status)) {
+      iree_hal_streaming_stream_record_memory_reuse_dependency(
+          stream, source_stream_id, source_timeline_value);
+    } else if (added_memory_reuse_dependency) {
+      iree_hal_streaming_stream_remove_uncommitted_memory_reuse_dependency(
+          stream, source_stream_id);
+    }
   }
   IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, status);
-  if (source_stream_id != 0 && source_stream_id != stream->stream_id &&
-      source_timeline_value != 0) {
-    iree_hal_streaming_stream_record_memory_reuse_dependency(
-        stream, source_stream_id, source_timeline_value);
-  }
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();

--- a/libhrx/src/binding/cuda/driver.c
+++ b/libhrx/src/binding/cuda/driver.c
@@ -1148,10 +1148,27 @@ CUDAAPI CUresult cuEventElapsedTime(float* pMilliseconds, CUevent hStart,
   if (!pMilliseconds) {
     return CUDA_ERROR_INVALID_VALUE;
   }
+  iree_hal_streaming_event_timing_t timing =
+      IREE_HAL_STREAMING_EVENT_TIMING_UNTIMED;
   iree_status_t status = iree_hal_streaming_event_elapsed_time(
       pMilliseconds, (iree_hal_streaming_event_t*)hStart,
-      (iree_hal_streaming_event_t*)hEnd);
-  CUresult result = iree_status_to_cu_result(status);
+      (iree_hal_streaming_event_t*)hEnd, &timing);
+  if (!iree_status_is_ok(status)) {
+    // The timeline a record names has failed; the event handles are fine.
+    return iree_status_to_cu_result(status);
+  }
+  CUresult result = CUDA_ERROR_INVALID_VALUE;
+  switch (timing) {
+    case IREE_HAL_STREAMING_EVENT_TIMING_MEASURED:
+      result = CUDA_SUCCESS;
+      break;
+    case IREE_HAL_STREAMING_EVENT_TIMING_INCOMPLETE:
+      result = CUDA_ERROR_NOT_READY;
+      break;
+    case IREE_HAL_STREAMING_EVENT_TIMING_UNTIMED:
+      result = CUDA_ERROR_INVALID_VALUE;
+      break;
+  }
   return result;
 }
 

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -11249,21 +11249,29 @@ HIPAPI hipError_t hipEventElapsedTime(float* ms, hipEvent_t start,
     HIP_RETURN_ERROR(hipErrorInvalidHandle);
   }
 
-  // Check if either event has timing disabled.
-  if ((start_event->flags & IREE_HAL_STREAMING_EVENT_FLAG_DISABLE_TIMING) ||
-      (stop_event->flags & IREE_HAL_STREAMING_EVENT_FLAG_DISABLE_TIMING)) {
-    HIP_RETURN_ERROR(hipErrorInvalidHandle);
+  iree_hal_streaming_event_timing_t timing =
+      IREE_HAL_STREAMING_EVENT_TIMING_UNTIMED;
+  iree_status_t status = iree_hal_streaming_event_elapsed_time(
+      ms, start_event, stop_event, &timing);
+  if (!iree_status_is_ok(status)) {
+    // The timeline a record names has failed; the event handles are fine.
+    return iree_status_to_hip_result(status);
   }
-
-  if (iree_hal_streaming_event_record_time_ns(start_event) == 0 ||
-      iree_hal_streaming_event_record_time_ns(stop_event) == 0) {
-    HIP_RETURN_ERROR(hipErrorInvalidHandle);
+  hipError_t result = hipErrorInvalidHandle;
+  switch (timing) {
+    case IREE_HAL_STREAMING_EVENT_TIMING_MEASURED:
+      result = hipSuccess;
+      break;
+    case IREE_HAL_STREAMING_EVENT_TIMING_INCOMPLETE:
+      result = hipErrorNotReady;
+      break;
+    case IREE_HAL_STREAMING_EVENT_TIMING_UNTIMED:
+      // An event with timing disabled or without a submitted record is a bad
+      // handle here, not a bad value.
+      result = hipErrorInvalidHandle;
+      break;
   }
-
-  iree_status_t status =
-      iree_hal_streaming_event_elapsed_time(ms, start_event, stop_event);
-  hipError_t result = iree_status_to_hip_result(status);
-  return result;
+  HIP_RETURN_ERROR(result);
 }
 
 //===----------------------------------------------------------------------===//

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -11255,7 +11255,8 @@ HIPAPI hipError_t hipEventElapsedTime(float* ms, hipEvent_t start,
     HIP_RETURN_ERROR(hipErrorInvalidHandle);
   }
 
-  if (start_event->record_time_ns == 0 || stop_event->record_time_ns == 0) {
+  if (iree_hal_streaming_event_record_time_ns(start_event) == 0 ||
+      iree_hal_streaming_event_record_time_ns(stop_event) == 0) {
     HIP_RETURN_ERROR(hipErrorInvalidHandle);
   }
 


### PR DESCRIPTION
An event no longer owns a timeline. A record names a point on the timeline of whichever submission carries it: the recording stream's own timeline for a stream record, and for a graph record node either the launching stream's timeline or one of the executable's internal partition semaphores. `iree_hal_streaming_recorded_point_t` in `libhrx/src/binding/common/internal.h` carries that point as one value: the semaphore, the value it reaches, and the stream timeline point reaching it is known to follow. The event retains the semaphore and swaps the whole struct under its own mutex. Readers copy the point and retain the semaphore before waiting, so no reader pairs one record's semaphore with another record's value and no re-record frees a timeline a waiter still names.

That last part is the ordering claim `hipStreamWaitEvent` files in the waiting stream's memory reuse ledger: exact for a stream record and for a record ending a launch, and a lower bound (the stream tail the launch waited behind) for a record internal to a launch. Every remaining gap errs one way: a missing or understated claim withholds an allocation from reuse and can never grant it.

## Motivation

The event's private semaphore was driven by values read off other timelines, so re-recording an event on a stream whose timeline sat behind it targeted a value already passed. `hipEventQuery` reported the new record complete before its work had run, `hipEventSynchronize` returned immediately, and a `hipStreamWaitEvent` on it was satisfied at submission, a cross-stream dependency dropped with no error anywhere. The reuse ledger filed that same counter paired with whichever stream last recorded the event, so a graph record could hand a waiting stream an allocation the producer was still using.

Repairs in the same paths: one helper reserves stream timeline values and owns the overflow check; a stream event wait also waits on the stream's own tail; a graph executable's resource set solely owns its internal semaphores, fixing a leak and keeping a record queryable after the executable is gone; semaphore bases advance past a block that failed to submit, which used to re-signal values and fail the executable permanently; stream query and synchronize propagate a failed timeline rather than reading it as incomplete.

## Tests

`libhrx/cts/tests/hip/event_test.cpp` drives the built `amdhip64` shim through public HIP entry points only. A host callback parks a stream until the test releases it, so a test can observe an event while its record is provably outstanding: the cross-stream re-record case requires `hipErrorNotReady` where the old counter read complete, and six reuse cases pin the grant and deny sides in pairs differing by one call, so neither blanket policy survives. A record that chains streams back together shows up as a hang, not a failed assertion. The concurrency case is a manual race-detector probe: unaided it pins only that every call succeeds and every stream drains.

Worth a close read: the claim in `graph_exec.c` that a record block's first signal value is the point the record names, and the lock order, with the event mutex innermost.
