### PR TITLE
[CI] Route CPU workloads to Azure runners

### DIFF
--- a/.github/workflows/build_core_linux.yml
+++ b/.github/workflows/build_core_linux.yml
@@ -64,7 +64,7 @@ permissions:
 jobs:
   build_core_linux:
     name: ${{ inputs.name }}
-    runs-on: aws-linux-scale-rocm-prod
+    runs-on: azure-linux-scale-rocm
     timeout-minutes: 30
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421

--- a/.github/workflows/ci_importers.yml
+++ b/.github/workflows/ci_importers.yml
@@ -50,7 +50,7 @@ permissions:
 jobs:
   linux_importer:
     name: ${{ matrix.name }}
-    runs-on: aws-linux-scale-rocm-prod
+    runs-on: azure-linux-scale-rocm
     timeout-minutes: 45
     container:
       image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98

--- a/.github/workflows/ci_iree_bazel.yml
+++ b/.github/workflows/ci_iree_bazel.yml
@@ -62,7 +62,7 @@ permissions:
 jobs:
   linux_bazel_cpu:
     name: ${{ matrix.name }}
-    runs-on: aws-linux-scale-rocm-prod
+    runs-on: azure-linux-scale-rocm
     timeout-minutes: 45
     container:
       image: ${{ matrix.container_image }}

--- a/.github/workflows/ci_iree_cmake.yml
+++ b/.github/workflows/ci_iree_cmake.yml
@@ -56,7 +56,7 @@ permissions:
 jobs:
   linux_cmake_cpu:
     name: ${{ matrix.name }}
-    runs-on: aws-linux-scale-rocm-prod
+    runs-on: azure-linux-scale-rocm
     timeout-minutes: 45
     container:
       image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98

--- a/.github/workflows/ci_libhrx_bazel.yml
+++ b/.github/workflows/ci_libhrx_bazel.yml
@@ -56,7 +56,7 @@ permissions:
 jobs:
   linux_amdgpu_build_host_tests:
     name: Linux / AMDGPU Build + Host Tests
-    runs-on: aws-linux-scale-rocm-prod
+    runs-on: azure-linux-scale-rocm
     timeout-minutes: 45
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   presubmit:
     name: Linux / Presubmit
-    runs-on: aws-linux-scale-rocm-prod
+    runs-on: azure-linux-scale-rocm
     timeout-minutes: 45
     container:
       image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421


### PR DESCRIPTION
CPU-only Linux CI now runs on azure-linux-scale-rocm, the scale pool used by current ROCm Systems Linux package builds and rocJITsu corpus jobs. The existing AWS pool has become the dominant latency in HRX CI: recent jobs waited 9–40+ minutes for a runner while executing in roughly 2–3 minutes after allocation. In the triggering run, GPU jobs acquired hardware in 12–23 seconds, one AWS CPU job waited 22 minutes, and five remained queued past 40 minutes.

This moves the importer, IREE Bazel and CMake, libhrx host-test, presubmit, and reusable core-build jobs together so every CPU-only workflow has consistent capacity routing. Containers, commands, timeouts, caches, and GPU-specific labels are unchanged.
