### PR TITLE
[Loom] Defer placement through required inlining

### DIFF
--- a/loom/py/loom/BUILD.bazel
+++ b/loom/py/loom/BUILD.bazel
@@ -78,6 +78,7 @@ iree_py_test(
     main = "pytest_style_runner.py",
     deps = [
         ":package",
+        "//loom/py/loom/dialect/func",
         "//loom/py/loom/dialect/test",
         "//loom/py/loom/format/bytecode",
         "//loom/py/loom/format/text",

--- a/loom/py/loom/CMakeLists.txt
+++ b/loom/py/loom/CMakeLists.txt
@@ -74,6 +74,7 @@ iree_py_test(
     "loom.verify_test"
   DEPS
     loom::py::loom::package
+    loom::py::loom::dialect::func::func
     loom::py::loom::dialect::test::test
     loom::py::loom::format::bytecode::bytecode
     loom::py::loom::format::text::text

--- a/loom/py/loom/dialect/func/defs.py
+++ b/loom/py/loom/dialect/func/defs.py
@@ -129,6 +129,9 @@ InlinePolicy = EnumDef(
         EnumCase("noinline", 2, doc="Preserve the callable boundary."),
     ],
     doc="Author inline policy. Absent (0) leaves the edge to the current pass.",
+    c_type="loom_inline_policy_t",
+    c_const_prefix="LOOM_INLINE_POLICY",
+    c_include="loom/ir/ir.h",
 )
 
 _RETAIN_ATTR = AttrDef("retain", "enum", enum_def=Retain, optional=True)

--- a/loom/py/loom/dialect/func/defs.py
+++ b/loom/py/loom/dialect/func/defs.py
@@ -59,6 +59,7 @@ from loom.dsl import (
     EnumCase,
     EnumDef,
     FuncLikeInterface,
+    InlinePolicy,
     Op,
     Operand,
     OpPhase,
@@ -122,11 +123,19 @@ Temperature = EnumDef(
     doc="Execution temperature hint. Absent (0) means unspecified.",
 )
 
-InlinePolicy = EnumDef(
+InlinePolicyAttr = EnumDef(
     "InlinePolicy",
     [
-        EnumCase("inline", 1, doc="Require inlining at the current IR stage."),
-        EnumCase("noinline", 2, doc="Preserve the callable boundary."),
+        EnumCase(
+            "inline",
+            InlinePolicy.INLINE.value,
+            doc="Require inlining at the current IR stage.",
+        ),
+        EnumCase(
+            "noinline",
+            InlinePolicy.NOINLINE.value,
+            doc="Preserve the callable boundary.",
+        ),
     ],
     doc="Author inline policy. Absent (0) leaves the edge to the current pass.",
     c_type="loom_inline_policy_t",
@@ -236,7 +245,7 @@ _MODIFIER_ATTRS = [
     AttrDef("cc", "enum", enum_def=CallingConv, optional=True),
     AttrDef("purity", "enum", enum_def=Purity, optional=True),
     AttrDef("temperature", "enum", enum_def=Temperature, optional=True),
-    AttrDef("inline_policy", "enum", enum_def=InlinePolicy, optional=True),
+    AttrDef("inline_policy", "enum", enum_def=InlinePolicyAttr, optional=True),
     AttrDef("predicates", "predicate_list", optional=True),
 ]
 
@@ -277,7 +286,7 @@ _DECL_ATTRS = [
     AttrDef("cc", "enum", enum_def=CallingConv, optional=True),
     AttrDef("purity", "enum", enum_def=Purity, optional=True),
     AttrDef("temperature", "enum", enum_def=Temperature, optional=True),
-    AttrDef("inline_policy", "enum", enum_def=InlinePolicy, optional=True),
+    AttrDef("inline_policy", "enum", enum_def=InlinePolicyAttr, optional=True),
     *_CONTRACT_ATTRS,
     AttrDef("predicates", "predicate_list", optional=True),
     _RETAIN_ATTR,
@@ -525,7 +534,7 @@ func_call = Op(
         ),
         AttrDef("purity", "enum", enum_def=Purity, optional=True),
         AttrDef("temperature", "enum", enum_def=Temperature, optional=True),
-        AttrDef("inline_policy", "enum", enum_def=InlinePolicy, optional=True),
+        AttrDef("inline_policy", "enum", enum_def=InlinePolicyAttr, optional=True),
     ],
     results=[Result("results", ANY, variadic=True)],
     traits=[UNKNOWN_EFFECTS],

--- a/loom/py/loom/dsl.py
+++ b/loom/py/loom/dsl.py
@@ -234,6 +234,7 @@ __all__ = [
     "CallLikeInterface",
     "CallLikeKind",
     "FuncLikeInterface",
+    "InlinePolicy",
     "LoopLikeInterface",
     "MemoryAccessInterface",
     "MemoryAccessOperationKind",
@@ -3547,6 +3548,14 @@ class CallLikeKind(Enum):
     LOW_INTERNAL = "low_internal"
     # Explicit semantic-to-target-low invocation of an already selected low function.
     LOW_INVOKE = "low_invoke"
+
+
+class InlinePolicy(Enum):
+    """Required callable-boundary policy."""
+
+    UNSPECIFIED = 0
+    INLINE = 1
+    NOINLINE = 2
 
 
 class CallLikeInterface(NamedTuple):

--- a/loom/py/loom/verify.py
+++ b/loom/py/loom/verify.py
@@ -13,7 +13,13 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from loom.diagnostics import DiagnosticEngine
-from loom.dsl import Op, TypeConstraint, type_constraint_name
+from loom.dsl import (
+    FuncLikeInterface,
+    InlinePolicy,
+    Op,
+    TypeConstraint,
+    type_constraint_name,
+)
 from loom.fields import FieldKind, FieldLayout, compute_layout, resolve_fields
 from loom.ir import (
     Block,
@@ -621,10 +627,9 @@ class ModuleVerifier:
                         operation.name == trait.args[0] for operation in parent_stack
                     ):
                         continue
-                    # Template bodies are verified before their application
-                    # context is known. Provider selection checks deferred
-                    # ancestor requirements at each materialization site.
-                    if self._has_deferred_template_ancestor(parent_stack):
+                    # Templates and required-inline functions are verified
+                    # before their final placement context is known.
+                    if self._has_deferred_required_ancestor(parent_stack):
                         continue
                     expected = trait.args[0] if trait.args else "<missing>"
                     self.diagnostics.error(
@@ -644,13 +649,24 @@ class ModuleVerifier:
                             details=(f"forbidden ancestor op '{trait.args[0]}'",),
                         )
 
-    def _has_deferred_template_ancestor(
+    def _has_deferred_required_ancestor(
         self, parent_stack: tuple[Operation, ...]
     ) -> bool:
         for operation in reversed(parent_stack):
             declaration = self.registry.op(operation.name)
             if operation.name == "func.template":
                 return True
+            if declaration:
+                for interface in declaration.interfaces:
+                    if not isinstance(interface, FuncLikeInterface):
+                        continue
+                    inline_policy = interface.inline_policy
+                    if (
+                        inline_policy
+                        and operation.attributes.get(inline_policy)
+                        == InlinePolicy.INLINE.value
+                    ):
+                        return True
             if declaration and any(
                 trait.name == "IsolatedFromAbove" for trait in declaration.traits
             ):

--- a/loom/py/loom/verify_test.py
+++ b/loom/py/loom/verify_test.py
@@ -6,12 +6,14 @@
 
 from loom.builtin_types import ALL_BUILTIN_TYPES
 from loom.diagnostics import DiagnosticEngine
+from loom.dialect.func import ALL_FUNC_OPS
 from loom.dialect.test import ALL_TEST_OPS
 from loom.dsl import (
     ANY,
     INTEGER,
     ISOLATED_FROM_ABOVE,
     HasAncestor,
+    InlinePolicy,
     Op,
     Operand,
     RegionDef,
@@ -269,6 +271,45 @@ def test_verifier_defers_template_ancestor_requirement() -> None:
     assert not diagnostics.has_errors
 
 
+def test_verifier_defers_required_inline_ancestor_requirement() -> None:
+    diagnostics = _verify_required_ancestor_in_func(
+        InlinePolicy.INLINE,
+        Operation(name="test.requires_context"),
+    )
+
+    assert not diagnostics.has_errors
+
+
+def test_verifier_does_not_defer_noinline_ancestor_requirement() -> None:
+    diagnostics = _verify_required_ancestor_in_func(
+        InlinePolicy.NOINLINE,
+        Operation(name="test.requires_context"),
+    )
+
+    assert _diagnostic_text_contains(diagnostics, "missing required ancestor")
+
+
+def test_verifier_does_not_defer_inline_through_nested_isolation() -> None:
+    isolated_op = Operation(
+        name="test.isolated_region",
+        regions=[
+            Region(
+                blocks=[
+                    Block(
+                        ops=[
+                            Operation(name="test.requires_context"),
+                            Operation(name="test.yield"),
+                        ]
+                    )
+                ]
+            )
+        ],
+    )
+    diagnostics = _verify_required_ancestor_in_func(InlinePolicy.INLINE, isolated_op)
+
+    assert _diagnostic_text_contains(diagnostics, "missing required ancestor")
+
+
 def test_verifier_does_not_defer_through_nested_isolation() -> None:
     requires_context = Op(
         "test.requires_context",
@@ -462,6 +503,45 @@ def _func(body: Region | None = None) -> Operation:
         name="test.func",
         attributes={"callee": "f"},
         regions=[body if body is not None else Region(blocks=[Block()])],
+    )
+
+
+def _func_def_with_ops(
+    name: str, inline_policy: InlinePolicy, *ops: Operation
+) -> Operation:
+    return Operation(
+        name="func.def",
+        attributes={
+            "callee": name,
+            "inline_policy": inline_policy.value,
+        },
+        regions=[
+            Region(
+                blocks=[
+                    Block(ops=[*ops, Operation(name="func.return")]),
+                ]
+            )
+        ],
+    )
+
+
+def _verify_required_ancestor_in_func(
+    inline_policy: InlinePolicy, *ops: Operation
+) -> DiagnosticEngine:
+    requires_context = Op(
+        "test.requires_context",
+        traits=[HasAncestor("test.context")],
+    )
+    module = Module()
+    module.symbols.append(
+        _symbol(
+            "helper",
+            _func_def_with_ops("helper", inline_policy, *ops),
+        )
+    )
+    return verify_module(
+        module,
+        ops=(*ALL_TEST_OPS, *ALL_FUNC_OPS, requires_context),
     )
 
 

--- a/loom/src/loom/analysis/func_provider_catalog.h
+++ b/loom/src/loom/analysis/func_provider_catalog.h
@@ -74,7 +74,7 @@ typedef struct loom_func_provider_summary_t {
   uint8_t temperature;
 
   // Inline policy enum value.
-  uint8_t inline_policy;
+  loom_inline_policy_t inline_policy;
 
   // Local module symbol reference, or null for external providers.
   loom_symbol_ref_t symbol;

--- a/loom/src/loom/ir/ir.h
+++ b/loom/src/loom/ir/ir.h
@@ -896,6 +896,15 @@ typedef iree_status_t (*loom_type_transfer_fn_t)(
 // CallLike interface vtable
 //===----------------------------------------------------------------------===//
 
+// Required callable-boundary policy shared by CallLike and FuncLike
+// implementations. Unspecified policy leaves the edge to the active pass.
+typedef enum loom_inline_policy_e {
+  LOOM_INLINE_POLICY_UNSPECIFIED = 0,
+  LOOM_INLINE_POLICY_INLINE = 1,
+  LOOM_INLINE_POLICY_NOINLINE = 2,
+  LOOM_INLINE_POLICY_COUNT_,
+} loom_inline_policy_t;
+
 typedef uint8_t loom_call_like_kind_t;
 
 enum loom_call_like_kind_e {

--- a/loom/src/loom/ops/func/ops.h
+++ b/loom/src/loom/ops/func/ops.h
@@ -13,6 +13,7 @@
 #define LOOM_OPS_FUNC_OPS_H_
 
 #include "loom/ops/op_defs.h"
+#include "loom/ir/ir.h"
 #include "loom/target/types.h"
 
 #ifdef __cplusplus
@@ -58,13 +59,6 @@ typedef enum loom_func_temperature_e {
   LOOM_FUNC_TEMPERATURE_COUNT_ = 3,
 } loom_func_temperature_t;
 
-// Author inline policy. Absent (0) leaves the edge to the current pass.
-typedef enum loom_func_inline_policy_e {
-  LOOM_FUNC_INLINE_POLICY_INLINE = 1,
-  LOOM_FUNC_INLINE_POLICY_NOINLINE = 2,
-  LOOM_FUNC_INLINE_POLICY_COUNT_ = 3,
-} loom_func_inline_policy_t;
-
 // Private symbol retention policy. Absent (0) permits ordinary DCE.
 typedef enum loom_func_retain_e {
   LOOM_FUNC_RETAIN_RETAIN = 1,
@@ -82,7 +76,7 @@ LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_def_visibility, 1, loom_func_visibility_t)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_def_cc, 2, loom_func_cc_t)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_def_purity, 3, loom_func_purity_t)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_def_temperature, 4, loom_func_temperature_t)
-LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_def_inline_policy, 5, loom_func_inline_policy_t)
+LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_def_inline_policy, 5, loom_inline_policy_t)
 LOOM_DEFINE_ATTR_PREDICATE_LIST(loom_func_def_predicates, 6)
 LOOM_DEFINE_ATTR_SYMBOL(loom_func_def_target, 7)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_def_abi, 8, loom_target_abi_kind_t)
@@ -144,7 +138,7 @@ LOOM_DEFINE_ATTR_STRING(loom_func_decl_import_symbol, 3)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_decl_cc, 4, loom_func_cc_t)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_decl_purity, 5, loom_func_purity_t)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_decl_temperature, 6, loom_func_temperature_t)
-LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_decl_inline_policy, 7, loom_func_inline_policy_t)
+LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_decl_inline_policy, 7, loom_inline_policy_t)
 LOOM_DEFINE_ATTR_SYMBOL(loom_func_decl_target, 8)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_decl_abi, 9, loom_target_abi_kind_t)
 LOOM_DEFINE_ATTR_DICT(loom_func_decl_abi_attrs, 10)
@@ -209,7 +203,7 @@ LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_template_visibility, 2, loom_func_visibili
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_template_cc, 3, loom_func_cc_t)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_template_purity, 4, loom_func_purity_t)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_template_temperature, 5, loom_func_temperature_t)
-LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_template_inline_policy, 6, loom_func_inline_policy_t)
+LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_template_inline_policy, 6, loom_inline_policy_t)
 LOOM_DEFINE_ATTR_PREDICATE_LIST(loom_func_template_predicates, 7)
 LOOM_DEFINE_ATTR_SYMBOL(loom_func_template_target, 8)
 LOOM_DEFINE_ATTR_I64(loom_func_template_priority, 9)
@@ -261,7 +255,7 @@ LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_ukernel_visibility, 2, loom_func_visibilit
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_ukernel_cc, 3, loom_func_cc_t)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_ukernel_purity, 4, loom_func_purity_t)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_ukernel_temperature, 5, loom_func_temperature_t)
-LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_ukernel_inline_policy, 6, loom_func_inline_policy_t)
+LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_ukernel_inline_policy, 6, loom_inline_policy_t)
 LOOM_DEFINE_ATTR_PREDICATE_LIST(loom_func_ukernel_predicates, 7)
 LOOM_DEFINE_ATTR_SYMBOL(loom_func_ukernel_target, 8)
 LOOM_DEFINE_ATTR_I64(loom_func_ukernel_priority, 9)
@@ -309,7 +303,7 @@ LOOM_DEFINE_VARIADIC_RESULTS(loom_func_call_results, 0)
 LOOM_DEFINE_ATTR_SYMBOL(loom_func_call_callee, 0)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_call_purity, 1, loom_func_purity_t)
 LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_call_temperature, 2, loom_func_temperature_t)
-LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_call_inline_policy, 3, loom_func_inline_policy_t)
+LOOM_DEFINE_ATTR_ENUM_TYPED(loom_func_call_inline_policy, 3, loom_inline_policy_t)
 enum loom_func_call_build_flag_bits_e {
   LOOM_FUNC_CALL_BUILD_FLAG_HAS_PURITY = 1u << 0,
   LOOM_FUNC_CALL_BUILD_FLAG_HAS_TEMPERATURE = 1u << 1,

--- a/loom/src/loom/ops/func_symbol_facts.h
+++ b/loom/src/loom/ops/func_symbol_facts.h
@@ -52,7 +52,7 @@ typedef struct loom_func_symbol_facts_t {
   uint8_t temperature;
 
   // Inline policy enum value from the func interface.
-  uint8_t inline_policy;
+  loom_inline_policy_t inline_policy;
 
   // True when the func op owns an implementation body.
   bool has_body;

--- a/loom/src/loom/ops/kernel/test/verify.loom-test
+++ b/loom/src/loom/ops/kernel/test/verify.loom-test
@@ -121,6 +121,32 @@ func.def @workitem_id_requires_kernel_def() {
 
 // ====
 
+func.def inline @required_inline_defers_kernel_placement() -> (index) {
+  %tid = kernel.workitem.id<x> : index
+  func.return %tid : index
+}
+
+// ====
+
+func.def noinline @noinline_does_not_defer_kernel_placement() -> (index) {
+  // ERROR@+1: STRUCTURE/029 "kernel.workitem.id" "required" "kernel.def" "func.def"
+  %tid = kernel.workitem.id<x> : index
+  func.return %tid : index
+}
+
+// ====
+
+func.def inline @nested_isolation_does_not_defer_kernel_placement() {
+  test.isolated_region {
+    // ERROR@+1: STRUCTURE/029 "kernel.workitem.id" "required" "kernel.def" "test.isolated_region"
+    %tid = kernel.workitem.id<x> : index
+    test.yield
+  }
+  func.return
+}
+
+// ====
+
 kernel.def @exit_requires_direct_kernel_body() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index

--- a/loom/src/loom/ops/op_defs.c
+++ b/loom/src/loom/ops/op_defs.c
@@ -832,14 +832,14 @@ uint8_t loom_call_like_temperature(loom_call_like_t call) {
       loom_op_attrs(call.op)[call.vtable->temperature_attr_index]);
 }
 
-uint8_t loom_call_like_inline_policy(loom_call_like_t call) {
+loom_inline_policy_t loom_call_like_inline_policy(loom_call_like_t call) {
   if (!call.vtable) {
-    return 0;
+    return LOOM_INLINE_POLICY_UNSPECIFIED;
   }
   if (call.vtable->inline_policy_attr_index == LOOM_ATTR_INDEX_NONE) {
-    return 0;
+    return LOOM_INLINE_POLICY_UNSPECIFIED;
   }
-  return loom_attr_as_enum(
+  return (loom_inline_policy_t)loom_attr_as_enum(
       loom_op_attrs(call.op)[call.vtable->inline_policy_attr_index]);
 }
 
@@ -918,10 +918,12 @@ uint8_t loom_func_like_temperature(loom_func_like_t func) {
       loom_op_attrs(func.op)[func.vtable->temperature_attr_index]);
 }
 
-uint8_t loom_func_like_inline_policy(loom_func_like_t func) {
-  if (!func.vtable) return 0;
-  if (func.vtable->inline_policy_attr_index == LOOM_ATTR_INDEX_NONE) return 0;
-  return loom_attr_as_enum(
+loom_inline_policy_t loom_func_like_inline_policy(loom_func_like_t func) {
+  if (!func.vtable) return LOOM_INLINE_POLICY_UNSPECIFIED;
+  if (func.vtable->inline_policy_attr_index == LOOM_ATTR_INDEX_NONE) {
+    return LOOM_INLINE_POLICY_UNSPECIFIED;
+  }
+  return (loom_inline_policy_t)loom_attr_as_enum(
       loom_op_attrs(func.op)[func.vtable->inline_policy_attr_index]);
 }
 

--- a/loom/src/loom/ops/op_defs.h
+++ b/loom/src/loom/ops/op_defs.h
@@ -1331,8 +1331,8 @@ uint8_t loom_call_like_purity(loom_call_like_t call);
 // Returns the temperature attr value (0 = unspecified).
 uint8_t loom_call_like_temperature(loom_call_like_t call);
 
-// Returns the inline policy attr value (0 = unspecified).
-uint8_t loom_call_like_inline_policy(loom_call_like_t call);
+// Returns the authored inline policy.
+loom_inline_policy_t loom_call_like_inline_policy(loom_call_like_t call);
 
 // Returns the semantic class of the call-like op.
 loom_call_like_kind_t loom_call_like_kind(loom_call_like_t call);
@@ -1386,8 +1386,8 @@ uint8_t loom_func_like_purity(loom_func_like_t func);
 // Returns the temperature attr value (0 = unspecified).
 uint8_t loom_func_like_temperature(loom_func_like_t func);
 
-// Returns the inline policy attr value (0 = unspecified).
-uint8_t loom_func_like_inline_policy(loom_func_like_t func);
+// Returns the authored inline policy.
+loom_inline_policy_t loom_func_like_inline_policy(loom_func_like_t func);
 
 // Returns the visibility attr value (0 = private, nonzero = public).
 uint8_t loom_func_like_visibility(loom_func_like_t func);

--- a/loom/src/loom/tools/loom-link/BUILD.bazel
+++ b/loom/src/loom/tools/loom-link/BUILD.bazel
@@ -47,7 +47,10 @@ loom_cc_binary(
 
 iree_execution_test_suite(
     name = "execution_test",
-    data = ["testdata/archive_many_symbols.loom"],
+    data = [
+        "testdata/archive_inline_kernel_helper.loom",
+        "testdata/archive_many_symbols.loom",
+    ],
     manifests = ["loom-link.test.json"],
     tags = ["hostonly"],
     tools = {

--- a/loom/src/loom/tools/loom-link/CMakeLists.txt
+++ b/loom/src/loom/tools/loom-link/CMakeLists.txt
@@ -51,6 +51,7 @@ iree_execution_test_suite(
     "loom-format=loom::tools::loom-format"
     "loom-link=::loom-link"
   DATA
+    "${PROJECT_SOURCE_DIR}/loom/src/loom/tools/loom-link/testdata/archive_inline_kernel_helper.loom"
     "${PROJECT_SOURCE_DIR}/loom/src/loom/tools/loom-link/testdata/archive_many_symbols.loom"
   LABELS
     "hostonly"

--- a/loom/src/loom/tools/loom-link/loom-link.test.json
+++ b/loom/src/loom/tools/loom-link/loom-link.test.json
@@ -37,6 +37,23 @@
       }
     },
     {
+      "name": "preserves required-inline kernel helper in archive",
+      "run": {
+        "tool": "loom-link",
+        "args": [
+          "{srcdir}/testdata/archive_inline_kernel_helper.loom",
+          "--mode=archive"
+        ]
+      },
+      "stdout": {
+        "contains": [
+          "func.def inline @subgroup_broadcast_helper",
+          "kernel.subgroup.broadcast",
+          "kernel.def @subgroup_broadcast_kernel"
+        ]
+      }
+    },
+    {
       "name": "links text corpus into harness",
       "steps": [
         {

--- a/loom/src/loom/tools/loom-link/testdata/archive_inline_kernel_helper.loom
+++ b/loom/src/loom/tools/loom-link/testdata/archive_inline_kernel_helper.loom
@@ -1,0 +1,18 @@
+// Required-inline helpers may contain operations whose final placement is
+// supplied by their caller. Archive linking preserves the helper for later
+// root selection and inlining.
+func.def inline @subgroup_broadcast_helper(%value: i32, %lane: i32) -> (i32) {
+  %broadcast = kernel.subgroup.broadcast %value from %lane : i32, i32
+  func.return %broadcast : i32
+}
+
+kernel.def @subgroup_broadcast_kernel() {
+  %one = index.constant 1 : index
+  %thirtytwo = index.constant 32 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%thirtytwo, %one, %one) : index
+} launch(%value: i32) {
+  %lane = kernel.subgroup.lane.id : index
+  %lane_i32 = index.cast %lane : index to i32
+  %broadcast = func.call @subgroup_broadcast_helper(%value, %lane_i32) : (i32, i32) -> (i32)
+  kernel.return
+}

--- a/loom/src/loom/transforms/symbol/inline_callables.c
+++ b/loom/src/loom/transforms/symbol/inline_callables.c
@@ -120,11 +120,11 @@ typedef struct loom_inline_plan_entry_t {
   // Function-like interface for the target definition.
   loom_func_like_t callee;
   // Inline policy read from the callee symbol definition.
-  uint8_t callee_policy;
+  loom_inline_policy_t callee_policy;
   // Inline policy read from the call site.
-  uint8_t call_policy;
+  loom_inline_policy_t call_policy;
   // Effective edge inline policy after conflict resolution.
-  uint8_t effective_policy;
+  loom_inline_policy_t effective_policy;
   // Temperature hint read from the callee symbol definition.
   uint8_t callee_temperature;
   // Temperature hint read from the call site.
@@ -162,12 +162,12 @@ typedef struct loom_inline_state_t {
   iree_host_size_t* component_by_symbol;
 } loom_inline_state_t;
 
-static bool loom_inline_policy_is_inline(uint8_t policy) {
-  return policy == LOOM_FUNC_INLINE_POLICY_INLINE;
+static bool loom_inline_policy_is_inline(loom_inline_policy_t policy) {
+  return policy == LOOM_INLINE_POLICY_INLINE;
 }
 
-static bool loom_inline_policy_is_noinline(uint8_t policy) {
-  return policy == LOOM_FUNC_INLINE_POLICY_NOINLINE;
+static bool loom_inline_policy_is_noinline(loom_inline_policy_t policy) {
+  return policy == LOOM_INLINE_POLICY_NOINLINE;
 }
 
 static iree_string_view_t loom_inline_symbol_name(const loom_module_t* module,
@@ -341,20 +341,20 @@ static void loom_inline_resolve_entry_policy(loom_inline_state_t* state,
   const bool call_noinline = loom_inline_policy_is_noinline(entry->call_policy);
 
   if ((callee_inline && call_noinline) || (callee_noinline && call_inline)) {
-    entry->effective_policy = LOOM_FUNC_INLINE_POLICY_INLINE;
+    entry->effective_policy = LOOM_INLINE_POLICY_INLINE;
     loom_inline_mark_blocker(entry, LOOM_INLINE_BLOCKER_POLICY_CONFLICT);
     return;
   }
 
   if (callee_noinline || call_noinline) {
-    entry->effective_policy = LOOM_FUNC_INLINE_POLICY_NOINLINE;
+    entry->effective_policy = LOOM_INLINE_POLICY_NOINLINE;
     entry->action = LOOM_INLINE_PLAN_ACTION_KEEP;
     ++state->statistics->kept_edges;
     return;
   }
 
   if (callee_inline || call_inline) {
-    entry->effective_policy = LOOM_FUNC_INLINE_POLICY_INLINE;
+    entry->effective_policy = LOOM_INLINE_POLICY_INLINE;
     entry->action = LOOM_INLINE_PLAN_ACTION_REQUIRED;
     ++state->statistics->required_edges;
     return;

--- a/loom/src/loom/transforms/symbol/template_selection.c
+++ b/loom/src/loom/transforms/symbol/template_selection.c
@@ -1507,7 +1507,7 @@ static iree_status_t loom_template_selection_rewrite_entry(
   loom_op_t* call_op = NULL;
   IREE_RETURN_IF_ERROR(loom_func_call_build(
       &rewriter->builder, build_flags, purity, temperature,
-      LOOM_FUNC_INLINE_POLICY_INLINE, entry->selected_provider->symbol,
+      LOOM_INLINE_POLICY_INLINE, entry->selected_provider->symbol,
       operands.values, operands.count, result_types, results.count,
       loom_op_tied_results(entry->apply_op), entry->apply_op->tied_result_count,
       entry->apply_op->location, &call_op));

--- a/loom/src/loom/transforms/symbol/test/inline_callables.loom-test
+++ b/loom/src/loom/transforms/symbol/test/inline_callables.loom-test
@@ -20,6 +20,49 @@ func.def public @entry(%arg: i32) -> (i32) {
 
 // RUN: pass inline-callables
 
+func.def inline @lane_id() -> (index) {
+  %lane = kernel.subgroup.lane.id : index
+  func.return %lane : index
+}
+
+kernel.def @inlines_into_required_ancestor() {
+  %one = index.constant 1 : index
+  %thirtytwo = index.constant 32 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%thirtytwo, %one, %one) : index
+} launch() {
+  %lane = func.call @lane_id() : () -> (index)
+  kernel.return
+}
+
+// ----
+kernel.def @inlines_into_required_ancestor() {
+  %one = index.constant 1 : index
+  %thirtytwo = index.constant 32 : index
+  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%thirtytwo, %one, %one) : index
+} launch() {
+  %lane = kernel.subgroup.lane.id : index
+  kernel.return
+}
+
+// ====
+
+// RUN: pass inline-callables
+
+func.def inline @misplaced_lane_id() -> (index) {
+  // ERROR@+1: STRUCTURE/029 "kernel.subgroup.lane.id" "required" "kernel.def" "func.def"
+  %lane = kernel.subgroup.lane.id : index
+  func.return %lane : index
+}
+
+func.def @rejects_illegal_final_inline_placement() {
+  %lane = func.call @misplaced_lane_id() : () -> (index)
+  func.return
+}
+
+// ====
+
+// RUN: pass inline-callables
+
 func.def @double(%value: i32) -> (i32) {
   %doubled = test.addi %value, %value : i32
   func.return %doubled : i32

--- a/loom/src/loom/verify/verify_structure.c
+++ b/loom/src/loom/verify/verify_structure.c
@@ -299,7 +299,7 @@ static const loom_op_t* loom_verify_find_ancestor(const loom_op_t* op,
   return NULL;
 }
 
-static bool loom_verify_has_deferred_template_ancestor(
+static bool loom_verify_has_deferred_required_ancestor(
     const loom_verify_state_t* state, const loom_op_t* op) {
   const loom_op_t* parent = op->parent_op;
   while (parent) {
@@ -308,6 +308,15 @@ static bool loom_verify_has_deferred_template_ancestor(
     if (parent_vtable &&
         parent_vtable->symbol_kind == LOOM_SYMBOL_FUNC_TEMPLATE) {
       return true;
+    }
+    if (parent_vtable && parent_vtable->func_like) {
+      const uint8_t inline_policy_attr_index =
+          parent_vtable->func_like->inline_policy_attr_index;
+      if (inline_policy_attr_index != LOOM_ATTR_INDEX_NONE &&
+          loom_attr_as_enum(loom_op_const_attrs(
+              parent)[inline_policy_attr_index]) == LOOM_INLINE_POLICY_INLINE) {
+        return true;
+      }
     }
     if (parent_vtable && loom_traits_is_isolated(parent_vtable->traits)) {
       return false;
@@ -346,10 +355,10 @@ void loom_verify_op_placement(loom_verify_state_t* state, const loom_op_t* op,
   for (uint8_t i = 0; i < placement->required_ancestor_count; ++i) {
     loom_op_kind_t ancestor_kind = placement->required_ancestors[i];
     if (loom_verify_find_ancestor(op, ancestor_kind)) continue;
-    // Template bodies are verified before their application context is known.
-    // Provider selection checks deferred ancestor requirements at each apply
-    // site before materializing the body.
-    if (loom_verify_has_deferred_template_ancestor(state, op)) {
+    // Templates and required-inline functions are verified before their final
+    // placement context is known. Materialization or inlining supplies that
+    // context, and verification after the transform enforces the requirement.
+    if (loom_verify_has_deferred_required_ancestor(state, op)) {
       continue;
     }
     loom_verify_emit_placement_diagnostic(


### PR DESCRIPTION
Archive linking can now preserve required-inline function bodies whose placement obligations are supplied by their eventual caller. This allows reusable source archives to contain context-sensitive helpers, such as subgroup collectives intended for kernel callers, without weakening placement verification for ordinary functions or final compiled IR.

## Design

CallLike and FuncLike already expose inline policy through generic interfaces, but their C policy vocabulary was owned by the func dialect. The first commit moves that small enum beside the callable interface definitions and teaches generated func APIs, symbol facts, provider summaries, and inlining plans to use the shared type without changing storage or behavior.

Required-ancestor verification already performs a bounded parent walk when an operation lacks its declared ancestor so that template bodies can defer placement until provider materialization. The verifier now recognizes a FuncLike parent authored with required `inline` policy during that same walk. An intervening isolated operation still terminates deferral, and unspecified or `noinline` callable boundaries still produce the original placement diagnostic.

Deferral is not exemption. Mandatory inlining supplies the final caller context, and normal post-transform verification enforces the operation's placement there. A helper inlined into a kernel is accepted; the same helper inlined into an ordinary function fails with the original required-ancestor diagnostic.

The Python verifier mirrors the C contract using the same generic FuncLike metadata and shared inline-policy values.

## Cost

The successful placement path is unchanged: finding the required ancestor returns before any deferral logic runs. The exceptional path reuses its existing parent traversal and adds only a FuncLike vtable check plus one byte-sized enum comparison per visited callable parent. There is no new allocation, persistent state, call graph, symbol-use table, provider lookup, archive mode, or module traversal.

## Impact

`loom-link --mode=archive` can retain reusable required-inline kernel helpers for later root selection and specialization. Regression coverage follows the complete obligation lifecycle: archive preservation, legal inlining into a kernel, rejection after illegal final placement, rejection for `noinline`, and rejection across nested isolation.

The motivating subgroup-broadcast helper compiles from archived source to the same native cross-lane instructions as direct compilation, confirming that the change affects verification staging rather than lowering or code quality.

## Reviewer Notes

The highest-value review surfaces are the ordering of required-inline recognition relative to isolation in the parent walk, the post-inline illegal-placement regression, and the shared inline-policy vocabulary used by both generated and generic consumers.
