### PR TITLE
[Loom] Hoist loop-invariant waits through preserved CFG loops

### DIFF
--- a/loom/src/loom/codegen/low/BUILD.bazel
+++ b/loom/src/loom/codegen/low/BUILD.bazel
@@ -212,6 +212,7 @@ loom_cc_library(
         "//loom/src/loom/error:emitter",
         "//loom/src/loom/ir",
         "//loom/src/loom/util:cfg_graph",
+        "//loom/src/loom/util:cfg_loop",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:arena",
     ],

--- a/loom/src/loom/codegen/low/CMakeLists.txt
+++ b/loom/src/loom/codegen/low/CMakeLists.txt
@@ -202,6 +202,7 @@ loom_cc_library(
     loom::error::emitter
     loom::ir
     loom::util::cfg_graph
+    loom::util::cfg_loop
   PUBLIC
 )
 

--- a/loom/src/loom/codegen/low/function_model.c
+++ b/loom/src/loom/codegen/low/function_model.c
@@ -47,14 +47,19 @@ iree_status_t loom_low_function_model_initialize(
       .region = out_model->body,
       .block_count = out_model->body->block_count,
   };
+  iree_status_t status = iree_ok_status();
   if (out_model->body->block_count > 1 ||
       iree_any_bit_set(out_model->body->flags, LOOM_REGION_INSTANCE_FLAG_CFG)) {
-    iree_status_t status = loom_cfg_graph_build(module, out_model->body, arena,
-                                                &out_model->cfg_graph);
-    if (!iree_status_is_ok(status)) {
-      loom_local_value_domain_release(&out_model->value_domain);
-      return status;
-    }
+    status = loom_cfg_graph_build(module, out_model->body, arena,
+                                  &out_model->cfg_graph);
+  }
+  if (iree_status_is_ok(status)) {
+    status = loom_cfg_loop_forest_build(&out_model->cfg_graph, arena,
+                                        &out_model->loop_forest);
+  }
+  if (!iree_status_is_ok(status)) {
+    loom_local_value_domain_release(&out_model->value_domain);
+    return status;
   }
   const loom_block_t* block = NULL;
   loom_region_for_each_block(out_model->body, block) {

--- a/loom/src/loom/codegen/low/function_model.h
+++ b/loom/src/loom/codegen/low/function_model.h
@@ -16,6 +16,7 @@
 #include "loom/error/emitter.h"
 #include "loom/ir/local_value_domain.h"
 #include "loom/util/cfg_graph.h"
+#include "loom/util/cfg_loop.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,6 +46,8 @@ typedef struct loom_low_function_model_t {
   loom_local_value_domain_t value_domain;
   // Read-only control-flow graph for the function body.
   loom_cfg_graph_t cfg_graph;
+  // Canonical loop intervals preserved from |cfg_graph|.
+  loom_cfg_loop_forest_t loop_forest;
   // Number of top-level operations in |body|.
   iree_host_size_t node_count;
   // Number of user-facing errors emitted while constructing the model.

--- a/loom/src/loom/codegen/low/lower/BUILD.bazel
+++ b/loom/src/loom/codegen/low/lower/BUILD.bazel
@@ -81,6 +81,7 @@ loom_cc_library(
         "//loom/src/loom/target:registers",
         "//loom/src/loom/target:types",
         "//loom/src/loom/util:cfg_graph",
+        "//loom/src/loom/util:cfg_loop",
         "//loom/src/loom/util:fact_table",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal",

--- a/loom/src/loom/codegen/low/lower/CMakeLists.txt
+++ b/loom/src/loom/codegen/low/lower/CMakeLists.txt
@@ -65,6 +65,7 @@ loom_cc_library(
     loom::target::registers
     loom::target::types
     loom::util::cfg_graph
+    loom::util::cfg_loop
     loom::util::fact_table
   PUBLIC
 )

--- a/loom/src/loom/codegen/low/lower/lower_report.c
+++ b/loom/src/loom/codegen/low/lower/lower_report.c
@@ -523,9 +523,6 @@ static iree_status_t loom_low_lower_memory_report_ensure_source_block_counts(
       &context->arena, body->block_count,
       sizeof(*context->lowering.source_block_execution_counts),
       (void**)&context->lowering.source_block_execution_counts));
-  for (uint16_t i = 0; i < body->block_count; ++i) {
-    context->lowering.source_block_execution_counts[i] = 1;
-  }
 
   loom_cfg_graph_t graph = {0};
   IREE_RETURN_IF_ERROR(

--- a/loom/src/loom/codegen/low/lower/lower_report.c
+++ b/loom/src/loom/codegen/low/lower/lower_report.c
@@ -549,7 +549,7 @@ static iree_status_t loom_low_lower_memory_report_ensure_source_block_counts(
   }
   context->lowering.source_block_execution_counts_exact =
       loom_cfg_loop_forest_calculate_block_execution_counts(
-          &loop_forest, trip_counts,
+          &loop_forest, &graph, trip_counts,
           context->lowering.source_block_execution_counts);
   return iree_ok_status();
 }

--- a/loom/src/loom/codegen/low/lower/lower_report.c
+++ b/loom/src/loom/codegen/low/lower/lower_report.c
@@ -12,6 +12,7 @@
 #include "loom/ops/func/ops.h"
 #include "loom/ops/index/ops.h"
 #include "loom/util/cfg_graph.h"
+#include "loom/util/cfg_loop.h"
 
 enum {
   // Default allocation block size for source-memory report rows.
@@ -451,102 +452,32 @@ static bool loom_low_lower_memory_report_compute_trip_count(
   return true;
 }
 
-static bool loom_low_lower_memory_report_multiply_block(
-    uint64_t* block_execution_counts, uint16_t block_index,
-    uint64_t multiplier) {
-  return loom_low_lower_memory_report_mul_u64(
-      block_execution_counts[block_index], multiplier,
-      &block_execution_counts[block_index]);
-}
-
-static bool loom_low_lower_memory_report_find_counted_backedge(
-    const loom_cfg_graph_t* graph, uint16_t header_index,
-    const loom_op_t** out_backedge_op, loom_cfg_edge_index_t* out_backedge_edge,
-    uint16_t* out_latch_index) {
-  *out_backedge_op = NULL;
-  *out_backedge_edge = LOOM_CFG_EDGE_INDEX_INVALID;
-  *out_latch_index = UINT16_MAX;
-  const loom_block_t* header = graph->blocks[header_index].block;
-  loom_cfg_edge_index_span_t predecessor_edges =
-      loom_cfg_graph_predecessor_edges(graph, header_index);
-  for (iree_host_size_t i = 0; i < predecessor_edges.count; ++i) {
-    const loom_cfg_edge_index_t edge_index = predecessor_edges.values[i];
-    const loom_cfg_edge_info_t* edge = loom_cfg_graph_edge(graph, edge_index);
-    if (edge == NULL ||
-        !loom_cfg_graph_block_is_reachable(graph, edge->source_block_index) ||
-        edge->source_block_index < header_index) {
-      continue;
-    }
-    const loom_op_t* branch_op = NULL;
-    if (!loom_low_lower_memory_report_block_branch_to(
-            graph->blocks[edge->source_block_index].block, header,
-            &branch_op)) {
-      return false;
-    }
-    if (*out_backedge_op != NULL) {
-      return false;
-    }
-    *out_backedge_op = branch_op;
-    *out_backedge_edge = edge_index;
-    *out_latch_index = edge->source_block_index;
-  }
-  return true;
-}
-
-static bool loom_low_lower_memory_report_loop_has_unmodeled_conditional(
-    const loom_cfg_graph_t* graph, uint16_t header_index,
-    const uint8_t* loop_blocks) {
-  for (uint16_t block_index = 0; block_index < graph->block_count;
-       ++block_index) {
-    if (block_index == header_index || !loop_blocks[block_index]) {
-      continue;
-    }
-    const loom_block_t* block = graph->blocks[block_index].block;
-    const loom_op_t* terminator = block ? block->last_op : NULL;
-    if (terminator == NULL || !loom_cfg_cond_br_isa(terminator)) {
-      continue;
-    }
-    const loom_op_t* nested_backedge_op = NULL;
-    loom_cfg_edge_index_t nested_backedge_edge = LOOM_CFG_EDGE_INDEX_INVALID;
-    uint16_t nested_latch_index = UINT16_MAX;
-    if (!loom_low_lower_memory_report_find_counted_backedge(
-            graph, block_index, &nested_backedge_op, &nested_backedge_edge,
-            &nested_latch_index) ||
-        nested_backedge_op == NULL) {
-      return true;
-    }
-  }
-  return false;
-}
-
 static bool loom_low_lower_memory_report_try_counted_cfg_loop(
     const loom_low_lower_context_t* context, const loom_cfg_graph_t* graph,
-    uint16_t header_index, uint64_t* block_execution_counts,
-    uint8_t* counted_backedge_edges, uint8_t* loop_blocks,
-    uint16_t* loop_stack) {
-  const loom_block_t* header = graph->blocks[header_index].block;
+    const loom_cfg_loop_interval_t* interval, uint64_t* out_trip_count) {
+  *out_trip_count = 0;
+  const loom_block_t* header = graph->blocks[interval->header_index].block;
   if (header == NULL || header->arg_count == 0 || header->last_op == NULL ||
       !loom_cfg_cond_br_isa(header->last_op)) {
-    return true;
+    return false;
   }
   const loom_value_id_t iv_id = loom_block_arg_id(header, 0);
+  const loom_cfg_edge_info_t* entry_edge =
+      loom_cfg_graph_edge(graph, interval->entry_edge_index);
+  const loom_cfg_edge_info_t* backedge =
+      loom_cfg_graph_edge(graph, interval->backedge_edge_index);
+  if (entry_edge == NULL || backedge == NULL) return false;
+
+  const loom_op_t* initial_branch_op = NULL;
+  if (!loom_low_lower_memory_report_block_branch_to(
+          graph->blocks[entry_edge->source_block_index].block, header,
+          &initial_branch_op)) {
+    return false;
+  }
   const loom_op_t* body_backedge_op = NULL;
-  loom_cfg_edge_index_t body_backedge_edge = LOOM_CFG_EDGE_INDEX_INVALID;
-  uint16_t latch_index = UINT16_MAX;
-  if (!loom_low_lower_memory_report_find_counted_backedge(
-          graph, header_index, &body_backedge_op, &body_backedge_edge,
-          &latch_index)) {
-    return false;
-  }
-  if (body_backedge_op == NULL) {
-    return true;
-  }
-  if (!loom_cfg_graph_mark_natural_loop_blocks(graph, header_index, latch_index,
-                                               loop_blocks, loop_stack)) {
-    return false;
-  }
-  if (loom_low_lower_memory_report_loop_has_unmodeled_conditional(
-          graph, header_index, loop_blocks)) {
+  if (!loom_low_lower_memory_report_block_branch_to(
+          graph->blocks[backedge->source_block_index].block, header,
+          &body_backedge_op)) {
     return false;
   }
 
@@ -556,33 +487,9 @@ static bool loom_low_lower_memory_report_try_counted_cfg_loop(
     return false;
   }
 
-  const loom_op_t* initial_branch_op = NULL;
   loom_value_id_t initial_arg = LOOM_VALUE_ID_INVALID;
-  loom_cfg_block_index_span_t predecessors =
-      loom_cfg_graph_predecessors(graph, header_index);
-  for (iree_host_size_t i = 0; i < predecessors.count; ++i) {
-    const uint16_t predecessor_index = predecessors.values[i];
-    if (loop_blocks[predecessor_index] ||
-        !loom_cfg_graph_block_is_reachable(graph, predecessor_index)) {
-      continue;
-    }
-    const loom_op_t* branch_op = NULL;
-    if (!loom_low_lower_memory_report_block_branch_to(
-            graph->blocks[predecessor_index].block, header, &branch_op)) {
-      return false;
-    }
-    loom_value_id_t branch_arg = LOOM_VALUE_ID_INVALID;
-    if (!loom_low_lower_memory_report_branch_arg(
-            branch_op, header, /*arg_index=*/0, &branch_arg)) {
-      return false;
-    }
-    if (initial_branch_op != NULL) {
-      return false;
-    }
-    initial_branch_op = branch_op;
-    initial_arg = branch_arg;
-  }
-  if (initial_branch_op == NULL) {
+  if (!loom_low_lower_memory_report_branch_arg(initial_branch_op, header,
+                                               /*arg_index=*/0, &initial_arg)) {
     return false;
   }
 
@@ -590,7 +497,6 @@ static bool loom_low_lower_memory_report_try_counted_cfg_loop(
   int64_t upper_bound = 0;
   int64_t step = 0;
   bool inclusive_upper_bound = false;
-  uint64_t trip_count = 0;
   bool lower_ok = loom_low_lower_memory_report_value_exact_i64(
       context, initial_arg, &lower_bound);
   bool step_ok = loom_low_lower_memory_report_add_step(
@@ -598,51 +504,8 @@ static bool loom_low_lower_memory_report_try_counted_cfg_loop(
   bool upper_ok = loom_low_lower_memory_report_header_upper_bound(
       context, header->last_op, iv_id, &upper_bound, &inclusive_upper_bound);
   bool trip_ok = loom_low_lower_memory_report_compute_trip_count(
-      lower_bound, upper_bound, inclusive_upper_bound, step, &trip_count);
-  if (!lower_ok || !step_ok || !upper_ok || !trip_ok) {
-    return false;
-  }
-
-  if (trip_count == UINT64_MAX) {
-    return false;
-  }
-  const uint64_t header_count = trip_count + 1;
-  if (!loom_low_lower_memory_report_multiply_block(
-          block_execution_counts, header_index, header_count)) {
-    return false;
-  }
-  for (uint16_t block_index = 0; block_index < graph->block_count;
-       ++block_index) {
-    if (block_index == header_index || !loop_blocks[block_index]) {
-      continue;
-    }
-    if (!loom_low_lower_memory_report_multiply_block(block_execution_counts,
-                                                     block_index, trip_count)) {
-      return false;
-    }
-  }
-  if (body_backedge_edge == LOOM_CFG_EDGE_INDEX_INVALID ||
-      body_backedge_edge >= graph->edge_count) {
-    return false;
-  }
-  counted_backedge_edges[body_backedge_edge] = 1;
-  return true;
-}
-
-static bool loom_low_lower_memory_report_has_uncounted_backedge(
-    const loom_cfg_graph_t* graph, const uint8_t* counted_backedge_edges) {
-  for (iree_host_size_t i = 0; i < graph->edge_count; ++i) {
-    const loom_cfg_edge_info_t* edge = loom_cfg_graph_edge(graph, (uint32_t)i);
-    if (edge == NULL ||
-        !loom_cfg_graph_block_is_reachable(graph, edge->source_block_index)) {
-      continue;
-    }
-    if (edge->target_block_index <= edge->source_block_index &&
-        counted_backedge_edges[i] == 0) {
-      return true;
-    }
-  }
-  return false;
+      lower_bound, upper_bound, inclusive_upper_bound, step, out_trip_count);
+  return lower_ok && step_ok && upper_ok && trip_ok;
 }
 
 static iree_status_t loom_low_lower_memory_report_ensure_source_block_counts(
@@ -671,40 +534,26 @@ static iree_status_t loom_low_lower_memory_report_ensure_source_block_counts(
     context->lowering.source_block_execution_counts_exact = false;
     return iree_ok_status();
   }
-  uint8_t* counted_backedge_edges = NULL;
-  if (graph.edge_count > 0) {
-    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-        &context->arena, graph.edge_count, sizeof(*counted_backedge_edges),
-        (void**)&counted_backedge_edges));
-    memset(counted_backedge_edges, 0,
-           graph.edge_count * sizeof(*counted_backedge_edges));
+  loom_cfg_loop_forest_t loop_forest = {0};
+  IREE_RETURN_IF_ERROR(
+      loom_cfg_loop_forest_build(&graph, &context->arena, &loop_forest));
+  uint64_t* trip_counts = NULL;
+  if (loop_forest.interval_count > 0) {
+    IREE_RETURN_IF_ERROR(
+        iree_arena_allocate_array(&context->arena, loop_forest.interval_count,
+                                  sizeof(*trip_counts), (void**)&trip_counts));
   }
-  uint8_t* loop_blocks = NULL;
-  uint16_t* loop_stack = NULL;
-  IREE_RETURN_IF_ERROR(
-      iree_arena_allocate_array(&context->arena, graph.block_count,
-                                sizeof(*loop_blocks), (void**)&loop_blocks));
-  IREE_RETURN_IF_ERROR(
-      iree_arena_allocate_array(&context->arena, graph.block_count,
-                                sizeof(*loop_stack), (void**)&loop_stack));
-  for (uint16_t block_index = 0; block_index < graph.block_count;
-       ++block_index) {
-    if (!loom_cfg_graph_block_is_reachable(&graph, block_index)) {
-      context->lowering.source_block_execution_counts[block_index] = 0;
-      continue;
-    }
+  for (iree_host_size_t i = 0; i < loop_forest.interval_count; ++i) {
     if (!loom_low_lower_memory_report_try_counted_cfg_loop(
-            context, &graph, block_index,
-            context->lowering.source_block_execution_counts,
-            counted_backedge_edges, loop_blocks, loop_stack)) {
+            context, &graph, &loop_forest.intervals[i], &trip_counts[i])) {
       context->lowering.source_block_execution_counts_exact = false;
       return iree_ok_status();
     }
   }
-  if (loom_low_lower_memory_report_has_uncounted_backedge(
-          &graph, counted_backedge_edges)) {
-    context->lowering.source_block_execution_counts_exact = false;
-  }
+  context->lowering.source_block_execution_counts_exact =
+      loom_cfg_loop_forest_calculate_block_execution_counts(
+          &loop_forest, trip_counts,
+          context->lowering.source_block_execution_counts);
   return iree_ok_status();
 }
 

--- a/loom/src/loom/codegen/low/schedule/BUILD.bazel
+++ b/loom/src/loom/codegen/low/schedule/BUILD.bazel
@@ -106,6 +106,7 @@ loom_cc_library(
         "//loom/src/loom/target:registers",
         "//loom/src/loom/target:residency",
         "//loom/src/loom/util:cfg_graph",
+        "//loom/src/loom/util:cfg_loop",
         "//loom/src/loom/util:json",
         "//loom/src/loom/util:segmented_storage",
         "//loom/src/loom/util:stream",

--- a/loom/src/loom/codegen/low/schedule/CMakeLists.txt
+++ b/loom/src/loom/codegen/low/schedule/CMakeLists.txt
@@ -110,6 +110,7 @@ loom_cc_library(
     loom::target::registers
     loom::target::residency
     loom::util::cfg_graph
+    loom::util::cfg_loop
     loom::util::json
     loom::util::segmented_storage
     loom::util::stream

--- a/loom/src/loom/codegen/low/schedule/run.c
+++ b/loom/src/loom/codegen/low/schedule/run.c
@@ -1465,7 +1465,6 @@ iree_status_t loom_low_schedule_function(
         .resource_summaries = state.resource_summaries,
         .resource_summary_count = state.resource_summary_count,
     };
-    out_table->loop_forest.graph = &out_table->cfg_graph;
     loom_low_schedule_dependency_graph_move(&state.dependencies,
                                             &out_table->dependencies);
   }

--- a/loom/src/loom/codegen/low/schedule/run.c
+++ b/loom/src/loom/codegen/low/schedule/run.c
@@ -1429,6 +1429,7 @@ iree_status_t loom_low_schedule_function(
                 .block_count = state.body->block_count,
             },
         .cfg_graph = model->cfg_graph,
+        .loop_forest = model->loop_forest,
         .nodes = state.nodes,
         .node_count = node_count,
         .dependency_group_count = state.dependency_index.group_count,
@@ -1464,6 +1465,7 @@ iree_status_t loom_low_schedule_function(
         .resource_summaries = state.resource_summaries,
         .resource_summary_count = state.resource_summary_count,
     };
+    out_table->loop_forest.graph = &out_table->cfg_graph;
     loom_low_schedule_dependency_graph_move(&state.dependencies,
                                             &out_table->dependencies);
   }

--- a/loom/src/loom/codegen/low/schedule/types.h
+++ b/loom/src/loom/codegen/low/schedule/types.h
@@ -30,6 +30,7 @@
 #include "loom/ir/ir.h"
 #include "loom/target/residency.h"
 #include "loom/util/cfg_graph.h"
+#include "loom/util/cfg_loop.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -642,6 +643,8 @@ typedef struct loom_low_schedule_table_t {
   loom_liveness_order_t operation_order;
   // Read-only control-flow graph shared by target planning overlays.
   loom_cfg_graph_t cfg_graph;
+  // Canonical loop intervals shared by target planning overlays.
+  loom_cfg_loop_forest_t loop_forest;
   // Per-op schedule nodes in source order.
   const loom_low_schedule_node_t* nodes;
   // Number of schedule nodes.

--- a/loom/src/loom/target/arch/amdgpu/planning/BUILD.bazel
+++ b/loom/src/loom/target/arch/amdgpu/planning/BUILD.bazel
@@ -209,6 +209,20 @@ loom_cc_library(
 )
 
 loom_cc_library(
+    name = "wait_loop",
+    srcs = ["wait_loop.c"],
+    hdrs = ["wait_loop.h"],
+    deps = [
+        "//loom/src/loom/codegen/low/schedule",
+        "//loom/src/loom/ops/low",
+        "//loom/src/loom/util:cfg_graph",
+        "//loom/src/loom/util:cfg_loop",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal:arena",
+    ],
+)
+
+loom_cc_library(
     name = "wait_plan",
     srcs = ["wait_plan.c"],
     hdrs = ["wait_plan.h"],
@@ -217,6 +231,7 @@ loom_cc_library(
         ":structural_packet",
         ":wait_counters",
         ":wait_frontier",
+        ":wait_loop",
         ":wait_packet_tables",
         "//loom/src/loom/codegen/low:allocation",
         "//loom/src/loom/codegen/low:descriptors",

--- a/loom/src/loom/target/arch/amdgpu/planning/CMakeLists.txt
+++ b/loom/src/loom/target/arch/amdgpu/planning/CMakeLists.txt
@@ -234,6 +234,25 @@ endif()
 if(LOOM_TARGET_ARCH_AMDGPU)
 loom_cc_library(
   NAME
+    wait_loop
+  HDRS
+    "wait_loop.h"
+  SRCS
+    "wait_loop.c"
+  DEPS
+    iree::base
+    iree::base::internal::arena
+    loom::codegen::low::schedule
+    loom::ops::low
+    loom::util::cfg_graph
+    loom::util::cfg_loop
+  PUBLIC
+)
+endif()
+
+if(LOOM_TARGET_ARCH_AMDGPU)
+loom_cc_library(
+  NAME
     wait_plan
   HDRS
     "wait_plan.h"
@@ -243,6 +262,7 @@ loom_cc_library(
     ::structural_packet
     ::wait_counters
     ::wait_frontier
+    ::wait_loop
     ::wait_packet_tables
     iree::base
     iree::base::internal

--- a/loom/src/loom/target/arch/amdgpu/planning/wait_frontier.c
+++ b/loom/src/loom/target/arch/amdgpu/planning/wait_frontier.c
@@ -174,6 +174,37 @@ static void loom_amdgpu_wait_storage_lease_state_drain(
   }
 }
 
+static bool loom_amdgpu_wait_storage_lease_state_union_after_drain_changed(
+    const loom_amdgpu_wait_frontier_t* frontier, uint64_t* target,
+    const uint64_t* source, uint32_t counter_mask) {
+  if (counter_mask == 0) {
+    return loom_amdgpu_wait_storage_lease_state_union_changed(
+        target, source, frontier->storage_leases.word_count);
+  }
+  bool changed = false;
+  // The inner mask traversal is bounded by the eight architectural wait
+  // counters, keeping this linear in the storage-lease word count.
+  for (iree_host_size_t word_index = 0;
+       word_index < frontier->storage_leases.word_count; ++word_index) {
+    uint64_t retained_source = source[word_index];
+    uint32_t remaining_counter_mask =
+        counter_mask & LOOM_AMDGPU_WAIT_COUNTER_MASK_ALL;
+    while (remaining_counter_mask != 0) {
+      const uint32_t counter_slot =
+          (uint32_t)iree_math_count_trailing_zeros_u32(remaining_counter_mask);
+      const uint64_t* release_counter_words =
+          loom_amdgpu_wait_frontier_const_storage_lease_counter_words(
+              frontier, counter_slot);
+      retained_source &= ~release_counter_words[word_index];
+      remaining_counter_mask &= remaining_counter_mask - 1;
+    }
+    const uint64_t result = target[word_index] | retained_source;
+    changed |= result != target[word_index];
+    target[word_index] = result;
+  }
+  return changed;
+}
+
 static void loom_amdgpu_wait_storage_lease_state_drain_xcnt_groups(
     const loom_amdgpu_wait_frontier_t* frontier, uint64_t* words,
     loom_amdgpu_wait_xcnt_group_flags_t group_flags) {
@@ -434,7 +465,8 @@ static void loom_amdgpu_wait_frontier_apply_static_xcnt_producer(
 }
 
 static void loom_amdgpu_wait_frontier_build_local_states(
-    loom_amdgpu_wait_frontier_t* frontier) {
+    loom_amdgpu_wait_frontier_t* frontier,
+    const uint32_t* planned_block_drain_counter_masks) {
   const loom_low_schedule_table_t* schedule = frontier->schedule;
   iree_host_size_t next_storage_lease_index = 0;
   for (iree_host_size_t block_index = 0; block_index < schedule->block_count;
@@ -460,6 +492,7 @@ static void loom_amdgpu_wait_frontier_build_local_states(
         frontier->xcnt.static_outgoing_flags == NULL
             ? NULL
             : &frontier->xcnt.static_outgoing_flags[block_index];
+    uint32_t block_drain_counter_mask = 0;
     for (uint32_t i = 0; i < block->scheduled_node_count; ++i) {
       const iree_host_size_t packet_index =
           (iree_host_size_t)block->scheduled_node_start + i;
@@ -467,15 +500,20 @@ static void loom_amdgpu_wait_frontier_build_local_states(
           schedule->scheduled_node_indices[packet_index];
       const loom_amdgpu_wait_frontier_node_t* node =
           &frontier->nodes[node_index];
+      uint32_t drain_counter_mask = node->drain_counter_mask;
+      if (planned_block_drain_counter_masks != NULL &&
+          schedule->nodes[node_index].op == block->block->last_op) {
+        drain_counter_mask |= planned_block_drain_counter_masks[block_index];
+      }
+      block_drain_counter_mask |= drain_counter_mask;
       if (memory_state != NULL) {
-        loom_amdgpu_wait_memory_state_drain(memory_state,
-                                            node->drain_counter_mask);
+        loom_amdgpu_wait_memory_state_drain(memory_state, drain_counter_mask);
         loom_amdgpu_wait_memory_state_add_node(memory_state, node,
                                                node->read_counter_mask,
                                                node->write_counter_mask);
       }
       if (vmem_result_words != NULL) {
-        if (iree_any_bit_set(node->drain_counter_mask,
+        if (iree_any_bit_set(drain_counter_mask,
                              LOOM_AMDGPU_WAIT_COUNTER_MASK_VMEM_LOAD)) {
           memset(
               vmem_result_words, 0,
@@ -486,10 +524,10 @@ static void loom_amdgpu_wait_frontier_build_local_states(
       }
       if (storage_lease_words != NULL) {
         loom_amdgpu_wait_storage_lease_state_drain(
-            frontier, storage_lease_words, node->drain_counter_mask);
+            frontier, storage_lease_words, drain_counter_mask);
       }
       if (xcnt_group_flags != NULL) {
-        if (iree_any_bit_set(node->drain_counter_mask,
+        if (iree_any_bit_set(drain_counter_mask,
                              LOOM_AMDGPU_WAIT_COUNTER_MASK_X)) {
           *xcnt_group_flags = 0;
         }
@@ -503,6 +541,7 @@ static void loom_amdgpu_wait_frontier_build_local_states(
             /*excluded_counter_mask=*/0, &next_storage_lease_index);
       }
     }
+    frontier->block_drain_counter_masks[block_index] = block_drain_counter_mask;
   }
 }
 
@@ -510,12 +549,19 @@ static bool loom_amdgpu_wait_frontier_block_state_union_changed(
     loom_amdgpu_wait_frontier_t* frontier, uint16_t target_block,
     uint16_t source_block) {
   bool changed = false;
+  const uint32_t drain_counter_mask =
+      frontier->block_drain_counter_masks[target_block];
   if (frontier->memory.static_outgoing_states != NULL) {
+    loom_amdgpu_wait_memory_state_t incoming_state =
+        frontier->memory.static_outgoing_states[source_block];
+    loom_amdgpu_wait_memory_state_drain(&incoming_state, drain_counter_mask);
     changed |= loom_amdgpu_wait_memory_state_union_changed(
         &frontier->memory.static_outgoing_states[target_block],
-        &frontier->memory.static_outgoing_states[source_block]);
+        &incoming_state);
   }
-  if (frontier->vmem_results.static_outgoing_words != NULL) {
+  if (frontier->vmem_results.static_outgoing_words != NULL &&
+      !iree_any_bit_set(drain_counter_mask,
+                        LOOM_AMDGPU_WAIT_COUNTER_MASK_VMEM_LOAD)) {
     changed |= loom_amdgpu_wait_vmem_result_state_union_changed(
         loom_amdgpu_wait_frontier_vmem_result_block_words(
             frontier, frontier->vmem_results.static_outgoing_words,
@@ -526,16 +572,18 @@ static bool loom_amdgpu_wait_frontier_block_state_union_changed(
         frontier->vmem_results.word_count);
   }
   if (frontier->storage_leases.static_outgoing_words != NULL) {
-    changed |= loom_amdgpu_wait_storage_lease_state_union_changed(
+    changed |= loom_amdgpu_wait_storage_lease_state_union_after_drain_changed(
+        frontier,
         loom_amdgpu_wait_frontier_storage_lease_block_words(
             frontier, frontier->storage_leases.static_outgoing_words,
             target_block),
         loom_amdgpu_wait_frontier_const_storage_lease_block_words(
             frontier, frontier->storage_leases.static_outgoing_words,
             source_block),
-        frontier->storage_leases.word_count);
+        drain_counter_mask);
   }
-  if (frontier->xcnt.static_outgoing_flags != NULL) {
+  if (frontier->xcnt.static_outgoing_flags != NULL &&
+      !iree_any_bit_set(drain_counter_mask, LOOM_AMDGPU_WAIT_COUNTER_MASK_X)) {
     const loom_amdgpu_wait_xcnt_group_flags_t flags =
         frontier->xcnt.static_outgoing_flags[target_block] |
         frontier->xcnt.static_outgoing_flags[source_block];
@@ -631,6 +679,7 @@ iree_status_t loom_amdgpu_wait_frontier_initialize(
     const loom_low_allocation_table_t* allocation,
     const loom_amdgpu_wait_frontier_node_t* nodes,
     iree_host_size_t vgpr_unit_count, iree_host_size_t agpr_unit_count,
+    const uint32_t* planned_block_drain_counter_masks,
     iree_arena_allocator_t* arena, loom_amdgpu_wait_frontier_t* out_frontier) {
   IREE_ASSERT_ARGUMENT(schedule);
   IREE_ASSERT_ARGUMENT(arena);
@@ -810,6 +859,13 @@ iree_status_t loom_amdgpu_wait_frontier_initialize(
                sizeof(*out_frontier->xcnt.resolved_outgoing_flags));
   }
   IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      arena, schedule->block_count,
+      sizeof(*out_frontier->block_drain_counter_masks),
+      (void**)&out_frontier->block_drain_counter_masks));
+  memset(
+      out_frontier->block_drain_counter_masks, 0,
+      schedule->block_count * sizeof(*out_frontier->block_drain_counter_masks));
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
       arena, schedule->block_count, sizeof(*out_frontier->block_flags),
       (void**)&out_frontier->block_flags));
   uint16_t* worklist = NULL;
@@ -818,7 +874,8 @@ iree_status_t loom_amdgpu_wait_frontier_initialize(
   memset(out_frontier->block_flags, 0,
          schedule->block_count * sizeof(*out_frontier->block_flags));
 
-  loom_amdgpu_wait_frontier_build_local_states(out_frontier);
+  loom_amdgpu_wait_frontier_build_local_states(
+      out_frontier, planned_block_drain_counter_masks);
   loom_amdgpu_wait_frontier_propagate_static_states(out_frontier, worklist);
   return iree_ok_status();
 }

--- a/loom/src/loom/target/arch/amdgpu/planning/wait_frontier.h
+++ b/loom/src/loom/target/arch/amdgpu/planning/wait_frontier.h
@@ -138,6 +138,8 @@ typedef struct loom_amdgpu_wait_frontier_t {
     // Incoming and locally produced groups active in the current block.
     loom_amdgpu_wait_xcnt_group_flags_t active_flags;
   } xcnt;
+  // Counter classes fully drained on every path through each block.
+  uint32_t* block_drain_counter_masks;
   // Per-block worklist and resolved-state bits.
   uint8_t* block_flags;
   // Current block index, or UINT16_MAX outside block processing.
@@ -156,6 +158,7 @@ iree_status_t loom_amdgpu_wait_frontier_initialize(
     const loom_low_allocation_table_t* allocation,
     const loom_amdgpu_wait_frontier_node_t* nodes,
     iree_host_size_t vgpr_unit_count, iree_host_size_t agpr_unit_count,
+    const uint32_t* planned_block_drain_counter_masks,
     iree_arena_allocator_t* arena, loom_amdgpu_wait_frontier_t* out_frontier);
 
 // Begins processing |block_index| and selects predecessor state. Processed

--- a/loom/src/loom/target/arch/amdgpu/planning/wait_loop.c
+++ b/loom/src/loom/target/arch/amdgpu/planning/wait_loop.c
@@ -1,0 +1,162 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/target/arch/amdgpu/planning/wait_loop.h"
+
+#include "loom/ops/low/ops.h"
+#include "loom/util/cfg_graph.h"
+
+// Number of binary-ancestor levels needed for uint16_t CFG block indices.
+#define LOOM_AMDGPU_WAIT_LOOP_ANCESTOR_LEVEL_COUNT 16u
+
+// AMDGPU eligibility layered over one generic canonical loop interval.
+struct loom_amdgpu_wait_loop_t {
+  // Nearest eligible enclosing loop, or LOOM_CFG_LOOP_NONE.
+  uint32_t valid_parent_loop_index;
+  // Whether both loop edges have the required target-low branch shape.
+  bool is_valid;
+};
+
+static bool loom_amdgpu_wait_loop_interval_is_supported(
+    const loom_low_schedule_table_t* schedule,
+    const loom_cfg_loop_interval_t* interval) {
+  if (!interval->is_canonical) return false;
+  const loom_cfg_graph_t* graph = &schedule->cfg_graph;
+  const loom_cfg_edge_info_t* entry_edge =
+      loom_cfg_graph_edge(graph, interval->entry_edge_index);
+  const loom_cfg_edge_info_t* backedge =
+      loom_cfg_graph_edge(graph, interval->backedge_edge_index);
+  const loom_block_t* header = graph->blocks[interval->header_index].block;
+  if (entry_edge == NULL || backedge == NULL ||
+      entry_edge->terminator == NULL || backedge->terminator == NULL ||
+      !loom_low_br_isa(entry_edge->terminator) ||
+      loom_low_br_dest(entry_edge->terminator) != header ||
+      !loom_low_br_isa(backedge->terminator) ||
+      loom_low_br_dest(backedge->terminator) != header ||
+      backedge->successor_index != 0) {
+    return false;
+  }
+
+  const loom_low_schedule_block_t* preheader =
+      &schedule->blocks[interval->preheader_index];
+  if (preheader->node_count == 0) return false;
+  const uint32_t insertion_node =
+      preheader->node_start + preheader->node_count - 1;
+  IREE_ASSERT_LT(insertion_node, schedule->node_count);
+  return schedule->nodes[insertion_node].op == entry_edge->terminator;
+}
+
+static iree_host_size_t loom_amdgpu_wait_loop_ancestor_slot_index(
+    uint32_t level, iree_host_size_t loop_count, uint32_t loop_index) {
+  IREE_ASSERT_LT(level, LOOM_AMDGPU_WAIT_LOOP_ANCESTOR_LEVEL_COUNT);
+  IREE_ASSERT_LT(loop_index, loop_count);
+  return (iree_host_size_t)level * loop_count + loop_index;
+}
+
+iree_status_t loom_amdgpu_wait_loop_analysis_initialize(
+    const loom_low_schedule_table_t* schedule, iree_arena_allocator_t* arena,
+    loom_amdgpu_wait_loop_analysis_t* out_analysis) {
+  IREE_ASSERT_ARGUMENT(schedule);
+  IREE_ASSERT_ARGUMENT(arena);
+  IREE_ASSERT_ARGUMENT(out_analysis);
+  *out_analysis = (loom_amdgpu_wait_loop_analysis_t){
+      .schedule = schedule,
+  };
+  const loom_cfg_loop_forest_t* forest = &schedule->loop_forest;
+  if (forest->interval_count == 0) return iree_ok_status();
+
+  loom_amdgpu_wait_loop_t* loops = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      arena, forest->interval_count, sizeof(*loops), (void**)&loops));
+  for (iree_host_size_t i = 0; i < forest->interval_count; ++i) {
+    const loom_cfg_loop_interval_t* interval = &forest->intervals[i];
+    const uint32_t parent_loop = interval->parent_loop_index;
+    uint32_t valid_parent_loop = LOOM_CFG_LOOP_NONE;
+    if (parent_loop != LOOM_CFG_LOOP_NONE) {
+      valid_parent_loop = loops[parent_loop].is_valid
+                              ? parent_loop
+                              : loops[parent_loop].valid_parent_loop_index;
+    }
+    loops[i] = (loom_amdgpu_wait_loop_t){
+        .valid_parent_loop_index = valid_parent_loop,
+        .is_valid =
+            loom_amdgpu_wait_loop_interval_is_supported(schedule, interval),
+    };
+  }
+
+  // Sixteen rows cover every ancestor distance representable by uint16_t block
+  // indices and make each dependency query a fixed number of probes.
+  const iree_host_size_t ancestor_slot_count =
+      forest->interval_count * LOOM_AMDGPU_WAIT_LOOP_ANCESTOR_LEVEL_COUNT;
+  uint32_t* valid_ancestor_loops = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      arena, ancestor_slot_count, sizeof(*valid_ancestor_loops),
+      (void**)&valid_ancestor_loops));
+  for (iree_host_size_t i = 0; i < forest->interval_count; ++i) {
+    valid_ancestor_loops[loom_amdgpu_wait_loop_ancestor_slot_index(
+        /*level=*/0, forest->interval_count, (uint32_t)i)] =
+        loops[i].is_valid ? loops[i].valid_parent_loop_index
+                          : LOOM_CFG_LOOP_NONE;
+  }
+  for (uint32_t level = 1; level < LOOM_AMDGPU_WAIT_LOOP_ANCESTOR_LEVEL_COUNT;
+       ++level) {
+    for (iree_host_size_t i = 0; i < forest->interval_count; ++i) {
+      const uint32_t prior_ancestor =
+          valid_ancestor_loops[loom_amdgpu_wait_loop_ancestor_slot_index(
+              level - 1, forest->interval_count, (uint32_t)i)];
+      valid_ancestor_loops[loom_amdgpu_wait_loop_ancestor_slot_index(
+          level, forest->interval_count, (uint32_t)i)] =
+          prior_ancestor == LOOM_CFG_LOOP_NONE
+              ? LOOM_CFG_LOOP_NONE
+              : valid_ancestor_loops[loom_amdgpu_wait_loop_ancestor_slot_index(
+                    level - 1, forest->interval_count, prior_ancestor)];
+    }
+  }
+
+  *out_analysis = (loom_amdgpu_wait_loop_analysis_t){
+      .schedule = schedule,
+      .loops = loops,
+      .valid_ancestor_loops = valid_ancestor_loops,
+      .loop_count = forest->interval_count,
+  };
+  return iree_ok_status();
+}
+
+uint16_t loom_amdgpu_wait_loop_analysis_preheader(
+    const loom_amdgpu_wait_loop_analysis_t* analysis, uint32_t producer_node,
+    uint32_t consumer_node) {
+  if (analysis->loop_count == 0) return UINT16_MAX;
+  const loom_cfg_loop_forest_t* forest = &analysis->schedule->loop_forest;
+  const uint16_t producer_block =
+      analysis->schedule->nodes[producer_node].block_index;
+  const uint16_t consumer_block =
+      analysis->schedule->nodes[consumer_node].block_index;
+  const uint32_t innermost_loop =
+      forest->innermost_loop_indices[consumer_block];
+  if (innermost_loop == LOOM_CFG_LOOP_NONE) return UINT16_MAX;
+
+  uint32_t loop_index =
+      analysis->loops[innermost_loop].is_valid
+          ? innermost_loop
+          : analysis->loops[innermost_loop].valid_parent_loop_index;
+  if (loop_index == LOOM_CFG_LOOP_NONE ||
+      forest->intervals[loop_index].header_index <= producer_block) {
+    return UINT16_MAX;
+  }
+
+  for (uint32_t i = LOOM_AMDGPU_WAIT_LOOP_ANCESTOR_LEVEL_COUNT; i > 0; --i) {
+    const uint32_t level = i - 1;
+    const uint32_t ancestor_loop =
+        analysis
+            ->valid_ancestor_loops[loom_amdgpu_wait_loop_ancestor_slot_index(
+                level, analysis->loop_count, loop_index)];
+    if (ancestor_loop != LOOM_CFG_LOOP_NONE &&
+        forest->intervals[ancestor_loop].header_index > producer_block) {
+      loop_index = ancestor_loop;
+    }
+  }
+  return forest->intervals[loop_index].preheader_index;
+}

--- a/loom/src/loom/target/arch/amdgpu/planning/wait_loop.c
+++ b/loom/src/loom/target/arch/amdgpu/planning/wait_loop.c
@@ -39,9 +39,14 @@ static bool loom_amdgpu_wait_loop_interval_is_supported(
       backedge->successor_index != 0) {
     return false;
   }
+  const loom_cfg_block_index_span_t entry_successors =
+      loom_cfg_graph_successors(graph, entry_edge->source_block_index);
+  if (entry_successors.count != 1 || entry_edge->successor_index != 0) {
+    return false;
+  }
 
   const loom_low_schedule_block_t* preheader =
-      &schedule->blocks[interval->preheader_index];
+      &schedule->blocks[interval->entry_predecessor_index];
   if (preheader->node_count == 0) return false;
   const uint32_t insertion_node =
       preheader->node_start + preheader->node_count - 1;
@@ -158,5 +163,5 @@ uint16_t loom_amdgpu_wait_loop_analysis_preheader(
       loop_index = ancestor_loop;
     }
   }
-  return forest->intervals[loop_index].preheader_index;
+  return forest->intervals[loop_index].entry_predecessor_index;
 }

--- a/loom/src/loom/target/arch/amdgpu/planning/wait_loop.h
+++ b/loom/src/loom/target/arch/amdgpu/planning/wait_loop.h
@@ -1,0 +1,56 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Canonical loop-interval analysis for AMDGPU wait placement.
+
+#ifndef LOOM_TARGET_ARCH_AMDGPU_PLANNING_WAIT_LOOP_H_
+#define LOOM_TARGET_ARCH_AMDGPU_PLANNING_WAIT_LOOP_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/arena.h"
+#include "loom/codegen/low/schedule/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct loom_amdgpu_wait_loop_t loom_amdgpu_wait_loop_t;
+
+// Transient AMDGPU eligibility and ancestor index over the schedule's preserved
+// canonical loop forest. Unsupported target-low edge shapes remain valid but
+// produce no relocation target.
+typedef struct loom_amdgpu_wait_loop_analysis_t {
+  // Schedule whose CFG and node table are analyzed.
+  const loom_low_schedule_table_t* schedule;
+  // Canonical loop records in header order.
+  const loom_amdgpu_wait_loop_t* loops;
+  // Binary-lifted valid ancestor loop indices.
+  const uint32_t* valid_ancestor_loops;
+  // Number of canonical loop records.
+  iree_host_size_t loop_count;
+} loom_amdgpu_wait_loop_analysis_t;
+
+// Builds target eligibility and a bounded ancestor index in |arena| from the
+// function model's preserved loop forest. Construction takes O(16L) time and
+// storage for L candidate loops. Acyclic schedules perform no allocations and
+// return an empty analysis.
+iree_status_t loom_amdgpu_wait_loop_analysis_initialize(
+    const loom_low_schedule_table_t* schedule, iree_arena_allocator_t* arena,
+    loom_amdgpu_wait_loop_analysis_t* out_analysis);
+
+// Returns the dedicated preheader that safely dominates |consumer_node| and
+// follows |producer_node|, choosing the outermost eligible loop. Returns
+// UINT16_MAX when the dependency must remain at its exact consumer. Queries
+// perform at most 16 ancestor probes independent of loop nesting depth.
+uint16_t loom_amdgpu_wait_loop_analysis_preheader(
+    const loom_amdgpu_wait_loop_analysis_t* analysis, uint32_t producer_node,
+    uint32_t consumer_node);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_TARGET_ARCH_AMDGPU_PLANNING_WAIT_LOOP_H_

--- a/loom/src/loom/target/arch/amdgpu/planning/wait_plan.c
+++ b/loom/src/loom/target/arch/amdgpu/planning/wait_plan.c
@@ -20,6 +20,7 @@
 #include "loom/ops/low/ops.h"
 #include "loom/target/arch/amdgpu/planning/structural_packet.h"
 #include "loom/target/arch/amdgpu/planning/wait_frontier.h"
+#include "loom/target/arch/amdgpu/planning/wait_loop.h"
 #include "loom/target/arch/amdgpu/planning/wait_packet_tables.h"
 #include "loom/target/arch/amdgpu/refs/target_refs.h"
 #include "loom/target/arch/amdgpu/target_id/target_id.h"
@@ -207,6 +208,12 @@ typedef struct loom_amdgpu_wait_plan_builder_t {
   uint32_t* first_block_arg_source_by_value;
   // Incoming low.br source records for non-entry block arguments.
   loom_amdgpu_wait_block_arg_source_t* block_arg_sources;
+  // Representative SSA dependency indexed by loop-entry block and counter.
+  uint32_t* loop_entry_dependency_links;
+  // Original consumer indexed by loop-entry block and counter.
+  uint32_t* loop_entry_consumer_nodes;
+  // Counter classes fully drained at each planned loop-entry block.
+  uint32_t* loop_entry_drain_counter_masks;
   // Storage-release actions grouped by insertion node.
   loom_low_storage_release_action_index_t storage_release_action_index;
   // DFS visit epoch per value while forwarding SSA wait dependencies.
@@ -1899,6 +1906,101 @@ static iree_status_t loom_amdgpu_wait_plan_classify_nodes(
   return loom_amdgpu_wait_plan_build_dependency_links(builder);
 }
 
+static iree_host_size_t loom_amdgpu_wait_plan_loop_entry_slot_index(
+    uint16_t block_index, uint32_t counter_slot) {
+  IREE_ASSERT_LT(counter_slot, LOOM_AMDGPU_WAIT_COUNTER_SLOT_COUNT);
+  return (iree_host_size_t)block_index * LOOM_AMDGPU_WAIT_COUNTER_SLOT_COUNT +
+         counter_slot;
+}
+
+static iree_status_t loom_amdgpu_wait_plan_allocate_loop_entry_tables(
+    loom_amdgpu_wait_plan_builder_t* builder) {
+  const iree_host_size_t entry_slot_count =
+      builder->schedule->block_count * LOOM_AMDGPU_WAIT_COUNTER_SLOT_COUNT;
+  IREE_RETURN_IF_ERROR(
+      iree_arena_allocate_array(builder->transient_arena, entry_slot_count,
+                                sizeof(*builder->loop_entry_dependency_links),
+                                (void**)&builder->loop_entry_dependency_links));
+  IREE_RETURN_IF_ERROR(
+      iree_arena_allocate_array(builder->transient_arena, entry_slot_count,
+                                sizeof(*builder->loop_entry_consumer_nodes),
+                                (void**)&builder->loop_entry_consumer_nodes));
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      builder->transient_arena, builder->schedule->block_count,
+      sizeof(*builder->loop_entry_drain_counter_masks),
+      (void**)&builder->loop_entry_drain_counter_masks));
+  for (iree_host_size_t i = 0; i < entry_slot_count; ++i) {
+    builder->loop_entry_dependency_links[i] = LOOM_LOW_SCHEDULE_NODE_NONE;
+    builder->loop_entry_consumer_nodes[i] = LOOM_LOW_SCHEDULE_NODE_NONE;
+  }
+  memset(builder->loop_entry_drain_counter_masks, 0,
+         builder->schedule->block_count *
+             sizeof(*builder->loop_entry_drain_counter_masks));
+  return iree_ok_status();
+}
+
+static iree_status_t loom_amdgpu_wait_plan_relocate_loop_entry_dependencies(
+    loom_amdgpu_wait_plan_builder_t* builder) {
+  const loom_low_schedule_table_t* schedule = builder->schedule;
+  if (builder->dependency_link_count == 0 || schedule->block_count <= 1 ||
+      schedule->cfg_graph.blocks == NULL) {
+    return iree_ok_status();
+  }
+
+  loom_amdgpu_wait_loop_analysis_t loop_analysis = {0};
+  IREE_RETURN_IF_ERROR(loom_amdgpu_wait_loop_analysis_initialize(
+      schedule, builder->transient_arena, &loop_analysis));
+  if (loop_analysis.loop_count == 0) return iree_ok_status();
+
+  // Consumer adjacency lists partition the dependency-link table. The nested
+  // loop therefore takes O(N+16D) for N nodes and D dependency links: it visits
+  // each node and link once, then performs at most 16 ancestor probes per link.
+  // It never rescans links or loop bodies for each natural loop.
+  for (uint32_t consumer_node = 0; consumer_node < schedule->node_count;
+       ++consumer_node) {
+    uint32_t* link_index_ptr =
+        &builder->first_dependency_link_by_consumer[consumer_node];
+    while (*link_index_ptr != LOOM_LOW_SCHEDULE_NODE_NONE) {
+      const uint32_t link_index = *link_index_ptr;
+      loom_amdgpu_wait_dependency_link_t* link =
+          &builder->dependency_links[link_index];
+      const uint32_t next_link = link->next_link;
+      if (link->reason != LOOM_AMDGPU_WAIT_PLAN_REASON_SSA_USE ||
+          iree_math_count_ones_u32(link->counter_mask) != 1) {
+        link_index_ptr = &link->next_link;
+        continue;
+      }
+      const uint16_t preheader_index = loom_amdgpu_wait_loop_analysis_preheader(
+          &loop_analysis, link->producer_node, consumer_node);
+      if (preheader_index == UINT16_MAX) {
+        link_index_ptr = &link->next_link;
+        continue;
+      }
+
+      if (builder->loop_entry_dependency_links == NULL) {
+        IREE_RETURN_IF_ERROR(
+            loom_amdgpu_wait_plan_allocate_loop_entry_tables(builder));
+      }
+
+      *link_index_ptr = next_link;
+      const uint32_t counter_slot =
+          (uint32_t)iree_math_count_trailing_zeros_u32(link->counter_mask);
+      const iree_host_size_t entry_slot_index =
+          loom_amdgpu_wait_plan_loop_entry_slot_index(preheader_index,
+                                                      counter_slot);
+      if (builder->loop_entry_dependency_links[entry_slot_index] ==
+          LOOM_LOW_SCHEDULE_NODE_NONE) {
+        builder->loop_entry_dependency_links[entry_slot_index] = link_index;
+        builder->loop_entry_consumer_nodes[entry_slot_index] = consumer_node;
+        builder->loop_entry_drain_counter_masks[preheader_index] |=
+            link->counter_mask;
+      }
+      link->next_link = LOOM_LOW_SCHEDULE_NODE_NONE;
+    }
+  }
+  return iree_ok_status();
+}
+
 static void loom_amdgpu_wait_plan_mark_drained_producers(
     loom_amdgpu_wait_plan_builder_t* builder, uint32_t node_index,
     uint32_t slot, uint32_t completed_position_count) {
@@ -2048,38 +2150,52 @@ static void loom_amdgpu_wait_plan_apply_counter_progress(
   }
 }
 
-static iree_status_t loom_amdgpu_wait_plan_wait_counter(
+static iree_status_t loom_amdgpu_wait_plan_wait_counter_at(
     loom_amdgpu_wait_plan_builder_t* builder,
     loom_amdgpu_wait_plan_action_kind_t kind,
     loom_amdgpu_wait_plan_action_flags_t flags,
-    loom_amdgpu_wait_plan_reason_t reason, uint32_t node_index,
-    uint32_t producer_node, uint16_t counter_id, uint16_t target_count) {
-  const loom_low_schedule_node_t* node = &builder->schedule->nodes[node_index];
+    loom_amdgpu_wait_plan_reason_t reason, uint32_t insertion_node,
+    uint32_t producer_node, uint32_t consumer_node, uint16_t counter_id,
+    uint16_t target_count) {
+  const loom_low_schedule_node_t* node =
+      &builder->schedule->nodes[insertion_node];
   IREE_ASSERT(loom_amdgpu_wait_counter_id_is_valid(counter_id));
   const uint32_t slot = loom_amdgpu_wait_counter_slot_from_id(counter_id);
   const uint32_t outstanding_before = builder->outstanding_counts[slot];
   target_count = loom_amdgpu_wait_plan_normalize_target_count(
       builder, counter_id, target_count);
   IREE_RETURN_IF_ERROR(loom_amdgpu_wait_plan_append_action(
-      builder,
-      (loom_amdgpu_wait_plan_action_t){
-          .kind = kind,
-          .flags = flags,
-          .reason = reason,
-          .counter_id = counter_id,
-          .target_count = target_count,
-          .block_index = node->block_index,
-          .node_index = node_index,
-          .scheduled_ordinal = node->scheduled_ordinal,
-          .producer_node = producer_node,
-          .consumer_node = loom_amdgpu_wait_plan_reason_has_consumer(reason)
-                               ? node_index
-                               : LOOM_LOW_SCHEDULE_NODE_NONE,
-          .outstanding_before = outstanding_before,
-      }));
+      builder, (loom_amdgpu_wait_plan_action_t){
+                   .kind = kind,
+                   .flags = flags,
+                   .reason = reason,
+                   .counter_id = counter_id,
+                   .target_count = target_count,
+                   .block_index = node->block_index,
+                   .node_index = insertion_node,
+                   .scheduled_ordinal = node->scheduled_ordinal,
+                   .producer_node = producer_node,
+                   .consumer_node = consumer_node,
+                   .outstanding_before = outstanding_before,
+               }));
   loom_amdgpu_wait_plan_apply_counter_progress(
-      builder, node_index, producer_node, counter_id, target_count);
+      builder, insertion_node, producer_node, counter_id, target_count);
   return iree_ok_status();
+}
+
+static iree_status_t loom_amdgpu_wait_plan_wait_counter(
+    loom_amdgpu_wait_plan_builder_t* builder,
+    loom_amdgpu_wait_plan_action_kind_t kind,
+    loom_amdgpu_wait_plan_action_flags_t flags,
+    loom_amdgpu_wait_plan_reason_t reason, uint32_t node_index,
+    uint32_t producer_node, uint16_t counter_id, uint16_t target_count) {
+  const uint32_t consumer_node =
+      loom_amdgpu_wait_plan_reason_has_consumer(reason)
+          ? node_index
+          : LOOM_LOW_SCHEDULE_NODE_NONE;
+  return loom_amdgpu_wait_plan_wait_counter_at(
+      builder, kind, flags, reason, node_index, producer_node, consumer_node,
+      counter_id, target_count);
 }
 
 static iree_status_t loom_amdgpu_wait_plan_drain_counter(
@@ -2104,6 +2220,31 @@ static iree_status_t loom_amdgpu_wait_plan_drain_mask(
     const uint16_t counter_id = loom_amdgpu_wait_counter_id_from_slot(slot);
     IREE_RETURN_IF_ERROR(loom_amdgpu_wait_plan_drain_counter(
         builder, kind, reason, node_index, producer_node, counter_id));
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_amdgpu_wait_plan_handle_loop_entry_dependencies(
+    loom_amdgpu_wait_plan_builder_t* builder, uint32_t node_index) {
+  if (builder->loop_entry_dependency_links == NULL) return iree_ok_status();
+  const loom_low_schedule_node_t* node = &builder->schedule->nodes[node_index];
+  const loom_low_schedule_block_t* block =
+      &builder->schedule->blocks[node->block_index];
+  if (node->op != block->block->last_op) return iree_ok_status();
+
+  for (uint32_t slot = 0; slot < LOOM_AMDGPU_WAIT_COUNTER_SLOT_COUNT; ++slot) {
+    const iree_host_size_t entry_slot_index =
+        loom_amdgpu_wait_plan_loop_entry_slot_index(node->block_index, slot);
+    const uint32_t link_index =
+        builder->loop_entry_dependency_links[entry_slot_index];
+    if (link_index == LOOM_LOW_SCHEDULE_NODE_NONE) continue;
+    const loom_amdgpu_wait_dependency_link_t* link =
+        &builder->dependency_links[link_index];
+    IREE_RETURN_IF_ERROR(loom_amdgpu_wait_plan_wait_counter_at(
+        builder, LOOM_AMDGPU_WAIT_PLAN_ACTION_PLANNED, /*flags=*/0,
+        link->reason, node_index, link->producer_node,
+        builder->loop_entry_consumer_nodes[entry_slot_index],
+        loom_amdgpu_wait_counter_id_from_slot(slot), /*target_count=*/0));
   }
   return iree_ok_status();
 }
@@ -3119,6 +3260,10 @@ static iree_status_t loom_amdgpu_wait_plan_process_node(
     loom_amdgpu_wait_plan_builder_t* builder, uint32_t node_index) {
   loom_amdgpu_wait_node_state_t* node_state = &builder->node_states[node_index];
 
+  // Loop-entry waits execute before branch-edge copies and the branch packet.
+  // Their producer/consumer provenance still names the original loop use.
+  IREE_RETURN_IF_ERROR(loom_amdgpu_wait_plan_handle_loop_entry_dependencies(
+      builder, node_index));
   // Branch-edge copies execute before the packet represented by the source
   // node. Protect them before crediting any progress supplied by that packet,
   // including an implicit XCNT drain from a hardware branch.
@@ -3407,13 +3552,17 @@ iree_status_t loom_amdgpu_wait_plan_build(
     status = loom_amdgpu_wait_plan_classify_nodes(&builder);
   }
   if (iree_status_is_ok(status)) {
+    status = loom_amdgpu_wait_plan_relocate_loop_entry_dependencies(&builder);
+  }
+  if (iree_status_is_ok(status)) {
     status = loom_amdgpu_wait_plan_allocate_physical_state(&builder);
   }
   if (iree_status_is_ok(status)) {
     status = loom_amdgpu_wait_frontier_initialize(
         schedule, allocation, builder.frontier_nodes,
         builder.physical_registers.vgpr_count,
-        builder.physical_registers.agpr_count, transient_arena,
+        builder.physical_registers.agpr_count,
+        builder.loop_entry_drain_counter_masks, transient_arena,
         &builder.frontier);
   }
   if (iree_status_is_ok(status)) {

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/low_wait_plan.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/low_wait_plan.loom-test
@@ -368,6 +368,112 @@ low.func.def target<amdgpu.rdna3.core>(@target) @loop_carried_branch_arg_waits_a
   s_endpgm
 
 // ====
+// RUN: emit amdgpu-wait-counter-plan-json @nested_loop_invariant_loads_wait_at_outermost_preheaders strategy=source
+
+amdgpu.target<gfx1100> @target
+low.func.def target<amdgpu.rdna3.core>(@target) @nested_loop_invariant_loads_wait_at_outermost_preheaders(%addr: reg<amdgpu.vgpr>, %outer_base: reg<amdgpu.sgpr x2>, %inner_base: reg<amdgpu.sgpr x2>, %output: reg<amdgpu.sgpr x2>, %outer_limit: reg<amdgpu.sgpr>, %inner_limit: reg<amdgpu.sgpr>) asm {
+  %outer_value = global_load_b32_saddr %addr, %outer_base
+  %zero_s = s_mov_b32 0
+  %zero_v = v_mov_b32 0
+  low.br ^outer(%zero_s: reg<amdgpu.sgpr>, %zero_v: reg<amdgpu.vgpr>)
+^outer(%outer_i: reg<amdgpu.sgpr>, %outer_acc: reg<amdgpu.vgpr>):
+  %outer_active = s_cmp_lt_i32 %outer_i, %outer_limit
+  low.cond_br %outer_active, ^outer_body, ^exit : reg<amdgpu.scc>
+^outer_body:
+  %inner_value = global_load_b32_saddr %addr, %inner_base
+  low.br ^inner(%zero_s: reg<amdgpu.sgpr>, %outer_acc: reg<amdgpu.vgpr>)
+^inner(%inner_i: reg<amdgpu.sgpr>, %inner_acc: reg<amdgpu.vgpr>):
+  %inner_active = s_cmp_lt_i32 %inner_i, %inner_limit
+  low.cond_br %inner_active, ^inner_body, ^outer_latch : reg<amdgpu.scc>
+^inner_body:
+  %with_outer = v_add_f32 %inner_acc, %outer_value
+  %next_acc = v_add_f32 %with_outer, %inner_value
+  %one = s_mov_b32 1
+  %next_inner_i = s_add_u32 %inner_i, %one
+  low.br ^inner(%next_inner_i: reg<amdgpu.sgpr>, %next_acc: reg<amdgpu.vgpr>)
+^outer_latch:
+  %outer_one = s_mov_b32 1
+  %next_outer_i = s_add_u32 %outer_i, %outer_one
+  low.br ^outer(%next_outer_i: reg<amdgpu.sgpr>, %inner_acc: reg<amdgpu.vgpr>)
+^exit:
+  global_store_b32_saddr %addr, %outer_acc, %output
+  return
+}
+
+// A dependency loaded outside both loops moves to the outer preheader. The
+// load issued once per outer iteration moves only to the inner preheader.
+// ----
+{"format":"loom.low.packet_hazard_plan.v1","function":"nested_loop_invariant_loads_wait_at_outermost_preheaders","target":"target","descriptor_set":"amdgpu.rdna3.core","progress_count":3,"hazard_count":3,"progress":[{"index":0,"packet":0,"node":0,"block":0,"scheduled_ordinal":0,"class_id":1,"class_name":"amdgpu.vmem_load","action":"advance","units":1},{"index":1,"packet":6,"node":6,"block":2,"scheduled_ordinal":0,"class_id":1,"class_name":"amdgpu.vmem_load","action":"advance","units":1},{"index":2,"packet":18,"node":18,"block":6,"scheduled_ordinal":0,"class_id":2,"class_name":"amdgpu.vmem_store","action":"advance","units":1}],"hazards":[{"index":0,"kind":"action","action_id":1,"action_name":"amdgpu.wait_packet","reason_id":2,"reason_name":"amdgpu.ssa_use","producer_node":0,"producer_packet":0,"producer_scheduled_ordinal":0,"consumer_node":3,"insertion_packet":3,"block":0,"scheduled_ordinal":3,"progress_class_id":1,"progress_class_name":"amdgpu.vmem_load","required":1,"observed":0,"residual":1},{"index":1,"kind":"action","action_id":1,"action_name":"amdgpu.wait_packet","reason_id":2,"reason_name":"amdgpu.ssa_use","producer_node":6,"producer_packet":6,"producer_scheduled_ordinal":0,"consumer_node":7,"insertion_packet":7,"block":2,"scheduled_ordinal":1,"progress_class_id":1,"progress_class_name":"amdgpu.vmem_load","required":1,"observed":0,"residual":1},{"index":2,"kind":"action","action_id":1,"action_name":"amdgpu.wait_packet","reason_id":9,"reason_name":"amdgpu.program_exit","producer_node":null,"producer_packet":null,"producer_scheduled_ordinal":null,"consumer_node":19,"insertion_packet":19,"block":6,"scheduled_ordinal":1,"progress_class_id":2,"progress_class_name":"amdgpu.vmem_store","required":1,"observed":0,"residual":1}]}
+
+// ====
+// RUN: emit amdgpu-assembly @nested_loop_invariant_loads_wait_at_outermost_preheaders_assembly strategy=source
+
+amdgpu.target<gfx1100> @target
+low.func.def target<amdgpu.rdna3.core>(@target) @nested_loop_invariant_loads_wait_at_outermost_preheaders_assembly(%addr: reg<amdgpu.vgpr>, %outer_base: reg<amdgpu.sgpr x2>, %inner_base: reg<amdgpu.sgpr x2>, %output: reg<amdgpu.sgpr x2>, %outer_limit: reg<amdgpu.sgpr>, %inner_limit: reg<amdgpu.sgpr>) asm {
+  %outer_value = global_load_b32_saddr %addr, %outer_base
+  %zero_s = s_mov_b32 0
+  %zero_v = v_mov_b32 0
+  low.br ^outer(%zero_s: reg<amdgpu.sgpr>, %zero_v: reg<amdgpu.vgpr>)
+^outer(%outer_i: reg<amdgpu.sgpr>, %outer_acc: reg<amdgpu.vgpr>):
+  %outer_active = s_cmp_lt_i32 %outer_i, %outer_limit
+  low.cond_br %outer_active, ^outer_body, ^exit : reg<amdgpu.scc>
+^outer_body:
+  %inner_value = global_load_b32_saddr %addr, %inner_base
+  low.br ^inner(%zero_s: reg<amdgpu.sgpr>, %outer_acc: reg<amdgpu.vgpr>)
+^inner(%inner_i: reg<amdgpu.sgpr>, %inner_acc: reg<amdgpu.vgpr>):
+  %inner_active = s_cmp_lt_i32 %inner_i, %inner_limit
+  low.cond_br %inner_active, ^inner_body, ^outer_latch : reg<amdgpu.scc>
+^inner_body:
+  %with_outer = v_add_f32 %inner_acc, %outer_value
+  %next_acc = v_add_f32 %with_outer, %inner_value
+  %one = s_mov_b32 1
+  %next_inner_i = s_add_u32 %inner_i, %one
+  low.br ^inner(%next_inner_i: reg<amdgpu.sgpr>, %next_acc: reg<amdgpu.vgpr>)
+^outer_latch:
+  %outer_one = s_mov_b32 1
+  %next_outer_i = s_add_u32 %outer_i, %outer_one
+  low.br ^outer(%next_outer_i: reg<amdgpu.sgpr>, %inner_acc: reg<amdgpu.vgpr>)
+^exit:
+  global_store_b32_saddr %addr, %outer_acc, %output
+  return
+}
+
+// ----
+  global_load_b32 v1, v0, s[0:1] offset:0
+  s_mov_b32 s8, 0
+  v_mov_b32 v2, 0
+  s_waitcnt vmcnt(0) lgkmcnt(63)
+  s_delay_alu instid0(VALU_DEP_1)
+  s_mov_b32 s9, s8
+.Lbb1:
+  s_cmp_lt_i32 s9, s4
+  s_delay_alu instid0(SALU_CYCLE_1)
+  s_cbranch_scc0 .Lbb6
+.Lbb2:
+  global_load_b32 v3, v0, s[2:3] offset:0
+  s_waitcnt vmcnt(0) lgkmcnt(63)
+  s_mov_b32 s10, s8
+.Lbb3:
+  s_cmp_lt_i32 s10, s5
+  s_delay_alu instid0(SALU_CYCLE_1)
+  s_cbranch_scc0 .Lbb5
+.Lbb4:
+  v_add_f32 v2, v2, v1
+  s_delay_alu instid0(VALU_DEP_1)
+  v_add_f32 v2, v2, v3
+  s_mov_b32 s11, 1
+  s_add_u32 s10, s10, s11
+  s_branch .Lbb3
+.Lbb5:
+  s_mov_b32 s10, 1
+  s_add_u32 s9, s9, s10
+  s_branch .Lbb1
+.Lbb6:
+  global_store_b32 v0, v2, s[6:7] offset:0
+  s_waitcnt_vscnt vscnt(0)
+  s_endpgm
+
+// ====
 // RUN: emit amdgpu-wait-counter-plan-json @branch_load_then_use_join_store strategy=source
 
 amdgpu.target<gfx1100> @target

--- a/loom/src/loom/target/reporting/BUILD.bazel
+++ b/loom/src/loom/target/reporting/BUILD.bazel
@@ -135,6 +135,7 @@ loom_cc_library(
         "//loom/src/loom/ops/low",
         "//loom/src/loom/target:registers",
         "//loom/src/loom/util:cfg_graph",
+        "//loom/src/loom/util:cfg_loop",
         "//loom/src/loom/util:fact_table",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal",

--- a/loom/src/loom/target/reporting/CMakeLists.txt
+++ b/loom/src/loom/target/reporting/CMakeLists.txt
@@ -138,6 +138,7 @@ loom_cc_library(
     loom::ops::low
     loom::target::registers
     loom::util::cfg_graph
+    loom::util::cfg_loop
     loom::util::fact_table
   PUBLIC
 )

--- a/loom/src/loom/target/reporting/low_mix.c
+++ b/loom/src/loom/target/reporting/low_mix.c
@@ -762,7 +762,7 @@ static iree_status_t loom_target_compile_report_low_block_multipliers(
     }
   }
   *out_exact = loom_cfg_loop_forest_calculate_block_execution_counts(
-      loop_forest, trip_counts, block_multipliers);
+      loop_forest, graph, trip_counts, block_multipliers);
   if (*out_exact) {
     *out_block_multipliers = block_multipliers;
   }

--- a/loom/src/loom/target/reporting/low_mix.c
+++ b/loom/src/loom/target/reporting/low_mix.c
@@ -19,6 +19,7 @@
 #include "loom/target/registers.h"
 #include "loom/target/reporting/low_names.h"
 #include "loom/util/cfg_graph.h"
+#include "loom/util/cfg_loop.h"
 
 static bool loom_target_compile_report_low_branch_falls_through(
     const loom_low_schedule_table_t* schedule,
@@ -491,53 +492,42 @@ static bool loom_target_compile_report_low_block_branch_to(
 }
 
 static bool loom_target_compile_report_low_edge_copy_branch_arg(
-    const loom_low_allocation_table_t* allocation, const loom_op_t* branch_op,
-    const loom_block_t* dest, uint16_t arg_index,
-    loom_value_id_t* out_value_id) {
-  if (allocation == NULL || branch_op == NULL || dest == NULL ||
-      arg_index >= dest->arg_count) {
+    const loom_low_allocation_table_t* allocation,
+    uint32_t branch_source_ordinal, const loom_block_t* dest,
+    uint16_t arg_index, loom_value_id_t* out_value_id) {
+  if (allocation == NULL || dest == NULL || arg_index >= dest->arg_count) {
     return false;
   }
   const loom_value_id_t destination_value_id =
       loom_block_arg_id(dest, arg_index);
-  for (iree_host_size_t i = 0; i < allocation->edge_copy_group_count; ++i) {
-    const loom_low_allocation_edge_copy_group_t* group =
-        &allocation->edge_copy_groups[i];
-    if (group->terminator_op != branch_op) {
+  const loom_low_allocation_edge_copy_group_t* group =
+      loom_low_allocation_find_edge_copy_group_by_source_ordinal(
+          allocation, branch_source_ordinal);
+  if (group == NULL) return false;
+  bool found = false;
+  loom_value_id_t source_value_id = LOOM_VALUE_ID_INVALID;
+  const iree_host_size_t copy_end =
+      (iree_host_size_t)group->copy_start + (iree_host_size_t)group->copy_count;
+  if (copy_end > allocation->edge_copy_count) return false;
+  for (iree_host_size_t i = group->copy_start; i < copy_end; ++i) {
+    const loom_low_allocation_edge_copy_t* copy = &allocation->edge_copies[i];
+    if (copy->payload_index != arg_index ||
+        copy->destination_value_id != destination_value_id) {
       continue;
     }
-    bool found = false;
-    loom_value_id_t source_value_id = LOOM_VALUE_ID_INVALID;
-    const iree_host_size_t copy_end = (iree_host_size_t)group->copy_start +
-                                      (iree_host_size_t)group->copy_count;
-    if (copy_end > allocation->edge_copy_count) {
-      return false;
-    }
-    for (iree_host_size_t j = group->copy_start; j < copy_end; ++j) {
-      const loom_low_allocation_edge_copy_t* copy = &allocation->edge_copies[j];
-      if (copy->payload_index != arg_index ||
-          copy->destination_value_id != destination_value_id) {
-        continue;
-      }
-      if (found && copy->source_value_id != source_value_id) {
-        return false;
-      }
-      found = true;
-      source_value_id = copy->source_value_id;
-    }
-    if (!found) {
-      return false;
-    }
-    *out_value_id = source_value_id;
-    return true;
+    if (found && copy->source_value_id != source_value_id) return false;
+    found = true;
+    source_value_id = copy->source_value_id;
   }
-  return false;
+  if (!found) return false;
+  *out_value_id = source_value_id;
+  return true;
 }
 
 static bool loom_target_compile_report_low_branch_arg(
     const loom_low_allocation_table_t* allocation, const loom_op_t* branch_op,
-    const loom_block_t* dest, uint16_t arg_index,
-    loom_value_id_t* out_value_id) {
+    uint32_t branch_source_ordinal, const loom_block_t* dest,
+    uint16_t arg_index, loom_value_id_t* out_value_id) {
   *out_value_id = LOOM_VALUE_ID_INVALID;
   if (branch_op == NULL || arg_index >= dest->arg_count) {
     return false;
@@ -548,7 +538,7 @@ static bool loom_target_compile_report_low_branch_arg(
     return true;
   }
   return loom_target_compile_report_low_edge_copy_branch_arg(
-      allocation, branch_op, dest, arg_index, out_value_id);
+      allocation, branch_source_ordinal, dest, arg_index, out_value_id);
 }
 
 static bool loom_target_compile_report_low_add_step(
@@ -658,139 +648,65 @@ static bool loom_target_compile_report_low_compute_trip_count(
   return true;
 }
 
-static bool loom_target_compile_report_low_multiply_block(
-    uint64_t* block_multipliers, uint16_t block_index, uint64_t multiplier) {
-  return iree_checked_mul_u64(block_multipliers[block_index], multiplier,
-                              &block_multipliers[block_index]);
-}
-
-static bool loom_target_compile_report_low_find_counted_backedge(
-    const loom_cfg_graph_t* graph, uint16_t header_index,
-    const loom_op_t** out_backedge_op, loom_cfg_edge_index_t* out_backedge_edge,
-    uint16_t* out_latch_index) {
-  *out_backedge_op = NULL;
-  *out_backedge_edge = LOOM_CFG_EDGE_INDEX_INVALID;
-  *out_latch_index = UINT16_MAX;
-  const loom_block_t* header = graph->blocks[header_index].block;
-  loom_cfg_edge_index_span_t predecessor_edges =
-      loom_cfg_graph_predecessor_edges(graph, header_index);
-  for (iree_host_size_t i = 0; i < predecessor_edges.count; ++i) {
-    const loom_cfg_edge_index_t edge_index = predecessor_edges.values[i];
-    const loom_cfg_edge_info_t* edge = loom_cfg_graph_edge(graph, edge_index);
-    if (edge == NULL ||
-        !loom_cfg_graph_block_is_reachable(graph, edge->source_block_index) ||
-        edge->source_block_index < header_index) {
-      continue;
-    }
-    const loom_op_t* branch_op = NULL;
-    if (!loom_target_compile_report_low_block_branch_to(
-            graph->blocks[edge->source_block_index].block, header,
-            &branch_op)) {
-      return false;
-    }
-    if (*out_backedge_op != NULL) {
-      return false;
-    }
-    *out_backedge_op = branch_op;
-    *out_backedge_edge = edge_index;
-    *out_latch_index = edge->source_block_index;
-  }
-  return true;
-}
-
-static bool loom_target_compile_report_low_loop_has_unmodeled_conditional(
-    const loom_cfg_graph_t* graph, uint16_t header_index,
-    const uint8_t* loop_blocks) {
-  for (uint16_t block_index = 0; block_index < graph->block_count;
-       ++block_index) {
-    if (block_index == header_index || !loop_blocks[block_index]) {
-      continue;
-    }
-    const loom_block_t* block = graph->blocks[block_index].block;
-    const loom_op_t* terminator = block ? block->last_op : NULL;
-    if (terminator == NULL || !loom_low_cond_br_isa(terminator)) {
-      continue;
-    }
-    const loom_op_t* nested_backedge_op = NULL;
-    loom_cfg_edge_index_t nested_backedge_edge = LOOM_CFG_EDGE_INDEX_INVALID;
-    uint16_t nested_latch_index = UINT16_MAX;
-    if (!loom_target_compile_report_low_find_counted_backedge(
-            graph, block_index, &nested_backedge_op, &nested_backedge_edge,
-            &nested_latch_index) ||
-        nested_backedge_op == NULL) {
-      return true;
-    }
-  }
-  return false;
+static uint32_t loom_target_compile_report_low_block_terminator_ordinal(
+    const loom_low_schedule_table_t* schedule, uint16_t block_index) {
+  const loom_low_schedule_block_t* block = &schedule->blocks[block_index];
+  IREE_ASSERT_GT(block->node_count, 0);
+  const uint32_t node_index = block->node_start + block->node_count - 1;
+  IREE_ASSERT_LT(node_index, schedule->node_count);
+  IREE_ASSERT(schedule->nodes[node_index].op == block->block->last_op);
+  return schedule->nodes[node_index].source_ordinal;
 }
 
 static bool loom_target_compile_report_low_try_counted_loop(
     const loom_low_schedule_table_t* schedule,
     const loom_low_allocation_table_t* allocation,
     const loom_value_fact_table_t* fact_table, const loom_module_t* module,
-    const loom_cfg_graph_t* graph, uint16_t header_index,
-    uint64_t* block_multipliers, uint8_t* counted_backedge_edges,
-    uint8_t* loop_blocks, uint16_t* loop_stack) {
-  const loom_block_t* header = graph->blocks[header_index].block;
+    const loom_cfg_graph_t* graph, const loom_cfg_loop_interval_t* interval,
+    uint64_t* out_trip_count) {
+  *out_trip_count = 0;
+  const loom_block_t* header = graph->blocks[interval->header_index].block;
   if (header == NULL || header->arg_count == 0 || header->last_op == NULL ||
       !loom_low_cond_br_isa(header->last_op)) {
-    return true;
+    return false;
   }
   const loom_value_id_t iv_id = loom_block_arg_id(header, 0);
-  const loom_op_t* body_backedge_op = NULL;
-  loom_cfg_edge_index_t body_backedge_edge = LOOM_CFG_EDGE_INDEX_INVALID;
-  uint16_t latch_index = UINT16_MAX;
-  if (!loom_target_compile_report_low_find_counted_backedge(
-          graph, header_index, &body_backedge_op, &body_backedge_edge,
-          &latch_index)) {
-    return false;
-  }
-  if (body_backedge_op == NULL) {
-    return true;
-  }
-  if (!loom_cfg_graph_mark_natural_loop_blocks(graph, header_index, latch_index,
-                                               loop_blocks, loop_stack)) {
-    return false;
-  }
-  if (loom_target_compile_report_low_loop_has_unmodeled_conditional(
-          graph, header_index, loop_blocks)) {
-    return false;
-  }
-
-  loom_value_id_t body_backedge_arg = LOOM_VALUE_ID_INVALID;
-  if (!loom_target_compile_report_low_branch_arg(allocation, body_backedge_op,
-                                                 header, /*arg_index=*/0,
-                                                 &body_backedge_arg)) {
-    return false;
-  }
+  const loom_cfg_edge_info_t* entry_edge =
+      loom_cfg_graph_edge(graph, interval->entry_edge_index);
+  const loom_cfg_edge_info_t* backedge =
+      loom_cfg_graph_edge(graph, interval->backedge_edge_index);
+  if (entry_edge == NULL || backedge == NULL) return false;
 
   const loom_op_t* initial_branch_op = NULL;
-  loom_value_id_t initial_arg = LOOM_VALUE_ID_INVALID;
-  loom_cfg_block_index_span_t predecessors =
-      loom_cfg_graph_predecessors(graph, header_index);
-  for (iree_host_size_t i = 0; i < predecessors.count; ++i) {
-    const uint16_t predecessor_index = predecessors.values[i];
-    if (loop_blocks[predecessor_index] ||
-        !loom_cfg_graph_block_is_reachable(graph, predecessor_index)) {
-      continue;
-    }
-    const loom_op_t* branch_op = NULL;
-    if (!loom_target_compile_report_low_block_branch_to(
-            graph->blocks[predecessor_index].block, header, &branch_op)) {
-      return false;
-    }
-    loom_value_id_t branch_arg = LOOM_VALUE_ID_INVALID;
-    if (!loom_target_compile_report_low_branch_arg(
-            allocation, branch_op, header, /*arg_index=*/0, &branch_arg)) {
-      return false;
-    }
-    if (initial_branch_op != NULL) {
-      return false;
-    }
-    initial_branch_op = branch_op;
-    initial_arg = branch_arg;
+  if (!loom_target_compile_report_low_block_branch_to(
+          graph->blocks[entry_edge->source_block_index].block, header,
+          &initial_branch_op)) {
+    return false;
   }
-  if (initial_branch_op == NULL) {
+  const loom_op_t* body_backedge_op = NULL;
+  if (!loom_target_compile_report_low_block_branch_to(
+          graph->blocks[backedge->source_block_index].block, header,
+          &body_backedge_op)) {
+    return false;
+  }
+
+  const uint32_t backedge_source_ordinal =
+      loom_target_compile_report_low_block_terminator_ordinal(
+          schedule, backedge->source_block_index);
+  loom_value_id_t body_backedge_arg = LOOM_VALUE_ID_INVALID;
+  if (!loom_target_compile_report_low_branch_arg(
+          allocation, body_backedge_op, backedge_source_ordinal, header,
+          /*arg_index=*/0, &body_backedge_arg)) {
+    return false;
+  }
+
+  const uint32_t entry_source_ordinal =
+      loom_target_compile_report_low_block_terminator_ordinal(
+          schedule, entry_edge->source_block_index);
+  loom_value_id_t initial_arg = LOOM_VALUE_ID_INVALID;
+  if (!loom_target_compile_report_low_branch_arg(
+          allocation, initial_branch_op, entry_source_ordinal, header,
+          /*arg_index=*/0, &initial_arg)) {
     return false;
   }
 
@@ -798,7 +714,6 @@ static bool loom_target_compile_report_low_try_counted_loop(
   int64_t upper_bound = 0;
   int64_t step = 0;
   bool inclusive_upper_bound = false;
-  uint64_t trip_count = 0;
   bool lower_ok = loom_target_compile_report_value_exact_i64(
       fact_table, initial_arg, &lower_bound);
   bool step_ok = loom_target_compile_report_low_add_step(
@@ -807,57 +722,16 @@ static bool loom_target_compile_report_low_try_counted_loop(
       schedule, fact_table, module, header->last_op, iv_id, &upper_bound,
       &inclusive_upper_bound);
   bool trip_ok = loom_target_compile_report_low_compute_trip_count(
-      lower_bound, upper_bound, inclusive_upper_bound, step, &trip_count);
-  if (!lower_ok || !step_ok || !upper_ok || !trip_ok) {
-    return false;
-  }
-
-  uint64_t header_count = 0;
-  if (!iree_checked_add_u64(trip_count, 1, &header_count) ||
-      !loom_target_compile_report_low_multiply_block(
-          block_multipliers, header_index, header_count)) {
-    return false;
-  }
-  for (uint16_t block_index = 0; block_index < graph->block_count;
-       ++block_index) {
-    if (block_index == header_index || !loop_blocks[block_index]) {
-      continue;
-    }
-    if (!loom_target_compile_report_low_multiply_block(
-            block_multipliers, block_index, trip_count)) {
-      return false;
-    }
-  }
-  if (body_backedge_edge == LOOM_CFG_EDGE_INDEX_INVALID ||
-      body_backedge_edge >= graph->edge_count) {
-    return false;
-  }
-  counted_backedge_edges[body_backedge_edge] = 1;
-  return true;
-}
-
-static bool loom_target_compile_report_low_has_uncounted_backedge(
-    const loom_cfg_graph_t* graph, const uint8_t* counted_backedge_edges) {
-  for (iree_host_size_t i = 0; i < graph->edge_count; ++i) {
-    const loom_cfg_edge_info_t* edge = loom_cfg_graph_edge(graph, (uint32_t)i);
-    if (edge == NULL ||
-        !loom_cfg_graph_block_is_reachable(graph, edge->source_block_index)) {
-      continue;
-    }
-    if (edge->target_block_index <= edge->source_block_index &&
-        counted_backedge_edges[i] == 0) {
-      return true;
-    }
-  }
-  return false;
+      lower_bound, upper_bound, inclusive_upper_bound, step, out_trip_count);
+  return lower_ok && step_ok && upper_ok && trip_ok;
 }
 
 static iree_status_t loom_target_compile_report_low_block_multipliers(
     const loom_low_schedule_table_t* schedule,
     const loom_low_allocation_table_t* allocation,
     const loom_value_fact_table_t* fact_table, const loom_module_t* module,
-    const loom_op_t* function_op, iree_arena_allocator_t* arena,
-    uint64_t** out_block_multipliers, bool* out_exact) {
+    iree_arena_allocator_t* arena, uint64_t** out_block_multipliers,
+    bool* out_exact) {
   *out_block_multipliers = NULL;
   *out_exact = true;
   if (schedule->block_count == 0) {
@@ -867,53 +741,31 @@ static iree_status_t loom_target_compile_report_low_block_multipliers(
   IREE_RETURN_IF_ERROR(iree_arena_allocate_array(arena, schedule->block_count,
                                                  sizeof(*block_multipliers),
                                                  (void**)&block_multipliers));
-  for (iree_host_size_t i = 0; i < schedule->block_count; ++i) {
-    block_multipliers[i] = 1;
-  }
-
-  const loom_region_t* body = loom_low_function_const_body(function_op);
-  if (body == NULL || body->block_count == 0) {
-    *out_block_multipliers = block_multipliers;
+  const loom_cfg_graph_t* graph = &schedule->cfg_graph;
+  const loom_cfg_loop_forest_t* loop_forest = &schedule->loop_forest;
+  if (graph->malformed || graph->block_count != schedule->block_count) {
+    *out_exact = false;
     return iree_ok_status();
   }
-  loom_cfg_graph_t graph = {0};
-  IREE_RETURN_IF_ERROR(loom_cfg_graph_build(module, body, arena, &graph));
-  if (graph.malformed || graph.block_count != schedule->block_count) {
-    *out_block_multipliers = block_multipliers;
-    return iree_ok_status();
+  uint64_t* trip_counts = NULL;
+  if (loop_forest->interval_count > 0) {
+    IREE_RETURN_IF_ERROR(
+        iree_arena_allocate_array(arena, loop_forest->interval_count,
+                                  sizeof(*trip_counts), (void**)&trip_counts));
   }
-  uint8_t* counted_backedge_edges = NULL;
-  if (graph.edge_count > 0) {
-    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-        arena, graph.edge_count, sizeof(*counted_backedge_edges),
-        (void**)&counted_backedge_edges));
-    memset(counted_backedge_edges, 0,
-           graph.edge_count * sizeof(*counted_backedge_edges));
-  }
-  uint8_t* loop_blocks = NULL;
-  uint16_t* loop_stack = NULL;
-  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-      arena, graph.block_count, sizeof(*loop_blocks), (void**)&loop_blocks));
-  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
-      arena, graph.block_count, sizeof(*loop_stack), (void**)&loop_stack));
-  for (uint16_t block_index = 0; block_index < graph.block_count;
-       ++block_index) {
+  for (iree_host_size_t i = 0; i < loop_forest->interval_count; ++i) {
     if (!loom_target_compile_report_low_try_counted_loop(
-            schedule, allocation, fact_table, module, &graph, block_index,
-            block_multipliers, counted_backedge_edges, loop_blocks,
-            loop_stack)) {
-      *out_block_multipliers = NULL;
+            schedule, allocation, fact_table, module, graph,
+            &loop_forest->intervals[i], &trip_counts[i])) {
       *out_exact = false;
       return iree_ok_status();
     }
   }
-  if (loom_target_compile_report_low_has_uncounted_backedge(
-          &graph, counted_backedge_edges)) {
-    *out_block_multipliers = NULL;
-    *out_exact = false;
-    return iree_ok_status();
+  *out_exact = loom_cfg_loop_forest_calculate_block_execution_counts(
+      loop_forest, trip_counts, block_multipliers);
+  if (*out_exact) {
+    *out_block_multipliers = block_multipliers;
   }
-  *out_block_multipliers = block_multipliers;
   return iree_ok_status();
 }
 
@@ -968,8 +820,8 @@ iree_status_t loom_target_compile_report_low_dynamic_context_initialize(
   if (iree_status_is_ok(status)) {
     status = loom_target_compile_report_low_block_multipliers(
         &frame->schedule, &frame->allocation, &out_context->fact_table,
-        frame->module, frame->function_op, &out_context->arena,
-        &out_context->block_multipliers, &block_multipliers_exact);
+        frame->module, &out_context->arena, &out_context->block_multipliers,
+        &block_multipliers_exact);
   }
   out_context->exact = iree_status_is_ok(status) && block_multipliers_exact;
   return status;

--- a/loom/src/loom/util/BUILD.bazel
+++ b/loom/src/loom/util/BUILD.bazel
@@ -240,6 +240,32 @@ loom_cc_test(
 )
 
 loom_cc_library(
+    name = "cfg_loop",
+    srcs = ["cfg_loop.c"],
+    hdrs = ["cfg_loop.h"],
+    deps = [
+        ":cfg_graph",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal:arena",
+    ],
+)
+
+loom_cc_test(
+    name = "cfg_loop_test",
+    srcs = ["cfg_loop_test.cc"],
+    deps = [
+        ":cfg_loop",
+        "//loom/src/loom/ir",
+        "//loom/src/loom/ops:op_defs",
+        "//loom/src/loom/ops/cfg",
+        "//loom/src/loom/ops/test",
+        "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+loom_cc_library(
     name = "dominance",
     srcs = ["dominance.c"],
     hdrs = ["dominance.h"],

--- a/loom/src/loom/util/CMakeLists.txt
+++ b/loom/src/loom/util/CMakeLists.txt
@@ -279,6 +279,36 @@ loom_cc_test(
 
 loom_cc_library(
   NAME
+    cfg_loop
+  HDRS
+    "cfg_loop.h"
+  SRCS
+    "cfg_loop.c"
+  DEPS
+    ::cfg_graph
+    iree::base
+    iree::base::internal::arena
+  PUBLIC
+)
+
+loom_cc_test(
+  NAME
+    cfg_loop_test
+  SRCS
+    "cfg_loop_test.cc"
+  DEPS
+    ::cfg_loop
+    iree::base::internal::arena
+    iree::testing::gtest
+    iree::testing::gtest_main
+    loom::ir
+    loom::ops::cfg
+    loom::ops::op_defs
+    loom::ops::test
+)
+
+loom_cc_library(
+  NAME
     dominance
   HDRS
     "dominance.h"

--- a/loom/src/loom/util/cfg_graph.c
+++ b/loom/src/loom/util/cfg_graph.c
@@ -154,6 +154,9 @@ static void loom_cfg_graph_write_edges(
               predecessor_write_positions[target_index]++;
           graph->predecessor_indices[predecessor_position] = block_index;
           graph->predecessor_edge_indices[predecessor_position] = edge_index;
+          if (target_index <= block_index) {
+            ++graph->backward_edge_count;
+          }
           ++edge_index;
         }
       }

--- a/loom/src/loom/util/cfg_graph.c
+++ b/loom/src/loom/util/cfg_graph.c
@@ -328,44 +328,6 @@ loom_cfg_edge_index_span_t loom_cfg_graph_predecessor_edges(
   };
 }
 
-bool loom_cfg_graph_mark_natural_loop_blocks(const loom_cfg_graph_t* graph,
-                                             uint16_t header_index,
-                                             uint16_t latch_index,
-                                             uint8_t* loop_blocks,
-                                             uint16_t* stack) {
-  if (!graph || !loop_blocks || !stack || header_index >= graph->block_count ||
-      latch_index >= graph->block_count) {
-    return false;
-  }
-  memset(loop_blocks, 0,
-         (iree_host_size_t)graph->block_count * sizeof(*loop_blocks));
-
-  loop_blocks[header_index] = 1;
-  iree_host_size_t stack_count = 0;
-  if (latch_index != header_index) {
-    loop_blocks[latch_index] = 1;
-    stack[stack_count++] = latch_index;
-  }
-  while (stack_count > 0) {
-    const uint16_t block_index = stack[--stack_count];
-    loom_cfg_block_index_span_t predecessors =
-        loom_cfg_graph_predecessors(graph, block_index);
-    for (iree_host_size_t i = 0; i < predecessors.count; ++i) {
-      const uint16_t predecessor_index = predecessors.values[i];
-      if (!loom_cfg_graph_block_is_reachable(graph, predecessor_index) ||
-          loop_blocks[predecessor_index]) {
-        continue;
-      }
-      if (stack_count >= graph->block_count) {
-        return false;
-      }
-      loop_blocks[predecessor_index] = 1;
-      stack[stack_count++] = predecessor_index;
-    }
-  }
-  return true;
-}
-
 const loom_cfg_edge_info_t* loom_cfg_graph_edge(
     const loom_cfg_graph_t* graph, loom_cfg_edge_index_t edge_index) {
   return graph && edge_index < graph->edge_count ? &graph->edges[edge_index]

--- a/loom/src/loom/util/cfg_graph.h
+++ b/loom/src/loom/util/cfg_graph.h
@@ -149,18 +149,6 @@ loom_cfg_block_index_span_t loom_cfg_graph_predecessors(
 loom_cfg_edge_index_span_t loom_cfg_graph_predecessor_edges(
     const loom_cfg_graph_t* graph, uint16_t block_index);
 
-// Marks the natural loop induced by a backedge from |latch_index| to
-// |header_index| in |loop_blocks|. |loop_blocks| and |stack| must have at
-// least graph->block_count entries and are overwritten on entry. Returns false
-// when the indices are invalid or the temporary stack cannot represent the
-// graph. Unreachable predecessors are ignored so callers can build conservative
-// execution counts after CFG simplification.
-bool loom_cfg_graph_mark_natural_loop_blocks(const loom_cfg_graph_t* graph,
-                                             uint16_t header_index,
-                                             uint16_t latch_index,
-                                             uint8_t* loop_blocks,
-                                             uint16_t* stack);
-
 // Returns edge metadata for |edge_index|, or NULL when out of range.
 const loom_cfg_edge_info_t* loom_cfg_graph_edge(
     const loom_cfg_graph_t* graph, loom_cfg_edge_index_t edge_index);

--- a/loom/src/loom/util/cfg_graph.h
+++ b/loom/src/loom/util/cfg_graph.h
@@ -102,6 +102,10 @@ typedef struct loom_cfg_graph_t {
   iree_host_size_t block_count;
   // Number of valid in-region successor edges.
   iree_host_size_t edge_count;
+  // Number of edges whose target does not follow their source in region block
+  // order. This is a cheap rejection fact for loop analyses; a backward edge
+  // is not necessarily a semantic CFG backedge.
+  iree_host_size_t backward_edge_count;
   // True when malformed successor structure was seen while building the graph.
   bool malformed;
 } loom_cfg_graph_t;

--- a/loom/src/loom/util/cfg_graph_test.cc
+++ b/loom/src/loom/util/cfg_graph_test.cc
@@ -154,6 +154,7 @@ TEST_F(CfgGraphTest, BuildsSuccessorsAndPredecessorsForDiamond) {
   EXPECT_FALSE(graph.malformed);
   EXPECT_EQ(graph.block_count, 4u);
   EXPECT_EQ(graph.edge_count, 4u);
+  EXPECT_EQ(graph.backward_edge_count, 0u);
 
   loom_cfg_block_index_span_t entry_successors =
       loom_cfg_graph_successors(&graph, 0);

--- a/loom/src/loom/util/cfg_loop.c
+++ b/loom/src/loom/util/cfg_loop.c
@@ -257,7 +257,6 @@ static iree_status_t loom_cfg_loop_forest_build_impl(
   memcpy(retained_innermost_loop_indices, innermost_loop_indices,
          graph->block_count * sizeof(*retained_innermost_loop_indices));
   *out_forest = (loom_cfg_loop_forest_t){
-      .graph = graph,
       .intervals = intervals,
       .innermost_loop_indices = retained_innermost_loop_indices,
       .interval_count = interval_count,
@@ -274,9 +273,7 @@ iree_status_t loom_cfg_loop_forest_build(const loom_cfg_graph_t* graph,
         IREE_STATUS_INVALID_ARGUMENT,
         "CFG loop forest build requires a graph, arena, and output forest");
   }
-  *out_forest = (loom_cfg_loop_forest_t){
-      .graph = graph,
-  };
+  *out_forest = (loom_cfg_loop_forest_t){0};
   if (graph->malformed || graph->block_count <= 1 || graph->blocks == NULL ||
       graph->backward_edge_count == 0) {
     return iree_ok_status();
@@ -291,11 +288,10 @@ iree_status_t loom_cfg_loop_forest_build(const loom_cfg_graph_t* graph,
 }
 
 bool loom_cfg_loop_forest_calculate_block_execution_counts(
-    const loom_cfg_loop_forest_t* forest, const uint64_t* trip_counts,
-    uint64_t* out_block_counts) {
+    const loom_cfg_loop_forest_t* forest, const loom_cfg_graph_t* graph,
+    const uint64_t* trip_counts, uint64_t* out_block_counts) {
   IREE_ASSERT(forest->interval_count == 0 || trip_counts != NULL);
 
-  const loom_cfg_graph_t* graph = forest->graph;
   for (iree_host_size_t i = 0; i < graph->block_count; ++i) {
     const bool is_reachable =
         graph->blocks == NULL ||

--- a/loom/src/loom/util/cfg_loop.c
+++ b/loom/src/loom/util/cfg_loop.c
@@ -1,0 +1,281 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/util/cfg_loop.h"
+
+#include <string.h>
+
+// Transient construction state for one public loop interval.
+typedef struct loom_cfg_loop_build_interval_t {
+  // Public interval retained after construction.
+  loom_cfg_loop_interval_t interval;
+  // Minimum predecessor entering the header.
+  uint16_t header_predecessor_min;
+  // Maximum predecessor entering the header.
+  uint16_t header_predecessor_max;
+  // Minimum predecessor entering a non-header interval block.
+  uint16_t body_predecessor_min;
+  // Maximum predecessor entering a non-header interval block.
+  uint16_t body_predecessor_max;
+  // Whether the header predecessor range is populated.
+  bool has_header_predecessor;
+  // Whether the body predecessor range is populated.
+  bool has_body_predecessor;
+} loom_cfg_loop_build_interval_t;
+
+static bool loom_cfg_loop_find_candidate(
+    const loom_cfg_graph_t* graph, uint16_t header_index,
+    loom_cfg_loop_interval_t* out_interval) {
+  *out_interval = (loom_cfg_loop_interval_t){0};
+  loom_cfg_edge_index_t entry_edge_index = LOOM_CFG_EDGE_INDEX_INVALID;
+  loom_cfg_edge_index_t backedge_edge_index = LOOM_CFG_EDGE_INDEX_INVALID;
+  const loom_cfg_edge_index_span_t predecessor_edges =
+      loom_cfg_graph_predecessor_edges(graph, header_index);
+  for (iree_host_size_t i = 0; i < predecessor_edges.count; ++i) {
+    const loom_cfg_edge_index_t edge_index = predecessor_edges.values[i];
+    const loom_cfg_edge_info_t* edge = loom_cfg_graph_edge(graph, edge_index);
+    if (edge == NULL ||
+        !loom_cfg_graph_block_is_reachable(graph, edge->source_block_index)) {
+      continue;
+    }
+    if (edge->source_block_index < header_index) {
+      if (entry_edge_index != LOOM_CFG_EDGE_INDEX_INVALID) return false;
+      entry_edge_index = edge_index;
+    } else {
+      if (backedge_edge_index != LOOM_CFG_EDGE_INDEX_INVALID) return false;
+      backedge_edge_index = edge_index;
+    }
+  }
+  if (entry_edge_index == LOOM_CFG_EDGE_INDEX_INVALID ||
+      backedge_edge_index == LOOM_CFG_EDGE_INDEX_INVALID) {
+    return false;
+  }
+
+  const loom_cfg_edge_info_t* entry_edge =
+      loom_cfg_graph_edge(graph, entry_edge_index);
+  const loom_cfg_edge_info_t* backedge =
+      loom_cfg_graph_edge(graph, backedge_edge_index);
+  const loom_cfg_block_index_span_t entry_successors =
+      loom_cfg_graph_successors(graph, entry_edge->source_block_index);
+  if (entry_successors.count != 1 || entry_edge->successor_index != 0) {
+    return false;
+  }
+
+  *out_interval = (loom_cfg_loop_interval_t){
+      .header_index = header_index,
+      .latch_index = backedge->source_block_index,
+      .preheader_index = entry_edge->source_block_index,
+      .parent_loop_index = LOOM_CFG_LOOP_NONE,
+      .entry_edge_index = entry_edge_index,
+      .backedge_edge_index = backedge_edge_index,
+      .is_canonical = true,
+  };
+  return true;
+}
+
+static void loom_cfg_loop_include_predecessor(uint16_t predecessor_index,
+                                              bool* has_predecessor,
+                                              uint16_t* predecessor_min,
+                                              uint16_t* predecessor_max) {
+  if (!*has_predecessor) {
+    *has_predecessor = true;
+    *predecessor_min = predecessor_index;
+    *predecessor_max = predecessor_index;
+    return;
+  }
+  *predecessor_min = iree_min(*predecessor_min, predecessor_index);
+  *predecessor_max = iree_max(*predecessor_max, predecessor_index);
+}
+
+static void loom_cfg_loop_include_predecessor_range(
+    bool source_has_predecessor, uint16_t source_predecessor_min,
+    uint16_t source_predecessor_max, bool* target_has_predecessor,
+    uint16_t* target_predecessor_min, uint16_t* target_predecessor_max) {
+  if (!source_has_predecessor) return;
+  loom_cfg_loop_include_predecessor(
+      source_predecessor_min, target_has_predecessor, target_predecessor_min,
+      target_predecessor_max);
+  loom_cfg_loop_include_predecessor(
+      source_predecessor_max, target_has_predecessor, target_predecessor_min,
+      target_predecessor_max);
+}
+
+static iree_status_t loom_cfg_loop_forest_build_impl(
+    const loom_cfg_graph_t* graph, iree_arena_allocator_t* transient_arena,
+    iree_arena_allocator_t* arena, loom_cfg_loop_forest_t* out_forest) {
+  const iree_host_size_t candidate_capacity =
+      iree_min(graph->block_count, graph->backward_edge_count);
+  loom_cfg_loop_build_interval_t* build_intervals = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      transient_arena, candidate_capacity, sizeof(*build_intervals),
+      (void**)&build_intervals));
+  uint32_t* loop_by_header = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      transient_arena, graph->block_count, sizeof(*loop_by_header),
+      (void**)&loop_by_header));
+  for (iree_host_size_t i = 0; i < graph->block_count; ++i) {
+    loop_by_header[i] = LOOM_CFG_LOOP_NONE;
+  }
+
+  iree_host_size_t interval_count = 0;
+  // Predecessor spans partition CFG edges, making discovery O(B+E).
+  for (iree_host_size_t i = 0; i < graph->block_count; ++i) {
+    loom_cfg_loop_interval_t interval = {0};
+    if (!loom_cfg_loop_find_candidate(graph, (uint16_t)i, &interval)) {
+      continue;
+    }
+    IREE_ASSERT_LT(interval_count, candidate_capacity);
+    const uint32_t loop_index = (uint32_t)interval_count++;
+    loop_by_header[i] = loop_index;
+    build_intervals[loop_index] = (loom_cfg_loop_build_interval_t){
+        .interval = interval,
+    };
+  }
+  if (interval_count == 0) return iree_ok_status();
+
+  uint32_t* innermost_loop_indices = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      transient_arena, graph->block_count, sizeof(*innermost_loop_indices),
+      (void**)&innermost_loop_indices));
+  uint32_t* loop_stack = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_arena_allocate_array(transient_arena, interval_count,
+                                sizeof(*loop_stack), (void**)&loop_stack));
+
+  iree_host_size_t loop_stack_count = 0;
+  // Each interval is pushed and popped at most once, making this O(B+L).
+  for (iree_host_size_t i = 0; i < graph->block_count; ++i) {
+    while (
+        loop_stack_count > 0 &&
+        build_intervals[loop_stack[loop_stack_count - 1]].interval.latch_index <
+            i) {
+      --loop_stack_count;
+    }
+    const uint32_t loop_index = loop_by_header[i];
+    if (loop_index != LOOM_CFG_LOOP_NONE) {
+      loom_cfg_loop_interval_t* interval =
+          &build_intervals[loop_index].interval;
+      if (loop_stack_count > 0 &&
+          build_intervals[loop_stack[loop_stack_count - 1]]
+                  .interval.latch_index < interval->latch_index) {
+        // Crossing intervals do not form a tree. Leave the forest empty so
+        // consumers preserve exact point-local behavior.
+        return iree_ok_status();
+      }
+      interval->parent_loop_index = loop_stack_count > 0
+                                        ? loop_stack[loop_stack_count - 1]
+                                        : LOOM_CFG_LOOP_NONE;
+      loop_stack[loop_stack_count++] = loop_index;
+    }
+    innermost_loop_indices[i] = loop_stack_count > 0
+                                    ? loop_stack[loop_stack_count - 1]
+                                    : LOOM_CFG_LOOP_NONE;
+  }
+
+  // Predecessor spans partition CFG edges, so nested intervals do not cause
+  // their contained blocks or edges to be revisited.
+  for (iree_host_size_t i = 0; i < graph->block_count; ++i) {
+    const uint16_t block_index = (uint16_t)i;
+    const uint32_t loop_index = innermost_loop_indices[block_index];
+    if (loop_index == LOOM_CFG_LOOP_NONE ||
+        !loom_cfg_graph_block_is_reachable(graph, block_index)) {
+      continue;
+    }
+    loom_cfg_loop_build_interval_t* build_interval =
+        &build_intervals[loop_index];
+    const bool is_loop_header =
+        block_index == build_interval->interval.header_index;
+    const loom_cfg_block_index_span_t predecessors =
+        loom_cfg_graph_predecessors(graph, block_index);
+    for (iree_host_size_t j = 0; j < predecessors.count; ++j) {
+      const uint16_t predecessor_index = predecessors.values[j];
+      if (!loom_cfg_graph_block_is_reachable(graph, predecessor_index)) {
+        continue;
+      }
+      if (is_loop_header) {
+        loom_cfg_loop_include_predecessor(
+            predecessor_index, &build_interval->has_header_predecessor,
+            &build_interval->header_predecessor_min,
+            &build_interval->header_predecessor_max);
+      } else {
+        loom_cfg_loop_include_predecessor(
+            predecessor_index, &build_interval->has_body_predecessor,
+            &build_interval->body_predecessor_min,
+            &build_interval->body_predecessor_max);
+      }
+    }
+  }
+
+  // Children follow parents in header order. Folding each child once carries
+  // every predecessor range through the forest in O(L).
+  for (iree_host_size_t i = interval_count; i > 0; --i) {
+    loom_cfg_loop_build_interval_t* build_interval = &build_intervals[i - 1];
+    loom_cfg_loop_interval_t* interval = &build_interval->interval;
+    if (build_interval->has_body_predecessor &&
+        (build_interval->body_predecessor_min < interval->header_index ||
+         build_interval->body_predecessor_max > interval->latch_index)) {
+      interval->is_canonical = false;
+    }
+    if (interval->parent_loop_index != LOOM_CFG_LOOP_NONE) {
+      loom_cfg_loop_build_interval_t* parent =
+          &build_intervals[interval->parent_loop_index];
+      loom_cfg_loop_include_predecessor_range(
+          build_interval->has_header_predecessor,
+          build_interval->header_predecessor_min,
+          build_interval->header_predecessor_max, &parent->has_body_predecessor,
+          &parent->body_predecessor_min, &parent->body_predecessor_max);
+      loom_cfg_loop_include_predecessor_range(
+          build_interval->has_body_predecessor,
+          build_interval->body_predecessor_min,
+          build_interval->body_predecessor_max, &parent->has_body_predecessor,
+          &parent->body_predecessor_min, &parent->body_predecessor_max);
+    }
+  }
+
+  loom_cfg_loop_interval_t* intervals = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      arena, interval_count, sizeof(*intervals), (void**)&intervals));
+  uint32_t* retained_innermost_loop_indices = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      arena, graph->block_count, sizeof(*retained_innermost_loop_indices),
+      (void**)&retained_innermost_loop_indices));
+  for (iree_host_size_t i = 0; i < interval_count; ++i) {
+    intervals[i] = build_intervals[i].interval;
+  }
+  memcpy(retained_innermost_loop_indices, innermost_loop_indices,
+         graph->block_count * sizeof(*retained_innermost_loop_indices));
+  *out_forest = (loom_cfg_loop_forest_t){
+      .graph = graph,
+      .intervals = intervals,
+      .innermost_loop_indices = retained_innermost_loop_indices,
+      .interval_count = interval_count,
+  };
+  return iree_ok_status();
+}
+
+iree_status_t loom_cfg_loop_forest_build(const loom_cfg_graph_t* graph,
+                                         iree_arena_allocator_t* arena,
+                                         loom_cfg_loop_forest_t* out_forest) {
+  if (!graph || !arena || !out_forest) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "CFG loop forest build requires a graph, arena, and output forest");
+  }
+  *out_forest = (loom_cfg_loop_forest_t){
+      .graph = graph,
+  };
+  if (graph->malformed || graph->block_count <= 1 || graph->blocks == NULL ||
+      graph->backward_edge_count == 0) {
+    return iree_ok_status();
+  }
+
+  iree_arena_allocator_t transient_arena;
+  iree_arena_initialize(arena->block_pool, &transient_arena);
+  iree_status_t status = loom_cfg_loop_forest_build_impl(
+      graph, &transient_arena, arena, out_forest);
+  iree_arena_deinitialize(&transient_arena);
+  return status;
+}

--- a/loom/src/loom/util/cfg_loop.c
+++ b/loom/src/loom/util/cfg_loop.c
@@ -28,10 +28,13 @@ typedef struct loom_cfg_loop_build_interval_t {
 
 static bool loom_cfg_loop_find_candidate(
     const loom_cfg_graph_t* graph, uint16_t header_index,
+    iree_host_size_t* inout_reachable_backward_edge_count,
     loom_cfg_loop_interval_t* out_interval) {
   *out_interval = (loom_cfg_loop_interval_t){0};
   loom_cfg_edge_index_t entry_edge_index = LOOM_CFG_EDGE_INDEX_INVALID;
   loom_cfg_edge_index_t backedge_edge_index = LOOM_CFG_EDGE_INDEX_INVALID;
+  bool has_unique_entry_edge = true;
+  bool has_unique_backedge = true;
   const loom_cfg_edge_index_span_t predecessor_edges =
       loom_cfg_graph_predecessor_edges(graph, header_index);
   for (iree_host_size_t i = 0; i < predecessor_edges.count; ++i) {
@@ -42,14 +45,22 @@ static bool loom_cfg_loop_find_candidate(
       continue;
     }
     if (edge->source_block_index < header_index) {
-      if (entry_edge_index != LOOM_CFG_EDGE_INDEX_INVALID) return false;
-      entry_edge_index = edge_index;
+      if (entry_edge_index == LOOM_CFG_EDGE_INDEX_INVALID) {
+        entry_edge_index = edge_index;
+      } else {
+        has_unique_entry_edge = false;
+      }
     } else {
-      if (backedge_edge_index != LOOM_CFG_EDGE_INDEX_INVALID) return false;
-      backedge_edge_index = edge_index;
+      ++*inout_reachable_backward_edge_count;
+      if (backedge_edge_index == LOOM_CFG_EDGE_INDEX_INVALID) {
+        backedge_edge_index = edge_index;
+      } else {
+        has_unique_backedge = false;
+      }
     }
   }
-  if (entry_edge_index == LOOM_CFG_EDGE_INDEX_INVALID ||
+  if (!has_unique_entry_edge || !has_unique_backedge ||
+      entry_edge_index == LOOM_CFG_EDGE_INDEX_INVALID ||
       backedge_edge_index == LOOM_CFG_EDGE_INDEX_INVALID) {
     return false;
   }
@@ -58,16 +69,11 @@ static bool loom_cfg_loop_find_candidate(
       loom_cfg_graph_edge(graph, entry_edge_index);
   const loom_cfg_edge_info_t* backedge =
       loom_cfg_graph_edge(graph, backedge_edge_index);
-  const loom_cfg_block_index_span_t entry_successors =
-      loom_cfg_graph_successors(graph, entry_edge->source_block_index);
-  if (entry_successors.count != 1 || entry_edge->successor_index != 0) {
-    return false;
-  }
 
   *out_interval = (loom_cfg_loop_interval_t){
       .header_index = header_index,
       .latch_index = backedge->source_block_index,
-      .preheader_index = entry_edge->source_block_index,
+      .entry_predecessor_index = entry_edge->source_block_index,
       .parent_loop_index = LOOM_CFG_LOOP_NONE,
       .entry_edge_index = entry_edge_index,
       .backedge_edge_index = backedge_edge_index,
@@ -121,10 +127,12 @@ static iree_status_t loom_cfg_loop_forest_build_impl(
   }
 
   iree_host_size_t interval_count = 0;
+  iree_host_size_t reachable_backward_edge_count = 0;
   // Predecessor spans partition CFG edges, making discovery O(B+E).
   for (iree_host_size_t i = 0; i < graph->block_count; ++i) {
     loom_cfg_loop_interval_t interval = {0};
-    if (!loom_cfg_loop_find_candidate(graph, (uint16_t)i, &interval)) {
+    if (!loom_cfg_loop_find_candidate(
+            graph, (uint16_t)i, &reachable_backward_edge_count, &interval)) {
       continue;
     }
     IREE_ASSERT_LT(interval_count, candidate_capacity);
@@ -134,6 +142,7 @@ static iree_status_t loom_cfg_loop_forest_build_impl(
         .interval = interval,
     };
   }
+  out_forest->reachable_backward_edge_count = reachable_backward_edge_count;
   if (interval_count == 0) return iree_ok_status();
 
   uint32_t* innermost_loop_indices = NULL;
@@ -252,6 +261,7 @@ static iree_status_t loom_cfg_loop_forest_build_impl(
       .intervals = intervals,
       .innermost_loop_indices = retained_innermost_loop_indices,
       .interval_count = interval_count,
+      .reachable_backward_edge_count = reachable_backward_edge_count,
   };
   return iree_ok_status();
 }
@@ -278,4 +288,76 @@ iree_status_t loom_cfg_loop_forest_build(const loom_cfg_graph_t* graph,
       graph, &transient_arena, arena, out_forest);
   iree_arena_deinitialize(&transient_arena);
   return status;
+}
+
+bool loom_cfg_loop_forest_calculate_block_execution_counts(
+    const loom_cfg_loop_forest_t* forest, const uint64_t* trip_counts,
+    uint64_t* out_block_counts) {
+  IREE_ASSERT(forest->interval_count == 0 || trip_counts != NULL);
+
+  const loom_cfg_graph_t* graph = forest->graph;
+  for (iree_host_size_t i = 0; i < graph->block_count; ++i) {
+    const bool is_reachable =
+        graph->blocks == NULL ||
+        loom_cfg_graph_block_is_reachable(graph, (uint16_t)i);
+    out_block_counts[i] = is_reachable ? 1 : 0;
+    if (!is_reachable || forest->interval_count == 0) continue;
+    const uint32_t loop_index = forest->innermost_loop_indices[i];
+    if (loop_index != LOOM_CFG_LOOP_NONE &&
+        forest->intervals[loop_index].header_index != i &&
+        graph->blocks[i].successor_count > 1) {
+      return false;
+    }
+  }
+  if (forest->interval_count != forest->reachable_backward_edge_count) {
+    return false;
+  }
+  if (forest->interval_count == 0) {
+    return true;
+  }
+
+  // Use each loop header's output slot as its body execution count until all
+  // non-header blocks have consumed it below.
+  for (iree_host_size_t i = 0; i < forest->interval_count; ++i) {
+    const loom_cfg_loop_interval_t* interval = &forest->intervals[i];
+    if (!interval->is_canonical) return false;
+    const uint64_t parent_body_count =
+        interval->parent_loop_index == LOOM_CFG_LOOP_NONE
+            ? 1
+            : out_block_counts[forest->intervals[interval->parent_loop_index]
+                                   .header_index];
+    if (!iree_checked_mul_u64(parent_body_count, trip_counts[i],
+                              &out_block_counts[interval->header_index])) {
+      return false;
+    }
+  }
+
+  for (iree_host_size_t i = 0; i < graph->block_count; ++i) {
+    if (!loom_cfg_graph_block_is_reachable(graph, (uint16_t)i)) continue;
+    const uint32_t loop_index = forest->innermost_loop_indices[i];
+    if (loop_index == LOOM_CFG_LOOP_NONE ||
+        forest->intervals[loop_index].header_index == i) {
+      continue;
+    }
+    out_block_counts[i] =
+        out_block_counts[forest->intervals[loop_index].header_index];
+  }
+
+  // Children follow parents in interval order. Finalizing in reverse preserves
+  // each parent's temporary body count until all child headers consume it.
+  for (iree_host_size_t i = forest->interval_count; i > 0; --i) {
+    const loom_cfg_loop_interval_t* interval = &forest->intervals[i - 1];
+    const uint64_t parent_body_count =
+        interval->parent_loop_index == LOOM_CFG_LOOP_NONE
+            ? 1
+            : out_block_counts[forest->intervals[interval->parent_loop_index]
+                                   .header_index];
+    uint64_t header_trip_count = 0;
+    if (!iree_checked_add_u64(trip_counts[i - 1], 1, &header_trip_count) ||
+        !iree_checked_mul_u64(parent_body_count, header_trip_count,
+                              &out_block_counts[interval->header_index])) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/loom/src/loom/util/cfg_loop.h
+++ b/loom/src/loom/util/cfg_loop.h
@@ -38,10 +38,10 @@ typedef struct loom_cfg_loop_interval_t {
   bool is_canonical;
 } loom_cfg_loop_interval_t;
 
-// Immutable canonical loop forest derived from one CFG graph.
+// Immutable canonical loop forest derived from one CFG graph. The forest holds
+// no pointer to its parent graph so enclosing analysis records remain safely
+// movable; consumers supply the paired graph when graph facts are required.
 typedef struct loom_cfg_loop_forest_t {
-  // CFG graph whose block and edge indices are referenced by the forest.
-  const loom_cfg_graph_t* graph;
   // Loop intervals in increasing header-block order.
   const loom_cfg_loop_interval_t* intervals;
   // Innermost candidate interval per CFG block, or LOOM_CFG_LOOP_NONE.
@@ -67,13 +67,14 @@ iree_status_t loom_cfg_loop_forest_build(const loom_cfg_graph_t* graph,
 //
 // Reachable blocks outside loops execute once. A loop header executes one more
 // time than its trip count, while other loop blocks execute once per trip.
-// Nested counts are multiplied. Returns false when the forest does not cover
-// every reachable backward edge, contains a noncanonical interval, has
-// unmodeled branching inside a loop, or a count overflows. Expansion takes
-// O(B+L) time and no additional storage.
+// Nested counts are multiplied. |graph| is the immutable graph from which
+// |forest| was built. Returns false when the forest does not cover every
+// reachable backward edge, contains a noncanonical interval, has unmodeled
+// branching inside a loop, or a count overflows. Expansion takes O(B+L) time
+// and no additional storage.
 bool loom_cfg_loop_forest_calculate_block_execution_counts(
-    const loom_cfg_loop_forest_t* forest, const uint64_t* trip_counts,
-    uint64_t* out_block_counts);
+    const loom_cfg_loop_forest_t* forest, const loom_cfg_graph_t* graph,
+    const uint64_t* trip_counts, uint64_t* out_block_counts);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/loom/src/loom/util/cfg_loop.h
+++ b/loom/src/loom/util/cfg_loop.h
@@ -1,0 +1,68 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Canonical loop intervals preserved from a dense CFG graph.
+
+#ifndef LOOM_UTIL_CFG_LOOP_H_
+#define LOOM_UTIL_CFG_LOOP_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/arena.h"
+#include "loom/util/cfg_graph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Sentinel for the absence of a loop interval.
+#define LOOM_CFG_LOOP_NONE UINT32_MAX
+
+// One candidate single-entry loop interval in deterministic block order.
+typedef struct loom_cfg_loop_interval_t {
+  // Dense block index of the loop header.
+  uint16_t header_index;
+  // Dense block index of the unique backward-edge source.
+  uint16_t latch_index;
+  // Dense block index of the dedicated entry predecessor.
+  uint16_t preheader_index;
+  // Immediately enclosing interval, or LOOM_CFG_LOOP_NONE.
+  uint32_t parent_loop_index;
+  // CFG edge entering the header from |preheader_index|.
+  loom_cfg_edge_index_t entry_edge_index;
+  // CFG edge entering the header from |latch_index|.
+  loom_cfg_edge_index_t backedge_edge_index;
+  // True when the interval is properly nested and has no side entry.
+  bool is_canonical;
+} loom_cfg_loop_interval_t;
+
+// Immutable canonical loop forest derived from one CFG graph.
+typedef struct loom_cfg_loop_forest_t {
+  // CFG graph whose block and edge indices are referenced by the forest.
+  const loom_cfg_graph_t* graph;
+  // Loop intervals in increasing header-block order.
+  const loom_cfg_loop_interval_t* intervals;
+  // Innermost candidate interval per CFG block, or LOOM_CFG_LOOP_NONE.
+  const uint32_t* innermost_loop_indices;
+  // Number of entries in |intervals|.
+  iree_host_size_t interval_count;
+} loom_cfg_loop_forest_t;
+
+// Builds canonical loop intervals for |graph| in |arena|.
+//
+// Construction takes O(B+E+L) time for B blocks, E edges, and L candidate
+// intervals. Graphs without backward edges perform no traversal or allocation.
+// Crossing intervals conservatively produce an empty forest. Noncanonical
+// nested intervals remain represented with |is_canonical| false so consumers
+// can continue with an enclosing canonical interval.
+iree_status_t loom_cfg_loop_forest_build(const loom_cfg_graph_t* graph,
+                                         iree_arena_allocator_t* arena,
+                                         loom_cfg_loop_forest_t* out_forest);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_UTIL_CFG_LOOP_H_

--- a/loom/src/loom/util/cfg_loop.h
+++ b/loom/src/loom/util/cfg_loop.h
@@ -26,11 +26,11 @@ typedef struct loom_cfg_loop_interval_t {
   uint16_t header_index;
   // Dense block index of the unique backward-edge source.
   uint16_t latch_index;
-  // Dense block index of the dedicated entry predecessor.
-  uint16_t preheader_index;
+  // Dense block index of the unique entry predecessor.
+  uint16_t entry_predecessor_index;
   // Immediately enclosing interval, or LOOM_CFG_LOOP_NONE.
   uint32_t parent_loop_index;
-  // CFG edge entering the header from |preheader_index|.
+  // CFG edge entering the header from |entry_predecessor_index|.
   loom_cfg_edge_index_t entry_edge_index;
   // CFG edge entering the header from |latch_index|.
   loom_cfg_edge_index_t backedge_edge_index;
@@ -48,6 +48,8 @@ typedef struct loom_cfg_loop_forest_t {
   const uint32_t* innermost_loop_indices;
   // Number of entries in |intervals|.
   iree_host_size_t interval_count;
+  // Number of reachable CFG edges that return to the same or an earlier block.
+  iree_host_size_t reachable_backward_edge_count;
 } loom_cfg_loop_forest_t;
 
 // Builds canonical loop intervals for |graph| in |arena|.
@@ -60,6 +62,18 @@ typedef struct loom_cfg_loop_forest_t {
 iree_status_t loom_cfg_loop_forest_build(const loom_cfg_graph_t* graph,
                                          iree_arena_allocator_t* arena,
                                          loom_cfg_loop_forest_t* out_forest);
+
+// Expands one exact trip count per interval into block execution counts.
+//
+// Reachable blocks outside loops execute once. A loop header executes one more
+// time than its trip count, while other loop blocks execute once per trip.
+// Nested counts are multiplied. Returns false when the forest does not cover
+// every reachable backward edge, contains a noncanonical interval, has
+// unmodeled branching inside a loop, or a count overflows. Expansion takes
+// O(B+L) time and no additional storage.
+bool loom_cfg_loop_forest_calculate_block_execution_counts(
+    const loom_cfg_loop_forest_t* forest, const uint64_t* trip_counts,
+    uint64_t* out_block_counts);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/loom/src/loom/util/cfg_loop_test.cc
+++ b/loom/src/loom/util/cfg_loop_test.cc
@@ -1,0 +1,222 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/util/cfg_loop.h"
+
+#include "iree/base/internal/arena.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+#include "loom/ir/context.h"
+#include "loom/ir/module.h"
+#include "loom/ops/cfg/ops.h"
+#include "loom/ops/op_defs.h"
+#include "loom/ops/test/ops.h"
+
+namespace loom {
+namespace {
+
+class CfgLoopTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    iree_arena_block_pool_initialize(4096, iree_allocator_system(),
+                                     &block_pool_);
+    loom_context_initialize(iree_allocator_system(), &context_);
+
+    iree_host_size_t cfg_vtable_count = 0;
+    const loom_op_vtable_t* const* cfg_vtables =
+        loom_cfg_dialect_vtables(&cfg_vtable_count);
+    IREE_ASSERT_OK(loom_context_register_dialect(
+        &context_, LOOM_DIALECT_CFG, cfg_vtables, (uint16_t)cfg_vtable_count));
+    iree_host_size_t test_vtable_count = 0;
+    const loom_op_vtable_t* const* test_vtables =
+        loom_test_dialect_vtables(&test_vtable_count);
+    IREE_ASSERT_OK(loom_context_register_dialect(&context_, LOOM_DIALECT_TEST,
+                                                 test_vtables,
+                                                 (uint16_t)test_vtable_count));
+    IREE_ASSERT_OK(loom_context_finalize(&context_));
+
+    IREE_ASSERT_OK(loom_module_allocate(&context_, IREE_SV("test"),
+                                        &block_pool_, nullptr,
+                                        iree_allocator_system(), &module_));
+    loom_builder_initialize(module_, &module_->arena,
+                            loom_module_block(module_), &builder_);
+    loom_string_id_t name_id = LOOM_STRING_ID_INVALID;
+    IREE_ASSERT_OK(
+        loom_builder_intern_string(&builder_, IREE_SV("test_fn"), &name_id));
+    uint16_t symbol_id = LOOM_SYMBOL_ID_INVALID;
+    IREE_ASSERT_OK(loom_module_add_symbol(module_, name_id, &symbol_id));
+    const loom_symbol_ref_t callee = {
+        /*.module_id=*/0,
+        /*.symbol_id=*/symbol_id,
+    };
+    IREE_ASSERT_OK(loom_test_func_build(&builder_, 0, 0, 0, callee, nullptr, 0,
+                                        nullptr, 0, nullptr, 0, nullptr, 0,
+                                        LOOM_LOCATION_UNKNOWN, &func_op_));
+    body_ = loom_func_like_body(loom_func_like_cast(module_, func_op_));
+    loom_builder_initialize(module_, &module_->arena,
+                            loom_region_entry_block(body_), &builder_);
+    builder_.ip.parent_op = func_op_;
+    body_->flags |= LOOM_REGION_INSTANCE_FLAG_CFG;
+
+    iree_arena_initialize(&block_pool_, &analysis_arena_);
+  }
+
+  void TearDown() override {
+    iree_arena_deinitialize(&analysis_arena_);
+    loom_module_free(module_);
+    loom_context_deinitialize(&context_);
+    iree_arena_block_pool_deinitialize(&block_pool_);
+  }
+
+  loom_block_t* AppendBlock() {
+    loom_block_t* block = nullptr;
+    IREE_CHECK_OK(loom_region_append_block(module_, body_, &block));
+    return block;
+  }
+
+  void SetBlock(loom_block_t* block) {
+    loom_builder_set_block(&builder_, block);
+    builder_.ip.parent_op = func_op_;
+  }
+
+  void BuildBranch(loom_block_t* destination) {
+    loom_op_t* branch_op = nullptr;
+    IREE_CHECK_OK(loom_cfg_br_build(&builder_, destination, nullptr, 0,
+                                    LOOM_LOCATION_UNKNOWN, &branch_op));
+  }
+
+  void BuildConditionalBranch(loom_block_t* true_destination,
+                              loom_block_t* false_destination) {
+    loom_op_t* condition_op = nullptr;
+    IREE_CHECK_OK(loom_test_constant_build(
+        &builder_, loom_attr_i64(1), loom_type_scalar(LOOM_SCALAR_TYPE_I1),
+        LOOM_LOCATION_UNKNOWN, &condition_op));
+    loom_op_t* branch_op = nullptr;
+    IREE_CHECK_OK(loom_cfg_cond_br_build(
+        &builder_, loom_test_constant_result(condition_op), true_destination,
+        false_destination, LOOM_LOCATION_UNKNOWN, &branch_op));
+  }
+
+  loom_cfg_loop_forest_t BuildForest(loom_cfg_graph_t* out_graph) {
+    IREE_CHECK_OK(
+        loom_cfg_graph_build(module_, body_, &analysis_arena_, out_graph));
+    loom_cfg_loop_forest_t forest = {0};
+    IREE_CHECK_OK(
+        loom_cfg_loop_forest_build(out_graph, &analysis_arena_, &forest));
+    return forest;
+  }
+
+  iree_arena_block_pool_t block_pool_;
+  loom_context_t context_;
+  loom_module_t* module_ = nullptr;
+  loom_op_t* func_op_ = nullptr;
+  loom_region_t* body_ = nullptr;
+  loom_builder_t builder_;
+  iree_arena_allocator_t analysis_arena_;
+};
+
+TEST_F(CfgLoopTest, AcyclicGraphHasEmptyForest) {
+  loom_block_t* entry = loom_region_entry_block(body_);
+  loom_block_t* exit = AppendBlock();
+  SetBlock(entry);
+  BuildBranch(exit);
+
+  loom_cfg_graph_t graph = {0};
+  const loom_cfg_loop_forest_t forest = BuildForest(&graph);
+
+  EXPECT_EQ(graph.backward_edge_count, 0u);
+  EXPECT_EQ(forest.graph, &graph);
+  EXPECT_EQ(forest.interval_count, 0u);
+  EXPECT_EQ(forest.intervals, nullptr);
+  EXPECT_EQ(forest.innermost_loop_indices, nullptr);
+}
+
+TEST_F(CfgLoopTest, BuildsNestedCanonicalIntervals) {
+  loom_block_t* entry = loom_region_entry_block(body_);
+  loom_block_t* outer_header = AppendBlock();
+  loom_block_t* inner_preheader = AppendBlock();
+  loom_block_t* inner_header = AppendBlock();
+  loom_block_t* inner_body = AppendBlock();
+  loom_block_t* outer_latch = AppendBlock();
+  loom_block_t* exit = AppendBlock();
+
+  SetBlock(entry);
+  BuildBranch(outer_header);
+  SetBlock(outer_header);
+  BuildConditionalBranch(inner_preheader, exit);
+  SetBlock(inner_preheader);
+  BuildBranch(inner_header);
+  SetBlock(inner_header);
+  BuildConditionalBranch(inner_body, outer_latch);
+  SetBlock(inner_body);
+  BuildBranch(inner_header);
+  SetBlock(outer_latch);
+  BuildBranch(outer_header);
+
+  loom_cfg_graph_t graph = {0};
+  const loom_cfg_loop_forest_t forest = BuildForest(&graph);
+
+  ASSERT_EQ(graph.backward_edge_count, 2u);
+  ASSERT_EQ(forest.interval_count, 2u);
+  const loom_cfg_loop_interval_t& outer = forest.intervals[0];
+  EXPECT_EQ(outer.header_index, 1u);
+  EXPECT_EQ(outer.latch_index, 5u);
+  EXPECT_EQ(outer.preheader_index, 0u);
+  EXPECT_EQ(outer.parent_loop_index, LOOM_CFG_LOOP_NONE);
+  EXPECT_TRUE(outer.is_canonical);
+  const loom_cfg_loop_interval_t& inner = forest.intervals[1];
+  EXPECT_EQ(inner.header_index, 3u);
+  EXPECT_EQ(inner.latch_index, 4u);
+  EXPECT_EQ(inner.preheader_index, 2u);
+  EXPECT_EQ(inner.parent_loop_index, 0u);
+  EXPECT_TRUE(inner.is_canonical);
+
+  ASSERT_NE(forest.innermost_loop_indices, nullptr);
+  EXPECT_EQ(forest.innermost_loop_indices[0], LOOM_CFG_LOOP_NONE);
+  EXPECT_EQ(forest.innermost_loop_indices[1], 0u);
+  EXPECT_EQ(forest.innermost_loop_indices[2], 0u);
+  EXPECT_EQ(forest.innermost_loop_indices[3], 1u);
+  EXPECT_EQ(forest.innermost_loop_indices[4], 1u);
+  EXPECT_EQ(forest.innermost_loop_indices[5], 0u);
+  EXPECT_EQ(forest.innermost_loop_indices[6], LOOM_CFG_LOOP_NONE);
+}
+
+TEST_F(CfgLoopTest, SideEntryInvalidatesOnlyInnerInterval) {
+  loom_block_t* entry = loom_region_entry_block(body_);
+  loom_block_t* outer_header = AppendBlock();
+  loom_block_t* inner_preheader = AppendBlock();
+  loom_block_t* side_entry = AppendBlock();
+  loom_block_t* inner_header = AppendBlock();
+  loom_block_t* inner_body = AppendBlock();
+  loom_block_t* outer_latch = AppendBlock();
+  loom_block_t* exit = AppendBlock();
+
+  SetBlock(entry);
+  BuildBranch(outer_header);
+  SetBlock(outer_header);
+  BuildConditionalBranch(inner_preheader, side_entry);
+  SetBlock(inner_preheader);
+  BuildBranch(inner_header);
+  SetBlock(side_entry);
+  BuildBranch(inner_body);
+  SetBlock(inner_header);
+  BuildConditionalBranch(inner_body, outer_latch);
+  SetBlock(inner_body);
+  BuildBranch(inner_header);
+  SetBlock(outer_latch);
+  BuildConditionalBranch(outer_header, exit);
+
+  loom_cfg_graph_t graph = {0};
+  const loom_cfg_loop_forest_t forest = BuildForest(&graph);
+
+  ASSERT_EQ(forest.interval_count, 2u);
+  EXPECT_TRUE(forest.intervals[0].is_canonical);
+  EXPECT_FALSE(forest.intervals[1].is_canonical);
+  EXPECT_EQ(forest.intervals[1].parent_loop_index, 0u);
+}
+
+}  // namespace
+}  // namespace loom

--- a/loom/src/loom/util/cfg_loop_test.cc
+++ b/loom/src/loom/util/cfg_loop_test.cc
@@ -130,6 +130,7 @@ TEST_F(CfgLoopTest, AcyclicGraphHasEmptyForest) {
   EXPECT_EQ(graph.backward_edge_count, 0u);
   EXPECT_EQ(forest.graph, &graph);
   EXPECT_EQ(forest.interval_count, 0u);
+  EXPECT_EQ(forest.reachable_backward_edge_count, 0u);
   EXPECT_EQ(forest.intervals, nullptr);
   EXPECT_EQ(forest.innermost_loop_indices, nullptr);
 }
@@ -161,16 +162,17 @@ TEST_F(CfgLoopTest, BuildsNestedCanonicalIntervals) {
 
   ASSERT_EQ(graph.backward_edge_count, 2u);
   ASSERT_EQ(forest.interval_count, 2u);
+  EXPECT_EQ(forest.reachable_backward_edge_count, 2u);
   const loom_cfg_loop_interval_t& outer = forest.intervals[0];
   EXPECT_EQ(outer.header_index, 1u);
   EXPECT_EQ(outer.latch_index, 5u);
-  EXPECT_EQ(outer.preheader_index, 0u);
+  EXPECT_EQ(outer.entry_predecessor_index, 0u);
   EXPECT_EQ(outer.parent_loop_index, LOOM_CFG_LOOP_NONE);
   EXPECT_TRUE(outer.is_canonical);
   const loom_cfg_loop_interval_t& inner = forest.intervals[1];
   EXPECT_EQ(inner.header_index, 3u);
   EXPECT_EQ(inner.latch_index, 4u);
-  EXPECT_EQ(inner.preheader_index, 2u);
+  EXPECT_EQ(inner.entry_predecessor_index, 2u);
   EXPECT_EQ(inner.parent_loop_index, 0u);
   EXPECT_TRUE(inner.is_canonical);
 
@@ -182,6 +184,67 @@ TEST_F(CfgLoopTest, BuildsNestedCanonicalIntervals) {
   EXPECT_EQ(forest.innermost_loop_indices[4], 1u);
   EXPECT_EQ(forest.innermost_loop_indices[5], 0u);
   EXPECT_EQ(forest.innermost_loop_indices[6], LOOM_CFG_LOOP_NONE);
+
+  const uint64_t trip_counts[] = {4, 8};
+  uint64_t block_counts[7] = {0};
+  EXPECT_TRUE(loom_cfg_loop_forest_calculate_block_execution_counts(
+      &forest, trip_counts, block_counts));
+  EXPECT_EQ(block_counts[0], 1u);
+  EXPECT_EQ(block_counts[1], 5u);
+  EXPECT_EQ(block_counts[2], 4u);
+  EXPECT_EQ(block_counts[3], 36u);
+  EXPECT_EQ(block_counts[4], 32u);
+  EXPECT_EQ(block_counts[5], 4u);
+  EXPECT_EQ(block_counts[6], 1u);
+}
+
+TEST_F(CfgLoopTest, RetainsEntryPredecessorWithMultipleSuccessors) {
+  loom_block_t* entry = loom_region_entry_block(body_);
+  loom_block_t* header = AppendBlock();
+  loom_block_t* body = AppendBlock();
+  loom_block_t* exit = AppendBlock();
+
+  SetBlock(entry);
+  BuildConditionalBranch(header, exit);
+  SetBlock(header);
+  BuildConditionalBranch(body, exit);
+  SetBlock(body);
+  BuildBranch(header);
+
+  loom_cfg_graph_t graph = {0};
+  const loom_cfg_loop_forest_t forest = BuildForest(&graph);
+
+  ASSERT_EQ(forest.interval_count, 1u);
+  EXPECT_EQ(forest.reachable_backward_edge_count, 1u);
+  EXPECT_EQ(forest.intervals[0].entry_predecessor_index, 0u);
+  EXPECT_TRUE(forest.intervals[0].is_canonical);
+}
+
+TEST_F(CfgLoopTest, RejectsUnmodeledBranchingInsideLoop) {
+  loom_block_t* entry = loom_region_entry_block(body_);
+  loom_block_t* header = AppendBlock();
+  loom_block_t* body = AppendBlock();
+  loom_block_t* latch = AppendBlock();
+  loom_block_t* exit = AppendBlock();
+
+  SetBlock(entry);
+  BuildBranch(header);
+  SetBlock(header);
+  BuildConditionalBranch(body, exit);
+  SetBlock(body);
+  BuildConditionalBranch(latch, exit);
+  SetBlock(latch);
+  BuildBranch(header);
+
+  loom_cfg_graph_t graph = {0};
+  const loom_cfg_loop_forest_t forest = BuildForest(&graph);
+
+  ASSERT_EQ(forest.interval_count, 1u);
+  EXPECT_TRUE(forest.intervals[0].is_canonical);
+  const uint64_t trip_counts[] = {4};
+  uint64_t block_counts[5] = {0};
+  EXPECT_FALSE(loom_cfg_loop_forest_calculate_block_execution_counts(
+      &forest, trip_counts, block_counts));
 }
 
 TEST_F(CfgLoopTest, SideEntryInvalidatesOnlyInnerInterval) {
@@ -213,9 +276,15 @@ TEST_F(CfgLoopTest, SideEntryInvalidatesOnlyInnerInterval) {
   const loom_cfg_loop_forest_t forest = BuildForest(&graph);
 
   ASSERT_EQ(forest.interval_count, 2u);
+  EXPECT_EQ(forest.reachable_backward_edge_count, 2u);
   EXPECT_TRUE(forest.intervals[0].is_canonical);
   EXPECT_FALSE(forest.intervals[1].is_canonical);
   EXPECT_EQ(forest.intervals[1].parent_loop_index, 0u);
+
+  const uint64_t trip_counts[] = {4, 8};
+  uint64_t block_counts[8] = {0};
+  EXPECT_FALSE(loom_cfg_loop_forest_calculate_block_execution_counts(
+      &forest, trip_counts, block_counts));
 }
 
 }  // namespace

--- a/loom/src/loom/util/cfg_loop_test.cc
+++ b/loom/src/loom/util/cfg_loop_test.cc
@@ -128,7 +128,6 @@ TEST_F(CfgLoopTest, AcyclicGraphHasEmptyForest) {
   const loom_cfg_loop_forest_t forest = BuildForest(&graph);
 
   EXPECT_EQ(graph.backward_edge_count, 0u);
-  EXPECT_EQ(forest.graph, &graph);
   EXPECT_EQ(forest.interval_count, 0u);
   EXPECT_EQ(forest.reachable_backward_edge_count, 0u);
   EXPECT_EQ(forest.intervals, nullptr);
@@ -188,7 +187,7 @@ TEST_F(CfgLoopTest, BuildsNestedCanonicalIntervals) {
   const uint64_t trip_counts[] = {4, 8};
   uint64_t block_counts[7] = {0};
   EXPECT_TRUE(loom_cfg_loop_forest_calculate_block_execution_counts(
-      &forest, trip_counts, block_counts));
+      &forest, &graph, trip_counts, block_counts));
   EXPECT_EQ(block_counts[0], 1u);
   EXPECT_EQ(block_counts[1], 5u);
   EXPECT_EQ(block_counts[2], 4u);
@@ -199,7 +198,7 @@ TEST_F(CfgLoopTest, BuildsNestedCanonicalIntervals) {
 
   const uint64_t zero_outer_trip_counts[] = {0, 8};
   EXPECT_TRUE(loom_cfg_loop_forest_calculate_block_execution_counts(
-      &forest, zero_outer_trip_counts, block_counts));
+      &forest, &graph, zero_outer_trip_counts, block_counts));
   EXPECT_EQ(block_counts[0], 1u);
   EXPECT_EQ(block_counts[1], 1u);
   EXPECT_EQ(block_counts[2], 0u);
@@ -210,10 +209,10 @@ TEST_F(CfgLoopTest, BuildsNestedCanonicalIntervals) {
 
   const uint64_t header_overflow_trip_counts[] = {UINT64_MAX, 0};
   EXPECT_FALSE(loom_cfg_loop_forest_calculate_block_execution_counts(
-      &forest, header_overflow_trip_counts, block_counts));
+      &forest, &graph, header_overflow_trip_counts, block_counts));
   const uint64_t nested_overflow_trip_counts[] = {UINT64_MAX / 2 + 1, 2};
   EXPECT_FALSE(loom_cfg_loop_forest_calculate_block_execution_counts(
-      &forest, nested_overflow_trip_counts, block_counts));
+      &forest, &graph, nested_overflow_trip_counts, block_counts));
 }
 
 TEST_F(CfgLoopTest, RetainsEntryPredecessorWithMultipleSuccessors) {
@@ -262,7 +261,7 @@ TEST_F(CfgLoopTest, RejectsUnmodeledBranchingInsideLoop) {
   const uint64_t trip_counts[] = {4};
   uint64_t block_counts[5] = {0};
   EXPECT_FALSE(loom_cfg_loop_forest_calculate_block_execution_counts(
-      &forest, trip_counts, block_counts));
+      &forest, &graph, trip_counts, block_counts));
 }
 
 TEST_F(CfgLoopTest, RejectsUnrepresentedBackwardEdges) {
@@ -287,7 +286,7 @@ TEST_F(CfgLoopTest, RejectsUnrepresentedBackwardEdges) {
   EXPECT_EQ(forest.reachable_backward_edge_count, 2u);
   uint64_t block_counts[4] = {0};
   EXPECT_FALSE(loom_cfg_loop_forest_calculate_block_execution_counts(
-      &forest, /*trip_counts=*/nullptr, block_counts));
+      &forest, &graph, /*trip_counts=*/nullptr, block_counts));
 }
 
 TEST_F(CfgLoopTest, SideEntryInvalidatesOnlyInnerInterval) {
@@ -327,7 +326,7 @@ TEST_F(CfgLoopTest, SideEntryInvalidatesOnlyInnerInterval) {
   const uint64_t trip_counts[] = {4, 8};
   uint64_t block_counts[8] = {0};
   EXPECT_FALSE(loom_cfg_loop_forest_calculate_block_execution_counts(
-      &forest, trip_counts, block_counts));
+      &forest, &graph, trip_counts, block_counts));
 }
 
 }  // namespace

--- a/loom/src/loom/util/cfg_loop_test.cc
+++ b/loom/src/loom/util/cfg_loop_test.cc
@@ -196,6 +196,24 @@ TEST_F(CfgLoopTest, BuildsNestedCanonicalIntervals) {
   EXPECT_EQ(block_counts[4], 32u);
   EXPECT_EQ(block_counts[5], 4u);
   EXPECT_EQ(block_counts[6], 1u);
+
+  const uint64_t zero_outer_trip_counts[] = {0, 8};
+  EXPECT_TRUE(loom_cfg_loop_forest_calculate_block_execution_counts(
+      &forest, zero_outer_trip_counts, block_counts));
+  EXPECT_EQ(block_counts[0], 1u);
+  EXPECT_EQ(block_counts[1], 1u);
+  EXPECT_EQ(block_counts[2], 0u);
+  EXPECT_EQ(block_counts[3], 0u);
+  EXPECT_EQ(block_counts[4], 0u);
+  EXPECT_EQ(block_counts[5], 0u);
+  EXPECT_EQ(block_counts[6], 1u);
+
+  const uint64_t header_overflow_trip_counts[] = {UINT64_MAX, 0};
+  EXPECT_FALSE(loom_cfg_loop_forest_calculate_block_execution_counts(
+      &forest, header_overflow_trip_counts, block_counts));
+  const uint64_t nested_overflow_trip_counts[] = {UINT64_MAX / 2 + 1, 2};
+  EXPECT_FALSE(loom_cfg_loop_forest_calculate_block_execution_counts(
+      &forest, nested_overflow_trip_counts, block_counts));
 }
 
 TEST_F(CfgLoopTest, RetainsEntryPredecessorWithMultipleSuccessors) {
@@ -245,6 +263,31 @@ TEST_F(CfgLoopTest, RejectsUnmodeledBranchingInsideLoop) {
   uint64_t block_counts[5] = {0};
   EXPECT_FALSE(loom_cfg_loop_forest_calculate_block_execution_counts(
       &forest, trip_counts, block_counts));
+}
+
+TEST_F(CfgLoopTest, RejectsUnrepresentedBackwardEdges) {
+  loom_block_t* entry = loom_region_entry_block(body_);
+  loom_block_t* header = AppendBlock();
+  loom_block_t* left_latch = AppendBlock();
+  loom_block_t* right_latch = AppendBlock();
+
+  SetBlock(entry);
+  BuildBranch(header);
+  SetBlock(header);
+  BuildConditionalBranch(left_latch, right_latch);
+  SetBlock(left_latch);
+  BuildBranch(header);
+  SetBlock(right_latch);
+  BuildBranch(header);
+
+  loom_cfg_graph_t graph = {0};
+  const loom_cfg_loop_forest_t forest = BuildForest(&graph);
+
+  EXPECT_EQ(forest.interval_count, 0u);
+  EXPECT_EQ(forest.reachable_backward_edge_count, 2u);
+  uint64_t block_counts[4] = {0};
+  EXPECT_FALSE(loom_cfg_loop_forest_calculate_block_execution_counts(
+      &forest, /*trip_counts=*/nullptr, block_counts));
 }
 
 TEST_F(CfgLoopTest, SideEntryInvalidatesOnlyInnerInterval) {


### PR DESCRIPTION
Loom now preserves canonical CFG loop intervals once in the low function model and reuses them to place loop-invariant completion waits and calculate dynamic report counts. This removes repeated CFG reconstruction from two hot compiler paths while fixing a concrete AMDGPU artifact that executed the same VMEM wait on every loop iteration.

**Design**

The target-independent CFG layer retains a compact loop forest beside the dense graph. Each interval records its header, latch, unique entry and backedge edges, parent interval, and canonicality; a block-indexed table identifies the innermost interval. The forest contains only values and arena-backed arrays rather than a pointer to its parent graph, preserving the emission frame's value semantics when accepted repair candidates move into caller-owned outputs. Consumers pass the paired immutable graph explicitly when querying graph facts. Construction partitions existing predecessor spans and performs one ordered stack traversal, taking `O(B + E + L)` time. Straight-line functions use the graph's lightweight identity and perform no loop allocation or traversal.

AMDGPU wait planning derives a bounded ancestor overlay from those preserved intervals. An SSA dependency produced outside a canonical loop and first consumed inside it may move its completion action to the loop entry predecessor. The original producer and consumer remain attached to the diagnostic action; only the insertion point changes. Dependencies produced inside the loop, memory-effect hazards, loops without a dedicated unconditional entry edge, and noncanonical control flow retain conservative point-local placement.

Frontier propagation now models full drains as a kill-and-generate transfer function. Incoming event state is filtered by each block's drain mask before locally generated events are joined, so a completion established at loop entry remains completed when the backedge frontier converges.

Detailed source and target reports consume the same loop forest. One allocation-free `O(B + L)` expansion maps exact interval trip counts to block execution counts, including nested products and the extra terminating header evaluation. Source lowering builds one forest lazily when report counts are requested; target reporting reuses the scheduled forest and finds branch payloads through the allocation table's source-ordinal index. The former per-loop predecessor worklists, whole-CFG scans, and edge-copy-group searches are deleted.

**Impact**

The motivating gfx1151 kernel issues one global load followed by a 64-iteration recurrence. Previously, native output placed `s_waitcnt vmcnt(0)` inside the recurrence immediately before the invariant value's consumer, executing the wait 64 times. The repaired artifact places one VMEM wait after the load and before the loop header, with no VMEM wait on the backedge.

The reporting paths no longer scale as `O(L(B + E))` for nested loops, and target branch-payload recovery no longer scales with every edge-copy group for every loop. Count expansion allocates no scratch storage and rejects overflow or incomplete loop coverage instead of publishing plausible but inexact dynamic totals.

**Conservative Boundaries**

The generic loop forest does not claim irreducible or crossing control flow is canonical. Report counts remain unknown for side entries, internal conditional paths not represented by nested intervals, multiple unrepresented backedges, or checked-arithmetic overflow. AMDGPU wait relocation applies a stricter target-local entry contract without narrowing the reusable CFG representation.

**Reviewer Notes**

The highest-value review surfaces are the loop-forest canonicality rules in `loom/src/loom/util/cfg_loop.c`, the wait relocation eligibility and frontier kill semantics under `loom/src/loom/target/arch/amdgpu/planning/`, and the removal of report-local natural-loop reconstruction in the two report consumers.
