### PR TITLE
[Loom] Evaluate workload launches without cloning modules

### DIFF
--- a/loom/binding/c/src/launch_config.c
+++ b/loom/binding/c/src/launch_config.c
@@ -108,13 +108,12 @@ loomc_launch_config_field_flags_from_kernel(
   return public_fields;
 }
 
-static bool loomc_launch_config_options_have_specialization(
+static bool loomc_launch_config_options_require_module_clone(
     const loomc_launch_config_resolved_options_t* options) {
   const loomc_config_options_t* config = options->config;
-  return options->workload_argument_count != 0 ||
-         (config != NULL && (config->binding_count != 0 ||
-                             !loomc_string_view_is_empty(config->json_object) ||
-                             config->flags != 0));
+  return config != NULL && (config->binding_count != 0 ||
+                            !loomc_string_view_is_empty(config->json_object) ||
+                            config->flags != 0);
 }
 
 static loomc_status_t loomc_launch_config_validate_result(
@@ -332,8 +331,10 @@ loomc_status_t loomc_module_evaluate_launch_config(
 
   const loom_module_t* source_internal_module =
       loomc_module_const_loom_module(module);
-  if (source_internal_module != NULL &&
-      !loomc_launch_config_options_have_specialization(&resolved_options)) {
+  const bool requires_module_clone =
+      loomc_launch_config_options_require_module_clone(&resolved_options);
+  if (source_internal_module != NULL && !requires_module_clone &&
+      resolved_options.workload_argument_count == 0) {
     bool direct_evaluated = false;
     loom_kernel_launch_config_t kernel_config = {0};
     const loom_kernel_launch_config_options_t kernel_options =
@@ -355,15 +356,18 @@ loomc_status_t loomc_module_evaluate_launch_config(
   }
 
   loomc_module_t* scratch_module = NULL;
-  loomc_status_t status =
-      loomc_module_clone(module, workspace, allocator, &scratch_module);
-  loom_module_t* internal_module =
-      loomc_status_is_ok(status) ? loomc_module_loom_module(scratch_module)
-                                 : NULL;
-  if (loomc_status_is_ok(status)) {
+  loomc_status_t status = loomc_ok_status();
+  const loom_module_t* internal_module = source_internal_module;
+  if (internal_module == NULL || requires_module_clone) {
+    status = loomc_module_clone(module, workspace, allocator, &scratch_module);
+    internal_module = loomc_status_is_ok(status)
+                          ? loomc_module_const_loom_module(scratch_module)
+                          : NULL;
+  }
+  if (loomc_status_is_ok(status) && scratch_module != NULL) {
     const loomc_config_apply_to_module_options_t config_options = {
         .config = resolved_options.config,
-        .module = internal_module,
+        .module = loomc_module_loom_module(scratch_module),
         .result = result,
         .diagnostic_code = loomc_make_cstring_view("CONFIG/INVALID"),
         .block_pool = loomc_workspace_block_pool(workspace),

--- a/loom/src/loom/analysis/kernel_launch_config.c
+++ b/loom/src/loom/analysis/kernel_launch_config.c
@@ -249,7 +249,7 @@ iree_status_t loom_kernel_launch_config_try_evaluate_direct(
 }
 
 iree_status_t loom_kernel_launch_config_evaluate(
-    loom_module_t* module, iree_arena_block_pool_t* block_pool,
+    const loom_module_t* module, iree_arena_block_pool_t* block_pool,
     const loom_kernel_launch_config_options_t* options,
     loom_kernel_launch_config_t* out_config) {
   if (!module || !block_pool || !options || !out_config) {

--- a/loom/src/loom/analysis/kernel_launch_config.h
+++ b/loom/src/loom/analysis/kernel_launch_config.h
@@ -128,7 +128,7 @@ iree_status_t loom_kernel_launch_config_try_evaluate_direct(
     loom_kernel_launch_config_t* out_config, bool* out_evaluated);
 
 iree_status_t loom_kernel_launch_config_evaluate(
-    loom_module_t* module, iree_arena_block_pool_t* block_pool,
+    const loom_module_t* module, iree_arena_block_pool_t* block_pool,
     const loom_kernel_launch_config_options_t* options,
     loom_kernel_launch_config_t* out_config);
 

--- a/loom/src/loom/pass/value_facts.c
+++ b/loom/src/loom/pass/value_facts.c
@@ -56,7 +56,7 @@ static iree_status_t loom_pass_value_fact_scope_validate(
 }
 
 static iree_status_t loom_pass_value_fact_owner_ensure_table(
-    loom_pass_value_fact_owner_t* owner, loom_module_t* module) {
+    loom_pass_value_fact_owner_t* owner, const loom_module_t* module) {
   iree_host_size_t capacity = loom_value_table_capacity(&module->values);
   if (iree_any_bit_set(owner->flags,
                        LOOM_PASS_VALUE_FACT_OWNER_FLAG_TABLE_INITIALIZED) &&
@@ -77,7 +77,7 @@ static iree_status_t loom_pass_value_fact_owner_ensure_table(
 }
 
 static iree_status_t loom_pass_value_fact_owner_compute_module(
-    loom_pass_value_fact_owner_t* owner, loom_module_t* module) {
+    loom_pass_value_fact_owner_t* owner, const loom_module_t* module) {
   for (iree_host_size_t i = 0; i < module->symbols.count; ++i) {
     loom_symbol_t* symbol = &module->symbols.entries[i];
     if (!loom_symbol_implements(symbol, LOOM_SYMBOL_INTERFACE_FUNC_LIKE)) {
@@ -125,7 +125,7 @@ void loom_pass_value_fact_owner_invalidate(
 }
 
 iree_status_t loom_pass_value_fact_owner_prepare(
-    loom_pass_value_fact_owner_t* owner, loom_module_t* module,
+    loom_pass_value_fact_owner_t* owner, const loom_module_t* module,
     loom_pass_value_fact_scope_t scope, loom_value_fact_table_t** out_table) {
   *out_table = NULL;
 
@@ -138,7 +138,7 @@ iree_status_t loom_pass_value_fact_owner_prepare(
 }
 
 iree_status_t loom_pass_value_fact_owner_acquire(
-    loom_pass_value_fact_owner_t* owner, loom_module_t* module,
+    loom_pass_value_fact_owner_t* owner, const loom_module_t* module,
     loom_pass_value_fact_scope_t scope, loom_value_fact_table_t** out_table) {
   *out_table = NULL;
 

--- a/loom/src/loom/pass/value_facts.h
+++ b/loom/src/loom/pass/value_facts.h
@@ -118,7 +118,7 @@ struct loom_pass_value_fact_owner_t {
   // Arena for scope-local extension payloads and inference scratch.
   iree_arena_allocator_t transient_arena;
   // Module whose value table is addressed by table entries.
-  loom_module_t* module;
+  const loom_module_t* module;
   // Reusable value-id-addressed fact table.
   loom_value_fact_table_t table;
   // Active populated fact scope, or NONE when table entries are not valid.
@@ -147,14 +147,14 @@ void loom_pass_value_fact_owner_invalidate(loom_pass_value_fact_owner_t* owner);
 // maintain facts while they mutate IR. If population fails, the caller must
 // invalidate the owner before returning the failure.
 iree_status_t loom_pass_value_fact_owner_prepare(
-    loom_pass_value_fact_owner_t* owner, loom_module_t* module,
+    loom_pass_value_fact_owner_t* owner, const loom_module_t* module,
     loom_pass_value_fact_scope_t scope, loom_value_fact_table_t** out_table);
 
 // Acquires computed facts for |scope|. The returned table is borrowed and
 // remains valid until the owner is invalidated, prepared or acquired for
 // another scope, or deinitialized.
 iree_status_t loom_pass_value_fact_owner_acquire(
-    loom_pass_value_fact_owner_t* owner, loom_module_t* module,
+    loom_pass_value_fact_owner_t* owner, const loom_module_t* module,
     loom_pass_value_fact_scope_t scope, loom_value_fact_table_t** out_table);
 
 // Prepares scoped fact storage through a pass invocation.


### PR DESCRIPTION
Launch-config evaluation classified concrete workload arguments as module specialization and cloned the entire source module before seeding invocation facts. Workload values do not rewrite IR, so repeated dynamic launch evaluation paid for an unnecessary clone and obscured the boundary between analysis and specialization.

Separate clone requirements from workload evaluation. Config bindings, JSON materialization, and config policies continue to operate on a scratch clone, while workload-only evaluation derives launch geometry directly from the retained immutable module. The zero-workload direct path remains unchanged.

Make the kernel launch evaluator and reusable value-fact owner accept immutable modules so the analysis contract is explicit throughout the call chain. Dynamic launch values remain temporary facts scoped to one evaluation and cannot mutate retained compiler state.