### PR TITLE
[Loom/AMDGPU] Materialize uniform branch addresses in SGPRs

### DIFF
--- a/loom/src/loom/target/arch/amdgpu/lower/control.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/control.c
@@ -206,10 +206,61 @@ static bool loom_amdgpu_cfg_cond_br_edge_implied_bool(
       module, fact_table, &edge_facts, condition, out_condition);
 }
 
-static iree_status_t loom_amdgpu_materialize_branch_address(
+// Materializes a subgroup-uniform 32- or 64-bit address stored in VGPRs as an
+// SGPR branch payload.
+static iree_status_t loom_amdgpu_materialize_uniform_vgpr_address_as_sgpr(
     loom_low_lower_context_t* context, const loom_op_t* source_op,
     loom_value_id_t low_value_id, loom_type_t required_low_type,
     loom_value_id_t* out_low_value_id) {
+  *out_low_value_id = LOOM_VALUE_ID_INVALID;
+  const loom_module_t* module = loom_low_lower_context_module(context);
+  const loom_type_t actual_type = loom_module_value_type(module, low_value_id);
+  IREE_ASSERT(loom_amdgpu_low_type_is_register_class(
+      context, actual_type, LOOM_AMDGPU_REG_CLASS_ID_VGPR));
+  IREE_ASSERT(loom_amdgpu_low_type_is_register_class(
+      context, required_low_type, LOOM_AMDGPU_REG_CLASS_ID_SGPR));
+
+  const uint32_t register_count =
+      loom_low_register_type_unit_count(actual_type);
+  IREE_ASSERT_GE(register_count, 1);
+  IREE_ASSERT_LE(register_count, 2);
+  const loom_type_t vgpr_type =
+      loom_low_register_type_with_unit_count(actual_type, 1);
+  const loom_type_t sgpr_type =
+      loom_low_register_type_with_unit_count(required_low_type, 1);
+  // Address scalars contain at most two 32-bit register units.
+  loom_value_id_t sgpr_registers[2] = {
+      LOOM_VALUE_ID_INVALID,
+      LOOM_VALUE_ID_INVALID,
+  };
+  for (uint32_t i = 0; i < register_count; ++i) {
+    loom_value_id_t vgpr_register = low_value_id;
+    if (register_count != 1) {
+      IREE_RETURN_IF_ERROR(loom_amdgpu_extract_low_register_unit(
+          context, source_op, low_value_id, register_count, i, vgpr_type,
+          &vgpr_register));
+    }
+    const loom_value_id_t operands[] = {vgpr_register};
+    loom_op_t* readfirstlane_op = NULL;
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_low_op(
+        context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_READFIRSTLANE_B32,
+        operands, IREE_ARRAYSIZE(operands), loom_make_named_attr_slice(NULL, 0),
+        &sgpr_type, 1, &readfirstlane_op));
+    sgpr_registers[i] =
+        loom_value_slice_get(loom_low_op_results(readfirstlane_op), 0);
+  }
+
+  const loom_type_t result_type =
+      loom_low_register_type_with_unit_count(required_low_type, register_count);
+  return loom_amdgpu_build_low_register_range(context, source_op,
+                                              sgpr_registers, register_count,
+                                              result_type, out_low_value_id);
+}
+
+static iree_status_t loom_amdgpu_materialize_branch_address(
+    loom_low_lower_context_t* context, const loom_op_t* source_op,
+    loom_value_id_t source_value_id, loom_value_id_t low_value_id,
+    loom_type_t required_low_type, loom_value_id_t* out_low_value_id) {
   *out_low_value_id = low_value_id;
 
   const loom_module_t* module = loom_low_lower_context_module(context);
@@ -230,10 +281,21 @@ static iree_status_t loom_amdgpu_materialize_branch_address(
 
   const bool actual_is_sgpr = loom_amdgpu_low_type_is_register_class(
       context, actual_type, LOOM_AMDGPU_REG_CLASS_ID_SGPR);
+  const bool actual_is_vgpr = loom_amdgpu_low_type_is_register_class(
+      context, actual_type, LOOM_AMDGPU_REG_CLASS_ID_VGPR);
   if (requires_vgpr && actual_is_sgpr) {
     IREE_RETURN_IF_ERROR(loom_amdgpu_materialize_low_vgpr_b32_registers(
         context, source_op, *out_low_value_id, out_low_value_id));
     actual_type = loom_module_value_type(module, *out_low_value_id);
+  } else if (requires_sgpr && actual_is_vgpr) {
+    const loom_value_facts_t source_facts = loom_value_fact_table_lookup(
+        loom_low_lower_context_fact_table(context), source_value_id);
+    if (loom_value_facts_is_subgroup_uniform(source_facts)) {
+      IREE_RETURN_IF_ERROR(loom_amdgpu_materialize_uniform_vgpr_address_as_sgpr(
+          context, source_op, *out_low_value_id, required_low_type,
+          out_low_value_id));
+      actual_type = loom_module_value_type(module, *out_low_value_id);
+    }
   }
 
   if (loom_type_equal(actual_type, required_low_type)) {
@@ -289,8 +351,8 @@ iree_status_t loom_amdgpu_materialize_branch_arg(
   if ((requires_sgpr || requires_vgpr) &&
       loom_amdgpu_type_is_address_scalar(source_type)) {
     return loom_amdgpu_materialize_branch_address(
-        context, source_terminator, low_value_id, required_low_type,
-        out_low_value_id);
+        context, source_terminator, source_value_id, low_value_id,
+        required_low_type, out_low_value_id);
   }
   if (requires_vgpr) {
     if (loom_amdgpu_type_is_i32(source_type) ||

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_control_flow.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_control_flow.loom-test
@@ -2412,3 +2412,82 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@wave64_target) workgroup_size(
   s_mov_b64_exec %83
   low.br ^_bb5
 }
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
+
+kernel.def target(@target) @uniform_vgpr_branch_address() {
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
+} launch(%control: buffer, %input: buffer, %output: buffer) {
+  %zero = index.constant 0 : index
+  %one = index.constant 1 : index
+  %base = index.constant 0 : offset
+  %seven = index.constant 7 : index
+  %three = index.constant 3 : index
+  %two = index.constant 2 : index
+  %twenty = index.constant 20 : index
+  %control_view = buffer.view %control[%base] : buffer -> view<1xi32, #dense>
+  %input_view = buffer.view %input[%base] : buffer -> view<32xi32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<32xi32, #dense>
+  %loaded = view.load %control_view[%zero] : view<1xi32, #dense> -> i32
+  %bounded = scalar.assume %loaded [range(%loaded, 0, 31)] : i32
+  %index_value = index.cast %bounded : i32 to index
+  %padded = index.add %index_value, %seven : index
+  %group = index.shrui %padded, %three : index
+  %element = index.shli %group, %two : index
+  cfg.br ^loop(%element: index)
+^loop(%carried: index):
+  %in_bounds = index.cmp ult, %carried, %twenty : index
+  cfg.cond_br %in_bounds, ^access, ^exit
+^access:
+  %active = index.assume %carried [range(%carried, 0, 19)] : index
+  %value = view.load %input_view[%active] : view<32xi32, #dense> -> i32
+  view.store %value, %output_view[%active] : i32, view<32xi32, #dense>
+  %next = index.add %active, %one : index
+  cfg.br ^loop(%next: index)
+^exit:
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @uniform_vgpr_branch_address() asm {
+  %control_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 4} : reg<amdgpu.sgpr x2>
+  %input_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 128} : reg<amdgpu.sgpr x2>
+  %output_view = resource<hal_binding> {index = 2, source_type = hal.buffer, extent = 128} : reg<amdgpu.sgpr x2>
+  %one = s_mov_b32 1
+  %twenty = s_mov_b32 20
+  %32 = v_mov_b32 0
+  %index_value = global_load_b32_saddr %32, %control_view
+  %34 = v_mov_b32 7
+  %padded = v_add_u32 %index_value, %34
+  %group = v_lshrrev_b32_lit %padded, 3
+  %element = v_lshlrev_b32_lit %group, 2
+  %38 = v_readfirstlane_b32 %element
+  low.br ^loop(%38: reg<amdgpu.sgpr>)
+^loop(%active: reg<amdgpu.sgpr>):
+  %in_bounds = s_cmp_lt_u32 %active, %twenty
+  low.cond_br %in_bounds, ^access, ^exit : reg<amdgpu.scc>
+^access:
+  %40 = v_mov_b32 0
+  %41 = s_lshl_b32_rhs_inline %active, 2
+  %42 = slice %input_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %43 = slice %input_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %44 = s_mov_b32 0
+  %45 = s_add_u32 %42, %41
+  %46 = s_addc_u32 %43, %44
+  %47 = concat(%45, %46) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %value = global_load_b32_saddr %40, %47
+  %50 = s_lshl_b32_rhs_inline %active, 2
+  %51 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %52 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %54 = s_add_u32 %51, %50
+  %55 = s_addc_u32 %52, %44
+  %56 = concat(%54, %55) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  global_store_b32_saddr %40, %value, %56
+  %next = s_add_u32 %active, %one
+  low.br ^loop(%next: reg<amdgpu.sgpr>)
+^exit:
+  return
+}


### PR DESCRIPTION
AMDGPU source-to-low now reconciles semantically uniform address values with scalar CFG destinations during branch materialization. A value loaded through a vector memory instruction may physically reside in VGPRs even when value facts prove every active lane observes the same address. If CFG placement selected an SGPR block argument, the previous materializer treated that physical mismatch as impossible and aborted.

## Design

Branch remapping is the first boundary with all of the information needed to resolve the mismatch: the source value and its established facts, the already-materialized low value and physical register type, and the register type required by the destination block argument. When an address scalar is proven subgroup-uniform but arrives in VGPRs for an SGPR destination, the materializer emits `v_readfirstlane_b32` for each 32-bit register unit.

Address scalars are 32 or 64 bits, so this path has a fixed maximum of two register units and uses only local storage. A non-uniform VGPR value still cannot enter an SGPR block argument and remains a hard compiler invariant. The existing SGPR-to-VGPR materialization path is unchanged.

This deliberately does not walk producer IR or extend placement analysis. Placement owns the semantic destination bank; branch materialization reconciles the physical source representation at the point where the mismatch is concrete. The work is constant with respect to producer-graph and CFG depth, which matters on the JIT path and avoids an optimization cliff for deeply authored IR.

## Behavioral Coverage

The source-to-low control-flow corpus now carries a subgroup-uniform global control load through an `index` cast, add, and shift chain into a loop block argument. Its low golden requires a single `v_readfirstlane_b32` at the incoming edge, followed by SGPR-backed comparison, increment, and global address arithmetic. This covers the original physical bank mismatch while preserving the scalar execution selected for the loop.

## Reviewer Notes

The primary review surface is `loom_amdgpu_materialize_branch_address`. The safety condition comes from the existing subgroup-uniform value fact; the conversion consumes that fact rather than reconstructing it from producer operations. The helper is intentionally local to control lowering because no broader producer-placement or subgroup-collective contract changes.
