### PR TITLE
[hip] Implement virtual memory APIs.

### DIFF
--- a/libhrx/include/hrx_runtime.h
+++ b/libhrx/include/hrx_runtime.h
@@ -1025,9 +1025,9 @@ HRX_API hrx_status_t hrx_mem_pool_set_attribute(hrx_mem_pool_t pool,
 HRX_API hrx_status_t hrx_mem_pool_trim(hrx_mem_pool_t pool,
                                        size_t min_bytes_to_keep);
 
-// Releases a fully idle pool's backing storage when its release threshold is
-// zero. This is intended for stream-ordered free completion paths.
-HRX_API void hrx_mem_pool_release_unused(hrx_mem_pool_t pool);
+// Trims unused backing storage toward the pool's configured release threshold.
+// This is intended for stream-ordered free completion paths.
+HRX_API hrx_status_t hrx_mem_pool_release_unused(hrx_mem_pool_t pool);
 
 // Records a logical allocation backed by |pool|. Logical usage is distinct
 // from physical TLSF reservations, which can remain retained for later

--- a/libhrx/include/hrx_runtime.h
+++ b/libhrx/include/hrx_runtime.h
@@ -1001,9 +1001,14 @@ typedef enum hrx_mem_pool_attr_t {
 } hrx_mem_pool_attr_t;
 
 typedef struct hrx_mem_pool_props_t {
+  // Platform allocation-handle types requested when the pool was created.
   uint32_t alloc_handle_type;
+  // Platform location type for the pool's backing storage.
   uint32_t location_type;
+  // Platform device ordinal for the pool's backing storage.
   int location_id;
+  // Maximum live reservation bytes, or zero when the pool is unbounded.
+  size_t max_size;
 } hrx_mem_pool_props_t;
 
 HRX_API hrx_status_t hrx_mem_pool_create(hrx_device_t device,
@@ -1019,6 +1024,21 @@ HRX_API hrx_status_t hrx_mem_pool_set_attribute(hrx_mem_pool_t pool,
                                                 uint64_t value);
 HRX_API hrx_status_t hrx_mem_pool_trim(hrx_mem_pool_t pool,
                                        size_t min_bytes_to_keep);
+
+// Releases a fully idle pool's backing storage when its release threshold is
+// zero. This is intended for stream-ordered free completion paths.
+HRX_API void hrx_mem_pool_release_unused(hrx_mem_pool_t pool);
+
+// Records a logical allocation backed by |pool|. Logical usage is distinct
+// from physical TLSF reservations, which can remain retained for later
+// stream-ordered reuse.
+HRX_API void hrx_mem_pool_record_logical_allocation(hrx_mem_pool_t pool,
+                                                    size_t size);
+
+// Records retirement of a logical allocation backed by |pool|. The physical
+// reservation remains owned by its buffer until that buffer is released or
+// reused.
+HRX_API void hrx_mem_pool_record_logical_free(hrx_mem_pool_t pool, size_t size);
 
 // Allocates a buffer from |pool| using the same parameter contract as
 // hrx_allocator_allocate_buffer. The returned buffer owns the allocation and

--- a/libhrx/src/binding/common/BUILD.bazel
+++ b/libhrx/src/binding/common/BUILD.bazel
@@ -22,6 +22,7 @@ hrx_cc_library(
     srcs = [
         "context.c",
         "device.c",
+        "direct_transfer.c",
         "event.c",
         "fat_binary.c",
         "graph.c",
@@ -39,12 +40,15 @@ hrx_cc_library(
         "tls.c",
     ],
     hdrs = [
+        "direct_transfer.h",
         "fat_binary.h",
         "graph.h",
         "hrx_bridge.h",
         "internal.h",
         "kernel_arguments.h",
         "kpack.h",
+        "memory.h",
+        "stream.h",
         "tls.h",
     ],
     includes = [

--- a/libhrx/src/binding/common/CMakeLists.txt
+++ b/libhrx/src/binding/common/CMakeLists.txt
@@ -8,16 +8,20 @@ iree_cc_library(
   NAME
     common
   HDRS
+    "direct_transfer.h"
     "fat_binary.h"
     "graph.h"
     "hrx_bridge.h"
     "internal.h"
     "kernel_arguments.h"
     "kpack.h"
+    "memory.h"
+    "stream.h"
     "tls.h"
   SRCS
     "context.c"
     "device.c"
+    "direct_transfer.c"
     "event.c"
     "fat_binary.c"
     "graph.c"

--- a/libhrx/src/binding/common/buffer_table_test.cc
+++ b/libhrx/src/binding/common/buffer_table_test.cc
@@ -71,6 +71,14 @@ static iree_status_t iree_hal_streaming_buffer_table_insert(
                               buffer->size, (hrx_buffer_t)buffer, nullptr));
 }
 
+static iree_status_t iree_hal_streaming_buffer_table_insert_reserved(
+    iree_hal_streaming_buffer_table_t* table,
+    iree_hal_streaming_buffer_t* buffer) {
+  return BufferTableStatus(hrx_buffer_table_insert_reserved(
+      table, buffer->device_ptr, buffer->host_ptr, buffer->size,
+      (hrx_buffer_t)buffer, nullptr));
+}
+
 static iree_status_t iree_hal_streaming_buffer_table_remove(
     iree_hal_streaming_buffer_table_t* table, uint64_t any_ptr) {
   return BufferTableStatus(hrx_buffer_table_remove(table, any_ptr));
@@ -641,6 +649,47 @@ TEST(BufferTableTest, InsertRemoveInsert) {
   iree_hal_streaming_buffer_table_free(table);
   FreeDummyBuffer(buffer1, allocator);
   FreeDummyBuffer(buffer2, allocator);
+}
+
+TEST(BufferTableTest, ReservedInsertSurvivesCapacityPressure) {
+  iree_allocator_t allocator = iree_allocator_system();
+  iree_hal_streaming_buffer_table_t* table = nullptr;
+  IREE_ASSERT_OK(iree_hal_streaming_buffer_table_allocate(allocator, &table));
+
+  auto* removed_buffer = CreateDummyBuffer(0x100000000ULL, 4096, allocator);
+  IREE_ASSERT_OK(iree_hal_streaming_buffer_table_insert(table, removed_buffer));
+  const size_t reserved_capacity = table->capacity;
+  IREE_ASSERT_OK(BufferTableStatus(hrx_buffer_table_reserve_insert(table)));
+  IREE_ASSERT_OK(iree_hal_streaming_buffer_table_remove(
+      table, removed_buffer->device_ptr));
+
+  std::vector<iree_hal_streaming_buffer_t*> competing_buffers;
+  competing_buffers.reserve(reserved_capacity - 1);
+  for (size_t i = 0; i < reserved_capacity - 1; ++i) {
+    auto* buffer =
+        CreateDummyBuffer(0x200000000ULL + i * 0x10000, 4096, allocator);
+    competing_buffers.push_back(buffer);
+    IREE_ASSERT_OK(iree_hal_streaming_buffer_table_insert(table, buffer));
+  }
+  EXPECT_EQ(table->capacity, reserved_capacity);
+  EXPECT_EQ(table->reserved_insert_count, 1u);
+
+  IREE_EXPECT_OK(
+      iree_hal_streaming_buffer_table_insert_reserved(table, removed_buffer));
+  EXPECT_EQ(table->capacity, reserved_capacity);
+  EXPECT_EQ(table->count, reserved_capacity);
+  EXPECT_EQ(table->reserved_insert_count, 0u);
+
+  iree_hal_streaming_buffer_t* found = nullptr;
+  IREE_EXPECT_OK(iree_hal_streaming_buffer_table_lookup(
+      table, removed_buffer->device_ptr, &found));
+  EXPECT_EQ(found, removed_buffer);
+
+  iree_hal_streaming_buffer_table_free(table);
+  FreeDummyBuffer(removed_buffer, allocator);
+  for (auto* buffer : competing_buffers) {
+    FreeDummyBuffer(buffer, allocator);
+  }
 }
 
 TEST(BufferTableTest, MixedOperations) {

--- a/libhrx/src/binding/common/context.c
+++ b/libhrx/src/binding/common/context.c
@@ -78,6 +78,7 @@ iree_status_t iree_hal_streaming_context_create(
   context->peer_capacity = 0;
   memset(&context->symbol_map, 0, sizeof(context->symbol_map));
   memset(&context->buffer_table, 0, sizeof(context->buffer_table));
+  context->pending_free_head = NULL;
   context->pageable_h2d_staging_buffer = NULL;
   context->pageable_h2d_staging_size = 0;
   iree_atomic_store(&context->capture_stream_count, 0,
@@ -85,6 +86,7 @@ iree_status_t iree_hal_streaming_context_create(
   context->host_allocator = host_allocator;
   iree_slim_mutex_initialize(&context->mutex);
   iree_slim_mutex_initialize(&context->direct_transfer_mutex);
+  iree_slim_mutex_initialize(&context->pending_free_mutex);
 
   // Initialize global list pointers.
   context->context_list_entry.next = NULL;
@@ -168,7 +170,16 @@ static void iree_hal_streaming_context_destroy(
 
   // Synchronize all streams before detaching them from the context; pending
   // command buffers require the context/device to flush correctly.
-  iree_status_ignore(iree_hal_streaming_context_synchronize(context));
+  iree_status_t status = iree_hal_streaming_context_synchronize(context);
+  if (!iree_status_is_ok(status)) {
+    iree_status_fprint(stderr, status);
+    iree_status_free(status);
+  }
+  status = iree_hal_streaming_memory_release_terminal_async_frees(context);
+  if (!iree_status_is_ok(status)) {
+    iree_status_fprint(stderr, status);
+    iree_status_free(status);
+  }
 
   iree_hal_streaming_memory_release_pageable_staging(context);
 
@@ -178,6 +189,10 @@ static void iree_hal_streaming_context_destroy(
 
   // Deinitialize buffer mapping table.
   hrx_buffer_table_deinitialize(&context->buffer_table);
+  IREE_ASSERT(context->pending_free_head == NULL,
+              "pending asynchronous frees must be drained before context "
+              "destruction");
+  iree_slim_mutex_deinitialize(&context->pending_free_mutex);
 
   // Release default stream.
   // This releases the context's reference but not the list's reference.

--- a/libhrx/src/binding/common/context.c
+++ b/libhrx/src/binding/common/context.c
@@ -84,6 +84,7 @@ iree_status_t iree_hal_streaming_context_create(
                     iree_memory_order_relaxed);
   context->host_allocator = host_allocator;
   iree_slim_mutex_initialize(&context->mutex);
+  iree_slim_mutex_initialize(&context->direct_transfer_mutex);
 
   // Initialize global list pointers.
   context->context_list_entry.next = NULL;
@@ -210,6 +211,7 @@ static void iree_hal_streaming_context_destroy(
   iree_hal_device_release(context->device);
 
   // Deinitialize synchronization.
+  iree_slim_mutex_deinitialize(&context->direct_transfer_mutex);
   iree_slim_mutex_deinitialize(&context->mutex);
 
   // Free context memory.

--- a/libhrx/src/binding/common/device.c
+++ b/libhrx/src/binding/common/device.c
@@ -166,7 +166,8 @@ iree_status_t iree_hal_streaming_device_memory_info(
   iree_hal_streaming_device_t* device = NULL;
   iree_status_t status = iree_hal_streaming_device_by_ordinal(ordinal, &device);
   if (iree_status_is_ok(status)) {
-    *out_free_memory = device->free_memory;
+    *out_free_memory = (iree_device_size_t)iree_atomic_load(
+        &device->free_memory, iree_memory_order_relaxed);
     *out_total_memory = device->total_memory;
   }
   return status;
@@ -303,61 +304,63 @@ iree_status_t iree_hal_streaming_device_ensure_default_mem_pool(
   return status;
 }
 
+// Requires |device->primary_context_mutex| to be held. The context and its
+// default allocation pool become visible together so callers never observe a
+// context that cannot service runtime allocations.
+static iree_status_t iree_hal_streaming_device_create_primary_context_locked(
+    iree_hal_streaming_device_t* device) {
+  IREE_ASSERT_ARGUMENT(device);
+  if (device->primary_context) {
+    return iree_hal_streaming_device_ensure_default_mem_pool_locked(device);
+  }
+
+  iree_hal_streaming_device_registry_t* device_registry =
+      iree_hal_streaming_device_registry();
+  if (!device_registry) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "device registry not initialized");
+  }
+
+  const bool had_default_mem_pool = device->default_mem_pool != NULL;
+  const bool had_current_mem_pool = device->current_mem_pool != NULL;
+  iree_hal_streaming_context_t* context = NULL;
+  iree_status_t status = iree_hal_streaming_context_create(
+      device, device->primary_context_flags, device_registry->host_allocator,
+      &context);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_device_ensure_default_mem_pool_locked(device);
+  }
+  if (iree_status_is_ok(status)) {
+    device->primary_context = context;
+    return iree_ok_status();
+  }
+
+  iree_hal_streaming_context_release(context);
+  if (!had_current_mem_pool) {
+    hrx_mem_pool_release(device->current_mem_pool);
+    device->current_mem_pool = NULL;
+  }
+  if (!had_default_mem_pool) {
+    hrx_mem_pool_release(device->default_mem_pool);
+    device->default_mem_pool = NULL;
+  }
+  return status;
+}
+
 iree_status_t iree_hal_streaming_device_get_or_create_primary_context(
     iree_hal_streaming_device_t* device,
     iree_hal_streaming_context_t** out_context) {
   IREE_ASSERT_ARGUMENT(device);
   IREE_ASSERT_ARGUMENT(out_context);
   IREE_TRACE_ZONE_BEGIN(z0);
+  *out_context = NULL;
 
-  // Fast path: context already exists.
-  if (device->primary_context) {
-    *out_context = device->primary_context;
-    IREE_TRACE_ZONE_END(z0);
-    return iree_ok_status();
-  }
-
-  // Slow path: need to create the context (with mutex protection).
   iree_slim_mutex_lock(&device->primary_context_mutex);
-
-  // Double-check inside the lock - another thread may have created it.
-  if (device->primary_context) {
-    *out_context = device->primary_context;
-    iree_slim_mutex_unlock(&device->primary_context_mutex);
-    IREE_TRACE_ZONE_END(z0);
-    return iree_ok_status();
-  }
-
-  // Create the primary context.
-  iree_hal_streaming_device_registry_t* device_registry =
-      iree_hal_streaming_device_registry();
-  if (!device_registry) {
-    iree_slim_mutex_unlock(&device->primary_context_mutex);
-    IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                             "device registry not initialized"));
-  }
-
-  iree_status_t status = iree_hal_streaming_context_create(
-      device, device->primary_context_flags, device_registry->host_allocator,
-      &device->primary_context);
-
-  // Ensure runtime allocations have a backing pool for this device.
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_streaming_device_ensure_default_mem_pool_locked(device);
-  }
-
+  iree_status_t status =
+      iree_hal_streaming_device_create_primary_context_locked(device);
   if (iree_status_is_ok(status)) {
     *out_context = device->primary_context;
-  } else {
-    iree_hal_streaming_context_release(device->primary_context);
-    device->primary_context = NULL;
-    hrx_mem_pool_release(device->current_mem_pool);
-    device->current_mem_pool = NULL;
-    hrx_mem_pool_release(device->default_mem_pool);
-    device->default_mem_pool = NULL;
   }
-
   iree_slim_mutex_unlock(&device->primary_context_mutex);
   IREE_TRACE_ZONE_END(z0);
   return status;
@@ -369,50 +372,28 @@ iree_status_t iree_hal_streaming_device_retain_primary_context(
   IREE_ASSERT_ARGUMENT(device);
   IREE_ASSERT_ARGUMENT(out_context);
   IREE_TRACE_ZONE_BEGIN(z0);
+  *out_context = NULL;
 
   iree_slim_mutex_lock(&device->primary_context_mutex);
 
-  // Increment reference count.
-  device->primary_context_ref_count++;
-
-  // If this is the first retain (count went from 0 to 1), create the context.
-  if (device->primary_context_ref_count == 1 && !device->primary_context) {
-    iree_hal_streaming_device_registry_t* device_registry =
-        iree_hal_streaming_device_registry();
-    if (!device_registry) {
-      device->primary_context_ref_count--;
-      iree_slim_mutex_unlock(&device->primary_context_mutex);
-      IREE_RETURN_AND_END_ZONE_IF_ERROR(
-          z0, iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                               "device registry not initialized"));
-    }
-
-    iree_status_t status = iree_hal_streaming_context_create(
-        device, device->primary_context_flags, device_registry->host_allocator,
-        &device->primary_context);
-
-    // Ensure runtime allocations have a backing pool for this device.
+  iree_status_t status = iree_ok_status();
+  if (device->primary_context_ref_count == INT32_MAX) {
+    status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                              "primary context reference count overflow");
+  } else {
+    ++device->primary_context_ref_count;
+    status = iree_hal_streaming_device_create_primary_context_locked(device);
     if (iree_status_is_ok(status)) {
-      status = iree_hal_streaming_device_ensure_default_mem_pool_locked(device);
-    }
-
-    if (!iree_status_is_ok(status)) {
-      // Creation failed - decrement ref count back to 0.
-      device->primary_context_ref_count--;
-      iree_hal_streaming_context_release(device->primary_context);
-      device->primary_context = NULL;
-      iree_slim_mutex_unlock(&device->primary_context_mutex);
-      IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, status);
+      iree_hal_streaming_context_retain(device->primary_context);
+      *out_context = device->primary_context;
+    } else {
+      --device->primary_context_ref_count;
     }
   }
 
-  // Retain the context for the caller.
-  iree_hal_streaming_context_retain(device->primary_context);
-  *out_context = device->primary_context;
-
   iree_slim_mutex_unlock(&device->primary_context_mutex);
   IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
+  return status;
 }
 
 iree_status_t iree_hal_streaming_device_release_primary_context(

--- a/libhrx/src/binding/common/direct_transfer.c
+++ b/libhrx/src/binding/common/direct_transfer.c
@@ -1,0 +1,75 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/direct_transfer.h"
+
+#include "common/internal.h"
+#include "iree/hal/buffer_transfer.h"
+
+// Direct HAL transfers may use backend-owned staging resources that are not
+// safe to drive concurrently. Keep serialization and chunking in one place so
+// callers cannot accidentally bypass the context-wide transfer contract.
+#define IREE_HAL_STREAMING_DIRECT_H2D_CHUNK_SIZE (63 * 1024)
+#define IREE_HAL_STREAMING_DIRECT_D2H_CHUNK_SIZE (4 * 1024 * 1024)
+
+iree_status_t iree_hal_streaming_direct_transfer_h2d(
+    iree_hal_streaming_context_t* context, const void* source,
+    iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
+    iree_device_size_t length) {
+  IREE_ASSERT_ARGUMENT(context);
+  IREE_ASSERT_ARGUMENT(source || length == 0);
+  IREE_ASSERT_ARGUMENT(target_buffer);
+  if (IREE_UNLIKELY(length > IREE_HOST_SIZE_MAX)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "direct H2D transfer exceeds host address range");
+  }
+
+  const uint8_t* source_bytes = (const uint8_t*)source;
+  iree_device_size_t transferred = 0;
+  iree_status_t status = iree_ok_status();
+  iree_slim_mutex_lock(&context->direct_transfer_mutex);
+  while (transferred < length && iree_status_is_ok(status)) {
+    const iree_device_size_t chunk_length =
+        iree_min(length - transferred,
+                 (iree_device_size_t)IREE_HAL_STREAMING_DIRECT_H2D_CHUNK_SIZE);
+    status = iree_hal_device_transfer_h2d(
+        context->device, source_bytes + (iree_host_size_t)transferred,
+        target_buffer, target_offset + transferred, chunk_length,
+        IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout());
+    transferred += chunk_length;
+  }
+  iree_slim_mutex_unlock(&context->direct_transfer_mutex);
+  return status;
+}
+
+iree_status_t iree_hal_streaming_direct_transfer_d2h(
+    iree_hal_streaming_context_t* context, iree_hal_buffer_t* source_buffer,
+    iree_device_size_t source_offset, void* target, iree_device_size_t length) {
+  IREE_ASSERT_ARGUMENT(context);
+  IREE_ASSERT_ARGUMENT(source_buffer);
+  IREE_ASSERT_ARGUMENT(target || length == 0);
+  if (IREE_UNLIKELY(length > IREE_HOST_SIZE_MAX)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "direct D2H transfer exceeds host address range");
+  }
+
+  uint8_t* target_bytes = (uint8_t*)target;
+  iree_device_size_t transferred = 0;
+  iree_status_t status = iree_ok_status();
+  iree_slim_mutex_lock(&context->direct_transfer_mutex);
+  while (transferred < length && iree_status_is_ok(status)) {
+    const iree_device_size_t chunk_length =
+        iree_min(length - transferred,
+                 (iree_device_size_t)IREE_HAL_STREAMING_DIRECT_D2H_CHUNK_SIZE);
+    status = iree_hal_device_transfer_d2h(
+        context->device, source_buffer, source_offset + transferred,
+        target_bytes + (iree_host_size_t)transferred, chunk_length,
+        IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout());
+    transferred += chunk_length;
+  }
+  iree_slim_mutex_unlock(&context->direct_transfer_mutex);
+  return status;
+}

--- a/libhrx/src/binding/common/direct_transfer.c
+++ b/libhrx/src/binding/common/direct_transfer.c
@@ -26,6 +26,8 @@ iree_status_t iree_hal_streaming_direct_transfer_h2d(
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "direct H2D transfer exceeds host address range");
   }
+  IREE_RETURN_IF_ERROR(
+      iree_hal_buffer_validate_range(target_buffer, target_offset, length));
 
   const uint8_t* source_bytes = (const uint8_t*)source;
   iree_device_size_t transferred = 0;
@@ -55,6 +57,8 @@ iree_status_t iree_hal_streaming_direct_transfer_d2h(
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "direct D2H transfer exceeds host address range");
   }
+  IREE_RETURN_IF_ERROR(
+      iree_hal_buffer_validate_range(source_buffer, source_offset, length));
 
   uint8_t* target_bytes = (uint8_t*)target;
   iree_device_size_t transferred = 0;

--- a/libhrx/src/binding/common/direct_transfer.h
+++ b/libhrx/src/binding/common/direct_transfer.h
@@ -1,0 +1,38 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_STREAMING_DIRECT_TRANSFER_H_
+#define IREE_HAL_STREAMING_DIRECT_TRANSFER_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct iree_hal_streaming_context_t iree_hal_streaming_context_t;
+
+// Performs a blocking host-to-device transfer serialized against other direct
+// transfers issued through |context|'s internal staging and managed-global
+// paths. Cross-context and direct device-to-device copies use other paths.
+iree_status_t iree_hal_streaming_direct_transfer_h2d(
+    iree_hal_streaming_context_t* context, const void* source,
+    iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
+    iree_device_size_t length);
+
+// Performs a blocking device-to-host transfer serialized against other direct
+// transfers issued through |context|'s internal staging and managed-global
+// paths. Cross-context and direct device-to-device copies use other paths.
+iree_status_t iree_hal_streaming_direct_transfer_d2h(
+    iree_hal_streaming_context_t* context, iree_hal_buffer_t* source_buffer,
+    iree_device_size_t source_offset, void* target, iree_device_size_t length);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_STREAMING_DIRECT_TRANSFER_H_

--- a/libhrx/src/binding/common/graph.c
+++ b/libhrx/src/binding/common/graph.c
@@ -8,6 +8,7 @@
 
 #include "common/internal.h"
 #include "common/kernel_arguments.h"
+#include "common/memory.h"
 
 //===----------------------------------------------------------------------===//
 // iree_hal_streaming_graph_t (template)
@@ -166,9 +167,8 @@ iree_status_t iree_hal_streaming_graph_allocate_host_staging(
 
   iree_hal_streaming_buffer_t* buffer = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_streaming_memory_allocate_host(
-              graph->context, size,
-              IREE_HAL_STREAMING_HOST_REGISTER_FLAG_DEFAULT, &buffer));
+      z0, iree_hal_streaming_memory_allocate_host_staging(graph->context, size,
+                                                          &buffer));
 
   iree_hal_streaming_graph_owned_host_allocation_t* owned_allocation = NULL;
   iree_status_t status = iree_arena_allocate(

--- a/libhrx/src/binding/common/graph_exec.c
+++ b/libhrx/src/binding/common/graph_exec.c
@@ -1484,6 +1484,28 @@ static bool iree_hal_streaming_graph_node_has_recorded_dependency_hazard(
   return false;
 }
 
+static iree_status_t iree_hal_streaming_graph_record_dependency_barrier(
+    iree_hal_command_buffer_t* command_buffer) {
+  // A dependency orders both command execution and memory visibility. Graph
+  // nodes can alternate between dispatches and transfers, so make writes from
+  // either operation class available to reads by either class.
+  static const iree_hal_memory_barrier_t memory_barrier = {
+      .source_scope = IREE_HAL_ACCESS_SCOPE_DISPATCH_READ |
+                      IREE_HAL_ACCESS_SCOPE_DISPATCH_WRITE |
+                      IREE_HAL_ACCESS_SCOPE_TRANSFER_READ |
+                      IREE_HAL_ACCESS_SCOPE_TRANSFER_WRITE,
+      .target_scope = IREE_HAL_ACCESS_SCOPE_DISPATCH_READ |
+                      IREE_HAL_ACCESS_SCOPE_DISPATCH_WRITE |
+                      IREE_HAL_ACCESS_SCOPE_TRANSFER_READ |
+                      IREE_HAL_ACCESS_SCOPE_TRANSFER_WRITE,
+  };
+  return iree_hal_command_buffer_execution_barrier(
+      command_buffer,
+      IREE_HAL_EXECUTION_STAGE_DISPATCH | IREE_HAL_EXECUTION_STAGE_TRANSFER,
+      IREE_HAL_EXECUTION_STAGE_DISPATCH | IREE_HAL_EXECUTION_STAGE_TRANSFER,
+      IREE_HAL_EXECUTION_BARRIER_FLAG_NONE, 1, &memory_barrier, 0, NULL);
+}
+
 // Helper to record nodes from a partition into a command buffer.
 static iree_status_t iree_hal_streaming_graph_record_partition(
     iree_hal_streaming_graph_exec_t* exec,
@@ -1534,10 +1556,8 @@ static iree_status_t iree_hal_streaming_graph_record_partition(
               node, additional_edges, node_index_map, &barrier_index_set);
       if (preserve_sorted_order || has_dependency_hazard) {
         IREE_RETURN_AND_END_ZONE_IF_ERROR(
-            z0, iree_hal_command_buffer_execution_barrier(
-                    command_buffer, IREE_HAL_EXECUTION_STAGE_COMMAND_RETIRE,
-                    IREE_HAL_EXECUTION_STAGE_COMMAND_ISSUE,
-                    IREE_HAL_EXECUTION_BARRIER_FLAG_NONE, 0, NULL, 0, NULL));
+            z0,
+            iree_hal_streaming_graph_record_dependency_barrier(command_buffer));
         iree_hal_streaming_node_index_set_reset(&barrier_index_set);
       }
     }

--- a/libhrx/src/binding/common/init.c
+++ b/libhrx/src/binding/common/init.c
@@ -110,7 +110,8 @@ static iree_status_t iree_hal_streaming_query_device_info(
                             "iree_device_size_t range");
   }
   device->total_memory = (iree_device_size_t)total_memory;
-  device->free_memory = device->total_memory;
+  iree_atomic_store(&device->free_memory, device->total_memory,
+                    iree_memory_order_relaxed);
 
   const iree_hal_device_spec_t* device_spec =
       iree_hal_device_spec(device->hal_device);

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -29,6 +29,8 @@ typedef struct iree_hal_streaming_context_module_entry_t
     iree_hal_streaming_context_module_entry_t;
 typedef struct iree_hal_streaming_context_symbol_map_t
     iree_hal_streaming_context_symbol_map_t;
+typedef struct iree_hal_streaming_deferred_device_free_t
+    iree_hal_streaming_deferred_device_free_t;
 typedef struct iree_hal_streaming_device_t iree_hal_streaming_device_t;
 typedef struct iree_hal_streaming_device_registry_t
     iree_hal_streaming_device_registry_t;
@@ -219,6 +221,13 @@ struct iree_hal_streaming_context_t {
 
   // Buffer mapping table (pyre unified implementation).
   hrx_buffer_table_t buffer_table;
+
+  // Stream-ordered frees available for dependency-aware reuse in this context.
+  // Protected by |pending_free_mutex|.
+  iree_hal_streaming_deferred_device_free_t* pending_free_head;
+
+  // Serializes access to |pending_free_head| and terminal free callbacks.
+  iree_slim_mutex_t pending_free_mutex;
 
   // Cached host-visible staging buffer for blocking pageable H2D transfers.
   // Guarded by |mutex| and released during context destruction.
@@ -1800,6 +1809,11 @@ iree_status_t iree_hal_streaming_memory_free_device_async(
 // Synchronization: stream (requires |stream| to be idle).
 iree_status_t iree_hal_streaming_memory_release_completed_async_frees(
     iree_hal_streaming_stream_t* stream);
+
+// Releases every terminal stream-ordered free owned by |context|.
+// Synchronization: all context streams have reached terminal queue state.
+iree_status_t iree_hal_streaming_memory_release_terminal_async_frees(
+    iree_hal_streaming_context_t* context);
 
 // Releases completed stream-ordered frees retained by |pool|.
 // Synchronization: none (each free has reached its queued host callback).

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -1796,14 +1796,14 @@ iree_status_t iree_hal_streaming_memory_free_device_async(
     iree_hal_streaming_context_t* context, iree_hal_streaming_deviceptr_t ptr,
     iree_hal_streaming_stream_t* stream);
 
-// Releases completed stream-ordered frees cached for reuse on |stream|.
+// Releases completed stream-ordered frees retained for conservative reuse.
 // Synchronization: stream (requires |stream| to be idle).
-void iree_hal_streaming_memory_release_completed_async_frees(
+iree_status_t iree_hal_streaming_memory_release_completed_async_frees(
     iree_hal_streaming_stream_t* stream);
 
-// Releases completed stream-ordered frees cached for reuse by |pool|.
+// Releases completed stream-ordered frees retained by |pool|.
 // Synchronization: none (each free has reached its queued host callback).
-void iree_hal_streaming_memory_release_completed_async_frees_from_pool(
+iree_status_t iree_hal_streaming_memory_release_completed_async_frees_from_pool(
     hrx_mem_pool_t pool);
 
 // Synchronization: none (allocates host memory).

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -233,6 +233,8 @@ struct iree_hal_streaming_context_t {
 
   // Synchronization.
   iree_slim_mutex_t mutex;
+  // Serializes direct HAL device transfer calls issued outside command buffers.
+  iree_slim_mutex_t direct_transfer_mutex;
 
   // Host allocator.
   iree_allocator_t host_allocator;
@@ -321,8 +323,8 @@ typedef struct iree_hal_streaming_device_t {
   uint32_t compute_capability_minor;
   // Total HIP-visible memory reported for the device.
   iree_device_size_t total_memory;
-  // Approximate HIP-visible free memory tracked by the binding.
-  iree_device_size_t free_memory;
+  // Approximate HIP-visible free memory tracked atomically by the binding.
+  iree_atomic_uint64_t free_memory;
   // True when cooperative launches are supported by the device.
   bool supports_cooperative_launch;
 
@@ -351,10 +353,10 @@ typedef struct iree_hal_streaming_device_t {
   // Primary context flags.
   iree_hal_streaming_context_flags_t primary_context_flags;
 
-  // Primary context mutex for thread-safe lazy initialization.
+  // Serializes primary-context publication and allocation-pool selection.
   iree_slim_mutex_t primary_context_mutex;
 
-  // Primary context (lazily created on first access).
+  // Fully initialized primary context, published under primary_context_mutex.
   iree_hal_streaming_context_t* primary_context;
 
   // Primary context reference count.
@@ -363,9 +365,9 @@ typedef struct iree_hal_streaming_device_t {
   // Protected by primary_context_mutex.
   int32_t primary_context_ref_count;
 
-  // Default device allocation pool used when no explicit pool is selected.
+  // Default device allocation pool, protected by primary_context_mutex.
   hrx_mem_pool_t default_mem_pool;
-  // Current device allocation pool used by HIP runtime allocation APIs.
+  // Current device allocation pool, protected by primary_context_mutex.
   hrx_mem_pool_t current_mem_pool;
 
   // Guards graph-memory accounting fields.
@@ -454,6 +456,14 @@ typedef enum iree_hal_streaming_capture_dependencies_mode_e {
   IREE_HAL_STREAMING_CAPTURE_DEPENDENCIES_ADD = 1,
 } iree_hal_streaming_capture_dependencies_mode_t;
 
+// A source-stream timeline point that orders all later work on a stream.
+typedef struct iree_hal_streaming_memory_reuse_dependency_t {
+  // Stable identifier of the source stream that recorded the event.
+  unsigned long long source_stream_id;
+  // Source timeline value the event is known to follow.
+  uint64_t source_timeline_value;
+} iree_hal_streaming_memory_reuse_dependency_t;
+
 // Stream for asynchronous execution.
 typedef struct iree_hal_streaming_stream_t {
   // Reference counting.
@@ -496,6 +506,13 @@ typedef struct iree_hal_streaming_stream_t {
   iree_hal_streaming_event_t** recorded_events;
   iree_host_size_t event_count;
   iree_host_size_t event_capacity;
+
+  // Event dependencies that establish safe cross-stream allocation reuse.
+  iree_hal_streaming_memory_reuse_dependency_t* memory_reuse_dependencies;
+  // Number of valid entries in |memory_reuse_dependencies|.
+  iree_host_size_t memory_reuse_dependency_count;
+  // Allocated entry capacity of |memory_reuse_dependencies|.
+  iree_host_size_t memory_reuse_dependency_capacity;
 
   // Stream capture state.
   iree_hal_streaming_capture_status_t capture_status;
@@ -739,6 +756,8 @@ typedef enum iree_hal_streaming_host_register_flag_bits_e {
   IREE_HAL_STREAMING_HOST_REGISTER_FLAG_WRITE_COMBINED = 1ull << 2,
   // Read-only from device.
   IREE_HAL_STREAMING_HOST_REGISTER_FLAG_READ_ONLY = 1ull << 3,
+  // HIP signal-memory allocation freed through hipFree.
+  IREE_HAL_STREAMING_HOST_REGISTER_FLAG_HIP_SIGNAL_MEMORY = 1ull << 27,
   // HIP uncached host allocation flag.
   IREE_HAL_STREAMING_HOST_REGISTER_FLAG_HIP_UNCACHED = 1ull << 28,
   // HIP NUMA-user host allocation flag.
@@ -805,6 +824,9 @@ typedef struct iree_hal_streaming_buffer_t {
 
   // HRX memory pool retained while |buffer| may borrow its HAL pool.
   hrx_mem_pool_t allocation_pool;
+
+  // True while this pool-backed buffer contributes to logical pool usage.
+  bool is_pool_allocation_live;
 
   // Platform-specific memory type.
   int memory_type;
@@ -1298,7 +1320,7 @@ iree_status_t iree_hal_streaming_device_primary_context_state(
 
 // Gets or creates the primary context for a device (thread-safe).
 // This performs lazy initialization of the primary context on first access.
-// Synchronization: none (thread-safe creation with internal locking).
+// Synchronization: thread-safe (serializes initialization and publication).
 iree_status_t iree_hal_streaming_device_get_or_create_primary_context(
     iree_hal_streaming_device_t* device,
     iree_hal_streaming_context_t** out_context);
@@ -1306,7 +1328,7 @@ iree_status_t iree_hal_streaming_device_get_or_create_primary_context(
 // Retains the primary context, creating it if necessary.
 // Increments device-level reference count.
 // Returns the retained context.
-// Synchronization: none (protected by internal mutex).
+// Synchronization: thread-safe (serializes initialization and retention).
 iree_status_t iree_hal_streaming_device_retain_primary_context(
     iree_hal_streaming_device_t* device,
     iree_hal_streaming_context_t** out_context);
@@ -1610,6 +1632,12 @@ iree_status_t iree_hal_streaming_stream_wait_submitted(
 iree_status_t iree_hal_streaming_stream_wait_event(
     iree_hal_streaming_stream_t* stream, iree_hal_streaming_event_t* event);
 
+// Returns whether work on |stream| is ordered after |source_timeline_value|
+// from the stream identified by |source_stream_id|.
+bool iree_hal_streaming_stream_has_memory_reuse_dependency(
+    iree_hal_streaming_stream_t* stream, unsigned long long source_stream_id,
+    uint64_t source_timeline_value);
+
 //===----------------------------------------------------------------------===//
 // Execution control
 //===----------------------------------------------------------------------===//
@@ -1694,6 +1722,7 @@ typedef enum iree_hal_streaming_memory_flag_bits_e {
   IREE_HAL_STREAMING_MEMORY_FLAG_PINNED = 1ull << 0,
   IREE_HAL_STREAMING_MEMORY_FLAG_PORTABLE = 1ull << 1,
   IREE_HAL_STREAMING_MEMORY_FLAG_WRITE_COMBINED = 1ull << 2,
+  IREE_HAL_STREAMING_MEMORY_FLAG_UNCACHED = 1ull << 3,
 } iree_hal_streaming_memory_flags_t;
 
 // Synchronization: none (returns pointer value).
@@ -1740,6 +1769,17 @@ iree_status_t iree_hal_streaming_memory_allocate_device_from_pool(
     iree_device_size_t size, iree_hal_streaming_memory_flags_t flags,
     iree_hal_streaming_buffer_t** out_buffer);
 
+// Synchronization: stream-ordered. Reuses a pending same-stream free when
+// possible and otherwise allocates memory from |pool|.
+iree_status_t iree_hal_streaming_memory_allocate_device_from_pool_async(
+    iree_hal_streaming_context_t* context, hrx_mem_pool_t pool,
+    iree_device_size_t size, iree_hal_streaming_memory_flags_t flags,
+    iree_hal_streaming_stream_t* stream,
+    iree_hal_streaming_buffer_t** out_buffer);
+
+// Row pitch alignment used by HIP pitched allocations.
+#define IREE_HAL_STREAMING_PITCHED_ALLOCATION_ALIGNMENT 256u
+
 // Synchronization: none (allocates pitched memory).
 iree_status_t iree_hal_streaming_memory_allocate_device_pitched(
     iree_hal_streaming_context_t* context, iree_device_size_t width_bytes,
@@ -1755,6 +1795,16 @@ iree_status_t iree_hal_streaming_memory_free_device(
 iree_status_t iree_hal_streaming_memory_free_device_async(
     iree_hal_streaming_context_t* context, iree_hal_streaming_deviceptr_t ptr,
     iree_hal_streaming_stream_t* stream);
+
+// Releases completed stream-ordered frees cached for reuse on |stream|.
+// Synchronization: stream (requires |stream| to be idle).
+void iree_hal_streaming_memory_release_completed_async_frees(
+    iree_hal_streaming_stream_t* stream);
+
+// Releases completed stream-ordered frees cached for reuse by |pool|.
+// Synchronization: none (each free has reached its queued host callback).
+void iree_hal_streaming_memory_release_completed_async_frees_from_pool(
+    hrx_mem_pool_t pool);
 
 // Synchronization: none (allocates host memory).
 iree_status_t iree_hal_streaming_memory_allocate_host(
@@ -1843,6 +1893,16 @@ iree_status_t iree_hal_streaming_memcpy_device_to_host(
     iree_hal_streaming_deviceptr_t src, iree_device_size_t size,
     iree_hal_streaming_stream_t* stream);
 
+// Enqueues a pitched D2H copy through queue-visible staging. A stream-ordered
+// host call scatters the packed staging rows into |dst| after the device copies
+// complete.
+// Synchronization: stream-ordered.
+iree_status_t iree_hal_streaming_memcpy_device_to_host_2d(
+    iree_hal_streaming_context_t* context, void* dst,
+    iree_device_size_t dst_pitch, iree_hal_streaming_deviceptr_t src,
+    iree_device_size_t src_pitch, iree_device_size_t width,
+    iree_host_size_t height, iree_hal_streaming_stream_t* stream);
+
 // Synchronization: stream or blocking (async if stream, sync if NULL stream).
 iree_status_t iree_hal_streaming_memcpy_device_to_device(
     iree_hal_streaming_context_t* context, iree_hal_streaming_deviceptr_t dst,
@@ -1876,14 +1936,28 @@ typedef enum iree_hal_streaming_mem_location_type_e {
 } iree_hal_streaming_mem_location_type_t;
 
 // Device pool accessors.
+// Returns a device-owned pool handle that remains valid while selected.
 hrx_mem_pool_t iree_hal_streaming_device_default_mem_pool(
     iree_hal_streaming_device_t* device);
+// Returns a device-owned pool handle that remains valid while selected.
 hrx_mem_pool_t iree_hal_streaming_device_mem_pool(
+    iree_hal_streaming_device_t* device);
+// Retains the selected pool for use outside the device lock. The caller must
+// release the returned handle with hrx_mem_pool_release.
+hrx_mem_pool_t iree_hal_streaming_device_retain_mem_pool(
+    iree_hal_streaming_device_t* device);
+// Retains the device default pool for use outside the device lock. The caller
+// must release the returned handle with hrx_mem_pool_release.
+hrx_mem_pool_t iree_hal_streaming_device_retain_default_mem_pool(
     iree_hal_streaming_device_t* device);
 iree_status_t iree_hal_streaming_device_ensure_default_mem_pool(
     iree_hal_streaming_device_t* device);
+// Replaces the selected pool while preserving any in-flight pool users.
 void iree_hal_streaming_device_set_mem_pool(iree_hal_streaming_device_t* device,
                                             hrx_mem_pool_t pool);
+// Restores the default pool only when |pool| is the selected pool.
+void iree_hal_streaming_device_reset_mem_pool_if_current(
+    iree_hal_streaming_device_t* device, hrx_mem_pool_t pool);
 
 //===----------------------------------------------------------------------===//
 // Graph management

--- a/libhrx/src/binding/common/mem_pool.c
+++ b/libhrx/src/binding/common/mem_pool.c
@@ -16,23 +16,73 @@
 hrx_mem_pool_t iree_hal_streaming_device_default_mem_pool(
     iree_hal_streaming_device_t* device) {
   IREE_ASSERT_ARGUMENT(device);
-  return device->default_mem_pool;
+  iree_slim_mutex_lock(&device->primary_context_mutex);
+  hrx_mem_pool_t pool = device->default_mem_pool;
+  iree_slim_mutex_unlock(&device->primary_context_mutex);
+  return pool;
 }
 
 hrx_mem_pool_t iree_hal_streaming_device_mem_pool(
     iree_hal_streaming_device_t* device) {
   IREE_ASSERT_ARGUMENT(device);
-  return device->current_mem_pool;
+  iree_slim_mutex_lock(&device->primary_context_mutex);
+  hrx_mem_pool_t pool = device->current_mem_pool;
+  iree_slim_mutex_unlock(&device->primary_context_mutex);
+  return pool;
+}
+
+hrx_mem_pool_t iree_hal_streaming_device_retain_mem_pool(
+    iree_hal_streaming_device_t* device) {
+  IREE_ASSERT_ARGUMENT(device);
+  iree_slim_mutex_lock(&device->primary_context_mutex);
+  hrx_mem_pool_t pool = device->current_mem_pool;
+  if (!pool) {
+    pool = device->default_mem_pool;
+  }
+  hrx_mem_pool_retain(pool);
+  iree_slim_mutex_unlock(&device->primary_context_mutex);
+  return pool;
+}
+
+hrx_mem_pool_t iree_hal_streaming_device_retain_default_mem_pool(
+    iree_hal_streaming_device_t* device) {
+  IREE_ASSERT_ARGUMENT(device);
+  iree_slim_mutex_lock(&device->primary_context_mutex);
+  hrx_mem_pool_t pool = device->default_mem_pool;
+  hrx_mem_pool_retain(pool);
+  iree_slim_mutex_unlock(&device->primary_context_mutex);
+  return pool;
 }
 
 void iree_hal_streaming_device_set_mem_pool(iree_hal_streaming_device_t* device,
                                             hrx_mem_pool_t pool) {
   IREE_ASSERT_ARGUMENT(device);
 
-  hrx_mem_pool_release(device->current_mem_pool);
-
+  // Retain before publishing so the new selection remains valid even if its
+  // caller releases its handle immediately after this API returns.
+  hrx_mem_pool_retain(pool);
+  iree_slim_mutex_lock(&device->primary_context_mutex);
+  hrx_mem_pool_t previous_pool = device->current_mem_pool;
   device->current_mem_pool = pool;
-  if (pool) {
-    hrx_mem_pool_retain(pool);
+  iree_slim_mutex_unlock(&device->primary_context_mutex);
+  hrx_mem_pool_release(previous_pool);
+}
+
+void iree_hal_streaming_device_reset_mem_pool_if_current(
+    iree_hal_streaming_device_t* device, hrx_mem_pool_t pool) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_ASSERT_ARGUMENT(pool);
+
+  iree_slim_mutex_lock(&device->primary_context_mutex);
+  hrx_mem_pool_t previous_pool = device->current_mem_pool;
+  if (previous_pool != pool || previous_pool == device->default_mem_pool) {
+    iree_slim_mutex_unlock(&device->primary_context_mutex);
+    return;
   }
+
+  hrx_mem_pool_t default_pool = device->default_mem_pool;
+  hrx_mem_pool_retain(default_pool);
+  device->current_mem_pool = default_pool;
+  iree_slim_mutex_unlock(&device->primary_context_mutex);
+  hrx_mem_pool_release(previous_pool);
 }

--- a/libhrx/src/binding/common/memory.c
+++ b/libhrx/src/binding/common/memory.c
@@ -1993,6 +1993,10 @@ static iree_status_t iree_hal_streaming_enqueue_buffer_copy(
 }
 
 typedef struct iree_hal_streaming_host_d2h_staging_t {
+  // Resource retained while the staging completion is pending in a HAL queue.
+  iree_hal_resource_t resource;
+  // Allocator used to release this staging operation.
+  iree_allocator_t host_allocator;
   // User host destination pointer populated after the stream D2H completes.
   void* dst;
   // Byte distance between consecutive destination rows.
@@ -2004,6 +2008,20 @@ typedef struct iree_hal_streaming_host_d2h_staging_t {
   // Number of rows copied from staging into the destination.
   iree_host_size_t height;
 } iree_hal_streaming_host_d2h_staging_t;
+
+static void iree_hal_streaming_host_d2h_staging_destroy(
+    iree_hal_resource_t* base_resource) {
+  iree_hal_streaming_host_d2h_staging_t* copy =
+      (iree_hal_streaming_host_d2h_staging_t*)base_resource;
+  iree_hal_streaming_temporary_host_buffer_free(copy->staging->context,
+                                                copy->staging);
+  iree_allocator_free(copy->host_allocator, copy);
+}
+
+static const iree_hal_resource_vtable_t
+    iree_hal_streaming_host_d2h_staging_vtable = {
+        .destroy = iree_hal_streaming_host_d2h_staging_destroy,
+};
 
 static void iree_hal_streaming_host_d2h_staging_scatter_rows(
     void* dst, iree_device_size_t dst_pitch, const void* src,
@@ -2025,9 +2043,6 @@ static iree_status_t iree_hal_streaming_host_d2h_staging_call(
   iree_hal_streaming_host_d2h_staging_scatter_rows(copy->dst, copy->dst_pitch,
                                                    copy->staging->host_ptr,
                                                    copy->width, copy->height);
-  iree_hal_streaming_temporary_host_buffer_free(copy->staging->context,
-                                                copy->staging);
-  iree_allocator_free(iree_allocator_system(), copy);
   return iree_ok_status();
 }
 
@@ -2050,11 +2065,14 @@ static iree_status_t iree_hal_streaming_enqueue_host_d2h_staging_copy(
     }
     iree_hal_streaming_temporary_host_buffer_free(staging->context, staging);
     if (iree_status_is_ok(sync_status)) {
-      iree_status_ignore(status);
+      iree_status_free(status);
       return iree_ok_status();
     }
     return iree_status_join(status, sync_status);
   }
+  iree_hal_resource_initialize(&iree_hal_streaming_host_d2h_staging_vtable,
+                               &copy->resource);
+  copy->host_allocator = iree_allocator_system();
   copy->dst = dst;
   copy->dst_pitch = dst_pitch;
   copy->staging = staging;
@@ -2062,8 +2080,8 @@ static iree_status_t iree_hal_streaming_enqueue_host_d2h_staging_copy(
   copy->height = height;
 
   uint64_t args[4] = {0, 0, 0, 0};
-  iree_hal_host_call_t call =
-      iree_hal_make_host_call(iree_hal_streaming_host_d2h_staging_call, copy);
+  iree_hal_host_call_t call = iree_hal_make_host_call_with_resource(
+      iree_hal_streaming_host_d2h_staging_call, copy, &copy->resource);
   status = iree_hal_streaming_queue_host_call(stream, call, args,
                                               IREE_HAL_HOST_CALL_FLAG_NONE);
   if (!iree_status_is_ok(status)) {
@@ -2072,16 +2090,17 @@ static iree_status_t iree_hal_streaming_enqueue_host_d2h_staging_copy(
       iree_hal_streaming_host_d2h_staging_scatter_rows(
           dst, dst_pitch, staging->host_ptr, width, height);
     }
-    iree_hal_streaming_temporary_host_buffer_free(staging->context, staging);
-    iree_allocator_free(iree_allocator_system(), copy);
+    iree_hal_resource_release(&copy->resource);
     if (iree_status_is_ok(sync_status)) {
-      iree_status_ignore(status);
+      iree_status_free(status);
       return iree_ok_status();
     }
     return iree_status_join(status, sync_status);
   }
+  iree_hal_resource_release(&copy->resource);
   return iree_ok_status();
 }
+
 static iree_status_t iree_hal_streaming_enqueue_host_update(
     iree_hal_streaming_stream_t* stream, const void* src,
     iree_hal_streaming_buffer_ref_t dst_ref, iree_device_size_t size) {

--- a/libhrx/src/binding/common/memory.c
+++ b/libhrx/src/binding/common/memory.c
@@ -613,10 +613,10 @@ iree_status_t iree_hal_streaming_memory_allocate_device_from_pool(
   return status;
 }
 
-typedef struct iree_hal_streaming_deferred_device_free_t {
-  // Next pending async free in the process-wide reuse registry.
-  struct iree_hal_streaming_deferred_device_free_t* next;
-  // Context retained while the detached allocation is pending release.
+struct iree_hal_streaming_deferred_device_free_t {
+  // Next pending async free in the owning context's reuse registry.
+  iree_hal_streaming_deferred_device_free_t* next;
+  // Context owning the registry and allocation bookkeeping.
   iree_hal_streaming_context_t* owner_context;
   // Stable identifier of the stream that orders this logical free.
   unsigned long long source_stream_id;
@@ -624,36 +624,36 @@ typedef struct iree_hal_streaming_deferred_device_free_t {
   uint64_t completion_value;
   // Detached allocation wrapper to release on the stream timeline.
   iree_hal_streaming_buffer_t* buffer;
-  // True while this operation is visible in the pending-free registry.
+  // True while this operation is visible in |owner_context|'s registry.
   bool is_registered;
-  // True after the source stream has completed the free operation.
+  // True when the host call ran after all stream prerequisites completed.
   bool is_ready;
-  // True when completion occurred before publication and permits immediate
-  // opportunistic release once publication completes.
-  bool release_on_registration;
+  // True after the queue has released its terminal resource reference.
+  bool is_terminal;
   // True when a later stream-ordered allocation adopted |buffer|.
   bool is_reused;
-} iree_hal_streaming_deferred_device_free_t;
+  // Reuse policy captured when the free is enqueued.
+  bool allow_opportunistic;
+};
 
-static iree_once_flag iree_hal_streaming_pending_free_mutex_once =
-    IREE_ONCE_FLAG_INIT;
-static iree_slim_mutex_t iree_hal_streaming_pending_free_mutex;
-static iree_hal_streaming_deferred_device_free_t*
-    iree_hal_streaming_pending_free_head = NULL;
+typedef struct iree_hal_streaming_pending_free_terminal_t {
+  // Resource retained by the accepted host call until callback completion or
+  // cancellation. It transitively owns the operation's context retain.
+  iree_hal_resource_t resource;
+  // Context-owned operation notified when the queued call becomes terminal.
+  iree_hal_streaming_deferred_device_free_t* free_op;
+} iree_hal_streaming_pending_free_terminal_t;
 
-static void iree_hal_streaming_pending_free_mutex_initialize(void) {
-  iree_slim_mutex_initialize(&iree_hal_streaming_pending_free_mutex);
-}
+static void iree_hal_streaming_pending_free_terminal_destroy(
+    iree_hal_resource_t* resource);
 
-static void iree_hal_streaming_pending_free_lock(void) {
-  iree_call_once(&iree_hal_streaming_pending_free_mutex_once,
-                 iree_hal_streaming_pending_free_mutex_initialize);
-  iree_slim_mutex_lock(&iree_hal_streaming_pending_free_mutex);
-}
+static const iree_hal_resource_vtable_t
+    iree_hal_streaming_pending_free_terminal_vtable = {
+        .destroy = iree_hal_streaming_pending_free_terminal_destroy,
+};
 
 static void iree_hal_streaming_pending_free_destroy(
     iree_hal_streaming_deferred_device_free_t* free_op) {
-  iree_hal_streaming_context_release(free_op->owner_context);
   iree_allocator_free(iree_allocator_system(), free_op);
 }
 
@@ -683,9 +683,10 @@ static iree_status_t iree_hal_streaming_pending_free_release_buffer(
 }
 
 static void iree_hal_streaming_pending_free_remove_locked(
+    iree_hal_streaming_context_t* context,
     iree_hal_streaming_deferred_device_free_t* free_op) {
   iree_hal_streaming_deferred_device_free_t** current =
-      &iree_hal_streaming_pending_free_head;
+      &context->pending_free_head;
   while (*current && *current != free_op) {
     current = &(*current)->next;
   }
@@ -695,26 +696,52 @@ static void iree_hal_streaming_pending_free_remove_locked(
   free_op->is_registered = false;
 }
 
-static void iree_hal_streaming_pending_free_register(
-    iree_hal_streaming_deferred_device_free_t* free_op) {
-  bool release_buffer = false;
-  iree_hal_streaming_pending_free_lock();
-  if (free_op->is_ready && free_op->release_on_registration) {
-    release_buffer = true;
-  } else {
-    free_op->next = iree_hal_streaming_pending_free_head;
-    iree_hal_streaming_pending_free_head = free_op;
-    free_op->is_registered = true;
+static void iree_hal_streaming_pending_free_terminal_destroy(
+    iree_hal_resource_t* resource) {
+  iree_hal_streaming_pending_free_terminal_t* terminal =
+      (iree_hal_streaming_pending_free_terminal_t*)resource;
+  iree_hal_streaming_deferred_device_free_t* free_op = terminal->free_op;
+  iree_hal_streaming_context_t* context = free_op->owner_context;
+  iree_hal_streaming_buffer_t* buffer = NULL;
+  bool destroy_free_op = false;
+
+  iree_slim_mutex_lock(&context->pending_free_mutex);
+  free_op->is_terminal = true;
+  if (free_op->is_reused) {
+    destroy_free_op = true;
+  } else if (!free_op->is_ready || free_op->allow_opportunistic) {
+    if (free_op->is_registered) {
+      iree_hal_streaming_pending_free_remove_locked(context, free_op);
+    }
+    buffer = free_op->buffer;
+    free_op->buffer = NULL;
+    destroy_free_op = true;
   }
-  iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
-  if (release_buffer) {
-    iree_status_t status = iree_hal_streaming_pending_free_release_buffer(
-        free_op, /*trim_to_release_threshold=*/true);
+  iree_slim_mutex_unlock(&context->pending_free_mutex);
+
+  if (buffer) {
+    iree_status_t status = iree_hal_streaming_buffer_free_and_trim_pool(
+        buffer, /*trim_to_release_threshold=*/true);
     if (!iree_status_is_ok(status)) {
       iree_status_fprint(stderr, status);
       iree_status_free(status);
     }
   }
+  if (destroy_free_op) {
+    iree_hal_streaming_pending_free_destroy(free_op);
+  }
+  iree_allocator_free(iree_allocator_system(), terminal);
+  iree_hal_streaming_context_release(context);
+}
+
+static void iree_hal_streaming_pending_free_register(
+    iree_hal_streaming_deferred_device_free_t* free_op) {
+  iree_hal_streaming_context_t* context = free_op->owner_context;
+  iree_slim_mutex_lock(&context->pending_free_mutex);
+  free_op->next = context->pending_free_head;
+  context->pending_free_head = free_op;
+  free_op->is_registered = true;
+  iree_slim_mutex_unlock(&context->pending_free_mutex);
 }
 
 static iree_status_t iree_hal_streaming_memory_try_reuse_pending_free(
@@ -723,14 +750,14 @@ static iree_status_t iree_hal_streaming_memory_try_reuse_pending_free(
     iree_hal_streaming_buffer_t** out_buffer) {
   *out_buffer = NULL;
 
-  iree_hal_streaming_pending_free_lock();
+  bool destroy_free_op = false;
+  iree_slim_mutex_lock(&context->pending_free_mutex);
   iree_hal_streaming_deferred_device_free_t** current =
-      &iree_hal_streaming_pending_free_head;
+      &context->pending_free_head;
   while (*current) {
     iree_hal_streaming_deferred_device_free_t* free_op = *current;
     iree_hal_streaming_buffer_t* buffer = free_op->buffer;
-    bool can_reuse = free_op->owner_context == context &&
-                     buffer->allocation_pool == pool && buffer->size == size;
+    bool can_reuse = buffer->allocation_pool == pool && buffer->size == size;
     if (can_reuse && free_op->source_stream_id != stream->stream_id) {
       uint64_t follow_event_dependencies = 0;
       uint64_t allow_opportunistic = 0;
@@ -754,23 +781,28 @@ static iree_status_t iree_hal_streaming_memory_try_reuse_pending_free(
           &context->buffer_table, buffer->device_ptr, buffer->host_ptr,
           buffer->size, buffer->hrx_buf, buffer);
       if (!hrx_status_is_ok(insert_status)) {
-        iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
+        iree_slim_mutex_unlock(&context->pending_free_mutex);
         return HRX_CALL(insert_status);
       }
       *current = free_op->next;
       free_op->next = NULL;
       free_op->is_registered = false;
       free_op->is_reused = true;
+      free_op->buffer = NULL;
+      destroy_free_op = free_op->is_terminal;
       iree_hal_streaming_buffer_activate_pool_allocation(buffer);
       iree_hal_streaming_memory_account_device_allocation(context->device_entry,
                                                           buffer->size);
       *out_buffer = buffer;
-      iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
+      iree_slim_mutex_unlock(&context->pending_free_mutex);
+      if (destroy_free_op) {
+        iree_hal_streaming_pending_free_destroy(free_op);
+      }
       return iree_ok_status();
     }
     current = &free_op->next;
   }
-  iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
+  iree_slim_mutex_unlock(&context->pending_free_mutex);
   return iree_ok_status();
 }
 
@@ -1046,50 +1078,18 @@ iree_status_t iree_hal_streaming_memory_free_device(
   return status;
 }
 
-static void iree_hal_streaming_deferred_device_free(void* user_data) {
+static iree_status_t iree_hal_streaming_deferred_device_free(
+    void* user_data, const uint64_t args[4],
+    iree_hal_host_call_context_t* call_context) {
+  (void)args;
+  (void)call_context;
   iree_hal_streaming_deferred_device_free_t* free_op =
       (iree_hal_streaming_deferred_device_free_t*)user_data;
-  hrx_mem_pool_t allocation_pool = free_op->buffer->allocation_pool;
-  // Non-pool allocations have no backing storage available for reuse and can
-  // be released as soon as the stream reaches the free operation.
-  uint64_t allow_opportunistic = allocation_pool ? 0 : 1;
-  if (allocation_pool) {
-    iree_status_t policy_status = HRX_CALL(hrx_mem_pool_get_attribute(
-        allocation_pool, HRX_MEM_POOL_ATTR_REUSE_ALLOW_OPPORTUNISTIC,
-        &allow_opportunistic));
-    if (!iree_status_is_ok(policy_status)) {
-      iree_status_fprint(stderr, policy_status);
-      iree_status_free(policy_status);
-      allow_opportunistic = 0;
-    }
-  }
-
-  bool is_reused = false;
-  bool release_buffer = false;
-  iree_hal_streaming_pending_free_lock();
-  is_reused = free_op->is_reused;
-  if (!is_reused) {
-    free_op->is_ready = true;
-    if (free_op->is_registered && allow_opportunistic != 0) {
-      iree_hal_streaming_pending_free_remove_locked(free_op);
-      release_buffer = true;
-    } else if (!free_op->is_registered) {
-      // The callback may run before the enqueueing thread publishes the
-      // operation. Publication observes this state and performs the release.
-      free_op->release_on_registration = allow_opportunistic != 0;
-    }
-  }
-  iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
-  if (is_reused) {
-    iree_hal_streaming_pending_free_destroy(free_op);
-  } else if (release_buffer) {
-    iree_status_t status = iree_hal_streaming_pending_free_release_buffer(
-        free_op, /*trim_to_release_threshold=*/true);
-    if (!iree_status_is_ok(status)) {
-      iree_status_fprint(stderr, status);
-      iree_status_free(status);
-    }
-  }
+  iree_hal_streaming_context_t* context = free_op->owner_context;
+  iree_slim_mutex_lock(&context->pending_free_mutex);
+  free_op->is_ready = true;
+  iree_slim_mutex_unlock(&context->pending_free_mutex);
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_streaming_pending_free_release_list(
@@ -1109,13 +1109,15 @@ static iree_status_t iree_hal_streaming_pending_free_release_list(
 iree_status_t iree_hal_streaming_memory_release_completed_async_frees(
     iree_hal_streaming_stream_t* stream) {
   iree_hal_streaming_deferred_device_free_t* completed_frees = NULL;
+  iree_hal_streaming_context_t* context = stream->context;
 
-  iree_hal_streaming_pending_free_lock();
+  iree_slim_mutex_lock(&context->pending_free_mutex);
   iree_hal_streaming_deferred_device_free_t** current =
-      &iree_hal_streaming_pending_free_head;
+      &context->pending_free_head;
   while (*current) {
     iree_hal_streaming_deferred_device_free_t* free_op = *current;
-    if (free_op->source_stream_id == stream->stream_id && free_op->is_ready) {
+    if (free_op->source_stream_id == stream->stream_id && free_op->is_ready &&
+        free_op->is_terminal) {
       *current = free_op->next;
       free_op->next = completed_frees;
       free_op->is_registered = false;
@@ -1124,7 +1126,28 @@ iree_status_t iree_hal_streaming_memory_release_completed_async_frees(
       current = &free_op->next;
     }
   }
-  iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
+  iree_slim_mutex_unlock(&context->pending_free_mutex);
+
+  return iree_hal_streaming_pending_free_release_list(
+      completed_frees, /*trim_to_release_threshold=*/true);
+}
+
+iree_status_t iree_hal_streaming_memory_release_terminal_async_frees(
+    iree_hal_streaming_context_t* context) {
+  iree_hal_streaming_deferred_device_free_t* completed_frees = NULL;
+
+  iree_slim_mutex_lock(&context->pending_free_mutex);
+  while (context->pending_free_head) {
+    iree_hal_streaming_deferred_device_free_t* free_op =
+        context->pending_free_head;
+    IREE_ASSERT(free_op->is_terminal,
+                "a nonterminal asynchronous free retained its context");
+    context->pending_free_head = free_op->next;
+    free_op->next = completed_frees;
+    free_op->is_registered = false;
+    completed_frees = free_op;
+  }
+  iree_slim_mutex_unlock(&context->pending_free_mutex);
 
   return iree_hal_streaming_pending_free_release_list(
       completed_frees, /*trim_to_release_threshold=*/true);
@@ -1135,21 +1158,37 @@ iree_status_t iree_hal_streaming_memory_release_completed_async_frees_from_pool(
   if (!pool) return iree_ok_status();
 
   iree_hal_streaming_deferred_device_free_t* completed_frees = NULL;
-  iree_hal_streaming_pending_free_lock();
-  iree_hal_streaming_deferred_device_free_t** current =
-      &iree_hal_streaming_pending_free_head;
-  while (*current) {
-    iree_hal_streaming_deferred_device_free_t* free_op = *current;
-    if (free_op->is_ready && free_op->buffer->allocation_pool == pool) {
-      *current = free_op->next;
-      free_op->next = completed_frees;
-      free_op->is_registered = false;
-      completed_frees = free_op;
-    } else {
-      current = &free_op->next;
-    }
+  iree_hal_streaming_device_registry_t* device_registry =
+      iree_hal_streaming_device_registry();
+  if (!device_registry) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "HAL stream layer not initialized");
   }
-  iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
+
+  // Pool trimming is an explicit cold-path operation. Scan contexts here
+  // instead of imposing a process-wide registry on every allocation.
+  iree_slim_mutex_lock(&device_registry->context_list.mutex);
+  for (iree_hal_streaming_context_t* context =
+           device_registry->context_list.head;
+       context; context = context->context_list_entry.next) {
+    iree_slim_mutex_lock(&context->pending_free_mutex);
+    iree_hal_streaming_deferred_device_free_t** current =
+        &context->pending_free_head;
+    while (*current) {
+      iree_hal_streaming_deferred_device_free_t* free_op = *current;
+      if (free_op->is_ready && free_op->is_terminal && free_op->buffer &&
+          free_op->buffer->allocation_pool == pool) {
+        *current = free_op->next;
+        free_op->next = completed_frees;
+        free_op->is_registered = false;
+        completed_frees = free_op;
+      } else {
+        current = &free_op->next;
+      }
+    }
+    iree_slim_mutex_unlock(&context->pending_free_mutex);
+  }
+  iree_slim_mutex_unlock(&device_registry->context_list.mutex);
 
   return iree_hal_streaming_pending_free_release_list(
       completed_frees, /*trim_to_release_threshold=*/false);
@@ -1177,6 +1216,22 @@ iree_status_t iree_hal_streaming_memory_free_device_async(
         "stream-ordered free cannot be enqueued on a foreign device context");
   }
 
+  // Non-pool allocations have no reusable backing and are retired as soon as
+  // the stream reaches the free. Pool policy is sampled when the operation is
+  // enqueued so terminal cleanup never needs to query a possibly reused
+  // wrapper.
+  uint64_t allow_opportunistic = wrapper->allocation_pool ? 0 : 1;
+  if (wrapper->allocation_pool) {
+    status = HRX_CALL(hrx_mem_pool_get_attribute(
+        wrapper->allocation_pool, HRX_MEM_POOL_ATTR_REUSE_ALLOW_OPPORTUNISTIC,
+        &allow_opportunistic));
+    if (!iree_status_is_ok(status)) {
+      iree_hal_streaming_context_release(owner_context);
+      IREE_TRACE_ZONE_END(z0);
+      return status;
+    }
+  }
+
   iree_hal_streaming_deferred_device_free_t* free_op = NULL;
   status = iree_allocator_malloc(iree_allocator_system(), sizeof(*free_op),
                                  (void**)&free_op);
@@ -1194,14 +1249,29 @@ iree_status_t iree_hal_streaming_memory_free_device_async(
   free_op->next = NULL;
   free_op->is_registered = false;
   free_op->is_ready = false;
-  free_op->release_on_registration = false;
+  free_op->is_terminal = false;
   free_op->is_reused = false;
+  free_op->allow_opportunistic = allow_opportunistic != 0;
+
+  iree_hal_streaming_pending_free_terminal_t* terminal = NULL;
+  status = iree_allocator_malloc(iree_allocator_system(), sizeof(*terminal),
+                                 (void**)&terminal);
+  if (!iree_status_is_ok(status)) {
+    free_op->buffer = NULL;
+    iree_hal_streaming_pending_free_destroy(free_op);
+    iree_hal_streaming_context_release(owner_context);
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
+  iree_hal_resource_initialize(&iree_hal_streaming_pending_free_terminal_vtable,
+                               &terminal->resource);
+  terminal->free_op = free_op;
 
   status =
       HRX_CALL(hrx_buffer_table_reserve_insert(&owner_context->buffer_table));
   if (!iree_status_is_ok(status)) {
-    iree_allocator_free(iree_allocator_system(), free_op);
-    iree_hal_streaming_context_release(owner_context);
+    free_op->buffer = NULL;
+    iree_hal_resource_release(&terminal->resource);
     IREE_TRACE_ZONE_END(z0);
     return status;
   }
@@ -1210,8 +1280,8 @@ iree_status_t iree_hal_streaming_memory_free_device_async(
       &owner_context->buffer_table, wrapper->device_ptr);
   if (!hrx_status_is_ok(remove_status)) {
     hrx_buffer_table_cancel_reserved_insert(&owner_context->buffer_table);
-    iree_allocator_free(iree_allocator_system(), free_op);
-    iree_hal_streaming_context_release(owner_context);
+    free_op->buffer = NULL;
+    iree_hal_resource_release(&terminal->resource);
     IREE_TRACE_ZONE_END(z0);
     return HRX_CALL(remove_status);
   }
@@ -1221,16 +1291,21 @@ iree_status_t iree_hal_streaming_memory_free_device_async(
   // free reaches the host callback.
   iree_hal_streaming_buffer_release_pool_allocation(wrapper);
   iree_hal_streaming_memory_account_device_free(wrapper);
-  status = iree_hal_streaming_launch_host_function(
-      stream, iree_hal_streaming_deferred_device_free, free_op);
+  uint64_t args[4] = {0, 0, 0, 0};
+  iree_hal_host_call_t call = iree_hal_make_host_call_with_resource(
+      iree_hal_streaming_deferred_device_free, free_op, &terminal->resource);
+  status = iree_hal_streaming_queue_host_call(stream, call, args,
+                                              IREE_HAL_HOST_CALL_FLAG_NONE);
   if (iree_status_is_ok(status)) {
     hrx_buffer_table_cancel_reserved_insert(&owner_context->buffer_table);
     iree_slim_mutex_lock(&stream->mutex);
     free_op->completion_value = stream->pending_value;
     iree_slim_mutex_unlock(&stream->mutex);
-    // Publish only after the callback has a stable completion value. If the
-    // callback already ran, publication retires the allocation immediately.
+    // Publish only after the callback has a stable completion value. The
+    // caller's resource reference prevents terminal cleanup from racing this
+    // publication even when the callback executes inline.
     iree_hal_streaming_pending_free_register(free_op);
+    iree_hal_resource_release(&terminal->resource);
   }
   if (!iree_status_is_ok(status)) {
     hrx_status_t insert_status = hrx_buffer_table_insert_reserved(
@@ -1246,8 +1321,8 @@ iree_status_t iree_hal_streaming_memory_free_device_async(
       iree_hal_streaming_memory_account_device_allocation(
           owner_context->device_entry, wrapper->size);
     }
-    iree_allocator_free(iree_allocator_system(), free_op);
-    iree_hal_streaming_context_release(owner_context);
+    free_op->buffer = NULL;
+    iree_hal_resource_release(&terminal->resource);
   }
 
   IREE_TRACE_ZONE_END(z0);

--- a/libhrx/src/binding/common/memory.c
+++ b/libhrx/src/binding/common/memory.c
@@ -4,9 +4,15 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "common/memory.h"
+
+#include "common/direct_transfer.h"
 #include "common/graph.h"
 #include "common/internal.h"
+#include "common/stream.h"
 #include "iree/base/internal/atomics.h"
+#include "iree/base/threading/call_once.h"
+#include "iree/hal/buffer_transfer.h"
 
 //===----------------------------------------------------------------------===//
 // Memory management
@@ -45,6 +51,26 @@ static void iree_hal_streaming_host_memcpy_callback(void* user_data) {
 
 static void iree_hal_streaming_buffer_free(iree_hal_streaming_buffer_t* buffer);
 
+static void iree_hal_streaming_buffer_activate_pool_allocation(
+    iree_hal_streaming_buffer_t* buffer) {
+  if (!buffer || !buffer->allocation_pool || buffer->is_pool_allocation_live) {
+    return;
+  }
+  hrx_mem_pool_record_logical_allocation(buffer->allocation_pool,
+                                         (size_t)buffer->size);
+  buffer->is_pool_allocation_live = true;
+}
+
+static void iree_hal_streaming_buffer_release_pool_allocation(
+    iree_hal_streaming_buffer_t* buffer) {
+  if (!buffer || !buffer->allocation_pool || !buffer->is_pool_allocation_live) {
+    return;
+  }
+  hrx_mem_pool_record_logical_free(buffer->allocation_pool,
+                                   (size_t)buffer->size);
+  buffer->is_pool_allocation_live = false;
+}
+
 static void iree_hal_streaming_memory_account_device_free(
     iree_hal_streaming_buffer_t* buffer) {
   if (!buffer || !buffer->context || !buffer->context->device_entry ||
@@ -52,7 +78,32 @@ static void iree_hal_streaming_memory_account_device_free(
                         IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL)) {
     return;
   }
-  buffer->context->device_entry->free_memory += buffer->size;
+  iree_hal_streaming_device_t* device = buffer->context->device_entry;
+  const uint64_t size = buffer->size;
+  const uint64_t total_memory = device->total_memory;
+  uint64_t observed =
+      iree_atomic_load(&device->free_memory, iree_memory_order_relaxed);
+  uint64_t desired = 0;
+  do {
+    desired = size >= total_memory || observed >= total_memory - size
+                  ? total_memory
+                  : observed + size;
+  } while (!iree_atomic_compare_exchange_weak(
+      &device->free_memory, &observed, desired, iree_memory_order_relaxed,
+      iree_memory_order_relaxed));
+}
+
+static void iree_hal_streaming_memory_account_device_allocation(
+    iree_hal_streaming_device_t* device, iree_device_size_t size) {
+  if (!device) return;
+  uint64_t observed =
+      iree_atomic_load(&device->free_memory, iree_memory_order_relaxed);
+  uint64_t desired = 0;
+  do {
+    desired = observed > size ? observed - size : 0;
+  } while (!iree_atomic_compare_exchange_weak(
+      &device->free_memory, &observed, desired, iree_memory_order_relaxed,
+      iree_memory_order_relaxed));
 }
 
 static void iree_hal_streaming_buffer_set_context(
@@ -108,6 +159,7 @@ static iree_status_t iree_hal_streaming_buffer_wrap_hrx_buffer(
   if (wrapper->allocation_pool) {
     hrx_mem_pool_retain(wrapper->allocation_pool);
   }
+  wrapper->is_pool_allocation_live = false;
   wrapper->memory_type = wrapper->buffer
                              ? (int)iree_hal_buffer_memory_type(wrapper->buffer)
                              : memory_type;
@@ -128,6 +180,7 @@ static iree_status_t iree_hal_streaming_buffer_wrap_hrx_buffer(
   wrapper->ipc_handle = NULL;
   wrapper->size = hrx_buf->size;
   wrapper->logical_size = wrapper->size;
+  iree_hal_streaming_buffer_activate_pool_allocation(wrapper);
 
   // Initialize unified memory attributes.
   wrapper->read_mostly_hint = false;
@@ -266,7 +319,7 @@ static iree_status_t iree_hal_streaming_buffer_wrap(
   return status;
 }
 
-// Frees a buffer wrapper and releases the underlying pyre buffer.
+// Frees a buffer wrapper and releases the underlying HRX buffer.
 static void iree_hal_streaming_buffer_free(
     iree_hal_streaming_buffer_t* buffer) {
   if (!buffer) return;
@@ -306,6 +359,7 @@ static void iree_hal_streaming_buffer_free(
     memset(&buffer->host_mapping, 0, sizeof(buffer->host_mapping));
     buffer->has_host_mapping = false;
   }
+  iree_hal_streaming_buffer_release_pool_allocation(buffer);
   if (buffer->hrx_buf) {
     hrx_buffer_release(buffer->hrx_buf);
     buffer->hrx_buf = NULL;
@@ -470,6 +524,9 @@ iree_status_t iree_hal_streaming_memory_allocate_device(
 
   iree_hal_buffer_usage_t usage = IREE_HAL_BUFFER_USAGE_DEFAULT;
   iree_hal_memory_type_t memory_type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
+  if (iree_any_bit_set(flags, IREE_HAL_STREAMING_MEMORY_FLAG_UNCACHED)) {
+    memory_type |= IREE_HAL_MEMORY_TYPE_DEVICE_UNCACHED;
+  }
   iree_hal_buffer_params_t params = {
       .usage = usage,
       .access = IREE_HAL_MEMORY_ACCESS_ALL,
@@ -496,16 +553,8 @@ iree_status_t iree_hal_streaming_memory_allocate_device(
 
   if (iree_status_is_ok(status)) {
     *out_buffer = wrapper;
-    // Update free memory tracking.
-    if (context->device_entry) {
-      // Use atomic or lock if needed for thread safety, but for now
-      // we match the pattern used in free.
-      if (context->device_entry->free_memory >= size) {
-        context->device_entry->free_memory -= size;
-      } else {
-        context->device_entry->free_memory = 0;
-      }
-    }
+    iree_hal_streaming_memory_account_device_allocation(context->device_entry,
+                                                        size);
   } else {
     iree_hal_streaming_buffer_free(wrapper);
   }
@@ -522,7 +571,12 @@ iree_status_t iree_hal_streaming_memory_allocate_device_from_pool(
   *out_buffer = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  (void)flags;
+  if (iree_any_bit_set(flags, IREE_HAL_STREAMING_MEMORY_FLAG_UNCACHED)) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "memory-pool allocations cannot satisfy uncached device memory");
+  }
   iree_hal_buffer_params_t params = {
       .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
       .access = IREE_HAL_MEMORY_ACCESS_ALL,
@@ -550,16 +604,135 @@ iree_status_t iree_hal_streaming_memory_allocate_device_from_pool(
 
   if (iree_status_is_ok(status)) {
     *out_buffer = wrapper;
-    if (context->device_entry) {
-      if (context->device_entry->free_memory >= size) {
-        context->device_entry->free_memory -= size;
-      } else {
-        context->device_entry->free_memory = 0;
-      }
-    }
+    iree_hal_streaming_memory_account_device_allocation(context->device_entry,
+                                                        size);
   }
   IREE_TRACE_ZONE_END(z0);
   return status;
+}
+
+typedef struct iree_hal_streaming_deferred_device_free_t {
+  // Next pending async free in the process-wide reuse registry.
+  struct iree_hal_streaming_deferred_device_free_t* next;
+  // Context retained while the detached allocation is pending release.
+  iree_hal_streaming_context_t* owner_context;
+  // Stable identifier of the stream that orders this logical free.
+  unsigned long long source_stream_id;
+  // Timeline value reached after this free's host completion callback.
+  uint64_t completion_value;
+  // Detached allocation wrapper to release on the stream timeline.
+  iree_hal_streaming_buffer_t* buffer;
+  // True after the source stream has completed the free operation.
+  bool is_ready;
+  // True when a later stream-ordered allocation adopted |buffer|.
+  bool is_reused;
+} iree_hal_streaming_deferred_device_free_t;
+
+static iree_once_flag iree_hal_streaming_pending_free_mutex_once =
+    IREE_ONCE_FLAG_INIT;
+static iree_slim_mutex_t iree_hal_streaming_pending_free_mutex;
+static iree_hal_streaming_deferred_device_free_t*
+    iree_hal_streaming_pending_free_head = NULL;
+
+static void iree_hal_streaming_pending_free_mutex_initialize(void) {
+  iree_slim_mutex_initialize(&iree_hal_streaming_pending_free_mutex);
+}
+
+static void iree_hal_streaming_pending_free_lock(void) {
+  iree_call_once(&iree_hal_streaming_pending_free_mutex_once,
+                 iree_hal_streaming_pending_free_mutex_initialize);
+  iree_slim_mutex_lock(&iree_hal_streaming_pending_free_mutex);
+}
+
+static void iree_hal_streaming_pending_free_register(
+    iree_hal_streaming_deferred_device_free_t* free_op) {
+  iree_hal_streaming_pending_free_lock();
+  free_op->next = iree_hal_streaming_pending_free_head;
+  iree_hal_streaming_pending_free_head = free_op;
+  iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
+}
+
+static void iree_hal_streaming_pending_free_destroy(
+    iree_hal_streaming_deferred_device_free_t* free_op) {
+  iree_hal_streaming_context_release(free_op->owner_context);
+  iree_allocator_free(iree_allocator_system(), free_op);
+}
+
+static iree_status_t iree_hal_streaming_memory_try_reuse_pending_free(
+    iree_hal_streaming_context_t* context, hrx_mem_pool_t pool,
+    iree_device_size_t size, iree_hal_streaming_stream_t* stream,
+    iree_hal_streaming_buffer_t** out_buffer) {
+  *out_buffer = NULL;
+
+  iree_hal_streaming_pending_free_lock();
+  iree_hal_streaming_deferred_device_free_t** current =
+      &iree_hal_streaming_pending_free_head;
+  while (*current) {
+    iree_hal_streaming_deferred_device_free_t* free_op = *current;
+    iree_hal_streaming_buffer_t* buffer = free_op->buffer;
+    bool can_reuse = free_op->owner_context == context &&
+                     buffer->allocation_pool == pool && buffer->size == size;
+    if (can_reuse && free_op->source_stream_id != stream->stream_id) {
+      uint64_t follow_event_dependencies = 0;
+      uint64_t allow_opportunistic = 0;
+      const bool has_reuse_policy =
+          hrx_status_is_ok(hrx_mem_pool_get_attribute(
+              pool, HRX_MEM_POOL_ATTR_REUSE_FOLLOW_EVENT_DEPENDENCIES,
+              &follow_event_dependencies)) &&
+          hrx_status_is_ok(hrx_mem_pool_get_attribute(
+              pool, HRX_MEM_POOL_ATTR_REUSE_ALLOW_OPPORTUNISTIC,
+              &allow_opportunistic));
+      can_reuse =
+          has_reuse_policy &&
+          ((follow_event_dependencies != 0 && free_op->completion_value != 0 &&
+            iree_hal_streaming_stream_has_memory_reuse_dependency(
+                stream, free_op->source_stream_id,
+                free_op->completion_value)) ||
+           (allow_opportunistic != 0 && free_op->is_ready));
+    }
+    if (can_reuse) {
+      hrx_status_t insert_status = hrx_buffer_table_insert(
+          &context->buffer_table, buffer->device_ptr, buffer->host_ptr,
+          buffer->size, buffer->hrx_buf, buffer);
+      if (!hrx_status_is_ok(insert_status)) {
+        iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
+        return HRX_CALL(insert_status);
+      }
+      *current = free_op->next;
+      free_op->next = NULL;
+      free_op->is_reused = true;
+      const bool is_ready = free_op->is_ready;
+      iree_hal_streaming_buffer_activate_pool_allocation(buffer);
+      iree_hal_streaming_memory_account_device_allocation(context->device_entry,
+                                                          buffer->size);
+      *out_buffer = buffer;
+      iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
+      if (is_ready) {
+        iree_hal_streaming_pending_free_destroy(free_op);
+      }
+      return iree_ok_status();
+    }
+    current = &free_op->next;
+  }
+  iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_streaming_memory_allocate_device_from_pool_async(
+    iree_hal_streaming_context_t* context, hrx_mem_pool_t pool,
+    iree_device_size_t size, iree_hal_streaming_memory_flags_t flags,
+    iree_hal_streaming_stream_t* stream,
+    iree_hal_streaming_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(context);
+  IREE_ASSERT_ARGUMENT(stream);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  *out_buffer = NULL;
+
+  IREE_RETURN_IF_ERROR(iree_hal_streaming_memory_try_reuse_pending_free(
+      context, pool, size, stream, out_buffer));
+  if (*out_buffer) return iree_ok_status();
+  return iree_hal_streaming_memory_allocate_device_from_pool(
+      context, pool, size, flags, out_buffer);
 }
 
 iree_status_t iree_hal_streaming_memory_allocate_device_pitched(
@@ -802,28 +975,99 @@ iree_status_t iree_hal_streaming_memory_free_device(
   // Update free memory tracking.
   iree_hal_streaming_memory_account_device_free(wrapper);
 
-  // Free wrapper.
+  // Synchronous frees return an entirely idle pool's backing storage to the
+  // allocator. Retain the pool across wrapper destruction because the wrapper
+  // owns the last allocation reference in the common case.
+  hrx_mem_pool_t allocation_pool = wrapper->allocation_pool;
+  hrx_mem_pool_retain(allocation_pool);
   iree_hal_streaming_buffer_free(wrapper);
+  hrx_mem_pool_release_unused(allocation_pool);
+  hrx_mem_pool_release(allocation_pool);
   iree_hal_streaming_context_release(owner_context);
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }
 
-typedef struct iree_hal_streaming_deferred_device_free_t {
-  // Context retained while the detached allocation is pending release.
-  iree_hal_streaming_context_t* owner_context;
-  // Detached allocation wrapper to release on the stream timeline.
-  iree_hal_streaming_buffer_t* buffer;
-} iree_hal_streaming_deferred_device_free_t;
-
 static void iree_hal_streaming_deferred_device_free(void* user_data) {
   iree_hal_streaming_deferred_device_free_t* free_op =
       (iree_hal_streaming_deferred_device_free_t*)user_data;
-  iree_hal_streaming_memory_account_device_free(free_op->buffer);
-  iree_hal_streaming_buffer_free(free_op->buffer);
-  iree_hal_streaming_context_release(free_op->owner_context);
-  iree_allocator_free(iree_allocator_system(), free_op);
+  bool is_reused = false;
+  iree_hal_streaming_pending_free_lock();
+  is_reused = free_op->is_reused;
+  if (!is_reused) {
+    // Keep the wrapper cached after the source stream has reached the free.
+    // A later allocation may safely adopt it on this stream, after an event
+    // dependency, or opportunistically after observing this completion.
+    free_op->is_ready = true;
+  }
+  iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
+  if (is_reused) {
+    iree_hal_streaming_pending_free_destroy(free_op);
+  }
+}
+
+static void iree_hal_streaming_pending_free_release_list(
+    iree_hal_streaming_deferred_device_free_t* completed_frees) {
+  while (completed_frees) {
+    iree_hal_streaming_deferred_device_free_t* free_op = completed_frees;
+    completed_frees = free_op->next;
+
+    // The wrapper may own the final pool reference. Keep the pool alive while
+    // releasing the wrapper, then return its backing storage when every
+    // allocation using the pool has completed on its ordering stream.
+    hrx_mem_pool_t allocation_pool = free_op->buffer->allocation_pool;
+    hrx_mem_pool_retain(allocation_pool);
+    iree_hal_streaming_buffer_free(free_op->buffer);
+    hrx_mem_pool_release_unused(allocation_pool);
+    hrx_mem_pool_release(allocation_pool);
+    iree_hal_streaming_pending_free_destroy(free_op);
+  }
+}
+
+void iree_hal_streaming_memory_release_completed_async_frees(
+    iree_hal_streaming_stream_t* stream) {
+  iree_hal_streaming_deferred_device_free_t* completed_frees = NULL;
+
+  iree_hal_streaming_pending_free_lock();
+  iree_hal_streaming_deferred_device_free_t** current =
+      &iree_hal_streaming_pending_free_head;
+  while (*current) {
+    iree_hal_streaming_deferred_device_free_t* free_op = *current;
+    if (free_op->source_stream_id == stream->stream_id && free_op->is_ready) {
+      *current = free_op->next;
+      free_op->next = completed_frees;
+      completed_frees = free_op;
+    } else {
+      current = &free_op->next;
+    }
+  }
+  iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
+
+  iree_hal_streaming_pending_free_release_list(completed_frees);
+}
+
+void iree_hal_streaming_memory_release_completed_async_frees_from_pool(
+    hrx_mem_pool_t pool) {
+  if (!pool) return;
+
+  iree_hal_streaming_deferred_device_free_t* completed_frees = NULL;
+  iree_hal_streaming_pending_free_lock();
+  iree_hal_streaming_deferred_device_free_t** current =
+      &iree_hal_streaming_pending_free_head;
+  while (*current) {
+    iree_hal_streaming_deferred_device_free_t* free_op = *current;
+    if (free_op->is_ready && free_op->buffer->allocation_pool == pool) {
+      *current = free_op->next;
+      free_op->next = completed_frees;
+      completed_frees = free_op;
+    } else {
+      current = &free_op->next;
+    }
+  }
+  iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
+
+  iree_hal_streaming_pending_free_release_list(completed_frees);
 }
 
 iree_status_t iree_hal_streaming_memory_free_device_async(
@@ -843,7 +1087,9 @@ iree_status_t iree_hal_streaming_memory_free_device_async(
   if (owner_context != stream->context) {
     iree_hal_streaming_context_release(owner_context);
     IREE_TRACE_ZONE_END(z0);
-    return iree_hal_streaming_memory_free_device(context, ptr);
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "stream-ordered free cannot be enqueued on a foreign device context");
   }
 
   iree_hal_streaming_deferred_device_free_t* free_op = NULL;
@@ -855,7 +1101,14 @@ iree_status_t iree_hal_streaming_memory_free_device_async(
     return status;
   }
   free_op->owner_context = owner_context;
+  free_op->source_stream_id = stream->stream_id;
+  // No event can safely reuse this allocation until the host call has been
+  // queued and its stream timeline value is known.
+  free_op->completion_value = UINT64_MAX;
   free_op->buffer = wrapper;
+  free_op->next = NULL;
+  free_op->is_ready = false;
+  free_op->is_reused = false;
 
   const hrx_status_t remove_status = hrx_buffer_table_remove(
       &owner_context->buffer_table, wrapper->device_ptr);
@@ -866,14 +1119,32 @@ iree_status_t iree_hal_streaming_memory_free_device_async(
     return HRX_CALL(remove_status);
   }
 
+  // The allocation becomes unavailable to future streams immediately, but a
+  // later allocation on this stream may adopt its backing before the queued
+  // free reaches the host callback.
+  iree_hal_streaming_buffer_release_pool_allocation(wrapper);
+  iree_hal_streaming_memory_account_device_free(wrapper);
   status = iree_hal_streaming_launch_host_function(
       stream, iree_hal_streaming_deferred_device_free, free_op);
+  if (iree_status_is_ok(status)) {
+    iree_slim_mutex_lock(&stream->mutex);
+    free_op->completion_value = stream->pending_value;
+    iree_slim_mutex_unlock(&stream->mutex);
+    // Publish only after the callback has a stable completion value. The host
+    // callback may run immediately on an idle queue, but it cannot destroy an
+    // unpublished operation; it only marks the operation ready for reuse.
+    iree_hal_streaming_pending_free_register(free_op);
+  }
   if (!iree_status_is_ok(status)) {
     hrx_status_t insert_status = hrx_buffer_table_insert(
         &owner_context->buffer_table, wrapper->device_ptr, wrapper->host_ptr,
         wrapper->size, wrapper->hrx_buf, wrapper);
     if (!hrx_status_is_ok(insert_status)) {
       status = iree_status_join(status, HRX_CALL(insert_status));
+    } else {
+      iree_hal_streaming_buffer_activate_pool_allocation(wrapper);
+      iree_hal_streaming_memory_account_device_allocation(
+          owner_context->device_entry, wrapper->size);
     }
     iree_allocator_free(iree_allocator_system(), free_op);
     iree_hal_streaming_context_release(owner_context);
@@ -924,6 +1195,9 @@ static iree_status_t iree_hal_streaming_memory_allocate_host_with_context_mode(
         IREE_STATUS_UNAVAILABLE,
         "host allocation did not export a host-visible pointer");
   }
+  if (iree_status_is_ok(status)) {
+    memset(wrapper->host_ptr, 0, allocation_size);
+  }
 
   if (iree_status_is_ok(status)) {
     wrapper->imported_host_allocation = false;
@@ -939,12 +1213,91 @@ static iree_status_t iree_hal_streaming_memory_allocate_host_with_context_mode(
   return status;
 }
 
+static iree_status_t
+iree_hal_streaming_memory_allocate_owned_host_import_with_context_mode(
+    iree_hal_streaming_context_t* context, iree_host_size_t size,
+    iree_hal_streaming_host_register_flags_t flags,
+    iree_hal_buffer_usage_t usage, iree_device_size_t min_alignment,
+    iree_hal_streaming_buffer_context_ownership_t context_ownership,
+    iree_hal_streaming_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(context);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  *out_buffer = NULL;
+
+  const iree_host_size_t allocation_size = iree_max(size, (iree_host_size_t)8);
+  const iree_host_size_t host_alignment =
+      iree_max((iree_host_size_t)min_alignment, (iree_host_size_t)4096);
+  void* host_ptr = NULL;
+  iree_status_t status = iree_allocator_malloc_aligned(
+      context->host_allocator, allocation_size, host_alignment,
+      /*offset=*/0, &host_ptr);
+
+  iree_hal_buffer_t* buffer = NULL;
+  if (iree_status_is_ok(status)) {
+    iree_hal_buffer_params_t params = {
+        .usage = usage,
+        .access = IREE_HAL_MEMORY_ACCESS_ALL,
+        .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+        .queue_affinity = IREE_HAL_QUEUE_AFFINITY_ANY,
+        .min_alignment = host_alignment,
+    };
+    iree_hal_external_buffer_t external_buffer = {
+        .type = IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION,
+        .flags = IREE_HAL_EXTERNAL_BUFFER_FLAG_NONE,
+        .size = allocation_size,
+        .handle.host_allocation.ptr = host_ptr,
+    };
+    status = iree_hal_allocator_import_buffer(
+        context->device_allocator, params, &external_buffer,
+        iree_hal_buffer_release_callback_null(), &buffer);
+  }
+
+  iree_hal_streaming_buffer_t* wrapper = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_buffer_wrap(
+        context, buffer,
+        (int)(IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+              IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE),
+        host_ptr, /*allocation_pool=*/NULL, context_ownership, &wrapper);
+  }
+  iree_hal_buffer_release(buffer);
+
+  if (iree_status_is_ok(status)) {
+    wrapper->owns_host_ptr = true;
+    wrapper->imported_host_allocation = false;
+    wrapper->host_register_flags = flags;
+    *out_buffer = wrapper;
+    host_ptr = NULL;
+  } else {
+    if (wrapper) {
+      hrx_buffer_table_remove(&context->buffer_table, wrapper->device_ptr);
+      iree_hal_streaming_buffer_free(wrapper);
+    }
+  }
+  iree_allocator_free_aligned(context->host_allocator, host_ptr);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 iree_status_t iree_hal_streaming_memory_allocate_host(
     iree_hal_streaming_context_t* context, iree_host_size_t size,
     iree_hal_streaming_host_register_flags_t flags,
     iree_hal_streaming_buffer_t** out_buffer) {
-  return iree_hal_streaming_memory_allocate_host_with_context_mode(
+  return iree_hal_streaming_memory_allocate_owned_host_import_with_context_mode(
       context, size, flags, IREE_HAL_BUFFER_USAGE_DEFAULT,
+      /*min_alignment=*/64, IREE_HAL_STREAMING_BUFFER_CONTEXT_RETAINED,
+      out_buffer);
+}
+
+iree_status_t iree_hal_streaming_memory_allocate_host_staging(
+    iree_hal_streaming_context_t* context, iree_host_size_t size,
+    iree_hal_streaming_buffer_t** out_buffer) {
+  return iree_hal_streaming_memory_allocate_host_with_context_mode(
+      context, size, IREE_HAL_STREAMING_HOST_REGISTER_FLAG_DEFAULT,
+      IREE_HAL_BUFFER_USAGE_DEFAULT,
       /*min_alignment=*/64, IREE_HAL_STREAMING_BUFFER_CONTEXT_RETAINED,
       out_buffer);
 }
@@ -1024,12 +1377,13 @@ iree_status_t iree_hal_streaming_memory_allocate_managed(
   const iree_host_size_t allocation_size = iree_max(size, (iree_host_size_t)8);
   iree_hal_streaming_buffer_t* buffer = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_streaming_memory_allocate_host_with_context_mode(
-              context, allocation_size,
-              (iree_hal_streaming_host_register_flags_t)allocation_flags,
-              IREE_HAL_BUFFER_USAGE_DEFAULT,
-              /*min_alignment=*/4096,
-              IREE_HAL_STREAMING_BUFFER_CONTEXT_RETAINED, &buffer));
+      z0,
+      iree_hal_streaming_memory_allocate_owned_host_import_with_context_mode(
+          context, allocation_size,
+          (iree_hal_streaming_host_register_flags_t)allocation_flags,
+          IREE_HAL_BUFFER_USAGE_DEFAULT,
+          /*min_alignment=*/4096, IREE_HAL_STREAMING_BUFFER_CONTEXT_RETAINED,
+          &buffer));
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
     buffer->is_managed = true;
@@ -1538,6 +1892,138 @@ static iree_status_t iree_hal_streaming_enqueue_buffer_copy(
   return status;
 }
 
+typedef struct iree_hal_streaming_host_d2h_staging_t {
+  // User host destination pointer populated after the stream D2H completes.
+  void* dst;
+  // Byte distance between consecutive destination rows.
+  iree_device_size_t dst_pitch;
+  // Host staging wrapper containing the completed D2H bytes.
+  iree_hal_streaming_buffer_t* staging;
+  // Number of bytes copied from each source row.
+  iree_device_size_t width;
+  // Number of rows copied from staging into the destination.
+  iree_host_size_t height;
+} iree_hal_streaming_host_d2h_staging_t;
+
+static void iree_hal_streaming_host_d2h_staging_scatter_rows(
+    void* dst, iree_device_size_t dst_pitch, const void* src,
+    iree_device_size_t width, iree_host_size_t height) {
+  uint8_t* dst_ptr = (uint8_t*)dst;
+  const uint8_t* src_ptr = (const uint8_t*)src;
+  for (iree_host_size_t row = 0; row < height; ++row) {
+    memcpy(dst_ptr + row * dst_pitch, src_ptr + row * width, width);
+  }
+}
+
+static iree_status_t iree_hal_streaming_host_d2h_staging_call(
+    void* user_data, const uint64_t args[4],
+    iree_hal_host_call_context_t* call_context) {
+  (void)args;
+  (void)call_context;
+  iree_hal_streaming_host_d2h_staging_t* copy =
+      (iree_hal_streaming_host_d2h_staging_t*)user_data;
+  iree_hal_streaming_host_d2h_staging_scatter_rows(copy->dst, copy->dst_pitch,
+                                                   copy->staging->host_ptr,
+                                                   copy->width, copy->height);
+  iree_hal_streaming_temporary_host_buffer_free(copy->staging->context,
+                                                copy->staging);
+  iree_allocator_free(iree_allocator_system(), copy);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_streaming_enqueue_host_d2h_staging_copy(
+    iree_hal_streaming_stream_t* stream, void* dst,
+    iree_device_size_t dst_pitch, iree_hal_streaming_buffer_t* staging,
+    iree_device_size_t width, iree_host_size_t height) {
+  IREE_ASSERT_ARGUMENT(stream);
+  IREE_ASSERT_ARGUMENT(dst);
+  IREE_ASSERT_ARGUMENT(staging);
+
+  iree_hal_streaming_host_d2h_staging_t* copy = NULL;
+  iree_status_t status = iree_allocator_malloc(iree_allocator_system(),
+                                               sizeof(*copy), (void**)&copy);
+  if (!iree_status_is_ok(status)) {
+    iree_status_t sync_status = iree_hal_streaming_stream_synchronize(stream);
+    if (iree_status_is_ok(sync_status)) {
+      iree_hal_streaming_host_d2h_staging_scatter_rows(
+          dst, dst_pitch, staging->host_ptr, width, height);
+    }
+    iree_hal_streaming_temporary_host_buffer_free(staging->context, staging);
+    if (iree_status_is_ok(sync_status)) {
+      iree_status_ignore(status);
+      return iree_ok_status();
+    }
+    return iree_status_join(status, sync_status);
+  }
+  copy->dst = dst;
+  copy->dst_pitch = dst_pitch;
+  copy->staging = staging;
+  copy->width = width;
+  copy->height = height;
+
+  uint64_t args[4] = {0, 0, 0, 0};
+  iree_hal_host_call_t call =
+      iree_hal_make_host_call(iree_hal_streaming_host_d2h_staging_call, copy);
+  status = iree_hal_streaming_queue_host_call(stream, call, args,
+                                              IREE_HAL_HOST_CALL_FLAG_NONE);
+  if (!iree_status_is_ok(status)) {
+    iree_status_t sync_status = iree_hal_streaming_stream_synchronize(stream);
+    if (iree_status_is_ok(sync_status)) {
+      iree_hal_streaming_host_d2h_staging_scatter_rows(
+          dst, dst_pitch, staging->host_ptr, width, height);
+    }
+    iree_hal_streaming_temporary_host_buffer_free(staging->context, staging);
+    iree_allocator_free(iree_allocator_system(), copy);
+    if (iree_status_is_ok(sync_status)) {
+      iree_status_ignore(status);
+      return iree_ok_status();
+    }
+    return iree_status_join(status, sync_status);
+  }
+  return iree_ok_status();
+}
+static iree_status_t iree_hal_streaming_enqueue_host_update(
+    iree_hal_streaming_stream_t* stream, const void* src,
+    iree_hal_streaming_buffer_ref_t dst_ref, iree_device_size_t size) {
+  IREE_ASSERT_ARGUMENT(stream);
+  IREE_ASSERT_ARGUMENT(src);
+  if (!dst_ref.buffer || !dst_ref.buffer->buffer) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "host update destination is not a device buffer");
+  }
+  iree_device_size_t range_end = 0;
+  if (IREE_UNLIKELY(
+          !iree_device_size_checked_add(dst_ref.offset, size, &range_end) ||
+          range_end > dst_ref.buffer->size)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "host update exceeds destination buffer range");
+  }
+
+  const uint8_t* src_ptr = (const uint8_t*)src;
+  iree_device_size_t remaining = size;
+  iree_device_size_t chunk_offset = 0;
+  iree_slim_mutex_lock(&stream->mutex);
+  iree_status_t status = iree_hal_streaming_stream_begin_locked(stream);
+  while (remaining > 0 && iree_status_is_ok(status)) {
+    const iree_device_size_t this_chunk =
+        remaining < IREE_HAL_COMMAND_BUFFER_MAX_UPDATE_SIZE
+            ? remaining
+            : IREE_HAL_COMMAND_BUFFER_MAX_UPDATE_SIZE;
+    const iree_hal_buffer_ref_t target_ref = iree_hal_make_buffer_ref(
+        dst_ref.buffer->buffer, dst_ref.offset + chunk_offset, this_chunk);
+    status = iree_hal_command_buffer_update_buffer(
+        stream->command_buffer, src_ptr + chunk_offset, 0, target_ref,
+        IREE_HAL_UPDATE_FLAG_NONE);
+    chunk_offset += this_chunk;
+    remaining -= this_chunk;
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_command_buffer_barrier(stream->command_buffer);
+  }
+  iree_slim_mutex_unlock(&stream->mutex);
+  return status;
+}
+
 //===----------------------------------------------------------------------===//
 // Memory copy helper functions
 //===----------------------------------------------------------------------===//
@@ -1615,6 +2101,7 @@ iree_status_t iree_hal_streaming_memcpy_host_to_device(
     return iree_ok_status();
   }
 
+  const iree_device_size_t staging_threshold = 256 * 1024;
   if (stream) {
     iree_hal_streaming_buffer_ref_t src_ref;
     iree_status_t src_status = iree_hal_streaming_memory_lookup(
@@ -1631,11 +2118,16 @@ iree_status_t iree_hal_streaming_memcpy_host_to_device(
       return queue_status;
     }
     iree_status_ignore(src_status);
+    if (size <= staging_threshold) {
+      iree_status_t queue_status =
+          iree_hal_streaming_enqueue_host_update(stream, src, dst_ref, size);
+      IREE_TRACE_ZONE_END(z0);
+      return queue_status;
+    }
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0, iree_hal_streaming_stream_synchronize(stream));
   }
 
-  const iree_device_size_t staging_threshold = 256 * 1024;
   if (size >= staging_threshold) {
     iree_hal_streaming_stream_t* copy_stream =
         stream ? stream : context->default_stream;
@@ -1677,21 +2169,9 @@ iree_status_t iree_hal_streaming_memcpy_host_to_device(
   } else {
     // Small host-to-device transfers are faster through the direct blocking
     // path than paying temporary host-visible allocation overhead.
-    const iree_device_size_t h2d_chunk_size = 63 * 1024;
-    const uint8_t* src_ptr = (const uint8_t*)src;
-    iree_device_size_t remaining = size;
-    iree_device_size_t chunk_offset = 0;
-    while (remaining > 0) {
-      iree_device_size_t this_chunk =
-          remaining < h2d_chunk_size ? remaining : h2d_chunk_size;
-      iree_status_t chunk_status = iree_hal_device_transfer_h2d(
-          context->device, src_ptr + chunk_offset, dst_ref.buffer->buffer,
-          dst_ref.offset + chunk_offset, this_chunk,
-          IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout());
-      IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, chunk_status);
-      chunk_offset += this_chunk;
-      remaining -= this_chunk;
-    }
+    iree_status_t direct_status = iree_hal_streaming_direct_transfer_h2d(
+        context, src, dst_ref.buffer->buffer, dst_ref.offset, size);
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, direct_status);
   }
 
   IREE_TRACE_ZONE_END(z0);
@@ -1783,31 +2263,47 @@ iree_status_t iree_hal_streaming_memcpy_device_to_host(
             IREE_STATUS_INVALID_ARGUMENT,
             "device-to-host destination is not host memory");
       }
-      iree_status_t queue_status = iree_hal_streaming_enqueue_buffer_copy(
-          stream, src_ref, dst_ref, size);
-      IREE_TRACE_ZONE_END(z0);
-      return queue_status;
+    } else {
+      iree_status_ignore(dst_status);
     }
-    iree_status_ignore(dst_status);
-    IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_hal_streaming_stream_synchronize(stream));
+
+    // Host allocations do not necessarily provide the system-scope visibility
+    // required for the CPU to consume a command-buffer D2H result directly.
+    // Copy into runtime-owned host-visible staging and publish the bytes to the
+    // destination in a stream-ordered host call. The callback performs CPU work
+    // only; starting another device transfer there can deadlock queue progress.
+    iree_hal_streaming_buffer_t* staging = NULL;
+    iree_status_t status =
+        iree_hal_streaming_memory_allocate_host_with_context_mode(
+            context, size, IREE_HAL_STREAMING_HOST_REGISTER_FLAG_DEFAULT,
+            IREE_HAL_BUFFER_USAGE_TRANSFER,
+            /*min_alignment=*/64, IREE_HAL_STREAMING_BUFFER_CONTEXT_RETAINED,
+            &staging);
+    if (iree_status_is_ok(status)) {
+      iree_hal_streaming_buffer_ref_t staging_ref = {
+          .buffer = staging,
+          .offset = 0,
+      };
+      status = iree_hal_streaming_enqueue_buffer_copy(stream, src_ref,
+                                                      staging_ref, size);
+    }
+    if (iree_status_is_ok(status)) {
+      iree_hal_streaming_buffer_t* callback_staging = staging;
+      staging = NULL;
+      status = iree_hal_streaming_enqueue_host_d2h_staging_copy(
+          stream, dst, /*dst_pitch=*/size, callback_staging,
+          /*width=*/size, /*height=*/1);
+    }
+    if (staging) {
+      iree_hal_streaming_temporary_host_buffer_free(staging->context, staging);
+    }
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, status);
+    IREE_TRACE_ZONE_END(z0);
+    return iree_ok_status();
   }
 
-  const iree_device_size_t d2h_chunk_size = 4 * 1024 * 1024;
-  uint8_t* dst_ptr = (uint8_t*)dst;
-  iree_device_size_t remaining = size;
-  iree_device_size_t chunk_offset = 0;
-  iree_status_t direct_status = iree_ok_status();
-  while (remaining > 0 && iree_status_is_ok(direct_status)) {
-    iree_device_size_t this_chunk =
-        remaining < d2h_chunk_size ? remaining : d2h_chunk_size;
-    direct_status = iree_hal_device_transfer_d2h(
-        context->device, src_ref.buffer->buffer, src_ref.offset + chunk_offset,
-        dst_ptr + chunk_offset, this_chunk,
-        IREE_HAL_TRANSFER_BUFFER_FLAG_DEFAULT, iree_infinite_timeout());
-    chunk_offset += this_chunk;
-    remaining -= this_chunk;
-  }
+  iree_status_t direct_status = iree_hal_streaming_direct_transfer_d2h(
+      context, src_ref.buffer->buffer, src_ref.offset, dst, size);
   if (iree_status_is_ok(direct_status)) {
     IREE_TRACE_ZONE_END(z0);
     return iree_ok_status();
@@ -1859,6 +2355,143 @@ iree_status_t iree_hal_streaming_memcpy_device_to_host(
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
+}
+
+iree_status_t iree_hal_streaming_memcpy_device_to_host_2d(
+    iree_hal_streaming_context_t* context, void* dst,
+    iree_device_size_t dst_pitch, iree_hal_streaming_deviceptr_t src,
+    iree_device_size_t src_pitch, iree_device_size_t width,
+    iree_host_size_t height, iree_hal_streaming_stream_t* stream) {
+  IREE_ASSERT_ARGUMENT(context);
+  IREE_ASSERT_ARGUMENT(dst);
+  IREE_ASSERT_ARGUMENT(src);
+  IREE_ASSERT_ARGUMENT(stream);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  if (width == 0 || height == 0) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_ok_status();
+  }
+  if (width > dst_pitch || width > src_pitch) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                             "copy width exceeds a row pitch"));
+  }
+  if (IREE_UNLIKELY((iree_host_size_t)(iree_device_size_t)height != height)) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                             "D2H row count exceeds device address space"));
+  }
+  iree_device_size_t destination_span = 0;
+  if (IREE_UNLIKELY(
+          !iree_device_size_checked_mul((iree_device_size_t)(height - 1),
+                                        dst_pitch, &destination_span) ||
+          !iree_device_size_checked_add(destination_span, width,
+                                        &destination_span))) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                             "D2H destination row address overflows"));
+  }
+
+  iree_host_size_t packed_size = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_mul((iree_host_size_t)width, height,
+                                                &packed_size) ||
+                    (iree_device_size_t)packed_size != packed_size)) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                             "packed D2H staging size overflows"));
+  }
+
+  iree_host_size_t source_refs_size = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+          height, sizeof(iree_hal_streaming_buffer_ref_t),
+          &source_refs_size))) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                             "D2H row reference array size overflows"));
+  }
+
+  iree_hal_streaming_buffer_ref_t* source_refs = NULL;
+  iree_status_t status = iree_allocator_malloc(
+      context->host_allocator, source_refs_size, (void**)&source_refs);
+  for (iree_host_size_t row = 0; row < height && iree_status_is_ok(status);
+       ++row) {
+    iree_device_size_t source_offset = 0;
+    iree_hal_streaming_deviceptr_t row_src = 0;
+    if (IREE_UNLIKELY(
+            !iree_device_size_checked_mul((iree_device_size_t)row, src_pitch,
+                                          &source_offset) ||
+            !iree_device_size_checked_add(src, source_offset, &row_src))) {
+      status = iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                                "D2H source row address overflows");
+      break;
+    }
+    status = iree_hal_streaming_memory_lookup_range(context, row_src, width,
+                                                    &source_refs[row]);
+    if (iree_status_is_ok(status) &&
+        (!source_refs[row].buffer || !source_refs[row].buffer->buffer ||
+         iree_any_bit_set(
+             (iree_hal_memory_type_t)source_refs[row].buffer->memory_type,
+             IREE_HAL_MEMORY_TYPE_HOST_LOCAL))) {
+      iree_status_ignore(status);
+      status =
+          iree_make_status(IREE_STATUS_UNAVAILABLE,
+                           "D2H source requires the non-batched transfer path");
+    }
+  }
+
+  iree_hal_streaming_buffer_t* staging = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_streaming_memory_allocate_host_with_context_mode(
+        context, packed_size, IREE_HAL_STREAMING_HOST_REGISTER_FLAG_DEFAULT,
+        IREE_HAL_BUFFER_USAGE_TRANSFER,
+        /*min_alignment=*/64, IREE_HAL_STREAMING_BUFFER_CONTEXT_RETAINED,
+        &staging);
+  }
+
+  if (iree_status_is_ok(status)) {
+    // The rows have independent packed destinations. Record all copies in one
+    // command buffer and add a single completion barrier before the host call.
+    iree_slim_mutex_lock(&stream->mutex);
+    status = iree_hal_streaming_stream_begin_locked(stream);
+    for (iree_host_size_t row = 0; row < height && iree_status_is_ok(status);
+         ++row) {
+      const iree_device_size_t packed_offset = row * width;
+      const iree_hal_buffer_ref_t src_buffer_ref =
+          iree_hal_streaming_convert_range_buffer_ref(source_refs[row], width);
+      const iree_hal_streaming_buffer_ref_t staging_ref = {
+          .buffer = staging,
+          .offset = packed_offset,
+      };
+      const iree_hal_buffer_ref_t dst_buffer_ref =
+          iree_hal_streaming_convert_range_buffer_ref(staging_ref, width);
+      status = iree_hal_command_buffer_copy_buffer(
+          stream->command_buffer, src_buffer_ref, dst_buffer_ref,
+          IREE_HAL_COPY_FLAG_NONE);
+    }
+    if (iree_status_is_ok(status)) {
+      status =
+          iree_hal_streaming_command_buffer_barrier(stream->command_buffer);
+    }
+    iree_slim_mutex_unlock(&stream->mutex);
+  }
+
+  if (iree_status_is_ok(status)) {
+    iree_hal_streaming_buffer_t* callback_staging = staging;
+    staging = NULL;
+    status = iree_hal_streaming_enqueue_host_d2h_staging_copy(
+        stream, dst, dst_pitch, callback_staging, width, height);
+  }
+
+  if (staging) {
+    iree_status_t sync_status = iree_hal_streaming_stream_synchronize(stream);
+    iree_hal_streaming_temporary_host_buffer_free(context, staging);
+    status = iree_status_join(status, sync_status);
+  }
+  iree_allocator_free(context->host_allocator, source_refs);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
 }
 
 iree_status_t iree_hal_streaming_memcpy_device_to_device(

--- a/libhrx/src/binding/common/memory.c
+++ b/libhrx/src/binding/common/memory.c
@@ -6,6 +6,8 @@
 
 #include "common/memory.h"
 
+#include <stdio.h>
+
 #include "common/direct_transfer.h"
 #include "common/graph.h"
 #include "common/internal.h"
@@ -622,8 +624,13 @@ typedef struct iree_hal_streaming_deferred_device_free_t {
   uint64_t completion_value;
   // Detached allocation wrapper to release on the stream timeline.
   iree_hal_streaming_buffer_t* buffer;
+  // True while this operation is visible in the pending-free registry.
+  bool is_registered;
   // True after the source stream has completed the free operation.
   bool is_ready;
+  // True when completion occurred before publication and permits immediate
+  // opportunistic release once publication completes.
+  bool release_on_registration;
   // True when a later stream-ordered allocation adopted |buffer|.
   bool is_reused;
 } iree_hal_streaming_deferred_device_free_t;
@@ -644,18 +651,61 @@ static void iree_hal_streaming_pending_free_lock(void) {
   iree_slim_mutex_lock(&iree_hal_streaming_pending_free_mutex);
 }
 
-static void iree_hal_streaming_pending_free_register(
-    iree_hal_streaming_deferred_device_free_t* free_op) {
-  iree_hal_streaming_pending_free_lock();
-  free_op->next = iree_hal_streaming_pending_free_head;
-  iree_hal_streaming_pending_free_head = free_op;
-  iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
-}
-
 static void iree_hal_streaming_pending_free_destroy(
     iree_hal_streaming_deferred_device_free_t* free_op) {
   iree_hal_streaming_context_release(free_op->owner_context);
   iree_allocator_free(iree_allocator_system(), free_op);
+}
+
+static iree_status_t iree_hal_streaming_pending_free_release_buffer(
+    iree_hal_streaming_deferred_device_free_t* free_op,
+    bool trim_to_release_threshold) {
+  hrx_mem_pool_t allocation_pool = free_op->buffer->allocation_pool;
+  IREE_ASSERT(allocation_pool);
+  hrx_mem_pool_retain(allocation_pool);
+  iree_hal_streaming_buffer_free(free_op->buffer);
+  iree_status_t status =
+      trim_to_release_threshold
+          ? HRX_CALL(hrx_mem_pool_release_unused(allocation_pool))
+          : iree_ok_status();
+  hrx_mem_pool_release(allocation_pool);
+  iree_hal_streaming_pending_free_destroy(free_op);
+  return status;
+}
+
+static void iree_hal_streaming_pending_free_remove_locked(
+    iree_hal_streaming_deferred_device_free_t* free_op) {
+  iree_hal_streaming_deferred_device_free_t** current =
+      &iree_hal_streaming_pending_free_head;
+  while (*current && *current != free_op) {
+    current = &(*current)->next;
+  }
+  IREE_ASSERT(*current == free_op);
+  *current = free_op->next;
+  free_op->next = NULL;
+  free_op->is_registered = false;
+}
+
+static void iree_hal_streaming_pending_free_register(
+    iree_hal_streaming_deferred_device_free_t* free_op) {
+  bool release_buffer = false;
+  iree_hal_streaming_pending_free_lock();
+  if (free_op->is_ready && free_op->release_on_registration) {
+    release_buffer = true;
+  } else {
+    free_op->next = iree_hal_streaming_pending_free_head;
+    iree_hal_streaming_pending_free_head = free_op;
+    free_op->is_registered = true;
+  }
+  iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
+  if (release_buffer) {
+    iree_status_t status = iree_hal_streaming_pending_free_release_buffer(
+        free_op, /*trim_to_release_threshold=*/true);
+    if (!iree_status_is_ok(status)) {
+      iree_status_fprint(stderr, status);
+      iree_status_free(status);
+    }
+  }
 }
 
 static iree_status_t iree_hal_streaming_memory_try_reuse_pending_free(
@@ -700,16 +750,13 @@ static iree_status_t iree_hal_streaming_memory_try_reuse_pending_free(
       }
       *current = free_op->next;
       free_op->next = NULL;
+      free_op->is_registered = false;
       free_op->is_reused = true;
-      const bool is_ready = free_op->is_ready;
       iree_hal_streaming_buffer_activate_pool_allocation(buffer);
       iree_hal_streaming_memory_account_device_allocation(context->device_entry,
                                                           buffer->size);
       *out_buffer = buffer;
       iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
-      if (is_ready) {
-        iree_hal_streaming_pending_free_destroy(free_op);
-      }
       return iree_ok_status();
     }
     current = &free_op->next;
@@ -969,8 +1016,13 @@ iree_status_t iree_hal_streaming_memory_free_device(
     return status;
   }
 
-  // Remove from mapping table.
-  hrx_buffer_table_remove(&owner_context->buffer_table, wrapper->device_ptr);
+  status = HRX_CALL(hrx_buffer_table_remove(&owner_context->buffer_table,
+                                            wrapper->device_ptr));
+  if (!iree_status_is_ok(status)) {
+    iree_hal_streaming_context_release(owner_context);
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
 
   // Update free memory tracking.
   iree_hal_streaming_memory_account_device_free(wrapper);
@@ -981,51 +1033,70 @@ iree_status_t iree_hal_streaming_memory_free_device(
   hrx_mem_pool_t allocation_pool = wrapper->allocation_pool;
   hrx_mem_pool_retain(allocation_pool);
   iree_hal_streaming_buffer_free(wrapper);
-  hrx_mem_pool_release_unused(allocation_pool);
+  status = HRX_CALL(hrx_mem_pool_release_unused(allocation_pool));
   hrx_mem_pool_release(allocation_pool);
   iree_hal_streaming_context_release(owner_context);
 
   IREE_TRACE_ZONE_END(z0);
-  return iree_ok_status();
+  return status;
 }
 
 static void iree_hal_streaming_deferred_device_free(void* user_data) {
   iree_hal_streaming_deferred_device_free_t* free_op =
       (iree_hal_streaming_deferred_device_free_t*)user_data;
+  uint64_t allow_opportunistic = 0;
+  iree_status_t policy_status = HRX_CALL(hrx_mem_pool_get_attribute(
+      free_op->buffer->allocation_pool,
+      HRX_MEM_POOL_ATTR_REUSE_ALLOW_OPPORTUNISTIC, &allow_opportunistic));
+  if (!iree_status_is_ok(policy_status)) {
+    iree_status_fprint(stderr, policy_status);
+    iree_status_free(policy_status);
+    allow_opportunistic = 0;
+  }
+
   bool is_reused = false;
+  bool release_buffer = false;
   iree_hal_streaming_pending_free_lock();
   is_reused = free_op->is_reused;
   if (!is_reused) {
-    // Keep the wrapper cached after the source stream has reached the free.
-    // A later allocation may safely adopt it on this stream, after an event
-    // dependency, or opportunistically after observing this completion.
     free_op->is_ready = true;
+    if (free_op->is_registered && allow_opportunistic != 0) {
+      iree_hal_streaming_pending_free_remove_locked(free_op);
+      release_buffer = true;
+    } else if (!free_op->is_registered) {
+      // The callback may run before the enqueueing thread publishes the
+      // operation. Publication observes this state and performs the release.
+      free_op->release_on_registration = allow_opportunistic != 0;
+    }
   }
   iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
   if (is_reused) {
     iree_hal_streaming_pending_free_destroy(free_op);
+  } else if (release_buffer) {
+    iree_status_t status = iree_hal_streaming_pending_free_release_buffer(
+        free_op, /*trim_to_release_threshold=*/true);
+    if (!iree_status_is_ok(status)) {
+      iree_status_fprint(stderr, status);
+      iree_status_free(status);
+    }
   }
 }
 
-static void iree_hal_streaming_pending_free_release_list(
-    iree_hal_streaming_deferred_device_free_t* completed_frees) {
+static iree_status_t iree_hal_streaming_pending_free_release_list(
+    iree_hal_streaming_deferred_device_free_t* completed_frees,
+    bool trim_to_release_threshold) {
+  iree_status_t status = iree_ok_status();
   while (completed_frees) {
     iree_hal_streaming_deferred_device_free_t* free_op = completed_frees;
     completed_frees = free_op->next;
-
-    // The wrapper may own the final pool reference. Keep the pool alive while
-    // releasing the wrapper, then return its backing storage when every
-    // allocation using the pool has completed on its ordering stream.
-    hrx_mem_pool_t allocation_pool = free_op->buffer->allocation_pool;
-    hrx_mem_pool_retain(allocation_pool);
-    iree_hal_streaming_buffer_free(free_op->buffer);
-    hrx_mem_pool_release_unused(allocation_pool);
-    hrx_mem_pool_release(allocation_pool);
-    iree_hal_streaming_pending_free_destroy(free_op);
+    status =
+        iree_status_join(status, iree_hal_streaming_pending_free_release_buffer(
+                                     free_op, trim_to_release_threshold));
   }
+  return status;
 }
 
-void iree_hal_streaming_memory_release_completed_async_frees(
+iree_status_t iree_hal_streaming_memory_release_completed_async_frees(
     iree_hal_streaming_stream_t* stream) {
   iree_hal_streaming_deferred_device_free_t* completed_frees = NULL;
 
@@ -1037,6 +1108,7 @@ void iree_hal_streaming_memory_release_completed_async_frees(
     if (free_op->source_stream_id == stream->stream_id && free_op->is_ready) {
       *current = free_op->next;
       free_op->next = completed_frees;
+      free_op->is_registered = false;
       completed_frees = free_op;
     } else {
       current = &free_op->next;
@@ -1044,12 +1116,13 @@ void iree_hal_streaming_memory_release_completed_async_frees(
   }
   iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
 
-  iree_hal_streaming_pending_free_release_list(completed_frees);
+  return iree_hal_streaming_pending_free_release_list(
+      completed_frees, /*trim_to_release_threshold=*/true);
 }
 
-void iree_hal_streaming_memory_release_completed_async_frees_from_pool(
+iree_status_t iree_hal_streaming_memory_release_completed_async_frees_from_pool(
     hrx_mem_pool_t pool) {
-  if (!pool) return;
+  if (!pool) return iree_ok_status();
 
   iree_hal_streaming_deferred_device_free_t* completed_frees = NULL;
   iree_hal_streaming_pending_free_lock();
@@ -1060,6 +1133,7 @@ void iree_hal_streaming_memory_release_completed_async_frees_from_pool(
     if (free_op->is_ready && free_op->buffer->allocation_pool == pool) {
       *current = free_op->next;
       free_op->next = completed_frees;
+      free_op->is_registered = false;
       completed_frees = free_op;
     } else {
       current = &free_op->next;
@@ -1067,7 +1141,8 @@ void iree_hal_streaming_memory_release_completed_async_frees_from_pool(
   }
   iree_slim_mutex_unlock(&iree_hal_streaming_pending_free_mutex);
 
-  iree_hal_streaming_pending_free_release_list(completed_frees);
+  return iree_hal_streaming_pending_free_release_list(
+      completed_frees, /*trim_to_release_threshold=*/false);
 }
 
 iree_status_t iree_hal_streaming_memory_free_device_async(
@@ -1107,12 +1182,24 @@ iree_status_t iree_hal_streaming_memory_free_device_async(
   free_op->completion_value = UINT64_MAX;
   free_op->buffer = wrapper;
   free_op->next = NULL;
+  free_op->is_registered = false;
   free_op->is_ready = false;
+  free_op->release_on_registration = false;
   free_op->is_reused = false;
+
+  status =
+      HRX_CALL(hrx_buffer_table_reserve_insert(&owner_context->buffer_table));
+  if (!iree_status_is_ok(status)) {
+    iree_allocator_free(iree_allocator_system(), free_op);
+    iree_hal_streaming_context_release(owner_context);
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
 
   const hrx_status_t remove_status = hrx_buffer_table_remove(
       &owner_context->buffer_table, wrapper->device_ptr);
   if (!hrx_status_is_ok(remove_status)) {
+    hrx_buffer_table_cancel_reserved_insert(&owner_context->buffer_table);
     iree_allocator_free(iree_allocator_system(), free_op);
     iree_hal_streaming_context_release(owner_context);
     IREE_TRACE_ZONE_END(z0);
@@ -1127,20 +1214,26 @@ iree_status_t iree_hal_streaming_memory_free_device_async(
   status = iree_hal_streaming_launch_host_function(
       stream, iree_hal_streaming_deferred_device_free, free_op);
   if (iree_status_is_ok(status)) {
+    hrx_buffer_table_cancel_reserved_insert(&owner_context->buffer_table);
     iree_slim_mutex_lock(&stream->mutex);
     free_op->completion_value = stream->pending_value;
     iree_slim_mutex_unlock(&stream->mutex);
-    // Publish only after the callback has a stable completion value. The host
-    // callback may run immediately on an idle queue, but it cannot destroy an
-    // unpublished operation; it only marks the operation ready for reuse.
+    // Publish only after the callback has a stable completion value. If the
+    // callback already ran, publication retires the allocation immediately.
     iree_hal_streaming_pending_free_register(free_op);
   }
   if (!iree_status_is_ok(status)) {
-    hrx_status_t insert_status = hrx_buffer_table_insert(
+    hrx_status_t insert_status = hrx_buffer_table_insert_reserved(
         &owner_context->buffer_table, wrapper->device_ptr, wrapper->host_ptr,
         wrapper->size, wrapper->hrx_buf, wrapper);
     if (!hrx_status_is_ok(insert_status)) {
       status = iree_status_join(status, HRX_CALL(insert_status));
+      hrx_mem_pool_t allocation_pool = wrapper->allocation_pool;
+      hrx_mem_pool_retain(allocation_pool);
+      iree_hal_streaming_buffer_free(wrapper);
+      status = iree_status_join(
+          status, HRX_CALL(hrx_mem_pool_release_unused(allocation_pool)));
+      hrx_mem_pool_release(allocation_pool);
     } else {
       iree_hal_streaming_buffer_activate_pool_allocation(wrapper);
       iree_hal_streaming_memory_account_device_allocation(

--- a/libhrx/src/binding/common/memory.c
+++ b/libhrx/src/binding/common/memory.c
@@ -657,18 +657,27 @@ static void iree_hal_streaming_pending_free_destroy(
   iree_allocator_free(iree_allocator_system(), free_op);
 }
 
+static iree_status_t iree_hal_streaming_buffer_free_and_trim_pool(
+    iree_hal_streaming_buffer_t* buffer, bool trim_to_release_threshold) {
+  // Pool-backed buffers retain their pool. Preserve it across buffer
+  // destruction so that any now-unused backing storage can be released.
+  hrx_mem_pool_t allocation_pool = buffer->allocation_pool;
+  if (allocation_pool) hrx_mem_pool_retain(allocation_pool);
+  iree_hal_streaming_buffer_free(buffer);
+
+  iree_status_t status = iree_ok_status();
+  if (allocation_pool && trim_to_release_threshold) {
+    status = HRX_CALL(hrx_mem_pool_release_unused(allocation_pool));
+  }
+  hrx_mem_pool_release(allocation_pool);
+  return status;
+}
+
 static iree_status_t iree_hal_streaming_pending_free_release_buffer(
     iree_hal_streaming_deferred_device_free_t* free_op,
     bool trim_to_release_threshold) {
-  hrx_mem_pool_t allocation_pool = free_op->buffer->allocation_pool;
-  IREE_ASSERT(allocation_pool);
-  hrx_mem_pool_retain(allocation_pool);
-  iree_hal_streaming_buffer_free(free_op->buffer);
-  iree_status_t status =
-      trim_to_release_threshold
-          ? HRX_CALL(hrx_mem_pool_release_unused(allocation_pool))
-          : iree_ok_status();
-  hrx_mem_pool_release(allocation_pool);
+  iree_status_t status = iree_hal_streaming_buffer_free_and_trim_pool(
+      free_op->buffer, trim_to_release_threshold);
   iree_hal_streaming_pending_free_destroy(free_op);
   return status;
 }
@@ -1028,13 +1037,9 @@ iree_status_t iree_hal_streaming_memory_free_device(
   iree_hal_streaming_memory_account_device_free(wrapper);
 
   // Synchronous frees return an entirely idle pool's backing storage to the
-  // allocator. Retain the pool across wrapper destruction because the wrapper
-  // owns the last allocation reference in the common case.
-  hrx_mem_pool_t allocation_pool = wrapper->allocation_pool;
-  hrx_mem_pool_retain(allocation_pool);
-  iree_hal_streaming_buffer_free(wrapper);
-  status = HRX_CALL(hrx_mem_pool_release_unused(allocation_pool));
-  hrx_mem_pool_release(allocation_pool);
+  // allocator. Ordinary device allocations have no pool to trim.
+  status = iree_hal_streaming_buffer_free_and_trim_pool(
+      wrapper, /*trim_to_release_threshold=*/true);
   iree_hal_streaming_context_release(owner_context);
 
   IREE_TRACE_ZONE_END(z0);
@@ -1044,14 +1049,19 @@ iree_status_t iree_hal_streaming_memory_free_device(
 static void iree_hal_streaming_deferred_device_free(void* user_data) {
   iree_hal_streaming_deferred_device_free_t* free_op =
       (iree_hal_streaming_deferred_device_free_t*)user_data;
-  uint64_t allow_opportunistic = 0;
-  iree_status_t policy_status = HRX_CALL(hrx_mem_pool_get_attribute(
-      free_op->buffer->allocation_pool,
-      HRX_MEM_POOL_ATTR_REUSE_ALLOW_OPPORTUNISTIC, &allow_opportunistic));
-  if (!iree_status_is_ok(policy_status)) {
-    iree_status_fprint(stderr, policy_status);
-    iree_status_free(policy_status);
-    allow_opportunistic = 0;
+  hrx_mem_pool_t allocation_pool = free_op->buffer->allocation_pool;
+  // Non-pool allocations have no backing storage available for reuse and can
+  // be released as soon as the stream reaches the free operation.
+  uint64_t allow_opportunistic = allocation_pool ? 0 : 1;
+  if (allocation_pool) {
+    iree_status_t policy_status = HRX_CALL(hrx_mem_pool_get_attribute(
+        allocation_pool, HRX_MEM_POOL_ATTR_REUSE_ALLOW_OPPORTUNISTIC,
+        &allow_opportunistic));
+    if (!iree_status_is_ok(policy_status)) {
+      iree_status_fprint(stderr, policy_status);
+      iree_status_free(policy_status);
+      allow_opportunistic = 0;
+    }
   }
 
   bool is_reused = false;
@@ -1228,12 +1238,9 @@ iree_status_t iree_hal_streaming_memory_free_device_async(
         wrapper->size, wrapper->hrx_buf, wrapper);
     if (!hrx_status_is_ok(insert_status)) {
       status = iree_status_join(status, HRX_CALL(insert_status));
-      hrx_mem_pool_t allocation_pool = wrapper->allocation_pool;
-      hrx_mem_pool_retain(allocation_pool);
-      iree_hal_streaming_buffer_free(wrapper);
       status = iree_status_join(
-          status, HRX_CALL(hrx_mem_pool_release_unused(allocation_pool)));
-      hrx_mem_pool_release(allocation_pool);
+          status, iree_hal_streaming_buffer_free_and_trim_pool(
+                      wrapper, /*trim_to_release_threshold=*/true));
     } else {
       iree_hal_streaming_buffer_activate_pool_allocation(wrapper);
       iree_hal_streaming_memory_account_device_allocation(

--- a/libhrx/src/binding/common/memory.h
+++ b/libhrx/src/binding/common/memory.h
@@ -1,0 +1,28 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_EXPERIMENTAL_STREAMING_MEMORY_H_
+#define IREE_EXPERIMENTAL_STREAMING_MEMORY_H_
+
+#include "iree/base/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct iree_hal_streaming_buffer_t iree_hal_streaming_buffer_t;
+typedef struct iree_hal_streaming_context_t iree_hal_streaming_context_t;
+
+// Allocates queue-visible host staging memory.
+iree_status_t iree_hal_streaming_memory_allocate_host_staging(
+    iree_hal_streaming_context_t* context, iree_host_size_t size,
+    iree_hal_streaming_buffer_t** out_buffer);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // IREE_EXPERIMENTAL_STREAMING_MEMORY_H_

--- a/libhrx/src/binding/common/stream.c
+++ b/libhrx/src/binding/common/stream.c
@@ -644,9 +644,8 @@ static iree_status_t iree_hal_streaming_stream_synchronize_impl(
   stream->completed_value = iree_max(stream->completed_value, completed_value);
   iree_slim_mutex_unlock(&stream->mutex);
 
-  // A completed stream can no longer expose its pending frees to a later
-  // stream-ordered allocation, so return any cached backing to the pool.
-  iree_hal_streaming_memory_release_completed_async_frees(stream);
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hal_streaming_memory_release_completed_async_frees(stream));
 
   if (timing_enabled) {
     ++g_hrx_launch_timing.sync_count;

--- a/libhrx/src/binding/common/stream.c
+++ b/libhrx/src/binding/common/stream.c
@@ -182,6 +182,110 @@ static int hrx_direct_queue_dispatch_enabled(void) {
 static void iree_hal_streaming_stream_destroy(
     iree_hal_streaming_stream_t* stream);
 
+static iree_status_t iree_hal_streaming_stream_reserve_memory_reuse_dependency(
+    iree_hal_streaming_stream_t* stream, unsigned long long source_stream_id,
+    bool* out_was_added) {
+  *out_was_added = false;
+  iree_slim_mutex_lock(&stream->mutex);
+  for (iree_host_size_t i = 0; i < stream->memory_reuse_dependency_count; ++i) {
+    if (stream->memory_reuse_dependencies[i].source_stream_id ==
+        source_stream_id) {
+      iree_slim_mutex_unlock(&stream->mutex);
+      return iree_ok_status();
+    }
+  }
+
+  iree_status_t status = iree_ok_status();
+  if (stream->memory_reuse_dependency_count ==
+      stream->memory_reuse_dependency_capacity) {
+    // A stream may wait on many producer streams. Grow geometrically so
+    // recording those dependencies remains amortized constant time.
+    iree_host_size_t new_capacity =
+        stream->memory_reuse_dependency_capacity
+            ? stream->memory_reuse_dependency_capacity
+            : 4;
+    iree_host_size_t allocation_size = 0;
+    if (IREE_UNLIKELY(
+            !iree_host_size_checked_mul(new_capacity, 2, &new_capacity) ||
+            !iree_host_size_checked_mul(
+                new_capacity, sizeof(*stream->memory_reuse_dependencies),
+                &allocation_size))) {
+      status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                "stream dependency count overflow");
+    } else {
+      status =
+          iree_allocator_realloc(stream->host_allocator, allocation_size,
+                                 (void**)&stream->memory_reuse_dependencies);
+      if (iree_status_is_ok(status)) {
+        stream->memory_reuse_dependency_capacity = new_capacity;
+      }
+    }
+  }
+  if (iree_status_is_ok(status)) {
+    stream->memory_reuse_dependencies[stream->memory_reuse_dependency_count++] =
+        (iree_hal_streaming_memory_reuse_dependency_t){
+            .source_stream_id = source_stream_id,
+            .source_timeline_value = 0,
+        };
+    *out_was_added = true;
+  }
+  iree_slim_mutex_unlock(&stream->mutex);
+  return status;
+}
+
+static void iree_hal_streaming_stream_record_memory_reuse_dependency(
+    iree_hal_streaming_stream_t* stream, unsigned long long source_stream_id,
+    uint64_t source_timeline_value) {
+  iree_slim_mutex_lock(&stream->mutex);
+  for (iree_host_size_t i = 0; i < stream->memory_reuse_dependency_count; ++i) {
+    iree_hal_streaming_memory_reuse_dependency_t* dependency =
+        &stream->memory_reuse_dependencies[i];
+    if (dependency->source_stream_id == source_stream_id) {
+      dependency->source_timeline_value =
+          iree_max(dependency->source_timeline_value, source_timeline_value);
+      break;
+    }
+  }
+  iree_slim_mutex_unlock(&stream->mutex);
+}
+
+static void
+iree_hal_streaming_stream_remove_uncommitted_memory_reuse_dependency(
+    iree_hal_streaming_stream_t* stream, unsigned long long source_stream_id) {
+  iree_slim_mutex_lock(&stream->mutex);
+  for (iree_host_size_t i = 0; i < stream->memory_reuse_dependency_count; ++i) {
+    iree_hal_streaming_memory_reuse_dependency_t* dependency =
+        &stream->memory_reuse_dependencies[i];
+    if (dependency->source_stream_id == source_stream_id &&
+        dependency->source_timeline_value == 0) {
+      --stream->memory_reuse_dependency_count;
+      stream->memory_reuse_dependencies[i] =
+          stream->memory_reuse_dependencies
+              [stream->memory_reuse_dependency_count];
+      break;
+    }
+  }
+  iree_slim_mutex_unlock(&stream->mutex);
+}
+
+bool iree_hal_streaming_stream_has_memory_reuse_dependency(
+    iree_hal_streaming_stream_t* stream, unsigned long long source_stream_id,
+    uint64_t source_timeline_value) {
+  bool has_dependency = false;
+  iree_slim_mutex_lock(&stream->mutex);
+  for (iree_host_size_t i = 0; i < stream->memory_reuse_dependency_count; ++i) {
+    const iree_hal_streaming_memory_reuse_dependency_t* dependency =
+        &stream->memory_reuse_dependencies[i];
+    if (dependency->source_stream_id == source_stream_id &&
+        dependency->source_timeline_value >= source_timeline_value) {
+      has_dependency = true;
+      break;
+    }
+  }
+  iree_slim_mutex_unlock(&stream->mutex);
+  return has_dependency;
+}
+
 iree_status_t iree_hal_streaming_stream_create(
     iree_hal_streaming_context_t* context,
     iree_hal_streaming_stream_flags_t flags, int priority,
@@ -214,6 +318,9 @@ iree_status_t iree_hal_streaming_stream_create(
   stream->recorded_events = NULL;
   stream->event_count = 0;
   stream->event_capacity = 0;
+  stream->memory_reuse_dependencies = NULL;
+  stream->memory_reuse_dependency_count = 0;
+  stream->memory_reuse_dependency_capacity = 0;
 
   stream->capture_status = IREE_HAL_STREAMING_CAPTURE_STATUS_NONE;
   stream->capture_mode = IREE_HAL_STREAMING_CAPTURE_MODE_GLOBAL;
@@ -271,6 +378,8 @@ static void iree_hal_streaming_stream_destroy(
     }
     iree_allocator_free(stream->host_allocator, stream->recorded_events);
   }
+  iree_allocator_free(stream->host_allocator,
+                      stream->memory_reuse_dependencies);
 
   // Release command buffer.
   iree_hal_command_buffer_release(stream->command_buffer);
@@ -452,12 +561,15 @@ iree_status_t iree_hal_streaming_stream_query(
   }
   IREE_RETURN_IF_ERROR(query_status);
 
-  if (current_value >= stream->pending_value) {
+  iree_slim_mutex_lock(&stream->mutex);
+  const uint64_t pending_value = stream->pending_value;
+  if (current_value >= pending_value) {
     *status = 0;  // Complete
-    stream->completed_value = current_value;
+    stream->completed_value = iree_max(stream->completed_value, current_value);
   } else {
     *status = 1;  // Not complete
   }
+  iree_slim_mutex_unlock(&stream->mutex);
 
   return iree_ok_status();
 }
@@ -487,6 +599,14 @@ static iree_status_t iree_hal_streaming_stream_synchronize_impl(
     IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, flush_status);
   }
 
+  // Snapshot the synchronization target under the same mutex used to reserve
+  // timeline values. Operations submitted after this point are not part of
+  // this synchronization operation.
+  iree_slim_mutex_lock(&stream->mutex);
+  const uint64_t target_value = stream->pending_value;
+  uint64_t completed_value = stream->completed_value;
+  iree_slim_mutex_unlock(&stream->mutex);
+
   timing_step_ns = timing_enabled ? hrx_launch_timing_now_ns() : 0;
   uint64_t current_value = 0;
   iree_status_t query_status =
@@ -495,8 +615,8 @@ static iree_status_t iree_hal_streaming_stream_synchronize_impl(
     iree_status_ignore(query_status);
     query_status = iree_ok_status();
   } else if (iree_status_is_ok(query_status)) {
-    if (current_value >= stream->pending_value) {
-      stream->completed_value = current_value;
+    if (current_value > completed_value) {
+      completed_value = current_value;
     }
   }
   if (timing_enabled) {
@@ -504,15 +624,12 @@ static iree_status_t iree_hal_streaming_stream_synchronize_impl(
   }
   IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, query_status);
 
-  // Wait for timeline semaphore to reach pending value.
-  if (stream->pending_value > stream->completed_value) {
-    // fprintf(stderr, "[STREAM] sync: waiting for semaphore pending=%"PRIu64"
-    // completed=%"PRIu64"\n",
-    //         stream->pending_value, stream->completed_value);
+  // Wait for the timeline semaphore to reach the captured target.
+  if (target_value > completed_value) {
     timing_step_ns = timing_enabled ? hrx_launch_timing_now_ns() : 0;
     iree_status_t wait_status = iree_hal_semaphore_wait(
-        stream->timeline_semaphore, stream->pending_value,
-        iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE);
+        stream->timeline_semaphore, target_value, iree_infinite_timeout(),
+        IREE_ASYNC_WAIT_FLAG_NONE);
     if (timing_enabled) {
       timing_wait_ns += hrx_launch_timing_now_ns() - timing_step_ns;
     }
@@ -520,9 +637,16 @@ static iree_status_t iree_hal_streaming_stream_synchronize_impl(
       IREE_TRACE_ZONE_END(z0);
       return wait_status;
     }
-    // fprintf(stderr, "[STREAM] sync: wait OK\n");
-    stream->completed_value = stream->pending_value;
+    completed_value = target_value;
   }
+
+  iree_slim_mutex_lock(&stream->mutex);
+  stream->completed_value = iree_max(stream->completed_value, completed_value);
+  iree_slim_mutex_unlock(&stream->mutex);
+
+  // A completed stream can no longer expose its pending frees to a later
+  // stream-ordered allocation, so return any cached backing to the pool.
+  iree_hal_streaming_memory_release_completed_async_frees(stream);
 
   if (timing_enabled) {
     ++g_hrx_launch_timing.sync_count;
@@ -554,13 +678,16 @@ iree_status_t iree_hal_streaming_stream_wait_submitted(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // Wait for already-submitted work to complete WITHOUT flushing.
-  // This is safe to call from other threads as it doesn't modify stream state.
-  // We wait for submitted_value (the last value that was actually submitted).
-  if (stream->submitted_value > 0) {
+  // Snapshot the last submitted value under the stream lock. New submissions
+  // after this point are outside this wait operation.
+  iree_slim_mutex_lock(&stream->mutex);
+  const uint64_t submitted_value = stream->submitted_value;
+  iree_slim_mutex_unlock(&stream->mutex);
+  if (submitted_value > 0) {
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_hal_semaphore_wait(
-                stream->timeline_semaphore, stream->submitted_value,
-                iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE));
+        z0, iree_hal_semaphore_wait(stream->timeline_semaphore, submitted_value,
+                                    iree_infinite_timeout(),
+                                    IREE_ASYNC_WAIT_FLAG_NONE));
   }
 
   IREE_TRACE_ZONE_END(z0);
@@ -637,6 +764,17 @@ iree_status_t iree_hal_streaming_stream_wait_event(
     return iree_ok_status();
   }
 
+  const unsigned long long source_stream_id =
+      event->recording_stream ? event->recording_stream->stream_id : 0;
+  const uint64_t source_timeline_value = event->signal_value;
+  bool added_memory_reuse_dependency = false;
+  if (source_stream_id != 0 && source_stream_id != stream->stream_id &&
+      source_timeline_value != 0) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_hal_streaming_stream_reserve_memory_reuse_dependency(
+                stream, source_stream_id, &added_memory_reuse_dependency));
+  }
+
   // Flush the stream to ensure all prior operations are submitted.
   IREE_RETURN_AND_END_ZONE_IF_ERROR(z0,
                                     iree_hal_streaming_stream_flush(stream));
@@ -671,7 +809,16 @@ iree_status_t iree_hal_streaming_stream_wait_event(
   }
 
   iree_slim_mutex_unlock(&stream->mutex);
+  if (!iree_status_is_ok(status) && added_memory_reuse_dependency) {
+    iree_hal_streaming_stream_remove_uncommitted_memory_reuse_dependency(
+        stream, source_stream_id);
+  }
   IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, status);
+  if (source_stream_id != 0 && source_stream_id != stream->stream_id &&
+      source_timeline_value != 0) {
+    iree_hal_streaming_stream_record_memory_reuse_dependency(
+        stream, source_stream_id, source_timeline_value);
+  }
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -1446,6 +1593,49 @@ static iree_status_t iree_hal_streaming_host_callback_thunk(
   return iree_ok_status();
 }
 
+iree_status_t iree_hal_streaming_queue_host_call(
+    iree_hal_streaming_stream_t* stream, iree_hal_host_call_t call,
+    const uint64_t args[4], iree_hal_host_call_flags_t flags) {
+  IREE_ASSERT_ARGUMENT(stream);
+  IREE_ASSERT_ARGUMENT(call.fn);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(z0,
+                                    iree_hal_streaming_stream_flush(stream));
+
+  iree_slim_mutex_lock(&stream->mutex);
+  uint64_t wait_value = stream->pending_value;
+  if (IREE_UNLIKELY(wait_value == UINT64_MAX)) {
+    iree_slim_mutex_unlock(&stream->mutex);
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "stream timeline value overflow");
+  }
+  uint64_t signal_value = wait_value + 1;
+  iree_hal_semaphore_list_t wait_semaphores = {
+      .count = wait_value > 0 ? 1 : 0,
+      .semaphores = &stream->timeline_semaphore,
+      .payload_values = &wait_value,
+  };
+  iree_hal_semaphore_list_t signal_semaphores = {
+      .count = 1,
+      .semaphores = &stream->timeline_semaphore,
+      .payload_values = &signal_value,
+  };
+
+  iree_status_t status = iree_hal_device_queue_host_call(
+      stream->context->device, stream->queue_affinity, wait_semaphores,
+      signal_semaphores, call, args, flags);
+  if (iree_status_is_ok(status)) {
+    stream->pending_value = signal_value;
+    stream->submitted_value = signal_value;
+  }
+  iree_slim_mutex_unlock(&stream->mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 iree_status_t iree_hal_streaming_launch_host_function(
     iree_hal_streaming_stream_t* stream, void (*fn)(void*), void* user_data) {
   IREE_ASSERT_ARGUMENT(stream);
@@ -1466,11 +1656,6 @@ iree_status_t iree_hal_streaming_launch_host_function(
     return iree_ok_status();
   }
 
-  // Flush any pending command-buffer work so the host call can sit at a
-  // concrete point on the stream timeline.
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(z0,
-                                    iree_hal_streaming_stream_flush(stream));
-
   // Allocate a wrapper structure to hold the callback and user data.
   iree_hal_streaming_host_callback_t* callback = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
@@ -1483,28 +1668,8 @@ iree_status_t iree_hal_streaming_launch_host_function(
   iree_hal_host_call_t call =
       iree_hal_make_host_call(iree_hal_streaming_host_callback_thunk, callback);
 
-  iree_slim_mutex_lock(&stream->mutex);
-  uint64_t wait_value = stream->pending_value;
-  uint64_t signal_value = wait_value + 1;
-  iree_hal_semaphore_list_t wait_semaphores = {
-      .count = wait_value > 0 ? 1 : 0,
-      .semaphores = &stream->timeline_semaphore,
-      .payload_values = &wait_value,
-  };
-  iree_hal_semaphore_list_t signal_semaphores = {
-      .count = 1,
-      .semaphores = &stream->timeline_semaphore,
-      .payload_values = &signal_value,
-  };
-
-  iree_status_t status = iree_hal_device_queue_host_call(
-      stream->context->device, stream->queue_affinity, wait_semaphores,
-      signal_semaphores, call, args, /*flags=*/0);
-  if (iree_status_is_ok(status)) {
-    stream->pending_value = signal_value;
-    stream->submitted_value = signal_value;
-  }
-  iree_slim_mutex_unlock(&stream->mutex);
+  iree_status_t status = iree_hal_streaming_queue_host_call(
+      stream, call, args, IREE_HAL_HOST_CALL_FLAG_NONE);
 
   if (!iree_status_is_ok(status)) {
     iree_allocator_free(iree_allocator_system(), callback);

--- a/libhrx/src/binding/common/stream.h
+++ b/libhrx/src/binding/common/stream.h
@@ -1,0 +1,28 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_EXPERIMENTAL_STREAMING_STREAM_H_
+#define IREE_EXPERIMENTAL_STREAMING_STREAM_H_
+
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct iree_hal_streaming_stream_t iree_hal_streaming_stream_t;
+
+// Enqueues a HAL host call at the current stream timeline point.
+// Synchronization: flushes pending stream commands before enqueueing.
+iree_status_t iree_hal_streaming_queue_host_call(
+    iree_hal_streaming_stream_t* stream, iree_hal_host_call_t call,
+    const uint64_t args[4], iree_hal_host_call_flags_t flags);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // IREE_EXPERIMENTAL_STREAMING_STREAM_H_

--- a/libhrx/src/binding/hip/BUILD.bazel
+++ b/libhrx/src/binding/hip/BUILD.bazel
@@ -5,7 +5,11 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("//build_tools/bazel:cmake.bzl", "iree_cmake_extra_content")
-load("//build_tools/sanitizer:suppressions.bzl", "rocm_suppressions")
+load(
+    "//build_tools/sanitizer:suppressions.bzl",
+    "hsa_suppressions",
+    "rocm_suppressions",
+)
 load(
     "//libhrx/build_tools/bazel:cc.bzl",
     "hrx_cc_library",
@@ -191,6 +195,25 @@ hrx_cc_test(
         ":launch_params",
         "//build_tools:dl",
         "//libhrx/src/binding/common",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+hrx_cc_test(
+    name = "hip_memory_pool_api_test",
+    srcs = ["hip_memory_pool_api_test.cc"],
+    # The test loads the built runtime through its public ABI and exercises
+    # device-backed allocation and graph teardown.
+    data = [":amdhip64"],
+    env = {
+        "HRX_TEST_LIBAMDHIP64": "$(location :amdhip64)",
+    },
+    sanitizer_suppressions = hsa_suppressions,
+    target_compatible_with = _LINUX_COMPATIBILITY,
+    deps = [
+        ":launch_params",
+        "//build_tools:dl",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",
     ],

--- a/libhrx/src/binding/hip/CMakeLists.txt
+++ b/libhrx/src/binding/hip/CMakeLists.txt
@@ -219,6 +219,28 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 iree_cc_test(
   NAME
+    hip_memory_pool_api_test
+  SRCS
+    "hip_memory_pool_api_test.cc"
+  DATA
+    ::amdhip64
+  DEPS
+    ${CMAKE_DL_LIBS}
+    ::launch_params
+    iree::testing::gtest
+    iree::testing::gtest_main
+    libhrx_defs
+  ENV
+    "HRX_TEST_LIBAMDHIP64=$<TARGET_FILE:libhrx::src::binding::hip::amdhip64>"
+  SANITIZER_SUPPRESSIONS
+    lsan
+    hsa
+)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+iree_cc_test(
+  NAME
     hostcall_message_test
   SRCS
     "hostcall_message_test.cc"

--- a/libhrx/src/binding/hip/abi_stubs.c
+++ b/libhrx/src/binding/hip/abi_stubs.c
@@ -1329,23 +1329,6 @@ HIPAPI hipError_t hipMemGetHandleForAddressRange(
   return hipErrorNotSupported;
 }
 
-HIPAPI hipError_t hipMemGetMemPool(hipMemPool_t* pool, hipMemLocation* location,
-                                   hipMemAllocationType type) {
-  (void)pool;
-  (void)location;
-  (void)type;
-  return hipErrorNotSupported;
-}
-
-HIPAPI hipError_t hipMemSetMemPool(hipMemLocation* location,
-                                   hipMemAllocationType type,
-                                   hipMemPool_t pool) {
-  (void)location;
-  (void)type;
-  (void)pool;
-  return hipErrorNotSupported;
-}
-
 static bool hrx_hip_batch_access_order_valid(hipMemcpySrcAccessOrder order) {
   return order == hipMemcpySrcAccessOrderInvalid ||
          order == hipMemcpySrcAccessOrderStream ||

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -325,7 +325,7 @@ static void iree_hip_mem_pool_release(struct hipMemPool_st* pool) {
   iree_allocator_free(iree_allocator_system(), pool);
 }
 
-static hipError_t iree_hip_mem_pool_registry_lookup_retain(
+static hipError_t iree_hip_mem_pool_registry_acquire(
     hipMemPool_t pool, struct hipMemPool_st** out_pool) {
   if (out_pool) *out_pool = NULL;
   if (!pool) return hipErrorInvalidValue;
@@ -22125,8 +22125,7 @@ HIPAPI hipError_t hipMemPoolSetAttribute(hipMemPool_t pool,
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t result =
-      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
+  hipError_t result = iree_hip_mem_pool_registry_acquire(pool, &pool_handle);
   if (result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(result);
@@ -22191,8 +22190,7 @@ HIPAPI hipError_t hipMemPoolGetAttribute(hipMemPool_t pool,
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t result =
-      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
+  hipError_t result = iree_hip_mem_pool_registry_acquire(pool, &pool_handle);
   if (result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(result);
@@ -22257,8 +22255,7 @@ HIPAPI hipError_t hipMemPoolSetAccess(hipMemPool_t pool,
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t result =
-      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
+  hipError_t result = iree_hip_mem_pool_registry_acquire(pool, &pool_handle);
   if (result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(result);
@@ -22313,8 +22310,7 @@ HIPAPI hipError_t hipMemPoolGetAccess(hipMemAccessFlags* flags,
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t result =
-      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
+  hipError_t result = iree_hip_mem_pool_registry_acquire(pool, &pool_handle);
   if (result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(result);
@@ -22362,8 +22358,7 @@ HIPAPI hipError_t hipMemPoolTrimTo(hipMemPool_t pool, size_t minBytesToKeep) {
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t result =
-      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
+  hipError_t result = iree_hip_mem_pool_registry_acquire(pool, &pool_handle);
   if (result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(result);
@@ -22492,8 +22487,7 @@ HIPAPI hipError_t hipDeviceSetMemPool(int device, hipMemPool_t pool) {
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t result =
-      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
+  hipError_t result = iree_hip_mem_pool_registry_acquire(pool, &pool_handle);
   if (result == hipSuccess &&
       (pool_handle->device_ordinal != device ||
        pool_handle->allocation_type != hipMemAllocationTypePinned)) {
@@ -22642,8 +22636,7 @@ HIPAPI hipError_t hipMemSetMemPool(hipMemLocation* location,
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t result =
-      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
+  hipError_t result = iree_hip_mem_pool_registry_acquire(pool, &pool_handle);
   if (result != hipSuccess) HIP_RETURN_ERROR(result);
   if (pool_handle->device_ordinal != location->id ||
       pool_handle->allocation_type != type) {
@@ -22796,7 +22789,7 @@ HIPAPI hipError_t hipMallocFromPoolAsync(void** ptr, size_t size,
 
   struct hipMemPool_st* pool_handle = NULL;
   hipError_t pool_result =
-      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
+      iree_hip_mem_pool_registry_acquire(pool, &pool_handle);
   if (pool_result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(pool_result);

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -18201,6 +18201,7 @@ HIPAPI hipError_t hipGraphAddMemAllocNode(hipGraphNode_t* pGraphNode,
   hipError_t alloc_result =
       iree_hip_malloc_from_pool(stream_graph->context, pool, params->bytesize,
                                 /*stream=*/NULL, &params->dptr);
+  hrx_mem_pool_release(pool);
   if (alloc_result != hipSuccess) {
     iree_status_ignore(iree_hal_streaming_graph_destroy_node(node));
     HIP_RETURN_ERROR(alloc_result);
@@ -22775,6 +22776,10 @@ HIPAPI hipError_t hipMallocFromPoolAsync(void** ptr, size_t size,
   if (stream_result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(stream_result);
+  }
+  if (size == 0) {
+    IREE_TRACE_ZONE_END(z0);
+    return hipSuccess;
   }
 
   struct hipMemPool_st* pool_handle = NULL;

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -325,8 +325,8 @@ static void iree_hip_mem_pool_release(struct hipMemPool_st* pool) {
   iree_allocator_free(iree_allocator_system(), pool);
 }
 
-static hipError_t iree_hip_mem_pool_retain(hipMemPool_t pool,
-                                           struct hipMemPool_st** out_pool) {
+static hipError_t iree_hip_mem_pool_registry_lookup_retain(
+    hipMemPool_t pool, struct hipMemPool_st** out_pool) {
   if (out_pool) *out_pool = NULL;
   if (!pool) return hipErrorInvalidValue;
 
@@ -14410,7 +14410,9 @@ HIPAPI hipError_t hipMemRangeGetAttributes(void** data, size_t* data_sizes,
 
 struct hipUserObject {
   // References held by the live-handle registry, graphs, and active API calls.
-  iree_atomic_ref_count_t handle_ref_count;
+  // This count protects the control block but is not its public reference
+  // count.
+  iree_atomic_int32_t handle_reference_count;
   // Next live user-object handle in the process registry.
   struct hipUserObject* next_live_object;
   // Protects reference count changes from user and graph-owner threads.
@@ -14445,12 +14447,11 @@ static void iree_hip_user_object_registry_lock(void) {
 }
 
 static void iree_hip_user_object_handle_release(hipUserObject_t user_object) {
-  if (!user_object ||
-      iree_atomic_ref_count_dec(&user_object->handle_ref_count) != 1) {
-    return;
+  if (user_object && iree_atomic_fetch_sub(&user_object->handle_reference_count,
+                                           1, iree_memory_order_acq_rel) == 1) {
+    iree_slim_mutex_deinitialize(&user_object->mutex);
+    iree_allocator_free(user_object->host_allocator, user_object);
   }
-  iree_slim_mutex_deinitialize(&user_object->mutex);
-  iree_allocator_free(user_object->host_allocator, user_object);
 }
 
 static void iree_hip_user_object_registry_insert(hipUserObject_t user_object) {
@@ -14460,8 +14461,8 @@ static void iree_hip_user_object_registry_insert(hipUserObject_t user_object) {
   iree_slim_mutex_unlock(&iree_hip_user_object_registry_mutex);
 }
 
-static bool iree_hip_user_object_registry_retain(hipUserObject_t object,
-                                                 hipUserObject_t* out_object) {
+static bool iree_hip_user_object_registry_lookup_retain(
+    hipUserObject_t object, hipUserObject_t* out_object) {
   if (out_object) *out_object = NULL;
   if (!object) return false;
 
@@ -14470,7 +14471,8 @@ static bool iree_hip_user_object_registry_retain(hipUserObject_t object,
   for (hipUserObject_t current = iree_hip_user_object_registry_head; current;
        current = current->next_live_object) {
     if (current == object) {
-      iree_atomic_ref_count_inc(&current->handle_ref_count);
+      iree_atomic_fetch_add(&current->handle_reference_count, 1,
+                            iree_memory_order_relaxed);
       if (out_object) *out_object = current;
       found = true;
       break;
@@ -14543,7 +14545,8 @@ static iree_status_t iree_hip_user_object_retain_graph_refs(void* object,
     status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED);
   } else {
     ++user_object->graph_association_count;
-    iree_atomic_ref_count_inc(&user_object->handle_ref_count);
+    iree_atomic_fetch_add(&user_object->handle_reference_count, 1,
+                          iree_memory_order_relaxed);
     if (!user_object->destructor_called) {
       user_object->ref_count += count;
     }
@@ -14561,7 +14564,8 @@ static hipError_t iree_hip_user_object_add_graph_association(
     result = hipErrorInvalidValue;
   } else {
     ++user_object->graph_association_count;
-    iree_atomic_ref_count_inc(&user_object->handle_ref_count);
+    iree_atomic_fetch_add(&user_object->handle_reference_count, 1,
+                          iree_memory_order_relaxed);
   }
   iree_slim_mutex_unlock(&user_object->mutex);
   return result;
@@ -14655,7 +14659,8 @@ HIPAPI hipError_t hipUserObjectCreate(hipUserObject_t* object_out, void* ptr,
     HIP_RETURN_ERROR(hipErrorOutOfMemory);
   }
   iree_slim_mutex_initialize(&object->mutex);
-  iree_atomic_ref_count_init(&object->handle_ref_count);
+  iree_atomic_store(&object->handle_reference_count, 1,
+                    iree_memory_order_relaxed);
   object->next_live_object = NULL;
   object->ref_count = initialRefcount;
   object->graph_association_count = 0;
@@ -14674,7 +14679,7 @@ HIPAPI hipError_t hipUserObjectRelease(hipUserObject_t object,
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
   hipUserObject_t retained_object = NULL;
-  if (!iree_hip_user_object_registry_retain(object, &retained_object)) {
+  if (!iree_hip_user_object_registry_lookup_retain(object, &retained_object)) {
     return hipSuccess;
   }
   hipError_t result =
@@ -14692,7 +14697,7 @@ HIPAPI hipError_t hipUserObjectRetain(hipUserObject_t object,
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
   hipUserObject_t retained_object = NULL;
-  if (!iree_hip_user_object_registry_retain(object, &retained_object)) {
+  if (!iree_hip_user_object_registry_lookup_retain(object, &retained_object)) {
     return hipSuccess;
   }
   hipError_t result =
@@ -14739,7 +14744,7 @@ HIPAPI hipError_t hipGraphRetainUserObject(hipGraph_t graph,
   }
 
   hipUserObject_t retained_object = NULL;
-  if (!iree_hip_user_object_registry_retain(object, &retained_object)) {
+  if (!iree_hip_user_object_registry_lookup_retain(object, &retained_object)) {
     return hipSuccess;
   }
   object = retained_object;
@@ -22120,7 +22125,8 @@ HIPAPI hipError_t hipMemPoolSetAttribute(hipMemPool_t pool,
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  hipError_t result =
+      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
   if (result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(result);
@@ -22185,7 +22191,8 @@ HIPAPI hipError_t hipMemPoolGetAttribute(hipMemPool_t pool,
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  hipError_t result =
+      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
   if (result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(result);
@@ -22250,7 +22257,8 @@ HIPAPI hipError_t hipMemPoolSetAccess(hipMemPool_t pool,
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  hipError_t result =
+      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
   if (result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(result);
@@ -22305,7 +22313,8 @@ HIPAPI hipError_t hipMemPoolGetAccess(hipMemAccessFlags* flags,
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  hipError_t result =
+      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
   if (result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(result);
@@ -22353,7 +22362,8 @@ HIPAPI hipError_t hipMemPoolTrimTo(hipMemPool_t pool, size_t minBytesToKeep) {
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  hipError_t result =
+      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
   if (result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(result);
@@ -22482,7 +22492,8 @@ HIPAPI hipError_t hipDeviceSetMemPool(int device, hipMemPool_t pool) {
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  hipError_t result =
+      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
   if (result == hipSuccess &&
       (pool_handle->device_ordinal != device ||
        pool_handle->allocation_type != hipMemAllocationTypePinned)) {
@@ -22631,7 +22642,8 @@ HIPAPI hipError_t hipMemSetMemPool(hipMemLocation* location,
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  hipError_t result =
+      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
   if (result != hipSuccess) HIP_RETURN_ERROR(result);
   if (pool_handle->device_ordinal != location->id ||
       pool_handle->allocation_type != type) {
@@ -22783,7 +22795,8 @@ HIPAPI hipError_t hipMallocFromPoolAsync(void** ptr, size_t size,
   }
 
   struct hipMemPool_st* pool_handle = NULL;
-  hipError_t pool_result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  hipError_t pool_result =
+      iree_hip_mem_pool_registry_lookup_retain(pool, &pool_handle);
   if (pool_result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(pool_result);

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -22360,9 +22360,11 @@ HIPAPI hipError_t hipMemPoolTrimTo(hipMemPool_t pool, size_t minBytesToKeep) {
   hrx_mem_pool_t hrx_pool = NULL;
   result = iree_hip_mem_pool_retain_backend(pool_handle, &hrx_pool);
   if (result == hipSuccess) {
-    iree_hal_streaming_memory_release_completed_async_frees_from_pool(hrx_pool);
     iree_status_t status =
-        HRX_CALL(hrx_mem_pool_trim(hrx_pool, minBytesToKeep));
+        iree_hal_streaming_memory_release_completed_async_frees_from_pool(
+            hrx_pool);
+    status = iree_status_join(
+        status, HRX_CALL(hrx_mem_pool_trim(hrx_pool, minBytesToKeep)));
     result = iree_status_to_hip_result(status);
   }
   hrx_mem_pool_release(hrx_pool);

--- a/libhrx/src/binding/hip/api.c
+++ b/libhrx/src/binding/hip/api.c
@@ -142,6 +142,7 @@ typedef struct hrx_hip_batch_mem_op_node_params_t {
 } hrx_hip_batch_mem_op_node_params_t;
 
 static bool iree_hip_graph_handle_is_live(hipGraph_t graph);
+static hipError_t iree_status_to_hip_result(iree_status_t status);
 
 #define IREE_HIP_ARRAY_MAGIC 0x6872786869706179ull
 // HRX HIP arrays are backed by normal device allocations. The practical limit
@@ -271,6 +272,291 @@ static bool iree_hip_array_registry_lookup(hipArray_const_t array,
   iree_slim_mutex_unlock(&iree_hip_array_registry_mutex);
   return found;
 }
+
+//===----------------------------------------------------------------------===//
+// Memory pool handles
+//===----------------------------------------------------------------------===//
+
+struct hipMemPool_st {
+  // References held by the live-handle registry and active API callers.
+  iree_atomic_ref_count_t ref_count;
+  // Next live pool handle in the process registry.
+  struct hipMemPool_st* next_live_pool;
+  // HRX pool owned by a user-created handle, or NULL for a default handle.
+  hrx_mem_pool_t hrx_pool;
+  // Device ordinal associated with the pool's allocation location.
+  int device_ordinal;
+  // Allocation type accepted by this pool handle.
+  hipMemAllocationType allocation_type;
+  // True when this handle resolves the device's default pool dynamically.
+  bool is_default;
+};
+
+typedef struct iree_hip_managed_mem_pool_selection_t {
+  // Next managed-pool selection in the process registry.
+  struct iree_hip_managed_mem_pool_selection_t* next;
+  // Device ordinal associated with the selected managed pool.
+  int device_ordinal;
+  // Retained pool handle selected for managed allocations on the device.
+  struct hipMemPool_st* pool;
+} iree_hip_managed_mem_pool_selection_t;
+
+static iree_once_flag iree_hip_mem_pool_registry_mutex_once =
+    IREE_ONCE_FLAG_INIT;
+static iree_slim_mutex_t iree_hip_mem_pool_registry_mutex;
+static struct hipMemPool_st* iree_hip_mem_pool_registry_head = NULL;
+static iree_hip_managed_mem_pool_selection_t*
+    iree_hip_managed_mem_pool_selection_head = NULL;
+
+static void iree_hip_mem_pool_registry_mutex_initialize(void) {
+  iree_slim_mutex_initialize(&iree_hip_mem_pool_registry_mutex);
+}
+
+static void iree_hip_mem_pool_registry_lock(void) {
+  iree_call_once(&iree_hip_mem_pool_registry_mutex_once,
+                 iree_hip_mem_pool_registry_mutex_initialize);
+  iree_slim_mutex_lock(&iree_hip_mem_pool_registry_mutex);
+}
+
+static void iree_hip_mem_pool_release(struct hipMemPool_st* pool) {
+  if (!pool) return;
+  if (iree_atomic_ref_count_dec(&pool->ref_count) != 1) return;
+  hrx_mem_pool_release(pool->hrx_pool);
+  iree_allocator_free(iree_allocator_system(), pool);
+}
+
+static hipError_t iree_hip_mem_pool_retain(hipMemPool_t pool,
+                                           struct hipMemPool_st** out_pool) {
+  if (out_pool) *out_pool = NULL;
+  if (!pool) return hipErrorInvalidValue;
+
+  iree_hip_mem_pool_registry_lock();
+  for (struct hipMemPool_st* current = iree_hip_mem_pool_registry_head; current;
+       current = current->next_live_pool) {
+    if (current == pool) {
+      iree_atomic_ref_count_inc(&current->ref_count);
+      if (out_pool) *out_pool = current;
+      iree_slim_mutex_unlock(&iree_hip_mem_pool_registry_mutex);
+      return hipSuccess;
+    }
+  }
+  iree_slim_mutex_unlock(&iree_hip_mem_pool_registry_mutex);
+  return hipErrorInvalidValue;
+}
+
+static hipError_t iree_hip_mem_pool_create_handle(
+    hrx_mem_pool_t hrx_pool, int device_ordinal,
+    hipMemAllocationType allocation_type, bool is_default,
+    hipMemPool_t* out_pool) {
+  *out_pool = NULL;
+  struct hipMemPool_st* pool = NULL;
+  iree_status_t status = iree_allocator_malloc(iree_allocator_system(),
+                                               sizeof(*pool), (void**)&pool);
+  if (!iree_status_is_ok(status)) return iree_status_to_hip_result(status);
+
+  memset(pool, 0, sizeof(*pool));
+  iree_atomic_ref_count_init(&pool->ref_count);
+  pool->hrx_pool = hrx_pool;
+  pool->device_ordinal = device_ordinal;
+  pool->allocation_type = allocation_type;
+  pool->is_default = is_default;
+
+  iree_hip_mem_pool_registry_lock();
+  pool->next_live_pool = iree_hip_mem_pool_registry_head;
+  iree_hip_mem_pool_registry_head = pool;
+  iree_slim_mutex_unlock(&iree_hip_mem_pool_registry_mutex);
+  *out_pool = pool;
+  return hipSuccess;
+}
+
+static hipError_t iree_hip_mem_pool_get_default(
+    int device_ordinal, hipMemAllocationType allocation_type,
+    hipMemPool_t* out_pool) {
+  *out_pool = NULL;
+  iree_hip_mem_pool_registry_lock();
+  for (struct hipMemPool_st* current = iree_hip_mem_pool_registry_head; current;
+       current = current->next_live_pool) {
+    if (current->is_default && current->device_ordinal == device_ordinal &&
+        current->allocation_type == allocation_type) {
+      *out_pool = current;
+      iree_slim_mutex_unlock(&iree_hip_mem_pool_registry_mutex);
+      return hipSuccess;
+    }
+  }
+  iree_slim_mutex_unlock(&iree_hip_mem_pool_registry_mutex);
+
+  struct hipMemPool_st* pool = NULL;
+  iree_status_t status = iree_allocator_malloc(iree_allocator_system(),
+                                               sizeof(*pool), (void**)&pool);
+  if (!iree_status_is_ok(status)) return iree_status_to_hip_result(status);
+  memset(pool, 0, sizeof(*pool));
+  iree_atomic_ref_count_init(&pool->ref_count);
+  pool->device_ordinal = device_ordinal;
+  pool->allocation_type = allocation_type;
+  pool->is_default = true;
+
+  iree_hip_mem_pool_registry_lock();
+  for (struct hipMemPool_st* current = iree_hip_mem_pool_registry_head; current;
+       current = current->next_live_pool) {
+    if (current->is_default && current->device_ordinal == device_ordinal &&
+        current->allocation_type == allocation_type) {
+      *out_pool = current;
+      iree_slim_mutex_unlock(&iree_hip_mem_pool_registry_mutex);
+      iree_allocator_free(iree_allocator_system(), pool);
+      return hipSuccess;
+    }
+  }
+  pool->next_live_pool = iree_hip_mem_pool_registry_head;
+  iree_hip_mem_pool_registry_head = pool;
+  iree_slim_mutex_unlock(&iree_hip_mem_pool_registry_mutex);
+  *out_pool = pool;
+  return hipSuccess;
+}
+
+static hipError_t iree_hip_mem_pool_retain_backend(
+    const struct hipMemPool_st* pool, hrx_mem_pool_t* out_hrx_pool) {
+  *out_hrx_pool = NULL;
+  if (!pool->is_default) {
+    hrx_mem_pool_retain(pool->hrx_pool);
+    *out_hrx_pool = pool->hrx_pool;
+    return hipSuccess;
+  }
+
+  iree_hal_streaming_device_t* device =
+      iree_hal_streaming_device_entry(pool->device_ordinal);
+  if (!device) return hipErrorInvalidDevice;
+  iree_status_t status =
+      iree_hal_streaming_device_ensure_default_mem_pool(device);
+  if (!iree_status_is_ok(status)) return iree_status_to_hip_result(status);
+  *out_hrx_pool = iree_hal_streaming_device_retain_default_mem_pool(device);
+  return *out_hrx_pool ? hipSuccess : hipErrorInvalidValue;
+}
+
+static bool iree_hip_mem_pool_registry_remove(hipMemPool_t pool,
+                                              struct hipMemPool_st** out_pool) {
+  if (out_pool) *out_pool = NULL;
+  if (!pool) return false;
+
+  iree_hip_managed_mem_pool_selection_t* removed_selection = NULL;
+  iree_hip_mem_pool_registry_lock();
+  struct hipMemPool_st** current = &iree_hip_mem_pool_registry_head;
+  while (*current) {
+    if (*current == pool && !pool->is_default) {
+      if (out_pool) *out_pool = *current;
+      *current = pool->next_live_pool;
+      pool->next_live_pool = NULL;
+
+      iree_hip_managed_mem_pool_selection_t** selection =
+          &iree_hip_managed_mem_pool_selection_head;
+      while (*selection) {
+        if ((*selection)->pool == pool) {
+          removed_selection = *selection;
+          *selection = removed_selection->next;
+          break;
+        }
+        selection = &(*selection)->next;
+      }
+      iree_slim_mutex_unlock(&iree_hip_mem_pool_registry_mutex);
+      if (removed_selection) {
+        iree_hip_mem_pool_release(removed_selection->pool);
+        iree_allocator_free(iree_allocator_system(), removed_selection);
+      }
+      return true;
+    }
+    current = &(*current)->next_live_pool;
+  }
+  iree_slim_mutex_unlock(&iree_hip_mem_pool_registry_mutex);
+  return false;
+}
+
+static hipError_t iree_hip_mem_pool_get_current(
+    iree_hal_streaming_device_t* device, int device_ordinal,
+    hipMemPool_t* out_pool) {
+  *out_pool = NULL;
+  hrx_mem_pool_t hrx_pool = iree_hal_streaming_device_retain_mem_pool(device);
+  if (!hrx_pool) return hipErrorInvalidValue;
+
+  iree_hip_mem_pool_registry_lock();
+  for (struct hipMemPool_st* current = iree_hip_mem_pool_registry_head; current;
+       current = current->next_live_pool) {
+    if (!current->is_default &&
+        current->allocation_type == hipMemAllocationTypePinned &&
+        current->device_ordinal == device_ordinal &&
+        current->hrx_pool == hrx_pool) {
+      *out_pool = current;
+      break;
+    }
+  }
+  iree_slim_mutex_unlock(&iree_hip_mem_pool_registry_mutex);
+  hrx_mem_pool_release(hrx_pool);
+
+  return *out_pool ? hipSuccess
+                   : iree_hip_mem_pool_get_default(
+                         device_ordinal, hipMemAllocationTypePinned, out_pool);
+}
+
+static hipError_t iree_hip_mem_pool_get_managed_selection(
+    int device_ordinal, hipMemPool_t* out_pool) {
+  *out_pool = NULL;
+  iree_hip_mem_pool_registry_lock();
+  for (iree_hip_managed_mem_pool_selection_t* selection =
+           iree_hip_managed_mem_pool_selection_head;
+       selection; selection = selection->next) {
+    if (selection->device_ordinal == device_ordinal) {
+      *out_pool = selection->pool;
+      break;
+    }
+  }
+  iree_slim_mutex_unlock(&iree_hip_mem_pool_registry_mutex);
+
+  return *out_pool ? hipSuccess
+                   : iree_hip_mem_pool_get_default(
+                         device_ordinal, hipMemAllocationTypeManaged, out_pool);
+}
+
+static hipError_t iree_hip_mem_pool_set_managed_selection(
+    int device_ordinal, struct hipMemPool_st* pool) {
+  iree_hip_managed_mem_pool_selection_t* new_selection = NULL;
+  iree_status_t status = iree_allocator_malloc(
+      iree_allocator_system(), sizeof(*new_selection), (void**)&new_selection);
+  if (!iree_status_is_ok(status)) return iree_status_to_hip_result(status);
+  memset(new_selection, 0, sizeof(*new_selection));
+
+  iree_hip_managed_mem_pool_selection_t* previous_selection = NULL;
+  iree_hip_mem_pool_registry_lock();
+  iree_hip_managed_mem_pool_selection_t** selection =
+      &iree_hip_managed_mem_pool_selection_head;
+  while (*selection && (*selection)->device_ordinal != device_ordinal) {
+    selection = &(*selection)->next;
+  }
+  if (*selection) {
+    previous_selection = *selection;
+    *selection = previous_selection->next;
+  }
+  new_selection->device_ordinal = device_ordinal;
+  new_selection->pool = pool;
+  iree_atomic_ref_count_inc(&pool->ref_count);
+  new_selection->next = iree_hip_managed_mem_pool_selection_head;
+  iree_hip_managed_mem_pool_selection_head = new_selection;
+  iree_slim_mutex_unlock(&iree_hip_mem_pool_registry_mutex);
+
+  if (previous_selection) {
+    iree_hip_mem_pool_release(previous_selection->pool);
+    iree_allocator_free(iree_allocator_system(), previous_selection);
+  }
+  return hipSuccess;
+}
+
+static bool iree_hip_mem_pool_allocation_type_is_supported(
+    hipMemAllocationType allocation_type) {
+  return allocation_type == hipMemAllocationTypePinned ||
+         allocation_type == hipMemAllocationTypeManaged;
+}
+
+// Pool allocation and stream-ordered release are implemented for every
+// registered streaming device. This capability is independent of GPU
+// architecture.
+static bool iree_hip_memory_pools_supported(void) { return true; }
 
 //===----------------------------------------------------------------------===//
 // Flag translation functions
@@ -471,6 +757,33 @@ static uint32_t iree_hip_mem_location_type_to_uint(hipMemLocationType type) {
     default:
       return IREE_HAL_STREAMING_MEM_LOCATION_TYPE_INVALID;
   }
+}
+
+static hipError_t iree_hip_validate_mem_pool_props(
+    const hipMemPoolProps* props) {
+  if (!props) return hipErrorInvalidValue;
+  if (!iree_hip_mem_pool_allocation_type_is_supported(props->allocType)) {
+    return hipErrorInvalidValue;
+  }
+  if (props->handleTypes != hipMemHandleTypeNone) {
+    return hipErrorNotSupported;
+  }
+  if (props->win32SecurityAttributes) {
+    return hipErrorInvalidValue;
+  }
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(props->reserved); ++i) {
+    if (props->reserved[i] != 0) return hipErrorInvalidValue;
+  }
+  if (props->location.type != hipMemLocationTypeDevice) {
+    return hipErrorInvalidValue;
+  }
+  int device_count = 0;
+  hipError_t count_result = hipGetDeviceCount(&device_count);
+  if (count_result != hipSuccess) return count_result;
+  if (props->location.id < 0 || props->location.id >= device_count) {
+    return hipErrorInvalidValue;
+  }
+  return hipSuccess;
 }
 
 static iree_hal_streaming_mem_access_flags_t
@@ -1800,7 +2113,7 @@ HIPAPI hipError_t hipGetDeviceProperties(hipDeviceProp_t* prop, int device) {
   // HIP-on-AMDGPU supports native host/device atomics on the fine-grained
   // shared memory required during device initialization.
   prop->hostNativeAtomicSupported = 1;
-  prop->memoryPoolsSupported = is_gfx1100 ? 1 : 0;
+  prop->memoryPoolsSupported = iree_hip_memory_pools_supported() ? 1 : 0;
   prop->hostRegisterSupported = 1;
   prop->hostRegisterReadOnlySupported = 1;
   prop->maxSharedMemoryPerMultiProcessor =
@@ -1981,6 +2294,9 @@ HIPAPI hipError_t hipDeviceGetAttribute(int* value, hipDeviceAttribute_t attr,
       break;
     case hipDeviceAttributeHostRegisterSupported:
       *value = 1;
+      break;
+    case hipDeviceAttributeMemoryPoolsSupported:
+      *value = iree_hip_memory_pools_supported() ? 1 : 0;
       break;
     case hipDeviceAttributeConcurrentManagedAccess:
       *value = 1;
@@ -3196,7 +3512,8 @@ HIPAPI hipError_t hipDevicePrimaryCtxReset(hipDevice_t dev) {
     }
 
     // All allocations are released with the context — reset free memory.
-    device->free_memory = device->total_memory;
+    iree_atomic_store(&device->free_memory, device->total_memory,
+                      iree_memory_order_relaxed);
 
     // Lock to ensure thread safety during reset.
     iree_slim_mutex_lock(&device->primary_context_mutex);
@@ -3917,10 +4234,7 @@ static hipError_t iree_hip_current_mem_pool(
     iree_hal_streaming_context_t* context, hrx_mem_pool_t* out_pool) {
   if (!context || !context->device_entry) return hipErrorInvalidDevice;
   hrx_mem_pool_t pool =
-      iree_hal_streaming_device_mem_pool(context->device_entry);
-  if (!pool) {
-    pool = iree_hal_streaming_device_default_mem_pool(context->device_entry);
-  }
+      iree_hal_streaming_device_retain_mem_pool(context->device_entry);
   if (!pool) return hipErrorInvalidDevice;
   *out_pool = pool;
   return hipSuccess;
@@ -3956,7 +4270,7 @@ static hipError_t iree_hip_context_total_memory_from_spec(
 
 static hipError_t iree_hip_malloc_from_pool(
     iree_hal_streaming_context_t* context, hrx_mem_pool_t pool, size_t size,
-    void** out_ptr) {
+    iree_hal_streaming_stream_t* stream, void** out_ptr) {
   if (!pool) return hipErrorInvalidValue;
 
   // Reject absurdly large sizes that can't possibly succeed.
@@ -3974,8 +4288,11 @@ static hipError_t iree_hip_malloc_from_pool(
 
   iree_hal_streaming_buffer_t* buffer = NULL;
   const size_t allocation_size = iree_max(size, (size_t)8);
-  iree_status_t status = iree_hal_streaming_memory_allocate_device_from_pool(
-      context, pool, allocation_size, /*flags=*/0, &buffer);
+  iree_status_t status =
+      stream ? iree_hal_streaming_memory_allocate_device_from_pool_async(
+                   context, pool, allocation_size, /*flags=*/0, stream, &buffer)
+             : iree_hal_streaming_memory_allocate_device_from_pool(
+                   context, pool, allocation_size, /*flags=*/0, &buffer);
   if (!iree_status_is_ok(status)) return iree_status_to_hip_result(status);
   buffer->logical_size = (iree_device_size_t)size;
   *out_ptr = (void*)buffer->device_ptr;
@@ -4356,6 +4673,7 @@ HIPAPI hipError_t hipMalloc(void** ptr, size_t size) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
+  *ptr = NULL;
 
   // Ensure initialization and get context.
   iree_hal_streaming_context_t* context = NULL;
@@ -4377,14 +4695,15 @@ HIPAPI hipError_t hipMalloc(void** ptr, size_t size) {
     return hipSuccess;
   }
 
-  hrx_mem_pool_t pool = NULL;
-  hipError_t pool_result = iree_hip_current_mem_pool(context, &pool);
-  if (pool_result != hipSuccess) {
-    IREE_TRACE_ZONE_END(z0);
-    HIP_RETURN_ERROR(pool_result);
+  iree_hal_streaming_buffer_t* buffer = NULL;
+  const size_t allocation_size = iree_max(size, (size_t)8);
+  iree_status_t status = iree_hal_streaming_memory_allocate_device(
+      context, allocation_size, /*flags=*/0, &buffer);
+  hipError_t result = iree_status_to_hip_result(status);
+  if (result == hipSuccess) {
+    buffer->logical_size = (iree_device_size_t)size;
+    *ptr = (void*)buffer->device_ptr;
   }
-
-  hipError_t result = iree_hip_malloc_from_pool(context, pool, size, ptr);
   IREE_TRACE_ZONE_END(z0);
   return result;
 }
@@ -4401,18 +4720,84 @@ HIPAPI hipError_t hipMalloc(void** ptr, size_t size) {
 //  - hipErrorInvalidValue: ptr is NULL or invalid flags.
 //  - hipErrorOutOfMemory: Insufficient device memory.
 //
-// Note: This implementation ignores the flags and allocates default device
-// memory. Special memory types (fine-grained, uncached, signal) are not
-// currently supported and will be allocated as regular device memory.
+// Note: Default, uncached, and fixed-size signal-memory allocation modes are
+// implemented. Fine-grained allocations require a distinct HAL memory property
+// and fail loudly instead of falling back to default memory.
 //
 // See also: hipMalloc, hipFree.
 HIPAPI hipError_t hipExtMallocWithFlags(void** ptr, size_t sizeBytes,
                                         unsigned int flags) {
-  // For now, ignore flags and delegate to regular hipMalloc.
-  // Special memory types would require HAL support for different
-  // memory pool types.
-  (void)flags;
-  return hipMalloc(ptr, sizeBytes);
+  hipError_t init_result = iree_hip_ensure_initialized();
+  if (init_result != hipSuccess) {
+    HIP_RETURN_ERROR(init_result);
+  }
+  if (!ptr) {
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+  *ptr = NULL;
+  switch (flags) {
+    case hipDeviceMallocDefault:
+      return hipMalloc(ptr, sizeBytes);
+    case hipMallocSignalMemory: {
+      if (sizeBytes != sizeof(uint64_t)) {
+        HIP_RETURN_ERROR(hipErrorInvalidValue);
+      }
+
+      iree_hal_streaming_context_t* context = NULL;
+      hipError_t context_result = iree_hip_ensure_context(&context);
+      if (context_result != hipSuccess) {
+        HIP_RETURN_ERROR(context_result);
+      }
+      if (iree_hip_context_invalidate_non_relaxed_visible_captures(context)) {
+        HIP_RETURN_ERROR(hipErrorStreamCaptureUnsupported);
+      }
+
+      iree_hal_streaming_buffer_t* buffer = NULL;
+      iree_status_t status = iree_hal_streaming_memory_allocate_host(
+          context, sizeBytes,
+          IREE_HAL_STREAMING_HOST_REGISTER_FLAG_HIP_SIGNAL_MEMORY, &buffer);
+      if (iree_status_is_ok(status)) {
+        *ptr = buffer->host_ptr;
+      }
+      return iree_status_to_hip_result(status);
+    }
+    case hipDeviceMallocUncached: {
+      if (sizeBytes == 0) {
+        return hipSuccess;
+      }
+      iree_hal_streaming_context_t* context = NULL;
+      hipError_t context_result = iree_hip_ensure_context(&context);
+      if (context_result != hipSuccess) {
+        HIP_RETURN_ERROR(context_result);
+      }
+      if (iree_hip_context_invalidate_non_relaxed_visible_captures(context)) {
+        HIP_RETURN_ERROR(hipErrorStreamCaptureUnsupported);
+      }
+      iree_hal_streaming_buffer_t* buffer = NULL;
+      iree_status_t status = iree_hal_streaming_memory_allocate_device(
+          context, sizeBytes, IREE_HAL_STREAMING_MEMORY_FLAG_UNCACHED, &buffer);
+      if (iree_status_is_ok(status)) {
+        *ptr = (void*)iree_hal_streaming_buffer_device_pointer(buffer);
+      }
+      return iree_status_to_hip_result(status);
+    }
+    case hipDeviceMallocFinegrained: {
+      // Zero-byte allocations never consume a mode-specific resource, while
+      // unrepresentable requests must not be misreported as missing hardware
+      // support.
+      if (sizeBytes == 0) {
+        return hipSuccess;
+      }
+      hipError_t size_result =
+          iree_hip_validate_host_allocation_size(sizeBytes);
+      if (size_result != hipSuccess) {
+        HIP_RETURN_ERROR(size_result);
+      }
+      HIP_RETURN_ERROR(hipErrorNotSupported);
+    }
+    default:
+      HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
 }
 
 // Allocates pitched linear memory on the device.
@@ -4540,15 +4925,42 @@ HIPAPI hipError_t hipFree(void* ptr) {
   iree_status_t status = iree_hal_streaming_memory_free_device(
       context, (iree_hal_streaming_deviceptr_t)ptr);
 
-  // Convert status to HIP error. Invalid pointers (including already-freed
-  // pointers) should return hipErrorInvalidValue, not hipErrorNotFound.
+  // A signal allocation is host-visible storage but, unlike ordinary host
+  // allocations, this API owns it. Keep that exception explicit so hipFree
+  // does not accidentally accept arbitrary pinned host pointers.
   hipError_t result;
   if (iree_status_is_ok(status)) {
     result = hipSuccess;
-  } else if (iree_status_code(status) == IREE_STATUS_NOT_FOUND) {
-    // Pointer not found in allocation table - invalid or already freed.
+  } else if (iree_status_code(status) == IREE_STATUS_NOT_FOUND ||
+             iree_status_code(status) == IREE_STATUS_INVALID_ARGUMENT) {
     iree_status_free(status);
-    result = hipErrorInvalidValue;
+    iree_hal_streaming_host_register_flags_t host_flags =
+        IREE_HAL_STREAMING_HOST_REGISTER_FLAG_DEFAULT;
+    status = iree_hal_streaming_memory_host_flags(context, ptr, &host_flags);
+    if (!iree_status_is_ok(status)) {
+      if (iree_status_code(status) == IREE_STATUS_NOT_FOUND ||
+          iree_status_code(status) == IREE_STATUS_INVALID_ARGUMENT) {
+        iree_status_free(status);
+        result = hipErrorInvalidValue;
+      } else {
+        result = iree_status_to_hip_result(status);
+      }
+    } else if (iree_any_bit_set(
+                   host_flags,
+                   IREE_HAL_STREAMING_HOST_REGISTER_FLAG_HIP_SIGNAL_MEMORY)) {
+      status = iree_hal_streaming_memory_free_host(context, ptr);
+      if (iree_status_is_ok(status)) {
+        result = hipSuccess;
+      } else if (iree_status_code(status) == IREE_STATUS_NOT_FOUND ||
+                 iree_status_code(status) == IREE_STATUS_INVALID_ARGUMENT) {
+        iree_status_free(status);
+        result = hipErrorInvalidValue;
+      } else {
+        result = iree_status_to_hip_result(status);
+      }
+    } else {
+      result = hipErrorInvalidValue;
+    }
   } else {
     result = iree_status_to_hip_result(status);
   }
@@ -5506,6 +5918,24 @@ static hipError_t iree_hip_validate_memcpy_ranges(
   }
 }
 
+// Returns true when |dst| is not backed by a host allocation tracked in the
+// current context. HIP completes D2H copies to such pageable memory before the
+// API call returns, while tracked host memory remains stream ordered.
+static bool iree_hip_memcpy_destination_is_pageable(
+    iree_hal_streaming_context_t* context, const void* dst, size_t size) {
+  iree_hal_streaming_buffer_ref_t dst_ref;
+  iree_status_t status = iree_hal_streaming_memory_lookup_range(
+      context, (iree_hal_streaming_deviceptr_t)(uintptr_t)dst, size, &dst_ref);
+  const bool is_pageable = !iree_status_is_ok(status);
+  iree_status_ignore(status);
+  return is_pageable;
+}
+
+static hipError_t iree_hip_memcpy_peer_staged(
+    iree_hal_streaming_context_t* dst_context, void* dst,
+    iree_hal_streaming_context_t* src_context, const void* src,
+    size_t size_bytes, iree_hal_streaming_stream_t* stream);
+
 static hipError_t iree_hip_try_cross_context_h2d(
     iree_hal_streaming_context_t* context, void* dst, const void* src,
     size_t size, bool* out_handled) {
@@ -5964,6 +6394,11 @@ HIPAPI hipError_t hipMemcpyAsync(void* dst, const void* src, size_t sizeBytes,
     HIP_RETURN_ERROR(range_result);
   }
 
+  const bool pageable_d2h =
+      kind == hipMemcpyDeviceToHost &&
+      stream_obj->capture_status != IREE_HAL_STREAMING_CAPTURE_STATUS_ACTIVE &&
+      iree_hip_memcpy_destination_is_pageable(context, dst, sizeBytes);
+
   if (!stream || stream == hipStreamLegacy) {
     iree_status_t order_status =
         iree_hal_streaming_context_synchronize_legacy_default(context);
@@ -6032,6 +6467,9 @@ HIPAPI hipError_t hipMemcpyAsync(void* dst, const void* src, size_t sizeBytes,
       status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT);
       break;
   }
+  if (iree_status_is_ok(status) && pageable_d2h) {
+    status = iree_hal_streaming_stream_synchronize(stream_obj);
+  }
 
   hipError_t result = iree_status_to_hip_result(status);
   IREE_TRACE_ZONE_END(z0);
@@ -6064,6 +6502,14 @@ HIPAPI hipError_t hipMemcpyWithStream(void* dst, const void* src,
   return result;
 }
 
+static bool iree_hip_calculate_2d_copy_span(size_t pitch, size_t width,
+                                            size_t height, size_t* out_span) {
+  *out_span = 0;
+  if (width == 0 || height == 0) return true;
+  return iree_host_size_checked_mul(height - 1, pitch, out_span) &&
+         iree_host_size_checked_add(*out_span, width, out_span);
+}
+
 static hipError_t iree_hip_validate_2d_copy_shape(size_t dst_pitch,
                                                   size_t src_pitch,
                                                   size_t width, size_t height,
@@ -6071,6 +6517,12 @@ static hipError_t iree_hip_validate_2d_copy_shape(size_t dst_pitch,
   if (width == 0 || height == 0) return hipSuccess;
   if (width > dst_pitch || width > src_pitch) {
     return pitch_error;
+  }
+  size_t dst_span = 0;
+  size_t src_span = 0;
+  if (!iree_hip_calculate_2d_copy_span(dst_pitch, width, height, &dst_span) ||
+      !iree_hip_calculate_2d_copy_span(src_pitch, width, height, &src_span)) {
+    return hipErrorInvalidValue;
   }
   int max_pitch = 0;
   if (hipDeviceGetAttribute(&max_pitch, hipDeviceAttributeMaxPitch, 0) ==
@@ -6314,6 +6766,30 @@ HIPAPI hipError_t hipMemcpy2DAsync(void* dst, size_t dpitch, const void* src,
     return hipSuccess;
   }
 
+  size_t dst_span = 0;
+  if (!iree_hip_calculate_2d_copy_span(dpitch, width, height, &dst_span)) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+  const bool pageable_d2h =
+      kind == hipMemcpyDeviceToHost &&
+      iree_hip_memcpy_destination_is_pageable(context, dst, dst_span);
+
+  if (kind == hipMemcpyDeviceToHost) {
+    iree_status_t packed_status = iree_hal_streaming_memcpy_device_to_host_2d(
+        context, dst, dpitch, (iree_hal_streaming_deviceptr_t)src, spitch,
+        width, height, stream_obj);
+    if (!iree_status_is_unavailable(packed_status)) {
+      if (iree_status_is_ok(packed_status) && pageable_d2h) {
+        packed_status = iree_hal_streaming_stream_synchronize(stream_obj);
+      }
+      hipError_t result = iree_status_to_hip_result(packed_status);
+      IREE_TRACE_ZONE_END(z0);
+      return result;
+    }
+    iree_status_ignore(packed_status);
+  }
+
   // Copy row by row.
   iree_status_t status = iree_ok_status();
   if (kind == hipMemcpyHostToHost) {
@@ -6349,6 +6825,9 @@ HIPAPI hipError_t hipMemcpy2DAsync(void* dst, size_t dpitch, const void* src,
     }
     src_ptr += spitch;
     dst_ptr += dpitch;
+  }
+  if (iree_status_is_ok(status) && pageable_d2h) {
+    status = iree_hal_streaming_stream_synchronize(stream_obj);
   }
 
   hipError_t result = iree_status_to_hip_result(status);
@@ -6472,21 +6951,47 @@ static hipError_t iree_hip_memcpy3d_staged_rows(
     return iree_status_to_hip_result(status);
   }
 
+  if (src_context) {
+    // A stream can only record commands for buffers owned by its HAL device.
+    // Cross-device copies may be requested while another device is current,
+    // making the implicit stream foreign to the source allocation. Preserve
+    // ordering with that stream, then use blocking transfers on the source
+    // device instead of recording an invalid cross-device command buffer.
+    if (stream->context != src_context) {
+      status = iree_hal_streaming_stream_synchronize(stream);
+      for (size_t z = 0; z < depth && iree_status_is_ok(status); ++z) {
+        uint8_t* dst_slice = dst_base + z * dst_slice_pitch;
+        const uint8_t* src_slice = src_base + z * src_slice_pitch;
+        for (size_t y = 0; y < height && iree_status_is_ok(status); ++y) {
+          status = iree_hal_streaming_memcpy_device_to_host(
+              src_context, dst_slice + y * dst_pitch,
+              (iree_hal_streaming_deviceptr_t)(src_slice + y * src_pitch),
+              width, NULL);
+        }
+      }
+      return iree_status_to_hip_result(status);
+    }
+    for (size_t z = 0; z < depth && iree_status_is_ok(status); ++z) {
+      status = iree_hal_streaming_memcpy_device_to_host_2d(
+          src_context, dst_base + z * dst_slice_pitch, dst_pitch,
+          (iree_hal_streaming_deviceptr_t)(src_base + z * src_slice_pitch),
+          src_pitch, width, height, stream);
+    }
+    return iree_status_to_hip_result(status);
+  }
+
+  if (stream->context != dst_context) {
+    status = iree_hal_streaming_stream_synchronize(stream);
+    stream = NULL;
+  }
   for (size_t z = 0; z < depth && iree_status_is_ok(status); ++z) {
     uint8_t* dst_slice = dst_base + z * dst_slice_pitch;
     const uint8_t* src_slice = src_base + z * src_slice_pitch;
     for (size_t y = 0; y < height && iree_status_is_ok(status); ++y) {
-      if (src_context) {
-        status = iree_hal_streaming_memcpy_device_to_host(
-            src_context, dst_slice + y * dst_pitch,
-            (iree_hal_streaming_deviceptr_t)(src_slice + y * src_pitch), width,
-            stream);
-      } else {
-        status = iree_hal_streaming_memcpy_host_to_device(
-            dst_context,
-            (iree_hal_streaming_deviceptr_t)(dst_slice + y * dst_pitch),
-            src_slice + y * src_pitch, width, stream);
-      }
+      status = iree_hal_streaming_memcpy_host_to_device(
+          dst_context,
+          (iree_hal_streaming_deviceptr_t)(dst_slice + y * dst_pitch),
+          src_slice + y * src_pitch, width, stream);
     }
   }
   return iree_status_to_hip_result(status);
@@ -6750,7 +7255,12 @@ HIPAPI hipError_t hipMemcpy3DAsync(const hipMemcpy3DParms* p,
   const bool dst_is_contiguous = p->dstPos.x == 0 && p->dstPos.y == 0 &&
                                  p->extent.width == p->dstPtr.pitch &&
                                  p->extent.height == dst_rows_per_slice;
-  if (!return_after_lookup && src_is_contiguous && dst_is_contiguous) {
+  const bool is_cross_context_device_copy =
+      (effective_kind == hipMemcpyDeviceToDevice ||
+       effective_kind == hipMemcpyDeviceToDeviceNoCU) &&
+      dst_is_device && src_is_device && dst_context != src_context;
+  if (!return_after_lookup && !is_cross_context_device_copy &&
+      src_is_contiguous && dst_is_contiguous) {
     iree_host_size_t byte_count = 0;
     if (IREE_UNLIKELY(!iree_host_size_checked_mul(
             src_slice_pitch, p->extent.depth, &byte_count))) {
@@ -6800,6 +7310,13 @@ HIPAPI hipError_t hipMemcpy3DAsync(const hipMemcpy3DParms* p,
     }
     if (use_staged_copy) {
       result = staged_result;
+      // Strided copies queue one transfer per row. Complete the pageable D2H
+      // operation only after its final row is queued on the source stream.
+      if (result == hipSuccess && effective_kind == hipMemcpyDeviceToHost &&
+          !have_dst && stream_obj->context == src_context) {
+        result = iree_status_to_hip_result(
+            iree_hal_streaming_stream_synchronize(stream_obj));
+      }
       return_after_lookup = true;
     }
   }
@@ -7083,18 +7600,12 @@ static hipError_t iree_hip_array_byte_range_to_elements(
   return result;
 }
 
-static hipError_t iree_hip_array_linear_range(
-    hipArray_const_t array, size_t byte_offset, size_t row_offset,
-    size_t byte_count, const struct hipArray_st** out_array,
+static hipError_t iree_hip_array_row_device_pointer(
+    const struct hipArray_st* array_info, size_t row_offset, size_t byte_offset,
     iree_hal_streaming_deviceptr_t* out_device_ptr) {
-  if (out_array) *out_array = NULL;
-  if (out_device_ptr) *out_device_ptr = 0;
-  struct hipArray_st* array_info = NULL;
-  hipError_t result = iree_hip_array_retain(array, &array_info);
-  if (result != hipSuccess) return result;
-  if (byte_offset > array_info->width_bytes ||
-      row_offset >= array_info->rows_per_slice) {
-    iree_hip_array_release(array_info);
+  *out_device_ptr = 0;
+  if (!array_info || row_offset >= array_info->rows_per_slice ||
+      byte_offset >= array_info->width_bytes) {
     return hipErrorInvalidValue;
   }
   iree_host_size_t row_start = 0;
@@ -7102,19 +7613,132 @@ static hipError_t iree_hip_array_linear_range(
   if (IREE_UNLIKELY(
           !iree_host_size_checked_mul(row_offset, array_info->pitch,
                                       &row_start) ||
-          !iree_host_size_checked_add(row_start, byte_offset, &range_start))) {
-    iree_hip_array_release(array_info);
+          !iree_host_size_checked_add(row_start, byte_offset, &range_start) ||
+          range_start > array_info->allocation_size)) {
     return hipErrorInvalidValue;
   }
-  if (range_start > array_info->allocation_size ||
-      byte_count > array_info->allocation_size - range_start) {
-    iree_hip_array_release(array_info);
-    return hipErrorInvalidValue;
-  }
-  if (out_array) *out_array = array_info;
-  if (out_device_ptr) *out_device_ptr = array_info->device_ptr + range_start;
-  if (!out_array) iree_hip_array_release(array_info);
+  *out_device_ptr = array_info->device_ptr + range_start;
   return hipSuccess;
+}
+
+static hipError_t iree_hip_array_enqueue_packed_row_copy(
+    bool array_is_destination, iree_hal_streaming_deviceptr_t array_ptr,
+    void* external_ptr, size_t byte_count, hipMemcpyKind kind) {
+  if (array_is_destination) {
+    return hipMemcpyAsync((void*)array_ptr, external_ptr, byte_count, kind,
+                          NULL);
+  }
+  return hipMemcpyAsync(external_ptr, (const void*)array_ptr, byte_count, kind,
+                        NULL);
+}
+
+static hipError_t iree_hip_array_enqueue_packed_rows_copy(
+    bool array_is_destination, iree_hal_streaming_deviceptr_t array_ptr,
+    size_t array_pitch, void* external_ptr, size_t row_width, size_t row_count,
+    hipMemcpyKind kind) {
+  if (array_is_destination) {
+    return hipMemcpy2DAsync((void*)array_ptr, array_pitch, external_ptr,
+                            row_width, row_width, row_count, kind, NULL);
+  }
+  return hipMemcpy2DAsync(external_ptr, row_width, (const void*)array_ptr,
+                          array_pitch, row_width, row_count, kind, NULL);
+}
+
+// Copies the selected 2D array slice as a packed byte stream. The allocation
+// pitch is an implementation detail, so a range spanning rows must skip its
+// padding rather than expose that padding to the caller. The synchronous APIs
+// enqueue a prefix, complete-row range, and suffix on the default stream, then
+// synchronize once after all successfully queued work has completed.
+static hipError_t iree_hip_array_copy_packed_rows(
+    hipArray_const_t array, size_t byte_offset, size_t row_offset,
+    void* external_ptr, size_t byte_count, hipMemcpyKind kind,
+    bool array_is_destination) {
+  struct hipArray_st* array_info = NULL;
+  hipError_t result = iree_hip_array_retain(array, &array_info);
+  if (result != hipSuccess) return result;
+
+  iree_host_size_t whole_row_byte_count = 0;
+  iree_host_size_t remaining_byte_count = 0;
+  if (byte_offset >= array_info->width_bytes ||
+      row_offset >= array_info->rows_per_slice ||
+      !iree_host_size_checked_mul(array_info->rows_per_slice - row_offset - 1,
+                                  array_info->width_bytes,
+                                  &whole_row_byte_count) ||
+      !iree_host_size_checked_add(array_info->width_bytes - byte_offset,
+                                  whole_row_byte_count,
+                                  &remaining_byte_count) ||
+      byte_count > remaining_byte_count) {
+    iree_hip_array_release(array_info);
+    return hipErrorInvalidValue;
+  }
+
+  iree_hal_streaming_context_t* context = NULL;
+  result = iree_hip_ensure_context(&context);
+  if (result == hipSuccess &&
+      iree_hip_context_invalidate_visible_captures(context)) {
+    result = hipErrorStreamCaptureImplicit;
+  }
+
+  bool may_have_enqueued_work = false;
+  size_t external_offset = 0;
+  size_t current_row = row_offset;
+  size_t remaining = byte_count;
+  const size_t first_row_byte_count =
+      byte_offset == 0 ? 0
+                       : (remaining < array_info->width_bytes - byte_offset
+                              ? remaining
+                              : array_info->width_bytes - byte_offset);
+  if (result == hipSuccess && first_row_byte_count != 0) {
+    iree_hal_streaming_deviceptr_t array_ptr = 0;
+    result = iree_hip_array_row_device_pointer(array_info, current_row,
+                                               byte_offset, &array_ptr);
+    if (result == hipSuccess) {
+      may_have_enqueued_work = true;
+      result = iree_hip_array_enqueue_packed_row_copy(
+          array_is_destination, array_ptr, (uint8_t*)external_ptr,
+          first_row_byte_count, kind);
+    }
+    external_offset = first_row_byte_count;
+    remaining -= first_row_byte_count;
+    ++current_row;
+  }
+
+  const size_t full_row_count = remaining / array_info->width_bytes;
+  if (result == hipSuccess && full_row_count != 0) {
+    iree_hal_streaming_deviceptr_t array_ptr = 0;
+    result = iree_hip_array_row_device_pointer(array_info, current_row, 0,
+                                               &array_ptr);
+    if (result == hipSuccess) {
+      may_have_enqueued_work = true;
+      result = iree_hip_array_enqueue_packed_rows_copy(
+          array_is_destination, array_ptr, array_info->pitch,
+          (uint8_t*)external_ptr + external_offset, array_info->width_bytes,
+          full_row_count, kind);
+    }
+    const size_t full_row_byte_count = full_row_count * array_info->width_bytes;
+    external_offset += full_row_byte_count;
+    remaining -= full_row_byte_count;
+    current_row += full_row_count;
+  }
+
+  if (result == hipSuccess && remaining != 0) {
+    iree_hal_streaming_deviceptr_t array_ptr = 0;
+    result = iree_hip_array_row_device_pointer(array_info, current_row, 0,
+                                               &array_ptr);
+    if (result == hipSuccess) {
+      may_have_enqueued_work = true;
+      result = iree_hip_array_enqueue_packed_row_copy(
+          array_is_destination, array_ptr,
+          (uint8_t*)external_ptr + external_offset, remaining, kind);
+    }
+  }
+
+  if (may_have_enqueued_work) {
+    hipError_t synchronize_result = hipDeviceSynchronize();
+    if (result == hipSuccess) result = synchronize_result;
+  }
+  iree_hip_array_release(array_info);
+  return result;
 }
 
 static hipError_t iree_hip_array_legacy_row_range(
@@ -7621,24 +8245,22 @@ HIPAPI hipError_t hipMemcpyToArray(hipArray_t dst, size_t wOffset,
                                    size_t hOffset, const void* src,
                                    size_t count, hipMemcpyKind kind) {
   if (!src) HIP_RETURN_ERROR(hipErrorInvalidValue);
-  if (count == 0) return hipSuccess;
-  iree_hal_streaming_deviceptr_t dst_ptr = 0;
-  hipError_t result = iree_hip_array_linear_range(
-      (hipArray_const_t)dst, wOffset, hOffset, count, NULL, &dst_ptr);
+  hipError_t result = iree_hip_array_copy_packed_rows(
+      (hipArray_const_t)dst, wOffset, hOffset, (void*)src, count, kind,
+      /*array_is_destination=*/true);
   if (result != hipSuccess) HIP_RETURN_ERROR(result);
-  return hipMemcpy((void*)dst_ptr, src, count, kind);
+  return hipSuccess;
 }
 
 HIPAPI hipError_t hipMemcpyFromArray(void* dst, hipArray_const_t srcArray,
                                      size_t wOffset, size_t hOffset,
                                      size_t count, hipMemcpyKind kind) {
   if (!dst) HIP_RETURN_ERROR(hipErrorInvalidValue);
-  if (count == 0) return hipSuccess;
-  iree_hal_streaming_deviceptr_t src_ptr = 0;
-  hipError_t result = iree_hip_array_linear_range(srcArray, wOffset, hOffset,
-                                                  count, NULL, &src_ptr);
+  hipError_t result = iree_hip_array_copy_packed_rows(
+      srcArray, wOffset, hOffset, dst, count, kind,
+      /*array_is_destination=*/false);
   if (result != hipSuccess) HIP_RETURN_ERROR(result);
-  return hipMemcpy(dst, (const void*)src_ptr, count, kind);
+  return hipSuccess;
 }
 
 HIPAPI hipError_t hipMemcpyHtoAAsync(hipArray_t dstArray, size_t dstOffset,
@@ -8100,7 +8722,7 @@ HIPAPI hipError_t hipMalloc3D(hipPitchedPtr* pitchedDevPtr, hipExtent extent) {
     HIP_RETURN_ERROR(init_result);
   }
 
-  const size_t alignment = 512;
+  const size_t alignment = IREE_HAL_STREAMING_PITCHED_ALLOCATION_ALIGNMENT;
   size_t pitch = 0;
   size_t slice_size = 0;
   size_t total_size = 0;
@@ -8411,6 +9033,12 @@ static hipError_t iree_hip_memcpy_peer_staged(
     status = iree_hal_streaming_memcpy_device_to_host(
         src_context, staging, (iree_hal_streaming_deviceptr_t)src, size_bytes,
         src_stream);
+  }
+  if (iree_status_is_ok(status) && src_stream) {
+    // This fallback consumes and releases |staging| before returning. A D2H
+    // queued on the source stream must complete before the destination
+    // transfer can read that storage.
+    status = iree_hal_streaming_stream_synchronize(src_stream);
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_streaming_memcpy_host_to_device(
@@ -13781,10 +14409,18 @@ HIPAPI hipError_t hipMemRangeGetAttributes(void** data, size_t* data_sizes,
 //===----------------------------------------------------------------------===//
 
 struct hipUserObject {
+  // References held by the live-handle registry, graphs, and active API calls.
+  iree_atomic_ref_count_t handle_ref_count;
+  // Next live user-object handle in the process registry.
+  struct hipUserObject* next_live_object;
   // Protects reference count changes from user and graph-owner threads.
   iree_slim_mutex_t mutex;
   // Current retained reference count.
   uint64_t ref_count;
+  // Number of graph records that still reference this control block.
+  uint64_t graph_association_count;
+  // Whether the user payload destructor has been invoked.
+  bool destructor_called;
   // User pointer passed to the destructor callback.
   void* ptr;
   // Destructor callback invoked when the retained count reaches zero.
@@ -13793,12 +14429,85 @@ struct hipUserObject {
   iree_allocator_t host_allocator;
 };
 
+static iree_once_flag iree_hip_user_object_registry_mutex_once =
+    IREE_ONCE_FLAG_INIT;
+static iree_slim_mutex_t iree_hip_user_object_registry_mutex;
+static hipUserObject_t iree_hip_user_object_registry_head = NULL;
+
+static void iree_hip_user_object_registry_mutex_initialize(void) {
+  iree_slim_mutex_initialize(&iree_hip_user_object_registry_mutex);
+}
+
+static void iree_hip_user_object_registry_lock(void) {
+  iree_call_once(&iree_hip_user_object_registry_mutex_once,
+                 iree_hip_user_object_registry_mutex_initialize);
+  iree_slim_mutex_lock(&iree_hip_user_object_registry_mutex);
+}
+
+static void iree_hip_user_object_handle_release(hipUserObject_t user_object) {
+  if (!user_object ||
+      iree_atomic_ref_count_dec(&user_object->handle_ref_count) != 1) {
+    return;
+  }
+  iree_slim_mutex_deinitialize(&user_object->mutex);
+  iree_allocator_free(user_object->host_allocator, user_object);
+}
+
+static void iree_hip_user_object_registry_insert(hipUserObject_t user_object) {
+  iree_hip_user_object_registry_lock();
+  user_object->next_live_object = iree_hip_user_object_registry_head;
+  iree_hip_user_object_registry_head = user_object;
+  iree_slim_mutex_unlock(&iree_hip_user_object_registry_mutex);
+}
+
+static bool iree_hip_user_object_registry_retain(hipUserObject_t object,
+                                                 hipUserObject_t* out_object) {
+  if (out_object) *out_object = NULL;
+  if (!object) return false;
+
+  bool found = false;
+  iree_hip_user_object_registry_lock();
+  for (hipUserObject_t current = iree_hip_user_object_registry_head; current;
+       current = current->next_live_object) {
+    if (current == object) {
+      iree_atomic_ref_count_inc(&current->handle_ref_count);
+      if (out_object) *out_object = current;
+      found = true;
+      break;
+    }
+  }
+  iree_slim_mutex_unlock(&iree_hip_user_object_registry_mutex);
+  return found;
+}
+
+static bool iree_hip_user_object_registry_remove(hipUserObject_t user_object) {
+  bool removed = false;
+  iree_hip_user_object_registry_lock();
+  hipUserObject_t* current = &iree_hip_user_object_registry_head;
+  while (*current) {
+    if (*current == user_object) {
+      *current = user_object->next_live_object;
+      user_object->next_live_object = NULL;
+      removed = true;
+      break;
+    }
+    current = &(*current)->next_live_object;
+  }
+  iree_slim_mutex_unlock(&iree_hip_user_object_registry_mutex);
+  if (removed) {
+    iree_hip_user_object_handle_release(user_object);
+  }
+  return removed;
+}
+
 static hipError_t iree_hip_user_object_retain_refs_checked(
     hipUserObject_t user_object, uint64_t count) {
   if (!user_object || count == 0) return hipErrorInvalidValue;
   hipError_t result = hipSuccess;
   iree_slim_mutex_lock(&user_object->mutex);
-  if (UINT64_MAX - user_object->ref_count < count) {
+  if (user_object->destructor_called) {
+    // A completed user object cannot be resurrected.
+  } else if (UINT64_MAX - user_object->ref_count < count) {
     result = hipErrorInvalidValue;
   } else {
     user_object->ref_count += count;
@@ -13812,56 +14521,121 @@ static hipError_t iree_hip_user_object_check_ref_count(
   if (!user_object || count == 0) return hipErrorInvalidValue;
   hipError_t result = hipSuccess;
   iree_slim_mutex_lock(&user_object->mutex);
-  if (count > user_object->ref_count) {
+  if (!user_object->destructor_called && count > user_object->ref_count) {
     result = hipErrorInvalidValue;
   }
   iree_slim_mutex_unlock(&user_object->mutex);
   return result;
 }
 
-static iree_status_t iree_hip_user_object_retain_refs(void* object,
-                                                      uint64_t count) {
+static iree_status_t iree_hip_user_object_retain_graph_refs(void* object,
+                                                            uint64_t count) {
   hipUserObject_t user_object = (hipUserObject_t)object;
-  hipError_t result =
-      iree_hip_user_object_retain_refs_checked(user_object, count);
-  if (result != hipSuccess) {
+  if (!user_object || count == 0) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT);
   }
-  return iree_ok_status();
+
+  iree_status_t status = iree_ok_status();
+  iree_slim_mutex_lock(&user_object->mutex);
+  if (user_object->graph_association_count == UINT64_MAX ||
+      (!user_object->destructor_called &&
+       UINT64_MAX - user_object->ref_count < count)) {
+    status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED);
+  } else {
+    ++user_object->graph_association_count;
+    iree_atomic_ref_count_inc(&user_object->handle_ref_count);
+    if (!user_object->destructor_called) {
+      user_object->ref_count += count;
+    }
+  }
+  iree_slim_mutex_unlock(&user_object->mutex);
+  return status;
+}
+
+static hipError_t iree_hip_user_object_add_graph_association(
+    hipUserObject_t user_object) {
+  if (!user_object) return hipErrorInvalidValue;
+  hipError_t result = hipSuccess;
+  iree_slim_mutex_lock(&user_object->mutex);
+  if (user_object->graph_association_count == UINT64_MAX) {
+    result = hipErrorInvalidValue;
+  } else {
+    ++user_object->graph_association_count;
+    iree_atomic_ref_count_inc(&user_object->handle_ref_count);
+  }
+  iree_slim_mutex_unlock(&user_object->mutex);
+  return result;
+}
+
+static hipError_t iree_hip_user_object_release_refs_internal(
+    hipUserObject_t user_object, uint64_t count,
+    bool release_graph_association) {
+  if (!user_object || count == 0) return hipErrorInvalidValue;
+
+  bool should_destroy = false;
+  void* ptr = NULL;
+  hipHostFn_t destroy = NULL;
+  hipError_t result = hipSuccess;
+  iree_slim_mutex_lock(&user_object->mutex);
+  if (release_graph_association && user_object->graph_association_count == 0) {
+    result = hipErrorInvalidValue;
+  } else if (!user_object->destructor_called &&
+             count > user_object->ref_count) {
+    result = hipErrorInvalidValue;
+  } else {
+    if (!user_object->destructor_called) {
+      user_object->ref_count -= count;
+      if (user_object->ref_count == 0) {
+        user_object->destructor_called = true;
+        should_destroy = true;
+        ptr = user_object->ptr;
+        destroy = user_object->destroy;
+      }
+    }
+    if (release_graph_association) {
+      --user_object->graph_association_count;
+    }
+  }
+  iree_slim_mutex_unlock(&user_object->mutex);
+
+  if (should_destroy) {
+    // Remove the public handle before invoking user code so reentrant API calls
+    // observe a completed object without dereferencing its control block.
+    (void)iree_hip_user_object_registry_remove(user_object);
+    destroy(ptr);
+  }
+  return result;
 }
 
 static hipError_t iree_hip_user_object_release_refs_checked(
     hipUserObject_t user_object, uint64_t count) {
-  if (!user_object || count == 0) return hipErrorInvalidValue;
-  bool should_destroy = false;
-  void* ptr = NULL;
-  hipHostFn_t destroy = NULL;
-  iree_allocator_t host_allocator = iree_allocator_system();
-  hipError_t result = hipSuccess;
-  iree_slim_mutex_lock(&user_object->mutex);
-  if (count > user_object->ref_count) {
-    result = hipErrorInvalidValue;
-  } else {
-    user_object->ref_count -= count;
-    if (user_object->ref_count == 0) {
-      should_destroy = true;
-      ptr = user_object->ptr;
-      destroy = user_object->destroy;
-      host_allocator = user_object->host_allocator;
-    }
+  return iree_hip_user_object_release_refs_internal(
+      user_object, count, /*release_graph_association=*/false);
+}
+
+static void iree_hip_user_object_release_graph_refs(void* object,
+                                                    uint64_t count) {
+  hipUserObject_t user_object = (hipUserObject_t)object;
+  hipError_t result = iree_hip_user_object_release_refs_internal(
+      user_object, count, /*release_graph_association=*/true);
+  if (result == hipSuccess) {
+    iree_hip_user_object_handle_release(user_object);
   }
-  iree_slim_mutex_unlock(&user_object->mutex);
-  if (should_destroy) {
-    destroy(ptr);
-    iree_slim_mutex_deinitialize(&user_object->mutex);
-    iree_allocator_free(host_allocator, user_object);
-  }
-  return result;
 }
 
 static void iree_hip_user_object_release_refs(void* object, uint64_t count) {
   (void)iree_hip_user_object_release_refs_checked((hipUserObject_t)object,
                                                   count);
+}
+
+static hipError_t iree_hip_user_object_remove_graph_association(
+    hipUserObject_t user_object, uint64_t count) {
+  hipError_t result = iree_hip_user_object_release_refs_internal(
+      user_object, count, /*release_graph_association=*/true);
+  if (result == hipSuccess) {
+    iree_hip_user_object_handle_release(user_object);
+  }
+  return result;
 }
 
 HIPAPI hipError_t hipUserObjectCreate(hipUserObject_t* object_out, void* ptr,
@@ -13881,10 +14655,15 @@ HIPAPI hipError_t hipUserObjectCreate(hipUserObject_t* object_out, void* ptr,
     HIP_RETURN_ERROR(hipErrorOutOfMemory);
   }
   iree_slim_mutex_initialize(&object->mutex);
+  iree_atomic_ref_count_init(&object->handle_ref_count);
+  object->next_live_object = NULL;
   object->ref_count = initialRefcount;
+  object->graph_association_count = 0;
+  object->destructor_called = false;
   object->ptr = ptr;
   object->destroy = destroy;
   object->host_allocator = host_allocator;
+  iree_hip_user_object_registry_insert(object);
   *object_out = object;
   return hipSuccess;
 }
@@ -13894,7 +14673,13 @@ HIPAPI hipError_t hipUserObjectRelease(hipUserObject_t object,
   if (!object || count == 0) {
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
-  hipError_t result = iree_hip_user_object_release_refs_checked(object, count);
+  hipUserObject_t retained_object = NULL;
+  if (!iree_hip_user_object_registry_retain(object, &retained_object)) {
+    return hipSuccess;
+  }
+  hipError_t result =
+      iree_hip_user_object_release_refs_checked(retained_object, count);
+  iree_hip_user_object_handle_release(retained_object);
   if (result != hipSuccess) {
     HIP_RETURN_ERROR(result);
   }
@@ -13906,7 +14691,13 @@ HIPAPI hipError_t hipUserObjectRetain(hipUserObject_t object,
   if (!object || count == 0) {
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
-  hipError_t result = iree_hip_user_object_retain_refs_checked(object, count);
+  hipUserObject_t retained_object = NULL;
+  if (!iree_hip_user_object_registry_retain(object, &retained_object)) {
+    return hipSuccess;
+  }
+  hipError_t result =
+      iree_hip_user_object_retain_refs_checked(retained_object, count);
+  iree_hip_user_object_handle_release(retained_object);
   if (result != hipSuccess) {
     HIP_RETURN_ERROR(result);
   }
@@ -13947,10 +14738,16 @@ HIPAPI hipError_t hipGraphRetainUserObject(hipGraph_t graph,
     }
   }
 
+  hipUserObject_t retained_object = NULL;
+  if (!iree_hip_user_object_registry_retain(object, &retained_object)) {
+    return hipSuccess;
+  }
+  object = retained_object;
   hipError_t retain_result =
       move_refs ? iree_hip_user_object_check_ref_count(object, count)
                 : iree_hip_user_object_retain_refs_checked(object, count);
   if (retain_result != hipSuccess) {
+    iree_hip_user_object_handle_release(retained_object);
     HIP_RETURN_ERROR(retain_result);
   }
   iree_hal_streaming_graph_user_object_ref_t* ref = NULL;
@@ -13961,14 +14758,25 @@ HIPAPI hipError_t hipGraphRetainUserObject(hipGraph_t graph,
     if (!move_refs) {
       iree_hip_user_object_release_refs(object, count);
     }
+    iree_hip_user_object_handle_release(retained_object);
     HIP_RETURN_ERROR(hipErrorOutOfMemory);
+  }
+  hipError_t association_result =
+      iree_hip_user_object_add_graph_association(object);
+  if (association_result != hipSuccess) {
+    if (!move_refs) {
+      (void)iree_hip_user_object_release_refs_checked(object, count);
+    }
+    iree_hip_user_object_handle_release(retained_object);
+    HIP_RETURN_ERROR(association_result);
   }
   ref->object = object;
   ref->count = count;
-  ref->retain = iree_hip_user_object_retain_refs;
-  ref->release = iree_hip_user_object_release_refs;
+  ref->retain = iree_hip_user_object_retain_graph_refs;
+  ref->release = iree_hip_user_object_release_graph_refs;
   ref->next = stream_graph->user_object_refs;
   stream_graph->user_object_refs = ref;
+  iree_hip_user_object_handle_release(retained_object);
   return hipSuccess;
 }
 
@@ -13990,8 +14798,11 @@ HIPAPI hipError_t hipGraphReleaseUserObject(hipGraph_t graph,
       if (count > ref->count) {
         HIP_RETURN_ERROR(hipErrorInvalidValue);
       }
+      const bool removes_association = count == ref->count;
       hipError_t release_result =
-          iree_hip_user_object_release_refs_checked(object, count);
+          removes_association
+              ? iree_hip_user_object_remove_graph_association(object, count)
+              : iree_hip_user_object_release_refs_checked(object, count);
       if (release_result != hipSuccess) {
         HIP_RETURN_ERROR(release_result);
       }
@@ -17387,8 +18198,9 @@ HIPAPI hipError_t hipGraphAddMemAllocNode(hipGraphNode_t* pGraphNode,
   // This graph-memory implementation allocates backing storage when the graph
   // template is built. Graph exec launch serialization prevents concurrent
   // launches from sharing the same backing allocation.
-  hipError_t alloc_result = iree_hip_malloc_from_pool(
-      stream_graph->context, pool, params->bytesize, &params->dptr);
+  hipError_t alloc_result =
+      iree_hip_malloc_from_pool(stream_graph->context, pool, params->bytesize,
+                                /*stream=*/NULL, &params->dptr);
   if (alloc_result != hipSuccess) {
     iree_status_ignore(iree_hal_streaming_graph_destroy_node(node));
     HIP_RETURN_ERROR(alloc_result);
@@ -21145,13 +21957,24 @@ HIPAPI hipError_t hipMemPoolCreate(hipMemPool_t* pool,
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
+  *pool = NULL;
 
-  // Ensure initialization and get context.
-  iree_hal_streaming_context_t* context = NULL;
-  hipError_t init_result = iree_hip_ensure_context(&context);
+  hipError_t init_result = iree_hip_ensure_initialized();
   if (init_result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(init_result);
+  }
+
+  hipError_t props_result = iree_hip_validate_mem_pool_props(poolProps);
+  if (props_result != hipSuccess) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(props_result);
+  }
+  iree_hal_streaming_device_t* device =
+      iree_hal_streaming_device_entry(poolProps->location.id);
+  if (!device) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(hipErrorInvalidDevice);
   }
 
   hrx_mem_pool_props_t props = {
@@ -21160,17 +21983,23 @@ HIPAPI hipError_t hipMemPoolCreate(hipMemPool_t* pool,
       .location_type =
           iree_hip_mem_location_type_to_uint(poolProps->location.type),
       .location_id = poolProps->location.id,
+      .max_size = poolProps->maxSize,
   };
 
   hrx_mem_pool_t mem_pool = NULL;
-  iree_status_t status = HRX_CALL(hrx_mem_pool_create(
-      context->device_entry->hrx_device, &props, &mem_pool));
-
-  if (iree_status_is_ok(status)) {
-    *pool = (hipMemPool_t)mem_pool;
-  }
+  iree_status_t status =
+      HRX_CALL(hrx_mem_pool_create(device->hrx_device, &props, &mem_pool));
 
   hipError_t result = iree_status_to_hip_result(status);
+  if (result == hipSuccess) {
+    result = iree_hip_mem_pool_create_handle(mem_pool, poolProps->location.id,
+                                             poolProps->allocType,
+                                             /*is_default=*/false, pool);
+    if (result != hipSuccess) {
+      hrx_mem_pool_release(mem_pool);
+    }
+  }
+
   IREE_TRACE_ZONE_END(z0);
   HIP_RETURN_ERROR(result);
 }
@@ -21204,12 +22033,21 @@ HIPAPI hipError_t hipMemPoolCreate(hipMemPool_t* pool,
 //           hipMemPoolTrimTo.
 HIPAPI hipError_t hipMemPoolDestroy(hipMemPool_t pool) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  if (!pool) {
+  struct hipMemPool_st* removed_pool = NULL;
+  if (!iree_hip_mem_pool_registry_remove(pool, &removed_pool)) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
 
-  hrx_mem_pool_release((hrx_mem_pool_t)pool);
+  if (removed_pool->allocation_type == hipMemAllocationTypePinned) {
+    iree_hal_streaming_device_t* device =
+        iree_hal_streaming_device_entry(removed_pool->device_ordinal);
+    if (device) {
+      iree_hal_streaming_device_reset_mem_pool_if_current(
+          device, removed_pool->hrx_pool);
+    }
+  }
+  iree_hip_mem_pool_release(removed_pool);
   IREE_TRACE_ZONE_END(z0);
   return hipSuccess;
 }
@@ -21266,7 +22104,9 @@ HIPAPI hipError_t hipMemPoolSetAttribute(hipMemPool_t pool,
   uint64_t attr_value = 0;
   switch (attr) {
     case hipMemPoolAttrReleaseThreshold:
-      attr_value = *(size_t*)value;
+    case hipMemPoolAttrReservedMemHigh:
+    case hipMemPoolAttrUsedMemHigh:
+      attr_value = *(uint64_t*)value;
       break;
     case hipMemPoolAttrReuseFollowEventDependencies:
     case hipMemPoolAttrReuseAllowOpportunistic:
@@ -21278,11 +22118,23 @@ HIPAPI hipError_t hipMemPoolSetAttribute(hipMemPool_t pool,
       HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
 
+  struct hipMemPool_st* pool_handle = NULL;
+  hipError_t result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  if (result != hipSuccess) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(result);
+  }
+  hrx_mem_pool_t hrx_pool = NULL;
+  result = iree_hip_mem_pool_retain_backend(pool_handle, &hrx_pool);
   hrx_mem_pool_attr_t hrx_attr = iree_hip_mempool_attr_to_hrx(attr);
-  iree_status_t status = HRX_CALL(
-      hrx_mem_pool_set_attribute((hrx_mem_pool_t)pool, hrx_attr, attr_value));
+  if (result == hipSuccess) {
+    iree_status_t status =
+        HRX_CALL(hrx_mem_pool_set_attribute(hrx_pool, hrx_attr, attr_value));
+    result = iree_status_to_hip_result(status);
+  }
+  hrx_mem_pool_release(hrx_pool);
+  iree_hip_mem_pool_release(pool_handle);
 
-  hipError_t result = iree_status_to_hip_result(status);
   IREE_TRACE_ZONE_END(z0);
   HIP_RETURN_ERROR(result);
 }
@@ -21331,12 +22183,24 @@ HIPAPI hipError_t hipMemPoolGetAttribute(hipMemPool_t pool,
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
 
+  struct hipMemPool_st* pool_handle = NULL;
+  hipError_t result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  if (result != hipSuccess) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(result);
+  }
+  hrx_mem_pool_t hrx_pool = NULL;
+  result = iree_hip_mem_pool_retain_backend(pool_handle, &hrx_pool);
+
   uint64_t attr_value = 0;
   hrx_mem_pool_attr_t hrx_attr = iree_hip_mempool_attr_to_hrx(attr);
-  iree_status_t status = HRX_CALL(
-      hrx_mem_pool_get_attribute((hrx_mem_pool_t)pool, hrx_attr, &attr_value));
+  iree_status_t status = iree_ok_status();
+  if (result == hipSuccess) {
+    status =
+        HRX_CALL(hrx_mem_pool_get_attribute(hrx_pool, hrx_attr, &attr_value));
+  }
 
-  if (iree_status_is_ok(status)) {
+  if (result == hipSuccess && iree_status_is_ok(status)) {
     switch (attr) {
       case hipMemPoolAttrReleaseThreshold:
       case hipMemPoolAttrReservedMemCurrent:
@@ -21356,7 +22220,9 @@ HIPAPI hipError_t hipMemPoolGetAttribute(hipMemPool_t pool,
     }
   }
 
-  hipError_t result = iree_status_to_hip_result(status);
+  if (result == hipSuccess) result = iree_status_to_hip_result(status);
+  hrx_mem_pool_release(hrx_pool);
+  iree_hip_mem_pool_release(pool_handle);
   IREE_TRACE_ZONE_END(z0);
   HIP_RETURN_ERROR(result);
 }
@@ -21369,17 +22235,51 @@ HIPAPI hipError_t hipMemPoolGetAttribute(hipMemPool_t pool,
 //  - count: [IN] Number of access descriptors.
 //
 // Returns:
-//  - hipSuccess: Access permissions set.
-//  - hipErrorNotSupported: Not implemented.
+//  - hipErrorInvalidValue: Invalid parameters.
+//  - hipErrorInvalidDevice: Invalid or unsupported device access.
 //
 // See also: hipMemPoolGetAccess.
 HIPAPI hipError_t hipMemPoolSetAccess(hipMemPool_t pool,
                                       const hipMemAccessDesc* map,
                                       size_t count) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  // Not implemented yet.
+  if (!pool || (count > 0 && !map)) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+
+  struct hipMemPool_st* pool_handle = NULL;
+  hipError_t result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  if (result != hipSuccess) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(result);
+  }
+
+  int device_count = 0;
+  result = hipGetDeviceCount(&device_count);
+  if (result == hipSuccess && count > (size_t)device_count) {
+    result = hipErrorInvalidDevice;
+  }
+  for (size_t i = 0; result == hipSuccess && i < count; ++i) {
+    if (map[i].location.type != hipMemLocationTypeDevice ||
+        (map[i].flags != hipMemAccessFlagsProtNone &&
+         map[i].flags != hipMemAccessFlagsProtRead &&
+         map[i].flags != hipMemAccessFlagsProtReadWrite)) {
+      result = hipErrorInvalidValue;
+    } else if (map[i].location.id < 0 || map[i].location.id >= device_count) {
+      result = hipErrorInvalidDevice;
+    } else if (map[i].location.id != pool_handle->device_ordinal) {
+      // Cross-device pool mappings require direct peer access. The streaming
+      // runtime does not advertise a peer path without a backend capability
+      // source that can establish that mapping.
+      result = hipErrorNotSupported;
+    } else if (map[i].flags != hipMemAccessFlagsProtReadWrite) {
+      result = hipErrorInvalidDevice;
+    }
+  }
+  iree_hip_mem_pool_release(pool_handle);
   IREE_TRACE_ZONE_END(z0);
-  HIP_RETURN_ERROR(hipErrorNotSupported);
+  HIP_RETURN_ERROR(result);
 }
 
 // Gets memory access permissions for a memory pool.
@@ -21390,17 +22290,45 @@ HIPAPI hipError_t hipMemPoolSetAccess(hipMemPool_t pool,
 //  - location: [IN] Memory location to query.
 //
 // Returns:
-//  - hipSuccess: Access permissions retrieved.
-//  - hipErrorNotSupported: Not implemented.
+//  - hipErrorInvalidValue: Invalid parameters.
+//  - hipErrorInvalidDevice: Invalid or unsupported device access.
 //
 // See also: hipMemPoolSetAccess.
 HIPAPI hipError_t hipMemPoolGetAccess(hipMemAccessFlags* flags,
                                       hipMemPool_t pool,
                                       hipMemLocation* location) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  // Not implemented yet.
+  if (!flags || !pool || !location) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+
+  struct hipMemPool_st* pool_handle = NULL;
+  hipError_t result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  if (result != hipSuccess) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(result);
+  }
+
+  if (location->type != hipMemLocationTypeDevice) {
+    result = hipErrorInvalidValue;
+  } else {
+    int device_count = 0;
+    result = hipGetDeviceCount(&device_count);
+    if (result == hipSuccess &&
+        (location->id < 0 || location->id >= device_count)) {
+      result = hipErrorInvalidValue;
+    }
+    if (result == hipSuccess && location->id != pool_handle->device_ordinal) {
+      result = hipErrorNotSupported;
+    }
+    if (result == hipSuccess) {
+      *flags = hipMemAccessFlagsProtReadWrite;
+    }
+  }
+  iree_hip_mem_pool_release(pool_handle);
   IREE_TRACE_ZONE_END(z0);
-  HIP_RETURN_ERROR(hipErrorNotSupported);
+  HIP_RETURN_ERROR(result);
 }
 
 // Trims a memory pool to specified size.
@@ -21423,10 +22351,23 @@ HIPAPI hipError_t hipMemPoolTrimTo(hipMemPool_t pool, size_t minBytesToKeep) {
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
 
-  iree_status_t status =
-      HRX_CALL(hrx_mem_pool_trim((hrx_mem_pool_t)pool, minBytesToKeep));
+  struct hipMemPool_st* pool_handle = NULL;
+  hipError_t result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  if (result != hipSuccess) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(result);
+  }
+  hrx_mem_pool_t hrx_pool = NULL;
+  result = iree_hip_mem_pool_retain_backend(pool_handle, &hrx_pool);
+  if (result == hipSuccess) {
+    iree_hal_streaming_memory_release_completed_async_frees_from_pool(hrx_pool);
+    iree_status_t status =
+        HRX_CALL(hrx_mem_pool_trim(hrx_pool, minBytesToKeep));
+    result = iree_status_to_hip_result(status);
+  }
+  hrx_mem_pool_release(hrx_pool);
+  iree_hip_mem_pool_release(pool_handle);
 
-  hipError_t result = iree_status_to_hip_result(status);
   IREE_TRACE_ZONE_END(z0);
   HIP_RETURN_ERROR(result);
 }
@@ -21530,9 +22471,31 @@ HIPAPI hipError_t hipDeviceSetMemPool(int device, hipMemPool_t pool) {
     HIP_RETURN_ERROR(hipErrorInvalidDevice);
   }
 
-  iree_hal_streaming_device_set_mem_pool(device_obj, (hrx_mem_pool_t)pool);
+  iree_status_t status =
+      iree_hal_streaming_device_ensure_default_mem_pool(device_obj);
+  if (!iree_status_is_ok(status)) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(iree_status_to_hip_result(status));
+  }
+
+  struct hipMemPool_st* pool_handle = NULL;
+  hipError_t result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  if (result == hipSuccess &&
+      (pool_handle->device_ordinal != device ||
+       pool_handle->allocation_type != hipMemAllocationTypePinned)) {
+    result = hipErrorInvalidValue;
+  }
+  hrx_mem_pool_t hrx_pool = NULL;
+  if (result == hipSuccess) {
+    result = iree_hip_mem_pool_retain_backend(pool_handle, &hrx_pool);
+  }
+  if (result == hipSuccess) {
+    iree_hal_streaming_device_set_mem_pool(device_obj, hrx_pool);
+  }
+  hrx_mem_pool_release(hrx_pool);
+  iree_hip_mem_pool_release(pool_handle);
   IREE_TRACE_ZONE_END(z0);
-  return hipSuccess;
+  HIP_RETURN_ERROR(result);
 }
 
 // Gets the current memory pool for a device.
@@ -21564,9 +22527,12 @@ HIPAPI hipError_t hipDeviceGetMemPool(hipMemPool_t* pool, int device) {
     HIP_RETURN_ERROR(hipErrorInvalidDevice);
   }
 
-  *pool = (hipMemPool_t)iree_hal_streaming_device_mem_pool(device_obj);
-
-  return hipSuccess;
+  iree_status_t status =
+      iree_hal_streaming_device_ensure_default_mem_pool(device_obj);
+  if (!iree_status_is_ok(status)) {
+    HIP_RETURN_ERROR(iree_status_to_hip_result(status));
+  }
+  HIP_RETURN_ERROR(iree_hip_mem_pool_get_current(device_obj, device, pool));
 }
 
 // Gets the default memory pool for a device.
@@ -21601,10 +22567,87 @@ HIPAPI hipError_t hipDeviceGetDefaultMemPool(hipMemPool_t* pool_out,
     HIP_RETURN_ERROR(hipErrorInvalidDevice);
   }
 
-  *pool_out =
-      (hipMemPool_t)iree_hal_streaming_device_default_mem_pool(device_obj);
+  iree_status_t status =
+      iree_hal_streaming_device_ensure_default_mem_pool(device_obj);
+  if (!iree_status_is_ok(status)) {
+    HIP_RETURN_ERROR(iree_status_to_hip_result(status));
+  }
+  HIP_RETURN_ERROR(iree_hip_mem_pool_get_default(
+      device, hipMemAllocationTypePinned, pool_out));
+}
 
-  return hipSuccess;
+HIPAPI hipError_t hipMemGetMemPool(hipMemPool_t* pool, hipMemLocation* location,
+                                   hipMemAllocationType type) {
+  if (!pool || !location ||
+      !iree_hip_mem_pool_allocation_type_is_supported(type)) {
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+  *pool = NULL;
+
+  hipError_t init_result = iree_hip_ensure_initialized();
+  if (init_result != hipSuccess) HIP_RETURN_ERROR(init_result);
+  if (location->type != hipMemLocationTypeDevice || location->id < 0) {
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+  iree_hal_streaming_device_t* device =
+      iree_hal_streaming_device_entry(location->id);
+  if (!device) HIP_RETURN_ERROR(hipErrorInvalidValue);
+  iree_status_t status =
+      iree_hal_streaming_device_ensure_default_mem_pool(device);
+  if (!iree_status_is_ok(status)) {
+    HIP_RETURN_ERROR(iree_status_to_hip_result(status));
+  }
+
+  if (type == hipMemAllocationTypePinned) {
+    HIP_RETURN_ERROR(iree_hip_mem_pool_get_current(device, location->id, pool));
+  }
+  HIP_RETURN_ERROR(iree_hip_mem_pool_get_managed_selection(location->id, pool));
+}
+
+HIPAPI hipError_t hipMemSetMemPool(hipMemLocation* location,
+                                   hipMemAllocationType type,
+                                   hipMemPool_t pool) {
+  if (!location || !pool ||
+      !iree_hip_mem_pool_allocation_type_is_supported(type)) {
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+
+  hipError_t init_result = iree_hip_ensure_initialized();
+  if (init_result != hipSuccess) HIP_RETURN_ERROR(init_result);
+  if (location->type != hipMemLocationTypeDevice || location->id < 0) {
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+  iree_hal_streaming_device_t* device =
+      iree_hal_streaming_device_entry(location->id);
+  if (!device) HIP_RETURN_ERROR(hipErrorInvalidValue);
+
+  iree_status_t status =
+      iree_hal_streaming_device_ensure_default_mem_pool(device);
+  if (!iree_status_is_ok(status)) {
+    HIP_RETURN_ERROR(iree_status_to_hip_result(status));
+  }
+
+  struct hipMemPool_st* pool_handle = NULL;
+  hipError_t result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  if (result != hipSuccess) HIP_RETURN_ERROR(result);
+  if (pool_handle->device_ordinal != location->id ||
+      pool_handle->allocation_type != type) {
+    iree_hip_mem_pool_release(pool_handle);
+    HIP_RETURN_ERROR(hipErrorInvalidValue);
+  }
+
+  if (type == hipMemAllocationTypePinned) {
+    hrx_mem_pool_t hrx_pool = NULL;
+    result = iree_hip_mem_pool_retain_backend(pool_handle, &hrx_pool);
+    if (result == hipSuccess) {
+      iree_hal_streaming_device_set_mem_pool(device, hrx_pool);
+    }
+    hrx_mem_pool_release(hrx_pool);
+  } else {
+    result = iree_hip_mem_pool_set_managed_selection(location->id, pool_handle);
+  }
+  iree_hip_mem_pool_release(pool_handle);
+  HIP_RETURN_ERROR(result);
 }
 
 // Allocates memory asynchronously from the default pool.
@@ -21632,6 +22675,7 @@ HIPAPI hipError_t hipMallocAsync(void** ptr, size_t size, hipStream_t stream) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
+  *ptr = NULL;
 
   iree_hal_streaming_stream_t* stream_obj = NULL;
   hipError_t resolve_result = iree_hip_resolve_stream(stream, &stream_obj);
@@ -21672,11 +22716,22 @@ HIPAPI hipError_t hipMallocAsync(void** ptr, size_t size, hipStream_t stream) {
     return hipSuccess;
   }
 
-  // Route through hipMalloc until HRX implements stream-ordered allocation.
-  // The synchronous path still allocates through the selected HRX/HAL pool.
-  hipError_t result = hipMalloc(ptr, size);
+  if (size == 0) {
+    IREE_TRACE_ZONE_END(z0);
+    return hipSuccess;
+  }
+
+  // Allocate eagerly from the stream's selected pool. A pending free on this
+  // stream can reuse its backing only after every preceding operation.
+  hrx_mem_pool_t pool = NULL;
+  hipError_t result = iree_hip_current_mem_pool(stream_obj->context, &pool);
+  if (result == hipSuccess) {
+    result = iree_hip_malloc_from_pool(stream_obj->context, pool, size,
+                                       stream_obj, ptr);
+  }
+  hrx_mem_pool_release(pool);
   IREE_TRACE_ZONE_END(z0);
-  return result;
+  HIP_RETURN_ERROR(result);
 }
 
 // Allocates memory asynchronously from a specific pool.
@@ -21707,31 +22762,67 @@ HIPAPI hipError_t hipMallocFromPoolAsync(void** ptr, size_t size,
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
+  *ptr = NULL;
   if (!pool) {
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(hipErrorInvalidValue);
   }
 
-  // Ensure initialization and get context.
-  iree_hal_streaming_context_t* context = NULL;
-  hipError_t init_result = iree_hip_ensure_context(&context);
-  if (init_result != hipSuccess) {
+  iree_hal_streaming_stream_t* stream_obj = NULL;
+  hipError_t stream_result = iree_hip_resolve_stream(stream, &stream_obj);
+  if (stream_result != hipSuccess) {
     IREE_TRACE_ZONE_END(z0);
-    HIP_RETURN_ERROR(init_result);
+    HIP_RETURN_ERROR(stream_result);
   }
 
-  // Check if capturing - synchronous operations not allowed during capture.
-  if (context->default_stream && context->default_stream->capture_status ==
-                                     IREE_HAL_STREAMING_CAPTURE_STATUS_ACTIVE) {
+  struct hipMemPool_st* pool_handle = NULL;
+  hipError_t pool_result = iree_hip_mem_pool_retain(pool, &pool_handle);
+  if (pool_result != hipSuccess) {
+    IREE_TRACE_ZONE_END(z0);
+    HIP_RETURN_ERROR(pool_result);
+  }
+
+  if (stream_obj->capture_status == IREE_HAL_STREAMING_CAPTURE_STATUS_ACTIVE) {
+    iree_hip_mem_pool_release(pool_handle);
     IREE_TRACE_ZONE_END(z0);
     HIP_RETURN_ERROR(hipErrorStreamCaptureUnsupported);
   }
 
-  // Use the explicit pool even though allocation is still synchronous.
-  hipError_t result =
-      iree_hip_malloc_from_pool(context, (hrx_mem_pool_t)pool, size, ptr);
+  // The allocation's backing is materialized before this call returns. A pool
+  // owned by another device therefore does not require foreign-stream work to
+  // make the returned address available, but it cannot reuse a free cached by
+  // that stream's context.
+  iree_hal_streaming_context_t* allocation_context = stream_obj->context;
+  iree_hal_streaming_stream_t* allocation_stream = stream_obj;
+  if (pool_handle->device_ordinal != (int)stream_obj->context->device_ordinal) {
+    iree_hal_streaming_device_t* pool_device =
+        iree_hal_streaming_device_entry(pool_handle->device_ordinal);
+    if (!pool_device) {
+      pool_result = hipErrorInvalidDevice;
+    } else {
+      iree_status_t status =
+          iree_hal_streaming_device_get_or_create_primary_context(
+              pool_device, &allocation_context);
+      if (!iree_status_is_ok(status)) {
+        pool_result = iree_status_to_hip_result(status);
+      } else {
+        allocation_stream = NULL;
+      }
+    }
+  }
+
+  hrx_mem_pool_t hrx_pool = NULL;
+  if (pool_result == hipSuccess) {
+    pool_result = iree_hip_mem_pool_retain_backend(pool_handle, &hrx_pool);
+  }
+  if (pool_result == hipSuccess) {
+    pool_result = iree_hip_malloc_from_pool(allocation_context, hrx_pool, size,
+                                            allocation_stream, ptr);
+  }
+  hrx_mem_pool_release(hrx_pool);
+  iree_hip_mem_pool_release(pool_handle);
   IREE_TRACE_ZONE_END(z0);
-  return result;
+  HIP_RETURN_ERROR(pool_result);
 }
 
 // Frees memory asynchronously.

--- a/libhrx/src/binding/hip/api.h
+++ b/libhrx/src/binding/hip/api.h
@@ -917,6 +917,8 @@ typedef enum hipMemAllocationHandleType {
 typedef enum hipMemAllocationType {
   hipMemAllocationTypeInvalid = 0,
   hipMemAllocationTypePinned = 1,
+  hipMemAllocationTypeManaged = 2,
+  hipMemAllocationTypeUncached = 0x40000000,
   hipMemAllocationTypeMax = 0x7FFFFFFF
 } hipMemAllocationType;
 

--- a/libhrx/src/binding/hip/hip_memory_pool_api_test.cc
+++ b/libhrx/src/binding/hip/hip_memory_pool_api_test.cc
@@ -1,0 +1,213 @@
+// Copyright 2026 The HRX Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <dlfcn.h>
+
+#include <cstdint>
+#include <cstdlib>
+
+#include "binding/hip/api.h"
+#include "iree/testing/gtest.h"
+
+namespace {
+
+const char* CandidateLibPath() {
+  if (const char* env = std::getenv("HRX_TEST_LIBAMDHIP64");
+      env && *env != '\0') {
+    return env;
+  }
+#ifdef HRX_TEST_LIBAMDHIP64_PATH
+  return HRX_TEST_LIBAMDHIP64_PATH;
+#else
+  return "libamdhip64.so";
+#endif
+}
+
+using HipInitFn = hipError_t (*)(unsigned int flags);
+using HipGetDeviceFn = hipError_t (*)(int* device);
+using HipStreamCreateFn = hipError_t (*)(hipStream_t* stream);
+using HipStreamDestroyFn = hipError_t (*)(hipStream_t stream);
+using HipDeviceGetDefaultMemPoolFn = hipError_t (*)(hipMemPool_t* pool,
+                                                    int device);
+using HipDeviceSetMemPoolFn = hipError_t (*)(int device, hipMemPool_t pool);
+using HipMemPoolCreateFn = hipError_t (*)(hipMemPool_t* pool,
+                                          const hipMemPoolProps* properties);
+using HipMemPoolDestroyFn = hipError_t (*)(hipMemPool_t pool);
+using HipMallocFromPoolAsyncFn = hipError_t (*)(void** pointer, size_t size,
+                                                hipMemPool_t pool,
+                                                hipStream_t stream);
+using HipGraphCreateFn = hipError_t (*)(hipGraph_t* graph, unsigned int flags);
+using HipGraphDestroyFn = hipError_t (*)(hipGraph_t graph);
+using HipGraphAddMemAllocNodeFn = hipError_t (*)(
+    hipGraphNode_t* node, hipGraph_t graph, const hipGraphNode_t* dependencies,
+    size_t dependency_count, void* allocation_parameters);
+
+// Owns an RTLD_LOCAL HIP runtime instance and the entry points exercised by
+// this test. All calls use the loaded library instead of a link-time runtime.
+struct HipRuntimeApi {
+  // Handle returned by dlopen for the HIP runtime instance.
+  void* library = nullptr;
+  // Initializes the HIP runtime instance.
+  HipInitFn init = nullptr;
+  // Returns the current device ordinal.
+  HipGetDeviceFn get_device = nullptr;
+  // Creates a stream for asynchronous allocation.
+  HipStreamCreateFn stream_create = nullptr;
+  // Destroys the stream used by asynchronous allocation.
+  HipStreamDestroyFn stream_destroy = nullptr;
+  // Returns a device's default memory pool.
+  HipDeviceGetDefaultMemPoolFn device_get_default_mem_pool = nullptr;
+  // Selects a device's current memory pool.
+  HipDeviceSetMemPoolFn device_set_mem_pool = nullptr;
+  // Creates a user-owned memory pool.
+  HipMemPoolCreateFn mem_pool_create = nullptr;
+  // Destroys a user-owned memory pool.
+  HipMemPoolDestroyFn mem_pool_destroy = nullptr;
+  // Allocates stream-ordered memory from an explicit pool.
+  HipMallocFromPoolAsyncFn malloc_from_pool_async = nullptr;
+  // Creates a graph template.
+  HipGraphCreateFn graph_create = nullptr;
+  // Destroys a graph template.
+  HipGraphDestroyFn graph_destroy = nullptr;
+  // Adds a memory-allocation node to a graph template.
+  HipGraphAddMemAllocNodeFn graph_add_mem_alloc_node = nullptr;
+};
+
+template <typename T>
+T ResolveHipSymbol(void* library, const char* name) {
+  return reinterpret_cast<T>(dlsym(library, name));
+}
+
+class HipMemoryPoolApiTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    if (!api_.library) {
+      api_.library = dlopen(CandidateLibPath(), RTLD_LAZY | RTLD_LOCAL);
+      if (!api_.library) {
+        GTEST_SKIP() << "cannot dlopen " << CandidateLibPath() << ": "
+                     << dlerror();
+      }
+
+      api_.init = ResolveHipSymbol<HipInitFn>(api_.library, "hipInit");
+      api_.get_device =
+          ResolveHipSymbol<HipGetDeviceFn>(api_.library, "hipGetDevice");
+      api_.stream_create =
+          ResolveHipSymbol<HipStreamCreateFn>(api_.library, "hipStreamCreate");
+      api_.stream_destroy = ResolveHipSymbol<HipStreamDestroyFn>(
+          api_.library, "hipStreamDestroy");
+      api_.device_get_default_mem_pool =
+          ResolveHipSymbol<HipDeviceGetDefaultMemPoolFn>(
+              api_.library, "hipDeviceGetDefaultMemPool");
+      api_.device_set_mem_pool = ResolveHipSymbol<HipDeviceSetMemPoolFn>(
+          api_.library, "hipDeviceSetMemPool");
+      api_.mem_pool_create = ResolveHipSymbol<HipMemPoolCreateFn>(
+          api_.library, "hipMemPoolCreate");
+      api_.mem_pool_destroy = ResolveHipSymbol<HipMemPoolDestroyFn>(
+          api_.library, "hipMemPoolDestroy");
+      api_.malloc_from_pool_async = ResolveHipSymbol<HipMallocFromPoolAsyncFn>(
+          api_.library, "hipMallocFromPoolAsync");
+      api_.graph_create =
+          ResolveHipSymbol<HipGraphCreateFn>(api_.library, "hipGraphCreate");
+      api_.graph_destroy =
+          ResolveHipSymbol<HipGraphDestroyFn>(api_.library, "hipGraphDestroy");
+      api_.graph_add_mem_alloc_node =
+          ResolveHipSymbol<HipGraphAddMemAllocNodeFn>(
+              api_.library, "hipGraphAddMemAllocNode");
+    }
+
+    ASSERT_NE(nullptr, api_.init);
+    ASSERT_NE(nullptr, api_.get_device);
+    ASSERT_NE(nullptr, api_.stream_create);
+    ASSERT_NE(nullptr, api_.stream_destroy);
+    ASSERT_NE(nullptr, api_.device_get_default_mem_pool);
+    ASSERT_NE(nullptr, api_.device_set_mem_pool);
+    ASSERT_NE(nullptr, api_.mem_pool_create);
+    ASSERT_NE(nullptr, api_.mem_pool_destroy);
+    ASSERT_NE(nullptr, api_.malloc_from_pool_async);
+    ASSERT_NE(nullptr, api_.graph_create);
+    ASSERT_NE(nullptr, api_.graph_destroy);
+    ASSERT_NE(nullptr, api_.graph_add_mem_alloc_node);
+
+    const hipError_t init_result = api_.init(/*flags=*/0);
+    if (init_result != hipSuccess) {
+      GTEST_SKIP() << "hipInit failed: " << init_result;
+    }
+    const hipError_t get_device_result = api_.get_device(&device_);
+    if (get_device_result != hipSuccess) {
+      GTEST_SKIP() << "hipGetDevice failed: " << get_device_result;
+    }
+    ASSERT_EQ(hipSuccess, api_.stream_create(&stream_));
+  }
+
+  void TearDown() override {
+    if (stream_) {
+      EXPECT_EQ(hipSuccess, api_.stream_destroy(stream_));
+      stream_ = nullptr;
+    }
+    // The runtime owns process-scoped driver services that cannot be
+    // reinitialized after the final dlclose in the same process.
+  }
+
+  // Runtime entry points loaded once from the HIP shared object under test.
+  static HipRuntimeApi api_;
+  // Stream supplied to asynchronous allocation entry points.
+  hipStream_t stream_ = nullptr;
+  // Device ordinal associated with the test stream and pools.
+  int device_ = -1;
+};
+
+HipRuntimeApi HipMemoryPoolApiTest::api_;
+
+TEST_F(HipMemoryPoolApiTest, ZeroByteAllocationReturnsNull) {
+  hipMemPool_t pool = nullptr;
+  ASSERT_EQ(hipSuccess, api_.device_get_default_mem_pool(&pool, device_));
+
+  void* pointer = reinterpret_cast<void*>(uintptr_t{1});
+  EXPECT_EQ(hipSuccess,
+            api_.malloc_from_pool_async(&pointer, /*size=*/0, pool, stream_));
+  EXPECT_EQ(nullptr, pointer);
+}
+
+TEST_F(HipMemoryPoolApiTest, GraphAllocationReleasesSelectedPool) {
+  hipMemPool_t default_pool = nullptr;
+  ASSERT_EQ(hipSuccess,
+            api_.device_get_default_mem_pool(&default_pool, device_));
+
+  hipMemPoolProps properties = {};
+  properties.allocType = hipMemAllocationTypePinned;
+  properties.location.type = hipMemLocationTypeDevice;
+  properties.location.id = device_;
+
+  hipMemPool_t pool = nullptr;
+  ASSERT_EQ(hipSuccess, api_.mem_pool_create(&pool, &properties));
+
+  const hipError_t set_pool_result = api_.device_set_mem_pool(device_, pool);
+  EXPECT_EQ(hipSuccess, set_pool_result);
+  if (set_pool_result != hipSuccess) {
+    EXPECT_EQ(hipSuccess, api_.mem_pool_destroy(pool));
+    return;
+  }
+
+  hipGraph_t graph = nullptr;
+  const hipError_t graph_create_result = api_.graph_create(&graph, /*flags=*/0);
+  EXPECT_EQ(hipSuccess, graph_create_result);
+  if (graph_create_result == hipSuccess) {
+    hipMemAllocNodeParams parameters = {};
+    parameters.poolProps = properties;
+    parameters.bytesize = 4096;
+    hipGraphNode_t node = nullptr;
+    EXPECT_EQ(hipSuccess, api_.graph_add_mem_alloc_node(
+                              &node, graph, /*dependencies=*/nullptr,
+                              /*dependency_count=*/0, &parameters));
+    EXPECT_NE(nullptr, parameters.dptr);
+    EXPECT_EQ(hipSuccess, api_.graph_destroy(graph));
+  }
+
+  EXPECT_EQ(hipSuccess, api_.device_set_mem_pool(device_, default_pool));
+  EXPECT_EQ(hipSuccess, api_.mem_pool_destroy(pool));
+}
+
+}  // namespace

--- a/libhrx/src/libhrx/BUILD.bazel
+++ b/libhrx/src/libhrx/BUILD.bazel
@@ -69,6 +69,7 @@ HRX_DEPS = [
     "//runtime/src/iree/async/util:proactor_pool",
     "//runtime/src/iree/hal",
     "//runtime/src/iree/hal/executable/amdgpu:executable_target",
+    "//runtime/src/iree/hal/memory:asan",
     "//runtime/src/iree/hal/memory:passthrough_pool",
     "//runtime/src/iree/hal/memory:slab_provider",
     "//runtime/src/iree/hal/memory:tlsf_pool",

--- a/libhrx/src/libhrx/BUILD.bazel
+++ b/libhrx/src/libhrx/BUILD.bazel
@@ -41,11 +41,14 @@ HRX_SRCS = [
     "stream.c",
     "transfer.c",
     "value_list.c",
+    "vmm_slab_provider.c",
+    "vmm_slab_provider.h",
 ]
 
 HRX_HDRS = [
     "buffer_table.h",
     "hrx_internal.h",
+    "mem_pool.h",
     "//libhrx/src:iree_hal_compat.h",
 ]
 
@@ -66,6 +69,8 @@ HRX_DEPS = [
     "//runtime/src/iree/async/util:proactor_pool",
     "//runtime/src/iree/hal",
     "//runtime/src/iree/hal/executable/amdgpu:executable_target",
+    "//runtime/src/iree/hal/memory:passthrough_pool",
+    "//runtime/src/iree/hal/memory:slab_provider",
     "//runtime/src/iree/hal/memory:tlsf_pool",
     "//runtime/src/iree/hal/drivers/local_task:task_driver",
     "//runtime/src/iree/hal/local/loaders/registration",

--- a/libhrx/src/libhrx/CMakeLists.txt
+++ b/libhrx/src/libhrx/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
   HDRS
     "buffer_table.h"
     "hrx_internal.h"
+    "mem_pool.h"
   SRCS
     "allocator.c"
     "buffer.c"
@@ -48,6 +49,8 @@ iree_cc_library(
     "stream.c"
     "transfer.c"
     "value_list.c"
+    "vmm_slab_provider.c"
+    "vmm_slab_provider.h"
   DEPS
     ${CMAKE_DL_LIBS}
     iree::async
@@ -61,6 +64,8 @@ iree_cc_library(
     iree::hal::drivers::local_task::task_driver
     iree::hal::executable::amdgpu::executable_target
     iree::hal::local::loaders::registration
+    iree::hal::memory::passthrough_pool
+    iree::hal::memory::slab_provider
     iree::hal::memory::tlsf_pool
     iree::hal::utils::profile_file
     iree::hal::utils::resource_set
@@ -96,6 +101,7 @@ iree_cc_library(
   HDRS
     "buffer_table.h"
     "hrx_internal.h"
+    "mem_pool.h"
   SRCS
     "allocator.c"
     "buffer.c"
@@ -119,6 +125,8 @@ iree_cc_library(
     "stream.c"
     "transfer.c"
     "value_list.c"
+    "vmm_slab_provider.c"
+    "vmm_slab_provider.h"
   DEPS
     ${CMAKE_DL_LIBS}
     iree::async
@@ -132,6 +140,8 @@ iree_cc_library(
     iree::hal::drivers::local_task::task_driver
     iree::hal::executable::amdgpu::executable_target
     iree::hal::local::loaders::registration
+    iree::hal::memory::passthrough_pool
+    iree::hal::memory::slab_provider
     iree::hal::memory::tlsf_pool
     iree::hal::utils::profile_file
     iree::hal::utils::resource_set

--- a/libhrx/src/libhrx/CMakeLists.txt
+++ b/libhrx/src/libhrx/CMakeLists.txt
@@ -64,6 +64,7 @@ iree_cc_library(
     iree::hal::drivers::local_task::task_driver
     iree::hal::executable::amdgpu::executable_target
     iree::hal::local::loaders::registration
+    iree::hal::memory::asan
     iree::hal::memory::passthrough_pool
     iree::hal::memory::slab_provider
     iree::hal::memory::tlsf_pool
@@ -140,6 +141,7 @@ iree_cc_library(
     iree::hal::drivers::local_task::task_driver
     iree::hal::executable::amdgpu::executable_target
     iree::hal::local::loaders::registration
+    iree::hal::memory::asan
     iree::hal::memory::passthrough_pool
     iree::hal::memory::slab_provider
     iree::hal::memory::tlsf_pool

--- a/libhrx/src/libhrx/allocator.c
+++ b/libhrx/src/libhrx/allocator.c
@@ -212,10 +212,13 @@ hrx_status_t hrx_allocator_virtual_memory_release(hrx_allocator_t allocator,
   }
   iree_status_t status = iree_hal_allocator_virtual_memory_release(
       allocator->hal_allocator, virtual_buffer->hal_buffer);
-  // Free the hrx wrapper (hal_buffer ownership transferred).
-  virtual_buffer->hal_buffer = NULL;
-  hrx_device_release(virtual_buffer->device);
-  iree_allocator_free(iree_allocator_system(), virtual_buffer);
+  if (iree_status_is_ok(status)) {
+    // Release consumes the HAL buffer only on success. Keep the wrapper usable
+    // when active mappings prevent release so the caller can unmap and retry.
+    virtual_buffer->hal_buffer = NULL;
+    hrx_device_release(virtual_buffer->device);
+    iree_allocator_free(iree_allocator_system(), virtual_buffer);
+  }
   HRX_RETURN_AND_END_ZONE(z0, hrx_status_from_iree(status));
 }
 

--- a/libhrx/src/libhrx/buffer.c
+++ b/libhrx/src/libhrx/buffer.c
@@ -7,6 +7,7 @@
 #include <string.h>
 
 #include "hrx_internal.h"
+#include "mem_pool.h"
 
 static iree_status_t hrx_buffer_unmap_internal(hrx_buffer_t buffer) {
   iree_status_t status = iree_hal_buffer_unmap_range(&buffer->mapping);
@@ -116,6 +117,7 @@ void hrx_buffer_retain(hrx_buffer_t buffer) {
   iree_hal_buffer_retain(buffer->hal_buffer);
   iree_hal_pool_retain(buffer->hal_pool);
   hrx_device_retain(buffer->device);
+  hrx_mem_pool_retain(buffer->allocation_budget_pool);
   iree_atomic_ref_count_inc(&buffer->ref_count);
 }
 
@@ -126,7 +128,11 @@ void hrx_buffer_release(hrx_buffer_t buffer) {
   iree_hal_buffer_t* hal_buffer = buffer->hal_buffer;
   iree_hal_pool_t* hal_pool = buffer->hal_pool;
   hrx_device_t device = buffer->device;
-  if (iree_atomic_ref_count_dec(&buffer->ref_count) == 1) {
+  hrx_mem_pool_t allocation_budget_pool = buffer->allocation_budget_pool;
+  const size_t allocation_budget_size = buffer->allocation_budget_size;
+  const bool is_final_reference =
+      iree_atomic_ref_count_dec(&buffer->ref_count) == 1;
+  if (is_final_reference) {
     if (buffer->is_mapped) {
       iree_status_ignore(hrx_buffer_unmap_internal(buffer));
     }
@@ -135,6 +141,11 @@ void hrx_buffer_release(hrx_buffer_t buffer) {
   iree_hal_buffer_release(hal_buffer);
   iree_hal_pool_release(hal_pool);
   hrx_device_release(device);
+  if (is_final_reference) {
+    hrx_mem_pool_release_allocation_budget(allocation_budget_pool,
+                                           allocation_budget_size);
+  }
+  hrx_mem_pool_release(allocation_budget_pool);
   HRX_TRACE_ZONE_END(z0);
 }
 

--- a/libhrx/src/libhrx/buffer_table.c
+++ b/libhrx/src/libhrx/buffer_table.c
@@ -17,6 +17,7 @@ void hrx_buffer_table_initialize(hrx_buffer_table_t* table) {
 }
 
 void hrx_buffer_table_deinitialize(hrx_buffer_table_t* table) {
+  IREE_ASSERT(table->reserved_insert_count == 0);
   iree_slim_mutex_deinitialize(&table->mutex);
   free(table->entries);
   memset(table, 0, sizeof(*table));
@@ -26,12 +27,13 @@ static size_t hrx_buffer_table_find_index(hrx_buffer_table_t* table,
                                           uint64_t any_ptr) {
   for (size_t i = 0; i < table->count; ++i) {
     hrx_buffer_table_entry_t* e = &table->entries[i];
-    if (any_ptr >= e->device_ptr && any_ptr < e->device_ptr + e->size) {
+    if (any_ptr >= e->device_ptr &&
+        any_ptr - e->device_ptr < (uint64_t)e->size) {
       return i;
     }
     if (e->host_ptr) {
       uint64_t host_addr = (uint64_t)(uintptr_t)e->host_ptr;
-      if (any_ptr >= host_addr && any_ptr < host_addr + e->size) {
+      if (any_ptr >= host_addr && any_ptr - host_addr < (uint64_t)e->size) {
         return i;
       }
     }
@@ -40,8 +42,18 @@ static size_t hrx_buffer_table_find_index(hrx_buffer_table_t* table,
 }
 
 static hrx_status_t hrx_buffer_table_grow(hrx_buffer_table_t* table) {
-  size_t new_cap =
-      table->capacity ? table->capacity * 2 : HRX_BUFFER_TABLE_INITIAL_CAPACITY;
+  size_t new_cap = HRX_BUFFER_TABLE_INITIAL_CAPACITY;
+  if (table->capacity) {
+    if (table->capacity > SIZE_MAX / 2) {
+      return hrx_make_status(HRX_STATUS_OUT_OF_MEMORY,
+                             "buffer table capacity overflow");
+    }
+    new_cap = table->capacity * 2;
+  }
+  if (new_cap > SIZE_MAX / sizeof(hrx_buffer_table_entry_t)) {
+    return hrx_make_status(HRX_STATUS_OUT_OF_MEMORY,
+                           "buffer table allocation size overflow");
+  }
   hrx_buffer_table_entry_t* new_entries =
       realloc(table->entries, new_cap * sizeof(hrx_buffer_table_entry_t));
   if (!new_entries) {
@@ -53,14 +65,26 @@ static hrx_status_t hrx_buffer_table_grow(hrx_buffer_table_t* table) {
   return hrx_ok_status();
 }
 
-hrx_status_t hrx_buffer_table_insert(hrx_buffer_table_t* table,
-                                     uint64_t device_ptr, void* host_ptr,
-                                     size_t size, hrx_buffer_t buffer,
-                                     void* user_data) {
-  iree_slim_mutex_lock(&table->mutex);
+static hrx_status_t hrx_buffer_table_ensure_insert_capacity_locked(
+    hrx_buffer_table_t* table, size_t additional_reservations) {
+  if (table->count > SIZE_MAX - table->reserved_insert_count ||
+      table->count + table->reserved_insert_count >
+          SIZE_MAX - additional_reservations) {
+    return hrx_make_status(HRX_STATUS_OUT_OF_MEMORY,
+                           "buffer table entry count overflow");
+  }
+  const size_t required_capacity =
+      table->count + table->reserved_insert_count + additional_reservations;
+  while (table->capacity < required_capacity) {
+    hrx_status_t status = hrx_buffer_table_grow(table);
+    if (!hrx_status_is_ok(status)) return status;
+  }
+  return hrx_ok_status();
+}
 
+static hrx_status_t hrx_buffer_table_validate_insert_locked(
+    hrx_buffer_table_t* table, uint64_t device_ptr, void* host_ptr) {
   if (hrx_buffer_table_find_index(table, device_ptr) < table->count) {
-    iree_slim_mutex_unlock(&table->mutex);
     return hrx_make_status(HRX_STATUS_ALREADY_EXISTS,
                            "device pointer already registered");
   }
@@ -68,18 +92,28 @@ hrx_status_t hrx_buffer_table_insert(hrx_buffer_table_t* table,
   if (host_ptr && (uint64_t)(uintptr_t)host_ptr != device_ptr) {
     uint64_t host_addr = (uint64_t)(uintptr_t)host_ptr;
     if (hrx_buffer_table_find_index(table, host_addr) < table->count) {
-      iree_slim_mutex_unlock(&table->mutex);
       return hrx_make_status(HRX_STATUS_ALREADY_EXISTS,
                              "host pointer already registered");
     }
   }
+  return hrx_ok_status();
+}
 
-  if (table->count >= table->capacity) {
-    hrx_status_t status = hrx_buffer_table_grow(table);
-    if (!hrx_status_is_ok(status)) {
-      iree_slim_mutex_unlock(&table->mutex);
-      return status;
-    }
+hrx_status_t hrx_buffer_table_insert(hrx_buffer_table_t* table,
+                                     uint64_t device_ptr, void* host_ptr,
+                                     size_t size, hrx_buffer_t buffer,
+                                     void* user_data) {
+  iree_slim_mutex_lock(&table->mutex);
+
+  hrx_status_t status =
+      hrx_buffer_table_validate_insert_locked(table, device_ptr, host_ptr);
+  if (hrx_status_is_ok(status)) {
+    status = hrx_buffer_table_ensure_insert_capacity_locked(
+        table, /*additional_reservations=*/1);
+  }
+  if (!hrx_status_is_ok(status)) {
+    iree_slim_mutex_unlock(&table->mutex);
+    return status;
   }
 
   table->entries[table->count++] = (hrx_buffer_table_entry_t){
@@ -107,6 +141,50 @@ hrx_status_t hrx_buffer_table_insert_if_new(hrx_buffer_table_t* table,
     return hrx_ok_status();
   }
   return status;
+}
+
+hrx_status_t hrx_buffer_table_reserve_insert(hrx_buffer_table_t* table) {
+  iree_slim_mutex_lock(&table->mutex);
+  hrx_status_t status = hrx_buffer_table_ensure_insert_capacity_locked(
+      table, /*additional_reservations=*/1);
+  if (hrx_status_is_ok(status)) {
+    ++table->reserved_insert_count;
+  }
+  iree_slim_mutex_unlock(&table->mutex);
+  return status;
+}
+
+hrx_status_t hrx_buffer_table_insert_reserved(hrx_buffer_table_t* table,
+                                              uint64_t device_ptr,
+                                              void* host_ptr, size_t size,
+                                              hrx_buffer_t buffer,
+                                              void* user_data) {
+  iree_slim_mutex_lock(&table->mutex);
+  IREE_ASSERT(table->reserved_insert_count > 0);
+  --table->reserved_insert_count;
+
+  hrx_status_t status =
+      hrx_buffer_table_validate_insert_locked(table, device_ptr, host_ptr);
+  if (hrx_status_is_ok(status)) {
+    IREE_ASSERT(table->count < table->capacity);
+    table->entries[table->count++] = (hrx_buffer_table_entry_t){
+        .device_ptr = device_ptr,
+        .host_ptr = host_ptr,
+        .size = size,
+        .buffer = buffer,
+        .user_data = user_data,
+    };
+  }
+
+  iree_slim_mutex_unlock(&table->mutex);
+  return status;
+}
+
+void hrx_buffer_table_cancel_reserved_insert(hrx_buffer_table_t* table) {
+  iree_slim_mutex_lock(&table->mutex);
+  IREE_ASSERT(table->reserved_insert_count > 0);
+  --table->reserved_insert_count;
+  iree_slim_mutex_unlock(&table->mutex);
 }
 
 hrx_status_t hrx_buffer_table_remove(hrx_buffer_table_t* table,
@@ -137,7 +215,8 @@ static void hrx_buffer_table_fill_result(hrx_buffer_table_entry_t* e,
                                          void** out_user_data) {
   if (out_buffer) *out_buffer = e->buffer;
   if (out_offset) {
-    if (any_ptr >= e->device_ptr && any_ptr < e->device_ptr + e->size) {
+    if (any_ptr >= e->device_ptr &&
+        any_ptr - e->device_ptr < (uint64_t)e->size) {
       *out_offset = (size_t)(any_ptr - e->device_ptr);
     } else {
       uint64_t host_addr = (uint64_t)(uintptr_t)e->host_ptr;
@@ -181,26 +260,29 @@ hrx_status_t hrx_buffer_table_find_range(hrx_buffer_table_t* table,
     return hrx_make_status(HRX_STATUS_INVALID_ARGUMENT,
                            "range size must be > 0");
   }
-  uint64_t range_end = any_ptr + size;
-  if (range_end < any_ptr) {
+  if ((uint64_t)size > UINT64_MAX - any_ptr) {
     return hrx_make_status(HRX_STATUS_INVALID_ARGUMENT, "range would overflow");
   }
-
   iree_slim_mutex_lock(&table->mutex);
 
   for (size_t i = 0; i < table->count; ++i) {
     hrx_buffer_table_entry_t* e = &table->entries[i];
-    uint64_t buf_end = e->device_ptr + e->size;
-    if (any_ptr >= e->device_ptr && range_end <= buf_end) {
-      hrx_buffer_table_fill_result(e, any_ptr, out_buffer, out_offset,
-                                   out_user_data);
-      iree_slim_mutex_unlock(&table->mutex);
-      return hrx_ok_status();
+    if (any_ptr >= e->device_ptr) {
+      const uint64_t offset = any_ptr - e->device_ptr;
+      if (offset <= (uint64_t)e->size &&
+          (uint64_t)size <= (uint64_t)e->size - offset) {
+        hrx_buffer_table_fill_result(e, any_ptr, out_buffer, out_offset,
+                                     out_user_data);
+        iree_slim_mutex_unlock(&table->mutex);
+        return hrx_ok_status();
+      }
     }
     if (e->host_ptr) {
-      uint64_t host_start = (uint64_t)(uintptr_t)e->host_ptr;
-      uint64_t host_end = host_start + e->size;
-      if (any_ptr >= host_start && range_end <= host_end) {
+      const uint64_t host_start = (uint64_t)(uintptr_t)e->host_ptr;
+      if (any_ptr < host_start) continue;
+      const uint64_t offset = any_ptr - host_start;
+      if (offset <= (uint64_t)e->size &&
+          (uint64_t)size <= (uint64_t)e->size - offset) {
         hrx_buffer_table_fill_result(e, any_ptr, out_buffer, out_offset,
                                      out_user_data);
         iree_slim_mutex_unlock(&table->mutex);

--- a/libhrx/src/libhrx/buffer_table.h
+++ b/libhrx/src/libhrx/buffer_table.h
@@ -30,6 +30,8 @@ typedef struct hrx_buffer_table_t {
   hrx_buffer_table_entry_t* entries;
   size_t count;
   size_t capacity;
+  // Slots promised to callers that require allocation-free rollback.
+  size_t reserved_insert_count;
 } hrx_buffer_table_t;
 
 void hrx_buffer_table_initialize(hrx_buffer_table_t* table);
@@ -47,6 +49,22 @@ hrx_status_t hrx_buffer_table_insert_if_new(hrx_buffer_table_t* table,
                                             uint64_t device_ptr, void* host_ptr,
                                             size_t size, hrx_buffer_t buffer,
                                             void* user_data);
+
+// Reserves capacity for one future insertion. Regular insertions cannot consume
+// the reserved slot. A successful call must be paired with either
+// hrx_buffer_table_insert_reserved or hrx_buffer_table_cancel_reserved_insert.
+hrx_status_t hrx_buffer_table_reserve_insert(hrx_buffer_table_t* table);
+
+// Inserts an entry using capacity reserved by hrx_buffer_table_reserve_insert.
+// This consumes one reservation even if pointer validation rejects the entry.
+hrx_status_t hrx_buffer_table_insert_reserved(hrx_buffer_table_t* table,
+                                              uint64_t device_ptr,
+                                              void* host_ptr, size_t size,
+                                              hrx_buffer_t buffer,
+                                              void* user_data);
+
+// Cancels one insertion reservation without inserting an entry.
+void hrx_buffer_table_cancel_reserved_insert(hrx_buffer_table_t* table);
 
 hrx_status_t hrx_buffer_table_remove(hrx_buffer_table_t* table,
                                      uint64_t any_ptr);

--- a/libhrx/src/libhrx/hrx_internal.h
+++ b/libhrx/src/libhrx/hrx_internal.h
@@ -466,19 +466,43 @@ iree_status_t hrx_graph_exec_instantiate_locked(
 
 // Buffer allocation.
 typedef struct hrx_buffer_s {
+  // References held by callers of the public buffer handle.
   iree_atomic_ref_count_t ref_count;
+
+  // HAL buffer owning the underlying allocation.
   iree_hal_buffer_t* hal_buffer;
+
+  // HAL pool that materialized |hal_buffer|.
   iree_hal_pool_t* hal_pool;
+
+  // Device associated with the buffer's allocation.
   hrx_device_t device;
+
+  // Memory properties selected for the allocation.
   hrx_memory_type_t mem_type;
+
+  // User-visible allocation length in bytes.
   size_t size;
+
+  // Optional bounded pool that charged |allocation_budget_size|.
+  hrx_mem_pool_t allocation_budget_pool;
+
+  // Bytes charged against |allocation_budget_pool|.
+  size_t allocation_budget_size;
+
+  // Active scoped mapping, valid only while |is_mapped| is true.
   iree_hal_buffer_mapping_t mapping;
+
+  // True when |mapping| currently owns an active mapping.
   bool is_mapped;
+
+  // Cached host pointer for the active mapping.
   void* mapped_ptr;
 } hrx_buffer_s;
 
 // Memory pool (stream-ordered memory management).
 typedef struct hrx_mem_pool_s {
+  // References held by public handles and bounded allocations.
   iree_atomic_ref_count_t ref_count;
 
   // Device whose HAL pool backend supplies this pool's backing storage.
@@ -487,11 +511,23 @@ typedef struct hrx_mem_pool_s {
   // HIP/CUDA-style creation properties used for attribute queries.
   hrx_mem_pool_props_t props;
 
-  // HAL pool lazily created on first allocation.
+  // TLSF HAL pool serving allocations up to |suballocation_max_size|.
   iree_hal_pool_t* hal_pool;
+
+  // Pass-through HAL pool serving allocations larger than the TLSF slab size.
+  iree_hal_pool_t* oversized_hal_pool;
+
+  // Largest request routed to |hal_pool| rather than |oversized_hal_pool|.
+  iree_device_size_t suballocation_max_size;
+
+  // Bytes charged to the immutable |props.max_size| allocation limit.
+  size_t allocation_budget_current;
 
   // HIP/CUDA release threshold attribute in bytes.
   uint64_t release_threshold;
+
+  // Allocations that have retained the HAL pool but have not reserved from it.
+  uint32_t inflight_allocation_count;
 
   // True when internal dependency insertion is allowed for reuse.
   bool reuse_allow_internal_dependencies;
@@ -519,15 +555,6 @@ typedef struct hrx_mem_pool_s {
 
   // Guards mutable pool attributes and lazy HAL pool creation.
   iree_slim_mutex_t mutex;
-
-  // True when the device allocator exposes HAL virtual-memory operations.
-  bool supports_virtual_memory;
-
-  // Minimum virtual-memory page size reported by the HAL allocator.
-  iree_device_size_t vm_page_size_min;
-
-  // Recommended virtual-memory page size reported by the HAL allocator.
-  iree_device_size_t vm_page_size_recommended;
 } hrx_mem_pool_s;
 
 // Loaded VM module with a context containing HAL + bytecode modules.

--- a/libhrx/src/libhrx/mem_pool.c
+++ b/libhrx/src/libhrx/mem_pool.c
@@ -6,22 +6,23 @@
 // management are implemented here; async alloc/free sequencing remains in the
 // binding layer because it requires stream host callback support.
 
+#include "mem_pool.h"
+
 #include <stdlib.h>
 #include <string.h>
 
 #include "hrx_internal.h"
+#include "iree/hal/memory/asan.h"
+#include "iree/hal/memory/passthrough_pool.h"
 #include "iree/hal/memory/tlsf_pool.h"
+#include "vmm_slab_provider.h"
 
 //===----------------------------------------------------------------------===//
 // Pool configuration
 //===----------------------------------------------------------------------===//
 
-// Default range length for GPU HIP/CUDA allocation pools.
-static const iree_device_size_t HRX_MEM_POOL_GPU_RANGE_LENGTH_DEFAULT =
-    (iree_device_size_t)16 * 1024 * 1024 * 1024;
-
-// Minimum range length for GPU HIP/CUDA allocation pools.
-static const iree_device_size_t HRX_MEM_POOL_GPU_RANGE_LENGTH_MIN =
+// Default slab length for growable GPU allocation pools.
+static const iree_device_size_t HRX_MEM_POOL_GPU_SLAB_LENGTH_DEFAULT =
     (iree_device_size_t)256 * 1024 * 1024;
 
 // Default range length for CPU/local allocation pools.
@@ -54,8 +55,7 @@ static iree_status_t hrx_mem_pool_parse_range_length_env(
 }
 
 static iree_status_t hrx_mem_pool_query_range_length(
-    hrx_mem_pool_t pool, iree_device_size_t min_allocation_size,
-    iree_device_size_t* out_range_length) {
+    hrx_mem_pool_t pool, iree_device_size_t* out_range_length) {
   bool has_env_range_length = false;
   iree_device_size_t range_length = 0;
   IREE_RETURN_IF_ERROR(hrx_mem_pool_parse_range_length_env(
@@ -67,23 +67,15 @@ static iree_status_t hrx_mem_pool_query_range_length(
 
   if (!has_env_range_length) {
     if (pool->device->type == HRX_ACCELERATOR_GPU) {
-      bool total_memory_known = false;
-      iree_device_size_t total_memory = 0;
-      hrx_status_t memory_status = hrx_device_query_total_memory_from_spec(
-          pool->device, &total_memory_known, &total_memory);
-      IREE_RETURN_IF_ERROR(hrx_status_to_iree(memory_status));
-      range_length = HRX_MEM_POOL_GPU_RANGE_LENGTH_DEFAULT;
-      if (total_memory_known && total_memory > 0) {
-        range_length = total_memory - total_memory / 4;
-        range_length =
-            iree_max(range_length, HRX_MEM_POOL_GPU_RANGE_LENGTH_MIN);
-      }
+      // TLSF grows by this range length one slab at a time. A slab is fully
+      // committed on first use, so its size bounds per-pool idle memory rather
+      // than expressing a fraction of total device memory.
+      range_length = HRX_MEM_POOL_GPU_SLAB_LENGTH_DEFAULT;
     } else {
       range_length = HRX_MEM_POOL_CPU_RANGE_LENGTH_DEFAULT;
     }
   }
 
-  range_length = iree_max(range_length, min_allocation_size);
   if (!iree_device_size_checked_align(range_length, HRX_MEM_POOL_ALIGNMENT,
                                       &range_length)) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
@@ -94,32 +86,109 @@ static iree_status_t hrx_mem_pool_query_range_length(
 }
 
 static void hrx_mem_pool_refresh_stats_locked(hrx_mem_pool_t pool) {
-  if (!pool->hal_pool) return;
-  iree_hal_pool_stats_t stats;
-  iree_hal_pool_query_stats(pool->hal_pool, &stats);
-  pool->reserved_mem_current = stats.bytes_committed;
-  pool->reserved_mem_high =
-      iree_max(pool->reserved_mem_high, pool->reserved_mem_current);
-  pool->used_mem_current = stats.bytes_reserved;
-  pool->used_mem_high = iree_max(pool->used_mem_high, pool->used_mem_current);
+  iree_hal_pool_stats_t tlsf_stats = {0};
+  iree_hal_pool_stats_t oversized_stats = {0};
+  if (pool->hal_pool) {
+    iree_hal_pool_query_stats(pool->hal_pool, &tlsf_stats);
+  }
+  if (pool->oversized_hal_pool) {
+    iree_hal_pool_query_stats(pool->oversized_hal_pool, &oversized_stats);
+  }
+  const uint64_t previous_reserved_mem_current = pool->reserved_mem_current;
+  pool->reserved_mem_current =
+      tlsf_stats.bytes_committed > UINT64_MAX - oversized_stats.bytes_committed
+          ? UINT64_MAX
+          : tlsf_stats.bytes_committed + oversized_stats.bytes_committed;
+  if (pool->reserved_mem_current > previous_reserved_mem_current) {
+    pool->reserved_mem_high =
+        iree_max(pool->reserved_mem_high, pool->reserved_mem_current);
+  }
 }
 
-static iree_status_t hrx_mem_pool_ensure_hal_pool_locked(
-    hrx_mem_pool_t pool, iree_device_size_t min_allocation_size) {
-  if (pool->hal_pool) return iree_ok_status();
+// Detaches both allocation classes only after every reservation has retired.
+// Callers must hold |pool->mutex| and release returned references after
+// unlocking.
+static void hrx_mem_pool_take_idle_hal_pools_locked(
+    hrx_mem_pool_t pool, bool require_zero_release_threshold,
+    iree_hal_pool_t** out_hal_pool, iree_hal_pool_t** out_oversized_hal_pool) {
+  *out_hal_pool = NULL;
+  *out_oversized_hal_pool = NULL;
+  if ((!pool->hal_pool && !pool->oversized_hal_pool) ||
+      pool->inflight_allocation_count != 0 ||
+      (require_zero_release_threshold && pool->release_threshold != 0)) {
+    return;
+  }
+
+  iree_hal_pool_stats_t tlsf_stats = {0};
+  iree_hal_pool_stats_t oversized_stats = {0};
+  if (pool->hal_pool) {
+    iree_hal_pool_query_stats(pool->hal_pool, &tlsf_stats);
+  }
+  if (pool->oversized_hal_pool) {
+    iree_hal_pool_query_stats(pool->oversized_hal_pool, &oversized_stats);
+  }
+  if (tlsf_stats.bytes_reserved != 0 || oversized_stats.bytes_reserved != 0 ||
+      pool->allocation_budget_current != 0) {
+    return;
+  }
+
+  *out_hal_pool = pool->hal_pool;
+  *out_oversized_hal_pool = pool->oversized_hal_pool;
+  pool->hal_pool = NULL;
+  pool->oversized_hal_pool = NULL;
+  pool->reserved_mem_current = 0;
+  pool->used_mem_current = 0;
+}
+
+// Device-local pools use the allocator VMM contract when it is available. This
+// gives every pool slab a stable device address while preserving the existing
+// TLSF policy for suballocation, trimming, and reservation accounting. ASAN
+// owns a separate slab lifecycle, so its configured device provider remains
+// authoritative for instrumented allocations.
+static bool hrx_mem_pool_uses_virtual_memory_slabs(
+    const hrx_mem_pool_t pool,
+    const iree_hal_queue_pool_backend_t* queue_pool_backend) {
+  return pool->device->type == HRX_ACCELERATOR_GPU &&
+         iree_hal_allocator_supports_virtual_memory(
+             pool->device->allocator.hal_allocator) &&
+         !iree_hal_asan_pool_options_is_enabled(&queue_pool_backend->asan);
+}
+
+static iree_status_t hrx_mem_pool_ensure_hal_pools_locked(hrx_mem_pool_t pool) {
+  if (pool->hal_pool && pool->oversized_hal_pool) return iree_ok_status();
+  IREE_ASSERT(!pool->hal_pool);
+  IREE_ASSERT(!pool->oversized_hal_pool);
 
   iree_hal_queue_pool_backend_t backend;
   IREE_RETURN_IF_ERROR(iree_hal_device_query_queue_pool_backend(
       pool->device->hal_device, IREE_HAL_QUEUE_AFFINITY_ANY, &backend));
-  if (!backend.slab_provider || !backend.notification) {
-    return iree_make_status(
-        IREE_STATUS_FAILED_PRECONDITION,
-        "HAL queue-pool backend returned an incomplete pool bundle");
+  if (!backend.notification) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "HAL queue-pool backend returned no allocation "
+                            "notification");
   }
 
   iree_device_size_t range_length = 0;
-  IREE_RETURN_IF_ERROR(hrx_mem_pool_query_range_length(
-      pool, min_allocation_size, &range_length));
+  IREE_RETURN_IF_ERROR(hrx_mem_pool_query_range_length(pool, &range_length));
+
+  iree_hal_slab_provider_t* slab_provider = backend.slab_provider;
+  bool owns_slab_provider = false;
+  if (hrx_mem_pool_uses_virtual_memory_slabs(pool, &backend)) {
+    const iree_hal_buffer_params_t physical_buffer_params = {
+        .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
+        .access = IREE_HAL_MEMORY_ACCESS_ALL,
+        .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+        .queue_affinity = IREE_HAL_QUEUE_AFFINITY_ANY,
+    };
+    IREE_RETURN_IF_ERROR(hrx_vmm_slab_provider_create(
+        pool->device->allocator.hal_allocator, physical_buffer_params,
+        iree_allocator_system(), &slab_provider));
+    owns_slab_provider = true;
+  }
+  if (!slab_provider) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "HAL memory pool has no slab provider");
+  }
 
   iree_hal_tlsf_pool_options_t options = {0};
   options.tlsf_options.range_length = range_length;
@@ -127,11 +196,36 @@ static iree_status_t hrx_mem_pool_ensure_hal_pool_locked(
   options.tlsf_options.frontier_capacity =
       IREE_HAL_MEMORY_TLSF_DEFAULT_FRONTIER_CAPACITY;
   options.asan = backend.asan;
+  options.budget_limit = 0;
   options.trace_name = iree_make_cstring_view("hrx-mem-pool");
 
-  IREE_RETURN_IF_ERROR(iree_hal_tlsf_pool_create(
-      options, backend.slab_provider, backend.notification, backend.epoch_query,
-      iree_allocator_system(), &pool->hal_pool));
+  iree_hal_pool_t* hal_pool = NULL;
+  iree_status_t status = iree_hal_tlsf_pool_create(
+      options, slab_provider, backend.notification, backend.epoch_query,
+      iree_allocator_system(), &hal_pool);
+  if (!iree_status_is_ok(status)) {
+    if (owns_slab_provider) iree_hal_slab_provider_release(slab_provider);
+    return status;
+  }
+
+  iree_hal_passthrough_pool_options_t oversized_options = {
+      .asan = backend.asan,
+      .trace_name = iree_make_cstring_view("hrx-mem-pool-oversized"),
+  };
+  iree_hal_pool_t* oversized_hal_pool = NULL;
+  status = iree_hal_passthrough_pool_create(
+      oversized_options, slab_provider, backend.notification,
+      iree_allocator_system(), &oversized_hal_pool);
+  if (!iree_status_is_ok(status)) {
+    iree_hal_pool_release(hal_pool);
+    if (owns_slab_provider) iree_hal_slab_provider_release(slab_provider);
+    return status;
+  }
+  if (owns_slab_provider) iree_hal_slab_provider_release(slab_provider);
+
+  pool->hal_pool = hal_pool;
+  pool->oversized_hal_pool = oversized_hal_pool;
+  pool->suballocation_max_size = range_length;
   hrx_mem_pool_refresh_stats_locked(pool);
   return iree_ok_status();
 }
@@ -159,9 +253,10 @@ hrx_status_t hrx_mem_pool_create(hrx_device_t device,
   hrx_device_retain(pool->device);
   pool->props = *props;
   pool->release_threshold = 0;
-  pool->reuse_allow_internal_dependencies = false;
+  pool->inflight_allocation_count = 0;
+  pool->reuse_allow_internal_dependencies = true;
   pool->reuse_follow_event_dependencies = true;
-  pool->reuse_allow_opportunistic = false;
+  pool->reuse_allow_opportunistic = true;
   pool->reserved_mem_current = 0;
   pool->reserved_mem_high = 0;
   pool->used_mem_current = 0;
@@ -169,40 +264,13 @@ hrx_status_t hrx_mem_pool_create(hrx_device_t device,
   pool->platform_handle = NULL;
   iree_slim_mutex_initialize(&pool->mutex);
 
-  // Check if the device allocator supports virtual memory.
-  pool->supports_virtual_memory = false;
-  pool->vm_page_size_min = 0;
-  pool->vm_page_size_recommended = 0;
-
-  iree_hal_allocator_t* hal_allocator = device->allocator.hal_allocator;
-  if (iree_hal_allocator_supports_virtual_memory(hal_allocator)) {
-    pool->supports_virtual_memory = true;
-
-    iree_hal_buffer_params_t params = {
-        .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
-        .access = IREE_HAL_MEMORY_ACCESS_ALL,
-        .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-        .queue_affinity = IREE_HAL_QUEUE_AFFINITY_ANY,
-    };
-    iree_status_t vm_status =
-        iree_hal_allocator_virtual_memory_query_granularity(
-            hal_allocator, params, &pool->vm_page_size_min,
-            &pool->vm_page_size_recommended);
-    if (!iree_status_is_ok(vm_status)) {
-      hrx_status_t status = hrx_status_from_iree(vm_status);
-      hrx_device_release(pool->device);
-      iree_slim_mutex_deinitialize(&pool->mutex);
-      free(pool);
-      return status;
-    }
-  }
-
   *out_pool = pool;
   return hrx_ok_status();
 }
 
 static void hrx_mem_pool_destroy(hrx_mem_pool_s* pool) {
   iree_hal_pool_release(pool->hal_pool);
+  iree_hal_pool_release(pool->oversized_hal_pool);
   hrx_device_release(pool->device);
   iree_slim_mutex_deinitialize(&pool->mutex);
   free(pool);
@@ -295,6 +363,24 @@ hrx_status_t hrx_mem_pool_set_attribute(hrx_mem_pool_t pool,
     case HRX_MEM_POOL_ATTR_RELEASE_THRESHOLD:
       pool->release_threshold = value;
       break;
+    case HRX_MEM_POOL_ATTR_RESERVED_MEM_HIGH:
+      if (value != 0) {
+        status = hrx_make_status(
+            HRX_STATUS_INVALID_ARGUMENT,
+            "reserved memory high watermark must reset to zero");
+      } else {
+        pool->reserved_mem_high = 0;
+      }
+      break;
+    case HRX_MEM_POOL_ATTR_USED_MEM_HIGH:
+      if (value != 0) {
+        status =
+            hrx_make_status(HRX_STATUS_INVALID_ARGUMENT,
+                            "used memory high watermark must reset to zero");
+      } else {
+        pool->used_mem_high = 0;
+      }
+      break;
     default:
       status = hrx_make_status(HRX_STATUS_INVALID_ARGUMENT,
                                "invalid or read-only memory pool attribute");
@@ -313,15 +399,70 @@ hrx_status_t hrx_mem_pool_trim(hrx_mem_pool_t pool, size_t min_bytes_to_keep) {
   if (!pool) {
     return hrx_make_status(HRX_STATUS_INVALID_ARGUMENT, "pool is NULL");
   }
-  (void)min_bytes_to_keep;
+
+  iree_hal_pool_t* idle_hal_pool = NULL;
+  iree_hal_pool_t* idle_oversized_hal_pool = NULL;
   iree_slim_mutex_lock(&pool->mutex);
-  iree_status_t status =
-      pool->hal_pool ? iree_hal_pool_trim(pool->hal_pool) : iree_ok_status();
+  iree_status_t status = pool->hal_pool ? iree_hal_tlsf_pool_trim_to(
+                                              pool->hal_pool, min_bytes_to_keep)
+                                        : iree_ok_status();
   if (iree_status_is_ok(status)) {
     hrx_mem_pool_refresh_stats_locked(pool);
+    if (min_bytes_to_keep == 0) {
+      hrx_mem_pool_take_idle_hal_pools_locked(
+          pool, /*require_zero_release_threshold=*/false, &idle_hal_pool,
+          &idle_oversized_hal_pool);
+    }
   }
   iree_slim_mutex_unlock(&pool->mutex);
+  iree_hal_pool_release(idle_hal_pool);
+  iree_hal_pool_release(idle_oversized_hal_pool);
   return hrx_status_from_iree(status);
+}
+
+void hrx_mem_pool_release_unused(hrx_mem_pool_t pool) {
+  if (!pool) return;
+
+  iree_slim_mutex_lock(&pool->mutex);
+  iree_hal_pool_t* idle_hal_pool = NULL;
+  iree_hal_pool_t* idle_oversized_hal_pool = NULL;
+  hrx_mem_pool_take_idle_hal_pools_locked(
+      pool, /*require_zero_release_threshold=*/true, &idle_hal_pool,
+      &idle_oversized_hal_pool);
+  iree_slim_mutex_unlock(&pool->mutex);
+  iree_hal_pool_release(idle_hal_pool);
+  iree_hal_pool_release(idle_oversized_hal_pool);
+}
+
+void hrx_mem_pool_record_logical_allocation(hrx_mem_pool_t pool, size_t size) {
+  if (!pool || size == 0) return;
+
+  iree_slim_mutex_lock(&pool->mutex);
+  if (size >= UINT64_MAX - pool->used_mem_current) {
+    pool->used_mem_current = UINT64_MAX;
+  } else {
+    pool->used_mem_current += size;
+  }
+  pool->used_mem_high = iree_max(pool->used_mem_high, pool->used_mem_current);
+  iree_slim_mutex_unlock(&pool->mutex);
+}
+
+void hrx_mem_pool_record_logical_free(hrx_mem_pool_t pool, size_t size) {
+  if (!pool || size == 0) return;
+
+  iree_slim_mutex_lock(&pool->mutex);
+  IREE_ASSERT(pool->used_mem_current >= size);
+  pool->used_mem_current -= size;
+  iree_slim_mutex_unlock(&pool->mutex);
+}
+
+void hrx_mem_pool_release_allocation_budget(hrx_mem_pool_t pool, size_t size) {
+  if (!pool || size == 0) return;
+
+  iree_slim_mutex_lock(&pool->mutex);
+  IREE_ASSERT(pool->allocation_budget_current >= size);
+  pool->allocation_budget_current -= size;
+  iree_slim_mutex_unlock(&pool->mutex);
 }
 
 //===----------------------------------------------------------------------===//
@@ -330,8 +471,8 @@ hrx_status_t hrx_mem_pool_trim(hrx_mem_pool_t pool, size_t min_bytes_to_keep) {
 
 static iree_status_t hrx_mem_pool_allocate_hal_buffer(
     hrx_mem_pool_t pool, iree_hal_buffer_params_t params,
-    iree_device_size_t size, iree_timeout_t timeout,
-    iree_hal_pool_t** out_hal_pool, iree_hal_buffer_t** out_buffer) {
+    iree_device_size_t size, iree_hal_pool_t** out_hal_pool,
+    iree_hal_buffer_t** out_buffer) {
   IREE_ASSERT_ARGUMENT(out_hal_pool);
   IREE_ASSERT_ARGUMENT(out_buffer);
   *out_hal_pool = NULL;
@@ -345,22 +486,49 @@ static iree_status_t hrx_mem_pool_allocate_hal_buffer(
   }
 
   iree_slim_mutex_lock(&pool->mutex);
-  iree_status_t status = hrx_mem_pool_ensure_hal_pool_locked(pool, size);
-  iree_hal_pool_t* hal_pool = pool->hal_pool;
+  iree_status_t status = hrx_mem_pool_ensure_hal_pools_locked(pool);
+  if (iree_status_is_ok(status) && pool->props.max_size != 0) {
+    if (pool->allocation_budget_current > pool->props.max_size ||
+        size > pool->props.max_size - pool->allocation_budget_current) {
+      status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                "memory pool allocation exceeds max size");
+    } else {
+      pool->allocation_budget_current += size;
+    }
+  }
+  iree_hal_pool_t* hal_pool = NULL;
   if (iree_status_is_ok(status)) {
+    hal_pool = size <= pool->suballocation_max_size ? pool->hal_pool
+                                                    : pool->oversized_hal_pool;
     iree_hal_pool_retain(hal_pool);
+    ++pool->inflight_allocation_count;
   }
   iree_slim_mutex_unlock(&pool->mutex);
   if (!iree_status_is_ok(status)) return status;
 
   status = iree_hal_pool_allocate_buffer(hal_pool, params, size,
-                                         /*requester_frontier=*/NULL, timeout,
-                                         out_buffer);
+                                         /*requester_frontier=*/NULL,
+                                         iree_immediate_timeout(), out_buffer);
+  if (!iree_status_is_ok(status) &&
+      iree_status_code(status) == IREE_STATUS_DEADLINE_EXCEEDED) {
+    iree_status_free(status);
+    status = iree_make_status(
+        IREE_STATUS_RESOURCE_EXHAUSTED,
+        "memory pool has no immediately reusable capacity for allocation");
+  }
+  iree_slim_mutex_lock(&pool->mutex);
+  --pool->inflight_allocation_count;
+  if (!iree_status_is_ok(status) && pool->props.max_size != 0) {
+    IREE_ASSERT(pool->allocation_budget_current >= size);
+    pool->allocation_budget_current -= size;
+  }
+  if (iree_status_is_ok(status)) {
+    hrx_mem_pool_refresh_stats_locked(pool);
+  }
+  iree_slim_mutex_unlock(&pool->mutex);
+
   if (iree_status_is_ok(status)) {
     *out_hal_pool = hal_pool;
-    iree_slim_mutex_lock(&pool->mutex);
-    hrx_mem_pool_refresh_stats_locked(pool);
-    iree_slim_mutex_unlock(&pool->mutex);
   } else {
     iree_hal_pool_release(hal_pool);
   }
@@ -388,8 +556,7 @@ hrx_status_t hrx_mem_pool_allocate_buffer(hrx_mem_pool_t pool,
   iree_hal_pool_t* hal_pool = NULL;
   iree_hal_buffer_t* hal_buffer = NULL;
   iree_status_t status = hrx_mem_pool_allocate_hal_buffer(
-      pool, hal_params, (iree_device_size_t)size, iree_infinite_timeout(),
-      &hal_pool, &hal_buffer);
+      pool, hal_params, (iree_device_size_t)size, &hal_pool, &hal_buffer);
   if (!iree_status_is_ok(status)) {
     HRX_RETURN_AND_END_ZONE(z0, hrx_status_from_iree(status));
   }
@@ -400,6 +567,9 @@ hrx_status_t hrx_mem_pool_allocate_buffer(hrx_mem_pool_t pool,
   if (!iree_status_is_ok(status)) {
     iree_hal_buffer_release(hal_buffer);
     iree_hal_pool_release(hal_pool);
+    if (pool->props.max_size != 0) {
+      hrx_mem_pool_release_allocation_budget(pool, size);
+    }
     HRX_RETURN_AND_END_ZONE(z0, hrx_status_from_iree(status));
   }
 
@@ -411,6 +581,11 @@ hrx_status_t hrx_mem_pool_allocate_buffer(hrx_mem_pool_t pool,
   hrx_device_retain(buf->device);
   buf->mem_type = params.type;
   buf->size = size;
+  if (pool->props.max_size != 0) {
+    hrx_mem_pool_retain(pool);
+    buf->allocation_budget_pool = pool;
+    buf->allocation_budget_size = size;
+  }
   *buffer = buf;
   HRX_RETURN_AND_END_ZONE(z0, hrx_ok_status());
 }

--- a/libhrx/src/libhrx/mem_pool.c
+++ b/libhrx/src/libhrx/mem_pool.c
@@ -109,13 +109,12 @@ static void hrx_mem_pool_refresh_stats_locked(hrx_mem_pool_t pool) {
 // Callers must hold |pool->mutex| and release returned references after
 // unlocking.
 static void hrx_mem_pool_take_idle_hal_pools_locked(
-    hrx_mem_pool_t pool, bool require_zero_release_threshold,
-    iree_hal_pool_t** out_hal_pool, iree_hal_pool_t** out_oversized_hal_pool) {
+    hrx_mem_pool_t pool, iree_hal_pool_t** out_hal_pool,
+    iree_hal_pool_t** out_oversized_hal_pool) {
   *out_hal_pool = NULL;
   *out_oversized_hal_pool = NULL;
   if ((!pool->hal_pool && !pool->oversized_hal_pool) ||
-      pool->inflight_allocation_count != 0 ||
-      (require_zero_release_threshold && pool->release_threshold != 0)) {
+      pool->inflight_allocation_count != 0) {
     return;
   }
 
@@ -409,9 +408,8 @@ hrx_status_t hrx_mem_pool_trim(hrx_mem_pool_t pool, size_t min_bytes_to_keep) {
   if (iree_status_is_ok(status)) {
     hrx_mem_pool_refresh_stats_locked(pool);
     if (min_bytes_to_keep == 0) {
-      hrx_mem_pool_take_idle_hal_pools_locked(
-          pool, /*require_zero_release_threshold=*/false, &idle_hal_pool,
-          &idle_oversized_hal_pool);
+      hrx_mem_pool_take_idle_hal_pools_locked(pool, &idle_hal_pool,
+                                              &idle_oversized_hal_pool);
     }
   }
   iree_slim_mutex_unlock(&pool->mutex);
@@ -420,18 +418,29 @@ hrx_status_t hrx_mem_pool_trim(hrx_mem_pool_t pool, size_t min_bytes_to_keep) {
   return hrx_status_from_iree(status);
 }
 
-void hrx_mem_pool_release_unused(hrx_mem_pool_t pool) {
-  if (!pool) return;
+hrx_status_t hrx_mem_pool_release_unused(hrx_mem_pool_t pool) {
+  if (!pool) {
+    return hrx_make_status(HRX_STATUS_INVALID_ARGUMENT, "pool is NULL");
+  }
 
   iree_slim_mutex_lock(&pool->mutex);
   iree_hal_pool_t* idle_hal_pool = NULL;
   iree_hal_pool_t* idle_oversized_hal_pool = NULL;
-  hrx_mem_pool_take_idle_hal_pools_locked(
-      pool, /*require_zero_release_threshold=*/true, &idle_hal_pool,
-      &idle_oversized_hal_pool);
+  iree_status_t status =
+      pool->hal_pool
+          ? iree_hal_tlsf_pool_trim_to(pool->hal_pool, pool->release_threshold)
+          : iree_ok_status();
+  if (iree_status_is_ok(status)) {
+    hrx_mem_pool_refresh_stats_locked(pool);
+    if (pool->release_threshold == 0) {
+      hrx_mem_pool_take_idle_hal_pools_locked(pool, &idle_hal_pool,
+                                              &idle_oversized_hal_pool);
+    }
+  }
   iree_slim_mutex_unlock(&pool->mutex);
   iree_hal_pool_release(idle_hal_pool);
   iree_hal_pool_release(idle_oversized_hal_pool);
+  return hrx_status_from_iree(status);
 }
 
 void hrx_mem_pool_record_logical_allocation(hrx_mem_pool_t pool, size_t size) {

--- a/libhrx/src/libhrx/mem_pool.h
+++ b/libhrx/src/libhrx/mem_pool.h
@@ -1,0 +1,15 @@
+// Copyright 2026 The HRX Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef LIBHRX_SRC_LIBHRX_MEM_POOL_H_
+#define LIBHRX_SRC_LIBHRX_MEM_POOL_H_
+
+#include <stddef.h>
+
+#include "hrx_runtime.h"
+
+// Releases the bounded-pool budget reservation associated with a buffer.
+// The buffer lifetime retains |pool| until this call completes.
+void hrx_mem_pool_release_allocation_budget(hrx_mem_pool_t pool, size_t size);
+
+#endif  // LIBHRX_SRC_LIBHRX_MEM_POOL_H_

--- a/libhrx/src/libhrx/vmm_slab_provider.c
+++ b/libhrx/src/libhrx/vmm_slab_provider.c
@@ -5,7 +5,10 @@
 
 #include <stdio.h>
 
+#include "iree/base/threading/mutex.h"
 #include "iree/hal/buffer.h"
+
+typedef struct hrx_vmm_slab_t hrx_vmm_slab_t;
 
 typedef struct hrx_vmm_slab_provider_t {
   // Base provider header for vtable dispatch and reference counting.
@@ -28,9 +31,16 @@ typedef struct hrx_vmm_slab_provider_t {
 
   // Cumulative number of slabs released through the VMM allocator interface.
   iree_atomic_int64_t total_released;
+
+  // Slabs whose native teardown failed and must retain their live handles.
+  // Protected by |mutex| and retried by provider trimming and destruction.
+  hrx_vmm_slab_t* failed_release_head;
+
+  // Serializes access to |failed_release_head|.
+  iree_slim_mutex_t mutex;
 } hrx_vmm_slab_provider_t;
 
-typedef struct hrx_vmm_slab_t {
+struct hrx_vmm_slab_t {
   // Virtual address reservation retained until the slab is released.
   iree_hal_buffer_t* virtual_buffer;
 
@@ -42,9 +52,18 @@ typedef struct hrx_vmm_slab_t {
 
   // True after the physical allocation has been mapped into the reservation.
   bool is_mapped;
-} hrx_vmm_slab_t;
+
+  // True after this slab has been returned to the owning HAL pool.
+  bool is_published;
+
+  // Next slab retained after a failed release attempt.
+  hrx_vmm_slab_t* next_failed_release;
+};
 
 static const iree_hal_slab_provider_vtable_t hrx_vmm_slab_provider_vtable;
+
+static iree_status_t hrx_vmm_slab_provider_retry_failed_releases(
+    hrx_vmm_slab_provider_t* provider);
 
 static hrx_vmm_slab_provider_t* hrx_vmm_slab_provider_cast(
     iree_hal_slab_provider_t* base_provider) {
@@ -59,6 +78,21 @@ static const hrx_vmm_slab_provider_t* hrx_vmm_slab_provider_const_cast(
 static void hrx_vmm_slab_provider_destroy(
     iree_hal_slab_provider_t* base_provider) {
   hrx_vmm_slab_provider_t* provider = hrx_vmm_slab_provider_cast(base_provider);
+  iree_status_t status = hrx_vmm_slab_provider_retry_failed_releases(provider);
+  if (!iree_status_is_ok(status)) {
+    iree_status_fprint(stderr, status);
+    iree_status_free(status);
+  }
+  iree_slim_mutex_lock(&provider->mutex);
+  const bool has_failed_releases = provider->failed_release_head != NULL;
+  iree_slim_mutex_unlock(&provider->mutex);
+  if (has_failed_releases) {
+    fprintf(stderr,
+            "VMM slab provider destroyed with live resources retained after "
+            "native teardown failure\n");
+    return;
+  }
+  iree_slim_mutex_deinitialize(&provider->mutex);
   iree_hal_allocator_release(provider->allocator);
   iree_allocator_free(provider->host_allocator, provider);
 }
@@ -99,7 +133,45 @@ static iree_status_t hrx_vmm_slab_provider_release_slab_state(
       status = iree_status_join(status, release_status);
     }
   }
-  iree_allocator_free(provider->host_allocator, slab);
+  if (!slab->is_mapped && !slab->physical_memory && !slab->virtual_buffer) {
+    iree_allocator_free(provider->host_allocator, slab);
+  }
+  return status;
+}
+
+static void hrx_vmm_slab_provider_retain_failed_release(
+    hrx_vmm_slab_provider_t* provider, hrx_vmm_slab_t* slab) {
+  iree_slim_mutex_lock(&provider->mutex);
+  slab->next_failed_release = provider->failed_release_head;
+  provider->failed_release_head = slab;
+  iree_slim_mutex_unlock(&provider->mutex);
+}
+
+static iree_status_t hrx_vmm_slab_provider_retry_failed_releases(
+    hrx_vmm_slab_provider_t* provider) {
+  iree_slim_mutex_lock(&provider->mutex);
+  hrx_vmm_slab_t* pending = provider->failed_release_head;
+  provider->failed_release_head = NULL;
+  iree_slim_mutex_unlock(&provider->mutex);
+
+  iree_status_t status = iree_ok_status();
+  while (pending) {
+    hrx_vmm_slab_t* slab = pending;
+    pending = slab->next_failed_release;
+    slab->next_failed_release = NULL;
+    const bool is_published = slab->is_published;
+    iree_status_t release_status =
+        hrx_vmm_slab_provider_release_slab_state(provider, slab);
+    if (iree_status_is_ok(release_status)) {
+      if (is_published) {
+        iree_atomic_fetch_add(&provider->total_released, 1,
+                              iree_memory_order_relaxed);
+      }
+    } else {
+      hrx_vmm_slab_provider_retain_failed_release(provider, slab);
+      status = iree_status_join(status, release_status);
+    }
+  }
   return status;
 }
 
@@ -165,13 +237,19 @@ static iree_status_t hrx_vmm_slab_provider_acquire_slab(
   }
 
   if (!iree_status_is_ok(status)) {
-    return iree_status_join(
-        status, hrx_vmm_slab_provider_release_slab_state(provider, slab));
+    iree_status_t release_status =
+        hrx_vmm_slab_provider_release_slab_state(provider, slab);
+    if (!iree_status_is_ok(release_status)) {
+      hrx_vmm_slab_provider_retain_failed_release(provider, slab);
+      status = iree_status_join(status, release_status);
+    }
+    return status;
   }
 
+  slab->is_published = true;
   out_slab->base_ptr =
       (uint8_t*)(uintptr_t)external_buffer.handle.device_allocation.ptr;
-  out_slab->length = min_length;
+  out_slab->length = allocation_size;
   out_slab->provider_handle = (uint64_t)(uintptr_t)slab;
   iree_atomic_fetch_add(&provider->total_acquired, 1,
                         iree_memory_order_relaxed);
@@ -182,12 +260,15 @@ static void hrx_vmm_slab_provider_release_slab(
     iree_hal_slab_provider_t* base_provider, const iree_hal_slab_t* slab) {
   if (!slab || !slab->provider_handle) return;
   hrx_vmm_slab_provider_t* provider = hrx_vmm_slab_provider_cast(base_provider);
-  iree_status_t status = hrx_vmm_slab_provider_release_slab_state(
-      provider, (hrx_vmm_slab_t*)(uintptr_t)slab->provider_handle);
+  hrx_vmm_slab_t* virtual_slab =
+      (hrx_vmm_slab_t*)(uintptr_t)slab->provider_handle;
+  iree_status_t status =
+      hrx_vmm_slab_provider_release_slab_state(provider, virtual_slab);
   if (iree_status_is_ok(status)) {
     iree_atomic_fetch_add(&provider->total_released, 1,
                           iree_memory_order_relaxed);
   } else {
+    hrx_vmm_slab_provider_retain_failed_release(provider, virtual_slab);
     iree_status_fprint(stderr, status);
     iree_status_free(status);
   }
@@ -261,8 +342,13 @@ static void hrx_vmm_slab_provider_prefault(
 static void hrx_vmm_slab_provider_trim(
     iree_hal_slab_provider_t* base_provider,
     iree_hal_slab_provider_trim_flags_t flags) {
-  (void)base_provider;
   (void)flags;
+  hrx_vmm_slab_provider_t* provider = hrx_vmm_slab_provider_cast(base_provider);
+  iree_status_t status = hrx_vmm_slab_provider_retry_failed_releases(provider);
+  if (!iree_status_is_ok(status)) {
+    iree_status_fprint(stderr, status);
+    iree_status_free(status);
+  }
 }
 
 static void hrx_vmm_slab_provider_query_stats(
@@ -337,7 +423,9 @@ iree_status_t hrx_vmm_slab_provider_create(
       .page_size = page_size,
       .total_acquired = IREE_ATOMIC_VAR_INIT(0),
       .total_released = IREE_ATOMIC_VAR_INIT(0),
+      .failed_release_head = NULL,
   };
+  iree_slim_mutex_initialize(&provider->mutex);
   iree_hal_slab_provider_initialize(&hrx_vmm_slab_provider_vtable,
                                     &provider->base);
   iree_hal_allocator_retain(provider->allocator);

--- a/libhrx/src/libhrx/vmm_slab_provider.c
+++ b/libhrx/src/libhrx/vmm_slab_provider.c
@@ -3,6 +3,8 @@
 
 #include "vmm_slab_provider.h"
 
+#include <stdio.h>
+
 #include "iree/hal/buffer.h"
 
 typedef struct hrx_vmm_slab_provider_t {
@@ -37,6 +39,9 @@ typedef struct hrx_vmm_slab_t {
 
   // Mapped byte length, rounded up to the VMM page granularity.
   iree_device_size_t allocation_size;
+
+  // True after the physical allocation has been mapped into the reservation.
+  bool is_mapped;
 } hrx_vmm_slab_t;
 
 static const iree_hal_slab_provider_vtable_t hrx_vmm_slab_provider_vtable;
@@ -51,12 +56,6 @@ static const hrx_vmm_slab_provider_t* hrx_vmm_slab_provider_const_cast(
   return (const hrx_vmm_slab_provider_t*)base_provider;
 }
 
-static void hrx_vmm_slab_provider_abort_on_error(iree_status_t status) {
-  if (!iree_status_is_ok(status)) {
-    iree_status_abort(status);
-  }
-}
-
 static void hrx_vmm_slab_provider_destroy(
     iree_hal_slab_provider_t* base_provider) {
   hrx_vmm_slab_provider_t* provider = hrx_vmm_slab_provider_cast(base_provider);
@@ -64,24 +63,44 @@ static void hrx_vmm_slab_provider_destroy(
   iree_allocator_free(provider->host_allocator, provider);
 }
 
-static void hrx_vmm_slab_provider_release_slab_state(
+static iree_status_t hrx_vmm_slab_provider_release_slab_state(
     hrx_vmm_slab_provider_t* provider, hrx_vmm_slab_t* slab) {
-  if (!slab) return;
-  if (slab->physical_memory) {
-    hrx_vmm_slab_provider_abort_on_error(
-        iree_hal_allocator_virtual_memory_unmap(
-            provider->allocator, slab->virtual_buffer, /*virtual_offset=*/0,
-            slab->allocation_size));
-    hrx_vmm_slab_provider_abort_on_error(
-        iree_hal_allocator_physical_memory_free(provider->allocator,
-                                                slab->physical_memory));
+  if (!slab) return iree_ok_status();
+
+  iree_status_t status = iree_ok_status();
+  if (slab->is_mapped) {
+    iree_status_t unmap_status = iree_hal_allocator_virtual_memory_unmap(
+        provider->allocator, slab->virtual_buffer, /*virtual_offset=*/0,
+        slab->allocation_size);
+    if (iree_status_is_ok(unmap_status)) {
+      slab->is_mapped = false;
+    } else {
+      status = iree_status_join(status, unmap_status);
+    }
   }
-  if (slab->virtual_buffer) {
-    hrx_vmm_slab_provider_abort_on_error(
-        iree_hal_allocator_virtual_memory_release(provider->allocator,
-                                                  slab->virtual_buffer));
+
+  // Mapped resources must stay alive when unmapping fails. Once unmapped, the
+  // physical allocation and virtual reservation have independent lifetimes.
+  if (!slab->is_mapped && slab->physical_memory) {
+    iree_status_t free_status = iree_hal_allocator_physical_memory_free(
+        provider->allocator, slab->physical_memory);
+    if (iree_status_is_ok(free_status)) {
+      slab->physical_memory = NULL;
+    } else {
+      status = iree_status_join(status, free_status);
+    }
+  }
+  if (!slab->is_mapped && slab->virtual_buffer) {
+    iree_status_t release_status = iree_hal_allocator_virtual_memory_release(
+        provider->allocator, slab->virtual_buffer);
+    if (iree_status_is_ok(release_status)) {
+      slab->virtual_buffer = NULL;
+    } else {
+      status = iree_status_join(status, release_status);
+    }
   }
   iree_allocator_free(provider->host_allocator, slab);
+  return status;
 }
 
 static iree_status_t hrx_vmm_slab_provider_acquire_slab(
@@ -122,6 +141,7 @@ static iree_status_t hrx_vmm_slab_provider_acquire_slab(
     status = iree_hal_allocator_virtual_memory_map(
         provider->allocator, slab->virtual_buffer, /*virtual_offset=*/0,
         slab->physical_memory, /*physical_offset=*/0, allocation_size);
+    slab->is_mapped = iree_status_is_ok(status);
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_allocator_virtual_memory_protect(
@@ -145,21 +165,8 @@ static iree_status_t hrx_vmm_slab_provider_acquire_slab(
   }
 
   if (!iree_status_is_ok(status)) {
-    if (slab->physical_memory && slab->virtual_buffer) {
-      iree_status_ignore(iree_hal_allocator_virtual_memory_unmap(
-          provider->allocator, slab->virtual_buffer, /*virtual_offset=*/0,
-          allocation_size));
-    }
-    if (slab->physical_memory) {
-      iree_status_ignore(iree_hal_allocator_physical_memory_free(
-          provider->allocator, slab->physical_memory));
-    }
-    if (slab->virtual_buffer) {
-      iree_status_ignore(iree_hal_allocator_virtual_memory_release(
-          provider->allocator, slab->virtual_buffer));
-    }
-    iree_allocator_free(provider->host_allocator, slab);
-    return status;
+    return iree_status_join(
+        status, hrx_vmm_slab_provider_release_slab_state(provider, slab));
   }
 
   out_slab->base_ptr =
@@ -175,10 +182,15 @@ static void hrx_vmm_slab_provider_release_slab(
     iree_hal_slab_provider_t* base_provider, const iree_hal_slab_t* slab) {
   if (!slab || !slab->provider_handle) return;
   hrx_vmm_slab_provider_t* provider = hrx_vmm_slab_provider_cast(base_provider);
-  hrx_vmm_slab_provider_release_slab_state(
+  iree_status_t status = hrx_vmm_slab_provider_release_slab_state(
       provider, (hrx_vmm_slab_t*)(uintptr_t)slab->provider_handle);
-  iree_atomic_fetch_add(&provider->total_released, 1,
-                        iree_memory_order_relaxed);
+  if (iree_status_is_ok(status)) {
+    iree_atomic_fetch_add(&provider->total_released, 1,
+                          iree_memory_order_relaxed);
+  } else {
+    iree_status_fprint(stderr, status);
+    iree_status_free(status);
+  }
 }
 
 static iree_status_t hrx_vmm_slab_provider_wrap_buffer(

--- a/libhrx/src/libhrx/vmm_slab_provider.c
+++ b/libhrx/src/libhrx/vmm_slab_provider.c
@@ -1,0 +1,347 @@
+// Copyright 2026 The HRX Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "vmm_slab_provider.h"
+
+#include "iree/hal/buffer.h"
+
+typedef struct hrx_vmm_slab_provider_t {
+  // Base provider header for vtable dispatch and reference counting.
+  iree_hal_slab_provider_t base;
+
+  // Allocator retained for virtual and physical memory operations.
+  iree_hal_allocator_t* allocator;
+
+  // Allocator used for provider and slab-state bookkeeping.
+  iree_allocator_t host_allocator;
+
+  // Parameters used to allocate physical backing for every slab.
+  iree_hal_buffer_params_t buffer_params;
+
+  // Granularity required for virtual reservations and physical allocations.
+  iree_device_size_t page_size;
+
+  // Cumulative number of slabs acquired through the VMM allocator interface.
+  iree_atomic_int64_t total_acquired;
+
+  // Cumulative number of slabs released through the VMM allocator interface.
+  iree_atomic_int64_t total_released;
+} hrx_vmm_slab_provider_t;
+
+typedef struct hrx_vmm_slab_t {
+  // Virtual address reservation retained until the slab is released.
+  iree_hal_buffer_t* virtual_buffer;
+
+  // Physical allocation mapped through |virtual_buffer|.
+  iree_hal_physical_memory_t* physical_memory;
+
+  // Mapped byte length, rounded up to the VMM page granularity.
+  iree_device_size_t allocation_size;
+} hrx_vmm_slab_t;
+
+static const iree_hal_slab_provider_vtable_t hrx_vmm_slab_provider_vtable;
+
+static hrx_vmm_slab_provider_t* hrx_vmm_slab_provider_cast(
+    iree_hal_slab_provider_t* base_provider) {
+  return (hrx_vmm_slab_provider_t*)base_provider;
+}
+
+static const hrx_vmm_slab_provider_t* hrx_vmm_slab_provider_const_cast(
+    const iree_hal_slab_provider_t* base_provider) {
+  return (const hrx_vmm_slab_provider_t*)base_provider;
+}
+
+static void hrx_vmm_slab_provider_abort_on_error(iree_status_t status) {
+  if (!iree_status_is_ok(status)) {
+    iree_status_abort(status);
+  }
+}
+
+static void hrx_vmm_slab_provider_destroy(
+    iree_hal_slab_provider_t* base_provider) {
+  hrx_vmm_slab_provider_t* provider = hrx_vmm_slab_provider_cast(base_provider);
+  iree_hal_allocator_release(provider->allocator);
+  iree_allocator_free(provider->host_allocator, provider);
+}
+
+static void hrx_vmm_slab_provider_release_slab_state(
+    hrx_vmm_slab_provider_t* provider, hrx_vmm_slab_t* slab) {
+  if (!slab) return;
+  if (slab->physical_memory) {
+    hrx_vmm_slab_provider_abort_on_error(
+        iree_hal_allocator_virtual_memory_unmap(
+            provider->allocator, slab->virtual_buffer, /*virtual_offset=*/0,
+            slab->allocation_size));
+    hrx_vmm_slab_provider_abort_on_error(
+        iree_hal_allocator_physical_memory_free(provider->allocator,
+                                                slab->physical_memory));
+  }
+  if (slab->virtual_buffer) {
+    hrx_vmm_slab_provider_abort_on_error(
+        iree_hal_allocator_virtual_memory_release(provider->allocator,
+                                                  slab->virtual_buffer));
+  }
+  iree_allocator_free(provider->host_allocator, slab);
+}
+
+static iree_status_t hrx_vmm_slab_provider_acquire_slab(
+    iree_hal_slab_provider_t* base_provider, iree_device_size_t min_length,
+    iree_hal_slab_t* out_slab) {
+  IREE_ASSERT_ARGUMENT(out_slab);
+  *out_slab = (iree_hal_slab_t){0};
+  if (IREE_UNLIKELY(min_length == 0)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "VMM slab allocations must be non-empty");
+  }
+
+  hrx_vmm_slab_provider_t* provider = hrx_vmm_slab_provider_cast(base_provider);
+  iree_device_size_t allocation_size = 0;
+  if (IREE_UNLIKELY(!iree_device_size_checked_align(
+          min_length, provider->page_size, &allocation_size))) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "VMM slab allocation size overflows page alignment");
+  }
+
+  hrx_vmm_slab_t* slab = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(provider->host_allocator,
+                                             sizeof(*slab), (void**)&slab));
+  *slab = (hrx_vmm_slab_t){
+      .allocation_size = allocation_size,
+  };
+
+  iree_status_t status = iree_hal_allocator_virtual_memory_reserve(
+      provider->allocator, provider->buffer_params.queue_affinity,
+      allocation_size, &slab->virtual_buffer);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_allocator_physical_memory_allocate(
+        provider->allocator, provider->buffer_params, allocation_size,
+        provider->host_allocator, &slab->physical_memory);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_allocator_virtual_memory_map(
+        provider->allocator, slab->virtual_buffer, /*virtual_offset=*/0,
+        slab->physical_memory, /*physical_offset=*/0, allocation_size);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_allocator_virtual_memory_protect(
+        provider->allocator, slab->virtual_buffer, /*virtual_offset=*/0,
+        allocation_size, provider->buffer_params.queue_affinity,
+        IREE_HAL_MEMORY_PROTECTION_READ_WRITE);
+  }
+
+  iree_hal_external_buffer_t external_buffer;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_allocator_export_buffer(
+        provider->allocator, slab->virtual_buffer,
+        IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION,
+        IREE_HAL_EXTERNAL_BUFFER_FLAG_NONE, &external_buffer);
+  }
+  if (iree_status_is_ok(status) &&
+      !external_buffer.handle.device_allocation.ptr) {
+    status = iree_make_status(
+        IREE_STATUS_UNAVAILABLE,
+        "VMM allocator returned a reservation without a device address");
+  }
+
+  if (!iree_status_is_ok(status)) {
+    if (slab->physical_memory && slab->virtual_buffer) {
+      iree_status_ignore(iree_hal_allocator_virtual_memory_unmap(
+          provider->allocator, slab->virtual_buffer, /*virtual_offset=*/0,
+          allocation_size));
+    }
+    if (slab->physical_memory) {
+      iree_status_ignore(iree_hal_allocator_physical_memory_free(
+          provider->allocator, slab->physical_memory));
+    }
+    if (slab->virtual_buffer) {
+      iree_status_ignore(iree_hal_allocator_virtual_memory_release(
+          provider->allocator, slab->virtual_buffer));
+    }
+    iree_allocator_free(provider->host_allocator, slab);
+    return status;
+  }
+
+  out_slab->base_ptr =
+      (uint8_t*)(uintptr_t)external_buffer.handle.device_allocation.ptr;
+  out_slab->length = min_length;
+  out_slab->provider_handle = (uint64_t)(uintptr_t)slab;
+  iree_atomic_fetch_add(&provider->total_acquired, 1,
+                        iree_memory_order_relaxed);
+  return iree_ok_status();
+}
+
+static void hrx_vmm_slab_provider_release_slab(
+    iree_hal_slab_provider_t* base_provider, const iree_hal_slab_t* slab) {
+  if (!slab || !slab->provider_handle) return;
+  hrx_vmm_slab_provider_t* provider = hrx_vmm_slab_provider_cast(base_provider);
+  hrx_vmm_slab_provider_release_slab_state(
+      provider, (hrx_vmm_slab_t*)(uintptr_t)slab->provider_handle);
+  iree_atomic_fetch_add(&provider->total_released, 1,
+                        iree_memory_order_relaxed);
+}
+
+static iree_status_t hrx_vmm_slab_provider_wrap_buffer(
+    iree_hal_slab_provider_t* base_provider, const iree_hal_slab_t* slab,
+    iree_device_size_t slab_offset, iree_device_size_t allocation_size,
+    iree_hal_buffer_params_t params,
+    iree_hal_buffer_release_callback_t release_callback,
+    iree_hal_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(slab);
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  *out_buffer = NULL;
+  hrx_vmm_slab_provider_t* provider = hrx_vmm_slab_provider_cast(base_provider);
+  hrx_vmm_slab_t* virtual_slab =
+      (hrx_vmm_slab_t*)(uintptr_t)slab->provider_handle;
+  if (!virtual_slab || !virtual_slab->virtual_buffer) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "VMM slab has no virtual reservation");
+  }
+
+  const iree_hal_memory_type_t required_type =
+      params.type & ~IREE_HAL_MEMORY_TYPE_OPTIMAL;
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_memory_type(
+      iree_hal_buffer_memory_type(virtual_slab->virtual_buffer),
+      required_type));
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_access(
+      iree_hal_buffer_allowed_access(virtual_slab->virtual_buffer),
+      params.access));
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_usage(
+      iree_hal_buffer_allowed_usage(virtual_slab->virtual_buffer),
+      params.usage));
+
+  // The callback returns this range to the pool. Tie it to the final subspan
+  // reference so TLSF cannot reuse the range while a caller still owns it.
+  return iree_hal_subspan_buffer_create_with_callback(
+      virtual_slab->virtual_buffer, slab_offset, allocation_size,
+      release_callback, provider->host_allocator, out_buffer);
+}
+
+static iree_status_t hrx_vmm_slab_provider_validate_asan_options(
+    const iree_hal_slab_provider_t* base_provider,
+    const iree_hal_asan_pool_options_t* options) {
+  (void)base_provider;
+  (void)options;
+  return iree_make_status(
+      IREE_STATUS_FAILED_PRECONDITION,
+      "VMM slab provider does not support HAL ASAN range advice");
+}
+
+static void hrx_vmm_slab_provider_advise_asan_range(
+    iree_hal_slab_provider_t* base_provider, const iree_hal_slab_t* slab,
+    iree_device_size_t backing_offset,
+    iree_hal_asan_range_advice_flags_t advice_flags,
+    const iree_hal_asan_allocation_layout_t* layout) {
+  (void)base_provider;
+  (void)slab;
+  (void)backing_offset;
+  (void)advice_flags;
+  (void)layout;
+  IREE_ASSERT(false, "VMM slab provider cannot advise ASAN ranges");
+}
+
+static void hrx_vmm_slab_provider_prefault(
+    iree_hal_slab_provider_t* base_provider, iree_hal_slab_t* slab) {
+  (void)base_provider;
+  (void)slab;
+}
+
+static void hrx_vmm_slab_provider_trim(
+    iree_hal_slab_provider_t* base_provider,
+    iree_hal_slab_provider_trim_flags_t flags) {
+  (void)base_provider;
+  (void)flags;
+}
+
+static void hrx_vmm_slab_provider_query_stats(
+    const iree_hal_slab_provider_t* base_provider,
+    iree_hal_slab_provider_visited_set_t* visited,
+    iree_hal_slab_provider_stats_t* out_stats) {
+  const hrx_vmm_slab_provider_t* provider =
+      hrx_vmm_slab_provider_const_cast(base_provider);
+  if (iree_hal_slab_provider_visited(visited, base_provider)) return;
+  out_stats->total_acquired += (uint64_t)iree_atomic_load(
+      (iree_atomic_int64_t*)&provider->total_acquired,
+      iree_memory_order_relaxed);
+  out_stats->total_released += (uint64_t)iree_atomic_load(
+      (iree_atomic_int64_t*)&provider->total_released,
+      iree_memory_order_relaxed);
+}
+
+static void hrx_vmm_slab_provider_query_properties(
+    const iree_hal_slab_provider_t* base_provider,
+    iree_hal_memory_type_t* out_memory_type,
+    iree_hal_buffer_usage_t* out_supported_usage) {
+  const hrx_vmm_slab_provider_t* provider =
+      hrx_vmm_slab_provider_const_cast(base_provider);
+  *out_memory_type = provider->buffer_params.type;
+  *out_supported_usage = provider->buffer_params.usage;
+}
+
+iree_status_t hrx_vmm_slab_provider_create(
+    iree_hal_allocator_t* allocator,
+    iree_hal_buffer_params_t physical_buffer_params,
+    iree_allocator_t host_allocator, iree_hal_slab_provider_t** out_provider) {
+  IREE_ASSERT_ARGUMENT(allocator);
+  IREE_ASSERT_ARGUMENT(out_provider);
+  *out_provider = NULL;
+  if (!iree_hal_allocator_supports_virtual_memory(allocator)) {
+    return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                            "allocator does not support virtual memory");
+  }
+
+  iree_hal_buffer_params_canonicalize(&physical_buffer_params);
+  const iree_hal_memory_type_t required_type =
+      physical_buffer_params.type & ~IREE_HAL_MEMORY_TYPE_OPTIMAL;
+  if (!iree_all_bits_set(required_type, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL) ||
+      iree_any_bit_set(required_type, IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                                          IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                                          IREE_HAL_MEMORY_TYPE_HOST_COHERENT |
+                                          IREE_HAL_MEMORY_TYPE_HOST_CACHED)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "VMM slab provider requires device-local memory without host access");
+  }
+
+  iree_device_size_t minimum_page_size = 0;
+  iree_device_size_t recommended_page_size = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_virtual_memory_query_granularity(
+      allocator, physical_buffer_params, &minimum_page_size,
+      &recommended_page_size));
+  const iree_device_size_t page_size =
+      recommended_page_size ? recommended_page_size : minimum_page_size;
+  if (IREE_UNLIKELY(!iree_device_size_is_valid_alignment(page_size))) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "allocator returned an invalid VMM page size");
+  }
+
+  hrx_vmm_slab_provider_t* provider = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(host_allocator, sizeof(*provider),
+                                             (void**)&provider));
+  *provider = (hrx_vmm_slab_provider_t){
+      .allocator = allocator,
+      .host_allocator = host_allocator,
+      .buffer_params = physical_buffer_params,
+      .page_size = page_size,
+      .total_acquired = IREE_ATOMIC_VAR_INIT(0),
+      .total_released = IREE_ATOMIC_VAR_INIT(0),
+  };
+  iree_hal_slab_provider_initialize(&hrx_vmm_slab_provider_vtable,
+                                    &provider->base);
+  iree_hal_allocator_retain(provider->allocator);
+  *out_provider = &provider->base;
+  return iree_ok_status();
+}
+
+static const iree_hal_slab_provider_vtable_t hrx_vmm_slab_provider_vtable = {
+    .destroy = hrx_vmm_slab_provider_destroy,
+    .acquire_slab = hrx_vmm_slab_provider_acquire_slab,
+    .release_slab = hrx_vmm_slab_provider_release_slab,
+    .wrap_buffer = hrx_vmm_slab_provider_wrap_buffer,
+    .validate_asan_options = hrx_vmm_slab_provider_validate_asan_options,
+    .advise_asan_range = hrx_vmm_slab_provider_advise_asan_range,
+    .prefault = hrx_vmm_slab_provider_prefault,
+    .trim = hrx_vmm_slab_provider_trim,
+    .query_stats = hrx_vmm_slab_provider_query_stats,
+    .query_properties = hrx_vmm_slab_provider_query_properties,
+};

--- a/libhrx/src/libhrx/vmm_slab_provider.h
+++ b/libhrx/src/libhrx/vmm_slab_provider.h
@@ -1,0 +1,30 @@
+// Copyright 2026 The HRX Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef HRX_LIBHRX_VMM_SLAB_PROVIDER_H_
+#define HRX_LIBHRX_VMM_SLAB_PROVIDER_H_
+
+#include "iree/hal/allocator.h"
+#include "iree/hal/memory/slab_provider.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Creates a slab provider that backs each slab with one virtual reservation and
+// one mapped physical allocation. Materialized buffers are subspans of that
+// reservation, so every pool allocation has a stable device-visible address.
+//
+// |physical_buffer_params| must require device-local memory and may not request
+// host access. The provider retains |allocator| and releases it at destruction.
+// Virtual memory must be supported by |allocator|.
+iree_status_t hrx_vmm_slab_provider_create(
+    iree_hal_allocator_t* allocator,
+    iree_hal_buffer_params_t physical_buffer_params,
+    iree_allocator_t host_allocator, iree_hal_slab_provider_t** out_provider);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // HRX_LIBHRX_VMM_SLAB_PROVIDER_H_

--- a/runtime/src/iree/base/internal/dynamic_library.h
+++ b/runtime/src/iree/base/internal/dynamic_library.h
@@ -18,7 +18,8 @@ extern "C" {
 // Defines the behavior of the dynamic library loader.
 enum iree_dynamic_library_flag_bits_t {
   IREE_DYNAMIC_LIBRARY_FLAG_NONE = 0u,
-  IREE_DYNAMIC_LIBRARY_FLAG_NODELETE = 1
+  // Keeps the loaded module mapped for the lifetime of the process.
+  IREE_DYNAMIC_LIBRARY_FLAG_NODELETE = 1u << 0,
 };
 typedef uint32_t iree_dynamic_library_flags_t;
 

--- a/runtime/src/iree/base/internal/dynamic_library_posix.c
+++ b/runtime/src/iree/base/internal/dynamic_library_posix.c
@@ -30,6 +30,9 @@ struct iree_dynamic_library_t {
   iree_atomic_ref_count_t ref_count;
   iree_allocator_t allocator;
 
+  // Flags controlling module lifetime.
+  iree_dynamic_library_flags_t flags;
+
   // dlopen shared object handle.
   void* handle;
 };
@@ -119,8 +122,8 @@ static iree_status_t iree_dynamic_library_write_temp_file(
 
 // Allocates an iree_dynamic_library_t with the given allocator.
 static iree_status_t iree_dynamic_library_create(
-    void* handle, iree_allocator_t allocator,
-    iree_dynamic_library_t** out_library) {
+    void* handle, iree_dynamic_library_flags_t flags,
+    iree_allocator_t allocator, iree_dynamic_library_t** out_library) {
   *out_library = NULL;
 
   iree_dynamic_library_t* library = NULL;
@@ -129,6 +132,7 @@ static iree_status_t iree_dynamic_library_create(
   memset(library, 0, sizeof(*library));
   iree_atomic_ref_count_init(&library->ref_count);
   library->allocator = allocator;
+  library->flags = flags;
   library->handle = handle;
 
   *out_library = library;
@@ -167,7 +171,7 @@ iree_status_t iree_dynamic_library_load_from_files(
 
   iree_dynamic_library_t* library = NULL;
   iree_status_t status =
-      iree_dynamic_library_create(handle, allocator, &library);
+      iree_dynamic_library_create(handle, flags, allocator, &library);
 
   if (iree_status_is_ok(status)) {
     *out_library = library;
@@ -287,7 +291,8 @@ static void iree_dynamic_library_delete(iree_dynamic_library_t* library) {
 #else
   // Close the library first as it may be loaded from one of the temp files we
   // are about to delete.
-  if (library->handle != NULL) {
+  if (library->handle != NULL &&
+      !iree_any_bit_set(library->flags, IREE_DYNAMIC_LIBRARY_FLAG_NODELETE)) {
     dlclose(library->handle);
   }
 #endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION

--- a/runtime/src/iree/base/internal/dynamic_library_win32.c
+++ b/runtime/src/iree/base/internal/dynamic_library_win32.c
@@ -30,6 +30,9 @@ struct iree_dynamic_library_t {
   iree_atomic_ref_count_t ref_count;
   iree_allocator_t allocator;
 
+  // Flags controlling module lifetime.
+  iree_dynamic_library_flags_t flags;
+
   // Base module name used as an identifier. When loaded from a file this must
   // be the basename for dbghelp to be able to find symbols.
   // Owned and allocated as part of the struct upon creation.
@@ -163,8 +166,8 @@ static iree_status_t iree_dynamic_library_write_temp_file(
 // Allocates an iree_dynamic_library_t with the given allocator.
 static iree_status_t iree_dynamic_library_create(
     iree_string_view_t identifier, iree_string_view_t module_path,
-    HMODULE module, iree_allocator_t allocator,
-    iree_dynamic_library_t** out_library) {
+    HMODULE module, iree_dynamic_library_flags_t flags,
+    iree_allocator_t allocator, iree_dynamic_library_t** out_library) {
   *out_library = NULL;
 
   iree_host_size_t identifier_storage_size = 0;
@@ -189,6 +192,7 @@ static iree_status_t iree_dynamic_library_create(
   memset(library, 0, total_size);
   iree_atomic_ref_count_init(&library->ref_count);
   library->allocator = allocator;
+  library->flags = flags;
   library->module = module;
 
   library->identifier = (char*)library + identifier_offset;
@@ -236,7 +240,7 @@ iree_status_t iree_dynamic_library_load_from_files(
 
   iree_dynamic_library_t* library = NULL;
   iree_status_t status = iree_dynamic_library_create(
-      identifier, file_path, module, allocator, &library);
+      identifier, file_path, module, flags, allocator, &library);
 
   if (iree_status_is_ok(status)) {
     *out_library = library;
@@ -293,7 +297,8 @@ static void iree_dynamic_library_delete(iree_dynamic_library_t* library) {
 #else
   // Close the library first as it may be loaded from one of the temp files we
   // are about to delete.
-  if (library->module != NULL) {
+  if (library->module != NULL &&
+      !iree_any_bit_set(library->flags, IREE_DYNAMIC_LIBRARY_FLAG_NODELETE)) {
     FreeLibrary(library->module);
   }
 #endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION

--- a/runtime/src/iree/base/testing/dynamic_library_test.cc
+++ b/runtime/src/iree/base/testing/dynamic_library_test.cc
@@ -86,6 +86,28 @@ TEST_F(DynamicLibraryTest, LoadLibraryTwice) {
   iree_dynamic_library_release(library2);
 }
 
+TEST_F(DynamicLibraryTest, NodeletePreservesModuleState) {
+  int (*next_value)() = nullptr;
+  iree_dynamic_library_t* library = NULL;
+  IREE_ASSERT_OK(iree_dynamic_library_load_from_file(
+      library_temp_path_.path().c_str(), IREE_DYNAMIC_LIBRARY_FLAG_NODELETE,
+      iree_allocator_system(), &library));
+  IREE_ASSERT_OK(iree_dynamic_library_lookup_symbol(
+      library, "next_value", reinterpret_cast<void**>(&next_value)));
+  EXPECT_EQ(1, next_value());
+  iree_dynamic_library_release(library);
+
+  library = NULL;
+  next_value = nullptr;
+  IREE_ASSERT_OK(iree_dynamic_library_load_from_file(
+      library_temp_path_.path().c_str(), IREE_DYNAMIC_LIBRARY_FLAG_NODELETE,
+      iree_allocator_system(), &library));
+  IREE_ASSERT_OK(iree_dynamic_library_lookup_symbol(
+      library, "next_value", reinterpret_cast<void**>(&next_value)));
+  EXPECT_EQ(2, next_value());
+  iree_dynamic_library_release(library);
+}
+
 TEST_F(DynamicLibraryTest, GetSymbolSuccess) {
   iree_dynamic_library_t* library = NULL;
   IREE_ASSERT_OK(iree_dynamic_library_load_from_file(

--- a/runtime/src/iree/base/testing/dynamic_library_test_library.cc
+++ b/runtime/src/iree/base/testing/dynamic_library_test_library.cc
@@ -16,6 +16,11 @@ extern "C" {
 
 int IREE_SYM_EXPORT times_two(int value) { return value * 2; }
 
+int IREE_SYM_EXPORT next_value() {
+  static int value = 0;
+  return ++value;
+}
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/runtime/src/iree/hal/allocator_heap.c
+++ b/runtime/src/iree/hal/allocator_heap.c
@@ -136,6 +136,10 @@ iree_hal_heap_allocator_query_buffer_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     iree_hal_buffer_params_t* IREE_RESTRICT params,
     iree_device_size_t* IREE_RESTRICT allocation_size) {
+  if (iree_any_bit_set(params->type, IREE_HAL_MEMORY_TYPE_DEVICE_UNCACHED)) {
+    return IREE_HAL_BUFFER_COMPATIBILITY_NONE;
+  }
+
   // All buffers can be allocated on the heap and all heap-accessible buffers
   // can be imported/exported.
   iree_hal_buffer_compatibility_t compatibility =

--- a/runtime/src/iree/hal/buffer.c
+++ b/runtime/src/iree/hal/buffer.c
@@ -30,6 +30,7 @@ static const iree_bitfield_string_mapping_t iree_hal_memory_type_mappings[] = {
     {IREE_HAL_MEMORY_TYPE_HOST_COHERENT, IREE_SVL("HOST_COHERENT")},
     {IREE_HAL_MEMORY_TYPE_HOST_CACHED, IREE_SVL("HOST_CACHED")},
     {IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE, IREE_SVL("DEVICE_VISIBLE")},
+    {IREE_HAL_MEMORY_TYPE_DEVICE_UNCACHED, IREE_SVL("DEVICE_UNCACHED")},
 };
 
 IREE_API_EXPORT iree_status_t iree_hal_memory_type_parse(
@@ -123,8 +124,14 @@ IREE_API_EXPORT iree_string_view_t iree_hal_buffer_usage_format(
 //===----------------------------------------------------------------------===//
 
 typedef struct iree_hal_subspan_buffer_t {
+  // Base HAL buffer resource exposed through this subspan.
   iree_hal_buffer_t base;
+
+  // Allocator used for the subspan wrapper itself.
   iree_allocator_t host_allocator;
+
+  // Invoked after |base.allocated_buffer| is released during destruction.
+  iree_hal_buffer_release_callback_t release_callback;
 } iree_hal_subspan_buffer_t;
 
 static const iree_hal_buffer_vtable_t iree_hal_subspan_buffer_vtable;
@@ -133,6 +140,16 @@ IREE_API_EXPORT iree_status_t iree_hal_subspan_buffer_create(
     iree_hal_buffer_t* allocated_buffer, iree_device_size_t byte_offset,
     iree_device_size_t byte_length, iree_allocator_t host_allocator,
     iree_hal_buffer_t** out_buffer) {
+  return iree_hal_subspan_buffer_create_with_callback(
+      allocated_buffer, byte_offset, byte_length,
+      iree_hal_buffer_release_callback_null(), host_allocator, out_buffer);
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_subspan_buffer_create_with_callback(
+    iree_hal_buffer_t* allocated_buffer, iree_device_size_t byte_offset,
+    iree_device_size_t byte_length,
+    iree_hal_buffer_release_callback_t release_callback,
+    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer) {
   IREE_ASSERT_ARGUMENT(allocated_buffer);
   IREE_ASSERT_ARGUMENT(out_buffer);
   *out_buffer = NULL;
@@ -149,6 +166,7 @@ IREE_API_EXPORT iree_status_t iree_hal_subspan_buffer_create(
         allocated_buffer->allowed_usage, &iree_hal_subspan_buffer_vtable,
         &buffer->base);
     buffer->host_allocator = host_allocator;
+    buffer->release_callback = release_callback;
     *out_buffer = &buffer->base;
   }
 
@@ -162,6 +180,10 @@ static void iree_hal_subspan_buffer_destroy(iree_hal_buffer_t* base_buffer) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_hal_buffer_release(base_buffer->allocated_buffer);
+  if (buffer->release_callback.fn) {
+    buffer->release_callback.fn(buffer->release_callback.user_data,
+                                base_buffer);
+  }
   iree_allocator_free(host_allocator, buffer);
 
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/hal/buffer.h
+++ b/runtime/src/iree/hal/buffer.h
@@ -95,6 +95,11 @@ enum iree_hal_memory_type_bits_t {
   IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL =
       IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE | (1u << 5),
 
+  // Memory accesses issued by the device bypass its normal cache hierarchy.
+  // This is an allocation requirement: drivers must reject the request when
+  // they cannot provide an uncached device-memory mapping.
+  IREE_HAL_MEMORY_TYPE_DEVICE_UNCACHED = 1u << 7,
+
   // The allocator will choose the optimal memory type based on buffer usage,
   // preferring to place the allocation in device-local memory.
   //
@@ -1082,12 +1087,23 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_mapping_subspan(
 //===----------------------------------------------------------------------===//
 
 // Creates a buffer referencing a subspan of some base allocation.
-// Optionally |device_allocator| can be provided if this subspan references
-// managed buffers that need deallocation callbacks.
 IREE_API_EXPORT iree_status_t iree_hal_subspan_buffer_create(
     iree_hal_buffer_t* allocated_buffer, iree_device_size_t byte_offset,
     iree_device_size_t byte_length, iree_allocator_t host_allocator,
     iree_hal_buffer_t** out_buffer);
+
+// Creates a buffer referencing a subspan of some base allocation and invokes
+// |release_callback| after the subspan releases its retained base buffer.
+//
+// This is used by allocators that need pool bookkeeping to observe the final
+// lifetime of a materialized view. The callback is intentionally sequenced
+// after the base release so it may release a pool slab without invalidating the
+// subspan while its final reference is being destroyed.
+IREE_API_EXPORT iree_status_t iree_hal_subspan_buffer_create_with_callback(
+    iree_hal_buffer_t* allocated_buffer, iree_device_size_t byte_offset,
+    iree_device_size_t byte_length,
+    iree_hal_buffer_release_callback_t release_callback,
+    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_heap_buffer_t

--- a/runtime/src/iree/hal/cts/queue/queue_host_call_test.cc
+++ b/runtime/src/iree/hal/cts/queue/queue_host_call_test.cc
@@ -18,6 +18,48 @@ using iree::testing::status::StatusIs;
 
 class QueueHostCallTest : public CtsTestBase<> {};
 
+class AsyncQueueHostCallLifetimeTest : public CtsTestBase<> {};
+
+struct HostCallResourceState {
+  // HAL resource retained by asynchronous queue implementations.
+  iree_hal_resource_t resource;
+
+  // External invocation counter that outlives this state.
+  std::atomic<int>* call_count;
+
+  // External notification fulfilled immediately before destruction.
+  std::promise<void>* destroyed;
+};
+
+static void DestroyHostCallResourceState(iree_hal_resource_t* base_resource) {
+  auto* state = reinterpret_cast<HostCallResourceState*>(base_resource);
+  state->destroyed->set_value();
+  delete state;
+}
+
+static const iree_hal_resource_vtable_t kHostCallResourceStateVtable = {
+    /*.destroy=*/DestroyHostCallResourceState,
+};
+
+static HostCallResourceState* CreateHostCallResourceState(
+    std::atomic<int>* call_count, std::promise<void>* destroyed) {
+  auto* state = new HostCallResourceState;
+  iree_hal_resource_initialize(&kHostCallResourceStateVtable, &state->resource);
+  state->call_count = call_count;
+  state->destroyed = destroyed;
+  return state;
+}
+
+static iree_status_t InvokeHostCallResourceState(
+    void* user_data, const uint64_t args[4],
+    iree_hal_host_call_context_t* context) {
+  (void)args;
+  (void)context;
+  auto* state = static_cast<HostCallResourceState*>(user_data);
+  ++*state->call_count;
+  return iree_ok_status();
+}
+
 // Enqueues a host call on a wait condition that is signaled after the queue
 // request starts.
 TEST_P(QueueHostCallTest, EnqueueBeforeSignal) {
@@ -369,6 +411,76 @@ TEST_P(QueueHostCallTest, CallbackReturnsErrorAfterWait) {
               StatusIs(StatusCode::kPermissionDenied));
 }
 
+// Proves that asynchronous queues retain callback state after queue submission
+// returns and until the delayed callback has completed.
+TEST_P(AsyncQueueHostCallLifetimeTest, RetainsStateUntilInvocation) {
+  IREE_TRACE_SCOPE();
+
+  std::atomic<int> call_count{0};
+  std::promise<void> destroyed;
+  std::future<void> destroyed_future = destroyed.get_future();
+  HostCallResourceState* state =
+      CreateHostCallResourceState(&call_count, &destroyed);
+  iree_hal_host_call_t call = iree_hal_make_host_call_with_resource(
+      InvokeHostCallResourceState, state, &state->resource);
+
+  SemaphoreList wait_semaphore_list(device_, {0}, {1});
+  SemaphoreList signal_semaphore_list(device_, {0}, {1});
+  uint64_t args[4] = {0, 0, 0, 0};
+
+  iree_status_t status = iree_hal_device_queue_host_call(
+      device_, IREE_HAL_QUEUE_AFFINITY_ANY, wait_semaphore_list,
+      signal_semaphore_list, call, args, IREE_HAL_HOST_CALL_FLAG_NONE);
+  iree_hal_resource_release(&state->resource);
+  IREE_ASSERT_OK(status);
+
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_list_signal(wait_semaphore_list, /*frontier=*/NULL));
+  IREE_ASSERT_OK(iree_hal_semaphore_list_wait(signal_semaphore_list,
+                                              iree_infinite_timeout(),
+                                              IREE_ASYNC_WAIT_FLAG_NONE));
+  destroyed_future.wait();
+
+  EXPECT_EQ(call_count, 1);
+}
+
+// Proves that a failed prerequisite skips the effect callback while still
+// releasing callback state through the queue's terminal cleanup path.
+TEST_P(AsyncQueueHostCallLifetimeTest, ReleasesStateAfterFailedPrerequisite) {
+  IREE_TRACE_SCOPE();
+
+  std::atomic<int> call_count{0};
+  std::promise<void> destroyed;
+  std::future<void> destroyed_future = destroyed.get_future();
+  HostCallResourceState* state =
+      CreateHostCallResourceState(&call_count, &destroyed);
+  iree_hal_host_call_t call = iree_hal_make_host_call_with_resource(
+      InvokeHostCallResourceState, state, &state->resource);
+
+  SemaphoreList wait_semaphore_list(device_, {0}, {1});
+  SemaphoreList signal_semaphore_list(device_, {0}, {1});
+  uint64_t args[4] = {0, 0, 0, 0};
+
+  iree_status_t status = iree_hal_device_queue_host_call(
+      device_, IREE_HAL_QUEUE_AFFINITY_ANY, wait_semaphore_list,
+      signal_semaphore_list, call, args, IREE_HAL_HOST_CALL_FLAG_NONE);
+  iree_hal_resource_release(&state->resource);
+  IREE_ASSERT_OK(status);
+
+  iree_hal_semaphore_fail(
+      wait_semaphore_list.semaphores[0],
+      iree_make_status(IREE_STATUS_CANCELLED, "host call prerequisite failed"));
+  EXPECT_THAT(Status(iree_hal_semaphore_list_wait(signal_semaphore_list,
+                                                  iree_infinite_timeout(),
+                                                  IREE_ASYNC_WAIT_FLAG_NONE)),
+              StatusIs(StatusCode::kCancelled));
+  destroyed_future.wait();
+
+  EXPECT_EQ(call_count, 0);
+}
+
 CTS_REGISTER_TEST_SUITE(QueueHostCallTest);
+CTS_REGISTER_TEST_SUITE_WITH_TAGS(AsyncQueueHostCallLifetimeTest,
+                                  {"async_queue"}, {});
 
 }  // namespace iree::hal::cts

--- a/runtime/src/iree/hal/device.h
+++ b/runtime/src/iree/hal/device.h
@@ -358,22 +358,24 @@ typedef struct iree_hal_queue_pool_backend_t {
 // Returns a host call bound to the given function pointer and user data.
 static inline iree_hal_host_call_t iree_hal_make_host_call(
     iree_hal_host_call_fn_t fn, void* user_data) {
-  return (iree_hal_host_call_t){
-      .fn = fn,
-      .user_data = user_data,
-      .resource = NULL,
+  iree_hal_host_call_t call = {
+      /*.fn=*/fn,
+      /*.user_data=*/user_data,
+      /*.resource=*/NULL,
   };
+  return call;
 }
 
 // Returns a host call whose callback state is retained by |resource|.
 static inline iree_hal_host_call_t iree_hal_make_host_call_with_resource(
     iree_hal_host_call_fn_t fn, void* user_data,
     iree_hal_resource_t* resource) {
-  return (iree_hal_host_call_t){
-      .fn = fn,
-      .user_data = user_data,
-      .resource = resource,
+  iree_hal_host_call_t call = {
+      /*.fn=*/fn,
+      /*.user_data=*/user_data,
+      /*.resource=*/resource,
   };
+  return call;
 }
 
 // Bitfield specifying flags controlling an execution operation.

--- a/runtime/src/iree/hal/device.h
+++ b/runtime/src/iree/hal/device.h
@@ -308,8 +308,24 @@ typedef iree_status_t(IREE_API_PTR* iree_hal_host_call_fn_t)(
 typedef struct iree_hal_host_call_t {
   // Callback function pointer in the host program.
   iree_hal_host_call_fn_t fn;
+
   // User data passed to the callback function. Unowned.
+  // When |resource| is provided it may retain |user_data| transitively.
   void* user_data;
+
+  // Optional resource retaining callback state.
+  //
+  // The caller must keep its reference live until
+  // iree_hal_device_queue_host_call returns. Implementations retain the
+  // resource when the call may execute after the queue operation returns and
+  // release it after |fn| returns or the queued call is cancelled before
+  // invocation.
+  //
+  // Returning IREE_STATUS_DEFERRED transfers signal semaphore completion to
+  // |fn| but does not extend this retain. A deferred continuation that still
+  // needs the resource must retain it before returning and release it after
+  // completion.
+  iree_hal_resource_t* resource;
 } iree_hal_host_call_t;
 
 // Backend-native ingredients required to create queue-allocation pools for a
@@ -342,8 +358,22 @@ typedef struct iree_hal_queue_pool_backend_t {
 // Returns a host call bound to the given function pointer and user data.
 static inline iree_hal_host_call_t iree_hal_make_host_call(
     iree_hal_host_call_fn_t fn, void* user_data) {
-  iree_hal_host_call_t call = {fn, user_data};
-  return call;
+  return (iree_hal_host_call_t){
+      .fn = fn,
+      .user_data = user_data,
+      .resource = NULL,
+  };
+}
+
+// Returns a host call whose callback state is retained by |resource|.
+static inline iree_hal_host_call_t iree_hal_make_host_call_with_resource(
+    iree_hal_host_call_fn_t fn, void* user_data,
+    iree_hal_resource_t* resource) {
+  return (iree_hal_host_call_t){
+      .fn = fn,
+      .user_data = user_data,
+      .resource = resource,
+  };
 }
 
 // Bitfield specifying flags controlling an execution operation.

--- a/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
@@ -247,6 +247,8 @@ iree_runtime_cc_library(
         "transient_buffer.h",
         "tsan_state.c",
         "tsan_state.h",
+        "virtual_memory.c",
+        "virtual_memory.h",
         "virtual_queue.h",
     ],
     hdrs = [
@@ -364,6 +366,7 @@ iree_runtime_cc_library(
         "system.h",
         "transient_buffer.h",
         "tsan_state.h",
+        "virtual_memory.h",
         "virtual_queue.h",
     ],
     deps = [

--- a/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
@@ -289,6 +289,8 @@ iree_cc_library(
     "transient_buffer.h"
     "tsan_state.c"
     "tsan_state.h"
+    "virtual_memory.c"
+    "virtual_memory.h"
     "virtual_queue.h"
   DEPS
     ::access_policy
@@ -403,6 +405,7 @@ iree_cc_library(
     "system.h"
     "transient_buffer.h"
     "tsan_state.h"
+    "virtual_memory.h"
     "virtual_queue.h"
   DEPS
     ::profile_events

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator.c
@@ -656,6 +656,12 @@ static iree_status_t iree_hal_amdgpu_allocator_resolve_virtual_memory_placement(
         IREE_STATUS_INVALID_ARGUMENT,
         "AMDGPU virtual-memory parameters cannot be placed on this device");
   }
+  if (!iree_all_bits_set(memory_placement.memory_type,
+                         IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU virtual-memory physical backing must be device-local");
+  }
   if (memory_placement.memory_pool->allocation_flags != 0) {
     return iree_make_status(
         IREE_STATUS_UNAVAILABLE,

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator.c
@@ -664,17 +664,18 @@ static iree_status_t iree_hal_amdgpu_allocator_resolve_virtual_memory_placement(
         memory_placement.memory_pool->allocation_flags);
   }
 
-  iree_device_size_t allocation_granule = 0;
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_vmem_query_alloc_granule(
+  iree_hal_amdgpu_vmem_granularity_t granularity;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_vmem_query_alloc_granularity(
       allocator->libhsa, memory_placement.memory_pool->memory_pool,
-      &allocation_granule));
+      &granularity));
   *out_placement = (iree_hal_amdgpu_virtual_memory_placement_t){
       .memory_pool = memory_placement.memory_pool->memory_pool,
       .device = (iree_hal_device_t*)allocator->logical_device,
       .queue_affinity = params->queue_affinity,
       .memory_type = memory_placement.memory_type,
       .buffer_usage = params->usage,
-      .allocation_granule = allocation_granule,
+      .minimum_granule = granularity.minimum,
+      .recommended_granule = granularity.recommended,
       .max_allocation_size = memory_placement.memory_pool->max_allocation_size,
   };
   return iree_ok_status();
@@ -762,8 +763,11 @@ iree_status_t iree_hal_amdgpu_allocator_create(
   }
 
   if (iree_status_is_ok(status)) {
+    iree_hal_allocator_statistics_t* statistics = NULL;
+    IREE_STATISTICS(statistics = &allocator->statistics);
     status = iree_hal_amdgpu_virtual_memory_state_create(
-        libhsa, topology, host_allocator, &allocator->virtual_memory);
+        libhsa, topology, (iree_hal_device_t*)logical_device, statistics,
+        host_allocator, &allocator->virtual_memory);
   }
 
   if (iree_status_is_ok(status)) {
@@ -1929,8 +1933,8 @@ static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_query_granularity(
   IREE_RETURN_IF_ERROR(
       iree_hal_amdgpu_allocator_resolve_virtual_memory_placement(
           allocator, &params, &placement));
-  *out_minimum_page_size = placement.allocation_granule;
-  *out_recommended_page_size = placement.allocation_granule;
+  *out_minimum_page_size = placement.minimum_granule;
+  *out_recommended_page_size = placement.recommended_granule;
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator.c
@@ -656,6 +656,13 @@ static iree_status_t iree_hal_amdgpu_allocator_resolve_virtual_memory_placement(
         IREE_STATUS_INVALID_ARGUMENT,
         "AMDGPU virtual-memory parameters cannot be placed on this device");
   }
+  if (memory_placement.memory_pool->allocation_flags != 0) {
+    return iree_make_status(
+        IREE_STATUS_UNAVAILABLE,
+        "AMDGPU virtual memory cannot represent required HSA allocation flags "
+        "0x%08" PRIx32,
+        memory_placement.memory_pool->allocation_flags);
+  }
 
   iree_device_size_t allocation_granule = 0;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_vmem_query_alloc_granule(

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator.c
@@ -31,6 +31,9 @@ typedef struct iree_hal_amdgpu_allocator_memory_pool_t {
   // HSA memory pool used for allocations.
   hsa_amd_memory_pool_t memory_pool;
 
+  // HSA allocation flags required for buffers from |memory_pool|.
+  uint32_t allocation_flags;
+
   // Allocation sizes submitted to HSA are rounded up to this granule.
   iree_device_size_t allocation_granule;
 
@@ -49,6 +52,10 @@ typedef struct iree_hal_amdgpu_allocator_memory_pools_t {
   // Fine-grained GPU-local pools used only for explicit host-visible requests.
   iree_hal_amdgpu_allocator_memory_pool_t
       device_fine[IREE_HAL_AMDGPU_MAX_GPU_AGENT];
+
+  // GPU-local pools used for allocations that bypass the normal device cache.
+  iree_hal_amdgpu_allocator_memory_pool_t
+      device_uncached[IREE_HAL_AMDGPU_MAX_GPU_AGENT];
 
   // Fine-grained host-local pools nearest to each GPU.
   iree_hal_amdgpu_allocator_memory_pool_t
@@ -508,6 +515,8 @@ static bool iree_hal_amdgpu_allocator_resolve_placement(
           IREE_HAL_MEMORY_TYPE_HOST_CACHED | IREE_HAL_MEMORY_TYPE_HOST_LOCAL);
   const bool requires_device_local =
       iree_all_bits_set(required_type, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL);
+  const bool requires_device_uncached =
+      iree_any_bit_set(required_type, IREE_HAL_MEMORY_TYPE_DEVICE_UNCACHED);
   const bool prefers_device_local =
       iree_any_bit_set(requested_type, IREE_HAL_MEMORY_TYPE_OPTIMAL) &&
       iree_any_bit_set(required_type, IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE);
@@ -533,7 +542,12 @@ static bool iree_hal_amdgpu_allocator_resolve_placement(
   iree_hal_buffer_usage_t supported_usage = IREE_HAL_BUFFER_USAGE_TRANSFER |
                                             IREE_HAL_BUFFER_USAGE_DISPATCH |
                                             sharing_usage;
-  if (requires_host_local) {
+  if (requires_device_uncached) {
+    if (!requires_device_local || requires_host_access) return false;
+    memory_pool = &allocator->memory_pools.device_uncached[device_ordinal];
+    memory_type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+                  IREE_HAL_MEMORY_TYPE_DEVICE_UNCACHED;
+  } else if (requires_host_local) {
     if (requires_device_local) return false;
     memory_pool = &allocator->memory_pools.host_fine[device_ordinal];
     memory_type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
@@ -715,6 +729,29 @@ iree_status_t iree_hal_amdgpu_allocator_create(
           logical_device->system->host_memory_pools[host_ordinal].fine_pool,
           &allocator->memory_pools.host_fine[i]);
     }
+
+    hsa_amd_memory_pool_t device_uncached_pool = {0};
+    bool device_uncached_pool_available = false;
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_amdgpu_query_extended_fine_global_memory_pool(
+          libhsa, topology->gpu_agents[i], &device_uncached_pool_available,
+          &device_uncached_pool);
+    }
+    if (iree_status_is_ok(status) && device_uncached_pool_available) {
+      status = iree_hal_amdgpu_allocator_query_pool_properties(
+          libhsa, device_uncached_pool,
+          &allocator->memory_pools.device_uncached[i]);
+    }
+    if (iree_status_is_ok(status) &&
+        logical_device->physical_devices[i]->isa.target_id.version.major >=
+            12) {
+      if (!device_uncached_pool_available) {
+        allocator->memory_pools.device_uncached[i] =
+            allocator->memory_pools.device_coarse[i];
+      }
+      allocator->memory_pools.device_uncached[i].allocation_flags |=
+          HSA_AMD_MEMORY_POOL_UNCACHED_FLAG;
+    }
   }
 
   if (iree_status_is_ok(status)) {
@@ -814,6 +851,14 @@ static iree_status_t iree_hal_amdgpu_allocator_query_memory_heaps(
           allocator->topology->gpu_agent_count,
           &device_fine_max_allocation_size, &device_fine_min_alignment);
 
+  iree_device_size_t device_uncached_max_allocation_size = 0;
+  iree_device_size_t device_uncached_min_alignment = 0;
+  const bool device_uncached_available =
+      iree_hal_amdgpu_allocator_query_pool_family_limits(
+          allocator->memory_pools.device_uncached,
+          allocator->topology->gpu_agent_count,
+          &device_uncached_max_allocation_size, &device_uncached_min_alignment);
+
   iree_device_size_t host_fine_max_allocation_size = 0;
   iree_device_size_t host_fine_min_alignment = 0;
   const bool host_fine_available =
@@ -835,7 +880,7 @@ static iree_status_t iree_hal_amdgpu_allocator_query_memory_heaps(
       IREE_HAL_BUFFER_USAGE_MAPPING_ACCESS_RANDOM |
       IREE_HAL_BUFFER_USAGE_MAPPING_ACCESS_SEQUENTIAL_WRITE;
 
-  iree_hal_allocator_memory_heap_t available_heaps[3] = {0};
+  iree_hal_allocator_memory_heap_t available_heaps[4] = {0};
   iree_host_size_t heap_count = 0;
   if (device_coarse_available) {
     available_heaps[heap_count++] = (iree_hal_allocator_memory_heap_t){
@@ -854,6 +899,16 @@ static iree_status_t iree_hal_amdgpu_allocator_query_memory_heaps(
         .allowed_usage = mappable_usage,
         .max_allocation_size = device_fine_max_allocation_size,
         .min_alignment = device_fine_min_alignment,
+    };
+  }
+  if (device_uncached_available) {
+    available_heaps[heap_count++] = (iree_hal_allocator_memory_heap_t){
+        .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+                IREE_HAL_MEMORY_TYPE_DEVICE_UNCACHED,
+        .allowed_usage = IREE_HAL_BUFFER_USAGE_TRANSFER |
+                         IREE_HAL_BUFFER_USAGE_DISPATCH | sharing_usage,
+        .max_allocation_size = device_uncached_max_allocation_size,
+        .min_alignment = device_uncached_min_alignment,
     };
   }
   if (host_fine_available) {
@@ -1089,7 +1144,8 @@ static bool iree_hal_amdgpu_allocator_should_use_asan_pool(
          iree_all_bits_set(memory_placement->memory_type,
                            IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL) &&
          !iree_any_bit_set(memory_placement->memory_type,
-                           IREE_HAL_MEMORY_TYPE_HOST_VISIBLE);
+                           IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                               IREE_HAL_MEMORY_TYPE_DEVICE_UNCACHED);
 }
 
 static bool iree_hal_amdgpu_allocator_should_publish_asan_allocation(
@@ -1271,7 +1327,7 @@ static iree_status_t iree_hal_amdgpu_allocator_allocate_buffer(
           allocation_size, memory_placement.memory_pool->allocation_granule,
           &allocation_size)) {
     IREE_TRACE_ZONE_END(z0);
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                             "allocation size %" PRIdsz
                             " overflows HSA memory pool allocation granule",
                             allocation_size);
@@ -1280,7 +1336,7 @@ static iree_status_t iree_hal_amdgpu_allocator_allocate_buffer(
                     memory_placement.memory_pool->max_allocation_size)) {
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(
-        IREE_STATUS_OUT_OF_RANGE,
+        IREE_STATUS_RESOURCE_EXHAUSTED,
         "AMDGPU allocation size %" PRIu64
         " exceeds HSA memory pool max allocation size %" PRIu64,
         (uint64_t)allocation_size,
@@ -1292,7 +1348,8 @@ static iree_status_t iree_hal_amdgpu_allocator_allocate_buffer(
   iree_hal_amdgpu_access_agent_list_t access_agents;
   iree_status_t status = iree_hsa_amd_memory_pool_allocate(
       IREE_LIBHSA(allocator->libhsa), memory_placement.memory_pool->memory_pool,
-      (size_t)allocation_size, HSA_AMD_MEMORY_POOL_STANDARD_FLAG, &host_ptr);
+      (size_t)allocation_size, memory_placement.memory_pool->allocation_flags,
+      &host_ptr);
 
   // Grant the physical devices selected by the buffer placement access. A
   // placement of ANY remains intentionally broad within the logical topology,
@@ -1475,6 +1532,14 @@ static iree_status_t iree_hal_amdgpu_allocator_import_device_allocation(
     const iree_hal_external_buffer_t* external_buffer,
     iree_hal_buffer_release_callback_t release_callback,
     iree_hal_buffer_t** out_buffer) {
+  // HSA pointer metadata does not expose the allocation cache policy. Do not
+  // claim that an externally allocated pointer is uncached without being able
+  // to establish that invariant.
+  if (iree_any_bit_set(params->type, IREE_HAL_MEMORY_TYPE_DEVICE_UNCACHED)) {
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "AMDGPU device allocation import cannot verify uncached memory");
+  }
   if (IREE_UNLIKELY(
           !iree_device_size_is_valid_alignment(params->min_alignment))) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator.c
@@ -750,8 +750,8 @@ iree_status_t iree_hal_amdgpu_allocator_create(
           &allocator->memory_pools.device_uncached[i]);
     }
     if (iree_status_is_ok(status) &&
-        logical_device->physical_devices[i]->isa.target_id.version.major >=
-            12) {
+        logical_device->system->gpu_agent_targets[i]
+                .primary_isa.identity.version.major >= 12) {
       if (!device_uncached_pool_available) {
         allocator->memory_pools.device_uncached[i] =
             allocator->memory_pools.device_coarse[i];

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator.c
@@ -16,6 +16,8 @@
 #include "iree/hal/drivers/amdgpu/queue_affinity.h"
 #include "iree/hal/drivers/amdgpu/system.h"
 #include "iree/hal/drivers/amdgpu/util/topology.h"
+#include "iree/hal/drivers/amdgpu/util/vmem.h"
+#include "iree/hal/drivers/amdgpu/virtual_memory.h"
 
 //===----------------------------------------------------------------------===//
 // iree_hal_amdgpu_allocator_t
@@ -71,6 +73,9 @@ typedef struct iree_hal_amdgpu_allocator_t {
 
   // Cached HSA memory pool properties used for placement and heap queries.
   iree_hal_amdgpu_allocator_memory_pools_t memory_pools;
+
+  // Generic VMM ownership and mapping state for this allocator.
+  iree_hal_amdgpu_virtual_memory_state_t* virtual_memory;
 
   IREE_STATISTICS(
       // Aggregate allocation statistics reported through the HAL allocator API.
@@ -479,6 +484,7 @@ static iree_status_t iree_hal_amdgpu_allocator_query_device_pointer_range(
 
 static bool iree_hal_amdgpu_allocator_resolve_placement(
     iree_hal_amdgpu_allocator_t* allocator, iree_hal_buffer_params_t* params,
+    bool allow_vmm_host_access,
     iree_hal_amdgpu_allocator_placement_t* out_placement) {
   memset(out_placement, 0, sizeof(*out_placement));
 
@@ -510,6 +516,12 @@ static bool iree_hal_amdgpu_allocator_resolve_placement(
   const bool device_fine_direct_host_access =
       allocator->memory_pools.device_fine[device_ordinal].memory_pool.handle &&
       physical_device && physical_device->memory_system.svm.direct_host_access;
+  // VMM physical handles have no host pointer until access is granted for the
+  // host agent. They can therefore use a fine-grained device pool even when
+  // ordinary buffers cannot promise direct host mapping.
+  const bool device_fine_vmm_host_access =
+      allow_vmm_host_access &&
+      allocator->memory_pools.device_fine[device_ordinal].memory_pool.handle;
 
   const iree_hal_amdgpu_allocator_memory_pool_t* memory_pool = NULL;
   iree_hal_memory_type_t memory_type = 0;
@@ -529,13 +541,15 @@ static bool iree_hal_amdgpu_allocator_resolve_placement(
                   IREE_HAL_MEMORY_TYPE_HOST_COHERENT |
                   IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   } else if (requires_host_access && requires_device_local) {
-    if (!device_fine_direct_host_access) return false;
+    if (!device_fine_direct_host_access && !device_fine_vmm_host_access) {
+      return false;
+    }
     memory_pool = &allocator->memory_pools.device_fine[device_ordinal];
     memory_type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
                   IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
                   IREE_HAL_MEMORY_TYPE_HOST_COHERENT;
   } else if (requires_host_access && prefers_device_local &&
-             device_fine_direct_host_access) {
+             (device_fine_direct_host_access || device_fine_vmm_host_access)) {
     memory_pool = &allocator->memory_pools.device_fine[device_ordinal];
     memory_type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
                   IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
@@ -582,6 +596,67 @@ static bool iree_hal_amdgpu_allocator_resolve_placement(
   out_placement->physical_device_ordinal = (uint32_t)device_ordinal;
   out_placement->memory_type = memory_type;
   return true;
+}
+
+static bool iree_hal_amdgpu_allocator_supports_virtual_memory_internal(
+    const iree_hal_amdgpu_allocator_t* allocator) {
+  return allocator->virtual_memory != NULL &&
+         !iree_hal_amdgpu_asan_state_is_enabled(
+             &allocator->logical_device->asan);
+}
+
+static iree_status_t iree_hal_amdgpu_allocator_require_virtual_memory(
+    const iree_hal_amdgpu_allocator_t* allocator) {
+  if (iree_hal_amdgpu_allocator_supports_virtual_memory_internal(allocator)) {
+    return iree_ok_status();
+  }
+  return iree_make_status(
+      IREE_STATUS_UNAVAILABLE,
+      "AMDGPU virtual memory is unavailable while address sanitization is "
+      "enabled");
+}
+
+static iree_hal_buffer_params_t iree_hal_amdgpu_allocator_virtual_buffer_params(
+    iree_hal_queue_affinity_t queue_affinity) {
+  return (iree_hal_buffer_params_t){
+      .type = IREE_HAL_MEMORY_TYPE_OPTIMAL_FOR_DEVICE |
+              IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+      .access = IREE_HAL_MEMORY_ACCESS_ALL,
+      .usage = IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_DISPATCH,
+      .queue_affinity = queue_affinity,
+  };
+}
+
+static iree_status_t iree_hal_amdgpu_allocator_resolve_virtual_memory_placement(
+    iree_hal_amdgpu_allocator_t* allocator, iree_hal_buffer_params_t* params,
+    iree_hal_amdgpu_virtual_memory_placement_t* out_placement) {
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_allocator_require_virtual_memory(allocator));
+  iree_hal_buffer_params_canonicalize(params);
+
+  iree_hal_amdgpu_allocator_placement_t memory_placement;
+  if (!iree_hal_amdgpu_allocator_resolve_placement(
+          allocator, params, /*allow_vmm_host_access=*/true,
+          &memory_placement)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU virtual-memory parameters cannot be placed on this device");
+  }
+
+  iree_device_size_t allocation_granule = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_vmem_query_alloc_granule(
+      allocator->libhsa, memory_placement.memory_pool->memory_pool,
+      &allocation_granule));
+  *out_placement = (iree_hal_amdgpu_virtual_memory_placement_t){
+      .memory_pool = memory_placement.memory_pool->memory_pool,
+      .device = (iree_hal_device_t*)allocator->logical_device,
+      .queue_affinity = params->queue_affinity,
+      .memory_type = memory_placement.memory_type,
+      .buffer_usage = params->usage,
+      .allocation_granule = allocation_granule,
+      .max_allocation_size = memory_placement.memory_pool->max_allocation_size,
+  };
+  return iree_ok_status();
 }
 
 iree_status_t iree_hal_amdgpu_allocator_create(
@@ -643,6 +718,11 @@ iree_status_t iree_hal_amdgpu_allocator_create(
   }
 
   if (iree_status_is_ok(status)) {
+    status = iree_hal_amdgpu_virtual_memory_state_create(
+        libhsa, topology, host_allocator, &allocator->virtual_memory);
+  }
+
+  if (iree_status_is_ok(status)) {
     *out_allocator = (iree_hal_allocator_t*)allocator;
   } else {
     iree_hal_allocator_release((iree_hal_allocator_t*)allocator);
@@ -657,6 +737,7 @@ static void iree_hal_amdgpu_allocator_destroy(
       iree_hal_amdgpu_allocator_cast(base_allocator);
   IREE_TRACE_ZONE_BEGIN(z0);
 
+  iree_hal_amdgpu_virtual_memory_state_destroy(allocator->virtual_memory);
   iree_allocator_free(allocator->host_allocator, allocator);
 
   IREE_TRACE_ZONE_END(z0);
@@ -806,8 +887,8 @@ iree_hal_amdgpu_allocator_query_buffer_compatibility(
       iree_hal_amdgpu_allocator_cast(base_allocator);
 
   iree_hal_amdgpu_allocator_placement_t placement;
-  if (!iree_hal_amdgpu_allocator_resolve_placement(allocator, params,
-                                                   &placement)) {
+  if (!iree_hal_amdgpu_allocator_resolve_placement(
+          allocator, params, /*allow_vmm_host_access=*/false, &placement)) {
     return IREE_HAL_BUFFER_COMPATIBILITY_NONE;
   }
   if (!iree_device_size_is_valid_alignment(params->min_alignment)) {
@@ -1126,8 +1207,9 @@ static iree_status_t iree_hal_amdgpu_allocator_allocate_buffer(
   const iree_hal_queue_affinity_t requested_queue_affinity =
       params->queue_affinity;
   iree_hal_amdgpu_allocator_placement_t memory_placement;
-  if (!iree_hal_amdgpu_allocator_resolve_placement(allocator, &compat_params,
-                                                   &memory_placement)) {
+  if (!iree_hal_amdgpu_allocator_resolve_placement(
+          allocator, &compat_params, /*allow_vmm_host_access=*/false,
+          &memory_placement)) {
 #if IREE_STATUS_MODE
     iree_bitfield_string_temp_t temp0, temp1;
     iree_string_view_t memory_type_str =
@@ -1415,8 +1497,9 @@ static iree_status_t iree_hal_amdgpu_allocator_import_device_allocation(
 
   iree_hal_buffer_params_t compat_params = *params;
   iree_hal_amdgpu_allocator_placement_t memory_placement;
-  if (!iree_hal_amdgpu_allocator_resolve_placement(allocator, &compat_params,
-                                                   &memory_placement)) {
+  if (!iree_hal_amdgpu_allocator_resolve_placement(
+          allocator, &compat_params, /*allow_vmm_host_access=*/false,
+          &memory_placement)) {
 #if IREE_STATUS_MODE
     iree_bitfield_string_temp_t temp0, temp1;
     iree_string_view_t memory_type_str =
@@ -1754,7 +1837,9 @@ static iree_status_t iree_hal_amdgpu_allocator_export_buffer(
 
 static bool iree_hal_amdgpu_allocator_supports_virtual_memory(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator) {
-  return false;
+  iree_hal_amdgpu_allocator_t* allocator =
+      iree_hal_amdgpu_allocator_cast(base_allocator);
+  return iree_hal_amdgpu_allocator_supports_virtual_memory_internal(allocator);
 }
 
 static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_query_granularity(
@@ -1762,26 +1847,48 @@ static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_query_granularity(
     iree_hal_buffer_params_t params,
     iree_device_size_t* IREE_RESTRICT out_minimum_page_size,
     iree_device_size_t* IREE_RESTRICT out_recommended_page_size) {
+  IREE_ASSERT_ARGUMENT(out_minimum_page_size);
+  IREE_ASSERT_ARGUMENT(out_recommended_page_size);
   *out_minimum_page_size = 0;
   *out_recommended_page_size = 0;
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "AMDGPU allocator does not support virtual memory");
+  iree_hal_amdgpu_allocator_t* allocator =
+      iree_hal_amdgpu_allocator_cast(base_allocator);
+  iree_hal_amdgpu_virtual_memory_placement_t placement;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_allocator_resolve_virtual_memory_placement(
+          allocator, &params, &placement));
+  *out_minimum_page_size = placement.allocation_granule;
+  *out_recommended_page_size = placement.allocation_granule;
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_reserve(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     iree_hal_queue_affinity_t queue_affinity, iree_device_size_t size,
     iree_hal_buffer_t** IREE_RESTRICT out_virtual_buffer) {
+  IREE_ASSERT_ARGUMENT(out_virtual_buffer);
   *out_virtual_buffer = NULL;
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "AMDGPU allocator does not support virtual memory");
+  iree_hal_amdgpu_allocator_t* allocator =
+      iree_hal_amdgpu_allocator_cast(base_allocator);
+  iree_hal_buffer_params_t params =
+      iree_hal_amdgpu_allocator_virtual_buffer_params(queue_affinity);
+  iree_hal_amdgpu_virtual_memory_placement_t placement;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_allocator_resolve_virtual_memory_placement(
+          allocator, &params, &placement));
+  return iree_hal_amdgpu_virtual_memory_reserve(
+      allocator->virtual_memory, placement, size, out_virtual_buffer);
 }
 
 static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_release(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer) {
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "AMDGPU allocator does not support virtual memory");
+  iree_hal_amdgpu_allocator_t* allocator =
+      iree_hal_amdgpu_allocator_cast(base_allocator);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_allocator_require_virtual_memory(allocator));
+  return iree_hal_amdgpu_virtual_memory_release(allocator->virtual_memory,
+                                                virtual_buffer);
 }
 
 static iree_status_t iree_hal_amdgpu_allocator_physical_memory_allocate(
@@ -1789,16 +1896,28 @@ static iree_status_t iree_hal_amdgpu_allocator_physical_memory_allocate(
     iree_hal_buffer_params_t params, iree_device_size_t size,
     iree_allocator_t host_allocator,
     iree_hal_physical_memory_t** IREE_RESTRICT out_physical_memory) {
+  IREE_ASSERT_ARGUMENT(out_physical_memory);
   *out_physical_memory = NULL;
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "AMDGPU allocator does not support virtual memory");
+  iree_hal_amdgpu_allocator_t* allocator =
+      iree_hal_amdgpu_allocator_cast(base_allocator);
+  iree_hal_amdgpu_virtual_memory_placement_t placement;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_allocator_resolve_virtual_memory_placement(
+          allocator, &params, &placement));
+  return iree_hal_amdgpu_physical_memory_allocate(
+      allocator->virtual_memory, placement, size, host_allocator,
+      out_physical_memory);
 }
 
 static iree_status_t iree_hal_amdgpu_allocator_physical_memory_free(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     iree_hal_physical_memory_t* IREE_RESTRICT physical_memory) {
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "AMDGPU allocator does not support virtual memory");
+  iree_hal_amdgpu_allocator_t* allocator =
+      iree_hal_amdgpu_allocator_cast(base_allocator);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_allocator_require_virtual_memory(allocator));
+  return iree_hal_amdgpu_physical_memory_free(allocator->virtual_memory,
+                                              physical_memory);
 }
 
 static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_map(
@@ -1807,16 +1926,25 @@ static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_map(
     iree_device_size_t virtual_offset,
     iree_hal_physical_memory_t* IREE_RESTRICT physical_memory,
     iree_device_size_t physical_offset, iree_device_size_t size) {
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "AMDGPU allocator does not support virtual memory");
+  iree_hal_amdgpu_allocator_t* allocator =
+      iree_hal_amdgpu_allocator_cast(base_allocator);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_allocator_require_virtual_memory(allocator));
+  return iree_hal_amdgpu_virtual_memory_map(
+      allocator->virtual_memory, virtual_buffer, virtual_offset,
+      physical_memory, physical_offset, size);
 }
 
 static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_unmap(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size) {
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "AMDGPU allocator does not support virtual memory");
+  iree_hal_amdgpu_allocator_t* allocator =
+      iree_hal_amdgpu_allocator_cast(base_allocator);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_allocator_require_virtual_memory(allocator));
+  return iree_hal_amdgpu_virtual_memory_unmap(
+      allocator->virtual_memory, virtual_buffer, virtual_offset, size);
 }
 
 static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_protect(
@@ -1825,8 +1953,13 @@ static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_protect(
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_affinity_t queue_affinity,
     iree_hal_memory_protection_t protection) {
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "AMDGPU allocator does not support virtual memory");
+  iree_hal_amdgpu_allocator_t* allocator =
+      iree_hal_amdgpu_allocator_cast(base_allocator);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_allocator_require_virtual_memory(allocator));
+  return iree_hal_amdgpu_virtual_memory_protect(
+      allocator->virtual_memory, virtual_buffer, virtual_offset, size,
+      queue_affinity, protection);
 }
 
 static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_advise(
@@ -1834,8 +1967,13 @@ static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_advise(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_affinity_t queue_affinity, iree_hal_memory_advice_t advice) {
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "AMDGPU allocator does not support virtual memory");
+  iree_hal_amdgpu_allocator_t* allocator =
+      iree_hal_amdgpu_allocator_cast(base_allocator);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_allocator_require_virtual_memory(allocator));
+  return iree_hal_amdgpu_virtual_memory_advise(allocator->virtual_memory,
+                                               virtual_buffer, virtual_offset,
+                                               size, queue_affinity, advice);
 }
 
 static const iree_hal_allocator_vtable_t iree_hal_amdgpu_allocator_vtable = {

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
@@ -64,6 +64,17 @@ static iree_hal_buffer_params_t HostLocalVirtualMemoryParams() {
   };
 }
 
+static iree_hal_buffer_params_t DeviceLocalHostVisibleVirtualMemoryParams() {
+  return (iree_hal_buffer_params_t){
+      /*.usage=*/IREE_HAL_BUFFER_USAGE_TRANSFER,
+      /*.access=*/IREE_HAL_MEMORY_ACCESS_ALL,
+      /*.type=*/IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+          IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+          IREE_HAL_MEMORY_TYPE_HOST_COHERENT,
+      /*.queue_affinity=*/kQueueAffinity0,
+  };
+}
+
 class VirtualMemoryReservation {
  public:
   explicit VirtualMemoryReservation(iree_hal_allocator_t* allocator)
@@ -471,12 +482,19 @@ TEST_F(AllocatorTest, VirtualMemoryMapsMinimumGranuleAcrossPools) {
   ASSERT_NE(0u, device_minimum_page_size);
   ASSERT_GE(device_recommended_page_size, device_minimum_page_size);
 
-  const iree_hal_buffer_params_t host_params = HostLocalVirtualMemoryParams();
+  const iree_hal_buffer_params_t host_params =
+      DeviceLocalHostVisibleVirtualMemoryParams();
   iree_device_size_t host_minimum_page_size = 0;
   iree_device_size_t host_recommended_page_size = 0;
-  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_query_granularity(
-      allocator, host_params, &host_minimum_page_size,
-      &host_recommended_page_size));
+  iree_status_t host_granularity_status =
+      iree_hal_allocator_virtual_memory_query_granularity(
+          allocator, host_params, &host_minimum_page_size,
+          &host_recommended_page_size);
+  if (iree_status_is_invalid_argument(host_granularity_status)) {
+    iree_status_free(host_granularity_status);
+    GTEST_SKIP() << "device-local host-visible VMM backing is unavailable";
+  }
+  IREE_ASSERT_OK(host_granularity_status);
   ASSERT_NE(0u, host_minimum_page_size);
   ASSERT_GE(host_recommended_page_size, host_minimum_page_size);
 
@@ -503,6 +521,19 @@ TEST_F(AllocatorTest, VirtualMemoryMapsMinimumGranuleAcrossPools) {
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
 
   IREE_ASSERT_OK(mapping.Unmap());
+}
+
+TEST_F(AllocatorTest, VirtualMemoryRejectsHostLocalBacking) {
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(&libhsa_, &topology_, host_allocator_));
+  iree_hal_allocator_t* allocator = test_device.allocator();
+
+  iree_device_size_t minimum_page_size = 0;
+  iree_device_size_t recommended_page_size = 0;
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_hal_allocator_virtual_memory_query_granularity(
+                            allocator, HostLocalVirtualMemoryParams(),
+                            &minimum_page_size, &recommended_page_size));
 }
 
 TEST_F(AllocatorTest, AsanStateReservesDefaultShadowMapWhenEnabled) {

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
@@ -21,11 +21,15 @@
 namespace iree::hal::amdgpu {
 namespace {
 
+constexpr iree_hal_queue_affinity_t kQueueAffinity0 =
+    ((iree_hal_queue_affinity_t)1ull) << 0;
+
 static void CountingReleaseCallback(void* user_data, iree_hal_buffer_t*) {
   ++*static_cast<int*>(user_data);
 }
 
 static iree_status_t QueueFillAndWait(iree_hal_device_t* device,
+                                      iree_hal_queue_affinity_t queue_affinity,
                                       iree_hal_buffer_t* target_buffer,
                                       iree_device_size_t length,
                                       const void* pattern,
@@ -33,12 +37,127 @@ static iree_status_t QueueFillAndWait(iree_hal_device_t* device,
   iree::hal::cts::SemaphoreList empty_wait;
   iree::hal::cts::SemaphoreList fill_signal(device, {0}, {1});
   IREE_RETURN_IF_ERROR(iree_hal_device_queue_fill(
-      device, IREE_HAL_QUEUE_AFFINITY_ANY, empty_wait, fill_signal,
-      target_buffer, /*target_offset=*/0, length, pattern, pattern_length,
+      device, queue_affinity, empty_wait, fill_signal, target_buffer,
+      /*target_offset=*/0, length, pattern, pattern_length,
       IREE_HAL_FILL_FLAG_NONE));
   return iree_hal_semaphore_list_wait(fill_signal, iree_infinite_timeout(),
                                       IREE_ASYNC_WAIT_FLAG_NONE);
 }
+
+static iree_hal_buffer_params_t DeviceLocalVirtualMemoryParams() {
+  return (iree_hal_buffer_params_t){
+      /*.usage=*/IREE_HAL_BUFFER_USAGE_TRANSFER |
+          IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE,
+      /*.access=*/IREE_HAL_MEMORY_ACCESS_ALL,
+      /*.type=*/IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+      /*.queue_affinity=*/kQueueAffinity0,
+  };
+}
+
+static iree_hal_buffer_params_t HostLocalVirtualMemoryParams() {
+  return (iree_hal_buffer_params_t){
+      /*.usage=*/IREE_HAL_BUFFER_USAGE_TRANSFER,
+      /*.access=*/IREE_HAL_MEMORY_ACCESS_ALL,
+      /*.type=*/
+      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+      /*.queue_affinity=*/kQueueAffinity0,
+  };
+}
+
+class VirtualMemoryReservation {
+ public:
+  explicit VirtualMemoryReservation(iree_hal_allocator_t* allocator)
+      : allocator_(allocator) {}
+  ~VirtualMemoryReservation() { Reset(); }
+
+  VirtualMemoryReservation(const VirtualMemoryReservation&) = delete;
+  VirtualMemoryReservation& operator=(const VirtualMemoryReservation&) = delete;
+
+  iree_hal_buffer_t* get() const { return buffer_; }
+  iree_hal_buffer_t** out() { return &buffer_; }
+
+  iree_status_t Release() {
+    if (!buffer_) return iree_ok_status();
+    iree_status_t status =
+        iree_hal_allocator_virtual_memory_release(allocator_, buffer_);
+    if (iree_status_is_ok(status)) buffer_ = nullptr;
+    return status;
+  }
+
+  void Reset() { IREE_EXPECT_OK(Release()); }
+
+ private:
+  iree_hal_allocator_t* allocator_ = nullptr;
+  iree_hal_buffer_t* buffer_ = nullptr;
+};
+
+class PhysicalMemoryAllocation {
+ public:
+  explicit PhysicalMemoryAllocation(iree_hal_allocator_t* allocator)
+      : allocator_(allocator) {}
+  ~PhysicalMemoryAllocation() { Reset(); }
+
+  PhysicalMemoryAllocation(const PhysicalMemoryAllocation&) = delete;
+  PhysicalMemoryAllocation& operator=(const PhysicalMemoryAllocation&) = delete;
+
+  iree_hal_physical_memory_t* get() const { return memory_; }
+  iree_hal_physical_memory_t** out() { return &memory_; }
+
+  iree_status_t Release() {
+    if (!memory_) return iree_ok_status();
+    iree_status_t status =
+        iree_hal_allocator_physical_memory_free(allocator_, memory_);
+    if (iree_status_is_ok(status)) memory_ = nullptr;
+    return status;
+  }
+
+  void Reset() { IREE_EXPECT_OK(Release()); }
+
+ private:
+  iree_hal_allocator_t* allocator_ = nullptr;
+  iree_hal_physical_memory_t* memory_ = nullptr;
+};
+
+class VirtualMemoryMapping {
+ public:
+  VirtualMemoryMapping(iree_hal_allocator_t* allocator,
+                       iree_hal_buffer_t* virtual_buffer,
+                       iree_device_size_t virtual_offset,
+                       iree_device_size_t size)
+      : allocator_(allocator),
+        virtual_buffer_(virtual_buffer),
+        virtual_offset_(virtual_offset),
+        size_(size) {}
+  ~VirtualMemoryMapping() { Reset(); }
+
+  VirtualMemoryMapping(const VirtualMemoryMapping&) = delete;
+  VirtualMemoryMapping& operator=(const VirtualMemoryMapping&) = delete;
+
+  iree_status_t Map(iree_hal_physical_memory_t* physical_memory) {
+    iree_status_t status = iree_hal_allocator_virtual_memory_map(
+        allocator_, virtual_buffer_, virtual_offset_, physical_memory,
+        /*physical_offset=*/0, size_);
+    is_mapped_ = iree_status_is_ok(status);
+    return status;
+  }
+
+  iree_status_t Unmap() {
+    if (!is_mapped_) return iree_ok_status();
+    iree_status_t status = iree_hal_allocator_virtual_memory_unmap(
+        allocator_, virtual_buffer_, virtual_offset_, size_);
+    if (iree_status_is_ok(status)) is_mapped_ = false;
+    return status;
+  }
+
+  void Reset() { IREE_EXPECT_OK(Unmap()); }
+
+ private:
+  iree_hal_allocator_t* allocator_ = nullptr;
+  iree_hal_buffer_t* virtual_buffer_ = nullptr;
+  iree_device_size_t virtual_offset_ = 0;
+  iree_device_size_t size_ = 0;
+  bool is_mapped_ = false;
+};
 
 static iree_status_t AllocateAndExportDevicePointer(
     iree_hal_allocator_t* allocator, iree_hal_buffer_params_t params,
@@ -232,6 +351,159 @@ iree_allocator_t AllocatorTest::host_allocator_;
 iree_hal_amdgpu_libhsa_t AllocatorTest::libhsa_;
 iree_hal_amdgpu_system_info_t AllocatorTest::system_info_;
 iree_hal_amdgpu_topology_t AllocatorTest::topology_;
+
+TEST_F(AllocatorTest, VirtualMemoryLifecycleUsesNativeState) {
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(&libhsa_, &topology_, host_allocator_));
+  iree_hal_allocator_t* allocator = test_device.allocator();
+  ASSERT_TRUE(iree_hal_allocator_supports_virtual_memory(allocator));
+
+  const iree_hal_buffer_params_t params = DeviceLocalVirtualMemoryParams();
+  iree_device_size_t minimum_page_size = 0;
+  iree_device_size_t recommended_page_size = 0;
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_query_granularity(
+      allocator, params, &minimum_page_size, &recommended_page_size));
+  ASSERT_NE(0u, minimum_page_size);
+  ASSERT_GE(recommended_page_size, minimum_page_size);
+
+  hsa_amd_memory_pool_t device_memory_pool = {0};
+  IREE_ASSERT_OK(iree_hal_amdgpu_find_coarse_global_memory_pool(
+      &libhsa_, topology_.gpu_agents[0], &device_memory_pool));
+  iree_hal_amdgpu_vmem_granularity_t native_granularity;
+  IREE_ASSERT_OK(iree_hal_amdgpu_vmem_query_alloc_granularity(
+      &libhsa_, device_memory_pool, &native_granularity));
+  EXPECT_EQ(native_granularity.minimum, minimum_page_size);
+  EXPECT_EQ(native_granularity.recommended, recommended_page_size);
+
+  iree_hal_allocator_statistics_t before_statistics = {};
+  iree_hal_allocator_query_statistics(allocator, &before_statistics);
+
+  VirtualMemoryReservation virtual_memory(allocator);
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_reserve(
+      allocator, kQueueAffinity0, recommended_page_size, virtual_memory.out()));
+  ASSERT_NE(nullptr, virtual_memory.get());
+
+  PhysicalMemoryAllocation physical_memory(allocator);
+  IREE_ASSERT_OK(iree_hal_allocator_physical_memory_allocate(
+      allocator, params, recommended_page_size, host_allocator_,
+      physical_memory.out()));
+  ASSERT_NE(nullptr, physical_memory.get());
+
+#if IREE_STATISTICS_ENABLE
+  iree_hal_allocator_statistics_t allocated_statistics = {};
+  iree_hal_allocator_query_statistics(allocator, &allocated_statistics);
+  EXPECT_EQ(before_statistics.device_bytes_allocated + recommended_page_size,
+            allocated_statistics.device_bytes_allocated);
+  EXPECT_GE(allocated_statistics.device_bytes_peak, recommended_page_size);
+#endif  // IREE_STATISTICS_ENABLE
+
+  // ROCr owns the mapping state and rejects operations that require a mapping
+  // before one exists.
+  IREE_ASSERT_NOT_OK(iree_hal_allocator_virtual_memory_unmap(
+      allocator, virtual_memory.get(), /*virtual_offset=*/0,
+      recommended_page_size));
+  IREE_ASSERT_NOT_OK(iree_hal_allocator_virtual_memory_protect(
+      allocator, virtual_memory.get(), /*virtual_offset=*/0,
+      recommended_page_size, kQueueAffinity0,
+      IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+
+  VirtualMemoryMapping mapping(allocator, virtual_memory.get(),
+                               /*virtual_offset=*/0, recommended_page_size);
+  IREE_ASSERT_OK(mapping.Map(physical_memory.get()));
+
+  // Native mapping state also rejects overlapping mappings without a second
+  // driver-owned ownership registry.
+  IREE_ASSERT_NOT_OK(iree_hal_allocator_virtual_memory_map(
+      allocator, virtual_memory.get(), /*virtual_offset=*/0,
+      physical_memory.get(), /*physical_offset=*/0, recommended_page_size));
+
+  // ROCr rejects releasing an address reservation while mappings remain. The
+  // failed operation must leave the same HAL buffer available for retry.
+  IREE_ASSERT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION,
+                        virtual_memory.Release());
+
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
+      allocator, virtual_memory.get(), /*virtual_offset=*/0,
+      recommended_page_size, kQueueAffinity0,
+      IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+
+  constexpr iree_device_size_t kTouchedSize = 256;
+  ASSERT_GE(recommended_page_size, kTouchedSize);
+  constexpr uint32_t kPattern = 0xA110CA7Eu;
+  IREE_ASSERT_OK(QueueFillAndWait(test_device.device(), kQueueAffinity0,
+                                  virtual_memory.get(), kTouchedSize, &kPattern,
+                                  sizeof(kPattern)));
+  std::array<uint32_t, kTouchedSize / sizeof(uint32_t)> observed = {};
+  IREE_ASSERT_OK(iree_hsa_memory_copy(
+      IREE_LIBHSA(&libhsa_), observed.data(),
+      iree_hal_amdgpu_buffer_device_pointer(virtual_memory.get()),
+      sizeof(observed)));
+  for (uint32_t value : observed) {
+    EXPECT_EQ(kPattern, value);
+  }
+
+  IREE_ASSERT_OK(mapping.Unmap());
+  IREE_ASSERT_OK(physical_memory.Release());
+
+#if IREE_STATISTICS_ENABLE
+  iree_hal_allocator_statistics_t freed_statistics = {};
+  iree_hal_allocator_query_statistics(allocator, &freed_statistics);
+  EXPECT_EQ(before_statistics.device_bytes_freed + recommended_page_size,
+            freed_statistics.device_bytes_freed);
+#endif  // IREE_STATISTICS_ENABLE
+
+  IREE_ASSERT_OK(virtual_memory.Release());
+}
+
+TEST_F(AllocatorTest, VirtualMemoryMapsMinimumGranuleAcrossPools) {
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(&libhsa_, &topology_, host_allocator_));
+  iree_hal_allocator_t* allocator = test_device.allocator();
+  ASSERT_TRUE(iree_hal_allocator_supports_virtual_memory(allocator));
+
+  const iree_hal_buffer_params_t device_params =
+      DeviceLocalVirtualMemoryParams();
+  iree_device_size_t device_minimum_page_size = 0;
+  iree_device_size_t device_recommended_page_size = 0;
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_query_granularity(
+      allocator, device_params, &device_minimum_page_size,
+      &device_recommended_page_size));
+  ASSERT_NE(0u, device_minimum_page_size);
+  ASSERT_GE(device_recommended_page_size, device_minimum_page_size);
+
+  const iree_hal_buffer_params_t host_params = HostLocalVirtualMemoryParams();
+  iree_device_size_t host_minimum_page_size = 0;
+  iree_device_size_t host_recommended_page_size = 0;
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_query_granularity(
+      allocator, host_params, &host_minimum_page_size,
+      &host_recommended_page_size));
+  ASSERT_NE(0u, host_minimum_page_size);
+  ASSERT_GE(host_recommended_page_size, host_minimum_page_size);
+
+  const iree_device_size_t reservation_size =
+      iree_max(device_recommended_page_size, host_minimum_page_size);
+  ASSERT_TRUE(iree_device_size_has_alignment(reservation_size,
+                                             device_minimum_page_size));
+
+  VirtualMemoryReservation virtual_memory(allocator);
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_reserve(
+      allocator, kQueueAffinity0, reservation_size, virtual_memory.out()));
+
+  PhysicalMemoryAllocation physical_memory(allocator);
+  IREE_ASSERT_OK(iree_hal_allocator_physical_memory_allocate(
+      allocator, host_params, host_minimum_page_size, host_allocator_,
+      physical_memory.out()));
+
+  VirtualMemoryMapping mapping(allocator, virtual_memory.get(),
+                               /*virtual_offset=*/0, host_minimum_page_size);
+  IREE_ASSERT_OK(mapping.Map(physical_memory.get()));
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
+      allocator, virtual_memory.get(), /*virtual_offset=*/0,
+      host_minimum_page_size, kQueueAffinity0,
+      IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+
+  IREE_ASSERT_OK(mapping.Unmap());
+}
 
 TEST_F(AllocatorTest, AsanStateReservesDefaultShadowMapWhenEnabled) {
   iree_hal_amdgpu_logical_device_options_t options;
@@ -986,8 +1258,9 @@ TEST_F(AllocatorTest, DeviceAllocationImportWrapsHsaAllocation) {
             external_buffer.handle.device_allocation.ptr);
 
   constexpr uint32_t kPattern = 0xACCE551u;
-  IREE_ASSERT_OK(QueueFillAndWait(test_device.device(), buffer, kAllocationSize,
-                                  &kPattern, sizeof(kPattern)));
+  IREE_ASSERT_OK(
+      QueueFillAndWait(test_device.device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+                       buffer, kAllocationSize, &kPattern, sizeof(kPattern)));
   std::array<uint32_t, kAllocationSize / sizeof(uint32_t)> observed = {};
   IREE_ASSERT_OK(iree_hsa_memory_copy(IREE_LIBHSA(&libhsa_), observed.data(),
                                       allocation.ptr(), kAllocationSize));
@@ -1253,9 +1526,9 @@ TEST_F(AllocatorTest, DeviceAllocationExportReportsHsaPointer) {
   EXPECT_GE(pointer_info.sizeInBytes, external_buffer.size);
 
   constexpr uint32_t kPattern = 0xA110CA7Eu;
-  IREE_ASSERT_OK(QueueFillAndWait(test_device.device(), buffer,
-                                  external_buffer.size, &kPattern,
-                                  sizeof(kPattern)));
+  IREE_ASSERT_OK(QueueFillAndWait(
+      test_device.device(), IREE_HAL_QUEUE_AFFINITY_ANY, buffer,
+      external_buffer.size, &kPattern, sizeof(kPattern)));
   std::array<uint32_t, 4096 / sizeof(uint32_t)> observed = {};
   IREE_ASSERT_OK(iree_hsa_memory_copy(
       IREE_LIBHSA(&libhsa_), observed.data(),

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
@@ -579,9 +579,9 @@ TEST_F(AllocatorTest, QueryMemoryHeapsReportsHsaLimits) {
                             test_device.allocator(),
                             /*capacity=*/0, /*heaps=*/NULL, &heap_count));
   ASSERT_GE(heap_count, 2u);
-  ASSERT_LE(heap_count, 3u);
+  ASSERT_LE(heap_count, 4u);
 
-  std::array<iree_hal_allocator_memory_heap_t, 3> heaps;
+  std::array<iree_hal_allocator_memory_heap_t, 4> heaps;
   IREE_ASSERT_OK(iree_hal_allocator_query_memory_heaps(
       test_device.allocator(), heaps.size(), heaps.data(), &heap_count));
   ASSERT_GE(heap_count, 2u);
@@ -600,7 +600,7 @@ TEST_F(AllocatorTest, OversizedAllocationIsRejectedByCompatibility) {
   TestLogicalDevice test_device;
   IREE_ASSERT_OK(test_device.Initialize(&libhsa_, &topology_, host_allocator_));
 
-  std::array<iree_hal_allocator_memory_heap_t, 3> heaps;
+  std::array<iree_hal_allocator_memory_heap_t, 4> heaps;
   iree_host_size_t heap_count = 0;
   IREE_ASSERT_OK(iree_hal_allocator_query_memory_heaps(
       test_device.allocator(), heaps.size(), heaps.data(), &heap_count));
@@ -745,7 +745,7 @@ TEST_F(AllocatorTest, OverAlignedAllocationIsRejected) {
   TestLogicalDevice test_device;
   IREE_ASSERT_OK(test_device.Initialize(&libhsa_, &topology_, host_allocator_));
 
-  std::array<iree_hal_allocator_memory_heap_t, 3> heaps;
+  std::array<iree_hal_allocator_memory_heap_t, 4> heaps;
   iree_host_size_t heap_count = 0;
   IREE_ASSERT_OK(iree_hal_allocator_query_memory_heaps(
       test_device.allocator(), heaps.size(), heaps.data(), &heap_count));

--- a/runtime/src/iree/hal/drivers/amdgpu/buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/buffer.c
@@ -236,6 +236,29 @@ void* iree_hal_amdgpu_buffer_device_pointer(iree_hal_buffer_t* base_buffer) {
   return ((iree_hal_amdgpu_buffer_t*)base_buffer)->host_ptr;
 }
 
+bool iree_hal_amdgpu_buffer_uses_release_callback(
+    iree_hal_buffer_t* base_buffer,
+    iree_hal_buffer_release_callback_t release_callback) {
+  if (!iree_hal_resource_is((const iree_hal_resource_t*)base_buffer,
+                            &iree_hal_amdgpu_buffer_vtable)) {
+    return false;
+  }
+  const iree_hal_amdgpu_buffer_t* buffer =
+      (const iree_hal_amdgpu_buffer_t*)base_buffer;
+  return buffer->release_callback.fn == release_callback.fn &&
+         buffer->release_callback.user_data == release_callback.user_data;
+}
+
+void iree_hal_amdgpu_buffer_disarm_storage(
+    iree_hal_buffer_t* base_buffer,
+    iree_hal_buffer_release_callback_t release_callback) {
+  IREE_ASSERT(iree_hal_amdgpu_buffer_uses_release_callback(base_buffer,
+                                                           release_callback));
+  iree_hal_amdgpu_buffer_t* buffer = iree_hal_amdgpu_buffer_cast(base_buffer);
+  buffer->host_ptr = NULL;
+  buffer->release_callback = iree_hal_buffer_release_callback_null();
+}
+
 static void iree_hal_amdgpu_buffer_initialize(
     const iree_hal_amdgpu_libhsa_t* libhsa,
     iree_hal_buffer_placement_t placement, iree_hal_memory_type_t memory_type,

--- a/runtime/src/iree/hal/drivers/amdgpu/buffer.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/buffer.h
@@ -122,6 +122,21 @@ void iree_hal_amdgpu_buffer_set_profile_allocation(
 // callers should use iree_hal_buffer_allocated_buffer() to unwrap first.
 void* iree_hal_amdgpu_buffer_device_pointer(iree_hal_buffer_t* buffer);
 
+// Returns true if |buffer| is a direct AMDGPU buffer using exactly
+// |release_callback| to release its backing storage.
+bool iree_hal_amdgpu_buffer_uses_release_callback(
+    iree_hal_buffer_t* buffer,
+    iree_hal_buffer_release_callback_t release_callback);
+
+// Disarms callback-owned storage that has already been released externally.
+//
+// |buffer| must be a direct AMDGPU buffer using exactly |release_callback|.
+// The backing pointer and callback are cleared so destroying the remaining
+// buffer wrapper performs no storage operation.
+void iree_hal_amdgpu_buffer_disarm_storage(
+    iree_hal_buffer_t* buffer,
+    iree_hal_buffer_release_callback_t release_callback);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_host_call.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_host_call.c
@@ -42,6 +42,7 @@ static void iree_hal_amdgpu_host_call_state_destroy(
   iree_hal_amdgpu_host_call_state_t* state =
       (iree_hal_amdgpu_host_call_state_t*)resource;
   IREE_TRACE_ZONE_BEGIN(z0);
+  iree_hal_resource_release(state->call.resource);
   if (!iree_hal_semaphore_list_is_empty(state->signal_semaphore_list)) {
     iree_hal_semaphore_list_free(state->signal_semaphore_list,
                                  state->host_allocator);
@@ -98,6 +99,7 @@ static iree_status_t iree_hal_amdgpu_host_call_state_create(
   state->device = queue->logical_device;
   state->queue_affinity = queue->queue_affinity;
   state->call = call;
+  iree_hal_resource_retain(state->call.resource);
   memcpy(state->args, args, sizeof(state->args));
   state->flags = flags;
 

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_pending_payload.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_pending_payload.c
@@ -574,15 +574,16 @@ iree_status_t iree_hal_amdgpu_host_queue_defer_host_call(
     const iree_hal_semaphore_list_t* signal_semaphore_list,
     iree_hal_host_call_t call, const uint64_t args[4],
     iree_hal_host_call_flags_t flags, iree_hal_amdgpu_pending_op_t** out_op) {
+  const iree_host_size_t operation_resource_count = call.resource ? 1 : 0;
   uint16_t max_resources = 0;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_host_queue_count_reclaim_resources(
-      signal_semaphore_list->count,
-      /*operation_resource_count=*/0, &max_resources));
+      signal_semaphore_list->count, operation_resource_count, &max_resources));
   iree_hal_amdgpu_pending_op_t* op = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_pending_op_allocate(
       queue, wait_semaphore_list, signal_semaphore_list,
       IREE_HAL_AMDGPU_PENDING_OP_HOST_CALL, max_resources, &op));
   op->host_call.call = call;
+  iree_hal_amdgpu_pending_op_retain(op, call.resource);
   memcpy(op->host_call.args, args, sizeof(op->host_call.args));
   op->host_call.flags = flags;
   *out_op = op;

--- a/runtime/src/iree/hal/drivers/amdgpu/slab_provider.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/slab_provider.c
@@ -517,9 +517,13 @@ iree_status_t iree_hal_amdgpu_slab_provider_create(
   }
   if (iree_status_is_ok(status)) {
     if (iree_hal_amdgpu_slab_provider_uses_asan_vmm(provider)) {
-      status = iree_hal_amdgpu_vmem_query_alloc_granule(
-          libhsa, options.memory_pool, &provider->allocation_granule);
-      provider->allocation_alignment = provider->allocation_granule;
+      iree_hal_amdgpu_vmem_granularity_t granularity;
+      status = iree_hal_amdgpu_vmem_query_alloc_granularity(
+          libhsa, options.memory_pool, &granularity);
+      if (iree_status_is_ok(status)) {
+        provider->allocation_granule = granularity.recommended;
+        provider->allocation_alignment = granularity.recommended;
+      }
     } else {
       provider->allocation_granule = properties.allocation_granule;
       provider->allocation_alignment = properties.allocation_alignment;

--- a/runtime/src/iree/hal/drivers/amdgpu/util/libhsa.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/libhsa.c
@@ -253,13 +253,15 @@ static iree_status_t iree_hal_amdgpu_libhsa_try_load_library_from_file(
     iree_string_builder_t* error_builder, iree_allocator_t host_allocator,
     iree_dynamic_library_t** out_library) {
   IREE_ASSERT_ARGUMENT(out_library);
+  (void)flags;
   IREE_TRACE_ZONE_BEGIN(z0);
   IREE_TRACE_ZONE_APPEND_TEXT(z0, file_path);
   *out_library = NULL;
 
   // Try loading from the given file path.
   iree_status_t status = iree_dynamic_library_load_from_file(
-      file_path, flags, host_allocator, out_library);
+      file_path, IREE_DYNAMIC_LIBRARY_FLAG_NODELETE, host_allocator,
+      out_library);
 
   // Append error message to the status builder.
   if (!iree_status_is_ok(status)) {

--- a/runtime/src/iree/hal/drivers/amdgpu/util/shadow_map.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/shadow_map.c
@@ -444,9 +444,10 @@ iree_status_t iree_hal_amdgpu_shadow_map_initialize_hsa(
   IREE_ASSERT_ARGUMENT(out_map);
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_shadow_map_validate_hsa_params(params));
 
-  iree_device_size_t allocation_granule = 0;
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_vmem_query_alloc_granule(
-      params->libhsa, params->memory_pool, &allocation_granule));
+  iree_hal_amdgpu_vmem_granularity_t granularity;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_vmem_query_alloc_granularity(
+      params->libhsa, params->memory_pool, &granularity));
+  const iree_device_size_t allocation_granule = granularity.recommended;
 
   iree_device_size_t slab_size = params->requested_slab_size;
   if (slab_size < allocation_granule) slab_size = allocation_granule;

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem.c
@@ -192,27 +192,40 @@ iree_status_t iree_hal_amdgpu_vmem_translate_memory_type(
   }
 }
 
-iree_status_t iree_hal_amdgpu_vmem_query_alloc_granule(
+iree_status_t iree_hal_amdgpu_vmem_query_alloc_granularity(
     const iree_hal_amdgpu_libhsa_t* libhsa, hsa_amd_memory_pool_t memory_pool,
-    iree_device_size_t* out_allocation_granule) {
+    iree_hal_amdgpu_vmem_granularity_t* out_granularity) {
   IREE_ASSERT_ARGUMENT(libhsa);
-  IREE_ASSERT_ARGUMENT(out_allocation_granule);
-  *out_allocation_granule = 0;
+  IREE_ASSERT_ARGUMENT(out_granularity);
+  *out_granularity = (iree_hal_amdgpu_vmem_granularity_t){0};
 
-  size_t alloc_rec_granule = 0;
+  size_t minimum = 0;
   IREE_RETURN_IF_ERROR(iree_hsa_amd_memory_pool_get_info(
       IREE_LIBHSA(libhsa), memory_pool,
-      HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE, &alloc_rec_granule));
-  if (alloc_rec_granule == 0 ||
-      !iree_device_size_is_power_of_two(alloc_rec_granule)) {
+      HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_GRANULE, &minimum));
+  if (minimum == 0 || !iree_device_size_is_power_of_two(minimum)) {
     return iree_make_status(
         IREE_STATUS_INTERNAL,
-        "invalid HSA VMM allocation granule for an AMDGPU memory pool: "
+        "invalid minimum HSA VMM allocation granule for an AMDGPU memory pool: "
         "%" PRIhsz,
-        (iree_host_size_t)alloc_rec_granule);
+        (iree_host_size_t)minimum);
   }
 
-  *out_allocation_granule = (iree_device_size_t)alloc_rec_granule;
+  size_t recommended = 0;
+  IREE_RETURN_IF_ERROR(iree_hsa_amd_memory_pool_get_info(
+      IREE_LIBHSA(libhsa), memory_pool,
+      HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_REC_GRANULE, &recommended));
+  if (recommended < minimum || !iree_device_size_is_power_of_two(recommended)) {
+    return iree_make_status(
+        IREE_STATUS_INTERNAL,
+        "invalid recommended HSA VMM allocation granule for an AMDGPU memory "
+        "pool: "
+        "%" PRIhsz,
+        (iree_host_size_t)recommended);
+  }
+
+  out_granularity->minimum = (iree_device_size_t)minimum;
+  out_granularity->recommended = (iree_device_size_t)recommended;
   return iree_ok_status();
 }
 
@@ -314,15 +327,15 @@ iree_status_t iree_hal_amdgpu_vmem_ringbuffer_initialize(
                                                      &hsa_memory_type));
 
   // hsa_amd_vmem_handle_create wants values aligned to this value.
-  iree_device_size_t alloc_rec_granule = 0;
+  iree_hal_amdgpu_vmem_granularity_t granularity;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_amdgpu_vmem_query_alloc_granule(libhsa, memory_pool,
-                                                   &alloc_rec_granule));
+      z0, iree_hal_amdgpu_vmem_query_alloc_granularity(libhsa, memory_pool,
+                                                       &granularity));
 
   // Round up capacity and alignment to the allocation granule.
-  const size_t alignment = (size_t)alloc_rec_granule;
+  const size_t alignment = (size_t)granularity.recommended;
   const size_t capacity =
-      (size_t)iree_device_align(min_capacity, alloc_rec_granule);
+      (size_t)iree_device_align(min_capacity, granularity.recommended);
   out_ringbuffer->capacity = capacity;
 
   // Reserve the virtual address space for the 3x the capacity. We'll map the

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem.c
@@ -131,6 +131,15 @@ iree_status_t iree_hal_amdgpu_query_fine_global_memory_pool(
       out_available, out_pool);
 }
 
+iree_status_t iree_hal_amdgpu_query_extended_fine_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    bool* out_available, hsa_amd_memory_pool_t* out_pool) {
+  return iree_hal_amdgpu_query_global_memory_pool(
+      libhsa, agent,
+      HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_EXTENDED_SCOPE_FINE_GRAINED,
+      out_available, out_pool);
+}
+
 bool iree_hal_amdgpu_try_find_coarse_global_memory_pool(
     const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
     hsa_amd_memory_pool_t* out_pool) {

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem.h
@@ -104,10 +104,19 @@ iree_status_t iree_hal_amdgpu_vmem_translate_memory_type(
     iree_hal_amdgpu_vmem_memory_type_t memory_type,
     hsa_amd_memory_type_t* out_hsa_memory_type);
 
-// Queries the recommended HSA VMM allocation granule for |memory_pool|.
-iree_status_t iree_hal_amdgpu_vmem_query_alloc_granule(
+// Native HSA VMM allocation granularity for one memory pool.
+typedef struct iree_hal_amdgpu_vmem_granularity_t {
+  // Smallest legal allocation and mapping multiple.
+  iree_device_size_t minimum;
+
+  // Preferred allocation multiple used to reduce internal fragmentation.
+  iree_device_size_t recommended;
+} iree_hal_amdgpu_vmem_granularity_t;
+
+// Queries the HSA VMM allocation granularity for |memory_pool|.
+iree_status_t iree_hal_amdgpu_vmem_query_alloc_granularity(
     const iree_hal_amdgpu_libhsa_t* libhsa, hsa_amd_memory_pool_t memory_pool,
-    iree_device_size_t* out_allocation_granule);
+    iree_hal_amdgpu_vmem_granularity_t* out_granularity);
 
 // Builds HSA VMM access descriptors for |topology| and |access_mode|.
 //

--- a/runtime/src/iree/hal/drivers/amdgpu/util/vmem.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/vmem.h
@@ -79,6 +79,13 @@ iree_status_t iree_hal_amdgpu_query_fine_global_memory_pool(
     const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
     bool* out_available, hsa_amd_memory_pool_t* out_pool);
 
+// Queries whether an extended fine-grained memory pool is available on the
+// |agent|. Such pools provide the device-side uncached memory mapping used by
+// allocation requests that cannot use the normal device cache hierarchy.
+iree_status_t iree_hal_amdgpu_query_extended_fine_global_memory_pool(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t agent,
+    bool* out_available, hsa_amd_memory_pool_t* out_pool);
+
 // Tries to find a coarse-grained memory pool on the |agent|.
 // Returns true and populates |out_pool| if found, false otherwise.
 bool iree_hal_amdgpu_try_find_coarse_global_memory_pool(

--- a/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
@@ -317,7 +317,7 @@ iree_status_t iree_hal_amdgpu_virtual_memory_release(
   const iree_hal_buffer_release_callback_t release_callback =
       iree_hal_amdgpu_virtual_memory_reservation_release_callback(state);
   iree_hal_amdgpu_buffer_disarm_storage(virtual_buffer, release_callback);
-  iree_hal_buffer_destroy(virtual_buffer);
+  iree_hal_buffer_release(virtual_buffer);
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
@@ -7,65 +7,32 @@
 #include "iree/hal/drivers/amdgpu/virtual_memory.h"
 
 #include <stdint.h>
-#include <stdio.h>
 
-#include "iree/base/threading/mutex.h"
 #include "iree/hal/drivers/amdgpu/access_policy.h"
 #include "iree/hal/drivers/amdgpu/buffer.h"
 #include "iree/hal/drivers/amdgpu/queue_affinity.h"
 #include "iree/hal/drivers/amdgpu/util/topology.h"
 #include "iree/hal/drivers/amdgpu/util/vmem.h"
 
-// ROCr maps and protects each VMM handle as one range. The HAL VMM API can
-// express subranges, but accepting them here would imply support ROCr does not
-// provide. Callers that need suballocation must allocate page-sized physical
-// handles and map them individually.
+// ROCr is the authoritative owner of reservation, mapping, access, and handle
+// state. This adapter retains only the objects needed to express HAL ownership.
 
-typedef struct iree_hal_amdgpu_virtual_memory_reservation_t {
-  // Next reservation in the allocator-owned registry.
-  struct iree_hal_amdgpu_virtual_memory_reservation_t* next;
-
-  // VMM state that owns this reservation and its registry entry.
-  iree_hal_amdgpu_virtual_memory_state_t* state;
-
-  // HAL buffer exposing the reserved virtual address range.
-  iree_hal_buffer_t* virtual_buffer;
-
-  // Base address returned by ROCr for the virtual reservation.
+typedef struct iree_hal_amdgpu_virtual_memory_range_t {
+  // Base address of the ROCr virtual reservation.
   void* base_ptr;
 
-  // Byte length of the reservation.
+  // Byte length of the ROCr virtual reservation.
   iree_device_size_t size;
 
-  // Required alignment for VMM offsets and mapping sizes.
-  iree_device_size_t allocation_granule;
-
-  // Queues permitted to receive access permissions for this reservation.
+  // HAL queues permitted to access the reservation.
   iree_hal_queue_affinity_t queue_affinity;
-} iree_hal_amdgpu_virtual_memory_reservation_t;
-
-typedef struct iree_hal_amdgpu_virtual_memory_mapping_t {
-  // Next mapping in the allocator-owned registry.
-  struct iree_hal_amdgpu_virtual_memory_mapping_t* next;
-
-  // Reservation whose address range contains this mapping.
-  iree_hal_amdgpu_virtual_memory_reservation_t* reservation;
-
-  // Physical allocation mapped into the virtual address range.
-  iree_hal_physical_memory_t* physical_memory;
-
-  // Byte offset in |reservation| where the mapping begins.
-  iree_device_size_t virtual_offset;
-
-  // Byte length of the mapping and its physical allocation.
-  iree_device_size_t size;
-} iree_hal_amdgpu_virtual_memory_mapping_t;
+} iree_hal_amdgpu_virtual_memory_range_t;
 
 struct iree_hal_physical_memory_t {
   // Host allocator used to release this physical-memory wrapper.
   iree_allocator_t host_allocator;
 
-  // VMM state that owns synchronization for this allocation.
+  // VMM context that created this allocation.
   iree_hal_amdgpu_virtual_memory_state_t* state;
 
   // HSA VMM handle representing the physical allocation.
@@ -74,11 +41,11 @@ struct iree_hal_physical_memory_t {
   // Byte length of the physical allocation.
   iree_device_size_t allocation_size;
 
-  // Required alignment for the physical allocation size.
-  iree_device_size_t allocation_granule;
+  // Smallest legal mapping multiple for this physical allocation.
+  iree_device_size_t minimum_granule;
 
-  // Total bytes currently mapped from this physical allocation.
-  iree_device_size_t mapped_size;
+  // HAL memory type used for allocator statistics.
+  iree_hal_memory_type_t memory_type;
 };
 
 struct iree_hal_amdgpu_virtual_memory_state_t {
@@ -88,25 +55,25 @@ struct iree_hal_amdgpu_virtual_memory_state_t {
   // Unowned topology used to grant access to selected queue agents.
   const iree_hal_amdgpu_topology_t* topology;
 
-  // Host allocator used for VMM bookkeeping.
+  // Unowned HAL device used to validate reservation ownership.
+  iree_hal_device_t* device;
+
+  // Unowned allocator statistics updated for physical allocations.
+  iree_hal_allocator_statistics_t* statistics;
+
+  // Host allocator used to release this context.
   iree_allocator_t host_allocator;
-
-  // Serializes reservation, mapping, and physical-memory ownership changes.
-  iree_slim_mutex_t mutex;
-
-  // Registry of live virtual-address reservations.
-  iree_hal_amdgpu_virtual_memory_reservation_t* reservations;
-
-  // Registry of live physical-to-virtual mappings.
-  iree_hal_amdgpu_virtual_memory_mapping_t* mappings;
-
-  // Number of physical-memory handles that have not been freed.
-  iree_host_size_t physical_memory_count;
 };
 
 static bool iree_hal_amdgpu_virtual_memory_is_aligned(
     iree_device_size_t value, iree_device_size_t alignment) {
   return alignment != 0 && value % alignment == 0;
+}
+
+static bool iree_hal_amdgpu_virtual_memory_range_is_in_bounds(
+    iree_device_size_t total_size, iree_device_size_t offset,
+    iree_device_size_t size) {
+  return offset <= total_size && size <= total_size - offset;
 }
 
 static bool iree_hal_amdgpu_virtual_memory_range_is_valid(
@@ -115,91 +82,42 @@ static bool iree_hal_amdgpu_virtual_memory_range_is_valid(
   return size != 0 &&
          iree_hal_amdgpu_virtual_memory_is_aligned(offset, alignment) &&
          iree_hal_amdgpu_virtual_memory_is_aligned(size, alignment) &&
-         offset <= total_size && size <= total_size - offset;
+         iree_hal_amdgpu_virtual_memory_range_is_in_bounds(total_size, offset,
+                                                           size);
 }
 
 static iree_status_t iree_hal_amdgpu_virtual_memory_validate_placement(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
     iree_hal_amdgpu_virtual_memory_placement_t placement) {
   if (IREE_UNLIKELY(!placement.memory_pool.handle)) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "AMDGPU VMM placement has no HSA memory pool");
   }
-  if (IREE_UNLIKELY(!placement.device)) {
+  if (IREE_UNLIKELY(placement.device != state->device)) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "AMDGPU VMM placement has no HAL device");
+                            "AMDGPU VMM placement belongs to another device");
   }
   if (IREE_UNLIKELY(
-          !iree_device_size_is_valid_alignment(placement.allocation_granule))) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "AMDGPU VMM placement has invalid allocation "
-                            "granule %" PRIu64,
-                            (uint64_t)placement.allocation_granule);
+          placement.minimum_granule == 0 ||
+          !iree_device_size_is_power_of_two(placement.minimum_granule))) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU VMM placement has invalid minimum granule %" PRIu64,
+        (uint64_t)placement.minimum_granule);
+  }
+  if (IREE_UNLIKELY(
+          placement.recommended_granule < placement.minimum_granule ||
+          !iree_device_size_is_power_of_two(placement.recommended_granule))) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU VMM placement has invalid recommended granule %" PRIu64,
+        (uint64_t)placement.recommended_granule);
   }
   if (IREE_UNLIKELY(placement.max_allocation_size == 0)) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "AMDGPU VMM placement has no allocation limit");
   }
   return iree_ok_status();
-}
-
-static iree_hal_amdgpu_virtual_memory_reservation_t*
-iree_hal_amdgpu_virtual_memory_find_reservation_locked(
-    iree_hal_amdgpu_virtual_memory_state_t* state,
-    iree_hal_buffer_t* virtual_buffer) {
-  for (iree_hal_amdgpu_virtual_memory_reservation_t* reservation =
-           state->reservations;
-       reservation; reservation = reservation->next) {
-    if (reservation->virtual_buffer == virtual_buffer) return reservation;
-  }
-  return NULL;
-}
-
-static bool iree_hal_amdgpu_virtual_memory_has_mapping_locked(
-    iree_hal_amdgpu_virtual_memory_state_t* state,
-    iree_hal_amdgpu_virtual_memory_reservation_t* reservation) {
-  for (iree_hal_amdgpu_virtual_memory_mapping_t* mapping = state->mappings;
-       mapping; mapping = mapping->next) {
-    if (mapping->reservation == reservation) return true;
-  }
-  return false;
-}
-
-static iree_hal_amdgpu_virtual_memory_mapping_t*
-iree_hal_amdgpu_virtual_memory_find_exact_mapping_locked(
-    iree_hal_amdgpu_virtual_memory_state_t* state,
-    iree_hal_amdgpu_virtual_memory_reservation_t* reservation,
-    iree_device_size_t virtual_offset, iree_device_size_t size) {
-  for (iree_hal_amdgpu_virtual_memory_mapping_t* mapping = state->mappings;
-       mapping; mapping = mapping->next) {
-    if (mapping->reservation == reservation &&
-        mapping->virtual_offset == virtual_offset && mapping->size == size) {
-      return mapping;
-    }
-  }
-  return NULL;
-}
-
-static bool iree_hal_amdgpu_virtual_memory_ranges_overlap(
-    iree_device_size_t lhs_offset, iree_device_size_t lhs_size,
-    iree_device_size_t rhs_offset, iree_device_size_t rhs_size) {
-  const iree_device_size_t lhs_end = lhs_offset + lhs_size;
-  const iree_device_size_t rhs_end = rhs_offset + rhs_size;
-  return lhs_offset < rhs_end && rhs_offset < lhs_end;
-}
-
-static bool iree_hal_amdgpu_virtual_memory_has_overlapping_mapping_locked(
-    iree_hal_amdgpu_virtual_memory_state_t* state,
-    iree_hal_amdgpu_virtual_memory_reservation_t* reservation,
-    iree_device_size_t virtual_offset, iree_device_size_t size) {
-  for (iree_hal_amdgpu_virtual_memory_mapping_t* mapping = state->mappings;
-       mapping; mapping = mapping->next) {
-    if (mapping->reservation == reservation &&
-        iree_hal_amdgpu_virtual_memory_ranges_overlap(
-            virtual_offset, size, mapping->virtual_offset, mapping->size)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 static hsa_access_permission_t
@@ -223,38 +141,96 @@ iree_hal_amdgpu_virtual_memory_translate_protection(
 
 static void iree_hal_amdgpu_virtual_memory_release_reservation(
     void* user_data, iree_hal_buffer_t* virtual_buffer) {
-  (void)virtual_buffer;
-  iree_hal_amdgpu_virtual_memory_reservation_t* reservation =
-      (iree_hal_amdgpu_virtual_memory_reservation_t*)user_data;
+  iree_hal_amdgpu_virtual_memory_state_t* state =
+      (iree_hal_amdgpu_virtual_memory_state_t*)user_data;
   IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status =
-      iree_hsa_amd_vmem_address_free(IREE_LIBHSA(reservation->state->libhsa),
-                                     reservation->base_ptr, reservation->size);
-  if (!iree_status_is_ok(status)) {
-    iree_status_fprint(stderr, status);
-    iree_status_free(status);
-  }
-  iree_allocator_free(reservation->state->host_allocator, reservation);
+  iree_hal_amdgpu_hsa_cleanup_assert_success(iree_hsa_amd_vmem_address_free_raw(
+      state->libhsa, iree_hal_amdgpu_buffer_device_pointer(virtual_buffer),
+      (size_t)iree_hal_buffer_allocation_size(virtual_buffer)));
   IREE_TRACE_ZONE_END(z0);
+}
+
+static iree_hal_buffer_release_callback_t
+iree_hal_amdgpu_virtual_memory_reservation_release_callback(
+    iree_hal_amdgpu_virtual_memory_state_t* state) {
+  return (iree_hal_buffer_release_callback_t){
+      .fn = iree_hal_amdgpu_virtual_memory_release_reservation,
+      .user_data = state,
+  };
+}
+
+static iree_status_t iree_hal_amdgpu_virtual_memory_free_address(
+    iree_hal_amdgpu_virtual_memory_state_t* state, void* base_ptr,
+    iree_device_size_t size) {
+  const hsa_status_t hsa_status =
+      iree_hsa_amd_vmem_address_free_raw(state->libhsa, base_ptr, (size_t)size);
+  if (hsa_status == HSA_STATUS_ERROR_RESOURCE_FREE) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "AMDGPU virtual-memory reservation still has mapped ranges");
+  }
+  return iree_status_from_hsa_status(__FILE__, __LINE__, hsa_status,
+                                     "hsa_amd_vmem_address_free", NULL);
+}
+
+static iree_status_t iree_hal_amdgpu_virtual_memory_resolve_range(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_buffer_t* virtual_buffer,
+    iree_hal_amdgpu_virtual_memory_range_t* out_range) {
+  *out_range = (iree_hal_amdgpu_virtual_memory_range_t){0};
+  const iree_hal_buffer_release_callback_t release_callback =
+      iree_hal_amdgpu_virtual_memory_reservation_release_callback(state);
+  if (!iree_hal_amdgpu_buffer_uses_release_callback(virtual_buffer,
+                                                    release_callback)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "virtual buffer does not belong to this AMDGPU VMM "
+                            "context");
+  }
+
+  const iree_hal_buffer_placement_t placement =
+      iree_hal_buffer_allocation_placement(virtual_buffer);
+  if (IREE_UNLIKELY(placement.device != state->device)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU virtual reservation belongs to another "
+                            "device");
+  }
+
+  void* base_ptr = iree_hal_amdgpu_buffer_device_pointer(virtual_buffer);
+  if (IREE_UNLIKELY(!base_ptr)) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "AMDGPU virtual reservation has no device address");
+  }
+
+  *out_range = (iree_hal_amdgpu_virtual_memory_range_t){
+      .base_ptr = base_ptr,
+      .size = iree_hal_buffer_allocation_size(virtual_buffer),
+      .queue_affinity = placement.queue_affinity,
+  };
+  return iree_ok_status();
 }
 
 iree_status_t iree_hal_amdgpu_virtual_memory_state_create(
     const iree_hal_amdgpu_libhsa_t* libhsa,
-    const iree_hal_amdgpu_topology_t* topology, iree_allocator_t host_allocator,
+    const iree_hal_amdgpu_topology_t* topology, iree_hal_device_t* device,
+    iree_hal_allocator_statistics_t* statistics,
+    iree_allocator_t host_allocator,
     iree_hal_amdgpu_virtual_memory_state_t** out_state) {
   IREE_ASSERT_ARGUMENT(libhsa);
   IREE_ASSERT_ARGUMENT(topology);
+  IREE_ASSERT_ARGUMENT(device);
   IREE_ASSERT_ARGUMENT(out_state);
   *out_state = NULL;
 
   iree_hal_amdgpu_virtual_memory_state_t* state = NULL;
   IREE_RETURN_IF_ERROR(
       iree_allocator_malloc(host_allocator, sizeof(*state), (void**)&state));
-  memset(state, 0, sizeof(*state));
-  state->libhsa = libhsa;
-  state->topology = topology;
-  state->host_allocator = host_allocator;
-  iree_slim_mutex_initialize(&state->mutex);
+  *state = (iree_hal_amdgpu_virtual_memory_state_t){
+      .libhsa = libhsa,
+      .topology = topology,
+      .device = device,
+      .statistics = statistics,
+      .host_allocator = host_allocator,
+  };
   *out_state = state;
   return iree_ok_status();
 }
@@ -263,13 +239,6 @@ void iree_hal_amdgpu_virtual_memory_state_destroy(
     iree_hal_amdgpu_virtual_memory_state_t* state) {
   if (!state) return;
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_ASSERT(state->reservations == NULL,
-              "destroying AMDGPU VMM state with live reservations");
-  IREE_ASSERT(state->mappings == NULL,
-              "destroying AMDGPU VMM state with live mappings");
-  IREE_ASSERT(state->physical_memory_count == 0,
-              "destroying AMDGPU VMM state with live physical allocations");
-  iree_slim_mutex_deinitialize(&state->mutex);
   iree_allocator_free(state->host_allocator, state);
   IREE_TRACE_ZONE_END(z0);
 }
@@ -282,35 +251,33 @@ iree_status_t iree_hal_amdgpu_virtual_memory_reserve(
   IREE_ASSERT_ARGUMENT(out_virtual_buffer);
   *out_virtual_buffer = NULL;
   IREE_RETURN_IF_ERROR(
-      iree_hal_amdgpu_virtual_memory_validate_placement(placement));
+      iree_hal_amdgpu_virtual_memory_validate_placement(state, placement));
   if (IREE_UNLIKELY(!iree_hal_amdgpu_virtual_memory_range_is_valid(
-          size, /*offset=*/0, size, placement.allocation_granule))) {
+          size, /*offset=*/0, size, placement.minimum_granule))) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
         "AMDGPU virtual-memory reservation size %" PRIu64
-        " must be a non-zero multiple of VMM granule %" PRIu64,
-        (uint64_t)size, (uint64_t)placement.allocation_granule);
+        " must be a non-zero multiple of minimum VMM granule %" PRIu64,
+        (uint64_t)size, (uint64_t)placement.minimum_granule);
   }
 
-  iree_hal_amdgpu_virtual_memory_reservation_t* reservation = NULL;
-  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
-      state->host_allocator, sizeof(*reservation), (void**)&reservation));
-  memset(reservation, 0, sizeof(*reservation));
-  reservation->state = state;
-  reservation->size = size;
-  reservation->allocation_granule = placement.allocation_granule;
-  reservation->queue_affinity = placement.queue_affinity;
-
-  const iree_device_size_t reservation_alignment = placement.allocation_granule;
+  const iree_device_size_t reservation_alignment =
+      iree_hal_amdgpu_virtual_memory_is_aligned(size,
+                                                placement.recommended_granule)
+          ? placement.recommended_granule
+          : placement.minimum_granule;
+  void* base_ptr = NULL;
   iree_status_t status = iree_hsa_amd_vmem_address_reserve_align(
-      IREE_LIBHSA(state->libhsa), &reservation->base_ptr, size,
-      /*address=*/0, reservation_alignment, /*flags=*/0);
+      IREE_LIBHSA(state->libhsa), &base_ptr, size, /*address=*/0,
+      reservation_alignment, /*flags=*/0);
   if (iree_status_is_ok(status) &&
-      (uintptr_t)reservation->base_ptr % reservation_alignment != 0) {
+      (uintptr_t)base_ptr % reservation_alignment != 0) {
     status =
         iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                          "AMDGPU VMM reservation has insufficient alignment");
   }
+
+  iree_hal_buffer_t* virtual_buffer = NULL;
   if (iree_status_is_ok(status)) {
     const iree_hal_buffer_placement_t buffer_placement = {
         .device = placement.device,
@@ -320,27 +287,17 @@ iree_status_t iree_hal_amdgpu_virtual_memory_reserve(
     status = iree_hal_amdgpu_buffer_create(
         state->libhsa, buffer_placement, placement.memory_type,
         IREE_HAL_MEMORY_ACCESS_ALL, placement.buffer_usage, size, size,
-        reservation->base_ptr,
-        (iree_hal_buffer_release_callback_t){
-            .fn = iree_hal_amdgpu_virtual_memory_release_reservation,
-            .user_data = reservation,
-        },
-        state->host_allocator, &reservation->virtual_buffer);
+        base_ptr,
+        iree_hal_amdgpu_virtual_memory_reservation_release_callback(state),
+        state->host_allocator, &virtual_buffer);
   }
 
   if (iree_status_is_ok(status)) {
-    iree_slim_mutex_lock(&state->mutex);
-    reservation->next = state->reservations;
-    state->reservations = reservation;
-    iree_slim_mutex_unlock(&state->mutex);
-    *out_virtual_buffer = reservation->virtual_buffer;
-  } else {
-    if (reservation->base_ptr) {
-      status = iree_status_join(
-          status, iree_hsa_amd_vmem_address_free(IREE_LIBHSA(state->libhsa),
-                                                 reservation->base_ptr, size));
-    }
-    iree_allocator_free(state->host_allocator, reservation);
+    *out_virtual_buffer = virtual_buffer;
+  } else if (base_ptr) {
+    status = iree_status_join(
+        status, iree_hsa_amd_vmem_address_free(IREE_LIBHSA(state->libhsa),
+                                               base_ptr, size));
   }
   return status;
 }
@@ -351,32 +308,17 @@ iree_status_t iree_hal_amdgpu_virtual_memory_release(
   IREE_ASSERT_ARGUMENT(state);
   IREE_ASSERT_ARGUMENT(virtual_buffer);
 
-  iree_slim_mutex_lock(&state->mutex);
-  iree_status_t status = iree_ok_status();
-  iree_hal_amdgpu_virtual_memory_reservation_t** reservation_ptr =
-      &state->reservations;
-  while (*reservation_ptr &&
-         (*reservation_ptr)->virtual_buffer != virtual_buffer) {
-    reservation_ptr = &(*reservation_ptr)->next;
-  }
-  if (!*reservation_ptr) {
-    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "virtual buffer does not belong to this AMDGPU "
-                              "VMM state");
-  } else if (iree_hal_amdgpu_virtual_memory_has_mapping_locked(
-                 state, *reservation_ptr)) {
-    status = iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                              "AMDGPU virtual-memory reservation must be "
-                              "fully unmapped before release");
-  } else {
-    *reservation_ptr = (*reservation_ptr)->next;
-  }
-  iree_slim_mutex_unlock(&state->mutex);
+  iree_hal_amdgpu_virtual_memory_range_t range;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_virtual_memory_resolve_range(
+      state, virtual_buffer, &range));
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_virtual_memory_free_address(
+      state, range.base_ptr, range.size));
 
-  if (iree_status_is_ok(status)) {
-    iree_hal_buffer_destroy(virtual_buffer);
-  }
-  return status;
+  const iree_hal_buffer_release_callback_t release_callback =
+      iree_hal_amdgpu_virtual_memory_reservation_release_callback(state);
+  iree_hal_amdgpu_buffer_disarm_storage(virtual_buffer, release_callback);
+  iree_hal_buffer_destroy(virtual_buffer);
+  return iree_ok_status();
 }
 
 iree_status_t iree_hal_amdgpu_physical_memory_allocate(
@@ -388,14 +330,14 @@ iree_status_t iree_hal_amdgpu_physical_memory_allocate(
   IREE_ASSERT_ARGUMENT(out_physical_memory);
   *out_physical_memory = NULL;
   IREE_RETURN_IF_ERROR(
-      iree_hal_amdgpu_virtual_memory_validate_placement(placement));
+      iree_hal_amdgpu_virtual_memory_validate_placement(state, placement));
   if (IREE_UNLIKELY(!iree_hal_amdgpu_virtual_memory_range_is_valid(
-          size, /*offset=*/0, size, placement.allocation_granule))) {
+          size, /*offset=*/0, size, placement.minimum_granule))) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
         "AMDGPU physical-memory allocation size %" PRIu64
-        " must be a non-zero multiple of VMM granule %" PRIu64,
-        (uint64_t)size, (uint64_t)placement.allocation_granule);
+        " must be a non-zero multiple of minimum VMM granule %" PRIu64,
+        (uint64_t)size, (uint64_t)placement.minimum_granule);
   }
   if (IREE_UNLIKELY(size > placement.max_allocation_size)) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
@@ -405,9 +347,8 @@ iree_status_t iree_hal_amdgpu_physical_memory_allocate(
                             (uint64_t)placement.max_allocation_size);
   }
 
-  // VMM physical handles must remain resident while their mappings are live.
-  // Placement rejects memory requirements that the HSA VMM handle API cannot
-  // represent before selecting the pool.
+  // HIP requires VMM backing allocations to remain resident and ROCr expresses
+  // that contract with MEMORY_TYPE_PINNED for both host and device pools.
   hsa_amd_memory_type_t hsa_memory_type = MEMORY_TYPE_NONE;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_vmem_translate_memory_type(
       IREE_HAL_AMDGPU_VMEM_MEMORY_TYPE_PINNED_HOST, &hsa_memory_type));
@@ -415,19 +356,25 @@ iree_status_t iree_hal_amdgpu_physical_memory_allocate(
   iree_hal_physical_memory_t* physical_memory = NULL;
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(
       host_allocator, sizeof(*physical_memory), (void**)&physical_memory));
-  memset(physical_memory, 0, sizeof(*physical_memory));
-  physical_memory->host_allocator = host_allocator;
-  physical_memory->state = state;
-  physical_memory->allocation_size = size;
-  physical_memory->allocation_granule = placement.allocation_granule;
+  *physical_memory = (iree_hal_physical_memory_t){
+      .host_allocator = host_allocator,
+      .state = state,
+      .allocation_size = size,
+      .minimum_granule = placement.minimum_granule,
+      .memory_type = placement.memory_type,
+  };
 
   iree_status_t status = iree_hsa_amd_vmem_handle_create(
       IREE_LIBHSA(state->libhsa), placement.memory_pool, size, hsa_memory_type,
       /*flags=*/0, &physical_memory->allocation_handle);
   if (iree_status_is_ok(status)) {
-    iree_slim_mutex_lock(&state->mutex);
-    ++state->physical_memory_count;
-    iree_slim_mutex_unlock(&state->mutex);
+    IREE_STATISTICS({
+      if (state->statistics) {
+        iree_hal_allocator_statistics_record_alloc(
+            state->statistics, physical_memory->memory_type,
+            physical_memory->allocation_size);
+      }
+    });
     *out_physical_memory = physical_memory;
   } else {
     iree_allocator_free(host_allocator, physical_memory);
@@ -443,30 +390,23 @@ iree_status_t iree_hal_amdgpu_physical_memory_free(
   if (physical_memory->state != state) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "physical memory belongs to a different AMDGPU "
-                            "VMM state");
+                            "VMM context");
   }
 
-  iree_slim_mutex_lock(&state->mutex);
-  iree_status_t status = iree_ok_status();
-  if (physical_memory->mapped_size != 0) {
-    status = iree_make_status(
-        IREE_STATUS_FAILED_PRECONDITION,
-        "AMDGPU physical-memory allocation still has %" PRIu64 " mapped bytes",
-        (uint64_t)physical_memory->mapped_size);
-  } else {
-    status = iree_hsa_amd_vmem_handle_release(
-        IREE_LIBHSA(state->libhsa), physical_memory->allocation_handle);
-  }
-  if (iree_status_is_ok(status)) {
-    IREE_ASSERT(state->physical_memory_count > 0);
-    --state->physical_memory_count;
-  }
-  iree_slim_mutex_unlock(&state->mutex);
-
-  if (iree_status_is_ok(status)) {
-    iree_allocator_free(physical_memory->host_allocator, physical_memory);
-  }
-  return status;
+  // The HAL contract requires callers to unmap every alias before freeing.
+  // ROCr retains mapped references internally, so no duplicate mapping ledger
+  // is needed here to preserve native allocation lifetime.
+  IREE_RETURN_IF_ERROR(iree_hsa_amd_vmem_handle_release(
+      IREE_LIBHSA(state->libhsa), physical_memory->allocation_handle));
+  IREE_STATISTICS({
+    if (state->statistics) {
+      iree_hal_allocator_statistics_record_free(
+          state->statistics, physical_memory->memory_type,
+          physical_memory->allocation_size);
+    }
+  });
+  iree_allocator_free(physical_memory->host_allocator, physical_memory);
+  return iree_ok_status();
 }
 
 iree_status_t iree_hal_amdgpu_virtual_memory_map(
@@ -480,7 +420,7 @@ iree_status_t iree_hal_amdgpu_virtual_memory_map(
   if (physical_memory->state != state) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "physical memory belongs to a different AMDGPU "
-                            "VMM state");
+                            "VMM context");
   }
   if (IREE_UNLIKELY(physical_offset != 0 ||
                     size != physical_memory->allocation_size)) {
@@ -490,56 +430,29 @@ iree_status_t iree_hal_amdgpu_virtual_memory_map(
         "memory allocation");
   }
 
-  iree_hal_amdgpu_virtual_memory_mapping_t* mapping = NULL;
-  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
-      state->host_allocator, sizeof(*mapping), (void**)&mapping));
-  memset(mapping, 0, sizeof(*mapping));
+  iree_hal_amdgpu_virtual_memory_range_t range;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_virtual_memory_resolve_range(
+      state, virtual_buffer, &range));
+  if (IREE_UNLIKELY(!iree_hal_amdgpu_virtual_memory_range_is_valid(
+          range.size, virtual_offset, size,
+          physical_memory->minimum_granule))) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU virtual-memory map range is not a valid minimum-granule "
+        "physical mapping");
+  }
 
-  iree_slim_mutex_lock(&state->mutex);
-  iree_status_t status = iree_ok_status();
-  iree_hal_amdgpu_virtual_memory_reservation_t* reservation =
-      iree_hal_amdgpu_virtual_memory_find_reservation_locked(state,
-                                                             virtual_buffer);
-  if (!reservation) {
-    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "virtual buffer does not belong to this AMDGPU "
-                              "VMM state");
-  } else if (!iree_hal_amdgpu_virtual_memory_range_is_valid(
-                 reservation->size, virtual_offset, size,
-                 reservation->allocation_granule)) {
-    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "AMDGPU virtual-memory map range is not a "
-                              "valid reservation-aligned range");
-  } else if (!iree_hal_amdgpu_virtual_memory_is_aligned(
-                 size, physical_memory->allocation_granule)) {
-    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "AMDGPU physical-memory map size is not aligned");
-  } else if (iree_hal_amdgpu_virtual_memory_has_overlapping_mapping_locked(
-                 state, reservation, virtual_offset, size)) {
-    status = iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                              "AMDGPU virtual-memory map range overlaps an "
-                              "existing mapping");
+  void* map_ptr = (uint8_t*)range.base_ptr + virtual_offset;
+  if (IREE_UNLIKELY((uintptr_t)map_ptr % physical_memory->minimum_granule !=
+                    0)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU virtual-memory map address is not aligned to the physical "
+        "allocation granule");
   }
-  if (iree_status_is_ok(status)) {
-    void* map_ptr = (uint8_t*)reservation->base_ptr + virtual_offset;
-    status = iree_hsa_amd_vmem_map(
-        IREE_LIBHSA(state->libhsa), map_ptr, size, /*in_offset=*/0,
-        physical_memory->allocation_handle, /*flags=*/0);
-  }
-  if (iree_status_is_ok(status)) {
-    mapping->reservation = reservation;
-    mapping->physical_memory = physical_memory;
-    mapping->virtual_offset = virtual_offset;
-    mapping->size = size;
-    mapping->next = state->mappings;
-    state->mappings = mapping;
-    IREE_ASSERT(physical_memory->mapped_size <= IREE_DEVICE_SIZE_MAX - size);
-    physical_memory->mapped_size += size;
-    mapping = NULL;
-  }
-  iree_slim_mutex_unlock(&state->mutex);
-  iree_allocator_free(state->host_allocator, mapping);
-  return status;
+  return iree_hsa_amd_vmem_map(IREE_LIBHSA(state->libhsa), map_ptr, size,
+                               /*in_offset=*/0,
+                               physical_memory->allocation_handle, /*flags=*/0);
 }
 
 iree_status_t iree_hal_amdgpu_virtual_memory_unmap(
@@ -549,57 +462,19 @@ iree_status_t iree_hal_amdgpu_virtual_memory_unmap(
   IREE_ASSERT_ARGUMENT(state);
   IREE_ASSERT_ARGUMENT(virtual_buffer);
 
-  iree_slim_mutex_lock(&state->mutex);
-  iree_status_t status = iree_ok_status();
-  iree_hal_amdgpu_virtual_memory_reservation_t* reservation =
-      iree_hal_amdgpu_virtual_memory_find_reservation_locked(state,
-                                                             virtual_buffer);
-  iree_hal_amdgpu_virtual_memory_mapping_t* mapping = NULL;
-  iree_hal_amdgpu_virtual_memory_mapping_t** mapping_ptr = NULL;
-  if (!reservation) {
-    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "virtual buffer does not belong to this AMDGPU "
-                              "VMM state");
-  } else if (!iree_hal_amdgpu_virtual_memory_range_is_valid(
-                 reservation->size, virtual_offset, size,
-                 reservation->allocation_granule)) {
-    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "AMDGPU virtual-memory unmap range is not a "
-                              "valid reservation-aligned range");
-  } else {
-    mapping_ptr = &state->mappings;
-    while (*mapping_ptr && ((*mapping_ptr)->reservation != reservation ||
-                            (*mapping_ptr)->virtual_offset != virtual_offset ||
-                            (*mapping_ptr)->size != size)) {
-      mapping_ptr = &(*mapping_ptr)->next;
-    }
-    mapping = *mapping_ptr;
-    if (!mapping) {
-      if (iree_hal_amdgpu_virtual_memory_has_overlapping_mapping_locked(
-              state, reservation, virtual_offset, size)) {
-        status = iree_make_status(
-            IREE_STATUS_UNIMPLEMENTED,
-            "AMDGPU VMM can only unmap complete physical-memory mappings");
-      } else {
-        status = iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                                  "AMDGPU virtual-memory range is not mapped");
-      }
-    }
+  iree_hal_amdgpu_virtual_memory_range_t range;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_virtual_memory_resolve_range(
+      state, virtual_buffer, &range));
+  if (IREE_UNLIKELY(size == 0 ||
+                    !iree_hal_amdgpu_virtual_memory_range_is_in_bounds(
+                        range.size, virtual_offset, size))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU virtual-memory unmap range exceeds the "
+                            "reservation");
   }
-  if (iree_status_is_ok(status)) {
-    void* map_ptr = (uint8_t*)reservation->base_ptr + virtual_offset;
-    status = iree_hsa_amd_vmem_unmap(IREE_LIBHSA(state->libhsa), map_ptr, size);
-  }
-  if (iree_status_is_ok(status)) {
-    IREE_ASSERT(mapping->physical_memory->mapped_size >= size);
-    mapping->physical_memory->mapped_size -= size;
-    *mapping_ptr = mapping->next;
-  }
-  iree_slim_mutex_unlock(&state->mutex);
-  if (iree_status_is_ok(status)) {
-    iree_allocator_free(state->host_allocator, mapping);
-  }
-  return status;
+
+  void* map_ptr = (uint8_t*)range.base_ptr + virtual_offset;
+  return iree_hsa_amd_vmem_unmap(IREE_LIBHSA(state->libhsa), map_ptr, size);
 }
 
 iree_status_t iree_hal_amdgpu_virtual_memory_protect(
@@ -619,65 +494,37 @@ iree_status_t iree_hal_amdgpu_virtual_memory_protect(
                             "invalid AMDGPU virtual-memory protection flags");
   }
 
-  iree_slim_mutex_lock(&state->mutex);
-  iree_status_t status = iree_ok_status();
-  iree_hal_amdgpu_virtual_memory_reservation_t* reservation =
-      iree_hal_amdgpu_virtual_memory_find_reservation_locked(state,
-                                                             virtual_buffer);
-  iree_hal_amdgpu_virtual_memory_mapping_t* mapping = NULL;
-  if (!reservation) {
-    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "virtual buffer does not belong to this AMDGPU "
-                              "VMM state");
-  } else if (!iree_hal_amdgpu_virtual_memory_range_is_valid(
-                 reservation->size, virtual_offset, size,
-                 reservation->allocation_granule)) {
-    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "AMDGPU virtual-memory protect range is not a "
-                              "valid reservation-aligned range");
-  } else {
-    mapping = iree_hal_amdgpu_virtual_memory_find_exact_mapping_locked(
-        state, reservation, virtual_offset, size);
-    if (!mapping) {
-      if (iree_hal_amdgpu_virtual_memory_has_overlapping_mapping_locked(
-              state, reservation, virtual_offset, size)) {
-        status = iree_make_status(
-            IREE_STATUS_UNIMPLEMENTED,
-            "AMDGPU VMM can only protect complete physical-memory mappings");
-      } else {
-        status = iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                                  "AMDGPU virtual-memory range is not mapped");
-      }
-    }
+  iree_hal_amdgpu_virtual_memory_range_t range;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_virtual_memory_resolve_range(
+      state, virtual_buffer, &range));
+  if (IREE_UNLIKELY(size == 0 ||
+                    !iree_hal_amdgpu_virtual_memory_range_is_in_bounds(
+                        range.size, virtual_offset, size))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU virtual-memory protection range exceeds "
+                            "the reservation");
   }
 
+  const iree_hal_amdgpu_queue_affinity_domain_t domain = {
+      .supported_affinity = range.queue_affinity,
+      .physical_device_count = state->topology->gpu_agent_count,
+      .queue_count_per_physical_device = state->topology->gpu_agent_queue_count,
+  };
   iree_hal_amdgpu_access_agent_list_t agent_list;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_access_agent_list_resolve(
+      state->topology, domain, queue_affinity, &agent_list));
+
   hsa_amd_memory_access_desc_t access_descs[IREE_HAL_AMDGPU_MAX_CPU_AGENT +
                                             IREE_HAL_AMDGPU_MAX_GPU_AGENT];
-  if (iree_status_is_ok(status)) {
-    const iree_hal_amdgpu_queue_affinity_domain_t domain = {
-        .supported_affinity = reservation->queue_affinity,
-        .physical_device_count = state->topology->gpu_agent_count,
-        .queue_count_per_physical_device =
-            state->topology->gpu_agent_queue_count,
+  for (uint32_t i = 0; i < agent_list.count; ++i) {
+    access_descs[i] = (hsa_amd_memory_access_desc_t){
+        .permissions = permissions,
+        .agent_handle = agent_list.values[i],
     };
-    status = iree_hal_amdgpu_access_agent_list_resolve(
-        state->topology, domain, queue_affinity, &agent_list);
   }
-  if (iree_status_is_ok(status)) {
-    for (uint32_t i = 0; i < agent_list.count; ++i) {
-      access_descs[i] = (hsa_amd_memory_access_desc_t){
-          .permissions = permissions,
-          .agent_handle = agent_list.values[i],
-      };
-    }
-    void* map_ptr = (uint8_t*)reservation->base_ptr + virtual_offset;
-    status = iree_hsa_amd_vmem_set_access(IREE_LIBHSA(state->libhsa), map_ptr,
-                                          mapping->size, access_descs,
-                                          agent_list.count);
-  }
-  iree_slim_mutex_unlock(&state->mutex);
-  return status;
+  void* map_ptr = (uint8_t*)range.base_ptr + virtual_offset;
+  return iree_hsa_amd_vmem_set_access(IREE_LIBHSA(state->libhsa), map_ptr, size,
+                                      access_descs, agent_list.count);
 }
 
 iree_status_t iree_hal_amdgpu_virtual_memory_advise(
@@ -690,21 +537,14 @@ iree_status_t iree_hal_amdgpu_virtual_memory_advise(
   IREE_ASSERT_ARGUMENT(state);
   IREE_ASSERT_ARGUMENT(virtual_buffer);
 
-  iree_slim_mutex_lock(&state->mutex);
-  iree_status_t status = iree_ok_status();
-  iree_hal_amdgpu_virtual_memory_reservation_t* reservation =
-      iree_hal_amdgpu_virtual_memory_find_reservation_locked(state,
-                                                             virtual_buffer);
-  if (!reservation) {
-    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "virtual buffer does not belong to this AMDGPU "
-                              "VMM state");
-  } else if (virtual_offset > reservation->size ||
-             size > reservation->size - virtual_offset) {
-    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "AMDGPU virtual-memory advice range exceeds "
-                              "the reservation");
+  iree_hal_amdgpu_virtual_memory_range_t range;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_virtual_memory_resolve_range(
+      state, virtual_buffer, &range));
+  if (IREE_UNLIKELY(!iree_hal_amdgpu_virtual_memory_range_is_in_bounds(
+          range.size, virtual_offset, size))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU virtual-memory advice range exceeds the "
+                            "reservation");
   }
-  iree_slim_mutex_unlock(&state->mutex);
-  return status;
+  return iree_ok_status();
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
@@ -7,6 +7,7 @@
 #include "iree/hal/drivers/amdgpu/virtual_memory.h"
 
 #include <stdint.h>
+#include <stdio.h>
 
 #include "iree/base/threading/mutex.h"
 #include "iree/hal/drivers/amdgpu/access_policy.h"
@@ -226,8 +227,13 @@ static void iree_hal_amdgpu_virtual_memory_release_reservation(
   iree_hal_amdgpu_virtual_memory_reservation_t* reservation =
       (iree_hal_amdgpu_virtual_memory_reservation_t*)user_data;
   IREE_TRACE_ZONE_BEGIN(z0);
-  iree_hal_amdgpu_hsa_cleanup_assert_success(iree_hsa_amd_vmem_address_free_raw(
-      reservation->state->libhsa, reservation->base_ptr, reservation->size));
+  iree_status_t status =
+      iree_hsa_amd_vmem_address_free(IREE_LIBHSA(reservation->state->libhsa),
+                                     reservation->base_ptr, reservation->size);
+  if (!iree_status_is_ok(status)) {
+    iree_status_fprint(stderr, status);
+    iree_status_free(status);
+  }
   iree_allocator_free(reservation->state->host_allocator, reservation);
   IREE_TRACE_ZONE_END(z0);
 }
@@ -330,9 +336,9 @@ iree_status_t iree_hal_amdgpu_virtual_memory_reserve(
     *out_virtual_buffer = reservation->virtual_buffer;
   } else {
     if (reservation->base_ptr) {
-      iree_hal_amdgpu_hsa_cleanup_assert_success(
-          iree_hsa_amd_vmem_address_free_raw(state->libhsa,
-                                             reservation->base_ptr, size));
+      status = iree_status_join(
+          status, iree_hsa_amd_vmem_address_free(IREE_LIBHSA(state->libhsa),
+                                                 reservation->base_ptr, size));
     }
     iree_allocator_free(state->host_allocator, reservation);
   }
@@ -400,7 +406,8 @@ iree_status_t iree_hal_amdgpu_physical_memory_allocate(
   }
 
   // VMM physical handles must remain resident while their mappings are live.
-  // The selected pool carries the cache policy, including uncached placement.
+  // Placement rejects memory requirements that the HSA VMM handle API cannot
+  // represent before selecting the pool.
   hsa_amd_memory_type_t hsa_memory_type = MEMORY_TYPE_NONE;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_vmem_translate_memory_type(
       IREE_HAL_AMDGPU_VMEM_MEMORY_TYPE_PINNED_HOST, &hsa_memory_type));
@@ -447,15 +454,16 @@ iree_status_t iree_hal_amdgpu_physical_memory_free(
         "AMDGPU physical-memory allocation still has %" PRIu64 " mapped bytes",
         (uint64_t)physical_memory->mapped_size);
   } else {
+    status = iree_hsa_amd_vmem_handle_release(
+        IREE_LIBHSA(state->libhsa), physical_memory->allocation_handle);
+  }
+  if (iree_status_is_ok(status)) {
     IREE_ASSERT(state->physical_memory_count > 0);
     --state->physical_memory_count;
   }
   iree_slim_mutex_unlock(&state->mutex);
 
   if (iree_status_is_ok(status)) {
-    iree_hal_amdgpu_hsa_cleanup_assert_success(
-        iree_hsa_amd_vmem_handle_release_raw(
-            state->libhsa, physical_memory->allocation_handle));
     iree_allocator_free(physical_memory->host_allocator, physical_memory);
   }
   return status;

--- a/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
@@ -1,0 +1,702 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/virtual_memory.h"
+
+#include <stdint.h>
+
+#include "iree/base/threading/mutex.h"
+#include "iree/hal/drivers/amdgpu/access_policy.h"
+#include "iree/hal/drivers/amdgpu/buffer.h"
+#include "iree/hal/drivers/amdgpu/queue_affinity.h"
+#include "iree/hal/drivers/amdgpu/util/topology.h"
+#include "iree/hal/drivers/amdgpu/util/vmem.h"
+
+// ROCr maps and protects each VMM handle as one range. The HAL VMM API can
+// express subranges, but accepting them here would imply support ROCr does not
+// provide. Callers that need suballocation must allocate page-sized physical
+// handles and map them individually.
+
+typedef struct iree_hal_amdgpu_virtual_memory_reservation_t {
+  // Next reservation in the allocator-owned registry.
+  struct iree_hal_amdgpu_virtual_memory_reservation_t* next;
+
+  // VMM state that owns this reservation and its registry entry.
+  iree_hal_amdgpu_virtual_memory_state_t* state;
+
+  // HAL buffer exposing the reserved virtual address range.
+  iree_hal_buffer_t* virtual_buffer;
+
+  // Base address returned by ROCr for the virtual reservation.
+  void* base_ptr;
+
+  // Byte length of the reservation.
+  iree_device_size_t size;
+
+  // Required alignment for VMM offsets and mapping sizes.
+  iree_device_size_t allocation_granule;
+
+  // Queues permitted to receive access permissions for this reservation.
+  iree_hal_queue_affinity_t queue_affinity;
+} iree_hal_amdgpu_virtual_memory_reservation_t;
+
+typedef struct iree_hal_amdgpu_virtual_memory_mapping_t {
+  // Next mapping in the allocator-owned registry.
+  struct iree_hal_amdgpu_virtual_memory_mapping_t* next;
+
+  // Reservation whose address range contains this mapping.
+  iree_hal_amdgpu_virtual_memory_reservation_t* reservation;
+
+  // Physical allocation mapped into the virtual address range.
+  iree_hal_physical_memory_t* physical_memory;
+
+  // Byte offset in |reservation| where the mapping begins.
+  iree_device_size_t virtual_offset;
+
+  // Byte length of the mapping and its physical allocation.
+  iree_device_size_t size;
+} iree_hal_amdgpu_virtual_memory_mapping_t;
+
+struct iree_hal_physical_memory_t {
+  // Host allocator used to release this physical-memory wrapper.
+  iree_allocator_t host_allocator;
+
+  // VMM state that owns synchronization for this allocation.
+  iree_hal_amdgpu_virtual_memory_state_t* state;
+
+  // HSA VMM handle representing the physical allocation.
+  hsa_amd_vmem_alloc_handle_t allocation_handle;
+
+  // Byte length of the physical allocation.
+  iree_device_size_t allocation_size;
+
+  // Required alignment for the physical allocation size.
+  iree_device_size_t allocation_granule;
+
+  // Total bytes currently mapped from this physical allocation.
+  iree_device_size_t mapped_size;
+};
+
+struct iree_hal_amdgpu_virtual_memory_state_t {
+  // Unowned HSA dynamic-library table used for VMM calls.
+  const iree_hal_amdgpu_libhsa_t* libhsa;
+
+  // Unowned topology used to grant access to selected queue agents.
+  const iree_hal_amdgpu_topology_t* topology;
+
+  // Host allocator used for VMM bookkeeping.
+  iree_allocator_t host_allocator;
+
+  // Serializes reservation, mapping, and physical-memory ownership changes.
+  iree_slim_mutex_t mutex;
+
+  // Registry of live virtual-address reservations.
+  iree_hal_amdgpu_virtual_memory_reservation_t* reservations;
+
+  // Registry of live physical-to-virtual mappings.
+  iree_hal_amdgpu_virtual_memory_mapping_t* mappings;
+
+  // Number of physical-memory handles that have not been freed.
+  iree_host_size_t physical_memory_count;
+};
+
+static bool iree_hal_amdgpu_virtual_memory_is_aligned(
+    iree_device_size_t value, iree_device_size_t alignment) {
+  return alignment != 0 && value % alignment == 0;
+}
+
+static bool iree_hal_amdgpu_virtual_memory_range_is_valid(
+    iree_device_size_t total_size, iree_device_size_t offset,
+    iree_device_size_t size, iree_device_size_t alignment) {
+  return size != 0 &&
+         iree_hal_amdgpu_virtual_memory_is_aligned(offset, alignment) &&
+         iree_hal_amdgpu_virtual_memory_is_aligned(size, alignment) &&
+         offset <= total_size && size <= total_size - offset;
+}
+
+static iree_status_t iree_hal_amdgpu_virtual_memory_validate_placement(
+    iree_hal_amdgpu_virtual_memory_placement_t placement) {
+  if (IREE_UNLIKELY(!placement.memory_pool.handle)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU VMM placement has no HSA memory pool");
+  }
+  if (IREE_UNLIKELY(!placement.device)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU VMM placement has no HAL device");
+  }
+  if (IREE_UNLIKELY(
+          !iree_device_size_is_valid_alignment(placement.allocation_granule))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU VMM placement has invalid allocation "
+                            "granule %" PRIu64,
+                            (uint64_t)placement.allocation_granule);
+  }
+  if (IREE_UNLIKELY(placement.max_allocation_size == 0)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU VMM placement has no allocation limit");
+  }
+  return iree_ok_status();
+}
+
+static iree_hal_amdgpu_virtual_memory_reservation_t*
+iree_hal_amdgpu_virtual_memory_find_reservation_locked(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_buffer_t* virtual_buffer) {
+  for (iree_hal_amdgpu_virtual_memory_reservation_t* reservation =
+           state->reservations;
+       reservation; reservation = reservation->next) {
+    if (reservation->virtual_buffer == virtual_buffer) return reservation;
+  }
+  return NULL;
+}
+
+static bool iree_hal_amdgpu_virtual_memory_has_mapping_locked(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_amdgpu_virtual_memory_reservation_t* reservation) {
+  for (iree_hal_amdgpu_virtual_memory_mapping_t* mapping = state->mappings;
+       mapping; mapping = mapping->next) {
+    if (mapping->reservation == reservation) return true;
+  }
+  return false;
+}
+
+static iree_hal_amdgpu_virtual_memory_mapping_t*
+iree_hal_amdgpu_virtual_memory_find_exact_mapping_locked(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_amdgpu_virtual_memory_reservation_t* reservation,
+    iree_device_size_t virtual_offset, iree_device_size_t size) {
+  for (iree_hal_amdgpu_virtual_memory_mapping_t* mapping = state->mappings;
+       mapping; mapping = mapping->next) {
+    if (mapping->reservation == reservation &&
+        mapping->virtual_offset == virtual_offset && mapping->size == size) {
+      return mapping;
+    }
+  }
+  return NULL;
+}
+
+static bool iree_hal_amdgpu_virtual_memory_ranges_overlap(
+    iree_device_size_t lhs_offset, iree_device_size_t lhs_size,
+    iree_device_size_t rhs_offset, iree_device_size_t rhs_size) {
+  const iree_device_size_t lhs_end = lhs_offset + lhs_size;
+  const iree_device_size_t rhs_end = rhs_offset + rhs_size;
+  return lhs_offset < rhs_end && rhs_offset < lhs_end;
+}
+
+static bool iree_hal_amdgpu_virtual_memory_has_overlapping_mapping_locked(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_amdgpu_virtual_memory_reservation_t* reservation,
+    iree_device_size_t virtual_offset, iree_device_size_t size) {
+  for (iree_hal_amdgpu_virtual_memory_mapping_t* mapping = state->mappings;
+       mapping; mapping = mapping->next) {
+    if (mapping->reservation == reservation &&
+        iree_hal_amdgpu_virtual_memory_ranges_overlap(
+            virtual_offset, size, mapping->virtual_offset, mapping->size)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static hsa_access_permission_t
+iree_hal_amdgpu_virtual_memory_translate_protection(
+    iree_hal_memory_protection_t protection, bool* out_is_valid) {
+  *out_is_valid = true;
+  switch (protection) {
+    case IREE_HAL_MEMORY_PROTECTION_NONE:
+      return HSA_ACCESS_PERMISSION_NONE;
+    case IREE_HAL_MEMORY_PROTECTION_READ:
+      return HSA_ACCESS_PERMISSION_RO;
+    case IREE_HAL_MEMORY_PROTECTION_WRITE:
+      return HSA_ACCESS_PERMISSION_WO;
+    case IREE_HAL_MEMORY_PROTECTION_READ_WRITE:
+      return HSA_ACCESS_PERMISSION_RW;
+    default:
+      *out_is_valid = false;
+      return HSA_ACCESS_PERMISSION_NONE;
+  }
+}
+
+static void iree_hal_amdgpu_virtual_memory_release_reservation(
+    void* user_data, iree_hal_buffer_t* virtual_buffer) {
+  (void)virtual_buffer;
+  iree_hal_amdgpu_virtual_memory_reservation_t* reservation =
+      (iree_hal_amdgpu_virtual_memory_reservation_t*)user_data;
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_hal_amdgpu_hsa_cleanup_assert_success(iree_hsa_amd_vmem_address_free_raw(
+      reservation->state->libhsa, reservation->base_ptr, reservation->size));
+  iree_allocator_free(reservation->state->host_allocator, reservation);
+  IREE_TRACE_ZONE_END(z0);
+}
+
+iree_status_t iree_hal_amdgpu_virtual_memory_state_create(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    const iree_hal_amdgpu_topology_t* topology, iree_allocator_t host_allocator,
+    iree_hal_amdgpu_virtual_memory_state_t** out_state) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(topology);
+  IREE_ASSERT_ARGUMENT(out_state);
+  *out_state = NULL;
+
+  iree_hal_amdgpu_virtual_memory_state_t* state = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(host_allocator, sizeof(*state), (void**)&state));
+  memset(state, 0, sizeof(*state));
+  state->libhsa = libhsa;
+  state->topology = topology;
+  state->host_allocator = host_allocator;
+  iree_slim_mutex_initialize(&state->mutex);
+  *out_state = state;
+  return iree_ok_status();
+}
+
+void iree_hal_amdgpu_virtual_memory_state_destroy(
+    iree_hal_amdgpu_virtual_memory_state_t* state) {
+  if (!state) return;
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_ASSERT(state->reservations == NULL,
+              "destroying AMDGPU VMM state with live reservations");
+  IREE_ASSERT(state->mappings == NULL,
+              "destroying AMDGPU VMM state with live mappings");
+  IREE_ASSERT(state->physical_memory_count == 0,
+              "destroying AMDGPU VMM state with live physical allocations");
+  iree_slim_mutex_deinitialize(&state->mutex);
+  iree_allocator_free(state->host_allocator, state);
+  IREE_TRACE_ZONE_END(z0);
+}
+
+iree_status_t iree_hal_amdgpu_virtual_memory_reserve(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_amdgpu_virtual_memory_placement_t placement,
+    iree_device_size_t size, iree_hal_buffer_t** out_virtual_buffer) {
+  IREE_ASSERT_ARGUMENT(state);
+  IREE_ASSERT_ARGUMENT(out_virtual_buffer);
+  *out_virtual_buffer = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_virtual_memory_validate_placement(placement));
+  if (IREE_UNLIKELY(!iree_hal_amdgpu_virtual_memory_range_is_valid(
+          size, /*offset=*/0, size, placement.allocation_granule))) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU virtual-memory reservation size %" PRIu64
+        " must be a non-zero multiple of VMM granule %" PRIu64,
+        (uint64_t)size, (uint64_t)placement.allocation_granule);
+  }
+
+  iree_hal_amdgpu_virtual_memory_reservation_t* reservation = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+      state->host_allocator, sizeof(*reservation), (void**)&reservation));
+  memset(reservation, 0, sizeof(*reservation));
+  reservation->state = state;
+  reservation->size = size;
+  reservation->allocation_granule = placement.allocation_granule;
+  reservation->queue_affinity = placement.queue_affinity;
+
+  const iree_device_size_t reservation_alignment = placement.allocation_granule;
+  iree_status_t status = iree_hsa_amd_vmem_address_reserve_align(
+      IREE_LIBHSA(state->libhsa), &reservation->base_ptr, size,
+      /*address=*/0, reservation_alignment, /*flags=*/0);
+  if (iree_status_is_ok(status) &&
+      (uintptr_t)reservation->base_ptr % reservation_alignment != 0) {
+    status =
+        iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                         "AMDGPU VMM reservation has insufficient alignment");
+  }
+  if (iree_status_is_ok(status)) {
+    const iree_hal_buffer_placement_t buffer_placement = {
+        .device = placement.device,
+        .queue_affinity = placement.queue_affinity,
+        .flags = IREE_HAL_BUFFER_PLACEMENT_FLAG_NONE,
+    };
+    status = iree_hal_amdgpu_buffer_create(
+        state->libhsa, buffer_placement, placement.memory_type,
+        IREE_HAL_MEMORY_ACCESS_ALL, placement.buffer_usage, size, size,
+        reservation->base_ptr,
+        (iree_hal_buffer_release_callback_t){
+            .fn = iree_hal_amdgpu_virtual_memory_release_reservation,
+            .user_data = reservation,
+        },
+        state->host_allocator, &reservation->virtual_buffer);
+  }
+
+  if (iree_status_is_ok(status)) {
+    iree_slim_mutex_lock(&state->mutex);
+    reservation->next = state->reservations;
+    state->reservations = reservation;
+    iree_slim_mutex_unlock(&state->mutex);
+    *out_virtual_buffer = reservation->virtual_buffer;
+  } else {
+    if (reservation->base_ptr) {
+      iree_hal_amdgpu_hsa_cleanup_assert_success(
+          iree_hsa_amd_vmem_address_free_raw(state->libhsa,
+                                             reservation->base_ptr, size));
+    }
+    iree_allocator_free(state->host_allocator, reservation);
+  }
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_virtual_memory_release(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_buffer_t* virtual_buffer) {
+  IREE_ASSERT_ARGUMENT(state);
+  IREE_ASSERT_ARGUMENT(virtual_buffer);
+
+  iree_slim_mutex_lock(&state->mutex);
+  iree_status_t status = iree_ok_status();
+  iree_hal_amdgpu_virtual_memory_reservation_t** reservation_ptr =
+      &state->reservations;
+  while (*reservation_ptr &&
+         (*reservation_ptr)->virtual_buffer != virtual_buffer) {
+    reservation_ptr = &(*reservation_ptr)->next;
+  }
+  if (!*reservation_ptr) {
+    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "virtual buffer does not belong to this AMDGPU "
+                              "VMM state");
+  } else if (iree_hal_amdgpu_virtual_memory_has_mapping_locked(
+                 state, *reservation_ptr)) {
+    status = iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                              "AMDGPU virtual-memory reservation must be "
+                              "fully unmapped before release");
+  } else {
+    *reservation_ptr = (*reservation_ptr)->next;
+  }
+  iree_slim_mutex_unlock(&state->mutex);
+
+  if (iree_status_is_ok(status)) {
+    iree_hal_buffer_destroy(virtual_buffer);
+  }
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_physical_memory_allocate(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_amdgpu_virtual_memory_placement_t placement,
+    iree_device_size_t size, iree_allocator_t host_allocator,
+    iree_hal_physical_memory_t** out_physical_memory) {
+  IREE_ASSERT_ARGUMENT(state);
+  IREE_ASSERT_ARGUMENT(out_physical_memory);
+  *out_physical_memory = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_virtual_memory_validate_placement(placement));
+  if (IREE_UNLIKELY(!iree_hal_amdgpu_virtual_memory_range_is_valid(
+          size, /*offset=*/0, size, placement.allocation_granule))) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "AMDGPU physical-memory allocation size %" PRIu64
+        " must be a non-zero multiple of VMM granule %" PRIu64,
+        (uint64_t)size, (uint64_t)placement.allocation_granule);
+  }
+  if (IREE_UNLIKELY(size > placement.max_allocation_size)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "AMDGPU physical-memory allocation size %" PRIu64
+                            " exceeds pool allocation limit %" PRIu64,
+                            (uint64_t)size,
+                            (uint64_t)placement.max_allocation_size);
+  }
+
+  // VMM physical handles must remain resident while their mappings are live.
+  // The selected pool carries the cache policy, including uncached placement.
+  hsa_amd_memory_type_t hsa_memory_type = MEMORY_TYPE_NONE;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_vmem_translate_memory_type(
+      IREE_HAL_AMDGPU_VMEM_MEMORY_TYPE_PINNED_HOST, &hsa_memory_type));
+
+  iree_hal_physical_memory_t* physical_memory = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+      host_allocator, sizeof(*physical_memory), (void**)&physical_memory));
+  memset(physical_memory, 0, sizeof(*physical_memory));
+  physical_memory->host_allocator = host_allocator;
+  physical_memory->state = state;
+  physical_memory->allocation_size = size;
+  physical_memory->allocation_granule = placement.allocation_granule;
+
+  iree_status_t status = iree_hsa_amd_vmem_handle_create(
+      IREE_LIBHSA(state->libhsa), placement.memory_pool, size, hsa_memory_type,
+      /*flags=*/0, &physical_memory->allocation_handle);
+  if (iree_status_is_ok(status)) {
+    iree_slim_mutex_lock(&state->mutex);
+    ++state->physical_memory_count;
+    iree_slim_mutex_unlock(&state->mutex);
+    *out_physical_memory = physical_memory;
+  } else {
+    iree_allocator_free(host_allocator, physical_memory);
+  }
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_physical_memory_free(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_physical_memory_t* physical_memory) {
+  IREE_ASSERT_ARGUMENT(state);
+  IREE_ASSERT_ARGUMENT(physical_memory);
+  if (physical_memory->state != state) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "physical memory belongs to a different AMDGPU "
+                            "VMM state");
+  }
+
+  iree_slim_mutex_lock(&state->mutex);
+  iree_status_t status = iree_ok_status();
+  if (physical_memory->mapped_size != 0) {
+    status = iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "AMDGPU physical-memory allocation still has %" PRIu64 " mapped bytes",
+        (uint64_t)physical_memory->mapped_size);
+  } else {
+    IREE_ASSERT(state->physical_memory_count > 0);
+    --state->physical_memory_count;
+  }
+  iree_slim_mutex_unlock(&state->mutex);
+
+  if (iree_status_is_ok(status)) {
+    iree_hal_amdgpu_hsa_cleanup_assert_success(
+        iree_hsa_amd_vmem_handle_release_raw(
+            state->libhsa, physical_memory->allocation_handle));
+    iree_allocator_free(physical_memory->host_allocator, physical_memory);
+  }
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_virtual_memory_map(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_buffer_t* virtual_buffer, iree_device_size_t virtual_offset,
+    iree_hal_physical_memory_t* physical_memory,
+    iree_device_size_t physical_offset, iree_device_size_t size) {
+  IREE_ASSERT_ARGUMENT(state);
+  IREE_ASSERT_ARGUMENT(virtual_buffer);
+  IREE_ASSERT_ARGUMENT(physical_memory);
+  if (physical_memory->state != state) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "physical memory belongs to a different AMDGPU "
+                            "VMM state");
+  }
+  if (IREE_UNLIKELY(physical_offset != 0 ||
+                    size != physical_memory->allocation_size)) {
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "AMDGPU VMM requires each mapping to cover one complete physical "
+        "memory allocation");
+  }
+
+  iree_hal_amdgpu_virtual_memory_mapping_t* mapping = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+      state->host_allocator, sizeof(*mapping), (void**)&mapping));
+  memset(mapping, 0, sizeof(*mapping));
+
+  iree_slim_mutex_lock(&state->mutex);
+  iree_status_t status = iree_ok_status();
+  iree_hal_amdgpu_virtual_memory_reservation_t* reservation =
+      iree_hal_amdgpu_virtual_memory_find_reservation_locked(state,
+                                                             virtual_buffer);
+  if (!reservation) {
+    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "virtual buffer does not belong to this AMDGPU "
+                              "VMM state");
+  } else if (!iree_hal_amdgpu_virtual_memory_range_is_valid(
+                 reservation->size, virtual_offset, size,
+                 reservation->allocation_granule)) {
+    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "AMDGPU virtual-memory map range is not a "
+                              "valid reservation-aligned range");
+  } else if (!iree_hal_amdgpu_virtual_memory_is_aligned(
+                 size, physical_memory->allocation_granule)) {
+    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "AMDGPU physical-memory map size is not aligned");
+  } else if (iree_hal_amdgpu_virtual_memory_has_overlapping_mapping_locked(
+                 state, reservation, virtual_offset, size)) {
+    status = iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                              "AMDGPU virtual-memory map range overlaps an "
+                              "existing mapping");
+  }
+  if (iree_status_is_ok(status)) {
+    void* map_ptr = (uint8_t*)reservation->base_ptr + virtual_offset;
+    status = iree_hsa_amd_vmem_map(
+        IREE_LIBHSA(state->libhsa), map_ptr, size, /*in_offset=*/0,
+        physical_memory->allocation_handle, /*flags=*/0);
+  }
+  if (iree_status_is_ok(status)) {
+    mapping->reservation = reservation;
+    mapping->physical_memory = physical_memory;
+    mapping->virtual_offset = virtual_offset;
+    mapping->size = size;
+    mapping->next = state->mappings;
+    state->mappings = mapping;
+    IREE_ASSERT(physical_memory->mapped_size <= IREE_DEVICE_SIZE_MAX - size);
+    physical_memory->mapped_size += size;
+    mapping = NULL;
+  }
+  iree_slim_mutex_unlock(&state->mutex);
+  iree_allocator_free(state->host_allocator, mapping);
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_virtual_memory_unmap(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_buffer_t* virtual_buffer, iree_device_size_t virtual_offset,
+    iree_device_size_t size) {
+  IREE_ASSERT_ARGUMENT(state);
+  IREE_ASSERT_ARGUMENT(virtual_buffer);
+
+  iree_slim_mutex_lock(&state->mutex);
+  iree_status_t status = iree_ok_status();
+  iree_hal_amdgpu_virtual_memory_reservation_t* reservation =
+      iree_hal_amdgpu_virtual_memory_find_reservation_locked(state,
+                                                             virtual_buffer);
+  iree_hal_amdgpu_virtual_memory_mapping_t* mapping = NULL;
+  iree_hal_amdgpu_virtual_memory_mapping_t** mapping_ptr = NULL;
+  if (!reservation) {
+    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "virtual buffer does not belong to this AMDGPU "
+                              "VMM state");
+  } else if (!iree_hal_amdgpu_virtual_memory_range_is_valid(
+                 reservation->size, virtual_offset, size,
+                 reservation->allocation_granule)) {
+    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "AMDGPU virtual-memory unmap range is not a "
+                              "valid reservation-aligned range");
+  } else {
+    mapping_ptr = &state->mappings;
+    while (*mapping_ptr && ((*mapping_ptr)->reservation != reservation ||
+                            (*mapping_ptr)->virtual_offset != virtual_offset ||
+                            (*mapping_ptr)->size != size)) {
+      mapping_ptr = &(*mapping_ptr)->next;
+    }
+    mapping = *mapping_ptr;
+    if (!mapping) {
+      if (iree_hal_amdgpu_virtual_memory_has_overlapping_mapping_locked(
+              state, reservation, virtual_offset, size)) {
+        status = iree_make_status(
+            IREE_STATUS_UNIMPLEMENTED,
+            "AMDGPU VMM can only unmap complete physical-memory mappings");
+      } else {
+        status = iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                                  "AMDGPU virtual-memory range is not mapped");
+      }
+    }
+  }
+  if (iree_status_is_ok(status)) {
+    void* map_ptr = (uint8_t*)reservation->base_ptr + virtual_offset;
+    status = iree_hsa_amd_vmem_unmap(IREE_LIBHSA(state->libhsa), map_ptr, size);
+  }
+  if (iree_status_is_ok(status)) {
+    IREE_ASSERT(mapping->physical_memory->mapped_size >= size);
+    mapping->physical_memory->mapped_size -= size;
+    *mapping_ptr = mapping->next;
+  }
+  iree_slim_mutex_unlock(&state->mutex);
+  if (iree_status_is_ok(status)) {
+    iree_allocator_free(state->host_allocator, mapping);
+  }
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_virtual_memory_protect(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_buffer_t* virtual_buffer, iree_device_size_t virtual_offset,
+    iree_device_size_t size, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_memory_protection_t protection) {
+  IREE_ASSERT_ARGUMENT(state);
+  IREE_ASSERT_ARGUMENT(virtual_buffer);
+
+  bool is_valid_protection = false;
+  const hsa_access_permission_t permissions =
+      iree_hal_amdgpu_virtual_memory_translate_protection(protection,
+                                                          &is_valid_protection);
+  if (!is_valid_protection) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid AMDGPU virtual-memory protection flags");
+  }
+
+  iree_slim_mutex_lock(&state->mutex);
+  iree_status_t status = iree_ok_status();
+  iree_hal_amdgpu_virtual_memory_reservation_t* reservation =
+      iree_hal_amdgpu_virtual_memory_find_reservation_locked(state,
+                                                             virtual_buffer);
+  iree_hal_amdgpu_virtual_memory_mapping_t* mapping = NULL;
+  if (!reservation) {
+    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "virtual buffer does not belong to this AMDGPU "
+                              "VMM state");
+  } else if (!iree_hal_amdgpu_virtual_memory_range_is_valid(
+                 reservation->size, virtual_offset, size,
+                 reservation->allocation_granule)) {
+    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "AMDGPU virtual-memory protect range is not a "
+                              "valid reservation-aligned range");
+  } else {
+    mapping = iree_hal_amdgpu_virtual_memory_find_exact_mapping_locked(
+        state, reservation, virtual_offset, size);
+    if (!mapping) {
+      if (iree_hal_amdgpu_virtual_memory_has_overlapping_mapping_locked(
+              state, reservation, virtual_offset, size)) {
+        status = iree_make_status(
+            IREE_STATUS_UNIMPLEMENTED,
+            "AMDGPU VMM can only protect complete physical-memory mappings");
+      } else {
+        status = iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                                  "AMDGPU virtual-memory range is not mapped");
+      }
+    }
+  }
+
+  iree_hal_amdgpu_access_agent_list_t agent_list;
+  hsa_amd_memory_access_desc_t access_descs[IREE_HAL_AMDGPU_MAX_CPU_AGENT +
+                                            IREE_HAL_AMDGPU_MAX_GPU_AGENT];
+  if (iree_status_is_ok(status)) {
+    const iree_hal_amdgpu_queue_affinity_domain_t domain = {
+        .supported_affinity = reservation->queue_affinity,
+        .physical_device_count = state->topology->gpu_agent_count,
+        .queue_count_per_physical_device =
+            state->topology->gpu_agent_queue_count,
+    };
+    status = iree_hal_amdgpu_access_agent_list_resolve(
+        state->topology, domain, queue_affinity, &agent_list);
+  }
+  if (iree_status_is_ok(status)) {
+    for (uint32_t i = 0; i < agent_list.count; ++i) {
+      access_descs[i] = (hsa_amd_memory_access_desc_t){
+          .permissions = permissions,
+          .agent_handle = agent_list.values[i],
+      };
+    }
+    void* map_ptr = (uint8_t*)reservation->base_ptr + virtual_offset;
+    status = iree_hsa_amd_vmem_set_access(IREE_LIBHSA(state->libhsa), map_ptr,
+                                          mapping->size, access_descs,
+                                          agent_list.count);
+  }
+  iree_slim_mutex_unlock(&state->mutex);
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_virtual_memory_advise(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_buffer_t* virtual_buffer, iree_device_size_t virtual_offset,
+    iree_device_size_t size, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_memory_advice_t advice) {
+  (void)queue_affinity;
+  (void)advice;
+  IREE_ASSERT_ARGUMENT(state);
+  IREE_ASSERT_ARGUMENT(virtual_buffer);
+
+  iree_slim_mutex_lock(&state->mutex);
+  iree_status_t status = iree_ok_status();
+  iree_hal_amdgpu_virtual_memory_reservation_t* reservation =
+      iree_hal_amdgpu_virtual_memory_find_reservation_locked(state,
+                                                             virtual_buffer);
+  if (!reservation) {
+    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "virtual buffer does not belong to this AMDGPU "
+                              "VMM state");
+  } else if (virtual_offset > reservation->size ||
+             size > reservation->size - virtual_offset) {
+    status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "AMDGPU virtual-memory advice range exceeds "
+                              "the reservation");
+  }
+  iree_slim_mutex_unlock(&state->mutex);
+  return status;
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.h
@@ -38,20 +38,25 @@ typedef struct iree_hal_amdgpu_virtual_memory_placement_t {
   // HAL buffer usage exposed by the virtual buffer.
   iree_hal_buffer_usage_t buffer_usage;
 
-  // Minimum HSA VMM granule for this memory pool.
-  iree_device_size_t allocation_granule;
+  // Smallest legal HSA VMM allocation and mapping multiple.
+  iree_device_size_t minimum_granule;
+
+  // Preferred HSA VMM allocation multiple for reducing fragmentation.
+  iree_device_size_t recommended_granule;
 
   // Maximum physical allocation size accepted by this memory pool.
   iree_device_size_t max_allocation_size;
 } iree_hal_amdgpu_virtual_memory_placement_t;
 
-// Creates generic virtual-memory bookkeeping for one AMDGPU allocator.
+// Creates the virtual-memory context for one AMDGPU allocator.
 iree_status_t iree_hal_amdgpu_virtual_memory_state_create(
     const iree_hal_amdgpu_libhsa_t* libhsa,
-    const iree_hal_amdgpu_topology_t* topology, iree_allocator_t host_allocator,
+    const iree_hal_amdgpu_topology_t* topology, iree_hal_device_t* device,
+    iree_hal_allocator_statistics_t* statistics,
+    iree_allocator_t host_allocator,
     iree_hal_amdgpu_virtual_memory_state_t** out_state);
 
-// Destroys allocator-owned VMM bookkeeping after all handles are released.
+// Destroys an allocator-owned VMM context after all handles are released.
 void iree_hal_amdgpu_virtual_memory_state_destroy(
     iree_hal_amdgpu_virtual_memory_state_t* state);
 

--- a/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.h
@@ -1,0 +1,113 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_VIRTUAL_MEMORY_H_
+#define IREE_HAL_DRIVERS_AMDGPU_VIRTUAL_MEMORY_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/allocator.h"
+#include "iree/hal/drivers/amdgpu/util/libhsa.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct iree_hal_amdgpu_topology_t iree_hal_amdgpu_topology_t;
+typedef struct iree_hal_amdgpu_virtual_memory_state_t
+    iree_hal_amdgpu_virtual_memory_state_t;
+
+// Placement and capability information selected by the AMDGPU allocator.
+// The virtual-memory component consumes this representation without owning the
+// allocator's broader pool-selection policy.
+typedef struct iree_hal_amdgpu_virtual_memory_placement_t {
+  // HSA memory pool used for the physical allocation.
+  hsa_amd_memory_pool_t memory_pool;
+
+  // HAL device that owns virtual-buffer placement metadata.
+  iree_hal_device_t* device;
+
+  // HAL queues permitted to access the virtual address range.
+  iree_hal_queue_affinity_t queue_affinity;
+
+  // HAL memory type exposed by the virtual buffer and physical allocation.
+  iree_hal_memory_type_t memory_type;
+
+  // HAL buffer usage exposed by the virtual buffer.
+  iree_hal_buffer_usage_t buffer_usage;
+
+  // Minimum HSA VMM granule for this memory pool.
+  iree_device_size_t allocation_granule;
+
+  // Maximum physical allocation size accepted by this memory pool.
+  iree_device_size_t max_allocation_size;
+} iree_hal_amdgpu_virtual_memory_placement_t;
+
+// Creates generic virtual-memory bookkeeping for one AMDGPU allocator.
+iree_status_t iree_hal_amdgpu_virtual_memory_state_create(
+    const iree_hal_amdgpu_libhsa_t* libhsa,
+    const iree_hal_amdgpu_topology_t* topology, iree_allocator_t host_allocator,
+    iree_hal_amdgpu_virtual_memory_state_t** out_state);
+
+// Destroys allocator-owned VMM bookkeeping after all handles are released.
+void iree_hal_amdgpu_virtual_memory_state_destroy(
+    iree_hal_amdgpu_virtual_memory_state_t* state);
+
+// Reserves a virtual buffer with no physical backing or access permissions.
+iree_status_t iree_hal_amdgpu_virtual_memory_reserve(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_amdgpu_virtual_memory_placement_t placement,
+    iree_device_size_t size, iree_hal_buffer_t** out_virtual_buffer);
+
+// Releases an unmapped virtual buffer returned by virtual_memory_reserve.
+iree_status_t iree_hal_amdgpu_virtual_memory_release(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_buffer_t* virtual_buffer);
+
+// Creates a physical allocation that can be mapped into one or more virtual
+// buffers associated with this state.
+iree_status_t iree_hal_amdgpu_physical_memory_allocate(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_amdgpu_virtual_memory_placement_t placement,
+    iree_device_size_t size, iree_allocator_t host_allocator,
+    iree_hal_physical_memory_t** out_physical_memory);
+
+// Releases an unmapped physical allocation.
+iree_status_t iree_hal_amdgpu_physical_memory_free(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_physical_memory_t* physical_memory);
+
+// Maps physical memory into an unmapped virtual address range.
+iree_status_t iree_hal_amdgpu_virtual_memory_map(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_buffer_t* virtual_buffer, iree_device_size_t virtual_offset,
+    iree_hal_physical_memory_t* physical_memory,
+    iree_device_size_t physical_offset, iree_device_size_t size);
+
+// Unmaps a fully mapped virtual address range.
+iree_status_t iree_hal_amdgpu_virtual_memory_unmap(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_buffer_t* virtual_buffer, iree_device_size_t virtual_offset,
+    iree_device_size_t size);
+
+// Sets the requested access permissions on a mapped virtual address range.
+iree_status_t iree_hal_amdgpu_virtual_memory_protect(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_buffer_t* virtual_buffer, iree_device_size_t virtual_offset,
+    iree_device_size_t size, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_memory_protection_t protection);
+
+// Validates an advisory virtual-address range and otherwise performs no work.
+iree_status_t iree_hal_amdgpu_virtual_memory_advise(
+    iree_hal_amdgpu_virtual_memory_state_t* state,
+    iree_hal_buffer_t* virtual_buffer, iree_device_size_t virtual_offset,
+    iree_device_size_t size, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_memory_advice_t advice);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_VIRTUAL_MEMORY_H_

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
@@ -253,6 +253,10 @@ iree_hal_cuda_allocator_query_buffer_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     iree_hal_buffer_params_t* IREE_RESTRICT params,
     iree_device_size_t* IREE_RESTRICT allocation_size) {
+  if (iree_any_bit_set(params->type, IREE_HAL_MEMORY_TYPE_DEVICE_UNCACHED)) {
+    return IREE_HAL_BUFFER_COMPATIBILITY_NONE;
+  }
+
   iree_hal_cuda_allocator_t* allocator =
       iree_hal_cuda_allocator_cast(base_allocator);
 

--- a/runtime/src/iree/hal/drivers/hip/hip_allocator.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_allocator.c
@@ -332,6 +332,10 @@ iree_hal_hip_allocator_query_buffer_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     iree_hal_buffer_params_t* IREE_RESTRICT params,
     iree_device_size_t* IREE_RESTRICT allocation_size) {
+  if (iree_any_bit_set(params->type, IREE_HAL_MEMORY_TYPE_DEVICE_UNCACHED)) {
+    return IREE_HAL_BUFFER_COMPATIBILITY_NONE;
+  }
+
   iree_hal_hip_allocator_t* allocator =
       iree_hal_hip_allocator_cast(base_allocator);
 

--- a/runtime/src/iree/hal/drivers/local_task/task_queue.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_queue.c
@@ -1692,6 +1692,7 @@ static iree_status_t iree_hal_task_queue_drain_host_call(
                                      operation->host_call.args, &context);
     if (is_nonblocking || iree_status_is_deferred(call_status)) {
       // User callback will signal in the future (or fire-and-forget).
+      iree_status_free(call_status);
     } else if (iree_status_is_ok(call_status)) {
       // Signal callback completed synchronously.
       if (!is_nonblocking) {
@@ -3498,8 +3499,11 @@ iree_status_t iree_hal_task_queue_submit_host_call(
   memcpy(operation->host_call.args, args, sizeof(operation->host_call.args));
   operation->host_call.flags = flags;
 
+  iree_hal_resource_t* operation_resources[1] = {
+      call.resource,
+  };
   status = iree_hal_task_queue_submit_op_finish(
-      operation, wait_semaphores, /*resource_count=*/0, /*resources=*/NULL);
+      operation, wait_semaphores, call.resource ? 1 : 0, operation_resources);
 
   IREE_TRACE_ZONE_END(z0);
   return status;

--- a/runtime/src/iree/hal/drivers/metal/direct_allocator.m
+++ b/runtime/src/iree/hal/drivers/metal/direct_allocator.m
@@ -145,6 +145,10 @@ static iree_hal_buffer_compatibility_t iree_hal_metal_allocator_query_buffer_com
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     iree_hal_buffer_params_t* IREE_RESTRICT params,
     iree_device_size_t* IREE_RESTRICT allocation_size) {
+  if (iree_any_bit_set(params->type, IREE_HAL_MEMORY_TYPE_DEVICE_UNCACHED)) {
+    return IREE_HAL_BUFFER_COMPATIBILITY_NONE;
+  }
+
   // All buffers can be allocated on the heap.
   iree_hal_buffer_compatibility_t compatibility = IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE;
 

--- a/runtime/src/iree/hal/drivers/vulkan/queue.c
+++ b/runtime/src/iree/hal/drivers/vulkan/queue.c
@@ -3678,6 +3678,7 @@ static iree_status_t iree_hal_vulkan_queue_pending_submission_create(
   }
   if (kind == IREE_HAL_VULKAN_QUEUE_SUBMISSION_KIND_HOST_CALL) {
     submission->host_call.call = call;
+    iree_hal_resource_retain(submission->host_call.call.resource);
     memcpy(submission->host_call.args, args,
            sizeof(submission->host_call.args));
     submission->host_call.flags = flags;
@@ -3776,7 +3777,9 @@ static void iree_hal_vulkan_queue_pending_submission_destroy(
       }
       break;
     case IREE_HAL_VULKAN_QUEUE_SUBMISSION_KIND_BARRIER:
+      break;
     case IREE_HAL_VULKAN_QUEUE_SUBMISSION_KIND_HOST_CALL:
+      iree_hal_resource_release(submission->host_call.call.resource);
       break;
   }
 

--- a/runtime/src/iree/hal/drivers/webgpu/webgpu_allocator.c
+++ b/runtime/src/iree/hal/drivers/webgpu/webgpu_allocator.c
@@ -234,6 +234,10 @@ iree_hal_webgpu_allocator_query_buffer_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     iree_hal_buffer_params_t* IREE_RESTRICT params,
     iree_device_size_t* IREE_RESTRICT allocation_size) {
+  if (iree_any_bit_set(params->type, IREE_HAL_MEMORY_TYPE_DEVICE_UNCACHED)) {
+    return IREE_HAL_BUFFER_COMPATIBILITY_NONE;
+  }
+
   iree_hal_buffer_compatibility_t compatibility =
       IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE;
 

--- a/runtime/src/iree/hal/drivers/webgpu/webgpu_queue.c
+++ b/runtime/src/iree/hal/drivers/webgpu/webgpu_queue.c
@@ -1780,7 +1780,7 @@ static iree_status_t iree_hal_webgpu_queue_execute_host_call(
         .queue_affinity = queue_affinity,
         .signal_semaphore_list = iree_hal_semaphore_list_empty(),
     };
-    iree_status_ignore(call.fn(call.user_data, args, &context));
+    iree_status_free(call.fn(call.user_data, args, &context));
     return signal_status;
   }
 
@@ -1794,7 +1794,7 @@ static iree_status_t iree_hal_webgpu_queue_execute_host_call(
     return iree_hal_semaphore_list_signal(signal_semaphore_list, frontier);
   } else if (iree_status_code(call_status) == IREE_STATUS_DEFERRED) {
     // The callback has cloned the signal list and will signal later.
-    iree_status_ignore(call_status);
+    iree_status_free(call_status);
     return iree_ok_status();
   } else {
     // Fail all signal semaphores with the error.
@@ -1837,7 +1837,7 @@ static void iree_hal_webgpu_host_call_completion_fn(
     const iree_async_frontier_t* frontier =
         iree_hal_webgpu_queue_build_frontier(state->queue, state->epoch,
                                              &frontier_storage);
-    iree_status_ignore(iree_hal_webgpu_queue_execute_host_call(
+    iree_status_free(iree_hal_webgpu_queue_execute_host_call(
         state->device, state->queue_affinity, state->signal_semaphore_list,
         frontier, state->call, state->args, state->flags));
   } else {
@@ -1851,6 +1851,7 @@ static void iree_hal_webgpu_host_call_completion_fn(
   // Release both semaphore lists and free the slab.
   iree_hal_semaphore_list_release(state->signal_semaphore_list);
   iree_hal_semaphore_list_release(state->wait_semaphore_list);
+  iree_hal_resource_release(state->call.resource);
   iree_allocator_free(state->allocator, state);
 }
 
@@ -1912,6 +1913,7 @@ iree_status_t iree_hal_webgpu_queue_host_call(
 
   // Copy call parameters.
   state->call = call;
+  iree_hal_resource_retain(state->call.resource);
   memcpy(state->args, args, sizeof(state->args));
   state->flags = flags;
   state->device = device;
@@ -1956,6 +1958,7 @@ iree_status_t iree_hal_webgpu_queue_host_call(
                                  iree_status_clone(status));
     iree_hal_semaphore_list_release(state->signal_semaphore_list);
     iree_hal_semaphore_list_release(state->wait_semaphore_list);
+    iree_hal_resource_release(state->call.resource);
     iree_allocator_free(queue->host_allocator, state);
   }
   return status;

--- a/runtime/src/iree/hal/memory/tlsf.c
+++ b/runtime/src/iree/hal/memory/tlsf.c
@@ -684,6 +684,31 @@ void iree_hal_memory_tlsf_query_stats(const iree_hal_memory_tlsf_t* tlsf,
   out_stats->tainted_coalesce_count = tlsf->tainted_coalesce_count;
 }
 
+bool iree_hal_memory_tlsf_query_full_free_block(
+    const iree_hal_memory_tlsf_t* tlsf,
+    const iree_async_frontier_t** out_death_frontier,
+    iree_hal_memory_tlsf_block_flags_t* out_block_flags) {
+  IREE_ASSERT_ARGUMENT(tlsf);
+  IREE_ASSERT_ARGUMENT(out_death_frontier);
+  IREE_ASSERT_ARGUMENT(out_block_flags);
+  *out_death_frontier = NULL;
+  *out_block_flags = IREE_HAL_MEMORY_TLSF_BLOCK_FLAG_NONE;
+
+  if (tlsf->allocation_count != 0 || tlsf->free_block_count != 1 ||
+      tlsf->bytes_free != tlsf->range_length) {
+    return false;
+  }
+
+  const iree_hal_memory_tlsf_block_t* block =
+      iree_hal_memory_tlsf_block_at(tlsf, 0);
+  IREE_ASSERT(block->offset == 0);
+  IREE_ASSERT(block->length == tlsf->range_length);
+  IREE_ASSERT(block->flags & IREE_HAL_MEMORY_TLSF_BLOCK_FLAG_FREE);
+  *out_death_frontier = iree_hal_memory_tlsf_block_death_frontier(tlsf, 0);
+  *out_block_flags = block->flags;
+  return true;
+}
+
 iree_device_size_t iree_hal_memory_tlsf_largest_free_block(
     const iree_hal_memory_tlsf_t* tlsf) {
   IREE_ASSERT_ARGUMENT(tlsf);

--- a/runtime/src/iree/hal/memory/tlsf.h
+++ b/runtime/src/iree/hal/memory/tlsf.h
@@ -526,6 +526,17 @@ void iree_hal_memory_tlsf_restore(
 void iree_hal_memory_tlsf_query_stats(const iree_hal_memory_tlsf_t* tlsf,
                                       iree_hal_memory_tlsf_stats_t* out_stats);
 
+// Queries the dependency metadata of a fully free allocator range.
+//
+// Returns true only when the entire managed range has coalesced into one free
+// block. |out_death_frontier| points into TLSF-owned storage and remains valid
+// until the next allocator operation. |out_block_flags| reports whether the
+// coalesced frontier is tainted and therefore cannot prove safe reuse.
+bool iree_hal_memory_tlsf_query_full_free_block(
+    const iree_hal_memory_tlsf_t* tlsf,
+    const iree_async_frontier_t** out_death_frontier,
+    iree_hal_memory_tlsf_block_flags_t* out_block_flags);
+
 // Returns the length of the largest free block. O(1) via bitmap scan: finds
 // the highest populated FL/SL bin and reads the head block's actual length.
 // Returns 0 if no free blocks exist.

--- a/runtime/src/iree/hal/memory/tlsf_pool.c
+++ b/runtime/src/iree/hal/memory/tlsf_pool.c
@@ -28,9 +28,6 @@ typedef struct iree_hal_tlsf_pool_release_node_t {
   // Stable slab object holding |block_index|.
   struct iree_hal_tlsf_pool_slab_t* slab;
 
-  // Index of |slab| in pool->slabs.
-  uint16_t slab_index;
-
   // TLSF block handle owned by this reservation.
   iree_hal_memory_tlsf_block_index_t block_index;
 
@@ -50,6 +47,9 @@ typedef struct iree_hal_tlsf_pool_slab_t {
 
   // Physical memory backing |tlsf|'s offset range.
   iree_hal_slab_t slab;
+
+  // Current position in pool->slabs, updated after slab-array compaction.
+  uint16_t index;
 } iree_hal_tlsf_pool_slab_t;
 
 typedef struct iree_hal_tlsf_pool_allocation_t {
@@ -76,11 +76,11 @@ typedef struct iree_hal_tlsf_pool_t {
   // Template options used when initializing each new TLSF slab.
   iree_hal_memory_tlsf_options_t slab_options;
 
-  // Maximum user-visible byte length served by this pool.
-  iree_device_size_t user_slab_length;
-
   // Minimum backing byte length requested for newly grown slabs.
   iree_device_size_t backing_slab_length;
+
+  // Maximum user-visible reservation length served by the TLSF slabs.
+  iree_device_size_t max_reservation_size;
 
   // Dynamic array of committed slab pointers. Protected by |mutex|.
   iree_hal_tlsf_pool_slab_t** slabs;
@@ -313,7 +313,6 @@ static iree_status_t iree_hal_tlsf_pool_acquire_release_node(
   }
   node->next = NULL;
   node->slab = NULL;
-  node->slab_index = 0;
   node->block_index = 0;
   node->charged_length = 0;
   node->backing_offset = 0;
@@ -354,7 +353,7 @@ static void iree_hal_tlsf_pool_return_release_node_to_tlsf(
   iree_async_frontier_t* death_frontier =
       iree_hal_tlsf_pool_release_node_frontier(pool, node);
   iree_hal_tlsf_pool_slab_t* slab = node->slab;
-  const uint16_t slab_index = node->slab_index;
+  const uint16_t slab_index = slab->index;
   iree_hal_memory_tlsf_free(
       &slab->tlsf, node->block_index,
       death_frontier->entry_count > 0 ? death_frontier : NULL);
@@ -513,14 +512,15 @@ static iree_status_t iree_hal_tlsf_pool_aligned_slab_length(
       pool->slab_options.alignment
           ? pool->slab_options.alignment
           : (iree_device_size_t)IREE_HAL_MEMORY_TLSF_MIN_ALIGNMENT;
-  if (pool->backing_slab_length > IREE_DEVICE_SIZE_MAX - (alignment - 1)) {
+  const iree_device_size_t unaligned_length = pool->backing_slab_length;
+  if (unaligned_length > IREE_DEVICE_SIZE_MAX - (alignment - 1)) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "slab length %" PRIdsz
                             " overflows when aligned to %" PRIdsz,
-                            pool->backing_slab_length, alignment);
+                            unaligned_length, alignment);
   }
   const iree_device_size_t required_length =
-      iree_device_align(pool->backing_slab_length, alignment);
+      iree_device_align(unaligned_length, alignment);
   *out_slab_length = required_length;
   return iree_ok_status();
 }
@@ -570,6 +570,7 @@ static iree_status_t iree_hal_tlsf_pool_append_slab(iree_hal_tlsf_pool_t* pool,
   slab_entry->slab = slab;
 
   const uint16_t slab_index = (uint16_t)pool->slab_count;
+  slab_entry->index = slab_index;
   pool->slabs[slab_index] = slab_entry;
   ++pool->slab_count;
   pool->preferred_slab_index = slab_index;
@@ -621,7 +622,6 @@ static iree_status_t iree_hal_tlsf_pool_return_allocation(
   IREE_RETURN_IF_ERROR(
       iree_hal_tlsf_pool_acquire_release_node(pool, &release_node));
   release_node->slab = slab;
-  release_node->slab_index = pool_allocation->slab_index;
   release_node->block_index = allocation->block_index;
   release_node->charged_length = charged_length;
   release_node->backing_offset = allocation->offset;
@@ -723,8 +723,8 @@ IREE_API_EXPORT iree_status_t iree_hal_tlsf_pool_create(
   pool->epoch_query = epoch_query;
   pool->budget_limit = options.budget_limit;
   pool->slab_options = tlsf_options;
-  pool->user_slab_length = options.tlsf_options.range_length;
   pool->backing_slab_length = backing_slab_length;
+  pool->max_reservation_size = options.tlsf_options.range_length;
   pool->asan_options = options.asan;
   iree_atomic_store(&pool->bytes_committed, 0, iree_memory_order_relaxed);
   iree_atomic_store(&pool->committed_slab_count, 0, iree_memory_order_relaxed);
@@ -873,16 +873,18 @@ static iree_status_t iree_hal_tlsf_pool_acquire_reservation(
                             " exceeds TLSF pool alignment %" PRIdsz,
                             alignment, pool_alignment);
   }
-  if (size > pool->user_slab_length) {
-    return iree_status_from_code(IREE_STATUS_OUT_OF_RANGE);
-  }
-
   iree_hal_asan_allocation_layout_t asan_layout = {0};
   iree_device_size_t allocation_length = size;
   if (iree_hal_asan_pool_options_is_enabled(&pool->asan_options)) {
     IREE_RETURN_IF_ERROR(iree_hal_asan_calculate_allocation_layout(
         &pool->asan_options, size, alignment, &asan_layout));
     allocation_length = asan_layout.backing_length;
+  }
+  if (size > pool->max_reservation_size) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "reservation size %" PRIdsz
+                            " exceeds TLSF pool limit %" PRIdsz,
+                            size, pool->max_reservation_size);
   }
 
   iree_device_size_t charged_length = allocation_length;
@@ -1063,21 +1065,23 @@ static iree_status_t iree_hal_tlsf_pool_materialize_reservation(
     const iree_hal_pool_reservation_t* reservation,
     iree_hal_pool_materialize_flags_t flags, iree_hal_buffer_t** out_buffer) {
   iree_hal_tlsf_pool_t* pool = (iree_hal_tlsf_pool_t*)base_pool;
+  if (!reservation->block_handle) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "reservation has no TLSF release node");
+  }
+  // The release node owns a stable slab pointer for the reservation lifetime.
+  // A trim can compact pool->slabs after releasing an earlier empty slab, so
+  // reservation->slab_index cannot identify a live reservation here.
+  iree_hal_tlsf_pool_release_node_t* release_node =
+      (iree_hal_tlsf_pool_release_node_t*)(uintptr_t)reservation->block_handle;
+  if (!release_node->slab) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "reservation has no TLSF slab");
+  }
   iree_hal_slab_t slab;
-  iree_status_t status = iree_ok_status();
   iree_slim_mutex_lock(&pool->mutex);
-  if (reservation->slab_index < pool->slab_count) {
-    slab = pool->slabs[reservation->slab_index]->slab;
-  } else {
-    status = iree_make_status(IREE_STATUS_INTERNAL,
-                              "reservation slab_index %" PRIu16
-                              " exceeds TLSF pool slab_count %" PRIu32,
-                              reservation->slab_index, pool->slab_count);
-  }
+  slab = release_node->slab->slab;
   iree_slim_mutex_unlock(&pool->mutex);
-  if (!iree_status_is_ok(status)) {
-    return status;
-  }
 
   iree_hal_tlsf_pool_buffer_state_t* state = NULL;
   iree_hal_buffer_release_callback_t release_callback =
@@ -1093,7 +1097,7 @@ static iree_status_t iree_hal_tlsf_pool_materialize_reservation(
     release_callback.fn = iree_hal_tlsf_pool_buffer_release;
     release_callback.user_data = state;
   }
-  status = iree_hal_slab_provider_wrap_buffer(
+  iree_status_t status = iree_hal_slab_provider_wrap_buffer(
       pool->slab_provider, &slab, reservation->offset, reservation->byte_length,
       params, release_callback, out_buffer);
   if (!iree_status_is_ok(status) && state) {
@@ -1109,7 +1113,7 @@ static void iree_hal_tlsf_pool_query_capabilities(
   out_capabilities->memory_type = pool->memory_type;
   out_capabilities->supported_usage = pool->supported_usage;
   out_capabilities->min_allocation_size = 1;
-  out_capabilities->max_allocation_size = pool->user_slab_length;
+  out_capabilities->max_allocation_size = pool->max_reservation_size;
 }
 
 static void iree_hal_tlsf_pool_query_stats(const iree_hal_pool_t* base_pool,
@@ -1146,15 +1150,73 @@ static void iree_hal_tlsf_pool_query_stats(const iree_hal_pool_t* base_pool,
       (uint64_t)iree_atomic_load(&pool->wait_count, iree_memory_order_relaxed);
 }
 
-static iree_status_t iree_hal_tlsf_pool_trim(iree_hal_pool_t* base_pool) {
+static void iree_hal_tlsf_pool_release_slab_locked(iree_hal_tlsf_pool_t* pool,
+                                                   uint16_t slab_index)
+    IREE_THREAD_ANNOTATION_ATTRIBUTE(requires_capability(&pool->mutex)) {
+  iree_hal_tlsf_pool_slab_t* slab = pool->slabs[slab_index];
+  const iree_device_size_t slab_length = slab->slab.length;
+  iree_hal_memory_tlsf_deinitialize(&slab->tlsf);
+  iree_hal_slab_provider_release_slab(pool->slab_provider, &slab->slab);
+  iree_allocator_free(pool->host_allocator, slab);
+
+  const uint32_t trailing_slab_count = pool->slab_count - slab_index - 1;
+  if (trailing_slab_count) {
+    memmove(&pool->slabs[slab_index], &pool->slabs[slab_index + 1],
+            (iree_host_size_t)trailing_slab_count * sizeof(pool->slabs[0]));
+  }
+  --pool->slab_count;
+  pool->slabs[pool->slab_count] = NULL;
+  for (uint32_t i = slab_index; i < pool->slab_count; ++i) {
+    pool->slabs[i]->index = (uint16_t)i;
+  }
+  iree_atomic_store(&pool->committed_slab_count, (int32_t)pool->slab_count,
+                    iree_memory_order_release);
+  iree_atomic_fetch_sub(&pool->bytes_committed, (int64_t)slab_length,
+                        iree_memory_order_relaxed);
+}
+
+static void iree_hal_tlsf_pool_trim_unused_slabs_locked(
+    iree_hal_tlsf_pool_t* pool, iree_device_size_t min_bytes_to_keep)
+    IREE_THREAD_ANNOTATION_ATTRIBUTE(requires_capability(&pool->mutex)) {
+  uint32_t slab_index = 0;
+  while (slab_index < pool->slab_count) {
+    iree_hal_tlsf_pool_slab_t* slab = pool->slabs[slab_index];
+    iree_hal_memory_tlsf_stats_t stats;
+    iree_hal_memory_tlsf_query_stats(&slab->tlsf, &stats);
+    const iree_device_size_t committed = (iree_device_size_t)iree_atomic_load(
+        &pool->bytes_committed, iree_memory_order_relaxed);
+    if (stats.allocation_count == 0 && committed >= min_bytes_to_keep &&
+        slab->slab.length <= committed - min_bytes_to_keep) {
+      iree_hal_tlsf_pool_release_slab_locked(pool, (uint16_t)slab_index);
+      continue;
+    }
+    ++slab_index;
+  }
+  pool->preferred_slab_index = 0;
+  pool->reuse_candidate_slab_count = 0;
+  pool->reuse_candidate_slab_cursor = 0;
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_tlsf_pool_trim_to(
+    iree_hal_pool_t* base_pool, iree_device_size_t min_bytes_to_keep) {
+  if (!iree_hal_resource_is(base_pool, &iree_hal_tlsf_pool_vtable)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "pool is not a TLSF pool");
+  }
   iree_hal_tlsf_pool_t* pool = (iree_hal_tlsf_pool_t*)base_pool;
   iree_slim_mutex_lock(&pool->mutex);
   iree_hal_tlsf_pool_drain_pending_releases(pool);
+  iree_hal_tlsf_pool_flush_quarantine(pool);
+  iree_hal_tlsf_pool_trim_unused_slabs_locked(pool, min_bytes_to_keep);
   iree_hal_tlsf_pool_free_release_nodes(pool);
   iree_slim_mutex_unlock(&pool->mutex);
   iree_hal_slab_provider_trim(pool->slab_provider,
                               IREE_HAL_SLAB_PROVIDER_TRIM_FLAG_EXCESS);
   return iree_ok_status();
+}
+
+static iree_status_t iree_hal_tlsf_pool_trim(iree_hal_pool_t* base_pool) {
+  return iree_hal_tlsf_pool_trim_to(base_pool, /*min_bytes_to_keep=*/0);
 }
 
 static iree_async_notification_t* iree_hal_tlsf_pool_notification(

--- a/runtime/src/iree/hal/memory/tlsf_pool.c
+++ b/runtime/src/iree/hal/memory/tlsf_pool.c
@@ -1181,11 +1181,17 @@ static void iree_hal_tlsf_pool_trim_unused_slabs_locked(
   uint32_t slab_index = 0;
   while (slab_index < pool->slab_count) {
     iree_hal_tlsf_pool_slab_t* slab = pool->slabs[slab_index];
-    iree_hal_memory_tlsf_stats_t stats;
-    iree_hal_memory_tlsf_query_stats(&slab->tlsf, &stats);
+    const iree_async_frontier_t* death_frontier = NULL;
+    iree_hal_memory_tlsf_block_flags_t block_flags =
+        IREE_HAL_MEMORY_TLSF_BLOCK_FLAG_NONE;
+    const bool is_reclaimable =
+        iree_hal_memory_tlsf_query_full_free_block(&slab->tlsf, &death_frontier,
+                                                   &block_flags) &&
+        iree_hal_tlsf_pool_frontier_is_satisfied(
+            pool, /*requester_frontier=*/NULL, death_frontier, block_flags);
     const iree_device_size_t committed = (iree_device_size_t)iree_atomic_load(
         &pool->bytes_committed, iree_memory_order_relaxed);
-    if (stats.allocation_count == 0 && committed >= min_bytes_to_keep &&
+    if (is_reclaimable && committed >= min_bytes_to_keep &&
         slab->slab.length <= committed - min_bytes_to_keep) {
       iree_hal_tlsf_pool_release_slab_locked(pool, (uint16_t)slab_index);
       continue;

--- a/runtime/src/iree/hal/memory/tlsf_pool.h
+++ b/runtime/src/iree/hal/memory/tlsf_pool.h
@@ -24,9 +24,8 @@ extern "C" {
 // Options for creating a HAL pool that wraps iree_hal_memory_tlsf_t.
 typedef struct iree_hal_tlsf_pool_options_t {
   // Raw TLSF allocator configuration for each slab. The range length is the
-  // fixed slab size and the maximum single reservation served by this pool.
+  // fixed slab size and maximum single reservation served by this pool.
   // Live-pressure exhaustion grows by acquiring another slab of this size.
-  // Larger requests are oversized for TLSF and should route to a direct pool.
   iree_hal_memory_tlsf_options_t tlsf_options;
 
   // ASAN policy used to shape hidden backing ranges for reservations.
@@ -67,6 +66,12 @@ IREE_API_EXPORT iree_status_t iree_hal_tlsf_pool_create(
     iree_async_notification_t* notification,
     iree_hal_pool_epoch_query_t epoch_query, iree_allocator_t host_allocator,
     iree_hal_pool_t** out_pool);
+
+// Releases fully idle slabs while retaining at least |min_bytes_to_keep| of
+// committed backing. |pool| must have been created by
+// iree_hal_tlsf_pool_create.
+IREE_API_EXPORT iree_status_t iree_hal_tlsf_pool_trim_to(
+    iree_hal_pool_t* pool, iree_device_size_t min_bytes_to_keep);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/memory/tlsf_pool_test.cc
+++ b/runtime/src/iree/hal/memory/tlsf_pool_test.cc
@@ -423,6 +423,43 @@ TEST_F(TLSFPoolTest, TrimToPreservesLiveSlab) {
   iree_hal_buffer_release(buffer);
 }
 
+TEST_F(TLSFPoolTest, TrimToRetainsByteThresholdForIdleSlabs) {
+  iree_hal_pool_acquire_info_t reserve_info;
+  iree_hal_pool_acquire_result_t result;
+  iree_hal_pool_reservation_t first_reservation;
+  IREE_ASSERT_OK(iree_hal_pool_acquire_reservation(
+      pool_, 4096, 16, /*requester_frontier=*/NULL,
+      IREE_HAL_POOL_RESERVE_FLAG_NONE, &first_reservation, &reserve_info,
+      &result));
+  EXPECT_EQ(result, IREE_HAL_POOL_ACQUIRE_OK_FRESH);
+
+  iree_hal_pool_reservation_t second_reservation;
+  IREE_ASSERT_OK(iree_hal_pool_acquire_reservation(
+      pool_, 4096, 16, /*requester_frontier=*/NULL,
+      IREE_HAL_POOL_RESERVE_FLAG_NONE, &second_reservation, &reserve_info,
+      &result));
+  EXPECT_EQ(result, IREE_HAL_POOL_ACQUIRE_OK_FRESH);
+
+  iree_hal_pool_release_reservation(pool_, &first_reservation, NULL);
+  iree_hal_pool_release_reservation(pool_, &second_reservation, NULL);
+
+  iree_hal_pool_stats_t stats;
+  IREE_ASSERT_OK(iree_hal_tlsf_pool_trim_to(pool_, 4097));
+  iree_hal_pool_query_stats(pool_, &stats);
+  EXPECT_EQ(stats.slab_count, 2u);
+  EXPECT_EQ(stats.bytes_committed, 8192u);
+
+  IREE_ASSERT_OK(iree_hal_tlsf_pool_trim_to(pool_, 4096));
+  iree_hal_pool_query_stats(pool_, &stats);
+  EXPECT_EQ(stats.slab_count, 1u);
+  EXPECT_EQ(stats.bytes_committed, 4096u);
+
+  IREE_ASSERT_OK(iree_hal_tlsf_pool_trim_to(pool_, 0));
+  iree_hal_pool_query_stats(pool_, &stats);
+  EXPECT_EQ(stats.slab_count, 0u);
+  EXPECT_EQ(stats.bytes_committed, 0u);
+}
+
 TEST(TLSFPool, ReleaseNodeReuseAvoidsRepeatedHostAllocation) {
   iree_hal_test_counting_allocator_t allocator_state = {
       /*.backing_allocator=*/iree_allocator_system(),

--- a/runtime/src/iree/hal/memory/tlsf_pool_test.cc
+++ b/runtime/src/iree/hal/memory/tlsf_pool_test.cc
@@ -59,6 +59,22 @@ static iree_async_frontier_t* BuildFrontier(
   iree_async_frontier_t* name =                                         \
       BuildFrontier(name##_storage, sizeof(name##_storage), {__VA_ARGS__})
 
+typedef struct iree_hal_test_epoch_query_t {
+  // Only axis recognized by the test query.
+  iree_async_axis_t axis;
+  // Greatest epoch reported complete on |axis|.
+  uint64_t completed_epoch;
+  // Number of completion queries received.
+  iree_host_size_t query_count;
+} iree_hal_test_epoch_query_t;
+
+static bool iree_hal_test_epoch_query(void* user_data, iree_async_axis_t axis,
+                                      uint64_t epoch) {
+  iree_hal_test_epoch_query_t* query = (iree_hal_test_epoch_query_t*)user_data;
+  ++query->query_count;
+  return axis == query->axis && epoch <= query->completed_epoch;
+}
+
 typedef struct iree_hal_test_counting_allocator_t {
   // Allocator that performs the actual memory operations.
   iree_allocator_t backing_allocator;
@@ -458,6 +474,109 @@ TEST_F(TLSFPoolTest, TrimToRetainsByteThresholdForIdleSlabs) {
   iree_hal_pool_query_stats(pool_, &stats);
   EXPECT_EQ(stats.slab_count, 0u);
   EXPECT_EQ(stats.bytes_committed, 0u);
+}
+
+TEST(TLSFPool, TrimToRetainsSlabUntilDeathFrontierCompletes) {
+  iree_allocator_t allocator = iree_allocator_system();
+  iree_hal_slab_provider_t* slab_provider = NULL;
+  IREE_ASSERT_OK(iree_hal_cpu_slab_provider_create(allocator, &slab_provider));
+  iree_async_notification_t* notification = NULL;
+  IREE_ASSERT_OK(iree_async_notification_create(
+      test_proactor(), IREE_ASYNC_NOTIFICATION_FLAG_NONE, &notification));
+
+  iree_hal_test_epoch_query_t query = {
+      /*.axis=*/TestQueueAxis(0),
+      /*.completed_epoch=*/41,
+      /*.query_count=*/0,
+  };
+  iree_hal_pool_t* pool = NULL;
+  IREE_ASSERT_OK(
+      iree_hal_tlsf_pool_create(DefaultOptions(), slab_provider, notification,
+                                (iree_hal_pool_epoch_query_t){
+                                    /*.fn=*/iree_hal_test_epoch_query,
+                                    /*.user_data=*/&query,
+                                },
+                                allocator, &pool));
+
+  iree_hal_pool_reservation_t reservation;
+  iree_hal_pool_acquire_info_t acquire_info;
+  iree_hal_pool_acquire_result_t result;
+  IREE_ASSERT_OK(iree_hal_pool_acquire_reservation(
+      pool, 4096, 16, /*requester_frontier=*/NULL,
+      IREE_HAL_POOL_RESERVE_FLAG_NONE, &reservation, &acquire_info, &result));
+  ASSERT_EQ(result, IREE_HAL_POOL_ACQUIRE_OK_FRESH);
+
+  MAKE_FRONTIER(death_frontier, 1, E(query.axis, 42));
+  iree_hal_pool_release_reservation(pool, &reservation, death_frontier);
+  IREE_ASSERT_OK(iree_hal_tlsf_pool_trim_to(pool, 0));
+
+  iree_hal_pool_stats_t stats;
+  iree_hal_pool_query_stats(pool, &stats);
+  EXPECT_EQ(stats.slab_count, 1u);
+  EXPECT_EQ(stats.bytes_committed, 4096u);
+  EXPECT_EQ(query.query_count, 1u);
+
+  query.completed_epoch = 42;
+  IREE_ASSERT_OK(iree_hal_tlsf_pool_trim_to(pool, 0));
+  iree_hal_pool_query_stats(pool, &stats);
+  EXPECT_EQ(stats.slab_count, 0u);
+  EXPECT_EQ(stats.bytes_committed, 0u);
+  EXPECT_EQ(query.query_count, 2u);
+
+  iree_hal_pool_release(pool);
+  iree_async_notification_release(notification);
+  iree_hal_slab_provider_release(slab_provider);
+}
+
+TEST(TLSFPool, TrimToRetainsSlabWithTaintedDeathFrontier) {
+  iree_allocator_t allocator = iree_allocator_system();
+  iree_hal_slab_provider_t* slab_provider = NULL;
+  IREE_ASSERT_OK(iree_hal_cpu_slab_provider_create(allocator, &slab_provider));
+  iree_async_notification_t* notification = NULL;
+  IREE_ASSERT_OK(iree_async_notification_create(
+      test_proactor(), IREE_ASYNC_NOTIFICATION_FLAG_NONE, &notification));
+
+  iree_hal_tlsf_pool_options_t options = DefaultOptions();
+  options.tlsf_options.frontier_capacity = 1;
+  iree_hal_test_epoch_query_t query = {
+      /*.axis=*/TestQueueAxis(0),
+      /*.completed_epoch=*/UINT64_MAX,
+      /*.query_count=*/0,
+  };
+  iree_hal_pool_t* pool = NULL;
+  IREE_ASSERT_OK(
+      iree_hal_tlsf_pool_create(options, slab_provider, notification,
+                                (iree_hal_pool_epoch_query_t){
+                                    /*.fn=*/iree_hal_test_epoch_query,
+                                    /*.user_data=*/&query,
+                                },
+                                allocator, &pool));
+
+  iree_hal_pool_reservation_t reservations[2];
+  iree_hal_pool_acquire_info_t acquire_info;
+  iree_hal_pool_acquire_result_t result;
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(reservations); ++i) {
+    IREE_ASSERT_OK(iree_hal_pool_acquire_reservation(
+        pool, 2048, 16, /*requester_frontier=*/NULL,
+        IREE_HAL_POOL_RESERVE_FLAG_NONE, &reservations[i], &acquire_info,
+        &result));
+  }
+
+  MAKE_FRONTIER(first_frontier, 1, E(TestQueueAxis(0), 1));
+  MAKE_FRONTIER(second_frontier, 1, E(TestQueueAxis(1), 1));
+  iree_hal_pool_release_reservation(pool, &reservations[0], first_frontier);
+  iree_hal_pool_release_reservation(pool, &reservations[1], second_frontier);
+  IREE_ASSERT_OK(iree_hal_tlsf_pool_trim_to(pool, 0));
+
+  iree_hal_pool_stats_t stats;
+  iree_hal_pool_query_stats(pool, &stats);
+  EXPECT_EQ(stats.slab_count, 1u);
+  EXPECT_EQ(stats.bytes_committed, 4096u);
+  EXPECT_EQ(query.query_count, 0u);
+
+  iree_hal_pool_release(pool);
+  iree_async_notification_release(notification);
+  iree_hal_slab_provider_release(slab_provider);
 }
 
 TEST(TLSFPool, ReleaseNodeReuseAvoidsRepeatedHostAllocation) {

--- a/runtime/src/iree/hal/memory/tlsf_pool_test.cc
+++ b/runtime/src/iree/hal/memory/tlsf_pool_test.cc
@@ -383,6 +383,46 @@ TEST_F(TLSFPoolTest, ReserveGrowsForLivePressure) {
   iree_hal_pool_release_reservation(pool_, &first_reservation, NULL);
 }
 
+TEST_F(TLSFPoolTest, TrimToPreservesLiveSlab) {
+  iree_hal_pool_reservation_t first_reservation;
+  iree_hal_pool_acquire_info_t reserve_info;
+  iree_hal_pool_acquire_result_t result;
+  IREE_ASSERT_OK(iree_hal_pool_acquire_reservation(
+      pool_, 4096, 16, /*requester_frontier=*/NULL,
+      IREE_HAL_POOL_RESERVE_FLAG_NONE, &first_reservation, &reserve_info,
+      &result));
+  EXPECT_EQ(result, IREE_HAL_POOL_ACQUIRE_OK_FRESH);
+
+  iree_hal_pool_reservation_t second_reservation;
+  IREE_ASSERT_OK(iree_hal_pool_acquire_reservation(
+      pool_, 16, 16, /*requester_frontier=*/NULL,
+      IREE_HAL_POOL_RESERVE_FLAG_NONE, &second_reservation, &reserve_info,
+      &result));
+  EXPECT_EQ(result, IREE_HAL_POOL_ACQUIRE_OK_FRESH);
+  EXPECT_NE(first_reservation.slab_index, second_reservation.slab_index);
+
+  iree_hal_pool_release_reservation(pool_, &first_reservation, NULL);
+  IREE_ASSERT_OK(iree_hal_tlsf_pool_trim_to(pool_, 16));
+
+  iree_hal_pool_stats_t stats;
+  iree_hal_pool_query_stats(pool_, &stats);
+  EXPECT_EQ(stats.slab_count, 1u);
+  EXPECT_EQ(stats.bytes_committed, 4096u);
+  EXPECT_EQ(stats.reservation_count, 1u);
+
+  iree_hal_buffer_params_t params = {0};
+  params.usage =
+      IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING_SCOPED;
+  params.type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL;
+  params.access = IREE_HAL_MEMORY_ACCESS_ALL;
+  iree_hal_buffer_t* buffer = NULL;
+  IREE_ASSERT_OK(iree_hal_pool_materialize_reservation(
+      pool_, params, &second_reservation,
+      IREE_HAL_POOL_MATERIALIZE_FLAG_TRANSFER_RESERVATION_OWNERSHIP, &buffer));
+  ASSERT_NE(buffer, nullptr);
+  iree_hal_buffer_release(buffer);
+}
+
 TEST(TLSFPool, ReleaseNodeReuseAvoidsRepeatedHostAllocation) {
   iree_hal_test_counting_allocator_t allocator_state = {
       /*.backing_allocator=*/iree_allocator_system(),

--- a/runtime/src/iree/hal/utils/queue_host_call_emulation.c
+++ b/runtime/src/iree/hal/utils/queue_host_call_emulation.c
@@ -44,7 +44,7 @@ static iree_status_t iree_hal_emulated_host_call_issue(
 
   if (is_nonblocking || iree_status_is_deferred(call_status)) {
     // User callback will signal in the future (or they are fire-and-forget).
-    iree_status_ignore(call_status);
+    iree_status_free(call_status);
   } else if (iree_status_is_ok(call_status)) {
     // Signal callback completed synchronously.
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
@@ -56,7 +56,7 @@ static iree_status_t iree_hal_emulated_host_call_issue(
     if (!is_nonblocking) {
       iree_hal_semaphore_list_fail(signal_semaphore_list, call_status);
     } else {
-      iree_status_ignore(call_status);
+      iree_status_free(call_status);
     }
   }
 
@@ -135,6 +135,7 @@ static int iree_hal_emulated_host_call_main(void* entry_arg) {
 
   // Release signal semaphores.
   iree_hal_semaphore_list_release(state->signal_semaphore_list);
+  iree_hal_resource_release(state->call.resource);
 
   // Deallocate state (note that we must take the thread handle locally).
   iree_allocator_t host_allocator =
@@ -188,6 +189,7 @@ IREE_API_EXPORT iree_status_t iree_hal_device_queue_emulated_host_call(
   state->device = device;
   state->queue_affinity = queue_affinity;
   state->call = call;
+  iree_hal_resource_retain(state->call.resource);
   memcpy(state->args, args, sizeof(state->args));
   state->flags = flags;
 
@@ -238,6 +240,7 @@ IREE_API_EXPORT iree_status_t iree_hal_device_queue_emulated_host_call(
   if (!iree_status_is_ok(status)) {
     iree_hal_semaphore_list_release(state->wait_semaphore_list);
     iree_hal_semaphore_list_release(state->signal_semaphore_list);
+    iree_hal_resource_release(state->call.resource);
     iree_allocator_free(host_allocator, state);
   }
 


### PR DESCRIPTION
## Summary

  This change implements stream-ordered HIP memory allocation on top of virtual-memory-backed TLSF pools. It separates the system into three layers:

  - The AMDGPU HAL implements the existing generic virtual-memory contract.
  - HRX owns VMM slab construction, pool policy, accounting, and lifetimes.
  - The HIP binding implements stream ordering, allocation reuse, pool attributes,
    and API behavior.

  Asynchronous allocations now receive stable device addresses backed by
  page-aligned virtual reservations. Physical backing is allocated, mapped, and
  protected through the HAL, then subdivided by TLSF in HRX. Freed ranges remain
  ordered against stream work and can be reused without attempting to discover
  device pointers embedded inside kernel arguments or device memory.

  ## AMDGPU Virtual Memory

  The AMDGPU allocator now implements the HAL virtual-memory operations:

  - Query allocation granularity.
  - Reserve and release virtual address ranges.
  - Allocate and free physical memory handles.
  - Map and unmap physical memory.
  - Apply queue-specific access protection.
  - Process supported virtual-memory advice.

  The implementation tracks reservations, mappings, and physical allocations in
  allocator-local state. It validates ownership, granularity, alignment, range
  bounds, mapping state, queue affinity, and release ordering.

  ROCr requires each mapping operation to cover a complete physical allocation.
  The implementation therefore rejects partial physical mappings instead of
  claiming support that the underlying interface cannot provide. VMM is also
  rejected when address sanitization or required allocation flags cannot be
  represented correctly.

  ## HRX Pool Architecture

  HRX provides a VMM slab provider that:

  1. Reserves a virtual address range.
  2. Allocates matching physical backing.
  3. Maps and protects the complete range.
  4. Exposes the resulting device address as a TLSF slab.
  5. Tears resources down in dependency order: unmap, free physical memory, then
     release the virtual reservation.

  Suballocations are represented as HAL buffer subspans. A generic callback-capable
  subspan constructor ties pool bookkeeping to the final buffer reference, so a
  TLSF range cannot be reused while any materialized view still retains it.

  Pool policy remains in HRX rather than AMDGPU. This includes:

  - Per-device default pools and explicitly created pools.
  - Logical allocation accounting and maximum-size enforcement.
  - Physical slab retention and trimming.
  - Oversized allocation routing.
  - Release thresholds expressed as byte counts.
  - Reuse policy attributes.
  - Pool access and location validation.

  The generic HAL additions are limited to the uncached-memory requirement,
  callback-capable subspans, and trimming a TLSF pool toward a byte threshold.

  ## Stream-Ordered Allocation

  The HIP binding now implements the primary stream-ordered allocation APIs,
  including:

  - hipMallocAsync
  - hipMallocFromPoolAsync
  - hipFreeAsync
  - Default and current device memory-pool selection
  - Memory-pool creation, destruction, attributes, access, and trimming

  An asynchronous free removes the allocation from the public buffer table before
  enqueueing its retirement operation. Capacity for rollback is reserved first,
  so an enqueue failure can restore ownership without performing another
  allocation or losing the buffer.

  Completed frees follow the configured reuse policy:

  - Opportunistic reuse returns completed allocations to TLSF immediately.
  - Conservative reuse retains completed allocations until an explicit stream
    synchronization, pool trim, or valid dependency-based reuse point.

  - Same-stream ordering and recorded cross-stream event dependencies allow reuse
    without global synchronization.

  Stream synchronization snapshots its target timeline value under the stream
  lock and only waits for work included in that snapshot. Completed asynchronous
  frees are retired after the corresponding timeline point is reached.

  ## Transfers and Graphs

  Host-visible and pageable transfers preserve stream ordering through registered
  buffers, owned staging allocations, and stream host calls. The direct HAL
  transfer path remains a serialized fallback for cases that cannot be represented
  as queued buffer operations. It validates the entire source or destination range
  before issuing any transfer chunks, preventing partial updates from an invalid
  request.

  Graph-owned staging allocations use the same queue-visible host-memory path.
  Graph dependency barriers now include both dispatch and transfer read/write
  scopes, preserving memory visibility when graph nodes alternate between kernels
  and copies.

  ## Error Handling and Cleanup

  The change also tightens failure behavior throughout the memory stack:

  - Buffer-table pointer and range checks avoid integer overflow.
  - Buffer-table growth checks capacity and allocation-size overflow.
  - Failed asynchronous-free enqueue operations restore ownership without an
    allocation.

  - VMM teardown preserves and joins cleanup failures.
  - Mapped physical resources remain alive when unmapping fails.
  - Pool trimming propagates errors and honors the configured byte threshold.
  - Synchronous frees verify that the allocation was removed successfully.
  - Unsupported VMM placements fail explicitly rather than silently changing
    memory properties.

  ## Verification

  The following verification passes on the final stack:

  - All 32 buffer-table tests.
  - All 20 TLSF pool tests.
  - Branch-specific regression coverage for allocation-free async-free rollback.
  - Branch-specific regression coverage for byte-valued TLSF release thresholds.
  - Repository pre-commit runtime and libhrx tests.
  - Formatting, build metadata validation, text hygiene, and Semgrep checks.