### PR TITLE
[Loom] Ignore unused config bindings

### DIFF
--- a/loom/binding/c/benchmark/target/amdgpu/compile_throughput_benchmark.cc
+++ b/loom/binding/c/benchmark/target/amdgpu/compile_throughput_benchmark.cc
@@ -139,8 +139,7 @@ class AmdgpuI32ChainScenario final : public TargetCompileScenario {
         /*.bindings=*/bindings,
         /*.binding_count=*/IREE_ARRAYSIZE(bindings),
         /*.json_object=*/loomc_string_view_empty(),
-        /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
-            LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+        /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
     };
     IREE_RETURN_IF_ERROR(CompileModuleToPreparedLow(
         workspace, module, loomc_make_cstring_view("i32_memory_chain"),

--- a/loom/binding/c/benchmark/target/spirv/compile_throughput_benchmark.cc
+++ b/loom/binding/c/benchmark/target/spirv/compile_throughput_benchmark.cc
@@ -218,8 +218,7 @@ class SpirvTunerFlowScenario final : public SpirvScenarioBase {
         /*.bindings=*/bindings,
         /*.binding_count=*/IREE_ARRAYSIZE(bindings),
         /*.json_object=*/loomc_string_view_empty(),
-        /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
-            LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+        /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
     };
 
     IREE_RETURN_IF_ERROR(CompileModuleToPreparedLow(
@@ -295,8 +294,7 @@ class SpirvI32ChainScenario final : public SpirvScenarioBase {
         /*.bindings=*/bindings,
         /*.binding_count=*/IREE_ARRAYSIZE(bindings),
         /*.json_object=*/loomc_string_view_empty(),
-        /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
-            LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+        /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
     };
 
     IREE_RETURN_IF_ERROR(CompileModuleToPreparedLow(

--- a/loom/binding/c/benchmark/targetless_compile_throughput_benchmark.cc
+++ b/loom/binding/c/benchmark/targetless_compile_throughput_benchmark.cc
@@ -89,8 +89,7 @@ class TunerFlowScenario final : public CompileScenario {
             /*.binding_count=*/IREE_ARRAYSIZE(bindings),
             /*.json_object=*/
             loomc_make_cstring_view("{\"@tuner.model.hidden_size\":\"4096\"}"),
-            /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
-                LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+            /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
         },
     };
 
@@ -203,8 +202,7 @@ class ModelFlowScenario final : public CompileScenario {
             /*.bindings=*/bindings,
             /*.binding_count=*/IREE_ARRAYSIZE(bindings),
             /*.json_object=*/loomc_string_view_empty(),
-            /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
-                LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+            /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
         },
     };
 

--- a/loom/binding/c/example/compile_text.c
+++ b/loom/binding/c/example/compile_text.c
@@ -178,8 +178,7 @@ static loomc_status_t compile_module(compile_text_state_t* state) {
           {
               .bindings = bindings,
               .binding_count = 1,
-              .flags = LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
-                       LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+              .flags = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
           },
   };
   loomc_status_t status = loomc_compile_module(

--- a/loom/binding/c/example/link_modules.c
+++ b/loom/binding/c/example/link_modules.c
@@ -279,8 +279,7 @@ static loomc_status_t compile_linked_module(link_modules_state_t* state) {
               .binding_count = 1,
               .json_object =
                   loomc_make_cstring_view("{\"model\":{\"hidden_size\":2048}}"),
-              .flags = LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
-                       LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+              .flags = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
           },
   };
 

--- a/loom/binding/c/include/loomc/config.h
+++ b/loom/binding/c/include/loomc/config.h
@@ -13,9 +13,10 @@
 /// Per-invocation configuration bindings.
 ///
 /// Configuration is intentionally represented as plain borrowed key/value data
-/// plus one optional JSON/JSONC object string. Operation descriptors decide how
-/// strictly bindings are validated and whether unresolved configuration is
-/// allowed to remain in the produced result.
+/// plus one optional JSON/JSONC object string. Bindings without a matching
+/// config declaration are ignored so one stable config bag can serve modules
+/// that consume different subsets. Operation descriptors decide whether
+/// unresolved configuration may remain in the produced result.
 ///
 /// @par Example
 /// Use JSON for a framework-provided configuration file and explicit bindings
@@ -33,8 +34,7 @@
 ///     .bindings = overrides,
 ///     .binding_count = 1,
 ///     .json_object = loomc_make_cstring_view(json_config),
-///     .flags = LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
-///              LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+///     .flags = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
 /// };
 /// @endcode
 
@@ -57,13 +57,8 @@ typedef struct loomc_config_binding_t {
 
 /// Configuration validation and resolution policy bit values.
 typedef enum loomc_config_policy_flag_bits_e {
-  /// Reject config bindings outside the current operation's known config
-  /// declaration set. Link operations validate this before final pruning so
-  /// declared-but-unused bindings may be accepted and ignored.
-  LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN = 1u << 0,
-
   /// Require all final operation config values to be resolved.
-  LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED = 1u << 1,
+  LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED = 1u << 0,
 } loomc_config_policy_flag_bits_t;
 
 /// Bitmask of `loomc_config_policy_flag_bits_t` values.

--- a/loom/binding/c/src/config.c
+++ b/loom/binding/c/src/config.c
@@ -44,7 +44,6 @@ loomc_status_t loomc_config_validate_options(
   LOOMC_RETURN_IF_ERROR(
       loomc_config_validate_string_view(options->json_object));
   const loomc_config_policy_flags_t known_flags =
-      LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
       LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED;
   if ((options->flags & ~known_flags) != 0) {
     return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
@@ -104,30 +103,6 @@ static iree_status_t loomc_config_populate_set(
   return status;
 }
 
-static loom_tooling_config_materialize_flags_t loomc_config_materialize_flags(
-    loomc_config_policy_flags_t flags) {
-  loom_tooling_config_materialize_flags_t result = 0;
-  if (iree_any_bit_set(flags, LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN)) {
-    result |= LOOM_TOOLING_CONFIG_MATERIALIZE_REQUIRE_MATCHES;
-  }
-  return result;
-}
-
-static iree_status_t loomc_config_validate_known_keys(
-    const loom_tooling_config_set_t* config_set,
-    loomc_config_known_key_fn_t is_known_key, void* known_key_user_data) {
-  if (!config_set || !is_known_key) return iree_ok_status();
-  for (iree_host_size_t i = 0; i < config_set->binding_count; ++i) {
-    const loom_tooling_config_binding_t* binding = &config_set->bindings[i];
-    if (is_known_key(known_key_user_data, binding->key)) {
-      continue;
-    }
-    return iree_make_status(IREE_STATUS_NOT_FOUND, "unknown config '%.*s'",
-                            (int)binding->key.size, binding->key.data);
-  }
-  return iree_ok_status();
-}
-
 loomc_status_t loomc_config_apply_to_module(
     const loomc_config_apply_to_module_options_t* options) {
   if (options == NULL || options->module == NULL || options->result == NULL ||
@@ -148,21 +123,9 @@ loomc_status_t loomc_config_apply_to_module(
   loomc_status_t status = loomc_status_from_iree(
       loomc_config_populate_set(options->config, host_allocator, &config_set));
   loom_tooling_config_materialize_result_t materialize_result = {0};
-  if (loomc_status_is_ok(status) && options->is_known_key &&
-      iree_any_bit_set(options->config->flags,
-                       LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN)) {
-    status = loomc_status_from_iree(loomc_config_validate_known_keys(
-        &config_set, options->is_known_key, options->known_key_user_data));
-  }
   if (loomc_status_is_ok(status)) {
     loom_tooling_config_materialize_options_t materialize_options;
     loom_tooling_config_materialize_options_initialize(&materialize_options);
-    materialize_options.flags =
-        loomc_config_materialize_flags(options->config->flags);
-    if (options->is_known_key) {
-      materialize_options.flags &=
-          ~LOOM_TOOLING_CONFIG_MATERIALIZE_REQUIRE_MATCHES;
-    }
     materialize_options.config_set = &config_set;
     status = loomc_status_from_iree(loom_tooling_config_materialize_module(
         options->module, &materialize_options, options->block_pool,

--- a/loom/binding/c/src/config.h
+++ b/loom/binding/c/src/config.h
@@ -18,11 +18,6 @@
 extern "C" {
 #endif
 
-// Returns true when |key| names a config symbol known to the enclosing
-// invocation before final pruning.
-typedef bool (*loomc_config_known_key_fn_t)(void* user_data,
-                                            iree_string_view_t key);
-
 // Module config application options.
 typedef struct loomc_config_apply_to_module_options_t {
   // Public per-invocation config options to materialize.
@@ -36,15 +31,6 @@ typedef struct loomc_config_apply_to_module_options_t {
 
   // Diagnostic code used when config-domain statuses become result diagnostics.
   loomc_string_view_t diagnostic_code;
-
-  // Optional config-key membership query used for REJECT_UNKNOWN. When set,
-  // unknown bindings are rejected against this query before materialization,
-  // and bindings known by the invocation but pruned from |module| are ignored
-  // by final materialization.
-  loomc_config_known_key_fn_t is_known_key;
-
-  // User data passed to |is_known_key|.
-  void* known_key_user_data;
 
   // Block pool for transient config materialization storage.
   iree_arena_block_pool_t* block_pool;

--- a/loom/binding/c/src/link.c
+++ b/loom/binding/c/src/link.c
@@ -68,15 +68,6 @@ typedef struct loomc_link_diagnostic_capture_t {
   const loomc_source_t* source;
 } loomc_link_diagnostic_capture_t;
 
-typedef struct loomc_link_config_known_key_query_t {
-  // Frozen index that supplied the link plan.
-  const loom_link_module_index_t* index;
-  // Module ordinals selected by the link plan.
-  const uint8_t* selected_modules;
-  // Number of entries in |selected_modules|.
-  iree_host_size_t selected_module_count;
-} loomc_link_config_known_key_query_t;
-
 static iree_allocator_t loomc_link_iree_allocator(loomc_allocator_t allocator) {
   return iree_allocator_from_loomc(allocator);
 }
@@ -84,12 +75,6 @@ static iree_allocator_t loomc_link_iree_allocator(loomc_allocator_t allocator) {
 static bool loomc_link_any_flag_set(loomc_link_flags_t flags,
                                     loomc_link_flags_t bits) {
   return (flags & bits) != 0;
-}
-
-static bool loomc_link_config_options_have_bindings(
-    const loomc_config_options_t* config) {
-  return config && (config->binding_count != 0 ||
-                    !loomc_string_view_is_empty(config->json_object));
 }
 
 static loomc_status_t loomc_link_validate_linker_options(
@@ -402,68 +387,6 @@ static iree_status_t loomc_link_plan_build_roots(
   return iree_ok_status();
 }
 
-static iree_status_t loomc_link_plan_build_module_bitmap(
-    const loom_link_plan_t* plan, iree_arena_allocator_t* arena,
-    const uint8_t** out_selected_modules,
-    iree_host_size_t* out_selected_module_count) {
-  *out_selected_modules = NULL;
-  *out_selected_module_count = 0;
-  const loom_link_module_index_t* index = loom_link_plan_index(plan);
-  const iree_host_size_t module_count =
-      loom_link_module_index_module_count(index);
-  if (module_count == 0) {
-    return iree_ok_status();
-  }
-
-  uint8_t* selected_modules = NULL;
-  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(arena, module_count,
-                                                 sizeof(*selected_modules),
-                                                 (void**)&selected_modules));
-  memset(selected_modules, 0, module_count * sizeof(*selected_modules));
-
-  const iree_host_size_t plan_symbol_count = loom_link_plan_symbol_count(plan);
-  for (iree_host_size_t i = 0; i < plan_symbol_count; ++i) {
-    const loom_link_plan_symbol_t* planned = loom_link_plan_symbol_at(plan, i);
-    const loom_link_module_index_symbol_t* symbol =
-        loom_link_module_index_symbol_at(index, planned->symbol_ordinal);
-    const loom_link_module_index_module_t* module =
-        loom_link_module_index_symbol_module(index, symbol);
-    if (module == NULL || module->ordinal >= module_count) {
-      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "link plan referenced a stale module");
-    }
-    selected_modules[module->ordinal] = 1;
-  }
-
-  *out_selected_modules = selected_modules;
-  *out_selected_module_count = module_count;
-  return iree_ok_status();
-}
-
-static bool loomc_link_config_key_known(void* user_data,
-                                        iree_string_view_t key) {
-  const loomc_link_config_known_key_query_t* query =
-      (const loomc_link_config_known_key_query_t*)user_data;
-  if (!query || !query->index || !query->selected_modules) {
-    return false;
-  }
-  const iree_host_size_t symbol_count =
-      loom_link_module_index_symbol_count(query->index);
-  for (iree_host_size_t i = 0; i < symbol_count; ++i) {
-    const loom_link_module_index_symbol_t* symbol =
-        loom_link_module_index_symbol_at(query->index, i);
-    if (!symbol || symbol->module_ordinal >= query->selected_module_count ||
-        !query->selected_modules[symbol->module_ordinal] ||
-        !iree_any_bit_set(symbol->flags, LOOM_LINK_SYMBOL_FLAG_CONFIG)) {
-      continue;
-    }
-    if (iree_string_view_equal(symbol->name, key)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 static iree_status_t loomc_link_add_planned_modules(
     loomc_link_materialization_cache_t* cache, const loom_link_plan_t* plan,
     bool selective, iree_arena_allocator_t* arena, loom_linker_t* linker) {
@@ -612,10 +535,6 @@ loomc_status_t loomc_link_module(loomc_linker_t* linker,
   loomc_module_t* module = NULL;
   loom_linker_t* internal_linker = NULL;
   loom_module_t* linked_module = NULL;
-  const uint8_t* config_selected_modules = NULL;
-  iree_host_size_t config_selected_module_count = 0;
-  loomc_link_config_known_key_query_t config_known_key_query = {0};
-
   loomc_status_t status = loomc_link_materialization_cache_initialize(
       linker, workspace, options->link_index, result, &cache);
 
@@ -707,28 +626,11 @@ loomc_status_t loomc_link_module(loomc_linker_t* linker,
         operation_status);
   }
   if (loomc_status_is_ok(status) && loomc_result_succeeded(result)) {
-    if (iree_any_bit_set(options->config.flags,
-                         LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN) &&
-        loomc_link_config_options_have_bindings(&options->config)) {
-      status = loomc_status_from_iree(loomc_link_plan_build_module_bitmap(
-          plan, &arena, &config_selected_modules,
-          &config_selected_module_count));
-      config_known_key_query = (loomc_link_config_known_key_query_t){
-          .index = cache.module_index,
-          .selected_modules = config_selected_modules,
-          .selected_module_count = config_selected_module_count,
-      };
-    }
-  }
-  if (loomc_status_is_ok(status) && loomc_result_succeeded(result)) {
     loomc_config_apply_to_module_options_t config_apply_options = {
         .config = &options->config,
         .module = linked_module,
         .result = result,
         .diagnostic_code = loomc_make_cstring_view("CONFIG/INVALID"),
-        .is_known_key =
-            config_selected_modules ? loomc_link_config_key_known : NULL,
-        .known_key_user_data = &config_known_key_query,
         .block_pool = loomc_workspace_block_pool(workspace),
         .allocator = linker->allocator,
     };

--- a/loom/binding/c/test/compile_test.cc
+++ b/loom/binding/c/test/compile_test.cc
@@ -443,7 +443,7 @@ TEST(CompileTest, CompileModuleEmitsRequestedArtifacts) {
   EXPECT_NE(report.find(R"("config_binding_count":1)"), std::string::npos);
 }
 
-TEST(CompileTest, CompileModuleReportsUnknownConfigAsResultDiagnostic) {
+TEST(CompileTest, CompileModuleIgnoresUnusedConfig) {
   ContextPtr context = CreateContext();
   WorkspacePtr workspace = CreateWorkspace();
   CompilerPtr compiler = CreateCompiler(context.get());
@@ -467,7 +467,7 @@ TEST(CompileTest, CompileModuleReportsUnknownConfigAsResultDiagnostic) {
           /*.bindings=*/bindings,
           /*.binding_count=*/1,
           /*.json_object=*/loomc_string_view_empty(),
-          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN,
+          /*.flags=*/0,
       },
   };
   loomc_result_t* result = nullptr;
@@ -476,14 +476,15 @@ TEST(CompileTest, CompileModuleReportsUnknownConfigAsResultDiagnostic) {
       &options, loomc_allocator_system(), &result);
   LOOMC_EXPECT_OK(status);
   ResultPtr result_ptr(result);
-  ExpectFailedResultCode(result_ptr.get(), "CONFIG/INVALID");
+  ExpectSucceededResult(result_ptr.get());
   ASSERT_EQ(loomc_result_artifact_count(result_ptr.get()), 1u);
   const loomc_artifact_t* report_artifact = FindArtifact(
       result_ptr.get(), LOOMC_ARTIFACT_KIND_REPORT, LOOMC_ARTIFACT_FORMAT_JSON);
   ASSERT_NE(report_artifact, nullptr);
   std::string report = ToString(report_artifact->contents);
-  EXPECT_NE(report.find(R"("state":"failed")"), std::string::npos);
-  EXPECT_NE(report.find(R"("diagnostic_count":1)"), std::string::npos);
+  EXPECT_NE(report.find(R"("state":"succeeded")"), std::string::npos);
+  EXPECT_NE(report.find(R"("diagnostic_count":0)"), std::string::npos);
+  EXPECT_NE(report.find(R"("config_binding_count":1)"), std::string::npos);
 }
 
 TEST(CompileTest, CompileModuleReportsUnresolvedConfigAsResultDiagnostic) {

--- a/loom/binding/c/test/launch_config_test.cc
+++ b/loom/binding/c/test/launch_config_test.cc
@@ -206,8 +206,7 @@ kernel.def @entry() {
                                LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE);
   options.config.bindings = bindings;
   options.config.binding_count = 3;
-  options.config.flags = LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
-                         LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED;
+  options.config.flags = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED;
   loomc_launch_config_t config = EmptyResultConfig();
   ResultPtr result;
   Evaluate(module.get(), workspace.get(), &options, &config, &result);
@@ -248,8 +247,7 @@ kernel.def @entry() {
           "cols": 17
         }
       })");
-  options.config.flags = LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
-                         LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED;
+  options.config.flags = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED;
   loomc_launch_config_t config = EmptyResultConfig();
   ResultPtr result;
   Evaluate(module.get(), workspace.get(), &options, &config, &result);
@@ -263,7 +261,7 @@ kernel.def @entry() {
   EXPECT_EQ(config.workgroup_size.z, 1u);
 }
 
-TEST(LaunchConfigTest, ReportsInvalidConfigBindingAsResultDiagnostic) {
+TEST(LaunchConfigTest, IgnoresUnusedConfigBinding) {
   ContextPtr context = CreateContext();
   WorkspacePtr workspace = CreateWorkspace();
   ModulePtr module = DeserializeModule(context.get(), workspace.get(), R"(
@@ -278,20 +276,29 @@ kernel.def @entry() {
 }
 )");
 
-  loomc_config_binding_t bindings[] = {{
-      /*.key=*/loomc_make_cstring_view("shape.cols"),
-      /*.value=*/loomc_make_cstring_view("7"),
-  }};
+  loomc_config_binding_t bindings[] = {
+      {
+          /*.key=*/loomc_make_cstring_view("shape.rows"),
+          /*.value=*/loomc_make_cstring_view("7"),
+      },
+      {
+          /*.key=*/loomc_make_cstring_view("shape.cols"),
+          /*.value=*/loomc_make_cstring_view("not parsed"),
+      },
+  };
   loomc_launch_config_eval_options_t options =
       EvalOptions("entry", LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT);
   options.config.bindings = bindings;
-  options.config.binding_count = 1;
-  options.config.flags = LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN;
+  options.config.binding_count = 2;
+  options.config.flags = LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED;
   loomc_launch_config_t config = EmptyResultConfig();
   ResultPtr result;
   Evaluate(module.get(), workspace.get(), &options, &config, &result);
 
-  ExpectFailedResultCode(result.get(), "CONFIG/INVALID");
+  ExpectSucceededResult(result.get());
+  EXPECT_EQ(config.workgroup_count.x, 7u);
+  EXPECT_EQ(config.workgroup_count.y, 1u);
+  EXPECT_EQ(config.workgroup_count.z, 1u);
 }
 
 TEST(LaunchConfigTest, EvaluatesWorkloadArguments) {

--- a/loom/binding/c/test/link_test.cc
+++ b/loom/binding/c/test/link_test.cc
@@ -753,8 +753,7 @@ func.def public @entry() -> (index) {
                   "model": {"hidden_size": 2048}
                 }
               })"),
-          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
-              LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
       },
   };
   ResultPtr first_result;
@@ -1114,8 +1113,7 @@ func.def public @from_bytecode() -> (index) {
           /*.bindings=*/bindings,
           /*.binding_count=*/1,
           /*.json_object=*/loomc_string_view_empty(),
-          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
-              LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
       },
   };
   ResultPtr result;
@@ -1183,8 +1181,7 @@ func.def public @specialized_rgb() -> (index) {
           /*.bindings=*/bindings,
           /*.binding_count=*/1,
           /*.json_object=*/loomc_string_view_empty(),
-          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
-              LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
       },
   };
   ResultPtr result;
@@ -1201,7 +1198,7 @@ func.def public @specialized_rgb() -> (index) {
             std::string::npos);
 }
 
-TEST(LinkTest, LinkModuleRejectsConfigDeclaredOnlyByUnselectedProvider) {
+TEST(LinkTest, LinkModuleIgnoresConfigDeclaredOnlyByUnselectedProvider) {
   ContextPtr context = CreateContext();
   BuilderPtr builder = CreateBuilder(context.get());
   SourcePtr selected_source = CreateTextSource("selected.loom", R"(
@@ -1250,18 +1247,22 @@ func.def public @unused() -> (index) {
           /*.bindings=*/bindings,
           /*.binding_count=*/1,
           /*.json_object=*/loomc_string_view_empty(),
-          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN,
+          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
       },
   };
   ResultPtr result;
   ModulePtr module = LinkIndex(linker.get(), workspace.get(), link_index.get(),
                                &options, &result);
 
-  EXPECT_EQ(module.get(), nullptr);
-  ExpectFailedResultCode(result.get(), "CONFIG/INVALID");
+  ASSERT_TRUE(loomc_result_succeeded(result.get()));
+  ASSERT_NE(module.get(), nullptr);
+  std::string text = SerializeModuleToText(module.get());
+  EXPECT_NE(text.find("func.def public retain @selected"), std::string::npos);
+  EXPECT_EQ(text.find("@unused"), std::string::npos);
+  EXPECT_EQ(text.find("unused.operation.tile_count"), std::string::npos);
 }
 
-TEST(LinkTest, LinkModuleReportsUnknownConfigAsResultDiagnostic) {
+TEST(LinkTest, LinkModuleIgnoresUnknownConfig) {
   ContextPtr context = CreateContext();
   BuilderPtr builder = CreateBuilder(context.get());
   SourcePtr source = CreateTextSource("entry.loom", R"(
@@ -1296,15 +1297,17 @@ func.def public @entry(%x: i32) -> (i32) {
           /*.bindings=*/bindings,
           /*.binding_count=*/1,
           /*.json_object=*/loomc_string_view_empty(),
-          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN,
+          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
       },
   };
   ResultPtr result;
   ModulePtr module = LinkIndex(linker.get(), workspace.get(), link_index.get(),
                                &options, &result);
 
-  EXPECT_EQ(module.get(), nullptr);
-  ExpectFailedResultCode(result.get(), "CONFIG/INVALID");
+  ASSERT_TRUE(loomc_result_succeeded(result.get()));
+  ASSERT_NE(module.get(), nullptr);
+  std::string text = SerializeModuleToText(module.get());
+  EXPECT_NE(text.find("func.def public @entry"), std::string::npos);
 }
 
 TEST(LinkTest, LinkModuleReportsUnresolvedConfigAsResultDiagnostic) {

--- a/loom/binding/c/test/target/amdgpu_test.cc
+++ b/loom/binding/c/test/target/amdgpu_test.cc
@@ -491,8 +491,7 @@ kernel.def target(@gfx11_generic) @configured_store() {
           /*.bindings=*/bindings,
           /*.binding_count=*/IREE_ARRAYSIZE(bindings),
           /*.json_object=*/loomc_string_view_empty(),
-          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REJECT_UNKNOWN |
-              LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
+          /*.flags=*/LOOMC_CONFIG_POLICY_FLAG_REQUIRE_RESOLVED,
       },
   };
 

--- a/loom/src/loom/tooling/config/config.c
+++ b/loom/src/loom/tooling/config/config.c
@@ -767,8 +767,6 @@ iree_status_t loom_tooling_config_materialize_module(
     return iree_ok_status();
   }
 
-  const bool require_matches = iree_any_bit_set(
-      options->flags, LOOM_TOOLING_CONFIG_MATERIALIZE_REQUIRE_MATCHES);
   for (iree_host_size_t i = 0; i < binding_count; ++i) {
     const loom_tooling_config_binding_t* binding = &config_set->bindings[i];
     iree_string_view_t key = binding->key;
@@ -777,24 +775,14 @@ iree_status_t loom_tooling_config_materialize_module(
     IREE_RETURN_IF_ERROR(
         loom_tooling_config_lookup_symbol(module, key, &symbol_id));
     if (symbol_id == LOOM_SYMBOL_ID_INVALID) {
-      if (require_matches) {
-        return iree_make_status(IREE_STATUS_NOT_FOUND, "unknown config '%.*s'",
-                                (int)key.size, key.data);
-      }
       ++result.ignored_count;
       continue;
     }
 
     loom_symbol_t* symbol = &module->symbols.entries[symbol_id];
     if (!loom_tooling_config_symbol_is_config(symbol)) {
-      if (!require_matches && symbol->definition == NULL &&
-          symbol->defining_op == NULL) {
-        ++result.ignored_count;
-        continue;
-      }
-      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "symbol '%.*s' is not a config symbol",
-                              (int)key.size, key.data);
+      ++result.ignored_count;
+      continue;
     }
     loom_op_t* old_op = symbol->defining_op;
     loom_value_id_t config_value =

--- a/loom/src/loom/tooling/config/config.h
+++ b/loom/src/loom/tooling/config/config.h
@@ -60,19 +60,8 @@ typedef struct loom_tooling_config_set_t {
   iree_host_size_t binding_capacity;
 } loom_tooling_config_set_t;
 
-// Materialization policy flags.
-enum loom_tooling_config_materialize_flag_bits_e {
-  // Reject bindings whose keys do not name config symbols in the module.
-  // Programmatic callers compiling many modules with a shared config map can
-  // leave this unset so non-sensitive bindings are ignored.
-  LOOM_TOOLING_CONFIG_MATERIALIZE_REQUIRE_MATCHES = 1u << 0,
-};
-typedef uint32_t loom_tooling_config_materialize_flags_t;
-
 // Options for materializing config values into a module.
 typedef struct loom_tooling_config_materialize_options_t {
-  // Policy flags controlling typo handling and module sensitivity.
-  loom_tooling_config_materialize_flags_t flags;
   // Borrowed config set for the current compiler operation. NULL is accepted
   // and treated as an empty set.
   const loom_tooling_config_set_t* config_set;
@@ -83,7 +72,7 @@ typedef struct loom_tooling_config_materialize_result_t {
   // Number of bindings that replaced config symbols with config.def ops.
   iree_host_size_t materialized_count;
   // Number of bindings ignored because the module has no matching config
-  // symbol and REQUIRE_MATCHES was unset.
+  // symbol.
   iree_host_size_t ignored_count;
 } loom_tooling_config_materialize_result_t;
 
@@ -149,7 +138,7 @@ iree_status_t loom_tooling_config_set_append_json_file(
 
 // Replaces matching config.decl/config.def symbol ops with config.def ops whose
 // initializer attributes are parsed from |options->config_set|. Bindings
-// without matching config symbols are ignored unless REQUIRE_MATCHES is set.
+// without matching config symbols are ignored.
 //
 // This is intentionally a direct module operation rather than a pass. Tooling
 // should call it immediately after loading and, when requested, initially

--- a/loom/src/loom/tooling/config/config_test.cc
+++ b/loom/src/loom/tooling/config/config_test.cc
@@ -77,13 +77,11 @@ class ConfigMaterializeTest : public ::testing::Test {
   iree_status_t Materialize(
       loom_module_t* module, const loom_tooling_config_binding_t* bindings,
       iree_host_size_t binding_count,
-      loom_tooling_config_materialize_flags_t flags,
       loom_tooling_config_materialize_result_t* out_result) {
     loom_tooling_config_set_t config_set;
     loom_tooling_config_set_initialize(iree_allocator_system(), &config_set);
     loom_tooling_config_materialize_options_t options;
     loom_tooling_config_materialize_options_initialize(&options);
-    options.flags = flags;
     options.config_set = &config_set;
     iree_status_t status = iree_ok_status();
     for (iree_host_size_t i = 0; i < binding_count && iree_status_is_ok(status);
@@ -195,7 +193,7 @@ TEST_F(ConfigMaterializeTest, ConfigSetAppendsJsonFileBindings) {
   loom_tooling_config_set_deinitialize(&config_set);
 }
 
-TEST_F(ConfigMaterializeTest, IgnoresNonSensitiveBindings) {
+TEST_F(ConfigMaterializeTest, IgnoresBindingsWithoutConfigSymbols) {
   ModulePtr module = Parse(R"(
 func.def @no_config(%x: i32) -> (i32) {
   func.return %x : i32
@@ -203,11 +201,11 @@ func.def @no_config(%x: i32) -> (i32) {
 )");
 
   loom_tooling_config_binding_t binding = {
-      /*.key=*/IREE_SV("model36.model.hidden_size"),
-      /*.value=*/IREE_SV("4096"),
+      /*.key=*/IREE_SV("no_config"),
+      /*.value=*/IREE_SV("not parsed"),
   };
   loom_tooling_config_materialize_result_t result = {0};
-  IREE_ASSERT_OK(Materialize(module.get(), &binding, 1, 0, &result));
+  IREE_ASSERT_OK(Materialize(module.get(), &binding, 1, &result));
   EXPECT_EQ(result.materialized_count, 0u);
   EXPECT_EQ(result.ignored_count, 1u);
 
@@ -231,9 +229,7 @@ func.def @read_config() -> (index) {
       /*.value=*/IREE_SV("4096"),
   };
   loom_tooling_config_materialize_result_t result = {0};
-  IREE_ASSERT_OK(Materialize(module.get(), &binding, 1,
-                             LOOM_TOOLING_CONFIG_MATERIALIZE_REQUIRE_MATCHES,
-                             &result));
+  IREE_ASSERT_OK(Materialize(module.get(), &binding, 1, &result));
   EXPECT_EQ(result.materialized_count, 1u);
   EXPECT_EQ(result.ignored_count, 0u);
 
@@ -254,9 +250,7 @@ config.decl @model36.model.hidden_size : %value: index where [range(%value, 0, 8
       /*.key=*/IREE_SV("model36.model.hidden_size"),
       /*.value=*/IREE_SV("4103"),
   };
-  iree_status_t status =
-      Materialize(module.get(), &binding, 1,
-                  LOOM_TOOLING_CONFIG_MATERIALIZE_REQUIRE_MATCHES, nullptr);
+  iree_status_t status = Materialize(module.get(), &binding, 1, nullptr);
   EXPECT_EQ(iree_status_code(status), IREE_STATUS_INVALID_ARGUMENT);
   iree_status_free(status);
 }
@@ -271,9 +265,7 @@ config.decl @model36.layout : encoding<layout>
       /*.value=*/IREE_SV(" #dense "),
   };
   loom_tooling_config_materialize_result_t result = {0};
-  IREE_ASSERT_OK(Materialize(module.get(), &binding, 1,
-                             LOOM_TOOLING_CONFIG_MATERIALIZE_REQUIRE_MATCHES,
-                             &result));
+  IREE_ASSERT_OK(Materialize(module.get(), &binding, 1, &result));
   EXPECT_EQ(result.materialized_count, 1u);
 
   std::string printed = Print(module.get());
@@ -291,9 +283,7 @@ config.decl @model36.layout : encoding<layout>
       /*.key=*/IREE_SV("model36.layout"),
       /*.value=*/IREE_SV("#ggml_q4_0<block_elems=32, storage_bytes=18>"),
   };
-  iree_status_t status =
-      Materialize(module.get(), &binding, 1,
-                  LOOM_TOOLING_CONFIG_MATERIALIZE_REQUIRE_MATCHES, nullptr);
+  iree_status_t status = Materialize(module.get(), &binding, 1, nullptr);
   EXPECT_EQ(iree_status_code(status), IREE_STATUS_INVALID_ARGUMENT);
   iree_status_free(status);
 }


### PR DESCRIPTION
Loom configuration is an invocation-wide bag of facts. Linking now materializes only bindings that name config symbols retained in the selected module, allowing hosts to reuse one stable superset across roots and partial-specialization outcomes.

Matched declarations continue to enforce their types, values, and constraints, and require-resolved continues to reject retained declarations without values. Completely unused bindings, bindings pruned by root or provider selection, and names colliding with non-config symbols are ignored without parsing.

This removes the reject-unknown public policy and the selected-provider membership scan. The main review surface is the simplified config materialization contract and the compile, launch-config, and link coverage for unused bindings.