### PR TITLE
[Loom] Remove rediscovery from AMDGPU packet planning

### DIFF
--- a/loom/py/loom/gen/target/arch/amdgpu/amdgpu_target_info.py
+++ b/loom/py/loom/gen/target/arch/amdgpu/amdgpu_target_info.py
@@ -1338,8 +1338,8 @@ def _emit_physical_target_rows(
     return lines
 
 
-def _matrix_coexecution_rule_symbol(profile: str) -> str:
-    return f"kAmdgpuMatrixCoexecutionRules{_c_ident(profile)}"
+def _matrix_coexecution_release_table_symbol(profile: str) -> str:
+    return f"kAmdgpuMatrixCoexecutionReleases{_c_ident(profile)}"
 
 
 def _emit_matrix_coexecution_source_layouts() -> str:
@@ -1363,18 +1363,27 @@ def _emit_matrix_coexecution_rows() -> list[str]:
     for profile, rules in AMDGPU_MATRIX_COEXECUTION_RULES_BY_PROFILE.items():
         if not rules:
             continue
-        lines.append(f"static const loom_amdgpu_matrix_coexecution_rule_t {_matrix_coexecution_rule_symbol(profile)}[] = {{")
-        for rule in rules:
-            lines.extend(
-                [
-                    "  {",
-                    f"    .source = {_matrix_coexecution_source_expr(rule.source)},",
-                    f"    .latency_cycles = {rule.latency_cycles},",
-                    f"    .matrix_issue_distance = {rule.matrix_issue_distance},",
-                    f"    .vector_issue_distance = {rule.vector_issue_distance},",
-                    "  },",
-                ]
-            )
+        lines.append(
+            "static const loom_amdgpu_matrix_coexecution_release_t "
+            f"{_matrix_coexecution_release_table_symbol(profile)}"
+            "[LOOM_AMDGPU_MATRIX_COEXECUTION_SOURCE_COUNT]"
+            "[LOOM_AMDGPU_MATRIX_COEXECUTION_LATENCY_COUNT] = {"
+        )
+        for source_info in AMDGPU_MATRIX_COEXECUTION_SOURCE_INFOS:
+            source_rules = tuple(rule for rule in rules if rule.source == source_info.source)
+            if not source_rules:
+                continue
+            lines.append(f"  [{_matrix_coexecution_source_expr(source_info.source)}] = {{")
+            for rule in source_rules:
+                lines.extend(
+                    [
+                        f"    [{rule.latency_cycles}] = {{",
+                        f"      .matrix_issue_distance = {rule.matrix_issue_distance},",
+                        f"      .vector_issue_distance = {rule.vector_issue_distance},",
+                        "    },",
+                    ]
+                )
+            lines.append("  },")
         lines.extend(["};", ""])
 
     lines.append("const loom_amdgpu_matrix_coexecution_profile_info_t loom_amdgpu_target_info_matrix_coexecution_profile_infos[] = {")
@@ -1387,8 +1396,7 @@ def _emit_matrix_coexecution_rows() -> list[str]:
         lines.extend(
             [
                 f"  [{profile_expr}] = {{",
-                f"    .rules = {_matrix_coexecution_rule_symbol(profile)},",
-                f"    .rule_count = {len(rules)},",
+                f"    .releases = {_matrix_coexecution_release_table_symbol(profile)},",
                 f"    .maximum_issue_distance = {maximum_issue_distance},",
                 "  },",
             ]

--- a/loom/src/loom/target/arch/amdgpu/planning/matrix_coexecution.c
+++ b/loom/src/loom/target/arch/amdgpu/planning/matrix_coexecution.c
@@ -173,7 +173,7 @@ struct loom_amdgpu_matrix_coexecution_t {
   uint32_t* active_vgpr_indices;
   // Number of entries in |active_vgpr_indices|.
   iree_host_size_t active_vgpr_count;
-  // Scratch lookup from physical VGPR to a node in one outgoing frontier.
+  // Multi-block scratch lookup from physical VGPR to one outgoing frontier.
   loom_amdgpu_matrix_coexecution_frontier_node_t** frontier_lookup;
   // Number of physical VGPR units in the release lattice.
   uint32_t vgpr_count;
@@ -833,13 +833,14 @@ iree_status_t loom_amdgpu_matrix_coexecution_allocate(
   IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
       arena, vgpr_count, sizeof(*coexecution->active_vgpr_indices),
       (void**)&coexecution->active_vgpr_indices));
-  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-      arena, vgpr_count, sizeof(*coexecution->frontier_lookup),
-      (void**)&coexecution->frontier_lookup));
-  memset(coexecution->frontier_lookup, 0,
-         (iree_host_size_t)vgpr_count * sizeof(*coexecution->frontier_lookup));
   if (schedule->block_count > 1) {
     IREE_ASSERT(schedule->cfg_graph.blocks != NULL);
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        arena, vgpr_count, sizeof(*coexecution->frontier_lookup),
+        (void**)&coexecution->frontier_lookup));
+    memset(
+        coexecution->frontier_lookup, 0,
+        (iree_host_size_t)vgpr_count * sizeof(*coexecution->frontier_lookup));
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
         arena, schedule->block_count, sizeof(*coexecution->blocks),
         (void**)&coexecution->blocks));

--- a/loom/src/loom/target/arch/amdgpu/planning/matrix_coexecution.c
+++ b/loom/src/loom/target/arch/amdgpu/planning/matrix_coexecution.c
@@ -324,25 +324,6 @@ static void loom_amdgpu_matrix_coexecution_publish_source(
   }
 }
 
-static const loom_amdgpu_matrix_coexecution_rule_t*
-loom_amdgpu_matrix_coexecution_select_rule(
-    const loom_amdgpu_matrix_coexecution_t* coexecution,
-    const loom_low_packet_view_t* packet,
-    loom_amdgpu_matrix_coexecution_source_kind_t source_kind) {
-  const loom_low_schedule_class_t* schedule_class =
-      &coexecution->descriptor_set
-           ->schedule_classes[packet->descriptor->schedule_class_id];
-  for (iree_host_size_t i = 0; i < coexecution->profile->rule_count; ++i) {
-    const loom_amdgpu_matrix_coexecution_rule_t* rule =
-        &coexecution->profile->rules[i];
-    if (rule->source == source_kind &&
-        rule->latency_cycles == schedule_class->latency_cycles) {
-      return rule;
-    }
-  }
-  return NULL;
-}
-
 static const loom_amdgpu_matrix_coexecution_source_t*
 loom_amdgpu_matrix_coexecution_append_source(
     loom_amdgpu_matrix_coexecution_t* coexecution,
@@ -361,10 +342,14 @@ loom_amdgpu_matrix_coexecution_append_source(
     IREE_ASSERT_UNREACHABLE(
         "matrix coexecution source trait requires WMMA or SWMMAC");
   }
-  const loom_amdgpu_matrix_coexecution_rule_t* rule =
-      loom_amdgpu_matrix_coexecution_select_rule(coexecution, packet,
-                                                 source_kind);
-  IREE_ASSERT(rule != NULL);
+  const loom_low_schedule_class_t* schedule_class =
+      &coexecution->descriptor_set
+           ->schedule_classes[packet->descriptor->schedule_class_id];
+  IREE_ASSERT_LE(schedule_class->latency_cycles, UINT8_MAX);
+  const uint8_t latency_cycles = (uint8_t)schedule_class->latency_cycles;
+  const loom_amdgpu_matrix_coexecution_release_t* release =
+      &coexecution->profile->releases[source_kind][latency_cycles];
+  IREE_ASSERT_NE(release->matrix_issue_distance, 0);
   const loom_amdgpu_matrix_coexecution_family_layout_t* layout =
       &kSourceLayouts[source_kind];
   loom_amdgpu_matrix_coexecution_source_t* source =
@@ -375,8 +360,8 @@ loom_amdgpu_matrix_coexecution_append_source(
       .result_operand_index = layout->result_operand_index,
       .source_operand_start = layout->source_operand_start,
       .source_operand_count = layout->source_operand_count,
-      .matrix_issue_distance = rule->matrix_issue_distance,
-      .vector_issue_distance = rule->vector_issue_distance,
+      .matrix_issue_distance = release->matrix_issue_distance,
+      .vector_issue_distance = release->vector_issue_distance,
   };
   return source;
 }
@@ -799,7 +784,7 @@ iree_status_t loom_amdgpu_matrix_coexecution_allocate(
   *out_coexecution = NULL;
   const loom_amdgpu_matrix_coexecution_profile_info_t* profile_model =
       loom_amdgpu_target_info_matrix_coexecution_profile(profile);
-  if (profile_model->rule_count == 0) return iree_ok_status();
+  if (profile_model->releases == NULL) return iree_ok_status();
   const iree_host_size_t source_capacity =
       schedule->matrix_coexecution_source_use_count;
   if (source_capacity == 0) return iree_ok_status();

--- a/loom/src/loom/target/arch/amdgpu/planning/packet_plan.c
+++ b/loom/src/loom/target/arch/amdgpu/planning/packet_plan.c
@@ -36,8 +36,8 @@ iree_status_t loom_amdgpu_packet_plan_build(
                                                   &out_plan->address_state);
   }
   if (iree_status_is_ok(status)) {
-    status = loom_amdgpu_wait_plan_build(schedule, allocation, arena,
-                                         &out_plan->wait_plan);
+    status = loom_amdgpu_wait_plan_build(
+        schedule, allocation, arena, &transient_arena, &out_plan->wait_plan);
   }
   if (iree_status_is_ok(status)) {
     status = loom_amdgpu_wait_packet_plan_build(&out_plan->wait_plan, arena,

--- a/loom/src/loom/target/arch/amdgpu/planning/wait_plan.c
+++ b/loom/src/loom/target/arch/amdgpu/planning/wait_plan.c
@@ -1657,14 +1657,11 @@ static iree_status_t loom_amdgpu_wait_plan_finish_node_classification(
       loom_amdgpu_processor_properties_have_scheduling(
           builder->processor_properties,
           LOOM_AMDGPU_PROCESSOR_SCHEDULING_VALU_TRANS_USE_DEPCTR);
-  bool supports_xcnt = false;
-  for (uint32_t i = 0; i < descriptor_set->descriptor_count; ++i) {
-    if (loom_amdgpu_wait_plan_descriptor_has_xcnt_source_lease(
-            descriptor_set, &descriptor_set->descriptors[i])) {
-      supports_xcnt = true;
-      break;
-    }
-  }
+  IREE_ASSERT_LT(LOOM_AMDGPU_WAIT_COUNTER_MASK_X,
+                 builder->wait_packet_target.selection_count);
+  const bool supports_xcnt =
+      builder->wait_packet_target.selections[LOOM_AMDGPU_WAIT_COUNTER_MASK_X]
+          .covered_counter_mask == LOOM_AMDGPU_WAIT_COUNTER_MASK_X;
   for (iree_host_size_t i = 0; i < schedule->node_count; ++i) {
     loom_amdgpu_wait_node_state_t* node_state = &builder->node_states[i];
     loom_amdgpu_wait_frontier_node_t* frontier_node =

--- a/loom/src/loom/target/arch/amdgpu/planning/wait_plan.c
+++ b/loom/src/loom/target/arch/amdgpu/planning/wait_plan.c
@@ -179,8 +179,10 @@ typedef struct loom_amdgpu_wait_plan_builder_t {
   const loom_low_schedule_table_t* schedule;
   // Optional physical assignment table for post-allocation hazards.
   const loom_low_allocation_table_t* allocation;
-  // Arena that owns all output and scratch arrays.
+  // Arena that owns tables retained by the completed plan.
   iree_arena_allocator_t* arena;
+  // Arena that owns builder state discarded after plan construction.
+  iree_arena_allocator_t* transient_arena;
   // Processor properties selected by the low target, or NULL if unavailable.
   const loom_amdgpu_processor_properties_t* processor_properties;
   // Generated wait-packet descriptors selected by the low target.
@@ -444,7 +446,7 @@ static iree_status_t loom_amdgpu_wait_plan_build_storage_release_action_index(
       allocation->storage_release_actions,
       allocation->storage_release_action_count,
       LOOM_LOW_STORAGE_RELEASE_ACTION_INDEX_BY_INSERTION_NODE,
-      schedule->node_count, builder->arena,
+      schedule->node_count, builder->transient_arena,
       &builder->storage_release_action_index);
 }
 
@@ -453,19 +455,19 @@ static iree_status_t loom_amdgpu_wait_plan_allocate(
   const loom_low_schedule_table_t* schedule = builder->schedule;
   if (schedule->node_count != 0) {
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-        builder->arena, schedule->node_count, sizeof(*builder->node_states),
-        (void**)&builder->node_states));
+        builder->transient_arena, schedule->node_count,
+        sizeof(*builder->node_states), (void**)&builder->node_states));
     memset(builder->node_states, 0,
            schedule->node_count * sizeof(*builder->node_states));
 
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-        builder->arena, schedule->node_count, sizeof(*builder->frontier_nodes),
-        (void**)&builder->frontier_nodes));
+        builder->transient_arena, schedule->node_count,
+        sizeof(*builder->frontier_nodes), (void**)&builder->frontier_nodes));
     memset(builder->frontier_nodes, 0,
            schedule->node_count * sizeof(*builder->frontier_nodes));
 
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-        builder->arena, schedule->node_count,
+        builder->transient_arena, schedule->node_count,
         sizeof(*builder->current_block_drained_counter_masks),
         (void**)&builder->current_block_drained_counter_masks));
     memset(builder->current_block_drained_counter_masks, 0,
@@ -473,7 +475,7 @@ static iree_status_t loom_amdgpu_wait_plan_allocate(
                sizeof(*builder->current_block_drained_counter_masks));
 
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-        builder->arena, schedule->node_count,
+        builder->transient_arena, schedule->node_count,
         sizeof(*builder->current_block_drained_epochs),
         (void**)&builder->current_block_drained_epochs));
     memset(
@@ -481,7 +483,7 @@ static iree_status_t loom_amdgpu_wait_plan_allocate(
         schedule->node_count * sizeof(*builder->current_block_drained_epochs));
 
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-        builder->arena, schedule->node_count,
+        builder->transient_arena, schedule->node_count,
         sizeof(*builder->first_dependency_link_by_consumer),
         (void**)&builder->first_dependency_link_by_consumer));
     for (iree_host_size_t i = 0; i < schedule->node_count; ++i) {
@@ -593,7 +595,7 @@ static iree_status_t loom_amdgpu_wait_plan_allocate_physical_state(
   }
   if (builder->physical_registers.vgpr_count != 0 && needs_trans_result_state) {
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-        builder->arena, builder->physical_registers.vgpr_count,
+        builder->transient_arena, builder->physical_registers.vgpr_count,
         sizeof(*builder->trans_result_vgprs),
         (void**)&builder->trans_result_vgprs));
     memset(builder->trans_result_vgprs, 0,
@@ -603,7 +605,7 @@ static iree_status_t loom_amdgpu_wait_plan_allocate_physical_state(
   }
   if (builder->physical_registers.sgpr_count != 0 && needs_sgpr_read_state) {
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-        builder->arena, builder->physical_registers.sgpr_count,
+        builder->transient_arena, builder->physical_registers.sgpr_count,
         sizeof(*builder->sgpr_read_registers),
         (void**)&builder->sgpr_read_registers));
     memset(builder->sgpr_read_registers, 0,
@@ -632,7 +634,7 @@ static iree_status_t loom_amdgpu_wait_plan_append_action(
   if (builder->action_stream.tail == NULL) {
     void* segment = NULL;
     IREE_RETURN_IF_ERROR(loom_segmented_storage_append(
-        &builder->action_stream.segments, builder->arena, &segment));
+        &builder->action_stream.segments, builder->transient_arena, &segment));
     builder->action_stream.tail =
         (loom_amdgpu_wait_plan_action_segment_t*)segment;
   }
@@ -684,7 +686,7 @@ static iree_status_t loom_amdgpu_wait_plan_ensure_dependency_link_capacity(
     return iree_ok_status();
   }
   return iree_arena_grow_array(
-      builder->arena, builder->dependency_link_count,
+      builder->transient_arena, builder->dependency_link_count,
       iree_max(required_capacity, (iree_host_size_t)16),
       sizeof(*builder->dependency_links), &builder->dependency_link_capacity,
       (void**)&builder->dependency_links);
@@ -829,27 +831,28 @@ static iree_status_t loom_amdgpu_wait_plan_build_block_arg_sources(
 
   uint32_t* block_arg_offsets = NULL;
   IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-      builder->arena, schedule->block_count, sizeof(*block_arg_offsets),
-      (void**)&block_arg_offsets));
+      builder->transient_arena, schedule->block_count,
+      sizeof(*block_arg_offsets), (void**)&block_arg_offsets));
   loom_amdgpu_wait_plan_compute_block_arg_offsets(schedule, block_arg_offsets);
 
   loom_value_ordinal_t* block_arg_ordinals = NULL;
   IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-      builder->arena, block_arg_count, sizeof(*block_arg_ordinals),
+      builder->transient_arena, block_arg_count, sizeof(*block_arg_ordinals),
       (void**)&block_arg_ordinals));
   loom_amdgpu_wait_plan_initialize_block_arg_ordinals(
       schedule, block_arg_offsets, block_arg_count, block_arg_ordinals);
 
   IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-      builder->arena, schedule->value_count,
+      builder->transient_arena, schedule->value_count,
       sizeof(*builder->first_block_arg_source_by_value),
       (void**)&builder->first_block_arg_source_by_value));
   for (iree_host_size_t i = 0; i < schedule->value_count; ++i) {
     builder->first_block_arg_source_by_value[i] = LOOM_LOW_SCHEDULE_NODE_NONE;
   }
-  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-      builder->arena, source_count, sizeof(*builder->block_arg_sources),
-      (void**)&builder->block_arg_sources));
+  IREE_RETURN_IF_ERROR(
+      iree_arena_allocate_array(builder->transient_arena, source_count,
+                                sizeof(*builder->block_arg_sources),
+                                (void**)&builder->block_arg_sources));
 
   for (iree_host_size_t i = 0; i < schedule->node_count; ++i) {
     const loom_low_schedule_node_t* node = &schedule->nodes[i];
@@ -889,12 +892,13 @@ static iree_status_t loom_amdgpu_wait_plan_ensure_dependency_visit_state(
     return iree_ok_status();
   }
   IREE_RETURN_IF_ERROR(
-      iree_arena_allocate_array(builder->arena, schedule->value_count,
+      iree_arena_allocate_array(builder->transient_arena, schedule->value_count,
                                 sizeof(*builder->dependency_visit_epochs),
                                 (void**)&builder->dependency_visit_epochs));
   memset(builder->dependency_visit_epochs, 0,
          schedule->value_count * sizeof(*builder->dependency_visit_epochs));
-  return iree_arena_allocate_array(builder->arena, schedule->value_count,
+  return iree_arena_allocate_array(builder->transient_arena,
+                                   schedule->value_count,
                                    sizeof(*builder->dependency_visit_worklist),
                                    (void**)&builder->dependency_visit_worklist);
 }
@@ -1811,7 +1815,7 @@ static iree_status_t loom_amdgpu_wait_plan_build_dependency_links(
 
   if (value_count != 0) {
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-        builder->arena, value_count, sizeof(*builder->producer_nodes),
+        builder->transient_arena, value_count, sizeof(*builder->producer_nodes),
         (void**)&builder->producer_nodes));
     for (iree_host_size_t i = 0; i < value_count; ++i) {
       builder->producer_nodes[i] = LOOM_LOW_SCHEDULE_NODE_NONE;
@@ -3376,12 +3380,14 @@ static iree_status_t loom_amdgpu_wait_plan_build_common_tables(
 iree_status_t loom_amdgpu_wait_plan_build(
     const loom_low_schedule_table_t* schedule,
     const loom_low_allocation_table_t* allocation,
-    iree_arena_allocator_t* arena, loom_amdgpu_wait_plan_t* out_plan) {
+    iree_arena_allocator_t* arena, iree_arena_allocator_t* transient_arena,
+    loom_amdgpu_wait_plan_t* out_plan) {
   *out_plan = (loom_amdgpu_wait_plan_t){0};
   loom_amdgpu_wait_plan_builder_t builder = {
       .schedule = schedule,
       .allocation = allocation,
       .arena = arena,
+      .transient_arena = transient_arena,
       .processor_properties =
           loom_amdgpu_target_processor_properties_from_resolved_target(
               &schedule->target),
@@ -3410,7 +3416,8 @@ iree_status_t loom_amdgpu_wait_plan_build(
     status = loom_amdgpu_wait_frontier_initialize(
         schedule, allocation, builder.frontier_nodes,
         builder.physical_registers.vgpr_count,
-        builder.physical_registers.agpr_count, arena, &builder.frontier);
+        builder.physical_registers.agpr_count, transient_arena,
+        &builder.frontier);
   }
   if (iree_status_is_ok(status)) {
     status = loom_amdgpu_wait_plan_build_actions(&builder);

--- a/loom/src/loom/target/arch/amdgpu/planning/wait_plan.h
+++ b/loom/src/loom/target/arch/amdgpu/planning/wait_plan.h
@@ -145,12 +145,14 @@ iree_string_view_t loom_amdgpu_wait_plan_residual_action_name(
 // actions requested by allocation, such as outstanding memory reads whose
 // destination registers have not yet been written and memory packets whose
 // scalar or vector sources have not yet been consumed by the memory pipe. The
-// caller must keep |schedule| and |allocation| immutable and |arena| alive for
-// as long as |out_plan| is used.
+// Builder state is allocated from |transient_arena| and may be discarded after
+// this function returns. The caller must keep |schedule| and |allocation|
+// immutable and |arena| alive for as long as |out_plan| is used.
 iree_status_t loom_amdgpu_wait_plan_build(
     const loom_low_schedule_table_t* schedule,
     const loom_low_allocation_table_t* allocation,
-    iree_arena_allocator_t* arena, loom_amdgpu_wait_plan_t* out_plan);
+    iree_arena_allocator_t* arena, iree_arena_allocator_t* transient_arena,
+    loom_amdgpu_wait_plan_t* out_plan);
 
 // Appends the common packet hazard JSON representation of |plan| to |builder|.
 iree_status_t loom_amdgpu_wait_plan_format_json(

--- a/loom/src/loom/target/arch/amdgpu/planning/wait_states.c
+++ b/loom/src/loom/target/arch/amdgpu/planning/wait_states.c
@@ -296,9 +296,9 @@ typedef struct loom_amdgpu_wait_state_builder_t {
   const loom_amdgpu_vopd_pair_t* vopd_pairs;
   // Descriptor set selected by the scheduled target.
   const loom_low_descriptor_set_t* descriptor_set;
-  // Arena that owns all output and scratch arrays.
+  // Arena that owns output tables retained by the completed plan.
   iree_arena_allocator_t* arena;
-  // Arena that owns analysis facts discarded after plan construction.
+  // Arena that owns builder state discarded after plan construction.
   iree_arena_allocator_t* transient_arena;
   // Processor properties selected by the low target, or NULL if unavailable.
   const loom_amdgpu_processor_properties_t* processor_properties;
@@ -506,17 +506,15 @@ static iree_status_t loom_amdgpu_wait_state_allocate(
       allocation->physical_extents
           .ends_by_reg_class[LOOM_AMDGPU_REG_CLASS_ID_SGPR];
   if (vgpr_count != 0) {
-    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(builder->arena, vgpr_count,
-                                                   sizeof(*builder->vgprs),
-                                                   (void**)&builder->vgprs));
-    memset(builder->vgprs, 0, vgpr_count * sizeof(*builder->vgprs));
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        builder->transient_arena, vgpr_count, sizeof(*builder->vgprs),
+        (void**)&builder->vgprs));
     builder->vgpr_count = vgpr_count;
   }
   if (sgpr_count != 0) {
-    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(builder->arena, sgpr_count,
-                                                   sizeof(*builder->sgprs),
-                                                   (void**)&builder->sgprs));
-    memset(builder->sgprs, 0, sgpr_count * sizeof(*builder->sgprs));
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        builder->transient_arena, sgpr_count, sizeof(*builder->sgprs),
+        (void**)&builder->sgprs));
     builder->sgpr_count = sgpr_count;
   }
   const iree_host_size_t states_per_packet =

--- a/loom/src/loom/target/arch/amdgpu/target_info_defs.h
+++ b/loom/src/loom/target/arch/amdgpu/target_info_defs.h
@@ -232,23 +232,23 @@ typedef enum loom_amdgpu_matrix_coexecution_source_kind_e {
   LOOM_AMDGPU_MATRIX_COEXECUTION_SOURCE_COUNT = 2,
 } loom_amdgpu_matrix_coexecution_source_kind_t;
 
-typedef struct loom_amdgpu_matrix_coexecution_rule_t {
-  // Matrix instruction family opening the release window.
-  loom_amdgpu_matrix_coexecution_source_kind_t source;
-  // Descriptor schedule latency selecting the rule.
-  uint8_t latency_cycles;
+enum {
+  // Number of entries required to index every uint8_t schedule latency.
+  LOOM_AMDGPU_MATRIX_COEXECUTION_LATENCY_COUNT = UINT8_MAX + 1,
+};
+
+typedef struct loom_amdgpu_matrix_coexecution_release_t {
   // Required vector issues before a dependent matrix packet.
   uint8_t matrix_issue_distance;
   // Required vector issues before a dependent ordinary vector packet.
   uint8_t vector_issue_distance;
-} loom_amdgpu_matrix_coexecution_rule_t;
+} loom_amdgpu_matrix_coexecution_release_t;
 
 typedef struct loom_amdgpu_matrix_coexecution_profile_info_t {
-  // Generated release rules for this processor profile.
-  const loom_amdgpu_matrix_coexecution_rule_t* rules;
-  // Number of entries in |rules|.
-  uint8_t rule_count;
-  // Largest vector issue distance in |rules|.
+  // Generated releases indexed directly by source kind and schedule latency.
+  const loom_amdgpu_matrix_coexecution_release_t (
+      *releases)[LOOM_AMDGPU_MATRIX_COEXECUTION_LATENCY_COUNT];
+  // Largest release distance, measured in vector issue slots, in |releases|.
   uint8_t maximum_issue_distance;
 } loom_amdgpu_matrix_coexecution_profile_info_t;
 

--- a/loom/src/loom/target/emit/native/amdgpu/packet_plan_benchmark.cc
+++ b/loom/src/loom/target/emit/native/amdgpu/packet_plan_benchmark.cc
@@ -102,6 +102,19 @@ constexpr FixtureSpec kMemoryControl = {
     /*.generated_matrix=*/{},
 };
 
+// A straight-line matrix workload that isolates the common single-block
+// coexecution path without CFG frontier propagation.
+constexpr FixtureSpec kMatrixSingleBlockCanary = {
+    /*.name=*/"matrix_single_block_canary",
+    /*.input_stage=*/FixtureInputStage::kGeneratedLow,
+    /*.generated_matrix=*/
+    {
+        /*.phase_count=*/1,
+        /*.valu_packets_per_phase=*/4,
+        /*.dependent_valu_packets_per_phase=*/4,
+    },
+};
+
 constexpr FixtureSpec kMatrixDependencyCanary = {
     /*.name=*/"matrix_dependency_canary",
     /*.input_stage=*/FixtureInputStage::kGeneratedLow,
@@ -704,6 +717,20 @@ static void BM_PacketPlan_MemoryControl(benchmark::State& state) {
 }
 BENCHMARK(BM_PacketPlan_MemoryControl)
     ->Iterations(2000)
+    ->Unit(benchmark::kNanosecond);
+
+static void BM_WaitPlan_MatrixSingleBlockCanary(benchmark::State& state) {
+  BenchmarkPlan(state, kMatrixSingleBlockCanary, PlanComponent::kWait);
+}
+BENCHMARK(BM_WaitPlan_MatrixSingleBlockCanary)
+    ->Iterations(1000)
+    ->Unit(benchmark::kNanosecond);
+
+static void BM_PacketPlan_MatrixSingleBlockCanary(benchmark::State& state) {
+  BenchmarkPlan(state, kMatrixSingleBlockCanary, PlanComponent::kComplete);
+}
+BENCHMARK(BM_PacketPlan_MatrixSingleBlockCanary)
+    ->Iterations(1000)
     ->Unit(benchmark::kNanosecond);
 
 static void BM_WaitPlan_MatrixDependencyCanary(benchmark::State& state) {

--- a/loom/src/loom/target/emit/native/amdgpu/packet_plan_benchmark.cc
+++ b/loom/src/loom/target/emit/native/amdgpu/packet_plan_benchmark.cc
@@ -447,6 +447,7 @@ class PacketPlanFixture {
                                      &plan_block_pool_);
     iree_arena_initialize(&frame_block_pool_, &frame_arena_);
     iree_arena_initialize(&plan_block_pool_, &plan_arena_);
+    iree_arena_initialize(&plan_block_pool_, &transient_arena_);
 
     AbortOnError(loom_target_environment_initialize(
         &loom_amdgpu_target_provider_set, &target_environment_));
@@ -571,6 +572,7 @@ class PacketPlanFixture {
   }
 
   ~PacketPlanFixture() {
+    iree_arena_deinitialize(&transient_arena_);
     iree_arena_deinitialize(&plan_arena_);
     iree_arena_deinitialize(&frame_arena_);
     if (module_ != nullptr) {
@@ -588,6 +590,7 @@ class PacketPlanFixture {
 
   const loom_low_emission_frame_t& frame() const { return frame_; }
   iree_arena_allocator_t* plan_arena() { return &plan_arena_; }
+  iree_arena_allocator_t* transient_arena() { return &transient_arena_; }
   iree_host_size_t frame_arena_used_bytes() const {
     return frame_arena_.used_allocation_size;
   }
@@ -599,6 +602,8 @@ class PacketPlanFixture {
   iree_arena_block_pool_t plan_block_pool_ = {};
   iree_arena_allocator_t frame_arena_ = {};
   iree_arena_allocator_t plan_arena_ = {};
+  // Scratch storage discarded after each direct wait-plan build.
+  iree_arena_allocator_t transient_arena_ = {};
   loom_target_environment_t target_environment_ = {};
   loom_context_t context_ = {};
   loom_target_low_descriptor_registry_t target_registry_ = {};
@@ -612,10 +617,11 @@ static PlanMetrics BuildReferencePlan(PacketPlanFixture& fixture,
   iree_arena_reset(fixture.plan_arena());
   PlanMetrics metrics = {};
   if (component == PlanComponent::kWait) {
+    iree_arena_reset(fixture.transient_arena());
     loom_amdgpu_wait_plan_t plan = {};
-    AbortOnError(loom_amdgpu_wait_plan_build(&fixture.frame().schedule,
-                                             &fixture.frame().allocation,
-                                             fixture.plan_arena(), &plan));
+    AbortOnError(loom_amdgpu_wait_plan_build(
+        &fixture.frame().schedule, &fixture.frame().allocation,
+        fixture.plan_arena(), fixture.transient_arena(), &plan));
     metrics.wait_action_count = plan.action_count;
     metrics.hazard_record_count = plan.hazard_plan.record_count;
     metrics.progress_record_count = plan.progress.record_count;
@@ -689,10 +695,11 @@ static void BenchmarkPlan(benchmark::State& state, const FixtureSpec& spec,
   for (auto _ : state) {
     iree_arena_reset(fixture.plan_arena());
     if (component == PlanComponent::kWait) {
+      iree_arena_reset(fixture.transient_arena());
       loom_amdgpu_wait_plan_t plan = {};
-      AbortOnError(loom_amdgpu_wait_plan_build(&fixture.frame().schedule,
-                                               &fixture.frame().allocation,
-                                               fixture.plan_arena(), &plan));
+      AbortOnError(loom_amdgpu_wait_plan_build(
+          &fixture.frame().schedule, &fixture.frame().allocation,
+          fixture.plan_arena(), fixture.transient_arena(), &plan));
       benchmark::DoNotOptimize(plan);
     } else {
       loom_amdgpu_packet_plan_t plan = {};


### PR DESCRIPTION
AMDGPU packet planning now keeps temporary hazard state temporary and consumes generated target facts directly instead of rediscovering them from descriptor and release-rule tables. The changes preserve the existing schedule and packet contracts while reducing allocation, initialization, and scan work on every compiled kernel.

Straight-line matrix kernels no longer allocate or clear CFG frontier storage that only multi-block schedules consume. Per-register wait-state lattices, wait-plan classification, dependency state, CFG frontiers, and segmented action staging now live in the packet planner's transient arena; only finalized actions, progress, and hazards survive in the output arena.

Wait planning reads XCNT support from the already-selected generated wait-packet row instead of scanning the descriptor inventory. Matrix coexecution release distances are likewise materialized as a generated source-family-by-latency table, turning the per-packet release-rule scan into one direct lookup over a small immutable table. Existing generator and profile validation guarantee that active matrix sources select populated entries, so the planner keeps assertions for its internal contract rather than adding runtime validation.

The packet-plan benchmark gains a production-shaped single-block matrix row alongside the existing multi-block dependency witness. Together they keep the important cost boundary visible: transient planning work is measured separately from parsing, lowering, scheduling, and allocation, and future target facts can be evaluated without hiding fixed rediscovery costs inside the planner.

These are compiler-wide JIT improvements, not gfx1250 special cases. Any AMDGPU kernel using wait planning or matrix coexecution benefits from the same ownership and direct-index paths, and targets added later inherit the generated tables without another hot-path branch.
