### PR TITLE
[Loom] Admit bounded strided global addresses

### DIFF
--- a/loom/src/loom/target/arch/amdgpu/lower/memory.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/memory.c
@@ -2053,18 +2053,13 @@ static bool loom_amdgpu_memory_dynamic_term_can_flat_address(
       (term->byte_shift == 0 ||
        term->byte_shift == LOOM_LOW_SOURCE_MEMORY_ACCESS_BYTE_SHIFT_NONE)) {
     const loom_type_t index_type = loom_module_value_type(module, term->index);
-    if (loom_type_is_scalar(index_type) &&
-        loom_type_element_type(index_type) == LOOM_SCALAR_TYPE_OFFSET) {
+    if (loom_amdgpu_type_is_address_scalar(index_type)) {
       return true;
     }
   }
   if (loom_value_facts_is_float(term->byte_facts) ||
       term->byte_facts.range_lo < 0 || term->byte_stride <= 0 ||
       term->byte_stride > UINT32_MAX) {
-    return false;
-  }
-  if (term->byte_stride != 1 &&
-      term->byte_shift == LOOM_LOW_SOURCE_MEMORY_ACCESS_BYTE_SHIFT_NONE) {
     return false;
   }
   if (term->byte_shift != LOOM_LOW_SOURCE_MEMORY_ACCESS_BYTE_SHIFT_NONE &&

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_record_stride.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_record_stride.loom-test
@@ -1,0 +1,50 @@
+// RUN: emit source-low output=low
+
+amdgpu.target<gfx11-generic> @target
+kernel.def target(@target) @global_vector_record_non_power_two_stride() {
+  %unit = index.constant 1 : index
+  %expert_count = index.constant 256 : index
+  %workgroup_size = index.constant 32 : index
+  kernel.launch.config workgroups(%expert_count, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
+} launch(%input: buffer, %output: buffer) {
+  %expert = kernel.workgroup.id<x> : index
+  %lane = kernel.workitem.id<x> : index
+  %sixteen = index.constant 16 : index
+  %channel = index.mul %lane, %sixteen : index
+  %base = index.constant 0 : offset
+  %input_global = buffer.assume.memory_space<global> %input : buffer
+  %input_noalias = buffer.assume.noalias %input_global : buffer
+  %output_global = buffer.assume.memory_space<global> %output : buffer
+  %output_noalias = buffer.assume.noalias %output_global : buffer
+  %input_view = buffer.view %input_noalias[%base] : buffer -> view<256x6119424xi8, #dense>
+  %output_view = buffer.view %output_noalias[%base] : buffer -> view<256x512xi8, #dense>
+  %loaded = vector.load %input_view[%expert, %channel] : view<256x6119424xi8, #dense> -> vector<16xi8>
+  vector.store %loaded, %output_view[%expert, %channel] : vector<16xi8>, view<256x512xi8, #dense>
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(256, 1, 1) @global_vector_record_non_power_two_stride() asm {
+  %expert = live_in<amdgpu.workgroup_id.x> : reg<amdgpu.sgpr>
+  %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
+  %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 1566572544} : reg<amdgpu.sgpr x2>
+  %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 131072} : reg<amdgpu.sgpr x2>
+  %30 = v_lshlrev_b32_src0_inline %lane, 4
+  %31 = s_mov_b32 6119424
+  %32 = s_mul_i32 %expert, %31
+  %33 = slice %input_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %34 = slice %input_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %35 = s_mov_b32 0
+  %36 = s_add_u32 %33, %32
+  %37 = s_addc_u32 %34, %35
+  %38 = concat(%36, %37) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %loaded = global_load_b128_saddr %30, %38
+  %41 = s_lshl_b32_rhs_inline %expert, 9
+  %42 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %43 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %45 = s_add_u32 %42, %41
+  %46 = s_addc_u32 %43, %35
+  %47 = concat(%45, %46) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  global_store_b128_saddr %30, %loaded, %47
+  return
+}


### PR DESCRIPTION
Loom's AMDGPU global-memory lowering rejected bounded record-address terms
when the scalar record ordinal used an `index` type or a non-power-of-two
constant byte stride. That forced otherwise representable global vector
accesses away from the ordinary flat-address path before the existing
materializer could lower them.

This change recognizes both address-capable scalar types and accepts positive
32-bit constant strides when the term's proven byte range fits the
flat-address contract. The emitter and address form remain unchanged: the
scalar record ordinal is scaled into the resource base while the vector lane
offset remains the vector address.

The source-low golden covers a model-sized 6,119,424-byte record stride and
pins the intended `global_*_b128_saddr` load/store form, including SGPR
record-base arithmetic and the independent VGPR lane offset.

## Reviewer Notes

The main review surface is
`loom_amdgpu_memory_dynamic_term_can_flat_address`: the widened admission must
stay aligned with the existing emission predicate while retaining rejection
of floating, negative, zero, oversized, and invalid-shift terms.
