### PR TITLE
[Runtime/IO] Parse current GGUF scalar types

### DIFF
--- a/runtime/src/iree/io/formats/gguf/gguf_parser.c
+++ b/runtime/src/iree/io/formats/gguf/gguf_parser.c
@@ -65,10 +65,30 @@ enum ggml_type_e {
   GGML_TYPE_Q5_K = 13,
   GGML_TYPE_Q6_K = 14,
   GGML_TYPE_Q8_K = 15,
-  GGML_TYPE_I8 = 16,
-  GGML_TYPE_I16 = 17,
-  GGML_TYPE_I32 = 18,
-  GGML_TYPE_COUNT,
+  GGML_TYPE_IQ2_XXS = 16,
+  GGML_TYPE_IQ2_XS = 17,
+  GGML_TYPE_IQ3_XXS = 18,
+  GGML_TYPE_IQ1_S = 19,
+  GGML_TYPE_IQ4_NL = 20,
+  GGML_TYPE_IQ3_S = 21,
+  GGML_TYPE_IQ2_S = 22,
+  GGML_TYPE_IQ4_XS = 23,
+  GGML_TYPE_I8 = 24,
+  GGML_TYPE_I16 = 25,
+  GGML_TYPE_I32 = 26,
+  GGML_TYPE_I64 = 27,
+  GGML_TYPE_F64 = 28,
+  GGML_TYPE_IQ1_M = 29,
+  GGML_TYPE_BF16 = 30,
+  // Types 31-33 were removed from the GGUF file format.
+  GGML_TYPE_TQ1_0 = 34,
+  GGML_TYPE_TQ2_0 = 35,
+  // Types 36-38 were removed from the GGUF file format.
+  GGML_TYPE_MXFP4 = 39,
+  GGML_TYPE_NVFP4 = 40,
+  GGML_TYPE_Q1_0 = 41,
+  GGML_TYPE_Q2_0 = 42,
+  GGML_TYPE_COUNT = 43,
 };
 typedef uint32_t ggml_type_t;
 
@@ -196,12 +216,27 @@ static const ggml_type_traits_t ggml_type_traits[GGML_TYPE_COUNT] = {
             .blck_size = 1,
             .type_size = sizeof(int32_t),
         },
+    [GGML_TYPE_I64] =
+        {
+            .blck_size = 1,
+            .type_size = sizeof(int64_t),
+        },
     [GGML_TYPE_F32] =
         {
             .blck_size = 1,
             .type_size = sizeof(float),
         },
     [GGML_TYPE_F16] =
+        {
+            .blck_size = 1,
+            .type_size = sizeof(uint16_t),
+        },
+    [GGML_TYPE_F64] =
+        {
+            .blck_size = 1,
+            .type_size = sizeof(double),
+        },
+    [GGML_TYPE_BF16] =
         {
             .blck_size = 1,
             .type_size = sizeof(uint16_t),
@@ -413,18 +448,39 @@ typedef struct iree_io_gguf_parser_t {
 static iree_status_t iree_io_gguf_calculate_storage_size(
     const gguf_tensor_info_t* tensor_info, uint64_t* out_storage_size) {
   *out_storage_size = 0;
-  uint64_t element_count = 1;
-  for (uint32_t i = 0; i < tensor_info->n_dimensions; ++i) {
-    element_count *= tensor_info->dimensions[i];
-  }
-  if (tensor_info->type < 0 || tensor_info->type >= GGML_TYPE_COUNT) {
+  if (tensor_info->type >= GGML_TYPE_COUNT) {
     return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
                             "GGML tensor type %d not supported",
                             (int)tensor_info->type);
   }
   const ggml_type_traits_t type_traits = ggml_type_traits[tensor_info->type];
-  *out_storage_size =
-      (element_count * type_traits.type_size) / type_traits.blck_size;
+  if (type_traits.blck_size == 0 || type_traits.type_size == 0) {
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                            "GGML tensor type %d not supported",
+                            (int)tensor_info->type);
+  }
+
+  uint64_t element_count = 1;
+  for (uint32_t i = 0; i < tensor_info->n_dimensions; ++i) {
+    if (!iree_checked_mul_u64(element_count, tensor_info->dimensions[i],
+                              &element_count)) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "GGML tensor element count overflow");
+    }
+  }
+  if (element_count % (uint64_t)type_traits.blck_size != 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "GGML tensor element count %" PRIu64
+                            " is not divisible by type %d block size %d",
+                            element_count, (int)tensor_info->type,
+                            type_traits.blck_size);
+  }
+  const uint64_t block_count = element_count / (uint64_t)type_traits.blck_size;
+  if (!iree_checked_mul_u64(block_count, (uint64_t)type_traits.type_size,
+                            out_storage_size)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "GGML tensor storage size overflow");
+  }
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/io/formats/gguf/gguf_parser_test.cc
+++ b/runtime/src/iree/io/formats/gguf/gguf_parser_test.cc
@@ -6,6 +6,9 @@
 
 #include "iree/io/formats/gguf/gguf_parser.h"
 
+#include <algorithm>
+#include <vector>
+
 #include "iree/io/formats/gguf/testdata/gguf_files.h"
 #include "iree/testing/gtest.h"
 #include "iree/testing/status_matchers.h"
@@ -30,6 +33,51 @@ static iree_io_file_handle_t* OpenTestFile(const char* name) {
       IREE_STATUS_NOT_FOUND,
       "test file `%s` not found embedded into test binary", name));
   return NULL;
+}
+
+static iree_io_file_handle_t* OpenTestFileWithFirstTensorType(
+    const char* name, uint32_t tensor_type,
+    std::vector<uint8_t>* out_file_contents) {
+  const struct iree_file_toc_t* files = iree_io_gguf_files_create();
+  const struct iree_file_toc_t* file = NULL;
+  for (size_t i = 0; i < iree_io_gguf_files_size(); ++i) {
+    if (strcmp(files[i].name, name) == 0) {
+      file = &files[i];
+      break;
+    }
+  }
+  IREE_ASSERT(file != NULL);
+  out_file_contents->assign(file->data, file->data + file->size);
+
+  static constexpr char kTensorName[] = "tensor0";
+  auto tensor_name =
+      std::search(out_file_contents->begin(), out_file_contents->end(),
+                  kTensorName, kTensorName + sizeof(kTensorName) - 1);
+  IREE_ASSERT(tensor_name != out_file_contents->end());
+  const size_t tensor_name_offset =
+      (size_t)(tensor_name - out_file_contents->begin());
+  const size_t dimension_count_offset =
+      tensor_name_offset + sizeof(kTensorName) - 1;
+  IREE_ASSERT(dimension_count_offset + sizeof(uint32_t) <=
+              out_file_contents->size());
+  uint32_t dimension_count = 0;
+  memcpy(&dimension_count, out_file_contents->data() + dimension_count_offset,
+         sizeof(dimension_count));
+  const size_t tensor_type_offset = dimension_count_offset +
+                                    sizeof(dimension_count) +
+                                    dimension_count * sizeof(uint64_t);
+  IREE_ASSERT(tensor_type_offset + sizeof(tensor_type) <=
+              out_file_contents->size());
+  memcpy(out_file_contents->data() + tensor_type_offset, &tensor_type,
+         sizeof(tensor_type));
+
+  iree_io_file_handle_t* file_handle = NULL;
+  IREE_CHECK_OK(iree_io_file_handle_wrap_host_allocation(
+      IREE_IO_FILE_ACCESS_READ,
+      iree_make_byte_span(out_file_contents->data(), out_file_contents->size()),
+      iree_io_file_handle_release_callback_null(), iree_allocator_system(),
+      &file_handle));
+  return file_handle;
 }
 
 TEST(GgufFormatTest, Empty) {
@@ -121,6 +169,43 @@ TEST(GgufFormatTest, MultipleTensors) {
   EXPECT_TRUE(iree_const_byte_span_is_empty(entry2->metadata));
   EXPECT_EQ(entry2->storage.file.offset, 576);
   EXPECT_EQ(entry2->length, 48);
+
+  iree_io_parameter_index_release(index);
+}
+
+TEST(GgufFormatTest, Bfloat16Tensor) {
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+
+  std::vector<uint8_t> file_contents;
+  iree_io_file_handle_t* file_handle = OpenTestFileWithFirstTensorType(
+      "single.gguf", /*GGML_TYPE_BF16=*/30, &file_contents);
+  IREE_ASSERT_OK(
+      iree_io_parse_gguf_index(file_handle, index, iree_allocator_system()));
+  iree_io_file_handle_release(file_handle);
+
+  const iree_io_parameter_index_entry_t* entry0 = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_lookup(index, IREE_SV("tensor0"), &entry0));
+  EXPECT_EQ(entry0->storage.file.offset, 384);
+  EXPECT_EQ(entry0->length, 8);
+
+  iree_io_parameter_index_release(index);
+}
+
+TEST(GgufFormatTest, UnsupportedModernQuantizedTensor) {
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+
+  std::vector<uint8_t> file_contents;
+  iree_io_file_handle_t* file_handle = OpenTestFileWithFirstTensorType(
+      "single.gguf", /*GGML_TYPE_IQ2_XXS=*/16, &file_contents);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_UNIMPLEMENTED,
+      iree_io_parse_gguf_index(file_handle, index, iree_allocator_system()));
+  iree_io_file_handle_release(file_handle);
 
   iree_io_parameter_index_release(index);
 }


### PR DESCRIPTION
GGML tensor type identifiers form an append-only file ABI, but the GGUF parser's private table still assigned integer storage traits to numeric IDs now occupied by IQ encodings. Contemporary checkpoints using BF16 therefore failed loud, while unsupported IQ tensors using the stale integer IDs could be assigned an incorrect byte extent.

This change aligns the parser's sparse type table with current GGML identifiers, adds storage geometry for the scalar I8, I16, I32, I64, F64, and BF16 formats, and retains the existing supported block-quantized layouts. Sparse IDs without implemented geometry are rejected before block arithmetic.

Dimension products and tensor storage calculations now use checked arithmetic so malformed metadata cannot overflow or truncate the indexed byte range. Parser coverage includes current BF16 success and explicit rejection of an unsupported IQ encoding.