### PR TITLE
[Runtime] Match wildcard patterns iteratively

### DIFF
--- a/runtime/src/iree/base/string_view.c
+++ b/runtime/src/iree/base/string_view.c
@@ -260,105 +260,40 @@ IREE_API_EXPORT void iree_string_view_replace_char(iree_string_view_t value,
   }
 }
 
-static bool iree_string_view_match_pattern_impl(iree_string_view_t value,
-                                                iree_string_view_t pattern) {
-  iree_host_size_t next_char_index = iree_string_view_find_first_of(
-      pattern, iree_make_cstring_view("*?"), /*pos=*/0);
-  if (next_char_index == IREE_STRING_VIEW_NPOS) {
-    return iree_string_view_equal(value, pattern);
-  } else if (next_char_index > 0) {
-    iree_string_view_t value_prefix =
-        iree_string_view_substr(value, 0, next_char_index);
-    iree_string_view_t pattern_prefix =
-        iree_string_view_substr(pattern, 0, next_char_index);
-    if (!iree_string_view_equal(value_prefix, pattern_prefix)) {
-      return false;
-    }
-    value =
-        iree_string_view_substr(value, next_char_index, IREE_STRING_VIEW_NPOS);
-    pattern = iree_string_view_substr(pattern, next_char_index,
-                                      IREE_STRING_VIEW_NPOS);
-  }
-  if (iree_string_view_is_empty(value) && iree_string_view_is_empty(pattern)) {
-    return true;
-  }
-  char pattern_char = pattern.data[0];
-
-  // Normalize wildcard sequences to avoid exponential backtracking.
-  // A sequence like *?*?* is equivalent to "match 2+ chars then match rest".
-  // We coalesce all * and ? into a single * with a minimum char requirement.
-  if (pattern_char == '*' || pattern_char == '?') {
-    iree_host_size_t min_chars = 0;
-    iree_host_size_t skip = 0;
-    bool has_star = false;
-    while (skip < pattern.size) {
-      char c = pattern.data[skip];
-      if (c == '*') {
-        has_star = true;
-        ++skip;
-      } else if (c == '?') {
-        ++min_chars;
-        ++skip;
-      } else {
-        break;
-      }
-    }
-
-    // Remaining pattern after wildcards.
-    iree_string_view_t rest =
-        iree_string_view_substr(pattern, skip, IREE_STRING_VIEW_NPOS);
-
-    if (!has_star) {
-      // Only ? wildcards - must match exactly min_chars characters.
-      if (value.size < min_chars) return false;
-      return iree_string_view_match_pattern_impl(
-          iree_string_view_substr(value, min_chars, IREE_STRING_VIEW_NPOS),
-          rest);
-    }
-
-    // Has * - must match at least min_chars, possibly more.
-    if (value.size < min_chars) return false;
-
-    // Empty rest means * matches everything remaining.
-    if (iree_string_view_is_empty(rest)) return true;
-
-    // Try matching rest at each position from min_chars to end.
-    for (iree_host_size_t i = min_chars; i <= value.size; ++i) {
-      if (iree_string_view_match_pattern_impl(
-              iree_string_view_substr(value, i, IREE_STRING_VIEW_NPOS), rest)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  // Literal character - must match exactly.
-  if (iree_string_view_is_empty(value) || value.data[0] != pattern_char) {
-    return false;
-  }
-  return iree_string_view_match_pattern_impl(
-      iree_string_view_substr(value, 1, IREE_STRING_VIEW_NPOS),
-      iree_string_view_substr(pattern, 1, IREE_STRING_VIEW_NPOS));
-}
-
-// Maximum wildcards allowed in a pattern to prevent pathological matching.
-// 16 is enough for any reasonable glob (e.g., "*foo*bar*baz*") while avoiding
-// O(n^2) blowup on patterns like "?*?*?*?*?*?*?*?*?*?*?*?*?*?*?*?*".
-#define IREE_STRING_VIEW_MAX_PATTERN_WILDCARDS 16
-
 IREE_API_EXPORT bool iree_string_view_match_pattern(
     iree_string_view_t value, iree_string_view_t pattern) {
-  // Count wildcards and reject patterns with too many.
-  iree_host_size_t wildcard_count = 0;
-  for (iree_host_size_t i = 0; i < pattern.size; ++i) {
-    if (pattern.data[i] == '*' || pattern.data[i] == '?') {
-      ++wildcard_count;
+  iree_host_size_t value_position = 0;
+  iree_host_size_t pattern_position = 0;
+  iree_host_size_t star_pattern_position = IREE_STRING_VIEW_NPOS;
+  iree_host_size_t star_value_position = 0;
+  while (value_position < value.size) {
+    if (pattern_position < pattern.size &&
+        pattern.data[pattern_position] == '*') {
+      // A later star subsumes backtracking to any earlier star. Remember where
+      // this star begins matching so a later mismatch can extend it by one
+      // byte and retry the remaining pattern.
+      star_pattern_position = pattern_position++;
+      star_value_position = value_position;
+      continue;
     }
+    if (pattern_position < pattern.size &&
+        (pattern.data[pattern_position] == '?' ||
+         pattern.data[pattern_position] == value.data[value_position])) {
+      ++pattern_position;
+      ++value_position;
+      continue;
+    }
+    if (star_pattern_position == IREE_STRING_VIEW_NPOS) return false;
+    pattern_position = star_pattern_position + 1;
+    value_position = ++star_value_position;
   }
-  if (wildcard_count > IREE_STRING_VIEW_MAX_PATTERN_WILDCARDS) {
-    return false;
+
+  // Only stars can match the empty suffix after consuming the value.
+  while (pattern_position < pattern.size &&
+         pattern.data[pattern_position] == '*') {
+    ++pattern_position;
   }
-  return iree_string_view_match_pattern_impl(value, pattern);
+  return pattern_position == pattern.size;
 }
 
 IREE_API_EXPORT void iree_string_view_to_cstring(

--- a/runtime/src/iree/base/string_view_test.cc
+++ b/runtime/src/iree/base/string_view_test.cc
@@ -818,20 +818,18 @@ TEST(StringViewTest, MatchPattern) {
   EXPECT_TRUE(match("abc", "?*?"));
   EXPECT_TRUE(match("abcdef", "a?c*f"));
 
-  // Consecutive wildcards (tests coalescing to avoid exponential backtracking).
+  // Consecutive stars share the same match semantics as one star.
   EXPECT_TRUE(match("abc", "**"));
   EXPECT_TRUE(match("abc", "***"));
   EXPECT_TRUE(match("abc", "a**c"));
   EXPECT_TRUE(match("abc", "**c"));
   EXPECT_TRUE(match("abc", "a**"));
+  EXPECT_TRUE(match("*ba", "*a"));
 
-  // Pathological pattern that would cause exponential backtracking without
-  // coalescing: many wildcards followed by a non-matching suffix.
-  // This must complete in reasonable time (milliseconds, not seconds).
+  // Repeated stars do not multiply suffix retries.
   EXPECT_FALSE(match("aaaaaaaaaaaaaaaaaaaab", "**************c"));
   EXPECT_TRUE(match("aaaaaaaaaaaaaaaaaaaab", "**************b"));
 
-  // Alternating ?* patterns - also pathological without normalization.
   // ?* means "1 or more chars", ?*?* means "2 or more chars", etc.
   EXPECT_TRUE(match("ab", "?*"));
   EXPECT_TRUE(match("abc", "?*?"));
@@ -839,19 +837,23 @@ TEST(StringViewTest, MatchPattern) {
   EXPECT_TRUE(match("abcd", "?*?*"));
   EXPECT_FALSE(match("a", "?*?*"));  // Need at least 2 chars.
 
-  // Pathological alternating patterns - must complete quickly.
+  // Alternating patterns retry both matching and non-matching suffixes.
   EXPECT_FALSE(match("aaaaaaaaaaaaaaaaaaaab", "?*?*?*?*?*?*?*c"));
   EXPECT_TRUE(match("aaaaaaaaaaaaaaaaaaaab", "?*?*?*?*?*?*?*b"));
   EXPECT_FALSE(match("aaaaaaaaaaaaaaaaaaaab", "*?*?*?*?*?*?*?c"));
   EXPECT_TRUE(match("aaaaaaaaaaaaaaaaaaaab", "*?*?*?*?*?*?*?b"));
 
-  // Patterns with too many wildcards are rejected (returns false).
-  // Limit is 16 wildcards to prevent O(n^2) blowup.
+  // Separated stars retry the remaining suffix without recursive
+  // combinatorial backtracking.
+  EXPECT_TRUE(match("aaaaaaaaaaaaaaaaab", "*a*a*a*a*a*a*a*a*b"));
+  EXPECT_FALSE(match("aaaaaaaaaaaaaaaaac", "*a*a*a*a*a*a*a*a*b"));
+
+  // Wildcard count does not change matching semantics.
   EXPECT_TRUE(match("abcdefghijklmnop", "????????????????"));  // 16 - ok
-  EXPECT_FALSE(
-      match("abcdefghijklmnopq", "?????????????????"));  // 17 - rejected
-  EXPECT_FALSE(
-      match("anything", "?*?*?*?*?*?*?*?*?*"));  // 18 wildcards - rejected
+  EXPECT_TRUE(match("abcdefghijklmnopq", "?????????????????"));
+  EXPECT_FALSE(match("abcdefghijklmnop", "?????????????????"));
+  EXPECT_TRUE(match("abcdefghijklmnopq", "*****************"));
+  EXPECT_TRUE(match("abcdefghijklmnopq", "?*?*?*?*?*?*?*?*?*?*?*?*?*?*?*?*"));
 }
 
 }  // namespace


### PR DESCRIPTION
Replaces recursive wildcard backtracking in `iree_string_view_match_pattern` with a constant-state cursor walk. Literal and question-mark matches advance directly; a mismatch extends only the most recent star and retries the remaining pattern. This removes caller-shaped native stack use and combinatorial branch search without allocating traversal state.

The previous matcher rejected patterns containing more than 16 wildcards as a containment measure for the recursive algorithm, even though the public API documents ordinary unrestricted `*` and `?` semantics. With the unsafe mechanism gone, arbitrary wildcard counts now follow that documented contract.

Coverage exercises empty inputs, repeated and separated stars, literal star bytes in values, matching and non-matching retry suffixes, and patterns above the former wildcard ceiling.