### PR TITLE
[Loom] Restore RDNA3 WMMA scheduling quality

### DIFF
--- a/loom/py/loom/gen/target/low/c_emit.py
+++ b/loom/py/loom/gen/target/low/c_emit.py
@@ -628,6 +628,7 @@ def emit_source_for_views(
             [
                 f".name_string_offset = {pool.ref(f'schedule_{schedule_class.name}')},",
                 f".latency_cycles = {schedule_class.latency_cycles},",
+                f".schedule_distance_cycles = {schedule_class.schedule_distance_cycles},",
                 f".latency_kind = {schedule_class.latency_kind.c_name},",
                 f".issue_use_start = {compiled.schedule_rows[i]['issue_use_start']},",
                 f".issue_use_count = {compiled.schedule_rows[i]['issue_use_count']},",

--- a/loom/py/loom/target/arch/amdgpu/descriptors/rdna3.py
+++ b/loom/py/loom/target/arch/amdgpu/descriptors/rdna3.py
@@ -87,6 +87,7 @@ _AMDGPU_RDNA3_CORE_DESCRIPTOR_SET_BASE = _amdgpu_core_descriptor_set(
             _SCHEDULE_WMMA,
             latency_kind=LatencyKind.ESTIMATE,
             latency_cycles=5,
+            schedule_distance_cycles=32,
             issue_uses=(IssueUse(_RESOURCE_WMMA, cycles=1, units=1),),
             hazards=_matrix_hazards(_RESOURCE_WMMA),
             model_quality=ModelQuality.ESTIMATED,

--- a/loom/py/loom/target/arch/amdgpu/descriptors_test.py
+++ b/loom/py/loom/target/arch/amdgpu/descriptors_test.py
@@ -849,6 +849,19 @@ def test_gfx9_4_matrix_schedule_classes_match_member_timings() -> None:
         )
 
 
+def test_gfx11_wmma_separates_hardware_latency_from_schedule_distance() -> None:
+    schedule_classes = {
+        schedule_class.name: schedule_class
+        for schedule_class in (
+            _AMDGPU_RDNA3_CORE_DESCRIPTOR_SET_BASE.schedule_classes
+        )
+    }
+    schedule_class = schedule_classes[_SCHEDULE_WMMA]
+    assert schedule_class.latency_kind is LatencyKind.ESTIMATE
+    assert schedule_class.latency_cycles == 5
+    assert schedule_class.schedule_distance_cycles == 32
+
+
 def test_gfx12_matrix_schedule_classes_match_processor_model() -> None:
     schedule_classes = {
         schedule_class.name: schedule_class

--- a/loom/py/loom/target/arch/amdgpu/descriptors_test.py
+++ b/loom/py/loom/target/arch/amdgpu/descriptors_test.py
@@ -852,9 +852,7 @@ def test_gfx9_4_matrix_schedule_classes_match_member_timings() -> None:
 def test_gfx11_wmma_separates_hardware_latency_from_schedule_distance() -> None:
     schedule_classes = {
         schedule_class.name: schedule_class
-        for schedule_class in (
-            _AMDGPU_RDNA3_CORE_DESCRIPTOR_SET_BASE.schedule_classes
-        )
+        for schedule_class in (_AMDGPU_RDNA3_CORE_DESCRIPTOR_SET_BASE.schedule_classes)
     }
     schedule_class = schedule_classes[_SCHEDULE_WMMA]
     assert schedule_class.latency_kind is LatencyKind.ESTIMATE

--- a/loom/py/loom/target/low_descriptors.py
+++ b/loom/py/loom/target/low_descriptors.py
@@ -523,6 +523,7 @@ class ScheduleClass:
     latency_kind: LatencyKind
     model_quality: ModelQuality
     latency_cycles: int = 0
+    schedule_distance_cycles: int = 0
     issue_uses: tuple[IssueUse, ...] = ()
     hazards: tuple[Hazard, ...] = ()
     flags: tuple[ScheduleClassFlag, ...] = ()

--- a/loom/src/loom/codegen/low/descriptors.h
+++ b/loom/src/loom/codegen/low/descriptors.h
@@ -756,6 +756,10 @@ typedef struct loom_low_schedule_class_t {
   loom_bstring_table_offset_t name_string_offset;
   // Latency in cycles when latency_kind is exact or estimated.
   uint16_t latency_cycles;
+  // Scheduler dependency distance in cycles, or zero to use latency_cycles.
+  // This permits target models to keep hardware dependency latency separate
+  // from a conservative readiness distance used only for instruction order.
+  uint16_t schedule_distance_cycles;
   // Latency interpretation for scheduling and diagnostics.
   loom_low_latency_kind_t latency_kind;
   // First issue-use row for this schedule class.
@@ -775,6 +779,16 @@ typedef struct loom_low_schedule_class_t {
   // Number of pressure-delta rows for this schedule class.
   uint16_t pressure_delta_count;
 } loom_low_schedule_class_t;
+
+// Returns the scheduler dependency distance for |schedule_class|.
+// A zero override preserves the historical latency_cycles behavior.
+static inline uint16_t loom_low_schedule_class_schedule_distance_cycles(
+    const loom_low_schedule_class_t* schedule_class) {
+  if (schedule_class == NULL) return 0;
+  return schedule_class->schedule_distance_cycles != 0
+             ? schedule_class->schedule_distance_cycles
+             : schedule_class->latency_cycles;
+}
 
 typedef struct loom_low_descriptor_t {
   // String-table offset for the stable descriptor key.

--- a/loom/src/loom/codegen/low/schedule/candidate_policy.c
+++ b/loom/src/loom/codegen/low/schedule/candidate_policy.c
@@ -214,11 +214,6 @@ static bool loom_low_schedule_candidate_score_less(
     if (loom_low_schedule_candidate_pair_affinity_differs(lhs, rhs)) {
       return loom_low_schedule_candidate_has_better_pair_affinity(lhs, rhs);
     }
-    if (iree_any_bit_set(lhs->flags ^ rhs->flags,
-                         LOOM_LOW_SCHEDULE_CANDIDATE_FLAG_ADVANCES_STORAGE)) {
-      return iree_any_bit_set(
-          lhs->flags, LOOM_LOW_SCHEDULE_CANDIDATE_FLAG_ADVANCES_STORAGE);
-    }
     if (live_value_order != 0 &&
         (loom_low_schedule_candidate_compacts_live_values(lhs) ||
          loom_low_schedule_candidate_compacts_live_values(rhs)) &&

--- a/loom/src/loom/codegen/low/schedule/pressure.c
+++ b/loom/src/loom/codegen/low/schedule/pressure.c
@@ -640,9 +640,9 @@ static uint64_t loom_low_schedule_ready_schedule_key(
           state->node_dependency_latency_cycles != NULL
               ? state->node_dependency_latency_cycles[node_index]
               : 0;
-      const uint16_t latency = node->schedule_class != NULL
-                                   ? node->schedule_class->latency_cycles
-                                   : 0;
+      const uint16_t latency =
+          loom_low_schedule_class_schedule_distance_cycles(
+              node->schedule_class);
       return ((uint64_t)dependency_latency << 32) |
              (uint64_t)(UINT16_MAX - latency);
     }
@@ -1386,7 +1386,7 @@ void loom_low_schedule_pressure_score_candidate(
       loom_low_schedule_ready_policy_preferred_anchor_priority(state, indegrees,
                                                                node_index);
   const uint16_t latency_cycles =
-      node->schedule_class ? node->schedule_class->latency_cycles : 0;
+      loom_low_schedule_class_schedule_distance_cycles(node->schedule_class);
   *out_score = (loom_low_schedule_candidate_score_t){
       .projected_live_units = projected_live_units,
       .killed_live_units = killed_live_units,
@@ -1588,9 +1588,8 @@ void loom_low_schedule_pressure_compute_node_priorities(
         const loom_low_schedule_class_t* producer_schedule_class =
             state->nodes[producer_node].schedule_class;
         const uint16_t producer_latency =
-            producer_schedule_class != NULL
-                ? producer_schedule_class->latency_cycles
-                : 0;
+            loom_low_schedule_class_schedule_distance_cycles(
+                producer_schedule_class);
         dependency_latency_cycles =
             iree_max(dependency_latency_cycles, producer_latency);
       }
@@ -1663,7 +1662,8 @@ void loom_low_schedule_pressure_compute_node_priorities(
     }
     if (state->node_critical_path_cycles != NULL) {
       const uint16_t latency_cycles =
-          node->schedule_class ? node->schedule_class->latency_cycles : 0;
+          loom_low_schedule_class_schedule_distance_cycles(
+              node->schedule_class);
       state->node_critical_path_cycles[node_index] =
           iree_math_saturating_add_u32(latency_cycles, successor_path_cycles);
     }

--- a/loom/src/loom/codegen/low/schedule/pressure.c
+++ b/loom/src/loom/codegen/low/schedule/pressure.c
@@ -640,9 +640,8 @@ static uint64_t loom_low_schedule_ready_schedule_key(
           state->node_dependency_latency_cycles != NULL
               ? state->node_dependency_latency_cycles[node_index]
               : 0;
-      const uint16_t latency =
-          loom_low_schedule_class_schedule_distance_cycles(
-              node->schedule_class);
+      const uint16_t latency = loom_low_schedule_class_schedule_distance_cycles(
+          node->schedule_class);
       return ((uint64_t)dependency_latency << 32) |
              (uint64_t)(UINT16_MAX - latency);
     }

--- a/loom/src/loom/codegen/low/schedule/run.c
+++ b/loom/src/loom/codegen/low/schedule/run.c
@@ -1114,7 +1114,7 @@ static iree_status_t loom_low_schedule_run_list_scheduler(
             state->nodes[chosen_node].schedule_class;
         result_ready_issue_cycle = iree_math_saturating_add_u32(
             result_ready_issue_cycle,
-            schedule_class ? schedule_class->latency_cycles : 0);
+            loom_low_schedule_class_schedule_distance_cycles(schedule_class));
       }
       const uint32_t group_begin =
           loom_low_schedule_dependency_index_group_begin(

--- a/loom/src/loom/codegen/low/schedule/test/schedule.loom-test
+++ b/loom/src/loom/codegen/low/schedule/test/schedule.loom-test
@@ -147,11 +147,11 @@ low.func.def target(@test_target) @resource_stall_hides_load_latency(
 }
 
 // ====
-// RUN: emit low-schedule-json @resource_stall_places_concat_before_payload_ready strategy=resource-stall diagnostics=candidates output=none
+// RUN: emit low-schedule-json @resource_stall_prefers_live_value_compaction_over_storage_progress strategy=resource-stall diagnostics=candidates output=none
 
 test.target<low_core> @test_target
 
-low.func.def target(@test_target) @resource_stall_places_concat_before_payload_ready(
+low.func.def target(@test_target) @resource_stall_prefers_live_value_compaction_over_storage_progress(
     %lhs0: reg<test.i32 x4>, %rhs0: reg<test.i32 x4>,
     %lhs1: reg<test.i32 x4>, %rhs1: reg<test.i32 x4>,
     %lhs: reg<test.i32>, %rhs: reg<test.i32>) ->
@@ -162,9 +162,9 @@ low.func.def target(@test_target) @resource_stall_places_concat_before_payload_r
   // REMARK@+1: BACKEND/015
   %part1 = low.op<test.add.v4i32>(%lhs1, %rhs1) :
       (reg<test.i32 x4>, reg<test.i32 x4>) -> reg<test.i32 x4>
-  // REMARK@+1: BACKEND/015 {scheduled_ordinal="2", chosen_packet="low.concat", rejected_packet="test.mul.i32", chosen_data_ready_stall_cycles="0"}
   %packed = low.concat(%part0, %part1) :
       (reg<test.i32 x4>, reg<test.i32 x4>) -> reg<test.i32 x8>
+  // REMARK@+1: BACKEND/015 {scheduled_ordinal="2", chosen_packet="test.mul.i32", rejected_packet="low.concat", chosen_data_ready_stall_cycles="0"}
   %independent = low.op<test.mul.i32>(%lhs, %rhs) :
       (reg<test.i32>, reg<test.i32>) -> reg<test.i32>
   low.return %packed, %independent : reg<test.i32 x8>, reg<test.i32>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/low_wmma_schedule.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/low_wmma_schedule.loom-test
@@ -459,12 +459,6 @@ low.func.def target(@target) @bf16_four_k_block_loads_schedule_before_wmma(%work
   s_waitcnt vmcnt(12) lgkmcnt(63)
   s_delay_alu instid0(VALU_DEP_1)
   v_wmma_f32_16x16x16_bf16 v[8:15], v[16:23], v[24:31], v[8:15]
-  s_waitcnt vmcnt(8) lgkmcnt(63)
-  s_delay_alu instid0(VALU_DEP_1)
-  v_wmma_f32_16x16x16_bf16 v[8:15], v[32:39], v[40:47], v[8:15]
-  s_waitcnt vmcnt(4) lgkmcnt(63)
-  s_delay_alu instid0(VALU_DEP_1)
-  v_wmma_f32_16x16x16_bf16 v[8:15], v[48:55], v[56:63], v[8:15]
   s_waitcnt vmcnt(2) lgkmcnt(63)
   v_mov_b32 v16, v4
   v_mov_b32 v17, v5
@@ -474,8 +468,11 @@ low.func.def target(@target) @bf16_four_k_block_loads_schedule_before_wmma(%work
   v_mov_b32 v21, v65
   v_mov_b32 v22, v66
   v_mov_b32 v23, v67
-  s_waitcnt vmcnt(0) lgkmcnt(63)
+  v_wmma_f32_16x16x16_bf16 v[8:15], v[32:39], v[40:47], v[8:15]
   s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x16_bf16 v[8:15], v[48:55], v[56:63], v[8:15]
+  s_waitcnt vmcnt(0) lgkmcnt(63)
+  s_delay_alu instid0(VALU_DEP_1) | instid1(VALU_DEP_3)
   v_wmma_f32_16x16x16_bf16 v[8:15], v[16:23], v[72:79], v[8:15]
   global_store_b32 v0, v8, s[4:5] offset:0
   global_store_b32 v0, v9, s[4:5] offset:128

--- a/loom/src/loom/target/emit/native/amdgpu/test/assembly.loom-test
+++ b/loom/src/loom/target/emit/native/amdgpu/test/assembly.loom-test
@@ -1164,9 +1164,9 @@ low.func.def target(@gfx11_target) @gfx11_vopd_fmac_chain_pair_exposure_through_
 }
 
 // ----
-  v_dual_fmac_f32 v8, v0, v4 :: v_dual_fmac_f32 v9, v2, v6
+  v_dual_fmac_f32 v0, v4, v8 :: v_dual_fmac_f32 v1, v6, v10
   s_delay_alu instid0(VALU_DEP_1)
-  v_dual_fmac_f32 v8, v1, v5 :: v_dual_fmac_f32 v9, v3, v7
+  v_dual_fmac_f32 v0, v5, v9 :: v_dual_fmac_f32 v1, v7, v11
   s_endpgm
 
 // ====
@@ -3029,18 +3029,18 @@ low.func.def target(@gfx11_target) @gfx11_stress_fragment(%s0: reg<amdgpu.sgpr>,
 }
 
 // ----
+  v_wmma_f32_16x16x16_f16 v[0:7], v[16:23], v[24:31], v[0:7]
   buffer_load_dword v11, v10, s[4:7], s8 offen offset:4
   buffer_load_b128 v[12:15], v10, s[4:7], s8 offen offset:16
   s_load_dwordx2 s[0:1], s[0:1], s8 offset:16
   s_buffer_load_dword s1, s[4:7], s8 offset:0
-  v_wmma_f32_16x16x16_f16 v[0:7], v[16:23], v[24:31], v[0:7]
   s_add_u32 s2, s2, s3
   v_add_u32 v8, v8, v9
-  v_wmma_f32_16x16x16_f16 v[0:7], v[16:23], v[24:31], v[0:7]
   s_add_u32 s1, s2, s1
-  v_add_u32 v4, v8, v11
-  buffer_store_dword v4, v10, s[4:7], s1 offen offset:8
+  v_add_u32 v8, v8, v11
+  buffer_store_dword v8, v10, s[4:7], s1 offen offset:8
   buffer_store_b128 v[12:15], v10, s[4:7], s0 offen offset:32
+  v_wmma_f32_16x16x16_f16 v[0:7], v[16:23], v[24:31], v[0:7]
   buffer_store_b128 v[0:3], v10, s[4:7], s8 offen offset:48
   s_waitcnt vmcnt(0) lgkmcnt(0)
   s_waitcnt_depctr depctr(0)


### PR DESCRIPTION
## Summary

This PR restores RDNA3/RDNA3.5 WMMA code-generation performance by separating hardware latency from the conservative dependency distance used by Loom's generic list scheduler.

It:

- Adds `schedule_distance_cycles` to Loom schedule-class descriptors.
- Falls back to `latency_cycles` when no scheduling-distance override is specified.
- Models RDNA3 WMMA with a 5-cycle hardware latency and a 32-cycle scheduling distance.
- Removes the `ADVANCES_STORAGE` candidate tie-break, which was producing poorer GEMM schedules.
- Adds a focused target-model test for the 5/32-cycle contract.

There are no kernel-name, model-name, shape, or llama.cpp-specific conditions.

## Motivation

An end-to-end regression appeared when moving llama.cpp from an older Loom compiler to current HRX Systems `main`.

With the runtime held constant, changing only `libloomc` reduced PP512 from approximately 2262 to 2118 tok/s. Paired HRX/IREE dispatch profiles attributed 28.72 ms of additional GPU service to the newer compiler:

- Ordinary Q8 WMMA kernels: +17.09 ms
- Fused Q8 GDN/RMS epilogue: +5.39 ms

These two families accounted for 78% of the measured regression.

Using a larger hardware latency globally was not appropriate because wait-state and matrix-coexecution planning need the actual hardware latency. The new field lets only generic scheduling use a more conservative dependency distance.

## Performance

Measured on gfx1151 using `Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf`:

| Configuration | PP512 | TG128 |
|---|---:|---:|
| Unmodified HRX Systems main | 2114.70 +/- 8.67 tok/s | 63.57 +/- 0.16 tok/s |
| This PR | 2309.66 +/- 5.00 tok/s | 63.02 +/- 0.17 tok/s |
| Fresh installed-prefix verification | 2318.88 +/- 6.28 tok/s | 63.07 +/- 0.19 tok/s |

PP512 improves by approximately 9.2% over unmodified `main`. Decode remains in the established 63 tok/s band.

## Correctness

Full 145-chunk WikiText-2 perplexity:

| Backend | PPL |
|---|---:|
| HRX with this PR | 5.9036 +/- 0.03675 |
| ROCm reference | 5.9049 +/- 0.03674 |

## Testing

The following focused Loom tests pass:

- `loom/py/loom/gen/target/arch/amdgpu/descriptors/descriptors_test`
- `loom/py/loom/gen/target/low/low_descriptors_test`
- `loom/py/loom/target/arch/amdgpu/descriptors_test`

The complete HRX Systems distribution and llama.cpp HRX backend were also rebuilt from a fresh install prefix.