### PR TITLE
[Loom/AMDGPU] Complete flat memory families and compact ASAN

### DIFF
--- a/loom/py/loom/gen/target/arch/amdgpu/refs/amdgpu_target_refs.py
+++ b/loom/py/loom/gen/target/arch/amdgpu/refs/amdgpu_target_refs.py
@@ -32,6 +32,10 @@ from loom.target.arch.amdgpu.descriptors import (  # noqa: E402
     amdgpu_immediate_encoding_id_items,
     build_amdgpu_core_descriptor_set_from_specs,
 )
+from loom.target.arch.amdgpu.descriptors.memory import (  # noqa: E402
+    _FLAT_LOAD_DESCRIPTOR_KEYS,
+    _FLAT_STORE_DESCRIPTOR_KEYS,
+)
 from loom.target.arch.amdgpu.encoding import (  # noqa: E402
     AMDGPU_ENCODING_FIELD_IDS,
     AMDGPU_ENCODING_FORMAT_FLAT,
@@ -72,8 +76,6 @@ _SYSTEM_MEMORY_GLOBAL_LOAD_DESCRIPTOR_KEYS = (
     "amdgpu.global_load_b32_saddr",
     "amdgpu.global_load_b64_saddr",
 )
-
-_SANITIZER_ACCESS_FLAT_LOAD_DESCRIPTOR_KEYS = ("amdgpu.flat_load_u8",)
 
 _SPILL_LOWERING_SCRATCH_DESCRIPTOR_KEYS = (
     "amdgpu.scratch_load_b32_offset_only",
@@ -346,8 +348,10 @@ def _validate_rel32_descriptor_contract(
 def _validate_lowering_descriptor_contracts(descriptor_set: DescriptorSet) -> None:
     for descriptor_key in _SYSTEM_MEMORY_GLOBAL_LOAD_DESCRIPTOR_KEYS:
         _validate_canonical_asm_operand_count(descriptor_set, descriptor_key, (2, 3))
-    for descriptor_key in _SANITIZER_ACCESS_FLAT_LOAD_DESCRIPTOR_KEYS:
+    for descriptor_key in _FLAT_LOAD_DESCRIPTOR_KEYS:
         _validate_canonical_asm_operand_count(descriptor_set, descriptor_key, (1, 2))
+    for descriptor_key in _FLAT_STORE_DESCRIPTOR_KEYS:
+        _validate_canonical_asm_operand_count(descriptor_set, descriptor_key, (2, 3))
     _validate_spill_lowering_descriptor_contracts(descriptor_set)
     for descriptor_key in _REL32_DESCRIPTOR_KEYS:
         _validate_rel32_descriptor_contract(descriptor_set, descriptor_key)

--- a/loom/py/loom/gen/target/arch/amdgpu/refs/amdgpu_target_refs_test.py
+++ b/loom/py/loom/gen/target/arch/amdgpu/refs/amdgpu_target_refs_test.py
@@ -216,6 +216,8 @@ def _valid_contract_descriptors() -> tuple[Descriptor, ...]:
         ),
         Immediate("byte_offset", ImmediateKind.UNSIGNED),
     )
+    flat_load_descriptors = tuple(_descriptor(descriptor_key, (AsmForm(operands=("addr",)),)) for descriptor_key in amdgpu_target_refs._FLAT_LOAD_DESCRIPTOR_KEYS)
+    flat_store_descriptors = tuple(_descriptor(descriptor_key, (AsmForm(operands=("addr", "value")),)) for descriptor_key in amdgpu_target_refs._FLAT_STORE_DESCRIPTOR_KEYS)
     return (
         _descriptor(
             "amdgpu.global_load_b32_saddr",
@@ -225,10 +227,8 @@ def _valid_contract_descriptors() -> tuple[Descriptor, ...]:
             "amdgpu.global_load_b64_saddr",
             (AsmForm(operands=("vaddr", "saddr", "m0")),),
         ),
-        _descriptor(
-            "amdgpu.flat_load_u8",
-            (AsmForm(operands=("addr",)),),
-        ),
+        *flat_load_descriptors,
+        *flat_store_descriptors,
         *_valid_spill_lowering_descriptors(),
         _descriptor(
             "amdgpu.s_add_u32.rhs_symbol_rel32_lo",
@@ -656,17 +656,31 @@ def test_lowering_descriptor_contracts_reject_missing_helper_descriptor() -> Non
 
 
 def test_lowering_descriptor_contracts_reject_bad_operand_count() -> None:
-    with _raises_value_error("amdgpu.flat_load_u8.*expected one of: 1, 2"):
-        amdgpu_target_refs._validate_lowering_descriptor_contracts(
-            _descriptor_set(
-                *_valid_contract_descriptors()[:2],
-                _descriptor(
-                    "amdgpu.flat_load_u8",
-                    (AsmForm(operands=("addr", "m0", "extra")),),
-                ),
-                *_valid_contract_descriptors()[3:],
-            )
+    descriptors = tuple(
+        _descriptor(
+            descriptor.key,
+            (AsmForm(operands=("addr", "m0", "extra")),),
         )
+        if descriptor.key == "amdgpu.flat_load_u8"
+        else descriptor
+        for descriptor in _valid_contract_descriptors()
+    )
+    with _raises_value_error("amdgpu.flat_load_u8.*expected one of: 1, 2"):
+        amdgpu_target_refs._validate_lowering_descriptor_contracts(_descriptor_set(*descriptors))
+
+
+def test_lowering_descriptor_contracts_reject_bad_flat_store_operand_count() -> None:
+    descriptors = tuple(
+        _descriptor(
+            descriptor.key,
+            (AsmForm(operands=("addr", "value", "m0", "extra")),),
+        )
+        if descriptor.key == "amdgpu.flat_store_b32"
+        else descriptor
+        for descriptor in _valid_contract_descriptors()
+    )
+    with _raises_value_error("amdgpu.flat_store_b32.*expected one of: 2, 3"):
+        amdgpu_target_refs._validate_lowering_descriptor_contracts(_descriptor_set(*descriptors))
 
 
 def test_spill_lowering_contracts_require_every_packet() -> None:

--- a/loom/py/loom/target/arch/amdgpu/descriptors/memory.py
+++ b/loom/py/loom/target/arch/amdgpu/descriptors/memory.py
@@ -3154,8 +3154,96 @@ def _flat_load_overlay(
     )
 
 
-def _flat_load_u8_overlay(
+_FLAT_LOAD_ROWS = (
+    (
+        "amdgpu.flat_load_u8",
+        "FLAT_LOAD_UBYTE",
+        8,
+        1,
+        "memory.generic.load.u8.zero_extend",
+        "FMT_NUM_U8",
+    ),
+    (
+        "amdgpu.flat_load_i8",
+        "FLAT_LOAD_SBYTE",
+        8,
+        1,
+        "memory.generic.load.i8.sign_extend",
+        "FMT_NUM_I8",
+    ),
+    (
+        "amdgpu.flat_load_u16",
+        "FLAT_LOAD_USHORT",
+        16,
+        1,
+        "memory.generic.load.u16.zero_extend",
+        "FMT_NUM_U16",
+    ),
+    (
+        "amdgpu.flat_load_i16",
+        "FLAT_LOAD_SSHORT",
+        16,
+        1,
+        "memory.generic.load.i16.sign_extend",
+        "FMT_NUM_I16",
+    ),
+    (
+        "amdgpu.flat_load_b32",
+        "FLAT_LOAD_DWORD",
+        32,
+        1,
+        "memory.generic.load.u32",
+        "FMT_NUM_B32",
+    ),
+    (
+        "amdgpu.flat_load_b64",
+        "FLAT_LOAD_DWORDX2",
+        64,
+        2,
+        "memory.generic.load.u64",
+        "FMT_NUM_B64",
+    ),
+    (
+        "amdgpu.flat_load_b96",
+        "FLAT_LOAD_DWORDX3",
+        96,
+        3,
+        "memory.generic.load.u96",
+        "FMT_NUM_B96",
+    ),
+    (
+        "amdgpu.flat_load_b128",
+        "FLAT_LOAD_DWORDX4",
+        128,
+        4,
+        "memory.generic.load.u128",
+        "FMT_NUM_B128",
+    ),
+)
+
+
+_FLAT_STORE_ROWS = (
+    ("amdgpu.flat_store_b8", "FLAT_STORE_BYTE", 8, 1, "FMT_NUM_B8"),
+    ("amdgpu.flat_store_b16", "FLAT_STORE_SHORT", 16, 1, "FMT_NUM_B16"),
+    ("amdgpu.flat_store_b32", "FLAT_STORE_DWORD", 32, 1, "FMT_NUM_B32"),
+    ("amdgpu.flat_store_b64", "FLAT_STORE_DWORDX2", 64, 2, "FMT_NUM_B64"),
+    ("amdgpu.flat_store_b96", "FLAT_STORE_DWORDX3", 96, 3, "FMT_NUM_B96"),
+    ("amdgpu.flat_store_b128", "FLAT_STORE_DWORDX4", 128, 4, "FMT_NUM_B128"),
+)
+
+_FLAT_LOAD_DESCRIPTOR_KEYS = tuple(
+    descriptor_key for descriptor_key, *_ in _FLAT_LOAD_ROWS
+)
+
+_FLAT_STORE_DESCRIPTOR_KEYS = tuple(
+    descriptor_key for descriptor_key, *_ in _FLAT_STORE_ROWS
+)
+
+
+def _flat_store_overlay(
     *,
+    descriptor_key: str,
+    instruction_name: str,
     mnemonic: str,
     encoding_name: str,
     address_field_name: str,
@@ -3163,68 +3251,151 @@ def _flat_load_u8_overlay(
     offset_field_name: str,
     offset_bit_width: int,
     offset_signed: bool,
+    width_bits: int,
+    units: int,
+    data_format_name: str,
     implicit_flat_scratch: bool,
-    implicit_m0: bool = False,
-    allow_accumulator_results: bool = False,
+    implicit_m0: bool,
+    allow_accumulator_operands: bool,
     fixed_saddr: AmdgpuFixedEncodingValue | None = None,
     cache_fields: tuple[tuple[str, int], ...] = (),
 ) -> AmdgpuDescriptorOverlay:
-    return _flat_load_overlay(
-        descriptor_key="amdgpu.flat_load_u8",
-        instruction_name="FLAT_LOAD_UBYTE",
+    value_operand = (
+        _vgpr_agpr_operand("value", units=units)
+        if allow_accumulator_operands
+        else _vgpr_operand("value", units=units)
+    )
+    implicit_operands: tuple[AmdgpuImplicitOperandOverlay, ...] = (
+        _ignore_generic_memory(
+            width_bits=width_bits,
+            data_format_name=data_format_name,
+            is_input=False,
+        ),
+    )
+    if implicit_flat_scratch:
+        implicit_operands += (_IGNORE_FLAT_SCRATCH_INPUT,)
+    if implicit_m0:
+        implicit_operands += (_implicit_m0_input(),)
+    fixed_encoding_fields: tuple[tuple[str, AmdgpuFixedEncodingValue], ...] = (
+        (("SADDR", fixed_saddr),) if fixed_saddr is not None else ()
+    )
+    offset_immediate = (
+        _signed_offset_immediate(offset_bit_width)
+        if offset_signed
+        else _offset_immediate(offset_bit_width)
+    )
+    asm_operands = ("addr", "value", "m0") if implicit_m0 else ("addr", "value")
+    return AmdgpuDescriptorOverlay(
+        descriptor_key=descriptor_key,
+        instruction_name=instruction_name,
         mnemonic=mnemonic,
         encoding_name=encoding_name,
-        address_field_name=address_field_name,
-        data_field_name=data_field_name,
-        offset_field_name=offset_field_name,
-        offset_bit_width=offset_bit_width,
-        offset_signed=offset_signed,
-        width_bits=8,
-        units=1,
-        semantic_tag="memory.generic.load.u8.zero_extend",
-        data_format_name="FMT_NUM_U8",
-        implicit_flat_scratch=implicit_flat_scratch,
-        implicit_m0=implicit_m0,
-        allow_accumulator_results=allow_accumulator_results,
-        fixed_saddr=fixed_saddr,
-        cache_fields=cache_fields,
+        semantic_tag=f"memory.generic.store.u{width_bits}",
+        schedule_class=_SCHEDULE_VMEM_STORE,
+        operands=(
+            AmdgpuOperandOverlay(address_field_name, _vgpr_operand("addr", units=2)),
+            AmdgpuOperandOverlay(data_field_name, value_operand),
+        ),
+        implicit_operands=implicit_operands,
+        fixed_encoding_fields=fixed_encoding_fields,
+        immediate_fields=(offset_field_name, *_cache_field_names(cache_fields)),
+        immediates=(offset_immediate, *_cache_immediates(cache_fields)),
+        effects=(_generic_write_effect(width_bits),),
+        flags=(DescriptorFlag.SIDE_EFFECTING,),
+        asm_forms=_asm(
+            mnemonic=mnemonic,
+            operands=asm_operands,
+            immediates=_memory_asm_immediate_names(cache_fields),
+            named_immediates=True,
+        ),
     )
 
 
-def _flat_load_u64_overlay(
+def _flat_memory_overlays(
     *,
-    mnemonic: str,
+    load_mnemonics: tuple[str, ...],
+    store_mnemonics: tuple[str, ...],
     encoding_name: str,
     address_field_name: str,
-    data_field_name: str,
+    load_data_field_name: str,
+    store_data_field_name: str,
     offset_field_name: str,
     offset_bit_width: int,
     offset_signed: bool,
     implicit_flat_scratch: bool,
     implicit_m0: bool = False,
     allow_accumulator_results: bool = False,
+    allow_accumulator_operands: bool = False,
     fixed_saddr: AmdgpuFixedEncodingValue | None = None,
     cache_fields: tuple[tuple[str, int], ...] = (),
-) -> AmdgpuDescriptorOverlay:
-    return _flat_load_overlay(
-        descriptor_key="amdgpu.flat_load_u64",
-        instruction_name="FLAT_LOAD_DWORDX2",
-        mnemonic=mnemonic,
-        encoding_name=encoding_name,
-        address_field_name=address_field_name,
-        data_field_name=data_field_name,
-        offset_field_name=offset_field_name,
-        offset_bit_width=offset_bit_width,
-        offset_signed=offset_signed,
-        width_bits=64,
-        units=2,
-        semantic_tag="memory.generic.load.u64",
-        data_format_name="FMT_NUM_B64",
-        implicit_flat_scratch=implicit_flat_scratch,
-        implicit_m0=implicit_m0,
-        allow_accumulator_results=allow_accumulator_results,
-        fixed_saddr=fixed_saddr,
-        cache_fields=cache_fields,
+) -> tuple[AmdgpuDescriptorOverlay, ...]:
+    return (
+        *(
+            _flat_load_overlay(
+                descriptor_key=descriptor_key,
+                instruction_name=instruction_name,
+                mnemonic=mnemonic,
+                encoding_name=encoding_name,
+                address_field_name=address_field_name,
+                data_field_name=load_data_field_name,
+                offset_field_name=offset_field_name,
+                offset_bit_width=offset_bit_width,
+                offset_signed=offset_signed,
+                width_bits=width_bits,
+                units=units,
+                semantic_tag=semantic_tag,
+                data_format_name=data_format_name,
+                implicit_flat_scratch=implicit_flat_scratch,
+                implicit_m0=implicit_m0,
+                allow_accumulator_results=allow_accumulator_results,
+                fixed_saddr=fixed_saddr,
+                cache_fields=cache_fields,
+            )
+            for (
+                descriptor_key,
+                instruction_name,
+                width_bits,
+                units,
+                semantic_tag,
+                data_format_name,
+            ), mnemonic in zip(
+                _FLAT_LOAD_ROWS,
+                load_mnemonics,
+                strict=True,
+            )
+        ),
+        *(
+            _flat_store_overlay(
+                descriptor_key=descriptor_key,
+                instruction_name=instruction_name,
+                mnemonic=mnemonic,
+                encoding_name=encoding_name,
+                address_field_name=address_field_name,
+                data_field_name=store_data_field_name,
+                offset_field_name=offset_field_name,
+                offset_bit_width=offset_bit_width,
+                offset_signed=offset_signed,
+                width_bits=width_bits,
+                units=units,
+                data_format_name=data_format_name,
+                implicit_flat_scratch=implicit_flat_scratch,
+                implicit_m0=implicit_m0,
+                allow_accumulator_operands=allow_accumulator_operands,
+                fixed_saddr=fixed_saddr,
+                cache_fields=cache_fields,
+            )
+            for (
+                descriptor_key,
+                instruction_name,
+                width_bits,
+                units,
+                data_format_name,
+            ), mnemonic in zip(
+                _FLAT_STORE_ROWS,
+                store_mnemonics,
+                strict=True,
+            )
+        ),
     )
 
 
@@ -4111,6 +4282,8 @@ __all__ = (
     "_BUFFER_LOAD_LDS_GFX950_VARIANTS",
     "_GLOBAL_LOAD_LDS_CDNA3_VARIANTS",
     "_GLOBAL_LOAD_LDS_GFX950_VARIANTS",
+    "_FLAT_LOAD_DESCRIPTOR_KEYS",
+    "_FLAT_STORE_DESCRIPTOR_KEYS",
     "_MEMORY_DWORD_VECTOR_WIDTHS",
     "_SMEM_DWORDX4_WIDTHS",
     "_buffer_b16_memory_overlays",
@@ -4153,9 +4326,8 @@ __all__ = (
     "_buffer_store_dword_vaddr_offset_overlay",
     "_buffer_store_off_zero_overlay",
     "_buffer_store_vaddr_offset_overlay",
+    "_flat_memory_overlays",
     "_flat_load_overlay",
-    "_flat_load_u8_overlay",
-    "_flat_load_u64_overlay",
     "_global_b16_memory_overlays",
     "_global_byte_memory_overlays",
     "_global_load_b16_d16_overlay",

--- a/loom/py/loom/target/arch/amdgpu/descriptors/sets.py
+++ b/loom/py/loom/target/arch/amdgpu/descriptors/sets.py
@@ -55,6 +55,43 @@ _CDNA_DWORD_MEMORY_MNEMONIC_SUFFIXES = (
 _BYTE_MEMORY_INSTRUCTION_SUFFIXES = ("B32", "B64", "B96", "B128")
 _BYTE_MEMORY_MNEMONIC_SUFFIXES = ("b32", "b64", "b96", "b128")
 
+_CDNA_FLAT_LOAD_MNEMONICS = (
+    "flat_load_ubyte",
+    "flat_load_sbyte",
+    "flat_load_ushort",
+    "flat_load_sshort",
+    "flat_load_dword",
+    "flat_load_dwordx2",
+    "flat_load_dwordx3",
+    "flat_load_dwordx4",
+)
+_CDNA_FLAT_STORE_MNEMONICS = (
+    "flat_store_byte",
+    "flat_store_short",
+    "flat_store_dword",
+    "flat_store_dwordx2",
+    "flat_store_dwordx3",
+    "flat_store_dwordx4",
+)
+_RDNA_FLAT_LOAD_MNEMONICS = (
+    "flat_load_u8",
+    "flat_load_i8",
+    "flat_load_u16",
+    "flat_load_i16",
+    "flat_load_dword",
+    "flat_load_dwordx2",
+    "flat_load_dwordx3",
+    "flat_load_dwordx4",
+)
+_RDNA_FLAT_STORE_MNEMONICS = (
+    "flat_store_b8",
+    "flat_store_b16",
+    "flat_store_b32",
+    "flat_store_b64",
+    "flat_store_b96",
+    "flat_store_b128",
+)
+
 _RDNA4_VBUFFER_DWORD_WIDTH_OVERLAY_ROWS = (
     (_buffer_load_dword_overlay, _buffer_load_dword_vaddr_offset_overlay),
     (_buffer_load_64_overlay, _buffer_load_64_vaddr_offset_overlay),
@@ -792,30 +829,20 @@ def _cdna_core_overlays(
             descriptor_key_suffix="_saddr",
             implicit_m0=True,
         ),
-        _flat_load_u8_overlay(
-            mnemonic="flat_load_ubyte",
+        *_flat_memory_overlays(
+            load_mnemonics=_CDNA_FLAT_LOAD_MNEMONICS,
+            store_mnemonics=_CDNA_FLAT_STORE_MNEMONICS,
             encoding_name="ENC_FLAT",
             address_field_name="ADDR",
-            data_field_name="VDST",
+            load_data_field_name="VDST",
+            store_data_field_name="DATA",
             offset_field_name="OFFSET",
             offset_bit_width=12,
             offset_signed=False,
             implicit_flat_scratch=True,
             implicit_m0=True,
             allow_accumulator_results=True,
-            cache_fields=_GFX950_VECTOR_CACHE_FIELDS,
-        ),
-        _flat_load_u64_overlay(
-            mnemonic="flat_load_dwordx2",
-            encoding_name="ENC_FLAT",
-            address_field_name="ADDR",
-            data_field_name="VDST",
-            offset_field_name="OFFSET",
-            offset_bit_width=12,
-            offset_signed=False,
-            implicit_flat_scratch=True,
-            implicit_m0=True,
-            allow_accumulator_results=True,
+            allow_accumulator_operands=True,
             cache_fields=_GFX950_VECTOR_CACHE_FIELDS,
         ),
         *_flat_atomic_overlays(
@@ -1298,23 +1325,13 @@ def _gfx11_core_overlays() -> tuple[AmdgpuDescriptorOverlay, ...]:
             address_units=1,
             descriptor_key_suffix="_saddr",
         ),
-        _flat_load_u8_overlay(
-            mnemonic="flat_load_u8",
+        *_flat_memory_overlays(
+            load_mnemonics=_RDNA_FLAT_LOAD_MNEMONICS,
+            store_mnemonics=_RDNA_FLAT_STORE_MNEMONICS,
             encoding_name="ENC_FLAT",
             address_field_name="ADDR",
-            data_field_name="VDST",
-            offset_field_name="OFFSET",
-            offset_bit_width=13,
-            offset_signed=True,
-            implicit_flat_scratch=True,
-            fixed_saddr=_predefined("NULL", "OPR_SREG"),
-            cache_fields=_GFX9_11_VECTOR_CACHE_FIELDS,
-        ),
-        _flat_load_u64_overlay(
-            mnemonic="flat_load_dwordx2",
-            encoding_name="ENC_FLAT",
-            address_field_name="ADDR",
-            data_field_name="VDST",
+            load_data_field_name="VDST",
+            store_data_field_name="DATA",
             offset_field_name="OFFSET",
             offset_bit_width=13,
             offset_signed=True,
@@ -1767,22 +1784,13 @@ def _rdna4_core_overlays() -> tuple[AmdgpuDescriptorOverlay, ...]:
             address_units=1,
             descriptor_key_suffix="_saddr",
         ),
-        _flat_load_u8_overlay(
-            mnemonic="flat_load_u8",
+        *_flat_memory_overlays(
+            load_mnemonics=_RDNA_FLAT_LOAD_MNEMONICS,
+            store_mnemonics=_RDNA_FLAT_STORE_MNEMONICS,
             encoding_name="ENC_VFLAT",
             address_field_name="VADDR",
-            data_field_name="VDST",
-            offset_field_name="IOFFSET",
-            offset_bit_width=24,
-            offset_signed=True,
-            implicit_flat_scratch=False,
-            cache_fields=_GFX12_VECTOR_CACHE_FIELDS,
-        ),
-        _flat_load_u64_overlay(
-            mnemonic="flat_load_dwordx2",
-            encoding_name="ENC_VFLAT",
-            address_field_name="VADDR",
-            data_field_name="VDST",
+            load_data_field_name="VDST",
+            store_data_field_name="VSRC",
             offset_field_name="IOFFSET",
             offset_bit_width=24,
             offset_signed=True,

--- a/loom/py/loom/target/arch/amdgpu/descriptors_test.py
+++ b/loom/py/loom/target/arch/amdgpu/descriptors_test.py
@@ -68,6 +68,7 @@ from loom.target.arch.amdgpu.descriptors import (
     _SCHEDULE_VALU,
     _SCHEDULE_VMEM_LOAD,
     _SCHEDULE_VMEM_LOAD_LDS,
+    _SCHEDULE_VMEM_STORE,
     _SCHEDULE_WAIT_ALU,
     _SCHEDULE_WMMA,
     _SOURCE_INLINE_F32_ENCODING_ID,
@@ -2469,10 +2470,47 @@ def test_feedback_atomic64_descriptors_expand_source_atomic_candidates() -> None
     assert "amdgpu.global_atomic_cmpswap_b64_rtn_saddr" in keys
 
 
-def test_flat_load_descriptors_cover_execution_families() -> None:
+def test_flat_memory_descriptors_cover_execution_families() -> None:
+    cdna_load_mnemonics = (
+        "flat_load_ubyte",
+        "flat_load_sbyte",
+        "flat_load_ushort",
+        "flat_load_sshort",
+        "flat_load_dword",
+        "flat_load_dwordx2",
+        "flat_load_dwordx3",
+        "flat_load_dwordx4",
+    )
+    rdna_load_mnemonics = (
+        "flat_load_u8",
+        "flat_load_i8",
+        "flat_load_u16",
+        "flat_load_i16",
+        "flat_load_dword",
+        "flat_load_dwordx2",
+        "flat_load_dwordx3",
+        "flat_load_dwordx4",
+    )
+    cdna_store_mnemonics = (
+        "flat_store_byte",
+        "flat_store_short",
+        "flat_store_dword",
+        "flat_store_dwordx2",
+        "flat_store_dwordx3",
+        "flat_store_dwordx4",
+    )
+    rdna_store_mnemonics = (
+        "flat_store_b8",
+        "flat_store_b16",
+        "flat_store_b32",
+        "flat_store_b64",
+        "flat_store_b96",
+        "flat_store_b128",
+    )
     for (
         overlays,
-        u8_mnemonic,
+        load_mnemonics,
+        store_mnemonics,
         uses_flat_scratch,
         uses_m0,
         expected_saddr_fields,
@@ -2480,7 +2518,8 @@ def test_flat_load_descriptors_cover_execution_families() -> None:
     ) in (
         (
             _gfx940_core_overlays(),
-            "flat_load_ubyte",
+            cdna_load_mnemonics,
+            cdna_store_mnemonics,
             True,
             True,
             (),
@@ -2488,7 +2527,8 @@ def test_flat_load_descriptors_cover_execution_families() -> None:
         ),
         (
             _gfx950_core_overlays(),
-            "flat_load_ubyte",
+            cdna_load_mnemonics,
+            cdna_store_mnemonics,
             True,
             True,
             (),
@@ -2496,7 +2536,8 @@ def test_flat_load_descriptors_cover_execution_families() -> None:
         ),
         (
             _gfx11_core_overlays(),
-            "flat_load_u8",
+            rdna_load_mnemonics,
+            rdna_store_mnemonics,
             True,
             False,
             (("SADDR", _predefined("NULL", "OPR_SREG")),),
@@ -2504,7 +2545,8 @@ def test_flat_load_descriptors_cover_execution_families() -> None:
         ),
         (
             _gfx12_core_overlays(),
-            "flat_load_u8",
+            rdna_load_mnemonics,
+            rdna_store_mnemonics,
             False,
             False,
             (),
@@ -2512,7 +2554,8 @@ def test_flat_load_descriptors_cover_execution_families() -> None:
         ),
         (
             _gfx125x_core_overlays(),
-            "flat_load_u8",
+            rdna_load_mnemonics,
+            rdna_store_mnemonics,
             False,
             False,
             (),
@@ -2524,26 +2567,69 @@ def test_flat_load_descriptors_cover_execution_families() -> None:
             descriptor_key,
             width_bits,
             semantic_tag,
-            mnemonic,
             operand_units,
             implicit_data_format,
-        ) in (
+        ), mnemonic in zip(
             (
-                "amdgpu.flat_load_u8",
-                8,
-                "memory.generic.load.u8.zero_extend",
-                u8_mnemonic,
-                1,
-                "FMT_NUM_U8",
+                (
+                    "amdgpu.flat_load_u8",
+                    8,
+                    "memory.generic.load.u8.zero_extend",
+                    1,
+                    "FMT_NUM_U8",
+                ),
+                (
+                    "amdgpu.flat_load_i8",
+                    8,
+                    "memory.generic.load.i8.sign_extend",
+                    1,
+                    "FMT_NUM_I8",
+                ),
+                (
+                    "amdgpu.flat_load_u16",
+                    16,
+                    "memory.generic.load.u16.zero_extend",
+                    1,
+                    "FMT_NUM_U16",
+                ),
+                (
+                    "amdgpu.flat_load_i16",
+                    16,
+                    "memory.generic.load.i16.sign_extend",
+                    1,
+                    "FMT_NUM_I16",
+                ),
+                (
+                    "amdgpu.flat_load_b32",
+                    32,
+                    "memory.generic.load.u32",
+                    1,
+                    "FMT_NUM_B32",
+                ),
+                (
+                    "amdgpu.flat_load_b64",
+                    64,
+                    "memory.generic.load.u64",
+                    2,
+                    "FMT_NUM_B64",
+                ),
+                (
+                    "amdgpu.flat_load_b96",
+                    96,
+                    "memory.generic.load.u96",
+                    3,
+                    "FMT_NUM_B96",
+                ),
+                (
+                    "amdgpu.flat_load_b128",
+                    128,
+                    "memory.generic.load.u128",
+                    4,
+                    "FMT_NUM_B128",
+                ),
             ),
-            (
-                "amdgpu.flat_load_u64",
-                64,
-                "memory.generic.load.u64",
-                "flat_load_dwordx2",
-                2,
-                "FMT_NUM_B64",
-            ),
+            load_mnemonics,
+            strict=True,
         ):
             descriptor = descriptors[descriptor_key]
             _assert_memory_width_overlay(
@@ -2570,6 +2656,54 @@ def test_flat_load_descriptors_cover_execution_families() -> None:
                 tuple(immediate.field_name for immediate in asm_form.immediates)
                 == expected_asm_immediates
             )
+            assert (
+                tuple(immediate.name for immediate in asm_form.immediates)
+                == expected_asm_immediates
+            )
+            assert (
+                any(
+                    operand.operand_type == "OPR_FLAT_SCRATCH"
+                    for operand in descriptor.implicit_operands
+                )
+                == uses_flat_scratch
+            )
+            assert descriptor.fixed_encoding_fields == expected_saddr_fields
+            assert (
+                any(
+                    operand.operand_type == "OPR_SDST_M0"
+                    for operand in descriptor.implicit_operands
+                )
+                == uses_m0
+            )
+
+        for (width_bits, operand_units), mnemonic in zip(
+            ((8, 1), (16, 1), (32, 1), (64, 2), (96, 3), (128, 4)),
+            store_mnemonics,
+            strict=True,
+        ):
+            descriptor = descriptors[f"amdgpu.flat_store_b{width_bits}"]
+            _assert_memory_width_overlay(
+                descriptor,
+                width_bits=width_bits,
+                semantic_tag=f"memory.generic.store.u{width_bits}",
+                mnemonic=mnemonic,
+                operand_units=operand_units,
+                payload_field_name="value",
+                effect_kind=EffectKind.WRITE,
+                memory_space=MemorySpace.GENERIC,
+                implicit_data_format=f"FMT_NUM_B{width_bits}",
+                implicit_ignore_reason="modeled-by-generic-write-effect",
+            )
+            assert descriptor.schedule_class == _SCHEDULE_VMEM_STORE
+            assert descriptor.asm_forms is not None
+            assert len(descriptor.asm_forms) == 1
+            asm_form = descriptor.asm_forms[0]
+            assert asm_form.mnemonic == mnemonic
+            assert asm_form.results == ()
+            expected_asm_operands = (
+                ("addr", "value", "m0") if uses_m0 else ("addr", "value")
+            )
+            assert asm_form.operands == expected_asm_operands
             assert (
                 tuple(immediate.name for immediate in asm_form.immediates)
                 == expected_asm_immediates

--- a/loom/src/loom/target/arch/amdgpu/lower/sanitizer_access.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/sanitizer_access.c
@@ -563,21 +563,43 @@ static iree_status_t loom_amdgpu_sanitizer_access_build_shadow_address(
       loom_low_concat_result(scaled_op), location, out_shadow_address);
 }
 
-static iree_status_t loom_amdgpu_sanitizer_access_build_shadow_load_u8(
+static iree_status_t loom_amdgpu_sanitizer_access_build_shadow_load(
     loom_builder_t* builder, const loom_low_descriptor_set_t* descriptor_set,
-    loom_value_id_t shadow_address, loom_location_id_t location,
-    loom_value_id_t* out_shadow_value) {
+    loom_value_id_t shadow_address, uint32_t byte_length,
+    loom_location_id_t location, loom_value_id_t* out_shadow_value) {
   *out_shadow_value = LOOM_VALUE_ID_INVALID;
   loom_amdgpu_sanitizer_access_require_register_class(
       builder, descriptor_set, shadow_address, 2,
       LOOM_AMDGPU_REG_CLASS_ID_VGPR);
 
-  loom_type_t vgpr_type = loom_type_none();
-  IREE_RETURN_IF_ERROR(loom_low_build_register_type(
-      descriptor_set, LOOM_AMDGPU_REG_CLASS_ID_VGPR, 1, &vgpr_type));
+  loom_amdgpu_descriptor_ref_t descriptor_ref = LOOM_AMDGPU_DESCRIPTOR_REF_NONE;
+  uint32_t result_unit_count = 1;
+  switch (byte_length) {
+    case 1:
+      descriptor_ref = LOOM_AMDGPU_DESCRIPTOR_REF_FLAT_LOAD_U8;
+      break;
+    case 2:
+      descriptor_ref = LOOM_AMDGPU_DESCRIPTOR_REF_FLAT_LOAD_U16;
+      break;
+    case 4:
+      descriptor_ref = LOOM_AMDGPU_DESCRIPTOR_REF_FLAT_LOAD_B32;
+      break;
+    case 8:
+      descriptor_ref = LOOM_AMDGPU_DESCRIPTOR_REF_FLAT_LOAD_B64;
+      result_unit_count = 2;
+      break;
+    default:
+      IREE_ASSERT_UNREACHABLE("unsupported AMDGPU ASAN shadow load width");
+      IREE_BUILTIN_UNREACHABLE();
+  }
 
-  const loom_low_descriptor_t* descriptor = loom_amdgpu_lookup_descriptor_ref(
-      descriptor_set, LOOM_AMDGPU_DESCRIPTOR_REF_FLAT_LOAD_U8);
+  loom_type_t result_type = loom_type_none();
+  IREE_RETURN_IF_ERROR(loom_low_build_register_type(
+      descriptor_set, LOOM_AMDGPU_REG_CLASS_ID_VGPR, result_unit_count,
+      &result_type));
+
+  const loom_low_descriptor_t* descriptor =
+      loom_amdgpu_lookup_descriptor_ref(descriptor_set, descriptor_ref);
   const loom_low_asm_form_t* asm_form =
       loom_amdgpu_sanitizer_access_canonical_asm_form(descriptor_set,
                                                       descriptor);
@@ -601,54 +623,7 @@ static iree_status_t loom_amdgpu_sanitizer_access_build_shadow_load_u8(
   loom_op_t* load_op = NULL;
   IREE_RETURN_IF_ERROR(loom_low_build_resolved_descriptor_op(
       builder, descriptor_set, descriptor, operands, operand_count,
-      loom_make_named_attr_slice(attrs, attr_count), &vgpr_type,
-      /*result_count=*/1, /*tied_results=*/NULL, /*tied_result_count=*/0,
-      location, &load_op));
-  *out_shadow_value = loom_value_slice_get(loom_low_op_results(load_op), 0);
-
-  return loom_amdgpu_system_memory_build_load_wait(builder, descriptor_set,
-                                                   location);
-}
-
-static iree_status_t loom_amdgpu_sanitizer_access_build_shadow_load_u64(
-    loom_builder_t* builder, const loom_low_descriptor_set_t* descriptor_set,
-    loom_value_id_t shadow_address, loom_location_id_t location,
-    loom_value_id_t* out_shadow_value) {
-  *out_shadow_value = LOOM_VALUE_ID_INVALID;
-  loom_amdgpu_sanitizer_access_require_register_class(
-      builder, descriptor_set, shadow_address, 2,
-      LOOM_AMDGPU_REG_CLASS_ID_VGPR);
-
-  loom_type_t vgpr_x2_type = loom_type_none();
-  IREE_RETURN_IF_ERROR(loom_low_build_register_type(
-      descriptor_set, LOOM_AMDGPU_REG_CLASS_ID_VGPR, 2, &vgpr_x2_type));
-
-  const loom_low_descriptor_t* descriptor = loom_amdgpu_lookup_descriptor_ref(
-      descriptor_set, LOOM_AMDGPU_DESCRIPTOR_REF_FLAT_LOAD_U64);
-  const loom_low_asm_form_t* asm_form =
-      loom_amdgpu_sanitizer_access_canonical_asm_form(descriptor_set,
-                                                      descriptor);
-  IREE_ASSERT(asm_form->operand_index_count == 1 ||
-              asm_form->operand_index_count == 2);
-  loom_named_attr_t attrs[3] = {0};
-  iree_host_size_t attr_count = 0;
-  IREE_RETURN_IF_ERROR(loom_amdgpu_system_memory_append_load_attrs(
-      builder, descriptor_set, attrs, IREE_ARRAYSIZE(attrs), &attr_count));
-  loom_amdgpu_filter_descriptor_optional_attrs(builder, descriptor_set,
-                                               descriptor, /*required_count=*/0,
-                                               attrs, &attr_count);
-  loom_value_id_t operands[2] = {shadow_address, LOOM_VALUE_ID_INVALID};
-  iree_host_size_t operand_count = 1;
-  if (asm_form->operand_index_count == 2) {
-    loom_value_id_t m0_value = LOOM_VALUE_ID_INVALID;
-    IREE_RETURN_IF_ERROR(loom_amdgpu_sanitizer_access_build_m0_const_u32(
-        builder, descriptor_set, descriptor, 0, location, &m0_value));
-    operands[operand_count++] = m0_value;
-  }
-  loom_op_t* load_op = NULL;
-  IREE_RETURN_IF_ERROR(loom_low_build_resolved_descriptor_op(
-      builder, descriptor_set, descriptor, operands, operand_count,
-      loom_make_named_attr_slice(attrs, attr_count), &vgpr_x2_type,
+      loom_make_named_attr_slice(attrs, attr_count), &result_type,
       /*result_count=*/1, /*tied_results=*/NULL, /*tied_result_count=*/0,
       location, &load_op));
   *out_shadow_value = loom_value_slice_get(loom_low_op_results(load_op), 0);
@@ -721,12 +696,28 @@ static iree_status_t loom_amdgpu_sanitizer_access_build_shadow_failure_mask(
 }
 
 static iree_status_t
-loom_amdgpu_sanitizer_access_build_shadow_word_failure_mask(
+loom_amdgpu_sanitizer_access_build_shadow_chunk_failure_mask(
     loom_builder_t* builder, const loom_low_descriptor_set_t* descriptor_set,
-    loom_value_id_t shadow_value, loom_value_id_t zero,
-    loom_location_id_t location, loom_value_id_t* out_failure_mask) {
+    loom_value_id_t shadow_value, uint32_t shadow_byte_length,
+    loom_value_id_t zero, loom_location_id_t location,
+    loom_value_id_t* out_failure_mask) {
   *out_failure_mask = LOOM_VALUE_ID_INVALID;
 
+  loom_type_t mask_type = loom_type_none();
+  IREE_RETURN_IF_ERROR(loom_low_build_register_type(
+      descriptor_set, LOOM_AMDGPU_REG_CLASS_ID_SGPR, 2, &mask_type));
+  if (shadow_byte_length <= 4) {
+    const loom_value_id_t operands[] = {shadow_value, zero};
+    loom_op_t* op = NULL;
+    IREE_RETURN_IF_ERROR(loom_amdgpu_sanitizer_access_build_descriptor_op(
+        builder, descriptor_set, LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_NE_I32,
+        operands, IREE_ARRAYSIZE(operands), loom_make_named_attr_slice(NULL, 0),
+        &mask_type, /*result_count=*/1, location, &op));
+    *out_failure_mask = loom_value_slice_get(loom_low_op_results(op), 0);
+    return iree_ok_status();
+  }
+
+  IREE_ASSERT_EQ(shadow_byte_length, 8u);
   loom_type_t vgpr_type = loom_type_none();
   IREE_RETURN_IF_ERROR(loom_low_build_register_type(
       descriptor_set, LOOM_AMDGPU_REG_CLASS_ID_VGPR, 1, &vgpr_type));
@@ -739,9 +730,6 @@ loom_amdgpu_sanitizer_access_build_shadow_word_failure_mask(
       builder, shadow_value, /*lane_index=*/1, vgpr_type, location,
       &shadow_hi));
 
-  loom_type_t mask_type = loom_type_none();
-  IREE_RETURN_IF_ERROR(loom_low_build_register_type(
-      descriptor_set, LOOM_AMDGPU_REG_CLASS_ID_SGPR, 2, &mask_type));
   const loom_value_id_t lo_operands[] = {shadow_lo, zero};
   loom_op_t* lo_op = NULL;
   IREE_RETURN_IF_ERROR(loom_amdgpu_sanitizer_access_build_descriptor_op(
@@ -812,9 +800,9 @@ static iree_status_t loom_amdgpu_sanitizer_access_build_packet_check(
       builder, descriptor_set, fault_address_vgpr, config->shadow_base,
       location, &first_shadow_address));
   loom_value_id_t first_shadow_value = LOOM_VALUE_ID_INVALID;
-  IREE_RETURN_IF_ERROR(loom_amdgpu_sanitizer_access_build_shadow_load_u8(
-      builder, descriptor_set, first_shadow_address, location,
-      &first_shadow_value));
+  IREE_RETURN_IF_ERROR(loom_amdgpu_sanitizer_access_build_shadow_load(
+      builder, descriptor_set, first_shadow_address, /*byte_length=*/1,
+      location, &first_shadow_value));
 
   loom_type_t vgpr_type = loom_type_none();
   IREE_RETURN_IF_ERROR(loom_low_build_register_type(
@@ -860,9 +848,9 @@ static iree_status_t loom_amdgpu_sanitizer_access_build_packet_check(
         builder, descriptor_set, last_address, config->shadow_base, location,
         &last_shadow_address));
     loom_value_id_t last_shadow_value = LOOM_VALUE_ID_INVALID;
-    IREE_RETURN_IF_ERROR(loom_amdgpu_sanitizer_access_build_shadow_load_u8(
-        builder, descriptor_set, last_shadow_address, location,
-        &last_shadow_value));
+    IREE_RETURN_IF_ERROR(loom_amdgpu_sanitizer_access_build_shadow_load(
+        builder, descriptor_set, last_shadow_address, /*byte_length=*/1,
+        location, &last_shadow_value));
 
     loom_value_id_t last_address_lo = LOOM_VALUE_ID_INVALID;
     IREE_RETURN_IF_ERROR(loom_amdgpu_sanitizer_access_build_register_lane(
@@ -929,8 +917,17 @@ loom_amdgpu_sanitizer_access_build_full_granule_failure_mask(
       descriptor_set, LOOM_AMDGPU_REG_CLASS_ID_SGPR, 2, &mask_type));
 
   loom_value_id_t failure_mask = LOOM_VALUE_ID_INVALID;
-  for (uint32_t chunk_offset = 0; chunk_offset < access_size;
-       chunk_offset += 64) {
+  uint32_t remaining_shadow_bytes =
+      access_size >> LOOM_AMDGPU_ASAN_SHADOW_SCALE_SHIFT;
+  for (uint32_t chunk_offset = 0; remaining_shadow_bytes != 0;) {
+    uint32_t shadow_byte_length = 1;
+    if (remaining_shadow_bytes >= 8) {
+      shadow_byte_length = 8;
+    } else if (remaining_shadow_bytes >= 4) {
+      shadow_byte_length = 4;
+    } else if (remaining_shadow_bytes >= 2) {
+      shadow_byte_length = 2;
+    }
     loom_value_id_t chunk_address = fault_address_vgpr;
     if (chunk_offset != 0) {
       loom_value_id_t chunk_delta = LOOM_VALUE_ID_INVALID;
@@ -946,13 +943,16 @@ loom_amdgpu_sanitizer_access_build_full_granule_failure_mask(
         builder, descriptor_set, chunk_address, config->shadow_base, location,
         &shadow_address));
     loom_value_id_t shadow_value = LOOM_VALUE_ID_INVALID;
-    IREE_RETURN_IF_ERROR(loom_amdgpu_sanitizer_access_build_shadow_load_u64(
-        builder, descriptor_set, shadow_address, location, &shadow_value));
+    IREE_RETURN_IF_ERROR(loom_amdgpu_sanitizer_access_build_shadow_load(
+        builder, descriptor_set, shadow_address, shadow_byte_length, location,
+        &shadow_value));
     loom_value_id_t chunk_failure_mask = LOOM_VALUE_ID_INVALID;
     IREE_RETURN_IF_ERROR(
-        loom_amdgpu_sanitizer_access_build_shadow_word_failure_mask(
-            builder, descriptor_set, shadow_value, config->zero, location,
-            &chunk_failure_mask));
+        loom_amdgpu_sanitizer_access_build_shadow_chunk_failure_mask(
+            builder, descriptor_set, shadow_value, shadow_byte_length,
+            config->zero, location, &chunk_failure_mask));
+    chunk_offset += shadow_byte_length << LOOM_AMDGPU_ASAN_SHADOW_SCALE_SHIFT;
+    remaining_shadow_bytes -= shadow_byte_length;
 
     if (failure_mask == LOOM_VALUE_ID_INVALID) {
       failure_mask = chunk_failure_mask;
@@ -969,8 +969,8 @@ loom_amdgpu_sanitizer_access_build_full_granule_failure_mask(
     failure_mask = loom_value_slice_get(loom_low_op_results(failure_op), 0);
   }
 
-  // Unknown address alignment can make each 64B access reach one final partial
-  // shadow granule beyond the full shadow word loaded above. Check that final
+  // Unknown address alignment can make the access reach one final partial
+  // shadow granule beyond the full shadow chunks loaded above. Check that final
   // byte precisely so row-strided fragments do not report on untouched padding.
   if (minimum_alignment < 8) {
     loom_value_id_t last_address_delta = LOOM_VALUE_ID_INVALID;
@@ -1121,7 +1121,7 @@ iree_status_t loom_amdgpu_build_sanitizer_access_failure_mask_with_config(
     loom_location_id_t location, loom_value_id_t* out_failure_mask) {
   IREE_ASSERT_ARGUMENT(out_failure_mask);
   *out_failure_mask = LOOM_VALUE_ID_INVALID;
-  if (access_size != 0 && access_size % 64 == 0) {
+  if (access_size != 0 && access_size % 8 == 0) {
     return loom_amdgpu_sanitizer_access_build_full_granule_failure_mask(
         builder, descriptor_set, config, fault_address, access_size,
         minimum_alignment, wavefront_size, location, out_failure_mask);

--- a/loom/src/loom/target/arch/amdgpu/lower/sanitizer_access.h
+++ b/loom/src/loom/target/arch/amdgpu/lower/sanitizer_access.h
@@ -51,8 +51,9 @@ iree_status_t loom_amdgpu_build_sanitizer_access_config(
 // Emits the hot-path AMDGPU ASAN-style failure predicate for one static access
 // range.
 //
-// |fault_address| must be a 64-bit SGPR or VGPR register range. |access_size|
-// is packetized into <=8 byte chunks so every touched shadow byte is covered.
+// |fault_address| must be a 64-bit SGPR or VGPR register range. Full shadow
+// granules use exact-width shadow loads; partial ranges use precise endpoint
+// checks so every touched shadow byte is covered.
 // |wavefront_size| must be 32 or 64 and controls whether the returned SGPRx2
 // |out_failure_mask| needs wave32 zero-extension before it is consumed as an
 // EXEC-width lane mask. This helper only returns the assertion predicate and

--- a/loom/src/loom/target/arch/amdgpu/lower/sanitizer_access_test.cc
+++ b/loom/src/loom/target/arch/amdgpu/lower/sanitizer_access_test.cc
@@ -518,7 +518,48 @@ TEST_F(AmdgpuSanitizerAccessTest, EmitsPacketizedStaticAccessCheck) {
       OpsForDescriptorRef(LOOM_AMDGPU_DESCRIPTOR_REF_V_CNDMASK_B32).size(), 9u);
 }
 
-TEST_F(AmdgpuSanitizerAccessTest, EmitsFailureMaskWithoutReportTuple) {
+TEST_F(AmdgpuSanitizerAccessTest, EmitsExactWidthFullGranuleFailureMasks) {
+  loom_symbol_ref_t asan_config_symbol = AddSymbol(IREE_SV("iree_asan_config"));
+  loom_value_id_t fault_address = LOOM_VALUE_ID_INVALID;
+  IREE_ASSERT_OK(BuildFaultAddress(asan_config_symbol, &fault_address));
+
+  loom_amdgpu_sanitizer_access_config_t config = {};
+  IREE_ASSERT_OK(loom_amdgpu_build_sanitizer_access_config(
+      &builder_, descriptor_set_, asan_config_symbol, LOOM_LOCATION_UNKNOWN,
+      &config));
+  for (uint32_t access_size : {8u, 16u, 24u, 32u, 40u, 64u, 72u}) {
+    loom_value_id_t failure_mask = LOOM_VALUE_ID_INVALID;
+    IREE_ASSERT_OK(loom_amdgpu_build_sanitizer_access_failure_mask_with_config(
+        &builder_, descriptor_set_, &config, fault_address, access_size,
+        /*minimum_alignment=*/8, /*wavefront_size=*/32, LOOM_LOCATION_UNKNOWN,
+        &failure_mask));
+    ExpectRegisterType(failure_mask, LOOM_AMDGPU_REG_CLASS_ID_SGPR, 2);
+  }
+  loom_op_t* return_op = NULL;
+  IREE_ASSERT_OK(loom_low_return_build(&builder_, /*values=*/NULL,
+                                       /*value_count=*/0, LOOM_LOCATION_UNKNOWN,
+                                       &return_op));
+
+  VerifyModuleOk();
+  VerifyLowModuleOk();
+
+  EXPECT_EQ(OpsForDescriptorRef(LOOM_AMDGPU_DESCRIPTOR_REF_FLAT_LOAD_U8).size(),
+            4u);
+  EXPECT_EQ(
+      OpsForDescriptorRef(LOOM_AMDGPU_DESCRIPTOR_REF_FLAT_LOAD_U16).size(), 2u);
+  EXPECT_EQ(
+      OpsForDescriptorRef(LOOM_AMDGPU_DESCRIPTOR_REF_FLAT_LOAD_B32).size(), 2u);
+  EXPECT_EQ(
+      OpsForDescriptorRef(LOOM_AMDGPU_DESCRIPTOR_REF_FLAT_LOAD_B64).size(), 2u);
+  EXPECT_EQ(OpsForDescriptorRef(LOOM_AMDGPU_DESCRIPTOR_REF_S_WAITCNT).size(),
+            10u);
+  EXPECT_EQ(OpsForDescriptorRef(LOOM_AMDGPU_DESCRIPTOR_REF_V_CMP_NE_I32).size(),
+            12u);
+  EXPECT_TRUE(
+      OpsForDescriptorRef(LOOM_AMDGPU_DESCRIPTOR_REF_V_CNDMASK_B32).empty());
+}
+
+TEST_F(AmdgpuSanitizerAccessTest, ChecksUnalignedFinalShadowGranule) {
   loom_symbol_ref_t asan_config_symbol = AddSymbol(IREE_SV("iree_asan_config"));
   loom_value_id_t fault_address = LOOM_VALUE_ID_INVALID;
   IREE_ASSERT_OK(BuildFaultAddress(asan_config_symbol, &fault_address));
@@ -538,9 +579,11 @@ TEST_F(AmdgpuSanitizerAccessTest, EmitsFailureMaskWithoutReportTuple) {
 
   ExpectRegisterType(failure_mask, LOOM_AMDGPU_REG_CLASS_ID_SGPR, 2);
   EXPECT_EQ(OpsForDescriptorRef(LOOM_AMDGPU_DESCRIPTOR_REF_FLAT_LOAD_U8).size(),
-            4u);
+            1u);
+  EXPECT_EQ(
+      OpsForDescriptorRef(LOOM_AMDGPU_DESCRIPTOR_REF_FLAT_LOAD_U16).size(), 1u);
   EXPECT_EQ(OpsForDescriptorRef(LOOM_AMDGPU_DESCRIPTOR_REF_S_WAITCNT).size(),
-            4u);
+            2u);
   EXPECT_TRUE(
       OpsForDescriptorRef(LOOM_AMDGPU_DESCRIPTOR_REF_V_CNDMASK_B32).empty());
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sanitizer.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sanitizer.loom-test
@@ -227,52 +227,46 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @sanitiz
   %41 = concat(%37, %39) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
   %42 = flat_load_u8 %41 {glc = 1, dlc = 1}
   s_waitcnt {vmcnt = 0}
-  %44 = v_and_b32_lit %18, 7
-  %45 = v_add_u32_lit %44, 7
-  %46 = v_cmp_ne_i32 %42, %14
-  %47 = v_cmp_ge_u32 %42, %15
-  %48 = v_cmp_ge_u32 %45, %42
-  %49 = s_and_b64 %46, %48
-  %50 = s_or_b64 %47, %49
-  %51 = v_mov_b32 7
-  %58, %59 = v_add_co_u32 %18, %51
-  %60, %61 = v_add_co_ci_u32 %19, %14, %59
-  %70 = v_lshrrev_b32_lit %58, 3
-  %71 = v_lshlrev_b32_lit %60, 29
-  %72 = v_or_b32 %70, %71
-  %73 = v_lshrrev_b32_lit %60, 3
-  %79, %80 = v_add_co_u32 %22, %72
-  %81, %82 = v_add_co_ci_u32 %24, %73, %80
-  %83 = concat(%79, %81) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
-  %84 = flat_load_u8 %83 {glc = 1, dlc = 1}
+  %43 = v_cmp_ne_i32 %42, %14
+  %44 = v_mov_b32 7
+  %51, %52 = v_add_co_u32 %18, %44
+  %53, %54 = v_add_co_ci_u32 %19, %14, %52
+  %63 = v_lshrrev_b32_lit %51, 3
+  %64 = v_lshlrev_b32_lit %53, 29
+  %65 = v_or_b32 %63, %64
+  %66 = v_lshrrev_b32_lit %53, 3
+  %72, %73 = v_add_co_u32 %22, %65
+  %74, %75 = v_add_co_ci_u32 %24, %66, %73
+  %76 = concat(%72, %74) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
+  %77 = flat_load_u8 %76 {glc = 1, dlc = 1}
   s_waitcnt {vmcnt = 0}
-  %86 = v_and_b32_lit %58, 7
-  %87 = v_cmp_ne_i32 %84, %14
-  %88 = v_cmp_ge_u32 %84, %15
-  %89 = v_cmp_ge_u32 %86, %84
-  %90 = s_and_b64 %87, %89
-  %91 = s_or_b64 %88, %90
-  %92 = s_or_b64 %50, %91
-  %93 = slice %92[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
-  %94 = s_mov_b32 0
-  %95 = concat(%93, %94) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %104 = concat(%94, %94) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %105 = s_cmp_lg_u64 %95, %104
-  low.cond_br %105, ^_bb2, ^_bb1 : reg<amdgpu.scc>
+  %79 = v_and_b32_lit %51, 7
+  %80 = v_cmp_ne_i32 %77, %14
+  %81 = v_cmp_ge_u32 %77, %15
+  %82 = v_cmp_ge_u32 %79, %77
+  %83 = s_and_b64 %80, %82
+  %84 = s_or_b64 %81, %83
+  %85 = s_or_b64 %43, %84
+  %86 = slice %85[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %87 = s_mov_b32 0
+  %88 = concat(%86, %87) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %97 = concat(%87, %87) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %98 = s_cmp_lg_u64 %88, %97
+  low.cond_br %98, ^_bb2, ^_bb1 : reg<amdgpu.scc>
 ^_bb1:
   return
 ^_bb2:
-  %106, %107 = s_and_saveexec_b64 %95
+  %99, %100 = s_and_saveexec_b64 %88
   low.br ^_bb3
 ^_bb3:
   s_trap {trapid = 2}
-  %96 = s_sendmsg_rtn_b32 {message = 128}
-  %97 = s_mov_b32 1023
-  %98 = s_and_b32 %96, %97
-  %99 = s_mov_b32 1024
-  %100 = s_or_b32 %98, %99
-  %101 = s_mov_b32_m0 %100
-  s_sendmsg %101 {message = 1}
+  %89 = s_sendmsg_rtn_b32 {message = 128}
+  %90 = s_mov_b32 1023
+  %91 = s_and_b32 %89, %90
+  %92 = s_mov_b32 1024
+  %93 = s_or_b32 %91, %92
+  %94 = s_mov_b32_m0 %93
+  s_sendmsg %94 {message = 1}
   low.br ^_bb4
 ^_bb4:
   s_sethalt {reason = 5}
@@ -318,92 +312,48 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @sanitiz
   %35, %36 = v_add_co_u32 %20, %28
   %37, %38 = v_add_co_ci_u32 %22, %29, %36
   %39 = concat(%35, %37) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
-  %40 = flat_load_u8 %39 {glc = 1, dlc = 1}
+  %40 = flat_load_u16 %39 {glc = 1, dlc = 1}
   s_waitcnt {vmcnt = 0}
-  %42 = v_and_b32_lit %16, 7
-  %43 = v_add_u32_lit %42, 7
-  %44 = v_cmp_ne_i32 %40, %12
-  %45 = v_cmp_ge_u32 %40, %13
-  %46 = v_cmp_ge_u32 %43, %40
-  %47 = s_and_b64 %44, %46
-  %48 = s_or_b64 %45, %47
-  %49 = v_mov_b32 7
-  %56, %57 = v_add_co_u32 %16, %49
-  %58, %59 = v_add_co_ci_u32 %17, %12, %57
-  %68 = v_lshrrev_b32_lit %56, 3
-  %69 = v_lshlrev_b32_lit %58, 29
-  %70 = v_or_b32 %68, %69
-  %71 = v_lshrrev_b32_lit %58, 3
-  %77, %78 = v_add_co_u32 %20, %70
-  %79, %80 = v_add_co_ci_u32 %22, %71, %78
-  %81 = concat(%77, %79) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
-  %82 = flat_load_u8 %81 {glc = 1, dlc = 1}
+  %41 = v_cmp_ne_i32 %40, %12
+  %42 = v_mov_b32 15
+  %49, %50 = v_add_co_u32 %16, %42
+  %51, %52 = v_add_co_ci_u32 %17, %12, %50
+  %61 = v_lshrrev_b32_lit %49, 3
+  %62 = v_lshlrev_b32_lit %51, 29
+  %63 = v_or_b32 %61, %62
+  %64 = v_lshrrev_b32_lit %51, 3
+  %70, %71 = v_add_co_u32 %20, %63
+  %72, %73 = v_add_co_ci_u32 %22, %64, %71
+  %74 = concat(%70, %72) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
+  %75 = flat_load_u8 %74 {glc = 1, dlc = 1}
   s_waitcnt {vmcnt = 0}
-  %84 = v_and_b32_lit %56, 7
-  %85 = v_cmp_ne_i32 %82, %12
-  %86 = v_cmp_ge_u32 %82, %13
-  %87 = v_cmp_ge_u32 %84, %82
-  %88 = s_and_b64 %85, %87
-  %89 = s_or_b64 %86, %88
-  %90 = s_or_b64 %48, %89
-  %91 = v_mov_b32 8
-  %98, %99 = v_add_co_u32 %16, %91
-  %100, %101 = v_add_co_ci_u32 %17, %12, %99
-  %110 = v_lshrrev_b32_lit %98, 3
-  %111 = v_lshlrev_b32_lit %100, 29
-  %112 = v_or_b32 %110, %111
-  %113 = v_lshrrev_b32_lit %100, 3
-  %119, %120 = v_add_co_u32 %20, %112
-  %121, %122 = v_add_co_ci_u32 %22, %113, %120
-  %123 = concat(%119, %121) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
-  %124 = flat_load_u8 %123 {glc = 1, dlc = 1}
-  s_waitcnt {vmcnt = 0}
-  %126 = v_and_b32_lit %98, 7
-  %127 = v_add_u32_lit %126, 7
-  %128 = v_cmp_ne_i32 %124, %12
-  %129 = v_cmp_ge_u32 %124, %13
-  %130 = v_cmp_ge_u32 %127, %124
-  %131 = s_and_b64 %128, %130
-  %132 = s_or_b64 %129, %131
-  %140, %141 = v_add_co_u32 %98, %49
-  %142, %143 = v_add_co_ci_u32 %100, %12, %141
-  %152 = v_lshrrev_b32_lit %140, 3
-  %153 = v_lshlrev_b32_lit %142, 29
-  %154 = v_or_b32 %152, %153
-  %155 = v_lshrrev_b32_lit %142, 3
-  %161, %162 = v_add_co_u32 %20, %154
-  %163, %164 = v_add_co_ci_u32 %22, %155, %162
-  %165 = concat(%161, %163) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
-  %166 = flat_load_u8 %165 {glc = 1, dlc = 1}
-  s_waitcnt {vmcnt = 0}
-  %168 = v_and_b32_lit %140, 7
-  %169 = v_cmp_ne_i32 %166, %12
-  %170 = v_cmp_ge_u32 %166, %13
-  %171 = v_cmp_ge_u32 %168, %166
-  %172 = s_and_b64 %169, %171
-  %173 = s_or_b64 %170, %172
-  %174 = s_or_b64 %132, %173
-  %175 = s_or_b64 %90, %174
-  %176 = slice %175[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
-  %177 = s_mov_b32 0
-  %178 = concat(%176, %177) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %187 = concat(%177, %177) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %188 = s_cmp_lg_u64 %178, %187
-  low.cond_br %188, ^_bb2, ^_bb1 : reg<amdgpu.scc>
+  %77 = v_and_b32_lit %49, 7
+  %78 = v_cmp_ne_i32 %75, %12
+  %79 = v_cmp_ge_u32 %75, %13
+  %80 = v_cmp_ge_u32 %77, %75
+  %81 = s_and_b64 %78, %80
+  %82 = s_or_b64 %79, %81
+  %83 = s_or_b64 %41, %82
+  %84 = slice %83[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %85 = s_mov_b32 0
+  %86 = concat(%84, %85) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %95 = concat(%85, %85) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %96 = s_cmp_lg_u64 %86, %95
+  low.cond_br %96, ^_bb2, ^_bb1 : reg<amdgpu.scc>
 ^_bb1:
   return
 ^_bb2:
-  %189, %190 = s_and_saveexec_b64 %178
+  %97, %98 = s_and_saveexec_b64 %86
   low.br ^_bb3
 ^_bb3:
   s_trap {trapid = 2}
-  %179 = s_sendmsg_rtn_b32 {message = 128}
-  %180 = s_mov_b32 1023
-  %181 = s_and_b32 %179, %180
-  %182 = s_mov_b32 1024
-  %183 = s_or_b32 %181, %182
-  %184 = s_mov_b32_m0 %183
-  s_sendmsg %184 {message = 1}
+  %87 = s_sendmsg_rtn_b32 {message = 128}
+  %88 = s_mov_b32 1023
+  %89 = s_and_b32 %87, %88
+  %90 = s_mov_b32 1024
+  %91 = s_or_b32 %89, %90
+  %92 = s_mov_b32_m0 %91
+  s_sendmsg %92 {message = 1}
   low.br ^_bb4
 ^_bb4:
   s_sethalt {reason = 5}

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sanitizer_accesses.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sanitizer_accesses.loom-test
@@ -137,6 +137,92 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @sanitiz
 
 amdgpu.target<gfx11-generic> @target
 
+func.def target(@target) @sanitizer_repeated_aligned_rows_read(%input: buffer) {
+  %base = index.constant 0 : offset
+  %input_global = buffer.assume.memory_space<global> %input : buffer
+  %input_aligned = buffer.assume.alignment %input_global {minimum_alignment = 32} : buffer
+  %input_view = buffer.view %input_aligned[%base] : buffer -> view<64xi8, #dense>
+  sanitizer.assert.accesses<read> %input_view[0] {static_count = 2, static_extents = [32], static_strides = [32]} : view<64xi8, #dense>
+  func.return
+}
+
+// ----
+low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @sanitizer_repeated_aligned_rows_read() asm {
+  %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 64} : reg<amdgpu.sgpr x2>
+  %6 = s_getpc_b64
+  %7 = slice %6[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %8 = slice %6[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %9 = s_add_u32_rhs_symbol_rel32_lo %7 {symbol = @iree_asan_config}
+  %10 = s_addc_u32_rhs_symbol_rel32_hi %8 {symbol = @iree_asan_config}
+  %11 = concat(%9, %10) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %12 = s_load_dwordx2_offset_only %11 {offset = 16}
+  %13 = v_mov_b32 0
+  %15 = slice %input_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %16 = slice %input_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %17 = v_mov_b32_copy %15
+  %18 = v_mov_b32_copy %16
+  %20 = slice %12[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %21 = v_mov_b32_copy %20
+  %22 = slice %12[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %23 = v_mov_b32_copy %22
+  %27 = v_lshrrev_b32_lit %17, 3
+  %28 = v_lshlrev_b32_lit %18, 29
+  %29 = v_or_b32 %27, %28
+  %30 = v_lshrrev_b32_lit %18, 3
+  %36, %37 = v_add_co_u32 %21, %29
+  %38, %39 = v_add_co_ci_u32 %23, %30, %37
+  %40 = concat(%36, %38) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
+  %41 = flat_load_dword %40 {glc = 1, dlc = 1}
+  s_waitcnt {vmcnt = 0}
+  %42 = v_cmp_ne_i32 %41, %13
+  %43 = slice %42[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %44 = s_mov_b32 0
+  %45 = concat(%43, %44) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %46 = s_mov_b32 32
+  %53 = s_add_u32 %15, %46
+  %54 = s_addc_u32 %16, %44
+  %58 = v_mov_b32_copy %53
+  %59 = v_mov_b32_copy %54
+  %68 = v_lshrrev_b32_lit %58, 3
+  %69 = v_lshlrev_b32_lit %59, 29
+  %70 = v_or_b32 %68, %69
+  %71 = v_lshrrev_b32_lit %59, 3
+  %77, %78 = v_add_co_u32 %21, %70
+  %79, %80 = v_add_co_ci_u32 %23, %71, %78
+  %81 = concat(%77, %79) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
+  %82 = flat_load_dword %81 {glc = 1, dlc = 1}
+  s_waitcnt {vmcnt = 0}
+  %83 = v_cmp_ne_i32 %82, %13
+  %84 = slice %83[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %86 = concat(%84, %44) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %87 = s_or_b64 %45, %86
+  %96 = concat(%44, %44) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %97 = s_cmp_lg_u64 %87, %96
+  low.cond_br %97, ^_bb2, ^_bb1 : reg<amdgpu.scc>
+^_bb1:
+  return
+^_bb2:
+  %98, %99 = s_and_saveexec_b64 %87
+  low.br ^_bb3
+^_bb3:
+  s_trap {trapid = 2}
+  %88 = s_sendmsg_rtn_b32 {message = 128}
+  %89 = s_mov_b32 1023
+  %90 = s_and_b32 %88, %89
+  %91 = s_mov_b32 1024
+  %92 = s_or_b32 %90, %91
+  %93 = s_mov_b32_m0 %92
+  s_sendmsg %93 {message = 1}
+  low.br ^_bb4
+^_bb4:
+  s_sethalt {reason = 5}
+  low.br ^_bb4
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
+
 func.def target(@target) @sanitizer_aligned_granule_access_read(%input: buffer) {
   %base = index.constant 0 : offset
   %input_global = buffer.assume.memory_space<global> %input : buffer
@@ -199,6 +285,134 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @sanitiz
   %54 = s_or_b32 %52, %53
   %55 = s_mov_b32_m0 %54
   s_sendmsg %55 {message = 1}
+  low.br ^_bb4
+^_bb4:
+  s_sethalt {reason = 5}
+  low.br ^_bb4
+}
+
+// ====
+
+amdgpu.target<gfx942> @target
+
+func.def target(@target) @sanitizer_cdna3_aligned_vector_read(%input: buffer) {
+  %base = index.constant 0 : offset
+  %input_global = buffer.assume.memory_space<global> %input : buffer
+  %input_aligned = buffer.assume.alignment %input_global {minimum_alignment = 32} : buffer
+  %input_view = buffer.view %input_aligned[%base] : buffer -> view<32xi8, #dense>
+  sanitizer.assert.access<read> %input_view[0] {static_extents = [32]} : view<32xi8, #dense>
+  func.return
+}
+
+// ----
+low.func.def target<amdgpu.cdna3.core>(@target) abi(hal_kernel) @sanitizer_cdna3_aligned_vector_read() asm {
+  %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 32} : reg<amdgpu.sgpr x2>
+  %6 = s_getpc_b64
+  %7 = slice %6[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %8 = slice %6[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %9 = s_add_u32_rhs_symbol_rel32_lo %7 {symbol = @iree_asan_config}
+  %10 = s_addc_u32_rhs_symbol_rel32_hi %8 {symbol = @iree_asan_config}
+  %11 = concat(%9, %10) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %12 = s_load_dwordx2_offset_only %11 {offset = 16}
+  %13 = v_mov_b32 0
+  %15 = slice %input_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %16 = slice %input_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %17 = v_mov_b32_copy %15
+  %18 = v_mov_b32_copy %16
+  %20 = slice %12[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %21 = v_mov_b32_copy %20
+  %22 = slice %12[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %23 = v_mov_b32_copy %22
+  %27 = v_lshrrev_b32_lit %17, 3
+  %28 = v_lshlrev_b32_lit %18, 29
+  %29 = v_or_b32 %27, %28
+  %30 = v_lshrrev_b32_lit %18, 3
+  %36, %37 = v_add_co_u32 %21, %29
+  %38, %39 = v_addc_co_u32 %23, %30, %37
+  %40 = concat(%36, %38) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
+  %41 = s_mov_b32_m0_imm 0
+  %42 = flat_load_dword %40, %41 {sc0 = 1, sc1 = 1} : reg<amdgpu.vgpr>
+  s_waitcnt {vmcnt = 0}
+  %43 = v_cmp_ne_i32 %42, %13
+  %44 = s_mov_b32 0
+  %46 = concat(%44, %44) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %47 = s_cmp_lg_u64 %43, %46
+  low.cond_br %47, ^_bb2, ^_bb1 : reg<amdgpu.scc>
+^_bb1:
+  return
+^_bb2:
+  %48, %49 = s_and_saveexec_b64 %43
+  low.br ^_bb3
+^_bb3:
+  s_trap {trapid = 2}
+  low.br ^_bb4
+^_bb4:
+  s_sethalt {reason = 5}
+  low.br ^_bb4
+}
+
+// ====
+
+amdgpu.target<gfx1200> @target
+
+func.def target(@target) @sanitizer_rdna4_aligned_vector_read(%input: buffer) {
+  %base = index.constant 0 : offset
+  %input_global = buffer.assume.memory_space<global> %input : buffer
+  %input_aligned = buffer.assume.alignment %input_global {minimum_alignment = 32} : buffer
+  %input_view = buffer.view %input_aligned[%base] : buffer -> view<32xi8, #dense>
+  sanitizer.assert.access<read> %input_view[0] {static_extents = [32]} : view<32xi8, #dense>
+  func.return
+}
+
+// ----
+low.func.def target<amdgpu.rdna4.core>(@target) abi(hal_kernel) @sanitizer_rdna4_aligned_vector_read() asm {
+  %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 32} : reg<amdgpu.sgpr x2>
+  %6 = s_getpc_b64
+  %7 = slice %6[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %8 = slice %6[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %9 = s_add_u32_rhs_symbol_rel32_lo %7 {symbol = @iree_asan_config}
+  %10 = s_addc_u32_rhs_symbol_rel32_hi %8 {symbol = @iree_asan_config}
+  %11 = concat(%9, %10) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %12 = s_load_dwordx2_offset_only %11 {offset = 16}
+  %13 = v_mov_b32 0
+  %15 = slice %input_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %16 = slice %input_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %17 = v_mov_b32_copy %15
+  %18 = v_mov_b32_copy %16
+  %20 = slice %12[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %21 = v_mov_b32_copy %20
+  %22 = slice %12[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %23 = v_mov_b32_copy %22
+  %27 = v_lshrrev_b32_lit %17, 3
+  %28 = v_lshlrev_b32_lit %18, 29
+  %29 = v_or_b32 %27, %28
+  %30 = v_lshrrev_b32_lit %18, 3
+  %36, %37 = v_add_co_u32 %21, %29
+  %38, %39 = v_add_co_ci_u32 %23, %30, %37
+  %40 = concat(%36, %38) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x2>
+  %41 = flat_load_dword %40 {scope = 3}
+  s_wait_loadcnt {loadcnt = 0}
+  %42 = v_cmp_ne_i32 %41, %13
+  %43 = slice %42[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %44 = s_mov_b32 0
+  %45 = concat(%43, %44) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %54 = concat(%44, %44) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %55 = s_cmp_lg_u64 %45, %54
+  low.cond_br %55, ^_bb2, ^_bb1 : reg<amdgpu.scc>
+^_bb1:
+  return
+^_bb2:
+  %56, %57 = s_and_saveexec_b64 %45
+  low.br ^_bb3
+^_bb3:
+  s_trap {trapid = 2}
+  %46 = s_sendmsg_rtn_b32 {message = 128}
+  %47 = s_mov_b32 1023
+  %48 = s_and_b32 %46, %47
+  %49 = s_mov_b32 1024
+  %50 = s_or_b32 %48, %49
+  %51 = s_mov_b32_m0 %50
+  s_sendmsg %51 {message = 1}
   low.br ^_bb4
 ^_bb4:
   s_sethalt {reason = 5}


### PR DESCRIPTION
AMDGPU now exposes complete typed flat-memory load and store families across the supported CDNA and RDNA descriptor sets, and the access sanitizer uses those generic target capabilities to compact checks over aligned application ranges.

## Target Descriptor Families

The previous flat-memory descriptor surface contained only the two widths first needed by access-sanitizer lowering. That made a generic machine capability look owned by one compiler consumer and left adjacent native instructions unavailable to every other lowering.

This change replaces those isolated declarations with table-driven families:

- signed and unsigned extending 8- and 16-bit loads;
- raw 32-, 64-, 96-, and 128-bit loads; and
- raw 8-, 16-, 32-, 64-, 96-, and 128-bit stores.

Each CDNA3, CDNA4, RDNA3, RDNA3.5, RDNA4, and RDNA4.5 descriptor set supplies its native instruction spelling and retains its encoding, cache controls, implicit resources, and legal register classes. Generic target intersections inherit the common family rather than introducing consumer-specific capability lists.

Target-reference generation now validates the canonical operand shape of every generic flat load and store. Descriptor completeness and assembly-form consistency therefore fail during generation instead of appearing as lowering-specific runtime checks.

## Exact-Width Shadow Checks

One ASAN shadow byte describes eight application bytes. A fully covered application range can therefore test its shadow with the narrowest exact load instead of packetizing the range into independent byte checks.

The sanitizer now greedily covers whole-granule shadow ranges with 64-, 32-, 16-, and 8-bit loads. Loads up to 32 bits use one nonzero comparison; a 64-bit load compares its two register lanes and combines their masks. When the application address may be unaligned, the existing precise final-granule predicate remains in place so untouched padding cannot produce a false report. Partial accesses and structured report construction retain their existing paths.

This changes a repeated aligned 32-byte application access from four shadow addresses, byte loads, waits, and predicates into one 32-bit shadow load and predicate. In a production-shaped stress witness, the sanitizer emits 256 shadow loads instead of 1,024, native code generation succeeds instead of exceeding the signed SOPP branch range, and the resulting kernel is 31,768 bytes. Unsanitized kernels are unchanged.

## Reviewer Notes

The first commit is intentionally broader than the immediate sanitizer use: it establishes the target-owned instruction families that future lowerings and spill paths can consume. The second commit contains the sanitizer policy and exact poisoning semantics. The main review boundaries are the per-generation mnemonic and operand tables, the generated canonical-form validation, and the unaligned endpoint handling in the full-granule failure-mask builder.
