### PR TITLE
[Loom] Preserve source reads during vector scalarization

### DIFF
--- a/loom/src/loom/analysis/motion.c
+++ b/loom/src/loom/analysis/motion.c
@@ -140,6 +140,24 @@ bool loom_motion_op_can_relocate_effect_free(const loom_module_t* module,
   return !loom_motion_op_has_retained_regions(module, op);
 }
 
+bool loom_motion_op_can_rematerialize_effect_free(const loom_module_t* module,
+                                                  const loom_op_t* op) {
+  if (!module || !op || iree_any_bit_set(op->flags, LOOM_OP_FLAG_DEAD) ||
+      op->tied_result_count != 0 || op->region_count != 0) {
+    return false;
+  }
+  const loom_trait_flags_t traits = loom_op_effective_traits(module, op);
+  if (!iree_any_bit_set(traits, LOOM_TRAIT_PURE) ||
+      loom_traits_may_read(traits) || loom_traits_may_write(traits) ||
+      iree_any_bit_set(traits, LOOM_TRAIT_TERMINATOR | LOOM_TRAIT_HINT |
+                                   LOOM_TRAIT_POISON_BOUNDARY |
+                                   LOOM_TRAIT_CONVERGENT |
+                                   LOOM_TRAIT_UNIQUE_IDENTITY)) {
+    return false;
+  }
+  return true;
+}
+
 bool loom_motion_op_can_speculate(const loom_module_t* module,
                                   const loom_op_t* op) {
   if (!module || !op || iree_any_bit_set(op->flags, LOOM_OP_FLAG_DEAD)) {
@@ -151,6 +169,19 @@ bool loom_motion_op_can_speculate(const loom_module_t* module,
     return false;
   }
   return !loom_motion_op_has_retained_regions(module, op);
+}
+
+bool loom_motion_read_can_cross_op(const loom_module_t* module,
+                                   const loom_op_t* op) {
+  if (!module || !op) return false;
+  if (iree_any_bit_set(op->flags, LOOM_OP_FLAG_DEAD)) return true;
+  if (op->region_count != 0) return false;
+  const loom_trait_flags_t traits = loom_op_effective_traits(module, op);
+  if (loom_traits_may_write(traits)) return false;
+  return !iree_any_bit_set(
+      traits, LOOM_TRAIT_NON_DETERMINISTIC | LOOM_TRAIT_HINT |
+                  LOOM_TRAIT_POISON_BOUNDARY | LOOM_TRAIT_CONVERGENT |
+                  LOOM_TRAIT_UNIQUE_IDENTITY);
 }
 
 //===----------------------------------------------------------------------===//
@@ -321,8 +352,8 @@ static iree_status_t loom_motion_evaluate_speculative_subtree(
   return iree_ok_status();
 }
 
-static bool loom_motion_op_is_ordinary_load_candidate(
-    const loom_module_t* module, const loom_op_t* op) {
+bool loom_motion_op_is_ordinary_load(const loom_module_t* module,
+                                     const loom_op_t* op) {
   if (!module || !op || iree_any_bit_set(op->flags, LOOM_OP_FLAG_DEAD) ||
       op->region_count != 0 || op->tied_result_count != 0) {
     return false;
@@ -500,8 +531,7 @@ iree_status_t loom_motion_subtree_evaluate_hoist_before_loop(
     return iree_ok_status();
   }
 
-  if (!loom_motion_op_is_ordinary_load_candidate(analysis->module,
-                                                 candidate_op)) {
+  if (!loom_motion_op_is_ordinary_load(analysis->module, candidate_op)) {
     return loom_motion_evaluate_speculative_subtree(analysis, candidate_op,
                                                     loop.op, out_result);
   }

--- a/loom/src/loom/analysis/motion.h
+++ b/loom/src/loom/analysis/motion.h
@@ -151,11 +151,32 @@ bool loom_motion_op_can_erase(const loom_module_t* module, const loom_op_t* op);
 bool loom_motion_op_can_relocate_effect_free(const loom_module_t* module,
                                              const loom_op_t* op);
 
+// Returns true if |op| may be rebuilt independently while preserving or
+// narrowing its original dynamic execution predicate. This requires pure,
+// deterministic, identity-free semantics and rejects retained regions,
+// terminators, hints, poison boundaries, and convergence. It does not require
+// SAFE_TO_SPECULATE because rematerialization must not introduce execution on
+// an additional control path.
+bool loom_motion_op_can_rematerialize_effect_free(const loom_module_t* module,
+                                                  const loom_op_t* op);
+
 // Returns true if |op| may be executed on additional control paths. This
 // requires SAFE_TO_SPECULATE and rejects any region side effects, convergence,
 // or hints.
 bool loom_motion_op_can_speculate(const loom_module_t* module,
                                   const loom_op_t* op);
+
+// Returns true when |op| is an ordinary unmasked view or vector load with no
+// write, ordering, convergence, identity, or nondeterministic semantics.
+bool loom_motion_op_is_ordinary_load(const loom_module_t* module,
+                                     const loom_op_t* op);
+
+// Returns true when sinking an ordinary load across |op| preserves source
+// ordering. This is a deliberately alias-independent predicate: any write,
+// fence, unknown effect, nested region, convergence, or retained semantic
+// boundary blocks motion.
+bool loom_motion_read_can_cross_op(const loom_module_t* module,
+                                   const loom_op_t* op);
 
 //===----------------------------------------------------------------------===//
 // Subtree motion

--- a/loom/src/loom/analysis/motion_test.cc
+++ b/loom/src/loom/analysis/motion_test.cc
@@ -158,6 +158,17 @@ TEST_F(MotionTest, LocalClassificationSeparatesEraseRelocateAndSpeculate) {
   IREE_ASSERT_OK(loom_test_convergent_build(
       &builder_, lhs, i32_type, LOOM_LOCATION_UNKNOWN, &convergent_op));
 
+  loom_op_t* size_op = nullptr;
+  loom_type_t index_type = loom_type_scalar(LOOM_SCALAR_TYPE_INDEX);
+  IREE_ASSERT_OK(loom_test_constant_build(&builder_, loom_attr_i64(4096),
+                                          index_type, LOOM_LOCATION_UNKNOWN,
+                                          &size_op));
+  loom_op_t* alloc_op = nullptr;
+  IREE_ASSERT_OK(
+      loom_test_alloc_build(&builder_, loom_test_constant_result(size_op),
+                            loom_type_pool(loom_dim_pack_static(4096)),
+                            LOOM_LOCATION_UNKNOWN, &alloc_op));
+
   loom_op_t* source_op = nullptr;
   IREE_ASSERT_OK(loom_test_constant_build(&builder_, loom_attr_i64(1),
                                           tile_type, LOOM_LOCATION_UNKNOWN,
@@ -196,9 +207,17 @@ TEST_F(MotionTest, LocalClassificationSeparatesEraseRelocateAndSpeculate) {
   EXPECT_FALSE(loom_motion_op_can_relocate_effect_free(module_, use_op));
   EXPECT_FALSE(loom_motion_op_can_relocate_effect_free(module_, convergent_op));
   EXPECT_FALSE(loom_motion_op_can_relocate_effect_free(module_, update_op));
+  EXPECT_TRUE(loom_motion_op_can_rematerialize_effect_free(module_, add_op));
+  EXPECT_FALSE(
+      loom_motion_op_can_rematerialize_effect_free(module_, convergent_op));
+  EXPECT_FALSE(loom_motion_op_can_rematerialize_effect_free(module_, alloc_op));
   EXPECT_FALSE(loom_motion_op_can_speculate(module_, add_op));
   EXPECT_FALSE(loom_motion_op_can_speculate(module_, convergent_op));
   EXPECT_TRUE(loom_motion_op_can_speculate(module_, select_op));
+  EXPECT_TRUE(loom_motion_read_can_cross_op(module_, add_op));
+  EXPECT_FALSE(loom_motion_read_can_cross_op(module_, use_op));
+  EXPECT_FALSE(loom_motion_read_can_cross_op(module_, convergent_op));
+  EXPECT_TRUE(loom_motion_read_can_cross_op(module_, update_op));
 }
 
 TEST_F(MotionTest, SubtreeAllowsOperandsAvailableBeforeInsertion) {

--- a/loom/src/loom/transforms/vector/BUILD.bazel
+++ b/loom/src/loom/transforms/vector/BUILD.bazel
@@ -56,6 +56,7 @@ loom_cc_library(
     srcs = ["sink_single_use_reads.c"],
     hdrs = ["sink_single_use_reads.h"],
     deps = [
+        "//loom/src/loom/analysis:motion",
         "//loom/src/loom/ir",
         "//loom/src/loom/ops:op_defs",
         "//loom/src/loom/pass:types",
@@ -99,6 +100,7 @@ loom_cc_library(
     deps = [
         "//loom/src/loom/analysis:contract",
         "//loom/src/loom/analysis:matrix_fragment_layout",
+        "//loom/src/loom/analysis:motion",
         "//loom/src/loom/error:error_defs",
         "//loom/src/loom/ir",
         "//loom/src/loom/ops:combining",

--- a/loom/src/loom/transforms/vector/CMakeLists.txt
+++ b/loom/src/loom/transforms/vector/CMakeLists.txt
@@ -59,6 +59,7 @@ loom_cc_library(
     "sink_single_use_reads.c"
   DEPS
     iree::base
+    loom::analysis::motion
     loom::ir
     loom::ops::op_defs
     loom::pass::types
@@ -104,6 +105,7 @@ loom_cc_library(
     iree::base::internal
     loom::analysis::contract
     loom::analysis::matrix_fragment_layout
+    loom::analysis::motion
     loom::error::error_defs
     loom::ir
     loom::ops::combining

--- a/loom/src/loom/transforms/vector/sink_single_use_reads.c
+++ b/loom/src/loom/transforms/vector/sink_single_use_reads.c
@@ -6,6 +6,7 @@
 
 #include "loom/transforms/vector/sink_single_use_reads.h"
 
+#include "loom/analysis/motion.h"
 #include "loom/ir/module.h"
 #include "loom/ops/op_defs.h"
 #include "loom/rewrite/rewriter.h"
@@ -186,22 +187,6 @@ static bool loom_sink_single_use_reads_is_read_candidate(
   return loom_value_has_single_use(loom_module_value(context->module, result));
 }
 
-static bool loom_sink_single_use_reads_can_cross(
-    const loom_sink_single_use_reads_context_t* context, loom_op_t* op) {
-  if (op->flags & LOOM_OP_FLAG_DEAD) return true;
-  if (op->region_count != 0) return false;
-  const loom_trait_flags_t traits =
-      loom_op_effective_traits(context->module, op);
-  if (loom_traits_may_write(traits)) return false;
-  if (iree_any_bit_set(traits, LOOM_TRAIT_NON_DETERMINISTIC | LOOM_TRAIT_HINT |
-                                   LOOM_TRAIT_POISON_BOUNDARY |
-                                   LOOM_TRAIT_CONVERGENT |
-                                   LOOM_TRAIT_UNIQUE_IDENTITY)) {
-    return false;
-  }
-  return !iree_any_bit_set(traits, LOOM_TRAIT_UNKNOWN_EFFECTS);
-}
-
 static bool loom_sink_single_use_reads_find_same_block_user(
     const loom_sink_single_use_reads_context_t* context, loom_op_t* op,
     loom_op_t** out_user_op) {
@@ -300,7 +285,7 @@ static iree_status_t loom_sink_single_use_reads_collect_block(
     context->ops[index] = op;
     context->segments[index] = segment;
     ++index;
-    if (!loom_sink_single_use_reads_can_cross(context, op)) {
+    if (!loom_motion_read_can_cross_op(context->module, op)) {
       ++segment;
     }
   }

--- a/loom/src/loom/transforms/vector/test/memory_to_scalar.loom-test
+++ b/loom/src/loom/transforms/vector/test/memory_to_scalar.loom-test
@@ -195,3 +195,82 @@ func.def @atomic_memory_stays_vector(%buffer: buffer, %origin: index, %offsets: 
   %old = vector.atomic.rmw<addi> %value, %view[%origin][%offsets] {ordering = relaxed, scope = workgroup} : vector<2xi32>, view<32xi32, #dense>, vector<2xindex>
   func.return %old : vector<2xi32>
 }
+
+// ====
+
+func.def @masked_store_rematerializes_ordinary_read(%input: buffer, %output: buffer, %origin: index, %mask: vector<2xi1>) {
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<32xf16, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<32xf32, #dense>
+  %loaded = vector.load %input_view[%origin] : view<32xf16, #dense> -> vector<2xf16>
+  %wide = vector.extf %loaded : vector<2xf16> to vector<2xf32>
+  vector.store.mask %wide, %output_view[%origin], %mask : vector<2xf32>, view<32xf32, #dense>, vector<2xi1>
+  func.return
+}
+
+// ----
+func.def @masked_store_rematerializes_ordinary_read(%input: buffer, %output: buffer, %origin: index, %mask: vector<2xi1>) {
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<32xf16, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<32xf32, #dense>
+  %9 = vector.extract %mask[0] : vector<2xi1> -> i1
+  scf.if %9 {
+    %10 = view.load %input_view[%origin] : view<32xf16, #dense> -> f16
+    %11 = scalar.extf %10 : f16 to f32
+    view.store %11, %output_view[%origin] : f32, view<32xf32, #dense>
+  } else {
+  }
+  %12 = vector.extract %mask[1] : vector<2xi1> -> i1
+  scf.if %12 {
+    %13 = index.constant 1 : index
+    %14 = index.add %origin, %13 : index
+    %15 = view.load %input_view[%14] : view<32xf16, #dense> -> f16
+    %16 = scalar.extf %15 : f16 to f32
+    view.store %16, %output_view[%14] : f32, view<32xf32, #dense>
+  } else {
+  }
+  func.return
+}
+
+// ====
+
+func.def @masked_store_preserves_effecting_producer_position(%storage: buffer, %output: buffer, %origin: index, %mask: vector<2xi1>, %replacement: vector<2xf16>) {
+  %base = index.constant 0 : offset
+  %storage_view = buffer.view %storage[%base] : buffer -> view<32xf16, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<32xf32, #dense>
+  %loaded = vector.load %storage_view[%origin] : view<32xf16, #dense> -> vector<2xf16>
+  %wide = vector.extf %loaded : vector<2xf16> to vector<2xf32>
+  kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
+  vector.store %replacement, %storage_view[%origin] : vector<2xf16>, view<32xf16, #dense>
+  kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
+  vector.store.mask %wide, %output_view[%origin], %mask : vector<2xf32>, view<32xf32, #dense>, vector<2xi1>
+  func.return
+}
+
+// ----
+func.def @masked_store_preserves_effecting_producer_position(%storage: buffer, %output: buffer, %origin: index, %mask: vector<2xi1>, %replacement: vector<2xf16>) {
+  %base = index.constant 0 : offset
+  %storage_view = buffer.view %storage[%base] : buffer -> view<32xf16, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<32xf32, #dense>
+  %loaded = vector.load %storage_view[%origin] : view<32xf16, #dense> -> vector<2xf16>
+  kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
+  vector.store %replacement, %storage_view[%origin] : vector<2xf16>, view<32xf16, #dense>
+  kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
+  %10 = vector.extract %mask[0] : vector<2xi1> -> i1
+  scf.if %10 {
+    %11 = vector.extract %loaded[0] : vector<2xf16> -> f16
+    %12 = scalar.extf %11 : f16 to f32
+    view.store %12, %output_view[%origin] : f32, view<32xf32, #dense>
+  } else {
+  }
+  %13 = vector.extract %mask[1] : vector<2xi1> -> i1
+  scf.if %13 {
+    %14 = vector.extract %loaded[1] : vector<2xf16> -> f16
+    %15 = scalar.extf %14 : f16 to f32
+    %16 = index.constant 1 : index
+    %17 = index.add %origin, %16 : index
+    view.store %15, %output_view[%17] : f32, view<32xf32, #dense>
+  } else {
+  }
+  func.return
+}

--- a/loom/src/loom/transforms/vector/to_scalar.c
+++ b/loom/src/loom/transforms/vector/to_scalar.c
@@ -128,7 +128,7 @@ static iree_status_t loom_vector_to_scalar_prepare_state(
       .result_scalar_type = loom_vector_to_scalar_lane_type(result_type),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(out_state, pass);
+  loom_vector_to_scalar_state_initialize(out_state, pass);
   return iree_ok_status();
 }
 
@@ -191,7 +191,7 @@ static iree_status_t loom_vector_to_scalar_lower_memory_store_op(
       .result_scalar_type = loom_vector_to_scalar_lane_type(vector_type),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   IREE_RETURN_IF_ERROR(loom_vector_to_scalar_lower_memory_store(&state));
   if (loom_pass_has_error_diagnostics(pass)) return iree_ok_status();
   return loom_vector_to_scalar_erase_lowered_op(&state);
@@ -212,7 +212,7 @@ static iree_status_t loom_vector_to_scalar_lower_fragment_store_op(
       .result_scalar_type = loom_vector_to_scalar_lane_type(vector_type),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   IREE_RETURN_IF_ERROR(
       loom_vector_to_scalar_lower_fragment_store(&state, out_handled));
   if (!*out_handled || loom_pass_has_error_diagnostics(pass)) {
@@ -236,7 +236,7 @@ static iree_status_t loom_vector_to_scalar_lower_store_compress_op(
       .result_scalar_type = loom_vector_to_scalar_lane_type(vector_type),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   IREE_RETURN_IF_ERROR(
       loom_vector_to_scalar_lower_memory_store_compress(&state));
   if (loom_pass_has_error_diagnostics(pass)) return iree_ok_status();
@@ -259,7 +259,7 @@ static iree_status_t loom_vector_to_scalar_lower_atomic_reduce_op(
       .result_scalar_type = loom_vector_to_scalar_lane_type(vector_type),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   IREE_RETURN_IF_ERROR(
       loom_vector_to_scalar_lower_memory_atomic_reduce(&state));
   if (loom_pass_has_error_diagnostics(pass)) return iree_ok_status();
@@ -281,7 +281,7 @@ static iree_status_t loom_vector_to_scalar_lower_atomic_rmw_op(
       .result_scalar_type = loom_vector_to_scalar_lane_type(vector_type),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   loom_value_id_t replacement = LOOM_VALUE_ID_INVALID;
   IREE_RETURN_IF_ERROR(
       loom_vector_to_scalar_lower_memory_atomic_rmw(&state, &replacement));
@@ -304,7 +304,7 @@ static iree_status_t loom_vector_to_scalar_lower_atomic_cmpxchg_op(
       .result_scalar_type = loom_vector_to_scalar_lane_type(vector_type),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   loom_value_id_t replacement = LOOM_VALUE_ID_INVALID;
   IREE_RETURN_IF_ERROR(
       loom_vector_to_scalar_lower_memory_atomic_cmpxchg(&state, &replacement));
@@ -337,7 +337,7 @@ static iree_status_t loom_vector_to_scalar_lower_scalar_extract(
       .result_scalar_type = result_type,
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   loom_value_id_t replacement = LOOM_VALUE_ID_INVALID;
   loom_vector_to_scalar_index_term_t* explicit_terms = NULL;
   uint8_t explicit_count = 0;
@@ -374,7 +374,7 @@ static iree_status_t loom_vector_to_scalar_lower_static_constant(
       .result_scalar_type = loom_vector_to_scalar_lane_type(result_type),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
 
   uint16_t element_count = 0;
   IREE_RETURN_IF_ERROR(loom_vector_to_scalar_static_element_count(
@@ -416,7 +416,7 @@ static iree_status_t loom_vector_to_scalar_lower_static_poison(
       .result_scalar_type = loom_vector_to_scalar_lane_type(result_type),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
 
   uint16_t element_count = 0;
   IREE_RETURN_IF_ERROR(loom_vector_to_scalar_static_element_count(
@@ -460,7 +460,6 @@ static iree_status_t loom_vector_to_scalar_lower_deinterleave(
         pass, rewriter, op, &descriptor, i, &state));
     if (i == 0) {
       first_state = state;
-      loom_vector_to_scalar_state_bind_statistics(&first_state, pass);
     }
     IREE_RETURN_IF_ERROR(
         loom_vector_to_scalar_lower_aggregate(&state, &replacements[i]));
@@ -515,7 +514,7 @@ static iree_status_t loom_vector_to_scalar_lower_reduce_op(
           loom_module_value_type(rewriter->module, loom_vector_reduce_init(op)),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   loom_value_id_t replacement = LOOM_VALUE_ID_INVALID;
   IREE_RETURN_IF_ERROR(
       loom_vector_to_scalar_lower_reduce(&state, &replacement));
@@ -543,7 +542,7 @@ static iree_status_t loom_vector_to_scalar_lower_reduce_axes_op(
                                 : result_type,
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   loom_value_id_t replacement = LOOM_VALUE_ID_INVALID;
   IREE_RETURN_IF_ERROR(
       loom_vector_to_scalar_lower_reduce_axes(&state, &replacement));
@@ -566,7 +565,7 @@ static iree_status_t loom_vector_to_scalar_lower_dotf_op(
           loom_module_value_type(rewriter->module, loom_vector_dotf_init(op)),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   loom_value_id_t replacement = LOOM_VALUE_ID_INVALID;
   IREE_RETURN_IF_ERROR(loom_vector_to_scalar_lower_dotf(&state, &replacement));
   if (loom_pass_has_error_diagnostics(pass)) return iree_ok_status();
@@ -588,7 +587,7 @@ static iree_status_t loom_vector_to_scalar_lower_mma_op(
           loom_module_value_type(rewriter->module, loom_vector_mma_result(op))),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   loom_value_id_t replacement = LOOM_VALUE_ID_INVALID;
   IREE_RETURN_IF_ERROR(
       loom_vector_to_scalar_lower_mma(&state, out_handled, &replacement));
@@ -752,7 +751,7 @@ iree_status_t loom_vector_reduce_to_scalar_rewrite_op(loom_pass_t* pass,
           loom_module_value_type(rewriter->module, loom_vector_reduce_init(op)),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   loom_value_id_t replacement = LOOM_VALUE_ID_INVALID;
   IREE_RETURN_IF_ERROR(
       loom_vector_to_scalar_lower_reduce(&state, &replacement));
@@ -791,7 +790,7 @@ iree_status_t loom_vector_reduce_axes_to_scalar_rewrite_op(
                                 : result_type,
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   loom_value_id_t replacement = LOOM_VALUE_ID_INVALID;
   IREE_RETURN_IF_ERROR(
       loom_vector_to_scalar_lower_reduce_axes(&state, &replacement));
@@ -877,7 +876,7 @@ uint32_t loom_vector_decode_to_scalar_reference_rejection_bits(
       .result_scalar_type = loom_vector_to_scalar_lane_type(result_type),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   return loom_vector_to_scalar_decode_rejection_bits(&state);
 }
 
@@ -902,7 +901,7 @@ iree_status_t loom_vector_mma_to_scalar_rewrite_op(
       .matrix_fragment_layout = options.matrix_fragment_layout,
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   loom_value_id_t replacement = LOOM_VALUE_ID_INVALID;
   IREE_RETURN_IF_ERROR(
       loom_vector_to_scalar_lower_mma(&state, out_rewritten, &replacement));
@@ -934,7 +933,7 @@ uint32_t loom_vector_mma_to_scalar_reference_rejection_bits(
       .matrix_fragment_layout = options.matrix_fragment_layout,
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   return loom_vector_to_scalar_mma_reference_rejection_bits(&state);
 }
 
@@ -956,7 +955,7 @@ uint32_t loom_vector_mma_to_scalar_reference_rejection_detail(
       .matrix_fragment_layout = options.matrix_fragment_layout,
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   return loom_vector_to_scalar_mma_reference_rejection_detail(&state);
 }
 
@@ -1010,7 +1009,7 @@ uint32_t loom_vector_fragment_store_to_scalar_reference_rejection_bits(
       .result_scalar_type = loom_vector_to_scalar_lane_type(vector_type),
       .location = op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
   return loom_vector_to_scalar_fragment_store_reference_rejection_bits(&state);
 }
 

--- a/loom/src/loom/transforms/vector/to_scalar_core.h
+++ b/loom/src/loom/transforms/vector/to_scalar_core.h
@@ -47,6 +47,8 @@ loom_vector_to_scalar_statistics_if_available(loom_pass_t* pass) {
 
 typedef struct loom_vector_to_scalar_lane_cache_entry_t
     loom_vector_to_scalar_lane_cache_entry_t;
+typedef struct loom_vector_to_scalar_rematerialization_context_t
+    loom_vector_to_scalar_rematerialization_context_t;
 
 typedef struct loom_vector_to_scalar_state_t {
   // Current pass instance owning statistics and transient arena state.
@@ -76,16 +78,21 @@ typedef struct loom_vector_to_scalar_state_t {
   const loom_matrix_fragment_layout_t* matrix_fragment_layout;
   // Cached static lane materializations owned by the rewriter arena.
   loom_vector_to_scalar_lane_cache_entry_t* lane_cache;
+  // Last source operation before op, captured before replacement IR is built.
+  const loom_op_t* source_predecessor_op;
+  // Source-position legality cache shared by recursively decomposed producers.
+  loom_vector_to_scalar_rematerialization_context_t* rematerialization;
   // Source location assigned to replacement ops.
   loom_location_id_t location;
 } loom_vector_to_scalar_state_t;
 
-static inline void loom_vector_to_scalar_state_bind_statistics(
+static inline void loom_vector_to_scalar_state_initialize(
     loom_vector_to_scalar_state_t* state, loom_pass_t* pass) {
   state->statistics = loom_vector_to_scalar_statistics_if_available(pass);
   if (!state->statistics) {
     state->statistics = &state->discarded_statistics;
   }
+  state->source_predecessor_op = state->op ? state->op->prev_op : NULL;
 }
 
 static inline void loom_vector_to_scalar_record_ops_lowered(

--- a/loom/src/loom/transforms/vector/to_scalar_lanes.c
+++ b/loom/src/loom/transforms/vector/to_scalar_lanes.c
@@ -7,6 +7,7 @@
 #include "loom/transforms/vector/to_scalar_lanes.h"
 
 #include "loom/analysis/contract.h"
+#include "loom/analysis/motion.h"
 #include "loom/ir/module.h"
 #include "loom/ir/scalar_type.h"
 #include "loom/ops/index/ops.h"
@@ -36,6 +37,24 @@ struct loom_vector_to_scalar_lane_cache_entry_t {
   loom_value_id_t lane;
   // Next entry in the state-local arena-owned cache.
   struct loom_vector_to_scalar_lane_cache_entry_t* next;
+};
+
+typedef struct loom_vector_to_scalar_rematerialization_entry_t {
+  // Read producer whose source-position legality was classified.
+  const loom_op_t* read_op;
+  // True when the read may be rebuilt at the root consumer.
+  bool can_rematerialize;
+  // Next arena-owned entry in the root-local cache.
+  struct loom_vector_to_scalar_rematerialization_entry_t* next;
+} loom_vector_to_scalar_rematerialization_entry_t;
+
+struct loom_vector_to_scalar_rematerialization_context_t {
+  // Original source consumer being replaced by scalar lane programs.
+  const loom_op_t* consumer_op;
+  // Last original source op before consumer_op.
+  const loom_op_t* source_predecessor_op;
+  // Cached legality results keyed by distinct read producer.
+  loom_vector_to_scalar_rematerialization_entry_t* entries;
 };
 
 bool loom_vector_to_scalar_indices_are_dynamic(
@@ -785,6 +804,86 @@ bool loom_vector_to_scalar_can_materialize_def_lane(
   }
 }
 
+static bool loom_vector_to_scalar_read_can_rematerialize_through(
+    const loom_module_t* module, const loom_op_t* read_op,
+    const loom_op_t* consumer_op, const loom_op_t* source_predecessor_op) {
+  if (!loom_motion_op_is_ordinary_load(module, read_op) || !consumer_op ||
+      read_op->parent_block != consumer_op->parent_block ||
+      !source_predecessor_op ||
+      source_predecessor_op->parent_block != consumer_op->parent_block ||
+      read_op->block_ordinal > source_predecessor_op->block_ordinal) {
+    return false;
+  }
+  if (read_op == source_predecessor_op) return true;
+  const loom_op_t* crossed_op = read_op->next_op;
+  while (crossed_op && crossed_op != consumer_op) {
+    if (!loom_motion_read_can_cross_op(module, crossed_op)) return false;
+    if (crossed_op == source_predecessor_op) return true;
+    crossed_op = crossed_op->next_op;
+  }
+  return false;
+}
+
+bool loom_vector_to_scalar_read_can_rematerialize_at(
+    const loom_module_t* module, const loom_op_t* read_op,
+    const loom_op_t* consumer_op) {
+  return loom_vector_to_scalar_read_can_rematerialize_through(
+      module, read_op, consumer_op, consumer_op ? consumer_op->prev_op : NULL);
+}
+
+static iree_status_t loom_vector_to_scalar_rematerialization_initialize(
+    loom_vector_to_scalar_state_t* state) {
+  if (state->rematerialization) return iree_ok_status();
+  loom_vector_to_scalar_rematerialization_context_t* context = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate(state->rewriter->arena,
+                                           sizeof(*context), (void**)&context));
+  *context = (loom_vector_to_scalar_rematerialization_context_t){
+      .consumer_op = state->op,
+      .source_predecessor_op = state->source_predecessor_op,
+  };
+  state->rematerialization = context;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_vector_to_scalar_can_rematerialize_def_at_use(
+    loom_vector_to_scalar_state_t* state, const loom_op_t* def_op,
+    bool* out_can_rematerialize) {
+  *out_can_rematerialize = false;
+  if (loom_motion_op_can_rematerialize_effect_free(state->rewriter->module,
+                                                   def_op)) {
+    *out_can_rematerialize = true;
+    return iree_ok_status();
+  }
+  if (!loom_motion_op_is_ordinary_load(state->rewriter->module, def_op)) {
+    return iree_ok_status();
+  }
+
+  loom_vector_to_scalar_rematerialization_context_t* context =
+      state->rematerialization;
+  for (const loom_vector_to_scalar_rematerialization_entry_t* entry =
+           context->entries;
+       entry; entry = entry->next) {
+    if (entry->read_op == def_op) {
+      *out_can_rematerialize = entry->can_rematerialize;
+      return iree_ok_status();
+    }
+  }
+
+  loom_vector_to_scalar_rematerialization_entry_t* entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate(state->rewriter->arena,
+                                           sizeof(*entry), (void**)&entry));
+  *entry = (loom_vector_to_scalar_rematerialization_entry_t){
+      .read_op = def_op,
+      .can_rematerialize = loom_vector_to_scalar_read_can_rematerialize_through(
+          state->rewriter->module, def_op, context->consumer_op,
+          context->source_predecessor_op),
+      .next = context->entries,
+  };
+  context->entries = entry;
+  *out_can_rematerialize = entry->can_rematerialize;
+  return iree_ok_status();
+}
+
 static bool loom_vector_to_scalar_try_from_elements_lane(
     loom_op_t* def_op, loom_type_t vector_type,
     loom_vector_to_scalar_index_list_t indices, loom_value_id_t* out_lane) {
@@ -823,6 +922,7 @@ loom_vector_to_scalar_try_physical_result_fragment_load_lane(
       .vector_type = vector_type,
       .result_scalar_type = loom_vector_to_scalar_lane_type(vector_type),
       .matrix_fragment_layout = state->matrix_fragment_layout,
+      .rematerialization = state->rematerialization,
       .location = def_op->location,
   };
 
@@ -857,6 +957,8 @@ iree_status_t loom_vector_to_scalar_try_materialize_def_lane(
     loom_type_t vector_type, loom_vector_to_scalar_index_list_t indices,
     bool* out_materialized, loom_value_id_t* out_lane) {
   *out_materialized = false;
+  IREE_RETURN_IF_ERROR(
+      loom_vector_to_scalar_rematerialization_initialize(state));
   loom_op_t* def_op =
       loom_vector_to_scalar_value_def_op(state->rewriter->module, value);
   if (!def_op) {
@@ -870,6 +972,12 @@ iree_status_t loom_vector_to_scalar_try_materialize_def_lane(
     return loom_vector_to_scalar_try_materialize_def_lane(
         state, loom_op_const_operands(def_op)[0], vector_type, indices,
         out_materialized, out_lane);
+  }
+  bool can_rematerialize = false;
+  IREE_RETURN_IF_ERROR(loom_vector_to_scalar_can_rematerialize_def_at_use(
+      state, def_op, &can_rematerialize));
+  if (!can_rematerialize) {
+    return iree_ok_status();
   }
   if (loom_vector_to_scalar_try_from_elements_lane(def_op, vector_type, indices,
                                                    out_lane)) {
@@ -891,6 +999,7 @@ iree_status_t loom_vector_to_scalar_try_materialize_def_lane(
         .vector_type = vector_type,
         .result_scalar_type = loom_vector_to_scalar_lane_type(vector_type),
         .matrix_fragment_layout = state->matrix_fragment_layout,
+        .rematerialization = state->rematerialization,
         .location = def_op->location,
     };
     IREE_RETURN_IF_ERROR(
@@ -908,6 +1017,7 @@ iree_status_t loom_vector_to_scalar_try_materialize_def_lane(
         .vector_type = vector_type,
         .result_scalar_type = loom_vector_to_scalar_lane_type(vector_type),
         .matrix_fragment_layout = state->matrix_fragment_layout,
+        .rematerialization = state->rematerialization,
         .location = def_op->location,
     };
     IREE_RETURN_IF_ERROR(
@@ -936,6 +1046,7 @@ iree_status_t loom_vector_to_scalar_try_materialize_def_lane(
         .vector_type = vector_type,
         .result_scalar_type = loom_vector_to_scalar_lane_type(vector_type),
         .matrix_fragment_layout = state->matrix_fragment_layout,
+        .rematerialization = state->rematerialization,
         .location = def_op->location,
     };
     IREE_RETURN_IF_ERROR(
@@ -968,6 +1079,7 @@ iree_status_t loom_vector_to_scalar_try_materialize_def_lane(
       .vector_type = result_type,
       .result_scalar_type = loom_vector_to_scalar_lane_type(result_type),
       .matrix_fragment_layout = state->matrix_fragment_layout,
+      .rematerialization = state->rematerialization,
       .location = def_op->location,
   };
   if (descriptor.lane_kind == LOOM_VECTOR_TO_SCALAR_LANE_DECODE &&

--- a/loom/src/loom/transforms/vector/to_scalar_lanes.h
+++ b/loom/src/loom/transforms/vector/to_scalar_lanes.h
@@ -120,6 +120,12 @@ bool loom_vector_to_scalar_can_materialize_def_lane(
     const loom_matrix_fragment_layout_t* matrix_fragment_layout,
     loom_vector_to_scalar_index_list_t indices);
 
+// Returns true when scalar lanes of |read_op| may be rebuilt immediately
+// before |consumer_op| without crossing a source ordering boundary.
+bool loom_vector_to_scalar_read_can_rematerialize_at(
+    const loom_module_t* module, const loom_op_t* read_op,
+    const loom_op_t* consumer_op);
+
 iree_status_t loom_vector_to_scalar_materialize_linear_lane(
     loom_vector_to_scalar_state_t* state, loom_value_id_t vector_value,
     loom_type_t vector_type, loom_vector_to_scalar_index_term_t ordinal,

--- a/loom/src/loom/transforms/vector/to_scalar_memory.c
+++ b/loom/src/loom/transforms/vector/to_scalar_memory.c
@@ -725,8 +725,12 @@ static bool loom_vector_to_scalar_fragment_store_source_is_supported(
     return loom_vector_to_scalar_fragment_store_source_is_supported(
         state, loom_op_const_operands(def_op)[0]);
   }
-  if (loom_vector_fragment_load_isa(def_op) || loom_vector_splat_isa(def_op) ||
-      loom_vector_constant_isa(def_op) || loom_vector_poison_isa(def_op)) {
+  if (loom_vector_fragment_load_isa(def_op)) {
+    return loom_vector_to_scalar_read_can_rematerialize_at(
+        state->rewriter->module, def_op, state->op);
+  }
+  if (loom_vector_splat_isa(def_op) || loom_vector_constant_isa(def_op) ||
+      loom_vector_poison_isa(def_op)) {
     return true;
   }
   if (loom_vector_mma_isa(def_op)) {
@@ -771,8 +775,14 @@ static uint32_t loom_vector_to_scalar_fragment_store_source_rejection_bits(
     return loom_vector_to_scalar_fragment_store_source_rejection_bits(
         state, loom_op_const_operands(def_op)[0]);
   }
-  if (loom_vector_fragment_load_isa(def_op) || loom_vector_splat_isa(def_op) ||
-      loom_vector_constant_isa(def_op) || loom_vector_poison_isa(def_op)) {
+  if (loom_vector_fragment_load_isa(def_op)) {
+    return loom_vector_to_scalar_read_can_rematerialize_at(
+               state->rewriter->module, def_op, state->op)
+               ? LOOM_CONTRACT_REJECTION_NONE
+               : LOOM_CONTRACT_REJECTION_POLICY;
+  }
+  if (loom_vector_splat_isa(def_op) || loom_vector_constant_isa(def_op) ||
+      loom_vector_poison_isa(def_op)) {
     return LOOM_CONTRACT_REJECTION_NONE;
   }
   if (loom_vector_mma_isa(def_op)) {
@@ -1103,8 +1113,10 @@ loom_vector_fragment_store_to_scalar_physical_result_loop_rewrite_ops(
 
   loom_type_t local_source_lane_types[8] = {0};
   loom_type_t local_store_lane_types[8] = {0};
+  const loom_op_t* local_source_predecessor_ops[8] = {0};
   loom_type_t* source_lane_types = local_source_lane_types;
   loom_type_t* store_lane_types = local_store_lane_types;
+  const loom_op_t** source_predecessor_ops = local_source_predecessor_ops;
   if (op_count > IREE_ARRAYSIZE(local_source_lane_types)) {
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
         rewriter->builder.arena, op_count, sizeof(*source_lane_types),
@@ -1112,6 +1124,9 @@ loom_vector_fragment_store_to_scalar_physical_result_loop_rewrite_ops(
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
         rewriter->builder.arena, op_count, sizeof(*store_lane_types),
         (void**)&store_lane_types));
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        rewriter->builder.arena, op_count, sizeof(*source_predecessor_ops),
+        (void**)&source_predecessor_ops));
   }
   for (iree_host_size_t i = 0; i < op_count; ++i) {
     if (!loom_vector_fragment_store_isa(ops[i]) ||
@@ -1120,6 +1135,7 @@ loom_vector_fragment_store_to_scalar_physical_result_loop_rewrite_ops(
             &store_lane_types[i])) {
       return iree_ok_status();
     }
+    source_predecessor_ops[i] = ops[i]->prev_op;
   }
   if (iree_any_bit_set(
           flags, LOOM_VECTOR_TO_SCALAR_FLAG_REQUIRE_PRODUCER_LANE_PROGRAM)) {
@@ -1152,7 +1168,7 @@ loom_vector_fragment_store_to_scalar_physical_result_loop_rewrite_ops(
       .matrix_fragment_layout = matrix_fragment_layout,
       .location = first_op->location,
   };
-  loom_vector_to_scalar_state_bind_statistics(&state, pass);
+  loom_vector_to_scalar_state_initialize(&state, pass);
 
   loom_value_id_t zero = LOOM_VALUE_ID_INVALID;
   loom_value_id_t upper_bound = LOOM_VALUE_ID_INVALID;
@@ -1188,6 +1204,8 @@ loom_vector_fragment_store_to_scalar_physical_result_loop_rewrite_ops(
       loom_region_entry_arg_id(loom_scf_for_body(loop), 0);
   for (iree_host_size_t i = 0; i < op_count; ++i) {
     state.op = ops[i];
+    state.source_predecessor_op = source_predecessor_ops[i];
+    state.rematerialization = NULL;
     state.vector_type = loom_module_value_type(
         rewriter->module, loom_vector_fragment_store_value(ops[i]));
     state.result_scalar_type = source_lane_types[i];


### PR DESCRIPTION
Vector scalarization now preserves the source ordering of ordinary loads when it rebuilds scalar lanes at generated consumers. Previously, lowering a masked store could recreate a vector load after an intervening barrier and overwrite, silently changing the value that reached the store.

## Motion Contract

The shared motion analysis now distinguishes two operations that had been conflated:

- Effect-free producers may be rematerialized when they are pure, deterministic, identity-free, and remain under the original execution predicate.
- Ordinary loads may move only when every crossed operation preserves read ordering. Writes, fences, nested regions, convergence, nondeterminism, and retained semantic boundaries block the move.

The existing single-use read-sinking transform consumes the same crossing predicate, so Loom has one definition of the ordering boundary rather than parallel transform-specific policies.

## Scalarization

Vector scalarization captures each root consumer's original predecessor before emitting replacement IR. Recursive lane materialization freely rebuilds effect-free producers, but it retains an ordinary load at its source position unless motion analysis proves that the load can reach the original consumer. Legality is cached once per distinct read producer in pass-owned arena storage.

Grouped fragment stores preserve the original source position for each store rather than inheriting the position of the first grouped operation. This keeps the same ordering contract when several physical result fragments share one generated scalar loop.

Paired lowering cases establish both sides of the behavior: an unobstructed load still sinks into masked scalar stores, while a load separated from its consumer by barriers and an overwrite remains at its original position.

## Review Surface

The central review boundary is the split between effect-free rematerialization and ordinary-read motion in `loom/analysis/motion`. The vector transform changes should only capture original positions, cache that decision, and preserve it through recursive lane and grouped-fragment lowering.
