### PR TITLE
[Loom] Enforce readable SSA constant names

### DIFF
--- a/build_tools/devtools/project_presubmit.py
+++ b/build_tools/devtools/project_presubmit.py
@@ -8,12 +8,44 @@
 
 from __future__ import annotations
 
+import argparse
 import os
 import subprocess
 import sys
 from pathlib import Path
 
 CMAKE_BUILD_DIR_ENV = "IREE_CMAKE_BUILD_DIR"
+
+
+def add_common_arguments(
+    parser: argparse.ArgumentParser,
+    *,
+    project_name: str,
+) -> None:
+    """Adds the phases and inputs understood by every project presubmit."""
+    mutation = parser.add_mutually_exclusive_group()
+    mutation.add_argument("--fix", action="store_true", help="Accepted for symmetry.")
+    mutation.add_argument("--check", action="store_true", help="Accepted for symmetry.")
+    parser.add_argument(
+        "--lane",
+        choices=("bazel", "cmake"),
+        default="bazel",
+        help="Build-system lane used for tests. Defaults to bazel.",
+    )
+    parser.add_argument(
+        "--hygiene",
+        action="store_true",
+        help=f"Run cheap {project_name} invariant checks.",
+    )
+    parser.add_argument(
+        "--tests",
+        action="store_true",
+        help=f"Run {project_name} tests.",
+    )
+    parser.add_argument(
+        "--files-from",
+        help="Path to a newline-separated repo-relative changed-file list.",
+    )
 
 
 def cmake_build_dir(repo_root: Path) -> Path:

--- a/build_tools/devtools/project_presubmit_test.py
+++ b/build_tools/devtools/project_presubmit_test.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import argparse
 import contextlib
 import io
 import os
@@ -18,6 +19,19 @@ from build_tools.devtools import project_presubmit
 
 
 class ProjectPresubmitTest(unittest.TestCase):
+    def test_common_arguments_expose_project_hygiene_phase(self):
+        parser = argparse.ArgumentParser()
+        project_presubmit.add_common_arguments(parser, project_name="example")
+
+        args = parser.parse_args(
+            ["--hygiene", "--lane", "cmake", "--files-from", "paths.txt"]
+        )
+
+        self.assertTrue(args.hygiene)
+        self.assertFalse(args.tests)
+        self.assertEqual(args.lane, "cmake")
+        self.assertEqual(args.files_from, "paths.txt")
+
     def test_cmake_build_dir_uses_environment_override(self):
         with mock.patch.dict(
             os.environ,

--- a/build_tools/lefthook/README.md
+++ b/build_tools/lefthook/README.md
@@ -270,5 +270,6 @@ configured project entry point instead of maintaining dependency-specific folder
 lists.
 
 This keeps root policy focused on repository-wide hygiene while preserving
-project ownership of tests, expensive checks, and future project-specific static
-analysis.
+project ownership of cheap invariant checks, tests, expensive checks, and
+future project-specific static analysis. `--no-project-tests` suppresses only
+the project test phase; project hygiene still runs in CI.

--- a/build_tools/lefthook/presubmit.py
+++ b/build_tools/lefthook/presubmit.py
@@ -1265,15 +1265,20 @@ def is_global_trigger(path: str) -> bool:
     )
 
 
-def run_project_tests(
+def run_project_presubmits(
     projects: list[Project],
     paths: list[str],
     fix: bool,
     verbose: bool,
     lane: str,
+    *,
+    phase: str,
 ) -> bool:
+    if phase not in ("hygiene", "tests"):
+        raise ValueError(f"unknown project presubmit phase: {phase}")
+    phase_description = "Project hygiene" if phase == "hygiene" else "Project tests"
     if not projects:
-        return skip_step("Project tests", "no affected project entry points")
+        return skip_step(phase_description, "no affected project entry points")
     ok = True
     with tempfile.NamedTemporaryFile(
         mode="w",
@@ -1294,10 +1299,10 @@ def run_project_tests(
                 lane,
                 "--files-from",
                 file_list_path,
-                "--tests",
+                f"--{phase}",
             ]
             command.append("--fix" if fix else "--check")
-            ok = run_command(command, f"{project.name} tests", verbose) and ok
+            ok = run_command(command, f"{project.name} {phase}", verbose) and ok
     finally:
         Path(file_list_path).unlink(missing_ok=True)
     return ok
@@ -2294,6 +2299,17 @@ def run_presubmit(
     ok = True
     if args.hygiene:
         ok = run_hygiene(paths, fix=args.fix, verbose=args.verbose) and ok
+        ok = (
+            run_project_presubmits(
+                projects,
+                paths,
+                fix=args.fix,
+                verbose=args.verbose,
+                lane=args.lane,
+                phase="hygiene",
+            )
+            and ok
+        )
     if args.tests:
         print_section("Tests")
         ok = (
@@ -2304,12 +2320,13 @@ def run_presubmit(
         )
         if args.project_tests:
             ok = (
-                run_project_tests(
+                run_project_presubmits(
                     projects,
                     paths,
                     fix=args.fix,
                     verbose=args.verbose,
                     lane=args.lane,
+                    phase="tests",
                 )
                 and ok
             )

--- a/build_tools/lefthook/presubmit_test.py
+++ b/build_tools/lefthook/presubmit_test.py
@@ -12,6 +12,7 @@ import io
 import os
 import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -638,6 +639,86 @@ class PresubmitTest(unittest.TestCase):
         self.assertIn(
             "loom",
             {project.name for project in presubmit.existing_project_scripts()},
+        )
+
+    def test_project_hygiene_dispatch_uses_project_presubmit_interface(self):
+        project = presubmit.Project(
+            name="loom",
+            root="loom/",
+            script="loom/build_tools/presubmit.py",
+        )
+        with (
+            tempfile.TemporaryDirectory() as temporary_directory,
+            mock.patch.object(
+                presubmit,
+                "git_worktree_dir",
+                return_value=Path(temporary_directory),
+            ),
+            mock.patch.object(
+                presubmit, "run_command", return_value=True
+            ) as run_command,
+        ):
+            self.assertTrue(
+                presubmit.run_project_presubmits(
+                    [project],
+                    ["loom/test.loom"],
+                    fix=False,
+                    verbose=False,
+                    lane="bazel",
+                    phase="hygiene",
+                )
+            )
+
+        command, description, verbose = run_command.call_args.args
+        self.assertEqual(command[:2], ["python", "loom/build_tools/presubmit.py"])
+        self.assertIn("--hygiene", command)
+        self.assertNotIn("--tests", command)
+        self.assertIn("--check", command)
+        self.assertEqual(description, "loom hygiene")
+        self.assertFalse(verbose)
+
+    def test_disabling_project_tests_preserves_project_hygiene(self):
+        project = presubmit.Project(
+            name="loom",
+            root="loom/",
+            script="loom/build_tools/presubmit.py",
+        )
+        args = types.SimpleNamespace(
+            check=True,
+            clang_tidy=False,
+            fix=False,
+            hygiene=True,
+            lane="bazel",
+            print_plan=False,
+            profile="ci",
+            project_tests=False,
+            static_analysis=False,
+            tests=True,
+            verbose=False,
+        )
+        with (
+            mock.patch.object(presubmit, "run_hygiene", return_value=True),
+            mock.patch.object(
+                presubmit, "run_project_presubmits", return_value=True
+            ) as run_project_presubmits,
+            mock.patch.object(
+                presubmit, "run_root_devtools_tests_for_lane", return_value=True
+            ),
+            mock.patch.object(presubmit, "skip_step", return_value=True),
+        ):
+            self.assertEqual(
+                presubmit.run_presubmit(
+                    args,
+                    input_scope(["loom/test.loom"]),
+                    [project],
+                ),
+                0,
+            )
+
+        run_project_presubmits.assert_called_once()
+        self.assertEqual(
+            run_project_presubmits.call_args.kwargs["phase"],
+            "hygiene",
         )
 
 

--- a/libhrx/build_tools/presubmit.py
+++ b/libhrx/build_tools/presubmit.py
@@ -32,20 +32,7 @@ GLOBAL_TEST_TRIGGERS = (
 
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run libhrx project presubmit.")
-    mutation = parser.add_mutually_exclusive_group()
-    mutation.add_argument("--fix", action="store_true", help="Accepted for symmetry.")
-    mutation.add_argument("--check", action="store_true", help="Accepted for symmetry.")
-    parser.add_argument(
-        "--lane",
-        choices=("bazel", "cmake"),
-        default="bazel",
-        help="Build-system lane used for tests. Defaults to bazel.",
-    )
-    parser.add_argument("--tests", action="store_true", help="Run libhrx tests.")
-    parser.add_argument(
-        "--files-from",
-        help="Path to a newline-separated repo-relative changed-file list.",
-    )
+    project_presubmit.add_common_arguments(parser, project_name=PROJECT_NAME)
     return parser.parse_args()
 
 

--- a/loom/binding/c/benchmark/kernels/i32_memory_chain.loom
+++ b/loom/binding/c/benchmark/kernels/i32_memory_chain.loom
@@ -8,15 +8,15 @@ kernel.def export("i32_memory_chain") @i32_memory_chain() {
   %workgroup_size_x = config.get @benchmark.workgroup_size : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size_x, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer, %byte_offset: offset) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %operation_count = config.get @benchmark.operation_count : index
   %byte_offset_aligned = index.assume %byte_offset [mul(%byte_offset, 4)] : offset
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
   %input_view = buffer.view %input_aligned[%byte_offset_aligned] : buffer -> view<1xi32, #dense>
   %loaded = view.load %input_view[0] : view<1xi32, #dense> -> i32
-  %acc = scf.for %i = [%zero to %operation_count step %one](%iter = %loaded : i32) -> (i32) unroll {
+  %acc = scf.for %i = [%loop_begin to %operation_count step %loop_step](%iter = %loaded : i32) -> (i32) unroll {
     %next = scalar.addi %iter, %loaded : i32
     scf.yield %next : i32
   }

--- a/loom/build_tools/bazel/test/link_kernels.loom
+++ b/loom/build_tools/bazel/test/link_kernels.loom
@@ -1,7 +1,7 @@
 kernel.def export("scale") @scale() {
   %unit = index.constant 1 : index
-  %four = index.constant 4 : index
-  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%four, %unit, %unit) : index
+  %workgroup_size = index.constant 4 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index

--- a/loom/build_tools/linters/loom_lint.py
+++ b/loom/build_tools/linters/loom_lint.py
@@ -9,8 +9,9 @@
 
 Runs checked-in code generators and Ruff fixups in place, then runs mypy on the
 Loom Python package. This is an explicit maintenance command, not the
-`dev.py bazel precommit` policy path. Normal presubmit checks generated files
-without mutating the worktree.
+`dev.py bazel precommit` policy path. Project hygiene runs the read-only builder
+and source-invariant checks during normal presubmit; this command additionally
+owns the mutating generator and formatter workflow plus mypy.
 
 Run from the repository root:
 

--- a/loom/build_tools/linters/loom_source_lint.py
+++ b/loom/build_tools/linters/loom_source_lint.py
@@ -31,7 +31,8 @@ The authoring corpus is a user-facing reference surface. It rejects stale
 boundary-proof boilerplate that agents are likely to copy into generated
 kernels: redundant kernel-buffer memory-space assumes, sentinel-sized views,
 late index-to-offset byte-address casts, and ggml-style byte strides typed as
-logical indices.
+logical indices. Constant SSA names must carry a program role or use the
+numeric `%c<literal>` convention instead of spelling the literal in English.
 """
 
 from __future__ import annotations
@@ -110,6 +111,64 @@ AUTHORING_INDEX_TO_OFFSET_CAST_PATTERN = re.compile(
 )
 AUTHORING_BYTE_STRIDE_INDEX_PATTERN = re.compile(
     r"%nb(?:\d+|_[A-Za-z0-9_]*)?\b\s*:\s*index\b"
+)
+AUTHORING_CONSTANT_RESULT_PATTERN = re.compile(
+    r"%(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
+    r"[A-Za-z_][A-Za-z0-9_.]*\.constant\b"
+)
+# Type, domain, and unit suffixes only decorate a spelled literal; semantic
+# continuations such as zero_point and fourth_word_ordinal remain intact.
+AUTHORING_NUMBER_NAME_SUFFIX_PATTERN = re.compile(
+    r"_(?:"
+    r"(?:[su]?i\d+|bf\d+|f\d+)(?:x\d+|v)?"
+    r"|index|offset"
+    r"|bytes?|bits?|elements?|lanes?|rows?|columns?|words?|values?"
+    r")$"
+)
+AUTHORING_NUMBER_WORDS = tuple(
+    sorted(
+        (
+            "zero",
+            "one",
+            "two",
+            "three",
+            "four",
+            "five",
+            "six",
+            "seven",
+            "eight",
+            "nine",
+            "ten",
+            "eleven",
+            "twelve",
+            "thirteen",
+            "fourteen",
+            "fifteen",
+            "sixteen",
+            "seventeen",
+            "eighteen",
+            "nineteen",
+            "twenty",
+            "thirty",
+            "forty",
+            "fifty",
+            "sixty",
+            "seventy",
+            "eighty",
+            "ninety",
+            "hundred",
+            "thousand",
+            "million",
+            "billion",
+            "trillion",
+            "and",
+        ),
+        key=len,
+        reverse=True,
+    )
+)
+AUTHORING_CONSTANT_NAME_MESSAGE = (
+    "authoring constant SSA names must describe a program role or use %c<literal>"
 )
 
 
@@ -390,12 +449,58 @@ def _iter_authoring_loom_files() -> list[Path]:
     )
 
 
+def _is_spelled_number_sequence(text: str) -> bool:
+    """Returns whether text can be segmented entirely into number words."""
+
+    if text.startswith("negative"):
+        text = text.removeprefix("negative")
+    elif text.startswith("minus"):
+        text = text.removeprefix("minus")
+    if not text:
+        return False
+
+    reachable = [False] * (len(text) + 1)
+    reachable[0] = True
+    for start in range(len(text)):
+        if not reachable[start]:
+            continue
+        for word in AUTHORING_NUMBER_WORDS:
+            if text.startswith(word, start):
+                reachable[start + len(word)] = True
+    return reachable[-1]
+
+
+def _is_spelled_number_constant_name(name: str) -> bool:
+    """Returns whether name communicates only a spelled numeric literal."""
+
+    normalized_name = name.lower()
+    match = AUTHORING_NUMBER_NAME_SUFFIX_PATTERN.search(normalized_name)
+    if match:
+        normalized_name = normalized_name[: match.start()]
+    return _is_spelled_number_sequence(normalized_name.replace("_", ""))
+
+
 def _scan_authoring_text(path: Path, text: str) -> list[Finding]:
     findings: list[Finding] = []
     for line_number, line in enumerate(text.splitlines(), start=1):
         stripped_line = _strip_line_comments(line).strip()
         if not stripped_line:
             continue
+        for match in AUTHORING_CONSTANT_RESULT_PATTERN.finditer(stripped_line):
+            name = match.group("name")
+            if _is_spelled_number_constant_name(name):
+                findings.append(
+                    Finding(
+                        path=path,
+                        line=line_number,
+                        message=AUTHORING_CONSTANT_NAME_MESSAGE,
+                        context=(
+                            f"%{name} spells the literal in English; use a "
+                            "program-role name such as %batch_size, or %c512 "
+                            "when the literal itself is the only meaning"
+                        ),
+                    )
+                )
         if AUTHORING_MEMORY_SPACE_ASSUME_PATTERN.search(stripped_line):
             findings.append(
                 Finding(
@@ -659,12 +764,48 @@ kernel.def @copy(%n: index) {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%n: index, %input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<[%n]xf32, #dense>
+  %base = index.constant 0 : offset
+  %batch_size = index.constant 512 : index
+  %c2 = index.constant 2 : index
+  %c0_i32 = scalar.constant 0 : i32
+  %zero_point = scalar.constant 128 : i32
+  %fourth_word_ordinal = scalar.constant 4 : i32
+  %input_view = buffer.view %input[%base] : buffer -> view<[%n]xf32, #dense>
+  test.use %batch_size, %c2, %c0_i32, %zero_point, %fourth_word_ordinal : index, index, i32, i32, i32
   kernel.return
 }
 """,
         (),
+    )
+    ok &= _expect_authoring_self_test(
+        "authoring simple English number name fails",
+        "%two = index.constant 2 : index\n",
+        (AUTHORING_CONSTANT_NAME_MESSAGE,),
+    )
+    ok &= _expect_authoring_self_test(
+        "authoring concatenated English number name fails",
+        "%fivehundredtwelve = index.constant 512 : index\n",
+        (AUTHORING_CONSTANT_NAME_MESSAGE,),
+    )
+    ok &= _expect_authoring_self_test(
+        "authoring underscored English number name fails",
+        "%thirty_two = index.constant 32 : index\n",
+        (AUTHORING_CONSTANT_NAME_MESSAGE,),
+    )
+    ok &= _expect_authoring_self_test(
+        "authoring type-suffixed English number name fails",
+        "%zero_f32x4 = vector.constant 0.0 : vector<4xf32>\n",
+        (AUTHORING_CONSTANT_NAME_MESSAGE,),
+    )
+    ok &= _expect_authoring_self_test(
+        "authoring unit-suffixed English number name fails",
+        "%four_bytes = index.constant 4 : offset\n",
+        (AUTHORING_CONSTANT_NAME_MESSAGE,),
+    )
+    ok &= _expect_authoring_self_test(
+        "authoring signed English number name fails",
+        "%negative_one = scalar.constant -1 : i32\n",
+        (AUTHORING_CONSTANT_NAME_MESSAGE,),
     )
     ok &= _expect_authoring_self_test(
         "authoring memory-space assume fails",

--- a/loom/build_tools/linters/loom_source_lint.py
+++ b/loom/build_tools/linters/loom_source_lint.py
@@ -28,12 +28,15 @@ large hand-maintained emitter. Backend source files must stay below the reviewed
 size ceiling and must not introduce broad `internal.h` umbrella headers as a
 cosmetic split.
 
-The authoring corpus is a user-facing reference surface. It rejects stale
-boundary-proof boilerplate that agents are likely to copy into generated
-kernels: redundant kernel-buffer memory-space assumes, sentinel-sized views,
-late index-to-offset byte-address casts, and ggml-style byte strides typed as
-logical indices. Constant SSA names must carry a program role or use the
-numeric `%c<literal>` convention instead of spelling the literal in English.
+Checked Loom text is a user-facing reference surface. Across every `.loom` file
+and every authored `.loom-test` input, constant SSA names must carry a program
+role or use the numeric `%c<literal>` convention instead of spelling the
+literal in English.
+
+The authoring corpus additionally rejects stale boundary-proof boilerplate that
+agents are likely to copy into generated kernels: redundant kernel-buffer
+memory-space assumes, sentinel-sized views, late index-to-offset byte-address
+casts, and ggml-style byte strides typed as logical indices.
 """
 
 from __future__ import annotations
@@ -44,9 +47,13 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+LOOM_PROJECT_ROOT = REPO_ROOT / "loom"
 LOOM_SOURCE_ROOT = REPO_ROOT / "loom" / "src" / "loom"
 AUTHORING_CORPUS_ROOT = LOOM_SOURCE_ROOT / "test" / "corpus" / "authoring"
 SOURCE_SUFFIXES = {".c", ".cc", ".h"}
+LOOM_TEXT_SUFFIXES = {".loom", ".loom-test"}
+LOOM_TEST_CASE_SEPARATOR_PREFIX = "// ===="
+LOOM_TEST_EXPECTED_SEPARATOR = "// ----"
 SPIRV_BACKEND_RELATIVE_ROOTS = (
     "loom/src/loom/target/arch/spirv",
     "loom/src/loom/target/emit/spirv",
@@ -117,20 +124,20 @@ AUTHORING_INDEX_TO_OFFSET_CAST_PATTERN = re.compile(
 AUTHORING_BYTE_STRIDE_INDEX_PATTERN = re.compile(
     r"%nb(?:\d+|_[A-Za-z0-9_]*)?\b\s*:\s*index\b"
 )
-AUTHORING_CONSTANT_RESULT_PATTERN = re.compile(
+LOOM_CONSTANT_RESULT_PATTERN = re.compile(
     r"%(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
     r"[A-Za-z_][A-Za-z0-9_.]*\.constant\b"
 )
 # Type, domain, and unit suffixes only decorate a spelled literal; semantic
 # continuations such as zero_point and fourth_word_ordinal remain intact.
-AUTHORING_NUMBER_NAME_SUFFIX_PATTERN = re.compile(
+LOOM_NUMBER_NAME_SUFFIX_PATTERN = re.compile(
     r"_(?:"
     r"(?:[su]?i\d+|bf\d+|f\d+)(?:x\d+|v)?"
     r"|index|offset"
     r"|bytes?|bits?|elements?|lanes?|rows?|columns?|words?|values?"
     r")$"
 )
-AUTHORING_NUMBER_WORDS = tuple(
+LOOM_NUMBER_WORDS = tuple(
     sorted(
         (
             "zero",
@@ -166,14 +173,14 @@ AUTHORING_NUMBER_WORDS = tuple(
             "million",
             "billion",
             "trillion",
-            "and",
         ),
         key=len,
         reverse=True,
     )
 )
-AUTHORING_CONSTANT_NAME_MESSAGE = (
-    "authoring constant SSA names must describe a program role or use %c<literal>"
+LOOM_NUMBER_CONNECTOR = "and"
+LOOM_CONSTANT_NAME_MESSAGE = (
+    "Loom constant SSA names must describe a program role or use %c<literal>"
 )
 
 
@@ -446,6 +453,14 @@ def _iter_authoring_loom_files() -> list[Path]:
     )
 
 
+def _iter_checked_loom_files() -> list[Path]:
+    return sorted(
+        path
+        for path in LOOM_PROJECT_ROOT.rglob("*")
+        if path.is_file() and path.suffix in LOOM_TEXT_SUFFIXES
+    )
+
+
 def _is_spelled_number_sequence(text: str) -> bool:
     """Returns whether text can be segmented entirely into number words."""
 
@@ -456,25 +471,78 @@ def _is_spelled_number_sequence(text: str) -> bool:
     if not text:
         return False
 
-    reachable = [False] * (len(text) + 1)
-    reachable[0] = True
+    # Each state records whether the previous token was numeric. `and` is an
+    # interior connector, not a number by itself: this accepts
+    # `onehundredandone` while leaving semantic names such as `and_zero`
+    # alone.
+    reachable = {(0, False)}
     for start in range(len(text)):
-        if not reachable[start]:
-            continue
-        for word in AUTHORING_NUMBER_WORDS:
-            if text.startswith(word, start):
-                reachable[start + len(word)] = True
-    return reachable[-1]
+        states = tuple(
+            previous_was_number
+            for position, previous_was_number in reachable
+            if position == start
+        )
+        for previous_was_number in states:
+            for word in LOOM_NUMBER_WORDS:
+                if text.startswith(word, start):
+                    reachable.add((start + len(word), True))
+            if previous_was_number and text.startswith(LOOM_NUMBER_CONNECTOR, start):
+                reachable.add((start + len(LOOM_NUMBER_CONNECTOR), False))
+    return (len(text), True) in reachable
 
 
 def _is_spelled_number_constant_name(name: str) -> bool:
     """Returns whether name communicates only a spelled numeric literal."""
 
     normalized_name = name.lower()
-    match = AUTHORING_NUMBER_NAME_SUFFIX_PATTERN.search(normalized_name)
+    match = LOOM_NUMBER_NAME_SUFFIX_PATTERN.search(normalized_name)
     if match:
         normalized_name = normalized_name[: match.start()]
     return _is_spelled_number_sequence(normalized_name.replace("_", ""))
+
+
+def _iter_loom_input_lines(path: Path, text: str) -> list[tuple[int, str]]:
+    """Returns source lines, excluding runner-owned `.loom-test` expectations."""
+
+    lines: list[tuple[int, str]] = []
+    is_loom_test = path.suffix == ".loom-test"
+    in_expected_section = False
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if is_loom_test:
+            if line.startswith(LOOM_TEST_CASE_SEPARATOR_PREFIX):
+                in_expected_section = False
+                continue
+            if line.strip() == LOOM_TEST_EXPECTED_SEPARATOR:
+                in_expected_section = True
+                continue
+            if in_expected_section:
+                continue
+        lines.append((line_number, line))
+    return lines
+
+
+def _scan_loom_constant_name_text(path: Path, text: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for line_number, line in _iter_loom_input_lines(path, text):
+        stripped_line = _strip_line_comments(line).strip()
+        if not stripped_line:
+            continue
+        for match in LOOM_CONSTANT_RESULT_PATTERN.finditer(stripped_line):
+            name = match.group("name")
+            if _is_spelled_number_constant_name(name):
+                findings.append(
+                    Finding(
+                        path=path,
+                        line=line_number,
+                        message=LOOM_CONSTANT_NAME_MESSAGE,
+                        context=(
+                            f"%{name} spells the literal in English; use a "
+                            "program-role name such as %batch_size, or %c512 "
+                            "when the literal itself is the only meaning"
+                        ),
+                    )
+                )
+    return findings
 
 
 def _scan_authoring_text(path: Path, text: str) -> list[Finding]:
@@ -483,21 +551,6 @@ def _scan_authoring_text(path: Path, text: str) -> list[Finding]:
         stripped_line = _strip_line_comments(line).strip()
         if not stripped_line:
             continue
-        for match in AUTHORING_CONSTANT_RESULT_PATTERN.finditer(stripped_line):
-            name = match.group("name")
-            if _is_spelled_number_constant_name(name):
-                findings.append(
-                    Finding(
-                        path=path,
-                        line=line_number,
-                        message=AUTHORING_CONSTANT_NAME_MESSAGE,
-                        context=(
-                            f"%{name} spells the literal in English; use a "
-                            "program-role name such as %batch_size, or %c512 "
-                            "when the literal itself is the only meaning"
-                        ),
-                    )
-                )
         if AUTHORING_MEMORY_SPACE_ASSUME_PATTERN.search(stripped_line):
             findings.append(
                 Finding(
@@ -724,6 +777,30 @@ def _expect_target_execution_self_test(
     return False
 
 
+def _expect_loom_constant_name_self_test(
+    name: str,
+    relative_path: str,
+    text: str,
+    expected_lines: tuple[int, ...],
+) -> bool:
+    path = REPO_ROOT / relative_path
+    findings = _scan_loom_constant_name_text(path, text)
+    actual = tuple(
+        (_relative_path(finding.path), finding.line, finding.message)
+        for finding in findings
+    )
+    expected = tuple(
+        (relative_path, line, LOOM_CONSTANT_NAME_MESSAGE) for line in expected_lines
+    )
+    if actual == expected:
+        print(f"  PASS  {name}")
+        return True
+    print(f"  FAIL  {name}")
+    print(f"        expected: {expected!r}")
+    print(f"        actual:   {actual!r}")
+    return False
+
+
 def _expect_authoring_self_test(
     name: str, text: str, expected_messages: tuple[str, ...]
 ) -> bool:
@@ -844,9 +921,7 @@ def _run_self_tests() -> int:
             "backend/provider stacks",
         ),
     )
-    ok &= _expect_authoring_self_test(
-        "authoring happy-path source passes",
-        """
+    checked_loom_happy_path = """
 kernel.def @copy(%n: index) {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
@@ -861,38 +936,98 @@ kernel.def @copy(%n: index) {
   test.use %batch_size, %c2, %c0_i32, %zero_point, %fourth_word_ordinal : index, index, i32, i32, i32
   kernel.return
 }
-""",
+"""
+    ok &= _expect_loom_constant_name_self_test(
+        "checked Loom semantic and numeric-literal names pass",
+        "loom/src/loom/test/corpus/authoring/self_test.loom",
+        checked_loom_happy_path,
         (),
     )
-    ok &= _expect_authoring_self_test(
-        "authoring simple English number name fails",
+    ok &= _expect_loom_constant_name_self_test(
+        "standalone simple English number name fails",
+        "loom/src/loom/test/self_test.loom",
         "%two = index.constant 2 : index\n",
-        (AUTHORING_CONSTANT_NAME_MESSAGE,),
+        (1,),
     )
-    ok &= _expect_authoring_self_test(
-        "authoring concatenated English number name fails",
+    ok &= _expect_loom_constant_name_self_test(
+        "standalone concatenated English number name fails",
+        "loom/src/loom/test/self_test.loom",
         "%fivehundredtwelve = index.constant 512 : index\n",
-        (AUTHORING_CONSTANT_NAME_MESSAGE,),
+        (1,),
     )
-    ok &= _expect_authoring_self_test(
-        "authoring underscored English number name fails",
+    ok &= _expect_loom_constant_name_self_test(
+        "standalone underscored English number name fails",
+        "loom/src/loom/test/self_test.loom",
         "%thirty_two = index.constant 32 : index\n",
-        (AUTHORING_CONSTANT_NAME_MESSAGE,),
+        (1,),
     )
-    ok &= _expect_authoring_self_test(
-        "authoring type-suffixed English number name fails",
+    ok &= _expect_loom_constant_name_self_test(
+        "standalone type-suffixed English number name fails",
+        "loom/src/loom/test/self_test.loom",
         "%zero_f32x4 = vector.constant 0.0 : vector<4xf32>\n",
-        (AUTHORING_CONSTANT_NAME_MESSAGE,),
+        (1,),
     )
-    ok &= _expect_authoring_self_test(
-        "authoring unit-suffixed English number name fails",
+    ok &= _expect_loom_constant_name_self_test(
+        "standalone unit-suffixed English number name fails",
+        "loom/src/loom/test/self_test.loom",
         "%four_bytes = index.constant 4 : offset\n",
-        (AUTHORING_CONSTANT_NAME_MESSAGE,),
+        (1,),
+    )
+    ok &= _expect_loom_constant_name_self_test(
+        "standalone signed English number name fails",
+        "loom/src/loom/test/self_test.loom",
+        "%negative_one = scalar.constant -1 : i32\n",
+        (1,),
+    )
+    ok &= _expect_loom_constant_name_self_test(
+        "English number connector and scale words fail",
+        "loom/src/loom/test/self_test.loom",
+        (
+            "%one_hundred_and_one = index.constant 101 : index\n"
+            "%thousand = index.constant 1000 : index\n"
+        ),
+        (1, 2),
+    )
+    ok &= _expect_loom_constant_name_self_test(
+        "semantic and connector-derived names pass",
+        "loom/src/loom/test/self_test.loom",
+        (
+            "%and = index.constant 15 : index\n"
+            "%and_zero = index.constant 0 : index\n"
+            "%zero_point = scalar.constant 128 : i32\n"
+            "%fourth_word_ordinal = scalar.constant 4 : i32\n"
+        ),
+        (),
+    )
+    ok &= _expect_loom_constant_name_self_test(
+        "loom-test expected output is excluded",
+        "loom/src/loom/test/self_test.loom-test",
+        (
+            "%batch_size = index.constant 512 : index\n"
+            "// ----\n"
+            "%fivehundredtwelve = index.constant 512 : index\n"
+            "%and_zero = index.constant 0 : index\n"
+        ),
+        (),
+    )
+    ok &= _expect_loom_constant_name_self_test(
+        "loom-test case boundaries restore authored input",
+        "loom/src/loom/test/self_test.loom-test",
+        (
+            "%two = index.constant 2 : index\n"
+            "// ----\n"
+            "%fivehundredtwelve = index.constant 512 : index\n"
+            "// ==== second case\n"
+            "%thirty_two = index.constant 32 : index\n"
+            "// ----\n"
+            "%sixty_four = index.constant 64 : index\n"
+        ),
+        (1, 5),
     )
     ok &= _expect_authoring_self_test(
-        "authoring signed English number name fails",
-        "%negative_one = scalar.constant -1 : i32\n",
-        (AUTHORING_CONSTANT_NAME_MESSAGE,),
+        "authoring happy-path source passes",
+        checked_loom_happy_path,
+        (),
     )
     ok &= _expect_authoring_self_test(
         "authoring memory-space assume fails",
@@ -931,11 +1066,14 @@ def main() -> int:
         findings.extend(_scan_core_tooling_flags_guardrails(path))
         findings.extend(_scan_target_execution_guardrails(path))
         findings.extend(_scan_spirv_backend_guardrails(path))
+    loom_files = _iter_checked_loom_files()
+    for path in loom_files:
+        findings.extend(_scan_loom_constant_name_text(path, path.read_text()))
     for path in _iter_authoring_loom_files():
         findings.extend(_scan_authoring_corpus(path))
 
     if not findings:
-        print("loom-source-lint: PASS")
+        print(f"loom-source-lint: PASS ({len(loom_files)} Loom text files scanned)")
         return 0
 
     print("loom-source-lint: FAIL: Loom source invariant violation.")

--- a/loom/build_tools/linters/loom_source_lint.py
+++ b/loom/build_tools/linters/loom_source_lint.py
@@ -13,9 +13,10 @@ function-local compiler phases: allocating or resetting scratch sized by
 `module->values.count`/`capacity` instead of using function-local domains,
 maintained facts, or reviewed module-owned structures.
 
-It also protects the Loom execution package boundary. Optional production
-targets may project device/environment facts and emit artifacts, but they must
-not grow private runner/execution stacks under `loom/src/loom/target/**`.
+It also protects the Loom execution mechanism boundary. Target-owned
+qualification programs and manifests may invoke shared tools, but production
+targets must not include execution internals or grow private runner/provider
+stacks under `loom/src/loom/target/**`.
 
 The core Loom compiler must stay independent from command-line flag machinery.
 Only tools, tooling helpers, and tests may include `iree/base/tooling/flags.h`
@@ -46,7 +47,6 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 LOOM_SOURCE_ROOT = REPO_ROOT / "loom" / "src" / "loom"
 AUTHORING_CORPUS_ROOT = LOOM_SOURCE_ROOT / "test" / "corpus" / "authoring"
 SOURCE_SUFFIXES = {".c", ".cc", ".h"}
-TARGET_SOURCE_ROOT = LOOM_SOURCE_ROOT / "target"
 SPIRV_BACKEND_RELATIVE_ROOTS = (
     "loom/src/loom/target/arch/spirv",
     "loom/src/loom/target/emit/spirv",
@@ -78,9 +78,14 @@ CARDINALITY_ALIAS_PATTERN = re.compile(
     r"\s*(?:=|\+=)"
 )
 
-TARGET_EXECUTION_INCLUDE_OR_DEP_PATTERN = re.compile(
-    r"(?:#\s*include\s+\"loom/tooling/execution/(?:hal|ireevm)/)"
-    r"|(?://loom/src/loom/tooling/execution/(?:hal|ireevm)(?::|/))"
+TARGET_EXECUTION_INCLUDE_PATTERN = re.compile(
+    r'#\s*include\s+"loom/tooling/execution/(?:hal|ireevm)/'
+)
+TARGET_EXECUTION_DEP_LABEL_PATTERN = re.compile(
+    r"//loom/src/loom/tooling/execution/(?:hal|ireevm)(?::|/)"
+)
+TARGET_EXECUTION_BAZEL_DEPS_PATTERN = re.compile(
+    r"\b(?:deps|implementation_deps)\s*=\s*\[(?P<body>.*?)\]", re.DOTALL
 )
 
 TARGET_PRIVATE_EXECUTION_SYMBOL_PATTERN = re.compile(
@@ -422,14 +427,6 @@ def _scan_spirv_backend_text(
     return findings
 
 
-def _target_path_has_execution_package(path: Path) -> bool:
-    try:
-        target_relative_path = path.relative_to(TARGET_SOURCE_ROOT)
-    except ValueError:
-        return False
-    return "execution" in target_relative_path.parts[:-1]
-
-
 def _iter_lint_files() -> list[Path]:
     return sorted(
         path
@@ -571,55 +568,83 @@ def _scan_authoring_corpus(path: Path) -> list[Finding]:
     return _scan_authoring_text(path, path.read_text())
 
 
-def _scan_target_execution_boundaries(path: Path) -> list[Finding]:
-    if not path.is_relative_to(TARGET_SOURCE_ROOT):
+def _scan_target_execution_text(
+    relative_path: str, text: str
+) -> list[tuple[int, str, str]]:
+    path = PurePosixPath(relative_path)
+    if len(path.parts) < 4 or path.parts[:4] != (
+        "loom",
+        "src",
+        "loom",
+        "target",
+    ):
+        return []
+    if path.suffix in SOURCE_SUFFIXES and _is_test_source_name(path.name):
         return []
 
-    findings: list[Finding] = []
-    if _target_path_has_execution_package(path):
-        findings.append(
-            Finding(
-                path=path,
-                line=1,
-                message="target packages must not own execution subpackages",
-                context=(
-                    "move runner/backend/provider/invocation code under "
-                    "loom/src/loom/tooling/execution/<mechanism>"
-                ),
-            )
-        )
-    if path.suffix in SOURCE_SUFFIXES and _is_test_source_name(path.name):
+    findings: list[tuple[int, str, str]] = []
+    if path.suffix in SOURCE_SUFFIXES:
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            stripped_line = _strip_line_comments(line).strip()
+            if TARGET_EXECUTION_INCLUDE_PATTERN.search(stripped_line):
+                findings.append(
+                    (
+                        line_number,
+                        (
+                            "target packages must not include or depend on "
+                            "execution mechanism internals"
+                        ),
+                        stripped_line,
+                    )
+                )
+            if TARGET_PRIVATE_EXECUTION_SYMBOL_PATTERN.search(stripped_line):
+                findings.append(
+                    (
+                        line_number,
+                        (
+                            "target packages must not define private Loom "
+                            "execution backend/provider stacks"
+                        ),
+                        stripped_line,
+                    )
+                )
         return findings
 
-    for line_number, line in enumerate(path.read_text().splitlines(), start=1):
-        stripped_line = _strip_line_comments(line).strip()
-        if TARGET_EXECUTION_INCLUDE_OR_DEP_PATTERN.search(stripped_line):
+    if path.name != "BUILD.bazel":
+        return findings
+    bazel_text = "\n".join(line.split("#", 1)[0] for line in text.splitlines())
+    lines = text.splitlines()
+    for deps_match in TARGET_EXECUTION_BAZEL_DEPS_PATTERN.finditer(bazel_text):
+        body = deps_match.group("body")
+        for label_match in TARGET_EXECUTION_DEP_LABEL_PATTERN.finditer(body):
+            offset = deps_match.start("body") + label_match.start()
+            line_number = bazel_text.count("\n", 0, offset) + 1
             findings.append(
-                Finding(
-                    path=path,
-                    line=line_number,
-                    message=(
+                (
+                    line_number,
+                    (
                         "target packages must not include or depend on "
                         "execution mechanism internals"
                     ),
-                    context=stripped_line,
+                    lines[line_number - 1].strip(),
                 )
             )
-        if (
-            path.suffix in SOURCE_SUFFIXES
-            and TARGET_PRIVATE_EXECUTION_SYMBOL_PATTERN.search(stripped_line)
-        ):
-            findings.append(
-                Finding(
-                    path=path,
-                    line=line_number,
-                    message=(
-                        "target packages must not define private Loom "
-                        "execution backend/provider stacks"
-                    ),
-                    context=stripped_line,
-                )
+    return findings
+
+
+def _scan_target_execution_guardrails(path: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for line, message, context in _scan_target_execution_text(
+        _relative_path(path), path.read_text()
+    ):
+        findings.append(
+            Finding(
+                path=path,
+                line=line,
+                message=message,
+                context=context,
             )
+        )
     return findings
 
 
@@ -675,6 +700,20 @@ def _expect_core_tooling_flags_self_test(
     name: str, relative_path: str, text: str, expected_messages: tuple[str, ...]
 ) -> bool:
     findings = _scan_core_tooling_flags_text(relative_path, text)
+    messages = tuple(finding[1] for finding in findings)
+    if messages == expected_messages:
+        print(f"  PASS  {name}")
+        return True
+    print(f"  FAIL  {name}")
+    print(f"        expected: {expected_messages!r}")
+    print(f"        actual:   {messages!r}")
+    return False
+
+
+def _expect_target_execution_self_test(
+    name: str, relative_path: str, text: str, expected_messages: tuple[str, ...]
+) -> bool:
+    findings = _scan_target_execution_text(relative_path, text)
     messages = tuple(finding[1] for finding in findings)
     if messages == expected_messages:
         print(f"  PASS  {name}")
@@ -756,6 +795,54 @@ def _run_self_tests() -> int:
         "loom/src/loom/sanitizer/options_test.cc",
         '#include "iree/base/tooling/flags.h"\n',
         (),
+    )
+    ok &= _expect_target_execution_self_test(
+        "target-owned qualification package passes",
+        "loom/src/loom/target/arch/amdgpu/test/execution/BUILD.bazel",
+        'tools = {"iree-test-loom": "//loom/src/loom/tools/iree-test-loom"}\n',
+        (),
+    )
+    ok &= _expect_target_execution_self_test(
+        "execution package visibility grant passes",
+        "loom/src/loom/target/arch/ireevm/BUILD.bazel",
+        (
+            "_EXECUTION_VISIBILITY = ["
+            '"//loom/src/loom/tooling/execution/ireevm:__pkg__"]\n'
+        ),
+        (),
+    )
+    ok &= _expect_target_execution_self_test(
+        "commented execution dependency passes",
+        "loom/src/loom/target/arch/amdgpu/BUILD.bazel",
+        ('# deps = [\n#     "//loom/src/loom/tooling/execution/hal:runtime",\n# ]\n'),
+        (),
+    )
+    ok &= _expect_target_execution_self_test(
+        "target execution-internal dependency fails",
+        "loom/src/loom/target/arch/amdgpu/BUILD.bazel",
+        ('deps = [\n    "//loom/src/loom/tooling/execution/hal:runtime",\n]\n'),
+        (
+            "target packages must not include or depend on execution "
+            "mechanism internals",
+        ),
+    )
+    ok &= _expect_target_execution_self_test(
+        "target execution-internal include fails",
+        "loom/src/loom/target/arch/amdgpu/run.c",
+        '#include "loom/tooling/execution/hal/runtime.h"\n',
+        (
+            "target packages must not include or depend on execution "
+            "mechanism internals",
+        ),
+    )
+    ok &= _expect_target_execution_self_test(
+        "target private execution stack fails",
+        "loom/src/loom/target/arch/amdgpu/run.c",
+        "void loom_run_hal_backend(void) {}\n",
+        (
+            "target packages must not define private Loom execution "
+            "backend/provider stacks",
+        ),
     )
     ok &= _expect_authoring_self_test(
         "authoring happy-path source passes",
@@ -842,7 +929,7 @@ def main() -> int:
         findings.extend(_scan_file(path))
     for path in _iter_lint_files():
         findings.extend(_scan_core_tooling_flags_guardrails(path))
-        findings.extend(_scan_target_execution_boundaries(path))
+        findings.extend(_scan_target_execution_guardrails(path))
         findings.extend(_scan_spirv_backend_guardrails(path))
     for path in _iter_authoring_loom_files():
         findings.extend(_scan_authoring_corpus(path))

--- a/loom/build_tools/linters/loom_source_lint.py
+++ b/loom/build_tools/linters/loom_source_lint.py
@@ -128,14 +128,16 @@ LOOM_CONSTANT_RESULT_PATTERN = re.compile(
     r"%(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
     r"[A-Za-z_][A-Za-z0-9_.]*\.constant\b"
 )
-# Type, domain, and unit suffixes only decorate a spelled literal; semantic
-# continuations such as zero_point and fourth_word_ordinal remain intact.
-LOOM_NUMBER_NAME_SUFFIX_PATTERN = re.compile(
-    r"_(?:"
-    r"(?:[su]?i\d+|bf\d+|f\d+)(?:x\d+|v)?"
-    r"|index|offset"
+# Type, domain, unit, and duplicate markers can decorate either side of a
+# spelled literal without giving it a program role. Semantic continuations
+# such as zero_point and fourth_word_ordinal remain intact.
+LOOM_NUMBER_NAME_DECORATOR_PATTERN = re.compile(
+    r"(?:"
+    r"(?:[su]?i\d+|(?:bf|fp|f)\d+)(?:x\d+|v)?"
+    r"|index|offset|scalars?|vectors?"
     r"|bytes?|bits?|elements?|lanes?|rows?|columns?|words?|values?"
-    r")$"
+    r"|all|[a-z]"
+    r")"
 )
 LOOM_NUMBER_WORDS = tuple(
     sorted(
@@ -179,6 +181,7 @@ LOOM_NUMBER_WORDS = tuple(
     )
 )
 LOOM_NUMBER_CONNECTOR = "and"
+LOOM_NUMBER_SIGN_PREFIXES = ("negative", "positive", "minus", "plus", "neg")
 LOOM_CONSTANT_NAME_MESSAGE = (
     "Loom constant SSA names must describe a program role or use %c<literal>"
 )
@@ -464,10 +467,10 @@ def _iter_checked_loom_files() -> list[Path]:
 def _is_spelled_number_sequence(text: str) -> bool:
     """Returns whether text can be segmented entirely into number words."""
 
-    if text.startswith("negative"):
-        text = text.removeprefix("negative")
-    elif text.startswith("minus"):
-        text = text.removeprefix("minus")
+    for prefix in LOOM_NUMBER_SIGN_PREFIXES:
+        if text.startswith(prefix):
+            text = text.removeprefix(prefix)
+            break
     if not text:
         return False
 
@@ -491,14 +494,39 @@ def _is_spelled_number_sequence(text: str) -> bool:
     return (len(text), True) in reachable
 
 
+def _is_spelled_number_or_plural(text: str) -> bool:
+    """Returns whether text is a spelled number or its English plural."""
+
+    if _is_spelled_number_sequence(text):
+        return True
+
+    singular_candidates: list[str] = []
+    if text.endswith("ies"):
+        singular_candidates.append(text[:-3] + "y")
+    if text.endswith("es"):
+        singular_candidates.append(text[:-2])
+    if text.endswith("s"):
+        singular_candidates.append(text[:-1])
+    return any(
+        _is_spelled_number_sequence(candidate) for candidate in singular_candidates
+    )
+
+
 def _is_spelled_number_constant_name(name: str) -> bool:
     """Returns whether name communicates only a spelled numeric literal."""
 
-    normalized_name = name.lower()
-    match = LOOM_NUMBER_NAME_SUFFIX_PATTERN.search(normalized_name)
-    if match:
-        normalized_name = normalized_name[: match.start()]
-    return _is_spelled_number_sequence(normalized_name.replace("_", ""))
+    tokens = [token for token in name.lower().split("_") if token]
+    while len(tokens) > 1:
+        stripped_decorator = False
+        if LOOM_NUMBER_NAME_DECORATOR_PATTERN.fullmatch(tokens[0]):
+            tokens.pop(0)
+            stripped_decorator = True
+        if len(tokens) > 1 and LOOM_NUMBER_NAME_DECORATOR_PATTERN.fullmatch(tokens[-1]):
+            tokens.pop()
+            stripped_decorator = True
+        if not stripped_decorator:
+            break
+    return _is_spelled_number_or_plural("".join(tokens))
 
 
 def _iter_loom_input_lines(path: Path, text: str) -> list[tuple[int, str]]:
@@ -980,6 +1008,31 @@ kernel.def @copy(%n: index) {
         (1,),
     )
     ok &= _expect_loom_constant_name_self_test(
+        "prefix and suffix decorators do not make numeric names semantic",
+        "loom/src/loom/test/self_test.loom",
+        (
+            "%i32_zero = scalar.constant 0 : i32\n"
+            "%zero_scalar = scalar.constant 0 : i32\n"
+            "%positive_zero = scalar.constant 0.0 : f32\n"
+            "%neg_one = scalar.constant -1 : i32\n"
+            "%all_ones = scalar.constant -1 : i32\n"
+            "%zero_a = scalar.constant 0 : i32\n"
+            "%f16_ones = vector.constant 1.0 : vector<4xf16>\n"
+        ),
+        (1, 2, 3, 4, 5, 6, 7),
+    )
+    ok &= _expect_loom_constant_name_self_test(
+        "plural English number names fail",
+        "loom/src/loom/test/self_test.loom",
+        (
+            "%ones = scalar.constant 1 : i32\n"
+            "%zeroes = vector.constant 0 : vector<4xi32>\n"
+            "%sixes = vector.constant 6 : vector<4xi32>\n"
+            "%twenties = vector.constant 20 : vector<4xi32>\n"
+        ),
+        (1, 2, 3, 4),
+    )
+    ok &= _expect_loom_constant_name_self_test(
         "English number connector and scale words fail",
         "loom/src/loom/test/self_test.loom",
         (
@@ -995,6 +1048,12 @@ kernel.def @copy(%n: index) {
             "%and = index.constant 15 : index\n"
             "%and_zero = index.constant 0 : index\n"
             "%zero_point = scalar.constant 128 : i32\n"
+            "%zero_exponent = scalar.constant 0 : i32\n"
+            "%two_pi = scalar.constant 6.283185 : f32\n"
+            "%positive_signed_zero = scalar.constant 0.0 : f32\n"
+            "%all_bits_set = scalar.constant -1 : i32\n"
+            "%f32_sign_threshold = scalar.constant 0.0 : f32\n"
+            "%nonzero = scalar.constant true : i1\n"
             "%fourth_word_ordinal = scalar.constant 4 : i32\n"
         ),
         (),

--- a/loom/build_tools/presubmit.py
+++ b/loom/build_tools/presubmit.py
@@ -41,20 +41,7 @@ CI_LOOM_TARGETS = "amdgpu,iree_vm,llvmir,spirv,x86"
 
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run Loom project presubmit.")
-    mutation = parser.add_mutually_exclusive_group()
-    mutation.add_argument("--fix", action="store_true", help="Accepted for symmetry.")
-    mutation.add_argument("--check", action="store_true", help="Accepted for symmetry.")
-    parser.add_argument(
-        "--lane",
-        choices=("bazel", "cmake"),
-        default="bazel",
-        help="Build-system lane used for tests. Defaults to bazel.",
-    )
-    parser.add_argument("--tests", action="store_true", help="Run Loom tests.")
-    parser.add_argument(
-        "--files-from",
-        help="Path to a newline-separated repo-relative changed-file list.",
-    )
+    project_presubmit.add_common_arguments(parser, project_name=PROJECT_NAME)
     return parser.parse_args()
 
 

--- a/loom/build_tools/presubmit.py
+++ b/loom/build_tools/presubmit.py
@@ -68,7 +68,7 @@ def selected_files(files_from: str | None) -> list[str]:
         return [line.strip() for line in file_list if line.strip()]
 
 
-def should_run_tests(files_from: str | None) -> bool:
+def should_run_presubmit(files_from: str | None) -> bool:
     paths = selected_files(files_from)
     if not paths:
         return files_from is None
@@ -86,6 +86,16 @@ def run_generated_builder_check() -> bool:
             "--check",
         ],
         "Generated builder stubs",
+    )
+
+
+def run_source_lint() -> bool:
+    return run_command(
+        [
+            sys.executable,
+            "loom/build_tools/linters/loom_source_lint.py",
+        ],
+        "Loom source invariants",
     )
 
 
@@ -132,18 +142,22 @@ def run_cmake_tests() -> bool:
 
 
 def run_presubmit(args: argparse.Namespace) -> int:
-    if not args.tests:
+    if not args.hygiene and not args.tests:
         return 0
-    if not should_run_tests(args.files_from):
+    if not should_run_presubmit(args.files_from):
         print("loom presubmit: no Loom-affecting files")
         return 0
-    ok = run_generated_builder_check()
-    if args.lane == "bazel":
-        ok = run_bazel_tests() and ok
-    elif args.lane == "cmake":
-        ok = run_cmake_tests() and ok
-    else:
-        raise ValueError(f"unknown lane: {args.lane}")
+    ok = True
+    if args.hygiene:
+        ok = run_generated_builder_check() and ok
+        ok = run_source_lint() and ok
+    if args.tests:
+        if args.lane == "bazel":
+            ok = run_bazel_tests() and ok
+        elif args.lane == "cmake":
+            ok = run_cmake_tests() and ok
+        else:
+            raise ValueError(f"unknown lane: {args.lane}")
     return 0 if ok else 1
 
 

--- a/loom/build_tools/presubmit_test.py
+++ b/loom/build_tools/presubmit_test.py
@@ -71,9 +71,24 @@ class LoomPresubmitTest(unittest.TestCase):
             "Generated builder stubs",
         )
 
+    def test_source_lint_is_project_owned_and_read_only(self):
+        with mock.patch.object(
+            self.presubmit, "run_command", return_value=True
+        ) as run_command:
+            self.assertTrue(self.presubmit.run_source_lint())
+
+        run_command.assert_called_once_with(
+            [
+                sys.executable,
+                "loom/build_tools/linters/loom_source_lint.py",
+            ],
+            "Loom source invariants",
+        )
+
     def test_generated_builder_drift_fails_presubmit(self):
         args = types.SimpleNamespace(
             files_from=None,
+            hygiene=True,
             lane="bazel",
             tests=True,
         )
@@ -82,17 +97,66 @@ class LoomPresubmitTest(unittest.TestCase):
                 self.presubmit, "run_generated_builder_check", return_value=False
             ) as generated_builder_check,
             mock.patch.object(
+                self.presubmit, "run_source_lint", return_value=True
+            ) as source_lint,
+            mock.patch.object(
                 self.presubmit, "run_bazel_tests", return_value=True
             ) as bazel_tests,
         ):
             self.assertEqual(self.presubmit.run_presubmit(args), 1)
 
         generated_builder_check.assert_called_once_with()
+        source_lint.assert_called_once_with()
+        bazel_tests.assert_called_once_with()
+
+    def test_source_lint_failure_fails_project_hygiene(self):
+        args = types.SimpleNamespace(
+            files_from=None,
+            hygiene=True,
+            lane="bazel",
+            tests=False,
+        )
+        with (
+            mock.patch.object(
+                self.presubmit, "run_generated_builder_check", return_value=True
+            ) as generated_builder_check,
+            mock.patch.object(
+                self.presubmit, "run_source_lint", return_value=False
+            ) as source_lint,
+            mock.patch.object(self.presubmit, "run_bazel_tests") as bazel_tests,
+        ):
+            self.assertEqual(self.presubmit.run_presubmit(args), 1)
+
+        generated_builder_check.assert_called_once_with()
+        source_lint.assert_called_once_with()
+        bazel_tests.assert_not_called()
+
+    def test_test_phase_does_not_repeat_hygiene_checks(self):
+        args = types.SimpleNamespace(
+            files_from=None,
+            hygiene=False,
+            lane="bazel",
+            tests=True,
+        )
+        with (
+            mock.patch.object(
+                self.presubmit, "run_generated_builder_check"
+            ) as generated_builder_check,
+            mock.patch.object(self.presubmit, "run_source_lint") as source_lint,
+            mock.patch.object(
+                self.presubmit, "run_bazel_tests", return_value=True
+            ) as bazel_tests,
+        ):
+            self.assertEqual(self.presubmit.run_presubmit(args), 0)
+
+        generated_builder_check.assert_not_called()
+        source_lint.assert_not_called()
         bazel_tests.assert_called_once_with()
 
     def test_main_rechecks_package_initializers_after_bazel_tests(self):
         args = types.SimpleNamespace(
             files_from=None,
+            hygiene=False,
             lane="bazel",
             tests=True,
         )
@@ -104,9 +168,6 @@ class LoomPresubmitTest(unittest.TestCase):
                 self.presubmit.NonEmptyTrackedFileSnapshot,
                 "capture_tracked_package_initializers",
                 return_value=snapshot,
-            ),
-            mock.patch.object(
-                self.presubmit, "run_generated_builder_check", return_value=True
             ),
             mock.patch.object(self.presubmit, "run_bazel_tests", return_value=True),
         ):

--- a/loom/src/loom/ops/config/test/canonicalize.loom-test
+++ b/loom/src/loom/ops/config/test/canonicalize.loom-test
@@ -6,8 +6,8 @@ config.def @answer = 40 : index
 
 func.def @read_scalar_config() -> (index) {
   %value = config.get @answer : index
-  %two = index.constant 2 : index
-  %result = index.add %value, %two : index
+  %c2 = index.constant 2 : index
+  %result = index.add %value, %c2 : index
   func.return %result : index
 }
 
@@ -48,8 +48,8 @@ config.decl @runtime_batch_size : index
 
 func.def @read_decl_config() -> (index) {
   %value = config.get @runtime_batch_size : index
-  %zero = index.constant 0 : index
-  %result = index.add %value, %zero : index
+  %c0 = index.constant 0 : index
+  %result = index.add %value, %c0 : index
   func.return %result : index
 }
 
@@ -92,8 +92,8 @@ config.decl @runtime_chunk_size : %value: index where [range(%value, 0, 131072),
 func.def @read_decl_config_predicate() -> (index) {
   %value = config.get @runtime_chunk_size : index
   test.use %value : index
-  %sixteen = index.constant 16 : index
-  %remainder = index.rem %value, %sixteen : index
+  %c16 = index.constant 16 : index
+  %remainder = index.rem %value, %c16 : index
   func.return %remainder : index
 }
 

--- a/loom/src/loom/ops/global/test/canonicalize.loom-test
+++ b/loom/src/loom/ops/global/test/canonicalize.loom-test
@@ -7,8 +7,8 @@ global.constant @answer : index = 40
 
 func.def @load_scalar_constant_global() -> (index) {
   %value = global.load @answer : index
-  %two = index.constant 2 : index
-  %result = index.add %value, %two : index
+  %c2 = index.constant 2 : index
+  %result = index.add %value, %c2 : index
   func.return %result : index
 }
 
@@ -49,8 +49,8 @@ global.constant @threshold : f32 = 1.5
 
 func.def @load_float_constant_global() -> (i32) {
   %value = global.load @threshold : f32
-  %one = scalar.constant 1.0 : f32
-  %cond = scalar.cmpf ogt, %value, %one : f32
+  %c1 = scalar.constant 1.0 : f32
+  %cond = scalar.cmpf ogt, %value, %c1 : f32
   %high = scalar.constant 1 : i32
   %low = scalar.constant 0 : i32
   %result = scf.select %cond, %high, %low : i32
@@ -73,8 +73,8 @@ global.variable @mutable_default : index = 40
 
 func.def @mutable_default_does_not_fold() -> (index) {
   %value = global.load @mutable_default : index
-  %two = index.constant 2 : index
-  %result = index.add %value, %two : index
+  %c2 = index.constant 2 : index
+  %result = index.add %value, %c2 : index
   func.return %result : index
 }
 
@@ -88,8 +88,8 @@ global.constant @weights : tile<[%n]xf32> where [mul(%n, 16)]
 func.def @load_global_predicate() -> (index) {
   %tile, %m = global.load @weights : tile<[%m]xf32>
   test.use %tile : tile<[%m]xf32>
-  %sixteen = index.constant 16 : index
-  %remainder = index.rem %m, %sixteen : index
+  %c16 = index.constant 16 : index
+  %remainder = index.rem %m, %c16 : index
   func.return %remainder : index
 }
 

--- a/loom/src/loom/ops/index/test/fold.loom-test
+++ b/loom/src/loom/ops/index/test/fold.loom-test
@@ -1059,20 +1059,20 @@ func.def @bitwise_facts(%x: index) -> (i64, i64, i1, i64, i64) {
 func.def @bit_count_facts_require_target_width() -> (index, index, index) {
   %c1 = index.constant 1 : index
   %c0 = index.constant 0 : index
-  %ones = index.constant -1 : index
+  %all_bits_set = index.constant -1 : index
   %clz = index.ctlzi %c1 : index
   %ctz = index.cttzi %c0 : index
-  %pop = index.ctpopi %ones : index
+  %pop = index.ctpopi %all_bits_set : index
   func.return %clz, %ctz, %pop : index, index, index
 }
 // ----
 func.def @bit_count_facts_require_target_width() -> (index, index, index) {
   %c1 = index.constant 1 : index
   %c0 = index.constant 0 : index
-  %ones = index.constant -1 : index
+  %all_bits_set = index.constant -1 : index
   %clz = index.ctlzi %c1 : index
   %ctz = index.cttzi %c0 : index
-  %pop = index.ctpopi %ones : index
+  %pop = index.ctpopi %all_bits_set : index
   func.return %clz, %ctz, %pop : index, index, index
 }
 
@@ -1105,23 +1105,23 @@ func.def @bitwise_exact_folds_preserve_target_rotate() -> (index, index, index, 
 
 func.def @bitwise_identities(%x: index) -> (index, index, index, index, index, index, index, index) {
   %c0 = index.constant 0 : index
-  %ones = index.constant -1 : index
+  %all_bits_set = index.constant -1 : index
   %and_self = index.andi %x, %x : index
   %and_zero = index.andi %x, %c0 : index
-  %and_ones = index.andi %x, %ones : index
+  %and_ones = index.andi %x, %all_bits_set : index
   %or_self = index.ori %x, %x : index
   %or_zero = index.ori %x, %c0 : index
-  %or_ones = index.ori %x, %ones : index
+  %or_ones = index.ori %x, %all_bits_set : index
   %xor_zero = index.xori %x, %c0 : index
   %xor_self = index.xori %x, %x : index
   func.return %and_self, %and_zero, %and_ones, %or_self, %or_zero, %or_ones, %xor_zero, %xor_self : index, index, index, index, index, index, index, index
 }
 // ----
 func.def @bitwise_identities(%x: index) -> (index, index, index, index, index, index, index, index) {
-  %ones = index.constant -1 : index
+  %all_bits_set = index.constant -1 : index
   %and_zero = index.constant 0 : index
   %xor_self = index.constant 0 : index
-  func.return %x, %and_zero, %x, %x, %x, %ones, %x, %xor_self : index, index, index, index, index, index, index, index
+  func.return %x, %and_zero, %x, %x, %x, %all_bits_set, %x, %xor_self : index, index, index, index, index, index, index, index
 }
 
 // ====

--- a/loom/src/loom/ops/index/test/fold.loom-test
+++ b/loom/src/loom/ops/index/test/fold.loom-test
@@ -330,8 +330,8 @@ func.def @cast_i32_to_offset_uses_unsigned_domain(%raw: i32) -> (i64, i64, i1) {
 // Exact negative integer payloads become their unsigned bit pattern when cast
 // into offset.
 func.def @cast_negative_i32_to_offset_zero_extends() -> (i64, i64) {
-  %negative_one = scalar.constant -1 : i32
-  %offset = index.cast %negative_one : i32 to offset
+  %cn1 = scalar.constant -1 : i32
+  %offset = index.cast %cn1 : i32 to offset
   %lo = test.fact_range_lo %offset : offset -> i64
   %hi = test.fact_range_hi %offset : offset -> i64
   func.return %lo, %hi : i64, i64
@@ -389,8 +389,8 @@ func.def @cast_index_to_i8_uses_result_domain(%raw: index) -> (i64, i64) {
 // index.add removes a fact-proven zero operand without requiring the other
 // operand to be constant.
 func.def @add_zero_identity(%x: index) -> (index) {
-  %zero = index.constant 0 : index
-  %r = index.add %x, %zero : index
+  %c0 = index.constant 0 : index
+  %r = index.add %x, %c0 : index
   func.return %r : index
 }
 // ----
@@ -402,10 +402,10 @@ func.def @add_zero_identity(%x: index) -> (index) {
 
 // index.mul removes one and annihilates with zero.
 func.def @mul_identities(%x: index) -> (index, index) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %same = index.mul %x, %one : index
-  %zeroed = index.mul %x, %zero : index
+  %c0 = index.constant 0 : index
+  %c1 = index.constant 1 : index
+  %same = index.mul %x, %c1 : index
+  %zeroed = index.mul %x, %c0 : index
   func.return %same, %zeroed : index, index
 }
 // ----
@@ -435,8 +435,8 @@ func.def @mul_power_of_two_waits_for_target_width(%x: index) -> (index) {
 // index.madd simplifies the common address form a*1 + c to add, keeping the
 // addend first because it is usually the base address.
 func.def @madd_identity_multiplier(%a: index, %c: index) -> (index) {
-  %one = index.constant 1 : index
-  %r = index.madd %a, %one, %c : index
+  %c1 = index.constant 1 : index
+  %r = index.madd %a, %c1, %c : index
   func.return %r : index
 }
 // ----
@@ -823,9 +823,9 @@ func.def @rem_divisible_coordinate(%x: index) -> (index) {
 // Zero modulo any fact-proven positive divisor is zero, even when the divisor
 // itself is dynamic.
 func.def @rem_zero_dynamic_positive_divisor(%d: index) -> (index) {
-  %zero = index.constant 0 : index
+  %c0 = index.constant 0 : index
   %d2 = index.assume %d [range(%d, 1, 64)] : index
-  %r = index.rem %zero, %d2 : index
+  %r = index.rem %c0, %d2 : index
   func.return %r : index
 }
 // ----
@@ -1027,13 +1027,13 @@ func.def @minmax_identities() -> (index, index, index, index) {
 func.def @bitwise_facts(%x: index) -> (i64, i64, i1, i64, i64) {
   %mask_aligned = index.constant -4 : index
   %mask_small = index.constant 15 : index
-  %one = index.constant 1 : index
+  %c1 = index.constant 1 : index
   %shift4 = index.constant 4 : index
   %shift3 = index.constant 3 : index
   %aligned = index.assume %x [range(%x, 0, 4096), mul(%x, 64)] : index
   %and_aligned = index.andi %x, %mask_aligned : index
   %and_small = index.andi %x, %mask_small : index
-  %or_one = index.ori %x, %one : index
+  %or_one = index.ori %x, %c1 : index
   %shifted_left = index.shli %x, %shift4 : index
   %shifted_right = index.shrui %aligned, %shift3 : index
   %and_div = test.fact_divisor %and_aligned : index -> i64
@@ -1057,21 +1057,21 @@ func.def @bitwise_facts(%x: index) -> (i64, i64, i1, i64, i64) {
 
 // Bit counts remain symbolic when no target has established index width.
 func.def @bit_count_facts_require_target_width() -> (index, index, index) {
-  %one = index.constant 1 : index
-  %zero = index.constant 0 : index
+  %c1 = index.constant 1 : index
+  %c0 = index.constant 0 : index
   %ones = index.constant -1 : index
-  %clz = index.ctlzi %one : index
-  %ctz = index.cttzi %zero : index
+  %clz = index.ctlzi %c1 : index
+  %ctz = index.cttzi %c0 : index
   %pop = index.ctpopi %ones : index
   func.return %clz, %ctz, %pop : index, index, index
 }
 // ----
 func.def @bit_count_facts_require_target_width() -> (index, index, index) {
-  %one = index.constant 1 : index
-  %zero = index.constant 0 : index
+  %c1 = index.constant 1 : index
+  %c0 = index.constant 0 : index
   %ones = index.constant -1 : index
-  %clz = index.ctlzi %one : index
-  %ctz = index.cttzi %zero : index
+  %clz = index.ctlzi %c1 : index
+  %ctz = index.cttzi %c0 : index
   %pop = index.ctpopi %ones : index
   func.return %clz, %ctz, %pop : index, index, index
 }
@@ -1104,15 +1104,15 @@ func.def @bitwise_exact_folds_preserve_target_rotate() -> (index, index, index, 
 // ====
 
 func.def @bitwise_identities(%x: index) -> (index, index, index, index, index, index, index, index) {
-  %zero = index.constant 0 : index
+  %c0 = index.constant 0 : index
   %ones = index.constant -1 : index
   %and_self = index.andi %x, %x : index
-  %and_zero = index.andi %x, %zero : index
+  %and_zero = index.andi %x, %c0 : index
   %and_ones = index.andi %x, %ones : index
   %or_self = index.ori %x, %x : index
-  %or_zero = index.ori %x, %zero : index
+  %or_zero = index.ori %x, %c0 : index
   %or_ones = index.ori %x, %ones : index
-  %xor_zero = index.xori %x, %zero : index
+  %xor_zero = index.xori %x, %c0 : index
   %xor_self = index.xori %x, %x : index
   func.return %and_self, %and_zero, %and_ones, %or_self, %or_zero, %or_ones, %xor_zero, %xor_self : index, index, index, index, index, index, index, index
 }
@@ -1141,10 +1141,10 @@ func.def @xori_cancels_nested_operand(%x: index, %y: index) -> (index, index) {
 // ====
 
 func.def @xori_cancels_duplicate_exact_constants(%x: index) -> (index) {
-  %c1 = index.constant 7 : index
-  %c2 = index.constant 7 : index
-  %nested = index.xori %x, %c1 : index
-  %r = index.xori %nested, %c2 : index
+  %lhs_constant = index.constant 7 : index
+  %rhs_constant = index.constant 7 : index
+  %nested = index.xori %x, %lhs_constant : index
+  %r = index.xori %nested, %rhs_constant : index
   func.return %r : index
 }
 // ----
@@ -1155,28 +1155,28 @@ func.def @xori_cancels_duplicate_exact_constants(%x: index) -> (index) {
 // ====
 
 func.def @shift_identities_without_target_reassociation(%x: index) -> (index, index, index, index, index, index) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %shl_zero_amount = index.shli %x, %zero : index
-  %shrsi_zero_amount = index.shrsi %x, %zero : index
-  %shrui_zero_amount = index.shrui %x, %zero : index
-  %shl_zero_value = index.shli %zero, %one : index
-  %inner_shl = index.shli %x, %one : index
-  %reassoc_shl = index.shli %inner_shl, %two : index
-  %inner_shr = index.shrui %x, %one : index
-  %reassoc_shr = index.shrui %inner_shr, %two : index
+  %c0 = index.constant 0 : index
+  %c1 = index.constant 1 : index
+  %c2 = index.constant 2 : index
+  %shl_zero_amount = index.shli %x, %c0 : index
+  %shrsi_zero_amount = index.shrsi %x, %c0 : index
+  %shrui_zero_amount = index.shrui %x, %c0 : index
+  %shl_zero_value = index.shli %c0, %c1 : index
+  %inner_shl = index.shli %x, %c1 : index
+  %reassoc_shl = index.shli %inner_shl, %c2 : index
+  %inner_shr = index.shrui %x, %c1 : index
+  %reassoc_shr = index.shrui %inner_shr, %c2 : index
   func.return %shl_zero_amount, %shrsi_zero_amount, %shrui_zero_amount, %shl_zero_value, %reassoc_shl, %reassoc_shr : index, index, index, index, index, index
 }
 // ----
 func.def @shift_identities_without_target_reassociation(%x: index) -> (index, index, index, index, index, index) {
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %c1 = index.constant 1 : index
+  %c2 = index.constant 2 : index
   %shl_zero_value = index.constant 0 : index
-  %inner_shl = index.shli %x, %one : index
-  %reassoc_shl = index.shli %inner_shl, %two : index
-  %inner_shr = index.shrui %x, %one : index
-  %reassoc_shr = index.shrui %inner_shr, %two : index
+  %inner_shl = index.shli %x, %c1 : index
+  %reassoc_shl = index.shli %inner_shl, %c2 : index
+  %inner_shr = index.shrui %x, %c1 : index
+  %reassoc_shr = index.shrui %inner_shr, %c2 : index
   func.return %x, %x, %x, %shl_zero_value, %reassoc_shl, %reassoc_shr : index, index, index, index, index, index
 }
 
@@ -1197,17 +1197,17 @@ func.def @shrsi_non_negative_becomes_shrui(%x: index, %amount: index) -> (index)
 // ====
 
 func.def @rotate_identities_without_target_direction_change(%x: index) -> (index, index, index) {
-  %zero = index.constant 0 : index
-  %eight = index.constant 8 : index
-  %rotl_zero = index.rotli %x, %zero : index
-  %rotr_zero = index.rotri %x, %zero : index
-  %rotr = index.rotri %x, %eight : index
+  %c0 = index.constant 0 : index
+  %c8 = index.constant 8 : index
+  %rotl_zero = index.rotli %x, %c0 : index
+  %rotr_zero = index.rotri %x, %c0 : index
+  %rotr = index.rotri %x, %c8 : index
   func.return %rotl_zero, %rotr_zero, %rotr : index, index, index
 }
 // ----
 func.def @rotate_identities_without_target_direction_change(%x: index) -> (index, index, index) {
-  %eight = index.constant 8 : index
-  %rotr = index.rotri %x, %eight : index
+  %c8 = index.constant 8 : index
+  %rotr = index.rotri %x, %c8 : index
   func.return %x, %x, %rotr : index, index, index
 }
 
@@ -1414,25 +1414,25 @@ func.def @select_identities(%x: index, %y: index) -> (index, index) {
 test.target<quirky> @target32
 test.target<low_core> @target64
 func.def target(@target32) @target_width_32(%x: index) -> (index, index, index, index) {
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %eight = index.constant 8 : index
-  %count = index.ctlzi %one : index
-  %rotate = index.rotri %x, %eight : index
-  %multiply = index.mul %x, %eight : index
-  %inner_shift = index.shli %x, %one : index
-  %outer_shift = index.shli %inner_shift, %two : index
+  %c1 = index.constant 1 : index
+  %c2 = index.constant 2 : index
+  %c8 = index.constant 8 : index
+  %count = index.ctlzi %c1 : index
+  %rotate = index.rotri %x, %c8 : index
+  %multiply = index.mul %x, %c8 : index
+  %inner_shift = index.shli %x, %c1 : index
+  %outer_shift = index.shli %inner_shift, %c2 : index
   func.return %count, %rotate, %multiply, %outer_shift : index, index, index, index
 }
 func.def target(@target64) @target_width_64(%x: index) -> (index, index, index, index) {
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %eight = index.constant 8 : index
-  %count = index.ctlzi %one : index
-  %rotate = index.rotri %x, %eight : index
-  %multiply = index.mul %x, %eight : index
-  %inner_shift = index.shli %x, %one : index
-  %outer_shift = index.shli %inner_shift, %two : index
+  %c1 = index.constant 1 : index
+  %c2 = index.constant 2 : index
+  %c8 = index.constant 8 : index
+  %count = index.ctlzi %c1 : index
+  %rotate = index.rotri %x, %c8 : index
+  %multiply = index.mul %x, %c8 : index
+  %inner_shift = index.shli %x, %c1 : index
+  %outer_shift = index.shli %inner_shift, %c2 : index
   func.return %count, %rotate, %multiply, %outer_shift : index, index, index, index
 }
 
@@ -1475,13 +1475,13 @@ test.target<low_core> @target64
 func.def target(@target32) @target_carrier_range_proofs_32(%x: index, %y: index) -> (i1, i1, index, index, index, i64, i64) {
   %high = index.assume %x [range(%x, 2147483648, 2147483663)] : index
   %low = index.assume %y [range(%y, 0, 15)] : index
-  %eight = index.constant 8 : index
-  %one = index.constant 1 : index
+  %c8 = index.constant 8 : index
+  %c1 = index.constant 1 : index
   %comparison = index.cmp slt, %high, %low : index
   %unsigned_comparison = index.cmp ugt, %high, %low : index
   %minimum = index.min %high, %low : index
-  %quotient = index.div %high, %eight : index
-  %shifted = index.shrsi %high, %one : index
+  %quotient = index.div %high, %c8 : index
+  %shifted = index.shrsi %high, %c1 : index
   %minimum_lo = test.fact_range_lo %minimum : index -> i64
   %minimum_hi = test.fact_range_hi %minimum : index -> i64
   func.return %comparison, %unsigned_comparison, %minimum, %quotient, %shifted, %minimum_lo, %minimum_hi : i1, i1, index, index, index, i64, i64
@@ -1489,13 +1489,13 @@ func.def target(@target32) @target_carrier_range_proofs_32(%x: index, %y: index)
 func.def target(@target64) @target_carrier_range_proofs_64(%x: index, %y: index) -> (i1, i1, index, index, index, i64, i64) {
   %high = index.assume %x [range(%x, 2147483648, 2147483663)] : index
   %low = index.assume %y [range(%y, 0, 15)] : index
-  %eight = index.constant 8 : index
-  %one = index.constant 1 : index
+  %c8 = index.constant 8 : index
+  %c1 = index.constant 1 : index
   %comparison = index.cmp slt, %high, %low : index
   %unsigned_comparison = index.cmp ugt, %high, %low : index
   %minimum = index.min %high, %low : index
-  %quotient = index.div %high, %eight : index
-  %shifted = index.shrsi %high, %one : index
+  %quotient = index.div %high, %c8 : index
+  %shifted = index.shrsi %high, %c1 : index
   %minimum_lo = test.fact_range_lo %minimum : index -> i64
   %minimum_hi = test.fact_range_hi %minimum : index -> i64
   func.return %comparison, %unsigned_comparison, %minimum, %quotient, %shifted, %minimum_lo, %minimum_hi : i1, i1, index, index, index, i64, i64
@@ -1509,13 +1509,13 @@ test.target<low_core> @target64
 func.def target(@target32) @target_carrier_range_proofs_32(%x: index, %y: index) -> (i1, i1, index, index, index, i64, i64) {
   %high = index.assume %x [range(%x, 2147483648, 2147483663)] : index
   %low = index.assume %y [range(%y, 0, 15)] : index
-  %one = index.constant 1 : index
+  %c1 = index.constant 1 : index
   %comparison = index.cmp slt, %high, %low : index
   %unsigned_comparison = scalar.constant true : i1
   %minimum = index.min %high, %low : index
   %42 = index.constant 3 : index
   %quotient = index.shrui %high, %42 : index
-  %shifted = index.shrsi %high, %one : index
+  %shifted = index.shrsi %high, %c1 : index
   %minimum_lo = scalar.constant -2147483648 : i64
   %minimum_hi = scalar.constant 2147483647 : i64
   func.return %comparison, %unsigned_comparison, %minimum, %quotient, %shifted, %minimum_lo, %minimum_hi : i1, i1, index, index, index, i64, i64
@@ -1524,12 +1524,12 @@ func.def target(@target32) @target_carrier_range_proofs_32(%x: index, %y: index)
 func.def target(@target64) @target_carrier_range_proofs_64(%x: index, %y: index) -> (i1, i1, index, index, index, i64, i64) {
   %high = index.assume %x [range(%x, 2147483648, 2147483663)] : index
   %low = index.assume %y [range(%y, 0, 15)] : index
-  %one = index.constant 1 : index
+  %c1 = index.constant 1 : index
   %comparison = scalar.constant false : i1
   %unsigned_comparison = scalar.constant true : i1
   %48 = index.constant 3 : index
   %quotient = index.shrui %high, %48 : index
-  %shifted = index.shrui %high, %one : index
+  %shifted = index.shrui %high, %c1 : index
   %minimum_lo = scalar.constant 0 : i64
   %minimum_hi = scalar.constant 15 : i64
   func.return %comparison, %unsigned_comparison, %low, %quotient, %shifted, %minimum_lo, %minimum_hi : i1, i1, index, index, index, i64, i64
@@ -1544,30 +1544,30 @@ func.def target(@target64) @target_carrier_range_proofs_64(%x: index, %y: index)
 test.target<quirky> @target32
 test.target<low_core> @target64
 func.def target(@target32) @target_carrier_equality_32() -> (i1) {
-  %negative_one = index.constant -1 : index
+  %cn1 = index.constant -1 : index
   %unsigned_max = index.constant 4294967295 : index
-  %comparison = index.cmp eq, %negative_one, %unsigned_max : index
+  %comparison = index.cmp eq, %cn1, %unsigned_max : index
   func.return %comparison : i1
 }
 func.def target(@target64) @target_carrier_equality_64() -> (i1) {
-  %negative_one = index.constant -1 : index
+  %cn1 = index.constant -1 : index
   %unsigned_max = index.constant 4294967295 : index
-  %comparison = index.cmp eq, %negative_one, %unsigned_max : index
+  %comparison = index.cmp eq, %cn1, %unsigned_max : index
   func.return %comparison : i1
 }
 func.def target(@target32) @target_carrier_symbolic_compare_32(%x: index) -> (i1) {
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %lhs = index.add %x, %one : index
-  %rhs = index.add %x, %two : index
+  %c1 = index.constant 1 : index
+  %c2 = index.constant 2 : index
+  %lhs = index.add %x, %c1 : index
+  %rhs = index.add %x, %c2 : index
   %comparison = index.cmp slt, %lhs, %rhs : index
   func.return %comparison : i1
 }
 func.def target(@target64) @target_carrier_symbolic_compare_64(%x: index) -> (i1) {
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %lhs = index.add %x, %one : index
-  %rhs = index.add %x, %two : index
+  %c1 = index.constant 1 : index
+  %c2 = index.constant 2 : index
+  %lhs = index.add %x, %c1 : index
+  %rhs = index.add %x, %c2 : index
   %comparison = index.cmp slt, %lhs, %rhs : index
   func.return %comparison : i1
 }
@@ -1578,9 +1578,9 @@ test.target<quirky> @target32
 test.target<low_core> @target64
 
 func.def target(@target32) @target_carrier_equality_32() -> (i1) {
-  %negative_one = index.constant -1 : index
+  %cn1 = index.constant -1 : index
   %unsigned_max = index.constant 4294967295 : index
-  %comparison = index.cmp eq, %negative_one, %unsigned_max : index
+  %comparison = index.cmp eq, %cn1, %unsigned_max : index
   func.return %comparison : i1
 }
 
@@ -1590,10 +1590,10 @@ func.def target(@target64) @target_carrier_equality_64() -> (i1) {
 }
 
 func.def target(@target32) @target_carrier_symbolic_compare_32(%x: index) -> (i1) {
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %lhs = index.add %x, %one : index
-  %rhs = index.add %x, %two : index
+  %c1 = index.constant 1 : index
+  %c2 = index.constant 2 : index
+  %lhs = index.add %x, %c1 : index
+  %rhs = index.add %x, %c2 : index
   %comparison = index.cmp slt, %lhs, %rhs : index
   func.return %comparison : i1
 }

--- a/loom/src/loom/ops/kernel/test/facts.loom-test
+++ b/loom/src/loom/ops/kernel/test/facts.loom-test
@@ -65,10 +65,10 @@ kernel.def @collective_uniform_scope_facts() {
 } launch(%arg: i32) {
   %lane = kernel.workitem.id<x> : index
   %lane_i32 = index.cast %lane : index to i32
-  %zero = index.constant 0 : index
-  %zero_i32 = scalar.constant 0 : i32
-  %predicate = index.cmp eq, %lane, %zero : index
-  %broadcast = kernel.subgroup.broadcast %lane_i32 from %zero_i32 : i32, i32
+  %first_lane = index.constant 0 : index
+  %first_lane_i32 = scalar.constant 0 : i32
+  %predicate = index.cmp eq, %lane, %first_lane : index
+  %broadcast = kernel.subgroup.broadcast %lane_i32 from %first_lane_i32 : i32, i32
   %broadcast_first = kernel.subgroup.broadcast.first %lane_i32 : i32
   %broadcast_uniform = kernel.subgroup.broadcast %arg from %lane_i32 : i32, i32
   %subgroup_sum = kernel.subgroup.reduce<addi> %lane_i32 : i32
@@ -97,10 +97,10 @@ kernel.def @collective_uniform_scope_facts() {
 } launch(%arg: i32) {
   %lane = kernel.workitem.id<x> : index
   %lane_i32 = index.cast %lane : index to i32
-  %zero = index.constant 0 : index
-  %zero_i32 = scalar.constant 0 : i32
-  %predicate = index.cmp eq, %lane, %zero : index
-  %broadcast = kernel.subgroup.broadcast %lane_i32 from %zero_i32 : i32, i32
+  %first_lane = index.constant 0 : index
+  %first_lane_i32 = scalar.constant 0 : i32
+  %predicate = index.cmp eq, %lane, %first_lane : index
+  %broadcast = kernel.subgroup.broadcast %lane_i32 from %first_lane_i32 : i32, i32
   %broadcast_first = kernel.subgroup.broadcast.first %lane_i32 : i32
   %broadcast_uniform = kernel.subgroup.broadcast %arg from %lane_i32 : i32, i32
   %subgroup_sum = kernel.subgroup.reduce<addi> %lane_i32 : i32
@@ -480,15 +480,15 @@ kernel.def @lane_predicate_bitwise_facts() {
   %index_predicate = index.cmp slt, %lane, %limit : index
   %both = scalar.andi %scalar_predicate, %index_predicate : i1
   %either = scalar.ori %scalar_predicate, %index_predicate : i1
-  %one = scalar.xori %scalar_predicate, %index_predicate : i1
+  %exclusive = scalar.xori %scalar_predicate, %index_predicate : i1
   %scalar_is_predicate = test.fact_lane_predicate %scalar_predicate : i1 -> i1
   %index_is_predicate = test.fact_lane_predicate %index_predicate : i1 -> i1
   %both_is_predicate = test.fact_lane_predicate %both : i1 -> i1
   %either_is_predicate = test.fact_lane_predicate %either : i1 -> i1
-  %one_is_predicate = test.fact_lane_predicate %one : i1 -> i1
+  %exclusive_is_predicate = test.fact_lane_predicate %exclusive : i1 -> i1
   %both_is_uniform = test.fact_subgroup_uniform %both : i1 -> i1
   %either_hi = test.fact_range_hi %either : i1 -> i64
-  test.use %scalar_is_predicate, %index_is_predicate, %both_is_predicate, %either_is_predicate, %one_is_predicate, %both_is_uniform, %either_hi : i1, i1, i1, i1, i1, i1, i64
+  test.use %scalar_is_predicate, %index_is_predicate, %both_is_predicate, %either_is_predicate, %exclusive_is_predicate, %both_is_uniform, %either_hi : i1, i1, i1, i1, i1, i1, i64
   kernel.return
 }
 
@@ -502,10 +502,10 @@ kernel.def @lane_predicate_bitwise_facts() {
   %index_is_predicate = scalar.constant true : i1
   %both_is_predicate = scalar.constant true : i1
   %either_is_predicate = scalar.constant true : i1
-  %one_is_predicate = scalar.constant true : i1
+  %exclusive_is_predicate = scalar.constant true : i1
   %both_is_uniform = scalar.constant false : i1
   %either_hi = scalar.constant 1 : i64
-  test.use %scalar_is_predicate, %index_is_predicate, %both_is_predicate, %either_is_predicate, %one_is_predicate, %both_is_uniform, %either_hi : i1, i1, i1, i1, i1, i1, i64
+  test.use %scalar_is_predicate, %index_is_predicate, %both_is_predicate, %either_is_predicate, %exclusive_is_predicate, %both_is_uniform, %either_hi : i1, i1, i1, i1, i1, i1, i64
   kernel.return
 }
 
@@ -517,8 +517,8 @@ kernel.def @lane_predicate_cmpf_facts() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%lhs: f32, %rhs: f32) {
   %lane = kernel.subgroup.lane.id : index
-  %zero = index.constant 0 : index
-  %condition = index.cmp eq, %lane, %zero : index
+  %first_lane = index.constant 0 : index
+  %condition = index.cmp eq, %lane, %first_lane : index
   %varying = scf.select %condition, %lhs, %rhs : f32
   %predicate = scalar.cmpf olt, %varying, %lhs : f32
   %predicate_is_lane = test.fact_lane_predicate %predicate : i1 -> i1
@@ -547,8 +547,8 @@ kernel.def @scalar_conversion_lane_distribution_facts() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch() {
   %lane = kernel.subgroup.lane.id : index
-  %zero = index.constant 0 : index
-  %condition = index.cmp eq, %lane, %zero : index
+  %first_lane = index.constant 0 : index
+  %condition = index.cmp eq, %lane, %first_lane : index
   %wide_a = scalar.constant 300 : i32
   %wide_b = scalar.constant 4 : i32
   %wide = scf.select %condition, %wide_a, %wide_b : i32

--- a/loom/src/loom/ops/kernel/test/roundtrip.loom-test
+++ b/loom/src/loom/ops/kernel/test/roundtrip.loom-test
@@ -407,11 +407,11 @@ func.def @async_tensor_load_to_lds(%source_buffer: buffer, %byte_offset: offset)
   %base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %i32_zero = scalar.constant 0 : i32
-  %d0 = vector.splat %i32_zero : vector<4xi32>
-  %d1 = vector.splat %i32_zero : vector<8xi32>
-  %d2 = vector.splat %i32_zero : vector<4xi32>
-  %d3 = vector.splat %i32_zero : vector<4xi32>
+  %descriptor_fill_value = scalar.constant 0 : i32
+  %d0 = vector.splat %descriptor_fill_value : vector<4xi32>
+  %d1 = vector.splat %descriptor_fill_value : vector<8xi32>
+  %d2 = vector.splat %descriptor_fill_value : vector<4xi32>
+  %d3 = vector.splat %descriptor_fill_value : vector<4xi32>
   %desc = kernel.tensor.lds.descriptor dgroups(%d0, %d1, %d2, %d3) : vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32> -> kernel.tensor.lds.descriptor
   %global = buffer.assume.memory_space<global> %source_buffer : buffer
   %source = buffer.view %global[%byte_offset] : buffer -> view<64x64xf32, %layout>
@@ -430,9 +430,9 @@ func.def @async_tensor_store_from_lds(%dest_buffer: buffer, %byte_offset: offset
   %base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %i32_zero = scalar.constant 0 : i32
-  %d0 = vector.splat %i32_zero : vector<4xi32>
-  %d1 = vector.splat %i32_zero : vector<8xi32>
+  %descriptor_fill_value = scalar.constant 0 : i32
+  %d0 = vector.splat %descriptor_fill_value : vector<4xi32>
+  %d1 = vector.splat %descriptor_fill_value : vector<8xi32>
   %desc = kernel.tensor.lds.descriptor dgroups(%d0, %d1) : vector<4xi32>, vector<8xi32> -> kernel.tensor.lds.descriptor
   %scratch = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
   %source = buffer.view %scratch[%base] : buffer -> view<64x64xf32, %layout>

--- a/loom/src/loom/ops/kernel/test/roundtrip.loom-test
+++ b/loom/src/loom/ops/kernel/test/roundtrip.loom-test
@@ -248,13 +248,13 @@ kernel.def @workgroup_collectives() {
 // ====
 
 func.def @async_copy_global_to_workgroup(%source_buffer: buffer, %byte_offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %source_buffer : buffer
   %source = buffer.view %global[%byte_offset] : buffer -> view<16xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, %layout>
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, %layout> to view<16xi8, %layout> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -265,13 +265,13 @@ func.def @async_copy_global_to_workgroup(%source_buffer: buffer, %byte_offset: o
 // ====
 
 func.def @async_copy_masked(%source_buffer: buffer, %byte_offset: offset, %in_bounds: i1) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %source_buffer : buffer
   %source = buffer.view %global[%byte_offset] : buffer -> view<16xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, %layout>
   %copy = kernel.async.copy.mask %source to %dest, %in_bounds {cache_scope = cu, cache_temporal = non_temporal, direction = global_to_workgroup} : view<16xi8, %layout> to view<16xi8, %layout>, i1 -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -281,11 +281,11 @@ func.def @async_copy_masked(%source_buffer: buffer, %byte_offset: offset, %in_bo
 // ====
 
 func.def @async_copy_workgroup_to_global(%dest_buffer: buffer, %byte_offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %source = buffer.view %scratch[%zero] : buffer -> view<16xi8, %layout>
+  %source = buffer.view %scratch[%base] : buffer -> view<16xi8, %layout>
   %global = buffer.assume.memory_space<global> %dest_buffer : buffer
   %dest = buffer.view %global[%byte_offset] : buffer -> view<16xi8, %layout>
   %copy = kernel.async.copy %source to %dest {cache_scope = system, cache_temporal = writeback, direction = workgroup_to_global} : view<16xi8, %layout> to view<16xi8, %layout> -> kernel.async.token
@@ -297,13 +297,13 @@ func.def @async_copy_workgroup_to_global(%dest_buffer: buffer, %byte_offset: off
 // ====
 
 func.def @async_copy_reinterpreted_bytes(%source_buffer: buffer, %byte_offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %source_buffer : buffer
   %source = buffer.view %global[%byte_offset] : buffer -> view<16xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi32, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi32, %layout>
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, %layout> to view<4xi32, %layout> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -313,13 +313,13 @@ func.def @async_copy_reinterpreted_bytes(%source_buffer: buffer, %byte_offset: o
 // ====
 
 func.def @async_subgroup_gather(%source_buffer: buffer, %byte_offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %source_buffer : buffer
   %source = buffer.view %global[%byte_offset] : buffer -> view<4xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x4xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<64x4xi8, %layout>
   %copy = kernel.async.gather %source to %dest {cache_scope = cu, cache_temporal = regular} : view<4xi8, %layout> to view<64x4xi8, %layout> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -329,13 +329,13 @@ func.def @async_subgroup_gather(%source_buffer: buffer, %byte_offset: offset) {
 // ====
 
 func.def @async_subgroup_gather_padded_lane_slot(%source_buffer: buffer, %byte_offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %source_buffer : buffer
   %source = buffer.view %global[%byte_offset] : buffer -> view<1xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x4xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<64x4xi8, %layout>
   %copy = kernel.async.gather %source to %dest {cache_scope = cu, cache_temporal = regular} : view<1xi8, %layout> to view<64x4xi8, %layout> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -345,13 +345,13 @@ func.def @async_subgroup_gather_padded_lane_slot(%source_buffer: buffer, %byte_o
 // ====
 
 func.def @async_subgroup_gather_gfx950_padded_lane_slot(%source_buffer: buffer, %byte_offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 4096 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %source_buffer : buffer
   %source = buffer.view %global[%byte_offset] : buffer -> view<12xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x16xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<64x16xi8, %layout>
   %copy = kernel.async.gather %source to %dest {cache_scope = cu, cache_temporal = regular} : view<12xi8, %layout> to view<64x16xi8, %layout> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -361,23 +361,23 @@ func.def @async_subgroup_gather_gfx950_padded_lane_slot(%source_buffer: buffer, 
 // ====
 
 func.def @async_cluster_gather_widths(%source_buffer: buffer, %byte_offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %cluster_mask = scalar.constant 15 : i32
   %global = buffer.assume.memory_space<global> %source_buffer : buffer
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
   %source_b8 = buffer.view %global[%byte_offset] : buffer -> view<1xi8, %layout>
-  %dest_b8 = buffer.view %scratch[%zero] : buffer -> view<1xi8, %layout>
+  %dest_b8 = buffer.view %scratch[%base] : buffer -> view<1xi8, %layout>
   %copy_b8 = kernel.async.cluster.gather %source_b8 to %dest_b8 using %cluster_mask {cache_scope = cu, cache_temporal = regular} : view<1xi8, %layout> to view<1xi8, %layout>, i32 -> kernel.async.token
   %source_b32 = buffer.view %global[%byte_offset] : buffer -> view<4xi8, %layout>
-  %dest_b32 = buffer.view %scratch[%zero] : buffer -> view<4xi8, %layout>
+  %dest_b32 = buffer.view %scratch[%base] : buffer -> view<4xi8, %layout>
   %copy_b32 = kernel.async.cluster.gather %source_b32 to %dest_b32 using %cluster_mask {cache_scope = se, cache_temporal = high_temporal} : view<4xi8, %layout> to view<4xi8, %layout>, i32 -> kernel.async.token
   %source_b64 = buffer.view %global[%byte_offset] : buffer -> view<8xi8, %layout>
-  %dest_b64 = buffer.view %scratch[%zero] : buffer -> view<8xi8, %layout>
+  %dest_b64 = buffer.view %scratch[%base] : buffer -> view<8xi8, %layout>
   %copy_b64 = kernel.async.cluster.gather %source_b64 to %dest_b64 using %cluster_mask {cache_scope = device, cache_temporal = non_temporal} : view<8xi8, %layout> to view<8xi8, %layout>, i32 -> kernel.async.token
   %source_b128 = buffer.view %global[%byte_offset] : buffer -> view<16xi8, %layout>
-  %dest_b128 = buffer.view %scratch[%zero] : buffer -> view<16xi8, %layout>
+  %dest_b128 = buffer.view %scratch[%base] : buffer -> view<16xi8, %layout>
   %copy_b128 = kernel.async.cluster.gather %source_b128 to %dest_b128 using %cluster_mask {cache_scope = system, cache_temporal = bypass} : view<16xi8, %layout> to view<16xi8, %layout>, i32 -> kernel.async.token
   %group = kernel.async.group %copy_b8, %copy_b32, %copy_b64, %copy_b128 : kernel.async.token, kernel.async.token, kernel.async.token, kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -387,14 +387,14 @@ func.def @async_cluster_gather_widths(%source_buffer: buffer, %byte_offset: offs
 // ====
 
 func.def @async_cluster_gather_masked(%source_buffer: buffer, %byte_offset: offset, %in_bounds: i1) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %cluster_mask = scalar.constant 3 : i32
   %global = buffer.assume.memory_space<global> %source_buffer : buffer
   %source = buffer.view %global[%byte_offset] : buffer -> view<4xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi8, %layout>
   %copy = kernel.async.cluster.gather.mask %source to %dest using %cluster_mask, %in_bounds {cache_scope = cu, cache_temporal = regular} : view<4xi8, %layout> to view<4xi8, %layout>, i32, i1 -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -404,7 +404,7 @@ func.def @async_cluster_gather_masked(%source_buffer: buffer, %byte_offset: offs
 // ====
 
 func.def @async_tensor_load_to_lds(%source_buffer: buffer, %byte_offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %i32_zero = scalar.constant 0 : i32
@@ -416,7 +416,7 @@ func.def @async_tensor_load_to_lds(%source_buffer: buffer, %byte_offset: offset)
   %global = buffer.assume.memory_space<global> %source_buffer : buffer
   %source = buffer.view %global[%byte_offset] : buffer -> view<64x64xf32, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x64xf32, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<64x64xf32, %layout>
   %copy = kernel.async.tensor.load.to.lds %source to %dest using %desc {cache_scope = cu, cache_temporal = regular} : view<64x64xf32, %layout> to view<64x64xf32, %layout>, kernel.tensor.lds.descriptor -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -427,7 +427,7 @@ func.def @async_tensor_load_to_lds(%source_buffer: buffer, %byte_offset: offset)
 // ====
 
 func.def @async_tensor_store_from_lds(%dest_buffer: buffer, %byte_offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %i32_zero = scalar.constant 0 : i32
@@ -435,7 +435,7 @@ func.def @async_tensor_store_from_lds(%dest_buffer: buffer, %byte_offset: offset
   %d1 = vector.splat %i32_zero : vector<8xi32>
   %desc = kernel.tensor.lds.descriptor dgroups(%d0, %d1) : vector<4xi32>, vector<8xi32> -> kernel.tensor.lds.descriptor
   %scratch = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
-  %source = buffer.view %scratch[%zero] : buffer -> view<64x64xf32, %layout>
+  %source = buffer.view %scratch[%base] : buffer -> view<64x64xf32, %layout>
   %global = buffer.assume.memory_space<global> %dest_buffer : buffer
   %dest = buffer.view %global[%byte_offset] : buffer -> view<64x64xf32, %layout>
   %copy = kernel.async.tensor.store.from.lds %source to %dest using %desc {cache_scope = device, cache_temporal = non_temporal_writeback} : view<64x64xf32, %layout> to view<64x64xf32, %layout>, kernel.tensor.lds.descriptor -> kernel.async.token

--- a/loom/src/loom/ops/kernel/test/verify.loom-test
+++ b/loom/src/loom/ops/kernel/test/verify.loom-test
@@ -1085,10 +1085,10 @@ func.def @async_cluster_gather_rejects_global_dest(%buffer: buffer, %offset: off
 // ====
 
 func.def @tensor_descriptor_rejects_three_dgroups() {
-  %i32_zero = scalar.constant 0 : i32
-  %d0 = vector.splat %i32_zero : vector<4xi32>
-  %d1 = vector.splat %i32_zero : vector<8xi32>
-  %d2 = vector.splat %i32_zero : vector<4xi32>
+  %descriptor_fill_value = scalar.constant 0 : i32
+  %d0 = vector.splat %descriptor_fill_value : vector<4xi32>
+  %d1 = vector.splat %descriptor_fill_value : vector<8xi32>
+  %d2 = vector.splat %descriptor_fill_value : vector<4xi32>
   // ERROR@+1: STRUCTURE/014 "dgroups" "3" "two or four AMDGPU tensor dgroups"
   %desc = kernel.tensor.lds.descriptor dgroups(%d0, %d1, %d2) : vector<4xi32>, vector<8xi32>, vector<4xi32> -> kernel.tensor.lds.descriptor
   test.use %desc : kernel.tensor.lds.descriptor
@@ -1098,9 +1098,9 @@ func.def @tensor_descriptor_rejects_three_dgroups() {
 // ====
 
 func.def @tensor_descriptor_rejects_wrong_d1_shape() {
-  %i32_zero = scalar.constant 0 : i32
-  %d0 = vector.splat %i32_zero : vector<4xi32>
-  %d1 = vector.splat %i32_zero : vector<4xi32>
+  %descriptor_fill_value = scalar.constant 0 : i32
+  %d0 = vector.splat %descriptor_fill_value : vector<4xi32>
+  %d1 = vector.splat %descriptor_fill_value : vector<4xi32>
   // ERROR@+1: TYPE/003 "dgroups" "vector<4xi32>" "D1 vector<8xi32>"
   %desc = kernel.tensor.lds.descriptor dgroups(%d0, %d1) : vector<4xi32>, vector<4xi32> -> kernel.tensor.lds.descriptor
   test.use %desc : kernel.tensor.lds.descriptor
@@ -1113,8 +1113,8 @@ func.def @async_tensor_load_rejects_wrong_descriptor_type(%buffer: buffer, %offs
   %base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %i32_zero = scalar.constant 0 : i32
-  %bad_desc = vector.splat %i32_zero : vector<4xi32>
+  %descriptor_fill_value = scalar.constant 0 : i32
+  %bad_desc = vector.splat %descriptor_fill_value : vector<4xi32>
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<64x64xf32, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
@@ -1132,9 +1132,9 @@ func.def @async_tensor_load_rejects_rank_mismatch(%buffer: buffer, %offset: offs
   %base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %i32_zero = scalar.constant 0 : i32
-  %d0 = vector.splat %i32_zero : vector<4xi32>
-  %d1 = vector.splat %i32_zero : vector<8xi32>
+  %descriptor_fill_value = scalar.constant 0 : i32
+  %d0 = vector.splat %descriptor_fill_value : vector<4xi32>
+  %d1 = vector.splat %descriptor_fill_value : vector<8xi32>
   %desc = kernel.tensor.lds.descriptor dgroups(%d0, %d1) : vector<4xi32>, vector<8xi32> -> kernel.tensor.lds.descriptor
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<64x64xf32, %layout>
@@ -1153,9 +1153,9 @@ func.def @async_tensor_store_rejects_constant_dest(%buffer: buffer, %offset: off
   %base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %i32_zero = scalar.constant 0 : i32
-  %d0 = vector.splat %i32_zero : vector<4xi32>
-  %d1 = vector.splat %i32_zero : vector<8xi32>
+  %descriptor_fill_value = scalar.constant 0 : i32
+  %d0 = vector.splat %descriptor_fill_value : vector<4xi32>
+  %d1 = vector.splat %descriptor_fill_value : vector<8xi32>
   %desc = kernel.tensor.lds.descriptor dgroups(%d0, %d1) : vector<4xi32>, vector<8xi32> -> kernel.tensor.lds.descriptor
   %scratch = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
   %source = buffer.view %scratch[%base] : buffer -> view<64x64xf32, %layout>

--- a/loom/src/loom/ops/kernel/test/verify.loom-test
+++ b/loom/src/loom/ops/kernel/test/verify.loom-test
@@ -733,6 +733,25 @@ func.def @async_copy_rejects_mismatched_byte_footprint(%buffer: buffer, %offset:
 
 // ====
 
+kernel.def @async_copy_accepts_noalias_kernel_buffer_memory_space() {
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
+} launch(%other_buffer: buffer, %source_buffer: buffer) {
+  %base = index.constant 0 : offset
+  %scratch_bytes = index.constant 16 : offset
+  %other_noalias, %source_noalias = buffer.assume.noalias %other_buffer, %source_buffer : buffer, buffer
+  %source = buffer.view %source_noalias[%base] : buffer -> view<16xi8, #dense>
+  %scratch = buffer.alloca %scratch_bytes {base_alignment = 16, memory_space = workgroup} : buffer
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
+  %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
+  %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
+  kernel.async.wait %group {newer_groups = 0} : kernel.async.group
+  test.use %other_noalias : buffer
+  kernel.return
+}
+
+// ====
+
 func.def @async_copy_rejects_unknown_source_memory(%buffer: buffer, %offset: offset) {
   %zero = index.constant 0 : offset
   %bytes = index.constant 1024 : offset

--- a/loom/src/loom/ops/kernel/test/verify.loom-test
+++ b/loom/src/loom/ops/kernel/test/verify.loom-test
@@ -382,9 +382,9 @@ kernel.def @workgroup_barrier_accepts_uniform_branch() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
-  %zero = index.constant 0 : index
+  %first_workgroup = index.constant 0 : index
   %workgroup = kernel.workgroup.id<x> : index
-  %is_first_workgroup = index.cmp eq, %workgroup, %zero : index
+  %is_first_workgroup = index.cmp eq, %workgroup, %first_workgroup : index
   scf.if %is_first_workgroup {
     kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
     scf.yield
@@ -417,10 +417,10 @@ kernel.def @workgroup_barrier_rejects_lane_varying_counted_loop_bound() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch() {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %lane = kernel.workitem.id<x> : index
-  scf.for %i = [%zero to %lane step %one] {
+  scf.for %i = [%loop_begin to %lane step %loop_step] {
     // ERROR@+1: STRUCTURE/038 {op_name="kernel.barrier", required_uniform_scope="workgroup", control_kind="loop_upper_bound", control_value="lane", control_op_name="scf.for", control_distribution="lane_varying"}
     kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   }
@@ -438,14 +438,14 @@ kernel.def target(@test_target) @workgroup_barrier_accepts_config_derived_loop_b
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch() {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %fifteen = index.constant 15 : index
-  %sixteen = index.constant 16 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_rounding_bias = index.constant 15 : index
+  %tile_size = index.constant 16 : index
   %valid_token_count = config.get @runtime.valid_token_count : index
-  %rounded_token_count = index.add %valid_token_count, %fifteen : index
-  %tile_count = index.div %rounded_token_count, %sixteen : index
-  scf.for %tile = [%zero to %tile_count step %one] {
+  %rounded_token_count = index.add %valid_token_count, %tile_rounding_bias : index
+  %tile_count = index.div %rounded_token_count, %tile_size : index
+  scf.for %tile = [%loop_begin to %tile_count step %loop_step] {
     kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   }
   kernel.return
@@ -472,9 +472,9 @@ kernel.def @barrier_scope_distinguishes_subgroup_control() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch() {
-  %zero = index.constant 0 : index
+  %first_subgroup = index.constant 0 : index
   %subgroup = kernel.subgroup.id : index
-  %is_first_subgroup = index.cmp eq, %subgroup, %zero : index
+  %is_first_subgroup = index.cmp eq, %subgroup, %first_subgroup : index
   scf.if %is_first_subgroup {
     kernel.barrier<workgroup> {ordering = acq_rel, scope = subgroup}
     // ERROR@+1: STRUCTURE/038 {op_name="kernel.barrier", required_uniform_scope="workgroup", control_kind="region_selector", control_value="is_first_subgroup", control_op_name="scf.if", control_distribution="subgroup"}
@@ -493,9 +493,9 @@ kernel.def target(@test_target) @workgroup_barrier_accepts_exact_single_subgroup
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch() {
-  %zero = index.constant 0 : index
+  %first_subgroup = index.constant 0 : index
   %subgroup = kernel.subgroup.id : index
-  %is_first_subgroup = index.cmp eq, %subgroup, %zero : index
+  %is_first_subgroup = index.cmp eq, %subgroup, %first_subgroup : index
   scf.if %is_first_subgroup {
     kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
     scf.yield
@@ -510,9 +510,9 @@ kernel.def @barrier_scope_distinguishes_collective_results() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch() {
-  %zero = index.constant 0 : index
+  %first_lane = index.constant 0 : index
   %lane = kernel.workitem.id<x> : index
-  %is_first_lane = index.cmp eq, %lane, %zero : index
+  %is_first_lane = index.cmp eq, %lane, %first_lane : index
   %subgroup_any = kernel.subgroup.vote.any %is_first_lane : i1
   scf.if %subgroup_any {
     kernel.barrier<workgroup> {ordering = acq_rel, scope = subgroup}
@@ -535,11 +535,11 @@ kernel.def @workgroup_barrier_rejects_scan_control() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch() {
-  %zero = scalar.constant 0 : i32
+  %first_prefix = scalar.constant 0 : i32
   %lane = kernel.workitem.id<x> : index
   %lane_i32 = index.cast %lane : index to i32
   %prefix = kernel.workgroup.scan<addi> %lane_i32 {mode = inclusive, direction = forward} : i32
-  %is_first_prefix = scalar.cmpi eq, %prefix, %zero : i32
+  %is_first_prefix = scalar.cmpi eq, %prefix, %first_prefix : i32
   scf.if %is_first_prefix {
     // ERROR@+1: STRUCTURE/038 {op_name="kernel.barrier", required_uniform_scope="workgroup", control_kind="region_selector", control_value="is_first_prefix", control_op_name="scf.if", control_distribution="lane_predicate"}
     kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
@@ -558,8 +558,8 @@ kernel.def @workgroup_barrier_rejects_unknown_control(%arg: i32) {
   // test.cast intentionally has no fact transfer and models an unsupported
   // producer whose execution distribution is unknown.
   %unknown = test.cast %arg : i32 to f32
-  %zero = scalar.constant 0.0 : f32
-  %condition = scalar.cmpf ogt, %unknown, %zero : f32
+  %control_threshold = scalar.constant 0.0 : f32
+  %condition = scalar.cmpf ogt, %unknown, %control_threshold : f32
   scf.if %condition {
     // ERROR@+1: STRUCTURE/038 {op_name="kernel.barrier", required_uniform_scope="workgroup", control_kind="region_selector", control_value="condition", control_op_name="scf.if", control_distribution="unknown"}
     kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
@@ -642,9 +642,9 @@ kernel.def @cfg_barrier_scope_distinguishes_subgroup_control() {
   %c128 = index.constant 128 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c128, %c1, %c1) : index
 } launch() {
-  %zero = index.constant 0 : index
+  %first_subgroup = index.constant 0 : index
   %subgroup = kernel.subgroup.id : index
-  %is_first_subgroup = index.cmp eq, %subgroup, %zero : index
+  %is_first_subgroup = index.cmp eq, %subgroup, %first_subgroup : index
   cfg.cond_br %is_first_subgroup, ^first_subgroup, ^other_subgroups
 ^first_subgroup:
   kernel.barrier<workgroup> {ordering = acq_rel, scope = subgroup}
@@ -699,13 +699,13 @@ kernel.def @workgroup_barrier_accepts_workgroup_uniform_cfg_control(%enabled: i1
 // ====
 
 func.def @async_copy_requires_static_byte_footprint(%buffer: buffer, %offset: offset, %n: index) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<[%n]xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<[%n]xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<[%n]xi8, %layout>
   // ERROR@+2: TYPE/003 "source" "view with a static byte-addressable footprint"
   // ERROR@+1: TYPE/003 "dest" "view with a static byte-addressable footprint"
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<[%n]xi8, %layout> to view<[%n]xi8, %layout> -> kernel.async.token
@@ -717,13 +717,13 @@ func.def @async_copy_requires_static_byte_footprint(%buffer: buffer, %offset: of
 // ====
 
 func.def @async_copy_rejects_mismatched_byte_footprint(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<16xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<8xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<8xi8, %layout>
   // ERROR@+1: TYPE/003 "dest" "same static byte footprint as source"
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, %layout> to view<8xi8, %layout> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -753,12 +753,12 @@ kernel.def @async_copy_accepts_noalias_kernel_buffer_memory_space() {
 // ====
 
 func.def @async_copy_rejects_unknown_source_memory(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %source = buffer.view %buffer[%offset] : buffer -> view<16xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, %layout>
   // ERROR@+1: TYPE/003 "source" "global, constant, or descriptor memory-space fact"
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, %layout> to view<16xi8, %layout> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -769,13 +769,13 @@ func.def @async_copy_rejects_unknown_source_memory(%buffer: buffer, %offset: off
 // ====
 
 func.def @async_copy_rejects_direction_memory_mismatch(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<16xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, %layout>
   // ERROR@+1: TYPE/003 "source" "workgroup memory-space fact"
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = workgroup_to_global} : view<16xi8, %layout> to view<16xi8, %layout> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -786,12 +786,12 @@ func.def @async_copy_rejects_direction_memory_mismatch(%buffer: buffer, %offset:
 // ====
 
 func.def @async_copy_rejects_global_store_last_use_cache(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source_buffer = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %source = buffer.view %source_buffer[%zero] : buffer -> view<16xi8, %layout>
+  %source = buffer.view %source_buffer[%base] : buffer -> view<16xi8, %layout>
   %dest = buffer.view %global[%offset] : buffer -> view<16xi8, %layout>
   // ERROR@+1: STRUCTURE/014 "cache_temporal" "3" "store-compatible temporal hint"
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = last_use, direction = workgroup_to_global} : view<16xi8, %layout> to view<16xi8, %layout> -> kernel.async.token
@@ -803,13 +803,13 @@ func.def @async_copy_rejects_global_store_last_use_cache(%buffer: buffer, %offse
 // ====
 
 func.def @async_copy_rejects_global_load_writeback_cache(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<16xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, %layout>
   // ERROR@+1: STRUCTURE/014 "cache_temporal" "4" "load-compatible temporal hint"
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = writeback, direction = global_to_workgroup} : view<16xi8, %layout> to view<16xi8, %layout> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -820,13 +820,13 @@ func.def @async_copy_rejects_global_load_writeback_cache(%buffer: buffer, %offse
 // ====
 
 func.def @async_copy_rejects_bypass_non_system_scope(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<16xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, %layout>
   // ERROR@+1: STRUCTURE/014 "cache_scope" "2" "system scope for bypass temporal hint"
   %copy = kernel.async.copy %source to %dest {cache_scope = device, cache_temporal = bypass, direction = global_to_workgroup} : view<16xi8, %layout> to view<16xi8, %layout> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -837,13 +837,13 @@ func.def @async_copy_rejects_bypass_non_system_scope(%buffer: buffer, %offset: o
 // ====
 
 func.def @async_copy_token_must_be_grouped(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<16xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, %layout>
   // ERROR@+1: DOMINANCE/009 "copy" "0" "exactly one kernel.async.group use"
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, %layout> to view<16xi8, %layout> -> kernel.async.token
   func.return
@@ -852,13 +852,13 @@ func.def @async_copy_token_must_be_grouped(%buffer: buffer, %offset: offset) {
 // ====
 
 func.def @async_group_must_be_used(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<16xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, %layout>
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, %layout> to view<16xi8, %layout> -> kernel.async.token
   // ERROR@+1: DOMINANCE/009 "group" "0" "at least one wait or carried group use"
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -915,13 +915,13 @@ func.def @async_group_rejects_block_arg_token(%token: kernel.async.token) {
 // ====
 
 func.def @async_copy_token_rejects_multiple_groups(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<16xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, %layout>
   // ERROR@+1: DOMINANCE/009 "copy" "2" "exactly one kernel.async.group use"
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, %layout> to view<16xi8, %layout> -> kernel.async.token
   %group0 = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -934,13 +934,13 @@ func.def @async_copy_token_rejects_multiple_groups(%buffer: buffer, %offset: off
 // ====
 
 func.def @async_gather_requires_lane_axis(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<4xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi8, %layout>
   // ERROR@+1: TYPE/003 "dest" "view with one leading subgroup-lane axis"
   %copy = kernel.async.gather %source to %dest {cache_scope = cu, cache_temporal = regular} : view<4xi8, %layout> to view<4xi8, %layout> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -951,13 +951,13 @@ func.def @async_gather_requires_lane_axis(%buffer: buffer, %offset: offset) {
 // ====
 
 func.def @async_gather_rejects_small_lane_slot(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<4xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x2xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<64x2xi8, %layout>
   // ERROR@+1: TYPE/003 "dest" "trailing lane byte footprint at least source footprint"
   %copy = kernel.async.gather %source to %dest {cache_scope = cu, cache_temporal = regular} : view<4xi8, %layout> to view<64x2xi8, %layout> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -968,13 +968,13 @@ func.def @async_gather_rejects_small_lane_slot(%buffer: buffer, %offset: offset)
 // ====
 
 func.def @async_gather_requires_static_lane_footprint(%buffer: buffer, %offset: offset, %n: index) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<4xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x[%n]xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<64x[%n]xi8, %layout>
   // ERROR@+1: TYPE/003 "dest" "view with static byte-addressable trailing lane footprint"
   %copy = kernel.async.gather %source to %dest {cache_scope = cu, cache_temporal = regular} : view<4xi8, %layout> to view<64x[%n]xi8, %layout> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -985,11 +985,11 @@ func.def @async_gather_requires_static_lane_footprint(%buffer: buffer, %offset: 
 // ====
 
 func.def @async_gather_rejects_workgroup_source(%bytes: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %source = buffer.view %scratch[%zero] : buffer -> view<4xi8, %layout>
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x4xi8, %layout>
+  %source = buffer.view %scratch[%base] : buffer -> view<4xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<64x4xi8, %layout>
   // ERROR@+1: TYPE/003 "source" "global, constant, or descriptor memory-space fact"
   %copy = kernel.async.gather %source to %dest {cache_scope = cu, cache_temporal = regular} : view<4xi8, %layout> to view<64x4xi8, %layout> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -1000,14 +1000,14 @@ func.def @async_gather_rejects_workgroup_source(%bytes: offset) {
 // ====
 
 func.def @async_cluster_gather_rejects_wrong_mask_type(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %bad_mask = scalar.constant 15 : i64
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<4xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi8, %layout>
   // ERROR@+1: TYPE/003 "cluster_mask" "i64" "i32"
   %copy = kernel.async.cluster.gather %source to %dest using %bad_mask {cache_scope = cu, cache_temporal = regular} : view<4xi8, %layout> to view<4xi8, %layout>, i64 -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -1018,14 +1018,14 @@ func.def @async_cluster_gather_rejects_wrong_mask_type(%buffer: buffer, %offset:
 // ====
 
 func.def @async_cluster_gather_rejects_unsupported_width(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %cluster_mask = scalar.constant 15 : i32
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<2xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<2xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<2xi8, %layout>
   // ERROR@+1: TYPE/003 "source" "view with static 1, 4, 8, or 16 byte footprint"
   %copy = kernel.async.cluster.gather %source to %dest using %cluster_mask {cache_scope = cu, cache_temporal = regular} : view<2xi8, %layout> to view<2xi8, %layout>, i32 -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -1036,14 +1036,14 @@ func.def @async_cluster_gather_rejects_unsupported_width(%buffer: buffer, %offse
 // ====
 
 func.def @async_cluster_gather_rejects_mismatched_width(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %cluster_mask = scalar.constant 15 : i32
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<8xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi8, %layout>
   // ERROR@+1: TYPE/003 "dest" "same static byte footprint as source"
   %copy = kernel.async.cluster.gather %source to %dest using %cluster_mask {cache_scope = cu, cache_temporal = regular} : view<8xi8, %layout> to view<4xi8, %layout>, i32 -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -1054,12 +1054,12 @@ func.def @async_cluster_gather_rejects_mismatched_width(%buffer: buffer, %offset
 // ====
 
 func.def @async_cluster_gather_rejects_workgroup_source(%bytes: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %cluster_mask = scalar.constant 15 : i32
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %source = buffer.view %scratch[%zero] : buffer -> view<4xi8, %layout>
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, %layout>
+  %source = buffer.view %scratch[%base] : buffer -> view<4xi8, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi8, %layout>
   // ERROR@+1: TYPE/003 "source" "global, constant, or descriptor memory-space fact"
   %copy = kernel.async.cluster.gather %source to %dest using %cluster_mask {cache_scope = cu, cache_temporal = regular} : view<4xi8, %layout> to view<4xi8, %layout>, i32 -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -1110,7 +1110,7 @@ func.def @tensor_descriptor_rejects_wrong_d1_shape() {
 // ====
 
 func.def @async_tensor_load_rejects_wrong_descriptor_type(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %i32_zero = scalar.constant 0 : i32
@@ -1118,7 +1118,7 @@ func.def @async_tensor_load_rejects_wrong_descriptor_type(%buffer: buffer, %offs
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<64x64xf32, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x64xf32, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<64x64xf32, %layout>
   // ERROR@+1: TYPE/003 "descriptor" "vector<4xi32>" "kernel.tensor.lds.descriptor"
   %copy = kernel.async.tensor.load.to.lds %source to %dest using %bad_desc {cache_scope = cu, cache_temporal = regular} : view<64x64xf32, %layout> to view<64x64xf32, %layout>, vector<4xi32> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -1129,7 +1129,7 @@ func.def @async_tensor_load_rejects_wrong_descriptor_type(%buffer: buffer, %offs
 // ====
 
 func.def @async_tensor_load_rejects_rank_mismatch(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %i32_zero = scalar.constant 0 : i32
@@ -1139,7 +1139,7 @@ func.def @async_tensor_load_rejects_rank_mismatch(%buffer: buffer, %offset: offs
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %source = buffer.view %global[%offset] : buffer -> view<64x64xf32, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64xf32, %layout>
+  %dest = buffer.view %scratch[%base] : buffer -> view<64xf32, %layout>
   // ERROR@+1: TYPE/003 "dest" "same rank as source"
   %copy = kernel.async.tensor.load.to.lds %source to %dest using %desc {cache_scope = cu, cache_temporal = regular} : view<64x64xf32, %layout> to view<64xf32, %layout>, kernel.tensor.lds.descriptor -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -1150,7 +1150,7 @@ func.def @async_tensor_load_rejects_rank_mismatch(%buffer: buffer, %offset: offs
 // ====
 
 func.def @async_tensor_store_rejects_constant_dest(%buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %i32_zero = scalar.constant 0 : i32
@@ -1158,7 +1158,7 @@ func.def @async_tensor_store_rejects_constant_dest(%buffer: buffer, %offset: off
   %d1 = vector.splat %i32_zero : vector<8xi32>
   %desc = kernel.tensor.lds.descriptor dgroups(%d0, %d1) : vector<4xi32>, vector<8xi32> -> kernel.tensor.lds.descriptor
   %scratch = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
-  %source = buffer.view %scratch[%zero] : buffer -> view<64x64xf32, %layout>
+  %source = buffer.view %scratch[%base] : buffer -> view<64x64xf32, %layout>
   %constant = buffer.assume.memory_space<constant> %buffer : buffer
   %dest = buffer.view %constant[%offset] : buffer -> view<64x64xf32, %layout>
   // ERROR@+1: TYPE/003 "dest" "global or descriptor memory-space fact"

--- a/loom/src/loom/ops/kernel/verify.c
+++ b/loom/src/loom/ops/kernel/verify.c
@@ -503,29 +503,69 @@ static iree_status_t loom_kernel_verify_cluster_attrs(
       IREE_SV("cluster_stride"));
 }
 
-static bool loom_kernel_try_get_local_buffer_memory_space(
-    const loom_module_t* module, loom_value_id_t buffer_id,
+static bool loom_kernel_try_get_block_arg_memory_space(
+    const loom_module_t* module, const loom_op_t* use_op,
+    const loom_value_t* value,
     loom_value_fact_memory_space_t* out_memory_space) {
-  if (buffer_id >= module->values.count) return false;
-  const loom_value_t* value = loom_module_value(module, buffer_id);
-  if (loom_value_is_block_arg(value)) return false;
-  const loom_op_t* defining_op = loom_value_def_op(value);
-  if (!defining_op) return false;
-  if (loom_buffer_alloca_isa(defining_op)) {
-    *out_memory_space = loom_buffer_alloca_memory_space(defining_op);
-    return true;
+  const loom_block_t* block = loom_value_def_block(value);
+  const loom_region_t* region = block ? block->parent_region : NULL;
+  if (!region) return false;
+  for (const loom_op_t* parent_op = use_op ? use_op->parent_op : NULL;
+       parent_op != NULL; parent_op = parent_op->parent_op) {
+    loom_region_t* const* regions = loom_op_regions(parent_op);
+    for (uint8_t i = 0; i < parent_op->region_count; ++i) {
+      if (regions[i] != region) continue;
+      const loom_op_vtable_t* vtable = loom_op_vtable(module, parent_op);
+      const loom_region_descriptor_t* descriptor =
+          loom_op_vtable_region_descriptor(vtable, i);
+      if (descriptor &&
+          iree_any_bit_set(descriptor->flags, LOOM_REGION_GLOBAL_BUFFER_ARGS)) {
+        *out_memory_space = LOOM_VALUE_FACT_MEMORY_SPACE_GLOBAL;
+        return true;
+      }
+      return false;
+    }
   }
-  if (loom_buffer_assume_memory_space_isa(defining_op)) {
-    *out_memory_space =
-        loom_buffer_assume_memory_space_memory_space(defining_op);
-    return true;
+  return false;
+}
+
+static bool loom_kernel_try_get_local_buffer_memory_space(
+    const loom_module_t* module, const loom_op_t* use_op,
+    loom_value_id_t buffer_id,
+    loom_value_fact_memory_space_t* out_memory_space) {
+  for (uint8_t depth = 0; depth < 32; ++depth) {
+    if (buffer_id >= module->values.count) return false;
+    const loom_value_t* value = loom_module_value(module, buffer_id);
+    if (loom_value_is_block_arg(value)) {
+      return loom_kernel_try_get_block_arg_memory_space(module, use_op, value,
+                                                        out_memory_space);
+    }
+    const loom_op_t* defining_op = loom_value_def_op(value);
+    if (!defining_op) return false;
+    if (loom_buffer_alloca_isa(defining_op)) {
+      *out_memory_space = loom_buffer_alloca_memory_space(defining_op);
+      return true;
+    }
+    if (loom_buffer_assume_memory_space_isa(defining_op)) {
+      *out_memory_space =
+          loom_buffer_assume_memory_space_memory_space(defining_op);
+      return true;
+    }
+    const loom_trait_flags_t traits =
+        loom_op_effective_traits(module, defining_op);
+    const uint16_t result_index = loom_value_def_index(value);
+    if (!loom_traits_are_fact_identity(traits) ||
+        result_index >= defining_op->operand_count) {
+      return false;
+    }
+    buffer_id = loom_op_const_operands(defining_op)[result_index];
   }
   return false;
 }
 
 static bool loom_kernel_try_get_local_view_memory_space(
-    const loom_module_t* module, loom_value_id_t view_id,
-    loom_value_fact_memory_space_t* out_memory_space) {
+    const loom_module_t* module, const loom_op_t* use_op,
+    loom_value_id_t view_id, loom_value_fact_memory_space_t* out_memory_space) {
   for (uint8_t depth = 0; depth < 32; ++depth) {
     if (view_id >= module->values.count) return false;
     const loom_value_t* value = loom_module_value(module, view_id);
@@ -535,7 +575,8 @@ static bool loom_kernel_try_get_local_view_memory_space(
 
     if (loom_buffer_view_isa(defining_op)) {
       return loom_kernel_try_get_local_buffer_memory_space(
-          module, loom_buffer_view_buffer(defining_op), out_memory_space);
+          module, use_op, loom_buffer_view_buffer(defining_op),
+          out_memory_space);
     }
     if (loom_view_subview_isa(defining_op)) {
       view_id = loom_view_subview_source(defining_op);
@@ -564,11 +605,12 @@ static bool loom_kernel_memory_space_is_global_dest(
 }
 
 static bool loom_kernel_view_memory_space_is(
-    const loom_module_t* module, loom_value_id_t view_id,
+    const loom_module_t* module, const loom_op_t* use_op,
+    loom_value_id_t view_id,
     bool (*predicate)(loom_value_fact_memory_space_t)) {
   loom_value_fact_memory_space_t memory_space =
       LOOM_VALUE_FACT_MEMORY_SPACE_UNKNOWN;
-  if (!loom_kernel_try_get_local_view_memory_space(module, view_id,
+  if (!loom_kernel_try_get_local_view_memory_space(module, use_op, view_id,
                                                    &memory_space)) {
     return false;
   }
@@ -689,14 +731,15 @@ static iree_status_t loom_kernel_verify_async_copy_memory_spaces(
   switch ((loom_kernel_direction_t)direction) {
     case LOOM_KERNEL_DIRECTION_GLOBAL_TO_WORKGROUP:
       if (!loom_kernel_view_memory_space_is(
-              module, source_id, loom_kernel_memory_space_is_global_source)) {
+              module, op, source_id,
+              loom_kernel_memory_space_is_global_source)) {
         loom_type_t source_type = loom_module_value_type(module, source_id);
         return loom_kernel_emit_operand_constraint(
             emitter, op, IREE_SV("source"), source_type,
             IREE_SV("global, constant, or descriptor memory-space fact"));
       }
       if (!loom_kernel_view_memory_space_is(
-              module, dest_id, loom_kernel_memory_space_is_workgroup)) {
+              module, op, dest_id, loom_kernel_memory_space_is_workgroup)) {
         loom_type_t dest_type = loom_module_value_type(module, dest_id);
         return loom_kernel_emit_operand_constraint(
             emitter, op, IREE_SV("dest"), dest_type,
@@ -705,14 +748,14 @@ static iree_status_t loom_kernel_verify_async_copy_memory_spaces(
       return iree_ok_status();
     case LOOM_KERNEL_DIRECTION_WORKGROUP_TO_GLOBAL:
       if (!loom_kernel_view_memory_space_is(
-              module, source_id, loom_kernel_memory_space_is_workgroup)) {
+              module, op, source_id, loom_kernel_memory_space_is_workgroup)) {
         loom_type_t source_type = loom_module_value_type(module, source_id);
         return loom_kernel_emit_operand_constraint(
             emitter, op, IREE_SV("source"), source_type,
             IREE_SV("workgroup memory-space fact"));
       }
       if (!loom_kernel_view_memory_space_is(
-              module, dest_id, loom_kernel_memory_space_is_global_dest)) {
+              module, op, dest_id, loom_kernel_memory_space_is_global_dest)) {
         loom_type_t dest_type = loom_module_value_type(module, dest_id);
         return loom_kernel_emit_operand_constraint(
             emitter, op, IREE_SV("dest"), dest_type,
@@ -855,14 +898,14 @@ static iree_status_t loom_kernel_verify_gather_memory_spaces(
     const loom_module_t* module, iree_diagnostic_emitter_t emitter,
     const loom_op_t* op, loom_value_id_t source_id, loom_value_id_t dest_id) {
   if (!loom_kernel_view_memory_space_is(
-          module, source_id, loom_kernel_memory_space_is_global_source)) {
+          module, op, source_id, loom_kernel_memory_space_is_global_source)) {
     loom_type_t source_type = loom_module_value_type(module, source_id);
     return loom_kernel_emit_operand_constraint(
         emitter, op, IREE_SV("source"), source_type,
         IREE_SV("global, constant, or descriptor memory-space fact"));
   }
   if (!loom_kernel_view_memory_space_is(
-          module, dest_id, loom_kernel_memory_space_is_workgroup)) {
+          module, op, dest_id, loom_kernel_memory_space_is_workgroup)) {
     loom_type_t dest_type = loom_module_value_type(module, dest_id);
     return loom_kernel_emit_operand_constraint(
         emitter, op, IREE_SV("dest"), dest_type,

--- a/loom/src/loom/ops/sanitizer/test/canonicalize.loom-test
+++ b/loom/src/loom/ops/sanitizer/test/canonicalize.loom-test
@@ -52,15 +52,15 @@ func.def @stronger_dominated_assertion_survives(%n: index) -> (index) {
 // Exact float facts prove matching float assertions, so no runtime boundary is
 // needed.
 func.def @proven_exact_float_assertion_folds() -> (f32) {
-  %two = scalar.constant 2.0 : f32
-  %checked = sanitizer.assert.value %two [finite(%two)] : f32
+  %c2 = scalar.constant 2.0 : f32
+  %checked = sanitizer.assert.value %c2 [finite(%c2)] : f32
   func.return %checked : f32
 }
 
 // ----
 func.def @proven_exact_float_assertion_folds() -> (f32) {
-  %two = scalar.constant 2.0 : f32
-  func.return %two : f32
+  %c2 = scalar.constant 2.0 : f32
+  func.return %c2 : f32
 }
 
 // ====

--- a/loom/src/loom/ops/scalar/test/facts/arithmeticf.loom-test
+++ b/loom/src/loom/ops/scalar/test/facts/arithmeticf.loom-test
@@ -99,10 +99,10 @@ func.def @rounds_each_instruction() -> (f32, f64) {
 
 // IEEE minimum and maximum choose opposite signed zeros.
 func.def @minmax_preserve_signed_zero_semantics() -> (i32, i32) {
-  %positive_zero = scalar.constant 0.0 : f32
+  %positive_signed_zero = scalar.constant 0.0 : f32
   %cn0 = scalar.constant -0.0 : f32
-  %minimum = scalar.minimumf %positive_zero, %cn0 : f32
-  %maximum = scalar.maximumf %positive_zero, %cn0 : f32
+  %minimum = scalar.minimumf %positive_signed_zero, %cn0 : f32
+  %maximum = scalar.maximumf %positive_signed_zero, %cn0 : f32
   %minimum_bits = scalar.bitcast %minimum : f32 to i32
   %maximum_bits = scalar.bitcast %maximum : f32 to i32
   func.return %minimum_bits, %maximum_bits : i32, i32

--- a/loom/src/loom/ops/scalar/test/facts/arithmeticf.loom-test
+++ b/loom/src/loom/ops/scalar/test/facts/arithmeticf.loom-test
@@ -4,8 +4,8 @@
 func.def @minimumf_propagates_nan() -> (i1) {
   %neg = scalar.constant -1.0 : f32
   %nan = scalar.logf %neg : f32
-  %three = scalar.constant 3.0 : f32
-  %min = scalar.minimumf %nan, %three : f32
+  %c3 = scalar.constant 3.0 : f32
+  %min = scalar.minimumf %nan, %c3 : f32
   %r = scalar.isnanf %min : f32
   func.return %r : i1
 }
@@ -21,8 +21,8 @@ func.def @minimumf_propagates_nan() -> (i1) {
 func.def @maximumf_propagates_nan() -> (i1) {
   %neg = scalar.constant -1.0 : f32
   %nan = scalar.logf %neg : f32
-  %three = scalar.constant 3.0 : f32
-  %max = scalar.maximumf %three, %nan : f32
+  %c3 = scalar.constant 3.0 : f32
+  %max = scalar.maximumf %c3, %nan : f32
   %r = scalar.isnanf %max : f32
   func.return %r : i1
 }
@@ -38,8 +38,8 @@ func.def @maximumf_propagates_nan() -> (i1) {
 func.def @minnumf_skips_nan() -> (f32) {
   %neg = scalar.constant -1.0 : f32
   %nan = scalar.logf %neg : f32
-  %three = scalar.constant 3.0 : f32
-  %min = scalar.minnumf %nan, %three : f32
+  %c3 = scalar.constant 3.0 : f32
+  %min = scalar.minnumf %nan, %c3 : f32
   func.return %min : f32
 }
 // ----
@@ -55,11 +55,11 @@ func.def @minnumf_skips_nan() -> (f32) {
 func.def @clampf_modes_name_nan_semantics() -> (i1, i1, i1) {
   %neg = scalar.constant -1.0 : f32
   %nan = scalar.logf %neg : f32
-  %zero = scalar.constant 0.0 : f32
-  %one = scalar.constant 1.0 : f32
-  %ordered = scalar.clampf<ordered> %nan, %zero, %one : f32
-  %number = scalar.clampf<number> %nan, %zero, %one : f32
-  %ieee = scalar.clampf<ieee> %nan, %zero, %one : f32
+  %c0 = scalar.constant 0.0 : f32
+  %c1 = scalar.constant 1.0 : f32
+  %ordered = scalar.clampf<ordered> %nan, %c0, %c1 : f32
+  %number = scalar.clampf<number> %nan, %c0, %c1 : f32
+  %ieee = scalar.clampf<ieee> %nan, %c0, %c1 : f32
   %ordered_is_nan = scalar.isnanf %ordered : f32
   %number_is_nan = scalar.isnanf %number : f32
   %ieee_is_nan = scalar.isnanf %ieee : f32
@@ -79,12 +79,12 @@ func.def @clampf_modes_name_nan_semantics() -> (i1, i1, i1) {
 // loses the unit before the subtraction while f64 retains it.
 func.def @rounds_each_instruction() -> (f32, f64) {
   %large_f32 = scalar.constant 16777216.0 : f32
-  %one_f32 = scalar.constant 1.0 : f32
-  %sum_f32 = scalar.addf %large_f32, %one_f32 : f32
+  %c1_f32 = scalar.constant 1.0 : f32
+  %sum_f32 = scalar.addf %large_f32, %c1_f32 : f32
   %result_f32 = scalar.subf %sum_f32, %large_f32 : f32
   %large_f64 = scalar.constant 16777216.0 : f64
-  %one_f64 = scalar.constant 1.0 : f64
-  %sum_f64 = scalar.addf %large_f64, %one_f64 : f64
+  %c1_f64 = scalar.constant 1.0 : f64
+  %sum_f64 = scalar.addf %large_f64, %c1_f64 : f64
   %result_f64 = scalar.subf %sum_f64, %large_f64 : f64
   func.return %result_f32, %result_f64 : f32, f64
 }
@@ -100,9 +100,9 @@ func.def @rounds_each_instruction() -> (f32, f64) {
 // IEEE minimum and maximum choose opposite signed zeros.
 func.def @minmax_preserve_signed_zero_semantics() -> (i32, i32) {
   %positive_zero = scalar.constant 0.0 : f32
-  %negative_zero = scalar.constant -0.0 : f32
-  %minimum = scalar.minimumf %positive_zero, %negative_zero : f32
-  %maximum = scalar.maximumf %positive_zero, %negative_zero : f32
+  %cn0 = scalar.constant -0.0 : f32
+  %minimum = scalar.minimumf %positive_zero, %cn0 : f32
+  %maximum = scalar.maximumf %positive_zero, %cn0 : f32
   %minimum_bits = scalar.bitcast %minimum : f32 to i32
   %maximum_bits = scalar.bitcast %maximum : f32 to i32
   func.return %minimum_bits, %maximum_bits : i32, i32

--- a/loom/src/loom/ops/scalar/test/facts/bitwisei.loom-test
+++ b/loom/src/loom/ops/scalar/test/facts/bitwisei.loom-test
@@ -47,8 +47,8 @@ func.def @andi_range_hi(%x: i32) -> (i64) {
 
 // ori with 1: result is definitely non-zero.
 func.def @ori_non_zero(%x: i32) -> (i1) {
-  %one = scalar.constant 1 : i32
-  %r = scalar.ori %x, %one : i32
+  %c1 = scalar.constant 1 : i32
+  %r = scalar.ori %x, %c1 : i32
   %nz = test.fact_non_zero %r : i32 -> i1
   func.return %nz : i1
 }

--- a/loom/src/loom/ops/scalar/test/fold/arithmeticf_structural.loom-test
+++ b/loom/src/loom/ops/scalar/test/fold/arithmeticf_structural.loom-test
@@ -1,11 +1,11 @@
 // RUN: pass canonicalize
 
 func.def @add_sub_nsz_identities(%x: f32) -> (f32, f32, f32, f32) {
-  %zero = scalar.constant 0.0 : f32
-  %add_lhs = scalar.addf<nsz> %zero, %x : f32
-  %add_rhs = scalar.addf<nsz> %x, %zero : f32
-  %sub_rhs = scalar.subf<nsz> %x, %zero : f32
-  %sub_lhs = scalar.subf<nnan|nsz> %zero, %x : f32
+  %c0 = scalar.constant 0.0 : f32
+  %add_lhs = scalar.addf<nsz> %c0, %x : f32
+  %add_rhs = scalar.addf<nsz> %x, %c0 : f32
+  %sub_rhs = scalar.subf<nsz> %x, %c0 : f32
+  %sub_lhs = scalar.subf<nnan|nsz> %c0, %x : f32
   func.return %add_lhs, %add_rhs, %sub_rhs, %sub_lhs : f32, f32, f32, f32
 }
 
@@ -18,19 +18,19 @@ func.def @add_sub_nsz_identities(%x: f32) -> (f32, f32, f32, f32) {
 // ====
 
 func.def @strict_add_zero_preserves_signed_zero(%x: f32) -> (f32) {
-  %zero = scalar.constant 0.0 : f32
-  %r = scalar.addf %x, %zero : f32
+  %c0 = scalar.constant 0.0 : f32
+  %r = scalar.addf %x, %c0 : f32
   func.return %r : f32
 }
 
 // ====
 
 func.def @mul_div_identities(%x: f32) -> (f32, f32, f32) {
-  %zero = scalar.constant 0.0 : f32
-  %one = scalar.constant 1.0 : f32
-  %mul = scalar.mulf %x, %one : f32
-  %div = scalar.divf %x, %one : f32
-  %zeroed = scalar.mulf<nnan|ninf|nsz> %x, %zero : f32
+  %c0 = scalar.constant 0.0 : f32
+  %c1 = scalar.constant 1.0 : f32
+  %mul = scalar.mulf %x, %c1 : f32
+  %div = scalar.divf %x, %c1 : f32
+  %zeroed = scalar.mulf<nnan|ninf|nsz> %x, %c0 : f32
   func.return %mul, %div, %zeroed : f32, f32, f32
 }
 
@@ -61,8 +61,8 @@ func.def @divf_arcp_constant_rhs_to_reciprocal_mulf(%x: f32) -> (f32, f32) {
 // ====
 
 func.def @mulf_absorbs_negated_input_constant(%x: f32) -> (f32) {
-  %zero = scalar.constant 0.0 : f32
-  %neg = scalar.subf<nnan|nsz> %zero, %x : f32
+  %c0 = scalar.constant 0.0 : f32
+  %neg = scalar.subf<nnan|nsz> %c0, %x : f32
   %scale = scalar.constant 1.4426950408889634 : f32
   %scaled = scalar.mulf<nnan|ninf|nsz> %neg, %scale : f32
   func.return %scaled : f32
@@ -97,11 +97,11 @@ func.def @neg_abs_copysign_structural(%x: f32) -> (f32, f32, f32, f32) {
 // ====
 
 func.def @fmaf_preserves_fastmath_flags(%a: f32, %b: f32, %c: f32) -> (f32, f32, f32) {
-  %zero = scalar.constant 0.0 : f32
-  %one = scalar.constant 1.0 : f32
-  %to_c = scalar.fmaf<nnan|ninf|nsz> %zero, %b, %c : f32
-  %to_mul = scalar.fmaf<nsz> %a, %b, %zero : f32
-  %to_add = scalar.fmaf<reassoc> %one, %b, %c : f32
+  %c0 = scalar.constant 0.0 : f32
+  %c1 = scalar.constant 1.0 : f32
+  %to_c = scalar.fmaf<nnan|ninf|nsz> %c0, %b, %c : f32
+  %to_mul = scalar.fmaf<nsz> %a, %b, %c0 : f32
+  %to_add = scalar.fmaf<reassoc> %c1, %b, %c : f32
   func.return %to_c, %to_mul, %to_add : f32, f32, f32
 }
 

--- a/loom/src/loom/ops/scalar/test/fold/arithmetici.loom-test
+++ b/loom/src/loom/ops/scalar/test/fold/arithmetici.loom-test
@@ -235,9 +235,9 @@ func.def @fmai_const() -> (i32) {
 
 // fmai: zero multiplier folds to exact c.
 func.def @fmai_zero_mul(%x: i32) -> (i32) {
-  %zero = scalar.constant 0 : i32
+  %c0 = scalar.constant 0 : i32
   %c = scalar.constant 42 : i32
-  %r = scalar.fmai %x, %zero, %c : i32
+  %r = scalar.fmai %x, %c0, %c : i32
   func.return %r : i32
 }
 // ----
@@ -250,9 +250,9 @@ func.def @fmai_zero_mul(%x: i32) -> (i32) {
 
 // fmai: zero multiplier first operand.
 func.def @fmai_zero_mul_first(%x: i32) -> (i32) {
-  %zero = scalar.constant 0 : i32
+  %c0 = scalar.constant 0 : i32
   %c = scalar.constant 42 : i32
-  %r = scalar.fmai %zero, %x, %c : i32
+  %r = scalar.fmai %c0, %x, %c : i32
   func.return %r : i32
 }
 // ----

--- a/loom/src/loom/ops/scalar/test/fold/arithmetici_structural.loom-test
+++ b/loom/src/loom/ops/scalar/test/fold/arithmetici_structural.loom-test
@@ -134,8 +134,8 @@ func.def @muli_power_of_two_to_shift(%x: i32) -> (i32) {
 // ====
 
 func.def @muli_negative_one_to_negi(%x: i32) -> (i32) {
-  %neg_one = scalar.constant -1 : i32
-  %r = scalar.muli %x, %neg_one : i32
+  %negation_factor = scalar.constant -1 : i32
+  %r = scalar.muli %x, %negation_factor : i32
   func.return %r : i32
 }
 
@@ -312,36 +312,36 @@ func.def @signed_minmax_extremes(%x: i32) -> (i32, i32, i32, i32, i32, i32) {
 
 func.def @unsigned_minmax_extremes(%x: i32) -> (i32, i32, i32, i32) {
   %c0 = scalar.constant 0 : i32
-  %all_ones = scalar.constant -1 : i32
+  %unsigned_max = scalar.constant -1 : i32
   %min_absorb = scalar.minui %x, %c0 : i32
-  %min_identity = scalar.minui %x, %all_ones : i32
+  %min_identity = scalar.minui %x, %unsigned_max : i32
   %max_identity = scalar.maxui %x, %c0 : i32
-  %max_absorb = scalar.maxui %x, %all_ones : i32
+  %max_absorb = scalar.maxui %x, %unsigned_max : i32
   func.return %min_absorb, %min_identity, %max_identity, %max_absorb : i32, i32, i32, i32
 }
 
 // ----
 func.def @unsigned_minmax_extremes(%x: i32) -> (i32, i32, i32, i32) {
   %c0 = scalar.constant 0 : i32
-  %all_ones = scalar.constant -1 : i32
-  func.return %c0, %x, %x, %all_ones : i32, i32, i32, i32
+  %unsigned_max = scalar.constant -1 : i32
+  func.return %c0, %x, %x, %unsigned_max : i32, i32, i32, i32
 }
 
 // ====
 
 func.def @unsigned_i64_minmax_extremes(%x: i64) -> (i64, i64, i64, i64) {
   %c0 = scalar.constant 0 : i64
-  %all_ones = scalar.constant -1 : i64
+  %unsigned_max = scalar.constant -1 : i64
   %min_absorb = scalar.minui %x, %c0 : i64
-  %min_identity = scalar.minui %x, %all_ones : i64
+  %min_identity = scalar.minui %x, %unsigned_max : i64
   %max_identity = scalar.maxui %x, %c0 : i64
-  %max_absorb = scalar.maxui %x, %all_ones : i64
+  %max_absorb = scalar.maxui %x, %unsigned_max : i64
   func.return %min_absorb, %min_identity, %max_identity, %max_absorb : i64, i64, i64, i64
 }
 
 // ----
 func.def @unsigned_i64_minmax_extremes(%x: i64) -> (i64, i64, i64, i64) {
   %c0 = scalar.constant 0 : i64
-  %all_ones = scalar.constant -1 : i64
-  func.return %c0, %x, %x, %all_ones : i64, i64, i64, i64
+  %unsigned_max = scalar.constant -1 : i64
+  func.return %c0, %x, %x, %unsigned_max : i64, i64, i64, i64
 }

--- a/loom/src/loom/ops/scalar/test/fold/arithmetici_structural.loom-test
+++ b/loom/src/loom/ops/scalar/test/fold/arithmetici_structural.loom-test
@@ -1,9 +1,9 @@
 // RUN: pass canonicalize
 
 func.def @addi_dynamic_identities(%x: i32) -> (i32, i32) {
-  %zero = scalar.constant 0 : i32
-  %lhs = scalar.addi %zero, %x : i32
-  %rhs = scalar.addi %x, %zero : i32
+  %c0 = scalar.constant 0 : i32
+  %lhs = scalar.addi %c0, %x : i32
+  %rhs = scalar.addi %x, %c0 : i32
   func.return %lhs, %rhs : i32, i32
 }
 
@@ -69,8 +69,8 @@ func.def @flagged_sub_add_cancellation_stays(%x: i32, %y: i32) -> (i32) {
 // ====
 
 func.def @subi_dynamic_identities(%x: i32, %y: i32) -> (i32, i32, i32) {
-  %zero = scalar.constant 0 : i32
-  %identity = scalar.subi %x, %zero : i32
+  %c0 = scalar.constant 0 : i32
+  %identity = scalar.subi %x, %c0 : i32
   %self = scalar.subi %x, %x : i32
   %sum = scalar.addi %x, %y : i32
   %cancel = scalar.subi %sum, %y : i32
@@ -101,11 +101,11 @@ func.def @subi_constant_to_add(%x: i32) -> (i32) {
 // ====
 
 func.def @muli_dynamic_identities(%x: i32) -> (i32, i32, i32) {
-  %zero = scalar.constant 0 : i32
-  %one = scalar.constant 1 : i32
-  %same = scalar.muli %x, %one : i32
-  %zeroed = scalar.muli %x, %zero : i32
-  %also_zero = scalar.muli %zero, %x : i32
+  %c0 = scalar.constant 0 : i32
+  %c1 = scalar.constant 1 : i32
+  %same = scalar.muli %x, %c1 : i32
+  %zeroed = scalar.muli %x, %c0 : i32
+  %also_zero = scalar.muli %c0, %x : i32
   func.return %same, %zeroed, %also_zero : i32, i32, i32
 }
 
@@ -148,13 +148,13 @@ func.def @muli_negative_one_to_negi(%x: i32) -> (i32) {
 // ====
 
 func.def @div_dynamic_identities(%x: i32, %d: i32) -> (i32, i32, i32) {
-  %one = scalar.constant 1 : i32
-  %zero = scalar.constant 0 : i32
+  %c1 = scalar.constant 1 : i32
+  %c0 = scalar.constant 0 : i32
   %x2 = scalar.assume %x [range(%x, 1, 1024)] : i32
   %d2 = scalar.assume %d [range(%d, 1, 1024)] : i32
   %self = scalar.divsi %x2, %x2 : i32
-  %zeroed = scalar.divsi %zero, %d2 : i32
-  %identity = scalar.divsi %x, %one : i32
+  %zeroed = scalar.divsi %c0, %d2 : i32
+  %identity = scalar.divsi %x, %c1 : i32
   func.return %self, %zeroed, %identity : i32, i32, i32
 }
 
@@ -183,13 +183,13 @@ func.def @divui_power_of_two_to_shift(%x: i32) -> (i32) {
 // ====
 
 func.def @rem_dynamic_identities(%x: i32, %d: i32) -> (i32, i32, i32) {
-  %one = scalar.constant 1 : i32
-  %zero = scalar.constant 0 : i32
+  %c1 = scalar.constant 1 : i32
+  %c0 = scalar.constant 0 : i32
   %x2 = scalar.assume %x [range(%x, 1, 1024)] : i32
   %d2 = scalar.assume %d [range(%d, 1, 1024)] : i32
   %self = scalar.remsi %x2, %x2 : i32
-  %zeroed = scalar.remsi %zero, %d2 : i32
-  %by_one = scalar.remsi %x, %one : i32
+  %zeroed = scalar.remsi %c0, %d2 : i32
+  %by_one = scalar.remsi %x, %c1 : i32
   func.return %self, %zeroed, %by_one : i32, i32, i32
 }
 
@@ -219,13 +219,13 @@ func.def @remui_power_of_two_to_mask(%x: i32) -> (i32) {
 // ====
 
 func.def @ceil_floor_div_identities(%x: i32, %d: i32) -> (i32, i32, i32, i32) {
-  %one = scalar.constant 1 : i32
-  %zero = scalar.constant 0 : i32
+  %c1 = scalar.constant 1 : i32
+  %c0 = scalar.constant 0 : i32
   %d2 = scalar.assume %d [range(%d, 1, 1024)] : i32
-  %ceil_identity = scalar.ceildivsi %x, %one : i32
-  %ceil_zero = scalar.ceildivui %zero, %d2 : i32
-  %floor_identity = scalar.floordivsi %x, %one : i32
-  %floor_zero = scalar.floordivsi %zero, %d2 : i32
+  %ceil_identity = scalar.ceildivsi %x, %c1 : i32
+  %ceil_zero = scalar.ceildivui %c0, %d2 : i32
+  %floor_identity = scalar.floordivsi %x, %c1 : i32
+  %floor_zero = scalar.floordivsi %c0, %d2 : i32
   func.return %ceil_identity, %ceil_zero, %floor_identity, %floor_zero : i32, i32, i32, i32
 }
 
@@ -239,11 +239,11 @@ func.def @ceil_floor_div_identities(%x: i32, %d: i32) -> (i32, i32, i32, i32) {
 // ====
 
 func.def @fmai_preserves_overflow_flags(%a: i32, %b: i32, %c: i32) -> (i32, i32, i32) {
-  %zero = scalar.constant 0 : i32
-  %one = scalar.constant 1 : i32
-  %to_mul = scalar.fmai<nuw> %a, %b, %zero : i32
-  %lhs_one = scalar.fmai<nsw> %one, %b, %c : i32
-  %rhs_one = scalar.fmai<nuw|nsw> %a, %one, %c : i32
+  %c0 = scalar.constant 0 : i32
+  %c1 = scalar.constant 1 : i32
+  %to_mul = scalar.fmai<nuw> %a, %b, %c0 : i32
+  %lhs_one = scalar.fmai<nsw> %c1, %b, %c : i32
+  %rhs_one = scalar.fmai<nuw|nsw> %a, %c1, %c : i32
   func.return %to_mul, %lhs_one, %rhs_one : i32, i32, i32
 }
 
@@ -311,37 +311,37 @@ func.def @signed_minmax_extremes(%x: i32) -> (i32, i32, i32, i32, i32, i32) {
 // ====
 
 func.def @unsigned_minmax_extremes(%x: i32) -> (i32, i32, i32, i32) {
-  %zero = scalar.constant 0 : i32
+  %c0 = scalar.constant 0 : i32
   %all_ones = scalar.constant -1 : i32
-  %min_absorb = scalar.minui %x, %zero : i32
+  %min_absorb = scalar.minui %x, %c0 : i32
   %min_identity = scalar.minui %x, %all_ones : i32
-  %max_identity = scalar.maxui %x, %zero : i32
+  %max_identity = scalar.maxui %x, %c0 : i32
   %max_absorb = scalar.maxui %x, %all_ones : i32
   func.return %min_absorb, %min_identity, %max_identity, %max_absorb : i32, i32, i32, i32
 }
 
 // ----
 func.def @unsigned_minmax_extremes(%x: i32) -> (i32, i32, i32, i32) {
-  %zero = scalar.constant 0 : i32
+  %c0 = scalar.constant 0 : i32
   %all_ones = scalar.constant -1 : i32
-  func.return %zero, %x, %x, %all_ones : i32, i32, i32, i32
+  func.return %c0, %x, %x, %all_ones : i32, i32, i32, i32
 }
 
 // ====
 
 func.def @unsigned_i64_minmax_extremes(%x: i64) -> (i64, i64, i64, i64) {
-  %zero = scalar.constant 0 : i64
+  %c0 = scalar.constant 0 : i64
   %all_ones = scalar.constant -1 : i64
-  %min_absorb = scalar.minui %x, %zero : i64
+  %min_absorb = scalar.minui %x, %c0 : i64
   %min_identity = scalar.minui %x, %all_ones : i64
-  %max_identity = scalar.maxui %x, %zero : i64
+  %max_identity = scalar.maxui %x, %c0 : i64
   %max_absorb = scalar.maxui %x, %all_ones : i64
   func.return %min_absorb, %min_identity, %max_identity, %max_absorb : i64, i64, i64, i64
 }
 
 // ----
 func.def @unsigned_i64_minmax_extremes(%x: i64) -> (i64, i64, i64, i64) {
-  %zero = scalar.constant 0 : i64
+  %c0 = scalar.constant 0 : i64
   %all_ones = scalar.constant -1 : i64
-  func.return %zero, %x, %x, %all_ones : i64, i64, i64, i64
+  func.return %c0, %x, %x, %all_ones : i64, i64, i64, i64
 }

--- a/loom/src/loom/ops/scalar/test/fold/bitwisei_structural.loom-test
+++ b/loom/src/loom/ops/scalar/test/fold/bitwisei_structural.loom-test
@@ -1,15 +1,15 @@
 // RUN: pass canonicalize
 
 func.def @bitwise_identities(%x: i32) -> (i32, i32, i32, i32, i32, i32, i32, i32) {
-  %zero = scalar.constant 0 : i32
+  %c0 = scalar.constant 0 : i32
   %ones = scalar.constant -1 : i32
   %and_self = scalar.andi %x, %x : i32
-  %and_zero = scalar.andi %x, %zero : i32
+  %and_zero = scalar.andi %x, %c0 : i32
   %and_ones = scalar.andi %x, %ones : i32
   %or_self = scalar.ori %x, %x : i32
-  %or_zero = scalar.ori %x, %zero : i32
+  %or_zero = scalar.ori %x, %c0 : i32
   %or_ones = scalar.ori %x, %ones : i32
-  %xor_zero = scalar.xori %x, %zero : i32
+  %xor_zero = scalar.xori %x, %c0 : i32
   %xor_self = scalar.xori %x, %x : i32
   func.return %and_self, %and_zero, %and_ones, %or_self, %or_zero, %or_ones, %xor_zero, %xor_self : i32, i32, i32, i32, i32, i32, i32, i32
 }
@@ -74,17 +74,17 @@ func.def @xori_cancels_duplicate_exact_constants(%x: i32) -> (i32) {
 // ====
 
 func.def @shift_identities_and_reassociation(%x: i32) -> (i32, i32, i32, i32, i32, i32) {
-  %zero = scalar.constant 0 : i32
-  %one = scalar.constant 1 : i32
-  %two = scalar.constant 2 : i32
-  %shl_zero_amount = scalar.shli %x, %zero : i32
-  %shrsi_zero_amount = scalar.shrsi %x, %zero : i32
-  %shrui_zero_amount = scalar.shrui %x, %zero : i32
-  %shl_zero_value = scalar.shli %zero, %one : i32
-  %inner_shl = scalar.shli %x, %one : i32
-  %reassoc_shl = scalar.shli %inner_shl, %two : i32
-  %inner_shr = scalar.shrui %x, %one : i32
-  %reassoc_shr = scalar.shrui %inner_shr, %two : i32
+  %c0 = scalar.constant 0 : i32
+  %c1 = scalar.constant 1 : i32
+  %c2 = scalar.constant 2 : i32
+  %shl_zero_amount = scalar.shli %x, %c0 : i32
+  %shrsi_zero_amount = scalar.shrsi %x, %c0 : i32
+  %shrui_zero_amount = scalar.shrui %x, %c0 : i32
+  %shl_zero_value = scalar.shli %c0, %c1 : i32
+  %inner_shl = scalar.shli %x, %c1 : i32
+  %reassoc_shl = scalar.shli %inner_shl, %c2 : i32
+  %inner_shr = scalar.shrui %x, %c1 : i32
+  %reassoc_shr = scalar.shrui %inner_shr, %c2 : i32
   func.return %shl_zero_amount, %shrsi_zero_amount, %shrui_zero_amount, %shl_zero_value, %reassoc_shl, %reassoc_shr : i32, i32, i32, i32, i32, i32
 }
 
@@ -101,11 +101,11 @@ func.def @shift_identities_and_reassociation(%x: i32) -> (i32, i32, i32, i32, i3
 // ====
 
 func.def @rotate_identities_and_direction(%x: i32) -> (i32, i32, i32) {
-  %zero = scalar.constant 0 : i32
-  %eight = scalar.constant 8 : i32
-  %rotl_zero = scalar.rotli %x, %zero : i32
-  %rotr_zero = scalar.rotri %x, %zero : i32
-  %rotr = scalar.rotri %x, %eight : i32
+  %c0 = scalar.constant 0 : i32
+  %c8 = scalar.constant 8 : i32
+  %rotl_zero = scalar.rotli %x, %c0 : i32
+  %rotr_zero = scalar.rotri %x, %c0 : i32
+  %rotr = scalar.rotri %x, %c8 : i32
   func.return %rotl_zero, %rotr_zero, %rotr : i32, i32, i32
 }
 

--- a/loom/src/loom/ops/scalar/test/fold/bitwisei_structural.loom-test
+++ b/loom/src/loom/ops/scalar/test/fold/bitwisei_structural.loom-test
@@ -2,13 +2,13 @@
 
 func.def @bitwise_identities(%x: i32) -> (i32, i32, i32, i32, i32, i32, i32, i32) {
   %c0 = scalar.constant 0 : i32
-  %ones = scalar.constant -1 : i32
+  %all_bits_set = scalar.constant -1 : i32
   %and_self = scalar.andi %x, %x : i32
   %and_zero = scalar.andi %x, %c0 : i32
-  %and_ones = scalar.andi %x, %ones : i32
+  %and_ones = scalar.andi %x, %all_bits_set : i32
   %or_self = scalar.ori %x, %x : i32
   %or_zero = scalar.ori %x, %c0 : i32
-  %or_ones = scalar.ori %x, %ones : i32
+  %or_ones = scalar.ori %x, %all_bits_set : i32
   %xor_zero = scalar.xori %x, %c0 : i32
   %xor_self = scalar.xori %x, %x : i32
   func.return %and_self, %and_zero, %and_ones, %or_self, %or_zero, %or_ones, %xor_zero, %xor_self : i32, i32, i32, i32, i32, i32, i32, i32
@@ -16,10 +16,10 @@ func.def @bitwise_identities(%x: i32) -> (i32, i32, i32, i32, i32, i32, i32, i32
 
 // ----
 func.def @bitwise_identities(%x: i32) -> (i32, i32, i32, i32, i32, i32, i32, i32) {
-  %ones = scalar.constant -1 : i32
+  %all_bits_set = scalar.constant -1 : i32
   %and_zero = scalar.constant 0 : i32
   %xor_self = scalar.constant 0 : i32
-  func.return %x, %and_zero, %x, %x, %x, %ones, %x, %xor_self : i32, i32, i32, i32, i32, i32, i32, i32
+  func.return %x, %and_zero, %x, %x, %x, %all_bits_set, %x, %xor_self : i32, i32, i32, i32, i32, i32, i32, i32
 }
 
 // ====

--- a/loom/src/loom/ops/scalar/test/fold/comparison_structural.loom-test
+++ b/loom/src/loom/ops/scalar/test/fold/comparison_structural.loom-test
@@ -32,16 +32,16 @@ func.def @cmpi_literal_rhs(%x: i32) -> (i1) {
 
 // Unsigned comparisons against zero collapse to constants or equality tests.
 func.def @cmpi_unsigned_zero(%x: i32) -> (i1, i1) {
-  %zero = scalar.constant 0 : i32
-  %lt = scalar.cmpi ult, %x, %zero : i32
-  %gt = scalar.cmpi ugt, %x, %zero : i32
+  %c0 = scalar.constant 0 : i32
+  %lt = scalar.cmpi ult, %x, %c0 : i32
+  %gt = scalar.cmpi ugt, %x, %c0 : i32
   func.return %lt, %gt : i1, i1
 }
 // ----
 func.def @cmpi_unsigned_zero(%x: i32) -> (i1, i1) {
-  %zero = scalar.constant 0 : i32
+  %c0 = scalar.constant 0 : i32
   %lt = scalar.constant false : i1
-  %gt = scalar.cmpi ne, %x, %zero : i32
+  %gt = scalar.cmpi ne, %x, %c0 : i32
   func.return %lt, %gt : i1, i1
 }
 

--- a/loom/src/loom/ops/scalar/test/fold/mathf_structural.loom-test
+++ b/loom/src/loom/ops/scalar/test/fold/mathf_structural.loom-test
@@ -75,22 +75,22 @@ func.def @activation_exact_zero() -> (f32, f32, f32, f32, f32, f32) {
 // of collapsing through an overflowing exp(-x) intermediate.
 func.def @activation_negative_tail() -> (i1, i1, i1, i1, i1, i1) {
   %f32_input = scalar.constant -100.0 : f32
-  %f32_zero = scalar.constant 0.0 : f32
+  %f32_sign_threshold = scalar.constant 0.0 : f32
   %f32_logistic = scalar.logisticf %f32_input : f32
   %f32_silu = scalar.siluf %f32_input : f32
   %f32_gelu = scalar.geluf<logistic> %f32_input {scale = 1.0} : f32
-  %f32_logistic_positive = scalar.cmpf ogt, %f32_logistic, %f32_zero : f32
-  %f32_silu_negative = scalar.cmpf olt, %f32_silu, %f32_zero : f32
-  %f32_gelu_negative = scalar.cmpf olt, %f32_gelu, %f32_zero : f32
+  %f32_logistic_positive = scalar.cmpf ogt, %f32_logistic, %f32_sign_threshold : f32
+  %f32_silu_negative = scalar.cmpf olt, %f32_silu, %f32_sign_threshold : f32
+  %f32_gelu_negative = scalar.cmpf olt, %f32_gelu, %f32_sign_threshold : f32
 
   %f64_input = scalar.constant -710.0 : f64
-  %f64_zero = scalar.constant 0.0 : f64
+  %f64_sign_threshold = scalar.constant 0.0 : f64
   %f64_logistic = scalar.logisticf %f64_input : f64
   %f64_silu = scalar.siluf %f64_input : f64
   %f64_gelu = scalar.geluf<logistic> %f64_input {scale = 1.0} : f64
-  %f64_logistic_positive = scalar.cmpf ogt, %f64_logistic, %f64_zero : f64
-  %f64_silu_negative = scalar.cmpf olt, %f64_silu, %f64_zero : f64
-  %f64_gelu_negative = scalar.cmpf olt, %f64_gelu, %f64_zero : f64
+  %f64_logistic_positive = scalar.cmpf ogt, %f64_logistic, %f64_sign_threshold : f64
+  %f64_silu_negative = scalar.cmpf olt, %f64_silu, %f64_sign_threshold : f64
+  %f64_gelu_negative = scalar.cmpf olt, %f64_gelu, %f64_sign_threshold : f64
   func.return %f32_logistic_positive, %f32_silu_negative, %f32_gelu_negative, %f64_logistic_positive, %f64_silu_negative, %f64_gelu_negative : i1, i1, i1, i1, i1, i1
 }
 // ----

--- a/loom/src/loom/ops/scalar/test/fold/mathf_structural.loom-test
+++ b/loom/src/loom/ops/scalar/test/fold/mathf_structural.loom-test
@@ -19,12 +19,12 @@ func.def @rounding_chain(%x: f32) -> (f32, f32) {
 
 // powf handles structural exponent identities without requiring exact lhs.
 func.def @powf_special_exponents(%x: f32) -> (f32, f32, f32) {
-  %zero = scalar.constant 0.0 : f32
-  %one = scalar.constant 1.0 : f32
-  %two = scalar.constant 2.0 : f32
-  %pow0 = scalar.powf %x, %zero : f32
-  %pow1 = scalar.powf %x, %one : f32
-  %pow2 = scalar.powf<nnan|ninf|nsz> %x, %two : f32
+  %c0 = scalar.constant 0.0 : f32
+  %c1 = scalar.constant 1.0 : f32
+  %c2 = scalar.constant 2.0 : f32
+  %pow0 = scalar.powf %x, %c0 : f32
+  %pow1 = scalar.powf %x, %c1 : f32
+  %pow2 = scalar.powf<nnan|ninf|nsz> %x, %c2 : f32
   func.return %pow0, %pow1, %pow2 : f32, f32, f32
 }
 // ----
@@ -48,13 +48,13 @@ func.def @log_exp_keeps_domain_and_overflow_semantics(%x: f32) -> (f32) {
 // Semantic activation facts fold exact constants without erasing the named op
 // surface for dynamic values.
 func.def @activation_exact_zero() -> (f32, f32, f32, f32, f32, f32) {
-  %zero = scalar.constant 0.0 : f32
-  %logistic = scalar.logisticf %zero : f32
-  %silu = scalar.siluf %zero : f32
-  %softplus = scalar.softplusf %zero : f32
-  %gelu_erf = scalar.geluf<erf> %zero : f32
-  %gelu_tanh = scalar.geluf<tanh> %zero : f32
-  %gelu_logistic = scalar.geluf<logistic> %zero {scale = 1.702} : f32
+  %c0 = scalar.constant 0.0 : f32
+  %logistic = scalar.logisticf %c0 : f32
+  %silu = scalar.siluf %c0 : f32
+  %softplus = scalar.softplusf %c0 : f32
+  %gelu_erf = scalar.geluf<erf> %c0 : f32
+  %gelu_tanh = scalar.geluf<tanh> %c0 : f32
+  %gelu_logistic = scalar.geluf<logistic> %c0 {scale = 1.702} : f32
   func.return %logistic, %silu, %softplus, %gelu_erf, %gelu_tanh, %gelu_logistic : f32, f32, f32, f32, f32, f32
 }
 
@@ -108,10 +108,10 @@ func.def @activation_negative_tail() -> (i1, i1, i1, i1, i1, i1) {
 
 // Turn-domain trig facts fold exact turns directly.
 func.def @turn_trig_exact_quadrants() -> (f32, f32, f32, f32) {
-  %zero = scalar.constant 0.0 : f32
+  %c0 = scalar.constant 0.0 : f32
   %quarter = scalar.constant 0.25 : f32
-  %sin_zero = scalar.sinturnsf %zero : f32
-  %cos_zero = scalar.costurnsf %zero : f32
+  %sin_zero = scalar.sinturnsf %c0 : f32
+  %cos_zero = scalar.costurnsf %c0 : f32
   %sin_quarter = scalar.sinturnsf %quarter : f32
   %cos_quarter = scalar.costurnsf %quarter : f32
   func.return %sin_zero, %cos_zero, %sin_quarter, %cos_quarter : f32, f32, f32, f32

--- a/loom/src/loom/ops/scf/test/canonicalize.loom-test
+++ b/loom/src/loom/ops/scf/test/canonicalize.loom-test
@@ -29,9 +29,9 @@ func.def @if_false_keeps_selected_store(%buffer: buffer, %offset: offset, %value
   %layout = encoding.layout.dense : encoding<layout>
   %view = buffer.view %buffer[%offset] : buffer -> view<1xf32, %layout>
   %cond = scalar.constant false : i1
-  %zero = scalar.constant 0.0 : f32
+  %c0 = scalar.constant 0.0 : f32
   scf.if %cond {
-    view.store %zero, %view[0] : f32, view<1xf32, %layout>
+    view.store %c0, %view[0] : f32, view<1xf32, %layout>
     scf.yield
   } else {
     view.store %value, %view[0] : f32, view<1xf32, %layout>
@@ -57,19 +57,19 @@ func.def @if_prunes_from_signed_index_range(%x: index, %y: index) -> (index) {
   %hi = index.assume %y [range(%y, 8, 16)] : index
   %cond = index.cmp slt, %lo, %hi : index
   %result = scf.if %cond -> (index) {
-    %one = index.constant 1 : index
-    scf.yield %one : index
+    %c1 = index.constant 1 : index
+    scf.yield %c1 : index
   } else {
-    %two = index.constant 2 : index
-    scf.yield %two : index
+    %c2 = index.constant 2 : index
+    scf.yield %c2 : index
   }
   func.return %result : index
 }
 
 // ----
 func.def @if_prunes_from_signed_index_range(%x: index, %y: index) -> (index) {
-  %one = index.constant 1 : index
-  func.return %one : index
+  %c1 = index.constant 1 : index
+  func.return %c1 : index
 }
 
 // ====
@@ -81,19 +81,19 @@ func.def @if_prunes_from_unsigned_index_range(%x: index, %y: index) -> (index) {
   %hi = index.assume %y [range(%y, 8, 16)] : index
   %cond = index.cmp ugt, %lo, %hi : index
   %result = scf.if %cond -> (index) {
-    %one = index.constant 1 : index
-    scf.yield %one : index
+    %c1 = index.constant 1 : index
+    scf.yield %c1 : index
   } else {
-    %two = index.constant 2 : index
-    scf.yield %two : index
+    %c2 = index.constant 2 : index
+    scf.yield %c2 : index
   }
   func.return %result : index
 }
 
 // ----
 func.def @if_prunes_from_unsigned_index_range(%x: index, %y: index) -> (index) {
-  %two = index.constant 2 : index
-  func.return %two : index
+  %c2 = index.constant 2 : index
+  func.return %c2 : index
 }
 
 // ====
@@ -105,11 +105,11 @@ func.def @if_preserves_inconclusive_unsigned_cmp(%x: index, %y: index) -> (index
   %positive = index.assume %y [range(%y, 8, 16)] : index
   %cond = index.cmp ult, %maybe_negative, %positive : index
   %result = scf.if %cond -> (index) {
-    %one = index.constant 1 : index
-    scf.yield %one : index
+    %c1 = index.constant 1 : index
+    scf.yield %c1 : index
   } else {
-    %two = index.constant 2 : index
-    scf.yield %two : index
+    %c2 = index.constant 2 : index
+    scf.yield %c2 : index
   }
   func.return %result : index
 }
@@ -119,9 +119,9 @@ func.def @if_preserves_inconclusive_unsigned_cmp(%x: index, %y: index) -> (index
   %maybe_negative = index.assume %x [range(%x, -4, 4)] : index
   %positive = index.assume %y [range(%y, 8, 16)] : index
   %cond = index.cmp ult, %maybe_negative, %positive : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %result = scf.select %cond, %one, %two : index
+  %c1 = index.constant 1 : index
+  %c2 = index.constant 2 : index
+  %result = scf.select %cond, %c1, %c2 : index
   func.return %result : index
 }
 
@@ -227,8 +227,8 @@ func.def @if_edge_rewrites_view_type_reference(%buffer: buffer, %offset: offset,
     %loaded = view.load %view[0] : view<[%n]xf32, %layout> -> f32
     scf.yield %loaded : f32
   } else {
-    %zero = scalar.constant 0.0 : f32
-    scf.yield %zero : f32
+    %c0 = scalar.constant 0.0 : f32
+    scf.yield %c0 : f32
   }
   func.return %result : f32
 }
@@ -243,8 +243,8 @@ func.def @if_edge_rewrites_view_type_reference(%buffer: buffer, %offset: offset,
     %loaded = view.load %view[0] : view<[%11]xf32, %layout> -> f32
     scf.yield %loaded : f32
   } else {
-    %zero = scalar.constant 0.0 : f32
-    scf.yield %zero : f32
+    %c0 = scalar.constant 0.0 : f32
+    scf.yield %c0 : f32
   }
   func.return %result : f32
 }
@@ -286,8 +286,8 @@ func.def @if_edge_rewrites_precast_index_reference(%buffer: buffer, %offset: off
   %layout = encoding.layout.dense : encoding<layout>
   %row_idx = index.cast %row : i32 to index
   %n_idx = index.cast %n : i32 to index
-  %zero = scalar.constant 0 : i32
-  %nonnegative = scalar.cmpi sge, %row, %zero : i32
+  %c0 = scalar.constant 0 : i32
+  %nonnegative = scalar.cmpi sge, %row, %c0 : i32
   %below = scalar.cmpi slt, %row, %n : i32
   %guard = scalar.andi %nonnegative, %below : i1
   scf.if %guard {
@@ -306,8 +306,8 @@ func.def @if_edge_rewrites_precast_index_reference(%buffer: buffer, %offset: off
   %layout = encoding.layout.dense : encoding<layout>
   %row_idx = index.cast %row : i32 to index
   %n_idx = index.cast %n : i32 to index
-  %zero = scalar.constant 0 : i32
-  %nonnegative = scalar.cmpi sge, %row, %zero : i32
+  %c0 = scalar.constant 0 : i32
+  %nonnegative = scalar.cmpi sge, %row, %c0 : i32
   %below = scalar.cmpi slt, %row, %n : i32
   %guard = scalar.andi %nonnegative, %below : i1
   scf.if %guard {
@@ -953,9 +953,9 @@ func.def @for_single_trip_resultless_inlines_effect(%buffer: buffer, %offset: of
   %lo = index.constant 3 : index
   %hi = index.constant 4 : index
   %step = index.constant 1 : index
-  %zero = index.constant 0 : index
+  %c0 = index.constant 0 : index
   scf.for %iv = [%lo to %hi step %step] {
-    %addr = index.add %iv, %zero : index
+    %addr = index.add %iv, %c0 : index
     view.store %value, %view[%addr] : f32, view<16xf32, %layout>
     scf.yield
   }
@@ -1402,8 +1402,8 @@ func.def @switch_with_body_preserved(%variant: index, %a: index, %b: index, %fal
 func.def @switch_case_edge_relation_folds_inside_region(%variant: index) -> (i1) {
   %result = scf.switch %variant -> (i1) {
     case 0 {
-      %zero = index.constant 0 : index
-      %known = index.cmp eq, %variant, %zero : index
+      %c0 = index.constant 0 : index
+      %known = index.cmp eq, %variant, %c0 : index
       scf.yield %known : i1
     }
     default {
@@ -1440,8 +1440,8 @@ func.def @switch_default_edge_relations_fold_inside_region(%variant: index) -> (
       scf.yield %false : i1
     }
     default {
-      %zero = index.constant 0 : index
-      %known = index.cmp ne, %variant, %zero : index
+      %c0 = index.constant 0 : index
+      %known = index.cmp ne, %variant, %c0 : index
       scf.yield %known : i1
     }
   }

--- a/loom/src/loom/ops/scf/test/facts.loom-test
+++ b/loom/src/loom/ops/scf/test/facts.loom-test
@@ -6,8 +6,8 @@ func.def @for_iv_static_bounds() -> (i64, i64, i64) {
   %lo = index.constant 4 : index
   %hi = index.constant 12 : index
   %step = index.constant 2 : index
-  %zero = scalar.constant 0 : i64
-  %iv_lo, %iv_hi, %iv_div = scf.for %iv = [%lo to %hi step %step](%carry_lo = %zero : i64, %carry_hi = %zero : i64, %carry_div = %zero : i64) -> (i64, i64, i64) {
+  %c0 = scalar.constant 0 : i64
+  %iv_lo, %iv_hi, %iv_div = scf.for %iv = [%lo to %hi step %step](%carry_lo = %c0 : i64, %carry_hi = %c0 : i64, %carry_div = %c0 : i64) -> (i64, i64, i64) {
     %fact_lo = test.fact_range_lo %iv : index -> i64
     %fact_hi = test.fact_range_hi %iv : index -> i64
     %fact_div = test.fact_divisor %iv : index -> i64
@@ -21,8 +21,8 @@ func.def @for_iv_static_bounds() -> (i64, i64, i64) {
   %lo = index.constant 4 : index
   %hi = index.constant 12 : index
   %step = index.constant 2 : index
-  %zero = scalar.constant 0 : i64
-  %iv_lo, %iv_hi, %iv_div = scf.for %iv = [%lo to %hi step %step](%carry_lo = %zero : i64, %carry_hi = %zero : i64, %carry_div = %zero : i64) -> (i64, i64, i64) {
+  %c0 = scalar.constant 0 : i64
+  %iv_lo, %iv_hi, %iv_div = scf.for %iv = [%lo to %hi step %step](%carry_lo = %c0 : i64, %carry_hi = %c0 : i64, %carry_div = %c0 : i64) -> (i64, i64, i64) {
     %fact_lo = scalar.constant 4 : i64
     %fact_hi = scalar.constant 10 : i64
     %fact_div = scalar.constant 2 : i64
@@ -39,9 +39,9 @@ func.def @for_iv_assumed_upper_bound(%n: index) -> (i64, i64, i64, i1) {
   %lo = index.constant 0 : index
   %n2 = index.assume %n [range(%n, 16, 64)] : index
   %step = index.constant 4 : index
-  %zero = scalar.constant 0 : i64
+  %c0 = scalar.constant 0 : i64
   %false = scalar.constant false : i1
-  %iv_lo, %iv_hi, %iv_div, %iv_non_negative = scf.for %iv = [%lo to %n2 step %step](%carry_lo = %zero : i64, %carry_hi = %zero : i64, %carry_div = %zero : i64, %carry_non_negative = %false : i1) -> (i64, i64, i64, i1) {
+  %iv_lo, %iv_hi, %iv_div, %iv_non_negative = scf.for %iv = [%lo to %n2 step %step](%carry_lo = %c0 : i64, %carry_hi = %c0 : i64, %carry_div = %c0 : i64, %carry_non_negative = %false : i1) -> (i64, i64, i64, i1) {
     %fact_lo = test.fact_range_lo %iv : index -> i64
     %fact_hi = test.fact_range_hi %iv : index -> i64
     %fact_div = test.fact_divisor %iv : index -> i64
@@ -56,9 +56,9 @@ func.def @for_iv_assumed_upper_bound(%n: index) -> (i64, i64, i64, i1) {
   %lo = index.constant 0 : index
   %n2 = index.assume %n [range(%n, 16, 64)] : index
   %step = index.constant 4 : index
-  %zero = scalar.constant 0 : i64
+  %c0 = scalar.constant 0 : i64
   %false = scalar.constant false : i1
-  %iv_lo, %iv_hi, %iv_div, %iv_non_negative = scf.for %iv = [%lo to %n2 step %step](%carry_lo = %zero : i64, %carry_hi = %zero : i64, %carry_div = %zero : i64, %carry_non_negative = %false : i1) -> (i64, i64, i64, i1) {
+  %iv_lo, %iv_hi, %iv_div, %iv_non_negative = scf.for %iv = [%lo to %n2 step %step](%carry_lo = %c0 : i64, %carry_hi = %c0 : i64, %carry_div = %c0 : i64, %carry_non_negative = %false : i1) -> (i64, i64, i64, i1) {
     %fact_lo = scalar.constant 0 : i64
     %fact_hi = scalar.constant 60 : i64
     %fact_div = scalar.constant 4 : i64
@@ -79,9 +79,9 @@ func.def @for_iv_matvec_lane_address_range(%lane0: index) -> (i64, i64, i1) {
   %block_step = index.constant 4 : index
   %lanes_per_group = index.constant 16 : index
   %block_stride = index.constant 105 : index
-  %zero = scalar.constant 0 : i64
+  %c0 = scalar.constant 0 : i64
   %false = scalar.constant false : i1
-  %linear_lo, %linear_hi, %linear_non_negative = scf.for %block_base = [%block_begin to %block_end step %block_step](%carry_lo = %zero : i64, %carry_hi = %zero : i64, %carry_non_negative = %false : i1) -> (i64, i64, i1) {
+  %linear_lo, %linear_hi, %linear_non_negative = scf.for %block_base = [%block_begin to %block_end step %block_step](%carry_lo = %c0 : i64, %carry_hi = %c0 : i64, %carry_non_negative = %false : i1) -> (i64, i64, i1) {
     %lane_group = index.div %lane, %lanes_per_group : index
     %lane_offset = index.rem %lane, %lanes_per_group : index
     %block = index.add %block_base, %lane_group : index
@@ -100,9 +100,9 @@ func.def @for_iv_matvec_lane_address_range(%lane0: index) -> (i64, i64, i1) {
   %block_begin = index.constant 0 : index
   %block_end = index.constant 12 : index
   %block_step = index.constant 4 : index
-  %zero = scalar.constant 0 : i64
+  %c0 = scalar.constant 0 : i64
   %false = scalar.constant false : i1
-  %linear_lo, %linear_hi, %linear_non_negative = scf.for %block_base = [%block_begin to %block_end step %block_step](%carry_lo = %zero : i64, %carry_hi = %zero : i64, %carry_non_negative = %false : i1) -> (i64, i64, i1) {
+  %linear_lo, %linear_hi, %linear_non_negative = scf.for %block_base = [%block_begin to %block_end step %block_step](%carry_lo = %c0 : i64, %carry_hi = %c0 : i64, %carry_non_negative = %false : i1) -> (i64, i64, i1) {
     %fact_lo = scalar.constant 0 : i64
     %fact_hi = scalar.constant 1170 : i64
     %fact_non_negative = scalar.constant true : i1
@@ -119,8 +119,8 @@ func.def @for_iv_projection_pair_origins() -> (i64, i64, i64) {
   %start = index.constant 0 : index
   %limit = index.constant 3584 : index
   %step = index.constant 2 : index
-  %zero = scalar.constant 0 : i64
-  %iv_lo, %iv_hi, %iv_div = scf.for %origin = [%start to %limit step %step](%carry_lo = %zero : i64, %carry_hi = %zero : i64, %carry_div = %zero : i64) -> (i64, i64, i64) {
+  %c0 = scalar.constant 0 : i64
+  %iv_lo, %iv_hi, %iv_div = scf.for %origin = [%start to %limit step %step](%carry_lo = %c0 : i64, %carry_hi = %c0 : i64, %carry_div = %c0 : i64) -> (i64, i64, i64) {
     %fact_lo = test.fact_range_lo %origin : index -> i64
     %fact_hi = test.fact_range_hi %origin : index -> i64
     %fact_div = test.fact_divisor %origin : index -> i64
@@ -134,8 +134,8 @@ func.def @for_iv_projection_pair_origins() -> (i64, i64, i64) {
   %start = index.constant 0 : index
   %limit = index.constant 3584 : index
   %step = index.constant 2 : index
-  %zero = scalar.constant 0 : i64
-  %iv_lo, %iv_hi, %iv_div = scf.for %origin = [%start to %limit step %step](%carry_lo = %zero : i64, %carry_hi = %zero : i64, %carry_div = %zero : i64) -> (i64, i64, i64) {
+  %c0 = scalar.constant 0 : i64
+  %iv_lo, %iv_hi, %iv_div = scf.for %origin = [%start to %limit step %step](%carry_lo = %c0 : i64, %carry_hi = %c0 : i64, %carry_div = %c0 : i64) -> (i64, i64, i64) {
     %fact_lo = scalar.constant 0 : i64
     %fact_hi = scalar.constant 3582 : i64
     %fact_div = scalar.constant 2 : i64
@@ -152,8 +152,8 @@ func.def @for_iv_single_trip_exact() -> (i64, i64, i64) {
   %lo = index.constant 8 : index
   %hi = index.constant 12 : index
   %step = index.constant 4 : index
-  %zero = scalar.constant 0 : i64
-  %iv_lo, %iv_hi, %iv_div = scf.for %iv = [%lo to %hi step %step](%carry_lo = %zero : i64, %carry_hi = %zero : i64, %carry_div = %zero : i64) -> (i64, i64, i64) {
+  %c0 = scalar.constant 0 : i64
+  %iv_lo, %iv_hi, %iv_div = scf.for %iv = [%lo to %hi step %step](%carry_lo = %c0 : i64, %carry_hi = %c0 : i64, %carry_div = %c0 : i64) -> (i64, i64, i64) {
     %fact_lo = test.fact_range_lo %iv : index -> i64
     %fact_hi = test.fact_range_hi %iv : index -> i64
     %fact_div = test.fact_divisor %iv : index -> i64
@@ -178,12 +178,12 @@ func.def @for_iv_feeds_index_consumers() -> (index, i1) {
   %lo = index.constant 8 : index
   %hi = index.constant 12 : index
   %step = index.constant 4 : index
-  %zero = index.constant 0 : index
+  %c0 = index.constant 0 : index
   %false = scalar.constant false : i1
-  %sum, %is_before_limit = scf.for %iv = [%lo to %hi step %step](%carry_sum = %zero : index, %carry_cmp = %false : i1) -> (index, i1) {
-    %two = index.constant 2 : index
+  %sum, %is_before_limit = scf.for %iv = [%lo to %hi step %step](%carry_sum = %c0 : index, %carry_cmp = %false : i1) -> (index, i1) {
+    %c2 = index.constant 2 : index
     %limit = index.constant 12 : index
-    %plus = index.add %iv, %two : index
+    %plus = index.add %iv, %c2 : index
     %cmp = index.cmp slt, %iv, %limit : index
     scf.yield %plus, %cmp : index, i1
   }
@@ -204,8 +204,8 @@ func.def @for_iv_feeds_index_consumers() -> (index, i1) {
 func.def @for_iv_unknown_step_is_unknown(%step: index) -> (i64, i64, i64) {
   %lo = index.constant 0 : index
   %hi = index.constant 16 : index
-  %zero = scalar.constant 0 : i64
-  %iv_lo, %iv_hi, %iv_div = scf.for %iv = [%lo to %hi step %step](%carry_lo = %zero : i64, %carry_hi = %zero : i64, %carry_div = %zero : i64) -> (i64, i64, i64) {
+  %c0 = scalar.constant 0 : i64
+  %iv_lo, %iv_hi, %iv_div = scf.for %iv = [%lo to %hi step %step](%carry_lo = %c0 : i64, %carry_hi = %c0 : i64, %carry_div = %c0 : i64) -> (i64, i64, i64) {
     %fact_lo = test.fact_range_lo %iv : index -> i64
     %fact_hi = test.fact_range_hi %iv : index -> i64
     %fact_div = test.fact_divisor %iv : index -> i64
@@ -218,8 +218,8 @@ func.def @for_iv_unknown_step_is_unknown(%step: index) -> (i64, i64, i64) {
 func.def @for_iv_unknown_step_is_unknown(%step: index) -> (i64, i64, i64) {
   %lo = index.constant 0 : index
   %hi = index.constant 16 : index
-  %zero = scalar.constant 0 : i64
-  %iv_lo, %iv_hi, %iv_div = scf.for %iv = [%lo to %hi step %step](%carry_lo = %zero : i64, %carry_hi = %zero : i64, %carry_div = %zero : i64) -> (i64, i64, i64) {
+  %c0 = scalar.constant 0 : i64
+  %iv_lo, %iv_hi, %iv_div = scf.for %iv = [%lo to %hi step %step](%carry_lo = %c0 : i64, %carry_hi = %c0 : i64, %carry_div = %c0 : i64) -> (i64, i64, i64) {
     %fact_lo = scalar.constant -9223372036854775808 : i64
     %fact_hi = scalar.constant 9223372036854775807 : i64
     %fact_div = scalar.constant 1 : i64
@@ -236,9 +236,9 @@ func.def @for_iter_arg_facts_reach_body(%n: index) -> (i64) {
   %lo = index.constant 0 : index
   %n2 = index.assume %n [range(%n, 1, 4)] : index
   %step = index.constant 1 : index
-  %seven = scalar.constant 7 : i64
-  %zero = scalar.constant 0 : i64
-  %forwarded, %observed = scf.for %iv = [%lo to %n2 step %step](%acc = %seven : i64, %prev = %zero : i64) -> (i64, i64) {
+  %c7 = scalar.constant 7 : i64
+  %c0 = scalar.constant 0 : i64
+  %forwarded, %observed = scf.for %iv = [%lo to %n2 step %step](%acc = %c7 : i64, %prev = %c0 : i64) -> (i64, i64) {
     %body_lo = test.fact_range_lo %acc : i64 -> i64
     scf.yield %acc, %body_lo : i64, i64
   }
@@ -250,8 +250,8 @@ func.def @for_iter_arg_facts_reach_body(%n: index) -> (i64) {
   %lo = index.constant 0 : index
   %n2 = index.assume %n [range(%n, 1, 4)] : index
   %step = index.constant 1 : index
-  %zero = scalar.constant 0 : i64
-  %observed = scf.for %iv = [%lo to %n2 step %step](%prev = %zero : i64) -> (i64) {
+  %c0 = scalar.constant 0 : i64
+  %observed = scf.for %iv = [%lo to %n2 step %step](%prev = %c0 : i64) -> (i64) {
     %body_lo = scalar.constant 7 : i64
     scf.yield %body_lo : i64
   }
@@ -266,8 +266,8 @@ func.def @for_may_zero_result_uses_loop_summary(%n: index) -> (i64) {
   %lo = index.constant 0 : index
   %n2 = index.assume %n [range(%n, 0, 4)] : index
   %step = index.constant 1 : index
-  %seven = scalar.constant 7 : i64
-  %observed = scf.for %iv = [%lo to %n2 step %step](%acc = %seven : i64) -> (i64) {
+  %c7 = scalar.constant 7 : i64
+  %observed = scf.for %iv = [%lo to %n2 step %step](%acc = %c7 : i64) -> (i64) {
     %body_lo = test.fact_range_lo %acc : i64 -> i64
     scf.yield %body_lo : i64
   }
@@ -289,10 +289,10 @@ func.def @for_zero_trip_result_is_init() -> (i64) {
   %lo = index.constant 8 : index
   %hi = index.constant 4 : index
   %step = index.constant 1 : index
-  %seven = scalar.constant 7 : i64
-  %forty_two = scalar.constant 42 : i64
-  %observed = scf.for %iv = [%lo to %hi step %step](%acc = %seven : i64) -> (i64) {
-    scf.yield %forty_two : i64
+  %c7 = scalar.constant 7 : i64
+  %c42 = scalar.constant 42 : i64
+  %observed = scf.for %iv = [%lo to %hi step %step](%acc = %c7 : i64) -> (i64) {
+    scf.yield %c42 : i64
   }
   %result_lo = test.fact_range_lo %observed : i64 -> i64
   func.return %result_lo : i64
@@ -312,10 +312,10 @@ func.def @for_arithmetic_carried_widens_to_unknown(%n: index) -> (i64, i64) {
   %lo = index.constant 0 : index
   %n2 = index.assume %n [range(%n, 0, 4)] : index
   %step = index.constant 1 : index
-  %zero = scalar.constant 0 : i64
-  %one = scalar.constant 1 : i64
-  %observed = scf.for %iv = [%lo to %n2 step %step](%acc = %zero : i64) -> (i64) {
-    %next = scalar.addi %acc, %one : i64
+  %c0 = scalar.constant 0 : i64
+  %c1 = scalar.constant 1 : i64
+  %observed = scf.for %iv = [%lo to %n2 step %step](%acc = %c0 : i64) -> (i64) {
+    %next = scalar.addi %acc, %c1 : i64
     scf.yield %next : i64
   }
   %result_lo = test.fact_range_lo %observed : i64 -> i64
@@ -335,8 +335,8 @@ func.def @for_arithmetic_carried_widens_to_unknown(%n: index) -> (i64, i64) {
 // The same loop-like summary path handles condition-region loops. The carried
 // value is forwarded unchanged through both the false exit and true body paths.
 func.def @while_unchanged_carried_result(%keep_going: i1) -> (i64) {
-  %nine = scalar.constant 9 : i64
-  %result = scf.while(%before = %nine : i64) -> (i64) {
+  %c9 = scalar.constant 9 : i64
+  %result = scf.while(%before = %c9 : i64) -> (i64) {
     scf.condition %keep_going, %before : i1, i64
   } do(%body: i64) {
     scf.yield %body : i64
@@ -361,8 +361,8 @@ kernel.def @select_lane_predicate_different_values_is_varying() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%lhs: i32, %rhs: i32) {
   %lane = kernel.subgroup.lane.id : index
-  %zero = index.constant 0 : index
-  %condition = index.cmp eq, %lane, %zero : index
+  %c0 = index.constant 0 : index
+  %condition = index.cmp eq, %lane, %c0 : index
   %selected = scf.select %condition, %lhs, %rhs : i32
   %selected_is_varying = test.fact_lane_varying %selected : i32 -> i1
   %selected_is_uniform = test.fact_subgroup_uniform %selected : i32 -> i1
@@ -391,8 +391,8 @@ kernel.def @select_lane_predicate_boolean_result_is_predicate() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%lhs: i1, %rhs: i1) {
   %lane = kernel.subgroup.lane.id : index
-  %zero = index.constant 0 : index
-  %condition = index.cmp eq, %lane, %zero : index
+  %c0 = index.constant 0 : index
+  %condition = index.cmp eq, %lane, %c0 : index
   %selected = scf.select %condition, %lhs, %rhs : i1
   %selected_is_predicate = test.fact_lane_predicate %selected : i1 -> i1
   %selected_is_uniform = test.fact_subgroup_uniform %selected : i1 -> i1
@@ -505,12 +505,12 @@ func.def @lookup_facts_prune_by_divisor(%variant: index) -> (i64, i64) {
 // 1660 rather than the interval-only upper bound of 2044.
 func.def @for_iv_ranged_lower_constant_trip_count(%lane0: index) -> (i64, i64, i64) {
   %lane = index.assume %lane0 [range(%lane0, 0, 31)] : index
-  %four = index.constant 4 : index
-  %lane_channel = index.mul %lane, %four : index
+  %c4 = index.constant 4 : index
+  %lane_channel = index.mul %lane, %c4 : index
   %limit = index.constant 2048 : index
   %step = index.constant 512 : index
-  %zero = scalar.constant 0 : i64
-  %iv_lo, %iv_hi, %iv_div = scf.for %channel = [%lane_channel to %limit step %step](%carry_lo = %zero : i64, %carry_hi = %zero : i64, %carry_div = %zero : i64) -> (i64, i64, i64) {
+  %c0 = scalar.constant 0 : i64
+  %iv_lo, %iv_hi, %iv_div = scf.for %channel = [%lane_channel to %limit step %step](%carry_lo = %c0 : i64, %carry_hi = %c0 : i64, %carry_div = %c0 : i64) -> (i64, i64, i64) {
     %fact_lo = test.fact_range_lo %channel : index -> i64
     %fact_hi = test.fact_range_hi %channel : index -> i64
     %fact_div = test.fact_divisor %channel : index -> i64
@@ -522,12 +522,12 @@ func.def @for_iv_ranged_lower_constant_trip_count(%lane0: index) -> (i64, i64, i
 // ----
 func.def @for_iv_ranged_lower_constant_trip_count(%lane0: index) -> (i64, i64, i64) {
   %lane = index.assume %lane0 [range(%lane0, 0, 31)] : index
-  %four = index.constant 4 : index
-  %lane_channel = index.mul %lane, %four : index
+  %c4 = index.constant 4 : index
+  %lane_channel = index.mul %lane, %c4 : index
   %limit = index.constant 2048 : index
   %step = index.constant 512 : index
-  %zero = scalar.constant 0 : i64
-  %iv_lo, %iv_hi, %iv_div = scf.for %channel = [%lane_channel to %limit step %step](%carry_lo = %zero : i64, %carry_hi = %zero : i64, %carry_div = %zero : i64) -> (i64, i64, i64) {
+  %c0 = scalar.constant 0 : i64
+  %iv_lo, %iv_hi, %iv_div = scf.for %channel = [%lane_channel to %limit step %step](%carry_lo = %c0 : i64, %carry_hi = %c0 : i64, %carry_div = %c0 : i64) -> (i64, i64, i64) {
     %fact_lo = scalar.constant 0 : i64
     %fact_hi = scalar.constant 1660 : i64
     %fact_div = scalar.constant 4 : i64

--- a/loom/src/loom/ops/scf/test/verify.loom-test
+++ b/loom/src/loom/ops/scf/test/verify.loom-test
@@ -109,11 +109,11 @@ func.def @if_result_missing_else(%cond: i1, %a: i32) -> (i32) {
 // forwarding rule as scf.yield. The init view is tied to the init layout, while
 // the loop result view is tied to the sibling loop result layout.
 func.def @for_iter_arg_result_type_refs_forwarded_results(%n: index, %buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %base_layout = encoding.layout.dense : encoding<layout>
   %base_view = buffer.view %buffer[%offset] : buffer -> view<4xf32, %base_layout>
-  %layout, %view = scf.for %i = [%zero to %n step %one](%layout_acc = %base_layout : encoding<layout>, %view_acc = %base_view : view<4xf32, %base_layout>) -> (encoding<layout>, view<4xf32, %layout>) {
+  %layout, %view = scf.for %i = [%loop_begin to %n step %loop_step](%layout_acc = %base_layout : encoding<layout>, %view_acc = %base_view : view<4xf32, %base_layout>) -> (encoding<layout>, view<4xf32, %layout>) {
     %next_layout = encoding.layout.dense : encoding<layout>
     %next_view = buffer.view %buffer[%offset] : buffer -> view<4xf32, %next_layout>
     scf.yield %next_layout, %next_view : encoding<layout>, view<4xf32, %next_layout>

--- a/loom/src/loom/ops/vector/test/block_quant_canonicalize.loom-test
+++ b/loom/src/loom/ops/vector/test/block_quant_canonicalize.loom-test
@@ -142,8 +142,8 @@ func.def @q8_0_dense_activation_dot_folds() -> (i1) {
   %activation = vector.from_elements %a0, %a1, %a2, %a3 : vector<4xf32>
 
   %products = vector.mulf %decoded, %activation : vector<4xf32>
-  %zero = scalar.constant 0.0 : f32
-  %dot = vector.reduce<addf> %products, %zero : vector<4xf32>, f32
+  %dot_init = scalar.constant 0.0 : f32
+  %dot = vector.reduce<addf> %products, %dot_init : vector<4xf32>, f32
   %expected = scalar.constant 0.875 : f32
   %ok = scalar.cmpf oeq, %dot, %expected : f32
   func.return %ok : i1
@@ -195,9 +195,9 @@ func.def @q8_0_two_row_micro_gemv_folds() -> (f32, f32) {
 
   %row0_products = vector.mulf %row0_decoded, %activation : vector<4xf32>
   %row1_products = vector.mulf %row1_decoded, %activation : vector<4xf32>
-  %zero = scalar.constant 0.0 : f32
-  %row0_dot = vector.reduce<addf> %row0_products, %zero : vector<4xf32>, f32
-  %row1_dot = vector.reduce<addf> %row1_products, %zero : vector<4xf32>, f32
+  %dot_init = scalar.constant 0.0 : f32
+  %row0_dot = vector.reduce<addf> %row0_products, %dot_init : vector<4xf32>, f32
+  %row1_dot = vector.reduce<addf> %row1_products, %dot_init : vector<4xf32>, f32
   func.return %row0_dot, %row1_dot : f32, f32
 }
 // ----
@@ -233,8 +233,8 @@ func.def @q8_0_decoded_pair_dot_reference_folds() -> (f32) {
   %rhs_scale = vector.constant -0.25 : vector<1xf16>
   %lhs = vector.decode %lhs_payload using %schema {scale = %lhs_scale : vector<1xf16>} : vector<4xi8>, encoding<schema> -> vector<4xf32>
   %rhs = vector.decode %rhs_payload using %schema {scale = %rhs_scale : vector<1xf16>} : vector<4xi8>, encoding<schema> -> vector<4xf32>
-  %zero = scalar.constant 0.0 : f32
-  %dot = vector.dotf %lhs, %rhs, %zero : vector<4xf32>, vector<4xf32>, f32
+  %dot_init = scalar.constant 0.0 : f32
+  %dot = vector.dotf %lhs, %rhs, %dot_init : vector<4xf32>, vector<4xf32>, f32
   func.return %dot : f32
 }
 // ----
@@ -313,8 +313,8 @@ func.def @q8_0_decoded_dotf_keeps_strict_float_contract(%lhs_payload: vector<32x
   %schema = encoding.define #ggml_q8_0<block_elems=32, storage_bytes=34> : encoding<schema>
   %lhs = vector.decode %lhs_payload using %schema {scale = %lhs_scale : vector<1xf16>} : vector<32xi8>, encoding<schema> -> vector<32xf32>
   %rhs = vector.decode %rhs_payload using %schema {scale = %rhs_scale : vector<1xf16>} : vector<32xi8>, encoding<schema> -> vector<32xf32>
-  %zero = scalar.constant 0.0 : f32
-  %dot = vector.dotf %lhs, %rhs, %zero : vector<32xf32>, vector<32xf32>, f32
+  %dot_init = scalar.constant 0.0 : f32
+  %dot = vector.dotf %lhs, %rhs, %dot_init : vector<32xf32>, vector<32xf32>, f32
   func.return %dot : f32
 }
 // ----
@@ -331,8 +331,8 @@ func.def @q8_0_decoded_dotf_keeps_strict_float_contract(%lhs_payload: vector<32x
   %13 = vector.bitunpacks<8> %rhs_payload : vector<32xi8> -> vector<32xi32>
   %14 = vector.sitofp %13 : vector<32xi32> to vector<32xf32>
   %rhs = vector.mulf %14, %12 : vector<32xf32>
-  %zero = scalar.constant 0.0 : f32
-  %dot = vector.dotf %lhs, %rhs, %zero : vector<32xf32>, vector<32xf32>, f32
+  %dot_init = scalar.constant 0.0 : f32
+  %dot = vector.dotf %lhs, %rhs, %dot_init : vector<32xf32>, vector<32xf32>, f32
   func.return %dot : f32
 }
 

--- a/loom/src/loom/ops/vector/test/block_quant_samples.loom-test
+++ b/loom/src/loom/ops/vector/test/block_quant_samples.loom-test
@@ -300,8 +300,8 @@ func.def @turboquant_logit_reference(%query: vector<4xf16>, %packed_codes: vecto
   %decoded = vector.table.lookup %centroids[%codes] : vector<4xf16>, vector<4xi8> -> vector<4xf16>
   %q32 = vector.extf %query : vector<4xf16> to vector<4xf32>
   %d32 = vector.extf %decoded : vector<4xf16> to vector<4xf32>
-  %zero = scalar.constant 0.0 : f32
-  %logit = vector.dotf %q32, %d32, %zero : vector<4xf32>, vector<4xf32>, f32
+  %reduction_init = scalar.constant 0.0 : f32
+  %logit = vector.dotf %q32, %d32, %reduction_init : vector<4xf32>, vector<4xf32>, f32
   func.return %logit : f32
 }
 
@@ -370,11 +370,11 @@ func.def @binary_sketch_dot_reference(%lhs_bits: vector<16xi8>, %rhs_bits: vecto
   %diff = vector.xori %lhs_bits, %rhs_bits : vector<16xi8>
   %byte_counts = vector.ctpopi %diff : vector<16xi8>
   %counts = vector.extui %byte_counts : vector<16xi8> to vector<16xi32>
-  %zero = scalar.constant 0 : i32
-  %hamming = vector.reduce<addi> %counts, %zero : vector<16xi32>, i32
-  %two = scalar.constant 2 : i32
+  %reduction_init = scalar.constant 0 : i32
+  %hamming = vector.reduce<addi> %counts, %reduction_init : vector<16xi32>, i32
+  %score_scale = scalar.constant 2 : i32
   %total = scalar.constant 128 : i32
-  %twice_hamming = scalar.muli %hamming, %two : i32
+  %twice_hamming = scalar.muli %hamming, %score_scale : i32
   %dot = scalar.subi %total, %twice_hamming : i32
   func.return %dot : i32
 }

--- a/loom/src/loom/ops/vector/test/canonicalize.loom-test
+++ b/loom/src/loom/ops/vector/test/canonicalize.loom-test
@@ -454,10 +454,10 @@ kernel.def @extract_single_use_workgroup_load_keeps_wide_load() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<4xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<4xi32, #dense>
   %seed = vector.constant 1 : vector<4xi32>
   vector.store %seed, %view[0] : vector<4xi32>, view<4xi32, #dense>
   %wide = vector.load %view[0] : view<4xi32, #dense> -> vector<4xi32>
@@ -923,9 +923,9 @@ func.def @addi_dynamic_zero_identity(%n: index, %x: vector<[%n]xi32>) -> (vector
 // Floating-point subtraction identities require signed-zero freedom and keep
 // negation explicit instead of relying on target-specific subtract literals.
 func.def @subf_zero_identities(%n: index, %x: vector<[%n]xf32>) -> (vector<[%n]xf32>, vector<[%n]xf32>) {
-  %zero = vector.constant 0.0 : vector<[%n]xf32>
-  %sub_rhs = vector.subf<nsz> %x, %zero : vector<[%n]xf32>
-  %sub_lhs = vector.subf<nnan|nsz> %zero, %x : vector<[%n]xf32>
+  %c0 = vector.constant 0.0 : vector<[%n]xf32>
+  %sub_rhs = vector.subf<nsz> %x, %c0 : vector<[%n]xf32>
+  %sub_lhs = vector.subf<nnan|nsz> %c0, %x : vector<[%n]xf32>
   func.return %sub_rhs, %sub_lhs : vector<[%n]xf32>, vector<[%n]xf32>
 }
 // ----
@@ -939,8 +939,8 @@ func.def @subf_zero_identities(%n: index, %x: vector<[%n]xf32>) -> (vector<[%n]x
 // A negated input multiplied by an exact constant keeps the sign on the
 // constant so target lowering does not need a separate negation instruction.
 func.def @mulf_absorbs_negated_input_constant(%x: vector<4xf32>) -> (vector<4xf32>) {
-  %zero = vector.constant 0.0 : vector<4xf32>
-  %neg = vector.subf<nnan|nsz> %zero, %x : vector<4xf32>
+  %c0 = vector.constant 0.0 : vector<4xf32>
+  %neg = vector.subf<nnan|nsz> %c0, %x : vector<4xf32>
   %scale = vector.constant 1.4426950408889634 : vector<4xf32>
   %scaled = vector.mulf<nnan|ninf|nsz> %neg, %scale : vector<4xf32>
   func.return %scaled : vector<4xf32>
@@ -1082,8 +1082,8 @@ func.def @reduce_axes_dynamic_zero_to_init(%n: index, %init: vector<2xi32>) -> (
 
 // Integer identities fold without requiring the vector shape to become static.
 func.def @integer_identities(%n: index, %x: vector<[%n]xi32>) -> (vector<[%n]xi32>, vector<[%n]xi32>, vector<[%n]xi32>) {
-  %zero = vector.constant 0 : vector<[%n]xi32>
-  %sub = vector.subi %x, %zero : vector<[%n]xi32>
+  %c0 = vector.constant 0 : vector<[%n]xi32>
+  %sub = vector.subi %x, %c0 : vector<[%n]xi32>
   %xor = vector.xori %x, %x : vector<[%n]xi32>
   %and = vector.andi %x, %x : vector<[%n]xi32>
   func.return %sub, %xor, %and : vector<[%n]xi32>, vector<[%n]xi32>, vector<[%n]xi32>
@@ -1114,14 +1114,14 @@ func.def @cmpi_same_operand(%x: vector<4xi32>) -> (vector<4xi1>, vector<4xi1>) {
 // Floating-point self-comparisons fold only for NaN-stable predicates.
 func.def @cmpf_same_operand(%x: vector<4xf32>) -> (vector<4xi1>, vector<4xi1>) {
   %ueq = vector.cmpf ueq, %x, %x : vector<4xf32> -> vector<4xi1>
-  %one = vector.cmpf one, %x, %x : vector<4xf32> -> vector<4xi1>
-  func.return %ueq, %one : vector<4xi1>, vector<4xi1>
+  %ordered_not_equal = vector.cmpf one, %x, %x : vector<4xf32> -> vector<4xi1>
+  func.return %ueq, %ordered_not_equal : vector<4xi1>, vector<4xi1>
 }
 // ----
 func.def @cmpf_same_operand(%x: vector<4xf32>) -> (vector<4xi1>, vector<4xi1>) {
   %ueq = vector.constant true : vector<4xi1>
-  %one = vector.constant false : vector<4xi1>
-  func.return %ueq, %one : vector<4xi1>, vector<4xi1>
+  %ordered_not_equal = vector.constant false : vector<4xi1>
+  func.return %ueq, %ordered_not_equal : vector<4xi1>, vector<4xi1>
 }
 
 // ====

--- a/loom/src/loom/ops/vector/test/canonicalize.loom-test
+++ b/loom/src/loom/ops/vector/test/canonicalize.loom-test
@@ -908,8 +908,8 @@ func.def @addi_uniform_constants_to_vector_constant() -> (vector<4xi32>) {
 
 // Dynamic vector shapes still use fact-driven integer identities.
 func.def @addi_dynamic_zero_identity(%n: index, %x: vector<[%n]xi32>) -> (vector<[%n]xi32>) {
-  %zero_scalar = scalar.constant 0 : i32
-  %zero = vector.splat %zero_scalar : vector<[%n]xi32>
+  %additive_identity_element = scalar.constant 0 : i32
+  %zero = vector.splat %additive_identity_element : vector<[%n]xi32>
   %r = vector.addi %x, %zero : vector<[%n]xi32>
   func.return %r : vector<[%n]xi32>
 }
@@ -1053,8 +1053,8 @@ func.def @shuffle_identity(%v: vector<4xf32>) -> (vector<4xf32>) {
 
 // Reducing identity lanes leaves the explicit accumulator unchanged.
 func.def @reduce_dynamic_zero_to_init(%n: index, %init: i32) -> (i32) {
-  %zero_scalar = scalar.constant 0 : i32
-  %zero = vector.splat %zero_scalar : vector<[%n]xi32>
+  %additive_identity_element = scalar.constant 0 : i32
+  %zero = vector.splat %additive_identity_element : vector<[%n]xi32>
   %r = vector.reduce<addi> %zero, %init : vector<[%n]xi32>, i32
   func.return %r : i32
 }
@@ -1067,8 +1067,8 @@ func.def @reduce_dynamic_zero_to_init(%n: index, %init: i32) -> (i32) {
 
 // Identity lanes preserve vector accumulators across dynamic reduced extents.
 func.def @reduce_axes_dynamic_zero_to_init(%n: index, %init: vector<2xi32>) -> (vector<2xi32>) {
-  %zero_scalar = scalar.constant 0 : i32
-  %zero = vector.splat %zero_scalar : vector<[%n]x2xi32>
+  %additive_identity_element = scalar.constant 0 : i32
+  %zero = vector.splat %additive_identity_element : vector<[%n]x2xi32>
   %r = vector.reduce.axes<addi> %zero, %init axes [0] : vector<[%n]x2xi32>, vector<2xi32>
   func.return %r : vector<2xi32>
 }

--- a/loom/src/loom/ops/vector/test/facts.loom-test
+++ b/loom/src/loom/ops/vector/test/facts.loom-test
@@ -110,10 +110,10 @@ func.def @reduce_uniform_splat_addi() -> (i32) {
 // Representative lanewise float facts preserve uniform summaries through the
 // expanded math surface.
 func.def @reduce_uniform_float_math() -> (f32) {
-  %nine = vector.constant 9.0 : vector<4xf32>
-  %four = vector.constant 4.0 : vector<4xf32>
-  %rem = vector.remf %nine, %four : vector<4xf32>
-  %root = vector.sqrtf %nine : vector<4xf32>
+  %c9 = vector.constant 9.0 : vector<4xf32>
+  %c4 = vector.constant 4.0 : vector<4xf32>
+  %rem = vector.remf %c9, %c4 : vector<4xf32>
+  %root = vector.sqrtf %c9 : vector<4xf32>
   %sum = vector.addf %rem, %root : vector<4xf32>
   %init = scalar.constant 1.0 : f32
   %r = vector.reduce<addf> %sum, %init : vector<4xf32>, f32
@@ -131,11 +131,11 @@ func.def @reduce_uniform_float_math() -> (f32) {
 // through the full reduction.
 func.def @reduce_f32_rounds_each_step() -> (f32) {
   %large = scalar.constant 16777216.0 : f32
-  %one = scalar.constant 1.0 : f32
+  %c1 = scalar.constant 1.0 : f32
   %negative_large = scalar.constant -16777216.0 : f32
-  %v = vector.from_elements %large, %one, %negative_large : vector<3xf32>
-  %zero = scalar.constant 0.0 : f32
-  %result = vector.reduce<addf> %v, %zero : vector<3xf32>, f32
+  %v = vector.from_elements %large, %c1, %negative_large : vector<3xf32>
+  %c0 = scalar.constant 0.0 : f32
+  %result = vector.reduce<addf> %v, %c0 : vector<3xf32>, f32
   func.return %result : f32
 }
 // ----
@@ -148,9 +148,9 @@ func.def @reduce_f32_rounds_each_step() -> (f32) {
 
 // Small per-lane float facts compose through new lanewise unary and binary ops.
 func.def @small_static_float_math_extract() -> (f32) {
-  %one = scalar.constant 1.0 : f32
-  %four = scalar.constant 4.0 : f32
-  %v = vector.from_elements %one, %four : vector<2xf32>
+  %c1 = scalar.constant 1.0 : f32
+  %c4 = scalar.constant 4.0 : f32
+  %v = vector.from_elements %c1, %c4 : vector<2xf32>
   %root = vector.sqrtf %v : vector<2xf32>
   %max = vector.maximumf %v, %root : vector<2xf32>
   %r = vector.extract %max[1] : vector<2xf32> -> f32
@@ -168,8 +168,8 @@ func.def @small_static_float_math_extract() -> (f32) {
 func.def @vector_minimumf_propagates_uniform_nan() -> (i1) {
   %neg = vector.constant -1.0 : vector<4xf32>
   %nan = vector.logf %neg : vector<4xf32>
-  %three = vector.constant 3.0 : vector<4xf32>
-  %min = vector.minimumf %nan, %three : vector<4xf32>
+  %c3 = vector.constant 3.0 : vector<4xf32>
+  %min = vector.minimumf %nan, %c3 : vector<4xf32>
   %lane = vector.extract %min[0] : vector<4xf32> -> f32
   %r = scalar.isnanf %lane : f32
   func.return %r : i1
@@ -186,8 +186,8 @@ func.def @vector_minimumf_propagates_uniform_nan() -> (i1) {
 func.def @vector_minnumf_skips_uniform_nan() -> (i1) {
   %neg = vector.constant -1.0 : vector<4xf32>
   %nan = vector.logf %neg : vector<4xf32>
-  %three = vector.constant 3.0 : vector<4xf32>
-  %min = vector.minnumf %nan, %three : vector<4xf32>
+  %c3 = vector.constant 3.0 : vector<4xf32>
+  %min = vector.minnumf %nan, %c3 : vector<4xf32>
   %lane = vector.extract %min[0] : vector<4xf32> -> f32
   %r = scalar.isnanf %lane : f32
   func.return %r : i1
@@ -205,11 +205,11 @@ func.def @vector_minnumf_skips_uniform_nan() -> (i1) {
 func.def @vector_clampf_modes_uniform_nan() -> (i1, i1, i1) {
   %neg = vector.constant -1.0 : vector<4xf32>
   %nan = vector.logf %neg : vector<4xf32>
-  %zero = vector.constant 0.0 : vector<4xf32>
-  %one = vector.constant 1.0 : vector<4xf32>
-  %ordered = vector.clampf<ordered> %nan, %zero, %one : vector<4xf32>
-  %number = vector.clampf<number> %nan, %zero, %one : vector<4xf32>
-  %ieee = vector.clampf<ieee> %nan, %zero, %one : vector<4xf32>
+  %c0 = vector.constant 0.0 : vector<4xf32>
+  %c1 = vector.constant 1.0 : vector<4xf32>
+  %ordered = vector.clampf<ordered> %nan, %c0, %c1 : vector<4xf32>
+  %number = vector.clampf<number> %nan, %c0, %c1 : vector<4xf32>
+  %ieee = vector.clampf<ieee> %nan, %c0, %c1 : vector<4xf32>
   %ordered_lane = vector.extract %ordered[0] : vector<4xf32> -> f32
   %number_lane = vector.extract %number[1] : vector<4xf32> -> f32
   %ieee_lane = vector.extract %ieee[2] : vector<4xf32> -> f32
@@ -231,9 +231,9 @@ func.def @vector_clampf_modes_uniform_nan() -> (i1, i1, i1) {
 // Identity elements can fold reductions over dynamic extents when the explicit
 // accumulator is itself exact.
 func.def @reduce_dynamic_zero_splat_addi(%n: index) -> (i32) {
-  %zero = scalar.constant 0 : i32
+  %c0 = scalar.constant 0 : i32
   %init = scalar.constant 5 : i32
-  %v = vector.splat %zero : vector<[%n]xi32>
+  %v = vector.splat %c0 : vector<[%n]xi32>
   %r = vector.reduce<addi> %v, %init : vector<[%n]xi32>, i32
   func.return %r : i32
 }
@@ -267,8 +267,8 @@ func.def @select_uniform_true_then_reduce() -> (i32) {
   %a = vector.constant 5 : vector<4xi32>
   %b = vector.constant 9 : vector<4xi32>
   %selected = vector.select %mask, %a, %b : vector<4xi32>
-  %zero = scalar.constant 0 : i32
-  %r = vector.reduce<addi> %selected, %zero : vector<4xi32>, i32
+  %c0 = scalar.constant 0 : i32
+  %r = vector.reduce<addi> %selected, %c0 : vector<4xi32>, i32
   func.return %r : i32
 }
 // ----
@@ -287,8 +287,8 @@ func.def @reduce_from_elements_addi() -> (i32) {
   %c3 = scalar.constant 3 : i32
   %c4 = scalar.constant 4 : i32
   %v = vector.from_elements %c1, %c2, %c3, %c4 : vector<4xi32>
-  %zero = scalar.constant 0 : i32
-  %r = vector.reduce<addi> %v, %zero : vector<4xi32>, i32
+  %c0 = scalar.constant 0 : i32
+  %r = vector.reduce<addi> %v, %c0 : vector<4xi32>, i32
   func.return %r : i32
 }
 // ----
@@ -302,18 +302,18 @@ func.def @reduce_from_elements_addi() -> (i32) {
 // Structural vector ops preserve uniform summaries when their lane mapping does
 // not change the scalar element fact.
 func.def @structural_uniform_facts() -> (i32, i32, i32, i32) {
-  %seven = vector.constant 7 : vector<2xi32>
-  %wide = vector.broadcast %seven : vector<2xi32> -> vector<3x2xi32>
+  %c7 = vector.constant 7 : vector<2xi32>
+  %wide = vector.broadcast %c7 : vector<2xi32> -> vector<3x2xi32>
   %r0 = vector.extract %wide[2, 1] : vector<3x2xi32> -> i32
-  %four = vector.constant 4 : vector<2x3xi32>
-  %transposed = vector.transpose<[1, 0]> %four : vector<2x3xi32> -> vector<3x2xi32>
+  %c4 = vector.constant 4 : vector<2x3xi32>
+  %transposed = vector.transpose<[1, 0]> %c4 : vector<2x3xi32> -> vector<3x2xi32>
   %r1 = vector.extract %transposed[1, 0] : vector<3x2xi32> -> i32
-  %three = scalar.constant 3 : i32
+  %c3 = scalar.constant 3 : i32
   %threes = vector.constant 3 : vector<4xi32>
-  %inserted = vector.insert %three into %threes[2] : i32, vector<4xi32>
+  %inserted = vector.insert %c3 into %threes[2] : i32, vector<4xi32>
   %r2 = vector.extract %inserted[0] : vector<4xi32> -> i32
-  %one = vector.constant 1.0 : vector<4xf32>
-  %bits = vector.bitcast %one : vector<4xf32> to vector<4xi32>
+  %c1 = vector.constant 1.0 : vector<4xf32>
+  %bits = vector.bitcast %c1 : vector<4xf32> to vector<4xi32>
   %r3 = vector.extract %bits[3] : vector<4xi32> -> i32
   func.return %r0, %r1, %r2, %r3 : i32, i32, i32, i32
 }
@@ -330,9 +330,9 @@ func.def @structural_uniform_facts() -> (i32, i32, i32, i32) {
 
 // Broadcast facts remap trailing source axes into each result lane.
 func.def @broadcast_small_static_lanes() -> (i32, i32) {
-  %five = scalar.constant 5 : i32
-  %six = scalar.constant 6 : i32
-  %v = vector.from_elements %five, %six : vector<2xi32>
+  %c5 = scalar.constant 5 : i32
+  %c6 = scalar.constant 6 : i32
+  %v = vector.from_elements %c5, %c6 : vector<2xi32>
   %wide = vector.broadcast %v : vector<2xi32> -> vector<3x2xi32>
   %r0 = vector.extract %wide[1, 0] : vector<3x2xi32> -> i32
   %r1 = vector.extract %wide[2, 1] : vector<3x2xi32> -> i32
@@ -349,13 +349,13 @@ func.def @broadcast_small_static_lanes() -> (i32, i32) {
 
 // Insert facts overwrite only the static inserted lane.
 func.def @insert_scalar_small_static_lane() -> (i32, i32) {
-  %one = scalar.constant 1 : i32
-  %two = scalar.constant 2 : i32
-  %three = scalar.constant 3 : i32
-  %four = scalar.constant 4 : i32
-  %nine = scalar.constant 9 : i32
-  %v = vector.from_elements %one, %two, %three, %four : vector<4xi32>
-  %updated = vector.insert %nine into %v[2] : i32, vector<4xi32>
+  %c1 = scalar.constant 1 : i32
+  %c2 = scalar.constant 2 : i32
+  %c3 = scalar.constant 3 : i32
+  %c4 = scalar.constant 4 : i32
+  %c9 = scalar.constant 9 : i32
+  %v = vector.from_elements %c1, %c2, %c3, %c4 : vector<4xi32>
+  %updated = vector.insert %c9 into %v[2] : i32, vector<4xi32>
   %r0 = vector.extract %updated[1] : vector<4xi32> -> i32
   %r1 = vector.extract %updated[2] : vector<4xi32> -> i32
   func.return %r0, %r1 : i32, i32
@@ -396,13 +396,13 @@ func.def @transpose_small_static_lanes() -> (i32, i32) {
 // Bitcast facts reinterpret exact same-width lanes without handling wider
 // byte-pack reshapes.
 func.def @bitcast_same_lane_raw_bits() -> (f32, i32) {
-  %one_bits = scalar.constant 0x3f800000 : i32
-  %two_bits = scalar.constant 0x40000000 : i32
-  %bits = vector.from_elements %one_bits, %two_bits : vector<2xi32>
+  %lhs_bits = scalar.constant 0x3f800000 : i32
+  %rhs_bits = scalar.constant 0x40000000 : i32
+  %bits = vector.from_elements %lhs_bits, %rhs_bits : vector<2xi32>
   %floats = vector.bitcast %bits : vector<2xi32> to vector<2xf32>
-  %one = scalar.constant 1.0 : f32
-  %two = scalar.constant 2.0 : f32
-  %float_values = vector.from_elements %one, %two : vector<2xf32>
+  %lhs_value = scalar.constant 1.0 : f32
+  %rhs_value = scalar.constant 2.0 : f32
+  %float_values = vector.from_elements %lhs_value, %rhs_value : vector<2xf32>
   %roundtrip = vector.bitcast %float_values : vector<2xf32> to vector<2xi32>
   %r0 = vector.extract %floats[0] : vector<2xf32> -> f32
   %r1 = vector.extract %roundtrip[1] : vector<2xi32> -> i32
@@ -423,12 +423,12 @@ func.def @small_lanewise_with_uniform_then_reduce() -> (i32) {
   %c2 = scalar.constant 2 : i32
   %c3 = scalar.constant 3 : i32
   %c4 = scalar.constant 4 : i32
-  %ten = scalar.constant 10 : i32
+  %c10 = scalar.constant 10 : i32
   %v = vector.from_elements %c1, %c2, %c3, %c4 : vector<4xi32>
-  %offset = vector.splat %ten : vector<4xi32>
+  %offset = vector.splat %c10 : vector<4xi32>
   %sum = vector.addi %v, %offset : vector<4xi32>
-  %zero = scalar.constant 0 : i32
-  %r = vector.reduce<addi> %sum, %zero : vector<4xi32>, i32
+  %c0 = scalar.constant 0 : i32
+  %r = vector.reduce<addi> %sum, %c0 : vector<4xi32>, i32
   func.return %r : i32
 }
 // ----
@@ -442,14 +442,14 @@ func.def @small_lanewise_with_uniform_then_reduce() -> (i32) {
 // Wave-2 integer ops preserve uniform summaries through arithmetic, min/max,
 // shifts, and sign.
 func.def @wave2_integer_uniform_facts() -> (i32, i32, i32, i32, i32) {
-  %eighteen = vector.constant 18 : vector<4xi32>
-  %five = vector.constant 5 : vector<4xi32>
-  %one = vector.constant 1 : vector<4xi32>
-  %sub = vector.subi %eighteen, %five : vector<4xi32>
-  %div = vector.divsi %eighteen, %five : vector<4xi32>
-  %rem = vector.remui %eighteen, %five : vector<4xi32>
+  %c18 = vector.constant 18 : vector<4xi32>
+  %c5 = vector.constant 5 : vector<4xi32>
+  %c1 = vector.constant 1 : vector<4xi32>
+  %sub = vector.subi %c18, %c5 : vector<4xi32>
+  %div = vector.divsi %c18, %c5 : vector<4xi32>
+  %rem = vector.remui %c18, %c5 : vector<4xi32>
   %min = vector.minsi %sub, %div : vector<4xi32>
-  %shl = vector.shli %min, %one : vector<4xi32>
+  %shl = vector.shli %min, %c1 : vector<4xi32>
   %sign = vector.signi %sub : vector<4xi32>
   %r0 = vector.extract %sub[0] : vector<4xi32> -> i32
   %r1 = vector.extract %div[0] : vector<4xi32> -> i32
@@ -472,10 +472,10 @@ func.def @wave2_integer_uniform_facts() -> (i32, i32, i32, i32, i32) {
 
 // Bit-count vector facts use the declared integer element width for each lane.
 func.def @wave2_bit_count_small_lanes() -> (i32, i32, i32) {
-  %one = scalar.constant 1 : i32
-  %eight = scalar.constant 8 : i32
-  %minus_one = scalar.constant -1 : i32
-  %v = vector.from_elements %one, %eight, %minus_one : vector<3xi32>
+  %c1 = scalar.constant 1 : i32
+  %c8 = scalar.constant 8 : i32
+  %cn1 = scalar.constant -1 : i32
+  %v = vector.from_elements %c1, %c8, %cn1 : vector<3xi32>
   %clz = vector.ctlzi %v : vector<3xi32>
   %ctz = vector.cttzi %v : vector<3xi32>
   %pop = vector.ctpopi %v : vector<3xi32>
@@ -518,11 +518,11 @@ func.def @bitfield_extract_small_lanes() -> (i32, i32) {
 // Semantic activation facts preserve uniform and exact-lane summaries so
 // canonicalization can fold through vector consumers.
 func.def @activation_uniform_exact_zero() -> (f32, f32, f32, f32) {
-  %zero = vector.constant 0.0 : vector<4xf32>
-  %logistic = vector.logisticf %zero : vector<4xf32>
-  %silu = vector.siluf %zero : vector<4xf32>
-  %softplus = vector.softplusf %zero : vector<4xf32>
-  %gelu = vector.geluf<logistic> %zero {scale = 1.702} : vector<4xf32>
+  %c0 = vector.constant 0.0 : vector<4xf32>
+  %logistic = vector.logisticf %c0 : vector<4xf32>
+  %silu = vector.siluf %c0 : vector<4xf32>
+  %softplus = vector.softplusf %c0 : vector<4xf32>
+  %gelu = vector.geluf<logistic> %c0 {scale = 1.702} : vector<4xf32>
   %r0 = vector.extract %logistic[0] : vector<4xf32> -> f32
   %r1 = vector.extract %silu[1] : vector<4xf32> -> f32
   %r2 = vector.extract %softplus[2] : vector<4xf32> -> f32
@@ -583,10 +583,10 @@ func.def @activation_uniform_negative_tail() -> (i1, i1, i1, i1, i1, i1) {
 
 // Turn-domain trig facts preserve exact lane values and uniform summaries.
 func.def @turn_trig_uniform_exact_quadrants() -> (f32, f32, f32, f32) {
-  %zero = vector.constant 0.0 : vector<4xf32>
+  %c0 = vector.constant 0.0 : vector<4xf32>
   %quarter = vector.constant 0.25 : vector<4xf32>
-  %sin_zero = vector.sinturnsf %zero : vector<4xf32>
-  %cos_zero = vector.costurnsf %zero : vector<4xf32>
+  %sin_zero = vector.sinturnsf %c0 : vector<4xf32>
+  %cos_zero = vector.costurnsf %c0 : vector<4xf32>
   %sin_quarter = vector.sinturnsf %quarter : vector<4xf32>
   %cos_quarter = vector.costurnsf %quarter : vector<4xf32>
   %r0 = vector.extract %sin_zero[0] : vector<4xf32> -> f32
@@ -853,10 +853,10 @@ func.def @transform_jl_dense_small_static_lanes() -> (f32, f32, f32) {
 // scalarization instead of summing a lane in host-double precision.
 func.def @transform_hadamard_rounds_each_step() -> (f32) {
   %large = scalar.constant 16777216.0 : f32
-  %one = scalar.constant 1.0 : f32
+  %c1 = scalar.constant 1.0 : f32
   %negative_large = scalar.constant -16777216.0 : f32
-  %zero = scalar.constant 0.0 : f32
-  %v = vector.from_elements %large, %one, %negative_large, %zero : vector<4xf32>
+  %c0 = scalar.constant 0.0 : f32
+  %v = vector.from_elements %large, %c1, %negative_large, %c0 : vector<4xf32>
   %xf = encoding.define #numeric_transform<family="hadamard", input_elems=4, output_elems=4> : encoding<transform>
   %r = vector.transform %v, %xf : vector<4xf32>, encoding<transform> -> vector<4xf32>
   %r0 = vector.extract %r[0] : vector<4xf32> -> f32
@@ -874,9 +874,9 @@ func.def @transform_hadamard_rounds_each_step() -> (f32) {
 // each intermediate f32 value.
 func.def @transform_jl_dense_rounds_each_step() -> (f32) {
   %large = scalar.constant 16777216.0 : f32
-  %one = scalar.constant 1.0 : f32
+  %c1 = scalar.constant 1.0 : f32
   %negative_large = scalar.constant -16777216.0 : f32
-  %v = vector.from_elements %large, %one, %negative_large : vector<3xf32>
+  %v = vector.from_elements %large, %c1, %negative_large : vector<3xf32>
   %m0 = scalar.constant 1.0 : f32
   %m1 = scalar.constant 1.0 : f32
   %m2 = scalar.constant 1.0 : f32
@@ -897,9 +897,9 @@ func.def @transform_jl_dense_rounds_each_step() -> (f32) {
 // Float predicate and sign facts can produce exact i1/float lane summaries.
 func.def @wave2_float_predicate_facts() -> (i1, i1, i1, f32) {
   %neg = vector.constant -1.0 : vector<4xf32>
-  %zero = vector.constant 0.0 : vector<4xf32>
+  %c0 = vector.constant 0.0 : vector<4xf32>
   %nan = vector.logf %neg : vector<4xf32>
-  %inf = vector.divf %neg, %zero : vector<4xf32>
+  %inf = vector.divf %neg, %c0 : vector<4xf32>
   %finite = vector.constant 2.0 : vector<4xf32>
   %is_nan = vector.isnanf %nan : vector<4xf32> -> vector<4xi1>
   %is_inf = vector.isinff %inf : vector<4xf32> -> vector<4xi1>
@@ -952,8 +952,8 @@ func.def @extract_rank2_small_static_lanes() -> (i32, i32) {
   %v = vector.from_elements %c1, %c2, %c3, %c4, %c5, %c6 : vector<2x3xi32>
   %element = vector.extract %v[1, 2] : vector<2x3xi32> -> i32
   %row = vector.extract %v[1] : vector<2x3xi32> -> vector<3xi32>
-  %zero = scalar.constant 0 : i32
-  %sum = vector.reduce<addi> %row, %zero : vector<3xi32>, i32
+  %c0 = scalar.constant 0 : i32
+  %sum = vector.reduce<addi> %row, %c0 : vector<3xi32>, i32
   func.return %element, %sum : i32, i32
 }
 // ----
@@ -993,13 +993,13 @@ func.def @select_small_mask_then_reduce() -> (i32) {
   %c2 = scalar.constant 2 : i32
   %c3 = scalar.constant 3 : i32
   %c4 = scalar.constant 4 : i32
-  %ten = scalar.constant 10 : i32
+  %c10 = scalar.constant 10 : i32
   %mask = vector.from_elements %true, %false, %true, %false : vector<4xi1>
-  %a = vector.splat %ten : vector<4xi32>
+  %a = vector.splat %c10 : vector<4xi32>
   %b = vector.from_elements %c1, %c2, %c3, %c4 : vector<4xi32>
   %selected = vector.select %mask, %a, %b : vector<4xi32>
-  %zero = scalar.constant 0 : i32
-  %r = vector.reduce<addi> %selected, %zero : vector<4xi32>, i32
+  %c0 = scalar.constant 0 : i32
+  %r = vector.reduce<addi> %selected, %c0 : vector<4xi32>, i32
   func.return %r : i32
 }
 // ----
@@ -1198,10 +1198,10 @@ func.def @dot8i4_small_static_lanes() -> (i32) {
 // Uniform packed-dot facts remain useful for dynamic vectors when a later
 // consumer can exploit a shape-independent identity.
 func.def @dot8i4_uniform_dynamic_identity(%n: index) -> (i32) {
-  %zero = scalar.constant 0 : i32
-  %lhs = vector.splat %zero : vector<[%n]xi32>
-  %rhs = vector.splat %zero : vector<[%n]xi32>
-  %acc = vector.splat %zero : vector<[%n]xi32>
+  %c0 = scalar.constant 0 : i32
+  %lhs = vector.splat %c0 : vector<[%n]xi32>
+  %rhs = vector.splat %c0 : vector<[%n]xi32>
+  %acc = vector.splat %c0 : vector<[%n]xi32>
   %dot = vector.dot8i4<u4u4> %lhs, %rhs, %acc : vector<[%n]xi32>
   %init = scalar.constant 7 : i32
   %r = vector.reduce<addi> %dot, %init : vector<[%n]xi32>, i32
@@ -1245,10 +1245,10 @@ func.def @dot4f8_small_static_lanes() -> (f32, f32) {
 func.def @dot4f8_all_kind_ones() -> (f32, f32, f32, f32) {
   %fp8_ones = scalar.constant 0x38383838 : i32
   %bf8_ones = scalar.constant 0x3c3c3c3c : i32
-  %zero = scalar.constant 0.0 : f32
+  %c0 = scalar.constant 0.0 : f32
   %fp8 = vector.from_elements %fp8_ones : vector<1xi32>
   %bf8 = vector.from_elements %bf8_ones : vector<1xi32>
-  %acc = vector.from_elements %zero : vector<1xf32>
+  %acc = vector.from_elements %c0 : vector<1xf32>
   %r0v = vector.dot4f8<fp8bf8> %fp8, %bf8, %acc : vector<1xi32>, vector<1xf32>
   %r1v = vector.dot4f8<bf8fp8> %bf8, %fp8, %acc : vector<1xi32>, vector<1xf32>
   %r2v = vector.dot4f8<fp8fp8> %fp8, %fp8, %acc : vector<1xi32>, vector<1xf32>
@@ -1274,10 +1274,10 @@ func.def @dot4f8_all_kind_ones() -> (f32, f32, f32, f32) {
 func.def @dot4f8_uniform_dynamic_extract(%n: index) -> (f32) {
   %lhs0 = scalar.constant 0x38383838 : i32
   %rhs0 = scalar.constant 0x3c3c3c3c : i32
-  %zero = scalar.constant 0.0 : f32
+  %c0 = scalar.constant 0.0 : f32
   %lhs = vector.splat %lhs0 : vector<[%n]xi32>
   %rhs = vector.splat %rhs0 : vector<[%n]xi32>
-  %acc = vector.splat %zero : vector<[%n]xf32>
+  %acc = vector.splat %c0 : vector<[%n]xf32>
   %dot = vector.dot4f8<fp8bf8> %lhs, %rhs, %acc : vector<[%n]xi32>, vector<[%n]xf32>
   %r = vector.extract %dot[0] : vector<[%n]xf32> -> f32
   func.return %r : f32
@@ -1293,10 +1293,10 @@ func.def @dot4f8_uniform_dynamic_extract(%n: index) -> (f32) {
 // Oversized explicit vectors deliberately degrade to unknown facts instead of
 // allocating unbounded per-lane analysis payloads.
 func.def @oversized_from_elements_degrades_to_unknown() -> (i64) {
-  %zero = scalar.constant 0 : i32
-  %one = scalar.constant 1 : i32
-  %v = vector.from_elements %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %one : vector<17xi32>
-  %r = vector.reduce<addi> %v, %zero : vector<17xi32>, i32
+  %c0 = scalar.constant 0 : i32
+  %c1 = scalar.constant 1 : i32
+  %v = vector.from_elements %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c1 : vector<17xi32>
+  %r = vector.reduce<addi> %v, %c0 : vector<17xi32>, i32
   %lo = test.fact_range_lo %r : i32 -> i64
   func.return %lo : i64
 }
@@ -1311,9 +1311,9 @@ func.def @oversized_from_elements_degrades_to_unknown() -> (i64) {
 // Oversized repeated-element vectors keep bounded uniform-element facts instead
 // of requiring per-lane payloads.
 func.def @oversized_repeated_from_elements_preserves_uniform_fact() -> (i64) {
-  %zero = scalar.constant 0 : i32
-  %v = vector.from_elements %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero, %zero : vector<17xi32>
-  %r = vector.reduce<addi> %v, %zero : vector<17xi32>, i32
+  %c0 = scalar.constant 0 : i32
+  %v = vector.from_elements %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0, %c0 : vector<17xi32>
+  %r = vector.reduce<addi> %v, %c0 : vector<17xi32>, i32
   %lo = test.fact_range_lo %r : i32 -> i64
   func.return %lo : i64
 }
@@ -1386,10 +1386,10 @@ func.def @f8e4m3_type_vector_load_content(%buffer: buffer) -> (i1, i1) {
 // loads even when the fragment result materializes as BF16.
 func.def @f8e4m3_type_fragment_load_content(%buffer: buffer) -> (i1, i1) {
   %offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %origin = index.constant 0 : index
+  %fragment_extent = index.constant 16 : index
   %view = buffer.view %buffer[%offset] : buffer -> view<16x16xf8E4M3, #dense>
-  %fragment = vector.fragment.load<rhs> %view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E4M3, #dense> -> vector<16xbf16>
+  %fragment = vector.fragment.load<rhs> %view[%origin, %origin] shape [%fragment_extent, %fragment_extent] : view<16x16xf8E4M3, #dense> -> vector<16xbf16>
   %inf = vector.isinff %fragment : vector<16xbf16> -> vector<16xi1>
   %finite = vector.isfinitef %fragment : vector<16xbf16> -> vector<16xi1>
   %inf_lane = vector.extract %inf[0] : vector<16xi1> -> i1
@@ -1399,10 +1399,10 @@ func.def @f8e4m3_type_fragment_load_content(%buffer: buffer) -> (i1, i1) {
 // ----
 func.def @f8e4m3_type_fragment_load_content(%buffer: buffer) -> (i1, i1) {
   %offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %origin = index.constant 0 : index
+  %fragment_extent = index.constant 16 : index
   %view = buffer.view %buffer[%offset] : buffer -> view<16x16xf8E4M3, #dense>
-  %fragment = vector.fragment.load<rhs> %view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E4M3, #dense> -> vector<16xbf16>
+  %fragment = vector.fragment.load<rhs> %view[%origin, %origin] shape [%fragment_extent, %fragment_extent] : view<16x16xf8E4M3, #dense> -> vector<16xbf16>
   %finite = vector.isfinitef %fragment : vector<16xbf16> -> vector<16xi1>
   %inf_lane = scalar.constant false : i1
   %finite_lane = vector.extract %finite[0] : vector<16xi1> -> i1
@@ -1523,13 +1523,13 @@ func.def @fnuz_fp8_storage_vector_load_content(%buffer: buffer) -> (i1, i1) {
 // loads while preserving NaN uncertainty.
 func.def @fn_fp8_storage_fragment_load_content(%buffer: buffer) -> (i1, i1) {
   %offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %origin = index.constant 0 : index
+  %fragment_extent = index.constant 16 : index
   %layout = encoding.layout.dense : encoding<layout>
   %schema = encoding.define #fp8_e4m3fn : encoding<schema>
   %storage = encoding.define #physical_storage {layout = %layout : encoding<layout>, schema = %schema : encoding<schema>} : encoding<storage>
   %view = buffer.view %buffer[%offset] : buffer -> view<16x16xf8E4M3, %storage>
-  %fragment = vector.fragment.load<rhs> %view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E4M3, %storage> -> vector<16xbf16>
+  %fragment = vector.fragment.load<rhs> %view[%origin, %origin] shape [%fragment_extent, %fragment_extent] : view<16x16xf8E4M3, %storage> -> vector<16xbf16>
   %inf = vector.isinff %fragment : vector<16xbf16> -> vector<16xi1>
   %finite = vector.isfinitef %fragment : vector<16xbf16> -> vector<16xi1>
   %inf_lane = vector.extract %inf[0] : vector<16xi1> -> i1
@@ -1539,13 +1539,13 @@ func.def @fn_fp8_storage_fragment_load_content(%buffer: buffer) -> (i1, i1) {
 // ----
 func.def @fn_fp8_storage_fragment_load_content(%buffer: buffer) -> (i1, i1) {
   %offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %origin = index.constant 0 : index
+  %fragment_extent = index.constant 16 : index
   %layout = encoding.layout.dense : encoding<layout>
   %schema = encoding.define #fp8_e4m3fn : encoding<schema>
   %storage = encoding.define #physical_storage {layout = %layout : encoding<layout>, schema = %schema : encoding<schema>} : encoding<storage>
   %view = buffer.view %buffer[%offset] : buffer -> view<16x16xf8E4M3, %storage>
-  %fragment = vector.fragment.load<rhs> %view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E4M3, %storage> -> vector<16xbf16>
+  %fragment = vector.fragment.load<rhs> %view[%origin, %origin] shape [%fragment_extent, %fragment_extent] : view<16x16xf8E4M3, %storage> -> vector<16xbf16>
   %finite = vector.isfinitef %fragment : vector<16xbf16> -> vector<16xi1>
   %inf_lane = scalar.constant false : i1
   %finite_lane = vector.extract %finite[0] : vector<16xi1> -> i1
@@ -1558,13 +1558,13 @@ func.def @fn_fp8_storage_fragment_load_content(%buffer: buffer) -> (i1, i1) {
 // through fragment loads while preserving NaN uncertainty.
 func.def @fnuz_fp8_storage_fragment_load_content(%buffer: buffer) -> (i1, i1) {
   %offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %origin = index.constant 0 : index
+  %fragment_extent = index.constant 16 : index
   %layout = encoding.layout.dense : encoding<layout>
   %schema = encoding.define #fp8_e4m3fnuz : encoding<schema>
   %storage = encoding.define #physical_storage {layout = %layout : encoding<layout>, schema = %schema : encoding<schema>} : encoding<storage>
   %view = buffer.view %buffer[%offset] : buffer -> view<16x16xf8E4M3, %storage>
-  %fragment = vector.fragment.load<rhs> %view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E4M3, %storage> -> vector<16xbf16>
+  %fragment = vector.fragment.load<rhs> %view[%origin, %origin] shape [%fragment_extent, %fragment_extent] : view<16x16xf8E4M3, %storage> -> vector<16xbf16>
   %inf = vector.isinff %fragment : vector<16xbf16> -> vector<16xi1>
   %finite = vector.isfinitef %fragment : vector<16xbf16> -> vector<16xi1>
   %inf_lane = vector.extract %inf[0] : vector<16xi1> -> i1
@@ -1574,13 +1574,13 @@ func.def @fnuz_fp8_storage_fragment_load_content(%buffer: buffer) -> (i1, i1) {
 // ----
 func.def @fnuz_fp8_storage_fragment_load_content(%buffer: buffer) -> (i1, i1) {
   %offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %origin = index.constant 0 : index
+  %fragment_extent = index.constant 16 : index
   %layout = encoding.layout.dense : encoding<layout>
   %schema = encoding.define #fp8_e4m3fnuz : encoding<schema>
   %storage = encoding.define #physical_storage {layout = %layout : encoding<layout>, schema = %schema : encoding<schema>} : encoding<storage>
   %view = buffer.view %buffer[%offset] : buffer -> view<16x16xf8E4M3, %storage>
-  %fragment = vector.fragment.load<rhs> %view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E4M3, %storage> -> vector<16xbf16>
+  %fragment = vector.fragment.load<rhs> %view[%origin, %origin] shape [%fragment_extent, %fragment_extent] : view<16x16xf8E4M3, %storage> -> vector<16xbf16>
   %finite = vector.isfinitef %fragment : vector<16xbf16> -> vector<16xi1>
   %inf_lane = scalar.constant false : i1
   %finite_lane = vector.extract %finite[0] : vector<16xi1> -> i1
@@ -1593,13 +1593,13 @@ func.def @fnuz_fp8_storage_fragment_load_content(%buffer: buffer) -> (i1, i1) {
 // while preserving subnormal uncertainty.
 func.def @finite_only_storage_fragment_load_content(%buffer: buffer) -> (i1, i1) {
   %offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %origin = index.constant 0 : index
+  %fragment_extent = index.constant 16 : index
   %layout = encoding.layout.dense : encoding<layout>
   %schema = encoding.define #matrix_operand<element_format=f8e4m3, payload_elements=16, payload_registers=4, rounding=finite_only> : encoding<schema>
   %storage = encoding.define #physical_storage {layout = %layout : encoding<layout>, schema = %schema : encoding<schema>} : encoding<storage>
   %view = buffer.view %buffer[%offset] : buffer -> view<16x16xf8E4M3, %storage>
-  %fragment = vector.fragment.load<rhs> %view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E4M3, %storage> -> vector<16xbf16>
+  %fragment = vector.fragment.load<rhs> %view[%origin, %origin] shape [%fragment_extent, %fragment_extent] : view<16x16xf8E4M3, %storage> -> vector<16xbf16>
   %finite = test.fact_finite %fragment : vector<16xbf16> -> i1
   %not_subnormal = test.fact_not_subnormal %fragment : vector<16xbf16> -> i1
   func.return %finite, %not_subnormal : i1, i1

--- a/loom/src/loom/ops/vector/test/facts.loom-test
+++ b/loom/src/loom/ops/vector/test/facts.loom-test
@@ -309,8 +309,8 @@ func.def @structural_uniform_facts() -> (i32, i32, i32, i32) {
   %transposed = vector.transpose<[1, 0]> %c4 : vector<2x3xi32> -> vector<3x2xi32>
   %r1 = vector.extract %transposed[1, 0] : vector<3x2xi32> -> i32
   %c3 = scalar.constant 3 : i32
-  %threes = vector.constant 3 : vector<4xi32>
-  %inserted = vector.insert %c3 into %threes[2] : i32, vector<4xi32>
+  %uniform_elements = vector.constant 3 : vector<4xi32>
+  %inserted = vector.insert %c3 into %uniform_elements[2] : i32, vector<4xi32>
   %r2 = vector.extract %inserted[0] : vector<4xi32> -> i32
   %c1 = vector.constant 1.0 : vector<4xf32>
   %bits = vector.bitcast %c1 : vector<4xf32> to vector<4xi32>
@@ -550,10 +550,10 @@ func.def @activation_uniform_negative_tail() -> (i1, i1, i1, i1, i1, i1) {
   %f32_logistic_lane = vector.extract %f32_logistic[0] : vector<4xf32> -> f32
   %f32_silu_lane = vector.extract %f32_silu[1] : vector<4xf32> -> f32
   %f32_gelu_lane = vector.extract %f32_gelu[2] : vector<4xf32> -> f32
-  %f32_zero = scalar.constant 0.0 : f32
-  %f32_logistic_positive = scalar.cmpf ogt, %f32_logistic_lane, %f32_zero : f32
-  %f32_silu_negative = scalar.cmpf olt, %f32_silu_lane, %f32_zero : f32
-  %f32_gelu_negative = scalar.cmpf olt, %f32_gelu_lane, %f32_zero : f32
+  %f32_sign_threshold = scalar.constant 0.0 : f32
+  %f32_logistic_positive = scalar.cmpf ogt, %f32_logistic_lane, %f32_sign_threshold : f32
+  %f32_silu_negative = scalar.cmpf olt, %f32_silu_lane, %f32_sign_threshold : f32
+  %f32_gelu_negative = scalar.cmpf olt, %f32_gelu_lane, %f32_sign_threshold : f32
 
   %f64_input = vector.constant -710.0 : vector<4xf64>
   %f64_logistic = vector.logisticf %f64_input : vector<4xf64>
@@ -562,10 +562,10 @@ func.def @activation_uniform_negative_tail() -> (i1, i1, i1, i1, i1, i1) {
   %f64_logistic_lane = vector.extract %f64_logistic[0] : vector<4xf64> -> f64
   %f64_silu_lane = vector.extract %f64_silu[1] : vector<4xf64> -> f64
   %f64_gelu_lane = vector.extract %f64_gelu[2] : vector<4xf64> -> f64
-  %f64_zero = scalar.constant 0.0 : f64
-  %f64_logistic_positive = scalar.cmpf ogt, %f64_logistic_lane, %f64_zero : f64
-  %f64_silu_negative = scalar.cmpf olt, %f64_silu_lane, %f64_zero : f64
-  %f64_gelu_negative = scalar.cmpf olt, %f64_gelu_lane, %f64_zero : f64
+  %f64_sign_threshold = scalar.constant 0.0 : f64
+  %f64_logistic_positive = scalar.cmpf ogt, %f64_logistic_lane, %f64_sign_threshold : f64
+  %f64_silu_negative = scalar.cmpf olt, %f64_silu_lane, %f64_sign_threshold : f64
+  %f64_gelu_negative = scalar.cmpf olt, %f64_gelu_lane, %f64_sign_threshold : f64
   func.return %f32_logistic_positive, %f32_silu_negative, %f32_gelu_negative, %f64_logistic_positive, %f64_silu_negative, %f64_gelu_negative : i1, i1, i1, i1, i1, i1
 }
 // ----
@@ -1243,11 +1243,11 @@ func.def @dot4f8_small_static_lanes() -> (f32, f32) {
 
 // All template spellings decode the selected lhs/rhs field formats.
 func.def @dot4f8_all_kind_ones() -> (f32, f32, f32, f32) {
-  %fp8_ones = scalar.constant 0x38383838 : i32
-  %bf8_ones = scalar.constant 0x3c3c3c3c : i32
+  %fp8_unit_lane_word = scalar.constant 0x38383838 : i32
+  %bf8_unit_lane_word = scalar.constant 0x3c3c3c3c : i32
   %c0 = scalar.constant 0.0 : f32
-  %fp8 = vector.from_elements %fp8_ones : vector<1xi32>
-  %bf8 = vector.from_elements %bf8_ones : vector<1xi32>
+  %fp8 = vector.from_elements %fp8_unit_lane_word : vector<1xi32>
+  %bf8 = vector.from_elements %bf8_unit_lane_word : vector<1xi32>
   %acc = vector.from_elements %c0 : vector<1xf32>
   %r0v = vector.dot4f8<fp8bf8> %fp8, %bf8, %acc : vector<1xi32>, vector<1xf32>
   %r1v = vector.dot4f8<bf8fp8> %bf8, %fp8, %acc : vector<1xi32>, vector<1xf32>

--- a/loom/src/loom/ops/view/test/canonicalize.loom-test
+++ b/loom/src/loom/ops/view/test/canonicalize.loom-test
@@ -1,10 +1,10 @@
 // RUN: pass canonicalize
 
 func.def @adjacent_f16_view_loads_to_vector_load(%input: buffer, %base: index) -> (f16, f16) {
-  %zero = index.constant 0 : offset
-  %one = index.constant 1 : index
-  %view = buffer.view %input[%zero] : buffer -> view<32xf16, #dense>
-  %next = index.add %base, %one : index
+  %byte_base = index.constant 0 : offset
+  %element_stride = index.constant 1 : index
+  %view = buffer.view %input[%byte_base] : buffer -> view<32xf16, #dense>
+  %next = index.add %base, %element_stride : index
   %a = view.load %view[%base] : view<32xf16, #dense> -> f16
   %b = view.load %view[%next] : view<32xf16, #dense> -> f16
   func.return %a, %b : f16, f16
@@ -12,8 +12,8 @@ func.def @adjacent_f16_view_loads_to_vector_load(%input: buffer, %base: index) -
 
 // ----
 func.def @adjacent_f16_view_loads_to_vector_load(%input: buffer, %base: index) -> (f16, f16) {
-  %zero = index.constant 0 : offset
-  %view = buffer.view %input[%zero] : buffer -> view<32xf16, #dense>
+  %byte_base = index.constant 0 : offset
+  %view = buffer.view %input[%byte_base] : buffer -> view<32xf16, #dense>
   %10 = vector.load %view[%base] : view<32xf16, #dense> -> vector<2xf16>
   %a = vector.extract %10[0] : vector<2xf16> -> f16
   %b = vector.extract %10[1] : vector<2xf16> -> f16
@@ -23,10 +23,10 @@ func.def @adjacent_f16_view_loads_to_vector_load(%input: buffer, %base: index) -
 // ====
 
 func.def @non_adjacent_f16_view_loads_stay_scalar(%input: buffer, %base: index) -> (f16, f16) {
-  %zero = index.constant 0 : offset
-  %two = index.constant 2 : index
-  %view = buffer.view %input[%zero] : buffer -> view<32xf16, #dense>
-  %next = index.add %base, %two : index
+  %byte_base = index.constant 0 : offset
+  %element_stride = index.constant 2 : index
+  %view = buffer.view %input[%byte_base] : buffer -> view<32xf16, #dense>
+  %next = index.add %base, %element_stride : index
   %a = view.load %view[%base] : view<32xf16, #dense> -> f16
   %b = view.load %view[%next] : view<32xf16, #dense> -> f16
   func.return %a, %b : f16, f16

--- a/loom/src/loom/ops/view/test/facts.loom-test
+++ b/loom/src/loom/ops/view/test/facts.loom-test
@@ -32,12 +32,12 @@ func.def @buffer_arg_memory_space_unknown(%buffer: buffer) -> (i64) {
 kernel.def @kernel_buffer_arg_memory_space_global(%buffer: buffer) {
   %config_space = test.fact_buffer_memory_space %buffer : buffer -> i64
   %workgroups = index.cast %config_space : i64 to index
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%workgroups, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%buffer: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%zero] : buffer -> view<1xi64, %layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<1xi64, %layout>
   %body_space = test.fact_buffer_memory_space %buffer : buffer -> i64
   %view_space = test.fact_view_memory_space %view : view<1xi64, %layout> -> i64
   %sum = scalar.addi %body_space, %view_space : i64
@@ -47,12 +47,12 @@ kernel.def @kernel_buffer_arg_memory_space_global(%buffer: buffer) {
 // ----
 kernel.def @kernel_buffer_arg_memory_space_global(%buffer: buffer) {
   %workgroups = index.constant 1 : index
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%workgroups, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%buffer: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%zero] : buffer -> view<1xi64, %layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<1xi64, %layout>
   %sum = scalar.constant 2 : i64
   view.store %sum, %view[0] : i64, view<1xi64, %layout>
   kernel.return
@@ -63,13 +63,13 @@ kernel.def @kernel_buffer_arg_memory_space_global(%buffer: buffer) {
 // Kernel ABI references and views are cluster-uniform. Derived views preserve
 // that scope until a lane-varying offset makes the addressed storage vary.
 kernel.def @kernel_reference_distribution(%buffer: buffer, %m: index) {
-  %one = index.constant 1 : index
-  %sixtyfour = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%sixtyfour, %one, %one) : index
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 64 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%buffer: buffer, %m: index) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
-  %source = buffer.view %buffer[%zero] : buffer -> view<[%m]xi32, #dense>
+  %source = buffer.view %buffer[%base] : buffer -> view<[%m]xi32, #dense>
   %refined = view.refine %source : view<[%m]xi32, #dense> -> view<64xi32, #dense>
   %lane_view = view.subview %refined[%lane] : view<64xi32, #dense> -> view<1xi32, #dense>
   %uniform_value = view.load %refined[0] : view<64xi32, #dense> -> i32
@@ -85,9 +85,9 @@ kernel.def @kernel_reference_distribution(%buffer: buffer, %m: index) {
 }
 // ----
 kernel.def @kernel_reference_distribution(%buffer: buffer, %m: index) {
-  %one = index.constant 1 : index
-  %sixtyfour = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%sixtyfour, %one, %one) : index
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 64 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%buffer: buffer, %m: index) {
   %buffer_uniform = scalar.constant true : i1
   %source_uniform = scalar.constant true : i1
@@ -106,10 +106,10 @@ kernel.def @kernel_reference_distribution(%buffer: buffer, %m: index) {
 // typed byte footprint.
 func.def @workgroup_alloca_reference() -> (i64, i64, i64, i64, i64) {
   %bytes = index.constant 256 : offset
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<16xf32, %layout>
+  %view = buffer.view %scratch[%base] : buffer -> view<16xf32, %layout>
   %buffer_space = test.fact_buffer_memory_space %scratch : buffer -> i64
   %buffer_align = test.fact_buffer_min_alignment %scratch : buffer -> i64
   %view_space = test.fact_view_memory_space %view : view<16xf32, %layout> -> i64
@@ -277,10 +277,10 @@ func.def @assume_same_root_feeds_view_scope(%lhs: buffer, %rhs: buffer, %offset:
 // Subview/refine preserve the underlying root memory-space facts.
 func.def @subview_refine_preserves_memory_space() -> (i64, i64) {
   %bytes = index.constant 256 : offset
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 128, memory_space = workgroup} : buffer
-  %source = buffer.view %scratch[%zero] : buffer -> view<16xf32, %layout>
+  %source = buffer.view %scratch[%base] : buffer -> view<16xf32, %layout>
   %sub = view.subview %source[4] : view<16xf32, %layout> -> view<8xf32, %layout>
   %refined = view.refine %sub : view<8xf32, %layout> -> view<4xf32, %layout>
   %space = test.fact_view_memory_space %refined : view<4xf32, %layout> -> i64

--- a/loom/src/loom/ops/view/test/roundtrip.loom-test
+++ b/loom/src/loom/ops/view/test/roundtrip.loom-test
@@ -12,10 +12,10 @@ func.def @dense_view(%buffer: buffer, %offset: offset, %m: index) {
 
 // Scratch roots carry explicit memory-space and root-alignment facts.
 func.def @workgroup_scratch_view(%bytes: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<16xf32, %layout>
+  %view = buffer.view %scratch[%base] : buffer -> view<16xf32, %layout>
   test.use %view : view<16xf32, %layout>
   func.return
 }

--- a/loom/src/loom/sanitizer/test/insert_assertions.loom-test
+++ b/loom/src/loom/sanitizer/test/insert_assertions.loom-test
@@ -148,56 +148,56 @@ func.def @access_only_instruments_scalar_view_memory(%layout: encoding<layout>, 
 
 // RUN: pass sanitizer-insert-assertions{checks=access}
 func.def @access_only_uses_memory_space_facts(%input: buffer, %output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %base = index.constant 0 : offset
+  %origin = index.constant 0 : index
   %global_input = buffer.assume.memory_space<global> %input : buffer
   %global_output = buffer.assume.memory_space<global> %output : buffer
   %generic_input = buffer.assume.memory_space<generic> %input : buffer
   %host_output = buffer.assume.memory_space<host> %output : buffer
-  %input_view = buffer.view %global_input[%zero_offset] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %global_output[%zero_offset] : buffer -> view<1xi32, #dense>
-  %generic_view = buffer.view %generic_input[%zero_offset] : buffer -> view<1xi32, #dense>
-  %host_view = buffer.view %host_output[%zero_offset] : buffer -> view<1xi32, #dense>
-  %global_value = view.load %input_view[%zero_index] : view<1xi32, #dense> -> i32
-  view.store %global_value, %output_view[%zero_index] : i32, view<1xi32, #dense>
-  %generic_value = view.load %generic_view[%zero_index] : view<1xi32, #dense> -> i32
-  view.store %generic_value, %host_view[%zero_index] : i32, view<1xi32, #dense>
+  %input_view = buffer.view %global_input[%base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %global_output[%base] : buffer -> view<1xi32, #dense>
+  %generic_view = buffer.view %generic_input[%base] : buffer -> view<1xi32, #dense>
+  %host_view = buffer.view %host_output[%base] : buffer -> view<1xi32, #dense>
+  %global_value = view.load %input_view[%origin] : view<1xi32, #dense> -> i32
+  view.store %global_value, %output_view[%origin] : i32, view<1xi32, #dense>
+  %generic_value = view.load %generic_view[%origin] : view<1xi32, #dense> -> i32
+  view.store %generic_value, %host_view[%origin] : i32, view<1xi32, #dense>
   %bytes = index.constant 4 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero_offset] : buffer -> view<1xi32, #dense>
-  %scratch_value = view.load %scratch_view[%zero_index] : view<1xi32, #dense> -> i32
+  %scratch_view = buffer.view %scratch[%base] : buffer -> view<1xi32, #dense>
+  %scratch_value = view.load %scratch_view[%origin] : view<1xi32, #dense> -> i32
   %private = buffer.alloca %bytes {base_alignment = 4, memory_space = private} : buffer
-  %private_view = buffer.view %private[%zero_offset] : buffer -> view<1xi32, #dense>
-  view.store %scratch_value, %private_view[%zero_index] : i32, view<1xi32, #dense>
+  %private_view = buffer.view %private[%base] : buffer -> view<1xi32, #dense>
+  view.store %scratch_value, %private_view[%origin] : i32, view<1xi32, #dense>
   func.return
 }
 
 // ----
 func.def @access_only_uses_memory_space_facts(%input: buffer, %output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %base = index.constant 0 : offset
+  %origin = index.constant 0 : index
   %global_input = buffer.assume.memory_space<global> %input : buffer
   %global_output = buffer.assume.memory_space<global> %output : buffer
   %generic_input = buffer.assume.memory_space<generic> %input : buffer
   %host_output = buffer.assume.memory_space<host> %output : buffer
-  %input_view = buffer.view %global_input[%zero_offset] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %global_output[%zero_offset] : buffer -> view<1xi32, #dense>
-  %generic_view = buffer.view %generic_input[%zero_offset] : buffer -> view<1xi32, #dense>
-  %host_view = buffer.view %host_output[%zero_offset] : buffer -> view<1xi32, #dense>
-  sanitizer.assert.access<read> %input_view[%zero_index] : view<1xi32, #dense>
-  %global_value = view.load %input_view[%zero_index] : view<1xi32, #dense> -> i32
-  sanitizer.assert.access<write> %output_view[%zero_index] : view<1xi32, #dense>
-  view.store %global_value, %output_view[%zero_index] : i32, view<1xi32, #dense>
-  sanitizer.assert.access<read> %generic_view[%zero_index] : view<1xi32, #dense>
-  %generic_value = view.load %generic_view[%zero_index] : view<1xi32, #dense> -> i32
-  view.store %generic_value, %host_view[%zero_index] : i32, view<1xi32, #dense>
+  %input_view = buffer.view %global_input[%base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %global_output[%base] : buffer -> view<1xi32, #dense>
+  %generic_view = buffer.view %generic_input[%base] : buffer -> view<1xi32, #dense>
+  %host_view = buffer.view %host_output[%base] : buffer -> view<1xi32, #dense>
+  sanitizer.assert.access<read> %input_view[%origin] : view<1xi32, #dense>
+  %global_value = view.load %input_view[%origin] : view<1xi32, #dense> -> i32
+  sanitizer.assert.access<write> %output_view[%origin] : view<1xi32, #dense>
+  view.store %global_value, %output_view[%origin] : i32, view<1xi32, #dense>
+  sanitizer.assert.access<read> %generic_view[%origin] : view<1xi32, #dense>
+  %generic_value = view.load %generic_view[%origin] : view<1xi32, #dense> -> i32
+  view.store %generic_value, %host_view[%origin] : i32, view<1xi32, #dense>
   %bytes = index.constant 4 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero_offset] : buffer -> view<1xi32, #dense>
-  %scratch_value = view.load %scratch_view[%zero_index] : view<1xi32, #dense> -> i32
+  %scratch_view = buffer.view %scratch[%base] : buffer -> view<1xi32, #dense>
+  %scratch_value = view.load %scratch_view[%origin] : view<1xi32, #dense> -> i32
   %private = buffer.alloca %bytes {base_alignment = 4, memory_space = private} : buffer
-  %private_view = buffer.view %private[%zero_offset] : buffer -> view<1xi32, #dense>
-  view.store %scratch_value, %private_view[%zero_index] : i32, view<1xi32, #dense>
+  %private_view = buffer.view %private[%base] : buffer -> view<1xi32, #dense>
+  view.store %scratch_value, %private_view[%origin] : i32, view<1xi32, #dense>
   func.return
 }
 
@@ -241,16 +241,16 @@ func.def @access_only_instruments_rank1_vector_memory(%layout: encoding<layout>,
 
 // RUN: pass sanitizer-insert-assertions{checks=access}
 func.def @access_only_instruments_dense_fragment_memory(%output: view<64x64xf32, #dense>, %row: index, %column: index, %value: vector<8xf32>) {
-  %four = index.constant 4 : index
-  vector.fragment.store<result> %value, %output[%row, %column] shape [%four, %four] : vector<8xf32>, view<64x64xf32, #dense>
+  %fragment_extent = index.constant 4 : index
+  vector.fragment.store<result> %value, %output[%row, %column] shape [%fragment_extent, %fragment_extent] : vector<8xf32>, view<64x64xf32, #dense>
   func.return
 }
 
 // ----
 func.def @access_only_instruments_dense_fragment_memory(%output: view<64x64xf32, #dense>, %row: index, %column: index, %value: vector<8xf32>) {
-  %four = index.constant 4 : index
+  %fragment_extent = index.constant 4 : index
   sanitizer.assert.accesses<write> %output[%row, %column] {static_count = 4, static_extents = [1, 4], static_strides = [1, 0]} : view<64x64xf32, #dense>
-  vector.fragment.store<result> %value, %output[%row, %column] shape [%four, %four] : vector<8xf32>, view<64x64xf32, #dense>
+  vector.fragment.store<result> %value, %output[%row, %column] shape [%fragment_extent, %fragment_extent] : vector<8xf32>, view<64x64xf32, #dense>
   func.return
 }
 
@@ -258,26 +258,26 @@ func.def @access_only_instruments_dense_fragment_memory(%output: view<64x64xf32,
 
 // RUN: pass sanitizer-insert-assertions{checks=access}
 func.def @access_only_instruments_strided_fragment_memory(%buffer: buffer, %row: index, %column: index, %value: vector<8xf32>) {
-  %two = index.constant 2 : index
-  %sixty_four = index.constant 64 : index
-  %layout = encoding.layout.strided [1, %sixty_four] : encoding<layout>
+  %fragment_extent = index.constant 2 : index
+  %row_stride = index.constant 64 : index
+  %layout = encoding.layout.strided [1, %row_stride] : encoding<layout>
   %base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %output = buffer.view %global[%base] : buffer -> view<64x64xf32, %layout>
-  vector.fragment.store<result> %value, %output[%row, %column] shape [%two, %two] : vector<8xf32>, view<64x64xf32, %layout>
+  vector.fragment.store<result> %value, %output[%row, %column] shape [%fragment_extent, %fragment_extent] : vector<8xf32>, view<64x64xf32, %layout>
   func.return
 }
 
 // ----
 func.def @access_only_instruments_strided_fragment_memory(%buffer: buffer, %row: index, %column: index, %value: vector<8xf32>) {
-  %two = index.constant 2 : index
-  %sixty_four = index.constant 64 : index
-  %layout = encoding.layout.strided [1, %sixty_four] : encoding<layout>
+  %fragment_extent = index.constant 2 : index
+  %row_stride = index.constant 64 : index
+  %layout = encoding.layout.strided [1, %row_stride] : encoding<layout>
   %base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %output = buffer.view %global[%base] : buffer -> view<64x64xf32, %layout>
   sanitizer.assert.accesses<write> %output[%row, %column] {static_count = 2, static_extents = [2, 1], static_strides = [0, 1]} : view<64x64xf32, %layout>
-  vector.fragment.store<result> %value, %output[%row, %column] shape [%two, %two] : vector<8xf32>, view<64x64xf32, %layout>
+  vector.fragment.store<result> %value, %output[%row, %column] shape [%fragment_extent, %fragment_extent] : vector<8xf32>, view<64x64xf32, %layout>
   func.return
 }
 
@@ -285,21 +285,21 @@ func.def @access_only_instruments_strided_fragment_memory(%buffer: buffer, %row:
 
 // RUN: pass sanitizer-insert-assertions{checks=access}
 func.def @access_only_instruments_non_contiguous_fragment_memory(%buffer: buffer, %row: index, %column: index, %value: vector<8xf32>) {
-  %two = index.constant 2 : index
-  %sixty_four = index.constant 64 : index
-  %layout = encoding.layout.strided [2, %sixty_four] : encoding<layout>
+  %fragment_extent = index.constant 2 : index
+  %row_stride = index.constant 64 : index
+  %layout = encoding.layout.strided [2, %row_stride] : encoding<layout>
   %base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %output = buffer.view %global[%base] : buffer -> view<64x64xf32, %layout>
-  vector.fragment.store<result> %value, %output[%row, %column] shape [%two, %two] : vector<8xf32>, view<64x64xf32, %layout>
+  vector.fragment.store<result> %value, %output[%row, %column] shape [%fragment_extent, %fragment_extent] : vector<8xf32>, view<64x64xf32, %layout>
   func.return
 }
 
 // ----
 func.def @access_only_instruments_non_contiguous_fragment_memory(%buffer: buffer, %row: index, %column: index, %value: vector<8xf32>) {
-  %two = index.constant 2 : index
-  %sixty_four = index.constant 64 : index
-  %layout = encoding.layout.strided [2, %sixty_four] : encoding<layout>
+  %fragment_extent = index.constant 2 : index
+  %row_stride = index.constant 64 : index
+  %layout = encoding.layout.strided [2, %row_stride] : encoding<layout>
   %base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %buffer : buffer
   %output = buffer.view %global[%base] : buffer -> view<64x64xf32, %layout>
@@ -307,7 +307,7 @@ func.def @access_only_instruments_non_contiguous_fragment_memory(%buffer: buffer
   %10 = index.constant 1 : index
   %11 = index.add %column, %10 : index
   sanitizer.assert.accesses<write> %output[%row, %11] {static_count = 2, static_extents = [1, 1], static_strides = [1, 0]} : view<64x64xf32, %layout>
-  vector.fragment.store<result> %value, %output[%row, %column] shape [%two, %two] : vector<8xf32>, view<64x64xf32, %layout>
+  vector.fragment.store<result> %value, %output[%row, %column] shape [%fragment_extent, %fragment_extent] : vector<8xf32>, view<64x64xf32, %layout>
   func.return
 }
 
@@ -315,21 +315,21 @@ func.def @access_only_instruments_non_contiguous_fragment_memory(%buffer: buffer
 
 // RUN: pass sanitizer-insert-assertions{checks=access}
 func.def @access_only_instruments_blocked_fragment_memory(%output: view<8x64x64xf32, #dense>, %block: index, %row: index, %column: index, %value: vector<32xf32>) {
-  %two = index.constant 2 : index
-  %four = index.constant 4 : index
-  vector.fragment.store<result> %value, %output[%block, %row, %column] shape [blocks(%two), %four, %four] : vector<32xf32>, view<8x64x64xf32, #dense>
+  %block_count = index.constant 2 : index
+  %fragment_extent = index.constant 4 : index
+  vector.fragment.store<result> %value, %output[%block, %row, %column] shape [blocks(%block_count), %fragment_extent, %fragment_extent] : vector<32xf32>, view<8x64x64xf32, #dense>
   func.return
 }
 
 // ----
 func.def @access_only_instruments_blocked_fragment_memory(%output: view<8x64x64xf32, #dense>, %block: index, %row: index, %column: index, %value: vector<32xf32>) {
-  %two = index.constant 2 : index
-  %four = index.constant 4 : index
+  %block_count = index.constant 2 : index
+  %fragment_extent = index.constant 4 : index
   sanitizer.assert.accesses<write> %output[%block, %row, %column] {static_count = 4, static_extents = [1, 1, 4], static_strides = [0, 1, 0]} : view<8x64x64xf32, #dense>
   %7 = index.constant 1 : index
   %8 = index.add %block, %7 : index
   sanitizer.assert.accesses<write> %output[%8, %row, %column] {static_count = 4, static_extents = [1, 1, 4], static_strides = [0, 1, 0]} : view<8x64x64xf32, #dense>
-  vector.fragment.store<result> %value, %output[%block, %row, %column] shape [blocks(%two), %four, %four] : vector<32xf32>, view<8x64x64xf32, #dense>
+  vector.fragment.store<result> %value, %output[%block, %row, %column] shape [blocks(%block_count), %fragment_extent, %fragment_extent] : vector<32xf32>, view<8x64x64xf32, #dense>
   func.return
 }
 
@@ -337,25 +337,25 @@ func.def @access_only_instruments_blocked_fragment_memory(%output: view<8x64x64x
 
 // RUN: pass sanitizer-insert-assertions{checks=access}
 func.def @access_only_skips_workgroup_vector_memory() {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %base = index.constant 0 : offset
+  %origin = index.constant 0 : index
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero_offset] : buffer -> view<4x4xi32, #dense>
-  %value = vector.load %view[%zero_index, 0] : view<4x4xi32, #dense> -> vector<4xi32>
-  vector.store %value, %view[%zero_index, 0] : vector<4xi32>, view<4x4xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<4x4xi32, #dense>
+  %value = vector.load %view[%origin, 0] : view<4x4xi32, #dense> -> vector<4xi32>
+  vector.store %value, %view[%origin, 0] : vector<4xi32>, view<4x4xi32, #dense>
   func.return
 }
 
 // ----
 func.def @access_only_skips_workgroup_vector_memory() {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %base = index.constant 0 : offset
+  %origin = index.constant 0 : index
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero_offset] : buffer -> view<4x4xi32, #dense>
-  %value = vector.load %view[%zero_index, 0] : view<4x4xi32, #dense> -> vector<4xi32>
-  vector.store %value, %view[%zero_index, 0] : vector<4xi32>, view<4x4xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<4x4xi32, #dense>
+  %value = vector.load %view[%origin, 0] : view<4x4xi32, #dense> -> vector<4xi32>
+  vector.store %value, %view[%origin, 0] : vector<4xi32>, view<4x4xi32, #dense>
   func.return
 }
 
@@ -379,28 +379,28 @@ func.def @access_only_keeps_existing_vector_assertions(%layout: encoding<layout>
 
 // RUN: pass sanitizer-insert-assertions{checks=access}
 func.def @access_only_skips_workgroup_vector_atomic_memory() {
-  %zero_offset = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %origin = index.constant 0 : index
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero_offset] : buffer -> view<16xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<16xi32, #dense>
   %offsets = vector.splat %origin : vector<2xindex>
-  %one = scalar.constant 1 : i32
-  %value = vector.splat %one : vector<2xi32>
+  %increment = scalar.constant 1 : i32
+  %value = vector.splat %increment : vector<2xi32>
   vector.atomic.reduce<addi> %value, %view[%origin][%offsets] {ordering = relaxed, scope = workgroup} : vector<2xi32>, view<16xi32, #dense>, vector<2xindex>
   func.return
 }
 
 // ----
 func.def @access_only_skips_workgroup_vector_atomic_memory() {
-  %zero_offset = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %origin = index.constant 0 : index
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero_offset] : buffer -> view<16xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<16xi32, #dense>
   %offsets = vector.splat %origin : vector<2xindex>
-  %one = scalar.constant 1 : i32
-  %value = vector.splat %one : vector<2xi32>
+  %increment = scalar.constant 1 : i32
+  %value = vector.splat %increment : vector<2xi32>
   vector.atomic.reduce<addi> %value, %view[%origin][%offsets] {ordering = relaxed, scope = workgroup} : vector<2xi32>, view<16xi32, #dense>, vector<2xindex>
   func.return
 }

--- a/loom/src/loom/sanitizer/test/insert_race_observations.loom-test
+++ b/loom/src/loom/sanitizer/test/insert_race_observations.loom-test
@@ -1,15 +1,15 @@
 // RUN: pass sanitizer-insert-race-observations{checks=race}
 
 kernel.def @workgroup_load_store_and_barrier() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%threads, %unit_extent, %unit_extent) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<64xi32, #dense>
   %value = view.load %view[%lane] : view<64xi32, #dense> -> i32
   view.store %value, %view[%lane] : i32, view<64xi32, #dense>
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
@@ -18,15 +18,15 @@ kernel.def @workgroup_load_store_and_barrier() {
 
 // ----
 kernel.def @workgroup_load_store_and_barrier() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%threads, %unit_extent, %unit_extent) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<64xi32, #dense>
   sanitizer.race.access<read> %view[%lane] : view<64xi32, #dense>
   %value = view.load %view[%lane] : view<64xi32, #dense> -> i32
   sanitizer.race.access<write> %view[%lane] : view<64xi32, #dense>
@@ -39,15 +39,15 @@ kernel.def @workgroup_load_store_and_barrier() {
 // ====
 
 kernel.def @workgroup_vector_load_store_lanes() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%threads, %unit_extent, %unit_extent) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<64x4xi32, #dense>
   %value = vector.load %view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %value, %view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
   kernel.return
@@ -55,15 +55,15 @@ kernel.def @workgroup_vector_load_store_lanes() {
 
 // ----
 kernel.def @workgroup_vector_load_store_lanes() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%threads, %unit_extent, %unit_extent) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<64x4xi32, #dense>
   sanitizer.race.access<read> %view[%lane, 0] : view<64x4xi32, #dense>
   sanitizer.race.access<read> %view[%lane, 1] : view<64x4xi32, #dense>
   sanitizer.race.access<read> %view[%lane, 2] : view<64x4xi32, #dense>
@@ -80,15 +80,15 @@ kernel.def @workgroup_vector_load_store_lanes() {
 // ====
 
 kernel.def @workgroup_vector_dynamic_lane_offsets() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%threads, %unit_extent, %unit_extent) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
   %bytes = index.constant 512 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 8, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<128xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<128xi32, #dense>
   %value = vector.load %view[%lane] : view<128xi32, #dense> -> vector<2xi32>
   vector.store %value, %view[%lane] : vector<2xi32>, view<128xi32, #dense>
   kernel.return
@@ -96,15 +96,15 @@ kernel.def @workgroup_vector_dynamic_lane_offsets() {
 
 // ----
 kernel.def @workgroup_vector_dynamic_lane_offsets() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%threads, %unit_extent, %unit_extent) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
   %bytes = index.constant 512 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 8, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<128xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<128xi32, #dense>
   sanitizer.race.access<read> %view[%lane] : view<128xi32, #dense>
   %10 = index.constant 1 : index
   %11 = index.add %lane, %10 : index
@@ -121,15 +121,15 @@ kernel.def @workgroup_vector_dynamic_lane_offsets() {
 // ====
 
 kernel.def @masked_vector_workgroup_access_requires_lane_activity() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%threads, %unit_extent, %unit_extent) : index
 } launch(%mask: vector<4xi1>, %old: vector<4xi32>) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<64x4xi32, #dense>
   // ERROR@+1: LOWERING/046 {op_name="vector.load.mask", phase_name="sanitizer-insert-race-observations", reason="local-memory vector operation requires lane-activity-aware race observation"}
   %value = vector.load.mask %view[%lane, 0], %mask, %old : view<64x4xi32, #dense>, vector<4xi1>, vector<4xi32>
   vector.store %value, %view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
@@ -139,15 +139,15 @@ kernel.def @masked_vector_workgroup_access_requires_lane_activity() {
 // ====
 
 kernel.def @workgroup_atomics_are_observed() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%threads, %unit_extent, %unit_extent) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<64xi32, #dense>
   %value = scalar.constant 1 : i32
   view.atomic.reduce<addi> %value, %view[%lane] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
   %old = view.atomic.rmw<addi> %value, %view[%lane] {ordering = release, scope = workgroup} : i32, view<64xi32, #dense> -> i32
@@ -157,15 +157,15 @@ kernel.def @workgroup_atomics_are_observed() {
 
 // ----
 kernel.def @workgroup_atomics_are_observed() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%threads, %unit_extent, %unit_extent) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<64xi32, #dense>
   %value = scalar.constant 1 : i32
   sanitizer.race.access<read_write> %view[%lane] {atomic = true, ordering = relaxed, scope = workgroup} : view<64xi32, #dense>
   view.atomic.reduce<addi> %value, %view[%lane] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
@@ -179,34 +179,34 @@ kernel.def @workgroup_atomics_are_observed() {
 // ====
 
 kernel.def @non_workgroup_memory_is_not_observed() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit_extent = index.constant 1 : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%unit_extent, %unit_extent, %unit_extent) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %i = index.constant 0 : index
   %global = buffer.assume.memory_space<global> %input : buffer
-  %global_view = buffer.view %global[%zero] : buffer -> view<1xi32, #dense>
+  %global_view = buffer.view %global[%base] : buffer -> view<1xi32, #dense>
   %global_value = view.load %global_view[%i] : view<1xi32, #dense> -> i32
   %bytes = index.constant 4 : offset
   %private = buffer.alloca %bytes {base_alignment = 4, memory_space = private} : buffer
-  %private_view = buffer.view %private[%zero] : buffer -> view<1xi32, #dense>
+  %private_view = buffer.view %private[%base] : buffer -> view<1xi32, #dense>
   view.store %global_value, %private_view[%i] : i32, view<1xi32, #dense>
   kernel.return
 }
 
 // ----
 kernel.def @non_workgroup_memory_is_not_observed() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit_extent = index.constant 1 : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%unit_extent, %unit_extent, %unit_extent) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %i = index.constant 0 : index
   %global = buffer.assume.memory_space<global> %input : buffer
-  %global_view = buffer.view %global[%zero] : buffer -> view<1xi32, #dense>
+  %global_view = buffer.view %global[%base] : buffer -> view<1xi32, #dense>
   %global_value = view.load %global_view[%i] : view<1xi32, #dense> -> i32
   %bytes = index.constant 4 : offset
   %private = buffer.alloca %bytes {base_alignment = 4, memory_space = private} : buffer
-  %private_view = buffer.view %private[%zero] : buffer -> view<1xi32, #dense>
+  %private_view = buffer.view %private[%base] : buffer -> view<1xi32, #dense>
   view.store %global_value, %private_view[%i] : i32, view<1xi32, #dense>
   kernel.return
 }
@@ -214,14 +214,14 @@ kernel.def @non_workgroup_memory_is_not_observed() {
 // ====
 
 kernel.def @existing_observations_are_preserved() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit_extent = index.constant 1 : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%unit_extent, %unit_extent, %unit_extent) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %i = index.constant 0 : index
   %bytes = index.constant 4 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<1xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<1xi32, #dense>
   sanitizer.race.access<read> %view[%i] : view<1xi32, #dense>
   %value = view.load %view[%i] : view<1xi32, #dense> -> i32
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
@@ -231,14 +231,14 @@ kernel.def @existing_observations_are_preserved() {
 
 // ----
 kernel.def @existing_observations_are_preserved() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit_extent = index.constant 1 : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%unit_extent, %unit_extent, %unit_extent) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %i = index.constant 0 : index
   %bytes = index.constant 4 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<1xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<1xi32, #dense>
   sanitizer.race.access<read> %view[%i] : view<1xi32, #dense>
   %value = view.load %view[%i] : view<1xi32, #dense> -> i32
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
@@ -251,14 +251,14 @@ kernel.def @existing_observations_are_preserved() {
 // RUN: with-locations pass sanitizer-insert-race-observations{checks=race}
 
 kernel.def @race_site_payload_locations() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit_extent = index.constant 1 : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%unit_extent, %unit_extent, %unit_extent) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %i = index.constant 0 : index
   %bytes = index.constant 4 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<1xi32, #dense>
+  %view = buffer.view %scratch[%base] : buffer -> view<1xi32, #dense>
   %value = view.load %view[%i] : view<1xi32, #dense> -> i32 loc("race.loom":8:1)
   view.store %value, %view[%i] : i32, view<1xi32, #dense> loc("race.loom":9:1)
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup} loc("race.loom":10:1)
@@ -267,14 +267,14 @@ kernel.def @race_site_payload_locations() {
 
 // ----
 kernel.def @race_site_payload_locations() {
-  %one = index.constant 1 : index loc("loom/src/loom/sanitizer/test/insert_race_observations.loom-test":2:3 to 2:34)
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index loc("loom/src/loom/sanitizer/test/insert_race_observations.loom-test":3:3 to 3:93)
+  %unit_extent = index.constant 1 : index loc("loom/src/loom/sanitizer/test/insert_race_observations.loom-test":2:3 to 2:42)
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%unit_extent, %unit_extent, %unit_extent) : index loc("loom/src/loom/sanitizer/test/insert_race_observations.loom-test":3:3 to 3:141)
 } launch() {
-  %zero = index.constant 0 : offset loc("loom/src/loom/sanitizer/test/insert_race_observations.loom-test":5:3 to 5:36)
+  %base = index.constant 0 : offset loc("loom/src/loom/sanitizer/test/insert_race_observations.loom-test":5:3 to 5:36)
   %i = index.constant 0 : index loc("loom/src/loom/sanitizer/test/insert_race_observations.loom-test":6:3 to 6:32)
   %bytes = index.constant 4 : offset loc("loom/src/loom/sanitizer/test/insert_race_observations.loom-test":7:3 to 7:37)
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer loc("loom/src/loom/sanitizer/test/insert_race_observations.loom-test":8:3 to 8:90)
-  %view = buffer.view %scratch[%zero] : buffer -> view<1xi32, #dense> loc("loom/src/loom/sanitizer/test/insert_race_observations.loom-test":9:3 to 9:70)
+  %view = buffer.view %scratch[%base] : buffer -> view<1xi32, #dense> loc("loom/src/loom/sanitizer/test/insert_race_observations.loom-test":9:3 to 9:70)
   sanitizer.race.access<read> %view[%i] : view<1xi32, #dense> loc(tagged<sanitizer_site, "00050f0402010000", "race.loom":8:1>)
   %value = view.load %view[%i] : view<1xi32, #dense> -> i32 loc("race.loom":8:1)
   sanitizer.race.access<write> %view[%i] : view<1xi32, #dense> loc(tagged<sanitizer_site, "00050f0402010000", "race.loom":9:1>)

--- a/loom/src/loom/target/arch/amdgpu/test/execution/divergent_loop_carry.loom
+++ b/loom/src/loom/target/arch/amdgpu/test/execution/divergent_loop_carry.loom
@@ -3,22 +3,22 @@
 amdgpu.target<gfx11-generic> @gfx11_wave64 {subgroup_size = 64}
 
 kernel.def target(@gfx11_wave64) @divergent_loop_carry() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%upper_bounds: buffer, %values: buffer, %output: buffer) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %zero_i32 = scalar.constant 0 : i32
-  %zero_offset = index.constant 0 : offset
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %initial_count = scalar.constant 0 : i32
+  %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
-  %upper_bound_view = buffer.view %upper_bounds[%zero_offset] : buffer -> view<64xi32, #dense>
-  %value_view = buffer.view %values[%zero_offset] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<64xi32, #dense>
+  %upper_bound_view = buffer.view %upper_bounds[%base] : buffer -> view<64xi32, #dense>
+  %value_view = buffer.view %values[%base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<64xi32, #dense>
   %upper_bound_i32 = view.load %upper_bound_view[%lane] : view<64xi32, #dense> -> i32
   %upper_bound0 = index.cast %upper_bound_i32 : i32 to index
   %upper_bound = index.assume %upper_bound0 [range(%upper_bound0, 0, 64)] : index
-  %count = scf.for %position = [%zero to %upper_bound step %one](%running_count = %zero_i32 : i32) -> (i32) {
+  %count = scf.for %position = [%loop_begin to %upper_bound step %loop_step](%running_count = %initial_count : i32) -> (i32) {
     %bounded_position = index.assume %position [range(%position, 0, 63)] : index
     %value = view.load %value_view[%bounded_position] : view<64xi32, #dense> -> i32
     %next_count = scalar.addi %running_count, %value : i32
@@ -39,4 +39,3 @@ check.case public @divergent_loop_carry_case {
 }
 
 check.benchmark<@divergent_loop_carry_case>
-

--- a/loom/src/loom/target/arch/amdgpu/test/execution/fp8_encode.loom
+++ b/loom/src/loom/target/arch/amdgpu/test/execution/fp8_encode.loom
@@ -10,13 +10,13 @@
 config.decl @fp8_encode.row_capacity : %value: index where [range(%value, 1, 4294967295)]
 
 kernel.def @f32_to_fp8(%row_count: index) {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
   %rounding = index.constant 63 : index
   %row_capacity = config.get @fp8_encode.row_capacity : index
   %rounded_rows = index.add %row_capacity, %rounding : index
   %workgroups = index.div %rounded_rows, %workgroup_size : index
-  kernel.launch.config workgroups(%workgroups, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%row_count: index, %input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %row_capacity = config.get @fp8_encode.row_capacity : index
@@ -25,27 +25,27 @@ kernel.def @f32_to_fp8(%row_count: index) {
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 64 : index
   %row = index.madd %workgroup, %workgroup_size, %lane : index
-  %zero = index.constant 0 : index
+  %vector_column = index.constant 0 : index
   %in_bounds = index.cmp ult, %row, %bounded_row_count : index
   %input_noalias, %output_noalias = buffer.assume.noalias %input, %output : buffer, buffer
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<[%bounded_row_count]x4xf32, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<[%bounded_row_count]x4xf8E4M3, #dense>
   scf.if %in_bounds {
-    %source = vector.load %input_view[%row, %zero] : view<[%bounded_row_count]x4xf32, #dense> -> vector<4xf32>
+    %source = vector.load %input_view[%row, %vector_column] : view<[%bounded_row_count]x4xf32, #dense> -> vector<4xf32>
     %encoded = vector.fptrunc %source : vector<4xf32> to vector<4xf8E4M3>
-    vector.store %encoded, %output_view[%row, %zero] : vector<4xf8E4M3>, view<[%bounded_row_count]x4xf8E4M3, #dense>
+    vector.store %encoded, %output_view[%row, %vector_column] : vector<4xf8E4M3>, view<[%bounded_row_count]x4xf8E4M3, #dense>
   }
   kernel.return
 }
 
 kernel.def @f32_to_bf8(%row_count: index) {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
   %rounding = index.constant 63 : index
   %row_capacity = config.get @fp8_encode.row_capacity : index
   %rounded_rows = index.add %row_capacity, %rounding : index
   %workgroups = index.div %rounded_rows, %workgroup_size : index
-  kernel.launch.config workgroups(%workgroups, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%row_count: index, %input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %row_capacity = config.get @fp8_encode.row_capacity : index
@@ -54,27 +54,27 @@ kernel.def @f32_to_bf8(%row_count: index) {
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 64 : index
   %row = index.madd %workgroup, %workgroup_size, %lane : index
-  %zero = index.constant 0 : index
+  %vector_column = index.constant 0 : index
   %in_bounds = index.cmp ult, %row, %bounded_row_count : index
   %input_noalias, %output_noalias = buffer.assume.noalias %input, %output : buffer, buffer
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<[%bounded_row_count]x4xf32, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<[%bounded_row_count]x4xf8E5M2, #dense>
   scf.if %in_bounds {
-    %source = vector.load %input_view[%row, %zero] : view<[%bounded_row_count]x4xf32, #dense> -> vector<4xf32>
+    %source = vector.load %input_view[%row, %vector_column] : view<[%bounded_row_count]x4xf32, #dense> -> vector<4xf32>
     %encoded = vector.fptrunc %source : vector<4xf32> to vector<4xf8E5M2>
-    vector.store %encoded, %output_view[%row, %zero] : vector<4xf8E5M2>, view<[%bounded_row_count]x4xf8E5M2, #dense>
+    vector.store %encoded, %output_view[%row, %vector_column] : vector<4xf8E5M2>, view<[%bounded_row_count]x4xf8E5M2, #dense>
   }
   kernel.return
 }
 
 kernel.def @f16_to_bf8(%row_count: index) {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
   %rounding = index.constant 63 : index
   %row_capacity = config.get @fp8_encode.row_capacity : index
   %rounded_rows = index.add %row_capacity, %rounding : index
   %workgroups = index.div %rounded_rows, %workgroup_size : index
-  kernel.launch.config workgroups(%workgroups, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%row_count: index, %input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %row_capacity = config.get @fp8_encode.row_capacity : index
@@ -83,27 +83,27 @@ kernel.def @f16_to_bf8(%row_count: index) {
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 64 : index
   %row = index.madd %workgroup, %workgroup_size, %lane : index
-  %zero = index.constant 0 : index
+  %vector_column = index.constant 0 : index
   %in_bounds = index.cmp ult, %row, %bounded_row_count : index
   %input_noalias, %output_noalias = buffer.assume.noalias %input, %output : buffer, buffer
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<[%bounded_row_count]x4xf16, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<[%bounded_row_count]x4xf8E5M2, #dense>
   scf.if %in_bounds {
-    %source = vector.load %input_view[%row, %zero] : view<[%bounded_row_count]x4xf16, #dense> -> vector<4xf16>
+    %source = vector.load %input_view[%row, %vector_column] : view<[%bounded_row_count]x4xf16, #dense> -> vector<4xf16>
     %encoded = vector.fptrunc %source : vector<4xf16> to vector<4xf8E5M2>
-    vector.store %encoded, %output_view[%row, %zero] : vector<4xf8E5M2>, view<[%bounded_row_count]x4xf8E5M2, #dense>
+    vector.store %encoded, %output_view[%row, %vector_column] : vector<4xf8E5M2>, view<[%bounded_row_count]x4xf8E5M2, #dense>
   }
   kernel.return
 }
 
 kernel.def @bf16_to_fp8(%row_count: index) {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
   %rounding = index.constant 63 : index
   %row_capacity = config.get @fp8_encode.row_capacity : index
   %rounded_rows = index.add %row_capacity, %rounding : index
   %workgroups = index.div %rounded_rows, %workgroup_size : index
-  kernel.launch.config workgroups(%workgroups, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%row_count: index, %input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %row_capacity = config.get @fp8_encode.row_capacity : index
@@ -112,15 +112,15 @@ kernel.def @bf16_to_fp8(%row_count: index) {
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 64 : index
   %row = index.madd %workgroup, %workgroup_size, %lane : index
-  %zero = index.constant 0 : index
+  %vector_column = index.constant 0 : index
   %in_bounds = index.cmp ult, %row, %bounded_row_count : index
   %input_noalias, %output_noalias = buffer.assume.noalias %input, %output : buffer, buffer
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<[%bounded_row_count]x4xbf16, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<[%bounded_row_count]x4xf8E4M3, #dense>
   scf.if %in_bounds {
-    %source = vector.load %input_view[%row, %zero] : view<[%bounded_row_count]x4xbf16, #dense> -> vector<4xbf16>
+    %source = vector.load %input_view[%row, %vector_column] : view<[%bounded_row_count]x4xbf16, #dense> -> vector<4xbf16>
     %encoded = vector.fptrunc %source : vector<4xbf16> to vector<4xf8E4M3>
-    vector.store %encoded, %output_view[%row, %zero] : vector<4xf8E4M3>, view<[%bounded_row_count]x4xf8E4M3, #dense>
+    vector.store %encoded, %output_view[%row, %vector_column] : vector<4xf8E4M3>, view<[%bounded_row_count]x4xf8E4M3, #dense>
   }
   kernel.return
 }
@@ -128,13 +128,13 @@ kernel.def @bf16_to_fp8(%row_count: index) {
 // Converts raw F32 payloads and stores the encoded bytes so signed zero, NaN,
 // infinity, and exact RNE boundaries can be checked bit-for-bit.
 kernel.def @f32_bits_to_fp8_bytes(%row_count: index) {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
   %rounding = index.constant 63 : index
   %row_capacity = config.get @fp8_encode.row_capacity : index
   %rounded_rows = index.add %row_capacity, %rounding : index
   %workgroups = index.div %rounded_rows, %workgroup_size : index
-  kernel.launch.config workgroups(%workgroups, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%row_count: index, %input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %row_capacity = config.get @fp8_encode.row_capacity : index
@@ -143,29 +143,29 @@ kernel.def @f32_bits_to_fp8_bytes(%row_count: index) {
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 64 : index
   %row = index.madd %workgroup, %workgroup_size, %lane : index
-  %zero = index.constant 0 : index
+  %vector_column = index.constant 0 : index
   %in_bounds = index.cmp ult, %row, %bounded_row_count : index
   %input_noalias, %output_noalias = buffer.assume.noalias %input, %output : buffer, buffer
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<[%bounded_row_count]x4xi32, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<[%bounded_row_count]x4xi8, #dense>
   scf.if %in_bounds {
-    %source_bits = vector.load %input_view[%row, %zero] : view<[%bounded_row_count]x4xi32, #dense> -> vector<4xi32>
+    %source_bits = vector.load %input_view[%row, %vector_column] : view<[%bounded_row_count]x4xi32, #dense> -> vector<4xi32>
     %source = vector.bitcast %source_bits : vector<4xi32> to vector<4xf32>
     %encoded = vector.fptrunc %source : vector<4xf32> to vector<4xf8E4M3>
     %encoded_bits = vector.bitcast %encoded : vector<4xf8E4M3> to vector<4xi8>
-    vector.store %encoded_bits, %output_view[%row, %zero] : vector<4xi8>, view<[%bounded_row_count]x4xi8, #dense>
+    vector.store %encoded_bits, %output_view[%row, %vector_column] : vector<4xi8>, view<[%bounded_row_count]x4xi8, #dense>
   }
   kernel.return
 }
 
 kernel.def @f32_bits_to_bf8_bytes(%row_count: index) {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
   %rounding = index.constant 63 : index
   %row_capacity = config.get @fp8_encode.row_capacity : index
   %rounded_rows = index.add %row_capacity, %rounding : index
   %workgroups = index.div %rounded_rows, %workgroup_size : index
-  kernel.launch.config workgroups(%workgroups, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%row_count: index, %input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %row_capacity = config.get @fp8_encode.row_capacity : index
@@ -174,17 +174,17 @@ kernel.def @f32_bits_to_bf8_bytes(%row_count: index) {
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 64 : index
   %row = index.madd %workgroup, %workgroup_size, %lane : index
-  %zero = index.constant 0 : index
+  %vector_column = index.constant 0 : index
   %in_bounds = index.cmp ult, %row, %bounded_row_count : index
   %input_noalias, %output_noalias = buffer.assume.noalias %input, %output : buffer, buffer
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<[%bounded_row_count]x4xi32, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<[%bounded_row_count]x4xi8, #dense>
   scf.if %in_bounds {
-    %source_bits = vector.load %input_view[%row, %zero] : view<[%bounded_row_count]x4xi32, #dense> -> vector<4xi32>
+    %source_bits = vector.load %input_view[%row, %vector_column] : view<[%bounded_row_count]x4xi32, #dense> -> vector<4xi32>
     %source = vector.bitcast %source_bits : vector<4xi32> to vector<4xf32>
     %encoded = vector.fptrunc %source : vector<4xf32> to vector<4xf8E5M2>
     %encoded_bits = vector.bitcast %encoded : vector<4xf8E5M2> to vector<4xi8>
-    vector.store %encoded_bits, %output_view[%row, %zero] : vector<4xi8>, view<[%bounded_row_count]x4xi8, #dense>
+    vector.store %encoded_bits, %output_view[%row, %vector_column] : vector<4xi8>, view<[%bounded_row_count]x4xi8, #dense>
   }
   kernel.return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/execution/fp8_finite_storage_decode.loom
+++ b/loom/src/loom/target/arch/amdgpu/test/execution/fp8_finite_storage_decode.loom
@@ -25,7 +25,7 @@ kernel.def @fp8_finite_storage_decode(%row_count: index) {
   %workgroup = kernel.workgroup.id<x> : index
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 64 : index
-  %zero_column = index.constant 0 : index
+  %vector_column = index.constant 0 : index
   %row = index.madd %workgroup, %workgroup_size, %lane : index
   %in_bounds = index.cmp ult, %row, %bounded_row_count : index
   %input_noalias, %output_noalias = buffer.assume.noalias %input, %output : buffer, buffer
@@ -35,9 +35,9 @@ kernel.def @fp8_finite_storage_decode(%row_count: index) {
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<[%bounded_row_count]x4xf8E4M3, %input_storage>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<[%bounded_row_count]x4xf32, #dense>
   scf.if %in_bounds {
-    %packed = vector.load %input_view[%row, %zero_column] : view<[%bounded_row_count]x4xf8E4M3, %input_storage> -> vector<4xf8E4M3>
+    %packed = vector.load %input_view[%row, %vector_column] : view<[%bounded_row_count]x4xf8E4M3, %input_storage> -> vector<4xf8E4M3>
     %decoded = vector.extf %packed : vector<4xf8E4M3> to vector<4xf32>
-    vector.store %decoded, %output_view[%row, %zero_column] : vector<4xf32>, view<[%bounded_row_count]x4xf32, #dense>
+    vector.store %decoded, %output_view[%row, %vector_column] : vector<4xf32>, view<[%bounded_row_count]x4xf32, #dense>
   }
   kernel.return
 }
@@ -58,7 +58,7 @@ kernel.def @fp8_finite_storage_decode_bf16(%row_count: index) {
   %workgroup = kernel.workgroup.id<x> : index
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 64 : index
-  %zero_column = index.constant 0 : index
+  %vector_column = index.constant 0 : index
   %row = index.madd %workgroup, %workgroup_size, %lane : index
   %in_bounds = index.cmp ult, %row, %bounded_row_count : index
   %input_noalias, %output_noalias = buffer.assume.noalias %input, %output : buffer, buffer
@@ -68,9 +68,9 @@ kernel.def @fp8_finite_storage_decode_bf16(%row_count: index) {
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<[%bounded_row_count]x4xf8E4M3, %input_storage>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<[%bounded_row_count]x4xbf16, #dense>
   scf.if %in_bounds {
-    %packed = vector.load %input_view[%row, %zero_column] : view<[%bounded_row_count]x4xf8E4M3, %input_storage> -> vector<4xf8E4M3>
+    %packed = vector.load %input_view[%row, %vector_column] : view<[%bounded_row_count]x4xf8E4M3, %input_storage> -> vector<4xf8E4M3>
     %decoded = vector.extf %packed : vector<4xf8E4M3> to vector<4xbf16>
-    vector.store %decoded, %output_view[%row, %zero_column] : vector<4xbf16>, view<[%bounded_row_count]x4xbf16, #dense>
+    vector.store %decoded, %output_view[%row, %vector_column] : vector<4xbf16>, view<[%bounded_row_count]x4xbf16, #dense>
   }
   kernel.return
 }
@@ -91,7 +91,7 @@ kernel.def @fp8_finite_storage_decode_f16(%row_count: index) {
   %workgroup = kernel.workgroup.id<x> : index
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 64 : index
-  %zero_column = index.constant 0 : index
+  %vector_column = index.constant 0 : index
   %row = index.madd %workgroup, %workgroup_size, %lane : index
   %in_bounds = index.cmp ult, %row, %bounded_row_count : index
   %input_noalias, %output_noalias = buffer.assume.noalias %input, %output : buffer, buffer
@@ -101,9 +101,9 @@ kernel.def @fp8_finite_storage_decode_f16(%row_count: index) {
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<[%bounded_row_count]x4xf8E4M3, %input_storage>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<[%bounded_row_count]x4xf16, #dense>
   scf.if %in_bounds {
-    %packed = vector.load %input_view[%row, %zero_column] : view<[%bounded_row_count]x4xf8E4M3, %input_storage> -> vector<4xf8E4M3>
+    %packed = vector.load %input_view[%row, %vector_column] : view<[%bounded_row_count]x4xf8E4M3, %input_storage> -> vector<4xf8E4M3>
     %decoded = vector.extf %packed : vector<4xf8E4M3> to vector<4xf16>
-    vector.store %decoded, %output_view[%row, %zero_column] : vector<4xf16>, view<[%bounded_row_count]x4xf16, #dense>
+    vector.store %decoded, %output_view[%row, %vector_column] : vector<4xf16>, view<[%bounded_row_count]x4xf16, #dense>
   }
   kernel.return
 }
@@ -124,7 +124,7 @@ kernel.def @bf8_finite_storage_decode_f16(%row_count: index) {
   %workgroup = kernel.workgroup.id<x> : index
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 64 : index
-  %zero_column = index.constant 0 : index
+  %vector_column = index.constant 0 : index
   %row = index.madd %workgroup, %workgroup_size, %lane : index
   %in_bounds = index.cmp ult, %row, %bounded_row_count : index
   %input_noalias, %output_noalias = buffer.assume.noalias %input, %output : buffer, buffer
@@ -134,9 +134,9 @@ kernel.def @bf8_finite_storage_decode_f16(%row_count: index) {
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<[%bounded_row_count]x4xf8E5M2, %input_storage>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<[%bounded_row_count]x4xf16, #dense>
   scf.if %in_bounds {
-    %packed = vector.load %input_view[%row, %zero_column] : view<[%bounded_row_count]x4xf8E5M2, %input_storage> -> vector<4xf8E5M2>
+    %packed = vector.load %input_view[%row, %vector_column] : view<[%bounded_row_count]x4xf8E5M2, %input_storage> -> vector<4xf8E5M2>
     %decoded = vector.extf %packed : vector<4xf8E5M2> to vector<4xf16>
-    vector.store %decoded, %output_view[%row, %zero_column] : vector<4xf16>, view<[%bounded_row_count]x4xf16, #dense>
+    vector.store %decoded, %output_view[%row, %vector_column] : vector<4xf16>, view<[%bounded_row_count]x4xf16, #dense>
   }
   kernel.return
 }
@@ -157,7 +157,7 @@ kernel.def @fp8_finite_storage_scale_decode_bf16(%row_count: index) {
   %workgroup = kernel.workgroup.id<x> : index
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 64 : index
-  %zero_column = index.constant 0 : index
+  %vector_column = index.constant 0 : index
   %row = index.madd %workgroup, %workgroup_size, %lane : index
   %in_bounds = index.cmp ult, %row, %bounded_row_count : index
   %input_noalias, %scale_noalias, %output_noalias = buffer.assume.noalias %input, %scale, %output : buffer, buffer, buffer
@@ -169,11 +169,11 @@ kernel.def @fp8_finite_storage_scale_decode_bf16(%row_count: index) {
   %scale_view = buffer.view %scale_noalias[%base] : buffer -> view<[%bounded_row_count]xf32, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<[%bounded_row_count]x4xbf16, #dense>
   scf.if %in_bounds {
-    %packed = vector.load %input_view[%row, %zero_column] : view<[%bounded_row_count]x4xf8E4M3, %input_storage> -> vector<4xf8E4M3>
+    %packed = vector.load %input_view[%row, %vector_column] : view<[%bounded_row_count]x4xf8E4M3, %input_storage> -> vector<4xf8E4M3>
     %row_scale = view.load %scale_view[%row] : view<[%bounded_row_count]xf32, #dense> -> f32
     %scale_vector = vector.splat %row_scale : vector<1xf32>
     %decoded = vector.decode %packed using %decode_schema {scale = %scale_vector : vector<1xf32>} : vector<4xf8E4M3>, encoding<schema> -> vector<4xbf16>
-    vector.store %decoded, %output_view[%row, %zero_column] : vector<4xbf16>, view<[%bounded_row_count]x4xbf16, #dense>
+    vector.store %decoded, %output_view[%row, %vector_column] : vector<4xbf16>, view<[%bounded_row_count]x4xbf16, #dense>
   }
   kernel.return
 }
@@ -194,7 +194,7 @@ kernel.def @bf8_finite_storage_scale_decode_bf16(%row_count: index) {
   %workgroup = kernel.workgroup.id<x> : index
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 64 : index
-  %zero_column = index.constant 0 : index
+  %vector_column = index.constant 0 : index
   %row = index.madd %workgroup, %workgroup_size, %lane : index
   %in_bounds = index.cmp ult, %row, %bounded_row_count : index
   %input_noalias, %scale_noalias, %output_noalias = buffer.assume.noalias %input, %scale, %output : buffer, buffer, buffer
@@ -206,11 +206,11 @@ kernel.def @bf8_finite_storage_scale_decode_bf16(%row_count: index) {
   %scale_view = buffer.view %scale_noalias[%base] : buffer -> view<[%bounded_row_count]xf32, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<[%bounded_row_count]x4xbf16, #dense>
   scf.if %in_bounds {
-    %packed = vector.load %input_view[%row, %zero_column] : view<[%bounded_row_count]x4xf8E5M2, %input_storage> -> vector<4xf8E5M2>
+    %packed = vector.load %input_view[%row, %vector_column] : view<[%bounded_row_count]x4xf8E5M2, %input_storage> -> vector<4xf8E5M2>
     %row_scale = view.load %scale_view[%row] : view<[%bounded_row_count]xf32, #dense> -> f32
     %scale_vector = vector.splat %row_scale : vector<1xf32>
     %decoded = vector.decode %packed using %decode_schema {scale = %scale_vector : vector<1xf32>} : vector<4xf8E5M2>, encoding<schema> -> vector<4xbf16>
-    vector.store %decoded, %output_view[%row, %zero_column] : vector<4xbf16>, view<[%bounded_row_count]x4xbf16, #dense>
+    vector.store %decoded, %output_view[%row, %vector_column] : vector<4xbf16>, view<[%bounded_row_count]x4xbf16, #dense>
   }
   kernel.return
 }
@@ -222,15 +222,15 @@ kernel.def @fp8_finite_storage_rhs_fragment_decode_bf16() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %fragment_origin = index.constant 0 : index
+  %tile_extent = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e4m3, payload_elements=16, payload_registers=4, rounding=finite_only> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
   %input_view = buffer.view %input[%base] : buffer -> view<16x16xf8E4M3, %input_storage>
   %output_view = buffer.view %output[%base] : buffer -> view<16xbf16, #dense>
-  %fragment = vector.fragment.load<rhs> %input_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E4M3, %input_storage> -> vector<16xbf16>
-  vector.store %fragment, %output_view[%zero] : vector<16xbf16>, view<16xbf16, #dense>
+  %fragment = vector.fragment.load<rhs> %input_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xf8E4M3, %input_storage> -> vector<16xbf16>
+  vector.store %fragment, %output_view[%fragment_origin] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
 }
 
@@ -240,15 +240,15 @@ kernel.def @fp8_finite_storage_compact_rhs_fragment_decode_bf16() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %fragment_origin = index.constant 0 : index
+  %tile_extent = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e4m3, payload_elements=1, payload_registers=1, rounding=finite_only> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
   %input_view = buffer.view %input[%base] : buffer -> view<16x16xf8E4M3, %input_storage>
   %output_view = buffer.view %output[%base] : buffer -> view<16xbf16, #dense>
-  %fragment = vector.fragment.load<rhs> %input_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E4M3, %input_storage> -> vector<16xbf16>
-  vector.store %fragment, %output_view[%zero] : vector<16xbf16>, view<16xbf16, #dense>
+  %fragment = vector.fragment.load<rhs> %input_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xf8E4M3, %input_storage> -> vector<16xbf16>
+  vector.store %fragment, %output_view[%fragment_origin] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
 }
 
@@ -259,15 +259,15 @@ kernel.def @bf8_finite_storage_rhs_fragment_decode_bf16() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %fragment_origin = index.constant 0 : index
+  %tile_extent = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e5m2, payload_elements=16, payload_registers=4, rounding=finite_only> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
   %input_view = buffer.view %input[%base] : buffer -> view<16x16xf8E5M2, %input_storage>
   %output_view = buffer.view %output[%base] : buffer -> view<16xbf16, #dense>
-  %fragment = vector.fragment.load<rhs> %input_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E5M2, %input_storage> -> vector<16xbf16>
-  vector.store %fragment, %output_view[%zero] : vector<16xbf16>, view<16xbf16, #dense>
+  %fragment = vector.fragment.load<rhs> %input_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xf8E5M2, %input_storage> -> vector<16xbf16>
+  vector.store %fragment, %output_view[%fragment_origin] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
 }
 
@@ -277,15 +277,15 @@ kernel.def @bf8_finite_storage_compact_rhs_fragment_decode_bf16() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %fragment_origin = index.constant 0 : index
+  %tile_extent = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e5m2, payload_elements=1, payload_registers=1, rounding=finite_only> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
   %input_view = buffer.view %input[%base] : buffer -> view<16x16xf8E5M2, %input_storage>
   %output_view = buffer.view %output[%base] : buffer -> view<16xbf16, #dense>
-  %fragment = vector.fragment.load<rhs> %input_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E5M2, %input_storage> -> vector<16xbf16>
-  vector.store %fragment, %output_view[%zero] : vector<16xbf16>, view<16xbf16, #dense>
+  %fragment = vector.fragment.load<rhs> %input_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xf8E5M2, %input_storage> -> vector<16xbf16>
+  vector.store %fragment, %output_view[%fragment_origin] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
 }
 
@@ -296,8 +296,8 @@ kernel.def @fp8_finite_storage_compact_rhs_fragment_mma_f32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs: buffer, %rhs: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %fragment_origin = index.constant 0 : index
+  %tile_extent = index.constant 16 : index
   %rhs_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %rhs_schema = encoding.define #matrix_operand<element_format=f8e4m3, payload_elements=1, payload_registers=1, rounding=finite_only> : encoding<schema>
   %rhs_storage = encoding.define #physical_storage {layout = %rhs_layout : encoding<layout>, schema = %rhs_schema : encoding<schema>} : encoding<storage>
@@ -305,11 +305,11 @@ kernel.def @fp8_finite_storage_compact_rhs_fragment_mma_f32() {
   %rhs_view = buffer.view %rhs[%base] : buffer -> view<16x16xf8E4M3, %rhs_storage>
   %output_view = buffer.view %output[%base] : buffer -> view<16x16xf32, #dense>
   %zero_accumulator = vector.constant 0.0 : vector<8xf32>
-  %init = vector.fragment<init> %zero_accumulator shape [%sixteen, %sixteen] : vector<8xf32>
-  %lhs_fragment = vector.fragment.load<lhs> %lhs_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xbf16, #dense> -> vector<16xbf16>
-  %rhs_fragment = vector.fragment.load<rhs> %rhs_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E4M3, %rhs_storage> -> vector<16xbf16>
+  %init = vector.fragment<init> %zero_accumulator shape [%tile_extent, %tile_extent] : vector<8xf32>
+  %lhs_fragment = vector.fragment.load<lhs> %lhs_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xbf16, #dense> -> vector<16xbf16>
+  %rhs_fragment = vector.fragment.load<rhs> %rhs_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xf8E4M3, %rhs_storage> -> vector<16xbf16>
   %result = vector.mma %lhs_fragment, %rhs_fragment, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
-  vector.fragment.store<result> %result, %output_view[%zero, %zero] shape [%sixteen, %sixteen] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %result, %output_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 
@@ -320,8 +320,8 @@ kernel.def @bf8_finite_storage_compact_rhs_fragment_mma_f32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs: buffer, %rhs: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %fragment_origin = index.constant 0 : index
+  %tile_extent = index.constant 16 : index
   %rhs_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %rhs_schema = encoding.define #matrix_operand<element_format=f8e5m2, payload_elements=1, payload_registers=1, rounding=finite_only> : encoding<schema>
   %rhs_storage = encoding.define #physical_storage {layout = %rhs_layout : encoding<layout>, schema = %rhs_schema : encoding<schema>} : encoding<storage>
@@ -329,11 +329,11 @@ kernel.def @bf8_finite_storage_compact_rhs_fragment_mma_f32() {
   %rhs_view = buffer.view %rhs[%base] : buffer -> view<16x16xf8E5M2, %rhs_storage>
   %output_view = buffer.view %output[%base] : buffer -> view<16x16xf32, #dense>
   %zero_accumulator = vector.constant 0.0 : vector<8xf32>
-  %init = vector.fragment<init> %zero_accumulator shape [%sixteen, %sixteen] : vector<8xf32>
-  %lhs_fragment = vector.fragment.load<lhs> %lhs_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xbf16, #dense> -> vector<16xbf16>
-  %rhs_fragment = vector.fragment.load<rhs> %rhs_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E5M2, %rhs_storage> -> vector<16xbf16>
+  %init = vector.fragment<init> %zero_accumulator shape [%tile_extent, %tile_extent] : vector<8xf32>
+  %lhs_fragment = vector.fragment.load<lhs> %lhs_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xbf16, #dense> -> vector<16xbf16>
+  %rhs_fragment = vector.fragment.load<rhs> %rhs_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xf8E5M2, %rhs_storage> -> vector<16xbf16>
   %result = vector.mma %lhs_fragment, %rhs_fragment, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
-  vector.fragment.store<result> %result, %output_view[%zero, %zero] shape [%sixteen, %sixteen] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %result, %output_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 
@@ -344,8 +344,8 @@ kernel.def @fp8_finite_flush_storage_compact_rhs_fragment_mma_f32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs: buffer, %rhs: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %fragment_origin = index.constant 0 : index
+  %tile_extent = index.constant 16 : index
   %rhs_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %rhs_schema = encoding.define #matrix_operand<element_format=f8e4m3, payload_elements=1, payload_registers=1, rounding=finite_flush_subnormal> : encoding<schema>
   %rhs_storage = encoding.define #physical_storage {layout = %rhs_layout : encoding<layout>, schema = %rhs_schema : encoding<schema>} : encoding<storage>
@@ -353,11 +353,11 @@ kernel.def @fp8_finite_flush_storage_compact_rhs_fragment_mma_f32() {
   %rhs_view = buffer.view %rhs[%base] : buffer -> view<16x16xf8E4M3, %rhs_storage>
   %output_view = buffer.view %output[%base] : buffer -> view<16x16xf32, #dense>
   %zero_accumulator = vector.constant 0.0 : vector<8xf32>
-  %init = vector.fragment<init> %zero_accumulator shape [%sixteen, %sixteen] : vector<8xf32>
-  %lhs_fragment = vector.fragment.load<lhs> %lhs_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xbf16, #dense> -> vector<16xbf16>
-  %rhs_fragment = vector.fragment.load<rhs> %rhs_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E4M3, %rhs_storage> -> vector<16xbf16>
+  %init = vector.fragment<init> %zero_accumulator shape [%tile_extent, %tile_extent] : vector<8xf32>
+  %lhs_fragment = vector.fragment.load<lhs> %lhs_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xbf16, #dense> -> vector<16xbf16>
+  %rhs_fragment = vector.fragment.load<rhs> %rhs_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xf8E4M3, %rhs_storage> -> vector<16xbf16>
   %result = vector.mma %lhs_fragment, %rhs_fragment, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
-  vector.fragment.store<result> %result, %output_view[%zero, %zero] shape [%sixteen, %sixteen] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %result, %output_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 
@@ -368,8 +368,8 @@ kernel.def @bf8_finite_flush_storage_compact_rhs_fragment_mma_f32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs: buffer, %rhs: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %fragment_origin = index.constant 0 : index
+  %tile_extent = index.constant 16 : index
   %rhs_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %rhs_schema = encoding.define #matrix_operand<element_format=f8e5m2, payload_elements=1, payload_registers=1, rounding=finite_flush_subnormal> : encoding<schema>
   %rhs_storage = encoding.define #physical_storage {layout = %rhs_layout : encoding<layout>, schema = %rhs_schema : encoding<schema>} : encoding<storage>
@@ -377,11 +377,11 @@ kernel.def @bf8_finite_flush_storage_compact_rhs_fragment_mma_f32() {
   %rhs_view = buffer.view %rhs[%base] : buffer -> view<16x16xf8E5M2, %rhs_storage>
   %output_view = buffer.view %output[%base] : buffer -> view<16x16xf32, #dense>
   %zero_accumulator = vector.constant 0.0 : vector<8xf32>
-  %init = vector.fragment<init> %zero_accumulator shape [%sixteen, %sixteen] : vector<8xf32>
-  %lhs_fragment = vector.fragment.load<lhs> %lhs_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xbf16, #dense> -> vector<16xbf16>
-  %rhs_fragment = vector.fragment.load<rhs> %rhs_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf8E5M2, %rhs_storage> -> vector<16xbf16>
+  %init = vector.fragment<init> %zero_accumulator shape [%tile_extent, %tile_extent] : vector<8xf32>
+  %lhs_fragment = vector.fragment.load<lhs> %lhs_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xbf16, #dense> -> vector<16xbf16>
+  %rhs_fragment = vector.fragment.load<rhs> %rhs_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xf8E5M2, %rhs_storage> -> vector<16xbf16>
   %result = vector.mma %lhs_fragment, %rhs_fragment, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
-  vector.fragment.store<result> %result, %output_view[%zero, %zero] shape [%sixteen, %sixteen] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %result, %output_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 
@@ -393,20 +393,21 @@ kernel.def @fp8_finite_storage_zero_scale_mixed_pair_bf16() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %scale: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %vector_origin = index.constant 0 : index
+  %scale_index = index.constant 0 : index
   %input_layout = encoding.layout.strided [1] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e4m3, payload_elements=8, payload_registers=2, rounding=finite_only> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
   %input_view = buffer.view %input[%base] : buffer -> view<8xf8E4M3, %input_storage>
   %scale_view = buffer.view %scale[%base] : buffer -> view<1xf32, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<8xbf16, #dense>
-  %packed = vector.load %input_view[%zero] : view<8xf8E4M3, %input_storage> -> vector<8xf8E4M3>
+  %packed = vector.load %input_view[%vector_origin] : view<8xf8E4M3, %input_storage> -> vector<8xf8E4M3>
   %wide = vector.extf %packed : vector<8xf8E4M3> to vector<8xf32>
-  %row_scale = view.load %scale_view[%zero] : view<1xf32, #dense> -> f32
+  %row_scale = view.load %scale_view[%scale_index] : view<1xf32, #dense> -> f32
   %scale_vector = vector.splat %row_scale : vector<8xf32>
   %scaled = vector.mulf %wide, %scale_vector : vector<8xf32>
   %rounded = vector.fptrunc %scaled : vector<8xf32> to vector<8xbf16>
-  vector.store %rounded, %output_view[%zero] : vector<8xbf16>, view<8xbf16, #dense>
+  vector.store %rounded, %output_view[%vector_origin] : vector<8xbf16>, view<8xbf16, #dense>
   kernel.return
 }
 
@@ -415,20 +416,21 @@ kernel.def @bf8_finite_storage_zero_scale_mixed_pair_bf16() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %scale: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %vector_origin = index.constant 0 : index
+  %scale_index = index.constant 0 : index
   %input_layout = encoding.layout.strided [1] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e5m2, payload_elements=8, payload_registers=2, rounding=finite_only> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
   %input_view = buffer.view %input[%base] : buffer -> view<8xf8E5M2, %input_storage>
   %scale_view = buffer.view %scale[%base] : buffer -> view<1xf32, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<8xbf16, #dense>
-  %packed = vector.load %input_view[%zero] : view<8xf8E5M2, %input_storage> -> vector<8xf8E5M2>
+  %packed = vector.load %input_view[%vector_origin] : view<8xf8E5M2, %input_storage> -> vector<8xf8E5M2>
   %wide = vector.extf %packed : vector<8xf8E5M2> to vector<8xf32>
-  %row_scale = view.load %scale_view[%zero] : view<1xf32, #dense> -> f32
+  %row_scale = view.load %scale_view[%scale_index] : view<1xf32, #dense> -> f32
   %scale_vector = vector.splat %row_scale : vector<8xf32>
   %scaled = vector.mulf %wide, %scale_vector : vector<8xf32>
   %rounded = vector.fptrunc %scaled : vector<8xf32> to vector<8xbf16>
-  vector.store %rounded, %output_view[%zero] : vector<8xbf16>, view<8xbf16, #dense>
+  vector.store %rounded, %output_view[%vector_origin] : vector<8xbf16>, view<8xbf16, #dense>
   kernel.return
 }
 
@@ -438,17 +440,17 @@ kernel.def @bf8_finite_storage_zero_scale_mixed_pair_bf16() {
 kernel.def @fp8_finite_storage_compact_rhs_tile_zero_scale_bf16(%output_size: index, %input_size: index) {
   %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  %sixteen = index.constant 16 : index
+  %tile_extent = index.constant 16 : index
   %input_capacity = config.get @finite_storage_decode.input_capacity : index
   %output_capacity = config.get @finite_storage_decode.output_capacity : index
-  %input_tile_count = index.div %input_capacity, %sixteen : index
-  %output_tile_count = index.div %output_capacity, %sixteen : index
+  %input_tile_count = index.div %input_capacity, %tile_extent : index
+  %output_tile_count = index.div %output_capacity, %tile_extent : index
   kernel.launch.config workgroups(%input_tile_count, %output_tile_count, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%output_size: index, %input_size: index, %weight: buffer, %scale: buffer, %target: buffer) {
   %base = index.constant 0 : offset
-  %two = index.constant 2 : index
-  %eight = index.constant 8 : index
-  %sixteen = index.constant 16 : index
+  %segments_per_output_row = index.constant 2 : index
+  %segment_extent = index.constant 8 : index
+  %tile_extent = index.constant 16 : index
   %input_tile0 = kernel.workgroup.id<x> : index
   %input_tile = index.assume %input_tile0 [range(%input_tile0, 0, 4095)] : index
   %output_tile0 = kernel.workgroup.id<y> : index
@@ -463,17 +465,17 @@ kernel.def @fp8_finite_storage_compact_rhs_tile_zero_scale_bf16(%output_size: in
   %output_capacity = config.get @finite_storage_decode.output_capacity : index
   %bounded_input_size = index.assume %input_size [range(%input_size, 16, 65536), mul(%input_size, 16), le(%input_size, %input_capacity)] : index
   %bounded_output_size = index.assume %output_size [range(%output_size, 16, 16384), mul(%output_size, 16), le(%output_size, %output_capacity)] : index
-  %input_tile_count = index.div %bounded_input_size, %sixteen : index
-  %output_tile_count = index.div %bounded_output_size, %sixteen : index
+  %input_tile_count = index.div %bounded_input_size, %tile_extent : index
+  %output_tile_count = index.div %bounded_output_size, %tile_extent : index
   %weight_view = buffer.view %weight_noalias[%base] : buffer -> view<[%bounded_output_size]x[%input_tile_count]x16xf8E4M3, %weight_storage>
   %scale_view = buffer.view %scale_noalias[%base] : buffer -> view<[%bounded_output_size]xf32, #dense>
   %target_view = buffer.view %target_noalias[%base] : buffer -> view<[%output_tile_count]x[%input_tile_count]x16x16xbf16, #dense>
-  %segment = index.rem %lane, %two : index
-  %output_lane0 = index.div %lane, %two : index
+  %segment = index.rem %lane, %segments_per_output_row : index
+  %output_lane0 = index.div %lane, %segments_per_output_row : index
   %output_lane = index.assume %output_lane0 [range(%output_lane0, 0, 15)] : index
-  %segment_offset0 = index.mul %segment, %eight : index
+  %segment_offset0 = index.mul %segment, %segment_extent : index
   %segment_offset = index.assume %segment_offset0 [range(%segment_offset0, 0, 8)] : index
-  %output_row = index.madd %output_tile, %sixteen, %output_lane : index
+  %output_row = index.madd %output_tile, %tile_extent, %output_lane : index
   %input_tile_in_bounds = index.cmp ult, %input_tile, %input_tile_count : index
   %output_tile_in_bounds = index.cmp ult, %output_tile, %output_tile_count : index
   %output_in_bounds = index.cmp ult, %output_row, %bounded_output_size : index

--- a/loom/src/loom/target/arch/amdgpu/test/execution/fragment_repack_bf16.loom
+++ b/loom/src/loom/target/arch/amdgpu/test/execution/fragment_repack_bf16.loom
@@ -6,8 +6,8 @@ kernel.def @fragment_repack_roundtrip_bf16() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %rhs: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %fragment_origin = index.constant 0 : index
+  %tile_extent = index.constant 16 : index
   %scratch_bytes = index.constant 512 : offset
 
   %rhs_layout = encoding.layout.strided [1, 16] : encoding<layout>
@@ -18,14 +18,14 @@ kernel.def @fragment_repack_roundtrip_bf16() {
   %scratch_view = buffer.view %scratch[%base] : buffer -> view<16x16xbf16, #dense>
 
   %zero_accumulator = vector.constant 0.0 : vector<8xf32>
-  %init = vector.fragment<init> %zero_accumulator shape [%sixteen, %sixteen] : vector<8xf32>
-  %result = vector.fragment.load<result> %input_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf32, #dense> -> vector<8xf32>
-  vector.fragment.store<result> %result, %scratch_view[%zero, %zero] shape [%sixteen, %sixteen] : vector<8xf32>, view<16x16xbf16, #dense>
+  %init = vector.fragment<init> %zero_accumulator shape [%tile_extent, %tile_extent] : vector<8xf32>
+  %result = vector.fragment.load<result> %input_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xf32, #dense> -> vector<8xf32>
+  vector.fragment.store<result> %result, %scratch_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : vector<8xf32>, view<16x16xbf16, #dense>
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
-  %lhs = vector.fragment.load<lhs> %scratch_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xbf16, #dense> -> vector<16xbf16>
-  %rhs_fragment = vector.fragment.load<rhs> %rhs_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xbf16, %rhs_layout> -> vector<16xbf16>
+  %lhs = vector.fragment.load<lhs> %scratch_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xbf16, #dense> -> vector<16xbf16>
+  %rhs_fragment = vector.fragment.load<rhs> %rhs_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xbf16, %rhs_layout> -> vector<16xbf16>
   %product = vector.mma %lhs, %rhs_fragment, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
-  vector.fragment.store<result> %product, %output_view[%zero, %zero] shape [%sixteen, %sixteen] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %product, %output_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 
@@ -35,8 +35,8 @@ kernel.def @fragment_repack_direct_bf16() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %rhs: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %fragment_origin = index.constant 0 : index
+  %tile_extent = index.constant 16 : index
 
   %rhs_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_view = buffer.view %input[%base] : buffer -> view<16x16xf32, #dense>
@@ -44,12 +44,12 @@ kernel.def @fragment_repack_direct_bf16() {
   %output_view = buffer.view %output[%base] : buffer -> view<16x16xf32, #dense>
 
   %zero_accumulator = vector.constant 0.0 : vector<8xf32>
-  %init = vector.fragment<init> %zero_accumulator shape [%sixteen, %sixteen] : vector<8xf32>
-  %result = vector.fragment.load<result> %input_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf32, #dense> -> vector<8xf32>
-  %lhs = vector.fragment.repack<lhs> %result shape [%sixteen, %sixteen] : vector<8xf32> -> vector<16xbf16>
-  %rhs_fragment = vector.fragment.load<rhs> %rhs_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xbf16, %rhs_layout> -> vector<16xbf16>
+  %init = vector.fragment<init> %zero_accumulator shape [%tile_extent, %tile_extent] : vector<8xf32>
+  %result = vector.fragment.load<result> %input_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xf32, #dense> -> vector<8xf32>
+  %lhs = vector.fragment.repack<lhs> %result shape [%tile_extent, %tile_extent] : vector<8xf32> -> vector<16xbf16>
+  %rhs_fragment = vector.fragment.load<rhs> %rhs_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xbf16, %rhs_layout> -> vector<16xbf16>
   %product = vector.mma %lhs, %rhs_fragment, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
-  vector.fragment.store<result> %product, %output_view[%zero, %zero] shape [%sixteen, %sixteen] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %product, %output_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/execution/gfx11_wmma_families.loom
+++ b/loom/src/loom/target/arch/amdgpu/test/execution/gfx11_wmma_families.loom
@@ -23,27 +23,27 @@ kernel.def target(@gfx11_wave32) @gfx11_wmma_families_wave32() {
   %i8_output_view = buffer.view %i8_output[%base] : buffer -> view<16x16xi32, #dense>
   %i4_output_view = buffer.view %i4_output[%base] : buffer -> view<16x16xi32, #dense>
 
-  %f16_ones = vector.constant 1.0 : vector<16xf16>
-  %f16_lhs = vector.fragment<lhs> %f16_ones shape [%m, %k] : vector<16xf16>
-  %f16_rhs = vector.fragment<rhs> %f16_ones shape [%k, %n] : vector<16xf16>
-  %f32_zero = vector.constant 0.0 : vector<8xf32>
-  %f32_init = vector.fragment<init> %f32_zero shape [%m, %n] : vector<8xf32>
+  %f16_operand_elements = vector.constant 1.0 : vector<16xf16>
+  %f16_lhs = vector.fragment<lhs> %f16_operand_elements shape [%m, %k] : vector<16xf16>
+  %f16_rhs = vector.fragment<rhs> %f16_operand_elements shape [%k, %n] : vector<16xf16>
+  %f32_accumulator_elements = vector.constant 0.0 : vector<8xf32>
+  %f32_init = vector.fragment<init> %f32_accumulator_elements shape [%m, %n] : vector<8xf32>
   %f32_f16_result = vector.mma %f16_lhs, %f16_rhs, %f32_init : vector<16xf16>, vector<16xf16>, vector<8xf32>
   vector.fragment.store<result> %f32_f16_result, %f32_f16_output_view[0, 0] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
 
-  %bf16_ones = vector.constant 1.0 : vector<16xbf16>
-  %bf16_lhs = vector.fragment<lhs> %bf16_ones shape [%m, %k] : vector<16xbf16>
-  %bf16_rhs = vector.fragment<rhs> %bf16_ones shape [%k, %n] : vector<16xbf16>
+  %bf16_operand_elements = vector.constant 1.0 : vector<16xbf16>
+  %bf16_lhs = vector.fragment<lhs> %bf16_operand_elements shape [%m, %k] : vector<16xbf16>
+  %bf16_rhs = vector.fragment<rhs> %bf16_operand_elements shape [%k, %n] : vector<16xbf16>
   %f32_bf16_result = vector.mma %bf16_lhs, %bf16_rhs, %f32_init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
   vector.fragment.store<result> %f32_bf16_result, %f32_bf16_output_view[0, 0] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
 
-  %f16_zero = vector.constant 0.0 : vector<16xf16>
-  %f16_init = vector.fragment<init> %f16_zero shape [%m, %n] : vector<16xf16>
+  %f16_accumulator_elements = vector.constant 0.0 : vector<16xf16>
+  %f16_init = vector.fragment<init> %f16_accumulator_elements shape [%m, %n] : vector<16xf16>
   %f16_result = vector.mma %f16_lhs, %f16_rhs, %f16_init : vector<16xf16>, vector<16xf16>, vector<16xf16>
   vector.fragment.store<result> %f16_result, %f16_output_view[0, 0] shape [%m, %n] : vector<16xf16>, view<16x16xf16, #dense>
 
-  %bf16_zero = vector.constant 0.0 : vector<16xbf16>
-  %bf16_init = vector.fragment<init> %bf16_zero shape [%m, %n] : vector<16xbf16>
+  %bf16_accumulator_elements = vector.constant 0.0 : vector<16xbf16>
+  %bf16_init = vector.fragment<init> %bf16_accumulator_elements shape [%m, %n] : vector<16xbf16>
   %bf16_result = vector.mma %bf16_lhs, %bf16_rhs, %bf16_init : vector<16xbf16>, vector<16xbf16>, vector<16xbf16>
   vector.fragment.store<result> %bf16_result, %bf16_output_view[0, 0] shape [%m, %n] : vector<16xbf16>, view<16x16xbf16, #dense>
 
@@ -53,8 +53,8 @@ kernel.def target(@gfx11_wave32) @gfx11_wmma_families_wave32() {
   %i8_rhs_words = vector.constant 33686018 : vector<4xi32>
   %i8_lhs = vector.fragment<lhs> %i8_lhs_words shape [%m, %k] using {schema = %i8_lhs_schema : encoding<schema>} : vector<4xi32>
   %i8_rhs = vector.fragment<rhs> %i8_rhs_words shape [%k, %n] using {schema = %i8_rhs_schema : encoding<schema>} : vector<4xi32>
-  %i32_zero = vector.constant 0 : vector<8xi32>
-  %i32_init = vector.fragment<init> %i32_zero shape [%m, %n] : vector<8xi32>
+  %i32_accumulator_elements = vector.constant 0 : vector<8xi32>
+  %i32_init = vector.fragment<init> %i32_accumulator_elements shape [%m, %n] : vector<8xi32>
   %i8_result = vector.mma %i8_lhs, %i8_rhs, %i32_init : vector<4xi32>, vector<4xi32>, vector<8xi32>
   vector.fragment.store<result> %i8_result, %i8_output_view[0, 0] shape [%m, %n] : vector<8xi32>, view<16x16xi32, #dense>
 
@@ -85,27 +85,27 @@ kernel.def target(@gfx11_wave64) @gfx11_wmma_families_wave64() {
   %i8_output_view = buffer.view %i8_output[%base] : buffer -> view<16x16xi32, #dense>
   %i4_output_view = buffer.view %i4_output[%base] : buffer -> view<16x16xi32, #dense>
 
-  %f16_ones = vector.constant 1.0 : vector<16xf16>
-  %f16_lhs = vector.fragment<lhs> %f16_ones shape [%m, %k] : vector<16xf16>
-  %f16_rhs = vector.fragment<rhs> %f16_ones shape [%k, %n] : vector<16xf16>
-  %f32_zero = vector.constant 0.0 : vector<4xf32>
-  %f32_init = vector.fragment<init> %f32_zero shape [%m, %n] : vector<4xf32>
+  %f16_operand_elements = vector.constant 1.0 : vector<16xf16>
+  %f16_lhs = vector.fragment<lhs> %f16_operand_elements shape [%m, %k] : vector<16xf16>
+  %f16_rhs = vector.fragment<rhs> %f16_operand_elements shape [%k, %n] : vector<16xf16>
+  %f32_accumulator_elements = vector.constant 0.0 : vector<4xf32>
+  %f32_init = vector.fragment<init> %f32_accumulator_elements shape [%m, %n] : vector<4xf32>
   %f32_f16_result = vector.mma %f16_lhs, %f16_rhs, %f32_init : vector<16xf16>, vector<16xf16>, vector<4xf32>
   vector.fragment.store<result> %f32_f16_result, %f32_f16_output_view[0, 0] shape [%m, %n] : vector<4xf32>, view<16x16xf32, #dense>
 
-  %bf16_ones = vector.constant 1.0 : vector<16xbf16>
-  %bf16_lhs = vector.fragment<lhs> %bf16_ones shape [%m, %k] : vector<16xbf16>
-  %bf16_rhs = vector.fragment<rhs> %bf16_ones shape [%k, %n] : vector<16xbf16>
+  %bf16_operand_elements = vector.constant 1.0 : vector<16xbf16>
+  %bf16_lhs = vector.fragment<lhs> %bf16_operand_elements shape [%m, %k] : vector<16xbf16>
+  %bf16_rhs = vector.fragment<rhs> %bf16_operand_elements shape [%k, %n] : vector<16xbf16>
   %f32_bf16_result = vector.mma %bf16_lhs, %bf16_rhs, %f32_init : vector<16xbf16>, vector<16xbf16>, vector<4xf32>
   vector.fragment.store<result> %f32_bf16_result, %f32_bf16_output_view[0, 0] shape [%m, %n] : vector<4xf32>, view<16x16xf32, #dense>
 
-  %f16_zero = vector.constant 0.0 : vector<8xf16>
-  %f16_init = vector.fragment<init> %f16_zero shape [%m, %n] : vector<8xf16>
+  %f16_accumulator_elements = vector.constant 0.0 : vector<8xf16>
+  %f16_init = vector.fragment<init> %f16_accumulator_elements shape [%m, %n] : vector<8xf16>
   %f16_result = vector.mma %f16_lhs, %f16_rhs, %f16_init : vector<16xf16>, vector<16xf16>, vector<8xf16>
   vector.fragment.store<result> %f16_result, %f16_output_view[0, 0] shape [%m, %n] : vector<8xf16>, view<16x16xf16, #dense>
 
-  %bf16_zero = vector.constant 0.0 : vector<8xbf16>
-  %bf16_init = vector.fragment<init> %bf16_zero shape [%m, %n] : vector<8xbf16>
+  %bf16_accumulator_elements = vector.constant 0.0 : vector<8xbf16>
+  %bf16_init = vector.fragment<init> %bf16_accumulator_elements shape [%m, %n] : vector<8xbf16>
   %bf16_result = vector.mma %bf16_lhs, %bf16_rhs, %bf16_init : vector<16xbf16>, vector<16xbf16>, vector<8xbf16>
   vector.fragment.store<result> %bf16_result, %bf16_output_view[0, 0] shape [%m, %n] : vector<8xbf16>, view<16x16xbf16, #dense>
 
@@ -115,8 +115,8 @@ kernel.def target(@gfx11_wave64) @gfx11_wmma_families_wave64() {
   %i8_rhs_words = vector.constant 33686018 : vector<4xi32>
   %i8_lhs = vector.fragment<lhs> %i8_lhs_words shape [%m, %k] using {schema = %i8_lhs_schema : encoding<schema>} : vector<4xi32>
   %i8_rhs = vector.fragment<rhs> %i8_rhs_words shape [%k, %n] using {schema = %i8_rhs_schema : encoding<schema>} : vector<4xi32>
-  %i32_zero = vector.constant 0 : vector<4xi32>
-  %i32_init = vector.fragment<init> %i32_zero shape [%m, %n] : vector<4xi32>
+  %i32_accumulator_elements = vector.constant 0 : vector<4xi32>
+  %i32_init = vector.fragment<init> %i32_accumulator_elements shape [%m, %n] : vector<4xi32>
   %i8_result = vector.mma %i8_lhs, %i8_rhs, %i32_init : vector<4xi32>, vector<4xi32>, vector<4xi32>
   vector.fragment.store<result> %i8_result, %i8_output_view[0, 0] shape [%m, %n] : vector<4xi32>, view<16x16xi32, #dense>
 

--- a/loom/src/loom/target/arch/amdgpu/test/execution/gfx9_4_mfma_families.loom
+++ b/loom/src/loom/target/arch/amdgpu/test/execution/gfx9_4_mfma_families.loom
@@ -27,40 +27,40 @@ kernel.def target(@gfx9_4_generic) @gfx9_4_mfma_families() {
   %sparse_bf16_output_view = buffer.view %sparse_bf16_output[%base] : buffer -> view<16x16xf32, #dense>
   %sparse_i8_output_view = buffer.view %sparse_i8_output[%base] : buffer -> view<16x16xi32, #dense>
 
-  %f16_ones = vector.constant 1.0 : vector<4xf16>
-  %f16_lhs = vector.fragment<lhs> %f16_ones shape [%m, %k16] : vector<4xf16>
-  %f16_rhs = vector.fragment<rhs> %f16_ones shape [%k16, %n] : vector<4xf16>
-  %f32_zero = vector.constant 0.0 : vector<4xf32>
-  %f32_init = vector.fragment<init> %f32_zero shape [%m, %n] : vector<4xf32>
+  %f16_operand_elements = vector.constant 1.0 : vector<4xf16>
+  %f16_lhs = vector.fragment<lhs> %f16_operand_elements shape [%m, %k16] : vector<4xf16>
+  %f16_rhs = vector.fragment<rhs> %f16_operand_elements shape [%k16, %n] : vector<4xf16>
+  %f32_accumulator_elements = vector.constant 0.0 : vector<4xf32>
+  %f32_init = vector.fragment<init> %f32_accumulator_elements shape [%m, %n] : vector<4xf32>
   %f16_result = vector.mma %f16_lhs, %f16_rhs, %f32_init : vector<4xf16>, vector<4xf16>, vector<4xf32>
   vector.fragment.store<result> %f16_result, %f16_output_view[0, 0] shape [%m, %n] : vector<4xf32>, view<16x16xf32, #dense>
 
-  %bf16_ones = vector.constant 1.0 : vector<4xbf16>
-  %bf16_lhs = vector.fragment<lhs> %bf16_ones shape [%m, %k16] : vector<4xbf16>
-  %bf16_rhs = vector.fragment<rhs> %bf16_ones shape [%k16, %n] : vector<4xbf16>
+  %bf16_operand_elements = vector.constant 1.0 : vector<4xbf16>
+  %bf16_lhs = vector.fragment<lhs> %bf16_operand_elements shape [%m, %k16] : vector<4xbf16>
+  %bf16_rhs = vector.fragment<rhs> %bf16_operand_elements shape [%k16, %n] : vector<4xbf16>
   %bf16_result = vector.mma %bf16_lhs, %bf16_rhs, %f32_init : vector<4xbf16>, vector<4xbf16>, vector<4xf32>
   vector.fragment.store<result> %bf16_result, %bf16_output_view[0, 0] shape [%m, %n] : vector<4xf32>, view<16x16xf32, #dense>
 
-  %f32_ones = vector.constant 1.0 : vector<1xf32>
-  %f32_lhs = vector.fragment<lhs> %f32_ones shape [%m, %k4] : vector<1xf32>
-  %f32_rhs = vector.fragment<rhs> %f32_ones shape [%k4, %n] : vector<1xf32>
+  %f32_operand_elements = vector.constant 1.0 : vector<1xf32>
+  %f32_lhs = vector.fragment<lhs> %f32_operand_elements shape [%m, %k4] : vector<1xf32>
+  %f32_rhs = vector.fragment<rhs> %f32_operand_elements shape [%k4, %n] : vector<1xf32>
   %f32_result = vector.mma %f32_lhs, %f32_rhs, %f32_init : vector<1xf32>, vector<1xf32>, vector<4xf32>
   vector.fragment.store<result> %f32_result, %f32_output_view[0, 0] shape [%m, %n] : vector<4xf32>, view<16x16xf32, #dense>
 
-  %f64_ones = vector.constant 1.0 : vector<1xf64>
-  %f64_lhs = vector.fragment<lhs> %f64_ones shape [%m, %k4] : vector<1xf64>
-  %f64_rhs = vector.fragment<rhs> %f64_ones shape [%k4, %n] : vector<1xf64>
-  %f64_zero = vector.constant 0.0 : vector<4xf64>
-  %f64_init = vector.fragment<init> %f64_zero shape [%m, %n] : vector<4xf64>
+  %f64_operand_elements = vector.constant 1.0 : vector<1xf64>
+  %f64_lhs = vector.fragment<lhs> %f64_operand_elements shape [%m, %k4] : vector<1xf64>
+  %f64_rhs = vector.fragment<rhs> %f64_operand_elements shape [%k4, %n] : vector<1xf64>
+  %f64_accumulator_elements = vector.constant 0.0 : vector<4xf64>
+  %f64_init = vector.fragment<init> %f64_accumulator_elements shape [%m, %n] : vector<4xf64>
   %f64_result = vector.mma %f64_lhs, %f64_rhs, %f64_init : vector<1xf64>, vector<1xf64>, vector<4xf64>
   vector.fragment.store<result> %f64_result, %f64_output_view[0, 0] shape [%m, %n] : vector<4xf64>, view<16x16xf64, #dense>
 
   %i8_schema = encoding.define #matrix_operand<element_format=i8, payload_elements=8, payload_registers=2> : encoding<schema>
-  %i8_ones = vector.constant 16843009 : vector<2xi32>
-  %i8_lhs = vector.fragment<lhs> %i8_ones shape [%m, %k32] using {schema = %i8_schema : encoding<schema>} : vector<2xi32>
-  %i8_rhs = vector.fragment<rhs> %i8_ones shape [%k32, %n] using {schema = %i8_schema : encoding<schema>} : vector<2xi32>
-  %i32_zero = vector.constant 0 : vector<4xi32>
-  %i32_init = vector.fragment<init> %i32_zero shape [%m, %n] : vector<4xi32>
+  %i8_operand_words = vector.constant 16843009 : vector<2xi32>
+  %i8_lhs = vector.fragment<lhs> %i8_operand_words shape [%m, %k32] using {schema = %i8_schema : encoding<schema>} : vector<2xi32>
+  %i8_rhs = vector.fragment<rhs> %i8_operand_words shape [%k32, %n] using {schema = %i8_schema : encoding<schema>} : vector<2xi32>
+  %i32_accumulator_elements = vector.constant 0 : vector<4xi32>
+  %i32_init = vector.fragment<init> %i32_accumulator_elements shape [%m, %n] : vector<4xi32>
   %i8_result = vector.mma %i8_lhs, %i8_rhs, %i32_init : vector<2xi32>, vector<2xi32>, vector<4xi32>
   vector.fragment.store<result> %i8_result, %i8_output_view[0, 0] shape [%m, %n] : vector<4xi32>, view<16x16xi32, #dense>
 

--- a/loom/src/loom/target/arch/amdgpu/test/execution/global_atomic_add_f32.loom
+++ b/loom/src/loom/target/arch/amdgpu/test/execution/global_atomic_add_f32.loom
@@ -2,35 +2,35 @@
 // with a native instruction retain the source operation, while targets without
 // one legalize it to a bitwise compare-exchange loop.
 kernel.def @global_atomic_reduce_add_f32() {
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%four, %one, %one) : index
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 4 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %output_index = index.constant 0 : index
   %output_global = buffer.assume.memory_space<global> %output : buffer
   %output_view = buffer.view %output_global[%base] : buffer -> view<1xf32, #dense>
-  %one = scalar.constant 1.0 : f32
-  view.atomic.reduce<addf> %one, %output_view[%zero] {ordering = relaxed, scope = device} : f32, view<1xf32, #dense>
+  %atomic_increment = scalar.constant 1.0 : f32
+  view.atomic.reduce<addf> %atomic_increment, %output_view[%output_index] {ordering = relaxed, scope = device} : f32, view<1xf32, #dense>
   kernel.return
 }
 
 // The old values returned by four unit increments of an accumulator initialized
 // to one are a permutation of [1, 2, 3, 4], whose sum is always ten.
 kernel.def @global_atomic_rmw_add_f32() {
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%four, %one, %one) : index
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 4 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%accumulator: buffer, %old_sum: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %result_index = index.constant 0 : index
   %accumulator_global = buffer.assume.memory_space<global> %accumulator : buffer
   %old_sum_global = buffer.assume.memory_space<global> %old_sum : buffer
   %accumulator_view = buffer.view %accumulator_global[%base] : buffer -> view<1xf32, #dense>
   %old_sum_view = buffer.view %old_sum_global[%base] : buffer -> view<1xf32, #dense>
-  %one = scalar.constant 1.0 : f32
-  %old = view.atomic.rmw<addf> %one, %accumulator_view[%zero] {ordering = relaxed, scope = device} : f32, view<1xf32, #dense> -> f32
-  view.atomic.reduce<addf> %old, %old_sum_view[%zero] {ordering = relaxed, scope = device} : f32, view<1xf32, #dense>
+  %atomic_increment = scalar.constant 1.0 : f32
+  %old = view.atomic.rmw<addf> %atomic_increment, %accumulator_view[%result_index] {ordering = relaxed, scope = device} : f32, view<1xf32, #dense> -> f32
+  view.atomic.reduce<addf> %old, %old_sum_view[%result_index] {ordering = relaxed, scope = device} : f32, view<1xf32, #dense>
   kernel.return
 }
 
@@ -38,19 +38,19 @@ kernel.def @global_atomic_rmw_add_f32() {
 // expected into its high half. Checking both memory and the returned old value
 // makes that physical operand order observable.
 kernel.def @global_atomic_cmpxchg_i64() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%value: buffer, %old_value: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %value_index = index.constant 0 : index
   %value_global = buffer.assume.memory_space<global> %value : buffer
   %old_value_global = buffer.assume.memory_space<global> %old_value : buffer
   %value_view = buffer.view %value_global[%base] : buffer -> view<1xi64, #dense>
   %old_value_view = buffer.view %old_value_global[%base] : buffer -> view<1xi64, #dense>
   %expected = scalar.constant 7 : i64
   %replacement = scalar.constant 9 : i64
-  %old = view.atomic.cmpxchg %expected, %replacement, %value_view[%zero] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i64, view<1xi64, #dense> -> i64
-  view.store %old, %old_value_view[%zero] : i64, view<1xi64, #dense>
+  %old = view.atomic.cmpxchg %expected, %replacement, %value_view[%value_index] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i64, view<1xi64, #dense> -> i64
+  view.store %old, %old_value_view[%value_index] : i64, view<1xi64, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/execution/loop_carried_lane_liveness.loom
+++ b/loom/src/loom/target/arch/amdgpu/test/execution/loop_carried_lane_liveness.loom
@@ -6,18 +6,18 @@ kernel.def @loop_carried_lane_liveness() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %sixteen = index.constant 16 : index
-  %thirty_two = index.constant 32 : index
+  %row_stride = index.constant 16 : index
+  %workgroup_stride = index.constant 32 : index
   %scratch_bytes = index.constant 1024 : offset
   %lane = kernel.workitem.id<x> : index
-  %layout = encoding.layout.strided [1, %sixteen] : encoding<layout>
+  %layout = encoding.layout.strided [1, %row_stride] : encoding<layout>
   %input_view = buffer.view %input[%base] : buffer -> view<16x32xbf16, %layout>
   %output_view = buffer.view %output[%base] : buffer -> view<32xbf16, #dense>
   %scratch = buffer.alloca %scratch_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch_view = buffer.view %scratch[%base] : buffer -> view<16x32xbf16, %layout>
 
   %element_count = index.constant 512 : index
-  scf.for %linear = [%lane to %element_count step %thirty_two] {
+  scf.for %linear = [%lane to %element_count step %workgroup_stride] {
     %mask = index.constant 15 : index
     %shift = index.constant 4 : index
     %column = index.andi %linear, %mask : index
@@ -57,15 +57,15 @@ kernel.def @loop_carried_lane_store_after_loop() {
   %lane = kernel.workitem.id<x> : index
   %limit = index.constant 64 : index
   %step = index.constant 32 : index
-  %zero = scalar.constant 0 : i32
-  %two = scalar.constant 2 : i32
+  %current_lane_value = scalar.constant 0 : i32
+  %next_lane_value = scalar.constant 2 : i32
   %output_view = buffer.view %output[%base] : buffer -> view<96xi32, #dense>
 
   scf.for %linear = [%lane to %limit step %step] {
-    view.store %two, %output_view[%linear] : i32, view<96xi32, #dense>
+    view.store %next_lane_value, %output_view[%linear] : i32, view<96xi32, #dense>
   }
 
-  view.store %zero, %output_view[%lane] : i32, view<96xi32, #dense>
+  view.store %current_lane_value, %output_view[%lane] : i32, view<96xi32, #dense>
   kernel.return
 }
 
@@ -78,12 +78,12 @@ kernel.def @loop_carried_lane_store_reference() {
   %lane = kernel.workitem.id<x> : index
   %step = index.constant 32 : index
   %next = index.add %lane, %step : index
-  %zero = scalar.constant 0 : i32
-  %two = scalar.constant 2 : i32
+  %current_lane_value = scalar.constant 0 : i32
+  %next_lane_value = scalar.constant 2 : i32
   %output_view = buffer.view %output[%base] : buffer -> view<96xi32, #dense>
 
-  view.store %two, %output_view[%next] : i32, view<96xi32, #dense>
-  view.store %zero, %output_view[%lane] : i32, view<96xi32, #dense>
+  view.store %next_lane_value, %output_view[%next] : i32, view<96xi32, #dense>
+  view.store %current_lane_value, %output_view[%lane] : i32, view<96xi32, #dense>
   kernel.return
 }
 
@@ -107,13 +107,13 @@ kernel.def @loop_edge_exact_extent() {
   %lane = kernel.workitem.id<x> : index
   %element_count = index.constant 128 : index
   %step = index.constant 32 : index
-  %zero = scalar.constant 0.0 : f32
+  %sum_initial = scalar.constant 0.0 : f32
   %input0_view = buffer.view %input0[%base] : buffer -> view<128xf32, #dense>
   %input1_view = buffer.view %input1[%base] : buffer -> view<128xf32, #dense>
   %input2_view = buffer.view %input2[%base] : buffer -> view<128xf32, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<32xf32, #dense>
 
-  %sum = scf.for %index = [%lane to %element_count step %step](%acc = %zero : f32) -> (f32) {
+  %sum = scf.for %index = [%lane to %element_count step %step](%acc = %sum_initial : f32) -> (f32) {
     %value0 = view.load %input0_view[%index] : view<128xf32, #dense> -> f32
     %value1 = view.load %input1_view[%index] : view<128xf32, #dense> -> f32
     %value2 = view.load %input2_view[%index] : view<128xf32, #dense> -> f32

--- a/loom/src/loom/target/arch/amdgpu/test/execution/workgroup_scan_wave64.loom
+++ b/loom/src/loom/target/arch/amdgpu/test/execution/workgroup_scan_wave64.loom
@@ -8,21 +8,21 @@
 amdgpu.target<gfx11-generic> @gfx11_wave64 {subgroup_size = 64}
 
 kernel.def target(@gfx11_wave64) @workgroup_scan_wave64() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 1024 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%forward_inclusive_output: buffer, %forward_exclusive_output: buffer, %reverse_inclusive_output: buffer, %reverse_exclusive_output: buffer) {
-  %one_i32 = scalar.constant 1 : i32
-  %zero_offset = index.constant 0 : offset
+  %scan_input = scalar.constant 1 : i32
+  %base = index.constant 0 : offset
   %thread = kernel.workitem.id<x> : index
-  %forward_inclusive_view = buffer.view %forward_inclusive_output[%zero_offset] : buffer -> view<1024xi32, #dense>
-  %forward_exclusive_view = buffer.view %forward_exclusive_output[%zero_offset] : buffer -> view<1024xi32, #dense>
-  %reverse_inclusive_view = buffer.view %reverse_inclusive_output[%zero_offset] : buffer -> view<1024xi32, #dense>
-  %reverse_exclusive_view = buffer.view %reverse_exclusive_output[%zero_offset] : buffer -> view<1024xi32, #dense>
-  %forward_inclusive = kernel.workgroup.scan<addi> %one_i32 {direction = forward, mode = inclusive} : i32
-  %forward_exclusive = kernel.workgroup.scan<addi> %one_i32 {direction = forward, mode = exclusive} : i32
-  %reverse_inclusive = kernel.workgroup.scan<addi> %one_i32 {direction = reverse, mode = inclusive} : i32
-  %reverse_exclusive = kernel.workgroup.scan<addi> %one_i32 {direction = reverse, mode = exclusive} : i32
+  %forward_inclusive_view = buffer.view %forward_inclusive_output[%base] : buffer -> view<1024xi32, #dense>
+  %forward_exclusive_view = buffer.view %forward_exclusive_output[%base] : buffer -> view<1024xi32, #dense>
+  %reverse_inclusive_view = buffer.view %reverse_inclusive_output[%base] : buffer -> view<1024xi32, #dense>
+  %reverse_exclusive_view = buffer.view %reverse_exclusive_output[%base] : buffer -> view<1024xi32, #dense>
+  %forward_inclusive = kernel.workgroup.scan<addi> %scan_input {direction = forward, mode = inclusive} : i32
+  %forward_exclusive = kernel.workgroup.scan<addi> %scan_input {direction = forward, mode = exclusive} : i32
+  %reverse_inclusive = kernel.workgroup.scan<addi> %scan_input {direction = reverse, mode = inclusive} : i32
+  %reverse_exclusive = kernel.workgroup.scan<addi> %scan_input {direction = reverse, mode = exclusive} : i32
   view.store %forward_inclusive, %forward_inclusive_view[%thread] : i32, view<1024xi32, #dense>
   view.store %forward_exclusive, %forward_exclusive_view[%thread] : i32, view<1024xi32, #dense>
   view.store %reverse_inclusive, %reverse_inclusive_view[%thread] : i32, view<1024xi32, #dense>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_addtid.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_addtid.loom-test
@@ -8,12 +8,12 @@ kernel.def target(@target) @wave_sized_workgroup_memory_workitem_x_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   %loaded = vector.load %scratch_view[%lane] : view<32xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   kernel.return
@@ -23,9 +23,9 @@ kernel.def target(@target) @wave_sized_workgroup_memory_workitem_x_b32() {
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @wave_sized_workgroup_memory_workitem_x_b32() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %10 = storage {byte_alignment = 16, byte_length = 128} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %13 = v_lshlrev_b32_src0_inline %lane, 2
-  low.op<amdgpu.ds_write_b32>(%13, %one) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%13, %stored_value) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%13) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   low.op<amdgpu.ds_write_b32>(%13, %loaded) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
@@ -40,12 +40,12 @@ kernel.def target(@target) @wave_sized_workgroup_memory_workitem_x_i8x4() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi8, #dense>
-  %one = vector.constant 1 : vector<4xi8>
-  vector.store %one, %scratch_view[%lane] : vector<4xi8>, view<64xi8, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi8, #dense>
+  %stored_value = vector.constant 1 : vector<4xi8>
+  vector.store %stored_value, %scratch_view[%lane] : vector<4xi8>, view<64xi8, #dense>
   %loaded = vector.load %scratch_view[%lane] : view<64xi8, #dense> -> vector<4xi8>
   vector.store %loaded, %scratch_view[%lane] : vector<4xi8>, view<64xi8, #dense>
   kernel.return
@@ -54,9 +54,9 @@ kernel.def target(@target) @wave_sized_workgroup_memory_workitem_x_i8x4() {
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @wave_sized_workgroup_memory_workitem_x_i8x4() asm {
   %10 = storage {byte_alignment = 16, byte_length = 64} : low.storage<workgroup>
-  %one = v_mov_b32 16843009
+  %stored_value = v_mov_b32 16843009
   %13 = s_mov_b32_m0_imm 0
-  low.op<amdgpu.ds_write_addtid_b32>(%one, %13) {offset = 0} memory_access([0, 3, 5, -1, 11, 0, 0, 0, 3, 0, 31, 4, 35]) : (reg<amdgpu.vgpr>, reg<amdgpu.m0>)
+  low.op<amdgpu.ds_write_addtid_b32>(%stored_value, %13) {offset = 0} memory_access([0, 3, 5, -1, 11, 0, 0, 0, 3, 0, 31, 4, 35]) : (reg<amdgpu.vgpr>, reg<amdgpu.m0>)
   %14 = s_mov_b32_m0_imm 0
   %loaded = low.op<amdgpu.ds_read_addtid_b32>(%14) {offset = 0} memory_access([0, 3, 5, -1, 11, 0, 0, 0, 3, 0, 31, 4, 35]) : (reg<amdgpu.m0>) -> reg<amdgpu.vgpr>
   %16 = s_mov_b32_m0_imm 0
@@ -73,12 +73,12 @@ kernel.def target(@target) @cross_wave_workgroup_memory_workitem_x_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
   %loaded = vector.load %scratch_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
@@ -88,9 +88,9 @@ kernel.def target(@target) @cross_wave_workgroup_memory_workitem_x_b32() {
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @cross_wave_workgroup_memory_workitem_x_b32() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %10 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %13 = v_lshlrev_b32_src0_inline %lane, 2
-  low.op<amdgpu.ds_write_b32>(%13, %one) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%13, %stored_value) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%13) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   low.op<amdgpu.ds_write_b32>(%13, %loaded) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
@@ -104,16 +104,16 @@ kernel.def target(@target) @workgroup_memory_scalar_loop_index_b32() {
   %workgroup_size = index.constant 8 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 32 : offset
-  %zero_index = index.constant 0 : index
-  %eight = index.constant 8 : index
-  %one_index = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 8 : index
+  %loop_step = index.constant 1 : index
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<8xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  scf.for %i = [%zero_index to %eight step %one_index] {
-    vector.store %one, %scratch_view[%i] : vector<1xi32>, view<8xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<8xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  scf.for %i = [%loop_begin to %loop_end step %loop_step] {
+    vector.store %stored_value, %scratch_view[%i] : vector<1xi32>, view<8xi32, #dense>
     %loaded = vector.load %scratch_view[%i] : view<8xi32, #dense> -> vector<1xi32>
     vector.store %loaded, %scratch_view[%i] : vector<1xi32>, view<8xi32, #dense>
   }
@@ -123,21 +123,21 @@ kernel.def target(@target) @workgroup_memory_scalar_loop_index_b32() {
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(8, 1, 1) workgroup_count(1, 1, 1) @workgroup_memory_scalar_loop_index_b32() asm {
   %17 = storage {byte_alignment = 16, byte_length = 32} : low.storage<workgroup>
-  %zero_index = s_mov_b32 0
-  %eight = s_mov_b32 8
-  %one_index = s_mov_b32 1
-  %one = v_mov_b32 1
-  low.br ^_bb1(%zero_index: reg<amdgpu.sgpr>)
+  %loop_begin = s_mov_b32 0
+  %loop_end = s_mov_b32 8
+  %loop_step = s_mov_b32 1
+  %stored_value = v_mov_b32 1
+  low.br ^_bb1(%loop_begin: reg<amdgpu.sgpr>)
 ^_bb1(%i: reg<amdgpu.sgpr>):
-  %23 = s_cmp_lt_i32 %i, %eight
+  %23 = s_cmp_lt_i32 %i, %loop_end
   low.cond_br %23, ^_bb2, ^_bb3 : reg<amdgpu.scc>
 ^_bb2:
   %24 = v_mov_b32_copy %i
   %25 = v_lshlrev_b32_src0_inline %24, 2
-  low.op<amdgpu.ds_write_b32>(%25, %one) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 28, 4, 32]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%25, %stored_value) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 28, 4, 32]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%25) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 28, 4, 32]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   low.op<amdgpu.ds_write_b32>(%25, %loaded) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 28, 4, 32]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
-  %31 = s_add_u32 %i, %one_index
+  %31 = s_add_u32 %i, %loop_step
   low.br ^_bb1(%31: reg<amdgpu.sgpr>)
 ^_bb3:
   return
@@ -152,14 +152,14 @@ kernel.def target(@target) @wave_sized_workgroup_memory_workitem_x_b32_static_of
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %four = index.constant 4 : index
-  %element_index = index.add %lane, %four : index
-  %zero = index.constant 0 : offset
+  %element_offset = index.constant 4 : index
+  %element_index = index.add %lane, %element_offset : index
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 160 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<40xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<40xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
   %loaded = vector.load %scratch_view[%element_index] : view<40xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
   kernel.return
@@ -169,9 +169,9 @@ kernel.def target(@target) @wave_sized_workgroup_memory_workitem_x_b32_static_of
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @wave_sized_workgroup_memory_workitem_x_b32_static_offset() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %12 = storage {byte_alignment = 16, byte_length = 160} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %15 = v_lshlrev_b32_src0_inline %lane, 2
-  low.op<amdgpu.ds_write_b32>(%15, %one) {offset = 16} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 16, 140, 20, 144]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%15, %stored_value) {offset = 16} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 16, 140, 20, 144]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%15) {offset = 16} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 16, 140, 20, 144]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   low.op<amdgpu.ds_write_b32>(%15, %loaded) {offset = 16} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 16, 140, 20, 144]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
@@ -186,16 +186,16 @@ kernel.def target(@target) @wave_sized_workgroup_memory_second_allocation_b32() 
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %first_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %second_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %first_view = buffer.view %first_scratch[%zero] : buffer -> view<32xi32, #dense>
-  %second_view = buffer.view %second_scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  %two = vector.constant 2 : vector<1xi32>
-  vector.store %one, %first_view[%lane] : vector<1xi32>, view<32xi32, #dense>
-  vector.store %two, %second_view[%lane] : vector<1xi32>, view<32xi32, #dense>
+  %first_view = buffer.view %first_scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %second_view = buffer.view %second_scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %first_value = vector.constant 1 : vector<1xi32>
+  %second_value = vector.constant 2 : vector<1xi32>
+  vector.store %first_value, %first_view[%lane] : vector<1xi32>, view<32xi32, #dense>
+  vector.store %second_value, %second_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   %loaded = vector.load %second_view[%lane] : view<32xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %first_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   kernel.return
@@ -206,11 +206,11 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %13 = storage {byte_alignment = 16, byte_length = 128} : low.storage<workgroup>
   %14 = storage {byte_alignment = 16, byte_length = 128} : low.storage<workgroup>
-  %one = v_mov_b32 1
-  %two = v_mov_b32 2
+  %first_value = v_mov_b32 1
+  %second_value = v_mov_b32 2
   %19 = v_lshlrev_b32_src0_inline %lane, 2
-  low.op<amdgpu.ds_write_b32>(%19, %one) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
-  low.op<amdgpu.ds_write_b32>(%19, %two) {offset = 128} memory_access([0, 3, 6, -1, 43, 4, 0, 4, 3, 128, 252, 132, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%19, %first_value) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%19, %second_value) {offset = 128} memory_access([0, 3, 6, -1, 43, 4, 0, 4, 3, 128, 252, 132, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%19) {offset = 128} memory_access([0, 3, 6, -1, 43, 4, 0, 4, 3, 128, 252, 132, 256]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   low.op<amdgpu.ds_write_b32>(%19, %loaded) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
@@ -225,14 +225,14 @@ kernel.def target(@target) @wave_sized_workgroup_memory_view_base_and_element_of
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %four = index.constant 4 : index
-  %element_index = index.add %lane, %four : index
+  %element_offset = index.constant 4 : index
+  %element_index = index.add %lane, %element_offset : index
   %base = index.constant 32 : offset
   %bytes = index.constant 224 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch_view = buffer.view %scratch[%base] : buffer -> view<40xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
   %loaded = vector.load %scratch_view[%element_index] : view<40xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
   kernel.return
@@ -242,9 +242,9 @@ kernel.def target(@target) @wave_sized_workgroup_memory_view_base_and_element_of
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @wave_sized_workgroup_memory_view_base_and_element_offset_b32() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %12 = storage {byte_alignment = 16, byte_length = 224} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %15 = v_lshlrev_b32_src0_inline %lane, 2
-  low.op<amdgpu.ds_write_b32>(%15, %one) {offset = 48} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 48, 172, 52, 176]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%15, %stored_value) {offset = 48} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 48, 172, 52, 176]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%15) {offset = 48} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 48, 172, 52, 176]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   low.op<amdgpu.ds_write_b32>(%15, %loaded) {offset = 48} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 48, 172, 52, 176]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
@@ -259,15 +259,15 @@ kernel.def target(@target) @wave_sized_workgroup_memory_interleaved_addtid_and_v
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %two = index.constant 2 : index
-  %scaled_lane = index.mul %lane, %two : index
-  %zero = index.constant 0 : offset
+  %lane_scale = index.constant 2 : index
+  %scaled_lane = index.mul %lane, %lane_scale : index
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %lane_value = vector.constant 1 : vector<1xi32>
   %other = vector.constant 2 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
+  vector.store %lane_value, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
   vector.store %other, %scratch_view[%scaled_lane] : vector<1xi32>, view<64xi32, #dense>
   %loaded = vector.load %scratch_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%scaled_lane] : vector<1xi32>, view<64xi32, #dense>
@@ -278,10 +278,10 @@ kernel.def target(@target) @wave_sized_workgroup_memory_interleaved_addtid_and_v
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @wave_sized_workgroup_memory_interleaved_addtid_and_vaddr_b32() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %15 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %lane_value = v_mov_b32 1
   %other = v_mov_b32 2
   %19 = v_lshlrev_b32_src0_inline %lane, 2
-  low.op<amdgpu.ds_write_b32>(%19, %one) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%19, %lane_value) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %20 = v_lshlrev_b32_src0_inline %lane, 3
   low.op<amdgpu.ds_write_b32>(%20, %other) {offset = 0} memory_access([0, 3, 7, -1, 43, 8, 0, 4, 3, 0, 248, 4, 252]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%19) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
@@ -300,12 +300,12 @@ kernel.def target(@target) @wave_sized_workgroup_memory_roundtrip_lane_cast_b32(
   %lane = kernel.workitem.id<x> : index
   %lane_i32 = index.cast %lane : index to i32
   %lane_index = index.cast %lane_i32 : i32 to index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane_index] : vector<1xi32>, view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%lane_index] : vector<1xi32>, view<32xi32, #dense>
   %loaded = vector.load %scratch_view[%lane_index] : view<32xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%lane_index] : vector<1xi32>, view<32xi32, #dense>
   kernel.return
@@ -315,9 +315,9 @@ kernel.def target(@target) @wave_sized_workgroup_memory_roundtrip_lane_cast_b32(
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @wave_sized_workgroup_memory_roundtrip_lane_cast_b32() asm {
   %lane_index = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %12 = storage {byte_alignment = 16, byte_length = 128} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %15 = v_lshlrev_b32_src0_inline %lane_index, 2
-  low.op<amdgpu.ds_write_b32>(%15, %one) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%15, %stored_value) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%15) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   low.op<amdgpu.ds_write_b32>(%15, %loaded) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
@@ -335,12 +335,12 @@ kernel.def target(@target) @wave_sized_workgroup_memory_select_same_lane_b32() {
   %limit = index.constant 32 : index
   %inside = index.cmp ult, %lane, %limit : index
   %selected_lane = scf.select %inside, %lane, %lane : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%selected_lane] : vector<1xi32>, view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%selected_lane] : vector<1xi32>, view<32xi32, #dense>
   %loaded = vector.load %scratch_view[%selected_lane] : view<32xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%selected_lane] : vector<1xi32>, view<32xi32, #dense>
   kernel.return
@@ -350,9 +350,9 @@ kernel.def target(@target) @wave_sized_workgroup_memory_select_same_lane_b32() {
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @wave_sized_workgroup_memory_select_same_lane_b32() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %13 = storage {byte_alignment = 16, byte_length = 128} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %16 = v_lshlrev_b32_src0_inline %lane, 2
-  low.op<amdgpu.ds_write_b32>(%16, %one) {offset = 0} memory_access([0, 3, 8, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%16, %stored_value) {offset = 0} memory_access([0, 3, 8, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%16) {offset = 0} memory_access([0, 3, 8, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   low.op<amdgpu.ds_write_b32>(%16, %loaded) {offset = 0} memory_access([0, 3, 8, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
@@ -367,17 +367,17 @@ kernel.def target(@target) @wave_sized_workgroup_memory_select_scaled_lane_b32()
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %two = index.constant 2 : index
-  %scaled_lane = index.mul %lane, %two : index
+  %lane_scale = index.constant 2 : index
+  %scaled_lane = index.mul %lane, %lane_scale : index
   %limit = index.constant 16 : index
   %inside = index.cmp ult, %lane, %limit : index
   %element_index = scf.select %inside, %lane, %scaled_lane : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%element_index] : vector<1xi32>, view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%element_index] : vector<1xi32>, view<64xi32, #dense>
   %loaded = vector.load %scratch_view[%element_index] : view<64xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%element_index] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
@@ -390,9 +390,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 
   %scaled_lane = v_lshlrev_b32_lit %lane, 1
   %inside = v_cmp_lt_u32_src1_inline %lane {rhs = 16}
   %element_index = v_cndmask_b32 %scaled_lane, %lane, %inside
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %23 = v_lshlrev_b32_src0_inline %element_index, 2
-  low.op<amdgpu.ds_write_b32>(%23, %one) {offset = 0} memory_access([0, 3, 10, -1, 43, 4, 0, 4, 3, 0, 248, 4, 252]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%23, %stored_value) {offset = 0} memory_access([0, 3, 10, -1, 43, 4, 0, 4, 3, 0, 248, 4, 252]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%23) {offset = 0} memory_access([0, 3, 10, -1, 43, 4, 0, 4, 3, 0, 248, 4, 252]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   low.op<amdgpu.ds_write_b32>(%23, %loaded) {offset = 0} memory_access([0, 3, 10, -1, 43, 4, 0, 4, 3, 0, 248, 4, 252]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
@@ -409,10 +409,10 @@ kernel.def target(@target) @wave_sized_workgroup_memory_guarded_lane_store_b32()
   %lane = kernel.workitem.id<x> : index
   %limit = index.constant 16 : index
   %inside = index.cmp ult, %lane, %limit : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
   %initial = vector.constant 0 : vector<1xi32>
   %replacement = vector.constant 1 : vector<1xi32>
   vector.store %initial, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
@@ -460,12 +460,12 @@ kernel.def target(@target) @wave_sized_workgroup_memory_guarded_lane_load_b32() 
   %lane = kernel.workitem.id<x> : index
   %limit = index.constant 16 : index
   %inside = index.cmp ult, %lane, %limit : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   scf.if %inside {
     %loaded = vector.load %scratch_view[%lane] : view<32xi32, #dense> -> vector<1xi32>
     vector.store %loaded, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
@@ -477,9 +477,9 @@ kernel.def target(@target) @wave_sized_workgroup_memory_guarded_lane_load_b32() 
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @wave_sized_workgroup_memory_guarded_lane_load_b32() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %13 = storage {byte_alignment = 16, byte_length = 128} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %16 = v_lshlrev_b32_src0_inline %lane, 2
-  low.op<amdgpu.ds_write_b32>(%16, %one) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%16, %stored_value) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %inside = v_cmp_lt_u32_src1_inline %lane {rhs = 16}
   %18, %19 = s_and_saveexec_b64 %inside
   low.cond_br %19, ^_bb1, ^_bb2 : reg<amdgpu.scc>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_addtid_topology.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_addtid_topology.loom-test
@@ -7,12 +7,12 @@ kernel.def target(@target) @wave64_workgroup_memory_workitem_x_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
   %loaded = vector.load %scratch_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
@@ -22,9 +22,9 @@ kernel.def target(@target) @wave64_workgroup_memory_workitem_x_b32() {
 low.kernel.def target<amdgpu.cdna3.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @wave64_workgroup_memory_workitem_x_b32() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %10 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %13 = v_lshlrev_b32_src0_inline %lane, 2
-  low.op<amdgpu.ds_write_b32>(%13, %one) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%13, %stored_value) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%13) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   low.op<amdgpu.ds_write_b32>(%13, %loaded) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
@@ -39,14 +39,14 @@ kernel.def target(@target) @wave64_workgroup_memory_workitem_x_b32_static_offset
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %four = index.constant 4 : index
-  %element_index = index.add %lane, %four : index
-  %zero = index.constant 0 : offset
+  %element_offset = index.constant 4 : index
+  %element_index = index.add %lane, %element_offset : index
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 272 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<68xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%element_index] : vector<1xi32>, view<68xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<68xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%element_index] : vector<1xi32>, view<68xi32, #dense>
   %loaded = vector.load %scratch_view[%element_index] : view<68xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%element_index] : vector<1xi32>, view<68xi32, #dense>
   kernel.return
@@ -56,9 +56,9 @@ kernel.def target(@target) @wave64_workgroup_memory_workitem_x_b32_static_offset
 low.kernel.def target<amdgpu.cdna3.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @wave64_workgroup_memory_workitem_x_b32_static_offset() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %12 = storage {byte_alignment = 16, byte_length = 272} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %15 = v_lshlrev_b32_src0_inline %lane, 2
-  low.op<amdgpu.ds_write_b32>(%15, %one) {offset = 16} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 16, 268, 20, 272]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%15, %stored_value) {offset = 16} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 16, 268, 20, 272]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%15) {offset = 16} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 16, 268, 20, 272]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   low.op<amdgpu.ds_write_b32>(%15, %loaded) {offset = 16} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 16, 268, 20, 272]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
@@ -73,12 +73,12 @@ kernel.def target(@target) @cross_wave64_workgroup_memory_workitem_x_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 512 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<128xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<128xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<128xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%lane] : vector<1xi32>, view<128xi32, #dense>
   %loaded = vector.load %scratch_view[%lane] : view<128xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%lane] : vector<1xi32>, view<128xi32, #dense>
   kernel.return
@@ -88,9 +88,9 @@ kernel.def target(@target) @cross_wave64_workgroup_memory_workitem_x_b32() {
 low.kernel.def target<amdgpu.cdna3.core>(@target) workgroup_size(128, 1, 1) workgroup_count(1, 1, 1) @cross_wave64_workgroup_memory_workitem_x_b32() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %10 = storage {byte_alignment = 16, byte_length = 512} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %13 = v_lshlrev_b32_src0_inline %lane, 2
-  low.op<amdgpu.ds_write_b32>(%13, %one) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 508, 4, 512]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%13, %stored_value) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 508, 4, 512]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%13) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 508, 4, 512]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   low.op<amdgpu.ds_write_b32>(%13, %loaded) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 508, 4, 512]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
@@ -106,12 +106,12 @@ kernel.def target(@target) @multidim_workgroup_memory_workitem_xy_b32() {
 } launch() {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<8x8xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%row, %column] : vector<1xi32>, view<8x8xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<8x8xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%row, %column] : vector<1xi32>, view<8x8xi32, #dense>
   %loaded = vector.load %scratch_view[%column, %row] : view<8x8xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%row, %column] : vector<1xi32>, view<8x8xi32, #dense>
   kernel.return
@@ -124,10 +124,10 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(8, 8, 1
   %column = v_and_b32_lit %packed_tid, 1023
   %21 = v_lshrrev_b32_src0_inline %packed_tid, 10
   %row = v_and_b32_lit %21, 1023
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %25 = v_lshl_add_u32_shift_imm %row, %column, 3
   %26 = v_lshlrev_b32_src0_inline %25, 2
-  low.op<amdgpu.ds_write_b32>(%26, %one) {offset = 0} memory_access([0, 3, 6, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%26, %stored_value) {offset = 0} memory_access([0, 3, 6, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %27 = v_lshl_add_u32_shift_imm %column, %row, 3
   %28 = v_lshlrev_b32_src0_inline %27, 2
   %loaded = low.op<amdgpu.ds_read_b32>(%28) {offset = 0} memory_access([0, 3, 6, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_async_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_async_diagnostics.loom-test
@@ -12,12 +12,12 @@ func.def target(@target) @async_group_argument_rejected(%group: kernel.async.gro
 amdgpu.target<gfx11-generic> @target
 
 func.def target(@target) @async_copy_transfer_rejected(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%buffer_base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<16xi8, #dense>
   // ERROR@+1: AMDGPU/023 {constraint_key="async.transfer_packet"}
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   // ERROR@+1: AMDGPU/023 {constraint_key="async_group.local_transfer_tokens"}
@@ -36,18 +36,18 @@ kernel.def target(@target) @async_gather_destination_read_before_wait() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x4xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x4xi8, #dense>
   %source = view.subview %source_base[%tid, 0] : view<64x4xi8, #dense> -> view<1x4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x1x4xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x1x4xi8, #dense>
   %copy = kernel.async.gather %source to %dest {cache_scope = device, cache_temporal = regular} : view<1x4xi8, #dense> to view<64x1x4xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   // ERROR@+1: LOWERING/028 {op_name="view.load", phase_name="source-low"}
   %loaded = view.load %dest[0, 0, 0] : view<64x1x4xi8, #dense> -> i8
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi8, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi8, #dense>
   view.store %loaded, %output_view[0] : i8, view<1xi8, #dense>
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
   kernel.return
@@ -68,14 +68,14 @@ kernel.def target(@target) @async_gather_dynamic_offset_sum_rejected() {
   %lane_y = kernel.workitem.id<y> : index
   %base_y = index.constant 2000 : index
   %y = index.add %lane_y, %base_y : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
   %layout = encoding.layout.strided [1, 1, 1] : encoding<layout>
-  %source_base = buffer.view %global[%zero] : buffer -> view<4294967296x4096x4xi8, %layout>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<4294967296x4096x4xi8, %layout>
   %source = view.subview %source_base[%x, %y, 0] : view<4294967296x4096x4xi8, %layout> -> view<1x1x4xi8, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x1x1x4xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x1x1x4xi8, #dense>
   // ERROR@+1: AMDGPU/023 {constraint_key="async_gather.offset_immediate"}
   %copy = kernel.async.gather %source to %dest {cache_scope = device, cache_temporal = regular} : view<1x1x4xi8, %layout> to view<64x1x1x4xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_async_gfx950.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_async_gfx950.loom-test
@@ -7,13 +7,13 @@ kernel.def target(@target) @async_gather_dword() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x4xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x4xi8, #dense>
   %source = view.subview %source_base[%tid, 0] : view<64x4xi8, #dense> -> view<1x4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x1x4xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x1x4xi8, #dense>
   %copy = kernel.async.gather %source to %dest {cache_scope = device, cache_temporal = regular} : view<1x4xi8, #dense> to view<64x1x4xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -39,13 +39,13 @@ kernel.def target(@target) @async_gather_b128() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x16xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x16xi8, #dense>
   %source = view.subview %source_base[%tid, 0] : view<64x16xi8, #dense> -> view<1x16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x1x16xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x1x16xi8, #dense>
   %copy = kernel.async.gather %source to %dest {cache_scope = device, cache_temporal = regular} : view<1x16xi8, #dense> to view<64x1x16xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -71,13 +71,13 @@ kernel.def target(@target) @async_gather_two_stage() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 2048 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x1x16xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x1x16xi8, #dense>
   %source = view.subview %source_base[%tid, 0, 0] : view<64x1x16xi8, #dense> -> view<1x1x16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest_base = buffer.view %scratch[%zero] : buffer -> view<2x64x1x16xi8, #dense>
+  %dest_base = buffer.view %scratch[%buffer_base] : buffer -> view<2x64x1x16xi8, #dense>
   %dest0 = view.subview %dest_base[0, 0, 0, 0] : view<2x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
   %dest1 = view.subview %dest_base[1, 0, 0, 0] : view<2x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
   %copy0 = kernel.async.gather %source to %dest0 {cache_scope = device, cache_temporal = regular} : view<1x1x16xi8, #dense> to view<1x64x1x16xi8, #dense> -> kernel.async.token
@@ -111,13 +111,13 @@ kernel.def target(@target) @async_gather_multi_packet_newer_group() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 3072 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x1x16xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x1x16xi8, #dense>
   %source = view.subview %source_base[%tid, 0, 0] : view<64x1x16xi8, #dense> -> view<1x1x16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest_base = buffer.view %scratch[%zero] : buffer -> view<3x64x1x16xi8, #dense>
+  %dest_base = buffer.view %scratch[%buffer_base] : buffer -> view<3x64x1x16xi8, #dense>
   %dest0 = view.subview %dest_base[0, 0, 0, 0] : view<3x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
   %dest1a = view.subview %dest_base[1, 0, 0, 0] : view<3x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
   %dest1b = view.subview %dest_base[2, 0, 0, 0] : view<3x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
@@ -155,15 +155,15 @@ kernel.def target(@target) @async_gather_second_lds_slot() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %pad_bytes = index.constant 256 : offset
   %scratch_bytes = index.constant 1024 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x16xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x16xi8, #dense>
   %source = view.subview %source_base[%tid, 0] : view<64x16xi8, #dense> -> view<1x16xi8, #dense>
   %pad = buffer.alloca %pad_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch = buffer.alloca %scratch_bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x1x16xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x1x16xi8, #dense>
   %copy = kernel.async.gather %source to %dest {cache_scope = device, cache_temporal = regular} : view<1x16xi8, #dense> to view<64x1x16xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_bitfield.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_bitfield.loom-test
@@ -3,9 +3,9 @@
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @i32_bitfield_extractu(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %nibble = vector.bitfield.extractu %loaded {offset = 4, width = 4} : vector<1xi32> -> vector<1xi32>
   vector.store %nibble, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
@@ -27,9 +27,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @i32_bit
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @i32_bitfield_extracts(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %nibble = vector.bitfield.extracts %loaded {offset = 4, width = 4} : vector<1xi32> -> vector<1xi32>
   vector.store %nibble, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
@@ -51,9 +51,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @i32_bit
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @i32_bitfield_extractu_full_width_alias(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %bits = vector.bitfield.extractu %loaded {offset = 0, width = 32} : vector<1xi32> -> vector<1xi32>
   vector.store %bits, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
@@ -74,9 +74,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @i32_bit
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @i32_bitfield_extracts_top_aligned(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %nibble = vector.bitfield.extracts %loaded {offset = 28, width = 4} : vector<1xi32> -> vector<1xi32>
   vector.store %nibble, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
@@ -98,10 +98,10 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @i32_bit
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @i32_bitfield_insert(%field_buffer: buffer, %base_buffer: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %field_view = buffer.view %field_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %base_view = buffer.view %base_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %field_view = buffer.view %field_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %base_view = buffer.view %base_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %field = vector.load %field_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %base = vector.load %base_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %inserted = vector.bitfield.insert %field into %base {offset = 8, width = 4} : vector<1xi32>, vector<1xi32>
@@ -127,10 +127,10 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @i32_bit
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @i32_bitfield_insert_offset0(%field_buffer: buffer, %base_buffer: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %field_view = buffer.view %field_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %base_view = buffer.view %base_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %field_view = buffer.view %field_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %base_view = buffer.view %base_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %field = vector.load %field_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %base = vector.load %base_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %inserted = vector.bitfield.insert %field into %base {offset = 0, width = 4} : vector<1xi32>, vector<1xi32>
@@ -155,10 +155,10 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @i32_bit
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @i32_bitfield_insert_full_width_alias(%field_buffer: buffer, %base_buffer: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %field_view = buffer.view %field_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %base_view = buffer.view %base_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %field_view = buffer.view %field_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %base_view = buffer.view %base_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %field = vector.load %field_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %base = vector.load %base_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %inserted = vector.bitfield.insert %field into %base {offset = 0, width = 32} : vector<1xi32>, vector<1xi32>
@@ -180,9 +180,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @i32_bit
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @i32_bitfield_b128_shape(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   %low = vector.bitfield.extractu %loaded {offset = 0, width = 4} : vector<4xi32> -> vector<4xi32>
   %high = vector.bitfield.extractu %loaded {offset = 4, width = 2} : vector<4xi32> -> vector<4xi32>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_bitpack.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_bitpack.loom-test
@@ -227,8 +227,8 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @i32x32_
 
 amdgpu.target<gfx11-generic> @target
 kernel.def target(@target) @uniform_global_i32x4_to_i8x4_bitpack_store() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%values: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %index = index.constant 0 : index

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_bitunpack.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_bitunpack.loom-test
@@ -147,8 +147,8 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @i8x2_to
 
 amdgpu.target<gfx11-generic> @target
 kernel.def target(@target) @uniform_global_i32_to_u8x4_bitunpack_store() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%values: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %index = index.constant 0 : index

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_branch_exclusive_workgroup_storage.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_branch_exclusive_workgroup_storage.loom-test
@@ -4,23 +4,23 @@ amdgpu.target<gfx11-generic> @target
 
 // Workgroup-uniform alternatives share one physical slot.
 kernel.def target(@target) @branch_exclusive_equal_slots() {
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  kernel.launch.config workgroups(%two, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  %workgroup_count = index.constant 2 : index
+  kernel.launch.config workgroups(%workgroup_count, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
   %workgroup = kernel.workgroup.id<x> : index
-  %zero = index.constant 0 : index
-  %zero_offset = index.constant 0 : offset
+  %first_workgroup = index.constant 0 : index
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %value = scalar.constant 1 : i32
-  %is_first = index.cmp eq, %workgroup, %zero : index
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<2xi32, #dense>
+  %is_first = index.cmp eq, %workgroup, %first_workgroup : index
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<2xi32, #dense>
   cfg.cond_br %is_first, ^first, ^second
 ^first:
   %first_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
   cfg.br ^first_body
 ^first_body:
-  %first_view = buffer.view %first_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  %first_view = buffer.view %first_scratch[%buffer_base] : buffer -> view<1xi32, #dense>
   view.store %value, %first_view[0] : i32, view<1xi32, #dense>
   %first_result = view.load %first_view[0] : view<1xi32, #dense> -> i32
   view.store %first_result, %output_view[%workgroup] : i32, view<2xi32, #dense>
@@ -29,7 +29,7 @@ kernel.def target(@target) @branch_exclusive_equal_slots() {
   %second_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
   cfg.br ^second_body
 ^second_body:
-  %second_view = buffer.view %second_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  %second_view = buffer.view %second_scratch[%buffer_base] : buffer -> view<1xi32, #dense>
   view.store %value, %second_view[0] : i32, view<1xi32, #dense>
   %second_result = view.load %second_view[0] : view<1xi32, #dense> -> i32
   view.store %second_result, %output_view[%workgroup] : i32, view<2xi32, #dense>
@@ -43,8 +43,8 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %workgroup = live_in<amdgpu.workgroup_id.x> : reg<amdgpu.sgpr>
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 8} : reg<amdgpu.sgpr x2>
   %18 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
-  %zero = s_mov_b32 0
-  %is_first = s_cmp_eq_i32 %workgroup, %zero
+  %first_workgroup = s_mov_b32 0
+  %is_first = s_cmp_eq_i32 %workgroup, %first_workgroup
   low.cond_br %is_first, ^first, ^second : reg<amdgpu.scc>
 ^first:
   %23 = v_mov_b32 1
@@ -55,7 +55,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %29 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %30 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %32 = s_add_u32 %29, %28
-  %33 = s_addc_u32 %30, %zero
+  %33 = s_addc_u32 %30, %first_workgroup
   %34 = concat(%32, %33) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
   global_store_b32_saddr %24, %first_result, %34
   low.br ^done
@@ -68,7 +68,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %42 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %43 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %45 = s_add_u32 %42, %41
-  %46 = s_addc_u32 %43, %zero
+  %46 = s_addc_u32 %43, %first_workgroup
   %47 = concat(%45, %46) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
   global_store_b32_saddr %37, %second_result, %47
   low.br ^done
@@ -82,25 +82,25 @@ amdgpu.target<gfx11-generic> @target
 
 // Nested alternatives grow their shared tail slot to the maximum aligned arm.
 kernel.def target(@target) @branch_exclusive_nested_max_slot() {
-  %one = index.constant 1 : index
-  %three = index.constant 3 : index
-  kernel.launch.config workgroups(%three, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  %workgroup_count = index.constant 3 : index
+  kernel.launch.config workgroups(%workgroup_count, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
   %workgroup = kernel.workgroup.id<x> : index
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %zero_offset = index.constant 0 : offset
+  %first_workgroup = index.constant 0 : index
+  %second_workgroup = index.constant 1 : index
+  %buffer_base = index.constant 0 : offset
   %small_bytes = index.constant 128 : offset
   %large_bytes = index.constant 256 : offset
   %medium_bytes = index.constant 192 : offset
   %value = scalar.constant 1 : i32
-  %is_first = index.cmp eq, %workgroup, %zero : index
-  %is_second = index.cmp eq, %workgroup, %one : index
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<3xi32, #dense>
+  %is_first = index.cmp eq, %workgroup, %first_workgroup : index
+  %is_second = index.cmp eq, %workgroup, %second_workgroup : index
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<3xi32, #dense>
   cfg.cond_br %is_first, ^first, ^not_first
 ^first:
   %first_scratch = buffer.alloca %small_bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %first_view = buffer.view %first_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  %first_view = buffer.view %first_scratch[%buffer_base] : buffer -> view<1xi32, #dense>
   view.store %value, %first_view[0] : i32, view<1xi32, #dense>
   %first_result = view.load %first_view[0] : view<1xi32, #dense> -> i32
   view.store %first_result, %output_view[%workgroup] : i32, view<3xi32, #dense>
@@ -109,14 +109,14 @@ kernel.def target(@target) @branch_exclusive_nested_max_slot() {
   cfg.cond_br %is_second, ^second, ^third
 ^second:
   %second_scratch = buffer.alloca %large_bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %second_view = buffer.view %second_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  %second_view = buffer.view %second_scratch[%buffer_base] : buffer -> view<1xi32, #dense>
   view.store %value, %second_view[0] : i32, view<1xi32, #dense>
   %second_result = view.load %second_view[0] : view<1xi32, #dense> -> i32
   view.store %second_result, %output_view[%workgroup] : i32, view<3xi32, #dense>
   cfg.br ^done
 ^third:
   %third_scratch = buffer.alloca %medium_bytes {base_alignment = 32, memory_space = workgroup} : buffer
-  %third_view = buffer.view %third_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  %third_view = buffer.view %third_scratch[%buffer_base] : buffer -> view<1xi32, #dense>
   view.store %value, %third_view[0] : i32, view<1xi32, #dense>
   %third_result = view.load %third_view[0] : view<1xi32, #dense> -> i32
   view.store %third_result, %output_view[%workgroup] : i32, view<3xi32, #dense>
@@ -130,9 +130,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %workgroup = live_in<amdgpu.workgroup_id.x> : reg<amdgpu.sgpr>
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 12} : reg<amdgpu.sgpr x2>
   %25 = storage {byte_alignment = 64, byte_length = 256} : low.storage<workgroup>
-  %zero = s_mov_b32 0
-  %one = s_mov_b32 1
-  %is_first = s_cmp_eq_i32 %workgroup, %zero
+  %first_workgroup = s_mov_b32 0
+  %second_workgroup = s_mov_b32 1
+  %is_first = s_cmp_eq_i32 %workgroup, %first_workgroup
   low.cond_br %is_first, ^first, ^not_first : reg<amdgpu.scc>
 ^first:
   %31 = v_mov_b32 1
@@ -143,12 +143,12 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %37 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %38 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %40 = s_add_u32 %37, %36
-  %41 = s_addc_u32 %38, %zero
+  %41 = s_addc_u32 %38, %first_workgroup
   %42 = concat(%40, %41) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
   global_store_b32_saddr %32, %first_result, %42
   low.br ^done
 ^not_first:
-  %is_second = s_cmp_eq_i32 %workgroup, %one
+  %is_second = s_cmp_eq_i32 %workgroup, %second_workgroup
   low.cond_br %is_second, ^second, ^third : reg<amdgpu.scc>
 ^second:
   %45 = v_mov_b32 1
@@ -159,7 +159,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %51 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %52 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %54 = s_add_u32 %51, %50
-  %55 = s_addc_u32 %52, %zero
+  %55 = s_addc_u32 %52, %first_workgroup
   %56 = concat(%54, %55) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
   global_store_b32_saddr %46, %second_result, %56
   low.br ^done
@@ -172,7 +172,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %64 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %65 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %67 = s_add_u32 %64, %63
-  %68 = s_addc_u32 %65, %zero
+  %68 = s_addc_u32 %65, %first_workgroup
   %69 = concat(%67, %68) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
   global_store_b32_saddr %59, %third_result, %69
   low.br ^done
@@ -186,28 +186,28 @@ amdgpu.target<gfx11-generic> @target
 
 // Lane-varying alternatives require distinct workgroup slots.
 kernel.def target(@target) @lane_varying_branches_remain_distinct() {
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%two, %one, %one) : index
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 2 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : index
-  %zero_offset = index.constant 0 : offset
+  %first_lane = index.constant 0 : index
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %value = scalar.constant 1 : i32
-  %is_first = index.cmp eq, %lane, %zero : index
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<2xi32, #dense>
+  %is_first = index.cmp eq, %lane, %first_lane : index
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<2xi32, #dense>
   cfg.cond_br %is_first, ^first, ^second
 ^first:
   %first_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %first_view = buffer.view %first_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  %first_view = buffer.view %first_scratch[%buffer_base] : buffer -> view<1xi32, #dense>
   view.store %value, %first_view[0] : i32, view<1xi32, #dense>
   %first_result = view.load %first_view[0] : view<1xi32, #dense> -> i32
   view.store %first_result, %output_view[%lane] : i32, view<2xi32, #dense>
   cfg.br ^done
 ^second:
   %second_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %second_view = buffer.view %second_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  %second_view = buffer.view %second_scratch[%buffer_base] : buffer -> view<1xi32, #dense>
   view.store %value, %second_view[0] : i32, view<1xi32, #dense>
   %second_result = view.load %second_view[0] : view<1xi32, #dense> -> i32
   view.store %second_result, %output_view[%lane] : i32, view<2xi32, #dense>
@@ -255,19 +255,19 @@ amdgpu.target<gfx11-generic> @target
 
 // Same-path allocations remain distinct without an explicit lifetime end.
 kernel.def target(@target) @sequential_allocations_remain_distinct() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
-  %zero_offset = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %first_bytes = index.constant 128 : offset
   %second_bytes = index.constant 256 : offset
   %first_value = scalar.constant 1 : i32
   %second_value = scalar.constant 2 : i32
   %first_scratch = buffer.alloca %first_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %second_scratch = buffer.alloca %second_bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %first_view = buffer.view %first_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
-  %second_view = buffer.view %second_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<2xi32, #dense>
+  %first_view = buffer.view %first_scratch[%buffer_base] : buffer -> view<1xi32, #dense>
+  %second_view = buffer.view %second_scratch[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<2xi32, #dense>
   view.store %first_value, %first_view[0] : i32, view<1xi32, #dense>
   view.store %second_value, %second_view[0] : i32, view<1xi32, #dense>
   %first_result = view.load %first_view[0] : view<1xi32, #dense> -> i32
@@ -300,39 +300,39 @@ amdgpu.target<gfx11-generic> @target
 
 // A cyclic controller may select both alternatives on different iterations.
 kernel.def target(@target) @cyclic_branch_allocations_remain_distinct() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
-  %zero = scalar.constant 0 : i32
-  %one = scalar.constant 1 : i32
-  %two = scalar.constant 2 : i32
-  %zero_offset = index.constant 0 : offset
+  %loop_begin = scalar.constant 0 : i32
+  %loop_step = scalar.constant 1 : i32
+  %loop_end = scalar.constant 2 : i32
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %value = scalar.constant 1 : i32
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<2xi32, #dense>
-  cfg.br ^loop(%zero: i32)
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<2xi32, #dense>
+  cfg.br ^loop(%loop_begin: i32)
 ^loop(%i: i32):
-  %in_range = scalar.cmpi ult, %i, %two : i32
+  %in_range = scalar.cmpi ult, %i, %loop_end : i32
   cfg.cond_br %in_range, ^body, ^done
 ^body:
-  %is_first = scalar.cmpi eq, %i, %zero : i32
+  %is_first = scalar.cmpi eq, %i, %loop_begin : i32
   cfg.cond_br %is_first, ^first, ^second
 ^first:
   %first_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %first_view = buffer.view %first_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  %first_view = buffer.view %first_scratch[%buffer_base] : buffer -> view<1xi32, #dense>
   view.store %value, %first_view[0] : i32, view<1xi32, #dense>
   %first_result = view.load %first_view[0] : view<1xi32, #dense> -> i32
   view.store %first_result, %output_view[0] : i32, view<2xi32, #dense>
   cfg.br ^continue
 ^second:
   %second_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %second_view = buffer.view %second_scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  %second_view = buffer.view %second_scratch[%buffer_base] : buffer -> view<1xi32, #dense>
   view.store %value, %second_view[0] : i32, view<1xi32, #dense>
   %second_result = view.load %second_view[0] : view<1xi32, #dense> -> i32
   view.store %second_result, %output_view[1] : i32, view<2xi32, #dense>
   cfg.br ^continue
 ^continue:
-  %next = scalar.addi %i, %one : i32
+  %next = scalar.addi %i, %loop_step : i32
   cfg.br ^loop(%next: i32)
 ^done:
   kernel.return
@@ -343,15 +343,15 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 8} : reg<amdgpu.sgpr x2>
   %21 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
   %22 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
-  %zero = s_mov_b32 0
-  %one = s_mov_b32 1
-  %two = s_mov_b32 2
-  low.br ^loop(%zero: reg<amdgpu.sgpr>)
+  %loop_begin = s_mov_b32 0
+  %loop_step = s_mov_b32 1
+  %loop_end = s_mov_b32 2
+  low.br ^loop(%loop_begin: reg<amdgpu.sgpr>)
 ^loop(%i: reg<amdgpu.sgpr>):
-  %in_range = s_cmp_lt_u32 %i, %two
+  %in_range = s_cmp_lt_u32 %i, %loop_end
   low.cond_br %in_range, ^body, ^done : reg<amdgpu.scc>
 ^body:
-  %is_first = s_cmp_eq_i32 %i, %zero
+  %is_first = s_cmp_eq_i32 %i, %loop_begin
   low.cond_br %is_first, ^first, ^second : reg<amdgpu.scc>
 ^first:
   %29 = v_mov_b32 1
@@ -368,7 +368,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   global_store_b32_saddr %36, %second_result, %output_view {offset = 4}
   low.br ^continue
 ^continue:
-  %next = s_add_u32 %i, %one
+  %next = s_add_u32 %i, %loop_step
   low.br ^loop(%next: reg<amdgpu.sgpr>)
 ^done:
   return
@@ -381,21 +381,21 @@ amdgpu.target<gfx11-generic> @target
 // A dynamic logical extent with a finite maximum reserves one static slot. The
 // zero-length path cannot access the allocation.
 kernel.def target(@target) @bounded_dynamic_workgroup_storage() {
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  kernel.launch.config workgroups(%two, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  %workgroup_count = index.constant 2 : index
+  kernel.launch.config workgroups(%workgroup_count, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
   %workgroup = kernel.workgroup.id<x> : index
-  %zero = index.constant 0 : index
-  %zero_offset = index.constant 0 : offset
+  %first_workgroup = index.constant 0 : index
+  %c0 = index.constant 0 : offset
   %capacity = index.constant 8192 : offset
-  %has_storage = index.cmp eq, %workgroup, %zero : index
-  %byte_length = scf.select %has_storage, %capacity, %zero_offset : offset
+  %has_storage = index.cmp eq, %workgroup, %first_workgroup : index
+  %byte_length = scf.select %has_storage, %capacity, %c0 : offset
   %scratch = buffer.alloca %byte_length {base_alignment = 16, memory_space = workgroup} : buffer
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<2xi32, #dense>
+  %output_view = buffer.view %output[%c0] : buffer -> view<2xi32, #dense>
   cfg.cond_br %has_storage, ^active, ^done
 ^active:
-  %scratch_view = buffer.view %scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  %scratch_view = buffer.view %scratch[%c0] : buffer -> view<1xi32, #dense>
   %value = scalar.constant 7 : i32
   view.store %value, %scratch_view[0] : i32, view<1xi32, #dense>
   %loaded = view.load %scratch_view[0] : view<1xi32, #dense> -> i32
@@ -410,8 +410,8 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %workgroup = live_in<amdgpu.workgroup_id.x> : reg<amdgpu.sgpr>
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 8} : reg<amdgpu.sgpr x2>
   %16 = storage {byte_alignment = 16, byte_length = 8192} : low.storage<workgroup>
-  %zero = s_mov_b32 0
-  %has_storage = s_cmp_eq_i32 %workgroup, %zero
+  %first_workgroup = s_mov_b32 0
+  %has_storage = s_cmp_eq_i32 %workgroup, %first_workgroup
   low.cond_br %has_storage, ^active, ^done : reg<amdgpu.scc>
 ^active:
   %21 = v_mov_b32 7
@@ -422,7 +422,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %27 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %28 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %30 = s_add_u32 %27, %26
-  %31 = s_addc_u32 %28, %zero
+  %31 = s_addc_u32 %28, %first_workgroup
   %32 = concat(%30, %31) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
   global_store_b32_saddr %22, %loaded, %32
   low.br ^done

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_buffer_control_flow.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_buffer_control_flow.loom-test
@@ -5,18 +5,18 @@
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @select_global_buffer(%select_rhs: index) {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%select_rhs: index, %lhs: buffer, %rhs: buffer, %output: buffer) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %zero_offset = index.constant 0 : offset
-  %use_rhs = index.cmp eq, %select_rhs, %one : index
+  %element_index = index.constant 0 : index
+  %rhs_selector = index.constant 1 : index
+  %buffer_base = index.constant 0 : offset
+  %use_rhs = index.cmp eq, %select_rhs, %rhs_selector : index
   %selected = scf.select %use_rhs, %rhs, %lhs : buffer
-  %selected_view = buffer.view %selected[%zero_offset] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xi32, #dense>
-  %selected_value = view.load %selected_view[%zero] : view<1xi32, #dense> -> i32
-  view.store %selected_value, %output_view[%zero] : i32, view<1xi32, #dense>
+  %selected_view = buffer.view %selected[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
+  %selected_value = view.load %selected_view[%element_index] : view<1xi32, #dense> -> i32
+  view.store %selected_value, %output_view[%element_index] : i32, view<1xi32, #dense>
   kernel.return
 }
 
@@ -25,8 +25,8 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %lhs = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
   %rhs = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 2, source_type = hal.buffer, extent = 4} : reg<amdgpu.sgpr x2>
-  %one = s_mov_b32 1
-  %use_rhs = s_cmp_eq_i32 %select_rhs, %one
+  %rhs_selector = s_mov_b32 1
+  %use_rhs = s_cmp_eq_i32 %select_rhs, %rhs_selector
   %20 = slice %rhs[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %21 = slice %lhs[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %22 = s_cselect_b32 %20, %21, %use_rhs

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cache_policy.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cache_policy.loom-test
@@ -38,9 +38,9 @@ kernel.def target(@target) @cache_system_bypass_scalar_load() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   // REMARK@+1: BACKEND/040 "selected cache policy 'system/bypass'" "decision 'memory_cache_policy.gfx12_nv_scope_th'" "scope_attr present true value 3" "th_attr present true value 3"
   %loaded = view.load %input_view[%lane] {cache_scope = system, cache_temporal = bypass} : view<64xi32, #dense> -> i32
   view.store %loaded, %output_view[%lane] : i32, view<64xi32, #dense>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cache_policy.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cache_policy.loom-test
@@ -8,9 +8,9 @@ kernel.def target(@target) @cache_system_bypass_load_device_writeback_store() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   // REMARK@+1: BACKEND/040 "selected cache policy 'system/bypass'" "decision 'memory_cache_policy.gfx12_nv_scope_th'" "scope_attr present true value 3" "th_attr present true value 3"
   %loaded = vector.load %input_view[%lane, 0] {cache_scope = system, cache_temporal = bypass} : view<64x4xi32, #dense> -> vector<4xi32>
   // REMARK@+1: BACKEND/040 "selected cache policy 'device/non_temporal_writeback'" "scope_attr present true value 2" "th_attr present true value 7" "nt_attr present false value 0"

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cache_policy_gfx1151.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cache_policy_gfx1151.loom-test
@@ -8,9 +8,9 @@ kernel.def target(@target) @cache_system_bypass_load_device_writeback_store() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   // REMARK@+1: BACKEND/040 "dropped cache policy 'system/bypass'" "decision 'memory_cache_policy.unsupported'" "encoding 'gfx9_11_glc_slc_dlc'" "scope_attr present false"
   %loaded = vector.load %input_view[%lane, 0] {cache_scope = system, cache_temporal = bypass} : view<64x4xi32, #dense> -> vector<4xi32>
   // REMARK@+1: BACKEND/040 "dropped cache policy 'device/non_temporal_writeback'" "decision 'memory_cache_policy.unsupported'" "encoding 'gfx9_11_glc_slc_dlc'" "scope_attr present false"
@@ -38,9 +38,9 @@ kernel.def target(@target) @cache_system_bypass_scalar_load() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   // REMARK@+1: BACKEND/040 "dropped cache policy 'system/bypass'" "decision 'memory_cache_policy.unsupported'" "encoding 'gfx9_11_glc_slc_dlc'" "scope_attr present false"
   %loaded = view.load %input_view[%lane] {cache_scope = system, cache_temporal = bypass} : view<64xi32, #dense> -> i32
   view.store %loaded, %output_view[%lane] : i32, view<64xi32, #dense>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cache_policy_gfx950.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cache_policy_gfx950.loom-test
@@ -8,9 +8,9 @@ kernel.def target(@target) @cache_device_non_temporal_load_store() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   // REMARK@+1: BACKEND/040 "selected cache policy 'device/non_temporal'" "decision 'memory_cache_policy.gfx950_nt_sc0_sc1'" "scope_attr present false value 0" "nt_attr present true value 1"
   %loaded = vector.load %input_view[%lane, 0] {cache_scope = device, cache_temporal = non_temporal} : view<64x4xi32, #dense> -> vector<4xi32>
   // REMARK@+1: BACKEND/040 "selected cache policy 'device/non_temporal'" "decision 'memory_cache_policy.gfx950_nt_sc0_sc1'" "th_attr present false value 0" "nt_attr present true value 1"

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cluster_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cluster_diagnostics.loom-test
@@ -7,13 +7,13 @@ kernel.def target(@target) @cluster_gather_requires_target_packets() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %participants = scalar.constant 3 : i32
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<4xi8, #dense>
+  %source = buffer.view %global[%buffer_base] : buffer -> view<4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<4xi8, #dense>
   // ERROR@+1: AMDGPU/023 {constraint_key="cluster_gather.descriptor_missing"}
   %copy = kernel.async.cluster.gather %source to %dest using %participants {cache_scope = device, cache_temporal = regular} : view<4xi8, #dense> to view<4xi8, #dense>, i32 -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -31,14 +31,14 @@ kernel.def target(@target) @masked_cluster_gather_is_not_yet_lowered() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %participants = scalar.constant 3 : i32
   %predicate = scalar.constant true : i1
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<4xi8, #dense>
+  %source = buffer.view %global[%buffer_base] : buffer -> view<4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<4xi8, #dense>
   // ERROR@+1: AMDGPU/023 {constraint_key="async.transfer_packet"}
   %copy = kernel.async.cluster.gather.mask %source to %dest using %participants, %predicate {cache_scope = device, cache_temporal = regular} : view<4xi8, #dense> to view<4xi8, #dense>, i32, i1 -> kernel.async.token
   // ERROR@+1: AMDGPU/023 {constraint_key="async_group.local_transfer_tokens"}
@@ -57,7 +57,7 @@ kernel.def target(@target) @cluster_gather_same_root_overlap() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %c64 = index.constant 64 : index
   %bytes = index.constant 4096 : offset
   %participants = scalar.constant 3 : i32
@@ -65,7 +65,7 @@ kernel.def target(@target) @cluster_gather_same_root_overlap() {
   %lane_base = index.mul %lane, %c64 : index
   %offset = index.cast %lane_base : index to offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%buffer_base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %dest = buffer.view %scratch[%offset] : buffer -> view<16xi8, #dense>
   %copy0 = kernel.async.cluster.gather %source to %dest using %participants {cache_scope = device, cache_temporal = regular} : view<16xi8, #dense> to view<16xi8, #dense>, i32 -> kernel.async.token

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cluster_gfx1250.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_cluster_gfx1250.loom-test
@@ -7,13 +7,13 @@ kernel.def target(@target) @cluster_gather_b32() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %participants = scalar.constant 3 : i32
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<4xi8, #dense>
+  %source = buffer.view %global[%buffer_base] : buffer -> view<4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<4xi8, #dense>
   %copy = kernel.async.cluster.gather %source to %dest using %participants {cache_scope = device, cache_temporal = regular} : view<4xi8, #dense> to view<4xi8, #dense>, i32 -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -40,21 +40,21 @@ kernel.def target(@target) @cluster_gather_packet_widths() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %offset16 = index.constant 16 : offset
   %offset32 = index.constant 32 : offset
   %bytes16 = index.constant 16 : offset
   %participants = scalar.constant 3 : i32
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source8 = buffer.view %global[%zero] : buffer -> view<1xi8, #dense>
+  %source8 = buffer.view %global[%buffer_base] : buffer -> view<1xi8, #dense>
   %source64 = buffer.view %global[%offset16] : buffer -> view<8xi8, #dense>
   %source128 = buffer.view %global[%offset32] : buffer -> view<16xi8, #dense>
   %scratch8 = buffer.alloca %bytes16 {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch64 = buffer.alloca %bytes16 {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch128 = buffer.alloca %bytes16 {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest8 = buffer.view %scratch8[%zero] : buffer -> view<1xi8, #dense>
-  %dest64 = buffer.view %scratch64[%zero] : buffer -> view<8xi8, #dense>
-  %dest128 = buffer.view %scratch128[%zero] : buffer -> view<16xi8, #dense>
+  %dest8 = buffer.view %scratch8[%buffer_base] : buffer -> view<1xi8, #dense>
+  %dest64 = buffer.view %scratch64[%buffer_base] : buffer -> view<8xi8, #dense>
+  %dest128 = buffer.view %scratch128[%buffer_base] : buffer -> view<16xi8, #dense>
   %copy8 = kernel.async.cluster.gather %source8 to %dest8 using %participants {cache_scope = cu, cache_temporal = regular} : view<1xi8, #dense> to view<1xi8, #dense>, i32 -> kernel.async.token
   %copy64 = kernel.async.cluster.gather %source64 to %dest64 using %participants {cache_scope = se, cache_temporal = high_temporal} : view<8xi8, #dense> to view<8xi8, #dense>, i32 -> kernel.async.token
   %copy128 = kernel.async.cluster.gather %source128 to %dest128 using %participants {cache_scope = system, cache_temporal = bypass} : view<16xi8, #dense> to view<16xi8, #dense>, i32 -> kernel.async.token
@@ -129,21 +129,21 @@ kernel.def target(@target) @cluster_gather_two_stage_wait_depth() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes16 = index.constant 16 : offset
   %participants = scalar.constant 3 : i32
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%buffer_base] : buffer -> view<16xi8, #dense>
   %scratch0 = buffer.alloca %bytes16 {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch1 = buffer.alloca %bytes16 {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch2 = buffer.alloca %bytes16 {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch3 = buffer.alloca %bytes16 {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch4 = buffer.alloca %bytes16 {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest0 = buffer.view %scratch0[%zero] : buffer -> view<16xi8, #dense>
-  %dest1 = buffer.view %scratch1[%zero] : buffer -> view<16xi8, #dense>
-  %dest2 = buffer.view %scratch2[%zero] : buffer -> view<16xi8, #dense>
-  %dest3 = buffer.view %scratch3[%zero] : buffer -> view<16xi8, #dense>
-  %dest4 = buffer.view %scratch4[%zero] : buffer -> view<16xi8, #dense>
+  %dest0 = buffer.view %scratch0[%buffer_base] : buffer -> view<16xi8, #dense>
+  %dest1 = buffer.view %scratch1[%buffer_base] : buffer -> view<16xi8, #dense>
+  %dest2 = buffer.view %scratch2[%buffer_base] : buffer -> view<16xi8, #dense>
+  %dest3 = buffer.view %scratch3[%buffer_base] : buffer -> view<16xi8, #dense>
+  %dest4 = buffer.view %scratch4[%buffer_base] : buffer -> view<16xi8, #dense>
   %copy0 = kernel.async.cluster.gather %source to %dest0 using %participants {cache_scope = device, cache_temporal = regular} : view<16xi8, #dense> to view<16xi8, #dense>, i32 -> kernel.async.token
   %group0 = kernel.async.group %copy0 : kernel.async.token -> kernel.async.group
   %copy1 = kernel.async.cluster.gather %source to %dest1 using %participants {cache_scope = device, cache_temporal = regular} : view<16xi8, #dense> to view<16xi8, #dense>, i32 -> kernel.async.token
@@ -193,7 +193,7 @@ kernel.def target(@target) @cluster_gather_same_root_disjoint_slots() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %c16 = index.constant 16 : index
   %c32 = index.constant 32 : index
   %c48 = index.constant 48 : index
@@ -210,7 +210,7 @@ kernel.def target(@target) @cluster_gather_same_root_disjoint_slots() {
   %offset2 = index.cast %slot2 : index to offset
   %offset3 = index.cast %slot3 : index to offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%buffer_base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %dest0 = buffer.view %scratch[%offset0] : buffer -> view<16xi8, #dense>
   %dest1 = buffer.view %scratch[%offset1] : buffer -> view<16xi8, #dense>
@@ -256,7 +256,7 @@ kernel.def target(@target) @cluster_gather_disjoint_workgroup_store() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer, %payload: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %c16 = index.constant 16 : index
   %bytes = index.constant 1024 : offset
   %participants = scalar.constant 3 : i32

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_config_decl_facts.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_config_decl_facts.loom-test
@@ -160,12 +160,12 @@ kernel.def target(@target) @config_decl_runtime_use_stays_illegal() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %output_index = index.constant 0 : index
   %output_view = buffer.view %output[%base] : buffer -> view<1xi32, #dense>
   // ERROR@+1: TARGET/003 {subject_role="value", subject_name="result", constraint_key="no_ordinary_uses"}
   %columns = config.get @runtime.scalar_count : index
   %columns_i32 = index.cast %columns : index to i32
   %stored = vector.splat %columns_i32 : vector<1xi32>
-  vector.store %stored, %output_view[%zero] : vector<1xi32>, view<1xi32, #dense>
+  vector.store %stored, %output_view[%output_index] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_control_flow.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_control_flow.loom-test
@@ -75,44 +75,44 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @cfg_bra
 amdgpu.target<gfx11-generic> @target
 
 func.def target(@target) @uniform_i1_reused_after_join(%count: i32, %lhs: i32, %rhs: i32) -> (i32) {
-  %zero = scalar.constant 0 : i32
-  %has_count = scalar.cmpi ne, %count, %zero : i32
+  %empty_value = scalar.constant 0 : i32
+  %has_count = scalar.cmpi ne, %count, %empty_value : i32
   cfg.cond_br %has_count, ^has_values, ^empty
 ^has_values:
   cfg.br ^join(%lhs: i32, %rhs: i32)
 ^empty:
-  cfg.br ^join(%zero: i32, %zero: i32)
+  cfg.br ^join(%empty_value: i32, %empty_value: i32)
 ^join(%selected_lhs: i32, %selected_rhs: i32):
   %sum = scalar.addi %selected_lhs, %selected_rhs : i32
   cfg.cond_br %has_count, ^sum, ^fallback
 ^sum:
   cfg.br ^done(%sum: i32)
 ^fallback:
-  cfg.br ^done(%zero: i32)
+  cfg.br ^done(%empty_value: i32)
 ^done(%result: i32):
   func.return %result : i32
 }
 
 // ----
 low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @uniform_i1_reused_after_join(%count: reg<amdgpu.sgpr>, %lhs: reg<amdgpu.sgpr>, %rhs: reg<amdgpu.sgpr>) -> (reg<amdgpu.sgpr>) asm {
-  %zero = s_mov_b32 0
-  %18 = s_cmp_lg_i32 %count, %zero
+  %empty_value = s_mov_b32 0
+  %18 = s_cmp_lg_i32 %count, %empty_value
   %20 = s_mov_b32 1
-  %has_count = s_cselect_b32 %20, %zero, %18
-  %23 = s_cmp_lg_i32 %has_count, %zero
+  %has_count = s_cselect_b32 %20, %empty_value, %18
+  %23 = s_cmp_lg_i32 %has_count, %empty_value
   low.cond_br %23, ^has_values, ^empty : reg<amdgpu.scc>
 ^has_values:
   low.br ^join(%lhs: reg<amdgpu.sgpr>, %rhs: reg<amdgpu.sgpr>)
 ^empty:
-  low.br ^join(%zero: reg<amdgpu.sgpr>, %zero: reg<amdgpu.sgpr>)
+  low.br ^join(%empty_value: reg<amdgpu.sgpr>, %empty_value: reg<amdgpu.sgpr>)
 ^join(%selected_lhs: reg<amdgpu.sgpr>, %selected_rhs: reg<amdgpu.sgpr>):
   %sum = s_add_u32 %selected_lhs, %selected_rhs
-  %26 = s_cmp_lg_i32 %has_count, %zero
+  %26 = s_cmp_lg_i32 %has_count, %empty_value
   low.cond_br %26, ^sum, ^fallback : reg<amdgpu.scc>
 ^sum:
   low.br ^done(%sum: reg<amdgpu.sgpr>)
 ^fallback:
-  low.br ^done(%zero: reg<amdgpu.sgpr>)
+  low.br ^done(%empty_value: reg<amdgpu.sgpr>)
 ^done(%result: reg<amdgpu.sgpr>):
   return %result
 }
@@ -130,8 +130,8 @@ func.def target(@target) @index_i1_reused_after_salu_scc_clobber(%row_i32: i32, 
   %rows = index.assume %rows0 [range(%rows0, 1, 1024)] : index
   %base = index.assume %base0 [range(%base0, 0, 1024)] : index
   %scale = index.assume %scale0 [range(%scale0, 0, 1024)] : index
-  %one = index.constant 1 : index
-  %row1 = index.add %row, %one : index
+  %row_increment = index.constant 1 : index
+  %row1 = index.add %row, %row_increment : index
   %in_bounds = index.cmp ult, %row1, %rows : index
   %entry_guard = scalar.cmpi ne, %base_i32, %scale_i32 : i32
   %combined_guard = scalar.andi %in_bounds, %entry_guard : i1
@@ -145,7 +145,7 @@ func.def target(@target) @index_i1_reused_after_salu_scc_clobber(%row_i32: i32, 
   %scaled = index.add %bounded_seed, %scale : index
   cfg.cond_br %in_bounds, ^then, ^body_done
 ^then:
-  %result = index.add %scaled, %one : index
+  %result = index.add %scaled, %row_increment : index
   cfg.br ^done(%result: index)
 ^body_done:
   cfg.br ^done(%scaled: index)
@@ -155,13 +155,13 @@ func.def target(@target) @index_i1_reused_after_salu_scc_clobber(%row_i32: i32, 
 
 // ----
 low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @index_i1_reused_after_salu_scc_clobber(%row: reg<amdgpu.sgpr>, %rows: reg<amdgpu.sgpr>, %base: reg<amdgpu.sgpr>, %scale: reg<amdgpu.sgpr>) -> (reg<amdgpu.sgpr>) asm {
-  %one = s_mov_b32 1
-  %row1 = s_add_u32 %row, %one
+  %row_increment = s_mov_b32 1
+  %row1 = s_add_u32 %row, %row_increment
   %32 = s_cmp_lt_u32 %row1, %rows
   %33 = s_mov_b32 0
-  %in_bounds = s_cselect_b32 %one, %33, %32
+  %in_bounds = s_cselect_b32 %row_increment, %33, %32
   %entry_guard = s_cmp_lg_i32 %base, %scale
-  %39 = s_cselect_b32 %one, %33, %entry_guard
+  %39 = s_cselect_b32 %row_increment, %33, %entry_guard
   %40 = s_and_b32 %in_bounds, %39
   %combined_guard = s_cmp_lg_i32 %40, %33
   low.cond_br %combined_guard, ^left, ^right : reg<amdgpu.scc>
@@ -174,7 +174,7 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @index_i
   %44 = s_cmp_lg_i32 %in_bounds, %33
   low.cond_br %44, ^then, ^body_done : reg<amdgpu.scc>
 ^then:
-  %result = s_add_u32 %scaled, %one
+  %result = s_add_u32 %scaled, %row_increment
   low.br ^done(%result: reg<amdgpu.sgpr>)
 ^body_done:
   low.br ^done(%scaled: reg<amdgpu.sgpr>)
@@ -187,10 +187,10 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @index_i
 amdgpu.target<gfx11-generic> @target
 
 func.def target(@target) @uniform_branch_condition_combined_with_lane_mask(%values: vector<2xi32>, %x: i32, %limit: i32, %true_value: i32, %false_value: i32) -> (i32) {
-  %zero = scalar.constant 0 : i32
+  %lower_bound = scalar.constant 0 : i32
   %lane = vector.extract %values[0] : vector<2xi32> -> i32
   %lane_ok = scalar.cmpi slt, %lane, %limit : i32
-  %x_lower = scalar.cmpi sge, %x, %zero : i32
+  %x_lower = scalar.cmpi sge, %x, %lower_bound : i32
   %x_upper = scalar.cmpi slt, %x, %limit : i32
   %x_ok = scalar.andi %x_lower, %x_upper : i1
   %combined = scalar.andi %lane_ok, %x_ok : i1
@@ -207,25 +207,25 @@ func.def target(@target) @uniform_branch_condition_combined_with_lane_mask(%valu
 
 // ----
 low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @uniform_branch_condition_combined_with_lane_mask(%values: reg<amdgpu.vgpr x2>, %x: reg<amdgpu.sgpr>, %limit: reg<amdgpu.sgpr>, %true_value: reg<amdgpu.sgpr>, %false_value: reg<amdgpu.sgpr>) -> (reg<amdgpu.vgpr>) asm {
-  %zero = s_mov_b32 0
+  %lower_bound = s_mov_b32 0
   %lane = slice %values[0] : reg<amdgpu.vgpr x2> -> reg<amdgpu.vgpr>
   %25 = v_mov_b32_copy %limit
   %lane_ok = v_cmp_lt_i32 %lane, %25
-  %x_lower = s_cmp_ge_i32 %x, %zero
+  %x_lower = s_cmp_ge_i32 %x, %lower_bound
   %x_upper = s_cmp_lt_i32 %x, %limit
   %30 = s_mov_b32 1
-  %31 = s_cselect_b32 %30, %zero, %x_lower
-  %32 = s_cselect_b32 %30, %zero, %x_upper
+  %31 = s_cselect_b32 %30, %lower_bound, %x_lower
+  %32 = s_cselect_b32 %30, %lower_bound, %x_upper
   %x_ok = s_and_b32 %31, %32
   %34 = s_cmp_lg_i32_src1_inline %x_ok {rhs = 0}
   %35 = s_mov_b64_exec_read
   %36 = slice %35[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %37 = slice %35[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
-  %39 = s_cselect_b32 %36, %zero, %34
-  %40 = s_cselect_b32 %37, %zero, %34
+  %39 = s_cselect_b32 %36, %lower_bound, %34
+  %40 = s_cselect_b32 %37, %lower_bound, %34
   %41 = concat(%39, %40) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
   %combined = s_and_b64 %lane_ok, %41
-  %44 = s_cmp_lg_i32 %x_ok, %zero
+  %44 = s_cmp_lg_i32 %x_ok, %lower_bound
   low.cond_br %44, ^valid, ^clamped : reg<amdgpu.scc>
 ^valid:
   low.br ^join(%true_value: reg<amdgpu.sgpr>)
@@ -350,8 +350,8 @@ kernel.def target(@target) @cfg_exact_divergent_condition() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   %lane = kernel.workitem.id<x> : index
   %cond = index.cmp eq, %lane, %lane : index
   cfg.cond_br %cond, ^then, ^else
@@ -367,8 +367,8 @@ kernel.def target(@target) @cfg_exact_false_divergent_condition() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   %lane = kernel.workitem.id<x> : index
   %cond = index.cmp ne, %lane, %lane : index
   cfg.cond_br %cond, ^then, ^else
@@ -404,8 +404,8 @@ amdgpu.target<gfx11-generic> @target
 func.def target(@target) @divergent_if_else(%values: vector<2xi32>, %limit: i32, %output: buffer) {
   %lane = vector.extract %values[0] : vector<2xi32> -> i32
   %cond = scalar.cmpi slt, %lane, %limit : i32
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<2xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<2xi32, #dense>
   cfg.cond_br %cond, ^then, ^else
 ^then:
   %then = vector.from_elements %lane : vector<1xi32>
@@ -461,8 +461,8 @@ func.def target(@target) @divergent_nested_if_else_stores(%values: vector<2xi32>
   %lane = vector.extract %values[0] : vector<2xi32> -> i32
   %after_lower = scalar.cmpi sge, %lane, %lower : i32
   %before_upper = scalar.cmpi slt, %lane, %upper : i32
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<3xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<3xi32, #dense>
   cfg.cond_br %after_lower, ^after, ^before
 ^after:
   cfg.cond_br %before_upper, ^inside, ^outside_high
@@ -1039,8 +1039,8 @@ amdgpu.target<gfx11-generic> @target
 func.def target(@target) @divergent_then_only(%values: vector<2xi32>, %limit: i32, %output: buffer) {
   %lane = vector.extract %values[0] : vector<2xi32> -> i32
   %cond = scalar.cmpi slt, %lane, %limit : i32
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<2xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<2xi32, #dense>
   cfg.cond_br %cond, ^then, ^join
 ^then:
   %biased = scalar.addi %lane, %limit : i32
@@ -1200,12 +1200,12 @@ kernel.def target(@target) @workgroup_loop_bound_f32_accumulator() {
   %row = kernel.workgroup.id<x> : index
   %start = index.constant 0 : index
   %step = index.constant 1 : index
-  %one = index.constant 1 : index
-  %zero = scalar.constant 0.0 : f32
+  %row_extent = index.constant 1 : index
+  %initial_sum = scalar.constant 0.0 : f32
   %input_view = buffer.view %input[%base] : buffer -> view<128xf32, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<128xf32, #dense>
-  %limit = index.add %row, %one : index
-  %sum = scf.for %position = [%start to %limit step %step](%current_sum = %zero : f32) -> (f32) {
+  %limit = index.add %row, %row_extent : index
+  %sum = scf.for %position = [%start to %limit step %step](%current_sum = %initial_sum : f32) -> (f32) {
     %loaded = view.load %input_view[%position] : view<128xf32, #dense> -> f32
     %next_sum = scalar.addf<reassoc|nnan|nsz> %current_sum, %loaded : f32
     scf.yield %next_sum : f32
@@ -1221,9 +1221,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 512} : reg<amdgpu.sgpr x2>
   %start = s_mov_b32 0
   %step = s_mov_b32 1
-  %zero = v_mov_b32 0
+  %initial_sum = v_mov_b32 0
   %limit = s_add_u32 %row, %step
-  low.br ^_bb1(%start: reg<amdgpu.sgpr>, %zero: reg<amdgpu.vgpr>)
+  low.br ^_bb1(%start: reg<amdgpu.sgpr>, %initial_sum: reg<amdgpu.vgpr>)
 ^_bb1(%position: reg<amdgpu.sgpr>, %current_sum: reg<amdgpu.vgpr>):
   %33 = s_cmp_lt_i32 %position, %limit
   low.cond_br %33, ^_bb2, ^_bb3 : reg<amdgpu.scc>
@@ -1234,7 +1234,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %39 = s_add_u32 %36, %35
   %40 = s_addc_u32 %37, %start
   %41 = concat(%39, %40) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %loaded = global_load_b32_saddr %zero, %41
+  %loaded = global_load_b32_saddr %initial_sum, %41
   %next_sum = v_add_f32 %current_sum, %loaded
   %44 = s_add_u32 %position, %step
   low.br ^_bb1(%44: reg<amdgpu.sgpr>, %next_sum: reg<amdgpu.vgpr>)
@@ -1245,7 +1245,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %50 = s_add_u32 %47, %46
   %51 = s_addc_u32 %48, %start
   %52 = concat(%50, %51) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  global_store_b32_saddr %zero, %current_sum, %52
+  global_store_b32_saddr %initial_sum, %current_sum, %52
   return
 }
 
@@ -1254,28 +1254,28 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
 amdgpu.target<gfx11-generic> @target
 
 func.def target(@target) @uniform_q4_scale_min_loop_decode(%input: buffer) -> (f32) {
-  %zero_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %three = index.constant 3 : index
-  %four = index.constant 4 : index
-  %four_i32 = scalar.constant 4 : i32
-  %two_i32 = scalar.constant 2 : i32
+  %input_base = index.constant 0 : offset
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %loop_end = index.constant 2 : index
+  %group_offset = index.constant 3 : index
+  %group_width = index.constant 4 : index
+  %nibble_shift = scalar.constant 4 : i32
+  %high_bits_shift = scalar.constant 2 : i32
   %mask_0f = scalar.constant 15 : i32
   %mask_3f = scalar.constant 63 : i32
   %mask_c0 = scalar.constant 192 : i32
-  %zero_f32 = scalar.constant 0.0 : f32
+  %initial_sum = scalar.constant 0.0 : f32
   %input_global = buffer.assume.memory_space<global> %input : buffer
   %input_noalias = buffer.assume.noalias %input_global : buffer
-  %input_view = buffer.view %input_noalias[%zero_offset] : buffer -> view<16xi8, #dense>
-  %sum = scf.for %position = [%zero to %two step %one](%acc = %zero_f32 : f32) -> (f32) {
-    %group0 = index.add %position, %three : index
+  %input_view = buffer.view %input_noalias[%input_base] : buffer -> view<16xi8, #dense>
+  %sum = scf.for %position = [%loop_begin to %loop_end step %loop_step](%acc = %initial_sum : f32) -> (f32) {
+    %group0 = index.add %position, %group_offset : index
     %group = index.assume %group0 [range(%group0, 3, 4)] : index
-    %group_lt4 = index.cmp slt, %group, %four : index
+    %group_lt4 = index.cmp slt, %group, %group_width : index
     %scale_i32, %min_i32 = scf.if %group_lt4 -> (i32, i32) {
       %scale_index = index.add %group, %position : index
-      %min_slot = index.add %group, %four : index
+      %min_slot = index.add %group, %group_width : index
       %min_index = index.add %min_slot, %position : index
       %scale_i8 = view.load %input_view[%scale_index] : view<16xi8, #dense> -> i8
       %min_i8 = view.load %input_view[%min_index] : view<16xi8, #dense> -> i8
@@ -1285,8 +1285,8 @@ func.def target(@target) @uniform_q4_scale_min_loop_decode(%input: buffer) -> (f
       %min = scalar.andi %min_u, %mask_3f : i32
       scf.yield %scale, %min : i32, i32
     } else {
-      %group_minus4 = index.sub %group, %four : index
-      %group_plus4 = index.add %group, %four : index
+      %group_minus4 = index.sub %group, %group_width : index
+      %group_plus4 = index.add %group, %group_width : index
       %low_index = index.add %group_minus4, %position : index
       %mid_index = index.add %group, %position : index
       %high_index = index.add %group_plus4, %position : index
@@ -1298,11 +1298,11 @@ func.def target(@target) @uniform_q4_scale_min_loop_decode(%input: buffer) -> (f
       %high = scalar.extui %high_i8 : i8 to i32
       %scale_low = scalar.andi %high, %mask_0f : i32
       %scale_hi0 = scalar.andi %low, %mask_c0 : i32
-      %scale_hi = scalar.shrui %scale_hi0, %two_i32 : i32
+      %scale_hi = scalar.shrui %scale_hi0, %high_bits_shift : i32
       %scale = scalar.ori %scale_low, %scale_hi : i32
-      %min_low = scalar.shrui %high, %four_i32 : i32
+      %min_low = scalar.shrui %high, %nibble_shift : i32
       %min_hi0 = scalar.andi %mid, %mask_c0 : i32
-      %min_hi = scalar.shrui %min_hi0, %two_i32 : i32
+      %min_hi = scalar.shrui %min_hi0, %high_bits_shift : i32
       %min = scalar.ori %min_low, %min_hi : i32
       scf.yield %scale, %min : i32, i32
     }
@@ -1318,31 +1318,31 @@ func.def target(@target) @uniform_q4_scale_min_loop_decode(%input: buffer) -> (f
 // ----
 low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @uniform_q4_scale_min_loop_decode() -> (reg<amdgpu.vgpr>) asm {
   %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 16} : reg<amdgpu.sgpr x2>
-  %zero = s_mov_b32 0
-  %one = s_mov_b32 1
-  %two = s_mov_b32 2
-  %three = s_mov_b32 3
-  %four = s_mov_b32 4
-  %zero_f32 = v_mov_b32 0
-  low.br ^_bb1(%zero: reg<amdgpu.sgpr>, %zero_f32: reg<amdgpu.vgpr>)
+  %loop_begin = s_mov_b32 0
+  %loop_step = s_mov_b32 1
+  %loop_end = s_mov_b32 2
+  %group_offset = s_mov_b32 3
+  %group_width = s_mov_b32 4
+  %initial_sum = v_mov_b32 0
+  low.br ^_bb1(%loop_begin: reg<amdgpu.sgpr>, %initial_sum: reg<amdgpu.vgpr>)
 ^_bb1(%position: reg<amdgpu.sgpr>, %acc: reg<amdgpu.vgpr>):
-  %83 = s_cmp_lt_i32 %position, %two
+  %83 = s_cmp_lt_i32 %position, %loop_end
   low.cond_br %83, ^_bb2, ^_bb6 : reg<amdgpu.scc>
 ^_bb2:
-  %group = s_add_u32 %position, %three
-  %group_lt4 = s_cmp_lt_i32 %group, %four
+  %group = s_add_u32 %position, %group_offset
+  %group_lt4 = s_cmp_lt_i32 %group, %group_width
   low.cond_br %group_lt4, ^_bb3, ^_bb4 : reg<amdgpu.scc>
 ^_bb3:
   %87 = slice %input_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %88 = slice %input_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %90 = s_add_u32 %87, %position
-  %91 = s_addc_u32 %88, %zero
+  %91 = s_addc_u32 %88, %loop_begin
   %92 = concat(%90, %91) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %scale_i8 = global_load_i8_saddr %zero_f32, %92 {offset = 3}
+  %scale_i8 = global_load_i8_saddr %initial_sum, %92 {offset = 3}
   %98 = s_add_u32 %87, %position
-  %99 = s_addc_u32 %88, %zero
+  %99 = s_addc_u32 %88, %loop_begin
   %100 = concat(%98, %99) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %min_i8 = global_load_i8_saddr %zero_f32, %100 {offset = 7}
+  %min_i8 = global_load_i8_saddr %initial_sum, %100 {offset = 7}
   %scale_u = v_and_b32_lit %scale_i8, 255
   %min_u = v_and_b32_lit %min_i8, 255
   %scale$104 = v_and_b32_lit %scale_u, 63
@@ -1352,17 +1352,17 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @uniform
   %107 = slice %input_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %108 = slice %input_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %110 = s_add_u32 %107, %position
-  %111 = s_addc_u32 %108, %zero
+  %111 = s_addc_u32 %108, %loop_begin
   %112 = concat(%110, %111) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %low_i8 = global_load_i8_saddr %zero_f32, %112
+  %low_i8 = global_load_i8_saddr %initial_sum, %112
   %118 = s_add_u32 %107, %position
-  %119 = s_addc_u32 %108, %zero
+  %119 = s_addc_u32 %108, %loop_begin
   %120 = concat(%118, %119) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %mid_i8 = global_load_i8_saddr %zero_f32, %120 {offset = 4}
+  %mid_i8 = global_load_i8_saddr %initial_sum, %120 {offset = 4}
   %126 = s_add_u32 %107, %position
-  %127 = s_addc_u32 %108, %zero
+  %127 = s_addc_u32 %108, %loop_begin
   %128 = concat(%126, %127) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
-  %high_i8 = global_load_i8_saddr %zero_f32, %128 {offset = 8}
+  %high_i8 = global_load_i8_saddr %initial_sum, %128 {offset = 8}
   %low = v_and_b32_lit %low_i8, 255
   %mid = v_and_b32_lit %mid_i8, 255
   %high = v_and_b32_lit %high_i8, 255
@@ -1380,7 +1380,7 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @uniform
   %min_f32 = v_cvt_f32_u32 %min_i32
   %term = v_add_f32 %scale_f32, %min_f32
   %next = v_add_f32 %acc, %term
-  %145 = s_add_u32 %position, %one
+  %145 = s_add_u32 %position, %loop_step
   low.br ^_bb1(%145: reg<amdgpu.sgpr>, %next: reg<amdgpu.vgpr>)
 ^_bb6:
   return %acc
@@ -1393,9 +1393,9 @@ amdgpu.target<gfx11-generic> @target
 func.def target(@target) @divergent_if_q6_nibble_i8_result(%values: vector<2xi32>, %limit: i32) -> (i8) {
   %code = vector.extract %values[0] : vector<2xi32> -> i32
   %selector = vector.extract %values[1] : vector<2xi32> -> i32
-  %four = scalar.constant 4 : i32
+  %nibble_shift = scalar.constant 4 : i32
   %mask = scalar.constant 15 : i32
-  %high_shifted = scalar.shrui %code, %four : i32
+  %high_shifted = scalar.shrui %code, %nibble_shift : i32
   %low_i32 = scalar.andi %code, %mask : i32
   %high_i32 = scalar.andi %high_shifted, %mask : i32
   %low = scalar.trunci %low_i32 : i32 to i8
@@ -1945,12 +1945,12 @@ func.def target(@target) @divergent_passthrough_else_i1_select_condition(%values
   %lane = vector.extract %values[0] : vector<2xi32> -> i32
   %limit = scalar.constant 8 : i32
   %upper = scalar.constant 16 : i32
-  %zero = scalar.constant 0 : i32
+  %positive_lower_bound = scalar.constant 0 : i32
   %lane_condition = scalar.cmpi slt, %lane, %limit : i32
   cfg.cond_br %lane_condition, ^then, ^else
 ^then:
   %inside_upper = scalar.cmpi slt, %lane, %upper : i32
-  %positive_lane = scalar.cmpi slt, %zero, %lane : i32
+  %positive_lane = scalar.cmpi slt, %positive_lower_bound, %lane : i32
   %then_condition = scf.select %inside_upper, %inside_upper, %positive_lane : i1
   cfg.br ^then_exit(%then_condition: i1)
 ^then_exit(%then_condition_arg: i1):
@@ -2009,7 +2009,7 @@ func.def target(@target) @divergent_passthrough_else_i1_nested_branch_condition(
   %lane = vector.extract %values[0] : vector<2xi32> -> i32
   %limit = scalar.constant 8 : i32
   %upper = scalar.constant 16 : i32
-  %zero = scalar.constant 0 : i32
+  %positive_lower_bound = scalar.constant 0 : i32
   %lane_condition = scalar.cmpi slt, %lane, %limit : i32
   cfg.cond_br %lane_condition, ^then, ^else
 ^then:
@@ -2018,7 +2018,7 @@ func.def target(@target) @divergent_passthrough_else_i1_nested_branch_condition(
 ^then_true:
   cfg.br ^then_exit(%inside_upper: i1)
 ^then_false:
-  %positive_lane = scalar.cmpi slt, %zero, %lane : i32
+  %positive_lane = scalar.cmpi slt, %positive_lower_bound, %lane : i32
   cfg.br ^then_exit(%positive_lane: i1)
 ^then_exit(%then_condition_arg: i1):
   cfg.br ^join(%then_condition_arg: i1)
@@ -2323,10 +2323,10 @@ kernel.def target(@wave64_target) @predicated_tile_sweep_kq_src1_reduction_shape
   kernel.launch.config workgroups(%workgroups_x, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%src0: buffer, %src1: buffer, %dst: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
-  %sixty_four = index.constant 64 : index
-  %one_twenty_eight = index.constant 128 : index
+  %c0 = index.constant 0 : index
+  %k_tile_size = index.constant 16 : index
+  %subgroup_stride = index.constant 64 : index
+  %k_extent = index.constant 128 : index
   %tile_elements = index.constant 256 : index
   %src0_count = index.constant 262144 : index
   %src1_count = index.constant 1577184 : index
@@ -2344,12 +2344,12 @@ kernel.def target(@wave64_target) @predicated_tile_sweep_kq_src1_reduction_shape
   %dst_view = buffer.view %dst_noalias[%base] : buffer -> view<[%dst_count]xf32, #dense>
   %lane0 = kernel.workitem.id<x> : index
   %lane = index.assume %lane0 [range(%lane0, 0, 31)] : index
-  %seed_f16 = view.load %src0_view[%zero] : view<[%src0_count]xf16, #dense> -> f16
+  %seed_f16 = view.load %src0_view[%c0] : view<[%src0_count]xf16, #dense> -> f16
   %seed = scalar.extf %seed_f16 : f16 to f32
-  %sum = scf.for %kk = [%zero to %one_twenty_eight step %sixteen](%outer_acc = %seed : f32) -> (f32) {
-    %inner_sum = scf.for %i = [%lane to %tile_elements step %sixty_four](%inner_acc = %outer_acc : f32) -> (f32) {
-      %rhs_k_inner = index.rem %i, %sixteen : index
-      %rhs_col_inner = index.div %i, %sixteen : index
+  %sum = scf.for %kk = [%c0 to %k_extent step %k_tile_size](%outer_acc = %seed : f32) -> (f32) {
+    %inner_sum = scf.for %i = [%lane to %tile_elements step %subgroup_stride](%inner_acc = %outer_acc : f32) -> (f32) {
+      %rhs_k_inner = index.rem %i, %k_tile_size : index
+      %rhs_col_inner = index.div %i, %k_tile_size : index
       %rhs_col_base = index.mul %rhs_col_inner, %src1_stride_col_elem : index
       %rhs_k = index.add %kk, %rhs_k_inner : index
       %rhs_index = index.add %rhs_col_base, %rhs_k : index
@@ -2359,7 +2359,7 @@ kernel.def target(@wave64_target) @predicated_tile_sweep_kq_src1_reduction_shape
     }
     scf.yield %inner_sum : f32
   }
-  view.store %sum, %dst_view[%zero] : f32, view<[%dst_count]xf32, #dense>
+  view.store %sum, %dst_view[%c0] : f32, view<[%dst_count]xf32, #dense>
   kernel.return
 }
 
@@ -2369,15 +2369,15 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@wave64_target) workgroup_size(
   %src0_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 524288} : reg<amdgpu.sgpr x2>
   %src1_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 6308736} : reg<amdgpu.sgpr x2>
   %dst_view = resource<hal_binding> {index = 2, source_type = hal.buffer, extent = 1048576} : reg<amdgpu.sgpr x2>
-  %zero = s_mov_b32 0
-  %sixteen = s_mov_b32 16
-  %one_twenty_eight = s_mov_b32 128
+  %c0 = s_mov_b32 0
+  %k_tile_size = s_mov_b32 16
+  %k_extent = s_mov_b32 128
   %77 = v_mov_b32 0
   %seed_f16 = global_load_d16_b16_saddr %77, %src0_view
   %seed = v_cvt_f32_f16 %seed_f16
-  low.br ^_bb1(%zero: reg<amdgpu.sgpr>, %seed: reg<amdgpu.vgpr>)
+  low.br ^_bb1(%c0: reg<amdgpu.sgpr>, %seed: reg<amdgpu.vgpr>)
 ^_bb1(%kk: reg<amdgpu.sgpr>, %outer_acc: reg<amdgpu.vgpr>):
-  %80 = s_cmp_lt_i32 %kk, %one_twenty_eight
+  %80 = s_cmp_lt_i32 %kk, %k_extent
   low.cond_br %80, ^_bb2, ^_bb6 : reg<amdgpu.scc>
 ^_bb2:
   low.br ^_bb7
@@ -2400,7 +2400,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@wave64_target) workgroup_size(
   %97 = v_add_u32 %i, %96
   low.br ^_bb3(%97: reg<amdgpu.vgpr>, %next: reg<amdgpu.vgpr>)
 ^_bb5:
-  %98 = s_add_u32 %kk, %sixteen
+  %98 = s_add_u32 %kk, %k_tile_size
   low.br ^_bb1(%98: reg<amdgpu.sgpr>, %inner_acc: reg<amdgpu.vgpr>)
 ^_bb6:
   global_store_b32_saddr %77, %outer_acc, %dst_view
@@ -2421,31 +2421,31 @@ kernel.def target(@target) @uniform_vgpr_branch_address() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%control: buffer, %input: buffer, %output: buffer) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %control_index = index.constant 0 : index
+  %loop_increment = index.constant 1 : index
   %base = index.constant 0 : offset
-  %seven = index.constant 7 : index
-  %three = index.constant 3 : index
-  %two = index.constant 2 : index
-  %twenty = index.constant 20 : index
+  %group_rounding_bias = index.constant 7 : index
+  %group_shift = index.constant 3 : index
+  %element_shift = index.constant 2 : index
+  %element_limit = index.constant 20 : index
   %control_view = buffer.view %control[%base] : buffer -> view<1xi32, #dense>
   %input_view = buffer.view %input[%base] : buffer -> view<32xi32, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<32xi32, #dense>
-  %loaded = view.load %control_view[%zero] : view<1xi32, #dense> -> i32
+  %loaded = view.load %control_view[%control_index] : view<1xi32, #dense> -> i32
   %bounded = scalar.assume %loaded [range(%loaded, 0, 31)] : i32
   %index_value = index.cast %bounded : i32 to index
-  %padded = index.add %index_value, %seven : index
-  %group = index.shrui %padded, %three : index
-  %element = index.shli %group, %two : index
+  %padded = index.add %index_value, %group_rounding_bias : index
+  %group = index.shrui %padded, %group_shift : index
+  %element = index.shli %group, %element_shift : index
   cfg.br ^loop(%element: index)
 ^loop(%carried: index):
-  %in_bounds = index.cmp ult, %carried, %twenty : index
+  %in_bounds = index.cmp ult, %carried, %element_limit : index
   cfg.cond_br %in_bounds, ^access, ^exit
 ^access:
   %active = index.assume %carried [range(%carried, 0, 19)] : index
   %value = view.load %input_view[%active] : view<32xi32, #dense> -> i32
   view.store %value, %output_view[%active] : i32, view<32xi32, #dense>
-  %next = index.add %active, %one : index
+  %next = index.add %active, %loop_increment : index
   cfg.br ^loop(%next: index)
 ^exit:
   kernel.return
@@ -2456,8 +2456,8 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %control_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 4} : reg<amdgpu.sgpr x2>
   %input_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 128} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 2, source_type = hal.buffer, extent = 128} : reg<amdgpu.sgpr x2>
-  %one = s_mov_b32 1
-  %twenty = s_mov_b32 20
+  %loop_increment = s_mov_b32 1
+  %element_limit = s_mov_b32 20
   %32 = v_mov_b32 0
   %index_value = global_load_b32_saddr %32, %control_view
   %34 = v_mov_b32 7
@@ -2467,7 +2467,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %38 = v_readfirstlane_b32 %element
   low.br ^loop(%38: reg<amdgpu.sgpr>)
 ^loop(%active: reg<amdgpu.sgpr>):
-  %in_bounds = s_cmp_lt_u32 %active, %twenty
+  %in_bounds = s_cmp_lt_u32 %active, %element_limit
   low.cond_br %in_bounds, ^access, ^exit : reg<amdgpu.scc>
 ^access:
   %40 = v_mov_b32 0
@@ -2486,7 +2486,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %55 = s_addc_u32 %52, %44
   %56 = concat(%54, %55) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
   global_store_b32_saddr %40, %value, %56
-  %next = s_add_u32 %active, %one
+  %next = s_add_u32 %active, %loop_increment
   low.br ^loop(%next: reg<amdgpu.sgpr>)
 ^exit:
   return

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_conversion.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_conversion.loom-test
@@ -1671,13 +1671,13 @@ kernel.def target(@target) @scalar_bitcast_direct_i32_arg_f32_store() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%output: buffer, %scale_bits: i32) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xf32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_element = index.constant 0 : index
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xf32, #dense>
   %scale = scalar.bitcast %scale_bits : i32 to f32
   %unit = scalar.constant 1.0 : f32
   %scaled = scalar.mulf %unit, %scale : f32
-  view.store %scaled, %output_view[%zero_index] : f32, view<1xf32, #dense>
+  view.store %scaled, %output_view[%output_element] : f32, view<1xf32, #dense>
   kernel.return
 }
 
@@ -1714,17 +1714,19 @@ kernel.def target(@target) @scalar_bitcast_lane_byte_decode_select_tree_store() 
   %exp = scalar.shrui %exp_bits, %exp_shift : i32
   %mantissa_mask = scalar.constant 7 : i32
   %mantissa = scalar.andi %wide, %mantissa_mask : i32
-  %zero = scalar.constant 0 : i32
+  %absent_mantissa_bit = scalar.constant 0 : i32
+  %base_mantissa_shift = scalar.constant 0 : i32
+  %zero_exponent = scalar.constant 0 : i32
   %mantissa_bit1_mask = scalar.constant 2 : i32
   %mantissa_bit1 = scalar.andi %mantissa, %mantissa_bit1_mask : i32
-  %has_mantissa_bit1 = scalar.cmpi ne, %mantissa_bit1, %zero : i32
-  %one = scalar.constant 1 : i32
-  %shift0 = scf.select %has_mantissa_bit1, %one, %zero : i32
+  %has_mantissa_bit1 = scalar.cmpi ne, %mantissa_bit1, %absent_mantissa_bit : i32
+  %low_mantissa_shift = scalar.constant 1 : i32
+  %shift0 = scf.select %has_mantissa_bit1, %low_mantissa_shift, %base_mantissa_shift : i32
   %mantissa_bit2_mask = scalar.constant 4 : i32
   %mantissa_bit2 = scalar.andi %mantissa, %mantissa_bit2_mask : i32
-  %has_mantissa_bit2 = scalar.cmpi ne, %mantissa_bit2, %zero : i32
-  %two = scalar.constant 2 : i32
-  %selected_shift = scf.select %has_mantissa_bit2, %two, %shift0 : i32
+  %has_mantissa_bit2 = scalar.cmpi ne, %mantissa_bit2, %absent_mantissa_bit : i32
+  %high_mantissa_shift = scalar.constant 2 : i32
+  %selected_shift = scf.select %has_mantissa_bit2, %high_mantissa_shift, %shift0 : i32
   %bias = scalar.constant 118 : i32
   %biased_exp = scalar.addi %selected_shift, %bias : i32
   %f32_exp_shift = scalar.constant 23 : i32
@@ -1736,7 +1738,7 @@ kernel.def target(@target) @scalar_bitcast_lane_byte_decode_select_tree_store() 
   %normal_head = scalar.ori %sign_bits, %f32_exp : i32
   %normal_bits = scalar.ori %normal_head, %f32_mantissa : i32
   %subnormal = scf.select %has_mantissa_bit2, %normal_bits, %sign_bits : i32
-  %is_zero_exp = scalar.cmpi eq, %exp, %zero : i32
+  %is_zero_exp = scalar.cmpi eq, %exp, %zero_exponent : i32
   %regular_exp_bias = scalar.constant 120 : i32
   %regular_exp = scalar.addi %exp, %regular_exp_bias : i32
   %regular_exp_bits = scalar.shli %regular_exp, %f32_exp_shift : i32
@@ -1774,19 +1776,19 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %mantissa_bit2 = v_and_b32_lit %mantissa, 4
   %has_mantissa_bit2 = v_cmp_ne_i32_src1_inline %mantissa_bit2 {rhs = 0}
   %selected_shift = v_cndmask_b32_src1_inline %shift0, %has_mantissa_bit2 {true_value = 2}
-  %79 = v_mov_b32 118
-  %biased_exp = v_add_u32 %selected_shift, %79
+  %81 = v_mov_b32 118
+  %biased_exp = v_add_u32 %selected_shift, %81
   %f32_exp = v_lshlrev_b32_lit %biased_exp, 23
-  %83 = v_mov_b32 23
-  %remaining_shift = v_sub_nc_u32 %83, %selected_shift
+  %85 = v_mov_b32 23
+  %remaining_shift = v_sub_nc_u32 %85, %selected_shift
   %shifted_mantissa = v_lshlrev_b32 %remaining_shift, %mantissa
   %f32_mantissa = v_and_b32_lit %shifted_mantissa, 8388607
   %normal_head = v_or_b32 %sign_bits, %f32_exp
   %normal_bits = v_or_b32 %normal_head, %f32_mantissa
   %subnormal = v_cndmask_b32 %sign_bits, %normal_bits, %has_mantissa_bit2
   %is_zero_exp = v_cmp_eq_i32_src1_inline %exp {rhs = 0}
-  %91 = v_mov_b32 120
-  %regular_exp = v_add_u32 %exp, %91
+  %93 = v_mov_b32 120
+  %regular_exp = v_add_u32 %exp, %93
   %regular_exp_bits = v_lshlrev_b32_lit %regular_exp, 23
   %regular_head = v_or_b32 %sign_bits, %regular_exp_bits
   %regular_bits = v_or_b32 %regular_head, %f32_mantissa
@@ -1795,8 +1797,8 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %is_nan_payload = v_cmp_eq_i32_src1_inline %mantissa {rhs = 7}
   %use_nan = s_and_b64 %is_special_exp, %is_nan_payload
   %value = v_cndmask_b32_src1_lit %finite_bits, %use_nan, 2143289344
-  %104 = v_lshlrev_b32_src0_inline %lane, 2
-  global_store_b32_saddr %104, %value, %output_view
+  %106 = v_lshlrev_b32_src0_inline %lane, 2
+  global_store_b32_saddr %106, %value, %output_view
   return
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_diagnostics.loom-test
@@ -7,14 +7,14 @@ kernel.def target(@target) @lds_b32_diagnostics() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_b32", address_form="default", dynamic_term_kind="vaddr", fallback_reason="cross_wave_workgroup", dynamic_stride_bytes="4"}
-  vector.store %one, %scratch_view[%tid] : vector<1xi32>, view<64xi32, #dense>
+  vector.store %stored_value, %scratch_view[%tid] : vector<1xi32>, view<64xi32, #dense>
   // REMARK@+1: BACKEND/017 {operation_kind="load", packet_key="amdgpu.ds_read_b32", address_form="default", dynamic_term_kind="vaddr", fallback_reason="cross_wave_workgroup", dynamic_stride_bytes="4"}
   %loaded = vector.load %scratch_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%tid] : vector<1xi32>, view<64xi32, #dense>
@@ -26,9 +26,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %tid = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
   %13 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %16 = v_lshlrev_b32_src0_inline %tid, 2
-  low.op<amdgpu.ds_write_b32>(%16, %one) {offset = 0} memory_access([0, 3, 6, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%16, %stored_value) {offset = 0} memory_access([0, 3, 6, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%16) {offset = 0} memory_access([0, 3, 6, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   global_store_b32_saddr %16, %loaded, %output_view
   return
@@ -44,15 +44,15 @@ kernel.def target(@target) @lds_padded_diagnostics() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 2048 : offset
   %layout = encoding.layout.strided [5, 1] : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, %layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
-  %one = vector.constant 1 : vector<4xi32>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, %layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %stored_value = vector.constant 1 : vector<4xi32>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_b128", address_form="default", dynamic_term_kind="vaddr", fallback_reason="cross_wave_workgroup", dynamic_stride_bytes="20"}
-  vector.store %one, %scratch_view[%tid, 0] : vector<4xi32>, view<64x4xi32, %layout>
+  vector.store %stored_value, %scratch_view[%tid, 0] : vector<4xi32>, view<64x4xi32, %layout>
   // REMARK@+1: BACKEND/017 {operation_kind="load", packet_key="amdgpu.ds_read_b128", address_form="default", dynamic_term_kind="vaddr", fallback_reason="cross_wave_workgroup", dynamic_stride_bytes="20"}
   %loaded = vector.load %scratch_view[%tid, 0] : view<64x4xi32, %layout> -> vector<4xi32>
   vector.store %loaded, %output_view[%tid, 0] : vector<4xi32>, view<64x4xi32, #dense>
@@ -65,10 +65,10 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
   %14 = storage {byte_alignment = 16, byte_length = 2048} : low.storage<workgroup>
   %16 = v_mov_b32 1
-  %one = concat(%16, %16, %16, %16) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x4>
+  %stored_value = concat(%16, %16, %16, %16) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x4>
   %21 = v_mov_b32 20
   %22 = v_mul_lo_u32 %tid, %21
-  low.op<amdgpu.ds_write_b128>(%22, %one) {offset = 0} memory_access([0, 3, 7, -1, 43, 20, 0, 16, 3, 0, 1260, 16, 1276]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr x4>)
+  low.op<amdgpu.ds_write_b128>(%22, %stored_value) {offset = 0} memory_access([0, 3, 7, -1, 43, 20, 0, 16, 3, 0, 1260, 16, 1276]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr x4>)
   %loaded = low.op<amdgpu.ds_read_b128>(%22) {offset = 0} memory_access([0, 3, 7, -1, 43, 20, 0, 16, 3, 0, 1260, 16, 1276]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x4>
   %26 = v_lshlrev_b32_src0_inline %tid, 4
   global_store_b128_saddr %26, %loaded, %output_view
@@ -85,15 +85,15 @@ kernel.def target(@target) @lds_read2_write2_diagnostics() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 2048 : offset
   %layout = encoding.layout.strided [8, 2] : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, %layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x2xi32, #dense>
-  %one = vector.constant 1 : vector<2xi32>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, %layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x2xi32, #dense>
+  %stored_value = vector.constant 1 : vector<2xi32>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write2_b32", address_form="ds_2addr", dynamic_term_kind="vaddr", fallback_reason="cross_wave_workgroup", dynamic_stride_bytes="32"}
-  vector.store %one, %scratch_view[%tid, 0] : vector<2xi32>, view<64x4xi32, %layout>
+  vector.store %stored_value, %scratch_view[%tid, 0] : vector<2xi32>, view<64x4xi32, %layout>
   // REMARK@+1: BACKEND/017 {operation_kind="load", packet_key="amdgpu.ds_read2_b32", address_form="ds_2addr", dynamic_term_kind="vaddr", fallback_reason="cross_wave_workgroup", dynamic_stride_bytes="32"}
   %loaded = vector.load %scratch_view[%tid, 0] : view<64x4xi32, %layout> -> vector<2xi32>
   vector.store %loaded, %output_view[%tid, 0] : vector<2xi32>, view<64x2xi32, #dense>
@@ -124,14 +124,14 @@ kernel.def target(@target) @lds_dense_b128_diagnostics() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
-  %one = vector.constant 1 : vector<4xi32>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %stored_value = vector.constant 1 : vector<4xi32>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_b128", address_form="default", dynamic_term_kind="vaddr", fallback_reason="cross_wave_workgroup", dynamic_stride_bytes="16"}
-  vector.store %one, %scratch_view[%tid, 0] : vector<4xi32>, view<64x4xi32, #dense>
+  vector.store %stored_value, %scratch_view[%tid, 0] : vector<4xi32>, view<64x4xi32, #dense>
   // REMARK@+1: BACKEND/017 {operation_kind="load", packet_key="amdgpu.ds_read_b128", address_form="default", dynamic_term_kind="vaddr", fallback_reason="cross_wave_workgroup", dynamic_stride_bytes="16"}
   %loaded = vector.load %scratch_view[%tid, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[%tid, 0] : vector<4xi32>, view<64x4xi32, #dense>
@@ -144,9 +144,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
   %13 = storage {byte_alignment = 16, byte_length = 1024} : low.storage<workgroup>
   %15 = v_mov_b32 1
-  %one = concat(%15, %15, %15, %15) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x4>
+  %stored_value = concat(%15, %15, %15, %15) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x4>
   %20 = v_lshlrev_b32_src0_inline %tid, 4
-  low.op<amdgpu.ds_write_b128>(%20, %one) {offset = 0} memory_access([0, 3, 6, -1, 43, 16, 0, 16, 3, 0, 1008, 16, 1024]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr x4>)
+  low.op<amdgpu.ds_write_b128>(%20, %stored_value) {offset = 0} memory_access([0, 3, 6, -1, 43, 16, 0, 16, 3, 0, 1008, 16, 1024]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr x4>)
   %loaded = low.op<amdgpu.ds_read_b128>(%20) {offset = 0} memory_access([0, 3, 6, -1, 43, 16, 0, 16, 3, 0, 1008, 16, 1024]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x4>
   global_store_b128_saddr %20, %loaded, %output_view
   return
@@ -162,12 +162,12 @@ kernel.def target(@target) @lds_f16_subword_stride_diagnostics() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<128xf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<128xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<128xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<128xf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<128xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<128xf16, #dense>
   %loaded = vector.load %input_view[%lane] : view<128xf16, #dense> -> vector<2xf16>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_b32", address_form="default", dynamic_term_kind="vaddr", fallback_reason="cross_wave_workgroup", dynamic_stride_bytes="2"}
   vector.store %loaded, %scratch_view[%lane] : vector<2xf16>, view<128xf16, #dense>
@@ -196,9 +196,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx11-generic> @target
 
 func.def target(@target) @buffer_view_i1_rejected(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   // ERROR@+1: AMDGPU/001 {field_name="result", required_storage="byte-addressable scalar elements"}
-  %input_view = buffer.view %input[%zero] : buffer -> view<8xi1, #dense>
+  %input_view = buffer.view %input[%input_base] : buffer -> view<8xi1, #dense>
   func.return
 }
 
@@ -207,9 +207,9 @@ func.def target(@target) @buffer_view_i1_rejected(%input: buffer) {
 amdgpu.target<gfx11-generic> @target
 
 func.def target(@target) @dynamic_scaled_index_large_extent_flat_load(%input: buffer, %index: index) -> (i32) {
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %bounded_index = index.assume %index [range(%index, 0, 1073741823)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<1073741824xi32, #dense>
+  %input_view = buffer.view %input[%input_base] : buffer -> view<1073741824xi32, #dense>
   %loaded = view.load %input_view[%bounded_index] : view<1073741824xi32, #dense> -> i32
   func.return %loaded : i32
 }
@@ -247,11 +247,11 @@ func.def target(@target) @dynamic_view_base_b128_alignment_rejected(%input: buff
 amdgpu.target<gfx11-generic> @target
 
 func.def target(@target) @fragment_store_tail_footprint_rejected(%output: buffer, %value: vector<8xf32>) {
-  %zero = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero] : buffer -> view<17x32xf32, #dense>
+  %output_view = buffer.view %output_global[%output_base] : buffer -> view<17x32xf32, #dense>
   // ERROR@+1: SUBRANGE/010 {op_name="vector.fragment.store", view_axis="0", vector_axis="0", vector_extent="16", view_bound="17", required_origin_upper_bound="1", constraint_key="vector_footprint.full_vector_upper_bound"}
   vector.fragment.store<result> %value, %output_view[16, 0] shape [%m, %n] : vector<8xf32>, view<17x32xf32, #dense>
   func.return
@@ -267,21 +267,21 @@ kernel.def target(@target) @fragment_store_launch_subgroup_footprint() {
   %workgroup_size = index.constant 64 : index
   kernel.launch.config workgroups(%workgroup_count, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %four = index.constant 4 : index
-  %six = index.constant 6 : index
+  %output_base = index.constant 0 : offset
+  %column = index.constant 0 : index
+  %subgroup_row_shift = index.constant 4 : index
+  %workgroup_row_shift = index.constant 6 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %workgroup = kernel.workgroup.id<x> : index
   %subgroup = kernel.subgroup.id : index
-  %workgroup_base = index.shli %workgroup, %six : index
-  %subgroup_base = index.shli %subgroup, %four : index
+  %workgroup_base = index.shli %workgroup, %workgroup_row_shift : index
+  %subgroup_base = index.shli %subgroup, %subgroup_row_shift : index
   %row = index.add %workgroup_base, %subgroup_base : index
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero_offset] : buffer -> view<4096x16xf32, #dense>
+  %output_view = buffer.view %output_global[%output_base] : buffer -> view<4096x16xf32, #dense>
   %value = vector.constant 0.0 : vector<8xf32>
-  vector.fragment.store<result> %value, %output_view[%row, %zero] shape [%m, %n] : vector<8xf32>, view<4096x16xf32, #dense>
+  vector.fragment.store<result> %value, %output_view[%row, %column] shape [%m, %n] : vector<8xf32>, view<4096x16xf32, #dense>
   kernel.return
 }
 
@@ -314,9 +314,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx11-generic> @target
 
 func.def target(@target) @oversized_f32x64_store_rejected(%output: buffer, %value: vector<64xf32>) {
-  %zero = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output_global[%output_base] : buffer -> view<64xf32, #dense>
   // ERROR@+1: AMDGPU/040 {vector_type="vector<64xf32>", vector_lane_count="64", element_byte_count="4", required_32bit_lane_count="64", native_max_32bit_lane_count="4", native_max_vector_lane_count="4", scalarized_max_32bit_lane_count="32", scalarized_max_vector_lane_count="32"}
   vector.store %value, %output_view[0] : vector<64xf32>, view<64xf32, #dense>
   func.return
@@ -327,9 +327,9 @@ func.def target(@target) @oversized_f32x64_store_rejected(%output: buffer, %valu
 amdgpu.target<gfx11-generic> @target
 
 func.def target(@target) @oversized_bf16x128_store_rejected(%output: buffer, %value: vector<128xbf16>) {
-  %zero = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero] : buffer -> view<128xbf16, #dense>
+  %output_view = buffer.view %output_global[%output_base] : buffer -> view<128xbf16, #dense>
   // ERROR@+1: AMDGPU/040 {vector_type="vector<128xbf16>", vector_lane_count="128", element_byte_count="2", required_32bit_lane_count="64", native_max_32bit_lane_count="4", native_max_vector_lane_count="8", scalarized_max_32bit_lane_count="32", scalarized_max_vector_lane_count="64"}
   vector.store %value, %output_view[0] : vector<128xbf16>, view<128xbf16, #dense>
   func.return
@@ -350,13 +350,13 @@ kernel.def target(@target) @workgroup_dependent_lds_index_rejected() {
   %span = index.constant 32 : index
   %base = index.mul %workgroup, %span : index
   %element_index = index.add %base, %lane : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
   // ERROR@+1: AMDGPU/023 {constraint_key="memory_access.workgroup_dynamic_index_source"}
-  vector.store %one, %scratch_view[%element_index] : vector<1xi32>, view<64xi32, #dense>
+  vector.store %stored_value, %scratch_view[%element_index] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
 }
 
@@ -369,11 +369,11 @@ kernel.def target(@target) @lds_i8x8_strided_load_rejected() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 4096 : offset
   %layout = encoding.layout.strided [8, 2] : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x8xi8, %layout>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64x8xi8, %layout>
   // ERROR@+1: AMDGPU/023 {constraint_key="memory_access.vector_axis_stride"}
   %loaded = vector.load %scratch_view[%tid, 0] : view<64x8xi8, %layout> -> vector<8xi8>
   kernel.return
@@ -388,14 +388,14 @@ kernel.def target(@target) @cache_policy_workgroup_store_rejected() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
-  %one = vector.constant 1 : vector<4xi32>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64x4xi32, #dense>
+  %stored_value = vector.constant 1 : vector<4xi32>
   // REMARK@+2: BACKEND/040 "rejected cache policy 'device/non_temporal'" "decision 'memory_cache_policy.workgroup'" "store in workgroup"
   // ERROR@+1: AMDGPU/024 {constraint_key="memory_cache_policy.workgroup", memory_space="workgroup", cache_scope="device", cache_temporal="non_temporal", descriptor_set_key="amdgpu.gfx11.generic.core"}
-  vector.store %one, %scratch_view[%tid, 0] {cache_scope = device, cache_temporal = non_temporal} : vector<4xi32>, view<64x4xi32, #dense>
+  vector.store %stored_value, %scratch_view[%tid, 0] {cache_scope = device, cache_temporal = non_temporal} : vector<4xi32>, view<64x4xi32, #dense>
   kernel.return
 }
 
@@ -408,12 +408,12 @@ kernel.def target(@target) @global_atomic_system_scope_rejected() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
+  %view = buffer.view %global[%input_base] : buffer -> view<64xi32, #dense>
+  %atomic_increment = scalar.constant 1 : i32
   // ERROR@+1: AMDGPU/023 {constraint_key="atomic.scope"}
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = release, scope = system} : i32, view<64xi32, #dense>
+  view.atomic.reduce<addi> %atomic_increment, %view[%tid] {ordering = release, scope = system} : i32, view<64xi32, #dense>
   kernel.return
 }
 
@@ -433,9 +433,9 @@ kernel.def target(@target) @global_dynamic_offset_sum_flat() {
   %lane_y = kernel.workitem.id<y> : index
   %base_y = index.constant 2000 : index
   %y = index.add %lane_y, %base_y : index
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %layout = encoding.layout.strided [1, 1] : encoding<layout>
-  %input_view = buffer.view %input[%zero] : buffer -> view<4294967296x4096xi8, %layout>
+  %input_view = buffer.view %input[%input_base] : buffer -> view<4294967296x4096xi8, %layout>
   %loaded = vector.load %input_view[%x, %y] : view<4294967296x4096xi8, %layout> -> vector<4xi8>
   kernel.return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_divergent_loop_carry.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_divergent_loop_carry.loom-test
@@ -3,22 +3,22 @@
 amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
 
 kernel.def target(@target) @divergent_loop_carry() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%upper_bounds: buffer, %values: buffer, %output: buffer) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %zero_i32 = scalar.constant 0 : i32
-  %zero_offset = index.constant 0 : offset
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %initial_count = scalar.constant 0 : i32
+  %buffer_base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
-  %upper_bound_view = buffer.view %upper_bounds[%zero_offset] : buffer -> view<64xi32, #dense>
-  %value_view = buffer.view %values[%zero_offset] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<64xi32, #dense>
+  %upper_bound_view = buffer.view %upper_bounds[%buffer_base] : buffer -> view<64xi32, #dense>
+  %value_view = buffer.view %values[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %upper_bound_i32 = view.load %upper_bound_view[%lane] : view<64xi32, #dense> -> i32
   %upper_bound0 = index.cast %upper_bound_i32 : i32 to index
   %upper_bound = index.assume %upper_bound0 [range(%upper_bound0, 0, 64)] : index
-  %count = scf.for %position = [%zero to %upper_bound step %one](%running_count = %zero_i32 : i32) -> (i32) {
+  %count = scf.for %position = [%loop_begin to %upper_bound step %loop_step](%running_count = %initial_count : i32) -> (i32) {
     %bounded_position = index.assume %position [range(%position, 0, 63)] : index
     %value = view.load %value_view[%bounded_position] : view<64xi32, #dense> -> i32
     %next_count = scalar.addi %running_count, %value : i32
@@ -34,8 +34,8 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %upper_bound_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
   %value_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 2, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
-  %zero = s_mov_b32 0
-  %one = s_mov_b32 1
+  %loop_begin = s_mov_b32 0
+  %loop_step = s_mov_b32 1
   %39 = v_lshlrev_b32_src0_inline %lane, 2
   %upper_bound = global_load_b32_saddr %39, %upper_bound_view
   %41 = v_mov_b32 0
@@ -56,7 +56,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %54 = concat(%52, %53) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
   %value = global_load_b32_saddr %47, %54
   %next_count = v_add_u32 %running_count, %value
-  %57 = s_add_u32 %bounded_position, %one
+  %57 = s_add_u32 %bounded_position, %loop_step
   low.br ^_bb1(%57: reg<amdgpu.sgpr>, %next_count: reg<amdgpu.vgpr>)
 ^_bb3:
   %58 = v_lshlrev_b32_src0_inline %lane, 2
@@ -64,7 +64,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   return
 ^_bb4:
   %44 = s_mov_b64_exec_read
-  low.br ^_bb1(%zero: reg<amdgpu.sgpr>, %41: reg<amdgpu.vgpr>)
+  low.br ^_bb1(%loop_begin: reg<amdgpu.sgpr>, %41: reg<amdgpu.vgpr>)
 ^_bb5:
   s_mov_b64_exec %44
   low.br ^_bb3

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_dot.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_dot.loom-test
@@ -28,8 +28,8 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @f32_dot
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @f32_dotf_zero_seed(%lhs: vector<4xf32>, %rhs: vector<4xf32>) -> (f32) {
-  %zero = scalar.constant 0.0 : f32
-  %dot = vector.dotf %lhs, %rhs, %zero : vector<4xf32>, vector<4xf32>, f32
+  %initial_accumulator = scalar.constant 0.0 : f32
+  %dot = vector.dotf %lhs, %rhs, %initial_accumulator : vector<4xf32>, vector<4xf32>, f32
   func.return %dot : f32
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_dot_amdgpu.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_dot_amdgpu.loom-test
@@ -2,9 +2,9 @@
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @f32_independent_dotf_shared_zero_seed(%lhs0: vector<2xf32>, %rhs0: vector<2xf32>, %lhs1: vector<2xf32>, %rhs1: vector<2xf32>) -> (f32, f32) {
-  %zero = scalar.constant 0.0 : f32
-  %dot0 = vector.dotf %lhs0, %rhs0, %zero : vector<2xf32>, vector<2xf32>, f32
-  %dot1 = vector.dotf %lhs1, %rhs1, %zero : vector<2xf32>, vector<2xf32>, f32
+  %initial_accumulator = scalar.constant 0.0 : f32
+  %dot0 = vector.dotf %lhs0, %rhs0, %initial_accumulator : vector<2xf32>, vector<2xf32>, f32
+  %dot1 = vector.dotf %lhs1, %rhs1, %initial_accumulator : vector<2xf32>, vector<2xf32>, f32
   func.return %dot0, %dot1 : f32, f32
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_dot_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_dot_diagnostics.loom-test
@@ -2,10 +2,10 @@
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @f32_dotf_zero_seed_fmac_diagnostics(%lhs: vector<2xf32>, %rhs: vector<2xf32>) -> (f32) {
-  %zero = scalar.constant 0.0 : f32
+  %initial_accumulator = scalar.constant 0.0 : f32
   // REMARK@+2: AMDGPU/028 {descriptor_name="amdgpu.v_fmac_f32", lane_index="0", descriptor_set_name="amdgpu.gfx11.generic.core", accumulator_kind="dot_local", decision_key="selected", reason_key="dot_local_accumulator"}
   // REMARK@+1: AMDGPU/028 {descriptor_name="amdgpu.v_fmac_f32", lane_index="1", descriptor_set_name="amdgpu.gfx11.generic.core", accumulator_kind="dot_local", decision_key="selected", reason_key="dot_local_accumulator"}
-  %dot = vector.dotf %lhs, %rhs, %zero : vector<2xf32>, vector<2xf32>, f32
+  %dot = vector.dotf %lhs, %rhs, %initial_accumulator : vector<2xf32>, vector<2xf32>, f32
   func.return %dot : f32
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_fma_mix.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_fma_mix.loom-test
@@ -42,12 +42,12 @@ kernel.def target(@gfx11_target) @packed_f16_affine_epilogue_kernel() {
   %workgroup_size = index.constant 64 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %scale_buffer: buffer, %bias_buffer: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %tid = kernel.workitem.id<x> : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xf16, #dense>
-  %scale_view = buffer.view %scale_buffer[%zero] : buffer -> view<64x4xf16, #dense>
-  %bias_view = buffer.view %bias_buffer[%zero] : buffer -> view<64x4xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xf16, #dense>
+  %scale_view = buffer.view %scale_buffer[%buffer_base] : buffer -> view<64x4xf16, #dense>
+  %bias_view = buffer.view %bias_buffer[%buffer_base] : buffer -> view<64x4xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf16, #dense>
   %x = vector.load %input_view[%tid, 0] : view<64x4xf16, #dense> -> vector<4xf16>
   %scale = vector.load %scale_view[%tid, 0] : view<64x4xf16, #dense> -> vector<4xf16>
   %bias = vector.load %bias_view[%tid, 0] : view<64x4xf16, #dense> -> vector<4xf16>
@@ -529,11 +529,11 @@ low.func.def target<amdgpu.gfx11.generic.core>(@gfx11_target) abi(hal_kernel) @v
 
 amdgpu.target<gfx11-generic> @gfx11_target
 func.def target(@gfx11_target) @vector_f32_mulf_fragment_splat_extf(%q: vector<2xf32>, %scale_half: f16) -> (vector<2xf32>) {
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %m = index.constant 1 : index
+  %n = index.constant 2 : index
   %scale = scalar.extf %scale_half : f16 to f32
   %scale_splat = vector.splat %scale : vector<2xf32>
-  %scale_vector = vector.fragment<result> %scale_splat shape [%one, %two] : vector<2xf32>
+  %scale_vector = vector.fragment<result> %scale_splat shape [%m, %n] : vector<2xf32>
   // REMARK@+1: AMDGPU/027 {descriptor_name="amdgpu.v_fma_mix_f32.f16lo_f32_f32.src2_lit", source_operand_index="2", descriptor_set_name="amdgpu.gfx11.generic.core", constant_form="exact_f32_positive_zero", decision_key="selected", reason_key="literal_descriptor_available"}
   %result = vector.mulf<nnan|nsz|contract> %q, %scale_vector : vector<2xf32>
   func.return %result : vector<2xf32>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_fp8_dequant_materialization.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_fp8_dequant_materialization.loom-test
@@ -1503,12 +1503,12 @@ kernel.def target(@target) @gfx1100_direct_decode_scalef32_identity_finite_f8e4m
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
-  %one = scalar.constant 1.0 : f32
+  %identity_scale = scalar.constant 1.0 : f32
   %schema = encoding.define #matrix_operand<affine=scale_only, element_format=f8e4m3fn, payload_elements=8, payload_packing=dense_lanes, payload_registers=0, rounding=finite_only, scale_format=f32, scale_group_elements=8, scale_operands=1, scale_topology=block_1d> : encoding<schema>
   %input_view = buffer.view %input[%base] : buffer -> view<64x8xf8E4M3, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<64x8xbf16, #dense>
   %payload = vector.load %input_view[%lane, 0] : view<64x8xf8E4M3, #dense> -> vector<8xf8E4M3>
-  %scale_vector = vector.splat %one : vector<1xf32>
+  %scale_vector = vector.splat %identity_scale : vector<1xf32>
   %decoded = vector.decode %payload using %schema {scale = %scale_vector : vector<1xf32>} : vector<8xf8E4M3>, encoding<schema> -> vector<8xbf16>
   vector.store %decoded, %output_view[%lane, 0] : vector<8xbf16>, view<64x8xbf16, #dense>
   kernel.return
@@ -1575,12 +1575,12 @@ kernel.def target(@target) @gfx1100_direct_decode_scalef32_identity_finite_f8e4m
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
-  %one = scalar.constant 1.0 : f32
+  %identity_scale = scalar.constant 1.0 : f32
   %schema = encoding.define #matrix_operand<affine=scale_only, element_format=f8e4m3fn, payload_elements=4, payload_packing=dense_lanes, payload_registers=0, rounding=finite_only, scale_format=f32, scale_group_elements=4, scale_operands=1, scale_topology=block_1d> : encoding<schema>
   %input_view = buffer.view %input[%base] : buffer -> view<64x4xf8E4M3, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<64x4xf16, #dense>
   %payload = vector.load %input_view[%lane, 0] : view<64x4xf8E4M3, #dense> -> vector<4xf8E4M3>
-  %scale_vector = vector.splat %one : vector<1xf32>
+  %scale_vector = vector.splat %identity_scale : vector<1xf32>
   %decoded = vector.decode %payload using %schema {scale = %scale_vector : vector<1xf32>} : vector<4xf8E4M3>, encoding<schema> -> vector<4xf16>
   vector.store %decoded, %output_view[%lane, 0] : vector<4xf16>, view<64x4xf16, #dense>
   kernel.return
@@ -1649,12 +1649,12 @@ kernel.def target(@target) @gfx1100_direct_decode_scalef32_identity_finite_f8e4m
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
-  %one = scalar.constant 1.0 : f32
+  %identity_scale = scalar.constant 1.0 : f32
   %schema = encoding.define #matrix_operand<affine=scale_only, element_format=f8e4m3fn, payload_elements=4, payload_packing=dense_lanes, payload_registers=0, rounding=finite_only, scale_format=f32, scale_group_elements=4, scale_operands=1, scale_topology=block_1d> : encoding<schema>
   %input_view = buffer.view %input[%base] : buffer -> view<64x4xf8E4M3, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<64x4xf32, #dense>
   %payload = vector.load %input_view[%lane, 0] : view<64x4xf8E4M3, #dense> -> vector<4xf8E4M3>
-  %scale_vector = vector.splat %one : vector<1xf32>
+  %scale_vector = vector.splat %identity_scale : vector<1xf32>
   %decoded = vector.decode %payload using %schema {scale = %scale_vector : vector<1xf32>} : vector<4xf8E4M3>, encoding<schema> -> vector<4xf32>
   vector.store %decoded, %output_view[%lane, 0] : vector<4xf32>, view<64x4xf32, #dense>
   kernel.return

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_fragment_memory_bank_service_gfx1250.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_fragment_memory_bank_service_gfx1250.loom-test
@@ -7,28 +7,28 @@ kernel.def target(@target) @gfx1250_fragment_bank_service() {
   %workgroup_size = index.constant 128 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %buffer_base = index.constant 0 : offset
+  %fragment_origin = index.constant 0 : index
+  %tile_extent = index.constant 16 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 32 : index
   %scratch_bytes = index.constant 4096 : offset
   %workitem = kernel.workitem.id<x> : index
   %subgroup = kernel.subgroup.id : index
-  %tile_origin = index.mul %subgroup, %sixteen : index
+  %tile_origin = index.mul %subgroup, %tile_extent : index
   %rhs_layout = encoding.layout.strided [1, 32] : encoding<layout>
-  %input_view = buffer.view %input[%zero] : buffer -> view<128x16xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x64xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<128x16xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x64xf32, #dense>
   %scratch = buffer.alloca %scratch_bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_stage = buffer.view %scratch[%zero] : buffer -> view<128x16xbf16, #dense>
+  %scratch_stage = buffer.view %scratch[%buffer_base] : buffer -> view<128x16xbf16, #dense>
   %staged = vector.load %input_view[%workitem, 0] : view<128x16xbf16, #dense> -> vector<16xbf16>
   vector.store %staged, %scratch_stage[%workitem, 0] : vector<16xbf16>, view<128x16xbf16, #dense>
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
-  %lhs_view = buffer.view %scratch[%zero] : buffer -> view<64x32xbf16, #dense>
-  %rhs_view = buffer.view %scratch[%zero] : buffer -> view<32x64xbf16, %rhs_layout>
-  %lhs = vector.fragment.load<lhs> %lhs_view[%tile_origin, %zero_index] shape [%m, %k] : view<64x32xbf16, #dense> -> vector<16xbf16>
-  %rhs = vector.fragment.load<rhs> %rhs_view[%zero_index, %tile_origin] shape [%k, %n] : view<32x64xbf16, %rhs_layout> -> vector<16xbf16>
+  %lhs_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x32xbf16, #dense>
+  %rhs_view = buffer.view %scratch[%buffer_base] : buffer -> view<32x64xbf16, %rhs_layout>
+  %lhs = vector.fragment.load<lhs> %lhs_view[%tile_origin, %fragment_origin] shape [%m, %k] : view<64x32xbf16, #dense> -> vector<16xbf16>
+  %rhs = vector.fragment.load<rhs> %rhs_view[%fragment_origin, %tile_origin] shape [%k, %n] : view<32x64xbf16, %rhs_layout> -> vector<16xbf16>
   %zero_acc = vector.constant 0.0 : vector<8xf32>
   %init = vector.fragment<init> %zero_acc shape [%m, %n] : vector<8xf32>
   %result = vector.mma %lhs, %rhs, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_gfx1250_a0_lds.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_gfx1250_a0_lds.loom-test
@@ -8,17 +8,17 @@ kernel.def target(@target) @a0_legalizes_constrained_lds_packets() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 4096 : offset
   %regular_b32_layout = encoding.layout.strided [8, 2] : encoding<layout>
   %regular_b64_layout = encoding.layout.strided [4, 2] : encoding<layout>
   %stride64_layout = encoding.layout.strided [512, 256] : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %regular_b32 = buffer.view %scratch[%zero] : buffer -> view<1x2xi32, %regular_b32_layout>
-  %regular_b64 = buffer.view %scratch[%zero] : buffer -> view<1x2xi64, %regular_b64_layout>
-  %stride64_b32 = buffer.view %scratch[%zero] : buffer -> view<1x2xi32, %stride64_layout>
-  %stride64_b64 = buffer.view %scratch[%zero] : buffer -> view<1x2xi64, %stride64_layout>
-  %dense = buffer.view %scratch[%zero] : buffer -> view<4096xi8, #dense>
+  %regular_b32 = buffer.view %scratch[%scratch_base] : buffer -> view<1x2xi32, %regular_b32_layout>
+  %regular_b64 = buffer.view %scratch[%scratch_base] : buffer -> view<1x2xi64, %regular_b64_layout>
+  %stride64_b32 = buffer.view %scratch[%scratch_base] : buffer -> view<1x2xi32, %stride64_layout>
+  %stride64_b64 = buffer.view %scratch[%scratch_base] : buffer -> view<1x2xi64, %stride64_layout>
+  %dense = buffer.view %scratch[%scratch_base] : buffer -> view<4096xi8, #dense>
   %pair_b32 = vector.constant 1 : vector<2xi32>
   %pair_b64 = vector.constant 1 : vector<2xi64>
   vector.store %pair_b32, %regular_b32[0, 0] : vector<2xi32>, view<1x2xi32, %regular_b32_layout>
@@ -92,17 +92,17 @@ kernel.def target(@target) @b0_retains_native_lds_packets() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 4096 : offset
   %regular_b32_layout = encoding.layout.strided [8, 2] : encoding<layout>
   %regular_b64_layout = encoding.layout.strided [4, 2] : encoding<layout>
   %stride64_layout = encoding.layout.strided [512, 256] : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %regular_b32 = buffer.view %scratch[%zero] : buffer -> view<1x2xi32, %regular_b32_layout>
-  %regular_b64 = buffer.view %scratch[%zero] : buffer -> view<1x2xi64, %regular_b64_layout>
-  %stride64_b32 = buffer.view %scratch[%zero] : buffer -> view<1x2xi32, %stride64_layout>
-  %stride64_b64 = buffer.view %scratch[%zero] : buffer -> view<1x2xi64, %stride64_layout>
-  %dense = buffer.view %scratch[%zero] : buffer -> view<4096xi8, #dense>
+  %regular_b32 = buffer.view %scratch[%scratch_base] : buffer -> view<1x2xi32, %regular_b32_layout>
+  %regular_b64 = buffer.view %scratch[%scratch_base] : buffer -> view<1x2xi64, %regular_b64_layout>
+  %stride64_b32 = buffer.view %scratch[%scratch_base] : buffer -> view<1x2xi32, %stride64_layout>
+  %stride64_b64 = buffer.view %scratch[%scratch_base] : buffer -> view<1x2xi64, %stride64_layout>
+  %dense = buffer.view %scratch[%scratch_base] : buffer -> view<4096xi8, #dense>
   %pair_b32 = vector.constant 1 : vector<2xi32>
   %pair_b64 = vector.constant 1 : vector<2xi64>
   vector.store %pair_b32, %regular_b32[0, 0] : vector<2xi32>, view<1x2xi32, %regular_b32_layout>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_index.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_index.loom-test
@@ -9,11 +9,11 @@ kernel.def target(@target) @index_madd_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 4 : index
   %linear = index.madd %row, %row_stride, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<16xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<16xi32, #dense>
   kernel.return
@@ -45,11 +45,11 @@ kernel.def target(@target) @index_madd_u24_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 9 : index
   %linear = index.madd %row, %row_stride, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<36xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<36xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<36xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<36xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<36xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<36xi32, #dense>
   kernel.return
@@ -81,11 +81,11 @@ kernel.def target(@target) @index_madd_u24_literal_lhs_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 9 : index
   %linear = index.madd %row_stride, %row, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<36xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<36xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<36xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<36xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<36xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<36xi32, #dense>
   kernel.return
@@ -117,11 +117,11 @@ kernel.def target(@target) @index_madd_u24_literal_addend_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %linear_bias = index.constant 1 : index
   %linear = index.madd %row, %column, %linear_bias : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<36xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<36xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<36xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<36xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<36xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<36xi32, #dense>
   kernel.return
@@ -151,12 +151,12 @@ kernel.def target(@target) @index_madd_constant_addend_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%row_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %row = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 4 : index
   %column = index.constant 1 : index
   %linear = index.madd %row, %row_stride, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<16xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<16xi32, #dense>
   kernel.return
@@ -182,14 +182,14 @@ kernel.def target(@target) @index_madd_nested_scale_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%row_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %row = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %c9 = index.constant 9 : index
   %c2 = index.constant 2 : index
   %c16 = index.constant 16 : index
   %scaled = index.mul %row, %c9 : index
   %linear = index.madd %scaled, %c2, %c16 : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<80xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<80xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<80xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<80xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<80xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<80xi32, #dense>
   kernel.return
@@ -216,11 +216,11 @@ kernel.def target(@target) @index_shli_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%lane_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %shift = index.constant 2 : index
   %linear = index.shli %lane, %shift : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<16xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<16xi32, #dense>
   kernel.return
@@ -246,13 +246,13 @@ kernel.def target(@target) @index_scale_byte_offset_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%element_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %element = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : index
+  %first_element = index.constant 0 : index
   %byte_stride = index.constant 4 : offset
   %byte_offset = index.scale %element, %byte_stride : index, offset -> offset
   %input_view = buffer.view %input[%byte_offset] : buffer -> view<1xi32, #dense>
   %output_view = buffer.view %output[%byte_offset] : buffer -> view<1xi32, #dense>
-  %loaded = vector.load %input_view[%zero] : view<1xi32, #dense> -> vector<1xi32>
-  vector.store %loaded, %output_view[%zero] : vector<1xi32>, view<1xi32, #dense>
+  %loaded = vector.load %input_view[%first_element] : view<1xi32, #dense> -> vector<1xi32>
+  vector.store %loaded, %output_view[%first_element] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
 
@@ -277,9 +277,9 @@ kernel.def target(@target) @index_shli_previous_row_global_b128() {
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
   %base_offset = index.constant 0 : offset
-  %one = index.constant 1 : index
-  %column = index.add %lane, %one : index
-  %previous = index.sub %column, %one : index
+  %column_offset = index.constant 1 : index
+  %column = index.add %lane, %column_offset : index
+  %previous = index.sub %column, %column_offset : index
   %shift = index.constant 2 : index
   %linear = index.shli %previous, %shift : index
   %input_view = buffer.view %input[%base_offset] : buffer -> view<128xi32, #dense>
@@ -310,21 +310,25 @@ kernel.def target(@target) @index_edge_loop_dynamic_lower_bound_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
   %base_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %three = index.constant 3 : index
+  %left_edge_lane = index.constant 0 : index
+  %full_tap_begin = index.constant 0 : index
+  %left_edge_tap_begin = index.constant 1 : index
+  %tap_step = index.constant 1 : index
+  %padding_offset = index.constant 1 : index
+  %right_edge_tap_end = index.constant 2 : index
+  %input_lane_divisor = index.constant 2 : index
+  %full_tap_end = index.constant 3 : index
   %last_lane = index.constant 1023 : index
-  %is_left_edge = index.cmp eq, %lane, %zero : index
-  %begin = scf.select %is_left_edge, %one, %zero : index
+  %is_left_edge = index.cmp eq, %lane, %left_edge_lane : index
+  %begin = scf.select %is_left_edge, %left_edge_tap_begin, %full_tap_begin : index
   %is_right_edge = index.cmp eq, %lane, %last_lane : index
-  %end = scf.select %is_right_edge, %two, %three : index
+  %end = scf.select %is_right_edge, %right_edge_tap_end, %full_tap_end : index
   %input_view = buffer.view %input[%base_offset] : buffer -> view<512xi32, #dense>
   %output_view = buffer.view %output[%base_offset] : buffer -> view<1024xi32, #dense>
-  scf.for %tap = [%begin to %end step %one] {
+  scf.for %tap = [%begin to %end step %tap_step] {
     %shifted = index.add %lane, %tap : index
-    %source_lane = index.sub %shifted, %one : index
-    %input_lane = index.div %source_lane, %two : index
+    %source_lane = index.sub %shifted, %padding_offset : index
+    %input_lane = index.div %source_lane, %input_lane_divisor : index
     %loaded = vector.load %input_view[%input_lane] : view<512xi32, #dense> -> vector<1xi32>
     vector.store %loaded, %output_view[%lane] : vector<1xi32>, view<1024xi32, #dense>
   }
@@ -338,30 +342,30 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1024, 1
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 4096} : reg<amdgpu.sgpr x2>
   %is_left_edge = v_cmp_eq_i32_src1_inline %lane {rhs = 0}
   %begin = v_cndmask_b32_src0_lit_src1_inline %is_left_edge {imm32 = 0, true_value = 1}
-  %38 = v_mov_b32 1023
-  %is_right_edge = v_cmp_eq_i32 %lane, %38
+  %42 = v_mov_b32 1023
+  %is_right_edge = v_cmp_eq_i32 %lane, %42
   %end = v_cndmask_b32_src0_lit_src1_inline %is_right_edge {imm32 = 3, true_value = 2}
   low.br ^_bb3
 ^_bb1(%tap: reg<amdgpu.vgpr>):
-  %41 = v_cmp_lt_i32 %tap, %end
-  %43, %44 = s_and_saveexec_b64 %41
-  low.cond_br %44, ^_bb2, ^_bb4 : reg<amdgpu.scc>
+  %45 = v_cmp_lt_i32 %tap, %end
+  %47, %48 = s_and_saveexec_b64 %45
+  low.cond_br %48, ^_bb2, ^_bb4 : reg<amdgpu.scc>
 ^_bb2:
   %shifted = v_add_u32 %lane, %tap
-  %46 = v_mov_b32 1
-  %source_lane = v_sub_nc_u32 %shifted, %46
+  %50 = v_mov_b32 1
+  %source_lane = v_sub_nc_u32 %shifted, %50
   %input_lane = v_lshrrev_b32_lit %source_lane, 1
-  %49 = v_lshlrev_b32_src0_inline %input_lane, 2
-  %loaded = global_load_b32_saddr %49, %input_view
-  %51 = v_lshlrev_b32_src0_inline %lane, 2
-  global_store_b32_saddr %51, %loaded, %output_view
-  %53 = v_add_u32 %tap, %46
-  low.br ^_bb1(%53: reg<amdgpu.vgpr>)
+  %53 = v_lshlrev_b32_src0_inline %input_lane, 2
+  %loaded = global_load_b32_saddr %53, %input_view
+  %55 = v_lshlrev_b32_src0_inline %lane, 2
+  global_store_b32_saddr %55, %loaded, %output_view
+  %57 = v_add_u32 %tap, %50
+  low.br ^_bb1(%57: reg<amdgpu.vgpr>)
 ^_bb3:
-  %42 = s_mov_b64_exec_read
+  %46 = s_mov_b64_exec_read
   low.br ^_bb1(%begin: reg<amdgpu.vgpr>)
 ^_bb4:
-  s_mov_b64_exec %42
+  s_mov_b64_exec %46
   return
 }
 
@@ -488,11 +492,12 @@ kernel.def target(@target) @workitem_y_lds_uses_explicit_vaddr() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %row_count, %unit) : index
 } launch(%output: buffer) {
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%output_base] : buffer -> view<64xi32, #dense>
   %value = vector.constant 7 : vector<1xi32>
   vector.store %value, %scratch_view[%row] : vector<1xi32>, view<64xi32, #dense>
   %loaded = vector.load %scratch_view[%row] : view<64xi32, #dense> -> vector<1xi32>
@@ -504,14 +509,14 @@ kernel.def target(@target) @workitem_y_lds_uses_explicit_vaddr() {
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 64, 1) workgroup_count(1, 1, 1) @workitem_y_lds_uses_explicit_vaddr() asm {
   %packed_tid = live_in<amdgpu.workitem_id.packed.xy> : reg<amdgpu.vgpr>
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
-  %13 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
-  %14 = v_lshrrev_b32_src0_inline %packed_tid, 10
-  %row = v_and_b32_lit %14, 1023
+  %14 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
+  %15 = v_lshrrev_b32_src0_inline %packed_tid, 10
+  %row = v_and_b32_lit %15, 1023
   %value = v_mov_b32 7
-  %18 = v_lshlrev_b32_src0_inline %row, 2
-  low.op<amdgpu.ds_write_b32>(%18, %value) {offset = 0} memory_access([0, 3, 6, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
-  %loaded = low.op<amdgpu.ds_read_b32>(%18) {offset = 0} memory_access([0, 3, 6, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
-  global_store_b32_saddr %18, %loaded, %output_view
+  %19 = v_lshlrev_b32_src0_inline %row, 2
+  low.op<amdgpu.ds_write_b32>(%19, %value) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  %loaded = low.op<amdgpu.ds_read_b32>(%19) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
+  global_store_b32_saddr %19, %loaded, %output_view
   return
 }
 
@@ -530,10 +535,10 @@ kernel.def target(@target) @dispatch_id_xy_global_b32() {
   %dispatch_row = kernel.workitem.dispatch.id<y> : index
   %row_stride = index.constant 32 : index
   %linear = index.madd %dispatch_row, %row_stride, %dispatch_column : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<512xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %output_view[%linear] : vector<1xi32>, view<512xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<512xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %output_view[%linear] : vector<1xi32>, view<512xi32, #dense>
   kernel.return
 }
 
@@ -552,9 +557,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(8, 4, 1
   %23 = v_mov_b32_copy %14
   %24 = v_lshlrev_b32_src0_inline %23, 2
   %dispatch_row = v_add_u32 %24, %22
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %27 = v_lshl_add_u32_shift_imm %dispatch_row, %dispatch_column, 5
   %28 = v_lshlrev_b32_src0_inline %27, 2
-  global_store_b32_saddr %28, %one, %output_view
+  global_store_b32_saddr %28, %stored_value, %output_view
   return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_index_amdgpu.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_index_amdgpu.loom-test
@@ -41,15 +41,15 @@ amdgpu.target<gfx11-generic> @target
 func.def target(@target) @index_uniform_signed32_subtract(%value_i32: i32) -> (index) {
   %value0 = index.cast %value_i32 : i32 to index
   %value = index.assume %value0 [range(%value0, 1, 32768)] : index
-  %fifteen = index.constant 15 : index
-  %difference = index.sub %value, %fifteen : index
+  %adjustment = index.constant 15 : index
+  %difference = index.sub %value, %adjustment : index
   func.return %difference : index
 }
 
 // ----
 low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @index_uniform_signed32_subtract(%value: reg<amdgpu.sgpr>) -> (reg<amdgpu.sgpr>) asm {
-  %fifteen = s_mov_b32 15
-  %difference = s_sub_u32 %value, %fifteen
+  %adjustment = s_mov_b32 15
+  %difference = s_sub_u32 %value, %adjustment
   return %difference
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_index_cast_i64.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_index_cast_i64.loom-test
@@ -9,8 +9,8 @@ kernel.def target(@target) @index_divergent_zero_extend_i64() {
 } launch(%output: buffer) {
   %lane = kernel.subgroup.lane.id : index
   %lane_i64 = index.cast %lane : index to i64
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi64, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<64xi64, #dense>
   %result = vector.from_elements %lane_i64 : vector<1xi64>
   vector.store %result, %output_view[%lane] : vector<1xi64>, view<64xi64, #dense>
   kernel.return

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_launch_config.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_launch_config.loom-test
@@ -37,8 +37,8 @@ kernel.def target(@target) @ordinary_gfx1200_workgroup_identity() {
   %xy = scalar.addi %x, %y : i32
   %xyz = scalar.addi %xy, %z : i32
   %result = vector.from_elements %xyz : vector<1xi32>
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   vector.store %result, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
@@ -155,8 +155,8 @@ kernel.def target(@target) @exact_workgroup_count_uses_facts() {
   %count_xyz = index.add %count_xy, %count_z : index
   %count_i32 = index.cast %count_xyz : index to i32
   %result = vector.from_elements %count_i32 : vector<1xi32>
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   vector.store %result, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
@@ -207,8 +207,8 @@ kernel.def target(@target) @dynamic_workgroup_count(%workgroups_x: index, %workg
   %count = index.add %count_xyz, %count_x_again : index
   %count_i32 = index.cast %count : index to i32
   %result = vector.from_elements %count_i32 : vector<1xi32>
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   vector.store %result, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
@@ -247,8 +247,8 @@ kernel.def target(@target) @target_subgroup_queries_use_wavefront_size() {
   %sum = index.add %subgroup_size, %subgroup_count : index
   %sum_i32 = index.cast %sum : index to i32
   %value = vector.splat %sum_i32 : vector<1xi32>
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   vector.store %value, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
@@ -337,8 +337,8 @@ kernel.def target(@target) @clustered_launch_queries(%workgroups_x: index, %work
   %sum = index.add %sum16, %workgroup_count_z : index
   %sum_i32 = index.cast %sum : index to i32
   %result = vector.from_elements %sum_i32 : vector<1xi32>
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   vector.store %result, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
@@ -412,8 +412,8 @@ kernel.def target(@target) @ordinary_gfx1250_workgroup_identity() {
   %xy = scalar.addi %x, %y : i32
   %xyz = scalar.addi %xy, %z : i32
   %result = vector.from_elements %xyz : vector<1xi32>
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   vector.store %result, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
@@ -446,8 +446,8 @@ kernel.def target(@target) @ordinary_gfx1250_workgroup_y() {
   %workgroup_y = kernel.workgroup.id<y> : index
   %value = index.cast %workgroup_y : index to i32
   %result = vector.from_elements %value : vector<1xi32>
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   vector.store %result, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
@@ -476,8 +476,8 @@ kernel.def target(@target) @ordinary_gfx1250_workgroup_z() {
   %workgroup_z = kernel.workgroup.id<z> : index
   %value = index.cast %workgroup_z : index to i32
   %result = vector.from_elements %value : vector<1xi32>
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   vector.store %result, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
@@ -507,8 +507,8 @@ kernel.def target(@target) @cluster_local_workgroup_y() {
   %local_y = kernel.cluster.workgroup.id<y> : index
   %value = index.cast %local_y : index to i32
   %result = vector.from_elements %value : vector<1xi32>
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   vector.store %result, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
@@ -538,8 +538,8 @@ kernel.def target(@target) @cluster_local_workgroup_z() {
   %local_z = kernel.cluster.workgroup.id<z> : index
   %value = index.cast %local_z : index to i32
   %result = vector.from_elements %value : vector<1xi32>
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   vector.store %result, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
@@ -569,8 +569,8 @@ kernel.def target(@target) @ordinary_gfx1250_workgroup_counts(%workgroups_y: ind
   %sum = index.add %count_y, %count_z : index
   %value = index.cast %sum : index to i32
   %result = vector.from_elements %value : vector<1xi32>
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   vector.store %result, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
@@ -602,8 +602,8 @@ kernel.def target(@target) @unsupported_cluster_workgroup_identity() {
   %workgroup_x = kernel.workgroup.id<x> : index
   %value = index.cast %workgroup_x : index to i32
   %result = vector.from_elements %value : vector<1xi32>
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   vector.store %result, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
@@ -623,8 +623,8 @@ kernel.def target(@target) @unmodeled_cluster_revision_identity() {
   %cluster_x = kernel.cluster.id<x> : index
   %value = index.cast %cluster_x : index to i32
   %result = vector.from_elements %value : vector<1xi32>
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   vector.store %result, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_legalize_math.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_legalize_math.loom-test
@@ -1065,8 +1065,8 @@ amdgpu.target<gfx11-generic> @target
 func.def target(@target) @scalar_box_muller_native_math(%u1: f32, %u2: f32) -> (f32, f32) {
   %two_pi = scalar.constant 6.283185307179586 : f32
   %radius_base = scalar.logf<afn> %u1 : f32
-  %negative_two = scalar.constant -2.0 : f32
-  %radius_squared = scalar.mulf<afn> %negative_two, %radius_base : f32
+  %radius_scale = scalar.constant -2.0 : f32
+  %radius_squared = scalar.mulf<afn> %radius_scale, %radius_base : f32
   %radius = scalar.sqrtf<afn> %radius_squared : f32
   %theta = scalar.mulf<afn> %u2, %two_pi : f32
   %sine = scalar.sinf<afn> %theta : f32

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mask.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mask.loom-test
@@ -46,8 +46,8 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @f32_cmp
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @scalar_cmpf_rhs_zero_inline(%value: f32) -> (i1) {
-  %zero = scalar.constant 0.0 : f32
-  %mask = scalar.cmpf one, %value, %zero : f32
+  %comparison_rhs = scalar.constant 0.0 : f32
+  %mask = scalar.cmpf one, %value, %comparison_rhs : f32
   func.return %mask : i1
 }
 
@@ -61,8 +61,8 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @scalar_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @scalar_cmpf_lhs_one_inline(%value: f32) -> (i1) {
-  %one = scalar.constant 1.0 : f32
-  %mask = scalar.cmpf olt, %one, %value : f32
+  %comparison_lhs = scalar.constant 1.0 : f32
+  %mask = scalar.cmpf olt, %comparison_lhs, %value : f32
   func.return %mask : i1
 }
 
@@ -76,9 +76,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @scalar_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @vector_cmpf_rhs_zero_inline(%value: vector<2xf32>) -> (vector<2xi1>) {
-  %zero = scalar.constant 0.0 : f32
-  %zeros = vector.splat %zero : vector<2xf32>
-  %mask = vector.cmpf one, %value, %zeros : vector<2xf32> -> vector<2xi1>
+  %comparison_rhs_element = scalar.constant 0.0 : f32
+  %comparison_rhs = vector.splat %comparison_rhs_element : vector<2xf32>
+  %mask = vector.cmpf one, %value, %comparison_rhs : vector<2xf32> -> vector<2xi1>
   func.return %mask : vector<2xi1>
 }
 
@@ -97,8 +97,8 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @vector_
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @i32_cmpi_select_zero_inline(%lhs: vector<2xi32>, %rhs: vector<2xi32>, %false_value: vector<2xi32>) -> (vector<2xi32>) {
   %mask = vector.cmpi slt, %lhs, %rhs : vector<2xi32> -> vector<2xi1>
-  %zero = scalar.constant 0 : i32
-  %true_value = vector.splat %zero : vector<2xi32>
+  %true_element = scalar.constant 0 : i32
+  %true_value = vector.splat %true_element : vector<2xi32>
   %selected = vector.select %mask, %true_value, %false_value : vector<2xi32>
   func.return %selected : vector<2xi32>
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_bank_service_gfx1250.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_bank_service_gfx1250.loom-test
@@ -8,7 +8,7 @@ kernel.def target(@target) @gfx1250_b128_bank_service() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 4096 : offset
   %stride16 = encoding.layout.strided [4, 1] : encoding<layout>
   %stride64 = encoding.layout.strided [16, 1] : encoding<layout>
@@ -18,11 +18,11 @@ kernel.def target(@target) @gfx1250_b128_bank_service() {
   %scratch64 = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch80 = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch96 = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %output_view = buffer.view %output[%zero] : buffer -> view<32x16xi32, #dense>
-  %view16 = buffer.view %scratch16[%zero] : buffer -> view<32x4xi32, %stride16>
-  %view64 = buffer.view %scratch64[%zero] : buffer -> view<32x4xi32, %stride64>
-  %view80 = buffer.view %scratch80[%zero] : buffer -> view<32x4xi32, %stride80>
-  %view96 = buffer.view %scratch96[%zero] : buffer -> view<32x4xi32, %stride96>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<32x16xi32, #dense>
+  %view16 = buffer.view %scratch16[%buffer_base] : buffer -> view<32x4xi32, %stride16>
+  %view64 = buffer.view %scratch64[%buffer_base] : buffer -> view<32x4xi32, %stride64>
+  %view80 = buffer.view %scratch80[%buffer_base] : buffer -> view<32x4xi32, %stride80>
+  %view96 = buffer.view %scratch96[%buffer_base] : buffer -> view<32x4xi32, %stride96>
   %value = vector.constant 1 : vector<4xi32>
   vector.store %value, %view16[%lane, 0] : vector<4xi32>, view<32x4xi32, %stride16>
   vector.store %value, %view64[%lane, 0] : vector<4xi32>, view<32x4xi32, %stride64>
@@ -63,11 +63,11 @@ kernel.def target(@target) @unknown_divergent_active_lanes() {
   %lane = kernel.workitem.id<x> : index
   %half_wave = index.constant 16 : index
   %active = index.cmp ult, %lane, %half_wave : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 2048 : offset
   %layout = encoding.layout.strided [16, 1] : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<32x4xi32, %layout>
+  %view = buffer.view %scratch[%scratch_base] : buffer -> view<32x4xi32, %layout>
   %value = vector.constant 1 : vector<4xi32>
   scf.if %active {
     vector.store %value, %view[%lane, 0] : vector<4xi32>, view<32x4xi32, %layout>
@@ -90,11 +90,11 @@ kernel.def target(@target) @unknown_address_alignment() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 2048 : offset
   %layout = encoding.layout.strided [16, 1] : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 1, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<32x4xi32, %layout>
+  %view = buffer.view %scratch[%scratch_base] : buffer -> view<32x4xi32, %layout>
   %value = vector.constant 1 : vector<4xi32>
   vector.store %value, %view[%lane, 0] : vector<4xi32>, view<32x4xi32, %layout>
   kernel.return

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_diagnostics_classification.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_diagnostics_classification.loom-test
@@ -6,22 +6,22 @@ kernel.def target(@target) @static_lds_address_fields() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 4 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<1xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<1xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_b32", address_form="default", dynamic_term_kind="none", fallback_reason="dynamic_term_count", static_offset_bytes="0", dynamic_stride_bytes="0"}
-  vector.store %one, %scratch_view[0] : vector<1xi32>, view<1xi32, #dense>
+  vector.store %stored_value, %scratch_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
 
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @static_lds_address_fields() asm {
   %6 = storage {byte_alignment = 4, byte_length = 4} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %9 = v_mov_b32 0
-  low.op<amdgpu.ds_write_b32>(%9, %one) {offset = 0} memory_access([0, 3, 3, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%9, %stored_value) {offset = 0} memory_access([0, 3, 3, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
 }
 
@@ -35,13 +35,13 @@ kernel.def target(@target) @addtid_byte_stride_selected_reason_fields() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi8, #dense>
-  %one = vector.constant 1 : vector<4xi8>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi8, #dense>
+  %stored_value = vector.constant 1 : vector<4xi8>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_addtid_b32", address_form="ds_addtid", dynamic_term_kind="vaddr", fallback_reason="selected", static_offset_bytes="0", dynamic_stride_bytes="1"}
-  vector.store %one, %scratch_view[%lane] : vector<4xi8>, view<64xi8, #dense>
+  vector.store %stored_value, %scratch_view[%lane] : vector<4xi8>, view<64xi8, #dense>
   // REMARK@+1: BACKEND/017 {operation_kind="load", packet_key="amdgpu.ds_read_addtid_b32", address_form="ds_addtid", dynamic_term_kind="vaddr", fallback_reason="selected", static_offset_bytes="0", dynamic_stride_bytes="1"}
   %loaded = vector.load %scratch_view[%lane] : view<64xi8, #dense> -> vector<4xi8>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_addtid_b32", address_form="ds_addtid", dynamic_term_kind="vaddr", fallback_reason="selected", static_offset_bytes="0", dynamic_stride_bytes="1"}
@@ -52,9 +52,9 @@ kernel.def target(@target) @addtid_byte_stride_selected_reason_fields() {
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @addtid_byte_stride_selected_reason_fields() asm {
   %10 = storage {byte_alignment = 16, byte_length = 64} : low.storage<workgroup>
-  %one = v_mov_b32 16843009
+  %stored_value = v_mov_b32 16843009
   %13 = s_mov_b32_m0_imm 0
-  low.op<amdgpu.ds_write_addtid_b32>(%one, %13) {offset = 0} memory_access([0, 3, 5, -1, 11, 0, 0, 0, 3, 0, 31, 4, 35]) : (reg<amdgpu.vgpr>, reg<amdgpu.m0>)
+  low.op<amdgpu.ds_write_addtid_b32>(%stored_value, %13) {offset = 0} memory_access([0, 3, 5, -1, 11, 0, 0, 0, 3, 0, 31, 4, 35]) : (reg<amdgpu.vgpr>, reg<amdgpu.m0>)
   %14 = s_mov_b32_m0_imm 0
   %loaded = low.op<amdgpu.ds_read_addtid_b32>(%14) {offset = 0} memory_access([0, 3, 5, -1, 11, 0, 0, 0, 3, 0, 31, 4, 35]) : (reg<amdgpu.m0>) -> reg<amdgpu.vgpr>
   %16 = s_mov_b32_m0_imm 0
@@ -72,13 +72,13 @@ kernel.def target(@target) @addtid_element_stride_reason_fields() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_b32", address_form="default", dynamic_term_kind="vaddr", fallback_reason="dynamic_stride_bytes", static_offset_bytes="0", dynamic_stride_bytes="4"}
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
+  vector.store %stored_value, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   // REMARK@+1: BACKEND/017 {operation_kind="load", packet_key="amdgpu.ds_read_b32", address_form="default", dynamic_term_kind="vaddr", fallback_reason="dynamic_stride_bytes", static_offset_bytes="0", dynamic_stride_bytes="4"}
   %loaded = vector.load %scratch_view[%lane] : view<32xi32, #dense> -> vector<1xi32>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_b32", address_form="default", dynamic_term_kind="vaddr", fallback_reason="dynamic_stride_bytes", static_offset_bytes="0", dynamic_stride_bytes="4"}
@@ -90,9 +90,9 @@ kernel.def target(@target) @addtid_element_stride_reason_fields() {
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @addtid_element_stride_reason_fields() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %10 = storage {byte_alignment = 16, byte_length = 128} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %13 = v_lshlrev_b32_src0_inline %lane, 2
-  low.op<amdgpu.ds_write_b32>(%13, %one) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%13, %stored_value) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%13) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   low.op<amdgpu.ds_write_b32>(%13, %loaded) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
@@ -108,13 +108,13 @@ kernel.def target(@target) @addtid_cross_wave_reason_fields() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_b32", address_form="default", dynamic_term_kind="vaddr", fallback_reason="cross_wave_workgroup", static_offset_bytes="0", dynamic_stride_bytes="4"}
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
+  vector.store %stored_value, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
   // REMARK@+1: BACKEND/017 {operation_kind="load", packet_key="amdgpu.ds_read_b32", address_form="default", dynamic_term_kind="vaddr", fallback_reason="cross_wave_workgroup", static_offset_bytes="0", dynamic_stride_bytes="4"}
   %loaded = vector.load %scratch_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_b32", address_form="default", dynamic_term_kind="vaddr", fallback_reason="cross_wave_workgroup", static_offset_bytes="0", dynamic_stride_bytes="4"}
@@ -126,9 +126,9 @@ kernel.def target(@target) @addtid_cross_wave_reason_fields() {
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @addtid_cross_wave_reason_fields() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %10 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %13 = v_lshlrev_b32_src0_inline %lane, 2
-  low.op<amdgpu.ds_write_b32>(%13, %one) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%13, %stored_value) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%13) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
   low.op<amdgpu.ds_write_b32>(%13, %loaded) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
@@ -144,16 +144,16 @@ kernel.def target(@target) @addtid_dynamic_stride_reason_fields() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %two = index.constant 2 : index
-  %scaled_lane = index.mul %lane, %two : index
-  %zero = index.constant 0 : offset
+  %lane_stride = index.constant 2 : index
+  %scaled_lane = index.mul %lane, %lane_stride : index
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
   %other = vector.constant 2 : vector<1xi32>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_b32", address_form="default", dynamic_term_kind="vaddr", fallback_reason="dynamic_stride_bytes", static_offset_bytes="0", dynamic_stride_bytes="4"}
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
+  vector.store %stored_value, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_b32", address_form="default", dynamic_term_kind="vaddr", fallback_reason="dynamic_stride_bytes", static_offset_bytes="0", dynamic_stride_bytes="8"}
   vector.store %other, %scratch_view[%scaled_lane] : vector<1xi32>, view<64xi32, #dense>
   // REMARK@+1: BACKEND/017 {operation_kind="load", packet_key="amdgpu.ds_read_b32", address_form="default", dynamic_term_kind="vaddr", fallback_reason="dynamic_stride_bytes", static_offset_bytes="0", dynamic_stride_bytes="4"}
@@ -167,10 +167,10 @@ kernel.def target(@target) @addtid_dynamic_stride_reason_fields() {
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @addtid_dynamic_stride_reason_fields() asm {
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %13 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %other = v_mov_b32 2
   %17 = v_lshlrev_b32_src0_inline %lane, 2
-  low.op<amdgpu.ds_write_b32>(%17, %one) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%17, %stored_value) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %18 = v_lshlrev_b32_src0_inline %lane, 3
   low.op<amdgpu.ds_write_b32>(%18, %other) {offset = 0} memory_access([0, 3, 7, -1, 43, 8, 0, 4, 3, 0, 248, 4, 252]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   %loaded = low.op<amdgpu.ds_read_b32>(%17) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr>
@@ -188,13 +188,13 @@ kernel.def target(@target) @addtid_payload_width_reason_fields() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 512 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32x4xi32, #dense>
-  %one = vector.constant 1 : vector<4xi32>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32x4xi32, #dense>
+  %stored_value = vector.constant 1 : vector<4xi32>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_b128", address_form="default", dynamic_term_kind="vaddr", fallback_reason="payload_width", static_offset_bytes="0", dynamic_stride_bytes="16"}
-  vector.store %one, %scratch_view[%lane, 0] : vector<4xi32>, view<32x4xi32, #dense>
+  vector.store %stored_value, %scratch_view[%lane, 0] : vector<4xi32>, view<32x4xi32, #dense>
   kernel.return
 }
 
@@ -203,9 +203,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 
   %lane = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %9 = storage {byte_alignment = 16, byte_length = 512} : low.storage<workgroup>
   %11 = v_mov_b32 1
-  %one = concat(%11, %11, %11, %11) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x4>
+  %stored_value = concat(%11, %11, %11, %11) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x4>
   %16 = v_lshlrev_b32_src0_inline %lane, 4
-  low.op<amdgpu.ds_write_b128>(%16, %one) {offset = 0} memory_access([0, 3, 5, -1, 43, 16, 0, 16, 3, 0, 496, 16, 512]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr x4>)
+  low.op<amdgpu.ds_write_b128>(%16, %stored_value) {offset = 0} memory_access([0, 3, 5, -1, 43, 16, 0, 16, 3, 0, 496, 16, 512]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr x4>)
   return
 }
 
@@ -219,10 +219,10 @@ kernel.def target(@target) @global_memory_diagnostics_stay_silent() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %output_view[%tid] : vector<1xi32>, view<64xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<64xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %output_view[%tid] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
 }
 
@@ -230,9 +230,9 @@ kernel.def target(@target) @global_memory_diagnostics_stay_silent() {
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @global_memory_diagnostics_stay_silent() asm {
   %tid = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %10 = v_lshlrev_b32_src0_inline %tid, 2
-  global_store_b32_saddr %10, %one, %output_view
+  global_store_b32_saddr %10, %stored_value, %output_view
   return
 }
 
@@ -248,13 +248,13 @@ kernel.def target(@target) @multi_term_lds_address_fields() {
 } launch() {
   %lane_x = kernel.workitem.id<x> : index
   %lane_y = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<8x4xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<8x4xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write_b32", address_form="default", dynamic_term_kind="multiple", fallback_reason="multidimensional_workgroup", static_offset_bytes="0", dynamic_stride_bytes="0"}
-  vector.store %one, %scratch_view[%lane_x, %lane_y] : vector<1xi32>, view<8x4xi32, #dense>
+  vector.store %stored_value, %scratch_view[%lane_x, %lane_y] : vector<1xi32>, view<8x4xi32, #dense>
   kernel.return
 }
 
@@ -265,10 +265,10 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(8, 4, 1
   %lane_x = v_and_b32_lit %packed_tid, 1023
   %13 = v_lshrrev_b32_src0_inline %packed_tid, 10
   %lane_y = v_and_b32_lit %13, 1023
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %17 = v_lshl_add_u32_shift_imm %lane_x, %lane_y, 2
   %18 = v_lshlrev_b32_src0_inline %17, 2
-  low.op<amdgpu.ds_write_b32>(%18, %one) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%18, %stored_value) {offset = 0} memory_access([0, 3, 7, -1, 43, 4, 0, 4, 3, 0, 124, 4, 128]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
 }
 
@@ -282,15 +282,15 @@ kernel.def target(@target) @lds_read2_write2_structured_fields() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 2048 : offset
   %layout = encoding.layout.strided [8, 2] : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, %layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x2xi32, #dense>
-  %one = vector.constant 1 : vector<2xi32>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, %layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x2xi32, #dense>
+  %stored_value = vector.constant 1 : vector<2xi32>
   // REMARK@+1: BACKEND/017 {operation_kind="store", packet_key="amdgpu.ds_write2_b32", address_form="ds_2addr", dynamic_term_kind="vaddr", fallback_reason="cross_wave_workgroup", static_offset_bytes="0", dynamic_stride_bytes="32"}
-  vector.store %one, %scratch_view[%tid, 0] : vector<2xi32>, view<64x4xi32, %layout>
+  vector.store %stored_value, %scratch_view[%tid, 0] : vector<2xi32>, view<64x4xi32, %layout>
   // REMARK@+1: BACKEND/017 {operation_kind="load", packet_key="amdgpu.ds_read2_b32", address_form="ds_2addr", dynamic_term_kind="vaddr", fallback_reason="cross_wave_workgroup", static_offset_bytes="0", dynamic_stride_bytes="32"}
   %loaded = vector.load %scratch_view[%tid, 0] : view<64x4xi32, %layout> -> vector<2xi32>
   vector.store %loaded, %output_view[%tid, 0] : vector<2xi32>, view<64x2xi32, #dense>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_diagnostics_silence.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_diagnostics_silence.loom-test
@@ -8,12 +8,12 @@ kernel.def target(@target) @default_source_low_memory_diagnostics_stay_silent() 
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%tid] : vector<1xi32>, view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%tid] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
 }
 
@@ -21,8 +21,8 @@ kernel.def target(@target) @default_source_low_memory_diagnostics_stay_silent() 
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @default_source_low_memory_diagnostics_stay_silent() asm {
   %tid = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %9 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
-  %one = v_mov_b32 1
+  %stored_value = v_mov_b32 1
   %12 = v_lshlrev_b32_src0_inline %tid, 2
-  low.op<amdgpu.ds_write_b32>(%12, %one) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  low.op<amdgpu.ds_write_b32>(%12, %stored_value) {offset = 0} memory_access([0, 3, 5, -1, 43, 4, 0, 4, 3, 0, 252, 4, 256]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
   return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_generic_atomic.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_generic_atomic.loom-test
@@ -3,12 +3,12 @@
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @generic_atomic_i32_static(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %generic = buffer.assume.memory_space<generic> %input : buffer
-  %view = buffer.view %generic[%zero] : buffer -> view<1xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense>
-  %old_add = view.atomic.rmw<addi> %one, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense> -> i32
+  %view = buffer.view %generic[%buffer_base] : buffer -> view<1xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense>
+  %old_add = view.atomic.rmw<addi> %increment, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense> -> i32
   func.return
 }
 
@@ -31,9 +31,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @generic
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @generic_atomic_cmpxchg_i32_static(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %generic = buffer.assume.memory_space<generic> %input : buffer
-  %view = buffer.view %generic[%zero] : buffer -> view<1xi32, #dense>
+  %view = buffer.view %generic[%buffer_base] : buffer -> view<1xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old_cmpxchg = view.atomic.cmpxchg %expected, %replacement, %view[0] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i32, view<1xi32, #dense> -> i32

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_generic_atomic_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_generic_atomic_diagnostics.loom-test
@@ -2,11 +2,11 @@
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @unknown_atomic_is_not_flat(%input: buffer) {
-  %zero = index.constant 0 : offset
-  %view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %one = scalar.constant 1 : i32
+  %input_base = index.constant 0 : offset
+  %view = buffer.view %input[%input_base] : buffer -> view<1xi32, #dense>
+  %increment = scalar.constant 1 : i32
   // ERROR@+1: AMDGPU/023 {constraint_key="atomic.memory_space"}
-  view.atomic.reduce<addi> %one, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense>
+  view.atomic.reduce<addi> %increment, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense>
   func.return
 }
 
@@ -20,11 +20,11 @@ kernel.def target(@target) @generic_dynamic_atomic_rejected() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %generic = buffer.assume.memory_space<generic> %input : buffer
-  %view = buffer.view %generic[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
+  %view = buffer.view %generic[%input_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
   // ERROR@+1: AMDGPU/020 {op_name="view.atomic.reduce", operation_kind="atomic_reduce", memory_space="generic", dynamic_term_index="0", byte_stride="4"}
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
   kernel.return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_generic_atomic_gfx12.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_generic_atomic_gfx12.loom-test
@@ -3,12 +3,12 @@
 
 amdgpu.target<gfx1200> @target
 func.def target(@target) @generic_atomic_i32_static(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %generic = buffer.assume.memory_space<generic> %input : buffer
-  %view = buffer.view %generic[%zero] : buffer -> view<1xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense>
-  %old_add = view.atomic.rmw<addi> %one, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense> -> i32
+  %view = buffer.view %generic[%buffer_base] : buffer -> view<1xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense>
+  %old_add = view.atomic.rmw<addi> %increment, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense> -> i32
   func.return
 }
 
@@ -31,9 +31,9 @@ low.func.def target<amdgpu.rdna4.core>(@target) abi(hal_kernel) @generic_atomic_
 
 amdgpu.target<gfx1200> @target
 func.def target(@target) @generic_atomic_cmpxchg_i32_static(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %generic = buffer.assume.memory_space<generic> %input : buffer
-  %view = buffer.view %generic[%zero] : buffer -> view<1xi32, #dense>
+  %view = buffer.view %generic[%buffer_base] : buffer -> view<1xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old_cmpxchg = view.atomic.cmpxchg %expected, %replacement, %view[0] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i32, view<1xi32, #dense> -> i32

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_generic_atomic_gfx950.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_generic_atomic_gfx950.loom-test
@@ -3,12 +3,12 @@
 
 amdgpu.target<gfx950> @target
 func.def target(@target) @generic_atomic_i32_static(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %generic = buffer.assume.memory_space<generic> %input : buffer
-  %view = buffer.view %generic[%zero] : buffer -> view<1xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense>
-  %old_add = view.atomic.rmw<addi> %one, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense> -> i32
+  %view = buffer.view %generic[%buffer_base] : buffer -> view<1xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense>
+  %old_add = view.atomic.rmw<addi> %increment, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense> -> i32
   func.return
 }
 
@@ -33,9 +33,9 @@ low.func.def target<amdgpu.cdna4.core>(@target) abi(hal_kernel) @generic_atomic_
 
 amdgpu.target<gfx950> @target
 func.def target(@target) @generic_atomic_cmpxchg_i32_static(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %generic = buffer.assume.memory_space<generic> %input : buffer
-  %view = buffer.view %generic[%zero] : buffer -> view<1xi32, #dense>
+  %view = buffer.view %generic[%buffer_base] : buffer -> view<1xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old_cmpxchg = view.atomic.cmpxchg %expected, %replacement, %view[0] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i32, view<1xi32, #dense> -> i32

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global.loom-test
@@ -25,9 +25,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @global_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @global_f32x7_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<7xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<7xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<7xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<7xf32, #dense>
   %loaded = vector.load %input_view[0] : view<7xf32, #dense> -> vector<7xf32>
   vector.store %loaded, %output_view[0] : vector<7xf32>, view<7xf32, #dense>
   func.return
@@ -49,9 +49,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @global_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @global_f32x64_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %loaded = vector.load %input_view[0] : view<64xf32, #dense> -> vector<64xf32>
   vector.store %loaded, %output_view[0] : vector<64xf32>, view<64xf32, #dense>
   func.return
@@ -101,10 +101,10 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @global_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @global_f32x64_add_roundtrip(%lhs: buffer, %rhs: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs[%zero] : buffer -> view<64xf32, #dense>
-  %rhs_view = buffer.view %rhs[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs[%buffer_base] : buffer -> view<64xf32, #dense>
+  %rhs_view = buffer.view %rhs[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %lhs_loaded = vector.load %lhs_view[0] : view<64xf32, #dense> -> vector<64xf32>
   %rhs_loaded = vector.load %rhs_view[0] : view<64xf32, #dense> -> vector<64xf32>
   %sum = vector.addf %lhs_loaded, %rhs_loaded : vector<64xf32>
@@ -381,9 +381,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @global_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @global_bf16x14_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<14xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<14xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<14xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<14xbf16, #dense>
   %loaded = vector.load %input_view[0] : view<14xbf16, #dense> -> vector<14xbf16>
   vector.store %loaded, %output_view[0] : vector<14xbf16>, view<14xbf16, #dense>
   func.return
@@ -405,9 +405,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @global_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @global_bf16x64_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xbf16, #dense>
   %loaded = vector.load %input_view[0] : view<64xbf16, #dense> -> vector<64xbf16>
   vector.store %loaded, %output_view[0] : vector<64xbf16>, view<64xbf16, #dense>
   func.return
@@ -441,9 +441,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @global_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @global_f16x7_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<7xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<7xf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<7xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<7xf16, #dense>
   %loaded = vector.load %input_view[0] : view<7xf16, #dense> -> vector<7xf16>
   vector.store %loaded, %output_view[0] : vector<7xf16>, view<7xf16, #dense>
   func.return
@@ -465,9 +465,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @global_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @global_bf16x7_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<7xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<7xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<7xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<7xbf16, #dense>
   %loaded = vector.load %input_view[0] : view<7xbf16, #dense> -> vector<7xbf16>
   vector.store %loaded, %output_view[0] : vector<7xbf16>, view<7xbf16, #dense>
   func.return
@@ -514,9 +514,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @global_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @global_store_i32_constant_saddr(%output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output_global[%buffer_base] : buffer -> view<1xi32, #dense>
   %value = scalar.constant 42 : i32
   view.store %value, %output_view[0] : i32, view<1xi32, #dense>
   func.return
@@ -554,9 +554,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @global_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @global_load_i16_saddr(%input: buffer) -> (i16) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_global = buffer.assume.memory_space<global> %input : buffer
-  %input_view = buffer.view %input_global[%zero] : buffer -> view<1xi16, #dense>
+  %input_view = buffer.view %input_global[%buffer_base] : buffer -> view<1xi16, #dense>
   %loaded = view.load %input_view[0] : view<1xi16, #dense> -> i16
   func.return %loaded : i16
 }
@@ -573,9 +573,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @global_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @global_store_i16_saddr(%output: buffer, %value: i16) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero] : buffer -> view<1xi16, #dense>
+  %output_view = buffer.view %output_global[%buffer_base] : buffer -> view<1xi16, #dense>
   view.store %value, %output_view[0] : i16, view<1xi16, #dense>
   func.return
 }
@@ -592,8 +592,8 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @global_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @i8x2_buffer_load(%input: buffer) -> (vector<2xi8>) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<2xi8, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<2xi8, #dense>
   %loaded = vector.load %input_view[0] : view<2xi8, #dense> -> vector<2xi8>
   func.return %loaded : vector<2xi8>
 }
@@ -610,9 +610,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @i8x2_bu
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @global_load_i8x2_saddr(%input: buffer) -> (vector<2xi8>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_global = buffer.assume.memory_space<global> %input : buffer
-  %input_view = buffer.view %input_global[%zero] : buffer -> view<2xi8, #dense>
+  %input_view = buffer.view %input_global[%buffer_base] : buffer -> view<2xi8, #dense>
   %loaded = vector.load %input_view[0] : view<2xi8, #dense> -> vector<2xi8>
   func.return %loaded : vector<2xi8>
 }
@@ -629,9 +629,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @global_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @global_store_i8x2_saddr(%output: buffer, %value: vector<2xi8>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero] : buffer -> view<2xi8, #dense>
+  %output_view = buffer.view %output_global[%buffer_base] : buffer -> view<2xi8, #dense>
   vector.store %value, %output_view[0] : vector<2xi8>, view<2xi8, #dense>
   func.return
 }
@@ -648,9 +648,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @global_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @descriptor_load_i16(%input: buffer) -> (i16) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_descriptor = buffer.assume.memory_space<descriptor> %input : buffer
-  %input_view = buffer.view %input_descriptor[%zero] : buffer -> view<1xi16, #dense>
+  %input_view = buffer.view %input_descriptor[%buffer_base] : buffer -> view<1xi16, #dense>
   %loaded = view.load %input_view[0] : view<1xi16, #dense> -> i16
   func.return %loaded : i16
 }
@@ -674,9 +674,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @descrip
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @descriptor_store_i16(%output: buffer, %value: i16) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_descriptor = buffer.assume.memory_space<descriptor> %output : buffer
-  %output_view = buffer.view %output_descriptor[%zero] : buffer -> view<1xi16, #dense>
+  %output_view = buffer.view %output_descriptor[%buffer_base] : buffer -> view<1xi16, #dense>
   view.store %value, %output_view[0] : i16, view<1xi16, #dense>
   func.return
 }
@@ -702,9 +702,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @descrip
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @descriptor_load_i8x2(%input: buffer) -> (vector<2xi8>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_descriptor = buffer.assume.memory_space<descriptor> %input : buffer
-  %input_view = buffer.view %input_descriptor[%zero] : buffer -> view<2xi8, #dense>
+  %input_view = buffer.view %input_descriptor[%buffer_base] : buffer -> view<2xi8, #dense>
   %loaded = vector.load %input_view[0] : view<2xi8, #dense> -> vector<2xi8>
   func.return %loaded : vector<2xi8>
 }
@@ -728,9 +728,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @descrip
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @descriptor_store_i8x2(%output: buffer, %value: vector<2xi8>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_descriptor = buffer.assume.memory_space<descriptor> %output : buffer
-  %output_view = buffer.view %output_descriptor[%zero] : buffer -> view<2xi8, #dense>
+  %output_view = buffer.view %output_descriptor[%buffer_base] : buffer -> view<2xi8, #dense>
   vector.store %value, %output_view[0] : vector<2xi8>, view<2xi8, #dense>
   func.return
 }
@@ -756,9 +756,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @descrip
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @descriptor_b128_off_zero(%input: buffer) -> (vector<4xi32>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_descriptor = buffer.assume.memory_space<descriptor> %input : buffer
-  %input_view = buffer.view %input_descriptor[%zero] : buffer -> view<4xi32, #dense>
+  %input_view = buffer.view %input_descriptor[%buffer_base] : buffer -> view<4xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   func.return %loaded : vector<4xi32>
 }
@@ -972,14 +972,14 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @descrip
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @descriptor_dynamic_extent_store_f32x4(%output: buffer, %value: vector<4xf32>, %row_count_i32: i32, %row_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %first_column = index.constant 0 : index
   %output_descriptor = buffer.assume.memory_space<descriptor> %output : buffer
   %row_count0 = index.cast %row_count_i32 : i32 to index
   %row_count = index.assume %row_count0 [range(%row_count0, 1, 1024)] : index
   %row0 = index.cast %row_i32 : i32 to index
   %row = index.assume %row0 [range(%row0, 0, 1023), lt(%row0, %row_count)] : index
   %output_view = buffer.view %output_descriptor[%base] : buffer -> view<[%row_count]x4xf32, #dense>
-  vector.store %value, %output_view[%row, %zero] : vector<4xf32>, view<[%row_count]x4xf32, #dense>
+  vector.store %value, %output_view[%row, %first_column] : vector<4xf32>, view<[%row_count]x4xf32, #dense>
   func.return
 }
 
@@ -1006,14 +1006,14 @@ amdgpu.target<gfx11-generic> @target
 func.def target(@target) @descriptor_dynamic_base_extent_store_f32x4(%output: buffer, %value: vector<4xf32>, %base_i32: i32, %row_count_i32: i32, %row_i32: i32) {
   %base0 = index.cast %base_i32 : i32 to offset
   %base = index.assume %base0 [range(%base0, 0, 8192), mul(%base0, 16)] : offset
-  %zero = index.constant 0 : index
+  %first_column = index.constant 0 : index
   %output_descriptor = buffer.assume.memory_space<descriptor> %output : buffer
   %row_count0 = index.cast %row_count_i32 : i32 to index
   %row_count = index.assume %row_count0 [range(%row_count0, 1, 512)] : index
   %row0 = index.cast %row_i32 : i32 to index
   %row = index.assume %row0 [range(%row0, 0, 511), lt(%row0, %row_count)] : index
   %output_view = buffer.view %output_descriptor[%base] : buffer -> view<[%row_count]x4xf32, #dense>
-  vector.store %value, %output_view[%row, %zero] : vector<4xf32>, view<[%row_count]x4xf32, #dense>
+  vector.store %value, %output_view[%row, %first_column] : vector<4xf32>, view<[%row_count]x4xf32, #dense>
   func.return
 }
 
@@ -1301,8 +1301,8 @@ kernel.def target(@target) @i32_dynamic_leading_dim_global_saddr() {
   %columns = index.assume %columns0 [range(%columns0, 32, 2147483647)] : index
   %output_global = buffer.assume.memory_space<global> %output : buffer
   %output_view = buffer.view %output_global[%base] : buffer -> view<2x[%columns]x8xi32, #dense>
-  %zero = scalar.constant 0 : i32
-  view.store %zero, %output_view[%workgroup, %column, 0] : i32, view<2x[%columns]x8xi32, #dense>
+  %cleared_value = scalar.constant 0 : i32
+  view.store %cleared_value, %output_view[%workgroup, %column, 0] : i32, view<2x[%columns]x8xi32, #dense>
   kernel.return
 }
 
@@ -1393,11 +1393,11 @@ kernel.def target(@target) @i32_readonly_uniform_smem_scalar_branch() {
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<16xi32, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<16xi32, #dense>
   %loaded = view.load %input_view[%workgroup] : view<16xi32, #dense> -> i32
-  %zero = scalar.constant 0 : i32
-  %negative = scalar.cmpi slt, %loaded, %zero : i32
+  %clamp_floor = scalar.constant 0 : i32
+  %negative = scalar.cmpi slt, %loaded, %clamp_floor : i32
   cfg.cond_br %negative, ^then, ^join
 ^then:
-  view.store %zero, %output_view[%workgroup] : i32, view<16xi32, #dense>
+  view.store %clamp_floor, %output_view[%workgroup] : i32, view<16xi32, #dense>
   cfg.br ^join
 ^join:
   kernel.return
@@ -1410,8 +1410,8 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 64} : reg<amdgpu.sgpr x2>
   %19 = s_lshl_b32_rhs_inline %workgroup, 2
   %loaded = s_load_dword %input_view, %19
-  %zero = s_mov_b32 0
-  %negative = s_cmp_lt_i32 %loaded, %zero
+  %clamp_floor = s_mov_b32 0
+  %negative = s_cmp_lt_i32 %loaded, %clamp_floor
   low.cond_br %negative, ^then, ^join : reg<amdgpu.scc>
 ^then:
   %23 = v_mov_b32 0
@@ -1419,7 +1419,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %26 = slice %output_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %27 = slice %output_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %29 = s_add_u32 %26, %25
-  %30 = s_addc_u32 %27, %zero
+  %30 = s_addc_u32 %27, %clamp_floor
   %31 = concat(%29, %30) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
   global_store_b32_saddr %23, %23, %31
   low.br ^join
@@ -1439,7 +1439,7 @@ kernel.def target(@target) @i32_readonly_uniform_smem_loop_bound() {
   %base = index.constant 0 : offset
   %start = index.constant 0 : index
   %step = index.constant 1 : index
-  %zero = scalar.constant 0.0 : f32
+  %initial_sum = scalar.constant 0.0 : f32
   %control_noalias, %input_noalias, %output_noalias = buffer.assume.noalias %control, %input, %output : buffer, buffer, buffer
   %control_view = buffer.view %control_noalias[%base] : buffer -> view<1xi32, #dense>
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<128xf32, #dense>
@@ -1447,7 +1447,7 @@ kernel.def target(@target) @i32_readonly_uniform_smem_loop_bound() {
   %limit_i32 = view.load %control_view[0] : view<1xi32, #dense> -> i32
   %limit0 = index.cast %limit_i32 : i32 to index
   %limit = index.assume %limit0 [range(%limit0, 0, 128)] : index
-  %sum = scf.for %position = [%start to %limit step %step](%current_sum = %zero : f32) -> (f32) {
+  %sum = scf.for %position = [%start to %limit step %step](%current_sum = %initial_sum : f32) -> (f32) {
     %loaded = view.load %input_view[%position] : view<128xf32, #dense> -> f32
     %next_sum = scalar.addf<reassoc|nnan|nsz> %current_sum, %loaded : f32
     scf.yield %next_sum : f32
@@ -1463,9 +1463,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %output_view = resource<hal_binding> {index = 2, source_type = hal.buffer, extent = 4} : reg<amdgpu.sgpr x2>
   %start = s_mov_b32 0
   %step = s_mov_b32 1
-  %zero = v_mov_b32 0
+  %initial_sum = v_mov_b32 0
   %limit = s_load_dword %control_view, %start
-  low.br ^_bb1(%start: reg<amdgpu.sgpr>, %zero: reg<amdgpu.vgpr>)
+  low.br ^_bb1(%start: reg<amdgpu.sgpr>, %initial_sum: reg<amdgpu.vgpr>)
 ^_bb1(%position: reg<amdgpu.sgpr>, %current_sum: reg<amdgpu.vgpr>):
   %39 = s_cmp_lt_i32 %position, %limit
   low.cond_br %39, ^_bb2, ^_bb3 : reg<amdgpu.scc>
@@ -1476,7 +1476,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %43 = s_add_u32 %position, %step
   low.br ^_bb1(%43: reg<amdgpu.sgpr>, %next_sum: reg<amdgpu.vgpr>)
 ^_bb3:
-  global_store_b32_saddr %zero, %current_sum, %output_view
+  global_store_b32_saddr %initial_sum, %current_sum, %output_view
   return
 }
 
@@ -1547,8 +1547,8 @@ kernel.def target(@target) @i32_readonly_uniform_smem_address() {
   %column_i32 = view.load %control_view[0] : view<1xi32, #dense> -> i32
   %column0 = index.cast %column_i32 : i32 to index
   %column = index.assume %column0 [range(%column0, 0, 63)] : index
-  %zero = scalar.constant 0 : i32
-  view.store %zero, %output_view[%column] : i32, view<64xi32, #dense>
+  %cleared_value = scalar.constant 0 : i32
+  view.store %cleared_value, %output_view[%column] : i32, view<64xi32, #dense>
   kernel.return
 }
 
@@ -1582,13 +1582,14 @@ kernel.def target(@target) @i32_readonly_uniform_smem_guarded_index_address() {
   %output_view = buffer.view %output[%base] : buffer -> view<64xi32, #dense>
   %column_i32 = view.load %control_view[0] : view<1xi32, #dense> -> i32
   %column = index.cast %column_i32 : i32 to index
-  %zero_i32 = scalar.constant 0 : i32
+  %minimum_column = scalar.constant 0 : i32
+  %cleared_value = scalar.constant 0 : i32
   %limit_i32 = scalar.constant 64 : i32
-  %nonnegative = scalar.cmpi sge, %column_i32, %zero_i32 : i32
+  %nonnegative = scalar.cmpi sge, %column_i32, %minimum_column : i32
   %below = scalar.cmpi slt, %column_i32, %limit_i32 : i32
   %guard = scalar.andi %nonnegative, %below : i1
   scf.if %guard {
-    view.store %zero_i32, %output_view[%column] : i32, view<64xi32, #dense>
+    view.store %cleared_value, %output_view[%column] : i32, view<64xi32, #dense>
   }
   kernel.return
 }
@@ -1597,20 +1598,20 @@ kernel.def target(@target) @i32_readonly_uniform_smem_guarded_index_address() {
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @i32_readonly_uniform_smem_guarded_index_address() asm {
   %control_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 4} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
-  %16 = v_mov_b32 0
-  %column = global_load_b32_saddr %16, %control_view
+  %17 = v_mov_b32 0
+  %column = global_load_b32_saddr %17, %control_view
   %nonnegative = v_cmp_ge_i32_src1_inline %column {rhs = 0}
   %below = v_cmp_lt_i32_src1_inline %column {rhs = 64}
   %guard = s_and_b64 %nonnegative, %below
-  %22, %23 = s_and_saveexec_b64 %guard
-  low.cond_br %23, ^_bb1, ^_bb2 : reg<amdgpu.scc>
+  %23, %24 = s_and_saveexec_b64 %guard
+  low.cond_br %24, ^_bb1, ^_bb2 : reg<amdgpu.scc>
 ^_bb1:
-  %24 = v_mov_b32 0
-  %25 = v_lshlrev_b32_src0_inline %column, 2
-  global_store_b32_saddr %25, %24, %output_view
+  %25 = v_mov_b32 0
+  %26 = v_lshlrev_b32_src0_inline %column, 2
+  global_store_b32_saddr %26, %25, %output_view
   low.br ^_bb2
 ^_bb2:
-  s_mov_b64_exec %22
+  s_mov_b64_exec %23
   return
 }
 
@@ -1626,16 +1627,16 @@ kernel.def target(@target) @i64_readonly_uniform_smem_guarded_index_address() {
   %control_view = buffer.view %control[%base] : buffer -> view<1xi64, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<64xi32, #dense>
   %column_i64 = view.load %control_view[0] : view<1xi64, #dense> -> i64
-  %zero_i64 = scalar.constant 0 : i64
+  %minimum_column = scalar.constant 0 : i64
   %limit_i64 = scalar.constant 64 : i64
-  %nonnegative = scalar.cmpi sge, %column_i64, %zero_i64 : i64
+  %nonnegative = scalar.cmpi sge, %column_i64, %minimum_column : i64
   %below = scalar.cmpi slt, %column_i64, %limit_i64 : i64
   %guard = scalar.andi %nonnegative, %below : i1
-  %zero_i32 = scalar.constant 0 : i32
+  %cleared_value = scalar.constant 0 : i32
   scf.if %guard {
     %bounded_column_i64 = scalar.assume %column_i64 [range(%column_i64, 0, 63)] : i64
     %column = index.cast %bounded_column_i64 : i64 to index
-    view.store %zero_i32, %output_view[%column] : i32, view<64xi32, #dense>
+    view.store %cleared_value, %output_view[%column] : i32, view<64xi32, #dense>
   }
   kernel.return
 }
@@ -1684,9 +1685,9 @@ kernel.def target(@target) @i32_b128() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   %raise = vector.constant 9 : vector<4xi32>
   %raised = vector.addi %loaded, %raise : vector<4xi32>
@@ -1730,9 +1731,9 @@ kernel.def target(@target) @f32x8_split_b128() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x8xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x8xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x8xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x8xf32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x8xf32, #dense> -> vector<8xf32>
   %raise = vector.constant 2.0 : vector<8xf32>
   %result = vector.addf %loaded, %raise : vector<8xf32>
@@ -1782,9 +1783,9 @@ kernel.def target(@target) @i32_scalar_2d_store() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4x8xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4x8xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4x8xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4x8xi32, #dense>
   %loaded = vector.load %input_view[%row, %column] : view<4x8xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%row, %column] : vector<1xi32>, view<4x8xi32, #dense>
   kernel.return
@@ -1848,12 +1849,12 @@ kernel.def target(@target) @i32_dynamic_constant_index() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<64x1x4xi32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<64x1x4xi32, #dense>
-  %loaded = vector.load %input_view[%lane, %zero, 0] : view<64x1x4xi32, #dense> -> vector<4xi32>
-  vector.store %loaded, %output_view[%lane, %zero, 0] : vector<4xi32>, view<64x1x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %singleton_axis = index.constant 0 : index
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x1x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x1x4xi32, #dense>
+  %loaded = vector.load %input_view[%lane, %singleton_axis, 0] : view<64x1x4xi32, #dense> -> vector<4xi32>
+  vector.store %loaded, %output_view[%lane, %singleton_axis, 0] : vector<4xi32>, view<64x1x4xi32, #dense>
   kernel.return
 }
 
@@ -1917,9 +1918,9 @@ kernel.def target(@target) @i32_dynamic_view_base() {
 } launch(%control: buffer, %output: buffer, %offset_i32: i32) {
   %base0 = index.cast %offset_i32 : i32 to offset
   %base = index.assume %base0 [range(%base0, 0, 4092), mul(%base0, 4)] : offset
-  %zero = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %control_view = buffer.view %control[%base] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   %loaded = view.load %control_view[2] : view<4xi32, #dense> -> i32
   view.store %loaded, %output_view[0] : i32, view<1xi32, #dense>
   kernel.return
@@ -1948,12 +1949,13 @@ kernel.def target(@target) @i32_dynamic_view_base_loaded() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%control: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %header_view = buffer.view %control[%zero] : buffer -> view<8xi32, #dense>
+  %header_base = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
+  %header_view = buffer.view %control[%header_base] : buffer -> view<8xi32, #dense>
   %base_i32 = view.load %header_view[7] : view<8xi32, #dense> -> i32
   %base = index.cast %base_i32 : i32 to offset
   %control_view = buffer.view %control[%base] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   %loaded = view.load %control_view[2] : view<4xi32, #dense> -> i32
   view.store %loaded, %output_view[0] : i32, view<1xi32, #dense>
   kernel.return
@@ -1963,10 +1965,10 @@ kernel.def target(@target) @i32_dynamic_view_base_loaded() {
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @i32_dynamic_view_base_loaded() asm {
   %control_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 4} : reg<amdgpu.sgpr x2>
-  %12 = v_mov_b32 0
-  %base = global_load_b32_saddr %12, %control_view {offset = 28}
+  %13 = v_mov_b32 0
+  %base = global_load_b32_saddr %13, %control_view {offset = 28}
   %loaded = global_load_b32_saddr %base, %control_view {offset = 8}
-  global_store_b32_saddr %12, %loaded, %output_view
+  global_store_b32_saddr %13, %loaded, %output_view
   return
 }
 
@@ -1979,9 +1981,9 @@ kernel.def target(@target) @i32x4_dynamic_view_base_b128() {
 } launch(%input: buffer, %output: buffer, %offset_i32: i32) {
   %base0 = index.cast %offset_i32 : i32 to offset
   %base = index.assume %base0 [range(%base0, 0, 4096), mul(%base0, 16)] : offset
-  %zero = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %input_view = buffer.view %input[%base] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xi32, #dense>
+  %output_view = buffer.view %output[%output_base] : buffer -> view<4xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[0] : vector<4xi32>, view<4xi32, #dense>
   kernel.return
@@ -2056,7 +2058,7 @@ kernel.def target(@target) @f16_view_scalar() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer, %column_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %first_column = index.constant 0 : index
   %column0 = index.cast %column_i32 : i32 to index
   %column = index.assume %column0 [range(%column0, 0, 7)] : index
   %input_view = buffer.view %input[%base] : buffer -> view<8xf16, #dense>
@@ -2064,7 +2066,7 @@ kernel.def target(@target) @f16_view_scalar() {
   %loaded = view.load %input_view[%column] : view<8xf16, #dense> -> f16
   view.store %loaded, %output_view[%column] : f16, view<8xf16, #dense>
   %cleared = scalar.constant 0.0 : f16
-  view.store %cleared, %output_view[%zero] : f16, view<8xf16, #dense>
+  view.store %cleared, %output_view[%first_column] : f16, view<8xf16, #dense>
   kernel.return
 }
 
@@ -2101,7 +2103,7 @@ kernel.def target(@target) @bf16_view_scalar() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer, %column_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %first_column = index.constant 0 : index
   %column0 = index.cast %column_i32 : i32 to index
   %column = index.assume %column0 [range(%column0, 0, 7)] : index
   %input_view = buffer.view %input[%base] : buffer -> view<8xbf16, #dense>
@@ -2109,7 +2111,7 @@ kernel.def target(@target) @bf16_view_scalar() {
   %loaded = view.load %input_view[%column] : view<8xbf16, #dense> -> bf16
   view.store %loaded, %output_view[%column] : bf16, view<8xbf16, #dense>
   %cleared = scalar.constant 0.0 : bf16
-  view.store %cleared, %output_view[%zero] : bf16, view<8xbf16, #dense>
+  view.store %cleared, %output_view[%first_column] : bf16, view<8xbf16, #dense>
   kernel.return
 }
 
@@ -2147,9 +2149,9 @@ kernel.def target(@target) @f16x2_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x2xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x2xf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x2xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x2xf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x2xf16, #dense> -> vector<2xf16>
   vector.store %loaded, %output_view[%lane, 0] : vector<2xf16>, view<64x2xf16, #dense>
   kernel.return
@@ -2175,9 +2177,9 @@ kernel.def target(@target) @f16x4_b64() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xf16, #dense> -> vector<4xf16>
   vector.store %loaded, %output_view[%lane, 0] : vector<4xf16>, view<64x4xf16, #dense>
   kernel.return
@@ -2203,9 +2205,9 @@ kernel.def target(@target) @bf16x2_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x2xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x2xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x2xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x2xbf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x2xbf16, #dense> -> vector<2xbf16>
   vector.store %loaded, %output_view[%lane, 0] : vector<2xbf16>, view<64x2xbf16, #dense>
   kernel.return
@@ -2231,9 +2233,9 @@ kernel.def target(@target) @bf16x4_b64() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xbf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xbf16, #dense> -> vector<4xbf16>
   vector.store %loaded, %output_view[%lane, 0] : vector<4xbf16>, view<64x4xbf16, #dense>
   kernel.return
@@ -2528,7 +2530,8 @@ kernel.def target(@target) @selected_i32_row_shift_store() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%idx: buffer, %output: buffer, %value: f32, %element_count_i32: i32, %condition_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %inactive_condition = index.constant 0 : index
+  %inactive_element = index.constant 0 : index
   %shift = index.constant 2 : index
   %element_count0 = index.cast %element_count_i32 : i32 to index
   %element_count = index.assume %element_count0 [range(%element_count0, 1, 2147483647)] : index
@@ -2540,8 +2543,8 @@ kernel.def target(@target) @selected_i32_row_shift_store() {
   %raw = index.shli %row, %shift : index
   %condition0 = index.cast %condition_i32 : i32 to index
   %condition = index.assume %condition0 [range(%condition0, 1, 1)] : index
-  %selected_condition = index.cmp ne, %condition, %zero : index
-  %selected = scf.select %selected_condition, %raw, %zero : index
+  %selected_condition = index.cmp ne, %condition, %inactive_condition : index
+  %selected = scf.select %selected_condition, %raw, %inactive_element : index
   %element = index.assume %selected [range(%selected, 0, 1073741823), lt(%selected, %element_count)] : index
   view.store %value, %output_view[%element] : f32, view<[%element_count]xf32, #dense>
   kernel.return
@@ -2551,11 +2554,11 @@ kernel.def target(@target) @selected_i32_row_shift_store() {
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @selected_i32_row_shift_store(%value: reg<amdgpu.sgpr>, %element_count: reg<amdgpu.sgpr>, %condition_i32: reg<amdgpu.sgpr>) asm {
   %idx_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 4} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
-  %27 = v_mov_b32 0
-  %row = global_load_b32_saddr %27, %idx_view
-  %30 = v_mov_b32_copy %value
-  %31 = v_lshlrev_b32_src0_inline %row, 4
-  global_store_b32_saddr %31, %30, %output_view
+  %28 = v_mov_b32 0
+  %row = global_load_b32_saddr %28, %idx_view
+  %31 = v_mov_b32_copy %value
+  %32 = v_lshlrev_b32_src0_inline %row, 4
+  global_store_b32_saddr %32, %31, %output_view
   return
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_atomic.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_atomic.loom-test
@@ -7,12 +7,12 @@ kernel.def target(@target) @global_atomic_add_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -44,12 +44,12 @@ kernel.def target(@target) @global_atomic_add_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
-  %one = scalar.constant 1 : i64
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense>
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
+  %increment = scalar.constant 1 : i64
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense>
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
 }
 
@@ -73,9 +73,9 @@ kernel.def target(@target) @global_atomic_dynamic_add_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer, %value: i64) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
   %old = view.atomic.rmw<addi> %value, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
 }
@@ -101,12 +101,12 @@ kernel.def target(@target) @global_atomic_add_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xf32, #dense>
-  %one = scalar.constant 1.0 : f32
-  view.atomic.reduce<addf> %one, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
-  %old = view.atomic.rmw<addf> %one, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xf32, #dense>
+  %increment = scalar.constant 1.0 : f32
+  view.atomic.reduce<addf> %increment, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
+  %old = view.atomic.rmw<addf> %increment, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
   kernel.return
 }
 
@@ -182,9 +182,9 @@ kernel.def target(@target) @global_atomic_minnum_maxnum_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xf32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xf32, #dense>
   %limit = scalar.constant 1.0 : f32
   view.atomic.reduce<minnumf> %limit, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
   view.atomic.reduce<maxnumf> %limit, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
@@ -224,9 +224,9 @@ kernel.def target(@target) @global_atomic_dynamic_minnum_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer, %value: f32) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xf32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xf32, #dense>
   %old_min = view.atomic.rmw<minnumf> %value, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
   %old_max = view.atomic.rmw<maxnumf> %value, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
   kernel.return
@@ -260,9 +260,9 @@ kernel.def target(@target) @global_atomic_bitwise_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %mask = scalar.constant 255 : i32
   view.atomic.reduce<andi> %mask, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
   view.atomic.reduce<ori> %mask, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
@@ -307,9 +307,9 @@ kernel.def target(@target) @global_atomic_sub_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %delta = scalar.constant 1 : i32
   view.atomic.reduce<subi> %delta, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
   %old_sub = view.atomic.rmw<subi> %delta, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
@@ -344,9 +344,9 @@ kernel.def target(@target) @global_atomic_exchange_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %value = scalar.constant 7 : i32
   %old = view.atomic.rmw<xchgi> %value, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
@@ -378,9 +378,9 @@ kernel.def target(@target) @global_atomic_exchange_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
   %value = scalar.constant 7 : i64
   %old = view.atomic.rmw<xchgi> %value, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
@@ -404,9 +404,9 @@ kernel.def target(@target) @global_atomic_cmpxchg_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old = view.atomic.cmpxchg %expected, %replacement, %view[%tid] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i32, view<64xi32, #dense> -> i32
@@ -441,9 +441,9 @@ kernel.def target(@target) @global_atomic_cmpxchg_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
   %expected = scalar.constant 7 : i64
   %replacement = scalar.constant 9 : i64
   %old = view.atomic.cmpxchg %expected, %replacement, %view[%tid] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i64, view<64xi64, #dense> -> i64
@@ -471,9 +471,9 @@ kernel.def target(@target) @global_atomic_minmax_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %limit = scalar.constant 1 : i32
   view.atomic.reduce<minsi> %limit, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
   view.atomic.reduce<maxsi> %limit, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_atomic_cdna3.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_atomic_cdna3.loom-test
@@ -6,24 +6,24 @@ kernel.def target(@target) @global_atomic_add_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xf32, #dense>
-  %one = scalar.constant 1.0 : f32
-  view.atomic.reduce<addf> %one, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
-  %old = view.atomic.rmw<addf> %one, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
+  %view = buffer.view %global[%input_base] : buffer -> view<64xf32, #dense>
+  %increment = scalar.constant 1.0 : f32
+  view.atomic.reduce<addf> %increment, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
+  %old = view.atomic.rmw<addf> %increment, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
   kernel.return
 }
 
 // ----
 low.kernel.def target<amdgpu.cdna3.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @global_atomic_add_f32() asm {
   %view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
-  %one = v_mov_b32 1065353216
+  %increment = v_mov_b32 1065353216
   %11 = v_mov_b32 0
   %12 = s_mov_b32_m0_imm 0
-  global_atomic_add_f32_saddr %11, %one, %view, %12
+  global_atomic_add_f32_saddr %11, %increment, %view, %12
   %14 = s_mov_b32_m0_imm 0
-  %old = global_atomic_add_f32_rtn_saddr %11, %one, %view, %14
+  %old = global_atomic_add_f32_rtn_saddr %11, %increment, %view, %14
   return
 }
 
@@ -35,12 +35,12 @@ kernel.def target(@target) @global_atomic_add_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
-  %one = scalar.constant 1 : i64
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense>
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
+  %view = buffer.view %global[%input_base] : buffer -> view<64xi64, #dense>
+  %increment = scalar.constant 1 : i64
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense>
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
 }
 
@@ -66,9 +66,9 @@ kernel.def target(@target) @global_atomic_dynamic_add_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer, %value: i64) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%input_base] : buffer -> view<64xi64, #dense>
   %old = view.atomic.rmw<addi> %value, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
 }
@@ -95,9 +95,9 @@ kernel.def target(@target) @global_atomic_exchange_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%input_base] : buffer -> view<64xi64, #dense>
   %value = scalar.constant 7 : i64
   %old = view.atomic.rmw<xchgi> %value, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
@@ -122,9 +122,9 @@ kernel.def target(@target) @global_atomic_cmpxchg_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%input_base] : buffer -> view<64xi64, #dense>
   %expected = scalar.constant 7 : i64
   %replacement = scalar.constant 9 : i64
   %old = view.atomic.cmpxchg %expected, %replacement, %view[%tid] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i64, view<64xi64, #dense> -> i64
@@ -158,12 +158,12 @@ kernel.def target(@target) @intermediate_block_atomic_output_f32() {
   %intermediate_block = kernel.workgroup.id<x> : index
   %row = kernel.workgroup.id<y> : index
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %partial_global = buffer.assume.memory_space<global> %partial : buffer
   %output_global = buffer.assume.memory_space<global> %output : buffer
   %partial_noalias, %output_noalias = buffer.assume.noalias %partial_global, %output_global : buffer, buffer
-  %partial_view = buffer.view %partial_noalias[%zero] : buffer -> view<2x4x64xf32, #dense>
-  %output_view = buffer.view %output_noalias[%zero] : buffer -> view<4x64xf32, #dense>
+  %partial_view = buffer.view %partial_noalias[%buffer_base] : buffer -> view<2x4x64xf32, #dense>
+  %output_view = buffer.view %output_noalias[%buffer_base] : buffer -> view<4x64xf32, #dense>
   %contribution = view.load %partial_view[%intermediate_block, %row, %lane] : view<2x4x64xf32, #dense> -> f32
   view.atomic.reduce<addf> %contribution, %output_view[%row, %lane] {ordering = relaxed, scope = device} : f32, view<4x64xf32, #dense>
   kernel.return

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_atomic_gfx12.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_atomic_gfx12.loom-test
@@ -7,12 +7,12 @@ kernel.def target(@target) @global_atomic_add_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -34,12 +34,12 @@ kernel.def target(@target) @global_atomic_add_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
-  %one = scalar.constant 1 : i64
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense>
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
+  %increment = scalar.constant 1 : i64
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense>
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
 }
 
@@ -63,9 +63,9 @@ kernel.def target(@target) @global_atomic_dynamic_add_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer, %value: i64) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
   %old = view.atomic.rmw<addi> %value, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
 }
@@ -91,22 +91,22 @@ kernel.def target(@target) @global_atomic_add_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xf32, #dense>
-  %one = scalar.constant 1.0 : f32
-  view.atomic.reduce<addf> %one, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
-  %old = view.atomic.rmw<addf> %one, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xf32, #dense>
+  %increment = scalar.constant 1.0 : f32
+  view.atomic.reduce<addf> %increment, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
+  %old = view.atomic.rmw<addf> %increment, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
   kernel.return
 }
 
 // ----
 low.kernel.def target<amdgpu.rdna4.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @global_atomic_add_f32() asm {
   %view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
-  %one = v_mov_b32 1065353216
+  %increment = v_mov_b32 1065353216
   %11 = v_mov_b32 0
-  global_atomic_add_f32_saddr %11, %one, %view {scope = 2}
-  %old = global_atomic_add_f32_rtn_saddr %11, %one, %view {scope = 2}
+  global_atomic_add_f32_saddr %11, %increment, %view {scope = 2}
+  %old = global_atomic_add_f32_rtn_saddr %11, %increment, %view {scope = 2}
   return
 }
 
@@ -118,9 +118,9 @@ kernel.def target(@target) @global_atomic_minnum_maxnum_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xf32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xf32, #dense>
   %limit = scalar.constant 1.0 : f32
   view.atomic.reduce<minnumf> %limit, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
   view.atomic.reduce<maxnumf> %limit, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
@@ -149,9 +149,9 @@ kernel.def target(@target) @global_atomic_dynamic_minnum_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer, %value: f32) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xf32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xf32, #dense>
   %old_min = view.atomic.rmw<minnumf> %value, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
   %old_max = view.atomic.rmw<maxnumf> %value, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
   kernel.return
@@ -175,9 +175,9 @@ kernel.def target(@target) @global_atomic_bitwise_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %mask = scalar.constant 255 : i32
   view.atomic.reduce<andi> %mask, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
   view.atomic.reduce<ori> %mask, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
@@ -210,9 +210,9 @@ kernel.def target(@target) @global_atomic_sub_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %delta = scalar.constant 1 : i32
   view.atomic.reduce<subi> %delta, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
   %old_sub = view.atomic.rmw<subi> %delta, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
@@ -237,9 +237,9 @@ kernel.def target(@target) @global_atomic_exchange_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %value = scalar.constant 7 : i32
   %old = view.atomic.rmw<xchgi> %value, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
@@ -262,9 +262,9 @@ kernel.def target(@target) @global_atomic_exchange_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
   %value = scalar.constant 7 : i64
   %old = view.atomic.rmw<xchgi> %value, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
@@ -288,9 +288,9 @@ kernel.def target(@target) @global_atomic_cmpxchg_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old = view.atomic.cmpxchg %expected, %replacement, %view[%tid] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i32, view<64xi32, #dense> -> i32
@@ -316,9 +316,9 @@ kernel.def target(@target) @global_atomic_cmpxchg_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
   %expected = scalar.constant 7 : i64
   %replacement = scalar.constant 9 : i64
   %old = view.atomic.cmpxchg %expected, %replacement, %view[%tid] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i64, view<64xi64, #dense> -> i64
@@ -346,9 +346,9 @@ kernel.def target(@target) @global_atomic_minmax_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %limit = scalar.constant 1 : i32
   view.atomic.reduce<minsi> %limit, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
   view.atomic.reduce<maxsi> %limit, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_atomic_ordering.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_atomic_ordering.loom-test
@@ -7,11 +7,11 @@ kernel.def target(@target) @global_atomic_release_reduce_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = release, scope = device} : i32, view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = release, scope = device} : i32, view<64xi32, #dense>
   kernel.return
 }
 
@@ -43,11 +43,11 @@ kernel.def target(@target) @global_atomic_acquire_rmw_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = acquire, scope = device} : i32, view<64xi32, #dense> -> i32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = acquire, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -80,11 +80,11 @@ kernel.def target(@target) @global_atomic_acq_rel_rmw_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = acq_rel, scope = device} : i32, view<64xi32, #dense> -> i32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = acq_rel, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -119,9 +119,9 @@ kernel.def target(@target) @global_atomic_acq_rel_cmpxchg_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old = view.atomic.cmpxchg %expected, %replacement, %view[%tid] {failure_ordering = acquire, scope = device, success_ordering = acq_rel} : i32, view<64xi32, #dense> -> i32
@@ -161,11 +161,11 @@ kernel.def target(@target) @global_atomic_seq_cst_reduce_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = seq_cst, scope = device} : i32, view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = seq_cst, scope = device} : i32, view<64xi32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_atomic_ordering_gfx12.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_atomic_ordering_gfx12.loom-test
@@ -7,11 +7,11 @@ kernel.def target(@target) @global_atomic_release_reduce_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = release, scope = device} : i32, view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = release, scope = device} : i32, view<64xi32, #dense>
   kernel.return
 }
 
@@ -32,11 +32,11 @@ kernel.def target(@target) @global_atomic_acquire_rmw_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = acquire, scope = device} : i32, view<64xi32, #dense> -> i32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = acquire, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -59,11 +59,11 @@ kernel.def target(@target) @global_atomic_acq_rel_rmw_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = acq_rel, scope = device} : i32, view<64xi32, #dense> -> i32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = acq_rel, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -86,9 +86,9 @@ kernel.def target(@target) @global_atomic_acq_rel_cmpxchg_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old = view.atomic.cmpxchg %expected, %replacement, %view[%tid] {failure_ordering = acquire, scope = device, success_ordering = acq_rel} : i32, view<64xi32, #dense> -> i32
@@ -116,11 +116,11 @@ kernel.def target(@target) @global_atomic_seq_cst_reduce_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = seq_cst, scope = device} : i32, view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = seq_cst, scope = device} : i32, view<64xi32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_record_stride.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_record_stride.loom-test
@@ -9,8 +9,8 @@ kernel.def target(@target) @global_vector_record_non_power_two_stride() {
 } launch(%input: buffer, %output: buffer) {
   %expert = kernel.workgroup.id<x> : index
   %lane = kernel.workitem.id<x> : index
-  %sixteen = index.constant 16 : index
-  %channel = index.mul %lane, %sixteen : index
+  %channel_stride = index.constant 16 : index
+  %channel = index.mul %lane, %channel_stride : index
   %base = index.constant 0 : offset
   %input_global = buffer.assume.memory_space<global> %input : buffer
   %input_noalias = buffer.assume.noalias %input_global : buffer

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_saddr_large_static.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global_saddr_large_static.loom-test
@@ -17,11 +17,11 @@ kernel.def target(@target) @i32x4_global_saddr_large_static_non_power_two_stride
   %output_row_byte_stride_i32 = scalar.constant 16 : i32
   %output_row_byte_base_i32 = scalar.muli %row_i32, %output_row_byte_stride_i32 : i32
   %output_row_byte_base = index.cast %output_row_byte_base_i32 : i32 to offset
-  %zero = index.constant 0 : index
+  %vector_origin = index.constant 0 : index
   %input_view = buffer.view %input[%row_byte_base] : buffer -> view<210xi32, #dense>
   %output_view = buffer.view %output[%output_row_byte_base] : buffer -> view<4xi32, #dense>
-  %value = vector.load %input_view[%zero] : view<210xi32, #dense> -> vector<4xi32>
-  vector.store %value, %output_view[%zero] : vector<4xi32>, view<4xi32, #dense>
+  %value = vector.load %input_view[%vector_origin] : view<210xi32, #dense> -> vector<4xi32>
+  vector.store %value, %output_view[%vector_origin] : vector<4xi32>, view<4xi32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_packed_half_atomic.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_packed_half_atomic.loom-test
@@ -7,10 +7,10 @@ kernel.def target(@target) @lds_packed_f16_atomic_add() {
 } launch(%value: vector<2xf16>) {
   %c0 = index.constant 0 : index
   %c1 = index.constant 1 : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xf16, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xf16, #dense>
   %offsets = vector.iota %c0 step %c1 : vector<2xindex>
   vector.atomic.reduce<addf> %value, %scratch_view[0][%offsets] {ordering = relaxed, scope = workgroup} : vector<2xf16>, view<32xf16, #dense>, vector<2xindex>
   %old = vector.atomic.rmw<addf> %value, %scratch_view[0][%offsets] {ordering = relaxed, scope = workgroup} : vector<2xf16>, view<32xf16, #dense>, vector<2xindex>
@@ -35,10 +35,10 @@ kernel.def target(@target) @lds_packed_f16_atomic_add_from_elements_offsets() {
 } launch(%value: vector<2xf16>) {
   %c0 = index.constant 0 : index
   %c1 = index.constant 1 : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xf16, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xf16, #dense>
   %offsets = vector.from_elements %c0, %c1 : vector<2xindex>
   vector.atomic.reduce<addf> %value, %scratch_view[0][%offsets] {ordering = relaxed, scope = workgroup} : vector<2xf16>, view<32xf16, #dense>, vector<2xindex>
   %old = vector.atomic.rmw<addf> %value, %scratch_view[0][%offsets] {ordering = relaxed, scope = workgroup} : vector<2xf16>, view<32xf16, #dense>, vector<2xindex>
@@ -63,10 +63,10 @@ kernel.def target(@target) @lds_packed_bf16_atomic_add() {
 } launch(%value: vector<2xbf16>) {
   %c0 = index.constant 0 : index
   %c1 = index.constant 1 : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xbf16, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xbf16, #dense>
   %offsets = vector.iota %c0 step %c1 : vector<2xindex>
   vector.atomic.reduce<addf> %value, %scratch_view[0][%offsets] {ordering = relaxed, scope = workgroup} : vector<2xbf16>, view<32xbf16, #dense>, vector<2xindex>
   %old = vector.atomic.rmw<addf> %value, %scratch_view[0][%offsets] {ordering = relaxed, scope = workgroup} : vector<2xbf16>, view<32xbf16, #dense>, vector<2xindex>
@@ -91,10 +91,10 @@ kernel.def target(@target) @global_packed_f16_atomic_add() {
 } launch(%input: buffer, %value: vector<2xf16>) {
   %c0 = index.constant 0 : index
   %c1 = index.constant 1 : index
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
   %global_aligned = buffer.assume.alignment %global {minimum_alignment = 4} : buffer
-  %view = buffer.view %global_aligned[%zero] : buffer -> view<64xf16, #dense>
+  %view = buffer.view %global_aligned[%input_base] : buffer -> view<64xf16, #dense>
   %offsets = vector.iota %c0 step %c1 : vector<2xindex>
   vector.atomic.reduce<addf> %value, %view[0][%offsets] {ordering = relaxed, scope = device} : vector<2xf16>, view<64xf16, #dense>, vector<2xindex>
   %old = vector.atomic.rmw<addf> %value, %view[0][%offsets] {ordering = relaxed, scope = device} : vector<2xf16>, view<64xf16, #dense>, vector<2xindex>
@@ -116,10 +116,10 @@ amdgpu.target<gfx12-generic> @target
 func.def target(@target) @generic_packed_f16_atomic_add(%input: buffer, %value: vector<2xf16>) {
   %c0 = index.constant 0 : index
   %c1 = index.constant 1 : index
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %generic = buffer.assume.memory_space<generic> %input : buffer
   %generic_aligned = buffer.assume.alignment %generic {minimum_alignment = 4} : buffer
-  %view = buffer.view %generic_aligned[%zero] : buffer -> view<64xf16, #dense>
+  %view = buffer.view %generic_aligned[%input_base] : buffer -> view<64xf16, #dense>
   %offsets = vector.iota %c0 step %c1 : vector<2xindex>
   vector.atomic.reduce<addf> %value, %view[0][%offsets] {ordering = relaxed, scope = device} : vector<2xf16>, view<64xf16, #dense>, vector<2xindex>
   %old = vector.atomic.rmw<addf> %value, %view[0][%offsets] {ordering = relaxed, scope = device} : vector<2xf16>, view<64xf16, #dense>, vector<2xindex>
@@ -149,10 +149,10 @@ kernel.def target(@target) @lds_half4_atomic_rejected() {
 } launch(%value: vector<4xf16>) {
   %c0 = index.constant 0 : index
   %c1 = index.constant 1 : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xf16, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xf16, #dense>
   %offsets = vector.iota %c0 step %c1 : vector<4xindex>
   // ERROR@+1: AMDGPU/023 {constraint_key="atomic.shape"}
   vector.atomic.reduce<addf> %value, %scratch_view[0][%offsets] {ordering = relaxed, scope = workgroup} : vector<4xf16>, view<32xf16, #dense>, vector<4xindex>
@@ -168,10 +168,10 @@ kernel.def target(@target) @lds_packed_f16_atomic_non_adjacent_rejected() {
 } launch(%value: vector<2xf16>) {
   %c0 = index.constant 0 : index
   %c2 = index.constant 2 : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xf16, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xf16, #dense>
   %offsets = vector.iota %c0 step %c2 : vector<2xindex>
   // ERROR@+1: AMDGPU/023 {constraint_key="atomic.shape"}
   vector.atomic.reduce<addf> %value, %scratch_view[0][%offsets] {ordering = relaxed, scope = workgroup} : vector<2xf16>, view<32xf16, #dense>, vector<2xindex>
@@ -187,10 +187,10 @@ kernel.def target(@target) @lds_packed_f16_atomic_misaligned_rejected() {
 } launch(%value: vector<2xf16>) {
   %c0 = index.constant 0 : index
   %c1 = index.constant 1 : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xf16, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xf16, #dense>
   %offsets = vector.iota %c0 step %c1 : vector<2xindex>
   // ERROR@+1: AMDGPU/023 {constraint_key="atomic.shape"}
   vector.atomic.reduce<addf> %value, %scratch_view[1][%offsets] {ordering = relaxed, scope = workgroup} : vector<2xf16>, view<32xf16, #dense>, vector<2xindex>
@@ -206,10 +206,10 @@ kernel.def target(@target) @lds_packed_f16_atomic_device_scope_rejected() {
 } launch(%value: vector<2xf16>) {
   %c0 = index.constant 0 : index
   %c1 = index.constant 1 : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xf16, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xf16, #dense>
   %offsets = vector.iota %c0 step %c1 : vector<2xindex>
   // ERROR@+1: AMDGPU/023 {constraint_key="atomic.scope"}
   vector.atomic.reduce<addf> %value, %scratch_view[0][%offsets] {ordering = relaxed, scope = device} : vector<2xf16>, view<32xf16, #dense>, vector<2xindex>
@@ -225,10 +225,10 @@ kernel.def target(@target) @lds_packed_f16_atomic_unsupported_target_rejected() 
 } launch(%value: vector<2xf16>) {
   %c0 = index.constant 0 : index
   %c1 = index.constant 1 : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xf16, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xf16, #dense>
   %offsets = vector.iota %c0 step %c1 : vector<2xindex>
   // ERROR@+1: AMDGPU/023 {constraint_key="atomic.descriptor_missing"}
   vector.atomic.reduce<addf> %value, %scratch_view[0][%offsets] {ordering = relaxed, scope = workgroup} : vector<2xf16>, view<32xf16, #dense>, vector<2xindex>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_packed_half_loads.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_packed_half_loads.loom-test
@@ -7,11 +7,11 @@ kernel.def target(@target) @adjacent_f16_scalar_loads_pack() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %one = index.constant 1 : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf16, #dense>
-  %next = index.add %lane, %one : index
+  %buffer_base = index.constant 0 : offset
+  %next_element_offset = index.constant 1 : index
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf16, #dense>
+  %next = index.add %lane, %next_element_offset : index
   %a = view.load %input_view[%lane] : view<64xf16, #dense> -> f16
   %b = view.load %input_view[%next] : view<64xf16, #dense> -> f16
   view.store %a, %output_view[%lane] : f16, view<64xf16, #dense>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_private.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_private.loom-test
@@ -7,12 +7,12 @@ kernel.def target(@target) @private_f32_dynamic_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = private} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %loaded = vector.load %input_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   vector.store %loaded, %scratch_view[%lane] : vector<1xf32>, view<64xf32, #dense>
   %roundtrip = vector.load %scratch_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
@@ -43,23 +43,23 @@ kernel.def target(@target) @private_root_static_offsets() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %one = index.constant 1 : index
+  %buffer_base = index.constant 0 : offset
+  %second_index_offset = index.constant 1 : index
   %first_bytes = index.constant 8 : offset
   %first = buffer.alloca %first_bytes {base_alignment = 4, memory_space = private} : buffer
   %second_bytes = index.constant 16 : offset
   %second = buffer.alloca %second_bytes {base_alignment = 8, memory_space = private} : buffer
-  %first_view = buffer.view %first[%zero] : buffer -> view<2xi32, #dense>
-  %second_view = buffer.view %second[%zero] : buffer -> view<4xi32, #dense>
-  %input_view = buffer.view %input[%zero] : buffer -> view<2xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xi32, #dense>
+  %first_view = buffer.view %first[%buffer_base] : buffer -> view<2xi32, #dense>
+  %second_view = buffer.view %second[%buffer_base] : buffer -> view<4xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<2xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xi32, #dense>
   %lhs = view.load %input_view[0] : view<2xi32, #dense> -> i32
   view.store %lhs, %first_view[0] : i32, view<2xi32, #dense>
   %rhs = view.load %input_view[1] : view<2xi32, #dense> -> i32
   view.store %rhs, %first_view[1] : i32, view<2xi32, #dense>
   view.store %lhs, %second_view[1] : i32, view<4xi32, #dense>
   view.store %rhs, %second_view[2] : i32, view<4xi32, #dense>
-  %second_index = index.add %lane, %one : index
+  %second_index = index.add %lane, %second_index_offset : index
   %first_loaded = view.load %first_view[%lane] : view<2xi32, #dense> -> i32
   %second_loaded = view.load %second_view[%second_index] : view<4xi32, #dense> -> i32
   view.store %first_loaded, %output_view[%lane] : i32, view<4xi32, #dense>
@@ -98,12 +98,12 @@ kernel.def target(@target) @private_f16_static_and_dynamic_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero_offset = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 4 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 2, memory_space = private} : buffer
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<2xf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero_offset] : buffer -> view<2xf16, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<2xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<2xf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<2xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<2xf16, #dense>
   %static_value = view.load %input_view[0] : view<2xf16, #dense> -> f16
   view.store %static_value, %scratch_view[0] : f16, view<2xf16, #dense>
   %dynamic_value = view.load %input_view[%lane] : view<2xf16, #dense> -> f16
@@ -145,12 +145,12 @@ kernel.def target(@target) @private_bf16_static_and_dynamic_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero_offset = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 4 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 2, memory_space = private} : buffer
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<2xbf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero_offset] : buffer -> view<2xbf16, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<2xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<2xbf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<2xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<2xbf16, #dense>
   %static_value = view.load %input_view[0] : view<2xbf16, #dense> -> bf16
   view.store %static_value, %scratch_view[0] : bf16, view<2xbf16, #dense>
   %dynamic_value = view.load %input_view[%lane] : view<2xbf16, #dense> -> bf16
@@ -192,12 +192,12 @@ kernel.def target(@target) @private_i8_static_and_dynamic_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero_offset = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 2 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 1, memory_space = private} : buffer
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<2xi8, #dense>
-  %scratch_view = buffer.view %scratch[%zero_offset] : buffer -> view<2xi8, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<2xi8, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<2xi8, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<2xi8, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<2xi8, #dense>
   %static_value = view.load %input_view[0] : view<2xi8, #dense> -> i8
   view.store %static_value, %scratch_view[0] : i8, view<2xi8, #dense>
   %dynamic_value = view.load %input_view[%lane] : view<2xi8, #dense> -> i8

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_report.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_report.loom-test
@@ -24,12 +24,12 @@ kernel.def target(@target) @report_static_lds_address_fields() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 4 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<1xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[0] : vector<1xi32>, view<1xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<1xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[0] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
 
@@ -57,12 +57,12 @@ kernel.def target(@target) @report_lds_f16_subword_stride_fields() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<128xf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<128xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<128xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<128xf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<128xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<128xf16, #dense>
   %loaded = vector.load %input_view[%tid] : view<128xf16, #dense> -> vector<2xf16>
   vector.store %loaded, %scratch_view[%tid] : vector<2xf16>, view<128xf16, #dense>
   %roundtrip = vector.load %scratch_view[%tid] : view<128xf16, #dense> -> vector<2xf16>
@@ -108,14 +108,14 @@ kernel.def target(@target) @report_lds_read2_write2_address_fields() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 2048 : offset
   %layout = encoding.layout.strided [8, 2] : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, %layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x2xi32, #dense>
-  %one = vector.constant 1 : vector<2xi32>
-  vector.store %one, %scratch_view[%tid, 0] : vector<2xi32>, view<64x4xi32, %layout>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, %layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x2xi32, #dense>
+  %stored_value = vector.constant 1 : vector<2xi32>
+  vector.store %stored_value, %scratch_view[%tid, 0] : vector<2xi32>, view<64x4xi32, %layout>
   %loaded = vector.load %scratch_view[%tid, 0] : view<64x4xi32, %layout> -> vector<2xi32>
   vector.store %loaded, %output_view[%tid, 0] : vector<2xi32>, view<64x2xi32, #dense>
   kernel.return
@@ -154,12 +154,12 @@ kernel.def target(@target) @report_lds_b128_single_lane_extract() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %scratch_view[%tid, 0] : vector<4xi32>, view<64x4xi32, #dense>
   %roundtrip = vector.load %scratch_view[%tid, 0] : view<64x4xi32, #dense> -> vector<4xi32>
@@ -205,11 +205,11 @@ kernel.def target(@target) @report_global_and_descriptor_load_families() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%global_input: buffer, %descriptor_input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %global_view = buffer.view %global_input[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %global_view = buffer.view %global_input[%buffer_base] : buffer -> view<1xi32, #dense>
   %descriptor_buffer = buffer.assume.memory_space<descriptor> %descriptor_input : buffer
-  %descriptor_view = buffer.view %descriptor_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %descriptor_view = buffer.view %descriptor_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %global_value = view.load %global_view[0] : view<1xi32, #dense> -> i32
   %descriptor_value = view.load %descriptor_view[0] : view<1xi32, #dense> -> i32
   %sum = scalar.addi %global_value, %descriptor_value : i32
@@ -252,11 +252,11 @@ kernel.def target(@target) @report_bf16_result_fragment_packets() {
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16x16xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16x16xbf16, #dense>
   %packed = vector.fragment.load<result> %input_view[0, 0] shape [%m, %n] : view<16x16xbf16, #dense> -> vector<8xbf16>
   %wide = vector.extf %packed : vector<8xbf16> to vector<8xf32>
   vector.fragment.store<result> %wide, %output_view[0, 0] shape [%m, %n] : vector<8xf32>, view<16x16xbf16, #dense>
@@ -444,15 +444,15 @@ kernel.def target(@target) @report_fp8_fragment_finite_only_packed_decode_cdna3(
   %workgroup_size = index.constant 64 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e4m3, payload_elements=16, payload_registers=4, rounding=finite_only> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E4M3, %input_storage>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E4M3, %input_storage>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E4M3, %input_storage> -> vector<4xbf16>
   vector.store %loaded, %output_view[0] : vector<4xbf16>, view<4xbf16, #dense>
   kernel.return
@@ -490,15 +490,15 @@ kernel.def target(@target) @report_bf8_fragment_finite_only_packed_decode_cdna3(
   %workgroup_size = index.constant 64 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e5m2, payload_elements=16, payload_registers=4, rounding=finite_only> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E5M2, %input_storage>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E5M2, %input_storage>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E5M2, %input_storage> -> vector<4xbf16>
   vector.store %loaded, %output_view[0] : vector<4xbf16>, view<4xbf16, #dense>
   kernel.return
@@ -603,21 +603,21 @@ kernel.def target(@target) @report_launch_subgroup_fragment_footprint() {
   %workgroup_size = index.constant 64 : index
   kernel.launch.config workgroups(%workgroup_count, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %four = index.constant 4 : index
-  %six = index.constant 6 : index
+  %buffer_base = index.constant 0 : offset
+  %column_origin = index.constant 0 : index
+  %subgroup_row_shift = index.constant 4 : index
+  %workgroup_row_shift = index.constant 6 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %workgroup = kernel.workgroup.id<x> : index
   %subgroup = kernel.subgroup.id : index
-  %workgroup_base = index.shli %workgroup, %six : index
-  %subgroup_base = index.shli %subgroup, %four : index
+  %workgroup_base = index.shli %workgroup, %workgroup_row_shift : index
+  %subgroup_base = index.shli %subgroup, %subgroup_row_shift : index
   %row = index.add %workgroup_base, %subgroup_base : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<4096x16xf8E4M3, %input_layout>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<16xbf16, #dense>
-  %loaded = vector.fragment.load<rhs> %input_view[%row, %zero] shape [%k, %n] : view<4096x16xf8E4M3, %input_layout> -> vector<16xbf16>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4096x16xf8E4M3, %input_layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xbf16, #dense>
+  %loaded = vector.fragment.load<rhs> %input_view[%row, %column_origin] shape [%k, %n] : view<4096x16xf8E4M3, %input_layout> -> vector<16xbf16>
   vector.store %loaded, %output_view[0] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
 }
@@ -662,13 +662,13 @@ kernel.def target(@target) @report_fp8_fragment_exact_packed_decode() {
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E4M3, %input_layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E4M3, %input_layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E4M3, %input_layout> -> vector<16xbf16>
   vector.store %loaded, %output_view[0] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
@@ -707,15 +707,15 @@ kernel.def target(@target) @report_fp8_fragment_finite_nan_storage_packed_decode
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #fp8_e4m3fn : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E4M3, %input_storage>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E4M3, %input_storage>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E4M3, %input_storage> -> vector<16xbf16>
   vector.store %loaded, %output_view[0] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
@@ -754,15 +754,15 @@ kernel.def target(@target) @report_fp8_fragment_finite_only_storage_packed_decod
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<affine=scale_only, element_format=f8e4m3fn, payload_elements=16, payload_packing=dense_lanes, payload_registers=0, rounding=finite_only, scale_format=f32, scale_group_elements=16, scale_operands=1, scale_topology=block_1d> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E4M3, %input_storage>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E4M3, %input_storage>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E4M3, %input_storage> -> vector<16xbf16>
   vector.store %loaded, %output_view[0] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
@@ -801,15 +801,15 @@ kernel.def target(@target) @report_fp8_fragment_compact_finite_only_storage_deco
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e4m3, payload_elements=1, payload_registers=1, rounding=finite_only> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E4M3, %input_storage>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E4M3, %input_storage>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E4M3, %input_storage> -> vector<16xbf16>
   vector.store %loaded, %output_view[0] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
@@ -848,15 +848,15 @@ kernel.def target(@target) @report_fp8_fragment_finite_packed_decode() {
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e4m3fn, payload_elements=16, payload_registers=4, rounding=finite_flush_subnormal> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E4M3, %input_storage>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E4M3, %input_storage>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E4M3, %input_storage> -> vector<16xbf16>
   vector.store %loaded, %output_view[0] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
@@ -895,15 +895,15 @@ kernel.def target(@target) @report_fp8_fragment_f16_finite_only_storage_decode()
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e4m3, payload_elements=16, payload_registers=4, rounding=finite_only> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E4M3, %input_storage>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E4M3, %input_storage>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E4M3, %input_storage> -> vector<16xf16>
   vector.store %loaded, %output_view[0] : vector<16xf16>, view<16xf16, #dense>
   kernel.return
@@ -942,15 +942,15 @@ kernel.def target(@target) @report_fp8_fragment_f16_finite_packed_decode() {
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e4m3fn, payload_elements=16, payload_registers=4, rounding=finite_flush_subnormal> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E4M3, %input_storage>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E4M3, %input_storage>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E4M3, %input_storage> -> vector<16xf16>
   vector.store %loaded, %output_view[0] : vector<16xf16>, view<16xf16, #dense>
   kernel.return
@@ -989,13 +989,13 @@ kernel.def target(@target) @report_bf8_fragment_exact_packed_decode() {
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E5M2, %input_layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E5M2, %input_layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E5M2, %input_layout> -> vector<16xbf16>
   vector.store %loaded, %output_view[0] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
@@ -1034,15 +1034,15 @@ kernel.def target(@target) @report_bf8_fragment_finite_only_decode() {
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e5m2, payload_elements=16, payload_registers=4, rounding=finite_only> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E5M2, %input_storage>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E5M2, %input_storage>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E5M2, %input_storage> -> vector<16xbf16>
   vector.store %loaded, %output_view[0] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
@@ -1081,15 +1081,15 @@ kernel.def target(@target) @report_bf8_fragment_finite_packed_decode() {
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e5m2, payload_elements=16, payload_registers=4, rounding=finite_flush_subnormal> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E5M2, %input_storage>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E5M2, %input_storage>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E5M2, %input_storage> -> vector<16xbf16>
   vector.store %loaded, %output_view[0] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
@@ -1128,13 +1128,13 @@ kernel.def target(@target) @report_fp8_fragment_native_decode() {
   %workgroup_size = index.constant 64 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E4M3, %input_layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E4M3, %input_layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E4M3, %input_layout> -> vector<4xbf16>
   vector.store %loaded, %output_view[0] : vector<4xbf16>, view<4xbf16, #dense>
   kernel.return
@@ -1172,13 +1172,13 @@ kernel.def target(@target) @report_bf8_fragment_native_decode() {
   %workgroup_size = index.constant 64 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E5M2, %input_layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E5M2, %input_layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E5M2, %input_layout> -> vector<4xbf16>
   vector.store %loaded, %output_view[0] : vector<4xbf16>, view<4xbf16, #dense>
   kernel.return
@@ -1216,13 +1216,13 @@ kernel.def target(@target) @report_fp8_fragment_native_f16_pair_cdna4() {
   %workgroup_size = index.constant 64 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 32 : index
   %input_layout = encoding.layout.strided [1, 32] : encoding<layout>
-  %input_view = buffer.view %input[%zero] : buffer -> view<32x16xf8E4M3, %input_layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<8xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32x16xf8E4M3, %input_layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<8xf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<32x16xf8E4M3, %input_layout> -> vector<8xf16>
   vector.store %loaded, %output_view[0] : vector<8xf16>, view<8xf16, #dense>
   kernel.return
@@ -1260,13 +1260,13 @@ kernel.def target(@target) @report_bf8_fragment_native_f16_pair_cdna4() {
   %workgroup_size = index.constant 64 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 32 : index
   %input_layout = encoding.layout.strided [1, 32] : encoding<layout>
-  %input_view = buffer.view %input[%zero] : buffer -> view<32x16xf8E5M2, %input_layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<8xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32x16xf8E5M2, %input_layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<8xf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<32x16xf8E5M2, %input_layout> -> vector<8xf16>
   vector.store %loaded, %output_view[0] : vector<8xf16>, view<8xf16, #dense>
   kernel.return
@@ -1304,15 +1304,15 @@ kernel.def target(@target) @report_fp8_fragment_native_f32_pair_cdna3() {
   %workgroup_size = index.constant 64 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e4m3fnuz, payload_elements=16, payload_registers=4> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E4M3, %input_storage>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E4M3, %input_storage>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E4M3, %input_storage> -> vector<4xbf16>
   vector.store %loaded, %output_view[0] : vector<4xbf16>, view<4xbf16, #dense>
   kernel.return
@@ -1350,15 +1350,15 @@ kernel.def target(@target) @report_bf8_fragment_native_f32_pair_cdna3() {
   %workgroup_size = index.constant 64 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %input_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %input_schema = encoding.define #matrix_operand<element_format=f8e5m2fnuz, payload_elements=16, payload_registers=4> : encoding<schema>
   %input_storage = encoding.define #physical_storage {layout = %input_layout : encoding<layout>, schema = %input_schema : encoding<schema>} : encoding<storage>
-  %input_view = buffer.view %input[%zero] : buffer -> view<16x16xf8E5M2, %input_storage>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16x16xf8E5M2, %input_storage>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<16x16xf8E5M2, %input_storage> -> vector<4xbf16>
   vector.store %loaded, %output_view[0] : vector<4xbf16>, view<4xbf16, #dense>
   kernel.return
@@ -1396,13 +1396,13 @@ kernel.def target(@target) @report_fp8_fragment_native_f32_pair_rdna4() {
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 32 : index
   %input_layout = encoding.layout.strided [1, 32] : encoding<layout>
-  %input_view = buffer.view %input[%zero] : buffer -> view<32x16xf8E4M3, %input_layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32x16xf8E4M3, %input_layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<32x16xf8E4M3, %input_layout> -> vector<16xbf16>
   vector.store %loaded, %output_view[0] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
@@ -1441,13 +1441,13 @@ kernel.def target(@target) @report_bf8_fragment_native_f32_pair_rdna4() {
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 32 : index
   %input_layout = encoding.layout.strided [1, 32] : encoding<layout>
-  %input_view = buffer.view %input[%zero] : buffer -> view<32x16xf8E5M2, %input_layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32x16xf8E5M2, %input_layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xbf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<32x16xf8E5M2, %input_layout> -> vector<16xbf16>
   vector.store %loaded, %output_view[0] : vector<16xbf16>, view<16xbf16, #dense>
   kernel.return
@@ -1486,13 +1486,13 @@ kernel.def target(@target) @report_fp8_fragment_native_f16_pair_rdna4() {
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 32 : index
   %input_layout = encoding.layout.strided [1, 32] : encoding<layout>
-  %input_view = buffer.view %input[%zero] : buffer -> view<32x16xf8E4M3, %input_layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32x16xf8E4M3, %input_layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<32x16xf8E4M3, %input_layout> -> vector<16xf16>
   vector.store %loaded, %output_view[0] : vector<16xf16>, view<16xf16, #dense>
   kernel.return
@@ -1531,13 +1531,13 @@ kernel.def target(@target) @report_bf8_fragment_native_f16_pair_rdna4() {
   %workgroup_size = index.constant 32 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 32 : index
   %input_layout = encoding.layout.strided [1, 32] : encoding<layout>
-  %input_view = buffer.view %input[%zero] : buffer -> view<32x16xf8E5M2, %input_layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32x16xf8E5M2, %input_layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xf16, #dense>
   %loaded = vector.fragment.load<rhs> %input_view[0, 0] shape [%k, %n] : view<32x16xf8E5M2, %input_layout> -> vector<16xf16>
   vector.store %loaded, %output_view[0] : vector<16xf16>, view<16xf16, #dense>
   kernel.return

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_report_cfg_loops.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_report_cfg_loops.loom-test
@@ -7,18 +7,18 @@ kernel.def target(@target) @report_nested_cfg_loop_memory_counts() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
-  %eight = index.constant 8 : index
-  %zero_f32 = scalar.constant 0.0 : f32
+  %c0 = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %outer_end = index.constant 4 : index
+  %inner_end = index.constant 8 : index
+  %initial_sum = scalar.constant 0.0 : f32
   %input_global = buffer.assume.memory_space<global> %input : buffer
   %output_global = buffer.assume.memory_space<global> %output : buffer
   %input_view = buffer.view %input_global[%base] : buffer -> view<64xf32, #dense>
   %output_view = buffer.view %output_global[%base] : buffer -> view<64xf32, #dense>
-  %sum = scf.for %outer = [%zero to %four step %one](%current = %zero_f32 : f32) -> (f32) {
-    %row_base = index.mul %outer, %eight : index
-    %inner_sum = scf.for %inner = [%zero to %eight step %one](%inner_current = %current : f32) -> (f32) {
+  %sum = scf.for %outer = [%c0 to %outer_end step %loop_step](%current = %initial_sum : f32) -> (f32) {
+    %row_base = index.mul %outer, %inner_end : index
+    %inner_sum = scf.for %inner = [%c0 to %inner_end step %loop_step](%inner_current = %current : f32) -> (f32) {
       %position = index.add %row_base, %inner : index
       %loaded = view.load %input_view[%position] : view<64xf32, #dense> -> f32
       %next = scalar.addf<reassoc|nnan|nsz> %inner_current, %loaded : f32
@@ -29,7 +29,7 @@ kernel.def target(@target) @report_nested_cfg_loop_memory_counts() {
     view.store %tail_value, %output_view[%row_base] : f32, view<64xf32, #dense>
     scf.yield %inner_sum : f32
   }
-  view.store %sum, %output_view[%zero] : f32, view<64xf32, #dense>
+  view.store %sum, %output_view[%c0] : f32, view<64xf32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_workgroup_atomic.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_workgroup_atomic.loom-test
@@ -7,13 +7,13 @@ kernel.def target(@target) @lds_atomic_add_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
-  %old = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
+  %old = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -34,16 +34,16 @@ kernel.def target(@target) @lds_atomic_scalar_loop_index_i32() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
-  %zero = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %eight = index.constant 8 : index
-  %one_index = index.constant 1 : index
+  %scratch_base = index.constant 0 : offset
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 8 : index
+  %loop_step = index.constant 1 : index
   %bytes = index.constant 32 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<8xi32, #dense>
-  %one = scalar.constant 1 : i32
-  scf.for %i = [%zero_index to %eight step %one_index] {
-    view.atomic.reduce<addi> %one, %scratch_view[%i] {ordering = relaxed, scope = workgroup} : i32, view<8xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<8xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  scf.for %i = [%loop_begin to %loop_end step %loop_step] {
+    view.atomic.reduce<addi> %increment, %scratch_view[%i] {ordering = relaxed, scope = workgroup} : i32, view<8xi32, #dense>
   }
   kernel.return
 }
@@ -51,13 +51,13 @@ kernel.def target(@target) @lds_atomic_scalar_loop_index_i32() {
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @lds_atomic_scalar_loop_index_i32() asm {
   %15 = storage {byte_alignment = 4, byte_length = 32} : low.storage<workgroup>
-  %zero_index = s_mov_b32 0
-  %eight = s_mov_b32 8
-  %one_index = s_mov_b32 1
+  %loop_begin = s_mov_b32 0
+  %loop_end = s_mov_b32 8
+  %loop_step = s_mov_b32 1
   %scratch_view = storage_address %15 : low.storage<workgroup> -> reg<amdgpu.vgpr>
-  low.br ^_bb1(%zero_index: reg<amdgpu.sgpr>)
+  low.br ^_bb1(%loop_begin: reg<amdgpu.sgpr>)
 ^_bb1(%i: reg<amdgpu.sgpr>):
-  %21 = s_cmp_lt_i32 %i, %eight
+  %21 = s_cmp_lt_i32 %i, %loop_end
   low.cond_br %21, ^_bb2, ^_bb3 : reg<amdgpu.scc>
 ^_bb2:
   %22 = v_mov_b32_copy %i
@@ -65,7 +65,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %24 = v_add_u32 %scratch_view, %23
   %25 = v_mov_b32 1
   ds_add_u32 %24, %25
-  %26 = s_add_u32 %i, %one_index
+  %26 = s_add_u32 %i, %loop_step
   low.br ^_bb1(%26: reg<amdgpu.sgpr>)
 ^_bb3:
   return
@@ -79,16 +79,16 @@ kernel.def target(@target) @lds_atomic_ordering_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %scratch_view[%tid] {ordering = release, scope = workgroup} : i32, view<64xi32, #dense>
-  %old_acquire = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = acquire, scope = workgroup} : i32, view<64xi32, #dense> -> i32
-  %old_release = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = release, scope = workgroup} : i32, view<64xi32, #dense> -> i32
-  %old_acq_rel = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = acq_rel, scope = workgroup} : i32, view<64xi32, #dense> -> i32
-  %old_seq_cst = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = seq_cst, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %scratch_view[%tid] {ordering = release, scope = workgroup} : i32, view<64xi32, #dense>
+  %old_acquire = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = acquire, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %old_release = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = release, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %old_acq_rel = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = acq_rel, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %old_seq_cst = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = seq_cst, scope = workgroup} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -113,13 +113,13 @@ kernel.def target(@target) @lds_atomic_add_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xf32, #dense>
-  %one = scalar.constant 1.0 : f32
-  view.atomic.reduce<addf> %one, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense>
-  %old = view.atomic.rmw<addf> %one, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense> -> f32
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xf32, #dense>
+  %increment = scalar.constant 1.0 : f32
+  view.atomic.reduce<addf> %increment, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense>
+  %old = view.atomic.rmw<addf> %increment, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense> -> f32
   kernel.return
 }
 
@@ -127,9 +127,9 @@ kernel.def target(@target) @lds_atomic_add_f32() {
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @lds_atomic_add_f32() asm {
   %9 = storage {byte_alignment = 4, byte_length = 256} : low.storage<workgroup>
   %scratch_view = storage_address %9 : low.storage<workgroup> -> reg<amdgpu.vgpr>
-  %one = v_mov_b32 1065353216
-  ds_add_f32 %scratch_view, %one
-  %old = ds_add_rtn_f32 %scratch_view, %one
+  %increment = v_mov_b32 1065353216
+  ds_add_f32 %scratch_view, %increment
+  %old = ds_add_rtn_f32 %scratch_view, %increment
   return
 }
 
@@ -141,10 +141,10 @@ kernel.def target(@target) @lds_atomic_minnum_maxnum_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xf32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xf32, #dense>
   %limit = scalar.constant 1.0 : f32
   view.atomic.reduce<minnumf> %limit, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense>
   view.atomic.reduce<maxnumf> %limit, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense>
@@ -173,10 +173,10 @@ kernel.def target(@target) @lds_atomic_bitwise_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %mask = scalar.constant 255 : i32
   view.atomic.reduce<andi> %mask, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
   view.atomic.reduce<ori> %mask, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
@@ -209,10 +209,10 @@ kernel.def target(@target) @lds_atomic_sub_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %delta = scalar.constant 1 : i32
   view.atomic.reduce<subi> %delta, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
   %old_sub = view.atomic.rmw<subi> %delta, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
@@ -237,10 +237,10 @@ kernel.def target(@target) @lds_atomic_exchange_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %value = scalar.constant 7 : i32
   %old = view.atomic.rmw<xchgi> %value, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
   kernel.return
@@ -263,10 +263,10 @@ kernel.def target(@target) @lds_atomic_cmpxchg_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old = view.atomic.cmpxchg %expected, %replacement, %scratch_view[%tid] {failure_ordering = relaxed, scope = workgroup, success_ordering = relaxed} : i32, view<64xi32, #dense> -> i32
@@ -291,10 +291,10 @@ kernel.def target(@target) @lds_atomic_minmax_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %limit = scalar.constant 1 : i32
   view.atomic.reduce<minsi> %limit, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
   view.atomic.reduce<maxsi> %limit, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
@@ -331,29 +331,30 @@ kernel.def target(@target) @lds_atomic_second_alloca_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %first_bytes = index.constant 64 : offset
   %second_bytes = index.constant 256 : offset
   %first_scratch = buffer.alloca %first_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %second_scratch = buffer.alloca %second_bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %first_view = buffer.view %first_scratch[%zero] : buffer -> view<16xi32, #dense>
-  %second_view = buffer.view %second_scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.store %one, %first_view[%tid] : i32, view<16xi32, #dense>
-  view.atomic.reduce<addi> %one, %second_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
-  %old = view.atomic.rmw<addi> %one, %second_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %first_view = buffer.view %first_scratch[%scratch_base] : buffer -> view<16xi32, #dense>
+  %second_view = buffer.view %second_scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %initial_value = scalar.constant 1 : i32
+  %increment = scalar.constant 1 : i32
+  view.store %initial_value, %first_view[%tid] : i32, view<16xi32, #dense>
+  view.atomic.reduce<addi> %increment, %second_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
+  %old = view.atomic.rmw<addi> %increment, %second_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @lds_atomic_second_alloca_i32() asm {
-  %12 = storage {byte_alignment = 16, byte_length = 64} : low.storage<workgroup>
-  %13 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
-  %second_view = storage_address %13 : low.storage<workgroup> -> reg<amdgpu.vgpr>
-  %17 = v_mov_b32 1
-  %18 = v_mov_b32 0
-  low.op<amdgpu.ds_write_b32>(%18, %17) {offset = 0} memory_access([0, 3, 5, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
-  ds_add_u32 %second_view, %17
-  %old = ds_add_rtn_u32 %second_view, %17
+  %13 = storage {byte_alignment = 16, byte_length = 64} : low.storage<workgroup>
+  %14 = storage {byte_alignment = 16, byte_length = 256} : low.storage<workgroup>
+  %second_view = storage_address %14 : low.storage<workgroup> -> reg<amdgpu.vgpr>
+  %18 = v_mov_b32 1
+  %19 = v_mov_b32 0
+  low.op<amdgpu.ds_write_b32>(%19, %18) {offset = 0} memory_access([0, 3, 5, -1, 11, 0, 0, 0, 3, 0, 0, 4, 4]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>)
+  ds_add_u32 %second_view, %18
+  %old = ds_add_rtn_u32 %second_view, %18
   return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_workgroup_b128.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_workgroup_b128.loom-test
@@ -8,12 +8,12 @@ kernel.def target(@target) @lds_b128_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
@@ -44,12 +44,12 @@ kernel.def target(@target) @lds_b128_single_lane_extract() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
@@ -83,12 +83,12 @@ kernel.def target(@target) @lds_b128_xor_swizzle_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %shift = index.constant 4 : index
   %shifted = index.shrui %lane, %shift : index
   %mask = index.constant 3 : index
@@ -129,13 +129,13 @@ kernel.def target(@target) @lds_b128_large_static_offset_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %large = index.constant 1024 : offset
   %bytes = index.constant 4096 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %scratch_view = buffer.view %scratch[%large] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
@@ -166,15 +166,15 @@ kernel.def target(@target) @lds_b128_split_second_alloca_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %first_bytes = index.constant 64 : offset
   %second_bytes = index.constant 2048 : offset
   %first = buffer.alloca %first_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %second = buffer.alloca %second_bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %first_view = buffer.view %first[%zero] : buffer -> view<16xi32, #dense>
-  %second_view = buffer.view %second[%zero] : buffer -> view<64x8xi32, #dense>
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x8xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x8xi32, #dense>
+  %first_view = buffer.view %first[%buffer_base] : buffer -> view<16xi32, #dense>
+  %second_view = buffer.view %second[%buffer_base] : buffer -> view<64x8xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x8xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x8xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x8xi32, #dense> -> vector<8xi32>
   vector.store %loaded, %second_view[%lane, 0] : vector<8xi32>, view<64x8xi32, #dense>
   %roundtrip = vector.load %second_view[%lane, 0] : view<64x8xi32, #dense> -> vector<8xi32>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_workgroup_packed16.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_workgroup_packed16.loom-test
@@ -8,12 +8,12 @@ kernel.def target(@target) @lds_f16x4_b64_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 512 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 8, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xf16, #dense> -> vector<4xf16>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xf16>, view<64x4xf16, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xf16, #dense> -> vector<4xf16>
@@ -44,12 +44,12 @@ kernel.def target(@target) @lds_f16x8_b128_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x8xf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x8xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x8xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x8xf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x8xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x8xf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x8xf16, #dense> -> vector<8xf16>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<8xf16>, view<64x8xf16, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x8xf16, #dense> -> vector<8xf16>
@@ -143,12 +143,12 @@ kernel.def target(@target) @lds_bf16x4_b64_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 512 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 8, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xbf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xbf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xbf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xbf16, #dense> -> vector<4xbf16>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xbf16>, view<64x4xbf16, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xbf16, #dense> -> vector<4xbf16>
@@ -179,12 +179,12 @@ kernel.def target(@target) @lds_bf16x8_b128_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x8xbf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x8xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x8xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x8xbf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x8xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x8xbf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x8xbf16, #dense> -> vector<8xbf16>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<8xbf16>, view<64x8xbf16, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x8xbf16, #dense> -> vector<8xbf16>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_minmax.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_minmax.loom-test
@@ -189,24 +189,24 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @scf_sel
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @scf_select_q6_nibble_i8(%code: i32, %use_high: i32) -> (i8) {
-  %zero = scalar.constant 0 : i32
-  %four = scalar.constant 4 : i32
+  %low_selector = scalar.constant 0 : i32
+  %nibble_shift = scalar.constant 4 : i32
   %mask = scalar.constant 15 : i32
-  %high_shifted = scalar.shrui %code, %four : i32
+  %high_shifted = scalar.shrui %code, %nibble_shift : i32
   %low_i32 = scalar.andi %code, %mask : i32
   %high_i32 = scalar.andi %high_shifted, %mask : i32
   %low = scalar.trunci %low_i32 : i32 to i8
   %high = scalar.trunci %high_i32 : i32 to i8
-  %cond = scalar.cmpi ne, %use_high, %zero : i32
+  %cond = scalar.cmpi ne, %use_high, %low_selector : i32
   %selected = scf.select %cond, %high, %low : i8
   func.return %selected : i8
 }
 
 // ----
 low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @scf_select_q6_nibble_i8(%code: reg<amdgpu.sgpr>, %use_high: reg<amdgpu.sgpr>) -> (reg<amdgpu.vgpr>) asm {
-  %four = s_mov_b32 4
+  %nibble_shift = s_mov_b32 4
   %mask = s_mov_b32 15
-  %high_shifted = s_lshr_b32 %code, %four
+  %high_shifted = s_lshr_b32 %code, %nibble_shift
   %low_i32 = s_and_b32 %code, %mask
   %high_i32 = s_and_b32 %high_shifted, %mask
   %21 = v_mov_b32_copy %low_i32
@@ -223,22 +223,22 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @scf_sel
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @scf_select_scale_piece_i16(%packed: i32, %use_high: i32) -> (i16) {
-  %zero = scalar.constant 0 : i32
-  %sixteen = scalar.constant 16 : i32
+  %low_selector = scalar.constant 0 : i32
+  %halfword_shift = scalar.constant 16 : i32
   %low = scalar.trunci %packed : i32 to i16
-  %high_shifted = scalar.shrui %packed, %sixteen : i32
+  %high_shifted = scalar.shrui %packed, %halfword_shift : i32
   %high = scalar.trunci %high_shifted : i32 to i16
-  %cond = scalar.cmpi ne, %use_high, %zero : i32
+  %cond = scalar.cmpi ne, %use_high, %low_selector : i32
   %selected = scf.select %cond, %high, %low : i16
   func.return %selected : i16
 }
 
 // ----
 low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @scf_select_scale_piece_i16(%packed: reg<amdgpu.sgpr>, %use_high: reg<amdgpu.sgpr>) -> (reg<amdgpu.vgpr>) asm {
-  %sixteen = s_mov_b32 16
+  %halfword_shift = s_mov_b32 16
   %14 = v_mov_b32_copy %packed
   %low = v_bfe_i32_offset_width_inline %14 {offset = 0, width = 16}
-  %high_shifted = s_lshr_b32 %packed, %sixteen
+  %high_shifted = s_lshr_b32 %packed, %halfword_shift
   %17 = v_mov_b32_copy %high_shifted
   %high = v_bfe_i32_offset_width_inline %17 {offset = 0, width = 16}
   %19 = v_mov_b32_copy %use_high
@@ -292,9 +292,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @scf_sel
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @scf_select_tail_zero_i32(%values: vector<2xi32>, %limit: i32) -> (i32) {
   %lane = vector.extract %values[0] : vector<2xi32> -> i32
-  %zero = scalar.constant 0 : i32
+  %tail_fill = scalar.constant 0 : i32
   %cond = scalar.cmpi slt, %lane, %limit : i32
-  %selected = scf.select %cond, %lane, %zero : i32
+  %selected = scf.select %cond, %lane, %tail_fill : i32
   func.return %selected : i32
 }
 
@@ -654,10 +654,10 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @scf_sel
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @scf_select_i1_scc_condition(%lhs: i32, %rhs: i32, %alt: i32, %true_value: f32, %false_value: f32) -> (f32) {
-  %zero = scalar.constant 0 : i32
+  %inactive_condition = scalar.constant 0 : i32
   %condition = scalar.cmpi slt, %lhs, %rhs : i32
-  %lhs_nonzero = scalar.cmpi ne, %lhs, %zero : i32
-  %alt_nonzero = scalar.cmpi ne, %alt, %zero : i32
+  %lhs_nonzero = scalar.cmpi ne, %lhs, %inactive_condition : i32
+  %alt_nonzero = scalar.cmpi ne, %alt, %inactive_condition : i32
   %selected_condition = scf.select %condition, %lhs_nonzero, %alt_nonzero : i1
   %result = scf.select %selected_condition, %true_value, %false_value : f32
   func.return %result : f32
@@ -665,20 +665,20 @@ func.def target(@target) @scf_select_i1_scc_condition(%lhs: i32, %rhs: i32, %alt
 
 // ----
 low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @scf_select_i1_scc_condition(%lhs: reg<amdgpu.sgpr>, %rhs: reg<amdgpu.sgpr>, %alt: reg<amdgpu.sgpr>, %true_value: reg<amdgpu.vgpr>, %false_value: reg<amdgpu.vgpr>) -> (reg<amdgpu.vgpr>) asm {
-  %zero = s_mov_b32 0
+  %inactive_condition = s_mov_b32 0
   %19 = s_cmp_lt_i32 %lhs, %rhs
   %21 = s_mov_b32 1
-  %condition = s_cselect_b32 %21, %zero, %19
-  %lhs_nonzero = s_cmp_lg_i32 %lhs, %zero
-  %alt_nonzero = s_cmp_lg_i32 %alt, %zero
+  %condition = s_cselect_b32 %21, %inactive_condition, %19
+  %lhs_nonzero = s_cmp_lg_i32 %lhs, %inactive_condition
+  %alt_nonzero = s_cmp_lg_i32 %alt, %inactive_condition
   %25 = s_cmp_lg_i32_src1_inline %condition {rhs = 0}
   %26 = s_mov_b64_exec_read
   %27 = slice %26[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %28 = slice %26[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
-  %30 = s_cselect_b32 %27, %zero, %lhs_nonzero
-  %31 = s_cselect_b32 %28, %zero, %lhs_nonzero
-  %37 = s_cselect_b32 %27, %zero, %alt_nonzero
-  %38 = s_cselect_b32 %28, %zero, %alt_nonzero
+  %30 = s_cselect_b32 %27, %inactive_condition, %lhs_nonzero
+  %31 = s_cselect_b32 %28, %inactive_condition, %lhs_nonzero
+  %37 = s_cselect_b32 %27, %inactive_condition, %alt_nonzero
+  %38 = s_cselect_b32 %28, %inactive_condition, %alt_nonzero
   %42 = s_cselect_b32 %30, %37, %25
   %45 = s_cselect_b32 %31, %38, %25
   %selected_condition = concat(%42, %45) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
@@ -700,8 +700,8 @@ kernel.def target(@target) @index_minmax_vgpr_select() {
   %max = index.max %lane, %limit : index
   %cond = index.cmp slt, %lane, %limit : index
   %selected = scf.select %cond, %min, %max : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<64xi32, #dense>
   %stored = vector.constant 1 : vector<1xi32>
   vector.store %stored, %output_view[%selected] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
@@ -726,9 +726,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @f32_reduce_minnum_maxnum(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<2xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<2xf32, #dense>
   %loaded = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %min_init = scalar.constant 1000.0 : f32
   %min = vector.reduce<minnumf, reassoc|nnan|nsz> %loaded, %min_init : vector<4xf32>, f32

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_minmax_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_minmax_diagnostics.loom-test
@@ -26,9 +26,9 @@ kernel.def target(@target) @global_atomic_ieee_minimum_rejected() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xf32, #dense>
+  %view = buffer.view %global[%input_base] : buffer -> view<64xf32, #dense>
   %limit = scalar.constant 1.0 : f32
   // ERROR@+1: AMDGPU/023 {constraint_key="atomic.kind"}
   view.atomic.reduce<minimumf> %limit, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
@@ -44,10 +44,10 @@ kernel.def target(@target) @lds_atomic_ieee_maximum_rejected() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xf32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xf32, #dense>
   %limit = scalar.constant 1.0 : f32
   // ERROR@+1: AMDGPU/023 {constraint_key="atomic.kind"}
   view.atomic.reduce<maximumf> %limit, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_ml_attention.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_ml_attention.loom-test
@@ -50,12 +50,12 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @online_
 
 amdgpu.target<gfx11-generic> @target
 kernel.def target(@target) @attention_probability_value_mma_repack() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%probabilities: vector<8xf32>, %values: vector<16xbf16>, %init_accumulator: vector<8xf32>, %output_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %output_origin = index.constant 0 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -67,7 +67,7 @@ kernel.def target(@target) @attention_probability_value_mma_repack() {
   %rhs = vector.fragment<rhs> %values shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %init_accumulator shape [%m, %n] : vector<8xf32>
   %output = vector.mma %lhs, %rhs, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
-  vector.fragment.store<result> %output, %output_view[%zero, %zero] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %output, %output_view[%output_origin, %output_origin] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 
@@ -192,13 +192,15 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 
 
 amdgpu.target<gfx11-generic> @target
 kernel.def target(@target) @attention_loop_carried_accumulator_barrier() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values0: vector<16xbf16>, %rhs_values1: vector<16xbf16>, %init_accumulator: vector<8xf32>, %output_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
+  %output_origin = index.constant 0 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -208,7 +210,7 @@ kernel.def target(@target) @attention_loop_carried_accumulator_barrier() {
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xbf16>
   %rhs0 = vector.fragment<rhs> %rhs_values0 shape [%k, %n] : vector<16xbf16>
   %rhs1 = vector.fragment<rhs> %rhs_values1 shape [%k, %n] : vector<16xbf16>
-  %carried = scf.for %tile = [%zero to %one step %one](%accumulator = %init_accumulator : vector<8xf32>) -> (vector<8xf32>) {
+  %carried = scf.for %tile = [%loop_begin to %loop_end step %loop_step](%accumulator = %init_accumulator : vector<8xf32>) -> (vector<8xf32>) {
     %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
     %next = vector.mma %lhs, %rhs0, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
@@ -216,36 +218,36 @@ kernel.def target(@target) @attention_loop_carried_accumulator_barrier() {
   }
   %carried_init = vector.fragment<init> %carried shape [%m, %n] : vector<8xf32>
   %output = vector.mma %lhs, %rhs1, %carried_init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
-  vector.fragment.store<result> %output, %output_view[%zero, %zero] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %output, %output_view[%output_origin, %output_origin] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @attention_loop_carried_accumulator_barrier(%lhs: reg<amdgpu.vgpr x8>, %rhs0: reg<amdgpu.vgpr x8>, %rhs1: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>) asm {
-  %30 = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
+  %32 = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
-  %32 = copy %init : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
-  %carried_init = v_wmma_f32_16x16x16_bf16 %lhs, %rhs0, %32
+  %34 = copy %init : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
+  %carried_init = v_wmma_f32_16x16x16_bf16 %lhs, %rhs0, %34
   s_barrier
-  %34 = copy %carried_init : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
-  %output = v_wmma_f32_16x16x16_bf16 %lhs, %rhs1, %34
-  %36 = v_lshlrev_b32_src0_inline %30, 2
-  %37 = slice %output[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  global_store_b32_saddr %36, %37, %output_view
-  %38 = slice %output[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  global_store_b32_saddr %36, %38, %output_view {offset = 128}
-  %39 = slice %output[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  global_store_b32_saddr %36, %39, %output_view {offset = 256}
-  %40 = slice %output[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  global_store_b32_saddr %36, %40, %output_view {offset = 384}
-  %41 = slice %output[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  global_store_b32_saddr %36, %41, %output_view {offset = 512}
-  %42 = slice %output[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  global_store_b32_saddr %36, %42, %output_view {offset = 640}
-  %43 = slice %output[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  global_store_b32_saddr %36, %43, %output_view {offset = 768}
-  %44 = slice %output[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  global_store_b32_saddr %36, %44, %output_view {offset = 896}
+  %36 = copy %carried_init : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
+  %output = v_wmma_f32_16x16x16_bf16 %lhs, %rhs1, %36
+  %38 = v_lshlrev_b32_src0_inline %32, 2
+  %39 = slice %output[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  global_store_b32_saddr %38, %39, %output_view
+  %40 = slice %output[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  global_store_b32_saddr %38, %40, %output_view {offset = 128}
+  %41 = slice %output[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  global_store_b32_saddr %38, %41, %output_view {offset = 256}
+  %42 = slice %output[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  global_store_b32_saddr %38, %42, %output_view {offset = 384}
+  %43 = slice %output[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  global_store_b32_saddr %38, %43, %output_view {offset = 512}
+  %44 = slice %output[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  global_store_b32_saddr %38, %44, %output_view {offset = 640}
+  %45 = slice %output[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  global_store_b32_saddr %38, %45, %output_view {offset = 768}
+  %46 = slice %output[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  global_store_b32_saddr %38, %46, %output_view {offset = 896}
   return
 }
 
@@ -253,25 +255,27 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 
 
 amdgpu.target<gfx11-generic> @target
 kernel.def target(@target) @attention_tail_peel_accumulator_merge() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values0: vector<16xbf16>, %rhs_values1: vector<16xbf16>, %init_accumulator: vector<8xf32>, %tail_tile_count: i32, %output_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %zero_i32 = scalar.constant 0 : i32
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
+  %output_origin = index.constant 0 : index
+  %no_tail_tiles = scalar.constant 0 : i32
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
-  %has_tail_tile = scalar.cmpi ne, %tail_tile_count, %zero_i32 : i32
+  %has_tail_tile = scalar.cmpi ne, %tail_tile_count, %no_tail_tiles : i32
   %output_global = buffer.assume.memory_space<global> %output_buffer : buffer
   %output_aligned = buffer.assume.alignment %output_global {minimum_alignment = 16} : buffer
   %output_view = buffer.view %output_aligned[%base] : buffer -> view<16x16xf32, #dense>
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xbf16>
   %rhs0 = vector.fragment<rhs> %rhs_values0 shape [%k, %n] : vector<16xbf16>
   %rhs1 = vector.fragment<rhs> %rhs_values1 shape [%k, %n] : vector<16xbf16>
-  %carried = scf.for %tile = [%zero to %one step %one](%accumulator = %init_accumulator : vector<8xf32>) -> (vector<8xf32>) {
+  %carried = scf.for %tile = [%loop_begin to %loop_end step %loop_step](%accumulator = %init_accumulator : vector<8xf32>) -> (vector<8xf32>) {
     %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
     %next = vector.mma %lhs, %rhs0, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     scf.yield %next : vector<8xf32>
@@ -283,51 +287,51 @@ kernel.def target(@target) @attention_tail_peel_accumulator_merge() {
   } else {
     scf.yield %carried : vector<8xf32>
   }
-  vector.fragment.store<result> %output_accumulator, %output_view[%zero, %zero] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %output_accumulator, %output_view[%output_origin, %output_origin] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @attention_tail_peel_accumulator_merge(%lhs: reg<amdgpu.vgpr x8>, %rhs0: reg<amdgpu.vgpr x8>, %rhs1: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>, %tail_tile_count: reg<amdgpu.sgpr>) asm {
-  %37 = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
+  %39 = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
-  %zero_i32 = s_mov_b32 0
-  %40 = copy %init : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
-  %tail_init = v_wmma_f32_16x16x16_bf16 %lhs, %rhs0, %40
-  %has_tail_tile = s_cmp_lg_i32 %tail_tile_count, %zero_i32
+  %no_tail_tiles = s_mov_b32 0
+  %42 = copy %init : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
+  %tail_init = v_wmma_f32_16x16x16_bf16 %lhs, %rhs0, %42
+  %has_tail_tile = s_cmp_lg_i32 %tail_tile_count, %no_tail_tiles
   low.cond_br %has_tail_tile, ^_bb1, ^_bb2 : reg<amdgpu.scc>
 ^_bb1:
-  %43 = copy %tail_init : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
-  %tail = v_wmma_f32_16x16x16_bf16 %lhs, %rhs1, %43
-  %62 = slice %tail[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  %63 = slice %tail[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  %64 = slice %tail[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  %65 = slice %tail[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  %66 = slice %tail[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  %67 = slice %tail[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  %68 = slice %tail[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  %69 = slice %tail[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  low.br ^_bb3(%62: reg<amdgpu.vgpr>, %63: reg<amdgpu.vgpr>, %64: reg<amdgpu.vgpr>, %65: reg<amdgpu.vgpr>, %66: reg<amdgpu.vgpr>, %67: reg<amdgpu.vgpr>, %68: reg<amdgpu.vgpr>, %69: reg<amdgpu.vgpr>)
+  %45 = copy %tail_init : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
+  %tail = v_wmma_f32_16x16x16_bf16 %lhs, %rhs1, %45
+  %64 = slice %tail[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %65 = slice %tail[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %66 = slice %tail[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %67 = slice %tail[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %68 = slice %tail[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %69 = slice %tail[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %70 = slice %tail[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %71 = slice %tail[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  low.br ^_bb3(%64: reg<amdgpu.vgpr>, %65: reg<amdgpu.vgpr>, %66: reg<amdgpu.vgpr>, %67: reg<amdgpu.vgpr>, %68: reg<amdgpu.vgpr>, %69: reg<amdgpu.vgpr>, %70: reg<amdgpu.vgpr>, %71: reg<amdgpu.vgpr>)
 ^_bb2:
-  %70 = slice %tail_init[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  %71 = slice %tail_init[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  %72 = slice %tail_init[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  %73 = slice %tail_init[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  %74 = slice %tail_init[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  %75 = slice %tail_init[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  %76 = slice %tail_init[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  %77 = slice %tail_init[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
-  low.br ^_bb3(%70: reg<amdgpu.vgpr>, %71: reg<amdgpu.vgpr>, %72: reg<amdgpu.vgpr>, %73: reg<amdgpu.vgpr>, %74: reg<amdgpu.vgpr>, %75: reg<amdgpu.vgpr>, %76: reg<amdgpu.vgpr>, %77: reg<amdgpu.vgpr>)
-^_bb3(%54: reg<amdgpu.vgpr>, %55: reg<amdgpu.vgpr>, %56: reg<amdgpu.vgpr>, %57: reg<amdgpu.vgpr>, %58: reg<amdgpu.vgpr>, %59: reg<amdgpu.vgpr>, %60: reg<amdgpu.vgpr>, %61: reg<amdgpu.vgpr>):
-  %45 = v_lshlrev_b32_src0_inline %37, 2
-  global_store_b32_saddr %45, %54, %output_view
-  global_store_b32_saddr %45, %55, %output_view {offset = 128}
-  global_store_b32_saddr %45, %56, %output_view {offset = 256}
-  global_store_b32_saddr %45, %57, %output_view {offset = 384}
-  global_store_b32_saddr %45, %58, %output_view {offset = 512}
-  global_store_b32_saddr %45, %59, %output_view {offset = 640}
-  global_store_b32_saddr %45, %60, %output_view {offset = 768}
-  global_store_b32_saddr %45, %61, %output_view {offset = 896}
+  %72 = slice %tail_init[0] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %73 = slice %tail_init[1] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %74 = slice %tail_init[2] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %75 = slice %tail_init[3] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %76 = slice %tail_init[4] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %77 = slice %tail_init[5] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %78 = slice %tail_init[6] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  %79 = slice %tail_init[7] : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr>
+  low.br ^_bb3(%72: reg<amdgpu.vgpr>, %73: reg<amdgpu.vgpr>, %74: reg<amdgpu.vgpr>, %75: reg<amdgpu.vgpr>, %76: reg<amdgpu.vgpr>, %77: reg<amdgpu.vgpr>, %78: reg<amdgpu.vgpr>, %79: reg<amdgpu.vgpr>)
+^_bb3(%56: reg<amdgpu.vgpr>, %57: reg<amdgpu.vgpr>, %58: reg<amdgpu.vgpr>, %59: reg<amdgpu.vgpr>, %60: reg<amdgpu.vgpr>, %61: reg<amdgpu.vgpr>, %62: reg<amdgpu.vgpr>, %63: reg<amdgpu.vgpr>):
+  %47 = v_lshlrev_b32_src0_inline %39, 2
+  global_store_b32_saddr %47, %56, %output_view
+  global_store_b32_saddr %47, %57, %output_view {offset = 128}
+  global_store_b32_saddr %47, %58, %output_view {offset = 256}
+  global_store_b32_saddr %47, %59, %output_view {offset = 384}
+  global_store_b32_saddr %47, %60, %output_view {offset = 512}
+  global_store_b32_saddr %47, %61, %output_view {offset = 640}
+  global_store_b32_saddr %47, %62, %output_view {offset = 768}
+  global_store_b32_saddr %47, %63, %output_view {offset = 896}
   return
 }
 
@@ -344,10 +348,10 @@ func.def target(@target) @tail_masked_score_block(%scores: vector<4xf32>, %valid
   %sentinels = vector.splat %negative_large : vector<4xf32>
   %masked_scores = vector.select %valid, %scores, %sentinels : vector<4xf32>
   %block_max = vector.reduce<maxnumf, reassoc|nnan|nsz> %masked_scores, %negative_large : vector<4xf32>, f32
-  %zero = scalar.constant 0.0 : f32
-  %zeros = vector.splat %zero : vector<4xf32>
-  %sum_scores = vector.select %valid, %scores, %zeros : vector<4xf32>
-  %block_sum = vector.reduce<addf, reassoc|nnan|nsz> %sum_scores, %zero : vector<4xf32>, f32
+  %sum_identity = scalar.constant 0.0 : f32
+  %sum_identity_vector = vector.splat %sum_identity : vector<4xf32>
+  %sum_scores = vector.select %valid, %scores, %sum_identity_vector : vector<4xf32>
+  %block_sum = vector.reduce<addf, reassoc|nnan|nsz> %sum_scores, %sum_identity : vector<4xf32>, f32
   func.return %block_max, %block_sum : f32, f32
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_ml_attention_report.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_ml_attention_report.loom-test
@@ -5,25 +5,25 @@ amdgpu.target<gfx11-generic> @target
 // A uniform tail-tile branch should keep the WMMA work attributable to the
 // source operations that shape the full-tile and tail paths.
 kernel.def target(@target) @report_attention_tail_peel_accumulator_merge() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values0: vector<16xbf16>, %rhs_values1: vector<16xbf16>, %init_accumulator: vector<8xf32>, %tail_tile_count: i32, %output_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %zero_i32 = scalar.constant 0 : i32
+  %c0 = index.constant 0 : index
+  %c1 = index.constant 1 : index
+  %no_tail_tiles = scalar.constant 0 : i32
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
-  %has_tail_tile = scalar.cmpi ne, %tail_tile_count, %zero_i32 : i32
+  %has_tail_tile = scalar.cmpi ne, %tail_tile_count, %no_tail_tiles : i32
   %output_global = buffer.assume.memory_space<global> %output_buffer : buffer
   %output_aligned = buffer.assume.alignment %output_global {minimum_alignment = 16} : buffer
   %output_view = buffer.view %output_aligned[%base] : buffer -> view<16x16xf32, #dense>
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xbf16>
   %rhs0 = vector.fragment<rhs> %rhs_values0 shape [%k, %n] : vector<16xbf16>
   %rhs1 = vector.fragment<rhs> %rhs_values1 shape [%k, %n] : vector<16xbf16>
-  %carried = scf.for %tile = [%zero to %one step %one](%accumulator = %init_accumulator : vector<8xf32>) -> (vector<8xf32>) {
+  %carried = scf.for %tile = [%c0 to %c1 step %c1](%accumulator = %init_accumulator : vector<8xf32>) -> (vector<8xf32>) {
     %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
     %next = vector.mma %lhs, %rhs0, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     scf.yield %next : vector<8xf32>
@@ -35,7 +35,7 @@ kernel.def target(@target) @report_attention_tail_peel_accumulator_merge() {
   } else {
     scf.yield %carried : vector<8xf32>
   }
-  vector.fragment.store<result> %output_accumulator, %output_view[%zero, %zero] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %output_accumulator, %output_view[%c0, %c0] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_ml_contraction.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_ml_contraction.loom-test
@@ -204,13 +204,13 @@ kernel.def target(@target) @workgroup_cached_dot4i_u8s8_tile() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output_buffer: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64x16xi8, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64x16xi8, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x16xi8, #dense>
-  %output_view = buffer.view %output_buffer[%zero] : buffer -> view<64x4xi32, #dense>
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64x16xi8, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64x16xi8, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x16xi8, #dense>
+  %output_view = buffer.view %output_buffer[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %lhs = vector.load %lhs_view[%lane, 0] : view<64x16xi8, #dense> -> vector<16xi8>
   vector.store %lhs, %scratch_view[%lane, 0] : vector<16xi8>, view<64x16xi8, #dense>
   %lhs_cached = vector.load %scratch_view[%lane, 0] : view<64x16xi8, #dense> -> vector<16xi8>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_ml_contraction_gfx12.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_ml_contraction_gfx12.loom-test
@@ -224,13 +224,13 @@ kernel.def target(@target) @workgroup_cached_dot4i_u8s8_tile() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output_buffer: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64x16xi8, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64x16xi8, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x16xi8, #dense>
-  %output_view = buffer.view %output_buffer[%zero] : buffer -> view<64x4xi32, #dense>
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64x16xi8, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64x16xi8, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x16xi8, #dense>
+  %output_view = buffer.view %output_buffer[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %lhs = vector.load %lhs_view[%lane, 0] : view<64x16xi8, #dense> -> vector<16xi8>
   vector.store %lhs, %scratch_view[%lane, 0] : vector<16xi8>, view<64x16xi8, #dense>
   %lhs_cached = vector.load %scratch_view[%lane, 0] : view<64x16xi8, #dense> -> vector<16xi8>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma.loom-test
@@ -23,15 +23,15 @@ low.func.def target<amdgpu.rdna3.core>(@target) abi(hal_kernel) @f16_wmmar3(%lhs
 
 amdgpu.target<gfx1100> @target
 func.def target(@target) @f16_wmmar3_static_k_loop_unroll(%lhs_data: vector<16xf16>, %rhs_data: vector<16xf16>, %init_data: vector<8xf32>) -> (vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
-  %thirty_two = index.constant 32 : index
+  %k_begin = index.constant 0 : index
+  %k_tile_size = index.constant 16 : index
+  %k_extent = index.constant 32 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
-  %lhs = vector.fragment<lhs> %lhs_data shape [%m, %sixteen] : vector<16xf16>
-  %rhs = vector.fragment<rhs> %rhs_data shape [%sixteen, %n] : vector<16xf16>
+  %lhs = vector.fragment<lhs> %lhs_data shape [%m, %k_tile_size] : vector<16xf16>
+  %rhs = vector.fragment<rhs> %rhs_data shape [%k_tile_size, %n] : vector<16xf16>
   %init = vector.fragment<init> %init_data shape [%m, %n] : vector<8xf32>
-  %result = scf.for %ki = [%zero to %thirty_two step %sixteen](%acc = %init : vector<8xf32>) -> (vector<8xf32>) unroll {
+  %result = scf.for %ki = [%k_begin to %k_extent step %k_tile_size](%acc = %init : vector<8xf32>) -> (vector<8xf32>) unroll {
     %next = vector.mma %lhs, %rhs, %acc : vector<16xf16>, vector<16xf16>, vector<8xf32>
     scf.yield %next : vector<8xf32>
   }
@@ -51,16 +51,16 @@ low.func.def target<amdgpu.rdna3.core>(@target) abi(hal_kernel) @f16_wmmar3_stat
 
 amdgpu.target<gfx1100> @target
 func.def target(@target) @bf16_wmmar3_loop_carried_accumulator(%lhs_data: vector<16xbf16>, %rhs_data: vector<16xbf16>, %init_data: vector<8xf32>) -> (vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %k_tile_begin = index.constant 0 : index
+  %k_tile_step = index.constant 1 : index
+  %k_tile_end = index.constant 2 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %lhs = vector.fragment<lhs> %lhs_data shape [%m, %k] : vector<16xbf16>
   %rhs = vector.fragment<rhs> %rhs_data shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %init_data shape [%m, %n] : vector<8xf32>
-  %result = scf.for %k_tile = [%zero to %two step %one](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
+  %result = scf.for %k_tile = [%k_tile_begin to %k_tile_end step %k_tile_step](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
     %next = vector.mma %lhs, %rhs, %acc : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     scf.yield %next : vector<8xf32>
   }
@@ -69,17 +69,17 @@ func.def target(@target) @bf16_wmmar3_loop_carried_accumulator(%lhs_data: vector
 
 // ----
 low.func.def target<amdgpu.rdna3.core>(@target) abi(hal_kernel) @bf16_wmmar3_loop_carried_accumulator(%lhs: reg<amdgpu.vgpr x8>, %rhs: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>) -> (reg<amdgpu.vgpr x8>) asm {
-  %zero = s_mov_b32 0
-  %one = s_mov_b32 1
-  %two = s_mov_b32 2
-  low.br ^_bb1(%zero: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x8>)
+  %k_tile_begin = s_mov_b32 0
+  %k_tile_step = s_mov_b32 1
+  %k_tile_end = s_mov_b32 2
+  low.br ^_bb1(%k_tile_begin: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x8>)
 ^_bb1(%k_tile: reg<amdgpu.sgpr>, %acc: reg<amdgpu.vgpr x8>):
-  %32 = s_cmp_lt_i32 %k_tile, %two
+  %32 = s_cmp_lt_i32 %k_tile, %k_tile_end
   low.cond_br %32, ^_bb2, ^_bb3 : reg<amdgpu.scc>
 ^_bb2:
   %33 = copy %acc : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
   %next = v_wmma_f32_16x16x16_bf16 %lhs, %rhs, %33
-  %35 = s_add_u32 %k_tile, %one
+  %35 = s_add_u32 %k_tile, %k_tile_step
   low.br ^_bb1(%35: reg<amdgpu.sgpr>, %next: reg<amdgpu.vgpr x8>)
 ^_bb3:
   return %acc
@@ -89,16 +89,16 @@ low.func.def target<amdgpu.rdna3.core>(@target) abi(hal_kernel) @bf16_wmmar3_loo
 
 amdgpu.target<gfx1100> @target
 func.def target(@target) @bf16_wmmar3_four_loop_carried_accumulators(%lhs_data: vector<16xbf16>, %rhs_data: vector<16xbf16>, %init_data: vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %k_tile_begin = index.constant 0 : index
+  %k_tile_step = index.constant 1 : index
+  %k_tile_end = index.constant 2 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %lhs = vector.fragment<lhs> %lhs_data shape [%m, %k] : vector<16xbf16>
   %rhs = vector.fragment<rhs> %rhs_data shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %init_data shape [%m, %n] : vector<8xf32>
-  %result0, %result1, %result2, %result3 = scf.for %k_tile = [%zero to %two step %one](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
+  %result0, %result1, %result2, %result3 = scf.for %k_tile = [%k_tile_begin to %k_tile_end step %k_tile_step](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
     %next0 = vector.mma %lhs, %rhs, %acc0 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     %next1 = vector.mma %lhs, %rhs, %acc1 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     %next2 = vector.mma %lhs, %rhs, %acc2 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
@@ -110,12 +110,12 @@ func.def target(@target) @bf16_wmmar3_four_loop_carried_accumulators(%lhs_data: 
 
 // ----
 low.func.def target<amdgpu.rdna3.core>(@target) abi(hal_kernel) @bf16_wmmar3_four_loop_carried_accumulators(%lhs: reg<amdgpu.vgpr x8>, %rhs: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>) -> (reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>) asm {
-  %zero = s_mov_b32 0
-  %one = s_mov_b32 1
-  %two = s_mov_b32 2
-  low.br ^_bb1(%zero: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>)
+  %k_tile_begin = s_mov_b32 0
+  %k_tile_step = s_mov_b32 1
+  %k_tile_end = s_mov_b32 2
+  low.br ^_bb1(%k_tile_begin: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>)
 ^_bb1(%k_tile: reg<amdgpu.sgpr>, %acc0: reg<amdgpu.vgpr x8>, %acc1: reg<amdgpu.vgpr x8>, %acc2: reg<amdgpu.vgpr x8>, %acc3: reg<amdgpu.vgpr x8>):
-  %56 = s_cmp_lt_i32 %k_tile, %two
+  %56 = s_cmp_lt_i32 %k_tile, %k_tile_end
   low.cond_br %56, ^_bb2, ^_bb3 : reg<amdgpu.scc>
 ^_bb2:
   %57 = copy %acc0 : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
@@ -126,7 +126,7 @@ low.func.def target<amdgpu.rdna3.core>(@target) abi(hal_kernel) @bf16_wmmar3_fou
   %next2 = v_wmma_f32_16x16x16_bf16 %lhs, %rhs, %61
   %63 = copy %acc3 : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
   %next3 = v_wmma_f32_16x16x16_bf16 %lhs, %rhs, %63
-  %65 = s_add_u32 %k_tile, %one
+  %65 = s_add_u32 %k_tile, %k_tile_step
   low.br ^_bb1(%65: reg<amdgpu.sgpr>, %next0: reg<amdgpu.vgpr x8>, %next1: reg<amdgpu.vgpr x8>, %next2: reg<amdgpu.vgpr x8>, %next3: reg<amdgpu.vgpr x8>)
 ^_bb3:
   return %acc0, %acc1, %acc2, %acc3
@@ -571,8 +571,8 @@ kernel.def target(@target) @bf16_wmmar3_f32_acc_bf16_epilogue() {
   %out_view = buffer.view %out_buffer[%base] : buffer -> view<16x16xbf16, #dense>
   %lhs = vector.fragment.load<lhs> %lhs_view[0, 0] shape [%m, %k] : view<16x16xbf16, #dense> -> vector<16xbf16>
   %rhs = vector.fragment.load<rhs> %rhs_view[0, 0] shape [%k, %n] : view<16x16xbf16, %rhs_layout> -> vector<16xbf16>
-  %zero_values = vector.constant 0.0 : vector<8xf32>
-  %init = vector.fragment<init> %zero_values shape [%m, %n] : vector<8xf32>
+  %initial_values = vector.constant 0.0 : vector<8xf32>
+  %init = vector.fragment<init> %initial_values shape [%m, %n] : vector<8xf32>
   %result = vector.mma %lhs, %rhs, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
   %scale = view.load %scale_view[0] : view<1xf32, #dense> -> f32
   %scale_vector = vector.splat %scale : vector<8xf32>
@@ -690,8 +690,8 @@ kernel.def target(@target) @bf16_wmmar3_two_k_blocks_fragment_memory() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %out_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %fragment_origin = index.constant 0 : index
+  %k_block_size = index.constant 16 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -699,15 +699,15 @@ kernel.def target(@target) @bf16_wmmar3_two_k_blocks_fragment_memory() {
   %lhs_view = buffer.view %lhs_buffer[%base] : buffer -> view<16x32xbf16, #dense>
   %rhs_view = buffer.view %rhs_buffer[%base] : buffer -> view<32x16xbf16, %rhs_layout>
   %out_view = buffer.view %out_buffer[%base] : buffer -> view<16x16xf32, #dense>
-  %lhs0 = vector.fragment.load<lhs> %lhs_view[%zero, %zero] shape [%m, %k] : view<16x32xbf16, #dense> -> vector<16xbf16>
-  %rhs0 = vector.fragment.load<rhs> %rhs_view[%zero, %zero] shape [%k, %n] : view<32x16xbf16, %rhs_layout> -> vector<16xbf16>
-  %zero_values = vector.constant 0.0 : vector<8xf32>
-  %zero_acc = vector.fragment<init> %zero_values shape [%m, %n] : vector<8xf32>
+  %lhs0 = vector.fragment.load<lhs> %lhs_view[%fragment_origin, %fragment_origin] shape [%m, %k] : view<16x32xbf16, #dense> -> vector<16xbf16>
+  %rhs0 = vector.fragment.load<rhs> %rhs_view[%fragment_origin, %fragment_origin] shape [%k, %n] : view<32x16xbf16, %rhs_layout> -> vector<16xbf16>
+  %initial_values = vector.constant 0.0 : vector<8xf32>
+  %zero_acc = vector.fragment<init> %initial_values shape [%m, %n] : vector<8xf32>
   %partial = vector.mma %lhs0, %rhs0, %zero_acc : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
-  %lhs1 = vector.fragment.load<lhs> %lhs_view[%zero, %sixteen] shape [%m, %k] : view<16x32xbf16, #dense> -> vector<16xbf16>
-  %rhs1 = vector.fragment.load<rhs> %rhs_view[%sixteen, %zero] shape [%k, %n] : view<32x16xbf16, %rhs_layout> -> vector<16xbf16>
+  %lhs1 = vector.fragment.load<lhs> %lhs_view[%fragment_origin, %k_block_size] shape [%m, %k] : view<16x32xbf16, #dense> -> vector<16xbf16>
+  %rhs1 = vector.fragment.load<rhs> %rhs_view[%k_block_size, %fragment_origin] shape [%k, %n] : view<32x16xbf16, %rhs_layout> -> vector<16xbf16>
   %result = vector.mma %lhs1, %rhs1, %partial : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
-  vector.fragment.store<result> %result, %out_view[%zero, %zero] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %result, %out_view[%fragment_origin, %fragment_origin] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 
@@ -913,26 +913,26 @@ kernel.def target(@target) @f16_wmmar3_wave64_dynamic_fragment_origins() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %out_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %two = index.constant 2 : index
+  %k_origin = index.constant 0 : index
+  %subgroup_grid_width = index.constant 2 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
-  %sixty_four = index.constant 64 : index
+  %quadrant_extent = index.constant 64 : index
   %rhs_layout = encoding.layout.strided [1, 16] : encoding<layout>
   %subgroup_raw = kernel.subgroup.id : index
   %subgroup = index.assume %subgroup_raw [range(%subgroup_raw, 0, 3)] : index
-  %quadrant_row = index.div %subgroup, %two : index
-  %quadrant_column = index.rem %subgroup, %two : index
-  %row_origin_raw = index.mul %quadrant_row, %sixty_four : index
-  %column_origin_raw = index.mul %quadrant_column, %sixty_four : index
+  %quadrant_row = index.div %subgroup, %subgroup_grid_width : index
+  %quadrant_column = index.rem %subgroup, %subgroup_grid_width : index
+  %row_origin_raw = index.mul %quadrant_row, %quadrant_extent : index
+  %column_origin_raw = index.mul %quadrant_column, %quadrant_extent : index
   %row_origin = index.assume %row_origin_raw [range(%row_origin_raw, 0, 64), mul(%row_origin_raw, 64)] : index
   %column_origin = index.assume %column_origin_raw [range(%column_origin_raw, 0, 64), mul(%column_origin_raw, 64)] : index
   %lhs_view = buffer.view %lhs_buffer[%base] : buffer -> view<128x16xf16, #dense>
   %rhs_view = buffer.view %rhs_buffer[%base] : buffer -> view<16x128xf16, %rhs_layout>
   %out_view = buffer.view %out_buffer[%base] : buffer -> view<128x128xf32, #dense>
-  %lhs = vector.fragment.load<lhs> %lhs_view[%row_origin, %zero] shape [%m, %k] : view<128x16xf16, #dense> -> vector<16xf16>
-  %rhs = vector.fragment.load<rhs> %rhs_view[%zero, %column_origin] shape [%k, %n] : view<16x128xf16, %rhs_layout> -> vector<16xf16>
+  %lhs = vector.fragment.load<lhs> %lhs_view[%row_origin, %k_origin] shape [%m, %k] : view<128x16xf16, #dense> -> vector<16xf16>
+  %rhs = vector.fragment.load<rhs> %rhs_view[%k_origin, %column_origin] shape [%k, %n] : view<16x128xf16, %rhs_layout> -> vector<16xf16>
   %zero_acc = vector.constant 0.0 : vector<4xf32>
   %init = vector.fragment<init> %zero_acc shape [%m, %n] : vector<4xf32>
   %result = vector.mma %lhs, %rhs, %init : vector<16xf16>, vector<16xf16>, vector<4xf32>
@@ -1131,15 +1131,15 @@ kernel.def target(@target) @f16_wmmar3_wave64_half_acc_loop_f32_fragment_memory(
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%out_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %sixteen = index.constant 16 : index
-  %sixty_four = index.constant 64 : index
+  %c0 = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %loop_end = index.constant 2 : index
+  %output_column = index.constant 16 : index
+  %row_stride = index.constant 64 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
-  %layout = encoding.layout.strided [1, %sixty_four] : encoding<layout>
+  %layout = encoding.layout.strided [1, %row_stride] : encoding<layout>
   %out_global = buffer.assume.memory_space<global> %out_buffer : buffer
   %out_aligned = buffer.assume.alignment %out_global {minimum_alignment = 16} : buffer
   %out_view = buffer.view %out_aligned[%base] : buffer -> view<64x64xf32, %layout>
@@ -1149,11 +1149,11 @@ kernel.def target(@target) @f16_wmmar3_wave64_half_acc_loop_f32_fragment_memory(
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xf16>
   %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xf16>
   %init = vector.fragment<init> %init_values shape [%m, %n] : vector<8xf16>
-  %result = scf.for %i = [%zero to %two step %one](%acc = %init : vector<8xf16>) -> (vector<8xf16>) {
+  %result = scf.for %i = [%c0 to %loop_end step %loop_step](%acc = %init : vector<8xf16>) -> (vector<8xf16>) {
     %next = vector.mma %lhs, %rhs, %acc : vector<16xf16>, vector<16xf16>, vector<8xf16>
     scf.yield %next : vector<8xf16>
   }
-  vector.fragment.store<result> %result, %out_view[%zero, %sixteen] shape [%m, %n] : vector<8xf16>, view<64x64xf32, %layout>
+  vector.fragment.store<result> %result, %out_view[%c0, %output_column] shape [%m, %n] : vector<8xf16>, view<64x64xf32, %layout>
   kernel.return
 }
 
@@ -1161,21 +1161,21 @@ kernel.def target(@target) @f16_wmmar3_wave64_half_acc_loop_f32_fragment_memory(
 low.kernel.def target<amdgpu.rdna3.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @f16_wmmar3_wave64_half_acc_loop_f32_fragment_memory() asm {
   %34 = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %out_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 16384} : reg<amdgpu.sgpr x2>
-  %zero = s_mov_b32 0
-  %one = s_mov_b32 1
-  %two = s_mov_b32 2
+  %c0 = s_mov_b32 0
+  %loop_step = s_mov_b32 1
+  %loop_end = s_mov_b32 2
   %39 = v_mov_b32 0
   %rhs = concat(%39, %39, %39, %39, %39, %39, %39, %39) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x8>
   %48 = v_mov_b32 1006648320
   %init = concat(%48, %48, %48, %48) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x4>
-  low.br ^_bb1(%zero: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x4>)
+  low.br ^_bb1(%c0: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x4>)
 ^_bb1(%i: reg<amdgpu.sgpr>, %acc: reg<amdgpu.vgpr x4>):
-  %53 = s_cmp_lt_i32 %i, %two
+  %53 = s_cmp_lt_i32 %i, %loop_end
   low.cond_br %53, ^_bb2, ^_bb3 : reg<amdgpu.scc>
 ^_bb2:
   %54 = copy %acc : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr x4>
   %next = v_wmma_f16_16x16x16_f16_w64 %rhs, %rhs, %54
-  %56 = s_add_u32 %i, %one
+  %56 = s_add_u32 %i, %loop_step
   low.br ^_bb1(%56: reg<amdgpu.sgpr>, %next: reg<amdgpu.vgpr x4>)
 ^_bb3:
   %57 = v_and_b32_src0_inline %34, 15
@@ -2531,16 +2531,16 @@ low.func.def target<amdgpu.rdna4.core>(@target) abi(hal_kernel) @f16_wmma_gfx12(
 
 amdgpu.target<gfx1200> @target
 func.def target(@target) @f16_wmma_gfx12_four_loop_carried_accumulators(%lhs_data: vector<8xf16>, %rhs_data: vector<8xf16>, %init_data: vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %k_tile_begin = index.constant 0 : index
+  %k_tile_step = index.constant 1 : index
+  %k_tile_end = index.constant 2 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %lhs = vector.fragment<lhs> %lhs_data shape [%m, %k] : vector<8xf16>
   %rhs = vector.fragment<rhs> %rhs_data shape [%k, %n] : vector<8xf16>
   %init = vector.fragment<init> %init_data shape [%m, %n] : vector<8xf32>
-  %result0, %result1, %result2, %result3 = scf.for %k_tile = [%zero to %two step %one](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
+  %result0, %result1, %result2, %result3 = scf.for %k_tile = [%k_tile_begin to %k_tile_end step %k_tile_step](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
     %next0 = vector.mma %lhs, %rhs, %acc0 : vector<8xf16>, vector<8xf16>, vector<8xf32>
     %next1 = vector.mma %lhs, %rhs, %acc1 : vector<8xf16>, vector<8xf16>, vector<8xf32>
     %next2 = vector.mma %lhs, %rhs, %acc2 : vector<8xf16>, vector<8xf16>, vector<8xf32>
@@ -2552,12 +2552,12 @@ func.def target(@target) @f16_wmma_gfx12_four_loop_carried_accumulators(%lhs_dat
 
 // ----
 low.func.def target<amdgpu.rdna4.core>(@target) abi(hal_kernel) @f16_wmma_gfx12_four_loop_carried_accumulators(%lhs: reg<amdgpu.vgpr x4>, %rhs: reg<amdgpu.vgpr x4>, %init: reg<amdgpu.vgpr x8>) -> (reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>) asm {
-  %zero = s_mov_b32 0
-  %one = s_mov_b32 1
-  %two = s_mov_b32 2
-  low.br ^_bb1(%zero: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>)
+  %k_tile_begin = s_mov_b32 0
+  %k_tile_step = s_mov_b32 1
+  %k_tile_end = s_mov_b32 2
+  low.br ^_bb1(%k_tile_begin: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>)
 ^_bb1(%k_tile: reg<amdgpu.sgpr>, %acc0: reg<amdgpu.vgpr x8>, %acc1: reg<amdgpu.vgpr x8>, %acc2: reg<amdgpu.vgpr x8>, %acc3: reg<amdgpu.vgpr x8>):
-  %56 = s_cmp_lt_i32 %k_tile, %two
+  %56 = s_cmp_lt_i32 %k_tile, %k_tile_end
   low.cond_br %56, ^_bb2, ^_bb3 : reg<amdgpu.scc>
 ^_bb2:
   %57 = copy %acc0 : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
@@ -2568,7 +2568,7 @@ low.func.def target<amdgpu.rdna4.core>(@target) abi(hal_kernel) @f16_wmma_gfx12_
   %next2 = v_wmma_f32_16x16x16_f16 %lhs, %rhs, %61
   %63 = copy %acc3 : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
   %next3 = v_wmma_f32_16x16x16_f16 %lhs, %rhs, %63
-  %65 = s_add_u32 %k_tile, %one
+  %65 = s_add_u32 %k_tile, %k_tile_step
   low.br ^_bb1(%65: reg<amdgpu.sgpr>, %next0: reg<amdgpu.vgpr x8>, %next1: reg<amdgpu.vgpr x8>, %next2: reg<amdgpu.vgpr x8>, %next3: reg<amdgpu.vgpr x8>)
 ^_bb3:
   return %acc0, %acc1, %acc2, %acc3
@@ -2923,16 +2923,16 @@ low.kernel.def target<amdgpu.rdna4.gfx125x.core>(@target) workgroup_size(32, 1, 
 amdgpu.target<gfx1250> @target
 
 func.def target(@target) @f16_wmma_gfx1250_four_loop_carried_accumulators(%lhs_data: vector<16xf16>, %rhs_data: vector<16xf16>, %init_data: vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %k_tile_begin = index.constant 0 : index
+  %k_tile_step = index.constant 1 : index
+  %k_tile_end = index.constant 2 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 32 : index
   %lhs = vector.fragment<lhs> %lhs_data shape [%m, %k] : vector<16xf16>
   %rhs = vector.fragment<rhs> %rhs_data shape [%k, %n] : vector<16xf16>
   %init = vector.fragment<init> %init_data shape [%m, %n] : vector<8xf32>
-  %result0, %result1, %result2, %result3 = scf.for %k_tile = [%zero to %two step %one](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
+  %result0, %result1, %result2, %result3 = scf.for %k_tile = [%k_tile_begin to %k_tile_end step %k_tile_step](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
     %next0 = vector.mma %lhs, %rhs, %acc0 : vector<16xf16>, vector<16xf16>, vector<8xf32>
     %next1 = vector.mma %lhs, %rhs, %acc1 : vector<16xf16>, vector<16xf16>, vector<8xf32>
     %next2 = vector.mma %lhs, %rhs, %acc2 : vector<16xf16>, vector<16xf16>, vector<8xf32>
@@ -2944,12 +2944,12 @@ func.def target(@target) @f16_wmma_gfx1250_four_loop_carried_accumulators(%lhs_d
 
 // ----
 low.func.def target<amdgpu.rdna4.gfx125x.core>(@target) abi(hal_kernel) @f16_wmma_gfx1250_four_loop_carried_accumulators(%lhs: reg<amdgpu.vgpr x8>, %rhs: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>) -> (reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>, reg<amdgpu.vgpr x8>) asm {
-  %zero = s_mov_b32 0
-  %one = s_mov_b32 1
-  %two = s_mov_b32 2
-  low.br ^_bb1(%zero: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>)
+  %k_tile_begin = s_mov_b32 0
+  %k_tile_step = s_mov_b32 1
+  %k_tile_end = s_mov_b32 2
+  low.br ^_bb1(%k_tile_begin: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>, %init: reg<amdgpu.vgpr x8>)
 ^_bb1(%k_tile: reg<amdgpu.sgpr>, %acc0: reg<amdgpu.vgpr x8>, %acc1: reg<amdgpu.vgpr x8>, %acc2: reg<amdgpu.vgpr x8>, %acc3: reg<amdgpu.vgpr x8>):
-  %56 = s_cmp_lt_i32 %k_tile, %two
+  %56 = s_cmp_lt_i32 %k_tile, %k_tile_end
   low.cond_br %56, ^_bb2, ^_bb3 : reg<amdgpu.scc>
 ^_bb2:
   %57 = copy %acc0 : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
@@ -2960,7 +2960,7 @@ low.func.def target<amdgpu.rdna4.gfx125x.core>(@target) abi(hal_kernel) @f16_wmm
   %next2 = v_wmma_f32_16x16x32_f16 %lhs, %rhs, %61
   %63 = copy %acc3 : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
   %next3 = v_wmma_f32_16x16x32_f16 %lhs, %rhs, %63
-  %65 = s_add_u32 %k_tile, %one
+  %65 = s_add_u32 %k_tile, %k_tile_step
   low.br ^_bb1(%65: reg<amdgpu.sgpr>, %next0: reg<amdgpu.vgpr x8>, %next1: reg<amdgpu.vgpr x8>, %next2: reg<amdgpu.vgpr x8>, %next3: reg<amdgpu.vgpr x8>)
 ^_bb3:
   return %acc0, %acc1, %acc2, %acc3
@@ -3684,13 +3684,13 @@ kernel.def target(@target) @f16acc_to_f32_dynamic_strided_column_store() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%out_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
-  %sixty_four = index.constant 64 : index
+  %output_row = index.constant 0 : index
+  %output_column = index.constant 16 : index
+  %row_stride = index.constant 64 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
-  %layout = encoding.layout.strided [1, %sixty_four] : encoding<layout>
+  %layout = encoding.layout.strided [1, %row_stride] : encoding<layout>
   %out_global = buffer.assume.memory_space<global> %out_buffer : buffer
   %out_aligned = buffer.assume.alignment %out_global {minimum_alignment = 16} : buffer
   %out_view = buffer.view %out_aligned[%base] : buffer -> view<64x64xf32, %layout>
@@ -3701,7 +3701,7 @@ kernel.def target(@target) @f16acc_to_f32_dynamic_strided_column_store() {
   %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xf16>
   %init = vector.fragment<init> %init_values shape [%m, %n] : vector<8xf16>
   %result = vector.mma %lhs, %rhs, %init : vector<16xf16>, vector<16xf16>, vector<8xf16>
-  vector.fragment.store<result> %result, %out_view[%zero, %sixteen] shape [%m, %n] : vector<8xf16>, view<64x64xf32, %layout>
+  vector.fragment.store<result> %result, %out_view[%output_row, %output_column] shape [%m, %n] : vector<8xf16>, view<64x64xf32, %layout>
   kernel.return
 }
 
@@ -3745,13 +3745,13 @@ kernel.def target(@target) @f32acc_dynamic_strided_column_store() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%out_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
-  %sixty_four = index.constant 64 : index
+  %output_row = index.constant 0 : index
+  %output_column = index.constant 16 : index
+  %row_stride = index.constant 64 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
-  %layout = encoding.layout.strided [1, %sixty_four] : encoding<layout>
+  %layout = encoding.layout.strided [1, %row_stride] : encoding<layout>
   %out_global = buffer.assume.memory_space<global> %out_buffer : buffer
   %out_aligned = buffer.assume.alignment %out_global {minimum_alignment = 16} : buffer
   %out_view = buffer.view %out_aligned[%base] : buffer -> view<64x64xf32, %layout>
@@ -3762,7 +3762,7 @@ kernel.def target(@target) @f32acc_dynamic_strided_column_store() {
   %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xf16>
   %init = vector.fragment<init> %init_values shape [%m, %n] : vector<4xf32>
   %result = vector.mma %lhs, %rhs, %init : vector<16xf16>, vector<16xf16>, vector<4xf32>
-  vector.fragment.store<result> %result, %out_view[%zero, %sixteen] shape [%m, %n] : vector<4xf32>, view<64x64xf32, %layout>
+  vector.fragment.store<result> %result, %out_view[%output_row, %output_column] shape [%m, %n] : vector<4xf32>, view<64x64xf32, %layout>
   kernel.return
 }
 
@@ -4242,7 +4242,7 @@ kernel.def target(@target) @f16_wmmar3_wave64_dynamic_view_extents() {
 } launch(%row_count: index, %lhs_buffer: buffer, %rhs_buffer: buffer, %out_buffer: buffer) {
   %bounded_row_count = index.assume %row_count [range(%row_count, 16, 128)] : index
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %fragment_origin = index.constant 0 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -4250,12 +4250,12 @@ kernel.def target(@target) @f16_wmmar3_wave64_dynamic_view_extents() {
   %lhs_view = buffer.view %lhs_buffer[%base] : buffer -> view<[%bounded_row_count]x16xf16, #dense>
   %rhs_view = buffer.view %rhs_buffer[%base] : buffer -> view<16x[%bounded_row_count]xf16, %rhs_layout>
   %out_view = buffer.view %out_buffer[%base] : buffer -> view<16x16xf32, #dense>
-  %lhs = vector.fragment.load<lhs> %lhs_view[%zero, %zero] shape [%m, %k] : view<[%bounded_row_count]x16xf16, #dense> -> vector<16xf16>
-  %rhs = vector.fragment.load<rhs> %rhs_view[%zero, %zero] shape [%k, %n] : view<16x[%bounded_row_count]xf16, %rhs_layout> -> vector<16xf16>
+  %lhs = vector.fragment.load<lhs> %lhs_view[%fragment_origin, %fragment_origin] shape [%m, %k] : view<[%bounded_row_count]x16xf16, #dense> -> vector<16xf16>
+  %rhs = vector.fragment.load<rhs> %rhs_view[%fragment_origin, %fragment_origin] shape [%k, %n] : view<16x[%bounded_row_count]xf16, %rhs_layout> -> vector<16xf16>
   %zero_acc = vector.constant 0.0 : vector<4xf32>
   %init = vector.fragment<init> %zero_acc shape [%m, %n] : vector<4xf32>
   %result = vector.mma %lhs, %rhs, %init : vector<16xf16>, vector<16xf16>, vector<4xf32>
-  vector.fragment.store<result> %result, %out_view[%zero, %zero] shape [%m, %n] : vector<4xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %result, %out_view[%fragment_origin, %fragment_origin] shape [%m, %n] : vector<4xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 
@@ -4299,7 +4299,7 @@ kernel.def target(@target) @f16_wmmar3_wave64_row_major_rhs() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%rhs_buffer: buffer, %out_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %fragment_origin = index.constant 0 : index
   %column_origin = index.constant 32 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
@@ -4308,11 +4308,11 @@ kernel.def target(@target) @f16_wmmar3_wave64_row_major_rhs() {
   %out_view = buffer.view %out_buffer[%base] : buffer -> view<16x16xf32, #dense>
   %lhs_values = vector.constant 1.0 : vector<16xf16>
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xf16>
-  %rhs = vector.fragment.load<rhs> %rhs_view[%zero, %column_origin] shape [%k, %n] : view<16x128xf16, #dense> -> vector<16xf16>
-  %zero_values = vector.constant 0.0 : vector<4xf32>
-  %init = vector.fragment<init> %zero_values shape [%m, %n] : vector<4xf32>
+  %rhs = vector.fragment.load<rhs> %rhs_view[%fragment_origin, %column_origin] shape [%k, %n] : view<16x128xf16, #dense> -> vector<16xf16>
+  %initial_values = vector.constant 0.0 : vector<4xf32>
+  %init = vector.fragment<init> %initial_values shape [%m, %n] : vector<4xf32>
   %result = vector.mma %lhs, %rhs, %init : vector<16xf16>, vector<16xf16>, vector<4xf32>
-  vector.fragment.store<result> %result, %out_view[%zero, %zero] shape [%m, %n] : vector<4xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %result, %out_view[%fragment_origin, %fragment_origin] shape [%m, %n] : vector<4xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_cdna3.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_cdna3.loom-test
@@ -23,16 +23,16 @@ low.func.def target<amdgpu.cdna3.core>(@target) abi(hal_kernel) @bf16_mfma(%lhs:
 
 amdgpu.target<gfx942> @target
 func.def target(@target) @bf16_mfma_four_loop_carried_accumulators(%lhs_data: vector<4xbf16>, %rhs_data: vector<4xbf16>, %init_data: vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %k_tile_begin = index.constant 0 : index
+  %k_tile_step = index.constant 1 : index
+  %k_tile_end = index.constant 2 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %lhs = vector.fragment<lhs> %lhs_data shape [%m, %k] : vector<4xbf16>
   %rhs = vector.fragment<rhs> %rhs_data shape [%k, %n] : vector<4xbf16>
   %init = vector.fragment<init> %init_data shape [%m, %n] : vector<4xf32>
-  %result0, %result1, %result2, %result3 = scf.for %k_tile = [%zero to %two step %one](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
+  %result0, %result1, %result2, %result3 = scf.for %k_tile = [%k_tile_begin to %k_tile_end step %k_tile_step](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
     %next0 = vector.mma %lhs, %rhs, %acc0 : vector<4xbf16>, vector<4xbf16>, vector<4xf32>
     %next1 = vector.mma %lhs, %rhs, %acc1 : vector<4xbf16>, vector<4xbf16>, vector<4xf32>
     %next2 = vector.mma %lhs, %rhs, %acc2 : vector<4xbf16>, vector<4xbf16>, vector<4xf32>
@@ -44,12 +44,12 @@ func.def target(@target) @bf16_mfma_four_loop_carried_accumulators(%lhs_data: ve
 
 // ----
 low.func.def target<amdgpu.cdna3.core>(@target) abi(hal_kernel) @bf16_mfma_four_loop_carried_accumulators(%lhs: reg<amdgpu.vgpr x2>, %rhs: reg<amdgpu.vgpr x2>, %init: reg<amdgpu.vgpr x4>) -> (reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>) asm {
-  %zero = s_mov_b32 0
-  %one = s_mov_b32 1
-  %two = s_mov_b32 2
-  low.br ^_bb1(%zero: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x4>, %init: reg<amdgpu.vgpr x4>, %init: reg<amdgpu.vgpr x4>, %init: reg<amdgpu.vgpr x4>)
+  %k_tile_begin = s_mov_b32 0
+  %k_tile_step = s_mov_b32 1
+  %k_tile_end = s_mov_b32 2
+  low.br ^_bb1(%k_tile_begin: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x4>, %init: reg<amdgpu.vgpr x4>, %init: reg<amdgpu.vgpr x4>, %init: reg<amdgpu.vgpr x4>)
 ^_bb1(%k_tile: reg<amdgpu.sgpr>, %acc0: reg<amdgpu.vgpr x4>, %acc1: reg<amdgpu.vgpr x4>, %acc2: reg<amdgpu.vgpr x4>, %acc3: reg<amdgpu.vgpr x4>):
-  %56 = s_cmp_lt_i32 %k_tile, %two
+  %56 = s_cmp_lt_i32 %k_tile, %k_tile_end
   low.cond_br %56, ^_bb2, ^_bb3 : reg<amdgpu.scc>
 ^_bb2:
   %57 = copy %acc0 : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr x4>
@@ -60,7 +60,7 @@ low.func.def target<amdgpu.cdna3.core>(@target) abi(hal_kernel) @bf16_mfma_four_
   %next2 = v_mfma_f32_16x16x16_bf16 %lhs, %rhs, %61
   %63 = copy %acc3 : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr x4>
   %next3 = v_mfma_f32_16x16x16_bf16 %lhs, %rhs, %63
-  %65 = s_add_u32 %k_tile, %one
+  %65 = s_add_u32 %k_tile, %k_tile_step
   low.br ^_bb1(%65: reg<amdgpu.sgpr>, %next0: reg<amdgpu.vgpr x4>, %next1: reg<amdgpu.vgpr x4>, %next2: reg<amdgpu.vgpr x4>, %next3: reg<amdgpu.vgpr x4>)
 ^_bb3:
   return %acc0, %acc1, %acc2, %acc3
@@ -457,13 +457,13 @@ kernel.def target(@target) @f32_fragment_memory_dynamic_lds_base() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch(%input_buffer: buffer, %out_buffer: buffer) {
   %base = index.constant 0 : offset
-  %sixty_four = index.constant 64 : index
+  %subgroup_size = index.constant 64 : index
   %wave_stride_bytes = index.constant 1024 : index
   %scratch_bytes = index.constant 4096 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %tid = kernel.workitem.id<x> : index
-  %wave = index.div %tid, %sixty_four : index
+  %wave = index.div %tid, %subgroup_size : index
   %wave_offset_index = index.mul %wave, %wave_stride_bytes : index
   %wave_offset = index.cast %wave_offset_index : index to offset
   %input_view = buffer.view %input_buffer[%base] : buffer -> view<16x16xf32, #dense>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_cdna_blocked.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_cdna_blocked.loom-test
@@ -147,9 +147,9 @@ func.def target(@target) @mfma_f64_4x4x4_4_blocks(%lhs_data: vector<1xf64>, %rhs
 }
 
 func.def target(@target) @mfma_f32_32x32x4_f16_2_blocks_loop_carried(%lhs_data: vector<4xf16>, %rhs_data: vector<4xf16>, %init_data: vector<32xf32>) -> (vector<32xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %k_tile_begin = index.constant 0 : index
+  %k_tile_step = index.constant 1 : index
+  %k_tile_end = index.constant 2 : index
   %blocks = index.constant 2 : index
   %m = index.constant 32 : index
   %n = index.constant 32 : index
@@ -157,7 +157,7 @@ func.def target(@target) @mfma_f32_32x32x4_f16_2_blocks_loop_carried(%lhs_data: 
   %lhs = vector.fragment<lhs> %lhs_data shape [blocks(%blocks), %m, %k] : vector<4xf16>
   %rhs = vector.fragment<rhs> %rhs_data shape [blocks(%blocks), %k, %n] : vector<4xf16>
   %init = vector.fragment<init> %init_data shape [blocks(%blocks), %m, %n] : vector<32xf32>
-  %result = scf.for %k_tile = [%zero to %two step %one](%acc = %init : vector<32xf32>) -> (vector<32xf32>) {
+  %result = scf.for %k_tile = [%k_tile_begin to %k_tile_end step %k_tile_step](%acc = %init : vector<32xf32>) -> (vector<32xf32>) {
     %next = vector.mma %lhs, %rhs, %acc : vector<4xf16>, vector<4xf16>, vector<32xf32>
     scf.yield %next : vector<32xf32>
   }
@@ -329,17 +329,17 @@ low.func.def target<amdgpu.cdna3.core>(@target) abi(hal_kernel) @mfma_f64_4x4x4_
 }
 
 low.func.def target<amdgpu.cdna3.core>(@target) abi(hal_kernel) @mfma_f32_32x32x4_f16_2_blocks_loop_carried(%lhs: reg<amdgpu.vgpr x2>, %rhs: reg<amdgpu.vgpr x2>, %init: reg<amdgpu.vgpr x32>) -> (reg<amdgpu.vgpr x32>) asm {
-  %zero = s_mov_b32 0
-  %one = s_mov_b32 1
-  %two = s_mov_b32 2
-  low.br ^_bb1(%zero: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x32>)
+  %k_tile_begin = s_mov_b32 0
+  %k_tile_step = s_mov_b32 1
+  %k_tile_end = s_mov_b32 2
+  low.br ^_bb1(%k_tile_begin: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x32>)
 ^_bb1(%k_tile: reg<amdgpu.sgpr>, %acc: reg<amdgpu.vgpr x32>):
-  %328 = s_cmp_lt_i32 %k_tile, %two
+  %328 = s_cmp_lt_i32 %k_tile, %k_tile_end
   low.cond_br %328, ^_bb2, ^_bb3 : reg<amdgpu.scc>
 ^_bb2:
   %329 = copy %acc : reg<amdgpu.vgpr x32> -> reg<amdgpu.vgpr x32>
   %next = v_mfma_f32_32x32x4_2b_f16 %lhs, %rhs, %329
-  %331 = s_add_u32 %k_tile, %one
+  %331 = s_add_u32 %k_tile, %k_tile_step
   low.br ^_bb1(%331: reg<amdgpu.sgpr>, %next: reg<amdgpu.vgpr x32>)
 ^_bb3:
   return %acc

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_fp4_e4m3_scale.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_fp4_e4m3_scale.loom-test
@@ -99,9 +99,9 @@ low.kernel.def target<amdgpu.rdna4.gfx125x.core>(@target) workgroup_size(32, 1, 
 amdgpu.target<gfx1250> @target
 
 func.def target(@target) @fp4_e4m3_scale16_wmma_k_loop_final_domain_accumulator(%lhs_data: vector<8xi32>, %rhs_data: vector<8xi32>, %lhs_block_scale: vector<2xi32>, %rhs_block_scale: vector<2xi32>, %final_domain_accumulator: vector<8xf32>, %lhs_global_scale: f32, %rhs_global_scale: f32) -> (vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %k_tile_begin = index.constant 0 : index
+  %k_tile_step = index.constant 1 : index
+  %k_tile_end = index.constant 2 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 128 : index
@@ -110,7 +110,7 @@ func.def target(@target) @fp4_e4m3_scale16_wmma_k_loop_final_domain_accumulator(
   %rhs = vector.fragment<rhs> %rhs_data shape [%k, %n] using {scale = %rhs_block_scale : vector<2xi32>, schema = %schema : encoding<schema>} : vector<8xi32>
   %zero_acc = vector.constant 0.0 : vector<8xf32>
   %init = vector.fragment<init> %zero_acc shape [%m, %n] : vector<8xf32>
-  %local_result = scf.for %k_tile = [%zero to %two step %one](%local_accumulator = %init : vector<8xf32>) -> (vector<8xf32>) {
+  %local_result = scf.for %k_tile = [%k_tile_begin to %k_tile_end step %k_tile_step](%local_accumulator = %init : vector<8xf32>) -> (vector<8xf32>) {
     %next = vector.mma %lhs, %rhs, %local_accumulator : vector<8xi32>, vector<8xi32>, vector<8xf32>
     scf.yield %next : vector<8xf32>
   }
@@ -123,19 +123,19 @@ func.def target(@target) @fp4_e4m3_scale16_wmma_k_loop_final_domain_accumulator(
 
 // ----
 low.func.def target<amdgpu.rdna4.gfx125x.core>(@target) abi(hal_kernel) @fp4_e4m3_scale16_wmma_k_loop_final_domain_accumulator(%lhs: reg<amdgpu.vgpr x8>, %rhs: reg<amdgpu.vgpr x8>, %lhs_block_scale: reg<amdgpu.vgpr x2>, %rhs_block_scale: reg<amdgpu.vgpr x2>, %final_domain_accumulator: reg<amdgpu.vgpr x8>, %lhs_global_scale: reg<amdgpu.vgpr>, %rhs_global_scale: reg<amdgpu.vgpr>) -> (reg<amdgpu.vgpr x8>) asm {
-  %zero = s_mov_b32 0
-  %one = s_mov_b32 1
-  %two = s_mov_b32 2
+  %k_tile_begin = s_mov_b32 0
+  %k_tile_step = s_mov_b32 1
+  %k_tile_end = s_mov_b32 2
   %46 = v_mov_b32 0
   %init = concat(%46, %46, %46, %46, %46, %46, %46, %46) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x8>
-  low.br ^_bb1(%zero: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x8>)
+  low.br ^_bb1(%k_tile_begin: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x8>)
 ^_bb1(%k_tile: reg<amdgpu.sgpr>, %local_accumulator: reg<amdgpu.vgpr x8>):
-  %55 = s_cmp_lt_i32 %k_tile, %two
+  %55 = s_cmp_lt_i32 %k_tile, %k_tile_end
   low.cond_br %55, ^_bb2, ^_bb3 : reg<amdgpu.scc>
 ^_bb2:
   %56 = copy %local_accumulator : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
   %next = v_wmma_scale16_f32_16x16x128_f8f6f4_f4_f4 %lhs, %rhs, %56, %lhs_block_scale, %rhs_block_scale {matrix_a_fmt = 4, matrix_b_fmt = 4, matrix_a_scale_fmt = 2, matrix_b_scale_fmt = 2}
-  %58 = s_add_u32 %k_tile, %one
+  %58 = s_add_u32 %k_tile, %k_tile_step
   low.br ^_bb1(%58: reg<amdgpu.sgpr>, %next: reg<amdgpu.vgpr x8>)
 ^_bb3:
   %global_scale = v_mul_f32 %lhs_global_scale, %rhs_global_scale

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_fragment_epilogue.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_fragment_epilogue.loom-test
@@ -2,19 +2,19 @@
 
 amdgpu.target<gfx1100> @target
 kernel.def target(@target) @bf16_result_fragment_epilogue_two_tiles() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%gate: buffer, %scale_buffer: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
-  %thirty_two = index.constant 32 : index
+  %fragment_origin = index.constant 0 : index
+  %tile_extent = index.constant 16 : index
+  %row_pair_stride = index.constant 32 : index
   %token_tile = kernel.workgroup.id<x> : index
   %row_pair = kernel.workgroup.id<y> : index
-  %token_origin = index.mul %token_tile, %sixteen : index
-  %row_origin0 = index.mul %row_pair, %thirty_two : index
-  %row_origin1 = index.add %row_origin0, %sixteen : index
+  %token_origin = index.mul %token_tile, %tile_extent : index
+  %row_origin0 = index.mul %row_pair, %row_pair_stride : index
+  %row_origin1 = index.add %row_origin0, %tile_extent : index
   %gate_global = buffer.assume.memory_space<global> %gate : buffer
   %scale_global = buffer.assume.memory_space<global> %scale_buffer : buffer
   %output_global = buffer.assume.memory_space<global> %output : buffer
@@ -25,16 +25,16 @@ kernel.def target(@target) @bf16_result_fragment_epilogue_two_tiles() {
   %gate_view = buffer.view %gate_aligned[%base] : buffer -> view<64x64xbf16, #dense>
   %scale_view = buffer.view %scale_aligned[%base] : buffer -> view<1xf32, #dense>
   %output_view = buffer.view %output_aligned[%base] : buffer -> view<64x64xbf16, #dense>
-  %gate0_bf16 = vector.fragment.load<result> %gate_view[%token_origin, %row_origin0] shape [%sixteen, %sixteen] : view<64x64xbf16, #dense> -> vector<8xbf16>
-  %gate1_bf16 = vector.fragment.load<result> %gate_view[%token_origin, %row_origin1] shape [%sixteen, %sixteen] : view<64x64xbf16, #dense> -> vector<8xbf16>
+  %gate0_bf16 = vector.fragment.load<result> %gate_view[%token_origin, %row_origin0] shape [%tile_extent, %tile_extent] : view<64x64xbf16, #dense> -> vector<8xbf16>
+  %gate1_bf16 = vector.fragment.load<result> %gate_view[%token_origin, %row_origin1] shape [%tile_extent, %tile_extent] : view<64x64xbf16, #dense> -> vector<8xbf16>
   %gate0 = vector.extf %gate0_bf16 : vector<8xbf16> to vector<8xf32>
   %gate1 = vector.extf %gate1_bf16 : vector<8xbf16> to vector<8xf32>
   %scale = view.load %scale_view[0] : view<1xf32, #dense> -> f32
   %scale_vector = vector.splat %scale : vector<8xf32>
   %product0 = vector.mulf<reassoc|nnan|ninf|nsz|contract> %gate0, %scale_vector : vector<8xf32>
   %product1 = vector.mulf<reassoc|nnan|ninf|nsz|contract> %scale_vector, %gate1 : vector<8xf32>
-  vector.fragment.store<result> %product0, %output_view[%token_origin, %row_origin0] shape [%sixteen, %sixteen] : vector<8xf32>, view<64x64xbf16, #dense>
-  vector.fragment.store<result> %product1, %output_view[%token_origin, %row_origin1] shape [%sixteen, %sixteen] : vector<8xf32>, view<64x64xbf16, #dense>
+  vector.fragment.store<result> %product0, %output_view[%token_origin, %row_origin0] shape [%tile_extent, %tile_extent] : vector<8xf32>, view<64x64xbf16, #dense>
+  vector.fragment.store<result> %product1, %output_view[%token_origin, %row_origin1] shape [%tile_extent, %tile_extent] : vector<8xf32>, view<64x64xbf16, #dense>
   kernel.return
 }
 
@@ -260,13 +260,13 @@ low.kernel.def target<amdgpu.rdna3.core>(@target) workgroup_size(32, 1, 1) workg
 
 amdgpu.target<gfx1100> @target
 kernel.def target(@target) @bf16_result_fragment_epilogue_after_barrier() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%gate: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
+  %fragment_origin = index.constant 0 : index
+  %tile_extent = index.constant 16 : index
   %gate_global = buffer.assume.memory_space<global> %gate : buffer
   %output_global = buffer.assume.memory_space<global> %output : buffer
   %gate_noalias, %output_noalias = buffer.assume.noalias %gate_global, %output_global : buffer, buffer
@@ -274,12 +274,12 @@ kernel.def target(@target) @bf16_result_fragment_epilogue_after_barrier() {
   %output_aligned = buffer.assume.alignment %output_noalias {minimum_alignment = 16} : buffer
   %gate_view = buffer.view %gate_aligned[%base] : buffer -> view<16x16xbf16, #dense>
   %output_view = buffer.view %output_aligned[%base] : buffer -> view<16x16xbf16, #dense>
-  %gate_bf16 = vector.fragment.load<result> %gate_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xbf16, #dense> -> vector<8xbf16>
+  %gate_bf16 = vector.fragment.load<result> %gate_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : view<16x16xbf16, #dense> -> vector<8xbf16>
   %gate_f32 = vector.extf %gate_bf16 : vector<8xbf16> to vector<8xf32>
   %scale = vector.constant 2.0 : vector<8xf32>
   %product = vector.mulf<reassoc|nnan|ninf|nsz|contract> %gate_f32, %scale : vector<8xf32>
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
-  vector.fragment.store<result> %product, %output_view[%zero, %zero] shape [%sixteen, %sixteen] : vector<8xf32>, view<16x16xbf16, #dense>
+  vector.fragment.store<result> %product, %output_view[%fragment_origin, %fragment_origin] shape [%tile_extent, %tile_extent] : vector<8xf32>, view<16x16xbf16, #dense>
   kernel.return
 }
 
@@ -415,9 +415,9 @@ low.func.def target<amdgpu.rdna3.core>(@target) abi(hal_kernel) @result_fragment
 
 amdgpu.target<gfx1100> @target
 kernel.def target(@target) @result_fragment_repack_to_lhs_bf16_bpermute() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %init_values: vector<8xf32>, %output: buffer) {
   %base = index.constant 0 : offset
   %m = index.constant 16 : index
@@ -545,9 +545,9 @@ low.kernel.def target<amdgpu.rdna3.core>(@target) workgroup_size(32, 1, 1) workg
 amdgpu.target<gfx1100> @target
 
 kernel.def target(@target) @result_fragment_repack_to_lhs_bf16_mma_chain() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>,
     %init_values: vector<8xf32>, %output: buffer) {
   %base = index.constant 0 : offset
@@ -690,9 +690,9 @@ low.kernel.def target<amdgpu.rdna3.core>(@target) workgroup_size(32, 1, 1) workg
 
 amdgpu.target<gfx1100> @wave64_target {subgroup_size = 64}
 kernel.def target(@wave64_target) @result_fragment_repack_to_lhs_bf16_bpermute_wave64() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %init_values: vector<4xf32>, %output: buffer) {
   %base = index.constant 0 : offset
   %m = index.constant 16 : index
@@ -781,9 +781,9 @@ low.kernel.def target<amdgpu.rdna3.core>(@wave64_target) workgroup_size(64, 1, 1
 amdgpu.target<gfx942> @target
 
 kernel.def target(@target) @cdna_result_fragment_repack_to_lhs_bf16_mma_chain() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_data: vector<4xbf16>, %rhs_data: vector<4xbf16>, %init_data: vector<4xf32>, %output: buffer) {
   %base = index.constant 0 : offset
   %m = index.constant 16 : index
@@ -891,9 +891,9 @@ low.kernel.def target<amdgpu.cdna3.core>(@target) workgroup_size(64, 1, 1) workg
 amdgpu.target<gfx1200> @target
 
 kernel.def target(@target) @rdna4_result_fragment_repack_to_lhs_bf16_mma_chain() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_data: vector<8xbf16>, %rhs_data: vector<8xbf16>, %init_data: vector<8xf32>, %output: buffer) {
   %base = index.constant 0 : offset
   %m = index.constant 16 : index
@@ -1039,9 +1039,9 @@ low.kernel.def target<amdgpu.rdna4.core>(@target) workgroup_size(32, 1, 1) workg
 amdgpu.target<gfx1250> @target
 
 kernel.def target(@target) @gfx1250_rejects_legacy_k16_bf16_mma_chain() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_data: vector<8xbf16>, %rhs_data: vector<8xbf16>, %init_data: vector<8xf32>, %output: buffer) {
   %base = index.constant 0 : offset
   %m = index.constant 16 : index
@@ -1067,9 +1067,9 @@ kernel.def target(@target) @gfx1250_rejects_legacy_k16_bf16_mma_chain() {
 amdgpu.target<gfx950> @target
 
 kernel.def target(@target) @gfx950_result_fragment_repack_to_lhs_bf16_mma_chain() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_data: vector<4xbf16>, %rhs_data: vector<4xbf16>, %init_data: vector<4xf32>, %output: buffer) {
   %base = index.constant 0 : offset
   %m = index.constant 16 : index
@@ -1172,8 +1172,8 @@ kernel.def target(@target) @bf16_wmmar3_dual_result_product_bf16_epilogue() {
   %lhs = vector.fragment.load<lhs> %lhs_view[0, 0] shape [%m, %k] : view<16x16xbf16, #dense> -> vector<16xbf16>
   %gate_rhs = vector.fragment.load<rhs> %gate_view[0, 0] shape [%k, %n] : view<16x16xbf16, %rhs_layout> -> vector<16xbf16>
   %up_rhs = vector.fragment.load<rhs> %up_view[0, 0] shape [%k, %n] : view<16x16xbf16, %rhs_layout> -> vector<16xbf16>
-  %zero_values = vector.constant 0.0 : vector<8xf32>
-  %zero_acc = vector.fragment<init> %zero_values shape [%m, %n] : vector<8xf32>
+  %initial_values = vector.constant 0.0 : vector<8xf32>
+  %zero_acc = vector.fragment<init> %initial_values shape [%m, %n] : vector<8xf32>
   %gate = vector.mma %lhs, %gate_rhs, %zero_acc : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
   %up = vector.mma %lhs, %up_rhs, %zero_acc : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
   %product = vector.mulf<reassoc|nnan|ninf|nsz|contract> %gate, %up : vector<8xf32>
@@ -1300,9 +1300,9 @@ low.kernel.def target<amdgpu.rdna3.core>(@target) workgroup_size(32, 1, 1) workg
 amdgpu.target<gfx1100> @target
 
 kernel.def target(@target) @report_result_fragment_repack_to_lhs_bf16() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%payload: vector<8xf32>, %output: buffer) {
   %base = index.constant 0 : offset
   %m = index.constant 16 : index
@@ -1338,19 +1338,19 @@ COMPILE-REPORT: source_low_memory_argument_packet[0] function=report_result_frag
 amdgpu.target<gfx1100> @target
 
 kernel.def target(@target) @report_select_fptrunc_bf16_result_fragment_epilogue() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%payload: vector<8xf32>, %selector: i32, %output: buffer) {
   %base = index.constant 0 : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
-  %zero_i32 = scalar.constant 0 : i32
+  %false_selector = scalar.constant 0 : i32
   %output_global = buffer.assume.memory_space<global> %output : buffer
   %output_aligned = buffer.assume.alignment %output_global {minimum_alignment = 16} : buffer
   %output_view = buffer.view %output_aligned[%base] : buffer -> view<16x16xbf16, #dense>
   %selector_true = scalar.assume %selector [range(%selector, 1, 1)] : i32
-  %condition = scalar.cmpi ne, %selector_true, %zero_i32 : i32
+  %condition = scalar.cmpi ne, %selector_true, %false_selector : i32
   %mask = vector.splat %condition : vector<8xi1>
   %payload_alias = vector.slice %payload[0] : vector<8xf32> -> vector<8xf32>
   %rounded_true = vector.fptrunc %payload : vector<8xf32> to vector<8xbf16>
@@ -1443,9 +1443,9 @@ low.kernel.def target<amdgpu.rdna3.core>(@target) workgroup_size(32, 1, 1) workg
 amdgpu.target<gfx1100> @target
 
 kernel.def target(@target) @report_large_bf16_result_epilogue_group() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%payload0: vector<8xf32>, %payload1: vector<8xf32>, %payload2: vector<8xf32>, %payload3: vector<8xf32>, %output: buffer) {
   %base = index.constant 0 : offset
   %m = index.constant 16 : index
@@ -1468,9 +1468,9 @@ kernel.def target(@target) @report_large_bf16_result_epilogue_group() {
 amdgpu.target<gfx1100> @target
 
 kernel.def target(@target) @report_large_bf16_result_epilogue_group() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%payload0: vector<8xf32>, %payload1: vector<8xf32>, %payload2: vector<8xf32>, %payload3: vector<8xf32>, %output: buffer) {
   %base = index.constant 0 : offset
   %output_global = buffer.assume.memory_space<global> %output : buffer
@@ -1541,9 +1541,9 @@ kernel.def target(@target) @report_large_bf16_result_epilogue_group() {
 amdgpu.target<gfx1100> @target
 
 kernel.def target(@target) @report_mixed_bf16_result_epilogue_group() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%payload0: vector<8xf32>, %payload1: vector<8xf32>, %payload2: vector<8xf32>, %payload3: vector<8xf32>, %payload4: vector<8xf32>, %payload5: vector<8xf32>, %payload6: vector<8xf32>, %payload7: vector<8xf32>, %scale: f32, %output: buffer) {
   %base = index.constant 0 : offset
   %m = index.constant 16 : index
@@ -1575,9 +1575,9 @@ kernel.def target(@target) @report_mixed_bf16_result_epilogue_group() {
 amdgpu.target<gfx1100> @target
 
 kernel.def target(@target) @report_mixed_bf16_result_epilogue_group() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%payload0: vector<8xf32>, %payload1: vector<8xf32>, %payload2: vector<8xf32>, %payload3: vector<8xf32>, %payload4: vector<8xf32>, %payload5: vector<8xf32>, %payload6: vector<8xf32>, %payload7: vector<8xf32>, %scale: f32, %output: buffer) {
   %base = index.constant 0 : offset
   %m = index.constant 16 : index
@@ -1659,9 +1659,9 @@ kernel.def target(@target) @report_mixed_bf16_result_epilogue_group() {
 amdgpu.target<gfx1100> @target
 
 kernel.def target(@target) @report_large_scaled_bf16_result_epilogue_group() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%payload0: vector<8xf32>, %payload1: vector<8xf32>, %payload2: vector<8xf32>, %payload3: vector<8xf32>, %scale: f32, %output: buffer) {
   %base = index.constant 0 : offset
   %m = index.constant 16 : index
@@ -1685,9 +1685,9 @@ kernel.def target(@target) @report_large_scaled_bf16_result_epilogue_group() {
 amdgpu.target<gfx1100> @target
 
 kernel.def target(@target) @report_large_scaled_bf16_result_epilogue_group() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%payload0: vector<8xf32>, %payload1: vector<8xf32>, %payload2: vector<8xf32>, %payload3: vector<8xf32>, %scale: f32, %output: buffer) {
   %base = index.constant 0 : offset
   %m = index.constant 16 : index

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_gfx950.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_gfx950.loom-test
@@ -23,16 +23,16 @@ low.func.def target<amdgpu.cdna4.core>(@target) abi(hal_kernel) @f16_mfma_gfx950
 
 amdgpu.target<gfx950> @target
 func.def target(@target) @f16_mfma_gfx950_four_loop_carried_accumulators(%lhs_data: vector<8xf16>, %rhs_data: vector<8xf16>, %init_data: vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %k_tile_begin = index.constant 0 : index
+  %k_tile_step = index.constant 1 : index
+  %k_tile_end = index.constant 2 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 32 : index
   %lhs = vector.fragment<lhs> %lhs_data shape [%m, %k] : vector<8xf16>
   %rhs = vector.fragment<rhs> %rhs_data shape [%k, %n] : vector<8xf16>
   %init = vector.fragment<init> %init_data shape [%m, %n] : vector<4xf32>
-  %result0, %result1, %result2, %result3 = scf.for %k_tile = [%zero to %two step %one](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
+  %result0, %result1, %result2, %result3 = scf.for %k_tile = [%k_tile_begin to %k_tile_end step %k_tile_step](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
     %next0 = vector.mma %lhs, %rhs, %acc0 : vector<8xf16>, vector<8xf16>, vector<4xf32>
     %next1 = vector.mma %lhs, %rhs, %acc1 : vector<8xf16>, vector<8xf16>, vector<4xf32>
     %next2 = vector.mma %lhs, %rhs, %acc2 : vector<8xf16>, vector<8xf16>, vector<4xf32>
@@ -44,12 +44,12 @@ func.def target(@target) @f16_mfma_gfx950_four_loop_carried_accumulators(%lhs_da
 
 // ----
 low.func.def target<amdgpu.cdna4.core>(@target) abi(hal_kernel) @f16_mfma_gfx950_four_loop_carried_accumulators(%lhs: reg<amdgpu.vgpr x4>, %rhs: reg<amdgpu.vgpr x4>, %init: reg<amdgpu.vgpr x4>) -> (reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>, reg<amdgpu.vgpr x4>) asm {
-  %zero = s_mov_b32 0
-  %one = s_mov_b32 1
-  %two = s_mov_b32 2
-  low.br ^_bb1(%zero: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x4>, %init: reg<amdgpu.vgpr x4>, %init: reg<amdgpu.vgpr x4>, %init: reg<amdgpu.vgpr x4>)
+  %k_tile_begin = s_mov_b32 0
+  %k_tile_step = s_mov_b32 1
+  %k_tile_end = s_mov_b32 2
+  low.br ^_bb1(%k_tile_begin: reg<amdgpu.sgpr>, %init: reg<amdgpu.vgpr x4>, %init: reg<amdgpu.vgpr x4>, %init: reg<amdgpu.vgpr x4>, %init: reg<amdgpu.vgpr x4>)
 ^_bb1(%k_tile: reg<amdgpu.sgpr>, %acc0: reg<amdgpu.vgpr x4>, %acc1: reg<amdgpu.vgpr x4>, %acc2: reg<amdgpu.vgpr x4>, %acc3: reg<amdgpu.vgpr x4>):
-  %56 = s_cmp_lt_i32 %k_tile, %two
+  %56 = s_cmp_lt_i32 %k_tile, %k_tile_end
   low.cond_br %56, ^_bb2, ^_bb3 : reg<amdgpu.scc>
 ^_bb2:
   %57 = copy %acc0 : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr x4>
@@ -60,7 +60,7 @@ low.func.def target<amdgpu.cdna4.core>(@target) abi(hal_kernel) @f16_mfma_gfx950
   %next2 = v_mfma_f32_16x16x32_f16 %lhs, %rhs, %61
   %63 = copy %acc3 : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr x4>
   %next3 = v_mfma_f32_16x16x32_f16 %lhs, %rhs, %63
-  %65 = s_add_u32 %k_tile, %one
+  %65 = s_add_u32 %k_tile, %k_tile_step
   low.br ^_bb1(%65: reg<amdgpu.sgpr>, %next0: reg<amdgpu.vgpr x4>, %next1: reg<amdgpu.vgpr x4>, %next2: reg<amdgpu.vgpr x4>, %next3: reg<amdgpu.vgpr x4>)
 ^_bb3:
   return %acc0, %acc1, %acc2, %acc3

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_gfx9_4_generic.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_gfx9_4_generic.loom-test
@@ -26,11 +26,11 @@ func.def target(@target) @f64_mfma_constants() -> (vector<4xf64>) {
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 4 : index
-  %ones = vector.constant 1.0 : vector<1xf64>
-  %zeroes = vector.constant 0.0 : vector<4xf64>
-  %lhs = vector.fragment<lhs> %ones shape [%m, %k] : vector<1xf64>
-  %rhs = vector.fragment<rhs> %ones shape [%k, %n] : vector<1xf64>
-  %init = vector.fragment<init> %zeroes shape [%m, %n] : vector<4xf64>
+  %operand_elements = vector.constant 1.0 : vector<1xf64>
+  %accumulator_elements = vector.constant 0.0 : vector<4xf64>
+  %lhs = vector.fragment<lhs> %operand_elements shape [%m, %k] : vector<1xf64>
+  %rhs = vector.fragment<rhs> %operand_elements shape [%k, %n] : vector<1xf64>
+  %init = vector.fragment<init> %accumulator_elements shape [%m, %n] : vector<4xf64>
   %result = vector.mma %lhs, %rhs, %init : vector<1xf64>, vector<1xf64>, vector<4xf64>
   func.return %result : vector<4xf64>
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_packed_e2m1_storage.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_packed_e2m1_storage.loom-test
@@ -7,17 +7,17 @@ kernel.def target(@target) @f16_lhs_packed_e2m1_rhs_grouped_scale_wmma() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %payload_buffer: buffer, %scale_buffer: buffer, %global_scale_buffer: buffer, %out_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %eight = index.constant 8 : index
-  %sixteen = index.constant 16 : index
+  %c0 = index.constant 0 : index
+  %c1 = index.constant 1 : index
+  %columns_per_byte = index.constant 2 : index
+  %packed_k_width = index.constant 8 : index
+  %tile_extent = index.constant 16 : index
   %lane = kernel.workitem.id<x> : index
-  %column = index.rem %lane, %sixteen : index
-  %column_pair = index.div %column, %two : index
-  %column_parity = index.rem %column, %two : index
-  %k_half = index.div %lane, %sixteen : index
-  %k_base = index.mul %k_half, %eight : index
+  %column = index.rem %lane, %tile_extent : index
+  %column_pair = index.div %column, %columns_per_byte : index
+  %column_parity = index.rem %column, %columns_per_byte : index
+  %k_half = index.div %lane, %tile_extent : index
+  %k_base = index.mul %k_half, %packed_k_width : index
 
   %payload_layout = encoding.layout.dense : encoding<layout>
   %payload_schema = encoding.define #matrix_operand<element_format=f4e2m1, payload_elements=16, payload_packing=little_endian_nibbles, payload_registers=2> : encoding<schema>
@@ -34,33 +34,33 @@ kernel.def target(@target) @f16_lhs_packed_e2m1_rhs_grouped_scale_wmma() {
   %global_scale_view = buffer.view %global_scale_noalias[%base] : buffer -> view<2xf32, #dense>
   %out_view = buffer.view %out_noalias[%base] : buffer -> view<16x16xf32, #dense>
 
-  %lhs = vector.fragment.load<lhs> %lhs_view[%zero, %zero] shape [%sixteen, %sixteen] : view<16x16xf16, #dense> -> vector<8xf16>
+  %lhs = vector.fragment.load<lhs> %lhs_view[%c0, %c0] shape [%tile_extent, %tile_extent] : view<16x16xf16, #dense> -> vector<8xf16>
   // compressed-tensors stores the two N-adjacent E2M1 values in each
   // little-endian byte of its dense [K, N/2] payload. Each lane gathers one
   // byte from eight K rows, decodes both N columns, then selects its parity.
-  %payload_origin = index.madd %k_base, %eight, %column_pair : index
-  %payload_offsets = vector.iota %zero step %eight : vector<8xindex>
+  %payload_origin = index.madd %k_base, %packed_k_width, %column_pair : index
+  %payload_offsets = vector.iota %c0 step %packed_k_width : vector<8xindex>
   %payload_bytes = vector.gather %payload_view[%payload_origin][%payload_offsets] : view<128xi8, %payload_storage>, vector<8xindex> -> vector<8xi8>
   %payload = vector.bitcast %payload_bytes : vector<8xi8> to vector<2xi32>
-  %scale_values = vector.load %scale_view[%zero, %k_base] : view<1x16xf8E4M3, %scale_storage> -> vector<8xf8E4M3>
+  %scale_values = vector.load %scale_view[%c0, %k_base] : view<1x16xf8E4M3, %scale_storage> -> vector<8xf8E4M3>
   %scale_bytes = vector.bitcast %scale_values : vector<8xf8E4M3> to vector<8xi8>
   %scales = vector.bitcast %scale_bytes : vector<8xi8> to vector<2xi32>
   %decoded_pairs = vector.decode %payload using %decode_schema {scale = %scales : vector<2xi32>} : vector<2xi32>, encoding<schema> -> vector<16xf16>
   %even_columns, %odd_columns = vector.deinterleave<0> %decoded_pairs : vector<16xf16> -> vector<8xf16>, vector<8xf16>
-  %is_odd_column = index.cmp eq, %column_parity, %one : index
+  %is_odd_column = index.cmp eq, %column_parity, %c1 : index
   %column_mask = vector.splat %is_odd_column : vector<8xi1>
   %rhs_values = vector.select %column_mask, %odd_columns, %even_columns : vector<8xf16>
-  %rhs = vector.fragment<rhs> %rhs_values shape [%sixteen, %sixteen] : vector<8xf16>
+  %rhs = vector.fragment<rhs> %rhs_values shape [%tile_extent, %tile_extent] : vector<8xf16>
   %zero_accumulator = vector.constant 0.0 : vector<8xf32>
-  %init = vector.fragment<init> %zero_accumulator shape [%sixteen, %sixteen] : vector<8xf32>
+  %init = vector.fragment<init> %zero_accumulator shape [%tile_extent, %tile_extent] : vector<8xf32>
   %local_result = vector.mma %lhs, %rhs, %init : vector<8xf16>, vector<8xf16>, vector<8xf32>
 
-  %input_global_scale = view.load %global_scale_view[%zero] : view<2xf32, #dense> -> f32
-  %weight_global_scale = view.load %global_scale_view[%one] : view<2xf32, #dense> -> f32
+  %input_global_scale = view.load %global_scale_view[%c0] : view<2xf32, #dense> -> f32
+  %weight_global_scale = view.load %global_scale_view[%c1] : view<2xf32, #dense> -> f32
   %global_scale = scalar.mulf<reassoc|nnan|ninf|nsz|contract> %input_global_scale, %weight_global_scale : f32
   %global_scale_vector = vector.splat %global_scale : vector<8xf32>
   %result = vector.mulf<reassoc|nnan|ninf|nsz|contract> %local_result, %global_scale_vector : vector<8xf32>
-  vector.fragment.store<result> %result, %out_view[%zero, %zero] shape [%sixteen, %sixteen] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %result, %out_view[%c0, %c0] shape [%tile_extent, %tile_extent] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_report.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_report.loom-test
@@ -3,16 +3,16 @@
 amdgpu.target<gfx11-generic> @target
 
 func.def target(@target) @report_fixed_trip_matrix_loop(%lhs_data: vector<16xbf16>, %rhs_data: vector<16xbf16>, %init_data: vector<8xf32>) -> (vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %k_tile_begin = index.constant 0 : index
+  %k_tile_step = index.constant 1 : index
+  %k_tile_end = index.constant 2 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %lhs = vector.fragment<lhs> %lhs_data shape [%m, %k] : vector<16xbf16>
   %rhs = vector.fragment<rhs> %rhs_data shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %init_data shape [%m, %n] : vector<8xf32>
-  %result = scf.for %k_tile = [%zero to %two step %one](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
+  %result = scf.for %k_tile = [%k_tile_begin to %k_tile_end step %k_tile_step](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
     %next = vector.mma %lhs, %rhs, %acc : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     scf.yield %next : vector<8xf32>
   }
@@ -45,14 +45,14 @@ kernel.def target(@target) @report_strided_packed_b16_fragment_load() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%rhs_buffer: buffer, %output_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %fragment_row_origin = index.constant 0 : index
   %column_origin = index.constant 32 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %rhs_view = buffer.view %rhs_buffer[%base] : buffer -> view<16x128xf16, #dense>
   %output_view = buffer.view %output_buffer[%base] : buffer -> view<64xf16, #dense>
-  %rhs = vector.fragment.load<rhs> %rhs_view[%zero, %column_origin] shape [%k, %n] : view<16x128xf16, #dense> -> vector<16xf16>
+  %rhs = vector.fragment.load<rhs> %rhs_view[%fragment_row_origin, %column_origin] shape [%k, %n] : view<16x128xf16, #dense> -> vector<16xf16>
   %lane0 = vector.extract %rhs[0] : vector<16xf16> -> f16
   %lane = kernel.workitem.id<x> : index
   view.store %lane0, %output_view[%lane] : f16, view<64xf16, #dense>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_sparse_memory.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_sparse_memory.loom-test
@@ -23,8 +23,8 @@ kernel.def target(@target) @smfmac_fp8_compact_lhs_memory() {
   %metadata = vector.splat %metadata_value : vector<1xi32>
   %lhs = vector.fragment.load<lhs> %lhs_view[0, 0] shape [%m, %k] using {sparsity = %metadata : vector<1xi32>} : view<16x32xf8E5M2, %lhs_storage> -> vector<2xi32>
   %rhs = vector.fragment.load<rhs> %rhs_view[0, 0] shape [%k, %n] : view<64x16xf8E4M3, %rhs_storage> -> vector<4xi32>
-  %zero = vector.constant 0.0 : vector<4xf32>
-  %init = vector.fragment<init> %zero shape [%m, %n] : vector<4xf32>
+  %initial_values = vector.constant 0.0 : vector<4xf32>
+  %init = vector.fragment<init> %initial_values shape [%m, %n] : vector<4xf32>
   %result = vector.mma %lhs, %rhs, %init : vector<2xi32>, vector<4xi32>, vector<4xf32>
   vector.fragment.store<result> %result, %out_view[0, 0] shape [%m, %n] : vector<4xf32>, view<16x16xf32, #dense>
   kernel.return
@@ -96,8 +96,8 @@ kernel.def target(@target) @smfmac_fp8_compact_lhs_memory() {
   %metadata = vector.splat %metadata_value : vector<1xi32>
   %lhs = vector.fragment.load<lhs> %lhs_view[0, 0] shape [%m, %k] using {sparsity = %metadata : vector<1xi32>} : view<16x64xf8E5M2, %lhs_storage> -> vector<4xi32>
   %rhs = vector.fragment.load<rhs> %rhs_view[0, 0] shape [%k, %n] : view<128x16xf8E4M3, %rhs_storage> -> vector<8xi32>
-  %zero = vector.constant 0.0 : vector<4xf32>
-  %init = vector.fragment<init> %zero shape [%m, %n] : vector<4xf32>
+  %initial_values = vector.constant 0.0 : vector<4xf32>
+  %init = vector.fragment<init> %initial_values shape [%m, %n] : vector<4xf32>
   %result = vector.mma %lhs, %rhs, %init : vector<4xi32>, vector<8xi32>, vector<4xf32>
   vector.fragment.store<result> %result, %out_view[0, 0] shape [%m, %n] : vector<4xf32>, view<16x16xf32, #dense>
   kernel.return
@@ -172,8 +172,8 @@ kernel.def target(@target) @swmmac_f16_compact_lhs_memory() {
   %metadata = vector.splat %metadata_value : vector<1xi32>
   %lhs = vector.fragment.load<lhs> %lhs_view[0, 0] shape [%m, %k] using {sparsity = %metadata : vector<1xi32>} : view<16x16xf16, %lhs_storage> -> vector<4xi32>
   %rhs = vector.fragment.load<rhs> %rhs_view[0, 0] shape [%k, %n] : view<32x16xf16, %rhs_storage> -> vector<8xi32>
-  %zero = vector.constant 0.0 : vector<8xf32>
-  %init = vector.fragment<init> %zero shape [%m, %n] : vector<8xf32>
+  %initial_values = vector.constant 0.0 : vector<8xf32>
+  %init = vector.fragment<init> %initial_values shape [%m, %n] : vector<8xf32>
   %result = vector.mma %lhs, %rhs, %init : vector<4xi32>, vector<8xi32>, vector<8xf32>
   vector.fragment.store<result> %result, %out_view[0, 0] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
@@ -249,8 +249,8 @@ kernel.def target(@target) @swmmac_fp8_compact_lhs_memory() {
   %metadata = vector.splat %metadata_value : vector<1xi32>
   %lhs = vector.fragment.load<lhs> %lhs_view[0, 0] shape [%m, %k] using {sparsity = %metadata : vector<1xi32>} : view<16x16xf8E4M3, %lhs_storage> -> vector<2xi32>
   %rhs = vector.fragment.load<rhs> %rhs_view[0, 0] shape [%k, %n] : view<32x16xf8E5M2, %rhs_storage> -> vector<4xi32>
-  %zero = vector.constant 0.0 : vector<8xf32>
-  %init = vector.fragment<init> %zero shape [%m, %n] : vector<8xf32>
+  %initial_values = vector.constant 0.0 : vector<8xf32>
+  %init = vector.fragment<init> %initial_values shape [%m, %n] : vector<8xf32>
   %result = vector.mma %lhs, %rhs, %init : vector<2xi32>, vector<4xi32>, vector<8xf32>
   vector.fragment.store<result> %result, %out_view[0, 0] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
@@ -324,8 +324,8 @@ kernel.def target(@target) @swmmac_fp8_compact_lhs_memory() {
   %metadata = vector.splat %metadata_value : vector<2xi32>
   %lhs = vector.fragment.load<lhs> %lhs_view[0, 0] shape [%m, %k] using {sparsity = %metadata : vector<2xi32>} : view<16x64xf8E4M3, %lhs_storage> -> vector<8xi32>
   %rhs = vector.fragment.load<rhs> %rhs_view[0, 0] shape [%k, %n] : view<128x16xf8E5M2, %rhs_storage> -> vector<16xi32>
-  %zero = vector.constant 0.0 : vector<8xf32>
-  %init = vector.fragment<init> %zero shape [%m, %n] : vector<8xf32>
+  %initial_values = vector.constant 0.0 : vector<8xf32>
+  %init = vector.fragment<init> %initial_values shape [%m, %n] : vector<8xf32>
   %result = vector.mma %lhs, %rhs, %init : vector<8xi32>, vector<16xi32>, vector<8xf32>
   vector.fragment.store<result> %result, %out_view[0, 0] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
@@ -406,8 +406,8 @@ kernel.def target(@target) @smfmac_i8_compact_lhs_memory() {
   %metadata = vector.splat %metadata_value : vector<1xi32>
   %lhs = vector.fragment.load<lhs> %lhs_view[0, 0] shape [%m, %k] using {sparsity = %metadata : vector<1xi32>} : view<16x32xi8, %lhs_storage> -> vector<2xi32>
   %rhs = vector.fragment.load<rhs> %rhs_view[0, 0] shape [%k, %n] : view<64x16xi8, %rhs_storage> -> vector<4xi32>
-  %zero = vector.constant 0 : vector<4xi32>
-  %init = vector.fragment<init> %zero shape [%m, %n] : vector<4xi32>
+  %initial_values = vector.constant 0 : vector<4xi32>
+  %init = vector.fragment<init> %initial_values shape [%m, %n] : vector<4xi32>
   %result = vector.mma %lhs, %rhs, %init : vector<2xi32>, vector<4xi32>, vector<4xi32>
   vector.fragment.store<result> %result, %out_view[0, 0] shape [%m, %n] : vector<4xi32>, view<16x16xi32, #dense>
   kernel.return
@@ -479,8 +479,8 @@ kernel.def target(@target) @swmmac_u8_compact_lhs_memory() {
   %metadata = vector.splat %metadata_value : vector<1xi32>
   %lhs = vector.fragment.load<lhs> %lhs_view[0, 0] shape [%m, %k] using {sparsity = %metadata : vector<1xi32>} : view<16x16xi8, %lhs_storage> -> vector<2xi32>
   %rhs = vector.fragment.load<rhs> %rhs_view[0, 0] shape [%k, %n] : view<32x16xi8, %rhs_storage> -> vector<4xi32>
-  %zero = vector.constant 0 : vector<8xi32>
-  %init = vector.fragment<init> %zero shape [%m, %n] : vector<8xi32>
+  %initial_values = vector.constant 0 : vector<8xi32>
+  %init = vector.fragment<init> %initial_values shape [%m, %n] : vector<8xi32>
   %result = vector.mma %lhs, %rhs, %init : vector<2xi32>, vector<4xi32>, vector<8xi32>
   vector.fragment.store<result> %result, %out_view[0, 0] shape [%m, %n] : vector<8xi32>, view<16x16xi32, #dense>
   kernel.return
@@ -600,8 +600,8 @@ kernel.def target(@target) @swmmac_u8_compact_lhs_memory() {
   %metadata = vector.splat %metadata_value : vector<2xi32>
   %lhs = vector.fragment.load<lhs> %lhs_view[0, 0] shape [%m, %k] using {sparsity = %metadata : vector<2xi32>} : view<16x64xi8, %lhs_storage> -> vector<8xi32>
   %rhs = vector.fragment.load<rhs> %rhs_view[0, 0] shape [%k, %n] : view<128x16xi8, %rhs_storage> -> vector<16xi32>
-  %zero = vector.constant 0 : vector<8xi32>
-  %init = vector.fragment<init> %zero shape [%m, %n] : vector<8xi32>
+  %initial_values = vector.constant 0 : vector<8xi32>
+  %init = vector.fragment<init> %initial_values shape [%m, %n] : vector<8xi32>
   %result = vector.mma %lhs, %rhs, %init : vector<8xi32>, vector<16xi32>, vector<8xi32>
   vector.fragment.store<result> %result, %out_view[0, 0] shape [%m, %n] : vector<8xi32>, view<16x16xi32, #dense>
   kernel.return

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_sparse_memory_report.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_sparse_memory_report.loom-test
@@ -25,8 +25,8 @@ kernel.def target(@target) @report_sparse_fragment_payload_and_metadata() {
   %metadata = vector.load %metadata_view[%tid] : view<32xi32, #dense> -> vector<1xi32>
   %lhs = vector.fragment.load<lhs> %lhs_view[0, 0] shape [%m, %k] using {sparsity = %metadata : vector<1xi32>} : view<16x16xf8E4M3, %lhs_storage> -> vector<2xi32>
   %rhs = vector.fragment.load<rhs> %rhs_view[0, 0] shape [%k, %n] : view<32x16xf8E5M2, %rhs_storage> -> vector<4xi32>
-  %zero = vector.constant 0.0 : vector<8xf32>
-  %init = vector.fragment<init> %zero shape [%m, %n] : vector<8xf32>
+  %initial_values = vector.constant 0.0 : vector<8xf32>
+  %init = vector.fragment<init> %initial_values shape [%m, %n] : vector<8xf32>
   %result = vector.mma %lhs, %rhs, %init : vector<2xi32>, vector<4xi32>, vector<8xf32>
   %lane0 = vector.extract %result[0] : vector<8xf32> -> f32
   view.store %lane0, %output_view[%tid] : f32, view<32xf32, #dense>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_nested_template_expansion.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_nested_template_expansion.loom-test
@@ -8,14 +8,14 @@
 amdgpu.target<gfx11-generic> @target
 
 func.template<nested.leaf> priority(20) @leaf_specialized(%value: index) -> (index) where [range(%value, 1, 256)] {
-  %one = index.constant 1 : index
-  %result = index.add %value, %one : index
+  %increment = index.constant 1 : index
+  %result = index.add %value, %increment : index
   func.return %result : index
 }
 
 func.template<nested.leaf> priority(10) @leaf_fallback(%value: index) -> (index) {
-  %zero = index.constant 0 : index
-  func.return %zero : index
+  %fallback_value = index.constant 0 : index
+  func.return %fallback_value : index
 }
 
 func.template<nested.middle> priority(20) @middle_specialized(%value: index) -> (index) where [range(%value, 1, 256)] {
@@ -24,8 +24,8 @@ func.template<nested.middle> priority(20) @middle_specialized(%value: index) -> 
 }
 
 func.template<nested.middle> priority(10) @middle_fallback(%value: index) -> (index) {
-  %zero = index.constant 0 : index
-  func.return %zero : index
+  %fallback_value = index.constant 0 : index
+  func.return %fallback_value : index
 }
 
 func.template<nested.outer> @outer(%value: index) -> (index) {
@@ -57,9 +57,9 @@ func.def target(@target) @nested_template_fallback() -> (index) {
 }
 
 kernel.def target(@target) @nested_kernel_template_expansion() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   func.apply<nested.kernel_outer>() : ()
   kernel.return
@@ -72,8 +72,8 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @nested_
 }
 
 low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @nested_template_fallback() -> (reg<amdgpu.sgpr>) asm {
-  %zero = s_mov_b32 0
-  return %zero
+  %fallback_value = s_mov_b32 0
+  return %fallback_value
 }
 
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @nested_kernel_template_expansion() asm {

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_numeric_f32.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_numeric_f32.loom-test
@@ -8,10 +8,10 @@ kernel.def target(@target) @f32_arith() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %lhs = vector.load %lhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %rhs = vector.load %rhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %sum = vector.addf %lhs, %rhs : vector<1xf32>
@@ -48,10 +48,10 @@ kernel.def target(@target) @f32_fma() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %lhs = vector.load %lhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %rhs = vector.load %rhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %bias = vector.constant 0.5 : vector<1xf32>
@@ -86,10 +86,10 @@ kernel.def target(@target) @f32_arcp_div() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64x4xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64x4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf32, #dense>
   %lhs = vector.load %lhs_view[%lane, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %rhs = vector.load %rhs_view[%lane, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %quotient = vector.divf<nnan|ninf|nsz|arcp> %lhs, %rhs : vector<4xf32>
@@ -212,19 +212,19 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @f32_vec
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @f32_guarded_arcp_reciprocal_scale(%amax: f32) -> (f32) {
-  %zero = scalar.constant 0.0 : f32
-  %one = scalar.constant 1.0 : f32
-  %one_over_127 = scalar.constant 0.007874015700000001 : f32
-  %scale = scalar.constant 127.0 : f32
-  %d = scalar.mulf<nnan|ninf|nsz|arcp> %amax, %one_over_127 : f32
+  %fallback_scale = scalar.constant 0.0 : f32
+  %reciprocal_numerator = scalar.constant 1.0 : f32
+  %inverse_scale_limit = scalar.constant 0.007874015700000001 : f32
+  %scale_limit = scalar.constant 127.0 : f32
+  %d = scalar.mulf<nnan|ninf|nsz|arcp> %amax, %inverse_scale_limit : f32
   %zero_for_cmp = scalar.subf %d, %d : f32
   %nonzero = scalar.cmpf one, %d, %zero_for_cmp : f32
   %d_inv = scf.if %nonzero -> (f32) {
-    %amax_inv = scalar.divf<nnan|ninf|nsz|arcp> %one, %amax : f32
-    %candidate = scalar.mulf<nnan|ninf|nsz|arcp> %amax_inv, %scale : f32
+    %amax_inv = scalar.divf<nnan|ninf|nsz|arcp> %reciprocal_numerator, %amax : f32
+    %candidate = scalar.mulf<nnan|ninf|nsz|arcp> %amax_inv, %scale_limit : f32
     scf.yield %candidate : f32
   } else {
-    scf.yield %zero : f32
+    scf.yield %fallback_scale : f32
   }
   func.return %d_inv : f32
 }
@@ -249,10 +249,10 @@ kernel.def target(@target) @f32_exact_vector_div() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %lhs = vector.load %lhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %rhs = vector.load %rhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %quotient = vector.divf %lhs, %rhs : vector<1xf32>
@@ -334,10 +334,10 @@ kernel.def target(@target) @f32_scalarized() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64x4xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64x4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf32, #dense>
   %lhs = vector.load %lhs_view[%lane, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %rhs = vector.load %rhs_view[%lane, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %lhs0 = vector.extract %lhs[0] : vector<4xf32> -> f32
@@ -447,8 +447,8 @@ func.def target(@target) @f32_uniform_vector_binary(%lhs_buffer: buffer, %rhs_bu
   %sum = vector.addf %lhs, %rhs : vector<4xf32>
   %difference = vector.subf %lhs, %rhs : vector<4xf32>
   %combined = vector.addf %product, %sum : vector<4xf32>
-  %two = vector.constant 2.0 : vector<4xf32>
-  %scaled = vector.mulf %lhs, %two : vector<4xf32>
+  %scale_factor = vector.constant 2.0 : vector<4xf32>
+  %scaled = vector.mulf %lhs, %scale_factor : vector<4xf32>
   %with_difference = vector.addf %combined, %difference : vector<4xf32>
   %result = vector.addf %with_difference, %scaled : vector<4xf32>
   func.return %result : vector<4xf32>
@@ -541,9 +541,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @f32_uni
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @f32_inline_zero_arithmetic(%scalar: f32, %vector: vector<2xf32>) -> (f32, vector<2xf32>) {
-  %zero = scalar.constant 0.0 : f32
-  %scalar_result = scalar.mulf %scalar, %zero : f32
-  %zero_vector = vector.splat %zero : vector<2xf32>
+  %zero_factor = scalar.constant 0.0 : f32
+  %scalar_result = scalar.mulf %scalar, %zero_factor : f32
+  %zero_vector = vector.splat %zero_factor : vector<2xf32>
   %vector_result = vector.mulf %vector, %zero_vector : vector<2xf32>
   func.return %scalar_result, %vector_result : f32, vector<2xf32>
 }
@@ -651,12 +651,12 @@ kernel.def target(@target) @f32_direct_arg_scale() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%output: buffer, %scale: f32) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xf32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_element = index.constant 0 : index
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xf32, #dense>
   %unit = scalar.constant 1.0 : f32
   %scaled = scalar.mulf %unit, %scale : f32
-  view.store %scaled, %output_view[%zero_index] : f32, view<1xf32, #dense>
+  view.store %scaled, %output_view[%output_element] : f32, view<1xf32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_numeric_f32_report.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_numeric_f32_report.loom-test
@@ -3,8 +3,8 @@
 amdgpu.target<gfx11-generic> @target
 
 func.def target(@target) @report_scalar_arcp_reciprocal_div(%rhs: f32) -> (f32) {
-  %one = scalar.constant 1.0 : f32
-  %quotient = scalar.divf<nnan|ninf|nsz|arcp> %one, %rhs : f32
+  %reciprocal_numerator = scalar.constant 1.0 : f32
+  %quotient = scalar.divf<nnan|ninf|nsz|arcp> %reciprocal_numerator, %rhs : f32
   func.return %quotient : f32
 }
 
@@ -63,8 +63,8 @@ COMPILE-REPORT: source_low[0] function=report_scalar_exact_div source_op=scalar.
 amdgpu.target<gfx11-generic> @target
 
 func.def target(@target) @report_vector_arcp_reciprocal_div(%rhs: vector<2xf32>) -> (vector<2xf32>) {
-  %one = vector.constant 1.0 : vector<2xf32>
-  %quotient = vector.divf<nnan|ninf|nsz|arcp> %one, %rhs : vector<2xf32>
+  %reciprocal_numerator = vector.constant 1.0 : vector<2xf32>
+  %quotient = vector.divf<nnan|ninf|nsz|arcp> %reciprocal_numerator, %rhs : vector<2xf32>
   func.return %quotient : vector<2xf32>
 }
 

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_numeric_i32.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_numeric_i32.loom-test
@@ -8,9 +8,9 @@ kernel.def target(@target) @i32_bitwise() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   %mask = vector.constant 15 : vector<1xi32>
   %masked = vector.andi %loaded, %mask : vector<1xi32>
@@ -44,9 +44,9 @@ kernel.def target(@target) @i32_shift() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   %shift = vector.constant 3 : vector<1xi32>
   %left = vector.shli %loaded, %shift : vector<1xi32>
@@ -83,9 +83,9 @@ kernel.def target(@target) @i32_negative_literal() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   %mask = vector.constant -1 : vector<1xi32>
   %result = vector.xori %loaded, %mask : vector<1xi32>
@@ -114,9 +114,9 @@ kernel.def target(@target) @i32_scalarized() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   %lane0 = vector.extract %loaded[0] : vector<4xi32> -> i32
   %lane1 = vector.extract %loaded[1] : vector<4xi32> -> i32

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_packed_q8_dequant_dot.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_packed_q8_dequant_dot.loom-test
@@ -46,23 +46,23 @@ kernel.def target(@target) @q8_packed_word_global_dequant_dot4_kernel() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%weights: buffer, %rhs_buffer: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %four = index.constant 4 : index
-  %four_bytes = index.constant 4 : offset
-  %eight = index.constant 8 : index
+  %packed_word_index = index.constant 0 : index
+  %rhs_elements_per_lane = index.constant 4 : index
+  %packed_word_bytes = index.constant 4 : offset
+  %lanes_per_scale = index.constant 8 : index
   %lane = kernel.workitem.id<x> : index
   %weights_global = buffer.assume.memory_space<global> %weights : buffer
   %rhs_global = buffer.assume.memory_space<global> %rhs_buffer : buffer
   %output_global = buffer.assume.memory_space<global> %output : buffer
   %weights_noalias, %rhs_noalias, %output_noalias = buffer.assume.noalias %weights_global, %rhs_global, %output_global : buffer, buffer, buffer
-  %q_byte_offset = index.scale %lane, %four_bytes : index, offset -> offset
-  %scale_index = index.div %lane, %eight : index
-  %rhs_index = index.mul %lane, %four : index
+  %q_byte_offset = index.scale %lane, %packed_word_bytes : index, offset -> offset
+  %scale_index = index.div %lane, %lanes_per_scale : index
+  %rhs_index = index.mul %lane, %rhs_elements_per_lane : index
   %q_word_view = buffer.view %weights_noalias[%q_byte_offset] : buffer -> view<1xi32, #dense>
   %scale_view = buffer.view %weights_noalias[%base] : buffer -> view<1024xf16, #dense>
   %rhs_view = buffer.view %rhs_noalias[%base] : buffer -> view<1024xf32, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<64xf32, #dense>
-  %packed = vector.load %q_word_view[%zero] : view<1xi32, #dense> -> vector<1xi32>
+  %packed = vector.load %q_word_view[%packed_word_index] : view<1xi32, #dense> -> vector<1xi32>
   %scale = view.load %scale_view[%scale_index] : view<1024xf16, #dense> -> f16
   %rhs = vector.load %rhs_view[%rhs_index] : view<1024xf32, #dense> -> vector<4xf32>
   %q_i32 = vector.bitunpacks<8> %packed : vector<1xi32> -> vector<4xi32>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_pipeline.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_pipeline.loom-test
@@ -204,8 +204,8 @@ low.func.def target<amdgpu.gfx11.generic.core>(@gfx11) abi(hal_kernel) @target_t
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @prepared_pipeline_probe() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%arg: buffer) {
   kernel.return
 }
@@ -334,9 +334,9 @@ func.template<pipeline.late_fragment_epilogue> target(@target) @late_fragment_ep
 }
 
 kernel.def target(@target) @target_legalization_precedes_cfg_finalization() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%output: buffer) {
   %payload0 = vector.constant 1.0 : vector<8xf32>
   %payload1 = vector.constant 2.0 : vector<8xf32>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_prefetch_gfx12.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_prefetch_gfx12.loom-test
@@ -35,8 +35,8 @@ kernel.def target(@target) @prefetch_workgroup_id() {
   kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer) {
   %workgroup = kernel.workgroup.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1025xi32, #dense>
+  %input_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%input_base] : buffer -> view<1025xi32, #dense>
   // REMARK@+1: BACKEND/041 "selected prefetch 'read/l2'" "immediate offset 0" "dynamic index 'soffset'" "count 1"
   view.prefetch %input_view[%workgroup] {intent = read, locality = l2} : view<1025xi32, #dense>
   kernel.return
@@ -75,8 +75,8 @@ kernel.def target(@target) @prefetch_fixed_query_offset() {
   %offset0 = index.add %workgroup_size_x, %workgroup_size_y : index
   %offset1 = index.add %offset0, %subgroup_size : index
   %offset = index.add %offset1, %subgroup_count : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  %input_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%input_base] : buffer -> view<64xi32, #dense>
   // REMARK@+1: BACKEND/041 "selected prefetch 'read/l1'" "immediate offset 180" "scalar byte offset 0" "dynamic index 'none'"
   view.prefetch %input_view[%offset] {intent = read, locality = l1} : view<64xi32, #dense>
   kernel.return
@@ -107,8 +107,8 @@ kernel.def target(@target) @prefetch_workitem_dropped() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  %input_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%input_base] : buffer -> view<64xi32, #dense>
   // REMARK@+1: BACKEND/041 "dropped prefetch 'read/l1'" "decision 'prefetch.dynamic_index'" "packet '<none>'" "count 0"
   view.prefetch %input_view[%lane] {intent = read, locality = l1} : view<64xi32, #dense>
   kernel.return

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_reduce.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_reduce.loom-test
@@ -3,9 +3,9 @@
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @i32_reduce_add(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   %init = scalar.constant 0 : i32
   %sum = vector.reduce<addi> %loaded, %init : vector<4xi32>, i32
@@ -35,9 +35,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @i32_red
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @f32_reduce_add(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
   %loaded = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %init = scalar.constant 0.0 : f32
   %sum = vector.reduce<addf> %loaded, %init : vector<4xf32>, f32
@@ -68,9 +68,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @f32_red
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @f32_reduce_add_fastmath(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
   %loaded = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %init = scalar.constant 0.0 : f32
   %sum = vector.reduce<addf, reassoc|nnan|nsz> %loaded, %init : vector<4xf32>, f32
@@ -100,9 +100,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @f32_red
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @f32x64_reduce_add_fastmath(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
   %loaded = vector.load %input_view[0] : view<64xf32, #dense> -> vector<64xf32>
   %init = scalar.constant 0.0 : f32
   %sum = vector.reduce<addf, reassoc|nnan|nsz> %loaded, %init : vector<64xf32>, f32
@@ -269,24 +269,24 @@ amdgpu.target<gfx11-generic> @target
 config.def @runtime.vector_width = 4 : index
 
 kernel.def target(@target) @f32_configured_width_square_reduce() {
-  %one = index.constant 1 : index
+  %singleton_dimension = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%singleton_dimension, %singleton_dimension, %singleton_dimension) workgroup_size(%workgroup_size, %singleton_dimension, %singleton_dimension) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero_offset = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %lane0 = kernel.workitem.id<x> : index
   %lane = index.assume %lane0 [range(%lane0, 0, 63)] : index
   %vector_width = config.get @runtime.vector_width : index
   %vector_width_bounded = index.assume %vector_width [range(%vector_width, 2, 4)] : index
   %element_count = index.constant 256 : index
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<[%element_count]xf32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<[%element_count]xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
   %linear0 = index.mul %lane, %vector_width_bounded : index
   %linear = index.assume %linear0 [range(%linear0, 0, 252)] : index
   %loaded = vector.load %input_view[%linear] : view<[%element_count]xf32, #dense> -> vector<[%vector_width_bounded]xf32>
   %squared = vector.mulf<reassoc|nnan|ninf|nsz|contract> %loaded, %loaded : vector<[%vector_width_bounded]xf32>
-  %zero_f32 = scalar.constant 0.0 : f32
-  %sum = vector.reduce<addf, reassoc|nnan|ninf|nsz|contract> %squared, %zero_f32 : vector<[%vector_width_bounded]xf32>, f32
+  %initial_sum = scalar.constant 0.0 : f32
+  %sum = vector.reduce<addf, reassoc|nnan|ninf|nsz|contract> %squared, %initial_sum : vector<[%vector_width_bounded]xf32>, f32
   %stored = vector.from_elements %sum : vector<1xf32>
   vector.store %stored, %output_view[0] : vector<1xf32>, view<1xf32, #dense>
   kernel.return
@@ -320,8 +320,8 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @i32_reduce_minui_select_sentinel(%values: vector<4xi32>) -> (i32) {
-  %zero = scalar.constant 0 : i32
-  %zeros = vector.splat %zero : vector<4xi32>
+  %empty_value = scalar.constant 0 : i32
+  %zeros = vector.splat %empty_value : vector<4xi32>
   %is_zero = vector.cmpi eq, %values, %zeros : vector<4xi32> -> vector<4xi1>
   %start = scalar.constant 0 : i32
   %step = scalar.constant 1 : i32

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sanitizer.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sanitizer.loom-test
@@ -190,8 +190,8 @@ amdgpu.target<gfx11-generic> @target
 
 func.def target(@target) @sanitizer_explicit_gfx11_strided_access_write(%output: buffer) {
   %base = index.constant 0 : offset
-  %sixty_four = index.constant 64 : index
-  %layout = encoding.layout.strided [1, %sixty_four] : encoding<layout>
+  %row_stride = index.constant 64 : index
+  %layout = encoding.layout.strided [1, %row_stride] : encoding<layout>
   %output_global = buffer.assume.memory_space<global> %output : buffer
   %output_view = buffer.view %output_global[%base] : buffer -> view<64x64xf32, %layout>
   sanitizer.assert.access<write> %output_view[0, 0] {static_extents = [2, 1]} : view<64x64xf32, %layout>
@@ -796,9 +796,9 @@ low.func.def target<amdgpu.rdna4.core>(@target) abi(hal_kernel) @sanitizer_expli
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @sanitizer_dynamic_byte_stride_read() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 256 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer) {
   %base = index.constant 0 : offset
   %lane0 = kernel.workitem.id<x> : index

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sanitizer_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sanitizer_diagnostics.loom-test
@@ -3,12 +3,12 @@
 amdgpu.target<gfx11-generic> @target
 
 func.def target(@target) @access_assert_workgroup_memory_rejected() {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %scratch_base = index.constant 0 : offset
+  %element_index = index.constant 0 : index
   %bytes = index.constant 4 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero_offset] : buffer -> view<1xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<1xi32, #dense>
   // ERROR@+1: AMDGPU/023 {constraint_key="memory_access.memory_space"}
-  sanitizer.assert.access<read> %scratch_view[%zero_index] : view<1xi32, #dense>
+  sanitizer.assert.access<read> %scratch_view[%element_index] : view<1xi32, #dense>
   func.return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sanitizer_dynamic_stride.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sanitizer_dynamic_stride.loom-test
@@ -5,7 +5,7 @@ amdgpu.target<gfx11-generic> @target
 func.def target(@target) @sanitizer_bounded_dynamic_stride_write(
     %output: buffer, %row_count_i32: i32, %row_size_i32: i32, %row_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %column = index.constant 0 : index
   %row_count0 = index.cast %row_count_i32 : i32 to index
   %row_count = index.assume %row_count0 [range(%row_count0, 1, 512)] : index
   %row_size0 = index.cast %row_size_i32 : i32 to index
@@ -14,7 +14,7 @@ func.def target(@target) @sanitizer_bounded_dynamic_stride_write(
   %row = index.assume %row0 [range(%row0, 0, 511), lt(%row0, %row_count)] : index
   %output_global = buffer.assume.memory_space<global> %output : buffer
   %output_view = buffer.view %output_global[%base] : buffer -> view<[%row_count]x[%row_size]xf32, #dense>
-  sanitizer.assert.access<write> %output_view[%row, %zero] : view<[%row_count]x[%row_size]xf32, #dense>
+  sanitizer.assert.access<write> %output_view[%row, %column] : view<[%row_count]x[%row_size]xf32, #dense>
   func.return
 }
 
@@ -116,18 +116,18 @@ amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @sanitizer_bounded_lane_dynamic_stride_write(
     %row_size_i32: i32) {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%output: buffer, %row_size_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %column = index.constant 0 : index
   %row = kernel.workitem.id<x> : index
   %row_size0 = index.cast %row_size_i32 : i32 to index
   %row_size = index.assume %row_size0 [range(%row_size0, 1, 4096)] : index
   %output_global = buffer.assume.memory_space<global> %output : buffer
   %output_view = buffer.view %output_global[%base] : buffer -> view<64x[%row_size]xf32, #dense>
-  sanitizer.assert.access<write> %output_view[%row, %zero] : view<64x[%row_size]xf32, #dense>
+  sanitizer.assert.access<write> %output_view[%row, %column] : view<64x[%row_size]xf32, #dense>
   kernel.return
 }
 
@@ -224,7 +224,7 @@ amdgpu.target<gfx11-generic> @target
 func.def target(@target) @sanitizer_wide_dynamic_stride_write_rejected(
     %output: buffer, %row_size_i32: i32, %row_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %column = index.constant 0 : index
   %row_size0 = index.cast %row_size_i32 : i32 to index
   %row_size = index.assume %row_size0 [range(%row_size0, 1, 1073741824)] : index
   %row0 = index.cast %row_i32 : i32 to index
@@ -232,6 +232,6 @@ func.def target(@target) @sanitizer_wide_dynamic_stride_write_rejected(
   %output_global = buffer.assume.memory_space<global> %output : buffer
   %output_view = buffer.view %output_global[%base] : buffer -> view<2x[%row_size]xf32, #dense>
   // ERROR@+1: AMDGPU/020
-  sanitizer.assert.access<write> %output_view[%row, %zero] : view<2x[%row_size]xf32, #dense>
+  sanitizer.assert.access<write> %output_view[%row, %column] : view<2x[%row_size]xf32, #dense>
   func.return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sanitizer_race_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sanitizer_race_diagnostics.loom-test
@@ -2,9 +2,9 @@
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @race_access_global_rejected(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<1xi32, #dense>
+  %view = buffer.view %global[%input_base] : buffer -> view<1xi32, #dense>
   // ERROR@+1: AMDGPU/023 {constraint_key="target_contract.sanitizer_race.workgroup_memory_required"}
   sanitizer.race.access<read> %view[0] : view<1xi32, #dense>
   func.return

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_scalar_i32.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_scalar_i32.loom-test
@@ -82,9 +82,9 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @scalar_
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @scalar_i1_bitwise_scc(%lhs: i32, %rhs: i32) -> (i1) {
-  %zero = scalar.constant 0 : i32
-  %lhs_nonzero = scalar.cmpi ne, %lhs, %zero : i32
-  %rhs_nonzero = scalar.cmpi ne, %rhs, %zero : i32
+  %inactive_condition = scalar.constant 0 : i32
+  %lhs_nonzero = scalar.cmpi ne, %lhs, %inactive_condition : i32
+  %rhs_nonzero = scalar.cmpi ne, %rhs, %inactive_condition : i32
   %both_nonzero = scalar.andi %lhs_nonzero, %rhs_nonzero : i1
   %either_nonzero = scalar.ori %lhs_nonzero, %rhs_nonzero : i1
   %one_nonzero = scalar.xori %both_nonzero, %either_nonzero : i1
@@ -93,19 +93,19 @@ func.def target(@target) @scalar_i1_bitwise_scc(%lhs: i32, %rhs: i32) -> (i1) {
 
 // ----
 low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @scalar_i1_bitwise_scc(%lhs: reg<amdgpu.sgpr>, %rhs: reg<amdgpu.sgpr>) -> (reg<amdgpu.scc>) asm {
-  %zero = s_mov_b32 0
-  %lhs_nonzero = s_cmp_lg_i32 %lhs, %zero
-  %rhs_nonzero = s_cmp_lg_i32 %rhs, %zero
+  %inactive_condition = s_mov_b32 0
+  %lhs_nonzero = s_cmp_lg_i32 %lhs, %inactive_condition
+  %rhs_nonzero = s_cmp_lg_i32 %rhs, %inactive_condition
   %16 = s_mov_b32 1
-  %17 = s_cselect_b32 %16, %zero, %lhs_nonzero
-  %18 = s_cselect_b32 %16, %zero, %rhs_nonzero
+  %17 = s_cselect_b32 %16, %inactive_condition, %lhs_nonzero
+  %18 = s_cselect_b32 %16, %inactive_condition, %rhs_nonzero
   %19 = s_and_b32 %17, %18
-  %both_nonzero = s_cmp_lg_i32 %19, %zero
+  %both_nonzero = s_cmp_lg_i32 %19, %inactive_condition
   %25 = s_or_b32 %17, %18
-  %either_nonzero = s_cmp_lg_i32 %25, %zero
-  %29 = s_cselect_b32 %16, %zero, %both_nonzero
-  %30 = s_cselect_b32 %16, %zero, %either_nonzero
+  %either_nonzero = s_cmp_lg_i32 %25, %inactive_condition
+  %29 = s_cselect_b32 %16, %inactive_condition, %both_nonzero
+  %30 = s_cselect_b32 %16, %inactive_condition, %either_nonzero
   %31 = s_xor_b32 %29, %30
-  %one_nonzero = s_cmp_lg_i32 %31, %zero
+  %one_nonzero = s_cmp_lg_i32 %31, %inactive_condition
   return %one_nonzero
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_scc_lifetimes.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_scc_lifetimes.loom-test
@@ -34,20 +34,20 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @select_
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @select_nested_global_buffer(%select_lhs: index, %select_rhs: index) {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%select_lhs: index, %select_rhs: index, %lhs: buffer, %middle: buffer, %rhs: buffer, %output: buffer) {
-  %zero = index.constant 0 : index
-  %two = index.constant 2 : index
-  %zero_offset = index.constant 0 : offset
-  %use_lhs = index.cmp eq, %select_lhs, %zero : index
-  %use_rhs = index.cmp eq, %select_rhs, %two : index
+  %c0 = index.constant 0 : index
+  %rhs_selector = index.constant 2 : index
+  %buffer_base = index.constant 0 : offset
+  %use_lhs = index.cmp eq, %select_lhs, %c0 : index
+  %use_rhs = index.cmp eq, %select_rhs, %rhs_selector : index
   %middle_or_rhs = scf.select %use_rhs, %rhs, %middle : buffer
   %selected = scf.select %use_lhs, %lhs, %middle_or_rhs : buffer
-  %selected_view = buffer.view %selected[%zero_offset] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xi32, #dense>
-  %selected_value = view.load %selected_view[%zero] : view<1xi32, #dense> -> i32
-  view.store %selected_value, %output_view[%zero] : i32, view<1xi32, #dense>
+  %selected_view = buffer.view %selected[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
+  %selected_value = view.load %selected_view[%c0] : view<1xi32, #dense> -> i32
+  view.store %selected_value, %output_view[%c0] : i32, view<1xi32, #dense>
   kernel.return
 }
 
@@ -57,12 +57,12 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
   %middle = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
   %rhs = resource<hal_binding> {index = 2, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 3, source_type = hal.buffer, extent = 4} : reg<amdgpu.sgpr x2>
-  %zero = s_mov_b32 0
-  %two = s_mov_b32 2
-  %27 = s_cmp_eq_i32 %select_lhs, %zero
+  %c0 = s_mov_b32 0
+  %rhs_selector = s_mov_b32 2
+  %27 = s_cmp_eq_i32 %select_lhs, %c0
   %29 = s_mov_b32 1
-  %use_lhs = s_cselect_b32 %29, %zero, %27
-  %use_rhs = s_cmp_eq_i32 %select_rhs, %two
+  %use_lhs = s_cselect_b32 %29, %c0, %27
+  %use_rhs = s_cmp_eq_i32 %select_rhs, %rhs_selector
   %32 = slice %rhs[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %33 = slice %middle[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
   %34 = s_cselect_b32 %32, %33, %use_rhs

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_slice.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_slice.loom-test
@@ -125,15 +125,15 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @f16x4_i
 
 amdgpu.target<gfx11-generic> @target
 func.def target(@target) @bf16x8_insert_static_constant(%values: vector<8xbf16>) -> (vector<8xbf16>) {
-  %zero = scalar.constant 0.0 : bf16
-  %updated = vector.insert %zero into %values[5] : bf16, vector<8xbf16>
+  %replacement = scalar.constant 0.0 : bf16
+  %updated = vector.insert %replacement into %values[5] : bf16, vector<8xbf16>
   func.return %updated : vector<8xbf16>
 }
 
 // ----
 low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @bf16x8_insert_static_constant(%values: reg<amdgpu.vgpr x4>) -> (reg<amdgpu.vgpr x4>) asm {
-  %zero = v_mov_b32 0
-  %7 = v_and_b32_lit %zero, 65535
+  %replacement = v_mov_b32 0
+  %7 = v_and_b32_lit %replacement, 65535
   %8 = slice %values[0] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
   %9 = slice %values[1] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>
   %10 = slice %values[2] : reg<amdgpu.vgpr x4> -> reg<amdgpu.vgpr>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_collective.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_collective.loom-test
@@ -7,9 +7,9 @@ kernel.def target(@target) @subgroup_broadcast_i32_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %lane = scalar.constant 7 : i32
@@ -45,9 +45,9 @@ kernel.def target(@target) @subgroup_broadcast_dynamic_i32_wave32() {
   %tid = kernel.workitem.id<x> : index
   %lane_id = kernel.subgroup.lane.id : index
   %lane = index.cast %lane_id : index to i32
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %broadcast = kernel.subgroup.broadcast %value from %lane : i32, i32
@@ -81,9 +81,9 @@ kernel.def target(@target) @subgroup_broadcast_first_i32_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %broadcast = kernel.subgroup.broadcast.first %value : i32
@@ -116,9 +116,9 @@ kernel.def target(@target) @subgroup_broadcast_first_i32_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %broadcast = kernel.subgroup.broadcast.first %value : i32
@@ -151,9 +151,9 @@ kernel.def target(@target) @subgroup_shuffle_index_i32_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %offset = scalar.constant 5 : i32
@@ -188,9 +188,9 @@ kernel.def target(@target) @subgroup_shuffle_up_i32_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %offset = scalar.constant 2 : i32
@@ -228,9 +228,9 @@ kernel.def target(@target) @subgroup_broadcast_f32_vector_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf32, #dense>
   %loaded = vector.load %input_view[%tid, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %lane = scalar.constant 3 : i32
   %broadcast = kernel.subgroup.broadcast %loaded from %lane : vector<4xf32>, i32
@@ -270,9 +270,9 @@ kernel.def target(@target) @subgroup_shuffle_down_f32_vector_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf32, #dense>
   %loaded = vector.load %input_view[%tid, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %offset = scalar.constant 4 : i32
   %width = scalar.constant 32 : i32
@@ -316,9 +316,9 @@ kernel.def target(@target) @subgroup_reduce_addi_i32_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %sum = kernel.subgroup.reduce<addi> %value : i32
@@ -354,9 +354,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @subgroup_reduce_addi_i32_sub_wave_power2() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 8 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -393,9 +393,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(8, 1, 1
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @subgroup_reduce_minsi_i32_wave32() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %wave_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%wave_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%wave_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -436,9 +436,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @workgroup_reduce_minsi_single_wave() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %wave_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%wave_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%wave_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -479,9 +479,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @workgroup_reduce_addf_sub_wave_power2() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 8 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -515,9 +515,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(8, 1, 1
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @workgroup_reduce_addf_sub_wave_non_power2() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 24 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -581,9 +581,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(24, 1, 
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @workgroup_reduce_addf_f32_multi_wave() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -645,9 +645,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
 
 kernel.def target(@target) @workgroup_reduce_addf_f32_wave64_sub_wave() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -684,9 +684,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 
 amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
 
 kernel.def target(@target) @workgroup_reduce_addf_f32_wave64_full_wave() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -750,31 +750,31 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
 
 kernel.def target(@target) @workgroup_reduce_addf_f32_wave64_two_rows() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%row_count: index, %fusion_flags: i32, %input0: buffer, %input1: buffer, %bias: buffer, %output: buffer) {
   %tid0 = kernel.workitem.id<x> : index
   %tid = index.assume %tid0 [range(%tid0, 0, 63)] : index
-  %zero_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %input0_view = buffer.view %input0[%zero_offset] : buffer -> view<64xf32, #dense>
-  %input1_view = buffer.view %input1[%zero_offset] : buffer -> view<64xf32, #dense>
-  %bias_view = buffer.view %bias[%zero_offset] : buffer -> view<2xf32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<2xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %c0 = index.constant 0 : index
+  %second_row = index.constant 1 : index
+  %input0_view = buffer.view %input0[%buffer_base] : buffer -> view<64xf32, #dense>
+  %input1_view = buffer.view %input1[%buffer_base] : buffer -> view<64xf32, #dense>
+  %bias_view = buffer.view %bias[%buffer_base] : buffer -> view<2xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<2xf32, #dense>
   %loaded0 = vector.load %input0_view[%tid] : view<64xf32, #dense> -> vector<1xf32>
   %value0 = vector.extract %loaded0[0] : vector<1xf32> -> f32
   %loaded1 = vector.load %input1_view[%tid] : view<64xf32, #dense> -> vector<1xf32>
   %value1 = vector.extract %loaded1[0] : vector<1xf32> -> f32
   %sum0 = kernel.workgroup.reduce<addf> %value0 : f32
   %sum1 = kernel.workgroup.reduce<addf> %value1 : f32
-  %zero_i32 = scalar.constant 0 : i32
-  %one_i32 = scalar.constant 1 : i32
-  %has_bias_bits = scalar.andi %fusion_flags, %one_i32 : i32
-  %has_bias = scalar.cmpi ne, %has_bias_bits, %zero_i32 : i32
+  %no_fusion = scalar.constant 0 : i32
+  %bias_flag = scalar.constant 1 : i32
+  %has_bias_bits = scalar.andi %fusion_flags, %bias_flag : i32
+  %has_bias = scalar.cmpi ne, %has_bias_bits, %no_fusion : i32
   %out0 = scf.if %has_bias -> (f32) {
-    %bias0 = vector.load %bias_view[%zero] : view<2xf32, #dense> -> vector<1xf32>
+    %bias0 = vector.load %bias_view[%c0] : view<2xf32, #dense> -> vector<1xf32>
     %bias0_scalar = vector.extract %bias0[0] : vector<1xf32> -> f32
     %with_bias0 = scalar.addf %sum0, %bias0_scalar : f32
     scf.yield %with_bias0 : f32
@@ -782,23 +782,23 @@ kernel.def target(@target) @workgroup_reduce_addf_f32_wave64_two_rows() {
     scf.yield %sum0 : f32
   }
   %out1 = scf.if %has_bias -> (f32) {
-    %bias1 = vector.load %bias_view[%one] : view<2xf32, #dense> -> vector<1xf32>
+    %bias1 = vector.load %bias_view[%second_row] : view<2xf32, #dense> -> vector<1xf32>
     %bias1_scalar = vector.extract %bias1[0] : vector<1xf32> -> f32
     %with_bias1 = scalar.addf %sum1, %bias1_scalar : f32
     scf.yield %with_bias1 : f32
   } else {
     scf.yield %sum1 : f32
   }
-  %is_lane0 = index.cmp eq, %tid, %zero : index
+  %is_lane0 = index.cmp eq, %tid, %c0 : index
   scf.if %is_lane0 {
     %result0 = vector.from_elements %out0 : vector<1xf32>
-    vector.store %result0, %output_view[%zero] : vector<1xf32>, view<2xf32, #dense>
+    vector.store %result0, %output_view[%c0] : vector<1xf32>, view<2xf32, #dense>
   }
-  %row1_in_bounds = index.cmp ult, %one, %row_count : index
+  %row1_in_bounds = index.cmp ult, %second_row, %row_count : index
   scf.if %row1_in_bounds {
     scf.if %is_lane0 {
       %result1 = vector.from_elements %out1 : vector<1xf32>
-      vector.store %result1, %output_view[%one] : vector<1xf32>, view<2xf32, #dense>
+      vector.store %result1, %output_view[%second_row] : vector<1xf32>, view<2xf32, #dense>
     }
   }
   kernel.return
@@ -811,7 +811,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %input1_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
   %bias_view = resource<hal_binding> {index = 2, source_type = hal.buffer, extent = 8} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 3, source_type = hal.buffer, extent = 8} : reg<amdgpu.sgpr x2>
-  %one = s_mov_b32 1
+  %second_row = s_mov_b32 1
   %57 = v_lshlrev_b32_src0_inline %tid, 2
   %value0 = global_load_b32_saddr %57, %input0_view
   %value1 = global_load_b32_saddr %57, %input1_view
@@ -881,12 +881,12 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   s_mov_b64_exec %116
   s_barrier
   %sum1 = ds_read_b32 %92
-  %zero_i32 = s_mov_b32 0
-  %one_i32 = s_mov_b32 1
-  %has_bias_bits = s_and_b32 %fusion_flags, %one_i32
-  %122 = s_cmp_lg_i32 %has_bias_bits, %zero_i32
-  %has_bias = s_cselect_b32 %one_i32, %zero_i32, %122
-  %127 = s_cmp_lg_i32 %has_bias, %zero_i32
+  %no_fusion = s_mov_b32 0
+  %bias_flag = s_mov_b32 1
+  %has_bias_bits = s_and_b32 %fusion_flags, %bias_flag
+  %122 = s_cmp_lg_i32 %has_bias_bits, %no_fusion
+  %has_bias = s_cselect_b32 %bias_flag, %no_fusion, %122
+  %127 = s_cmp_lg_i32 %has_bias, %no_fusion
   low.cond_br %127, ^_bb1, ^_bb2 : reg<amdgpu.scc>
 ^_bb1:
   %128 = v_mov_b32 0
@@ -896,7 +896,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 ^_bb2:
   low.br ^_bb3(%sum0: reg<amdgpu.vgpr>)
 ^_bb3(%result0: reg<amdgpu.vgpr>):
-  %132 = s_cmp_lg_i32 %has_bias, %zero_i32
+  %132 = s_cmp_lg_i32 %has_bias, %no_fusion
   low.cond_br %132, ^_bb4, ^_bb5 : reg<amdgpu.scc>
 ^_bb4:
   %133 = v_mov_b32 0
@@ -914,7 +914,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   global_store_b32_saddr %139, %result0, %output_view
   low.br ^_bb12
 ^_bb8:
-  %row1_in_bounds = s_cmp_lt_u32 %one, %row_count
+  %row1_in_bounds = s_cmp_lt_u32 %second_row, %row_count
   low.cond_br %row1_in_bounds, ^_bb9, ^_bb11 : reg<amdgpu.scc>
 ^_bb9:
   %141, %142 = s_and_saveexec_b64 %is_lane0
@@ -938,9 +938,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
 
 kernel.def target(@target) @workgroup_reduce_addf_f32_wave64_multi_wave() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 128 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -1010,9 +1010,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(128, 1,
 amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
 
 kernel.def target(@target) @workgroup_reduce_addf_f32_wave64_partial_tail() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 96 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -1079,22 +1079,22 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(96, 1, 
 amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
 
 kernel.def target(@target) @workgroup_reduce_addf_f32_wave64_leader_only_full_wave() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %leader_index = index.constant 0 : index
   %input_view = buffer.view %input[%start] : buffer -> view<64xf32, #dense>
   %output_view = buffer.view %output[%start] : buffer -> view<1xf32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xf32, #dense> -> vector<1xf32>
   %value = vector.extract %loaded[0] : vector<1xf32> -> f32
   %sum = kernel.workgroup.reduce<addf> %value : f32
-  %is_leader = index.cmp eq, %tid, %zero : index
+  %is_leader = index.cmp eq, %tid, %leader_index : index
   scf.if %is_leader {
     %result = vector.from_elements %sum : vector<1xf32>
-    vector.store %result, %output_view[%zero] : vector<1xf32>, view<1xf32, #dense>
+    vector.store %result, %output_view[%leader_index] : vector<1xf32>, view<1xf32, #dense>
   }
   kernel.return
 }
@@ -1149,22 +1149,22 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
 
 kernel.def target(@target) @workgroup_reduce_addf_f32_wave64_leader_only_cross_wave() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 128 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %leader_index = index.constant 0 : index
   %input_view = buffer.view %input[%start] : buffer -> view<128xf32, #dense>
   %output_view = buffer.view %output[%start] : buffer -> view<1xf32, #dense>
   %loaded = vector.load %input_view[%tid] : view<128xf32, #dense> -> vector<1xf32>
   %value = vector.extract %loaded[0] : vector<1xf32> -> f32
   %sum = kernel.workgroup.reduce<addf> %value : f32
-  %is_leader = index.cmp eq, %tid, %zero : index
+  %is_leader = index.cmp eq, %tid, %leader_index : index
   scf.if %is_leader {
     %result = vector.from_elements %sum : vector<1xf32>
-    vector.store %result, %output_view[%zero] : vector<1xf32>, view<1xf32, #dense>
+    vector.store %result, %output_view[%leader_index] : vector<1xf32>, view<1xf32, #dense>
   }
   kernel.return
 }
@@ -1228,22 +1228,22 @@ amdgpu.target<gfx11-generic> @target
 // leave the cross-wave partial in that leader workitem instead of publishing it
 // back through LDS for every workitem.
 kernel.def target(@target) @workgroup_reduce_addf_f32_leader_only_multi_wave() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %leader_index = index.constant 0 : index
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xf32, #dense> -> vector<1xf32>
   %value = vector.extract %loaded[0] : vector<1xf32> -> f32
   %sum = kernel.workgroup.reduce<addf> %value : f32
-  %is_leader = index.cmp eq, %tid, %zero : index
+  %is_leader = index.cmp eq, %tid, %leader_index : index
   scf.if %is_leader {
     %result = vector.from_elements %sum : vector<1xf32>
-    vector.store %result, %output_view[%zero] : vector<1xf32>, view<1xf32, #dense>
+    vector.store %result, %output_view[%leader_index] : vector<1xf32>, view<1xf32, #dense>
   }
   kernel.return
 }
@@ -1304,20 +1304,20 @@ amdgpu.target<gfx11-generic> @target
 // reduce the per-wave partials in each wave without broadcasting the final
 // result to non-leader lanes.
 kernel.def target(@target) @workgroup_reduce_addf_f32_wave_leader_multi_wave() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %lane = kernel.subgroup.lane.id : index
-  %zero_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %leader_lane = index.constant 0 : index
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xf32, #dense> -> vector<1xf32>
   %value = vector.extract %loaded[0] : vector<1xf32> -> f32
   %sum = kernel.workgroup.reduce<addf> %value : f32
-  %is_wave_leader = index.cmp eq, %lane, %zero : index
+  %is_wave_leader = index.cmp eq, %lane, %leader_lane : index
   scf.if %is_wave_leader {
     %result = vector.from_elements %sum : vector<1xf32>
     vector.store %result, %output_view[%tid] : vector<1xf32>, view<64xf32, #dense>
@@ -1378,9 +1378,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @workgroup_reduce_addf_f32_fourteen_waves() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 448 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -1465,9 +1465,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(448, 1,
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @workgroup_reduce_addf_f32_partial_tail() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 48 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -1559,9 +1559,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(48, 1, 
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @workgroup_reduce_minsi_vector_partial_tail() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 48 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -1685,9 +1685,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(48, 1, 
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @workgroup_reduce_addf_f32_vector_multi_wave() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -1809,9 +1809,9 @@ kernel.def target(@target) @subgroup_scan_inclusive_addi_i32_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %prefix = kernel.subgroup.scan<addi> %value {direction = forward, mode = inclusive} : i32
@@ -1878,9 +1878,9 @@ kernel.def target(@target) @subgroup_scan_exclusive_reverse_addi_i32_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %prefix = kernel.subgroup.scan<addi> %value {direction = reverse, mode = exclusive} : i32
@@ -1951,9 +1951,9 @@ kernel.def target(@target) @workgroup_scan_inclusive_addi_i32_one_wave() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c16, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<16xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %prefix = kernel.workgroup.scan<addi> %value {direction = forward, mode = inclusive} : i32
@@ -2012,9 +2012,9 @@ kernel.def target(@target) @workgroup_scan_inclusive_addi_i32_multi_wave() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %prefix = kernel.workgroup.scan<addi> %value {direction = forward, mode = inclusive} : i32
@@ -2099,9 +2099,9 @@ kernel.def target(@target) @workgroup_scan_inclusive_addi_i32_partial_tail() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c48, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<48xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<48xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<48xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<48xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<48xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %prefix = kernel.workgroup.scan<addi> %value {direction = forward, mode = inclusive} : i32
@@ -2188,9 +2188,9 @@ kernel.def target(@target) @workgroup_scan_reverse_exclusive_addi_i32_partial_ta
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c48, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<48xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<48xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<48xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<48xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<48xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %prefix = kernel.workgroup.scan<addi> %value {direction = reverse, mode = exclusive} : i32
@@ -2281,9 +2281,9 @@ kernel.def target(@target) @workgroup_scan_reverse_exclusive_addi_i32_partial_ta
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c80, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<80xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<80xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<80xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<80xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<80xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %prefix = kernel.workgroup.scan<addi> %value {direction = reverse, mode = exclusive} : i32
@@ -2400,9 +2400,9 @@ kernel.def target(@target) @workgroup_scan_reverse_exclusive_addi_i32_multi_wave
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %prefix = kernel.workgroup.scan<addi> %value {direction = reverse, mode = exclusive} : i32
@@ -2493,8 +2493,8 @@ kernel.def target(@target) @subgroup_active_mask_i32_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %mask = kernel.subgroup.active.mask : i32
   %result = vector.from_elements %mask : vector<1xi32>
   vector.store %result, %output_view[%tid] : vector<1xi32>, view<64xi32, #dense>
@@ -2523,9 +2523,9 @@ kernel.def target(@target) @subgroup_vote_ballot_i32_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %threshold = scalar.constant 0 : i32
@@ -2560,9 +2560,9 @@ kernel.def target(@target) @subgroup_vote_ballot_i64_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi64, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi64, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %threshold = scalar.constant 0 : i32
@@ -2601,8 +2601,8 @@ kernel.def target(@target) @subgroup_vote_any_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %threshold = scalar.constant 0 : i32
@@ -2641,8 +2641,8 @@ kernel.def target(@target) @subgroup_vote_all_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %threshold = scalar.constant 0 : i32
@@ -2683,8 +2683,8 @@ kernel.def target(@target) @subgroup_vote_any_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %threshold = scalar.constant 0 : i32
@@ -2724,8 +2724,8 @@ kernel.def target(@target) @subgroup_vote_all_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %threshold = scalar.constant 0 : i32
@@ -2763,9 +2763,9 @@ kernel.def target(@target) @subgroup_match_all_i32_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %mask, %all = kernel.subgroup.match.all %value : i32 -> i32, i1
@@ -2805,9 +2805,9 @@ kernel.def target(@target) @subgroup_match_all_i32_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi64, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi64, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %mask, %all = kernel.subgroup.match.all %value : i32 -> i64, i1
@@ -2852,8 +2852,8 @@ kernel.def target(@target) @subgroup_match_any_i32_wave32_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi64, #dense>
+  %buffer_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi64, #dense>
   %lane = kernel.subgroup.lane.id : index
   %lane_i32 = index.cast %lane : index to i32
   %mod_mask = scalar.constant 3 : i32
@@ -3575,15 +3575,15 @@ kernel.def target(@target) @subgroup_divergent_lane_mask_select_i64_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero_offset = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<64xi64, #dense>
+  %buffer_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi64, #dense>
   %lane = kernel.subgroup.lane.id : index
   %lane_i32 = index.cast %lane : index to i32
   %limit = scalar.constant 32 : i32
   %predicate = scalar.cmpi slt, %lane_i32, %limit : i32
   %active = kernel.subgroup.active.mask : i64
-  %zero = scalar.constant 0 : i64
-  %selected = scf.select %predicate, %active, %zero : i64
+  %inactive_mask = scalar.constant 0 : i64
+  %selected = scf.select %predicate, %active, %inactive_mask : i64
   %result = vector.from_elements %selected : vector<1xi64>
   vector.store %result, %output_view[%tid] : vector<1xi64>, view<64xi64, #dense>
   kernel.return
@@ -3620,8 +3620,8 @@ kernel.def target(@target) @subgroup_active_mask_trunci_i32_wave64() {
 } launch() {
   %mask64 = kernel.subgroup.active.mask : i64
   %mask = scalar.trunci %mask64 : i64 to i32
-  %zero = scalar.constant 0 : i32
-  %condition = scalar.cmpi ne, %mask, %zero : i32
+  %empty_mask = scalar.constant 0 : i32
+  %condition = scalar.cmpi ne, %mask, %empty_mask : i32
   cfg.cond_br %condition, ^then, ^join
 ^then:
   cfg.br ^join
@@ -3643,9 +3643,9 @@ kernel.def target(@target) @subgroup_broadcast_i32_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %lane = scalar.constant 63 : i32
@@ -3680,9 +3680,9 @@ kernel.def target(@target) @subgroup_reduce_addf_f32_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xf32, #dense> -> vector<1xf32>
   %value = vector.extract %loaded[0] : vector<1xf32> -> f32
   %sum = kernel.subgroup.reduce<addf> %value : f32
@@ -3738,9 +3738,9 @@ kernel.def target(@target) @subgroup_shuffle_xor_i32_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %offset = scalar.constant 32 : i32
@@ -3778,15 +3778,15 @@ kernel.def target(@target) @subgroup_reduce_addf_f32_wave64_leader_lane() {
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %lane = kernel.subgroup.lane.id : index
-  %zero_index = index.constant 0 : index
-  %zero_offset = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xf32, #dense>
+  %leader_lane = index.constant 0 : index
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %sum = kernel.subgroup.reduce<addf> %value : f32
-  %is_leader_lane = index.cmp eq, %lane, %zero_index : index
+  %is_leader_lane = index.cmp eq, %lane, %leader_lane : index
   scf.if %is_leader_lane {
-    view.store %sum, %output_view[%zero_index] : f32, view<1xf32, #dense>
+    view.store %sum, %output_view[%leader_lane] : f32, view<1xf32, #dense>
   }
   kernel.return
 }
@@ -3829,28 +3829,28 @@ kernel.def target(@target) @subgroup_reduce_addf_f32_wave64_scalar_workitem_guar
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer, %bias: buffer, %flags: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero_index = index.constant 0 : index
-  %zero_offset = index.constant 0 : offset
-  %zero_i32 = scalar.constant 0 : i32
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xf32, #dense>
-  %bias_view = buffer.view %bias[%zero_offset] : buffer -> view<1xf32, #dense>
-  %flags_view = buffer.view %flags[%zero_offset] : buffer -> view<1xi32, #dense>
+  %element_index = index.constant 0 : index
+  %buffer_base = index.constant 0 : offset
+  %c0 = scalar.constant 0 : i32
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
+  %bias_view = buffer.view %bias[%buffer_base] : buffer -> view<1xf32, #dense>
+  %flags_view = buffer.view %flags[%buffer_base] : buffer -> view<1xi32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %sum = kernel.subgroup.reduce<addf> %value : f32
   %tid_i32 = index.cast %tid : index to i32
-  %is_leader = scalar.cmpi eq, %tid_i32, %zero_i32 : i32
+  %is_leader = scalar.cmpi eq, %tid_i32, %c0 : i32
   scf.if %is_leader {
-    %flag = view.load %flags_view[%zero_index] : view<1xi32, #dense> -> i32
-    %has_bias = scalar.cmpi ne, %flag, %zero_i32 : i32
+    %flag = view.load %flags_view[%element_index] : view<1xi32, #dense> -> i32
+    %has_bias = scalar.cmpi ne, %flag, %c0 : i32
     %out = scf.if %has_bias -> (f32) {
-      %bias_value = view.load %bias_view[%zero_index] : view<1xf32, #dense> -> f32
+      %bias_value = view.load %bias_view[%element_index] : view<1xf32, #dense> -> f32
       %biased = scalar.addf %sum, %bias_value : f32
       scf.yield %biased : f32
     } else {
       scf.yield %sum : f32
     }
-    view.store %out, %output_view[%zero_index] : f32, view<1xf32, #dense>
+    view.store %out, %output_view[%element_index] : f32, view<1xf32, #dense>
   }
   kernel.return
 }
@@ -3924,15 +3924,15 @@ kernel.def target(@target) @subgroup_reduce_addf_f32_cluster32_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : index
+  %leader_index = index.constant 0 : index
   %base = index.constant 0 : offset
   %input_view = buffer.view %input[%base] : buffer -> view<64xf32, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<1xf32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %sum = kernel.subgroup.reduce<addf> %value {cluster_size = 32} : f32
-  %is_leader = index.cmp eq, %tid, %zero : index
+  %is_leader = index.cmp eq, %tid, %leader_index : index
   scf.if %is_leader {
-    view.store %sum, %output_view[%zero] : f32, view<1xf32, #dense>
+    view.store %sum, %output_view[%leader_index] : f32, view<1xf32, #dense>
   }
   kernel.return
 }
@@ -3971,9 +3971,9 @@ kernel.def target(@target) @subgroup_shuffle_xor_f32_pair_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %offset = scalar.constant 1 : i32
   %width = scalar.constant 2 : i32
@@ -4004,9 +4004,9 @@ kernel.def target(@target) @subgroup_shuffle_xor_v2f32_pair_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x2xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x2xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x2xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x2xf32, #dense>
   %value = vector.load %input_view[%tid, 0] : view<64x2xf32, #dense> -> vector<2xf32>
   %offset = scalar.constant 1 : i32
   %width = scalar.constant 2 : i32
@@ -4041,9 +4041,9 @@ kernel.def target(@target) @subgroup_shuffle_xor_i32_quad_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %value = view.load %input_view[%tid] : view<64xi32, #dense> -> i32
   %offset = scalar.constant 2 : i32
   %width = scalar.constant 4 : i32
@@ -4074,9 +4074,9 @@ kernel.def target(@target) @subgroup_shuffle_xor_f32_cluster8_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %offset = scalar.constant 4 : i32
   %width = scalar.constant 8 : i32
@@ -4107,9 +4107,9 @@ kernel.def target(@target) @subgroup_shuffle_xor_f32_cluster16_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %offset = scalar.constant 8 : i32
   %width = scalar.constant 16 : i32
@@ -4140,9 +4140,9 @@ kernel.def target(@target) @subgroup_shuffle_xor_f32_cluster32_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %offset = scalar.constant 16 : i32
   %width = scalar.constant 32 : i32
@@ -4173,9 +4173,9 @@ kernel.def target(@target) @subgroup_shuffle_index_i32_cluster8_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %offset = scalar.constant 5 : i32
@@ -4211,9 +4211,9 @@ kernel.def target(@target) @subgroup_shuffle_down_i32_cluster8_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %offset = scalar.constant 2 : i32
@@ -4249,9 +4249,9 @@ kernel.def target(@target) @subgroup_shuffle_down_valid_cluster8_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %offset = scalar.constant 2 : i32
@@ -4299,9 +4299,9 @@ kernel.def target(@target) @subgroup_reduce_addf_f32_cluster8_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %sum = kernel.subgroup.reduce<addf> %value {cluster_size = 8} : f32
   view.store %sum, %output_view[%tid] : f32, view<64xf32, #dense>
@@ -4332,9 +4332,9 @@ kernel.def target(@target) @subgroup_reduce_maxnumf_f32_cluster8_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %max = kernel.subgroup.reduce<maxnumf> %value {cluster_size = 8} : f32
   view.store %max, %output_view[%tid] : f32, view<64xf32, #dense>
@@ -4361,15 +4361,15 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
 
 kernel.def target(@target) @subgroup_reduce_f32x4_wave64_all_lanes() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %max_output: buffer, %sum_output: buffer) {
   %lane = kernel.subgroup.lane.id : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xf32, #dense>
-  %max_output_view = buffer.view %max_output[%zero] : buffer -> view<64x4xf32, #dense>
-  %sum_output_view = buffer.view %sum_output[%zero] : buffer -> view<64x4xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %max_output_view = buffer.view %max_output[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %sum_output_view = buffer.view %sum_output[%buffer_base] : buffer -> view<64x4xf32, #dense>
   %value = vector.load %input_view[%lane, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %max = kernel.subgroup.reduce<maxnumf> %value : vector<4xf32>
   %sum = kernel.subgroup.reduce<addf> %value : vector<4xf32>
@@ -4487,21 +4487,21 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @workgroup_reduce_result_drives_divergent_control() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%output: buffer) {
   %lane = kernel.workitem.id<x> : index
   %lane_i32 = index.cast %lane : index to i32
   %sum = kernel.workgroup.reduce<addi> %lane_i32 : i32
   %expected = scalar.constant 496 : i32
   %matches = scalar.cmpi eq, %sum, %expected : i32
-  %zero = index.constant 0 : index
-  %zero_offset = index.constant 0 : offset
-  %one_i32 = scalar.constant 1 : i32
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xi32, #dense>
+  %output_index = index.constant 0 : index
+  %output_base = index.constant 0 : offset
+  %success_value = scalar.constant 1 : i32
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   scf.if %matches {
-    view.store %one_i32, %output_view[%zero] : i32, view<1xi32, #dense>
+    view.store %success_value, %output_view[%output_index] : i32, view<1xi32, #dense>
   }
   kernel.return
 }
@@ -4539,21 +4539,21 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @workgroup_scan_result_drives_divergent_control() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 16 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%output: buffer) {
   %lane = kernel.workitem.id<x> : index
   %lane_i32 = index.cast %lane : index to i32
   %sum = kernel.workgroup.scan<addi> %lane_i32 {direction = forward, mode = inclusive} : i32
   %expected = scalar.constant 0 : i32
   %matches = scalar.cmpi eq, %sum, %expected : i32
-  %zero = index.constant 0 : index
-  %zero_offset = index.constant 0 : offset
-  %one_i32 = scalar.constant 1 : i32
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xi32, #dense>
+  %output_index = index.constant 0 : index
+  %output_base = index.constant 0 : offset
+  %success_value = scalar.constant 1 : i32
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   scf.if %matches {
-    view.store %one_i32, %output_view[%zero] : i32, view<1xi32, #dense>
+    view.store %success_value, %output_view[%output_index] : i32, view<1xi32, #dense>
   }
   kernel.return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_collective_cdna3.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_collective_cdna3.loom-test
@@ -7,14 +7,14 @@ amdgpu.target<gfx942> @target
 // operations must not reuse VGPR materializations produced under that narrowed
 // participant set.
 kernel.def target(@target) @workgroup_reduce_then_all_lane_bias_load() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 128 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %bias: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %leader_index = index.constant 0 : index
+  %second_output = index.constant 1 : index
   %input_global = buffer.assume.memory_space<global> %input : buffer
   %bias_global = buffer.assume.memory_space<global> %bias : buffer
   %output_global = buffer.assume.memory_space<global> %output : buffer
@@ -25,14 +25,14 @@ kernel.def target(@target) @workgroup_reduce_then_all_lane_bias_load() {
   %value = view.load %input_view[%tid] : view<128xf32, #dense> -> f32
   %sum0 = kernel.workgroup.reduce<addf> %value : f32
   %sum1 = kernel.workgroup.reduce<addf> %value : f32
-  %bias_bf16 = view.load %bias_view[%zero] : view<1xbf16, #dense> -> bf16
+  %bias_bf16 = view.load %bias_view[%leader_index] : view<1xbf16, #dense> -> bf16
   %bias_f32 = scalar.extf %bias_bf16 : bf16 to f32
   %result0 = scalar.addf<reassoc|nnan|ninf|nsz> %sum0, %bias_f32 : f32
   %result1 = scalar.addf<reassoc|nnan|ninf|nsz> %sum1, %bias_f32 : f32
-  %is_lane0 = index.cmp eq, %tid, %zero : index
+  %is_lane0 = index.cmp eq, %tid, %leader_index : index
   scf.if %is_lane0 {
-    view.store %result0, %output_view[%zero] : f32, view<2xf32, #dense>
-    view.store %result1, %output_view[%one] : f32, view<2xf32, #dense>
+    view.store %result0, %output_view[%leader_index] : f32, view<2xf32, #dense>
+    view.store %result1, %output_view[%second_output] : f32, view<2xf32, #dense>
   }
   kernel.return
 }
@@ -175,9 +175,9 @@ kernel.def target(@target) @subgroup_shuffle_xor_f32_pair_cdna3() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %offset = scalar.constant 1 : i32
   %width = scalar.constant 2 : i32
@@ -211,9 +211,9 @@ kernel.def target(@target) @subgroup_shuffle_xor_f32_octet_cdna3() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %offset = scalar.constant 4 : i32
   %width = scalar.constant 8 : i32
@@ -247,9 +247,9 @@ kernel.def target(@target) @subgroup_shuffle_xor_f32_cluster16_cdna3() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %offset = scalar.constant 8 : i32
   %width = scalar.constant 16 : i32
@@ -283,9 +283,9 @@ kernel.def target(@target) @subgroup_reduce_addf_f32_cluster8_cdna3() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %sum = kernel.subgroup.reduce<addf> %value {cluster_size = 8} : f32
   view.store %sum, %output_view[%tid] : f32, view<64xf32, #dense>
@@ -319,9 +319,9 @@ kernel.def target(@target) @subgroup_reduce_maxnumf_f32_cluster8_cdna3() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %max = kernel.subgroup.reduce<maxnumf> %value {cluster_size = 8} : f32
   view.store %max, %output_view[%tid] : f32, view<64xf32, #dense>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_collective_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_collective_diagnostics.loom-test
@@ -6,8 +6,8 @@ kernel.def target(@target) @subgroup_broadcast_dynamic_lane_rejected() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
+  %input_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%input_base] : buffer -> view<1xi32, #dense>
   %lane_vector = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %lane = vector.extract %lane_vector[0] : vector<1xi32> -> i32
   %workitem = kernel.workitem.id<x> : index
@@ -74,8 +74,8 @@ kernel.def target(@target) @subgroup_shuffle_dynamic_offset_rejected() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
+  %input_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%input_base] : buffer -> view<1xi32, #dense>
   %offset_vector = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %offset = vector.extract %offset_vector[0] : vector<1xi32> -> i32
   %width = scalar.constant 32 : i32
@@ -94,8 +94,8 @@ kernel.def target(@target) @subgroup_shuffle_dynamic_width_rejected() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
+  %input_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%input_base] : buffer -> view<1xi32, #dense>
   %width_vector = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %width = vector.extract %width_vector[0] : vector<1xi32> -> i32
   %offset = scalar.constant 1 : i32
@@ -426,15 +426,15 @@ kernel.def target(@target) @subgroup_reduce_wave64_leader_publication_rejected()
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %lane = kernel.subgroup.lane.id : index
-  %zero_index = index.constant 0 : index
-  %zero_offset = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xi32, #dense>
+  %leader_lane = index.constant 0 : index
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   %value = scalar.constant 1 : i32
   // ERROR@+1: AMDGPU/023 {constraint_key="subgroup_reduce.native_width.scalar_broadcast"}
   %sum = kernel.subgroup.reduce<addi> %value : i32
-  %is_leader_lane = index.cmp eq, %lane, %zero_index : index
+  %is_leader_lane = index.cmp eq, %lane, %leader_lane : index
   scf.if %is_leader_lane {
-    view.store %sum, %output_view[%zero_index] : i32, view<1xi32, #dense>
+    view.store %sum, %output_view[%leader_lane] : i32, view<1xi32, #dense>
   }
   kernel.return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_collective_gfx12.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_collective_gfx12.loom-test
@@ -3,9 +3,9 @@
 amdgpu.target<gfx1250> @target
 
 kernel.def target(@target) @workgroup_reduce_addf_f32_multi_wave_gfx1250() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -68,9 +68,9 @@ low.kernel.def target<amdgpu.rdna4.gfx125x.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx1250> @target
 
 kernel.def target(@target) @workgroup_scan_inclusive_addi_i32_multi_wave_gfx1250() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -161,8 +161,8 @@ kernel.def target(@target) @subgroup_vote_any_wave64_gfx12() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %threshold = scalar.constant 0 : i32
@@ -202,8 +202,8 @@ kernel.def target(@target) @subgroup_vote_all_wave64_gfx12() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %threshold = scalar.constant 0 : i32
@@ -242,9 +242,9 @@ kernel.def target(@target) @subgroup_broadcast_first_i32_wave64_gfx12() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xi32, #dense> -> vector<1xi32>
   %value = vector.extract %loaded[0] : vector<1xi32> -> i32
   %broadcast = kernel.subgroup.broadcast.first %value : i32

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_collective_report.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_collective_report.loom-test
@@ -3,9 +3,9 @@
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @report_workgroup_reduce_scalar_publication() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -47,23 +47,23 @@ COMPILE-REPORT: target_legalization[0] function=report_workgroup_reduce_scalar_p
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @report_workgroup_reduce_scalar_leader_publication() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %leader_index = index.constant 0 : index
   %input_view = buffer.view %input[%start] : buffer -> view<64xf32, #dense>
   %output_view = buffer.view %output[%start] : buffer -> view<1xf32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xf32, #dense> -> vector<1xf32>
   %value = vector.extract %loaded[0] : vector<1xf32> -> f32
   %sum = kernel.workgroup.reduce<addf> %value : f32
-  %is_leader = index.cmp eq, %tid, %zero : index
+  %is_leader = index.cmp eq, %tid, %leader_index : index
   cfg.cond_br %is_leader, ^then, ^done
 ^then:
   %result = vector.from_elements %sum : vector<1xf32>
-  vector.store %result, %output_view[%zero] : vector<1xf32>, view<1xf32, #dense>
+  vector.store %result, %output_view[%leader_index] : vector<1xf32>, view<1xf32, #dense>
   cfg.br ^done
 ^done:
   kernel.return
@@ -99,25 +99,25 @@ COMPILE-REPORT: target_legalization[0] function=report_workgroup_reduce_scalar_l
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @report_workgroup_reduce_scalar_leader_publication_projected_tid() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   cfg.br ^body(%tid: index)
 ^body(%tid_arg: index):
   %start = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %leader_index = index.constant 0 : index
   %input_view = buffer.view %input[%start] : buffer -> view<64xf32, #dense>
   %output_view = buffer.view %output[%start] : buffer -> view<1xf32, #dense>
   %loaded = vector.load %input_view[%tid_arg] : view<64xf32, #dense> -> vector<1xf32>
   %value = vector.extract %loaded[0] : vector<1xf32> -> f32
   %sum = kernel.workgroup.reduce<addf> %value : f32
-  %is_leader = index.cmp eq, %tid_arg, %zero : index
+  %is_leader = index.cmp eq, %tid_arg, %leader_index : index
   cfg.cond_br %is_leader, ^then, ^done
 ^then:
   %result = vector.from_elements %sum : vector<1xf32>
-  vector.store %result, %output_view[%zero] : vector<1xf32>, view<1xf32, #dense>
+  vector.store %result, %output_view[%leader_index] : vector<1xf32>, view<1xf32, #dense>
   cfg.br ^done
 ^done:
   kernel.return
@@ -153,20 +153,20 @@ COMPILE-REPORT: target_legalization[0] function=report_workgroup_reduce_scalar_l
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @report_workgroup_reduce_scalar_wave_leader_publication() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %lane = kernel.subgroup.lane.id : index
   %start = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %leader_lane = index.constant 0 : index
   %input_view = buffer.view %input[%start] : buffer -> view<64xf32, #dense>
   %output_view = buffer.view %output[%start] : buffer -> view<64xf32, #dense>
   %loaded = vector.load %input_view[%tid] : view<64xf32, #dense> -> vector<1xf32>
   %value = vector.extract %loaded[0] : vector<1xf32> -> f32
   %sum = kernel.workgroup.reduce<addf> %value : f32
-  %is_wave_leader = index.cmp eq, %lane, %zero : index
+  %is_wave_leader = index.cmp eq, %lane, %leader_lane : index
   cfg.cond_br %is_wave_leader, ^then, ^done
 ^then:
   %result = vector.from_elements %sum : vector<1xf32>
@@ -207,9 +207,9 @@ COMPILE-REPORT: target_legalization[0] function=report_workgroup_reduce_scalar_w
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @report_workgroup_reduce_vector_publication() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -263,9 +263,9 @@ COMPILE-REPORT: target_legalization[0] function=report_workgroup_reduce_vector_p
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @report_subgroup_reduce_addf_f32_wave32_all_lanes() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %start = index.constant 0 : offset
@@ -303,22 +303,22 @@ COMPILE-REPORT: source_low_memory_argument_packet[1] function=report_subgroup_re
 amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
 
 kernel.def target(@target) @report_subgroup_reduce_addf_f32_wave64_leader_lane() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
   %lane = kernel.subgroup.lane.id : index
-  %zero = index.constant 0 : index
+  %leader_lane = index.constant 0 : index
   %start = index.constant 0 : offset
   %input_view = buffer.view %input[%start] : buffer -> view<64xf32, #dense>
   %output_view = buffer.view %output[%start] : buffer -> view<1xf32, #dense>
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %sum = kernel.subgroup.reduce<addf> %value : f32
-  %is_leader_lane = index.cmp eq, %lane, %zero : index
+  %is_leader_lane = index.cmp eq, %lane, %leader_lane : index
   cfg.cond_br %is_leader_lane, ^then, ^done
 ^then:
-  view.store %sum, %output_view[%zero] : f32, view<1xf32, #dense>
+  view.store %sum, %output_view[%leader_lane] : f32, view<1xf32, #dense>
   cfg.br ^done
 ^done:
   kernel.return
@@ -353,14 +353,14 @@ COMPILE-REPORT: source_low_memory_argument_packet[1] function=report_subgroup_re
 amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
 
 kernel.def target(@target) @report_subgroup_reduce_addf_f32_wave64_scalar_workitem_guard_nested() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer, %bias: buffer, %flags: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : index
+  %element_index = index.constant 0 : index
   %start = index.constant 0 : offset
-  %zero_i32 = scalar.constant 0 : i32
+  %c0 = scalar.constant 0 : i32
   %input_view = buffer.view %input[%start] : buffer -> view<64xf32, #dense>
   %output_view = buffer.view %output[%start] : buffer -> view<1xf32, #dense>
   %bias_view = buffer.view %bias[%start] : buffer -> view<1xf32, #dense>
@@ -368,20 +368,20 @@ kernel.def target(@target) @report_subgroup_reduce_addf_f32_wave64_scalar_workit
   %value = view.load %input_view[%tid] : view<64xf32, #dense> -> f32
   %sum = kernel.subgroup.reduce<addf> %value : f32
   %tid_i32 = index.cast %tid : index to i32
-  %is_leader = scalar.cmpi eq, %tid_i32, %zero_i32 : i32
+  %is_leader = scalar.cmpi eq, %tid_i32, %c0 : i32
   cfg.cond_br %is_leader, ^then, ^done
 ^then:
-  %flag = view.load %flags_view[%zero] : view<1xi32, #dense> -> i32
-  %has_bias = scalar.cmpi ne, %flag, %zero_i32 : i32
+  %flag = view.load %flags_view[%element_index] : view<1xi32, #dense> -> i32
+  %has_bias = scalar.cmpi ne, %flag, %c0 : i32
   cfg.cond_br %has_bias, ^bias, ^no_bias
 ^bias:
-  %bias_value = view.load %bias_view[%zero] : view<1xf32, #dense> -> f32
+  %bias_value = view.load %bias_view[%element_index] : view<1xf32, #dense> -> f32
   %biased = scalar.addf %sum, %bias_value : f32
   cfg.br ^join(%biased: f32)
 ^no_bias:
   cfg.br ^join(%sum: f32)
 ^join(%out: f32):
-  view.store %out, %output_view[%zero] : f32, view<1xf32, #dense>
+  view.store %out, %output_view[%element_index] : f32, view<1xf32, #dense>
   cfg.br ^done
 ^done:
   kernel.return

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_index.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_index.loom-test
@@ -7,10 +7,10 @@ kernel.def target(@target) @subgroup_id_x_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %subgroup_id = kernel.subgroup.id : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<2xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %output_view[%subgroup_id] : vector<1xi32>, view<2xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<2xi32, #dense>
+  %marker_value = vector.constant 1 : vector<1xi32>
+  vector.store %marker_value, %output_view[%subgroup_id] : vector<1xi32>, view<2xi32, #dense>
   kernel.return
 }
 
@@ -19,9 +19,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %7 = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 8} : reg<amdgpu.sgpr x2>
   %subgroup_id = v_lshrrev_b32_src0_inline %7, 5
-  %one = v_mov_b32 1
+  %marker_value = v_mov_b32 1
   %11 = v_lshlrev_b32_src0_inline %subgroup_id, 2
-  global_store_b32_saddr %11, %one, %output_view
+  global_store_b32_saddr %11, %marker_value, %output_view
   return
 }
 
@@ -35,19 +35,19 @@ kernel.def target(@target) @subgroup_id_single_wave_gfx11() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c32, %c1, %c1) : index
 } launch(%output: buffer) {
   %subgroup_id = kernel.subgroup.id : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %output_view[%subgroup_id] : vector<1xi32>, view<1xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
+  %marker_value = vector.constant 1 : vector<1xi32>
+  vector.store %marker_value, %output_view[%subgroup_id] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
 
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @subgroup_id_single_wave_gfx11() asm {
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 4} : reg<amdgpu.sgpr x2>
-  %one = v_mov_b32 1
+  %marker_value = v_mov_b32 1
   %10 = v_mov_b32 0
-  global_store_b32_saddr %10, %one, %output_view
+  global_store_b32_saddr %10, %marker_value, %output_view
   return
 }
 
@@ -63,10 +63,10 @@ kernel.def target(@target) @subgroup_lane_id_xyz_wave32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c8, %c4, %c2) : index
 } launch(%output: buffer) {
   %lane_id = kernel.subgroup.lane.id : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %output_view[%lane_id] : vector<1xi32>, view<32xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<32xi32, #dense>
+  %marker_value = vector.constant 1 : vector<1xi32>
+  vector.store %marker_value, %output_view[%lane_id] : vector<1xi32>, view<32xi32, #dense>
   kernel.return
 }
 
@@ -84,9 +84,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(8, 4, 2
   %18 = v_lshlrev_b32_src0_inline %17, 5
   %19 = v_add_u32 %15, %18
   %lane_id = v_and_b32_src0_inline %19, 31
-  %one = v_mov_b32 1
+  %marker_value = v_mov_b32 1
   %22 = v_lshlrev_b32_src0_inline %lane_id, 2
-  global_store_b32_saddr %22, %one, %output_view
+  global_store_b32_saddr %22, %marker_value, %output_view
   return
 }
 
@@ -101,10 +101,10 @@ kernel.def target(@target) @subgroup_lane_id_xyz_wave32_gfx12() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c8, %c4, %c2) : index
 } launch(%output: buffer) {
   %lane_id = kernel.subgroup.lane.id : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %output_view[%lane_id] : vector<1xi32>, view<32xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<32xi32, #dense>
+  %marker_value = vector.constant 1 : vector<1xi32>
+  vector.store %marker_value, %output_view[%lane_id] : vector<1xi32>, view<32xi32, #dense>
   kernel.return
 }
 
@@ -122,9 +122,9 @@ low.kernel.def target<amdgpu.rdna4.core>(@target) workgroup_size(8, 4, 2) workgr
   %18 = v_lshlrev_b32_src0_inline %17, 5
   %19 = v_add_u32 %15, %18
   %lane_id = v_and_b32_src0_inline %19, 31
-  %one = v_mov_b32 1
+  %marker_value = v_mov_b32 1
   %22 = v_lshlrev_b32_src0_inline %lane_id, 2
-  global_store_b32_saddr %22, %one, %output_view
+  global_store_b32_saddr %22, %marker_value, %output_view
   return
 }
 
@@ -137,10 +137,10 @@ kernel.def target(@target) @subgroup_id_x_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c128, %c1, %c1) : index
 } launch(%output: buffer) {
   %subgroup_id = kernel.subgroup.id : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<2xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %output_view[%subgroup_id] : vector<1xi32>, view<2xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<2xi32, #dense>
+  %marker_value = vector.constant 1 : vector<1xi32>
+  vector.store %marker_value, %output_view[%subgroup_id] : vector<1xi32>, view<2xi32, #dense>
   kernel.return
 }
 
@@ -149,10 +149,10 @@ low.kernel.def target<amdgpu.cdna4.core>(@target) workgroup_size(128, 1, 1) work
   %7 = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 8} : reg<amdgpu.sgpr x2>
   %subgroup_id = v_lshrrev_b32_src0_inline %7, 6
-  %one = v_mov_b32 1
+  %marker_value = v_mov_b32 1
   %11 = v_lshlrev_b32_src0_inline %subgroup_id, 2
   %12 = s_mov_b32_m0_imm 0
-  global_store_dword_saddr %11, %one, %output_view, %12
+  global_store_dword_saddr %11, %marker_value, %output_view, %12
   return
 }
 
@@ -165,10 +165,10 @@ kernel.def target(@target) @subgroup_lane_id_x_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %lane_id = kernel.subgroup.lane.id : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %output_view[%lane_id] : vector<1xi32>, view<64xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<64xi32, #dense>
+  %marker_value = vector.constant 1 : vector<1xi32>
+  vector.store %marker_value, %output_view[%lane_id] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
 }
 
@@ -176,9 +176,9 @@ kernel.def target(@target) @subgroup_lane_id_x_wave64() {
 low.kernel.def target<amdgpu.cdna4.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @subgroup_lane_id_x_wave64() asm {
   %lane_id = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
-  %one = v_mov_b32 1
+  %marker_value = v_mov_b32 1
   %10 = v_lshlrev_b32_src0_inline %lane_id, 2
   %11 = s_mov_b32_m0_imm 0
-  global_store_dword_saddr %10, %one, %output_view, %11
+  global_store_dword_saddr %10, %marker_value, %output_view, %11
   return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_mask_wave64.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_mask_wave64.loom-test
@@ -8,8 +8,8 @@ kernel.def target(@target) @subgroup_active_mask_i64_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi64, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<64xi64, #dense>
   %mask = kernel.subgroup.active.mask : i64
   %result = vector.from_elements %mask : vector<1xi64>
   vector.store %result, %output_view[%tid] : vector<1xi64>, view<64xi64, #dense>
@@ -41,8 +41,8 @@ kernel.def target(@target) @subgroup_vote_ballot_i64_wave64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi64, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<64xi64, #dense>
   %lane = kernel.subgroup.lane.id : index
   %lane_i32 = index.cast %lane : index to i32
   %limit = scalar.constant 32 : i32

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sync_kernel.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sync_kernel.loom-test
@@ -3,9 +3,9 @@
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @single_wave_barrier() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   kernel.return
@@ -22,9 +22,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @multi_wave_barrier() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   kernel.return
@@ -41,9 +41,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @global_release_barrier() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<global> {ordering = release, scope = workgroup}
   kernel.return
@@ -62,9 +62,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @global_acquire_barrier() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<global> {ordering = acquire, scope = workgroup}
   kernel.return
@@ -84,9 +84,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @global_acq_rel_barrier() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<global> {ordering = acq_rel, scope = workgroup}
   kernel.return
@@ -108,9 +108,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx11-generic> @target
 
 kernel.def target(@target) @multi_wave_subgroup_barrier() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<workgroup> {ordering = acq_rel, scope = subgroup}
   kernel.return
@@ -127,9 +127,9 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx12-generic> @target
 
 kernel.def target(@target) @single_wave_barrier_gfx12() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   kernel.return
@@ -147,9 +147,9 @@ low.kernel.def target<amdgpu.gfx12.generic.core>(@target) workgroup_size(32, 1, 
 amdgpu.target<gfx12-generic> @target
 
 kernel.def target(@target) @multi_wave_barrier_gfx12() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   kernel.return
@@ -167,9 +167,9 @@ low.kernel.def target<amdgpu.gfx12.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx12-generic> @target
 
 kernel.def target(@target) @global_acq_rel_barrier_gfx12() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<global> {ordering = acq_rel, scope = workgroup}
   kernel.return
@@ -191,9 +191,9 @@ low.kernel.def target<amdgpu.gfx12.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx12-generic> @target
 
 kernel.def target(@target) @multi_wave_subgroup_barrier_gfx12() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<workgroup> {ordering = acq_rel, scope = subgroup}
   kernel.return
@@ -210,9 +210,9 @@ low.kernel.def target<amdgpu.gfx12.generic.core>(@target) workgroup_size(64, 1, 
 amdgpu.target<gfx12-5-generic> @target
 
 kernel.def target(@target) @single_wave_barrier_gfx12_5() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   kernel.return
@@ -230,9 +230,9 @@ low.kernel.def target<amdgpu.gfx12_5.generic.core>(@target) workgroup_size(32, 1
 amdgpu.target<gfx12-5-generic> @target
 
 kernel.def target(@target) @multi_wave_barrier_gfx12_5() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   kernel.return
@@ -250,9 +250,9 @@ low.kernel.def target<amdgpu.gfx12_5.generic.core>(@target) workgroup_size(64, 1
 amdgpu.target<gfx12-5-generic> @target
 
 kernel.def target(@target) @multi_wave_subgroup_barrier_gfx12_5() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<workgroup> {ordering = acq_rel, scope = subgroup}
   kernel.return
@@ -269,9 +269,9 @@ low.kernel.def target<amdgpu.gfx12_5.generic.core>(@target) workgroup_size(64, 1
 amdgpu.target<gfx9-4-generic> @target
 
 kernel.def target(@target) @single_wave_barrier_gfx9_4() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   kernel.return
@@ -288,9 +288,9 @@ low.kernel.def target<amdgpu.gfx9_4.generic.core>(@target) workgroup_size(64, 1,
 amdgpu.target<gfx9-4-generic> @target
 
 kernel.def target(@target) @global_acq_rel_barrier_gfx9_4() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<global> {ordering = acq_rel, scope = workgroup}
   kernel.return
@@ -310,9 +310,9 @@ low.kernel.def target<amdgpu.gfx9_4.generic.core>(@target) workgroup_size(64, 1,
 amdgpu.target<gfx9-4-generic> @target
 
 kernel.def target(@target) @multi_wave_subgroup_barrier_gfx9_4() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 128 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<workgroup> {ordering = acq_rel, scope = subgroup}
   kernel.return
@@ -329,9 +329,9 @@ low.kernel.def target<amdgpu.gfx9_4.generic.core>(@target) workgroup_size(128, 1
 amdgpu.target<gfx950> @target
 
 kernel.def target(@target) @global_acq_rel_barrier_gfx950() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch() {
   kernel.barrier<global> {ordering = acq_rel, scope = workgroup}
   kernel.return
@@ -353,16 +353,16 @@ amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
 // A read-only control value loaded from a uniform global address is uniform
 // across the workgroup and may guard a convergent barrier.
 kernel.def target(@target) @uniform_global_load_controls_barrier() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch(%control: buffer) {
-  %zero_index = index.constant 0 : index
-  %zero_offset = index.constant 0 : offset
-  %zero_i32 = scalar.constant 0 : i32
-  %control_view = buffer.view %control[%zero_offset] : buffer -> view<1xi32, #dense>
-  %control_value = view.load %control_view[%zero_index] : view<1xi32, #dense> -> i32
-  %is_zero = scalar.cmpi eq, %control_value, %zero_i32 : i32
+  %control_index = index.constant 0 : index
+  %control_base = index.constant 0 : offset
+  %barrier_control = scalar.constant 0 : i32
+  %control_view = buffer.view %control[%control_base] : buffer -> view<1xi32, #dense>
+  %control_value = view.load %control_view[%control_index] : view<1xi32, #dense> -> i32
+  %is_zero = scalar.cmpi eq, %control_value, %barrier_control : i32
   scf.if %is_zero {
     kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
     scf.yield

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_template_expansion.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_template_expansion.loom-test
@@ -10,25 +10,25 @@
 amdgpu.target<gfx11-generic> @gfx11 {subgroup_size = 32}
 
 func.template<hip.recipe.vector_loop> device @vector_loop_provider(%publish_optional: i1, %input: buffer, %weight: buffer, %optional_output: buffer, %output: buffer) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
-  %onezerotwofour = index.constant 1024 : index
-  %twentyfortyeight = index.constant 2048 : index
-  %zero_offset = index.constant 0 : offset
-  %zero_f32x4 = vector.constant 0.0 : vector<4xf32>
+  %loop_begin = index.constant 0 : index
+  %mask_step = index.constant 1 : index
+  %vector_width = index.constant 4 : index
+  %stripe_step = index.constant 1024 : index
+  %element_count = index.constant 2048 : index
+  %buffer_base = index.constant 0 : offset
+  %masked_zero = vector.constant 0.0 : vector<4xf32>
   %workitem = kernel.workitem.id<x> : index
-  %word_element_add = index.mul %workitem, %four : index
+  %word_element_add = index.mul %workitem, %vector_width : index
   %input_noalias, %weight_noalias, %output_noalias = buffer.assume.noalias %input, %weight, %output : buffer, buffer, buffer
-  %input_view = buffer.view %input_noalias[%zero_offset] : buffer -> view<2048xf32, #dense>
-  %weight_view = buffer.view %weight_noalias[%zero_offset] : buffer -> view<2048xf32, #dense>
-  %optional_output_view = buffer.view %optional_output[%zero_offset] : buffer -> view<2048xf32, #dense>
-  %output_view = buffer.view %output_noalias[%zero_offset] : buffer -> view<2048xf32, #dense>
-  scf.for %stripe_base = [%zero to %twentyfortyeight step %onezerotwofour] {
+  %input_view = buffer.view %input_noalias[%buffer_base] : buffer -> view<2048xf32, #dense>
+  %weight_view = buffer.view %weight_noalias[%buffer_base] : buffer -> view<2048xf32, #dense>
+  %optional_output_view = buffer.view %optional_output[%buffer_base] : buffer -> view<2048xf32, #dense>
+  %output_view = buffer.view %output_noalias[%buffer_base] : buffer -> view<2048xf32, #dense>
+  scf.for %stripe_base = [%loop_begin to %element_count step %stripe_step] {
     %channel = index.add %stripe_base, %word_element_add : index
-    %mask = vector.mask.range [%channel to %twentyfortyeight step %one] : index -> vector<4xi1>
-    %input_values = vector.load.mask %input_view[%channel], %mask, %zero_f32x4 : view<2048xf32, #dense>, vector<4xi1>, vector<4xf32>
-    %weight_values = vector.load.mask %weight_view[%channel], %mask, %zero_f32x4 : view<2048xf32, #dense>, vector<4xi1>, vector<4xf32>
+    %mask = vector.mask.range [%channel to %element_count step %mask_step] : index -> vector<4xi1>
+    %input_values = vector.load.mask %input_view[%channel], %mask, %masked_zero : view<2048xf32, #dense>, vector<4xi1>, vector<4xf32>
+    %weight_values = vector.load.mask %weight_view[%channel], %mask, %masked_zero : view<2048xf32, #dense>, vector<4xi1>, vector<4xf32>
     %result = vector.mulf %input_values, %weight_values : vector<4xf32>
     scf.if %publish_optional {
       vector.store.mask %result, %optional_output_view[%channel], %mask : vector<4xf32>, view<2048xf32, #dense>, vector<4xi1>
@@ -39,9 +39,9 @@ func.template<hip.recipe.vector_loop> device @vector_loop_provider(%publish_opti
 }
 
 kernel.def target(@gfx11) @template_constant_pruning_memory_width() {
-  %one = index.constant 1 : index
-  %twofiftysix = index.constant 256 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%twofiftysix, %one, %one) : index
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 256 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %weight: buffer, %output: buffer) {
   %false = scalar.constant false : i1
   %input_noalias, %weight_noalias, %output_noalias = buffer.assume.noalias %input, %weight, %output : buffer, buffer, buffer
@@ -55,12 +55,12 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@gfx11) workgroup_size(256, 1, 
   %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 8192} : reg<amdgpu.sgpr x2>
   %weight_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 8192} : reg<amdgpu.sgpr x2>
   %output_view = resource<hal_binding> {index = 2, source_type = hal.buffer, extent = 8192} : reg<amdgpu.sgpr x2>
-  %zero = s_mov_b32 0
-  %onezerotwofour = s_mov_b32 1024
-  %twentyfortyeight = s_mov_b32 2048
-  low.br ^_bb1(%zero: reg<amdgpu.sgpr>)
+  %loop_begin = s_mov_b32 0
+  %stripe_step = s_mov_b32 1024
+  %element_count = s_mov_b32 2048
+  low.br ^_bb1(%loop_begin: reg<amdgpu.sgpr>)
 ^_bb1(%stripe_base: reg<amdgpu.sgpr>):
-  %51 = s_cmp_lt_i32 %stripe_base, %twentyfortyeight
+  %51 = s_cmp_lt_i32 %stripe_base, %element_count
   low.cond_br %51, ^_bb2, ^_bb3 : reg<amdgpu.scc>
 ^_bb2:
   %52 = v_mov_b32_copy %stripe_base
@@ -82,7 +82,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@gfx11) workgroup_size(256, 1, 
   %71 = v_mul_f32 %69, %70
   %result = concat(%62, %65, %68, %71) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>, reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x4>
   global_store_b128_saddr %54, %result, %output_view
-  %76 = s_add_u32 %stripe_base, %onezerotwofour
+  %76 = s_add_u32 %stripe_base, %stripe_step
   low.br ^_bb1(%76: reg<amdgpu.sgpr>)
 ^_bb3:
   return

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_tensor_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_tensor_diagnostics.loom-test
@@ -6,16 +6,16 @@ kernel.def target(@target) @tensor_memory_requires_gfx125x() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %d0 = vector.constant 0 : vector<4xi32>
   %d1 = vector.constant 0 : vector<8xi32>
   // ERROR@+1: AMDGPU/023 {constraint_key="tensor_memory.provider_required"}
   %descriptor = kernel.tensor.lds.descriptor dgroups(%d0, %d1) : vector<4xi32>, vector<8xi32> -> kernel.tensor.lds.descriptor
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<64x64xf32, #dense>
+  %source = buffer.view %global[%buffer_base] : buffer -> view<64x64xf32, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x64xf32, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x64xf32, #dense>
   // ERROR@+1: AMDGPU/023 {constraint_key="tensor_memory.provider_required"}
   %copy = kernel.async.tensor.load.to.lds %source to %dest using %descriptor {cache_scope = cu, cache_temporal = regular} : view<64x64xf32, #dense> to view<64x64xf32, #dense>, kernel.tensor.lds.descriptor -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -34,15 +34,15 @@ kernel.def target(@target) @tensor_dgroups_must_be_subgroup_uniform() {
 } launch(%input: buffer) {
   %lane = kernel.workitem.id<x> : index
   %lane_i32 = index.cast %lane : index to i32
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %d0 = vector.splat %lane_i32 : vector<4xi32>
   %d1 = vector.constant 0 : vector<8xi32>
   %descriptor = kernel.tensor.lds.descriptor dgroups(%d0, %d1) : vector<4xi32>, vector<8xi32> -> kernel.tensor.lds.descriptor
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<64x64xf32, #dense>
+  %source = buffer.view %global[%buffer_base] : buffer -> view<64x64xf32, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x64xf32, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x64xf32, #dense>
   // ERROR@+1: AMDGPU/023 {constraint_key="tensor_memory.dgroup_uniformity"}
   %copy = kernel.async.tensor.load.to.lds %source to %dest using %descriptor {cache_scope = cu, cache_temporal = regular} : view<64x64xf32, #dense> to view<64x64xf32, #dense>, kernel.tensor.lds.descriptor -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_tensor_gfx1250.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_tensor_gfx1250.loom-test
@@ -6,15 +6,15 @@ kernel.def target(@target) @tensor_load_to_lds_d4() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %d0 = vector.constant 0 : vector<4xi32>
   %d1 = vector.constant 0 : vector<8xi32>
   %descriptor = kernel.tensor.lds.descriptor dgroups(%d0, %d1, %d0, %d0) : vector<4xi32>, vector<8xi32>, vector<4xi32>, vector<4xi32> -> kernel.tensor.lds.descriptor
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<64x64xf32, #dense>
+  %source = buffer.view %global[%buffer_base] : buffer -> view<64x64xf32, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x64xf32, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x64xf32, #dense>
   %copy = kernel.async.tensor.load.to.lds %source to %dest using %descriptor {cache_scope = cu, cache_temporal = regular} : view<64x64xf32, #dense> to view<64x64xf32, #dense>, kernel.tensor.lds.descriptor -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -62,15 +62,15 @@ kernel.def target(@target) @tensor_load_to_lds_d2() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %d0 = vector.constant 0 : vector<4xi32>
   %d1 = vector.constant 0 : vector<8xi32>
   %descriptor = kernel.tensor.lds.descriptor dgroups(%d0, %d1) : vector<4xi32>, vector<8xi32> -> kernel.tensor.lds.descriptor
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<64x64xf32, #dense>
+  %source = buffer.view %global[%buffer_base] : buffer -> view<64x64xf32, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x64xf32, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x64xf32, #dense>
   %copy = kernel.async.tensor.load.to.lds %source to %dest using %descriptor {cache_scope = cu, cache_temporal = regular} : view<64x64xf32, #dense> to view<64x64xf32, #dense>, kernel.tensor.lds.descriptor -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -108,19 +108,19 @@ kernel.def target(@target) @tensor_load_two_stage_wait_depth() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %d0 = vector.constant 0 : vector<4xi32>
   %d1 = vector.constant 0 : vector<8xi32>
   %descriptor = kernel.tensor.lds.descriptor dgroups(%d0, %d1) : vector<4xi32>, vector<8xi32> -> kernel.tensor.lds.descriptor
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<64x64xf32, #dense>
+  %source = buffer.view %global[%buffer_base] : buffer -> view<64x64xf32, #dense>
   %scratch0 = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
-  %dest0 = buffer.view %scratch0[%zero] : buffer -> view<64x64xf32, #dense>
+  %dest0 = buffer.view %scratch0[%buffer_base] : buffer -> view<64x64xf32, #dense>
   %copy0 = kernel.async.tensor.load.to.lds %source to %dest0 using %descriptor {cache_scope = cu, cache_temporal = regular} : view<64x64xf32, #dense> to view<64x64xf32, #dense>, kernel.tensor.lds.descriptor -> kernel.async.token
   %group0 = kernel.async.group %copy0 : kernel.async.token -> kernel.async.group
   %scratch1 = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
-  %dest1 = buffer.view %scratch1[%zero] : buffer -> view<64x64xf32, #dense>
+  %dest1 = buffer.view %scratch1[%buffer_base] : buffer -> view<64x64xf32, #dense>
   %copy1 = kernel.async.tensor.load.to.lds %source to %dest1 using %descriptor {cache_scope = cu, cache_temporal = regular} : view<64x64xf32, #dense> to view<64x64xf32, #dense>, kernel.tensor.lds.descriptor -> kernel.async.token
   %group1 = kernel.async.group %copy1 : kernel.async.token -> kernel.async.group
   kernel.async.wait %group0 {newer_groups = 1} : kernel.async.group

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_tensor_report.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_tensor_report.loom-test
@@ -6,15 +6,15 @@ kernel.def target(@target) @report_tensor_load_to_lds() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %d0 = vector.constant 0 : vector<4xi32>
   %d1 = vector.constant 0 : vector<8xi32>
   %descriptor = kernel.tensor.lds.descriptor dgroups(%d0, %d1) : vector<4xi32>, vector<8xi32> -> kernel.tensor.lds.descriptor
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<64x64xf32, #dense>
+  %source = buffer.view %global[%buffer_base] : buffer -> view<64x64xf32, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x64xf32, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x64xf32, #dense>
   %copy = kernel.async.tensor.load.to.lds %source to %dest using %descriptor {cache_scope = cu, cache_temporal = regular} : view<64x64xf32, #dense> to view<64x64xf32, #dense>, kernel.tensor.lds.descriptor -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_vector_16bit_float_conversion_report.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_vector_16bit_float_conversion_report.loom-test
@@ -9,12 +9,12 @@ kernel.def target(@target) @report_gfx1100_fp8_to_bf16_software_decode() {
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
-  %one = scalar.constant 1.0 : f32
+  %identity_scale = scalar.constant 1.0 : f32
   %schema = encoding.define #matrix_operand<affine=scale_only, element_format=f8e4m3fn, payload_elements=8, payload_packing=dense_lanes, payload_registers=0, rounding=finite_only, scale_format=f32, scale_group_elements=8, scale_operands=1, scale_topology=block_1d> : encoding<schema>
   %input_view = buffer.view %input[%base] : buffer -> view<64x8xf8E4M3, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<64x8xbf16, #dense>
   %payload = vector.load %input_view[%lane, 0] : view<64x8xf8E4M3, #dense> -> vector<8xf8E4M3>
-  %scale_vector = vector.splat %one : vector<1xf32>
+  %scale_vector = vector.splat %identity_scale : vector<1xf32>
   %decoded = vector.decode %payload using %schema {scale = %scale_vector : vector<1xf32>} : vector<8xf8E4M3>, encoding<schema> -> vector<8xbf16>
   vector.store %decoded, %output_view[%lane, 0] : vector<8xbf16>, view<64x8xbf16, #dense>
   kernel.return

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_workgroup_scan_wave64.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_workgroup_scan_wave64.loom-test
@@ -3,14 +3,14 @@
 amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
 
 kernel.def target(@target) @workgroup_scan_wave64_native_partitions() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %thread = kernel.workitem.id<x> : index
-  %zero_offset = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %value = view.load %input_view[%thread] : view<64xi32, #dense> -> i32
   %prefix = kernel.workgroup.scan<addi> %value {direction = forward, mode = exclusive} : i32
   view.store %prefix, %output_view[%thread] : i32, view<64xi32, #dense>

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/async_gather.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/async_gather.loom-test
@@ -9,13 +9,13 @@ kernel.def target(@target) @async_gather_dword() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x4xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x4xi8, #dense>
   %source = view.subview %source_base[%tid, 0] : view<64x4xi8, #dense> -> view<1x4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x1x4xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x1x4xi8, #dense>
   // ERROR@+1: TARGET/032 {op_name="kernel.async.gather", op_constraint="target_contract.kernel_async.provider_required"}
   %copy = kernel.async.gather %source to %dest {cache_scope = device, cache_temporal = regular} : view<1x4xi8, #dense> to view<64x1x4xi8, #dense> -> kernel.async.token
   // ERROR@+1: TARGET/032 {op_name="kernel.async.group", op_constraint="target_contract.kernel_async.provider_required"}
@@ -35,13 +35,13 @@ kernel.def target(@target) @async_gather_b128() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x16xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x16xi8, #dense>
   %source = view.subview %source_base[%tid, 0] : view<64x16xi8, #dense> -> view<1x16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x1x16xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x1x16xi8, #dense>
   // ERROR@+1: TARGET/032 {op_name="kernel.async.gather", op_constraint="target_contract.kernel_async.provider_required"}
   %copy = kernel.async.gather %source to %dest {cache_scope = device, cache_temporal = regular} : view<1x16xi8, #dense> to view<64x1x16xi8, #dense> -> kernel.async.token
   // ERROR@+1: TARGET/032 {op_name="kernel.async.group", op_constraint="target_contract.kernel_async.provider_required"}
@@ -61,13 +61,13 @@ kernel.def target(@target) @async_gather_two_stage() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 2048 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x1x16xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x1x16xi8, #dense>
   %source = view.subview %source_base[%tid, 0, 0] : view<64x1x16xi8, #dense> -> view<1x1x16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest_base = buffer.view %scratch[%zero] : buffer -> view<2x64x1x16xi8, #dense>
+  %dest_base = buffer.view %scratch[%buffer_base] : buffer -> view<2x64x1x16xi8, #dense>
   %dest0 = view.subview %dest_base[0, 0, 0, 0] : view<2x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
   %dest1 = view.subview %dest_base[1, 0, 0, 0] : view<2x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
   // ERROR@+1: TARGET/032 {op_name="kernel.async.gather", op_constraint="target_contract.kernel_async.provider_required"}
@@ -95,13 +95,13 @@ kernel.def target(@target) @async_gather_multi_packet_newer_group() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 3072 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x1x16xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x1x16xi8, #dense>
   %source = view.subview %source_base[%tid, 0, 0] : view<64x1x16xi8, #dense> -> view<1x1x16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest_base = buffer.view %scratch[%zero] : buffer -> view<3x64x1x16xi8, #dense>
+  %dest_base = buffer.view %scratch[%buffer_base] : buffer -> view<3x64x1x16xi8, #dense>
   %dest0 = view.subview %dest_base[0, 0, 0, 0] : view<3x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
   %dest1a = view.subview %dest_base[1, 0, 0, 0] : view<3x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
   %dest1b = view.subview %dest_base[2, 0, 0, 0] : view<3x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
@@ -132,15 +132,15 @@ kernel.def target(@target) @async_gather_second_lds_slot() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %pad_bytes = index.constant 256 : offset
   %scratch_bytes = index.constant 1024 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x16xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x16xi8, #dense>
   %source = view.subview %source_base[%tid, 0] : view<64x16xi8, #dense> -> view<1x16xi8, #dense>
   %pad = buffer.alloca %pad_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch = buffer.alloca %scratch_bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x1x16xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x1x16xi8, #dense>
   // ERROR@+1: TARGET/032 {op_name="kernel.async.gather", op_constraint="target_contract.kernel_async.provider_required"}
   %copy = kernel.async.gather %source to %dest {cache_scope = device, cache_temporal = regular} : view<1x16xi8, #dense> to view<64x1x16xi8, #dense> -> kernel.async.token
   // ERROR@+1: TARGET/032 {op_name="kernel.async.group", op_constraint="target_contract.kernel_async.provider_required"}

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/index_addressing.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/index_addressing.loom-test
@@ -11,11 +11,11 @@ kernel.def target(@target) @index_madd_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 4 : index
   %linear = index.madd %row, %row_stride, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<16xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<16xi32, #dense>
   kernel.return
@@ -50,11 +50,11 @@ kernel.def target(@target) @index_madd_u24_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 9 : index
   %linear = index.madd %row, %row_stride, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<36xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<36xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<36xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<36xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<36xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<36xi32, #dense>
   kernel.return
@@ -89,11 +89,11 @@ kernel.def target(@target) @index_madd_u24_literal_lhs_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 9 : index
   %linear = index.madd %row_stride, %row, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<36xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<36xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<36xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<36xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<36xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<36xi32, #dense>
   kernel.return
@@ -128,11 +128,11 @@ kernel.def target(@target) @index_madd_u24_literal_addend_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %linear_bias = index.constant 1 : index
   %linear = index.madd %row, %column, %linear_bias : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<36xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<36xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<36xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<36xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<36xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<36xi32, #dense>
   kernel.return
@@ -163,12 +163,12 @@ kernel.def target(@target) @index_madd_constant_addend_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%row_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %row = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 4 : index
   %column = index.constant 1 : index
   %linear = index.madd %row, %row_stride, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<16xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<16xi32, #dense>
   kernel.return
@@ -195,14 +195,14 @@ kernel.def target(@target) @index_madd_nested_scale_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%row_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %row = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %c9 = index.constant 9 : index
   %c2 = index.constant 2 : index
   %c16 = index.constant 16 : index
   %scaled = index.mul %row, %c9 : index
   %linear = index.madd %scaled, %c2, %c16 : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<80xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<80xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<80xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<80xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<80xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<80xi32, #dense>
   kernel.return
@@ -229,11 +229,11 @@ kernel.def target(@target) @index_shli_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%lane_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %shift = index.constant 2 : index
   %linear = index.shli %lane, %shift : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<16xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<16xi32, #dense>
   kernel.return
@@ -260,13 +260,13 @@ kernel.def target(@target) @index_scale_byte_offset_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%element_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %element = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : index
+  %first_element = index.constant 0 : index
   %byte_stride = index.constant 4 : offset
   %byte_offset = index.scale %element, %byte_stride : index, offset -> offset
   %input_view = buffer.view %input[%byte_offset] : buffer -> view<1xi32, #dense>
   %output_view = buffer.view %output[%byte_offset] : buffer -> view<1xi32, #dense>
-  %loaded = vector.load %input_view[%zero] : view<1xi32, #dense> -> vector<1xi32>
-  vector.store %loaded, %output_view[%zero] : vector<1xi32>, view<1xi32, #dense>
+  %loaded = vector.load %input_view[%first_element] : view<1xi32, #dense> -> vector<1xi32>
+  vector.store %loaded, %output_view[%first_element] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
 
@@ -294,9 +294,9 @@ kernel.def target(@target) @index_shli_previous_row_global_b128() {
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
   %base_offset = index.constant 0 : offset
-  %one = index.constant 1 : index
-  %column = index.add %lane, %one : index
-  %previous = index.sub %column, %one : index
+  %column_offset = index.constant 1 : index
+  %column = index.add %lane, %column_offset : index
+  %previous = index.sub %column, %column_offset : index
   %shift = index.constant 2 : index
   %linear = index.shli %previous, %shift : index
   %input_view = buffer.view %input[%base_offset] : buffer -> view<128xi32, #dense>
@@ -328,21 +328,25 @@ kernel.def target(@target) @index_edge_loop_dynamic_lower_bound_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
   %base_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %three = index.constant 3 : index
+  %left_edge_lane = index.constant 0 : index
+  %full_tap_begin = index.constant 0 : index
+  %left_edge_tap_begin = index.constant 1 : index
+  %tap_step = index.constant 1 : index
+  %padding_offset = index.constant 1 : index
+  %right_edge_tap_end = index.constant 2 : index
+  %input_lane_divisor = index.constant 2 : index
+  %full_tap_end = index.constant 3 : index
   %last_lane = index.constant 1023 : index
-  %is_left_edge = index.cmp eq, %lane, %zero : index
-  %begin = scf.select %is_left_edge, %one, %zero : index
+  %is_left_edge = index.cmp eq, %lane, %left_edge_lane : index
+  %begin = scf.select %is_left_edge, %left_edge_tap_begin, %full_tap_begin : index
   %is_right_edge = index.cmp eq, %lane, %last_lane : index
-  %end = scf.select %is_right_edge, %two, %three : index
+  %end = scf.select %is_right_edge, %right_edge_tap_end, %full_tap_end : index
   %input_view = buffer.view %input[%base_offset] : buffer -> view<512xi32, #dense>
   %output_view = buffer.view %output[%base_offset] : buffer -> view<1024xi32, #dense>
-  scf.for %tap = [%begin to %end step %one] {
+  scf.for %tap = [%begin to %end step %tap_step] {
     %shifted = index.add %lane, %tap : index
-    %source_lane = index.sub %shifted, %one : index
-    %input_lane = index.div %source_lane, %two : index
+    %source_lane = index.sub %shifted, %padding_offset : index
+    %input_lane = index.div %source_lane, %input_lane_divisor : index
     %loaded = vector.load %input_view[%input_lane] : view<512xi32, #dense> -> vector<1xi32>
     vector.store %loaded, %output_view[%lane] : vector<1xi32>, view<1024xi32, #dense>
   }
@@ -354,27 +358,27 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1024, 1, 1) w
   %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<llvmir.ptr>
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<llvmir.ptr>
   %lane = kernel.workitem_id.x
-  %zero = const.i64 0
-  %one = const.i64 1
-  %two = const.i64 2
-  %three = const.i64 3
+  %left_edge_lane = const.i64 0
+  %left_edge_tap_begin = const.i64 1
+  %right_edge_tap_end = const.i64 2
+  %full_tap_end = const.i64 3
   %last_lane = const.i64 1023
-  %is_left_edge = cmp.eq.i64 %lane, %zero
-  %begin = select.i64 %is_left_edge, %one, %zero
+  %is_left_edge = cmp.eq.i64 %lane, %left_edge_lane
+  %begin = select.i64 %is_left_edge, %left_edge_tap_begin, %left_edge_lane
   %is_right_edge = cmp.eq.i64 %lane, %last_lane
-  %end = select.i64 %is_right_edge, %two, %three
+  %end = select.i64 %is_right_edge, %right_edge_tap_end, %full_tap_end
   low.br ^_bb1(%begin: reg<llvmir.i64>)
 ^_bb1(%tap: reg<llvmir.i64>):
-  %39 = cmp.slt.i64 %tap, %end
-  low.cond_br %39, ^_bb2, ^_bb3 : reg<llvmir.i1>
+  %43 = cmp.slt.i64 %tap, %end
+  low.cond_br %43, ^_bb2, ^_bb3 : reg<llvmir.i1>
 ^_bb2:
   %shifted = add.i64 %lane, %tap
-  %source_lane = sub.i64 %shifted, %one
-  %input_lane = udiv.i64 %source_lane, %two
+  %source_lane = sub.i64 %shifted, %left_edge_tap_begin
+  %input_lane = udiv.i64 %source_lane, %right_edge_tap_end
   %loaded = load.indexed.i32 %input_view, %input_lane, 0, 4
   store.indexed.i32 %loaded, %output_view, %lane, 0, 4
-  %44 = add.i64 %tap, %one
-  low.br ^_bb1(%44: reg<llvmir.i64>)
+  %48 = add.i64 %tap, %left_edge_tap_begin
+  low.br ^_bb1(%48: reg<llvmir.i64>)
 ^_bb3:
   return
 }
@@ -496,11 +500,12 @@ kernel.def target(@target) @workitem_y_lds_uses_explicit_vaddr() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %row_count, %unit) : index
 } launch(%output: buffer) {
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%output_base] : buffer -> view<64xi32, #dense>
   %value = vector.constant 7 : vector<1xi32>
   vector.store %value, %scratch_view[%row] : vector<1xi32>, view<64xi32, #dense>
   %loaded = vector.load %scratch_view[%row] : view<64xi32, #dense> -> vector<1xi32>
@@ -538,10 +543,10 @@ kernel.def target(@target) @dispatch_id_xy_global_b32() {
   %dispatch_row = kernel.workitem.dispatch.id<y> : index
   %row_stride = index.constant 32 : index
   %linear = index.madd %dispatch_row, %row_stride, %dispatch_column : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<512xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %output_view[%linear] : vector<1xi32>, view<512xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<512xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %output_view[%linear] : vector<1xi32>, view<512xi32, #dense>
   kernel.return
 }
 
@@ -550,12 +555,12 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(8, 4, 1) work
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<llvmir.ptr>
   %dispatch_column = kernel.workitem_dispatch_id.x
   %dispatch_row = kernel.workitem_dispatch_id.y
-  %one = const.i32 1
+  %stored_value = const.i32 1
   %17 = const.i64 2
   %18 = shl.i64 %dispatch_column, %17
   %19 = const.i64 7
   %20 = shl.i64 %dispatch_row, %19
   %21 = add.i64 %18, %20
-  store.indexed.i32 %one, %output_view, %21, 0, 1
+  store.indexed.i32 %stored_value, %output_view, %21, 0, 1
   return
 }

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_cache_policy_non_temporal.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_cache_policy_non_temporal.loom-test
@@ -10,9 +10,9 @@ kernel.def target(@target) @cache_device_non_temporal_load_store() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] {cache_scope = device, cache_temporal = non_temporal} : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[%lane, 0] {cache_scope = device, cache_temporal = non_temporal} : vector<4xi32>, view<64x4xi32, #dense>
   kernel.return

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_cache_policy_scopes.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_cache_policy_scopes.loom-test
@@ -39,9 +39,9 @@ kernel.def target(@target) @cache_system_bypass_scalar_load() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = view.load %input_view[%lane] {cache_scope = system, cache_temporal = bypass} : view<64xi32, #dense> -> i32
   view.store %loaded, %output_view[%lane] : i32, view<64xi32, #dense>
   kernel.return

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_cache_policy_scopes.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_cache_policy_scopes.loom-test
@@ -10,9 +10,9 @@ kernel.def target(@target) @cache_system_bypass_load_device_writeback_store() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] {cache_scope = system, cache_temporal = bypass} : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[%lane, 0] {cache_scope = device, cache_temporal = non_temporal_writeback} : vector<4xi32>, view<64x4xi32, #dense>
   kernel.return

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_generic_atomic.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_generic_atomic.loom-test
@@ -6,20 +6,20 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @generic_atomic_i32_static(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %generic = buffer.assume.memory_space<generic> %input : buffer
-  %view = buffer.view %generic[%zero] : buffer -> view<1xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense>
-  %old_add = view.atomic.rmw<addi> %one, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense> -> i32
+  %view = buffer.view %generic[%buffer_base] : buffer -> view<1xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense>
+  %old_add = view.atomic.rmw<addi> %increment, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense> -> i32
   func.return
 }
 
 // ----
 low.func.def target<llvmir.generic.core>(@target) abi(object_function) @generic_atomic_i32_static(%view: reg<llvmir.ptr>) asm {
-  %one = const.i32 1
-  atomic.reduce.add.i32 %one, %view, 0, 0, 3
-  %old_add = atomic.rmw.add.i32 %one, %view, 0, 0, 3
+  %increment = const.i32 1
+  atomic.reduce.add.i32 %increment, %view, 0, 0, 3
+  %old_add = atomic.rmw.add.i32 %increment, %view, 0, 0, 3
   return
 }
 
@@ -30,9 +30,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @generic_atomic_cmpxchg_i32_static(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %generic = buffer.assume.memory_space<generic> %input : buffer
-  %view = buffer.view %generic[%zero] : buffer -> view<1xi32, #dense>
+  %view = buffer.view %generic[%buffer_base] : buffer -> view<1xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old_cmpxchg = view.atomic.cmpxchg %expected, %replacement, %view[0] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i32, view<1xi32, #dense> -> i32

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_global.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_global.loom-test
@@ -29,9 +29,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @global_f32x7_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<7xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<7xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<7xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<7xf32, #dense>
   %loaded = vector.load %input_view[0] : view<7xf32, #dense> -> vector<7xf32>
   vector.store %loaded, %output_view[0] : vector<7xf32>, view<7xf32, #dense>
   func.return
@@ -45,9 +45,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @global_f32x64_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %loaded = vector.load %input_view[0] : view<64xf32, #dense> -> vector<64xf32>
   vector.store %loaded, %output_view[0] : vector<64xf32>, view<64xf32, #dense>
   func.return
@@ -61,10 +61,10 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @global_f32x64_add_roundtrip(%lhs: buffer, %rhs: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs[%zero] : buffer -> view<64xf32, #dense>
-  %rhs_view = buffer.view %rhs[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs[%buffer_base] : buffer -> view<64xf32, #dense>
+  %rhs_view = buffer.view %rhs[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %lhs_loaded = vector.load %lhs_view[0] : view<64xf32, #dense> -> vector<64xf32>
   %rhs_loaded = vector.load %rhs_view[0] : view<64xf32, #dense> -> vector<64xf32>
   %sum = vector.addf %lhs_loaded, %rhs_loaded : vector<64xf32>
@@ -80,9 +80,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @global_bf16x14_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<14xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<14xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<14xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<14xbf16, #dense>
   %loaded = vector.load %input_view[0] : view<14xbf16, #dense> -> vector<14xbf16>
   vector.store %loaded, %output_view[0] : vector<14xbf16>, view<14xbf16, #dense>
   func.return
@@ -96,9 +96,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @global_bf16x64_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xbf16, #dense>
   %loaded = vector.load %input_view[0] : view<64xbf16, #dense> -> vector<64xbf16>
   vector.store %loaded, %output_view[0] : vector<64xbf16>, view<64xbf16, #dense>
   func.return
@@ -112,9 +112,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @global_f16x7_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<7xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<7xf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<7xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<7xf16, #dense>
   %loaded = vector.load %input_view[0] : view<7xf16, #dense> -> vector<7xf16>
   vector.store %loaded, %output_view[0] : vector<7xf16>, view<7xf16, #dense>
   func.return
@@ -128,9 +128,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @global_bf16x7_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<7xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<7xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<7xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<7xbf16, #dense>
   %loaded = vector.load %input_view[0] : view<7xbf16, #dense> -> vector<7xbf16>
   vector.store %loaded, %output_view[0] : vector<7xbf16>, view<7xbf16, #dense>
   func.return
@@ -162,9 +162,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @global_store_i32_constant_saddr(%output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output_global[%buffer_base] : buffer -> view<1xi32, #dense>
   %value = scalar.constant 42 : i32
   view.store %value, %output_view[0] : i32, view<1xi32, #dense>
   func.return
@@ -204,9 +204,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @global_load_i16_saddr(%input: buffer) -> (i16) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_global = buffer.assume.memory_space<global> %input : buffer
-  %input_view = buffer.view %input_global[%zero] : buffer -> view<1xi16, #dense>
+  %input_view = buffer.view %input_global[%buffer_base] : buffer -> view<1xi16, #dense>
   %loaded = view.load %input_view[0] : view<1xi16, #dense> -> i16
   func.return %loaded : i16
 }
@@ -224,9 +224,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @global_store_i16_saddr(%output: buffer, %value: i16) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero] : buffer -> view<1xi16, #dense>
+  %output_view = buffer.view %output_global[%buffer_base] : buffer -> view<1xi16, #dense>
   view.store %value, %output_view[0] : i16, view<1xi16, #dense>
   func.return
 }
@@ -244,8 +244,8 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @i8x2_buffer_load(%input: buffer) -> (vector<2xi8>) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<2xi8, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<2xi8, #dense>
   %loaded = vector.load %input_view[0] : view<2xi8, #dense> -> vector<2xi8>
   func.return %loaded : vector<2xi8>
 }
@@ -263,9 +263,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @global_load_i8x2_saddr(%input: buffer) -> (vector<2xi8>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_global = buffer.assume.memory_space<global> %input : buffer
-  %input_view = buffer.view %input_global[%zero] : buffer -> view<2xi8, #dense>
+  %input_view = buffer.view %input_global[%buffer_base] : buffer -> view<2xi8, #dense>
   %loaded = vector.load %input_view[0] : view<2xi8, #dense> -> vector<2xi8>
   func.return %loaded : vector<2xi8>
 }
@@ -283,9 +283,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @global_store_i8x2_saddr(%output: buffer, %value: vector<2xi8>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero] : buffer -> view<2xi8, #dense>
+  %output_view = buffer.view %output_global[%buffer_base] : buffer -> view<2xi8, #dense>
   vector.store %value, %output_view[0] : vector<2xi8>, view<2xi8, #dense>
   func.return
 }
@@ -303,9 +303,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @descriptor_load_i16(%input: buffer) -> (i16) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_descriptor = buffer.assume.memory_space<descriptor> %input : buffer
-  %input_view = buffer.view %input_descriptor[%zero] : buffer -> view<1xi16, #dense>
+  %input_view = buffer.view %input_descriptor[%buffer_base] : buffer -> view<1xi16, #dense>
   %loaded = view.load %input_view[0] : view<1xi16, #dense> -> i16
   func.return %loaded : i16
 }
@@ -323,9 +323,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @descriptor_store_i16(%output: buffer, %value: i16) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_descriptor = buffer.assume.memory_space<descriptor> %output : buffer
-  %output_view = buffer.view %output_descriptor[%zero] : buffer -> view<1xi16, #dense>
+  %output_view = buffer.view %output_descriptor[%buffer_base] : buffer -> view<1xi16, #dense>
   view.store %value, %output_view[0] : i16, view<1xi16, #dense>
   func.return
 }
@@ -343,9 +343,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @descriptor_load_i8x2(%input: buffer) -> (vector<2xi8>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_descriptor = buffer.assume.memory_space<descriptor> %input : buffer
-  %input_view = buffer.view %input_descriptor[%zero] : buffer -> view<2xi8, #dense>
+  %input_view = buffer.view %input_descriptor[%buffer_base] : buffer -> view<2xi8, #dense>
   %loaded = vector.load %input_view[0] : view<2xi8, #dense> -> vector<2xi8>
   func.return %loaded : vector<2xi8>
 }
@@ -363,9 +363,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @descriptor_store_i8x2(%output: buffer, %value: vector<2xi8>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_descriptor = buffer.assume.memory_space<descriptor> %output : buffer
-  %output_view = buffer.view %output_descriptor[%zero] : buffer -> view<2xi8, #dense>
+  %output_view = buffer.view %output_descriptor[%buffer_base] : buffer -> view<2xi8, #dense>
   vector.store %value, %output_view[0] : vector<2xi8>, view<2xi8, #dense>
   func.return
 }
@@ -383,9 +383,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @descriptor_b128_off_zero(%input: buffer) -> (vector<4xi32>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_descriptor = buffer.assume.memory_space<descriptor> %input : buffer
-  %input_view = buffer.view %input_descriptor[%zero] : buffer -> view<4xi32, #dense>
+  %input_view = buffer.view %input_descriptor[%buffer_base] : buffer -> view<4xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   func.return %loaded : vector<4xi32>
 }
@@ -547,14 +547,14 @@ llvmir.target<object> @target {
 }
 func.def target(@target) @descriptor_dynamic_extent_store_f32x4(%output: buffer, %value: vector<4xf32>, %row_count_i32: i32, %row_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %first_column = index.constant 0 : index
   %output_descriptor = buffer.assume.memory_space<descriptor> %output : buffer
   %row_count0 = index.cast %row_count_i32 : i32 to index
   %row_count = index.assume %row_count0 [range(%row_count0, 1, 1024)] : index
   %row0 = index.cast %row_i32 : i32 to index
   %row = index.assume %row0 [range(%row0, 0, 1023), lt(%row0, %row_count)] : index
   %output_view = buffer.view %output_descriptor[%base] : buffer -> view<[%row_count]x4xf32, #dense>
-  vector.store %value, %output_view[%row, %zero] : vector<4xf32>, view<[%row_count]x4xf32, #dense>
+  vector.store %value, %output_view[%row, %first_column] : vector<4xf32>, view<[%row_count]x4xf32, #dense>
   func.return
 }
 
@@ -576,14 +576,14 @@ llvmir.target<object> @target {
 func.def target(@target) @descriptor_dynamic_base_extent_store_f32x4(%output: buffer, %value: vector<4xf32>, %base_i32: i32, %row_count_i32: i32, %row_i32: i32) {
   %base0 = index.cast %base_i32 : i32 to offset
   %base = index.assume %base0 [range(%base0, 0, 8192), mul(%base0, 16)] : offset
-  %zero = index.constant 0 : index
+  %first_column = index.constant 0 : index
   %output_descriptor = buffer.assume.memory_space<descriptor> %output : buffer
   %row_count0 = index.cast %row_count_i32 : i32 to index
   %row_count = index.assume %row_count0 [range(%row_count0, 1, 512)] : index
   %row0 = index.cast %row_i32 : i32 to index
   %row = index.assume %row0 [range(%row0, 0, 511), lt(%row0, %row_count)] : index
   %output_view = buffer.view %output_descriptor[%base] : buffer -> view<[%row_count]x4xf32, #dense>
-  vector.store %value, %output_view[%row, %zero] : vector<4xf32>, view<[%row_count]x4xf32, #dense>
+  vector.store %value, %output_view[%row, %first_column] : vector<4xf32>, view<[%row_count]x4xf32, #dense>
   func.return
 }
 
@@ -802,8 +802,8 @@ kernel.def target(@target) @i32_dynamic_leading_dim_global_saddr() {
   %columns = index.assume %columns0 [range(%columns0, 32, 2147483647)] : index
   %output_global = buffer.assume.memory_space<global> %output : buffer
   %output_view = buffer.view %output_global[%base] : buffer -> view<2x[%columns]x8xi32, #dense>
-  %zero = scalar.constant 0 : i32
-  view.store %zero, %output_view[%workgroup, %column, 0] : i32, view<2x[%columns]x8xi32, #dense>
+  %cleared_value = scalar.constant 0 : i32
+  view.store %cleared_value, %output_view[%workgroup, %column, 0] : i32, view<2x[%columns]x8xi32, #dense>
   kernel.return
 }
 
@@ -813,13 +813,13 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(32, 1, 1) wor
   %workgroup = kernel.workgroup_id.x
   %column = kernel.workitem_id.x
   %columns = sext.i32.i64 %columns_i32
-  %zero = const.i32 0
+  %cleared_value = const.i32 0
   %19 = mul.i64 %workgroup, %columns
   %20 = const.i64 5
   %21 = shl.i64 %19, %20
   %23 = shl.i64 %column, %20
   %24 = add.i64 %21, %23
-  store.indexed.i32 %zero, %output_view, %24, 0, 1
+  store.indexed.i32 %cleared_value, %output_view, %24, 0, 1
   return
 }
 
@@ -878,11 +878,11 @@ kernel.def target(@target) @i32_readonly_uniform_smem_scalar_branch() {
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<16xi32, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<16xi32, #dense>
   %loaded = view.load %input_view[%workgroup] : view<16xi32, #dense> -> i32
-  %zero = scalar.constant 0 : i32
-  %negative = scalar.cmpi slt, %loaded, %zero : i32
+  %clamp_floor = scalar.constant 0 : i32
+  %negative = scalar.cmpi slt, %loaded, %clamp_floor : i32
   cfg.cond_br %negative, ^then, ^join
 ^then:
-  view.store %zero, %output_view[%workgroup] : i32, view<16xi32, #dense>
+  view.store %clamp_floor, %output_view[%workgroup] : i32, view<16xi32, #dense>
   cfg.br ^join
 ^join:
   kernel.return
@@ -894,11 +894,11 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(64, 1, 1) wor
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<llvmir.ptr>
   %workgroup = kernel.workgroup_id.x
   %loaded = load.indexed.i32 %input_view, %workgroup, 0, 4
-  %zero = const.i32 0
-  %negative = cmp.slt.i32 %loaded, %zero
+  %clamp_floor = const.i32 0
+  %negative = cmp.slt.i32 %loaded, %clamp_floor
   low.cond_br %negative, ^then, ^join : reg<llvmir.i1>
 ^then:
-  store.indexed.i32 %zero, %output_view, %workgroup, 0, 4
+  store.indexed.i32 %clamp_floor, %output_view, %workgroup, 0, 4
   low.br ^join
 ^join:
   return
@@ -918,7 +918,7 @@ kernel.def target(@target) @i32_readonly_uniform_smem_loop_bound() {
   %base = index.constant 0 : offset
   %start = index.constant 0 : index
   %step = index.constant 1 : index
-  %zero = scalar.constant 0.0 : f32
+  %initial_sum = scalar.constant 0.0 : f32
   %control_noalias, %input_noalias, %output_noalias = buffer.assume.noalias %control, %input, %output : buffer, buffer, buffer
   %control_view = buffer.view %control_noalias[%base] : buffer -> view<1xi32, #dense>
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<128xf32, #dense>
@@ -926,7 +926,7 @@ kernel.def target(@target) @i32_readonly_uniform_smem_loop_bound() {
   %limit_i32 = view.load %control_view[0] : view<1xi32, #dense> -> i32
   %limit0 = index.cast %limit_i32 : i32 to index
   %limit = index.assume %limit0 [range(%limit0, 0, 128)] : index
-  %sum = scf.for %position = [%start to %limit step %step](%current_sum = %zero : f32) -> (f32) {
+  %sum = scf.for %position = [%start to %limit step %step](%current_sum = %initial_sum : f32) -> (f32) {
     %loaded = view.load %input_view[%position] : view<128xf32, #dense> -> f32
     %next_sum = scalar.addf<reassoc|nnan|nsz> %current_sum, %loaded : f32
     scf.yield %next_sum : f32
@@ -942,10 +942,10 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(64, 1, 1) wor
   %output_view = resource<hal_binding> {index = 2, source_type = hal.buffer} : reg<llvmir.ptr>
   %start = const.i64 0
   %step = const.i64 1
-  %zero = const.f32 0
+  %initial_sum = const.f32 0
   %limit_i32 = load.i32 %control_view, 0
   %limit = sext.i32.i64 %limit_i32
-  low.br ^_bb1(%start: reg<llvmir.i64>, %zero: reg<llvmir.f32>)
+  low.br ^_bb1(%start: reg<llvmir.i64>, %initial_sum: reg<llvmir.f32>)
 ^_bb1(%position: reg<llvmir.i64>, %current_sum: reg<llvmir.f32>):
   %39 = cmp.slt.i64 %position, %limit
   low.cond_br %39, ^_bb2, ^_bb3 : reg<llvmir.i1>
@@ -1020,8 +1020,8 @@ kernel.def target(@target) @i32_readonly_uniform_smem_address() {
   %column_i32 = view.load %control_view[0] : view<1xi32, #dense> -> i32
   %column0 = index.cast %column_i32 : i32 to index
   %column = index.assume %column0 [range(%column0, 0, 63)] : index
-  %zero = scalar.constant 0 : i32
-  view.store %zero, %output_view[%column] : i32, view<64xi32, #dense>
+  %cleared_value = scalar.constant 0 : i32
+  view.store %cleared_value, %output_view[%column] : i32, view<64xi32, #dense>
   kernel.return
 }
 
@@ -1031,8 +1031,8 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) work
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<llvmir.ptr>
   %column_i32 = load.i32 %control_view, 0
   %column = sext.i32.i64 %column_i32
-  %zero = const.i32 0
-  store.indexed.i32 %zero, %output_view, %column, 0, 4
+  %cleared_value = const.i32 0
+  store.indexed.i32 %cleared_value, %output_view, %column, 0, 4
   return
 }
 
@@ -1052,13 +1052,14 @@ kernel.def target(@target) @i32_readonly_uniform_smem_guarded_index_address() {
   %output_view = buffer.view %output[%base] : buffer -> view<64xi32, #dense>
   %column_i32 = view.load %control_view[0] : view<1xi32, #dense> -> i32
   %column = index.cast %column_i32 : i32 to index
-  %zero_i32 = scalar.constant 0 : i32
+  %minimum_column = scalar.constant 0 : i32
+  %cleared_value = scalar.constant 0 : i32
   %limit_i32 = scalar.constant 64 : i32
-  %nonnegative = scalar.cmpi sge, %column_i32, %zero_i32 : i32
+  %nonnegative = scalar.cmpi sge, %column_i32, %minimum_column : i32
   %below = scalar.cmpi slt, %column_i32, %limit_i32 : i32
   %guard = scalar.andi %nonnegative, %below : i1
   scf.if %guard {
-    view.store %zero_i32, %output_view[%column] : i32, view<64xi32, #dense>
+    view.store %cleared_value, %output_view[%column] : i32, view<64xi32, #dense>
   }
   kernel.return
 }
@@ -1069,14 +1070,14 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) work
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<llvmir.ptr>
   %column_i32 = load.i32 %control_view, 0
   %column = sext.i32.i64 %column_i32
-  %zero_i32 = const.i32 0
+  %minimum_column = const.i32 0
   %limit_i32 = const.i32 64
-  %nonnegative = cmp.sge.i32 %column_i32, %zero_i32
+  %nonnegative = cmp.sge.i32 %column_i32, %minimum_column
   %below = cmp.slt.i32 %column_i32, %limit_i32
   %guard = and.i1 %nonnegative, %below
   low.cond_br %guard, ^_bb1, ^_bb2 : reg<llvmir.i1>
 ^_bb1:
-  store.indexed.i32 %zero_i32, %output_view, %column, 0, 4
+  store.indexed.i32 %minimum_column, %output_view, %column, 0, 4
   low.br ^_bb2
 ^_bb2:
   return
@@ -1097,16 +1098,16 @@ kernel.def target(@target) @i64_readonly_uniform_smem_guarded_index_address() {
   %control_view = buffer.view %control[%base] : buffer -> view<1xi64, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<64xi32, #dense>
   %column_i64 = view.load %control_view[0] : view<1xi64, #dense> -> i64
-  %zero_i64 = scalar.constant 0 : i64
+  %minimum_column = scalar.constant 0 : i64
   %limit_i64 = scalar.constant 64 : i64
-  %nonnegative = scalar.cmpi sge, %column_i64, %zero_i64 : i64
+  %nonnegative = scalar.cmpi sge, %column_i64, %minimum_column : i64
   %below = scalar.cmpi slt, %column_i64, %limit_i64 : i64
   %guard = scalar.andi %nonnegative, %below : i1
-  %zero_i32 = scalar.constant 0 : i32
+  %cleared_value = scalar.constant 0 : i32
   scf.if %guard {
     %bounded_column_i64 = scalar.assume %column_i64 [range(%column_i64, 0, 63)] : i64
     %column = index.cast %bounded_column_i64 : i64 to index
-    view.store %zero_i32, %output_view[%column] : i32, view<64xi32, #dense>
+    view.store %cleared_value, %output_view[%column] : i32, view<64xi32, #dense>
   }
   kernel.return
 }
@@ -1116,15 +1117,15 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) work
   %control_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<llvmir.ptr>
   %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<llvmir.ptr>
   %column = load.i64 %control_view, 0
-  %zero_i64 = const.i64 0
+  %minimum_column = const.i64 0
   %limit_i64 = const.i64 64
-  %nonnegative = cmp.sge.i64 %column, %zero_i64
+  %nonnegative = cmp.sge.i64 %column, %minimum_column
   %below = cmp.slt.i64 %column, %limit_i64
-  %zero_i32 = const.i32 0
+  %cleared_value = const.i32 0
   %guard = and.i1 %nonnegative, %below
   low.cond_br %guard, ^_bb1, ^_bb2 : reg<llvmir.i1>
 ^_bb1:
-  store.indexed.i32 %zero_i32, %output_view, %column, 0, 4
+  store.indexed.i32 %cleared_value, %output_view, %column, 0, 4
   low.br ^_bb2
 ^_bb2:
   return
@@ -1141,9 +1142,9 @@ kernel.def target(@target) @i32_b128() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   %raise = vector.constant 9 : vector<4xi32>
   %raised = vector.addi %loaded, %raise : vector<4xi32>
@@ -1178,9 +1179,9 @@ kernel.def target(@target) @f32x8_split_b128() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x8xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x8xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x8xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x8xf32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x8xf32, #dense> -> vector<8xf32>
   %raise = vector.constant 2.0 : vector<8xf32>
   %result = vector.addf %loaded, %raise : vector<8xf32>
@@ -1213,9 +1214,9 @@ kernel.def target(@target) @i32_scalar_2d_store() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4x8xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4x8xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4x8xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4x8xi32, #dense>
   %loaded = vector.load %input_view[%row, %column] : view<4x8xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%row, %column] : vector<1xi32>, view<4x8xi32, #dense>
   kernel.return
@@ -1285,12 +1286,12 @@ kernel.def target(@target) @i32_dynamic_constant_index() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<64x1x4xi32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<64x1x4xi32, #dense>
-  %loaded = vector.load %input_view[%lane, %zero, 0] : view<64x1x4xi32, #dense> -> vector<4xi32>
-  vector.store %loaded, %output_view[%lane, %zero, 0] : vector<4xi32>, view<64x1x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %singleton_axis = index.constant 0 : index
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x1x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x1x4xi32, #dense>
+  %loaded = vector.load %input_view[%lane, %singleton_axis, 0] : view<64x1x4xi32, #dense> -> vector<4xi32>
+  vector.store %loaded, %output_view[%lane, %singleton_axis, 0] : vector<4xi32>, view<64x1x4xi32, #dense>
   kernel.return
 }
 
@@ -1344,9 +1345,9 @@ kernel.def target(@target) @i32_dynamic_view_base() {
 } launch(%control: buffer, %output: buffer, %offset_i32: i32) {
   %base0 = index.cast %offset_i32 : i32 to offset
   %base = index.assume %base0 [range(%base0, 0, 4092), mul(%base0, 4)] : offset
-  %zero = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %control_view = buffer.view %control[%base] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   %loaded = view.load %control_view[2] : view<4xi32, #dense> -> i32
   view.store %loaded, %output_view[0] : i32, view<1xi32, #dense>
   kernel.return
@@ -1371,12 +1372,13 @@ kernel.def target(@target) @i32_dynamic_view_base_loaded() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%control: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %header_view = buffer.view %control[%zero] : buffer -> view<8xi32, #dense>
+  %header_base = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
+  %header_view = buffer.view %control[%header_base] : buffer -> view<8xi32, #dense>
   %base_i32 = view.load %header_view[7] : view<8xi32, #dense> -> i32
   %base = index.cast %base_i32 : i32 to offset
   %control_view = buffer.view %control[%base] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   %loaded = view.load %control_view[2] : view<4xi32, #dense> -> i32
   view.store %loaded, %output_view[0] : i32, view<1xi32, #dense>
   kernel.return
@@ -1404,9 +1406,9 @@ kernel.def target(@target) @i32x4_dynamic_view_base_b128() {
 } launch(%input: buffer, %output: buffer, %offset_i32: i32) {
   %base0 = index.cast %offset_i32 : i32 to offset
   %base = index.assume %base0 [range(%base0, 0, 4096), mul(%base0, 16)] : offset
-  %zero = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %input_view = buffer.view %input[%base] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xi32, #dense>
+  %output_view = buffer.view %output[%output_base] : buffer -> view<4xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[0] : vector<4xi32>, view<4xi32, #dense>
   kernel.return
@@ -1474,7 +1476,7 @@ kernel.def target(@target) @f16_view_scalar() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer, %column_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %first_column = index.constant 0 : index
   %column0 = index.cast %column_i32 : i32 to index
   %column = index.assume %column0 [range(%column0, 0, 7)] : index
   %input_view = buffer.view %input[%base] : buffer -> view<8xf16, #dense>
@@ -1482,7 +1484,7 @@ kernel.def target(@target) @f16_view_scalar() {
   %loaded = view.load %input_view[%column] : view<8xf16, #dense> -> f16
   view.store %loaded, %output_view[%column] : f16, view<8xf16, #dense>
   %cleared = scalar.constant 0.0 : f16
-  view.store %cleared, %output_view[%zero] : f16, view<8xf16, #dense>
+  view.store %cleared, %output_view[%first_column] : f16, view<8xf16, #dense>
   kernel.return
 }
 
@@ -1508,7 +1510,7 @@ kernel.def target(@target) @bf16_view_scalar() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer, %column_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %first_column = index.constant 0 : index
   %column0 = index.cast %column_i32 : i32 to index
   %column = index.assume %column0 [range(%column0, 0, 7)] : index
   %input_view = buffer.view %input[%base] : buffer -> view<8xbf16, #dense>
@@ -1516,7 +1518,7 @@ kernel.def target(@target) @bf16_view_scalar() {
   %loaded = view.load %input_view[%column] : view<8xbf16, #dense> -> bf16
   view.store %loaded, %output_view[%column] : bf16, view<8xbf16, #dense>
   %cleared = scalar.constant 0.0 : bf16
-  view.store %cleared, %output_view[%zero] : bf16, view<8xbf16, #dense>
+  view.store %cleared, %output_view[%first_column] : bf16, view<8xbf16, #dense>
   kernel.return
 }
 
@@ -1543,9 +1545,9 @@ kernel.def target(@target) @f16x2_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x2xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x2xf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x2xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x2xf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x2xf16, #dense> -> vector<2xf16>
   vector.store %loaded, %output_view[%lane, 0] : vector<2xf16>, view<64x2xf16, #dense>
   kernel.return
@@ -1572,9 +1574,9 @@ kernel.def target(@target) @f16x4_b64() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xf16, #dense> -> vector<4xf16>
   vector.store %loaded, %output_view[%lane, 0] : vector<4xf16>, view<64x4xf16, #dense>
   kernel.return
@@ -1601,9 +1603,9 @@ kernel.def target(@target) @bf16x2_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x2xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x2xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x2xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x2xbf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x2xbf16, #dense> -> vector<2xbf16>
   vector.store %loaded, %output_view[%lane, 0] : vector<2xbf16>, view<64x2xbf16, #dense>
   kernel.return
@@ -1630,9 +1632,9 @@ kernel.def target(@target) @bf16x4_b64() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xbf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xbf16, #dense> -> vector<4xbf16>
   vector.store %loaded, %output_view[%lane, 0] : vector<4xbf16>, view<64x4xbf16, #dense>
   kernel.return
@@ -1918,7 +1920,8 @@ kernel.def target(@target) @selected_i32_row_shift_store() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%idx: buffer, %output: buffer, %value: f32, %element_count_i32: i32, %condition_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %inactive_condition = index.constant 0 : index
+  %inactive_element = index.constant 0 : index
   %shift = index.constant 2 : index
   %element_count0 = index.cast %element_count_i32 : i32 to index
   %element_count = index.assume %element_count0 [range(%element_count0, 1, 2147483647)] : index
@@ -1930,8 +1933,8 @@ kernel.def target(@target) @selected_i32_row_shift_store() {
   %raw = index.shli %row, %shift : index
   %condition0 = index.cast %condition_i32 : i32 to index
   %condition = index.assume %condition0 [range(%condition0, 1, 1)] : index
-  %selected_condition = index.cmp ne, %condition, %zero : index
-  %selected = scf.select %selected_condition, %raw, %zero : index
+  %selected_condition = index.cmp ne, %condition, %inactive_condition : index
+  %selected = scf.select %selected_condition, %raw, %inactive_element : index
   %element = index.assume %selected [range(%selected, 0, 1073741823), lt(%selected, %element_count)] : index
   view.store %value, %output_view[%element] : f32, view<[%element_count]xf32, #dense>
   kernel.return

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_global_atomic.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_global_atomic.loom-test
@@ -9,21 +9,21 @@ kernel.def target(@target) @global_atomic_add_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
 // ----
 low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @global_atomic_add_i32() asm {
   %view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<llvmir.ptr>
-  %one = const.i32 1
-  atomic.reduce.add.i32 %one, %view, 0, 0, 3
-  %old = atomic.rmw.add.i32 %one, %view, 0, 0, 3
+  %increment = const.i32 1
+  atomic.reduce.add.i32 %increment, %view, 0, 0, 3
+  %old = atomic.rmw.add.i32 %increment, %view, 0, 0, 3
   return
 }
 
@@ -37,21 +37,21 @@ kernel.def target(@target) @global_atomic_add_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
-  %one = scalar.constant 1 : i64
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense>
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
+  %increment = scalar.constant 1 : i64
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense>
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
 }
 
 // ----
 low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @global_atomic_add_i64() asm {
   %view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<llvmir.ptr>
-  %one = const.i64 1
-  atomic.reduce.add.i64 %one, %view, 0, 0, 3
-  %old = atomic.rmw.add.i64 %one, %view, 0, 0, 3
+  %increment = const.i64 1
+  atomic.reduce.add.i64 %increment, %view, 0, 0, 3
+  %old = atomic.rmw.add.i64 %increment, %view, 0, 0, 3
   return
 }
 
@@ -65,9 +65,9 @@ kernel.def target(@target) @global_atomic_dynamic_add_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer, %value: i64) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
   %old = view.atomic.rmw<addi> %value, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
 }
@@ -89,21 +89,21 @@ kernel.def target(@target) @global_atomic_add_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xf32, #dense>
-  %one = scalar.constant 1.0 : f32
-  view.atomic.reduce<addf> %one, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
-  %old = view.atomic.rmw<addf> %one, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xf32, #dense>
+  %increment = scalar.constant 1.0 : f32
+  view.atomic.reduce<addf> %increment, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
+  %old = view.atomic.rmw<addf> %increment, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
   kernel.return
 }
 
 // ----
 low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @global_atomic_add_f32() asm {
   %view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<llvmir.ptr>
-  %one = const.f32 1065353216
-  atomic.reduce.fadd.f32 %one, %view, 0, 0, 3
-  %old = atomic.rmw.fadd.f32 %one, %view, 0, 0, 3
+  %increment = const.f32 1065353216
+  atomic.reduce.fadd.f32 %increment, %view, 0, 0, 3
+  %old = atomic.rmw.fadd.f32 %increment, %view, 0, 0, 3
   return
 }
 
@@ -117,9 +117,9 @@ kernel.def target(@target) @global_atomic_minnum_maxnum_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xf32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xf32, #dense>
   %limit = scalar.constant 1.0 : f32
   view.atomic.reduce<minnumf> %limit, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
   view.atomic.reduce<maxnumf> %limit, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
@@ -149,9 +149,9 @@ kernel.def target(@target) @global_atomic_dynamic_minnum_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer, %value: f32) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xf32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xf32, #dense>
   %old_min = view.atomic.rmw<minnumf> %value, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
   %old_max = view.atomic.rmw<maxnumf> %value, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
   kernel.return
@@ -175,9 +175,9 @@ kernel.def target(@target) @global_atomic_bitwise_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %mask = scalar.constant 255 : i32
   view.atomic.reduce<andi> %mask, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
   view.atomic.reduce<ori> %mask, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
@@ -211,9 +211,9 @@ kernel.def target(@target) @global_atomic_sub_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %delta = scalar.constant 1 : i32
   view.atomic.reduce<subi> %delta, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
   %old_sub = view.atomic.rmw<subi> %delta, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
@@ -239,9 +239,9 @@ kernel.def target(@target) @global_atomic_exchange_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %value = scalar.constant 7 : i32
   %old = view.atomic.rmw<xchgi> %value, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
@@ -265,9 +265,9 @@ kernel.def target(@target) @global_atomic_exchange_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
   %value = scalar.constant 7 : i64
   %old = view.atomic.rmw<xchgi> %value, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
@@ -291,9 +291,9 @@ kernel.def target(@target) @global_atomic_cmpxchg_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old = view.atomic.cmpxchg %expected, %replacement, %view[%tid] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i32, view<64xi32, #dense> -> i32
@@ -319,9 +319,9 @@ kernel.def target(@target) @global_atomic_cmpxchg_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
   %expected = scalar.constant 7 : i64
   %replacement = scalar.constant 9 : i64
   %old = view.atomic.cmpxchg %expected, %replacement, %view[%tid] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i64, view<64xi64, #dense> -> i64
@@ -347,9 +347,9 @@ kernel.def target(@target) @global_atomic_minmax_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %limit = scalar.constant 1 : i32
   view.atomic.reduce<minsi> %limit, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
   view.atomic.reduce<maxsi> %limit, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_global_atomic_ordering.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_global_atomic_ordering.loom-test
@@ -9,19 +9,19 @@ kernel.def target(@target) @global_atomic_release_reduce_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = release, scope = device} : i32, view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = release, scope = device} : i32, view<64xi32, #dense>
   kernel.return
 }
 
 // ----
 low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @global_atomic_release_reduce_i32() asm {
   %view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<llvmir.ptr>
-  %one = const.i32 1
-  atomic.reduce.add.i32 %one, %view, 0, 2, 3
+  %increment = const.i32 1
+  atomic.reduce.add.i32 %increment, %view, 0, 2, 3
   return
 }
 
@@ -35,19 +35,19 @@ kernel.def target(@target) @global_atomic_acquire_rmw_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = acquire, scope = device} : i32, view<64xi32, #dense> -> i32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = acquire, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
 // ----
 low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @global_atomic_acquire_rmw_i32() asm {
   %view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<llvmir.ptr>
-  %one = const.i32 1
-  %old = atomic.rmw.add.i32 %one, %view, 0, 1, 3
+  %increment = const.i32 1
+  %old = atomic.rmw.add.i32 %increment, %view, 0, 1, 3
   return
 }
 
@@ -61,19 +61,19 @@ kernel.def target(@target) @global_atomic_acq_rel_rmw_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = acq_rel, scope = device} : i32, view<64xi32, #dense> -> i32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = acq_rel, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
 // ----
 low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @global_atomic_acq_rel_rmw_i32() asm {
   %view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<llvmir.ptr>
-  %one = const.i32 1
-  %old = atomic.rmw.add.i32 %one, %view, 0, 3, 3
+  %increment = const.i32 1
+  %old = atomic.rmw.add.i32 %increment, %view, 0, 3, 3
   return
 }
 
@@ -87,9 +87,9 @@ kernel.def target(@target) @global_atomic_acq_rel_cmpxchg_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old = view.atomic.cmpxchg %expected, %replacement, %view[%tid] {failure_ordering = acquire, scope = device, success_ordering = acq_rel} : i32, view<64xi32, #dense> -> i32
@@ -115,18 +115,18 @@ kernel.def target(@target) @global_atomic_seq_cst_reduce_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = seq_cst, scope = device} : i32, view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = seq_cst, scope = device} : i32, view<64xi32, #dense>
   kernel.return
 }
 
 // ----
 low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @global_atomic_seq_cst_reduce_i32() asm {
   %view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<llvmir.ptr>
-  %one = const.i32 1
-  atomic.reduce.add.i32 %one, %view, 0, 4, 3
+  %increment = const.i32 1
+  atomic.reduce.add.i32 %increment, %view, 0, 4, 3
   return
 }

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_prefetch.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_prefetch.loom-test
@@ -28,8 +28,8 @@ kernel.def target(@target) @prefetch_workgroup_id() {
   kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer) {
   %workgroup = kernel.workgroup.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1025xi32, #dense>
+  %input_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%input_base] : buffer -> view<1025xi32, #dense>
   view.prefetch %input_view[%workgroup] {intent = read, locality = l2} : view<1025xi32, #dense>
   kernel.return
 }
@@ -58,8 +58,8 @@ kernel.def target(@target) @prefetch_fixed_query_offset() {
   %offset0 = index.add %workgroup_size_x, %workgroup_size_y : index
   %offset1 = index.add %offset0, %subgroup_size : index
   %offset = index.add %offset1, %subgroup_count : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  %input_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%input_base] : buffer -> view<64xi32, #dense>
   view.prefetch %input_view[%offset] {intent = read, locality = l1} : view<64xi32, #dense>
   kernel.return
 }
@@ -81,8 +81,8 @@ kernel.def target(@target) @prefetch_workitem_dropped() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  %input_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%input_base] : buffer -> view<64xi32, #dense>
   view.prefetch %input_view[%lane] {intent = read, locality = l1} : view<64xi32, #dense>
   kernel.return
 }

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_workgroup_atomic.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_workgroup_atomic.loom-test
@@ -9,13 +9,13 @@ kernel.def target(@target) @lds_atomic_add_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
-  %old = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
+  %old = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -23,9 +23,9 @@ kernel.def target(@target) @lds_atomic_add_i32() {
 low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @lds_atomic_add_i32() asm {
   %bytes = const.i64 256
   %scratch_view = alloca.workgroup.i8 %bytes, 4
-  %one = const.i32 1
-  atomic.reduce.add.i32 %one, %scratch_view, 0, 0, 2
-  %old = atomic.rmw.add.i32 %one, %scratch_view, 0, 0, 2
+  %increment = const.i32 1
+  atomic.reduce.add.i32 %increment, %scratch_view, 0, 0, 2
+  %old = atomic.rmw.add.i32 %increment, %scratch_view, 0, 0, 2
   return
 }
 
@@ -38,35 +38,35 @@ kernel.def target(@target) @lds_atomic_scalar_loop_index_i32() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
-  %zero = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %eight = index.constant 8 : index
-  %one_index = index.constant 1 : index
+  %scratch_base = index.constant 0 : offset
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 8 : index
+  %loop_step = index.constant 1 : index
   %bytes = index.constant 32 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<8xi32, #dense>
-  %one = scalar.constant 1 : i32
-  scf.for %i = [%zero_index to %eight step %one_index] {
-    view.atomic.reduce<addi> %one, %scratch_view[%i] {ordering = relaxed, scope = workgroup} : i32, view<8xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<8xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  scf.for %i = [%loop_begin to %loop_end step %loop_step] {
+    view.atomic.reduce<addi> %increment, %scratch_view[%i] {ordering = relaxed, scope = workgroup} : i32, view<8xi32, #dense>
   }
   kernel.return
 }
 
 // ----
 low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @lds_atomic_scalar_loop_index_i32() asm {
-  %zero_index = const.i64 0
-  %eight = const.i64 8
-  %one_index = const.i64 1
+  %loop_begin = const.i64 0
+  %loop_end = const.i64 8
+  %loop_step = const.i64 1
   %bytes = const.i64 32
   %scratch_view = alloca.workgroup.i8 %bytes, 4
-  %one = const.i32 1
-  low.br ^_bb1(%zero_index: reg<llvmir.i64>)
+  %increment = const.i32 1
+  low.br ^_bb1(%loop_begin: reg<llvmir.i64>)
 ^_bb1(%i: reg<llvmir.i64>):
-  %21 = cmp.slt.i64 %i, %eight
+  %21 = cmp.slt.i64 %i, %loop_end
   low.cond_br %21, ^_bb2, ^_bb3 : reg<llvmir.i1>
 ^_bb2:
-  atomic.reduce.indexed.add.i32 %one, %scratch_view, %i, 0, 0, 2, 4
-  %22 = add.i64 %i, %one_index
+  atomic.reduce.indexed.add.i32 %increment, %scratch_view, %i, 0, 0, 2, 4
+  %22 = add.i64 %i, %loop_step
   low.br ^_bb1(%22: reg<llvmir.i64>)
 ^_bb3:
   return
@@ -82,16 +82,16 @@ kernel.def target(@target) @lds_atomic_ordering_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %scratch_view[%tid] {ordering = release, scope = workgroup} : i32, view<64xi32, #dense>
-  %old_acquire = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = acquire, scope = workgroup} : i32, view<64xi32, #dense> -> i32
-  %old_release = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = release, scope = workgroup} : i32, view<64xi32, #dense> -> i32
-  %old_acq_rel = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = acq_rel, scope = workgroup} : i32, view<64xi32, #dense> -> i32
-  %old_seq_cst = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = seq_cst, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %scratch_view[%tid] {ordering = release, scope = workgroup} : i32, view<64xi32, #dense>
+  %old_acquire = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = acquire, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %old_release = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = release, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %old_acq_rel = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = acq_rel, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %old_seq_cst = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = seq_cst, scope = workgroup} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -99,12 +99,12 @@ kernel.def target(@target) @lds_atomic_ordering_i32() {
 low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @lds_atomic_ordering_i32() asm {
   %bytes = const.i64 256
   %scratch_view = alloca.workgroup.i8 %bytes, 4
-  %one = const.i32 1
-  atomic.reduce.add.i32 %one, %scratch_view, 0, 2, 2
-  %old_acquire = atomic.rmw.add.i32 %one, %scratch_view, 0, 1, 2
-  %old_release = atomic.rmw.add.i32 %one, %scratch_view, 0, 2, 2
-  %old_acq_rel = atomic.rmw.add.i32 %one, %scratch_view, 0, 3, 2
-  %old_seq_cst = atomic.rmw.add.i32 %one, %scratch_view, 0, 4, 2
+  %increment = const.i32 1
+  atomic.reduce.add.i32 %increment, %scratch_view, 0, 2, 2
+  %old_acquire = atomic.rmw.add.i32 %increment, %scratch_view, 0, 1, 2
+  %old_release = atomic.rmw.add.i32 %increment, %scratch_view, 0, 2, 2
+  %old_acq_rel = atomic.rmw.add.i32 %increment, %scratch_view, 0, 3, 2
+  %old_seq_cst = atomic.rmw.add.i32 %increment, %scratch_view, 0, 4, 2
   return
 }
 
@@ -118,13 +118,13 @@ kernel.def target(@target) @lds_atomic_add_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xf32, #dense>
-  %one = scalar.constant 1.0 : f32
-  view.atomic.reduce<addf> %one, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense>
-  %old = view.atomic.rmw<addf> %one, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense> -> f32
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xf32, #dense>
+  %increment = scalar.constant 1.0 : f32
+  view.atomic.reduce<addf> %increment, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense>
+  %old = view.atomic.rmw<addf> %increment, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense> -> f32
   kernel.return
 }
 
@@ -132,9 +132,9 @@ kernel.def target(@target) @lds_atomic_add_f32() {
 low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(1, 1, 1) @lds_atomic_add_f32() asm {
   %bytes = const.i64 256
   %scratch_view = alloca.workgroup.i8 %bytes, 4
-  %one = const.f32 1065353216
-  atomic.reduce.fadd.f32 %one, %scratch_view, 0, 0, 2
-  %old = atomic.rmw.fadd.f32 %one, %scratch_view, 0, 0, 2
+  %increment = const.f32 1065353216
+  atomic.reduce.fadd.f32 %increment, %scratch_view, 0, 0, 2
+  %old = atomic.rmw.fadd.f32 %increment, %scratch_view, 0, 0, 2
   return
 }
 
@@ -148,10 +148,10 @@ kernel.def target(@target) @lds_atomic_minnum_maxnum_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xf32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xf32, #dense>
   %limit = scalar.constant 1.0 : f32
   view.atomic.reduce<minnumf> %limit, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense>
   view.atomic.reduce<maxnumf> %limit, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense>
@@ -182,10 +182,10 @@ kernel.def target(@target) @lds_atomic_bitwise_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %mask = scalar.constant 255 : i32
   view.atomic.reduce<andi> %mask, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
   view.atomic.reduce<ori> %mask, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
@@ -220,10 +220,10 @@ kernel.def target(@target) @lds_atomic_sub_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %delta = scalar.constant 1 : i32
   view.atomic.reduce<subi> %delta, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
   %old_sub = view.atomic.rmw<subi> %delta, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
@@ -250,10 +250,10 @@ kernel.def target(@target) @lds_atomic_exchange_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %value = scalar.constant 7 : i32
   %old = view.atomic.rmw<xchgi> %value, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
   kernel.return
@@ -278,10 +278,10 @@ kernel.def target(@target) @lds_atomic_cmpxchg_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old = view.atomic.cmpxchg %expected, %replacement, %scratch_view[%tid] {failure_ordering = relaxed, scope = workgroup, success_ordering = relaxed} : i32, view<64xi32, #dense> -> i32
@@ -308,10 +308,10 @@ kernel.def target(@target) @lds_atomic_minmax_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %limit = scalar.constant 1 : i32
   view.atomic.reduce<minsi> %limit, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
   view.atomic.reduce<maxsi> %limit, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
@@ -350,17 +350,18 @@ kernel.def target(@target) @lds_atomic_second_alloca_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %first_bytes = index.constant 64 : offset
   %second_bytes = index.constant 256 : offset
   %first_scratch = buffer.alloca %first_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %second_scratch = buffer.alloca %second_bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %first_view = buffer.view %first_scratch[%zero] : buffer -> view<16xi32, #dense>
-  %second_view = buffer.view %second_scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.store %one, %first_view[%tid] : i32, view<16xi32, #dense>
-  view.atomic.reduce<addi> %one, %second_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
-  %old = view.atomic.rmw<addi> %one, %second_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %first_view = buffer.view %first_scratch[%scratch_base] : buffer -> view<16xi32, #dense>
+  %second_view = buffer.view %second_scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %initial_value = scalar.constant 1 : i32
+  %increment = scalar.constant 1 : i32
+  view.store %initial_value, %first_view[%tid] : i32, view<16xi32, #dense>
+  view.atomic.reduce<addi> %increment, %second_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
+  %old = view.atomic.rmw<addi> %increment, %second_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -370,9 +371,9 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) work
   %second_bytes = const.i64 256
   %first_view = alloca.workgroup.i8 %first_bytes, 16
   %second_view = alloca.workgroup.i8 %second_bytes, 16
-  %one = const.i32 1
-  store.i32 %one, %first_view, 0
-  atomic.reduce.add.i32 %one, %second_view, 0, 0, 2
-  %old = atomic.rmw.add.i32 %one, %second_view, 0, 0, 2
+  %initial_value = const.i32 1
+  store.i32 %initial_value, %first_view, 0
+  atomic.reduce.add.i32 %initial_value, %second_view, 0, 0, 2
+  %old = atomic.rmw.add.i32 %initial_value, %second_view, 0, 0, 2
   return
 }

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_workgroup_b128.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_workgroup_b128.loom-test
@@ -10,12 +10,12 @@ kernel.def target(@target) @lds_b128_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
@@ -48,12 +48,12 @@ kernel.def target(@target) @lds_b128_single_lane_extract() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
@@ -88,12 +88,12 @@ kernel.def target(@target) @lds_b128_xor_swizzle_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %shift = index.constant 4 : index
   %shifted = index.shrui %lane, %shift : index
   %mask = index.constant 3 : index
@@ -136,13 +136,13 @@ kernel.def target(@target) @lds_b128_large_static_offset_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %large = index.constant 1024 : offset
   %bytes = index.constant 4096 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %scratch_view = buffer.view %scratch[%large] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
@@ -175,15 +175,15 @@ kernel.def target(@target) @lds_b128_split_second_alloca_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %first_bytes = index.constant 64 : offset
   %second_bytes = index.constant 2048 : offset
   %first = buffer.alloca %first_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %second = buffer.alloca %second_bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %first_view = buffer.view %first[%zero] : buffer -> view<16xi32, #dense>
-  %second_view = buffer.view %second[%zero] : buffer -> view<64x8xi32, #dense>
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x8xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x8xi32, #dense>
+  %first_view = buffer.view %first[%buffer_base] : buffer -> view<16xi32, #dense>
+  %second_view = buffer.view %second[%buffer_base] : buffer -> view<64x8xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x8xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x8xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x8xi32, #dense> -> vector<8xi32>
   vector.store %loaded, %second_view[%lane, 0] : vector<8xi32>, view<64x8xi32, #dense>
   %roundtrip = vector.load %second_view[%lane, 0] : view<64x8xi32, #dense> -> vector<8xi32>

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_workgroup_indexed.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_workgroup_indexed.loom-test
@@ -10,12 +10,12 @@ kernel.def target(@target) @wave_sized_workgroup_memory_workitem_x_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   %loaded = vector.load %scratch_view[%lane] : view<32xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   kernel.return
@@ -26,8 +26,8 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(32, 1, 1) wor
   %lane = kernel.workitem_id.x
   %bytes = const.i64 128
   %scratch_view = alloca.workgroup.i8 %bytes, 16
-  %one = const.i32 1
-  store.indexed.i32 %one, %scratch_view, %lane, 0, 4
+  %stored_value = const.i32 1
+  store.indexed.i32 %stored_value, %scratch_view, %lane, 0, 4
   %loaded = load.indexed.i32 %scratch_view, %lane, 0, 4
   store.indexed.i32 %loaded, %scratch_view, %lane, 0, 4
   return
@@ -44,12 +44,12 @@ kernel.def target(@target) @wave_sized_workgroup_memory_workitem_x_i8x4() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi8, #dense>
-  %one = vector.constant 1 : vector<4xi8>
-  vector.store %one, %scratch_view[%lane] : vector<4xi8>, view<64xi8, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi8, #dense>
+  %stored_value = vector.constant 1 : vector<4xi8>
+  vector.store %stored_value, %scratch_view[%lane] : vector<4xi8>, view<64xi8, #dense>
   %loaded = vector.load %scratch_view[%lane] : view<64xi8, #dense> -> vector<4xi8>
   vector.store %loaded, %scratch_view[%lane] : vector<4xi8>, view<64xi8, #dense>
   kernel.return
@@ -60,8 +60,8 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(32, 1, 1) wor
   %lane = kernel.workitem_id.x
   %bytes = const.i64 64
   %scratch_view = alloca.workgroup.i8 %bytes, 16
-  %one = const.v4i8 1
-  store.indexed.v4i8 %one, %scratch_view, %lane, 0, 1
+  %stored_value = const.v4i8 1
+  store.indexed.v4i8 %stored_value, %scratch_view, %lane, 0, 1
   %loaded = load.indexed.v4i8 %scratch_view, %lane, 0, 1
   store.indexed.v4i8 %loaded, %scratch_view, %lane, 0, 1
   return
@@ -78,12 +78,12 @@ kernel.def target(@target) @cross_wave_workgroup_memory_workitem_x_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
   %loaded = vector.load %scratch_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
@@ -94,8 +94,8 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(64, 1, 1) wor
   %lane = kernel.workitem_id.x
   %bytes = const.i64 256
   %scratch_view = alloca.workgroup.i8 %bytes, 16
-  %one = const.i32 1
-  store.indexed.i32 %one, %scratch_view, %lane, 0, 4
+  %stored_value = const.i32 1
+  store.indexed.i32 %stored_value, %scratch_view, %lane, 0, 4
   %loaded = load.indexed.i32 %scratch_view, %lane, 0, 4
   store.indexed.i32 %loaded, %scratch_view, %lane, 0, 4
   return
@@ -111,16 +111,16 @@ kernel.def target(@target) @workgroup_memory_scalar_loop_index_b32() {
   %workgroup_size = index.constant 8 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 32 : offset
-  %zero_index = index.constant 0 : index
-  %eight = index.constant 8 : index
-  %one_index = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 8 : index
+  %loop_step = index.constant 1 : index
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<8xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  scf.for %i = [%zero_index to %eight step %one_index] {
-    vector.store %one, %scratch_view[%i] : vector<1xi32>, view<8xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<8xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  scf.for %i = [%loop_begin to %loop_end step %loop_step] {
+    vector.store %stored_value, %scratch_view[%i] : vector<1xi32>, view<8xi32, #dense>
     %loaded = vector.load %scratch_view[%i] : view<8xi32, #dense> -> vector<1xi32>
     vector.store %loaded, %scratch_view[%i] : vector<1xi32>, view<8xi32, #dense>
   }
@@ -130,20 +130,20 @@ kernel.def target(@target) @workgroup_memory_scalar_loop_index_b32() {
 // ----
 low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(8, 1, 1) workgroup_count(1, 1, 1) @workgroup_memory_scalar_loop_index_b32() asm {
   %bytes = const.i64 32
-  %zero_index = const.i64 0
-  %eight = const.i64 8
-  %one_index = const.i64 1
+  %loop_begin = const.i64 0
+  %loop_end = const.i64 8
+  %loop_step = const.i64 1
   %scratch_view = alloca.workgroup.i8 %bytes, 16
-  %one = const.i32 1
-  low.br ^_bb1(%zero_index: reg<llvmir.i64>)
+  %stored_value = const.i32 1
+  low.br ^_bb1(%loop_begin: reg<llvmir.i64>)
 ^_bb1(%i: reg<llvmir.i64>):
-  %23 = cmp.slt.i64 %i, %eight
+  %23 = cmp.slt.i64 %i, %loop_end
   low.cond_br %23, ^_bb2, ^_bb3 : reg<llvmir.i1>
 ^_bb2:
-  store.indexed.i32 %one, %scratch_view, %i, 0, 4
+  store.indexed.i32 %stored_value, %scratch_view, %i, 0, 4
   %loaded = load.indexed.i32 %scratch_view, %i, 0, 4
   store.indexed.i32 %loaded, %scratch_view, %i, 0, 4
-  %25 = add.i64 %i, %one_index
+  %25 = add.i64 %i, %loop_step
   low.br ^_bb1(%25: reg<llvmir.i64>)
 ^_bb3:
   return
@@ -160,14 +160,14 @@ kernel.def target(@target) @wave_sized_workgroup_memory_workitem_x_b32_static_of
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %four = index.constant 4 : index
-  %element_index = index.add %lane, %four : index
-  %zero = index.constant 0 : offset
+  %element_offset = index.constant 4 : index
+  %element_index = index.add %lane, %element_offset : index
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 160 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<40xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<40xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
   %loaded = vector.load %scratch_view[%element_index] : view<40xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
   kernel.return
@@ -178,8 +178,8 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(32, 1, 1) wor
   %lane = kernel.workitem_id.x
   %bytes = const.i64 160
   %scratch_view = alloca.workgroup.i8 %bytes, 16
-  %one = const.i32 1
-  store.indexed.i32 %one, %scratch_view, %lane, 16, 4
+  %stored_value = const.i32 1
+  store.indexed.i32 %stored_value, %scratch_view, %lane, 16, 4
   %loaded = load.indexed.i32 %scratch_view, %lane, 16, 4
   store.indexed.i32 %loaded, %scratch_view, %lane, 16, 4
   return
@@ -196,16 +196,16 @@ kernel.def target(@target) @wave_sized_workgroup_memory_second_allocation_b32() 
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %first_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %second_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %first_view = buffer.view %first_scratch[%zero] : buffer -> view<32xi32, #dense>
-  %second_view = buffer.view %second_scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  %two = vector.constant 2 : vector<1xi32>
-  vector.store %one, %first_view[%lane] : vector<1xi32>, view<32xi32, #dense>
-  vector.store %two, %second_view[%lane] : vector<1xi32>, view<32xi32, #dense>
+  %first_view = buffer.view %first_scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %second_view = buffer.view %second_scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %first_value = vector.constant 1 : vector<1xi32>
+  %second_value = vector.constant 2 : vector<1xi32>
+  vector.store %first_value, %first_view[%lane] : vector<1xi32>, view<32xi32, #dense>
+  vector.store %second_value, %second_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   %loaded = vector.load %second_view[%lane] : view<32xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %first_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   kernel.return
@@ -217,10 +217,10 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(32, 1, 1) wor
   %bytes = const.i64 128
   %first_view = alloca.workgroup.i8 %bytes, 16
   %second_view = alloca.workgroup.i8 %bytes, 16
-  %one = const.i32 1
-  %two = const.i32 2
-  store.indexed.i32 %one, %first_view, %lane, 0, 4
-  store.indexed.i32 %two, %second_view, %lane, 0, 4
+  %first_value = const.i32 1
+  %second_value = const.i32 2
+  store.indexed.i32 %first_value, %first_view, %lane, 0, 4
+  store.indexed.i32 %second_value, %second_view, %lane, 0, 4
   %loaded = load.indexed.i32 %second_view, %lane, 0, 4
   store.indexed.i32 %loaded, %first_view, %lane, 0, 4
   return
@@ -237,14 +237,14 @@ kernel.def target(@target) @wave_sized_workgroup_memory_view_base_and_element_of
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %four = index.constant 4 : index
-  %element_index = index.add %lane, %four : index
+  %element_offset = index.constant 4 : index
+  %element_index = index.add %lane, %element_offset : index
   %base = index.constant 32 : offset
   %bytes = index.constant 224 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch_view = buffer.view %scratch[%base] : buffer -> view<40xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
   %loaded = vector.load %scratch_view[%element_index] : view<40xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
   kernel.return
@@ -255,8 +255,8 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(32, 1, 1) wor
   %lane = kernel.workitem_id.x
   %bytes = const.i64 224
   %scratch_view = alloca.workgroup.i8 %bytes, 16
-  %one = const.i32 1
-  store.indexed.i32 %one, %scratch_view, %lane, 48, 4
+  %stored_value = const.i32 1
+  store.indexed.i32 %stored_value, %scratch_view, %lane, 48, 4
   %loaded = load.indexed.i32 %scratch_view, %lane, 48, 4
   store.indexed.i32 %loaded, %scratch_view, %lane, 48, 4
   return
@@ -273,15 +273,15 @@ kernel.def target(@target) @wave_sized_workgroup_memory_interleaved_addtid_and_v
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %two = index.constant 2 : index
-  %scaled_lane = index.mul %lane, %two : index
-  %zero = index.constant 0 : offset
+  %lane_scale = index.constant 2 : index
+  %scaled_lane = index.mul %lane, %lane_scale : index
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %lane_value = vector.constant 1 : vector<1xi32>
   %other = vector.constant 2 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
+  vector.store %lane_value, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
   vector.store %other, %scratch_view[%scaled_lane] : vector<1xi32>, view<64xi32, #dense>
   %loaded = vector.load %scratch_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%scaled_lane] : vector<1xi32>, view<64xi32, #dense>
@@ -293,9 +293,9 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(32, 1, 1) wor
   %lane = kernel.workitem_id.x
   %bytes = const.i64 256
   %scratch_view = alloca.workgroup.i8 %bytes, 16
-  %one = const.i32 1
+  %lane_value = const.i32 1
   %other = const.i32 2
-  store.indexed.i32 %one, %scratch_view, %lane, 0, 4
+  store.indexed.i32 %lane_value, %scratch_view, %lane, 0, 4
   store.indexed.i32 %other, %scratch_view, %lane, 0, 8
   %loaded = load.indexed.i32 %scratch_view, %lane, 0, 4
   store.indexed.i32 %loaded, %scratch_view, %lane, 0, 8
@@ -315,12 +315,12 @@ kernel.def target(@target) @wave_sized_workgroup_memory_roundtrip_lane_cast_b32(
   %lane = kernel.workitem.id<x> : index
   %lane_i32 = index.cast %lane : index to i32
   %lane_index = index.cast %lane_i32 : i32 to index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane_index] : vector<1xi32>, view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%lane_index] : vector<1xi32>, view<32xi32, #dense>
   %loaded = vector.load %scratch_view[%lane_index] : view<32xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%lane_index] : vector<1xi32>, view<32xi32, #dense>
   kernel.return
@@ -333,8 +333,8 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(32, 1, 1) wor
   %lane_index = sext.i32.i64 %lane_i32
   %bytes = const.i64 128
   %scratch_view = alloca.workgroup.i8 %bytes, 16
-  %one = const.i32 1
-  store.indexed.i32 %one, %scratch_view, %lane_index, 0, 4
+  %stored_value = const.i32 1
+  store.indexed.i32 %stored_value, %scratch_view, %lane_index, 0, 4
   %loaded = load.indexed.i32 %scratch_view, %lane_index, 0, 4
   store.indexed.i32 %loaded, %scratch_view, %lane_index, 0, 4
   return
@@ -354,12 +354,12 @@ kernel.def target(@target) @wave_sized_workgroup_memory_select_same_lane_b32() {
   %limit = index.constant 32 : index
   %inside = index.cmp ult, %lane, %limit : index
   %selected_lane = scf.select %inside, %lane, %lane : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%selected_lane] : vector<1xi32>, view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%selected_lane] : vector<1xi32>, view<32xi32, #dense>
   %loaded = vector.load %scratch_view[%selected_lane] : view<32xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%selected_lane] : vector<1xi32>, view<32xi32, #dense>
   kernel.return
@@ -370,8 +370,8 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(32, 1, 1) wor
   %lane = kernel.workitem_id.x
   %bytes = const.i64 128
   %scratch_view = alloca.workgroup.i8 %bytes, 16
-  %one = const.i32 1
-  store.indexed.i32 %one, %scratch_view, %lane, 0, 4
+  %stored_value = const.i32 1
+  store.indexed.i32 %stored_value, %scratch_view, %lane, 0, 4
   %loaded = load.indexed.i32 %scratch_view, %lane, 0, 4
   store.indexed.i32 %loaded, %scratch_view, %lane, 0, 4
   return
@@ -388,17 +388,17 @@ kernel.def target(@target) @wave_sized_workgroup_memory_select_scaled_lane_b32()
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %two = index.constant 2 : index
-  %scaled_lane = index.mul %lane, %two : index
+  %lane_scale = index.constant 2 : index
+  %scaled_lane = index.mul %lane, %lane_scale : index
   %limit = index.constant 16 : index
   %inside = index.cmp ult, %lane, %limit : index
   %element_index = scf.select %inside, %lane, %scaled_lane : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%element_index] : vector<1xi32>, view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%element_index] : vector<1xi32>, view<64xi32, #dense>
   %loaded = vector.load %scratch_view[%element_index] : view<64xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%element_index] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
@@ -414,8 +414,8 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(32, 1, 1) wor
   %element_index = select.i64 %inside, %lane, %scaled_lane
   %bytes = const.i64 256
   %scratch_view = alloca.workgroup.i8 %bytes, 16
-  %one = const.i32 1
-  store.indexed.i32 %one, %scratch_view, %element_index, 0, 4
+  %stored_value = const.i32 1
+  store.indexed.i32 %stored_value, %scratch_view, %element_index, 0, 4
   %loaded = load.indexed.i32 %scratch_view, %element_index, 0, 4
   store.indexed.i32 %loaded, %scratch_view, %element_index, 0, 4
   return
@@ -434,10 +434,10 @@ kernel.def target(@target) @wave_sized_workgroup_memory_guarded_lane_store_b32()
   %lane = kernel.workitem.id<x> : index
   %limit = index.constant 16 : index
   %inside = index.cmp ult, %lane, %limit : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
   %initial = vector.constant 0 : vector<1xi32>
   %replacement = vector.constant 1 : vector<1xi32>
   vector.store %initial, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
@@ -482,12 +482,12 @@ kernel.def target(@target) @wave_sized_workgroup_memory_guarded_lane_load_b32() 
   %lane = kernel.workitem.id<x> : index
   %limit = index.constant 16 : index
   %inside = index.cmp ult, %lane, %limit : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   scf.if %inside {
     %loaded = vector.load %scratch_view[%lane] : view<32xi32, #dense> -> vector<1xi32>
     vector.store %loaded, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
@@ -501,8 +501,8 @@ low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(32, 1, 1) wor
   %limit = const.i64 16
   %bytes = const.i64 128
   %scratch_view = alloca.workgroup.i8 %bytes, 16
-  %one = const.i32 1
-  store.indexed.i32 %one, %scratch_view, %lane, 0, 4
+  %stored_value = const.i32 1
+  store.indexed.i32 %stored_value, %scratch_view, %lane, 0, 4
   %inside = cmp.ult.i64 %lane, %limit
   low.cond_br %inside, ^_bb1, ^_bb2 : reg<llvmir.i1>
 ^_bb1:

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_workgroup_packed16.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_workgroup_packed16.loom-test
@@ -10,12 +10,12 @@ kernel.def target(@target) @lds_f16x4_b64_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 512 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 8, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xf16, #dense> -> vector<4xf16>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xf16>, view<64x4xf16, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xf16, #dense> -> vector<4xf16>
@@ -48,12 +48,12 @@ kernel.def target(@target) @lds_f16x8_b128_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x8xf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x8xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x8xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x8xf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x8xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x8xf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x8xf16, #dense> -> vector<8xf16>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<8xf16>, view<64x8xf16, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x8xf16, #dense> -> vector<8xf16>
@@ -151,12 +151,12 @@ kernel.def target(@target) @lds_bf16x4_b64_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 512 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 8, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xbf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xbf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xbf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xbf16, #dense> -> vector<4xbf16>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xbf16>, view<64x4xbf16, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xbf16, #dense> -> vector<4xbf16>
@@ -189,12 +189,12 @@ kernel.def target(@target) @lds_bf16x8_b128_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x8xbf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x8xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x8xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x8xbf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x8xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x8xbf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x8xbf16, #dense> -> vector<8xbf16>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<8xbf16>, view<64x8xbf16, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x8xbf16, #dense> -> vector<8xbf16>

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/numeric_conversion.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/numeric_conversion.loom-test
@@ -1255,13 +1255,13 @@ kernel.def target(@target) @scalar_bitcast_direct_i32_arg_f32_store() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%output: buffer, %scale_bits: i32) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xf32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_element = index.constant 0 : index
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xf32, #dense>
   %scale = scalar.bitcast %scale_bits : i32 to f32
   %unit = scalar.constant 1.0 : f32
   %scaled = scalar.mulf %unit, %scale : f32
-  view.store %scaled, %output_view[%zero_index] : f32, view<1xf32, #dense>
+  view.store %scaled, %output_view[%output_element] : f32, view<1xf32, #dense>
   kernel.return
 }
 
@@ -1301,17 +1301,19 @@ kernel.def target(@target) @scalar_bitcast_lane_byte_decode_select_tree_store() 
   %exp = scalar.shrui %exp_bits, %exp_shift : i32
   %mantissa_mask = scalar.constant 7 : i32
   %mantissa = scalar.andi %wide, %mantissa_mask : i32
-  %zero = scalar.constant 0 : i32
+  %absent_mantissa_bit = scalar.constant 0 : i32
+  %base_mantissa_shift = scalar.constant 0 : i32
+  %zero_exponent = scalar.constant 0 : i32
   %mantissa_bit1_mask = scalar.constant 2 : i32
   %mantissa_bit1 = scalar.andi %mantissa, %mantissa_bit1_mask : i32
-  %has_mantissa_bit1 = scalar.cmpi ne, %mantissa_bit1, %zero : i32
-  %one = scalar.constant 1 : i32
-  %shift0 = scf.select %has_mantissa_bit1, %one, %zero : i32
+  %has_mantissa_bit1 = scalar.cmpi ne, %mantissa_bit1, %absent_mantissa_bit : i32
+  %low_mantissa_shift = scalar.constant 1 : i32
+  %shift0 = scf.select %has_mantissa_bit1, %low_mantissa_shift, %base_mantissa_shift : i32
   %mantissa_bit2_mask = scalar.constant 4 : i32
   %mantissa_bit2 = scalar.andi %mantissa, %mantissa_bit2_mask : i32
-  %has_mantissa_bit2 = scalar.cmpi ne, %mantissa_bit2, %zero : i32
-  %two = scalar.constant 2 : i32
-  %selected_shift = scf.select %has_mantissa_bit2, %two, %shift0 : i32
+  %has_mantissa_bit2 = scalar.cmpi ne, %mantissa_bit2, %absent_mantissa_bit : i32
+  %high_mantissa_shift = scalar.constant 2 : i32
+  %selected_shift = scf.select %has_mantissa_bit2, %high_mantissa_shift, %shift0 : i32
   %bias = scalar.constant 118 : i32
   %biased_exp = scalar.addi %selected_shift, %bias : i32
   %f32_exp_shift = scalar.constant 23 : i32
@@ -1323,7 +1325,7 @@ kernel.def target(@target) @scalar_bitcast_lane_byte_decode_select_tree_store() 
   %normal_head = scalar.ori %sign_bits, %f32_exp : i32
   %normal_bits = scalar.ori %normal_head, %f32_mantissa : i32
   %subnormal = scf.select %has_mantissa_bit2, %normal_bits, %sign_bits : i32
-  %is_zero_exp = scalar.cmpi eq, %exp, %zero : i32
+  %is_zero_exp = scalar.cmpi eq, %exp, %zero_exponent : i32
   %regular_exp_bias = scalar.constant 120 : i32
   %regular_exp = scalar.addi %exp, %regular_exp_bias : i32
   %regular_exp_bits = scalar.shli %regular_exp, %f32_exp_shift : i32

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/numeric_f32_memory.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/numeric_f32_memory.loom-test
@@ -10,10 +10,10 @@ kernel.def target(@target) @f32_arith() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %lhs = vector.load %lhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %rhs = vector.load %rhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %sum = vector.addf %lhs, %rhs : vector<1xf32>
@@ -51,10 +51,10 @@ kernel.def target(@target) @f32_fma() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %lhs = vector.load %lhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %rhs = vector.load %rhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %bias = vector.constant 0.5 : vector<1xf32>
@@ -90,10 +90,10 @@ kernel.def target(@target) @f32_arcp_div() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64x4xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64x4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf32, #dense>
   %lhs = vector.load %lhs_view[%lane, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %rhs = vector.load %rhs_view[%lane, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %quotient = vector.divf<nnan|ninf|nsz|arcp> %lhs, %rhs : vector<4xf32>
@@ -192,35 +192,35 @@ llvmir.target<object> @target {
   triple = "amdgcn-amd-amdhsa"
 }
 func.def target(@target) @f32_guarded_arcp_reciprocal_scale(%amax: f32) -> (f32) {
-  %zero = scalar.constant 0.0 : f32
-  %one = scalar.constant 1.0 : f32
-  %one_over_127 = scalar.constant 0.007874015700000001 : f32
-  %scale = scalar.constant 127.0 : f32
-  %d = scalar.mulf<nnan|ninf|nsz|arcp> %amax, %one_over_127 : f32
+  %fallback_scale = scalar.constant 0.0 : f32
+  %reciprocal_numerator = scalar.constant 1.0 : f32
+  %inverse_scale_limit = scalar.constant 0.007874015700000001 : f32
+  %scale_limit = scalar.constant 127.0 : f32
+  %d = scalar.mulf<nnan|ninf|nsz|arcp> %amax, %inverse_scale_limit : f32
   %zero_for_cmp = scalar.subf %d, %d : f32
   %nonzero = scalar.cmpf one, %d, %zero_for_cmp : f32
   %d_inv = scf.if %nonzero -> (f32) {
-    %amax_inv = scalar.divf<nnan|ninf|nsz|arcp> %one, %amax : f32
-    %candidate = scalar.mulf<nnan|ninf|nsz|arcp> %amax_inv, %scale : f32
+    %amax_inv = scalar.divf<nnan|ninf|nsz|arcp> %reciprocal_numerator, %amax : f32
+    %candidate = scalar.mulf<nnan|ninf|nsz|arcp> %amax_inv, %scale_limit : f32
     scf.yield %candidate : f32
   } else {
-    scf.yield %zero : f32
+    scf.yield %fallback_scale : f32
   }
   func.return %d_inv : f32
 }
 
 // ----
 low.func.def target<llvmir.generic.core>(@target) abi(object_function) @f32_guarded_arcp_reciprocal_scale(%amax: reg<llvmir.f32>) -> (reg<llvmir.f32>) asm {
-  %zero = const.f32 0
-  %one = const.f32 1065353216
-  %one_over_127 = const.f32 1006699012
-  %scale = const.f32 1123942400
-  %d = mul.f32 %amax, %one_over_127 {fast_math_flags = 30}
+  %fallback_scale = const.f32 0
+  %reciprocal_numerator = const.f32 1065353216
+  %inverse_scale_limit = const.f32 1006699012
+  %scale_limit = const.f32 1123942400
+  %d = mul.f32 %amax, %inverse_scale_limit {fast_math_flags = 30}
   %zero_for_cmp = sub.f32 %d, %d
   %nonzero = cmp.one.f32 %d, %zero_for_cmp
-  %amax_inv = div.f32 %one, %amax {fast_math_flags = 30}
-  %candidate = mul.f32 %amax_inv, %scale {fast_math_flags = 30}
-  %d_inv = select.f32 %nonzero, %candidate, %zero
+  %amax_inv = div.f32 %reciprocal_numerator, %amax {fast_math_flags = 30}
+  %candidate = mul.f32 %amax_inv, %scale_limit {fast_math_flags = 30}
+  %d_inv = select.f32 %nonzero, %candidate, %fallback_scale
   return %d_inv
 }
 
@@ -235,10 +235,10 @@ kernel.def target(@target) @f32_exact_vector_div() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %lhs = vector.load %lhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %rhs = vector.load %rhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %quotient = vector.divf %lhs, %rhs : vector<1xf32>
@@ -296,10 +296,10 @@ kernel.def target(@target) @f32_scalarized() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64x4xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64x4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf32, #dense>
   %lhs = vector.load %lhs_view[%lane, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %rhs = vector.load %rhs_view[%lane, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %lhs0 = vector.extract %lhs[0] : vector<4xf32> -> f32
@@ -395,8 +395,8 @@ func.def target(@target) @f32_uniform_vector_binary(%lhs_buffer: buffer, %rhs_bu
   %sum = vector.addf %lhs, %rhs : vector<4xf32>
   %difference = vector.subf %lhs, %rhs : vector<4xf32>
   %combined = vector.addf %product, %sum : vector<4xf32>
-  %two = vector.constant 2.0 : vector<4xf32>
-  %scaled = vector.mulf %lhs, %two : vector<4xf32>
+  %scale_factor = vector.constant 2.0 : vector<4xf32>
+  %scaled = vector.mulf %lhs, %scale_factor : vector<4xf32>
   %with_difference = vector.addf %combined, %difference : vector<4xf32>
   %result = vector.addf %with_difference, %scaled : vector<4xf32>
   func.return %result : vector<4xf32>
@@ -410,8 +410,8 @@ low.func.def target<llvmir.generic.core>(@target) abi(object_function) @f32_unif
   %sum = add.v4f32 %lhs, %rhs
   %difference = sub.v4f32 %lhs, %rhs
   %combined = add.v4f32 %product, %sum
-  %two = const.v4f32 1073741824
-  %scaled = mul.v4f32 %lhs, %two
+  %scale_factor = const.v4f32 1073741824
+  %scaled = mul.v4f32 %lhs, %scale_factor
   %with_difference = add.v4f32 %combined, %difference
   %result = add.v4f32 %with_difference, %scaled
   return %result
@@ -450,17 +450,17 @@ llvmir.target<object> @target {
   triple = "amdgcn-amd-amdhsa"
 }
 func.def target(@target) @f32_inline_zero_arithmetic(%scalar: f32, %vector: vector<2xf32>) -> (f32, vector<2xf32>) {
-  %zero = scalar.constant 0.0 : f32
-  %scalar_result = scalar.mulf %scalar, %zero : f32
-  %zero_vector = vector.splat %zero : vector<2xf32>
+  %zero_factor = scalar.constant 0.0 : f32
+  %scalar_result = scalar.mulf %scalar, %zero_factor : f32
+  %zero_vector = vector.splat %zero_factor : vector<2xf32>
   %vector_result = vector.mulf %vector, %zero_vector : vector<2xf32>
   func.return %scalar_result, %vector_result : f32, vector<2xf32>
 }
 
 // ----
 low.func.def target<llvmir.generic.core>(@target) abi(object_function) @f32_inline_zero_arithmetic(%scalar: reg<llvmir.f32>, %vector: reg<llvmir.f32 x2>) -> (reg<llvmir.f32>, reg<llvmir.f32 x2>) asm {
-  %zero = const.f32 0
-  %scalar_result = mul.f32 %scalar, %zero
+  %zero_factor = const.f32 0
+  %scalar_result = mul.f32 %scalar, %zero_factor
   %zero_vector = const.v2f32 0
   %vector_result = mul.v2f32 %vector, %zero_vector
   return %scalar_result, %vector_result
@@ -537,12 +537,12 @@ kernel.def target(@target) @f32_direct_arg_scale() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%output: buffer, %scale: f32) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xf32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_element = index.constant 0 : index
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xf32, #dense>
   %unit = scalar.constant 1.0 : f32
   %scaled = scalar.mulf %unit, %scale : f32
-  view.store %scaled, %output_view[%zero_index] : f32, view<1xf32, #dense>
+  view.store %scaled, %output_view[%output_element] : f32, view<1xf32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/numeric_i32_memory.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/numeric_i32_memory.loom-test
@@ -10,9 +10,9 @@ kernel.def target(@target) @i32_bitwise() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   %mask = vector.constant 15 : vector<1xi32>
   %masked = vector.andi %loaded, %mask : vector<1xi32>
@@ -49,9 +49,9 @@ kernel.def target(@target) @i32_shift() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   %shift = vector.constant 3 : vector<1xi32>
   %left = vector.shli %loaded, %shift : vector<1xi32>
@@ -90,9 +90,9 @@ kernel.def target(@target) @i32_negative_literal() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   %mask = vector.constant -1 : vector<1xi32>
   %result = vector.xori %loaded, %mask : vector<1xi32>
@@ -123,9 +123,9 @@ kernel.def target(@target) @i32_scalarized() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   %lane0 = vector.extract %loaded[0] : vector<4xi32> -> i32
   %lane1 = vector.extract %loaded[1] : vector<4xi32> -> i32

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/numeric_minmax.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/numeric_minmax.loom-test
@@ -196,15 +196,15 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @scf_select_q6_nibble_i8(%code: i32, %use_high: i32) -> (i8) {
-  %zero = scalar.constant 0 : i32
-  %four = scalar.constant 4 : i32
+  %low_selector = scalar.constant 0 : i32
+  %nibble_shift = scalar.constant 4 : i32
   %mask = scalar.constant 15 : i32
-  %high_shifted = scalar.shrui %code, %four : i32
+  %high_shifted = scalar.shrui %code, %nibble_shift : i32
   %low_i32 = scalar.andi %code, %mask : i32
   %high_i32 = scalar.andi %high_shifted, %mask : i32
   %low = scalar.trunci %low_i32 : i32 to i8
   %high = scalar.trunci %high_i32 : i32 to i8
-  %cond = scalar.cmpi ne, %use_high, %zero : i32
+  %cond = scalar.cmpi ne, %use_high, %low_selector : i32
   %selected = scf.select %cond, %high, %low : i8
   func.return %selected : i8
 }
@@ -217,12 +217,12 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @scf_select_scale_piece_i16(%packed: i32, %use_high: i32) -> (i16) {
-  %zero = scalar.constant 0 : i32
-  %sixteen = scalar.constant 16 : i32
+  %low_selector = scalar.constant 0 : i32
+  %halfword_shift = scalar.constant 16 : i32
   %low = scalar.trunci %packed : i32 to i16
-  %high_shifted = scalar.shrui %packed, %sixteen : i32
+  %high_shifted = scalar.shrui %packed, %halfword_shift : i32
   %high = scalar.trunci %high_shifted : i32 to i16
-  %cond = scalar.cmpi ne, %use_high, %zero : i32
+  %cond = scalar.cmpi ne, %use_high, %low_selector : i32
   %selected = scf.select %cond, %high, %low : i16
   func.return %selected : i16
 }
@@ -279,18 +279,18 @@ llvmir.target<object> @target {
 }
 func.def target(@target) @scf_select_tail_zero_i32(%values: vector<2xi32>, %limit: i32) -> (i32) {
   %lane = vector.extract %values[0] : vector<2xi32> -> i32
-  %zero = scalar.constant 0 : i32
+  %tail_fill = scalar.constant 0 : i32
   %cond = scalar.cmpi slt, %lane, %limit : i32
-  %selected = scf.select %cond, %lane, %zero : i32
+  %selected = scf.select %cond, %lane, %tail_fill : i32
   func.return %selected : i32
 }
 
 // ----
 low.func.def target<llvmir.generic.core>(@target) abi(object_function) @scf_select_tail_zero_i32(%values: reg<llvmir.i32 x2>, %limit: reg<llvmir.i32>) -> (reg<llvmir.i32>) asm {
   %lane = extract.v2i32 %values, 0
-  %zero = const.i32 0
+  %tail_fill = const.i32 0
   %cond = cmp.slt.i32 %lane, %limit
-  %selected = select.i32 %cond, %lane, %zero
+  %selected = select.i32 %cond, %lane, %tail_fill
   return %selected
 }
 
@@ -583,10 +583,10 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @scf_select_i1_scc_condition(%lhs: i32, %rhs: i32, %alt: i32, %true_value: f32, %false_value: f32) -> (f32) {
-  %zero = scalar.constant 0 : i32
+  %inactive_condition = scalar.constant 0 : i32
   %condition = scalar.cmpi slt, %lhs, %rhs : i32
-  %lhs_nonzero = scalar.cmpi ne, %lhs, %zero : i32
-  %alt_nonzero = scalar.cmpi ne, %alt, %zero : i32
+  %lhs_nonzero = scalar.cmpi ne, %lhs, %inactive_condition : i32
+  %alt_nonzero = scalar.cmpi ne, %alt, %inactive_condition : i32
   %selected_condition = scf.select %condition, %lhs_nonzero, %alt_nonzero : i1
   %result = scf.select %selected_condition, %true_value, %false_value : f32
   func.return %result : f32
@@ -594,10 +594,10 @@ func.def target(@target) @scf_select_i1_scc_condition(%lhs: i32, %rhs: i32, %alt
 
 // ----
 low.func.def target<llvmir.generic.core>(@target) abi(object_function) @scf_select_i1_scc_condition(%lhs: reg<llvmir.i32>, %rhs: reg<llvmir.i32>, %alt: reg<llvmir.i32>, %true_value: reg<llvmir.f32>, %false_value: reg<llvmir.f32>) -> (reg<llvmir.f32>) asm {
-  %zero = const.i32 0
+  %inactive_condition = const.i32 0
   %condition = cmp.slt.i32 %lhs, %rhs
-  %lhs_nonzero = cmp.ne.i32 %lhs, %zero
-  %alt_nonzero = cmp.ne.i32 %alt, %zero
+  %lhs_nonzero = cmp.ne.i32 %lhs, %inactive_condition
+  %alt_nonzero = cmp.ne.i32 %alt, %inactive_condition
   %selected_condition = select.i1 %condition, %lhs_nonzero, %alt_nonzero
   %result = select.f32 %selected_condition, %true_value, %false_value
   return %result
@@ -619,8 +619,8 @@ kernel.def target(@target) @index_minmax_vgpr_select() {
   %max = index.max %lane, %limit : index
   %cond = index.cmp slt, %lane, %limit : index
   %selected = scf.select %cond, %min, %max : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<64xi32, #dense>
   %stored = vector.constant 1 : vector<1xi32>
   vector.store %stored, %output_view[%selected] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
@@ -648,9 +648,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @f32_reduce_minnum_maxnum(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<2xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<2xf32, #dense>
   %loaded = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %min_init = scalar.constant 1000.0 : f32
   %min = vector.reduce<minnumf, reassoc|nnan|nsz> %loaded, %min_init : vector<4xf32>, f32

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/numeric_reduce.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/numeric_reduce.loom-test
@@ -6,9 +6,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @i32_reduce_add(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   %init = scalar.constant 0 : i32
   %sum = vector.reduce<addi> %loaded, %init : vector<4xi32>, i32
@@ -37,9 +37,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @f32_reduce_add(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
   %loaded = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %init = scalar.constant 0.0 : f32
   %sum = vector.reduce<addf> %loaded, %init : vector<4xf32>, f32
@@ -70,9 +70,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @f32_reduce_add_fastmath(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
   %loaded = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %init = scalar.constant 0.0 : f32
   %sum = vector.reduce<addf, reassoc|nnan|nsz> %loaded, %init : vector<4xf32>, f32
@@ -101,9 +101,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @f32x64_reduce_add_fastmath(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
   %loaded = vector.load %input_view[0] : view<64xf32, #dense> -> vector<64xf32>
   %init = scalar.constant 0.0 : f32
   %sum = vector.reduce<addf, reassoc|nnan|nsz> %loaded, %init : vector<64xf32>, f32
@@ -254,24 +254,24 @@ llvmir.target<object> @target {
 config.def @runtime.vector_width = 4 : index
 
 kernel.def target(@target) @f32_configured_width_square_reduce() {
-  %one = index.constant 1 : index
+  %singleton_dimension = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%singleton_dimension, %singleton_dimension, %singleton_dimension) workgroup_size(%workgroup_size, %singleton_dimension, %singleton_dimension) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero_offset = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %lane0 = kernel.workitem.id<x> : index
   %lane = index.assume %lane0 [range(%lane0, 0, 63)] : index
   %vector_width = config.get @runtime.vector_width : index
   %vector_width_bounded = index.assume %vector_width [range(%vector_width, 2, 4)] : index
   %element_count = index.constant 256 : index
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<[%element_count]xf32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<[%element_count]xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
   %linear0 = index.mul %lane, %vector_width_bounded : index
   %linear = index.assume %linear0 [range(%linear0, 0, 252)] : index
   %loaded = vector.load %input_view[%linear] : view<[%element_count]xf32, #dense> -> vector<[%vector_width_bounded]xf32>
   %squared = vector.mulf<reassoc|nnan|ninf|nsz|contract> %loaded, %loaded : vector<[%vector_width_bounded]xf32>
-  %zero_f32 = scalar.constant 0.0 : f32
-  %sum = vector.reduce<addf, reassoc|nnan|ninf|nsz|contract> %squared, %zero_f32 : vector<[%vector_width_bounded]xf32>, f32
+  %initial_sum = scalar.constant 0.0 : f32
+  %sum = vector.reduce<addf, reassoc|nnan|ninf|nsz|contract> %squared, %initial_sum : vector<[%vector_width_bounded]xf32>, f32
   %stored = vector.from_elements %sum : vector<1xf32>
   vector.store %stored, %output_view[0] : vector<1xf32>, view<1xf32, #dense>
   kernel.return
@@ -301,8 +301,8 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @i32_reduce_minui_select_sentinel(%values: vector<4xi32>) -> (i32) {
-  %zero = scalar.constant 0 : i32
-  %zeros = vector.splat %zero : vector<4xi32>
+  %empty_value = scalar.constant 0 : i32
+  %zeros = vector.splat %empty_value : vector<4xi32>
   %is_zero = vector.cmpi eq, %values, %zeros : vector<4xi32> -> vector<4xi1>
   %start = scalar.constant 0 : i32
   %step = scalar.constant 1 : i32

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/numeric_scalar_i32.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/numeric_scalar_i32.loom-test
@@ -82,9 +82,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @scalar_i1_bitwise_scc(%lhs: i32, %rhs: i32) -> (i1) {
-  %zero = scalar.constant 0 : i32
-  %lhs_nonzero = scalar.cmpi ne, %lhs, %zero : i32
-  %rhs_nonzero = scalar.cmpi ne, %rhs, %zero : i32
+  %inactive_condition = scalar.constant 0 : i32
+  %lhs_nonzero = scalar.cmpi ne, %lhs, %inactive_condition : i32
+  %rhs_nonzero = scalar.cmpi ne, %rhs, %inactive_condition : i32
   %both_nonzero = scalar.andi %lhs_nonzero, %rhs_nonzero : i1
   %either_nonzero = scalar.ori %lhs_nonzero, %rhs_nonzero : i1
   %one_nonzero = scalar.xori %both_nonzero, %either_nonzero : i1
@@ -93,9 +93,9 @@ func.def target(@target) @scalar_i1_bitwise_scc(%lhs: i32, %rhs: i32) -> (i1) {
 
 // ----
 low.func.def target<llvmir.generic.core>(@target) abi(object_function) @scalar_i1_bitwise_scc(%lhs: reg<llvmir.i32>, %rhs: reg<llvmir.i32>) -> (reg<llvmir.i1>) asm {
-  %zero = const.i32 0
-  %lhs_nonzero = cmp.ne.i32 %lhs, %zero
-  %rhs_nonzero = cmp.ne.i32 %rhs, %zero
+  %inactive_condition = const.i32 0
+  %lhs_nonzero = cmp.ne.i32 %lhs, %inactive_condition
+  %rhs_nonzero = cmp.ne.i32 %rhs, %inactive_condition
   %both_nonzero = and.i1 %lhs_nonzero, %rhs_nonzero
   %either_nonzero = or.i1 %lhs_nonzero, %rhs_nonzero
   %one_nonzero = xor.i1 %both_nonzero, %either_nonzero

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/packed_bitfield.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/packed_bitfield.loom-test
@@ -6,9 +6,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @i32_bitfield_extractu(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %nibble = vector.bitfield.extractu %loaded {offset = 4, width = 4} : vector<1xi32> -> vector<1xi32>
   vector.store %nibble, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
@@ -33,9 +33,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @i32_bitfield_extracts(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %nibble = vector.bitfield.extracts %loaded {offset = 4, width = 4} : vector<1xi32> -> vector<1xi32>
   vector.store %nibble, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
@@ -60,9 +60,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @i32_bitfield_extractu_full_width_alias(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %bits = vector.bitfield.extractu %loaded {offset = 0, width = 32} : vector<1xi32> -> vector<1xi32>
   vector.store %bits, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
@@ -83,9 +83,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @i32_bitfield_extracts_top_aligned(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %nibble = vector.bitfield.extracts %loaded {offset = 28, width = 4} : vector<1xi32> -> vector<1xi32>
   vector.store %nibble, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
@@ -108,10 +108,10 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @i32_bitfield_insert(%field_buffer: buffer, %base_buffer: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %field_view = buffer.view %field_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %base_view = buffer.view %base_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %field_view = buffer.view %field_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %base_view = buffer.view %base_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %field = vector.load %field_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %base = vector.load %base_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %inserted = vector.bitfield.insert %field into %base {offset = 8, width = 4} : vector<1xi32>, vector<1xi32>
@@ -141,10 +141,10 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @i32_bitfield_insert_offset0(%field_buffer: buffer, %base_buffer: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %field_view = buffer.view %field_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %base_view = buffer.view %base_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %field_view = buffer.view %field_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %base_view = buffer.view %base_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %field = vector.load %field_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %base = vector.load %base_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %inserted = vector.bitfield.insert %field into %base {offset = 0, width = 4} : vector<1xi32>, vector<1xi32>
@@ -173,10 +173,10 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @i32_bitfield_insert_full_width_alias(%field_buffer: buffer, %base_buffer: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %field_view = buffer.view %field_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %base_view = buffer.view %base_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %field_view = buffer.view %field_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %base_view = buffer.view %base_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %field = vector.load %field_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %base = vector.load %base_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %inserted = vector.bitfield.insert %field into %base {offset = 0, width = 32} : vector<1xi32>, vector<1xi32>
@@ -191,9 +191,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @i32_bitfield_b128_shape(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   %low = vector.bitfield.extractu %loaded {offset = 0, width = 4} : vector<4xi32> -> vector<4xi32>
   %high = vector.bitfield.extractu %loaded {offset = 4, width = 2} : vector<4xi32> -> vector<4xi32>

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/packed_bitpack.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/packed_bitpack.loom-test
@@ -312,8 +312,8 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 kernel.def target(@target) @uniform_global_i32x4_to_i8x4_bitpack_store() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%values: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %index = index.constant 0 : index

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/packed_bitunpack.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/packed_bitunpack.loom-test
@@ -250,8 +250,8 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 kernel.def target(@target) @uniform_global_i32_to_u8x4_bitunpack_store() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%values: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %index = index.constant 0 : index

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/vector_dot.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/vector_dot.loom-test
@@ -34,17 +34,17 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @f32_dotf_zero_seed(%lhs: vector<4xf32>, %rhs: vector<4xf32>) -> (f32) {
-  %zero = scalar.constant 0.0 : f32
-  %dot = vector.dotf %lhs, %rhs, %zero : vector<4xf32>, vector<4xf32>, f32
+  %initial_accumulator = scalar.constant 0.0 : f32
+  %dot = vector.dotf %lhs, %rhs, %initial_accumulator : vector<4xf32>, vector<4xf32>, f32
   func.return %dot : f32
 }
 
 // ----
 low.func.def target<llvmir.generic.core>(@target) abi(object_function) @f32_dotf_zero_seed(%lhs: reg<llvmir.f32 x4>, %rhs: reg<llvmir.f32 x4>) -> (reg<llvmir.f32>) asm {
-  %zero = const.f32 0
+  %initial_accumulator = const.f32 0
   %21 = extract.v4f32 %lhs, 0
   %22 = extract.v4f32 %rhs, 0
-  %23 = fma.f32 %21, %22, %zero
+  %23 = fma.f32 %21, %22, %initial_accumulator
   %24 = extract.v4f32 %lhs, 1
   %25 = extract.v4f32 %rhs, 1
   %26 = fma.f32 %24, %25, %23

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/vector_mask_select.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/vector_mask_select.loom-test
@@ -44,15 +44,15 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @scalar_cmpf_rhs_zero_inline(%value: f32) -> (i1) {
-  %zero = scalar.constant 0.0 : f32
-  %mask = scalar.cmpf one, %value, %zero : f32
+  %comparison_rhs = scalar.constant 0.0 : f32
+  %mask = scalar.cmpf one, %value, %comparison_rhs : f32
   func.return %mask : i1
 }
 
 // ----
 low.func.def target<llvmir.generic.core>(@target) abi(object_function) @scalar_cmpf_rhs_zero_inline(%value: reg<llvmir.f32>) -> (reg<llvmir.i1>) asm {
-  %zero = const.f32 0
-  %mask = cmp.one.f32 %value, %zero
+  %comparison_rhs = const.f32 0
+  %mask = cmp.one.f32 %value, %comparison_rhs
   return %mask
 }
 
@@ -63,15 +63,15 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @scalar_cmpf_lhs_one_inline(%value: f32) -> (i1) {
-  %one = scalar.constant 1.0 : f32
-  %mask = scalar.cmpf olt, %one, %value : f32
+  %comparison_lhs = scalar.constant 1.0 : f32
+  %mask = scalar.cmpf olt, %comparison_lhs, %value : f32
   func.return %mask : i1
 }
 
 // ----
 low.func.def target<llvmir.generic.core>(@target) abi(object_function) @scalar_cmpf_lhs_one_inline(%value: reg<llvmir.f32>) -> (reg<llvmir.i1>) asm {
-  %one = const.f32 1065353216
-  %mask = cmp.olt.f32 %one, %value
+  %comparison_lhs = const.f32 1065353216
+  %mask = cmp.olt.f32 %comparison_lhs, %value
   return %mask
 }
 
@@ -82,16 +82,16 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @vector_cmpf_rhs_zero_inline(%value: vector<2xf32>) -> (vector<2xi1>) {
-  %zero = scalar.constant 0.0 : f32
-  %zeros = vector.splat %zero : vector<2xf32>
-  %mask = vector.cmpf one, %value, %zeros : vector<2xf32> -> vector<2xi1>
+  %comparison_rhs_element = scalar.constant 0.0 : f32
+  %comparison_rhs = vector.splat %comparison_rhs_element : vector<2xf32>
+  %mask = vector.cmpf one, %value, %comparison_rhs : vector<2xf32> -> vector<2xi1>
   func.return %mask : vector<2xi1>
 }
 
 // ----
 low.func.def target<llvmir.generic.core>(@target) abi(object_function) @vector_cmpf_rhs_zero_inline(%value: reg<llvmir.f32 x2>) -> (reg<llvmir.i1 x2>) asm {
-  %zeros = const.v2f32 0
-  %mask = cmp.one.v2f32 %value, %zeros
+  %comparison_rhs = const.v2f32 0
+  %mask = cmp.one.v2f32 %value, %comparison_rhs
   return %mask
 }
 
@@ -103,8 +103,8 @@ llvmir.target<object> @target {
 }
 func.def target(@target) @i32_cmpi_select_zero_inline(%lhs: vector<2xi32>, %rhs: vector<2xi32>, %false_value: vector<2xi32>) -> (vector<2xi32>) {
   %mask = vector.cmpi slt, %lhs, %rhs : vector<2xi32> -> vector<2xi1>
-  %zero = scalar.constant 0 : i32
-  %true_value = vector.splat %zero : vector<2xi32>
+  %true_element = scalar.constant 0 : i32
+  %true_value = vector.splat %true_element : vector<2xi32>
   %selected = vector.select %mask, %true_value, %false_value : vector<2xi32>
   func.return %selected : vector<2xi32>
 }

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/vector_slice.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/vector_slice.loom-test
@@ -142,15 +142,15 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @bf16x8_insert_static_constant(%values: vector<8xbf16>) -> (vector<8xbf16>) {
-  %zero = scalar.constant 0.0 : bf16
-  %updated = vector.insert %zero into %values[5] : bf16, vector<8xbf16>
+  %replacement = scalar.constant 0.0 : bf16
+  %updated = vector.insert %replacement into %values[5] : bf16, vector<8xbf16>
   func.return %updated : vector<8xbf16>
 }
 
 // ----
 low.func.def target<llvmir.generic.core>(@target) abi(object_function) @bf16x8_insert_static_constant(%values: reg<llvmir.bf16 x8>) -> (reg<llvmir.bf16 x8>) asm {
-  %zero = const.bf16 0
-  %updated = insert.v8bf16 %values, %zero, 5
+  %replacement = const.bf16 0
+  %updated = insert.v8bf16 %values, %replacement, 5
   return %updated
 }
 

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/vector_v16.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/vector_v16.loom-test
@@ -308,11 +308,11 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @f32x16_index_add_memory(%input: buffer, %output: buffer, %i: index, %j: index) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %sum = index.add %i, %j : index
   %bounded_sum = index.assume %sum [range(%sum, 0, 16)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<32xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<32xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<32xf32, #dense>
   %loaded = vector.load %input_view[%bounded_sum] : view<32xf32, #dense> -> vector<16xf32>
   vector.store %loaded, %output_view[%bounded_sum] : vector<16xf32>, view<32xf32, #dense>
   func.return
@@ -335,11 +335,11 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @f32x16_index_madd_memory(%input: buffer, %output: buffer, %row: index, %stride: index, %col: index) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %linear = index.madd %row, %stride, %col : index
   %bounded_linear = index.assume %linear [range(%linear, 0, 16)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<32xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<32xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<32xf32, #dense>
   %loaded = vector.load %input_view[%bounded_linear] : view<32xf32, #dense> -> vector<16xf32>
   vector.store %loaded, %output_view[%bounded_linear] : vector<16xf32>, view<32xf32, #dense>
   func.return

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/vector_v4.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/vector_v4.loom-test
@@ -246,9 +246,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @i32x4_memory_copy(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[0] : vector<4xi32>, view<4xi32, #dense>
   func.return
@@ -269,9 +269,9 @@ llvmir.target<object> @target {
 }
 func.def target(@target) @i32x4_memory_indexed(%input: buffer, %output: buffer, %i: index) {
   %bounded_i = index.assume %i [range(%i, 0, 12)] : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%bounded_i] : view<16xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[%bounded_i] : vector<4xi32>, view<16xi32, #dense>
   func.return
@@ -291,9 +291,9 @@ llvmir.target<object> @target {
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
 func.def target(@target) @f32x4_memory_copy(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xf32, #dense>
   %loaded = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   vector.store %loaded, %output_view[0] : vector<4xf32>, view<4xf32, #dense>
   func.return
@@ -314,10 +314,10 @@ llvmir.target<object> @target {
 }
 func.def target(@target) @f32x4_memory_indexed_add(%lhs: buffer, %rhs: buffer, %output: buffer, %i: index) {
   %bounded_i = index.assume %i [range(%i, 0, 12)] : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs[%zero] : buffer -> view<16xf32, #dense>
-  %rhs_view = buffer.view %rhs[%zero] : buffer -> view<16xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs[%buffer_base] : buffer -> view<16xf32, #dense>
+  %rhs_view = buffer.view %rhs[%buffer_base] : buffer -> view<16xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xf32, #dense>
   %lhs_v = vector.load %lhs_view[%bounded_i] : view<16xf32, #dense> -> vector<4xf32>
   %rhs_v = vector.load %rhs_view[%bounded_i] : view<16xf32, #dense> -> vector<4xf32>
   %sum = vector.addf %lhs_v, %rhs_v : vector<4xf32>

--- a/loom/src/loom/target/arch/llvmir/test/source_low/source_low.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/source_low.loom-test
@@ -242,9 +242,9 @@ kernel.def target(@target) @llvmir_hal_buffer_resources() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = view.load %input_view[0] : view<1xi32, #dense> -> i32
   view.store %loaded, %output_view[0] : i32, view<1xi32, #dense>
   kernel.return
@@ -267,18 +267,18 @@ llvmir.target<object> @target {
 }
 
 func.def target(@target) @llvmir_canonical_dynamic_memory_address(%input: buffer, %output: buffer, %i: index) {
-  %zero = index.constant 0 : offset
-  %two = index.constant 2 : index
-  %four = index.constant 4 : index
-  %element_index = index.madd %i, %two, %four : index
+  %buffer_base = index.constant 0 : offset
+  %index_stride = index.constant 2 : index
+  %index_bias = index.constant 4 : index
+  %element_index = index.madd %i, %index_stride, %index_bias : index
   %bounded_index = index.assume %element_index [range(%element_index, 0, 31)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = view.load %input_view[%bounded_index] : view<64xi32, #dense> -> i32
   view.store %loaded, %output_view[%bounded_index] : i32, view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %output_view[%bounded_index] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
-  %old = view.atomic.rmw<addi> %one, %output_view[%bounded_index] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %output_view[%bounded_index] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
+  %old = view.atomic.rmw<addi> %increment, %output_view[%bounded_index] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
   %replacement = scalar.constant 9 : i32
   %previous = view.atomic.cmpxchg %old, %replacement, %output_view[%bounded_index] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i32, view<64xi32, #dense> -> i32
   func.return
@@ -288,9 +288,9 @@ func.def target(@target) @llvmir_canonical_dynamic_memory_address(%input: buffer
 low.func.def target<llvmir.generic.core>(@target) abi(object_function) @llvmir_canonical_dynamic_memory_address(%input_view: reg<llvmir.ptr>, %output_view: reg<llvmir.ptr>, %i: reg<llvmir.i64>) asm {
   %loaded = load.indexed.i32 %input_view, %i, 16, 8
   store.indexed.i32 %loaded, %output_view, %i, 16, 8
-  %one = const.i32 1
-  atomic.reduce.indexed.add.i32 %one, %output_view, %i, 16, 0, 3, 8
-  %old = atomic.rmw.indexed.add.i32 %one, %output_view, %i, 16, 0, 3, 8
+  %increment = const.i32 1
+  atomic.reduce.indexed.add.i32 %increment, %output_view, %i, 16, 0, 3, 8
+  %old = atomic.rmw.indexed.add.i32 %increment, %output_view, %i, 16, 0, 3, 8
   %replacement = const.i32 9
   %previous = atomic.cmpxchg.indexed.i32 %old, %replacement, %output_view, %i, 16, 0, 0, 3, 8
   return

--- a/loom/src/loom/target/arch/spirv/test/source_low/corpus/index_addressing.loom-test
+++ b/loom/src/loom/target/arch/spirv/test/source_low/corpus/index_addressing.loom-test
@@ -10,11 +10,11 @@ kernel.def target(@target) @index_madd_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 4 : index
   %linear = index.madd %row, %row_stride, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<16xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<16xi32, #dense>
   kernel.return
@@ -32,11 +32,11 @@ kernel.def target(@target) @index_madd_u24_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 9 : index
   %linear = index.madd %row, %row_stride, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<36xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<36xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<36xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<36xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<36xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<36xi32, #dense>
   kernel.return
@@ -54,11 +54,11 @@ kernel.def target(@target) @index_madd_u24_literal_lhs_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 9 : index
   %linear = index.madd %row_stride, %row, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<36xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<36xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<36xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<36xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<36xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<36xi32, #dense>
   kernel.return
@@ -76,11 +76,11 @@ kernel.def target(@target) @index_madd_u24_literal_addend_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %linear_bias = index.constant 1 : index
   %linear = index.madd %row, %column, %linear_bias : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<36xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<36xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<36xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<36xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<36xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<36xi32, #dense>
   kernel.return
@@ -96,12 +96,12 @@ kernel.def target(@target) @index_madd_constant_addend_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%row_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %row = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 4 : index
   %column = index.constant 1 : index
   %linear = index.madd %row, %row_stride, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<16xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<16xi32, #dense>
   kernel.return
@@ -117,14 +117,14 @@ kernel.def target(@target) @index_madd_nested_scale_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%row_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %row = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %c9 = index.constant 9 : index
   %c2 = index.constant 2 : index
   %c16 = index.constant 16 : index
   %scaled = index.mul %row, %c9 : index
   %linear = index.madd %scaled, %c2, %c16 : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<80xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<80xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<80xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<80xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<80xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<80xi32, #dense>
   kernel.return
@@ -140,11 +140,11 @@ kernel.def target(@target) @index_shli_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%lane_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %shift = index.constant 2 : index
   %linear = index.shli %lane, %shift : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<16xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<16xi32, #dense>
   kernel.return
@@ -160,13 +160,13 @@ kernel.def target(@target) @index_scale_byte_offset_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%element_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %element = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : index
+  %first_element = index.constant 0 : index
   %byte_stride = index.constant 4 : offset
   %byte_offset = index.scale %element, %byte_stride : index, offset -> offset
   %input_view = buffer.view %input[%byte_offset] : buffer -> view<1xi32, #dense>
   %output_view = buffer.view %output[%byte_offset] : buffer -> view<1xi32, #dense>
-  %loaded = vector.load %input_view[%zero] : view<1xi32, #dense> -> vector<1xi32>
-  vector.store %loaded, %output_view[%zero] : vector<1xi32>, view<1xi32, #dense>
+  %loaded = vector.load %input_view[%first_element] : view<1xi32, #dense> -> vector<1xi32>
+  vector.store %loaded, %output_view[%first_element] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
 
@@ -181,9 +181,9 @@ kernel.def target(@target) @index_shli_previous_row_global_b128() {
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
   %base_offset = index.constant 0 : offset
-  %one = index.constant 1 : index
-  %column = index.add %lane, %one : index
-  %previous = index.sub %column, %one : index
+  %column_offset = index.constant 1 : index
+  %column = index.add %lane, %column_offset : index
+  %previous = index.sub %column, %column_offset : index
   %shift = index.constant 2 : index
   %linear = index.shli %previous, %shift : index
   %input_view = buffer.view %input[%base_offset] : buffer -> view<128xi32, #dense>
@@ -204,21 +204,25 @@ kernel.def target(@target) @index_edge_loop_dynamic_lower_bound_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
   %base_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %three = index.constant 3 : index
+  %left_edge_lane = index.constant 0 : index
+  %full_tap_begin = index.constant 0 : index
+  %left_edge_tap_begin = index.constant 1 : index
+  %tap_step = index.constant 1 : index
+  %padding_offset = index.constant 1 : index
+  %right_edge_tap_end = index.constant 2 : index
+  %input_lane_divisor = index.constant 2 : index
+  %full_tap_end = index.constant 3 : index
   %last_lane = index.constant 1023 : index
-  %is_left_edge = index.cmp eq, %lane, %zero : index
-  %begin = scf.select %is_left_edge, %one, %zero : index
+  %is_left_edge = index.cmp eq, %lane, %left_edge_lane : index
+  %begin = scf.select %is_left_edge, %left_edge_tap_begin, %full_tap_begin : index
   %is_right_edge = index.cmp eq, %lane, %last_lane : index
-  %end = scf.select %is_right_edge, %two, %three : index
+  %end = scf.select %is_right_edge, %right_edge_tap_end, %full_tap_end : index
   %input_view = buffer.view %input[%base_offset] : buffer -> view<512xi32, #dense>
   %output_view = buffer.view %output[%base_offset] : buffer -> view<1024xi32, #dense>
-  scf.for %tap = [%begin to %end step %one] {
+  scf.for %tap = [%begin to %end step %tap_step] {
     %shifted = index.add %lane, %tap : index
-    %source_lane = index.sub %shifted, %one : index
-    %input_lane = index.div %source_lane, %two : index
+    %source_lane = index.sub %shifted, %padding_offset : index
+    %input_lane = index.div %source_lane, %input_lane_divisor : index
     %loaded = vector.load %input_view[%input_lane] : view<512xi32, #dense> -> vector<1xi32>
     vector.store %loaded, %output_view[%lane] : vector<1xi32>, view<1024xi32, #dense>
   }
@@ -298,11 +302,12 @@ kernel.def target(@target) @workitem_y_lds_uses_explicit_vaddr() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %row_count, %unit) : index
 } launch(%output: buffer) {
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%output_base] : buffer -> view<64xi32, #dense>
   %value = vector.constant 7 : vector<1xi32>
   vector.store %value, %scratch_view[%row] : vector<1xi32>, view<64xi32, #dense>
   %loaded = vector.load %scratch_view[%row] : view<64xi32, #dense> -> vector<1xi32>
@@ -326,9 +331,9 @@ kernel.def target(@target) @dispatch_id_xy_global_b32() {
   %dispatch_row = kernel.workitem.dispatch.id<y> : index
   %row_stride = index.constant 32 : index
   %linear = index.madd %dispatch_row, %row_stride, %dispatch_column : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<512xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %output_view[%linear] : vector<1xi32>, view<512xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<512xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %output_view[%linear] : vector<1xi32>, view<512xi32, #dense>
   kernel.return
 }

--- a/loom/src/loom/target/arch/spirv/test/source_low/corpus/memory_scalar_addressing.loom-test
+++ b/loom/src/loom/target/arch/spirv/test/source_low/corpus/memory_scalar_addressing.loom-test
@@ -30,11 +30,11 @@ low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_lay
 spirv.target<vulkan1_3> @target
 func.def target(@target) @scalar_dynamic_view_base_i32(%input: buffer, %output: buffer, %base: offset) -> (i32) {
   %base_aligned = index.assume %base [range(%base, 0, 4092), mul(%base, 4)] : offset
-  %zero = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
   %input_view = buffer.view %input_aligned[%base_aligned] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output_aligned[%zero] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output_aligned[%output_base] : buffer -> view<1xi32, #dense>
   %loaded = view.load %input_view[2] : view<4xi32, #dense> -> i32
   view.store %loaded, %output_view[0] : i32, view<1xi32, #dense>
   func.return %loaded : i32
@@ -87,12 +87,12 @@ low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_lay
 
 spirv.target<vulkan1_3> @target
 func.def target(@target) @scalar_dynamic_index_i32(%input: buffer, %output: buffer, %element: index) -> (i32) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %element_bounded = index.assume %element [range(%element, 0, 7)] : index
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
-  %input_view = buffer.view %input_aligned[%zero] : buffer -> view<8xi32, #dense>
-  %output_view = buffer.view %output_aligned[%zero] : buffer -> view<8xi32, #dense>
+  %input_view = buffer.view %input_aligned[%buffer_base] : buffer -> view<8xi32, #dense>
+  %output_view = buffer.view %output_aligned[%buffer_base] : buffer -> view<8xi32, #dense>
   %loaded = view.load %input_view[%element_bounded] : view<8xi32, #dense> -> i32
   view.store %loaded, %output_view[%element_bounded] : i32, view<8xi32, #dense>
   func.return %loaded : i32
@@ -150,14 +150,14 @@ low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_lay
 
 spirv.target<vulkan1_3> @target
 func.def target(@target) @scalar_dynamic_stride_i32(%input: buffer, %output: buffer, %columns: index, %row: index, %column: index) -> (i32) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %columns_bounded = index.assume %columns [range(%columns, 1, 8)] : index
   %row_bounded = index.assume %row [range(%row, 0, 3)] : index
   %column_bounded = index.assume %column [range(%column, 0, 7), lt(%column, %columns_bounded)] : index
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
-  %input_view = buffer.view %input_aligned[%zero] : buffer -> view<4x[%columns_bounded]xi32, #dense>
-  %output_view = buffer.view %output_aligned[%zero] : buffer -> view<4x[%columns_bounded]xi32, #dense>
+  %input_view = buffer.view %input_aligned[%buffer_base] : buffer -> view<4x[%columns_bounded]xi32, #dense>
+  %output_view = buffer.view %output_aligned[%buffer_base] : buffer -> view<4x[%columns_bounded]xi32, #dense>
   %loaded = view.load %input_view[%row_bounded, %column_bounded] : view<4x[%columns_bounded]xi32, #dense> -> i32
   view.store %loaded, %output_view[%row_bounded, %column_bounded] : i32, view<4x[%columns_bounded]xi32, #dense>
   func.return %loaded : i32

--- a/loom/src/loom/target/arch/spirv/test/source_low/corpus/memory_workgroup_scalar_addressing.loom-test
+++ b/loom/src/loom/target/arch/spirv/test/source_low/corpus/memory_workgroup_scalar_addressing.loom-test
@@ -64,12 +64,12 @@ low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_lay
 spirv.target<vulkan1_3> @target {contract_feature_bits = 37374}
 func.def target(@target) @workgroup_dynamic_stride_rank2_i32(%value: i32, %column_count: index, %row: index, %column: index) -> (i32) {
   %byte_length = index.constant 128 : offset
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %column_count_bounded = index.assume %column_count [range(%column_count, 1, 8)] : index
   %row_bounded = index.assume %row [range(%row, 0, 3)] : index
   %column_bounded = index.assume %column [range(%column, 0, 7), lt(%column, %column_count_bounded)] : index
   %scratch = buffer.alloca %byte_length {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<4x[%column_count_bounded]xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<4x[%column_count_bounded]xi32, #dense>
   view.store %value, %scratch_view[%row_bounded, %column_bounded] : i32, view<4x[%column_count_bounded]xi32, #dense>
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   %loaded = view.load %scratch_view[%row_bounded, %column_bounded] : view<4x[%column_count_bounded]xi32, #dense> -> i32
@@ -130,15 +130,15 @@ low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_lay
 spirv.target<vulkan1_3> @target {contract_feature_bits = 37374}
 func.def target(@target) @workgroup_integer_scalar_widths(%value_i8: i8, %value_i16: i16, %value_i32: i32, %value_i64: i64) -> (i8, i16, i32, i64) {
   %byte_length = index.constant 16 : offset
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %scratch_i8 = buffer.alloca %byte_length {base_alignment = 1, memory_space = workgroup} : buffer
   %scratch_i16 = buffer.alloca %byte_length {base_alignment = 2, memory_space = workgroup} : buffer
   %scratch_i32 = buffer.alloca %byte_length {base_alignment = 4, memory_space = workgroup} : buffer
   %scratch_i64 = buffer.alloca %byte_length {base_alignment = 8, memory_space = workgroup} : buffer
-  %view_i8 = buffer.view %scratch_i8[%zero] : buffer -> view<2xi8, #dense>
-  %view_i16 = buffer.view %scratch_i16[%zero] : buffer -> view<2xi16, #dense>
-  %view_i32 = buffer.view %scratch_i32[%zero] : buffer -> view<2xi32, #dense>
-  %view_i64 = buffer.view %scratch_i64[%zero] : buffer -> view<2xi64, #dense>
+  %view_i8 = buffer.view %scratch_i8[%scratch_base] : buffer -> view<2xi8, #dense>
+  %view_i16 = buffer.view %scratch_i16[%scratch_base] : buffer -> view<2xi16, #dense>
+  %view_i32 = buffer.view %scratch_i32[%scratch_base] : buffer -> view<2xi32, #dense>
+  %view_i64 = buffer.view %scratch_i64[%scratch_base] : buffer -> view<2xi64, #dense>
   view.store %value_i8, %view_i8[1] : i8, view<2xi8, #dense>
   view.store %value_i16, %view_i16[1] : i16, view<2xi16, #dense>
   view.store %value_i32, %view_i32[1] : i32, view<2xi32, #dense>
@@ -188,15 +188,15 @@ low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_lay
 spirv.target<vulkan1_3> @target {contract_feature_bits = 37374}
 func.def target(@target) @workgroup_float_scalar_widths(%value_f16: f16, %value_bf16: bf16, %value_f32: f32, %value_f64: f64) -> (f16, bf16, f32, f64) {
   %byte_length = index.constant 16 : offset
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %scratch_f16 = buffer.alloca %byte_length {base_alignment = 2, memory_space = workgroup} : buffer
   %scratch_bf16 = buffer.alloca %byte_length {base_alignment = 2, memory_space = workgroup} : buffer
   %scratch_f32 = buffer.alloca %byte_length {base_alignment = 4, memory_space = workgroup} : buffer
   %scratch_f64 = buffer.alloca %byte_length {base_alignment = 8, memory_space = workgroup} : buffer
-  %view_f16 = buffer.view %scratch_f16[%zero] : buffer -> view<2xf16, #dense>
-  %view_bf16 = buffer.view %scratch_bf16[%zero] : buffer -> view<2xbf16, #dense>
-  %view_f32 = buffer.view %scratch_f32[%zero] : buffer -> view<2xf32, #dense>
-  %view_f64 = buffer.view %scratch_f64[%zero] : buffer -> view<2xf64, #dense>
+  %view_f16 = buffer.view %scratch_f16[%scratch_base] : buffer -> view<2xf16, #dense>
+  %view_bf16 = buffer.view %scratch_bf16[%scratch_base] : buffer -> view<2xbf16, #dense>
+  %view_f32 = buffer.view %scratch_f32[%scratch_base] : buffer -> view<2xf32, #dense>
+  %view_f64 = buffer.view %scratch_f64[%scratch_base] : buffer -> view<2xf64, #dense>
   view.store %value_f16, %view_f16[1] : f16, view<2xf16, #dense>
   view.store %value_bf16, %view_bf16[1] : bf16, view<2xbf16, #dense>
   view.store %value_f32, %view_f32[1] : f32, view<2xf32, #dense>

--- a/loom/src/loom/target/arch/spirv/test/source_low/corpus/numeric_conversion.loom-test
+++ b/loom/src/loom/target/arch/spirv/test/source_low/corpus/numeric_conversion.loom-test
@@ -1021,13 +1021,13 @@ kernel.def target(@target) @scalar_bitcast_direct_i32_arg_f32_store() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%output: buffer, %scale_bits: i32) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xf32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_element = index.constant 0 : index
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xf32, #dense>
   %scale = scalar.bitcast %scale_bits : i32 to f32
   %unit = scalar.constant 1.0 : f32
   %scaled = scalar.mulf %unit, %scale : f32
-  view.store %scaled, %output_view[%zero_index] : f32, view<1xf32, #dense>
+  view.store %scaled, %output_view[%output_element] : f32, view<1xf32, #dense>
   kernel.return
 }
 
@@ -1056,17 +1056,19 @@ kernel.def target(@target) @scalar_bitcast_lane_byte_decode_select_tree_store() 
   %exp = scalar.shrui %exp_bits, %exp_shift : i32
   %mantissa_mask = scalar.constant 7 : i32
   %mantissa = scalar.andi %wide, %mantissa_mask : i32
-  %zero = scalar.constant 0 : i32
+  %absent_mantissa_bit = scalar.constant 0 : i32
+  %base_mantissa_shift = scalar.constant 0 : i32
+  %zero_exponent = scalar.constant 0 : i32
   %mantissa_bit1_mask = scalar.constant 2 : i32
   %mantissa_bit1 = scalar.andi %mantissa, %mantissa_bit1_mask : i32
-  %has_mantissa_bit1 = scalar.cmpi ne, %mantissa_bit1, %zero : i32
-  %one = scalar.constant 1 : i32
-  %shift0 = scf.select %has_mantissa_bit1, %one, %zero : i32
+  %has_mantissa_bit1 = scalar.cmpi ne, %mantissa_bit1, %absent_mantissa_bit : i32
+  %low_mantissa_shift = scalar.constant 1 : i32
+  %shift0 = scf.select %has_mantissa_bit1, %low_mantissa_shift, %base_mantissa_shift : i32
   %mantissa_bit2_mask = scalar.constant 4 : i32
   %mantissa_bit2 = scalar.andi %mantissa, %mantissa_bit2_mask : i32
-  %has_mantissa_bit2 = scalar.cmpi ne, %mantissa_bit2, %zero : i32
-  %two = scalar.constant 2 : i32
-  %selected_shift = scf.select %has_mantissa_bit2, %two, %shift0 : i32
+  %has_mantissa_bit2 = scalar.cmpi ne, %mantissa_bit2, %absent_mantissa_bit : i32
+  %high_mantissa_shift = scalar.constant 2 : i32
+  %selected_shift = scf.select %has_mantissa_bit2, %high_mantissa_shift, %shift0 : i32
   %bias = scalar.constant 118 : i32
   %biased_exp = scalar.addi %selected_shift, %bias : i32
   %f32_exp_shift = scalar.constant 23 : i32
@@ -1078,7 +1080,7 @@ kernel.def target(@target) @scalar_bitcast_lane_byte_decode_select_tree_store() 
   %normal_head = scalar.ori %sign_bits, %f32_exp : i32
   %normal_bits = scalar.ori %normal_head, %f32_mantissa : i32
   %subnormal = scf.select %has_mantissa_bit2, %normal_bits, %sign_bits : i32
-  %is_zero_exp = scalar.cmpi eq, %exp, %zero : i32
+  %is_zero_exp = scalar.cmpi eq, %exp, %zero_exponent : i32
   %regular_exp_bias = scalar.constant 120 : i32
   %regular_exp = scalar.addi %exp, %regular_exp_bias : i32
   %regular_exp_bits = scalar.shli %regular_exp, %f32_exp_shift : i32

--- a/loom/src/loom/target/arch/spirv/test/source_low/corpus/numeric_minmax.loom-test
+++ b/loom/src/loom/target/arch/spirv/test/source_low/corpus/numeric_minmax.loom-test
@@ -119,30 +119,30 @@ low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_lay
 
 spirv.target<vulkan1_3> @target {contract_feature_bits = 37374}
 func.def target(@target) @scf_select_q6_nibble_i8(%code: i32, %use_high: i32) -> (i8) {
-  %zero = scalar.constant 0 : i32
-  %four = scalar.constant 4 : i32
+  %low_selector = scalar.constant 0 : i32
+  %nibble_shift = scalar.constant 4 : i32
   %mask = scalar.constant 15 : i32
-  %high_shifted = scalar.shrui %code, %four : i32
+  %high_shifted = scalar.shrui %code, %nibble_shift : i32
   %low_i32 = scalar.andi %code, %mask : i32
   %high_i32 = scalar.andi %high_shifted, %mask : i32
   %low = scalar.trunci %low_i32 : i32 to i8
   %high = scalar.trunci %high_i32 : i32 to i8
-  %cond = scalar.cmpi ne, %use_high, %zero : i32
+  %cond = scalar.cmpi ne, %use_high, %low_selector : i32
   %selected = scf.select %cond, %high, %low : i8
   func.return %selected : i8
 }
 
 // ----
 low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_layout({spirv_arg_value_types = [23, 23], spirv_result_value_types = [21]}) @scf_select_q6_nibble_i8(%code: reg<spirv.id>, %use_high: reg<spirv.id>) -> (reg<spirv.id>) asm {
-  %zero = OpConstant.i32 0
-  %four = OpConstant.i32 4
+  %low_selector = OpConstant.i32 0
+  %nibble_shift = OpConstant.i32 4
   %mask = OpConstant.i32 15
-  %high_shifted = OpShiftRightLogical %code, %four
+  %high_shifted = OpShiftRightLogical %code, %nibble_shift
   %low_i32 = OpBitwiseAnd %code, %mask
   %high_i32 = OpBitwiseAnd %high_shifted, %mask
   %low = OpSConvert.i32.i8 %low_i32
   %high = OpSConvert.i32.i8 %high_i32
-  %cond = OpINotEqual %use_high, %zero
+  %cond = OpINotEqual %use_high, %low_selector
   %selected = OpSelect.i8 %cond, %high, %low
   return %selected
 }
@@ -151,24 +151,24 @@ low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_lay
 
 spirv.target<vulkan1_3> @target {contract_feature_bits = 37374}
 func.def target(@target) @scf_select_scale_piece_i16(%packed: i32, %use_high: i32) -> (i16) {
-  %zero = scalar.constant 0 : i32
-  %sixteen = scalar.constant 16 : i32
+  %low_selector = scalar.constant 0 : i32
+  %halfword_shift = scalar.constant 16 : i32
   %low = scalar.trunci %packed : i32 to i16
-  %high_shifted = scalar.shrui %packed, %sixteen : i32
+  %high_shifted = scalar.shrui %packed, %halfword_shift : i32
   %high = scalar.trunci %high_shifted : i32 to i16
-  %cond = scalar.cmpi ne, %use_high, %zero : i32
+  %cond = scalar.cmpi ne, %use_high, %low_selector : i32
   %selected = scf.select %cond, %high, %low : i16
   func.return %selected : i16
 }
 
 // ----
 low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_layout({spirv_arg_value_types = [23, 23], spirv_result_value_types = [22]}) @scf_select_scale_piece_i16(%packed: reg<spirv.id>, %use_high: reg<spirv.id>) -> (reg<spirv.id>) asm {
-  %zero = OpConstant.i32 0
-  %sixteen = OpConstant.i32 16
+  %low_selector = OpConstant.i32 0
+  %halfword_shift = OpConstant.i32 16
   %low = OpSConvert.i32.i16 %packed
-  %high_shifted = OpShiftRightLogical %packed, %sixteen
+  %high_shifted = OpShiftRightLogical %packed, %halfword_shift
   %high = OpSConvert.i32.i16 %high_shifted
-  %cond = OpINotEqual %use_high, %zero
+  %cond = OpINotEqual %use_high, %low_selector
   %selected = OpSelect.i16 %cond, %high, %low
   return %selected
 }
@@ -202,9 +202,9 @@ func.def target(@target) @scf_select_chained_vgpr_i32(%values: vector<2xi32>, %l
 spirv.target<vulkan1_3> @target {contract_feature_bits = 37374}
 func.def target(@target) @scf_select_tail_zero_i32(%values: vector<2xi32>, %limit: i32) -> (i32) {
   %lane = vector.extract %values[0] : vector<2xi32> -> i32
-  %zero = scalar.constant 0 : i32
+  %tail_fill = scalar.constant 0 : i32
   %cond = scalar.cmpi slt, %lane, %limit : i32
-  %selected = scf.select %cond, %lane, %zero : i32
+  %selected = scf.select %cond, %lane, %tail_fill : i32
   func.return %selected : i32
 }
 
@@ -396,10 +396,10 @@ low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_lay
 
 spirv.target<vulkan1_3> @target {contract_feature_bits = 37374}
 func.def target(@target) @scf_select_i1_scc_condition(%lhs: i32, %rhs: i32, %alt: i32, %true_value: f32, %false_value: f32) -> (f32) {
-  %zero = scalar.constant 0 : i32
+  %inactive_condition = scalar.constant 0 : i32
   %condition = scalar.cmpi slt, %lhs, %rhs : i32
-  %lhs_nonzero = scalar.cmpi ne, %lhs, %zero : i32
-  %alt_nonzero = scalar.cmpi ne, %alt, %zero : i32
+  %lhs_nonzero = scalar.cmpi ne, %lhs, %inactive_condition : i32
+  %alt_nonzero = scalar.cmpi ne, %alt, %inactive_condition : i32
   %selected_condition = scf.select %condition, %lhs_nonzero, %alt_nonzero : i1
   %result = scf.select %selected_condition, %true_value, %false_value : f32
   func.return %result : f32
@@ -407,10 +407,10 @@ func.def target(@target) @scf_select_i1_scc_condition(%lhs: i32, %rhs: i32, %alt
 
 // ----
 low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_layout({spirv_arg_value_types = [23, 23, 23, 18, 18], spirv_result_value_types = [18]}) @scf_select_i1_scc_condition(%lhs: reg<spirv.id>, %rhs: reg<spirv.id>, %alt: reg<spirv.id>, %true_value: reg<spirv.id>, %false_value: reg<spirv.id>) -> (reg<spirv.id>) asm {
-  %zero = OpConstant.i32 0
+  %inactive_condition = OpConstant.i32 0
   %condition = OpSLessThan %lhs, %rhs
-  %lhs_nonzero = OpINotEqual %lhs, %zero
-  %alt_nonzero = OpINotEqual %alt, %zero
+  %lhs_nonzero = OpINotEqual %lhs, %inactive_condition
+  %alt_nonzero = OpINotEqual %alt, %inactive_condition
   %selected_condition = OpSelect.bool %condition, %lhs_nonzero, %alt_nonzero
   %result = OpSelect.f32 %selected_condition, %true_value, %false_value
   return %result
@@ -431,8 +431,8 @@ kernel.def target(@target) @index_minmax_vgpr_select() {
   %max = index.max %lane, %limit : index
   %cond = index.cmp slt, %lane, %limit : index
   %selected = scf.select %cond, %min, %max : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<64xi32, #dense>
   %stored = vector.constant 1 : vector<1xi32>
   vector.store %stored, %output_view[%selected] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
@@ -443,9 +443,9 @@ kernel.def target(@target) @index_minmax_vgpr_select() {
 // XFAIL: SPIR-V f32 constants and vector memory alignment are unsupported
 spirv.target<vulkan1_3> @target {contract_feature_bits = 37374}
 func.def target(@target) @f32_reduce_minnum_maxnum(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<2xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<2xf32, #dense>
   %loaded = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %min_init = scalar.constant 1000.0 : f32
   %min = vector.reduce<minnumf, reassoc|nnan|nsz> %loaded, %min_init : vector<4xf32>, f32

--- a/loom/src/loom/target/arch/spirv/test/source_low/corpus/numeric_scalar_i32.loom-test
+++ b/loom/src/loom/target/arch/spirv/test/source_low/corpus/numeric_scalar_i32.loom-test
@@ -73,9 +73,9 @@ low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_lay
 
 spirv.target<vulkan1_3> @target
 func.def target(@target) @scalar_i1_bitwise_scc(%lhs: i32, %rhs: i32) -> (i1) {
-  %zero = scalar.constant 0 : i32
-  %lhs_nonzero = scalar.cmpi ne, %lhs, %zero : i32
-  %rhs_nonzero = scalar.cmpi ne, %rhs, %zero : i32
+  %inactive_condition = scalar.constant 0 : i32
+  %lhs_nonzero = scalar.cmpi ne, %lhs, %inactive_condition : i32
+  %rhs_nonzero = scalar.cmpi ne, %rhs, %inactive_condition : i32
   %both_nonzero = scalar.andi %lhs_nonzero, %rhs_nonzero : i1
   %either_nonzero = scalar.ori %lhs_nonzero, %rhs_nonzero : i1
   %one_nonzero = scalar.xori %both_nonzero, %either_nonzero : i1
@@ -84,9 +84,9 @@ func.def target(@target) @scalar_i1_bitwise_scc(%lhs: i32, %rhs: i32) -> (i1) {
 
 // ----
 low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_layout({spirv_arg_value_types = [23, 23], spirv_result_value_types = [1]}) @scalar_i1_bitwise_scc(%lhs: reg<spirv.id>, %rhs: reg<spirv.id>) -> (reg<spirv.id>) asm {
-  %zero = OpConstant.i32 0
-  %lhs_nonzero = OpINotEqual %lhs, %zero
-  %rhs_nonzero = OpINotEqual %rhs, %zero
+  %inactive_condition = OpConstant.i32 0
+  %lhs_nonzero = OpINotEqual %lhs, %inactive_condition
+  %rhs_nonzero = OpINotEqual %rhs, %inactive_condition
   %both_nonzero = OpLogicalAnd.bool %lhs_nonzero, %rhs_nonzero
   %either_nonzero = OpLogicalOr.bool %lhs_nonzero, %rhs_nonzero
   %one_nonzero = OpLogicalNotEqual.bool %both_nonzero, %either_nonzero

--- a/loom/src/loom/target/arch/spirv/test/source_low/source_low.loom-test
+++ b/loom/src/loom/target/arch/spirv/test/source_low/source_low.loom-test
@@ -175,19 +175,19 @@ low.kernel.def target<spirv.logical.core>(@hal_target_scalar_payloads) abi_layou
 spirv.target<vulkan1_3> @target
 
 func.def target(@target) @spirv_index_arithmetic(%index: index, %factor: index) -> (index) {
-  %one = index.constant 1 : index
-  %previous = index.sub %index, %one : index
+  %index_adjustment = index.constant 1 : index
+  %previous = index.sub %index, %index_adjustment : index
   %scaled = index.mul %previous, %factor : index
-  %next = index.madd %scaled, %factor, %one : index
+  %next = index.madd %scaled, %factor, %index_adjustment : index
   func.return %next : index
 }
 
 // ----
 low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_layout({spirv_arg_value_types = [23, 23], spirv_result_value_types = [23]}) @spirv_index_arithmetic(%index: reg<spirv.id>, %factor: reg<spirv.id>) -> (reg<spirv.id>) asm {
-  %one = OpConstant.i32 1
-  %previous = OpISub %index, %one
+  %index_adjustment = OpConstant.i32 1
+  %previous = OpISub %index, %index_adjustment
   %scaled = OpIMul %previous, %factor
-  %next = OpIMulAdd %scaled, %factor, %one
+  %next = OpIMulAdd %scaled, %factor, %index_adjustment
   return %next
 }
 
@@ -196,17 +196,17 @@ low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) abi_lay
 spirv.target<vulkan1_3> @target
 
 func.def target(@target) @spirv_offset_compare_select(%byte_offset: offset, %limit: offset) -> (offset) {
-  %zero = index.constant 0 : offset
+  %fallback = index.constant 0 : offset
   %inside = index.cmp ule, %byte_offset, %limit : offset
-  %selected = scf.select %inside, %byte_offset, %zero : offset
+  %selected = scf.select %inside, %byte_offset, %fallback : offset
   func.return %selected : offset
 }
 
 // ----
 low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) @spirv_offset_compare_select(%byte_offset: reg<spirv.offset64>, %limit: reg<spirv.offset64>) -> (reg<spirv.offset64>) asm {
-  %zero = OpConstant.offset64 0
+  %fallback = OpConstant.offset64 0
   %inside = OpULessThanEqual.offset64 %byte_offset, %limit
-  %selected = OpSelect.offset64 %inside, %byte_offset, %zero
+  %selected = OpSelect.offset64 %inside, %byte_offset, %fallback
   return %selected
 }
 
@@ -240,9 +240,9 @@ spirv.target<vulkan1_3> @hal_target {abi = hal_kernel}
 kernel.def target(@hal_target) @spirv_dynamic_builtin_storage_buffer_i32() {
   %groups_x = index.constant 4 : index
   %groups_z = index.constant 3 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  kernel.launch.config workgroups(%groups_x, %one, %groups_z) workgroup_size(%one, %two, %one) : index
+  %unit = index.constant 1 : index
+  %workgroup_size_y = index.constant 2 : index
+  kernel.launch.config workgroups(%groups_x, %unit, %groups_z) workgroup_size(%unit, %workgroup_size_y, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %workgroup_x = kernel.workgroup.id<x> : index
   %local_y = kernel.workitem.id<y> : index

--- a/loom/src/loom/target/arch/spirv/test/source_low/source_low_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/spirv/test/source_low/source_low_diagnostics.loom-test
@@ -176,8 +176,8 @@ spirv.target<vulkan1_3> @target
 
 func.def target(@target) @storage_buffer_i32_rejects_misaligned_static_offset(%input: buffer) -> (i32) {
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
-  %two = index.constant 2 : offset
-  %input_view = buffer.view %input_aligned[%two] : buffer -> view<1xi32, #dense>
+  %misaligned_base = index.constant 2 : offset
+  %input_view = buffer.view %input_aligned[%misaligned_base] : buffer -> view<1xi32, #dense>
   // ERROR@+1: TARGET/050 {required_alignment="4", known_alignment="2"}
   %loaded = view.load %input_view[0] : view<1xi32, #dense> -> i32
   func.return %loaded : i32
@@ -188,10 +188,10 @@ func.def target(@target) @storage_buffer_i32_rejects_misaligned_static_offset(%i
 spirv.target<vulkan1_3> @target
 
 func.def target(@target) @storage_buffer_i32_rejects_wide_index(%input: buffer, %element0: index) -> (i32) {
-  %zero = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %element = index.assume %element0 [range(%element0, 0, 2147483648)] : index
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
-  %input_view = buffer.view %input_aligned[%zero] : buffer -> view<2147483649xi32, #dense>
+  %input_view = buffer.view %input_aligned[%input_base] : buffer -> view<2147483649xi32, #dense>
   // ERROR@+1: SPIRV/028 {required_range_lo="0", required_range_hi="2147483647", constraint_key="source_memory.address_index_non_negative_s32"}
   %loaded = view.load %input_view[%element] : view<2147483649xi32, #dense> -> i32
   func.return %loaded : i32
@@ -202,11 +202,11 @@ func.def target(@target) @storage_buffer_i32_rejects_wide_index(%input: buffer, 
 spirv.target<vulkan1_3> @target
 
 func.def target(@target) @storage_buffer_i32_rejects_wide_dynamic_stride(%input: buffer, %columns0: index, %row0: index) -> (i32) {
-  %zero_offset = index.constant 0 : offset
+  %input_base = index.constant 0 : offset
   %columns = index.assume %columns0 [range(%columns0, 1, 2147483648)] : index
   %row = index.assume %row0 [range(%row0, 0, 3)] : index
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
-  %input_view = buffer.view %input_aligned[%zero_offset] : buffer -> view<4x[%columns]xi32, #dense>
+  %input_view = buffer.view %input_aligned[%input_base] : buffer -> view<4x[%columns]xi32, #dense>
   // ERROR@+1: SPIRV/028 {required_range_lo="0", required_range_hi="2147483647", constraint_key="source_memory.address_index_non_negative_s32"}
   %loaded = view.load %input_view[%row, 0] : view<4x[%columns]xi32, #dense> -> i32
   func.return %loaded : i32
@@ -218,9 +218,9 @@ spirv.target<vulkan1_3> @target
 
 func.def target(@target) @workgroup_i32_rejects_wide_element_index() -> (i32) {
   %byte_length = index.constant 8589934596 : offset
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %scratch = buffer.alloca %byte_length {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<2147483649xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<2147483649xi32, #dense>
   // ERROR@+1: SPIRV/029 {element_byte_count="4", required_range_lo="0", required_range_hi="2147483647", constraint_key="source_memory.workgroup_element_index_non_negative_s32"}
   %loaded = view.load %scratch_view[2147483648] : view<2147483649xi32, #dense> -> i32
   func.return %loaded : i32

--- a/loom/src/loom/target/arch/spirv/test/source_low/workgroup_storage.loom-test
+++ b/loom/src/loom/target/arch/spirv/test/source_low/workgroup_storage.loom-test
@@ -36,9 +36,9 @@ spirv.target<vulkan1_3> @target
 // storage while remaining available to source-level control flow.
 func.def target(@target) @spirv_bounded_dynamic_workgroup_storage(%value: i32, %byte_length0: offset) -> (i32) {
   %byte_length = index.assume %byte_length0 [range(%byte_length0, 4, 8192)] : offset
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %scratch = buffer.alloca %byte_length {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<1xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<1xi32, #dense>
   view.store %value, %scratch_view[0] : i32, view<1xi32, #dense>
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   %loaded = view.load %scratch_view[0] : view<1xi32, #dense> -> i32

--- a/loom/src/loom/target/arch/wasm/test/source_low/source_low.loom-test
+++ b/loom/src/loom/target/arch/wasm/test/source_low/source_low.loom-test
@@ -209,9 +209,9 @@ low.func.def target<wasm.core.simd128>(@target) abi(wasm_function) @f32x4_select
 
 wasm.target<simd128> @target
 func.def target(@target) @i32x4_memory_copy(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[0] : vector<4xi32>, view<4xi32, #dense>
   func.return
@@ -229,9 +229,9 @@ low.func.def target<wasm.core.simd128>(@target) abi(wasm_function) @i32x4_memory
 wasm.target<simd128> @target
 func.def target(@target) @i32x4_memory_indexed(%input: buffer, %output: buffer, %i: index) {
   %bounded_i = index.assume %i [range(%i, 0, 12)] : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%bounded_i] : view<16xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[%bounded_i] : vector<4xi32>, view<16xi32, #dense>
   func.return
@@ -252,9 +252,9 @@ low.func.def target<wasm.core.simd128>(@target) abi(wasm_function) @i32x4_memory
 
 wasm.target<simd128> @target
 func.def target(@target) @f32x4_memory_copy(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xf32, #dense>
   %loaded = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   vector.store %loaded, %output_view[0] : vector<4xf32>, view<4xf32, #dense>
   func.return
@@ -272,10 +272,10 @@ low.func.def target<wasm.core.simd128>(@target) abi(wasm_function) @f32x4_memory
 wasm.target<simd128> @target
 func.def target(@target) @f32x4_memory_indexed_add(%lhs: buffer, %rhs: buffer, %output: buffer, %i: index) {
   %bounded_i = index.assume %i [range(%i, 0, 12)] : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs[%zero] : buffer -> view<16xf32, #dense>
-  %rhs_view = buffer.view %rhs[%zero] : buffer -> view<16xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs[%buffer_base] : buffer -> view<16xf32, #dense>
+  %rhs_view = buffer.view %rhs[%buffer_base] : buffer -> view<16xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xf32, #dense>
   %lhs_v = vector.load %lhs_view[%bounded_i] : view<16xf32, #dense> -> vector<4xf32>
   %rhs_v = vector.load %rhs_view[%bounded_i] : view<16xf32, #dense> -> vector<4xf32>
   %sum = vector.addf %lhs_v, %rhs_v : vector<4xf32>

--- a/loom/src/loom/target/arch/wasm/test/source_low/source_low_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/wasm/test/source_low/source_low_diagnostics.loom-test
@@ -44,8 +44,8 @@ wasm.target<simd128> @target
 
 func.def target(@target) @rejects_wasm32_address_overflow(%input: buffer, %i: index) -> (vector<4xi32>) {
   %bounded_i = index.assume %i [range(%i, 0, 1073741824)] : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1073741828xi32, #dense>
+  %input_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%input_base] : buffer -> view<1073741828xi32, #dense>
   // ERROR@+1: WASM/006 {bit_count="32"}
   %loaded = vector.load %input_view[%bounded_i] : view<1073741828xi32, #dense> -> vector<4xi32>
   func.return %loaded : vector<4xi32>

--- a/loom/src/loom/target/arch/wasm/test/source_low/source_low_wasm32_address_boundary.loom-test
+++ b/loom/src/loom/target/arch/wasm/test/source_low/source_low_wasm32_address_boundary.loom-test
@@ -3,8 +3,8 @@
 wasm.target<simd128> @target
 func.def target(@target) @i32x4_memory_wasm32_address_boundary(%input: buffer, %i: index) -> (vector<4xi32>) {
   %bounded_i = index.assume %i [range(%i, 0, 1073741820)] : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1073741824xi32, #dense>
+  %input_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%input_base] : buffer -> view<1073741824xi32, #dense>
   %loaded = vector.load %input_view[%bounded_i] : view<1073741824xi32, #dense> -> vector<4xi32>
   func.return %loaded : vector<4xi32>
 }

--- a/loom/src/loom/target/arch/wasm/test/source_low/structured_control.loom-test
+++ b/loom/src/loom/target/arch/wasm/test/source_low/structured_control.loom-test
@@ -4,8 +4,8 @@ wasm.target<simd128> @target
 
 func.def target(@target) @if_without_results(%control: i32, %limit: i32, %lhs: vector<4xi32>, %rhs: vector<4xi32>, %output: buffer) {
   %cond = scalar.cmpi ult, %control, %limit : i32
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<4xi32, #dense>
   scf.if %cond {
     %sum = vector.addi %lhs, %rhs : vector<4xi32>
     vector.store %sum, %output_view[0] : vector<4xi32>, view<4xi32, #dense>
@@ -58,8 +58,8 @@ low.func.def target<wasm.core.simd128>(@target) abi(wasm_function) @if_with_resu
 wasm.target<simd128> @target
 
 func.def target(@target) @for_without_iter_args(%lo: index, %hi: index, %step: index, %lhs: vector<4xi32>, %rhs: vector<4xi32>, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<4xi32, #dense>
   scf.for %iv = [%lo to %hi step %step] {
     %sum = vector.addi %lhs, %rhs : vector<4xi32>
     vector.store %sum, %output_view[0] : vector<4xi32>, view<4xi32, #dense>

--- a/loom/src/loom/target/arch/x86/test/source_low/source_low.loom-test
+++ b/loom/src/loom/target/arch/x86/test/source_low/source_low.loom-test
@@ -246,11 +246,11 @@ low.func.def target<x86.avx512.core>(@target) abi(object_function) @f32x16_dynam
 
 x86.target<avx512> @target
 func.def target(@target) @f32x16_index_add_memory(%input: buffer, %output: buffer, %i: index, %j: index) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %sum = index.add %i, %j : index
   %bounded_sum = index.assume %sum [range(%sum, 0, 16)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<32xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<32xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<32xf32, #dense>
   %loaded = vector.load %input_view[%bounded_sum] : view<32xf32, #dense> -> vector<16xf32>
   vector.store %loaded, %output_view[%bounded_sum] : vector<16xf32>, view<32xf32, #dense>
   func.return
@@ -268,11 +268,11 @@ low.func.def target<x86.avx512.core>(@target) abi(object_function) @f32x16_index
 
 x86.target<avx512> @target
 func.def target(@target) @f32x16_index_madd_memory(%input: buffer, %output: buffer, %row: index, %stride: index, %col: index) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %linear = index.madd %row, %stride, %col : index
   %bounded_linear = index.assume %linear [range(%linear, 0, 16)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<32xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<32xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<32xf32, #dense>
   %loaded = vector.load %input_view[%bounded_linear] : view<32xf32, #dense> -> vector<16xf32>
   vector.store %loaded, %output_view[%bounded_linear] : vector<16xf32>, view<32xf32, #dense>
   func.return

--- a/loom/src/loom/target/arch/x86/test/source_low/source_low_avx2.loom-test
+++ b/loom/src/loom/target/arch/x86/test/source_low/source_low_avx2.loom-test
@@ -90,9 +90,9 @@ x86.target<avx2> @target
 
 func.def target(@target) @i32x4_memory_indexed(%input: buffer, %output: buffer, %i: index) {
   %bounded_i = index.assume %i [range(%i, 0, 12)] : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%bounded_i] : view<16xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[%bounded_i] : vector<4xi32>, view<16xi32, #dense>
   func.return
@@ -110,13 +110,13 @@ low.func.def target<x86.avx2.core>(@target) abi(object_function) @i32x4_memory_i
 x86.target<avx2> @target
 
 func.def target(@target) @i32x4_index_madd_scaled_bias_memory(%input: buffer, %output: buffer, %row: index) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %stride = index.constant 4 : index
   %bias = index.constant 1 : index
   %linear = index.madd %row, %stride, %bias : index
   %bounded_linear = index.assume %linear [range(%linear, 0, 16)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<32xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<32xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<32xi32, #dense>
   %loaded = vector.load %input_view[%bounded_linear] : view<32xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[%bounded_linear] : vector<4xi32>, view<32xi32, #dense>
   func.return

--- a/loom/src/loom/target/arch/x86/test/source_low/source_low_scalar_addressing.loom-test
+++ b/loom/src/loom/target/arch/x86/test/source_low/source_low_scalar_addressing.loom-test
@@ -129,13 +129,13 @@ low.func.def target<x86.scalar.core>(@target) abi(object_function) @index_madd_d
 x86.target<avx512> @target
 
 func.def target(@target) @f32x16_index_madd_scaled_bias_memory(%input: buffer, %output: buffer, %row: index) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %stride = index.constant 4 : index
   %bias = index.constant 1 : index
   %linear = index.madd %row, %stride, %bias : index
   %bounded_linear = index.assume %linear [range(%linear, 0, 16)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<32xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<32xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<32xf32, #dense>
   %loaded = vector.load %input_view[%bounded_linear] : view<32xf32, #dense> -> vector<16xf32>
   vector.store %loaded, %output_view[%bounded_linear] : vector<16xf32>, view<32xf32, #dense>
   func.return
@@ -154,13 +154,13 @@ low.func.def target<x86.avx512.core>(@target) abi(object_function) @f32x16_index
 x86.target<scalar> @target
 
 func.def target(@target) @i32_index_madd_scaled_bias_memory(%input: buffer, %output: buffer, %row: index) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %stride = index.constant 4 : index
   %bias = index.constant 1 : index
   %linear = index.madd %row, %stride, %bias : index
   %bounded_linear = index.assume %linear [range(%linear, 0, 16)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<32xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<32xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<32xi32, #dense>
   %loaded = view.load %input_view[%bounded_linear] : view<32xi32, #dense> -> i32
   %incremented = scalar.addi %loaded, %loaded : i32
   view.store %incremented, %output_view[%bounded_linear] : i32, view<32xi32, #dense>
@@ -182,13 +182,13 @@ low.func.def target<x86.scalar.core>(@target) abi(object_function) @i32_index_ma
 x86.target<scalar> @target
 
 func.def target(@target) @i64_index_madd_scaled_bias_memory(%input: buffer, %output: buffer, %row: index) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %stride = index.constant 4 : index
   %bias = index.constant 1 : index
   %linear = index.madd %row, %stride, %bias : index
   %bounded_linear = index.assume %linear [range(%linear, 0, 16)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<32xi64, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<32xi64, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32xi64, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<32xi64, #dense>
   %loaded = view.load %input_view[%bounded_linear] : view<32xi64, #dense> -> i64
   %incremented = scalar.addi %loaded, %loaded : i64
   view.store %incremented, %output_view[%bounded_linear] : i64, view<32xi64, #dense>
@@ -210,13 +210,13 @@ low.func.def target<x86.scalar.core>(@target) abi(object_function) @i64_index_ma
 x86.target<scalar> @target
 
 func.def target(@target) @i64_index_add_madd_memory(%input: buffer, %output: buffer, %i: index, %j: index, %row: index) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %stride = index.constant 4 : index
   %sum = index.add %i, %j : index
   %linear = index.madd %row, %stride, %sum : index
   %bounded_linear = index.assume %linear [range(%linear, 0, 16)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<32xi64, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<32xi64, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32xi64, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<32xi64, #dense>
   %loaded = view.load %input_view[%bounded_linear] : view<32xi64, #dense> -> i64
   %incremented = scalar.addi %loaded, %loaded : i64
   view.store %incremented, %output_view[%bounded_linear] : i64, view<32xi64, #dense>
@@ -244,14 +244,14 @@ func.def target(@target) @guarded_loaded_i64_index_address(%control: buffer, %ou
   %output_view = buffer.view %output[%base] : buffer -> view<64xi32, #dense>
   %row_i64 = view.load %control_view[0] : view<1xi64, #dense> -> i64
   %row = index.cast %row_i64 : i64 to index
-  %zero_i64 = scalar.constant 0 : i64
+  %minimum_row = scalar.constant 0 : i64
   %limit_i64 = scalar.constant 64 : i64
-  %nonnegative = scalar.cmpi sge, %row_i64, %zero_i64 : i64
+  %nonnegative = scalar.cmpi sge, %row_i64, %minimum_row : i64
   %below = scalar.cmpi slt, %row_i64, %limit_i64 : i64
   %guard = scalar.andi %nonnegative, %below : i1
-  %zero_i32 = scalar.constant 0 : i32
+  %stored_value = scalar.constant 0 : i32
   scf.if %guard {
-    view.store %zero_i32, %output_view[%row] : i32, view<64xi32, #dense>
+    view.store %stored_value, %output_view[%row] : i32, view<64xi32, #dense>
   }
   func.return
 }
@@ -259,16 +259,16 @@ func.def target(@target) @guarded_loaded_i64_index_address(%control: buffer, %ou
 // ----
 low.func.def target<x86.scalar.core>(@target) abi(object_function) @guarded_loaded_i64_index_address(%control_view: reg<x86.gpr64>, %output_view: reg<x86.gpr64>) asm {
   %row = mov.load.gpr64 %control_view {disp32 = 0}
-  %zero_i64 = mov.imm64 0
+  %minimum_row = mov.imm64 0
   %limit_i64 = mov.imm64 64
-  %nonnegative = cmp.sge.gpr64 %row, %zero_i64
+  %nonnegative = cmp.sge.gpr64 %row, %minimum_row
   %below = cmp.slt.gpr64 %row, %limit_i64
-  %zero_i32 = mov.imm32 0
+  %stored_value = mov.imm32 0
   %22 = copy %nonnegative : reg<x86.gpr32> -> reg<x86.gpr32>
   %guard = and.gpr32 %22, %below
   low.cond_br %guard, ^_bb1, ^_bb2 : reg<x86.gpr32>
 ^_bb1:
-  mov.store.indexed.gpr32 %zero_i32, %output_view, %row {disp32 = 0, scale = 4}
+  mov.store.indexed.gpr32 %stored_value, %output_view, %row {disp32 = 0, scale = 4}
   low.br ^_bb2
 ^_bb2:
   return
@@ -284,13 +284,13 @@ func.def target(@target) @guarded_loaded_i32_index_address(%control: buffer, %ou
   %output_view = buffer.view %output[%base] : buffer -> view<64xi32, #dense>
   %row_i32 = view.load %control_view[0] : view<1xi32, #dense> -> i32
   %row = index.cast %row_i32 : i32 to index
-  %zero_i32 = scalar.constant 0 : i32
+  %c0 = scalar.constant 0 : i32
   %limit_i32 = scalar.constant 64 : i32
-  %nonnegative = scalar.cmpi sge, %row_i32, %zero_i32 : i32
+  %nonnegative = scalar.cmpi sge, %row_i32, %c0 : i32
   %below = scalar.cmpi slt, %row_i32, %limit_i32 : i32
   %guard = scalar.andi %nonnegative, %below : i1
   scf.if %guard {
-    view.store %zero_i32, %output_view[%row] : i32, view<64xi32, #dense>
+    view.store %c0, %output_view[%row] : i32, view<64xi32, #dense>
   }
   func.return
 }
@@ -299,15 +299,15 @@ func.def target(@target) @guarded_loaded_i32_index_address(%control: buffer, %ou
 low.func.def target<x86.scalar.core>(@target) abi(object_function) @guarded_loaded_i32_index_address(%control_view: reg<x86.gpr64>, %output_view: reg<x86.gpr64>) asm {
   %row_i32 = mov.load.gpr32 %control_view {disp32 = 0}
   %row = movsxd.gpr64.gpr32 %row_i32
-  %zero_i32 = mov.imm32 0
+  %c0 = mov.imm32 0
   %limit_i32 = mov.imm32 64
-  %nonnegative = cmp.sge.gpr32 %row_i32, %zero_i32
+  %nonnegative = cmp.sge.gpr32 %row_i32, %c0
   %below = cmp.slt.gpr32 %row_i32, %limit_i32
   %21 = copy %nonnegative : reg<x86.gpr32> -> reg<x86.gpr32>
   %guard = and.gpr32 %21, %below
   low.cond_br %guard, ^_bb1, ^_bb2 : reg<x86.gpr32>
 ^_bb1:
-  mov.store.indexed.gpr32 %zero_i32, %output_view, %row {disp32 = 0, scale = 4}
+  mov.store.indexed.gpr32 %c0, %output_view, %row {disp32 = 0, scale = 4}
   low.br ^_bb2
 ^_bb2:
   return
@@ -334,12 +334,12 @@ low.func.def target<x86.scalar.core>(@target) abi(object_function) @nonnegative_
 x86.target<scalar> @target
 
 func.def target(@target) @i32_source_index_static_suffix(%input: buffer, %output: buffer, %i: index) {
-  %zero = index.constant 0 : offset
-  %four = index.constant 4 : index
-  %element_index = index.add %i, %four : index
+  %buffer_base = index.constant 0 : offset
+  %element_suffix = index.constant 4 : index
+  %element_index = index.add %i, %element_suffix : index
   %bounded_index = index.assume %element_index [range(%element_index, 0, 31)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = view.load %input_view[%bounded_index] : view<64xi32, #dense> -> i32
   view.store %loaded, %output_view[%bounded_index] : i32, view<64xi32, #dense>
   func.return
@@ -357,12 +357,12 @@ low.func.def target<x86.scalar.core>(@target) abi(object_function) @i32_source_i
 x86.target<avx2> @target
 
 func.def target(@target) @f32x4_source_index_static_suffix(%input: buffer, %output: buffer, %i: index) {
-  %zero = index.constant 0 : offset
-  %four = index.constant 4 : index
-  %element_index = index.add %i, %four : index
+  %buffer_base = index.constant 0 : offset
+  %element_suffix = index.constant 4 : index
+  %element_index = index.add %i, %element_suffix : index
   %bounded_index = index.assume %element_index [range(%element_index, 0, 31)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %loaded = vector.load %input_view[%bounded_index] : view<64xf32, #dense> -> vector<4xf32>
   vector.store %loaded, %output_view[%bounded_index] : vector<4xf32>, view<64xf32, #dense>
   func.return
@@ -380,12 +380,12 @@ low.func.def target<x86.avx2.core>(@target) abi(object_function) @f32x4_source_i
 x86.target<avx512> @target
 
 func.def target(@target) @f32x16_source_index_static_suffix(%input: buffer, %output: buffer, %i: index) {
-  %zero = index.constant 0 : offset
-  %four = index.constant 4 : index
-  %element_index = index.add %i, %four : index
+  %buffer_base = index.constant 0 : offset
+  %element_suffix = index.constant 4 : index
+  %element_index = index.add %i, %element_suffix : index
   %bounded_index = index.assume %element_index [range(%element_index, 0, 31)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %loaded = vector.load %input_view[%bounded_index] : view<64xf32, #dense> -> vector<16xf32>
   vector.store %loaded, %output_view[%bounded_index] : vector<16xf32>, view<64xf32, #dense>
   func.return
@@ -403,13 +403,13 @@ low.func.def target<x86.avx512.core>(@target) abi(object_function) @f32x16_sourc
 x86.target<scalar> @target
 
 func.def target(@target) @i32_multi_term_static_suffix(%input: buffer, %output: buffer, %i: index, %j: index) {
-  %zero = index.constant 0 : offset
-  %four = index.constant 4 : index
+  %buffer_base = index.constant 0 : offset
+  %element_suffix = index.constant 4 : index
   %linear = index.add %i, %j : index
-  %element_index = index.add %linear, %four : index
+  %element_index = index.add %linear, %element_suffix : index
   %bounded_index = index.assume %element_index [range(%element_index, 0, 31)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = view.load %input_view[%bounded_index] : view<64xi32, #dense> -> i32
   view.store %loaded, %output_view[%bounded_index] : i32, view<64xi32, #dense>
   func.return
@@ -440,13 +440,13 @@ low.func.def target<x86.scalar.core>(@target) abi(object_function) @i32_multi_te
 x86.target<avx2> @target
 
 func.def target(@target) @f32x4_multi_term_static_suffix(%input: buffer, %output: buffer, %i: index, %j: index) {
-  %zero = index.constant 0 : offset
-  %four = index.constant 4 : index
+  %buffer_base = index.constant 0 : offset
+  %element_suffix = index.constant 4 : index
   %linear = index.add %i, %j : index
-  %element_index = index.add %linear, %four : index
+  %element_index = index.add %linear, %element_suffix : index
   %bounded_index = index.assume %element_index [range(%element_index, 0, 31)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %loaded = vector.load %input_view[%bounded_index] : view<64xf32, #dense> -> vector<4xf32>
   vector.store %loaded, %output_view[%bounded_index] : vector<4xf32>, view<64xf32, #dense>
   func.return
@@ -477,13 +477,13 @@ low.func.def target<x86.avx2.core>(@target) abi(object_function) @f32x4_multi_te
 x86.target<avx512> @target
 
 func.def target(@target) @f32x16_multi_term_static_suffix(%input: buffer, %output: buffer, %i: index, %j: index) {
-  %zero = index.constant 0 : offset
-  %four = index.constant 4 : index
+  %buffer_base = index.constant 0 : offset
+  %element_suffix = index.constant 4 : index
   %linear = index.add %i, %j : index
-  %element_index = index.add %linear, %four : index
+  %element_index = index.add %linear, %element_suffix : index
   %bounded_index = index.assume %element_index [range(%element_index, 0, 31)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %loaded = vector.load %input_view[%bounded_index] : view<64xf32, #dense> -> vector<16xf32>
   vector.store %loaded, %output_view[%bounded_index] : vector<16xf32>, view<64xf32, #dense>
   func.return

--- a/loom/src/loom/target/arch/x86/test/source_low/source_low_scalar_i64.loom-test
+++ b/loom/src/loom/target/arch/x86/test/source_low/source_low_scalar_i64.loom-test
@@ -155,10 +155,10 @@ low.func.def target<x86.scalar.core>(@target) abi(object_function) @scalar_i64_s
 x86.target<scalar> @target
 
 func.def target(@target) @scalar_i64_dynamic_memory(%input: buffer, %output: buffer, %i: index) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bounded_i = index.assume %i [range(%i, 0, 7)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<8xi64, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<8xi64, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<8xi64, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<8xi64, #dense>
   %loaded = view.load %input_view[%bounded_i] : view<8xi64, #dense> -> i64
   %incremented = scalar.addi %loaded, %loaded : i64
   view.store %incremented, %output_view[%bounded_i] : i64, view<8xi64, #dense>

--- a/loom/src/loom/target/arch/x86/test/source_low/source_low_scalar_memory.loom-test
+++ b/loom/src/loom/target/arch/x86/test/source_low/source_low_scalar_memory.loom-test
@@ -24,10 +24,10 @@ low.func.def target<x86.scalar.core>(@target) abi(object_function) @scalar_i32_s
 x86.target<scalar> @target
 
 func.def target(@target) @scalar_i32_dynamic_memory(%input: buffer, %output: buffer, %i: index) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bounded_i = index.assume %i [range(%i, 0, 7)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<8xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<8xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<8xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<8xi32, #dense>
   %loaded = view.load %input_view[%bounded_i] : view<8xi32, #dense> -> i32
   %incremented = scalar.addi %loaded, %loaded : i32
   view.store %incremented, %output_view[%bounded_i] : i32, view<8xi32, #dense>

--- a/loom/src/loom/target/arch/x86/test/source_low/source_low_v4.loom-test
+++ b/loom/src/loom/target/arch/x86/test/source_low/source_low_v4.loom-test
@@ -211,9 +211,9 @@ low.func.def target<x86.avx512.core>(@target) abi(object_function) @f32x4_select
 
 x86.target<avx512> @target
 func.def target(@target) @i32x4_memory_copy(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[0] : vector<4xi32>, view<4xi32, #dense>
   func.return
@@ -231,9 +231,9 @@ low.func.def target<x86.avx512.core>(@target) abi(object_function) @i32x4_memory
 x86.target<avx512> @target
 func.def target(@target) @i32x4_memory_indexed(%input: buffer, %output: buffer, %i: index) {
   %bounded_i = index.assume %i [range(%i, 0, 12)] : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%bounded_i] : view<16xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[%bounded_i] : vector<4xi32>, view<16xi32, #dense>
   func.return
@@ -250,9 +250,9 @@ low.func.def target<x86.avx512.core>(@target) abi(object_function) @i32x4_memory
 
 x86.target<avx512> @target
 func.def target(@target) @f32x4_memory_copy(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xf32, #dense>
   %loaded = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   vector.store %loaded, %output_view[0] : vector<4xf32>, view<4xf32, #dense>
   func.return
@@ -270,10 +270,10 @@ low.func.def target<x86.avx512.core>(@target) abi(object_function) @f32x4_memory
 x86.target<avx512> @target
 func.def target(@target) @f32x4_memory_indexed_add(%lhs: buffer, %rhs: buffer, %output: buffer, %i: index) {
   %bounded_i = index.assume %i [range(%i, 0, 12)] : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs[%zero] : buffer -> view<16xf32, #dense>
-  %rhs_view = buffer.view %rhs[%zero] : buffer -> view<16xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs[%buffer_base] : buffer -> view<16xf32, #dense>
+  %rhs_view = buffer.view %rhs[%buffer_base] : buffer -> view<16xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xf32, #dense>
   %lhs_v = vector.load %lhs_view[%bounded_i] : view<16xf32, #dense> -> vector<4xf32>
   %rhs_v = vector.load %rhs_view[%bounded_i] : view<16xf32, #dense> -> vector<4xf32>
   %sum = vector.addf %lhs_v, %rhs_v : vector<4xf32>

--- a/loom/src/loom/target/emit/native/amdgpu/packet_plan_attention_bf16.loom
+++ b/loom/src/loom/target/emit/native/amdgpu/packet_plan_attention_bf16.loom
@@ -3,11 +3,11 @@ amdgpu.target<gfx1250> @gfx1250
 
 kernel.def target(@gfx1250) export("planner_attention_bf16") @planner_attention_bf16() {
   %unit = index.constant 1 : index
-  %sixteen = index.constant 16 : index
+  %query_tile_extent = index.constant 16 : index
   %workgroup_size_x = index.constant 32 : index
   %query_block_token_count = index.constant 4096 : index
   %attention_head_count = index.constant 18 : index
-  %query_tile_count = index.div %query_block_token_count, %sixteen : index
+  %query_tile_count = index.div %query_block_token_count, %query_tile_extent : index
   kernel.launch.config workgroups(%query_tile_count, %attention_head_count, %unit) workgroup_size(%workgroup_size_x, %unit, %unit) : index
 } launch(%query: buffer, %key: buffer, %value: buffer, %output: buffer) {
   %query_tile = kernel.workgroup.id<x> : index
@@ -21,21 +21,20 @@ func.template<benchmark.attention_bf16.m16n16> target(@gfx1250) priority(20) @pl
   %k_step_gfx1250 = index.constant 32 : index
   %base = index.constant 0 : offset
   %probability_scratch_bytes = index.constant 512 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %eight = index.constant 8 : index
-  %fifteen = index.constant 15 : index
-  %sixteen = index.constant 16 : index
-  %thirty_two = index.constant 32 : index
-  %forty_eight = index.constant 48 : index
-  %sixty_four = index.constant 64 : index
-  %eighty = index.constant 80 : index
-  %ninety_six = index.constant 96 : index
-  %one_twelve = index.constant 112 : index
-  %one_twenty_eight = index.constant 128 : index
-  %lane_column = index.rem %lane, %sixteen : index
-  %lane_group = index.div %lane, %sixteen : index
-  %lane_group_even = index.cmp eq, %lane_group, %zero : index
+  %c0 = index.constant 0 : index
+  %tile_step = index.constant 1 : index
+  %tile_rounding_bias = index.constant 15 : index
+  %tile_extent = index.constant 16 : index
+  %channel_offset2 = index.constant 32 : index
+  %channel_offset3 = index.constant 48 : index
+  %channel_offset4 = index.constant 64 : index
+  %channel_offset5 = index.constant 80 : index
+  %channel_offset6 = index.constant 96 : index
+  %channel_offset7 = index.constant 112 : index
+  %channel_offset8 = index.constant 128 : index
+  %lane_column = index.rem %lane, %tile_extent : index
+  %lane_group = index.div %lane, %tile_extent : index
+  %lane_group_even = index.cmp eq, %lane_group, %c0 : index
   %valid_token_count = index.constant 4096 : index
   %padded_token_count = index.constant 4096 : index
   %query_block_offset = index.constant 0 : index
@@ -44,16 +43,16 @@ func.template<benchmark.attention_bf16.m16n16> target(@gfx1250) priority(20) @pl
   %head_pair_tile_count = index.div %head_size, %k_step_gfx1250 : index
   %hidden_size = index.mul %attention_head_count, %head_size : index
   %head_base = index.mul %query_head, %head_size : index
-  %value_base = index.add %head_base, %zero : index
-  %local_query_origin = index.mul %query_tile, %sixteen : index
+  %value_base = index.add %head_base, %c0 : index
+  %local_query_origin = index.mul %query_tile, %tile_extent : index
   %query_origin = index.add %query_block_offset, %local_query_origin : index
-  %valid_token_count_rounded = index.add %valid_token_count, %fifteen : index
-  %key_tile_count = index.div %valid_token_count_rounded, %sixteen : index
-  %zero_f32 = scalar.constant 0.0 : f32
+  %valid_token_count_rounded = index.add %valid_token_count, %tile_rounding_bias : index
+  %key_tile_count = index.div %valid_token_count_rounded, %tile_extent : index
+  %additive_identity = scalar.constant 0.0 : f32
   %negative_large = scalar.constant -1000000000.0 : f32
   %zero_acc = vector.constant 0.0 : vector<8xf32>
   %zero_operand = vector.constant 0.0 : vector<16xbf16>
-  %zero_vector = vector.splat %zero_f32 : vector<8xf32>
+  %zero_vector = vector.splat %additive_identity : vector<8xf32>
   %negative_vector = vector.splat %negative_large : vector<8xf32>
   %head_size_i32 = index.cast %head_size : index to i32
   %head_size_f32 = scalar.sitofp %head_size_i32 : i32 to f32
@@ -78,13 +77,13 @@ func.template<benchmark.attention_bf16.m16n16> target(@gfx1250) priority(20) @pl
   %probability_scratch = buffer.alloca %probability_scratch_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %probability_scratch_view = buffer.view %probability_scratch[%base] : buffer -> view<16x16xbf16, #dense>
   %init = vector.fragment<init> %zero_acc shape [%m, %n] : vector<8xf32>
-  %final_max_even, %final_sum_even, %final_max_odd, %final_sum_odd, %final_acc0, %final_acc1, %final_acc2, %final_acc3, %final_acc4, %final_acc5, %final_acc6, %final_acc7, %final_acc8, %final_acc9, %final_acc10, %final_acc11, %final_acc12, %final_acc13, %final_acc14, %final_acc15 = scf.for %key_tile = [%zero to %key_tile_count step %one](%current_max_even = %negative_vector : vector<8xf32>, %current_sum_even = %zero_vector : vector<8xf32>, %current_max_odd = %negative_vector : vector<8xf32>, %current_sum_odd = %zero_vector : vector<8xf32>, %current_acc0 = %init : vector<8xf32>, %current_acc1 = %init : vector<8xf32>, %current_acc2 = %init : vector<8xf32>, %current_acc3 = %init : vector<8xf32>, %current_acc4 = %init : vector<8xf32>, %current_acc5 = %init : vector<8xf32>, %current_acc6 = %init : vector<8xf32>, %current_acc7 = %init : vector<8xf32>, %current_acc8 = %init : vector<8xf32>, %current_acc9 = %init : vector<8xf32>, %current_acc10 = %init : vector<8xf32>, %current_acc11 = %init : vector<8xf32>, %current_acc12 = %init : vector<8xf32>, %current_acc13 = %init : vector<8xf32>, %current_acc14 = %init : vector<8xf32>, %current_acc15 = %init : vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
-    %key_origin = index.mul %key_tile, %sixteen : index
+  %final_max_even, %final_sum_even, %final_max_odd, %final_sum_odd, %final_acc0, %final_acc1, %final_acc2, %final_acc3, %final_acc4, %final_acc5, %final_acc6, %final_acc7, %final_acc8, %final_acc9, %final_acc10, %final_acc11, %final_acc12, %final_acc13, %final_acc14, %final_acc15 = scf.for %key_tile = [%c0 to %key_tile_count step %tile_step](%current_max_even = %negative_vector : vector<8xf32>, %current_sum_even = %zero_vector : vector<8xf32>, %current_max_odd = %negative_vector : vector<8xf32>, %current_sum_odd = %zero_vector : vector<8xf32>, %current_acc0 = %init : vector<8xf32>, %current_acc1 = %init : vector<8xf32>, %current_acc2 = %init : vector<8xf32>, %current_acc3 = %init : vector<8xf32>, %current_acc4 = %init : vector<8xf32>, %current_acc5 = %init : vector<8xf32>, %current_acc6 = %init : vector<8xf32>, %current_acc7 = %init : vector<8xf32>, %current_acc8 = %init : vector<8xf32>, %current_acc9 = %init : vector<8xf32>, %current_acc10 = %init : vector<8xf32>, %current_acc11 = %init : vector<8xf32>, %current_acc12 = %init : vector<8xf32>, %current_acc13 = %init : vector<8xf32>, %current_acc14 = %init : vector<8xf32>, %current_acc15 = %init : vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
+    %key_origin = index.mul %key_tile, %tile_extent : index
     %key_token = index.add %key_origin, %lane_column : index
     %key_valid = index.cmp ult, %key_token, %valid_token_count : index
     %lane_query_token = index.add %query_origin, %lane_column : index
-    %lane_head_offset = index.mul %lane_group, %sixteen : index
-    %raw_scores = scf.for %head_pair_tile = [%zero to %head_pair_tile_count step %one](%qk_acc = %init : vector<8xf32>) -> (vector<8xf32>) {
+    %lane_head_offset = index.mul %lane_group, %tile_extent : index
+    %raw_scores = scf.for %head_pair_tile = [%c0 to %head_pair_tile_count step %tile_step](%qk_acc = %init : vector<8xf32>) -> (vector<8xf32>) {
       %head_pair_offset = index.mul %head_pair_tile, %k_step_gfx1250 : index
       %lane_head_origin = index.add %head_pair_offset, %lane_head_offset : index
       %query_channel = index.add %head_base, %lane_head_origin : index
@@ -152,31 +151,31 @@ func.template<benchmark.attention_bf16.m16n16> target(@gfx1250) priority(20) @pl
     } else {
       scf.yield %old_scale_odd : vector<8xf32>
     }
-    vector.fragment.store<result> %weight, %probability_scratch_view[%zero, %zero] shape [%m, %n] : vector<8xf32>, view<16x16xbf16, #dense>
+    vector.fragment.store<result> %weight, %probability_scratch_view[%c0, %c0] shape [%m, %n] : vector<8xf32>, view<16x16xbf16, #dense>
     kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
     %probability_values = scf.if %lane_group_even -> (vector<16xbf16>) {
-      %loaded_probability = vector.load %probability_scratch_view[%lane_column, %zero] : view<16x16xbf16, #dense> -> vector<16xbf16>
+      %loaded_probability = vector.load %probability_scratch_view[%lane_column, %c0] : view<16x16xbf16, #dense> -> vector<16xbf16>
       scf.yield %loaded_probability : vector<16xbf16>
     } else {
       scf.yield %zero_operand : vector<16xbf16>
     }
     %probability_lhs = vector.fragment<lhs> %probability_values shape [%m, %k] : vector<16xbf16>
-    %channel0 = index.add %value_base, %zero : index
-    %channel1 = index.add %value_base, %sixteen : index
-    %channel2 = index.add %value_base, %thirty_two : index
-    %channel3 = index.add %value_base, %forty_eight : index
-    %channel4 = index.add %value_base, %sixty_four : index
-    %channel5 = index.add %value_base, %eighty : index
-    %channel6 = index.add %value_base, %ninety_six : index
-    %channel7 = index.add %value_base, %one_twelve : index
-    %channel8 = index.add %value_base, %one_twenty_eight : index
-    %channel9 = index.add %channel8, %sixteen : index
-    %channel10 = index.add %channel9, %sixteen : index
-    %channel11 = index.add %channel10, %sixteen : index
-    %channel12 = index.add %channel11, %sixteen : index
-    %channel13 = index.add %channel12, %sixteen : index
-    %channel14 = index.add %channel13, %sixteen : index
-    %channel15 = index.add %channel14, %sixteen : index
+    %channel0 = index.add %value_base, %c0 : index
+    %channel1 = index.add %value_base, %tile_extent : index
+    %channel2 = index.add %value_base, %channel_offset2 : index
+    %channel3 = index.add %value_base, %channel_offset3 : index
+    %channel4 = index.add %value_base, %channel_offset4 : index
+    %channel5 = index.add %value_base, %channel_offset5 : index
+    %channel6 = index.add %value_base, %channel_offset6 : index
+    %channel7 = index.add %value_base, %channel_offset7 : index
+    %channel8 = index.add %value_base, %channel_offset8 : index
+    %channel9 = index.add %channel8, %tile_extent : index
+    %channel10 = index.add %channel9, %tile_extent : index
+    %channel11 = index.add %channel10, %tile_extent : index
+    %channel12 = index.add %channel11, %tile_extent : index
+    %channel13 = index.add %channel12, %tile_extent : index
+    %channel14 = index.add %channel13, %tile_extent : index
+    %channel15 = index.add %channel14, %tile_extent : index
     %lane_channel0 = index.add %channel0, %lane_column : index
     %lane_channel1 = index.add %channel1, %lane_column : index
     %lane_channel2 = index.add %channel2, %lane_column : index
@@ -302,22 +301,22 @@ func.template<benchmark.attention_bf16.m16n16> target(@gfx1250) priority(20) @pl
   %output13 = vector.divf<nnan|ninf|nsz|arcp> %final_acc13, %selected_final_sum : vector<8xf32>
   %output14 = vector.divf<nnan|ninf|nsz|arcp> %final_acc14, %selected_final_sum : vector<8xf32>
   %output15 = vector.divf<nnan|ninf|nsz|arcp> %final_acc15, %selected_final_sum : vector<8xf32>
-  %channel0 = index.add %value_base, %zero : index
-  %channel1 = index.add %value_base, %sixteen : index
-  %channel2 = index.add %value_base, %thirty_two : index
-  %channel3 = index.add %value_base, %forty_eight : index
-  %channel4 = index.add %value_base, %sixty_four : index
-  %channel5 = index.add %value_base, %eighty : index
-  %channel6 = index.add %value_base, %ninety_six : index
-  %channel7 = index.add %value_base, %one_twelve : index
-  %channel8 = index.add %value_base, %one_twenty_eight : index
-  %channel9 = index.add %channel8, %sixteen : index
-  %channel10 = index.add %channel9, %sixteen : index
-  %channel11 = index.add %channel10, %sixteen : index
-  %channel12 = index.add %channel11, %sixteen : index
-  %channel13 = index.add %channel12, %sixteen : index
-  %channel14 = index.add %channel13, %sixteen : index
-  %channel15 = index.add %channel14, %sixteen : index
+  %channel0 = index.add %value_base, %c0 : index
+  %channel1 = index.add %value_base, %tile_extent : index
+  %channel2 = index.add %value_base, %channel_offset2 : index
+  %channel3 = index.add %value_base, %channel_offset3 : index
+  %channel4 = index.add %value_base, %channel_offset4 : index
+  %channel5 = index.add %value_base, %channel_offset5 : index
+  %channel6 = index.add %value_base, %channel_offset6 : index
+  %channel7 = index.add %value_base, %channel_offset7 : index
+  %channel8 = index.add %value_base, %channel_offset8 : index
+  %channel9 = index.add %channel8, %tile_extent : index
+  %channel10 = index.add %channel9, %tile_extent : index
+  %channel11 = index.add %channel10, %tile_extent : index
+  %channel12 = index.add %channel11, %tile_extent : index
+  %channel13 = index.add %channel12, %tile_extent : index
+  %channel14 = index.add %channel13, %tile_extent : index
+  %channel15 = index.add %channel14, %tile_extent : index
   vector.fragment.store<result> %output0, %output_view[%query_origin, %channel0] shape [%m, %n] : vector<8xf32>, view<[%padded_token_count]x[%hidden_size]xbf16, #dense>
   vector.fragment.store<result> %output1, %output_view[%query_origin, %channel1] shape [%m, %n] : vector<8xf32>, view<[%padded_token_count]x[%hidden_size]xbf16, #dense>
   vector.fragment.store<result> %output2, %output_view[%query_origin, %channel2] shape [%m, %n] : vector<8xf32>, view<[%padded_token_count]x[%hidden_size]xbf16, #dense>

--- a/loom/src/loom/target/emit/spirv/test/memory_scalar_addressing.loom-test
+++ b/loom/src/loom/target/emit/spirv/test/memory_scalar_addressing.loom-test
@@ -79,11 +79,11 @@ func.def target(@target) @scalar_static_rank2_i32(%input: buffer, %output: buffe
 spirv.target<vulkan1_3> @target
 func.def target(@target) @scalar_dynamic_view_base_i32(%input: buffer, %output: buffer, %base: offset) -> (i32) {
   %base_aligned = index.assume %base [range(%base, 0, 4092), mul(%base, 4)] : offset
-  %zero = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
   %input_view = buffer.view %input_aligned[%base_aligned] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output_aligned[%zero] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output_aligned[%output_base] : buffer -> view<1xi32, #dense>
   %loaded = view.load %input_view[2] : view<4xi32, #dense> -> i32
   view.store %loaded, %output_view[0] : i32, view<1xi32, #dense>
   func.return %loaded : i32
@@ -246,12 +246,12 @@ func.def target(@target) @scalar_materialized_view_base_suffix_i32(%input: buffe
 
 spirv.target<vulkan1_3> @target
 func.def target(@target) @scalar_dynamic_index_i32(%input: buffer, %output: buffer, %element: index) -> (i32) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %element_bounded = index.assume %element [range(%element, 0, 7)] : index
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
-  %input_view = buffer.view %input_aligned[%zero] : buffer -> view<8xi32, #dense>
-  %output_view = buffer.view %output_aligned[%zero] : buffer -> view<8xi32, #dense>
+  %input_view = buffer.view %input_aligned[%buffer_base] : buffer -> view<8xi32, #dense>
+  %output_view = buffer.view %output_aligned[%buffer_base] : buffer -> view<8xi32, #dense>
   %loaded = view.load %input_view[%element_bounded] : view<8xi32, #dense> -> i32
   view.store %loaded, %output_view[%element_bounded] : i32, view<8xi32, #dense>
   func.return %loaded : i32
@@ -431,14 +431,14 @@ func.def target(@target) @scalar_mixed_rank2_i32(%input: buffer, %output: buffer
 
 spirv.target<vulkan1_3> @target
 func.def target(@target) @scalar_dynamic_stride_i32(%input: buffer, %output: buffer, %columns: index, %row: index, %column: index) -> (i32) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %columns_bounded = index.assume %columns [range(%columns, 1, 8)] : index
   %row_bounded = index.assume %row [range(%row, 0, 3)] : index
   %column_bounded = index.assume %column [range(%column, 0, 7), lt(%column, %columns_bounded)] : index
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
-  %input_view = buffer.view %input_aligned[%zero] : buffer -> view<4x[%columns_bounded]xi32, #dense>
-  %output_view = buffer.view %output_aligned[%zero] : buffer -> view<4x[%columns_bounded]xi32, #dense>
+  %input_view = buffer.view %input_aligned[%buffer_base] : buffer -> view<4x[%columns_bounded]xi32, #dense>
+  %output_view = buffer.view %output_aligned[%buffer_base] : buffer -> view<4x[%columns_bounded]xi32, #dense>
   %loaded = view.load %input_view[%row_bounded, %column_bounded] : view<4x[%columns_bounded]xi32, #dense> -> i32
   view.store %loaded, %output_view[%row_bounded, %column_bounded] : i32, view<4x[%columns_bounded]xi32, #dense>
   func.return %loaded : i32

--- a/loom/src/loom/target/emit/spirv/test/memory_workgroup_scalar_addressing.loom-test
+++ b/loom/src/loom/target/emit/spirv/test/memory_workgroup_scalar_addressing.loom-test
@@ -177,12 +177,12 @@ func.def target(@target) @workgroup_dynamic_base_and_index_i32(%value: i32, %bas
 spirv.target<vulkan1_3> @target {contract_feature_bits = 37374}
 func.def target(@target) @workgroup_dynamic_stride_rank2_i32(%value: i32, %column_count: index, %row: index, %column: index) -> (i32) {
   %byte_length = index.constant 128 : offset
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %column_count_bounded = index.assume %column_count [range(%column_count, 1, 8)] : index
   %row_bounded = index.assume %row [range(%row, 0, 3)] : index
   %column_bounded = index.assume %column [range(%column, 0, 7), lt(%column, %column_count_bounded)] : index
   %scratch = buffer.alloca %byte_length {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<4x[%column_count_bounded]xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<4x[%column_count_bounded]xi32, #dense>
   view.store %value, %scratch_view[%row_bounded, %column_bounded] : i32, view<4x[%column_count_bounded]xi32, #dense>
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   %loaded = view.load %scratch_view[%row_bounded, %column_bounded] : view<4x[%column_count_bounded]xi32, #dense> -> i32
@@ -367,15 +367,15 @@ func.def target(@target) @workgroup_subview_refine_i32(%value: i32, %element: in
 spirv.target<vulkan1_3> @target {contract_feature_bits = 37374}
 func.def target(@target) @workgroup_integer_scalar_widths(%value_i8: i8, %value_i16: i16, %value_i32: i32, %value_i64: i64) -> (i8, i16, i32, i64) {
   %byte_length = index.constant 16 : offset
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %scratch_i8 = buffer.alloca %byte_length {base_alignment = 1, memory_space = workgroup} : buffer
   %scratch_i16 = buffer.alloca %byte_length {base_alignment = 2, memory_space = workgroup} : buffer
   %scratch_i32 = buffer.alloca %byte_length {base_alignment = 4, memory_space = workgroup} : buffer
   %scratch_i64 = buffer.alloca %byte_length {base_alignment = 8, memory_space = workgroup} : buffer
-  %view_i8 = buffer.view %scratch_i8[%zero] : buffer -> view<2xi8, #dense>
-  %view_i16 = buffer.view %scratch_i16[%zero] : buffer -> view<2xi16, #dense>
-  %view_i32 = buffer.view %scratch_i32[%zero] : buffer -> view<2xi32, #dense>
-  %view_i64 = buffer.view %scratch_i64[%zero] : buffer -> view<2xi64, #dense>
+  %view_i8 = buffer.view %scratch_i8[%scratch_base] : buffer -> view<2xi8, #dense>
+  %view_i16 = buffer.view %scratch_i16[%scratch_base] : buffer -> view<2xi16, #dense>
+  %view_i32 = buffer.view %scratch_i32[%scratch_base] : buffer -> view<2xi32, #dense>
+  %view_i64 = buffer.view %scratch_i64[%scratch_base] : buffer -> view<2xi64, #dense>
   view.store %value_i8, %view_i8[1] : i8, view<2xi8, #dense>
   view.store %value_i16, %view_i16[1] : i16, view<2xi16, #dense>
   view.store %value_i32, %view_i32[1] : i32, view<2xi32, #dense>
@@ -543,15 +543,15 @@ func.def target(@target) @workgroup_integer_scalar_widths(%value_i8: i8, %value_
 spirv.target<vulkan1_3> @target {contract_feature_bits = 37374}
 func.def target(@target) @workgroup_float_scalar_widths(%value_f16: f16, %value_bf16: bf16, %value_f32: f32, %value_f64: f64) -> (f16, bf16, f32, f64) {
   %byte_length = index.constant 16 : offset
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %scratch_f16 = buffer.alloca %byte_length {base_alignment = 2, memory_space = workgroup} : buffer
   %scratch_bf16 = buffer.alloca %byte_length {base_alignment = 2, memory_space = workgroup} : buffer
   %scratch_f32 = buffer.alloca %byte_length {base_alignment = 4, memory_space = workgroup} : buffer
   %scratch_f64 = buffer.alloca %byte_length {base_alignment = 8, memory_space = workgroup} : buffer
-  %view_f16 = buffer.view %scratch_f16[%zero] : buffer -> view<2xf16, #dense>
-  %view_bf16 = buffer.view %scratch_bf16[%zero] : buffer -> view<2xbf16, #dense>
-  %view_f32 = buffer.view %scratch_f32[%zero] : buffer -> view<2xf32, #dense>
-  %view_f64 = buffer.view %scratch_f64[%zero] : buffer -> view<2xf64, #dense>
+  %view_f16 = buffer.view %scratch_f16[%scratch_base] : buffer -> view<2xf16, #dense>
+  %view_bf16 = buffer.view %scratch_bf16[%scratch_base] : buffer -> view<2xbf16, #dense>
+  %view_f32 = buffer.view %scratch_f32[%scratch_base] : buffer -> view<2xf32, #dense>
+  %view_f64 = buffer.view %scratch_f64[%scratch_base] : buffer -> view<2xf64, #dense>
   view.store %value_f16, %view_f16[1] : f16, view<2xf16, #dense>
   view.store %value_bf16, %view_bf16[1] : bf16, view<2xbf16, #dense>
   view.store %value_f32, %view_f32[1] : f32, view<2xf32, #dense>

--- a/loom/src/loom/test/corpus/authoring/README.md
+++ b/loom/src/loom/test/corpus/authoring/README.md
@@ -561,6 +561,12 @@ when 512 is the batch size, and `%c512` when the literal itself is the only
 meaning. Type suffixes disambiguate otherwise identical bare literals when
 needed, such as `%c0_i32` and `%c0_f32x4`.
 
+Type, shape, sign, and duplicate markers do not turn a literal into a role.
+Names such as `%i32_zero`, `%zero_scalar`, `%positive_zero`, `%zero_a`, and
+`%f16_ones` still read like declarations of the number itself. They use a
+semantic name when the use provides one, or the `%c<literal>` spelling when it
+does not.
+
 Literal equality does not imply semantic identity. Two constants whose value
 is 16 can remain separate as `%channels_per_group` and
 `%lane_partition_width`; merging them under `%c16` would discard information

--- a/loom/src/loom/test/corpus/authoring/README.md
+++ b/loom/src/loom/test/corpus/authoring/README.md
@@ -648,7 +648,9 @@ and to authored input sections in `.loom-test` files. Runner-owned expected
 sections remain generated test output; only `loom-check --update` changes them.
 The linter rejects English-spelled numeric constant names in favor of semantic
 roles or the `%c<literal>` convention, because agents copy examples before they
-read design notes.
+read design notes. Loom project hygiene runs this linter in normal precommit and
+CI flows, including root CI invocations that delegate project test suites to
+separate workflows.
 
 Additional authoring-corpus rules keep this reference surface aligned with the
 boundary contract. They reject redundant kernel-buffer memory-space assumes,

--- a/loom/src/loom/test/corpus/authoring/README.md
+++ b/loom/src/loom/test/corpus/authoring/README.md
@@ -554,6 +554,18 @@ sample values remain runtime inputs and do not alter the executable.
 
 ## Authoring Rules
 
+An SSA value name carries the value's program role. A constant named
+`%fivehundredtwelve` communicates no more than its literal and reads like
+`int fivehundredtwelve = 512;` in C. The authored spelling is `%batch_size`
+when 512 is the batch size, and `%c512` when the literal itself is the only
+meaning. Type suffixes disambiguate otherwise identical bare literals when
+needed, such as `%c0_i32` and `%c0_f32x4`.
+
+Literal equality does not imply semantic identity. Two constants whose value
+is 16 can remain separate as `%channels_per_group` and
+`%lane_partition_width`; merging them under `%c16` would discard information
+the source already has.
+
 `func.call` is an exact symbol reference. It is the right spelling when the
 caller wants one specific helper or declaration, as with
 `@q6_signed_pack_dot4i` and `@bf16_dot32`.
@@ -634,8 +646,9 @@ source hid storage materialization inside the matrix kernel.
 The authoring source linter keeps this reference surface aligned with those
 rules. It rejects redundant kernel-buffer memory-space assumes, sentinel-sized
 views, late `index.cast` byte-address conversions, and ggml-style `nb*` byte
-strides typed as `index`, because agents copy examples before they read design
-notes.
+strides typed as `index`. It also rejects English-spelled numeric constant
+names in favor of semantic roles or the `%c<literal>` convention, because
+agents copy examples before they read design notes.
 
 `check.case` owns correctness policy for a workload. It creates inputs, calls
 the unit under test, and states expectations. `check.benchmark<@case>` selects

--- a/loom/src/loom/test/corpus/authoring/README.md
+++ b/loom/src/loom/test/corpus/authoring/README.md
@@ -643,12 +643,17 @@ source hid storage materialization inside the matrix kernel.
 %weight_view = buffer.view %weight_buffer[%base] : buffer -> view<[%input_size]x[%output_size]xf8E4M3, %weight_storage>
 ```
 
-The authoring source linter keeps this reference surface aligned with those
-rules. It rejects redundant kernel-buffer memory-space assumes, sentinel-sized
-views, late `index.cast` byte-address conversions, and ggml-style `nb*` byte
-strides typed as `index`. It also rejects English-spelled numeric constant
-names in favor of semantic roles or the `%c<literal>` convention, because
-agents copy examples before they read design notes.
+The Loom source linter applies constant naming to every checked `.loom` file
+and to authored input sections in `.loom-test` files. Runner-owned expected
+sections remain generated test output; only `loom-check --update` changes them.
+The linter rejects English-spelled numeric constant names in favor of semantic
+roles or the `%c<literal>` convention, because agents copy examples before they
+read design notes.
+
+Additional authoring-corpus rules keep this reference surface aligned with the
+boundary contract. They reject redundant kernel-buffer memory-space assumes,
+sentinel-sized views, late `index.cast` byte-address conversions, and ggml-style
+`nb*` byte strides typed as `index`.
 
 `check.case` owns correctness policy for a workload. It creates inputs, calls
 the unit under test, and states expectations. `check.benchmark<@case>` selects

--- a/loom/src/loom/test/corpus/authoring/ffn_gate_up_swiglu_q6q8.loom
+++ b/loom/src/loom/test/corpus/authoring/ffn_gate_up_swiglu_q6q8.loom
@@ -1,15 +1,15 @@
 // q6_K stores low bits and sign/high-bit state separately. The q6/q8 dot path
 // calls this concrete sign-pack helper directly.
 func.def inline @q6_signed_pack_dot4i(%code: vector<1xi32>) -> (vector<4xi8>) {
-  %one_i32v = vector.constant 1 : vector<1xi32>
-  %two_i32v = vector.constant 2 : vector<1xi32>
+  %bit6_shift = vector.constant 1 : vector<1xi32>
+  %bit7_shift = vector.constant 2 : vector<1xi32>
   %low5_mask = vector.constant 522133279 : vector<1xi32>
   %bit5_mask = vector.constant 538976288 : vector<1xi32>
   %sign_mask = vector.constant -522133280 : vector<1xi32>
   %low5 = vector.andi %code, %low5_mask : vector<1xi32>
   %bit5 = vector.andi %code, %bit5_mask : vector<1xi32>
-  %bit6 = vector.shli %bit5, %one_i32v : vector<1xi32>
-  %bit7 = vector.shli %bit5, %two_i32v : vector<1xi32>
+  %bit6 = vector.shli %bit5, %bit6_shift : vector<1xi32>
+  %bit7 = vector.shli %bit5, %bit7_shift : vector<1xi32>
   %high01 = vector.ori %bit5, %bit6 : vector<1xi32>
   %high = vector.ori %high01, %bit7 : vector<1xi32>
   %sign = vector.xori %high, %sign_mask : vector<1xi32>
@@ -23,27 +23,28 @@ func.def inline @q6_signed_pack_dot4i(%code: vector<1xi32>) -> (vector<4xi8>) {
 // call: future libraries can offer different implementations of the same
 // packed accumulation contract without changing the model-shaped kernel body.
 func.template<model.q6q8.accumulate_part> device priority(10) @q6q8_accumulate_part(%acc: f32, %weight_i8: view<55695360xi8, #dense>, %weight_i16: view<27847680xi16, #dense>, %weight_f16: view<27847680xf16, #dense>, %q8_i32: view<31248xi32, #dense>, %q8_f16: view<62496xf16, #dense>, %row_i8_base: index, %row_i16_base: index, %q8_i32_row_base: index, %q8_f16_row_base: index, %block: index, %part: index, %lane: index, %vh_index: index, %vh_shift_i32: i32, %bq8_offset: index, %q8_qword: index, %scale_lane_base: index) -> (f32) {
-  %two = index.constant 2 : index
-  %four = index.constant 4 : index
-  %eight = index.constant 8 : index
-  %nine = index.constant 9 : index
-  %eighteen = index.constant 18 : index
+  %i16_elements_per_i32 = index.constant 2 : index
+  %q8_blocks_per_part = index.constant 2 : index
+  %part_shift_bits = index.constant 4 : index
+  %q8_blocks_per_q6_block = index.constant 8 : index
+  %q8_i32_values_per_block = index.constant 9 : index
+  %q8_f16_values_per_block = index.constant 18 : index
   %block_i16_stride = index.constant 105 : index
   %block_i8_stride = index.constant 210 : index
   %qh_add = index.constant 64 : index
   %d_add = index.constant 104 : index
   %scale_add = index.constant 192 : index
-  %zero_i32v = vector.constant 0 : vector<1xi32>
-  %four_i32v = vector.constant 4 : vector<1xi32>
+  %dot_initial = vector.constant 0 : vector<1xi32>
+  %q6_high_shift = vector.constant 4 : vector<1xi32>
   %nibble_mask = vector.constant 252645135 : vector<1xi32>
   %q6_high_mask = vector.constant 808464432 : vector<1xi32>
 
   %block_i16 = index.mul %block, %block_i16_stride : index
   %block_i8 = index.mul %block, %block_i8_stride : index
-  %lane_i16 = index.mul %lane, %two : index
+  %lane_i16 = index.mul %lane, %i16_elements_per_i32 : index
   %ql_row_index = index.add %block_i16, %lane_i16 : index
   %ql_index = index.add %row_i16_base, %ql_row_index : index
-  %vh_lane0 = index.mul %vh_index, %two : index
+  %vh_lane0 = index.mul %vh_index, %i16_elements_per_i32 : index
   %qh_base = index.add %block_i16, %qh_add : index
   %qh_row_index = index.add %qh_base, %vh_lane0 : index
   %qh_index = index.add %row_i16_base, %qh_row_index : index
@@ -56,7 +57,7 @@ func.template<model.q6q8.accumulate_part> device priority(10) @q6q8_accumulate_p
   %d_f16 = view.load %weight_f16[%d_index] : view<27847680xf16, #dense> -> f16
   %d = scalar.extf %d_f16 : f16 to f32
 
-  %part_shift_index = index.mul %part, %four : index
+  %part_shift_index = index.mul %part, %part_shift_bits : index
   %part_shift_i32 = index.cast %part_shift_index : index to i32
   %part_shift = vector.splat %part_shift_i32 : vector<1xi32>
   %vl = vector.shrui %vl_raw, %part_shift : vector<1xi32>
@@ -64,21 +65,21 @@ func.template<model.q6q8.accumulate_part> device priority(10) @q6q8_accumulate_p
   %vh_shift_part_i32 = scalar.addi %vh_shift_i32, %part_shift_i32 : i32
   %vh_shift = vector.splat %vh_shift_part_i32 : vector<1xi32>
   %vh0 = vector.shrui %vh, %vh_shift : vector<1xi32>
-  %vh1 = vector.shli %vh0, %four_i32v : vector<1xi32>
+  %vh1 = vector.shli %vh0, %q6_high_shift : vector<1xi32>
   %vih = vector.andi %vh1, %q6_high_mask : vector<1xi32>
   %code = vector.ori %vil, %vih : vector<1xi32>
   %signed = func.call @q6_signed_pack_dot4i(%code) : (vector<1xi32>) -> (vector<4xi8>)
 
-  %q8_block_base = index.mul %block, %eight : index
-  %q8_part_add = index.mul %part, %two : index
+  %q8_block_base = index.mul %block, %q8_blocks_per_q6_block : index
+  %q8_part_add = index.mul %part, %q8_blocks_per_part : index
   %q8_block_part = index.add %q8_block_base, %q8_part_add : index
   %q8_block = index.add %q8_block_part, %bq8_offset : index
-  %q8_i32_block = index.mul %q8_block, %nine : index
+  %q8_i32_block = index.mul %q8_block, %q8_i32_values_per_block : index
   %q8_i32_base = index.add %q8_i32_row_base, %q8_i32_block : index
   %q8_i32_index = index.add %q8_i32_base, %q8_qword : index
   %q8_word = vector.load %q8_i32[%q8_i32_index] : view<31248xi32, #dense> -> vector<1xi32>
   %q8 = vector.bitcast %q8_word : vector<1xi32> to vector<4xi8>
-  %dot = vector.dot4i<s8s8> %signed, %q8, %zero_i32v : vector<4xi8>, vector<4xi8>, vector<1xi32>
+  %dot = vector.dot4i<s8s8> %signed, %q8, %dot_initial : vector<4xi8>, vector<4xi8>, vector<1xi32>
   %dot_i32 = vector.extract %dot[0] : vector<1xi32> -> i32
   %dot_f32 = scalar.sitofp %dot_i32 : i32 to f32
 
@@ -88,7 +89,7 @@ func.template<model.q6q8.accumulate_part> device priority(10) @q6q8_accumulate_p
   %scale_index = index.add %row_i8_base, %scale_row_index : index
   %scale_i8 = view.load %weight_i8[%scale_index] : view<55695360xi8, #dense> -> i8
   %scale = scalar.sitofp %scale_i8 : i8 to f32
-  %q8_f16_block = index.mul %q8_block, %eighteen : index
+  %q8_f16_block = index.mul %q8_block, %q8_f16_values_per_block : index
   %q8_d_index = index.add %q8_f16_row_base, %q8_f16_block : index
   %q8_d_f16 = view.load %q8_f16[%q8_d_index] : view<62496xf16, #dense> -> f16
   %q8_d = scalar.extf %q8_d_f16 : f16 to f32
@@ -111,40 +112,43 @@ kernel.def @ffn_gate_up_swiglu_q6q8() {
   %channel_group = kernel.workgroup.id<y> : index
   %subgroup_id = kernel.subgroup.id : index
   %lane = kernel.subgroup.lane.id : index
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %four = index.constant 4 : index
-  %eight = index.constant 8 : index
-  %fourteen = index.constant 14 : index
-  %sixteen = index.constant 16 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %q8_qword_bias = index.constant 1 : index
+  %part_count = index.constant 2 : index
+  %high_bit_shift_stride = index.constant 2 : index
+  %lane_quad_width = index.constant 4 : index
+  %lane_octet_width = index.constant 8 : index
+  %q6_block_count = index.constant 14 : index
+  %channels_per_group = index.constant 16 : index
+  %lane_partition_width = index.constant 16 : index
   %q8_i32_row_stride = index.constant 1008 : index
   %q8_f16_row_stride = index.constant 2016 : index
   %weight_i8_row_stride = index.constant 2940 : index
   %weight_i16_row_stride = index.constant 1470 : index
-  %zero_f32 = scalar.constant 0.0 : f32
-  %zero_i32 = scalar.constant 0 : i32
-  %channel_base0 = index.mul %channel_group, %sixteen : index
+  %dot_initial = scalar.constant 0.0 : f32
+  %leader_lane_i32 = scalar.constant 0 : i32
+  %channel_base0 = index.mul %channel_group, %channels_per_group : index
   %channel0 = index.add %channel_base0, %subgroup_id : index
   %channel = index.assume %channel0 [range(%channel0, 0, 18943)] : index
   %q8_i32_row_base = index.mul %row, %q8_i32_row_stride : index
   %q8_f16_row_base = index.mul %row, %q8_f16_row_stride : index
-  %lane_mod8 = index.rem %lane, %eight : index
-  %lane_mod16 = index.rem %lane, %sixteen : index
-  %lane_div16 = index.div %lane, %sixteen : index
-  %lane_div8_in_16 = index.div %lane_mod16, %eight : index
-  %lane_div4_in_16 = index.div %lane_mod16, %four : index
-  %vh_hi_group = index.mul %lane_div16, %eight : index
+  %lane_mod8 = index.rem %lane, %lane_octet_width : index
+  %lane_mod16 = index.rem %lane, %lane_partition_width : index
+  %lane_div16 = index.div %lane, %lane_partition_width : index
+  %lane_div8_in_16 = index.div %lane_mod16, %lane_octet_width : index
+  %lane_div4_in_16 = index.div %lane_mod16, %lane_quad_width : index
+  %vh_hi_group = index.mul %lane_div16, %lane_octet_width : index
   %vh_index0 = index.add %vh_hi_group, %lane_mod8 : index
   %vh_index = index.assume %vh_index0 [range(%vh_index0, 0, 15)] : index
-  %vh_shift_index = index.mul %lane_div8_in_16, %two : index
+  %vh_shift_index = index.mul %lane_div8_in_16, %high_bit_shift_stride : index
   %vh_shift_i32 = index.cast %vh_shift_index : index to i32
-  %bq8_hi_group = index.mul %lane_div16, %four : index
+  %bq8_hi_group = index.mul %lane_div16, %lane_quad_width : index
   %bq8_offset0 = index.add %bq8_hi_group, %lane_div8_in_16 : index
   %bq8_offset = index.assume %bq8_offset0 [range(%bq8_offset0, 0, 5)] : index
-  %q8_qword0 = index.add %lane_mod8, %one : index
+  %q8_qword0 = index.add %lane_mod8, %q8_qword_bias : index
   %q8_qword = index.assume %q8_qword0 [range(%q8_qword0, 1, 8)] : index
-  %scale_hi_group = index.mul %lane_div16, %eight : index
+  %scale_hi_group = index.mul %lane_div16, %lane_octet_width : index
   %scale_lane_base0 = index.add %scale_hi_group, %lane_div4_in_16 : index
   %scale_lane_base = index.assume %scale_lane_base0 [range(%scale_lane_base0, 0, 11)] : index
 
@@ -166,8 +170,8 @@ kernel.def @ffn_gate_up_swiglu_q6q8() {
   // These loops are local transform intent, not source expansion. Full unroll is
   // requested where the q6_K block/part trip counts are tiny and compile-time
   // known, and the source still exposes the logical reduction structure.
-  %gate_acc, %up_acc = scf.for %block = [%zero to %fourteen step %one](%gate_block_acc = %zero_f32 : f32, %up_block_acc = %zero_f32 : f32) -> (f32, f32) unroll {
-    %gate_next, %up_next = scf.for %part = [%zero to %two step %one](%gate_part_acc = %gate_block_acc : f32, %up_part_acc = %up_block_acc : f32) -> (f32, f32) unroll {
+  %gate_acc, %up_acc = scf.for %block = [%loop_begin to %q6_block_count step %loop_step](%gate_block_acc = %dot_initial : f32, %up_block_acc = %dot_initial : f32) -> (f32, f32) unroll {
+    %gate_next, %up_next = scf.for %part = [%loop_begin to %part_count step %loop_step](%gate_part_acc = %gate_block_acc : f32, %up_part_acc = %up_block_acc : f32) -> (f32, f32) unroll {
       %gate_step = func.apply<model.q6q8.accumulate_part>(%gate_part_acc, %gate_i8_view, %gate_i16_view, %gate_f16_view, %q8_i32_view, %q8_f16_view, %gate_row_i8_base, %gate_row_i16_base, %q8_i32_row_base, %q8_f16_row_base, %block, %part, %lane, %vh_index, %vh_shift_i32, %bq8_offset, %q8_qword, %scale_lane_base) : (f32, view<55695360xi8, #dense>, view<27847680xi16, #dense>, view<27847680xf16, #dense>, view<31248xi32, #dense>, view<62496xf16, #dense>, index, index, index, index, index, index, index, index, i32, index, index, index) -> (f32)
       %up_step = func.apply<model.q6q8.accumulate_part>(%up_part_acc, %up_i8_view, %up_i16_view, %up_f16_view, %q8_i32_view, %q8_f16_view, %up_row_i8_base, %up_row_i16_base, %q8_i32_row_base, %q8_f16_row_base, %block, %part, %lane, %vh_index, %vh_shift_i32, %bq8_offset, %q8_qword, %scale_lane_base) : (f32, view<55695360xi8, #dense>, view<27847680xi16, #dense>, view<27847680xf16, #dense>, view<31248xi32, #dense>, view<62496xf16, #dense>, index, index, index, index, index, index, index, index, i32, index, index, index) -> (f32)
       scf.yield %gate_step, %up_step : f32, f32
@@ -178,7 +182,7 @@ kernel.def @ffn_gate_up_swiglu_q6q8() {
   %gate_dot = kernel.subgroup.reduce<addf> %gate_acc : f32
   %up_dot = kernel.subgroup.reduce<addf> %up_acc : f32
   %lane_i32 = index.cast %lane : index to i32
-  %is_lane0 = scalar.cmpi eq, %lane_i32, %zero_i32 : i32
+  %is_lane0 = scalar.cmpi eq, %lane_i32, %leader_lane_i32 : i32
   scf.if %is_lane0 {
     %gate_silu = scalar.siluf %gate_dot : f32
     %result = scalar.mulf<nnan|ninf|nsz> %gate_silu, %up_dot : f32

--- a/loom/src/loom/test/corpus/authoring/hip/cluster_b128_multicast.loom
+++ b/loom/src/loom/test/corpus/authoring/hip/cluster_b128_multicast.loom
@@ -10,31 +10,30 @@
 amdgpu.target<gfx1250> @gfx1250
 
 kernel.def target(@gfx1250) @cluster_b128_multicast() {
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %thirty_two = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %two, %one) workgroup_size(%thirty_two, %one, %one) cluster_size(%one, %two, %one) : index
+  %unit = index.constant 1 : index
+  %cluster_workgroups_y = index.constant 2 : index
+  %workgroup_size = index.constant 32 : index
+  kernel.launch.config workgroups(%unit, %cluster_workgroups_y, %unit) workgroup_size(%workgroup_size, %unit, %unit) cluster_size(%unit, %cluster_workgroups_y, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %sixteen = index.constant 16 : index
+  %lane_transfer_bytes = index.constant 16 : offset
   %scratch_bytes = index.constant 512 : offset
   %participants = scalar.constant 3 : i32
-  %zero_i32 = scalar.constant 0 : i32
-  %one_i32 = scalar.constant 1 : i32
-  %two_i32 = scalar.constant 2 : i32
-  %three_i32 = scalar.constant 3 : i32
-  %four_i32 = scalar.constant 4 : i32
+  %failure_value = scalar.constant 0 : i32
+  %success_value = scalar.constant 1 : i32
+  %first_word_ordinal = scalar.constant 1 : i32
+  %second_word_ordinal = scalar.constant 2 : i32
+  %third_word_ordinal = scalar.constant 3 : i32
+  %fourth_word_ordinal = scalar.constant 4 : i32
+  %words_per_lane = scalar.constant 4 : i32
 
   %lane = kernel.workitem.id<x> : index
   %workgroup_y = kernel.workgroup.id<y> : index
-  %lane_byte_index = index.mul %lane, %sixteen : index
-  %lane_byte_offset = index.cast %lane_byte_index : index to offset
+  %lane_byte_offset = index.scale %lane, %lane_transfer_bytes : index, offset -> offset
 
   %input_noalias, %output_noalias = buffer.assume.noalias %input, %output : buffer, buffer
-  %input_global = buffer.assume.memory_space<global> %input_noalias : buffer
-  %output_global = buffer.assume.memory_space<global> %output_noalias : buffer
-  %source = buffer.view %input_global[%lane_byte_offset] : buffer -> view<16xi8, #dense>
-  %output_view = buffer.view %output_global[%base] : buffer -> view<2x32xi32, #dense>
+  %source = buffer.view %input_noalias[%lane_byte_offset] : buffer -> view<16xi8, #dense>
+  %output_view = buffer.view %output_noalias[%base] : buffer -> view<2x32xi32, #dense>
 
   %scratch = buffer.alloca %scratch_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %destination = buffer.view %scratch[%lane_byte_offset] : buffer -> view<16xi8, #dense>
@@ -51,11 +50,11 @@ kernel.def target(@gfx1250) @cluster_b128_multicast() {
   %actual2 = vector.extract %actual[2] : vector<4xi32> -> i32
   %actual3 = vector.extract %actual[3] : vector<4xi32> -> i32
   %lane_i32 = index.cast %lane : index to i32
-  %expected_base = scalar.muli %lane_i32, %four_i32 : i32
-  %expected0 = scalar.addi %expected_base, %one_i32 : i32
-  %expected1 = scalar.addi %expected_base, %two_i32 : i32
-  %expected2 = scalar.addi %expected_base, %three_i32 : i32
-  %expected3 = scalar.addi %expected_base, %four_i32 : i32
+  %expected_base = scalar.muli %lane_i32, %words_per_lane : i32
+  %expected0 = scalar.addi %expected_base, %first_word_ordinal : i32
+  %expected1 = scalar.addi %expected_base, %second_word_ordinal : i32
+  %expected2 = scalar.addi %expected_base, %third_word_ordinal : i32
+  %expected3 = scalar.addi %expected_base, %fourth_word_ordinal : i32
   %valid0 = scalar.cmpi eq, %actual0, %expected0 : i32
   %valid1 = scalar.cmpi eq, %actual1, %expected1 : i32
   %valid2 = scalar.cmpi eq, %actual2, %expected2 : i32
@@ -63,7 +62,7 @@ kernel.def target(@gfx1250) @cluster_b128_multicast() {
   %valid01 = scalar.andi %valid0, %valid1 : i1
   %valid23 = scalar.andi %valid2, %valid3 : i1
   %valid = scalar.andi %valid01, %valid23 : i1
-  %result = scf.select %valid, %one_i32, %zero_i32 : i32
+  %result = scf.select %valid, %success_value, %failure_value : i32
   view.store %result, %output_view[%workgroup_y, %lane] : i32, view<2x32xi32, #dense>
   kernel.return
 }

--- a/loom/src/loom/test/corpus/authoring/hip/lane_distribution.loom
+++ b/loom/src/loom/test/corpus/authoring/hip/lane_distribution.loom
@@ -10,7 +10,7 @@ kernel.def @lane_distribution_contract() {
   %workgroup_size = index.constant 64 : index
   kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs: i32, %rhs: i32) {
-  %zero_index = index.constant 0 : index
+  %leader_lane = index.constant 0 : index
   %workgroup_size = index.constant 64 : index
 
   // HIP concept: `blockIdx.x`, `blockDim.x`, grid constants, and scalar kernel
@@ -54,7 +54,7 @@ kernel.def @lane_distribution_contract() {
   // Loom spelling: a comparison that depends on the lane id is a lane predicate.
   // Selecting between uniform scalar arguments with such a predicate produces
   // lane-varying data.
-  %is_lane_zero = index.cmp eq, %lane, %zero_index : index
+  %is_lane_zero = index.cmp eq, %lane, %leader_lane : index
   %selected = scf.select %is_lane_zero, %lhs, %rhs : i32
   %predicate_is_lane = test.fact_lane_predicate %is_lane_zero : i1 -> i1
   %predicate_is_uniform = test.fact_subgroup_uniform %is_lane_zero : i1 -> i1

--- a/loom/src/loom/test/corpus/authoring/hip/q8_block_unroll.loom
+++ b/loom/src/loom/test/corpus/authoring/hip/q8_block_unroll.loom
@@ -10,10 +10,10 @@ kernel.def @q8_block_unroll_wg64() {
   kernel.launch.config workgroups(%row_groups, %cols, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%src0: buffer, %src1: buffer, %dst: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %four = index.constant 4 : index
-  %four_bytes = index.constant 4 : offset
-  %eight = index.constant 8 : index
+  %packed_word_index = index.constant 0 : index
+  %packed_element_count = index.constant 4 : index
+  %packed_word_bytes = index.constant 4 : offset
+  %block_lane_count = index.constant 8 : index
   %qk = index.constant 32 : index
   %block_bytes = index.constant 34 : offset
   %block_f16s = index.constant 17 : index
@@ -29,8 +29,8 @@ kernel.def @q8_block_unroll_wg64() {
   %row = kernel.workgroup.id<x> : index
   %col = kernel.workgroup.id<y> : index
   %lane = kernel.workitem.id<x> : index
-  %zero_f32 = scalar.constant 0.0 : f32
-  %zero_i32 = scalar.constant 0 : i32
+  %dot_initial = scalar.constant 0.0 : f32
+  %leader_lane = scalar.constant 0 : i32
 
   // HIP concept: split a 64-lane workgroup into eight lanes per q8 block:
   //   block_lane = threadIdx.x & 7;
@@ -38,10 +38,10 @@ kernel.def @q8_block_unroll_wg64() {
   //   block_step = blockDim.x / 8;
   // Loom spelling: index math plus value facts. These facts let full-unroll
   // prove every lane visits exactly two blocks below.
-  %block_lane = index.rem %lane, %eight : index
-  %block_slot = index.div %lane, %eight : index
-  %in_block_base = index.mul %block_lane, %four : index
-  %block_step = index.div %workgroup_size, %eight : index
+  %block_lane = index.rem %lane, %block_lane_count : index
+  %block_slot = index.div %lane, %block_lane_count : index
+  %in_block_base = index.mul %block_lane, %packed_element_count : index
+  %block_step = index.div %workgroup_size, %block_lane_count : index
 
   // HIP concept: `const block_q8_0 *__restrict__`, `float *__restrict__`.
   // Loom spelling: kernel ABI buffers already carry global memory-space facts.
@@ -62,7 +62,7 @@ kernel.def @q8_block_unroll_wg64() {
   // Loom spelling: `scf.for ... unroll`. The lower bound is lane-dependent,
   // but facts prove `%block_slot in [0,7]`, upper `16`, and step `8`, so
   // `unroll-scf-for` reports a dynamic-lower proof with trip_count = 2.
-  %sum = scf.for %block_idx_raw = [%block_slot to %blocks_per_row step %block_step](%acc = %zero_f32 : f32) -> (f32) unroll {
+  %sum = scf.for %block_idx_raw = [%block_slot to %blocks_per_row step %block_step](%acc = %dot_initial : f32) -> (f32) unroll {
     // HIP concept: local block index stays in the q8 row domain.
     // Loom spelling: attach the post-IV range fact so address math and later
     // lowering know the packed block index is bounded.
@@ -72,7 +72,7 @@ kernel.def @q8_block_unroll_wg64() {
     %linear_block = index.add %row_block_base, %block_idx : index
     %block_byte_base = index.scale %linear_block, %block_bytes : index, offset -> offset
     %q_byte_payload = index.add %block_byte_base, %qs_offset : offset
-    %in_block_byte = index.scale %block_lane, %four_bytes : index, offset -> offset
+    %in_block_byte = index.scale %block_lane, %packed_word_bytes : index, offset -> offset
     %q_byte_offset = index.add %q_byte_payload, %in_block_byte : offset
 
     // HIP concept: `global_load_b32` of four packed q8 bytes.
@@ -80,7 +80,7 @@ kernel.def @q8_block_unroll_wg64() {
     // i32 lane and unpack bytes explicitly. Adjacent scalar loads are not a
     // request for coalescing; source load width is part of the contract.
     %q_word_view = buffer.view %src0_noalias[%q_byte_offset] : buffer -> view<1xi32, #dense>
-    %q_packed = vector.load %q_word_view[%zero] : view<1xi32, #dense> -> vector<1xi32>
+    %q_packed = vector.load %q_word_view[%packed_word_index] : view<1xi32, #dense> -> vector<1xi32>
     %q_i32 = vector.bitunpacks<8> %q_packed : vector<1xi32> -> vector<4xi32>
     %q_f32 = vector.sitofp %q_i32 : vector<4xi32> to vector<4xf32>
 
@@ -105,7 +105,7 @@ kernel.def @q8_block_unroll_wg64() {
   %dot = kernel.workgroup.reduce<addf> %sum : f32
   %dst_index = index.add %dst_col_base, %row : index
   %lane_i32 = index.cast %lane : index to i32
-  %is_lane0 = scalar.cmpi eq, %lane_i32, %zero_i32 : i32
+  %is_lane0 = scalar.cmpi eq, %lane_i32, %leader_lane : i32
   scf.if %is_lane0 {
     view.store %dot, %dst_view[%dst_index] : f32, view<512xf32, #dense>
   }

--- a/loom/src/loom/test/corpus/authoring/hip/q8_q4_signedness.loom
+++ b/loom/src/loom/test/corpus/authoring/hip/q8_q4_signedness.loom
@@ -60,17 +60,17 @@ kernel.def @q8_mixed_u8s8_dot4_all_ones() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
   %base = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %output_index = index.constant 0 : index
   %lhs0 = scalar.constant -1 : i8
   %rhs0 = scalar.constant -1 : i8
-  %zero = scalar.constant 0 : i32
+  %dot_initial = scalar.constant 0 : i32
   %output_words = buffer.view %output[%base] : buffer -> view<1xi32, #dense>
   %lhs = vector.from_elements %lhs0, %lhs0, %lhs0, %lhs0 : vector<4xi8>
   %rhs = vector.from_elements %rhs0, %rhs0, %rhs0, %rhs0 : vector<4xi8>
-  %acc = vector.from_elements %zero : vector<1xi32>
+  %acc = vector.from_elements %dot_initial : vector<1xi32>
   %dot = vector.dot4i<u8s8> %lhs, %rhs, %acc : vector<4xi8>, vector<4xi8>, vector<1xi32>
   %result = vector.extract %dot[0] : vector<1xi32> -> i32
-  view.store %result, %output_words[%zero_index] : i32, view<1xi32, #dense>
+  view.store %result, %output_words[%output_index] : i32, view<1xi32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/test/corpus/authoring/hip/shared_memory_wave_tile.loom
+++ b/loom/src/loom/test/corpus/authoring/hip/shared_memory_wave_tile.loom
@@ -44,8 +44,8 @@ kernel.def @shared_memory_wave_i32_roundtrip_static_offset() {
 } launch(%output: buffer) {
   %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
-  %four = index.constant 4 : index
-  %scratch_index = index.add %lane, %four : index
+  %scratch_prefix_elements = index.constant 4 : index
+  %scratch_index = index.add %lane, %scratch_prefix_elements : index
   %lane_i32 = index.cast %lane : index to i32
   %bias = scalar.constant 11 : i32
   %value = scalar.addi %lane_i32, %bias : i32
@@ -111,8 +111,8 @@ kernel.def @shared_memory_cross_wave_i32_roundtrip_two_regions() {
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %lane = kernel.workitem.id<x> : index
-  %onehundredtwentyeight = index.constant 128 : index
-  %second_region_index = index.add %lane, %onehundredtwentyeight : index
+  %region_element_count = index.constant 128 : index
+  %second_region_index = index.add %lane, %region_element_count : index
   %scratch_bytes = index.constant 1024 : offset
 
   %input_view = buffer.view %input[%base] : buffer -> view<256xi32, #dense>

--- a/loom/src/loom/test/corpus/authoring/hip/target_provider_selection.loom
+++ b/loom/src/loom/test/corpus/authoring/hip/target_provider_selection.loom
@@ -11,8 +11,8 @@ amdgpu.target<gfx1200> @gfx1200
 // Loom spelling: a `func.template<contract>` provider filtered by target and
 // ranked by priority. `target(@gfx1100)` says where this provider is legal.
 func.template<hip.recipe.scale_i32> target(@gfx1100) priority(20) @scale_i32_gfx1100(%value: i32) -> (i32) {
-  %two = scalar.constant 2 : i32
-  %scaled = scalar.muli %value, %two : i32
+  %scale_factor = scalar.constant 2 : i32
+  %scaled = scalar.muli %value, %scale_factor : i32
   func.return %scaled : i32
 }
 

--- a/loom/src/loom/test/corpus/authoring/hip/template_math_legalization.loom
+++ b/loom/src/loom/test/corpus/authoring/hip/template_math_legalization.loom
@@ -26,17 +26,17 @@ kernel.def target(@gfx11) @template_math_legalization() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%scalar_input: buffer, %vector_input: buffer, %scalar_output: buffer, %vector_output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %element_index = index.constant 0 : index
   %scalar_input_noalias, %vector_input_noalias, %scalar_output_noalias, %vector_output_noalias = buffer.assume.noalias %scalar_input, %vector_input, %scalar_output, %vector_output : buffer, buffer, buffer, buffer
   %scalar_input_view = buffer.view %scalar_input_noalias[%base] : buffer -> view<1xf32, #dense>
   %vector_input_view = buffer.view %vector_input_noalias[%base] : buffer -> view<4xf32, #dense>
   %scalar_output_view = buffer.view %scalar_output_noalias[%base] : buffer -> view<1xf32, #dense>
   %vector_output_view = buffer.view %vector_output_noalias[%base] : buffer -> view<4xf32, #dense>
-  %scalar = view.load %scalar_input_view[%zero] : view<1xf32, #dense> -> f32
-  %values = vector.load %vector_input_view[%zero] : view<4xf32, #dense> -> vector<4xf32>
+  %scalar = view.load %scalar_input_view[%element_index] : view<1xf32, #dense> -> f32
+  %values = vector.load %vector_input_view[%element_index] : view<4xf32, #dense> -> vector<4xf32>
   %scalar_result, %vector_result = func.apply<hip.recipe.exp_f32>(%scalar, %values) : (f32, vector<4xf32>) -> (f32, vector<4xf32>)
-  view.store %scalar_result, %scalar_output_view[%zero] : f32, view<1xf32, #dense>
-  vector.store %vector_result, %vector_output_view[%zero] : vector<4xf32>, view<4xf32, #dense>
+  view.store %scalar_result, %scalar_output_view[%element_index] : f32, view<1xf32, #dense>
+  vector.store %vector_result, %vector_output_view[%element_index] : vector<4xf32>, view<4xf32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/test/corpus/authoring/hip/wave64_reductions.loom
+++ b/loom/src/loom/test/corpus/authoring/hip/wave64_reductions.loom
@@ -15,15 +15,16 @@ kernel.def target(@gfx11_wave64) @wave64_workgroup_reduce_sub_wave() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %result_index = index.constant 0 : index
+  %leader_lane = index.constant 0 : index
   %lane = kernel.workitem.id<x> : index
   %input_view = buffer.view %input[%base] : buffer -> view<32xf32, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<1xf32, #dense>
   %value = view.load %input_view[%lane] : view<32xf32, #dense> -> f32
   %sum = kernel.workgroup.reduce<addf> %value : f32
-  %is_leader = index.cmp eq, %lane, %zero : index
+  %is_leader = index.cmp eq, %lane, %leader_lane : index
   scf.if %is_leader {
-    view.store %sum, %output_view[%zero] : f32, view<1xf32, #dense>
+    view.store %sum, %output_view[%result_index] : f32, view<1xf32, #dense>
   }
   kernel.return
 }
@@ -34,15 +35,16 @@ kernel.def target(@gfx11_wave64) @wave64_workgroup_reduce_full_wave() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %result_index = index.constant 0 : index
+  %leader_lane = index.constant 0 : index
   %lane = kernel.workitem.id<x> : index
   %input_view = buffer.view %input[%base] : buffer -> view<64xf32, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<1xf32, #dense>
   %value = view.load %input_view[%lane] : view<64xf32, #dense> -> f32
   %sum = kernel.workgroup.reduce<addf> %value : f32
-  %is_leader = index.cmp eq, %lane, %zero : index
+  %is_leader = index.cmp eq, %lane, %leader_lane : index
   scf.if %is_leader {
-    view.store %sum, %output_view[%zero] : f32, view<1xf32, #dense>
+    view.store %sum, %output_view[%result_index] : f32, view<1xf32, #dense>
   }
   kernel.return
 }
@@ -53,15 +55,16 @@ kernel.def target(@gfx11_wave64) @wave64_workgroup_reduce_cross_wave() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %result_index = index.constant 0 : index
+  %leader_lane = index.constant 0 : index
   %lane = kernel.workitem.id<x> : index
   %input_view = buffer.view %input[%base] : buffer -> view<128xf32, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<1xf32, #dense>
   %value = view.load %input_view[%lane] : view<128xf32, #dense> -> f32
   %sum = kernel.workgroup.reduce<addf> %value : f32
-  %is_leader = index.cmp eq, %lane, %zero : index
+  %is_leader = index.cmp eq, %lane, %leader_lane : index
   scf.if %is_leader {
-    view.store %sum, %output_view[%zero] : f32, view<1xf32, #dense>
+    view.store %sum, %output_view[%result_index] : f32, view<1xf32, #dense>
   }
   kernel.return
 }
@@ -72,23 +75,24 @@ kernel.def target(@gfx11_wave64) @wave64_workgroup_reduce_loop_accumulation() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %result_index = index.constant 0 : index
+  %leader_lane = index.constant 0 : index
   %column_count = index.constant 3072 : index
   %workgroup_size = index.constant 512 : index
   %lane0 = kernel.workitem.id<x> : index
   %lane = index.assume %lane0 [range(%lane0, 0, 511)] : index
-  %zero_f32 = scalar.constant 0.0 : f32
+  %sum_initial = scalar.constant 0.0 : f32
   %input_view = buffer.view %input[%base] : buffer -> view<3072xf32, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<1xf32, #dense>
-  %lane_sum = scf.for %column = [%lane to %column_count step %workgroup_size](%acc = %zero_f32 : f32) -> (f32) {
+  %lane_sum = scf.for %column = [%lane to %column_count step %workgroup_size](%acc = %sum_initial : f32) -> (f32) {
     %value = view.load %input_view[%column] : view<3072xf32, #dense> -> f32
     %next = scalar.addf<reassoc|nnan|ninf|nsz> %acc, %value : f32
     scf.yield %next : f32
   }
   %sum = kernel.workgroup.reduce<addf> %lane_sum : f32
-  %is_lane0 = index.cmp eq, %lane, %zero : index
+  %is_lane0 = index.cmp eq, %lane, %leader_lane : index
   scf.if %is_lane0 {
-    view.store %sum, %output_view[%zero] : f32, view<1xf32, #dense>
+    view.store %sum, %output_view[%result_index] : f32, view<1xf32, #dense>
   }
   kernel.return
 }
@@ -99,26 +103,27 @@ kernel.def target(@gfx11_wave64) @wave64_workgroup_reduce_sparse_loop_accumulati
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixtyfour = index.constant 64 : index
+  %result_index = index.constant 0 : index
+  %leader_lane = index.constant 0 : index
+  %block_lane_count = index.constant 64 : index
   %workgroup_size = index.constant 256 : index
   %block_count = index.constant 2 : index
   %lane0 = kernel.workitem.id<x> : index
   %lane = index.assume %lane0 [range(%lane0, 0, 255)] : index
-  %block_slot = index.div %lane, %sixtyfour : index
-  %block_step = index.div %workgroup_size, %sixtyfour : index
-  %zero_f32 = scalar.constant 0.0 : f32
+  %block_slot = index.div %lane, %block_lane_count : index
+  %block_step = index.div %workgroup_size, %block_lane_count : index
+  %sum_initial = scalar.constant 0.0 : f32
   %input_view = buffer.view %input[%base] : buffer -> view<2xf32, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<1xf32, #dense>
-  %lane_sum = scf.for %block = [%block_slot to %block_count step %block_step](%acc = %zero_f32 : f32) -> (f32) {
+  %lane_sum = scf.for %block = [%block_slot to %block_count step %block_step](%acc = %sum_initial : f32) -> (f32) {
     %value = view.load %input_view[%block] : view<2xf32, #dense> -> f32
     %next = scalar.addf<reassoc|nnan|ninf|nsz> %acc, %value : f32
     scf.yield %next : f32
   }
   %sum = kernel.workgroup.reduce<addf> %lane_sum : f32
-  %is_lane0 = index.cmp eq, %lane, %zero : index
+  %is_lane0 = index.cmp eq, %lane, %leader_lane : index
   scf.if %is_lane0 {
-    view.store %sum, %output_view[%zero] : f32, view<1xf32, #dense>
+    view.store %sum, %output_view[%result_index] : f32, view<1xf32, #dense>
   }
   kernel.return
 }
@@ -133,12 +138,12 @@ kernel.def target(@gfx11_wave64) @wave64_workgroup_reduce_loop_all_workitems() {
   %workgroup_size = index.constant 512 : index
   %lane0 = kernel.workitem.id<x> : index
   %lane = index.assume %lane0 [range(%lane0, 0, 511)] : index
-  %zero_f32 = scalar.constant 0.0 : f32
+  %sum_initial = scalar.constant 0.0 : f32
   %column_count_i32 = scalar.constant 3072 : i32
   %column_count_f32 = scalar.sitofp %column_count_i32 : i32 to f32
   %input_view = buffer.view %input[%base] : buffer -> view<3072xf32, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<3072xf32, #dense>
-  %lane_sum = scf.for %column = [%lane to %column_count step %workgroup_size](%acc = %zero_f32 : f32) -> (f32) {
+  %lane_sum = scf.for %column = [%lane to %column_count step %workgroup_size](%acc = %sum_initial : f32) -> (f32) {
     %value = view.load %input_view[%column] : view<3072xf32, #dense> -> f32
     %next = scalar.addf<reassoc|nnan|ninf|nsz> %acc, %value : f32
     scf.yield %next : f32
@@ -160,8 +165,9 @@ kernel.def target(@gfx11_wave64) @wave64_workgroup_reduce_two_rows() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%row_count: index, %fusion_flags: i32, %input0: buffer, %input1: buffer, %bias: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %leader_lane = index.constant 0 : index
+  %row0 = index.constant 0 : index
+  %row1 = index.constant 1 : index
   %lane0 = kernel.workitem.id<x> : index
   %lane = index.assume %lane0 [range(%lane0, 0, 63)] : index
   %input0_view = buffer.view %input0[%base] : buffer -> view<64xf32, #dense>
@@ -172,32 +178,32 @@ kernel.def target(@gfx11_wave64) @wave64_workgroup_reduce_two_rows() {
   %value1 = view.load %input1_view[%lane] : view<64xf32, #dense> -> f32
   %sum0 = kernel.workgroup.reduce<addf> %value0 : f32
   %sum1 = kernel.workgroup.reduce<addf> %value1 : f32
-  %zero_i32 = scalar.constant 0 : i32
-  %one_i32 = scalar.constant 1 : i32
-  %has_bias_bits = scalar.andi %fusion_flags, %one_i32 : i32
-  %has_bias = scalar.cmpi ne, %has_bias_bits, %zero_i32 : i32
+  %no_fusion_flags = scalar.constant 0 : i32
+  %bias_flag = scalar.constant 1 : i32
+  %has_bias_bits = scalar.andi %fusion_flags, %bias_flag : i32
+  %has_bias = scalar.cmpi ne, %has_bias_bits, %no_fusion_flags : i32
   %out0 = scf.if %has_bias -> (f32) {
-    %bias0 = view.load %bias_view[%zero] : view<2xf32, #dense> -> f32
+    %bias0 = view.load %bias_view[%row0] : view<2xf32, #dense> -> f32
     %with_bias0 = scalar.addf %sum0, %bias0 : f32
     scf.yield %with_bias0 : f32
   } else {
     scf.yield %sum0 : f32
   }
   %out1 = scf.if %has_bias -> (f32) {
-    %bias1 = view.load %bias_view[%one] : view<2xf32, #dense> -> f32
+    %bias1 = view.load %bias_view[%row1] : view<2xf32, #dense> -> f32
     %with_bias1 = scalar.addf %sum1, %bias1 : f32
     scf.yield %with_bias1 : f32
   } else {
     scf.yield %sum1 : f32
   }
-  %is_lane0 = index.cmp eq, %lane, %zero : index
+  %is_lane0 = index.cmp eq, %lane, %leader_lane : index
   scf.if %is_lane0 {
-    view.store %out0, %output_view[%zero] : f32, view<2xf32, #dense>
+    view.store %out0, %output_view[%row0] : f32, view<2xf32, #dense>
   }
-  %row1_in_bounds = index.cmp ult, %one, %row_count : index
+  %row1_in_bounds = index.cmp ult, %row1, %row_count : index
   scf.if %row1_in_bounds {
     scf.if %is_lane0 {
-      view.store %out1, %output_view[%one] : f32, view<2xf32, #dense>
+      view.store %out1, %output_view[%row1] : f32, view<2xf32, #dense>
     }
   }
   kernel.return

--- a/loom/src/loom/test/corpus/authoring/indexed_row_gather_f32.loom
+++ b/loom/src/loom/test/corpus/authoring/indexed_row_gather_f32.loom
@@ -22,7 +22,7 @@ kernel.def @indexed_row_gather_f32(%nrows: index, %ncols: index, %source_rows: i
   kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%nrows: index, %ncols: index, %source_rows: index, %source: buffer, %indices: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero_i32 = scalar.constant 0 : i32
+  %minimum_row_id = scalar.constant 0 : i32
   %workgroup = kernel.workgroup.id<x> : index
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 256 : index
@@ -43,7 +43,7 @@ kernel.def @indexed_row_gather_f32(%nrows: index, %ncols: index, %source_rows: i
     %row0 = index.div %linear, %bounded_ncols : index
     %row = index.assume %row0 [range(%row0, 0, 65534), lt(%row0, %bounded_nrows)] : index
     %source_row_i32 = view.load %indices_view[%row] : view<[%bounded_nrows]xi32, #dense> -> i32
-    %source_row_nonnegative = scalar.cmpi sge, %source_row_i32, %zero_i32 : i32
+    %source_row_nonnegative = scalar.cmpi sge, %source_row_i32, %minimum_row_id : i32
     scf.if %source_row_nonnegative {
       %source_row = index.cast %source_row_i32 : i32 to index
       %source_row_valid = index.cmp ult, %source_row, %bounded_source_rows : index

--- a/loom/src/loom/test/corpus/authoring/linking/providers.loom
+++ b/loom/src/loom/test/corpus/authoring/linking/providers.loom
@@ -3,8 +3,8 @@ amdgpu.target<gfx1200> @gfx1200
 
 // RDNA3 provider selected when its caller specializes to @gfx1100.
 func.template<authoring.link.scale_i32> target(@gfx1100) priority(20) @scale_i32_gfx1100(%value: i32) -> (i32) {
-  %two = scalar.constant 2 : i32
-  %scaled = scalar.muli %value, %two : i32
+  %scale_factor = scalar.constant 2 : i32
+  %scaled = scalar.muli %value, %scale_factor : i32
   func.return %scaled : i32
 }
 

--- a/loom/src/loom/test/corpus/authoring/linking/root.loom
+++ b/loom/src/loom/test/corpus/authoring/linking/root.loom
@@ -11,11 +11,11 @@ kernel.def export("scale_i32_buffer") @scale_i32_buffer(%element_count: index) {
   %workgroup = kernel.workgroup.id<x> : index
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 64 : index
-  %zero_offset = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %element_index = index.madd %workgroup, %workgroup_size, %lane : index
   %in_bounds = index.cmp ult, %element_index, %element_count : index
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<[%element_count]xi32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<[%element_count]xi32, #dense>
+  %input_view = buffer.view %input[%base] : buffer -> view<[%element_count]xi32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<[%element_count]xi32, #dense>
   scf.if %in_bounds {
     %value = view.load %input_view[%element_index] : view<[%element_count]xi32, #dense> -> i32
     %scaled = func.apply<authoring.link.scale_i32>(%value) : (i32) -> (i32)

--- a/loom/src/loom/test/corpus/authoring/memset_i8.loom
+++ b/loom/src/loom/test/corpus/authoring/memset_i8.loom
@@ -17,13 +17,13 @@ kernel.def @memset_i8(%element_length: index) {
   %workgroup = kernel.workgroup.id<x> : index
   %lane = kernel.workitem.id<x> : index
   %workgroup_size = index.constant 256 : index
-  %zero_offset = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %element_capacity = config.get @memset_i8.element_capacity : index
   %bounded_element_length = index.assume %element_length [le(%element_length, %element_capacity)] : index
   %element_index = index.madd %workgroup, %workgroup_size, %lane : index
   %in_bounds = index.cmp ult, %element_index, %bounded_element_length : index
   %pattern_i8 = scalar.trunci %pattern : i64 to i8
-  %target_view = buffer.view %target[%zero_offset] : buffer -> view<[%bounded_element_length]xi8, #dense>
+  %target_view = buffer.view %target[%base] : buffer -> view<[%bounded_element_length]xi8, #dense>
   scf.if %in_bounds {
     view.store %pattern_i8, %target_view[%element_index] : i8, view<[%bounded_element_length]xi8, #dense>
   }

--- a/loom/src/loom/test/corpus/authoring/mlp_down_projection_residual_bf16.loom
+++ b/loom/src/loom/test/corpus/authoring/mlp_down_projection_residual_bf16.loom
@@ -1,10 +1,10 @@
 // The down-projection kernel calls this concrete per-row dot helper for each
 // output row handled by the workgroup.
 func.def inline @bf16_dot32(%input_values: vector<32xf32>, %weight_values: vector<32xbf16>) -> (f32) {
-  %zero_f32 = scalar.constant 0.0 : f32
+  %sum_initial = scalar.constant 0.0 : f32
   %weight_f32 = vector.extf %weight_values : vector<32xbf16> to vector<32xf32>
   %products = vector.mulf<reassoc|nnan|ninf|nsz> %input_values, %weight_f32 : vector<32xf32>
-  %sum = vector.reduce<addf, reassoc|nnan|ninf|nsz> %products, %zero_f32 : vector<32xf32>, f32
+  %sum = vector.reduce<addf, reassoc|nnan|ninf|nsz> %products, %sum_initial : vector<32xf32>, f32
   func.return %sum : f32
 }
 

--- a/loom/src/loom/test/corpus/sanitizer/amdgpu_asan_actual.loom
+++ b/loom/src/loom/test/corpus/sanitizer/amdgpu_asan_actual.loom
@@ -1,29 +1,29 @@
 kernel.def @asan_global_store_valid() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %base = index.constant 0 : offset
+  %output_index = index.constant 0 : index
   %value = scalar.constant 7 : i32
   %global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %global[%zero_offset] : buffer -> view<1xi32, #dense>
-  view.store %value, %output_view[%zero_index] : i32, view<1xi32, #dense>
+  %output_view = buffer.view %global[%base] : buffer -> view<1xi32, #dense>
+  view.store %value, %output_view[%output_index] : i32, view<1xi32, #dense>
   kernel.return
 }
 
 kernel.def @asan_global_store_redzone() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %one_index = index.constant 1 : index
+  %base = index.constant 0 : offset
+  %valid_index = index.constant 0 : index
+  %redzone_index = index.constant 1 : index
   %value = scalar.constant 11 : i32
   %continued_value = scalar.constant 99 : i32
   %global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %global[%zero_offset] : buffer -> view<2xi32, #dense>
-  view.store %value, %output_view[%one_index] : i32, view<2xi32, #dense>
-  view.store %continued_value, %output_view[%zero_index] : i32, view<2xi32, #dense>
+  %output_view = buffer.view %global[%base] : buffer -> view<2xi32, #dense>
+  view.store %value, %output_view[%redzone_index] : i32, view<2xi32, #dense>
+  view.store %continued_value, %output_view[%valid_index] : i32, view<2xi32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/test/corpus/sanitizer/amdgpu_tsan_actual.loom
+++ b/loom/src/loom/test/corpus/sanitizer/amdgpu_tsan_actual.loom
@@ -1,54 +1,54 @@
 kernel.def @tsan_workgroup_write_race() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 2 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch(%output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %base = index.constant 0 : offset
+  %element_index = index.constant 0 : index
   %bytes = index.constant 4 : offset
   %value = scalar.constant 1 : i32
   %continued_value = scalar.constant 9 : i32
   %global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %global[%zero_offset] : buffer -> view<1xi32, #dense>
-  view.store %value, %output_view[%zero_index] : i32, view<1xi32, #dense>
+  %output_view = buffer.view %global[%base] : buffer -> view<1xi32, #dense>
+  view.store %value, %output_view[%element_index] : i32, view<1xi32, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero_offset] : buffer -> view<1xi32, #dense>
-  view.store %value, %scratch_view[%zero_index] : i32, view<1xi32, #dense>
-  view.store %continued_value, %output_view[%zero_index] : i32, view<1xi32, #dense>
+  %scratch_view = buffer.view %scratch[%base] : buffer -> view<1xi32, #dense>
+  view.store %value, %scratch_view[%element_index] : i32, view<1xi32, #dense>
+  view.store %continued_value, %output_view[%element_index] : i32, view<1xi32, #dense>
   kernel.return
 }
 
 kernel.def @tsan_workgroup_barrier_safe_write() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %threads = index.constant 2 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%threads, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
 } launch(%output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %one_index = index.constant 1 : index
+  %base = index.constant 0 : offset
+  %first_lane = index.constant 0 : index
+  %second_lane = index.constant 1 : index
   %bytes = index.constant 4 : offset
   %before_value = scalar.constant 1 : i32
   %after_value = scalar.constant 2 : i32
   %lane = kernel.workitem.id<x> : index
   %global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %global[%zero_offset] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %global[%base] : buffer -> view<1xi32, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero_offset] : buffer -> view<1xi32, #dense>
-  %is_lane_zero = index.cmp eq, %lane, %zero_index : index
-  scf.if %is_lane_zero {
-    view.store %before_value, %scratch_view[%zero_index] : i32, view<1xi32, #dense>
+  %scratch_view = buffer.view %scratch[%base] : buffer -> view<1xi32, #dense>
+  %is_first_lane = index.cmp eq, %lane, %first_lane : index
+  scf.if %is_first_lane {
+    view.store %before_value, %scratch_view[%first_lane] : i32, view<1xi32, #dense>
     scf.yield
   }
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
-  %is_lane_one = index.cmp eq, %lane, %one_index : index
-  scf.if %is_lane_one {
-    view.store %after_value, %scratch_view[%zero_index] : i32, view<1xi32, #dense>
+  %is_second_lane = index.cmp eq, %lane, %second_lane : index
+  scf.if %is_second_lane {
+    view.store %after_value, %scratch_view[%first_lane] : i32, view<1xi32, #dense>
     scf.yield
   }
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
-  scf.if %is_lane_zero {
-    %result = view.load %scratch_view[%zero_index] : view<1xi32, #dense> -> i32
-    view.store %result, %output_view[%zero_index] : i32, view<1xi32, #dense>
+  scf.if %is_first_lane {
+    %result = view.load %scratch_view[%first_lane] : view<1xi32, #dense> -> i32
+    view.store %result, %output_view[%first_lane] : i32, view<1xi32, #dense>
     scf.yield
   }
   kernel.return

--- a/loom/src/loom/test/corpus/source_low/async_gather.loom-test
+++ b/loom/src/loom/test/corpus/source_low/async_gather.loom-test
@@ -5,13 +5,13 @@ kernel.def @async_gather_dword() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x4xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x4xi8, #dense>
   %source = view.subview %source_base[%tid, 0] : view<64x4xi8, #dense> -> view<1x4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x1x4xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x1x4xi8, #dense>
   %copy = kernel.async.gather %source to %dest {cache_scope = device, cache_temporal = regular} : view<1x4xi8, #dense> to view<64x1x4xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -25,13 +25,13 @@ kernel.def @async_gather_b128() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x16xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x16xi8, #dense>
   %source = view.subview %source_base[%tid, 0] : view<64x16xi8, #dense> -> view<1x16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x1x16xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x1x16xi8, #dense>
   %copy = kernel.async.gather %source to %dest {cache_scope = device, cache_temporal = regular} : view<1x16xi8, #dense> to view<64x1x16xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -45,13 +45,13 @@ kernel.def @async_gather_two_stage() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 2048 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x1x16xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x1x16xi8, #dense>
   %source = view.subview %source_base[%tid, 0, 0] : view<64x1x16xi8, #dense> -> view<1x1x16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest_base = buffer.view %scratch[%zero] : buffer -> view<2x64x1x16xi8, #dense>
+  %dest_base = buffer.view %scratch[%buffer_base] : buffer -> view<2x64x1x16xi8, #dense>
   %dest0 = view.subview %dest_base[0, 0, 0, 0] : view<2x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
   %dest1 = view.subview %dest_base[1, 0, 0, 0] : view<2x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
   %copy0 = kernel.async.gather %source to %dest0 {cache_scope = device, cache_temporal = regular} : view<1x1x16xi8, #dense> to view<1x64x1x16xi8, #dense> -> kernel.async.token
@@ -70,13 +70,13 @@ kernel.def @async_gather_multi_packet_newer_group() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 3072 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x1x16xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x1x16xi8, #dense>
   %source = view.subview %source_base[%tid, 0, 0] : view<64x1x16xi8, #dense> -> view<1x1x16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest_base = buffer.view %scratch[%zero] : buffer -> view<3x64x1x16xi8, #dense>
+  %dest_base = buffer.view %scratch[%buffer_base] : buffer -> view<3x64x1x16xi8, #dense>
   %dest0 = view.subview %dest_base[0, 0, 0, 0] : view<3x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
   %dest1a = view.subview %dest_base[1, 0, 0, 0] : view<3x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
   %dest1b = view.subview %dest_base[2, 0, 0, 0] : view<3x64x1x16xi8, #dense> -> view<1x64x1x16xi8, #dense>
@@ -97,15 +97,15 @@ kernel.def @async_gather_second_lds_slot() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %pad_bytes = index.constant 256 : offset
   %scratch_bytes = index.constant 1024 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source_base = buffer.view %global[%zero] : buffer -> view<64x16xi8, #dense>
+  %source_base = buffer.view %global[%buffer_base] : buffer -> view<64x16xi8, #dense>
   %source = view.subview %source_base[%tid, 0] : view<64x16xi8, #dense> -> view<1x16xi8, #dense>
   %pad = buffer.alloca %pad_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch = buffer.alloca %scratch_bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x1x16xi8, #dense>
+  %dest = buffer.view %scratch[%buffer_base] : buffer -> view<64x1x16xi8, #dense>
   %copy = kernel.async.gather %source to %dest {cache_scope = device, cache_temporal = regular} : view<1x16xi8, #dense> to view<64x1x16xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group

--- a/loom/src/loom/test/corpus/source_low/encoding_facts.loom-test
+++ b/loom/src/loom/test/corpus/source_low/encoding_facts.loom-test
@@ -1,9 +1,9 @@
 // RUN: pass canonicalize
 
 func.def @mixed_dynamic_strided_layout_facts() -> (i64, i64, i64, i64) {
-  %sixty_four = index.constant 64 : index
-  %layout = encoding.layout.strided [1, %sixty_four] : encoding<layout>
-  %constant_hi = test.fact_range_hi %sixty_four : index -> i64
+  %outer_stride = index.constant 64 : index
+  %layout = encoding.layout.strided [1, %outer_stride] : encoding<layout>
+  %constant_hi = test.fact_range_hi %outer_stride : index -> i64
   %kind = test.fact_encoding_layout_kind %layout : encoding<layout> -> i64
   %stride0 = test.fact_encoding_layout_stride_hi %layout[0] : encoding<layout> -> i64
   %stride1 = test.fact_encoding_layout_stride_hi %layout[1] : encoding<layout> -> i64
@@ -41,16 +41,16 @@ func.def @assumed_strided_layout_facts() -> (i64, i64, i64) {
 // ====
 
 func.def @predicate_attribute_keeps_dynamic_bound(%origin0: index, %count: index) -> (index) {
-  %one = index.constant 1 : index
-  %max_vector_origin = index.sub %count, %one : index
+  %last_origin_adjustment = index.constant 1 : index
+  %max_vector_origin = index.sub %count, %last_origin_adjustment : index
   %origin = index.assume %origin0 [lt(%origin0, %max_vector_origin)] : index
   func.return %origin : index
 }
 
 // ----
 func.def @predicate_attribute_keeps_dynamic_bound(%origin0: index, %count: index) -> (index) {
-  %one = index.constant 1 : index
-  %max_vector_origin = index.sub %count, %one : index
+  %last_origin_adjustment = index.constant 1 : index
+  %max_vector_origin = index.sub %count, %last_origin_adjustment : index
   %origin = index.assume %origin0 [lt(%origin0, %max_vector_origin)] : index
   func.return %origin : index
 }

--- a/loom/src/loom/test/corpus/source_low/index_addressing.loom-test
+++ b/loom/src/loom/test/corpus/source_low/index_addressing.loom-test
@@ -7,11 +7,11 @@ kernel.def @index_madd_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 4 : index
   %linear = index.madd %row, %row_stride, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<16xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<16xi32, #dense>
   kernel.return
@@ -27,11 +27,11 @@ kernel.def @index_madd_u24_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 9 : index
   %linear = index.madd %row, %row_stride, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<36xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<36xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<36xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<36xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<36xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<36xi32, #dense>
   kernel.return
@@ -47,11 +47,11 @@ kernel.def @index_madd_u24_literal_lhs_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 9 : index
   %linear = index.madd %row_stride, %row, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<36xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<36xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<36xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<36xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<36xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<36xi32, #dense>
   kernel.return
@@ -67,11 +67,11 @@ kernel.def @index_madd_u24_literal_addend_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %linear_bias = index.constant 1 : index
   %linear = index.madd %row, %column, %linear_bias : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<36xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<36xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<36xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<36xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<36xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<36xi32, #dense>
   kernel.return
@@ -85,12 +85,12 @@ kernel.def @index_madd_constant_addend_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%row_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %row = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %row_stride = index.constant 4 : index
   %column = index.constant 1 : index
   %linear = index.madd %row, %row_stride, %column : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<16xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<16xi32, #dense>
   kernel.return
@@ -104,14 +104,14 @@ kernel.def @index_madd_nested_scale_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%row_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %row = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %c9 = index.constant 9 : index
   %c2 = index.constant 2 : index
   %c16 = index.constant 16 : index
   %scaled = index.mul %row, %c9 : index
   %linear = index.madd %scaled, %c2, %c16 : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<80xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<80xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<80xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<80xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<80xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<80xi32, #dense>
   kernel.return
@@ -125,11 +125,11 @@ kernel.def @index_shli_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%lane_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %shift = index.constant 2 : index
   %linear = index.shli %lane, %shift : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%linear] : view<16xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%linear] : vector<1xi32>, view<16xi32, #dense>
   kernel.return
@@ -143,13 +143,13 @@ kernel.def @index_scale_byte_offset_global_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%element_count, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %element = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : index
+  %first_element = index.constant 0 : index
   %byte_stride = index.constant 4 : offset
   %byte_offset = index.scale %element, %byte_stride : index, offset -> offset
   %input_view = buffer.view %input[%byte_offset] : buffer -> view<1xi32, #dense>
   %output_view = buffer.view %output[%byte_offset] : buffer -> view<1xi32, #dense>
-  %loaded = vector.load %input_view[%zero] : view<1xi32, #dense> -> vector<1xi32>
-  vector.store %loaded, %output_view[%zero] : vector<1xi32>, view<1xi32, #dense>
+  %loaded = vector.load %input_view[%first_element] : view<1xi32, #dense> -> vector<1xi32>
+  vector.store %loaded, %output_view[%first_element] : vector<1xi32>, view<1xi32, #dense>
   kernel.return
 }
 
@@ -162,9 +162,9 @@ kernel.def @index_shli_previous_row_global_b128() {
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
   %base_offset = index.constant 0 : offset
-  %one = index.constant 1 : index
-  %column = index.add %lane, %one : index
-  %previous = index.sub %column, %one : index
+  %column_offset = index.constant 1 : index
+  %column = index.add %lane, %column_offset : index
+  %previous = index.sub %column, %column_offset : index
   %shift = index.constant 2 : index
   %linear = index.shli %previous, %shift : index
   %input_view = buffer.view %input[%base_offset] : buffer -> view<128xi32, #dense>
@@ -183,21 +183,25 @@ kernel.def @index_edge_loop_dynamic_lower_bound_global_b32() {
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
   %base_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %three = index.constant 3 : index
+  %left_edge_lane = index.constant 0 : index
+  %full_tap_begin = index.constant 0 : index
+  %left_edge_tap_begin = index.constant 1 : index
+  %tap_step = index.constant 1 : index
+  %padding_offset = index.constant 1 : index
+  %right_edge_tap_end = index.constant 2 : index
+  %input_lane_divisor = index.constant 2 : index
+  %full_tap_end = index.constant 3 : index
   %last_lane = index.constant 1023 : index
-  %is_left_edge = index.cmp eq, %lane, %zero : index
-  %begin = scf.select %is_left_edge, %one, %zero : index
+  %is_left_edge = index.cmp eq, %lane, %left_edge_lane : index
+  %begin = scf.select %is_left_edge, %left_edge_tap_begin, %full_tap_begin : index
   %is_right_edge = index.cmp eq, %lane, %last_lane : index
-  %end = scf.select %is_right_edge, %two, %three : index
+  %end = scf.select %is_right_edge, %right_edge_tap_end, %full_tap_end : index
   %input_view = buffer.view %input[%base_offset] : buffer -> view<512xi32, #dense>
   %output_view = buffer.view %output[%base_offset] : buffer -> view<1024xi32, #dense>
-  scf.for %tap = [%begin to %end step %one] {
+  scf.for %tap = [%begin to %end step %tap_step] {
     %shifted = index.add %lane, %tap : index
-    %source_lane = index.sub %shifted, %one : index
-    %input_lane = index.div %source_lane, %two : index
+    %source_lane = index.sub %shifted, %padding_offset : index
+    %input_lane = index.div %source_lane, %input_lane_divisor : index
     %loaded = vector.load %input_view[%input_lane] : view<512xi32, #dense> -> vector<1xi32>
     vector.store %loaded, %output_view[%lane] : vector<1xi32>, view<1024xi32, #dense>
   }
@@ -269,11 +273,12 @@ kernel.def @workitem_y_lds_uses_explicit_vaddr() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %row_count, %unit) : index
 } launch(%output: buffer) {
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%output_base] : buffer -> view<64xi32, #dense>
   %value = vector.constant 7 : vector<1xi32>
   vector.store %value, %scratch_view[%row] : vector<1xi32>, view<64xi32, #dense>
   %loaded = vector.load %scratch_view[%row] : view<64xi32, #dense> -> vector<1xi32>
@@ -295,9 +300,9 @@ kernel.def @dispatch_id_xy_global_b32() {
   %dispatch_row = kernel.workitem.dispatch.id<y> : index
   %row_stride = index.constant 32 : index
   %linear = index.madd %dispatch_row, %row_stride, %dispatch_column : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<512xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %output_view[%linear] : vector<1xi32>, view<512xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<512xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %output_view[%linear] : vector<1xi32>, view<512xi32, #dense>
   kernel.return
 }

--- a/loom/src/loom/test/corpus/source_low/memory_cache_policy_non_temporal.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_cache_policy_non_temporal.loom-test
@@ -6,9 +6,9 @@ kernel.def @cache_device_non_temporal_load_store() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] {cache_scope = device, cache_temporal = non_temporal} : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[%lane, 0] {cache_scope = device, cache_temporal = non_temporal} : vector<4xi32>, view<64x4xi32, #dense>
   kernel.return

--- a/loom/src/loom/test/corpus/source_low/memory_cache_policy_scopes.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_cache_policy_scopes.loom-test
@@ -6,9 +6,9 @@ kernel.def @cache_system_bypass_load_device_writeback_store() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] {cache_scope = system, cache_temporal = bypass} : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[%lane, 0] {cache_scope = device, cache_temporal = non_temporal_writeback} : vector<4xi32>, view<64x4xi32, #dense>
   kernel.return

--- a/loom/src/loom/test/corpus/source_low/memory_cache_policy_scopes.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_cache_policy_scopes.loom-test
@@ -22,9 +22,9 @@ kernel.def @cache_system_bypass_scalar_load() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = view.load %input_view[%lane] {cache_scope = system, cache_temporal = bypass} : view<64xi32, #dense> -> i32
   view.store %loaded, %output_view[%lane] : i32, view<64xi32, #dense>
   kernel.return

--- a/loom/src/loom/test/corpus/source_low/memory_generic_atomic.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_generic_atomic.loom-test
@@ -1,21 +1,21 @@
 // RUN: roundtrip
 
 func.def @generic_atomic_i32_static(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %generic = buffer.assume.memory_space<generic> %input : buffer
-  %view = buffer.view %generic[%zero] : buffer -> view<1xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense>
-  %old_add = view.atomic.rmw<addi> %one, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense> -> i32
+  %view = buffer.view %generic[%buffer_base] : buffer -> view<1xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense>
+  %old_add = view.atomic.rmw<addi> %increment, %view[0] {ordering = relaxed, scope = device} : i32, view<1xi32, #dense> -> i32
   func.return
 }
 
 // ====
 
 func.def @generic_atomic_cmpxchg_i32_static(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %generic = buffer.assume.memory_space<generic> %input : buffer
-  %view = buffer.view %generic[%zero] : buffer -> view<1xi32, #dense>
+  %view = buffer.view %generic[%buffer_base] : buffer -> view<1xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old_cmpxchg = view.atomic.cmpxchg %expected, %replacement, %view[0] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i32, view<1xi32, #dense> -> i32

--- a/loom/src/loom/test/corpus/source_low/memory_global.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_global.loom-test
@@ -12,9 +12,9 @@ func.def @global_saddr_fallback(%input: buffer, %output: buffer) {
 // ====
 
 func.def @global_f32x7_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<7xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<7xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<7xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<7xf32, #dense>
   %loaded = vector.load %input_view[0] : view<7xf32, #dense> -> vector<7xf32>
   vector.store %loaded, %output_view[0] : vector<7xf32>, view<7xf32, #dense>
   func.return
@@ -23,9 +23,9 @@ func.def @global_f32x7_roundtrip(%input: buffer, %output: buffer) {
 // ====
 
 func.def @global_f32x64_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %loaded = vector.load %input_view[0] : view<64xf32, #dense> -> vector<64xf32>
   vector.store %loaded, %output_view[0] : vector<64xf32>, view<64xf32, #dense>
   func.return
@@ -34,10 +34,10 @@ func.def @global_f32x64_roundtrip(%input: buffer, %output: buffer) {
 // ====
 
 func.def @global_f32x64_add_roundtrip(%lhs: buffer, %rhs: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs[%zero] : buffer -> view<64xf32, #dense>
-  %rhs_view = buffer.view %rhs[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs[%buffer_base] : buffer -> view<64xf32, #dense>
+  %rhs_view = buffer.view %rhs[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %lhs_loaded = vector.load %lhs_view[0] : view<64xf32, #dense> -> vector<64xf32>
   %rhs_loaded = vector.load %rhs_view[0] : view<64xf32, #dense> -> vector<64xf32>
   %sum = vector.addf %lhs_loaded, %rhs_loaded : vector<64xf32>
@@ -48,9 +48,9 @@ func.def @global_f32x64_add_roundtrip(%lhs: buffer, %rhs: buffer, %output: buffe
 // ====
 
 func.def @global_bf16x14_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<14xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<14xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<14xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<14xbf16, #dense>
   %loaded = vector.load %input_view[0] : view<14xbf16, #dense> -> vector<14xbf16>
   vector.store %loaded, %output_view[0] : vector<14xbf16>, view<14xbf16, #dense>
   func.return
@@ -59,9 +59,9 @@ func.def @global_bf16x14_roundtrip(%input: buffer, %output: buffer) {
 // ====
 
 func.def @global_bf16x64_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xbf16, #dense>
   %loaded = vector.load %input_view[0] : view<64xbf16, #dense> -> vector<64xbf16>
   vector.store %loaded, %output_view[0] : vector<64xbf16>, view<64xbf16, #dense>
   func.return
@@ -70,9 +70,9 @@ func.def @global_bf16x64_roundtrip(%input: buffer, %output: buffer) {
 // ====
 
 func.def @global_f16x7_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<7xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<7xf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<7xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<7xf16, #dense>
   %loaded = vector.load %input_view[0] : view<7xf16, #dense> -> vector<7xf16>
   vector.store %loaded, %output_view[0] : vector<7xf16>, view<7xf16, #dense>
   func.return
@@ -81,9 +81,9 @@ func.def @global_f16x7_roundtrip(%input: buffer, %output: buffer) {
 // ====
 
 func.def @global_bf16x7_roundtrip(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<7xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<7xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<7xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<7xbf16, #dense>
   %loaded = vector.load %input_view[0] : view<7xbf16, #dense> -> vector<7xbf16>
   vector.store %loaded, %output_view[0] : vector<7xbf16>, view<7xbf16, #dense>
   func.return
@@ -101,9 +101,9 @@ func.def @global_saddr_dynamic_offset_argument(%input: buffer, %byte_offset: off
 // ====
 
 func.def @global_store_i32_constant_saddr(%output: buffer) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output_global[%buffer_base] : buffer -> view<1xi32, #dense>
   %value = scalar.constant 42 : i32
   view.store %value, %output_view[0] : i32, view<1xi32, #dense>
   func.return
@@ -122,9 +122,9 @@ func.def @global_store_i8_saddr(%output: buffer, %value: i8) {
 // ====
 
 func.def @global_load_i16_saddr(%input: buffer) -> (i16) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_global = buffer.assume.memory_space<global> %input : buffer
-  %input_view = buffer.view %input_global[%zero] : buffer -> view<1xi16, #dense>
+  %input_view = buffer.view %input_global[%buffer_base] : buffer -> view<1xi16, #dense>
   %loaded = view.load %input_view[0] : view<1xi16, #dense> -> i16
   func.return %loaded : i16
 }
@@ -132,9 +132,9 @@ func.def @global_load_i16_saddr(%input: buffer) -> (i16) {
 // ====
 
 func.def @global_store_i16_saddr(%output: buffer, %value: i16) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero] : buffer -> view<1xi16, #dense>
+  %output_view = buffer.view %output_global[%buffer_base] : buffer -> view<1xi16, #dense>
   view.store %value, %output_view[0] : i16, view<1xi16, #dense>
   func.return
 }
@@ -142,8 +142,8 @@ func.def @global_store_i16_saddr(%output: buffer, %value: i16) {
 // ====
 
 func.def @i8x2_buffer_load(%input: buffer) -> (vector<2xi8>) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<2xi8, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<2xi8, #dense>
   %loaded = vector.load %input_view[0] : view<2xi8, #dense> -> vector<2xi8>
   func.return %loaded : vector<2xi8>
 }
@@ -151,9 +151,9 @@ func.def @i8x2_buffer_load(%input: buffer) -> (vector<2xi8>) {
 // ====
 
 func.def @global_load_i8x2_saddr(%input: buffer) -> (vector<2xi8>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_global = buffer.assume.memory_space<global> %input : buffer
-  %input_view = buffer.view %input_global[%zero] : buffer -> view<2xi8, #dense>
+  %input_view = buffer.view %input_global[%buffer_base] : buffer -> view<2xi8, #dense>
   %loaded = vector.load %input_view[0] : view<2xi8, #dense> -> vector<2xi8>
   func.return %loaded : vector<2xi8>
 }
@@ -161,9 +161,9 @@ func.def @global_load_i8x2_saddr(%input: buffer) -> (vector<2xi8>) {
 // ====
 
 func.def @global_store_i8x2_saddr(%output: buffer, %value: vector<2xi8>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero] : buffer -> view<2xi8, #dense>
+  %output_view = buffer.view %output_global[%buffer_base] : buffer -> view<2xi8, #dense>
   vector.store %value, %output_view[0] : vector<2xi8>, view<2xi8, #dense>
   func.return
 }
@@ -171,9 +171,9 @@ func.def @global_store_i8x2_saddr(%output: buffer, %value: vector<2xi8>) {
 // ====
 
 func.def @descriptor_load_i16(%input: buffer) -> (i16) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_descriptor = buffer.assume.memory_space<descriptor> %input : buffer
-  %input_view = buffer.view %input_descriptor[%zero] : buffer -> view<1xi16, #dense>
+  %input_view = buffer.view %input_descriptor[%buffer_base] : buffer -> view<1xi16, #dense>
   %loaded = view.load %input_view[0] : view<1xi16, #dense> -> i16
   func.return %loaded : i16
 }
@@ -181,9 +181,9 @@ func.def @descriptor_load_i16(%input: buffer) -> (i16) {
 // ====
 
 func.def @descriptor_store_i16(%output: buffer, %value: i16) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_descriptor = buffer.assume.memory_space<descriptor> %output : buffer
-  %output_view = buffer.view %output_descriptor[%zero] : buffer -> view<1xi16, #dense>
+  %output_view = buffer.view %output_descriptor[%buffer_base] : buffer -> view<1xi16, #dense>
   view.store %value, %output_view[0] : i16, view<1xi16, #dense>
   func.return
 }
@@ -191,9 +191,9 @@ func.def @descriptor_store_i16(%output: buffer, %value: i16) {
 // ====
 
 func.def @descriptor_load_i8x2(%input: buffer) -> (vector<2xi8>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_descriptor = buffer.assume.memory_space<descriptor> %input : buffer
-  %input_view = buffer.view %input_descriptor[%zero] : buffer -> view<2xi8, #dense>
+  %input_view = buffer.view %input_descriptor[%buffer_base] : buffer -> view<2xi8, #dense>
   %loaded = vector.load %input_view[0] : view<2xi8, #dense> -> vector<2xi8>
   func.return %loaded : vector<2xi8>
 }
@@ -201,9 +201,9 @@ func.def @descriptor_load_i8x2(%input: buffer) -> (vector<2xi8>) {
 // ====
 
 func.def @descriptor_store_i8x2(%output: buffer, %value: vector<2xi8>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %output_descriptor = buffer.assume.memory_space<descriptor> %output : buffer
-  %output_view = buffer.view %output_descriptor[%zero] : buffer -> view<2xi8, #dense>
+  %output_view = buffer.view %output_descriptor[%buffer_base] : buffer -> view<2xi8, #dense>
   vector.store %value, %output_view[0] : vector<2xi8>, view<2xi8, #dense>
   func.return
 }
@@ -211,9 +211,9 @@ func.def @descriptor_store_i8x2(%output: buffer, %value: vector<2xi8>) {
 // ====
 
 func.def @descriptor_b128_off_zero(%input: buffer) -> (vector<4xi32>) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %input_descriptor = buffer.assume.memory_space<descriptor> %input : buffer
-  %input_view = buffer.view %input_descriptor[%zero] : buffer -> view<4xi32, #dense>
+  %input_view = buffer.view %input_descriptor[%buffer_base] : buffer -> view<4xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   func.return %loaded : vector<4xi32>
 }
@@ -301,14 +301,14 @@ func.def @descriptor_dynamic_base_extent_load_f32(%input: buffer, %base_i32: i32
 
 func.def @descriptor_dynamic_extent_store_f32x4(%output: buffer, %value: vector<4xf32>, %row_count_i32: i32, %row_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %first_column = index.constant 0 : index
   %output_descriptor = buffer.assume.memory_space<descriptor> %output : buffer
   %row_count0 = index.cast %row_count_i32 : i32 to index
   %row_count = index.assume %row_count0 [range(%row_count0, 1, 1024)] : index
   %row0 = index.cast %row_i32 : i32 to index
   %row = index.assume %row0 [range(%row0, 0, 1023), lt(%row0, %row_count)] : index
   %output_view = buffer.view %output_descriptor[%base] : buffer -> view<[%row_count]x4xf32, #dense>
-  vector.store %value, %output_view[%row, %zero] : vector<4xf32>, view<[%row_count]x4xf32, #dense>
+  vector.store %value, %output_view[%row, %first_column] : vector<4xf32>, view<[%row_count]x4xf32, #dense>
   func.return
 }
 
@@ -317,14 +317,14 @@ func.def @descriptor_dynamic_extent_store_f32x4(%output: buffer, %value: vector<
 func.def @descriptor_dynamic_base_extent_store_f32x4(%output: buffer, %value: vector<4xf32>, %base_i32: i32, %row_count_i32: i32, %row_i32: i32) {
   %base0 = index.cast %base_i32 : i32 to offset
   %base = index.assume %base0 [range(%base0, 0, 8192), mul(%base0, 16)] : offset
-  %zero = index.constant 0 : index
+  %first_column = index.constant 0 : index
   %output_descriptor = buffer.assume.memory_space<descriptor> %output : buffer
   %row_count0 = index.cast %row_count_i32 : i32 to index
   %row_count = index.assume %row_count0 [range(%row_count0, 1, 512)] : index
   %row0 = index.cast %row_i32 : i32 to index
   %row = index.assume %row0 [range(%row0, 0, 511), lt(%row0, %row_count)] : index
   %output_view = buffer.view %output_descriptor[%base] : buffer -> view<[%row_count]x4xf32, #dense>
-  vector.store %value, %output_view[%row, %zero] : vector<4xf32>, view<[%row_count]x4xf32, #dense>
+  vector.store %value, %output_view[%row, %first_column] : vector<4xf32>, view<[%row_count]x4xf32, #dense>
   func.return
 }
 
@@ -464,8 +464,8 @@ kernel.def target(@target) @i32_dynamic_leading_dim_global_saddr() {
   %columns = index.assume %columns0 [range(%columns0, 32, 2147483647)] : index
   %output_global = buffer.assume.memory_space<global> %output : buffer
   %output_view = buffer.view %output_global[%base] : buffer -> view<2x[%columns]x8xi32, #dense>
-  %zero = scalar.constant 0 : i32
-  view.store %zero, %output_view[%workgroup, %column, 0] : i32, view<2x[%columns]x8xi32, #dense>
+  %cleared_value = scalar.constant 0 : i32
+  view.store %cleared_value, %output_view[%workgroup, %column, 0] : i32, view<2x[%columns]x8xi32, #dense>
   kernel.return
 }
 
@@ -510,11 +510,11 @@ kernel.def target(@target) @i32_readonly_uniform_smem_scalar_branch() {
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<16xi32, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<16xi32, #dense>
   %loaded = view.load %input_view[%workgroup] : view<16xi32, #dense> -> i32
-  %zero = scalar.constant 0 : i32
-  %negative = scalar.cmpi slt, %loaded, %zero : i32
+  %clamp_floor = scalar.constant 0 : i32
+  %negative = scalar.cmpi slt, %loaded, %clamp_floor : i32
   cfg.cond_br %negative, ^then, ^join
 ^then:
-  view.store %zero, %output_view[%workgroup] : i32, view<16xi32, #dense>
+  view.store %clamp_floor, %output_view[%workgroup] : i32, view<16xi32, #dense>
   cfg.br ^join
 ^join:
   kernel.return
@@ -532,7 +532,7 @@ kernel.def target(@target) @i32_readonly_uniform_smem_loop_bound() {
   %base = index.constant 0 : offset
   %start = index.constant 0 : index
   %step = index.constant 1 : index
-  %zero = scalar.constant 0.0 : f32
+  %initial_sum = scalar.constant 0.0 : f32
   %control_noalias, %input_noalias, %output_noalias = buffer.assume.noalias %control, %input, %output : buffer, buffer, buffer
   %control_view = buffer.view %control_noalias[%base] : buffer -> view<1xi32, #dense>
   %input_view = buffer.view %input_noalias[%base] : buffer -> view<128xf32, #dense>
@@ -540,7 +540,7 @@ kernel.def target(@target) @i32_readonly_uniform_smem_loop_bound() {
   %limit_i32 = view.load %control_view[0] : view<1xi32, #dense> -> i32
   %limit0 = index.cast %limit_i32 : i32 to index
   %limit = index.assume %limit0 [range(%limit0, 0, 128)] : index
-  %sum = scf.for %position = [%start to %limit step %step](%current_sum = %zero : f32) -> (f32) {
+  %sum = scf.for %position = [%start to %limit step %step](%current_sum = %initial_sum : f32) -> (f32) {
     %loaded = view.load %input_view[%position] : view<128xf32, #dense> -> f32
     %next_sum = scalar.addf<reassoc|nnan|nsz> %current_sum, %loaded : f32
     scf.yield %next_sum : f32
@@ -592,8 +592,8 @@ kernel.def target(@target) @i32_readonly_uniform_smem_address() {
   %column_i32 = view.load %control_view[0] : view<1xi32, #dense> -> i32
   %column0 = index.cast %column_i32 : i32 to index
   %column = index.assume %column0 [range(%column0, 0, 63)] : index
-  %zero = scalar.constant 0 : i32
-  view.store %zero, %output_view[%column] : i32, view<64xi32, #dense>
+  %cleared_value = scalar.constant 0 : i32
+  view.store %cleared_value, %output_view[%column] : i32, view<64xi32, #dense>
   kernel.return
 }
 
@@ -610,13 +610,14 @@ kernel.def target(@target) @i32_readonly_uniform_smem_guarded_index_address() {
   %output_view = buffer.view %output[%base] : buffer -> view<64xi32, #dense>
   %column_i32 = view.load %control_view[0] : view<1xi32, #dense> -> i32
   %column = index.cast %column_i32 : i32 to index
-  %zero_i32 = scalar.constant 0 : i32
+  %minimum_column = scalar.constant 0 : i32
+  %cleared_value = scalar.constant 0 : i32
   %limit_i32 = scalar.constant 64 : i32
-  %nonnegative = scalar.cmpi sge, %column_i32, %zero_i32 : i32
+  %nonnegative = scalar.cmpi sge, %column_i32, %minimum_column : i32
   %below = scalar.cmpi slt, %column_i32, %limit_i32 : i32
   %guard = scalar.andi %nonnegative, %below : i1
   scf.if %guard {
-    view.store %zero_i32, %output_view[%column] : i32, view<64xi32, #dense>
+    view.store %cleared_value, %output_view[%column] : i32, view<64xi32, #dense>
   }
   kernel.return
 }
@@ -633,16 +634,16 @@ kernel.def target(@target) @i64_readonly_uniform_smem_guarded_index_address() {
   %control_view = buffer.view %control[%base] : buffer -> view<1xi64, #dense>
   %output_view = buffer.view %output[%base] : buffer -> view<64xi32, #dense>
   %column_i64 = view.load %control_view[0] : view<1xi64, #dense> -> i64
-  %zero_i64 = scalar.constant 0 : i64
+  %minimum_column = scalar.constant 0 : i64
   %limit_i64 = scalar.constant 64 : i64
-  %nonnegative = scalar.cmpi sge, %column_i64, %zero_i64 : i64
+  %nonnegative = scalar.cmpi sge, %column_i64, %minimum_column : i64
   %below = scalar.cmpi slt, %column_i64, %limit_i64 : i64
   %guard = scalar.andi %nonnegative, %below : i1
-  %zero_i32 = scalar.constant 0 : i32
+  %cleared_value = scalar.constant 0 : i32
   scf.if %guard {
     %bounded_column_i64 = scalar.assume %column_i64 [range(%column_i64, 0, 63)] : i64
     %column = index.cast %bounded_column_i64 : i64 to index
-    view.store %zero_i32, %output_view[%column] : i32, view<64xi32, #dense>
+    view.store %cleared_value, %output_view[%column] : i32, view<64xi32, #dense>
   }
   kernel.return
 }
@@ -655,9 +656,9 @@ kernel.def @i32_b128() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   %raise = vector.constant 9 : vector<4xi32>
   %raised = vector.addi %loaded, %raise : vector<4xi32>
@@ -675,9 +676,9 @@ kernel.def @f32x8_split_b128() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x8xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x8xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x8xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x8xf32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x8xf32, #dense> -> vector<8xf32>
   %raise = vector.constant 2.0 : vector<8xf32>
   %result = vector.addf %loaded, %raise : vector<8xf32>
@@ -695,9 +696,9 @@ kernel.def @i32_scalar_2d_store() {
 } launch(%input: buffer, %output: buffer) {
   %column = kernel.workitem.id<x> : index
   %row = kernel.workitem.id<y> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4x8xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4x8xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4x8xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4x8xi32, #dense>
   %loaded = vector.load %input_view[%row, %column] : view<4x8xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %output_view[%row, %column] : vector<1xi32>, view<4x8xi32, #dense>
   kernel.return
@@ -729,12 +730,12 @@ kernel.def @i32_dynamic_constant_index() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<64x1x4xi32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<64x1x4xi32, #dense>
-  %loaded = vector.load %input_view[%lane, %zero, 0] : view<64x1x4xi32, #dense> -> vector<4xi32>
-  vector.store %loaded, %output_view[%lane, %zero, 0] : vector<4xi32>, view<64x1x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %singleton_axis = index.constant 0 : index
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x1x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x1x4xi32, #dense>
+  %loaded = vector.load %input_view[%lane, %singleton_axis, 0] : view<64x1x4xi32, #dense> -> vector<4xi32>
+  vector.store %loaded, %output_view[%lane, %singleton_axis, 0] : vector<4xi32>, view<64x1x4xi32, #dense>
   kernel.return
 }
 
@@ -762,9 +763,9 @@ kernel.def @i32_dynamic_view_base() {
 } launch(%control: buffer, %output: buffer, %offset_i32: i32) {
   %base0 = index.cast %offset_i32 : i32 to offset
   %base = index.assume %base0 [range(%base0, 0, 4092), mul(%base0, 4)] : offset
-  %zero = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %control_view = buffer.view %control[%base] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   %loaded = view.load %control_view[2] : view<4xi32, #dense> -> i32
   view.store %loaded, %output_view[0] : i32, view<1xi32, #dense>
   kernel.return
@@ -776,12 +777,13 @@ kernel.def @i32_dynamic_view_base_loaded() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%control: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %header_view = buffer.view %control[%zero] : buffer -> view<8xi32, #dense>
+  %header_base = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
+  %header_view = buffer.view %control[%header_base] : buffer -> view<8xi32, #dense>
   %base_i32 = view.load %header_view[7] : view<8xi32, #dense> -> i32
   %base = index.cast %base_i32 : i32 to offset
   %control_view = buffer.view %control[%base] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xi32, #dense>
   %loaded = view.load %control_view[2] : view<4xi32, #dense> -> i32
   view.store %loaded, %output_view[0] : i32, view<1xi32, #dense>
   kernel.return
@@ -795,9 +797,9 @@ kernel.def @i32x4_dynamic_view_base_b128() {
 } launch(%input: buffer, %output: buffer, %offset_i32: i32) {
   %base0 = index.cast %offset_i32 : i32 to offset
   %base = index.assume %base0 [range(%base0, 0, 4096), mul(%base0, 16)] : offset
-  %zero = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %input_view = buffer.view %input[%base] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xi32, #dense>
+  %output_view = buffer.view %output[%output_base] : buffer -> view<4xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[0] : vector<4xi32>, view<4xi32, #dense>
   kernel.return
@@ -835,7 +837,7 @@ kernel.def @f16_view_scalar() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer, %column_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %first_column = index.constant 0 : index
   %column0 = index.cast %column_i32 : i32 to index
   %column = index.assume %column0 [range(%column0, 0, 7)] : index
   %input_view = buffer.view %input[%base] : buffer -> view<8xf16, #dense>
@@ -843,7 +845,7 @@ kernel.def @f16_view_scalar() {
   %loaded = view.load %input_view[%column] : view<8xf16, #dense> -> f16
   view.store %loaded, %output_view[%column] : f16, view<8xf16, #dense>
   %cleared = scalar.constant 0.0 : f16
-  view.store %cleared, %output_view[%zero] : f16, view<8xf16, #dense>
+  view.store %cleared, %output_view[%first_column] : f16, view<8xf16, #dense>
   kernel.return
 }
 
@@ -854,7 +856,7 @@ kernel.def @bf16_view_scalar() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer, %column_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %first_column = index.constant 0 : index
   %column0 = index.cast %column_i32 : i32 to index
   %column = index.assume %column0 [range(%column0, 0, 7)] : index
   %input_view = buffer.view %input[%base] : buffer -> view<8xbf16, #dense>
@@ -862,7 +864,7 @@ kernel.def @bf16_view_scalar() {
   %loaded = view.load %input_view[%column] : view<8xbf16, #dense> -> bf16
   view.store %loaded, %output_view[%column] : bf16, view<8xbf16, #dense>
   %cleared = scalar.constant 0.0 : bf16
-  view.store %cleared, %output_view[%zero] : bf16, view<8xbf16, #dense>
+  view.store %cleared, %output_view[%first_column] : bf16, view<8xbf16, #dense>
   kernel.return
 }
 
@@ -874,9 +876,9 @@ kernel.def @f16x2_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x2xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x2xf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x2xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x2xf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x2xf16, #dense> -> vector<2xf16>
   vector.store %loaded, %output_view[%lane, 0] : vector<2xf16>, view<64x2xf16, #dense>
   kernel.return
@@ -890,9 +892,9 @@ kernel.def @f16x4_b64() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xf16, #dense> -> vector<4xf16>
   vector.store %loaded, %output_view[%lane, 0] : vector<4xf16>, view<64x4xf16, #dense>
   kernel.return
@@ -906,9 +908,9 @@ kernel.def @bf16x2_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x2xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x2xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x2xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x2xbf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x2xbf16, #dense> -> vector<2xbf16>
   vector.store %loaded, %output_view[%lane, 0] : vector<2xbf16>, view<64x2xbf16, #dense>
   kernel.return
@@ -922,9 +924,9 @@ kernel.def @bf16x4_b64() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xbf16, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xbf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xbf16, #dense> -> vector<4xbf16>
   vector.store %loaded, %output_view[%lane, 0] : vector<4xbf16>, view<64x4xbf16, #dense>
   kernel.return
@@ -1084,7 +1086,8 @@ kernel.def @selected_i32_row_shift_store() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%idx: buffer, %output: buffer, %value: f32, %element_count_i32: i32, %condition_i32: i32) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %inactive_condition = index.constant 0 : index
+  %inactive_element = index.constant 0 : index
   %shift = index.constant 2 : index
   %element_count0 = index.cast %element_count_i32 : i32 to index
   %element_count = index.assume %element_count0 [range(%element_count0, 1, 2147483647)] : index
@@ -1096,8 +1099,8 @@ kernel.def @selected_i32_row_shift_store() {
   %raw = index.shli %row, %shift : index
   %condition0 = index.cast %condition_i32 : i32 to index
   %condition = index.assume %condition0 [range(%condition0, 1, 1)] : index
-  %selected_condition = index.cmp ne, %condition, %zero : index
-  %selected = scf.select %selected_condition, %raw, %zero : index
+  %selected_condition = index.cmp ne, %condition, %inactive_condition : index
+  %selected = scf.select %selected_condition, %raw, %inactive_element : index
   %element = index.assume %selected [range(%selected, 0, 1073741823), lt(%selected, %element_count)] : index
   view.store %value, %output_view[%element] : f32, view<[%element_count]xf32, #dense>
   kernel.return

--- a/loom/src/loom/test/corpus/source_low/memory_global_atomic.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_global_atomic.loom-test
@@ -5,12 +5,12 @@ kernel.def @global_atomic_add_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -21,12 +21,12 @@ kernel.def @global_atomic_add_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
-  %one = scalar.constant 1 : i64
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense>
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
+  %increment = scalar.constant 1 : i64
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense>
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
 }
 
@@ -37,9 +37,9 @@ kernel.def @global_atomic_dynamic_add_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer, %value: i64) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
   %old = view.atomic.rmw<addi> %value, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
 }
@@ -51,12 +51,12 @@ kernel.def @global_atomic_add_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xf32, #dense>
-  %one = scalar.constant 1.0 : f32
-  view.atomic.reduce<addf> %one, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
-  %old = view.atomic.rmw<addf> %one, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xf32, #dense>
+  %increment = scalar.constant 1.0 : f32
+  view.atomic.reduce<addf> %increment, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
+  %old = view.atomic.rmw<addf> %increment, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
   kernel.return
 }
 
@@ -67,9 +67,9 @@ kernel.def @global_atomic_minnum_maxnum_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xf32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xf32, #dense>
   %limit = scalar.constant 1.0 : f32
   view.atomic.reduce<minnumf> %limit, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
   view.atomic.reduce<maxnumf> %limit, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense>
@@ -85,9 +85,9 @@ kernel.def @global_atomic_dynamic_minnum_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer, %value: f32) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xf32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xf32, #dense>
   %old_min = view.atomic.rmw<minnumf> %value, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
   %old_max = view.atomic.rmw<maxnumf> %value, %view[%tid] {ordering = relaxed, scope = device} : f32, view<64xf32, #dense> -> f32
   kernel.return
@@ -100,9 +100,9 @@ kernel.def @global_atomic_bitwise_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %mask = scalar.constant 255 : i32
   view.atomic.reduce<andi> %mask, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
   view.atomic.reduce<ori> %mask, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
@@ -120,9 +120,9 @@ kernel.def @global_atomic_sub_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %delta = scalar.constant 1 : i32
   view.atomic.reduce<subi> %delta, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
   %old_sub = view.atomic.rmw<subi> %delta, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
@@ -136,9 +136,9 @@ kernel.def @global_atomic_exchange_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %value = scalar.constant 7 : i32
   %old = view.atomic.rmw<xchgi> %value, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
@@ -151,9 +151,9 @@ kernel.def @global_atomic_exchange_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
   %value = scalar.constant 7 : i64
   %old = view.atomic.rmw<xchgi> %value, %view[%tid] {ordering = relaxed, scope = device} : i64, view<64xi64, #dense> -> i64
   kernel.return
@@ -166,9 +166,9 @@ kernel.def @global_atomic_cmpxchg_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old = view.atomic.cmpxchg %expected, %replacement, %view[%tid] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i32, view<64xi32, #dense> -> i32
@@ -182,9 +182,9 @@ kernel.def @global_atomic_cmpxchg_i64() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi64, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi64, #dense>
   %expected = scalar.constant 7 : i64
   %replacement = scalar.constant 9 : i64
   %old = view.atomic.cmpxchg %expected, %replacement, %view[%tid] {failure_ordering = relaxed, scope = device, success_ordering = relaxed} : i64, view<64xi64, #dense> -> i64
@@ -198,9 +198,9 @@ kernel.def @global_atomic_minmax_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %limit = scalar.constant 1 : i32
   view.atomic.reduce<minsi> %limit, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>
   view.atomic.reduce<maxsi> %limit, %view[%tid] {ordering = relaxed, scope = device} : i32, view<64xi32, #dense>

--- a/loom/src/loom/test/corpus/source_low/memory_global_atomic_ordering.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_global_atomic_ordering.loom-test
@@ -5,11 +5,11 @@ kernel.def @global_atomic_release_reduce_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = release, scope = device} : i32, view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = release, scope = device} : i32, view<64xi32, #dense>
   kernel.return
 }
 
@@ -20,11 +20,11 @@ kernel.def @global_atomic_acquire_rmw_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = acquire, scope = device} : i32, view<64xi32, #dense> -> i32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = acquire, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -35,11 +35,11 @@ kernel.def @global_atomic_acq_rel_rmw_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  %old = view.atomic.rmw<addi> %one, %view[%tid] {ordering = acq_rel, scope = device} : i32, view<64xi32, #dense> -> i32
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  %old = view.atomic.rmw<addi> %increment, %view[%tid] {ordering = acq_rel, scope = device} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -50,9 +50,9 @@ kernel.def @global_atomic_acq_rel_cmpxchg_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old = view.atomic.cmpxchg %expected, %replacement, %view[%tid] {failure_ordering = acquire, scope = device, success_ordering = acq_rel} : i32, view<64xi32, #dense> -> i32
@@ -66,10 +66,10 @@ kernel.def @global_atomic_seq_cst_reduce_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%input: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %view = buffer.view %global[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %view[%tid] {ordering = seq_cst, scope = device} : i32, view<64xi32, #dense>
+  %view = buffer.view %global[%buffer_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %view[%tid] {ordering = seq_cst, scope = device} : i32, view<64xi32, #dense>
   kernel.return
 }

--- a/loom/src/loom/test/corpus/source_low/memory_prefetch.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_prefetch.loom-test
@@ -15,8 +15,8 @@ kernel.def @prefetch_workgroup_id() {
   kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer) {
   %workgroup = kernel.workgroup.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1025xi32, #dense>
+  %input_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%input_base] : buffer -> view<1025xi32, #dense>
   view.prefetch %input_view[%workgroup] {intent = read, locality = l2} : view<1025xi32, #dense>
   kernel.return
 }
@@ -36,8 +36,8 @@ kernel.def @prefetch_fixed_query_offset() {
   %offset0 = index.add %workgroup_size_x, %workgroup_size_y : index
   %offset1 = index.add %offset0, %subgroup_size : index
   %offset = index.add %offset1, %subgroup_count : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  %input_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%input_base] : buffer -> view<64xi32, #dense>
   view.prefetch %input_view[%offset] {intent = read, locality = l1} : view<64xi32, #dense>
   kernel.return
 }
@@ -50,8 +50,8 @@ kernel.def @prefetch_workitem_dropped() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
+  %input_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%input_base] : buffer -> view<64xi32, #dense>
   view.prefetch %input_view[%lane] {intent = read, locality = l1} : view<64xi32, #dense>
   kernel.return
 }

--- a/loom/src/loom/test/corpus/source_low/memory_scalar_addressing.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_scalar_addressing.loom-test
@@ -16,11 +16,11 @@ func.def @scalar_static_rank2_i32(%input: buffer, %output: buffer) -> (i32) {
 
 func.def @scalar_dynamic_view_base_i32(%input: buffer, %output: buffer, %base: offset) -> (i32) {
   %base_aligned = index.assume %base [range(%base, 0, 4092), mul(%base, 4)] : offset
-  %zero = index.constant 0 : offset
+  %output_base = index.constant 0 : offset
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
   %input_view = buffer.view %input_aligned[%base_aligned] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output_aligned[%zero] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output_aligned[%output_base] : buffer -> view<1xi32, #dense>
   %loaded = view.load %input_view[2] : view<4xi32, #dense> -> i32
   view.store %loaded, %output_view[0] : i32, view<1xi32, #dense>
   func.return %loaded : i32
@@ -44,12 +44,12 @@ func.def @scalar_materialized_view_base_suffix_i32(%input: buffer, %output: buff
 // ====
 
 func.def @scalar_dynamic_index_i32(%input: buffer, %output: buffer, %element: index) -> (i32) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %element_bounded = index.assume %element [range(%element, 0, 7)] : index
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
-  %input_view = buffer.view %input_aligned[%zero] : buffer -> view<8xi32, #dense>
-  %output_view = buffer.view %output_aligned[%zero] : buffer -> view<8xi32, #dense>
+  %input_view = buffer.view %input_aligned[%buffer_base] : buffer -> view<8xi32, #dense>
+  %output_view = buffer.view %output_aligned[%buffer_base] : buffer -> view<8xi32, #dense>
   %loaded = view.load %input_view[%element_bounded] : view<8xi32, #dense> -> i32
   view.store %loaded, %output_view[%element_bounded] : i32, view<8xi32, #dense>
   func.return %loaded : i32
@@ -73,14 +73,14 @@ func.def @scalar_mixed_rank2_i32(%input: buffer, %output: buffer, %base: offset,
 // ====
 
 func.def @scalar_dynamic_stride_i32(%input: buffer, %output: buffer, %columns: index, %row: index, %column: index) -> (i32) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %columns_bounded = index.assume %columns [range(%columns, 1, 8)] : index
   %row_bounded = index.assume %row [range(%row, 0, 3)] : index
   %column_bounded = index.assume %column [range(%column, 0, 7), lt(%column, %columns_bounded)] : index
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
-  %input_view = buffer.view %input_aligned[%zero] : buffer -> view<4x[%columns_bounded]xi32, #dense>
-  %output_view = buffer.view %output_aligned[%zero] : buffer -> view<4x[%columns_bounded]xi32, #dense>
+  %input_view = buffer.view %input_aligned[%buffer_base] : buffer -> view<4x[%columns_bounded]xi32, #dense>
+  %output_view = buffer.view %output_aligned[%buffer_base] : buffer -> view<4x[%columns_bounded]xi32, #dense>
   %loaded = view.load %input_view[%row_bounded, %column_bounded] : view<4x[%columns_bounded]xi32, #dense> -> i32
   view.store %loaded, %output_view[%row_bounded, %column_bounded] : i32, view<4x[%columns_bounded]xi32, #dense>
   func.return %loaded : i32

--- a/loom/src/loom/test/corpus/source_low/memory_workgroup_atomic.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_workgroup_atomic.loom-test
@@ -5,13 +5,13 @@ kernel.def @lds_atomic_add_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
-  %old = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
+  %old = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -21,16 +21,16 @@ kernel.def @lds_atomic_scalar_loop_index_i32() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
-  %zero = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %eight = index.constant 8 : index
-  %one_index = index.constant 1 : index
+  %scratch_base = index.constant 0 : offset
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 8 : index
+  %loop_step = index.constant 1 : index
   %bytes = index.constant 32 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<8xi32, #dense>
-  %one = scalar.constant 1 : i32
-  scf.for %i = [%zero_index to %eight step %one_index] {
-    view.atomic.reduce<addi> %one, %scratch_view[%i] {ordering = relaxed, scope = workgroup} : i32, view<8xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<8xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  scf.for %i = [%loop_begin to %loop_end step %loop_step] {
+    view.atomic.reduce<addi> %increment, %scratch_view[%i] {ordering = relaxed, scope = workgroup} : i32, view<8xi32, #dense>
   }
   kernel.return
 }
@@ -42,16 +42,16 @@ kernel.def @lds_atomic_ordering_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.atomic.reduce<addi> %one, %scratch_view[%tid] {ordering = release, scope = workgroup} : i32, view<64xi32, #dense>
-  %old_acquire = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = acquire, scope = workgroup} : i32, view<64xi32, #dense> -> i32
-  %old_release = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = release, scope = workgroup} : i32, view<64xi32, #dense> -> i32
-  %old_acq_rel = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = acq_rel, scope = workgroup} : i32, view<64xi32, #dense> -> i32
-  %old_seq_cst = view.atomic.rmw<addi> %one, %scratch_view[%tid] {ordering = seq_cst, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  view.atomic.reduce<addi> %increment, %scratch_view[%tid] {ordering = release, scope = workgroup} : i32, view<64xi32, #dense>
+  %old_acquire = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = acquire, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %old_release = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = release, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %old_acq_rel = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = acq_rel, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %old_seq_cst = view.atomic.rmw<addi> %increment, %scratch_view[%tid] {ordering = seq_cst, scope = workgroup} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }
 
@@ -62,13 +62,13 @@ kernel.def @lds_atomic_add_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xf32, #dense>
-  %one = scalar.constant 1.0 : f32
-  view.atomic.reduce<addf> %one, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense>
-  %old = view.atomic.rmw<addf> %one, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense> -> f32
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xf32, #dense>
+  %increment = scalar.constant 1.0 : f32
+  view.atomic.reduce<addf> %increment, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense>
+  %old = view.atomic.rmw<addf> %increment, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense> -> f32
   kernel.return
 }
 
@@ -79,10 +79,10 @@ kernel.def @lds_atomic_minnum_maxnum_f32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xf32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xf32, #dense>
   %limit = scalar.constant 1.0 : f32
   view.atomic.reduce<minnumf> %limit, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense>
   view.atomic.reduce<maxnumf> %limit, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : f32, view<64xf32, #dense>
@@ -98,10 +98,10 @@ kernel.def @lds_atomic_bitwise_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %mask = scalar.constant 255 : i32
   view.atomic.reduce<andi> %mask, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
   view.atomic.reduce<ori> %mask, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
@@ -119,10 +119,10 @@ kernel.def @lds_atomic_sub_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %delta = scalar.constant 1 : i32
   view.atomic.reduce<subi> %delta, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
   %old_sub = view.atomic.rmw<subi> %delta, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
@@ -136,10 +136,10 @@ kernel.def @lds_atomic_exchange_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %value = scalar.constant 7 : i32
   %old = view.atomic.rmw<xchgi> %value, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
   kernel.return
@@ -152,10 +152,10 @@ kernel.def @lds_atomic_cmpxchg_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %expected = scalar.constant 7 : i32
   %replacement = scalar.constant 9 : i32
   %old = view.atomic.cmpxchg %expected, %replacement, %scratch_view[%tid] {failure_ordering = relaxed, scope = workgroup, success_ordering = relaxed} : i32, view<64xi32, #dense> -> i32
@@ -169,10 +169,10 @@ kernel.def @lds_atomic_minmax_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
   %limit = scalar.constant 1 : i32
   view.atomic.reduce<minsi> %limit, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
   view.atomic.reduce<maxsi> %limit, %scratch_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
@@ -192,16 +192,17 @@ kernel.def @lds_atomic_second_alloca_i32() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch() {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %first_bytes = index.constant 64 : offset
   %second_bytes = index.constant 256 : offset
   %first_scratch = buffer.alloca %first_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %second_scratch = buffer.alloca %second_bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %first_view = buffer.view %first_scratch[%zero] : buffer -> view<16xi32, #dense>
-  %second_view = buffer.view %second_scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = scalar.constant 1 : i32
-  view.store %one, %first_view[%tid] : i32, view<16xi32, #dense>
-  view.atomic.reduce<addi> %one, %second_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
-  %old = view.atomic.rmw<addi> %one, %second_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
+  %first_view = buffer.view %first_scratch[%scratch_base] : buffer -> view<16xi32, #dense>
+  %second_view = buffer.view %second_scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %initial_value = scalar.constant 1 : i32
+  %increment = scalar.constant 1 : i32
+  view.store %initial_value, %first_view[%tid] : i32, view<16xi32, #dense>
+  view.atomic.reduce<addi> %increment, %second_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense>
+  %old = view.atomic.rmw<addi> %increment, %second_view[%tid] {ordering = relaxed, scope = workgroup} : i32, view<64xi32, #dense> -> i32
   kernel.return
 }

--- a/loom/src/loom/test/corpus/source_low/memory_workgroup_b128.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_workgroup_b128.loom-test
@@ -6,12 +6,12 @@ kernel.def @lds_b128_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
@@ -27,12 +27,12 @@ kernel.def @lds_b128_single_lane_extract() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
@@ -49,12 +49,12 @@ kernel.def @lds_b128_xor_swizzle_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %shift = index.constant 4 : index
   %shifted = index.shrui %lane, %shift : index
   %mask = index.constant 3 : index
@@ -75,13 +75,13 @@ kernel.def @lds_b128_large_static_offset_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %large = index.constant 1024 : offset
   %bytes = index.constant 4096 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %scratch_view = buffer.view %scratch[%large] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xi32>, view<64x4xi32, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
@@ -97,15 +97,15 @@ kernel.def @lds_b128_split_second_alloca_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %first_bytes = index.constant 64 : offset
   %second_bytes = index.constant 2048 : offset
   %first = buffer.alloca %first_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %second = buffer.alloca %second_bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %first_view = buffer.view %first[%zero] : buffer -> view<16xi32, #dense>
-  %second_view = buffer.view %second[%zero] : buffer -> view<64x8xi32, #dense>
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x8xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x8xi32, #dense>
+  %first_view = buffer.view %first[%buffer_base] : buffer -> view<16xi32, #dense>
+  %second_view = buffer.view %second[%buffer_base] : buffer -> view<64x8xi32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x8xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x8xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x8xi32, #dense> -> vector<8xi32>
   vector.store %loaded, %second_view[%lane, 0] : vector<8xi32>, view<64x8xi32, #dense>
   %roundtrip = vector.load %second_view[%lane, 0] : view<64x8xi32, #dense> -> vector<8xi32>

--- a/loom/src/loom/test/corpus/source_low/memory_workgroup_indexed.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_workgroup_indexed.loom-test
@@ -6,12 +6,12 @@ kernel.def @wave_sized_workgroup_memory_workitem_x_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   %loaded = vector.load %scratch_view[%lane] : view<32xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   kernel.return
@@ -25,12 +25,12 @@ kernel.def @wave_sized_workgroup_memory_workitem_x_i8x4() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi8, #dense>
-  %one = vector.constant 1 : vector<4xi8>
-  vector.store %one, %scratch_view[%lane] : vector<4xi8>, view<64xi8, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi8, #dense>
+  %stored_value = vector.constant 1 : vector<4xi8>
+  vector.store %stored_value, %scratch_view[%lane] : vector<4xi8>, view<64xi8, #dense>
   %loaded = vector.load %scratch_view[%lane] : view<64xi8, #dense> -> vector<4xi8>
   vector.store %loaded, %scratch_view[%lane] : vector<4xi8>, view<64xi8, #dense>
   kernel.return
@@ -44,12 +44,12 @@ kernel.def @cross_wave_workgroup_memory_workitem_x_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
   %loaded = vector.load %scratch_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
@@ -62,16 +62,16 @@ kernel.def @workgroup_memory_scalar_loop_index_b32() {
   %workgroup_size = index.constant 8 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 32 : offset
-  %zero_index = index.constant 0 : index
-  %eight = index.constant 8 : index
-  %one_index = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 8 : index
+  %loop_step = index.constant 1 : index
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<8xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  scf.for %i = [%zero_index to %eight step %one_index] {
-    vector.store %one, %scratch_view[%i] : vector<1xi32>, view<8xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<8xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  scf.for %i = [%loop_begin to %loop_end step %loop_step] {
+    vector.store %stored_value, %scratch_view[%i] : vector<1xi32>, view<8xi32, #dense>
     %loaded = vector.load %scratch_view[%i] : view<8xi32, #dense> -> vector<1xi32>
     vector.store %loaded, %scratch_view[%i] : vector<1xi32>, view<8xi32, #dense>
   }
@@ -86,14 +86,14 @@ kernel.def @wave_sized_workgroup_memory_workitem_x_b32_static_offset() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %four = index.constant 4 : index
-  %element_index = index.add %lane, %four : index
-  %zero = index.constant 0 : offset
+  %element_offset = index.constant 4 : index
+  %element_index = index.add %lane, %element_offset : index
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 160 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<40xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<40xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
   %loaded = vector.load %scratch_view[%element_index] : view<40xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
   kernel.return
@@ -107,16 +107,16 @@ kernel.def @wave_sized_workgroup_memory_second_allocation_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %first_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %second_scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %first_view = buffer.view %first_scratch[%zero] : buffer -> view<32xi32, #dense>
-  %second_view = buffer.view %second_scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  %two = vector.constant 2 : vector<1xi32>
-  vector.store %one, %first_view[%lane] : vector<1xi32>, view<32xi32, #dense>
-  vector.store %two, %second_view[%lane] : vector<1xi32>, view<32xi32, #dense>
+  %first_view = buffer.view %first_scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %second_view = buffer.view %second_scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %first_value = vector.constant 1 : vector<1xi32>
+  %second_value = vector.constant 2 : vector<1xi32>
+  vector.store %first_value, %first_view[%lane] : vector<1xi32>, view<32xi32, #dense>
+  vector.store %second_value, %second_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   %loaded = vector.load %second_view[%lane] : view<32xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %first_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   kernel.return
@@ -130,14 +130,14 @@ kernel.def @wave_sized_workgroup_memory_view_base_and_element_offset_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %four = index.constant 4 : index
-  %element_index = index.add %lane, %four : index
+  %element_offset = index.constant 4 : index
+  %element_index = index.add %lane, %element_offset : index
   %base = index.constant 32 : offset
   %bytes = index.constant 224 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch_view = buffer.view %scratch[%base] : buffer -> view<40xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
   %loaded = vector.load %scratch_view[%element_index] : view<40xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%element_index] : vector<1xi32>, view<40xi32, #dense>
   kernel.return
@@ -151,15 +151,15 @@ kernel.def @wave_sized_workgroup_memory_interleaved_addtid_and_vaddr_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %two = index.constant 2 : index
-  %scaled_lane = index.mul %lane, %two : index
-  %zero = index.constant 0 : offset
+  %lane_scale = index.constant 2 : index
+  %scaled_lane = index.mul %lane, %lane_scale : index
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %lane_value = vector.constant 1 : vector<1xi32>
   %other = vector.constant 2 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
+  vector.store %lane_value, %scratch_view[%lane] : vector<1xi32>, view<64xi32, #dense>
   vector.store %other, %scratch_view[%scaled_lane] : vector<1xi32>, view<64xi32, #dense>
   %loaded = vector.load %scratch_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%scaled_lane] : vector<1xi32>, view<64xi32, #dense>
@@ -176,12 +176,12 @@ kernel.def @wave_sized_workgroup_memory_roundtrip_lane_cast_b32() {
   %lane = kernel.workitem.id<x> : index
   %lane_i32 = index.cast %lane : index to i32
   %lane_index = index.cast %lane_i32 : i32 to index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane_index] : vector<1xi32>, view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%lane_index] : vector<1xi32>, view<32xi32, #dense>
   %loaded = vector.load %scratch_view[%lane_index] : view<32xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%lane_index] : vector<1xi32>, view<32xi32, #dense>
   kernel.return
@@ -198,12 +198,12 @@ kernel.def @wave_sized_workgroup_memory_select_same_lane_b32() {
   %limit = index.constant 32 : index
   %inside = index.cmp ult, %lane, %limit : index
   %selected_lane = scf.select %inside, %lane, %lane : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%selected_lane] : vector<1xi32>, view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%selected_lane] : vector<1xi32>, view<32xi32, #dense>
   %loaded = vector.load %scratch_view[%selected_lane] : view<32xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%selected_lane] : vector<1xi32>, view<32xi32, #dense>
   kernel.return
@@ -217,17 +217,17 @@ kernel.def @wave_sized_workgroup_memory_select_scaled_lane_b32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   %lane = kernel.workitem.id<x> : index
-  %two = index.constant 2 : index
-  %scaled_lane = index.mul %lane, %two : index
+  %lane_scale = index.constant 2 : index
+  %scaled_lane = index.mul %lane, %lane_scale : index
   %limit = index.constant 16 : index
   %inside = index.cmp ult, %lane, %limit : index
   %element_index = scf.select %inside, %lane, %scaled_lane : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 256 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%element_index] : vector<1xi32>, view<64xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<64xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%element_index] : vector<1xi32>, view<64xi32, #dense>
   %loaded = vector.load %scratch_view[%element_index] : view<64xi32, #dense> -> vector<1xi32>
   vector.store %loaded, %scratch_view[%element_index] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
@@ -243,10 +243,10 @@ kernel.def @wave_sized_workgroup_memory_guarded_lane_store_b32() {
   %lane = kernel.workitem.id<x> : index
   %limit = index.constant 16 : index
   %inside = index.cmp ult, %lane, %limit : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
   %initial = vector.constant 0 : vector<1xi32>
   %replacement = vector.constant 1 : vector<1xi32>
   vector.store %initial, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
@@ -268,12 +268,12 @@ kernel.def @wave_sized_workgroup_memory_guarded_lane_load_b32() {
   %lane = kernel.workitem.id<x> : index
   %limit = index.constant 16 : index
   %inside = index.cmp ult, %lane, %limit : index
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 128 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<32xi32, #dense>
-  %one = vector.constant 1 : vector<1xi32>
-  vector.store %one, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<32xi32, #dense>
+  %stored_value = vector.constant 1 : vector<1xi32>
+  vector.store %stored_value, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>
   scf.if %inside {
     %loaded = vector.load %scratch_view[%lane] : view<32xi32, #dense> -> vector<1xi32>
     vector.store %loaded, %scratch_view[%lane] : vector<1xi32>, view<32xi32, #dense>

--- a/loom/src/loom/test/corpus/source_low/memory_workgroup_packed16.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_workgroup_packed16.loom-test
@@ -6,12 +6,12 @@ kernel.def @lds_f16x4_b64_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 512 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 8, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xf16, #dense> -> vector<4xf16>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xf16>, view<64x4xf16, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xf16, #dense> -> vector<4xf16>
@@ -27,12 +27,12 @@ kernel.def @lds_f16x8_b128_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x8xf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x8xf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x8xf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x8xf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x8xf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x8xf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x8xf16, #dense> -> vector<8xf16>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<8xf16>, view<64x8xf16, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x8xf16, #dense> -> vector<8xf16>
@@ -82,12 +82,12 @@ kernel.def @lds_bf16x4_b64_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 512 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 8, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xbf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x4xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xbf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x4xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xbf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xbf16, #dense> -> vector<4xbf16>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<4xbf16>, view<64x4xbf16, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x4xbf16, #dense> -> vector<4xbf16>
@@ -103,12 +103,12 @@ kernel.def @lds_bf16x8_b128_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x8xbf16, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x8xbf16, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x8xbf16, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x8xbf16, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x8xbf16, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x8xbf16, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x8xbf16, #dense> -> vector<8xbf16>
   vector.store %loaded, %scratch_view[%lane, 0] : vector<8xbf16>, view<64x8xbf16, #dense>
   %roundtrip = vector.load %scratch_view[%lane, 0] : view<64x8xbf16, #dense> -> vector<8xbf16>

--- a/loom/src/loom/test/corpus/source_low/memory_workgroup_scalar_addressing.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_workgroup_scalar_addressing.loom-test
@@ -32,12 +32,12 @@ func.def @workgroup_dynamic_base_and_index_i32(%value: i32, %base_element: index
 
 func.def @workgroup_dynamic_stride_rank2_i32(%value: i32, %column_count: index, %row: index, %column: index) -> (i32) {
   %byte_length = index.constant 128 : offset
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %column_count_bounded = index.assume %column_count [range(%column_count, 1, 8)] : index
   %row_bounded = index.assume %row [range(%row, 0, 3)] : index
   %column_bounded = index.assume %column [range(%column, 0, 7), lt(%column, %column_count_bounded)] : index
   %scratch = buffer.alloca %byte_length {base_alignment = 4, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<4x[%column_count_bounded]xi32, #dense>
+  %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<4x[%column_count_bounded]xi32, #dense>
   view.store %value, %scratch_view[%row_bounded, %column_bounded] : i32, view<4x[%column_count_bounded]xi32, #dense>
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
   %loaded = view.load %scratch_view[%row_bounded, %column_bounded] : view<4x[%column_count_bounded]xi32, #dense> -> i32
@@ -64,15 +64,15 @@ func.def @workgroup_subview_refine_i32(%value: i32, %element: index) -> (i32) {
 
 func.def @workgroup_integer_scalar_widths(%value_i8: i8, %value_i16: i16, %value_i32: i32, %value_i64: i64) -> (i8, i16, i32, i64) {
   %byte_length = index.constant 16 : offset
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %scratch_i8 = buffer.alloca %byte_length {base_alignment = 1, memory_space = workgroup} : buffer
   %scratch_i16 = buffer.alloca %byte_length {base_alignment = 2, memory_space = workgroup} : buffer
   %scratch_i32 = buffer.alloca %byte_length {base_alignment = 4, memory_space = workgroup} : buffer
   %scratch_i64 = buffer.alloca %byte_length {base_alignment = 8, memory_space = workgroup} : buffer
-  %view_i8 = buffer.view %scratch_i8[%zero] : buffer -> view<2xi8, #dense>
-  %view_i16 = buffer.view %scratch_i16[%zero] : buffer -> view<2xi16, #dense>
-  %view_i32 = buffer.view %scratch_i32[%zero] : buffer -> view<2xi32, #dense>
-  %view_i64 = buffer.view %scratch_i64[%zero] : buffer -> view<2xi64, #dense>
+  %view_i8 = buffer.view %scratch_i8[%scratch_base] : buffer -> view<2xi8, #dense>
+  %view_i16 = buffer.view %scratch_i16[%scratch_base] : buffer -> view<2xi16, #dense>
+  %view_i32 = buffer.view %scratch_i32[%scratch_base] : buffer -> view<2xi32, #dense>
+  %view_i64 = buffer.view %scratch_i64[%scratch_base] : buffer -> view<2xi64, #dense>
   view.store %value_i8, %view_i8[1] : i8, view<2xi8, #dense>
   view.store %value_i16, %view_i16[1] : i16, view<2xi16, #dense>
   view.store %value_i32, %view_i32[1] : i32, view<2xi32, #dense>
@@ -89,15 +89,15 @@ func.def @workgroup_integer_scalar_widths(%value_i8: i8, %value_i16: i16, %value
 
 func.def @workgroup_float_scalar_widths(%value_f16: f16, %value_bf16: bf16, %value_f32: f32, %value_f64: f64) -> (f16, bf16, f32, f64) {
   %byte_length = index.constant 16 : offset
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %scratch_f16 = buffer.alloca %byte_length {base_alignment = 2, memory_space = workgroup} : buffer
   %scratch_bf16 = buffer.alloca %byte_length {base_alignment = 2, memory_space = workgroup} : buffer
   %scratch_f32 = buffer.alloca %byte_length {base_alignment = 4, memory_space = workgroup} : buffer
   %scratch_f64 = buffer.alloca %byte_length {base_alignment = 8, memory_space = workgroup} : buffer
-  %view_f16 = buffer.view %scratch_f16[%zero] : buffer -> view<2xf16, #dense>
-  %view_bf16 = buffer.view %scratch_bf16[%zero] : buffer -> view<2xbf16, #dense>
-  %view_f32 = buffer.view %scratch_f32[%zero] : buffer -> view<2xf32, #dense>
-  %view_f64 = buffer.view %scratch_f64[%zero] : buffer -> view<2xf64, #dense>
+  %view_f16 = buffer.view %scratch_f16[%scratch_base] : buffer -> view<2xf16, #dense>
+  %view_bf16 = buffer.view %scratch_bf16[%scratch_base] : buffer -> view<2xbf16, #dense>
+  %view_f32 = buffer.view %scratch_f32[%scratch_base] : buffer -> view<2xf32, #dense>
+  %view_f64 = buffer.view %scratch_f64[%scratch_base] : buffer -> view<2xf64, #dense>
   view.store %value_f16, %view_f16[1] : f16, view<2xf16, #dense>
   view.store %value_bf16, %view_bf16[1] : bf16, view<2xbf16, #dense>
   view.store %value_f32, %view_f32[1] : f32, view<2xf32, #dense>

--- a/loom/src/loom/test/corpus/source_low/ml_attention.loom-test
+++ b/loom/src/loom/test/corpus/source_low/ml_attention.loom-test
@@ -23,12 +23,12 @@ func.def @online_softmax_update(%old_max: f32, %old_sum: f32, %old_acc: vector<4
 // The direct result-to-LHS repack avoids a workgroup-memory round trip while
 // preserving the same BF16 operand contract expected by the second MMA.
 kernel.def @attention_probability_value_mma_repack() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%probabilities: vector<8xf32>, %values: vector<16xbf16>, %init_accumulator: vector<8xf32>, %output_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %output_origin = index.constant 0 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -40,7 +40,7 @@ kernel.def @attention_probability_value_mma_repack() {
   %rhs = vector.fragment<rhs> %values shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %init_accumulator shape [%m, %n] : vector<8xf32>
   %output = vector.mma %lhs, %rhs, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
-  vector.fragment.store<result> %output, %output_view[%zero, %zero] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %output, %output_view[%output_origin, %output_origin] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 
@@ -49,13 +49,15 @@ kernel.def @attention_probability_value_mma_repack() {
 // Online attention can keep a matrix accumulator payload live across the
 // probability-scratch barrier instead of materializing it through LDS.
 kernel.def @attention_loop_carried_accumulator_barrier() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values0: vector<16xbf16>, %rhs_values1: vector<16xbf16>, %init_accumulator: vector<8xf32>, %output_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
+  %output_origin = index.constant 0 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -65,7 +67,7 @@ kernel.def @attention_loop_carried_accumulator_barrier() {
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xbf16>
   %rhs0 = vector.fragment<rhs> %rhs_values0 shape [%k, %n] : vector<16xbf16>
   %rhs1 = vector.fragment<rhs> %rhs_values1 shape [%k, %n] : vector<16xbf16>
-  %carried = scf.for %tile = [%zero to %one step %one](%accumulator = %init_accumulator : vector<8xf32>) -> (vector<8xf32>) {
+  %carried = scf.for %tile = [%loop_begin to %loop_end step %loop_step](%accumulator = %init_accumulator : vector<8xf32>) -> (vector<8xf32>) {
     %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
     %next = vector.mma %lhs, %rhs0, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
@@ -73,7 +75,7 @@ kernel.def @attention_loop_carried_accumulator_barrier() {
   }
   %carried_init = vector.fragment<init> %carried shape [%m, %n] : vector<8xf32>
   %output = vector.mma %lhs, %rhs1, %carried_init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
-  vector.fragment.store<result> %output, %output_view[%zero, %zero] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %output, %output_view[%output_origin, %output_origin] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 
@@ -82,25 +84,27 @@ kernel.def @attention_loop_carried_accumulator_barrier() {
 // A peeled tail block in online attention applies one final score/value tile to
 // the loop-carried accumulator when the dynamic sequence has a tail tile.
 kernel.def @attention_tail_peel_accumulator_merge() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values0: vector<16xbf16>, %rhs_values1: vector<16xbf16>, %init_accumulator: vector<8xf32>, %tail_tile_count: i32, %output_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %zero_i32 = scalar.constant 0 : i32
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
+  %output_origin = index.constant 0 : index
+  %no_tail_tiles = scalar.constant 0 : i32
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
-  %has_tail_tile = scalar.cmpi ne, %tail_tile_count, %zero_i32 : i32
+  %has_tail_tile = scalar.cmpi ne, %tail_tile_count, %no_tail_tiles : i32
   %output_global = buffer.assume.memory_space<global> %output_buffer : buffer
   %output_aligned = buffer.assume.alignment %output_global {minimum_alignment = 16} : buffer
   %output_view = buffer.view %output_aligned[%base] : buffer -> view<16x16xf32, #dense>
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xbf16>
   %rhs0 = vector.fragment<rhs> %rhs_values0 shape [%k, %n] : vector<16xbf16>
   %rhs1 = vector.fragment<rhs> %rhs_values1 shape [%k, %n] : vector<16xbf16>
-  %carried = scf.for %tile = [%zero to %one step %one](%accumulator = %init_accumulator : vector<8xf32>) -> (vector<8xf32>) {
+  %carried = scf.for %tile = [%loop_begin to %loop_end step %loop_step](%accumulator = %init_accumulator : vector<8xf32>) -> (vector<8xf32>) {
     %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
     %next = vector.mma %lhs, %rhs0, %init : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     scf.yield %next : vector<8xf32>
@@ -112,7 +116,7 @@ kernel.def @attention_tail_peel_accumulator_merge() {
   } else {
     scf.yield %carried : vector<8xf32>
   }
-  vector.fragment.store<result> %output_accumulator, %output_view[%zero, %zero] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %output_accumulator, %output_view[%output_origin, %output_origin] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
   kernel.return
 }
 
@@ -129,10 +133,10 @@ func.def @tail_masked_score_block(%scores: vector<4xf32>, %valid_count: i32) -> 
   %sentinels = vector.splat %negative_large : vector<4xf32>
   %masked_scores = vector.select %valid, %scores, %sentinels : vector<4xf32>
   %block_max = vector.reduce<maxnumf, reassoc|nnan|nsz> %masked_scores, %negative_large : vector<4xf32>, f32
-  %zero = scalar.constant 0.0 : f32
-  %zeros = vector.splat %zero : vector<4xf32>
-  %sum_scores = vector.select %valid, %scores, %zeros : vector<4xf32>
-  %block_sum = vector.reduce<addf, reassoc|nnan|nsz> %sum_scores, %zero : vector<4xf32>, f32
+  %sum_identity = scalar.constant 0.0 : f32
+  %sum_identity_vector = vector.splat %sum_identity : vector<4xf32>
+  %sum_scores = vector.select %valid, %scores, %sum_identity_vector : vector<4xf32>
+  %block_sum = vector.reduce<addf, reassoc|nnan|nsz> %sum_scores, %sum_identity : vector<4xf32>, f32
   func.return %block_max, %block_sum : f32, f32
 }
 

--- a/loom/src/loom/test/corpus/source_low/ml_contraction.loom-test
+++ b/loom/src/loom/test/corpus/source_low/ml_contraction.loom-test
@@ -61,13 +61,13 @@ kernel.def @workgroup_cached_dot4i_u8s8_tile() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output_buffer: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %bytes = index.constant 1024 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64x16xi8, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64x16xi8, #dense>
-  %scratch_view = buffer.view %scratch[%zero] : buffer -> view<64x16xi8, #dense>
-  %output_view = buffer.view %output_buffer[%zero] : buffer -> view<64x4xi32, #dense>
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64x16xi8, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64x16xi8, #dense>
+  %scratch_view = buffer.view %scratch[%buffer_base] : buffer -> view<64x16xi8, #dense>
+  %output_view = buffer.view %output_buffer[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %lhs = vector.load %lhs_view[%lane, 0] : view<64x16xi8, #dense> -> vector<16xi8>
   vector.store %lhs, %scratch_view[%lane, 0] : vector<16xi8>, view<64x16xi8, #dense>
   %lhs_cached = vector.load %scratch_view[%lane, 0] : view<64x16xi8, #dense> -> vector<16xi8>

--- a/loom/src/loom/test/corpus/source_low/numeric_conversion.loom-test
+++ b/loom/src/loom/test/corpus/source_low/numeric_conversion.loom-test
@@ -662,13 +662,13 @@ kernel.def @scalar_bitcast_direct_i32_arg_f32_store() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%output: buffer, %scale_bits: i32) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xf32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_element = index.constant 0 : index
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xf32, #dense>
   %scale = scalar.bitcast %scale_bits : i32 to f32
   %unit = scalar.constant 1.0 : f32
   %scaled = scalar.mulf %unit, %scale : f32
-  view.store %scaled, %output_view[%zero_index] : f32, view<1xf32, #dense>
+  view.store %scaled, %output_view[%output_element] : f32, view<1xf32, #dense>
   kernel.return
 }
 
@@ -695,17 +695,19 @@ kernel.def @scalar_bitcast_lane_byte_decode_select_tree_store() {
   %exp = scalar.shrui %exp_bits, %exp_shift : i32
   %mantissa_mask = scalar.constant 7 : i32
   %mantissa = scalar.andi %wide, %mantissa_mask : i32
-  %zero = scalar.constant 0 : i32
+  %absent_mantissa_bit = scalar.constant 0 : i32
+  %base_mantissa_shift = scalar.constant 0 : i32
+  %zero_exponent = scalar.constant 0 : i32
   %mantissa_bit1_mask = scalar.constant 2 : i32
   %mantissa_bit1 = scalar.andi %mantissa, %mantissa_bit1_mask : i32
-  %has_mantissa_bit1 = scalar.cmpi ne, %mantissa_bit1, %zero : i32
-  %one = scalar.constant 1 : i32
-  %shift0 = scf.select %has_mantissa_bit1, %one, %zero : i32
+  %has_mantissa_bit1 = scalar.cmpi ne, %mantissa_bit1, %absent_mantissa_bit : i32
+  %low_mantissa_shift = scalar.constant 1 : i32
+  %shift0 = scf.select %has_mantissa_bit1, %low_mantissa_shift, %base_mantissa_shift : i32
   %mantissa_bit2_mask = scalar.constant 4 : i32
   %mantissa_bit2 = scalar.andi %mantissa, %mantissa_bit2_mask : i32
-  %has_mantissa_bit2 = scalar.cmpi ne, %mantissa_bit2, %zero : i32
-  %two = scalar.constant 2 : i32
-  %selected_shift = scf.select %has_mantissa_bit2, %two, %shift0 : i32
+  %has_mantissa_bit2 = scalar.cmpi ne, %mantissa_bit2, %absent_mantissa_bit : i32
+  %high_mantissa_shift = scalar.constant 2 : i32
+  %selected_shift = scf.select %has_mantissa_bit2, %high_mantissa_shift, %shift0 : i32
   %bias = scalar.constant 118 : i32
   %biased_exp = scalar.addi %selected_shift, %bias : i32
   %f32_exp_shift = scalar.constant 23 : i32
@@ -717,7 +719,7 @@ kernel.def @scalar_bitcast_lane_byte_decode_select_tree_store() {
   %normal_head = scalar.ori %sign_bits, %f32_exp : i32
   %normal_bits = scalar.ori %normal_head, %f32_mantissa : i32
   %subnormal = scf.select %has_mantissa_bit2, %normal_bits, %sign_bits : i32
-  %is_zero_exp = scalar.cmpi eq, %exp, %zero : i32
+  %is_zero_exp = scalar.cmpi eq, %exp, %zero_exponent : i32
   %regular_exp_bias = scalar.constant 120 : i32
   %regular_exp = scalar.addi %exp, %regular_exp_bias : i32
   %regular_exp_bits = scalar.shli %regular_exp, %f32_exp_shift : i32

--- a/loom/src/loom/test/corpus/source_low/numeric_f32_memory.loom-test
+++ b/loom/src/loom/test/corpus/source_low/numeric_f32_memory.loom-test
@@ -6,10 +6,10 @@ kernel.def @f32_arith() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %lhs = vector.load %lhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %rhs = vector.load %rhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %sum = vector.addf %lhs, %rhs : vector<1xf32>
@@ -28,10 +28,10 @@ kernel.def @f32_fma() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %lhs = vector.load %lhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %rhs = vector.load %rhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %bias = vector.constant 0.5 : vector<1xf32>
@@ -49,10 +49,10 @@ kernel.def @f32_arcp_div() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64x4xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64x4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf32, #dense>
   %lhs = vector.load %lhs_view[%lane, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %rhs = vector.load %rhs_view[%lane, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %quotient = vector.divf<nnan|ninf|nsz|arcp> %lhs, %rhs : vector<4xf32>
@@ -95,19 +95,19 @@ func.def @f32_vector_arcp_literal_dividend(%values: vector<4xf32>) -> (vector<4x
 // ====
 
 func.def @f32_guarded_arcp_reciprocal_scale(%amax: f32) -> (f32) {
-  %zero = scalar.constant 0.0 : f32
-  %one = scalar.constant 1.0 : f32
-  %one_over_127 = scalar.constant 0.007874015700000001 : f32
-  %scale = scalar.constant 127.0 : f32
-  %d = scalar.mulf<nnan|ninf|nsz|arcp> %amax, %one_over_127 : f32
+  %fallback_scale = scalar.constant 0.0 : f32
+  %reciprocal_numerator = scalar.constant 1.0 : f32
+  %inverse_scale_limit = scalar.constant 0.007874015700000001 : f32
+  %scale_limit = scalar.constant 127.0 : f32
+  %d = scalar.mulf<nnan|ninf|nsz|arcp> %amax, %inverse_scale_limit : f32
   %zero_for_cmp = scalar.subf %d, %d : f32
   %nonzero = scalar.cmpf one, %d, %zero_for_cmp : f32
   %d_inv = scf.if %nonzero -> (f32) {
-    %amax_inv = scalar.divf<nnan|ninf|nsz|arcp> %one, %amax : f32
-    %candidate = scalar.mulf<nnan|ninf|nsz|arcp> %amax_inv, %scale : f32
+    %amax_inv = scalar.divf<nnan|ninf|nsz|arcp> %reciprocal_numerator, %amax : f32
+    %candidate = scalar.mulf<nnan|ninf|nsz|arcp> %amax_inv, %scale_limit : f32
     scf.yield %candidate : f32
   } else {
-    scf.yield %zero : f32
+    scf.yield %fallback_scale : f32
   }
   func.return %d_inv : f32
 }
@@ -120,10 +120,10 @@ kernel.def @f32_exact_vector_div() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xf32, #dense>
   %lhs = vector.load %lhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %rhs = vector.load %rhs_view[%lane] : view<64xf32, #dense> -> vector<1xf32>
   %quotient = vector.divf %lhs, %rhs : vector<1xf32>
@@ -154,10 +154,10 @@ kernel.def @f32_scalarized() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64x4xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64x4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%buffer_base] : buffer -> view<64x4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xf32, #dense>
   %lhs = vector.load %lhs_view[%lane, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %rhs = vector.load %rhs_view[%lane, 0] : view<64x4xf32, #dense> -> vector<4xf32>
   %lhs0 = vector.extract %lhs[0] : vector<4xf32> -> f32
@@ -209,8 +209,8 @@ func.def @f32_uniform_vector_binary(%lhs_buffer: buffer, %rhs_buffer: buffer) ->
   %sum = vector.addf %lhs, %rhs : vector<4xf32>
   %difference = vector.subf %lhs, %rhs : vector<4xf32>
   %combined = vector.addf %product, %sum : vector<4xf32>
-  %two = vector.constant 2.0 : vector<4xf32>
-  %scaled = vector.mulf %lhs, %two : vector<4xf32>
+  %scale_factor = vector.constant 2.0 : vector<4xf32>
+  %scaled = vector.mulf %lhs, %scale_factor : vector<4xf32>
   %with_difference = vector.addf %combined, %difference : vector<4xf32>
   %result = vector.addf %with_difference, %scaled : vector<4xf32>
   func.return %result : vector<4xf32>
@@ -234,9 +234,9 @@ func.def @f32_uniform_scalar_binary(%lhs_buffer: buffer, %rhs_buffer: buffer) ->
 // ====
 
 func.def @f32_inline_zero_arithmetic(%scalar: f32, %vector: vector<2xf32>) -> (f32, vector<2xf32>) {
-  %zero = scalar.constant 0.0 : f32
-  %scalar_result = scalar.mulf %scalar, %zero : f32
-  %zero_vector = vector.splat %zero : vector<2xf32>
+  %zero_factor = scalar.constant 0.0 : f32
+  %scalar_result = scalar.mulf %scalar, %zero_factor : f32
+  %zero_vector = vector.splat %zero_factor : vector<2xf32>
   %vector_result = vector.mulf %vector, %zero_vector : vector<2xf32>
   func.return %scalar_result, %vector_result : f32, vector<2xf32>
 }
@@ -283,11 +283,11 @@ kernel.def @f32_direct_arg_scale() {
   %c1 = index.constant 1 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%output: buffer, %scale: f32) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xf32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_element = index.constant 0 : index
+  %output_view = buffer.view %output[%output_base] : buffer -> view<1xf32, #dense>
   %unit = scalar.constant 1.0 : f32
   %scaled = scalar.mulf %unit, %scale : f32
-  view.store %scaled, %output_view[%zero_index] : f32, view<1xf32, #dense>
+  view.store %scaled, %output_view[%output_element] : f32, view<1xf32, #dense>
   kernel.return
 }

--- a/loom/src/loom/test/corpus/source_low/numeric_i32_memory.loom-test
+++ b/loom/src/loom/test/corpus/source_low/numeric_i32_memory.loom-test
@@ -6,9 +6,9 @@ kernel.def @i32_bitwise() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   %mask = vector.constant 15 : vector<1xi32>
   %masked = vector.andi %loaded, %mask : vector<1xi32>
@@ -27,9 +27,9 @@ kernel.def @i32_shift() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   %shift = vector.constant 3 : vector<1xi32>
   %left = vector.shli %loaded, %shift : vector<1xi32>
@@ -49,9 +49,9 @@ kernel.def @i32_negative_literal() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32, #dense>
   %loaded = vector.load %input_view[%lane] : view<64xi32, #dense> -> vector<1xi32>
   %mask = vector.constant -1 : vector<1xi32>
   %result = vector.xori %loaded, %mask : vector<1xi32>
@@ -67,9 +67,9 @@ kernel.def @i32_scalarized() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64x4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64x4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64x4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64x4xi32, #dense>
   %loaded = vector.load %input_view[%lane, 0] : view<64x4xi32, #dense> -> vector<4xi32>
   %lane0 = vector.extract %loaded[0] : vector<4xi32> -> i32
   %lane1 = vector.extract %loaded[1] : vector<4xi32> -> i32

--- a/loom/src/loom/test/corpus/source_low/numeric_minmax.loom-test
+++ b/loom/src/loom/test/corpus/source_low/numeric_minmax.loom-test
@@ -78,15 +78,15 @@ func.def @scf_select_i64_sgpr(%lhs: i32, %rhs: i32, %a: i64, %b: i64) -> (i64) {
 // ====
 
 func.def @scf_select_q6_nibble_i8(%code: i32, %use_high: i32) -> (i8) {
-  %zero = scalar.constant 0 : i32
-  %four = scalar.constant 4 : i32
+  %low_selector = scalar.constant 0 : i32
+  %nibble_shift = scalar.constant 4 : i32
   %mask = scalar.constant 15 : i32
-  %high_shifted = scalar.shrui %code, %four : i32
+  %high_shifted = scalar.shrui %code, %nibble_shift : i32
   %low_i32 = scalar.andi %code, %mask : i32
   %high_i32 = scalar.andi %high_shifted, %mask : i32
   %low = scalar.trunci %low_i32 : i32 to i8
   %high = scalar.trunci %high_i32 : i32 to i8
-  %cond = scalar.cmpi ne, %use_high, %zero : i32
+  %cond = scalar.cmpi ne, %use_high, %low_selector : i32
   %selected = scf.select %cond, %high, %low : i8
   func.return %selected : i8
 }
@@ -94,12 +94,12 @@ func.def @scf_select_q6_nibble_i8(%code: i32, %use_high: i32) -> (i8) {
 // ====
 
 func.def @scf_select_scale_piece_i16(%packed: i32, %use_high: i32) -> (i16) {
-  %zero = scalar.constant 0 : i32
-  %sixteen = scalar.constant 16 : i32
+  %low_selector = scalar.constant 0 : i32
+  %halfword_shift = scalar.constant 16 : i32
   %low = scalar.trunci %packed : i32 to i16
-  %high_shifted = scalar.shrui %packed, %sixteen : i32
+  %high_shifted = scalar.shrui %packed, %halfword_shift : i32
   %high = scalar.trunci %high_shifted : i32 to i16
-  %cond = scalar.cmpi ne, %use_high, %zero : i32
+  %cond = scalar.cmpi ne, %use_high, %low_selector : i32
   %selected = scf.select %cond, %high, %low : i16
   func.return %selected : i16
 }
@@ -127,9 +127,9 @@ func.def @scf_select_chained_vgpr_i32(%values: vector<2xi32>, %limit: i32, %fall
 
 func.def @scf_select_tail_zero_i32(%values: vector<2xi32>, %limit: i32) -> (i32) {
   %lane = vector.extract %values[0] : vector<2xi32> -> i32
-  %zero = scalar.constant 0 : i32
+  %tail_fill = scalar.constant 0 : i32
   %cond = scalar.cmpi slt, %lane, %limit : i32
-  %selected = scf.select %cond, %lane, %zero : i32
+  %selected = scf.select %cond, %lane, %tail_fill : i32
   func.return %selected : i32
 }
 
@@ -284,10 +284,10 @@ func.def @scf_select_i1_false_condition_constant(%true_value: f32, %false_value:
 // ====
 
 func.def @scf_select_i1_scc_condition(%lhs: i32, %rhs: i32, %alt: i32, %true_value: f32, %false_value: f32) -> (f32) {
-  %zero = scalar.constant 0 : i32
+  %inactive_condition = scalar.constant 0 : i32
   %condition = scalar.cmpi slt, %lhs, %rhs : i32
-  %lhs_nonzero = scalar.cmpi ne, %lhs, %zero : i32
-  %alt_nonzero = scalar.cmpi ne, %alt, %zero : i32
+  %lhs_nonzero = scalar.cmpi ne, %lhs, %inactive_condition : i32
+  %alt_nonzero = scalar.cmpi ne, %alt, %inactive_condition : i32
   %selected_condition = scf.select %condition, %lhs_nonzero, %alt_nonzero : i1
   %result = scf.select %selected_condition, %true_value, %false_value : f32
   func.return %result : f32
@@ -306,8 +306,8 @@ kernel.def @index_minmax_vgpr_select() {
   %max = index.max %lane, %limit : index
   %cond = index.cmp slt, %lane, %limit : index
   %selected = scf.select %cond, %min, %max : index
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xi32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<64xi32, #dense>
   %stored = vector.constant 1 : vector<1xi32>
   vector.store %stored, %output_view[%selected] : vector<1xi32>, view<64xi32, #dense>
   kernel.return
@@ -316,9 +316,9 @@ kernel.def @index_minmax_vgpr_select() {
 // ====
 
 func.def @f32_reduce_minnum_maxnum(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<2xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<2xf32, #dense>
   %loaded = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %min_init = scalar.constant 1000.0 : f32
   %min = vector.reduce<minnumf, reassoc|nnan|nsz> %loaded, %min_init : vector<4xf32>, f32

--- a/loom/src/loom/test/corpus/source_low/numeric_reduce.loom-test
+++ b/loom/src/loom/test/corpus/source_low/numeric_reduce.loom-test
@@ -1,9 +1,9 @@
 // RUN: roundtrip
 
 func.def @i32_reduce_add(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   %init = scalar.constant 0 : i32
   %sum = vector.reduce<addi> %loaded, %init : vector<4xi32>, i32
@@ -15,9 +15,9 @@ func.def @i32_reduce_add(%input: buffer, %output: buffer) {
 // ====
 
 func.def @f32_reduce_add(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
   %loaded = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %init = scalar.constant 0.0 : f32
   %sum = vector.reduce<addf> %loaded, %init : vector<4xf32>, f32
@@ -29,9 +29,9 @@ func.def @f32_reduce_add(%input: buffer, %output: buffer) {
 // ====
 
 func.def @f32_reduce_add_fastmath(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
   %loaded = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %init = scalar.constant 0.0 : f32
   %sum = vector.reduce<addf, reassoc|nnan|nsz> %loaded, %init : vector<4xf32>, f32
@@ -43,9 +43,9 @@ func.def @f32_reduce_add_fastmath(%input: buffer, %output: buffer) {
 // ====
 
 func.def @f32x64_reduce_add_fastmath(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
   %loaded = vector.load %input_view[0] : view<64xf32, #dense> -> vector<64xf32>
   %init = scalar.constant 0.0 : f32
   %sum = vector.reduce<addf, reassoc|nnan|nsz> %loaded, %init : vector<64xf32>, f32
@@ -59,24 +59,24 @@ func.def @f32x64_reduce_add_fastmath(%input: buffer, %output: buffer) {
 config.def @runtime.vector_width = 4 : index
 
 kernel.def @f32_configured_width_square_reduce() {
-  %one = index.constant 1 : index
+  %singleton_dimension = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%singleton_dimension, %singleton_dimension, %singleton_dimension) workgroup_size(%workgroup_size, %singleton_dimension, %singleton_dimension) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero_offset = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %lane0 = kernel.workitem.id<x> : index
   %lane = index.assume %lane0 [range(%lane0, 0, 63)] : index
   %vector_width = config.get @runtime.vector_width : index
   %vector_width_bounded = index.assume %vector_width [range(%vector_width, 2, 4)] : index
   %element_count = index.constant 256 : index
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<[%element_count]xf32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<[%element_count]xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xf32, #dense>
   %linear0 = index.mul %lane, %vector_width_bounded : index
   %linear = index.assume %linear0 [range(%linear0, 0, 252)] : index
   %loaded = vector.load %input_view[%linear] : view<[%element_count]xf32, #dense> -> vector<[%vector_width_bounded]xf32>
   %squared = vector.mulf<reassoc|nnan|ninf|nsz|contract> %loaded, %loaded : vector<[%vector_width_bounded]xf32>
-  %zero_f32 = scalar.constant 0.0 : f32
-  %sum = vector.reduce<addf, reassoc|nnan|ninf|nsz|contract> %squared, %zero_f32 : vector<[%vector_width_bounded]xf32>, f32
+  %initial_sum = scalar.constant 0.0 : f32
+  %sum = vector.reduce<addf, reassoc|nnan|ninf|nsz|contract> %squared, %initial_sum : vector<[%vector_width_bounded]xf32>, f32
   %stored = vector.from_elements %sum : vector<1xf32>
   vector.store %stored, %output_view[0] : vector<1xf32>, view<1xf32, #dense>
   kernel.return
@@ -85,8 +85,8 @@ kernel.def @f32_configured_width_square_reduce() {
 // ====
 
 func.def @i32_reduce_minui_select_sentinel(%values: vector<4xi32>) -> (i32) {
-  %zero = scalar.constant 0 : i32
-  %zeros = vector.splat %zero : vector<4xi32>
+  %empty_value = scalar.constant 0 : i32
+  %zeros = vector.splat %empty_value : vector<4xi32>
   %is_zero = vector.cmpi eq, %values, %zeros : vector<4xi32> -> vector<4xi1>
   %start = scalar.constant 0 : i32
   %step = scalar.constant 1 : i32

--- a/loom/src/loom/test/corpus/source_low/numeric_scalar_i32.loom-test
+++ b/loom/src/loom/test/corpus/source_low/numeric_scalar_i32.loom-test
@@ -41,9 +41,9 @@ func.def @scalar_i1_constants_scc() -> (i1, i1) {
 // ====
 
 func.def @scalar_i1_bitwise_scc(%lhs: i32, %rhs: i32) -> (i1) {
-  %zero = scalar.constant 0 : i32
-  %lhs_nonzero = scalar.cmpi ne, %lhs, %zero : i32
-  %rhs_nonzero = scalar.cmpi ne, %rhs, %zero : i32
+  %inactive_condition = scalar.constant 0 : i32
+  %lhs_nonzero = scalar.cmpi ne, %lhs, %inactive_condition : i32
+  %rhs_nonzero = scalar.cmpi ne, %rhs, %inactive_condition : i32
   %both_nonzero = scalar.andi %lhs_nonzero, %rhs_nonzero : i1
   %either_nonzero = scalar.ori %lhs_nonzero, %rhs_nonzero : i1
   %one_nonzero = scalar.xori %both_nonzero, %either_nonzero : i1

--- a/loom/src/loom/test/corpus/source_low/packed_bitfield.loom-test
+++ b/loom/src/loom/test/corpus/source_low/packed_bitfield.loom-test
@@ -1,9 +1,9 @@
 // RUN: roundtrip
 
 func.def @i32_bitfield_extractu(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %nibble = vector.bitfield.extractu %loaded {offset = 4, width = 4} : vector<1xi32> -> vector<1xi32>
   vector.store %nibble, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
@@ -13,9 +13,9 @@ func.def @i32_bitfield_extractu(%input: buffer, %output: buffer) {
 // ====
 
 func.def @i32_bitfield_extracts(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %nibble = vector.bitfield.extracts %loaded {offset = 4, width = 4} : vector<1xi32> -> vector<1xi32>
   vector.store %nibble, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
@@ -25,9 +25,9 @@ func.def @i32_bitfield_extracts(%input: buffer, %output: buffer) {
 // ====
 
 func.def @i32_bitfield_extractu_full_width_alias(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %bits = vector.bitfield.extractu %loaded {offset = 0, width = 32} : vector<1xi32> -> vector<1xi32>
   vector.store %bits, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
@@ -37,9 +37,9 @@ func.def @i32_bitfield_extractu_full_width_alias(%input: buffer, %output: buffer
 // ====
 
 func.def @i32_bitfield_extracts_top_aligned(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %loaded = vector.load %input_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %nibble = vector.bitfield.extracts %loaded {offset = 28, width = 4} : vector<1xi32> -> vector<1xi32>
   vector.store %nibble, %output_view[0] : vector<1xi32>, view<1xi32, #dense>
@@ -49,10 +49,10 @@ func.def @i32_bitfield_extracts_top_aligned(%input: buffer, %output: buffer) {
 // ====
 
 func.def @i32_bitfield_insert(%field_buffer: buffer, %base_buffer: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %field_view = buffer.view %field_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %base_view = buffer.view %base_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %field_view = buffer.view %field_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %base_view = buffer.view %base_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %field = vector.load %field_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %base = vector.load %base_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %inserted = vector.bitfield.insert %field into %base {offset = 8, width = 4} : vector<1xi32>, vector<1xi32>
@@ -63,10 +63,10 @@ func.def @i32_bitfield_insert(%field_buffer: buffer, %base_buffer: buffer, %outp
 // ====
 
 func.def @i32_bitfield_insert_offset0(%field_buffer: buffer, %base_buffer: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %field_view = buffer.view %field_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %base_view = buffer.view %base_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %field_view = buffer.view %field_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %base_view = buffer.view %base_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %field = vector.load %field_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %base = vector.load %base_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %inserted = vector.bitfield.insert %field into %base {offset = 0, width = 4} : vector<1xi32>, vector<1xi32>
@@ -77,10 +77,10 @@ func.def @i32_bitfield_insert_offset0(%field_buffer: buffer, %base_buffer: buffe
 // ====
 
 func.def @i32_bitfield_insert_full_width_alias(%field_buffer: buffer, %base_buffer: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %field_view = buffer.view %field_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %base_view = buffer.view %base_buffer[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %field_view = buffer.view %field_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %base_view = buffer.view %base_buffer[%buffer_base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<1xi32, #dense>
   %field = vector.load %field_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %base = vector.load %base_view[0] : view<1xi32, #dense> -> vector<1xi32>
   %inserted = vector.bitfield.insert %field into %base {offset = 0, width = 32} : vector<1xi32>, vector<1xi32>
@@ -91,9 +91,9 @@ func.def @i32_bitfield_insert_full_width_alias(%field_buffer: buffer, %base_buff
 // ====
 
 func.def @i32_bitfield_b128_shape(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   %low = vector.bitfield.extractu %loaded {offset = 0, width = 4} : vector<4xi32> -> vector<4xi32>
   %high = vector.bitfield.extractu %loaded {offset = 4, width = 2} : vector<4xi32> -> vector<4xi32>

--- a/loom/src/loom/test/corpus/source_low/packed_bitpack.loom-test
+++ b/loom/src/loom/test/corpus/source_low/packed_bitpack.loom-test
@@ -29,8 +29,8 @@ func.def @i32x32_to_i1x32_bitpack(%mask: vector<32xi32>) -> (vector<4xi8>) {
 // ====
 
 kernel.def @uniform_global_i32x4_to_i8x4_bitpack_store() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%values: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %index = index.constant 0 : index

--- a/loom/src/loom/test/corpus/source_low/packed_bitunpack.loom-test
+++ b/loom/src/loom/test/corpus/source_low/packed_bitunpack.loom-test
@@ -50,8 +50,8 @@ func.def @i8x2_to_s4x4_bitunpack_i8_result(%packed: vector<2xi8>) -> (vector<4xi
 // ====
 
 kernel.def @uniform_global_i32_to_u8x4_bitunpack_store() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%values: buffer, %output: buffer) {
   %base = index.constant 0 : offset
   %index = index.constant 0 : index

--- a/loom/src/loom/test/corpus/source_low/packed_q8_dequant_dot.loom-test
+++ b/loom/src/loom/test/corpus/source_low/packed_q8_dequant_dot.loom-test
@@ -18,23 +18,23 @@ kernel.def @q8_packed_word_global_dequant_dot4_kernel() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%weights: buffer, %rhs_buffer: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %four = index.constant 4 : index
-  %four_bytes = index.constant 4 : offset
-  %eight = index.constant 8 : index
+  %packed_word_index = index.constant 0 : index
+  %rhs_elements_per_lane = index.constant 4 : index
+  %packed_word_bytes = index.constant 4 : offset
+  %lanes_per_scale = index.constant 8 : index
   %lane = kernel.workitem.id<x> : index
   %weights_global = buffer.assume.memory_space<global> %weights : buffer
   %rhs_global = buffer.assume.memory_space<global> %rhs_buffer : buffer
   %output_global = buffer.assume.memory_space<global> %output : buffer
   %weights_noalias, %rhs_noalias, %output_noalias = buffer.assume.noalias %weights_global, %rhs_global, %output_global : buffer, buffer, buffer
-  %q_byte_offset = index.scale %lane, %four_bytes : index, offset -> offset
-  %scale_index = index.div %lane, %eight : index
-  %rhs_index = index.mul %lane, %four : index
+  %q_byte_offset = index.scale %lane, %packed_word_bytes : index, offset -> offset
+  %scale_index = index.div %lane, %lanes_per_scale : index
+  %rhs_index = index.mul %lane, %rhs_elements_per_lane : index
   %q_word_view = buffer.view %weights_noalias[%q_byte_offset] : buffer -> view<1xi32, #dense>
   %scale_view = buffer.view %weights_noalias[%base] : buffer -> view<1024xf16, #dense>
   %rhs_view = buffer.view %rhs_noalias[%base] : buffer -> view<1024xf32, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<64xf32, #dense>
-  %packed = vector.load %q_word_view[%zero] : view<1xi32, #dense> -> vector<1xi32>
+  %packed = vector.load %q_word_view[%packed_word_index] : view<1xi32, #dense> -> vector<1xi32>
   %scale = view.load %scale_view[%scale_index] : view<1024xf16, #dense> -> f16
   %rhs = vector.load %rhs_view[%rhs_index] : view<1024xf32, #dense> -> vector<4xf32>
   %q_i32 = vector.bitunpacks<8> %packed : vector<1xi32> -> vector<4xi32>

--- a/loom/src/loom/test/corpus/source_low/vector_dot.loom-test
+++ b/loom/src/loom/test/corpus/source_low/vector_dot.loom-test
@@ -8,8 +8,8 @@ func.def @f32_dotf(%lhs: vector<4xf32>, %rhs: vector<4xf32>, %acc: f32) -> (f32)
 // ====
 
 func.def @f32_dotf_zero_seed(%lhs: vector<4xf32>, %rhs: vector<4xf32>) -> (f32) {
-  %zero = scalar.constant 0.0 : f32
-  %dot = vector.dotf %lhs, %rhs, %zero : vector<4xf32>, vector<4xf32>, f32
+  %initial_accumulator = scalar.constant 0.0 : f32
+  %dot = vector.dotf %lhs, %rhs, %initial_accumulator : vector<4xf32>, vector<4xf32>, f32
   func.return %dot : f32
 }
 

--- a/loom/src/loom/test/corpus/source_low/vector_mask_select.loom-test
+++ b/loom/src/loom/test/corpus/source_low/vector_mask_select.loom-test
@@ -17,25 +17,25 @@ func.def @f32_cmpf_select(%lhs: vector<1xf32>, %rhs: vector<1xf32>, %true_value:
 // ====
 
 func.def @scalar_cmpf_rhs_zero_inline(%value: f32) -> (i1) {
-  %zero = scalar.constant 0.0 : f32
-  %mask = scalar.cmpf one, %value, %zero : f32
+  %comparison_rhs = scalar.constant 0.0 : f32
+  %mask = scalar.cmpf one, %value, %comparison_rhs : f32
   func.return %mask : i1
 }
 
 // ====
 
 func.def @scalar_cmpf_lhs_one_inline(%value: f32) -> (i1) {
-  %one = scalar.constant 1.0 : f32
-  %mask = scalar.cmpf olt, %one, %value : f32
+  %comparison_lhs = scalar.constant 1.0 : f32
+  %mask = scalar.cmpf olt, %comparison_lhs, %value : f32
   func.return %mask : i1
 }
 
 // ====
 
 func.def @vector_cmpf_rhs_zero_inline(%value: vector<2xf32>) -> (vector<2xi1>) {
-  %zero = scalar.constant 0.0 : f32
-  %zeros = vector.splat %zero : vector<2xf32>
-  %mask = vector.cmpf one, %value, %zeros : vector<2xf32> -> vector<2xi1>
+  %comparison_rhs_element = scalar.constant 0.0 : f32
+  %comparison_rhs = vector.splat %comparison_rhs_element : vector<2xf32>
+  %mask = vector.cmpf one, %value, %comparison_rhs : vector<2xf32> -> vector<2xi1>
   func.return %mask : vector<2xi1>
 }
 
@@ -43,8 +43,8 @@ func.def @vector_cmpf_rhs_zero_inline(%value: vector<2xf32>) -> (vector<2xi1>) {
 
 func.def @i32_cmpi_select_zero_inline(%lhs: vector<2xi32>, %rhs: vector<2xi32>, %false_value: vector<2xi32>) -> (vector<2xi32>) {
   %mask = vector.cmpi slt, %lhs, %rhs : vector<2xi32> -> vector<2xi1>
-  %zero = scalar.constant 0 : i32
-  %true_value = vector.splat %zero : vector<2xi32>
+  %true_element = scalar.constant 0 : i32
+  %true_value = vector.splat %true_element : vector<2xi32>
   %selected = vector.select %mask, %true_value, %false_value : vector<2xi32>
   func.return %selected : vector<2xi32>
 }

--- a/loom/src/loom/test/corpus/source_low/vector_scalarization_diagnostics.loom-test
+++ b/loom/src/loom/test/corpus/source_low/vector_scalarization_diagnostics.loom-test
@@ -1,8 +1,8 @@
 // RUN: pass vector-to-scalar
 
 func.def @oversized_static_vector_store_rejected(%output: buffer, %value: vector<65536xf32>) {
-  %zero = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero] : buffer -> view<65536xf32, #dense>
+  %output_base = index.constant 0 : offset
+  %output_view = buffer.view %output[%output_base] : buffer -> view<65536xf32, #dense>
   // ERROR@+1: SHAPE/007 {op_name="vector.store", pass_name="vector-to-scalar", vector_type="vector<65536xf32>"}
   vector.store %value, %output_view[0] : vector<65536xf32>, view<65536xf32, #dense>
   func.return

--- a/loom/src/loom/test/corpus/source_low/vector_slice.loom-test
+++ b/loom/src/loom/test/corpus/source_low/vector_slice.loom-test
@@ -57,8 +57,8 @@ func.def @f16x4_insert_static(%values: vector<4xf16>, %value: f16) -> (vector<4x
 // ====
 
 func.def @bf16x8_insert_static_constant(%values: vector<8xbf16>) -> (vector<8xbf16>) {
-  %zero = scalar.constant 0.0 : bf16
-  %updated = vector.insert %zero into %values[5] : bf16, vector<8xbf16>
+  %replacement = scalar.constant 0.0 : bf16
+  %updated = vector.insert %replacement into %values[5] : bf16, vector<8xbf16>
   func.return %updated : vector<8xbf16>
 }
 

--- a/loom/src/loom/test/corpus/source_low/vector_v16.loom-test
+++ b/loom/src/loom/test/corpus/source_low/vector_v16.loom-test
@@ -121,11 +121,11 @@ func.def @f32x16_dynamic_memory(%input: buffer, %output: buffer, %i: index) {
 // ====
 
 func.def @f32x16_index_add_memory(%input: buffer, %output: buffer, %i: index, %j: index) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %sum = index.add %i, %j : index
   %bounded_sum = index.assume %sum [range(%sum, 0, 16)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<32xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<32xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<32xf32, #dense>
   %loaded = vector.load %input_view[%bounded_sum] : view<32xf32, #dense> -> vector<16xf32>
   vector.store %loaded, %output_view[%bounded_sum] : vector<16xf32>, view<32xf32, #dense>
   func.return
@@ -134,11 +134,11 @@ func.def @f32x16_index_add_memory(%input: buffer, %output: buffer, %i: index, %j
 // ====
 
 func.def @f32x16_index_madd_memory(%input: buffer, %output: buffer, %row: index, %stride: index, %col: index) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %linear = index.madd %row, %stride, %col : index
   %bounded_linear = index.assume %linear [range(%linear, 0, 16)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<32xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<32xf32, #dense>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<32xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<32xf32, #dense>
   %loaded = vector.load %input_view[%bounded_linear] : view<32xf32, #dense> -> vector<16xf32>
   vector.store %loaded, %output_view[%bounded_linear] : vector<16xf32>, view<32xf32, #dense>
   func.return

--- a/loom/src/loom/test/corpus/source_low/vector_v4.loom-test
+++ b/loom/src/loom/test/corpus/source_low/vector_v4.loom-test
@@ -97,9 +97,9 @@ func.def @f32x4_select(%lhs: vector<4xf32>, %rhs: vector<4xf32>, %true_value: ve
 // ====
 
 func.def @i32x4_memory_copy(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xi32, #dense>
   %loaded = vector.load %input_view[0] : view<4xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[0] : vector<4xi32>, view<4xi32, #dense>
   func.return
@@ -109,9 +109,9 @@ func.def @i32x4_memory_copy(%input: buffer, %output: buffer) {
 
 func.def @i32x4_memory_indexed(%input: buffer, %output: buffer, %i: index) {
   %bounded_i = index.assume %i [range(%i, 0, 12)] : index
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<16xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xi32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<16xi32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xi32, #dense>
   %loaded = vector.load %input_view[%bounded_i] : view<16xi32, #dense> -> vector<4xi32>
   vector.store %loaded, %output_view[%bounded_i] : vector<4xi32>, view<16xi32, #dense>
   func.return
@@ -120,9 +120,9 @@ func.def @i32x4_memory_indexed(%input: buffer, %output: buffer, %i: index) {
 // ====
 
 func.def @f32x4_memory_copy(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<4xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<4xf32, #dense>
   %loaded = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   vector.store %loaded, %output_view[0] : vector<4xf32>, view<4xf32, #dense>
   func.return
@@ -132,10 +132,10 @@ func.def @f32x4_memory_copy(%input: buffer, %output: buffer) {
 
 func.def @f32x4_memory_indexed_add(%lhs: buffer, %rhs: buffer, %output: buffer, %i: index) {
   %bounded_i = index.assume %i [range(%i, 0, 12)] : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs[%zero] : buffer -> view<16xf32, #dense>
-  %rhs_view = buffer.view %rhs[%zero] : buffer -> view<16xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<16xf32, #dense>
+  %buffer_base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs[%buffer_base] : buffer -> view<16xf32, #dense>
+  %rhs_view = buffer.view %rhs[%buffer_base] : buffer -> view<16xf32, #dense>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<16xf32, #dense>
   %lhs_v = vector.load %lhs_view[%bounded_i] : view<16xf32, #dense> -> vector<4xf32>
   %rhs_v = vector.load %rhs_view[%bounded_i] : view<16xf32, #dense> -> vector<4xf32>
   %sum = vector.addf %lhs_v, %rhs_v : vector<4xf32>

--- a/loom/src/loom/test/corpus/text/buffers_views.loom
+++ b/loom/src/loom/test/corpus/text/buffers_views.loom
@@ -10,10 +10,10 @@ func.def @views(%buffer: buffer, %offset: offset, %row_stride: index, %row: inde
 }
 
 func.def @scratch(%bytes: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %view = buffer.view %scratch[%zero] : buffer -> view<16xi32, %layout>
+  %view = buffer.view %scratch[%base] : buffer -> view<16xi32, %layout>
   test.use %view : view<16xi32, %layout>
   func.return
 }

--- a/loom/src/loom/test/corpus/text/kernel_async.loom
+++ b/loom/src/loom/test/corpus/text/kernel_async.loom
@@ -2,9 +2,9 @@ func.def @kernel_async(%source_buffer: buffer, %byte_offset: offset) {
   %scratch_base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %i32_zero = scalar.constant 0 : i32
-  %d0 = vector.splat %i32_zero : vector<4xi32>
-  %d1 = vector.splat %i32_zero : vector<8xi32>
+  %descriptor_fill_value = scalar.constant 0 : i32
+  %d0 = vector.splat %descriptor_fill_value : vector<4xi32>
+  %d1 = vector.splat %descriptor_fill_value : vector<8xi32>
   %desc = kernel.tensor.lds.descriptor dgroups(%d0, %d1) : vector<4xi32>, vector<8xi32> -> kernel.tensor.lds.descriptor
   %global = buffer.assume.memory_space<global> %source_buffer : buffer
   %source = buffer.view %global[%byte_offset] : buffer -> view<64x64xf32, %layout>

--- a/loom/src/loom/test/corpus/text/kernel_async.loom
+++ b/loom/src/loom/test/corpus/text/kernel_async.loom
@@ -1,5 +1,5 @@
 func.def @kernel_async(%source_buffer: buffer, %byte_offset: offset) {
-  %zero = index.constant 0 : offset
+  %scratch_base = index.constant 0 : offset
   %bytes = index.constant 16384 : offset
   %layout = encoding.layout.dense : encoding<layout>
   %i32_zero = scalar.constant 0 : i32
@@ -9,7 +9,7 @@ func.def @kernel_async(%source_buffer: buffer, %byte_offset: offset) {
   %global = buffer.assume.memory_space<global> %source_buffer : buffer
   %source = buffer.view %global[%byte_offset] : buffer -> view<64x64xf32, %layout>
   %scratch = buffer.alloca %bytes {base_alignment = 256, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<64x64xf32, %layout>
+  %dest = buffer.view %scratch[%scratch_base] : buffer -> view<64x64xf32, %layout>
   %copy = kernel.async.tensor.load.to.lds %source to %dest using %desc {cache_scope = cu, cache_temporal = regular} : view<64x64xf32, %layout> to view<64x64xf32, %layout>, kernel.tensor.lds.descriptor -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group

--- a/loom/src/loom/test/integration/checked_benchmarks/fragment_result_dynamic_strided_f16acc_f32_store.loom
+++ b/loom/src/loom/test/integration/checked_benchmarks/fragment_result_dynamic_strided_f16acc_f32_store.loom
@@ -13,13 +13,13 @@ kernel.def target(@gfx1100_wave64) @fragment_result_dynamic_strided_f16acc_f32_s
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%out_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %sixteen = index.constant 16 : index
-  %sixty_four = index.constant 64 : index
+  %tile_origin = index.constant 0 : index
+  %tile_extent = index.constant 16 : index
+  %column_stride = index.constant 64 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
-  %layout = encoding.layout.strided [1, %sixty_four] : encoding<layout>
+  %layout = encoding.layout.strided [1, %column_stride] : encoding<layout>
 
   %out_global = buffer.assume.memory_space<global> %out_buffer : buffer
   %out_aligned = buffer.assume.alignment %out_global {minimum_alignment = 16} : buffer
@@ -44,10 +44,10 @@ kernel.def target(@gfx1100_wave64) @fragment_result_dynamic_strided_f16acc_f32_s
   %result2 = vector.mma %lhs, %rhs, %init2 : vector<16xf16>, vector<16xf16>, vector<8xf16>
   %result3 = vector.mma %lhs, %rhs, %init3 : vector<16xf16>, vector<16xf16>, vector<8xf16>
 
-  vector.fragment.store<result> %result0, %out_view[%zero, %zero] shape [%m, %n] : vector<8xf16>, view<64x64xf32, %layout>
-  vector.fragment.store<result> %result1, %out_view[%zero, %sixteen] shape [%m, %n] : vector<8xf16>, view<64x64xf32, %layout>
-  vector.fragment.store<result> %result2, %out_view[%sixteen, %zero] shape [%m, %n] : vector<8xf16>, view<64x64xf32, %layout>
-  vector.fragment.store<result> %result3, %out_view[%sixteen, %sixteen] shape [%m, %n] : vector<8xf16>, view<64x64xf32, %layout>
+  vector.fragment.store<result> %result0, %out_view[%tile_origin, %tile_origin] shape [%m, %n] : vector<8xf16>, view<64x64xf32, %layout>
+  vector.fragment.store<result> %result1, %out_view[%tile_origin, %tile_extent] shape [%m, %n] : vector<8xf16>, view<64x64xf32, %layout>
+  vector.fragment.store<result> %result2, %out_view[%tile_extent, %tile_origin] shape [%m, %n] : vector<8xf16>, view<64x64xf32, %layout>
+  vector.fragment.store<result> %result3, %out_view[%tile_extent, %tile_extent] shape [%m, %n] : vector<8xf16>, view<64x64xf32, %layout>
   kernel.return
 }
 
@@ -60,22 +60,22 @@ kernel.def @fill_fragment_result_dynamic_strided_f16acc_f32_store_expected() {
   %base = index.constant 0 : offset
   %wg = kernel.workgroup.id<x> : index
   %lane = kernel.workitem.id<x> : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %sixteen = index.constant 16 : index
-  %sixty_four = index.constant 64 : index
+  %tile_value_bias = index.constant 1 : index
+  %tile_grid_width = index.constant 2 : index
+  %tile_extent = index.constant 16 : index
+  %column_stride = index.constant 64 : index
 
-  %tile_row = index.div %wg, %two : index
-  %tile_column = index.rem %wg, %two : index
-  %row_origin = index.mul %tile_row, %sixteen : index
-  %column_origin = index.mul %tile_column, %sixteen : index
-  %local_row = index.rem %lane, %sixteen : index
-  %local_column = index.div %lane, %sixteen : index
+  %tile_row = index.div %wg, %tile_grid_width : index
+  %tile_column = index.rem %wg, %tile_grid_width : index
+  %row_origin = index.mul %tile_row, %tile_extent : index
+  %column_origin = index.mul %tile_column, %tile_extent : index
+  %local_row = index.rem %lane, %tile_extent : index
+  %local_column = index.div %lane, %tile_extent : index
   %row = index.add %row_origin, %local_row : index
   %column = index.add %column_origin, %local_column : index
-  %element_index = index.madd %column, %sixty_four, %row : index
+  %element_index = index.madd %column, %column_stride, %row : index
 
-  %tile_value_index = index.add %wg, %one : index
+  %tile_value_index = index.add %wg, %tile_value_bias : index
   %tile_value_i32 = index.cast %tile_value_index : index to i32
   %tile_value = scalar.uitofp %tile_value_i32 : i32 to f32
 

--- a/loom/src/loom/test/integration/checked_benchmarks/fragment_result_f16_lds_roundtrip.loom
+++ b/loom/src/loom/test/integration/checked_benchmarks/fragment_result_f16_lds_roundtrip.loom
@@ -11,11 +11,12 @@ kernel.def target(@gfx1100_wave64) @fragment_result_f16_lds_roundtrip() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%direct_buffer: buffer, %roundtrip_buffer: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
-  %sixteen = index.constant 16 : index
-  %sixty_four = index.constant 64 : index
+  %fragment_origin = index.constant 0 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %lane_segment_count = index.constant 4 : index
+  %tile_extent = index.constant 16 : index
+  %wave_size = index.constant 64 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -26,20 +27,20 @@ kernel.def target(@gfx1100_wave64) @fragment_result_f16_lds_roundtrip() {
   %lane_i32 = index.cast %lane : index to i32
   %lane_f32 = scalar.uitofp %lane_i32 : i32 to f32
   %lane_f16 = scalar.fptrunc %lane_f32 : f32 to f16
-  %one_f32 = scalar.constant 1.0 : f32
-  %two_f32 = scalar.constant 2.0 : f32
-  %three_f32 = scalar.constant 3.0 : f32
-  %four_f32 = scalar.constant 4.0 : f32
-  %five_f32 = scalar.constant 5.0 : f32
-  %six_f32 = scalar.constant 6.0 : f32
-  %seven_f32 = scalar.constant 7.0 : f32
-  %lane_plus1_f32 = scalar.addf %lane_f32, %one_f32 : f32
-  %lane_plus2_f32 = scalar.addf %lane_f32, %two_f32 : f32
-  %lane_plus3_f32 = scalar.addf %lane_f32, %three_f32 : f32
-  %lane_plus4_f32 = scalar.addf %lane_f32, %four_f32 : f32
-  %lane_plus5_f32 = scalar.addf %lane_f32, %five_f32 : f32
-  %lane_plus6_f32 = scalar.addf %lane_f32, %six_f32 : f32
-  %lane_plus7_f32 = scalar.addf %lane_f32, %seven_f32 : f32
+  %lane_value_offset1 = scalar.constant 1.0 : f32
+  %lane_value_offset2 = scalar.constant 2.0 : f32
+  %lane_value_offset3 = scalar.constant 3.0 : f32
+  %lane_value_offset4 = scalar.constant 4.0 : f32
+  %lane_value_offset5 = scalar.constant 5.0 : f32
+  %lane_value_offset6 = scalar.constant 6.0 : f32
+  %lane_value_offset7 = scalar.constant 7.0 : f32
+  %lane_plus1_f32 = scalar.addf %lane_f32, %lane_value_offset1 : f32
+  %lane_plus2_f32 = scalar.addf %lane_f32, %lane_value_offset2 : f32
+  %lane_plus3_f32 = scalar.addf %lane_f32, %lane_value_offset3 : f32
+  %lane_plus4_f32 = scalar.addf %lane_f32, %lane_value_offset4 : f32
+  %lane_plus5_f32 = scalar.addf %lane_f32, %lane_value_offset5 : f32
+  %lane_plus6_f32 = scalar.addf %lane_f32, %lane_value_offset6 : f32
+  %lane_plus7_f32 = scalar.addf %lane_f32, %lane_value_offset7 : f32
   %lane_plus1_f16 = scalar.fptrunc %lane_plus1_f32 : f32 to f16
   %lane_plus2_f16 = scalar.fptrunc %lane_plus2_f32 : f32 to f16
   %lane_plus3_f16 = scalar.fptrunc %lane_plus3_f32 : f32 to f16
@@ -59,20 +60,20 @@ kernel.def target(@gfx1100_wave64) @fragment_result_f16_lds_roundtrip() {
 
   %direct_global = buffer.assume.memory_space<global> %direct_buffer : buffer
   %direct_view = buffer.view %direct_global[%base] : buffer -> view<16x16xf32, #dense>
-  vector.fragment.store<result> %result, %direct_view[%zero, %zero] shape [%m, %n] : vector<8xf16>, view<16x16xf32, #dense>
+  vector.fragment.store<result> %result, %direct_view[%fragment_origin, %fragment_origin] shape [%m, %n] : vector<8xf16>, view<16x16xf32, #dense>
 
   %scratch = buffer.alloca %scratch_bytes {base_alignment = 16, memory_space = workgroup} : buffer
   %scratch_view = buffer.view %scratch[%base] : buffer -> view<16x16xf16, #dense>
-  vector.fragment.store<result> %result, %scratch_view[%zero, %zero] shape [%m, %n] : vector<8xf16>, view<16x16xf16, #dense>
+  vector.fragment.store<result> %result, %scratch_view[%fragment_origin, %fragment_origin] shape [%m, %n] : vector<8xf16>, view<16x16xf16, #dense>
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
 
   %roundtrip_global = buffer.assume.memory_space<global> %roundtrip_buffer : buffer
   %roundtrip_view = buffer.view %roundtrip_global[%base] : buffer -> view<256xf32, #dense>
-  scf.for %i = [%zero to %four step %one] {
-    %linear_lane = index.mul %i, %sixty_four : index
+  scf.for %i = [%loop_begin to %lane_segment_count step %loop_step] {
+    %linear_lane = index.mul %i, %wave_size : index
     %linear = index.add %linear_lane, %lane : index
-    %row = index.div %linear, %sixteen : index
-    %column = index.rem %linear, %sixteen : index
+    %row = index.div %linear, %tile_extent : index
+    %column = index.rem %linear, %tile_extent : index
     %value_f16 = view.load %scratch_view[%row, %column] : view<16x16xf16, #dense> -> f16
     %value = scalar.extf %value_f16 : f16 to f32
     view.store %value, %roundtrip_view[%linear] : f32, view<256xf32, #dense>

--- a/loom/src/loom/test/integration/checked_benchmarks/online_softmax_tail_attention_tile_f32.loom
+++ b/loom/src/loom/test/integration/checked_benchmarks/online_softmax_tail_attention_tile_f32.loom
@@ -13,10 +13,11 @@ kernel.def @online_softmax_tail_attention_tile_f32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%valid_count: i32, %old_state: buffer, %old_acc: buffer, %scores: buffer, %values: buffer, %new_state: buffer, %new_acc: buffer) {
   %base = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %zero_i32 = scalar.constant 0 : i32
-  %one_i32 = scalar.constant 1 : i32
-  %zero_f32 = scalar.constant 0.0 : f32
+  %max_state_index = index.constant 0 : index
+  %lane_sequence_begin = scalar.constant 0 : i32
+  %lane_sequence_step = scalar.constant 1 : i32
+  %masked_weight_fill = scalar.constant 0.0 : f32
+  %sum_initial = scalar.constant 0.0 : f32
   %negative_large = scalar.constant -1000000000.0 : f32
 
   %old_state_noalias, %old_acc_noalias, %scores_noalias, %values_noalias, %new_state_noalias, %new_acc_noalias = buffer.assume.noalias %old_state, %old_acc, %scores, %values, %new_state, %new_acc : buffer, buffer, buffer, buffer, buffer, buffer
@@ -32,7 +33,7 @@ kernel.def @online_softmax_tail_attention_tile_f32() {
   %old_acc_values = vector.load %old_acc_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %score_values = vector.load %scores_view[0] : view<4xf32, #dense> -> vector<4xf32>
 
-  %lanes = vector.iota %zero_i32 step %one_i32 : vector<4xi32>
+  %lanes = vector.iota %lane_sequence_begin step %lane_sequence_step : vector<4xi32>
   %valid_limits = vector.splat %valid_count : vector<4xi32>
   %valid = vector.cmpi slt, %lanes, %valid_limits : vector<4xi32> -> vector<4xi1>
   %sentinels = vector.splat %negative_large : vector<4xf32>
@@ -49,9 +50,9 @@ kernel.def @online_softmax_tail_attention_tile_f32() {
   %new_max_vector = vector.splat %new_max : vector<4xf32>
   %score_deltas = vector.subf %score_values, %new_max_vector : vector<4xf32>
   %raw_weights = vector.expf<afn> %score_deltas : vector<4xf32>
-  %zero_weights = vector.splat %zero_f32 : vector<4xf32>
+  %zero_weights = vector.splat %masked_weight_fill : vector<4xf32>
   %weights = vector.select %valid, %raw_weights, %zero_weights : vector<4xf32>
-  %block_sum = vector.reduce<addf, reassoc|nnan|nsz> %weights, %zero_f32 : vector<4xf32>, f32
+  %block_sum = vector.reduce<addf, reassoc|nnan|nsz> %weights, %sum_initial : vector<4xf32>, f32
   %new_sum = scalar.addf<reassoc|nnan|nsz|contract> %rescaled_old_sum, %block_sum : f32
 
   %value0 = vector.load %values_view[0, 0] : view<4x4xf32, #dense> -> vector<4xf32>
@@ -75,7 +76,7 @@ kernel.def @online_softmax_tail_attention_tile_f32() {
   %new_acc2 = vector.addf<reassoc|nnan|nsz|contract> %new_acc1, %weighted_value2 : vector<4xf32>
   %new_acc3 = vector.addf<reassoc|nnan|nsz|contract> %new_acc2, %weighted_value3 : vector<4xf32>
 
-  view.store %new_max, %new_state_view[%zero_index] : f32, view<2xf32, #dense>
+  view.store %new_max, %new_state_view[%max_state_index] : f32, view<2xf32, #dense>
   view.store %new_sum, %new_state_view[1] : f32, view<2xf32, #dense>
   vector.store %new_acc3, %new_acc_view[0] : vector<4xf32>, view<4xf32, #dense>
   kernel.return

--- a/loom/src/loom/test/integration/checked_benchmarks/packed_s8_fields_f16scale_f32dot.loom
+++ b/loom/src/loom/test/integration/checked_benchmarks/packed_s8_fields_f16scale_f32dot.loom
@@ -13,8 +13,7 @@ kernel.def @packed_s8_fields_f16scale_f32dot() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%packed_fields: buffer, %scales: buffer, %rhs: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %four = index.constant 4 : index
+  %packed_field_count = index.constant 4 : index
   %lane = kernel.workitem.id<x> : index
 
   %fields_noalias, %scales_noalias, %rhs_noalias, %output_noalias = buffer.assume.noalias %packed_fields, %scales, %rhs, %output : buffer, buffer, buffer, buffer
@@ -23,7 +22,7 @@ kernel.def @packed_s8_fields_f16scale_f32dot() {
   %rhs_view = buffer.view %rhs_noalias[%base] : buffer -> view<16xf32, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<4xf32, #dense>
 
-  %rhs_base0 = index.mul %lane, %four : index
+  %rhs_base0 = index.mul %lane, %packed_field_count : index
   %rhs_base = index.assume %rhs_base0 [range(%rhs_base0, 0, 12), mul(%rhs_base0, 4)] : index
   %packed = vector.load %field_view[%lane] : view<4xi32, #dense> -> vector<1xi32>
   %scale_f16 = view.load %scale_view[%lane] : view<4xf16, #dense> -> f16
@@ -34,8 +33,8 @@ kernel.def @packed_s8_fields_f16scale_f32dot() {
   %scale_f32 = scalar.extf %scale_f16 : f16 to f32
   %scale_vector = vector.splat %scale_f32 : vector<4xf32>
   %scaled_fields = vector.mulf<reassoc|nnan|ninf|nsz|contract> %field_f32, %scale_vector : vector<4xf32>
-  %zero_f32 = scalar.constant 0.0 : f32
-  %dot = vector.dotf %scaled_fields, %rhs_values, %zero_f32 : vector<4xf32>, vector<4xf32>, f32
+  %dot_initial = scalar.constant 0.0 : f32
+  %dot = vector.dotf %scaled_fields, %rhs_values, %dot_initial : vector<4xf32>, vector<4xf32>, f32
   view.store %dot, %output_view[%lane] : f32, view<4xf32, #dense>
   kernel.return
 }

--- a/loom/src/loom/test/integration/checked_benchmarks/paged_decode_attention_tile_f32.loom
+++ b/loom/src/loom/test/integration/checked_benchmarks/paged_decode_attention_tile_f32.loom
@@ -13,13 +13,16 @@ kernel.def @paged_decode_attention_tile_f32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%block_id0: index, %lane_start0: index, %valid_count: i32, %old_state: buffer, %old_acc: buffer, %query: buffer, %page_table: buffer, %key_pool: buffer, %value_pool: buffer, %new_state: buffer, %new_acc: buffer) {
   %base = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %one_index = index.constant 1 : index
-  %two_index = index.constant 2 : index
-  %three_index = index.constant 3 : index
-  %zero_i32 = scalar.constant 0 : i32
-  %one_i32 = scalar.constant 1 : i32
-  %zero_f32 = scalar.constant 0.0 : f32
+  %max_state_index = index.constant 0 : index
+  %lane_offset1 = index.constant 1 : index
+  %lane_offset2 = index.constant 2 : index
+  %lane_offset3 = index.constant 3 : index
+  %lane_sequence_begin = scalar.constant 0 : i32
+  %lane_sequence_step = scalar.constant 1 : i32
+  %dot_initial = scalar.constant 0.0 : f32
+  %masked_score_fill = scalar.constant 0.0 : f32
+  %masked_weight_fill = scalar.constant 0.0 : f32
+  %sum_initial = scalar.constant 0.0 : f32
   %negative_large = scalar.constant -1000000000.0 : f32
 
   %block_id = index.assume %block_id0 [range(%block_id0, 0, 1)] : index
@@ -41,9 +44,9 @@ kernel.def @paged_decode_attention_tile_f32() {
   %page0 = index.cast %page_i32 : i32 to index
   %page = index.assume %page0 [range(%page0, 0, 1)] : index
 
-  %lane1 = index.add %lane_start, %one_index : index
-  %lane2 = index.add %lane_start, %two_index : index
-  %lane3 = index.add %lane_start, %three_index : index
+  %lane1 = index.add %lane_start, %lane_offset1 : index
+  %lane2 = index.add %lane_start, %lane_offset2 : index
+  %lane3 = index.add %lane_start, %lane_offset3 : index
   %page_base = index.scale %page, %page_byte_stride : index, offset -> offset
   %lane0_offset = index.scale %lane_start, %lane_byte_stride : index, offset -> offset
   %lane1_offset = index.scale %lane1, %lane_byte_stride : index, offset -> offset
@@ -71,17 +74,17 @@ kernel.def @paged_decode_attention_tile_f32() {
   %key1 = vector.load %key1_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %key2 = vector.load %key2_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %key3 = vector.load %key3_view[0] : view<4xf32, #dense> -> vector<4xf32>
-  %score0 = vector.dotf %query_values, %key0, %zero_f32 : vector<4xf32>, vector<4xf32>, f32
-  %score1 = vector.dotf %query_values, %key1, %zero_f32 : vector<4xf32>, vector<4xf32>, f32
-  %score2 = vector.dotf %query_values, %key2, %zero_f32 : vector<4xf32>, vector<4xf32>, f32
-  %score3 = vector.dotf %query_values, %key3, %zero_f32 : vector<4xf32>, vector<4xf32>, f32
-  %score_zeros = vector.splat %zero_f32 : vector<4xf32>
+  %score0 = vector.dotf %query_values, %key0, %dot_initial : vector<4xf32>, vector<4xf32>, f32
+  %score1 = vector.dotf %query_values, %key1, %dot_initial : vector<4xf32>, vector<4xf32>, f32
+  %score2 = vector.dotf %query_values, %key2, %dot_initial : vector<4xf32>, vector<4xf32>, f32
+  %score3 = vector.dotf %query_values, %key3, %dot_initial : vector<4xf32>, vector<4xf32>, f32
+  %score_zeros = vector.splat %masked_score_fill : vector<4xf32>
   %scores01 = vector.insert %score0 into %score_zeros[0] : f32, vector<4xf32>
   %scores02 = vector.insert %score1 into %scores01[1] : f32, vector<4xf32>
   %scores03 = vector.insert %score2 into %scores02[2] : f32, vector<4xf32>
   %scores = vector.insert %score3 into %scores03[3] : f32, vector<4xf32>
 
-  %lanes = vector.iota %zero_i32 step %one_i32 : vector<4xi32>
+  %lanes = vector.iota %lane_sequence_begin step %lane_sequence_step : vector<4xi32>
   %valid_limits = vector.splat %valid_count : vector<4xi32>
   %valid = vector.cmpi slt, %lanes, %valid_limits : vector<4xi32> -> vector<4xi1>
   %sentinels = vector.splat %negative_large : vector<4xf32>
@@ -98,9 +101,9 @@ kernel.def @paged_decode_attention_tile_f32() {
   %new_max_vector = vector.splat %new_max : vector<4xf32>
   %score_deltas = vector.subf %scores, %new_max_vector : vector<4xf32>
   %raw_weights = vector.expf<afn> %score_deltas : vector<4xf32>
-  %zero_weights = vector.splat %zero_f32 : vector<4xf32>
+  %zero_weights = vector.splat %masked_weight_fill : vector<4xf32>
   %weights = vector.select %valid, %raw_weights, %zero_weights : vector<4xf32>
-  %block_sum = vector.reduce<addf, reassoc|nnan|nsz> %weights, %zero_f32 : vector<4xf32>, f32
+  %block_sum = vector.reduce<addf, reassoc|nnan|nsz> %weights, %sum_initial : vector<4xf32>, f32
   %new_sum = scalar.addf<reassoc|nnan|nsz|contract> %rescaled_old_sum, %block_sum : f32
 
   %value0 = vector.load %value0_view[0] : view<4xf32, #dense> -> vector<4xf32>
@@ -124,7 +127,7 @@ kernel.def @paged_decode_attention_tile_f32() {
   %new_acc2 = vector.addf<reassoc|nnan|nsz|contract> %new_acc1, %weighted_value2 : vector<4xf32>
   %new_acc3 = vector.addf<reassoc|nnan|nsz|contract> %new_acc2, %weighted_value3 : vector<4xf32>
 
-  view.store %new_max, %new_state_view[%zero_index] : f32, view<2xf32, #dense>
+  view.store %new_max, %new_state_view[%max_state_index] : f32, view<2xf32, #dense>
   view.store %new_sum, %new_state_view[1] : f32, view<2xf32, #dense>
   vector.store %new_acc3, %new_acc_view[0] : vector<4xf32>, view<4xf32, #dense>
   kernel.return

--- a/loom/src/loom/test/integration/checked_benchmarks/paged_kv_block_gather_score_tile_f32.loom
+++ b/loom/src/loom/test/integration/checked_benchmarks/paged_kv_block_gather_score_tile_f32.loom
@@ -10,10 +10,11 @@ kernel.def @paged_kv_block_gather_score_tile_f32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%block_id0: index, %lane_start0: index, %valid_count: i32, %query: buffer, %page_table: buffer, %page_pool: buffer, %score_output: buffer, %payload_output: buffer) {
   %base = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %zero_i32 = scalar.constant 0 : i32
-  %one_i32 = scalar.constant 1 : i32
-  %zero_f32 = scalar.constant 0.0 : f32
+  %result_index = index.constant 0 : index
+  %lane_sequence_begin = scalar.constant 0 : i32
+  %lane_sequence_step = scalar.constant 1 : i32
+  %masked_payload_fill = scalar.constant 0.0 : f32
+  %score_initial = scalar.constant 0.0 : f32
 
   %block_id = index.assume %block_id0 [range(%block_id0, 0, 1)] : index
   %lane_start = index.assume %lane_start0 [range(%lane_start0, 0, 4)] : index
@@ -39,16 +40,16 @@ kernel.def @paged_kv_block_gather_score_tile_f32() {
 
   %query_values = vector.load %query_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %payload_values = vector.load %payload_view[0] : view<4xf32, #dense> -> vector<4xf32>
-  %lanes = vector.iota %zero_i32 step %one_i32 : vector<4xi32>
+  %lanes = vector.iota %lane_sequence_begin step %lane_sequence_step : vector<4xi32>
   %valid_limits = vector.splat %valid_count : vector<4xi32>
   %valid = vector.cmpi slt, %lanes, %valid_limits : vector<4xi32> -> vector<4xi1>
-  %zeros = vector.splat %zero_f32 : vector<4xf32>
+  %zeros = vector.splat %masked_payload_fill : vector<4xf32>
   %masked_payload_values = vector.select %valid, %payload_values, %zeros : vector<4xf32>
   %products = vector.mulf<reassoc|nnan|nsz|contract> %query_values, %masked_payload_values : vector<4xf32>
-  %score = vector.reduce<addf, reassoc|nnan|nsz|contract> %products, %zero_f32 : vector<4xf32>, f32
+  %score = vector.reduce<addf, reassoc|nnan|nsz|contract> %products, %score_initial : vector<4xf32>, f32
 
-  view.store %score, %score_output_view[%zero_index] : f32, view<1xf32, #dense>
-  vector.store %masked_payload_values, %payload_output_view[%zero_index] : vector<4xf32>, view<4xf32, #dense>
+  view.store %score, %score_output_view[%result_index] : f32, view<1xf32, #dense>
+  vector.store %masked_payload_values, %payload_output_view[%result_index] : vector<4xf32>, view<4xf32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/test/integration/checked_benchmarks/rope_pair_rotate_tile_f32.loom
+++ b/loom/src/loom/test/integration/checked_benchmarks/rope_pair_rotate_tile_f32.loom
@@ -11,7 +11,7 @@ kernel.def @rope_pair_rotate_tile_f32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%even: buffer, %odd: buffer, %angles: buffer, %rotated_even: buffer, %rotated_odd: buffer) {
   %base = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %tile_origin = index.constant 0 : index
 
   %even_noalias, %odd_noalias, %angles_noalias, %rotated_even_noalias, %rotated_odd_noalias = buffer.assume.noalias %even, %odd, %angles, %rotated_even, %rotated_odd : buffer, buffer, buffer, buffer, buffer
   %even_view = buffer.view %even_noalias[%base] : buffer -> view<4xf32, #dense>
@@ -33,8 +33,8 @@ kernel.def @rope_pair_rotate_tile_f32() {
   %odd_cos = vector.mulf<reassoc|nnan|nsz|contract> %odd_values, %cosine : vector<4xf32>
   %new_odd = vector.addf<reassoc|nnan|nsz|contract> %even_sin, %odd_cos : vector<4xf32>
 
-  vector.store %new_even, %rotated_even_view[%zero_index] : vector<4xf32>, view<4xf32, #dense>
-  vector.store %new_odd, %rotated_odd_view[%zero_index] : vector<4xf32>, view<4xf32, #dense>
+  vector.store %new_even, %rotated_even_view[%tile_origin] : vector<4xf32>, view<4xf32, #dense>
+  vector.store %new_odd, %rotated_odd_view[%tile_origin] : vector<4xf32>, view<4xf32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/test/integration/checked_benchmarks/signed_i8_tile_quantize_f32.loom
+++ b/loom/src/loom/test/integration/checked_benchmarks/signed_i8_tile_quantize_f32.loom
@@ -10,16 +10,18 @@ kernel.def @signed_i8_tile_quantize_even_ties_f32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%values: buffer, %inverse_scale: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %tile_origin = index.constant 0 : index
+  %scale_index = index.constant 0 : index
+  %first_output_index = index.constant 0 : index
+  %last_output_index = index.constant 1 : index
 
   %values_noalias, %inverse_scale_noalias, %output_noalias = buffer.assume.noalias %values, %inverse_scale, %output : buffer, buffer, buffer
   %values_view = buffer.view %values_noalias[%base] : buffer -> view<4xf32, #dense>
   %inverse_scale_view = buffer.view %inverse_scale_noalias[%base] : buffer -> view<1xf32, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<2xi8, #dense>
 
-  %value_vector = vector.load %values_view[%zero] : view<4xf32, #dense> -> vector<4xf32>
-  %inverse_scale_scalar = view.load %inverse_scale_view[%zero] : view<1xf32, #dense> -> f32
+  %value_vector = vector.load %values_view[%tile_origin] : view<4xf32, #dense> -> vector<4xf32>
+  %inverse_scale_scalar = view.load %inverse_scale_view[%scale_index] : view<1xf32, #dense> -> f32
   %inverse_scale_vector = vector.splat %inverse_scale_scalar : vector<4xf32>
   %scaled = vector.mulf %value_vector, %inverse_scale_vector : vector<4xf32>
   %rounded = vector.roundevenf %scaled : vector<4xf32>
@@ -27,8 +29,8 @@ kernel.def @signed_i8_tile_quantize_even_ties_f32() {
   %i8_values = vector.trunci %i32_values : vector<4xi32> to vector<4xi8>
   %first = vector.extract %i8_values[0] : vector<4xi8> -> i8
   %last = vector.extract %i8_values[3] : vector<4xi8> -> i8
-  view.store %first, %output_view[%zero] : i8, view<2xi8, #dense>
-  view.store %last, %output_view[%one] : i8, view<2xi8, #dense>
+  view.store %first, %output_view[%first_output_index] : i8, view<2xi8, #dense>
+  view.store %last, %output_view[%last_output_index] : i8, view<2xi8, #dense>
   kernel.return
 }
 
@@ -37,15 +39,17 @@ kernel.def @signed_i8_tile_quantize_arcp_f32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%values: buffer, %amax: buffer, %output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %tile_origin = index.constant 0 : index
+  %amax_index = index.constant 0 : index
+  %output_origin = index.constant 0 : index
 
   %values_noalias, %amax_noalias, %output_noalias = buffer.assume.noalias %values, %amax, %output : buffer, buffer, buffer
   %values_view = buffer.view %values_noalias[%base] : buffer -> view<4xf32, #dense>
   %amax_view = buffer.view %amax_noalias[%base] : buffer -> view<1xf32, #dense>
   %output_view = buffer.view %output_noalias[%base] : buffer -> view<4xi8, #dense>
 
-  %value_vector = vector.load %values_view[%zero] : view<4xf32, #dense> -> vector<4xf32>
-  %amax_scalar = view.load %amax_view[%zero] : view<1xf32, #dense> -> f32
+  %value_vector = vector.load %values_view[%tile_origin] : view<4xf32, #dense> -> vector<4xf32>
+  %amax_scalar = view.load %amax_view[%amax_index] : view<1xf32, #dense> -> f32
   %scale_limit = scalar.constant 127.0 : f32
   %inverse_scale = scalar.divf<nnan|ninf|nsz|arcp> %scale_limit, %amax_scalar : f32
   %inverse_scale_vector = vector.splat %inverse_scale : vector<4xf32>
@@ -53,7 +57,7 @@ kernel.def @signed_i8_tile_quantize_arcp_f32() {
   %rounded = vector.roundf<afn> %scaled : vector<4xf32>
   %i32_values = vector.fptosi %rounded : vector<4xf32> to vector<4xi32>
   %i8_values = vector.trunci %i32_values : vector<4xi32> to vector<4xi8>
-  vector.store %i8_values, %output_view[%zero] : vector<4xi8>, view<4xi8, #dense>
+  vector.store %i8_values, %output_view[%output_origin] : vector<4xi8>, view<4xi8, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/test/integration/checked_benchmarks/split_kv_online_softmax_combine_f32.loom
+++ b/loom/src/loom/test/integration/checked_benchmarks/split_kv_online_softmax_combine_f32.loom
@@ -13,7 +13,7 @@ kernel.def @split_kv_online_softmax_combine_f32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%state0: buffer, %acc0: buffer, %state1: buffer, %acc1: buffer, %combined_state: buffer, %combined_acc: buffer) {
   %base = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %max_state_index = index.constant 0 : index
 
   %state0_noalias, %acc0_noalias, %state1_noalias, %acc1_noalias, %combined_state_noalias, %combined_acc_noalias = buffer.assume.noalias %state0, %acc0, %state1, %acc1, %combined_state, %combined_acc : buffer, buffer, buffer, buffer, buffer, buffer
   %state0_view = buffer.view %state0_noalias[%base] : buffer -> view<2xf32, #dense>
@@ -45,7 +45,7 @@ kernel.def @split_kv_online_softmax_combine_f32() {
   %scaled_acc1 = vector.mulf<reassoc|nnan|nsz|contract> %acc1_values, %scale1_vector : vector<4xf32>
   %combined_acc_values = vector.addf<reassoc|nnan|nsz|contract> %scaled_acc0, %scaled_acc1 : vector<4xf32>
 
-  view.store %combined_max, %combined_state_view[%zero_index] : f32, view<2xf32, #dense>
+  view.store %combined_max, %combined_state_view[%max_state_index] : f32, view<2xf32, #dense>
   view.store %combined_sum, %combined_state_view[1] : f32, view<2xf32, #dense>
   vector.store %combined_acc_values, %combined_acc_view[0] : vector<4xf32>, view<4xf32, #dense>
   kernel.return

--- a/loom/src/loom/test/integration/checked_benchmarks/top2_routing_expert_gather_f32.loom
+++ b/loom/src/loom/test/integration/checked_benchmarks/top2_routing_expert_gather_f32.loom
@@ -27,15 +27,19 @@ kernel.def @top2_routing_expert_gather_f32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%scores: buffer, %expert_payloads: buffer, %route_ids: buffer, %route_scores: buffer, %combined_payload: buffer) {
   %base = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %one_index = index.constant 1 : index
-  %two_index = index.constant 2 : index
-  %three_index = index.constant 3 : index
+  %initial_route_row = index.constant 0 : index
+  %expert_row0 = index.constant 0 : index
+  %expert_row1 = index.constant 1 : index
+  %expert_row2 = index.constant 2 : index
+  %expert_row3 = index.constant 3 : index
+  %payload_origin = index.constant 0 : index
+  %best_route_slot = index.constant 0 : index
+  %second_route_slot = index.constant 1 : index
   %invalid_id = scalar.constant -1 : i32
-  %zero_i32 = scalar.constant 0 : i32
-  %one_i32 = scalar.constant 1 : i32
-  %two_i32 = scalar.constant 2 : i32
-  %three_i32 = scalar.constant 3 : i32
+  %expert_id0 = scalar.constant 0 : i32
+  %expert_id1 = scalar.constant 1 : i32
+  %expert_id2 = scalar.constant 2 : i32
+  %expert_id3 = scalar.constant 3 : i32
   %negative_large = scalar.constant -1000000000.0 : f32
 
   %scores_noalias, %expert_payloads_noalias, %route_ids_noalias, %route_scores_noalias, %combined_payload_noalias = buffer.assume.noalias %scores, %expert_payloads, %route_ids, %route_scores, %combined_payload : buffer, buffer, buffer, buffer, buffer
@@ -51,19 +55,19 @@ kernel.def @top2_routing_expert_gather_f32() {
   %score2 = vector.extract %score_values[2] : vector<4xf32> -> f32
   %score3 = vector.extract %score_values[3] : vector<4xf32> -> f32
 
-  %best_score0, %best_id0, %best_row0, %second_score0, %second_id0, %second_row0 = func.call @top2_route_update(%score0, %zero_i32, %zero_index, %negative_large, %invalid_id, %zero_index, %negative_large, %invalid_id, %zero_index) : (f32, i32, index, f32, i32, index, f32, i32, index) -> (f32, i32, index, f32, i32, index)
-  %best_score1, %best_id1, %best_row1, %second_score1, %second_id1, %second_row1 = func.call @top2_route_update(%score1, %one_i32, %one_index, %best_score0, %best_id0, %best_row0, %second_score0, %second_id0, %second_row0) : (f32, i32, index, f32, i32, index, f32, i32, index) -> (f32, i32, index, f32, i32, index)
-  %best_score2, %best_id2, %best_row2, %second_score2, %second_id2, %second_row2 = func.call @top2_route_update(%score2, %two_i32, %two_index, %best_score1, %best_id1, %best_row1, %second_score1, %second_id1, %second_row1) : (f32, i32, index, f32, i32, index, f32, i32, index) -> (f32, i32, index, f32, i32, index)
-  %best_score3, %best_id3, %best_row3, %second_score3, %second_id3, %second_row3 = func.call @top2_route_update(%score3, %three_i32, %three_index, %best_score2, %best_id2, %best_row2, %second_score2, %second_id2, %second_row2) : (f32, i32, index, f32, i32, index, f32, i32, index) -> (f32, i32, index, f32, i32, index)
+  %best_score0, %best_id0, %best_row0, %second_score0, %second_id0, %second_row0 = func.call @top2_route_update(%score0, %expert_id0, %expert_row0, %negative_large, %invalid_id, %initial_route_row, %negative_large, %invalid_id, %initial_route_row) : (f32, i32, index, f32, i32, index, f32, i32, index) -> (f32, i32, index, f32, i32, index)
+  %best_score1, %best_id1, %best_row1, %second_score1, %second_id1, %second_row1 = func.call @top2_route_update(%score1, %expert_id1, %expert_row1, %best_score0, %best_id0, %best_row0, %second_score0, %second_id0, %second_row0) : (f32, i32, index, f32, i32, index, f32, i32, index) -> (f32, i32, index, f32, i32, index)
+  %best_score2, %best_id2, %best_row2, %second_score2, %second_id2, %second_row2 = func.call @top2_route_update(%score2, %expert_id2, %expert_row2, %best_score1, %best_id1, %best_row1, %second_score1, %second_id1, %second_row1) : (f32, i32, index, f32, i32, index, f32, i32, index) -> (f32, i32, index, f32, i32, index)
+  %best_score3, %best_id3, %best_row3, %second_score3, %second_id3, %second_row3 = func.call @top2_route_update(%score3, %expert_id3, %expert_row3, %best_score2, %best_id2, %best_row2, %second_score2, %second_id2, %second_row2) : (f32, i32, index, f32, i32, index, f32, i32, index) -> (f32, i32, index, f32, i32, index)
 
-  %best_payload = vector.load %expert_payloads_view[%best_row3, %zero_index] : view<4x4xf32, #dense> -> vector<4xf32>
-  %second_payload = vector.load %expert_payloads_view[%second_row3, %zero_index] : view<4x4xf32, #dense> -> vector<4xf32>
+  %best_payload = vector.load %expert_payloads_view[%best_row3, %payload_origin] : view<4x4xf32, #dense> -> vector<4xf32>
+  %second_payload = vector.load %expert_payloads_view[%second_row3, %payload_origin] : view<4x4xf32, #dense> -> vector<4xf32>
   %combined = vector.addf<reassoc|nnan|nsz> %best_payload, %second_payload : vector<4xf32>
 
-  view.store %best_id3, %route_ids_view[%zero_index] : i32, view<2xi32, #dense>
-  view.store %second_id3, %route_ids_view[%one_index] : i32, view<2xi32, #dense>
-  view.store %best_score3, %route_scores_view[%zero_index] : f32, view<2xf32, #dense>
-  view.store %second_score3, %route_scores_view[%one_index] : f32, view<2xf32, #dense>
+  view.store %best_id3, %route_ids_view[%best_route_slot] : i32, view<2xi32, #dense>
+  view.store %second_id3, %route_ids_view[%second_route_slot] : i32, view<2xi32, #dense>
+  view.store %best_score3, %route_scores_view[%best_route_slot] : f32, view<2xf32, #dense>
+  view.store %second_score3, %route_scores_view[%second_route_slot] : f32, view<2xf32, #dense>
   vector.store %combined, %combined_payload_view[0] : vector<4xf32>, view<4xf32, #dense>
   kernel.return
 }

--- a/loom/src/loom/test/integration/checked_benchmarks/weighted_expert_route_gather_f32.loom
+++ b/loom/src/loom/test/integration/checked_benchmarks/weighted_expert_route_gather_f32.loom
@@ -12,7 +12,8 @@ kernel.def @weighted_expert_route_gather_f32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%route_ids: buffer, %route_weights: buffer, %expert_payloads: buffer, %combined_payload: buffer) {
   %base = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %payload_origin = index.constant 0 : index
+  %combined_payload_origin = index.constant 0 : index
 
   %route_ids_noalias, %route_weights_noalias, %expert_payloads_noalias, %combined_payload_noalias = buffer.assume.noalias %route_ids, %route_weights, %expert_payloads, %combined_payload : buffer, buffer, buffer, buffer
   %route_ids_view = buffer.view %route_ids_noalias[%base] : buffer -> view<2xi32, #dense>
@@ -28,14 +29,14 @@ kernel.def @weighted_expert_route_gather_f32() {
   %route_id1 = index.assume %route_id1_index0 [range(%route_id1_index0, 0, 3)] : index
   %weight0 = view.load %route_weights_view[0] : view<2xf32, #dense> -> f32
   %weight1 = view.load %route_weights_view[1] : view<2xf32, #dense> -> f32
-  %payload0 = vector.load %expert_payloads_view[%route_id0, %zero_index] : view<4x4xf32, #dense> -> vector<4xf32>
-  %payload1 = vector.load %expert_payloads_view[%route_id1, %zero_index] : view<4x4xf32, #dense> -> vector<4xf32>
+  %payload0 = vector.load %expert_payloads_view[%route_id0, %payload_origin] : view<4x4xf32, #dense> -> vector<4xf32>
+  %payload1 = vector.load %expert_payloads_view[%route_id1, %payload_origin] : view<4x4xf32, #dense> -> vector<4xf32>
   %weight0_vector = vector.splat %weight0 : vector<4xf32>
   %weight1_vector = vector.splat %weight1 : vector<4xf32>
   %weighted_payload0 = vector.mulf<reassoc|nnan|nsz|contract> %payload0, %weight0_vector : vector<4xf32>
   %weighted_payload1 = vector.mulf<reassoc|nnan|nsz|contract> %payload1, %weight1_vector : vector<4xf32>
   %combined = vector.addf<reassoc|nnan|nsz|contract> %weighted_payload0, %weighted_payload1 : vector<4xf32>
-  vector.store %combined, %combined_payload_view[%zero_index] : vector<4xf32>, view<4xf32, #dense>
+  vector.store %combined, %combined_payload_view[%combined_payload_origin] : vector<4xf32>, view<4xf32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/test/integration/checked_benchmarks/workgroup_rank_sort_f32_i32.loom
+++ b/loom/src/loom/test/integration/checked_benchmarks/workgroup_rank_sort_f32_i32.loom
@@ -12,11 +12,11 @@ kernel.def @workgroup_rank_sort_f32_i32() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%scores: buffer, %sorted_ids: buffer) {
   %base = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %eight_index = index.constant 8 : index
-  %one_index = index.constant 1 : index
-  %zero_i32 = scalar.constant 0 : i32
-  %one_i32 = scalar.constant 1 : i32
+  %peer_begin = index.constant 0 : index
+  %peer_end = index.constant 8 : index
+  %peer_step = index.constant 1 : index
+  %initial_rank = scalar.constant 0 : i32
+  %rank_increment = scalar.constant 1 : i32
   %scratch_bytes = index.constant 32 : offset
 
   %lane0 = kernel.workitem.id<x> : index
@@ -34,7 +34,7 @@ kernel.def @workgroup_rank_sort_f32_i32() {
 
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
 
-  %rank = scf.for %other = [%zero_index to %eight_index step %one_index](%acc = %zero_i32 : i32) -> (i32) {
+  %rank = scf.for %other = [%peer_begin to %peer_end step %peer_step](%acc = %initial_rank : i32) -> (i32) {
     %other_score = view.load %scratch_view[%other] : view<8xf32, #dense> -> f32
     %other_i32 = index.cast %other : index to i32
     %greater = scalar.cmpf ogt, %other_score, %score : f32
@@ -43,7 +43,7 @@ kernel.def @workgroup_rank_sort_f32_i32() {
     %tie_before = scalar.andi %equal, %other_before : i1
     %precedes = scalar.ori %greater, %tie_before : i1
     %next = scf.if %precedes -> (i32) {
-      %incremented = scalar.addi %acc, %one_i32 : i32
+      %incremented = scalar.addi %acc, %rank_increment : i32
       scf.yield %incremented : i32
     } else {
       scf.yield %acc : i32

--- a/loom/src/loom/tooling/execution/hal/testdata/dynamic_workgroup_hal_actual.loom
+++ b/loom/src/loom/tooling/execution/hal/testdata/dynamic_workgroup_hal_actual.loom
@@ -1,17 +1,17 @@
 kernel.def @dynamic_workgroup_fill(%workgroup_count: index) {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%workgroup_count, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%workgroup_count, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%workgroup_count: index, %output: buffer) {
   %workgroup_count_bounded = index.assume %workgroup_count [range(%workgroup_count, 1, 4)] : index
   %workgroup_id0 = kernel.workgroup.id<x> : index
-  %four = index.constant 4 : index
-  %workgroup_id = index.rem %workgroup_id0, %four : index
-  %zero = index.constant 0 : offset
+  %element_count = index.constant 4 : index
+  %workgroup_id = index.rem %workgroup_id0, %element_count : index
+  %base = index.constant 0 : offset
   %value = scalar.constant 42 : i32
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
   %global_output = buffer.assume.memory_space<global> %output_aligned : buffer
-  %output_view = buffer.view %global_output[%zero] : buffer -> view<4xi32, #dense>
-  scf.for %i = [%workgroup_id to %four step %workgroup_count_bounded] {
+  %output_view = buffer.view %global_output[%base] : buffer -> view<4xi32, #dense>
+  scf.for %i = [%workgroup_id to %element_count step %workgroup_count_bounded] {
     view.store %value, %output_view[%i] : i32, view<4xi32, #dense>
   }
   kernel.return

--- a/loom/src/loom/tooling/execution/hal/testdata/launch_schedule_hal_actual.loom
+++ b/loom/src/loom/tooling/execution/hal/testdata/launch_schedule_hal_actual.loom
@@ -2,14 +2,14 @@ kernel.def @launch_schedule_increment_i32() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
-  %input_view = buffer.view %input_aligned[%zero] : buffer -> view<1xi32, #dense>
+  %input_view = buffer.view %input_aligned[%base] : buffer -> view<1xi32, #dense>
   %value = view.load %input_view[0] : view<1xi32, #dense> -> i32
-  %one = scalar.constant 1 : i32
-  %incremented = scalar.addi %value, %one : i32
-  %output_view = buffer.view %output_aligned[%zero] : buffer -> view<1xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  %incremented = scalar.addi %value, %increment : i32
+  %output_view = buffer.view %output_aligned[%base] : buffer -> view<1xi32, #dense>
   view.store %incremented, %output_view[0] : i32, view<1xi32, #dense>
   kernel.return
 }
@@ -18,13 +18,13 @@ kernel.def @launch_schedule_double_i32() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
-  %input_view = buffer.view %input_aligned[%zero] : buffer -> view<1xi32, #dense>
+  %input_view = buffer.view %input_aligned[%base] : buffer -> view<1xi32, #dense>
   %value = view.load %input_view[0] : view<1xi32, #dense> -> i32
   %doubled = scalar.addi %value, %value : i32
-  %output_view = buffer.view %output_aligned[%zero] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output_aligned[%base] : buffer -> view<1xi32, #dense>
   view.store %doubled, %output_view[0] : i32, view<1xi32, #dense>
   kernel.return
 }

--- a/loom/src/loom/tooling/target/amdgpu/test/amdgpu_hal_actual.loom
+++ b/loom/src/loom/tooling/target/amdgpu/test/amdgpu_hal_actual.loom
@@ -2,12 +2,12 @@ kernel.def @store_i32() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %base = index.constant 0 : offset
+  %output_index = index.constant 0 : index
   %value = scalar.constant 42 : i32
   %global = buffer.assume.memory_space<global> %output : buffer
-  %view = buffer.view %global[%zero_offset] : buffer -> view<1xi32, #dense>
-  view.store %value, %view[%zero_index] : i32, view<1xi32, #dense>
+  %view = buffer.view %global[%base] : buffer -> view<1xi32, #dense>
+  view.store %value, %view[%output_index] : i32, view<1xi32, #dense>
   kernel.return
 }
 
@@ -15,13 +15,13 @@ kernel.def @double_i32() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %base = index.constant 0 : offset
+  %output_index = index.constant 0 : index
   %global = buffer.assume.memory_space<global> %output : buffer
-  %view = buffer.view %global[%zero_offset] : buffer -> view<1xi32, #dense>
-  %loaded = view.load %view[%zero_index] : view<1xi32, #dense> -> i32
+  %view = buffer.view %global[%base] : buffer -> view<1xi32, #dense>
+  %loaded = view.load %view[%output_index] : view<1xi32, #dense> -> i32
   %doubled = scalar.addi %loaded, %loaded : i32
-  view.store %doubled, %view[%zero_index] : i32, view<1xi32, #dense>
+  view.store %doubled, %view[%output_index] : i32, view<1xi32, #dense>
   kernel.return
 }
 

--- a/loom/src/loom/tooling/target/amdgpu/test/amdgpu_unused_kernargs.loom
+++ b/loom/src/loom/tooling/target/amdgpu/test/amdgpu_unused_kernargs.loom
@@ -20,9 +20,9 @@ kernel.def @unused_middle_binding() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %unused: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<1xi32, #dense>
   %value = view.load %input_view[0] : view<1xi32, #dense> -> i32
   view.store %value, %output_view[0] : i32, view<1xi32, #dense>
   kernel.return
@@ -43,16 +43,16 @@ kernel.def @selected_buffer(%select_rhs: index) {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%select_rhs: index, %lhs: buffer, %rhs: buffer, %output: buffer) {
-  %one = index.constant 1 : index
-  %zero = index.constant 0 : offset
-  %use_rhs = index.cmp eq, %select_rhs, %one : index
+  %rhs_selector = index.constant 1 : index
+  %base = index.constant 0 : offset
+  %use_rhs = index.cmp eq, %select_rhs, %rhs_selector : index
   %selected = scf.if %use_rhs -> (buffer) {
     scf.yield %rhs : buffer
   } else {
     scf.yield %lhs : buffer
   }
-  %selected_view = buffer.view %selected[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %selected_view = buffer.view %selected[%base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<1xi32, #dense>
   %value = view.load %selected_view[0] : view<1xi32, #dense> -> i32
   view.store %value, %output_view[0] : i32, view<1xi32, #dense>
   kernel.return
@@ -82,20 +82,20 @@ check.case @selected_rhs_case {
 // within one dispatch, preventing check-case specialization from folding the
 // choices.
 kernel.def @selected_buffer_per_workgroup() {
-  %three = index.constant 3 : index
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%three, %one, %one) workgroup_size(%one, %one, %one) : index
+  %workgroup_count = index.constant 3 : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%workgroup_count, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%lhs: buffer, %middle: buffer, %rhs: buffer, %output: buffer) {
   %workgroup = kernel.workgroup.id<x> : index
-  %zero = index.constant 0 : index
-  %two = index.constant 2 : index
-  %zero_offset = index.constant 0 : offset
-  %use_lhs = index.cmp eq, %workgroup, %zero : index
-  %use_rhs = index.cmp eq, %workgroup, %two : index
+  %lhs_workgroup = index.constant 0 : index
+  %rhs_workgroup = index.constant 2 : index
+  %base = index.constant 0 : offset
+  %use_lhs = index.cmp eq, %workgroup, %lhs_workgroup : index
+  %use_rhs = index.cmp eq, %workgroup, %rhs_workgroup : index
   %middle_or_rhs = scf.select %use_rhs, %rhs, %middle : buffer
   %selected = scf.select %use_lhs, %lhs, %middle_or_rhs : buffer
-  %selected_view = buffer.view %selected[%zero_offset] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<3xi32, #dense>
+  %selected_view = buffer.view %selected[%base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<3xi32, #dense>
   %value = view.load %selected_view[0] : view<1xi32, #dense> -> i32
   view.store %value, %output_view[%workgroup] : i32, view<3xi32, #dense>
   kernel.return

--- a/loom/src/loom/tooling/target/amdgpu/test/complete_authoring_module.loom
+++ b/loom/src/loom/tooling/target/amdgpu/test/complete_authoring_module.loom
@@ -2,9 +2,9 @@ kernel.def @complete_authoring_copy_i32() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero] : buffer -> view<1xi32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<1xi32, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<1xi32, #dense>
   %value = view.load %input_view[0] : view<1xi32, #dense> -> i32
   view.store %value, %output_view[0] : i32, view<1xi32, #dense>
   kernel.return

--- a/loom/src/loom/tooling/target/amdgpu/test/gfx1250_configured_fragment_bank.loom
+++ b/loom/src/loom/tooling/target/amdgpu/test/gfx1250_configured_fragment_bank.loom
@@ -11,16 +11,16 @@ config.decl @test.fragment_bank.scratch_elements : %value: index where [range(%v
 amdgpu.target<gfx1250> @target
 
 kernel.def target(@target) export("configured_fragment_bank") @configured_fragment_bank() {
-  %one = index.constant 1 : index
+  %unit = index.constant 1 : index
   %workgroup_size = config.get @test.fragment_bank.workgroup_size : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %four = index.constant 4 : index
-  %c16 = index.constant 16 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %stage_count = index.constant 2 : index
+  %element_bytes = index.constant 4 : index
+  %tile_extent = index.constant 16 : index
   %matrix_m = index.constant 16 : index
   %matrix_n = index.constant 16 : index
   %matrix_k = index.constant 32 : index
@@ -28,9 +28,9 @@ kernel.def target(@target) export("configured_fragment_bank") @configured_fragme
   %n_fragments = config.get @test.fragment_bank.n_fragments : index
   %k_fragments = config.get @test.fragment_bank.k_fragments : index
   %scratch_elements = config.get @test.fragment_bank.scratch_elements : index
-  %m_extent = index.mul %m_fragments, %c16 : index
-  %n_extent = index.mul %n_fragments, %c16 : index
-  %scratch_bytes_index = index.mul %scratch_elements, %four : index
+  %m_extent = index.mul %m_fragments, %tile_extent : index
+  %n_extent = index.mul %n_fragments, %tile_extent : index
+  %scratch_bytes_index = index.mul %scratch_elements, %element_bytes : index
   %scratch_bytes = index.cast %scratch_bytes_index : index to offset
   %lane = kernel.workitem.id<x> : index
   %output_global = buffer.assume.memory_space<global> %output : buffer
@@ -47,10 +47,10 @@ kernel.def target(@target) export("configured_fragment_bank") @configured_fragme
   %zero_payload = vector.constant 0.0 : vector<8xf32>
   %zero_fragment = vector.fragment<init> %zero_payload shape [%matrix_m, %matrix_n] : vector<8xf32>
   %initial_bank = vector.broadcast %zero_fragment : vector<8xf32> -> vector<[%m_fragments]x[%n_fragments]x8xf32>
-  %result_bank = scf.for %stage = [%zero to %two step %one](%stage_bank = %initial_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) {
-    %after_k = scf.for %k_fragment = [%zero to %k_fragments step %one](%k_bank = %stage_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) unroll {
-      %after_m = scf.for %m_fragment = [%zero to %m_fragments step %one](%m_bank = %k_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) unroll {
-        %after_n = scf.for %n_fragment = [%zero to %n_fragments step %one](%n_bank = %m_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) unroll {
+  %result_bank = scf.for %stage = [%loop_begin to %stage_count step %loop_step](%stage_bank = %initial_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) {
+    %after_k = scf.for %k_fragment = [%loop_begin to %k_fragments step %loop_step](%k_bank = %stage_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) unroll {
+      %after_m = scf.for %m_fragment = [%loop_begin to %m_fragments step %loop_step](%m_bank = %k_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) unroll {
+        %after_n = scf.for %n_fragment = [%loop_begin to %n_fragments step %loop_step](%n_bank = %m_bank : vector<[%m_fragments]x[%n_fragments]x8xf32>) -> (vector<[%m_fragments]x[%n_fragments]x8xf32>) unroll {
           %accumulator_payload = vector.extract %n_bank[%m_fragment, %n_fragment] : vector<[%m_fragments]x[%n_fragments]x8xf32> -> vector<8xf32>
           %accumulator = vector.fragment<init> %accumulator_payload shape [%matrix_m, %matrix_n] : vector<8xf32>
           %next_accumulator = vector.mma %lhs, %rhs, %accumulator : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
@@ -63,10 +63,10 @@ kernel.def target(@target) export("configured_fragment_bank") @configured_fragme
     }
     scf.yield %after_k : vector<[%m_fragments]x[%n_fragments]x8xf32>
   }
-  scf.for %store_m = [%zero to %m_fragments step %one] unroll {
-    %store_m_offset = index.mul %store_m, %c16 : index
-    scf.for %store_n = [%zero to %n_fragments step %one] unroll {
-      %store_n_offset = index.mul %store_n, %c16 : index
+  scf.for %store_m = [%loop_begin to %m_fragments step %loop_step] unroll {
+    %store_m_offset = index.mul %store_m, %tile_extent : index
+    scf.for %store_n = [%loop_begin to %n_fragments step %loop_step] unroll {
+      %store_n_offset = index.mul %store_n, %tile_extent : index
       %store_payload = vector.extract %result_bank[%store_m, %store_n] : vector<[%m_fragments]x[%n_fragments]x8xf32> -> vector<8xf32>
       %store_fragment = vector.fragment<result> %store_payload shape [%matrix_m, %matrix_n] : vector<8xf32>
       vector.fragment.store<result> %store_fragment, %output_view[%store_m_offset, %store_n_offset] shape [%matrix_m, %matrix_n] : vector<8xf32>, view<[%m_extent]x[%n_extent]xf32, #dense>

--- a/loom/src/loom/tooling/target/amdgpu/test/loom_opt_f32_arith.loom
+++ b/loom/src/loom/tooling/target/amdgpu/test/loom_opt_f32_arith.loom
@@ -6,10 +6,10 @@ kernel.def target(@target) @f32_arith() {
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %output: buffer) {
   %tid = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
-  %lhs_view = buffer.view %lhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %rhs_view = buffer.view %rhs_buffer[%zero] : buffer -> view<64xf32, #dense>
-  %output_view = buffer.view %output[%zero] : buffer -> view<64xf32, #dense>
+  %base = index.constant 0 : offset
+  %lhs_view = buffer.view %lhs_buffer[%base] : buffer -> view<64xf32, #dense>
+  %rhs_view = buffer.view %rhs_buffer[%base] : buffer -> view<64xf32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<64xf32, #dense>
   %lhs = vector.load %lhs_view[%tid] : view<64xf32, #dense> -> vector<1xf32>
   %rhs = vector.load %rhs_view[%tid] : view<64xf32, #dense> -> vector<1xf32>
   %sum = vector.addf %lhs, %rhs : vector<1xf32>

--- a/loom/src/loom/tooling/target/amdgpu/test/selected_root_amdgpu.loom
+++ b/loom/src/loom/tooling/target/amdgpu/test/selected_root_amdgpu.loom
@@ -8,12 +8,12 @@ kernel.def target(@gfx11_generic_target) export("selected_store_i32") @selected_
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %base = index.constant 0 : offset
+  %output_index = index.constant 0 : index
   %value = scalar.constant 42 : i32
   %global = buffer.assume.memory_space<global> %output : buffer
-  %view = buffer.view %global[%zero_offset] : buffer -> view<1xi32, #dense>
-  view.store %value, %view[%zero_index] : i32, view<1xi32, #dense>
+  %view = buffer.view %global[%base] : buffer -> view<1xi32, #dense>
+  view.store %value, %view[%output_index] : i32, view<1xi32, #dense>
   kernel.return
 }
 
@@ -23,12 +23,12 @@ kernel.def export("configured_targetless_store_i32") @configured_targetless_stor
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%workgroups_x, %unit, %unit) workgroup_size(%workgroup_size_x, %unit, %unit) : index
 } launch(%output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
+  %base = index.constant 0 : offset
+  %output_index = index.constant 0 : index
   %value = scalar.constant 7 : i32
   %global = buffer.assume.memory_space<global> %output : buffer
-  %view = buffer.view %global[%zero_offset] : buffer -> view<1xi32, #dense>
-  view.store %value, %view[%zero_index] : i32, view<1xi32, #dense>
+  %view = buffer.view %global[%base] : buffer -> view<1xi32, #dense>
+  view.store %value, %view[%output_index] : i32, view<1xi32, #dense>
   kernel.return
 }
 
@@ -38,13 +38,13 @@ kernel.def export("targetless_math_f32") @targetless_math_f32() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero_index = index.constant 0 : index
-  %input_view = buffer.view %input[%zero_offset] : buffer -> view<1xf32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xf32, #dense>
-  %input_value = view.load %input_view[%zero_index] : view<1xf32, #dense> -> f32
+  %base = index.constant 0 : offset
+  %element_index = index.constant 0 : index
+  %input_view = buffer.view %input[%base] : buffer -> view<1xf32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<1xf32, #dense>
+  %input_value = view.load %input_view[%element_index] : view<1xf32, #dense> -> f32
   %activated = scalar.siluf %input_value : f32
   %rounded = scalar.roundf %activated : f32
-  view.store %rounded, %output_view[%zero_index] : f32, view<1xf32, #dense>
+  view.store %rounded, %output_view[%element_index] : f32, view<1xf32, #dense>
   kernel.return
 }

--- a/loom/src/loom/tooling/target/amdgpu/test/target_family_template_provider_amdgpu.loom
+++ b/loom/src/loom/tooling/target/amdgpu/test/target_family_template_provider_amdgpu.loom
@@ -10,15 +10,15 @@ func.template<demo.target_family> target(@gfx12_5_family) @gfx12_5_provider(%val
 }
 
 kernel.def export("target_family_template_provider") @target_family_template_provider() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
   %base = index.constant 0 : offset
-  %zero = index.constant 0 : index
+  %output_index = index.constant 0 : index
   %value = scalar.constant 42 : i32
   %selected = func.apply<demo.target_family>(%value) : (i32) -> (i32)
   %global = buffer.assume.memory_space<global> %output : buffer
   %view = buffer.view %global[%base] : buffer -> view<1xi32, #dense>
-  view.store %selected, %view[%zero] : i32, view<1xi32, #dense>
+  view.store %selected, %view[%output_index] : i32, view<1xi32, #dense>
   kernel.return
 }

--- a/loom/src/loom/tooling/target/spirv/test/spirv_vulkan_coop_hal_actual.loom
+++ b/loom/src/loom/tooling/target/spirv/test/spirv_vulkan_coop_hal_actual.loom
@@ -1,10 +1,10 @@
 spirv.target<vulkan1_3> @target {abi = hal_kernel}
 
 kernel.def target(@target) @cooperative_matrix_f16_two_tiles() {
-  %two = index.constant 2 : index
+  %workgroup_count = index.constant 2 : index
   %unit = index.constant 1 : index
   %subgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%two, %unit, %unit) workgroup_size(%subgroup_size, %unit, %unit) : index
+  kernel.launch.config workgroups(%workgroup_count, %unit, %unit) workgroup_size(%subgroup_size, %unit, %unit) : index
 } launch(%lhs_buffer: buffer, %rhs_buffer: buffer, %init_buffer: buffer, %out_buffer: buffer) {
   %workgroup_x = kernel.workgroup.id<x> : index
   %lhs_tile_bytes = index.constant 512 : index
@@ -15,8 +15,8 @@ kernel.def target(@target) @cooperative_matrix_f16_two_tiles() {
   %acc_byte_offset = index.cast %acc_byte_index : index to offset
   %lhs_byte_offset_aligned = index.assume %lhs_byte_offset [mul(%lhs_byte_offset, 16)] : offset
   %acc_byte_offset_aligned = index.assume %acc_byte_offset [mul(%acc_byte_offset, 16)] : offset
-  %zero_offset = index.constant 0 : offset
-  %zero_offset_aligned = index.assume %zero_offset [mul(%zero_offset, 16)] : offset
+  %rhs_base = index.constant 0 : offset
+  %rhs_base_aligned = index.assume %rhs_base [mul(%rhs_base, 16)] : offset
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -25,7 +25,7 @@ kernel.def target(@target) @cooperative_matrix_f16_two_tiles() {
   %init_aligned = buffer.assume.alignment %init_buffer {minimum_alignment = 16} : buffer
   %out_aligned = buffer.assume.alignment %out_buffer {minimum_alignment = 16} : buffer
   %lhs_view = buffer.view %lhs_aligned[%lhs_byte_offset_aligned] : buffer -> view<16x16xf16, #dense>
-  %rhs_view = buffer.view %rhs_aligned[%zero_offset_aligned] : buffer -> view<16x16xf16, #dense>
+  %rhs_view = buffer.view %rhs_aligned[%rhs_base_aligned] : buffer -> view<16x16xf16, #dense>
   %init_view = buffer.view %init_aligned[%acc_byte_offset_aligned] : buffer -> view<16x16xf32, #dense>
   %out_view = buffer.view %out_aligned[%acc_byte_offset_aligned] : buffer -> view<16x16xf32, #dense>
   %lhs = vector.fragment.load<lhs> %lhs_view[0, 0] shape [%m, %k] : view<16x16xf16, #dense> -> vector<16xf16>
@@ -63,7 +63,7 @@ kernel.def target(@target) @dense_projection_tiled_f16_128() {
   %k_tiles = index.constant 8 : index
   %n_tiles = index.constant 8 : index
   %unit = index.constant 1 : index
-  %zero = index.constant 0 : index
+  %loop_begin = index.constant 0 : index
   %lhs_tile_bytes = index.constant 512 : index
   %rhs_tile_bytes = index.constant 512 : index
   %acc_tile_bytes = index.constant 1024 : index
@@ -81,7 +81,7 @@ kernel.def target(@target) @dense_projection_tiled_f16_128() {
   %init_view = buffer.view %init_aligned[%out_byte_offset_aligned] : buffer -> view<16x16xf32, #dense>
   %out_view = buffer.view %out_aligned[%out_byte_offset_aligned] : buffer -> view<16x16xf32, #dense>
   %init = vector.fragment.load<init> %init_view[0, 0] shape [%m, %n] : view<16x16xf32, #dense> -> vector<8xf32>
-  %result = scf.for %kt = [%zero to %k_tiles step %unit](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
+  %result = scf.for %kt = [%loop_begin to %k_tiles step %unit](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
     %lhs_tile_index = index.madd %workgroup_m, %k_tiles, %kt : index
     %rhs_tile_index = index.madd %kt, %n_tiles, %workgroup_n : index
     %lhs_byte_index = index.mul %lhs_tile_index, %lhs_tile_bytes : index
@@ -128,14 +128,14 @@ kernel.def target(@target) @narrow_score_tiled_f16_128x16_m1() {
   %k_tiles = index.constant 8 : index
   %n_tiles = index.constant 1 : index
   %unit = index.constant 1 : index
-  %zero = index.constant 0 : index
+  %c0 = index.constant 0 : index
   %lhs_tile_bytes = index.constant 512 : index
   %rhs_tile_bytes = index.constant 512 : index
   %acc_tile_bytes = index.constant 1024 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
-  %out_tile_index = index.madd %workgroup_m, %n_tiles, %zero : index
+  %out_tile_index = index.madd %workgroup_m, %n_tiles, %c0 : index
   %out_byte_index = index.mul %out_tile_index, %acc_tile_bytes : index
   %out_byte_offset = index.cast %out_byte_index : index to offset
   %out_byte_offset_aligned = index.assume %out_byte_offset [mul(%out_byte_offset, 16)] : offset
@@ -146,9 +146,9 @@ kernel.def target(@target) @narrow_score_tiled_f16_128x16_m1() {
   %init_view = buffer.view %init_aligned[%out_byte_offset_aligned] : buffer -> view<16x16xf32, #dense>
   %out_view = buffer.view %out_aligned[%out_byte_offset_aligned] : buffer -> view<16x16xf32, #dense>
   %init = vector.fragment.load<init> %init_view[0, 0] shape [%m, %n] : view<16x16xf32, #dense> -> vector<8xf32>
-  %result = scf.for %kt = [%zero to %k_tiles step %unit](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
+  %result = scf.for %kt = [%c0 to %k_tiles step %unit](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
     %lhs_tile_index = index.madd %workgroup_m, %k_tiles, %kt : index
-    %rhs_tile_index = index.madd %kt, %n_tiles, %zero : index
+    %rhs_tile_index = index.madd %kt, %n_tiles, %c0 : index
     %lhs_byte_index = index.mul %lhs_tile_index, %lhs_tile_bytes : index
     %rhs_byte_index = index.mul %rhs_tile_index, %rhs_tile_bytes : index
     %lhs_byte_offset = index.cast %lhs_byte_index : index to offset
@@ -176,30 +176,30 @@ kernel.def target(@target) @narrow_score_tiled_f16_128x16_m2() {
   %k_tiles = index.constant 8 : index
   %n_tiles = index.constant 1 : index
   %unit = index.constant 1 : index
-  %zero = index.constant 0 : index
-  %two = index.constant 2 : index
+  %c0 = index.constant 0 : index
+  %tiles_per_workgroup = index.constant 2 : index
   %lhs_tile_bytes = index.constant 512 : index
   %rhs_tile_bytes = index.constant 512 : index
   %acc_tile_bytes = index.constant 1024 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
-  %workgroup_m0 = index.mul %workgroup_pair, %two : index
+  %workgroup_m0 = index.mul %workgroup_pair, %tiles_per_workgroup : index
   %workgroup_m1 = index.add %workgroup_m0, %unit : index
   %lhs_aligned = buffer.assume.alignment %lhs_buffer {minimum_alignment = 16} : buffer
   %rhs_aligned = buffer.assume.alignment %rhs_buffer {minimum_alignment = 16} : buffer
   %init_aligned = buffer.assume.alignment %init_buffer {minimum_alignment = 16} : buffer
   %out_aligned = buffer.assume.alignment %out_buffer {minimum_alignment = 16} : buffer
-  %out_tile_index0 = index.madd %workgroup_m0, %n_tiles, %zero : index
+  %out_tile_index0 = index.madd %workgroup_m0, %n_tiles, %c0 : index
   %out_byte_index0 = index.mul %out_tile_index0, %acc_tile_bytes : index
   %out_byte_offset0 = index.cast %out_byte_index0 : index to offset
   %out_byte_offset_aligned0 = index.assume %out_byte_offset0 [mul(%out_byte_offset0, 16)] : offset
   %init_view0 = buffer.view %init_aligned[%out_byte_offset_aligned0] : buffer -> view<16x16xf32, #dense>
   %out_view0 = buffer.view %out_aligned[%out_byte_offset_aligned0] : buffer -> view<16x16xf32, #dense>
   %init0 = vector.fragment.load<init> %init_view0[0, 0] shape [%m, %n] : view<16x16xf32, #dense> -> vector<8xf32>
-  %result0 = scf.for %kt0 = [%zero to %k_tiles step %unit](%acc0 = %init0 : vector<8xf32>) -> (vector<8xf32>) {
+  %result0 = scf.for %kt0 = [%c0 to %k_tiles step %unit](%acc0 = %init0 : vector<8xf32>) -> (vector<8xf32>) {
     %lhs_tile_index0 = index.madd %workgroup_m0, %k_tiles, %kt0 : index
-    %rhs_tile_index0 = index.madd %kt0, %n_tiles, %zero : index
+    %rhs_tile_index0 = index.madd %kt0, %n_tiles, %c0 : index
     %lhs_byte_index0 = index.mul %lhs_tile_index0, %lhs_tile_bytes : index
     %rhs_byte_index0 = index.mul %rhs_tile_index0, %rhs_tile_bytes : index
     %lhs_byte_offset0 = index.cast %lhs_byte_index0 : index to offset
@@ -214,16 +214,16 @@ kernel.def target(@target) @narrow_score_tiled_f16_128x16_m2() {
     scf.yield %next0 : vector<8xf32>
   }
   vector.fragment.store<result> %result0, %out_view0[0, 0] shape [%m, %n] : vector<8xf32>, view<16x16xf32, #dense>
-  %out_tile_index1 = index.madd %workgroup_m1, %n_tiles, %zero : index
+  %out_tile_index1 = index.madd %workgroup_m1, %n_tiles, %c0 : index
   %out_byte_index1 = index.mul %out_tile_index1, %acc_tile_bytes : index
   %out_byte_offset1 = index.cast %out_byte_index1 : index to offset
   %out_byte_offset_aligned1 = index.assume %out_byte_offset1 [mul(%out_byte_offset1, 16)] : offset
   %init_view1 = buffer.view %init_aligned[%out_byte_offset_aligned1] : buffer -> view<16x16xf32, #dense>
   %out_view1 = buffer.view %out_aligned[%out_byte_offset_aligned1] : buffer -> view<16x16xf32, #dense>
   %init1 = vector.fragment.load<init> %init_view1[0, 0] shape [%m, %n] : view<16x16xf32, #dense> -> vector<8xf32>
-  %result1 = scf.for %kt1 = [%zero to %k_tiles step %unit](%acc1 = %init1 : vector<8xf32>) -> (vector<8xf32>) {
+  %result1 = scf.for %kt1 = [%c0 to %k_tiles step %unit](%acc1 = %init1 : vector<8xf32>) -> (vector<8xf32>) {
     %lhs_tile_index1 = index.madd %workgroup_m1, %k_tiles, %kt1 : index
-    %rhs_tile_index1 = index.madd %kt1, %n_tiles, %zero : index
+    %rhs_tile_index1 = index.madd %kt1, %n_tiles, %c0 : index
     %lhs_byte_index1 = index.mul %lhs_tile_index1, %lhs_tile_bytes : index
     %rhs_byte_index1 = index.mul %rhs_tile_index1, %rhs_tile_bytes : index
     %lhs_byte_offset1 = index.cast %lhs_byte_index1 : index to offset

--- a/loom/src/loom/tooling/target/spirv/test/spirv_vulkan_coop_u8_hal_actual.loom
+++ b/loom/src/loom/tooling/target/spirv/test/spirv_vulkan_coop_u8_hal_actual.loom
@@ -12,7 +12,7 @@ kernel.def target(@target) @dense_projection_tiled_u8_128() {
   %k_tiles = index.constant 4 : index
   %n_tiles = index.constant 8 : index
   %unit = index.constant 1 : index
-  %zero = index.constant 0 : index
+  %loop_begin = index.constant 0 : index
   %lhs_tile_bytes = index.constant 512 : index
   %rhs_tile_bytes = index.constant 512 : index
   %acc_tile_bytes = index.constant 1024 : index
@@ -33,7 +33,7 @@ kernel.def target(@target) @dense_projection_tiled_u8_128() {
   %init_view = buffer.view %init_aligned[%out_byte_offset_aligned] : buffer -> view<16x16xi32, %acc_storage>
   %out_view = buffer.view %out_aligned[%out_byte_offset_aligned] : buffer -> view<16x16xi32, %acc_storage>
   %init = vector.fragment.load<init> %init_view[0, 0] shape [%m, %n] : view<16x16xi32, %acc_storage> -> vector<8xi32>
-  %result = scf.for %kt = [%zero to %k_tiles step %unit](%acc = %init : vector<8xi32>) -> (vector<8xi32>) {
+  %result = scf.for %kt = [%loop_begin to %k_tiles step %unit](%acc = %init : vector<8xi32>) -> (vector<8xi32>) {
     %lhs_tile_index = index.madd %workgroup_m, %k_tiles, %kt : index
     %rhs_tile_index = index.madd %kt, %n_tiles, %workgroup_n : index
     %lhs_byte_index = index.mul %lhs_tile_index, %lhs_tile_bytes : index

--- a/loom/src/loom/tooling/target/spirv/test/spirv_vulkan_hal_actual.loom
+++ b/loom/src/loom/tooling/target/spirv/test/spirv_vulkan_hal_actual.loom
@@ -31,14 +31,14 @@ kernel.def target(@target) @increment_i32() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero_offset = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
-  %input_view = buffer.view %input_aligned[%zero_offset] : buffer -> view<1xi32, #dense>
+  %input_view = buffer.view %input_aligned[%base] : buffer -> view<1xi32, #dense>
   %value = view.load %input_view[0] : view<1xi32, #dense> -> i32
-  %one = scalar.constant 1 : i32
-  %incremented = scalar.addi %value, %one : i32
-  %output_view = buffer.view %output_aligned[%zero_offset] : buffer -> view<1xi32, #dense>
+  %increment = scalar.constant 1 : i32
+  %incremented = scalar.addi %value, %increment : i32
+  %output_view = buffer.view %output_aligned[%base] : buffer -> view<1xi32, #dense>
   view.store %incremented, %output_view[0] : i32, view<1xi32, #dense>
   kernel.return
 }
@@ -47,13 +47,13 @@ kernel.def target(@target) @double_i32() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
-  %zero_offset = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
-  %input_view = buffer.view %input_aligned[%zero_offset] : buffer -> view<1xi32, #dense>
+  %input_view = buffer.view %input_aligned[%base] : buffer -> view<1xi32, #dense>
   %value = view.load %input_view[0] : view<1xi32, #dense> -> i32
   %doubled = scalar.addi %value, %value : i32
-  %output_view = buffer.view %output_aligned[%zero_offset] : buffer -> view<1xi32, #dense>
+  %output_view = buffer.view %output_aligned[%base] : buffer -> view<1xi32, #dense>
   view.store %doubled, %output_view[0] : i32, view<1xi32, #dense>
   kernel.return
 }
@@ -78,7 +78,7 @@ kernel.def target(@target) @scalar_addressing_i32() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer, %base: offset, %element: index, %mixed_row: index, %column: index, %stride_row: index, %columns: index, %subview_element: index) {
-  %zero = index.constant 0 : offset
+  %buffer_base = index.constant 0 : offset
   %static_base = index.constant 8 : offset
   %subview_base = index.constant 40 : offset
   %base_bias = index.constant 4 : offset
@@ -95,13 +95,13 @@ kernel.def target(@target) @scalar_addressing_i32() {
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
   %static_view = buffer.view %input_aligned[%static_base] : buffer -> view<2x4xi32, #dense>
   %dynamic_base_view = buffer.view %input_aligned[%base_aligned] : buffer -> view<4xi32, #dense>
-  %dynamic_index_view = buffer.view %input_aligned[%zero] : buffer -> view<16xi32, #dense>
+  %dynamic_index_view = buffer.view %input_aligned[%buffer_base] : buffer -> view<16xi32, #dense>
   %mixed_view = buffer.view %input_aligned[%base_aligned] : buffer -> view<4x8xi32, #dense>
-  %dynamic_stride_view = buffer.view %input_aligned[%zero] : buffer -> view<4x[%columns_bounded]xi32, #dense>
+  %dynamic_stride_view = buffer.view %input_aligned[%buffer_base] : buffer -> view<4x[%columns_bounded]xi32, #dense>
   %subview_source = buffer.view %input_aligned[%subview_base] : buffer -> view<8xi32, #dense>
   %subview = view.subview %subview_source[1] : view<8xi32, #dense> -> view<4xi32, #dense>
   %materialized_base_view = buffer.view %input_aligned[%biased_base] : buffer -> view<8xi32, #dense>
-  %output_view = buffer.view %output_aligned[%zero] : buffer -> view<7xi32, #dense>
+  %output_view = buffer.view %output_aligned[%buffer_base] : buffer -> view<7xi32, #dense>
   %static_value = view.load %static_view[1, 2] : view<2x4xi32, #dense> -> i32
   %dynamic_base_value = view.load %dynamic_base_view[2] : view<4xi32, #dense> -> i32
   %dynamic_index_value = view.load %dynamic_index_view[%element_bounded] : view<16xi32, #dense> -> i32
@@ -137,17 +137,17 @@ check.case @scalar_addressing_i32_case {
 
 kernel.def target(@target) @workgroup_addressing_i32() {
   %unit = index.constant 1 : index
-  %four = index.constant 4 : index
-  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%four, %unit, %unit) : index
+  %workgroup_size = index.constant 4 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %lane = kernel.workitem.id<x> : index
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %scratch_base = index.constant 4 : offset
   %scratch_byte_length = index.constant 32 : offset
   %input_aligned = buffer.assume.alignment %input {minimum_alignment = 4} : buffer
   %output_aligned = buffer.assume.alignment %output {minimum_alignment = 4} : buffer
-  %input_view = buffer.view %input_aligned[%zero] : buffer -> view<4xi32, #dense>
-  %output_view = buffer.view %output_aligned[%zero] : buffer -> view<4xi32, #dense>
+  %input_view = buffer.view %input_aligned[%base] : buffer -> view<4xi32, #dense>
+  %output_view = buffer.view %output_aligned[%base] : buffer -> view<4xi32, #dense>
   %scratch = buffer.alloca %scratch_byte_length {base_alignment = 4, memory_space = workgroup} : buffer
   %scratch_view = buffer.view %scratch[%scratch_base] : buffer -> view<6xi32, #dense>
   %scratch_subview = view.subview %scratch_view[1] : view<6xi32, #dense> -> view<4xi32, #dense>

--- a/loom/src/loom/tooling/target/spirv/test/spirv_vulkan_integer_hal_actual.loom
+++ b/loom/src/loom/tooling/target/spirv/test/spirv_vulkan_integer_hal_actual.loom
@@ -63,23 +63,23 @@ kernel.def target(@target) @integer_i32_truth_table() {
 
   %lhs = view.load %input_lhs_view[0] : view<1xi32, #dense> -> i32
   %rhs = view.load %input_rhs_view[0] : view<1xi32, #dense> -> i32
-  %minus_eight = scalar.constant -8 : i32
-  %minus_six = scalar.constant -6 : i32
-  %minus_one = scalar.constant -1 : i32
-  %zero = scalar.constant 0 : i32
-  %one = scalar.constant 1 : i32
-  %two = scalar.constant 2 : i32
-  %three = scalar.constant 3 : i32
-  %eight = scalar.constant 8 : i32
-  %bitwise_and = scalar.andi %minus_six, %minus_one : i32
-  %shift_right_arithmetic = scalar.shrsi %minus_eight, %one : i32
-  %bitwise_xor = scalar.xori %minus_one, %one : i32
+  %cn8 = scalar.constant -8 : i32
+  %cn6 = scalar.constant -6 : i32
+  %cn1 = scalar.constant -1 : i32
+  %c0 = scalar.constant 0 : i32
+  %c1 = scalar.constant 1 : i32
+  %c2 = scalar.constant 2 : i32
+  %c3 = scalar.constant 3 : i32
+  %c8 = scalar.constant 8 : i32
+  %bitwise_and = scalar.andi %cn6, %cn1 : i32
+  %shift_right_arithmetic = scalar.shrsi %cn8, %c1 : i32
+  %bitwise_xor = scalar.xori %cn1, %c1 : i32
   %equal = scalar.cmpi eq, %lhs, %rhs : i32
-  %selected = scf.select %equal, %eight, %zero : i32
-  %bitwise_or = scalar.ori %zero, %two : i32
-  %shift_right_logical = scalar.shrui %eight, %one : i32
-  %shift_left = scalar.shli %three, %one : i32
-  view.store %minus_eight, %value_output0_view[0] : i32, view<1xi32, #dense>
+  %selected = scf.select %equal, %c8, %c0 : i32
+  %bitwise_or = scalar.ori %c0, %c2 : i32
+  %shift_right_logical = scalar.shrui %c8, %c1 : i32
+  %shift_left = scalar.shli %c3, %c1 : i32
+  view.store %cn8, %value_output0_view[0] : i32, view<1xi32, #dense>
   view.store %bitwise_and, %value_output1_view[0] : i32, view<1xi32, #dense>
   view.store %shift_right_arithmetic, %value_output2_view[0] : i32, view<1xi32, #dense>
   view.store %bitwise_xor, %value_output3_view[0] : i32, view<1xi32, #dense>
@@ -97,16 +97,16 @@ kernel.def target(@target) @integer_i32_truth_table() {
   %unsigned_less_equal = scalar.cmpi ule, %lhs, %rhs : i32
   %unsigned_greater = scalar.cmpi ugt, %lhs, %rhs : i32
   %unsigned_greater_equal = scalar.cmpi uge, %lhs, %rhs : i32
-  %equal_i32 = scf.select %equal, %one, %zero : i32
-  %not_equal_i32 = scf.select %not_equal, %one, %zero : i32
-  %signed_greater_i32 = scf.select %signed_greater, %one, %zero : i32
-  %signed_less_i32 = scf.select %signed_less, %one, %zero : i32
-  %signed_greater_equal_i32 = scf.select %signed_greater_equal, %one, %zero : i32
-  %signed_less_equal_i32 = scf.select %signed_less_equal, %one, %zero : i32
-  %unsigned_less_i32 = scf.select %unsigned_less, %one, %zero : i32
-  %unsigned_greater_i32 = scf.select %unsigned_greater, %one, %zero : i32
-  %unsigned_less_equal_i32 = scf.select %unsigned_less_equal, %one, %zero : i32
-  %unsigned_greater_equal_i32 = scf.select %unsigned_greater_equal, %one, %zero : i32
+  %equal_i32 = scf.select %equal, %c1, %c0 : i32
+  %not_equal_i32 = scf.select %not_equal, %c1, %c0 : i32
+  %signed_greater_i32 = scf.select %signed_greater, %c1, %c0 : i32
+  %signed_less_i32 = scf.select %signed_less, %c1, %c0 : i32
+  %signed_greater_equal_i32 = scf.select %signed_greater_equal, %c1, %c0 : i32
+  %signed_less_equal_i32 = scf.select %signed_less_equal, %c1, %c0 : i32
+  %unsigned_less_i32 = scf.select %unsigned_less, %c1, %c0 : i32
+  %unsigned_greater_i32 = scf.select %unsigned_greater, %c1, %c0 : i32
+  %unsigned_less_equal_i32 = scf.select %unsigned_less_equal, %c1, %c0 : i32
+  %unsigned_greater_equal_i32 = scf.select %unsigned_greater_equal, %c1, %c0 : i32
   view.store %equal_i32, %comparison_output0_view[0] : i32, view<1xi32, #dense>
   view.store %not_equal_i32, %comparison_output1_view[0] : i32, view<1xi32, #dense>
   view.store %signed_greater_i32, %comparison_output2_view[0] : i32, view<1xi32, #dense>
@@ -134,22 +134,22 @@ kernel.def target(@target) @integer_i32_truth_table() {
   %xor_true_false = scalar.xori %not_equal, %equal : i1
   %select_false = scf.select %equal, %not_equal, %equal : i1
   %select_true = scf.select %not_equal, %not_equal, %equal : i1
-  %constant_false_i32 = scf.select %constant_false, %one, %zero : i32
-  %constant_true_i32 = scf.select %constant_true, %one, %zero : i32
-  %and_false_false_i32 = scf.select %and_false_false, %one, %zero : i32
-  %and_true_true_i32 = scf.select %and_true_true, %one, %zero : i32
-  %and_false_true_i32 = scf.select %and_false_true, %one, %zero : i32
-  %or_false_true_i32 = scf.select %or_false_true, %one, %zero : i32
-  %and_true_false_i32 = scf.select %and_true_false, %one, %zero : i32
-  %or_true_false_i32 = scf.select %or_true_false, %one, %zero : i32
-  %or_false_false_i32 = scf.select %or_false_false, %one, %zero : i32
-  %or_true_true_i32 = scf.select %or_true_true, %one, %zero : i32
-  %xor_false_false_i32 = scf.select %xor_false_false, %one, %zero : i32
-  %xor_false_true_i32 = scf.select %xor_false_true, %one, %zero : i32
-  %xor_true_true_i32 = scf.select %xor_true_true, %one, %zero : i32
-  %xor_true_false_i32 = scf.select %xor_true_false, %one, %zero : i32
-  %select_false_i32 = scf.select %select_false, %one, %zero : i32
-  %select_true_i32 = scf.select %select_true, %one, %zero : i32
+  %constant_false_i32 = scf.select %constant_false, %c1, %c0 : i32
+  %constant_true_i32 = scf.select %constant_true, %c1, %c0 : i32
+  %and_false_false_i32 = scf.select %and_false_false, %c1, %c0 : i32
+  %and_true_true_i32 = scf.select %and_true_true, %c1, %c0 : i32
+  %and_false_true_i32 = scf.select %and_false_true, %c1, %c0 : i32
+  %or_false_true_i32 = scf.select %or_false_true, %c1, %c0 : i32
+  %and_true_false_i32 = scf.select %and_true_false, %c1, %c0 : i32
+  %or_true_false_i32 = scf.select %or_true_false, %c1, %c0 : i32
+  %or_false_false_i32 = scf.select %or_false_false, %c1, %c0 : i32
+  %or_true_true_i32 = scf.select %or_true_true, %c1, %c0 : i32
+  %xor_false_false_i32 = scf.select %xor_false_false, %c1, %c0 : i32
+  %xor_false_true_i32 = scf.select %xor_false_true, %c1, %c0 : i32
+  %xor_true_true_i32 = scf.select %xor_true_true, %c1, %c0 : i32
+  %xor_true_false_i32 = scf.select %xor_true_false, %c1, %c0 : i32
+  %select_false_i32 = scf.select %select_false, %c1, %c0 : i32
+  %select_true_i32 = scf.select %select_true, %c1, %c0 : i32
   view.store %constant_false_i32, %boolean_output0_view[0] : i32, view<1xi32, #dense>
   view.store %constant_true_i32, %boolean_output1_view[0] : i32, view<1xi32, #dense>
   view.store %and_false_false_i32, %boolean_output2_view[0] : i32, view<1xi32, #dense>
@@ -230,25 +230,25 @@ kernel.def target(@target) @integer_i8_truth_table() {
 
   %lhs = view.load %input_lhs_view[0] : view<1xi8, #dense> -> i8
   %rhs = view.load %input_rhs_view[0] : view<1xi8, #dense> -> i8
-  %minus_eight = scalar.constant -8 : i8
-  %minus_six = scalar.constant -6 : i8
-  %minus_one = scalar.constant -1 : i8
-  %zero = scalar.constant 0 : i8
-  %one = scalar.constant 1 : i8
-  %two = scalar.constant 2 : i8
-  %three = scalar.constant 3 : i8
-  %eight = scalar.constant 8 : i8
-  %zero_i32 = scalar.constant 0 : i32
-  %one_i32 = scalar.constant 1 : i32
-  %bitwise_and = scalar.andi %minus_six, %minus_one : i8
-  %shift_right_arithmetic = scalar.shrsi %minus_eight, %one : i8
-  %bitwise_xor = scalar.xori %minus_one, %one : i8
+  %cn8 = scalar.constant -8 : i8
+  %cn6 = scalar.constant -6 : i8
+  %cn1 = scalar.constant -1 : i8
+  %c0 = scalar.constant 0 : i8
+  %c1 = scalar.constant 1 : i8
+  %c2 = scalar.constant 2 : i8
+  %c3 = scalar.constant 3 : i8
+  %c8 = scalar.constant 8 : i8
+  %false_i32 = scalar.constant 0 : i32
+  %true_i32 = scalar.constant 1 : i32
+  %bitwise_and = scalar.andi %cn6, %cn1 : i8
+  %shift_right_arithmetic = scalar.shrsi %cn8, %c1 : i8
+  %bitwise_xor = scalar.xori %cn1, %c1 : i8
   %equal = scalar.cmpi eq, %lhs, %rhs : i8
-  %selected = scf.select %equal, %eight, %zero : i8
-  %bitwise_or = scalar.ori %zero, %two : i8
-  %shift_right_logical = scalar.shrui %eight, %one : i8
-  %shift_left = scalar.shli %three, %one : i8
-  view.store %minus_eight, %value_output0_view[0] : i8, view<1xi8, #dense>
+  %selected = scf.select %equal, %c8, %c0 : i8
+  %bitwise_or = scalar.ori %c0, %c2 : i8
+  %shift_right_logical = scalar.shrui %c8, %c1 : i8
+  %shift_left = scalar.shli %c3, %c1 : i8
+  view.store %cn8, %value_output0_view[0] : i8, view<1xi8, #dense>
   view.store %bitwise_and, %value_output1_view[0] : i8, view<1xi8, #dense>
   view.store %shift_right_arithmetic, %value_output2_view[0] : i8, view<1xi8, #dense>
   view.store %bitwise_xor, %value_output3_view[0] : i8, view<1xi8, #dense>
@@ -266,16 +266,16 @@ kernel.def target(@target) @integer_i8_truth_table() {
   %unsigned_less_equal = scalar.cmpi ule, %lhs, %rhs : i8
   %unsigned_greater = scalar.cmpi ugt, %lhs, %rhs : i8
   %unsigned_greater_equal = scalar.cmpi uge, %lhs, %rhs : i8
-  %equal_i32 = scf.select %equal, %one_i32, %zero_i32 : i32
-  %not_equal_i32 = scf.select %not_equal, %one_i32, %zero_i32 : i32
-  %signed_greater_i32 = scf.select %signed_greater, %one_i32, %zero_i32 : i32
-  %signed_less_i32 = scf.select %signed_less, %one_i32, %zero_i32 : i32
-  %signed_greater_equal_i32 = scf.select %signed_greater_equal, %one_i32, %zero_i32 : i32
-  %signed_less_equal_i32 = scf.select %signed_less_equal, %one_i32, %zero_i32 : i32
-  %unsigned_less_i32 = scf.select %unsigned_less, %one_i32, %zero_i32 : i32
-  %unsigned_greater_i32 = scf.select %unsigned_greater, %one_i32, %zero_i32 : i32
-  %unsigned_less_equal_i32 = scf.select %unsigned_less_equal, %one_i32, %zero_i32 : i32
-  %unsigned_greater_equal_i32 = scf.select %unsigned_greater_equal, %one_i32, %zero_i32 : i32
+  %equal_i32 = scf.select %equal, %true_i32, %false_i32 : i32
+  %not_equal_i32 = scf.select %not_equal, %true_i32, %false_i32 : i32
+  %signed_greater_i32 = scf.select %signed_greater, %true_i32, %false_i32 : i32
+  %signed_less_i32 = scf.select %signed_less, %true_i32, %false_i32 : i32
+  %signed_greater_equal_i32 = scf.select %signed_greater_equal, %true_i32, %false_i32 : i32
+  %signed_less_equal_i32 = scf.select %signed_less_equal, %true_i32, %false_i32 : i32
+  %unsigned_less_i32 = scf.select %unsigned_less, %true_i32, %false_i32 : i32
+  %unsigned_greater_i32 = scf.select %unsigned_greater, %true_i32, %false_i32 : i32
+  %unsigned_less_equal_i32 = scf.select %unsigned_less_equal, %true_i32, %false_i32 : i32
+  %unsigned_greater_equal_i32 = scf.select %unsigned_greater_equal, %true_i32, %false_i32 : i32
   view.store %equal_i32, %comparison_output0_view[0] : i32, view<1xi32, #dense>
   view.store %not_equal_i32, %comparison_output1_view[0] : i32, view<1xi32, #dense>
   view.store %signed_greater_i32, %comparison_output2_view[0] : i32, view<1xi32, #dense>
@@ -347,25 +347,25 @@ kernel.def target(@target) @integer_i16_truth_table() {
 
   %lhs = view.load %input_lhs_view[0] : view<1xi16, #dense> -> i16
   %rhs = view.load %input_rhs_view[0] : view<1xi16, #dense> -> i16
-  %minus_eight = scalar.constant -8 : i16
-  %minus_six = scalar.constant -6 : i16
-  %minus_one = scalar.constant -1 : i16
-  %zero = scalar.constant 0 : i16
-  %one = scalar.constant 1 : i16
-  %two = scalar.constant 2 : i16
-  %three = scalar.constant 3 : i16
-  %eight = scalar.constant 8 : i16
-  %zero_i32 = scalar.constant 0 : i32
-  %one_i32 = scalar.constant 1 : i32
-  %bitwise_and = scalar.andi %minus_six, %minus_one : i16
-  %shift_right_arithmetic = scalar.shrsi %minus_eight, %one : i16
-  %bitwise_xor = scalar.xori %minus_one, %one : i16
+  %cn8 = scalar.constant -8 : i16
+  %cn6 = scalar.constant -6 : i16
+  %cn1 = scalar.constant -1 : i16
+  %c0 = scalar.constant 0 : i16
+  %c1 = scalar.constant 1 : i16
+  %c2 = scalar.constant 2 : i16
+  %c3 = scalar.constant 3 : i16
+  %c8 = scalar.constant 8 : i16
+  %false_i32 = scalar.constant 0 : i32
+  %true_i32 = scalar.constant 1 : i32
+  %bitwise_and = scalar.andi %cn6, %cn1 : i16
+  %shift_right_arithmetic = scalar.shrsi %cn8, %c1 : i16
+  %bitwise_xor = scalar.xori %cn1, %c1 : i16
   %equal = scalar.cmpi eq, %lhs, %rhs : i16
-  %selected = scf.select %equal, %eight, %zero : i16
-  %bitwise_or = scalar.ori %zero, %two : i16
-  %shift_right_logical = scalar.shrui %eight, %one : i16
-  %shift_left = scalar.shli %three, %one : i16
-  view.store %minus_eight, %value_output0_view[0] : i16, view<1xi16, #dense>
+  %selected = scf.select %equal, %c8, %c0 : i16
+  %bitwise_or = scalar.ori %c0, %c2 : i16
+  %shift_right_logical = scalar.shrui %c8, %c1 : i16
+  %shift_left = scalar.shli %c3, %c1 : i16
+  view.store %cn8, %value_output0_view[0] : i16, view<1xi16, #dense>
   view.store %bitwise_and, %value_output1_view[0] : i16, view<1xi16, #dense>
   view.store %shift_right_arithmetic, %value_output2_view[0] : i16, view<1xi16, #dense>
   view.store %bitwise_xor, %value_output3_view[0] : i16, view<1xi16, #dense>
@@ -383,16 +383,16 @@ kernel.def target(@target) @integer_i16_truth_table() {
   %unsigned_less_equal = scalar.cmpi ule, %lhs, %rhs : i16
   %unsigned_greater = scalar.cmpi ugt, %lhs, %rhs : i16
   %unsigned_greater_equal = scalar.cmpi uge, %lhs, %rhs : i16
-  %equal_i32 = scf.select %equal, %one_i32, %zero_i32 : i32
-  %not_equal_i32 = scf.select %not_equal, %one_i32, %zero_i32 : i32
-  %signed_greater_i32 = scf.select %signed_greater, %one_i32, %zero_i32 : i32
-  %signed_less_i32 = scf.select %signed_less, %one_i32, %zero_i32 : i32
-  %signed_greater_equal_i32 = scf.select %signed_greater_equal, %one_i32, %zero_i32 : i32
-  %signed_less_equal_i32 = scf.select %signed_less_equal, %one_i32, %zero_i32 : i32
-  %unsigned_less_i32 = scf.select %unsigned_less, %one_i32, %zero_i32 : i32
-  %unsigned_greater_i32 = scf.select %unsigned_greater, %one_i32, %zero_i32 : i32
-  %unsigned_less_equal_i32 = scf.select %unsigned_less_equal, %one_i32, %zero_i32 : i32
-  %unsigned_greater_equal_i32 = scf.select %unsigned_greater_equal, %one_i32, %zero_i32 : i32
+  %equal_i32 = scf.select %equal, %true_i32, %false_i32 : i32
+  %not_equal_i32 = scf.select %not_equal, %true_i32, %false_i32 : i32
+  %signed_greater_i32 = scf.select %signed_greater, %true_i32, %false_i32 : i32
+  %signed_less_i32 = scf.select %signed_less, %true_i32, %false_i32 : i32
+  %signed_greater_equal_i32 = scf.select %signed_greater_equal, %true_i32, %false_i32 : i32
+  %signed_less_equal_i32 = scf.select %signed_less_equal, %true_i32, %false_i32 : i32
+  %unsigned_less_i32 = scf.select %unsigned_less, %true_i32, %false_i32 : i32
+  %unsigned_greater_i32 = scf.select %unsigned_greater, %true_i32, %false_i32 : i32
+  %unsigned_less_equal_i32 = scf.select %unsigned_less_equal, %true_i32, %false_i32 : i32
+  %unsigned_greater_equal_i32 = scf.select %unsigned_greater_equal, %true_i32, %false_i32 : i32
   view.store %equal_i32, %comparison_output0_view[0] : i32, view<1xi32, #dense>
   view.store %not_equal_i32, %comparison_output1_view[0] : i32, view<1xi32, #dense>
   view.store %signed_greater_i32, %comparison_output2_view[0] : i32, view<1xi32, #dense>
@@ -463,25 +463,25 @@ kernel.def target(@target) @integer_i64_truth_table() {
 
   %lhs = view.load %input_lhs_view[0] : view<1xi64, #dense> -> i64
   %rhs = view.load %input_rhs_view[0] : view<1xi64, #dense> -> i64
-  %minus_eight = scalar.constant -8 : i64
-  %minus_six = scalar.constant -6 : i64
-  %minus_one = scalar.constant -1 : i64
-  %zero = scalar.constant 0 : i64
-  %one = scalar.constant 1 : i64
-  %two = scalar.constant 2 : i64
-  %three = scalar.constant 3 : i64
-  %eight = scalar.constant 8 : i64
-  %zero_i32 = scalar.constant 0 : i32
-  %one_i32 = scalar.constant 1 : i32
-  %bitwise_and = scalar.andi %minus_six, %minus_one : i64
-  %shift_right_arithmetic = scalar.shrsi %minus_eight, %one : i64
-  %bitwise_xor = scalar.xori %minus_one, %one : i64
+  %cn8 = scalar.constant -8 : i64
+  %cn6 = scalar.constant -6 : i64
+  %cn1 = scalar.constant -1 : i64
+  %c0 = scalar.constant 0 : i64
+  %c1 = scalar.constant 1 : i64
+  %c2 = scalar.constant 2 : i64
+  %c3 = scalar.constant 3 : i64
+  %c8 = scalar.constant 8 : i64
+  %false_i32 = scalar.constant 0 : i32
+  %true_i32 = scalar.constant 1 : i32
+  %bitwise_and = scalar.andi %cn6, %cn1 : i64
+  %shift_right_arithmetic = scalar.shrsi %cn8, %c1 : i64
+  %bitwise_xor = scalar.xori %cn1, %c1 : i64
   %equal = scalar.cmpi eq, %lhs, %rhs : i64
-  %selected = scf.select %equal, %eight, %zero : i64
-  %bitwise_or = scalar.ori %zero, %two : i64
-  %shift_right_logical = scalar.shrui %eight, %one : i64
-  %shift_left = scalar.shli %three, %one : i64
-  view.store %minus_eight, %value_output0_view[0] : i64, view<1xi64, #dense>
+  %selected = scf.select %equal, %c8, %c0 : i64
+  %bitwise_or = scalar.ori %c0, %c2 : i64
+  %shift_right_logical = scalar.shrui %c8, %c1 : i64
+  %shift_left = scalar.shli %c3, %c1 : i64
+  view.store %cn8, %value_output0_view[0] : i64, view<1xi64, #dense>
   view.store %bitwise_and, %value_output1_view[0] : i64, view<1xi64, #dense>
   view.store %shift_right_arithmetic, %value_output2_view[0] : i64, view<1xi64, #dense>
   view.store %bitwise_xor, %value_output3_view[0] : i64, view<1xi64, #dense>
@@ -499,16 +499,16 @@ kernel.def target(@target) @integer_i64_truth_table() {
   %unsigned_less_equal = scalar.cmpi ule, %lhs, %rhs : i64
   %unsigned_greater = scalar.cmpi ugt, %lhs, %rhs : i64
   %unsigned_greater_equal = scalar.cmpi uge, %lhs, %rhs : i64
-  %equal_i32 = scf.select %equal, %one_i32, %zero_i32 : i32
-  %not_equal_i32 = scf.select %not_equal, %one_i32, %zero_i32 : i32
-  %signed_greater_i32 = scf.select %signed_greater, %one_i32, %zero_i32 : i32
-  %signed_less_i32 = scf.select %signed_less, %one_i32, %zero_i32 : i32
-  %signed_greater_equal_i32 = scf.select %signed_greater_equal, %one_i32, %zero_i32 : i32
-  %signed_less_equal_i32 = scf.select %signed_less_equal, %one_i32, %zero_i32 : i32
-  %unsigned_less_i32 = scf.select %unsigned_less, %one_i32, %zero_i32 : i32
-  %unsigned_greater_i32 = scf.select %unsigned_greater, %one_i32, %zero_i32 : i32
-  %unsigned_less_equal_i32 = scf.select %unsigned_less_equal, %one_i32, %zero_i32 : i32
-  %unsigned_greater_equal_i32 = scf.select %unsigned_greater_equal, %one_i32, %zero_i32 : i32
+  %equal_i32 = scf.select %equal, %true_i32, %false_i32 : i32
+  %not_equal_i32 = scf.select %not_equal, %true_i32, %false_i32 : i32
+  %signed_greater_i32 = scf.select %signed_greater, %true_i32, %false_i32 : i32
+  %signed_less_i32 = scf.select %signed_less, %true_i32, %false_i32 : i32
+  %signed_greater_equal_i32 = scf.select %signed_greater_equal, %true_i32, %false_i32 : i32
+  %signed_less_equal_i32 = scf.select %signed_less_equal, %true_i32, %false_i32 : i32
+  %unsigned_less_i32 = scf.select %unsigned_less, %true_i32, %false_i32 : i32
+  %unsigned_greater_i32 = scf.select %unsigned_greater, %true_i32, %false_i32 : i32
+  %unsigned_less_equal_i32 = scf.select %unsigned_less_equal, %true_i32, %false_i32 : i32
+  %unsigned_greater_equal_i32 = scf.select %unsigned_greater_equal, %true_i32, %false_i32 : i32
   view.store %equal_i32, %comparison_output0_view[0] : i32, view<1xi32, #dense>
   view.store %not_equal_i32, %comparison_output1_view[0] : i32, view<1xi32, #dense>
   view.store %signed_greater_i32, %comparison_output2_view[0] : i32, view<1xi32, #dense>

--- a/loom/src/loom/tooling/target/spirv/test/spirv_vulkan_quantized_hal_actual.loom
+++ b/loom/src/loom/tooling/target/spirv/test/spirv_vulkan_quantized_hal_actual.loom
@@ -11,7 +11,7 @@ kernel.def target(@target) @quantized_projection_u8_scalar_128() {
   %k_count = index.constant 128 : index
   %n_count = index.constant 128 : index
   %unit = index.constant 1 : index
-  %zero = index.constant 0 : index
+  %loop_begin = index.constant 0 : index
   %f32_bytes = index.constant 4 : index
   %lhs_aligned = buffer.assume.alignment %lhs_buffer {minimum_alignment = 1} : buffer
   %rhs_aligned = buffer.assume.alignment %rhs_buffer {minimum_alignment = 1} : buffer
@@ -23,7 +23,7 @@ kernel.def target(@target) @quantized_projection_u8_scalar_128() {
   %out_byte_offset_aligned = index.assume %out_byte_offset [mul(%out_byte_offset, 4)] : offset
   %init_view = buffer.view %init_aligned[%out_byte_offset_aligned] : buffer -> view<1xf32, #dense>
   %init = view.load %init_view[0] : view<1xf32, #dense> -> f32
-  %result = scf.for %k = [%zero to %k_count step %unit](%acc = %init : f32) -> (f32) {
+  %result = scf.for %k = [%loop_begin to %k_count step %unit](%acc = %init : f32) -> (f32) {
     %lhs_element_index = index.madd %row, %k_count, %k : index
     %rhs_element_index = index.madd %k, %n_count, %column : index
     %lhs_byte_offset = index.cast %lhs_element_index : index to offset

--- a/loom/src/loom/tools/loom-link/testdata/archive_inline_kernel_helper.loom
+++ b/loom/src/loom/tools/loom-link/testdata/archive_inline_kernel_helper.loom
@@ -7,9 +7,9 @@ func.def inline @subgroup_broadcast_helper(%value: i32, %lane: i32) -> (i32) {
 }
 
 kernel.def @subgroup_broadcast_kernel() {
-  %one = index.constant 1 : index
-  %thirtytwo = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%thirtytwo, %one, %one) : index
+  %unit = index.constant 1 : index
+  %workgroup_size = index.constant 32 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch(%value: i32) {
   %lane = kernel.subgroup.lane.id : index
   %lane_i32 = index.cast %lane : index to i32

--- a/loom/src/loom/transforms/cfg/test/cfg_simplify.loom-test
+++ b/loom/src/loom/transforms/cfg/test/cfg_simplify.loom-test
@@ -864,15 +864,15 @@ func.def @fuses_block_with_cond_terminator(%cond: i1, %a: i32, %b: i32) -> (i32)
 // ====
 
 func.def @preserves_loop_carried_args(%n: index, %seed: i32, %x: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  cfg.br ^loop(%zero: index, %seed: i32)
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  cfg.br ^loop(%loop_begin: index, %seed: i32)
 ^loop(%i: index, %acc: i32):
   %keep_going = index.cmp slt, %i, %n : index
   cfg.cond_br %keep_going, ^body, ^exit
 ^body:
   %next = test.addi %acc, %x : i32
-  %next_i = index.add %i, %one : index
+  %next_i = index.add %i, %loop_step : index
   cfg.br ^loop(%next_i: index, %next: i32)
 ^exit:
   func.return %acc : i32

--- a/loom/src/loom/transforms/cleanup/test/value_facts.loom-test
+++ b/loom/src/loom/transforms/cleanup/test/value_facts.loom-test
@@ -3,7 +3,7 @@
 func.def @cfg_join_unknown_and_zero_is_not_exact_zero(%cond: i1, %input: buffer) -> (f32) {
   %base = index.constant 0 : offset
   %index = index.constant 0 : index
-  %zero = scalar.constant 0.0 : f32
+  %padding = scalar.constant 0.0 : f32
   %scale = scalar.constant 2.0 : f32
   %view = buffer.view %input[%base] : buffer -> view<1xf32, #dense>
   cfg.cond_br %cond, ^load, ^pad
@@ -11,7 +11,7 @@ func.def @cfg_join_unknown_and_zero_is_not_exact_zero(%cond: i1, %input: buffer)
   %loaded = view.load %view[%index] : view<1xf32, #dense> -> f32
   cfg.br ^join(%loaded: f32)
 ^pad:
-  cfg.br ^join(%zero: f32)
+  cfg.br ^join(%padding: f32)
 ^join(%value: f32):
   %scaled = scalar.mulf<nnan|ninf|nsz> %value, %scale : f32
   func.return %scaled : f32
@@ -21,7 +21,7 @@ func.def @cfg_join_unknown_and_zero_is_not_exact_zero(%cond: i1, %input: buffer)
 func.def @cfg_join_unknown_and_zero_is_not_exact_zero(%cond: i1, %input: buffer) -> (f32) {
   %base = index.constant 0 : offset
   %index = index.constant 0 : index
-  %zero = scalar.constant 0.0 : f32
+  %padding = scalar.constant 0.0 : f32
   %scale = scalar.constant 2.0 : f32
   %view = buffer.view %input[%base] : buffer -> view<1xf32, #dense>
   cfg.cond_br %cond, ^load, ^pad
@@ -29,7 +29,7 @@ func.def @cfg_join_unknown_and_zero_is_not_exact_zero(%cond: i1, %input: buffer)
   %loaded = view.load %view[%index] : view<1xf32, #dense> -> f32
   cfg.br ^join(%loaded: f32)
 ^pad:
-  cfg.br ^join(%zero: f32)
+  cfg.br ^join(%padding: f32)
 ^join(%value: f32):
   %scaled = scalar.mulf<nnan|ninf|nsz> %value, %scale : f32
   func.return %scaled : f32

--- a/loom/src/loom/transforms/kernel/test/kernel_async_legality.loom-test
+++ b/loom/src/loom/transforms/kernel/test/kernel_async_legality.loom-test
@@ -159,15 +159,15 @@ func.def @rejects_region_wait_without_parent_wait(%cond: i1) {
 // ====
 
 func.def @allows_static_disjoint_pending_async_destinations(%input: buffer) {
-  %zero = index.constant 0 : offset
-  %sixteen = index.constant 16 : offset
+  %base = index.constant 0 : offset
+  %adjacent_base = index.constant 16 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source0 = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
-  %source1 = buffer.view %global[%sixteen] : buffer -> view<16xi8, #dense>
+  %source0 = buffer.view %global[%base] : buffer -> view<16xi8, #dense>
+  %source1 = buffer.view %global[%adjacent_base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest0 = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
-  %dest1 = buffer.view %scratch[%sixteen] : buffer -> view<16xi8, #dense>
+  %dest0 = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
+  %dest1 = buffer.view %scratch[%adjacent_base] : buffer -> view<16xi8, #dense>
   %copy0 = kernel.async.copy %source0 to %dest0 {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   %group0 = kernel.async.group %copy0 : kernel.async.token -> kernel.async.group
   %copy1 = kernel.async.copy %source1 to %dest1 {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
@@ -180,13 +180,13 @@ func.def @allows_static_disjoint_pending_async_destinations(%input: buffer) {
 // ====
 
 func.def @rejects_overlapping_pending_async_destinations(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest0 = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
-  %dest1 = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %dest0 = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
+  %dest1 = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
   %copy0 = kernel.async.copy %source to %dest0 {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   %group0 = kernel.async.group %copy0 : kernel.async.token -> kernel.async.group
   // ERROR@+1: LOWERING/026 {op_name="kernel.async.copy", phase_name="kernel-async-legality"}
@@ -200,12 +200,12 @@ func.def @rejects_overlapping_pending_async_destinations(%input: buffer) {
 // ====
 
 func.def @rejects_unknown_same_root_pending_async_overlap(%input: buffer, %dest_offset: offset) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest0 = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %dest0 = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
   %dest1 = buffer.view %scratch[%dest_offset] : buffer -> view<16xi8, #dense>
   %copy0 = kernel.async.copy %source to %dest0 {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   %group0 = kernel.async.group %copy0 : kernel.async.token -> kernel.async.group
@@ -220,12 +220,12 @@ func.def @rejects_unknown_same_root_pending_async_overlap(%input: buffer, %dest_
 // ====
 
 func.def @rejects_destination_overwrite_before_wait(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   %value = scalar.constant 1 : i8
@@ -238,12 +238,12 @@ func.def @rejects_destination_overwrite_before_wait(%input: buffer) {
 // ====
 
 func.def @rejects_destination_read_before_wait(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   // ERROR@+1: LOWERING/028 {op_name="view.load", phase_name="kernel-async-legality"}
@@ -256,12 +256,12 @@ func.def @rejects_destination_read_before_wait(%input: buffer) {
 // ====
 
 func.def @rejects_source_overwrite_between_issue_and_group(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   %value = scalar.constant 1 : i8
   // ERROR@+1: LOWERING/037 {op_name="view.store", phase_name="kernel-async-legality"}
@@ -274,12 +274,12 @@ func.def @rejects_source_overwrite_between_issue_and_group(%input: buffer) {
 // ====
 
 func.def @rejects_source_overwrite_between_group_and_wait(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   %value = scalar.constant 1 : i8
@@ -292,14 +292,14 @@ func.def @rejects_source_overwrite_between_group_and_wait(%input: buffer) {
 // ====
 
 func.def @rejects_potentially_aliasing_source_write(%input: buffer, %other_input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
   %other_global = buffer.assume.memory_space<global> %other_input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
-  %other = buffer.view %other_global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<16xi8, #dense>
+  %other = buffer.view %other_global[%base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   %value = scalar.constant 1 : i8
@@ -313,14 +313,14 @@ func.def @rejects_potentially_aliasing_source_write(%input: buffer, %other_input
 
 func.def @allows_noalias_source_write(%input: buffer, %other_input: buffer) {
   %input_unique, %other_unique = buffer.assume.noalias %input, %other_input : buffer, buffer
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input_unique : buffer
   %other_global = buffer.assume.memory_space<global> %other_unique : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
-  %other = buffer.view %other_global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<16xi8, #dense>
+  %other = buffer.view %other_global[%base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   %value = scalar.constant 1 : i8
@@ -332,14 +332,14 @@ func.def @allows_noalias_source_write(%input: buffer, %other_input: buffer) {
 // ====
 
 func.def @allows_disjoint_source_write_before_wait(%input: buffer) {
-  %zero = index.constant 0 : offset
-  %sixteen = index.constant 16 : offset
+  %base = index.constant 0 : offset
+  %adjacent_base = index.constant 16 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
-  %other = buffer.view %global[%sixteen] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<16xi8, #dense>
+  %other = buffer.view %global[%adjacent_base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   %value = scalar.constant 1 : i8
@@ -351,12 +351,12 @@ func.def @allows_disjoint_source_write_before_wait(%input: buffer) {
 // ====
 
 func.def @allows_source_write_after_wait(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
   kernel.async.wait %group {newer_groups = 0} : kernel.async.group
@@ -368,15 +368,15 @@ func.def @allows_source_write_after_wait(%input: buffer) {
 // ====
 
 func.def @rejects_reordered_transfer_group(%input: buffer) {
-  %zero = index.constant 0 : offset
-  %sixteen = index.constant 16 : offset
+  %base = index.constant 0 : offset
+  %adjacent_base = index.constant 16 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source0 = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
-  %source1 = buffer.view %global[%sixteen] : buffer -> view<16xi8, #dense>
+  %source0 = buffer.view %global[%base] : buffer -> view<16xi8, #dense>
+  %source1 = buffer.view %global[%adjacent_base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest0 = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
-  %dest1 = buffer.view %scratch[%sixteen] : buffer -> view<16xi8, #dense>
+  %dest0 = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
+  %dest1 = buffer.view %scratch[%adjacent_base] : buffer -> view<16xi8, #dense>
   %copy0 = kernel.async.copy %source0 to %dest0 {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   %copy1 = kernel.async.copy %source1 to %dest1 {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   // ERROR@+1: LOWERING/038 {op_name="kernel.async.group", phase_name="kernel-async-legality"}
@@ -388,12 +388,12 @@ func.def @rejects_reordered_transfer_group(%input: buffer) {
 // ====
 
 func.def @rejects_wait_between_transfer_and_group(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
   %older = kernel.async.group -> kernel.async.group
   // ERROR@+1: LOWERING/039 {op_name="kernel.async.copy", phase_name="kernel-async-legality"}
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
@@ -406,12 +406,12 @@ func.def @rejects_wait_between_transfer_and_group(%input: buffer) {
 // ====
 
 func.def @rejects_transfer_token_escape(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<16xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<16xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<16xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<16xi8, #dense>
   // ERROR@+1: LOWERING/040 {op_name="kernel.async.copy", phase_name="kernel-async-legality"}
   %copy = kernel.async.copy %source to %dest {cache_scope = cu, cache_temporal = regular, direction = global_to_workgroup} : view<16xi8, #dense> to view<16xi8, #dense> -> kernel.async.token
   test.use %copy : kernel.async.token
@@ -480,13 +480,13 @@ kernel.def @rejects_cluster_gather_without_static_cluster() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %participants = scalar.constant 1 : i32
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<4xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi8, #dense>
   // ERROR@+1: LOWERING/024 {op_name="kernel.async.cluster.gather", phase_name="kernel-async-legality", rejection_bits="256"}
   %copy = kernel.async.cluster.gather %source to %dest using %participants {cache_scope = cu, cache_temporal = regular} : view<4xi8, #dense> to view<4xi8, #dense>, i32 -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -502,12 +502,12 @@ kernel.def @rejects_inexact_cluster_participant_set() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer, %participants: i32) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<4xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi8, #dense>
   // ERROR@+1: LOWERING/024 {op_name="kernel.async.cluster.gather", phase_name="kernel-async-legality", rejection_bits="512"}
   %copy = kernel.async.cluster.gather %source to %dest using %participants {cache_scope = cu, cache_temporal = regular} : view<4xi8, #dense> to view<4xi8, #dense>, i32 -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -523,13 +523,13 @@ kernel.def @rejects_omitted_cluster_participant() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %participants = scalar.constant 1 : i32
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<4xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi8, #dense>
   // ERROR@+1: LOWERING/024 {op_name="kernel.async.cluster.gather", phase_name="kernel-async-legality", rejection_bits="512"}
   %copy = kernel.async.cluster.gather %source to %dest using %participants {cache_scope = cu, cache_temporal = regular} : view<4xi8, #dense> to view<4xi8, #dense>, i32 -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -545,13 +545,13 @@ kernel.def @rejects_target_control_bits_in_cluster_participants() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %participants_with_m0_control = scalar.constant 65539 : i32
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<4xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi8, #dense>
   // ERROR@+1: LOWERING/024 {op_name="kernel.async.cluster.gather", phase_name="kernel-async-legality", rejection_bits="512"}
   %copy = kernel.async.cluster.gather %source to %dest using %participants_with_m0_control {cache_scope = cu, cache_temporal = regular} : view<4xi8, #dense> to view<4xi8, #dense>, i32 -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -567,16 +567,16 @@ kernel.def @rejects_workgroup_varying_cluster_control() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer) {
-  %zero_index = index.constant 0 : index
-  %zero = index.constant 0 : offset
+  %first_cluster_workgroup = index.constant 0 : index
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %participants = scalar.constant 3 : i32
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<4xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi8, #dense>
   %cluster_workgroup = kernel.cluster.workgroup.id<y> : index
-  %is_first = index.cmp eq, %cluster_workgroup, %zero_index : index
+  %is_first = index.cmp eq, %cluster_workgroup, %first_cluster_workgroup : index
   scf.if %is_first {
     // ERROR@+1: LOWERING/024 {op_name="kernel.async.cluster.gather", phase_name="kernel-async-legality", rejection_bits="1024"}
     %copy = kernel.async.cluster.gather %source to %dest using %participants {cache_scope = cu, cache_temporal = regular} : view<4xi8, #dense> to view<4xi8, #dense>, i32 -> kernel.async.token
@@ -594,13 +594,13 @@ kernel.def @allows_cluster_uniform_cfg_control() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer, %enabled: i1) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %participants = scalar.constant 3 : i32
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<4xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi8, #dense>
   cfg.cond_br %enabled, ^enabled_arm, ^disabled_arm
 ^enabled_arm:
   %copy = kernel.async.cluster.gather %source to %dest using %participants {cache_scope = cu, cache_temporal = regular} : view<4xi8, #dense> to view<4xi8, #dense>, i32 -> kernel.async.token
@@ -621,16 +621,16 @@ kernel.def @rejects_workgroup_varying_cluster_cfg_control() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer) {
-  %zero_index = index.constant 0 : index
-  %zero = index.constant 0 : offset
+  %first_cluster_workgroup = index.constant 0 : index
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %participants = scalar.constant 3 : i32
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<4xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi8, #dense>
   %cluster_workgroup = kernel.cluster.workgroup.id<y> : index
-  %is_first = index.cmp eq, %cluster_workgroup, %zero_index : index
+  %is_first = index.cmp eq, %cluster_workgroup, %first_cluster_workgroup : index
   cfg.cond_br %is_first, ^enabled_arm, ^disabled_arm
 ^enabled_arm:
   // ERROR@+1: LOWERING/024 {op_name="kernel.async.cluster.gather", phase_name="kernel-async-legality", rejection_bits="1024"}
@@ -652,7 +652,7 @@ kernel.def @rejects_workgroup_varying_cluster_source_address() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %participants = scalar.constant 3 : i32
   %global = buffer.assume.memory_space<global> %input : buffer
@@ -660,7 +660,7 @@ kernel.def @rejects_workgroup_varying_cluster_source_address() {
   %cluster_offset = index.cast %cluster_workgroup : index to offset
   %source = buffer.view %global[%cluster_offset] : buffer -> view<4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi8, #dense>
   // ERROR@+1: LOWERING/024 {op_name="kernel.async.cluster.gather", phase_name="kernel-async-legality", rejection_bits="2048"}
   %copy = kernel.async.cluster.gather %source to %dest using %participants {cache_scope = cu, cache_temporal = regular} : view<4xi8, #dense> to view<4xi8, #dense>, i32 -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group
@@ -676,11 +676,11 @@ kernel.def @rejects_workgroup_varying_cluster_dest_address() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %participants = scalar.constant 3 : i32
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<4xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
   %cluster_workgroup = kernel.cluster.workgroup.id<y> : index
   %cluster_offset = index.cast %cluster_workgroup : index to offset
@@ -700,13 +700,13 @@ kernel.def @rejects_dynamic_cluster_predicate() {
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c2, %c1) workgroup_size(%c64, %c1, %c1) cluster_size(%c1, %c2, %c1) : index
 } launch(%input: buffer, %predicate: i1) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 64 : offset
   %participants = scalar.constant 3 : i32
   %global = buffer.assume.memory_space<global> %input : buffer
-  %source = buffer.view %global[%zero] : buffer -> view<4xi8, #dense>
+  %source = buffer.view %global[%base] : buffer -> view<4xi8, #dense>
   %scratch = buffer.alloca %bytes {base_alignment = 64, memory_space = workgroup} : buffer
-  %dest = buffer.view %scratch[%zero] : buffer -> view<4xi8, #dense>
+  %dest = buffer.view %scratch[%base] : buffer -> view<4xi8, #dense>
   // ERROR@+1: LOWERING/024 {op_name="kernel.async.cluster.gather.mask", phase_name="kernel-async-legality", rejection_bits="8192"}
   %copy = kernel.async.cluster.gather.mask %source to %dest using %participants, %predicate {cache_scope = cu, cache_temporal = regular} : view<4xi8, #dense> to view<4xi8, #dense>, i32, i1 -> kernel.async.token
   %group = kernel.async.group %copy : kernel.async.token -> kernel.async.group

--- a/loom/src/loom/transforms/kernel/test/promote_private_fragments.loom-test
+++ b/loom/src/loom/transforms/kernel/test/promote_private_fragments.loom-test
@@ -1,12 +1,12 @@
 // RUN: pass promote-private-fragments,dce
 
 func.def @promote_static_fragment_load(%input: buffer, %output: buffer) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<4xf32, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<4xf32, #dense>
   %fragment_bytes = index.constant 16 : offset
   %fragment_buffer = buffer.alloca %fragment_bytes {base_alignment = 4, memory_space = private} : buffer
-  %fragment = buffer.view %fragment_buffer[%zero_bytes] : buffer -> view<4xf32, #dense>
+  %fragment = buffer.view %fragment_buffer[%base] : buffer -> view<4xf32, #dense>
   %start = index.constant 0 : index
   %end = index.constant 4 : index
   %step = index.constant 1 : index
@@ -21,9 +21,9 @@ func.def @promote_static_fragment_load(%input: buffer, %output: buffer) {
 
 // ----
 func.def @promote_static_fragment_load(%input: buffer, %output: buffer) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<4xf32, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<4xf32, #dense>
   %fragment_vector = vector.load %input_view[0] : view<4xf32, #dense> -> vector<4xf32>
   %selected = vector.extract %fragment_vector[2] : vector<4xf32> -> f32
   view.store %selected, %output_view[2] : f32, view<4xf32, #dense>
@@ -33,12 +33,12 @@ func.def @promote_static_fragment_load(%input: buffer, %output: buffer) {
 // ====
 
 func.def @promote_trailing_axis_fragment(%input: buffer, %output: buffer, %row: index, %lane: index) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<8x4xi32, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<4xi32, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<8x4xi32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<4xi32, #dense>
   %fragment_bytes = index.constant 16 : offset
   %fragment_buffer = buffer.alloca %fragment_bytes {base_alignment = 4, memory_space = private} : buffer
-  %fragment = buffer.view %fragment_buffer[%zero_bytes] : buffer -> view<4xi32, #dense>
+  %fragment = buffer.view %fragment_buffer[%base] : buffer -> view<4xi32, #dense>
   %start = index.constant 0 : index
   %end = index.constant 4 : index
   %step = index.constant 1 : index
@@ -53,9 +53,9 @@ func.def @promote_trailing_axis_fragment(%input: buffer, %output: buffer, %row: 
 
 // ----
 func.def @promote_trailing_axis_fragment(%input: buffer, %output: buffer, %row: index, %lane: index) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<8x4xi32, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<4xi32, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<8x4xi32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<4xi32, #dense>
   %fragment_vector = vector.load %input_view[%row, 0] : view<8x4xi32, #dense> -> vector<4xi32>
   %selected = vector.extract %fragment_vector[%lane] : vector<4xi32> -> i32
   view.store %selected, %output_view[%lane] : i32, view<4xi32, #dense>
@@ -67,12 +67,12 @@ func.def @promote_trailing_axis_fragment(%input: buffer, %output: buffer, %row: 
 // Partial initialization stays explicit. The pass only promotes full-copy
 // fragments because anything else needs a stronger dataflow representation.
 func.def @keeps_partial_fragment_copy(%input: buffer, %output: buffer) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<4xf32, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<4xf32, #dense>
   %fragment_bytes = index.constant 16 : offset
   %fragment_buffer = buffer.alloca %fragment_bytes {base_alignment = 4, memory_space = private} : buffer
-  %fragment = buffer.view %fragment_buffer[%zero_bytes] : buffer -> view<4xf32, #dense>
+  %fragment = buffer.view %fragment_buffer[%base] : buffer -> view<4xf32, #dense>
   %start = index.constant 0 : index
   %partial_end = index.constant 3 : index
   %step = index.constant 1 : index
@@ -87,12 +87,12 @@ func.def @keeps_partial_fragment_copy(%input: buffer, %output: buffer) {
 
 // ----
 func.def @keeps_partial_fragment_copy(%input: buffer, %output: buffer) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<4xf32, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<4xf32, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<4xf32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<4xf32, #dense>
   %fragment_bytes = index.constant 16 : offset
   %fragment_buffer = buffer.alloca %fragment_bytes {base_alignment = 4, memory_space = private} : buffer
-  %fragment = buffer.view %fragment_buffer[%zero_bytes] : buffer -> view<4xf32, #dense>
+  %fragment = buffer.view %fragment_buffer[%base] : buffer -> view<4xf32, #dense>
   %start = index.constant 0 : index
   %partial_end = index.constant 3 : index
   %step = index.constant 1 : index
@@ -108,12 +108,12 @@ func.def @keeps_partial_fragment_copy(%input: buffer, %output: buffer) {
 // ====
 
 func.def @forward_dominated_private_lane(%input: buffer, %output: buffer, %lane: index, %cond: i1) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<64xf16, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<64xf16, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<64xf16, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<64xf16, #dense>
   %fragment_bytes = index.constant 128 : offset
   %fragment_buffer = buffer.alloca %fragment_bytes {base_alignment = 2, memory_space = private} : buffer
-  %fragment = buffer.view %fragment_buffer[%zero_bytes] : buffer -> view<64xf16, #dense>
+  %fragment = buffer.view %fragment_buffer[%base] : buffer -> view<64xf16, #dense>
   %copy = view.load %input_view[%lane] : view<64xf16, #dense> -> f16
   view.store %copy, %fragment[%lane] : f16, view<64xf16, #dense>
   scf.if %cond {
@@ -125,9 +125,9 @@ func.def @forward_dominated_private_lane(%input: buffer, %output: buffer, %lane:
 
 // ----
 func.def @forward_dominated_private_lane(%input: buffer, %output: buffer, %lane: index, %cond: i1) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<64xf16, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<64xf16, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<64xf16, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<64xf16, #dense>
   %copy = view.load %input_view[%lane] : view<64xf16, #dense> -> f16
   scf.if %cond {
     view.store %copy, %output_view[%lane] : f16, view<64xf16, #dense>
@@ -138,11 +138,11 @@ func.def @forward_dominated_private_lane(%input: buffer, %output: buffer, %lane:
 // ====
 
 func.def @forward_linear_scalar_slot(%output: buffer, %lhs: i64, %rhs: i64) {
-  %zero_bytes = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<1xi64, #dense>
+  %base = index.constant 0 : offset
+  %output_view = buffer.view %output[%base] : buffer -> view<1xi64, #dense>
   %slot_bytes = index.constant 8 : offset
   %slot_buffer = buffer.alloca %slot_bytes {base_alignment = 8, memory_space = private} : buffer
-  %slot = buffer.view %slot_buffer[%zero_bytes] : buffer -> view<1xi64, #dense>
+  %slot = buffer.view %slot_buffer[%base] : buffer -> view<1xi64, #dense>
   %slot_index = index.constant 0 : index
   %initial = scalar.constant 0 : i64
   view.store %initial, %slot[%slot_index] : i64, view<1xi64, #dense>
@@ -158,8 +158,8 @@ func.def @forward_linear_scalar_slot(%output: buffer, %lhs: i64, %rhs: i64) {
 
 // ----
 func.def @forward_linear_scalar_slot(%output: buffer, %lhs: i64, %rhs: i64) {
-  %zero_bytes = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<1xi64, #dense>
+  %base = index.constant 0 : offset
+  %output_view = buffer.view %output[%base] : buffer -> view<1xi64, #dense>
   %slot_index = index.constant 0 : index
   %initial = scalar.constant 0 : i64
   %sum = scalar.addi %initial, %lhs : i64
@@ -171,12 +171,12 @@ func.def @forward_linear_scalar_slot(%output: buffer, %lhs: i64, %rhs: i64) {
 // ====
 
 func.def @forward_static_private_slots(%input: buffer, %output: buffer) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<2xf32, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<2xf32, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<2xf32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<2xf32, #dense>
   %slot_bytes = index.constant 8 : offset
   %slot_buffer = buffer.alloca %slot_bytes {base_alignment = 4, memory_space = private} : buffer
-  %slots = buffer.view %slot_buffer[%zero_bytes] : buffer -> view<2xf32, #dense>
+  %slots = buffer.view %slot_buffer[%base] : buffer -> view<2xf32, #dense>
   %lane0 = index.constant 0 : index
   %lane1 = index.constant 1 : index
   %loaded0 = view.load %input_view[%lane0] : view<2xf32, #dense> -> f32
@@ -192,9 +192,9 @@ func.def @forward_static_private_slots(%input: buffer, %output: buffer) {
 
 // ----
 func.def @forward_static_private_slots(%input: buffer, %output: buffer) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<2xf32, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<2xf32, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<2xf32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<2xf32, #dense>
   %lane0 = index.constant 0 : index
   %lane1 = index.constant 1 : index
   %loaded0 = view.load %input_view[%lane0] : view<2xf32, #dense> -> f32
@@ -207,11 +207,11 @@ func.def @forward_static_private_slots(%input: buffer, %output: buffer) {
 // ====
 
 func.def @erase_noop_private_slot_before_static_forward(%output: buffer, %lhs: i64, %rhs: i64) {
-  %zero_bytes = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<1xi64, #dense>
+  %base = index.constant 0 : offset
+  %output_view = buffer.view %output[%base] : buffer -> view<1xi64, #dense>
   %slot_bytes = index.constant 16 : offset
   %slot_buffer = buffer.alloca %slot_bytes {base_alignment = 8, memory_space = private} : buffer
-  %slots = buffer.view %slot_buffer[%zero_bytes] : buffer -> view<2xi64, #dense>
+  %slots = buffer.view %slot_buffer[%base] : buffer -> view<2xi64, #dense>
   %slot0 = index.constant 0 : index
   %slot1 = index.constant 1 : index
   %initial = scalar.constant 0 : i64
@@ -230,8 +230,8 @@ func.def @erase_noop_private_slot_before_static_forward(%output: buffer, %lhs: i
 
 // ----
 func.def @erase_noop_private_slot_before_static_forward(%output: buffer, %lhs: i64, %rhs: i64) {
-  %zero_bytes = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<1xi64, #dense>
+  %base = index.constant 0 : offset
+  %output_view = buffer.view %output[%base] : buffer -> view<1xi64, #dense>
   %slot0 = index.constant 0 : index
   %initial = scalar.constant 0 : i64
   %sum = scalar.addi %initial, %lhs : i64
@@ -243,11 +243,11 @@ func.def @erase_noop_private_slot_before_static_forward(%output: buffer, %lhs: i
 // ====
 
 func.def @keeps_conditionally_stored_scalar_slot(%output: buffer, %value: i64, %cond: i1) {
-  %zero_bytes = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<1xi64, #dense>
+  %base = index.constant 0 : offset
+  %output_view = buffer.view %output[%base] : buffer -> view<1xi64, #dense>
   %slot_bytes = index.constant 8 : offset
   %slot_buffer = buffer.alloca %slot_bytes {base_alignment = 8, memory_space = private} : buffer
-  %slot = buffer.view %slot_buffer[%zero_bytes] : buffer -> view<1xi64, #dense>
+  %slot = buffer.view %slot_buffer[%base] : buffer -> view<1xi64, #dense>
   %slot_index = index.constant 0 : index
   %initial = scalar.constant 0 : i64
   view.store %initial, %slot[%slot_index] : i64, view<1xi64, #dense>
@@ -261,11 +261,11 @@ func.def @keeps_conditionally_stored_scalar_slot(%output: buffer, %value: i64, %
 
 // ----
 func.def @keeps_conditionally_stored_scalar_slot(%output: buffer, %value: i64, %cond: i1) {
-  %zero_bytes = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<1xi64, #dense>
+  %base = index.constant 0 : offset
+  %output_view = buffer.view %output[%base] : buffer -> view<1xi64, #dense>
   %slot_bytes = index.constant 8 : offset
   %slot_buffer = buffer.alloca %slot_bytes {base_alignment = 8, memory_space = private} : buffer
-  %slot = buffer.view %slot_buffer[%zero_bytes] : buffer -> view<1xi64, #dense>
+  %slot = buffer.view %slot_buffer[%base] : buffer -> view<1xi64, #dense>
   %slot_index = index.constant 0 : index
   %initial = scalar.constant 0 : i64
   view.store %initial, %slot[%slot_index] : i64, view<1xi64, #dense>
@@ -280,12 +280,12 @@ func.def @keeps_conditionally_stored_scalar_slot(%output: buffer, %value: i64, %
 // ====
 
 func.def @forward_branch_local_accumulator(%input: buffer, %output: buffer, %cond: i1) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<2xf32, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<1xf32, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<2xf32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<1xf32, #dense>
   %slot_bytes = index.constant 4 : offset
   %slot_buffer = buffer.alloca %slot_bytes {base_alignment = 4, memory_space = private} : buffer
-  %slot = buffer.view %slot_buffer[%zero_bytes] : buffer -> view<1xf32, #dense>
+  %slot = buffer.view %slot_buffer[%base] : buffer -> view<1xf32, #dense>
   %slot_index = index.constant 0 : index
   %initial = scalar.constant 0.0 : f32
   view.store %initial, %slot[%slot_index] : f32, view<1xf32, #dense>
@@ -304,9 +304,9 @@ func.def @forward_branch_local_accumulator(%input: buffer, %output: buffer, %con
 
 // ----
 func.def @forward_branch_local_accumulator(%input: buffer, %output: buffer, %cond: i1) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<2xf32, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<1xf32, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<2xf32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<1xf32, #dense>
   %slot_index = index.constant 0 : index
   %initial = scalar.constant 0.0 : f32
   scf.if %cond {
@@ -325,13 +325,13 @@ kernel.def @forward_kernel_branch_local_accumulator() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer, %cond: i1) {
-  %zero_bytes = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<2xf32, %layout>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<1xf32, %layout>
+  %input_view = buffer.view %input[%base] : buffer -> view<2xf32, %layout>
+  %output_view = buffer.view %output[%base] : buffer -> view<1xf32, %layout>
   %slot_bytes = index.constant 4 : offset
   %slot_buffer = buffer.alloca %slot_bytes {base_alignment = 4, memory_space = private} : buffer
-  %slot = buffer.view %slot_buffer[%zero_bytes] : buffer -> view<1xf32, %layout>
+  %slot = buffer.view %slot_buffer[%base] : buffer -> view<1xf32, %layout>
   %slot_index = index.constant 0 : index
   %initial = scalar.constant 0.0 : f32
   view.store %initial, %slot[%slot_index] : f32, view<1xf32, %layout>
@@ -353,10 +353,10 @@ kernel.def @forward_kernel_branch_local_accumulator() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer, %cond: i1) {
-  %zero_bytes = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<2xf32, %layout>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<1xf32, %layout>
+  %input_view = buffer.view %input[%base] : buffer -> view<2xf32, %layout>
+  %output_view = buffer.view %output[%base] : buffer -> view<1xf32, %layout>
   %slot_index = index.constant 0 : index
   %initial = scalar.constant 0.0 : f32
   scf.if %cond {
@@ -375,14 +375,14 @@ kernel.def @forward_imported_branch_accumulator() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %sum_output: buffer, %normalized_output: buffer, %limit: index) {
-  %zero_bytes = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<[%limit]x2xf32, %layout>
-  %sum_output_view = buffer.view %sum_output[%zero_bytes] : buffer -> view<[%limit]xf32, %layout>
-  %normalized_output_view = buffer.view %normalized_output[%zero_bytes] : buffer -> view<[%limit]x2xf32, %layout>
+  %input_view = buffer.view %input[%base] : buffer -> view<[%limit]x2xf32, %layout>
+  %sum_output_view = buffer.view %sum_output[%base] : buffer -> view<[%limit]xf32, %layout>
+  %normalized_output_view = buffer.view %normalized_output[%base] : buffer -> view<[%limit]x2xf32, %layout>
   %slot_bytes = index.constant 4 : offset
   %slot_buffer = buffer.alloca %slot_bytes {base_alignment = 4, memory_space = private} : buffer
-  %slot = buffer.view %slot_buffer[%zero_bytes] : buffer -> view<1xf32, %layout>
+  %slot = buffer.view %slot_buffer[%base] : buffer -> view<1xf32, %layout>
   %slot_index = index.constant 0 : index
   %initial = scalar.constant 9.9999999999999995e-21 : f32
   view.store %initial, %slot[%slot_index] : f32, view<1xf32, %layout>
@@ -415,11 +415,11 @@ kernel.def @forward_imported_branch_accumulator() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %sum_output: buffer, %normalized_output: buffer, %limit: index) {
-  %zero_bytes = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<[%limit]x2xf32, %layout>
-  %sum_output_view = buffer.view %sum_output[%zero_bytes] : buffer -> view<[%limit]xf32, %layout>
-  %normalized_output_view = buffer.view %normalized_output[%zero_bytes] : buffer -> view<[%limit]x2xf32, %layout>
+  %input_view = buffer.view %input[%base] : buffer -> view<[%limit]x2xf32, %layout>
+  %sum_output_view = buffer.view %sum_output[%base] : buffer -> view<[%limit]xf32, %layout>
+  %normalized_output_view = buffer.view %normalized_output[%base] : buffer -> view<[%limit]x2xf32, %layout>
   %slot_index = index.constant 0 : index
   %initial = scalar.constant 9.9999999999999995e-21 : f32
   %workgroup = kernel.workgroup.id<x> : index
@@ -449,17 +449,17 @@ kernel.def @forward_fragment_and_accumulator() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %sum_output: buffer, %normalized_output: buffer, %limit: index) {
-  %zero_bytes = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<[%limit]x2xf32, %layout>
-  %sum_output_view = buffer.view %sum_output[%zero_bytes] : buffer -> view<[%limit]xf32, %layout>
-  %normalized_output_view = buffer.view %normalized_output[%zero_bytes] : buffer -> view<[%limit]x2xf32, %layout>
+  %input_view = buffer.view %input[%base] : buffer -> view<[%limit]x2xf32, %layout>
+  %sum_output_view = buffer.view %sum_output[%base] : buffer -> view<[%limit]xf32, %layout>
+  %normalized_output_view = buffer.view %normalized_output[%base] : buffer -> view<[%limit]x2xf32, %layout>
   %fragment_bytes = index.constant 8 : offset
   %fragment_buffer = buffer.alloca %fragment_bytes {base_alignment = 4, memory_space = private} : buffer
-  %fragment = buffer.view %fragment_buffer[%zero_bytes] : buffer -> view<2xf32, %layout>
+  %fragment = buffer.view %fragment_buffer[%base] : buffer -> view<2xf32, %layout>
   %slot_bytes = index.constant 4 : offset
   %slot_buffer = buffer.alloca %slot_bytes {base_alignment = 4, memory_space = private} : buffer
-  %slot = buffer.view %slot_buffer[%zero_bytes] : buffer -> view<1xf32, %layout>
+  %slot = buffer.view %slot_buffer[%base] : buffer -> view<1xf32, %layout>
   %slot_index = index.constant 0 : index
   %initial = scalar.constant 9.9999999999999995e-21 : f32
   view.store %initial, %slot[%slot_index] : f32, view<1xf32, %layout>
@@ -499,11 +499,11 @@ kernel.def @forward_fragment_and_accumulator() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %sum_output: buffer, %normalized_output: buffer, %limit: index) {
-  %zero_bytes = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<[%limit]x2xf32, %layout>
-  %sum_output_view = buffer.view %sum_output[%zero_bytes] : buffer -> view<[%limit]xf32, %layout>
-  %normalized_output_view = buffer.view %normalized_output[%zero_bytes] : buffer -> view<[%limit]x2xf32, %layout>
+  %input_view = buffer.view %input[%base] : buffer -> view<[%limit]x2xf32, %layout>
+  %sum_output_view = buffer.view %sum_output[%base] : buffer -> view<[%limit]xf32, %layout>
+  %normalized_output_view = buffer.view %normalized_output[%base] : buffer -> view<[%limit]x2xf32, %layout>
   %slot_index = index.constant 0 : index
   %initial = scalar.constant 9.9999999999999995e-21 : f32
   %workgroup = kernel.workgroup.id<x> : index
@@ -534,12 +534,12 @@ kernel.def @forward_fragment_and_accumulator() {
 // ====
 
 func.def @keeps_mismatched_private_lane(%input: buffer, %output: buffer, %store_lane: index, %load_lane: index) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<64xf16, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<64xf16, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<64xf16, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<64xf16, #dense>
   %fragment_bytes = index.constant 128 : offset
   %fragment_buffer = buffer.alloca %fragment_bytes {base_alignment = 2, memory_space = private} : buffer
-  %fragment = buffer.view %fragment_buffer[%zero_bytes] : buffer -> view<64xf16, #dense>
+  %fragment = buffer.view %fragment_buffer[%base] : buffer -> view<64xf16, #dense>
   %copy = view.load %input_view[%store_lane] : view<64xf16, #dense> -> f16
   view.store %copy, %fragment[%store_lane] : f16, view<64xf16, #dense>
   %selected = view.load %fragment[%load_lane] : view<64xf16, #dense> -> f16
@@ -549,12 +549,12 @@ func.def @keeps_mismatched_private_lane(%input: buffer, %output: buffer, %store_
 
 // ----
 func.def @keeps_mismatched_private_lane(%input: buffer, %output: buffer, %store_lane: index, %load_lane: index) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<64xf16, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<64xf16, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<64xf16, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<64xf16, #dense>
   %fragment_bytes = index.constant 128 : offset
   %fragment_buffer = buffer.alloca %fragment_bytes {base_alignment = 2, memory_space = private} : buffer
-  %fragment = buffer.view %fragment_buffer[%zero_bytes] : buffer -> view<64xf16, #dense>
+  %fragment = buffer.view %fragment_buffer[%base] : buffer -> view<64xf16, #dense>
   %copy = view.load %input_view[%store_lane] : view<64xf16, #dense> -> f16
   view.store %copy, %fragment[%store_lane] : f16, view<64xf16, #dense>
   %selected = view.load %fragment[%load_lane] : view<64xf16, #dense> -> f16
@@ -565,12 +565,12 @@ func.def @keeps_mismatched_private_lane(%input: buffer, %output: buffer, %store_
 // ====
 
 func.def @keeps_conditionally_stored_private_lane(%input: buffer, %output: buffer, %lane: index, %cond: i1) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<64xf16, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<64xf16, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<64xf16, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<64xf16, #dense>
   %fragment_bytes = index.constant 128 : offset
   %fragment_buffer = buffer.alloca %fragment_bytes {base_alignment = 2, memory_space = private} : buffer
-  %fragment = buffer.view %fragment_buffer[%zero_bytes] : buffer -> view<64xf16, #dense>
+  %fragment = buffer.view %fragment_buffer[%base] : buffer -> view<64xf16, #dense>
   %copy = view.load %input_view[%lane] : view<64xf16, #dense> -> f16
   scf.if %cond {
     view.store %copy, %fragment[%lane] : f16, view<64xf16, #dense>
@@ -582,12 +582,12 @@ func.def @keeps_conditionally_stored_private_lane(%input: buffer, %output: buffe
 
 // ----
 func.def @keeps_conditionally_stored_private_lane(%input: buffer, %output: buffer, %lane: index, %cond: i1) {
-  %zero_bytes = index.constant 0 : offset
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<64xf16, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<64xf16, #dense>
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input[%base] : buffer -> view<64xf16, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<64xf16, #dense>
   %fragment_bytes = index.constant 128 : offset
   %fragment_buffer = buffer.alloca %fragment_bytes {base_alignment = 2, memory_space = private} : buffer
-  %fragment = buffer.view %fragment_buffer[%zero_bytes] : buffer -> view<64xf16, #dense>
+  %fragment = buffer.view %fragment_buffer[%base] : buffer -> view<64xf16, #dense>
   %copy = view.load %input_view[%lane] : view<64xf16, #dense> -> f16
   scf.if %cond {
     view.store %copy, %fragment[%lane] : f16, view<64xf16, #dense>

--- a/loom/src/loom/transforms/kernel/test/promote_private_fragments_after_unroll.loom-test
+++ b/loom/src/loom/transforms/kernel/test/promote_private_fragments_after_unroll.loom-test
@@ -1,17 +1,17 @@
 // RUN: pass unroll-scf-for,canonicalize,cse,promote-private-fragments,dce
 
 func.def @forward_after_unrolled_private_init(%output: buffer, %lhs: i64, %rhs: i64) {
-  %zero_bytes = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<1xi64, #dense>
+  %base = index.constant 0 : offset
+  %output_view = buffer.view %output[%base] : buffer -> view<1xi64, #dense>
   %slot_bytes = index.constant 16 : offset
   %slot_buffer = buffer.alloca %slot_bytes {base_alignment = 8, memory_space = private} : buffer
-  %slots = buffer.view %slot_buffer[%zero_bytes] : buffer -> view<2xi64, #dense>
+  %slots = buffer.view %slot_buffer[%base] : buffer -> view<2xi64, #dense>
   %start = index.constant 0 : index
   %end = index.constant 2 : index
   %step = index.constant 1 : index
   scf.for %j = [%start to %end step %step] unroll {
-    %zero = scalar.constant 0 : i64
-    view.store %zero, %slots[%j] : i64, view<2xi64, #dense>
+    %initial_value = scalar.constant 0 : i64
+    view.store %initial_value, %slots[%j] : i64, view<2xi64, #dense>
   }
   %slot0 = index.constant 0 : index
   %slot1 = index.constant 1 : index
@@ -30,12 +30,12 @@ func.def @forward_after_unrolled_private_init(%output: buffer, %lhs: i64, %rhs: 
 
 // ----
 func.def @forward_after_unrolled_private_init(%output: buffer, %lhs: i64, %rhs: i64) {
-  %zero_bytes = index.constant 0 : offset
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<1xi64, #dense>
+  %base = index.constant 0 : offset
+  %output_view = buffer.view %output[%base] : buffer -> view<1xi64, #dense>
   %j_0 = index.constant 0 : index
-  %zero = scalar.constant 0 : i64
-  %sum = scalar.addi %zero, %lhs : i64
-  %xor = scalar.xori %zero, %rhs : i64
+  %initial_value = scalar.constant 0 : i64
+  %sum = scalar.addi %initial_value, %lhs : i64
+  %xor = scalar.xori %initial_value, %rhs : i64
   %result = scalar.ori %sum, %xor : i64
   view.store %result, %output_view[%j_0] : i64, view<1xi64, #dense>
   func.return

--- a/loom/src/loom/transforms/kernel/test/promote_private_fragments_footprint.loom-test
+++ b/loom/src/loom/transforms/kernel/test/promote_private_fragments_footprint.loom-test
@@ -1,14 +1,14 @@
 // RUN: pass promote-private-fragments,dce,vector-memory-footprint
 
 func.def @promoted_fragment_preserves_assume_predicates(%input: buffer, %output: buffer, %row: index, %n: i32, %value: vector<4xf32>) {
-  %zero_bytes = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %n_idx = index.cast %n : i32 to index
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<[%n_idx]x2xi32, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<[%n_idx]x4xf32, #dense>
+  %input_view = buffer.view %input[%base] : buffer -> view<[%n_idx]x2xi32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<[%n_idx]x4xf32, #dense>
   %row_in_bounds, %n_idx_assumed = index.assume %row, %n_idx [ge(%row, 0), lt(%row, %n_idx)] : index, index
   %fragment_bytes = index.constant 8 : offset
   %fragment_buffer = buffer.alloca %fragment_bytes {base_alignment = 4, memory_space = private} : buffer
-  %fragment = buffer.view %fragment_buffer[%zero_bytes] : buffer -> view<2xi32, #dense>
+  %fragment = buffer.view %fragment_buffer[%base] : buffer -> view<2xi32, #dense>
   %start = index.constant 0 : index
   %end = index.constant 2 : index
   %step = index.constant 1 : index
@@ -16,8 +16,8 @@ func.def @promoted_fragment_preserves_assume_predicates(%input: buffer, %output:
     %copy = view.load %input_view[%row_in_bounds, %lane] : view<[%n_idx]x2xi32, #dense> -> i32
     view.store %copy, %fragment[%lane] : i32, view<2xi32, #dense>
   }
-  %lane_zero = index.constant 0 : index
-  %selected = view.load %fragment[%lane_zero] : view<2xi32, #dense> -> i32
+  %first_lane = index.constant 0 : index
+  %selected = view.load %fragment[%first_lane] : view<2xi32, #dense> -> i32
   %selected_bounded, %n_bounded = scalar.assume %selected, %n [lt(%selected, %n)] : i32, i32
   %selected_nonnegative = scalar.assume %selected_bounded [ge(%selected_bounded, 0)] : i32
   %selected_idx = index.cast %selected_nonnegative : i32 to index
@@ -27,14 +27,14 @@ func.def @promoted_fragment_preserves_assume_predicates(%input: buffer, %output:
 
 // ----
 func.def @promoted_fragment_preserves_assume_predicates(%input: buffer, %output: buffer, %row: index, %n: i32, %value: vector<4xf32>) {
-  %zero_bytes = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %n_idx = index.cast %n : i32 to index
-  %input_view = buffer.view %input[%zero_bytes] : buffer -> view<[%n_idx]x2xi32, #dense>
-  %output_view = buffer.view %output[%zero_bytes] : buffer -> view<[%n_idx]x4xf32, #dense>
+  %input_view = buffer.view %input[%base] : buffer -> view<[%n_idx]x2xi32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<[%n_idx]x4xf32, #dense>
   %row_in_bounds, %n_idx_assumed = index.assume %row, %n_idx [ge(%row, 0), lt(%row, %n_idx)] : index, index
   %fragment_vector = vector.load %input_view[%row_in_bounds, 0] : view<[%n_idx]x2xi32, #dense> -> vector<2xi32>
-  %lane_zero = index.constant 0 : index
-  %selected = vector.extract %fragment_vector[%lane_zero] : vector<2xi32> -> i32
+  %first_lane = index.constant 0 : index
+  %selected = vector.extract %fragment_vector[%first_lane] : vector<2xi32> -> i32
   %selected_bounded, %n_bounded = scalar.assume %selected, %n [lt(%selected, %n)] : i32, i32
   %selected_nonnegative = scalar.assume %selected_bounded [ge(%selected_bounded, 0)] : i32
   %selected_idx = index.cast %selected_nonnegative : i32 to index

--- a/loom/src/loom/transforms/kernel/test/stage_loop_carried_fragments.loom-test
+++ b/loom/src/loom/transforms/kernel/test/stage_loop_carried_fragments.loom-test
@@ -3,20 +3,20 @@
 test.target<low_core> @target {abi = hal_kernel, subgroup_size = 64}
 
 kernel.def target(@target) @stage_dense_accumulator_fragments() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %accumulator: vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xbf16>
   %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
-  %result0, %result1, %result2, %result3 = scf.for %tile = [%zero to %four step %one](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
+  %result0, %result1, %result2, %result3 = scf.for %tile = [%loop_begin to %tile_count step %loop_step](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
     %next0 = vector.mma %lhs, %rhs, %acc0 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     %next1 = vector.mma %lhs, %rhs, %acc1 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     %next2 = vector.mma %lhs, %rhs, %acc2 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
@@ -31,13 +31,13 @@ kernel.def target(@target) @stage_dense_accumulator_fragments() {
 test.target<low_core> @target {abi = hal_kernel, subgroup_size = 64}
 
 kernel.def target(@target) @stage_dense_accumulator_fragments() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %accumulator: vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -59,7 +59,7 @@ kernel.def target(@target) @stage_dense_accumulator_fragments() {
   %36 = index.constant 48 : index
   vector.fragment.store<result> %init, %32[%29, %36] shape [%m, %n] : vector<8xf32>, view<16x64xf32, %30>
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
-  scf.for %37 = [%zero to %four step %one] {
+  scf.for %37 = [%loop_begin to %tile_count step %loop_step] {
     %38 = vector.fragment.load<init> %32[%29, %33] shape [%m, %n] : view<16x64xf32, %30> -> vector<8xf32>
     %39 = vector.fragment.load<init> %32[%29, %34] shape [%m, %n] : view<16x64xf32, %30> -> vector<8xf32>
     %40 = vector.fragment.load<init> %32[%29, %35] shape [%m, %n] : view<16x64xf32, %30> -> vector<8xf32>
@@ -86,13 +86,13 @@ kernel.def target(@target) @stage_dense_accumulator_fragments() {
 test.target<low_core> @target {abi = hal_kernel, subgroup_size = 64}
 
 kernel.def target(@target) @stage_blocked_accumulator_fragment() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%lhs_values: vector<4xf16>, %rhs_values: vector<4xf16>, %accumulator: vector<16xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %blocks = index.constant 4 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
@@ -100,7 +100,7 @@ kernel.def target(@target) @stage_blocked_accumulator_fragment() {
   %lhs = vector.fragment<lhs> %lhs_values shape [blocks(%blocks), %m, %k] : vector<4xf16>
   %rhs = vector.fragment<rhs> %rhs_values shape [blocks(%blocks), %k, %n] : vector<4xf16>
   %init = vector.fragment<init> %accumulator shape [blocks(%blocks), %m, %n] : vector<16xf32>
-  %result = scf.for %tile = [%zero to %four step %one](%acc = %init : vector<16xf32>) -> (vector<16xf32>) {
+  %result = scf.for %tile = [%loop_begin to %tile_count step %loop_step](%acc = %init : vector<16xf32>) -> (vector<16xf32>) {
     %next = vector.mma %lhs, %rhs, %acc : vector<4xf16>, vector<4xf16>, vector<16xf32>
     scf.yield %next : vector<16xf32>
   }
@@ -112,13 +112,13 @@ kernel.def target(@target) @stage_blocked_accumulator_fragment() {
 test.target<low_core> @target {abi = hal_kernel, subgroup_size = 64}
 
 kernel.def target(@target) @stage_blocked_accumulator_fragment() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%lhs_values: vector<4xf16>, %rhs_values: vector<4xf16>, %accumulator: vector<16xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %blocks = index.constant 4 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
@@ -135,7 +135,7 @@ kernel.def target(@target) @stage_blocked_accumulator_fragment() {
   %25 = index.constant 0 : index
   vector.fragment.store<result> %init, %24[%21, %21, %25] shape [blocks(%blocks), %m, %n] : vector<16xf32>, view<4x16x16xf32, %22>
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
-  scf.for %26 = [%zero to %four step %one] {
+  scf.for %26 = [%loop_begin to %tile_count step %loop_step] {
     %27 = vector.fragment.load<init> %24[%21, %21, %25] shape [blocks(%blocks), %m, %n] : view<4x16x16xf32, %22> -> vector<16xf32>
     %next = vector.mma %lhs, %rhs, %27 : vector<4xf16>, vector<4xf16>, vector<16xf32>
     vector.fragment.store<result> %next, %24[%21, %21, %25] shape [blocks(%blocks), %m, %n] : vector<16xf32>, view<4x16x16xf32, %22>
@@ -152,13 +152,13 @@ kernel.def target(@target) @stage_blocked_accumulator_fragment() {
 test.target<low_core> @target {abi = hal_kernel, subgroup_size = 64}
 
 kernel.def target(@target) @report_blocked_accumulator_fragment_staging() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%lhs_values: vector<4xf16>, %rhs_values: vector<4xf16>, %accumulator: vector<16xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %blocks = index.constant 4 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
@@ -166,7 +166,7 @@ kernel.def target(@target) @report_blocked_accumulator_fragment_staging() {
   %lhs = vector.fragment<lhs> %lhs_values shape [blocks(%blocks), %m, %k] : vector<4xf16>
   %rhs = vector.fragment<rhs> %rhs_values shape [blocks(%blocks), %k, %n] : vector<4xf16>
   %init = vector.fragment<init> %accumulator shape [blocks(%blocks), %m, %n] : vector<16xf32>
-  %result = scf.for %tile = [%zero to %four step %one](%acc = %init : vector<16xf32>) -> (vector<16xf32>) {
+  %result = scf.for %tile = [%loop_begin to %tile_count step %loop_step](%acc = %init : vector<16xf32>) -> (vector<16xf32>) {
     %next = vector.mma %lhs, %rhs, %acc : vector<4xf16>, vector<4xf16>, vector<16xf32>
     scf.yield %next : vector<16xf32>
   }
@@ -175,20 +175,20 @@ kernel.def target(@target) @report_blocked_accumulator_fragment_staging() {
 }
 
 kernel.def target(@target) @explicitly_stage_one_accumulator_fragment() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %accumulator: vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xbf16>
   %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
-  %result = scf.for %tile = [%zero to %four step %one](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
+  %result = scf.for %tile = [%loop_begin to %tile_count step %loop_step](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
     %next = vector.mma %lhs, %rhs, %acc : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     scf.yield %next : vector<8xf32>
   }
@@ -197,20 +197,20 @@ kernel.def target(@target) @explicitly_stage_one_accumulator_fragment() {
 }
 
 kernel.def target(@target) @report_dense_accumulator_fragment_staging() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %accumulator: vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xbf16>
   %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
-  %result0, %result1, %result2, %result3 = scf.for %tile = [%zero to %four step %one](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
+  %result0, %result1, %result2, %result3 = scf.for %tile = [%loop_begin to %tile_count step %loop_step](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
     %next0 = vector.mma %lhs, %rhs, %acc0 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     %next1 = vector.mma %lhs, %rhs, %acc1 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     %next2 = vector.mma %lhs, %rhs, %acc2 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
@@ -235,13 +235,13 @@ COMPILE-REPORT: source_low_transform[2] function=report_dense_accumulator_fragme
 test.target<low_core> @target {abi = hal_kernel, subgroup_size = 64}
 
 kernel.def target(@target) @stage_after_sinking_single_use_fragment_read() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%rhs_buffer: buffer, %base: offset, %lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %accumulator: vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -250,7 +250,7 @@ kernel.def target(@target) @stage_after_sinking_single_use_fragment_read() {
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xbf16>
   %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
-  %result0, %result1, %result2, %result3 = scf.for %tile = [%zero to %four step %one](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
+  %result0, %result1, %result2, %result3 = scf.for %tile = [%loop_begin to %tile_count step %loop_step](%acc0 = %init, %acc1 = %init, %acc2 = %init, %acc3 = %init : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
     %loaded_rhs = vector.fragment.load<rhs> %rhs_view[0, 0] shape [%k, %n] : view<16x16xbf16, %layout> -> vector<16xbf16>
     %noise = vector.mulf %accumulator, %accumulator : vector<8xf32>
     %next0 = vector.mma %lhs, %loaded_rhs, %acc0 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
@@ -275,14 +275,14 @@ COMPILE-REPORT: source_low_transform[0] function=stage_after_sinking_single_use_
 test.target<low_core> @target {abi = hal_kernel, subgroup_size = 64}
 
 kernel.def target(@target) @stage_multi_subgroup_accumulator_fragments() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 128 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %base = index.constant 0 : offset
+  %origin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -291,7 +291,7 @@ kernel.def target(@target) @stage_multi_subgroup_accumulator_fragments() {
   %input = vector.fragment<init> %payload shape [%m, %n] : vector<8xf32>
   %lhs = vector.fragment<lhs> %payload shape [%m, %k] : vector<8xf32>
   %rhs = vector.fragment<rhs> %payload shape [%k, %n] : vector<8xf32>
-  %result0, %result1, %result2, %result3 = scf.for %tile = [%zero to %four step %one](%acc0 = %input, %acc1 = %input, %acc2 = %input, %acc3 = %input : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
+  %result0, %result1, %result2, %result3 = scf.for %tile = [%origin to %tile_count step %loop_step](%acc0 = %input, %acc1 = %input, %acc2 = %input, %acc3 = %input : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) -> (vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>) {
     %next0 = vector.mma %lhs, %rhs, %acc0 : vector<8xf32>, vector<8xf32>, vector<8xf32>
     %next1 = vector.mma %lhs, %rhs, %acc1 : vector<8xf32>, vector<8xf32>, vector<8xf32>
     %next2 = vector.mma %lhs, %rhs, %acc2 : vector<8xf32>, vector<8xf32>, vector<8xf32>
@@ -299,8 +299,8 @@ kernel.def target(@target) @stage_multi_subgroup_accumulator_fragments() {
     scf.yield %next0, %next1, %next2, %next3 : vector<8xf32>, vector<8xf32>, vector<8xf32>, vector<8xf32>
   }
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero_offset] : buffer -> view<16x64xf32, #dense>
-  vector.fragment.store<result> %result0, %output_view[%zero, %zero] shape [%m, %n] : vector<8xf32>, view<16x64xf32, #dense>
+  %output_view = buffer.view %output_global[%base] : buffer -> view<16x64xf32, #dense>
+  vector.fragment.store<result> %result0, %output_view[%origin, %origin] shape [%m, %n] : vector<8xf32>, view<16x64xf32, #dense>
   kernel.return
 }
 
@@ -308,14 +308,14 @@ kernel.def target(@target) @stage_multi_subgroup_accumulator_fragments() {
 test.target<low_core> @target {abi = hal_kernel, subgroup_size = 64}
 
 kernel.def target(@target) @stage_multi_subgroup_accumulator_fragments() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 128 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%output: buffer) {
-  %zero_offset = index.constant 0 : offset
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %base = index.constant 0 : offset
+  %origin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -344,7 +344,7 @@ kernel.def target(@target) @stage_multi_subgroup_accumulator_fragments() {
   %44 = index.add %38, %43 : index
   vector.fragment.store<result> %input, %35[%32, %44] shape [%m, %n] : vector<8xf32>, view<16x128xf32, %33>
   kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
-  scf.for %45 = [%zero to %four step %one] {
+  scf.for %45 = [%origin to %tile_count step %loop_step] {
     %46 = vector.fragment.load<init> %35[%32, %38] shape [%m, %n] : view<16x128xf32, %33> -> vector<8xf32>
     %47 = vector.fragment.load<init> %35[%32, %40] shape [%m, %n] : view<16x128xf32, %33> -> vector<8xf32>
     %48 = vector.fragment.load<init> %35[%32, %42] shape [%m, %n] : view<16x128xf32, %33> -> vector<8xf32>
@@ -361,24 +361,24 @@ kernel.def target(@target) @stage_multi_subgroup_accumulator_fragments() {
   }
   %result0 = vector.fragment.load<init> %35[%32, %38] shape [%m, %n] : view<16x128xf32, %33> -> vector<8xf32>
   %output_global = buffer.assume.memory_space<global> %output : buffer
-  %output_view = buffer.view %output_global[%zero_offset] : buffer -> view<16x64xf32, #dense>
-  vector.fragment.store<result> %result0, %output_view[%zero, %zero] shape [%m, %n] : vector<8xf32>, view<16x64xf32, #dense>
+  %output_view = buffer.view %output_global[%base] : buffer -> view<16x64xf32, #dense>
+  vector.fragment.store<result> %result0, %output_view[%origin, %origin] shape [%m, %n] : vector<8xf32>, view<16x64xf32, #dense>
   kernel.return
 }
 
 // ====
 
 func.def @does_not_stage_ordinary_function(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %accumulator: vector<8xf32>) -> (vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xbf16>
   %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
-  %result = scf.for %tile = [%zero to %four step %one](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
+  %result = scf.for %tile = [%loop_begin to %tile_count step %loop_step](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
     %next = vector.mma %lhs, %rhs, %acc : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     scf.yield %next : vector<8xf32>
   }
@@ -387,16 +387,16 @@ func.def @does_not_stage_ordinary_function(%lhs_values: vector<16xbf16>, %rhs_va
 
 // ----
 func.def @does_not_stage_ordinary_function(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %accumulator: vector<8xf32>) -> (vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xbf16>
   %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
-  %result = scf.for %tile = [%zero to %four step %one](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
+  %result = scf.for %tile = [%loop_begin to %tile_count step %loop_step](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
     %next = vector.mma %lhs, %rhs, %acc : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     scf.yield %next : vector<8xf32>
   }
@@ -409,12 +409,12 @@ func.def @does_not_stage_ordinary_function(%lhs_values: vector<16xbf16>, %rhs_va
 test.target<low_core> @target {abi = hal_kernel, subgroup_size = 64}
 
 kernel.def target(@target) @decline_subgroup_dependent_loop_bound() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 128 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %accumulator: vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %origin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %subgroup = kernel.subgroup.id : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
@@ -422,7 +422,7 @@ kernel.def target(@target) @decline_subgroup_dependent_loop_bound() {
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xbf16>
   %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
-  %result = scf.for %tile = [%zero to %subgroup step %one](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
+  %result = scf.for %tile = [%origin to %subgroup step %loop_step](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
     %next = vector.mma %lhs, %rhs, %acc : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     scf.yield %next : vector<8xf32>
   }
@@ -431,15 +431,15 @@ kernel.def target(@target) @decline_subgroup_dependent_loop_bound() {
 }
 
 kernel.def target(@target) @decline_subgroup_dependent_branch() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 128 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %accumulator: vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %origin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %subgroup = kernel.subgroup.id : index
-  %is_first_subgroup = index.cmp eq, %subgroup, %zero : index
+  %is_first_subgroup = index.cmp eq, %subgroup, %origin : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -447,7 +447,7 @@ kernel.def target(@target) @decline_subgroup_dependent_branch() {
   %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
   scf.if %is_first_subgroup {
-    %result = scf.for %tile = [%zero to %four step %one](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
+    %result = scf.for %tile = [%origin to %tile_count step %loop_step](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
       %next = vector.mma %lhs, %rhs, %acc : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
       scf.yield %next : vector<8xf32>
     }
@@ -458,16 +458,15 @@ kernel.def target(@target) @decline_subgroup_dependent_branch() {
 }
 
 kernel.def target(@target) @decline_lane_dependent_cfg_arm() {
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 128 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %accumulator: vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %origin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %lane = kernel.workitem.id<x> : index
-  %active = index.cmp ult, %lane, %four : index
+  %active = index.cmp ult, %lane, %tile_count : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -476,7 +475,7 @@ kernel.def target(@target) @decline_lane_dependent_cfg_arm() {
   %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
   cfg.cond_br %active, ^active_arm, ^join
 ^active_arm:
-  %result = scf.for %tile = [%zero to %four step %one](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
+  %result = scf.for %tile = [%origin to %tile_count step %loop_step](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
     %next = vector.mma %lhs, %rhs, %acc : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     scf.yield %next : vector<8xf32>
   }
@@ -487,15 +486,15 @@ kernel.def target(@target) @decline_lane_dependent_cfg_arm() {
 }
 
 kernel.def target(@target) @stage_exact_single_subgroup_control() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %accumulator: vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %origin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %subgroup = kernel.subgroup.id : index
-  %is_first_subgroup = index.cmp eq, %subgroup, %zero : index
+  %is_first_subgroup = index.cmp eq, %subgroup, %origin : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
@@ -503,7 +502,7 @@ kernel.def target(@target) @stage_exact_single_subgroup_control() {
   %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
   scf.if %is_first_subgroup {
-    %result = scf.for %tile = [%zero to %four step %one](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
+    %result = scf.for %tile = [%origin to %tile_count step %loop_step](%acc = %init : vector<8xf32>) -> (vector<8xf32>) {
       %next = vector.mma %lhs, %rhs, %acc : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
       scf.yield %next : vector<8xf32>
     }
@@ -528,32 +527,32 @@ COMPILE-REPORT: source_low_transform[3] function=stage_exact_single_subgroup_con
 test.target<low_core> @target {abi = hal_kernel, subgroup_size = 64}
 
 kernel.def target(@target) @stage_fragment_loop_chain() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %accumulator: vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xbf16>
   %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
-  %result0 = scf.for %tile0 = [%zero to %four step %one](%acc0 = %init : vector<8xf32>) -> (vector<8xf32>) {
+  %result0 = scf.for %tile0 = [%loop_begin to %tile_count step %loop_step](%acc0 = %init : vector<8xf32>) -> (vector<8xf32>) {
     %next0 = vector.mma %lhs, %rhs, %acc0 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     scf.yield %next0 : vector<8xf32>
   }
-  %result1 = scf.for %tile1 = [%zero to %four step %one](%acc1 = %result0 : vector<8xf32>) -> (vector<8xf32>) {
+  %result1 = scf.for %tile1 = [%loop_begin to %tile_count step %loop_step](%acc1 = %result0 : vector<8xf32>) -> (vector<8xf32>) {
     %next1 = vector.mma %lhs, %rhs, %acc1 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     scf.yield %next1 : vector<8xf32>
   }
-  %result2 = scf.for %tile2 = [%zero to %four step %one](%acc2 = %result1 : vector<8xf32>) -> (vector<8xf32>) {
+  %result2 = scf.for %tile2 = [%loop_begin to %tile_count step %loop_step](%acc2 = %result1 : vector<8xf32>) -> (vector<8xf32>) {
     %next2 = vector.mma %lhs, %rhs, %acc2 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     scf.yield %next2 : vector<8xf32>
   }
-  %result3 = scf.for %tile3 = [%zero to %four step %one](%acc3 = %result2 : vector<8xf32>) -> (vector<8xf32>) {
+  %result3 = scf.for %tile3 = [%loop_begin to %tile_count step %loop_step](%acc3 = %result2 : vector<8xf32>) -> (vector<8xf32>) {
     %next3 = vector.mma %lhs, %rhs, %acc3 : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
     scf.yield %next3 : vector<8xf32>
   }
@@ -562,21 +561,21 @@ kernel.def target(@target) @stage_fragment_loop_chain() {
 }
 
 kernel.def target(@target) @stage_nested_fragment_loops() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 64 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%lhs_values: vector<16xbf16>, %rhs_values: vector<16xbf16>, %accumulator: vector<8xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %tile_count = index.constant 4 : index
   %m = index.constant 16 : index
   %n = index.constant 16 : index
   %k = index.constant 16 : index
   %lhs = vector.fragment<lhs> %lhs_values shape [%m, %k] : vector<16xbf16>
   %rhs = vector.fragment<rhs> %rhs_values shape [%k, %n] : vector<16xbf16>
   %init = vector.fragment<init> %accumulator shape [%m, %n] : vector<8xf32>
-  %outer_result = scf.for %outer = [%zero to %four step %one](%outer_acc = %init : vector<8xf32>) -> (vector<8xf32>) {
-    %inner_result = scf.for %inner = [%zero to %four step %one](%inner_acc = %outer_acc : vector<8xf32>) -> (vector<8xf32>) {
+  %outer_result = scf.for %outer = [%loop_begin to %tile_count step %loop_step](%outer_acc = %init : vector<8xf32>) -> (vector<8xf32>) {
+    %inner_result = scf.for %inner = [%loop_begin to %tile_count step %loop_step](%inner_acc = %outer_acc : vector<8xf32>) -> (vector<8xf32>) {
       %next = vector.mma %lhs, %rhs, %inner_acc : vector<16xbf16>, vector<16xbf16>, vector<8xf32>
       scf.yield %next : vector<8xf32>
     }

--- a/loom/src/loom/transforms/loop/test/licm.loom-test
+++ b/loom/src/loom/transforms/loop/test/licm.loom-test
@@ -3,9 +3,9 @@
 // A chain of speculatable ops whose operands are all loop-invariant moves
 // before the loop in program order. The effectful sink stays in the loop body.
 func.def @hoists_speculatable_invariant_chain(%n: index, %a: i32, %b: i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  scf.for %iv = [%zero to %n step %one] {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  scf.for %iv = [%loop_begin to %n step %loop_step] {
     %less = test.cmp lt, %a, %b : i32
     %selected = scf.select %less, %a, %b : i32
     test.use %selected : i32
@@ -16,11 +16,11 @@ func.def @hoists_speculatable_invariant_chain(%n: index, %a: i32, %b: i32) {
 
 // ----
 func.def @hoists_speculatable_invariant_chain(%n: index, %a: i32, %b: i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %less = test.cmp lt, %a, %b : i32
   %selected = scf.select %less, %a, %b : i32
-  scf.for %iv = [%zero to %n step %one] {
+  scf.for %iv = [%loop_begin to %n step %loop_step] {
     test.use %selected : i32
   }
   func.return
@@ -32,9 +32,9 @@ func.def @hoists_speculatable_invariant_chain(%n: index, %a: i32, %b: i32) {
 // not run. test.addi intentionally lacks SAFE_TO_SPECULATE and stays inside a
 // loop whose trip count may be zero.
 func.def @keeps_non_speculatable_pure_op(%n: index, %value: i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  scf.for %iv = [%zero to %n step %one] {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  scf.for %iv = [%loop_begin to %n step %loop_step] {
     %doubled = test.addi %value, %value : i32
     test.use %doubled : i32
   }
@@ -47,9 +47,9 @@ func.def @keeps_non_speculatable_pure_op(%n: index, %value: i32) {
 // move before the loop: the move can reorder a trap ahead of observable work
 // earlier in the body.
 func.def @keeps_non_speculatable_after_effect_in_single_trip(%value: i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  scf.for %iv = [%zero to %one step %one] {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  scf.for %iv = [%loop_begin to %loop_step step %loop_step] {
     test.use %value : i32
     %doubled = test.addi %value, %value : i32
     test.use %doubled : i32
@@ -62,10 +62,10 @@ func.def @keeps_non_speculatable_after_effect_in_single_trip(%value: i32) {
 // The induction variable and loop-carried block arguments are loop-local
 // definitions, so pure users of them remain in the loop.
 func.def @keeps_loop_local_values(%n: index, %init: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %n step %one](%acc = %init : i32) -> (i32) {
-    %address = index.add %iv, %one : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %n step %loop_step](%acc = %init : i32) -> (i32) {
+    %address = index.add %iv, %loop_step : index
     test.use %address : index
     %next = test.addi %acc, %acc : i32
     scf.yield %next : i32
@@ -77,9 +77,9 @@ func.def @keeps_loop_local_values(%n: index, %init: i32) -> (i32) {
 
 // Unknown-effect ops are not hoisted even when every operand is loop-invariant.
 func.def @keeps_unknown_effects_inside_loop(%n: index, %value: i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  scf.for %iv = [%zero to %n step %one] {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  scf.for %iv = [%loop_begin to %n step %loop_step] {
     test.use %value : i32
     scf.yield
   }
@@ -88,9 +88,9 @@ func.def @keeps_unknown_effects_inside_loop(%n: index, %value: i32) {
 
 // ----
 func.def @keeps_unknown_effects_inside_loop(%n: index, %value: i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  scf.for %iv = [%zero to %n step %one] {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  scf.for %iv = [%loop_begin to %n step %loop_step] {
     test.use %value : i32
   }
   func.return
@@ -101,9 +101,9 @@ func.def @keeps_unknown_effects_inside_loop(%n: index, %value: i32) {
 // A PURE region op without a speculation contract stays under the loop
 // predicate even when all captures are loop-invariant.
 func.def @keeps_non_speculatable_region_op(%cond: i1, %n: index, %a: i32, %b: i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  scf.for %iv = [%zero to %n step %one] {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  scf.for %iv = [%loop_begin to %n step %loop_step] {
     %selected = scf.if %cond -> (i32) {
       %doubled = test.addi %a, %a : i32
       scf.yield %doubled : i32
@@ -118,9 +118,9 @@ func.def @keeps_non_speculatable_region_op(%cond: i1, %n: index, %a: i32, %b: i3
 
 // ----
 func.def @keeps_non_speculatable_region_op(%cond: i1, %n: index, %a: i32, %b: i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  scf.for %iv = [%zero to %n step %one] {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  scf.for %iv = [%loop_begin to %n step %loop_step] {
     %selected = scf.if %cond -> (i32) {
       %doubled = test.addi %a, %a : i32
       scf.yield %doubled : i32
@@ -137,9 +137,9 @@ func.def @keeps_non_speculatable_region_op(%cond: i1, %n: index, %a: i32, %b: i3
 // Speculatable nested work can cross both the conditional and loop predicates
 // even when its effectful parent region stays in place.
 func.def @hoists_from_nested_region(%cond: i1, %n: index, %a: i32, %b: i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  scf.for %iv = [%zero to %n step %one] {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  scf.for %iv = [%loop_begin to %n step %loop_step] {
     scf.if %cond {
       %less = test.cmp lt, %a, %b : i32
       test.use %less : i1
@@ -154,10 +154,10 @@ func.def @hoists_from_nested_region(%cond: i1, %n: index, %a: i32, %b: i32) {
 
 // ----
 func.def @hoists_from_nested_region(%cond: i1, %n: index, %a: i32, %b: i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %less = test.cmp lt, %a, %b : i32
-  scf.for %iv = [%zero to %n step %one] {
+  scf.for %iv = [%loop_begin to %n step %loop_step] {
     scf.if %cond {
       test.use %less : i1
     } else {
@@ -171,9 +171,9 @@ func.def @hoists_from_nested_region(%cond: i1, %n: index, %a: i32, %b: i32) {
 // Result types are dependencies too: the view result references %layout, and
 // %layout depends on the loop IV, so buffer.view must stay in the loop.
 func.def @keeps_type_ref_to_loop_local_layout(%buffer: buffer, %offset: offset, %n: index) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  scf.for %iv = [%zero to %n step %one] {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  scf.for %iv = [%loop_begin to %n step %loop_step] {
     %layout = encoding.layout.strided [%iv] : encoding<layout>
     %view = buffer.view %buffer[%offset] : buffer -> view<1xf32, %layout>
     test.use %view : view<1xf32, %layout>
@@ -184,9 +184,9 @@ func.def @keeps_type_ref_to_loop_local_layout(%buffer: buffer, %offset: offset, 
 
 // ----
 func.def @keeps_type_ref_to_loop_local_layout(%buffer: buffer, %offset: offset, %n: index) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  scf.for %iv = [%zero to %n step %one] {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  scf.for %iv = [%loop_begin to %n step %loop_step] {
     %layout = encoding.layout.strided [%iv] : encoding<layout>
     %view = buffer.view %buffer[%offset] : buffer -> view<1xf32, %layout>
     test.use %view : view<1xf32, %layout>
@@ -256,9 +256,9 @@ func.def @keeps_while_effects_inside_after(%cond: i1, %init: i32) -> (i32) {
 // source path. With no writes to its storage, it may be materialized once in
 // the loop preheader.
 func.def @hoists_immutable_scalar_load(%input: view<8xi32, #dense>, %initial: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     %value = view.load %input[3] : view<8xi32, #dense> -> i32
     scf.yield %value : i32
   }
@@ -267,10 +267,10 @@ func.def @hoists_immutable_scalar_load(%input: view<8xi32, #dense>, %initial: i3
 
 // ----
 func.def @hoists_immutable_scalar_load(%input: view<8xi32, #dense>, %initial: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %value = view.load %input[3] : view<8xi32, #dense> -> i32
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     scf.yield %value : i32
   }
   func.return %result : i32
@@ -281,9 +281,9 @@ func.def @hoists_immutable_scalar_load(%input: view<8xi32, #dense>, %initial: i3
 // The address may remain symbolic as long as every captured value is
 // available at the preheader and the one-element footprint is representable.
 func.def @hoists_immutable_dynamic_scalar_load(%input: view<8xi32, #dense>, %index: index, %initial: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     %value = view.load %input[%index] : view<8xi32, #dense> -> i32
     scf.yield %value : i32
   }
@@ -292,10 +292,10 @@ func.def @hoists_immutable_dynamic_scalar_load(%input: view<8xi32, #dense>, %ind
 
 // ----
 func.def @hoists_immutable_dynamic_scalar_load(%input: view<8xi32, #dense>, %index: index, %initial: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %value = view.load %input[%index] : view<8xi32, #dense> -> i32
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     scf.yield %value : i32
   }
   func.return %result : i32
@@ -306,9 +306,9 @@ func.def @hoists_immutable_dynamic_scalar_load(%input: view<8xi32, #dense>, %ind
 // An address derived from the induction variable is not available at the
 // preheader even when the loop is guaranteed to execute.
 func.def @keeps_loop_variant_scalar_load(%input: view<8xi32, #dense>, %initial: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     %value = view.load %input[%iv] : view<8xi32, #dense> -> i32
     scf.yield %value : i32
   }
@@ -319,9 +319,9 @@ func.def @keeps_loop_variant_scalar_load(%input: view<8xi32, #dense>, %initial: 
 
 // The same byte-region proof applies to ordinary unmasked vector loads.
 func.def @hoists_immutable_vector_load(%input: view<8xi32, #dense>, %initial: vector<4xi32>) -> (vector<4xi32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : vector<4xi32>) -> (vector<4xi32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : vector<4xi32>) -> (vector<4xi32>) {
     %value = vector.load %input[0] : view<8xi32, #dense> -> vector<4xi32>
     scf.yield %value : vector<4xi32>
   }
@@ -330,10 +330,10 @@ func.def @hoists_immutable_vector_load(%input: view<8xi32, #dense>, %initial: ve
 
 // ----
 func.def @hoists_immutable_vector_load(%input: view<8xi32, #dense>, %initial: vector<4xi32>) -> (vector<4xi32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %value = vector.load %input[0] : view<8xi32, #dense> -> vector<4xi32>
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : vector<4xi32>) -> (vector<4xi32>) {
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : vector<4xi32>) -> (vector<4xi32>) {
     scf.yield %value : vector<4xi32>
   }
   func.return %result : vector<4xi32>
@@ -348,9 +348,9 @@ func.def @hoists_load_from_transformed_view(%input: buffer, %initial: i32) -> (i
   %input_view = buffer.view %input[%offset] : buffer -> view<8xi32, #dense>
   %input_subview = view.subview %input_view[2] : view<8xi32, #dense> -> view<4xi32, #dense>
   %input_refined = view.refine %input_subview : view<4xi32, #dense> -> view<4xi32, #dense>
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     %value = view.load %input_refined[1] : view<4xi32, #dense> -> i32
     scf.yield %value : i32
   }
@@ -363,10 +363,10 @@ func.def @hoists_load_from_transformed_view(%input: buffer, %initial: i32) -> (i
   %input_view = buffer.view %input[%offset] : buffer -> view<8xi32, #dense>
   %input_subview = view.subview %input_view[2] : view<8xi32, #dense> -> view<4xi32, #dense>
   %input_refined = view.refine %input_subview : view<4xi32, #dense> -> view<4xi32, #dense>
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %value = view.load %input_refined[1] : view<4xi32, #dense> -> i32
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     scf.yield %value : i32
   }
   func.return %result : i32
@@ -378,9 +378,9 @@ func.def @hoists_load_from_transformed_view(%input: buffer, %initial: i32) -> (i
 // function's required valid-access domain, so the load remains guarded by the
 // loop predicate.
 func.def @keeps_load_in_maybe_empty_loop(%input: view<8xi32, #dense>, %n: index, %initial: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %n step %one](%carry = %initial : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %n step %loop_step](%carry = %initial : i32) -> (i32) {
     %value = view.load %input[3] : view<8xi32, #dense> -> i32
     scf.yield %value : i32
   }
@@ -392,9 +392,9 @@ func.def @keeps_load_in_maybe_empty_loop(%input: view<8xi32, #dense>, %n: index,
 // A condition nested inside the loop adds another execution predicate. Even a
 // nonempty loop does not prove that the read executes.
 func.def @keeps_conditionally_executed_load(%input: view<8xi32, #dense>, %condition: i1, %initial: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     %next = scf.if %condition -> (i32) {
       %value = view.load %input[3] : view<8xi32, #dense> -> i32
       scf.yield %value : i32
@@ -410,9 +410,9 @@ func.def @keeps_conditionally_executed_load(%input: view<8xi32, #dense>, %condit
 
 // Exact same-root byte regions allow a read to cross a disjoint write.
 func.def @hoists_load_across_disjoint_store(%storage: view<8xi32, #dense>, %replacement: i32, %initial: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     %value = view.load %storage[0] : view<8xi32, #dense> -> i32
     view.store %replacement, %storage[4] : i32, view<8xi32, #dense>
     scf.yield %value : i32
@@ -422,10 +422,10 @@ func.def @hoists_load_across_disjoint_store(%storage: view<8xi32, #dense>, %repl
 
 // ----
 func.def @hoists_load_across_disjoint_store(%storage: view<8xi32, #dense>, %replacement: i32, %initial: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %value = view.load %storage[0] : view<8xi32, #dense> -> i32
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     view.store %replacement, %storage[4] : i32, view<8xi32, #dense>
     scf.yield %value : i32
   }
@@ -437,10 +437,10 @@ func.def @hoists_load_across_disjoint_store(%storage: view<8xi32, #dense>, %repl
 // A write to the loaded byte region changes the value observed by later loop
 // iterations and blocks hoisting.
 func.def @keeps_load_with_overlapping_store(%storage: view<8xi32, #dense>, %replacement: i32, %initial: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %two = index.constant 2 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %two step %one](%carry = %initial : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 2 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %loop_end step %loop_step](%carry = %initial : i32) -> (i32) {
     %value = view.load %storage[0] : view<8xi32, #dense> -> i32
     view.store %replacement, %storage[0] : i32, view<8xi32, #dense>
     scf.yield %value : i32
@@ -453,9 +453,9 @@ func.def @keeps_load_with_overlapping_store(%storage: view<8xi32, #dense>, %repl
 // Writes nested under another structured predicate still participate in the
 // loop-wide interference proof.
 func.def @keeps_load_with_nested_overlapping_store(%storage: view<8xi32, #dense>, %replacement: i32, %condition: i1, %initial: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     %value = view.load %storage[0] : view<8xi32, #dense> -> i32
     scf.if %condition {
       view.store %replacement, %storage[0] : i32, view<8xi32, #dense>
@@ -469,11 +469,11 @@ func.def @keeps_load_with_nested_overlapping_store(%storage: view<8xi32, #dense>
 
 // Interference in a nested loop is part of the enclosing loop interval.
 func.def @keeps_load_with_nested_loop_write(%storage: view<8xi32, #dense>, %replacement: i32, %initial: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %outer = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %outer = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     %value = view.load %storage[0] : view<8xi32, #dense> -> i32
-    scf.for %inner = [%zero to %one step %one] {
+    scf.for %inner = [%loop_begin to %loop_step step %loop_step] {
       view.store %replacement, %storage[0] : i32, view<8xi32, #dense>
     }
     scf.yield %value : i32
@@ -486,9 +486,9 @@ func.def @keeps_load_with_nested_loop_write(%storage: view<8xi32, #dense>, %repl
 // Distinct external view arguments are addressing provenance, not an implicit
 // noalias contract.
 func.def @keeps_load_across_unproven_distinct_root(%input: view<8xi32, #dense>, %output: view<8xi32, #dense>, %replacement: i32, %initial: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     %value = view.load %input[0] : view<8xi32, #dense> -> i32
     view.store %replacement, %output[0] : i32, view<8xi32, #dense>
     scf.yield %value : i32
@@ -504,9 +504,9 @@ func.def @hoists_load_across_noalias_root(%input: buffer, %output: buffer, %repl
   %input_unique, %output_unique = buffer.assume.noalias %input, %output : buffer, buffer
   %input_view = buffer.view %input_unique[%offset] : buffer -> view<8xi32, #dense>
   %output_view = buffer.view %output_unique[%offset] : buffer -> view<8xi32, #dense>
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     %value = view.load %input_view[0] : view<8xi32, #dense> -> i32
     view.store %replacement, %output_view[0] : i32, view<8xi32, #dense>
     scf.yield %value : i32
@@ -520,10 +520,10 @@ func.def @hoists_load_across_noalias_root(%input: buffer, %output: buffer, %repl
   %input_unique, %output_unique = buffer.assume.noalias %input, %output : buffer, buffer
   %input_view = buffer.view %input_unique[%offset] : buffer -> view<8xi32, #dense>
   %output_view = buffer.view %output_unique[%offset] : buffer -> view<8xi32, #dense>
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %value = view.load %input_view[0] : view<8xi32, #dense> -> i32
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     view.store %replacement, %output_view[0] : i32, view<8xi32, #dense>
     scf.yield %value : i32
   }
@@ -540,9 +540,9 @@ func.def @keeps_load_across_unmodeled_atomic(%input: buffer, %output: buffer, %r
   %input_unique, %output_unique = buffer.assume.noalias %input, %output : buffer, buffer
   %input_view = buffer.view %input_unique[%offset] : buffer -> view<8xi32, #dense>
   %output_view = buffer.view %output_unique[%offset] : buffer -> view<8xi32, #dense>
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     %value = view.load %input_view[0] : view<8xi32, #dense> -> i32
     view.atomic.reduce<addi> %replacement, %output_view[0] {ordering = relaxed, scope = workgroup} : i32, view<8xi32, #dense>
     scf.yield %value : i32
@@ -555,9 +555,9 @@ func.def @keeps_load_across_unmodeled_atomic(%input: buffer, %output: buffer, %r
 // An operation with unknown effects may write storage that is not represented
 // by an SSA operand. Its presence in the loop therefore blocks read motion.
 func.def @keeps_load_across_unknown_effect(%input: view<8xi32, #dense>, %initial: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     %value = view.load %input[0] : view<8xi32, #dense> -> i32
     test.use %initial : i32
     scf.yield %value : i32
@@ -571,16 +571,16 @@ func.def @keeps_load_across_unknown_effect(%input: view<8xi32, #dense>, %initial
 // root. Immutable loads can cross it without weakening its convergence or
 // memory-ordering contract.
 kernel.def @hoists_immutable_load_across_barrier() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %offset = index.constant 0 : offset
   %input_view = buffer.view %input[%offset] : buffer -> view<8xi32, #dense>
   %output_view = buffer.view %output[%offset] : buffer -> view<8xi32, #dense>
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %initial = scalar.constant 0 : i32
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     %value = view.load %input_view[0] : view<8xi32, #dense> -> i32
     kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
     scf.yield %value : i32
@@ -591,17 +591,17 @@ kernel.def @hoists_immutable_load_across_barrier() {
 
 // ----
 kernel.def @hoists_immutable_load_across_barrier() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%input: buffer, %output: buffer) {
   %offset = index.constant 0 : offset
   %input_view = buffer.view %input[%offset] : buffer -> view<8xi32, #dense>
   %output_view = buffer.view %output[%offset] : buffer -> view<8xi32, #dense>
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %initial = scalar.constant 0 : i32
   %value = view.load %input_view[0] : view<8xi32, #dense> -> i32
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
     scf.yield %value : i32
   }
@@ -615,18 +615,18 @@ kernel.def @hoists_immutable_load_across_barrier() {
 // loaded region. Moving the load before the loop would move it before that
 // matching fence even when the loop is known to execute exactly once.
 kernel.def @keeps_workgroup_load_after_matching_barrier() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
 } launch(%output: buffer) {
-  %zero_offset = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %bytes = index.constant 32 : offset
   %scratch = buffer.alloca %bytes {base_alignment = 16, memory_space = workgroup} : buffer
-  %scratch_view = buffer.view %scratch[%zero_offset] : buffer -> view<8xi32, #dense>
-  %output_view = buffer.view %output[%zero_offset] : buffer -> view<1xi32, #dense>
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %scratch_view = buffer.view %scratch[%base] : buffer -> view<8xi32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<1xi32, #dense>
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %initial = scalar.constant 0 : i32
-  %result = scf.for %iv = [%zero to %one step %one](%carry = %initial : i32) -> (i32) {
+  %result = scf.for %iv = [%loop_begin to %loop_step step %loop_step](%carry = %initial : i32) -> (i32) {
     kernel.barrier<workgroup> {ordering = acq_rel, scope = workgroup}
     %value = view.load %scratch_view[0] : view<8xi32, #dense> -> i32
     scf.yield %value : i32

--- a/loom/src/loom/transforms/loop/test/loop_fusion.loom-test
+++ b/loom/src/loom/transforms/loop/test/loop_fusion.loom-test
@@ -1,13 +1,13 @@
 // RUN: pass loop-fusion
 
 func.def @fuses_independent_pure_loops(%n: index, %a: i32, %b: i32) -> (i32, i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %sum_a = scf.for %i = [%zero to %n step %one](%acc = %a : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %sum_a = scf.for %i = [%loop_begin to %n step %loop_step](%acc = %a : i32) -> (i32) {
     %next = test.addi %acc, %b : i32
     scf.yield %next : i32
   }
-  %sum_b = scf.for %j = [%zero to %n step %one](%acc = %b : i32) -> (i32) {
+  %sum_b = scf.for %j = [%loop_begin to %n step %loop_step](%acc = %b : i32) -> (i32) {
     %next = test.addi %acc, %a : i32
     scf.yield %next : i32
   }
@@ -16,9 +16,9 @@ func.def @fuses_independent_pure_loops(%n: index, %a: i32, %b: i32) -> (i32, i32
 
 // ----
 func.def @fuses_independent_pure_loops(%n: index, %a: i32, %b: i32) -> (i32, i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %sum_a, %sum_b = scf.for %15 = [%zero to %n step %one](%16 = %a : i32, %17 = %b : i32) -> (i32, i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %sum_a, %sum_b = scf.for %15 = [%loop_begin to %n step %loop_step](%16 = %a : i32, %17 = %b : i32) -> (i32, i32) {
     %next = test.addi %16, %b : i32
     %14 = test.addi %17, %a : i32
     scf.yield %next, %14 : i32, i32
@@ -85,16 +85,16 @@ func.def @does_not_fuse_while(%cond: i1, %a: i32, %b: i32) -> (i32, i32) {
 // ====
 
 func.def @fuses_dynamic_result_type_references(%n: index, %buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %base_layout = encoding.layout.dense : encoding<layout>
   %base_view = buffer.view %buffer[%offset] : buffer -> view<4xf32, %base_layout>
-  %left_layout, %left_view = scf.for %i = [%zero to %n step %one](%layout_acc = %base_layout : encoding<layout>, %view_acc = %base_view : view<4xf32, %base_layout>) -> (encoding<layout>, view<4xf32, %left_layout>) {
+  %left_layout, %left_view = scf.for %i = [%loop_begin to %n step %loop_step](%layout_acc = %base_layout : encoding<layout>, %view_acc = %base_view : view<4xf32, %base_layout>) -> (encoding<layout>, view<4xf32, %left_layout>) {
     %dense = encoding.layout.dense : encoding<layout>
     %view = buffer.view %buffer[%offset] : buffer -> view<4xf32, %dense>
     scf.yield %dense, %view : encoding<layout>, view<4xf32, %dense>
   }
-  %right_layout, %right_view = scf.for %j = [%zero to %n step %one](%layout_acc = %base_layout : encoding<layout>, %view_acc = %base_view : view<4xf32, %base_layout>) -> (encoding<layout>, view<4xf32, %right_layout>) {
+  %right_layout, %right_view = scf.for %j = [%loop_begin to %n step %loop_step](%layout_acc = %base_layout : encoding<layout>, %view_acc = %base_view : view<4xf32, %base_layout>) -> (encoding<layout>, view<4xf32, %right_layout>) {
     %dense = encoding.layout.dense : encoding<layout>
     %view = buffer.view %buffer[%offset] : buffer -> view<4xf32, %dense>
     scf.yield %dense, %view : encoding<layout>, view<4xf32, %dense>
@@ -106,11 +106,11 @@ func.def @fuses_dynamic_result_type_references(%n: index, %buffer: buffer, %offs
 
 // ----
 func.def @fuses_dynamic_result_type_references(%n: index, %buffer: buffer, %offset: offset) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
   %base_layout = encoding.layout.dense : encoding<layout>
   %base_view = buffer.view %buffer[%offset] : buffer -> view<4xf32, %base_layout>
-  %left_layout, %left_view, %right_layout, %right_view = scf.for %21 = [%zero to %n step %one](%22 = %base_layout : encoding<layout>, %23 = %base_view : view<4xf32, %base_layout>, %24 = %base_layout : encoding<layout>, %25 = %base_view : view<4xf32, %base_layout>) -> (encoding<layout>, view<4xf32, %left_layout>, encoding<layout>, view<4xf32, %right_layout>) {
+  %left_layout, %left_view, %right_layout, %right_view = scf.for %21 = [%loop_begin to %n step %loop_step](%22 = %base_layout : encoding<layout>, %23 = %base_view : view<4xf32, %base_layout>, %24 = %base_layout : encoding<layout>, %25 = %base_view : view<4xf32, %base_layout>) -> (encoding<layout>, view<4xf32, %left_layout>, encoding<layout>, view<4xf32, %right_layout>) {
     %dense = encoding.layout.dense : encoding<layout>
     %view = buffer.view %buffer[%offset] : buffer -> view<4xf32, %dense>
     %19 = encoding.layout.dense : encoding<layout>
@@ -127,15 +127,15 @@ func.def @fuses_dynamic_result_type_references(%n: index, %buffer: buffer, %offs
 func.def @fuses_load_then_lane_local_compute(%n: index, %buffer: buffer, %byte_offset: offset, %origin: index, %seed: vector<[%n]xf32>, %old: vector<[%n]xf32>) -> (vector<[%n]xf32>, vector<[%n]xf32>) {
   %layout = encoding.layout.dense : encoding<layout>
   %view = buffer.view %buffer[%byte_offset] : buffer -> view<[%n]xf32, %layout>
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %loaded = scf.for %i = [%zero to %n step %one](%acc = %seed : vector<[%n]xf32>) -> (vector<[%n]xf32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %loaded = scf.for %i = [%loop_begin to %n step %loop_step](%acc = %seed : vector<[%n]xf32>) -> (vector<[%n]xf32>) {
     %address = index.add %origin, %i : index
     %lane = view.load %view[%address] : view<[%n]xf32, %layout> -> f32
     %next = vector.insert %lane into %acc[%i] : f32, vector<[%n]xf32>
     scf.yield %next : vector<[%n]xf32>
   }
-  %doubled = scf.for %j = [%zero to %n step %one](%acc = %old : vector<[%n]xf32>) -> (vector<[%n]xf32>) {
+  %doubled = scf.for %j = [%loop_begin to %n step %loop_step](%acc = %old : vector<[%n]xf32>) -> (vector<[%n]xf32>) {
     %lane = vector.extract %loaded[%j] : vector<[%n]xf32> -> f32
     %twice = scalar.addf %lane, %lane : f32
     %next = vector.insert %twice into %acc[%j] : f32, vector<[%n]xf32>
@@ -148,9 +148,9 @@ func.def @fuses_load_then_lane_local_compute(%n: index, %buffer: buffer, %byte_o
 func.def @fuses_load_then_lane_local_compute(%n: index, %buffer: buffer, %byte_offset: offset, %origin: index, %seed: vector<[%n]xf32>, %old: vector<[%n]xf32>) -> (vector<[%n]xf32>, vector<[%n]xf32>) {
   %layout = encoding.layout.dense : encoding<layout>
   %view = buffer.view %buffer[%byte_offset] : buffer -> view<[%n]xf32, %layout>
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %loaded, %doubled = scf.for %24 = [%zero to %n step %one](%25 = %seed : vector<[%n]xf32>, %26 = %old : vector<[%n]xf32>) -> (vector<[%n]xf32>, vector<[%n]xf32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %loaded, %doubled = scf.for %24 = [%loop_begin to %n step %loop_step](%25 = %seed : vector<[%n]xf32>, %26 = %old : vector<[%n]xf32>) -> (vector<[%n]xf32>, vector<[%n]xf32>) {
     %address = index.add %origin, %24 : index
     %lane = view.load %view[%address] : view<[%n]xf32, %layout> -> f32
     %next = vector.insert %lane into %25[%24] : f32, vector<[%n]xf32>
@@ -165,9 +165,9 @@ func.def @fuses_load_then_lane_local_compute(%n: index, %buffer: buffer, %byte_o
 // ====
 
 func.def @fuses_masked_lane_local_compute(%n: index, %mask: vector<[%n]xi1>, %seed: vector<[%n]xi32>, %old: vector<[%n]xi32>, %one_i32: i32) -> (vector<[%n]xi32>, vector<[%n]xi32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %selected = scf.for %i = [%zero to %n step %one](%acc = %seed : vector<[%n]xi32>) -> (vector<[%n]xi32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %selected = scf.for %i = [%loop_begin to %n step %loop_step](%acc = %seed : vector<[%n]xi32>) -> (vector<[%n]xi32>) {
     %m = vector.extract %mask[%i] : vector<[%n]xi1> -> i1
     %lane = scf.if %m -> (i32) {
       scf.yield %one_i32 : i32
@@ -178,7 +178,7 @@ func.def @fuses_masked_lane_local_compute(%n: index, %mask: vector<[%n]xi1>, %se
     %next = vector.insert %lane into %acc[%i] : i32, vector<[%n]xi32>
     scf.yield %next : vector<[%n]xi32>
   }
-  %incremented = scf.for %j = [%zero to %n step %one](%acc = %old : vector<[%n]xi32>) -> (vector<[%n]xi32>) {
+  %incremented = scf.for %j = [%loop_begin to %n step %loop_step](%acc = %old : vector<[%n]xi32>) -> (vector<[%n]xi32>) {
     %lane = vector.extract %selected[%j] : vector<[%n]xi32> -> i32
     %next_lane = test.addi %lane, %one_i32 : i32
     %next = vector.insert %next_lane into %acc[%j] : i32, vector<[%n]xi32>
@@ -189,9 +189,9 @@ func.def @fuses_masked_lane_local_compute(%n: index, %mask: vector<[%n]xi1>, %se
 
 // ----
 func.def @fuses_masked_lane_local_compute(%n: index, %mask: vector<[%n]xi1>, %seed: vector<[%n]xi32>, %old: vector<[%n]xi32>, %one_i32: i32) -> (vector<[%n]xi32>, vector<[%n]xi32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %selected, %incremented = scf.for %22 = [%zero to %n step %one](%23 = %seed : vector<[%n]xi32>, %24 = %old : vector<[%n]xi32>) -> (vector<[%n]xi32>, vector<[%n]xi32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %selected, %incremented = scf.for %22 = [%loop_begin to %n step %loop_step](%23 = %seed : vector<[%n]xi32>, %24 = %old : vector<[%n]xi32>) -> (vector<[%n]xi32>, vector<[%n]xi32>) {
     %m = vector.extract %mask[%22] : vector<[%n]xi1> -> i1
     %lane = scf.if %m -> (i32) {
       scf.yield %one_i32 : i32
@@ -211,14 +211,14 @@ func.def @fuses_masked_lane_local_compute(%n: index, %mask: vector<[%n]xi1>, %se
 // ====
 
 func.def @rejects_non_lane_local_forwarding(%n: index, %seed: vector<[%n]xi32>, %old: vector<[%n]xi32>, %lane_value: i32) -> (vector<[%n]xi32>, vector<[%n]xi32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %built = scf.for %i = [%zero to %n step %one](%acc = %seed : vector<[%n]xi32>) -> (vector<[%n]xi32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %built = scf.for %i = [%loop_begin to %n step %loop_step](%acc = %seed : vector<[%n]xi32>) -> (vector<[%n]xi32>) {
     %next = vector.insert %lane_value into %acc[%i] : i32, vector<[%n]xi32>
     scf.yield %next : vector<[%n]xi32>
   }
-  %broadcast_first = scf.for %j = [%zero to %n step %one](%acc = %old : vector<[%n]xi32>) -> (vector<[%n]xi32>) {
-    %first_lane = vector.extract %built[%zero] : vector<[%n]xi32> -> i32
+  %broadcast_first = scf.for %j = [%loop_begin to %n step %loop_step](%acc = %old : vector<[%n]xi32>) -> (vector<[%n]xi32>) {
+    %first_lane = vector.extract %built[%loop_begin] : vector<[%n]xi32> -> i32
     %next = vector.insert %first_lane into %acc[%j] : i32, vector<[%n]xi32>
     scf.yield %next : vector<[%n]xi32>
   }
@@ -228,13 +228,13 @@ func.def @rejects_non_lane_local_forwarding(%n: index, %seed: vector<[%n]xi32>, 
 // ====
 
 func.def @rejects_write_effect_hazard(%n: index, %pool: pool<16>, %tile: tile<4xf32>, %a: i32, %b: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  scf.for %i = [%zero to %n step %one] {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  scf.for %i = [%loop_begin to %n step %loop_step] {
     test.write_resource %pool, %tile : pool<16>, tile<4xf32>
     scf.yield
   }
-  %sum = scf.for %j = [%zero to %n step %one](%acc = %a : i32) -> (i32) {
+  %sum = scf.for %j = [%loop_begin to %n step %loop_step](%acc = %a : i32) -> (i32) {
     %next = test.addi %acc, %b : i32
     scf.yield %next : i32
   }
@@ -243,12 +243,12 @@ func.def @rejects_write_effect_hazard(%n: index, %pool: pool<16>, %tile: tile<4x
 
 // ----
 func.def @rejects_write_effect_hazard(%n: index, %pool: pool<16>, %tile: tile<4xf32>, %a: i32, %b: i32) -> (i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  scf.for %i = [%zero to %n step %one] {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  scf.for %i = [%loop_begin to %n step %loop_step] {
     test.write_resource %pool, %tile : pool<16>, tile<4xf32>
   }
-  %sum = scf.for %j = [%zero to %n step %one](%acc = %a : i32) -> (i32) {
+  %sum = scf.for %j = [%loop_begin to %n step %loop_step](%acc = %a : i32) -> (i32) {
     %next = test.addi %acc, %b : i32
     scf.yield %next : i32
   }

--- a/loom/src/loom/transforms/loop/test/loop_fusion.loom-test
+++ b/loom/src/loom/transforms/loop/test/loop_fusion.loom-test
@@ -29,17 +29,17 @@ func.def @fuses_independent_pure_loops(%n: index, %a: i32, %b: i32) -> (i32, i32
 // ====
 
 func.def @fuses_equal_constant_domains(%a: i32, %b: i32) -> (i32, i32) {
-  %zero_a = index.constant 0 : index
-  %zero_b = index.constant 0 : index
-  %four_a = index.constant 4 : index
-  %four_b = index.constant 4 : index
-  %one_a = index.constant 1 : index
-  %one_b = index.constant 1 : index
-  %sum_a = scf.for %i = [%zero_a to %four_a step %one_a](%acc = %a : i32) -> (i32) {
+  %loop_a_begin = index.constant 0 : index
+  %loop_b_begin = index.constant 0 : index
+  %loop_a_end = index.constant 4 : index
+  %loop_b_end = index.constant 4 : index
+  %loop_a_step = index.constant 1 : index
+  %loop_b_step = index.constant 1 : index
+  %sum_a = scf.for %i = [%loop_a_begin to %loop_a_end step %loop_a_step](%acc = %a : i32) -> (i32) {
     %next = test.addi %acc, %b : i32
     scf.yield %next : i32
   }
-  %sum_b = scf.for %j = [%zero_b to %four_b step %one_b](%acc = %b : i32) -> (i32) {
+  %sum_b = scf.for %j = [%loop_b_begin to %loop_b_end step %loop_b_step](%acc = %b : i32) -> (i32) {
     %next = test.addi %acc, %a : i32
     scf.yield %next : i32
   }
@@ -48,13 +48,13 @@ func.def @fuses_equal_constant_domains(%a: i32, %b: i32) -> (i32, i32) {
 
 // ----
 func.def @fuses_equal_constant_domains(%a: i32, %b: i32) -> (i32, i32) {
-  %zero_a = index.constant 0 : index
-  %zero_b = index.constant 0 : index
-  %four_a = index.constant 4 : index
-  %four_b = index.constant 4 : index
-  %one_a = index.constant 1 : index
-  %one_b = index.constant 1 : index
-  %sum_a, %sum_b = scf.for %18 = [%zero_a to %four_a step %one_a](%19 = %a : i32, %20 = %b : i32) -> (i32, i32) {
+  %loop_a_begin = index.constant 0 : index
+  %loop_b_begin = index.constant 0 : index
+  %loop_a_end = index.constant 4 : index
+  %loop_b_end = index.constant 4 : index
+  %loop_a_step = index.constant 1 : index
+  %loop_b_step = index.constant 1 : index
+  %sum_a, %sum_b = scf.for %18 = [%loop_a_begin to %loop_a_end step %loop_a_step](%19 = %a : i32, %20 = %b : i32) -> (i32, i32) {
     %next = test.addi %19, %b : i32
     %17 = test.addi %20, %a : i32
     scf.yield %next, %17 : i32, i32

--- a/loom/src/loom/transforms/scf/test/scf_index.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_index.loom-test
@@ -5,9 +5,9 @@
 func.def @tail_branch_pruned_by_divisibility(%n: index) -> (index) {
   %n_aligned = index.assume %n [range(%n, 16, 4096), mul(%n, 16)] : index
   %tile = index.constant 16 : index
-  %zero = index.constant 0 : index
+  %no_remainder = index.constant 0 : index
   %remainder = index.rem %n_aligned, %tile : index
-  %has_tail = index.cmp ne, %remainder, %zero : index
+  %has_tail = index.cmp ne, %remainder, %no_remainder : index
   %result = scf.if %has_tail -> (index) {
     %tail = index.add %remainder, %tile : index
     scf.yield %tail : index
@@ -32,9 +32,9 @@ func.def @tail_branch_pruned_by_divisibility(%n: index) -> (index) {
 // instead of forcing frontends to avoid emitting the structurally valid path.
 func.def @zero_extent_loop_erases(%features: index, %init: f32) -> (f32) {
   %disabled = index.assume %features [range(%features, 0, 0)] : index
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %disabled step %one](%acc = %init : f32) -> (f32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %disabled step %loop_step](%acc = %init : f32) -> (f32) {
     %next = test.neg %acc : f32
     scf.yield %next : f32
   }
@@ -52,9 +52,9 @@ func.def @zero_extent_loop_erases(%features: index, %init: f32) -> (f32) {
 // proves the loop trip count.
 func.def @single_tile_loop_inlines(%tiles: index, %init: i32) -> (i32) {
   %one_tile = index.assume %tiles [range(%tiles, 1, 1)] : index
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %iv = [%zero to %one_tile step %one](%acc = %init : i32) -> (i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %iv = [%loop_begin to %one_tile step %loop_step](%acc = %init : i32) -> (i32) {
     %next = test.addi %acc, %acc : i32
     scf.yield %next : i32
   }
@@ -99,25 +99,25 @@ func.def @layout_guard_pruned_by_symbolic_address_order(%row: index, %lane: inde
 // after the derived value's defining op. Inserting the index.assume at the
 // branch entry would create a use-before-def when source-to-low binds aliases.
 func.def @guarded_i32_cast_inside_branch_keeps_assume_after_cast(%row: i32, %row_count: i32) -> (index) {
-  %zero_i32 = scalar.constant 0 : i32
-  %zero_idx = index.constant 0 : index
-  %nonnegative = scalar.cmpi sge, %row, %zero_i32 : i32
+  %minimum_row = scalar.constant 0 : i32
+  %fallback_row = index.constant 0 : index
+  %nonnegative = scalar.cmpi sge, %row, %minimum_row : i32
   %below = scalar.cmpi slt, %row, %row_count : i32
   %guard = scalar.andi %nonnegative, %below : i1
   %result = scf.if %guard -> (index) {
     %row_idx = index.cast %row : i32 to index
     scf.yield %row_idx : index
   } else {
-    scf.yield %zero_idx : index
+    scf.yield %fallback_row : index
   }
   func.return %result : index
 }
 
 // ----
 func.def @guarded_i32_cast_inside_branch_keeps_assume_after_cast(%row: i32, %row_count: i32) -> (index) {
-  %zero_i32 = scalar.constant 0 : i32
-  %zero_idx = index.constant 0 : index
-  %nonnegative = scalar.cmpi sge, %row, %zero_i32 : i32
+  %minimum_row = scalar.constant 0 : i32
+  %fallback_row = index.constant 0 : index
+  %nonnegative = scalar.cmpi sge, %row, %minimum_row : i32
   %below = scalar.cmpi slt, %row, %row_count : i32
   %guard = scalar.andi %nonnegative, %below : i1
   %result = scf.if %guard -> (index) {
@@ -126,7 +126,7 @@ func.def @guarded_i32_cast_inside_branch_keeps_assume_after_cast(%row: i32, %row
     %11 = index.assume %row_idx [ge(%row_idx, 0), lt(%row_idx, %row_count)] : index
     scf.yield %11 : index
   } else {
-    scf.yield %zero_idx : index
+    scf.yield %fallback_row : index
   }
   func.return %result : index
 }

--- a/loom/src/loom/transforms/scf/test/scf_to_cfg.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_to_cfg.loom-test
@@ -282,9 +282,9 @@ func.def @remaps_join_argument_dependent_type(%cond: i1, %buffer: buffer, %offse
 // ====
 
 func.def @rejects_unknown_for_step(%n: index, %step: index) {
-  %zero = index.constant 0 : index
+  %loop_begin = index.constant 0 : index
   // ERROR@+1: STRUCTURE/035 {op_name="scf.for", pass_name="scf-to-cfg"}
-  scf.for %i = [%zero to %n step %step] {
+  scf.for %i = [%loop_begin to %n step %step] {
     scf.yield
   }
   func.return

--- a/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll.loom-test
@@ -232,13 +232,13 @@ func.def @interleaved_write_read_hazard_preserves_order(%pool: pool<16>, %input:
 // ====
 
 func.def @interleaved_disjoint_vector_stores_commute(%buffer: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %value0 = scalar.constant 1 : i32
   %value1 = scalar.constant 2 : i32
   %vec0 = vector.splat %value0 : vector<4xi32>
   %vec1 = vector.splat %value1 : vector<4xi32>
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%zero] : buffer -> view<8xi32, %layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<8xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 2 : index
   %step = index.constant 1 : index
@@ -251,13 +251,13 @@ func.def @interleaved_disjoint_vector_stores_commute(%buffer: buffer) {
 
 // ----
 func.def @interleaved_disjoint_vector_stores_commute(%buffer: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %value0 = scalar.constant 1 : i32
   %value1 = scalar.constant 2 : i32
   %vec0 = vector.splat %value0 : vector<4xi32>
   %vec1 = vector.splat %value1 : vector<4xi32>
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%zero] : buffer -> view<8xi32, %layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<8xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 2 : index
   %step = index.constant 1 : index
@@ -274,14 +274,14 @@ func.def @interleaved_disjoint_vector_stores_commute(%buffer: buffer) {
 
 func.def @interleaved_noalias_vector_stores_commute(%left: buffer, %right: buffer) {
   %left_unique, %right_unique = buffer.assume.noalias %left, %right : buffer, buffer
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %value0 = scalar.constant 1 : i32
   %value1 = scalar.constant 2 : i32
   %vec0 = vector.splat %value0 : vector<4xi32>
   %vec1 = vector.splat %value1 : vector<4xi32>
   %layout = encoding.layout.dense : encoding<layout>
-  %left_view = buffer.view %left_unique[%zero] : buffer -> view<4xi32, %layout>
-  %right_view = buffer.view %right_unique[%zero] : buffer -> view<4xi32, %layout>
+  %left_view = buffer.view %left_unique[%base] : buffer -> view<4xi32, %layout>
+  %right_view = buffer.view %right_unique[%base] : buffer -> view<4xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 2 : index
   %step = index.constant 1 : index
@@ -295,14 +295,14 @@ func.def @interleaved_noalias_vector_stores_commute(%left: buffer, %right: buffe
 // ----
 func.def @interleaved_noalias_vector_stores_commute(%left: buffer, %right: buffer) {
   %left_unique, %right_unique = buffer.assume.noalias %left, %right : buffer, buffer
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %value0 = scalar.constant 1 : i32
   %value1 = scalar.constant 2 : i32
   %vec0 = vector.splat %value0 : vector<4xi32>
   %vec1 = vector.splat %value1 : vector<4xi32>
   %layout = encoding.layout.dense : encoding<layout>
-  %left_view = buffer.view %left_unique[%zero] : buffer -> view<4xi32, %layout>
-  %right_view = buffer.view %right_unique[%zero] : buffer -> view<4xi32, %layout>
+  %left_view = buffer.view %left_unique[%base] : buffer -> view<4xi32, %layout>
+  %right_view = buffer.view %right_unique[%base] : buffer -> view<4xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 2 : index
   %step = index.constant 1 : index
@@ -357,13 +357,13 @@ func.def @interleaved_dynamic_base_vector_stores_commute(%buffer: buffer, %base:
 // ====
 
 func.def @interleaved_dynamic_index_vector_stores_commute(%buffer: buffer, %row: index) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %value0 = scalar.constant 1 : i32
   %value1 = scalar.constant 2 : i32
   %vec0 = vector.splat %value0 : vector<4xi32>
   %vec1 = vector.splat %value1 : vector<4xi32>
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%zero] : buffer -> view<4x8xi32, %layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<4x8xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 2 : index
   %step = index.constant 1 : index
@@ -376,13 +376,13 @@ func.def @interleaved_dynamic_index_vector_stores_commute(%buffer: buffer, %row:
 
 // ----
 func.def @interleaved_dynamic_index_vector_stores_commute(%buffer: buffer, %row: index) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %value0 = scalar.constant 1 : i32
   %value1 = scalar.constant 2 : i32
   %vec0 = vector.splat %value0 : vector<4xi32>
   %vec1 = vector.splat %value1 : vector<4xi32>
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%zero] : buffer -> view<4x8xi32, %layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<4x8xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 2 : index
   %step = index.constant 1 : index
@@ -398,13 +398,13 @@ func.def @interleaved_dynamic_index_vector_stores_commute(%buffer: buffer, %row:
 // ====
 
 func.def @interleaved_carried_disjoint_vector_stores_commute(%buffer: buffer, %input: i32) -> (i32) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %value0 = scalar.constant 1 : i32
   %value1 = scalar.constant 2 : i32
   %vec0 = vector.splat %value0 : vector<4xi32>
   %vec1 = vector.splat %value1 : vector<4xi32>
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%zero] : buffer -> view<8xi32, %layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<8xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 2 : index
   %step = index.constant 1 : index
@@ -419,13 +419,13 @@ func.def @interleaved_carried_disjoint_vector_stores_commute(%buffer: buffer, %i
 
 // ----
 func.def @interleaved_carried_disjoint_vector_stores_commute(%buffer: buffer, %input: i32) -> (i32) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %value0 = scalar.constant 1 : i32
   %value1 = scalar.constant 2 : i32
   %vec0 = vector.splat %value0 : vector<4xi32>
   %vec1 = vector.splat %value1 : vector<4xi32>
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%zero] : buffer -> view<8xi32, %layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<8xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 2 : index
   %step = index.constant 1 : index
@@ -443,13 +443,13 @@ func.def @interleaved_carried_disjoint_vector_stores_commute(%buffer: buffer, %i
 // ====
 
 func.def @interleaved_overlapping_vector_stores_preserve_order(%buffer: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %value0 = scalar.constant 1 : i32
   %value1 = scalar.constant 2 : i32
   %vec0 = vector.splat %value0 : vector<4xi32>
   %vec1 = vector.splat %value1 : vector<4xi32>
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%zero] : buffer -> view<4xi32, %layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<4xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 2 : index
   %step = index.constant 1 : index
@@ -462,13 +462,13 @@ func.def @interleaved_overlapping_vector_stores_preserve_order(%buffer: buffer) 
 
 // ----
 func.def @interleaved_overlapping_vector_stores_preserve_order(%buffer: buffer) {
-  %zero = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %value0 = scalar.constant 1 : i32
   %value1 = scalar.constant 2 : i32
   %vec0 = vector.splat %value0 : vector<4xi32>
   %vec1 = vector.splat %value1 : vector<4xi32>
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%zero] : buffer -> view<4xi32, %layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<4xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 2 : index
   %step = index.constant 1 : index
@@ -484,19 +484,19 @@ func.def @interleaved_overlapping_vector_stores_preserve_order(%buffer: buffer) 
 // ====
 
 func.def @interleaved_induction_vector_stores_preserve_order(%buffer: buffer) {
-  %zero = index.constant 0 : offset
-  %one = index.constant 1 : index
+  %base = index.constant 0 : offset
+  %element_step = index.constant 1 : index
   %value0 = scalar.constant 1 : i32
   %value1 = scalar.constant 2 : i32
   %vec0 = vector.splat %value0 : vector<1xi32>
   %vec1 = vector.splat %value1 : vector<1xi32>
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%zero] : buffer -> view<4xi32, %layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<4xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 2 : index
   %step = index.constant 1 : index
   scf.for %i = [%start to %end step %step] unroll schedule(interleaved) {
-    %next = index.add %i, %one : index
+    %next = index.add %i, %element_step : index
     vector.store %vec0, %view[%i] : vector<1xi32>, view<4xi32, %layout>
     vector.store %vec1, %view[%next] : vector<1xi32>, view<4xi32, %layout>
   }
@@ -505,21 +505,21 @@ func.def @interleaved_induction_vector_stores_preserve_order(%buffer: buffer) {
 
 // ----
 func.def @interleaved_induction_vector_stores_preserve_order(%buffer: buffer) {
-  %zero = index.constant 0 : offset
-  %one = index.constant 1 : index
+  %base = index.constant 0 : offset
+  %element_step = index.constant 1 : index
   %value0 = scalar.constant 1 : i32
   %value1 = scalar.constant 2 : i32
   %vec0 = vector.splat %value0 : vector<1xi32>
   %vec1 = vector.splat %value1 : vector<1xi32>
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%zero] : buffer -> view<4xi32, %layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<4xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 2 : index
   %step = index.constant 1 : index
   %i_0 = index.constant 0 : index
   %i_1 = index.constant 1 : index
-  %next = index.add %i_0, %one : index
-  %next_1 = index.add %i_1, %one : index
+  %next = index.add %i_0, %element_step : index
+  %next_1 = index.add %i_1, %element_step : index
   vector.store %vec0, %view[%i_0] : vector<1xi32>, view<4xi32, %layout>
   vector.store %vec1, %view[%next] : vector<1xi32>, view<4xi32, %layout>
   vector.store %vec0, %view[%i_1] : vector<1xi32>, view<4xi32, %layout>
@@ -1073,9 +1073,9 @@ func.def @interleaved_partial_factor_carried_loop(%input: i32) -> (i32) {
 // ====
 
 func.def @interleaved_carried_loop_with_vector_read(%buffer: buffer, %input: vector<4xi32>) -> (vector<4xi32>) {
-  %zero_offset = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%zero_offset] : buffer -> view<4xi32, %layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<4xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 3 : index
   %step = index.constant 1 : index
@@ -1089,9 +1089,9 @@ func.def @interleaved_carried_loop_with_vector_read(%buffer: buffer, %input: vec
 
 // ----
 func.def @interleaved_carried_loop_with_vector_read(%buffer: buffer, %input: vector<4xi32>) -> (vector<4xi32>) {
-  %zero_offset = index.constant 0 : offset
+  %base = index.constant 0 : offset
   %layout = encoding.layout.dense : encoding<layout>
-  %view = buffer.view %buffer[%zero_offset] : buffer -> view<4xi32, %layout>
+  %view = buffer.view %buffer[%base] : buffer -> view<4xi32, %layout>
   %start = index.constant 0 : index
   %end = index.constant 3 : index
   %step = index.constant 1 : index

--- a/loom/src/loom/transforms/scf/test/scf_unroll_bounds.loom-test
+++ b/loom/src/loom/transforms/scf/test/scf_unroll_bounds.loom-test
@@ -1,12 +1,12 @@
 // RUN: pass unroll-scf-for,scf-to-cfg,vector-memory-footprint
 
 func.def @dynamic_interleaved_tile_indices_remain_in_bounds(%payload: buffer, %base: offset, %end0: index, %value: i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %unroll_factor = index.constant 4 : index
   %end = index.assume %end0 [range(%end0, 1, 32)] : index
   %view = buffer.view %payload[%base] : buffer -> view<[%end]xi32, #dense>
-  scf.for %i = [%zero to %end step %one] unroll(%four) schedule(interleaved) {
+  scf.for %i = [%loop_begin to %end step %loop_step] unroll(%unroll_factor) schedule(interleaved) {
     view.store %value, %view[%i] : i32, view<[%end]xi32, #dense>
   }
   func.return
@@ -14,20 +14,20 @@ func.def @dynamic_interleaved_tile_indices_remain_in_bounds(%payload: buffer, %b
 
 // ----
 func.def @dynamic_interleaved_tile_indices_remain_in_bounds(%payload: buffer, %base: offset, %end0: index, %value: i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %unroll_factor = index.constant 4 : index
   %end = index.assume %end0 [range(%end0, 1, 32)] : index
   %view = buffer.view %payload[%base] : buffer -> view<[%end]xi32, #dense>
   %10 = index.constant 4 : index
   %11 = index.constant 0 : index
-  %12 = index.sub %end, %zero : index
+  %12 = index.sub %end, %loop_begin : index
   %13 = index.max %12, %11 : index
   %14 = index.constant 4 : index
   %15 = index.div %13, %14 : index
   %16 = index.mul %15, %10 : index
-  %17 = index.add %zero, %16 : index
-  cfg.br ^_bb1(%zero: index)
+  %17 = index.add %loop_begin, %16 : index
+  cfg.br ^_bb1(%loop_begin: index)
 ^_bb1(%30: index):
   %32 = index.cmp slt, %30, %17 : index
   cfg.cond_br %32, ^_bb2, ^_bb3
@@ -54,7 +54,7 @@ func.def @dynamic_interleaved_tile_indices_remain_in_bounds(%payload: buffer, %b
 ^_bb5:
   %i$35 = index.assume %34 [range(%34, 0, 31), ge(%34, %17), lt(%34, %end)] : index
   view.store %value, %view[%i$35] : i32, view<[%end]xi32, #dense>
-  %37 = index.add %i$35, %one : index
+  %37 = index.add %i$35, %loop_step : index
   cfg.br ^_bb4(%37: index)
 ^_bb6:
   func.return
@@ -67,12 +67,12 @@ func.def @dynamic_interleaved_tile_indices_remain_in_bounds(%payload: buffer, %b
 // cloned vector origins, including the final packet at channel 2044.
 func.def @ranged_lower_full_span_vector_origins(%payload: buffer, %base: offset, %lane0: index) {
   %lane = index.assume %lane0 [range(%lane0, 0, 31)] : index
-  %four = index.constant 4 : index
-  %channel_start = index.mul %lane, %four : index
+  %vector_width = index.constant 4 : index
+  %channel_start = index.mul %lane, %vector_width : index
   %channel_end = index.constant 2048 : index
   %channel_step = index.constant 128 : index
   %view = buffer.view %payload[%base] : buffer -> view<2048xf32, #dense>
-  scf.for %channel = [%channel_start to %channel_end step %channel_step] unroll(%four) schedule(interleaved) {
+  scf.for %channel = [%channel_start to %channel_end step %channel_step] unroll(%vector_width) schedule(interleaved) {
     %values = vector.load %view[%channel] : view<2048xf32, #dense> -> vector<4xf32>
     test.use %values : vector<4xf32>
   }
@@ -82,8 +82,8 @@ func.def @ranged_lower_full_span_vector_origins(%payload: buffer, %base: offset,
 // ----
 func.def @ranged_lower_full_span_vector_origins(%payload: buffer, %base: offset, %lane0: index) {
   %lane = index.assume %lane0 [range(%lane0, 0, 31)] : index
-  %four = index.constant 4 : index
-  %channel_start = index.mul %lane, %four : index
+  %vector_width = index.constant 4 : index
+  %channel_start = index.mul %lane, %vector_width : index
   %channel_end = index.constant 2048 : index
   %channel_step = index.constant 128 : index
   %view = buffer.view %payload[%base] : buffer -> view<2048xf32, #dense>

--- a/loom/src/loom/transforms/symbol/test/inline_callables.loom-test
+++ b/loom/src/loom/transforms/symbol/test/inline_callables.loom-test
@@ -26,9 +26,9 @@ func.def inline @lane_id() -> (index) {
 }
 
 kernel.def @inlines_into_required_ancestor() {
-  %one = index.constant 1 : index
-  %thirtytwo = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%thirtytwo, %one, %one) : index
+  %unit_extent = index.constant 1 : index
+  %workgroup_size = index.constant 32 : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch() {
   %lane = func.call @lane_id() : () -> (index)
   kernel.return
@@ -36,9 +36,9 @@ kernel.def @inlines_into_required_ancestor() {
 
 // ----
 kernel.def @inlines_into_required_ancestor() {
-  %one = index.constant 1 : index
-  %thirtytwo = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%thirtytwo, %one, %one) : index
+  %unit_extent = index.constant 1 : index
+  %workgroup_size = index.constant 32 : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch() {
   %lane = kernel.subgroup.lane.id : index
   kernel.return

--- a/loom/src/loom/transforms/symbol/test/refine_boundaries.loom-test
+++ b/loom/src/loom/transforms/symbol/test/refine_boundaries.loom-test
@@ -4,9 +4,9 @@
 // return facts then seed call results, letting callers fold ordinary local code.
 func.def @private_extent_identity(%n: index) -> (index) {
   %tile = index.constant 16 : index
-  %zero = index.constant 0 : index
+  %no_remainder = index.constant 0 : index
   %remainder = index.rem %n, %tile : index
-  %is_aligned = index.cmp eq, %remainder, %zero : index
+  %is_aligned = index.cmp eq, %remainder, %no_remainder : index
   %result = scf.if %is_aligned -> (index) {
     scf.yield %n : index
   } else {
@@ -19,8 +19,8 @@ func.def @private_extent_identity(%n: index) -> (index) {
 func.def public @entry() -> (index) {
   %n = index.constant 32 : index
   %result = func.call @private_extent_identity(%n) : (index) -> (index)
-  %two = index.constant 2 : index
-  %scaled = index.mul %result, %two : index
+  %scale_factor = index.constant 2 : index
+  %scaled = index.mul %result, %scale_factor : index
   func.return %scaled : index
 }
 
@@ -40,9 +40,9 @@ func.def public @entry() -> (index) {
 // external callers may pass different values.
 func.def public @public_extent_identity(%n: index) -> (index) {
   %tile = index.constant 16 : index
-  %zero = index.constant 0 : index
+  %no_remainder = index.constant 0 : index
   %remainder = index.rem %n, %tile : index
-  %is_aligned = index.cmp eq, %remainder, %zero : index
+  %is_aligned = index.cmp eq, %remainder, %no_remainder : index
   %result = scf.if %is_aligned -> (index) {
     scf.yield %n : index
   } else {
@@ -55,17 +55,17 @@ func.def public @public_extent_identity(%n: index) -> (index) {
 func.def public @calls_public() -> (index) {
   %n = index.constant 32 : index
   %result = func.call @public_extent_identity(%n) : (index) -> (index)
-  %two = index.constant 2 : index
-  %scaled = index.mul %result, %two : index
+  %scale_factor = index.constant 2 : index
+  %scaled = index.mul %result, %scale_factor : index
   func.return %scaled : index
 }
 
 // ----
 func.def public @public_extent_identity(%n: index) -> (index) {
   %tile = index.constant 16 : index
-  %zero = index.constant 0 : index
+  %no_remainder = index.constant 0 : index
   %remainder = index.rem %n, %tile : index
-  %is_aligned = index.cmp eq, %remainder, %zero : index
+  %is_aligned = index.cmp eq, %remainder, %no_remainder : index
   %result = scf.if %is_aligned -> (index) {
     scf.yield %n : index
   } else {
@@ -78,8 +78,8 @@ func.def public @public_extent_identity(%n: index) -> (index) {
 func.def public @calls_public() -> (index) {
   %n = index.constant 32 : index
   %result = func.call pure @public_extent_identity(%n) : (index) -> (index)
-  %two = index.constant 2 : index
-  %scaled = index.mul %result, %two : index
+  %scale_factor = index.constant 2 : index
+  %scaled = index.mul %result, %scale_factor : index
   func.return %scaled : index
 }
 
@@ -90,9 +90,9 @@ func.def public @calls_public() -> (index) {
 // checks without pretending both calls returned the same constant.
 func.def @private_joined_extent(%n: index) -> (index) {
   %tile = index.constant 16 : index
-  %zero = index.constant 0 : index
+  %no_remainder = index.constant 0 : index
   %remainder = index.rem %n, %tile : index
-  %is_aligned = index.cmp eq, %remainder, %zero : index
+  %is_aligned = index.cmp eq, %remainder, %no_remainder : index
   %result = scf.if %is_aligned -> (index) {
     scf.yield %n : index
   } else {
@@ -136,8 +136,8 @@ func.def @same_actual_arguments(%lhs: index, %rhs: index) -> (index) {
 
 func.def public @call_same_actual(%n: index) -> (index) {
   %result = func.call @same_actual_arguments(%n, %n) : (index, index) -> (index)
-  %one = index.constant 1 : index
-  %biased = index.add %result, %one : index
+  %bias = index.constant 1 : index
+  %biased = index.add %result, %bias : index
   func.return %biased : index
 }
 
@@ -389,8 +389,8 @@ func.def public @call_effectful_return_tied_after_dead(%dead: index, %buffer: bu
 // slot is pruned. This is weaker than argument forwarding: the value cannot be
 // named by the caller until the call executes.
 func.def @effectful_return_duplicate_computed(%x: index) -> (index, index) {
-  %one = index.constant 1 : index
-  %sum = index.add %x, %one : index
+  %increment = index.constant 1 : index
+  %sum = index.add %x, %increment : index
   test.use %x : index
   func.return %sum, %sum : index, index
 }
@@ -403,8 +403,8 @@ func.def public @call_effectful_return_duplicate_computed(%x: index) -> (index) 
 
 // ----
 func.def @effectful_return_duplicate_computed(%x: index) -> (index) {
-  %one = index.constant 1 : index
-  %sum = index.add %x, %one : index
+  %increment = index.constant 1 : index
+  %sum = index.add %x, %increment : index
   test.use %x : index
   func.return %sum : index
 }
@@ -566,13 +566,13 @@ func.def public @call_private_conflicting_layout_view(%buffer: buffer) {
 // facts materialize as separate constants in each isolated projection so body
 // and config rewrite independently without crossing region SSA boundaries.
 test.split_func @projected_exact_constant(%n: index) {
-  %cfg_one = index.constant 1 : index
-  %cfg_sum = index.add %n, %cfg_one : index
+  %cfg_bias = index.constant 1 : index
+  %cfg_sum = index.add %n, %cfg_bias : index
   test.use %cfg_sum : index
   test.yield
 } launch {
-  %one = index.constant 1 : index
-  %sum = index.add %n, %one : index
+  %launch_bias = index.constant 1 : index
+  %sum = index.add %n, %launch_bias : index
   test.use %sum : index
   test.yield
 }
@@ -677,7 +677,7 @@ func.def @identity(%value: index) -> (index) {
 }
 
 func.def public @caller() -> (index) {
-  %zero = index.constant 0 : index
-  %result = func.call @identity(%zero) : (index) -> (index)
+  %identity_input = index.constant 0 : index
+  %result = func.call @identity(%identity_input) : (index) -> (index)
   func.return %result : index
 }

--- a/loom/src/loom/transforms/symbol/test/template_selection.loom-test
+++ b/loom/src/loom/transforms/symbol/test/template_selection.loom-test
@@ -527,9 +527,9 @@ func.template<demo.workgroup_reduce> @reduce_provider(%value: f32) -> (f32) {
 }
 
 kernel.def export("entry") @entry() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%value: f32) {
   %sum = func.apply<demo.workgroup_reduce>(%value) : (f32) -> (f32)
   kernel.return
@@ -537,9 +537,9 @@ kernel.def export("entry") @entry() {
 
 // ----
 kernel.def export("entry") @entry() {
-  %one = index.constant 1 : index
+  %unit_extent = index.constant 1 : index
   %workgroup_size = index.constant 32 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%workgroup_size, %one, %one) : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%workgroup_size, %unit_extent, %unit_extent) : index
 } launch(%value: f32) {
   %sum = kernel.workgroup.reduce<addf> %value : f32
   kernel.return
@@ -551,16 +551,16 @@ kernel.def export("entry") @entry() {
 // RUN: pass select-templates{mode=final}
 
 kernel.def @implicit_export() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit_extent = index.constant 1 : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%unit_extent, %unit_extent, %unit_extent) : index
 } launch() {
   kernel.return
 }
 
 // ----
 kernel.def @implicit_export() {
-  %one = index.constant 1 : index
-  kernel.launch.config workgroups(%one, %one, %one) workgroup_size(%one, %one, %one) : index
+  %unit_extent = index.constant 1 : index
+  kernel.launch.config workgroups(%unit_extent, %unit_extent, %unit_extent) workgroup_size(%unit_extent, %unit_extent, %unit_extent) : index
 } launch() {
   kernel.return
 }

--- a/loom/src/loom/transforms/test/effects/canonicalize.loom-test
+++ b/loom/src/loom/transforms/test/effects/canonicalize.loom-test
@@ -106,13 +106,13 @@ func.def @effectful_exact_facts_do_not_erase_producer() -> (i64) {
 // Function-level canonicalization runs over every root region. Projected
 // regions keep distinct SSA values, but use the same logical signature facts.
 test.split_func @split_func_all_regions_canonicalize(%arg: i32) {
-  %cfg_zero = test.constant 0 : i32
-  %cfg_sum = test.addi %arg, %cfg_zero : i32
+  %cfg_identity = test.constant 0 : i32
+  %cfg_sum = test.addi %arg, %cfg_identity : i32
   test.use %cfg_sum : i32
   test.yield
 } launch {
-  %zero = test.constant 0 : i32
-  %sum = test.addi %arg, %zero : i32
+  %launch_identity = test.constant 0 : i32
+  %sum = test.addi %arg, %launch_identity : i32
   test.use %sum : i32
   test.yield
 }

--- a/loom/src/loom/transforms/vector/test/bank_sroa.loom-test
+++ b/loom/src/loom/transforms/vector/test/bank_sroa.loom-test
@@ -1,10 +1,10 @@
 // RUN: pass sroa-vector-banks
 
 func.def @rank3_vector_payload_bank(%initial: vector<2x2x4xf32>, %increment: vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
-  %result = scf.for %i = [%zero to %four step %one](%bank = %initial : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %loop_end = index.constant 4 : index
+  %result = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank = %initial : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) {
     %old00 = vector.extract %bank[0, 0] : vector<2x2x4xf32> -> vector<4xf32>
     %next00 = vector.addf %old00, %increment : vector<4xf32>
     %bank0 = vector.insert %next00 into %bank[0, 0] : vector<4xf32>, vector<2x2x4xf32>
@@ -22,14 +22,14 @@ func.def @rank3_vector_payload_bank(%initial: vector<2x2x4xf32>, %increment: vec
 
 // ----
 func.def @rank3_vector_payload_bank(%initial: vector<2x2x4xf32>, %increment: vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %loop_end = index.constant 4 : index
   %initial_slot_0 = vector.extract %initial[0, 0] : vector<2x2x4xf32> -> vector<4xf32>
   %initial_slot_1 = vector.extract %initial[0, 1] : vector<2x2x4xf32> -> vector<4xf32>
   %initial_slot_2 = vector.extract %initial[1, 0] : vector<2x2x4xf32> -> vector<4xf32>
   %initial_slot_3 = vector.extract %initial[1, 1] : vector<2x2x4xf32> -> vector<4xf32>
-  %result_slot_0, %result_slot_1, %result_slot_2, %result_slot_3 = scf.for %i = [%zero to %four step %one](%bank_slot_0 = %initial_slot_0 : vector<4xf32>, %bank_slot_1 = %initial_slot_1 : vector<4xf32>, %bank_slot_2 = %initial_slot_2 : vector<4xf32>, %bank_slot_3 = %initial_slot_3 : vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
+  %result_slot_0, %result_slot_1, %result_slot_2, %result_slot_3 = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank_slot_0 = %initial_slot_0 : vector<4xf32>, %bank_slot_1 = %initial_slot_1 : vector<4xf32>, %bank_slot_2 = %initial_slot_2 : vector<4xf32>, %bank_slot_3 = %initial_slot_3 : vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
     %next00 = vector.addf %bank_slot_0, %increment : vector<4xf32>
     %next11 = vector.addf %bank_slot_3, %increment : vector<4xf32>
     scf.yield %next00, %bank_slot_1, %bank_slot_2, %next11 : vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>
@@ -40,9 +40,10 @@ func.def @rank3_vector_payload_bank(%initial: vector<2x2x4xf32>, %increment: vec
 // ====
 
 func.def @rank2_scalar_payload_bank(%initial: vector<2x2xi32>, %increment: i32) -> (i32, i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %i = [%zero to %one step %one](%bank = %initial : vector<2x2xi32>) -> (vector<2x2xi32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank = %initial : vector<2x2xi32>) -> (vector<2x2xi32>) {
     %old = vector.extract %bank[0, 1] : vector<2x2xi32> -> i32
     %next = scalar.addi %old, %increment : i32
     %updated = vector.insert %next into %bank[0, 1] : i32, vector<2x2xi32>
@@ -55,13 +56,14 @@ func.def @rank2_scalar_payload_bank(%initial: vector<2x2xi32>, %increment: i32) 
 
 // ----
 func.def @rank2_scalar_payload_bank(%initial: vector<2x2xi32>, %increment: i32) -> (i32, i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
   %initial_slot_0 = vector.extract %initial[0, 0] : vector<2x2xi32> -> i32
   %initial_slot_1 = vector.extract %initial[0, 1] : vector<2x2xi32> -> i32
   %initial_slot_2 = vector.extract %initial[1, 0] : vector<2x2xi32> -> i32
   %initial_slot_3 = vector.extract %initial[1, 1] : vector<2x2xi32> -> i32
-  %result_slot_0, %result_slot_1, %result_slot_2, %result_slot_3 = scf.for %i = [%zero to %one step %one](%bank_slot_0 = %initial_slot_0 : i32, %bank_slot_1 = %initial_slot_1 : i32, %bank_slot_2 = %initial_slot_2 : i32, %bank_slot_3 = %initial_slot_3 : i32) -> (i32, i32, i32, i32) {
+  %result_slot_0, %result_slot_1, %result_slot_2, %result_slot_3 = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank_slot_0 = %initial_slot_0 : i32, %bank_slot_1 = %initial_slot_1 : i32, %bank_slot_2 = %initial_slot_2 : i32, %bank_slot_3 = %initial_slot_3 : i32) -> (i32, i32, i32, i32) {
     %next = scalar.addi %bank_slot_1, %increment : i32
     scf.yield %bank_slot_0, %next, %bank_slot_2, %bank_slot_3 : i32, i32, i32, i32
   }
@@ -71,9 +73,10 @@ func.def @rank2_scalar_payload_bank(%initial: vector<2x2xi32>, %increment: i32) 
 // ====
 
 func.def @mixed_carried_values(%initial: vector<1x2x4xf32>, %scalar: i32) -> (vector<4xf32>, i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %bank_result, %scalar_result = scf.for %i = [%zero to %one step %one](%bank = %initial : vector<1x2x4xf32>, %count = %scalar : i32) -> (vector<1x2x4xf32>, i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
+  %bank_result, %scalar_result = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank = %initial : vector<1x2x4xf32>, %count = %scalar : i32) -> (vector<1x2x4xf32>, i32) {
     %value = vector.extract %bank[0, 1] : vector<1x2x4xf32> -> vector<4xf32>
     %updated = vector.insert %value into %bank[0, 1] : vector<4xf32>, vector<1x2x4xf32>
     %next_count = scalar.addi %count, %scalar : i32
@@ -85,11 +88,12 @@ func.def @mixed_carried_values(%initial: vector<1x2x4xf32>, %scalar: i32) -> (ve
 
 // ----
 func.def @mixed_carried_values(%initial: vector<1x2x4xf32>, %scalar: i32) -> (vector<4xf32>, i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
   %initial_slot_0 = vector.extract %initial[0, 0] : vector<1x2x4xf32> -> vector<4xf32>
   %initial_slot_1 = vector.extract %initial[0, 1] : vector<1x2x4xf32> -> vector<4xf32>
-  %bank_result_slot_0, %bank_result_slot_1, %scalar_result = scf.for %i = [%zero to %one step %one](%bank_slot_0 = %initial_slot_0 : vector<4xf32>, %bank_slot_1 = %initial_slot_1 : vector<4xf32>, %count = %scalar : i32) -> (vector<4xf32>, vector<4xf32>, i32) {
+  %bank_result_slot_0, %bank_result_slot_1, %scalar_result = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank_slot_0 = %initial_slot_0 : vector<4xf32>, %bank_slot_1 = %initial_slot_1 : vector<4xf32>, %count = %scalar : i32) -> (vector<4xf32>, vector<4xf32>, i32) {
     %next_count = scalar.addi %count, %scalar : i32
     scf.yield %bank_slot_0, %bank_slot_1, %next_count : vector<4xf32>, vector<4xf32>, i32
   }
@@ -100,13 +104,13 @@ func.def @mixed_carried_values(%initial: vector<1x2x4xf32>, %scalar: i32) -> (ve
 // RUN: pass unroll-scf-for,canonicalize,cse,sroa-vector-banks,canonicalize,cse
 
 func.def @nested_configured_bank_updates(%initial: vector<2x2x4xf32>, %increment: vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
-  %four = index.constant 4 : index
-  %result = scf.for %stage = [%zero to %four step %one](%bank = %initial : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) {
-    %after_rows = scf.for %row = [%zero to %two step %one](%row_bank = %bank : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) unroll {
-      %after_columns = scf.for %column = [%zero to %two step %one](%column_bank = %row_bank : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) unroll {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %bank_extent = index.constant 2 : index
+  %stage_count = index.constant 4 : index
+  %result = scf.for %stage = [%loop_begin to %stage_count step %loop_step](%bank = %initial : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) {
+    %after_rows = scf.for %row = [%loop_begin to %bank_extent step %loop_step](%row_bank = %bank : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) unroll {
+      %after_columns = scf.for %column = [%loop_begin to %bank_extent step %loop_step](%column_bank = %row_bank : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) unroll {
         %old = vector.extract %column_bank[%row, %column] : vector<2x2x4xf32> -> vector<4xf32>
         %next = vector.addf %old, %increment : vector<4xf32>
         %updated = vector.insert %next into %column_bank[%row, %column] : vector<4xf32>, vector<2x2x4xf32>
@@ -125,14 +129,14 @@ func.def @nested_configured_bank_updates(%initial: vector<2x2x4xf32>, %increment
 
 // ----
 func.def @nested_configured_bank_updates(%initial: vector<2x2x4xf32>, %increment: vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %stage_count = index.constant 4 : index
   %initial_slot_0 = vector.extract %initial[0, 0] : vector<2x2x4xf32> -> vector<4xf32>
   %initial_slot_1 = vector.extract %initial[0, 1] : vector<2x2x4xf32> -> vector<4xf32>
   %initial_slot_2 = vector.extract %initial[1, 0] : vector<2x2x4xf32> -> vector<4xf32>
   %initial_slot_3 = vector.extract %initial[1, 1] : vector<2x2x4xf32> -> vector<4xf32>
-  %result_slot_0, %result_slot_1, %result_slot_2, %result_slot_3 = scf.for %stage = [%zero to %four step %one](%bank_slot_0 = %initial_slot_0 : vector<4xf32>, %bank_slot_1 = %initial_slot_1 : vector<4xf32>, %bank_slot_2 = %initial_slot_2 : vector<4xf32>, %bank_slot_3 = %initial_slot_3 : vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
+  %result_slot_0, %result_slot_1, %result_slot_2, %result_slot_3 = scf.for %stage = [%loop_begin to %stage_count step %loop_step](%bank_slot_0 = %initial_slot_0 : vector<4xf32>, %bank_slot_1 = %initial_slot_1 : vector<4xf32>, %bank_slot_2 = %initial_slot_2 : vector<4xf32>, %bank_slot_3 = %initial_slot_3 : vector<4xf32>) -> (vector<4xf32>, vector<4xf32>, vector<4xf32>, vector<4xf32>) {
     %next$83 = vector.addf %bank_slot_0, %increment : vector<4xf32>
     %next_1$84 = vector.addf %bank_slot_1, %increment : vector<4xf32>
     %next$85 = vector.addf %bank_slot_2, %increment : vector<4xf32>
@@ -146,12 +150,12 @@ func.def @nested_configured_bank_updates(%initial: vector<2x2x4xf32>, %increment
 // RUN: pass canonicalize,cse,sroa-vector-banks,canonicalize,cse
 
 func.def @uniform_initialization_and_repeated_updates(%increment: vector<4xf32>) -> (vector<4xf32>, vector<4xf32>) {
-  %zero_index = index.constant 0 : index
-  %one_index = index.constant 1 : index
-  %four_index = index.constant 4 : index
-  %zero = scalar.constant 0.0 : f32
-  %initial = vector.splat %zero : vector<1x2x4xf32>
-  %result = scf.for %i = [%zero_index to %four_index step %one_index](%bank = %initial : vector<1x2x4xf32>) -> (vector<1x2x4xf32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %loop_end = index.constant 4 : index
+  %initial_value = scalar.constant 0.0 : f32
+  %initial = vector.splat %initial_value : vector<1x2x4xf32>
+  %result = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank = %initial : vector<1x2x4xf32>) -> (vector<1x2x4xf32>) {
     %old = vector.extract %bank[0, 0] : vector<1x2x4xf32> -> vector<4xf32>
     %first = vector.addf %old, %increment : vector<4xf32>
     %after_first = vector.insert %first into %bank[0, 0] : vector<4xf32>, vector<1x2x4xf32>
@@ -170,11 +174,11 @@ func.def @uniform_initialization_and_repeated_updates(%increment: vector<4xf32>)
 
 // ----
 func.def @uniform_initialization_and_repeated_updates(%increment: vector<4xf32>) -> (vector<4xf32>, vector<4xf32>) {
-  %zero_index = index.constant 0 : index
-  %one_index = index.constant 1 : index
-  %four_index = index.constant 4 : index
+  %loop_begin = index.constant 0 : index
+  %loop_step = index.constant 1 : index
+  %loop_end = index.constant 4 : index
   %initial_slot_0 = vector.constant 0.0 : vector<4xf32>
-  %result_slot_0, %result_slot_1 = scf.for %i = [%zero_index to %four_index step %one_index](%bank_slot_0 = %initial_slot_0 : vector<4xf32>, %bank_slot_1 = %initial_slot_0 : vector<4xf32>) -> (vector<4xf32>, vector<4xf32>) {
+  %result_slot_0, %result_slot_1 = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank_slot_0 = %initial_slot_0 : vector<4xf32>, %bank_slot_1 = %initial_slot_0 : vector<4xf32>) -> (vector<4xf32>, vector<4xf32>) {
     %first = vector.addf %bank_slot_0, %increment : vector<4xf32>
     %second = vector.addf %first, %increment : vector<4xf32>
     %next_other = vector.addf %bank_slot_1, %increment : vector<4xf32>
@@ -187,9 +191,10 @@ func.def @uniform_initialization_and_repeated_updates(%increment: vector<4xf32>)
 // RUN: pass sroa-vector-banks
 
 func.def @partial_prefix_preserves_vector_tail(%initial: vector<2x2x4xf32>, %increment: vector<2x4xf32>) -> (vector<2x4xf32>, vector<2x4xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %i = [%zero to %one step %one](%bank = %initial : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank = %initial : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) {
     %old = vector.extract %bank[1] : vector<2x2x4xf32> -> vector<2x4xf32>
     %next = vector.addf %old, %increment : vector<2x4xf32>
     %updated = vector.insert %next into %bank[1] : vector<2x4xf32>, vector<2x2x4xf32>
@@ -202,11 +207,12 @@ func.def @partial_prefix_preserves_vector_tail(%initial: vector<2x2x4xf32>, %inc
 
 // ----
 func.def @partial_prefix_preserves_vector_tail(%initial: vector<2x2x4xf32>, %increment: vector<2x4xf32>) -> (vector<2x4xf32>, vector<2x4xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
   %initial_slot_0 = vector.extract %initial[0] : vector<2x2x4xf32> -> vector<2x4xf32>
   %initial_slot_1 = vector.extract %initial[1] : vector<2x2x4xf32> -> vector<2x4xf32>
-  %result_slot_0, %result_slot_1 = scf.for %i = [%zero to %one step %one](%bank_slot_0 = %initial_slot_0 : vector<2x4xf32>, %bank_slot_1 = %initial_slot_1 : vector<2x4xf32>) -> (vector<2x4xf32>, vector<2x4xf32>) {
+  %result_slot_0, %result_slot_1 = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank_slot_0 = %initial_slot_0 : vector<2x4xf32>, %bank_slot_1 = %initial_slot_1 : vector<2x4xf32>) -> (vector<2x4xf32>, vector<2x4xf32>) {
     %next = vector.addf %bank_slot_1, %increment : vector<2x4xf32>
     scf.yield %bank_slot_0, %next : vector<2x4xf32>, vector<2x4xf32>
   }
@@ -217,9 +223,10 @@ func.def @partial_prefix_preserves_vector_tail(%initial: vector<2x2x4xf32>, %inc
 // RUN: pass sroa-vector-banks
 
 func.def @multiple_banks_and_nonbank_state(%integer_initial: vector<2x2xi32>, %vector_initial: vector<1x2x4xf32>, %integer_increment: i32, %vector_increment: vector<4xf32>, %initial_count: i32) -> (i32, vector<4xf32>, i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %integer_result, %vector_result, %count_result = scf.for %i = [%zero to %one step %one](%integer_bank = %integer_initial : vector<2x2xi32>, %vector_bank = %vector_initial : vector<1x2x4xf32>, %count = %initial_count : i32) -> (vector<2x2xi32>, vector<1x2x4xf32>, i32) {
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
+  %integer_result, %vector_result, %count_result = scf.for %i = [%loop_begin to %loop_end step %loop_step](%integer_bank = %integer_initial : vector<2x2xi32>, %vector_bank = %vector_initial : vector<1x2x4xf32>, %count = %initial_count : i32) -> (vector<2x2xi32>, vector<1x2x4xf32>, i32) {
     %old_integer = vector.extract %integer_bank[1, 0] : vector<2x2xi32> -> i32
     %next_integer = scalar.addi %old_integer, %integer_increment : i32
     %updated_integer = vector.insert %next_integer into %integer_bank[1, 0] : i32, vector<2x2xi32>
@@ -236,15 +243,16 @@ func.def @multiple_banks_and_nonbank_state(%integer_initial: vector<2x2xi32>, %v
 
 // ----
 func.def @multiple_banks_and_nonbank_state(%integer_initial: vector<2x2xi32>, %vector_initial: vector<1x2x4xf32>, %integer_increment: i32, %vector_increment: vector<4xf32>, %initial_count: i32) -> (i32, vector<4xf32>, i32) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
   %integer_initial_slot_0 = vector.extract %integer_initial[0, 0] : vector<2x2xi32> -> i32
   %integer_initial_slot_1 = vector.extract %integer_initial[0, 1] : vector<2x2xi32> -> i32
   %integer_initial_slot_2 = vector.extract %integer_initial[1, 0] : vector<2x2xi32> -> i32
   %integer_initial_slot_3 = vector.extract %integer_initial[1, 1] : vector<2x2xi32> -> i32
   %vector_initial_slot_0 = vector.extract %vector_initial[0, 0] : vector<1x2x4xf32> -> vector<4xf32>
   %vector_initial_slot_1 = vector.extract %vector_initial[0, 1] : vector<1x2x4xf32> -> vector<4xf32>
-  %integer_result_slot_0, %integer_result_slot_1, %integer_result_slot_2, %integer_result_slot_3, %vector_result_slot_0, %vector_result_slot_1, %count_result = scf.for %i = [%zero to %one step %one](%integer_bank_slot_0 = %integer_initial_slot_0 : i32, %integer_bank_slot_1 = %integer_initial_slot_1 : i32, %integer_bank_slot_2 = %integer_initial_slot_2 : i32, %integer_bank_slot_3 = %integer_initial_slot_3 : i32, %vector_bank_slot_0 = %vector_initial_slot_0 : vector<4xf32>, %vector_bank_slot_1 = %vector_initial_slot_1 : vector<4xf32>, %count = %initial_count : i32) -> (i32, i32, i32, i32, vector<4xf32>, vector<4xf32>, i32) {
+  %integer_result_slot_0, %integer_result_slot_1, %integer_result_slot_2, %integer_result_slot_3, %vector_result_slot_0, %vector_result_slot_1, %count_result = scf.for %i = [%loop_begin to %loop_end step %loop_step](%integer_bank_slot_0 = %integer_initial_slot_0 : i32, %integer_bank_slot_1 = %integer_initial_slot_1 : i32, %integer_bank_slot_2 = %integer_initial_slot_2 : i32, %integer_bank_slot_3 = %integer_initial_slot_3 : i32, %vector_bank_slot_0 = %vector_initial_slot_0 : vector<4xf32>, %vector_bank_slot_1 = %vector_initial_slot_1 : vector<4xf32>, %count = %initial_count : i32) -> (i32, i32, i32, i32, vector<4xf32>, vector<4xf32>, i32) {
     %next_integer = scalar.addi %integer_bank_slot_2, %integer_increment : i32
     %next_vector = vector.addf %vector_bank_slot_1, %vector_increment : vector<4xf32>
     %next_count = scalar.addi %count, %integer_increment : i32
@@ -257,9 +265,10 @@ func.def @multiple_banks_and_nonbank_state(%integer_initial: vector<2x2xi32>, %v
 // RUN: pass sroa-vector-banks
 
 func.def @zero_extent_unselected_bank_is_unchanged(%initial: vector<0x2x4xf32>) -> (vector<0x2x4xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %i = [%zero to %one step %one](%bank = %initial : vector<0x2x4xf32>) -> (vector<0x2x4xf32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank = %initial : vector<0x2x4xf32>) -> (vector<0x2x4xf32>) {
     scf.yield %bank : vector<0x2x4xf32>
   }
   func.return %result : vector<0x2x4xf32>
@@ -267,9 +276,10 @@ func.def @zero_extent_unselected_bank_is_unchanged(%initial: vector<0x2x4xf32>) 
 
 // ----
 func.def @zero_extent_unselected_bank_is_unchanged(%initial: vector<0x2x4xf32>) -> (vector<0x2x4xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %i = [%zero to %one step %one](%bank = %initial : vector<0x2x4xf32>) -> (vector<0x2x4xf32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank = %initial : vector<0x2x4xf32>) -> (vector<0x2x4xf32>) {
     scf.yield %bank : vector<0x2x4xf32>
   }
   func.return %result : vector<0x2x4xf32>
@@ -279,9 +289,10 @@ func.def @zero_extent_unselected_bank_is_unchanged(%initial: vector<0x2x4xf32>) 
 // RUN: pass sroa-vector-banks
 
 func.def @nested_region_bank_escape_is_rejected(%initial: vector<2x2x4xf32>, %condition: i1) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %i = [%zero to %one step %one](%bank = %initial : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank = %initial : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) {
     %top_level = vector.extract %bank[0, 0] : vector<2x2x4xf32> -> vector<4xf32>
     scf.if %condition {
       // ERROR@+1: LOWERING/047 {op_name="vector.extract", phase_name="sroa-vector-banks", slot="0", reason="an aggregate state has a non-prefix or nested-region use"}
@@ -301,9 +312,10 @@ func.def @nested_region_bank_escape_is_rejected(%initial: vector<2x2x4xf32>, %co
 // RUN: pass sroa-vector-banks
 
 func.def @dynamic_prefix_is_rejected(%initial: vector<2x2x4xf32>, %dynamic: index) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %i = [%zero to %one step %one](%bank = %initial : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank = %initial : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) {
     // ERROR@+1: LOWERING/047 {op_name="vector.extract", phase_name="sroa-vector-banks", slot="0", reason="the access has a dynamic prefix index"}
     %value = vector.extract %bank[%dynamic, 0] : vector<2x2x4xf32> -> vector<4xf32>
     %updated = vector.insert %value into %bank[0, 0] : vector<4xf32>, vector<2x2x4xf32>
@@ -318,9 +330,10 @@ func.def @dynamic_prefix_is_rejected(%initial: vector<2x2x4xf32>, %dynamic: inde
 // RUN: pass sroa-vector-banks
 
 func.def @aggregate_result_escape_is_rejected(%initial: vector<2x2x4xf32>) {
-  %zero = index.constant 0 : index
-  %one = index.constant 1 : index
-  %result = scf.for %i = [%zero to %one step %one](%bank = %initial : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) {
+  %loop_begin = index.constant 0 : index
+  %loop_end = index.constant 1 : index
+  %loop_step = index.constant 1 : index
+  %result = scf.for %i = [%loop_begin to %loop_end step %loop_step](%bank = %initial : vector<2x2x4xf32>) -> (vector<2x2x4xf32>) {
     %value = vector.extract %bank[0, 0] : vector<2x2x4xf32> -> vector<4xf32>
     %updated = vector.insert %value into %bank[0, 0] : vector<4xf32>, vector<2x2x4xf32>
     scf.yield %updated : vector<2x2x4xf32>

--- a/loom/src/loom/transforms/vector/test/memory_footprint.loom-test
+++ b/loom/src/loom/transforms/vector/test/memory_footprint.loom-test
@@ -100,23 +100,23 @@ func.def @fragment_load_rejects_storage_root_overflow() {
 func.def @strided_fragment_rejects_subgroup_dependent_root_overflow(%subgroup0: index, %pair0: index) {
   %subgroup = index.assume %subgroup0 [range(%subgroup0, 0, 3)] : index
   %pair = index.assume %pair0 [range(%pair0, 0, 1)] : index
-  %two = index.constant 2 : index
-  %sixteen = index.constant 16 : index
-  %thirty_two = index.constant 32 : index
-  %forty_eight = index.constant 48 : index
-  %sixty_four = index.constant 64 : index
+  %subgroups_per_quadrant = index.constant 2 : index
+  %fragment_columns = index.constant 16 : index
+  %fragment_k = index.constant 32 : index
+  %row_bias = index.constant 48 : index
+  %row_wave_stride = index.constant 64 : index
   %stride = index.constant 72 : index
   %byte_length = index.constant 16384 : offset
   %base = index.constant 0 : offset
-  %row_quadrant = index.div %subgroup, %two : index
-  %row_wave_offset = index.mul %row_quadrant, %sixty_four : index
-  %row_origin = index.add %row_wave_offset, %forty_eight : index
-  %k_origin = index.mul %pair, %thirty_two : index
+  %row_quadrant = index.div %subgroup, %subgroups_per_quadrant : index
+  %row_wave_offset = index.mul %row_quadrant, %row_wave_stride : index
+  %row_origin = index.add %row_wave_offset, %row_bias : index
+  %k_origin = index.mul %pair, %fragment_k : index
   %layout = encoding.layout.strided [1, %stride] : encoding<layout>
   %scratch = buffer.alloca %byte_length {base_alignment = 16, memory_space = workgroup} : buffer
   %view = buffer.view %scratch[%base] : buffer -> view<64x128xbf16, %layout>
   // ERROR@+1: SUBRANGE/026 {op_name="vector.fragment.load", maximum_access_byte_end="18416", root_byte_extent="16384"}
-  %loaded = vector.fragment.load<rhs> %view[%k_origin, %row_origin] shape [%thirty_two, %sixteen] : view<64x128xbf16, %layout> -> vector<16xbf16>
+  %loaded = vector.fragment.load<rhs> %view[%k_origin, %row_origin] shape [%fragment_k, %fragment_columns] : view<64x128xbf16, %layout> -> vector<16xbf16>
   test.use %loaded : vector<16xbf16>
   func.return
 }
@@ -139,11 +139,11 @@ func.def @sparse_lhs_fragment_load_uses_compact_physical_extent(%buffer: buffer,
 
 func.def @dynamic_sparse_lhs_fragment_load_proves_compact_physical_extent(%buffer: buffer, %base: offset, %group_count0: index, %metadata: vector<1xi32>) {
   %group_count = index.assume %group_count0 [range(%group_count0, 1, 4096)] : index
-  %two = index.constant 2 : index
-  %four = index.constant 4 : index
+  %physical_group_elements = index.constant 2 : index
+  %logical_group_elements = index.constant 4 : index
   %m = index.constant 16 : index
-  %physical_k = index.mul %group_count, %two : index
-  %logical_k = index.mul %group_count, %four : index
+  %physical_k = index.mul %group_count, %physical_group_elements : index
+  %logical_k = index.mul %group_count, %logical_group_elements : index
   %schema = encoding.define #matrix_operand<element_format=f8e5m2, payload_elements=8, payload_registers=2, sparsity=n_m_structured, sparsity_group_elements=4, sparsity_group_nonzero_elements=2> : encoding<schema>
   %layout = encoding.layout.dense : encoding<layout>
   %storage = encoding.define #physical_storage {layout = %layout : encoding<layout>, schema = %schema : encoding<schema>} : encoding<storage>
@@ -347,10 +347,10 @@ func.def @dynamic_unit_axis_proven_by_remainder_relation(%buffer: buffer, %base:
 
 func.def @dynamic_scaled_vector_origin_proven_by_assume_relation(%buffer: buffer, %base: offset, %i: index, %n: index) {
   %layout = encoding.layout.dense : encoding<layout>
-  %four = index.constant 4 : index
+  %vector_width = index.constant 4 : index
   %i_in_bounds, %n_assumed = index.assume %i, %n [ge(%i, 0), lt(%i, %n)] : index, index
-  %element_count = index.mul %n_assumed, %four : index
-  %origin = index.mul %i_in_bounds, %four : index
+  %element_count = index.mul %n_assumed, %vector_width : index
+  %origin = index.mul %i_in_bounds, %vector_width : index
   %view = buffer.view %buffer[%base] : buffer -> view<[%element_count]xf32, %layout>
   %loaded = vector.load %view[%origin] : view<[%element_count]xf32, %layout> -> vector<4xf32>
   func.return
@@ -361,8 +361,8 @@ func.def @dynamic_scaled_vector_origin_proven_by_assume_relation(%buffer: buffer
 func.def @dynamic_vector_origin_proven_by_shifted_assume_relation(%buffer: buffer, %base: offset, %origin0: index, %n0: index) {
   %layout = encoding.layout.dense : encoding<layout>
   %n = index.assume %n0 [range(%n0, 4, 4096)] : index
-  %three = index.constant 3 : index
-  %last_valid_start = index.sub %n, %three : index
+  %last_start_bias = index.constant 3 : index
+  %last_valid_start = index.sub %n, %last_start_bias : index
   %origin = index.assume %origin0 [ge(%origin0, 0), lt(%origin0, %last_valid_start)] : index
   %view = buffer.view %buffer[%base] : buffer -> view<[%n]xi32, %layout>
   %words = vector.load %view[%origin] : view<[%n]xi32, %layout> -> vector<4xi32>
@@ -375,8 +375,8 @@ func.def @dynamic_vector_origin_proven_by_shifted_assume_relation(%buffer: buffe
 func.def @dynamic_vector_origin_proven_by_exact_count_minus_extent_relation(%buffer: buffer, %base: offset, %origin0: index, %n0: index) {
   %layout = encoding.layout.dense : encoding<layout>
   %n = index.assume %n0 [range(%n0, 262144, 262144)] : index
-  %seven = index.constant 7 : index
-  %last_valid_start = index.sub %n, %seven : index
+  %last_start_bias = index.constant 7 : index
+  %last_valid_start = index.sub %n, %last_start_bias : index
   %origin = index.assume %origin0 [ge(%origin0, 0), lt(%origin0, %last_valid_start), mul(%origin0, 8)] : index
   %view = buffer.view %buffer[%base] : buffer -> view<[%n]xf16, %layout>
   %values = vector.load %view[%origin] : view<[%n]xf16, %layout> -> vector<8xf16>
@@ -388,8 +388,8 @@ func.def @dynamic_vector_origin_proven_by_exact_count_minus_extent_relation(%buf
 
 func.def @dynamic_vector_tail_origin_proven_by_dynamic_bound(%input: buffer, %output: buffer, %base_i32: i32, %tail_i32: i32, %stride_i32: i32, %token_count_i32: i32) {
   %layout = encoding.layout.dense : encoding<layout>
-  %zero = index.constant 0 : offset
-  %one = index.constant 1 : index
+  %buffer_base = index.constant 0 : offset
+  %last_start_bias = index.constant 1 : index
   %stride0 = index.cast %stride_i32 : i32 to index
   %stride = index.assume %stride0 [range(%stride0, 2, 2048)] : index
   %token_count0 = index.cast %token_count_i32 : i32 to index
@@ -401,10 +401,10 @@ func.def @dynamic_vector_tail_origin_proven_by_dynamic_bound(%input: buffer, %ou
   %tail = index.assume %tail0 [range(%tail0, 0, 4094)] : index
   %origin0 = index.add %base, %tail : index
   %origin_nonnegative = index.assume %origin0 [range(%origin0, 0, 4094)] : index
-  %max_vector_origin = index.sub %element_count, %one : index
+  %max_vector_origin = index.sub %element_count, %last_start_bias : index
   %origin = index.assume %origin_nonnegative [lt(%origin_nonnegative, %max_vector_origin)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<[%element_count]xf32, %layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<[%element_count]xf32, %layout>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<[%element_count]xf32, %layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<[%element_count]xf32, %layout>
   %loaded = vector.load %input_view[%origin] : view<[%element_count]xf32, %layout> -> vector<2xf32>
   vector.store %loaded, %output_view[%origin] : vector<2xf32>, view<[%element_count]xf32, %layout>
   func.return
@@ -414,9 +414,9 @@ func.def @dynamic_vector_tail_origin_proven_by_dynamic_bound(%input: buffer, %ou
 
 func.def @dynamic_vector_tail_origin_proven_by_relation_lower_bound(%input: buffer, %output: buffer, %pair_i32: i32, %half_i32: i32, %base_i32: i32, %n_dims_i32: i32, %element_count_i32: i32) {
   %layout = encoding.layout.dense : encoding<layout>
-  %zero = index.constant 0 : offset
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %buffer_base = index.constant 0 : offset
+  %last_start_bias = index.constant 1 : index
+  %tail_scale = index.constant 2 : index
   %element_count0 = index.cast %element_count_i32 : i32 to index
   %element_count = index.assume %element_count0 [range(%element_count0, 2, 8192)] : index
   %half0 = index.cast %half_i32 : i32 to index
@@ -426,14 +426,14 @@ func.def @dynamic_vector_tail_origin_proven_by_relation_lower_bound(%input: buff
   %tail_pair = index.sub %pair, %half : index
   %n_dims0 = index.cast %n_dims_i32 : i32 to index
   %n_dims = index.assume %n_dims0 [range(%n_dims0, 0, 4094)] : index
-  %tail0 = index.madd %tail_pair, %two, %n_dims : index
+  %tail0 = index.madd %tail_pair, %tail_scale, %n_dims : index
   %base0 = index.cast %base_i32 : i32 to index
   %base = index.assume %base0 [range(%base0, 0, 4094)] : index
   %origin0 = index.add %base, %tail0 : index
-  %max_vector_origin = index.sub %element_count, %one : index
+  %max_vector_origin = index.sub %element_count, %last_start_bias : index
   %origin = index.assume %origin0 [lt(%origin0, %max_vector_origin)] : index
-  %input_view = buffer.view %input[%zero] : buffer -> view<[%element_count]xf32, %layout>
-  %output_view = buffer.view %output[%zero] : buffer -> view<[%element_count]xf32, %layout>
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<[%element_count]xf32, %layout>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<[%element_count]xf32, %layout>
   %loaded = vector.load %input_view[%origin] : view<[%element_count]xf32, %layout> -> vector<2xf32>
   vector.store %loaded, %output_view[%origin] : vector<2xf32>, view<[%element_count]xf32, %layout>
   func.return
@@ -444,8 +444,8 @@ func.def @dynamic_vector_tail_origin_proven_by_relation_lower_bound(%input: buff
 func.def @dynamic_vector_origin_rejects_insufficient_shifted_assume_relation(%buffer: buffer, %base: offset, %origin0: index, %n0: index) {
   %layout = encoding.layout.dense : encoding<layout>
   %n = index.assume %n0 [range(%n0, 4, 4096)] : index
-  %two = index.constant 2 : index
-  %late_start = index.sub %n, %two : index
+  %insufficient_bias = index.constant 2 : index
+  %late_start = index.sub %n, %insufficient_bias : index
   %origin = index.assume %origin0 [ge(%origin0, 0), lt(%origin0, %late_start)] : index
   %view = buffer.view %buffer[%base] : buffer -> view<[%n]xi32, %layout>
   // ERROR@+1: SUBRANGE/010 {op_name="vector.load", vector_extent="4", constraint_key="vector_footprint.full_vector_upper_bound"}
@@ -458,26 +458,26 @@ func.def @dynamic_vector_origin_rejects_insufficient_shifted_assume_relation(%bu
 
 func.def @quantized_q8_x4_word_chunk_vector_load_is_proven(%buffer: buffer, %base: offset, %lane0: index, %iter0: index) {
   %layout = encoding.layout.dense : encoding<layout>
-  %two = index.constant 2 : index
-  %four = index.constant 4 : index
-  %eight = index.constant 8 : index
-  %sixteen = index.constant 16 : index
-  %thirtytwo = index.constant 32 : index
-  %thirtysix = index.constant 36 : index
-  %tentwentyfour = index.constant 1024 : index
+  %word_pair_count = index.constant 2 : index
+  %word_chunk_size = index.constant 4 : index
+  %block_group_width = index.constant 8 : index
+  %lane_column_stride = index.constant 16 : index
+  %block_column_width = index.constant 32 : index
+  %block_word_stride = index.constant 36 : index
+  %iteration_column_stride = index.constant 1024 : index
   %lane = index.assume %lane0 [range(%lane0, 0, 63)] : index
   %iter = index.assume %iter0 [range(%iter0, 0, 31)] : index
-  %q8_word_pair = index.rem %lane, %two : index
-  %lane_column = index.mul %lane, %sixteen : index
-  %iter_column_base = index.mul %iter, %tentwentyfour : index
+  %q8_word_pair = index.rem %lane, %word_pair_count : index
+  %lane_column = index.mul %lane, %lane_column_stride : index
+  %iter_column_base = index.mul %iter, %iteration_column_stride : index
   %column = index.add %iter_column_base, %lane_column : index
-  %block_column = index.div %column, %thirtytwo : index
-  %block_outer = index.div %block_column, %four : index
-  %block_inner = index.rem %block_column, %four : index
-  %outer_word_base = index.mul %block_outer, %thirtysix : index
-  %payload_base = index.add %outer_word_base, %four : index
-  %inner_word_base = index.mul %block_inner, %eight : index
-  %q8_word_offset = index.mul %q8_word_pair, %four : index
+  %block_column = index.div %column, %block_column_width : index
+  %block_outer = index.div %block_column, %word_chunk_size : index
+  %block_inner = index.rem %block_column, %word_chunk_size : index
+  %outer_word_base = index.mul %block_outer, %block_word_stride : index
+  %payload_base = index.add %outer_word_base, %word_chunk_size : index
+  %inner_word_base = index.mul %block_inner, %block_group_width : index
+  %q8_word_offset = index.mul %q8_word_pair, %word_chunk_size : index
   %payload_word_base = index.add %payload_base, %inner_word_base : index
   %word_origin = index.add %payload_word_base, %q8_word_offset : index
   %view = buffer.view %buffer[%base] : buffer -> view<9216xi32, %layout>
@@ -490,36 +490,36 @@ func.def @quantized_q8_x4_word_chunk_vector_load_is_proven(%buffer: buffer, %bas
 
 func.def @quantized_q4_row_word_chunk_reports_storage_envelope(%buffer: buffer, %base: offset, %row0: index, %ncols0: index, %lane0: index, %iter0: index) {
   %layout = encoding.layout.dense : encoding<layout>
-  %two = index.constant 2 : index
-  %four = index.constant 4 : index
-  %eight = index.constant 8 : index
-  %sixteen = index.constant 16 : index
-  %thirtytwo = index.constant 32 : index
-  %thirtysix = index.constant 36 : index
-  %tentwentyfour = index.constant 1024 : index
+  %word_pair_count = index.constant 2 : index
+  %word_chunk_size = index.constant 4 : index
+  %block_group_width = index.constant 8 : index
+  %lane_column_stride = index.constant 16 : index
+  %block_column_width = index.constant 32 : index
+  %block_word_stride = index.constant 36 : index
+  %iteration_column_stride = index.constant 1024 : index
   %row = index.assume %row0 [range(%row0, 0, 32767)] : index
   %ncols = index.assume %ncols0 [range(%ncols0, 256, 32768), mul(%ncols0, 256)] : index
   %lane = index.assume %lane0 [range(%lane0, 0, 63)] : index
   %iter = index.assume %iter0 [range(%iter0, 0, 31)] : index
-  %q8_word_pair = index.rem %lane, %two : index
-  %lane_column = index.mul %lane, %sixteen : index
+  %q8_word_pair = index.rem %lane, %word_pair_count : index
+  %lane_column = index.mul %lane, %lane_column_stride : index
   %row_column_base = index.mul %row, %ncols : index
-  %iter_column_base = index.mul %iter, %tentwentyfour : index
+  %iter_column_base = index.mul %iter, %iteration_column_stride : index
   %column = index.add %iter_column_base, %lane_column : index
   %element = index.add %row_column_base, %column : index
-  %block_column = index.div %element, %thirtytwo : index
-  %block = index.div %block_column, %eight : index
-  %group = index.rem %block_column, %eight : index
-  %group_payload_base = index.mul %group, %eight : index
-  %q8_payload_base = index.mul %q8_word_pair, %four : index
+  %block_column = index.div %element, %block_column_width : index
+  %block = index.div %block_column, %block_group_width : index
+  %group = index.rem %block_column, %block_group_width : index
+  %group_payload_base = index.mul %group, %block_group_width : index
+  %q8_payload_base = index.mul %q8_word_pair, %word_chunk_size : index
   %intra_block_payload = index.add %group_payload_base, %q8_payload_base : index
   %scale_group_divisor = index.constant 16 : index
   %payload_group = index.div %intra_block_payload, %scale_group_divisor : index
-  %payload_lane = index.rem %intra_block_payload, %eight : index
-  %payload_group_base = index.mul %payload_group, %eight : index
+  %payload_lane = index.rem %intra_block_payload, %block_group_width : index
+  %payload_group_base = index.mul %payload_group, %block_group_width : index
   %payload_word = index.add %payload_group_base, %payload_lane : index
-  %block_word_base = index.mul %block, %thirtysix : index
-  %payload_word_base = index.add %block_word_base, %four : index
+  %block_word_base = index.mul %block, %block_word_stride : index
+  %payload_word_base = index.add %block_word_base, %word_chunk_size : index
   %word_origin = index.add %payload_word_base, %payload_word : index
   %view = buffer.view %buffer[%base] : buffer -> view<8388608xi32, %layout>
   // ERROR@+1: SUBRANGE/010 {op_name="vector.load", vector_extent="4", view_bound="8388608", required_origin_upper_bound="8388604", constraint_key="vector_footprint.full_vector_upper_bound"}
@@ -615,8 +615,8 @@ func.def @guarded_loaded_i32_precast_index_proves_unit_axis(%ids: buffer, %paylo
   %row = vector.extract %id_vec[0] : vector<1xi32> -> i32
   %row_idx = index.cast %row : i32 to index
   %row_count_idx = index.cast %row_count : i32 to index
-  %zero = scalar.constant 0 : i32
-  %nonnegative = scalar.cmpi sge, %row, %zero : i32
+  %minimum_row = scalar.constant 0 : i32
+  %nonnegative = scalar.cmpi sge, %row, %minimum_row : i32
   %below = scalar.cmpi slt, %row, %row_count : i32
   %guard = scalar.andi %nonnegative, %below : i1
   scf.if %guard {
@@ -637,8 +637,8 @@ func.def @guarded_loaded_i32_precast_index_proves_unit_axis(%ids: buffer, %paylo
   %row = view.load %id_view[0] : view<1xi32, %layout> -> i32
   %row_idx = index.cast %row : i32 to index
   %row_count_idx = index.cast %row_count : i32 to index
-  %zero = scalar.constant 0 : i32
-  %nonnegative = scalar.cmpi sge, %row, %zero : i32
+  %minimum_row = scalar.constant 0 : i32
+  %nonnegative = scalar.cmpi sge, %row, %minimum_row : i32
   %below = scalar.cmpi slt, %row, %row_count : i32
   %guard = scalar.andi %nonnegative, %below : i1
   scf.if %guard {
@@ -658,8 +658,8 @@ func.def @guarded_i64_precast_index_proves_store_unit_axis(%payload: buffer, %ba
   %layout = encoding.layout.dense : encoding<layout>
   %row_idx = index.cast %row : i64 to index
   %row_count_idx = index.cast %row_count : i64 to index
-  %zero = scalar.constant 0 : i64
-  %nonnegative = scalar.cmpi sge, %row, %zero : i64
+  %minimum_row = scalar.constant 0 : i64
+  %nonnegative = scalar.cmpi sge, %row, %minimum_row : i64
   %below = scalar.cmpi slt, %row, %row_count : i64
   %guard = scalar.andi %nonnegative, %below : i1
   scf.if %guard {
@@ -677,8 +677,8 @@ func.def @guarded_i64_precast_index_proves_store_unit_axis(%payload: buffer, %ba
   %layout = encoding.layout.dense : encoding<layout>
   %row_idx = index.cast %row : i64 to index
   %row_count_idx = index.cast %row_count : i64 to index
-  %zero = scalar.constant 0 : i64
-  %nonnegative = scalar.cmpi sge, %row, %zero : i64
+  %minimum_row = scalar.constant 0 : i64
+  %nonnegative = scalar.cmpi sge, %row, %minimum_row : i64
   %below = scalar.cmpi slt, %row, %row_count : i64
   %guard = scalar.andi %nonnegative, %below : i1
   scf.if %guard {
@@ -695,9 +695,9 @@ func.def @guarded_i64_precast_index_proves_store_unit_axis(%payload: buffer, %ba
 func.def @guarded_flattened_store_proves_dynamic_axis_bounds(%payload: buffer, %base: offset, %row0: index, %row_count0: index, %column0: index, %column_count0: index, %lane: i32, %value: f32) {
   %row, %row_count = index.assume %row0, %row_count0 [range(%row0, 0, 2047), range(%row_count0, 1, 2048), lt(%row0, %row_count0)] : index, index
   %column, %column_count = index.assume %column0, %column_count0 [range(%column0, 0, 262143), range(%column_count0, 1, 262144)] : index, index
-  %zero_i32 = scalar.constant 0 : i32
+  %first_lane = scalar.constant 0 : i32
   %valid_column = index.cmp ult, %column, %column_count : index
-  %is_lane_zero = scalar.cmpi eq, %lane, %zero_i32 : i32
+  %is_lane_zero = scalar.cmpi eq, %lane, %first_lane : i32
   %writes_output = scalar.andi %valid_column, %is_lane_zero : i1
   scf.if %writes_output {
     %element_count = index.mul %row_count, %column_count : index
@@ -715,12 +715,12 @@ func.def @guarded_flattened_store_proves_dynamic_axis_bounds(%payload: buffer, %
 // of a convergent operation. The active branch relation still proves that an
 // index guarded by the first quotient fits a view shaped by the second.
 func.def @guarded_recomputed_quotient_proves_dynamic_axis_bound(%payload: buffer, %base: offset, %active_count0: index, %block0: index, %value: i32) {
-  %sixtythree = index.constant 63 : index
-  %sixtyfour = index.constant 64 : index
+  %block_rounding_bias = index.constant 63 : index
+  %block_size = index.constant 64 : index
   %active_count = index.assume %active_count0 [range(%active_count0, 1, 2048)] : index
   %block = index.assume %block0 [range(%block0, 0, 31)] : index
-  %padded_count = index.add %active_count, %sixtythree : index
-  %block_count0 = index.div %padded_count, %sixtyfour : index
+  %padded_count = index.add %active_count, %block_rounding_bias : index
+  %block_count0 = index.div %padded_count, %block_size : index
   %block_count = index.assume %block_count0 [range(%block_count0, 1, 32)] : index
   %barrier = test.convergent %value : i32
   test.use %barrier : i32
@@ -728,8 +728,8 @@ func.def @guarded_recomputed_quotient_proves_dynamic_axis_bound(%payload: buffer
   scf.if %is_active {
     %active_block, %active_block_count, %active_token_count = index.assume %block, %block_count, %active_count [lt(%block, %block_count)] : index, index, index
     %inner_active_count = index.assume %active_token_count [range(%active_token_count, 1, 32768)] : index
-    %inner_padded_count = index.add %inner_active_count, %sixtythree : index
-    %inner_block_count0 = index.div %inner_padded_count, %sixtyfour : index
+    %inner_padded_count = index.add %inner_active_count, %block_rounding_bias : index
+    %inner_block_count0 = index.div %inner_padded_count, %block_size : index
     %inner_block_count = index.assume %inner_block_count0 [range(%inner_block_count0, 1, 512)] : index
     %view = buffer.view %payload[%base] : buffer -> view<[%inner_block_count]xi32, #dense>
     view.store %value, %view[%active_block] : i32, view<[%inner_block_count]xi32, #dense>
@@ -740,19 +740,19 @@ func.def @guarded_recomputed_quotient_proves_dynamic_axis_bound(%payload: buffer
 // ====
 
 func.def @guarded_distinct_quotient_rejects_unproven_dynamic_axis_bound(%payload: buffer, %base: offset, %active_count0: index, %block0: index, %value: i32) {
-  %sixtythree = index.constant 63 : index
-  %sixtyfour = index.constant 64 : index
-  %onetwentyeight = index.constant 128 : index
+  %block_rounding_bias = index.constant 63 : index
+  %outer_block_size = index.constant 64 : index
+  %inner_block_size = index.constant 128 : index
   %active_count = index.assume %active_count0 [range(%active_count0, 1, 2048)] : index
   %block = index.assume %block0 [range(%block0, 0, 31)] : index
-  %padded_count = index.add %active_count, %sixtythree : index
-  %block_count0 = index.div %padded_count, %sixtyfour : index
+  %padded_count = index.add %active_count, %block_rounding_bias : index
+  %block_count0 = index.div %padded_count, %outer_block_size : index
   %block_count = index.assume %block_count0 [range(%block_count0, 1, 32)] : index
   %is_active = index.cmp ult, %block, %block_count : index
   scf.if %is_active {
     %inner_active_count = index.assume %active_count [range(%active_count, 1, 32768)] : index
-    %inner_padded_count = index.add %inner_active_count, %sixtythree : index
-    %inner_block_count0 = index.div %inner_padded_count, %onetwentyeight : index
+    %inner_padded_count = index.add %inner_active_count, %block_rounding_bias : index
+    %inner_block_count0 = index.div %inner_padded_count, %inner_block_size : index
     %inner_block_count = index.assume %inner_block_count0 [range(%inner_block_count0, 1, 256)] : index
     %view = buffer.view %payload[%base] : buffer -> view<[%inner_block_count]xi32, #dense>
     // ERROR@+1: SUBRANGE/024 {op_name="view.store", view_axis="0"}
@@ -817,8 +817,8 @@ kernel.def @scalar_store_tail_origin_proven_by_launch_product_quotient_remainder
   kernel.launch.config workgroups(%row_count, %c1, %c1) workgroup_size(%workgroup_size, %c1, %c1) : index
 } launch(%buffer: buffer, %base: offset, %value: f32) {
   %layout = encoding.layout.dense : encoding<layout>
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %tail_increment = index.constant 1 : index
+  %tail_scale = index.constant 2 : index
   %head_count = index.constant 24 : index
   %token_count = index.constant 512 : index
   %half_cols = index.constant 64 : index
@@ -845,9 +845,9 @@ kernel.def @scalar_store_tail_origin_proven_by_launch_product_quotient_remainder
     scf.if %pair_in_rot {
     } else {
       %tail_pair = index.sub %pair, %half_dims : index
-      %tail_pair2 = index.mul %tail_pair, %two : index
+      %tail_pair2 = index.mul %tail_pair, %tail_scale : index
       %tail0 = index.add %n_dims, %tail_pair2 : index
-      %tail1 = index.add %tail0, %one : index
+      %tail1 = index.add %tail0, %tail_increment : index
       %origin = index.add %dst_base, %tail1 : index
       view.store %value, %view[%origin] : f32, view<[%view_count]xf32, %layout>
     }
@@ -876,11 +876,11 @@ kernel.def @dynamic_scaled_vector_origin_proven_by_workitem_id_launch_config(%co
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%columns, %c1, %c1) : index
 } launch(%buffer: buffer, %base: offset) {
   %layout = encoding.layout.dense : encoding<layout>
-  %four = index.constant 4 : index
+  %vector_width = index.constant 4 : index
   %column = kernel.workitem.id<x> : index
   %column_count = kernel.workgroup.size<x> : index
-  %element_count = index.mul %column_count, %four : index
-  %origin = index.mul %column, %four : index
+  %element_count = index.mul %column_count, %vector_width : index
+  %origin = index.mul %column, %vector_width : index
   %view = buffer.view %buffer[%base] : buffer -> view<[%element_count]xf32, %layout>
   %loaded = vector.load %view[%origin] : view<[%element_count]xf32, %layout> -> vector<4xf32>
   kernel.return
@@ -893,13 +893,13 @@ kernel.def @dynamic_scaled_vector_origin_rejects_offset_workitem_id(%columns: in
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%columns, %c1, %c1) : index
 } launch(%buffer: buffer, %base: offset) {
   %layout = encoding.layout.dense : encoding<layout>
-  %one = index.constant 1 : index
-  %four = index.constant 4 : index
+  %column_offset = index.constant 1 : index
+  %vector_width = index.constant 4 : index
   %column = kernel.workitem.id<x> : index
   %column_count = kernel.workgroup.size<x> : index
-  %element_count = index.mul %column_count, %four : index
-  %next_column = index.add %column, %one : index
-  %origin = index.mul %next_column, %four : index
+  %element_count = index.mul %column_count, %vector_width : index
+  %next_column = index.add %column, %column_offset : index
+  %origin = index.mul %next_column, %vector_width : index
   %view = buffer.view %buffer[%base] : buffer -> view<[%element_count]xf32, %layout>
   // ERROR@+1: SUBRANGE/010 {op_name="vector.load", vector_extent="4", constraint_key="vector_footprint.full_vector_upper_bound"}
   %loaded = vector.load %view[%origin] : view<[%element_count]xf32, %layout> -> vector<4xf32>
@@ -913,9 +913,9 @@ kernel.def @dynamic_unit_axis_rejects_offset_workgroup_id(%rows: index) {
   kernel.launch.config workgroups(%rows, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
 } launch(%buffer: buffer, %base: offset) {
   %layout = encoding.layout.dense : encoding<layout>
-  %one = index.constant 1 : index
+  %row_offset = index.constant 1 : index
   %row = kernel.workgroup.id<x> : index
-  %next_row = index.add %row, %one : index
+  %next_row = index.add %row, %row_offset : index
   %row_count = kernel.workgroup.count<x> : index
   %view = buffer.view %buffer[%base] : buffer -> view<[%row_count]x2xf32, %layout>
   // ERROR@+1: SUBRANGE/011 {op_name="vector.load", vector_extent="1", constraint_key="vector_footprint.scalar_axis_upper_bound"}
@@ -927,26 +927,26 @@ kernel.def @dynamic_unit_axis_rejects_offset_workgroup_id(%rows: index) {
 
 func.def @scalar_view_access_rejects_same_padding_edge_tap_without_origin_proof(%input: buffer, %output: buffer, %base: offset, %x0: index) {
   %layout = encoding.layout.dense : encoding<layout>
-  %zero = index.constant 0 : index
+  %left_edge_origin = index.constant 0 : index
   %unit = index.constant 1 : index
-  %two = index.constant 2 : index
-  %three = index.constant 3 : index
+  %right_edge_end = index.constant 2 : index
+  %full_kernel_end = index.constant 3 : index
   %width = index.constant 64 : index
   %x = index.assume %x0 [range(%x0, 0, 63)] : index
   %input_view = buffer.view %input[%base] : buffer -> view<64xi32, %layout>
   %output_view = buffer.view %output[%base] : buffer -> view<64xi32, %layout>
   %last_x = index.sub %width, %unit : index
-  %is_left_edge = index.cmp eq, %x, %zero : index
+  %is_left_edge = index.cmp eq, %x, %left_edge_origin : index
   %kernel_x_begin = scf.if %is_left_edge -> (index) {
     scf.yield %unit : index
   } else {
-    scf.yield %zero : index
+    scf.yield %left_edge_origin : index
   }
   %is_right_edge = index.cmp eq, %x, %last_x : index
   %kernel_x_end = scf.if %is_right_edge -> (index) {
-    scf.yield %two : index
+    scf.yield %right_edge_end : index
   } else {
-    scf.yield %three : index
+    scf.yield %full_kernel_end : index
   }
   scf.for %kernel_x = [%kernel_x_begin to %kernel_x_end step %unit] {
     %x_with_kernel = index.add %x, %kernel_x : index
@@ -963,26 +963,26 @@ func.def @scalar_view_access_rejects_same_padding_edge_tap_without_origin_proof(
 
 func.def @scalar_view_access_accepts_same_padding_edge_tap_with_origin_proof(%input: buffer, %output: buffer, %base: offset, %x0: index) {
   %layout = encoding.layout.dense : encoding<layout>
-  %zero = index.constant 0 : index
+  %left_edge_origin = index.constant 0 : index
   %unit = index.constant 1 : index
-  %two = index.constant 2 : index
-  %three = index.constant 3 : index
+  %right_edge_end = index.constant 2 : index
+  %full_kernel_end = index.constant 3 : index
   %width = index.constant 64 : index
   %x = index.assume %x0 [range(%x0, 0, 63)] : index
   %input_view = buffer.view %input[%base] : buffer -> view<64xi32, %layout>
   %output_view = buffer.view %output[%base] : buffer -> view<64xi32, %layout>
   %last_x = index.sub %width, %unit : index
-  %is_left_edge = index.cmp eq, %x, %zero : index
+  %is_left_edge = index.cmp eq, %x, %left_edge_origin : index
   %kernel_x_begin = scf.if %is_left_edge -> (index) {
     scf.yield %unit : index
   } else {
-    scf.yield %zero : index
+    scf.yield %left_edge_origin : index
   }
   %is_right_edge = index.cmp eq, %x, %last_x : index
   %kernel_x_end = scf.if %is_right_edge -> (index) {
-    scf.yield %two : index
+    scf.yield %right_edge_end : index
   } else {
-    scf.yield %three : index
+    scf.yield %full_kernel_end : index
   }
   scf.for %kernel_x = [%kernel_x_begin to %kernel_x_end step %unit] {
     %x_with_kernel0 = index.add %x, %kernel_x : index
@@ -998,9 +998,9 @@ func.def @scalar_view_access_accepts_same_padding_edge_tap_with_origin_proof(%in
 
 func.def @scalar_view_atomic_rejects_unproven_origin_while_prefetch_is_ignored(%buffer: buffer, %base: offset, %value: i32) {
   %layout = encoding.layout.dense : encoding<layout>
-  %zero = index.constant 0 : index
+  %view_origin = index.constant 0 : index
   %unit = index.constant 1 : index
-  %origin = index.sub %zero, %unit : index
+  %origin = index.sub %view_origin, %unit : index
   %view = buffer.view %buffer[%base] : buffer -> view<64xi32, %layout>
   // ERROR@+1: SUBRANGE/023 {op_name="view.atomic.reduce", view_axis="0"}
   view.atomic.reduce<addi> %value, %view[%origin] {ordering = relaxed, scope = device} : i32, view<64xi32, %layout>
@@ -1327,8 +1327,8 @@ kernel.def @scalar_store_tail_origin_proven_after_scf_to_cfg() {
   kernel.launch.config workgroups(%row_count, %c1, %c1) workgroup_size(%workgroup_size, %c1, %c1) : index
 } launch(%buffer: buffer, %base: offset, %value: f32) {
   %layout = encoding.layout.dense : encoding<layout>
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %tail_increment = index.constant 1 : index
+  %tail_scale = index.constant 2 : index
   %head_count = index.constant 24 : index
   %token_count = index.constant 512 : index
   %half_cols = index.constant 64 : index
@@ -1351,9 +1351,9 @@ kernel.def @scalar_store_tail_origin_proven_after_scf_to_cfg() {
     scf.if %pair_in_rot {
     } else {
       %tail_pair = index.sub %lane, %half_dims : index
-      %tail_pair2 = index.mul %tail_pair, %two : index
+      %tail_pair2 = index.mul %tail_pair, %tail_scale : index
       %tail0 = index.add %n_dims, %tail_pair2 : index
-      %tail1 = index.add %tail0, %one : index
+      %tail1 = index.add %tail0, %tail_increment : index
       %origin = index.add %dst_base, %tail1 : index
       view.store %value, %view[%origin] : f32, view<[%view_count]xf32, %layout>
     }
@@ -1371,8 +1371,8 @@ kernel.def @scalar_store_tail_origin_proven_after_scf_to_cfg() {
   kernel.launch.config workgroups(%row_count, %c1, %c1) workgroup_size(%workgroup_size, %c1, %c1) : index
 } launch(%buffer: buffer, %base: offset, %value: f32) {
   %layout = encoding.layout.dense : encoding<layout>
-  %one = index.constant 1 : index
-  %two = index.constant 2 : index
+  %tail_increment = index.constant 1 : index
+  %tail_scale = index.constant 2 : index
   %head_count = index.constant 24 : index
   %token_count = index.constant 512 : index
   %half_cols = index.constant 64 : index
@@ -1398,9 +1398,9 @@ kernel.def @scalar_store_tail_origin_proven_after_scf_to_cfg() {
   cfg.br ^_bb4
 ^_bb3:
   %tail_pair = index.sub %lane, %half_dims : index
-  %tail_pair2 = index.mul %tail_pair, %two : index
+  %tail_pair2 = index.mul %tail_pair, %tail_scale : index
   %tail0 = index.add %n_dims, %tail_pair2 : index
-  %tail1 = index.add %tail0, %one : index
+  %tail1 = index.add %tail0, %tail_increment : index
   %origin = index.add %dst_base, %tail1 : index
   view.store %value, %view[%origin] : f32, view<[%view_count]xf32, %layout>
   cfg.br ^_bb4

--- a/loom/src/loom/transforms/vector/test/to_scalar.loom-test
+++ b/loom/src/loom/transforms/vector/test/to_scalar.loom-test
@@ -953,8 +953,9 @@ func.def @rejects_static_lane_count_beyond_value_slice() {
 // ====
 
 func.def @rejects_out_of_bounds_transform_iota_permutation(%v: vector<2xf32>, %signs: vector<2xi1>) -> (vector<2xf32>) {
-  %one = index.constant 1 : index
-  %permutation = vector.iota %one step %one : vector<2xindex>
+  %permutation_start = index.constant 1 : index
+  %permutation_step = index.constant 1 : index
+  %permutation = vector.iota %permutation_start step %permutation_step : vector<2xindex>
   %xf = encoding.define #numeric_transform<family="sign_permute_hadamard", input_elems=2, output_elems=2> {permutation = %permutation : vector<2xindex>, signs = %signs : vector<2xi1>} : encoding<transform>
   // ERROR@+1: ENCODING/020 {op_name="vector.transform", pass_name="vector-to-scalar"}
   %r = vector.transform %v, %xf : vector<2xf32>, encoding<transform> -> vector<2xf32>

--- a/runtime/build_tools/presubmit.py
+++ b/runtime/build_tools/presubmit.py
@@ -40,20 +40,7 @@ BAZEL_TEST_EXCLUDES = ("-//runtime/src/iree/hal/local/elf:elf_module_test",)
 
 def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run runtime project presubmit.")
-    mutation = parser.add_mutually_exclusive_group()
-    mutation.add_argument("--fix", action="store_true", help="Accepted for symmetry.")
-    mutation.add_argument("--check", action="store_true", help="Accepted for symmetry.")
-    parser.add_argument(
-        "--lane",
-        choices=("bazel", "cmake"),
-        default="bazel",
-        help="Build-system lane used for tests. Defaults to bazel.",
-    )
-    parser.add_argument("--tests", action="store_true", help="Run runtime tests.")
-    parser.add_argument(
-        "--files-from",
-        help="Path to a newline-separated repo-relative changed-file list.",
-    )
+    project_presubmit.add_common_arguments(parser, project_name=PROJECT_NAME)
     return parser.parse_args()
 
 


### PR DESCRIPTION
Loom source now treats constant SSA names as preserved program information: constants use role names such as `%batch_size` when the source knows why a value exists, and `%c512` when the literal is the only meaning. The repository-wide cleanup removes English-number spellings such as `%fivehundredtwelve`, which were awkward to read and highly copyable from reference and test sources.

## Naming contract

Literal equality does not erase semantic identity. Equal-valued constants may remain separate as `%channels_per_group` and `%lane_partition_width` when they carry different information; a bare `%c16` is reserved for cases where the literal itself is the useful name. This follows the same readability standard that makes `int fivehundredtwelve = 512;` unreasonable in C.

The source linter recognizes concatenated and underscored English numerals, signed aliases, plurals, and type, domain, unit, or duplicate decorations that do not make a literal semantic. Names such as `%zero_point`, `%two_pi`, `%nonzero`, and `%all_bits_set` remain legal because the numeric vocabulary participates in a real program concept rather than restating the constant value.

## Enforcement

Constant naming is checked across all 610 tracked `.loom` and `.loom-test` files. Loom-test scanning follows the runner's ownership boundaries: authored input is checked, exact `// ----` expected-output regions are ignored, and the next `// ====` case separator resumes authored input. Self-tests cover standalone sources, multi-case fixtures, exact diagnostic locations, accepted semantic and `%c<literal>` forms, and rejected decorated or plural aliases.

The lint implementation and project policy live under `loom/build_tools`. Generic repository presubmit dispatch invokes each affected project's hygiene phase even when CI schedules project tests separately, so the naming rule remains enforced without embedding Loom commands or source-layout knowledge in root policy.

The existing target-execution guardrail is also aligned with Loom's target-owned qualification architecture. It now detects dependencies on execution internals, private execution stacks, and forbidden C includes by content instead of rejecting qualification packages merely because their path contains `execution`.

## Repository cleanup

Standalone programs, checked benchmarks, target qualification sources, transform fixtures, and diagnostic corpora now use semantic role names wherever the source establishes one. Literal-focused tests use compact `%c<literal>` spellings with suffixes only where disambiguation is required. Runner-owned `.loom-test` expectations were regenerated from the renamed authored inputs rather than exempted from the new contract.

## Kernel ABI invariant

Removing redundant authoring assertions exposed that async endpoint verification lost the kernel ABI's global memory-space fact after a `FactIdentity` refinement such as `buffer.assume.noalias`. The verifier now classifies kernel block arguments from the region contract and follows matching identity result/operand pairs. Ordinary `func.def` buffer arguments remain unknown unless explicitly refined, preserving the external verification boundary while making the kernel invariant durable.

## Reviewer Notes

- The highest-value naming review surface is the numeral recognizer and its distinction between decorated literals and semantic continuations.
- The `.loom-test` boundary scanner must exclude only runner-owned expectations and resume at every authored case separator.
- The presubmit boundary keeps Loom-specific commands under `loom/build_tools`; root infrastructure only dispatches generic project phases.
- The verifier change should preserve memory-space facts only through declared `FactIdentity` pairs and the kernel region ABI contract.
