### PR TITLE
[Loom] Preserve vector facts across control-flow joins

### DIFF
--- a/loom/src/loom/ops/vector/facts.c
+++ b/loom/src/loom/ops/vector/facts.c
@@ -507,6 +507,145 @@ static iree_status_t loom_vector_make_accumulator_join_fragment(
   return iree_ok_status();
 }
 
+typedef enum loom_vector_aggregate_fact_kind_e {
+  LOOM_VECTOR_AGGREGATE_FACT_NONE = 0,
+  LOOM_VECTOR_AGGREGATE_FACT_UNIFORM = 1,
+  LOOM_VECTOR_AGGREGATE_FACT_SMALL_STATIC_LANES = 2,
+} loom_vector_aggregate_fact_kind_t;
+
+static loom_vector_aggregate_fact_kind_t loom_vector_query_aggregate_extension(
+    const loom_fact_context_t* context, loom_value_facts_t facts,
+    loom_value_facts_t* out_uniform_element,
+    loom_value_fact_small_static_lanes_t* out_small_static_lanes) {
+  loom_value_fact_uniform_element_t uniform = {0};
+  if (loom_value_facts_query_uniform_element(context, facts, &uniform)) {
+    *out_uniform_element = uniform.element;
+    return LOOM_VECTOR_AGGREGATE_FACT_UNIFORM;
+  }
+  if (loom_value_facts_query_small_static_lanes(context, facts,
+                                                out_small_static_lanes)) {
+    return LOOM_VECTOR_AGGREGATE_FACT_SMALL_STATIC_LANES;
+  }
+  return LOOM_VECTOR_AGGREGATE_FACT_NONE;
+}
+
+static iree_status_t loom_vector_try_join_aggregate_extensions(
+    loom_value_fact_table_t* target, const loom_value_fact_table_t* lhs_table,
+    loom_value_facts_t lhs, const loom_value_fact_table_t* rhs_table,
+    loom_value_facts_t rhs, loom_value_facts_t* inout_facts,
+    bool* out_handled) {
+  loom_value_facts_t lhs_uniform = loom_value_facts_unknown();
+  loom_value_facts_t rhs_uniform = loom_value_facts_unknown();
+  loom_value_fact_small_static_lanes_t lhs_lanes = {0};
+  loom_value_fact_small_static_lanes_t rhs_lanes = {0};
+  const loom_vector_aggregate_fact_kind_t lhs_kind =
+      loom_vector_query_aggregate_extension(&lhs_table->context, lhs,
+                                            &lhs_uniform, &lhs_lanes);
+  const loom_vector_aggregate_fact_kind_t rhs_kind =
+      loom_vector_query_aggregate_extension(&rhs_table->context, rhs,
+                                            &rhs_uniform, &rhs_lanes);
+  *out_handled = lhs_kind != LOOM_VECTOR_AGGREGATE_FACT_NONE ||
+                 rhs_kind != LOOM_VECTOR_AGGREGATE_FACT_NONE;
+  if (!*out_handled) return iree_ok_status();
+  if (lhs_kind == LOOM_VECTOR_AGGREGATE_FACT_NONE ||
+      rhs_kind == LOOM_VECTOR_AGGREGATE_FACT_NONE) {
+    return iree_ok_status();
+  }
+
+  if (lhs_kind == LOOM_VECTOR_AGGREGATE_FACT_UNIFORM &&
+      rhs_kind == LOOM_VECTOR_AGGREGATE_FACT_UNIFORM) {
+    loom_value_facts_t element = loom_value_facts_unknown();
+    loom_value_facts_meet(&lhs_uniform, &rhs_uniform, &element);
+    loom_value_facts_t extension = loom_value_facts_unknown();
+    IREE_RETURN_IF_ERROR(loom_value_facts_make_uniform_element(
+        &target->context, element, &extension));
+    inout_facts->extension_id = extension.extension_id;
+    return iree_ok_status();
+  }
+
+  if (lhs_kind == LOOM_VECTOR_AGGREGATE_FACT_SMALL_STATIC_LANES &&
+      rhs_kind == LOOM_VECTOR_AGGREGATE_FACT_SMALL_STATIC_LANES &&
+      lhs_lanes.count != rhs_lanes.count) {
+    return iree_ok_status();
+  }
+  const iree_host_size_t lane_count =
+      lhs_kind == LOOM_VECTOR_AGGREGATE_FACT_SMALL_STATIC_LANES
+          ? lhs_lanes.count
+          : rhs_lanes.count;
+
+  loom_value_facts_t joined_lanes[LOOM_VALUE_FACT_SMALL_STATIC_LANE_LIMIT] = {
+      {0}};
+  for (iree_host_size_t i = 0; i < lane_count; ++i) {
+    const loom_value_facts_t lhs_lane =
+        lhs_kind == LOOM_VECTOR_AGGREGATE_FACT_UNIFORM ? lhs_uniform
+                                                       : lhs_lanes.lanes[i];
+    const loom_value_facts_t rhs_lane =
+        rhs_kind == LOOM_VECTOR_AGGREGATE_FACT_UNIFORM ? rhs_uniform
+                                                       : rhs_lanes.lanes[i];
+    loom_value_facts_meet(&lhs_lane, &rhs_lane, &joined_lanes[i]);
+  }
+  loom_value_fact_small_static_lanes_t joined = {
+      .lanes = joined_lanes,
+      .count = lane_count,
+  };
+  loom_value_facts_t extension = loom_value_facts_unknown();
+  IREE_RETURN_IF_ERROR(loom_value_facts_make_small_static_lanes(
+      &target->context, joined, &extension));
+  inout_facts->extension_id = extension.extension_id;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_vector_try_join_iota_extensions(
+    loom_value_fact_table_t* target, const loom_value_fact_table_t* lhs_table,
+    loom_value_facts_t lhs, const loom_value_fact_table_t* rhs_table,
+    loom_value_facts_t rhs, loom_value_facts_t* inout_facts,
+    bool* out_handled) {
+  loom_value_fact_vector_iota_t lhs_iota = {0};
+  loom_value_fact_vector_iota_t rhs_iota = {0};
+  const bool lhs_has_iota =
+      loom_value_facts_query_vector_iota(&lhs_table->context, lhs, &lhs_iota);
+  const bool rhs_has_iota =
+      loom_value_facts_query_vector_iota(&rhs_table->context, rhs, &rhs_iota);
+  *out_handled = lhs_has_iota || rhs_has_iota;
+  if (!lhs_has_iota || !rhs_has_iota) return iree_ok_status();
+
+  loom_value_fact_vector_iota_t joined = {0};
+  loom_value_facts_meet(&lhs_iota.base, &rhs_iota.base, &joined.base);
+  loom_value_facts_meet(&lhs_iota.step, &rhs_iota.step, &joined.step);
+  loom_value_facts_t extension = loom_value_facts_unknown();
+  IREE_RETURN_IF_ERROR(
+      loom_value_facts_make_vector_iota(&target->context, joined, &extension));
+  inout_facts->extension_id = extension.extension_id;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_vector_try_join_prefix_mask_extensions(
+    loom_value_fact_table_t* target, const loom_value_fact_table_t* lhs_table,
+    loom_value_facts_t lhs, const loom_value_fact_table_t* rhs_table,
+    loom_value_facts_t rhs, loom_value_facts_t* inout_facts,
+    bool* out_handled) {
+  loom_value_fact_vector_prefix_mask_t lhs_mask = {0};
+  loom_value_fact_vector_prefix_mask_t rhs_mask = {0};
+  const bool lhs_has_mask = loom_value_facts_query_vector_prefix_mask(
+      &lhs_table->context, lhs, &lhs_mask);
+  const bool rhs_has_mask = loom_value_facts_query_vector_prefix_mask(
+      &rhs_table->context, rhs, &rhs_mask);
+  *out_handled = lhs_has_mask || rhs_has_mask;
+  if (!lhs_has_mask || !rhs_has_mask) return iree_ok_status();
+
+  loom_value_fact_vector_prefix_mask_t joined = {0};
+  loom_value_facts_meet(&lhs_mask.lower_bound, &rhs_mask.lower_bound,
+                        &joined.lower_bound);
+  loom_value_facts_meet(&lhs_mask.upper_bound, &rhs_mask.upper_bound,
+                        &joined.upper_bound);
+  loom_value_facts_meet(&lhs_mask.step, &rhs_mask.step, &joined.step);
+  loom_value_facts_t extension = loom_value_facts_unknown();
+  IREE_RETURN_IF_ERROR(loom_value_facts_make_vector_prefix_mask(
+      &target->context, joined, &extension));
+  inout_facts->extension_id = extension.extension_id;
+  return iree_ok_status();
+}
+
 static iree_status_t loom_vector_join_fragment_extension(
     loom_value_fact_table_t* target, const loom_value_fact_table_t* lhs_table,
     loom_value_facts_t lhs, const loom_value_fact_table_t* rhs_table,
@@ -531,6 +670,29 @@ static iree_status_t loom_vector_join_fragment_extension(
       &target->context, lhs_fragment, rhs_fragment, inout_facts);
 }
 
+static iree_status_t loom_vector_join_extension(
+    loom_value_fact_table_t* target, const loom_value_fact_table_t* lhs_table,
+    loom_value_facts_t lhs, const loom_value_fact_table_t* rhs_table,
+    loom_value_facts_t rhs, loom_value_facts_t* inout_facts) {
+  if (loom_value_fact_table_extensions_equal(lhs_table, lhs, rhs_table, rhs)) {
+    return loom_vector_clone_equal_extension(target, lhs_table, lhs,
+                                             inout_facts);
+  }
+
+  bool handled = false;
+  IREE_RETURN_IF_ERROR(loom_vector_try_join_aggregate_extensions(
+      target, lhs_table, lhs, rhs_table, rhs, inout_facts, &handled));
+  if (handled) return iree_ok_status();
+  IREE_RETURN_IF_ERROR(loom_vector_try_join_iota_extensions(
+      target, lhs_table, lhs, rhs_table, rhs, inout_facts, &handled));
+  if (handled) return iree_ok_status();
+  IREE_RETURN_IF_ERROR(loom_vector_try_join_prefix_mask_extensions(
+      target, lhs_table, lhs, rhs_table, rhs, inout_facts, &handled));
+  if (handled) return iree_ok_status();
+  return loom_vector_join_fragment_extension(target, lhs_table, lhs, rhs_table,
+                                             rhs, inout_facts);
+}
+
 static iree_status_t loom_vector_meet_extension(
     const loom_value_fact_domain_t* domain, const loom_module_t* module,
     loom_type_t type, loom_value_fact_table_t* target,
@@ -540,8 +702,8 @@ static iree_status_t loom_vector_meet_extension(
   (void)domain;
   (void)module;
   (void)type;
-  return loom_vector_join_fragment_extension(target, lhs_table, lhs, rhs_table,
-                                             rhs, inout_facts);
+  return loom_vector_join_extension(target, lhs_table, lhs, rhs_table, rhs,
+                                    inout_facts);
 }
 
 static iree_status_t loom_vector_widen_extension(
@@ -554,6 +716,10 @@ static iree_status_t loom_vector_widen_extension(
   (void)module;
   (void)type;
   (void)iteration;
+  // The generic solver calls this only after its two precise meet iterations.
+  // Stable extensions still clone below, and matrix fragment roles form a
+  // finite join. Aggregate component ranges can otherwise expand on every
+  // backedge, so changing aggregate summaries deliberately degrade here.
   return loom_vector_join_fragment_extension(target, previous_table, previous,
                                              next_table, next, inout_facts);
 }

--- a/loom/src/loom/ops/vector/test/facts.loom-test
+++ b/loom/src/loom/ops/vector/test/facts.loom-test
@@ -1357,6 +1357,352 @@ func.def @prefix_mask_summary_fact(%n: index) -> (i1) {
 
 // ====
 
+// CFG joins preserve the conservative scalar fact shared by two uniform
+// vector summaries.
+func.def @cfg_join_uniform_vector_facts(%condition: i1) -> (i64, i64) {
+  %c2 = scalar.constant 2 : i32
+  %c6 = scalar.constant 6 : i32
+  cfg.cond_br %condition, ^left, ^right
+^left:
+  %left_value = vector.splat %c2 : vector<4xi32>
+  cfg.br ^join(%left_value: vector<4xi32>)
+^right:
+  %right_value = vector.splat %c6 : vector<4xi32>
+  cfg.br ^join(%right_value: vector<4xi32>)
+^join(%value: vector<4xi32>):
+  %lane = vector.extract %value[2] : vector<4xi32> -> i32
+  %lo = test.fact_range_lo %lane : i32 -> i64
+  %hi = test.fact_range_hi %lane : i32 -> i64
+  func.return %lo, %hi : i64, i64
+}
+
+// ----
+func.def @cfg_join_uniform_vector_facts(%condition: i1) -> (i64, i64) {
+  cfg.cond_br %condition, ^left, ^right
+^left:
+  %left_value = vector.constant 2 : vector<4xi32>
+  cfg.br ^join(%left_value: vector<4xi32>)
+^right:
+  %right_value = vector.constant 6 : vector<4xi32>
+  cfg.br ^join(%right_value: vector<4xi32>)
+^join(%value: vector<4xi32>):
+  %lo = scalar.constant 2 : i64
+  %hi = scalar.constant 6 : i64
+  func.return %lo, %hi : i64, i64
+}
+
+// ====
+
+// Small static summaries meet corresponding lanes instead of flattening the
+// whole vector to one aggregate scalar range.
+func.def @cfg_join_small_static_lane_facts(%condition: i1) -> (i64, i64, i64, i64) {
+  %c1 = scalar.constant 1 : i32
+  %c2 = scalar.constant 2 : i32
+  %c3 = scalar.constant 3 : i32
+  %c4 = scalar.constant 4 : i32
+  %c5 = scalar.constant 5 : i32
+  %c7 = scalar.constant 7 : i32
+  cfg.cond_br %condition, ^left, ^right
+^left:
+  %left_value = vector.from_elements %c1, %c2, %c3, %c4 : vector<4xi32>
+  cfg.br ^join(%left_value: vector<4xi32>)
+^right:
+  %right_value = vector.from_elements %c5, %c2, %c7, %c4 : vector<4xi32>
+  cfg.br ^join(%right_value: vector<4xi32>)
+^join(%value: vector<4xi32>):
+  %lane0 = vector.extract %value[0] : vector<4xi32> -> i32
+  %lane2 = vector.extract %value[2] : vector<4xi32> -> i32
+  %lane0_lo = test.fact_range_lo %lane0 : i32 -> i64
+  %lane0_hi = test.fact_range_hi %lane0 : i32 -> i64
+  %lane2_lo = test.fact_range_lo %lane2 : i32 -> i64
+  %lane2_hi = test.fact_range_hi %lane2 : i32 -> i64
+  func.return %lane0_lo, %lane0_hi, %lane2_lo, %lane2_hi : i64, i64, i64, i64
+}
+
+// ----
+func.def @cfg_join_small_static_lane_facts(%condition: i1) -> (i64, i64, i64, i64) {
+  %c1 = scalar.constant 1 : i32
+  %c2 = scalar.constant 2 : i32
+  %c3 = scalar.constant 3 : i32
+  %c4 = scalar.constant 4 : i32
+  %c5 = scalar.constant 5 : i32
+  %c7 = scalar.constant 7 : i32
+  cfg.cond_br %condition, ^left, ^right
+^left:
+  %left_value = vector.from_elements %c1, %c2, %c3, %c4 : vector<4xi32>
+  cfg.br ^join(%left_value: vector<4xi32>)
+^right:
+  %right_value = vector.from_elements %c5, %c2, %c7, %c4 : vector<4xi32>
+  cfg.br ^join(%right_value: vector<4xi32>)
+^join(%value: vector<4xi32>):
+  %lane0_lo = scalar.constant 1 : i64
+  %lane0_hi = scalar.constant 5 : i64
+  %lane2_lo = scalar.constant 3 : i64
+  %lane2_hi = scalar.constant 7 : i64
+  func.return %lane0_lo, %lane0_hi, %lane2_lo, %lane2_hi : i64, i64, i64, i64
+}
+
+// ====
+
+// A uniform summary can meet a bounded per-lane summary without discarding
+// lanes whose fact remains exact.
+func.def @cfg_join_uniform_and_small_static_facts(%condition: i1) -> (i64, i64, i64, i64) {
+  %c2 = scalar.constant 2 : i32
+  %c4 = scalar.constant 4 : i32
+  %c8 = scalar.constant 8 : i32
+  cfg.cond_br %condition, ^uniform, ^lanes
+^uniform:
+  %uniform_value = vector.splat %c4 : vector<4xi32>
+  cfg.br ^join(%uniform_value: vector<4xi32>)
+^lanes:
+  %lane_value = vector.from_elements %c2, %c4, %c8, %c4 : vector<4xi32>
+  cfg.br ^join(%lane_value: vector<4xi32>)
+^join(%value: vector<4xi32>):
+  %lane0 = vector.extract %value[0] : vector<4xi32> -> i32
+  %lane1 = vector.extract %value[1] : vector<4xi32> -> i32
+  %lane0_lo = test.fact_range_lo %lane0 : i32 -> i64
+  %lane0_hi = test.fact_range_hi %lane0 : i32 -> i64
+  %lane1_lo = test.fact_range_lo %lane1 : i32 -> i64
+  %lane1_hi = test.fact_range_hi %lane1 : i32 -> i64
+  func.return %lane0_lo, %lane0_hi, %lane1_lo, %lane1_hi : i64, i64, i64, i64
+}
+
+// ----
+func.def @cfg_join_uniform_and_small_static_facts(%condition: i1) -> (i64, i64, i64, i64) {
+  %c2 = scalar.constant 2 : i32
+  %c4 = scalar.constant 4 : i32
+  %c8 = scalar.constant 8 : i32
+  cfg.cond_br %condition, ^uniform, ^lanes
+^uniform:
+  %uniform_value = vector.constant 4 : vector<4xi32>
+  cfg.br ^join(%uniform_value: vector<4xi32>)
+^lanes:
+  %lane_value = vector.from_elements %c2, %c4, %c8, %c4 : vector<4xi32>
+  cfg.br ^join(%lane_value: vector<4xi32>)
+^join(%value: vector<4xi32>):
+  %lane0_lo = scalar.constant 2 : i64
+  %lane0_hi = scalar.constant 4 : i64
+  %lane1_lo = scalar.constant 4 : i64
+  %lane1_hi = scalar.constant 4 : i64
+  func.return %lane0_lo, %lane0_hi, %lane1_lo, %lane1_hi : i64, i64, i64, i64
+}
+
+// ====
+
+// Structured branch results use the same type-owned extension join as CFG
+// block arguments. Side effects keep both regions present so this crosses the
+// generic RegionBranch summary path.
+func.def @region_branch_join_uniform_and_small_static_facts(%condition: i1) -> (i64, i64, i64, i64) {
+  %c2 = scalar.constant 2 : i32
+  %c4 = scalar.constant 4 : i32
+  %c8 = scalar.constant 8 : i32
+  %value = scf.if %condition -> (vector<4xi32>) {
+    %uniform_value = vector.splat %c4 : vector<4xi32>
+    test.use %uniform_value : vector<4xi32>
+    scf.yield %uniform_value : vector<4xi32>
+  } else {
+    %lane_value = vector.from_elements %c2, %c4, %c8, %c4 : vector<4xi32>
+    test.use %lane_value : vector<4xi32>
+    scf.yield %lane_value : vector<4xi32>
+  }
+  %lane0 = vector.extract %value[0] : vector<4xi32> -> i32
+  %lane1 = vector.extract %value[1] : vector<4xi32> -> i32
+  %lane0_lo = test.fact_range_lo %lane0 : i32 -> i64
+  %lane0_hi = test.fact_range_hi %lane0 : i32 -> i64
+  %lane1_lo = test.fact_range_lo %lane1 : i32 -> i64
+  %lane1_hi = test.fact_range_hi %lane1 : i32 -> i64
+  func.return %lane0_lo, %lane0_hi, %lane1_lo, %lane1_hi : i64, i64, i64, i64
+}
+
+// ----
+func.def @region_branch_join_uniform_and_small_static_facts(%condition: i1) -> (i64, i64, i64, i64) {
+  %c2 = scalar.constant 2 : i32
+  %c4 = scalar.constant 4 : i32
+  %c8 = scalar.constant 8 : i32
+  scf.if %condition {
+    %uniform_value = vector.constant 4 : vector<4xi32>
+    test.use %uniform_value : vector<4xi32>
+  } else {
+    %lane_value = vector.from_elements %c2, %c4, %c8, %c4 : vector<4xi32>
+    test.use %lane_value : vector<4xi32>
+  }
+  %lane0_lo = scalar.constant 2 : i64
+  %lane0_hi = scalar.constant 4 : i64
+  %lane1_lo = scalar.constant 4 : i64
+  %lane1_hi = scalar.constant 4 : i64
+  func.return %lane0_lo, %lane0_hi, %lane1_lo, %lane1_hi : i64, i64, i64, i64
+}
+
+// ====
+
+// Iota summaries with compatible structure retain that structure while their
+// differing bases meet conservatively.
+func.def @cfg_join_iota_summaries(%condition: i1, %n: index) -> (i1) {
+  %c0 = index.constant 0 : index
+  %c1 = index.constant 1 : index
+  %c4 = index.constant 4 : index
+  cfg.cond_br %condition, ^left, ^right
+^left:
+  %left_value = vector.iota %c0 step %c1 : vector<[%n]xindex>
+  cfg.br ^join(%left_value: vector<[%n]xindex>)
+^right:
+  %right_value = vector.iota %c4 step %c1 : vector<[%n]xindex>
+  cfg.br ^join(%right_value: vector<[%n]xindex>)
+^join(%value: vector<[%n]xindex>):
+  %is_iota = test.fact_is_vector_iota %value : vector<[%n]xindex> -> i1
+  func.return %is_iota : i1
+}
+
+// ----
+func.def @cfg_join_iota_summaries(%condition: i1, %n: index) -> (i1) {
+  %c0 = index.constant 0 : index
+  %c1 = index.constant 1 : index
+  %c4 = index.constant 4 : index
+  cfg.cond_br %condition, ^left, ^right
+^left:
+  %left_value = vector.iota %c0 step %c1 : vector<[%n]xindex>
+  cfg.br ^join(%left_value: vector<[%n]xindex>)
+^right:
+  %right_value = vector.iota %c4 step %c1 : vector<[%n]xindex>
+  cfg.br ^join(%right_value: vector<[%n]xindex>)
+^join(%value: vector<[%n]xindex>):
+  %is_iota = scalar.constant true : i1
+  func.return %is_iota : i1
+}
+
+// ====
+
+// Prefix-mask summaries preserve their structural family across a CFG join.
+func.def @cfg_join_prefix_mask_summaries(%condition: i1, %n: index) -> (i1) {
+  %c0 = index.constant 0 : index
+  %c1 = index.constant 1 : index
+  cfg.cond_br %condition, ^left, ^right
+^left:
+  %left_value = vector.mask.range [%c0 to %n step %c1] : index -> vector<[%n]xi1>
+  cfg.br ^join(%left_value: vector<[%n]xi1>)
+^right:
+  %right_value = vector.mask.range [%c1 to %n step %c1] : index -> vector<[%n]xi1>
+  cfg.br ^join(%right_value: vector<[%n]xi1>)
+^join(%value: vector<[%n]xi1>):
+  %is_mask = test.fact_is_vector_prefix_mask %value : vector<[%n]xi1> -> i1
+  func.return %is_mask : i1
+}
+
+// ----
+func.def @cfg_join_prefix_mask_summaries(%condition: i1, %n: index) -> (i1) {
+  %c0 = index.constant 0 : index
+  %c1 = index.constant 1 : index
+  cfg.cond_br %condition, ^left, ^right
+^left:
+  %left_value = vector.mask.range [%c0 to %n step %c1] : index -> vector<[%n]xi1>
+  cfg.br ^join(%left_value: vector<[%n]xi1>)
+^right:
+  %right_value = vector.mask.range [%c1 to %n step %c1] : index -> vector<[%n]xi1>
+  cfg.br ^join(%right_value: vector<[%n]xi1>)
+^join(%value: vector<[%n]xi1>):
+  %is_mask = scalar.constant true : i1
+  func.return %is_mask : i1
+}
+
+// ====
+
+// Structurally different extension families have no shared vector summary.
+func.def @cfg_join_incompatible_vector_summaries(%condition: i1, %n: index) -> (i1) {
+  %c0 = index.constant 0 : index
+  %c1 = index.constant 1 : index
+  cfg.cond_br %condition, ^iota, ^uniform
+^iota:
+  %iota_value = vector.iota %c0 step %c1 : vector<[%n]xindex>
+  cfg.br ^join(%iota_value: vector<[%n]xindex>)
+^uniform:
+  %uniform_value = vector.splat %c0 : vector<[%n]xindex>
+  cfg.br ^join(%uniform_value: vector<[%n]xindex>)
+^join(%value: vector<[%n]xindex>):
+  %is_iota = test.fact_is_vector_iota %value : vector<[%n]xindex> -> i1
+  func.return %is_iota : i1
+}
+
+// ----
+func.def @cfg_join_incompatible_vector_summaries(%condition: i1, %n: index) -> (i1) {
+  %c0 = index.constant 0 : index
+  %c1 = index.constant 1 : index
+  cfg.cond_br %condition, ^iota, ^uniform
+^iota:
+  %iota_value = vector.iota %c0 step %c1 : vector<[%n]xindex>
+  cfg.br ^join(%iota_value: vector<[%n]xindex>)
+^uniform:
+  %uniform_value = vector.constant 0 : vector<[%n]xindex>
+  cfg.br ^join(%uniform_value: vector<[%n]xindex>)
+^join(%value: vector<[%n]xindex>):
+  %is_iota = scalar.constant false : i1
+  func.return %is_iota : i1
+}
+
+// ====
+
+// A loop summary stabilizes a bounded per-lane join between its zero-trip
+// initial value and invariant backedge value.
+func.def @loop_join_small_static_lane_facts(%n: index) -> (i64, i64, i64, i64) {
+  %c0 = index.constant 0 : index
+  %n2 = index.assume %n [range(%n, 0, 4)] : index
+  %c1 = index.constant 1 : index
+  %v0 = scalar.constant 0 : i32
+  %v4 = scalar.constant 4 : i32
+  %v6 = scalar.constant 6 : i32
+  %v10 = scalar.constant 10 : i32
+  %initial = vector.from_elements %v0, %v10 : vector<2xi32>
+  %backedge = vector.from_elements %v4, %v6 : vector<2xi32>
+  %result = scf.for %iv = [%c0 to %n2 step %c1](%carried = %initial : vector<2xi32>) -> (vector<2xi32>) {
+    scf.yield %backedge : vector<2xi32>
+  }
+  %lane0 = vector.extract %result[0] : vector<2xi32> -> i32
+  %lane1 = vector.extract %result[1] : vector<2xi32> -> i32
+  %lane0_lo = test.fact_range_lo %lane0 : i32 -> i64
+  %lane0_hi = test.fact_range_hi %lane0 : i32 -> i64
+  %lane1_lo = test.fact_range_lo %lane1 : i32 -> i64
+  %lane1_hi = test.fact_range_hi %lane1 : i32 -> i64
+  func.return %lane0_lo, %lane0_hi, %lane1_lo, %lane1_hi : i64, i64, i64, i64
+}
+
+// ----
+func.def @loop_join_small_static_lane_facts(%n: index) -> (i64, i64, i64, i64) {
+  %lane0_lo = scalar.constant 0 : i64
+  %lane0_hi = scalar.constant 4 : i64
+  %lane1_lo = scalar.constant 6 : i64
+  %lane1_hi = scalar.constant 10 : i64
+  func.return %lane0_lo, %lane0_hi, %lane1_lo, %lane1_hi : i64, i64, i64, i64
+}
+
+// ====
+
+// A changing aggregate reaches the solver's late widening boundary and drops
+// per-lane detail instead of growing an unbounded sequence of range summaries.
+func.def @loop_widens_changing_small_static_lane_facts(%n: index) -> (i64, i64) {
+  %c0 = index.constant 0 : index
+  %n2 = index.assume %n [range(%n, 1, 8)] : index
+  %c1 = index.constant 1 : index
+  %v0 = scalar.constant 0 : i32
+  %initial = vector.from_elements %v0, %v0 : vector<2xi32>
+  %increment = vector.constant 1 : vector<2xi32>
+  %result = scf.for %iv = [%c0 to %n2 step %c1](%carried = %initial : vector<2xi32>) -> (vector<2xi32>) {
+    %next = vector.addi %carried, %increment : vector<2xi32>
+    scf.yield %next : vector<2xi32>
+  }
+  %lane = vector.extract %result[0] : vector<2xi32> -> i32
+  %lo = test.fact_range_lo %lane : i32 -> i64
+  %hi = test.fact_range_hi %lane : i32 -> i64
+  func.return %lo, %hi : i64, i64
+}
+
+// ----
+func.def @loop_widens_changing_small_static_lane_facts(%n: index) -> (i64, i64) {
+  %lo = scalar.constant -9223372036854775808 : i64
+  %hi = scalar.constant 9223372036854775807 : i64
+  func.return %lo, %hi : i64, i64
+}
+
+// ====
+
 // Finite-number FP8 scalar types publish no-infinity facts even without a
 // physical-storage schema.
 func.def @f8e4m3_type_vector_load_content(%buffer: buffer) -> (i1, i1) {


### PR DESCRIPTION
Vector fact extensions now survive control-flow joins whenever their representation has a bounded conservative meet.

The vector type domain previously handled semantically identical payloads and matrix-fragment role joins, but differing uniform-element, small-static-lane, iota, and prefix-mask summaries fell to unknown. Ordinary CFG and loop joins consequently discarded facts that downstream vector extraction, memory analysis, and lowering can still use.

Uniform and small-static aggregate facts now meet per logical lane within the existing fixed lane cap. Iota and prefix-mask summaries retain their structural family by meeting their scalar parameters. Mixed or incompatible families remain incomparable and drop the extension instead of inventing a common representation.

Late loop widening maintains the existing convergence boundary: stable summaries survive, finite matrix-fragment joins remain available, and changing aggregate summaries drop after the precise meet iterations instead of producing an unbounded sequence of ranges.

The generic RegionBranch summarization from #290 flows through the same type-owned meet. A structured `scf.if` result witness proves that path composes with vector extension joins, alongside CFG witnesses for every supported family and loop witnesses for stable and widening behavior.

## Reviewer Notes

The key policy boundary is between `loom_vector_meet_extension`, which performs every bounded conservative join, and `loom_vector_widen_extension`, which deliberately retains only stable payloads and finite matrix-fragment joins.
