### PR TITLE
[Runtime/IO] Check IRPA builder layout arithmetic

### DIFF
--- a/runtime/src/iree/io/formats/irpa/BUILD.bazel
+++ b/runtime/src/iree/io/formats/irpa/BUILD.bazel
@@ -33,6 +33,20 @@ iree_runtime_cc_library(
 )
 
 iree_runtime_cc_test(
+    name = "irpa_builder_test",
+    srcs = ["irpa_builder_test.cc"],
+    deps = [
+        ":irpa",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/io:file_handle",
+        "//runtime/src/iree/io:parameter_index",
+        "//runtime/src/iree/io:stream",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_test(
     name = "irpa_parser_test",
     srcs = ["irpa_parser_test.cc"],
     tags = ["requires-filesystem"],

--- a/runtime/src/iree/io/formats/irpa/CMakeLists.txt
+++ b/runtime/src/iree/io/formats/irpa/CMakeLists.txt
@@ -29,6 +29,21 @@ iree_cc_library(
 
 iree_cc_test(
   NAME
+    irpa_builder_test
+  SRCS
+    "irpa_builder_test.cc"
+  DEPS
+    ::irpa
+    iree::base
+    iree::io::file_handle
+    iree::io::parameter_index
+    iree::io::stream
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
+iree_cc_test(
+  NAME
     irpa_parser_test
   SRCS
     "irpa_parser_test.cc"

--- a/runtime/src/iree/io/formats/irpa/irpa_builder.c
+++ b/runtime/src/iree/io/formats/irpa/irpa_builder.c
@@ -6,6 +6,113 @@
 
 #include "iree/io/formats/irpa/irpa_builder.h"
 
+// Fully resolved relative layout of an IRPA archive.
+typedef struct iree_io_parameter_archive_layout_t {
+  // Serialized entry table range.
+  iree_io_parameter_archive_range_t entry_segment;
+  // Serialized names and metadata range.
+  iree_io_parameter_archive_range_t metadata_segment;
+  // File-backed parameter data range.
+  iree_io_parameter_archive_range_t storage_segment;
+  // Final archive size including trailing file-alignment padding.
+  iree_io_physical_size_t total_size;
+} iree_io_parameter_archive_layout_t;
+
+// Normalizes an optional alignment and verifies that it can be used by the
+// checked alignment helpers.
+static iree_status_t iree_io_parameter_archive_normalize_alignment(
+    iree_io_physical_size_t alignment, iree_io_physical_size_t* out_alignment) {
+  *out_alignment = alignment ? alignment : 1;
+  if (!iree_is_power_of_two_uint64(*out_alignment)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "IRPA alignment %" PRIu64 " is not zero or a power of two", alignment);
+  }
+  return iree_ok_status();
+}
+
+// Resolves all archive ranges from the builder segment extents. The builder's
+// public add APIs establish this layout before mutating the entry index; this
+// function also validates callers that customize exposed builder alignment
+// fields directly.
+static iree_status_t iree_io_parameter_archive_builder_calculate_layout(
+    const iree_io_parameter_archive_builder_t* builder,
+    iree_io_parameter_archive_layout_t* out_layout) {
+  iree_io_physical_size_t file_alignment = 0;
+  IREE_RETURN_IF_ERROR(iree_io_parameter_archive_normalize_alignment(
+      builder->file_alignment, &file_alignment));
+  iree_io_physical_size_t storage_alignment = 0;
+  IREE_RETURN_IF_ERROR(iree_io_parameter_archive_normalize_alignment(
+      builder->segments.storage_alignment, &storage_alignment));
+
+  iree_io_parameter_archive_layout_t layout;
+  memset(&layout, 0, sizeof(layout));
+  if (!iree_checked_align_u64(sizeof(iree_io_parameter_archive_header_v0_t),
+                              IREE_IO_PARAMETER_ARCHIVE_ENTRY_ALIGNMENT,
+                              &layout.entry_segment.offset)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "IRPA entry segment offset overflow");
+  }
+  layout.entry_segment.length = builder->segments.entry;
+  if (!iree_checked_add_u64(layout.entry_segment.offset,
+                            layout.entry_segment.length,
+                            &layout.metadata_segment.offset)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "IRPA metadata segment offset overflow");
+  }
+  layout.metadata_segment.length = builder->segments.metadata;
+  iree_io_physical_offset_t metadata_end = 0;
+  if (!iree_checked_add_u64(layout.metadata_segment.offset,
+                            layout.metadata_segment.length, &metadata_end) ||
+      !iree_checked_align_u64(metadata_end, storage_alignment,
+                              &layout.storage_segment.offset)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "IRPA storage segment offset overflow");
+  }
+  layout.storage_segment.length = builder->segments.storage;
+  iree_io_physical_size_t unaligned_total_size = 0;
+  if (!iree_checked_add_u64(layout.storage_segment.offset,
+                            layout.storage_segment.length,
+                            &unaligned_total_size) ||
+      !iree_checked_align_u64(unaligned_total_size, file_alignment,
+                              &layout.total_size)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "IRPA total size overflow");
+  }
+
+  *out_layout = layout;
+  return iree_ok_status();
+}
+
+// Calculates the common entry and metadata extents for one prospective add.
+// No builder-owned state is modified until the caller validates the complete
+// layout and inserts the entry template into the index.
+static iree_status_t iree_io_parameter_archive_builder_prepare_add(
+    const iree_io_parameter_archive_builder_t* builder,
+    iree_io_physical_size_t archive_entry_size, iree_string_view_t name,
+    iree_const_byte_span_t metadata,
+    iree_io_parameter_archive_builder_t* out_prospective_builder) {
+  iree_io_parameter_archive_builder_t prospective_builder = *builder;
+  iree_io_physical_size_t entry_offset = 0;
+  if (!iree_checked_align_u64(builder->segments.entry,
+                              IREE_IO_PARAMETER_ARCHIVE_ENTRY_ALIGNMENT,
+                              &entry_offset) ||
+      !iree_checked_add_u64(entry_offset, archive_entry_size,
+                            &prospective_builder.segments.entry)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "IRPA entry segment size overflow");
+  }
+  iree_io_physical_size_t metadata_size = 0;
+  if (!iree_checked_add_u64(name.size, metadata.data_length, &metadata_size) ||
+      !iree_checked_add_u64(builder->segments.metadata, metadata_size,
+                            &prospective_builder.segments.metadata)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "IRPA metadata segment size overflow");
+  }
+  *out_prospective_builder = prospective_builder;
+  return iree_ok_status();
+}
+
 IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_initialize(
     iree_allocator_t host_allocator,
     iree_io_parameter_archive_builder_t* out_builder) {
@@ -30,40 +137,30 @@ IREE_API_EXPORT bool iree_io_parameter_archive_builder_is_empty(
   return iree_io_parameter_index_count(builder->index) == 0;
 }
 
-static iree_io_physical_size_t
-iree_io_parameter_archive_builder_storage_alignment(
-    const iree_io_parameter_archive_builder_t* builder) {
+IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_header_size(
+    const iree_io_parameter_archive_builder_t* builder,
+    iree_io_physical_size_t* out_header_size) {
   IREE_ASSERT_ARGUMENT(builder);
-  return builder->storage_alignment ? builder->storage_alignment : 1;
+  IREE_ASSERT_ARGUMENT(out_header_size);
+  *out_header_size = 0;
+  iree_io_parameter_archive_layout_t layout;
+  IREE_RETURN_IF_ERROR(
+      iree_io_parameter_archive_builder_calculate_layout(builder, &layout));
+  *out_header_size = layout.storage_segment.offset;
+  return iree_ok_status();
 }
 
-static iree_io_physical_offset_t
-iree_io_parameter_archive_builder_storage_offset(
-    const iree_io_parameter_archive_builder_t* builder) {
+IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_total_size(
+    const iree_io_parameter_archive_builder_t* builder,
+    iree_io_physical_size_t* out_total_size) {
   IREE_ASSERT_ARGUMENT(builder);
-  return iree_align_uint64(
-      iree_align_uint64(sizeof(iree_io_parameter_archive_header_v0_t),
-                        IREE_IO_PARAMETER_ARCHIVE_ENTRY_ALIGNMENT) +
-          builder->entry_segment_size + builder->metadata_segment_size,
-      iree_io_parameter_archive_builder_storage_alignment(builder));
-}
-
-IREE_API_EXPORT iree_io_physical_size_t
-iree_io_parameter_archive_builder_header_size(
-    const iree_io_parameter_archive_builder_t* builder) {
-  IREE_ASSERT_ARGUMENT(builder);
-  return (iree_io_physical_size_t)
-      iree_io_parameter_archive_builder_storage_offset(builder);
-}
-
-IREE_API_EXPORT iree_io_physical_size_t
-iree_io_parameter_archive_builder_total_size(
-    const iree_io_parameter_archive_builder_t* builder) {
-  IREE_ASSERT_ARGUMENT(builder);
-  return iree_align_uint64(
-      iree_io_parameter_archive_builder_storage_offset(builder) +
-          builder->storage_segment_size,
-      builder->file_alignment);
+  IREE_ASSERT_ARGUMENT(out_total_size);
+  *out_total_size = 0;
+  iree_io_parameter_archive_layout_t layout;
+  IREE_RETURN_IF_ERROR(
+      iree_io_parameter_archive_builder_calculate_layout(builder, &layout));
+  *out_total_size = layout.total_size;
+  return iree_ok_status();
 }
 
 IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_write(
@@ -76,24 +173,11 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_write(
   IREE_ASSERT_ARGUMENT(target_index);
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  // Calculate relative segment offsets in the file based on the expected header
-  // size. This allows us to emit header-relative file offsets in the header
-  // itself but absolute offsets for consumers of the target_index.
-  const iree_io_parameter_archive_range_t entry_segment = {
-      .offset = iree_align_uint64(sizeof(iree_io_parameter_archive_header_v0_t),
-                                  IREE_IO_PARAMETER_ARCHIVE_ENTRY_ALIGNMENT),
-      .length = builder->entry_segment_size,
-  };
-  const iree_io_parameter_archive_range_t metadata_segment = {
-      .offset = entry_segment.offset + entry_segment.length,
-      .length = builder->metadata_segment_size,
-  };
-  const iree_io_parameter_archive_range_t storage_segment = {
-      .offset = iree_align_uint64(
-          metadata_segment.offset + metadata_segment.length,
-          iree_io_parameter_archive_builder_storage_alignment(builder)),
-      .length = builder->storage_segment_size,
-  };
+  // Resolve the relative segment ranges once for both the serialized header
+  // and target index entries.
+  iree_io_parameter_archive_layout_t layout;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_io_parameter_archive_builder_calculate_layout(builder, &layout));
 
   // Write the archive header referencing the other segments in the file.
   iree_io_parameter_archive_header_v0_t header = {
@@ -107,9 +191,9 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_write(
               .flags = 0,
           },
       .entry_count = iree_io_parameter_index_count(builder->index),
-      .entry_segment = entry_segment,
-      .metadata_segment = metadata_segment,
-      .storage_segment = storage_segment,
+      .entry_segment = layout.entry_segment,
+      .metadata_segment = layout.metadata_segment,
+      .storage_segment = layout.storage_segment,
   };
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_io_stream_write(stream, sizeof(header), &header));
@@ -191,7 +275,7 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_write(
                 },
         };
         target_entry.storage.file.handle = file_handle;
-        target_entry.storage.file.offset += storage_segment.offset;
+        target_entry.storage.file.offset += layout.storage_segment.offset;
         IREE_RETURN_AND_END_ZONE_IF_ERROR(
             z0, iree_io_stream_write(stream, sizeof(data_entry), &data_entry));
         break;
@@ -245,8 +329,25 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_add_splat_entry(
         "splat pattern length %u invalid; must be 1, 2, 4, 8, or 16 bytes",
         pattern_length);
   }
+  if (data_length % pattern_length != 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "splat data length %" PRIu64
+                            " is not evenly divisible by pattern length %u",
+                            data_length, pattern_length);
+  }
   IREE_TRACE_ZONE_BEGIN(z0);
   IREE_TRACE_ZONE_APPEND_TEXT(z0, name.data, name.size);
+
+  iree_io_parameter_archive_builder_t prospective_builder;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_io_parameter_archive_builder_prepare_add(
+              builder, sizeof(iree_io_parameter_archive_splat_entry_t), name,
+              metadata, &prospective_builder));
+  iree_io_parameter_archive_layout_t prospective_layout;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_io_parameter_archive_builder_calculate_layout(
+              &prospective_builder, &prospective_layout));
+
   iree_io_parameter_index_entry_t entry = {
       .key = name,
       .metadata = metadata,
@@ -264,11 +365,7 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_add_splat_entry(
   memcpy(entry.storage.splat.pattern, pattern, pattern_length);
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_io_parameter_index_add(builder->index, &entry));
-  builder->entry_segment_size =
-      iree_align_uint64(builder->entry_segment_size,
-                        IREE_IO_PARAMETER_ARCHIVE_ENTRY_ALIGNMENT) +
-      sizeof(iree_io_parameter_archive_splat_entry_t);
-  builder->metadata_segment_size += name.size + metadata.data_length;
+  builder->segments = prospective_builder.segments;
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }
@@ -278,8 +375,36 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_add_data_entry(
     iree_const_byte_span_t metadata, iree_io_physical_size_t minimum_alignment,
     iree_io_physical_size_t data_length) {
   IREE_ASSERT_ARGUMENT(builder);
+  iree_io_physical_size_t normalized_alignment = 0;
+  IREE_RETURN_IF_ERROR(iree_io_parameter_archive_normalize_alignment(
+      minimum_alignment, &normalized_alignment));
+  iree_io_physical_size_t current_storage_alignment = 0;
+  IREE_RETURN_IF_ERROR(iree_io_parameter_archive_normalize_alignment(
+      builder->segments.storage_alignment, &current_storage_alignment));
   IREE_TRACE_ZONE_BEGIN(z0);
   IREE_TRACE_ZONE_APPEND_TEXT(z0, name.data, name.size);
+
+  iree_io_parameter_archive_builder_t prospective_builder;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_io_parameter_archive_builder_prepare_add(
+              builder, sizeof(iree_io_parameter_archive_data_entry_t), name,
+              metadata, &prospective_builder));
+  iree_io_physical_offset_t storage_offset = 0;
+  if (!iree_checked_align_u64(builder->segments.storage, normalized_alignment,
+                              &storage_offset) ||
+      !iree_checked_add_u64(storage_offset, data_length,
+                            &prospective_builder.segments.storage)) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "IRPA storage segment size overflow");
+  }
+  prospective_builder.segments.storage_alignment =
+      iree_max(current_storage_alignment, normalized_alignment);
+  iree_io_parameter_archive_layout_t prospective_layout;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_io_parameter_archive_builder_calculate_layout(
+              &prospective_builder, &prospective_layout));
+
   iree_io_parameter_index_entry_t entry = {
       .key = name,
       .metadata = metadata,
@@ -290,23 +415,13 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_add_data_entry(
               .file =
                   {
                       .handle = NULL,  // set on commit
-                      .offset = iree_align_uint64(builder->storage_segment_size,
-                                                  minimum_alignment),
+                      .offset = storage_offset,
                   },
           },
   };
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_io_parameter_index_add(builder->index, &entry));
-  builder->entry_segment_size =
-      iree_align_uint64(builder->entry_segment_size,
-                        IREE_IO_PARAMETER_ARCHIVE_ENTRY_ALIGNMENT) +
-      sizeof(iree_io_parameter_archive_data_entry_t);
-  builder->metadata_segment_size += name.size + metadata.data_length;
-  builder->storage_segment_size = entry.storage.file.offset + entry.length;
-  if (!builder->storage_alignment) {
-    // First entry sets the base alignment.
-    builder->storage_alignment = minimum_alignment;
-  }
+  builder->segments = prospective_builder.segments;
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }
@@ -361,8 +476,11 @@ IREE_API_EXPORT iree_status_t iree_io_build_parameter_archive(
   // Open a file of sufficient size (now that we know it) for writing.
   iree_io_physical_offset_t archive_offset = iree_align_uint64(
       target_file_offset, IREE_IO_PARAMETER_ARCHIVE_HEADER_ALIGNMENT);
-  iree_io_physical_size_t archive_length =
-      iree_io_parameter_archive_builder_total_size(&builder);
+  iree_io_physical_size_t archive_length = 0;
+  if (iree_status_is_ok(status)) {
+    status =
+        iree_io_parameter_archive_builder_total_size(&builder, &archive_length);
+  }
   iree_io_file_handle_t* target_file_handle = NULL;
   if (iree_status_is_ok(status)) {
     status = target_file_open.fn(target_file_open.user_data, archive_offset,

--- a/runtime/src/iree/io/formats/irpa/irpa_builder.h
+++ b/runtime/src/iree/io/formats/irpa/irpa_builder.h
@@ -25,7 +25,7 @@ extern "C" {
 //  iree_io_parameter_archive_builder_add_data_entry(&builder, ...);
 //  iree_io_parameter_archive_builder_add_data_entry(&builder, ...);
 //  iree_io_parameter_archive_builder_add_data_entry(&builder, ...);
-//  total_size = iree_io_parameter_archive_builder_total_size(&builder);
+//  iree_io_parameter_archive_builder_total_size(&builder, &total_size);
 //  << create file of total_size, map into memory >>
 //  iree_io_parameter_archive_builder_write(&builder, file, &target_index);
 //  << file now contains the full archive header >>
@@ -33,13 +33,23 @@ extern "C" {
 //  << write parameter contents, or don't if leaving uninitialized >>
 //  iree_io_parameter_archive_builder_deinitialize(&builder);
 typedef struct iree_io_parameter_archive_builder_t {
+  // Allocator used for builder-owned state.
   iree_allocator_t host_allocator;
+  // Builder-owned entry templates in archive order.
   iree_io_parameter_index_t* index;
+  // Alignment applied to the final archive size, or zero for no alignment.
   iree_io_physical_size_t file_alignment;
-  iree_io_physical_size_t entry_segment_size;
-  iree_io_physical_size_t metadata_segment_size;
-  iree_io_physical_size_t storage_segment_size;
-  iree_io_physical_size_t storage_alignment;
+  // Serialized segment extent state updated atomically with the index.
+  struct {
+    // Bytes occupied by serialized entry records and their padding.
+    iree_io_physical_size_t entry;
+    // Bytes occupied by entry names and metadata.
+    iree_io_physical_size_t metadata;
+    // Bytes reserved for file-backed parameter data and its padding.
+    iree_io_physical_size_t storage;
+    // Strongest alignment required by any file-backed parameter.
+    iree_io_physical_size_t storage_alignment;
+  } segments;
 } iree_io_parameter_archive_builder_t;
 
 // Initializes a new parameter builder in |out_builder| for use.
@@ -57,25 +67,30 @@ IREE_API_EXPORT void iree_io_parameter_archive_builder_deinitialize(
 IREE_API_EXPORT bool iree_io_parameter_archive_builder_is_empty(
     const iree_io_parameter_archive_builder_t* builder);
 
-// Returns the size required to store the parameter archive header and
-// associated metadata (excluding parameters). Adding new parameters will
-// invalidate this value.
-IREE_API_EXPORT iree_io_physical_size_t
-iree_io_parameter_archive_builder_header_size(
-    const iree_io_parameter_archive_builder_t* builder);
+// Calculates the size required to store the parameter archive header and
+// associated metadata (excluding parameters). Returns
+// IREE_STATUS_INVALID_ARGUMENT for an invalid configured alignment or
+// IREE_STATUS_OUT_OF_RANGE if the layout is not representable by the IRPA
+// physical offset type.
+IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_header_size(
+    const iree_io_parameter_archive_builder_t* builder,
+    iree_io_physical_size_t* out_header_size);
 
-// Returns the total file size required to store the parameter archive header
-// and contents of all added parameters. Adding new parameters will invalidate
-// this value.
-IREE_API_EXPORT iree_io_physical_size_t
-iree_io_parameter_archive_builder_total_size(
-    const iree_io_parameter_archive_builder_t* builder);
+// Calculates the total file size required to store the parameter archive
+// header and contents of all added parameters. Returns
+// IREE_STATUS_INVALID_ARGUMENT for an invalid configured alignment or
+// IREE_STATUS_OUT_OF_RANGE if the layout is not representable by the IRPA
+// physical offset type.
+IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_total_size(
+    const iree_io_parameter_archive_builder_t* builder,
+    iree_io_physical_size_t* out_total_size);
 
 // Writes the parameter archive to the given |file_handle|. The file must have
-// at least enough storage to fit iree_io_parameter_archive_builder_total_size.
+// at least enough storage to fit the size calculated by
+// iree_io_parameter_archive_builder_total_size.
 // The archive will be written starting at the given |file_offset|.
-// If an optional |target_index| is provided entries for all parameters will be
-// appended to the index referencing the given |file_handle|.
+// Entries for all parameters will be appended to |target_index| referencing
+// the given |file_handle|.
 IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_write(
     const iree_io_parameter_archive_builder_t* builder,
     iree_io_file_handle_t* file_handle, iree_io_physical_offset_t file_offset,
@@ -84,7 +99,8 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_write(
 // Adds a new splat entry to |builder|.
 // Splat entries have no physical storage and exist only in the header.
 // |pattern| and |metadata| (if provided) are copied prior to returning.
-// |pattern_length| must be <= 16 (enough for complex<f64>).
+// |pattern_length| must be 1, 2, 4, 8, or 16 and must evenly divide
+// |data_length|.
 IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_add_splat_entry(
     iree_io_parameter_archive_builder_t* builder, iree_string_view_t name,
     iree_const_byte_span_t metadata, const void* pattern,
@@ -93,7 +109,8 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_add_splat_entry(
 // Adds a new data entry to |builder|.
 // |metadata| (if provided) is copied prior to returning.
 // Physical storage will be allocated for |data_length| and it will be aligned
-// to at least |minimum_alignment|.
+// to at least |minimum_alignment|. Zero specifies no additional alignment;
+// nonzero alignments must be powers of two.
 IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_add_data_entry(
     iree_io_parameter_archive_builder_t* builder, iree_string_view_t name,
     iree_const_byte_span_t metadata, iree_io_physical_size_t minimum_alignment,

--- a/runtime/src/iree/io/formats/irpa/irpa_builder_test.cc
+++ b/runtime/src/iree/io/formats/irpa/irpa_builder_test.cc
@@ -1,0 +1,182 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/io/formats/irpa/irpa_builder.h"
+
+#include <limits>
+#include <vector>
+
+#include "iree/io/formats/irpa/irpa_parser.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree {
+namespace {
+
+class IrpaBuilderTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    IREE_ASSERT_OK(iree_io_parameter_archive_builder_initialize(
+        iree_allocator_system(), &builder_));
+  }
+
+  void TearDown() override {
+    iree_io_parameter_archive_builder_deinitialize(&builder_);
+  }
+
+  iree_io_physical_size_t HeaderSize() {
+    iree_io_physical_size_t header_size = 0;
+    IREE_EXPECT_OK(
+        iree_io_parameter_archive_builder_header_size(&builder_, &header_size));
+    return header_size;
+  }
+
+  iree_io_physical_size_t TotalSize() {
+    iree_io_physical_size_t total_size = 0;
+    IREE_EXPECT_OK(
+        iree_io_parameter_archive_builder_total_size(&builder_, &total_size));
+    return total_size;
+  }
+
+  iree_io_parameter_archive_builder_t builder_;
+};
+
+TEST_F(IrpaBuilderTest, EmptyLayout) {
+  EXPECT_TRUE(iree_io_parameter_archive_builder_is_empty(&builder_));
+  EXPECT_EQ(96u, HeaderSize());
+  EXPECT_EQ(4096u, TotalSize());
+}
+
+TEST_F(IrpaBuilderTest, WritesExpectedV0Layout) {
+  IREE_ASSERT_OK(iree_io_parameter_archive_builder_add_data_entry(
+      &builder_, IREE_SV("key0"), iree_const_byte_span_empty(), 64, 16));
+  IREE_ASSERT_OK(iree_io_parameter_archive_builder_add_data_entry(
+      &builder_, IREE_SV("key1"), iree_const_byte_span_empty(), 64, 5));
+
+  EXPECT_EQ(320u, HeaderSize());
+  const iree_io_physical_size_t total_size = TotalSize();
+  EXPECT_EQ(4096u, total_size);
+
+  std::vector<uint8_t> file_contents(total_size, 0);
+  iree_io_file_handle_t* file_handle = NULL;
+  IREE_ASSERT_OK(iree_io_file_handle_wrap_host_allocation(
+      IREE_IO_FILE_ACCESS_READ | IREE_IO_FILE_ACCESS_WRITE,
+      iree_make_byte_span(file_contents.data(), file_contents.size()),
+      iree_io_file_handle_release_callback_null(), iree_allocator_system(),
+      &file_handle));
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_stream_open(IREE_IO_STREAM_MODE_WRITABLE, file_handle,
+                                     0, iree_allocator_system(), &stream));
+  iree_io_parameter_index_t* built_index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &built_index));
+  IREE_ASSERT_OK(iree_io_parameter_archive_builder_write(
+      &builder_, file_handle, 0, stream, built_index));
+
+  const auto* header =
+      reinterpret_cast<const iree_io_parameter_archive_header_v0_t*>(
+          file_contents.data());
+  EXPECT_EQ(96u, header->entry_segment.offset);
+  EXPECT_EQ(156u, header->entry_segment.length);
+  EXPECT_EQ(252u, header->metadata_segment.offset);
+  EXPECT_EQ(8u, header->metadata_segment.length);
+  EXPECT_EQ(320u, header->storage_segment.offset);
+  EXPECT_EQ(69u, header->storage_segment.length);
+
+  const iree_io_parameter_index_entry_t* entry = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_lookup(built_index, IREE_SV("key0"), &entry));
+  EXPECT_EQ(320u, entry->storage.file.offset);
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_lookup(built_index, IREE_SV("key1"), &entry));
+  EXPECT_EQ(384u, entry->storage.file.offset);
+
+  iree_io_parameter_index_t* parsed_index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &parsed_index));
+  IREE_EXPECT_OK(iree_io_parse_irpa_index(file_handle, parsed_index,
+                                          iree_allocator_system()));
+  EXPECT_EQ(2u, iree_io_parameter_index_count(parsed_index));
+
+  iree_io_parameter_index_release(parsed_index);
+  iree_io_parameter_index_release(built_index);
+  iree_io_stream_release(stream);
+  iree_io_file_handle_release(file_handle);
+}
+
+TEST_F(IrpaBuilderTest, UsesStrongestStorageAlignment) {
+  IREE_ASSERT_OK(iree_io_parameter_archive_builder_add_data_entry(
+      &builder_, IREE_SV("a"), iree_const_byte_span_empty(), 16, 1));
+  IREE_ASSERT_OK(iree_io_parameter_archive_builder_add_data_entry(
+      &builder_, IREE_SV("b"), iree_const_byte_span_empty(), 256, 1));
+
+  EXPECT_EQ(256u, HeaderSize());
+  EXPECT_EQ(4096u, TotalSize());
+  const iree_io_parameter_index_entry_t* entry = NULL;
+  IREE_ASSERT_OK(iree_io_parameter_index_get(builder_.index, 0, &entry));
+  EXPECT_EQ(0u, entry->storage.file.offset);
+  EXPECT_EQ(0u, (HeaderSize() + entry->storage.file.offset) % 16);
+  IREE_ASSERT_OK(iree_io_parameter_index_get(builder_.index, 1, &entry));
+  EXPECT_EQ(256u, entry->storage.file.offset);
+  EXPECT_EQ(0u, (HeaderSize() + entry->storage.file.offset) % 256);
+}
+
+TEST_F(IrpaBuilderTest, TreatsZeroAlignmentAsUnspecified) {
+  IREE_ASSERT_OK(iree_io_parameter_archive_builder_add_data_entry(
+      &builder_, IREE_SV("a"), iree_const_byte_span_empty(), 0, 1));
+  IREE_ASSERT_OK(iree_io_parameter_archive_builder_add_data_entry(
+      &builder_, IREE_SV("b"), iree_const_byte_span_empty(), 0, 1));
+
+  const iree_io_parameter_index_entry_t* entry = NULL;
+  IREE_ASSERT_OK(iree_io_parameter_index_get(builder_.index, 0, &entry));
+  EXPECT_EQ(0u, entry->storage.file.offset);
+  IREE_ASSERT_OK(iree_io_parameter_index_get(builder_.index, 1, &entry));
+  EXPECT_EQ(1u, entry->storage.file.offset);
+}
+
+TEST_F(IrpaBuilderTest, RejectsInvalidAlignmentWithoutMutation) {
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_io_parameter_archive_builder_add_data_entry(
+          &builder_, IREE_SV("invalid"), iree_const_byte_span_empty(), 3, 1));
+  EXPECT_TRUE(iree_io_parameter_archive_builder_is_empty(&builder_));
+  EXPECT_EQ(4096u, TotalSize());
+}
+
+TEST_F(IrpaBuilderTest, RejectsOverflowWithoutMutation) {
+  IREE_ASSERT_OK(iree_io_parameter_archive_builder_add_data_entry(
+      &builder_, IREE_SV("valid"), iree_const_byte_span_empty(), 64, 64));
+  const iree_io_physical_size_t total_size = TotalSize();
+
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_OUT_OF_RANGE,
+      iree_io_parameter_archive_builder_add_data_entry(
+          &builder_, IREE_SV("overflow"), iree_const_byte_span_empty(), 64,
+          std::numeric_limits<iree_io_physical_size_t>::max() - 64));
+  EXPECT_EQ(1u, iree_io_parameter_index_count(builder_.index));
+  EXPECT_EQ(total_size, TotalSize());
+}
+
+TEST_F(IrpaBuilderTest, RejectsInvalidFileAlignment) {
+  builder_.file_alignment = 3;
+  iree_io_physical_size_t total_size = 0;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_io_parameter_archive_builder_total_size(&builder_, &total_size));
+}
+
+TEST_F(IrpaBuilderTest, RejectsNonIntegralSplatPattern) {
+  const uint32_t pattern = 0;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_io_parameter_archive_builder_add_splat_entry(
+          &builder_, IREE_SV("invalid"), iree_const_byte_span_empty(), &pattern,
+          sizeof(pattern), 6));
+  EXPECT_TRUE(iree_io_parameter_archive_builder_is_empty(&builder_));
+}
+
+}  // namespace
+}  // namespace iree

--- a/runtime/src/iree/tools/iree-create-parameters-main.c
+++ b/runtime/src/iree/tools/iree-create-parameters-main.c
@@ -238,18 +238,24 @@ int main(int argc, char** argv) {
   iree_flags_parse_checked(IREE_FLAGS_PARSE_MODE_DEFAULT, &argc, &argv);
 
   iree_io_parameter_archive_builder_t builder;
-  iree_io_parameter_archive_builder_initialize(host_allocator, &builder);
+  iree_status_t status =
+      iree_io_parameter_archive_builder_initialize(host_allocator, &builder);
 
   // Declare parameters based on flags, populating the builder with the metadata
   // for each parameter without yet writing any data.
-  iree_status_t status = iree_tooling_declare_parameters(&builder);
+  if (iree_status_is_ok(status)) {
+    status = iree_tooling_declare_parameters(&builder);
+  }
 
   // Open a file of sufficient size (now that we know it) for writing.
   iree_io_physical_offset_t target_file_offset = 0;
   iree_io_physical_offset_t archive_offset = iree_align_uint64(
       target_file_offset, IREE_IO_PARAMETER_ARCHIVE_HEADER_ALIGNMENT);
-  iree_io_physical_size_t archive_length =
-      iree_io_parameter_archive_builder_total_size(&builder);
+  iree_io_physical_size_t archive_length = 0;
+  if (iree_status_is_ok(status)) {
+    status =
+        iree_io_parameter_archive_builder_total_size(&builder, &archive_length);
+  }
   iree_io_file_handle_t* target_file_handle = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_tooling_open_output_parameter_file(

--- a/runtime/src/iree/tools/iree-encode-parameters-main.c
+++ b/runtime/src/iree/tools/iree-encode-parameters-main.c
@@ -652,8 +652,10 @@ static iree_status_t iree_encode_create_archives(
     for (iree_host_size_t i = 0; i < output_list->count; ++i) {
       iree_output_archive_t* archive = &archives[i];
 
-      iree_io_physical_size_t archive_size =
-          iree_io_parameter_archive_builder_total_size(&archive->builder);
+      iree_io_physical_size_t archive_size = 0;
+      status = iree_io_parameter_archive_builder_total_size(&archive->builder,
+                                                            &archive_size);
+      if (!iree_status_is_ok(status)) break;
 
       // Create null-terminated path.
       char* path_cstr = NULL;
@@ -948,11 +950,14 @@ static iree_status_t iree_encode_dump_outputs(iree_output_archive_t* archives,
     if (!iree_status_is_ok(status)) break;
 
     // Print archive header.
-    iree_io_physical_size_t archive_size =
-        iree_io_parameter_archive_builder_total_size(&archive->builder);
-    status = iree_string_builder_append_format(
-        &sb, "// Output: %.*s (%" PRIu64 " bytes)\n", (int)archive->path.size,
-        archive->path.data, archive_size);
+    iree_io_physical_size_t archive_size = 0;
+    status = iree_io_parameter_archive_builder_total_size(&archive->builder,
+                                                          &archive_size);
+    if (iree_status_is_ok(status)) {
+      status = iree_string_builder_append_format(
+          &sb, "// Output: %.*s (%" PRIu64 " bytes)\n", (int)archive->path.size,
+          archive->path.data, archive_size);
+    }
     if (!iree_status_is_ok(status)) break;
 
     // Dump parameter index.


### PR DESCRIPTION
IRPA builders now resolve entry, metadata, and storage ranges plus final file size through one checked 64-bit layout calculation. Entry admission validates prospective extents before mutating the insert-only index, so an invalid alignment or unrepresentable archive leaves the builder unchanged.

Size queries now propagate layout failures instead of returning wrapped values. Data entries treat zero alignment as unspecified, reject non-power-of-two values, and retain the strongest requested storage alignment so every relative entry remains correctly aligned once the storage segment is placed. Splat admission also enforces the v0 requirement that the pattern evenly divide the logical length.

The new builder test serializes and reparses the ordinary v0 layout to pin existing offsets, then exercises heterogeneous and zero alignments, atomic overflow rejection, invalid file alignment, and invalid splat lengths.