### PR TITLE
[Runtime/IO] Enforce IRPA layout and GGUF decoding invariants

### DIFF
--- a/build_tools/devtools/ci_config.py
+++ b/build_tools/devtools/ci_config.py
@@ -115,7 +115,6 @@ CPU_SANITIZERS_XFAILS = (
     bazel_xfail("//runtime/src/iree/hal/local/elf/..."),
     bazel_xfail("//runtime/src/iree/hal/local:profile_test"),
     bazel_xfail("//runtime/src/iree/hal/replay:execute_test"),
-    bazel_xfail("//runtime/src/iree/io/formats/gguf:gguf_parser_test"),
     bazel_xfail("//runtime/src/iree/tokenizer/..."),
     bazel_xfail("//runtime/src/iree/tooling/profile:cli_test"),
     bazel_xfail("//runtime/src/iree/vm:list_test"),

--- a/runtime/src/iree/io/formats/gguf/gguf_parser.c
+++ b/runtime/src/iree/io/formats/gguf/gguf_parser.c
@@ -411,10 +411,15 @@ typedef struct {
 //   uint64_t offset;
 // };
 typedef struct {
+  // Tensor name referencing the mapped file contents.
   iree_string_view_t name;
-  uint32_t n_dimensions;
-  const uint64_t* dimensions;  // n_dimensions
+  // Number of encoded uint64_t dimension values.
+  uint32_t dimension_count;
+  // Little-endian dimension values referencing byte-aligned file contents.
+  const uint8_t* dimension_data;
+  // GGML tensor element type.
   ggml_type_t type;
+  // Byte offset within the tensor data region.
   uint64_t offset;
 } gguf_tensor_info_t;
 
@@ -461,9 +466,10 @@ static iree_status_t iree_io_gguf_calculate_storage_size(
   }
 
   uint64_t element_count = 1;
-  for (uint32_t i = 0; i < tensor_info->n_dimensions; ++i) {
-    if (!iree_checked_mul_u64(element_count, tensor_info->dimensions[i],
-                              &element_count)) {
+  for (uint32_t i = 0; i < tensor_info->dimension_count; ++i) {
+    const uint64_t dimension = iree_unaligned_load_le_u64(
+        tensor_info->dimension_data + i * sizeof(uint64_t));
+    if (!iree_checked_mul_u64(element_count, dimension, &element_count)) {
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                               "GGML tensor element count overflow");
     }
@@ -499,11 +505,25 @@ static iree_status_t iree_io_gguf_parse_value(iree_const_byte_span_t* contents,
 }
 static iree_status_t iree_io_gguf_parse_uint32(iree_const_byte_span_t* contents,
                                                uint32_t* out_value) {
-  return iree_io_gguf_parse_value(contents, sizeof(*out_value), out_value);
+  if (contents->data_length < sizeof(*out_value)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "file buffer underrun parsing uint32 value");
+  }
+  *out_value = iree_unaligned_load_le_u32(contents->data);
+  contents->data += sizeof(*out_value);
+  contents->data_length -= sizeof(*out_value);
+  return iree_ok_status();
 }
 static iree_status_t iree_io_gguf_parse_uint64(iree_const_byte_span_t* contents,
                                                uint64_t* out_value) {
-  return iree_io_gguf_parse_value(contents, sizeof(*out_value), out_value);
+  if (contents->data_length < sizeof(*out_value)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "file buffer underrun parsing uint64 value");
+  }
+  *out_value = iree_unaligned_load_le_u64(contents->data);
+  contents->data += sizeof(*out_value);
+  contents->data_length -= sizeof(*out_value);
+  return iree_ok_status();
 }
 
 static iree_status_t iree_io_gguf_parse_array(iree_const_byte_span_t* contents,
@@ -535,9 +555,12 @@ static iree_status_t iree_io_gguf_parse_string(iree_const_byte_span_t* contents,
                             "attempting to load a 64-bit file on a 32-bit arch "
                             "(out of bounds string length)");
   }
-  out_value->size = (iree_host_size_t)length;
-  return iree_io_gguf_parse_array(contents, length, sizeof(char),
-                                  (const uint8_t**)&out_value->data);
+  const uint8_t* value_data = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_io_gguf_parse_array(contents, length, sizeof(char), &value_data));
+  *out_value =
+      iree_make_string_view((const char*)value_data, (iree_host_size_t)length);
+  return iree_ok_status();
 }
 
 static iree_status_t iree_io_gguf_skip_metadata_array(
@@ -638,10 +661,10 @@ static iree_status_t iree_io_gguf_enumerate_tensor_info(
     IREE_RETURN_IF_ERROR(
         iree_io_gguf_parse_string(contents, &tensor_info.name));
     IREE_RETURN_IF_ERROR(
-        iree_io_gguf_parse_uint32(contents, &tensor_info.n_dimensions));
+        iree_io_gguf_parse_uint32(contents, &tensor_info.dimension_count));
     IREE_RETURN_IF_ERROR(iree_io_gguf_parse_array(
-        contents, tensor_info.n_dimensions, sizeof(tensor_info.dimensions[0]),
-        (const uint8_t**)&tensor_info.dimensions));
+        contents, tensor_info.dimension_count, sizeof(uint64_t),
+        &tensor_info.dimension_data));
     IREE_RETURN_IF_ERROR(
         iree_io_gguf_parse_uint32(contents, &tensor_info.type));
     IREE_RETURN_IF_ERROR(

--- a/runtime/src/iree/io/formats/irpa/irpa_builder.c
+++ b/runtime/src/iree/io/formats/irpa/irpa_builder.c
@@ -239,13 +239,21 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_write(
   // Write entry table following the header.
   // This references ranges in the metadata and storage segment but to preserve
   // forward-only writes we populate those after writing the table.
+  const uint8_t zero = 0;
+  iree_io_physical_offset_t entry_offset = sizeof(header);
   iree_io_physical_offset_t metadata_offset = 0;
   for (iree_host_size_t i = 0;
        i < iree_io_parameter_index_count(builder->index); ++i) {
-    // Align each entry to the base alignment.
+    // Explicitly zero alignment padding so writing into reused storage produces
+    // the deterministic bytes required by the archive format.
+    const iree_io_physical_offset_t aligned_entry_offset = iree_align_uint64(
+        entry_offset, IREE_IO_PARAMETER_ARCHIVE_ENTRY_ALIGNMENT);
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_io_stream_seek_to_alignment(
-                stream, IREE_IO_PARAMETER_ARCHIVE_ENTRY_ALIGNMENT));
+        z0,
+        iree_io_stream_fill(
+            stream, (iree_io_stream_pos_t)(aligned_entry_offset - entry_offset),
+            &zero, sizeof(zero)));
+    entry_offset = aligned_entry_offset;
 
     // Query the source entry template.
     const iree_io_parameter_index_entry_t* source_entry = NULL;
@@ -292,6 +300,7 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_write(
         IREE_RETURN_AND_END_ZONE_IF_ERROR(
             z0,
             iree_io_stream_write(stream, sizeof(splat_entry), &splat_entry));
+        entry_offset += sizeof(splat_entry);
         break;
       }
       case IREE_IO_PARAMETER_INDEX_ENTRY_STORAGE_TYPE_FILE: {
@@ -316,6 +325,7 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_write(
         target_entry.storage.file.offset += storage_base_offset;
         IREE_RETURN_AND_END_ZONE_IF_ERROR(
             z0, iree_io_stream_write(stream, sizeof(data_entry), &data_entry));
+        entry_offset += sizeof(data_entry);
         break;
       }
       default: {

--- a/runtime/src/iree/io/formats/irpa/irpa_builder.c
+++ b/runtime/src/iree/io/formats/irpa/irpa_builder.c
@@ -313,7 +313,7 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_write(
                     .name = name_ref,
                     .metadata = metadata_ref,
                     .minimum_alignment =
-                        IREE_IO_PARAMETER_ARCHIVE_DEFAULT_DATA_ALIGNMENT,
+                        target_entry.storage.file.minimum_alignment,
                 },
             .storage =
                 {
@@ -464,6 +464,7 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_add_data_entry(
                   {
                       .handle = NULL,  // set on commit
                       .offset = storage_offset,
+                      .minimum_alignment = minimum_alignment,
                   },
           },
   };
@@ -509,7 +510,8 @@ IREE_API_EXPORT iree_status_t iree_io_build_parameter_archive(
       case IREE_IO_PARAMETER_INDEX_ENTRY_STORAGE_TYPE_FILE:
         status = iree_io_parameter_archive_builder_add_data_entry(
             &builder, source_entry->key, source_entry->metadata,
-            IREE_IO_PARAMETER_ARCHIVE_DEFAULT_DATA_ALIGNMENT,
+            iree_max(IREE_IO_PARAMETER_ARCHIVE_DEFAULT_DATA_ALIGNMENT,
+                     source_entry->storage.file.minimum_alignment),
             source_entry->length);
         break;
       default:

--- a/runtime/src/iree/io/formats/irpa/irpa_builder.c
+++ b/runtime/src/iree/io/formats/irpa/irpa_builder.c
@@ -14,6 +14,8 @@ typedef struct iree_io_parameter_archive_layout_t {
   iree_io_parameter_archive_range_t metadata_segment;
   // File-backed parameter data range.
   iree_io_parameter_archive_range_t storage_segment;
+  // Required alignment of the archive header in the target file.
+  iree_io_physical_size_t archive_alignment;
   // Final archive size including trailing file-alignment padding.
   iree_io_physical_size_t total_size;
 } iree_io_parameter_archive_layout_t;
@@ -47,6 +49,8 @@ static iree_status_t iree_io_parameter_archive_builder_calculate_layout(
 
   iree_io_parameter_archive_layout_t layout;
   memset(&layout, 0, sizeof(layout));
+  layout.archive_alignment =
+      iree_max(IREE_IO_PARAMETER_ARCHIVE_HEADER_ALIGNMENT, storage_alignment);
   if (!iree_checked_align_u64(sizeof(iree_io_parameter_archive_header_v0_t),
                               IREE_IO_PARAMETER_ARCHIVE_ENTRY_ALIGNMENT,
                               &layout.entry_segment.offset)) {
@@ -81,6 +85,33 @@ static iree_status_t iree_io_parameter_archive_builder_calculate_layout(
   }
 
   *out_layout = layout;
+  return iree_ok_status();
+}
+
+// Verifies that a resolved archive layout can be written at an exact file
+// offset using the signed stream position type.
+static iree_status_t iree_io_parameter_archive_validate_file_range(
+    const iree_io_parameter_archive_layout_t* layout,
+    iree_io_physical_offset_t file_offset) {
+  if (file_offset % layout->archive_alignment != 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "IRPA file offset %" PRIu64
+                            " is not aligned to %" PRIu64 " bytes",
+                            file_offset, layout->archive_alignment);
+  }
+  iree_io_physical_offset_t file_end = 0;
+  if (!iree_checked_add_u64(file_offset, layout->total_size, &file_end)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "IRPA file range overflow (offset=%" PRIu64
+                            ", length=%" PRIu64 ")",
+                            file_offset, layout->total_size);
+  }
+  if (file_end > INT64_MAX) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "IRPA file range end %" PRIu64
+                            " exceeds stream position range",
+                            file_end);
+  }
   return iree_ok_status();
 }
 
@@ -178,6 +209,13 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_write(
   iree_io_parameter_archive_layout_t layout;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_io_parameter_archive_builder_calculate_layout(builder, &layout));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_io_parameter_archive_validate_file_range(&layout, file_offset));
+
+  // The complete file range and relative storage segment have been checked,
+  // so this absolute segment base is representable for every builder entry.
+  const iree_io_physical_offset_t storage_base_offset =
+      file_offset + layout.storage_segment.offset;
 
   // Write the archive header referencing the other segments in the file.
   iree_io_parameter_archive_header_v0_t header = {
@@ -275,7 +313,7 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_write(
                 },
         };
         target_entry.storage.file.handle = file_handle;
-        target_entry.storage.file.offset += layout.storage_segment.offset;
+        target_entry.storage.file.offset += storage_base_offset;
         IREE_RETURN_AND_END_ZONE_IF_ERROR(
             z0, iree_io_stream_write(stream, sizeof(data_entry), &data_entry));
         break;
@@ -473,14 +511,28 @@ IREE_API_EXPORT iree_status_t iree_io_build_parameter_archive(
     if (!iree_status_is_ok(status)) break;
   }
 
-  // Open a file of sufficient size (now that we know it) for writing.
-  iree_io_physical_offset_t archive_offset = iree_align_uint64(
-      target_file_offset, IREE_IO_PARAMETER_ARCHIVE_HEADER_ALIGNMENT);
-  iree_io_physical_size_t archive_length = 0;
+  // Resolve the complete archive range before opening or mutating the target.
+  iree_io_parameter_archive_layout_t layout = {0};
   if (iree_status_is_ok(status)) {
     status =
-        iree_io_parameter_archive_builder_total_size(&builder, &archive_length);
+        iree_io_parameter_archive_builder_calculate_layout(&builder, &layout);
   }
+  iree_io_physical_offset_t archive_offset = 0;
+  if (iree_status_is_ok(status) &&
+      !iree_checked_align_u64(target_file_offset, layout.archive_alignment,
+                              &archive_offset)) {
+    status =
+        iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                         "IRPA file offset alignment overflow (offset=%" PRIu64
+                         ", alignment=%" PRIu64 ")",
+                         target_file_offset, layout.archive_alignment);
+  }
+  if (iree_status_is_ok(status)) {
+    status =
+        iree_io_parameter_archive_validate_file_range(&layout, archive_offset);
+  }
+  const iree_io_physical_size_t archive_length =
+      iree_status_is_ok(status) ? layout.total_size : 0;
   iree_io_file_handle_t* target_file_handle = NULL;
   if (iree_status_is_ok(status)) {
     status = target_file_open.fn(target_file_open.user_data, archive_offset,
@@ -492,14 +544,14 @@ IREE_API_EXPORT iree_status_t iree_io_build_parameter_archive(
   if (iree_status_is_ok(status)) {
     status =
         iree_io_stream_open(IREE_IO_STREAM_MODE_WRITABLE, target_file_handle,
-                            target_file_offset, host_allocator, &target_stream);
+                            archive_offset, host_allocator, &target_stream);
   }
 
   // Commit the archive header to the file and produce an index referencing it.
   // This will allow us to know where to copy file contents.
   if (iree_status_is_ok(status)) {
     status = iree_io_parameter_archive_builder_write(
-        &builder, target_file_handle, target_file_offset, target_stream,
+        &builder, target_file_handle, archive_offset, target_stream,
         target_index);
   }
 
@@ -507,29 +559,40 @@ IREE_API_EXPORT iree_status_t iree_io_build_parameter_archive(
   // This is a slow operation and something we could optimize with lower-level
   // platform primitives.
   if (iree_status_is_ok(status)) {
+    // The writer leaves the stream immediately after the metadata segment.
+    // Track that archive-relative position independently of the stream's
+    // implementation-specific base coordinate.
+    iree_io_physical_offset_t archive_stream_offset =
+        layout.metadata_segment.offset + layout.metadata_segment.length;
     for (iree_host_size_t i = 0;
          i < iree_io_parameter_index_count(source_index); ++i) {
       const iree_io_parameter_index_entry_t* source_entry = NULL;
       status = iree_io_parameter_index_get(source_index, i, &source_entry);
       if (!iree_status_is_ok(status)) break;
-      const iree_io_parameter_index_entry_t* target_entry = NULL;
-      status = iree_io_parameter_index_lookup(target_index, source_entry->key,
-                                              &target_entry);
+      const iree_io_parameter_index_entry_t* builder_entry = NULL;
+      status = iree_io_parameter_index_get(builder.index, i, &builder_entry);
       if (!iree_status_is_ok(status)) break;
       switch (source_entry->type) {
         case IREE_IO_PARAMETER_INDEX_ENTRY_STORAGE_TYPE_SPLAT:
           // No work to do.
           break;
-        case IREE_IO_PARAMETER_INDEX_ENTRY_STORAGE_TYPE_FILE:
+        case IREE_IO_PARAMETER_INDEX_ENTRY_STORAGE_TYPE_FILE: {
+          // Builder storage offsets are monotonically allocated, allowing all
+          // target implementations to use the same forward-only positioning.
+          const iree_io_physical_offset_t target_offset =
+              layout.storage_segment.offset +
+              builder_entry->storage.file.offset;
           status = iree_io_stream_seek(
-              target_stream, IREE_IO_STREAM_SEEK_SET,
-              target_file_offset + target_entry->storage.file.offset);
+              target_stream, IREE_IO_STREAM_SEEK_FROM_CURRENT,
+              (iree_io_stream_pos_t)(target_offset - archive_stream_offset));
           if (!iree_status_is_ok(status)) break;
           status = iree_io_stream_write_file(
               target_stream, source_entry->storage.file.handle,
-              source_entry->storage.file.offset, target_entry->length,
-              host_allocator);
+              source_entry->storage.file.offset,
+              (iree_io_stream_pos_t)source_entry->length, host_allocator);
+          archive_stream_offset = target_offset + source_entry->length;
           break;
+        }
         default:
           status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                                     "unhandled index entry storage type %d",

--- a/runtime/src/iree/io/formats/irpa/irpa_builder.h
+++ b/runtime/src/iree/io/formats/irpa/irpa_builder.h
@@ -27,7 +27,8 @@ extern "C" {
 //  iree_io_parameter_archive_builder_add_data_entry(&builder, ...);
 //  iree_io_parameter_archive_builder_total_size(&builder, &total_size);
 //  << create file of total_size, map into memory >>
-//  iree_io_parameter_archive_builder_write(&builder, file, &target_index);
+//  iree_io_parameter_archive_builder_write(&builder, file, 0, stream,
+//                                          target_index);
 //  << file now contains the full archive header >>
 //  << target_index now references the ranges in the file >>
 //  << write parameter contents, or don't if leaving uninitialized >>
@@ -88,9 +89,11 @@ IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_total_size(
 // Writes the parameter archive to the given |file_handle|. The file must have
 // at least enough storage to fit the size calculated by
 // iree_io_parameter_archive_builder_total_size.
-// The archive will be written starting at the given |file_offset|.
-// Entries for all parameters will be appended to |target_index| referencing
-// the given |file_handle|.
+// The archive will be written starting at the exact |file_offset|, which must
+// satisfy the header and storage alignment requirements. |stream| must already
+// be positioned at that location in |file_handle|. Entries for all parameters
+// will be appended to |target_index| with offsets relative to the base of
+// |file_handle|.
 IREE_API_EXPORT iree_status_t iree_io_parameter_archive_builder_write(
     const iree_io_parameter_archive_builder_t* builder,
     iree_io_file_handle_t* file_handle, iree_io_physical_offset_t file_offset,
@@ -138,6 +141,9 @@ typedef struct {
 // |target_file_open| callback will be used to acquire a handle to a writeable
 // file with enough capacity to fit the whole archive. All parameter contents
 // will be written and flushed to the file prior to returning.
+// |target_file_offset| is the minimum placement offset. The archive may be
+// advanced to satisfy its header and storage alignment requirements; the
+// callback receives the resolved archive offset.
 IREE_API_EXPORT iree_status_t iree_io_build_parameter_archive(
     iree_io_parameter_index_t* source_index,
     iree_io_parameter_index_t* target_index,

--- a/runtime/src/iree/io/formats/irpa/irpa_builder_test.cc
+++ b/runtime/src/iree/io/formats/irpa/irpa_builder_test.cc
@@ -6,6 +6,7 @@
 
 #include "iree/io/formats/irpa/irpa_builder.h"
 
+#include <array>
 #include <limits>
 #include <vector>
 
@@ -15,6 +16,56 @@
 
 namespace iree {
 namespace {
+
+struct BuildArchiveTarget {
+  // Full target file contents allocated by the callback.
+  std::vector<uint8_t> contents;
+  // Resolved archive offset reported to the callback.
+  iree_io_physical_offset_t archive_offset = 0;
+  // Archive byte length reported to the callback.
+  iree_io_physical_size_t archive_length = 0;
+  // Number of times the callback has been invoked.
+  iree_host_size_t open_count = 0;
+  // Whether to link a valid empty archive at offset zero to the built archive.
+  bool link_from_file_start = false;
+};
+
+static iree_status_t OpenBuildArchiveTarget(
+    void* user_data, iree_io_physical_offset_t archive_offset,
+    iree_io_physical_size_t archive_length,
+    iree_io_file_handle_t** out_file_handle) {
+  auto* target = static_cast<BuildArchiveTarget*>(user_data);
+  ++target->open_count;
+  target->archive_offset = archive_offset;
+  target->archive_length = archive_length;
+
+  uint64_t file_length = 0;
+  if (!iree_checked_add_u64(archive_offset, archive_length, &file_length) ||
+      file_length > IREE_HOST_SIZE_MAX) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "test archive allocation range overflow");
+  }
+  target->contents.assign(static_cast<size_t>(file_length), 0xCD);
+  if (target->link_from_file_start) {
+    if (archive_offset < sizeof(iree_io_parameter_archive_header_v0_t)) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "embedded archive overlaps prefix header");
+    }
+    iree_io_parameter_archive_header_v0_t prefix_header = {};
+    prefix_header.prefix.magic = IREE_IO_PARAMETER_ARCHIVE_MAGIC;
+    prefix_header.prefix.version_major = 0;
+    prefix_header.prefix.version_minor = 0;
+    prefix_header.prefix.header_size = sizeof(prefix_header);
+    prefix_header.prefix.next_header_offset = archive_offset;
+    memcpy(target->contents.data(), &prefix_header, sizeof(prefix_header));
+  }
+
+  return iree_io_file_handle_wrap_host_allocation(
+      IREE_IO_FILE_ACCESS_READ | IREE_IO_FILE_ACCESS_WRITE,
+      iree_make_byte_span(target->contents.data(), target->contents.size()),
+      iree_io_file_handle_release_callback_null(), iree_allocator_system(),
+      out_file_handle);
+}
 
 class IrpaBuilderTest : public ::testing::Test {
  protected:
@@ -176,6 +227,129 @@ TEST_F(IrpaBuilderTest, RejectsNonIntegralSplatPattern) {
           &builder_, IREE_SV("invalid"), iree_const_byte_span_empty(), &pattern,
           sizeof(pattern), 6));
   EXPECT_TRUE(iree_io_parameter_archive_builder_is_empty(&builder_));
+}
+
+TEST(IrpaBuilderIntegrationTest, BuildsEmbeddedArchiveAtReportedOffset) {
+  const std::array<uint8_t, 5> source_contents = {1, 3, 5, 7, 9};
+  iree_io_file_handle_t* source_file_handle = NULL;
+  IREE_ASSERT_OK(iree_io_file_handle_wrap_host_allocation(
+      IREE_IO_FILE_ACCESS_READ,
+      iree_make_byte_span(const_cast<uint8_t*>(source_contents.data()),
+                          source_contents.size()),
+      iree_io_file_handle_release_callback_null(), iree_allocator_system(),
+      &source_file_handle));
+  iree_io_parameter_index_t* source_index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &source_index));
+  iree_io_parameter_index_entry_t source_entry = {};
+  source_entry.key = IREE_SV("embedded");
+  source_entry.metadata = iree_const_byte_span_empty();
+  source_entry.length = source_contents.size();
+  source_entry.type = IREE_IO_PARAMETER_INDEX_ENTRY_STORAGE_TYPE_FILE;
+  source_entry.storage.file.handle = source_file_handle;
+  source_entry.storage.file.offset = 0;
+  IREE_ASSERT_OK(iree_io_parameter_index_add(source_index, &source_entry));
+  iree_io_file_handle_release(source_file_handle);
+
+  iree_io_parameter_index_t* target_index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &target_index));
+  BuildArchiveTarget target;
+  target.link_from_file_start = true;
+  const iree_io_parameter_archive_file_open_callback_t open_callback = {
+      /*.fn=*/OpenBuildArchiveTarget,
+      /*.user_data=*/&target,
+  };
+  const iree_io_physical_offset_t requested_offset =
+      sizeof(iree_io_parameter_archive_header_v0_t) + 1;
+  IREE_ASSERT_OK(iree_io_build_parameter_archive(
+      source_index, target_index, open_callback, requested_offset,
+      iree_allocator_system()));
+
+  ASSERT_EQ(1u, target.open_count);
+  const iree_io_physical_size_t archive_alignment =
+      iree_max(IREE_IO_PARAMETER_ARCHIVE_HEADER_ALIGNMENT,
+               IREE_IO_PARAMETER_ARCHIVE_DEFAULT_DATA_ALIGNMENT);
+  ASSERT_EQ(iree_align_uint64(requested_offset, archive_alignment),
+            target.archive_offset);
+  EXPECT_EQ(target.archive_offset + target.archive_length,
+            target.contents.size());
+  EXPECT_EQ(0xCD, target.contents[requested_offset]);
+  const auto* archive_header =
+      reinterpret_cast<const iree_io_parameter_archive_header_v0_t*>(
+          target.contents.data() + target.archive_offset);
+  EXPECT_EQ(IREE_IO_PARAMETER_ARCHIVE_MAGIC, archive_header->prefix.magic);
+
+  const iree_io_parameter_index_entry_t* target_entry = NULL;
+  IREE_ASSERT_OK(iree_io_parameter_index_lookup(
+      target_index, IREE_SV("embedded"), &target_entry));
+  const iree_io_physical_offset_t expected_data_offset =
+      target.archive_offset + archive_header->storage_segment.offset;
+  EXPECT_EQ(expected_data_offset, target_entry->storage.file.offset);
+  EXPECT_EQ(0u, target_entry->storage.file.offset % archive_alignment);
+  EXPECT_EQ(0, memcmp(target.contents.data() + expected_data_offset,
+                      source_contents.data(), source_contents.size()));
+
+  iree_io_file_handle_t* target_file_handle = NULL;
+  IREE_ASSERT_OK(iree_io_file_handle_wrap_host_allocation(
+      IREE_IO_FILE_ACCESS_READ,
+      iree_make_byte_span(target.contents.data(), target.contents.size()),
+      iree_io_file_handle_release_callback_null(), iree_allocator_system(),
+      &target_file_handle));
+  iree_io_parameter_index_t* parsed_index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &parsed_index));
+  IREE_ASSERT_OK(iree_io_parse_irpa_index(target_file_handle, parsed_index,
+                                          iree_allocator_system()));
+  const iree_io_parameter_index_entry_t* parsed_entry = NULL;
+  IREE_ASSERT_OK(iree_io_parameter_index_lookup(
+      parsed_index, IREE_SV("embedded"), &parsed_entry));
+  EXPECT_EQ(expected_data_offset, parsed_entry->storage.file.offset);
+
+  iree_io_parameter_index_release(parsed_index);
+  iree_io_file_handle_release(target_file_handle);
+  iree_io_parameter_index_release(target_index);
+  iree_io_parameter_index_release(source_index);
+}
+
+TEST(IrpaBuilderIntegrationTest, RejectsEmbeddedRangeBeforeOpen) {
+  iree_io_parameter_index_t* source_index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &source_index));
+  iree_io_parameter_index_t* target_index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &target_index));
+  BuildArchiveTarget target;
+  const iree_io_parameter_archive_file_open_callback_t open_callback = {
+      /*.fn=*/OpenBuildArchiveTarget,
+      /*.user_data=*/&target,
+  };
+
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_OUT_OF_RANGE,
+      iree_io_build_parameter_archive(
+          source_index, target_index, open_callback,
+          std::numeric_limits<iree_io_physical_offset_t>::max() - 1,
+          iree_allocator_system()));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_OUT_OF_RANGE,
+      iree_io_build_parameter_archive(
+          source_index, target_index, open_callback,
+          std::numeric_limits<iree_io_physical_offset_t>::max() -
+              (IREE_IO_PARAMETER_ARCHIVE_HEADER_ALIGNMENT - 1),
+          iree_allocator_system()));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_OUT_OF_RANGE,
+      iree_io_build_parameter_archive(
+          source_index, target_index, open_callback,
+          static_cast<iree_io_physical_offset_t>(INT64_MAX) -
+              (IREE_IO_PARAMETER_ARCHIVE_HEADER_ALIGNMENT - 1),
+          iree_allocator_system()));
+  EXPECT_EQ(0u, target.open_count);
+  EXPECT_EQ(0u, iree_io_parameter_index_count(target_index));
+
+  iree_io_parameter_index_release(target_index);
+  iree_io_parameter_index_release(source_index);
 }
 
 }  // namespace

--- a/runtime/src/iree/io/formats/irpa/irpa_builder_test.cc
+++ b/runtime/src/iree/io/formats/irpa/irpa_builder_test.cc
@@ -216,21 +216,6 @@ TEST_F(IrpaBuilderTest, PreservesPerEntryStorageAlignment) {
   IREE_ASSERT_OK(iree_io_parameter_archive_builder_write(
       &builder_, file_handle, 0, stream, built_index));
 
-  const auto* header =
-      reinterpret_cast<const iree_io_parameter_archive_header_v0_t*>(
-          file_contents.data());
-  iree_io_physical_offset_t archive_entry_offset = header->entry_segment.offset;
-  for (iree_host_size_t i = 0; i < keys.size(); ++i) {
-    const auto* data_entry =
-        reinterpret_cast<const iree_io_parameter_archive_data_entry_t*>(
-            file_contents.data() + archive_entry_offset);
-    EXPECT_EQ(minimum_alignments[i], data_entry->header.minimum_alignment);
-    EXPECT_EQ(relative_offsets[i], data_entry->storage.offset);
-    archive_entry_offset =
-        iree_align_uint64(archive_entry_offset + data_entry->header.entry_size,
-                          IREE_IO_PARAMETER_ARCHIVE_ENTRY_ALIGNMENT);
-  }
-
   iree_io_parameter_index_t* parsed_index = NULL;
   IREE_ASSERT_OK(
       iree_io_parameter_index_create(iree_allocator_system(), &parsed_index));

--- a/runtime/src/iree/io/formats/irpa/irpa_builder_test.cc
+++ b/runtime/src/iree/io/formats/irpa/irpa_builder_test.cc
@@ -111,7 +111,7 @@ TEST_F(IrpaBuilderTest, WritesExpectedV0Layout) {
   const iree_io_physical_size_t total_size = TotalSize();
   EXPECT_EQ(4096u, total_size);
 
-  std::vector<uint8_t> file_contents(total_size, 0);
+  std::vector<uint8_t> file_contents(total_size, 0xCD);
   iree_io_file_handle_t* file_handle = NULL;
   IREE_ASSERT_OK(iree_io_file_handle_wrap_host_allocation(
       IREE_IO_FILE_ACCESS_READ | IREE_IO_FILE_ACCESS_WRITE,
@@ -136,6 +136,25 @@ TEST_F(IrpaBuilderTest, WritesExpectedV0Layout) {
   EXPECT_EQ(8u, header->metadata_segment.length);
   EXPECT_EQ(320u, header->storage_segment.offset);
   EXPECT_EQ(69u, header->storage_segment.length);
+
+  iree_io_physical_offset_t entry_offset = header->entry_segment.offset;
+  for (iree_host_size_t i = 0; i < header->entry_count; ++i) {
+    const auto* archive_entry =
+        reinterpret_cast<const iree_io_parameter_archive_entry_header_t*>(
+            file_contents.data() + entry_offset);
+    const iree_io_physical_offset_t unaligned_next_entry_offset =
+        entry_offset + archive_entry->entry_size;
+    const iree_io_physical_offset_t next_entry_offset = iree_align_uint64(
+        unaligned_next_entry_offset, IREE_IO_PARAMETER_ARCHIVE_ENTRY_ALIGNMENT);
+    if (i + 1 < header->entry_count) {
+      for (iree_io_physical_offset_t padding_offset =
+               unaligned_next_entry_offset;
+           padding_offset < next_entry_offset; ++padding_offset) {
+        EXPECT_EQ(0u, file_contents[padding_offset]);
+      }
+    }
+    entry_offset = next_entry_offset;
+  }
 
   const iree_io_parameter_index_entry_t* entry = NULL;
   IREE_ASSERT_OK(

--- a/runtime/src/iree/io/formats/irpa/irpa_builder_test.cc
+++ b/runtime/src/iree/io/formats/irpa/irpa_builder_test.cc
@@ -177,21 +177,83 @@ TEST_F(IrpaBuilderTest, WritesExpectedV0Layout) {
   iree_io_file_handle_release(file_handle);
 }
 
-TEST_F(IrpaBuilderTest, UsesStrongestStorageAlignment) {
+TEST_F(IrpaBuilderTest, PreservesPerEntryStorageAlignment) {
   IREE_ASSERT_OK(iree_io_parameter_archive_builder_add_data_entry(
-      &builder_, IREE_SV("a"), iree_const_byte_span_empty(), 16, 1));
+      &builder_, IREE_SV("a"), iree_const_byte_span_empty(), 0, 1));
   IREE_ASSERT_OK(iree_io_parameter_archive_builder_add_data_entry(
-      &builder_, IREE_SV("b"), iree_const_byte_span_empty(), 256, 1));
+      &builder_, IREE_SV("b"), iree_const_byte_span_empty(), 16, 1));
+  IREE_ASSERT_OK(iree_io_parameter_archive_builder_add_data_entry(
+      &builder_, IREE_SV("c"), iree_const_byte_span_empty(), 256, 1));
 
-  EXPECT_EQ(256u, HeaderSize());
+  EXPECT_EQ(512u, HeaderSize());
   EXPECT_EQ(4096u, TotalSize());
+  const std::array<iree_string_view_t, 3> keys = {IREE_SV("a"), IREE_SV("b"),
+                                                  IREE_SV("c")};
+  const std::array<iree_io_physical_offset_t, 3> relative_offsets = {0, 16,
+                                                                     256};
+  const std::array<iree_io_physical_size_t, 3> minimum_alignments = {0, 16,
+                                                                     256};
   const iree_io_parameter_index_entry_t* entry = NULL;
-  IREE_ASSERT_OK(iree_io_parameter_index_get(builder_.index, 0, &entry));
-  EXPECT_EQ(0u, entry->storage.file.offset);
-  EXPECT_EQ(0u, (HeaderSize() + entry->storage.file.offset) % 16);
-  IREE_ASSERT_OK(iree_io_parameter_index_get(builder_.index, 1, &entry));
-  EXPECT_EQ(256u, entry->storage.file.offset);
-  EXPECT_EQ(0u, (HeaderSize() + entry->storage.file.offset) % 256);
+  for (iree_host_size_t i = 0; i < keys.size(); ++i) {
+    IREE_ASSERT_OK(iree_io_parameter_index_get(builder_.index, i, &entry));
+    EXPECT_EQ(relative_offsets[i], entry->storage.file.offset);
+    EXPECT_EQ(minimum_alignments[i], entry->storage.file.minimum_alignment);
+  }
+
+  std::vector<uint8_t> file_contents(TotalSize(), 0);
+  iree_io_file_handle_t* file_handle = NULL;
+  IREE_ASSERT_OK(iree_io_file_handle_wrap_host_allocation(
+      IREE_IO_FILE_ACCESS_READ | IREE_IO_FILE_ACCESS_WRITE,
+      iree_make_byte_span(file_contents.data(), file_contents.size()),
+      iree_io_file_handle_release_callback_null(), iree_allocator_system(),
+      &file_handle));
+  iree_io_stream_t* stream = NULL;
+  IREE_ASSERT_OK(iree_io_stream_open(IREE_IO_STREAM_MODE_WRITABLE, file_handle,
+                                     0, iree_allocator_system(), &stream));
+  iree_io_parameter_index_t* built_index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &built_index));
+  IREE_ASSERT_OK(iree_io_parameter_archive_builder_write(
+      &builder_, file_handle, 0, stream, built_index));
+
+  const auto* header =
+      reinterpret_cast<const iree_io_parameter_archive_header_v0_t*>(
+          file_contents.data());
+  iree_io_physical_offset_t archive_entry_offset = header->entry_segment.offset;
+  for (iree_host_size_t i = 0; i < keys.size(); ++i) {
+    const auto* data_entry =
+        reinterpret_cast<const iree_io_parameter_archive_data_entry_t*>(
+            file_contents.data() + archive_entry_offset);
+    EXPECT_EQ(minimum_alignments[i], data_entry->header.minimum_alignment);
+    EXPECT_EQ(relative_offsets[i], data_entry->storage.offset);
+    archive_entry_offset =
+        iree_align_uint64(archive_entry_offset + data_entry->header.entry_size,
+                          IREE_IO_PARAMETER_ARCHIVE_ENTRY_ALIGNMENT);
+  }
+
+  iree_io_parameter_index_t* parsed_index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &parsed_index));
+  IREE_ASSERT_OK(iree_io_parse_irpa_index(file_handle, parsed_index,
+                                          iree_allocator_system()));
+  const std::array<iree_io_parameter_index_t*, 2> output_indices = {
+      built_index, parsed_index};
+  for (iree_io_parameter_index_t* output_index : output_indices) {
+    for (iree_host_size_t i = 0; i < keys.size(); ++i) {
+      IREE_ASSERT_OK(
+          iree_io_parameter_index_lookup(output_index, keys[i], &entry));
+      EXPECT_EQ(HeaderSize() + relative_offsets[i], entry->storage.file.offset);
+      EXPECT_EQ(minimum_alignments[i], entry->storage.file.minimum_alignment);
+      if (minimum_alignments[i] != 0) {
+        EXPECT_EQ(0u, entry->storage.file.offset % minimum_alignments[i]);
+      }
+    }
+  }
+
+  iree_io_parameter_index_release(parsed_index);
+  iree_io_parameter_index_release(built_index);
+  iree_io_stream_release(stream);
+  iree_io_file_handle_release(file_handle);
 }
 
 TEST_F(IrpaBuilderTest, TreatsZeroAlignmentAsUnspecified) {
@@ -267,6 +329,7 @@ TEST(IrpaBuilderIntegrationTest, BuildsEmbeddedArchiveAtReportedOffset) {
   source_entry.type = IREE_IO_PARAMETER_INDEX_ENTRY_STORAGE_TYPE_FILE;
   source_entry.storage.file.handle = source_file_handle;
   source_entry.storage.file.offset = 0;
+  source_entry.storage.file.minimum_alignment = 256;
   IREE_ASSERT_OK(iree_io_parameter_index_add(source_index, &source_entry));
   iree_io_file_handle_release(source_file_handle);
 
@@ -288,7 +351,7 @@ TEST(IrpaBuilderIntegrationTest, BuildsEmbeddedArchiveAtReportedOffset) {
   ASSERT_EQ(1u, target.open_count);
   const iree_io_physical_size_t archive_alignment =
       iree_max(IREE_IO_PARAMETER_ARCHIVE_HEADER_ALIGNMENT,
-               IREE_IO_PARAMETER_ARCHIVE_DEFAULT_DATA_ALIGNMENT);
+               source_entry.storage.file.minimum_alignment);
   ASSERT_EQ(iree_align_uint64(requested_offset, archive_alignment),
             target.archive_offset);
   EXPECT_EQ(target.archive_offset + target.archive_length,
@@ -306,6 +369,8 @@ TEST(IrpaBuilderIntegrationTest, BuildsEmbeddedArchiveAtReportedOffset) {
       target.archive_offset + archive_header->storage_segment.offset;
   EXPECT_EQ(expected_data_offset, target_entry->storage.file.offset);
   EXPECT_EQ(0u, target_entry->storage.file.offset % archive_alignment);
+  EXPECT_EQ(source_entry.storage.file.minimum_alignment,
+            target_entry->storage.file.minimum_alignment);
   EXPECT_EQ(0, memcmp(target.contents.data() + expected_data_offset,
                       source_contents.data(), source_contents.size()));
 
@@ -324,6 +389,8 @@ TEST(IrpaBuilderIntegrationTest, BuildsEmbeddedArchiveAtReportedOffset) {
   IREE_ASSERT_OK(iree_io_parameter_index_lookup(
       parsed_index, IREE_SV("embedded"), &parsed_entry));
   EXPECT_EQ(expected_data_offset, parsed_entry->storage.file.offset);
+  EXPECT_EQ(source_entry.storage.file.minimum_alignment,
+            parsed_entry->storage.file.minimum_alignment);
 
   iree_io_parameter_index_release(parsed_index);
   iree_io_file_handle_release(target_file_handle);

--- a/runtime/src/iree/io/formats/irpa/irpa_parser.c
+++ b/runtime/src/iree/io/formats/irpa/irpa_parser.c
@@ -98,11 +98,20 @@ static iree_status_t iree_io_parse_irpa_v0_splat_entry(
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "splat entry length underflow");
   }
-  if (splat_entry->pattern_length > sizeof(splat_entry->pattern)) {
+  if (splat_entry->pattern_length == 0 ||
+      splat_entry->pattern_length >
+          IREE_IO_PARAMETER_MAX_SPLAT_PATTERN_LENGTH ||
+      !iree_is_power_of_two_uint64(splat_entry->pattern_length)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "splat pattern length %u invalid; must be 1, 2, 4, 8, or 16 bytes",
+        splat_entry->pattern_length);
+  }
+  if (splat_entry->length % splat_entry->pattern_length != 0) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "splat pattern length %u out of bounds %" PRIhsz,
-                            splat_entry->pattern_length,
-                            sizeof(splat_entry->pattern));
+                            "splat data length %" PRIu64
+                            " is not evenly divisible by pattern length %u",
+                            splat_entry->length, splat_entry->pattern_length);
   }
   iree_io_parameter_index_entry_t entry = {
       .key = name,

--- a/runtime/src/iree/io/formats/irpa/irpa_parser.c
+++ b/runtime/src/iree/io/formats/irpa/irpa_parser.c
@@ -133,9 +133,24 @@ static iree_status_t iree_io_parse_irpa_v0_data_entry(
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "data entry length underflow");
   }
+  const iree_io_physical_size_t minimum_alignment =
+      data_entry->header.minimum_alignment;
+  if (minimum_alignment != 0 &&
+      !iree_is_power_of_two_uint64(minimum_alignment)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "data entry minimum alignment %" PRIu64
+                            " is not zero or a power of two",
+                            minimum_alignment);
+  }
   iree_io_physical_offset_t storage_offset = 0;
   IREE_RETURN_IF_ERROR(iree_io_resolve_irpa_v0_storage(
       storage_segment, data_entry->storage, &storage_offset));
+  if (minimum_alignment != 0 && storage_offset % minimum_alignment != 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "data entry storage offset %" PRIu64
+                            " is not aligned to %" PRIu64 " bytes",
+                            storage_offset, minimum_alignment);
+  }
   iree_io_parameter_index_entry_t entry = {
       .key = name,
       .metadata = metadata,
@@ -147,6 +162,7 @@ static iree_status_t iree_io_parse_irpa_v0_data_entry(
                   {
                       .handle = file_handle,
                       .offset = storage_offset,
+                      .minimum_alignment = minimum_alignment,
                   },
           },
   };

--- a/runtime/src/iree/io/formats/irpa/irpa_parser_test.cc
+++ b/runtime/src/iree/io/formats/irpa/irpa_parser_test.cc
@@ -106,6 +106,39 @@ static std::vector<uint8_t> BuildLinkedSplatArchive(
   return archive_contents;
 }
 
+static std::vector<uint8_t> BuildDataArchive(
+    iree_io_physical_size_t minimum_alignment,
+    iree_io_physical_offset_t storage_relative_offset) {
+  const iree_host_size_t entry_offset = ArchiveHeaderStride();
+  const iree_host_size_t metadata_offset =
+      entry_offset + sizeof(iree_io_parameter_archive_data_entry_t);
+  const iree_host_size_t storage_segment_offset =
+      (iree_host_size_t)iree_align_uint64(
+          metadata_offset, IREE_IO_PARAMETER_ARCHIVE_DEFAULT_DATA_ALIGNMENT);
+  const iree_host_size_t storage_segment_length =
+      (iree_host_size_t)storage_relative_offset + 1;
+
+  std::vector<uint8_t> archive_contents(
+      storage_segment_offset + storage_segment_length, 0);
+  iree_io_parameter_archive_header_v0_t header = MakeArchiveHeader(0);
+  header.entry_count = 1;
+  header.entry_segment.offset = entry_offset;
+  header.entry_segment.length = sizeof(iree_io_parameter_archive_data_entry_t);
+  header.metadata_segment.offset = metadata_offset;
+  header.storage_segment.offset = storage_segment_offset;
+  header.storage_segment.length = storage_segment_length;
+  WriteArchiveStruct(archive_contents, 0, header);
+
+  iree_io_parameter_archive_data_entry_t entry = {};
+  entry.header.entry_size = sizeof(entry);
+  entry.header.type = IREE_IO_PARAMETER_ARCHIVE_ENTRY_TYPE_DATA;
+  entry.header.minimum_alignment = minimum_alignment;
+  entry.storage.offset = storage_relative_offset;
+  entry.storage.length = 1;
+  WriteArchiveStruct(archive_contents, entry_offset, entry);
+  return archive_contents;
+}
+
 static iree_io_file_handle_t* OpenTestFile(const char* name) {
   const struct iree_file_toc_t* file_toc = iree_io_irpa_files_create();
   for (size_t i = 0; i < iree_io_irpa_files_size(); ++i) {
@@ -347,6 +380,30 @@ TEST(IrpaFormatTest, RejectsOverflowingMetadataReference) {
       iree_io_parameter_index_create(iree_allocator_system(), &index));
 
   IREE_EXPECT_STATUS_IS(IREE_STATUS_OUT_OF_RANGE,
+                        ParseTestArchive(archive_contents, index));
+
+  iree_io_parameter_index_release(index);
+}
+
+TEST(IrpaFormatTest, RejectsNonPowerOfTwoDataAlignment) {
+  std::vector<uint8_t> archive_contents = BuildDataArchive(3, 0);
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        ParseTestArchive(archive_contents, index));
+
+  iree_io_parameter_index_release(index);
+}
+
+TEST(IrpaFormatTest, RejectsMisalignedDataStorage) {
+  std::vector<uint8_t> archive_contents = BuildDataArchive(64, 1);
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
                         ParseTestArchive(archive_contents, index));
 
   iree_io_parameter_index_release(index);

--- a/runtime/src/iree/io/formats/irpa/irpa_parser_test.cc
+++ b/runtime/src/iree/io/formats/irpa/irpa_parser_test.cc
@@ -6,6 +6,7 @@
 
 #include "iree/io/formats/irpa/irpa_parser.h"
 
+#include <array>
 #include <vector>
 
 #include "iree/io/formats/irpa/testdata/irpa_files.h"
@@ -70,7 +71,8 @@ static std::vector<uint8_t> BuildEmptyArchiveChain(
 }
 
 static std::vector<uint8_t> BuildLinkedSplatArchive(
-    iree_io_physical_offset_t name_offset) {
+    iree_io_physical_offset_t name_offset, uint8_t pattern_length = 1,
+    iree_io_physical_size_t data_length = 4) {
   const iree_host_size_t header_stride = ArchiveHeaderStride();
   const iree_host_size_t entry_offset = header_stride;
   const iree_host_size_t metadata_offset =
@@ -97,9 +99,9 @@ static std::vector<uint8_t> BuildLinkedSplatArchive(
   entry.header.type = IREE_IO_PARAMETER_ARCHIVE_ENTRY_TYPE_SPLAT;
   entry.header.name.offset = name_offset;
   entry.header.name.length = key.size;
-  entry.length = 4;
+  entry.length = data_length;
   entry.pattern[0] = 0x5A;
-  entry.pattern_length = 1;
+  entry.pattern_length = pattern_length;
   WriteArchiveStruct(archive_contents, header_stride + entry_offset, entry);
   memcpy(archive_contents.data() + header_stride + metadata_offset, key.data,
          key.size);
@@ -380,6 +382,35 @@ TEST(IrpaFormatTest, RejectsOverflowingMetadataReference) {
       iree_io_parameter_index_create(iree_allocator_system(), &index));
 
   IREE_EXPECT_STATUS_IS(IREE_STATUS_OUT_OF_RANGE,
+                        ParseTestArchive(archive_contents, index));
+
+  iree_io_parameter_index_release(index);
+}
+
+TEST(IrpaFormatTest, RejectsInvalidSplatPatternLengths) {
+  const std::array<uint8_t, 3> invalid_pattern_lengths = {0, 3, 17};
+  for (uint8_t pattern_length : invalid_pattern_lengths) {
+    SCOPED_TRACE(static_cast<unsigned int>(pattern_length));
+    std::vector<uint8_t> archive_contents =
+        BuildLinkedSplatArchive(0, pattern_length, 4);
+    iree_io_parameter_index_t* index = NULL;
+    IREE_ASSERT_OK(
+        iree_io_parameter_index_create(iree_allocator_system(), &index));
+
+    IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                          ParseTestArchive(archive_contents, index));
+
+    iree_io_parameter_index_release(index);
+  }
+}
+
+TEST(IrpaFormatTest, RejectsNonIntegralSplatPattern) {
+  std::vector<uint8_t> archive_contents = BuildLinkedSplatArchive(0, 4, 6);
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
                         ParseTestArchive(archive_contents, index));
 
   iree_io_parameter_index_release(index);

--- a/runtime/src/iree/io/parameter_index.h
+++ b/runtime/src/iree/io/parameter_index.h
@@ -63,6 +63,9 @@ typedef struct iree_io_parameter_index_entry_t {
       iree_io_file_handle_t* handle;
       // Offset of the entry in bytes relative to the base file offset.
       uint64_t offset;
+      // Minimum required byte alignment of the file offset, or zero if
+      // unspecified.
+      uint64_t minimum_alignment;
     } file;
   } storage;
 } iree_io_parameter_index_entry_t;


### PR DESCRIPTION
IRPA's writer and parser disagreed with several format invariants that were easy to miss with standalone, zero-initialized files. Embedded archives could open and write at different offsets, seeks left entry-table padding stale in caller-owned storage, every data entry declared a fixed 64-byte alignment regardless of its requested layout, and malformed splats could enter the parameter index.

Resolve one archive base from the header and strongest storage alignment, validate the complete range before invoking the target callback, and use that base consistently for opening, writing, and target-index entries. Serialized ranges remain header-relative, while data copies use forward archive-relative movement independent of the stream implementation's base coordinate. Entry alignment gaps are emitted explicitly as zero bytes instead of skipped.

File-backed index entries now retain the minimum alignment beside the handle and offset it governs, using representation capacity already required by the splat variant. The low-level builder serializes each exact request, while archive conversion preserves its 64-byte output floor and honors stronger source requirements. The public parser rejects invalid alignment declarations, resolved offsets that violate them, illegal splat pattern lengths, and splat patterns that do not evenly tile the logical entry length.

GGUF's variable-length header leaves later scalar fields byte-aligned. Keep tensor dimension arrays byte-backed, decode dimensions and structural integers with unaligned little-endian loads, and construct string views without pointer-to-pointer type punning. The parser's real fixtures now run in CPU sanitizer CI instead of being excluded.

The coverage embeds a linked archive after an unaligned valid prefix, writes entry records into nonzero-initialized storage, round-trips mixed zero/16/256 byte alignments through returned and parsed indices, and constructs malformed archives for each rejected IRPA parser contract. Existing GGUF fixtures exercise byte-aligned tensor dimensions through the public parser.
