### PR TITLE
[Loom] Verify modules before format conversion

### DIFF
--- a/loom/src/loom/tools/loom-check/execute_test.cc
+++ b/loom/src/loom/tools/loom-check/execute_test.cc
@@ -1412,9 +1412,11 @@ TEST_F(ExecuteTest, FormatModeBytecodeRoundTrips) {
   IREE_ASSERT_OK(
       ExecuteFirst("// RUN: format bytecode\n"
                    "func.def @f() {\n"
+                   "  func.return\n"
                    "}\n"
                    "// ----\n"
                    "func.def @f() {\n"
+                   "  func.return\n"
                    "}\n",
                    &result));
   EXPECT_EQ(result.raw_outcome, LOOM_CHECK_PASS);

--- a/loom/src/loom/tools/loom-format/BUILD.bazel
+++ b/loom/src/loom/tools/loom-format/BUILD.bazel
@@ -26,6 +26,7 @@ loom_cc_library(
         "//loom/src/loom/format/text:parser",
         "//loom/src/loom/format/text:printer",
         "//loom/src/loom/ir",
+        "//loom/src/loom/verify",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:arena",
         "//runtime/src/iree/io:stream",

--- a/loom/src/loom/tools/loom-format/CMakeLists.txt
+++ b/loom/src/loom/tools/loom-format/CMakeLists.txt
@@ -28,6 +28,7 @@ loom_cc_library(
     loom::format::text::parser
     loom::format::text::printer
     loom::ir
+    loom::verify
   PUBLIC
 )
 

--- a/loom/src/loom/tools/loom-format/convert.c
+++ b/loom/src/loom/tools/loom-format/convert.c
@@ -15,6 +15,7 @@
 #include "loom/format/text/parser.h"
 #include "loom/format/text/printer.h"
 #include "loom/ir/module.h"
+#include "loom/verify/verify.h"
 
 //===----------------------------------------------------------------------===//
 // Format parsing and detection
@@ -237,6 +238,46 @@ static iree_status_t loom_format_write_output(
                           loom_module_format_name(output_format));
 }
 
+// Verifies the complete module after parsing or reading and before any output
+// formatter observes it. Parsing must permit forward references, so unresolved
+// symbols and other cross-operation errors become visible only at this point.
+static iree_status_t loom_format_verify_input_module(
+    iree_const_byte_span_t input, iree_string_view_t filename,
+    loom_module_format_t input_format, const loom_module_t* module,
+    loom_diagnostic_sink_t diagnostic_sink) {
+  loom_source_entry_t source_entry = {
+      .source_id = 0,
+      .source =
+          iree_make_string_view((const char*)input.data, input.data_length),
+      .filename = filename,
+  };
+  loom_source_table_resolver_t source_table = {
+      .entries = &source_entry,
+      .count = 1,
+  };
+  loom_verify_options_t verify_options = {
+      .sink = diagnostic_sink,
+      .max_errors = 100,
+  };
+  if (input_format == LOOM_MODULE_FORMAT_TEXT) {
+    verify_options.source_resolver = (loom_source_resolver_t){
+        .fn = loom_source_table_resolve,
+        .user_data = &source_table,
+    };
+  }
+
+  loom_verify_result_t verify_result = {0};
+  IREE_RETURN_IF_ERROR(
+      loom_verify_module(module, &verify_options, &verify_result));
+  if (verify_result.error_count > 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "module verification failed with %u error%s",
+                            verify_result.error_count,
+                            verify_result.error_count == 1 ? "" : "s");
+  }
+  return iree_ok_status();
+}
+
 //===----------------------------------------------------------------------===//
 // Conversion
 //===----------------------------------------------------------------------===//
@@ -262,11 +303,21 @@ iree_status_t loom_format_convert(iree_const_byte_span_t input,
                             "output format must be explicit");
   }
 
+  loom_module_format_t input_format = resolved_options.input_format;
+  if (input_format == LOOM_MODULE_FORMAT_AUTO) {
+    input_format = loom_module_format_detect_input(input);
+  }
+
   loom_module_t* module = NULL;
   iree_status_t status = loom_format_read_module(
-      input, filename, resolved_options.input_format, context, block_pool,
+      input, filename, input_format, context, block_pool,
       resolved_options.diagnostic_sink, resolved_options.low_asm_environment,
       &module, allocator);
+  if (iree_status_is_ok(status)) {
+    status =
+        loom_format_verify_input_module(input, filename, input_format, module,
+                                        resolved_options.diagnostic_sink);
+  }
   if (iree_status_is_ok(status)) {
     status = loom_format_write_output(
         module, resolved_options.output_format, block_pool,

--- a/loom/src/loom/tools/loom-format/convert.h
+++ b/loom/src/loom/tools/loom-format/convert.h
@@ -71,6 +71,10 @@ loom_module_format_t loom_module_format_detect_input(
 
 // Converts |input| from options.input_format to options.output_format.
 //
+// The parsed/read module is verified before either output format is written.
+// Syntax and verification diagnostics are reported through
+// options.diagnostic_sink and invalid modules return INVALID_ARGUMENT.
+//
 // The context must be finalized with every dialect/encoding that may appear in
 // the input. |block_pool| supplies transient parser, reader, and writer
 // storage. The returned output must be released with

--- a/loom/src/loom/tools/loom-format/convert_test.cc
+++ b/loom/src/loom/tools/loom-format/convert_test.cc
@@ -7,6 +7,7 @@
 #include "loom/tools/loom-format/convert.h"
 
 #include <string>
+#include <vector>
 
 #include "iree/base/internal/arena.h"
 #include "iree/testing/gtest.h"
@@ -19,6 +20,13 @@ namespace loom {
 namespace {
 
 using DialectVtablesFn = const loom_op_vtable_t* const* (*)(iree_host_size_t*);
+
+static iree_status_t CaptureDiagnostic(void* user_data,
+                                       const loom_diagnostic_t* diagnostic) {
+  auto* error_ids = static_cast<std::vector<std::string>*>(user_data);
+  error_ids->push_back(diagnostic->error->error_id);
+  return iree_ok_status();
+}
 
 iree_status_t RegisterDialect(loom_context_t* context, uint8_t dialect_id,
                               DialectVtablesFn dialect_vtables_fn) {
@@ -96,6 +104,26 @@ static iree_string_view_t ModuleText() {
       "}\n");
 }
 
+static iree_string_view_t UnresolvedCallText() {
+  return IREE_SV(
+      "func.def @caller(%value: index) -> (index) {\n"
+      "  %result = func.call @external_identity(%value) : (index) -> "
+      "(index)\n"
+      "  func.return %result : index\n"
+      "}\n");
+}
+
+static iree_string_view_t DeclaredCallText() {
+  return IREE_SV(
+      "func.decl @external_identity(%value: index) -> (index)\n"
+      "\n"
+      "func.def @caller(%value: index) -> (index) {\n"
+      "  %result = func.call @external_identity(%value) : (index) -> "
+      "(index)\n"
+      "  func.return %result : index\n"
+      "}\n");
+}
+
 TEST(FormatKind, ParsesAcceptedSpellings) {
   loom_module_format_t format = LOOM_MODULE_FORMAT_AUTO;
 
@@ -137,6 +165,37 @@ TEST_F(LoomFormatConvertTest, TextToBytecodeEmitsMagic) {
   ASSERT_GE(bytecode.size(), static_cast<size_t>(LOOM_BYTECODE_MAGIC_LENGTH));
   EXPECT_EQ(
       bytecode.compare(0, LOOM_BYTECODE_MAGIC_LENGTH, LOOM_BYTECODE_MAGIC), 0);
+}
+
+TEST_F(LoomFormatConvertTest, TextToBytecodeAcceptsDeclaredCall) {
+  std::string bytecode = ConvertTextToBytecode(DeclaredCallText());
+  ASSERT_GE(bytecode.size(), static_cast<size_t>(LOOM_BYTECODE_MAGIC_LENGTH));
+  EXPECT_EQ(
+      bytecode.compare(0, LOOM_BYTECODE_MAGIC_LENGTH, LOOM_BYTECODE_MAGIC), 0);
+}
+
+TEST_F(LoomFormatConvertTest, RejectsUnresolvedCallBeforeWritingOutput) {
+  for (loom_module_format_t output_format :
+       {LOOM_MODULE_FORMAT_TEXT, LOOM_MODULE_FORMAT_BYTECODE}) {
+    std::vector<std::string> error_ids;
+    loom_format_output_t output = {0};
+    loom_format_convert_options_t options = {
+        /*.input_format=*/LOOM_MODULE_FORMAT_TEXT,
+        /*.output_format=*/output_format,
+        /*.diagnostic_sink=*/{CaptureDiagnostic, &error_ids},
+    };
+    IREE_EXPECT_STATUS_IS(
+        IREE_STATUS_INVALID_ARGUMENT,
+        loom_format_convert(
+            iree_make_const_byte_span(UnresolvedCallText().data,
+                                      UnresolvedCallText().size),
+            IREE_SV("unresolved.loom"), &context_, &block_pool_, &options,
+            &output, iree_allocator_system()));
+    EXPECT_EQ(error_ids, std::vector<std::string>({"ERR_SYMBOL_002"}));
+    EXPECT_EQ(output.data, nullptr);
+    EXPECT_EQ(output.length, 0u);
+    loom_format_output_deinitialize(&output, iree_allocator_system());
+  }
 }
 
 TEST_F(LoomFormatConvertTest, BytecodeRoundTripsToText) {

--- a/loom/src/loom/tools/loom-format/loom-format.c
+++ b/loom/src/loom/tools/loom-format/loom-format.c
@@ -62,7 +62,9 @@ static void loom_format_print_agents_markdown(FILE* stream) {
       "`--from=auto` detects bytecode by the LOOM file magic and treats every\n"
       "other input as text. `--to=text` prints canonical text IR. `--to=bc`\n"
       "writes bytecode suitable for `loom-link --library=...` and\n"
-      "`loom-compile` input.\n");
+      "`loom-compile` input. The complete module is verified before either\n"
+      "output is written; external calls require a matching `func.decl` or\n"
+      "definition.\n");
 }
 
 int main(int argc, char** argv) {
@@ -81,7 +83,8 @@ int main(int argc, char** argv) {
       "stdout.\n"
       "The auto input format detects bytecode by the LOOM file magic and "
       "treats\n"
-      "all other input as text.\n");
+      "all other input as text. The complete module is verified before output "
+      "is written.\n");
   for (int i = 1; i < argc; ++i) {
     if (loom_tooling_cli_is_agents_markdown_arg(argv[i])) {
       loom_format_print_agents_markdown(stdout);

--- a/loom/src/loom/tools/loom-format/loom-format.test.json
+++ b/loom/src/loom/tools/loom-format/loom-format.test.json
@@ -16,6 +16,28 @@
           "loom-link --library"
         ]
       }
+    },
+    {
+      "name": "diagnoses unresolved symbol before bytecode output",
+      "run": {
+        "tool": "loom-format",
+        "args": [
+          "--from=text",
+          "--to=bc",
+          "--output={tmp}/invalid.loombc"
+        ]
+      },
+      "stdin": {
+        "text": "func.def @caller(%value: index) -> (index) {\n  %result = func.call @external_identity(%value) : (index) -> (index)\n  func.return %result : index\n}\n"
+      },
+      "exit": {
+        "nonzero": true
+      },
+      "stderr": {
+        "contains": [
+          "error [SYMBOL/002]: symbol '@external_identity' is referenced but not defined"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
`loom-format` now verifies a completed module before writing either canonical text or bytecode. Missing external declarations therefore produce the normal source-attributed `SYMBOL/002` diagnostic instead of surviving text formatting or reaching a bytecode-writer invariant.

Text parsing intentionally permits forward symbol references because a declaration or definition may occur later in the module. Previously, successful parsing was also treated as successful conversion: text output preserved unresolved placeholders, while bytecode output encountered the placeholder's empty symbol kind and reported an internal writer error.

The converter now invokes the existing module verifier once after text parsing or bytecode reading and before either output path. Text inputs retain their source resolver so verifier diagnostics include the original filename, line, and caret. External calls remain supported when the module provides the corresponding `func.decl` or definition.

The coverage exercises the user-reported unresolved call through both output formats, confirms that an explicitly declared external call still emits bytecode, and checks the CLI diagnostic. A `loom-check` bytecode round-trip fixture was also corrected to contain a valid function terminator now that format conversion enforces the normal module contract.
