### PR TITLE
[Loom] Lower global-memory workgroup barriers on AMDGPU

### DIFF
--- a/loom/py/loom/dialect/kernel/defs.py
+++ b/loom/py/loom/dialect/kernel/defs.py
@@ -1268,12 +1268,13 @@ kernel_barrier = Op(
     contracts=[ContractFamily.KERNEL_SYNCHRONIZATION],
     doc=(
         "Synchronize invocations in an explicit execution scope and fence a "
-        "named memory space with a required ordering. Supported source-level "
-        "kernel barriers synchronize either the current subgroup or workgroup "
-        "while fencing workgroup memory with acquire-release ordering. "
+        "named memory space with a required ordering. Workgroup-memory "
+        "barriers synchronize either the current subgroup or workgroup with "
+        "acquire-release ordering. Global-memory barriers synchronize the "
+        "current workgroup with acquire, release, or acquire-release ordering. "
         "Async-copy completion is modeled by kernel.async.wait; use "
         "kernel.barrier only when invocations must rendezvous before "
-        "consuming shared memory."
+        "consuming shared or global memory."
     ),
     attrs=[
         AttrDef(
@@ -1301,6 +1302,8 @@ kernel_barrier = Op(
     examples=[
         "kernel.barrier<workgroup> {ordering = acq_rel, scope = subgroup}",
         "kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}",
+        "kernel.barrier<global> {ordering = release, scope = workgroup}",
+        "kernel.barrier<global> {ordering = acquire, scope = workgroup}",
     ],
 )
 

--- a/loom/src/loom/ops/kernel/ops.h
+++ b/loom/src/loom/ops/kernel/ops.h
@@ -236,7 +236,7 @@ iree_status_t loom_kernel_exit_build(
     loom_op_t** out_op);
 iree_status_t loom_kernel_exit_canonicalize(loom_op_t* op, loom_rewriter_t* rewriter);
 
-// LOOM_OP_KERNEL_BARRIER: Synchronize invocations in an explicit execution scope and fence a named memory space with a required ordering. Supported source-level kernel barriers synchronize either the current subgroup or workgroup while fencing workgroup memory with acquire-release ordering. Async-copy completion is modeled by kernel.async.wait; use kernel.barrier only when invocations must rendezvous before consuming shared memory.
+// LOOM_OP_KERNEL_BARRIER: Synchronize invocations in an explicit execution scope and fence a named memory space with a required ordering. Workgroup-memory barriers synchronize either the current subgroup or workgroup with acquire-release ordering. Global-memory barriers synchronize the current workgroup with acquire, release, or acquire-release ordering. Async-copy completion is modeled by kernel.async.wait; use kernel.barrier only when invocations must rendezvous before consuming shared or global memory.
 // kernel.barrier<workgroup> {ordering = acq_rel, scope = subgroup}
 LOOM_DEFINE_ISA(loom_kernel_barrier_isa, LOOM_OP_KERNEL_BARRIER)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_kernel_barrier_memory_space, 0, loom_value_fact_memory_space_t)

--- a/loom/src/loom/ops/kernel/test/roundtrip.loom-test
+++ b/loom/src/loom/ops/kernel/test/roundtrip.loom-test
@@ -120,6 +120,17 @@ func.def @subgroup_barrier() {
 
 test.target<low_core> @test_target
 
+func.def @global_barriers() {
+  kernel.barrier<global> {ordering = release, scope = workgroup}
+  kernel.barrier<global> {ordering = acquire, scope = workgroup}
+  kernel.barrier<global> {ordering = acq_rel, scope = workgroup}
+  func.return
+}
+
+// ====
+
+test.target<low_core> @test_target
+
 kernel.def @workitem_coordinates() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index

--- a/loom/src/loom/ops/kernel/test/roundtrip.loom-test
+++ b/loom/src/loom/ops/kernel/test/roundtrip.loom-test
@@ -100,8 +100,6 @@ kernel.def retain @retained_kernel() {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @workgroup_barrier() {
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   func.return
@@ -109,16 +107,12 @@ func.def @workgroup_barrier() {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @subgroup_barrier() {
   kernel.barrier<workgroup> {ordering = acq_rel, scope = subgroup}
   func.return
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @global_barriers() {
   kernel.barrier<global> {ordering = release, scope = workgroup}
@@ -128,8 +122,6 @@ func.def @global_barriers() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @workitem_coordinates() {
   %c1 = index.constant 1 : index
@@ -143,8 +135,6 @@ kernel.def @workitem_coordinates() {
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @conditional_exit() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
@@ -154,8 +144,6 @@ kernel.def @conditional_exit() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @conditional_exit_with_body() {
   %c1 = index.constant 1 : index
@@ -168,8 +156,6 @@ kernel.def @conditional_exit_with_body() {
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @runtime_asserts() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
@@ -180,8 +166,6 @@ kernel.def @runtime_asserts() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @workgroup_coordinates() {
   %c1 = index.constant 1 : index
@@ -194,8 +178,6 @@ kernel.def @workgroup_coordinates() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @launch_queries() {
   %c1 = index.constant 1 : index
@@ -215,8 +197,6 @@ kernel.def @launch_queries() {
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @subgroup_queries() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
@@ -229,8 +209,6 @@ kernel.def @subgroup_queries() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @subgroup_collectives() {
   %c1 = index.constant 1 : index
@@ -255,8 +233,6 @@ kernel.def @subgroup_collectives() {
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @workgroup_collectives() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
@@ -270,8 +246,6 @@ kernel.def @workgroup_collectives() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_copy_global_to_workgroup(%source_buffer: buffer, %byte_offset: offset) {
   %zero = index.constant 0 : offset
@@ -290,8 +264,6 @@ func.def @async_copy_global_to_workgroup(%source_buffer: buffer, %byte_offset: o
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_copy_masked(%source_buffer: buffer, %byte_offset: offset, %in_bounds: i1) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
@@ -307,8 +279,6 @@ func.def @async_copy_masked(%source_buffer: buffer, %byte_offset: offset, %in_bo
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_copy_workgroup_to_global(%dest_buffer: buffer, %byte_offset: offset) {
   %zero = index.constant 0 : offset
@@ -326,8 +296,6 @@ func.def @async_copy_workgroup_to_global(%dest_buffer: buffer, %byte_offset: off
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_copy_reinterpreted_bytes(%source_buffer: buffer, %byte_offset: offset) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
@@ -343,8 +311,6 @@ func.def @async_copy_reinterpreted_bytes(%source_buffer: buffer, %byte_offset: o
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_subgroup_gather(%source_buffer: buffer, %byte_offset: offset) {
   %zero = index.constant 0 : offset
@@ -362,8 +328,6 @@ func.def @async_subgroup_gather(%source_buffer: buffer, %byte_offset: offset) {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_subgroup_gather_padded_lane_slot(%source_buffer: buffer, %byte_offset: offset) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
@@ -380,8 +344,6 @@ func.def @async_subgroup_gather_padded_lane_slot(%source_buffer: buffer, %byte_o
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_subgroup_gather_gfx950_padded_lane_slot(%source_buffer: buffer, %byte_offset: offset) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 4096 : offset
@@ -397,8 +359,6 @@ func.def @async_subgroup_gather_gfx950_padded_lane_slot(%source_buffer: buffer, 
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_cluster_gather_widths(%source_buffer: buffer, %byte_offset: offset) {
   %zero = index.constant 0 : offset
@@ -426,8 +386,6 @@ func.def @async_cluster_gather_widths(%source_buffer: buffer, %byte_offset: offs
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_cluster_gather_masked(%source_buffer: buffer, %byte_offset: offset, %in_bounds: i1) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
@@ -444,8 +402,6 @@ func.def @async_cluster_gather_masked(%source_buffer: buffer, %byte_offset: offs
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_tensor_load_to_lds(%source_buffer: buffer, %byte_offset: offset) {
   %zero = index.constant 0 : offset
@@ -470,8 +426,6 @@ func.def @async_tensor_load_to_lds(%source_buffer: buffer, %byte_offset: offset)
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_tensor_store_from_lds(%dest_buffer: buffer, %byte_offset: offset) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
@@ -491,8 +445,6 @@ func.def @async_tensor_store_from_lds(%dest_buffer: buffer, %byte_offset: offset
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_empty_pipeline_marker() {
   %group = kernel.async.group -> kernel.async.group

--- a/loom/src/loom/ops/kernel/test/verify.loom-test
+++ b/loom/src/loom/ops/kernel/test/verify.loom-test
@@ -12,8 +12,6 @@ kernel.def target(@test_target) linkage(dso_local) @kernel_linkage_requires_expo
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @launch_config_requires_index_operands() {
   %c1 = index.constant 1 : index
   %bad = scalar.constant 0 : i32
@@ -25,8 +23,6 @@ kernel.def @launch_config_requires_index_operands() {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @workitem_id_requires_kernel_def() {
   // ERROR@+1: STRUCTURE/029 "kernel.workitem.id" "required" "kernel.def" "func.def"
   %tid = kernel.workitem.id<x> : index
@@ -34,8 +30,6 @@ func.def @workitem_id_requires_kernel_def() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @exit_requires_direct_kernel_body() {
   %c1 = index.constant 1 : index
@@ -51,8 +45,6 @@ kernel.def @exit_requires_direct_kernel_body() {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @workgroup_id_requires_kernel_def() {
   // ERROR@+1: STRUCTURE/029 "kernel.workgroup.id" "required" "kernel.def" "func.def"
   %gid = kernel.workgroup.id<x> : index
@@ -61,8 +53,6 @@ func.def @workgroup_id_requires_kernel_def() {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @workgroup_size_requires_kernel_def() {
   // ERROR@+1: STRUCTURE/029 "kernel.workgroup.size" "required" "kernel.def" "func.def"
   %size = kernel.workgroup.size<x> : index
@@ -70,8 +60,6 @@ func.def @workgroup_size_requires_kernel_def() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @cluster_queries_require_kernel_def() {
   // ERROR@+1: STRUCTURE/029 "kernel.cluster.id" "required" "kernel.def" "func.def"
@@ -88,8 +76,6 @@ func.def @cluster_queries_require_kernel_def() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @subgroup_collective_requires_kernel_def(%value: f32) {
   // ERROR@+1: STRUCTURE/029 "kernel.subgroup.reduce" "required" "kernel.def" "func.def"
@@ -118,8 +104,6 @@ func.template<demo.isolated_workgroup_reduce> @isolated_workgroup_reduce_provide
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @subgroup_shuffle_requires_i32_offset() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
@@ -130,8 +114,6 @@ kernel.def @subgroup_shuffle_requires_i32_offset() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @subgroup_broadcast_requires_i32_lane() {
   %c1 = index.constant 1 : index
@@ -144,8 +126,6 @@ kernel.def @subgroup_broadcast_requires_i32_lane() {
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @subgroup_reduce_rejects_integer_value_for_float_kind() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
@@ -156,8 +136,6 @@ kernel.def @subgroup_reduce_rejects_integer_value_for_float_kind() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @subgroup_reduce_rejects_non_collective_value() {
   %c1 = index.constant 1 : index
@@ -170,8 +148,6 @@ kernel.def @subgroup_reduce_rejects_non_collective_value() {
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @subgroup_scan_requires_cluster_size_with_stride() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
@@ -182,8 +158,6 @@ kernel.def @subgroup_scan_requires_cluster_size_with_stride() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @subgroup_ballot_rejects_narrow_mask() {
   %c1 = index.constant 1 : index
@@ -196,8 +170,6 @@ kernel.def @subgroup_ballot_rejects_narrow_mask() {
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @subgroup_match_all_rejects_non_i1_all_equal() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
@@ -208,8 +180,6 @@ kernel.def @subgroup_match_all_rejects_non_i1_all_equal() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @workgroup_reduce_rejects_float_value_for_integer_kind() {
   %c1 = index.constant 1 : index
@@ -222,8 +192,6 @@ kernel.def @workgroup_reduce_rejects_float_value_for_integer_kind() {
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @workgroup_scan_rejects_float_value_for_integer_kind() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
@@ -234,8 +202,6 @@ kernel.def @workgroup_scan_rejects_float_value_for_integer_kind() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @workgroup_vote_count_rejects_narrow_result() {
   %c1 = index.constant 1 : index
@@ -248,8 +214,6 @@ kernel.def @workgroup_vote_count_rejects_narrow_result() {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @barrier_rejects_private_memory_space() {
   // ERROR@+1: STRUCTURE/014 "memory_space" "3" "workgroup or global memory space"
   kernel.barrier<private> {ordering = acq_rel, scope = workgroup}
@@ -257,8 +221,6 @@ func.def @barrier_rejects_private_memory_space() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @barrier_rejects_acquire_ordering() {
   // ERROR@+1: STRUCTURE/014 "ordering" "1" "acq_rel ordering for workgroup memory"
@@ -268,8 +230,6 @@ func.def @barrier_rejects_acquire_ordering() {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @barrier_rejects_device_scope() {
   // ERROR@+1: STRUCTURE/014 "scope" "3" "subgroup or workgroup scope for workgroup memory"
   kernel.barrier<workgroup> {ordering = acq_rel, scope = device}
@@ -277,8 +237,6 @@ func.def @barrier_rejects_device_scope() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @global_barrier_rejects_subgroup_scope() {
   // ERROR@+1: STRUCTURE/014 "scope" "1" "workgroup scope for global memory"
@@ -288,8 +246,6 @@ func.def @global_barrier_rejects_subgroup_scope() {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @global_barrier_rejects_relaxed_ordering() {
   // ERROR@+1: STRUCTURE/014 "ordering" "0" "acquire, release, or acq_rel ordering for global memory"
   kernel.barrier<global> {ordering = relaxed, scope = workgroup}
@@ -298,8 +254,6 @@ func.def @global_barrier_rejects_relaxed_ordering() {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @global_barrier_rejects_sequentially_consistent_ordering() {
   // ERROR@+1: STRUCTURE/014 "ordering" "4" "acquire, release, or acq_rel ordering for global memory"
   kernel.barrier<global> {ordering = seq_cst, scope = workgroup}
@@ -307,8 +261,6 @@ func.def @global_barrier_rejects_sequentially_consistent_ordering() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @workgroup_barrier_accepts_uniform_branch() {
   %c1 = index.constant 1 : index
@@ -325,8 +277,6 @@ kernel.def @workgroup_barrier_accepts_uniform_branch() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @workgroup_barrier_rejects_lane_predicated_branch() {
   %c1 = index.constant 1 : index
@@ -345,8 +295,6 @@ kernel.def @workgroup_barrier_rejects_lane_predicated_branch() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @workgroup_barrier_rejects_lane_varying_counted_loop_bound() {
   %c1 = index.constant 1 : index
@@ -389,8 +337,6 @@ kernel.def target(@test_target) @workgroup_barrier_accepts_config_derived_loop_b
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @workgroup_barrier_accepts_kernel_argument_control(%enabled: i1) {
   %c1 = index.constant 1 : index
   %c64 = index.constant 64 : index
@@ -404,8 +350,6 @@ kernel.def @workgroup_barrier_accepts_kernel_argument_control(%enabled: i1) {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @barrier_scope_distinguishes_subgroup_control() {
   %c1 = index.constant 1 : index
@@ -445,8 +389,6 @@ kernel.def target(@test_target) @workgroup_barrier_accepts_exact_single_subgroup
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @barrier_scope_distinguishes_collective_results() {
   %c1 = index.constant 1 : index
   %c64 = index.constant 64 : index
@@ -472,8 +414,6 @@ kernel.def @barrier_scope_distinguishes_collective_results() {
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @workgroup_barrier_rejects_scan_control() {
   %c1 = index.constant 1 : index
   %c64 = index.constant 64 : index
@@ -493,8 +433,6 @@ kernel.def @workgroup_barrier_rejects_scan_control() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @workgroup_barrier_rejects_unknown_control(%arg: i32) {
   %c1 = index.constant 1 : index
@@ -516,8 +454,6 @@ kernel.def @workgroup_barrier_rejects_unknown_control(%arg: i32) {
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @workgroup_barrier_rejects_lane_divergent_cfg_arm() {
   %c1 = index.constant 1 : index
   %c64 = index.constant 64 : index
@@ -538,8 +474,6 @@ kernel.def @workgroup_barrier_rejects_lane_divergent_cfg_arm() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @workgroup_barrier_rejects_nested_cfg_control(%enabled: i1) {
   %c1 = index.constant 1 : index
@@ -565,8 +499,6 @@ kernel.def @workgroup_barrier_rejects_nested_cfg_control(%enabled: i1) {
 
 // ====
 
-test.target<low_core> @test_target
-
 // Explicit CFG reconvergence restores workgroup-uniform execution even when
 // the predecessor arms were selected independently by each invocation.
 kernel.def @workgroup_barrier_accepts_reconverged_cfg_join() {
@@ -588,8 +520,6 @@ kernel.def @workgroup_barrier_accepts_reconverged_cfg_join() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 kernel.def @cfg_barrier_scope_distinguishes_subgroup_control() {
   %c1 = index.constant 1 : index
@@ -614,8 +544,6 @@ kernel.def @cfg_barrier_scope_distinguishes_subgroup_control() {
 
 // ====
 
-test.target<low_core> @test_target
-
 // A loop header is reached uniformly once, but a varying continuation makes
 // later dynamic executions non-uniform and therefore cannot contain a barrier.
 kernel.def @workgroup_barrier_rejects_lane_divergent_cfg_loop() {
@@ -637,8 +565,6 @@ kernel.def @workgroup_barrier_rejects_lane_divergent_cfg_loop() {
 
 // ====
 
-test.target<low_core> @test_target
-
 kernel.def @workgroup_barrier_accepts_workgroup_uniform_cfg_control(%enabled: i1) {
   %c1 = index.constant 1 : index
   %c64 = index.constant 64 : index
@@ -655,8 +581,6 @@ kernel.def @workgroup_barrier_accepts_workgroup_uniform_cfg_control(%enabled: i1
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_copy_requires_static_byte_footprint(%buffer: buffer, %offset: offset, %n: index) {
   %zero = index.constant 0 : offset
@@ -676,8 +600,6 @@ func.def @async_copy_requires_static_byte_footprint(%buffer: buffer, %offset: of
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_copy_rejects_mismatched_byte_footprint(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
@@ -695,8 +617,6 @@ func.def @async_copy_rejects_mismatched_byte_footprint(%buffer: buffer, %offset:
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_copy_rejects_unknown_source_memory(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
@@ -712,8 +632,6 @@ func.def @async_copy_rejects_unknown_source_memory(%buffer: buffer, %offset: off
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_copy_rejects_direction_memory_mismatch(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
@@ -732,8 +650,6 @@ func.def @async_copy_rejects_direction_memory_mismatch(%buffer: buffer, %offset:
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_copy_rejects_global_store_last_use_cache(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
@@ -750,8 +666,6 @@ func.def @async_copy_rejects_global_store_last_use_cache(%buffer: buffer, %offse
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_copy_rejects_global_load_writeback_cache(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
@@ -770,8 +684,6 @@ func.def @async_copy_rejects_global_load_writeback_cache(%buffer: buffer, %offse
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_copy_rejects_bypass_non_system_scope(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
@@ -789,8 +701,6 @@ func.def @async_copy_rejects_bypass_non_system_scope(%buffer: buffer, %offset: o
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_copy_token_must_be_grouped(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
@@ -805,8 +715,6 @@ func.def @async_copy_token_must_be_grouped(%buffer: buffer, %offset: offset) {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_group_must_be_used(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
@@ -824,8 +732,6 @@ func.def @async_group_must_be_used(%buffer: buffer, %offset: offset) {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_wait_rejects_negative_newer_group_count(%group: kernel.async.group) {
   // ERROR@+1: STRUCTURE/014 "newer_groups" "-1" "nonnegative i16 wait count"
   kernel.async.wait %group {newer_groups = -1} : kernel.async.group
@@ -834,8 +740,6 @@ func.def @async_wait_rejects_negative_newer_group_count(%group: kernel.async.gro
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_wait_rejects_large_newer_group_count(%group: kernel.async.group) {
   // ERROR@+1: STRUCTURE/014 "newer_groups" "65536" "nonnegative i16 wait count"
   kernel.async.wait %group {newer_groups = 65536} : kernel.async.group
@@ -843,8 +747,6 @@ func.def @async_wait_rejects_large_newer_group_count(%group: kernel.async.group)
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.decl noinline @runtime_group() -> (kernel.async.group)
 
@@ -857,8 +759,6 @@ func.def @async_wait_rejects_runtime_call_group() {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_group_rejects_group_operand_as_token() {
   %empty = kernel.async.group -> kernel.async.group
   // ERROR@+1: TYPE/003 "tokens" "kernel.async.group" "kernel.async.token"
@@ -870,8 +770,6 @@ func.def @async_group_rejects_group_operand_as_token() {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_group_rejects_block_arg_token(%token: kernel.async.token) {
   // ERROR@+1: DOMINANCE/010 "token" "<null>" "kernel async transfer result"
   %group = kernel.async.group %token : kernel.async.token -> kernel.async.group
@@ -880,8 +778,6 @@ func.def @async_group_rejects_block_arg_token(%token: kernel.async.token) {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_copy_token_rejects_multiple_groups(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
@@ -902,8 +798,6 @@ func.def @async_copy_token_rejects_multiple_groups(%buffer: buffer, %offset: off
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_gather_requires_lane_axis(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
@@ -920,8 +814,6 @@ func.def @async_gather_requires_lane_axis(%buffer: buffer, %offset: offset) {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_gather_rejects_small_lane_slot(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
@@ -940,8 +832,6 @@ func.def @async_gather_rejects_small_lane_slot(%buffer: buffer, %offset: offset)
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_gather_requires_static_lane_footprint(%buffer: buffer, %offset: offset, %n: index) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
@@ -959,8 +849,6 @@ func.def @async_gather_requires_static_lane_footprint(%buffer: buffer, %offset: 
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_gather_rejects_workgroup_source(%bytes: offset) {
   %zero = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
@@ -975,8 +863,6 @@ func.def @async_gather_rejects_workgroup_source(%bytes: offset) {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_cluster_gather_rejects_wrong_mask_type(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
@@ -996,8 +882,6 @@ func.def @async_cluster_gather_rejects_wrong_mask_type(%buffer: buffer, %offset:
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_cluster_gather_rejects_unsupported_width(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
@@ -1015,8 +899,6 @@ func.def @async_cluster_gather_rejects_unsupported_width(%buffer: buffer, %offse
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_cluster_gather_rejects_mismatched_width(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
@@ -1036,8 +918,6 @@ func.def @async_cluster_gather_rejects_mismatched_width(%buffer: buffer, %offset
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_cluster_gather_rejects_workgroup_source(%bytes: offset) {
   %zero = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
@@ -1054,8 +934,6 @@ func.def @async_cluster_gather_rejects_workgroup_source(%bytes: offset) {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @async_cluster_gather_rejects_global_dest(%buffer: buffer, %offset: offset) {
   %layout = encoding.layout.dense : encoding<layout>
   %cluster_mask = scalar.constant 15 : i32
@@ -1071,8 +949,6 @@ func.def @async_cluster_gather_rejects_global_dest(%buffer: buffer, %offset: off
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @tensor_descriptor_rejects_three_dgroups() {
   %i32_zero = scalar.constant 0 : i32
   %d0 = vector.splat %i32_zero : vector<4xi32>
@@ -1086,8 +962,6 @@ func.def @tensor_descriptor_rejects_three_dgroups() {
 
 // ====
 
-test.target<low_core> @test_target
-
 func.def @tensor_descriptor_rejects_wrong_d1_shape() {
   %i32_zero = scalar.constant 0 : i32
   %d0 = vector.splat %i32_zero : vector<4xi32>
@@ -1099,8 +973,6 @@ func.def @tensor_descriptor_rejects_wrong_d1_shape() {
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_tensor_load_rejects_wrong_descriptor_type(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
@@ -1120,8 +992,6 @@ func.def @async_tensor_load_rejects_wrong_descriptor_type(%buffer: buffer, %offs
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_tensor_load_rejects_rank_mismatch(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
@@ -1143,8 +1013,6 @@ func.def @async_tensor_load_rejects_rank_mismatch(%buffer: buffer, %offset: offs
 }
 
 // ====
-
-test.target<low_core> @test_target
 
 func.def @async_tensor_store_rejects_constant_dest(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset

--- a/loom/src/loom/ops/kernel/test/verify.loom-test
+++ b/loom/src/loom/ops/kernel/test/verify.loom-test
@@ -250,9 +250,9 @@ kernel.def @workgroup_vote_count_rejects_narrow_result() {
 
 test.target<low_core> @test_target
 
-func.def @barrier_rejects_global_memory_space() {
-  // ERROR@+1: STRUCTURE/014 "memory_space" "1" "workgroup memory space"
-  kernel.barrier<global> {ordering = acq_rel, scope = workgroup}
+func.def @barrier_rejects_private_memory_space() {
+  // ERROR@+1: STRUCTURE/014 "memory_space" "3" "workgroup or global memory space"
+  kernel.barrier<private> {ordering = acq_rel, scope = workgroup}
   func.return
 }
 
@@ -261,7 +261,7 @@ func.def @barrier_rejects_global_memory_space() {
 test.target<low_core> @test_target
 
 func.def @barrier_rejects_acquire_ordering() {
-  // ERROR@+1: STRUCTURE/014 "ordering" "1" "acq_rel ordering"
+  // ERROR@+1: STRUCTURE/014 "ordering" "1" "acq_rel ordering for workgroup memory"
   kernel.barrier<workgroup> {ordering = acquire, scope = workgroup}
   func.return
 }
@@ -271,8 +271,38 @@ func.def @barrier_rejects_acquire_ordering() {
 test.target<low_core> @test_target
 
 func.def @barrier_rejects_device_scope() {
-  // ERROR@+1: STRUCTURE/014 "scope" "3" "subgroup or workgroup scope"
+  // ERROR@+1: STRUCTURE/014 "scope" "3" "subgroup or workgroup scope for workgroup memory"
   kernel.barrier<workgroup> {ordering = acq_rel, scope = device}
+  func.return
+}
+
+// ====
+
+test.target<low_core> @test_target
+
+func.def @global_barrier_rejects_subgroup_scope() {
+  // ERROR@+1: STRUCTURE/014 "scope" "1" "workgroup scope for global memory"
+  kernel.barrier<global> {ordering = acquire, scope = subgroup}
+  func.return
+}
+
+// ====
+
+test.target<low_core> @test_target
+
+func.def @global_barrier_rejects_relaxed_ordering() {
+  // ERROR@+1: STRUCTURE/014 "ordering" "0" "acquire, release, or acq_rel ordering for global memory"
+  kernel.barrier<global> {ordering = relaxed, scope = workgroup}
+  func.return
+}
+
+// ====
+
+test.target<low_core> @test_target
+
+func.def @global_barrier_rejects_sequentially_consistent_ordering() {
+  // ERROR@+1: STRUCTURE/014 "ordering" "4" "acquire, release, or acq_rel ordering for global memory"
+  kernel.barrier<global> {ordering = seq_cst, scope = workgroup}
   func.return
 }
 

--- a/loom/src/loom/ops/kernel/verify.c
+++ b/loom/src/loom/ops/kernel/verify.c
@@ -1060,25 +1060,41 @@ iree_status_t loom_kernel_barrier_verify(const loom_module_t* module,
 
   loom_value_fact_memory_space_t memory_space =
       loom_kernel_barrier_memory_space(op);
-  if (memory_space != LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP) {
+  if (memory_space != LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP &&
+      memory_space != LOOM_VALUE_FACT_MEMORY_SPACE_GLOBAL) {
     return loom_kernel_emit_attribute_value_constraint(
         emitter, op, IREE_SV("memory_space"), memory_space,
-        IREE_SV("workgroup memory space"));
+        IREE_SV("workgroup or global memory space"));
   }
 
   loom_atomic_ordering_t ordering = loom_kernel_barrier_ordering(op);
-  if (ordering != LOOM_ATOMIC_ORDERING_ACQ_REL) {
+  const bool ordering_supported =
+      memory_space == LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP
+          ? ordering == LOOM_ATOMIC_ORDERING_ACQ_REL
+          : ordering == LOOM_ATOMIC_ORDERING_ACQUIRE ||
+                ordering == LOOM_ATOMIC_ORDERING_RELEASE ||
+                ordering == LOOM_ATOMIC_ORDERING_ACQ_REL;
+  if (!ordering_supported) {
     return loom_kernel_emit_attribute_value_constraint(
         emitter, op, IREE_SV("ordering"), ordering,
-        IREE_SV("acq_rel ordering"));
+        memory_space == LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP
+            ? IREE_SV("acq_rel ordering for workgroup memory")
+            : IREE_SV(
+                  "acquire, release, or acq_rel ordering for global memory"));
   }
 
   loom_atomic_scope_t scope = loom_kernel_barrier_scope(op);
-  if (scope != LOOM_ATOMIC_SCOPE_SUBGROUP &&
-      scope != LOOM_ATOMIC_SCOPE_WORKGROUP) {
+  const bool scope_supported =
+      memory_space == LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP
+          ? scope == LOOM_ATOMIC_SCOPE_SUBGROUP ||
+                scope == LOOM_ATOMIC_SCOPE_WORKGROUP
+          : scope == LOOM_ATOMIC_SCOPE_WORKGROUP;
+  if (!scope_supported) {
     return loom_kernel_emit_attribute_value_constraint(
         emitter, op, IREE_SV("scope"), scope,
-        IREE_SV("subgroup or workgroup scope"));
+        memory_space == LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP
+            ? IREE_SV("subgroup or workgroup scope for workgroup memory")
+            : IREE_SV("workgroup scope for global memory"));
   }
   return iree_ok_status();
 }

--- a/loom/src/loom/target/arch/amdgpu/lower/sync.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/sync.c
@@ -10,29 +10,42 @@
 #include "loom/ops/kernel/ops.h"
 #include "loom/target/arch/amdgpu/lower/emit.h"
 #include "loom/target/arch/amdgpu/lower/legality.h"
+#include "loom/target/arch/amdgpu/lower/system_memory.h"
 #include "loom/target/arch/amdgpu/planning/wait_packets.h"
 #include "loom/target/arch/amdgpu/planning/wait_plan.h"
 #include "loom/target/arch/amdgpu/refs/target_refs.h"
 
-static bool loom_amdgpu_kernel_barrier_is_workgroup_memory_acq_rel(
+static bool loom_amdgpu_kernel_barrier_is_global_memory(
     const loom_op_t* source_op) {
   return loom_kernel_barrier_memory_space(source_op) ==
-             LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP &&
-         loom_kernel_barrier_ordering(source_op) ==
-             LOOM_ATOMIC_ORDERING_ACQ_REL;
+         LOOM_VALUE_FACT_MEMORY_SPACE_GLOBAL;
 }
 
-static bool loom_amdgpu_kernel_barrier_has_supported_scope(
+static bool loom_amdgpu_kernel_barrier_global_ordering_has_acquire(
     const loom_op_t* source_op) {
-  const loom_atomic_scope_t scope = loom_kernel_barrier_scope(source_op);
-  return scope == LOOM_ATOMIC_SCOPE_SUBGROUP ||
-         scope == LOOM_ATOMIC_SCOPE_WORKGROUP;
+  const loom_atomic_ordering_t ordering =
+      loom_kernel_barrier_ordering(source_op);
+  return ordering == LOOM_ATOMIC_ORDERING_ACQUIRE ||
+         ordering == LOOM_ATOMIC_ORDERING_ACQ_REL;
 }
 
-static bool loom_amdgpu_kernel_barrier_is_supported(
+static bool loom_amdgpu_kernel_barrier_global_ordering_has_release(
     const loom_op_t* source_op) {
-  return loom_amdgpu_kernel_barrier_is_workgroup_memory_acq_rel(source_op) &&
-         loom_amdgpu_kernel_barrier_has_supported_scope(source_op);
+  const loom_atomic_ordering_t ordering =
+      loom_kernel_barrier_ordering(source_op);
+  return ordering == LOOM_ATOMIC_ORDERING_RELEASE ||
+         ordering == LOOM_ATOMIC_ORDERING_ACQ_REL;
+}
+
+static bool loom_amdgpu_kernel_barrier_global_ordering_available(
+    const loom_low_descriptor_set_t* descriptor_set,
+    const loom_op_t* source_op) {
+  if (loom_amdgpu_kernel_barrier_global_ordering_has_release(source_op) &&
+      !loom_amdgpu_system_memory_release_ordering_available(descriptor_set)) {
+    return false;
+  }
+  return !loom_amdgpu_kernel_barrier_global_ordering_has_acquire(source_op) ||
+         loom_amdgpu_system_memory_acquire_ordering_available(descriptor_set);
 }
 
 static iree_status_t loom_amdgpu_select_kernel_barrier_lds_wait(
@@ -117,7 +130,9 @@ iree_status_t loom_amdgpu_select_kernel_barrier_plan(
   if (!loom_kernel_barrier_isa(source_op)) {
     return iree_ok_status();
   }
-  if (!loom_amdgpu_kernel_barrier_is_supported(source_op)) {
+  if (loom_amdgpu_kernel_barrier_is_global_memory(source_op) &&
+      !loom_amdgpu_kernel_barrier_global_ordering_available(
+          loom_low_lower_context_descriptor_set(context), source_op)) {
     return iree_ok_status();
   }
 
@@ -174,7 +189,28 @@ iree_status_t loom_amdgpu_lower_workgroup_barrier_plan(
 iree_status_t loom_amdgpu_lower_kernel_barrier(
     loom_low_lower_context_t* context, const loom_op_t* source_op,
     const loom_amdgpu_kernel_barrier_plan_t* plan) {
-  return loom_amdgpu_lower_workgroup_barrier_plan(context, source_op, plan);
+  if (!loom_amdgpu_kernel_barrier_is_global_memory(source_op)) {
+    return loom_amdgpu_lower_workgroup_barrier_plan(context, source_op, plan);
+  }
+
+  loom_builder_t* builder = loom_low_lower_context_builder(context);
+  const loom_low_descriptor_set_t* descriptor_set =
+      loom_low_lower_context_descriptor_set(context);
+  if (loom_amdgpu_kernel_barrier_global_ordering_has_release(source_op)) {
+    IREE_RETURN_IF_ERROR(
+        loom_amdgpu_system_memory_build_release_ordering_scoped(
+            builder, descriptor_set, LOOM_CACHE_SCOPE_DEVICE,
+            source_op->location));
+  }
+  IREE_RETURN_IF_ERROR(
+      loom_amdgpu_lower_workgroup_barrier_plan(context, source_op, plan));
+  if (loom_amdgpu_kernel_barrier_global_ordering_has_acquire(source_op)) {
+    IREE_RETURN_IF_ERROR(
+        loom_amdgpu_system_memory_build_acquire_ordering_scoped(
+            builder, descriptor_set, LOOM_CACHE_SCOPE_DEVICE,
+            source_op->location));
+  }
+  return iree_ok_status();
 }
 
 iree_status_t loom_amdgpu_low_legality_verify_kernel_barrier(
@@ -186,27 +222,36 @@ iree_status_t loom_amdgpu_low_legality_verify_kernel_barrier(
     return iree_ok_status();
   }
   *out_handled = true;
+  const loom_low_descriptor_set_t* descriptor_set =
+      loom_target_low_legality_descriptor_set(context);
 
-  if (!loom_amdgpu_kernel_barrier_is_workgroup_memory_acq_rel(op)) {
-    return loom_amdgpu_low_legality_reject(context, op,
-                                           IREE_SV("barrier.workgroup_memory"));
-  }
-  if (!loom_amdgpu_kernel_barrier_has_supported_scope(op)) {
-    return loom_amdgpu_low_legality_reject(
-        context, op, IREE_SV("barrier.subgroup_or_workgroup_scope"));
+  if (loom_amdgpu_kernel_barrier_is_global_memory(op)) {
+    if (loom_amdgpu_kernel_barrier_global_ordering_has_release(op) &&
+        !loom_amdgpu_system_memory_release_ordering_available(descriptor_set)) {
+      return loom_amdgpu_low_legality_reject(
+          context, op, IREE_SV("descriptor.global_memory_release"));
+    }
+    if (loom_amdgpu_kernel_barrier_global_ordering_has_acquire(op) &&
+        !loom_amdgpu_system_memory_acquire_ordering_available(descriptor_set)) {
+      return loom_amdgpu_low_legality_reject(
+          context, op, IREE_SV("descriptor.global_memory_acquire"));
+    }
+    if (!loom_amdgpu_workgroup_barrier_lowering_available(descriptor_set)) {
+      return loom_amdgpu_low_legality_reject(
+          context, op, IREE_SV("descriptor.workgroup_barrier"));
+    }
+    return iree_ok_status();
   }
 
   if (loom_kernel_barrier_scope(op) == LOOM_ATOMIC_SCOPE_SUBGROUP) {
-    if (!loom_amdgpu_workgroup_memory_wait_lowering_available(
-            loom_target_low_legality_descriptor_set(context))) {
+    if (!loom_amdgpu_workgroup_memory_wait_lowering_available(descriptor_set)) {
       return loom_amdgpu_low_legality_reject(
           context, op, IREE_SV("descriptor.workgroup_memory_wait"));
     }
     return iree_ok_status();
   }
 
-  if (!loom_amdgpu_workgroup_barrier_lowering_available(
-          loom_target_low_legality_descriptor_set(context))) {
+  if (!loom_amdgpu_workgroup_barrier_lowering_available(descriptor_set)) {
     return loom_amdgpu_low_legality_reject(
         context, op, IREE_SV("descriptor.workgroup_barrier"));
   }

--- a/loom/src/loom/target/arch/amdgpu/lower/system_memory.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/system_memory.c
@@ -519,6 +519,53 @@ loom_amdgpu_system_memory_policy_lookup(
   return NULL;
 }
 
+static bool loom_amdgpu_system_memory_actions_available(
+    const loom_low_descriptor_set_t* descriptor_set,
+    const loom_amdgpu_system_memory_action_t* actions,
+    iree_host_size_t action_count) {
+  for (iree_host_size_t i = 0; i < action_count; ++i) {
+    const loom_amdgpu_system_memory_action_t* action = &actions[i];
+    switch (action->kind) {
+      case LOOM_AMDGPU_SYSTEM_MEMORY_ACTION_NONE:
+        break;
+      case LOOM_AMDGPU_SYSTEM_MEMORY_ACTION_WAIT_COUNTER: {
+        loom_amdgpu_wait_packet_selection_t selection = {0};
+        if (!loom_amdgpu_wait_packet_try_select_counter_mask(
+                descriptor_set, action->counter_mask, /*target_count=*/0,
+                &selection)) {
+          return false;
+        }
+        break;
+      }
+      case LOOM_AMDGPU_SYSTEM_MEMORY_ACTION_EXPLICIT_PACKET:
+        if (!loom_amdgpu_descriptor_set_has_ref(descriptor_set,
+                                                action->descriptor_ref)) {
+          return false;
+        }
+        break;
+    }
+  }
+  return true;
+}
+
+bool loom_amdgpu_system_memory_release_ordering_available(
+    const loom_low_descriptor_set_t* descriptor_set) {
+  const loom_amdgpu_system_memory_policy_t* policy =
+      loom_amdgpu_system_memory_policy_lookup(descriptor_set);
+  return policy != NULL && loom_amdgpu_system_memory_actions_available(
+                               descriptor_set, policy->release_actions,
+                               policy->release_action_count);
+}
+
+bool loom_amdgpu_system_memory_acquire_ordering_available(
+    const loom_low_descriptor_set_t* descriptor_set) {
+  const loom_amdgpu_system_memory_policy_t* policy =
+      loom_amdgpu_system_memory_policy_lookup(descriptor_set);
+  return policy != NULL && loom_amdgpu_system_memory_actions_available(
+                               descriptor_set, policy->acquire_actions,
+                               policy->acquire_action_count);
+}
+
 static const loom_amdgpu_system_memory_policy_t*
 loom_amdgpu_system_memory_policy_require(
     const loom_low_descriptor_set_t* descriptor_set) {

--- a/loom/src/loom/target/arch/amdgpu/lower/system_memory.h
+++ b/loom/src/loom/target/arch/amdgpu/lower/system_memory.h
@@ -14,6 +14,7 @@
 #ifndef LOOM_TARGET_ARCH_AMDGPU_LOWER_SYSTEM_MEMORY_H_
 #define LOOM_TARGET_ARCH_AMDGPU_LOWER_SYSTEM_MEMORY_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "iree/base/api.h"
@@ -28,6 +29,16 @@ extern "C" {
 #endif
 
 typedef struct loom_builder_t loom_builder_t;
+
+// Returns true when the descriptor set provides every packet required to emit
+// release ordering for prior global-memory accesses.
+bool loom_amdgpu_system_memory_release_ordering_available(
+    const loom_low_descriptor_set_t* descriptor_set);
+
+// Returns true when the descriptor set provides every packet required to emit
+// acquire ordering for later global-memory accesses.
+bool loom_amdgpu_system_memory_acquire_ordering_available(
+    const loom_low_descriptor_set_t* descriptor_set);
 
 // Flags controlling system-memory loads.
 typedef uint32_t loom_amdgpu_system_memory_load_flags_t;

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sync_kernel.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sync_kernel.loom-test
@@ -40,6 +40,73 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 
 amdgpu.target<gfx11-generic> @target
 
+kernel.def target(@target) @global_release_barrier() {
+  %one = index.constant 1 : index
+  %threads = index.constant 64 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+} launch() {
+  kernel.barrier<global> {ordering = release, scope = workgroup}
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @global_release_barrier() asm {
+  s_waitcnt {vmcnt = 0}
+  s_waitcnt_vscnt {vscnt = 0}
+  s_barrier
+  return
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
+
+kernel.def target(@target) @global_acquire_barrier() {
+  %one = index.constant 1 : index
+  %threads = index.constant 64 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+} launch() {
+  kernel.barrier<global> {ordering = acquire, scope = workgroup}
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @global_acquire_barrier() asm {
+  s_barrier
+  s_waitcnt {vmcnt = 0}
+  buffer_gl1_inv
+  buffer_gl0_inv
+  return
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
+
+kernel.def target(@target) @global_acq_rel_barrier() {
+  %one = index.constant 1 : index
+  %threads = index.constant 64 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+} launch() {
+  kernel.barrier<global> {ordering = acq_rel, scope = workgroup}
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @global_acq_rel_barrier() asm {
+  s_waitcnt {vmcnt = 0}
+  s_waitcnt_vscnt {vscnt = 0}
+  s_barrier
+  s_waitcnt {vmcnt = 0}
+  buffer_gl1_inv
+  buffer_gl0_inv
+  return
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
+
 kernel.def target(@target) @multi_wave_subgroup_barrier() {
   %one = index.constant 1 : index
   %threads = index.constant 64 : index
@@ -92,6 +159,30 @@ kernel.def target(@target) @multi_wave_barrier_gfx12() {
 low.kernel.def target<amdgpu.gfx12.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @multi_wave_barrier_gfx12() asm {
   s_barrier_signal_all
   s_barrier_wait_all
+  return
+}
+
+// ====
+
+amdgpu.target<gfx12-generic> @target
+
+kernel.def target(@target) @global_acq_rel_barrier_gfx12() {
+  %one = index.constant 1 : index
+  %threads = index.constant 64 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+} launch() {
+  kernel.barrier<global> {ordering = acq_rel, scope = workgroup}
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx12.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @global_acq_rel_barrier_gfx12() asm {
+  global_wb {scope = 2}
+  s_wait_storecnt {storecnt = 0}
+  s_barrier_signal_all
+  s_barrier_wait_all
+  s_wait_loadcnt {loadcnt = 0}
+  global_inv {scope = 2}
   return
 }
 
@@ -196,6 +287,28 @@ low.kernel.def target<amdgpu.gfx9_4.generic.core>(@target) workgroup_size(64, 1,
 
 amdgpu.target<gfx9-4-generic> @target
 
+kernel.def target(@target) @global_acq_rel_barrier_gfx9_4() {
+  %one = index.constant 1 : index
+  %threads = index.constant 64 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+} launch() {
+  kernel.barrier<global> {ordering = acq_rel, scope = workgroup}
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx9_4.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @global_acq_rel_barrier_gfx9_4() asm {
+  buffer_wbl2 {sc0 = 1, sc1 = 1}
+  s_barrier
+  s_waitcnt {vmcnt = 0}
+  buffer_inv {sc0 = 1, sc1 = 1}
+  return
+}
+
+// ====
+
+amdgpu.target<gfx9-4-generic> @target
+
 kernel.def target(@target) @multi_wave_subgroup_barrier_gfx9_4() {
   %one = index.constant 1 : index
   %threads = index.constant 128 : index
@@ -208,6 +321,28 @@ kernel.def target(@target) @multi_wave_subgroup_barrier_gfx9_4() {
 // ----
 low.kernel.def target<amdgpu.gfx9_4.generic.core>(@target) workgroup_size(128, 1, 1) workgroup_count(1, 1, 1) @multi_wave_subgroup_barrier_gfx9_4() asm {
   s_waitcnt {lgkmcnt = 0}
+  return
+}
+
+// ====
+
+amdgpu.target<gfx950> @target
+
+kernel.def target(@target) @global_acq_rel_barrier_gfx950() {
+  %one = index.constant 1 : index
+  %threads = index.constant 64 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+} launch() {
+  kernel.barrier<global> {ordering = acq_rel, scope = workgroup}
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.cdna4.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @global_acq_rel_barrier_gfx950() asm {
+  buffer_wbl2 {sc0 = 1, sc1 = 1}
+  s_barrier
+  s_waitcnt {vmcnt = 0}
+  buffer_inv {sc0 = 1, sc1 = 1}
   return
 }
 


### PR DESCRIPTION
kernel.barrier can now express a workgroup rendezvous that fences device-visible global memory with acquire, release, or acquire-release ordering. Source kernels can state producer and consumer synchronization directly instead of embedding target cache-control behavior.

Generic verification owns the accepted source forms: global-memory barriers synchronize a workgroup and use acquire, release, or acquire-release ordering. AMDGPU legality therefore checks only whether the selected descriptor set provides the required ordering and execution packets.

AMDGPU lowering composes the existing architecture-specific release and acquire policy around the selected workgroup barrier. The same source contract consequently selects the appropriate waits, cache writebacks or invalidations, and monolithic or split execution barrier across RDNA and CDNA targets.

The generic kernel round-trip and verifier corpus no longer declares ambient test targets. Only cases whose kernel explicitly binds a target symbol retain declarations, making the lack of any module-wide target context visible in the fixtures.

Reviewer Notes

The source contract and diagnostics live with kernel.barrier. The target review surface is the composition in sync.c and the packet-availability queries owned by system_memory.c; architecture-family fixtures pin the resulting RDNA3, RDNA4, CDNA3, and CDNA4 sequences.