### PR TITLE
[Runtime] Let proactor pools select a creator

### DIFF
--- a/runtime/src/iree/async/util/proactor_pool.c
+++ b/runtime/src/iree/async/util/proactor_pool.c
@@ -183,8 +183,11 @@ static iree_status_t iree_async_proactor_pool_ensure_entry_locked(
         iree_make_string_view(name_buffer, strlen(name_buffer));
   }
 
-  IREE_RETURN_IF_ERROR(iree_async_proactor_create_platform(
-      proactor_options, pool->allocator, &entry->proactor));
+  iree_async_proactor_pool_proactor_create_fn_t proactor_create =
+      pool->options.proactor_create ? pool->options.proactor_create
+                                    : iree_async_proactor_create_platform;
+  IREE_RETURN_IF_ERROR(
+      proactor_create(proactor_options, pool->allocator, &entry->proactor));
 
   // Create a poll runner if the factory is configured.
   if (pool->options.runner.create) {

--- a/runtime/src/iree/async/util/proactor_pool.h
+++ b/runtime/src/iree/async/util/proactor_pool.h
@@ -76,6 +76,11 @@ typedef struct iree_async_proactor_pool_options_t {
   // Options applied to each proactor created by the pool.
   iree_async_proactor_options_t proactor_options;
 
+  // Optional proactor creator. NULL selects the platform-optimal creator.
+  // A caller can provide an existing backend creator when its workload has a
+  // stronger execution-policy requirement than the platform default.
+  iree_async_proactor_pool_proactor_create_fn_t proactor_create;
+
   // Optional runner factory for creating poll runners that drive proactors.
   // When create is non-NULL, the pool calls it for each proactor during
   // pool_get(). When create is NULL (zero-initialized), proactors are created

--- a/runtime/src/iree/async/util/proactor_pool_test.cc
+++ b/runtime/src/iree/async/util/proactor_pool_test.cc
@@ -11,6 +11,15 @@
 
 namespace {
 
+static iree_status_t RejectProactorCreation(
+    iree_async_proactor_options_t options, iree_allocator_t allocator,
+    iree_async_proactor_t** out_proactor) {
+  (void)options;
+  (void)allocator;
+  *out_proactor = nullptr;
+  return iree_make_status(IREE_STATUS_ABORTED, "selected creator invoked");
+}
+
 class ProactorPoolTest : public ::testing::Test {
  protected:
   iree_async_proactor_pool_options_t default_options() {
@@ -56,6 +65,21 @@ TEST_F(ProactorPoolTest, CreateAndReleaseWithoutGet) {
       &pool));
   ASSERT_NE(pool, nullptr);
   EXPECT_EQ(iree_async_proactor_pool_count(pool), 1u);
+  iree_async_proactor_pool_release(pool);
+}
+
+TEST_F(ProactorPoolTest, SelectedCreatorIsLazyAndPropagatesFailure) {
+  iree_async_proactor_pool_options_t options = default_options();
+  options.proactor_create = RejectProactorCreation;
+  iree_async_proactor_pool_t* pool = nullptr;
+  IREE_ASSERT_OK(iree_async_proactor_pool_create(
+      1, /*node_ids=*/nullptr, options, iree_allocator_system(), &pool));
+
+  iree_async_proactor_t* proactor = nullptr;
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED,
+                        iree_async_proactor_pool_get(pool, 0, &proactor));
+  EXPECT_EQ(proactor, nullptr);
+
   iree_async_proactor_pool_release(pool);
 }
 

--- a/runtime/src/iree/async/util/proactor_pool_types.h
+++ b/runtime/src/iree/async/util/proactor_pool_types.h
@@ -16,6 +16,16 @@
 extern "C" {
 #endif  // __cplusplus
 
+// Creates a proactor for one pool entry.
+//
+// The pool supplies its per-entry options and retains the returned proactor.
+// Implementations may select a specific backend or delegate to the platform
+// creator. Creation is lazy and occurs while the pool mutex is held.
+typedef iree_status_t(
+    IREE_API_PTR* iree_async_proactor_pool_proactor_create_fn_t)(
+    iree_async_proactor_options_t options, iree_allocator_t allocator,
+    iree_async_proactor_t** out_proactor);
+
 // Factory callbacks for creating poll runners that drive proactors.
 //
 // When a proactor is first accessed via pool_get(), the pool calls |create| to


### PR DESCRIPTION
Proactor pools currently hard-code platform backend selection when each lazy NUMA entry is first accessed. That prevents an application with a measured execution-policy requirement from selecting an existing backend without giving up the pool's runner, ownership, and teardown lifecycle.

Add an optional proactor creator to pool options. A null callback retains the platform-optimal creator for every existing caller; an explicit callback is invoked at the same lazy creation boundary and its proactor remains owned by the pool. This lets bulk cached-file workloads select worker-backed execution while keeping the platform default intact elsewhere.

The focused pool test exercises the actual lazy get path and verifies that a selected creator is not called during pool construction and that its failure is propagated.