### PR TITLE
[Loom] Initialize tracing in compiler tools

### DIFF
--- a/loom/src/loom/tools/loom-check/loom-check.c
+++ b/loom/src/loom/tools/loom-check/loom-check.c
@@ -102,5 +102,11 @@ static const loom_check_provider_set_t kLoomCheckProviderSet = {
 };
 
 int main(int argc, char** argv) {
-  return loom_check_provider_main(argc, argv, &kLoomCheckProviderSet);
+  IREE_TRACE_APP_ENTER();
+  IREE_TRACE_ZONE_BEGIN(z0);
+  const int exit_code =
+      loom_check_provider_main(argc, argv, &kLoomCheckProviderSet);
+  IREE_TRACE_ZONE_END(z0);
+  IREE_TRACE_APP_EXIT(exit_code);
+  return exit_code;
 }

--- a/loom/src/loom/tools/loom-format/loom-format.c
+++ b/loom/src/loom/tools/loom-format/loom-format.c
@@ -88,6 +88,9 @@ int main(int argc, char** argv) {
       return 0;
     }
   }
+  IREE_TRACE_APP_ENTER();
+  IREE_TRACE_ZONE_BEGIN(z0);
+
   loom_tooling_cli_set_default_help_filter();
   iree_flags_parse_checked(IREE_FLAGS_PARSE_MODE_DEFAULT, &argc, &argv);
 
@@ -168,5 +171,8 @@ int main(int argc, char** argv) {
     loom_context_deinitialize(&context);
   }
   iree_arena_block_pool_deinitialize(&block_pool);
+
+  IREE_TRACE_ZONE_END(z0);
+  IREE_TRACE_APP_EXIT(exit_code);
   return exit_code;
 }

--- a/loom/src/loom/tools/loom-link/loom-link.c
+++ b/loom/src/loom/tools/loom-link/loom-link.c
@@ -1295,6 +1295,9 @@ int main(int argc, char** argv) {
       return 0;
     }
   }
+  IREE_TRACE_APP_ENTER();
+  IREE_TRACE_ZONE_BEGIN(z0);
+
   loom_tooling_cli_set_default_help_filter();
   iree_flags_parse_checked(IREE_FLAGS_PARSE_MODE_DEFAULT, &argc, &argv);
 
@@ -1452,5 +1455,8 @@ int main(int argc, char** argv) {
     loom_context_deinitialize(&context);
   }
   iree_arena_block_pool_deinitialize(&block_pool);
+
+  IREE_TRACE_ZONE_END(z0);
+  IREE_TRACE_APP_EXIT(exit_code);
   return exit_code;
 }

--- a/loom/src/loom/tools/loom-opt/loom-opt.c
+++ b/loom/src/loom/tools/loom-opt/loom-opt.c
@@ -1219,6 +1219,9 @@ int main(int argc, char** argv) {
       return 0;
     }
   }
+  IREE_TRACE_APP_ENTER();
+  IREE_TRACE_ZONE_BEGIN(z0);
+
   loom_tooling_cli_set_default_help_filter();
   iree_flags_parse_checked(IREE_FLAGS_PARSE_MODE_DEFAULT, &argc, &argv);
 
@@ -1460,5 +1463,9 @@ int main(int argc, char** argv) {
   loom_run_module_deinitialize(&run_module);
   iree_io_file_contents_free(contents);
   loom_run_session_deinitialize(&run_session);
-  return had_error ? 1 : 0;
+
+  const int exit_code = had_error ? 1 : 0;
+  IREE_TRACE_ZONE_END(z0);
+  IREE_TRACE_APP_EXIT(exit_code);
+  return exit_code;
 }


### PR DESCRIPTION
Several public Loom tools enter parser, linker, arena, allocator, and compiler code containing trace zones without establishing an application tracing lifetime. Providers with application-owned state, including the console provider, can therefore dereference absent state and terminate the tool instead of returning its normal result.

This change gives `loom-link`, `loom-format`, `loom-opt`, and `loom-check` the same process-level tracing contract already used by `loom-compile` and the execution tools. Each ordinary tool invocation enters one application lifetime, wraps execution in one top-level zone, and exits with the actual tool result code. Early agent-guidance exits remain outside tracing because they enter no traced compiler code.

The boundary is deliberately in each executable entry point: compiler libraries continue to assume their embedding process owns tracing initialization rather than creating nested global lifetimes.