### PR TITLE
[HRX] Serialize graph launch state updates

### DIFF
--- a/libhrx/src/libhrx/graph_buffer_test.cc
+++ b/libhrx/src/libhrx/graph_buffer_test.cc
@@ -114,6 +114,36 @@ TEST_F(GraphBufferTest, DependentFillThenCopyProducesExpectedContents) {
   hrx_graph_release(graph);
 }
 
+TEST_F(GraphBufferTest, LaunchFlushesPendingStreamWorkBeforeGraphCommands) {
+  const uint8_t pattern = 0x5Au;
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_stream_fill_buffer(
+      stream_, source_, 0, 64, &pattern, sizeof(pattern))));
+
+  hrx_graph_t graph = nullptr;
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_graph_create(device_, 0, &graph)));
+  const hrx_graph_copy_buffer_node_attrs_t copy_attrs = {
+      /*.src=*/{source_, 0, 64},
+      /*.dst=*/{destination_, 0, 64},
+  };
+  IREE_ASSERT_OK(hrx_status_to_iree(
+      hrx_graph_add_copy_buffer_node(graph, nullptr, 0, &copy_attrs, nullptr)));
+
+  hrx_graph_exec_t executable = nullptr;
+  IREE_ASSERT_OK(
+      hrx_status_to_iree(hrx_graph_instantiate(graph, 0, &executable)));
+  IREE_ASSERT_OK(
+      hrx_status_to_iree(hrx_graph_exec_launch(executable, stream_)));
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_stream_synchronize(stream_)));
+
+  uint8_t contents[64] = {};
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_synchronous_d2h(
+      device_, destination_, 0, contents, sizeof(contents))));
+  for (uint8_t value : contents) EXPECT_EQ(value, pattern);
+
+  hrx_graph_exec_release(executable);
+  hrx_graph_release(graph);
+}
+
 TEST_F(GraphBufferTest, AddedDependencyOrdersFillBeforeCopy) {
   hrx_graph_t graph = nullptr;
   IREE_ASSERT_OK(hrx_status_to_iree(hrx_graph_create(device_, 0, &graph)));

--- a/libhrx/src/libhrx/graph_exec.c
+++ b/libhrx/src/libhrx/graph_exec.c
@@ -536,38 +536,22 @@ hrx_status_t hrx_graph_exec_launch(hrx_graph_exec_t exec, hrx_stream_t stream) {
   }
 
   // Flush pending stream work before graph launch.
-  if (stream->has_pending_work) {
-    HRX_RETURN_AND_END_ZONE_IF_IREE_ERROR(
-        z0, iree_hal_command_buffer_end(stream->pending_cb));
-    iree_hal_semaphore_list_t wait_list = {
-        .count = 1,
-        .semaphores = &stream->semaphore->hal_semaphore,
-        .payload_values = &stream->timepoint,
-    };
-    uint64_t next_value = stream->timepoint + 1;
-    iree_hal_semaphore_list_t signal_list = {
-        .count = 1,
-        .semaphores = &stream->semaphore->hal_semaphore,
-        .payload_values = &next_value,
-    };
-    HRX_RETURN_AND_END_ZONE_IF_IREE_ERROR(
-        z0,
-        iree_hal_device_queue_execute(
-            stream->device->hal_device, IREE_HAL_QUEUE_AFFINITY_ANY, wait_list,
-            signal_list, stream->pending_cb,
-            iree_hal_buffer_binding_table_empty(), IREE_HAL_EXECUTE_FLAG_NONE));
-    stream->timepoint = next_value;
-    stream->has_pending_work = false;
-    stream->pending_cb = NULL;
+  hrx_status_t flush_status = hrx_stream_flush(stream);
+  if (!hrx_status_is_ok(flush_status)) {
+    HRX_RETURN_AND_END_ZONE(z0, flush_status);
   }
 
-  for (uint32_t i = 0; i < exec->semaphore_count; i++) {
-    HRX_RETURN_AND_END_ZONE_IF_IREE_ERROR(
-        z0, iree_hal_semaphore_query(exec->semaphores[i],
-                                     &exec->semaphore_base_values[i]));
-  }
-
+  // Multiple threads may launch the same executable. Serialize the semaphore
+  // query and advancement as one transaction so each launch observes the
+  // timeline values committed by the preceding launch.
   iree_slim_mutex_lock(&exec->mutex);
+
+  iree_status_t status = iree_ok_status();
+  for (uint32_t i = 0; iree_status_is_ok(status) && i < exec->semaphore_count;
+       i++) {
+    status = iree_hal_semaphore_query(exec->semaphores[i],
+                                      &exec->semaphore_base_values[i]);
+  }
 
   uint64_t stream_wait_value = stream->timepoint;
   uint64_t stream_signal_value = stream->timepoint + 1;
@@ -580,7 +564,6 @@ hrx_status_t hrx_graph_exec_launch(hrx_graph_exec_t exec, hrx_stream_t stream) {
     memcpy(new_base_values, exec->semaphore_base_values, base_values_size);
   }
 
-  iree_status_t status = iree_ok_status();
   iree_hal_device_t* hal_device = exec->device->hal_device;
   for (uint32_t block_index = 0;
        iree_status_is_ok(status) && block_index < exec->block_count;


### PR DESCRIPTION
Graph launch duplicated the stream flush path, bypassing the established command-buffer ownership lifecycle and dropping the submitted pending command buffer without releasing it. Executable semaphore state was also queried before acquiring the mutex that protects launch advancement, allowing concurrent launches to observe and update different timeline snapshots.

Route pending stream work through the stream-owned flush operation and hold the executable mutex across semaphore queries, command submission, and timeline advancement. Each launch now observes one coherent executable state transaction while command-buffer ownership remains on the common stream path.