### PR TITLE
[Loom/AMDGPU] Preserve global saddr for large offsets

### DIFF
--- a/loom/src/loom/target/arch/amdgpu/lower/memory.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/memory.c
@@ -1414,8 +1414,7 @@ static bool loom_amdgpu_memory_access_split_global_saddr_static_offset(
   const int64_t signed_max = offset_info->unsigned_max > INT64_MAX
                                  ? INT64_MAX
                                  : (int64_t)offset_info->unsigned_max;
-  if (static_byte_offset < offset_info->signed_min ||
-      static_byte_offset > signed_max) {
+  if (static_byte_offset < offset_info->signed_min) {
     diagnostic->rejection_bits |=
         LOOM_AMDGPU_MEMORY_ACCESS_REJECTION_DESCRIPTOR_OFFSET_RANGE |
         LOOM_AMDGPU_MEMORY_ACCESS_REJECTION_GLOBAL_FALLBACK_OFFSET_RANGE;
@@ -1427,8 +1426,33 @@ static bool loom_amdgpu_memory_access_split_global_saddr_static_offset(
         LOOM_AMDGPU_MEMORY_ACCESS_REJECTION_DYNAMIC_OFFSET_RANGE;
     return false;
   }
-  access->immediate_offset = static_byte_offset;
-  access->scalar_byte_offset = 0;
+  if (static_byte_offset <= signed_max) {
+    access->immediate_offset = static_byte_offset;
+    access->scalar_byte_offset = 0;
+    access->scalar_base_byte_offset = 0;
+    access->scalar_offset_placement =
+        LOOM_AMDGPU_MEMORY_SCALAR_OFFSET_PLACEMENT_SOFFSET;
+    return true;
+  }
+
+  uint64_t immediate_offset = (uint64_t)signed_max;
+  if (access->payload_register_count == 4) {
+    immediate_offset &= ~UINT64_C(15);
+  }
+  const uint64_t scalar_byte_offset =
+      (uint64_t)static_byte_offset - immediate_offset;
+  access->immediate_offset = (int64_t)immediate_offset;
+  if (scalar_byte_offset <= UINT32_MAX) {
+    access->scalar_byte_offset = (uint32_t)scalar_byte_offset;
+    access->scalar_base_byte_offset = 0;
+    access->scalar_offset_placement =
+        LOOM_AMDGPU_MEMORY_SCALAR_OFFSET_PLACEMENT_SOFFSET;
+  } else {
+    access->scalar_byte_offset = 0;
+    access->scalar_base_byte_offset = scalar_byte_offset;
+    access->scalar_offset_placement =
+        LOOM_AMDGPU_MEMORY_SCALAR_OFFSET_PLACEMENT_BASE;
+  }
   return true;
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global.loom-test
@@ -1993,7 +1993,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
 // ====
 
 amdgpu.target<gfx11-generic> @target
-kernel.def target(@target) @f32x4_dynamic_view_base_flat() {
+kernel.def target(@target) @f32x4_dynamic_view_base_large_static_offset() {
   %unit = index.constant 1 : index
   %workgroup_size = index.constant 256 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
@@ -2017,26 +2017,21 @@ kernel.def target(@target) @f32x4_dynamic_view_base_flat() {
 }
 
 // ----
-low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(256, 1, 1) workgroup_count(1, 1, 1) @f32x4_dynamic_view_base_flat(%input_base: reg<amdgpu.sgpr>) asm {
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(256, 1, 1) workgroup_count(1, 1, 1) @f32x4_dynamic_view_base_large_static_offset(%input_base: reg<amdgpu.sgpr>) asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 4096} : reg<amdgpu.sgpr x2>
-  %31 = s_mov_b32 24576
-  %32 = s_mov_b32 0
+  %31 = v_lshlrev_b32_src0_inline %lane, 4
+  %32 = s_mov_b32 20496
+  %33 = s_add_u32 %input_base, %32
   %34 = slice %input_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %35 = slice %input_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
-  %38 = s_add_u32 %34, %31
-  %39 = s_addc_u32 %35, %32
-  %47 = s_add_u32 %38, %input_base
-  %48 = s_addc_u32 %39, %32
-  %50 = v_lshlrev_b32_src0_inline %lane, 4
-  %51 = v_lshrrev_b32_src0_inline %lane, 28
-  %54, %55 = v_add_co_u32 %47, %50
-  %56 = v_mov_b32_copy %48
-  %57, %58 = v_add_co_ci_u32 %56, %51, %55
-  %59 = concat(%54, %57) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
-  %loaded = global_load_b128_vaddr %59
-  global_store_b128_saddr %50, %loaded, %output_view
+  %36 = s_mov_b32 0
+  %37 = s_add_u32 %34, %33
+  %38 = s_addc_u32 %35, %36
+  %39 = concat(%37, %38) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %loaded = global_load_b128_saddr %31, %39 {offset = 4080}
+  global_store_b128_saddr %31, %loaded, %output_view
   return
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_saddr_large_static.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_saddr_large_static.loom-test
@@ -26,7 +26,7 @@ kernel.def target(@target) @i32x4_global_saddr_large_static_non_power_two_stride
 }
 
 // ----
-low.kernel.def target(@target) workgroup_size(256, 1, 1) workgroup_count(1, 1, 1) @i32x4_global_saddr_large_static_non_power_two_stride() asm<amdgpu.gfx11.generic.core> {
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(256, 1, 1) workgroup_count(1, 1, 1) @i32x4_global_saddr_large_static_non_power_two_stride() asm {
   %22 = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<amdgpu.sgpr x2>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_saddr_large_static.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_saddr_large_static.loom-test
@@ -1,0 +1,47 @@
+// RUN: emit source-low output=low
+
+amdgpu.target<gfx11-generic> @target
+kernel.def target(@target) @i32x4_global_saddr_large_static_non_power_two_stride() {
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 256 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
+} launch(%input: buffer, %output: buffer) {
+  %subgroup0 = kernel.subgroup.id : index
+  %subgroup = index.assume %subgroup0 [range(%subgroup0, 0, 7)] : index
+  %row_i32 = index.cast %subgroup : index to i32
+  %row_byte_stride_i32 = scalar.constant 840 : i32
+  %down_page_byte_add_i32 = scalar.constant 3538944 : i32
+  %row_byte_add_i32 = scalar.muli %row_i32, %row_byte_stride_i32 : i32
+  %row_byte_base_i32 = scalar.addi %down_page_byte_add_i32, %row_byte_add_i32 : i32
+  %row_byte_base = index.cast %row_byte_base_i32 : i32 to offset
+  %output_row_byte_stride_i32 = scalar.constant 16 : i32
+  %output_row_byte_base_i32 = scalar.muli %row_i32, %output_row_byte_stride_i32 : i32
+  %output_row_byte_base = index.cast %output_row_byte_base_i32 : i32 to offset
+  %zero = index.constant 0 : index
+  %input_view = buffer.view %input[%row_byte_base] : buffer -> view<210xi32, #dense>
+  %output_view = buffer.view %output[%output_row_byte_base] : buffer -> view<4xi32, #dense>
+  %value = vector.load %input_view[%zero] : view<210xi32, #dense> -> vector<4xi32>
+  vector.store %value, %output_view[%zero] : vector<4xi32>, view<4xi32, #dense>
+  kernel.return
+}
+
+// ----
+low.kernel.def target(@target) workgroup_size(256, 1, 1) workgroup_count(1, 1, 1) @i32x4_global_saddr_large_static_non_power_two_stride() asm<amdgpu.gfx11.generic.core> {
+  %22 = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
+  %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %row_i32 = v_lshrrev_b32_src0_inline %22, 5
+  %output_row_byte_base = v_lshlrev_b32_lit %row_i32, 4
+  %33 = v_mov_b32 840
+  %34 = v_mul_lo_u32 %row_i32, %33
+  %35 = s_mov_b32 3534864
+  %36 = slice %input_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %37 = slice %input_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %38 = s_mov_b32 0
+  %39 = s_add_u32 %36, %35
+  %40 = s_addc_u32 %37, %38
+  %41 = concat(%39, %40) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %value = global_load_b128_saddr %34, %41 {offset = 4080}
+  global_store_b128_saddr %output_row_byte_base, %value, %output_view
+  return
+}

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_global.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_global.loom-test
@@ -1414,7 +1414,7 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) work
 llvmir.target<object> @target {
   triple = "amdgcn-amd-amdhsa"
 }
-kernel.def target(@target) @f32x4_dynamic_view_base_flat() {
+kernel.def target(@target) @f32x4_dynamic_view_base_large_static_offset() {
   %unit = index.constant 1 : index
   %workgroup_size = index.constant 256 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
@@ -1438,7 +1438,7 @@ kernel.def target(@target) @f32x4_dynamic_view_base_flat() {
 }
 
 // ----
-low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(256, 1, 1) workgroup_count(1, 1, 1) @f32x4_dynamic_view_base_flat(%offset_i32: reg<llvmir.i32>) asm {
+low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(256, 1, 1) workgroup_count(1, 1, 1) @f32x4_dynamic_view_base_large_static_offset(%offset_i32: reg<llvmir.i32>) asm {
   %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<llvmir.ptr>
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<llvmir.ptr>
   %input_base = zext.i32.i64 %offset_i32

--- a/loom/src/loom/test/corpus/source_low/memory_global.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_global.loom-test
@@ -779,7 +779,7 @@ kernel.def @i32x4_dynamic_view_base_b128() {
 
 // ====
 
-kernel.def @f32x4_dynamic_view_base_flat() {
+kernel.def @f32x4_dynamic_view_base_large_static_offset() {
   %unit = index.constant 1 : index
   %workgroup_size = index.constant 256 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index


### PR DESCRIPTION
AMDGPU global-memory selection previously abandoned the scalar-base addressing form whenever a static byte offset exceeded the packet immediate range. That forced otherwise compact accesses through full 64-bit flat-address materialization, and valid wide accesses with a bounded non-power-of-two row stride could then be rejected by the stricter flat-address contract.

This change splits a large positive static offset between the largest legal aligned packet immediate and the scalar base remainder. Dynamic row terms remain in the 32-bit vector address, preserving wide scalar-base packets without changing the authored memory layout or requiring source-side address reconstruction.

The production-shaped regression combines a 3,538,944-byte static base with an 840-byte dynamic row stride and requires a 128-bit global load. Shared source-low coverage also locks the improved addressing form for large static offsets.