### PR TITLE
[Runtime] Insert graph command-buffer barriers

### DIFF
--- a/libhrx/src/libhrx/BUILD.bazel
+++ b/libhrx/src/libhrx/BUILD.bazel
@@ -115,6 +115,18 @@ hrx_cc_shared_library(
 )
 
 hrx_cc_test(
+    name = "graph_exec_test",
+    srcs = ["graph_exec_test.cc"],
+    deps = [
+        ":hrx_static",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+hrx_cc_test(
     name = "graph_buffer_test",
     srcs = ["graph_buffer_test.cc"],
     deps = [

--- a/libhrx/src/libhrx/CMakeLists.txt
+++ b/libhrx/src/libhrx/CMakeLists.txt
@@ -156,6 +156,20 @@ iree_cc_library(
 
 iree_cc_test(
   NAME
+    graph_exec_test
+  SRCS
+    "graph_exec_test.cc"
+  DEPS
+    ::hrx_static
+    iree::base
+    iree::hal
+    iree::testing::gtest
+    iree::testing::gtest_main
+    libhrx_defs
+)
+
+iree_cc_test(
+  NAME
     graph_buffer_test
   SRCS
     "graph_buffer_test.cc"

--- a/libhrx/src/libhrx/graph_analysis.c
+++ b/libhrx/src/libhrx/graph_analysis.c
@@ -207,6 +207,7 @@ typedef struct hrx_uint32x2_t {
 
 static hrx_uint32x2_t hrx_graph_partition_with_streams(
     hrx_graph_sort_node_t* nodes, uint32_t node_count, uint32_t* node_index_map,
+    const hrx_graph_edge_t* additional_edges,
     hrx_graph_partition_t* partitions) {
   uint32_t partition_count = 0;
   uint32_t block_count = 0;
@@ -260,6 +261,12 @@ static hrx_uint32x2_t hrx_graph_partition_with_streams(
             break;
           }
         }
+        for (const hrx_graph_edge_t* edge = additional_edges;
+             deps_satisfied && edge != NULL; edge = edge->next) {
+          if (edge->to != nodes[i].node) continue;
+          const uint32_t dep_index = node_index_map[edge->from->node_index];
+          if (dep_index >= i) deps_satisfied = false;
+        }
         if (!deps_satisfied) break;
 
         const bool use_workstreams =
@@ -273,6 +280,17 @@ static hrx_uint32x2_t hrx_graph_partition_with_streams(
               node_index_map[nodes[i].node->dependencies[j]->node_index];
           if (dep_index >= recordable_start && dep_index < i) {
             uint8_t dep_stream = nodes[dep_index].stream_id;
+            connected_streams |= (1 << dep_stream);
+          }
+        }
+        uint32_t additional_dependency_count = 0;
+        for (const hrx_graph_edge_t* edge = additional_edges; edge != NULL;
+             edge = edge->next) {
+          if (edge->to != nodes[i].node) continue;
+          ++additional_dependency_count;
+          const uint32_t dep_index = node_index_map[edge->from->node_index];
+          if (dep_index >= recordable_start && dep_index < i) {
+            const uint8_t dep_stream = nodes[dep_index].stream_id;
             connected_streams |= (1 << dep_stream);
           }
         }
@@ -305,7 +323,8 @@ static hrx_uint32x2_t hrx_graph_partition_with_streams(
           const uint32_t dep_count =
               iree_math_count_ones_u32(connected_streams);
           const bool is_sync_point =
-              (nodes[i].node->dependency_count > HRX_GRAPH_MAX_FAN_OUT);
+              (nodes[i].node->dependency_count + additional_dependency_count >
+               HRX_GRAPH_MAX_FAN_OUT);
           if (!use_workstreams || dep_count > 1 || is_sync_point) {
             assigned_stream = 0;
             for (uint32_t k = recordable_start; k < i; ++k) {
@@ -383,7 +402,7 @@ iree_status_t hrx_graph_schedule_nodes(hrx_graph_node_block_t* node_blocks,
 
   const hrx_uint32x2_t partition_block_counts =
       hrx_graph_partition_with_streams(sorted_nodes, node_count, node_index_map,
-                                       partitions);
+                                       additional_edges, partitions);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, partition_block_counts.values[0]);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, partition_block_counts.values[1]);
 

--- a/libhrx/src/libhrx/graph_buffer_test.cc
+++ b/libhrx/src/libhrx/graph_buffer_test.cc
@@ -77,6 +77,82 @@ TEST_F(GraphBufferTest, RecordsAndInstantiatesHandleBasedCopyAndFill) {
   hrx_graph_release(graph);
 }
 
+TEST_F(GraphBufferTest, DependentFillThenCopyProducesExpectedContents) {
+  hrx_graph_t graph = nullptr;
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_graph_create(device_, 0, &graph)));
+
+  const hrx_graph_fill_buffer_node_attrs_t fill_attrs = {
+      /*.dst=*/{source_, 0, 64},
+      /*.pattern=*/0xA5u,
+      /*.pattern_size=*/1,
+  };
+  hrx_graph_node_t fill_node = nullptr;
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_graph_add_fill_buffer_node(
+      graph, nullptr, 0, &fill_attrs, &fill_node)));
+
+  const hrx_graph_copy_buffer_node_attrs_t copy_attrs = {
+      /*.src=*/{source_, 0, 64},
+      /*.dst=*/{destination_, 0, 64},
+  };
+  hrx_graph_node_t copy_node = nullptr;
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_graph_add_copy_buffer_node(
+      graph, &fill_node, 1, &copy_attrs, &copy_node)));
+
+  hrx_graph_exec_t executable = nullptr;
+  IREE_ASSERT_OK(
+      hrx_status_to_iree(hrx_graph_instantiate(graph, 0, &executable)));
+  IREE_ASSERT_OK(
+      hrx_status_to_iree(hrx_graph_exec_launch(executable, stream_)));
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_stream_synchronize(stream_)));
+
+  uint8_t contents[64] = {};
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_synchronous_d2h(
+      device_, destination_, 0, contents, sizeof(contents))));
+  for (uint8_t value : contents) EXPECT_EQ(value, 0xA5u);
+
+  hrx_graph_exec_release(executable);
+  hrx_graph_release(graph);
+}
+
+TEST_F(GraphBufferTest, AddedDependencyOrdersFillBeforeCopy) {
+  hrx_graph_t graph = nullptr;
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_graph_create(device_, 0, &graph)));
+
+  const hrx_graph_fill_buffer_node_attrs_t fill_attrs = {
+      /*.dst=*/{source_, 0, 64},
+      /*.pattern=*/0x3Cu,
+      /*.pattern_size=*/1,
+  };
+  hrx_graph_node_t fill_node = nullptr;
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_graph_add_fill_buffer_node(
+      graph, nullptr, 0, &fill_attrs, &fill_node)));
+
+  const hrx_graph_copy_buffer_node_attrs_t copy_attrs = {
+      /*.src=*/{source_, 0, 64},
+      /*.dst=*/{destination_, 0, 64},
+  };
+  hrx_graph_node_t copy_node = nullptr;
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_graph_add_copy_buffer_node(
+      graph, nullptr, 0, &copy_attrs, &copy_node)));
+  IREE_ASSERT_OK(hrx_status_to_iree(
+      hrx_graph_add_dependencies(graph, &fill_node, &copy_node, /*count=*/1)));
+
+  hrx_graph_exec_t executable = nullptr;
+  IREE_ASSERT_OK(
+      hrx_status_to_iree(hrx_graph_instantiate(graph, 0, &executable)));
+  IREE_ASSERT_OK(
+      hrx_status_to_iree(hrx_graph_exec_launch(executable, stream_)));
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_stream_synchronize(stream_)));
+
+  uint8_t contents[64] = {};
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_synchronous_d2h(
+      device_, destination_, 0, contents, sizeof(contents))));
+  for (uint8_t value : contents) EXPECT_EQ(value, 0x3Cu);
+
+  hrx_graph_exec_release(executable);
+  hrx_graph_release(graph);
+}
+
 TEST_F(GraphBufferTest, RejectsInvalidHandleRangesAndPatterns) {
   hrx_graph_t graph = nullptr;
   IREE_ASSERT_OK(hrx_status_to_iree(hrx_graph_create(device_, 0, &graph)));

--- a/libhrx/src/libhrx/graph_exec.c
+++ b/libhrx/src/libhrx/graph_exec.c
@@ -139,34 +139,76 @@ static iree_status_t hrx_graph_block_allocate(
 // Hazard tracking for command buffer recording
 //===----------------------------------------------------------------------===//
 
-typedef struct hrx_graph_node_index_set_t {
-  uint32_t values[8];
-  uint32_t count : 31;
-  uint32_t invalid : 1;
-} hrx_graph_node_index_set_t;
-
-static inline void hrx_graph_node_index_set_reset(
-    hrx_graph_node_index_set_t* set) {
-  set->count = 0;
-  set->invalid = 0;
+void hrx_graph_barrier_state_reset(hrx_graph_barrier_state_t* state) {
+  state->count = 0;
+  state->invalid = 0;
 }
 
-static bool hrx_graph_node_index_set_test_hazard(
-    const hrx_graph_node_index_set_t* set, uint32_t value) {
-  if (set->invalid) return true;
-  for (uint32_t i = 0; i < set->count; ++i) {
-    if (set->values[i] == value) return true;
+static bool hrx_graph_barrier_state_test_hazard(
+    const hrx_graph_barrier_state_t* state, uint32_t value) {
+  if (state->invalid) return true;
+  for (uint32_t i = 0; i < state->count; ++i) {
+    if (state->values[i] == value) return true;
   }
   return false;
 }
 
-static void hrx_graph_node_index_set_insert(hrx_graph_node_index_set_t* set,
-                                            uint32_t value) {
-  if (set->count >= IREE_ARRAYSIZE(set->values)) {
-    set->invalid = 1;
+static void hrx_graph_barrier_state_insert(hrx_graph_barrier_state_t* state,
+                                           uint32_t value) {
+  if (state->count >= IREE_ARRAYSIZE(state->values)) {
+    state->invalid = 1;
     return;
   }
-  set->values[set->count++] = value;
+  state->values[state->count++] = value;
+}
+
+iree_status_t hrx_graph_record_node_barrier(
+    hrx_graph_barrier_state_t* state, const hrx_graph_node_s* node,
+    const hrx_graph_edge_t* additional_edges, const uint32_t* node_index_map,
+    uint32_t sorted_index, iree_hal_command_buffer_t* command_buffer,
+    bool* out_did_barrier) {
+  IREE_ASSERT_ARGUMENT(state);
+  IREE_ASSERT_ARGUMENT(node);
+  IREE_ASSERT_ARGUMENT(node_index_map);
+  IREE_ASSERT_ARGUMENT(command_buffer);
+  IREE_ASSERT_ARGUMENT(out_did_barrier);
+  *out_did_barrier = false;
+
+  bool has_hazard = false;
+  for (uint32_t i = 0; i < node->dependency_count; ++i) {
+    const uint32_t dependency_sort_index =
+        node_index_map[node->dependencies[i]->node_index];
+    if (dependency_sort_index == UINT32_MAX) continue;
+    if (hrx_graph_barrier_state_test_hazard(state, dependency_sort_index)) {
+      has_hazard = true;
+      break;
+    }
+  }
+  for (const hrx_graph_edge_t* edge = additional_edges;
+       !has_hazard && edge != NULL; edge = edge->next) {
+    if (edge->to != node) continue;
+    const uint32_t dependency_sort_index =
+        node_index_map[edge->from->node_index];
+    if (dependency_sort_index == UINT32_MAX) continue;
+    has_hazard =
+        hrx_graph_barrier_state_test_hazard(state, dependency_sort_index);
+  }
+
+  if (has_hazard) {
+    const iree_hal_memory_barrier_t memory_barrier = {
+        .source_scope = IREE_HAL_MEMORY_ACCESS_ALL,
+        .target_scope = IREE_HAL_MEMORY_ACCESS_ALL,
+    };
+    IREE_RETURN_IF_ERROR(iree_hal_command_buffer_execution_barrier(
+        command_buffer, IREE_HAL_EXECUTION_STAGE_COMMAND_RETIRE,
+        IREE_HAL_EXECUTION_STAGE_COMMAND_ISSUE,
+        IREE_HAL_EXECUTION_BARRIER_FLAG_NONE, 1, &memory_barrier, 0, NULL));
+    hrx_graph_barrier_state_reset(state);
+    *out_did_barrier = true;
+  }
+
+  hrx_graph_barrier_state_insert(state, sorted_index);
+  return iree_ok_status();
 }
 
 //===----------------------------------------------------------------------===//
@@ -177,6 +219,7 @@ static iree_status_t hrx_graph_record_partition(
     hrx_graph_exec_s* exec, hrx_graph_sort_node_t* sorted_nodes,
     uint32_t node_start_index, uint32_t node_count,
     const uint32_t* node_index_map, uint8_t stream_id,
+    const hrx_graph_edge_t* additional_edges,
     iree_hal_command_buffer_t* command_buffer) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
@@ -191,32 +234,17 @@ static iree_status_t hrx_graph_record_partition(
                                                     label_color, location));
 
   iree_status_t status = iree_ok_status();
-  uint32_t in_stream_count = 0;
-  hrx_graph_node_index_set_t barrier_index_set;
-  hrx_graph_node_index_set_reset(&barrier_index_set);
+  hrx_graph_barrier_state_t barrier_state;
+  hrx_graph_barrier_state_reset(&barrier_state);
   for (uint32_t i = 0; iree_status_is_ok(status) && i < node_count; ++i) {
     hrx_graph_sort_node_t* sort_node = &sorted_nodes[node_start_index + i];
     if (sort_node->stream_id != stream_id) continue;
     hrx_graph_node_s* node = sort_node->node;
-    if (in_stream_count > 1) {
-      for (uint32_t j = 0; j < node->dependency_count; ++j) {
-        const uint32_t dependency_sort_index =
-            node_index_map[node->dependencies[j]->node_index];
-        const bool has_hazard = hrx_graph_node_index_set_test_hazard(
-            &barrier_index_set, dependency_sort_index);
-        if (has_hazard) {
-          IREE_RETURN_AND_END_ZONE_IF_ERROR(
-              z0, iree_hal_command_buffer_execution_barrier(
-                      command_buffer, IREE_HAL_EXECUTION_STAGE_COMMAND_RETIRE,
-                      IREE_HAL_EXECUTION_STAGE_COMMAND_ISSUE,
-                      IREE_HAL_EXECUTION_BARRIER_FLAG_NONE, 0, NULL, 0, NULL));
-          hrx_graph_node_index_set_reset(&barrier_index_set);
-        }
-        hrx_graph_node_index_set_insert(&barrier_index_set,
-                                        sort_node->sorted_index);
-      }
-    }
-    ++in_stream_count;
+    bool did_barrier = false;
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, hrx_graph_record_node_barrier(
+                &barrier_state, node, additional_edges, node_index_map,
+                sort_node->sorted_index, command_buffer, &did_barrier));
     switch (node->type) {
       case HRX_GRAPH_NODE_TYPE_INTERNAL_KERNEL: {
         const hrx_graph_kernel_node_attrs_internal_t* attrs =
@@ -411,7 +439,7 @@ iree_status_t hrx_graph_exec_instantiate_locked(
             z0, hrx_graph_record_partition(
                     exec, schedule.sorted_nodes, partition->start_index,
                     partition->count, schedule.node_index_map, s,
-                    ptrs.attrs->execute.command_buffer));
+                    additional_edges, ptrs.attrs->execute.command_buffer));
 
         if (wait_semaphore_count > 0) {
           for (uint16_t w = 0; w < wait_semaphore_count; w++) {

--- a/libhrx/src/libhrx/graph_exec_test.cc
+++ b/libhrx/src/libhrx/graph_exec_test.cc
@@ -1,0 +1,250 @@
+// Copyright 2026 The HRX Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <memory>
+#include <vector>
+
+#include "hrx_internal.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+class TestNode {
+ public:
+  TestNode(uint32_t node_index, std::vector<hrx_graph_node_s*> dependencies)
+      : storage_(new uint8_t[sizeof(hrx_graph_node_s) +
+                             dependencies.size() * sizeof(hrx_graph_node_s*)]) {
+    memset(storage_.get(), 0,
+           sizeof(hrx_graph_node_s) +
+               dependencies.size() * sizeof(hrx_graph_node_s*));
+    node_ = reinterpret_cast<hrx_graph_node_s*>(storage_.get());
+    node_->type = HRX_GRAPH_NODE_TYPE_INTERNAL_KERNEL;
+    node_->node_index = node_index;
+    node_->dependency_count = dependencies.size();
+    for (size_t i = 0; i < dependencies.size(); ++i) {
+      node_->dependencies[i] = dependencies[i];
+    }
+  }
+
+  hrx_graph_node_s* get() const { return node_; }
+
+ private:
+  std::unique_ptr<uint8_t[]> storage_;
+  hrx_graph_node_s* node_ = nullptr;
+};
+
+typedef struct BarrierSpyCommandBuffer {
+  iree_hal_command_buffer_t base;
+  iree_status_code_t failure_code;
+  uint32_t barrier_count;
+  iree_hal_execution_stage_t source_stage;
+  iree_hal_execution_stage_t target_stage;
+  iree_hal_execution_barrier_flags_t flags;
+  iree_host_size_t memory_barrier_count;
+  iree_hal_memory_barrier_t memory_barrier;
+  iree_host_size_t buffer_barrier_count;
+} BarrierSpyCommandBuffer;
+
+static void BarrierSpyDestroy(iree_hal_command_buffer_t* base_command_buffer) {}
+
+static iree_status_t BarrierSpyExecutionBarrier(
+    iree_hal_command_buffer_t* base_command_buffer,
+    iree_hal_execution_stage_t source_stage,
+    iree_hal_execution_stage_t target_stage,
+    iree_hal_execution_barrier_flags_t flags,
+    iree_host_size_t memory_barrier_count,
+    const iree_hal_memory_barrier_t* memory_barriers,
+    iree_host_size_t buffer_barrier_count,
+    const iree_hal_buffer_barrier_t* buffer_barriers) {
+  auto* command_buffer =
+      reinterpret_cast<BarrierSpyCommandBuffer*>(base_command_buffer);
+  if (command_buffer->failure_code != IREE_STATUS_OK) {
+    return iree_make_status(command_buffer->failure_code);
+  }
+  ++command_buffer->barrier_count;
+  command_buffer->source_stage = source_stage;
+  command_buffer->target_stage = target_stage;
+  command_buffer->flags = flags;
+  command_buffer->memory_barrier_count = memory_barrier_count;
+  if (memory_barrier_count > 0) {
+    command_buffer->memory_barrier = memory_barriers[0];
+  }
+  command_buffer->buffer_barrier_count = buffer_barrier_count;
+  return iree_ok_status();
+}
+
+static const iree_hal_command_buffer_vtable_t kBarrierSpyVtable = {
+    .destroy = BarrierSpyDestroy,
+    .execution_barrier = BarrierSpyExecutionBarrier,
+};
+
+class GraphBarrierTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    memset(&command_buffer_, 0, sizeof(command_buffer_));
+    iree_hal_command_buffer_initialize(
+        /*device_allocator=*/nullptr, IREE_HAL_COMMAND_BUFFER_MODE_UNVALIDATED,
+        IREE_HAL_COMMAND_CATEGORY_ANY, IREE_HAL_QUEUE_AFFINITY_ANY,
+        /*binding_capacity=*/0, /*validation_state=*/nullptr,
+        &kBarrierSpyVtable, &command_buffer_.base);
+    hrx_graph_barrier_state_reset(&state_);
+  }
+
+  void TearDown() override {
+    iree_hal_command_buffer_release(&command_buffer_.base);
+  }
+
+  bool Record(TestNode& node,
+              const hrx_graph_edge_t* additional_edges = nullptr) {
+    bool did_barrier = false;
+    IREE_EXPECT_OK(hrx_graph_record_node_barrier(
+        &state_, node.get(), additional_edges, node_index_map_,
+        node.get()->node_index, &command_buffer_.base, &did_barrier));
+    return did_barrier;
+  }
+
+  uint32_t node_index_map_[32] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+                                  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+                                  22, 23, 24, 25, 26, 27, 28, 29, 30, 31};
+  hrx_graph_barrier_state_t state_;
+  BarrierSpyCommandBuffer command_buffer_;
+};
+
+TEST_F(GraphBarrierTest, SingleAndIndependentNodesDoNotBarrier) {
+  TestNode a(0, {});
+  TestNode b(1, {});
+  EXPECT_FALSE(Record(a));
+  EXPECT_FALSE(Record(b));
+  EXPECT_EQ(command_buffer_.barrier_count, 0u);
+}
+
+TEST_F(GraphBarrierTest, LinearChainBarriersBeforeEachConsumer) {
+  TestNode a(0, {});
+  TestNode b(1, {a.get()});
+  TestNode c(2, {b.get()});
+  EXPECT_FALSE(Record(a));
+  EXPECT_TRUE(Record(b));
+  EXPECT_TRUE(Record(c));
+  EXPECT_EQ(command_buffer_.barrier_count, 2u);
+}
+
+TEST_F(GraphBarrierTest, FanInEmitsExactlyOneBarrier) {
+  TestNode a(0, {});
+  TestNode b(1, {});
+  TestNode c(2, {a.get(), b.get()});
+  EXPECT_FALSE(Record(a));
+  EXPECT_FALSE(Record(b));
+  EXPECT_TRUE(Record(c));
+  EXPECT_EQ(command_buffer_.barrier_count, 1u);
+}
+
+TEST_F(GraphBarrierTest, EarlierBarrierCoversOlderProducer) {
+  TestNode a(0, {});
+  TestNode b(1, {a.get()});
+  TestNode c(2, {a.get()});
+  EXPECT_FALSE(Record(a));
+  EXPECT_TRUE(Record(b));
+  EXPECT_FALSE(Record(c));
+  EXPECT_EQ(command_buffer_.barrier_count, 1u);
+}
+
+TEST_F(GraphBarrierTest, OverflowForcesConservativeDependencyBarrier) {
+  std::vector<std::unique_ptr<TestNode>> nodes;
+  for (uint32_t i = 0; i < 9; ++i) {
+    nodes.push_back(
+        std::make_unique<TestNode>(i, std::vector<hrx_graph_node_s*>{}));
+    EXPECT_FALSE(Record(*nodes.back()));
+  }
+  TestNode consumer(9, {nodes[0]->get()});
+  EXPECT_TRUE(Record(consumer));
+  EXPECT_EQ(command_buffer_.barrier_count, 1u);
+}
+
+TEST_F(GraphBarrierTest, AdditionalDependencyEdgeBarriersLikeInlineEdge) {
+  TestNode a(0, {});
+  TestNode b(1, {});
+  hrx_graph_edge_t edge = {/*.next=*/nullptr, /*.from=*/a.get(),
+                           /*.to=*/b.get()};
+  EXPECT_FALSE(Record(a, &edge));
+  EXPECT_TRUE(Record(b, &edge));
+  EXPECT_EQ(command_buffer_.barrier_count, 1u);
+}
+
+TEST_F(GraphBarrierTest, BarrierUsesRetireIssueAndAllMemoryScopes) {
+  TestNode a(0, {});
+  TestNode b(1, {a.get()});
+  EXPECT_FALSE(Record(a));
+  EXPECT_TRUE(Record(b));
+  EXPECT_EQ(command_buffer_.source_stage,
+            IREE_HAL_EXECUTION_STAGE_COMMAND_RETIRE);
+  EXPECT_EQ(command_buffer_.target_stage,
+            IREE_HAL_EXECUTION_STAGE_COMMAND_ISSUE);
+  EXPECT_EQ(command_buffer_.flags, IREE_HAL_EXECUTION_BARRIER_FLAG_NONE);
+  EXPECT_EQ(command_buffer_.memory_barrier_count, 1u);
+  EXPECT_EQ(command_buffer_.memory_barrier.source_scope,
+            IREE_HAL_MEMORY_ACCESS_ALL);
+  EXPECT_EQ(command_buffer_.memory_barrier.target_scope,
+            IREE_HAL_MEMORY_ACCESS_ALL);
+  EXPECT_EQ(command_buffer_.buffer_barrier_count, 0u);
+}
+
+TEST_F(GraphBarrierTest, BarrierFailureIsPropagatedAndStateIsPreserved) {
+  TestNode a(0, {});
+  TestNode b(1, {a.get()});
+  EXPECT_FALSE(Record(a));
+  command_buffer_.failure_code = IREE_STATUS_INTERNAL;
+  bool did_barrier = false;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INTERNAL,
+      hrx_graph_record_node_barrier(&state_, b.get(), nullptr, node_index_map_,
+                                    1, &command_buffer_.base, &did_barrier));
+  EXPECT_FALSE(did_barrier);
+  command_buffer_.failure_code = IREE_STATUS_OK;
+  EXPECT_TRUE(Record(b));
+}
+
+TEST(GraphScheduleTest, AdditionalDependencyStaysOnProducerWorkstream) {
+  constexpr uint32_t kNodeCount = 17;
+  std::vector<std::unique_ptr<TestNode>> nodes;
+  nodes.reserve(kNodeCount);
+  for (uint32_t i = 0; i < kNodeCount; ++i) {
+    nodes.push_back(
+        std::make_unique<TestNode>(i, std::vector<hrx_graph_node_s*>{}));
+  }
+
+  std::unique_ptr<uint8_t[]> block_storage(
+      new uint8_t[sizeof(hrx_graph_node_block_t) +
+                  kNodeCount * sizeof(hrx_graph_node_s*)]);
+  memset(
+      block_storage.get(), 0,
+      sizeof(hrx_graph_node_block_t) + kNodeCount * sizeof(hrx_graph_node_s*));
+  auto* block = reinterpret_cast<hrx_graph_node_block_t*>(block_storage.get());
+  block->capacity = kNodeCount;
+  block->count = kNodeCount;
+  for (uint32_t i = 0; i < kNodeCount; ++i) {
+    block->nodes[i] = nodes[i]->get();
+  }
+
+  hrx_graph_edge_t edge = {/*.next=*/nullptr, /*.from=*/nodes[0]->get(),
+                           /*.to=*/nodes[16]->get()};
+  iree_arena_block_pool_t block_pool;
+  iree_arena_block_pool_initialize(4096, iree_allocator_system(), &block_pool);
+  iree_arena_allocator_t arena;
+  iree_arena_initialize(&block_pool, &arena);
+
+  hrx_graph_schedule_t schedule;
+  IREE_ASSERT_OK(
+      hrx_graph_schedule_nodes(block, kNodeCount, &edge, &arena, &schedule));
+  const hrx_graph_sort_node_t& producer =
+      schedule.sorted_nodes[schedule.node_index_map[0]];
+  const hrx_graph_sort_node_t& consumer =
+      schedule.sorted_nodes[schedule.node_index_map[16]];
+  EXPECT_EQ(consumer.partition_id, producer.partition_id);
+  EXPECT_EQ(consumer.stream_id, producer.stream_id);
+
+  iree_arena_deinitialize(&arena);
+  iree_arena_block_pool_deinitialize(&block_pool);
+}
+
+}  // namespace

--- a/libhrx/src/libhrx/hrx_internal.h
+++ b/libhrx/src/libhrx/hrx_internal.h
@@ -413,6 +413,15 @@ typedef struct hrx_graph_schedule_t {
   iree_host_size_t block_count;
 } hrx_graph_schedule_t;
 
+// Tracks commands recorded since the most recent graph command-buffer
+// barrier. Exposed internally so the barrier planner can be tested without
+// depending on backend command scheduling behavior.
+typedef struct hrx_graph_barrier_state_t {
+  uint32_t values[8];
+  uint32_t count : 31;
+  uint32_t invalid : 1;
+} hrx_graph_barrier_state_t;
+
 typedef struct hrx_graph_exec_s {
   iree_atomic_ref_count_t ref_count;
   hrx_device_t device;
@@ -438,6 +447,13 @@ iree_status_t hrx_graph_schedule_nodes(hrx_graph_node_block_t* node_blocks,
                                        hrx_graph_edge_t* additional_edges,
                                        iree_arena_allocator_t* arena,
                                        hrx_graph_schedule_t* out_schedule);
+
+void hrx_graph_barrier_state_reset(hrx_graph_barrier_state_t* state);
+iree_status_t hrx_graph_record_node_barrier(
+    hrx_graph_barrier_state_t* state, const hrx_graph_node_s* node,
+    const hrx_graph_edge_t* additional_edges, const uint32_t* node_index_map,
+    uint32_t sorted_index, iree_hal_command_buffer_t* command_buffer,
+    bool* out_did_barrier);
 
 // Internal graph exec APIs (implemented in graph_exec.c).
 iree_status_t hrx_graph_exec_instantiate_locked(


### PR DESCRIPTION
Track each command recorded since the previous barrier and test dependencies before recording a consumer. This fixes the skipped second-command hazard, missing root and independent-node tracking, duplicate fan-in insertion, and delayed barriers in linear chains.

Emit retire-to-issue barriers with ALL-to-ALL memory scopes so dependent AMDGPU commands have both execution ordering and memory visibility. Treat edges added by hrx_graph_add_dependencies like inline dependencies during barrier planning and workstream assignment, preventing consumers from escaping to an unsynchronized command buffer.

Add deterministic barrier tests for independent nodes, chains, fan-in, epoch reset, tracker overflow, added edges, exact scopes, and error propagation. Add a scheduler workstream regression and public fill-to-copy readback tests for inline and subsequently added dependencies.