### PR TITLE
[Loom] Register implicit Python parser sources

### DIFF
--- a/loom/py/loom/format/text/parser.py
+++ b/loom/py/loom/format/text/parser.py
@@ -1253,6 +1253,7 @@ class Parser:
         self._scope: NameScope = NameScope()
         self._module: Module = Module()
         self._tokenizer: Tokenizer = Tokenizer("")
+        self._implicit_source_id: int | None = None
         self._encoding_aliases: dict[str, EncodingInstance] = {}
         self._known_encodings: set[str] = set()
         self._reserved_result_names: list[str] = []
@@ -1292,6 +1293,9 @@ class Parser:
         global _CURRENT_ALIASES, _CURRENT_KNOWN_ENCODINGS
         self._tokenizer = Tokenizer(source, filename)
         self._module = Module()
+        self._implicit_source_id = (
+            self._find_or_add_source(filename) if filename else None
+        )
         self._scope = NameScope()
         self._encoding_aliases = {}
         _CURRENT_ALIASES = self._encoding_aliases
@@ -1664,6 +1668,7 @@ class Parser:
         """Parse a single operation from text. Convenience for testing."""
         self._tokenizer = Tokenizer(text)
         self._module = module if module is not None else Module()
+        self._implicit_source_id = self._find_or_add_source(self._tokenizer._filename)
         self._scope = scope if scope is not None else NameScope()
         op = self._parse_operation()
         op_decl = self._op_registry.get(op.name)
@@ -1802,15 +1807,7 @@ class Parser:
         # 5. Build Operation.
         # Default location: implicit source position from tokenizer.
         end_loc = tok.current_location()
-        location_id = self._module.add_location(
-            FileLocation(
-                source_id=0,
-                start_line=start_loc.line,
-                start_col=start_loc.column,
-                end_line=end_loc.line,
-                end_col=end_loc.column,
-            )
-        )
+        location_id = self._add_implicit_location(start_loc, end_loc)
 
         # Explicit location annotation overrides the implicit one.
         if tok.at(TokenKind.BARE_IDENT) and tok.peek().text == "loc":
@@ -1906,6 +1903,20 @@ class Parser:
         source_id = len(self._module.sources)
         self._module.sources.append(name)
         return source_id
+
+    def _add_implicit_location(self, start: SourceLocation, end: SourceLocation) -> int:
+        """Adds a source-backed implicit location, or returns unknown."""
+        if self._implicit_source_id is None:
+            return 0
+        return self._module.add_location(
+            FileLocation(
+                source_id=self._implicit_source_id,
+                start_line=start.line,
+                start_col=start.column,
+                end_line=end.line,
+                end_col=end.column,
+            )
+        )
 
     def _parse_file_location(self) -> int:
         """Parse "source":start_line:start_col to end_line:end_col.
@@ -3394,15 +3405,7 @@ class Parser:
         start_loc: SourceLocation,
     ) -> Operation:
         end_loc = self._tokenizer.current_location()
-        location_id = self._module.add_location(
-            FileLocation(
-                source_id=0,
-                start_line=start_loc.line,
-                start_col=start_loc.column,
-                end_line=end_loc.line,
-                end_col=end_loc.column,
-            )
-        )
+        location_id = self._add_implicit_location(start_loc, end_loc)
         op = Operation(
             name=name,
             attributes=attributes,

--- a/loom/py/loom/format/text/parser_test.py
+++ b/loom/py/loom/format/text/parser_test.py
@@ -2385,8 +2385,31 @@ class TestLocationParsing:
         loc = module.locations.get(op.location_id)
         # Implicit locations are FileLocations derived from the source text.
         assert isinstance(loc, FileLocation)
-        # source_id is 0 (the default for implicit locations).
         assert loc.source_id == 0
+        assert module.sources[loc.source_id] == "<input>"
+
+    def test_module_parser_registers_implicit_location_source(self) -> None:
+        from loom.ir import FileLocation
+
+        module = _op_parser().parse(
+            "test.decl @identity(%arg: i32) -> (i32)\n",
+            filename="model.loom",
+        )
+        op = module.symbols[0].op
+        assert op is not None
+        loc = module.locations.get(op.location_id)
+        assert isinstance(loc, FileLocation)
+        assert module.sources[loc.source_id] == "model.loom"
+
+    def test_empty_filename_omits_implicit_location(self) -> None:
+        module = _op_parser().parse(
+            "test.decl @identity(%arg: i32) -> (i32)\n",
+            filename="",
+        )
+        op = module.symbols[0].op
+        assert op is not None
+        assert op.location_id == 0
+        assert module.sources == []
 
 
 # ============================================================================


### PR DESCRIPTION
Python text parsing now interns the source name used by every implicit operation location before the module location table can be serialized.

Implicit locations previously hard-coded source ID zero without ensuring that the module had a source-table entry at that position. A module parsed from ordinary text could therefore contain an out-of-range location reference that only surfaced during later bytecode serialization.

Complete-module parsing now tracks and interns the selected filename, single-operation parsing interns its default source in the destination module, and deliberately source-less parsing uses the canonical unknown location instead of manufacturing a dangling reference.

Coverage exercises default, custom, and empty filenames through the production parser path.
