### PR TITLE
[Loom/AMDGPU] Drop unsupported advisory cache hints

### DIFF
--- a/loom/src/loom/ops/cache.h
+++ b/loom/src/loom/ops/cache.h
@@ -4,10 +4,12 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Shared cache-policy vocabulary used by kernel async copies, view scalar
-// memory operations, and vector memory operations. Generated dialect APIs alias
-// these enum types directly so verification, lowering, and builders use one
-// semantic domain.
+// Shared advisory cache-policy vocabulary used by kernel async copies, view
+// scalar memory operations, and vector memory operations. Cache policies may
+// improve locality or reduce pollution but do not alter memory ordering or
+// coherence semantics; targets may ignore policies they cannot encode.
+// Generated dialect APIs alias these enum types directly so verification,
+// lowering, and builders use one semantic domain.
 
 #ifndef LOOM_OPS_CACHE_H_
 #define LOOM_OPS_CACHE_H_
@@ -18,7 +20,7 @@
 extern "C" {
 #endif
 
-// Cache/coherency scope for memory operations.
+// Cache hierarchy scope at which an advisory policy applies.
 typedef enum loom_cache_scope_e {
   // Cache/coherency scope is the compute unit.
   LOOM_CACHE_SCOPE_CU = 0,

--- a/loom/src/loom/target/arch/amdgpu/lower/memory.h
+++ b/loom/src/loom/target/arch/amdgpu/lower/memory.h
@@ -138,6 +138,18 @@ typedef struct loom_amdgpu_memory_cache_policy_attrs_t {
   int64_t nt;
 } loom_amdgpu_memory_cache_policy_attrs_t;
 
+// Result of resolving an advisory source cache policy for a descriptor set.
+typedef enum loom_amdgpu_memory_cache_policy_resolution_e {
+  // The source memory operation has no cache policy.
+  LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_ABSENT = 0,
+  // The selected descriptor set can encode the source cache policy.
+  LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_ENCODED = 1,
+  // The policy is valid but unsupported and must be omitted from the packet.
+  LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_DROPPED = 2,
+  // The policy is invalid for the selected memory access or descriptor set.
+  LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_REJECTED = 3,
+} loom_amdgpu_memory_cache_policy_resolution_t;
+
 // Reads common offset-immediate limits from a descriptor.
 bool loom_amdgpu_descriptor_offset_immediate_info(
     const loom_low_descriptor_set_t* descriptor_set,
@@ -279,8 +291,8 @@ loom_amdgpu_memory_cache_policy_descriptor_encoding(
 iree_string_view_t loom_amdgpu_memory_cache_policy_selected_key(
     const loom_low_descriptor_set_t* descriptor_set);
 
-// Returns true when the selected descriptor set can encode the cache policy on
-// the memory access plan.
+// Returns true when the cache policy can be encoded or safely omitted for the
+// selected descriptor set and memory access plan.
 bool loom_amdgpu_memory_cache_policy_can_lower(
     const loom_low_descriptor_set_t* descriptor_set,
     const loom_amdgpu_memory_access_t* access);
@@ -316,9 +328,10 @@ iree_string_view_t loom_amdgpu_cache_scope_name(uint8_t scope);
 // Returns the stable diagnostic name for a cache temporal policy.
 iree_string_view_t loom_amdgpu_cache_temporal_name(uint8_t temporal);
 
-// Encodes the target-specific cache-policy attributes for a selected memory
-// access plan. Missing source cache policy encodes as an empty attrs struct.
-bool loom_amdgpu_memory_cache_policy_encode(
+// Resolves target-specific cache-policy attributes for a selected memory
+// access plan. Absent and dropped policies produce an empty attrs struct.
+loom_amdgpu_memory_cache_policy_resolution_t
+loom_amdgpu_memory_cache_policy_resolve(
     const loom_low_descriptor_set_t* descriptor_set,
     const loom_amdgpu_memory_access_t* access,
     loom_amdgpu_memory_cache_policy_attrs_t* out_attrs);
@@ -361,7 +374,8 @@ iree_status_t loom_amdgpu_record_memory_cache_policy_diagnostic(
     loom_target_low_legality_context_t* context, const loom_op_t* op,
     const loom_low_descriptor_set_t* descriptor_set,
     const loom_amdgpu_memory_access_t* access,
-    loom_low_source_memory_operation_kind_t kind);
+    loom_amdgpu_memory_cache_policy_resolution_t resolution,
+    const loom_amdgpu_memory_cache_policy_attrs_t* cache_attrs);
 
 // Records optional cache-policy diagnostics for a rejected memory access plan.
 iree_status_t loom_amdgpu_record_memory_cache_policy_rejection_diagnostic(

--- a/loom/src/loom/target/arch/amdgpu/lower/memory_cache.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/memory_cache.c
@@ -159,7 +159,8 @@ static bool loom_amdgpu_memory_cache_policy_bits_contain(uint32_t bits,
   return ordinal < 32 && iree_any_bit_set(bits, (uint32_t)1u << ordinal);
 }
 
-bool loom_amdgpu_memory_cache_policy_encode(
+loom_amdgpu_memory_cache_policy_resolution_t
+loom_amdgpu_memory_cache_policy_resolve(
     const loom_low_descriptor_set_t* descriptor_set,
     const loom_amdgpu_memory_access_t* access,
     loom_amdgpu_memory_cache_policy_attrs_t* out_attrs) {
@@ -168,28 +169,30 @@ bool loom_amdgpu_memory_cache_policy_encode(
   const loom_vector_memory_cache_policy_t* policy =
       &access->source.cache_policy;
   if (!loom_amdgpu_memory_cache_policy_is_present(policy)) {
-    return true;
+    return LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_ABSENT;
   }
   if (!loom_amdgpu_memory_cache_policy_is_complete(policy) ||
       access->source.memory_space == LOOM_VALUE_FACT_MEMORY_SPACE_WORKGROUP) {
-    return false;
+    return LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_REJECTED;
   }
 
   const loom_amdgpu_descriptor_set_info_t* descriptor_set_info =
       loom_amdgpu_target_info_descriptor_set_at(
           descriptor_set->descriptor_set_ordinal);
   if (descriptor_set_info == NULL) {
-    return false;
+    return LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_REJECTED;
   }
   const loom_amdgpu_memory_cache_policy_encoding_row_t* row =
       loom_amdgpu_memory_cache_policy_encoding_row(
           descriptor_set_info->vector_memory.cache_policy_encoding);
-  if (row == NULL ||
-      !loom_amdgpu_memory_cache_policy_bits_contain(row->scope_bits,
+  if (row == NULL) {
+    return LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_REJECTED;
+  }
+  if (!loom_amdgpu_memory_cache_policy_bits_contain(row->scope_bits,
                                                     policy->cache_scope) ||
       !loom_amdgpu_memory_cache_policy_bits_contain(row->temporal_bits,
                                                     policy->cache_temporal)) {
-    return false;
+    return LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_DROPPED;
   }
 
   if (iree_any_bit_set(row->attr_flags,
@@ -210,14 +213,16 @@ bool loom_amdgpu_memory_cache_policy_encode(
     out_attrs->flags |= LOOM_AMDGPU_MEMORY_CACHE_POLICY_ATTR_NT;
     out_attrs->nt = 1;
   }
-  return true;
+  return LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_ENCODED;
 }
 
 bool loom_amdgpu_memory_cache_policy_can_lower(
     const loom_low_descriptor_set_t* descriptor_set,
     const loom_amdgpu_memory_access_t* access) {
   loom_amdgpu_memory_cache_policy_attrs_t attrs;
-  return loom_amdgpu_memory_cache_policy_encode(descriptor_set, access, &attrs);
+  return loom_amdgpu_memory_cache_policy_resolve(descriptor_set, access,
+                                                 &attrs) !=
+         LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_REJECTED;
 }
 
 iree_string_view_t loom_amdgpu_memory_cache_policy_rejection_key(

--- a/loom/src/loom/target/arch/amdgpu/lower/memory_diagnostics.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/memory_diagnostics.c
@@ -505,23 +505,28 @@ iree_status_t loom_amdgpu_record_memory_cache_policy_diagnostic(
     loom_target_low_legality_context_t* context, const loom_op_t* op,
     const loom_low_descriptor_set_t* descriptor_set,
     const loom_amdgpu_memory_access_t* access,
-    loom_low_source_memory_operation_kind_t kind) {
+    loom_amdgpu_memory_cache_policy_resolution_t resolution,
+    const loom_amdgpu_memory_cache_policy_attrs_t* cache_attrs) {
   if (!iree_any_bit_set(loom_target_low_legality_diagnostic_flags(context),
                         LOOM_TARGET_LOW_LEGALITY_DIAGNOSTIC_MEMORY_ACCESS) ||
-      !loom_amdgpu_memory_cache_policy_is_present(
-          &access->source.cache_policy)) {
+      resolution == LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_ABSENT) {
     return iree_ok_status();
   }
 
-  loom_amdgpu_memory_cache_policy_attrs_t cache_attrs = {0};
-  if (!loom_amdgpu_memory_cache_policy_encode(descriptor_set, access,
-                                              &cache_attrs)) {
-    return iree_ok_status();
+  IREE_ASSERT_NE(resolution,
+                 LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_REJECTED);
+  const loom_low_source_memory_operation_kind_t kind =
+      access->source.operation_kind;
+  if (resolution == LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_DROPPED) {
+    return loom_amdgpu_record_memory_cache_policy(
+        context, op, descriptor_set, access, kind,
+        IREE_SV("memory_cache_policy.unsupported"), IREE_SV("dropped"),
+        /*cache_attrs=*/NULL);
   }
   return loom_amdgpu_record_memory_cache_policy(
       context, op, descriptor_set, access, kind,
       loom_amdgpu_memory_cache_policy_selected_key(descriptor_set),
-      IREE_SV("selected"), &cache_attrs);
+      IREE_SV("selected"), cache_attrs);
 }
 
 iree_status_t loom_amdgpu_record_memory_cache_policy_rejection_diagnostic(

--- a/loom/src/loom/target/arch/amdgpu/lower/memory_emit.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/memory_emit.c
@@ -1787,9 +1787,14 @@ static iree_status_t loom_amdgpu_append_memory_cache_attrs(
   const loom_low_descriptor_set_t* descriptor_set =
       loom_low_lower_context_descriptor_set(context);
   loom_amdgpu_memory_cache_policy_attrs_t cache_attrs = {0};
-  const bool encoded = loom_amdgpu_memory_cache_policy_encode(
-      descriptor_set, access, &cache_attrs);
-  IREE_ASSERT(encoded);
+  const loom_amdgpu_memory_cache_policy_resolution_t resolution =
+      loom_amdgpu_memory_cache_policy_resolve(descriptor_set, access,
+                                              &cache_attrs);
+  IREE_ASSERT_NE(resolution,
+                 LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_REJECTED);
+  if (resolution != LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_ENCODED) {
+    return iree_ok_status();
+  }
 
   for (iree_host_size_t i = 0;
        i < IREE_ARRAYSIZE(kLoomAmdgpuMemoryCacheAttrFields); ++i) {

--- a/loom/src/loom/target/arch/amdgpu/lower/memory_legality.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/memory_legality.c
@@ -125,22 +125,23 @@ iree_status_t loom_amdgpu_low_legality_verify_memory(
   }
   for (uint32_t i = 0; i < plan.packet_count; ++i) {
     const loom_amdgpu_memory_access_t* access = &plan.packets[i].access;
-    if (!loom_amdgpu_memory_cache_policy_can_lower(descriptor_set, access)) {
+    loom_amdgpu_memory_cache_policy_attrs_t cache_attrs;
+    const loom_amdgpu_memory_cache_policy_resolution_t resolution =
+        loom_amdgpu_memory_cache_policy_resolve(descriptor_set, access,
+                                                &cache_attrs);
+    if (resolution == LOOM_AMDGPU_MEMORY_CACHE_POLICY_RESOLUTION_REJECTED) {
       IREE_RETURN_IF_ERROR(
           loom_amdgpu_record_memory_cache_policy_rejection_diagnostic(
               context, op, descriptor_set, access));
       return loom_amdgpu_emit_memory_cache_policy_rejection(
           context, op, descriptor_set, access);
     }
-  }
-  for (uint32_t i = 0; i < plan.packet_count; ++i) {
-    const loom_amdgpu_memory_access_t* access = &plan.packets[i].access;
-    const loom_low_source_memory_operation_kind_t kind =
-        access->source.operation_kind;
-    IREE_RETURN_IF_ERROR(loom_amdgpu_record_memory_cache_policy_diagnostic(
-        context, op, descriptor_set, access, kind));
+    if (i == 0) {
+      IREE_RETURN_IF_ERROR(loom_amdgpu_record_memory_cache_policy_diagnostic(
+          context, op, descriptor_set, access, resolution, &cache_attrs));
+    }
     IREE_RETURN_IF_ERROR(loom_amdgpu_record_memory_access_diagnostic(
-        context, op, descriptor_set, access, kind));
+        context, op, descriptor_set, access, access->source.operation_kind));
   }
   return iree_ok_status();
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cache_policy_gfx1151.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cache_policy_gfx1151.loom-test
@@ -1,7 +1,7 @@
 // TEMPLATE: loom/src/loom/test/corpus/source_low/memory_cache_policy_scopes.loom-test
 // RUN: emit source-low diagnostics=memory output=low
 
-amdgpu.target<gfx1200> @target
+amdgpu.target<gfx1151> @target
 kernel.def target(@target) @cache_system_bypass_load_device_writeback_store() {
   %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
@@ -11,27 +11,27 @@ kernel.def target(@target) @cache_system_bypass_load_device_writeback_store() {
   %zero = index.constant 0 : offset
   %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
   %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
-  // REMARK@+1: BACKEND/040 "selected cache policy 'system/bypass'" "decision 'memory_cache_policy.gfx12_nv_scope_th'" "scope_attr present true value 3" "th_attr present true value 3"
+  // REMARK@+1: BACKEND/040 "dropped cache policy 'system/bypass'" "decision 'memory_cache_policy.unsupported'" "encoding 'gfx9_11_glc_slc_dlc'" "scope_attr present false"
   %loaded = vector.load %input_view[%lane, 0] {cache_scope = system, cache_temporal = bypass} : view<64x4xi32, #dense> -> vector<4xi32>
-  // REMARK@+1: BACKEND/040 "selected cache policy 'device/non_temporal_writeback'" "scope_attr present true value 2" "th_attr present true value 7" "nt_attr present false value 0"
+  // REMARK@+1: BACKEND/040 "dropped cache policy 'device/non_temporal_writeback'" "decision 'memory_cache_policy.unsupported'" "encoding 'gfx9_11_glc_slc_dlc'" "scope_attr present false"
   vector.store %loaded, %output_view[%lane, 0] {cache_scope = device, cache_temporal = non_temporal_writeback} : vector<4xi32>, view<64x4xi32, #dense>
   kernel.return
 }
 
 // ----
-low.kernel.def target<amdgpu.rdna4.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @cache_system_bypass_load_device_writeback_store() asm {
+low.kernel.def target<amdgpu.rdna3_5.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @cache_system_bypass_load_device_writeback_store() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
   %12 = v_lshlrev_b32_src0_inline %lane, 4
-  %loaded = global_load_b128_saddr %12, %input_view {scope = 3, th = 3}
-  global_store_b128_saddr %12, %loaded, %output_view {scope = 2, th = 7}
+  %loaded = global_load_b128_saddr %12, %input_view
+  global_store_b128_saddr %12, %loaded, %output_view
   return
 }
 
 // ====
 
-amdgpu.target<gfx1200> @target
+amdgpu.target<gfx1151> @target
 kernel.def target(@target) @cache_system_bypass_scalar_load() {
   %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
@@ -41,19 +41,19 @@ kernel.def target(@target) @cache_system_bypass_scalar_load() {
   %zero = index.constant 0 : offset
   %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
   %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
-  // REMARK@+1: BACKEND/040 "selected cache policy 'system/bypass'" "decision 'memory_cache_policy.gfx12_nv_scope_th'" "scope_attr present true value 3" "th_attr present true value 3"
+  // REMARK@+1: BACKEND/040 "dropped cache policy 'system/bypass'" "decision 'memory_cache_policy.unsupported'" "encoding 'gfx9_11_glc_slc_dlc'" "scope_attr present false"
   %loaded = view.load %input_view[%lane] {cache_scope = system, cache_temporal = bypass} : view<64xi32, #dense> -> i32
   view.store %loaded, %output_view[%lane] : i32, view<64xi32, #dense>
   kernel.return
 }
 
 // ----
-low.kernel.def target<amdgpu.rdna4.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @cache_system_bypass_scalar_load() asm {
+low.kernel.def target<amdgpu.rdna3_5.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @cache_system_bypass_scalar_load() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
   %12 = v_lshlrev_b32_src0_inline %lane, 2
-  %loaded = global_load_b32_saddr %12, %input_view {scope = 3, th = 3}
+  %loaded = global_load_b32_saddr %12, %input_view
   global_store_b32_saddr %12, %loaded, %output_view
   return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_diagnostics.loom-test
@@ -383,23 +383,6 @@ kernel.def target(@target) @lds_i8x8_strided_load_rejected() {
 
 amdgpu.target<gfx11-generic> @target
 
-kernel.def target(@target) @cache_policy_non_temporal_load_rejected() {
-  %c1 = index.constant 1 : index
-  kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
-} launch(%input: buffer) {
-  %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  // REMARK@+2: BACKEND/040 "rejected cache policy 'device/non_temporal'" "decision 'memory_cache_policy.descriptor_encoding'" "encoding 'gfx9_11_glc_slc_dlc'"
-  // ERROR@+1: AMDGPU/024 {constraint_key="memory_cache_policy.descriptor_encoding", memory_space="global", cache_scope="device", cache_temporal="non_temporal", descriptor_set_key="amdgpu.gfx11.generic.core"}
-  %loaded = vector.load %input_view[%tid, 0] {cache_scope = device, cache_temporal = non_temporal} : view<64x4xi32, #dense> -> vector<4xi32>
-  kernel.return
-}
-
-// ====
-
-amdgpu.target<gfx11-generic> @target
-
 kernel.def target(@target) @cache_policy_workgroup_store_rejected() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_cache_policy_scopes.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_cache_policy_scopes.loom-test
@@ -27,3 +27,32 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(64, 1, 1) wor
   store.indexed.v4i32 %loaded, %output_view, %lane, 0, 16 {cache_scope = 2, cache_temporal = 8}
   return
 }
+
+// ====
+
+llvmir.target<object> @target {
+  triple = "amdgcn-amd-amdhsa"
+}
+kernel.def target(@target) @cache_system_bypass_scalar_load() {
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 64 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
+} launch(%input: buffer, %output: buffer) {
+  %lane = kernel.workitem.id<x> : index
+  %zero = index.constant 0 : offset
+  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %loaded = view.load %input_view[%lane] {cache_scope = system, cache_temporal = bypass} : view<64xi32, #dense> -> i32
+  view.store %loaded, %output_view[%lane] : i32, view<64xi32, #dense>
+  kernel.return
+}
+
+// ----
+low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @cache_system_bypass_scalar_load() asm {
+  %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<llvmir.ptr>
+  %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<llvmir.ptr>
+  %lane = kernel.workitem_id.x
+  %loaded = load.indexed.i32 %input_view, %lane, 0, 4 {cache_scope = 3, cache_temporal = 9}
+  store.indexed.i32 %loaded, %output_view, %lane, 0, 4
+  return
+}

--- a/loom/src/loom/test/corpus/source_low/memory_cache_policy_scopes.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_cache_policy_scopes.loom-test
@@ -13,3 +13,19 @@ kernel.def @cache_system_bypass_load_device_writeback_store() {
   vector.store %loaded, %output_view[%lane, 0] {cache_scope = device, cache_temporal = non_temporal_writeback} : vector<4xi32>, view<64x4xi32, #dense>
   kernel.return
 }
+
+// ====
+
+kernel.def @cache_system_bypass_scalar_load() {
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 64 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
+} launch(%input: buffer, %output: buffer) {
+  %lane = kernel.workitem.id<x> : index
+  %zero = index.constant 0 : offset
+  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %loaded = view.load %input_view[%lane] {cache_scope = system, cache_temporal = bypass} : view<64xi32, #dense> -> i32
+  view.store %loaded, %output_view[%lane] : i32, view<64xi32, #dense>
+  kernel.return
+}


### PR DESCRIPTION
Cache-policy attributes now remain portable across AMDGPU targets. A valid policy that the selected descriptor set cannot encode lowers to the ordinary memory packet and records a structured dropped-policy remark instead of making the source operation illegal.

**Design**

The AMDGPU memory-policy resolver now distinguishes absent, encoded, dropped, and rejected outcomes. Encodable policies continue to materialize target fields such as gfx12 SCOPE/TH. Unsupported advisory combinations produce no packet attributes. Invalid source/target combinations, including cache policy on workgroup memory, retain their existing structured rejection.

Legality records one cache-policy decision per source memory operation even when lowering splits it into multiple packets. The same lowerability query is shared by direct memory operations and async memory selection, so portable source does not require target-specific policy branches.

The shared cache-policy contract now states explicitly that these attributes express locality and pollution intent rather than memory ordering or coherence semantics.

**Coverage**

One shared corpus source exercises vector and scalar memory operations. The gfx1151 target proves unsupported policies produce ordinary B128/B32 packets and structured dropped decisions; the gfx1200 target proves the same source retains SCOPE/TH fields. Existing invalid-workgroup diagnostics remain covered.
