### PR TITLE
[Runtime/IO] Harden linked IRPA archives

### DIFF
--- a/runtime/src/iree/io/formats/irpa/BUILD.bazel
+++ b/runtime/src/iree/io/formats/irpa/BUILD.bazel
@@ -39,6 +39,7 @@ iree_runtime_cc_test(
     deps = [
         ":irpa",
         "//runtime/src/iree/io/formats/irpa/testdata:irpa_files",
+        "//runtime/src/iree/schemas:parameter_archive",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",
     ],

--- a/runtime/src/iree/io/formats/irpa/CMakeLists.txt
+++ b/runtime/src/iree/io/formats/irpa/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_cc_test(
   DEPS
     ::irpa
     iree::io::formats::irpa::testdata::irpa_files
+    iree::schemas::parameter_archive
     iree::testing::gtest
     iree::testing::gtest_main
   LABELS

--- a/runtime/src/iree/io/formats/irpa/irpa_parser.c
+++ b/runtime/src/iree/io/formats/irpa/irpa_parser.c
@@ -8,88 +8,89 @@
 
 #include "iree/schemas/parameter_archive.h"
 
-static iree_status_t iree_io_verify_irpa_v0_file_range(
+typedef struct iree_io_irpa_resolved_range_t {
+  // Absolute byte offset of the range in the archive file.
+  iree_io_physical_offset_t offset;
+  // Host-accessible contents of the range in the mapped archive file.
+  iree_const_byte_span_t contents;
+} iree_io_irpa_resolved_range_t;
+
+// Resolves a header-relative range into the mapped archive file.
+static iree_status_t iree_io_resolve_irpa_file_range(
     iree_const_byte_span_t file_contents, iree_io_physical_offset_t base_offset,
-    iree_io_parameter_archive_range_t range) {
+    iree_io_parameter_archive_range_t range,
+    iree_io_irpa_resolved_range_t* out_range) {
+  out_range->offset = 0;
+  out_range->contents = iree_const_byte_span_empty();
   if (range.length == 0) return iree_ok_status();
-  if (base_offset + range.offset + range.length > file_contents.data_length) {
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "file segment out of range (%" PRIu64 " to %" PRIu64
-                            " for %" PRIu64 ", file_size=%" PRIhsz ")",
-                            base_offset + range.offset,
-                            base_offset + range.offset + range.length - 1,
-                            range.length, file_contents.data_length);
+
+  iree_io_physical_offset_t absolute_offset = 0;
+  if (!iree_checked_add_u64(base_offset, range.offset, &absolute_offset) ||
+      absolute_offset > file_contents.data_length ||
+      range.length >
+          file_contents.data_length - (iree_host_size_t)absolute_offset) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "file range out of bounds (base=%" PRIu64 ", offset=%" PRIu64
+        ", length=%" PRIu64 ", file_size=%" PRIhsz ")",
+        base_offset, range.offset, range.length, file_contents.data_length);
   }
+
+  out_range->offset = absolute_offset;
+  out_range->contents = iree_make_const_byte_span(
+      file_contents.data + (iree_host_size_t)absolute_offset,
+      (iree_host_size_t)range.length);
   return iree_ok_status();
 }
 
-static iree_status_t iree_io_resolve_irpa_v0_string(
-    iree_const_byte_span_t file_contents, iree_io_physical_offset_t base_offset,
-    const iree_io_parameter_archive_header_v0_t* header,
-    iree_io_parameter_archive_metadata_ref_t range,
-    iree_string_view_t* out_view) {
-  *out_view = iree_string_view_empty();
+// Resolves a range relative to an already resolved parent range.
+static iree_status_t iree_io_resolve_irpa_subrange(
+    const iree_io_irpa_resolved_range_t* parent_range,
+    iree_io_parameter_archive_range_t range,
+    iree_io_irpa_resolved_range_t* out_range) {
+  out_range->offset = 0;
+  out_range->contents = iree_const_byte_span_empty();
   if (range.length == 0) return iree_ok_status();
-  if (range.offset + range.length > header->metadata_segment.length) {
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "metadata segment reference out of range (%" PRIu64
-                            " to %" PRIu64 " for %" PRIu64
-                            ", segment_size=%" PRIu64 ")",
-                            range.offset, range.offset + range.length - 1,
-                            range.length, header->metadata_segment.length);
-  }
-  iree_io_physical_offset_t view_offset =
-      base_offset + header->metadata_segment.offset + range.offset;
-  *out_view = iree_make_string_view(
-      (const char*)file_contents.data + view_offset, range.length);
-  return iree_ok_status();
-}
 
-static iree_status_t iree_io_resolve_irpa_v0_metadata(
-    iree_const_byte_span_t file_contents, iree_io_physical_offset_t base_offset,
-    const iree_io_parameter_archive_header_v0_t* header,
-    iree_io_parameter_archive_metadata_ref_t range,
-    iree_const_byte_span_t* out_span) {
-  *out_span = iree_const_byte_span_empty();
-  if (range.length == 0) return iree_ok_status();
-  if (range.offset + range.length > header->metadata_segment.length) {
+  if (range.offset > parent_range->contents.data_length ||
+      range.length >
+          parent_range->contents.data_length - (iree_host_size_t)range.offset) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "metadata segment reference out of range (%" PRIu64
-                            " to %" PRIu64 " for %" PRIu64
-                            ", segment_size=%" PRIu64 ")",
-                            range.offset, range.offset + range.length - 1,
-                            range.length, header->metadata_segment.length);
+                            "segment range out of bounds (offset=%" PRIu64
+                            ", length=%" PRIu64 ", segment_size=%" PRIhsz ")",
+                            range.offset, range.length,
+                            parent_range->contents.data_length);
   }
-  iree_io_physical_offset_t span_offset =
-      base_offset + header->metadata_segment.offset + range.offset;
-  *out_span =
-      iree_make_const_byte_span(file_contents.data + span_offset, range.length);
+
+  iree_io_physical_offset_t absolute_offset = 0;
+  if (!iree_checked_add_u64(parent_range->offset, range.offset,
+                            &absolute_offset)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "absolute segment offset overflow (base=%" PRIu64
+                            ", offset=%" PRIu64 ")",
+                            parent_range->offset, range.offset);
+  }
+
+  out_range->offset = absolute_offset;
+  out_range->contents = iree_make_const_byte_span(
+      parent_range->contents.data + (iree_host_size_t)range.offset,
+      (iree_host_size_t)range.length);
   return iree_ok_status();
 }
 
 static iree_status_t iree_io_resolve_irpa_v0_storage(
-    iree_const_byte_span_t file_contents, iree_io_physical_offset_t base_offset,
-    const iree_io_parameter_archive_header_v0_t* header,
+    const iree_io_irpa_resolved_range_t* storage_segment,
     iree_io_parameter_archive_storage_ref_t range,
     iree_io_physical_offset_t* out_offset) {
   *out_offset = 0;
-  if (range.length == 0) return iree_ok_status();
-  if (range.offset + range.length > header->storage_segment.length) {
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "storage segment reference out of range (%" PRIu64
-                            " to %" PRIu64 " for %" PRIu64
-                            ", segment_size=%" PRIu64 ")",
-                            range.offset, range.offset + range.length - 1,
-                            range.length, header->storage_segment.length);
-  }
-  iree_io_physical_offset_t storage_offset =
-      base_offset + header->storage_segment.offset + range.offset;
-  *out_offset = storage_offset;
+  iree_io_irpa_resolved_range_t resolved_range;
+  IREE_RETURN_IF_ERROR(
+      iree_io_resolve_irpa_subrange(storage_segment, range, &resolved_range));
+  *out_offset = resolved_range.offset;
   return iree_ok_status();
 }
 
 static iree_status_t iree_io_parse_irpa_v0_splat_entry(
-    const iree_io_parameter_archive_header_v0_t* header,
     const iree_io_parameter_archive_splat_entry_t* splat_entry,
     iree_string_view_t name, iree_const_byte_span_t metadata,
     iree_io_parameter_index_t* index) {
@@ -123,9 +124,8 @@ static iree_status_t iree_io_parse_irpa_v0_splat_entry(
 }
 
 static iree_status_t iree_io_parse_irpa_v0_data_entry(
-    iree_io_file_handle_t* file_handle, iree_const_byte_span_t file_contents,
-    iree_io_physical_offset_t base_offset,
-    const iree_io_parameter_archive_header_v0_t* header,
+    iree_io_file_handle_t* file_handle,
+    const iree_io_irpa_resolved_range_t* storage_segment,
     const iree_io_parameter_archive_data_entry_t* data_entry,
     iree_string_view_t name, iree_const_byte_span_t metadata,
     iree_io_parameter_index_t* index) {
@@ -134,9 +134,8 @@ static iree_status_t iree_io_parse_irpa_v0_data_entry(
                             "data entry length underflow");
   }
   iree_io_physical_offset_t storage_offset = 0;
-  IREE_RETURN_IF_ERROR(
-      iree_io_resolve_irpa_v0_storage(file_contents, base_offset, header,
-                                      data_entry->storage, &storage_offset));
+  IREE_RETURN_IF_ERROR(iree_io_resolve_irpa_v0_storage(
+      storage_segment, data_entry->storage, &storage_offset));
   iree_io_parameter_index_entry_t entry = {
       .key = name,
       .metadata = metadata,
@@ -176,26 +175,32 @@ static iree_status_t iree_io_parse_irpa_v0_index_from_memory(
                             header_prefix->header_size);
   }
   const iree_io_parameter_archive_header_v0_t* header =
-      (const iree_io_parameter_archive_header_v0_t*)file_contents.data;
+      (const iree_io_parameter_archive_header_v0_t*)header_prefix;
 
-  // Verify the base data ranges; this lets all subsequent checks be against the
-  // header instead of needing to know about the view into the file.
-  IREE_RETURN_IF_ERROR(iree_io_verify_irpa_v0_file_range(
-                           file_contents, base_offset, header->entry_segment),
-                       "verifying entry table");
+  // Resolve the base data ranges once so all entry references are checked
+  // against spans that have already been proven to reside in the mapped file.
+  iree_io_irpa_resolved_range_t entry_segment;
   IREE_RETURN_IF_ERROR(
-      iree_io_verify_irpa_v0_file_range(file_contents, base_offset,
-                                        header->metadata_segment),
-      "verifying metadata segment");
-  IREE_RETURN_IF_ERROR(iree_io_verify_irpa_v0_file_range(
-                           file_contents, base_offset, header->storage_segment),
-                       "verifying storage segment");
+      iree_io_resolve_irpa_file_range(file_contents, base_offset,
+                                      header->entry_segment, &entry_segment),
+      "resolving entry table");
+  iree_io_irpa_resolved_range_t metadata_segment;
+  IREE_RETURN_IF_ERROR(iree_io_resolve_irpa_file_range(
+                           file_contents, base_offset, header->metadata_segment,
+                           &metadata_segment),
+                       "resolving metadata segment");
+  iree_io_irpa_resolved_range_t storage_segment;
+  IREE_RETURN_IF_ERROR(iree_io_resolve_irpa_file_range(
+                           file_contents, base_offset, header->storage_segment,
+                           &storage_segment),
+                       "resolving storage segment");
 
   // Walk the entry table, which has variable-length entries.
-  iree_io_physical_offset_t entry_offset =
-      base_offset + header->entry_segment.offset;
-  iree_io_physical_size_t entry_size_remaining = header->entry_segment.length;
+  iree_host_size_t entry_offset = 0;
   for (iree_io_physical_size_t i = 0; i < header->entry_count; ++i) {
+    const iree_host_size_t entry_size_remaining =
+        entry_segment.contents.data_length - entry_offset;
+
     // Ensure there's enough space in the table for the base entry header.
     if (entry_size_remaining <
         sizeof(iree_io_parameter_archive_entry_header_t)) {
@@ -206,7 +211,8 @@ static iree_status_t iree_io_parse_irpa_v0_index_from_memory(
 
     // Ensure there's enough space for the declared entry size (if any larger).
     const iree_io_parameter_archive_entry_header_t* entry_header =
-        (const iree_io_parameter_archive_entry_header_t*)(file_contents.data +
+        (const iree_io_parameter_archive_entry_header_t*)(entry_segment.contents
+                                                              .data +
                                                           entry_offset);
     if (entry_header->entry_size < sizeof(*entry_header) ||
         entry_size_remaining < entry_header->entry_size) {
@@ -214,22 +220,22 @@ static iree_status_t iree_io_parse_irpa_v0_index_from_memory(
           IREE_STATUS_OUT_OF_RANGE,
           "entry table truncated; insufficient bytes for sized header");
     }
-    // TODO(benvanik): make this explicit with iree_io_stream_seek_to_alignment.
-    iree_io_physical_offset_t aligned_entry_size = iree_align_uint64(
-        entry_header->entry_size, IREE_IO_PARAMETER_ARCHIVE_ENTRY_ALIGNMENT);
-    entry_offset += aligned_entry_size;
-    entry_size_remaining -= aligned_entry_size;
 
     // Resolve entry metadata from the archive metadata segment.
-    iree_string_view_t name = iree_string_view_empty();
+    iree_io_irpa_resolved_range_t name_range;
     IREE_RETURN_IF_ERROR(
-        iree_io_resolve_irpa_v0_string(file_contents, base_offset, header,
-                                       entry_header->name, &name),
+        iree_io_resolve_irpa_subrange(&metadata_segment, entry_header->name,
+                                      &name_range),
         "resolving entry name");
-    iree_const_byte_span_t metadata = iree_const_byte_span_empty();
+    iree_string_view_t name =
+        name_range.contents.data_length == 0
+            ? iree_string_view_empty()
+            : iree_make_string_view((const char*)name_range.contents.data,
+                                    name_range.contents.data_length);
+    iree_io_irpa_resolved_range_t metadata_range;
     IREE_RETURN_IF_ERROR(
-        iree_io_resolve_irpa_v0_metadata(file_contents, base_offset, header,
-                                         entry_header->metadata, &metadata),
+        iree_io_resolve_irpa_subrange(&metadata_segment, entry_header->metadata,
+                                      &metadata_range),
         "resolving entry metadata");
 
     // Handle each entry type.
@@ -238,22 +244,36 @@ static iree_status_t iree_io_parse_irpa_v0_index_from_memory(
         break;
       case IREE_IO_PARAMETER_ARCHIVE_ENTRY_TYPE_SPLAT: {
         IREE_RETURN_IF_ERROR(iree_io_parse_irpa_v0_splat_entry(
-            header,
             (const iree_io_parameter_archive_splat_entry_t*)entry_header, name,
-            metadata, index));
+            metadata_range.contents, index));
         break;
       }
       case IREE_IO_PARAMETER_ARCHIVE_ENTRY_TYPE_DATA: {
         IREE_RETURN_IF_ERROR(iree_io_parse_irpa_v0_data_entry(
-            file_handle, file_contents, base_offset, header,
+            file_handle, &storage_segment,
             (const iree_io_parameter_archive_data_entry_t*)entry_header, name,
-            metadata, index));
+            metadata_range.contents, index));
         break;
       }
       default:
         return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
                                 "parser does not support entry type %d",
                                 (int)entry_header->type);
+    }
+
+    // Padding is required only between entries; the final entry may end at the
+    // end of the segment without trailing alignment bytes.
+    if (i + 1 < header->entry_count) {
+      iree_io_physical_size_t aligned_entry_size = 0;
+      if (!iree_checked_align_u64(entry_header->entry_size,
+                                  IREE_IO_PARAMETER_ARCHIVE_ENTRY_ALIGNMENT,
+                                  &aligned_entry_size) ||
+          aligned_entry_size > entry_size_remaining) {
+        return iree_make_status(
+            IREE_STATUS_OUT_OF_RANGE,
+            "entry table truncated; insufficient bytes for entry alignment");
+      }
+      entry_offset += (iree_host_size_t)aligned_entry_size;
     }
   }
 
@@ -263,62 +283,77 @@ static iree_status_t iree_io_parse_irpa_v0_index_from_memory(
 static iree_status_t iree_io_parse_irpa_index_from_memory(
     iree_io_file_handle_t* file_handle, iree_const_byte_span_t file_contents,
     iree_io_physical_offset_t base_offset, iree_io_parameter_index_t* index) {
-  // Check the basic header information is something we can process.
-  if (file_contents.data_length <
-      base_offset + sizeof(iree_io_parameter_archive_header_prefix_t)) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "not enough bytes for a valid IRPA header; file "
-                            "may be empty or truncated");
-  }
-  const iree_io_parameter_archive_header_prefix_t* header_prefix =
-      (const iree_io_parameter_archive_header_prefix_t*)(file_contents.data +
-                                                         base_offset);
-  if (header_prefix->magic != IREE_IO_PARAMETER_ARCHIVE_MAGIC) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "IRPA file magic missing or invalid %08X; expected %08X",
-        header_prefix->magic, IREE_IO_PARAMETER_ARCHIVE_MAGIC);
-  }
-  if (header_prefix->header_size > file_contents.data_length) {
-    return iree_make_status(
-        IREE_STATUS_OUT_OF_RANGE,
-        "file buffer underrun parsing header of reported size %" PRIu64
-        " (only %" PRIhsz " bytes available)",
-        header_prefix->header_size, file_contents.data_length);
-  }
-  if (header_prefix->next_header_offset != 0 &&
-      file_contents.data_length <
-          base_offset + header_prefix->next_header_offset +
-              sizeof(iree_io_parameter_archive_header_prefix_t)) {
-    return iree_make_status(
-        IREE_STATUS_OUT_OF_RANGE,
-        "file buffer underrun verifying linked header at offset %" PRIu64
-        " (only %" PRIhsz " bytes available)",
-        base_offset + header_prefix->next_header_offset,
-        file_contents.data_length);
-  }
-
-  // Route major versions to their parsers, allowing us to change everything but
-  // the prefix without breaking compatibility.
-  switch (header_prefix->version_major) {
-    case 0: {
-      IREE_RETURN_IF_ERROR(iree_io_parse_irpa_v0_index_from_memory(
-          file_handle, file_contents, base_offset, header_prefix, index));
-      break;
+  while (true) {
+    // Check the basic header information before forming a pointer into the
+    // mapped file. Once this succeeds base_offset is host-addressable.
+    if (base_offset > file_contents.data_length ||
+        sizeof(iree_io_parameter_archive_header_prefix_t) >
+            file_contents.data_length - (iree_host_size_t)base_offset) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "not enough bytes for a valid IRPA header at "
+                              "offset %" PRIu64 "; file may be truncated",
+                              base_offset);
     }
-    default: {
+    const iree_io_parameter_archive_header_prefix_t* header_prefix =
+        (const iree_io_parameter_archive_header_prefix_t*)(file_contents.data +
+                                                           (iree_host_size_t)
+                                                               base_offset);
+    if (header_prefix->magic != IREE_IO_PARAMETER_ARCHIVE_MAGIC) {
       return iree_make_status(
-          IREE_STATUS_UNIMPLEMENTED,
-          "IRPA major version %u.%u not supported by this runtime",
-          header_prefix->version_major, header_prefix->version_minor);
+          IREE_STATUS_INVALID_ARGUMENT,
+          "IRPA file magic missing or invalid %08X; expected %08X",
+          header_prefix->magic, IREE_IO_PARAMETER_ARCHIVE_MAGIC);
     }
-  }
+    if (header_prefix->header_size >
+        file_contents.data_length - (iree_host_size_t)base_offset) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "file buffer underrun parsing header of reported size %" PRIu64
+          " at offset %" PRIu64 " (only %" PRIhsz " bytes available)",
+          header_prefix->header_size, base_offset,
+          file_contents.data_length - (iree_host_size_t)base_offset);
+    }
 
-  // If there's a linked header then tail-call process it.
-  if (header_prefix->next_header_offset == 0) return iree_ok_status();
-  return iree_io_parse_irpa_index_from_memory(
-      file_handle, file_contents,
-      base_offset + header_prefix->next_header_offset, index);
+    // Route major versions to their parsers, allowing us to change everything
+    // but the prefix without breaking compatibility.
+    switch (header_prefix->version_major) {
+      case 0: {
+        IREE_RETURN_IF_ERROR(iree_io_parse_irpa_v0_index_from_memory(
+            file_handle, file_contents, base_offset, header_prefix, index));
+        break;
+      }
+      default: {
+        return iree_make_status(
+            IREE_STATUS_UNIMPLEMENTED,
+            "IRPA major version %u.%u not supported by this runtime",
+            header_prefix->version_major, header_prefix->version_minor);
+      }
+    }
+
+    // Advance through the linked list without carrying user-controlled depth on
+    // the native stack. A nonzero relative offset makes forward progress; the
+    // checked addition rejects wraparound before the next pointer is formed.
+    if (header_prefix->next_header_offset == 0) return iree_ok_status();
+    if (header_prefix->next_header_offset %
+            IREE_IO_PARAMETER_ARCHIVE_HEADER_ALIGNMENT !=
+        0) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "linked IRPA header offset %" PRIu64 " is not aligned to %u bytes",
+          header_prefix->next_header_offset,
+          (unsigned int)IREE_IO_PARAMETER_ARCHIVE_HEADER_ALIGNMENT);
+    }
+    iree_io_physical_offset_t next_base_offset = 0;
+    if (!iree_checked_add_u64(base_offset, header_prefix->next_header_offset,
+                              &next_base_offset)) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "linked IRPA header offset overflow (base=%" PRIu64
+          ", relative_offset=%" PRIu64 ")",
+          base_offset, header_prefix->next_header_offset);
+    }
+    base_offset = next_base_offset;
+  }
 }
 
 IREE_API_EXPORT iree_status_t iree_io_parse_irpa_index(

--- a/runtime/src/iree/io/formats/irpa/irpa_parser_test.cc
+++ b/runtime/src/iree/io/formats/irpa/irpa_parser_test.cc
@@ -6,12 +6,105 @@
 
 #include "iree/io/formats/irpa/irpa_parser.h"
 
+#include <vector>
+
 #include "iree/io/formats/irpa/testdata/irpa_files.h"
+#include "iree/schemas/parameter_archive.h"
 #include "iree/testing/gtest.h"
 #include "iree/testing/status_matchers.h"
 
 namespace iree {
 namespace {
+
+static iree_status_t ParseTestArchive(std::vector<uint8_t>& archive_contents,
+                                      iree_io_parameter_index_t* index) {
+  iree_io_file_handle_t* file_handle = NULL;
+  IREE_RETURN_IF_ERROR(iree_io_file_handle_wrap_host_allocation(
+      IREE_IO_FILE_ACCESS_READ,
+      iree_make_byte_span(archive_contents.data(), archive_contents.size()),
+      iree_io_file_handle_release_callback_null(), iree_allocator_system(),
+      &file_handle));
+  iree_status_t status =
+      iree_io_parse_irpa_index(file_handle, index, iree_allocator_system());
+  iree_io_file_handle_release(file_handle);
+  return status;
+}
+
+static iree_host_size_t ArchiveHeaderStride() {
+  return (iree_host_size_t)iree_align_uint64(
+      sizeof(iree_io_parameter_archive_header_v0_t),
+      IREE_IO_PARAMETER_ARCHIVE_HEADER_ALIGNMENT);
+}
+
+static iree_io_parameter_archive_header_v0_t MakeArchiveHeader(
+    iree_io_physical_offset_t next_header_offset) {
+  iree_io_parameter_archive_header_v0_t header = {};
+  header.prefix.magic = IREE_IO_PARAMETER_ARCHIVE_MAGIC;
+  header.prefix.version_major = 0;
+  header.prefix.version_minor = 0;
+  header.prefix.header_size = sizeof(header);
+  header.prefix.next_header_offset = next_header_offset;
+  return header;
+}
+
+template <typename T>
+static void WriteArchiveStruct(std::vector<uint8_t>& archive_contents,
+                               iree_host_size_t offset, const T& value) {
+  const iree_host_size_t required_size = offset + sizeof(value);
+  if (archive_contents.size() < required_size) {
+    archive_contents.resize(required_size);
+  }
+  memcpy(archive_contents.data() + offset, &value, sizeof(value));
+}
+
+static std::vector<uint8_t> BuildEmptyArchiveChain(
+    iree_host_size_t header_count) {
+  const iree_host_size_t header_stride = ArchiveHeaderStride();
+  std::vector<uint8_t> archive_contents(header_count * header_stride, 0);
+  for (iree_host_size_t i = 0; i < header_count; ++i) {
+    const iree_io_parameter_archive_header_v0_t header =
+        MakeArchiveHeader(i + 1 < header_count ? header_stride : 0);
+    WriteArchiveStruct(archive_contents, i * header_stride, header);
+  }
+  return archive_contents;
+}
+
+static std::vector<uint8_t> BuildLinkedSplatArchive(
+    iree_io_physical_offset_t name_offset) {
+  const iree_host_size_t header_stride = ArchiveHeaderStride();
+  const iree_host_size_t entry_offset = header_stride;
+  const iree_host_size_t metadata_offset =
+      entry_offset + sizeof(iree_io_parameter_archive_splat_entry_t);
+  const iree_string_view_t key = IREE_SV("linked");
+
+  std::vector<uint8_t> archive_contents(
+      header_stride + metadata_offset + key.size, 0);
+  const iree_io_parameter_archive_header_v0_t first_header =
+      MakeArchiveHeader(header_stride);
+  WriteArchiveStruct(archive_contents, 0, first_header);
+
+  iree_io_parameter_archive_header_v0_t linked_header = MakeArchiveHeader(0);
+  linked_header.entry_count = 1;
+  linked_header.entry_segment.offset = entry_offset;
+  linked_header.entry_segment.length =
+      sizeof(iree_io_parameter_archive_splat_entry_t);
+  linked_header.metadata_segment.offset = metadata_offset;
+  linked_header.metadata_segment.length = key.size;
+  WriteArchiveStruct(archive_contents, header_stride, linked_header);
+
+  iree_io_parameter_archive_splat_entry_t entry = {};
+  entry.header.entry_size = sizeof(entry);
+  entry.header.type = IREE_IO_PARAMETER_ARCHIVE_ENTRY_TYPE_SPLAT;
+  entry.header.name.offset = name_offset;
+  entry.header.name.length = key.size;
+  entry.length = 4;
+  entry.pattern[0] = 0x5A;
+  entry.pattern_length = 1;
+  WriteArchiveStruct(archive_contents, header_stride + entry_offset, entry);
+  memcpy(archive_contents.data() + header_stride + metadata_offset, key.data,
+         key.size);
+  return archive_contents;
+}
 
 static iree_io_file_handle_t* OpenTestFile(const char* name) {
   const struct iree_file_toc_t* file_toc = iree_io_irpa_files_create();
@@ -153,6 +246,108 @@ TEST(IrpaFormatTest, MixedDataAndSplats) {
   EXPECT_EQ(0, memcmp(&entry3_pattern, entry3->storage.splat.pattern,
                       sizeof(entry3_pattern)));
   EXPECT_EQ(entry3->length, 33554432);
+
+  iree_io_parameter_index_release(index);
+}
+
+TEST(IrpaFormatTest, LinkedHeadersUseSelectedArchive) {
+  std::vector<uint8_t> archive_contents = BuildLinkedSplatArchive(0);
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+
+  IREE_ASSERT_OK(ParseTestArchive(archive_contents, index));
+  ASSERT_EQ(1, iree_io_parameter_index_count(index));
+  const iree_io_parameter_index_entry_t* entry = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_lookup(index, IREE_SV("linked"), &entry));
+  EXPECT_EQ(IREE_IO_PARAMETER_INDEX_ENTRY_STORAGE_TYPE_SPLAT, entry->type);
+  EXPECT_EQ(4, entry->length);
+  EXPECT_EQ(1, entry->storage.splat.pattern_length);
+  EXPECT_EQ(0x5A, entry->storage.splat.pattern[0]);
+
+  iree_io_parameter_index_release(index);
+}
+
+TEST(IrpaFormatTest, LongLinkedHeaderChain) {
+  std::vector<uint8_t> archive_contents = BuildEmptyArchiveChain(32 * 1024);
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+
+  IREE_EXPECT_OK(ParseTestArchive(archive_contents, index));
+  EXPECT_EQ(0, iree_io_parameter_index_count(index));
+
+  iree_io_parameter_index_release(index);
+}
+
+TEST(IrpaFormatTest, RejectsTruncatedLinkedHeader) {
+  std::vector<uint8_t> archive_contents = BuildEmptyArchiveChain(2);
+  archive_contents.resize(ArchiveHeaderStride() +
+                          sizeof(iree_io_parameter_archive_header_prefix_t));
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_OUT_OF_RANGE,
+                        ParseTestArchive(archive_contents, index));
+
+  iree_io_parameter_index_release(index);
+}
+
+TEST(IrpaFormatTest, RejectsUnalignedLinkedHeaderOffset) {
+  std::vector<uint8_t> archive_contents = BuildEmptyArchiveChain(1);
+  const iree_io_parameter_archive_header_v0_t header = MakeArchiveHeader(1);
+  WriteArchiveStruct(archive_contents, 0, header);
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        ParseTestArchive(archive_contents, index));
+
+  iree_io_parameter_index_release(index);
+}
+
+TEST(IrpaFormatTest, RejectsOverflowingLinkedHeaderOffset) {
+  std::vector<uint8_t> archive_contents = BuildEmptyArchiveChain(2);
+  iree_io_parameter_archive_header_v0_t linked_header = MakeArchiveHeader(
+      UINT64_MAX - (IREE_IO_PARAMETER_ARCHIVE_HEADER_ALIGNMENT - 1));
+  WriteArchiveStruct(archive_contents, ArchiveHeaderStride(), linked_header);
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_OUT_OF_RANGE,
+                        ParseTestArchive(archive_contents, index));
+
+  iree_io_parameter_index_release(index);
+}
+
+TEST(IrpaFormatTest, RejectsOverflowingSegmentRange) {
+  std::vector<uint8_t> archive_contents = BuildEmptyArchiveChain(2);
+  iree_io_parameter_archive_header_v0_t linked_header = MakeArchiveHeader(0);
+  linked_header.entry_segment.offset = UINT64_MAX;
+  linked_header.entry_segment.length = 1;
+  WriteArchiveStruct(archive_contents, ArchiveHeaderStride(), linked_header);
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_OUT_OF_RANGE,
+                        ParseTestArchive(archive_contents, index));
+
+  iree_io_parameter_index_release(index);
+}
+
+TEST(IrpaFormatTest, RejectsOverflowingMetadataReference) {
+  std::vector<uint8_t> archive_contents = BuildLinkedSplatArchive(UINT64_MAX);
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_OUT_OF_RANGE,
+                        ParseTestArchive(archive_contents, index));
 
   iree_io_parameter_index_release(index);
 }


### PR DESCRIPTION
IRPA files can chain independently based archives to support concatenation and appending. The parser previously validated each linked prefix at its relative offset but decoded the v0 body from file offset zero, so later archives were never actually selected. The same path used native recursion and allowed unsigned offset arithmetic to wrap before its bounds checks.

This change resolves each top-level archive segment once into an absolute offset and checked mapped span. Entry names, metadata, and storage references are then validated as subranges before any pointer is formed. Linked headers advance iteratively through checked, aligned offsets, so file length bounds traversal without an arbitrary nesting cap or auxiliary stack.

Entry-table padding is now consumed only between records, eliminating the final-record remaining-length underflow. Public parser coverage includes a linked archive with distinct contents, a 32K-header valid chain, truncated and unaligned links, and overflowing top-level and nested ranges.

Reviewer Notes

The central review surface is the resolved-range invariant in irpa_parser.c: every non-empty range carries both a proven mapped span and its absolute file offset. The linked-splat test is the regression witness for selecting the wrong header body.