### PR TITLE
[HAL/AMDGPU] Bridge feedback publication to TSAN

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -1330,6 +1330,9 @@ static iree_status_t iree_hal_amdgpu_executable_publish_feedback_config(
           "AMDGPU feedback config global `%s` did not resolve to device memory",
           IREE_HAL_AMDGPU_FEEDBACK_CONFIG_GLOBAL_NAME);
     }
+    // The context pointer crosses the device global and feedback packet before
+    // an HSA signal wakes the host reader. TSAN cannot observe that path.
+    IREE_TSAN_RELEASE(&executable->source_context);
     IREE_RETURN_IF_ERROR(
         iree_hsa_memory_copy(IREE_LIBHSA(executable->libhsa), target_ptr,
                              &config, sizeof(config)),

--- a/runtime/src/iree/hal/drivers/amdgpu/feedback_state.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/feedback_state.c
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 
+#include "iree/base/internal/debugging.h"
 #include "iree/base/threading/affinity.h"
 #include "iree/base/threading/thread.h"
 #include "iree/hal/drivers/amdgpu/abi/asan.h"
@@ -147,8 +148,14 @@ static uint32_t iree_hal_amdgpu_feedback_state_physical_device_ordinal(
 static const iree_hal_amdgpu_source_context_t*
 iree_hal_amdgpu_feedback_state_source_context(
     const iree_hal_amdgpu_feedback_packet_t* packet) {
-  return (const iree_hal_amdgpu_source_context_t*)(uintptr_t)
-      packet->source_context;
+  const iree_hal_amdgpu_source_context_t* source_context =
+      (const iree_hal_amdgpu_source_context_t*)(uintptr_t)
+          packet->source_context;
+  if (source_context) {
+    // Pair with the release before this pointer enters the device/HSA path.
+    IREE_TSAN_ACQUIRE((void*)source_context);
+  }
+  return source_context;
 }
 
 static void iree_hal_amdgpu_feedback_state_publish_asan_event(


### PR DESCRIPTION
AMDGPU feedback carries a host-owned executable source-context pointer through a device global and feedback packet before the service thread resolves it after an HSA notification. The HSA system-scope publication protocol orders those accesses, but host ThreadSanitizer cannot infer a happens-before edge that transits the GPU and reports the immutable context read as a race.

This annotates the existing boundary with an `IREE_TSAN_RELEASE` before the context pointer enters the device path and a matching `IREE_TSAN_ACQUIRE` when the host recovers it from a packet. Both annotations compile away outside host TSAN builds; production executable layout, dispatch work, synchronization, and feedback behavior are unchanged.

The existing lifetime path remains authoritative: direct dispatch and command-buffer submissions retain their executable through GPU completion, and queue reclaim drains feedback under the per-device mutex before releasing submission resources. No additional teardown drain or ownership layer is required.

## Reproduction

The focused AMDGPU TSAN executable CTS failed 7 of 20 repeated runs before this change. It passed 20 of 20 and then 50 of 50 repeated runs with the bridge. Focused source-context, feedback-channel, and TSAN-executable ASAN coverage also passes.
