### PR TITLE
[Loom] Preserve dynamic program facts through AMDGPU lowering

### DIFF
--- a/loom/py/loom/builtin_types.py
+++ b/loom/py/loom/builtin_types.py
@@ -148,6 +148,7 @@ buffer_type = TypeDef(
     name="buffer",
     doc="Opaque untyped storage identity used as the root for typed views.",
     ir_kind="buffer",
+    fact_domain="loom_buffer_fact_domain",
 )
 
 # ============================================================================

--- a/loom/py/loom/target/arch/amdgpu/contracts/integer.py
+++ b/loom/py/loom/target/arch/amdgpu/contracts/integer.py
@@ -111,6 +111,11 @@ _ADDRESS_U32_DIAGNOSTIC = GuardDiagnostic(
     subject_name="u32",
     constraint_key="amdgpu.address.u32",
 )
+_ADDRESS_I32_DIAGNOSTIC = GuardDiagnostic(
+    subject_role="address-width",
+    subject_name="i32",
+    constraint_key="amdgpu.address.i32",
+)
 _BYTE_OFFSET_U32_DIAGNOSTIC = GuardDiagnostic(
     subject_role="byte-offset-width",
     subject_name="u32",
@@ -157,6 +162,8 @@ def _descriptor_available_guards(*descriptors: Descriptor) -> tuple[Guard, ...]:
 def _typed_binary_guards(
     type_pattern: TypePattern,
     *,
+    signed_bit_count: int | None = None,
+    signed_diagnostic: GuardDiagnostic | None = None,
     unsigned_bit_count: int | None = None,
     unsigned_diagnostic: GuardDiagnostic | None = None,
 ) -> tuple[Guard, ...]:
@@ -165,6 +172,14 @@ def _typed_binary_guards(
         Guard.value_type("rhs", type_pattern),
         Guard.value_type("result", type_pattern),
     ]
+    if signed_bit_count is not None:
+        guards.append(
+            Guard.value_signed_bit_count(
+                "result",
+                signed_bit_count,
+                diagnostic=signed_diagnostic,
+            )
+        )
     if unsigned_bit_count is not None:
         guards.append(
             Guard.value_unsigned_bit_count(
@@ -181,6 +196,8 @@ def _sgpr_binary_rule(
     type_pattern: TypePattern,
     descriptor: Descriptor,
     *,
+    signed_bit_count: int | None = None,
+    signed_diagnostic: GuardDiagnostic | None = None,
     unsigned_bit_count: int | None = None,
     unsigned_diagnostic: GuardDiagnostic | None = None,
 ) -> DescriptorRule:
@@ -190,6 +207,8 @@ def _sgpr_binary_rule(
         guards=(
             *_typed_binary_guards(
                 type_pattern,
+                signed_bit_count=signed_bit_count,
+                signed_diagnostic=signed_diagnostic,
                 unsigned_bit_count=unsigned_bit_count,
                 unsigned_diagnostic=unsigned_diagnostic,
             ),
@@ -222,6 +241,8 @@ def _vgpr_binary_rule(
     descriptor_rhs: str = "rhs",
     source_lhs: str = "lhs",
     source_rhs: str = "rhs",
+    signed_bit_count: int | None = None,
+    signed_diagnostic: GuardDiagnostic | None = None,
     unsigned_bit_count: int | None = None,
     unsigned_diagnostic: GuardDiagnostic | None = None,
 ) -> DescriptorRule:
@@ -231,6 +252,8 @@ def _vgpr_binary_rule(
         guards=(
             *_typed_binary_guards(
                 type_pattern,
+                signed_bit_count=signed_bit_count,
+                signed_diagnostic=signed_diagnostic,
                 unsigned_bit_count=unsigned_bit_count,
                 unsigned_diagnostic=unsigned_diagnostic,
             ),
@@ -719,6 +742,32 @@ def _address_rules(
             unsigned_diagnostic=_ADDRESS_U32_DIAGNOSTIC,
         )
         for type_pattern in (_INDEX, _OFFSET)
+    )
+
+
+def _signed_index_binary_rules(
+    source_op: Op,
+    sgpr_descriptor_key: str,
+    vgpr_descriptor_key: str,
+) -> tuple[DescriptorRule, ...]:
+    sgpr_descriptor = _descriptor(sgpr_descriptor_key)
+    vgpr_descriptor = _descriptor(vgpr_descriptor_key)
+    return (
+        _sgpr_binary_rule(
+            source_op,
+            _INDEX,
+            sgpr_descriptor,
+            signed_bit_count=32,
+            signed_diagnostic=_ADDRESS_I32_DIAGNOSTIC,
+        ),
+        _vgpr_binary_rule(
+            source_op,
+            _INDEX,
+            vgpr_descriptor,
+            ADDRESS_VGPR_MATERIALIZER,
+            signed_bit_count=32,
+            signed_diagnostic=_ADDRESS_I32_DIAGNOSTIC,
+        ),
     )
 
 
@@ -1658,6 +1707,13 @@ def _rules() -> tuple[DescriptorRule, ...]:
     )
     rules.extend(
         _address_rules(index.index_sub, "amdgpu.s_sub_u32", "amdgpu.v_sub_u32")
+    )
+    rules.extend(
+        _signed_index_binary_rules(
+            index.index_sub,
+            "amdgpu.s_sub_u32",
+            "amdgpu.v_sub_u32",
+        )
     )
     rules.extend(
         _address_rules(

--- a/loom/src/loom/analysis/BUILD.bazel
+++ b/loom/src/loom/analysis/BUILD.bazel
@@ -17,6 +17,7 @@ loom_cc_library(
     srcs = ["control_uniformity.c"],
     hdrs = ["control_uniformity.h"],
     deps = [
+        ":scc",
         "//loom/src/loom/ir",
         "//loom/src/loom/ir:facts",
         "//loom/src/loom/ops:op_defs",
@@ -24,6 +25,24 @@ loom_cc_library(
         "//loom/src/loom/util:fact_table",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:arena",
+    ],
+)
+
+loom_cc_test(
+    name = "control_uniformity_test",
+    srcs = ["control_uniformity_test.cc"],
+    deps = [
+        ":control_uniformity",
+        "//loom/src/loom/format/text:parser",
+        "//loom/src/loom/ir",
+        "//loom/src/loom/ops/cfg",
+        "//loom/src/loom/ops/func",
+        "//loom/src/loom/ops/scalar",
+        "//loom/src/loom/ops/test",
+        "//loom/src/loom/testing:module_ptr",
+        "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
     ],
 )
 

--- a/loom/src/loom/analysis/CMakeLists.txt
+++ b/loom/src/loom/analysis/CMakeLists.txt
@@ -17,6 +17,7 @@ loom_cc_library(
   SRCS
     "control_uniformity.c"
   DEPS
+    ::scc
     iree::base
     iree::base::internal::arena
     loom::ir
@@ -25,6 +26,25 @@ loom_cc_library(
     loom::util::cfg_graph
     loom::util::fact_table
   PUBLIC
+)
+
+loom_cc_test(
+  NAME
+    control_uniformity_test
+  SRCS
+    "control_uniformity_test.cc"
+  DEPS
+    ::control_uniformity
+    iree::base::internal::arena
+    iree::testing::gtest
+    iree::testing::gtest_main
+    loom::format::text::parser
+    loom::ir
+    loom::ops::cfg
+    loom::ops::func
+    loom::ops::scalar
+    loom::ops::test
+    loom::testing::module_ptr
 )
 
 loom_cc_library(

--- a/loom/src/loom/analysis/control_uniformity.c
+++ b/loom/src/loom/analysis/control_uniformity.c
@@ -8,15 +8,25 @@
 
 #include <string.h>
 
+#include "loom/analysis/scc.h"
 #include "loom/ops/op_defs.h"
 #include "loom/util/cfg_graph.h"
 
 #define LOOM_CONTROL_UNIFORMITY_NODE_INVALID UINT32_MAX
+#define LOOM_CONTROL_UNIFORMITY_RECORD_INVALID UINT32_MAX
 
 typedef enum loom_control_uniformity_cfg_node_flag_bits_e {
   LOOM_CONTROL_UNIFORMITY_CFG_NODE_CAN_REACH_EXIT = 1u << 0,
+  LOOM_CONTROL_UNIFORMITY_CFG_NODE_IS_CYCLIC = 1u << 1,
 } loom_control_uniformity_cfg_node_flag_bits_t;
 typedef uint8_t loom_control_uniformity_cfg_node_flags_t;
+
+typedef struct loom_control_uniformity_cfg_record_t {
+  // CFG edge selecting the control alternative.
+  loom_cfg_edge_index_t edge_index;
+  // Next control record for the same block.
+  uint32_t next_record_index;
+} loom_control_uniformity_cfg_record_t;
 
 typedef struct loom_control_uniformity_cfg_node_t {
   // One-based reverse-CFG depth-first-search number, or zero when unvisited.
@@ -39,6 +49,8 @@ typedef struct loom_control_uniformity_cfg_node_t {
   uint32_t scratch;
   // CFG edge identifying the weakest controller assigned to this block.
   loom_cfg_edge_index_t controller_edge_index;
+  // Head of the lazily retained control-alternative record list.
+  uint32_t control_record_head;
   // Depth in the postdominator tree.
   uint32_t postdominator_depth;
   // Strongest execution scope proven for the block.
@@ -56,6 +68,24 @@ struct loom_control_uniformity_cfg_region_t {
   loom_control_uniformity_cfg_node_t* nodes;
   // Synthetic exit node index, equal to graph->block_count.
   uint32_t exit_node;
+  // Control-alternative records shared by per-block intrusive lists.
+  loom_control_uniformity_cfg_record_t* control_records;
+  // Number of initialized control-alternative records.
+  uint32_t control_record_count;
+  // Allocated control-alternative record capacity.
+  uint32_t control_record_capacity;
+  // Per-block generation marks used by control-context queries.
+  uint32_t* query_marks;
+  // Current nonzero generation in |query_marks|.
+  uint32_t query_generation;
+  // Block traversal stack used by control-context queries.
+  uint32_t* query_stack;
+  // Collected left-hand control-context edges.
+  loom_cfg_edge_index_t* query_lhs_edges;
+  // Collected right-hand control-context edges.
+  loom_cfg_edge_index_t* query_rhs_edges;
+  // True after control alternatives and cyclic controllers are retained.
+  bool exclusivity_initialized;
 };
 
 static iree_host_size_t loom_control_uniformity_region_hash(
@@ -446,6 +476,189 @@ static void loom_control_uniformity_cfg_assign_control_scope(
   }
 }
 
+static iree_status_t loom_control_uniformity_cfg_visit_scc_successors(
+    void* user_data, iree_host_size_t node,
+    loom_scc_successor_callback_t successor) {
+  const loom_cfg_graph_t* graph = (const loom_cfg_graph_t*)user_data;
+  const loom_cfg_block_index_span_t successors =
+      loom_cfg_graph_successors(graph, (uint16_t)node);
+  for (iree_host_size_t i = 0; i < successors.count; ++i) {
+    IREE_RETURN_IF_ERROR(
+        successor.fn(successor.user_data, successors.values[i]));
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_control_uniformity_cfg_mark_cycles(
+    loom_control_uniformity_info_t* info,
+    loom_control_uniformity_cfg_region_t* summary) {
+  const iree_arena_checkpoint_t checkpoint =
+      iree_arena_checkpoint_save(info->arena);
+  const loom_scc_graph_t scc_graph = {
+      .node_count = summary->graph->block_count,
+      .visit_successors = loom_scc_visit_successors_callback_make(
+          loom_control_uniformity_cfg_visit_scc_successors,
+          (void*)summary->graph),
+  };
+  loom_scc_list_t sccs = {0};
+  iree_status_t status =
+      loom_scc_compute(&scc_graph, /*options=*/NULL, info->arena, &sccs);
+  if (iree_status_is_ok(status)) {
+    for (iree_host_size_t i = 0; i < sccs.count; ++i) {
+      const loom_scc_t* scc = &sccs.values[i];
+      if (!scc->is_cycle) continue;
+      for (iree_host_size_t j = 0; j < scc->node_count; ++j) {
+        summary->nodes[scc->nodes[j]].flags |=
+            LOOM_CONTROL_UNIFORMITY_CFG_NODE_IS_CYCLIC;
+      }
+    }
+  }
+  iree_arena_checkpoint_restore(&checkpoint);
+  return status;
+}
+
+static iree_status_t loom_control_uniformity_cfg_append_control_record(
+    loom_control_uniformity_info_t* info,
+    loom_control_uniformity_cfg_region_t* summary, uint32_t node_index,
+    loom_cfg_edge_index_t edge_index) {
+  const uint32_t minimum_capacity = summary->control_record_count + 1;
+  if (minimum_capacity > summary->control_record_capacity) {
+    iree_host_size_t capacity = summary->control_record_capacity;
+    IREE_RETURN_IF_ERROR(iree_arena_grow_array(
+        info->arena, summary->control_record_count,
+        iree_max((iree_host_size_t)minimum_capacity, (iree_host_size_t)16),
+        sizeof(*summary->control_records), &capacity,
+        (void**)&summary->control_records));
+    IREE_ASSERT_LE(capacity, UINT32_MAX);
+    summary->control_record_capacity = (uint32_t)capacity;
+  }
+  loom_control_uniformity_cfg_node_t* node = &summary->nodes[node_index];
+  const uint32_t record_index = summary->control_record_count++;
+  summary->control_records[record_index] =
+      (loom_control_uniformity_cfg_record_t){
+          .edge_index = edge_index,
+          .next_record_index = node->control_record_head,
+      };
+  node->control_record_head = record_index;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_control_uniformity_cfg_retain_control_path(
+    loom_control_uniformity_info_t* info,
+    loom_control_uniformity_cfg_region_t* summary,
+    loom_cfg_edge_index_t edge_index) {
+  const loom_cfg_edge_info_t* edge =
+      loom_cfg_graph_edge(summary->graph, edge_index);
+  const uint32_t stop_index =
+      summary->nodes[edge->source_block_index].immediate_postdominator;
+  uint32_t node_index = edge->target_block_index;
+  while (summary->nodes[node_index].postdominator_depth >
+         summary->nodes[stop_index].postdominator_depth) {
+    IREE_RETURN_IF_ERROR(loom_control_uniformity_cfg_append_control_record(
+        info, summary, node_index, edge_index));
+    node_index = summary->nodes[node_index].immediate_postdominator;
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_control_uniformity_cfg_initialize_exclusivity(
+    loom_control_uniformity_info_t* info,
+    loom_control_uniformity_cfg_region_t* summary) {
+  if (summary->exclusivity_initialized || !summary->nodes) {
+    return iree_ok_status();
+  }
+  IREE_RETURN_IF_ERROR(loom_control_uniformity_cfg_mark_cycles(info, summary));
+  for (uint32_t block_index = 0; block_index < summary->exit_node;
+       ++block_index) {
+    if (summary->nodes[block_index].dfs_number == 0 ||
+        !loom_control_uniformity_cfg_block_has_distinct_successors(
+            summary->graph, block_index)) {
+      continue;
+    }
+    const loom_cfg_edge_index_span_t edges =
+        loom_cfg_graph_successor_edges(summary->graph, (uint16_t)block_index);
+    for (iree_host_size_t i = 0; i < edges.count; ++i) {
+      const loom_cfg_edge_info_t* edge =
+          loom_cfg_graph_edge(summary->graph, edges.values[i]);
+      if (edge && summary->nodes[edge->target_block_index].dfs_number != 0) {
+        IREE_RETURN_IF_ERROR(loom_control_uniformity_cfg_retain_control_path(
+            info, summary, edges.values[i]));
+      }
+    }
+  }
+  if (summary->exit_node != 0) {
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        info->arena, summary->exit_node, sizeof(*summary->query_marks),
+        (void**)&summary->query_marks));
+    memset(summary->query_marks, 0,
+           summary->exit_node * sizeof(*summary->query_marks));
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        info->arena, summary->exit_node, sizeof(*summary->query_stack),
+        (void**)&summary->query_stack));
+  }
+  if (summary->control_record_count != 0) {
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        info->arena, summary->control_record_count,
+        sizeof(*summary->query_lhs_edges), (void**)&summary->query_lhs_edges));
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        info->arena, summary->control_record_count,
+        sizeof(*summary->query_rhs_edges), (void**)&summary->query_rhs_edges));
+  }
+  summary->exclusivity_initialized = true;
+  return iree_ok_status();
+}
+
+static uint32_t loom_control_uniformity_cfg_next_query_generation(
+    loom_control_uniformity_cfg_region_t* summary) {
+  ++summary->query_generation;
+  if (summary->query_generation == 0) {
+    memset(summary->query_marks, 0,
+           summary->exit_node * sizeof(*summary->query_marks));
+    summary->query_generation = 1;
+  }
+  return summary->query_generation;
+}
+
+static iree_host_size_t loom_control_uniformity_cfg_collect_control_context(
+    loom_control_uniformity_info_t* info,
+    loom_control_uniformity_cfg_region_t* summary, uint32_t node_index,
+    loom_value_fact_uniform_scope_t required_scope,
+    loom_cfg_edge_index_t* out_edges) {
+  const uint32_t generation =
+      loom_control_uniformity_cfg_next_query_generation(summary);
+  iree_host_size_t stack_count = 1;
+  summary->query_stack[0] = node_index;
+  summary->query_marks[node_index] = generation;
+  iree_host_size_t edge_count = 0;
+  while (stack_count != 0) {
+    const uint32_t current_node_index = summary->query_stack[--stack_count];
+    uint32_t record_index =
+        summary->nodes[current_node_index].control_record_head;
+    while (record_index != LOOM_CONTROL_UNIFORMITY_RECORD_INVALID) {
+      const loom_control_uniformity_cfg_record_t* record =
+          &summary->control_records[record_index];
+      const loom_cfg_edge_info_t* edge =
+          loom_cfg_graph_edge(summary->graph, record->edge_index);
+      const uint32_t controller_index = edge->source_block_index;
+      const loom_control_uniformity_cfg_node_t* controller =
+          &summary->nodes[controller_index];
+      if (!iree_any_bit_set(controller->flags,
+                            LOOM_CONTROL_UNIFORMITY_CFG_NODE_IS_CYCLIC) &&
+          loom_control_uniformity_cfg_selector_scope(info, edge) >=
+              required_scope) {
+        out_edges[edge_count++] = record->edge_index;
+      }
+      if (summary->query_marks[controller_index] != generation) {
+        summary->query_marks[controller_index] = generation;
+        summary->query_stack[stack_count++] = controller_index;
+      }
+      record_index = record->next_record_index;
+    }
+  }
+  IREE_ASSERT_LE(edge_count, summary->control_record_count);
+  return edge_count;
+}
+
 static iree_status_t loom_control_uniformity_cfg_region_initialize(
     const loom_control_uniformity_info_t* info, const loom_region_t* region,
     loom_control_uniformity_cfg_region_t* summary) {
@@ -471,6 +684,8 @@ static iree_status_t loom_control_uniformity_cfg_region_initialize(
     summary->nodes[i].bucket_head = LOOM_CONTROL_UNIFORMITY_NODE_INVALID;
     summary->nodes[i].bucket_next = LOOM_CONTROL_UNIFORMITY_NODE_INVALID;
     summary->nodes[i].controller_edge_index = LOOM_CFG_EDGE_INDEX_INVALID;
+    summary->nodes[i].control_record_head =
+        LOOM_CONTROL_UNIFORMITY_RECORD_INVALID;
     summary->nodes[i].execution_scope = LOOM_VALUE_FACT_UNIFORM_SCOPE_NONE;
   }
 
@@ -689,6 +904,108 @@ iree_status_t loom_control_uniformity_prove_execution(
             out_failure)) {
       return iree_ok_status();
     }
+  }
+  *out_proven = true;
+  return iree_ok_status();
+}
+
+iree_status_t loom_control_uniformity_prove_mutually_exclusive_execution(
+    loom_control_uniformity_info_t* info, iree_host_size_t lhs_op_count,
+    const loom_op_t* const* lhs_ops, iree_host_size_t rhs_op_count,
+    const loom_op_t* const* rhs_ops,
+    loom_value_fact_uniform_scope_t required_scope, bool* out_proven) {
+  IREE_ASSERT_ARGUMENT(info);
+  IREE_ASSERT_GT(lhs_op_count, 0u);
+  IREE_ASSERT_ARGUMENT(lhs_ops);
+  IREE_ASSERT_GT(rhs_op_count, 0u);
+  IREE_ASSERT_ARGUMENT(rhs_ops);
+  IREE_ASSERT_ARGUMENT(out_proven);
+  IREE_ASSERT(required_scope == LOOM_VALUE_FACT_UNIFORM_SCOPE_SUBGROUP ||
+              required_scope == LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP ||
+              required_scope == LOOM_VALUE_FACT_UNIFORM_SCOPE_CLUSTER);
+  *out_proven = false;
+  const loom_block_t* first_block = lhs_ops[0]->parent_block;
+  if (!first_block || !first_block->parent_region) {
+    return iree_ok_status();
+  }
+  const loom_region_t* region = first_block->parent_region;
+  for (iree_host_size_t i = 0; i < lhs_op_count; ++i) {
+    IREE_ASSERT_ARGUMENT(lhs_ops[i]);
+    const loom_block_t* block = lhs_ops[i]->parent_block;
+    if (!block || block->parent_region != region) return iree_ok_status();
+  }
+  for (iree_host_size_t i = 0; i < rhs_op_count; ++i) {
+    IREE_ASSERT_ARGUMENT(rhs_ops[i]);
+    const loom_block_t* block = rhs_ops[i]->parent_block;
+    if (!block || block->parent_region != region) return iree_ok_status();
+  }
+
+  loom_control_uniformity_cfg_region_t* summary = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_control_uniformity_cfg_region(info, region, &summary));
+  if (!summary->nodes) return iree_ok_status();
+  IREE_RETURN_IF_ERROR(
+      loom_control_uniformity_cfg_initialize_exclusivity(info, summary));
+
+  if (first_block->region_index >= summary->exit_node) return iree_ok_status();
+  iree_host_size_t candidate_edge_count =
+      loom_control_uniformity_cfg_collect_control_context(
+          info, summary, first_block->region_index, required_scope,
+          summary->query_lhs_edges);
+  for (iree_host_size_t i = 1; i < lhs_op_count; ++i) {
+    const loom_block_t* block = lhs_ops[i]->parent_block;
+    if (block->region_index >= summary->exit_node) return iree_ok_status();
+    const iree_host_size_t edge_count =
+        loom_control_uniformity_cfg_collect_control_context(
+            info, summary, block->region_index, required_scope,
+            summary->query_rhs_edges);
+    iree_host_size_t retained_edge_count = 0;
+    for (iree_host_size_t j = 0; j < candidate_edge_count; ++j) {
+      const loom_cfg_edge_index_t candidate_edge = summary->query_lhs_edges[j];
+      bool retained = false;
+      for (iree_host_size_t k = 0; k < edge_count; ++k) {
+        if (candidate_edge == summary->query_rhs_edges[k]) {
+          retained = true;
+          break;
+        }
+      }
+      if (retained) {
+        summary->query_lhs_edges[retained_edge_count++] = candidate_edge;
+      }
+    }
+    candidate_edge_count = retained_edge_count;
+    if (candidate_edge_count == 0) return iree_ok_status();
+  }
+
+  for (iree_host_size_t i = 0; i < rhs_op_count; ++i) {
+    const loom_block_t* block = rhs_ops[i]->parent_block;
+    if (block->region_index >= summary->exit_node) return iree_ok_status();
+    const iree_host_size_t edge_count =
+        loom_control_uniformity_cfg_collect_control_context(
+            info, summary, block->region_index, required_scope,
+            summary->query_rhs_edges);
+    iree_host_size_t retained_edge_count = 0;
+    for (iree_host_size_t j = 0; j < candidate_edge_count; ++j) {
+      const loom_cfg_edge_index_t candidate_edge = summary->query_lhs_edges[j];
+      const loom_cfg_edge_info_t* lhs_edge =
+          loom_cfg_graph_edge(summary->graph, candidate_edge);
+      bool retained = false;
+      for (iree_host_size_t k = 0; k < edge_count; ++k) {
+        const loom_cfg_edge_info_t* rhs_edge =
+            loom_cfg_graph_edge(summary->graph, summary->query_rhs_edges[k]);
+        if (lhs_edge->terminator == rhs_edge->terminator &&
+            lhs_edge->successor_index != rhs_edge->successor_index &&
+            lhs_edge->target_block_index != rhs_edge->target_block_index) {
+          retained = true;
+          break;
+        }
+      }
+      if (retained) {
+        summary->query_lhs_edges[retained_edge_count++] = candidate_edge;
+      }
+    }
+    candidate_edge_count = retained_edge_count;
+    if (candidate_edge_count == 0) return iree_ok_status();
   }
   *out_proven = true;
   return iree_ok_status();

--- a/loom/src/loom/analysis/control_uniformity.h
+++ b/loom/src/loom/analysis/control_uniformity.h
@@ -83,6 +83,23 @@ iree_status_t loom_control_uniformity_prove_execution(
     loom_value_fact_uniform_scope_t required_scope,
     loom_control_uniformity_failure_t* out_failure, bool* out_proven);
 
+// Proves that every operation in |lhs_ops| and |rhs_ops| executes on distinct
+// alternatives of a common CFG controller whose selector is uniform at
+// |required_scope|. Controllers inside a CFG cycle are rejected because
+// distinct alternatives may execute on different loop iterations. Different
+// regions, structured-only control, and incomplete CFG facts conservatively
+// produce a failed proof.
+//
+// The first query in a CFG region lazily retains its control-dependence edges
+// and cycle membership. Later queries compare those retained summaries without
+// walking IR or recomputing graph structure. Infrastructure failures are
+// returned as status; an ordinary failed proof writes false to |out_proven|.
+iree_status_t loom_control_uniformity_prove_mutually_exclusive_execution(
+    loom_control_uniformity_info_t* info, iree_host_size_t lhs_op_count,
+    const loom_op_t* const* lhs_ops, iree_host_size_t rhs_op_count,
+    const loom_op_t* const* rhs_ops,
+    loom_value_fact_uniform_scope_t required_scope, bool* out_proven);
+
 // Returns the stable diagnostic name for a control source.
 iree_string_view_t loom_control_uniformity_source_name(
     loom_control_uniformity_source_t source);

--- a/loom/src/loom/analysis/control_uniformity_test.cc
+++ b/loom/src/loom/analysis/control_uniformity_test.cc
@@ -1,0 +1,337 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/analysis/control_uniformity.h"
+
+#include <vector>
+
+#include "iree/base/internal/arena.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+#include "loom/format/text/parser.h"
+#include "loom/ir/context.h"
+#include "loom/ir/module.h"
+#include "loom/ops/cfg/ops.h"
+#include "loom/ops/func/ops.h"
+#include "loom/ops/scalar/ops.h"
+#include "loom/ops/test/ops.h"
+#include "loom/testing/module_ptr.h"
+
+namespace loom {
+namespace {
+
+using ModulePtr = ::loom::testing::ModulePtr;
+
+class ControlUniformityTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    iree_arena_block_pool_initialize(4096, iree_allocator_system(),
+                                     &block_pool_);
+    iree_arena_initialize(&block_pool_, &analysis_arena_);
+    loom_context_initialize(iree_allocator_system(), &context_);
+    RegisterDialect(LOOM_DIALECT_CFG, loom_cfg_dialect_vtables);
+    RegisterDialect(LOOM_DIALECT_FUNC, loom_func_dialect_vtables);
+    RegisterDialect(LOOM_DIALECT_SCALAR, loom_scalar_dialect_vtables);
+    RegisterDialect(LOOM_DIALECT_TEST, loom_test_dialect_vtables);
+    IREE_ASSERT_OK(loom_context_finalize(&context_));
+  }
+
+  void TearDown() override {
+    loom_context_deinitialize(&context_);
+    iree_arena_deinitialize(&analysis_arena_);
+    iree_arena_block_pool_deinitialize(&block_pool_);
+  }
+
+  using DialectVtablesFn =
+      const loom_op_vtable_t* const* (*)(iree_host_size_t*);
+
+  void RegisterDialect(uint8_t dialect_id,
+                       DialectVtablesFn dialect_vtables_fn) {
+    iree_host_size_t count = 0;
+    const loom_op_vtable_t* const* vtables = dialect_vtables_fn(&count);
+    IREE_ASSERT_OK(loom_context_register_dialect(&context_, dialect_id, vtables,
+                                                 (uint16_t)count));
+  }
+
+  ModulePtr ParseModule(const char* source) {
+    loom_module_t* module = nullptr;
+    loom_text_parse_options_t options = {};
+    IREE_EXPECT_OK(loom_text_parse(iree_make_cstring_view(source),
+                                   IREE_SV("control_uniformity_test.loom"),
+                                   &context_, &block_pool_, &options, &module));
+    EXPECT_NE(module, nullptr);
+    return ModulePtr(module);
+  }
+
+  loom_func_like_t FindFunction(loom_module_t* module,
+                                iree_string_view_t name) {
+    const loom_string_id_t name_id = loom_module_lookup_string(module, name);
+    IREE_ASSERT(name_id != LOOM_STRING_ID_INVALID);
+    const uint16_t symbol_id = loom_module_find_symbol(module, name_id);
+    IREE_ASSERT(symbol_id != LOOM_SYMBOL_ID_INVALID);
+    loom_func_like_t function = loom_func_like_cast(
+        module, module->symbols.entries[symbol_id].defining_op);
+    IREE_ASSERT(function.op != nullptr);
+    return function;
+  }
+
+  std::vector<const loom_op_t*> FindUses(loom_func_like_t function) {
+    std::vector<const loom_op_t*> uses;
+    loom_region_t* body = loom_func_like_body(function);
+    loom_block_t* block = nullptr;
+    loom_region_for_each_block(body, block) {
+      loom_op_t* op = nullptr;
+      loom_block_for_each_op(block, op) {
+        if (loom_test_use_isa(op)) uses.push_back(op);
+      }
+    }
+    return uses;
+  }
+
+  void DefineArgumentScope(loom_value_fact_table_t* fact_table,
+                           loom_func_like_t function, uint16_t argument_ordinal,
+                           loom_value_fact_uniform_scope_t scope) {
+    uint16_t argument_count = 0;
+    const loom_value_id_t* arguments =
+        loom_func_like_arg_ids(function, &argument_count);
+    ASSERT_LT(argument_ordinal, argument_count);
+    loom_value_facts_t facts = loom_value_facts_make(0, 1, 1);
+    loom_value_facts_mark_uniform_at_scope(&facts, scope);
+    IREE_ASSERT_OK(loom_value_fact_table_define(
+        fact_table, arguments[argument_ordinal], facts));
+  }
+
+  bool ProveMutuallyExclusive(loom_control_uniformity_info_t* info,
+                              const std::vector<const loom_op_t*>& uses,
+                              iree_host_size_t lhs_ordinal,
+                              iree_host_size_t rhs_ordinal,
+                              loom_value_fact_uniform_scope_t required_scope) {
+    EXPECT_LT(lhs_ordinal, uses.size());
+    EXPECT_LT(rhs_ordinal, uses.size());
+    const loom_op_t* lhs_ops[] = {uses[lhs_ordinal]};
+    const loom_op_t* rhs_ops[] = {uses[rhs_ordinal]};
+    bool proven = false;
+    IREE_EXPECT_OK(loom_control_uniformity_prove_mutually_exclusive_execution(
+        info, IREE_ARRAYSIZE(lhs_ops), lhs_ops, IREE_ARRAYSIZE(rhs_ops),
+        rhs_ops, required_scope, &proven));
+    return proven;
+  }
+
+  bool ProveOperationSetsMutuallyExclusive(
+      loom_control_uniformity_info_t* info,
+      const std::vector<const loom_op_t*>& lhs_ops,
+      const std::vector<const loom_op_t*>& rhs_ops,
+      loom_value_fact_uniform_scope_t required_scope) {
+    bool proven = false;
+    IREE_EXPECT_OK(loom_control_uniformity_prove_mutually_exclusive_execution(
+        info, lhs_ops.size(), lhs_ops.data(), rhs_ops.size(), rhs_ops.data(),
+        required_scope, &proven));
+    return proven;
+  }
+
+  iree_arena_block_pool_t block_pool_;
+  iree_arena_allocator_t analysis_arena_;
+  loom_context_t context_;
+};
+
+TEST_F(ControlUniformityTest, ProvesDirectAlternativesAtSelectorScope) {
+  ModulePtr module = ParseModule(R"(
+func.def @direct(%condition: i1, %lhs: i32, %rhs: i32) {
+  cfg.cond_br %condition, ^left, ^right
+^left:
+  test.use %lhs : i32
+  cfg.br ^done
+^right:
+  test.use %rhs : i32
+  cfg.br ^done
+^done:
+  func.return
+}
+)");
+  IREE_ASSERT_OK(loom_module_compute_uses(module.get()));
+  loom_func_like_t function = FindFunction(module.get(), IREE_SV("direct"));
+  const std::vector<const loom_op_t*> uses = FindUses(function);
+  ASSERT_EQ(uses.size(), 2u);
+
+  loom_value_fact_table_t fact_table;
+  IREE_ASSERT_OK(
+      loom_value_fact_table_initialize(&fact_table, &analysis_arena_, 8));
+  DefineArgumentScope(&fact_table, function, 0,
+                      LOOM_VALUE_FACT_UNIFORM_SCOPE_SUBGROUP);
+  IREE_ASSERT_OK(
+      loom_value_fact_table_compute(&fact_table, module.get(), function));
+  loom_control_uniformity_info_t info;
+  loom_control_uniformity_info_initialize(module.get(), &fact_table,
+                                          &analysis_arena_, &info);
+  EXPECT_TRUE(ProveMutuallyExclusive(&info, uses, 0, 1,
+                                     LOOM_VALUE_FACT_UNIFORM_SCOPE_SUBGROUP));
+  EXPECT_FALSE(ProveMutuallyExclusive(&info, uses, 0, 1,
+                                      LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP));
+}
+
+TEST_F(ControlUniformityTest, ProvesInheritedNestedAlternatives) {
+  ModulePtr module = ParseModule(R"(
+func.def @nested(%outer: i1, %inner: i1, %a: i32, %b: i32, %c: i32) {
+  cfg.cond_br %outer, ^first, ^not_first
+^first:
+  test.use %a : i32
+  cfg.br ^done
+^not_first:
+  cfg.cond_br %inner, ^second, ^third
+^second:
+  test.use %b : i32
+  cfg.br ^done
+^third:
+  test.use %c : i32
+  cfg.br ^done
+^done:
+  func.return
+}
+)");
+  IREE_ASSERT_OK(loom_module_compute_uses(module.get()));
+  loom_func_like_t function = FindFunction(module.get(), IREE_SV("nested"));
+  const std::vector<const loom_op_t*> uses = FindUses(function);
+  ASSERT_EQ(uses.size(), 3u);
+
+  loom_value_fact_table_t fact_table;
+  IREE_ASSERT_OK(
+      loom_value_fact_table_initialize(&fact_table, &analysis_arena_, 8));
+  DefineArgumentScope(&fact_table, function, 0,
+                      LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP);
+  DefineArgumentScope(&fact_table, function, 1,
+                      LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP);
+  IREE_ASSERT_OK(
+      loom_value_fact_table_compute(&fact_table, module.get(), function));
+  loom_control_uniformity_info_t info;
+  loom_control_uniformity_info_initialize(module.get(), &fact_table,
+                                          &analysis_arena_, &info);
+  EXPECT_TRUE(ProveMutuallyExclusive(&info, uses, 0, 1,
+                                     LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP));
+  EXPECT_TRUE(ProveMutuallyExclusive(&info, uses, 0, 2,
+                                     LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP));
+  EXPECT_TRUE(ProveMutuallyExclusive(&info, uses, 1, 2,
+                                     LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP));
+}
+
+TEST_F(ControlUniformityTest, ProvesCompleteFootprintsInsideAlternatives) {
+  ModulePtr module = ParseModule(R"(
+func.def @footprints(%outer: i1, %continue: i1, %lhs: i32, %rhs: i32, %joined: i32) {
+  cfg.cond_br %outer, ^left, ^right
+^left:
+  test.use %lhs : i32
+  cfg.br ^left_loop
+^left_loop:
+  test.use %lhs : i32
+  cfg.cond_br %continue, ^left_loop, ^left_done
+^left_done:
+  cfg.br ^done
+^right:
+  test.use %rhs : i32
+  cfg.br ^right_loop
+^right_loop:
+  test.use %rhs : i32
+  cfg.cond_br %continue, ^right_loop, ^right_done
+^right_done:
+  cfg.br ^done
+^done:
+  test.use %joined : i32
+  func.return
+}
+)");
+  IREE_ASSERT_OK(loom_module_compute_uses(module.get()));
+  loom_func_like_t function = FindFunction(module.get(), IREE_SV("footprints"));
+  const std::vector<const loom_op_t*> uses = FindUses(function);
+  ASSERT_EQ(uses.size(), 5u);
+
+  loom_value_fact_table_t fact_table;
+  IREE_ASSERT_OK(
+      loom_value_fact_table_initialize(&fact_table, &analysis_arena_, 8));
+  DefineArgumentScope(&fact_table, function, 0,
+                      LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP);
+  IREE_ASSERT_OK(
+      loom_value_fact_table_compute(&fact_table, module.get(), function));
+  loom_control_uniformity_info_t info;
+  loom_control_uniformity_info_initialize(module.get(), &fact_table,
+                                          &analysis_arena_, &info);
+
+  const std::vector<const loom_op_t*> lhs_ops = {uses[0], uses[1]};
+  const std::vector<const loom_op_t*> rhs_ops = {uses[2], uses[3]};
+  EXPECT_TRUE(ProveOperationSetsMutuallyExclusive(
+      &info, lhs_ops, rhs_ops, LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP));
+
+  const std::vector<const loom_op_t*> lhs_join_live_ops = {uses[0], uses[1],
+                                                           uses[4]};
+  EXPECT_FALSE(ProveOperationSetsMutuallyExclusive(
+      &info, lhs_join_live_ops, rhs_ops,
+      LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP));
+}
+
+TEST_F(ControlUniformityTest, RejectsAlternativesControlledInsideCycle) {
+  ModulePtr module = ParseModule(R"(
+func.def @cyclic(%continue: i1, %condition: i1, %lhs: i32, %rhs: i32) {
+  cfg.br ^loop
+^loop:
+  cfg.cond_br %continue, ^body, ^done
+^body:
+  cfg.cond_br %condition, ^left, ^right
+^left:
+  test.use %lhs : i32
+  cfg.br ^loop
+^right:
+  test.use %rhs : i32
+  cfg.br ^loop
+^done:
+  func.return
+}
+)");
+  IREE_ASSERT_OK(loom_module_compute_uses(module.get()));
+  loom_func_like_t function = FindFunction(module.get(), IREE_SV("cyclic"));
+  const std::vector<const loom_op_t*> uses = FindUses(function);
+  ASSERT_EQ(uses.size(), 2u);
+
+  loom_value_fact_table_t fact_table;
+  IREE_ASSERT_OK(
+      loom_value_fact_table_initialize(&fact_table, &analysis_arena_, 8));
+  DefineArgumentScope(&fact_table, function, 0,
+                      LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP);
+  DefineArgumentScope(&fact_table, function, 1,
+                      LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP);
+  IREE_ASSERT_OK(
+      loom_value_fact_table_compute(&fact_table, module.get(), function));
+  loom_control_uniformity_info_t info;
+  loom_control_uniformity_info_initialize(module.get(), &fact_table,
+                                          &analysis_arena_, &info);
+  EXPECT_FALSE(ProveMutuallyExclusive(&info, uses, 0, 1,
+                                      LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP));
+}
+
+TEST_F(ControlUniformityTest, SamePathOperationsAreNotAlternatives) {
+  ModulePtr module = ParseModule(R"(
+func.def @linear(%lhs: i32, %rhs: i32) {
+  test.use %lhs : i32
+  test.use %rhs : i32
+  func.return
+}
+)");
+  IREE_ASSERT_OK(loom_module_compute_uses(module.get()));
+  loom_func_like_t function = FindFunction(module.get(), IREE_SV("linear"));
+  const std::vector<const loom_op_t*> uses = FindUses(function);
+  ASSERT_EQ(uses.size(), 2u);
+
+  loom_value_fact_table_t fact_table;
+  IREE_ASSERT_OK(
+      loom_value_fact_table_initialize(&fact_table, &analysis_arena_, 8));
+  IREE_ASSERT_OK(
+      loom_value_fact_table_compute(&fact_table, module.get(), function));
+  loom_control_uniformity_info_t info;
+  loom_control_uniformity_info_initialize(module.get(), &fact_table,
+                                          &analysis_arena_, &info);
+  EXPECT_FALSE(ProveMutuallyExclusive(&info, uses, 0, 1,
+                                      LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP));
+}
+
+}  // namespace
+}  // namespace loom

--- a/loom/src/loom/analysis/symbolic_expr.c
+++ b/loom/src/loom/analysis/symbolic_expr.c
@@ -33,6 +33,8 @@ enum loom_symbolic_expr_memo_state_e {
 #define LOOM_SYMBOLIC_EXPR_SELECT_CASE_CONDITION_LIMIT 8
 #define LOOM_SYMBOLIC_EXPR_SELECT_CASE_DEPTH_LIMIT 2
 #define LOOM_SYMBOLIC_EXPR_SELECT_DEPENDENCY_SEARCH_LIMIT 64
+#define LOOM_SYMBOLIC_EXPR_SEMANTIC_MATCH_DEPTH_LIMIT 16
+#define LOOM_SYMBOLIC_EXPR_SEMANTIC_MATCH_PAIR_LIMIT 64
 
 struct loom_symbolic_expr_memo_entry_t {
   // Current memo state for this value ID.
@@ -2027,6 +2029,74 @@ static bool loom_symbolic_expr_value_is_integer_domain(
          loom_scalar_type_is_integer(scalar_type);
 }
 
+static loom_value_id_t loom_symbolic_expr_assumption_source_value(
+    const loom_symbolic_expr_context_t* context, loom_value_id_t value_id) {
+  if (!context->module) return value_id;
+  uint8_t remaining_steps = LOOM_SYMBOLIC_EXPR_IDENTITY_CHAIN_LIMIT;
+  while (remaining_steps-- > 0) {
+    loom_symbolic_expr_identity_chain_step_t step = {0};
+    if (!loom_symbolic_expr_identity_chain_step(context, value_id,
+                                                /*flags=*/0, &step)) {
+      return value_id;
+    }
+    value_id = step.next_value;
+  }
+  return value_id;
+}
+
+static bool loom_symbolic_expr_ops_can_structurally_match(
+    const loom_module_t* module, const loom_op_t* left_op,
+    const loom_op_t* right_op, uint16_t left_result_index,
+    uint16_t right_result_index) {
+  if (!left_op || !right_op || left_op->kind != right_op->kind ||
+      left_result_index != right_result_index ||
+      left_op->operand_count != right_op->operand_count ||
+      left_op->result_count != right_op->result_count ||
+      left_op->attribute_count != right_op->attribute_count ||
+      left_op->instance_flags != right_op->instance_flags ||
+      left_op->region_count != 0 || right_op->region_count != 0 ||
+      left_op->tied_result_count != 0 || right_op->tied_result_count != 0) {
+    return false;
+  }
+
+  const loom_trait_flags_t prohibited_traits =
+      LOOM_TRAIT_NON_DETERMINISTIC | LOOM_TRAIT_UNKNOWN_EFFECTS |
+      LOOM_TRAIT_UNIQUE_IDENTITY | LOOM_TRAIT_CONVERGENT |
+      LOOM_TRAIT_READS_MEMORY | LOOM_TRAIT_WRITES_MEMORY |
+      LOOM_TRAIT_MEMORY_FENCE;
+  const loom_trait_flags_t left_traits =
+      loom_op_effective_traits(module, left_op);
+  const loom_trait_flags_t right_traits =
+      loom_op_effective_traits(module, right_op);
+  if (!iree_all_bits_set(left_traits, LOOM_TRAIT_PURE) ||
+      !iree_all_bits_set(right_traits, LOOM_TRAIT_PURE) ||
+      iree_any_bit_set(left_traits | right_traits, prohibited_traits)) {
+    return false;
+  }
+
+  const loom_op_vtable_t* vtable = loom_op_vtable(module, left_op);
+  const uint8_t operand_segment_count =
+      loom_op_vtable_operand_segment_count(vtable);
+  if (operand_segment_count != 0 &&
+      memcmp(loom_op_const_operand_segment_counts(left_op),
+             loom_op_const_operand_segment_counts(right_op),
+             (iree_host_size_t)operand_segment_count * sizeof(uint16_t)) != 0) {
+    return false;
+  }
+  const loom_attribute_t* left_attrs = loom_op_const_attrs(left_op);
+  const loom_attribute_t* right_attrs = loom_op_const_attrs(right_op);
+  for (uint8_t i = 0; i < left_op->attribute_count; ++i) {
+    if (!loom_attribute_equal(&left_attrs[i], &right_attrs[i])) return false;
+  }
+
+  const loom_value_id_t left_result =
+      loom_op_const_results(left_op)[left_result_index];
+  const loom_value_id_t right_result =
+      loom_op_const_results(right_op)[right_result_index];
+  return loom_type_equal(loom_module_value_type(module, left_result),
+                         loom_module_value_type(module, right_result));
+}
+
 static iree_status_t loom_symbolic_expr_values_match(
     loom_symbolic_expr_context_t* context, loom_value_id_t left_value,
     loom_value_id_t right_value, bool* out_match) {
@@ -2055,6 +2125,69 @@ static iree_status_t loom_symbolic_expr_values_match(
   return iree_ok_status();
 }
 
+// Compares values produced by equivalent deterministic expression trees. This
+// is a bounded fallback for opaque terms in branch-relation proofs: CSE must
+// not move materializations across a convergent barrier, but their pure value
+// semantics remain equivalent.
+static iree_status_t loom_symbolic_expr_values_semantically_match_bounded(
+    loom_symbolic_expr_context_t* context, loom_value_id_t left_value,
+    loom_value_id_t right_value, uint8_t remaining_depth,
+    uint16_t* remaining_pair_count, bool* out_match) {
+  IREE_RETURN_IF_ERROR(loom_symbolic_expr_values_match(context, left_value,
+                                                       right_value, out_match));
+  if (*out_match || remaining_depth == 0 || *remaining_pair_count == 0) {
+    return iree_ok_status();
+  }
+
+  left_value = loom_symbolic_expr_assumption_source_value(context, left_value);
+  right_value =
+      loom_symbolic_expr_assumption_source_value(context, right_value);
+  if (left_value == right_value) {
+    *out_match = true;
+    return iree_ok_status();
+  }
+  if (!context->module || left_value >= context->module->values.count ||
+      right_value >= context->module->values.count) {
+    return iree_ok_status();
+  }
+
+  const loom_value_t* left = loom_module_value(context->module, left_value);
+  const loom_value_t* right = loom_module_value(context->module, right_value);
+  if (loom_value_is_block_arg(left) || loom_value_is_block_arg(right)) {
+    return iree_ok_status();
+  }
+  const loom_op_t* left_op = loom_value_def_op(left);
+  const loom_op_t* right_op = loom_value_def_op(right);
+  if (!loom_symbolic_expr_ops_can_structurally_match(
+          context->module, left_op, right_op, loom_value_def_index(left),
+          loom_value_def_index(right))) {
+    return iree_ok_status();
+  }
+
+  --*remaining_pair_count;
+  const loom_value_id_t* left_operands = loom_op_const_operands(left_op);
+  const loom_value_id_t* right_operands = loom_op_const_operands(right_op);
+  for (uint16_t i = 0; i < left_op->operand_count; ++i) {
+    bool operands_match = false;
+    IREE_RETURN_IF_ERROR(loom_symbolic_expr_values_semantically_match_bounded(
+        context, left_operands[i], right_operands[i], remaining_depth - 1,
+        remaining_pair_count, &operands_match));
+    if (!operands_match) return iree_ok_status();
+  }
+  *out_match = true;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_symbolic_expr_values_semantically_match(
+    loom_symbolic_expr_context_t* context, loom_value_id_t left_value,
+    loom_value_id_t right_value, bool* out_match) {
+  uint16_t remaining_pair_count = LOOM_SYMBOLIC_EXPR_SEMANTIC_MATCH_PAIR_LIMIT;
+  return loom_symbolic_expr_values_semantically_match_bounded(
+      context, left_value, right_value,
+      LOOM_SYMBOLIC_EXPR_SEMANTIC_MATCH_DEPTH_LIMIT, &remaining_pair_count,
+      out_match);
+}
+
 static iree_status_t loom_symbolic_expr_value_matches_constant(
     loom_symbolic_expr_context_t* context, loom_value_id_t value,
     int64_t constant, bool* out_match) {
@@ -2067,21 +2200,6 @@ static iree_status_t loom_symbolic_expr_value_matches_constant(
       loom_symbolic_expr_constant_value(&expression, &expression_constant) &&
       expression_constant == constant;
   return iree_ok_status();
-}
-
-static loom_value_id_t loom_symbolic_expr_assumption_source_value(
-    const loom_symbolic_expr_context_t* context, loom_value_id_t value_id) {
-  if (!context->module) return value_id;
-  uint8_t remaining_steps = LOOM_SYMBOLIC_EXPR_IDENTITY_CHAIN_LIMIT;
-  while (remaining_steps-- > 0) {
-    loom_symbolic_expr_identity_chain_step_t step = {0};
-    if (!loom_symbolic_expr_identity_chain_step(context, value_id,
-                                                /*flags=*/0, &step)) {
-      return value_id;
-    }
-    value_id = step.next_value;
-  }
-  return value_id;
 }
 
 typedef enum loom_symbolic_kernel_bound_kind_e {
@@ -3014,7 +3132,14 @@ static bool loom_symbolic_expr_condition_relation_upper_bound(
   }
 }
 
-static bool loom_symbolic_expr_terms_are_positive_multiple(
+static loom_value_id_t loom_symbolic_expr_term_relation_value(
+    const loom_symbolic_term_t* term) {
+  return term->relation_value_id == LOOM_VALUE_ID_INVALID
+             ? term->value_id
+             : term->relation_value_id;
+}
+
+static bool loom_symbolic_expr_terms_are_exact_positive_multiple(
     const loom_symbolic_term_t* expression_terms,
     iree_host_size_t expression_term_count,
     const loom_symbolic_term_t* relation_terms,
@@ -3027,7 +3152,7 @@ static bool loom_symbolic_expr_terms_are_positive_multiple(
        relation_terms[0].coefficient == -1)) {
     return false;
   }
-  int64_t multiplier =
+  const int64_t multiplier =
       expression_terms[0].coefficient / relation_terms[0].coefficient;
   if (multiplier <= 0 ||
       expression_terms[0].coefficient % relation_terms[0].coefficient != 0) {
@@ -3044,6 +3169,85 @@ static bool loom_symbolic_expr_terms_are_positive_multiple(
   }
   *out_multiplier = multiplier;
   return true;
+}
+
+static iree_status_t loom_symbolic_expr_terms_are_positive_multiple(
+    loom_symbolic_expr_context_t* context,
+    const loom_symbolic_term_t* expression_terms,
+    iree_host_size_t expression_term_count,
+    const loom_symbolic_term_t* relation_terms,
+    iree_host_size_t relation_term_count, bool* out_match,
+    int64_t* out_multiplier) {
+  *out_match = false;
+  *out_multiplier = 0;
+  if (loom_symbolic_expr_terms_are_exact_positive_multiple(
+          expression_terms, expression_term_count, relation_terms,
+          relation_term_count, out_multiplier)) {
+    *out_match = true;
+    return iree_ok_status();
+  }
+  if (expression_term_count == 0 ||
+      expression_term_count != relation_term_count ||
+      expression_term_count > LOOM_SYMBOLIC_EXPR_DEFAULT_TERM_LIMIT) {
+    return iree_ok_status();
+  }
+
+  bool matched_relation_terms[LOOM_SYMBOLIC_EXPR_DEFAULT_TERM_LIMIT] = {false};
+  int64_t multiplier = 0;
+  for (iree_host_size_t expression_index = 0;
+       expression_index < expression_term_count; ++expression_index) {
+    bool term_matched = false;
+    for (iree_host_size_t relation_index = 0;
+         relation_index < relation_term_count; ++relation_index) {
+      if (matched_relation_terms[relation_index] ||
+          relation_terms[relation_index].coefficient == 0) {
+        continue;
+      }
+
+      int64_t candidate_multiplier = multiplier;
+      if (candidate_multiplier == 0) {
+        if (expression_terms[expression_index].coefficient == INT64_MIN &&
+            relation_terms[relation_index].coefficient == -1) {
+          continue;
+        }
+        candidate_multiplier = expression_terms[expression_index].coefficient /
+                               relation_terms[relation_index].coefficient;
+        if (candidate_multiplier <= 0 ||
+            expression_terms[expression_index].coefficient %
+                    relation_terms[relation_index].coefficient !=
+                0) {
+          continue;
+        }
+      }
+      int64_t scaled_coefficient = 0;
+      if (!iree_checked_mul_i64(relation_terms[relation_index].coefficient,
+                                candidate_multiplier, &scaled_coefficient) ||
+          expression_terms[expression_index].coefficient !=
+              scaled_coefficient) {
+        continue;
+      }
+
+      bool values_match = false;
+      IREE_RETURN_IF_ERROR(loom_symbolic_expr_values_semantically_match(
+          context,
+          loom_symbolic_expr_term_relation_value(
+              &expression_terms[expression_index]),
+          loom_symbolic_expr_term_relation_value(
+              &relation_terms[relation_index]),
+          &values_match));
+      if (!values_match) continue;
+
+      multiplier = candidate_multiplier;
+      matched_relation_terms[relation_index] = true;
+      term_matched = true;
+      break;
+    }
+    if (!term_matched) return iree_ok_status();
+  }
+
+  *out_match = true;
+  *out_multiplier = multiplier;
+  return iree_ok_status();
 }
 
 // Matches an expanded query against an active edge relation. For integral
@@ -3102,11 +3306,16 @@ static iree_status_t loom_symbolic_expr_prove_le_by_condition_relations(
         relation_term_count > LOOM_SYMBOLIC_EXPR_DEFAULT_TERM_LIMIT) {
       continue;
     }
+    loom_symbolic_term_t relation_terms[LOOM_SYMBOLIC_EXPR_DEFAULT_TERM_LIMIT];
+    memcpy(relation_terms, context->scratch_terms,
+           relation_term_count * sizeof(*relation_terms));
 
+    bool terms_match = false;
     int64_t multiplier = 0;
-    if (!loom_symbolic_expr_terms_are_positive_multiple(
-            expression_terms, expression_term_count, context->scratch_terms,
-            relation_term_count, &multiplier)) {
+    IREE_RETURN_IF_ERROR(loom_symbolic_expr_terms_are_positive_multiple(
+        context, expression_terms, expression_term_count, relation_terms,
+        relation_term_count, &terms_match, &multiplier));
+    if (!terms_match) {
       continue;
     }
     int64_t scaled_relation_constant = 0;

--- a/loom/src/loom/analysis/symbolic_expr.c
+++ b/loom/src/loom/analysis/symbolic_expr.c
@@ -2274,19 +2274,26 @@ static bool loom_symbolic_expr_multiply_def(const loom_op_t* op,
   return false;
 }
 
+static bool loom_symbolic_expr_value_product_factors(
+    loom_symbolic_expr_context_t* context, loom_value_id_t product_value,
+    loom_value_id_t* out_lhs, loom_value_id_t* out_rhs) {
+  loom_value_id_t product_source =
+      loom_symbolic_expr_assumption_source_value(context, product_value);
+  const loom_op_t* product_op =
+      loom_symbolic_expr_value_defining_op(context, product_source);
+  return product_op &&
+         loom_symbolic_expr_multiply_def(product_op, out_lhs, out_rhs);
+}
+
 static iree_status_t loom_symbolic_expr_value_matches_product(
     loom_symbolic_expr_context_t* context, loom_value_id_t product_value,
     loom_value_id_t left_factor, loom_value_id_t right_factor,
     bool* out_match) {
   *out_match = false;
-  loom_value_id_t product_source =
-      loom_symbolic_expr_assumption_source_value(context, product_value);
-  const loom_op_t* product_op =
-      loom_symbolic_expr_value_defining_op(context, product_source);
   loom_value_id_t product_lhs = LOOM_VALUE_ID_INVALID;
   loom_value_id_t product_rhs = LOOM_VALUE_ID_INVALID;
-  if (!product_op || !loom_symbolic_expr_multiply_def(product_op, &product_lhs,
-                                                      &product_rhs)) {
+  if (!loom_symbolic_expr_value_product_factors(context, product_value,
+                                                &product_lhs, &product_rhs)) {
     return iree_ok_status();
   }
 
@@ -2964,6 +2971,336 @@ static iree_status_t loom_symbolic_expr_prove_direct_value_relation(
   return iree_ok_status();
 }
 
+static iree_status_t loom_symbolic_expr_condition_operand_expression(
+    loom_symbolic_expr_context_t* context,
+    loom_condition_integer_operand_t operand,
+    loom_symbolic_expr_t* out_expression) {
+  if (operand.kind == LOOM_CONDITION_INTEGER_OPERAND_CONSTANT) {
+    loom_symbolic_expr_constant(operand.constant, out_expression);
+    return iree_ok_status();
+  }
+  return loom_symbolic_expr_from_value(context, operand.value_id,
+                                       out_expression);
+}
+
+static bool loom_symbolic_expr_condition_relation_upper_bound(
+    const loom_condition_integer_relation_t* relation,
+    loom_condition_integer_operand_t* out_lower,
+    loom_condition_integer_operand_t* out_upper, bool* out_strict) {
+  switch (relation->relation) {
+    case LOOM_SYMBOLIC_INTEGER_RELATION_EQ:
+    case LOOM_SYMBOLIC_INTEGER_RELATION_LE:
+      *out_lower = relation->left;
+      *out_upper = relation->right;
+      *out_strict = false;
+      return true;
+    case LOOM_SYMBOLIC_INTEGER_RELATION_LT:
+      *out_lower = relation->left;
+      *out_upper = relation->right;
+      *out_strict = true;
+      return true;
+    case LOOM_SYMBOLIC_INTEGER_RELATION_GE:
+      *out_lower = relation->right;
+      *out_upper = relation->left;
+      *out_strict = false;
+      return true;
+    case LOOM_SYMBOLIC_INTEGER_RELATION_GT:
+      *out_lower = relation->right;
+      *out_upper = relation->left;
+      *out_strict = true;
+      return true;
+    default:
+      return false;
+  }
+}
+
+static bool loom_symbolic_expr_terms_are_positive_multiple(
+    const loom_symbolic_term_t* expression_terms,
+    iree_host_size_t expression_term_count,
+    const loom_symbolic_term_t* relation_terms,
+    iree_host_size_t relation_term_count, int64_t* out_multiplier) {
+  *out_multiplier = 0;
+  if (expression_term_count == 0 ||
+      expression_term_count != relation_term_count ||
+      relation_terms[0].coefficient == 0 ||
+      (expression_terms[0].coefficient == INT64_MIN &&
+       relation_terms[0].coefficient == -1)) {
+    return false;
+  }
+  int64_t multiplier =
+      expression_terms[0].coefficient / relation_terms[0].coefficient;
+  if (multiplier <= 0 ||
+      expression_terms[0].coefficient % relation_terms[0].coefficient != 0) {
+    return false;
+  }
+  for (iree_host_size_t i = 0; i < expression_term_count; ++i) {
+    int64_t scaled_coefficient = 0;
+    if (expression_terms[i].value_id != relation_terms[i].value_id ||
+        !iree_checked_mul_i64(relation_terms[i].coefficient, multiplier,
+                              &scaled_coefficient) ||
+        expression_terms[i].coefficient != scaled_coefficient) {
+      return false;
+    }
+  }
+  *out_multiplier = multiplier;
+  return true;
+}
+
+// Matches an expanded query against an active edge relation. For integral
+// values, scale * lower + residual <= scale * upper follows from lower < upper
+// when residual <= scale, or from lower <= upper when residual <= 0.
+static iree_status_t loom_symbolic_expr_prove_le_by_condition_relations(
+    loom_symbolic_expr_context_t* context,
+    const loom_symbolic_expr_t* left_expression,
+    const loom_symbolic_expr_t* right_expression,
+    loom_symbolic_proof_result_t* out_result) {
+  *out_result = LOOM_SYMBOLIC_PROOF_UNKNOWN;
+  if (!context->condition_facts ||
+      context->condition_facts->integer_relation_count == 0) {
+    return iree_ok_status();
+  }
+
+  int64_t expression_constant = 0;
+  iree_host_size_t expression_term_count = 0;
+  bool expression_linear = false;
+  IREE_RETURN_IF_ERROR(loom_symbolic_expr_normalize_difference_into_scratch(
+      context, left_expression, right_expression, &expression_constant,
+      &expression_term_count, &expression_linear));
+  if (!expression_linear || expression_term_count == 0 ||
+      expression_term_count > LOOM_SYMBOLIC_EXPR_DEFAULT_TERM_LIMIT) {
+    return iree_ok_status();
+  }
+  loom_symbolic_term_t expression_terms[LOOM_SYMBOLIC_EXPR_DEFAULT_TERM_LIMIT];
+  memcpy(expression_terms, context->scratch_terms,
+         expression_term_count * sizeof(*expression_terms));
+
+  for (iree_host_size_t i = 0;
+       i < context->condition_facts->integer_relation_count; ++i) {
+    const loom_condition_integer_relation_t* relation =
+        &context->condition_facts->integer_relations[i];
+    loom_condition_integer_operand_t lower_operand = {0};
+    loom_condition_integer_operand_t upper_operand = {0};
+    bool strict = false;
+    if (!loom_symbolic_expr_condition_relation_upper_bound(
+            relation, &lower_operand, &upper_operand, &strict)) {
+      continue;
+    }
+
+    loom_symbolic_expr_t lower_expression = {0};
+    loom_symbolic_expr_t upper_expression = {0};
+    IREE_RETURN_IF_ERROR(loom_symbolic_expr_condition_operand_expression(
+        context, lower_operand, &lower_expression));
+    IREE_RETURN_IF_ERROR(loom_symbolic_expr_condition_operand_expression(
+        context, upper_operand, &upper_expression));
+    int64_t relation_constant = 0;
+    iree_host_size_t relation_term_count = 0;
+    bool relation_linear = false;
+    IREE_RETURN_IF_ERROR(loom_symbolic_expr_normalize_difference_into_scratch(
+        context, &lower_expression, &upper_expression, &relation_constant,
+        &relation_term_count, &relation_linear));
+    if (!relation_linear ||
+        relation_term_count > LOOM_SYMBOLIC_EXPR_DEFAULT_TERM_LIMIT) {
+      continue;
+    }
+
+    int64_t multiplier = 0;
+    if (!loom_symbolic_expr_terms_are_positive_multiple(
+            expression_terms, expression_term_count, context->scratch_terms,
+            relation_term_count, &multiplier)) {
+      continue;
+    }
+    int64_t scaled_relation_constant = 0;
+    int64_t residual_constant = 0;
+    if (!iree_checked_mul_i64(relation_constant, multiplier,
+                              &scaled_relation_constant) ||
+        !iree_checked_sub_i64(expression_constant, scaled_relation_constant,
+                              &residual_constant)) {
+      continue;
+    }
+    if (residual_constant <= (strict ? multiplier : 0)) {
+      *out_result = LOOM_SYMBOLIC_PROOF_TRUE;
+      return iree_ok_status();
+    }
+  }
+  return iree_ok_status();
+}
+
+static bool loom_symbolic_expr_scale_linear_view(
+    const loom_symbolic_expr_t* expression, int64_t multiplier,
+    loom_symbolic_term_t* term_storage, iree_host_size_t term_storage_capacity,
+    loom_symbolic_expr_t* out_expression) {
+  if (!loom_symbolic_expr_is_linear(expression) || multiplier <= 0 ||
+      expression->term_count > term_storage_capacity) {
+    return false;
+  }
+
+  int64_t constant = 0;
+  if (!iree_checked_mul_i64(expression->constant, multiplier, &constant)) {
+    return false;
+  }
+  for (iree_host_size_t i = 0; i < expression->term_count; ++i) {
+    int64_t coefficient = 0;
+    if (!iree_checked_mul_i64(expression->terms[i].coefficient, multiplier,
+                              &coefficient)) {
+      return false;
+    }
+    term_storage[i] = expression->terms[i];
+    term_storage[i].coefficient = coefficient;
+  }
+
+  loom_value_facts_t multiplier_facts = loom_value_facts_exact_i64(multiplier);
+  loom_value_facts_t facts = loom_value_facts_unknown();
+  loom_value_facts_muli(&expression->facts, &multiplier_facts, &facts);
+  *out_expression = (loom_symbolic_expr_t){
+      .constant = constant,
+      .terms = expression->term_count == 0 ? NULL : term_storage,
+      .term_count = expression->term_count,
+      .facts = facts,
+      .flags = LOOM_SYMBOLIC_EXPR_FLAG_LINEAR,
+  };
+  return true;
+}
+
+static void loom_symbolic_expr_residual_excluding_pair(
+    int64_t constant, const loom_symbolic_term_t* terms,
+    iree_host_size_t term_count, iree_host_size_t first_index,
+    iree_host_size_t second_index, loom_symbolic_term_t* term_storage,
+    loom_symbolic_expr_t* out_expression) {
+  iree_host_size_t residual_count = 0;
+  for (iree_host_size_t i = 0; i < term_count; ++i) {
+    if (i == first_index || i == second_index) continue;
+    term_storage[residual_count++] = terms[i];
+  }
+  *out_expression = (loom_symbolic_expr_t){
+      .constant = constant,
+      .terms = residual_count == 0 ? NULL : term_storage,
+      .term_count = residual_count,
+      .facts = loom_value_facts_unknown(),
+      .flags = LOOM_SYMBOLIC_EXPR_FLAG_LINEAR,
+  };
+}
+
+static iree_status_t loom_symbolic_expr_try_common_product_factor(
+    loom_symbolic_expr_context_t* context, loom_value_id_t common_factor,
+    loom_value_id_t positive_relation_value,
+    loom_value_id_t negative_relation_value, int64_t coefficient,
+    const loom_symbolic_expr_t* residual,
+    loom_symbolic_proof_result_t* out_result) {
+  if (!loom_symbolic_expr_value_facts_are_non_negative(context,
+                                                       common_factor)) {
+    return iree_ok_status();
+  }
+
+  loom_symbolic_proof_result_t relation = LOOM_SYMBOLIC_PROOF_UNKNOWN;
+  IREE_RETURN_IF_ERROR(loom_symbolic_expr_prove_direct_value_relation(
+      context, LOOM_SYMBOLIC_INTEGER_RELATION_LT, positive_relation_value,
+      negative_relation_value, &relation));
+  if (relation == LOOM_SYMBOLIC_PROOF_TRUE) {
+    loom_symbolic_expr_t factor = {0};
+    IREE_RETURN_IF_ERROR(
+        loom_symbolic_expr_from_value(context, common_factor, &factor));
+    loom_symbolic_term_t
+        scaled_factor_terms[LOOM_SYMBOLIC_EXPR_DEFAULT_TERM_LIMIT];
+    loom_symbolic_expr_t scaled_factor = {0};
+    if (loom_symbolic_expr_scale_linear_view(
+            &factor, coefficient, scaled_factor_terms,
+            IREE_ARRAYSIZE(scaled_factor_terms), &scaled_factor)) {
+      loom_symbolic_proof_result_t residual_proof = LOOM_SYMBOLIC_PROOF_UNKNOWN;
+      IREE_RETURN_IF_ERROR(loom_symbolic_expr_prove_le(
+          context, residual, &scaled_factor, &residual_proof));
+      if (residual_proof == LOOM_SYMBOLIC_PROOF_TRUE) {
+        *out_result = LOOM_SYMBOLIC_PROOF_TRUE;
+        return iree_ok_status();
+      }
+    }
+  }
+
+  relation = LOOM_SYMBOLIC_PROOF_UNKNOWN;
+  IREE_RETURN_IF_ERROR(loom_symbolic_expr_prove_direct_value_relation(
+      context, LOOM_SYMBOLIC_INTEGER_RELATION_LE, positive_relation_value,
+      negative_relation_value, &relation));
+  if (relation == LOOM_SYMBOLIC_PROOF_TRUE) {
+    loom_symbolic_expr_t zero = {0};
+    loom_symbolic_expr_constant(0, &zero);
+    loom_symbolic_proof_result_t residual_proof = LOOM_SYMBOLIC_PROOF_UNKNOWN;
+    IREE_RETURN_IF_ERROR(
+        loom_symbolic_expr_prove_le(context, residual, &zero, &residual_proof));
+    if (residual_proof == LOOM_SYMBOLIC_PROOF_TRUE) {
+      *out_result = LOOM_SYMBOLIC_PROOF_TRUE;
+    }
+  }
+  return iree_ok_status();
+}
+
+// Proves row-major forms such as row * stride + residual <= rows * stride.
+// Dynamic products remain opaque symbolic terms, so identify a shared
+// non-negative factor and discharge the row and residual bounds separately.
+static iree_status_t loom_symbolic_expr_prove_le_by_common_product_factor(
+    loom_symbolic_expr_context_t* context, int64_t constant,
+    const loom_symbolic_term_t* terms, iree_host_size_t term_count,
+    loom_symbolic_proof_result_t* out_result) {
+  *out_result = LOOM_SYMBOLIC_PROOF_UNKNOWN;
+  if (term_count < 2 || term_count > LOOM_SYMBOLIC_EXPR_DEFAULT_TERM_LIMIT) {
+    return iree_ok_status();
+  }
+
+  for (iree_host_size_t i = 0; i < term_count; ++i) {
+    for (iree_host_size_t j = i + 1; j < term_count; ++j) {
+      const loom_symbolic_term_t* positive_term = &terms[i];
+      const loom_symbolic_term_t* negative_term = &terms[j];
+      if (positive_term->coefficient < 0) {
+        positive_term = &terms[j];
+        negative_term = &terms[i];
+      }
+      if (positive_term->coefficient <= 0 || negative_term->coefficient >= 0 ||
+          negative_term->coefficient == INT64_MIN ||
+          positive_term->coefficient != -negative_term->coefficient) {
+        continue;
+      }
+
+      loom_value_id_t positive_factors[2] = {LOOM_VALUE_ID_INVALID,
+                                             LOOM_VALUE_ID_INVALID};
+      loom_value_id_t negative_factors[2] = {LOOM_VALUE_ID_INVALID,
+                                             LOOM_VALUE_ID_INVALID};
+      if (!loom_symbolic_expr_value_product_factors(
+              context, positive_term->value_id, &positive_factors[0],
+              &positive_factors[1]) ||
+          !loom_symbolic_expr_value_product_factors(
+              context, negative_term->value_id, &negative_factors[0],
+              &negative_factors[1])) {
+        continue;
+      }
+
+      loom_symbolic_term_t
+          residual_terms[LOOM_SYMBOLIC_EXPR_DEFAULT_TERM_LIMIT];
+      loom_symbolic_expr_t residual = {0};
+      loom_symbolic_expr_residual_excluding_pair(constant, terms, term_count, i,
+                                                 j, residual_terms, &residual);
+      for (uint8_t positive_factor_index = 0; positive_factor_index < 2;
+           ++positive_factor_index) {
+        for (uint8_t negative_factor_index = 0; negative_factor_index < 2;
+             ++negative_factor_index) {
+          bool factors_match = false;
+          IREE_RETURN_IF_ERROR(loom_symbolic_expr_values_match(
+              context, positive_factors[positive_factor_index],
+              negative_factors[negative_factor_index], &factors_match));
+          if (!factors_match) continue;
+
+          IREE_RETURN_IF_ERROR(loom_symbolic_expr_try_common_product_factor(
+              context, positive_factors[positive_factor_index],
+              positive_factors[1 - positive_factor_index],
+              negative_factors[1 - negative_factor_index],
+              positive_term->coefficient, &residual, out_result));
+          if (*out_result != LOOM_SYMBOLIC_PROOF_UNKNOWN) {
+            return iree_ok_status();
+          }
+        }
+      }
+    }
+  }
+  return iree_ok_status();
+}
+
 static bool loom_symbolic_expr_scaled_pair_terms(
     const loom_symbolic_term_t* terms, iree_host_size_t term_count,
     int64_t* out_scale, loom_value_id_t* out_positive_relation_value,
@@ -3168,6 +3505,10 @@ static iree_status_t loom_symbolic_expr_prove_le_by_scaled_relation(
     IREE_RETURN_IF_ERROR(
         loom_symbolic_expr_prove_le_by_scaled_relation_with_residual(
             context, constant, terms, term_count, out_result));
+    if (*out_result == LOOM_SYMBOLIC_PROOF_UNKNOWN) {
+      IREE_RETURN_IF_ERROR(loom_symbolic_expr_prove_le_by_common_product_factor(
+          context, constant, terms, term_count, out_result));
+    }
     return iree_ok_status();
   }
 
@@ -3220,6 +3561,10 @@ static iree_status_t loom_symbolic_expr_prove_le_by_scaled_relation(
   IREE_RETURN_IF_ERROR(
       loom_symbolic_expr_prove_le_by_scaled_relation_with_residual(
           context, constant, terms, term_count, out_result));
+  if (*out_result == LOOM_SYMBOLIC_PROOF_UNKNOWN) {
+    IREE_RETURN_IF_ERROR(loom_symbolic_expr_prove_le_by_common_product_factor(
+        context, constant, terms, term_count, out_result));
+  }
   return iree_ok_status();
 }
 
@@ -3529,6 +3874,9 @@ iree_status_t loom_symbolic_expr_prove_le(
   if (loom_symbolic_expr_is_linear(left_expression) &&
       loom_symbolic_expr_is_linear(right_expression)) {
     IREE_RETURN_IF_ERROR(loom_symbolic_expr_prove_le_linear(
+        context, left_expression, right_expression, out_result));
+    if (*out_result != LOOM_SYMBOLIC_PROOF_UNKNOWN) return iree_ok_status();
+    IREE_RETURN_IF_ERROR(loom_symbolic_expr_prove_le_by_condition_relations(
         context, left_expression, right_expression, out_result));
     if (*out_result != LOOM_SYMBOLIC_PROOF_UNKNOWN) return iree_ok_status();
     IREE_RETURN_IF_ERROR(loom_symbolic_expr_prove_le_by_scaled_relation(

--- a/loom/src/loom/analysis/symbolic_expr_test.cc
+++ b/loom/src/loom/analysis/symbolic_expr_test.cc
@@ -640,6 +640,118 @@ TEST_F(SymbolicExprTest, DynamicMultiplyFallsBackToResultSymbol) {
   EXPECT_EQ(expression.terms[0].value_id, result);
 }
 
+TEST_F(SymbolicExprTest, ProvesFlattenedAddressFromDynamicAxisBounds) {
+  loom_type_t index_type = loom_type_scalar(LOOM_SCALAR_TYPE_INDEX);
+  loom_value_id_t row_source = DefineIndexValue();
+  loom_value_id_t row_count_source = DefineIndexValue();
+  loom_value_id_t column = DefineIndexValue();
+  loom_value_id_t column_count = DefineIndexValue();
+  DefineFacts(row_source, loom_value_facts_make(0, 2047, 1));
+  DefineFacts(row_count_source, loom_value_facts_make(1, 2048, 1));
+  DefineFacts(column, loom_value_facts_make(0, 262143, 1));
+  DefineFacts(column_count, loom_value_facts_make(1, 262144, 1));
+
+  loom_value_id_t row_values[] = {row_source, row_count_source};
+  loom_predicate_t row_predicate = {
+      /*.kind=*/LOOM_PREDICATE_LT,
+      /*.arg_count=*/2,
+      /*.arg_tags=*/{LOOM_PRED_ARG_VALUE, LOOM_PRED_ARG_VALUE},
+      /*.reserved=*/{},
+      /*.args=*/{row_source, row_count_source, 0},
+  };
+  loom_type_t row_result_types[] = {index_type, index_type};
+  loom_op_t* row_assume_op = nullptr;
+  IREE_ASSERT_OK(loom_index_assume_build(
+      &builder_, row_values, IREE_ARRAYSIZE(row_values), &row_predicate, 1,
+      row_result_types, IREE_ARRAYSIZE(row_result_types), LOOM_LOCATION_UNKNOWN,
+      &row_assume_op));
+  loom_value_slice_t row_results = loom_index_assume_results(row_assume_op);
+  loom_value_id_t row = row_results.values[0];
+  loom_value_id_t row_count = row_results.values[1];
+
+  loom_op_t* column_compare_op = nullptr;
+  IREE_ASSERT_OK(loom_index_cmp_build(
+      &builder_, LOOM_INDEX_CMP_PREDICATE_ULT, column, column_count, index_type,
+      loom_type_scalar(LOOM_SCALAR_TYPE_I1), LOOM_LOCATION_UNKNOWN,
+      &column_compare_op));
+  loom_condition_integer_relation_t relation_storage[4];
+  loom_condition_fact_set_t condition_facts;
+  loom_condition_fact_set_initialize(
+      relation_storage, IREE_ARRAYSIZE(relation_storage), &condition_facts);
+  ASSERT_TRUE(loom_condition_facts_query(
+      module_, &fact_table_, loom_index_cmp_result(column_compare_op), true,
+      &condition_facts));
+  expression_context_.condition_facts = &condition_facts;
+  loom_symbolic_expr_context_reset(&expression_context_);
+
+  loom_op_t* row_base_op = nullptr;
+  IREE_ASSERT_OK(loom_index_mul_build(&builder_, row, column_count, index_type,
+                                      LOOM_LOCATION_UNKNOWN, &row_base_op));
+  loom_op_t* origin_op = nullptr;
+  IREE_ASSERT_OK(loom_index_add_build(
+      &builder_, loom_index_mul_result(row_base_op), column, index_type,
+      LOOM_LOCATION_UNKNOWN, &origin_op));
+  loom_op_t* element_count_op = nullptr;
+  IREE_ASSERT_OK(loom_index_mul_build(&builder_, row_count, column_count,
+                                      index_type, LOOM_LOCATION_UNKNOWN,
+                                      &element_count_op));
+
+  loom_symbolic_expr_t origin = {};
+  IREE_ASSERT_OK(loom_symbolic_expr_from_value(
+      &expression_context_, loom_index_add_result(origin_op), &origin));
+  loom_symbolic_expr_t one = {};
+  loom_symbolic_expr_constant(1, &one);
+  loom_symbolic_expr_t exclusive_end = {};
+  IREE_ASSERT_OK(loom_symbolic_expr_add(&expression_context_, &origin, &one,
+                                        &exclusive_end));
+  loom_symbolic_expr_t element_count = {};
+  IREE_ASSERT_OK(loom_symbolic_expr_from_value(
+      &expression_context_, loom_index_mul_result(element_count_op),
+      &element_count));
+
+  loom_symbolic_proof_result_t proof = LOOM_SYMBOLIC_PROOF_UNKNOWN;
+  IREE_ASSERT_OK(loom_symbolic_expr_prove_le(
+      &expression_context_, &exclusive_end, &element_count, &proof));
+  EXPECT_EQ(proof, LOOM_SYMBOLIC_PROOF_TRUE);
+
+  loom_op_t* row_nonstrict_compare_op = nullptr;
+  IREE_ASSERT_OK(loom_index_cmp_build(
+      &builder_, LOOM_INDEX_CMP_PREDICATE_ULE, row_source, row_count_source,
+      index_type, loom_type_scalar(LOOM_SCALAR_TYPE_I1), LOOM_LOCATION_UNKNOWN,
+      &row_nonstrict_compare_op));
+  ASSERT_TRUE(loom_condition_facts_query(
+      module_, &fact_table_, loom_index_cmp_result(row_nonstrict_compare_op),
+      true, &condition_facts));
+  ASSERT_TRUE(loom_condition_facts_query_into(
+      module_, &fact_table_, loom_index_cmp_result(column_compare_op), true,
+      &condition_facts));
+  loom_symbolic_expr_context_reset(&expression_context_);
+
+  loom_op_t* nonstrict_row_base_op = nullptr;
+  IREE_ASSERT_OK(loom_index_mul_build(&builder_, row_source, column_count,
+                                      index_type, LOOM_LOCATION_UNKNOWN,
+                                      &nonstrict_row_base_op));
+  loom_op_t* nonstrict_origin_op = nullptr;
+  IREE_ASSERT_OK(loom_index_add_build(
+      &builder_, loom_index_mul_result(nonstrict_row_base_op), column,
+      index_type, LOOM_LOCATION_UNKNOWN, &nonstrict_origin_op));
+  loom_op_t* nonstrict_element_count_op = nullptr;
+  IREE_ASSERT_OK(loom_index_mul_build(&builder_, row_count_source, column_count,
+                                      index_type, LOOM_LOCATION_UNKNOWN,
+                                      &nonstrict_element_count_op));
+  IREE_ASSERT_OK(loom_symbolic_expr_from_value(
+      &expression_context_, loom_index_add_result(nonstrict_origin_op),
+      &origin));
+  IREE_ASSERT_OK(loom_symbolic_expr_add(&expression_context_, &origin, &one,
+                                        &exclusive_end));
+  IREE_ASSERT_OK(loom_symbolic_expr_from_value(
+      &expression_context_, loom_index_mul_result(nonstrict_element_count_op),
+      &element_count));
+  IREE_ASSERT_OK(loom_symbolic_expr_prove_le(
+      &expression_context_, &exclusive_end, &element_count, &proof));
+  EXPECT_EQ(proof, LOOM_SYMBOLIC_PROOF_UNKNOWN);
+}
+
 TEST_F(SymbolicExprTest, BoundedDynamicMaddFallsBackToResultSymbol) {
   loom_value_id_t left = DefineIndexValue();
   loom_value_id_t right = DefineIndexValue();

--- a/loom/src/loom/ops/BUILD.bazel
+++ b/loom/src/loom/ops/BUILD.bazel
@@ -212,6 +212,7 @@ loom_generated_cc_library(
         ":op_defs",
         ":storage_facts",
         "//loom/src/loom/ir",
+        "//loom/src/loom/ops/buffer",
         "//loom/src/loom/ops/vector",
         "//loom/src/loom/util:fact_table",
         "//runtime/src/iree/base",

--- a/loom/src/loom/ops/CMakeLists.txt
+++ b/loom/src/loom/ops/CMakeLists.txt
@@ -242,6 +242,7 @@ loom_generated_cc_library(
     ::storage_facts
     iree::base
     loom::ir
+    loom::ops::buffer
     loom::ops::vector
     loom::util::fact_table
 )

--- a/loom/src/loom/ops/buffer/facts.c
+++ b/loom/src/loom/ops/buffer/facts.c
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 
+#include "iree/base/internal/math.h"
 #include "loom/ir/module.h"
 #include "loom/ops/buffer/ops.h"
 #include "loom/ops/view/reference.h"
@@ -41,6 +42,71 @@ static loom_value_fact_buffer_reference_t loom_buffer_default_reference(
   };
 }
 
+static iree_status_t loom_buffer_meet_reference_extension(
+    const loom_value_fact_domain_t* domain, const loom_module_t* module,
+    loom_type_t type, loom_value_fact_table_t* target,
+    const loom_value_fact_table_t* lhs_table, loom_value_facts_t lhs,
+    const loom_value_fact_table_t* rhs_table, loom_value_facts_t rhs,
+    loom_value_facts_t* inout_facts) {
+  (void)domain;
+  (void)module;
+  (void)type;
+  loom_value_fact_buffer_reference_t lhs_reference = {0};
+  loom_value_fact_buffer_reference_t rhs_reference = {0};
+  if (!loom_value_facts_query_buffer_reference(&lhs_table->context, lhs,
+                                               &lhs_reference) ||
+      !loom_value_facts_query_buffer_reference(&rhs_table->context, rhs,
+                                               &rhs_reference)) {
+    inout_facts->extension_id = LOOM_VALUE_FACT_EXTENSION_ID_NONE;
+    return iree_ok_status();
+  }
+
+  loom_value_facts_t lhs_extent = lhs_reference.maximum_byte_extent;
+  loom_value_facts_t rhs_extent = rhs_reference.maximum_byte_extent;
+  lhs_extent.extension_id = LOOM_VALUE_FACT_EXTENSION_ID_NONE;
+  rhs_extent.extension_id = LOOM_VALUE_FACT_EXTENSION_ID_NONE;
+  loom_value_fact_buffer_reference_t reference = {
+      .minimum_alignment = iree_math_gcd_u64(lhs_reference.minimum_alignment,
+                                             rhs_reference.minimum_alignment),
+      .memory_space = lhs_reference.memory_space == rhs_reference.memory_space
+                          ? lhs_reference.memory_space
+                          : LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN,
+      .root_value_id =
+          lhs_reference.root_value_id == rhs_reference.root_value_id
+              ? lhs_reference.root_value_id
+              : LOOM_VALUE_ID_INVALID,
+      .alias_scope_id =
+          lhs_reference.alias_scope_id == rhs_reference.alias_scope_id
+              ? lhs_reference.alias_scope_id
+              : LOOM_VALUE_FACT_ALIAS_SCOPE_ID_NONE,
+      .nullability = lhs_reference.nullability == rhs_reference.nullability
+                         ? lhs_reference.nullability
+                         : LOOM_VALUE_FACT_REFERENCE_NULLABILITY_UNKNOWN,
+  };
+  loom_value_facts_meet(&lhs_extent, &rhs_extent,
+                        &reference.maximum_byte_extent);
+  if (reference.minimum_alignment == 0) reference.minimum_alignment = 1;
+  return loom_value_facts_make_buffer_reference(&target->context, reference,
+                                                inout_facts);
+}
+
+static iree_status_t loom_buffer_widen_reference_extension(
+    const loom_value_fact_domain_t* domain, const loom_module_t* module,
+    loom_type_t type, loom_value_fact_table_t* target,
+    const loom_value_fact_table_t* previous_table, loom_value_facts_t previous,
+    const loom_value_fact_table_t* next_table, loom_value_facts_t next,
+    uint32_t iteration, loom_value_facts_t* inout_facts) {
+  (void)iteration;
+  return loom_buffer_meet_reference_extension(domain, module, type, target,
+                                              previous_table, previous,
+                                              next_table, next, inout_facts);
+}
+
+const loom_value_fact_domain_t loom_buffer_fact_domain = {
+    .meet_extension = loom_buffer_meet_reference_extension,
+    .widen_extension = loom_buffer_widen_reference_extension,
+};
+
 iree_status_t loom_buffer_alloca_facts(loom_fact_context_t* context,
                                        const loom_module_t* module,
                                        const loom_op_t* op,
@@ -67,6 +133,8 @@ iree_status_t loom_buffer_assume_memory_space_facts(
       loom_buffer_default_reference(loom_buffer_assume_memory_space_buffer(op));
   (void)loom_value_facts_query_buffer_reference(context, operand_facts[0],
                                                 &reference);
+  reference.root_value_id = loom_value_fact_buffer_reference_resolve_root_value(
+      reference, loom_buffer_assume_memory_space_buffer(op));
   reference.memory_space = loom_buffer_assume_memory_space_memory_space(op);
   return loom_value_facts_make_buffer_reference(context, reference,
                                                 &result_facts[0]);
@@ -87,6 +155,9 @@ iree_status_t loom_buffer_assume_alignment_facts(
         loom_buffer_default_reference(buffers.values[i]);
     (void)loom_value_facts_query_buffer_reference(context, operand_facts[i],
                                                   &reference);
+    reference.root_value_id =
+        loom_value_fact_buffer_reference_resolve_root_value(reference,
+                                                            buffers.values[i]);
     if (reference.minimum_alignment < minimum_alignment) {
       reference.minimum_alignment = minimum_alignment;
     }
@@ -112,6 +183,9 @@ iree_status_t loom_buffer_assume_noalias_facts(
         loom_buffer_default_reference(buffers.values[i]);
     (void)loom_value_facts_query_buffer_reference(context, operand_facts[i],
                                                   &reference);
+    reference.root_value_id =
+        loom_value_fact_buffer_reference_resolve_root_value(reference,
+                                                            buffers.values[i]);
     reference.alias_scope_id = reference.root_value_id;
     IREE_RETURN_IF_ERROR(loom_value_facts_make_buffer_reference(
         context, reference, &result_facts[i]));
@@ -130,12 +204,15 @@ iree_status_t loom_buffer_assume_same_root_facts(
       loom_buffer_default_reference(loom_buffer_assume_same_root_buffer(op));
   (void)loom_value_facts_query_buffer_reference(context, operand_facts[0],
                                                 &reference);
+  reference.root_value_id = loom_value_fact_buffer_reference_resolve_root_value(
+      reference, loom_buffer_assume_same_root_buffer(op));
 
   loom_value_fact_buffer_reference_t root_reference =
       loom_buffer_default_reference(loom_buffer_assume_same_root_root(op));
   (void)loom_value_facts_query_buffer_reference(context, operand_facts[1],
                                                 &root_reference);
-  reference.root_value_id = root_reference.root_value_id;
+  reference.root_value_id = loom_value_fact_buffer_reference_resolve_root_value(
+      root_reference, loom_buffer_assume_same_root_root(op));
   reference.alias_scope_id = root_reference.alias_scope_id;
   if (reference.memory_space == LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN) {
     reference.memory_space = root_reference.memory_space;

--- a/loom/src/loom/ops/test/facts.c
+++ b/loom/src/loom/ops/test/facts.c
@@ -456,7 +456,8 @@ iree_status_t loom_test_fact_view_root_matches_facts(
   loom_value_fact_view_reference_t other_view_reference = {0};
   if (loom_value_facts_query_buffer_reference(context, operand_facts[1],
                                               &buffer_reference)) {
-    root_value_id = buffer_reference.root_value_id;
+    root_value_id = loom_value_fact_buffer_reference_resolve_root_value(
+        buffer_reference, root_value_id);
   } else if (loom_value_facts_query_view_reference(context, operand_facts[1],
                                                    &other_view_reference)) {
     root_value_id = other_view_reference.root_value_id;

--- a/loom/src/loom/ops/view/reference.c
+++ b/loom/src/loom/ops/view/reference.c
@@ -365,6 +365,9 @@ iree_status_t loom_view_reference_make_buffer_view(
       loom_view_default_buffer_reference(buffer_value_id);
   (void)loom_value_facts_query_buffer_reference(context, buffer_facts,
                                                 &buffer_reference);
+  buffer_reference.root_value_id =
+      loom_value_fact_buffer_reference_resolve_root_value(buffer_reference,
+                                                          buffer_value_id);
 
   loom_value_fact_view_reference_t view_reference = {0};
   view_reference.base_byte_offset =

--- a/loom/src/loom/ops/view/test/facts.loom-test
+++ b/loom/src/loom/ops/view/test/facts.loom-test
@@ -60,6 +60,47 @@ kernel.def @kernel_buffer_arg_memory_space_global(%buffer: buffer) {
 
 // ====
 
+// Kernel ABI references and views are cluster-uniform. Derived views preserve
+// that scope until a lane-varying offset makes the addressed storage vary.
+kernel.def @kernel_reference_distribution(%buffer: buffer, %m: index) {
+  %one = index.constant 1 : index
+  %sixtyfour = index.constant 64 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%sixtyfour, %one, %one) : index
+} launch(%buffer: buffer, %m: index) {
+  %zero = index.constant 0 : offset
+  %lane = kernel.workitem.id<x> : index
+  %source = buffer.view %buffer[%zero] : buffer -> view<[%m]xi32, #dense>
+  %refined = view.refine %source : view<[%m]xi32, #dense> -> view<64xi32, #dense>
+  %lane_view = view.subview %refined[%lane] : view<64xi32, #dense> -> view<1xi32, #dense>
+  %uniform_value = view.load %refined[0] : view<64xi32, #dense> -> i32
+  %lane_value = view.load %lane_view[0] : view<1xi32, #dense> -> i32
+  %buffer_uniform = test.fact_cluster_uniform %buffer : buffer -> i1
+  %source_uniform = test.fact_cluster_uniform %source : view<[%m]xi32, #dense> -> i1
+  %refined_uniform = test.fact_cluster_uniform %refined : view<64xi32, #dense> -> i1
+  %uniform_value_uniform = test.fact_cluster_uniform %uniform_value : i32 -> i1
+  %lane_view_varying = test.fact_lane_varying %lane_view : view<1xi32, #dense> -> i1
+  %lane_value_varying = test.fact_lane_varying %lane_value : i32 -> i1
+  test.use %buffer_uniform, %source_uniform, %refined_uniform, %uniform_value_uniform, %lane_view_varying, %lane_value_varying : i1, i1, i1, i1, i1, i1
+  kernel.return
+}
+// ----
+kernel.def @kernel_reference_distribution(%buffer: buffer, %m: index) {
+  %one = index.constant 1 : index
+  %sixtyfour = index.constant 64 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%sixtyfour, %one, %one) : index
+} launch(%buffer: buffer, %m: index) {
+  %buffer_uniform = scalar.constant true : i1
+  %source_uniform = scalar.constant true : i1
+  %refined_uniform = scalar.constant true : i1
+  %uniform_value_uniform = scalar.constant true : i1
+  %lane_view_varying = scalar.constant true : i1
+  %lane_value_varying = scalar.constant true : i1
+  test.use %buffer_uniform, %source_uniform, %refined_uniform, %uniform_value_uniform, %lane_view_varying, %lane_value_varying : i1, i1, i1, i1, i1, i1
+  kernel.return
+}
+
+// ====
+
 // Scratch buffer roots seed extent, base alignment, memory-space, and non-null
 // facts. Views derived from them keep the root facts while computing their own
 // typed byte footprint.

--- a/loom/src/loom/ops/view/test/facts.loom-test
+++ b/loom/src/loom/ops/view/test/facts.loom-test
@@ -107,6 +107,74 @@ func.def @assume_memory_space_feeds_view(%buffer: buffer, %offset: offset) -> (i
 
 // ====
 
+// Selecting between roots with the same storage contract preserves their
+// shared memory space and makes the selected descriptor the new dynamic root.
+func.def @select_global_buffer_preserves_reference(%condition: i1, %lhs: buffer, %rhs: buffer, %offset: offset) -> (i1, i64, i64, i1) {
+  %layout = encoding.layout.dense : encoding<layout>
+  %global_lhs = buffer.assume.memory_space<global> %lhs : buffer
+  %global_rhs = buffer.assume.memory_space<global> %rhs : buffer
+  %selected = scf.select %condition, %global_lhs, %global_rhs : buffer
+  %view = buffer.view %selected[%offset] : buffer -> view<4xf32, %layout>
+  %is_reference = test.fact_is_buffer_reference %selected : buffer -> i1
+  %buffer_space = test.fact_buffer_memory_space %selected : buffer -> i64
+  %view_space = test.fact_view_memory_space %view : view<4xf32, %layout> -> i64
+  %root_matches = test.fact_view_root_matches %view, %selected : view<4xf32, %layout>, buffer -> i1
+  func.return %is_reference, %buffer_space, %view_space, %root_matches : i1, i64, i64, i1
+}
+// ----
+func.def @select_global_buffer_preserves_reference(%condition: i1, %lhs: buffer, %rhs: buffer, %offset: offset) -> (i1, i64, i64, i1) {
+  %is_reference = scalar.constant true : i1
+  %buffer_space = scalar.constant 1 : i64
+  %view_space = scalar.constant 1 : i64
+  %root_matches = scalar.constant true : i1
+  func.return %is_reference, %buffer_space, %view_space, %root_matches : i1, i64, i64, i1
+}
+
+// ====
+
+// Selecting roots from different memory spaces keeps the dynamic storage root
+// but conservatively drops the incompatible memory-space fact.
+func.def @select_mixed_buffer_space_degrades_space(%condition: i1, %external: buffer, %offset: offset) -> (i1, i64, i64, i1) {
+  %layout = encoding.layout.dense : encoding<layout>
+  %bytes = index.constant 64 : offset
+  %global = buffer.assume.memory_space<global> %external : buffer
+  %workgroup = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
+  %selected = scf.select %condition, %global, %workgroup : buffer
+  %view = buffer.view %selected[%offset] : buffer -> view<4xf32, %layout>
+  %is_reference = test.fact_is_buffer_reference %selected : buffer -> i1
+  %buffer_space = test.fact_buffer_memory_space %selected : buffer -> i64
+  %view_space = test.fact_view_memory_space %view : view<4xf32, %layout> -> i64
+  %root_matches = test.fact_view_root_matches %view, %selected : view<4xf32, %layout>, buffer -> i1
+  func.return %is_reference, %buffer_space, %view_space, %root_matches : i1, i64, i64, i1
+}
+// ----
+func.def @select_mixed_buffer_space_degrades_space(%condition: i1, %external: buffer, %offset: offset) -> (i1, i64, i64, i1) {
+  %is_reference = scalar.constant true : i1
+  %buffer_space = scalar.constant -1 : i64
+  %view_space = scalar.constant -1 : i64
+  %root_matches = scalar.constant true : i1
+  func.return %is_reference, %buffer_space, %view_space, %root_matches : i1, i64, i64, i1
+}
+
+// ====
+
+// A dynamic root retains only the alignment guaranteed by both candidates.
+func.def @select_buffer_meets_alignment(%condition: i1) -> (i64) {
+  %bytes = index.constant 64 : offset
+  %lhs = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
+  %rhs = buffer.alloca %bytes {base_alignment = 128, memory_space = workgroup} : buffer
+  %selected = scf.select %condition, %lhs, %rhs : buffer
+  %alignment = test.fact_buffer_min_alignment %selected : buffer -> i64
+  func.return %alignment : i64
+}
+// ----
+func.def @select_buffer_meets_alignment(%condition: i1) -> (i64) {
+  %alignment = scalar.constant 64 : i64
+  func.return %alignment : i64
+}
+
+// ====
+
 // External buffer arguments are storage provenance roots but do not get a
 // comparable noalias scope until an explicit contract says so.
 func.def @external_buffer_arg_has_no_alias_scope(%buffer: buffer) -> (i1) {

--- a/loom/src/loom/target/arch/amdgpu/lower/buffer.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/buffer.c
@@ -68,10 +68,7 @@ iree_status_t loom_amdgpu_select_buffer_plan(loom_low_lower_context_t* context,
         return iree_ok_status();
       }
       IREE_RETURN_IF_ERROR(loom_amdgpu_source_alloca_layout_record_lower_alloca(
-          context, loom_buffer_alloca_memory_space(source_op),
-          loom_buffer_alloca_result(source_op),
-          (uint64_t)local_plan.byte_length,
-          (uint64_t)local_plan.base_alignment));
+          context, source_op, (uint64_t)local_plan.byte_length));
       loom_amdgpu_buffer_alloca_plan_t* plan_data = NULL;
       IREE_RETURN_IF_ERROR(loom_low_lower_allocate_plan_data(
           context, sizeof(*plan_data), (void**)&plan_data));
@@ -100,27 +97,27 @@ iree_status_t loom_amdgpu_low_legality_record_buffer_op(
     return iree_ok_status();
   }
   return loom_amdgpu_source_alloca_layout_record_low_legality_alloca(
-      context, loom_buffer_alloca_memory_space(op),
-      loom_buffer_alloca_result(op), (uint64_t)plan.byte_length,
-      (uint64_t)plan.base_alignment);
+      context, op, (uint64_t)plan.byte_length);
 }
 
 static iree_status_t loom_amdgpu_lower_buffer_alloca(
     loom_low_lower_context_t* context, const loom_op_t* source_op,
     const loom_amdgpu_buffer_alloca_plan_t* plan) {
   loom_builder_t* builder = loom_low_lower_context_builder(context);
-  loom_op_t* storage_op = NULL;
-  IREE_RETURN_IF_ERROR(loom_low_storage_reserve_build(
-      builder, plan->byte_length, plan->base_alignment,
-      loom_type_storage(plan->storage_space), source_op->location,
-      &storage_op));
+  const loom_amdgpu_source_alloca_layout_t* layout = NULL;
+  IREE_RETURN_IF_ERROR(
+      loom_amdgpu_source_alloca_layout_for_lower_context(context, &layout));
+  loom_value_id_t storage_root = LOOM_VALUE_ID_INVALID;
+  loom_amdgpu_source_alloca_layout_lookup_low_storage(
+      layout, loom_buffer_alloca_memory_space(source_op),
+      loom_buffer_alloca_result(source_op), &storage_root);
 
   loom_type_t vgpr_type = loom_type_none();
   IREE_RETURN_IF_ERROR(loom_amdgpu_make_vgpr_type(context, &vgpr_type));
   loom_op_t* address_op = NULL;
   IREE_RETURN_IF_ERROR(loom_low_storage_address_build(
-      builder, loom_low_storage_reserve_storage(storage_op),
-      /*offset=*/0, vgpr_type, source_op->location, &address_op));
+      builder, storage_root, /*offset=*/0, vgpr_type, source_op->location,
+      &address_op));
   return loom_low_lower_bind_value(context,
                                    loom_buffer_alloca_result(source_op),
                                    loom_low_storage_address_result(address_op));

--- a/loom/src/loom/target/arch/amdgpu/lower/mask.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/mask.c
@@ -418,6 +418,13 @@ static iree_status_t loom_amdgpu_resolve_i1_mask_select_descriptors(
       context, LOOM_AMDGPU_DESCRIPTOR_REF_S_CSELECT_B32, &plan->scc_descriptor,
       &scc_present));
   all_present = all_present && scc_present;
+  if (plan->condition_kind == LOOM_AMDGPU_SELECT_CONDITION_KIND_SGPR_BOOL) {
+    bool compare_present = false;
+    IREE_RETURN_IF_ERROR(loom_amdgpu_resolve_descriptor_ref_if_present(
+        context, LOOM_AMDGPU_DESCRIPTOR_REF_S_CMP_LG_I32_SRC1_INLINE,
+        &plan->sgpr_bool_compare_descriptor, &compare_present));
+    all_present = all_present && compare_present;
+  }
   bool exec_read_present = false;
   IREE_RETURN_IF_ERROR(loom_amdgpu_resolve_descriptor_ref_if_present(
       context, LOOM_AMDGPU_DESCRIPTOR_REF_S_MOV_B64_EXEC_READ,
@@ -425,6 +432,7 @@ static iree_status_t loom_amdgpu_resolve_i1_mask_select_descriptors(
   all_present = all_present && exec_read_present;
   if (!all_present ||
       plan->condition_kind == LOOM_AMDGPU_SELECT_CONDITION_KIND_SCC ||
+      plan->condition_kind == LOOM_AMDGPU_SELECT_CONDITION_KIND_SGPR_BOOL ||
       plan->true_value == plan->false_value) {
     *out_present = all_present;
     return iree_ok_status();
@@ -543,17 +551,23 @@ static iree_status_t loom_amdgpu_select_scf_select_i1_mask_plan(
                                                 &condition_low_type));
   const bool condition_is_scc = loom_amdgpu_low_type_is_register_class_count(
       context, condition_low_type, LOOM_AMDGPU_REG_CLASS_ID_SCC, 1);
+  const bool condition_is_sgpr_bool =
+      loom_amdgpu_low_type_is_register_class_count(
+          context, condition_low_type, LOOM_AMDGPU_REG_CLASS_ID_SGPR, 1);
   const bool condition_is_mask = loom_amdgpu_low_type_is_register_class_count(
       context, condition_low_type, LOOM_AMDGPU_REG_CLASS_ID_SGPR, 2);
-  if (!condition_is_scc && !condition_is_mask) {
+  if (!condition_is_scc && !condition_is_sgpr_bool && !condition_is_mask) {
     return iree_ok_status();
   }
 
   loom_amdgpu_vector_select_plan_t plan = {
       .payload_kind = LOOM_AMDGPU_SELECT_PAYLOAD_KIND_I1_MASK,
-      .condition_kind = condition_is_scc
-                            ? LOOM_AMDGPU_SELECT_CONDITION_KIND_SCC
-                            : LOOM_AMDGPU_SELECT_CONDITION_KIND_SCALAR_MASK,
+      .condition_kind =
+          condition_is_scc
+              ? LOOM_AMDGPU_SELECT_CONDITION_KIND_SCC
+              : (condition_is_sgpr_bool
+                     ? LOOM_AMDGPU_SELECT_CONDITION_KIND_SGPR_BOOL
+                     : LOOM_AMDGPU_SELECT_CONDITION_KIND_SCALAR_MASK),
       .condition = condition,
       .true_value = true_value,
       .false_value = false_value,
@@ -612,9 +626,12 @@ iree_status_t loom_amdgpu_select_scf_select_plan(
 
   const bool condition_is_scc = loom_amdgpu_low_type_is_register_class_count(
       context, condition_low_type, LOOM_AMDGPU_REG_CLASS_ID_SCC, 1);
+  const bool condition_is_sgpr_bool =
+      loom_amdgpu_low_type_is_register_class_count(
+          context, condition_low_type, LOOM_AMDGPU_REG_CLASS_ID_SGPR, 1);
   const bool result_is_sgpr = loom_amdgpu_low_type_is_register_class_count(
       context, result_low_type, LOOM_AMDGPU_REG_CLASS_ID_SGPR, register_count);
-  if (condition_is_scc && result_is_sgpr) {
+  if ((condition_is_scc || condition_is_sgpr_bool) && result_is_sgpr) {
     loom_low_lower_resolved_descriptor_t scc_descriptor = {0};
     bool scc_descriptor_present = false;
     IREE_RETURN_IF_ERROR(loom_amdgpu_resolve_descriptor_ref_if_present(
@@ -623,10 +640,23 @@ iree_status_t loom_amdgpu_select_scf_select_plan(
     if (!scc_descriptor_present) {
       return iree_ok_status();
     }
+    loom_low_lower_resolved_descriptor_t sgpr_bool_compare_descriptor = {0};
+    if (condition_is_sgpr_bool) {
+      bool compare_present = false;
+      IREE_RETURN_IF_ERROR(loom_amdgpu_resolve_descriptor_ref_if_present(
+          context, LOOM_AMDGPU_DESCRIPTOR_REF_S_CMP_LG_I32_SRC1_INLINE,
+          &sgpr_bool_compare_descriptor, &compare_present));
+      if (!compare_present) {
+        return iree_ok_status();
+      }
+    }
     *out_plan = (loom_amdgpu_vector_select_plan_t){
         .payload_kind = LOOM_AMDGPU_SELECT_PAYLOAD_KIND_DATA,
-        .condition_kind = LOOM_AMDGPU_SELECT_CONDITION_KIND_SCC,
+        .condition_kind = condition_is_scc
+                              ? LOOM_AMDGPU_SELECT_CONDITION_KIND_SCC
+                              : LOOM_AMDGPU_SELECT_CONDITION_KIND_SGPR_BOOL,
         .scc_descriptor = scc_descriptor,
+        .sgpr_bool_compare_descriptor = sgpr_bool_compare_descriptor,
         .condition = condition,
         .true_value = true_value,
         .false_value = false_value,
@@ -1751,6 +1781,27 @@ static iree_status_t loom_amdgpu_emit_i1_mask_exec_read(
   return iree_ok_status();
 }
 
+static iree_status_t loom_amdgpu_emit_sgpr_bool_scc(
+    loom_low_lower_context_t* context, const loom_op_t* source_op,
+    const loom_amdgpu_vector_select_plan_t* plan, loom_value_id_t low_condition,
+    loom_value_id_t* out_low_condition) {
+  *out_low_condition = LOOM_VALUE_ID_INVALID;
+  loom_type_t scc_type = loom_type_none();
+  IREE_RETURN_IF_ERROR(loom_amdgpu_make_scc_type(context, &scc_type));
+  loom_named_attr_t attrs[1] = {0};
+  iree_host_size_t attr_count = 0;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_append_i64_attr(
+      context, IREE_SV("rhs"), 0, attrs, IREE_ARRAYSIZE(attrs), &attr_count));
+  loom_op_t* compare_op = NULL;
+  IREE_RETURN_IF_ERROR(loom_low_lower_emit_resolved_descriptor_op(
+      context, &plan->sgpr_bool_compare_descriptor, &low_condition, 1,
+      loom_make_named_attr_slice(attrs, attr_count), &scc_type, 1,
+      /*tied_results=*/NULL, /*tied_result_count=*/0, source_op->location,
+      &compare_op));
+  *out_low_condition = loom_value_slice_get(loom_low_op_results(compare_op), 0);
+  return iree_ok_status();
+}
+
 static iree_status_t loom_amdgpu_emit_i1_zero_mask(
     loom_low_lower_context_t* context, const loom_op_t* source_op,
     loom_type_t lane_type, loom_type_t mask_type, loom_value_id_t* out_mask) {
@@ -1820,11 +1871,16 @@ static iree_status_t loom_amdgpu_lower_i1_mask_select(
         &low_value));
     return loom_low_lower_bind_value(context, plan->result, low_value);
   }
+  if (plan->condition_kind == LOOM_AMDGPU_SELECT_CONDITION_KIND_SGPR_BOOL) {
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_sgpr_bool_scc(
+        context, source_op, plan, low_condition, &low_condition));
+  }
 
   loom_value_id_t low_true_value = LOOM_VALUE_ID_INVALID;
   loom_value_id_t low_false_value = LOOM_VALUE_ID_INVALID;
 
-  if (plan->condition_kind == LOOM_AMDGPU_SELECT_CONDITION_KIND_SCC) {
+  if (plan->condition_kind == LOOM_AMDGPU_SELECT_CONDITION_KIND_SCC ||
+      plan->condition_kind == LOOM_AMDGPU_SELECT_CONDITION_KIND_SGPR_BOOL) {
     IREE_RETURN_IF_ERROR(loom_amdgpu_lookup_or_emit_i1_mask_value(
         context, source_op, plan->true_value, lane_type, mask_type, plan,
         &low_true_value));
@@ -1976,6 +2032,10 @@ iree_status_t loom_amdgpu_lower_select(
   loom_value_id_t low_condition = LOOM_VALUE_ID_INVALID;
   IREE_RETURN_IF_ERROR(
       loom_low_lower_lookup_value(context, plan->condition, &low_condition));
+  if (plan->condition_kind == LOOM_AMDGPU_SELECT_CONDITION_KIND_SGPR_BOOL) {
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_sgpr_bool_scc(
+        context, source_op, plan, low_condition, &low_condition));
+  }
   loom_value_id_t low_true_value = LOOM_VALUE_ID_INVALID;
   IREE_RETURN_IF_ERROR(
       loom_low_lower_lookup_value(context, plan->true_value, &low_true_value));
@@ -1983,7 +2043,8 @@ iree_status_t loom_amdgpu_lower_select(
   IREE_RETURN_IF_ERROR(loom_low_lower_lookup_value(context, plan->false_value,
                                                    &low_false_value));
 
-  if (plan->condition_kind == LOOM_AMDGPU_SELECT_CONDITION_KIND_SCC) {
+  if (plan->condition_kind == LOOM_AMDGPU_SELECT_CONDITION_KIND_SCC ||
+      plan->condition_kind == LOOM_AMDGPU_SELECT_CONDITION_KIND_SGPR_BOOL) {
     loom_type_t lane_type = loom_type_none();
     IREE_RETURN_IF_ERROR(loom_amdgpu_make_sgpr_type(context, &lane_type));
     loom_value_id_t lane_results[LOOM_AMDGPU_MAX_SCALARIZED_32BIT_LANES];

--- a/loom/src/loom/target/arch/amdgpu/lower/mask.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/mask.c
@@ -586,8 +586,10 @@ iree_status_t loom_amdgpu_select_scf_select_plan(
   }
   uint32_t register_count = 0;
   bool allows_lane_immediates = false;
-  if (!loom_amdgpu_select_payload_storage(result_type, &register_count,
-                                          &allows_lane_immediates)) {
+  if (loom_type_is_buffer(result_type)) {
+    register_count = 2;
+  } else if (!loom_amdgpu_select_payload_storage(result_type, &register_count,
+                                                 &allows_lane_immediates)) {
     return iree_ok_status();
   }
   const loom_value_id_t condition = loom_scf_select_condition(source_op);

--- a/loom/src/loom/target/arch/amdgpu/lower/memory.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/memory.c
@@ -2043,12 +2043,13 @@ static bool loom_amdgpu_memory_dynamic_term_can_flat_address(
       term->byte_shift == LOOM_LOW_SOURCE_MEMORY_ACCESS_BYTE_SHIFT_NONE) {
     return false;
   }
-  if (term->stride_value_count != 0) {
-    return false;
-  }
   if (term->byte_shift != LOOM_LOW_SOURCE_MEMORY_ACCESS_BYTE_SHIFT_NONE &&
       term->byte_shift >= 32) {
     return false;
+  }
+  if (term->stride_value_count != 0) {
+    return loom_low_source_memory_dynamic_term_fits_unsigned_bit_count(term,
+                                                                       32);
   }
   return term->byte_facts.range_hi / term->byte_stride <= UINT32_MAX;
 }
@@ -2092,11 +2093,12 @@ static bool loom_amdgpu_memory_dynamic_term_can_emit_flat_address(
   if (term->byte_stride <= 0 || term->byte_stride > UINT32_MAX) {
     return false;
   }
-  if (term->stride_value_count != 0) {
+  if (term->byte_shift != LOOM_LOW_SOURCE_MEMORY_ACCESS_BYTE_SHIFT_NONE &&
+      term->byte_shift >= 32) {
     return false;
   }
-  return term->byte_shift == LOOM_LOW_SOURCE_MEMORY_ACCESS_BYTE_SHIFT_NONE ||
-         term->byte_shift < 32;
+  return term->stride_value_count == 0 ||
+         loom_low_source_memory_dynamic_term_fits_unsigned_bit_count(term, 32);
 }
 
 static bool loom_amdgpu_memory_access_dynamic_terms_can_emit_flat_address(

--- a/loom/src/loom/target/arch/amdgpu/lower/memory_emit.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/memory_emit.c
@@ -1404,6 +1404,47 @@ static iree_status_t loom_amdgpu_emit_memory_flat_wide_dynamic_term(
   return iree_ok_status();
 }
 
+// Materializes a dynamic-stride product whose complete byte value is proven
+// unsigned 32-bit. The low-word products are exact under that proof and the
+// high word of the resulting flat-address term is zero.
+static iree_status_t loom_amdgpu_emit_memory_flat_bounded_u32_dynamic_term(
+    loom_low_lower_context_t* context, const loom_op_t* source_op,
+    const loom_low_source_memory_dynamic_term_t* term, loom_type_t vgpr_type,
+    loom_value_id_t* out_low_lo, loom_value_id_t* out_low_hi,
+    bool* out_emitted) {
+  *out_emitted = false;
+  if (term->stride_value_count == 0 ||
+      !loom_low_source_memory_dynamic_term_fits_unsigned_bit_count(term, 32)) {
+    return iree_ok_status();
+  }
+
+  loom_value_id_t low_offset = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_lookup_or_materialize_memory_u32_vaddr_term(
+      context, source_op, term, term->index, &low_offset));
+  for (uint8_t i = 0; i < term->stride_value_count; ++i) {
+    loom_value_id_t low_stride = LOOM_VALUE_ID_INVALID;
+    IREE_RETURN_IF_ERROR(
+        loom_amdgpu_lookup_or_materialize_memory_u32_vaddr_term(
+            context, source_op, term, term->stride_values[i], &low_stride));
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_binary(
+        context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_MUL_LO_U32, low_offset,
+        low_stride, vgpr_type, &low_offset));
+  }
+  if (term->byte_stride != 1) {
+    IREE_ASSERT(term->byte_stride > 0 && term->byte_stride <= UINT32_MAX);
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_vgpr_scale_u32(
+        context, source_op, low_offset, (uint32_t)term->byte_stride,
+        LOOM_AMDGPU_VGPR_SCALE_U32_FLAG_NONE, vgpr_type, &low_offset));
+  }
+
+  *out_low_lo = low_offset;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_const_u32(
+      context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_MOV_B32, 0, vgpr_type,
+      out_low_hi));
+  *out_emitted = true;
+  return iree_ok_status();
+}
+
 static iree_status_t loom_amdgpu_emit_memory_flat_dynamic_term(
     loom_low_lower_context_t* context, const loom_op_t* source_op,
     const loom_low_source_memory_dynamic_term_t* term, loom_type_t vgpr_type,
@@ -1419,6 +1460,14 @@ static iree_status_t loom_amdgpu_emit_memory_flat_dynamic_term(
       context, source_op, term, low_index, vgpr_type, out_low_lo, out_low_hi,
       &emitted_wide));
   if (emitted_wide) {
+    return iree_ok_status();
+  }
+
+  bool emitted_bounded_u32 = false;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_emit_memory_flat_bounded_u32_dynamic_term(
+      context, source_op, term, vgpr_type, out_low_lo, out_low_hi,
+      &emitted_bounded_u32));
+  if (emitted_bounded_u32) {
     return iree_ok_status();
   }
 

--- a/loom/src/loom/target/arch/amdgpu/lower/plan.h
+++ b/loom/src/loom/target/arch/amdgpu/lower/plan.h
@@ -715,6 +715,7 @@ typedef enum loom_amdgpu_select_condition_kind_e {
   LOOM_AMDGPU_SELECT_CONDITION_KIND_SCC = 1,
   LOOM_AMDGPU_SELECT_CONDITION_KIND_SCALAR_MASK = 2,
   LOOM_AMDGPU_SELECT_CONDITION_KIND_VECTOR_MASK = 3,
+  LOOM_AMDGPU_SELECT_CONDITION_KIND_SGPR_BOOL = 4,
 } loom_amdgpu_select_condition_kind_t;
 
 typedef enum loom_amdgpu_select_payload_kind_e {
@@ -736,6 +737,8 @@ typedef struct loom_amdgpu_vector_select_plan_t {
   loom_amdgpu_select_condition_kind_t condition_kind;
   // Descriptor row selected for SCC-controlled scalar selects.
   loom_low_lower_resolved_descriptor_t scc_descriptor;
+  // Descriptor row rematerializing SCC from an SGPR boolean condition.
+  loom_low_lower_resolved_descriptor_t sgpr_bool_compare_descriptor;
   // Descriptor rows selected for scalar-mask v_cndmask_b32 lane selects.
   loom_amdgpu_cndmask_b32_descriptors_t cndmask_descriptors;
   // Descriptor row selected to read EXEC for i1 mask selection.

--- a/loom/src/loom/target/arch/amdgpu/lower/preamble.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/preamble.c
@@ -1793,6 +1793,8 @@ iree_status_t loom_amdgpu_emit_entry_setup(void* user_data,
                                            loom_low_lower_context_t* context) {
   (void)user_data;
   IREE_RETURN_IF_ERROR(loom_amdgpu_cluster_preamble_emit_entry_setup(context));
+  IREE_RETURN_IF_ERROR(
+      loom_amdgpu_source_alloca_layout_emit_low_storage_roots(context));
 
   const loom_op_t* first_workgroup_count_ops[LOOM_KERNEL_DIMENSION_COUNT_];
   loom_amdgpu_find_first_dynamic_count_ops(

--- a/loom/src/loom/target/arch/amdgpu/lower/source_alloca_layout.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/source_alloca_layout.c
@@ -15,7 +15,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "loom/analysis/control_uniformity.h"
 #include "loom/ir/local_value_domain.h"
+#include "loom/ops/buffer/ops.h"
+#include "loom/ops/low/ops.h"
 #include "loom/target/arch/amdgpu/lower/constants.h"
 #include "loom/target/arch/amdgpu/lower/topology.h"
 #include "loom/target/low_legality.h"
@@ -29,6 +32,15 @@ typedef uint8_t loom_amdgpu_source_alloca_layout_entry_flags_t;
 
 #define LOOM_AMDGPU_SOURCE_ALLOCA_LAYOUT_ENTRY_HAS_OFFSET ((uint8_t)1u << 0)
 
+typedef struct loom_amdgpu_source_alloca_layout_footprint_t {
+  // Operations that define or use the source allocation and its aliases.
+  const loom_op_t** operations;
+  // Number of operations in the allocation footprint.
+  iree_host_size_t operation_count;
+  // Allocated operation pointer capacity.
+  iree_host_size_t operation_capacity;
+} loom_amdgpu_source_alloca_layout_footprint_t;
+
 typedef struct loom_amdgpu_source_alloca_layout_entry_t {
   // Entry state bits.
   loom_amdgpu_source_alloca_layout_entry_flags_t flags;
@@ -36,24 +48,52 @@ typedef struct loom_amdgpu_source_alloca_layout_entry_t {
   loom_value_fact_memory_space_t memory_space;
   // Analyzed byte offset assigned to the allocation root.
   uint64_t byte_offset;
+  // Physical slot ordinal in the allocation memory-space segment.
+  iree_host_size_t slot_ordinal;
+  // Complete operation footprint when this value is an allocation root.
+  loom_amdgpu_source_alloca_layout_footprint_t* footprint;
 } loom_amdgpu_source_alloca_layout_entry_t;
 
-typedef uint8_t loom_amdgpu_source_alloca_layout_segment_flags_t;
+typedef struct loom_amdgpu_source_alloca_layout_occupant_t {
+  // Source allocation root value.
+  loom_value_id_t root_value_id;
+  // Next allocation sharing the physical slot.
+  struct loom_amdgpu_source_alloca_layout_occupant_t* next;
+} loom_amdgpu_source_alloca_layout_occupant_t;
 
-#define LOOM_AMDGPU_SOURCE_ALLOCA_LAYOUT_SEGMENT_VALID ((uint8_t)1u << 0)
+typedef struct loom_amdgpu_source_alloca_layout_slot_t {
+  // Physical byte offset in the memory-space root.
+  uint64_t byte_offset;
+  // Physical slot capacity in bytes.
+  uint64_t byte_size;
+  // Maximum base alignment required by allocations sharing the slot.
+  uint64_t byte_alignment;
+  // Source allocations assigned to the slot.
+  loom_amdgpu_source_alloca_layout_occupant_t* occupants;
+  // Emitted low-storage root, or INVALID before entry setup.
+  loom_value_id_t low_storage_value_id;
+} loom_amdgpu_source_alloca_layout_slot_t;
 
 typedef struct loom_amdgpu_source_alloca_layout_segment_t {
-  // Segment state bits for prefix layout validity.
-  loom_amdgpu_source_alloca_layout_segment_flags_t flags;
   // Next byte offset before applying the next allocation alignment.
   uint64_t byte_size;
+  // Physical slots in stable first-allocation order.
+  loom_amdgpu_source_alloca_layout_slot_t* slots;
+  // Number of initialized physical slots.
+  iree_host_size_t slot_count;
+  // Allocated physical-slot capacity.
+  iree_host_size_t slot_capacity;
 } loom_amdgpu_source_alloca_layout_segment_t;
 
 struct loom_amdgpu_source_alloca_layout_t {
   // Source value domain covered by entries.
   const loom_local_value_domain_t* value_domain;
+  // Module containing source operations and values.
+  const loom_module_t* module;
   // Fact table used to derive allocation sizes.
   const loom_value_fact_table_t* fact_table;
+  // Arena owning allocation footprints, slots, and retained control summaries.
+  iree_arena_allocator_t* arena;
   // Source function covered by entries.
   const loom_op_t* source_function_op;
   // Allocation-root entries indexed by source value ordinal.
@@ -63,6 +103,8 @@ struct loom_amdgpu_source_alloca_layout_t {
   // Per-memory-space segment cursors for selected allocation layout.
   loom_amdgpu_source_alloca_layout_segment_t
       segments[LOOM_AMDGPU_SOURCE_ALLOCA_LAYOUT_MEMORY_SPACE_COUNT];
+  // Lazily populated control facts used for branch-exclusive slots.
+  loom_control_uniformity_info_t control_uniformity;
   // Analysis lifecycle bits.
   uint8_t flags;
 };
@@ -77,12 +119,12 @@ static const loom_amdgpu_source_alloca_layout_t
 
 static bool loom_amdgpu_source_alloca_layout_matches(
     const loom_amdgpu_source_alloca_layout_t* layout,
-    const loom_value_fact_table_t* fact_table,
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
     const loom_local_value_domain_t* value_domain,
     loom_func_like_t source_function) {
   return iree_all_bits_set(layout->flags,
                            LOOM_AMDGPU_SOURCE_ALLOCA_LAYOUT_INITIALIZED) &&
-         layout->fact_table == fact_table &&
+         layout->fact_table == fact_table && layout->module == module &&
          layout->value_domain == value_domain &&
          layout->source_function_op == source_function.op;
 }
@@ -90,30 +132,254 @@ static bool loom_amdgpu_source_alloca_layout_matches(
 static void loom_amdgpu_source_alloca_layout_record_entry(
     const loom_local_value_domain_t* value_domain,
     loom_amdgpu_source_alloca_layout_t* layout, loom_value_id_t root_value_id,
-    loom_value_fact_memory_space_t memory_space, uint64_t byte_offset) {
+    loom_value_fact_memory_space_t memory_space, uint64_t byte_offset,
+    iree_host_size_t slot_ordinal) {
   const loom_value_ordinal_t value_ordinal =
       loom_local_value_domain_try_ordinal(value_domain, root_value_id);
   if (value_ordinal == LOOM_VALUE_ORDINAL_INVALID ||
       value_ordinal >= layout->entry_count) {
     return;
   }
-  layout->entries[value_ordinal] = (loom_amdgpu_source_alloca_layout_entry_t){
-      .flags = LOOM_AMDGPU_SOURCE_ALLOCA_LAYOUT_ENTRY_HAS_OFFSET,
-      .memory_space = memory_space,
-      .byte_offset = byte_offset,
-  };
+  loom_amdgpu_source_alloca_layout_entry_t* entry =
+      &layout->entries[value_ordinal];
+  entry->flags = LOOM_AMDGPU_SOURCE_ALLOCA_LAYOUT_ENTRY_HAS_OFFSET;
+  entry->memory_space = memory_space;
+  entry->byte_offset = byte_offset;
+  entry->slot_ordinal = slot_ordinal;
 }
 
-static void loom_amdgpu_source_alloca_layout_record_allocation(
+static bool loom_amdgpu_source_alloca_layout_value_root(
+    const loom_amdgpu_source_alloca_layout_t* layout, loom_value_id_t value_id,
+    loom_value_id_t* out_root_value_id) {
+  *out_root_value_id = LOOM_VALUE_ID_INVALID;
+  const loom_value_facts_t facts =
+      loom_value_fact_table_lookup(layout->fact_table, value_id);
+  loom_value_fact_buffer_reference_t buffer_reference;
+  if (loom_value_facts_query_buffer_reference(&layout->fact_table->context,
+                                              facts, &buffer_reference)) {
+    *out_root_value_id = loom_value_fact_buffer_reference_resolve_root_value(
+        buffer_reference, value_id);
+    return true;
+  }
+  loom_value_fact_view_reference_t view_reference;
+  if (loom_value_facts_query_view_reference(&layout->fact_table->context, facts,
+                                            &view_reference)) {
+    *out_root_value_id = view_reference.root_value_id;
+    return true;
+  }
+  return false;
+}
+
+static iree_status_t
+loom_amdgpu_source_alloca_layout_append_footprint_operation(
     loom_amdgpu_source_alloca_layout_t* layout,
-    loom_value_fact_memory_space_t memory_space, loom_value_id_t root_value_id,
-    uint64_t byte_length, uint64_t byte_alignment) {
+    loom_amdgpu_source_alloca_layout_footprint_t* footprint,
+    const loom_op_t* operation) {
+  if (footprint->operation_count >= footprint->operation_capacity) {
+    IREE_RETURN_IF_ERROR(iree_arena_grow_array(
+        layout->arena, footprint->operation_count,
+        footprint->operation_capacity == 0 ? 8
+                                           : footprint->operation_capacity * 2,
+        sizeof(*footprint->operations), &footprint->operation_capacity,
+        (void**)&footprint->operations));
+  }
+  footprint->operations[footprint->operation_count++] = operation;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_amdgpu_source_alloca_layout_initialize_footprints(
+    loom_amdgpu_source_alloca_layout_t* layout) {
+  if (layout->entry_count == 0) return iree_ok_status();
+  for (loom_value_ordinal_t value_ordinal = 0;
+       value_ordinal < layout->value_domain->value_count; ++value_ordinal) {
+    const loom_value_id_t value_id =
+        layout->value_domain->value_ids[value_ordinal];
+    loom_value_id_t value_root_id = LOOM_VALUE_ID_INVALID;
+    if (!loom_amdgpu_source_alloca_layout_value_root(layout, value_id,
+                                                     &value_root_id)) {
+      continue;
+    }
+    const loom_value_ordinal_t root_ordinal =
+        loom_local_value_domain_try_ordinal(layout->value_domain,
+                                            value_root_id);
+    if (root_ordinal == LOOM_VALUE_ORDINAL_INVALID) continue;
+
+    const loom_value_t* root_value =
+        loom_module_value(layout->module, value_root_id);
+    if (loom_value_is_block_arg(root_value)) continue;
+    const loom_op_t* alloca_op = loom_value_def_op(root_value);
+    if (!alloca_op || !loom_buffer_alloca_isa(alloca_op) ||
+        !alloca_op->parent_block) {
+      continue;
+    }
+    loom_amdgpu_source_alloca_layout_entry_t* entry =
+        &layout->entries[root_ordinal];
+    if (!entry->footprint) {
+      IREE_RETURN_IF_ERROR(iree_arena_allocate(
+          layout->arena, sizeof(*entry->footprint), (void**)&entry->footprint));
+      *entry->footprint = (loom_amdgpu_source_alloca_layout_footprint_t){0};
+      IREE_RETURN_IF_ERROR(
+          loom_amdgpu_source_alloca_layout_append_footprint_operation(
+              layout, entry->footprint, alloca_op));
+    }
+    const loom_value_t* value = loom_module_value(layout->module, value_id);
+    const loom_use_t* use = NULL;
+    loom_value_for_each_use(value, use) {
+      const loom_op_t* user_op = loom_use_user_op(*use);
+      IREE_RETURN_IF_ERROR(
+          loom_amdgpu_source_alloca_layout_append_footprint_operation(
+              layout, entry->footprint, user_op));
+    }
+  }
+  return iree_ok_status();
+}
+
+static const loom_amdgpu_source_alloca_layout_footprint_t*
+loom_amdgpu_source_alloca_layout_lookup_footprint(
+    const loom_amdgpu_source_alloca_layout_t* layout,
+    loom_value_id_t root_value_id) {
+  const loom_value_ordinal_t root_ordinal =
+      loom_local_value_domain_try_ordinal(layout->value_domain, root_value_id);
+  if (root_ordinal == LOOM_VALUE_ORDINAL_INVALID) return NULL;
+  return layout->entries[root_ordinal].footprint;
+}
+
+static bool loom_amdgpu_source_alloca_layout_slot_can_grow(
+    const loom_amdgpu_source_alloca_layout_segment_t* segment,
+    const loom_amdgpu_source_alloca_layout_slot_t* slot, uint64_t byte_size) {
+  uint64_t slot_end = 0;
+  return byte_size > slot->byte_size &&
+         iree_checked_add_u64(slot->byte_offset, slot->byte_size, &slot_end) &&
+         slot_end == segment->byte_size;
+}
+
+static iree_status_t loom_amdgpu_source_alloca_layout_append_occupant(
+    loom_amdgpu_source_alloca_layout_t* layout,
+    loom_amdgpu_source_alloca_layout_slot_t* slot,
+    loom_value_id_t root_value_id) {
+  loom_amdgpu_source_alloca_layout_occupant_t* occupant = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_arena_allocate(layout->arena, sizeof(*occupant), (void**)&occupant));
+  *occupant = (loom_amdgpu_source_alloca_layout_occupant_t){
+      .root_value_id = root_value_id,
+      .next = slot->occupants,
+  };
+  slot->occupants = occupant;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_amdgpu_source_alloca_layout_try_reuse_slot(
+    loom_amdgpu_source_alloca_layout_t* layout,
+    loom_amdgpu_source_alloca_layout_segment_t* segment,
+    loom_amdgpu_source_alloca_layout_slot_t* slot, const loom_op_t* alloca_op,
+    loom_value_id_t root_value_id, uint64_t byte_length,
+    uint64_t byte_alignment, bool* out_reused) {
+  *out_reused = false;
+  if (slot->byte_offset % byte_alignment != 0 ||
+      (byte_length > slot->byte_size &&
+       !loom_amdgpu_source_alloca_layout_slot_can_grow(segment, slot,
+                                                       byte_length))) {
+    return iree_ok_status();
+  }
+  const loom_amdgpu_source_alloca_layout_footprint_t* footprint =
+      loom_amdgpu_source_alloca_layout_lookup_footprint(layout, root_value_id);
+  if (!footprint) return iree_ok_status();
+  for (loom_amdgpu_source_alloca_layout_occupant_t* occupant = slot->occupants;
+       occupant; occupant = occupant->next) {
+    const loom_amdgpu_source_alloca_layout_footprint_t* occupant_footprint =
+        loom_amdgpu_source_alloca_layout_lookup_footprint(
+            layout, occupant->root_value_id);
+    if (!occupant_footprint) return iree_ok_status();
+    bool mutually_exclusive = false;
+    IREE_RETURN_IF_ERROR(
+        loom_control_uniformity_prove_mutually_exclusive_execution(
+            &layout->control_uniformity, footprint->operation_count,
+            footprint->operations, occupant_footprint->operation_count,
+            occupant_footprint->operations,
+            LOOM_VALUE_FACT_UNIFORM_SCOPE_WORKGROUP, &mutually_exclusive));
+    if (!mutually_exclusive) return iree_ok_status();
+  }
+
+  if (byte_length > slot->byte_size) {
+    uint64_t next_segment_byte_size = 0;
+    if (!iree_checked_add_u64(slot->byte_offset, byte_length,
+                              &next_segment_byte_size) ||
+        next_segment_byte_size > INT64_MAX) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "source allocation layout exceeds INT64_MAX");
+    }
+    slot->byte_size = byte_length;
+    segment->byte_size = next_segment_byte_size;
+  }
+  slot->byte_alignment = iree_max(slot->byte_alignment, byte_alignment);
+  IREE_RETURN_IF_ERROR(loom_amdgpu_source_alloca_layout_append_occupant(
+      layout, slot, root_value_id));
+  loom_amdgpu_source_alloca_layout_record_entry(
+      layout->value_domain, layout, root_value_id,
+      loom_buffer_alloca_memory_space(alloca_op), slot->byte_offset,
+      (iree_host_size_t)(slot - segment->slots));
+  *out_reused = true;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_amdgpu_source_alloca_layout_append_slot(
+    loom_amdgpu_source_alloca_layout_t* layout,
+    loom_amdgpu_source_alloca_layout_segment_t* segment,
+    loom_value_fact_memory_space_t memory_space, const loom_op_t* alloca_op,
+    loom_value_id_t root_value_id, uint64_t byte_length,
+    uint64_t byte_alignment) {
+  uint64_t slot_byte_offset = 0;
+  if (!iree_is_power_of_two_uint64(byte_alignment) ||
+      !iree_checked_align_u64(segment->byte_size, byte_alignment,
+                              &slot_byte_offset)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "source allocation layout alignment overflows");
+  }
+  uint64_t next_segment_byte_size = 0;
+  if (!iree_checked_add_u64(slot_byte_offset, byte_length,
+                            &next_segment_byte_size) ||
+      next_segment_byte_size > INT64_MAX) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "source allocation layout exceeds INT64_MAX");
+  }
+  const iree_host_size_t minimum_capacity = segment->slot_count + 1;
+  if (minimum_capacity > segment->slot_capacity) {
+    IREE_RETURN_IF_ERROR(iree_arena_grow_array(
+        layout->arena, segment->slot_count, iree_max(minimum_capacity, 4u),
+        sizeof(*segment->slots), &segment->slot_capacity,
+        (void**)&segment->slots));
+  }
+  loom_amdgpu_source_alloca_layout_slot_t* slot =
+      &segment->slots[segment->slot_count++];
+  *slot = (loom_amdgpu_source_alloca_layout_slot_t){
+      .byte_offset = slot_byte_offset,
+      .byte_size = byte_length,
+      .byte_alignment = byte_alignment,
+      .low_storage_value_id = LOOM_VALUE_ID_INVALID,
+  };
+  IREE_RETURN_IF_ERROR(loom_amdgpu_source_alloca_layout_append_occupant(
+      layout, slot, root_value_id));
+  segment->byte_size = next_segment_byte_size;
+  loom_amdgpu_source_alloca_layout_record_entry(
+      layout->value_domain, layout, root_value_id, memory_space,
+      slot_byte_offset, segment->slot_count - 1);
+  return iree_ok_status();
+}
+
+static iree_status_t loom_amdgpu_source_alloca_layout_record_allocation(
+    loom_amdgpu_source_alloca_layout_t* layout, const loom_op_t* alloca_op,
+    uint64_t byte_length) {
+  const loom_value_fact_memory_space_t memory_space =
+      loom_buffer_alloca_memory_space(alloca_op);
+  const loom_value_id_t root_value_id = loom_buffer_alloca_result(alloca_op);
+  const uint64_t byte_alignment =
+      (uint64_t)loom_buffer_alloca_base_alignment(alloca_op);
   if ((uint32_t)memory_space >= IREE_ARRAYSIZE(layout->segments)) {
-    return;
+    return iree_ok_status();
   }
   if (layout->value_domain == NULL ||
       !loom_local_value_domain_is_acquired(layout->value_domain)) {
-    return;
+    return iree_ok_status();
   }
   const loom_value_ordinal_t value_ordinal =
       loom_local_value_domain_try_ordinal(layout->value_domain, root_value_id);
@@ -121,44 +387,35 @@ static void loom_amdgpu_source_alloca_layout_record_allocation(
       value_ordinal < layout->entry_count &&
       iree_all_bits_set(layout->entries[value_ordinal].flags,
                         LOOM_AMDGPU_SOURCE_ALLOCA_LAYOUT_ENTRY_HAS_OFFSET)) {
-    return;
+    return iree_ok_status();
   }
 
   loom_amdgpu_source_alloca_layout_segment_t* segment =
       &layout->segments[memory_space];
-  if (!iree_all_bits_set(segment->flags,
-                         LOOM_AMDGPU_SOURCE_ALLOCA_LAYOUT_SEGMENT_VALID)) {
-    return;
-  }
 
-  uint64_t slot_byte_offset = 0;
-  if (!iree_is_power_of_two_uint64(byte_alignment) ||
-      !iree_checked_align_u64(segment->byte_size, byte_alignment,
-                              &slot_byte_offset)) {
-    segment->flags &=
-        (loom_amdgpu_source_alloca_layout_segment_flags_t)~LOOM_AMDGPU_SOURCE_ALLOCA_LAYOUT_SEGMENT_VALID;
-    return;
+  if (memory_space == LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP) {
+    for (iree_host_size_t i = 0; i < segment->slot_count; ++i) {
+      bool reused = false;
+      IREE_RETURN_IF_ERROR(loom_amdgpu_source_alloca_layout_try_reuse_slot(
+          layout, segment, &segment->slots[i], alloca_op, root_value_id,
+          byte_length, byte_alignment, &reused));
+      if (reused) return iree_ok_status();
+    }
   }
-  loom_amdgpu_source_alloca_layout_record_entry(layout->value_domain, layout,
-                                                root_value_id, memory_space,
-                                                slot_byte_offset);
-  uint64_t next_segment_byte_size = 0;
-  if (!iree_checked_add_u64(slot_byte_offset, byte_length,
-                            &next_segment_byte_size)) {
-    segment->flags &=
-        (loom_amdgpu_source_alloca_layout_segment_flags_t)~LOOM_AMDGPU_SOURCE_ALLOCA_LAYOUT_SEGMENT_VALID;
-    return;
-  }
-  segment->byte_size = next_segment_byte_size;
+  return loom_amdgpu_source_alloca_layout_append_slot(
+      layout, segment, memory_space, alloca_op, root_value_id, byte_length,
+      byte_alignment);
 }
 
 static iree_status_t loom_amdgpu_source_alloca_layout_initialize(
-    const loom_value_fact_table_t* fact_table,
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
     const loom_local_value_domain_t* value_domain,
     iree_arena_allocator_t* arena, loom_func_like_t source_function,
     loom_amdgpu_source_alloca_layout_t* layout) {
   layout->value_domain = value_domain;
+  layout->module = module;
   layout->fact_table = fact_table;
+  layout->arena = arena;
   layout->source_function_op = source_function.op;
   layout->entries = NULL;
   layout->entry_count = value_domain != NULL ? value_domain->value_count : 0;
@@ -171,10 +428,12 @@ static iree_status_t loom_amdgpu_source_alloca_layout_initialize(
   }
 
   for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(layout->segments); ++i) {
-    layout->segments[i] = (loom_amdgpu_source_alloca_layout_segment_t){
-        .flags = LOOM_AMDGPU_SOURCE_ALLOCA_LAYOUT_SEGMENT_VALID,
-    };
+    layout->segments[i] = (loom_amdgpu_source_alloca_layout_segment_t){0};
   }
+  IREE_RETURN_IF_ERROR(
+      loom_amdgpu_source_alloca_layout_initialize_footprints(layout));
+  loom_control_uniformity_info_initialize(module, fact_table, arena,
+                                          &layout->control_uniformity);
   layout->flags = LOOM_AMDGPU_SOURCE_ALLOCA_LAYOUT_INITIALIZED;
   return iree_ok_status();
 }
@@ -185,14 +444,14 @@ loom_amdgpu_source_alloca_layout_empty(void) {
 }
 
 static iree_status_t loom_amdgpu_source_alloca_layout_initialize_for_inputs(
-    const loom_value_fact_table_t* fact_table,
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
     const loom_local_value_domain_t* value_domain,
     iree_arena_allocator_t* arena, loom_func_like_t source_function,
     loom_amdgpu_source_alloca_layout_t* layout) {
   if (!loom_amdgpu_source_alloca_layout_matches(
-          layout, fact_table, value_domain, source_function)) {
+          layout, module, fact_table, value_domain, source_function)) {
     IREE_RETURN_IF_ERROR(loom_amdgpu_source_alloca_layout_initialize(
-        fact_table, value_domain, arena, source_function, layout));
+        module, fact_table, value_domain, arena, source_function, layout));
   }
   return iree_ok_status();
 }
@@ -212,23 +471,65 @@ iree_status_t loom_amdgpu_source_alloca_layout_for_lower_context(
   const loom_func_like_t source_function =
       loom_low_lower_context_source_function(context);
   IREE_RETURN_IF_ERROR(loom_amdgpu_source_alloca_layout_initialize_for_inputs(
-      fact_table, value_domain, loom_low_lower_context_scratch_arena(context),
-      source_function, layout));
+      loom_low_lower_context_module(context), fact_table, value_domain,
+      loom_low_lower_context_scratch_arena(context), source_function, layout));
   *out_layout = layout;
   return iree_ok_status();
 }
 
 iree_status_t loom_amdgpu_source_alloca_layout_record_lower_alloca(
-    loom_low_lower_context_t* context,
-    loom_value_fact_memory_space_t memory_space, loom_value_id_t root_value_id,
-    uint64_t byte_length, uint64_t byte_alignment) {
+    loom_low_lower_context_t* context, const loom_op_t* alloca_op,
+    uint64_t byte_length) {
   const loom_amdgpu_source_alloca_layout_t* const_layout = NULL;
   IREE_RETURN_IF_ERROR(loom_amdgpu_source_alloca_layout_for_lower_context(
       context, &const_layout));
   loom_amdgpu_source_alloca_layout_t* layout =
       (loom_amdgpu_source_alloca_layout_t*)const_layout;
-  loom_amdgpu_source_alloca_layout_record_allocation(
-      layout, memory_space, root_value_id, byte_length, byte_alignment);
+  return loom_amdgpu_source_alloca_layout_record_allocation(layout, alloca_op,
+                                                            byte_length);
+}
+
+static bool loom_amdgpu_source_alloca_layout_storage_space(
+    loom_value_fact_memory_space_t memory_space,
+    loom_storage_space_t* out_storage_space) {
+  switch (memory_space) {
+    case LOOM_VALUE_FACT_MEMORY_SPACE_PRIVATE:
+      *out_storage_space = LOOM_STORAGE_SPACE_PRIVATE;
+      return true;
+    case LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP:
+      *out_storage_space = LOOM_STORAGE_SPACE_WORKGROUP;
+      return true;
+    default:
+      return false;
+  }
+}
+
+iree_status_t loom_amdgpu_source_alloca_layout_emit_low_storage_roots(
+    loom_low_lower_context_t* context) {
+  const loom_amdgpu_source_alloca_layout_t* const_layout = NULL;
+  IREE_RETURN_IF_ERROR(loom_amdgpu_source_alloca_layout_for_lower_context(
+      context, &const_layout));
+  loom_amdgpu_source_alloca_layout_t* layout =
+      (loom_amdgpu_source_alloca_layout_t*)const_layout;
+  loom_builder_t* builder = loom_low_lower_context_builder(context);
+  for (uint32_t i = 0; i < IREE_ARRAYSIZE(layout->segments); ++i) {
+    loom_amdgpu_source_alloca_layout_segment_t* segment = &layout->segments[i];
+    loom_storage_space_t storage_space = LOOM_STORAGE_SPACE_STACK;
+    if (!loom_amdgpu_source_alloca_layout_storage_space(
+            (loom_value_fact_memory_space_t)i, &storage_space)) {
+      continue;
+    }
+    for (iree_host_size_t j = 0; j < segment->slot_count; ++j) {
+      loom_amdgpu_source_alloca_layout_slot_t* slot = &segment->slots[j];
+      IREE_ASSERT_EQ(slot->low_storage_value_id, LOOM_VALUE_ID_INVALID);
+      loom_op_t* storage_op = NULL;
+      IREE_RETURN_IF_ERROR(loom_low_storage_reserve_build(
+          builder, (int64_t)slot->byte_size, (int64_t)slot->byte_alignment,
+          loom_type_storage(storage_space),
+          layout->source_function_op->location, &storage_op));
+      slot->low_storage_value_id = loom_low_storage_reserve_storage(storage_op);
+    }
+  }
   return iree_ok_status();
 }
 
@@ -245,7 +546,8 @@ iree_status_t loom_amdgpu_source_alloca_layout_for_low_legality(
   const loom_func_like_t source_function =
       loom_target_low_legality_function(context);
   IREE_RETURN_IF_ERROR(loom_amdgpu_source_alloca_layout_initialize_for_inputs(
-      fact_table, loom_target_low_legality_value_domain(context),
+      loom_target_low_legality_module(context), fact_table,
+      loom_target_low_legality_value_domain(context),
       loom_target_low_legality_scratch_arena(context), source_function,
       layout));
   *out_layout = layout;
@@ -253,17 +555,15 @@ iree_status_t loom_amdgpu_source_alloca_layout_for_low_legality(
 }
 
 iree_status_t loom_amdgpu_source_alloca_layout_record_low_legality_alloca(
-    loom_target_low_legality_context_t* context,
-    loom_value_fact_memory_space_t memory_space, loom_value_id_t root_value_id,
-    uint64_t byte_length, uint64_t byte_alignment) {
+    loom_target_low_legality_context_t* context, const loom_op_t* alloca_op,
+    uint64_t byte_length) {
   const loom_amdgpu_source_alloca_layout_t* const_layout = NULL;
   IREE_RETURN_IF_ERROR(loom_amdgpu_source_alloca_layout_for_low_legality(
       context, &const_layout));
   loom_amdgpu_source_alloca_layout_t* layout =
       (loom_amdgpu_source_alloca_layout_t*)const_layout;
-  loom_amdgpu_source_alloca_layout_record_allocation(
-      layout, memory_space, root_value_id, byte_length, byte_alignment);
-  return iree_ok_status();
+  return loom_amdgpu_source_alloca_layout_record_allocation(layout, alloca_op,
+                                                            byte_length);
 }
 
 bool loom_amdgpu_source_alloca_layout_lookup_root(
@@ -292,4 +592,26 @@ bool loom_amdgpu_source_alloca_layout_lookup_root(
   }
   *out_byte_offset = entry->byte_offset;
   return true;
+}
+
+void loom_amdgpu_source_alloca_layout_lookup_low_storage(
+    const loom_amdgpu_source_alloca_layout_t* layout,
+    loom_value_fact_memory_space_t memory_space, loom_value_id_t root_value_id,
+    loom_value_id_t* out_storage_value_id) {
+  IREE_ASSERT_ARGUMENT(out_storage_value_id);
+  IREE_ASSERT((uint32_t)memory_space < IREE_ARRAYSIZE(layout->segments));
+  const loom_value_ordinal_t value_ordinal =
+      loom_local_value_domain_ordinal(layout->value_domain, root_value_id);
+  const loom_amdgpu_source_alloca_layout_entry_t* entry =
+      &layout->entries[value_ordinal];
+  IREE_ASSERT(
+      iree_all_bits_set(entry->flags,
+                        LOOM_AMDGPU_SOURCE_ALLOCA_LAYOUT_ENTRY_HAS_OFFSET) &&
+      entry->memory_space == memory_space);
+  const loom_amdgpu_source_alloca_layout_segment_t* segment =
+      &layout->segments[memory_space];
+  IREE_ASSERT_LT(entry->slot_ordinal, segment->slot_count);
+  *out_storage_value_id =
+      segment->slots[entry->slot_ordinal].low_storage_value_id;
+  IREE_ASSERT_NE(*out_storage_value_id, LOOM_VALUE_ID_INVALID);
 }

--- a/loom/src/loom/target/arch/amdgpu/lower/support.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/support.c
@@ -2643,6 +2643,34 @@ static bool loom_amdgpu_source_vector_value_register_shape(
   return false;
 }
 
+static bool loom_amdgpu_source_buffer_value_register_shape(
+    const loom_value_fact_table_t* fact_table, loom_value_id_t source_value_id,
+    loom_type_t source_type, loom_amdgpu_register_shape_t* out_shape) {
+  if (!loom_type_is_buffer(source_type) || fact_table == NULL) return false;
+  const loom_value_facts_t facts =
+      loom_value_fact_table_lookup(fact_table, source_value_id);
+  if (loom_value_facts_is_lane_varying(facts)) return false;
+  loom_value_fact_buffer_reference_t reference = {0};
+  if (!loom_value_facts_query_buffer_reference(&fact_table->context, facts,
+                                               &reference)) {
+    return false;
+  }
+  switch (reference.memory_space) {
+    case LOOM_VALUE_FACT_MEMORY_SPACE_GLOBAL:
+    case LOOM_VALUE_FACT_MEMORY_SPACE_CONSTANT:
+    case LOOM_VALUE_FACT_MEMORY_SPACE_DESCRIPTOR:
+      *out_shape = loom_amdgpu_register_shape(LOOM_AMDGPU_REG_CLASS_ID_SGPR, 2);
+      return true;
+    case LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN:
+    case LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP:
+    case LOOM_VALUE_FACT_MEMORY_SPACE_PRIVATE:
+    case LOOM_VALUE_FACT_MEMORY_SPACE_HOST:
+    case LOOM_VALUE_FACT_MEMORY_SPACE_GENERIC:
+      return false;
+  }
+  return false;
+}
+
 static bool loom_amdgpu_source_value_register_shape_needs_analysis(
     loom_type_t source_type) {
   if (loom_type_is_scalar(source_type)) {
@@ -2665,7 +2693,9 @@ static bool loom_amdgpu_source_value_register_shape(
     loom_amdgpu_source_value_analysis_t* analysis,
     loom_value_id_t source_value_id, loom_type_t source_type,
     loom_amdgpu_register_shape_t* out_shape) {
-  return loom_amdgpu_source_scalar_value_register_shape(
+  return loom_amdgpu_source_buffer_value_register_shape(
+             fact_table, source_value_id, source_type, out_shape) ||
+         loom_amdgpu_source_scalar_value_register_shape(
              module, fact_table, view_regions, analysis, source_value_id,
              source_type, out_shape) ||
          loom_amdgpu_source_vector_value_register_shape(

--- a/loom/src/loom/target/arch/amdgpu/lower/support.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/support.c
@@ -1665,6 +1665,19 @@ static bool loom_amdgpu_i1_use_is_control_condition(
                                   LOOM_OPERAND_ROLE_CONTROL_CONDITION);
 }
 
+static bool loom_amdgpu_i1_use_is_condition_operand(
+    const loom_module_t* module, const loom_op_t* user_op,
+    uint16_t operand_index, loom_value_id_t source_value_id) {
+  if (operand_index >= user_op->operand_count ||
+      loom_op_const_operands(user_op)[operand_index] != source_value_id) {
+    return false;
+  }
+  const loom_operand_role_t role =
+      loom_op_operand_role(module, user_op, operand_index);
+  return role == LOOM_OPERAND_ROLE_CONTROL_CONDITION ||
+         role == LOOM_OPERAND_ROLE_SELECT_CONDITION;
+}
+
 static bool loom_amdgpu_source_i1_value_has_cross_block_use(
     const loom_module_t* module, loom_value_id_t source_value_id) {
   if (source_value_id >= module->values.count ||
@@ -2106,6 +2119,105 @@ static bool loom_amdgpu_source_i1_value_has_same_block_branch_and_mask_use(
   return false;
 }
 
+static bool loom_amdgpu_source_value_is_later_same_block_scc_i1(
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    const loom_view_region_table_t* view_regions,
+    loom_amdgpu_source_value_analysis_t* analysis, const loom_op_t* defining_op,
+    loom_value_id_t candidate_value_id) {
+  if (candidate_value_id >= module->values.count ||
+      !loom_amdgpu_type_is_i1(
+          loom_module_value_type(module, candidate_value_id))) {
+    return false;
+  }
+  const loom_value_t* candidate_value =
+      loom_module_value(module, candidate_value_id);
+  if (loom_value_is_block_arg(candidate_value)) {
+    return false;
+  }
+  const loom_op_t* candidate_defining_op = loom_value_def_op(candidate_value);
+  return candidate_defining_op != NULL &&
+         candidate_defining_op->parent_block == defining_op->parent_block &&
+         candidate_defining_op->block_ordinal > defining_op->block_ordinal &&
+         loom_amdgpu_analyzed_source_value_can_lower_as_scc_i1(
+             module, fact_table, view_regions, analysis, candidate_value_id);
+}
+
+// Returns true when an operand is a later scalar condition or was produced by
+// a control operation with a later scalar condition. The latter recognizes
+// nested selects without depending on a particular source dialect.
+static bool loom_amdgpu_source_operand_has_later_scc_i1_condition(
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    const loom_view_region_table_t* view_regions,
+    loom_amdgpu_source_value_analysis_t* analysis, const loom_op_t* defining_op,
+    loom_value_id_t operand_value_id) {
+  if (loom_amdgpu_source_value_is_later_same_block_scc_i1(
+          module, fact_table, view_regions, analysis, defining_op,
+          operand_value_id)) {
+    return true;
+  }
+  const loom_value_t* operand_value =
+      loom_module_value(module, operand_value_id);
+  if (loom_value_is_block_arg(operand_value)) {
+    return false;
+  }
+  const loom_op_t* operand_defining_op = loom_value_def_op(operand_value);
+  if (operand_defining_op == NULL ||
+      operand_defining_op->parent_block != defining_op->parent_block) {
+    return false;
+  }
+  const loom_value_id_t* operands = loom_op_const_operands(operand_defining_op);
+  for (uint16_t i = 0; i < operand_defining_op->operand_count; ++i) {
+    if (loom_amdgpu_i1_use_is_condition_operand(module, operand_defining_op, i,
+                                                operands[i]) &&
+        loom_amdgpu_source_value_is_later_same_block_scc_i1(
+            module, fact_table, view_regions, analysis, defining_op,
+            operands[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// SCC is ephemeral architectural state. A control condition that precedes a
+// later condition needed by its payload cannot remain in SCC: low scheduling
+// must materialize the payload before consuming the outer condition. Retaining
+// the outer condition in an SGPR prevents source order from imposing a state
+// dependency cycle.
+static bool loom_amdgpu_source_i1_value_has_nested_control_dependency(
+    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
+    const loom_view_region_table_t* view_regions,
+    loom_amdgpu_source_value_analysis_t* analysis,
+    loom_value_id_t source_value_id) {
+  const loom_value_t* source_value = loom_module_value(module, source_value_id);
+  if (loom_value_is_block_arg(source_value)) {
+    return false;
+  }
+  const loom_op_t* defining_op = loom_value_def_op(source_value);
+  if (defining_op == NULL || defining_op->parent_block == NULL) {
+    return false;
+  }
+  const loom_use_t* use = NULL;
+  loom_value_for_each_use(source_value, use) {
+    const loom_op_t* user_op = loom_use_user_op(*use);
+    const uint16_t condition_operand_index = loom_use_operand_index(*use);
+    if (user_op == NULL || user_op->parent_block != defining_op->parent_block ||
+        !loom_amdgpu_i1_use_is_condition_operand(
+            module, user_op, condition_operand_index, source_value_id)) {
+      continue;
+    }
+    const loom_value_id_t* operands = loom_op_const_operands(user_op);
+    for (uint16_t i = 0; i < user_op->operand_count; ++i) {
+      if (i != condition_operand_index &&
+          loom_amdgpu_source_operand_has_later_scc_i1_condition(
+              module, fact_table, view_regions, analysis, defining_op,
+              operands[i])) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 static bool loom_amdgpu_source_value_is_durable_i1_bool(
     const loom_module_t* module, const loom_value_fact_table_t* fact_table,
     const loom_view_region_table_t* view_regions,
@@ -2114,6 +2226,8 @@ static bool loom_amdgpu_source_value_is_durable_i1_bool(
   return (loom_amdgpu_source_i1_value_has_cross_block_use(module,
                                                           source_value_id) ||
           loom_amdgpu_source_i1_value_has_same_block_branch_and_mask_use(
+              module, fact_table, view_regions, analysis, source_value_id) ||
+          loom_amdgpu_source_i1_value_has_nested_control_dependency(
               module, fact_table, view_regions, analysis, source_value_id)) &&
          loom_amdgpu_analyzed_source_value_can_lower_as_sgpr_i1_bool(
              module, fact_table, view_regions, analysis, source_value_id);

--- a/loom/src/loom/target/arch/amdgpu/lower/topology.h
+++ b/loom/src/loom/target/arch/amdgpu/lower/topology.h
@@ -43,9 +43,15 @@ iree_status_t loom_amdgpu_source_alloca_layout_for_lower_context(
 // Source-to-low planning calls this while visiting buffer.alloca ops, so later
 // selectors can resolve allocation roots without scanning source IR.
 iree_status_t loom_amdgpu_source_alloca_layout_record_lower_alloca(
-    loom_low_lower_context_t* context,
-    loom_value_fact_memory_space_t memory_space, loom_value_id_t root_value_id,
-    uint64_t byte_length, uint64_t byte_alignment);
+    loom_low_lower_context_t* context, const loom_op_t* alloca_op,
+    uint64_t byte_length);
+
+// Emits one physical low-storage root for each planned source-allocation slot.
+// Mutually exclusive logical allocations share a slot and therefore share its
+// root. Source allocation plans are complete before entry setup, so each root
+// carries the final maximum capacity and alignment of its occupants.
+iree_status_t loom_amdgpu_source_alloca_layout_emit_low_storage_roots(
+    loom_low_lower_context_t* context);
 
 // Returns the function-local source allocation layout analysis for low-legality
 // verification. The returned object is allocated from the legality context's
@@ -58,9 +64,8 @@ iree_status_t loom_amdgpu_source_alloca_layout_for_low_legality(
 // verification calls this while visiting buffer.alloca ops, so later provider
 // checks can resolve allocation roots without scanning source IR.
 iree_status_t loom_amdgpu_source_alloca_layout_record_low_legality_alloca(
-    loom_target_low_legality_context_t* context,
-    loom_value_fact_memory_space_t memory_space, loom_value_id_t root_value_id,
-    uint64_t byte_length, uint64_t byte_alignment);
+    loom_target_low_legality_context_t* context, const loom_op_t* alloca_op,
+    uint64_t byte_length);
 
 // Resolves the analyzed storage base for a source buffer.alloca root in the
 // requested memory space. Returns false when the analysis cannot prove the root
@@ -69,6 +74,15 @@ bool loom_amdgpu_source_alloca_layout_lookup_root(
     const loom_amdgpu_source_alloca_layout_t* layout,
     loom_value_fact_memory_space_t memory_space, loom_value_id_t root_value_id,
     uint64_t* out_byte_offset);
+
+// Resolves the emitted physical low-storage root for a planned source
+// allocation. Entry setup must have emitted the roots before this is called
+// during body lowering. Packet planning separately consumes the allocation's
+// analyzed suballocation offset through lookup_root.
+void loom_amdgpu_source_alloca_layout_lookup_low_storage(
+    const loom_amdgpu_source_alloca_layout_t* layout,
+    loom_value_fact_memory_space_t memory_space, loom_value_id_t root_value_id,
+    loom_value_id_t* out_storage_value_id);
 
 // Returns the exact wavefront size selected by the active target bundle.
 uint32_t loom_amdgpu_target_wavefront_size(const loom_target_bundle_t* bundle);

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_addtid.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_addtid.loom-test
@@ -122,10 +122,10 @@ kernel.def target(@target) @workgroup_memory_scalar_loop_index_b32() {
 
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(8, 1, 1) workgroup_count(1, 1, 1) @workgroup_memory_scalar_loop_index_b32() asm {
+  %17 = storage {byte_alignment = 16, byte_length = 32} : low.storage<workgroup>
   %zero_index = s_mov_b32 0
   %eight = s_mov_b32 8
   %one_index = s_mov_b32 1
-  %20 = storage {byte_alignment = 16, byte_length = 32} : low.storage<workgroup>
   %one = v_mov_b32 1
   low.br ^_bb1(%zero_index: reg<amdgpu.sgpr>)
 ^_bb1(%i: reg<amdgpu.sgpr>):
@@ -205,7 +205,7 @@ kernel.def target(@target) @wave_sized_workgroup_memory_second_allocation_b32() 
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @wave_sized_workgroup_memory_second_allocation_b32() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %13 = storage {byte_alignment = 16, byte_length = 128} : low.storage<workgroup>
-  %15 = storage {byte_alignment = 16, byte_length = 128} : low.storage<workgroup>
+  %14 = storage {byte_alignment = 16, byte_length = 128} : low.storage<workgroup>
   %one = v_mov_b32 1
   %two = v_mov_b32 2
   %19 = v_lshlrev_b32_src0_inline %lane, 2
@@ -386,10 +386,10 @@ kernel.def target(@target) @wave_sized_workgroup_memory_select_scaled_lane_b32()
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @wave_sized_workgroup_memory_select_scaled_lane_b32() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
+  %17 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
   %scaled_lane = v_lshlrev_b32_lit %lane, 1
   %inside = v_cmp_lt_u32_src1_inline %lane {rhs = 16}
   %element_index = v_cndmask_b32 %scaled_lane, %lane, %inside
-  %20 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
   %one = v_mov_b32 1
   %23 = v_lshlrev_b32_src0_inline %element_index, 2
   low.op<amdgpu.ds_write_b32>(%23, %one) {offset = 0} memory_access([0, 3, 10, -1, 43, 4, 0, 4, 3, 0, 248, 4, 252]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_addtid_topology.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_addtid_topology.loom-test
@@ -120,10 +120,10 @@ kernel.def target(@target) @multidim_workgroup_memory_workitem_xy_b32() {
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(8, 8, 1) workgroup_count(1, 1, 1) @multidim_workgroup_memory_workitem_xy_b32() asm {
   %packed_tid = live_in<amdgpu.workitem_id.packed.xy> : reg<amdgpu.vgpr>
+  %19 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
   %column = v_and_b32_lit %packed_tid, 1023
-  %20 = v_lshrrev_b32_src0_inline %packed_tid, 10
-  %row = v_and_b32_lit %20, 1023
-  %22 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
+  %21 = v_lshrrev_b32_src0_inline %packed_tid, 10
+  %row = v_and_b32_lit %21, 1023
   %one = v_mov_b32 1
   %25 = v_lshl_add_u32_shift_imm %row, %column, 3
   %26 = v_lshlrev_b32_src0_inline %25, 2

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_branch_exclusive_workgroup_storage.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_branch_exclusive_workgroup_storage.loom-test
@@ -1,0 +1,375 @@
+// RUN: emit source-low output=low
+
+amdgpu.target<gfx11-generic> @target
+
+// Workgroup-uniform alternatives share one physical slot.
+kernel.def target(@target) @branch_exclusive_equal_slots() {
+  %one = index.constant 1 : index
+  %two = index.constant 2 : index
+  kernel.launch.config workgroups(%two, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch(%output: buffer) {
+  %workgroup = kernel.workgroup.id<x> : index
+  %zero = index.constant 0 : index
+  %zero_offset = index.constant 0 : offset
+  %bytes = index.constant 256 : offset
+  %value = scalar.constant 1 : i32
+  %is_first = index.cmp eq, %workgroup, %zero : index
+  %output_view = buffer.view %output[%zero_offset] : buffer -> view<2xi32, #dense>
+  cfg.cond_br %is_first, ^first, ^second
+^first:
+  %first_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  cfg.br ^first_body
+^first_body:
+  %first_view = buffer.view %first_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  view.store %value, %first_view[0] : i32, view<1xi32, #dense>
+  %first_result = view.load %first_view[0] : view<1xi32, #dense> -> i32
+  view.store %first_result, %output_view[%workgroup] : i32, view<2xi32, #dense>
+  cfg.br ^done
+^second:
+  %second_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  cfg.br ^second_body
+^second_body:
+  %second_view = buffer.view %second_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  view.store %value, %second_view[0] : i32, view<1xi32, #dense>
+  %second_result = view.load %second_view[0] : view<1xi32, #dense> -> i32
+  view.store %second_result, %output_view[%workgroup] : i32, view<2xi32, #dense>
+  cfg.br ^done
+^done:
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(2, 1, 1) @branch_exclusive_equal_slots() asm {
+  %workgroup = live_in<amdgpu.workgroup_id.x> : reg<amdgpu.sgpr>
+  %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 8} : reg<amdgpu.sgpr x2>
+  %18 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
+  %zero = s_mov_b32 0
+  %is_first = s_cmp_eq_i32 %workgroup, %zero
+  low.cond_br %is_first, ^first, ^second : reg<amdgpu.scc>
+^first:
+  %23 = v_mov_b32 1
+  %24 = v_mov_b32 0
+  low.op<amdgpu.ds_write_b32>(%24, %23) {offset = 0} memory_access([0, 3, 10, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  %first_result = low.op<amdgpu.ds_read_b32>(%24) {offset = 0} memory_access([0, 3, 10, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
+  %28 = s_lshl_b32_rhs_inline %workgroup, 2
+  %29 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %30 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %32 = s_add_u32 %29, %28
+  %33 = s_addc_u32 %30, %zero
+  %34 = concat(%32, %33) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  global_store_b32_saddr %24, %first_result, %34
+  low.br ^done
+^second:
+  %36 = v_mov_b32 1
+  %37 = v_mov_b32 0
+  low.op<amdgpu.ds_write_b32>(%37, %36) {offset = 0} memory_access([0, 3, 13, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  %second_result = low.op<amdgpu.ds_read_b32>(%37) {offset = 0} memory_access([0, 3, 13, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
+  %41 = s_lshl_b32_rhs_inline %workgroup, 2
+  %42 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %43 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %45 = s_add_u32 %42, %41
+  %46 = s_addc_u32 %43, %zero
+  %47 = concat(%45, %46) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  global_store_b32_saddr %37, %second_result, %47
+  low.br ^done
+^done:
+  return
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
+
+// Nested alternatives grow their shared tail slot to the maximum aligned arm.
+kernel.def target(@target) @branch_exclusive_nested_max_slot() {
+  %one = index.constant 1 : index
+  %three = index.constant 3 : index
+  kernel.launch.config workgroups(%three, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch(%output: buffer) {
+  %workgroup = kernel.workgroup.id<x> : index
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %zero_offset = index.constant 0 : offset
+  %small_bytes = index.constant 128 : offset
+  %large_bytes = index.constant 256 : offset
+  %medium_bytes = index.constant 192 : offset
+  %value = scalar.constant 1 : i32
+  %is_first = index.cmp eq, %workgroup, %zero : index
+  %is_second = index.cmp eq, %workgroup, %one : index
+  %output_view = buffer.view %output[%zero_offset] : buffer -> view<3xi32, #dense>
+  cfg.cond_br %is_first, ^first, ^not_first
+^first:
+  %first_scratch = buffer.alloca %small_bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %first_view = buffer.view %first_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  view.store %value, %first_view[0] : i32, view<1xi32, #dense>
+  %first_result = view.load %first_view[0] : view<1xi32, #dense> -> i32
+  view.store %first_result, %output_view[%workgroup] : i32, view<3xi32, #dense>
+  cfg.br ^done
+^not_first:
+  cfg.cond_br %is_second, ^second, ^third
+^second:
+  %second_scratch = buffer.alloca %large_bytes {base_alignment = 64, memory_space = workgroup} : buffer
+  %second_view = buffer.view %second_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  view.store %value, %second_view[0] : i32, view<1xi32, #dense>
+  %second_result = view.load %second_view[0] : view<1xi32, #dense> -> i32
+  view.store %second_result, %output_view[%workgroup] : i32, view<3xi32, #dense>
+  cfg.br ^done
+^third:
+  %third_scratch = buffer.alloca %medium_bytes {base_alignment = 32, memory_space = workgroup} : buffer
+  %third_view = buffer.view %third_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  view.store %value, %third_view[0] : i32, view<1xi32, #dense>
+  %third_result = view.load %third_view[0] : view<1xi32, #dense> -> i32
+  view.store %third_result, %output_view[%workgroup] : i32, view<3xi32, #dense>
+  cfg.br ^done
+^done:
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(3, 1, 1) @branch_exclusive_nested_max_slot() asm {
+  %workgroup = live_in<amdgpu.workgroup_id.x> : reg<amdgpu.sgpr>
+  %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 12} : reg<amdgpu.sgpr x2>
+  %25 = storage {byte_alignment = 64, byte_length = 256} : low.storage<workgroup>
+  %zero = s_mov_b32 0
+  %one = s_mov_b32 1
+  %is_first = s_cmp_eq_i32 %workgroup, %zero
+  low.cond_br %is_first, ^first, ^not_first : reg<amdgpu.scc>
+^first:
+  %31 = v_mov_b32 1
+  %32 = v_mov_b32 0
+  low.op<amdgpu.ds_write_b32>(%32, %31) {offset = 0} memory_access([0, 3, 14, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  %first_result = low.op<amdgpu.ds_read_b32>(%32) {offset = 0} memory_access([0, 3, 14, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
+  %36 = s_lshl_b32_rhs_inline %workgroup, 2
+  %37 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %38 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %40 = s_add_u32 %37, %36
+  %41 = s_addc_u32 %38, %zero
+  %42 = concat(%40, %41) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  global_store_b32_saddr %32, %first_result, %42
+  low.br ^done
+^not_first:
+  %is_second = s_cmp_eq_i32 %workgroup, %one
+  low.cond_br %is_second, ^second, ^third : reg<amdgpu.scc>
+^second:
+  %45 = v_mov_b32 1
+  %46 = v_mov_b32 0
+  low.op<amdgpu.ds_write_b32>(%46, %45) {offset = 0} memory_access([0, 3, 17, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  %second_result = low.op<amdgpu.ds_read_b32>(%46) {offset = 0} memory_access([0, 3, 17, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
+  %50 = s_lshl_b32_rhs_inline %workgroup, 2
+  %51 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %52 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %54 = s_add_u32 %51, %50
+  %55 = s_addc_u32 %52, %zero
+  %56 = concat(%54, %55) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  global_store_b32_saddr %46, %second_result, %56
+  low.br ^done
+^third:
+  %58 = v_mov_b32 1
+  %59 = v_mov_b32 0
+  low.op<amdgpu.ds_write_b32>(%59, %58) {offset = 0} memory_access([0, 3, 20, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  %third_result = low.op<amdgpu.ds_read_b32>(%59) {offset = 0} memory_access([0, 3, 20, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
+  %63 = s_lshl_b32_rhs_inline %workgroup, 2
+  %64 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %65 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %67 = s_add_u32 %64, %63
+  %68 = s_addc_u32 %65, %zero
+  %69 = concat(%67, %68) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  global_store_b32_saddr %59, %third_result, %69
+  low.br ^done
+^done:
+  return
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
+
+// Lane-varying alternatives require distinct workgroup slots.
+kernel.def target(@target) @lane_varying_branches_remain_distinct() {
+  %one = index.constant 1 : index
+  %two = index.constant 2 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%two, %one, %one) : index
+} launch(%output: buffer) {
+  %lane = kernel.workitem.id<x> : index
+  %zero = index.constant 0 : index
+  %zero_offset = index.constant 0 : offset
+  %bytes = index.constant 256 : offset
+  %value = scalar.constant 1 : i32
+  %is_first = index.cmp eq, %lane, %zero : index
+  %output_view = buffer.view %output[%zero_offset] : buffer -> view<2xi32, #dense>
+  cfg.cond_br %is_first, ^first, ^second
+^first:
+  %first_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %first_view = buffer.view %first_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  view.store %value, %first_view[0] : i32, view<1xi32, #dense>
+  %first_result = view.load %first_view[0] : view<1xi32, #dense> -> i32
+  view.store %first_result, %output_view[%lane] : i32, view<2xi32, #dense>
+  cfg.br ^done
+^second:
+  %second_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %second_view = buffer.view %second_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  view.store %value, %second_view[0] : i32, view<1xi32, #dense>
+  %second_result = view.load %second_view[0] : view<1xi32, #dense> -> i32
+  view.store %second_result, %output_view[%lane] : i32, view<2xi32, #dense>
+  cfg.br ^done
+^done:
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(2, 1, 1) workgroup_count(1, 1, 1) @lane_varying_branches_remain_distinct() asm {
+  %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
+  %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 8} : reg<amdgpu.sgpr x2>
+  %18 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
+  %19 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
+  %is_first = v_cmp_eq_i32_src1_inline %lane {rhs = 0}
+  %22, %23 = s_and_saveexec_b64 %is_first
+  low.cond_br %23, ^first, ^_bb3 : reg<amdgpu.scc>
+^first:
+  %26 = v_mov_b32 1
+  %27 = v_mov_b32 0
+  low.op<amdgpu.ds_write_b32>(%27, %26) {offset = 0} memory_access([0, 3, 10, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  %first_result = low.op<amdgpu.ds_read_b32>(%27) {offset = 0} memory_access([0, 3, 10, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
+  %30 = v_lshlrev_b32_src0_inline %lane, 2
+  global_store_b32_saddr %30, %first_result, %output_view
+  low.br ^_bb3
+^second:
+  %32 = v_mov_b32 1
+  %33 = v_mov_b32 0
+  low.op<amdgpu.ds_write_b32>(%33, %32) {offset = 256} memory_access([0, 3, 13, -1, 11, 0, 0, 0, 3, 256, 256, 260, 260]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  %second_result = low.op<amdgpu.ds_read_b32>(%33) {offset = 256} memory_access([0, 3, 13, -1, 11, 0, 0, 0, 3, 256, 256, 260, 260]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
+  %36 = v_lshlrev_b32_src0_inline %lane, 2
+  global_store_b32_saddr %36, %second_result, %output_view
+  low.br ^_bb4
+^_bb3:
+  %24 = s_xor_b64_exec %22
+  low.cond_br %24, ^second, ^_bb4 : reg<amdgpu.scc>
+^_bb4:
+  s_mov_b64_exec %22
+  return
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
+
+// Same-path allocations remain distinct without an explicit lifetime end.
+kernel.def target(@target) @sequential_allocations_remain_distinct() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch(%output: buffer) {
+  %zero_offset = index.constant 0 : offset
+  %first_bytes = index.constant 128 : offset
+  %second_bytes = index.constant 256 : offset
+  %first_value = scalar.constant 1 : i32
+  %second_value = scalar.constant 2 : i32
+  %first_scratch = buffer.alloca %first_bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %second_scratch = buffer.alloca %second_bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %first_view = buffer.view %first_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  %second_view = buffer.view %second_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%zero_offset] : buffer -> view<2xi32, #dense>
+  view.store %first_value, %first_view[0] : i32, view<1xi32, #dense>
+  view.store %second_value, %second_view[0] : i32, view<1xi32, #dense>
+  %first_result = view.load %first_view[0] : view<1xi32, #dense> -> i32
+  %second_result = view.load %second_view[0] : view<1xi32, #dense> -> i32
+  view.store %first_result, %output_view[0] : i32, view<2xi32, #dense>
+  view.store %second_result, %output_view[1] : i32, view<2xi32, #dense>
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @sequential_allocations_remain_distinct() asm {
+  %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 8} : reg<amdgpu.sgpr x2>
+  %15 = storage {byte_alignment = 16, byte_length = 128} : low.storage<workgroup>
+  %16 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
+  %21 = v_mov_b32 1
+  %22 = v_mov_b32 0
+  low.op<amdgpu.ds_write_b32>(%22, %21) {offset = 0} memory_access([0, 3, 7, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  %23 = v_mov_b32 2
+  low.op<amdgpu.ds_write_b32>(%22, %23) {offset = 128} memory_access([0, 3, 8, -1, 11, 0, 0, 0, 3, 128, 128, 132, 132]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  %first_result = low.op<amdgpu.ds_read_b32>(%22) {offset = 0} memory_access([0, 3, 7, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
+  %second_result = low.op<amdgpu.ds_read_b32>(%22) {offset = 128} memory_access([0, 3, 8, -1, 11, 0, 0, 0, 3, 128, 128, 132, 132]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
+  global_store_b32_saddr %22, %first_result, %output_view
+  global_store_b32_saddr %22, %second_result, %output_view {offset = 4}
+  return
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
+
+// A cyclic controller may select both alternatives on different iterations.
+kernel.def target(@target) @cyclic_branch_allocations_remain_distinct() {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch(%output: buffer) {
+  %zero = scalar.constant 0 : i32
+  %one = scalar.constant 1 : i32
+  %two = scalar.constant 2 : i32
+  %zero_offset = index.constant 0 : offset
+  %bytes = index.constant 256 : offset
+  %value = scalar.constant 1 : i32
+  %output_view = buffer.view %output[%zero_offset] : buffer -> view<2xi32, #dense>
+  cfg.br ^loop(%zero: i32)
+^loop(%i: i32):
+  %in_range = scalar.cmpi ult, %i, %two : i32
+  cfg.cond_br %in_range, ^body, ^done
+^body:
+  %is_first = scalar.cmpi eq, %i, %zero : i32
+  cfg.cond_br %is_first, ^first, ^second
+^first:
+  %first_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %first_view = buffer.view %first_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  view.store %value, %first_view[0] : i32, view<1xi32, #dense>
+  %first_result = view.load %first_view[0] : view<1xi32, #dense> -> i32
+  view.store %first_result, %output_view[0] : i32, view<2xi32, #dense>
+  cfg.br ^continue
+^second:
+  %second_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %second_view = buffer.view %second_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  view.store %value, %second_view[0] : i32, view<1xi32, #dense>
+  %second_result = view.load %second_view[0] : view<1xi32, #dense> -> i32
+  view.store %second_result, %output_view[1] : i32, view<2xi32, #dense>
+  cfg.br ^continue
+^continue:
+  %next = scalar.addi %i, %one : i32
+  cfg.br ^loop(%next: i32)
+^done:
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @cyclic_branch_allocations_remain_distinct() asm {
+  %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 8} : reg<amdgpu.sgpr x2>
+  %21 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
+  %22 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
+  %zero = s_mov_b32 0
+  %one = s_mov_b32 1
+  %two = s_mov_b32 2
+  low.br ^loop(%zero: reg<amdgpu.sgpr>)
+^loop(%i: reg<amdgpu.sgpr>):
+  %in_range = s_cmp_lt_u32 %i, %two
+  low.cond_br %in_range, ^body, ^done : reg<amdgpu.scc>
+^body:
+  %is_first = s_cmp_eq_i32 %i, %zero
+  low.cond_br %is_first, ^first, ^second : reg<amdgpu.scc>
+^first:
+  %29 = v_mov_b32 1
+  %30 = v_mov_b32 0
+  low.op<amdgpu.ds_write_b32>(%30, %29) {offset = 0} memory_access([0, 3, 12, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  %first_result = low.op<amdgpu.ds_read_b32>(%30) {offset = 0} memory_access([0, 3, 12, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
+  global_store_b32_saddr %30, %first_result, %output_view
+  low.br ^continue
+^second:
+  %35 = v_mov_b32 1
+  %36 = v_mov_b32 0
+  low.op<amdgpu.ds_write_b32>(%36, %35) {offset = 256} memory_access([0, 3, 15, -1, 11, 0, 0, 0, 3, 256, 256, 260, 260]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  %second_result = low.op<amdgpu.ds_read_b32>(%36) {offset = 256} memory_access([0, 3, 15, -1, 11, 0, 0, 0, 3, 256, 256, 260, 260]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
+  global_store_b32_saddr %36, %second_result, %output_view {offset = 4}
+  low.br ^continue
+^continue:
+  %next = s_add_u32 %i, %one
+  low.br ^loop(%next: reg<amdgpu.sgpr>)
+^done:
+  return
+}

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_buffer_control_flow.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_buffer_control_flow.loom-test
@@ -1,0 +1,41 @@
+// RUN: emit source-low output=low
+
+// A workgroup-uniform choice between global buffer roots selects both halves of
+// the 64-bit address in SGPRs before using it as a scalar global-load base.
+amdgpu.target<gfx11-generic> @target
+
+kernel.def target(@target) @select_global_buffer(%select_rhs: index) {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch(%select_rhs: index, %lhs: buffer, %rhs: buffer, %output: buffer) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %zero_offset = index.constant 0 : offset
+  %use_rhs = index.cmp eq, %select_rhs, %one : index
+  %selected = scf.select %use_rhs, %rhs, %lhs : buffer
+  %selected_view = buffer.view %selected[%zero_offset] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xi32, #dense>
+  %selected_value = view.load %selected_view[%zero] : view<1xi32, #dense> -> i32
+  view.store %selected_value, %output_view[%zero] : i32, view<1xi32, #dense>
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @select_global_buffer(%select_rhs: reg<amdgpu.sgpr>) asm {
+  %lhs = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %rhs = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %output_view = resource<hal_binding> {index = 2, source_type = hal.buffer, extent = 4} : reg<amdgpu.sgpr x2>
+  %one = s_mov_b32 1
+  %use_rhs = s_cmp_eq_i32 %select_rhs, %one
+  %20 = slice %rhs[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %21 = slice %lhs[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %22 = s_cselect_b32 %20, %21, %use_rhs
+  %23 = slice %rhs[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %24 = slice %lhs[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %25 = s_cselect_b32 %23, %24, %use_rhs
+  %selected_view = concat(%22, %25) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %27 = v_mov_b32 0
+  %selected_value = global_load_b32_saddr %27, %selected_view
+  global_store_b32_saddr %27, %selected_value, %output_view
+  return
+}

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cluster_gfx1250.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cluster_gfx1250.loom-test
@@ -67,8 +67,8 @@ kernel.def target(@target) @cluster_gather_packet_widths() {
 low.kernel.def target<amdgpu.rdna4.gfx125x.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 2, 1) cluster_size(1, 2, 1) @cluster_gather_packet_widths() asm {
   %global = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 48} : reg<amdgpu.sgpr x2>
   %24 = storage {byte_alignment = 16, byte_length = 16} : low.storage<workgroup>
+  %25 = storage {byte_alignment = 16, byte_length = 16} : low.storage<workgroup>
   %26 = storage {byte_alignment = 16, byte_length = 16} : low.storage<workgroup>
-  %28 = storage {byte_alignment = 16, byte_length = 16} : low.storage<workgroup>
   %30 = v_mov_b32 0
   %32 = s_mov_b32_m0_imm 3
   low.op<amdgpu.cluster_load_async_to_lds_b8>(%30, %30, %global, %32) {offset = 0, scope = 0, th = 0} memory_access([0, 3, 13, -1, 11, 0, 0, 0, 3, 0, 0, 1, 1]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.sgpr x2>, reg<amdgpu.m0>)
@@ -160,10 +160,10 @@ kernel.def target(@target) @cluster_gather_two_stage_wait_depth() {
 low.kernel.def target<amdgpu.rdna4.gfx125x.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 2, 1) cluster_size(1, 2, 1) @cluster_gather_two_stage_wait_depth() asm {
   %global = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 16} : reg<amdgpu.sgpr x2>
   %27 = storage {byte_alignment = 16, byte_length = 16} : low.storage<workgroup>
+  %28 = storage {byte_alignment = 16, byte_length = 16} : low.storage<workgroup>
   %29 = storage {byte_alignment = 16, byte_length = 16} : low.storage<workgroup>
+  %30 = storage {byte_alignment = 16, byte_length = 16} : low.storage<workgroup>
   %31 = storage {byte_alignment = 16, byte_length = 16} : low.storage<workgroup>
-  %33 = storage {byte_alignment = 16, byte_length = 16} : low.storage<workgroup>
-  %35 = storage {byte_alignment = 16, byte_length = 16} : low.storage<workgroup>
   %37 = v_mov_b32 0
   %39 = s_mov_b32_m0_imm 3
   low.op<amdgpu.cluster_load_async_to_lds_b128>(%37, %37, %global, %39) {offset = 0, scope = 2, th = 0} memory_access([0, 3, 9, -1, 11, 0, 0, 0, 3, 0, 0, 16, 16]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.sgpr x2>, reg<amdgpu.m0>)
@@ -284,8 +284,8 @@ low.kernel.def target<amdgpu.rdna4.gfx125x.core>(@target) workgroup_size(64, 1, 
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %global_input = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
   %payload_view = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %28 = storage {byte_alignment = 16, byte_length = 1024} : low.storage<workgroup>
   %29 = storage {byte_alignment = 16, byte_length = 1024} : low.storage<workgroup>
-  %31 = storage {byte_alignment = 16, byte_length = 1024} : low.storage<workgroup>
   %33 = v_lshlrev_b32_src0_inline %lane, 4
   %35 = s_mov_b32_m0_imm 3
   low.op<amdgpu.cluster_load_async_to_lds_b128>(%33, %33, %global_input, %35) {offset = 0, scope = 2, th = 0} memory_access([0, 3, 16, -1, 43, 16, 0, 16, 3, 0, 1008, 16, 1024]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.sgpr x2>, reg<amdgpu.m0>)

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_index.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_index.loom-test
@@ -504,9 +504,9 @@ kernel.def target(@target) @workitem_y_lds_uses_explicit_vaddr() {
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 64, 1) workgroup_count(1, 1, 1) @workitem_y_lds_uses_explicit_vaddr() asm {
   %packed_tid = live_in<amdgpu.workitem_id.packed.xy> : reg<amdgpu.vgpr>
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
-  %13 = v_lshrrev_b32_src0_inline %packed_tid, 10
-  %row = v_and_b32_lit %13, 1023
-  %15 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
+  %13 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
+  %14 = v_lshrrev_b32_src0_inline %packed_tid, 10
+  %row = v_and_b32_lit %14, 1023
   %value = v_mov_b32 7
   %18 = v_lshlrev_b32_src0_inline %row, 2
   low.op<amdgpu.ds_write_b32>(%18, %value) {offset = 0} memory_access([0, 3, 6, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_index_amdgpu.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_index_amdgpu.loom-test
@@ -38,6 +38,24 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @index_u
 // ====
 
 amdgpu.target<gfx11-generic> @target
+func.def target(@target) @index_uniform_signed32_subtract(%value_i32: i32) -> (index) {
+  %value0 = index.cast %value_i32 : i32 to index
+  %value = index.assume %value0 [range(%value0, 1, 32768)] : index
+  %fifteen = index.constant 15 : index
+  %difference = index.sub %value, %fifteen : index
+  func.return %difference : index
+}
+
+// ----
+low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @index_uniform_signed32_subtract(%value: reg<amdgpu.sgpr>) -> (reg<amdgpu.sgpr>) asm {
+  %fifteen = s_mov_b32 15
+  %difference = s_sub_u32 %value, %fifteen
+  return %difference
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
 func.def target(@target) @index_uniform_madd(%row_i32: i32, %column_i32: i32) -> (index) {
   %row_index = index.cast %row_i32 : i32 to index
   %column_index = index.cast %column_i32 : i32 to index

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_diagnostics_classification.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_diagnostics_classification.loom-test
@@ -261,10 +261,10 @@ kernel.def target(@target) @multi_term_lds_address_fields() {
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(8, 4, 1) workgroup_count(1, 1, 1) @multi_term_lds_address_fields() asm {
   %packed_tid = live_in<amdgpu.workitem_id.packed.xy> : reg<amdgpu.vgpr>
+  %11 = storage {byte_alignment = 16, byte_length = 128} : low.storage<workgroup>
   %lane_x = v_and_b32_lit %packed_tid, 1023
-  %12 = v_lshrrev_b32_src0_inline %packed_tid, 10
-  %lane_y = v_and_b32_lit %12, 1023
-  %14 = storage {byte_alignment = 16, byte_length = 128} : low.storage<workgroup>
+  %13 = v_lshrrev_b32_src0_inline %packed_tid, 10
+  %lane_y = v_and_b32_lit %13, 1023
   %one = v_mov_b32 1
   %17 = v_lshl_add_u32_shift_imm %lane_x, %lane_y, 2
   %18 = v_lshlrev_b32_src0_inline %17, 2

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_private.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_private.loom-test
@@ -73,7 +73,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(2, 1, 1
   %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 8} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 16} : reg<amdgpu.sgpr x2>
   %23 = storage {byte_alignment = 4, byte_length = 8} : low.storage<private>
-  %25 = storage {byte_alignment = 8, byte_length = 16} : low.storage<private>
+  %24 = storage {byte_alignment = 8, byte_length = 16} : low.storage<private>
   %27 = v_mov_b32 0
   %lhs = global_load_b32_saddr %27, %input_view
   scratch_store_b32_vaddr %27, %lhs

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_report.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_report.loom-test
@@ -36,11 +36,11 @@ kernel.def target(@target) @report_static_lds_address_fields() {
 // ----
 COMPILE-REPORT: summary artifact=none status=OK function=- backend=- bundle=- export=- export_symbol=- config=- lowered=-
 COMPILE-REPORT: workload workgroup_size=1x1x1 flat_workgroup_size=1 workgroup_count=1x1x1 dispatch_workgroup_count=1 dispatch_workitem_count=1
-COMPILE-REPORT: source_low selected_ops=6 emitted_ops=5 rows=6
+COMPILE-REPORT: source_low selected_ops=6 emitted_ops=4 rows=6
 COMPILE-REPORT: source_low_memory roots=1 arguments=0 argument_packets=0 strategies=0 packets=1 loads=0 stores=1 scalar_packets=1 vector_packets=0 source_lanes=1 source_bytes=4 read_bytes=0 write_bytes=4 issued_read_bytes=0 issued_write_bytes=4 issued_read_unknown_widths=0 issued_write_unknown_widths=0 contiguous_vector_packets=0 strided_vector_packets=0 unknown_stride_vector_packets=0 exact_dynamic_packets=1 unknown_dynamic_packets=0 dynamic_packets=1 dynamic_source_bytes=4 dynamic_read_bytes=0 dynamic_write_bytes=4 dynamic_issued_read_bytes=0 dynamic_issued_write_bytes=4 dynamic_issued_read_unknown_widths=0 dynamic_issued_write_unknown_widths=0 dispatch_source_read_bytes=0 dispatch_source_write_bytes=4 dispatch_source_total_bytes=4 dispatch_issued_read_bytes=0 dispatch_issued_write_bytes=4 dispatch_issued_total_bytes=4 interval_envelope={packets:1,begin_min_bytes:0,end_max_bytes:4,byte_count:4} write_interval_envelope={packets:1,begin_min_bytes:0,end_max_bytes:4,byte_count:4}
 COMPILE-REPORT: source_low[0] function=report_static_lds_address_fields source_op=index.constant selection=plan emitted_ops=0
 COMPILE-REPORT: source_low[1] function=report_static_lds_address_fields source_op=index.constant selection=plan emitted_ops=0
-COMPILE-REPORT: source_low[2] function=report_static_lds_address_fields source_op=buffer.alloca selection=plan emitted_ops=2
+COMPILE-REPORT: source_low[2] function=report_static_lds_address_fields source_op=buffer.alloca selection=plan emitted_ops=1
 COMPILE-REPORT: source_low[3] function=report_static_lds_address_fields source_op=buffer.view selection=rule emitted_ops=0
 COMPILE-REPORT: source_low[4] function=report_static_lds_address_fields source_op=vector.constant selection=plan emitted_ops=1
 COMPILE-REPORT: source_low[5] function=report_static_lds_address_fields source_op=vector.store selection=plan emitted_ops=2
@@ -73,12 +73,12 @@ kernel.def target(@target) @report_lds_f16_subword_stride_fields() {
 // ----
 COMPILE-REPORT: summary artifact=none status=OK function=- backend=- bundle=- export=- export_symbol=- config=- lowered=-
 COMPILE-REPORT: workload workgroup_size=64x1x1 flat_workgroup_size=64 workgroup_count=1x1x1 dispatch_workgroup_count=1 dispatch_workitem_count=64
-COMPILE-REPORT: source_low selected_ops=11 emitted_ops=10 rows=11
+COMPILE-REPORT: source_low selected_ops=11 emitted_ops=9 rows=11
 COMPILE-REPORT: source_low_memory roots=3 arguments=2 argument_packets=2 strategies=0 packets=4 loads=2 stores=2 scalar_packets=0 vector_packets=4 source_lanes=8 source_bytes=16 read_bytes=8 write_bytes=8 issued_read_bytes=8 issued_write_bytes=8 issued_read_unknown_widths=0 issued_write_unknown_widths=0 contiguous_vector_packets=4 strided_vector_packets=0 unknown_stride_vector_packets=0 exact_dynamic_packets=4 unknown_dynamic_packets=0 dynamic_packets=4 dynamic_source_bytes=16 dynamic_read_bytes=8 dynamic_write_bytes=8 dynamic_issued_read_bytes=8 dynamic_issued_write_bytes=8 dynamic_issued_read_unknown_widths=0 dynamic_issued_write_unknown_widths=0 dispatch_source_read_bytes=512 dispatch_source_write_bytes=512 dispatch_source_total_bytes=1024 dispatch_issued_read_bytes=512 dispatch_issued_write_bytes=512 dispatch_issued_total_bytes=1024 interval_envelope={packets:4,begin_min_bytes:0,end_max_bytes:130,byte_count:130} read_interval_envelope={packets:2,begin_min_bytes:0,end_max_bytes:130,byte_count:130} write_interval_envelope={packets:2,begin_min_bytes:0,end_max_bytes:130,byte_count:130}
 COMPILE-REPORT: source_low[0] function=report_lds_f16_subword_stride_fields source_op=kernel.workitem.id selection=plan emitted_ops=0
 COMPILE-REPORT: source_low[1] function=report_lds_f16_subword_stride_fields source_op=index.constant selection=plan emitted_ops=0
 COMPILE-REPORT: source_low[2] function=report_lds_f16_subword_stride_fields source_op=index.constant selection=plan emitted_ops=0
-COMPILE-REPORT: source_low[3] function=report_lds_f16_subword_stride_fields source_op=buffer.alloca selection=plan emitted_ops=2
+COMPILE-REPORT: source_low[3] function=report_lds_f16_subword_stride_fields source_op=buffer.alloca selection=plan emitted_ops=1
 COMPILE-REPORT: source_low[4] function=report_lds_f16_subword_stride_fields source_op=buffer.view selection=rule emitted_ops=0
 COMPILE-REPORT: source_low[5] function=report_lds_f16_subword_stride_fields source_op=buffer.view selection=rule emitted_ops=0
 COMPILE-REPORT: source_low[6] function=report_lds_f16_subword_stride_fields source_op=buffer.view selection=rule emitted_ops=0
@@ -124,12 +124,12 @@ kernel.def target(@target) @report_lds_read2_write2_address_fields() {
 // ----
 COMPILE-REPORT: summary artifact=none status=OK function=- backend=- bundle=- export=- export_symbol=- config=- lowered=-
 COMPILE-REPORT: workload workgroup_size=64x1x1 flat_workgroup_size=64 workgroup_count=1x1x1 dispatch_workgroup_count=1 dispatch_workitem_count=64
-COMPILE-REPORT: source_low selected_ops=10 emitted_ops=13 rows=10
+COMPILE-REPORT: source_low selected_ops=10 emitted_ops=12 rows=10
 COMPILE-REPORT: source_low_memory roots=2 arguments=1 argument_packets=1 strategies=0 packets=3 loads=1 stores=2 scalar_packets=0 vector_packets=3 source_lanes=6 source_bytes=24 read_bytes=8 write_bytes=16 issued_read_bytes=8 issued_write_bytes=16 issued_read_unknown_widths=0 issued_write_unknown_widths=0 contiguous_vector_packets=1 strided_vector_packets=2 unknown_stride_vector_packets=0 exact_dynamic_packets=3 unknown_dynamic_packets=0 dynamic_packets=3 dynamic_source_bytes=24 dynamic_read_bytes=8 dynamic_write_bytes=16 dynamic_issued_read_bytes=8 dynamic_issued_write_bytes=16 dynamic_issued_read_unknown_widths=0 dynamic_issued_write_unknown_widths=0 dispatch_source_read_bytes=512 dispatch_source_write_bytes=1024 dispatch_source_total_bytes=1536 dispatch_issued_read_bytes=512 dispatch_issued_write_bytes=1024 dispatch_issued_total_bytes=1536 interval_envelope={packets:3,begin_min_bytes:0,end_max_bytes:2028,byte_count:2028} read_interval_envelope={packets:1,begin_min_bytes:0,end_max_bytes:2028,byte_count:2028} write_interval_envelope={packets:2,begin_min_bytes:0,end_max_bytes:2028,byte_count:2028}
 COMPILE-REPORT: source_low[0] function=report_lds_read2_write2_address_fields source_op=kernel.workitem.id selection=plan emitted_ops=0
 COMPILE-REPORT: source_low[1] function=report_lds_read2_write2_address_fields source_op=index.constant selection=plan emitted_ops=0
 COMPILE-REPORT: source_low[2] function=report_lds_read2_write2_address_fields source_op=index.constant selection=plan emitted_ops=0
-COMPILE-REPORT: source_low[3] function=report_lds_read2_write2_address_fields source_op=buffer.alloca selection=plan emitted_ops=2
+COMPILE-REPORT: source_low[3] function=report_lds_read2_write2_address_fields source_op=buffer.alloca selection=plan emitted_ops=1
 COMPILE-REPORT: source_low[4] function=report_lds_read2_write2_address_fields source_op=buffer.view selection=rule emitted_ops=0
 COMPILE-REPORT: source_low[5] function=report_lds_read2_write2_address_fields source_op=buffer.view selection=rule emitted_ops=0
 COMPILE-REPORT: source_low[6] function=report_lds_read2_write2_address_fields source_op=vector.constant selection=plan emitted_ops=3
@@ -171,12 +171,12 @@ kernel.def target(@target) @report_lds_b128_single_lane_extract() {
 // ----
 COMPILE-REPORT: summary artifact=none status=OK function=- backend=- bundle=- export=- export_symbol=- config=- lowered=-
 COMPILE-REPORT: workload workgroup_size=64x1x1 flat_workgroup_size=64 workgroup_count=1x1x1 dispatch_workgroup_count=1 dispatch_workitem_count=64
-COMPILE-REPORT: source_low selected_ops=12 emitted_ops=11 rows=12
+COMPILE-REPORT: source_low selected_ops=12 emitted_ops=10 rows=12
 COMPILE-REPORT: source_low_memory roots=3 arguments=2 argument_packets=2 strategies=0 packets=4 loads=2 stores=2 scalar_packets=1 vector_packets=3 source_lanes=13 source_bytes=52 read_bytes=32 write_bytes=20 issued_read_bytes=32 issued_write_bytes=20 issued_read_unknown_widths=0 issued_write_unknown_widths=0 contiguous_vector_packets=3 strided_vector_packets=0 unknown_stride_vector_packets=0 exact_dynamic_packets=4 unknown_dynamic_packets=0 dynamic_packets=4 dynamic_source_bytes=52 dynamic_read_bytes=32 dynamic_write_bytes=20 dynamic_issued_read_bytes=32 dynamic_issued_write_bytes=20 dynamic_issued_read_unknown_widths=0 dynamic_issued_write_unknown_widths=0 dispatch_source_read_bytes=2048 dispatch_source_write_bytes=1280 dispatch_source_total_bytes=3328 dispatch_issued_read_bytes=2048 dispatch_issued_write_bytes=1280 dispatch_issued_total_bytes=3328 interval_envelope={packets:4,begin_min_bytes:0,end_max_bytes:1024,byte_count:1024} read_interval_envelope={packets:2,begin_min_bytes:0,end_max_bytes:1024,byte_count:1024} write_interval_envelope={packets:2,begin_min_bytes:0,end_max_bytes:1024,byte_count:1024}
 COMPILE-REPORT: source_low[0] function=report_lds_b128_single_lane_extract source_op=kernel.workitem.id selection=plan emitted_ops=0
 COMPILE-REPORT: source_low[1] function=report_lds_b128_single_lane_extract source_op=index.constant selection=plan emitted_ops=0
 COMPILE-REPORT: source_low[2] function=report_lds_b128_single_lane_extract source_op=index.constant selection=plan emitted_ops=0
-COMPILE-REPORT: source_low[3] function=report_lds_b128_single_lane_extract source_op=buffer.alloca selection=plan emitted_ops=2
+COMPILE-REPORT: source_low[3] function=report_lds_b128_single_lane_extract source_op=buffer.alloca selection=plan emitted_ops=1
 COMPILE-REPORT: source_low[4] function=report_lds_b128_single_lane_extract source_op=buffer.view selection=rule emitted_ops=0
 COMPILE-REPORT: source_low[5] function=report_lds_b128_single_lane_extract source_op=buffer.view selection=rule emitted_ops=0
 COMPILE-REPORT: source_low[6] function=report_lds_b128_single_lane_extract source_op=buffer.view selection=rule emitted_ops=0

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_workgroup_atomic.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_workgroup_atomic.loom-test
@@ -50,11 +50,11 @@ kernel.def target(@target) @lds_atomic_scalar_loop_index_i32() {
 
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @lds_atomic_scalar_loop_index_i32() asm {
+  %15 = storage {byte_alignment = 4, byte_length = 32} : low.storage<workgroup>
   %zero_index = s_mov_b32 0
   %eight = s_mov_b32 8
   %one_index = s_mov_b32 1
-  %18 = storage {byte_alignment = 4, byte_length = 32} : low.storage<workgroup>
-  %scratch_view = storage_address %18 : low.storage<workgroup> -> reg<amdgpu.vgpr>
+  %scratch_view = storage_address %15 : low.storage<workgroup> -> reg<amdgpu.vgpr>
   low.br ^_bb1(%zero_index: reg<amdgpu.sgpr>)
 ^_bb1(%i: reg<amdgpu.sgpr>):
   %21 = s_cmp_lt_i32 %i, %eight
@@ -348,8 +348,8 @@ kernel.def target(@target) @lds_atomic_second_alloca_i32() {
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @lds_atomic_second_alloca_i32() asm {
   %12 = storage {byte_alignment = 16, byte_length = 64} : low.storage<workgroup>
-  %14 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
-  %second_view = storage_address %14 : low.storage<workgroup> -> reg<amdgpu.vgpr>
+  %13 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
+  %second_view = storage_address %13 : low.storage<workgroup> -> reg<amdgpu.vgpr>
   %17 = v_mov_b32 1
   %18 = v_mov_b32 0
   low.op<amdgpu.ds_write_b32>(%18, %17) {offset = 0} memory_access([0, 3, 5, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_workgroup_b128.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_workgroup_b128.loom-test
@@ -190,7 +190,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 2048} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 2048} : reg<amdgpu.sgpr x2>
   %67 = storage {byte_alignment = 16, byte_length = 64} : low.storage<workgroup>
-  %69 = storage {byte_alignment = 16, byte_length = 2048} : low.storage<workgroup>
+  %68 = storage {byte_alignment = 16, byte_length = 2048} : low.storage<workgroup>
   %71 = v_lshlrev_b32_src0_inline %lane, 5
   %72 = global_load_b128_saddr %71, %input_view
   %74 = global_load_b128_saddr %71, %input_view {offset = 16}

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_workgroup_packed16.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_workgroup_packed16.loom-test
@@ -376,10 +376,10 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(16, 16,
   %packed_tid = live_in<amdgpu.workitem_id.packed.xy> : reg<amdgpu.vgpr>
   %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 512} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 512} : reg<amdgpu.sgpr x2>
+  %25 = storage {byte_alignment = 2, byte_length = 512} : low.storage<workgroup>
   %row = v_and_b32_lit %packed_tid, 1023
-  %26 = v_lshrrev_b32_src0_inline %packed_tid, 10
-  %column = v_and_b32_lit %26, 1023
-  %28 = storage {byte_alignment = 2, byte_length = 512} : low.storage<workgroup>
+  %27 = v_lshrrev_b32_src0_inline %packed_tid, 10
+  %column = v_and_b32_lit %27, 1023
   %30 = v_lshl_add_u32_shift_imm %row, %column, 4
   %31 = v_lshlrev_b32_src0_inline %30, 1
   %loaded = global_load_d16_b16_saddr %31, %input_view

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_minmax.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_minmax.loom-test
@@ -666,19 +666,22 @@ func.def target(@target) @scf_select_i1_scc_condition(%lhs: i32, %rhs: i32, %alt
 // ----
 low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @scf_select_i1_scc_condition(%lhs: reg<amdgpu.sgpr>, %rhs: reg<amdgpu.sgpr>, %alt: reg<amdgpu.sgpr>, %true_value: reg<amdgpu.vgpr>, %false_value: reg<amdgpu.vgpr>) -> (reg<amdgpu.vgpr>) asm {
   %zero = s_mov_b32 0
-  %condition = s_cmp_lt_i32 %lhs, %rhs
+  %19 = s_cmp_lt_i32 %lhs, %rhs
+  %21 = s_mov_b32 1
+  %condition = s_cselect_b32 %21, %zero, %19
   %lhs_nonzero = s_cmp_lg_i32 %lhs, %zero
   %alt_nonzero = s_cmp_lg_i32 %alt, %zero
-  %22 = s_mov_b64_exec_read
-  %23 = slice %22[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
-  %24 = slice %22[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
-  %26 = s_cselect_b32 %23, %zero, %lhs_nonzero
-  %27 = s_cselect_b32 %24, %zero, %lhs_nonzero
-  %33 = s_cselect_b32 %23, %zero, %alt_nonzero
-  %34 = s_cselect_b32 %24, %zero, %alt_nonzero
-  %38 = s_cselect_b32 %26, %33, %condition
-  %41 = s_cselect_b32 %27, %34, %condition
-  %selected_condition = concat(%38, %41) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %25 = s_cmp_lg_i32_src1_inline %condition {rhs = 0}
+  %26 = s_mov_b64_exec_read
+  %27 = slice %26[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %28 = slice %26[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %30 = s_cselect_b32 %27, %zero, %lhs_nonzero
+  %31 = s_cselect_b32 %28, %zero, %lhs_nonzero
+  %37 = s_cselect_b32 %27, %zero, %alt_nonzero
+  %38 = s_cselect_b32 %28, %zero, %alt_nonzero
+  %42 = s_cselect_b32 %30, %37, %25
+  %45 = s_cselect_b32 %31, %38, %25
+  %selected_condition = concat(%42, %45) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
   %result = v_cndmask_b32 %false_value, %true_value, %selected_condition
   return %result
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma.loom-test
@@ -435,7 +435,7 @@ low.kernel.def target<amdgpu.rdna3.core>(@target) workgroup_size(32, 1, 1) workg
   %init_view = resource<hal_binding> {index = 2, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
   %out_view = resource<hal_binding> {index = 3, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
   %56 = storage {byte_alignment = 16, byte_length = 512} : low.storage<workgroup>
-  %58 = storage {byte_alignment = 16, byte_length = 512} : low.storage<workgroup>
+  %57 = storage {byte_alignment = 16, byte_length = 512} : low.storage<workgroup>
   %60 = v_lshlrev_b32_src0_inline %tid, 4
   %lhs_loaded = global_load_b128_saddr %60, %lhs_buffer_view
   %rhs_loaded = global_load_b128_saddr %60, %rhs_buffer_view

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_cdna3.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_cdna3.loom-test
@@ -483,9 +483,9 @@ low.kernel.def target<amdgpu.cdna3.core>(@target) workgroup_size(256, 1, 1) work
   %tid = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
   %out_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
+  %27 = storage {byte_alignment = 16, byte_length = 4096} : low.storage<workgroup>
   %wave = v_lshrrev_b32_lit %tid, 6
   %wave_offset = v_lshlrev_b32_lit %wave, 10
-  %29 = storage {byte_alignment = 16, byte_length = 4096} : low.storage<workgroup>
   %31 = v_and_b32_src0_inline %tid, 63
   %32 = v_and_b32_src0_inline %31, 15
   %33 = v_lshlrev_b32_src0_inline %32, 2

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sanitizer_dynamic_stride.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sanitizer_dynamic_stride.loom-test
@@ -1,0 +1,237 @@
+// RUN: emit source-low output=low sanitizer=access sanitizer-reporting=trap
+
+amdgpu.target<gfx11-generic> @target
+
+func.def target(@target) @sanitizer_bounded_dynamic_stride_write(
+    %output: buffer, %row_count_i32: i32, %row_size_i32: i32, %row_i32: i32) {
+  %base = index.constant 0 : offset
+  %zero = index.constant 0 : index
+  %row_count0 = index.cast %row_count_i32 : i32 to index
+  %row_count = index.assume %row_count0 [range(%row_count0, 1, 512)] : index
+  %row_size0 = index.cast %row_size_i32 : i32 to index
+  %row_size = index.assume %row_size0 [range(%row_size0, 1, 4096)] : index
+  %row0 = index.cast %row_i32 : i32 to index
+  %row = index.assume %row0 [range(%row0, 0, 511), lt(%row0, %row_count)] : index
+  %output_global = buffer.assume.memory_space<global> %output : buffer
+  %output_view = buffer.view %output_global[%base] : buffer -> view<[%row_count]x[%row_size]xf32, #dense>
+  sanitizer.assert.access<write> %output_view[%row, %zero] : view<[%row_count]x[%row_size]xf32, #dense>
+  func.return
+}
+
+// ----
+low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @sanitizer_bounded_dynamic_stride_write(%row_count: reg<amdgpu.sgpr>, %row_size: reg<amdgpu.sgpr>, %row: reg<amdgpu.sgpr>) asm {
+  %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %18 = s_getpc_b64
+  %19 = slice %18[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %20 = slice %18[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %21 = s_add_u32_rhs_symbol_rel32_lo %19 {symbol = @iree_asan_config}
+  %22 = s_addc_u32_rhs_symbol_rel32_hi %20 {symbol = @iree_asan_config}
+  %23 = concat(%21, %22) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %24 = s_load_dwordx2_offset_only %23 {offset = 16}
+  %25 = v_mov_b32 0
+  %26 = v_mov_b32 128
+  %27 = s_mov_b32 0
+  %31 = s_mul_i32 %row, %row_size
+  %32 = s_mul_hi_u32 %row, %row_size
+  %33 = s_mul_i32 %27, %row_size
+  %34 = s_add_u32 %32, %33
+  %35 = concat(%31, %34) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %36 = s_mov_b32 2
+  %37 = s_lshl_b64 %35, %36
+  %38 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %39 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %40 = slice %37[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %41 = slice %37[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %42 = s_add_u32 %38, %40
+  %43 = s_addc_u32 %39, %41
+  %47 = v_mov_b32_copy %42
+  %48 = v_mov_b32_copy %43
+  %50 = slice %24[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %51 = v_mov_b32_copy %50
+  %52 = slice %24[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %53 = v_mov_b32_copy %52
+  %57 = v_lshrrev_b32_lit %47, 3
+  %58 = v_lshlrev_b32_lit %48, 29
+  %59 = v_or_b32 %57, %58
+  %60 = v_lshrrev_b32_lit %48, 3
+  %66, %67 = v_add_co_u32 %51, %59
+  %68, %69 = v_add_co_ci_u32 %53, %60, %67
+  %70 = concat(%66, %68) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
+  %71 = flat_load_u8 %70 {glc = 1, dlc = 1}
+  s_waitcnt {vmcnt = 0}
+  %73 = v_and_b32_lit %47, 7
+  %74 = v_add_u32_lit %73, 3
+  %75 = v_cmp_ne_i32 %71, %25
+  %76 = v_cmp_ge_u32 %71, %26
+  %77 = v_cmp_ge_u32 %74, %71
+  %78 = s_and_b64 %75, %77
+  %79 = s_or_b64 %76, %78
+  %80 = v_mov_b32 3
+  %87, %88 = v_add_co_u32 %47, %80
+  %89, %90 = v_add_co_ci_u32 %48, %25, %88
+  %99 = v_lshrrev_b32_lit %87, 3
+  %100 = v_lshlrev_b32_lit %89, 29
+  %101 = v_or_b32 %99, %100
+  %102 = v_lshrrev_b32_lit %89, 3
+  %108, %109 = v_add_co_u32 %51, %101
+  %110, %111 = v_add_co_ci_u32 %53, %102, %109
+  %112 = concat(%108, %110) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
+  %113 = flat_load_u8 %112 {glc = 1, dlc = 1}
+  s_waitcnt {vmcnt = 0}
+  %115 = v_and_b32_lit %87, 7
+  %116 = v_cmp_ne_i32 %113, %25
+  %117 = v_cmp_ge_u32 %113, %26
+  %118 = v_cmp_ge_u32 %115, %113
+  %119 = s_and_b64 %116, %118
+  %120 = s_or_b64 %117, %119
+  %121 = s_or_b64 %79, %120
+  %122 = slice %121[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %124 = concat(%122, %27) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %133 = concat(%27, %27) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %134 = s_cmp_lg_u64 %124, %133
+  low.cond_br %134, ^_bb2, ^_bb1 : reg<amdgpu.scc>
+^_bb1:
+  return
+^_bb2:
+  %135, %136 = s_and_saveexec_b64 %124
+  low.br ^_bb3
+^_bb3:
+  s_trap {trapid = 2}
+  %125 = s_sendmsg_rtn_b32 {message = 128}
+  %126 = s_mov_b32 1023
+  %127 = s_and_b32 %125, %126
+  %128 = s_mov_b32 1024
+  %129 = s_or_b32 %127, %128
+  %130 = s_mov_b32_m0 %129
+  s_sendmsg %130 {message = 1}
+  low.br ^_bb4
+^_bb4:
+  s_sethalt {reason = 5}
+  low.br ^_bb4
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
+
+kernel.def target(@target) @sanitizer_bounded_lane_dynamic_stride_write(
+    %row_size_i32: i32) {
+  %one = index.constant 1 : index
+  %workgroup_size = index.constant 64 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+} launch(%output: buffer, %row_size_i32: i32) {
+  %base = index.constant 0 : offset
+  %zero = index.constant 0 : index
+  %row = kernel.workitem.id<x> : index
+  %row_size0 = index.cast %row_size_i32 : i32 to index
+  %row_size = index.assume %row_size0 [range(%row_size0, 1, 4096)] : index
+  %output_global = buffer.assume.memory_space<global> %output : buffer
+  %output_view = buffer.view %output_global[%base] : buffer -> view<64x[%row_size]xf32, #dense>
+  sanitizer.assert.access<write> %output_view[%row, %zero] : view<64x[%row_size]xf32, #dense>
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @sanitizer_bounded_lane_dynamic_stride_write(%row_size: reg<amdgpu.sgpr>) asm {
+  %row = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
+  %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %15 = s_getpc_b64
+  %16 = slice %15[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %17 = slice %15[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %18 = s_add_u32_rhs_symbol_rel32_lo %16 {symbol = @iree_asan_config}
+  %19 = s_addc_u32_rhs_symbol_rel32_hi %17 {symbol = @iree_asan_config}
+  %20 = concat(%18, %19) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %21 = s_load_dwordx2_offset_only %20 {offset = 16}
+  %22 = v_mov_b32 0
+  %23 = v_mov_b32 128
+  %24 = v_mov_b32_copy %row_size
+  %25 = v_mul_lo_u32 %row, %24
+  %26 = v_lshlrev_b32_src0_inline %25, 2
+  %28 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %29 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %30, %31 = v_add_co_u32 %28, %26
+  %32 = v_mov_b32_copy %29
+  %33, %34 = v_add_co_ci_u32 %32, %22, %31
+  %36 = slice %21[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %37 = v_mov_b32_copy %36
+  %38 = slice %21[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %39 = v_mov_b32_copy %38
+  %43 = v_lshrrev_b32_lit %30, 3
+  %44 = v_lshlrev_b32_lit %33, 29
+  %45 = v_or_b32 %43, %44
+  %46 = v_lshrrev_b32_lit %33, 3
+  %52, %53 = v_add_co_u32 %37, %45
+  %54, %55 = v_add_co_ci_u32 %39, %46, %53
+  %56 = concat(%52, %54) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
+  %57 = flat_load_u8 %56 {glc = 1, dlc = 1}
+  s_waitcnt {vmcnt = 0}
+  %59 = v_and_b32_lit %30, 7
+  %60 = v_add_u32_lit %59, 3
+  %61 = v_cmp_ne_i32 %57, %22
+  %62 = v_cmp_ge_u32 %57, %23
+  %63 = v_cmp_ge_u32 %60, %57
+  %64 = s_and_b64 %61, %63
+  %65 = s_or_b64 %62, %64
+  %66 = v_mov_b32 3
+  %73, %74 = v_add_co_u32 %30, %66
+  %75, %76 = v_add_co_ci_u32 %33, %22, %74
+  %85 = v_lshrrev_b32_lit %73, 3
+  %86 = v_lshlrev_b32_lit %75, 29
+  %87 = v_or_b32 %85, %86
+  %88 = v_lshrrev_b32_lit %75, 3
+  %94, %95 = v_add_co_u32 %37, %87
+  %96, %97 = v_add_co_ci_u32 %39, %88, %95
+  %98 = concat(%94, %96) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
+  %99 = flat_load_u8 %98 {glc = 1, dlc = 1}
+  s_waitcnt {vmcnt = 0}
+  %101 = v_and_b32_lit %73, 7
+  %102 = v_cmp_ne_i32 %99, %22
+  %103 = v_cmp_ge_u32 %99, %23
+  %104 = v_cmp_ge_u32 %101, %99
+  %105 = s_and_b64 %102, %104
+  %106 = s_or_b64 %103, %105
+  %107 = s_or_b64 %65, %106
+  %108 = slice %107[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %109 = s_mov_b32 0
+  %110 = concat(%108, %109) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %119 = concat(%109, %109) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %120 = s_cmp_lg_u64 %110, %119
+  low.cond_br %120, ^_bb2, ^_bb1 : reg<amdgpu.scc>
+^_bb1:
+  return
+^_bb2:
+  %121, %122 = s_and_saveexec_b64 %110
+  low.br ^_bb3
+^_bb3:
+  s_trap {trapid = 2}
+  %111 = s_sendmsg_rtn_b32 {message = 128}
+  %112 = s_mov_b32 1023
+  %113 = s_and_b32 %111, %112
+  %114 = s_mov_b32 1024
+  %115 = s_or_b32 %113, %114
+  %116 = s_mov_b32_m0 %115
+  s_sendmsg %116 {message = 1}
+  low.br ^_bb4
+^_bb4:
+  s_sethalt {reason = 5}
+  low.br ^_bb4
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
+
+func.def target(@target) @sanitizer_wide_dynamic_stride_write_rejected(
+    %output: buffer, %row_size_i32: i32, %row_i32: i32) {
+  %base = index.constant 0 : offset
+  %zero = index.constant 0 : index
+  %row_size0 = index.cast %row_size_i32 : i32 to index
+  %row_size = index.assume %row_size0 [range(%row_size0, 1, 1073741824)] : index
+  %row0 = index.cast %row_i32 : i32 to index
+  %row = index.assume %row0 [range(%row0, 0, 1)] : index
+  %output_global = buffer.assume.memory_space<global> %output : buffer
+  %output_view = buffer.view %output_global[%base] : buffer -> view<2x[%row_size]xf32, #dense>
+  // ERROR@+1: AMDGPU/020
+  sanitizer.assert.access<write> %output_view[%row, %zero] : view<2x[%row_size]xf32, #dense>
+  func.return
+}

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_scc_lifetimes.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_scc_lifetimes.loom-test
@@ -1,0 +1,82 @@
+// RUN: emit source-low output=low
+
+// An outer condition cannot remain in ephemeral SCC while its payload
+// materializes a later condition. The outer condition is retained as an SGPR
+// boolean and rematerializes SCC immediately before its select.
+amdgpu.target<gfx11-generic> @target
+
+func.def target(@target) @select_nested_scalar(%x: i32, %y: i32, %zero: i32, %two: i32, %lhs: i32, %middle: i32, %rhs: i32) -> (i32) {
+  %use_lhs = scalar.cmpi eq, %x, %zero : i32
+  %use_rhs = scalar.cmpi eq, %y, %two : i32
+  %middle_or_rhs = scf.select %use_rhs, %rhs, %middle : i32
+  %selected = scf.select %use_lhs, %lhs, %middle_or_rhs : i32
+  func.return %selected : i32
+}
+
+// ----
+low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @select_nested_scalar(%x: reg<amdgpu.sgpr>, %y: reg<amdgpu.sgpr>, %zero: reg<amdgpu.sgpr>, %two: reg<amdgpu.sgpr>, %lhs: reg<amdgpu.sgpr>, %middle: reg<amdgpu.sgpr>, %rhs: reg<amdgpu.sgpr>) -> (reg<amdgpu.sgpr>) asm {
+  %20 = s_cmp_eq_i32 %x, %zero
+  %21 = s_mov_b32 0
+  %22 = s_mov_b32 1
+  %use_lhs = s_cselect_b32 %22, %21, %20
+  %use_rhs = s_cmp_eq_i32 %y, %two
+  %middle_or_rhs = s_cselect_b32 %rhs, %middle, %use_rhs
+  %26 = s_cmp_lg_i32_src1_inline %use_lhs {rhs = 0}
+  %selected = s_cselect_b32 %lhs, %middle_or_rhs, %26
+  return %selected
+}
+
+// ====
+
+// The same predicate lifetime applies to multi-register global buffer
+// descriptors. Both descriptor lanes must select under the corresponding
+// condition before the selected address is consumed.
+amdgpu.target<gfx11-generic> @target
+
+kernel.def target(@target) @select_nested_global_buffer(%select_lhs: index, %select_rhs: index) {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch(%select_lhs: index, %select_rhs: index, %lhs: buffer, %middle: buffer, %rhs: buffer, %output: buffer) {
+  %zero = index.constant 0 : index
+  %two = index.constant 2 : index
+  %zero_offset = index.constant 0 : offset
+  %use_lhs = index.cmp eq, %select_lhs, %zero : index
+  %use_rhs = index.cmp eq, %select_rhs, %two : index
+  %middle_or_rhs = scf.select %use_rhs, %rhs, %middle : buffer
+  %selected = scf.select %use_lhs, %lhs, %middle_or_rhs : buffer
+  %selected_view = buffer.view %selected[%zero_offset] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xi32, #dense>
+  %selected_value = view.load %selected_view[%zero] : view<1xi32, #dense> -> i32
+  view.store %selected_value, %output_view[%zero] : i32, view<1xi32, #dense>
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @select_nested_global_buffer(%select_lhs: reg<amdgpu.sgpr>, %select_rhs: reg<amdgpu.sgpr>) asm {
+  %lhs = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %middle = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %rhs = resource<hal_binding> {index = 2, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %output_view = resource<hal_binding> {index = 3, source_type = hal.buffer, extent = 4} : reg<amdgpu.sgpr x2>
+  %zero = s_mov_b32 0
+  %two = s_mov_b32 2
+  %27 = s_cmp_eq_i32 %select_lhs, %zero
+  %29 = s_mov_b32 1
+  %use_lhs = s_cselect_b32 %29, %zero, %27
+  %use_rhs = s_cmp_eq_i32 %select_rhs, %two
+  %32 = slice %rhs[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %33 = slice %middle[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %34 = s_cselect_b32 %32, %33, %use_rhs
+  %35 = slice %rhs[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %36 = slice %middle[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %37 = s_cselect_b32 %35, %36, %use_rhs
+  %39 = s_cmp_lg_i32_src1_inline %use_lhs {rhs = 0}
+  %40 = slice %lhs[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %42 = s_cselect_b32 %40, %34, %39
+  %43 = slice %lhs[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %45 = s_cselect_b32 %43, %37, %39
+  %selected_view = concat(%42, %45) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %47 = v_mov_b32 0
+  %selected_value = global_load_b32_saddr %47, %selected_view
+  global_store_b32_saddr %47, %selected_value, %output_view
+  return
+}

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sync_kernel.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sync_kernel.loom-test
@@ -210,3 +210,43 @@ low.kernel.def target<amdgpu.gfx9_4.generic.core>(@target) workgroup_size(128, 1
   s_waitcnt {lgkmcnt = 0}
   return
 }
+
+// ====
+
+amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
+
+// A read-only control value loaded from a uniform global address is uniform
+// across the workgroup and may guard a convergent barrier.
+kernel.def target(@target) @uniform_global_load_controls_barrier() {
+  %one = index.constant 1 : index
+  %threads = index.constant 64 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+} launch(%control: buffer) {
+  %zero_index = index.constant 0 : index
+  %zero_offset = index.constant 0 : offset
+  %zero_i32 = scalar.constant 0 : i32
+  %control_view = buffer.view %control[%zero_offset] : buffer -> view<1xi32, #dense>
+  %control_value = view.load %control_view[%zero_index] : view<1xi32, #dense> -> i32
+  %is_zero = scalar.cmpi eq, %control_value, %zero_i32 : i32
+  scf.if %is_zero {
+    kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
+    scf.yield
+  }
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @uniform_global_load_controls_barrier() asm {
+  %control_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 4} : reg<amdgpu.sgpr x2>
+  %10 = v_mov_b32 0
+  %control_value = global_load_b32_saddr %10, %control_view
+  %is_zero = v_cmp_eq_i32_src1_inline %control_value {rhs = 0}
+  %13, %14 = s_and_saveexec_b64 %is_zero
+  low.cond_br %14, ^_bb1, ^_bb2 : reg<amdgpu.scc>
+^_bb1:
+  s_barrier
+  low.br ^_bb2
+^_bb2:
+  s_mov_b64_exec %13
+  return
+}

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_tensor_gfx1250.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_tensor_gfx1250.loom-test
@@ -23,31 +23,31 @@ kernel.def target(@target) @tensor_load_to_lds_d4() {
 
 // ----
 low.kernel.def target<amdgpu.rdna4.gfx125x.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @tensor_load_to_lds_d4() asm {
-  %15 = v_mov_b32 0
-  %29 = storage {byte_alignment = 256, byte_length = 16384} : low.storage<workgroup>
-  %32 = v_readfirstlane_b32 %15
-  %34 = v_readfirstlane_b32 %15
-  %36 = v_readfirstlane_b32 %15
-  %38 = v_readfirstlane_b32 %15
+  %15 = storage {byte_alignment = 256, byte_length = 16384} : low.storage<workgroup>
+  %16 = v_mov_b32 0
+  %32 = v_readfirstlane_b32 %16
+  %34 = v_readfirstlane_b32 %16
+  %36 = v_readfirstlane_b32 %16
+  %38 = v_readfirstlane_b32 %16
   %39 = concat(%32, %34, %36, %38) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x4>
-  %41 = v_readfirstlane_b32 %15
-  %43 = v_readfirstlane_b32 %15
-  %45 = v_readfirstlane_b32 %15
-  %47 = v_readfirstlane_b32 %15
-  %49 = v_readfirstlane_b32 %15
-  %51 = v_readfirstlane_b32 %15
-  %53 = v_readfirstlane_b32 %15
-  %55 = v_readfirstlane_b32 %15
+  %41 = v_readfirstlane_b32 %16
+  %43 = v_readfirstlane_b32 %16
+  %45 = v_readfirstlane_b32 %16
+  %47 = v_readfirstlane_b32 %16
+  %49 = v_readfirstlane_b32 %16
+  %51 = v_readfirstlane_b32 %16
+  %53 = v_readfirstlane_b32 %16
+  %55 = v_readfirstlane_b32 %16
   %56 = concat(%41, %43, %45, %47, %49, %51, %53, %55) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x8>
-  %58 = v_readfirstlane_b32 %15
-  %60 = v_readfirstlane_b32 %15
-  %62 = v_readfirstlane_b32 %15
-  %64 = v_readfirstlane_b32 %15
+  %58 = v_readfirstlane_b32 %16
+  %60 = v_readfirstlane_b32 %16
+  %62 = v_readfirstlane_b32 %16
+  %64 = v_readfirstlane_b32 %16
   %65 = concat(%58, %60, %62, %64) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x4>
-  %67 = v_readfirstlane_b32 %15
-  %69 = v_readfirstlane_b32 %15
-  %71 = v_readfirstlane_b32 %15
-  %73 = v_readfirstlane_b32 %15
+  %67 = v_readfirstlane_b32 %16
+  %69 = v_readfirstlane_b32 %16
+  %71 = v_readfirstlane_b32 %16
+  %73 = v_readfirstlane_b32 %16
   %74 = concat(%67, %69, %71, %73) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x4>
   tensor_load_to_lds_d4 %39, %56, %65, %74
   s_wait_tensorcnt {tensorcnt = 0}
@@ -79,21 +79,21 @@ kernel.def target(@target) @tensor_load_to_lds_d2() {
 
 // ----
 low.kernel.def target<amdgpu.rdna4.gfx125x.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @tensor_load_to_lds_d2() asm {
-  %15 = v_mov_b32 0
-  %29 = storage {byte_alignment = 256, byte_length = 16384} : low.storage<workgroup>
-  %32 = v_readfirstlane_b32 %15
-  %34 = v_readfirstlane_b32 %15
-  %36 = v_readfirstlane_b32 %15
-  %38 = v_readfirstlane_b32 %15
+  %15 = storage {byte_alignment = 256, byte_length = 16384} : low.storage<workgroup>
+  %16 = v_mov_b32 0
+  %32 = v_readfirstlane_b32 %16
+  %34 = v_readfirstlane_b32 %16
+  %36 = v_readfirstlane_b32 %16
+  %38 = v_readfirstlane_b32 %16
   %39 = concat(%32, %34, %36, %38) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x4>
-  %41 = v_readfirstlane_b32 %15
-  %43 = v_readfirstlane_b32 %15
-  %45 = v_readfirstlane_b32 %15
-  %47 = v_readfirstlane_b32 %15
-  %49 = v_readfirstlane_b32 %15
-  %51 = v_readfirstlane_b32 %15
-  %53 = v_readfirstlane_b32 %15
-  %55 = v_readfirstlane_b32 %15
+  %41 = v_readfirstlane_b32 %16
+  %43 = v_readfirstlane_b32 %16
+  %45 = v_readfirstlane_b32 %16
+  %47 = v_readfirstlane_b32 %16
+  %49 = v_readfirstlane_b32 %16
+  %51 = v_readfirstlane_b32 %16
+  %53 = v_readfirstlane_b32 %16
+  %55 = v_readfirstlane_b32 %16
   %56 = concat(%41, %43, %45, %47, %49, %51, %53, %55) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x8>
   tensor_load_to_lds_d2 %39, %56
   s_wait_tensorcnt {tensorcnt = 0}
@@ -130,37 +130,37 @@ kernel.def target(@target) @tensor_load_two_stage_wait_depth() {
 
 // ----
 low.kernel.def target<amdgpu.rdna4.gfx125x.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @tensor_load_two_stage_wait_depth() asm {
-  %19 = v_mov_b32 0
-  %33 = storage {byte_alignment = 256, byte_length = 16384} : low.storage<workgroup>
-  %36 = v_readfirstlane_b32 %19
-  %38 = v_readfirstlane_b32 %19
-  %40 = v_readfirstlane_b32 %19
-  %42 = v_readfirstlane_b32 %19
-  %43 = concat(%36, %38, %40, %42) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x4>
-  %45 = v_readfirstlane_b32 %19
-  %47 = v_readfirstlane_b32 %19
-  %49 = v_readfirstlane_b32 %19
-  %51 = v_readfirstlane_b32 %19
-  %53 = v_readfirstlane_b32 %19
-  %55 = v_readfirstlane_b32 %19
-  %57 = v_readfirstlane_b32 %19
-  %59 = v_readfirstlane_b32 %19
-  %60 = concat(%45, %47, %49, %51, %53, %55, %57, %59) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x8>
-  tensor_load_to_lds_d2 %43, %60
-  %61 = storage {byte_alignment = 256, byte_length = 16384} : low.storage<workgroup>
-  %64 = v_readfirstlane_b32 %19
-  %66 = v_readfirstlane_b32 %19
-  %68 = v_readfirstlane_b32 %19
-  %70 = v_readfirstlane_b32 %19
+  %19 = storage {byte_alignment = 256, byte_length = 16384} : low.storage<workgroup>
+  %20 = storage {byte_alignment = 256, byte_length = 16384} : low.storage<workgroup>
+  %21 = v_mov_b32 0
+  %37 = v_readfirstlane_b32 %21
+  %39 = v_readfirstlane_b32 %21
+  %41 = v_readfirstlane_b32 %21
+  %43 = v_readfirstlane_b32 %21
+  %44 = concat(%37, %39, %41, %43) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x4>
+  %46 = v_readfirstlane_b32 %21
+  %48 = v_readfirstlane_b32 %21
+  %50 = v_readfirstlane_b32 %21
+  %52 = v_readfirstlane_b32 %21
+  %54 = v_readfirstlane_b32 %21
+  %56 = v_readfirstlane_b32 %21
+  %58 = v_readfirstlane_b32 %21
+  %60 = v_readfirstlane_b32 %21
+  %61 = concat(%46, %48, %50, %52, %54, %56, %58, %60) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x8>
+  tensor_load_to_lds_d2 %44, %61
+  %64 = v_readfirstlane_b32 %21
+  %66 = v_readfirstlane_b32 %21
+  %68 = v_readfirstlane_b32 %21
+  %70 = v_readfirstlane_b32 %21
   %71 = concat(%64, %66, %68, %70) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x4>
-  %73 = v_readfirstlane_b32 %19
-  %75 = v_readfirstlane_b32 %19
-  %77 = v_readfirstlane_b32 %19
-  %79 = v_readfirstlane_b32 %19
-  %81 = v_readfirstlane_b32 %19
-  %83 = v_readfirstlane_b32 %19
-  %85 = v_readfirstlane_b32 %19
-  %87 = v_readfirstlane_b32 %19
+  %73 = v_readfirstlane_b32 %21
+  %75 = v_readfirstlane_b32 %21
+  %77 = v_readfirstlane_b32 %21
+  %79 = v_readfirstlane_b32 %21
+  %81 = v_readfirstlane_b32 %21
+  %83 = v_readfirstlane_b32 %21
+  %85 = v_readfirstlane_b32 %21
+  %87 = v_readfirstlane_b32 %21
   %88 = concat(%73, %75, %77, %79, %81, %83, %85, %87) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x8>
   tensor_load_to_lds_d2 %71, %88
   s_wait_tensorcnt {tensorcnt = 1}

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_tensor_report.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_tensor_report.loom-test
@@ -24,14 +24,14 @@ kernel.def target(@target) @report_tensor_load_to_lds() {
 // ----
 COMPILE-REPORT: summary artifact=none status=OK function=- backend=- bundle=- export=- export_symbol=- config=- lowered=-
 COMPILE-REPORT: workload workgroup_size=64x1x1 flat_workgroup_size=64 workgroup_count=1x1x1 dispatch_workgroup_count=1 dispatch_workitem_count=64
-COMPILE-REPORT: source_low selected_ops=11 emitted_ops=44 rows=11
+COMPILE-REPORT: source_low selected_ops=11 emitted_ops=43 rows=11
 COMPILE-REPORT: source_low[0] function=report_tensor_load_to_lds source_op=index.constant selection=plan emitted_ops=0
 COMPILE-REPORT: source_low[1] function=report_tensor_load_to_lds source_op=index.constant selection=plan emitted_ops=0
 COMPILE-REPORT: source_low[2] function=report_tensor_load_to_lds source_op=vector.constant selection=plan emitted_ops=5
 COMPILE-REPORT: source_low[3] function=report_tensor_load_to_lds source_op=vector.constant selection=plan emitted_ops=9
 COMPILE-REPORT: source_low[4] function=report_tensor_load_to_lds source_op=kernel.tensor.lds.descriptor selection=rule emitted_ops=0
 COMPILE-REPORT: source_low[5] function=report_tensor_load_to_lds source_op=buffer.view selection=rule emitted_ops=0
-COMPILE-REPORT: source_low[6] function=report_tensor_load_to_lds source_op=buffer.alloca selection=plan emitted_ops=2
+COMPILE-REPORT: source_low[6] function=report_tensor_load_to_lds source_op=buffer.alloca selection=plan emitted_ops=1
 COMPILE-REPORT: source_low[7] function=report_tensor_load_to_lds source_op=buffer.view selection=rule emitted_ops=0
 COMPILE-REPORT: source_low[8] function=report_tensor_load_to_lds source_op=kernel.async.tensor.load.to.lds selection=plan plan_key=amdgpu.tensor_load_to_lds.d2 emitted_ops=27
 COMPILE-REPORT: source_low[9] function=report_tensor_load_to_lds source_op=kernel.async.group selection=rule emitted_ops=0

--- a/loom/src/loom/tooling/target/amdgpu/test/amdgpu_unused_kernargs.loom
+++ b/loom/src/loom/tooling/target/amdgpu/test/amdgpu_unused_kernargs.loom
@@ -37,8 +37,8 @@ check.case @unused_middle_binding_case {
   check.return
 }
 
-// Buffer-valued control flow retains every possible binding root while
-// specialization selects one input for the checked invocation.
+// A runtime-uniform condition selects one of two HAL binding descriptors while
+// retaining the declared binding ordinals in the exported ABI.
 kernel.def @selected_buffer(%select_rhs: index) {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
@@ -75,5 +75,39 @@ check.case @selected_rhs_case {
   %output = check.generate.fill value(0) : tensor<1xi32>
   func.call @selected_buffer(%select_rhs, %lhs, %rhs, %output) : (index, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>)
   check.expect.equal actual(%output) expected(%rhs) : tensor<1xi32>
+  check.return
+}
+
+// Workgroup-uniform runtime conditions select among three nested descriptors
+// within one dispatch, preventing check-case specialization from folding the
+// choices.
+kernel.def @selected_buffer_per_workgroup() {
+  %three = index.constant 3 : index
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%three, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch(%lhs: buffer, %middle: buffer, %rhs: buffer, %output: buffer) {
+  %workgroup = kernel.workgroup.id<x> : index
+  %zero = index.constant 0 : index
+  %two = index.constant 2 : index
+  %zero_offset = index.constant 0 : offset
+  %use_rhs = index.cmp eq, %workgroup, %two : index
+  %middle_or_rhs = scf.select %use_rhs, %rhs, %middle : buffer
+  %use_lhs = index.cmp eq, %workgroup, %zero : index
+  %selected = scf.select %use_lhs, %lhs, %middle_or_rhs : buffer
+  %selected_view = buffer.view %selected[%zero_offset] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%zero_offset] : buffer -> view<3xi32, #dense>
+  %value = view.load %selected_view[0] : view<1xi32, #dense> -> i32
+  view.store %value, %output_view[%workgroup] : i32, view<3xi32, #dense>
+  kernel.return
+}
+
+check.case @selected_buffer_per_workgroup_case {
+  %lhs = check.generate.fill value(17) : tensor<1xi32>
+  %middle = check.generate.fill value(42) : tensor<1xi32>
+  %rhs = check.generate.fill value(67) : tensor<1xi32>
+  %output = check.generate.fill value(0) : tensor<3xi32>
+  func.call @selected_buffer_per_workgroup(%lhs, %middle, %rhs, %output) : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>, tensor<3xi32>)
+  %expected = check.generate.iota offset(17) step(25) : tensor<3xi32>
+  check.expect.equal actual(%output) expected(%expected) : tensor<3xi32>
   check.return
 }

--- a/loom/src/loom/tooling/target/amdgpu/test/amdgpu_unused_kernargs.loom
+++ b/loom/src/loom/tooling/target/amdgpu/test/amdgpu_unused_kernargs.loom
@@ -90,9 +90,9 @@ kernel.def @selected_buffer_per_workgroup() {
   %zero = index.constant 0 : index
   %two = index.constant 2 : index
   %zero_offset = index.constant 0 : offset
+  %use_lhs = index.cmp eq, %workgroup, %zero : index
   %use_rhs = index.cmp eq, %workgroup, %two : index
   %middle_or_rhs = scf.select %use_rhs, %rhs, %middle : buffer
-  %use_lhs = index.cmp eq, %workgroup, %zero : index
   %selected = scf.select %use_lhs, %lhs, %middle_or_rhs : buffer
   %selected_view = buffer.view %selected[%zero_offset] : buffer -> view<1xi32, #dense>
   %output_view = buffer.view %output[%zero_offset] : buffer -> view<3xi32, #dense>

--- a/loom/src/loom/tooling/target/amdgpu/test/iree-test-loom_amdgpu.test.json
+++ b/loom/src/loom/tooling/target/amdgpu/test/iree-test-loom_amdgpu.test.json
@@ -109,6 +109,9 @@
             {
               "regex": "\"case\":\"selected_rhs_case\"[^}]*\"passed\":true"
             },
+            {
+              "regex": "\"case\":\"selected_buffer_per_workgroup_case\"[^}]*\"passed\":true"
+            },
             "\"failed_sample_count\":0"
           ]
         }

--- a/loom/src/loom/tooling/target/amdgpu/test/iree-test-loom_amdgpu_asan.test.json
+++ b/loom/src/loom/tooling/target/amdgpu/test/iree-test-loom_amdgpu_asan.test.json
@@ -73,6 +73,9 @@
             {
               "regex": "\"case\":\"selected_rhs_case\"[^}]*\"passed\":true"
             },
+            {
+              "regex": "\"case\":\"selected_buffer_per_workgroup_case\"[^}]*\"passed\":true"
+            },
             "\"failed_sample_count\":0"
           ]
         }

--- a/loom/src/loom/tooling/target/amdgpu/test/loom-compile-amdgpu.test.json
+++ b/loom/src/loom/tooling/target/amdgpu/test/loom-compile-amdgpu.test.json
@@ -26,6 +26,30 @@
       ]
     },
     {
+      "name": "compiles runtime-selected HAL binding descriptors",
+      "run": {
+        "tool": "loom-compile",
+        "args": [
+          "{srcdir}/amdgpu_unused_kernargs.loom",
+          "--backend=amdgpu-hal",
+          "--target=gfx1100",
+          "--root=@selected_buffer",
+          "--output={tmp}/selected_buffer.hal",
+          "--emit-target-artifact={tmp}/selected_buffer.hsaco"
+        ]
+      },
+      "files": [
+        {
+          "path": "{tmp}/selected_buffer.hal",
+          "non_empty": true
+        },
+        {
+          "path": "{tmp}/selected_buffer.hsaco",
+          "non_empty": true
+        }
+      ]
+    },
+    {
       "name": "compiles parameterized gfx1250 matrix kernel",
       "run": {
         "tool": "loom-compile",

--- a/loom/src/loom/transforms/scf/scf_unroll.c
+++ b/loom/src/loom/transforms/scf/scf_unroll.c
@@ -1935,6 +1935,7 @@ static iree_status_t loom_scf_unroll_initialize_scheduled_tile(
     loom_scf_unroll_context_t* context, loom_op_t* op,
     const loom_block_t* body_block, loom_op_t* yield,
     const loom_scf_unroll_trip_count_t* trip_count,
+    loom_value_id_t iteration_upper_bound,
     const loom_value_id_t* initial_carried_values, uint16_t carried_count,
     loom_scf_for_unroll_schedule_t schedule,
     iree_arena_allocator_t* scratch_arena,
@@ -1990,6 +1991,10 @@ static iree_status_t loom_scf_unroll_initialize_scheduled_tile(
       &out_tile->effect_dependency_plan));
 
   const loom_value_id_t induction_variable = body_block->arg_ids[0];
+  loom_value_id_t* iteration_indices = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      scratch_arena, out_tile->unroll_count, sizeof(*iteration_indices),
+      (void**)&iteration_indices));
   for (uint32_t ordinal = 0; ordinal < out_tile->unroll_count; ++ordinal) {
     IREE_RETURN_IF_ERROR(loom_ir_remap_initialize(
         context->module, context->module, scratch_arena,
@@ -1998,17 +2003,57 @@ static iree_status_t loom_scf_unroll_initialize_scheduled_tile(
             .remap_symbol = loom_ir_remap_symbol_callback_empty(),
         },
         &out_tile->remaps[ordinal]));
-    loom_value_id_t iteration_index = LOOM_VALUE_ID_INVALID;
     IREE_RETURN_IF_ERROR(loom_scf_unroll_build_iteration_index(
         context, op, induction_variable, trip_count, ordinal,
-        &iteration_index));
-    if (iteration_index == LOOM_VALUE_ID_INVALID) {
+        &iteration_indices[ordinal]));
+    if (iteration_indices[ordinal] == LOOM_VALUE_ID_INVALID) {
       return loom_scf_unroll_emit_policy_error(
           context, op, IREE_SV("schedule"), ordinal,
           IREE_SV("iteration index representable as i64"));
     }
-    IREE_RETURN_IF_ERROR(loom_ir_remap_map_value(
-        &out_tile->remaps[ordinal], induction_variable, iteration_index));
+  }
+
+  const loom_value_id_t* remapped_iteration_indices = iteration_indices;
+  // Dynamic partial unrolling replaces the source upper bound with an aligned
+  // main-loop bound. Preserve the source bound on every materialized index so
+  // consumers do not have to reconstruct the split arithmetic.
+  if (iteration_upper_bound != LOOM_VALUE_ID_INVALID) {
+    loom_predicate_t* predicates = NULL;
+    IREE_RETURN_IF_ERROR(
+        iree_arena_allocate_array(scratch_arena, out_tile->unroll_count,
+                                  sizeof(*predicates), (void**)&predicates));
+    loom_type_t* result_types = NULL;
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        scratch_arena, out_tile->unroll_count, sizeof(*result_types),
+        (void**)&result_types));
+    for (uint32_t ordinal = 0; ordinal < out_tile->unroll_count; ++ordinal) {
+      predicates[ordinal] = (loom_predicate_t){
+          .kind = LOOM_PREDICATE_LT,
+          .arg_count = 2,
+          .arg_tags = {LOOM_PRED_ARG_VALUE, LOOM_PRED_ARG_VALUE,
+                       LOOM_PRED_ARG_NONE},
+          .args = {iteration_indices[ordinal], iteration_upper_bound, 0},
+      };
+      result_types[ordinal] =
+          loom_module_value_type(context->module, iteration_indices[ordinal]);
+    }
+    loom_op_t* assume_op = NULL;
+    IREE_RETURN_IF_ERROR(loom_index_assume_build(
+        &context->rewriter->builder, iteration_indices, out_tile->unroll_count,
+        predicates, out_tile->unroll_count, result_types,
+        out_tile->unroll_count, op->location, &assume_op));
+    remapped_iteration_indices = loom_index_assume_results(assume_op).values;
+    for (uint32_t ordinal = 0; ordinal < out_tile->unroll_count; ++ordinal) {
+      IREE_RETURN_IF_ERROR(loom_rewriter_move_value_name(
+          context->rewriter, iteration_indices[ordinal],
+          remapped_iteration_indices[ordinal]));
+    }
+  }
+
+  for (uint32_t ordinal = 0; ordinal < out_tile->unroll_count; ++ordinal) {
+    IREE_RETURN_IF_ERROR(
+        loom_ir_remap_map_value(&out_tile->remaps[ordinal], induction_variable,
+                                remapped_iteration_indices[ordinal]));
   }
   for (uint16_t i = 0; i < carried_count; ++i) {
     IREE_RETURN_IF_ERROR(loom_ir_remap_map_value(&out_tile->remaps[0],
@@ -2278,6 +2323,7 @@ static iree_status_t loom_scf_unroll_emit_scheduled_tile(
     loom_scf_unroll_context_t* context, loom_op_t* op,
     const loom_block_t* body_block, loom_op_t* yield,
     const loom_scf_unroll_trip_count_t* trip_count,
+    loom_value_id_t iteration_upper_bound,
     const loom_value_id_t* initial_carried_values, uint16_t carried_count,
     loom_scf_for_unroll_schedule_t schedule,
     iree_arena_allocator_t* scratch_arena,
@@ -2292,8 +2338,8 @@ static iree_status_t loom_scf_unroll_emit_scheduled_tile(
 
   loom_scf_unroll_scheduled_tile_t tile = {0};
   IREE_RETURN_IF_ERROR(loom_scf_unroll_initialize_scheduled_tile(
-      context, op, body_block, yield, trip_count, initial_carried_values,
-      carried_count, schedule, scratch_arena, &tile));
+      context, op, body_block, yield, trip_count, iteration_upper_bound,
+      initial_carried_values, carried_count, schedule, scratch_arena, &tile));
   if (loom_pass_has_error_diagnostics(context->pass)) return iree_ok_status();
 
   switch (schedule) {
@@ -2337,8 +2383,9 @@ static iree_status_t loom_scf_unroll_full_unroll_scheduled_with_arena(
   loom_value_id_t value_checkpoint =
       loom_rewriter_value_checkpoint(context->rewriter);
   iree_status_t status = loom_scf_unroll_emit_scheduled_tile(
-      context, op, body_block, yield, trip_count, iter_args.values,
-      carried_count, schedule, scratch_arena, final_carried_values);
+      context, op, body_block, yield, trip_count, LOOM_VALUE_ID_INVALID,
+      iter_args.values, carried_count, schedule, scratch_arena,
+      final_carried_values);
   loom_builder_restore(&context->rewriter->builder, saved_ip);
   IREE_RETURN_IF_ERROR(status);
   if (loom_pass_has_error_diagnostics(context->pass)) return iree_ok_status();
@@ -2600,8 +2647,10 @@ static iree_status_t loom_scf_unroll_partial_unroll_scheduled_with_arena(
       .lower_range_max = 0,
   };
   iree_status_t status = loom_scf_unroll_emit_scheduled_tile(
-      context, op, old_block, yield, &tile_trip_count, main_carried_values,
-      op->result_count, schedule, scratch_arena, final_main_carried_values);
+      context, op, old_block, yield, &tile_trip_count,
+      trip_count ? LOOM_VALUE_ID_INVALID : loom_scf_for_upper_bound(op),
+      main_carried_values, op->result_count, schedule, scratch_arena,
+      final_main_carried_values);
   if (iree_status_is_ok(status)) {
     loom_op_t* main_yield = NULL;
     status = loom_scf_yield_build(&context->rewriter->builder,

--- a/loom/src/loom/transforms/scf/test/BUILD.bazel
+++ b/loom/src/loom/transforms/scf/test/BUILD.bazel
@@ -18,5 +18,6 @@ loom_check_test_suite(
         "scf_index.loom-test",
         "scf_to_cfg.loom-test",
         "scf_unroll.loom-test",
+        "scf_unroll_bounds.loom-test",
     ],
 )

--- a/loom/src/loom/transforms/scf/test/CMakeLists.txt
+++ b/loom/src/loom/transforms/scf/test/CMakeLists.txt
@@ -16,6 +16,7 @@ loom_check_test_suite(
     "scf_index.loom-test"
     "scf_to_cfg.loom-test"
     "scf_unroll.loom-test"
+    "scf_unroll_bounds.loom-test"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -893,9 +893,10 @@ func.def @interleaved_partial_factor_dynamic_tail_loop(%end: index) {
   %10 = index.div %8, %9 : index
   %11 = index.mul %10, %5 : index
   %12 = index.add %start, %11 : index
-  scf.for %i = [%start to %12 step %5] {
+  scf.for %13 = [%start to %12 step %5] {
     %14 = index.constant 1 : index
-    %i_1 = index.add %i, %14 : index
+    %15 = index.add %13, %14 : index
+    %i, %i_1 = index.assume %13, %15 [lt(%13, %end), lt(%15, %end)] : index, index
     test.use %i : index
     test.use %i_1 : index
   }
@@ -934,9 +935,10 @@ func.def @interleaved_partial_config_factor_dynamic_tail_loop(%end: index) {
   %11 = index.div %9, %10 : index
   %12 = index.mul %11, %6 : index
   %13 = index.add %start, %12 : index
-  scf.for %i = [%start to %13 step %6] {
+  scf.for %14 = [%start to %13 step %6] {
     %15 = index.constant 1 : index
-    %i_1 = index.add %i, %15 : index
+    %16 = index.add %14, %15 : index
+    %i, %i_1 = index.assume %14, %16 [lt(%14, %end), lt(%16, %end)] : index, index
     test.use %i : index
     test.use %i_1 : index
   }
@@ -979,14 +981,15 @@ func.def @interleaved_partial_config_step_dynamic_tail_loop(%end: index) {
   %15 = index.div %13, %14 : index
   %16 = index.mul %15, %6 : index
   %17 = index.add %start, %16 : index
-  scf.for %i = [%start to %17 step %6] {
+  scf.for %18 = [%start to %17 step %6] {
     %19 = index.constant 2 : index
-    %i_2 = index.add %i, %19 : index
+    %20 = index.add %18, %19 : index
+    %i, %i_2 = index.assume %18, %20 [lt(%18, %end), lt(%20, %end)] : index, index
     test.use %i : index
     test.use %i_2 : index
   }
-  %21 = index.constant 2 : index
-  scf.for %i = [%17 to %end step %21] {
+  %23 = index.constant 2 : index
+  scf.for %i = [%17 to %end step %23] {
     test.use %i : index
   }
   func.return
@@ -1021,14 +1024,15 @@ func.def @interleaved_partial_factor_dynamic_tail_step_two(%end: index) {
   %14 = index.div %12, %13 : index
   %15 = index.mul %14, %5 : index
   %16 = index.add %start, %15 : index
-  scf.for %i = [%start to %16 step %5] {
+  scf.for %17 = [%start to %16 step %5] {
     %18 = index.constant 2 : index
-    %i_2 = index.add %i, %18 : index
+    %19 = index.add %17, %18 : index
+    %i, %i_2 = index.assume %17, %19 [lt(%17, %end), lt(%19, %end)] : index, index
     test.use %i : index
     test.use %i_2 : index
   }
-  %20 = index.constant 2 : index
-  scf.for %i = [%16 to %end step %20] {
+  %22 = index.constant 2 : index
+  scf.for %i = [%16 to %end step %22] {
     test.use %i : index
   }
   func.return
@@ -1227,11 +1231,12 @@ func.def @recurrence_partial_factor_dynamic_tail(%end: index, %input: i32) -> (i
   %16 = index.div %14, %15 : index
   %17 = index.mul %16, %11 : index
   %18 = index.add %start, %17 : index
-  %21 = scf.for %i = [%start to %18 step %11](%acc = %input : i32) -> (i32) {
+  %21 = scf.for %19 = [%start to %18 step %11](%acc = %input : i32) -> (i32) {
     %22 = index.constant 1 : index
-    %i_1 = index.add %i, %22 : index
+    %23 = index.add %19, %22 : index
     %24 = index.constant 2 : index
-    %i_2 = index.add %i, %24 : index
+    %25 = index.add %19, %24 : index
+    %i, %i_1, %i_2 = index.assume %19, %23, %25 [lt(%19, %end), lt(%23, %end), lt(%25, %end)] : index, index, index
     %producer = test.addi %input, %input : i32
     %producer_1 = test.addi %input, %input : i32
     scf.schedule.fence

--- a/loom/src/loom/transforms/scf/test/scf_unroll_bounds.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll_bounds.loom-test
@@ -1,0 +1,61 @@
+// RUN: pass unroll-scf-for,scf-to-cfg,vector-memory-footprint
+
+func.def @dynamic_interleaved_tile_indices_remain_in_bounds(%payload: buffer, %base: offset, %end0: index, %value: i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %four = index.constant 4 : index
+  %end = index.assume %end0 [range(%end0, 1, 32)] : index
+  %view = buffer.view %payload[%base] : buffer -> view<[%end]xi32, #dense>
+  scf.for %i = [%zero to %end step %one] unroll(%four) schedule(interleaved) {
+    view.store %value, %view[%i] : i32, view<[%end]xi32, #dense>
+  }
+  func.return
+}
+
+// ----
+func.def @dynamic_interleaved_tile_indices_remain_in_bounds(%payload: buffer, %base: offset, %end0: index, %value: i32) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %four = index.constant 4 : index
+  %end = index.assume %end0 [range(%end0, 1, 32)] : index
+  %view = buffer.view %payload[%base] : buffer -> view<[%end]xi32, #dense>
+  %10 = index.constant 4 : index
+  %11 = index.constant 0 : index
+  %12 = index.sub %end, %zero : index
+  %13 = index.max %12, %11 : index
+  %14 = index.constant 4 : index
+  %15 = index.div %13, %14 : index
+  %16 = index.mul %15, %10 : index
+  %17 = index.add %zero, %16 : index
+  cfg.br ^_bb1(%zero: index)
+^_bb1(%30: index):
+  %32 = index.cmp slt, %30, %17 : index
+  cfg.cond_br %32, ^_bb2, ^_bb3
+^_bb2:
+  %31 = index.assume %30 [range(%30, 0, 28), mul(%30, 4), lt(%30, %17)] : index
+  %19 = index.constant 1 : index
+  %20 = index.add %31, %19 : index
+  %21 = index.constant 2 : index
+  %22 = index.add %31, %21 : index
+  %23 = index.constant 3 : index
+  %24 = index.add %31, %23 : index
+  %i$25, %i_1, %i_2, %i_3 = index.assume %31, %20, %22, %24 [lt(%31, %end), lt(%20, %end), lt(%22, %end), lt(%24, %end)] : index, index, index, index
+  view.store %value, %view[%i$25] : i32, view<[%end]xi32, #dense>
+  view.store %value, %view[%i_1] : i32, view<[%end]xi32, #dense>
+  view.store %value, %view[%i_2] : i32, view<[%end]xi32, #dense>
+  view.store %value, %view[%i_3] : i32, view<[%end]xi32, #dense>
+  %33 = index.add %31, %10 : index
+  cfg.br ^_bb1(%33: index)
+^_bb3:
+  cfg.br ^_bb4(%17: index)
+^_bb4(%34: index):
+  %36 = index.cmp slt, %34, %end : index
+  cfg.cond_br %36, ^_bb5, ^_bb6
+^_bb5:
+  %i$35 = index.assume %34 [range(%34, 0, 31), ge(%34, %17), lt(%34, %end)] : index
+  view.store %value, %view[%i$35] : i32, view<[%end]xi32, #dense>
+  %37 = index.add %i$35, %one : index
+  cfg.br ^_bb4(%37: index)
+^_bb6:
+  func.return
+}

--- a/loom/src/loom/transforms/vector/test/memory_footprint.loom-test
+++ b/loom/src/loom/transforms/vector/test/memory_footprint.loom-test
@@ -692,6 +692,25 @@ func.def @guarded_i64_precast_index_proves_store_unit_axis(%payload: buffer, %ba
 
 // ====
 
+func.def @guarded_flattened_store_proves_dynamic_axis_bounds(%payload: buffer, %base: offset, %row0: index, %row_count0: index, %column0: index, %column_count0: index, %lane: i32, %value: f32) {
+  %row, %row_count = index.assume %row0, %row_count0 [range(%row0, 0, 2047), range(%row_count0, 1, 2048), lt(%row0, %row_count0)] : index, index
+  %column, %column_count = index.assume %column0, %column_count0 [range(%column0, 0, 262143), range(%column_count0, 1, 262144)] : index, index
+  %zero_i32 = scalar.constant 0 : i32
+  %valid_column = index.cmp ult, %column, %column_count : index
+  %is_lane_zero = scalar.cmpi eq, %lane, %zero_i32 : i32
+  %writes_output = scalar.andi %valid_column, %is_lane_zero : i1
+  scf.if %writes_output {
+    %element_count = index.mul %row_count, %column_count : index
+    %view = buffer.view %payload[%base] : buffer -> view<[%element_count]xf32, #dense>
+    %row_base = index.mul %row, %column_count : index
+    %origin = index.add %row_base, %column : index
+    view.store %value, %view[%origin] : f32, view<[%element_count]xf32, #dense>
+  }
+  func.return
+}
+
+// ====
+
 kernel.def @dynamic_unit_axis_proven_by_workgroup_id_launch_config(%rows: index) {
   %c1 = index.constant 1 : index
   %c128 = index.constant 128 : index

--- a/loom/src/loom/transforms/vector/test/memory_footprint.loom-test
+++ b/loom/src/loom/transforms/vector/test/memory_footprint.loom-test
@@ -711,6 +711,58 @@ func.def @guarded_flattened_store_proves_dynamic_axis_bounds(%payload: buffer, %
 
 // ====
 
+// Equivalent nonlinear bounds may be materialized independently on each side
+// of a convergent operation. The active branch relation still proves that an
+// index guarded by the first quotient fits a view shaped by the second.
+func.def @guarded_recomputed_quotient_proves_dynamic_axis_bound(%payload: buffer, %base: offset, %active_count0: index, %block0: index, %value: i32) {
+  %sixtythree = index.constant 63 : index
+  %sixtyfour = index.constant 64 : index
+  %active_count = index.assume %active_count0 [range(%active_count0, 1, 2048)] : index
+  %block = index.assume %block0 [range(%block0, 0, 31)] : index
+  %padded_count = index.add %active_count, %sixtythree : index
+  %block_count0 = index.div %padded_count, %sixtyfour : index
+  %block_count = index.assume %block_count0 [range(%block_count0, 1, 32)] : index
+  %barrier = test.convergent %value : i32
+  test.use %barrier : i32
+  %is_active = index.cmp ult, %block, %block_count : index
+  scf.if %is_active {
+    %active_block, %active_block_count, %active_token_count = index.assume %block, %block_count, %active_count [lt(%block, %block_count)] : index, index, index
+    %inner_active_count = index.assume %active_token_count [range(%active_token_count, 1, 32768)] : index
+    %inner_padded_count = index.add %inner_active_count, %sixtythree : index
+    %inner_block_count0 = index.div %inner_padded_count, %sixtyfour : index
+    %inner_block_count = index.assume %inner_block_count0 [range(%inner_block_count0, 1, 512)] : index
+    %view = buffer.view %payload[%base] : buffer -> view<[%inner_block_count]xi32, #dense>
+    view.store %value, %view[%active_block] : i32, view<[%inner_block_count]xi32, #dense>
+  }
+  func.return
+}
+
+// ====
+
+func.def @guarded_distinct_quotient_rejects_unproven_dynamic_axis_bound(%payload: buffer, %base: offset, %active_count0: index, %block0: index, %value: i32) {
+  %sixtythree = index.constant 63 : index
+  %sixtyfour = index.constant 64 : index
+  %onetwentyeight = index.constant 128 : index
+  %active_count = index.assume %active_count0 [range(%active_count0, 1, 2048)] : index
+  %block = index.assume %block0 [range(%block0, 0, 31)] : index
+  %padded_count = index.add %active_count, %sixtythree : index
+  %block_count0 = index.div %padded_count, %sixtyfour : index
+  %block_count = index.assume %block_count0 [range(%block_count0, 1, 32)] : index
+  %is_active = index.cmp ult, %block, %block_count : index
+  scf.if %is_active {
+    %inner_active_count = index.assume %active_count [range(%active_count, 1, 32768)] : index
+    %inner_padded_count = index.add %inner_active_count, %sixtythree : index
+    %inner_block_count0 = index.div %inner_padded_count, %onetwentyeight : index
+    %inner_block_count = index.assume %inner_block_count0 [range(%inner_block_count0, 1, 256)] : index
+    %view = buffer.view %payload[%base] : buffer -> view<[%inner_block_count]xi32, #dense>
+    // ERROR@+1: SUBRANGE/024 {op_name="view.store", view_axis="0"}
+    view.store %value, %view[%block] : i32, view<[%inner_block_count]xi32, #dense>
+  }
+  func.return
+}
+
+// ====
+
 kernel.def @dynamic_unit_axis_proven_by_workgroup_id_launch_config(%rows: index) {
   %c1 = index.constant 1 : index
   %c128 = index.constant 128 : index

--- a/loom/src/loom/util/fact_table.c
+++ b/loom/src/loom/util/fact_table.c
@@ -2418,8 +2418,7 @@ static iree_status_t loom_value_fact_table_seed_block_args(
             loom_value_fact_table_seed_scalar_arg(table, module, value_id));
       }
     }
-    if ((has_workgroup_uniform_args || has_cluster_uniform_args) &&
-        loom_type_is_scalar(type)) {
+    if (has_workgroup_uniform_args || has_cluster_uniform_args) {
       loom_value_facts_t facts = loom_value_fact_table_lookup(table, value_id);
       if (has_cluster_uniform_args) {
         loom_value_facts_mark_cluster_uniform(&facts);

--- a/loom/src/loom/util/fact_table.h
+++ b/loom/src/loom/util/fact_table.h
@@ -521,7 +521,8 @@ typedef struct loom_value_fact_buffer_reference_t {
   // Target-independent memory space for the storage root.
   loom_value_fact_memory_space_t memory_space;
 
-  // SSA value that represents the root storage identity.
+  // SSA value that represents the root storage identity. INVALID means the
+  // value carrying these facts is itself the dynamic storage root.
   loom_value_id_t root_value_id;
 
   // Comparable alias scope for disjointness proofs, or NONE.
@@ -530,6 +531,17 @@ typedef struct loom_value_fact_buffer_reference_t {
   // Known nullability for the storage root.
   loom_value_fact_reference_nullability_t nullability;
 } loom_value_fact_buffer_reference_t;
+
+// Resolves the concrete storage root for |reference_value_id|. Buffer fact
+// joins use a self-root when control flow chooses between distinct roots.
+static inline loom_value_id_t
+loom_value_fact_buffer_reference_resolve_root_value(
+    loom_value_fact_buffer_reference_t reference,
+    loom_value_id_t reference_value_id) {
+  return reference.root_value_id == LOOM_VALUE_ID_INVALID
+             ? reference_value_id
+             : reference.root_value_id;
+}
 
 // View value is a typed projection over a storage root.
 typedef struct loom_value_fact_view_reference_t {


### PR DESCRIPTION
Dynamic layouts, runtime buffer selection, and branch-local storage now carry enough proof and representation information from source facts through scheduling and AMDGPU emission to compile unspecialized, access-sanitized kernels. Flattened dynamic row-major addresses retain branch-derived bounds across symbolic recomputation and partial unrolling, bounded coordinate differences stay in one register even when their conservative range crosses zero, selected buffers preserve compatible storage facts, kernel ABI references retain their declared execution scope, global descriptors stay in SGPRs, overlapping select predicates are materialized only when SCC lifetimes require it, and mutually exclusive workgroup allocations share physical storage without giving up logical ownership.

## Dynamic Address Proofs

Memory footprint analysis previously lost information at three boundaries. Value-to-value edge relations no longer matched after their operands became affine terms, independently materialized nonlinear expressions no longer had identical value identities, and products of dynamic dimensions remained opaque even when paired expressions shared a nonnegative factor.

Symbolic comparison now checks expanded expressions against active condition relations and factors paired products after cheaper proof paths fail. When exact algebraic matching cannot relate pure recomputations, a bounded deterministic expression-tree comparison preserves their value semantics while rejecting regions, ties, side effects, convergence, and identity-bearing operations. This proves strict row-major bounds such as `(row * stride) + column < row_count * stride` while continuing to reject non-strict off-by-one cases.

Dynamic partial unrolling also preserves the source loop's exclusive upper bound on every materialized tile index. The scheduler refines the generated indices through one multi-result assumption before cloning the tile, allowing downstream memory analysis to consume the original bound directly instead of reconstructing it from the aligned main-loop split. Exact-trip schedules remain unchanged.

AMDGPU flat-memory lowering consumes the resulting unsigned 32-bit proof for runtime-stride terms. Lane-varying products use low-word multiplies with a known-zero high word; terms that may exceed 32 bits retain the existing diagnostic because they require true wide dynamic multiplication. Access instrumentation can therefore preserve dynamic selected layouts without weakening address-width guarantees.

## Signed Coordinate Differences

AMDGPU index subtraction now has a signed 32-bit selection path alongside its existing unsigned address path. Loom's index domain may conservatively cross zero for expressions such as `bounded_count - tile_width` even when every value still fits one hardware register. SGPR and VGPR lowering use the same two's-complement subtract instructions for that domain, while wider results continue through the existing wide-address path.

This keeps bounded differences from failing target selection or widening merely because a conservative lower bound is negative. Offset arithmetic remains unsigned, and the signed rule applies only to index subtraction.

## Buffer Facts Through Control Flow

Buffer values now have a type-owned fact domain that joins compatible storage contracts field by field. A runtime choice between different roots retains shared extent, alignment, memory space, alias, and nullability facts while representing the selected identity as a dynamic self-root.

Views and explicit buffer contracts resolve self-roots at their consumption boundary. Structured control flow remains generic: it joins facts through the normal type interface and does not depend on buffer operations or target details.

This separates two questions that were previously conflated. The selected root may be unknown until runtime while its storage properties remain statically useful for bounds analysis, sanitization, and target placement.

## AMDGPU Descriptor Selection

Non-lane-varying global buffer values now use the same SGPR-pair representation as HAL binding arguments. Buffer-valued selects apply the scalar condition to both descriptor lanes, allowing one unspecialized kernel to choose among runtime bindings without converting uniform addresses into lane-varying state.

The hardware coverage chooses three different bindings from separate workgroups in one dispatch. This keeps case literals from specializing away the descriptor selection and exercises the exported ABI and selected address together.

Nested descriptor choices also expose an architectural lifetime constraint: SCC is ephemeral and cannot retain one predicate while a later predicate is materialized for an inner selection. Source placement detects that structural overlap through generic operand roles, retains only the outer predicate as a 0/1 SGPR, and rematerializes SCC immediately before its select. Independent predicates continue to use the compact SCC path.

## Operation Footprints And Workgroup Storage

Control-uniformity analysis now retains acyclic control-dependence alternatives in its existing CFG summary and can prove that two complete operation footprints execute under distinct successors of one uniformly selected controller. The proof intersects the controlling context across every operation in each footprint. A post-join operation, a selector below the requested uniformity scope, or a controller inside a cycle makes the proof fail conservatively.

AMDGPU source-allocation layout uses that proof to separate logical allocation ownership from physical workgroup storage. Each allocation footprint includes its definition and all uses of fact-preserving aliases. A physical slot may be reused only when the new footprint is mutually exclusive with every existing occupant; same-path, lane-varying, cyclic, and otherwise unproven allocations remain distinct.

Entry setup emits one low-storage root per physical slot, and each logical allocation lowers to the root selected by the plan. Slot capacity and alignment track the maximum requirement among occupants. This turns mutually exclusive branch frames from an additive LDS cost into a maximum while preserving authored allocations, source packet offsets, sanitizer coverage, and stable first-allocation ordering.

## Uniform Kernel ABI References

Kernel body arguments inherit the execution-scope contract declared by the body region for every supported argument type. Previously the fact seeding path applied that contract only to scalar arguments, leaving buffer references without the cluster-uniform fact guaranteed by the ABI. A uniform control load could consequently appear lane-varying and fail verification when it guarded a workgroup barrier.

The body-region contract now seeds scalar and storage-reference arguments uniformly through the same generic block-argument path. Existing type-owned propagation carries that fact through views, refinements, subviews, and loads; lane-varying indexing still makes the resulting reference and load lane-varying. This restores the authored ABI guarantee without target-specific propagation or operation-name checks.

## Design Impact

The resulting path preserves information at its owning boundary:

- Control-flow relations, equivalent pure computations, and scheduled-loop bounds feed symbolic address proofs instead of requiring source-level restatements or downstream reconstruction.
- Buffer types retain compatible storage facts independently from runtime root identity.
- Kernel ABI references retain their declared execution scope through type-owned fact propagation.
- Source placement chooses durable predicate and descriptor representations before target emission.
- Control analysis retains branch alternatives once and answers complete-footprint lifetime queries without downstream IR scans.
- Source allocation planning keeps logical ownership separate from physical storage assignment.
- AMDGPU plans resolve the exact instructions required to materialize proven addresses and consume selected descriptors.

These contracts make runtime-selected layouts, bindings, predicates, and storage lifetimes ordinary specialization inputs rather than reasons to clone source kernels, add explicit assumptions, manually alias scratch buffers, or disable sanitization.

## Reviewer Notes

The retained-root ABI contract already on `main` lets the unspecialized compiler tests preserve the complete external binding layout. The highest-value review surfaces are the symbolic expression comparison, scheduled-unroll bound refinement, and complete-footprint exclusivity proof: all must remain conservative when facts are incomplete. The buffer fact join, AMDGPU representation choices, and source-allocation planner then consume those proofs without reconstructing them downstream.
