### PR TITLE
[Loom] Preserve explicit HAL testbench launch inputs

### DIFF
--- a/loom/src/loom/tooling/execution/hal/testbench_actual.c
+++ b/loom/src/loom/tooling/execution/hal/testbench_actual.c
@@ -422,6 +422,37 @@ static bool loom_run_hal_testbench_find_case_constant_value_for_name(
   return false;
 }
 
+static bool loom_run_hal_testbench_find_actual_input_value_for_name(
+    const loom_run_hal_testbench_actual_provider_t* provider,
+    loom_func_like_t func, iree_string_view_t name,
+    loom_value_id_t* out_value_id) {
+  if (iree_string_view_is_empty(name)) {
+    *out_value_id = LOOM_VALUE_ID_INVALID;
+    return false;
+  }
+  loom_region_t* body = loom_func_like_body(func);
+  if (body == NULL || body->block_count == 0) {
+    *out_value_id = LOOM_VALUE_ID_INVALID;
+    return false;
+  }
+  const loom_block_t* entry_block = loom_region_const_entry_block(body);
+  for (uint16_t argument_index = 0; argument_index < entry_block->arg_count;
+       ++argument_index) {
+    const loom_value_id_t argument_id =
+        loom_block_arg_id(entry_block, argument_index);
+    if (iree_string_view_equal(
+            loom_run_hal_testbench_value_name(provider->compile_module.module,
+                                              argument_id),
+            name)) {
+      *out_value_id =
+          provider->actual_invocation->input_value_ids[argument_index];
+      return true;
+    }
+  }
+  *out_value_id = LOOM_VALUE_ID_INVALID;
+  return false;
+}
+
 static bool loom_run_hal_testbench_value_facts_from_constant_attr(
     loom_attribute_t attr, loom_scalar_type_t scalar_type,
     loom_value_facts_t* out_facts) {
@@ -560,7 +591,11 @@ loom_run_hal_testbench_apply_case_constants_to_named_region_args(
     const iree_string_view_t argument_name = loom_run_hal_testbench_value_name(
         provider->compile_module.module, argument_id);
     loom_value_id_t case_value_id = LOOM_VALUE_ID_INVALID;
-    if (!loom_run_hal_testbench_find_case_constant_value_for_name(
+    const bool binds_actual_input =
+        loom_run_hal_testbench_find_actual_input_value_for_name(
+            provider, func, argument_name, &case_value_id);
+    if (!binds_actual_input &&
+        !loom_run_hal_testbench_find_case_constant_value_for_name(
             provider->test_module, provider->case_plan, argument_name,
             &case_value_id)) {
       continue;

--- a/loom/src/loom/tooling/execution/hal/testbench_actual_test.cc
+++ b/loom/src/loom/tooling/execution/hal/testbench_actual_test.cc
@@ -339,6 +339,59 @@ check.case @dynamic_workgroups_case {
   loom_run_module_deinitialize(&run_module);
 }
 
+TEST_F(HalTestbenchActualTest, LaunchConfigBindsInputsBeforeConfigOnlyNames) {
+  static constexpr char kSource[] = R"(
+kernel.def @selected(%token_count: index, %config_only_count: index) {
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%token_count, %config_only_count, %unit) workgroup_size(%unit, %unit, %unit) : index
+} launch(%token_count: index) {
+  kernel.return
+}
+
+check.case @selected_case {
+  %token_count = check.literal value(1) : index
+  %routed_row_count = check.literal value(2) : index
+  %config_only_count = check.literal value(3) : index
+  func.call @selected(%routed_row_count) : (index)
+  check.return
+}
+)";
+  loom_run_module_t run_module = {};
+  loom_testbench_module_plan_t module_plan = {};
+  ParseAndPlan(IREE_SV(kSource), &run_module, &module_plan);
+  ASSERT_EQ(module_plan.case_count, 1u);
+  const loom_testbench_case_plan_t* case_plan = &module_plan.cases[0];
+  const loom_testbench_invocation_plan_t* actual_invocation = nullptr;
+  IREE_ASSERT_OK(loom_run_hal_testbench_select_actual_invocation(
+      case_plan, &actual_invocation));
+
+  loom_run_hal_testbench_context_t context = {};
+  context.artifact_provider = &kFakeHalArtifactProvider;
+  context.runtime_initialized = true;
+  context.host_allocator = iree_allocator_system();
+
+  loom_run_hal_testbench_actual_provider_options_t options = {};
+  options.context = &context;
+  options.session = &session_;
+  options.filename = IREE_SV("hal_testbench_actual_test.loom");
+  options.source = IREE_SV(kSource);
+  options.test_module = run_module.module;
+  options.actual_invocation = actual_invocation;
+  options.case_plan = case_plan;
+
+  loom_run_hal_testbench_actual_provider_t provider = {};
+  loom_run_hal_testbench_actual_provider_initialize(&options, &provider);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_FAILED_PRECONDITION,
+      loom_run_hal_testbench_actual_provider_compile(&provider));
+  EXPECT_EQ(provider.invocation_options.workgroup_count[0], 2u);
+  EXPECT_EQ(provider.invocation_options.workgroup_count[1], 3u);
+  EXPECT_EQ(provider.invocation_options.workgroup_count[2], 1u);
+
+  loom_run_hal_testbench_actual_provider_deinitialize(&provider);
+  loom_run_module_deinitialize(&run_module);
+}
+
 TEST_F(HalTestbenchActualTest, CompileModuleContainsOnlySelectedEntry) {
   static constexpr char kSource[] = R"(
 kernel.def @selected(%element_count: index) {


### PR DESCRIPTION
HAL testbench compilation specializes a selected kernel from the values supplied by each `check.case` invocation. Explicit call operands were first projected positionally into the kernel body, but launch-configuration specialization then looked up all host inputs by SSA name. A case-local value that happened to share a body argument's name could therefore replace the value actually passed by the call and silently compile a different dispatch grid.

This change gives explicit invocation operands precedence. A launch-config argument matching a kernel body ABI argument now resolves through that argument's ordinal to the call's actual operand. Name-based case lookup remains available for launch-only configuration inputs that have no body ABI counterpart.

The regression deliberately gives a body argument, its actual call operand, and an unrelated case literal different values while reusing one name. It proves that the explicit operand determines one workgroup dimension and a launch-only named value determines another.

The review surface is limited to the HAL testbench's case-constant specialization. Kernel IR, runtime dispatch ABI, and target lowering are unchanged.
