### PR TITLE
[Loom/HRX] Tighten launch-path ownership

### DIFF
--- a/libhrx/src/libhrx/graph_buffer_test.cc
+++ b/libhrx/src/libhrx/graph_buffer_test.cc
@@ -114,6 +114,36 @@ TEST_F(GraphBufferTest, DependentFillThenCopyProducesExpectedContents) {
   hrx_graph_release(graph);
 }
 
+TEST_F(GraphBufferTest, LaunchFlushesPendingStreamWorkBeforeGraphCommands) {
+  const uint8_t pattern = 0x5Au;
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_stream_fill_buffer(
+      stream_, source_, 0, 64, &pattern, sizeof(pattern))));
+
+  hrx_graph_t graph = nullptr;
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_graph_create(device_, 0, &graph)));
+  const hrx_graph_copy_buffer_node_attrs_t copy_attrs = {
+      /*.src=*/{source_, 0, 64},
+      /*.dst=*/{destination_, 0, 64},
+  };
+  IREE_ASSERT_OK(hrx_status_to_iree(
+      hrx_graph_add_copy_buffer_node(graph, nullptr, 0, &copy_attrs, nullptr)));
+
+  hrx_graph_exec_t executable = nullptr;
+  IREE_ASSERT_OK(
+      hrx_status_to_iree(hrx_graph_instantiate(graph, 0, &executable)));
+  IREE_ASSERT_OK(
+      hrx_status_to_iree(hrx_graph_exec_launch(executable, stream_)));
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_stream_synchronize(stream_)));
+
+  uint8_t contents[64] = {};
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_synchronous_d2h(
+      device_, destination_, 0, contents, sizeof(contents))));
+  for (uint8_t value : contents) EXPECT_EQ(value, pattern);
+
+  hrx_graph_exec_release(executable);
+  hrx_graph_release(graph);
+}
+
 TEST_F(GraphBufferTest, AddedDependencyOrdersFillBeforeCopy) {
   hrx_graph_t graph = nullptr;
   IREE_ASSERT_OK(hrx_status_to_iree(hrx_graph_create(device_, 0, &graph)));

--- a/libhrx/src/libhrx/graph_exec.c
+++ b/libhrx/src/libhrx/graph_exec.c
@@ -536,38 +536,22 @@ hrx_status_t hrx_graph_exec_launch(hrx_graph_exec_t exec, hrx_stream_t stream) {
   }
 
   // Flush pending stream work before graph launch.
-  if (stream->has_pending_work) {
-    HRX_RETURN_AND_END_ZONE_IF_IREE_ERROR(
-        z0, iree_hal_command_buffer_end(stream->pending_cb));
-    iree_hal_semaphore_list_t wait_list = {
-        .count = 1,
-        .semaphores = &stream->semaphore->hal_semaphore,
-        .payload_values = &stream->timepoint,
-    };
-    uint64_t next_value = stream->timepoint + 1;
-    iree_hal_semaphore_list_t signal_list = {
-        .count = 1,
-        .semaphores = &stream->semaphore->hal_semaphore,
-        .payload_values = &next_value,
-    };
-    HRX_RETURN_AND_END_ZONE_IF_IREE_ERROR(
-        z0,
-        iree_hal_device_queue_execute(
-            stream->device->hal_device, IREE_HAL_QUEUE_AFFINITY_ANY, wait_list,
-            signal_list, stream->pending_cb,
-            iree_hal_buffer_binding_table_empty(), IREE_HAL_EXECUTE_FLAG_NONE));
-    stream->timepoint = next_value;
-    stream->has_pending_work = false;
-    stream->pending_cb = NULL;
+  hrx_status_t flush_status = hrx_stream_flush(stream);
+  if (!hrx_status_is_ok(flush_status)) {
+    HRX_RETURN_AND_END_ZONE(z0, flush_status);
   }
 
-  for (uint32_t i = 0; i < exec->semaphore_count; i++) {
-    HRX_RETURN_AND_END_ZONE_IF_IREE_ERROR(
-        z0, iree_hal_semaphore_query(exec->semaphores[i],
-                                     &exec->semaphore_base_values[i]));
-  }
-
+  // Multiple threads may launch the same executable. Serialize the semaphore
+  // query and advancement as one transaction so each launch observes the
+  // timeline values committed by the preceding launch.
   iree_slim_mutex_lock(&exec->mutex);
+
+  iree_status_t status = iree_ok_status();
+  for (uint32_t i = 0; iree_status_is_ok(status) && i < exec->semaphore_count;
+       i++) {
+    status = iree_hal_semaphore_query(exec->semaphores[i],
+                                      &exec->semaphore_base_values[i]);
+  }
 
   uint64_t stream_wait_value = stream->timepoint;
   uint64_t stream_signal_value = stream->timepoint + 1;
@@ -580,7 +564,6 @@ hrx_status_t hrx_graph_exec_launch(hrx_graph_exec_t exec, hrx_stream_t stream) {
     memcpy(new_base_values, exec->semaphore_base_values, base_values_size);
   }
 
-  iree_status_t status = iree_ok_status();
   iree_hal_device_t* hal_device = exec->device->hal_device;
   for (uint32_t block_index = 0;
        iree_status_is_ok(status) && block_index < exec->block_count;

--- a/loom/binding/c/src/launch_config.c
+++ b/loom/binding/c/src/launch_config.c
@@ -108,13 +108,12 @@ loomc_launch_config_field_flags_from_kernel(
   return public_fields;
 }
 
-static bool loomc_launch_config_options_have_specialization(
+static bool loomc_launch_config_options_require_module_clone(
     const loomc_launch_config_resolved_options_t* options) {
   const loomc_config_options_t* config = options->config;
-  return options->workload_argument_count != 0 ||
-         (config != NULL && (config->binding_count != 0 ||
-                             !loomc_string_view_is_empty(config->json_object) ||
-                             config->flags != 0));
+  return config != NULL && (config->binding_count != 0 ||
+                            !loomc_string_view_is_empty(config->json_object) ||
+                            config->flags != 0);
 }
 
 static loomc_status_t loomc_launch_config_validate_result(
@@ -332,8 +331,10 @@ loomc_status_t loomc_module_evaluate_launch_config(
 
   const loom_module_t* source_internal_module =
       loomc_module_const_loom_module(module);
-  if (source_internal_module != NULL &&
-      !loomc_launch_config_options_have_specialization(&resolved_options)) {
+  const bool requires_module_clone =
+      loomc_launch_config_options_require_module_clone(&resolved_options);
+  if (source_internal_module != NULL && !requires_module_clone &&
+      resolved_options.workload_argument_count == 0) {
     bool direct_evaluated = false;
     loom_kernel_launch_config_t kernel_config = {0};
     const loom_kernel_launch_config_options_t kernel_options =
@@ -355,15 +356,18 @@ loomc_status_t loomc_module_evaluate_launch_config(
   }
 
   loomc_module_t* scratch_module = NULL;
-  loomc_status_t status =
-      loomc_module_clone(module, workspace, allocator, &scratch_module);
-  loom_module_t* internal_module =
-      loomc_status_is_ok(status) ? loomc_module_loom_module(scratch_module)
-                                 : NULL;
-  if (loomc_status_is_ok(status)) {
+  loomc_status_t status = loomc_ok_status();
+  const loom_module_t* internal_module = source_internal_module;
+  if (internal_module == NULL || requires_module_clone) {
+    status = loomc_module_clone(module, workspace, allocator, &scratch_module);
+    internal_module = loomc_status_is_ok(status)
+                          ? loomc_module_const_loom_module(scratch_module)
+                          : NULL;
+  }
+  if (loomc_status_is_ok(status) && scratch_module != NULL) {
     const loomc_config_apply_to_module_options_t config_options = {
         .config = resolved_options.config,
-        .module = internal_module,
+        .module = loomc_module_loom_module(scratch_module),
         .result = result,
         .diagnostic_code = loomc_make_cstring_view("CONFIG/INVALID"),
         .block_pool = loomc_workspace_block_pool(workspace),

--- a/loom/src/loom/analysis/kernel_launch_config.c
+++ b/loom/src/loom/analysis/kernel_launch_config.c
@@ -249,7 +249,7 @@ iree_status_t loom_kernel_launch_config_try_evaluate_direct(
 }
 
 iree_status_t loom_kernel_launch_config_evaluate(
-    loom_module_t* module, iree_arena_block_pool_t* block_pool,
+    const loom_module_t* module, iree_arena_block_pool_t* block_pool,
     const loom_kernel_launch_config_options_t* options,
     loom_kernel_launch_config_t* out_config) {
   if (!module || !block_pool || !options || !out_config) {

--- a/loom/src/loom/analysis/kernel_launch_config.h
+++ b/loom/src/loom/analysis/kernel_launch_config.h
@@ -128,7 +128,7 @@ iree_status_t loom_kernel_launch_config_try_evaluate_direct(
     loom_kernel_launch_config_t* out_config, bool* out_evaluated);
 
 iree_status_t loom_kernel_launch_config_evaluate(
-    loom_module_t* module, iree_arena_block_pool_t* block_pool,
+    const loom_module_t* module, iree_arena_block_pool_t* block_pool,
     const loom_kernel_launch_config_options_t* options,
     loom_kernel_launch_config_t* out_config);
 

--- a/loom/src/loom/pass/value_facts.c
+++ b/loom/src/loom/pass/value_facts.c
@@ -56,7 +56,7 @@ static iree_status_t loom_pass_value_fact_scope_validate(
 }
 
 static iree_status_t loom_pass_value_fact_owner_ensure_table(
-    loom_pass_value_fact_owner_t* owner, loom_module_t* module) {
+    loom_pass_value_fact_owner_t* owner, const loom_module_t* module) {
   iree_host_size_t capacity = loom_value_table_capacity(&module->values);
   if (iree_any_bit_set(owner->flags,
                        LOOM_PASS_VALUE_FACT_OWNER_FLAG_TABLE_INITIALIZED) &&
@@ -77,7 +77,7 @@ static iree_status_t loom_pass_value_fact_owner_ensure_table(
 }
 
 static iree_status_t loom_pass_value_fact_owner_compute_module(
-    loom_pass_value_fact_owner_t* owner, loom_module_t* module) {
+    loom_pass_value_fact_owner_t* owner, const loom_module_t* module) {
   for (iree_host_size_t i = 0; i < module->symbols.count; ++i) {
     loom_symbol_t* symbol = &module->symbols.entries[i];
     if (!loom_symbol_implements(symbol, LOOM_SYMBOL_INTERFACE_FUNC_LIKE)) {
@@ -125,7 +125,7 @@ void loom_pass_value_fact_owner_invalidate(
 }
 
 iree_status_t loom_pass_value_fact_owner_prepare(
-    loom_pass_value_fact_owner_t* owner, loom_module_t* module,
+    loom_pass_value_fact_owner_t* owner, const loom_module_t* module,
     loom_pass_value_fact_scope_t scope, loom_value_fact_table_t** out_table) {
   *out_table = NULL;
 
@@ -138,7 +138,7 @@ iree_status_t loom_pass_value_fact_owner_prepare(
 }
 
 iree_status_t loom_pass_value_fact_owner_acquire(
-    loom_pass_value_fact_owner_t* owner, loom_module_t* module,
+    loom_pass_value_fact_owner_t* owner, const loom_module_t* module,
     loom_pass_value_fact_scope_t scope, loom_value_fact_table_t** out_table) {
   *out_table = NULL;
 

--- a/loom/src/loom/pass/value_facts.h
+++ b/loom/src/loom/pass/value_facts.h
@@ -118,7 +118,7 @@ struct loom_pass_value_fact_owner_t {
   // Arena for scope-local extension payloads and inference scratch.
   iree_arena_allocator_t transient_arena;
   // Module whose value table is addressed by table entries.
-  loom_module_t* module;
+  const loom_module_t* module;
   // Reusable value-id-addressed fact table.
   loom_value_fact_table_t table;
   // Active populated fact scope, or NONE when table entries are not valid.
@@ -147,14 +147,14 @@ void loom_pass_value_fact_owner_invalidate(loom_pass_value_fact_owner_t* owner);
 // maintain facts while they mutate IR. If population fails, the caller must
 // invalidate the owner before returning the failure.
 iree_status_t loom_pass_value_fact_owner_prepare(
-    loom_pass_value_fact_owner_t* owner, loom_module_t* module,
+    loom_pass_value_fact_owner_t* owner, const loom_module_t* module,
     loom_pass_value_fact_scope_t scope, loom_value_fact_table_t** out_table);
 
 // Acquires computed facts for |scope|. The returned table is borrowed and
 // remains valid until the owner is invalidated, prepared or acquired for
 // another scope, or deinitialized.
 iree_status_t loom_pass_value_fact_owner_acquire(
-    loom_pass_value_fact_owner_t* owner, loom_module_t* module,
+    loom_pass_value_fact_owner_t* owner, const loom_module_t* module,
     loom_pass_value_fact_scope_t scope, loom_value_fact_table_t** out_table);
 
 // Prepares scoped fact storage through a pass invocation.


### PR DESCRIPTION
Workload launch configuration evaluation now treats dynamic workload values as temporary analysis facts over an immutable retained module. Only config materialization clones and rewrites IR, removing whole-module link work from ordinary dynamic launch evaluation and making the analysis boundary const-correct.

HRX graph launch now delegates pending command-buffer submission to the stream flush owner and serializes executable semaphore queries with timeline advancement. This closes a command-buffer lifetime leak and makes concurrent launches observe one coherent executable state transaction.

## Reviewer Notes

The two commits are independent. The Loom commit centers on the distinction between analysis inputs and IR specialization. The HRX commit centers on stream command-buffer ownership and the existing executable mutex contract.