### PR TITLE
[Loom] Preserve offsets across dynamic dense strides

### DIFF
--- a/loom/src/loom/codegen/low/source_memory_plan.c
+++ b/loom/src/loom/codegen/low/source_memory_plan.c
@@ -868,35 +868,19 @@ static bool loom_low_source_memory_access_scaled_index_from_value(
   return true;
 }
 
-static bool loom_low_source_memory_access_scaled_dynamic_index(
-    const loom_module_t* module, const loom_value_fact_table_t* fact_table,
-    loom_value_id_t dynamic_index, int64_t byte_stride,
-    int64_t static_byte_offset, loom_value_id_t* out_scaled_index,
-    int64_t* out_index_multiplier, int64_t* out_index_offset,
-    int64_t* out_byte_stride, int64_t* out_static_byte_offset,
-    loom_value_facts_t* out_expression_facts) {
-  *out_scaled_index = dynamic_index;
-  *out_index_multiplier = 1;
-  *out_index_offset = 0;
+static bool loom_low_source_memory_access_apply_scaled_index(
+    const loom_low_source_memory_scaled_index_t* scaled_index,
+    int64_t byte_stride, int64_t static_byte_offset, int64_t* out_byte_stride,
+    int64_t* out_static_byte_offset) {
   *out_byte_stride = byte_stride;
   *out_static_byte_offset = static_byte_offset;
-  *out_expression_facts =
-      loom_value_fact_table_lookup(fact_table, dynamic_index);
-
-  loom_low_source_memory_scaled_index_t scaled_index = {0};
-  if (!loom_low_source_memory_access_scaled_index_from_value(
-          module, fact_table, dynamic_index, &scaled_index) ||
-      (scaled_index.index == dynamic_index && scaled_index.multiplier == 1 &&
-       scaled_index.offset == 0)) {
-    return false;
-  }
 
   int64_t scaled_byte_stride = 0;
   int64_t static_offset_delta = 0;
   int64_t new_static_byte_offset = 0;
-  if (!iree_checked_mul_i64(byte_stride, scaled_index.multiplier,
+  if (!iree_checked_mul_i64(byte_stride, scaled_index->multiplier,
                             &scaled_byte_stride) ||
-      !iree_checked_mul_i64(byte_stride, scaled_index.offset,
+      !iree_checked_mul_i64(byte_stride, scaled_index->offset,
                             &static_offset_delta) ||
       !iree_checked_add_i64(static_byte_offset, static_offset_delta,
                             &new_static_byte_offset)) {
@@ -907,12 +891,8 @@ static bool loom_low_source_memory_access_scaled_dynamic_index(
   if (static_byte_offset >= 0 && new_static_byte_offset < 0) {
     return false;
   }
-  *out_scaled_index = scaled_index.index;
-  *out_index_multiplier = scaled_index.multiplier;
-  *out_index_offset = scaled_index.offset;
   *out_byte_stride = scaled_byte_stride;
   *out_static_byte_offset = new_static_byte_offset;
-  *out_expression_facts = scaled_index.expression_facts;
   return true;
 }
 
@@ -1500,12 +1480,29 @@ static bool loom_low_source_memory_access_plan_from_components(
     // affine expression. This retains any reusable dynamic prefix while
     // keeping the final canonical terms independent of source spelling.
     const int64_t unscaled_static_byte_offset = static_byte_offset;
-    if (loom_low_source_memory_access_scaled_dynamic_index(
-            module, fact_table, dynamic_index, byte_stride, static_byte_offset,
-            &dynamic_index, &dynamic_index_multiplier, &dynamic_index_offset,
-            &byte_stride, &static_byte_offset, &expression_facts) &&
-        static_byte_offset != unscaled_static_byte_offset) {
-      out_plan->source_index_static_offset_extracted = true;
+    loom_low_source_memory_scaled_index_t scaled_index = {0};
+    const bool has_scaled_index =
+        loom_low_source_memory_access_scaled_index_from_value(
+            module, fact_table, dynamic_index, &scaled_index) &&
+        (scaled_index.index != dynamic_index || scaled_index.multiplier != 1 ||
+         scaled_index.offset != 0);
+    // A coordinate suffix cannot become a static byte offset when its axis
+    // stride contains a dynamic extent: the suffix is multiplied by that
+    // extent and remains part of the dynamic address. A multiplier-only
+    // decomposition remains safe because every dynamic stride value stays on
+    // the term.
+    if (has_scaled_index &&
+        (scaled_index.offset == 0 || stride_value_count == 0) &&
+        loom_low_source_memory_access_apply_scaled_index(
+            &scaled_index, byte_stride, static_byte_offset, &byte_stride,
+            &static_byte_offset)) {
+      dynamic_index = scaled_index.index;
+      dynamic_index_multiplier = scaled_index.multiplier;
+      dynamic_index_offset = scaled_index.offset;
+      expression_facts = scaled_index.expression_facts;
+      if (static_byte_offset != unscaled_static_byte_offset) {
+        out_plan->source_index_static_offset_extracted = true;
+      }
     }
 
     loom_low_source_memory_affine_index_term_t
@@ -1517,6 +1514,7 @@ static bool loom_low_source_memory_access_plan_from_components(
             module, fact_table, dynamic_index, affine_terms, &affine_term_count,
             &affine_index_offset) &&
         affine_term_count > 1 &&
+        (affine_index_offset == 0 || stride_value_count == 0) &&
         loom_low_source_memory_access_can_extract_static_index_offset(
             affine_index_offset);
     int64_t affine_static_byte_offset = static_byte_offset;

--- a/loom/src/loom/codegen/low/source_memory_plan_test.cc
+++ b/loom/src/loom/codegen/low/source_memory_plan_test.cc
@@ -1309,6 +1309,94 @@ TEST_F(SourceMemoryPlanTest, DynamicDenseLoadClassifiesMultipleIndices) {
       &plan, /*static_byte_offset=*/plan.static_byte_offset, 32));
 }
 
+TEST_F(SourceMemoryPlanTest, DynamicDenseLoadRetainsOffsetAcrossDynamicStride) {
+  loom_value_id_t buffer = DefineBufferArg();
+  loom_value_id_t row = DefineIndexArg();
+  loom_value_id_t row_component = DefineIndexArg();
+  loom_value_id_t column_count = DefineIndexArg();
+  loom_value_id_t column = DefineIndexArg();
+  loom_value_id_t layout = BuildDenseLayout();
+  loom_value_id_t base_offset =
+      loom_index_constant_result(BuildOffsetConstant(0));
+
+  loom_type_t view_type = loom_type_shaped_2d(
+      LOOM_TYPE_VIEW, LOOM_SCALAR_TYPE_F16, loom_dim_pack_static(16),
+      loom_dim_pack_dynamic(column_count), /*encoding_id=*/0);
+  view_type.encoding_id = (uint16_t)layout;
+  view_type.encoding_flags = LOOM_ENCODING_FLAG_SSA;
+  loom_op_t* view_op = nullptr;
+  IREE_ASSERT_OK(loom_buffer_view_build(&builder_, buffer, base_offset,
+                                        view_type, LOOM_LOCATION_UNKNOWN,
+                                        &view_op));
+
+  loom_value_id_t one = loom_index_constant_result(BuildIndexConstant(1));
+  loom_op_t* row_sum_op = nullptr;
+  IREE_ASSERT_OK(loom_index_add_build(&builder_, row, row_component,
+                                      loom_type_scalar(LOOM_SCALAR_TYPE_INDEX),
+                                      LOOM_LOCATION_UNKNOWN, &row_sum_op));
+  loom_op_t* offset_row_op = nullptr;
+  IREE_ASSERT_OK(loom_index_add_build(&builder_,
+                                      loom_index_add_result(row_sum_op), one,
+                                      loom_type_scalar(LOOM_SCALAR_TYPE_INDEX),
+                                      LOOM_LOCATION_UNKNOWN, &offset_row_op));
+  const loom_value_id_t dynamic_indices[] = {
+      loom_index_add_result(offset_row_op),
+      column,
+  };
+  const int64_t static_indices[] = {INT64_MIN, INT64_MIN};
+  loom_op_t* load_op = nullptr;
+  IREE_ASSERT_OK(loom_vector_load_build(
+      &builder_, 0, loom_buffer_view_result(view_op), dynamic_indices,
+      IREE_ARRAYSIZE(dynamic_indices), static_indices,
+      IREE_ARRAYSIZE(static_indices), 0, 0,
+      VectorType1D(LOOM_SCALAR_TYPE_F16, 1), LOOM_LOCATION_UNKNOWN, &load_op));
+
+  loom_value_id_t two = loom_index_constant_result(BuildIndexConstant(2));
+  loom_op_t* scaled_row_op = nullptr;
+  IREE_ASSERT_OK(loom_index_mul_build(&builder_, row, two,
+                                      loom_type_scalar(LOOM_SCALAR_TYPE_INDEX),
+                                      LOOM_LOCATION_UNKNOWN, &scaled_row_op));
+  const loom_value_id_t scaled_dynamic_indices[] = {
+      loom_index_mul_result(scaled_row_op),
+      column,
+  };
+  loom_op_t* scaled_load_op = nullptr;
+  IREE_ASSERT_OK(loom_vector_load_build(
+      &builder_, 0, loom_buffer_view_result(view_op), scaled_dynamic_indices,
+      IREE_ARRAYSIZE(scaled_dynamic_indices), static_indices,
+      IREE_ARRAYSIZE(static_indices), 0, 0,
+      VectorType1D(LOOM_SCALAR_TYPE_F16, 1), LOOM_LOCATION_UNKNOWN,
+      &scaled_load_op));
+
+  loom_value_fact_table_t facts = {0};
+  ComputeFacts(&facts);
+  loom_low_source_memory_access_plan_t plan = {};
+  loom_low_source_memory_access_diagnostic_t diagnostic = {0};
+  ASSERT_TRUE(BuildPlan(&facts, load_op, &plan, &diagnostic));
+  EXPECT_EQ(plan.static_byte_offset, 0);
+  EXPECT_FALSE(plan.source_index_static_offset_extracted);
+  ASSERT_EQ(plan.dynamic_term_count, 2u);
+  EXPECT_EQ(plan.dynamic_terms[0].index, loom_index_add_result(offset_row_op));
+  EXPECT_EQ(plan.dynamic_terms[0].axis, 0u);
+  EXPECT_EQ(plan.dynamic_terms[0].byte_stride, 2);
+  ASSERT_EQ(plan.dynamic_terms[0].stride_value_count, 1u);
+  EXPECT_EQ(plan.dynamic_terms[0].stride_values[0], column_count);
+  EXPECT_EQ(plan.dynamic_terms[1].index, column);
+  EXPECT_EQ(plan.dynamic_terms[1].axis, 1u);
+  EXPECT_EQ(plan.dynamic_terms[1].byte_stride, 2);
+  EXPECT_EQ(plan.dynamic_terms[1].stride_value_count, 0u);
+
+  loom_low_source_memory_access_plan_t scaled_plan = {};
+  ASSERT_TRUE(BuildPlan(&facts, scaled_load_op, &scaled_plan, &diagnostic));
+  EXPECT_EQ(scaled_plan.static_byte_offset, 0);
+  EXPECT_FALSE(scaled_plan.source_index_static_offset_extracted);
+  ASSERT_EQ(scaled_plan.dynamic_term_count, 2u);
+  EXPECT_EQ(scaled_plan.dynamic_terms[0].index, row);
+  EXPECT_EQ(scaled_plan.dynamic_terms[0].byte_stride, 4);
+  ASSERT_EQ(scaled_plan.dynamic_terms[0].stride_value_count, 1u);
+  EXPECT_EQ(scaled_plan.dynamic_terms[0].stride_values[0], column_count);
+}
+
 TEST_F(SourceMemoryPlanTest, ScalarViewAccessClassifiesCoordinateAxes) {
   loom_value_id_t buffer = DefineBufferArg();
   loom_value_id_t layout = BuildDenseLayout();


### PR DESCRIPTION
Source-memory planning now preserves affine coordinate offsets when their axis stride contains runtime extents. A coordinate such as `row + 1` in a dense view with a dynamic trailing dimension must remain `(row + 1) * dynamic_stride`; moving the suffix into the target's static byte-offset field incorrectly forms `row * dynamic_stride + 1`.

The planner still extracts affine suffixes when the complete byte stride is static, and it still folds constant multipliers into dynamic terms when no offset would cross the runtime stride. This retains the target-friendly canonical forms that are algebraically valid without changing the authored address.

## Planning Invariant

Dense axis strides are represented as a constant byte multiplier plus zero or more runtime extent values. A coordinate offset can become a static byte offset only when that runtime extent list is empty. Otherwise the offset is multiplied by every runtime extent and remains part of the dynamic coordinate expression.

Both affine decomposition paths now enforce that invariant. The simple scaled-index path receives the stride classification explicitly, while the multi-term affine path declines expansion when a nonzero affine constant would be separated from a dynamic stride. The resulting plan continues to expose reusable dynamic expressions and fact-derived constant scaling where doing so preserves the address exactly.

## Coverage

The source-memory planner test constructs a rank-two dense F16 view with a dynamic column count and verifies that a row-coordinate suffix remains attached to the dynamic row term. A second access verifies the optimization control: a multiplier-only row expression still becomes a larger constant byte multiplier while retaining the dynamic column-count stride.

## Reviewer Notes

The central review point is the distinction between `byte_stride`, which contains the known constant element and layout factors, and `stride_values`, which contains runtime extents multiplied into the term later. Any coordinate constant moved into `static_byte_offset` has escaped those runtime multipliers, so extraction is legal precisely when `stride_value_count` is zero.
