### PR TITLE
[Loom] Make compile reports actionable for autoresearch

### DIFF
--- a/loom/README.md
+++ b/loom/README.md
@@ -127,13 +127,19 @@ python dev.py bazel run //loom/py/loom/tools:loom-compile-report -- \
   diff /tmp/baseline.json /tmp/candidate.json --format=json
 python dev.py bazel run //loom/py/loom/tools:loom-compile-report -- \
   suggest /tmp/candidate.json --format=json
+python dev.py bazel run //loom/py/loom/tools:loom-compile-report -- \
+  suggest /tmp/candidate.json --include-experimental --format=json
 ```
 
 `show` separates emitted artifact facts from compiler analysis and omits
 unavailable metrics from its compact JSON. `diff` rejects reports unless their
 schema, target, specialization, workload, and entry identities match exactly.
 `suggest` delegates interpretation to the selected target family and cites the
-evidence behind each proposed experiment.
+evidence behind each proposed experiment. Default findings require a documented
+or silicon-calibrated target model. `--include-experimental` also exposes
+structurally exact findings from hardware-unvalidated models and labels them
+`experimental`, allowing pre-silicon search without presenting model
+predictions as measured hardware behavior.
 
 Compile reports are version-zero, same-compiler-horizon diagnostics. Regenerate
 them with the current checkout instead of treating them as durable records or

--- a/loom/README.md
+++ b/loom/README.md
@@ -141,6 +141,16 @@ structurally exact findings from hardware-unvalidated models and labels them
 `experimental`, allowing pre-silicon search without presenting model
 predictions as measured hardware behavior.
 
+Final-native facts expose the scheduled body separately from the target-owned
+entry envelope, native coissued instructions separately from their semantic
+components, and each matrix family separately from the broad matrix total.
+Dispatch-scaled operation counts appear only when the report carries an exact
+workload scale. Wait analysis distinguishes waits already present in the low
+stream from waits inserted by target planning, while target-insertion coverage
+states whether dynamic packet counts are exact or unknown. These are structural
+search signals rather than cycle estimates; absent values stay unavailable
+instead of being inferred by the report tool.
+
 Compile reports are version-zero, same-compiler-horizon diagnostics. Regenerate
 them with the current checkout instead of treating them as durable records or
 adding compatibility paths to the consumer.

--- a/loom/py/loom/reporting/BUILD.bazel
+++ b/loom/py/loom/reporting/BUILD.bazel
@@ -16,6 +16,7 @@ iree_py_library(
     srcs = [
         "__init__.py",
         "compile_report.py",
+        "compile_report_bank_service.py",
         "compile_report_suggestions.py",
         "compile_report_view.py",
     ],
@@ -25,11 +26,13 @@ iree_py_library(
 iree_py_test(
     name = "reporting_test",
     srcs = [
+        "compile_report_bank_service_test.py",
         "compile_report_suggestions_test.py",
         "compile_report_test.py",
         "//loom/py/loom/tools:pytest_style_runner.py",
     ],
     args = [
+        "loom.reporting.compile_report_bank_service_test",
         "loom.reporting.compile_report_suggestions_test",
         "loom.reporting.compile_report_test",
     ],

--- a/loom/py/loom/reporting/CMakeLists.txt
+++ b/loom/py/loom/reporting/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_py_library(
   SRCS
     "__init__.py"
     "compile_report.py"
+    "compile_report_bank_service.py"
     "compile_report_suggestions.py"
     "compile_report_view.py"
   IMPORTS
@@ -27,10 +28,12 @@ iree_py_test(
   MAIN
     "../tools/pytest_style_runner.py"
   SRCS
+    "compile_report_bank_service_test.py"
     "compile_report_suggestions_test.py"
     "compile_report_test.py"
     "../tools/pytest_style_runner.py"
   ARGS
+    "loom.reporting.compile_report_bank_service_test"
     "loom.reporting.compile_report_suggestions_test"
     "loom.reporting.compile_report_test"
   DEPS

--- a/loom/py/loom/reporting/compile_report_bank_service.py
+++ b/loom/py/loom/reporting/compile_report_bank_service.py
@@ -1,0 +1,657 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Bank-service views, semantic diffs, and text formatting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loom.reporting.compile_report import CompileReportDocument, CompileReportError
+
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class _MetricSpec:
+    """One stable bank-service scalar."""
+
+    key: str
+    label: str
+    path: str
+
+
+_METRIC_SPECS = (
+    _MetricSpec("modeled_packet_count", "modeled packets", "modeled_packet_count"),
+    _MetricSpec("exact_packet_count", "exact packets", "exact_packet_count"),
+    _MetricSpec("unknown_packet_count", "unknown packets", "unknown_packet_count"),
+    _MetricSpec(
+        "conflict_free_packet_count",
+        "conflict-free packets",
+        "structural.conflict_free_packet_count",
+    ),
+    _MetricSpec(
+        "conflicted_packet_count",
+        "conflicted packets",
+        "structural.conflicted_packet_count",
+    ),
+    _MetricSpec(
+        "required_round_count",
+        "structural required rounds",
+        "structural.required_round_count",
+    ),
+    _MetricSpec(
+        "uncontended_round_count",
+        "structural uncontended rounds",
+        "structural.uncontended_round_count",
+    ),
+    _MetricSpec(
+        "extra_round_count",
+        "structural extra rounds",
+        "structural.extra_round_count",
+    ),
+    _MetricSpec(
+        "maximum_request_multiplicity",
+        "maximum request multiplicity",
+        "structural.maximum_request_multiplicity",
+    ),
+    _MetricSpec(
+        "exact_dynamic_packet_count",
+        "dynamically exact source packets",
+        "dynamic.exact_packet_count",
+    ),
+    _MetricSpec(
+        "unknown_dynamic_packet_count",
+        "dynamically unknown source packets",
+        "dynamic.unknown_packet_count",
+    ),
+    _MetricSpec(
+        "dynamic_packet_count",
+        "dynamic packet executions",
+        "dynamic.packet_count",
+    ),
+    _MetricSpec(
+        "dynamic_required_round_count",
+        "dynamic required rounds",
+        "dynamic.required_round_count",
+    ),
+    _MetricSpec(
+        "dynamic_uncontended_round_count",
+        "dynamic uncontended rounds",
+        "dynamic.uncontended_round_count",
+    ),
+    _MetricSpec(
+        "dynamic_extra_round_count",
+        "dynamic extra rounds",
+        "dynamic.extra_round_count",
+    ),
+)
+
+_GROUP_IDENTITY_FIELDS = (
+    "function",
+    "source_op",
+    "source_op_kind",
+    "source_root",
+    "source_root_argument_index",
+    "memory_space",
+    "operation",
+    "packet",
+    "strategy",
+)
+
+_MODEL_FIELDS = (
+    "key",
+    "revision",
+    "evidence",
+    "request_policy",
+    "wave_size",
+    "bank_count",
+    "bank_word_bytes",
+    "packet_bank_words",
+)
+
+
+def build_bank_service_show(
+    document: CompileReportDocument,
+) -> dict[str, object] | None:
+    """Builds the compact bank-service view when evidence is available."""
+    memory = _optional_memory(document)
+    if memory is None:
+        return None
+    summary = memory.get("bank_service")
+    groups = memory.get("bank_service_groups")
+    if summary is None and groups is None:
+        return None
+    summary_object = _require_object(
+        summary,
+        f"{document.source}.source_low.memory.bank_service",
+    )
+    group_values = _require_list(
+        groups,
+        f"{document.source}.source_low.memory.bank_service_groups",
+    )
+    expected_group_count = memory.get("bank_service_group_count")
+    if (
+        not isinstance(expected_group_count, int)
+        or isinstance(expected_group_count, bool)
+        or expected_group_count != len(group_values)
+    ):
+        raise CompileReportError(
+            f"{document.source}.source_low.memory.bank_service_group_count: "
+            f"expected {len(group_values)}, got {expected_group_count!r}"
+        )
+    shown_groups = [
+        _show_group(
+            value,
+            f"{document.source}.source_low.memory.bank_service_groups[{index}]",
+        )
+        for index, value in enumerate(group_values)
+    ]
+    shown_groups.sort(key=_group_key)
+    return {
+        "summary": _show_metrics(
+            summary_object,
+            f"{document.source}.source_low.memory.bank_service",
+        ),
+        "group_count": len(shown_groups),
+        "groups": shown_groups,
+    }
+
+
+def build_bank_service_diff(
+    baseline: CompileReportDocument,
+    candidate: CompileReportDocument,
+) -> dict[str, object] | None:
+    """Builds a semantic bank-service diff without globally netting groups."""
+    baseline_show = build_bank_service_show(baseline)
+    candidate_show = build_bank_service_show(candidate)
+    if baseline_show is None and candidate_show is None:
+        return None
+    if baseline_show is None or candidate_show is None:
+        return {
+            "availability": {
+                "baseline": "available" if baseline_show is not None else "unavailable",
+                "candidate": (
+                    "available" if candidate_show is not None else "unavailable"
+                ),
+            },
+            "changed_group_count": 0,
+            "unchanged_group_count": 0,
+            "groups": [],
+        }
+
+    summary_diff = _diff_metrics(
+        _expect_dict(baseline_show["summary"]),
+        _expect_dict(candidate_show["summary"]),
+    )
+    baseline_groups = _groups_by_key(
+        _expect_list(baseline_show["groups"]),
+        baseline.source,
+    )
+    candidate_groups = _groups_by_key(
+        _expect_list(candidate_show["groups"]),
+        candidate.source,
+    )
+    changed_groups = []
+    unchanged_group_count = 0
+    for key in sorted(set(baseline_groups) | set(candidate_groups)):
+        baseline_group = baseline_groups.get(key)
+        candidate_group = candidate_groups.get(key)
+        if baseline_group is None:
+            changed_groups.append(
+                {
+                    "identity": candidate_group["identity"],
+                    "status": "added",
+                    "candidate": candidate_group,
+                }
+            )
+            continue
+        if candidate_group is None:
+            changed_groups.append(
+                {
+                    "identity": baseline_group["identity"],
+                    "status": "removed",
+                    "baseline": baseline_group,
+                }
+            )
+            continue
+
+        model_diff = _diff_model(
+            _expect_dict(baseline_group["model"]),
+            _expect_dict(candidate_group["model"]),
+        )
+        baseline_summary = _expect_dict(baseline_group["summary"])
+        candidate_summary = _expect_dict(candidate_group["summary"])
+        service_diff = _diff_metrics(baseline_summary, candidate_summary)
+        baseline_unknown = baseline_group.get("unknown_evidence")
+        candidate_unknown = candidate_group.get("unknown_evidence")
+        if (
+            not model_diff
+            and not _diff_has_changes(service_diff)
+            and baseline_unknown == candidate_unknown
+        ):
+            unchanged_group_count += 1
+            continue
+        group_diff: dict[str, object] = {
+            "identity": baseline_group["identity"],
+            "status": "changed",
+            "proof_loss": _proof_lost(baseline_summary, candidate_summary),
+            "service": service_diff,
+        }
+        if model_diff:
+            group_diff["model"] = model_diff
+        if baseline_unknown != candidate_unknown:
+            group_diff["unknown_evidence"] = {
+                "baseline": baseline_unknown,
+                "candidate": candidate_unknown,
+            }
+        changed_groups.append(group_diff)
+
+    return {
+        "summary": summary_diff,
+        "changed_group_count": len(changed_groups),
+        "unchanged_group_count": unchanged_group_count,
+        "groups": changed_groups,
+    }
+
+
+def append_bank_service_show_text(
+    lines: list[str],
+    bank_service: dict[str, object],
+) -> None:
+    """Appends the human-readable bank-service view."""
+    lines.extend(("", "Bank service (compiler analysis)"))
+    _append_metrics(lines, _expect_dict(bank_service["summary"]), indent="  ")
+    actionable_groups = [
+        _expect_dict(value)
+        for value in _expect_list(bank_service["groups"])
+        if _group_is_actionable(_expect_dict(value))
+    ]
+    lines.append(
+        f"  groups: {bank_service['group_count']} total, "
+        f"{len(actionable_groups)} conflicted or incomplete"
+    )
+    for group in actionable_groups:
+        _append_group(lines, group, indent="  ")
+
+
+def append_bank_service_diff_text(
+    lines: list[str],
+    bank_service: dict[str, object],
+) -> None:
+    """Appends the human-readable semantic bank-service diff."""
+    lines.extend(("", "Bank service diff (compiler analysis)"))
+    availability = bank_service.get("availability")
+    if isinstance(availability, dict):
+        lines.append(
+            f"  evidence: {availability['baseline']} -> {availability['candidate']}"
+        )
+        return
+    summary = _expect_dict(bank_service["summary"])
+    if _diff_has_changes(summary):
+        lines.append("  Aggregate service")
+        _append_diff_metrics(lines, summary, indent="    ")
+    else:
+        lines.append("  aggregate service: unchanged")
+    lines.append(
+        f"  groups: {bank_service['changed_group_count']} changed, "
+        f"{bank_service['unchanged_group_count']} unchanged"
+    )
+    for group_value in _expect_list(bank_service["groups"]):
+        group = _expect_dict(group_value)
+        status = group["status"]
+        identity = _expect_dict(group["identity"])
+        lines.append(f"  {_format_group_identity(identity)}: {status}")
+        if status == "added":
+            _append_group(
+                lines,
+                _expect_dict(group["candidate"]),
+                indent="    ",
+                include_identity=False,
+            )
+            continue
+        if status == "removed":
+            _append_group(
+                lines,
+                _expect_dict(group["baseline"]),
+                indent="    ",
+                include_identity=False,
+            )
+            continue
+        if group.get("proof_loss") is True:
+            lines.append("    exact proof coverage regressed")
+        model = group.get("model")
+        if isinstance(model, dict):
+            for field, change_value in model.items():
+                change = _expect_dict(change_value)
+                lines.append(
+                    f"    model {field}: {change['baseline']} -> {change['candidate']}"
+                )
+        _append_diff_metrics(
+            lines,
+            _expect_dict(group["service"]),
+            indent="    ",
+        )
+        unknown_evidence = group.get("unknown_evidence")
+        if isinstance(unknown_evidence, dict):
+            lines.append(
+                "    unknown evidence: "
+                f"{unknown_evidence['baseline']} -> "
+                f"{unknown_evidence['candidate']}"
+            )
+
+
+def _optional_memory(
+    document: CompileReportDocument,
+) -> dict[str, object] | None:
+    source_low = document.report.get("source_low")
+    if source_low is None:
+        return None
+    source_low_object = _require_object(
+        source_low,
+        f"{document.source}.source_low",
+    )
+    memory = source_low_object.get("memory")
+    if memory is None:
+        return None
+    return _require_object(memory, f"{document.source}.source_low.memory")
+
+
+def _show_group(value: object, source: str) -> dict[str, object]:
+    group = _require_object(value, source)
+    identity = {
+        field: _identity_component(group.get(field), f"{source}.{field}")
+        for field in _GROUP_IDENTITY_FIELDS
+    }
+    model = _require_object(group.get("model"), f"{source}.model")
+    summary = _require_object(group.get("summary"), f"{source}.summary")
+    shown: dict[str, object] = {
+        "report_index": _require_integer(group.get("index"), f"{source}.index"),
+        "identity": identity,
+        "model": {
+            field: _model_component(model.get(field), f"{source}.model.{field}")
+            for field in _MODEL_FIELDS
+        },
+        "summary": _show_metrics(summary, f"{source}.summary"),
+    }
+    if "unknown_evidence" in group:
+        unknown_evidence = _require_object(
+            group["unknown_evidence"],
+            f"{source}.unknown_evidence",
+        )
+        reason = unknown_evidence.get("reason")
+        if reason is not None and not isinstance(reason, str):
+            raise CompileReportError(
+                f"{source}.unknown_evidence.reason: expected string or null"
+            )
+        mixed_reasons = unknown_evidence.get("mixed_reasons")
+        if not isinstance(mixed_reasons, bool):
+            raise CompileReportError(
+                f"{source}.unknown_evidence.mixed_reasons: expected boolean"
+            )
+        shown["unknown_evidence"] = {
+            "reason": reason,
+            "mixed_reasons": mixed_reasons,
+        }
+    return shown
+
+
+def _show_metrics(
+    summary: dict[str, object],
+    source: str,
+) -> dict[str, object]:
+    metrics = {}
+    for spec in _METRIC_SPECS:
+        value = _lookup(summary, spec.path)
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise CompileReportError(f"{source}.{spec.path}: expected integer")
+        metrics[spec.key] = value
+    return metrics
+
+
+def _identity_component(value: object, source: str) -> object:
+    if value is None or isinstance(value, str):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    raise CompileReportError(f"{source}: expected string, integer, or null")
+
+
+def _model_component(value: object, source: str) -> object:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    raise CompileReportError(f"{source}: expected string or integer")
+
+
+def _require_object(value: object, source: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise CompileReportError(f"{source}: expected object")
+    return value
+
+
+def _require_list(value: object, source: str) -> list[object]:
+    if not isinstance(value, list):
+        raise CompileReportError(f"{source}: expected array")
+    return value
+
+
+def _require_integer(value: object, source: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise CompileReportError(f"{source}: expected integer")
+    return value
+
+
+def _group_key(
+    group: dict[str, object],
+) -> tuple[tuple[int, object], ...]:
+    identity = _expect_dict(group["identity"])
+    return tuple(
+        _sortable_component(identity[field]) for field in _GROUP_IDENTITY_FIELDS
+    )
+
+
+def _groups_by_key(
+    values: list[object],
+    source: str,
+) -> dict[tuple[tuple[int, object], ...], dict[str, object]]:
+    groups = {}
+    for position, value in enumerate(values):
+        group = _expect_dict(value)
+        key = _group_key(group)
+        if key in groups:
+            raise CompileReportError(
+                f"{source}.source_low.memory.bank_service_groups[{position}]: "
+                "duplicate semantic group identity"
+            )
+        groups[key] = group
+    return groups
+
+
+def _sortable_component(value: object) -> tuple[int, object]:
+    if value is None:
+        return (0, "")
+    if isinstance(value, int):
+        return (1, value)
+    return (2, str(value))
+
+
+def _diff_model(
+    baseline: dict[str, object],
+    candidate: dict[str, object],
+) -> dict[str, object]:
+    return {
+        field: {
+            "baseline": baseline.get(field),
+            "candidate": candidate.get(field),
+        }
+        for field in _MODEL_FIELDS
+        if baseline.get(field) != candidate.get(field)
+    }
+
+
+def _proof_lost(
+    baseline: dict[str, object],
+    candidate: dict[str, object],
+) -> bool:
+    return (
+        candidate["exact_packet_count"] < baseline["exact_packet_count"]
+        or candidate["unknown_packet_count"] > baseline["unknown_packet_count"]
+    )
+
+
+def _diff_metrics(
+    baseline: dict[str, object],
+    candidate: dict[str, object],
+) -> dict[str, object]:
+    changed: dict[str, object] = {}
+    unchanged_count = 0
+    for spec in _METRIC_SPECS:
+        baseline_value = baseline[spec.key]
+        candidate_value = candidate[spec.key]
+        if baseline_value == candidate_value:
+            unchanged_count += 1
+            continue
+        delta = candidate_value - baseline_value
+        metric: dict[str, object] = {
+            "baseline": baseline_value,
+            "candidate": candidate_value,
+            "delta": delta,
+        }
+        if baseline_value != 0:
+            metric["change_percent"] = delta * 100.0 / baseline_value
+        changed[spec.key] = metric
+    return {
+        "changed": changed,
+        "incomplete": {},
+        "unchanged_count": unchanged_count,
+        "unavailable_count": 0,
+    }
+
+
+def _diff_has_changes(group: dict[str, object]) -> bool:
+    return bool(group["changed"] or group["incomplete"])
+
+
+def _append_metrics(
+    lines: list[str],
+    metric_values: dict[str, object],
+    *,
+    indent: str,
+) -> None:
+    lines.extend(
+        f"{indent}{spec.label}: {_format_value(metric_values[spec.key])}"
+        for spec in _METRIC_SPECS
+    )
+
+
+def _append_diff_metrics(
+    lines: list[str],
+    metric_values: dict[str, object],
+    *,
+    indent: str,
+) -> None:
+    changed = _expect_dict(metric_values["changed"])
+    for spec in _METRIC_SPECS:
+        metric_value = changed.get(spec.key)
+        if metric_value is None:
+            continue
+        metric = _expect_dict(metric_value)
+        suffix = f", delta {_format_signed_value(metric['delta'])}"
+        if "change_percent" in metric:
+            suffix += f" ({metric['change_percent']:+.2f}%)"
+        lines.append(
+            f"{indent}{spec.label}: "
+            f"{_format_value(metric['baseline'])} -> "
+            f"{_format_value(metric['candidate'])}{suffix}"
+        )
+
+
+def _append_group(
+    lines: list[str],
+    group: dict[str, object],
+    *,
+    indent: str,
+    include_identity: bool = True,
+) -> None:
+    identity = _expect_dict(group["identity"])
+    model = _expect_dict(group["model"])
+    summary = _expect_dict(group["summary"])
+    if include_identity:
+        lines.append(f"{indent}{_format_group_identity(identity)}")
+        indent += "  "
+    lines.append(
+        f"{indent}model: {model['key']} @ {model['revision']} "
+        f"({model['evidence']}, {model['request_policy']})"
+    )
+    lines.append(
+        f"{indent}proof: {summary['exact_packet_count']} exact, "
+        f"{summary['unknown_packet_count']} unknown"
+    )
+    lines.append(
+        f"{indent}structural service: "
+        f"{summary['required_round_count']} required, "
+        f"{summary['uncontended_round_count']} uncontended, "
+        f"{summary['extra_round_count']} extra rounds"
+    )
+    unknown_evidence = group.get("unknown_evidence")
+    if isinstance(unknown_evidence, dict):
+        lines.append(
+            f"{indent}unknown evidence: {unknown_evidence.get('reason') or 'mixed'}"
+        )
+
+
+def _group_is_actionable(group: dict[str, object]) -> bool:
+    summary = _expect_dict(group["summary"])
+    return summary["conflicted_packet_count"] > 0 or summary["unknown_packet_count"] > 0
+
+
+def _format_group_identity(identity: dict[str, object]) -> str:
+    function = identity.get("function") or "<unnamed>"
+    source_op = identity.get("source_op") or "<unknown-op>"
+    source_root = identity.get("source_root")
+    if not source_root and identity.get("source_root_argument_index") is not None:
+        source_root = f"arg{identity['source_root_argument_index']}"
+    packet = identity.get("packet") or "<unknown-packet>"
+    return f"{function}: {source_op} {source_root or '<unknown-root>'} [{packet}]"
+
+
+def _lookup(root: object, path: str) -> object:
+    value = root
+    for component in path.split("."):
+        if not isinstance(value, dict) or component not in value:
+            return _MISSING
+        value = value[component]
+    return value
+
+
+def _format_value(value: object) -> str:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return f"{value:,}"
+    if isinstance(value, float):
+        return f"{value:.4g}"
+    return str(value)
+
+
+def _format_signed_value(value: object) -> str:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return f"{value:+,}"
+    if isinstance(value, float):
+        return f"{value:+.4g}"
+    return str(value)
+
+
+def _expect_dict(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise TypeError("invalid internal bank-service report object")
+    return value
+
+
+def _expect_list(value: object) -> list[object]:
+    if not isinstance(value, list):
+        raise TypeError("invalid internal bank-service report array")
+    return value

--- a/loom/py/loom/reporting/compile_report_bank_service_test.py
+++ b/loom/py/loom/reporting/compile_report_bank_service_test.py
@@ -1,0 +1,213 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from loom.reporting.compile_report import CompileReportError, parse_compile_report
+from loom.reporting.compile_report_view import (
+    build_compile_report_diff,
+    build_compile_report_show,
+    format_compile_report_diff_text,
+    format_compile_report_show_text,
+)
+
+
+def _bank_service_summary(
+    *,
+    exact_packets: int = 1,
+    unknown_packets: int = 0,
+    conflict_free_packets: int = 0,
+    conflicted_packets: int = 1,
+    required_rounds: int = 4,
+    uncontended_rounds: int = 2,
+    extra_rounds: int = 2,
+) -> dict[str, object]:
+    return {
+        "modeled_packet_count": exact_packets + unknown_packets,
+        "exact_packet_count": exact_packets,
+        "unknown_packet_count": unknown_packets,
+        "structural": {
+            "conflict_free_packet_count": conflict_free_packets,
+            "conflicted_packet_count": conflicted_packets,
+            "required_round_count": required_rounds,
+            "uncontended_round_count": uncontended_rounds,
+            "extra_round_count": extra_rounds,
+            "maximum_request_multiplicity": 2,
+        },
+        "dynamic": {
+            "exact_packet_count": exact_packets,
+            "unknown_packet_count": unknown_packets,
+            "packet_count": exact_packets,
+            "required_round_count": required_rounds,
+            "uncontended_round_count": uncontended_rounds,
+            "extra_round_count": extra_rounds,
+        },
+    }
+
+
+def _bank_service_group() -> dict[str, object]:
+    return {
+        "index": 0,
+        "function": "routed_linear",
+        "source_op": "vector.fragment.load",
+        "source_op_kind": 80,
+        "source_root": "scratch",
+        "memory_space": "workgroup",
+        "operation": "load",
+        "packet": "amdgpu.ds_read_b128",
+        "strategy": None,
+        "model": {
+            "key": "amdgpu.lds.wave32.b128.quad-phases.read.count-each",
+            "revision": "llvm-project@bank-model",
+            "evidence": "silicon-calibrated-vendor-model",
+            "request_policy": "count-each",
+            "wave_size": 32,
+            "bank_count": 32,
+            "bank_word_bytes": 4,
+            "packet_bank_words": 4,
+        },
+        "summary": _bank_service_summary(),
+    }
+
+
+def _compile_report() -> dict[str, object]:
+    workload = {
+        "workgroup_size": {"x": 128, "y": 1, "z": 1, "flat": 128},
+        "workgroup_count": {"x": 1, "y": 1, "z": 1, "flat": 1},
+        "dispatch_workitem_count": 128,
+    }
+    return {
+        "kind": "loom.compile_report",
+        "schema_version": 0,
+        "mode": "summary",
+        "artifact_kind": "hal-executable",
+        "artifact_format": "hsaco",
+        "backend": "amdgpu-hal",
+        "status": {"code": 0, "name": "OK"},
+        "target_family": "AMDGPU",
+        "target_key": "gfx1250-a0",
+        "target_bundle": "gfx1250-a0",
+        "target_snapshot": "gfx1250-a0",
+        "target_config": "gfx1250-a0",
+        "workload": workload,
+        "source_low": {
+            "memory": {
+                "bank_service": _bank_service_summary(),
+                "bank_service_group_count": 1,
+                "bank_service_groups": [_bank_service_group()],
+            }
+        },
+        "entries": {
+            "count": 1,
+            "rows": [
+                {
+                    "index": 0,
+                    "function": "routed_linear",
+                    "source_function": "routed_linear",
+                    "target_bundle": "gfx1250-a0",
+                    "target_snapshot": "gfx1250-a0",
+                    "target_export": "routed_linear",
+                    "target_export_symbol": None,
+                    "target_config": "gfx1250-a0",
+                    "workload": workload,
+                }
+            ],
+        },
+    }
+
+
+def test_show_preserves_service_proof_and_model_provenance() -> None:
+    document = parse_compile_report(_compile_report(), source="report.json")
+
+    view = build_compile_report_show(document)
+
+    bank_service = view["bank_service"]
+    assert bank_service["summary"]["conflicted_packet_count"] == 1
+    assert (
+        bank_service["groups"][0]["model"]["evidence"]
+        == "silicon-calibrated-vendor-model"
+    )
+    text = format_compile_report_show_text(view)
+    assert "Bank service (compiler analysis)" in text
+    assert "structural extra rounds: 2" in text
+    assert "vector.fragment.load scratch [amdgpu.ds_read_b128]" in text
+
+
+def test_diff_matches_semantic_groups_and_reports_service_delta() -> None:
+    baseline = parse_compile_report(_compile_report(), source="baseline.json")
+    candidate_report = _compile_report()
+    candidate_memory = candidate_report["source_low"]["memory"]
+    candidate_memory["bank_service"]["structural"]["extra_round_count"] = 1
+    candidate_memory["bank_service"]["dynamic"]["extra_round_count"] = 1
+    candidate_summary = candidate_memory["bank_service_groups"][0]["summary"]
+    candidate_summary["structural"]["extra_round_count"] = 1
+    candidate_summary["dynamic"]["extra_round_count"] = 1
+    candidate = parse_compile_report(candidate_report, source="candidate.json")
+
+    view = build_compile_report_diff(baseline, candidate)
+
+    bank_service = view["bank_service"]
+    assert bank_service["changed_group_count"] == 1
+    group = bank_service["groups"][0]
+    assert group["proof_loss"] is False
+    assert group["service"]["changed"]["extra_round_count"]["delta"] == -1
+    text = format_compile_report_diff_text(view)
+    assert "Bank service diff (compiler analysis)" in text
+    assert "structural extra rounds: 2 -> 1, delta -1" in text
+
+
+def test_diff_calls_out_proof_and_model_regressions() -> None:
+    baseline = parse_compile_report(_compile_report(), source="baseline.json")
+    candidate_report = _compile_report()
+    memory = candidate_report["source_low"]["memory"]
+    memory["bank_service"] = _bank_service_summary(
+        exact_packets=0,
+        unknown_packets=1,
+        conflicted_packets=0,
+        required_rounds=0,
+        uncontended_rounds=0,
+        extra_rounds=0,
+    )
+    group = memory["bank_service_groups"][0]
+    group["summary"] = deepcopy(memory["bank_service"])
+    group["unknown_evidence"] = {
+        "reason": "active-lane-control-not-uniform",
+        "mixed_reasons": False,
+    }
+    group["model"]["revision"] = "llvm-project@new-bank-model"
+    candidate = parse_compile_report(candidate_report, source="candidate.json")
+
+    view = build_compile_report_diff(baseline, candidate)
+
+    bank_service = view["bank_service"]
+    group_diff = bank_service["groups"][0]
+    assert group_diff["proof_loss"] is True
+    assert group_diff["model"]["revision"] == {
+        "baseline": "llvm-project@bank-model",
+        "candidate": "llvm-project@new-bank-model",
+    }
+    text = format_compile_report_diff_text(view)
+    assert "exact proof coverage regressed" in text
+    assert "unknown evidence" in text
+
+
+def test_diff_rejects_duplicate_semantic_group_identity() -> None:
+    baseline_report = _compile_report()
+    duplicate = deepcopy(
+        baseline_report["source_low"]["memory"]["bank_service_groups"][0]
+    )
+    duplicate["index"] = 1
+    baseline_report["source_low"]["memory"]["bank_service_groups"].append(duplicate)
+    baseline_report["source_low"]["memory"]["bank_service_group_count"] = 2
+    baseline = parse_compile_report(baseline_report, source="baseline.json")
+    candidate = parse_compile_report(_compile_report(), source="candidate.json")
+
+    with pytest.raises(CompileReportError, match="duplicate semantic group identity"):
+        build_compile_report_diff(baseline, candidate)

--- a/loom/py/loom/reporting/compile_report_suggestions.py
+++ b/loom/py/loom/reporting/compile_report_suggestions.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Protocol
 
 from loom.reporting.compile_report import (
@@ -17,6 +18,20 @@ from loom.reporting.compile_report import (
 )
 
 SUGGEST_KIND = "loom.compile_report.suggest"
+
+
+class CompileReportSuggestionConfidence(StrEnum):
+    """Evidence tier for one proposed experiment."""
+
+    HIGH = "high"
+    EXPERIMENTAL = "experimental"
+
+
+@dataclass(frozen=True, slots=True)
+class CompileReportSuggestionOptions:
+    """Controls whether lower-confidence experiments may be surfaced."""
+
+    include_experimental: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,6 +50,9 @@ class CompileReportSuggestion:
     entry_name: str
     action: str
     evidence: tuple[CompileReportSuggestionEvidence, ...]
+    confidence: CompileReportSuggestionConfidence = (
+        CompileReportSuggestionConfidence.HIGH
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,7 +70,11 @@ class CompileReportSuggestionProvider(Protocol):
     target_family: str
     provider_name: str
 
-    def suggest(self, document: CompileReportDocument) -> CompileReportSuggestionResult:
+    def suggest(
+        self,
+        document: CompileReportDocument,
+        options: CompileReportSuggestionOptions,
+    ) -> CompileReportSuggestionResult:
         """Returns ordered suggestions for a validated compile report."""
         ...
 
@@ -83,6 +105,7 @@ def build_compile_report_suggestions(
             {
                 "id": suggestion.suggestion_id,
                 "entry": suggestion.entry_name,
+                "confidence": suggestion.confidence.value,
                 "action": suggestion.action,
                 "evidence": {
                     evidence.path: evidence.value for evidence in suggestion.evidence
@@ -124,6 +147,7 @@ def format_compile_report_suggestions_text(view: dict[str, object]) -> str:
             (
                 "",
                 f"[{finding['id']}] {finding['entry']}",
+                f"  confidence: {finding['confidence']}",
                 f"  action: {finding['action']}",
                 "  evidence:",
             )

--- a/loom/py/loom/reporting/compile_report_suggestions_test.py
+++ b/loom/py/loom/reporting/compile_report_suggestions_test.py
@@ -55,12 +55,14 @@ def test_builds_compact_suggestion_view_with_cited_evidence() -> None:
         {
             "id": "test.reduce_pressure",
             "entry": "kernel",
+            "confidence": "high",
             "action": "Reduce pressure and recompile.",
             "evidence": {"entries.rows[0].pressure": 128},
         }
     ]
     text = format_compile_report_suggestions_text(view)
     assert "[test.reduce_pressure] kernel" in text
+    assert "confidence: high" in text
     assert "entries.rows[0].pressure: 128" in text
 
 

--- a/loom/py/loom/reporting/compile_report_test.py
+++ b/loom/py/loom/reporting/compile_report_test.py
@@ -41,6 +41,10 @@ def _compile_report() -> dict[str, object]:
         "target_config": "gfx11_wave64",
         "workload": workload,
         "instruction_count": 100,
+        "body_instruction_count": 97,
+        "entry_instruction_count": 3,
+        "coissued_instruction_count": 4,
+        "coissued_component_count": 8,
         "code_byte_count": 512,
         "code_storage_byte_count": 512,
         "local_memory_bytes": 4096,
@@ -53,9 +57,15 @@ def _compile_report() -> dict[str, object]:
         "schedule_dependency_count": 120,
         "schedule_hazard_gap_count": 2,
         "static_instruction_mix": {
+            "unknown_count": 0,
             "scalar_alu_count": 10,
             "vector_alu_count": 40,
             "matrix_count": 8,
+            "mfma_count": 0,
+            "smfmac_count": 0,
+            "wmma_count": 8,
+            "swmmac_count": 0,
+            "dot_count": 0,
             "global_load_count": 4,
             "global_store_count": 2,
             "buffer_load_count": 6,
@@ -99,6 +109,7 @@ def _compile_report() -> dict[str, object]:
                 "dispatch": {
                     "vector_alu_count": 40960,
                     "matrix_count": 8192,
+                    "wmma_count": 8192,
                 }
             },
             "memory": {
@@ -111,8 +122,20 @@ def _compile_report() -> dict[str, object]:
         },
         "wait_plan": {
             "action_count": 12,
+            "explicit_action_count": 2,
+            "planned_action_count": 10,
             "full_drain_count": 3,
             "partial_wait_count": 9,
+            "drained_count": 20,
+            "max_drained_count": 4,
+            "max_outstanding_before": 7,
+            "max_full_drain_outstanding_before": 6,
+        },
+        "target_insertions": {
+            "static_packet_count": 4,
+            "exact_dynamic_packet_count": 4,
+            "unknown_dynamic_packet_count": 0,
+            "dynamic_packet_count": 384,
         },
     }
     return {
@@ -252,6 +275,10 @@ def test_rejects_incomparable_reports(mutate, message: str) -> None:
 def test_show_separates_facts_analysis_and_unavailable_evidence() -> None:
     report = _compile_report()
     del report["entries"]["rows"][0]["wait_plan"]["partial_wait_count"]
+    report["entries"]["rows"][0]["target_insertions"][
+        "unknown_dynamic_packet_count"
+    ] = 1
+    report["entries"]["rows"][0]["target_insertions"]["dynamic_packet_count"] = None
     document = parse_compile_report(report, source="report.json")
 
     view = build_compile_report_show(document)
@@ -262,14 +289,27 @@ def test_show_separates_facts_analysis_and_unavailable_evidence() -> None:
     assert view["missing_evidence"] == "omitted_metrics_are_unavailable"
     assert artifact_facts["code_byte_count"] == 512
     assert artifact_facts["private_memory_bytes"] == 0
+    assert artifact_facts["body_instruction_count"] == 97
+    assert artifact_facts["entry_instruction_count"] == 3
+    assert artifact_facts["coissued_instruction_count"] == 4
+    assert artifact_facts["coissued_component_count"] == 8
+    assert artifact_facts["wmma_count"] == 8
+    assert artifact_facts["unclassified_instruction_count"] == 0
     assert compiler_analysis["occupancy_percent"] == 31
     assert compiler_analysis["residency_next_better_tier"] == 6
     assert compiler_analysis["dispatch_total_bytes"] == 4096
+    assert compiler_analysis["dispatch_wmma_count"] == 8192
+    assert compiler_analysis["planned_wait_action_count"] == 10
+    assert compiler_analysis["target_insertion_static_packet_count"] == 4
+    assert compiler_analysis["target_insertion_unknown_dynamic_packet_count"] == 1
+    assert "target_insertion_dynamic_packet_count" not in compiler_analysis
     assert "partial_wait_count" not in compiler_analysis
     text = format_compile_report_show_text(view)
     assert "Artifact facts" in text
     assert "Compiler analysis" in text
     assert "code bytes: 512 B" in text
+    assert "WMMA instructions: 8" in text
+    assert "target-planned wait actions: 10" in text
     assert "partial waits: unavailable" in text
 
 
@@ -278,22 +318,55 @@ def test_diff_preserves_missing_evidence_and_numeric_deltas() -> None:
     candidate_report = _compile_report()
     candidate_entry = candidate_report["entries"]["rows"][0]
     candidate_entry["code_byte_count"] = 480
+    candidate_entry["body_instruction_count"] = 89
+    candidate_entry["static_instruction_mix"]["wmma_count"] = 6
+    candidate_entry["economics"]["operations"]["dispatch"]["wmma_count"] = 6144
+    candidate_entry["wait_plan"]["planned_action_count"] = 8
+    candidate_entry["target_insertions"]["dynamic_packet_count"] = 256
     del candidate_entry["wait_plan"]["partial_wait_count"]
     candidate = parse_compile_report(candidate_report, source="candidate.json")
 
     view = build_compile_report_diff(baseline, candidate)
     entry = view["entries"][0]
     code_bytes = entry["artifact_facts"]["changed"]["code_byte_count"]
+    body_instructions = entry["artifact_facts"]["changed"]["body_instruction_count"]
+    wmma = entry["artifact_facts"]["changed"]["wmma_count"]
     partial_waits = entry["compiler_analysis"]["incomplete"]["partial_wait_count"]
+    dynamic_wmma = entry["compiler_analysis"]["changed"]["dispatch_wmma_count"]
+    planned_waits = entry["compiler_analysis"]["changed"]["planned_wait_action_count"]
+    target_insertions = entry["compiler_analysis"]["changed"][
+        "target_insertion_dynamic_packet_count"
+    ]
 
     assert code_bytes["delta"] == -32
     assert code_bytes["change_percent"] == -6.25
+    assert body_instructions["delta"] == -8
+    assert wmma["delta"] == -2
+    assert dynamic_wmma["delta"] == -2048
+    assert planned_waits["delta"] == -2
+    assert target_insertions["delta"] == -128
     assert partial_waits["candidate"] is None
     assert view["changed_entry_count"] == 1
     assert view["unchanged_entry_count"] == 0
     text = format_compile_report_diff_text(view)
     assert "512 B -> 480 B, delta -32 B (-6.25%)" in text
     assert "partial waits: 9 -> unavailable" in text
+
+
+def test_diff_treats_explicit_null_as_unavailable_evidence() -> None:
+    baseline = parse_compile_report(_compile_report(), source="baseline.json")
+    candidate_report = _compile_report()
+    candidate_report["entries"]["rows"][0]["target_insertions"][
+        "dynamic_packet_count"
+    ] = None
+    candidate = parse_compile_report(candidate_report, source="candidate.json")
+
+    view = build_compile_report_diff(baseline, candidate)
+    target_insertions = view["entries"][0]["compiler_analysis"]["incomplete"][
+        "target_insertion_dynamic_packet_count"
+    ]
+
+    assert target_insertions == {"baseline": 384, "candidate": None}
 
 
 def test_diff_omits_unchanged_entries() -> None:

--- a/loom/py/loom/reporting/compile_report_view.py
+++ b/loom/py/loom/reporting/compile_report_view.py
@@ -60,6 +60,26 @@ def _analysis(key: str, label: str, path: str, unit: str | None = None) -> Metri
 
 _METRIC_SPECS = (
     _artifact("instruction_count", "instructions", "instruction_count"),
+    _artifact(
+        "body_instruction_count",
+        "body instructions",
+        "body_instruction_count",
+    ),
+    _artifact(
+        "entry_instruction_count",
+        "entry-envelope instructions",
+        "entry_instruction_count",
+    ),
+    _artifact(
+        "coissued_instruction_count",
+        "native coissued instructions",
+        "coissued_instruction_count",
+    ),
+    _artifact(
+        "coissued_component_count",
+        "coissued semantic components",
+        "coissued_component_count",
+    ),
     _artifact("code_byte_count", "code bytes", "code_byte_count", "bytes"),
     _artifact(
         "code_storage_byte_count",
@@ -80,6 +100,11 @@ _METRIC_SPECS = (
         "static_instruction_mix.scalar_alu_count",
     ),
     _artifact(
+        "unclassified_instruction_count",
+        "unclassified instructions",
+        "static_instruction_mix.unknown_count",
+    ),
+    _artifact(
         "vector_alu_count",
         "vector ALU instructions",
         "static_instruction_mix.vector_alu_count",
@@ -89,6 +114,19 @@ _METRIC_SPECS = (
         "matrix instructions",
         "static_instruction_mix.matrix_count",
     ),
+    _artifact("mfma_count", "MFMA instructions", "static_instruction_mix.mfma_count"),
+    _artifact(
+        "smfmac_count",
+        "SMFMAC instructions",
+        "static_instruction_mix.smfmac_count",
+    ),
+    _artifact("wmma_count", "WMMA instructions", "static_instruction_mix.wmma_count"),
+    _artifact(
+        "swmmac_count",
+        "SWMMAC instructions",
+        "static_instruction_mix.swmmac_count",
+    ),
+    _artifact("dot_count", "dot instructions", "static_instruction_mix.dot_count"),
     _artifact(
         "global_load_count",
         "global loads",
@@ -217,6 +255,31 @@ _METRIC_SPECS = (
         "estimated dispatch matrix operations",
         "economics.operations.dispatch.matrix_count",
     ),
+    _analysis(
+        "dispatch_mfma_count",
+        "estimated dispatch MFMA",
+        "economics.operations.dispatch.mfma_count",
+    ),
+    _analysis(
+        "dispatch_smfmac_count",
+        "estimated dispatch SMFMAC",
+        "economics.operations.dispatch.smfmac_count",
+    ),
+    _analysis(
+        "dispatch_wmma_count",
+        "estimated dispatch WMMA",
+        "economics.operations.dispatch.wmma_count",
+    ),
+    _analysis(
+        "dispatch_swmmac_count",
+        "estimated dispatch SWMMAC",
+        "economics.operations.dispatch.swmmac_count",
+    ),
+    _analysis(
+        "dispatch_dot_count",
+        "estimated dispatch dot operations",
+        "economics.operations.dispatch.dot_count",
+    ),
     _analysis("schedule_node_count", "schedule nodes", "schedule_node_count"),
     _analysis(
         "schedule_dependency_count",
@@ -251,8 +314,58 @@ _METRIC_SPECS = (
         "bytes",
     ),
     _analysis("wait_action_count", "wait actions", "wait_plan.action_count"),
+    _analysis(
+        "explicit_wait_action_count",
+        "explicit wait actions",
+        "wait_plan.explicit_action_count",
+    ),
+    _analysis(
+        "planned_wait_action_count",
+        "target-planned wait actions",
+        "wait_plan.planned_action_count",
+    ),
     _analysis("full_drain_count", "full drains", "wait_plan.full_drain_count"),
     _analysis("partial_wait_count", "partial waits", "wait_plan.partial_wait_count"),
+    _analysis(
+        "wait_drained_packet_count",
+        "packets drained by waits",
+        "wait_plan.drained_count",
+    ),
+    _analysis(
+        "wait_maximum_drained_packet_count",
+        "maximum packets drained by one wait",
+        "wait_plan.max_drained_count",
+    ),
+    _analysis(
+        "wait_maximum_outstanding_packet_count",
+        "maximum packets outstanding before a wait",
+        "wait_plan.max_outstanding_before",
+    ),
+    _analysis(
+        "wait_maximum_full_drain_outstanding_packet_count",
+        "maximum packets outstanding before a full drain",
+        "wait_plan.max_full_drain_outstanding_before",
+    ),
+    _analysis(
+        "target_insertion_static_packet_count",
+        "target-inserted static packets",
+        "target_insertions.static_packet_count",
+    ),
+    _analysis(
+        "target_insertion_exact_dynamic_packet_count",
+        "target insertions with exact dynamic counts",
+        "target_insertions.exact_dynamic_packet_count",
+    ),
+    _analysis(
+        "target_insertion_unknown_dynamic_packet_count",
+        "target insertions with unknown dynamic counts",
+        "target_insertions.unknown_dynamic_packet_count",
+    ),
+    _analysis(
+        "target_insertion_dynamic_packet_count",
+        "target-inserted dynamic packets",
+        "target_insertions.dynamic_packet_count",
+    ),
 )
 
 
@@ -451,7 +564,7 @@ def _show_metrics(
         if spec.evidence is not evidence:
             continue
         value = _lookup(entry, spec.path)
-        if value is not _MISSING:
+        if value is not _MISSING and value is not None:
             metrics[spec.key] = value
     return metrics
 
@@ -470,6 +583,10 @@ def _diff_metrics(
             continue
         baseline_value = _lookup(baseline, spec.path)
         candidate_value = _lookup(candidate, spec.path)
+        if baseline_value is None:
+            baseline_value = _MISSING
+        if candidate_value is None:
+            candidate_value = _MISSING
         if baseline_value is _MISSING and candidate_value is _MISSING:
             unavailable_count += 1
             continue

--- a/loom/py/loom/reporting/compile_report_view.py
+++ b/loom/py/loom/reporting/compile_report_view.py
@@ -19,6 +19,12 @@ from loom.reporting.compile_report import (
     match_compile_report_entries,
     report_identity_json,
 )
+from loom.reporting.compile_report_bank_service import (
+    append_bank_service_diff_text,
+    append_bank_service_show_text,
+    build_bank_service_diff,
+    build_bank_service_show,
+)
 
 SHOW_KIND = "loom.compile_report.show"
 DIFF_KIND = "loom.compile_report.diff"
@@ -274,6 +280,9 @@ def build_compile_report_show(
             for entry in document.entries
         ],
     }
+    bank_service = build_bank_service_show(document)
+    if bank_service is not None:
+        view["bank_service"] = bank_service
     if document.envelope_context:
         view["envelope_context"] = dict(document.envelope_context)
     return view
@@ -310,7 +319,7 @@ def build_compile_report_diff(
                 "compiler_analysis": compiler_analysis,
             }
         )
-    return {
+    view: dict[str, object] = {
         "kind": DIFF_KIND,
         "schema_version": COMPILE_REPORT_SCHEMA_VERSION,
         "missing_evidence": "omitted_metrics_are_unavailable",
@@ -321,6 +330,10 @@ def build_compile_report_diff(
         "unchanged_entry_count": unchanged_entry_count,
         "entries": entries,
     }
+    bank_service = build_bank_service_diff(baseline, candidate)
+    if bank_service is not None:
+        view["bank_service"] = bank_service
+    return view
 
 
 def format_compile_report_show_text(view: dict[str, object]) -> str:
@@ -372,6 +385,9 @@ def format_compile_report_show_text(view: dict[str, object]) -> str:
             _expect_dict(entry["compiler_analysis"]),
             EvidenceClass.COMPILER_ANALYSIS,
         )
+    bank_service = view.get("bank_service")
+    if isinstance(bank_service, dict):
+        append_bank_service_show_text(lines, bank_service)
     return "\n".join(lines) + "\n"
 
 
@@ -406,6 +422,9 @@ def format_compile_report_diff_text(view: dict[str, object]) -> str:
             _expect_dict(entry["compiler_analysis"]),
             EvidenceClass.COMPILER_ANALYSIS,
         )
+    bank_service = view.get("bank_service")
+    if isinstance(bank_service, dict):
+        append_bank_service_diff_text(lines, bank_service)
     return "\n".join(lines) + "\n"
 
 

--- a/loom/py/loom/target/arch/amdgpu/BUILD.bazel
+++ b/loom/py/loom/target/arch/amdgpu/BUILD.bazel
@@ -62,6 +62,7 @@ iree_py_library(
     srcs = ["compile_report_suggestions.py"],
     deps = [
         ":target_identity",
+        ":target_info",
         "//loom/py/loom/reporting",
     ],
 )

--- a/loom/py/loom/target/arch/amdgpu/CMakeLists.txt
+++ b/loom/py/loom/target/arch/amdgpu/CMakeLists.txt
@@ -70,6 +70,7 @@ iree_py_library(
     "compile_report_suggestions.py"
   DEPS
     loom::py::loom::target::arch::amdgpu::target_identity
+    loom::py::loom::target::arch::amdgpu::target_info
     loom::py::loom::reporting::reporting
 )
 

--- a/loom/py/loom/target/arch/amdgpu/compile_report_suggestions.py
+++ b/loom/py/loom/target/arch/amdgpu/compile_report_suggestions.py
@@ -10,12 +10,20 @@ from __future__ import annotations
 
 from loom.reporting.compile_report import (
     CompileReportDocument,
+    CompileReportError,
     compile_report_entry_identity,
 )
 from loom.reporting.compile_report_suggestions import (
     CompileReportSuggestion,
+    CompileReportSuggestionConfidence,
     CompileReportSuggestionEvidence,
+    CompileReportSuggestionOptions,
     CompileReportSuggestionResult,
+)
+from loom.target.arch.amdgpu.lds_bank_service import (
+    AMDGPU_LDS_BANK_SERVICE_EVIDENCE_PUBLIC_VENDOR_DOCUMENTATION,
+    AMDGPU_LDS_BANK_SERVICE_EVIDENCE_SILICON_CALIBRATED_VENDOR_MODEL,
+    AMDGPU_LDS_BANK_SERVICE_EVIDENCE_VENDOR_SOFTWARE_MODEL_UNVALIDATED,
 )
 from loom.target.arch.amdgpu.target_identity import (
     AmdgpuArtifactTargetKeyError,
@@ -29,7 +37,13 @@ class AmdgpuCompileReportSuggestionProvider:
     target_family = "AMDGPU"
     provider_name = "amdgpu"
 
-    def suggest(self, document: CompileReportDocument) -> CompileReportSuggestionResult:
+    def suggest(
+        self,
+        document: CompileReportDocument,
+        options: CompileReportSuggestionOptions | None = None,
+    ) -> CompileReportSuggestionResult:
+        if options is None:
+            options = CompileReportSuggestionOptions()
         target_key = document.report.get("target_key")
         if target_key is None:
             return CompileReportSuggestionResult(
@@ -76,6 +90,7 @@ class AmdgpuCompileReportSuggestionProvider:
             )
             if wave_suggestion is not None:
                 suggestions.append(wave_suggestion)
+        suggestions.extend(_suggest_lds_bank_service(document, options))
         return CompileReportSuggestionResult(
             provider_name=self.provider_name,
             unavailable_reason=None,
@@ -243,6 +258,223 @@ def _suggest_nondefault_wave_size(
             ),
         ),
     )
+
+
+def _suggest_lds_bank_service(
+    document: CompileReportDocument,
+    options: CompileReportSuggestionOptions,
+) -> tuple[CompileReportSuggestion, ...]:
+    source_low = document.report.get("source_low")
+    if source_low is None:
+        return ()
+    source_low_object = _report_object(source_low, "source_low")
+    memory = source_low_object.get("memory")
+    if memory is None:
+        return ()
+    memory_object = _report_object(memory, "source_low.memory")
+    group_values = memory_object.get("bank_service_groups")
+    if group_values is None:
+        return ()
+    if not isinstance(group_values, list):
+        raise CompileReportError(
+            "source_low.memory.bank_service_groups: expected array"
+        )
+    group_count = _report_integer(
+        memory_object.get("bank_service_group_count"),
+        "source_low.memory.bank_service_group_count",
+    )
+    if group_count != len(group_values):
+        raise CompileReportError(
+            "source_low.memory.bank_service_group_count: "
+            f"expected {len(group_values)}, got {group_count}"
+        )
+
+    suggestions = []
+    for group_position, group_value in enumerate(group_values):
+        path_prefix = f"source_low.memory.bank_service_groups[{group_position}]"
+        group = _report_object(group_value, path_prefix)
+        report_index = _report_integer(group.get("index"), f"{path_prefix}.index")
+        if report_index != group_position:
+            raise CompileReportError(
+                f"{path_prefix}.index: expected {group_position}, got {report_index}"
+            )
+        model = _report_object(group.get("model"), f"{path_prefix}.model")
+        summary = _report_object(group.get("summary"), f"{path_prefix}.summary")
+        structural = _report_object(
+            summary.get("structural"),
+            f"{path_prefix}.summary.structural",
+        )
+
+        exact_packet_count = _report_integer(
+            summary.get("exact_packet_count"),
+            f"{path_prefix}.summary.exact_packet_count",
+        )
+        unknown_packet_count = _report_integer(
+            summary.get("unknown_packet_count"),
+            f"{path_prefix}.summary.unknown_packet_count",
+        )
+        conflicted_packet_count = _report_integer(
+            structural.get("conflicted_packet_count"),
+            f"{path_prefix}.summary.structural.conflicted_packet_count",
+        )
+        extra_round_count = _report_integer(
+            structural.get("extra_round_count"),
+            f"{path_prefix}.summary.structural.extra_round_count",
+        )
+        maximum_request_multiplicity = _report_integer(
+            structural.get("maximum_request_multiplicity"),
+            (f"{path_prefix}.summary.structural.maximum_request_multiplicity"),
+        )
+        if (
+            exact_packet_count == 0
+            or unknown_packet_count != 0
+            or conflicted_packet_count == 0
+            or extra_round_count == 0
+        ):
+            continue
+
+        model_evidence = _report_string(
+            model.get("evidence"),
+            f"{path_prefix}.model.evidence",
+        )
+        if model_evidence in (
+            AMDGPU_LDS_BANK_SERVICE_EVIDENCE_PUBLIC_VENDOR_DOCUMENTATION,
+            AMDGPU_LDS_BANK_SERVICE_EVIDENCE_SILICON_CALIBRATED_VENDOR_MODEL,
+        ):
+            confidence = CompileReportSuggestionConfidence.HIGH
+        elif (
+            model_evidence
+            == AMDGPU_LDS_BANK_SERVICE_EVIDENCE_VENDOR_SOFTWARE_MODEL_UNVALIDATED
+        ):
+            if not options.include_experimental:
+                continue
+            confidence = CompileReportSuggestionConfidence.EXPERIMENTAL
+        else:
+            raise CompileReportError(
+                f"{path_prefix}.model.evidence: unsupported evidence class "
+                f"{model_evidence!r}"
+            )
+
+        function_name = _optional_report_string(
+            group.get("function"),
+            f"{path_prefix}.function",
+        )
+        source_op = _optional_report_string(
+            group.get("source_op"),
+            f"{path_prefix}.source_op",
+        )
+        source_root = _optional_report_string(
+            group.get("source_root"),
+            f"{path_prefix}.source_root",
+        )
+        source_root_argument_index_value = group.get("source_root_argument_index")
+        if source_root_argument_index_value is not None:
+            source_root_argument_index = _report_integer(
+                source_root_argument_index_value,
+                f"{path_prefix}.source_root_argument_index",
+            )
+            if source_root is None:
+                source_root = f"arg{source_root_argument_index}"
+        packet = _optional_report_string(
+            group.get("packet"),
+            f"{path_prefix}.packet",
+        )
+        entry_name = _entry_name_for_function(document, function_name)
+        location = "/".join(
+            value for value in (source_op, source_root, packet) if value is not None
+        )
+        suggestions.append(
+            CompileReportSuggestion(
+                suggestion_id="amdgpu.lds_bank_service",
+                entry_name=entry_name,
+                confidence=confidence,
+                action=(
+                    f"Search layout variants for {location or 'this LDS access'} "
+                    "using pitch or padding, lane mapping, fragment layout, or "
+                    "packet width to reduce exact structural extra rounds. "
+                    "Recompile each candidate, reject spill or occupancy "
+                    "regressions, and select only from hardware timing."
+                ),
+                evidence=(
+                    CompileReportSuggestionEvidence(
+                        path=f"{path_prefix}.summary.exact_packet_count",
+                        value=exact_packet_count,
+                    ),
+                    CompileReportSuggestionEvidence(
+                        path=(
+                            f"{path_prefix}.summary.structural.conflicted_packet_count"
+                        ),
+                        value=conflicted_packet_count,
+                    ),
+                    CompileReportSuggestionEvidence(
+                        path=(f"{path_prefix}.summary.structural.extra_round_count"),
+                        value=extra_round_count,
+                    ),
+                    CompileReportSuggestionEvidence(
+                        path=(
+                            f"{path_prefix}.summary.structural."
+                            "maximum_request_multiplicity"
+                        ),
+                        value=maximum_request_multiplicity,
+                    ),
+                    CompileReportSuggestionEvidence(
+                        path=f"{path_prefix}.model.evidence",
+                        value=model_evidence,
+                    ),
+                    CompileReportSuggestionEvidence(
+                        path=f"{path_prefix}.model.revision",
+                        value=_report_string(
+                            model.get("revision"),
+                            f"{path_prefix}.model.revision",
+                        ),
+                    ),
+                ),
+            )
+        )
+    return tuple(suggestions)
+
+
+def _entry_name_for_function(
+    document: CompileReportDocument,
+    function_name: str | None,
+) -> str:
+    if function_name is not None:
+        for entry in document.entries:
+            if function_name in (
+                entry.get("function"),
+                entry.get("source_function"),
+                entry.get("target_export"),
+                entry.get("target_export_symbol"),
+            ):
+                return compile_report_entry_identity(entry).display_name()
+        return function_name
+    if len(document.entries) == 1:
+        return compile_report_entry_identity(document.entries[0]).display_name()
+    return "<report>"
+
+
+def _report_object(value: object, path: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise CompileReportError(f"{path}: expected object")
+    return value
+
+
+def _report_integer(value: object, path: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise CompileReportError(f"{path}: expected integer")
+    return value
+
+
+def _report_string(value: object, path: str) -> str:
+    if not isinstance(value, str):
+        raise CompileReportError(f"{path}: expected string")
+    return value
+
+
+def _optional_report_string(value: object, path: str) -> str | None:
+    if value is None:
+        return None
+    return _report_string(value, path)
 
 
 def _object_at(root: dict[str, object], *components: str) -> dict[str, object] | None:

--- a/loom/py/loom/target/arch/amdgpu/compile_report_suggestions_test.py
+++ b/loom/py/loom/target/arch/amdgpu/compile_report_suggestions_test.py
@@ -6,7 +6,12 @@
 
 from __future__ import annotations
 
-from loom.reporting.compile_report import parse_compile_report
+import pytest
+
+from loom.reporting.compile_report import CompileReportError, parse_compile_report
+from loom.reporting.compile_report_suggestions import (
+    CompileReportSuggestionOptions,
+)
 from loom.target.arch.amdgpu.compile_report_suggestions import (
     AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER,
 )
@@ -50,6 +55,89 @@ def _compile_report(
     if target_key is not None:
         report["target_key"] = target_key
     return report
+
+
+def _add_bank_service_group(
+    report: dict[str, object],
+    *,
+    model_evidence: str,
+    exact_packet_count: int = 1,
+    unknown_packet_count: int = 0,
+    conflicted_packet_count: int = 1,
+    extra_round_count: int = 8,
+) -> None:
+    report["source_low"] = {
+        "memory": {
+            "bank_service": {
+                "modeled_packet_count": exact_packet_count + unknown_packet_count,
+                "exact_packet_count": exact_packet_count,
+                "unknown_packet_count": unknown_packet_count,
+                "structural": {
+                    "conflict_free_packet_count": 0,
+                    "conflicted_packet_count": conflicted_packet_count,
+                    "required_round_count": 16,
+                    "uncontended_round_count": 8,
+                    "extra_round_count": extra_round_count,
+                    "maximum_request_multiplicity": 2,
+                },
+                "dynamic": {
+                    "exact_packet_count": exact_packet_count,
+                    "unknown_packet_count": unknown_packet_count,
+                    "packet_count": exact_packet_count,
+                    "required_round_count": 16,
+                    "uncontended_round_count": 8,
+                    "extra_round_count": extra_round_count,
+                },
+            },
+            "bank_service_group_count": 1,
+            "bank_service_groups": [
+                {
+                    "index": 0,
+                    "function": "routed_linear",
+                    "source_op": "vector.fragment.load",
+                    "source_op_kind": 80,
+                    "source_root": "scratch",
+                    "memory_space": "workgroup",
+                    "operation": "load",
+                    "packet": "amdgpu.ds_read_b128",
+                    "strategy": None,
+                    "model": {
+                        "key": ("amdgpu.lds.wave32.b128.quad-phases.read.count-each"),
+                        "revision": "ROCm/rocm-libraries@model",
+                        "evidence": model_evidence,
+                        "request_policy": "count-each",
+                        "wave_size": 32,
+                        "bank_count": 32,
+                        "bank_word_bytes": 4,
+                        "packet_bank_words": 4,
+                    },
+                    "summary": {
+                        "modeled_packet_count": (
+                            exact_packet_count + unknown_packet_count
+                        ),
+                        "exact_packet_count": exact_packet_count,
+                        "unknown_packet_count": unknown_packet_count,
+                        "structural": {
+                            "conflict_free_packet_count": 0,
+                            "conflicted_packet_count": conflicted_packet_count,
+                            "required_round_count": 16,
+                            "uncontended_round_count": 8,
+                            "extra_round_count": extra_round_count,
+                            "maximum_request_multiplicity": 2,
+                        },
+                        "dynamic": {
+                            "exact_packet_count": exact_packet_count,
+                            "unknown_packet_count": unknown_packet_count,
+                            "packet_count": exact_packet_count,
+                            "required_round_count": 16,
+                            "uncontended_round_count": 8,
+                            "extra_round_count": extra_round_count,
+                        },
+                    },
+                }
+            ],
+        }
+    }
 
 
 def test_suggests_ordered_experiments_from_exact_target_evidence() -> None:
@@ -132,3 +220,75 @@ def test_private_memory_is_reported_once_without_spill_evidence() -> None:
         "amdgpu.residency_cliff",
         "amdgpu.nondefault_wave_size",
     ]
+
+
+def test_unvalidated_bank_model_is_explicitly_opt_in() -> None:
+    report = _compile_report(target_key="gfx1250-a0", subgroup_size=32)
+    _add_bank_service_group(
+        report,
+        model_evidence="vendor-software-model-unvalidated",
+    )
+    document = parse_compile_report(report)
+
+    default_result = AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER.suggest(document)
+    experimental_result = AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER.suggest(
+        document,
+        CompileReportSuggestionOptions(include_experimental=True),
+    )
+
+    assert "amdgpu.lds_bank_service" not in {
+        suggestion.suggestion_id for suggestion in default_result.suggestions
+    }
+    bank_suggestion = experimental_result.suggestions[-1]
+    assert bank_suggestion.suggestion_id == "amdgpu.lds_bank_service"
+    assert bank_suggestion.confidence == "experimental"
+    assert "spill or occupancy regressions" in bank_suggestion.action
+    assert "hardware timing" in bank_suggestion.action
+    assert bank_suggestion.evidence[2].path.endswith(
+        "summary.structural.extra_round_count"
+    )
+    assert bank_suggestion.evidence[2].value == 8
+
+
+def test_calibrated_exact_bank_conflict_is_high_confidence() -> None:
+    report = _compile_report(target_key="gfx1250-a0", subgroup_size=32)
+    _add_bank_service_group(
+        report,
+        model_evidence="silicon-calibrated-vendor-model",
+    )
+    document = parse_compile_report(report)
+
+    result = AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER.suggest(document)
+
+    bank_suggestion = result.suggestions[-1]
+    assert bank_suggestion.suggestion_id == "amdgpu.lds_bank_service"
+    assert bank_suggestion.confidence == "high"
+
+
+def test_bank_suggestion_requires_complete_exact_conflict_evidence() -> None:
+    report = _compile_report(target_key="gfx1250-a0", subgroup_size=32)
+    _add_bank_service_group(
+        report,
+        model_evidence="silicon-calibrated-vendor-model",
+        exact_packet_count=1,
+        unknown_packet_count=1,
+    )
+    document = parse_compile_report(report)
+
+    result = AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER.suggest(document)
+
+    assert "amdgpu.lds_bank_service" not in {
+        suggestion.suggestion_id for suggestion in result.suggestions
+    }
+
+
+def test_bank_suggestion_rejects_unknown_model_evidence_class() -> None:
+    report = _compile_report(target_key="gfx1250-a0", subgroup_size=32)
+    _add_bank_service_group(
+        report,
+        model_evidence="unversioned-model",
+    )
+    document = parse_compile_report(report)
+
+    with pytest.raises(CompileReportError, match="unsupported evidence class"):
+        AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER.suggest(document)

--- a/loom/py/loom/target/arch/compile_report_suggestions.py
+++ b/loom/py/loom/target/arch/compile_report_suggestions.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from loom.reporting.compile_report import CompileReportDocument
 from loom.reporting.compile_report_suggestions import (
+    CompileReportSuggestionOptions,
     CompileReportSuggestionProvider,
     CompileReportSuggestionResult,
 )
@@ -24,8 +25,11 @@ _PROVIDERS: tuple[CompileReportSuggestionProvider, ...] = (
 
 def suggest_compile_report(
     document: CompileReportDocument,
+    options: CompileReportSuggestionOptions | None = None,
 ) -> CompileReportSuggestionResult:
     """Dispatches a validated report to its exact target-family provider."""
+    if options is None:
+        options = CompileReportSuggestionOptions()
     if document.status_code != 0:
         return CompileReportSuggestionResult(
             provider_name=None,
@@ -39,7 +43,7 @@ def suggest_compile_report(
         )
     for provider in _PROVIDERS:
         if provider.target_family == target_family:
-            return provider.suggest(document)
+            return provider.suggest(document, options)
     return CompileReportSuggestionResult(
         provider_name=None,
         unavailable_reason="unsupported_target_family",

--- a/loom/py/loom/tools/compile_report.py
+++ b/loom/py/loom/tools/compile_report.py
@@ -20,6 +20,7 @@ from loom.reporting.compile_report import (
     load_compile_report,
 )
 from loom.reporting.compile_report_suggestions import (
+    CompileReportSuggestionOptions,
     build_compile_report_suggestions,
     format_compile_report_suggestions_text,
 )
@@ -56,7 +57,12 @@ def run(args: argparse.Namespace, *, stdout: TextIO) -> int:
         text = format_compile_report_diff_text(view)
     elif args.command == "suggest":
         document = load_compile_report(args.report)
-        result = suggest_compile_report(document)
+        result = suggest_compile_report(
+            document,
+            CompileReportSuggestionOptions(
+                include_experimental=args.include_experimental,
+            ),
+        )
         view = build_compile_report_suggestions(document, result)
         text = format_compile_report_suggestions_text(view)
     else:
@@ -99,6 +105,14 @@ def _create_argument_parser() -> argparse.ArgumentParser:
         help="Suggests target-owned optimization experiments.",
     )
     suggest_parser.add_argument("report", type=Path, help="Compile report JSON path.")
+    suggest_parser.add_argument(
+        "--include-experimental",
+        action="store_true",
+        help=(
+            "Include experiments grounded in structurally exact but "
+            "hardware-unvalidated target models."
+        ),
+    )
     _add_output_format_argument(suggest_parser)
     return parser
 

--- a/loom/py/loom/tools/compile_report_test.py
+++ b/loom/py/loom/tools/compile_report_test.py
@@ -21,6 +21,7 @@ def _write_report(
     target_family: str = "AMDGPU",
     target_key: str = "gfx11-generic",
     target_record: str = "gfx11-generic",
+    experimental_bank_conflict: bool = False,
 ) -> None:
     workload = {
         "workgroup_size": {"x": 64, "y": 1, "z": 1, "flat": 64},
@@ -63,6 +64,60 @@ def _write_report(
             ],
         },
     }
+    if experimental_bank_conflict:
+        bank_service = {
+            "modeled_packet_count": 1,
+            "exact_packet_count": 1,
+            "unknown_packet_count": 0,
+            "structural": {
+                "conflict_free_packet_count": 0,
+                "conflicted_packet_count": 1,
+                "required_round_count": 16,
+                "uncontended_round_count": 8,
+                "extra_round_count": 8,
+                "maximum_request_multiplicity": 2,
+            },
+            "dynamic": {
+                "exact_packet_count": 1,
+                "unknown_packet_count": 0,
+                "packet_count": 1,
+                "required_round_count": 16,
+                "uncontended_round_count": 8,
+                "extra_round_count": 8,
+            },
+        }
+        report["source_low"] = {
+            "memory": {
+                "bank_service": bank_service,
+                "bank_service_group_count": 1,
+                "bank_service_groups": [
+                    {
+                        "index": 0,
+                        "function": "kernel",
+                        "source_op": "vector.fragment.load",
+                        "source_op_kind": 80,
+                        "source_root": "scratch",
+                        "memory_space": "workgroup",
+                        "operation": "load",
+                        "packet": "amdgpu.ds_read_b128",
+                        "strategy": None,
+                        "model": {
+                            "key": (
+                                "amdgpu.lds.wave32.b128.quad-phases.read.count-each"
+                            ),
+                            "revision": "ROCm/rocm-libraries@model",
+                            "evidence": "vendor-software-model-unvalidated",
+                            "request_policy": "count-each",
+                            "wave_size": 32,
+                            "bank_count": 32,
+                            "bank_word_bytes": 4,
+                            "packet_bank_words": 4,
+                        },
+                        "summary": bank_service,
+                    }
+                ],
+            }
+        }
     path.write_text(json.dumps(report), encoding="utf-8")
 
 
@@ -167,6 +222,44 @@ def test_suggest_json_uses_registered_target_provider(
     assert view["provider"] == "amdgpu"
     assert view["status"] == "available"
     assert view["findings"] == []
+
+
+def test_suggest_experimental_bank_model_requires_explicit_opt_in(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    report_path = tmp_path / "report.json"
+    _write_report(
+        report_path,
+        target_key="gfx1250-a0",
+        target_record="gfx1250-a0",
+        experimental_bank_conflict=True,
+    )
+
+    assert main(["suggest", str(report_path), "--format=json"]) == 0
+    default_view = json.loads(capsys.readouterr().out)
+    assert "amdgpu.lds_bank_service" not in {
+        finding["id"] for finding in default_view["findings"]
+    }
+
+    assert (
+        main(
+            [
+                "suggest",
+                str(report_path),
+                "--include-experimental",
+                "--format=json",
+            ]
+        )
+        == 0
+    )
+    experimental_view = json.loads(capsys.readouterr().out)
+    finding = next(
+        finding
+        for finding in experimental_view["findings"]
+        if finding["id"] == "amdgpu.lds_bank_service"
+    )
+    assert finding["confidence"] == "experimental"
 
 
 @pytest.mark.parametrize(

--- a/loom/src/loom/target/reporting/format_json.c
+++ b/loom/src/loom/target/reporting/format_json.c
@@ -1333,6 +1333,18 @@ static iree_status_t loom_target_compile_report_format_entry_json(
       &object, IREE_SV("private_memory_bytes"), row->private_memory_bytes));
   IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
       &object, IREE_SV("local_memory_bytes"), row->local_memory_bytes));
+  if (row->bank_service_summary.modeled_packet_count != 0) {
+    IREE_RETURN_IF_ERROR(
+        loom_json_object_begin_field(&object, IREE_SV("source_low_memory")));
+    loom_json_object_writer_t source_low_memory;
+    IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &source_low_memory));
+    IREE_RETURN_IF_ERROR(loom_json_object_begin_field(&source_low_memory,
+                                                      IREE_SV("bank_service")));
+    IREE_RETURN_IF_ERROR(
+        loom_target_compile_report_format_bank_service_summary_json(
+            &row->bank_service_summary, stream));
+    IREE_RETURN_IF_ERROR(loom_json_object_end(&source_low_memory));
+  }
   IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(
       &object, IREE_SV("pressure_row_count"), row->pressure_row_count));
   IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(

--- a/loom/src/loom/target/reporting/format_json.h
+++ b/loom/src/loom/target/reporting/format_json.h
@@ -52,6 +52,11 @@ iree_status_t loom_target_compile_report_format_operation_economics_json(
     const loom_target_compile_report_static_instruction_mix_t* mix,
     uint64_t scale, loom_output_stream_t* stream);
 
+// Writes one structural bank-service summary object.
+iree_status_t loom_target_compile_report_format_bank_service_summary_json(
+    const loom_target_compile_report_bank_service_summary_t* summary,
+    loom_output_stream_t* stream);
+
 // Returns true when the report has economics evidence to serialize.
 bool loom_target_compile_report_has_report_economics(
     const loom_target_compile_report_t* report);

--- a/loom/src/loom/target/reporting/format_json_lowering.c
+++ b/loom/src/loom/target/reporting/format_json_lowering.c
@@ -570,6 +570,66 @@ loom_target_compile_report_format_source_low_memory_bank_service_json(
   return loom_json_object_end(&object);
 }
 
+iree_status_t loom_target_compile_report_format_bank_service_summary_json(
+    const loom_target_compile_report_bank_service_summary_t* summary,
+    loom_output_stream_t* stream) {
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("modeled_packet_count"), summary->modeled_packet_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("exact_packet_count"), summary->exact_packet_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &object, IREE_SV("unknown_packet_count"), summary->unknown_packet_count));
+
+  IREE_RETURN_IF_ERROR(
+      loom_json_object_begin_field(&object, IREE_SV("structural")));
+  loom_json_object_writer_t structural;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &structural));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &structural, IREE_SV("conflict_free_packet_count"),
+      summary->conflict_free_packet_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &structural, IREE_SV("conflicted_packet_count"),
+      summary->conflicted_packet_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &structural, IREE_SV("required_round_count"),
+      summary->required_round_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &structural, IREE_SV("uncontended_round_count"),
+      summary->uncontended_round_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &structural, IREE_SV("extra_round_count"), summary->extra_round_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &structural, IREE_SV("maximum_request_multiplicity"),
+      summary->maximum_request_multiplicity));
+  IREE_RETURN_IF_ERROR(loom_json_object_end(&structural));
+
+  IREE_RETURN_IF_ERROR(
+      loom_json_object_begin_field(&object, IREE_SV("dynamic")));
+  loom_json_object_writer_t dynamic;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &dynamic));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &dynamic, IREE_SV("exact_packet_count"),
+      summary->exact_dynamic_packet_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &dynamic, IREE_SV("unknown_packet_count"),
+      summary->unknown_dynamic_packet_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &dynamic, IREE_SV("packet_count"), summary->dynamic_packet_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &dynamic, IREE_SV("required_round_count"),
+      summary->dynamic_required_round_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &dynamic, IREE_SV("uncontended_round_count"),
+      summary->dynamic_uncontended_round_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint64_field(
+      &dynamic, IREE_SV("extra_round_count"),
+      summary->dynamic_extra_round_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_end(&dynamic));
+  return loom_json_object_end(&object);
+}
+
 static iree_status_t
 loom_target_compile_report_format_source_low_memory_row_json(
     const loom_target_compile_report_source_low_memory_row_t* row,
@@ -652,6 +712,86 @@ loom_target_compile_report_format_source_low_memory_row_json(
   }
   IREE_RETURN_IF_ERROR(loom_target_compile_report_format_memory_interval_json(
       &row->source_interval, &object));
+  return loom_json_object_end(&object);
+}
+
+static iree_status_t
+loom_target_compile_report_format_source_low_bank_service_summary_json(
+    const loom_target_compile_report_source_low_bank_service_summary_t* row,
+    iree_host_size_t row_index, loom_output_stream_t* stream) {
+  loom_json_object_writer_t object;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &object));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(
+      &object, IREE_SV("index"), row_index));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("function"), row->function_name));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("source_op"), row->source_op_name));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &object, IREE_SV("source_op_kind"), row->source_op_kind));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("source_root"), row->source_root_name));
+  if (row->source_root_argument_index != UINT16_MAX) {
+    IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+        &object, IREE_SV("source_root_argument_index"),
+        row->source_root_argument_index));
+  }
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("memory_space"), row->memory_space));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("operation"), row->operation_kind));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("packet"), row->packet_key));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_json_write_optional_string_field(
+          &object, IREE_SV("strategy"), row->strategy_key));
+
+  IREE_RETURN_IF_ERROR(loom_json_object_begin_field(&object, IREE_SV("model")));
+  loom_json_object_writer_t model;
+  IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &model));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
+      &model, IREE_SV("key"), row->model_key));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
+      &model, IREE_SV("revision"), row->model_revision));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
+      &model, IREE_SV("evidence"), row->model_evidence));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_string_field(
+      &model, IREE_SV("request_policy"), row->request_policy));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &model, IREE_SV("wave_size"), row->wave_size));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &model, IREE_SV("bank_count"), row->bank_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &model, IREE_SV("bank_word_bytes"), row->bank_word_byte_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_write_uint32_field(
+      &model, IREE_SV("packet_bank_words"), row->packet_word_count));
+  IREE_RETURN_IF_ERROR(loom_json_object_end(&model));
+
+  if (row->summary.unknown_packet_count != 0) {
+    IREE_RETURN_IF_ERROR(
+        loom_json_object_begin_field(&object, IREE_SV("unknown_evidence")));
+    loom_json_object_writer_t unknown_evidence;
+    IREE_RETURN_IF_ERROR(loom_json_object_begin(stream, &unknown_evidence));
+    IREE_RETURN_IF_ERROR(
+        loom_target_compile_report_json_write_optional_string_field(
+            &unknown_evidence, IREE_SV("reason"), row->unknown_reason));
+    IREE_RETURN_IF_ERROR(loom_json_object_write_bool_field(
+        &unknown_evidence, IREE_SV("mixed_reasons"),
+        row->has_mixed_unknown_reasons));
+    IREE_RETURN_IF_ERROR(loom_json_object_end(&unknown_evidence));
+  }
+
+  IREE_RETURN_IF_ERROR(
+      loom_json_object_begin_field(&object, IREE_SV("summary")));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_format_bank_service_summary_json(&row->summary,
+                                                                  stream));
   return loom_json_object_end(&object);
 }
 
@@ -976,6 +1116,13 @@ loom_target_compile_report_format_source_low_memory_summary_json(
   IREE_RETURN_IF_ERROR(
       loom_target_compile_report_format_source_low_memory_summary_fields_json(
           summary, &report->workload, &object));
+  if (report->bank_service_summary.modeled_packet_count != 0) {
+    IREE_RETURN_IF_ERROR(
+        loom_json_object_begin_field(&object, IREE_SV("bank_service")));
+    IREE_RETURN_IF_ERROR(
+        loom_target_compile_report_format_bank_service_summary_json(
+            &report->bank_service_summary, stream));
+  }
   if (report->source_low_memory_root_summaries.count != 0) {
     IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(
         &object, IREE_SV("root_count"),
@@ -1072,6 +1219,30 @@ loom_target_compile_report_format_source_low_memory_summary_json(
       }
     }
     IREE_RETURN_IF_ERROR(loom_json_array_end(&array_3));
+  }
+  if (report->source_low_bank_service_summaries.count != 0) {
+    IREE_RETURN_IF_ERROR(loom_json_object_write_host_size_field(
+        &object, IREE_SV("bank_service_group_count"),
+        report->source_low_bank_service_summaries.count));
+    IREE_RETURN_IF_ERROR(
+        loom_json_object_begin_field(&object, IREE_SV("bank_service_groups")));
+    loom_json_array_writer_t array_4;
+    IREE_RETURN_IF_ERROR(loom_json_array_begin(stream, &array_4));
+    iree_host_size_t row_index = 0;
+    for (const loom_target_compile_report_vec_t* vec =
+             report->source_low_bank_service_summaries.head;
+         vec != NULL; vec = vec->next) {
+      const loom_target_compile_report_source_low_bank_service_summary_t* rows =
+          (const loom_target_compile_report_source_low_bank_service_summary_t*)
+              loom_target_compile_report_vec_const_rows(vec);
+      for (iree_host_size_t i = 0; i < vec->count; ++i, ++row_index) {
+        IREE_RETURN_IF_ERROR(loom_json_array_begin_element(&array_4));
+        IREE_RETURN_IF_ERROR(
+            loom_target_compile_report_format_source_low_bank_service_summary_json(
+                &rows[i], row_index, stream));
+      }
+    }
+    IREE_RETURN_IF_ERROR(loom_json_array_end(&array_4));
   }
   return loom_json_object_end(&object);
 }

--- a/loom/src/loom/target/reporting/format_lowering_test.cc
+++ b/loom/src/loom/target/reporting/format_lowering_test.cc
@@ -162,6 +162,41 @@ TEST(CompileReportFormatTest, FormatsSourceToLowSelectionAndMemory) {
   const iree_string_view_t source_low =
       LookupObject(root, IREE_SV("source_low"));
   ExpectObjectUint64Equals(source_low, IREE_SV("selected_op_count"), 4);
+  const iree_string_view_t memory_summary =
+      LookupObject(source_low, IREE_SV("memory"));
+  const iree_string_view_t bank_service_summary =
+      LookupObject(memory_summary, IREE_SV("bank_service"));
+  ExpectObjectUint64Equals(bank_service_summary,
+                           IREE_SV("modeled_packet_count"), 1);
+  ExpectObjectUint64Equals(bank_service_summary, IREE_SV("exact_packet_count"),
+                           1);
+  const iree_string_view_t structural_bank_service =
+      LookupObject(bank_service_summary, IREE_SV("structural"));
+  ExpectObjectUint64Equals(structural_bank_service,
+                           IREE_SV("conflicted_packet_count"), 1);
+  ExpectObjectUint64Equals(structural_bank_service,
+                           IREE_SV("extra_round_count"), 2);
+  const iree_string_view_t dynamic_bank_service =
+      LookupObject(bank_service_summary, IREE_SV("dynamic"));
+  ExpectObjectUint64Equals(dynamic_bank_service, IREE_SV("packet_count"), 1);
+  ExpectObjectUint64Equals(dynamic_bank_service, IREE_SV("extra_round_count"),
+                           2);
+  ExpectObjectUint64Equals(memory_summary, IREE_SV("bank_service_group_count"),
+                           1);
+  const iree_string_view_t bank_service_group = LookupArrayElement(
+      LookupObject(memory_summary, IREE_SV("bank_service_groups")),
+      /*index=*/0);
+  ExpectObjectValueEquals(bank_service_group, IREE_SV("function"),
+                          IREE_SV("branchy"));
+  ExpectObjectValueEquals(bank_service_group, IREE_SV("source_root"),
+                          IREE_SV("lhs"));
+  const iree_string_view_t group_model =
+      LookupObject(bank_service_group, IREE_SV("model"));
+  ExpectObjectValueEquals(group_model, IREE_SV("key"),
+                          IREE_SV("test.ds_read_b128"));
+  const iree_string_view_t group_summary =
+      LookupObject(bank_service_group, IREE_SV("summary"));
+  ExpectObjectUint64Equals(group_summary, IREE_SV("exact_packet_count"), 1);
   const iree_string_view_t selection_row = LookupArrayElement(
       LookupObject(source_low, IREE_SV("rows")), /*index=*/0);
   ExpectObjectValueEquals(selection_row, IREE_SV("plan_key"),

--- a/loom/src/loom/target/reporting/format_text.c
+++ b/loom/src/loom/target/reporting/format_text.c
@@ -593,6 +593,16 @@ static iree_status_t loom_target_compile_report_format_summary(
           loom_target_compile_report_format_text_source_low_memory_summary(
               summary, &report->workload, builder));
       IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(builder, "\n"));
+      if (report->bank_service_summary.modeled_packet_count != 0) {
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+            builder,
+            "COMPILE-REPORT: source_low_bank_service_summary groups=%" PRIhsz,
+            report->source_low_bank_service_summaries.count));
+        IREE_RETURN_IF_ERROR(
+            loom_target_compile_report_append_bank_service_summary_text_fields(
+                &report->bank_service_summary, builder));
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(builder, "\n"));
+      }
     }
   }
 
@@ -828,6 +838,16 @@ static iree_status_t loom_target_compile_report_format_entry_rows(
           row->wait_counter_row_count, row->wait_reason_summary_row_count,
           row->wait_action_row_count, row->target_capability_row_count,
           row->target_insertion_row_count));
+      if (row->bank_service_summary.modeled_packet_count != 0) {
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+            builder,
+            "COMPILE-REPORT: entry_bank_service[%" PRIhsz "] function=%.*s",
+            row_index, (int)function_name.size, function_name.data));
+        IREE_RETURN_IF_ERROR(
+            loom_target_compile_report_append_bank_service_summary_text_fields(
+                &row->bank_service_summary, builder));
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(builder, "\n"));
+      }
       if (iree_any_bit_set(row->detail_flags,
                            LOOM_TARGET_COMPILE_REPORT_DETAIL_LOW_PLANNING)) {
         IREE_RETURN_IF_ERROR(iree_string_builder_append_format(

--- a/loom/src/loom/target/reporting/format_text.h
+++ b/loom/src/loom/target/reporting/format_text.h
@@ -30,6 +30,12 @@ iree_status_t loom_target_compile_report_format_text_source_low_memory_summary(
     const loom_target_compile_report_workload_t* workload,
     iree_string_builder_t* builder);
 
+// Appends the fields of one structural bank-service summary.
+iree_status_t
+loom_target_compile_report_append_bank_service_summary_text_fields(
+    const loom_target_compile_report_bank_service_summary_t* summary,
+    iree_string_builder_t* builder);
+
 // Appends detailed source-low, math, and target legalization evidence.
 iree_status_t loom_target_compile_report_format_text_lowering_details(
     const loom_target_compile_report_t* report, iree_string_builder_t* builder);

--- a/loom/src/loom/target/reporting/format_text_lowering.c
+++ b/loom/src/loom/target/reporting/format_text_lowering.c
@@ -140,6 +140,33 @@ loom_target_compile_report_append_source_low_memory_bank_service_text(
   return iree_string_builder_append_cstring(builder, "}");
 }
 
+iree_status_t
+loom_target_compile_report_append_bank_service_summary_text_fields(
+    const loom_target_compile_report_bank_service_summary_t* summary,
+    iree_string_builder_t* builder) {
+  return iree_string_builder_append_format(
+      builder,
+      " modeled_packets=%" PRIu64 " exact_packets=%" PRIu64
+      " unknown_packets=%" PRIu64 " conflict_free_packets=%" PRIu64
+      " conflicted_packets=%" PRIu64 " structural_required_rounds=%" PRIu64
+      " structural_uncontended_rounds=%" PRIu64
+      " structural_extra_rounds=%" PRIu64
+      " maximum_request_multiplicity=%" PRIu16 " dynamic_exact_packets=%" PRIu64
+      " dynamic_unknown_packets=%" PRIu64 " dynamic_packets=%" PRIu64
+      " dynamic_required_rounds=%" PRIu64 " dynamic_uncontended_rounds=%" PRIu64
+      " dynamic_extra_rounds=%" PRIu64,
+      summary->modeled_packet_count, summary->exact_packet_count,
+      summary->unknown_packet_count, summary->conflict_free_packet_count,
+      summary->conflicted_packet_count, summary->required_round_count,
+      summary->uncontended_round_count, summary->extra_round_count,
+      summary->maximum_request_multiplicity,
+      summary->exact_dynamic_packet_count,
+      summary->unknown_dynamic_packet_count, summary->dynamic_packet_count,
+      summary->dynamic_required_round_count,
+      summary->dynamic_uncontended_round_count,
+      summary->dynamic_extra_round_count);
+}
+
 static iree_status_t loom_target_compile_report_append_memory_interval_text(
     const loom_target_compile_report_memory_interval_t* interval,
     iree_string_builder_t* builder) {
@@ -851,6 +878,75 @@ loom_target_compile_report_format_source_low_memory_strategy_summaries(
   return iree_ok_status();
 }
 
+static iree_status_t
+loom_target_compile_report_format_source_low_bank_service_summaries(
+    const loom_target_compile_report_t* report,
+    iree_string_builder_t* builder) {
+  iree_host_size_t row_index = 0;
+  for (const loom_target_compile_report_vec_t* vec =
+           report->source_low_bank_service_summaries.head;
+       vec != NULL; vec = vec->next) {
+    const loom_target_compile_report_source_low_bank_service_summary_t* rows =
+        (const loom_target_compile_report_source_low_bank_service_summary_t*)
+            loom_target_compile_report_vec_const_rows(vec);
+    for (iree_host_size_t i = 0; i < vec->count; ++i, ++row_index) {
+      const loom_target_compile_report_source_low_bank_service_summary_t* row =
+          &rows[i];
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          builder,
+          "COMPILE-REPORT: source_low_bank_service[%" PRIhsz
+          "] function=%.*s source_op=%.*s source_op_kind=%" PRIu32,
+          row_index, (int)row->function_name.size, row->function_name.data,
+          (int)row->source_op_name.size, row->source_op_name.data,
+          row->source_op_kind));
+      IREE_RETURN_IF_ERROR(loom_target_compile_report_text_append_string_field(
+          builder, IREE_SV("source_root"), row->source_root_name));
+      if (row->source_root_argument_index != UINT16_MAX) {
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+            builder, " source_root_argument=%" PRIu16,
+            row->source_root_argument_index));
+      }
+      IREE_RETURN_IF_ERROR(loom_target_compile_report_text_append_string_field(
+          builder, IREE_SV("memory_space"), row->memory_space));
+      IREE_RETURN_IF_ERROR(loom_target_compile_report_text_append_string_field(
+          builder, IREE_SV("operation"), row->operation_kind));
+      IREE_RETURN_IF_ERROR(loom_target_compile_report_text_append_string_field(
+          builder, IREE_SV("packet"), row->packet_key));
+      IREE_RETURN_IF_ERROR(loom_target_compile_report_text_append_string_field(
+          builder, IREE_SV("strategy"), row->strategy_key));
+      IREE_RETURN_IF_ERROR(loom_target_compile_report_text_append_string_field(
+          builder, IREE_SV("model"), row->model_key));
+      IREE_RETURN_IF_ERROR(loom_target_compile_report_text_append_string_field(
+          builder, IREE_SV("model_revision"), row->model_revision));
+      IREE_RETURN_IF_ERROR(loom_target_compile_report_text_append_string_field(
+          builder, IREE_SV("model_evidence"), row->model_evidence));
+      IREE_RETURN_IF_ERROR(loom_target_compile_report_text_append_string_field(
+          builder, IREE_SV("request_policy"), row->request_policy));
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          builder,
+          " wave_size=%" PRIu8 " banks=%" PRIu8 " bank_word_bytes=%" PRIu8
+          " packet_bank_words=%" PRIu8,
+          row->wave_size, row->bank_count, row->bank_word_byte_count,
+          row->packet_word_count));
+      if (row->summary.unknown_packet_count != 0) {
+        const iree_string_view_t unknown_reason =
+            row->has_mixed_unknown_reasons
+                ? IREE_SV("mixed")
+                : loom_target_compile_report_text_non_empty(
+                      row->unknown_reason);
+        IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+            builder, " unknown_reason=%.*s", (int)unknown_reason.size,
+            unknown_reason.data));
+      }
+      IREE_RETURN_IF_ERROR(
+          loom_target_compile_report_append_bank_service_summary_text_fields(
+              &row->summary, builder));
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(builder, "\n"));
+    }
+  }
+  return iree_ok_status();
+}
+
 static iree_status_t loom_target_compile_report_format_math_rows(
     const loom_target_compile_report_t* report,
     iree_string_builder_t* builder) {
@@ -1010,6 +1106,9 @@ iree_status_t loom_target_compile_report_format_text_lowering_details(
           report, builder));
   IREE_RETURN_IF_ERROR(
       loom_target_compile_report_format_source_low_memory_strategy_summaries(
+          report, builder));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_format_source_low_bank_service_summaries(
           report, builder));
   return loom_target_compile_report_format_legalization_rows(report, builder);
 }

--- a/loom/src/loom/target/reporting/memory_summary.c
+++ b/loom/src/loom/target/reporting/memory_summary.c
@@ -350,6 +350,29 @@ static void loom_target_compile_report_forget_memory_interval_unique_accounting(
   summary->unique_byte_count = 0;
 }
 
+void loom_target_compile_report_accumulate_bank_service_summaries(
+    loom_target_compile_report_bank_service_summary_t* target,
+    const loom_target_compile_report_bank_service_summary_t* source) {
+  target->modeled_packet_count += source->modeled_packet_count;
+  target->exact_packet_count += source->exact_packet_count;
+  target->unknown_packet_count += source->unknown_packet_count;
+  target->conflict_free_packet_count += source->conflict_free_packet_count;
+  target->conflicted_packet_count += source->conflicted_packet_count;
+  target->required_round_count += source->required_round_count;
+  target->uncontended_round_count += source->uncontended_round_count;
+  target->extra_round_count += source->extra_round_count;
+  target->exact_dynamic_packet_count += source->exact_dynamic_packet_count;
+  target->unknown_dynamic_packet_count += source->unknown_dynamic_packet_count;
+  target->dynamic_packet_count += source->dynamic_packet_count;
+  target->dynamic_required_round_count += source->dynamic_required_round_count;
+  target->dynamic_uncontended_round_count +=
+      source->dynamic_uncontended_round_count;
+  target->dynamic_extra_round_count += source->dynamic_extra_round_count;
+  target->maximum_request_multiplicity =
+      iree_max(target->maximum_request_multiplicity,
+               source->maximum_request_multiplicity);
+}
+
 void loom_target_compile_report_accumulate_source_low_memory_summaries(
     loom_target_compile_report_source_low_memory_summary_t* target,
     const loom_target_compile_report_source_low_memory_summary_t* source) {
@@ -793,6 +816,229 @@ loom_target_compile_report_record_source_low_memory_strategy_summary_row(
       report->allocator, row);
 }
 
+static bool loom_target_compile_report_source_low_bank_service_summaries_match(
+    const loom_target_compile_report_source_low_bank_service_summary_t* lhs,
+    const loom_target_compile_report_source_low_bank_service_summary_t* rhs) {
+  return iree_string_view_equal(lhs->function_name, rhs->function_name) &&
+         iree_string_view_equal(lhs->source_op_name, rhs->source_op_name) &&
+         lhs->source_op_kind == rhs->source_op_kind &&
+         iree_string_view_equal(lhs->source_root_name, rhs->source_root_name) &&
+         lhs->source_root_argument_index == rhs->source_root_argument_index &&
+         iree_string_view_equal(lhs->memory_space, rhs->memory_space) &&
+         iree_string_view_equal(lhs->operation_kind, rhs->operation_kind) &&
+         iree_string_view_equal(lhs->packet_key, rhs->packet_key) &&
+         iree_string_view_equal(lhs->strategy_key, rhs->strategy_key) &&
+         iree_string_view_equal(lhs->model_key, rhs->model_key) &&
+         iree_string_view_equal(lhs->model_revision, rhs->model_revision) &&
+         iree_string_view_equal(lhs->model_evidence, rhs->model_evidence) &&
+         iree_string_view_equal(lhs->request_policy, rhs->request_policy) &&
+         lhs->wave_size == rhs->wave_size &&
+         lhs->bank_count == rhs->bank_count &&
+         lhs->bank_word_byte_count == rhs->bank_word_byte_count &&
+         lhs->packet_word_count == rhs->packet_word_count;
+}
+
+static loom_target_compile_report_source_low_bank_service_summary_t*
+loom_target_compile_report_find_source_low_bank_service_summary(
+    loom_target_compile_report_t* report,
+    const loom_target_compile_report_source_low_bank_service_summary_t* row) {
+  for (loom_target_compile_report_vec_t* vec =
+           report->source_low_bank_service_summaries.head;
+       vec != NULL; vec = vec->next) {
+    loom_target_compile_report_source_low_bank_service_summary_t* summaries =
+        (loom_target_compile_report_source_low_bank_service_summary_t*)
+            loom_target_compile_report_vec_rows(vec);
+    for (iree_host_size_t i = 0; i < vec->count; ++i) {
+      loom_target_compile_report_source_low_bank_service_summary_t* summary =
+          &summaries[i];
+      if (loom_target_compile_report_source_low_bank_service_summaries_match(
+              summary, row)) {
+        return summary;
+      }
+    }
+  }
+  return NULL;
+}
+
+static void loom_target_compile_report_merge_unknown_bank_service_reason(
+    loom_target_compile_report_source_low_bank_service_summary_t* target,
+    iree_string_view_t source_reason, bool source_has_mixed_reasons,
+    uint64_t source_unknown_packet_count) {
+  if (source_unknown_packet_count == 0) {
+    return;
+  }
+  if (target->summary.unknown_packet_count == 0) {
+    target->unknown_reason = source_reason;
+    target->has_mixed_unknown_reasons = source_has_mixed_reasons;
+    return;
+  }
+  if (target->has_mixed_unknown_reasons || source_has_mixed_reasons ||
+      !iree_string_view_equal(target->unknown_reason, source_reason)) {
+    target->unknown_reason = iree_string_view_empty();
+    target->has_mixed_unknown_reasons = true;
+  }
+}
+
+static void loom_target_compile_report_accumulate_bank_service_summary(
+    loom_target_compile_report_bank_service_summary_t* summary,
+    const loom_target_compile_report_source_low_memory_row_t* row) {
+  const loom_target_compile_report_bank_service_t* bank_service =
+      &row->bank_service;
+  if (iree_string_view_is_empty(bank_service->model_key)) {
+    return;
+  }
+
+  ++summary->modeled_packet_count;
+  if (!iree_string_view_equal(bank_service->proof, IREE_SV("exact"))) {
+    ++summary->unknown_packet_count;
+    ++summary->unknown_dynamic_packet_count;
+    return;
+  }
+
+  ++summary->exact_packet_count;
+  if (iree_string_view_equal(bank_service->classification,
+                             IREE_SV("conflict-free"))) {
+    ++summary->conflict_free_packet_count;
+  } else if (iree_string_view_equal(bank_service->classification,
+                                    IREE_SV("conflicted"))) {
+    ++summary->conflicted_packet_count;
+  }
+  summary->required_round_count += bank_service->required_rounds;
+  summary->uncontended_round_count += bank_service->uncontended_rounds;
+  summary->extra_round_count += bank_service->extra_rounds;
+  summary->maximum_request_multiplicity =
+      iree_max(summary->maximum_request_multiplicity,
+               bank_service->maximum_request_multiplicity);
+
+  if (row->execution_count_plus_one ==
+      LOOM_TARGET_COMPILE_REPORT_SOURCE_LOW_MEMORY_EXECUTION_COUNT_PLUS_ONE_UNKNOWN) {
+    ++summary->unknown_dynamic_packet_count;
+    return;
+  }
+
+  const uint64_t execution_count = row->execution_count_plus_one - 1;
+  uint64_t dynamic_required_round_count = 0;
+  uint64_t dynamic_uncontended_round_count = 0;
+  uint64_t dynamic_extra_round_count = 0;
+  const bool dynamic_counts_ok =
+      iree_checked_mul_u64(bank_service->required_rounds, execution_count,
+                           &dynamic_required_round_count) &&
+      iree_checked_mul_u64(bank_service->uncontended_rounds, execution_count,
+                           &dynamic_uncontended_round_count) &&
+      iree_checked_mul_u64(bank_service->extra_rounds, execution_count,
+                           &dynamic_extra_round_count);
+  uint64_t new_dynamic_packet_count = summary->dynamic_packet_count;
+  uint64_t new_dynamic_required_round_count =
+      summary->dynamic_required_round_count;
+  uint64_t new_dynamic_uncontended_round_count =
+      summary->dynamic_uncontended_round_count;
+  uint64_t new_dynamic_extra_round_count = summary->dynamic_extra_round_count;
+  const bool dynamic_accumulation_ok =
+      dynamic_counts_ok &&
+      iree_checked_add_u64(new_dynamic_packet_count, execution_count,
+                           &new_dynamic_packet_count) &&
+      iree_checked_add_u64(new_dynamic_required_round_count,
+                           dynamic_required_round_count,
+                           &new_dynamic_required_round_count) &&
+      iree_checked_add_u64(new_dynamic_uncontended_round_count,
+                           dynamic_uncontended_round_count,
+                           &new_dynamic_uncontended_round_count) &&
+      iree_checked_add_u64(new_dynamic_extra_round_count,
+                           dynamic_extra_round_count,
+                           &new_dynamic_extra_round_count);
+  if (!dynamic_accumulation_ok) {
+    ++summary->unknown_dynamic_packet_count;
+    return;
+  }
+
+  ++summary->exact_dynamic_packet_count;
+  summary->dynamic_packet_count = new_dynamic_packet_count;
+  summary->dynamic_required_round_count = new_dynamic_required_round_count;
+  summary->dynamic_uncontended_round_count =
+      new_dynamic_uncontended_round_count;
+  summary->dynamic_extra_round_count = new_dynamic_extra_round_count;
+}
+
+static loom_target_compile_report_source_low_bank_service_summary_t
+loom_target_compile_report_source_low_bank_service_summary_from_row(
+    const loom_target_compile_report_source_low_memory_row_t* row) {
+  const loom_target_compile_report_bank_service_t* bank_service =
+      &row->bank_service;
+  return (loom_target_compile_report_source_low_bank_service_summary_t){
+      .function_name = row->function_name,
+      .source_op_name = row->source_op_name,
+      .source_op_kind = row->source_op_kind,
+      .source_root_name = row->source_root_name,
+      .source_root_argument_index = row->source_root_argument_index,
+      .memory_space = row->memory_space,
+      .operation_kind = row->operation_kind,
+      .packet_key = row->packet_key,
+      .strategy_key = row->strategy_key,
+      .model_key = bank_service->model_key,
+      .model_revision = bank_service->model_revision,
+      .model_evidence = bank_service->model_evidence,
+      .request_policy = bank_service->request_policy,
+      .wave_size = bank_service->wave_size,
+      .bank_count = bank_service->bank_count,
+      .bank_word_byte_count = bank_service->bank_word_byte_count,
+      .packet_word_count = bank_service->packet_word_count,
+  };
+}
+
+static iree_status_t
+loom_target_compile_report_record_source_low_bank_service_summary_row(
+    loom_target_compile_report_t* report,
+    const loom_target_compile_report_source_low_bank_service_summary_t* row) {
+  loom_target_compile_report_source_low_bank_service_summary_t* summary =
+      loom_target_compile_report_find_source_low_bank_service_summary(report,
+                                                                      row);
+  if (summary != NULL) {
+    loom_target_compile_report_merge_unknown_bank_service_reason(
+        summary, row->unknown_reason, row->has_mixed_unknown_reasons,
+        row->summary.unknown_packet_count);
+    loom_target_compile_report_accumulate_bank_service_summaries(
+        &summary->summary, &row->summary);
+    return iree_ok_status();
+  }
+  return loom_target_compile_report_row_list_append(
+      &report->source_low_bank_service_summaries, sizeof(*row),
+      report->allocator, row);
+}
+
+static iree_status_t
+loom_target_compile_report_record_source_low_bank_service_summary(
+    loom_target_compile_report_t* report,
+    const loom_target_compile_report_source_low_memory_row_t* row) {
+  if (iree_string_view_is_empty(row->bank_service.model_key)) {
+    return iree_ok_status();
+  }
+  loom_target_compile_report_source_low_bank_service_summary_t key =
+      loom_target_compile_report_source_low_bank_service_summary_from_row(row);
+  loom_target_compile_report_source_low_bank_service_summary_t* summary =
+      loom_target_compile_report_find_source_low_bank_service_summary(report,
+                                                                      &key);
+  if (summary == NULL) {
+    loom_target_compile_report_merge_unknown_bank_service_reason(
+        &key, row->bank_service.unknown_reason,
+        /*source_has_mixed_reasons=*/false,
+        iree_string_view_equal(row->bank_service.proof, IREE_SV("exact")) ? 0
+                                                                          : 1);
+    loom_target_compile_report_accumulate_bank_service_summary(&key.summary,
+                                                               row);
+    return loom_target_compile_report_row_list_append(
+        &report->source_low_bank_service_summaries, sizeof(key),
+        report->allocator, &key);
+  }
+  loom_target_compile_report_merge_unknown_bank_service_reason(
+      summary, row->bank_service.unknown_reason,
+      /*source_has_mixed_reasons=*/false,
+      iree_string_view_equal(row->bank_service.proof, IREE_SV("exact")) ? 0
+                                                                        : 1);
+  loom_target_compile_report_accumulate_bank_service_summary(&summary->summary,
+                                                             row);
+  return iree_ok_status();
+}
+
 iree_status_t loom_target_compile_report_merge_source_low_memory_details(
     loom_target_compile_report_t* target,
     const loom_target_compile_report_t* source) {
@@ -846,6 +1092,18 @@ iree_status_t loom_target_compile_report_merge_source_low_memory_details(
     for (iree_host_size_t i = 0; i < vec->count; ++i) {
       IREE_RETURN_IF_ERROR(
           loom_target_compile_report_record_source_low_memory_strategy_summary_row(
+              target, &rows[i]));
+    }
+  }
+  for (const loom_target_compile_report_vec_t* vec =
+           source->source_low_bank_service_summaries.head;
+       vec != NULL; vec = vec->next) {
+    const loom_target_compile_report_source_low_bank_service_summary_t* rows =
+        (const loom_target_compile_report_source_low_bank_service_summary_t*)
+            loom_target_compile_report_vec_const_rows(vec);
+    for (iree_host_size_t i = 0; i < vec->count; ++i) {
+      IREE_RETURN_IF_ERROR(
+          loom_target_compile_report_record_source_low_bank_service_summary_row(
               target, &rows[i]));
     }
   }
@@ -1117,6 +1375,8 @@ iree_status_t loom_target_compile_report_record_source_low_memory_row(
   loom_target_compile_report_accumulate_source_low_memory_summary(
       &report->source_low_memory_summary, row, no_unique_delta,
       no_unique_delta);
+  loom_target_compile_report_accumulate_bank_service_summary(
+      &report->bank_service_summary, row);
   IREE_RETURN_IF_ERROR(
       loom_target_compile_report_record_source_low_memory_root_summary(
           report, row, unique_delta, direction_unique_delta));
@@ -1135,5 +1395,8 @@ iree_status_t loom_target_compile_report_record_source_low_memory_row(
   IREE_RETURN_IF_ERROR(
       loom_target_compile_report_record_source_low_memory_strategy_summary(
           report, row));
+  IREE_RETURN_IF_ERROR(
+      loom_target_compile_report_record_source_low_bank_service_summary(report,
+                                                                        row));
   return iree_ok_status();
 }

--- a/loom/src/loom/target/reporting/memory_summary.h
+++ b/loom/src/loom/target/reporting/memory_summary.h
@@ -13,6 +13,11 @@
 extern "C" {
 #endif  // __cplusplus
 
+// Accumulates structural bank-service counters from |source| into |target|.
+void loom_target_compile_report_accumulate_bank_service_summaries(
+    loom_target_compile_report_bank_service_summary_t* target,
+    const loom_target_compile_report_bank_service_summary_t* source);
+
 // Accumulates source-memory summary counters from |source| into |target|.
 void loom_target_compile_report_accumulate_source_low_memory_summaries(
     loom_target_compile_report_source_low_memory_summary_t* target,

--- a/loom/src/loom/target/reporting/memory_summary_test.cc
+++ b/loom/src/loom/target/reporting/memory_summary_test.cc
@@ -83,6 +83,28 @@ static loom_target_compile_report_source_low_memory_row_t MakeMemoryRow(
   return row;
 }
 
+static void SetBankService(
+    iree_string_view_t proof, iree_string_view_t classification,
+    iree_string_view_t unknown_reason, uint16_t required_rounds,
+    uint16_t uncontended_rounds, uint16_t maximum_request_multiplicity,
+    loom_target_compile_report_source_low_memory_row_t* row) {
+  row->bank_service.proof = proof;
+  row->bank_service.classification = classification;
+  row->bank_service.model_key = IREE_SVL("test.ds_read_b32");
+  row->bank_service.model_revision = IREE_SVL("test-model@1");
+  row->bank_service.model_evidence = IREE_SVL("silicon-calibrated");
+  row->bank_service.request_policy = IREE_SVL("collapse-identical");
+  row->bank_service.unknown_reason = unknown_reason;
+  row->bank_service.wave_size = 32;
+  row->bank_service.bank_count = 32;
+  row->bank_service.bank_word_byte_count = 4;
+  row->bank_service.packet_word_count = 1;
+  row->bank_service.required_rounds = required_rounds;
+  row->bank_service.uncontended_rounds = uncontended_rounds;
+  row->bank_service.extra_rounds = required_rounds - uncontended_rounds;
+  row->bank_service.maximum_request_multiplicity = maximum_request_multiplicity;
+}
+
 static const loom_target_compile_report_source_low_memory_summary_t*
 GetOnlySourceLowMemoryRootSummary(const loom_target_compile_report_t* report) {
   if (report->source_low_memory_root_summaries.count != 1u ||
@@ -95,6 +117,116 @@ GetOnlySourceLowMemoryRootSummary(const loom_target_compile_report_t* report) {
           loom_target_compile_report_vec_const_rows(
               report->source_low_memory_root_summaries.head));
   return &root_summaries[0].summary;
+}
+
+TEST(CompileReportFormatTest, PreservesBankServiceProofAndDynamicCoverage) {
+  loom_target_compile_report_t entry_report;
+  loom_target_compile_report_initialize(&entry_report, iree_allocator_system());
+  entry_report.function_name = IREE_SVL("kernel_v0");
+  entry_report.lowered_symbol = IREE_SVL("kernel");
+
+  loom_target_compile_report_source_low_memory_row_t rows[] = {
+      MakeMemoryRow(IREE_SVL("view.load"), /*source_op_kind=*/43,
+                    IREE_SVL("load"), IREE_SVL("test.ds_read_b32"),
+                    /*static_offset_bytes=*/0,
+                    /*vector_lane_count=*/1,
+                    /*issued_read_byte_count=*/4,
+                    /*issued_write_byte_count=*/0,
+                    /*dynamic_stride_bytes=*/4,
+                    /*vector_lane_stride_bytes=*/4,
+                    MakeExactSourceInterval(/*begin_bytes=*/0,
+                                            /*end_bytes=*/4)),
+      MakeMemoryRow(IREE_SVL("view.load"), /*source_op_kind=*/43,
+                    IREE_SVL("load"), IREE_SVL("test.ds_read_b32"),
+                    /*static_offset_bytes=*/4,
+                    /*vector_lane_count=*/1,
+                    /*issued_read_byte_count=*/4,
+                    /*issued_write_byte_count=*/0,
+                    /*dynamic_stride_bytes=*/4,
+                    /*vector_lane_stride_bytes=*/4,
+                    MakeExactSourceInterval(/*begin_bytes=*/4,
+                                            /*end_bytes=*/8)),
+      MakeMemoryRow(IREE_SVL("view.load"), /*source_op_kind=*/43,
+                    IREE_SVL("load"), IREE_SVL("test.ds_read_b32"),
+                    /*static_offset_bytes=*/8,
+                    /*vector_lane_count=*/1,
+                    /*issued_read_byte_count=*/4,
+                    /*issued_write_byte_count=*/0,
+                    /*dynamic_stride_bytes=*/4,
+                    /*vector_lane_stride_bytes=*/4,
+                    MakeExactSourceInterval(/*begin_bytes=*/8,
+                                            /*end_bytes=*/12)),
+  };
+  SetBankService(IREE_SVL("exact"), IREE_SVL("conflict-free"),
+                 iree_string_view_empty(), /*required_rounds=*/1,
+                 /*uncontended_rounds=*/1,
+                 /*maximum_request_multiplicity=*/1, &rows[0]);
+  rows[0].execution_count_plus_one = 3;
+  SetBankService(IREE_SVL("exact"), IREE_SVL("conflicted"),
+                 iree_string_view_empty(), /*required_rounds=*/3,
+                 /*uncontended_rounds=*/1,
+                 /*maximum_request_multiplicity=*/3, &rows[1]);
+  rows[1].execution_count_plus_one = 4;
+  SetBankService(IREE_SVL("unknown"), iree_string_view_empty(),
+                 IREE_SVL("base-residue-unknown"), /*required_rounds=*/0,
+                 /*uncontended_rounds=*/0,
+                 /*maximum_request_multiplicity=*/0, &rows[2]);
+  rows[2].execution_count_plus_one =
+      LOOM_TARGET_COMPILE_REPORT_SOURCE_LOW_MEMORY_EXECUTION_COUNT_PLUS_ONE_UNKNOWN;
+  for (const auto& row : rows) {
+    IREE_ASSERT_OK(loom_target_compile_report_record_source_low_memory_row(
+        &entry_report, &row));
+  }
+
+  const loom_target_compile_report_bank_service_summary_t* summary =
+      &entry_report.bank_service_summary;
+  EXPECT_EQ(summary->modeled_packet_count, 3u);
+  EXPECT_EQ(summary->exact_packet_count, 2u);
+  EXPECT_EQ(summary->unknown_packet_count, 1u);
+  EXPECT_EQ(summary->conflict_free_packet_count, 1u);
+  EXPECT_EQ(summary->conflicted_packet_count, 1u);
+  EXPECT_EQ(summary->required_round_count, 4u);
+  EXPECT_EQ(summary->uncontended_round_count, 2u);
+  EXPECT_EQ(summary->extra_round_count, 2u);
+  EXPECT_EQ(summary->maximum_request_multiplicity, 3u);
+  EXPECT_EQ(summary->exact_dynamic_packet_count, 2u);
+  EXPECT_EQ(summary->unknown_dynamic_packet_count, 1u);
+  EXPECT_EQ(summary->dynamic_packet_count, 5u);
+  EXPECT_EQ(summary->dynamic_required_round_count, 11u);
+  EXPECT_EQ(summary->dynamic_uncontended_round_count, 5u);
+  EXPECT_EQ(summary->dynamic_extra_round_count, 6u);
+
+  ASSERT_EQ(entry_report.source_low_bank_service_summaries.count, 1u);
+  ASSERT_NE(entry_report.source_low_bank_service_summaries.head, nullptr);
+  const auto* group = static_cast<
+      const loom_target_compile_report_source_low_bank_service_summary_t*>(
+      loom_target_compile_report_vec_const_rows(
+          entry_report.source_low_bank_service_summaries.head));
+  EXPECT_EQ(group[0].summary.modeled_packet_count, 3u);
+  EXPECT_TRUE(iree_string_view_equal(group[0].unknown_reason,
+                                     IREE_SVL("base-residue-unknown")));
+  EXPECT_FALSE(group[0].has_mixed_unknown_reasons);
+
+  loom_target_compile_report_t report;
+  loom_target_compile_report_initialize(&report, iree_allocator_system());
+  IREE_ASSERT_OK(
+      loom_target_compile_report_record_entry_report(&report, &entry_report));
+  ASSERT_EQ(report.entry_rows.count, 1u);
+  const auto* entry = static_cast<const loom_target_compile_report_entry_t*>(
+      loom_target_compile_report_vec_const_rows(report.entry_rows.head));
+  EXPECT_EQ(entry[0].bank_service_summary.dynamic_extra_round_count, 6u);
+  EXPECT_EQ(report.bank_service_summary.dynamic_extra_round_count, 6u);
+  ASSERT_EQ(report.source_low_bank_service_summaries.count, 1u);
+
+  loom_target_compile_report_t clone = {};
+  IREE_ASSERT_OK(loom_target_compile_report_clone(
+      &report, iree_allocator_system(), &clone));
+  EXPECT_EQ(clone.bank_service_summary.dynamic_extra_round_count, 6u);
+  ASSERT_EQ(clone.source_low_bank_service_summaries.count, 1u);
+  loom_target_compile_report_deinitialize(&clone);
+
+  loom_target_compile_report_deinitialize(&report);
+  loom_target_compile_report_deinitialize(&entry_report);
 }
 
 TEST(CompileReportFormatTest, MergesSourceLowMemorySummariesFromEntries) {

--- a/loom/src/loom/target/reporting/report.c
+++ b/loom/src/loom/target/reporting/report.c
@@ -72,6 +72,8 @@ void loom_target_compile_report_deinitialize(
   loom_target_compile_report_row_list_deinitialize(
       allocator, &report->source_low_memory_strategy_summaries);
   loom_target_compile_report_row_list_deinitialize(
+      allocator, &report->source_low_bank_service_summaries);
+  loom_target_compile_report_row_list_deinitialize(
       allocator, &report->math_legalization_rows);
   loom_target_compile_report_row_list_deinitialize(
       allocator, &report->target_legalization_rows);
@@ -103,6 +105,7 @@ static bool loom_target_compile_report_has_rows(
          report->source_low_memory_argument_summaries.count != 0 ||
          report->source_low_memory_argument_packet_summaries.count != 0 ||
          report->source_low_memory_strategy_summaries.count != 0 ||
+         report->source_low_bank_service_summaries.count != 0 ||
          report->math_legalization_rows.count != 0 ||
          report->target_legalization_rows.count != 0 ||
          report->target_capability_rows.count != 0;
@@ -157,6 +160,8 @@ iree_status_t loom_target_compile_report_clone(
       (loom_target_compile_report_row_list_t){0};
   target.source_low_memory_strategy_summaries =
       (loom_target_compile_report_row_list_t){0};
+  target.source_low_bank_service_summaries =
+      (loom_target_compile_report_row_list_t){0};
   target.math_legalization_rows = (loom_target_compile_report_row_list_t){0};
   target.target_legalization_rows = (loom_target_compile_report_row_list_t){0};
   target.target_capability_rows = (loom_target_compile_report_row_list_t){0};
@@ -181,6 +186,7 @@ iree_status_t loom_target_compile_report_clone(
       source->source_low_memory_argument_summaries.count == 0 &&
       source->source_low_memory_argument_packet_summaries.count == 0 &&
       source->source_low_memory_strategy_summaries.count == 0 &&
+      source->source_low_bank_service_summaries.count == 0 &&
       source->math_legalization_rows.count == 0 &&
       source->target_legalization_rows.count == 0 &&
       source->target_capability_rows.count == 0) {
@@ -325,6 +331,12 @@ iree_status_t loom_target_compile_report_clone(
         &source->source_low_memory_strategy_summaries,
         sizeof(loom_target_compile_report_source_low_memory_strategy_summary_t),
         allocator, &target.source_low_memory_strategy_summaries);
+  }
+  if (iree_status_is_ok(status)) {
+    status = loom_target_compile_report_row_list_clone(
+        &source->source_low_bank_service_summaries,
+        sizeof(loom_target_compile_report_source_low_bank_service_summary_t),
+        allocator, &target.source_low_bank_service_summaries);
   }
   if (iree_status_is_ok(status)) {
     status = loom_target_compile_report_row_list_clone(
@@ -1084,6 +1096,8 @@ static void loom_target_compile_report_merge_entry_summary(
       loom_target_compile_report_accumulate_source_low_memory_summaries(
           &report->source_low_memory_summary,
           &entry_report->source_low_memory_summary);
+      loom_target_compile_report_accumulate_bank_service_summaries(
+          &report->bank_service_summary, &entry_report->bank_service_summary);
     }
     return;
   }
@@ -1200,6 +1214,8 @@ static void loom_target_compile_report_merge_entry_summary(
   loom_target_compile_report_accumulate_source_low_memory_summaries(
       &report->source_low_memory_summary,
       &entry_report->source_low_memory_summary);
+  loom_target_compile_report_accumulate_bank_service_summaries(
+      &report->bank_service_summary, &entry_report->bank_service_summary);
   if (iree_any_bit_set(entry_report->detail_flags,
                        LOOM_TARGET_COMPILE_REPORT_DETAIL_TARGET_RESOURCES)) {
     if (report_had_target_resources) {
@@ -1273,6 +1289,7 @@ loom_target_compile_report_entry_from_report(
       .emission_breakdown = entry_report->emission_breakdown,
       .private_memory_bytes = entry_report->private_memory_bytes,
       .local_memory_bytes = entry_report->local_memory_bytes,
+      .bank_service_summary = entry_report->bank_service_summary,
       .static_instruction_mix = entry_report->static_instruction_mix,
       .dynamic_instruction_mix = entry_report->dynamic_instruction_mix,
       .target_resources = entry_report->target_resources,

--- a/loom/src/loom/target/reporting/report.h
+++ b/loom/src/loom/target/reporting/report.h
@@ -559,6 +559,40 @@ typedef struct loom_target_compile_report_workload_t {
   uint64_t dispatch_workitem_count;
 } loom_target_compile_report_workload_t;
 
+// Structural target bank-service evidence accumulated across source packets.
+typedef struct loom_target_compile_report_bank_service_summary_t {
+  // Number of source packets for which a target service model was selected.
+  uint64_t modeled_packet_count;
+  // Number of modeled source packets with exact service evidence.
+  uint64_t exact_packet_count;
+  // Number of modeled source packets without exact service evidence.
+  uint64_t unknown_packet_count;
+  // Number of exact source packets requiring no extra service rounds.
+  uint64_t conflict_free_packet_count;
+  // Number of exact source packets requiring extra service rounds.
+  uint64_t conflicted_packet_count;
+  // Required service rounds summed once per exact source packet.
+  uint64_t required_round_count;
+  // Uncontended service rounds summed once per exact source packet.
+  uint64_t uncontended_round_count;
+  // Extra service rounds summed once per exact source packet.
+  uint64_t extra_round_count;
+  // Number of source packets with exact dynamic service contributions.
+  uint64_t exact_dynamic_packet_count;
+  // Number of source packets without exact dynamic service contributions.
+  uint64_t unknown_dynamic_packet_count;
+  // Dynamic executions represented by exact service contributions.
+  uint64_t dynamic_packet_count;
+  // Required service rounds across exact dynamic packet executions.
+  uint64_t dynamic_required_round_count;
+  // Uncontended service rounds across exact dynamic packet executions.
+  uint64_t dynamic_uncontended_round_count;
+  // Extra service rounds across exact dynamic packet executions.
+  uint64_t dynamic_extra_round_count;
+  // Maximum requests assigned to one bank in one exact packet phase.
+  uint16_t maximum_request_multiplicity;
+} loom_target_compile_report_bank_service_summary_t;
+
 // One emitted artifact entry summary in a compile report.
 typedef struct loom_target_compile_report_entry_t {
   // Target artifact function symbol emitted for this entry.
@@ -633,6 +667,8 @@ typedef struct loom_target_compile_report_entry_t {
   uint64_t private_memory_bytes;
   // Estimated target local/shared memory bytes.
   uint64_t local_memory_bytes;
+  // Structural target bank-service evidence for this entry.
+  loom_target_compile_report_bank_service_summary_t bank_service_summary;
   // Residual target move counts indexed by
   // loom_target_compile_report_move_cause_t.
   loom_target_compile_report_move_cause_counts_t
@@ -1362,6 +1398,50 @@ typedef struct loom_target_compile_report_source_low_memory_row_t {
   uint64_t execution_count_plus_one;
 } loom_target_compile_report_source_low_memory_row_t;
 
+// Bank-service evidence grouped by one stable source and target packet shape.
+typedef struct loom_target_compile_report_source_low_bank_service_summary_t {
+  // Source function symbol containing the modeled memory packets.
+  iree_string_view_t function_name;
+  // Source operation mnemonic that emitted the modeled memory packets.
+  iree_string_view_t source_op_name;
+  // Numeric source operation kind that emitted the modeled memory packets.
+  uint32_t source_op_kind;
+  // Named source memory root selected by value facts, if available.
+  iree_string_view_t source_root_name;
+  // Source function entry argument index for the memory root, or UINT16_MAX.
+  uint16_t source_root_argument_index;
+  // Target-independent memory-space key selected by the target.
+  iree_string_view_t memory_space;
+  // Source memory operation kind selected by the target.
+  iree_string_view_t operation_kind;
+  // Stable target packet key selected for the modeled packets.
+  iree_string_view_t packet_key;
+  // Stable target-owned strategy key selected for the modeled packets.
+  iree_string_view_t strategy_key;
+  // Stable target packet-service model key.
+  iree_string_view_t model_key;
+  // Immutable source revision defining the selected model.
+  iree_string_view_t model_revision;
+  // Provenance strength of the selected model.
+  iree_string_view_t model_evidence;
+  // Treatment of requests to identical bank-word addresses.
+  iree_string_view_t request_policy;
+  // Stable reason shared by unknown rows, or empty when none or mixed.
+  iree_string_view_t unknown_reason;
+  // Whether unknown rows carried more than one stable reason.
+  bool has_mixed_unknown_reasons;
+  // Number of lanes represented by the model phases.
+  uint8_t wave_size;
+  // Number of independently serviced banks.
+  uint8_t bank_count;
+  // Byte width of one bank word.
+  uint8_t bank_word_byte_count;
+  // Number of consecutive bank words requested by each active lane.
+  uint8_t packet_word_count;
+  // Accumulated structural service evidence for the packet group.
+  loom_target_compile_report_bank_service_summary_t summary;
+} loom_target_compile_report_source_low_bank_service_summary_t;
+
 // Summary of emitted source-memory packet shape.
 typedef struct loom_target_compile_report_source_low_memory_summary_t {
   // Number of emitted source-memory packets.
@@ -1841,9 +1921,13 @@ typedef struct loom_target_compile_report_t {
       source_low_memory_argument_packet_summaries;
   // Owned source-memory summaries grouped by selected target strategy.
   loom_target_compile_report_row_list_t source_low_memory_strategy_summaries;
+  // Owned bank-service summaries grouped by source root and target packet.
+  loom_target_compile_report_row_list_t source_low_bank_service_summaries;
   // Derived summary of emitted source-memory packet shape.
   loom_target_compile_report_source_low_memory_summary_t
       source_low_memory_summary;
+  // Derived structural bank-service evidence across emitted source packets.
+  loom_target_compile_report_bank_service_summary_t bank_service_summary;
   // Owned target math-legalization decision rows.
   loom_target_compile_report_row_list_t math_legalization_rows;
   // Owned target-legalization decision rows.

--- a/loom/src/loom/test/corpus/authoring/README.md
+++ b/loom/src/loom/test/corpus/authoring/README.md
@@ -133,7 +133,11 @@ replaying the full report. Omitted metrics are unavailable, not zero. `diff`
 requires exact schema, target, config, workload, and entry identity; it has no
 force mode for unlike compilations. `suggest` uses only explicitly registered
 target providers and reports unavailable target interpretation instead of
-guessing from bundle names.
+guessing from bundle names. Findings carry an evidence tier. The default output
+contains only target models backed by public documentation or silicon
+calibration; `--include-experimental` additionally admits exact compiler proofs
+against hardware-unvalidated models. That opt-in is useful for pre-silicon
+search, but hardware timing still decides whether a candidate is adopted.
 
 Version-zero reports are ephemeral diagnostics co-versioned with the compiler.
 Regenerate them after changing compiler versions. Use the full report and
@@ -425,12 +429,34 @@ visible before object disassembly enters the debugging loop.
 
 The AMDGPU compile report explains selected workgroup-memory packets and the
 source address facts retained at packet selection. When Loom has a named
-instruction- and target-specific service model, detailed rows also report an
-exact structural LDS bank-service profile or an explicit reason the source
+instruction- and target-specific service model, summary reports retain compact
+global and per-source-operation bank-service groups. Detailed rows additionally
+report each exact structural LDS bank-service profile or the reason the source
 address and active-lane facts were insufficient. These are bank service rounds,
 not cycle predictions. Runtime measurements and profiler counters remain
 necessary when occupancy, cache behavior, scheduling, or data-dependent control
 flow dominates.
+
+The bounded report tools preserve the same evidence without replaying lowering:
+
+```bash
+loom-compile-report show /tmp/kernel.compile-report.json
+loom-compile-report \
+  diff /tmp/baseline.compile-report.json \
+       /tmp/candidate.compile-report.json
+loom-compile-report \
+  suggest /tmp/candidate.compile-report.json --include-experimental
+```
+
+`show` calls out conflicted and incomplete semantic groups. `diff` matches groups
+by function, source operation, memory root, operation, packet, and strategy, so
+an improvement in one access cannot hide a regression in another through global
+netting. It also reports loss of exact proof coverage and changes to the model
+revision or evidence class. `suggest` proposes bounded layout experiments only
+when a group has complete exact proof, conflicts, and structural extra rounds.
+The experiment searches padding or pitch, lane mapping, fragment layout, and
+packet width, then rejects spill or occupancy regressions before hardware
+timing.
 
 Compile with detailed reports when investigating shared-memory layout,
 padding, swizzling, vectorization, or imported kernel staging choices:
@@ -461,7 +487,10 @@ class independently from the address proof. `proof: "exact"` carries the
 per-phase service rounds, uncontended baseline, extra rounds, and maximum
 same-bank request multiplicity. `proof: "unknown"` carries a stable
 `unknown_reason` instead of guessing through unsupported address shapes or
-divergent active-lane control.
+divergent active-lane control. Exact proof establishes the result within the
+named model; the model's evidence class separately states whether its behavior
+has been documented, calibrated on silicon, or only recovered from vendor
+software.
 
 The current gfx1250 model covers full-wave `ds_read_b128` and
 `ds_write_b128` packets whose lane addresses are an aligned affine function of


### PR DESCRIPTION
`loom-compile-report` can now explain why a kernel candidate changed and turn exact target evidence into bounded next experiments, giving autoresearch loops a useful result between “the score moved” and reading a full compiler dump. `show` presents the final artifact and compiler analysis compactly, `diff` compares only genuinely equivalent compilations, and `suggest` identifies target-backed experiments without presenting structural evidence as measured performance.

## A real kernel search

A strict comparison of production Qwen MoE gate/up wave64 and wave32 schedules on gfx1151 now produces the following evidence directly from their compile reports:

| Signal | Wave64 baseline | Wave32 candidate | Change |
| --- | ---: | ---: | ---: |
| Native body instructions | 918 | 824 | -94 (-10.24%) |
| Code size | 4,736 B | 4,312 B | -424 B (-8.95%) |
| WMMA instructions | 8 | 4 | -4 (-50.00%) |
| LDS instructions | 64 | 48 | -16 (-25.00%) |
| Native coissued instructions | 0 | 10 | +10 carrying 20 semantic components |
| Modeled occupancy | 62% | 100% | +38 percentage points |
| Total waits | 84 | 61 | -23 (-27.38%) |
| Target-planned waits | 68 | 53 | -15 (-22.06%) |
| LDS allocation | 9,888 B | 11,936 B | +2,048 B (+20.71%) |
| Scalar registers | 48 | 52 | +4 (+8.33%) |

That is enough to understand the candidate before timing it: the wave32 schedule crosses an occupancy tier while removing instructions, waits, WMMA issues, and LDS instructions, but pays for the change with 2 KiB more LDS and four scalar registers. The report does not declare the candidate faster. It exposes the causal shape and the regressions that an agent must preserve in its search state, leaving hardware timing to decide whether the trade is worthwhile.

## Actionable LDS evidence

AMDGPU summary reports now retain the named bank model, its evidence class and revision, and per-semantic-access service groups with exact-proof coverage, structural and dynamic service rounds, extra rounds, and maximum bank multiplicity. `diff` matches those groups by source identity and selected packet strategy, so an improvement in one access cannot hide a regression in another through global netting.

When a semantic access has complete exact proof and requires extra bank-service rounds, `suggest` proposes a bounded search over pitch and padding, lane mapping, fragment layout, and packet width. Every finding cites the source access and target model that produced it. Models backed by public documentation or silicon calibration participate by default; structurally exact findings from hardware-unvalidated models require `--include-experimental` and remain labeled experimental.

## A trustworthy bounded view

The target-neutral views expose scheduled body versus target-owned entry-envelope instructions, native coissued instructions versus their semantic components, unclassified instructions, individual matrix families, exact dispatch-scaled family counts when available, explicit versus target-planned waits, wait-drain shape, and target-insertion proof coverage. Explicit JSON nulls remain unavailable evidence rather than silently becoming zero.

The bounded views project facts already retained by optional reporting. Normal compilation gains no new traversal, and the consumer never replays lowering to reconstruct discarded information. Full reports continue to own detailed attribution, while planner bookkeeping, allocation cardinalities, and ambiguous move-cause totals stay out of the interface until they support a concrete authoring decision.