### PR TITLE
[HAL/AMDGPU] Provision PM4 dynamic binding uploads

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/api.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/api.h
@@ -350,9 +350,11 @@ typedef struct iree_hal_amdgpu_logical_device_options_t {
     // together before publishing packets.
     uint32_t kernarg_capacity;
     // Device-visible control upload ring capacity in bytes for each host queue.
-    // Zero disables the optional upload ring; non-zero values must be powers of
-    // two. This carries queue-ordered metadata such as device-side
-    // command-buffer fixup inputs without using the file staging pool.
+    // Zero disables the optional upload ring in AQL mode. PM4 and automatic
+    // modes resolve zero to the capacity required for PM4 command buffers.
+    // Non-zero values must be powers of two. This carries queue-ordered
+    // metadata such as device-side command-buffer fixup inputs without using
+    // the file staging pool.
     uint32_t upload_capacity;
   } host_queues;
 

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_test.cc
@@ -1162,39 +1162,10 @@ TEST_F(HostQueueCommandBufferTest, HostcallAddressIsBakedIntoPm4Dispatches) {
 }
 
 TEST_F(HostQueueCommandBufferTest,
-       AutoCommandBufferModeUsesAqlWithoutUploadRing) {
+       AutoCommandBufferModeSelectsPm4WhenAvailable) {
   iree_hal_amdgpu_logical_device_options_t options;
   iree_hal_amdgpu_logical_device_options_initialize(&options);
   options.command_buffer_mode = IREE_HAL_AMDGPU_COMMAND_BUFFER_MODE_AUTO;
-  options.preallocate_pools = 0;
-
-  TestLogicalDevice test_device;
-  IREE_ASSERT_OK(
-      test_device.Initialize(&options, &libhsa_, &topology_, host_allocator_));
-
-  Ref<iree_hal_command_buffer_t> command_buffer;
-  IREE_ASSERT_OK(iree_hal_command_buffer_create(
-      test_device.base_device(), IREE_HAL_COMMAND_BUFFER_MODE_DEFAULT,
-      IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
-      /*binding_capacity=*/0, command_buffer.out()));
-  EXPECT_TRUE(iree_hal_amdgpu_aql_command_buffer_isa(command_buffer));
-  EXPECT_FALSE(iree_hal_amdgpu_pm4_command_buffer_isa(command_buffer));
-
-  Ref<iree_hal_command_buffer_t> transfer_command_buffer;
-  IREE_ASSERT_OK(iree_hal_command_buffer_create(
-      test_device.base_device(), IREE_HAL_COMMAND_BUFFER_MODE_DEFAULT,
-      IREE_HAL_COMMAND_CATEGORY_TRANSFER, IREE_HAL_QUEUE_AFFINITY_ANY,
-      /*binding_capacity=*/0, transfer_command_buffer.out()));
-  EXPECT_TRUE(iree_hal_amdgpu_aql_command_buffer_isa(transfer_command_buffer));
-  EXPECT_FALSE(iree_hal_amdgpu_pm4_command_buffer_isa(transfer_command_buffer));
-}
-
-TEST_F(HostQueueCommandBufferTest,
-       AutoCommandBufferModeUsesPm4WhenFullySupported) {
-  iree_hal_amdgpu_logical_device_options_t options;
-  iree_hal_amdgpu_logical_device_options_initialize(&options);
-  options.command_buffer_mode = IREE_HAL_AMDGPU_COMMAND_BUFFER_MODE_AUTO;
-  options.host_queues.upload_capacity = 64 * 1024;
   options.preallocate_pools = 0;
 
   TestLogicalDevice test_device;
@@ -1216,6 +1187,14 @@ TEST_F(HostQueueCommandBufferTest,
             iree_hal_amdgpu_pm4_command_buffer_isa(command_buffer));
   EXPECT_NE(pm4_supported,
             iree_hal_amdgpu_aql_command_buffer_isa(command_buffer));
+
+  Ref<iree_hal_command_buffer_t> transfer_command_buffer;
+  IREE_ASSERT_OK(iree_hal_command_buffer_create(
+      test_device.base_device(), IREE_HAL_COMMAND_BUFFER_MODE_DEFAULT,
+      IREE_HAL_COMMAND_CATEGORY_TRANSFER, IREE_HAL_QUEUE_AFFINITY_ANY,
+      /*binding_capacity=*/0, transfer_command_buffer.out()));
+  EXPECT_TRUE(iree_hal_amdgpu_aql_command_buffer_isa(transfer_command_buffer));
+  EXPECT_FALSE(iree_hal_amdgpu_pm4_command_buffer_isa(transfer_command_buffer));
 }
 
 TEST_F(HostQueueCommandBufferTest,
@@ -1223,7 +1202,6 @@ TEST_F(HostQueueCommandBufferTest,
   iree_hal_amdgpu_logical_device_options_t options;
   iree_hal_amdgpu_logical_device_options_initialize(&options);
   options.command_buffer_mode = IREE_HAL_AMDGPU_COMMAND_BUFFER_MODE_AUTO;
-  options.host_queues.upload_capacity = 64 * 1024;
   options.preallocate_pools = 0;
 
   TestLogicalDevice test_device;
@@ -1377,11 +1355,11 @@ TEST_F(HostQueueCommandBufferTest,
   iree_hal_command_buffer_release(command_buffer);
 }
 
-TEST_F(HostQueueCommandBufferTest, Pm4MixedDynamicDispatchUsesGpuFixup) {
+TEST_F(HostQueueCommandBufferTest,
+       AutoMixedDynamicDispatchUsesDefaultUploadRing) {
   iree_hal_amdgpu_logical_device_options_t options;
   iree_hal_amdgpu_logical_device_options_initialize(&options);
-  options.command_buffer_mode = IREE_HAL_AMDGPU_COMMAND_BUFFER_MODE_PM4;
-  options.host_queues.upload_capacity = 64 * 1024;
+  options.command_buffer_mode = IREE_HAL_AMDGPU_COMMAND_BUFFER_MODE_AUTO;
   options.preallocate_pools = 0;
 
   TestLogicalDevice test_device;
@@ -1499,11 +1477,10 @@ TEST_F(HostQueueCommandBufferTest, Pm4MixedDynamicDispatchUsesGpuFixup) {
   iree_hal_executable_release(executable);
 }
 
-TEST_F(HostQueueCommandBufferTest, Pm4DynamicDispatchUsesBindingTableSlots) {
+TEST_F(HostQueueCommandBufferTest, Pm4DynamicDispatchUsesDefaultUploadRing) {
   iree_hal_amdgpu_logical_device_options_t options;
   iree_hal_amdgpu_logical_device_options_initialize(&options);
   options.command_buffer_mode = IREE_HAL_AMDGPU_COMMAND_BUFFER_MODE_PM4;
-  options.host_queues.upload_capacity = 64 * 1024;
   options.preallocate_pools = 0;
 
   TestLogicalDevice test_device;

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -160,6 +160,10 @@ iree_hal_amdgpu_logical_device_query_device_memory_capacity(
 // much memory).
 #define IREE_HAL_AMDGPU_LOGICAL_DEVICE_MIN_LARGE_HOST_BLOCK_SIZE (64 * 1024)
 
+// Per-queue device-visible control upload ring capacity in bytes provisioned
+// when PM4 command buffers may require dynamic binding-table fixups.
+#define IREE_HAL_AMDGPU_LOGICAL_DEVICE_PM4_UPLOAD_CAPACITY_DEFAULT (64 * 1024)
+
 IREE_API_EXPORT void iree_hal_amdgpu_logical_device_options_initialize(
     iree_hal_amdgpu_logical_device_options_t* out_options) {
   IREE_ASSERT_ARGUMENT(out_options);
@@ -2010,6 +2014,18 @@ iree_status_t iree_hal_amdgpu_logical_device_create(
   iree_hal_amdgpu_logical_device_options_t resolved_options = *options;
   iree_hal_amdgpu_logical_device_options_apply_create_params(&resolved_options,
                                                              create_params);
+  // PM4 and automatic modes promise reusable dispatch command buffers,
+  // including dynamic binding-table fixups. Provision their queue-control
+  // storage here so a valid recording cannot fail only when first submitted.
+  // Applications requiring AQL without this storage select AQL mode directly.
+  if ((resolved_options.command_buffer_mode ==
+           IREE_HAL_AMDGPU_COMMAND_BUFFER_MODE_PM4 ||
+       resolved_options.command_buffer_mode ==
+           IREE_HAL_AMDGPU_COMMAND_BUFFER_MODE_AUTO) &&
+      resolved_options.host_queues.upload_capacity == 0) {
+    resolved_options.host_queues.upload_capacity =
+        IREE_HAL_AMDGPU_LOGICAL_DEVICE_PM4_UPLOAD_CAPACITY_DEFAULT;
+  }
 
   // Verify the topology is valid for a logical device.
   // This may have already been performed by the caller but doing it here


### PR DESCRIPTION
AMDGPU command-buffer modes that admit PM4 now provision the queue-control upload storage required by reusable dynamic binding tables. Previously, normal device options allowed an explicit PM4 command buffer to record successfully and then fail its first queue execution because the per-queue upload ring was disabled. Automatic mode avoided that failure by silently excluding PM4 unless the caller supplied a non-default ring size.

## Device Contract

Logical-device creation resolves a zero upload capacity to a 64 KiB per-queue control ring when the caller selects PM4 or automatic mode. Resolution happens before option verification and physical-resource allocation, so the realized device satisfies the complete command-buffer capability it advertises.

Automatic mode can therefore select PM4 whenever the request and physical device satisfy its capability checks, including for reusable command buffers with dynamic binding-table fixups. Requests that PM4 cannot represent still use AQL. Explicit AQL mode retains zero as its no-upload-storage policy, and explicit nonzero capacities remain unchanged in every mode.

This keeps resource policy at device creation instead of adding a tooling-only flag or allowing a late submission failure. Registered command-line tools and direct C API callers pass through the same resolution boundary.

## Coverage

The dynamic-dispatch tests now exercise both explicit PM4 and automatic mode with the default zero upload option. Each records an indirect-binding command buffer and exercises device-side binding fixup during submission. Automatic-mode coverage also verifies that supported dispatch recordings select PM4 while unsupported transfer and one-shot requests continue to select AQL.

## Reviewer Notes

The important distinction is whether a device mode admits PM4. Both PM4 and automatic modes own the storage needed to make every selected PM4 command buffer executable. Applications that require AQL's lower memory footprint select AQL mode directly rather than configuring an automatic mode that is unable to realize one of its advertised implementations.
