### PR TITLE
[Loom] Select target providers for launch evaluation

### DIFF
--- a/loom/binding/c/BUILD.bazel
+++ b/loom/binding/c/BUILD.bazel
@@ -197,6 +197,7 @@ loom_cc_library(
         "//loom/src/loom/target/reporting:artifact_manifest",
         "//loom/src/loom/target/reporting:format",
         "//loom/src/loom/target/reporting:report",
+        "//loom/src/loom/tooling/compile:pipeline",
         "//loom/src/loom/tooling/config",
         "//loom/src/loom/util:json",
         "//loom/src/loom/util:stream",

--- a/loom/binding/c/CMakeLists.txt
+++ b/loom/binding/c/CMakeLists.txt
@@ -121,6 +121,7 @@ loom_cc_library(
     loom::target::reporting::report
     loom::target::specialization
     loom::target::types
+    loom::tooling::compile::pipeline
     loom::tooling::config
     loom::util::json
     loom::util::stream

--- a/loom/binding/c/include/loomc/launch_config.h
+++ b/loom/binding/c/include/loomc/launch_config.h
@@ -92,7 +92,7 @@ typedef struct loomc_launch_config_eval_options_t {
   /// Size of this structure in bytes.
   loomc_host_size_t structure_size;
 
-  /// Extension chain for future launch configuration evaluation options.
+  /// Unordered extension chain for launch configuration evaluation options.
   const void* next;
 
   /// Kernel function symbol to evaluate, with or without a leading `@`.

--- a/loom/binding/c/include/loomc/target.h
+++ b/loom/binding/c/include/loomc/target.h
@@ -176,15 +176,16 @@ typedef struct loomc_target_specialization_t {
   /// Function symbol name. A leading `@` is accepted.
   loomc_string_view_t function_symbol;
 
-  /// Complete target profile borrowed for the compile invocation.
+  /// Complete target profile borrowed for the invocation.
   loomc_target_profile_t* target_profile;
 } loomc_target_specialization_t;
 
-/// Compile option extension carrying per-function target specializations.
+/// Option extension carrying per-function target specializations.
 ///
-/// Put this descriptor on `loomc_compile_options_t::next`. Every row is
-/// validated before any function target is changed. The invocation borrows the
-/// row array, symbol strings, and profiles for the duration of the call.
+/// Put this descriptor on `loomc_compile_options_t::next` or
+/// `loomc_launch_config_eval_options_t::next`. Every row is validated before
+/// any function target is changed. The invocation borrows the row array,
+/// symbol strings, and profiles for the duration of the call.
 typedef struct loomc_target_specialization_options_t {
   /// Structure type. Must be
   /// `LOOMC_STRUCTURE_TYPE_TARGET_SPECIALIZATION_OPTIONS`.
@@ -193,7 +194,7 @@ typedef struct loomc_target_specialization_options_t {
   /// Size of this structure in bytes.
   loomc_host_size_t structure_size;
 
-  /// Next compile option extension.
+  /// Additional option extensions in the same unordered chain.
   const void* next;
 
   /// Specialization rows borrowed for the invocation.

--- a/loom/binding/c/src/compile.c
+++ b/loom/binding/c/src/compile.c
@@ -165,20 +165,9 @@ static loomc_status_t loomc_compile_specialize_functions(
     return loomc_ok_status();
   }
 
-  loom_target_specialization_request_t* requests = NULL;
-  LOOMC_RETURN_IF_ERROR(loomc_status_from_iree(
-      iree_arena_allocate_array(arena, options->specialization_count,
-                                sizeof(*requests), (void**)&requests)));
-  for (loomc_host_size_t i = 0; i < options->specialization_count; ++i) {
-    const loomc_target_specialization_t* specialization =
-        &options->specializations[i];
-    requests[i] = (loom_target_specialization_request_t){
-        .function_name =
-            iree_string_view_from_loomc(specialization->function_symbol),
-        .target_profile = loomc_target_profile_loom_target_profile(
-            specialization->target_profile),
-    };
-  }
+  loom_target_specialization_request_list_t requests = {0};
+  LOOMC_RETURN_IF_ERROR(loomc_target_specialization_options_make_request_list(
+      options, arena, &requests));
 
   loomc_compile_diagnostic_capture_t capture = {
       .result = result,
@@ -186,11 +175,7 @@ static loomc_status_t loomc_compile_specialize_functions(
   loom_target_specialization_result_t specialization_result = {0};
   LOOMC_RETURN_IF_ERROR(loomc_status_from_iree(loom_target_specialize_functions(
       loomc_target_environment_loom_target_environment(target_environment),
-      module,
-      (loom_target_specialization_request_list_t){
-          .values = requests,
-          .count = options->specialization_count,
-      },
+      module, requests,
       (iree_diagnostic_emitter_t){
           .fn = loomc_compile_capture_diagnostic_emission,
           .user_data = &capture,

--- a/loom/binding/c/src/launch_config.c
+++ b/loom/binding/c/src/launch_config.c
@@ -9,12 +9,16 @@
 #include <stdint.h>
 
 #include "config.h"
+#include "context.h"
 #include "diagnostic.h"
 #include "iree/base/api.h"
 #include "loom/analysis/kernel_launch_config.h"
+#include "loom/ops/op_defs.h"
+#include "loom/tooling/compile/pipeline.h"
 #include "loomc/iree.h"
 #include "module.h"
 #include "result.h"
+#include "target.h"
 #include "workspace.h"
 
 typedef struct loomc_launch_config_target_capture_t {
@@ -37,7 +41,21 @@ typedef struct loomc_launch_config_resolved_options_t {
 
   // Fields that must be proven.
   loomc_launch_config_field_flags_t required_fields;
+
+  // Optional exact per-function target specializations.
+  const loomc_target_specialization_options_t* target_specialization;
 } loomc_launch_config_resolved_options_t;
+
+typedef struct loomc_launch_config_target_preparation_t {
+  // Expanded-source pipeline products owning exact target facts.
+  loom_compile_pipeline_result_t pipeline_result;
+
+  // Exact target facts selected for the requested launch function.
+  const loom_target_facts_t* effective_target_facts;
+
+  // True when pipeline_result requires deinitialization.
+  bool pipeline_initialized;
+} loomc_launch_config_target_preparation_t;
 
 static iree_status_t loomc_launch_config_capture_diagnostic(
     void* user_data, const loom_diagnostic_emission_t* emission) {
@@ -45,6 +63,14 @@ static iree_status_t loomc_launch_config_capture_diagnostic(
       (loomc_launch_config_target_capture_t*)user_data;
   return iree_status_from_loomc(loomc_result_add_loom_diagnostic_emission(
       capture->result, /*source=*/NULL, LOOM_EMITTER_PASS, emission));
+}
+
+static iree_status_t loomc_launch_config_capture_pipeline_diagnostic(
+    void* user_data, const loom_diagnostic_t* diagnostic) {
+  loomc_launch_config_target_capture_t* capture =
+      (loomc_launch_config_target_capture_t*)user_data;
+  return iree_status_from_loomc(loomc_result_add_loom_diagnostic(
+      capture->result, /*source=*/NULL, diagnostic));
 }
 
 static bool loomc_launch_config_string_view_is_valid(
@@ -108,12 +134,22 @@ loomc_launch_config_field_flags_from_kernel(
   return public_fields;
 }
 
+static bool loomc_launch_config_options_have_target_specialization(
+    const loomc_launch_config_resolved_options_t* options) {
+  return options->target_specialization != NULL &&
+         options->target_specialization->specialization_count != 0;
+}
+
+// TODO(benvanik): Remove source-module cloning when compilation emits a
+// compact launch configuration artifact. Configuration and target
+// specialization must then be applied only by the owning compilation.
 static bool loomc_launch_config_options_require_module_clone(
     const loomc_launch_config_resolved_options_t* options) {
   const loomc_config_options_t* config = options->config;
-  return config != NULL && (config->binding_count != 0 ||
-                            !loomc_string_view_is_empty(config->json_object) ||
-                            config->flags != 0);
+  return loomc_launch_config_options_have_target_specialization(options) ||
+         (config != NULL && (config->binding_count != 0 ||
+                             !loomc_string_view_is_empty(config->json_object) ||
+                             config->flags != 0));
 }
 
 static loomc_status_t loomc_launch_config_validate_result(
@@ -158,11 +194,9 @@ static loomc_status_t loomc_launch_config_resolve_options(
         LOOMC_STATUS_INVALID_ARGUMENT,
         "launch config eval options structure_size is too small");
   }
-  if (options->next != NULL) {
-    return loomc_make_status(
-        LOOMC_STATUS_UNIMPLEMENTED,
-        "launch config eval option extensions are not supported");
-  }
+  const loomc_target_specialization_options_t* target_specialization = NULL;
+  LOOMC_RETURN_IF_ERROR(loomc_target_specialization_options_resolve(
+      options->next, &target_specialization));
   if (!loomc_launch_config_string_view_is_valid(options->function_symbol)) {
     return loomc_make_status(LOOMC_STATUS_INVALID_ARGUMENT,
                              "function symbol has length but no data");
@@ -190,6 +224,7 @@ static loomc_status_t loomc_launch_config_resolve_options(
       .workload_arguments = options->workload_arguments,
       .workload_argument_count = options->workload_argument_count,
       .required_fields = options->required_fields,
+      .target_specialization = target_specialization,
   };
   return loomc_ok_status();
 }
@@ -293,6 +328,7 @@ static void loomc_launch_config_copy_from_kernel(
 static loom_kernel_launch_config_options_t
 loomc_launch_config_make_kernel_options(
     const loomc_launch_config_resolved_options_t* options,
+    const loom_target_facts_t* effective_target_facts,
     iree_diagnostic_emitter_t emitter) {
   return (loom_kernel_launch_config_options_t){
       .function_symbol = options->function_symbol,
@@ -300,8 +336,106 @@ loomc_launch_config_make_kernel_options(
       .workload_argument_count = options->workload_argument_count,
       .required_fields =
           loomc_launch_config_field_flags_to_kernel(options->required_fields),
+      .effective_target_facts = effective_target_facts,
       .diagnostic_emitter = emitter,
   };
+}
+
+static loom_func_like_t loomc_launch_config_find_function(
+    loom_module_t* module, iree_string_view_t function_symbol) {
+  function_symbol = iree_string_view_trim(function_symbol);
+  (void)iree_string_view_consume_prefix_char(&function_symbol, '@');
+  const loom_string_id_t name_id =
+      loom_module_lookup_string(module, function_symbol);
+  if (name_id == LOOM_STRING_ID_INVALID) {
+    return (loom_func_like_t){0};
+  }
+  const loom_symbol_id_t symbol_id = loom_module_find_symbol(module, name_id);
+  if (symbol_id == LOOM_SYMBOL_ID_INVALID) {
+    return (loom_func_like_t){0};
+  }
+  return loom_func_like_cast(module,
+                             module->symbols.entries[symbol_id].defining_op);
+}
+
+static void loomc_launch_config_target_preparation_deinitialize(
+    loomc_launch_config_target_preparation_t* preparation) {
+  if (preparation->pipeline_initialized) {
+    loom_compile_pipeline_result_deinitialize(&preparation->pipeline_result);
+  }
+  *preparation = (loomc_launch_config_target_preparation_t){0};
+}
+
+// TODO(benvanik): Delete this parallel expanded-source compilation when the
+// device compilation emits launch functions from its prepared function
+// versions.
+static loomc_status_t loomc_launch_config_prepare_target(
+    loomc_context_t* context, loom_module_t* module,
+    loomc_workspace_t* workspace,
+    const loomc_launch_config_resolved_options_t* options,
+    loomc_result_t* result,
+    loomc_launch_config_target_preparation_t* out_preparation) {
+  *out_preparation = (loomc_launch_config_target_preparation_t){0};
+  const loomc_target_specialization_options_t* target_specialization =
+      options->target_specialization;
+  if (target_specialization == NULL ||
+      target_specialization->specialization_count == 0) {
+    return loomc_ok_status();
+  }
+
+  loomc_target_environment_t* public_target_environment =
+      loomc_context_target_environment(context);
+  const loomc_target_pass_environment_t* pass_environment =
+      loomc_context_target_pass_environment(context);
+
+  iree_arena_allocator_t request_arena;
+  iree_arena_initialize(loomc_workspace_block_pool(workspace), &request_arena);
+  loom_target_specialization_request_list_t requests = {0};
+  loomc_status_t status = loomc_target_specialization_options_make_request_list(
+      target_specialization, &request_arena, &requests);
+  if (loomc_status_is_ok(status)) {
+    loomc_launch_config_target_capture_t capture = {
+        .result = result,
+    };
+    loom_compile_pipeline_options_t pipeline_options = {0};
+    loom_compile_pipeline_options_initialize(&pipeline_options);
+    pipeline_options.default_pipeline =
+        LOOM_COMPILE_DEFAULT_PIPELINE_EXPANDED_SOURCE;
+    pipeline_options.target_environment =
+        loomc_target_environment_loom_target_environment(
+            public_target_environment);
+    pipeline_options.target_specializations = requests;
+    pipeline_options.low_descriptor_registry =
+        &pass_environment->low_descriptor_registry;
+    pipeline_options.diagnostic_sink = (loom_diagnostic_sink_t){
+        .fn = loomc_launch_config_capture_pipeline_diagnostic,
+        .user_data = &capture,
+    };
+    out_preparation->pipeline_initialized = true;
+    status = loomc_status_from_iree(loom_compile_run_pipeline(
+        module, &pipeline_options, loomc_workspace_block_pool(workspace),
+        &out_preparation->pipeline_result));
+  }
+  iree_arena_deinitialize(&request_arena);
+
+  if (loomc_status_is_ok(status) &&
+      out_preparation->pipeline_result.pass.error_count != 0) {
+    status = loomc_result_set_state(result, LOOMC_RESULT_STATE_FAILED);
+  }
+  if (loomc_status_is_ok(status) && loomc_result_succeeded(result)) {
+    const loom_func_like_t function =
+        loomc_launch_config_find_function(module, options->function_symbol);
+    if (loom_func_like_isa(function)) {
+      const loom_target_function_version_t* function_version =
+          loom_target_function_version_list_find(
+              &out_preparation->pipeline_result.function_versions, function);
+      if (function_version != NULL) {
+        out_preparation->effective_target_facts =
+            function_version->effective_target_facts;
+      }
+    }
+  }
+  return status;
 }
 
 loomc_status_t loomc_module_evaluate_launch_config(
@@ -324,6 +458,11 @@ loomc_status_t loomc_module_evaluate_launch_config(
   loomc_launch_config_resolved_options_t resolved_options = {0};
   LOOMC_RETURN_IF_ERROR(
       loomc_launch_config_resolve_options(options, &resolved_options));
+  loomc_context_t* context = loomc_module_context(module);
+  LOOMC_RETURN_IF_ERROR(
+      loomc_target_specialization_options_validate_environment(
+          resolved_options.target_specialization,
+          loomc_context_target_environment(context)));
 
   loomc_result_t* result = NULL;
   LOOMC_RETURN_IF_ERROR(
@@ -338,7 +477,7 @@ loomc_status_t loomc_module_evaluate_launch_config(
     bool direct_evaluated = false;
     loom_kernel_launch_config_t kernel_config = {0};
     const loom_kernel_launch_config_options_t kernel_options =
-        loomc_launch_config_make_kernel_options(&resolved_options,
+        loomc_launch_config_make_kernel_options(&resolved_options, NULL,
                                                 (iree_diagnostic_emitter_t){0});
     loomc_status_t direct_status =
         loomc_status_from_iree(loom_kernel_launch_config_try_evaluate_direct(
@@ -356,6 +495,7 @@ loomc_status_t loomc_module_evaluate_launch_config(
   }
 
   loomc_module_t* scratch_module = NULL;
+  loomc_launch_config_target_preparation_t target_preparation = {0};
   loomc_status_t status = loomc_ok_status();
   const loom_module_t* internal_module = source_internal_module;
   if (internal_module == NULL || requires_module_clone) {
@@ -375,6 +515,13 @@ loomc_status_t loomc_module_evaluate_launch_config(
     };
     status = loomc_config_apply_to_module(&config_options);
   }
+  if (loomc_status_is_ok(status) && loomc_result_succeeded(result) &&
+      loomc_launch_config_options_have_target_specialization(
+          &resolved_options)) {
+    status = loomc_launch_config_prepare_target(
+        context, loomc_module_loom_module(scratch_module), workspace,
+        &resolved_options, result, &target_preparation);
+  }
 
   loom_kernel_launch_config_t kernel_config = {0};
   if (loomc_status_is_ok(status) && loomc_result_succeeded(result)) {
@@ -386,7 +533,9 @@ loomc_status_t loomc_module_evaluate_launch_config(
         .user_data = &capture,
     };
     const loom_kernel_launch_config_options_t kernel_options =
-        loomc_launch_config_make_kernel_options(&resolved_options, emitter);
+        loomc_launch_config_make_kernel_options(
+            &resolved_options, target_preparation.effective_target_facts,
+            emitter);
     status = loomc_status_from_iree(loom_kernel_launch_config_evaluate(
         internal_module, loomc_workspace_block_pool(workspace), &kernel_options,
         &kernel_config));
@@ -404,6 +553,7 @@ loomc_status_t loomc_module_evaluate_launch_config(
   }
 
   loomc_result_release(result);
+  loomc_launch_config_target_preparation_deinitialize(&target_preparation);
   loomc_module_release(scratch_module);
   return status;
 }

--- a/loom/binding/c/src/target.c
+++ b/loom/binding/c/src/target.c
@@ -346,6 +346,36 @@ loomc_status_t loomc_target_specialization_options_validate_environment(
   return loomc_ok_status();
 }
 
+loomc_status_t loomc_target_specialization_options_make_request_list(
+    const loomc_target_specialization_options_t* options,
+    iree_arena_allocator_t* arena,
+    loom_target_specialization_request_list_t* out_requests) {
+  *out_requests = (loom_target_specialization_request_list_t){0};
+  if (options == NULL || options->specialization_count == 0) {
+    return loomc_ok_status();
+  }
+
+  loom_target_specialization_request_t* requests = NULL;
+  LOOMC_RETURN_IF_ERROR(loomc_status_from_iree(
+      iree_arena_allocate_array(arena, options->specialization_count,
+                                sizeof(*requests), (void**)&requests)));
+  for (loomc_host_size_t i = 0; i < options->specialization_count; ++i) {
+    const loomc_target_specialization_t* specialization =
+        &options->specializations[i];
+    requests[i] = (loom_target_specialization_request_t){
+        .function_name =
+            iree_string_view_from_loomc(specialization->function_symbol),
+        .target_profile = loomc_target_profile_loom_target_profile(
+            specialization->target_profile),
+    };
+  }
+  *out_requests = (loom_target_specialization_request_list_t){
+      .values = requests,
+      .count = options->specialization_count,
+  };
+  return loomc_ok_status();
+}
+
 loomc_status_t loomc_target_pass_registry_initialize(
     const loomc_target_environment_t* target_environment,
     loom_pass_registry_storage_t* out_storage,

--- a/loom/binding/c/src/target.h
+++ b/loom/binding/c/src/target.h
@@ -7,11 +7,13 @@
 #ifndef LOOMC_TARGET_STORAGE_H_
 #define LOOMC_TARGET_STORAGE_H_
 
+#include "iree/base/internal/arena.h"
 #include "loom/codegen/low/pipeline/pass_environment.h"
 #include "loom/pass/registry.h"
 #include "loom/target/function_version.h"
 #include "loom/target/profile.h"
 #include "loom/target/provider.h"
+#include "loom/target/specialization.h"
 #include "loom/target/types.h"
 #include "loomc/target.h"
 #include "visibility.h"
@@ -90,6 +92,14 @@ LOOMC_API_PRIVATE loomc_status_t
 loomc_target_specialization_options_validate_environment(
     const loomc_target_specialization_options_t* options,
     const loomc_target_environment_t* target_environment);
+
+// Materializes internal target specialization requests from public options.
+// The returned list is owned by |arena| and remains valid until it is reset.
+LOOMC_API_PRIVATE loomc_status_t
+loomc_target_specialization_options_make_request_list(
+    const loomc_target_specialization_options_t* options,
+    iree_arena_allocator_t* arena,
+    loom_target_specialization_request_list_t* out_requests);
 
 // Creates a public target profile from a prepared target-family profile. Takes
 // ownership of |target_profile| on entry and calls |deinitialize| on failure or

--- a/loom/binding/c/test/target/amdgpu_test.cc
+++ b/loom/binding/c/test/target/amdgpu_test.cc
@@ -15,6 +15,7 @@
 #include "loomc/compile.h"
 #include "loomc/context.h"
 #include "loomc/emit.h"
+#include "loomc/launch_config.h"
 #include "loomc/module.h"
 #include "loomc/pass.h"
 #include "loomc/result.h"
@@ -425,6 +426,93 @@ ResultPtr EmitModule(loomc_target_environment_t* target_environment,
                         loomc_allocator_system(), &result);
   LOOMC_EXPECT_OK(status);
   return ResultPtr(result);
+}
+
+TEST(AmdgpuTargetTest, EvaluateLaunchConfigSelectsExactTargetProviders) {
+  TargetEnvironmentPtr target_environment = CreateAmdgpuTargetEnvironment();
+  ContextPtr context = CreateAmdgpuContext(target_environment.get());
+  WorkspacePtr workspace = CreateWorkspace();
+  SourcePtr source = CreateTextSource("target_specialized_launch.loom", R"(
+amdgpu.target<gfx11-generic> @gfx11_wave64 {subgroup_size = 64}
+amdgpu.target<gfx1151> @gfx1151_wave64 {subgroup_size = 64}
+
+func.template<test.experts_per_wave> target(@gfx1151_wave64) priority(20) @two_experts_per_wave(%expert_count: index) -> (index) {
+  %c2 = index.constant 2 : index
+  func.return %c2 : index
+}
+
+func.template<test.experts_per_wave> priority(1) @four_experts_per_wave(%expert_count: index) -> (index) {
+  %c4 = index.constant 4 : index
+  func.return %c4 : index
+}
+
+kernel.def target(@gfx11_wave64) @target_specialized_launch(%expert_count: index) {
+  %c1 = index.constant 1 : index
+  %wave_size = index.constant 64 : index
+  %experts_per_wave = func.apply<test.experts_per_wave>(%expert_count) : (index) -> (index)
+  %workgroup_count = index.div %expert_count, %experts_per_wave : index
+  kernel.launch.config workgroups(%workgroup_count, %c1, %c1) workgroup_size(%wave_size, %c1, %c1) : index
+} launch(%output: buffer) {
+  kernel.return
+}
+)");
+  ModulePtr module =
+      DeserializeModule(context.get(), workspace.get(), source.get());
+
+  struct TargetCase {
+    const char* target;
+    uint32_t expected_workgroup_count;
+  };
+  const TargetCase target_cases[] = {
+      {"gfx1100", 32},
+      {"gfx1151", 64},
+  };
+  for (const TargetCase& target_case : target_cases) {
+    TargetProfilePtr profile =
+        CreateTargetProfile(target_environment.get(), target_case.target);
+    const loomc_target_specialization_t specialization = {
+        /*.function_symbol=*/
+        loomc_make_cstring_view("target_specialized_launch"),
+        /*.target_profile=*/profile.get(),
+    };
+    const loomc_target_specialization_options_t target_options = {
+        /*.type=*/LOOMC_STRUCTURE_TYPE_TARGET_SPECIALIZATION_OPTIONS,
+        /*.structure_size=*/sizeof(target_options),
+        /*.next=*/nullptr,
+        /*.specializations=*/&specialization,
+        /*.specialization_count=*/1,
+    };
+    const int64_t workload_arguments[] = {128};
+    const loomc_launch_config_eval_options_t options = {
+        /*.type=*/LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG_EVAL_OPTIONS,
+        /*.structure_size=*/sizeof(options),
+        /*.next=*/&target_options,
+        /*.function_symbol=*/
+        loomc_make_cstring_view("target_specialized_launch"),
+        /*.config=*/{},
+        /*.workload_arguments=*/workload_arguments,
+        /*.workload_argument_count=*/IREE_ARRAYSIZE(workload_arguments),
+        /*.required_fields=*/
+        LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT |
+            LOOMC_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_SIZE,
+    };
+    loomc_launch_config_t launch_config = {
+        /*.type=*/LOOMC_STRUCTURE_TYPE_LAUNCH_CONFIG,
+        /*.structure_size=*/sizeof(launch_config),
+    };
+    loomc_result_t* result = nullptr;
+    LOOMC_EXPECT_OK(loomc_module_evaluate_launch_config(
+        module.get(), workspace.get(), &options, loomc_allocator_system(),
+        &launch_config, &result));
+    ResultPtr result_ptr(result);
+    ExpectSucceededResult(result_ptr.get());
+    EXPECT_EQ(launch_config.workgroup_count.x,
+              target_case.expected_workgroup_count)
+        << target_case.target;
+    EXPECT_EQ(launch_config.workgroup_count.y, 1u) << target_case.target;
+    EXPECT_EQ(launch_config.workgroup_count.z, 1u) << target_case.target;
+    EXPECT_EQ(launch_config.workgroup_size.x, 64u) << target_case.target;
+  }
 }
 
 TEST(AmdgpuTargetTest,

--- a/loom/src/loom/target/arch/amdgpu/test/execution/BUILD.bazel
+++ b/loom/src/loom/target/arch/amdgpu/test/execution/BUILD.bazel
@@ -24,6 +24,7 @@ exports_files([
     "gfx9_4_mfma_families.loom",
     "loop_carried_lane_liveness.loom",
     "mxfp4_decode_bf16.loom",
+    "target_specialized_launch_config.loom",
     "workgroup_scan_wave64.loom",
 ])
 
@@ -147,6 +148,19 @@ iree_execution_test_suite(
         "global_atomic_add_f32.loom",
     ],
     manifests = ["global_atomic_add_f32.test.json"],
+    tags = _AMDGPU_EXECUTION_TEST_TAGS,
+    target_compatible_with = _AMDGPU_HAL_COMPATIBLE_WITH,
+    tools = {
+        "iree-test-loom": "//loom/src/loom/tools/iree-test-loom",
+    },
+)
+
+iree_execution_test_suite(
+    name = "target_specialized_launch_config_execution_test",
+    data = [
+        "target_specialized_launch_config.loom",
+    ],
+    manifests = ["target_specialized_launch_config.test.json"],
     tags = _AMDGPU_EXECUTION_TEST_TAGS,
     target_compatible_with = _AMDGPU_HAL_COMPATIBLE_WITH,
     tools = {

--- a/loom/src/loom/target/arch/amdgpu/test/execution/CMakeLists.txt
+++ b/loom/src/loom/target/arch/amdgpu/test/execution/CMakeLists.txt
@@ -281,6 +281,23 @@ endif()
 if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_AMDGPU)
 iree_execution_test_suite(
   NAME
+    target_specialized_launch_config_execution_test
+  MANIFESTS
+    "target_specialized_launch_config.test.json"
+  TOOLS
+    "iree-test-loom=loom::tools::iree-test-loom"
+  DATA
+    "${PROJECT_SOURCE_DIR}/loom/src/loom/target/arch/amdgpu/test/execution/target_specialized_launch_config.loom"
+  LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
+    "requires-gpu-amd"
+    "runtime-resource=amd-gpu"
+)
+endif()
+
+if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU AND LOOM_EXECUTE_IREE_HAL AND IREE_HAL_DRIVER_AMDGPU)
+iree_execution_test_suite(
+  NAME
     workgroup_scan_wave64_execution_test
   MANIFESTS
     "workgroup_scan_wave64.test.json"

--- a/loom/src/loom/target/arch/amdgpu/test/execution/target_specialized_launch_config.loom
+++ b/loom/src/loom/target/arch/amdgpu/test/execution/target_specialized_launch_config.loom
@@ -1,0 +1,52 @@
+// Target provider selection must expand the launch region and device body
+// against the same exact profile. Gfx1100 uses four items per workgroup while
+// gfx1151 uses two; both paths must cover the same 128-item workload.
+amdgpu.target<gfx11-generic> @gfx11_wave64 {subgroup_size = 64}
+
+amdgpu.target<gfx1151> @gfx1151_wave64 {subgroup_size = 64}
+
+func.template<test.items_per_workgroup> target(@gfx1151_wave64) priority(20) @gfx1151_items_per_workgroup() -> (index) {
+  %c2 = index.constant 2 : index
+  func.return %c2 : index
+}
+
+func.template<test.items_per_workgroup> priority(1) @gfx11_items_per_workgroup() -> (index) {
+  %c4 = index.constant 4 : index
+  func.return %c4 : index
+}
+
+kernel.def target(@gfx11_wave64) @target_specialized_launch_config(%item_count: index) {
+  %c1 = index.constant 1 : index
+  %wave_size = index.constant 64 : index
+  %items_per_workgroup = func.apply<test.items_per_workgroup>() : () -> (index)
+  %workgroup_count = index.div %item_count, %items_per_workgroup : index
+  kernel.launch.config workgroups(%workgroup_count, %c1, %c1) workgroup_size(%wave_size, %c1, %c1) : index
+} launch(%output: buffer) {
+  %c0 = index.constant 0 : index
+  %base = index.constant 0 : offset
+  %workgroup = kernel.workgroup.id<x> : index
+  %is_first_workgroup = index.cmp eq, %workgroup, %c0 : index
+  scf.if %is_first_workgroup {
+    %workitem = kernel.workitem.id<x> : index
+    %is_first_workitem = index.cmp eq, %workitem, %c0 : index
+    scf.if %is_first_workitem {
+      %items_per_workgroup = func.apply<test.items_per_workgroup>() : () -> (index)
+      %workgroup_count = kernel.workgroup.count<x> : index
+      %covered_item_count = index.mul %items_per_workgroup, %workgroup_count : index
+      %covered_item_count_i32 = index.cast %covered_item_count : index to i32
+      %output_global = buffer.assume.memory_space<global> %output : buffer
+      %output_view = buffer.view %output_global[%base] : buffer -> view<1xi32, #dense>
+      view.store %covered_item_count_i32, %output_view[%c0] : i32, view<1xi32, #dense>
+    }
+  }
+  kernel.return
+}
+
+check.case public @target_specialized_launch_config_case {
+  %item_count = check.literal value(128) : index
+  %actual = check.generate.fill value(0) : tensor<1xi32>
+  %expected = check.generate.fill value(128) : tensor<1xi32>
+  kernel.launch @target_specialized_launch_config[%item_count](%actual) : [index](tensor<1xi32>)
+  check.expect.equal actual(%actual) expected(%expected) : tensor<1xi32>
+  check.return
+}

--- a/loom/src/loom/target/arch/amdgpu/test/execution/target_specialized_launch_config.test.json
+++ b/loom/src/loom/target/arch/amdgpu/test/execution/target_specialized_launch_config.test.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "cases": [
+    {
+      "name": "selects matching target providers for launch and body",
+      "run": {
+        "tool": "iree-test-loom",
+        "args": [
+          "{srcdir}/target_specialized_launch_config.loom",
+          "--device=amdgpu"
+        ]
+      },
+      "stdout": {
+        "contains": {
+          "unordered": [
+            "\"format\":\"loom.test.v0\"",
+            "\"case_count\":1",
+            "\"sample_count\":1",
+            "\"failed_sample_count\":0",
+            "\"skipped_case_count\":0",
+            "\"planning_issue_count\":0"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/loom/src/loom/target/pipeline.c
+++ b/loom/src/loom/target/pipeline.c
@@ -402,6 +402,16 @@ static iree_status_t loom_target_pipeline_build_low_preparation(
   return loom_low_pipeline_build_packetization_preparation(builder);
 }
 
+static iree_status_t loom_target_pipeline_build_expanded_source_body(
+    loom_builder_t* builder, void* user_data) {
+  loom_op_t* for_op = NULL;
+  IREE_RETURN_IF_ERROR(loom_target_pipeline_build_for_target_functions(
+      builder,
+      loom_target_pipeline_build_source_normalization_before_authoring_expansion,
+      user_data, &for_op));
+  return loom_target_pipeline_build_authoring_expansion(builder);
+}
+
 static iree_status_t loom_target_pipeline_build_source_low_body(
     loom_builder_t* builder, void* user_data) {
   const loom_target_pipeline_build_context_t* context =
@@ -411,11 +421,8 @@ static iree_status_t loom_target_pipeline_build_source_low_body(
   IREE_RETURN_IF_ERROR(loom_target_pipeline_resolve_control_flow_lowering(
       context->options, &control_flow_lowering));
   loom_op_t* for_op = NULL;
-  IREE_RETURN_IF_ERROR(loom_target_pipeline_build_for_target_functions(
-      builder,
-      loom_target_pipeline_build_source_normalization_before_authoring_expansion,
-      user_data, &for_op));
-  IREE_RETURN_IF_ERROR(loom_target_pipeline_build_authoring_expansion(builder));
+  IREE_RETURN_IF_ERROR(
+      loom_target_pipeline_build_expanded_source_body(builder, user_data));
   IREE_RETURN_IF_ERROR(loom_target_pipeline_build_for_target_functions(
       builder,
       loom_target_pipeline_build_math_legalization_after_authoring_expansion,
@@ -495,6 +502,27 @@ static iree_status_t loom_target_pipeline_build_prepared_low_body(
   loom_op_t* for_op = NULL;
   return loom_target_pipeline_build_for_target_functions(
       builder, loom_target_pipeline_build_low_preparation, user_data, &for_op);
+}
+
+iree_status_t loom_target_pipeline_build_to_expanded_source(
+    loom_module_t* pipeline_module, iree_string_view_t name,
+    const loom_target_pipeline_options_t* options,
+    const loom_target_environment_t* target_environment,
+    loom_pass_environment_t pass_environment, loom_op_t** out_pipeline_op) {
+  IREE_ASSERT_ARGUMENT(pipeline_module);
+  IREE_ASSERT_ARGUMENT(target_environment);
+  IREE_ASSERT_ARGUMENT(out_pipeline_op);
+  *out_pipeline_op = NULL;
+
+  const loom_target_pipeline_build_context_t context = {
+      .target_environment = target_environment,
+      .pass_environment = pass_environment,
+      .options = options,
+  };
+  return loom_pass_ir_build_pipeline(
+      pipeline_module, name, LOOM_PASS_ANCHOR_MODULE,
+      loom_target_pipeline_build_expanded_source_body, (void*)&context,
+      out_pipeline_op);
 }
 
 iree_status_t loom_target_pipeline_build_to_source_low(

--- a/loom/src/loom/target/pipeline.h
+++ b/loom/src/loom/target/pipeline.h
@@ -23,6 +23,22 @@
 extern "C" {
 #endif
 
+// Builds a module-root pipeline that normalizes target source and expands all
+// resolvable authoring templates.
+//
+// The resulting source module retains kernel launch regions and device bodies
+// while selecting the same target providers consumed by later source-to-low
+// lowering. This boundary is suitable for target-specific source inspection
+// and launch configuration evaluation.
+//
+// |pass_environment| must contain exact function versions when target provider
+// predicates depend on invocation-selected target profiles.
+iree_status_t loom_target_pipeline_build_to_expanded_source(
+    loom_module_t* pipeline_module, iree_string_view_t name,
+    const loom_target_pipeline_options_t* options,
+    const loom_target_environment_t* target_environment,
+    loom_pass_environment_t pass_environment, loom_op_t** out_pipeline_op);
+
 // Builds a module-root pipeline that lowers source/kernel IR to target-low IR.
 //
 // The produced pipeline stops before target ABI/resource materialization and

--- a/loom/src/loom/tooling/compile/pipeline.c
+++ b/loom/src/loom/tooling/compile/pipeline.c
@@ -69,6 +69,11 @@ static iree_status_t loom_compile_build_default_pipeline(
     const loom_compile_pipeline_options_t* options,
     loom_pass_environment_t pass_environment, loom_op_t** out_pipeline_op) {
   switch (options->default_pipeline) {
+    case LOOM_COMPILE_DEFAULT_PIPELINE_EXPANDED_SOURCE:
+      return loom_target_pipeline_build_to_expanded_source(
+          pipeline_module, IREE_SV("__loom_compile_default"),
+          &options->target_pipeline_options, options->target_environment,
+          pass_environment, out_pipeline_op);
     case LOOM_COMPILE_DEFAULT_PIPELINE_SOURCE_LOW:
       return loom_target_pipeline_build_to_source_low(
           pipeline_module, IREE_SV("__loom_compile_default"),
@@ -99,6 +104,8 @@ static iree_status_t loom_compile_build_default_pipeline(
 static iree_string_view_t loom_compile_default_pipeline_stage_name(
     loom_compile_default_pipeline_t default_pipeline) {
   switch (default_pipeline) {
+    case LOOM_COMPILE_DEFAULT_PIPELINE_EXPANDED_SOURCE:
+      return IREE_SV("expanded-source");
     case LOOM_COMPILE_DEFAULT_PIPELINE_SOURCE_LOW:
       return IREE_SV("source-low");
     case LOOM_COMPILE_DEFAULT_PIPELINE_SOURCE_LOW_ARTIFACTS:

--- a/loom/src/loom/tooling/compile/pipeline.h
+++ b/loom/src/loom/tooling/compile/pipeline.h
@@ -45,6 +45,9 @@ typedef enum loom_compile_default_pipeline_e {
   // Build the full prepared target-low pipeline including target ABI/resource
   // materialization and packetization preparation.
   LOOM_COMPILE_DEFAULT_PIPELINE_PREPARED_LOW = 3,
+  // Normalize target source and expand resolvable authoring templates while
+  // retaining source kernel launch regions and device bodies.
+  LOOM_COMPILE_DEFAULT_PIPELINE_EXPANDED_SOURCE = 4,
 } loom_compile_default_pipeline_t;
 
 typedef struct loom_compile_pipeline_options_t {

--- a/loom/src/loom/tooling/execution/hal/testbench_actual.c
+++ b/loom/src/loom/tooling/execution/hal/testbench_actual.c
@@ -327,6 +327,8 @@ void loom_run_hal_testbench_actual_provider_deinitialize(
         provider->context->host_allocator);
   }
   loom_compile_pipeline_result_deinitialize(&provider->pipeline_result);
+  loom_compile_pipeline_result_deinitialize(
+      &provider->launch_config_pipeline_result);
   loom_module_free(provider->launch_config_module);
   if (provider->compile_module_initialized) {
     loom_run_module_deinitialize(&provider->compile_module);
@@ -357,16 +359,15 @@ static iree_status_t loom_run_hal_testbench_module_symbol_name_from_ref(
   return iree_ok_status();
 }
 
-static iree_status_t loom_run_hal_testbench_resolve_compile_func(
-    loom_run_hal_testbench_actual_provider_t* provider,
-    iree_string_view_t entry_symbol, loom_func_like_t* out_func) {
+static iree_status_t loom_run_hal_testbench_resolve_func(
+    loom_module_t* module, iree_string_view_t entry_symbol,
+    loom_func_like_t* out_func) {
   *out_func = (loom_func_like_t){0};
-  loom_module_t* module = provider->compile_module.module;
   const loom_string_id_t entry_name_id =
       loom_module_lookup_string(module, entry_symbol);
   if (entry_name_id == LOOM_STRING_ID_INVALID) {
     return iree_make_status(IREE_STATUS_NOT_FOUND,
-                            "entry symbol '@%.*s' was not found in compile "
+                            "entry symbol '@%.*s' was not found in selected "
                             "module string table",
                             (int)entry_symbol.size, entry_symbol.data);
   }
@@ -374,7 +375,7 @@ static iree_status_t loom_run_hal_testbench_resolve_compile_func(
   if (symbol_id == LOOM_SYMBOL_ID_INVALID ||
       symbol_id >= module->symbols.count) {
     return iree_make_status(IREE_STATUS_NOT_FOUND,
-                            "entry symbol '@%.*s' was not found in compile "
+                            "entry symbol '@%.*s' was not found in selected "
                             "module symbol table",
                             (int)entry_symbol.size, entry_symbol.data);
   }
@@ -496,6 +497,30 @@ static uint32_t loom_run_hal_testbench_max_errors(
   return provider->max_errors == 0 ? 20 : provider->max_errors;
 }
 
+static iree_status_t loom_run_hal_testbench_run_compile_pipeline(
+    loom_run_hal_testbench_actual_provider_t* provider, loom_module_t* module,
+    const loom_compile_pipeline_options_t* options, iree_string_view_t stage,
+    loom_compile_pipeline_result_t* out_result) {
+  const iree_host_size_t prior_error_count = provider->diagnostic_error_count;
+  iree_status_t status = loom_compile_run_pipeline(
+      module, options, loom_run_session_block_pool(provider->session),
+      out_result);
+  if (!iree_status_is_ok(status)) {
+    if (provider->diagnostic_error_count == prior_error_count) {
+      return status;
+    }
+    iree_status_free(status);
+    loom_run_hal_testbench_record_compile_rejection(
+        provider, stage, IREE_SV("pass_diagnostics"), iree_string_view_empty());
+    return iree_ok_status();
+  }
+  if (out_result->pass.error_count != 0) {
+    loom_run_hal_testbench_record_compile_rejection(
+        provider, stage, IREE_SV("pass_diagnostics"), iree_string_view_empty());
+  }
+  return iree_ok_status();
+}
+
 static iree_status_t loom_run_hal_testbench_resolve_target_requirement(
     loom_module_t* module, loom_func_like_t func,
     const loom_target_facts_t** out_target_requirement) {
@@ -566,8 +591,8 @@ iree_status_t loom_run_hal_testbench_actual_provider_compile(
   }
 
   loom_func_like_t entry_func = {0};
-  IREE_RETURN_IF_ERROR(loom_run_hal_testbench_resolve_compile_func(
-      provider, entry_symbol, &entry_func));
+  IREE_RETURN_IF_ERROR(loom_run_hal_testbench_resolve_func(
+      provider->compile_module.module, entry_symbol, &entry_func));
   provider->invocation_options.function_name = entry_symbol;
 
   if (provider->target_environment == NULL) {
@@ -615,37 +640,40 @@ iree_status_t loom_run_hal_testbench_actual_provider_compile(
   pipeline_options.source_resolver =
       loom_run_module_source_resolver(&provider->compile_module);
   pipeline_options.report = provider->report;
-  const iree_host_size_t compile_error_count = provider->diagnostic_error_count;
-  iree_status_t status = loom_compile_run_pipeline(
-      provider->compile_module.module, &pipeline_options,
-      loom_run_session_block_pool(provider->session),
-      &provider->pipeline_result);
-  if (!iree_status_is_ok(status)) {
-    if (provider->diagnostic_error_count != compile_error_count) {
-      iree_status_free(status);
-      loom_run_hal_testbench_record_compile_rejection(
-          provider, IREE_SV("compile"), IREE_SV("pass_diagnostics"),
-          iree_string_view_empty());
-      return iree_ok_status();
-    }
-    return status;
-  }
-  if (provider->pipeline_result.pass.error_count != 0) {
-    loom_run_hal_testbench_record_compile_rejection(
-        provider, IREE_SV("compile"), IREE_SV("pass_diagnostics"),
-        iree_string_view_empty());
+
+  // TODO(benvanik): Replace this independently prepared launch source with the
+  // launch configuration artifact emitted by the device compilation.
+  loom_compile_pipeline_options_t launch_config_pipeline_options =
+      pipeline_options;
+  launch_config_pipeline_options.pipeline = IREE_SV("default");
+  launch_config_pipeline_options.default_pipeline =
+      LOOM_COMPILE_DEFAULT_PIPELINE_EXPANDED_SOURCE;
+  launch_config_pipeline_options.report = NULL;
+  IREE_RETURN_IF_ERROR(loom_run_hal_testbench_run_compile_pipeline(
+      provider, provider->launch_config_module, &launch_config_pipeline_options,
+      IREE_SV("launch_config"), &provider->launch_config_pipeline_result));
+  if (provider->compile_rejected) {
     return iree_ok_status();
   }
 
-  loom_func_like_t compiled_entry_func = {0};
-  IREE_RETURN_IF_ERROR(loom_run_hal_testbench_resolve_compile_func(
-      provider, entry_symbol, &compiled_entry_func));
-  const loom_target_function_version_t* function_version =
+  loom_func_like_t launch_config_func = {0};
+  IREE_RETURN_IF_ERROR(loom_run_hal_testbench_resolve_func(
+      provider->launch_config_module, entry_symbol, &launch_config_func));
+  const loom_target_function_version_t* launch_config_function_version =
       loom_target_function_version_list_find(
-          &provider->pipeline_result.function_versions, compiled_entry_func);
-  IREE_ASSERT(function_version != NULL);
-  IREE_ASSERT(function_version->effective_target_facts != NULL);
-  provider->effective_target_facts = function_version->effective_target_facts;
+          &provider->launch_config_pipeline_result.function_versions,
+          launch_config_func);
+  IREE_ASSERT(launch_config_function_version != NULL);
+  IREE_ASSERT(launch_config_function_version->effective_target_facts != NULL);
+  provider->launch_config_target_facts =
+      launch_config_function_version->effective_target_facts;
+
+  IREE_RETURN_IF_ERROR(loom_run_hal_testbench_run_compile_pipeline(
+      provider, provider->compile_module.module, &pipeline_options,
+      IREE_SV("compile"), &provider->pipeline_result));
+  if (provider->compile_rejected) {
+    return iree_ok_status();
+  }
 
   loom_run_candidate_compile_options_t compile_options = {0};
   loom_run_candidate_compile_options_initialize(&compile_options);
@@ -664,7 +692,7 @@ iree_status_t loom_run_hal_testbench_actual_provider_compile(
 
   provider->candidate_initialized = true;
   const iree_host_size_t emit_error_count = provider->diagnostic_error_count;
-  status = loom_run_hal_candidate_emit_target(
+  iree_status_t status = loom_run_hal_candidate_emit_target(
       provider->context->artifact_provider, &provider->compile_device_target,
       &provider->compile_module, &compile_options,
       provider->context->host_allocator, &provider->candidate);
@@ -839,14 +867,14 @@ static iree_status_t loom_run_hal_testbench_evaluate_launch_config(
                             "HAL kernel launch workload count mismatch");
   }
   IREE_ASSERT(provider->launch_config_module != NULL);
-  IREE_ASSERT(provider->effective_target_facts != NULL);
+  IREE_ASSERT(provider->launch_config_target_facts != NULL);
 
   const loom_kernel_launch_config_options_t options = {
       .function_symbol = provider->invocation_options.function_name,
       .workload_arguments = provider->workload_arguments,
       .workload_argument_count = workload_count,
       .required_fields = LOOM_KERNEL_LAUNCH_CONFIG_FIELD_FLAG_WORKGROUP_COUNT,
-      .effective_target_facts = provider->effective_target_facts,
+      .effective_target_facts = provider->launch_config_target_facts,
   };
   loom_kernel_launch_config_t config = {0};
   IREE_RETURN_IF_ERROR(loom_kernel_launch_config_evaluate(

--- a/loom/src/loom/tooling/execution/hal/testbench_actual.h
+++ b/loom/src/loom/tooling/execution/hal/testbench_actual.h
@@ -165,8 +165,8 @@ typedef struct loom_run_hal_testbench_actual_provider_t {
   loom_run_module_t compile_module;
   // Config-materialized source kernel retained for launch evaluation.
   loom_module_t* launch_config_module;
-  // Exact target facts used to compile the selected function version.
-  const loom_target_facts_t* effective_target_facts;
+  // Exact target facts used to expand and evaluate the launch region.
+  const loom_target_facts_t* launch_config_target_facts;
   // Reusable signed workload arguments used during launch evaluation.
   int64_t* workload_arguments;
   // Backend-produced HAL executable candidate.
@@ -179,6 +179,8 @@ typedef struct loom_run_hal_testbench_actual_provider_t {
   loom_run_hal_invocation_options_t invocation_options;
   // Compiler products retained through artifact emission.
   loom_compile_pipeline_result_t pipeline_result;
+  // Expanded-source products retained through launch evaluation.
+  loom_compile_pipeline_result_t launch_config_pipeline_result;
   // Product stage that rejected the compile, when |compile_rejected| is true.
   iree_string_view_t compile_failure_stage;
   // Stable diagnostic category for |compile_rejected|.


### PR DESCRIPTION
Launch configuration evaluation now applies the exact per-function target specialization used by device compilation. A kernel can retain one public symbol and ABI while target providers select architecture-specific launch geometry and device schedules; applications no longer need to route symbols or launch conservative superset grids.

This is a bounded bridge for the existing source-module evaluator. Target-specialized requests clone and expand source through the shared expanded-source boundary before value analysis, while workload-only requests retain the direct no-clone path. The HAL testbench similarly prepares a second retained source module against the selected device profile. These paths deliberately pay duplicate preparation so current kernel integrations can use correct target-specific launch geometry.

The bridge isolates that duplication behind explicit preparation boundaries. Compiler-emitted multi-entry launch configuration artifacts will replace the source clone, parallel expansion, and second HAL module without changing the device executable ABI or the dynamic workload inputs.
