### PR TITLE
[Infra] Resolve exported headers in bazel try

### DIFF
--- a/build_tools/devtools/bazel.py
+++ b/build_tools/devtools/bazel.py
@@ -978,17 +978,40 @@ def infer_dep_for_header_path(
         return None
     package_label = "//" + package_dir.relative_to(REPO_ROOT).as_posix()
     header_label_path = re.escape(header_path.relative_to(package_dir).as_posix())
+    labels = query_rules_with_header(
+        bazel,
+        header_label_path=header_label_path,
+        target_pattern=f"{package_label}:*",
+        env=env,
+    )
+    if not labels:
+        labels = query_rules_with_header(
+            bazel,
+            header_label_path=header_label_path,
+            target_pattern=f"{package_label}/...",
+            env=env,
+        )
+    if labels:
+        return labels[0]
+    return fallback_dep_for_header_dir(package_dir)
+
+
+def query_rules_with_header(
+    bazel: str,
+    *,
+    header_label_path: str,
+    target_pattern: str,
+    env: dict[str, str] | None,
+) -> list[str]:
     query_expression = (
-        f'kind(".* rule", attr("hdrs", "{header_label_path}", {package_label}:*))'
+        f'kind(".* rule", attr("hdrs", "{header_label_path}", {target_pattern}))'
     )
     completed = run_captured([bazel, "query", query_expression], cwd=REPO_ROOT, env=env)
     if completed.returncode == 0:
-        labels = sorted(
+        return sorted(
             line.strip() for line in completed.stdout.splitlines() if line.strip()
         )
-        if labels:
-            return labels[0]
-    return fallback_dep_for_header_dir(package_dir)
+    return []
 
 
 def nearest_package_dir(path: Path) -> Path | None:

--- a/build_tools/devtools/cli_test.py
+++ b/build_tools/devtools/cli_test.py
@@ -10,6 +10,7 @@ import contextlib
 import io
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -538,6 +539,32 @@ class CliTest(unittest.TestCase):
             bazel_dev.REPO_ROOT / "loom/binding/c/include/loomc/context.h",
         )
         self.assertIsNone(bazel_dev.header_path_for_include("stdio.h"))
+
+    def test_bazel_try_finds_exported_header_owner_in_subpackage(self):
+        direct_query = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        recursive_query = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="//loom/binding/c/target/amdgpu:amdgpu\n",
+            stderr="",
+        )
+        with mock.patch.object(
+            bazel_dev,
+            "run_captured",
+            side_effect=(direct_query, recursive_query),
+        ) as run_captured:
+            dep = bazel_dev.infer_dep_for_header(
+                "bazel", "loomc/target/amdgpu.h", env=None
+            )
+
+        self.assertEqual(dep, "//loom/binding/c/target/amdgpu:amdgpu")
+        self.assertEqual(run_captured.call_count, 2)
+        direct_expression = run_captured.call_args_list[0].args[0][2]
+        recursive_expression = run_captured.call_args_list[1].args[0][2]
+        self.assertIn("//loom/binding/c:*", direct_expression)
+        self.assertIn("//loom/binding/c/...", recursive_expression)
 
     def test_bazel_fuzz_builds_with_fuzzer_config_before_running_binary(self):
         args = cli.parse_arguments(


### PR DESCRIPTION
`iree-bazel-try` can now infer dependencies for public headers exported from a parent Bazel package but owned by a library in one of its descendant packages. This is the layout used by Loom C target extensions: `loomc/target/amdgpu.h` is exported from `//loom/binding/c`, while its implementation library is `//loom/binding/c/target/amdgpu:amdgpu`.

Dependency lookup remains local-first. It queries the nearest package as before, searches descendant packages only when that produces no owner, and retains the conventional package-name fallback for headers without a declared owner. This handles the package layout generically instead of maintaining a target-specific header map.

The regression covers the Loom C AMDGPU target header and verifies both stages of the owner search.
