### PR TITLE
[Loom] Iterate simple recursive chains

### DIFF
--- a/loom/src/loom/error/error_defs.c
+++ b/loom/src/loom/error/error_defs.c
@@ -59,18 +59,23 @@ const char* loom_emitter_name(loom_emitter_t emitter) {
 const loom_error_def_t* loom_error_catalog_lookup(
     const loom_error_catalog_t* catalog, loom_error_domain_t domain,
     uint16_t code) {
-  if (catalog == NULL || domain >= LOOM_ERROR_DOMAIN_COUNT_) {
+  if (domain >= LOOM_ERROR_DOMAIN_COUNT_) {
     return NULL;
   }
-  const loom_error_domain_catalog_t* domain_catalog = catalog->domains[domain];
-  if (domain_catalog == NULL || code >= domain_catalog->code_count) {
-    return loom_error_catalog_lookup(catalog->fallback_catalog, domain, code);
+  for (const loom_error_catalog_t* current_catalog = catalog;
+       current_catalog != NULL;
+       current_catalog = current_catalog->fallback_catalog) {
+    const loom_error_domain_catalog_t* domain_catalog =
+        current_catalog->domains[domain];
+    if (domain_catalog == NULL || code >= domain_catalog->code_count) {
+      continue;
+    }
+    const loom_error_def_t* error = domain_catalog->errors_by_code[code];
+    if (error != NULL) {
+      return error;
+    }
   }
-  const loom_error_def_t* error = domain_catalog->errors_by_code[code];
-  if (error != NULL) {
-    return error;
-  }
-  return loom_error_catalog_lookup(catalog->fallback_catalog, domain, code);
+  return NULL;
 }
 
 const loom_error_def_t* loom_error_catalog_lookup_ref(

--- a/loom/src/loom/error/error_defs_test.cc
+++ b/loom/src/loom/error/error_defs_test.cc
@@ -6,6 +6,8 @@
 
 #include "loom/error/error_defs.h"
 
+#include <vector>
+
 #include "iree/testing/gtest.h"
 
 namespace {
@@ -78,6 +80,63 @@ TEST(ErrorDefsTest, LookupBackendAllocationError) {
 TEST(ErrorDefsTest, LookupNonExistentReturnsNull) {
   EXPECT_EQ(loom_error_def_lookup(LOOM_ERROR_DOMAIN_TYPE, 999), nullptr);
   EXPECT_EQ(loom_error_def_lookup(LOOM_ERROR_DOMAIN_FOLD, 0), nullptr);
+}
+
+TEST(ErrorDefsTest, LookupComposedCatalogFallsBackAndShadows) {
+  const loom_error_def_t* expected =
+      loom_error_def_lookup(LOOM_ERROR_DOMAIN_TYPE, 1);
+  ASSERT_NE(expected, nullptr);
+
+  const loom_error_def_t* terminal_errors[] = {nullptr, expected};
+  loom_error_domain_catalog_t terminal_domain = {};
+  terminal_domain.domain = LOOM_ERROR_DOMAIN_TYPE;
+  terminal_domain.code_count = IREE_ARRAYSIZE(terminal_errors);
+  terminal_domain.errors_by_code = terminal_errors;
+  loom_error_catalog_t terminal_catalog = {};
+  terminal_catalog.domains[LOOM_ERROR_DOMAIN_TYPE] = &terminal_domain;
+
+  const loom_error_def_t* missing_errors[] = {nullptr, nullptr};
+  loom_error_domain_catalog_t missing_domain = {};
+  missing_domain.domain = LOOM_ERROR_DOMAIN_TYPE;
+  missing_domain.code_count = IREE_ARRAYSIZE(missing_errors);
+  missing_domain.errors_by_code = missing_errors;
+  loom_error_catalog_t catalog = {};
+  catalog.domains[LOOM_ERROR_DOMAIN_TYPE] = &missing_domain;
+  catalog.fallback_catalog = &terminal_catalog;
+
+  EXPECT_EQ(loom_error_catalog_lookup(&catalog, LOOM_ERROR_DOMAIN_TYPE, 1),
+            expected);
+
+  loom_error_def_t shadow = *expected;
+  const loom_error_def_t* shadow_errors[] = {nullptr, &shadow};
+  loom_error_domain_catalog_t shadow_domain = missing_domain;
+  shadow_domain.errors_by_code = shadow_errors;
+  catalog.domains[LOOM_ERROR_DOMAIN_TYPE] = &shadow_domain;
+  EXPECT_EQ(loom_error_catalog_lookup(&catalog, LOOM_ERROR_DOMAIN_TYPE, 1),
+            &shadow);
+}
+
+TEST(ErrorDefsTest, LookupDeepFallbackChain) {
+  const loom_error_def_t* expected =
+      loom_error_def_lookup(LOOM_ERROR_DOMAIN_TYPE, 1);
+  ASSERT_NE(expected, nullptr);
+
+  const loom_error_def_t* terminal_errors[] = {nullptr, expected};
+  loom_error_domain_catalog_t terminal_domain = {};
+  terminal_domain.domain = LOOM_ERROR_DOMAIN_TYPE;
+  terminal_domain.code_count = IREE_ARRAYSIZE(terminal_errors);
+  terminal_domain.errors_by_code = terminal_errors;
+
+  constexpr size_t kCatalogCount = 16384;
+  std::vector<loom_error_catalog_t> catalogs(kCatalogCount);
+  for (size_t i = 0; i + 1 < catalogs.size(); ++i) {
+    catalogs[i].fallback_catalog = &catalogs[i + 1];
+  }
+  catalogs.back().domains[LOOM_ERROR_DOMAIN_TYPE] = &terminal_domain;
+
+  EXPECT_EQ(
+      loom_error_catalog_lookup(&catalogs.front(), LOOM_ERROR_DOMAIN_TYPE, 1),
+      expected);
 }
 
 TEST(ErrorDefsTest, GlobalLookupExcludesOptionalTargetCatalogs) {

--- a/loom/src/loom/ops/low/test/verify.loom-test
+++ b/loom/src/loom/ops/low/test/verify.loom-test
@@ -86,6 +86,32 @@ low.func.def target<test.low.core>(@test_target) @storage_view_passes(%value: re
 
 test.target<low_core> @test_target
 
+low.func.def target<test.low.core>(@test_target) @storage_view_chain_passes(%value: reg<test.i32>) -> (reg<test.i32>) {
+  %storage = low.storage.reserve {byte_alignment = 16, byte_length = 128} : low.storage<scratch>
+  %outer = low.storage.view %storage {offset = 16, byte_length = 96} : low.storage<scratch> -> low.storage<scratch>
+  %middle = low.storage.view %outer {offset = 24, byte_length = 48} : low.storage<scratch> -> low.storage<scratch>
+  %inner = low.storage.view %middle {offset = 8, byte_length = 16} : low.storage<scratch> -> low.storage<scratch>
+  low.spill %value, %inner {offset = 15} : reg<test.i32>, low.storage<scratch>
+  %reload = low.reload %inner {offset = 15} : low.storage<scratch> -> reg<test.i32>
+  low.return %reload : reg<test.i32>
+}
+
+// ====
+
+test.target<low_core> @test_target
+
+low.func.def target<test.low.core>(@test_target) @storage_view_chain_rejects_nested_overflow() {
+  %storage = low.storage.reserve {byte_alignment = 16, byte_length = 128} : low.storage<scratch>
+  %outer = low.storage.view %storage {offset = 16, byte_length = 64} : low.storage<scratch> -> low.storage<scratch>
+  // ERROR@+1: SUBRANGE/004 {dim_index="0", offset="48", size="32", total="80", bound="64"}
+  %inner = low.storage.view %outer {offset = 48, byte_length = 32} : low.storage<scratch> -> low.storage<scratch>
+  low.return
+}
+
+// ====
+
+test.target<low_core> @test_target
+
 low.func.def target<test.low.core>(@test_target) @storage_view_rejects_overflowing_length() {
   %storage = low.storage.reserve {byte_alignment = 16, byte_length = 64} : low.storage<scratch>
   // ERROR@+1: SUBRANGE/004 {dim_index="0", offset="48", size="32", total="80", bound="64"}

--- a/loom/src/loom/ops/low/verify.c
+++ b/loom/src/loom/ops/low/verify.c
@@ -906,51 +906,54 @@ typedef struct loom_low_static_storage_reference_t {
   // Reserving op that owns the backing storage identity.
   const loom_op_t* reserve_op;
 
-  // Static byte offset from reserve_op to this storage handle.
-  int64_t byte_offset;
-
-  // Static byte length valid from byte_offset.
+  // Static byte length available through this storage handle.
   int64_t byte_length;
 } loom_low_static_storage_reference_t;
 
 static bool loom_low_try_resolve_storage_reference(
     const loom_module_t* module, loom_value_id_t storage_id,
     loom_low_static_storage_reference_t* out_reference) {
-  const loom_value_t* storage_value = loom_module_value(module, storage_id);
-  if (!storage_value || loom_value_is_block_arg(storage_value)) return false;
-  const loom_op_t* defining_op = loom_value_def_op(storage_value);
-  if (!defining_op) return false;
-  if (loom_low_storage_reserve_isa(defining_op)) {
-    int64_t byte_length = loom_low_storage_reserve_byte_length(defining_op);
-    if (byte_length <= 0) return false;
-    *out_reference = (loom_low_static_storage_reference_t){
-        .reserve_op = defining_op,
-        .byte_offset = 0,
-        .byte_length = byte_length,
-    };
-    return true;
-  }
-  if (!loom_low_storage_view_isa(defining_op)) return false;
+  int64_t resolved_byte_length = 0;
+  int64_t projection_offset = 0;
+  int64_t projection_byte_length = 0;
+  while (true) {
+    const loom_value_t* storage_value = loom_module_value(module, storage_id);
+    if (!storage_value || loom_value_is_block_arg(storage_value)) return false;
+    const loom_op_t* defining_op = loom_value_def_op(storage_value);
+    if (!defining_op) return false;
 
-  loom_low_static_storage_reference_t source_reference = {0};
-  if (!loom_low_try_resolve_storage_reference(
-          module, loom_low_storage_view_source(defining_op),
-          &source_reference)) {
-    return false;
+    const bool is_reserve = loom_low_storage_reserve_isa(defining_op);
+    int64_t available_byte_length = 0;
+    if (is_reserve) {
+      available_byte_length = loom_low_storage_reserve_byte_length(defining_op);
+    } else if (loom_low_storage_view_isa(defining_op)) {
+      available_byte_length = loom_low_storage_view_byte_length(defining_op);
+    } else {
+      return false;
+    }
+    if (available_byte_length <= 0) return false;
+
+    if (resolved_byte_length == 0) {
+      resolved_byte_length = available_byte_length;
+    } else if (projection_offset < 0 ||
+               projection_offset >= available_byte_length ||
+               projection_byte_length >
+                   available_byte_length - projection_offset) {
+      return false;
+    }
+
+    if (is_reserve) {
+      *out_reference = (loom_low_static_storage_reference_t){
+          .reserve_op = defining_op,
+          .byte_length = resolved_byte_length,
+      };
+      return true;
+    }
+
+    projection_offset = loom_low_storage_view_offset(defining_op);
+    projection_byte_length = available_byte_length;
+    storage_id = loom_low_storage_view_source(defining_op);
   }
-  int64_t offset = loom_low_storage_view_offset(defining_op);
-  int64_t byte_length = loom_low_storage_view_byte_length(defining_op);
-  if (offset < 0 || byte_length <= 0 ||
-      offset >= source_reference.byte_length ||
-      byte_length > source_reference.byte_length - offset) {
-    return false;
-  }
-  *out_reference = (loom_low_static_storage_reference_t){
-      .reserve_op = source_reference.reserve_op,
-      .byte_offset = source_reference.byte_offset + offset,
-      .byte_length = byte_length,
-  };
-  return true;
 }
 
 static iree_status_t loom_low_verify_storage_use(


### PR DESCRIPTION
Removes native-stack growth from two simple producer/list walks surfaced by the whole-target recursion analyzer.

Error catalog lookup now follows fallback catalogs iteratively while preserving first-match shadowing and missing-entry fallthrough. Its production-path coverage includes a 16,384-catalog chain, so the test would have exercised unsafe recursive depth before this change.

Low storage verification now follows `low.storage.view` producer chains toward their owning `low.storage.reserve` with constant state. Each view is still bounded against its immediate source, the queried handle retains its usable byte length, and the unused root-relative byte offset accumulation is gone. Nested-view fixtures cover both valid traversal and an intermediate overflow.

Neither change adds a depth cap, cycle recovery, suppression, or recursion-check enablement. The catalogs are immutable trusted structures and verified SSA producer chains are acyclic; iteration removes native-stack exposure without weakening those contracts.

## Reviewer Notes

The commits are intentionally independent. The catalog change is a pointer-list walk; the low verifier change is the more semantic review surface because it preserves recursive-unwind validation while walking in the opposite direction.