### PR TITLE
[CI] Ignore uninstrumented ROCr accesses in TSAN

### DIFF
--- a/build_tools/devtools/tsan.supp
+++ b/build_tools/devtools/tsan.supp
@@ -1,3 +1,3 @@
-# Suppress ROCr runtime async event bookkeeping races reported while HSA-backed
-# tests initialize and tear down the external runtime.
-race:rocr::core::Runtime::ConcurrentAsyncEvents::GetAllEvents*
+# ROCr is not TSAN-instrumented, so interceptor accesses originating within it
+# cannot be analyzed against its internal synchronization.
+called_from_lib:libhsa-runtime64.so


### PR DESCRIPTION
ROCr is not TSAN-instrumented, so allocator accesses observed through TSAN interceptors do not include the synchronization inside ROCr. The existing function-level suppression still requires TSAN to construct and symbolize a report before it can match `ConcurrentAsyncEvents::GetAllEvents`.

That report path can deadlock during `hsa_init`: the initialization thread holds the dynamic-loader lock in ROCr tool discovery while waiting for a TSAN trace slot, and ROCr's async-event thread holds that trace slot while TSAN's symbolizer waits for the dynamic-loader lock.

This changes the suppression to `called_from_lib:libhsa-runtime64.so`. TSAN then ignores interceptor accesses originating inside the uninstrumented ROCr library before report generation. Instrumented IREE and HRX code remains visible to TSAN, and the policy is scoped to libhsa rather than all non-instrumented modules.

A live gfx942 capture confirmed the lock inversion before the feedback test body executed. The original suppression produced three hangs in 2,021 concurrent fresh-process launches. The library-boundary suppression matched the exact CI ROCr artifact and passed 9,000 concurrent launches, followed by the focused production test on the rebased mainline.
