### PR TITLE
[Runtime/IO] Enforce GGUF bounds and alignment invariants

### DIFF
--- a/runtime/src/iree/io/formats/gguf/gguf_parser.c
+++ b/runtime/src/iree/io/formats/gguf/gguf_parser.c
@@ -530,7 +530,11 @@ static iree_status_t iree_io_gguf_parse_array(iree_const_byte_span_t* contents,
                                               uint64_t element_count,
                                               uint64_t element_size,
                                               const uint8_t** out_base_ptr) {
-  uint64_t total_length = element_count * element_size;
+  uint64_t total_length = 0;
+  if (!iree_checked_mul_u64(element_count, element_size, &total_length)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "GGUF array byte length overflow");
+  }
   if (total_length > IREE_HOST_SIZE_MAX) {
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                             "attempting to load a 64-bit file on a 32-bit arch "

--- a/runtime/src/iree/io/formats/gguf/gguf_parser.c
+++ b/runtime/src/iree/io/formats/gguf/gguf_parser.c
@@ -798,6 +798,12 @@ static iree_status_t iree_io_parse_gguf_index_from_memory(
   parser.tensor_data_offset = iree_align_uint64(
       (uint64_t)(tensor_info_contents.data - file_contents.data),
       parser.alignment);
+  if (parser.tensor_data_offset > file_contents.data_length) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "GGUF tensor data offset %" PRIu64 " exceeds file length %" PRIhsz,
+        parser.tensor_data_offset, file_contents.data_length);
+  }
   parser.tensor_data_size =
       file_contents.data_length - parser.tensor_data_offset;
 

--- a/runtime/src/iree/io/formats/gguf/gguf_parser.c
+++ b/runtime/src/iree/io/formats/gguf/gguf_parser.c
@@ -49,6 +49,7 @@
 #define GGUF_MIN_VERSION 2
 #define GGUF_MAX_VERSION 3
 #define GGUF_DEFAULT_ALIGNMENT 32
+#define GGUF_ALIGNMENT_MULTIPLE 8u
 
 enum ggml_type_e {
   GGML_TYPE_F32 = 0,
@@ -450,6 +451,20 @@ typedef struct iree_io_gguf_parser_t {
   uint64_t tensor_data_size;
 } iree_io_gguf_parser_t;
 
+// Aligns |value| up to an arbitrary nonzero |alignment| while checking for
+// overflow.
+static bool iree_io_gguf_checked_align_u64(uint64_t value, uint32_t alignment,
+                                           uint64_t* out_aligned_value) {
+  const uint64_t remainder = value % alignment;
+  const uint64_t padding = remainder == 0 ? 0 : alignment - remainder;
+  return iree_checked_add_u64(value, padding, out_aligned_value);
+}
+
+// Returns the strongest power-of-two alignment guaranteed by |alignment|.
+static uint64_t iree_io_gguf_power_of_two_alignment(uint32_t alignment) {
+  return alignment & (~alignment + 1u);
+}
+
 static iree_status_t iree_io_gguf_calculate_storage_size(
     const gguf_tensor_info_t* tensor_info, uint64_t* out_storage_size) {
   *out_storage_size = 0;
@@ -689,6 +704,13 @@ static iree_status_t iree_io_gguf_parse_metadata(void* user_data,
           IREE_STATUS_INVALID_ARGUMENT,
           "general.alignment metadata value must be uint32");
     }
+    if (kv->value.uint32 == 0 ||
+        kv->value.uint32 % GGUF_ALIGNMENT_MULTIPLE != 0) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "general.alignment must be a nonzero multiple of %u (got %u)",
+          GGUF_ALIGNMENT_MULTIPLE, kv->value.uint32);
+    }
     parser->alignment = kv->value.uint32;
   }
   return iree_ok_status();
@@ -697,6 +719,12 @@ static iree_status_t iree_io_gguf_parse_metadata(void* user_data,
 static iree_status_t iree_io_gguf_append_tensor_info(
     void* user_data, const gguf_tensor_info_t* tensor_info) {
   iree_io_gguf_parser_t* parser = (iree_io_gguf_parser_t*)user_data;
+  if (tensor_info->offset % parser->alignment != 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "tensor offset %" PRIu64
+                            " is not aligned to %u bytes",
+                            tensor_info->offset, parser->alignment);
+  }
 
   // Unfortunately (I've said that a lot here?) the total size of the tensor is
   // not stored and as such we need to calculate it based on the metadata we
@@ -730,6 +758,8 @@ static iree_status_t iree_io_gguf_append_tensor_info(
                   {
                       .handle = parser->file_handle,
                       .offset = parser->tensor_data_offset + begin,
+                      .minimum_alignment = iree_io_gguf_power_of_two_alignment(
+                          parser->alignment),
                   },
           },
   };
@@ -795,9 +825,16 @@ static iree_status_t iree_io_parse_gguf_index_from_memory(
 
   // Calculate where the tensor data begins in the file. This respects the
   // default alignment or the general.alignment specified by the file.
-  parser.tensor_data_offset = iree_align_uint64(
-      (uint64_t)(tensor_info_contents.data - file_contents.data),
-      parser.alignment);
+  const uint64_t unaligned_tensor_data_offset =
+      (uint64_t)(tensor_info_contents.data - file_contents.data);
+  if (!iree_io_gguf_checked_align_u64(unaligned_tensor_data_offset,
+                                      parser.alignment,
+                                      &parser.tensor_data_offset)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "GGUF tensor data offset overflow aligning %" PRIu64
+                            " to %u bytes",
+                            unaligned_tensor_data_offset, parser.alignment);
+  }
   if (parser.tensor_data_offset > file_contents.data_length) {
     return iree_make_status(
         IREE_STATUS_OUT_OF_RANGE,

--- a/runtime/src/iree/io/formats/gguf/gguf_parser_test.cc
+++ b/runtime/src/iree/io/formats/gguf/gguf_parser_test.cc
@@ -170,6 +170,25 @@ TEST(GgufFormatTest, RejectsOverflowingMetadataArrayLength) {
   iree_io_parameter_index_release(index);
 }
 
+TEST(GgufFormatTest, RejectsTruncatedTensorData) {
+  std::vector<uint8_t> file_contents = CopyTestFile("single.gguf");
+
+  static constexpr size_t kTensorDataOffset = 384;
+  ASSERT_GT(file_contents.size(), kTensorDataOffset);
+  file_contents.resize(kTensorDataOffset - 1);
+
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+  iree_io_file_handle_t* file_handle = OpenTestFileContents(
+      iree_make_byte_span(file_contents.data(), file_contents.size()));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_OUT_OF_RANGE,
+      iree_io_parse_gguf_index(file_handle, index, iree_allocator_system()));
+  iree_io_file_handle_release(file_handle);
+  iree_io_parameter_index_release(index);
+}
+
 // Tests that GGUF version 2 parses. Other tests use version 3.
 TEST(GgufFormatTest, SingleTensorV2) {
   iree_io_parameter_index_t* index = NULL;

--- a/runtime/src/iree/io/formats/gguf/gguf_parser_test.cc
+++ b/runtime/src/iree/io/formats/gguf/gguf_parser_test.cc
@@ -16,6 +16,7 @@
 namespace iree {
 namespace {
 
+static constexpr uint32_t kMetadataValueTypeUint32 = 4;
 static constexpr uint32_t kMetadataValueTypeString = 8;
 static constexpr uint32_t kMetadataValueTypeArray = 9;
 static constexpr uint32_t kMetadataValueTypeUint64 = 10;
@@ -61,25 +62,54 @@ static size_t FindTextOffset(const std::vector<uint8_t>& file_contents,
   return (size_t)(text_position - file_contents.begin());
 }
 
+static void SetGeneralAlignment(uint32_t alignment,
+                                std::vector<uint8_t>* file_contents) {
+  static constexpr char kMetadataKey[] = "general.alignment";
+  const size_t metadata_key_offset =
+      FindTextOffset(*file_contents, kMetadataKey);
+  const size_t value_type_offset =
+      metadata_key_offset + sizeof(kMetadataKey) - 1;
+  const size_t alignment_offset = value_type_offset + sizeof(uint32_t);
+  IREE_ASSERT(alignment_offset + sizeof(uint32_t) <= file_contents->size());
+  IREE_ASSERT(
+      iree_unaligned_load_le_u32(file_contents->data() + value_type_offset) ==
+      kMetadataValueTypeUint32);
+  iree_unaligned_store_le_u32(file_contents->data() + alignment_offset,
+                              alignment);
+}
+
+static size_t FindFirstTensorTypeOffset(
+    const std::vector<uint8_t>& file_contents) {
+  static constexpr char kTensorName[] = "tensor0";
+  const size_t tensor_name_offset = FindTextOffset(file_contents, kTensorName);
+  const size_t dimension_count_offset =
+      tensor_name_offset + sizeof(kTensorName) - 1;
+  IREE_ASSERT(dimension_count_offset + sizeof(uint32_t) <=
+              file_contents.size());
+  const uint32_t dimension_count =
+      iree_unaligned_load_le_u32(file_contents.data() + dimension_count_offset);
+  const size_t tensor_type_offset = dimension_count_offset +
+                                    sizeof(dimension_count) +
+                                    dimension_count * sizeof(uint64_t);
+  IREE_ASSERT(tensor_type_offset + sizeof(uint32_t) <= file_contents.size());
+  return tensor_type_offset;
+}
+
+static void SetFirstTensorOffset(uint64_t offset,
+                                 std::vector<uint8_t>* file_contents) {
+  const size_t tensor_offset_offset =
+      FindFirstTensorTypeOffset(*file_contents) + sizeof(uint32_t);
+  IREE_ASSERT(tensor_offset_offset + sizeof(uint64_t) <= file_contents->size());
+  iree_unaligned_store_le_u64(file_contents->data() + tensor_offset_offset,
+                              offset);
+}
+
 static iree_io_file_handle_t* OpenTestFileWithFirstTensorType(
     const char* name, uint32_t tensor_type,
     std::vector<uint8_t>* out_file_contents) {
   *out_file_contents = CopyTestFile(name);
-
-  static constexpr char kTensorName[] = "tensor0";
-  const size_t tensor_name_offset =
-      FindTextOffset(*out_file_contents, kTensorName);
-  const size_t dimension_count_offset =
-      tensor_name_offset + sizeof(kTensorName) - 1;
-  IREE_ASSERT(dimension_count_offset + sizeof(uint32_t) <=
-              out_file_contents->size());
-  const uint32_t dimension_count = iree_unaligned_load_le_u32(
-      out_file_contents->data() + dimension_count_offset);
-  const size_t tensor_type_offset = dimension_count_offset +
-                                    sizeof(dimension_count) +
-                                    dimension_count * sizeof(uint64_t);
-  IREE_ASSERT(tensor_type_offset + sizeof(tensor_type) <=
-              out_file_contents->size());
+  const size_t tensor_type_offset =
+      FindFirstTensorTypeOffset(*out_file_contents);
   iree_unaligned_store_le_u32(out_file_contents->data() + tensor_type_offset,
                               tensor_type);
 
@@ -116,6 +146,7 @@ TEST(GgufFormatTest, SingleTensor) {
   EXPECT_TRUE(iree_string_view_equal(IREE_SV("tensor0"), entry0->key));
   EXPECT_TRUE(iree_const_byte_span_is_empty(entry0->metadata));
   EXPECT_EQ(entry0->storage.file.offset, 384);
+  EXPECT_EQ(entry0->storage.file.minimum_alignment, 64);
   EXPECT_EQ(entry0->length, 16);
 
   iree_io_parameter_index_release(index);
@@ -189,6 +220,71 @@ TEST(GgufFormatTest, RejectsTruncatedTensorData) {
   iree_io_parameter_index_release(index);
 }
 
+TEST(GgufFormatTest, RejectsInvalidTensorAlignments) {
+  static constexpr uint32_t kInvalidAlignments[] = {0, 10};
+  for (uint32_t alignment : kInvalidAlignments) {
+    SCOPED_TRACE(alignment);
+    std::vector<uint8_t> file_contents = CopyTestFile("single.gguf");
+    SetGeneralAlignment(alignment, &file_contents);
+
+    iree_io_parameter_index_t* index = NULL;
+    IREE_ASSERT_OK(
+        iree_io_parameter_index_create(iree_allocator_system(), &index));
+    iree_io_file_handle_t* file_handle = OpenTestFileContents(
+        iree_make_byte_span(file_contents.data(), file_contents.size()));
+    IREE_EXPECT_STATUS_IS(
+        IREE_STATUS_INVALID_ARGUMENT,
+        iree_io_parse_gguf_index(file_handle, index, iree_allocator_system()));
+    iree_io_file_handle_release(file_handle);
+    iree_io_parameter_index_release(index);
+  }
+}
+
+TEST(GgufFormatTest, SupportsNonPowerOfTwoTensorAlignment) {
+  std::vector<uint8_t> file_contents = CopyTestFile("single.gguf");
+  SetGeneralAlignment(24, &file_contents);
+
+  static constexpr size_t kAlignedTensorDataOffset = 336;
+  static constexpr size_t kOriginalTensorDataOffset = 384;
+  ASSERT_LE(kOriginalTensorDataOffset, file_contents.size());
+  file_contents.erase(file_contents.begin() + kAlignedTensorDataOffset,
+                      file_contents.begin() + kOriginalTensorDataOffset);
+
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+  iree_io_file_handle_t* file_handle = OpenTestFileContents(
+      iree_make_byte_span(file_contents.data(), file_contents.size()));
+  IREE_ASSERT_OK(
+      iree_io_parse_gguf_index(file_handle, index, iree_allocator_system()));
+  iree_io_file_handle_release(file_handle);
+
+  const iree_io_parameter_index_entry_t* entry = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_lookup(index, IREE_SV("tensor0"), &entry));
+  EXPECT_EQ(entry->storage.file.offset, kAlignedTensorDataOffset);
+  EXPECT_EQ(entry->storage.file.minimum_alignment, 8);
+  EXPECT_EQ(entry->length, 16);
+
+  iree_io_parameter_index_release(index);
+}
+
+TEST(GgufFormatTest, RejectsMisalignedTensorOffset) {
+  std::vector<uint8_t> file_contents = CopyTestFile("single.gguf");
+  SetFirstTensorOffset(1, &file_contents);
+
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+  iree_io_file_handle_t* file_handle = OpenTestFileContents(
+      iree_make_byte_span(file_contents.data(), file_contents.size()));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_io_parse_gguf_index(file_handle, index, iree_allocator_system()));
+  iree_io_file_handle_release(file_handle);
+  iree_io_parameter_index_release(index);
+}
+
 // Tests that GGUF version 2 parses. Other tests use version 3.
 TEST(GgufFormatTest, SingleTensorV2) {
   iree_io_parameter_index_t* index = NULL;
@@ -206,6 +302,7 @@ TEST(GgufFormatTest, SingleTensorV2) {
   EXPECT_TRUE(iree_string_view_equal(IREE_SV("tensor0"), entry0->key));
   EXPECT_TRUE(iree_const_byte_span_is_empty(entry0->metadata));
   EXPECT_EQ(entry0->storage.file.offset, 384);
+  EXPECT_EQ(entry0->storage.file.minimum_alignment, 64);
   EXPECT_EQ(entry0->length, 16);
 
   iree_io_parameter_index_release(index);
@@ -227,6 +324,7 @@ TEST(GgufFormatTest, MultipleTensors) {
   EXPECT_TRUE(iree_string_view_equal(IREE_SV("tensor0"), entry0->key));
   EXPECT_TRUE(iree_const_byte_span_is_empty(entry0->metadata));
   EXPECT_EQ(entry0->storage.file.offset, 448);
+  EXPECT_EQ(entry0->storage.file.minimum_alignment, 64);
   EXPECT_EQ(entry0->length, 16);
 
   const iree_io_parameter_index_entry_t* entry1 = NULL;
@@ -235,6 +333,7 @@ TEST(GgufFormatTest, MultipleTensors) {
   EXPECT_TRUE(iree_string_view_equal(IREE_SV("tensor1"), entry1->key));
   EXPECT_TRUE(iree_const_byte_span_is_empty(entry1->metadata));
   EXPECT_EQ(entry1->storage.file.offset, 512);
+  EXPECT_EQ(entry1->storage.file.minimum_alignment, 64);
   EXPECT_EQ(entry1->length, 8);
 
   const iree_io_parameter_index_entry_t* entry2 = NULL;
@@ -243,6 +342,7 @@ TEST(GgufFormatTest, MultipleTensors) {
   EXPECT_TRUE(iree_string_view_equal(IREE_SV("tensor2"), entry2->key));
   EXPECT_TRUE(iree_const_byte_span_is_empty(entry2->metadata));
   EXPECT_EQ(entry2->storage.file.offset, 576);
+  EXPECT_EQ(entry2->storage.file.minimum_alignment, 64);
   EXPECT_EQ(entry2->length, 48);
 
   iree_io_parameter_index_release(index);

--- a/runtime/src/iree/io/formats/gguf/gguf_parser_test.cc
+++ b/runtime/src/iree/io/formats/gguf/gguf_parser_test.cc
@@ -16,18 +16,14 @@
 namespace iree {
 namespace {
 
-static iree_io_file_handle_t* OpenTestFile(const char* name) {
-  const struct iree_file_toc_t* file_toc = iree_io_gguf_files_create();
+static constexpr uint32_t kMetadataValueTypeString = 8;
+static constexpr uint32_t kMetadataValueTypeArray = 9;
+static constexpr uint32_t kMetadataValueTypeUint64 = 10;
+
+static const struct iree_file_toc_t* FindTestFile(const char* name) {
+  const struct iree_file_toc_t* files = iree_io_gguf_files_create();
   for (size_t i = 0; i < iree_io_gguf_files_size(); ++i) {
-    if (strcmp(file_toc[i].name, name) == 0) {
-      iree_io_file_handle_t* file_handle = NULL;
-      IREE_CHECK_OK(iree_io_file_handle_wrap_host_allocation(
-          IREE_IO_FILE_ACCESS_READ,
-          iree_make_byte_span((void*)file_toc[i].data, file_toc[i].size),
-          iree_io_file_handle_release_callback_null(), iree_allocator_system(),
-          &file_handle));
-      return file_handle;
-    }
+    if (strcmp(files[i].name, name) == 0) return &files[i];
   }
   IREE_CHECK_OK(iree_make_status(
       IREE_STATUS_NOT_FOUND,
@@ -35,49 +31,60 @@ static iree_io_file_handle_t* OpenTestFile(const char* name) {
   return NULL;
 }
 
+static iree_io_file_handle_t* OpenTestFileContents(
+    iree_byte_span_t file_contents) {
+  iree_io_file_handle_t* file_handle = NULL;
+  IREE_CHECK_OK(iree_io_file_handle_wrap_host_allocation(
+      IREE_IO_FILE_ACCESS_READ, file_contents,
+      iree_io_file_handle_release_callback_null(), iree_allocator_system(),
+      &file_handle));
+  return file_handle;
+}
+
+static iree_io_file_handle_t* OpenTestFile(const char* name) {
+  const struct iree_file_toc_t* file = FindTestFile(name);
+  return OpenTestFileContents(
+      iree_make_byte_span((void*)file->data, file->size));
+}
+
+static std::vector<uint8_t> CopyTestFile(const char* name) {
+  const struct iree_file_toc_t* file = FindTestFile(name);
+  return std::vector<uint8_t>(file->data, file->data + file->size);
+}
+
+template <size_t N>
+static size_t FindTextOffset(const std::vector<uint8_t>& file_contents,
+                             const char (&text)[N]) {
+  auto text_position = std::search(file_contents.begin(), file_contents.end(),
+                                   text, text + N - 1);
+  IREE_ASSERT(text_position != file_contents.end());
+  return (size_t)(text_position - file_contents.begin());
+}
+
 static iree_io_file_handle_t* OpenTestFileWithFirstTensorType(
     const char* name, uint32_t tensor_type,
     std::vector<uint8_t>* out_file_contents) {
-  const struct iree_file_toc_t* files = iree_io_gguf_files_create();
-  const struct iree_file_toc_t* file = NULL;
-  for (size_t i = 0; i < iree_io_gguf_files_size(); ++i) {
-    if (strcmp(files[i].name, name) == 0) {
-      file = &files[i];
-      break;
-    }
-  }
-  IREE_ASSERT(file != NULL);
-  out_file_contents->assign(file->data, file->data + file->size);
+  *out_file_contents = CopyTestFile(name);
 
   static constexpr char kTensorName[] = "tensor0";
-  auto tensor_name =
-      std::search(out_file_contents->begin(), out_file_contents->end(),
-                  kTensorName, kTensorName + sizeof(kTensorName) - 1);
-  IREE_ASSERT(tensor_name != out_file_contents->end());
   const size_t tensor_name_offset =
-      (size_t)(tensor_name - out_file_contents->begin());
+      FindTextOffset(*out_file_contents, kTensorName);
   const size_t dimension_count_offset =
       tensor_name_offset + sizeof(kTensorName) - 1;
   IREE_ASSERT(dimension_count_offset + sizeof(uint32_t) <=
               out_file_contents->size());
-  uint32_t dimension_count = 0;
-  memcpy(&dimension_count, out_file_contents->data() + dimension_count_offset,
-         sizeof(dimension_count));
+  const uint32_t dimension_count = iree_unaligned_load_le_u32(
+      out_file_contents->data() + dimension_count_offset);
   const size_t tensor_type_offset = dimension_count_offset +
                                     sizeof(dimension_count) +
                                     dimension_count * sizeof(uint64_t);
   IREE_ASSERT(tensor_type_offset + sizeof(tensor_type) <=
               out_file_contents->size());
-  memcpy(out_file_contents->data() + tensor_type_offset, &tensor_type,
-         sizeof(tensor_type));
+  iree_unaligned_store_le_u32(out_file_contents->data() + tensor_type_offset,
+                              tensor_type);
 
-  iree_io_file_handle_t* file_handle = NULL;
-  IREE_CHECK_OK(iree_io_file_handle_wrap_host_allocation(
-      IREE_IO_FILE_ACCESS_READ,
-      iree_make_byte_span(out_file_contents->data(), out_file_contents->size()),
-      iree_io_file_handle_release_callback_null(), iree_allocator_system(),
-      &file_handle));
-  return file_handle;
+  return OpenTestFileContents(iree_make_byte_span(out_file_contents->data(),
+                                                  out_file_contents->size()));
 }
 
 TEST(GgufFormatTest, Empty) {
@@ -111,6 +118,55 @@ TEST(GgufFormatTest, SingleTensor) {
   EXPECT_EQ(entry0->storage.file.offset, 384);
   EXPECT_EQ(entry0->length, 16);
 
+  iree_io_parameter_index_release(index);
+}
+
+TEST(GgufFormatTest, RejectsOverflowingMetadataArrayLength) {
+  std::vector<uint8_t> file_contents = CopyTestFile("single.gguf");
+
+  static constexpr char kMetadataKey[] = "metadata_strs";
+  const size_t metadata_key_offset =
+      FindTextOffset(file_contents, kMetadataKey);
+  const size_t value_type_offset =
+      metadata_key_offset + sizeof(kMetadataKey) - 1;
+  const size_t array_element_type_offset = value_type_offset + sizeof(uint32_t);
+  const size_t array_length_offset =
+      array_element_type_offset + sizeof(uint32_t);
+  const size_t array_data_offset = array_length_offset + sizeof(uint64_t);
+  ASSERT_LE(array_data_offset, file_contents.size());
+  EXPECT_EQ(
+      iree_unaligned_load_le_u32(file_contents.data() + value_type_offset),
+      kMetadataValueTypeArray);
+  EXPECT_EQ(iree_unaligned_load_le_u32(file_contents.data() +
+                                       array_element_type_offset),
+            kMetadataValueTypeString);
+  EXPECT_EQ(
+      iree_unaligned_load_le_u64(file_contents.data() + array_length_offset),
+      3u);
+
+  static constexpr char kTensorName[] = "tensor0";
+  const size_t tensor_name_offset = FindTextOffset(file_contents, kTensorName);
+  ASSERT_GE(tensor_name_offset, sizeof(uint64_t));
+  const size_t tensor_info_offset = tensor_name_offset - sizeof(uint64_t);
+  ASSERT_LE(array_data_offset, tensor_info_offset);
+
+  iree_unaligned_store_le_u32(file_contents.data() + array_element_type_offset,
+                              kMetadataValueTypeUint64);
+  const uint64_t overflowing_element_count = UINT64_MAX / sizeof(uint64_t) + 1;
+  iree_unaligned_store_le_u64(file_contents.data() + array_length_offset,
+                              overflowing_element_count);
+  file_contents.erase(file_contents.begin() + array_data_offset,
+                      file_contents.begin() + tensor_info_offset);
+
+  iree_io_parameter_index_t* index = NULL;
+  IREE_ASSERT_OK(
+      iree_io_parameter_index_create(iree_allocator_system(), &index));
+  iree_io_file_handle_t* file_handle = OpenTestFileContents(
+      iree_make_byte_span(file_contents.data(), file_contents.size()));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_io_parse_gguf_index(file_handle, index, iree_allocator_system()));
+  iree_io_file_handle_release(file_handle);
   iree_io_parameter_index_release(index);
 }
 


### PR DESCRIPTION
This hardens three independent contracts at the public GGUF parsing boundary, with each repair kept in its own commit.

Metadata array byte extents are now computed with checked 64-bit multiplication before host-size conversion, file bounds checks, or cursor movement. An overflowing element count previously wrapped the extent and allowed array payload to be reinterpreted as later tensor metadata.

The aligned tensor-data base is now checked against the mapped file before deriving the remaining data length. A file containing a complete header and tensor-info record but ending before the aligned data region previously underflowed that subtraction and produced an apparently valid tensor range beyond EOF.

Alignment handling now implements GGUF's actual contract: `general.alignment` must be a nonzero multiple of 8, but need not be a power of two; tensor-relative offsets must be multiples of that value; and tensor-data base alignment uses checked arithmetic for arbitrary valid multiples. Parameter index entries retain the strongest power-of-two alignment guaranteed by the file, so a 64-byte file reports 64 while a valid 24-byte file reports 8.

The regressions mutate the existing production GGUF fixture to preserve realistic header and tensor layouts. They cover the overflowing array extent, truncated data region, zero and non-multiple-of-8 alignments, a valid 24-byte alignment whose data begins at byte 336, a misaligned tensor-relative offset, and alignment propagation for existing valid fixtures.
