### PR TITLE
[HRX] Use portable graph test vtable initialization

### DIFF
--- a/libhrx/src/libhrx/graph_exec_test.cc
+++ b/libhrx/src/libhrx/graph_exec_test.cc
@@ -75,8 +75,12 @@ static iree_status_t BarrierSpyExecutionBarrier(
 }
 
 static const iree_hal_command_buffer_vtable_t kBarrierSpyVtable = {
-    .destroy = BarrierSpyDestroy,
-    .execution_barrier = BarrierSpyExecutionBarrier,
+    /*.destroy=*/BarrierSpyDestroy,
+    /*.begin=*/nullptr,
+    /*.end=*/nullptr,
+    /*.begin_debug_group=*/nullptr,
+    /*.end_debug_group=*/nullptr,
+    /*.execution_barrier=*/BarrierSpyExecutionBarrier,
 };
 
 class GraphBarrierTest : public ::testing::Test {


### PR DESCRIPTION
The graph execution test now initializes its command-buffer vtable with portable C++17 aggregate syntax. This restores MSVC compatibility and satisfies the repository's designated-initializer check.

The barrier spy previously used C designated initializers to skip directly from `destroy` to `execution_barrier`. C++17 does not support that syntax on MSVC. The initializer now names each positional field with the standard comment labels and explicitly supplies null callbacks through the execution-barrier slot, preserving the test's behavior.
