### PR TITLE
[Loom] Gate generated builder stubs in presubmit

### DIFF
--- a/loom/build_tools/linters/loom_lint.py
+++ b/loom/build_tools/linters/loom_lint.py
@@ -5,15 +5,19 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-"""Loom Python linting orchestrator.
+"""Standalone Loom Python source maintenance driver.
 
-Runs code generators, ruff (lint + format), and mypy on the loom Python
-package. Used by the `dev.py bazel precommit` Loom lint path and runnable
-standalone:
+Runs checked-in code generators and Ruff fixups in place, then runs mypy on the
+Loom Python package. This is an explicit maintenance command, not the
+`dev.py bazel precommit` policy path. Normal presubmit checks generated files
+without mutating the worktree.
+
+Run from the repository root:
 
     python loom/build_tools/linters/loom_lint.py
 
-Exit code is 0 only if all steps pass and no files were modified.
+Exit code is zero when all maintenance steps succeed; generated or formatted
+changes may remain in the worktree for review.
 """
 
 import os

--- a/loom/build_tools/presubmit.py
+++ b/loom/build_tools/presubmit.py
@@ -90,6 +90,18 @@ def should_run_tests(files_from: str | None) -> bool:
     )
 
 
+def run_generated_builder_check() -> bool:
+    return run_command(
+        [
+            sys.executable,
+            "loom/py/loom/gen/run.py",
+            "builders_pyi",
+            "--check",
+        ],
+        "Generated builder stubs",
+    )
+
+
 def bazel_test_command() -> list[str]:
     return [
         "bazel",
@@ -138,10 +150,11 @@ def run_presubmit(args: argparse.Namespace) -> int:
     if not should_run_tests(args.files_from):
         print("loom presubmit: no Loom-affecting files")
         return 0
+    ok = run_generated_builder_check()
     if args.lane == "bazel":
-        ok = run_bazel_tests()
+        ok = run_bazel_tests() and ok
     elif args.lane == "cmake":
-        ok = run_cmake_tests()
+        ok = run_cmake_tests() and ok
     else:
         raise ValueError(f"unknown lane: {args.lane}")
     return 0 if ok else 1

--- a/loom/build_tools/presubmit_test.py
+++ b/loom/build_tools/presubmit_test.py
@@ -55,6 +55,41 @@ class LoomPresubmitTest(unittest.TestCase):
             "runtime-resource=",
         )
 
+    def test_generated_builder_check_is_read_only(self):
+        with mock.patch.object(
+            self.presubmit, "run_command", return_value=True
+        ) as run_command:
+            self.assertTrue(self.presubmit.run_generated_builder_check())
+
+        run_command.assert_called_once_with(
+            [
+                sys.executable,
+                "loom/py/loom/gen/run.py",
+                "builders_pyi",
+                "--check",
+            ],
+            "Generated builder stubs",
+        )
+
+    def test_generated_builder_drift_fails_presubmit(self):
+        args = types.SimpleNamespace(
+            files_from=None,
+            lane="bazel",
+            tests=True,
+        )
+        with (
+            mock.patch.object(
+                self.presubmit, "run_generated_builder_check", return_value=False
+            ) as generated_builder_check,
+            mock.patch.object(
+                self.presubmit, "run_bazel_tests", return_value=True
+            ) as bazel_tests,
+        ):
+            self.assertEqual(self.presubmit.run_presubmit(args), 1)
+
+        generated_builder_check.assert_called_once_with()
+        bazel_tests.assert_called_once_with()
+
     def test_main_rechecks_package_initializers_after_bazel_tests(self):
         args = types.SimpleNamespace(
             files_from=None,
@@ -69,6 +104,9 @@ class LoomPresubmitTest(unittest.TestCase):
                 self.presubmit.NonEmptyTrackedFileSnapshot,
                 "capture_tracked_package_initializers",
                 return_value=snapshot,
+            ),
+            mock.patch.object(
+                self.presubmit, "run_generated_builder_check", return_value=True
             ),
             mock.patch.object(self.presubmit, "run_bazel_tests", return_value=True),
         ):

--- a/loom/py/loom/dialect/kernel/builders/__init__.pyi
+++ b/loom/py/loom/dialect/kernel/builders/__init__.pyi
@@ -517,3 +517,41 @@ class KernelBuilder(DialectBuilder):
         result_names: Sequence[str] | None = ...,
         location_id: int | None = ...,
     ) -> ValueRef: ...
+    def decl(
+        self,
+        *,
+        retain: str | None = ...,
+        target: str | None = ...,
+        export_symbol: str | None = ...,
+        export_linkage: str | None = ...,
+        callee: str,
+        workloads: list[ValueRef] = ...,
+        args: list[ValueRef] = ...,
+        predicates: list[Predicate] = ...,
+        location_id: int | None = ...,
+    ) -> None: ...
+    def launch(
+        self,
+        *,
+        callee: str,
+        workloads: list[ValueRef] = ...,
+        arguments: list[ValueRef] = ...,
+        location_id: int | None = ...,
+    ) -> None: ...
+    def yield_(
+        self,
+        *,
+        location_id: int | None = ...,
+    ) -> None: ...
+    def serial(
+        self,
+        *,
+        body: Region | None = ...,
+        location_id: int | None = ...,
+    ) -> None: ...
+    def concurrent(
+        self,
+        *,
+        body: Region | None = ...,
+        location_id: int | None = ...,
+    ) -> None: ...


### PR DESCRIPTION
Checked-in Python builder stubs are now part of Loom's enforced presubmit contract. Every Loom-affecting Bazel or CMake presubmit runs the complete `builders_pyi --check` generator before project tests, so a dialect declaration cannot land while the author-facing builder interface remains stale.

The kernel launch cutover exposed the gap: the runtime builder understood the new kernel declaration and launch contracts, but the checked-in `KernelBuilder` stub omitted `decl`, `launch`, `yield_`, `serial`, and `concurrent`. This change regenerates that interface, making the explicit workload, argument, and launch-scheduling APIs available to typed Python authoring immediately.

The check is deliberately read-only. Presubmit reports every stale, missing, or unexpected generated stub and points authors to the explicit `builders_pyi --in-place` repair command instead of silently rewriting a shared worktree or staging outputs outside the intended commit. The older standalone Loom lint driver remains an explicit mutating maintenance tool and now documents that boundary accurately.

This closes the loop between dialect design and the API agents and authors actually import: changing any Loom operation now requires its generated builder surface to agree before either build-system lane can pass.
