### PR TITLE
[Loom] Summarize facts across region branches

### DIFF
--- a/loom/src/loom/ops/low/test/facts.loom-test
+++ b/loom/src/loom/ops/low/test/facts.loom-test
@@ -124,6 +124,100 @@ low.kernel.def target<test.low.core>(@target) @low_storage_select_same_backing()
 
 // ====
 
+// RegionBranch summaries use the result type's fact domain, preserving shared
+// storage identity while meeting the offsets yielded by both branch regions.
+test.target<low_core> @target
+
+low.kernel.def target<test.low.core>(@target) @low_storage_if_same_backing() {
+  %condition_seed = scalar.constant true : i1
+  %cond = test.convergent %condition_seed : i1
+  %storage = low.storage.reserve {byte_alignment = 64, byte_length = 256} : low.storage<workgroup>
+  %a = low.storage.view %storage {offset = 16, byte_length = 32} : low.storage<workgroup> -> low.storage<workgroup>
+  %b = low.storage.view %storage {offset = 32, byte_length = 32} : low.storage<workgroup> -> low.storage<workgroup>
+  %selected = scf.if %cond -> (low.storage<workgroup>) {
+    test.use %a : low.storage<workgroup>
+    scf.yield %a : low.storage<workgroup>
+  } else {
+    test.use %b : low.storage<workgroup>
+    scf.yield %b : low.storage<workgroup>
+  }
+  %same = test.fact_storage_same_backing %selected, %storage : low.storage<workgroup>, low.storage<workgroup> -> i1
+  %offset_lo = test.fact_storage_byte_offset_lo %selected : low.storage<workgroup> -> i64
+  %offset_hi = test.fact_storage_byte_offset_hi %selected : low.storage<workgroup> -> i64
+  %offset_div = test.fact_storage_byte_offset_divisor %selected : low.storage<workgroup> -> i64
+  %alignment = test.fact_storage_min_alignment %selected : low.storage<workgroup> -> i64
+  test.use %same, %offset_lo, %offset_hi, %offset_div, %alignment : i1, i64, i64, i64, i64
+  low.return
+}
+
+// ----
+test.target<low_core> @target
+
+low.kernel.def target<test.low.core>(@target) @low_storage_if_same_backing() {
+  %condition_seed = scalar.constant true : i1
+  %cond = test.convergent %condition_seed : i1
+  %storage = low.storage.reserve {byte_alignment = 64, byte_length = 256} : low.storage<workgroup>
+  %a = low.storage.view %storage {byte_length = 32, offset = 16} : low.storage<workgroup> -> low.storage<workgroup>
+  %b = low.storage.view %storage {byte_length = 32, offset = 32} : low.storage<workgroup> -> low.storage<workgroup>
+  scf.if %cond {
+    test.use %a : low.storage<workgroup>
+  } else {
+    test.use %b : low.storage<workgroup>
+  }
+  %same = scalar.constant true : i1
+  %offset_lo = scalar.constant 16 : i64
+  %offset_hi = scalar.constant 32 : i64
+  %offset_div = scalar.constant 16 : i64
+  %alignment = scalar.constant 16 : i64
+  test.use %same, %offset_lo, %offset_hi, %offset_div, %alignment : i1, i64, i64, i64, i64
+  low.return
+}
+
+// ====
+
+// Type-owned RegionBranch joins discard a storage-reference payload when the
+// yielded values have different backing allocations.
+test.target<low_core> @target
+
+low.kernel.def target<test.low.core>(@target) @low_storage_if_different_backing() {
+  %condition_seed = scalar.constant true : i1
+  %cond = test.convergent %condition_seed : i1
+  %lhs = low.storage.reserve {byte_alignment = 64, byte_length = 128} : low.storage<private>
+  %rhs = low.storage.reserve {byte_alignment = 64, byte_length = 128} : low.storage<private>
+  %selected = scf.if %cond -> (low.storage<private>) {
+    test.use %lhs : low.storage<private>
+    scf.yield %lhs : low.storage<private>
+  } else {
+    test.use %rhs : low.storage<private>
+    scf.yield %rhs : low.storage<private>
+  }
+  %is = test.fact_is_storage_reference %selected : low.storage<private> -> i1
+  %offset_lo = test.fact_storage_byte_offset_lo %selected : low.storage<private> -> i64
+  test.use %is, %offset_lo : i1, i64
+  low.return
+}
+
+// ----
+test.target<low_core> @target
+
+low.kernel.def target<test.low.core>(@target) @low_storage_if_different_backing() {
+  %condition_seed = scalar.constant true : i1
+  %cond = test.convergent %condition_seed : i1
+  %lhs = low.storage.reserve {byte_alignment = 64, byte_length = 128} : low.storage<private>
+  %rhs = low.storage.reserve {byte_alignment = 64, byte_length = 128} : low.storage<private>
+  scf.if %cond {
+    test.use %lhs : low.storage<private>
+  } else {
+    test.use %rhs : low.storage<private>
+  }
+  %is = scalar.constant false : i1
+  %offset_lo = scalar.constant -9223372036854775808 : i64
+  test.use %is, %offset_lo : i1, i64
+  low.return
+}
+
+// ====
+
 test.target<low_core> @target
 
 low.kernel.def target<test.low.core>(@target) @low_storage_select_different_backing() {

--- a/loom/src/loom/ops/op_defs.c
+++ b/loom/src/loom/ops/op_defs.c
@@ -3062,7 +3062,9 @@ iree_status_t loom_builder_finalize_op(loom_builder_t* builder, loom_op_t* op) {
     loom_module_link_symbol_defining_op(builder->module, op, vtable);
   }
   loom_module_record_op_effects(builder->module, op);
-  // Notify the rewriter (or other listener) that a fully-wired op exists.
+  // Notify the rewriter (or other listener) that the op's direct fields are
+  // fully wired. Callers may populate nested regions after their parent
+  // builder returns.
   if (builder->on_op_finalized.fn) {
     IREE_RETURN_IF_ERROR(
         builder->on_op_finalized.fn(builder->on_op_finalized.user_data, op));

--- a/loom/src/loom/ops/op_defs.h
+++ b/loom/src/loom/ops/op_defs.h
@@ -1959,8 +1959,10 @@ typedef struct loom_builder_ip_t {
   loom_op_t* before_op;
 } loom_builder_ip_t;
 
-// Callback invoked when an op is fully constructed (after finalize_op).
-// Used by the rewriter to add newly created ops to its worklist.
+// Callback invoked after an op's direct fields are finalized. Region-owning op
+// builders create their regions before invoking this callback, but callers may
+// populate those regions afterward. Used by the rewriter to add newly created
+// ops to its worklist.
 typedef iree_status_t (*loom_builder_op_fn_t)(void* user_data, loom_op_t* op);
 typedef struct loom_builder_callback_t {
   loom_builder_op_fn_t fn;
@@ -1979,8 +1981,9 @@ typedef struct loom_builder_callback_t {
 // control storage lifetime: linking into a fresh arena, per-thread
 // arenas during parallel compilation, etc.
 //
-// The optional on_op_finalized callback fires after finalize_op
-// completes (uses registered, def pointers set). NULL when unused.
+// The optional on_op_finalized callback fires after finalize_op completes
+// (uses registered, def pointers set). Nested regions may still be empty at
+// this point. NULL when unused.
 typedef struct loom_builder_t {
   loom_module_t* module;
   iree_arena_allocator_t* arena;

--- a/loom/src/loom/ops/scf/test/facts.loom-test
+++ b/loom/src/loom/ops/scf/test/facts.loom-test
@@ -353,6 +353,229 @@ func.def @while_unchanged_carried_result(%keep_going: i1) -> (i64) {
 
 // ====
 
+// RegionBranch results meet the corresponding yielded facts after analyzing
+// every branch body. Side effects keep the conditional structured so this
+// exercises the branch summary instead of select canonicalization.
+func.def @if_result_meets_yielded_facts(%condition: i1) -> (i64, i64, i64) {
+  %c4 = scalar.constant 4 : i64
+  %c12 = scalar.constant 12 : i64
+  %result = scf.if %condition -> (i64) {
+    test.use %c4 : i64
+    scf.yield %c4 : i64
+  } else {
+    test.use %c12 : i64
+    scf.yield %c12 : i64
+  }
+  %result_lo = test.fact_range_lo %result : i64 -> i64
+  %result_hi = test.fact_range_hi %result : i64 -> i64
+  %result_div = test.fact_divisor %result : i64 -> i64
+  func.return %result_lo, %result_hi, %result_div : i64, i64, i64
+}
+
+// ----
+func.def @if_result_meets_yielded_facts(%condition: i1) -> (i64, i64, i64) {
+  %c4 = scalar.constant 4 : i64
+  %c12 = scalar.constant 12 : i64
+  scf.if %condition {
+    test.use %c4 : i64
+  } else {
+    test.use %c12 : i64
+  }
+  %result_lo = scalar.constant 4 : i64
+  %result_hi = scalar.constant 12 : i64
+  %result_div = scalar.constant 4 : i64
+  func.return %result_lo, %result_hi, %result_div : i64, i64, i64
+}
+
+// ====
+
+// The same generic RegionBranch summary covers every case and the default of a
+// multi-way switch.
+func.def @switch_result_meets_all_regions(%variant: index) -> (i64, i64, i64) {
+  %c8 = scalar.constant 8 : i64
+  %c12 = scalar.constant 12 : i64
+  %c20 = scalar.constant 20 : i64
+  %result = scf.switch %variant -> (i64) {
+    case 0 {
+      test.use %c8 : i64
+      scf.yield %c8 : i64
+    }
+    case 1 {
+      test.use %c12 : i64
+      scf.yield %c12 : i64
+    }
+    default {
+      test.use %c20 : i64
+      scf.yield %c20 : i64
+    }
+  }
+  %result_lo = test.fact_range_lo %result : i64 -> i64
+  %result_hi = test.fact_range_hi %result : i64 -> i64
+  %result_div = test.fact_divisor %result : i64 -> i64
+  func.return %result_lo, %result_hi, %result_div : i64, i64, i64
+}
+
+// ----
+func.def @switch_result_meets_all_regions(%variant: index) -> (i64, i64, i64) {
+  %c8 = scalar.constant 8 : i64
+  %c12 = scalar.constant 12 : i64
+  %c20 = scalar.constant 20 : i64
+  %result = scf.switch %variant -> (i64) {
+    case 0 {
+      test.use %c8 : i64
+      scf.yield %c8 : i64
+    }
+    case 1 {
+      test.use %c12 : i64
+      scf.yield %c12 : i64
+    }
+    default {
+      test.use %c20 : i64
+      scf.yield %c20 : i64
+    }
+  }
+  %result_lo = scalar.constant 8 : i64
+  %result_hi = scalar.constant 20 : i64
+  %result_div = scalar.constant 4 : i64
+  func.return %result_lo, %result_hi, %result_div : i64, i64, i64
+}
+
+// ====
+
+// A lane-local branch selector makes a non-exact merge of different SSA
+// values lane-varying even when each incoming value is uniform.
+kernel.def @if_lane_predicate_different_values_is_varying() {
+  %c1 = index.constant 1 : index
+  %c64 = index.constant 64 : index
+  kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
+} launch(%lhs: i32, %rhs: i32) {
+  %lane = kernel.subgroup.lane.id : index
+  %c0 = index.constant 0 : index
+  %condition = index.cmp eq, %lane, %c0 : index
+  %selected = scf.if %condition -> (i32) {
+    test.use %lhs : i32
+    scf.yield %lhs : i32
+  } else {
+    test.use %rhs : i32
+    scf.yield %rhs : i32
+  }
+  %selected_is_varying = test.fact_lane_varying %selected : i32 -> i1
+  %selected_is_uniform = test.fact_subgroup_uniform %selected : i32 -> i1
+  test.use %selected_is_varying, %selected_is_uniform : i1, i1
+  kernel.return
+}
+
+// ----
+kernel.def @if_lane_predicate_different_values_is_varying() {
+  %c1 = index.constant 1 : index
+  %c64 = index.constant 64 : index
+  kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
+} launch(%lhs: i32, %rhs: i32) {
+  %lane = kernel.subgroup.lane.id : index
+  %c0 = index.constant 0 : index
+  %condition = index.cmp eq, %lane, %c0 : index
+  scf.if %condition {
+    test.use %lhs : i32
+  } else {
+    test.use %rhs : i32
+  }
+  %selected_is_varying = scalar.constant true : i1
+  %selected_is_uniform = scalar.constant false : i1
+  test.use %selected_is_varying, %selected_is_uniform : i1, i1
+  kernel.return
+}
+
+// ====
+
+// A lane-local selector does not make a result varying when every region
+// yields the same SSA value.
+kernel.def @if_lane_predicate_same_value_stays_uniform() {
+  %c1 = index.constant 1 : index
+  %c64 = index.constant 64 : index
+  kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
+} launch(%value: i32) {
+  %lane = kernel.subgroup.lane.id : index
+  %c0 = index.constant 0 : index
+  %condition = index.cmp eq, %lane, %c0 : index
+  %selected = scf.if %condition -> (i32) {
+    test.use %value : i32
+    scf.yield %value : i32
+  } else {
+    test.use %value : i32
+    scf.yield %value : i32
+  }
+  %selected_is_varying = test.fact_lane_varying %selected : i32 -> i1
+  %selected_is_uniform = test.fact_subgroup_uniform %selected : i32 -> i1
+  test.use %selected_is_varying, %selected_is_uniform : i1, i1
+  kernel.return
+}
+
+// ----
+kernel.def @if_lane_predicate_same_value_stays_uniform() {
+  %c1 = index.constant 1 : index
+  %c64 = index.constant 64 : index
+  kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
+} launch(%value: i32) {
+  %lane = kernel.subgroup.lane.id : index
+  %c0 = index.constant 0 : index
+  %condition = index.cmp eq, %lane, %c0 : index
+  scf.if %condition {
+    test.use %value : i32
+  } else {
+    test.use %value : i32
+  }
+  %selected_is_varying = scalar.constant false : i1
+  %selected_is_uniform = scalar.constant true : i1
+  test.use %selected_is_varying, %selected_is_uniform : i1, i1
+  kernel.return
+}
+
+// ====
+
+// Boolean branch results retain the stronger lane-predicate classification.
+kernel.def @if_lane_predicate_boolean_result_is_predicate() {
+  %c1 = index.constant 1 : index
+  %c64 = index.constant 64 : index
+  kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
+} launch(%lhs: i1, %rhs: i1) {
+  %lane = kernel.subgroup.lane.id : index
+  %c0 = index.constant 0 : index
+  %condition = index.cmp eq, %lane, %c0 : index
+  %selected = scf.if %condition -> (i1) {
+    test.use %lhs : i1
+    scf.yield %lhs : i1
+  } else {
+    test.use %rhs : i1
+    scf.yield %rhs : i1
+  }
+  %selected_is_predicate = test.fact_lane_predicate %selected : i1 -> i1
+  %selected_is_uniform = test.fact_subgroup_uniform %selected : i1 -> i1
+  test.use %selected_is_predicate, %selected_is_uniform : i1, i1
+  kernel.return
+}
+
+// ----
+kernel.def @if_lane_predicate_boolean_result_is_predicate() {
+  %c1 = index.constant 1 : index
+  %c64 = index.constant 64 : index
+  kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
+} launch(%lhs: i1, %rhs: i1) {
+  %lane = kernel.subgroup.lane.id : index
+  %c0 = index.constant 0 : index
+  %condition = index.cmp eq, %lane, %c0 : index
+  scf.if %condition {
+    test.use %lhs : i1
+  } else {
+    test.use %rhs : i1
+  }
+  %selected_is_predicate = scalar.constant true : i1
+  %selected_is_uniform = scalar.constant false : i1
+  test.use %selected_is_predicate, %selected_is_uniform : i1, i1
+  kernel.return
+}
+
+// ====
+
 // Selecting between different uniform values with a lane-local predicate
 // produces lane-varying data, not a uniform unknown.
 kernel.def @select_lane_predicate_different_values_is_varying() {

--- a/loom/src/loom/rewrite/rewriter.c
+++ b/loom/src/loom/rewrite/rewriter.c
@@ -26,6 +26,29 @@ typedef enum loom_rewriter_fact_recompute_flag_bits_e {
 } loom_rewriter_fact_recompute_flag_bits_t;
 typedef uint32_t loom_rewriter_fact_recompute_flags_t;
 
+static bool loom_rewriter_op_summarizes_nested_regions(
+    const loom_op_vtable_t* vtable) {
+  return vtable && (vtable->loop_like || vtable->region_branch);
+}
+
+static bool loom_rewriter_region_branch_summary_is_ready(
+    const loom_rewriter_t* rewriter, loom_op_t* op,
+    const loom_op_vtable_t* vtable) {
+  if (!vtable || !vtable->region_branch) return true;
+  loom_region_branch_t branch = loom_region_branch_cast(rewriter->module, op);
+  for (uint8_t region_index = 0; region_index < op->region_count;
+       ++region_index) {
+    if (!loom_region_branch_region(rewriter->module, branch, region_index)) {
+      continue;
+    }
+    if (!loom_region_branch_region_terminator(rewriter->module, branch,
+                                              region_index)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 static iree_status_t loom_rewriter_recompute_op_facts(
     loom_rewriter_t* rewriter, loom_op_t* op,
     loom_rewriter_fact_recompute_flags_t flags) {
@@ -49,10 +72,12 @@ static iree_status_t loom_rewriter_recompute_op_facts(
 // Builder callback
 //===----------------------------------------------------------------------===//
 
-// Callback installed on the builder. Fired by finalize_op after a new
-// op is fully wired. Adds the op to the rewriter's worklist so the
-// driver can attempt patterns on it. When analysis is enabled, also
-// computes facts for the new op's results.
+// Callback installed on the builder. Fired by finalize_op after a new op's
+// direct fields are fully wired. Adds the op to the rewriter's worklist so the
+// driver can attempt patterns on it. When analysis is enabled, also computes
+// facts for ordinary op results and complete structured ops. RegionBranch
+// shells remain on the worklist until callers have populated the regions
+// created by their builders.
 static iree_status_t loom_rewriter_on_op_finalized(void* user_data,
                                                    loom_op_t* op) {
   loom_rewriter_t* rewriter = (loom_rewriter_t*)user_data;
@@ -60,6 +85,10 @@ static iree_status_t loom_rewriter_on_op_finalized(void* user_data,
   IREE_RETURN_IF_ERROR(loom_rewriter_add_to_worklist(rewriter, op));
   IREE_RETURN_IF_ERROR(
       loom_rewriter_add_parent_summary_ops_to_worklist(rewriter, op));
+  const loom_op_vtable_t* vtable = loom_op_vtable(rewriter->module, op);
+  if (!loom_rewriter_region_branch_summary_is_ready(rewriter, op, vtable)) {
+    return iree_ok_status();
+  }
   return loom_rewriter_recompute_op_facts(rewriter, op, /*flags=*/0);
 }
 
@@ -204,7 +233,8 @@ iree_status_t loom_rewriter_try_fold(loom_rewriter_t* rewriter, loom_op_t* op,
   *out_folded = false;
   if (!rewriter->fact_table) return iree_ok_status();
   const loom_op_vtable_t* vtable = loom_op_vtable(rewriter->module, op);
-  if (!vtable || (!vtable->infer_facts && !vtable->loop_like)) {
+  if (!vtable || (!vtable->infer_facts &&
+                  !loom_rewriter_op_summarizes_nested_regions(vtable))) {
     return iree_ok_status();
   }
 
@@ -399,7 +429,7 @@ static iree_status_t loom_rewriter_add_parent_summary_ops_to_worklist(
   for (loom_op_t* parent = op ? op->parent_op : NULL; parent;
        parent = parent->parent_op) {
     const loom_op_vtable_t* vtable = loom_op_vtable(rewriter->module, parent);
-    if (vtable && vtable->loop_like) {
+    if (loom_rewriter_op_summarizes_nested_regions(vtable)) {
       IREE_RETURN_IF_ERROR(loom_rewriter_add_to_worklist(rewriter, parent));
     }
   }

--- a/loom/src/loom/rewrite/rewriter.h
+++ b/loom/src/loom/rewrite/rewriter.h
@@ -183,12 +183,13 @@ iree_status_t loom_rewriter_build_constant(loom_rewriter_t* rewriter,
                                            loom_location_id_t location,
                                            loom_value_id_t* out_value_id);
 
-// Attempts to fold a side-effect-free op to constants using its vtable fact
-// inference function. Gathers operand facts, updates stored facts in the table,
-// and materializes constants via the rewriter's materialize_constant callback
-// when all results produce exact facts. Replaces the original op via
-// RAUW+erase. Sets |*out_folded| to true if the op was erased, false otherwise.
-// No-op if analysis is not enabled or the op has no inference function.
+// Recomputes an op's inferred or structured-region result facts, then attempts
+// to fold a side-effect-free op with vtable fact inference to constants.
+// Materializes constants via the rewriter's materialize_constant callback when
+// every result is exact and replaces the original op via RAUW+erase. Sets
+// |*out_folded| to true if the op was erased, false otherwise. No-op if
+// analysis is not enabled or the op has no fact inference or region summary
+// interface.
 iree_status_t loom_rewriter_try_fold(loom_rewriter_t* rewriter, loom_op_t* op,
                                      bool* out_folded);
 

--- a/loom/src/loom/util/fact_table.c
+++ b/loom/src/loom/util/fact_table.c
@@ -2700,7 +2700,7 @@ static iree_status_t loom_value_fact_table_compute_cfg_block_args(
 }
 
 //===----------------------------------------------------------------------===//
-// Loop-like region summaries
+// Structured region summaries
 //===----------------------------------------------------------------------===//
 
 #define LOOM_VALUE_FACT_CFG_MAX_ITERATIONS 16
@@ -2716,6 +2716,11 @@ static iree_status_t loom_value_fact_table_compute_region_tree(
     loom_value_fact_table_t* table, const loom_module_t* module,
     loom_region_t* region, loom_op_t* parent_op);
 
+static bool loom_value_fact_op_summarizes_nested_regions(
+    const loom_op_vtable_t* vtable) {
+  return vtable && (vtable->loop_like || vtable->region_branch);
+}
+
 static iree_status_t loom_value_fact_table_compute_cfg_block_tree(
     loom_value_fact_table_t* table, const loom_module_t* module,
     const loom_block_t* block, bool* out_changed) {
@@ -2726,8 +2731,8 @@ static iree_status_t loom_value_fact_table_compute_cfg_block_tree(
         table, module, op, &op_changed));
     *out_changed = *out_changed || op_changed;
     const loom_op_vtable_t* vtable = loom_op_vtable(module, op);
-    if (vtable && vtable->loop_like) {
-      // Loop-like fact callbacks summarize and visit their nested regions.
+    if (loom_value_fact_op_summarizes_nested_regions(vtable)) {
+      // Structured fact summaries visit their own nested regions.
       continue;
     }
     loom_region_t** regions = loom_op_regions(op);
@@ -2790,8 +2795,8 @@ static iree_status_t loom_value_fact_table_compute_region_tree(
     loom_block_for_each_op(block, op) {
       IREE_RETURN_IF_ERROR(loom_value_fact_table_compute_op(table, module, op));
       const loom_op_vtable_t* vtable = loom_op_vtable(module, op);
-      if (vtable && vtable->loop_like) {
-        // Loop-like fact callbacks summarize and visit their nested regions.
+      if (loom_value_fact_op_summarizes_nested_regions(vtable)) {
+        // Structured fact summaries visit their own nested regions.
         continue;
       }
       loom_region_t** regions = loom_op_regions(op);
@@ -2968,7 +2973,7 @@ static iree_status_t loom_value_fact_table_join_loop_backedge(
   return iree_ok_status();
 }
 
-static iree_status_t loom_value_fact_table_define_loop_results(
+static iree_status_t loom_value_fact_table_define_region_results(
     loom_value_fact_table_t* table, const loom_module_t* module, loom_op_t* op,
     loom_value_facts_t* result_facts, uint16_t result_count,
     bool* out_changed) {
@@ -3002,14 +3007,109 @@ static iree_status_t loom_value_fact_table_define_loop_results(
         i < result_count ? result_facts[i] : loom_value_facts_unknown();
     loom_type_t type = loom_module_value_type(module, result);
     if (out_changed &&
-        !loom_value_fact_table_facts_equal_for_type(
-            module, type, table, loom_value_fact_table_lookup(table, result),
-            table, facts)) {
+        (!loom_value_fact_table_has_entry(table, result) ||
+         !loom_value_fact_table_facts_equal_for_type(
+             module, type, table, loom_value_fact_table_lookup(table, result),
+             table, facts))) {
       *out_changed = true;
     }
     IREE_RETURN_IF_ERROR(loom_value_fact_table_define(table, result, facts));
   }
   return iree_ok_status();
+}
+
+typedef struct loom_value_fact_region_branch_result_state_t {
+  // Meet of facts yielded for this result by every visited branch region.
+  loom_value_facts_t facts;
+  // Value yielded by the first branch region.
+  loom_value_id_t first_source_value;
+  // Whether every branch yields the same SSA value as the first branch.
+  bool all_source_values_match;
+} loom_value_fact_region_branch_result_state_t;
+
+static iree_status_t loom_value_fact_table_compute_region_branch_summary(
+    loom_value_fact_table_t* table, const loom_module_t* module, loom_op_t* op,
+    bool* out_changed) {
+  loom_region_branch_t branch = loom_region_branch_cast(module, op);
+  IREE_ASSERT(loom_region_branch_isa(branch));
+
+  loom_value_fact_region_branch_result_state_t* result_states = NULL;
+  if (op->result_count > 0) {
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        table->transient_arena, op->result_count,
+        sizeof(loom_value_fact_region_branch_result_state_t),
+        (void**)&result_states));
+  }
+
+  uint8_t visited_region_count = 0;
+  const loom_value_id_t* results = loom_op_const_results(op);
+  for (uint8_t region_index = 0; region_index < op->region_count;
+       ++region_index) {
+    loom_region_t* region =
+        loom_region_branch_region(module, branch, region_index);
+    if (!region) continue;
+    IREE_RETURN_IF_ERROR(
+        loom_value_fact_table_compute_region_tree(table, module, region, op));
+    loom_op_t* terminator =
+        loom_region_branch_region_terminator(module, branch, region_index);
+    IREE_ASSERT(terminator);
+    if (op->result_count == 0) {
+      ++visited_region_count;
+      continue;
+    }
+
+    IREE_ASSERT_EQ(terminator->operand_count, op->result_count);
+    const loom_value_id_t* yielded_values = loom_op_const_operands(terminator);
+    for (uint16_t result_index = 0; result_index < op->result_count;
+         ++result_index) {
+      const loom_value_id_t yielded_value = yielded_values[result_index];
+      loom_value_fact_region_branch_result_state_t* state =
+          &result_states[result_index];
+      const loom_value_facts_t yielded_facts =
+          loom_value_fact_table_lookup(table, yielded_value);
+      if (visited_region_count == 0) {
+        state->facts = yielded_facts;
+        state->first_source_value = yielded_value;
+        state->all_source_values_match = true;
+        continue;
+      }
+
+      if (yielded_value != state->first_source_value) {
+        state->all_source_values_match = false;
+      }
+      loom_value_facts_t joined_facts = loom_value_facts_unknown();
+      const loom_type_t result_type =
+          loom_module_value_type(module, results[result_index]);
+      IREE_RETURN_IF_ERROR(loom_value_fact_table_meet_for_type(
+          table, module, result_type, table, state->facts, table, yielded_facts,
+          &joined_facts));
+      state->facts = joined_facts;
+    }
+    ++visited_region_count;
+  }
+
+  if (op->result_count == 0) return iree_ok_status();
+  IREE_ASSERT_GT(visited_region_count, 0);
+
+  loom_value_facts_t* result_facts = NULL;
+  IREE_RETURN_IF_ERROR(loom_value_fact_table_facts_scratch(
+      table, op->result_count, &result_facts));
+  const bool selector_is_lane_varying =
+      loom_value_fact_table_selector_is_lane_varying(
+          table, loom_region_branch_selector(branch));
+  for (uint16_t result_index = 0; result_index < op->result_count;
+       ++result_index) {
+    loom_value_facts_t facts = result_states[result_index].facts;
+    if (selector_is_lane_varying &&
+        !result_states[result_index].all_source_values_match &&
+        !loom_value_facts_is_exact(facts)) {
+      loom_value_fact_mark_lane_distribution_for_type(
+          loom_module_value_type(module, results[result_index]), &facts);
+    }
+    result_facts[result_index] = facts;
+  }
+  return loom_value_fact_table_define_region_results(
+      table, module, op, result_facts, op->result_count, out_changed);
 }
 
 static iree_status_t loom_value_fact_table_compute_counted_loop_summary(
@@ -3096,7 +3196,7 @@ static iree_status_t loom_value_fact_table_compute_counted_loop_summary(
           yielded_facts[i], &result_facts[i]));
     }
   }
-  return loom_value_fact_table_define_loop_results(
+  return loom_value_fact_table_define_region_results(
       table, module, loop.op, result_facts, count, out_changed);
 }
 
@@ -3182,7 +3282,7 @@ static iree_status_t loom_value_fact_table_compute_condition_loop_summary(
         table, yield, /*operand_offset=*/0, yielded_facts, count);
   }
 
-  return loom_value_fact_table_define_loop_results(
+  return loom_value_fact_table_define_region_results(
       table, module, loop.op, forwarded_facts, count, out_changed);
 }
 
@@ -3224,6 +3324,10 @@ iree_status_t loom_value_fact_table_compute_op_and_report(
   const loom_op_vtable_t* vtable = loom_op_vtable(module, op);
   if (vtable && vtable->loop_like) {
     return loom_value_fact_table_compute_loop_like_summary(
+        table, module, (loom_op_t*)op, out_changed);
+  }
+  if (vtable && vtable->region_branch) {
+    return loom_value_fact_table_compute_region_branch_summary(
         table, module, (loom_op_t*)op, out_changed);
   }
   if (!vtable || !vtable->infer_facts) {

--- a/loom/src/loom/util/fact_table.h
+++ b/loom/src/loom/util/fact_table.h
@@ -931,15 +931,16 @@ iree_status_t loom_value_fact_table_clone_defined_facts(
     loom_value_fact_table_t* target, const loom_value_fact_table_t* source,
     const loom_module_t* module);
 
-// Computes facts for a single op by calling its vtable fact inference function.
-// Gathers operand facts from the table, calls the callback, and defines result
-// facts. No-op if the op has no inference function.
+// Computes facts for a single op. Ordinary ops call their vtable fact inference
+// function; LoopLike and RegionBranch ops visit their nested regions and
+// summarize the values returned to the parent results. Ops without either form
+// of fact inference define their results with unknown facts.
 iree_status_t loom_value_fact_table_compute_op(loom_value_fact_table_t* table,
                                                const loom_module_t* module,
                                                const loom_op_t* op);
 
 // Computes facts for a single op and reports whether any result facts changed
-// relative to the table's previous entries. No-op ops report false.
+// relative to the table's previous entries.
 iree_status_t loom_value_fact_table_compute_op_and_report(
     loom_value_fact_table_t* table, const loom_module_t* module,
     const loom_op_t* op, bool* out_changed);


### PR DESCRIPTION
RegionBranch operations now preserve facts established by their mutually exclusive regions instead of defining parent results as unknown. The generic value-fact solver analyzes each branch, meets corresponding yields through the result type's fact domain, and carries compatible scalar and extension facts into downstream canonicalization and lowering.

Lane-varying selectors preserve the distinction between selecting distinct SSA values and forwarding one common value: distinct non-exact results become lane-varying (or lane predicates for `i1`), while common and exact results retain their stronger distribution facts.

The rewriter now schedules RegionBranch summaries alongside LoopLike summaries. Generated branch builders expose a finalized parent shell before regions are populated, so immediate inference waits until each branch has a valid terminator; fully cloned branches remain immediately analyzable, and nested rewrites reschedule every enclosing summary.

Coverage includes `scf.if`, `scf.switch`, multi-way scalar meets, distribution semantics, and type-owned Low storage payloads across compatible and incompatible backing allocations.

## Reviewer Notes

The key review surfaces are the RegionBranch lattice merge in `fact_table.c` and the builder-readiness scheduling in `rewriter.c`.
