### PR TITLE
[Loom] Traverse symbolic expressions iteratively

### DIFF
--- a/loom/src/loom/analysis/symbolic_expr.c
+++ b/loom/src/loom/analysis/symbolic_expr.c
@@ -476,94 +476,28 @@ static bool loom_symbolic_expr_constant_value(
 // Value expansion
 //===----------------------------------------------------------------------===//
 
-static iree_status_t loom_symbolic_expr_from_binary_value(
-    loom_symbolic_expr_context_t* context, loom_value_id_t left_value,
-    loom_value_id_t right_value, bool subtract,
-    loom_symbolic_expr_t* out_expression) {
-  loom_symbolic_expr_t left_expression = {0};
-  loom_symbolic_expr_t right_expression = {0};
-  IREE_RETURN_IF_ERROR(
-      loom_symbolic_expr_from_value(context, left_value, &left_expression));
-  IREE_RETURN_IF_ERROR(
-      loom_symbolic_expr_from_value(context, right_value, &right_expression));
-  return loom_symbolic_expr_add_or_sub(
-      context, &left_expression, &right_expression, subtract, out_expression);
-}
-
-static iree_status_t loom_symbolic_expr_from_mul_value(
+static iree_status_t loom_symbolic_expr_multiply(
     loom_symbolic_expr_context_t* context, loom_value_id_t result_value,
-    loom_value_id_t left_value, loom_value_id_t right_value,
+    const loom_symbolic_expr_t* left_expression,
+    const loom_symbolic_expr_t* right_expression,
     loom_symbolic_expr_t* out_expression) {
-  loom_symbolic_expr_t left_expression = {0};
-  loom_symbolic_expr_t right_expression = {0};
-  IREE_RETURN_IF_ERROR(
-      loom_symbolic_expr_from_value(context, left_value, &left_expression));
-  IREE_RETURN_IF_ERROR(
-      loom_symbolic_expr_from_value(context, right_value, &right_expression));
   int64_t left_constant = 0;
   int64_t right_constant = 0;
-  if (loom_symbolic_expr_constant_value(&left_expression, &left_constant)) {
-    return loom_symbolic_expr_mul_i64(context, &right_expression, left_constant,
+  if (loom_symbolic_expr_constant_value(left_expression, &left_constant)) {
+    return loom_symbolic_expr_mul_i64(context, right_expression, left_constant,
                                       out_expression);
   }
-  if (loom_symbolic_expr_constant_value(&right_expression, &right_constant)) {
-    return loom_symbolic_expr_mul_i64(context, &left_expression, right_constant,
+  if (loom_symbolic_expr_constant_value(right_expression, &right_constant)) {
+    return loom_symbolic_expr_mul_i64(context, left_expression, right_constant,
                                       out_expression);
   }
   return loom_symbolic_expr_value(context, result_value, out_expression);
 }
 
-static iree_status_t loom_symbolic_expr_from_madd_value(
-    loom_symbolic_expr_context_t* context, loom_value_id_t result_value,
-    loom_value_id_t a_value, loom_value_id_t b_value, loom_value_id_t c_value,
-    loom_symbolic_expr_t* out_expression) {
-  loom_symbolic_expr_t product_expression = {0};
-  IREE_RETURN_IF_ERROR(loom_symbolic_expr_from_mul_value(
-      context, result_value, a_value, b_value, &product_expression));
-  if (product_expression.term_count == 1 &&
-      product_expression.terms[0].value_id == result_value &&
-      product_expression.constant == 0) {
-    return loom_symbolic_expr_value(context, result_value, out_expression);
-  }
-  loom_symbolic_expr_t c_expression = {0};
-  IREE_RETURN_IF_ERROR(
-      loom_symbolic_expr_from_value(context, c_value, &c_expression));
-  return loom_symbolic_expr_add(context, &product_expression, &c_expression,
-                                out_expression);
-}
-
-static iree_status_t loom_symbolic_expr_from_shli_value(
-    loom_symbolic_expr_context_t* context, loom_value_id_t result_value,
-    loom_value_id_t left_value, loom_value_id_t right_value,
-    loom_symbolic_expr_t* out_expression) {
-  loom_symbolic_expr_t right_expression = {0};
-  IREE_RETURN_IF_ERROR(
-      loom_symbolic_expr_from_value(context, right_value, &right_expression));
-  int64_t shift_amount = 0;
-  if (!loom_symbolic_expr_constant_value(&right_expression, &shift_amount) ||
-      shift_amount < 0 || shift_amount > 62) {
-    return loom_symbolic_expr_value(context, result_value, out_expression);
-  }
-  loom_symbolic_expr_t left_expression = {0};
-  IREE_RETURN_IF_ERROR(
-      loom_symbolic_expr_from_value(context, left_value, &left_expression));
-  return loom_symbolic_expr_mul_i64(context, &left_expression,
-                                    INT64_C(1) << shift_amount, out_expression);
-}
-
-static iree_status_t loom_symbolic_expr_from_select_value(
-    loom_symbolic_expr_context_t* context, loom_value_id_t result_value,
-    loom_value_id_t condition_value, loom_value_id_t true_value,
-    loom_value_id_t false_value, loom_symbolic_expr_t* out_expression) {
-  loom_symbolic_expr_t condition_expression = {0};
-  IREE_RETURN_IF_ERROR(loom_symbolic_expr_from_value(context, condition_value,
-                                                     &condition_expression));
-  int64_t condition = 0;
-  if (loom_symbolic_expr_constant_value(&condition_expression, &condition)) {
-    return loom_symbolic_expr_from_value(
-        context, condition ? true_value : false_value, out_expression);
-  }
-  return loom_symbolic_expr_value(context, result_value, out_expression);
+static bool loom_symbolic_expr_is_result_symbol(
+    const loom_symbolic_expr_t* expression, loom_value_id_t value_id) {
+  return expression->constant == 0 && expression->term_count == 1 &&
+         expression->terms[0].value_id == value_id;
 }
 
 static iree_status_t loom_symbolic_expr_attach_identity_relation_value(
@@ -581,46 +515,116 @@ static iree_status_t loom_symbolic_expr_attach_identity_relation_value(
                                         expression->facts, expression);
 }
 
-static iree_status_t loom_symbolic_expr_from_assume_value(
-    loom_symbolic_expr_context_t* context, const loom_value_slice_t values,
-    loom_value_id_t result_value, uint16_t result_index,
-    loom_symbolic_expr_t* out_expression) {
-  if (result_index >= values.count) {
+typedef enum loom_symbolic_expr_expansion_kind_e {
+  LOOM_SYMBOLIC_EXPR_EXPANSION_IDENTITY = 0,
+  LOOM_SYMBOLIC_EXPR_EXPANSION_ASSUME,
+  LOOM_SYMBOLIC_EXPR_EXPANSION_ADD,
+  LOOM_SYMBOLIC_EXPR_EXPANSION_SUBTRACT,
+  LOOM_SYMBOLIC_EXPR_EXPANSION_MULTIPLY,
+  LOOM_SYMBOLIC_EXPR_EXPANSION_MULTIPLY_ADD,
+  LOOM_SYMBOLIC_EXPR_EXPANSION_SHIFT_LEFT,
+  LOOM_SYMBOLIC_EXPR_EXPANSION_NEGATE,
+  LOOM_SYMBOLIC_EXPR_EXPANSION_SELECT,
+} loom_symbolic_expr_expansion_kind_t;
+
+typedef enum loom_symbolic_expr_expansion_stage_e {
+  LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_BEGIN = 0,
+  LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_FIRST_OPERAND,
+  LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_SECOND_OPERAND,
+  LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_THIRD_OPERAND,
+} loom_symbolic_expr_expansion_stage_t;
+
+typedef struct loom_symbolic_expr_expansion_frame_t {
+  // SSA value whose expression this frame computes.
+  loom_value_id_t value_id;
+
+  // Operation-specific expansion category.
+  loom_symbolic_expr_expansion_kind_t kind;
+
+  // Continuation stage within the operation-specific expansion.
+  loom_symbolic_expr_expansion_stage_t stage;
+
+  // Producer values consumed in operation-specific order.
+  loom_value_id_t operand_values[3];
+
+  // Partial expression retained while a later operand is expanded.
+  loom_symbolic_expr_t intermediate_expression;
+
+  // Exact shift amount retained while the shifted value is expanded.
+  int64_t shift_amount;
+} loom_symbolic_expr_expansion_frame_t;
+
+#define LOOM_SYMBOLIC_EXPR_EXPANSION_INLINE_FRAME_CAPACITY 8
+
+static iree_status_t loom_symbolic_expr_expansion_request_value(
+    loom_symbolic_expr_context_t* context,
+    iree_arena_allocator_t* transient_arena, loom_value_id_t value_id,
+    loom_symbolic_expr_expansion_frame_t** inout_frames,
+    iree_host_size_t* inout_frame_count, iree_host_size_t* inout_frame_capacity,
+    loom_symbolic_expr_t* out_expression, bool* out_pending) {
+  *out_pending = false;
+  if (!context->module || value_id >= context->module->values.count) {
     loom_symbolic_expr_unknown(loom_value_facts_unknown(), out_expression);
     return iree_ok_status();
   }
-  IREE_RETURN_IF_ERROR(loom_symbolic_expr_from_value(
-      context, values.values[result_index], out_expression));
-  return loom_symbolic_expr_attach_identity_relation_value(
-      context, result_value, out_expression);
+
+  IREE_RETURN_IF_ERROR(
+      loom_symbolic_expr_ensure_memo_capacity(context, value_id + 1));
+  loom_symbolic_expr_memo_entry_t* memo_entry =
+      &context->memo_entries[value_id];
+  if (memo_entry->state == LOOM_SYMBOLIC_EXPR_MEMO_READY) {
+    *out_expression = memo_entry->expression;
+    return iree_ok_status();
+  }
+  if (memo_entry->state == LOOM_SYMBOLIC_EXPR_MEMO_VISITING) {
+    return loom_symbolic_expr_value(context, value_id, out_expression);
+  }
+
+  if (*inout_frame_count == *inout_frame_capacity) {
+    void* frames = *inout_frames;
+    IREE_RETURN_IF_ERROR(iree_arena_grow_array(
+        transient_arena, *inout_frame_count, *inout_frame_count + 1,
+        sizeof(**inout_frames), inout_frame_capacity, &frames));
+    *inout_frames = (loom_symbolic_expr_expansion_frame_t*)frames;
+  }
+
+  memo_entry->state = LOOM_SYMBOLIC_EXPR_MEMO_VISITING;
+  (*inout_frames)[(*inout_frame_count)++] =
+      (loom_symbolic_expr_expansion_frame_t){
+          .value_id = value_id,
+          .stage = LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_BEGIN,
+      };
+  *out_pending = true;
+  return iree_ok_status();
 }
 
-static iree_status_t loom_symbolic_expr_from_value_uncached(
-    loom_symbolic_expr_context_t* context, loom_value_id_t value_id,
-    loom_symbolic_expr_t* out_expression) {
+static iree_status_t loom_symbolic_expr_expansion_prepare_frame(
+    loom_symbolic_expr_context_t* context,
+    loom_symbolic_expr_expansion_frame_t* frame,
+    loom_symbolic_expr_t* out_expression, bool* out_complete) {
+  *out_complete = false;
   loom_value_facts_t facts =
-      loom_symbolic_expr_context_lookup_facts(context, value_id);
+      loom_symbolic_expr_context_lookup_facts(context, frame->value_id);
   int64_t exact_value = 0;
   if (loom_symbolic_expr_exact_integer_facts(facts, &exact_value)) {
     loom_symbolic_expr_constant(exact_value, out_expression);
     out_expression->facts = facts;
-    return iree_ok_status();
-  }
-  if (!context->module || value_id >= context->module->values.count) {
-    loom_symbolic_expr_unknown(facts, out_expression);
+    *out_complete = true;
     return iree_ok_status();
   }
 
-  const loom_value_t* value = loom_module_value(context->module, value_id);
+  const loom_value_t* value =
+      loom_module_value(context->module, frame->value_id);
   if (loom_value_is_block_arg(value)) {
-    return loom_symbolic_expr_value(context, value_id, out_expression);
+    *out_complete = true;
+    return loom_symbolic_expr_value(context, frame->value_id, out_expression);
   }
   const loom_op_t* defining_op = loom_value_def_op(value);
   if (!defining_op) {
-    return loom_symbolic_expr_value(context, value_id, out_expression);
+    *out_complete = true;
+    return loom_symbolic_expr_value(context, frame->value_id, out_expression);
   }
 
-  iree_status_t status = iree_ok_status();
   switch (defining_op->kind) {
     case LOOM_OP_INDEX_CONSTANT: {
       loom_attribute_t value_attr = loom_index_constant_value(defining_op);
@@ -628,49 +632,58 @@ static iree_status_t loom_symbolic_expr_from_value_uncached(
         loom_symbolic_expr_constant(loom_attr_as_i64(value_attr),
                                     out_expression);
       } else {
-        status = loom_symbolic_expr_value(context, value_id, out_expression);
+        IREE_RETURN_IF_ERROR(
+            loom_symbolic_expr_value(context, frame->value_id, out_expression));
       }
+      *out_complete = true;
       break;
     }
     case LOOM_OP_INDEX_CAST:
-      status = loom_symbolic_expr_from_value(
-          context, loom_index_cast_input(defining_op), out_expression);
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_IDENTITY;
+      frame->operand_values[0] = loom_index_cast_input(defining_op);
       break;
-    case LOOM_OP_INDEX_ASSUME:
-      status = loom_symbolic_expr_from_assume_value(
-          context, loom_index_assume_values(defining_op), value_id,
-          loom_value_def_index(value), out_expression);
+    case LOOM_OP_INDEX_ASSUME: {
+      loom_value_slice_t values = loom_index_assume_values(defining_op);
+      uint16_t result_index = loom_value_def_index(value);
+      if (result_index >= values.count) {
+        *out_complete = true;
+        return loom_symbolic_expr_value(context, frame->value_id,
+                                        out_expression);
+      }
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_ASSUME;
+      frame->operand_values[0] = values.values[result_index];
       break;
+    }
     case LOOM_OP_INDEX_ADD:
-      status = loom_symbolic_expr_from_binary_value(
-          context, loom_index_add_lhs(defining_op),
-          loom_index_add_rhs(defining_op), false, out_expression);
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_ADD;
+      frame->operand_values[0] = loom_index_add_lhs(defining_op);
+      frame->operand_values[1] = loom_index_add_rhs(defining_op);
       break;
     case LOOM_OP_INDEX_SUB:
-      status = loom_symbolic_expr_from_binary_value(
-          context, loom_index_sub_lhs(defining_op),
-          loom_index_sub_rhs(defining_op), true, out_expression);
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_SUBTRACT;
+      frame->operand_values[0] = loom_index_sub_lhs(defining_op);
+      frame->operand_values[1] = loom_index_sub_rhs(defining_op);
       break;
     case LOOM_OP_INDEX_MUL:
-      status = loom_symbolic_expr_from_mul_value(
-          context, value_id, loom_index_mul_lhs(defining_op),
-          loom_index_mul_rhs(defining_op), out_expression);
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_MULTIPLY;
+      frame->operand_values[0] = loom_index_mul_lhs(defining_op);
+      frame->operand_values[1] = loom_index_mul_rhs(defining_op);
       break;
     case LOOM_OP_INDEX_SCALE:
-      status = loom_symbolic_expr_from_mul_value(
-          context, value_id, loom_index_scale_index(defining_op),
-          loom_index_scale_stride(defining_op), out_expression);
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_MULTIPLY;
+      frame->operand_values[0] = loom_index_scale_index(defining_op);
+      frame->operand_values[1] = loom_index_scale_stride(defining_op);
       break;
     case LOOM_OP_INDEX_MADD:
-      status = loom_symbolic_expr_from_madd_value(
-          context, value_id, loom_index_madd_a(defining_op),
-          loom_index_madd_b(defining_op), loom_index_madd_c(defining_op),
-          out_expression);
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_MULTIPLY_ADD;
+      frame->operand_values[0] = loom_index_madd_a(defining_op);
+      frame->operand_values[1] = loom_index_madd_b(defining_op);
+      frame->operand_values[2] = loom_index_madd_c(defining_op);
       break;
     case LOOM_OP_INDEX_SHLI:
-      status = loom_symbolic_expr_from_shli_value(
-          context, value_id, loom_index_shli_lhs(defining_op),
-          loom_index_shli_rhs(defining_op), out_expression);
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_SHIFT_LEFT;
+      frame->operand_values[0] = loom_index_shli_lhs(defining_op);
+      frame->operand_values[1] = loom_index_shli_rhs(defining_op);
       break;
     case LOOM_OP_SCALAR_CONSTANT: {
       loom_attribute_t value_attr = loom_scalar_constant_value(defining_op);
@@ -678,65 +691,217 @@ static iree_status_t loom_symbolic_expr_from_value_uncached(
         loom_symbolic_expr_constant(loom_attr_as_i64(value_attr),
                                     out_expression);
       } else {
-        status = loom_symbolic_expr_value(context, value_id, out_expression);
+        IREE_RETURN_IF_ERROR(
+            loom_symbolic_expr_value(context, frame->value_id, out_expression));
       }
+      *out_complete = true;
       break;
     }
     case LOOM_OP_SCALAR_ADDI:
-      status = loom_symbolic_expr_from_binary_value(
-          context, loom_scalar_addi_lhs(defining_op),
-          loom_scalar_addi_rhs(defining_op), false, out_expression);
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_ADD;
+      frame->operand_values[0] = loom_scalar_addi_lhs(defining_op);
+      frame->operand_values[1] = loom_scalar_addi_rhs(defining_op);
       break;
     case LOOM_OP_SCALAR_SUBI:
-      status = loom_symbolic_expr_from_binary_value(
-          context, loom_scalar_subi_lhs(defining_op),
-          loom_scalar_subi_rhs(defining_op), true, out_expression);
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_SUBTRACT;
+      frame->operand_values[0] = loom_scalar_subi_lhs(defining_op);
+      frame->operand_values[1] = loom_scalar_subi_rhs(defining_op);
       break;
     case LOOM_OP_SCALAR_MULI:
-      status = loom_symbolic_expr_from_mul_value(
-          context, value_id, loom_scalar_muli_lhs(defining_op),
-          loom_scalar_muli_rhs(defining_op), out_expression);
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_MULTIPLY;
+      frame->operand_values[0] = loom_scalar_muli_lhs(defining_op);
+      frame->operand_values[1] = loom_scalar_muli_rhs(defining_op);
       break;
-    case LOOM_OP_SCALAR_NEGI: {
-      loom_symbolic_expr_t input_expression = {0};
-      status = loom_symbolic_expr_from_value(
-          context, loom_scalar_negi_input(defining_op), &input_expression);
-      if (iree_status_is_ok(status)) {
-        status = loom_symbolic_expr_mul_i64(context, &input_expression, -1,
-                                            out_expression);
+    case LOOM_OP_SCALAR_NEGI:
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_NEGATE;
+      frame->operand_values[0] = loom_scalar_negi_input(defining_op);
+      break;
+    case LOOM_OP_SCALAR_FMAI:
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_MULTIPLY_ADD;
+      frame->operand_values[0] = loom_scalar_fmai_a(defining_op);
+      frame->operand_values[1] = loom_scalar_fmai_b(defining_op);
+      frame->operand_values[2] = loom_scalar_fmai_c(defining_op);
+      break;
+    case LOOM_OP_SCALAR_ASSUME: {
+      loom_value_slice_t values = loom_scalar_assume_values(defining_op);
+      uint16_t result_index = loom_value_def_index(value);
+      if (result_index >= values.count) {
+        *out_complete = true;
+        return loom_symbolic_expr_value(context, frame->value_id,
+                                        out_expression);
       }
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_ASSUME;
+      frame->operand_values[0] = values.values[result_index];
       break;
     }
-    case LOOM_OP_SCALAR_FMAI:
-      status = loom_symbolic_expr_from_madd_value(
-          context, value_id, loom_scalar_fmai_a(defining_op),
-          loom_scalar_fmai_b(defining_op), loom_scalar_fmai_c(defining_op),
-          out_expression);
-      break;
-    case LOOM_OP_SCALAR_ASSUME:
-      status = loom_symbolic_expr_from_assume_value(
-          context, loom_scalar_assume_values(defining_op), value_id,
-          loom_value_def_index(value), out_expression);
-      break;
     case LOOM_OP_SCF_SELECT:
-      status = loom_symbolic_expr_from_select_value(
-          context, value_id, loom_scf_select_condition(defining_op),
-          loom_scf_select_true_value(defining_op),
-          loom_scf_select_false_value(defining_op), out_expression);
+      frame->kind = LOOM_SYMBOLIC_EXPR_EXPANSION_SELECT;
+      frame->operand_values[0] = loom_scf_select_condition(defining_op);
+      frame->operand_values[1] = loom_scf_select_true_value(defining_op);
+      frame->operand_values[2] = loom_scf_select_false_value(defining_op);
       break;
     default:
-      status = loom_symbolic_expr_value(context, value_id, out_expression);
+      *out_complete = true;
+      return loom_symbolic_expr_value(context, frame->value_id, out_expression);
+  }
+  if (!*out_complete) {
+    frame->stage = LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_FIRST_OPERAND;
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_symbolic_expr_expansion_step(
+    loom_symbolic_expr_context_t* context,
+    iree_arena_allocator_t* transient_arena,
+    loom_symbolic_expr_expansion_frame_t** inout_frames,
+    iree_host_size_t* inout_frame_count, iree_host_size_t* inout_frame_capacity,
+    loom_symbolic_expr_t* out_expression, bool* out_complete) {
+  *out_complete = false;
+  loom_symbolic_expr_expansion_frame_t* frame =
+      &(*inout_frames)[*inout_frame_count - 1];
+  if (frame->stage == LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_BEGIN) {
+    return loom_symbolic_expr_expansion_prepare_frame(
+        context, frame, out_expression, out_complete);
+  }
+
+  loom_symbolic_expr_t operand_expression = {0};
+  bool operand_pending = false;
+  switch (frame->stage) {
+    case LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_FIRST_OPERAND:
+      switch (frame->kind) {
+        case LOOM_SYMBOLIC_EXPR_EXPANSION_IDENTITY:
+        case LOOM_SYMBOLIC_EXPR_EXPANSION_ASSUME:
+        case LOOM_SYMBOLIC_EXPR_EXPANSION_NEGATE: {
+          IREE_RETURN_IF_ERROR(loom_symbolic_expr_expansion_request_value(
+              context, transient_arena, frame->operand_values[0], inout_frames,
+              inout_frame_count, inout_frame_capacity, &operand_expression,
+              &operand_pending));
+          if (operand_pending) return iree_ok_status();
+          *out_expression = operand_expression;
+          if (frame->kind == LOOM_SYMBOLIC_EXPR_EXPANSION_ASSUME) {
+            IREE_RETURN_IF_ERROR(
+                loom_symbolic_expr_attach_identity_relation_value(
+                    context, frame->value_id, out_expression));
+          } else if (frame->kind == LOOM_SYMBOLIC_EXPR_EXPANSION_NEGATE) {
+            IREE_RETURN_IF_ERROR(loom_symbolic_expr_mul_i64(
+                context, &operand_expression, -1, out_expression));
+          }
+          *out_complete = true;
+          return iree_ok_status();
+        }
+        case LOOM_SYMBOLIC_EXPR_EXPANSION_ADD:
+        case LOOM_SYMBOLIC_EXPR_EXPANSION_SUBTRACT:
+        case LOOM_SYMBOLIC_EXPR_EXPANSION_MULTIPLY:
+        case LOOM_SYMBOLIC_EXPR_EXPANSION_MULTIPLY_ADD: {
+          IREE_RETURN_IF_ERROR(loom_symbolic_expr_expansion_request_value(
+              context, transient_arena, frame->operand_values[0], inout_frames,
+              inout_frame_count, inout_frame_capacity, &operand_expression,
+              &operand_pending));
+          if (operand_pending) return iree_ok_status();
+          frame->intermediate_expression = operand_expression;
+          frame->stage = LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_SECOND_OPERAND;
+          return iree_ok_status();
+        }
+        case LOOM_SYMBOLIC_EXPR_EXPANSION_SHIFT_LEFT: {
+          IREE_RETURN_IF_ERROR(loom_symbolic_expr_expansion_request_value(
+              context, transient_arena, frame->operand_values[1], inout_frames,
+              inout_frame_count, inout_frame_capacity, &operand_expression,
+              &operand_pending));
+          if (operand_pending) return iree_ok_status();
+          if (!loom_symbolic_expr_constant_value(&operand_expression,
+                                                 &frame->shift_amount) ||
+              frame->shift_amount < 0 || frame->shift_amount > 62) {
+            *out_complete = true;
+            return loom_symbolic_expr_value(context, frame->value_id,
+                                            out_expression);
+          }
+          frame->stage = LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_SECOND_OPERAND;
+          return iree_ok_status();
+        }
+        case LOOM_SYMBOLIC_EXPR_EXPANSION_SELECT: {
+          IREE_RETURN_IF_ERROR(loom_symbolic_expr_expansion_request_value(
+              context, transient_arena, frame->operand_values[0], inout_frames,
+              inout_frame_count, inout_frame_capacity, &operand_expression,
+              &operand_pending));
+          if (operand_pending) return iree_ok_status();
+          int64_t condition = 0;
+          if (!loom_symbolic_expr_constant_value(&operand_expression,
+                                                 &condition)) {
+            *out_complete = true;
+            return loom_symbolic_expr_value(context, frame->value_id,
+                                            out_expression);
+          }
+          frame->operand_values[0] =
+              condition ? frame->operand_values[1] : frame->operand_values[2];
+          frame->stage = LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_SECOND_OPERAND;
+          return iree_ok_status();
+        }
+      }
+      break;
+    case LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_SECOND_OPERAND: {
+      if (frame->kind == LOOM_SYMBOLIC_EXPR_EXPANSION_SHIFT_LEFT ||
+          frame->kind == LOOM_SYMBOLIC_EXPR_EXPANSION_SELECT) {
+        IREE_RETURN_IF_ERROR(loom_symbolic_expr_expansion_request_value(
+            context, transient_arena, frame->operand_values[0], inout_frames,
+            inout_frame_count, inout_frame_capacity, &operand_expression,
+            &operand_pending));
+        if (operand_pending) return iree_ok_status();
+        if (frame->kind == LOOM_SYMBOLIC_EXPR_EXPANSION_SHIFT_LEFT) {
+          IREE_RETURN_IF_ERROR(loom_symbolic_expr_mul_i64(
+              context, &operand_expression, INT64_C(1) << frame->shift_amount,
+              out_expression));
+        } else {
+          *out_expression = operand_expression;
+        }
+        *out_complete = true;
+        return iree_ok_status();
+      }
+
+      IREE_RETURN_IF_ERROR(loom_symbolic_expr_expansion_request_value(
+          context, transient_arena, frame->operand_values[1], inout_frames,
+          inout_frame_count, inout_frame_capacity, &operand_expression,
+          &operand_pending));
+      if (operand_pending) return iree_ok_status();
+      if (frame->kind == LOOM_SYMBOLIC_EXPR_EXPANSION_ADD ||
+          frame->kind == LOOM_SYMBOLIC_EXPR_EXPANSION_SUBTRACT) {
+        IREE_RETURN_IF_ERROR(loom_symbolic_expr_add_or_sub(
+            context, &frame->intermediate_expression, &operand_expression,
+            frame->kind == LOOM_SYMBOLIC_EXPR_EXPANSION_SUBTRACT,
+            out_expression));
+        *out_complete = true;
+        return iree_ok_status();
+      }
+
+      IREE_RETURN_IF_ERROR(loom_symbolic_expr_multiply(
+          context, frame->value_id, &frame->intermediate_expression,
+          &operand_expression, out_expression));
+      if (frame->kind == LOOM_SYMBOLIC_EXPR_EXPANSION_MULTIPLY ||
+          loom_symbolic_expr_is_result_symbol(out_expression,
+                                              frame->value_id)) {
+        *out_complete = true;
+        return iree_ok_status();
+      }
+      frame->intermediate_expression = *out_expression;
+      frame->stage = LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_THIRD_OPERAND;
+      return iree_ok_status();
+    }
+    case LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_THIRD_OPERAND: {
+      IREE_RETURN_IF_ERROR(loom_symbolic_expr_expansion_request_value(
+          context, transient_arena, frame->operand_values[2], inout_frames,
+          inout_frame_count, inout_frame_capacity, &operand_expression,
+          &operand_pending));
+      if (operand_pending) return iree_ok_status();
+      IREE_RETURN_IF_ERROR(
+          loom_symbolic_expr_add(context, &frame->intermediate_expression,
+                                 &operand_expression, out_expression));
+      *out_complete = true;
+      return iree_ok_status();
+    }
+    case LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_BEGIN:
       break;
   }
-  if (iree_status_is_ok(status)) {
-    if (!loom_symbolic_expr_is_linear(out_expression)) {
-      status = loom_symbolic_expr_value(context, value_id, out_expression);
-    }
-  }
-  if (iree_status_is_ok(status)) {
-    loom_symbolic_expr_override_facts(context, value_id, out_expression);
-  }
-  return status;
+  IREE_ASSERT_UNREACHABLE("invalid symbolic expression expansion state");
+  IREE_BUILTIN_UNREACHABLE();
 }
 
 iree_status_t loom_symbolic_expr_from_value(
@@ -757,18 +922,53 @@ iree_status_t loom_symbolic_expr_from_value(
     return loom_symbolic_expr_value(context, value_id, out_expression);
   }
 
+  loom_symbolic_expr_expansion_frame_t
+      inline_frames[LOOM_SYMBOLIC_EXPR_EXPANSION_INLINE_FRAME_CAPACITY];
+  inline_frames[0] = (loom_symbolic_expr_expansion_frame_t){
+      .value_id = value_id,
+      .stage = LOOM_SYMBOLIC_EXPR_EXPANSION_STAGE_BEGIN,
+  };
+  loom_symbolic_expr_expansion_frame_t* frames = inline_frames;
+  iree_host_size_t frame_count = 1;
+  iree_host_size_t frame_capacity = IREE_ARRAYSIZE(inline_frames);
+  iree_arena_allocator_t transient_arena;
+  iree_arena_initialize(context->arena->block_pool, &transient_arena);
+
   entry->state = LOOM_SYMBOLIC_EXPR_MEMO_VISITING;
-  iree_status_t status =
-      loom_symbolic_expr_from_value_uncached(context, value_id, out_expression);
-  // Recursive expansion can grow and move the memo table when a lower value ID
-  // expands through a producer with a higher value ID. Reacquire the entry
-  // before publishing the completed expression.
-  entry = &context->memo_entries[value_id];
-  if (iree_status_is_ok(status)) {
-    entry->expression = *out_expression;
-    entry->state = LOOM_SYMBOLIC_EXPR_MEMO_READY;
-  } else {
-    entry->state = LOOM_SYMBOLIC_EXPR_MEMO_EMPTY;
+  iree_status_t status = iree_ok_status();
+  while (iree_status_is_ok(status) && frame_count > 0) {
+    loom_symbolic_expr_t expression = {0};
+    bool frame_complete = false;
+    status = loom_symbolic_expr_expansion_step(
+        context, &transient_arena, &frames, &frame_count, &frame_capacity,
+        &expression, &frame_complete);
+    if (!iree_status_is_ok(status) || !frame_complete) continue;
+
+    loom_value_id_t completed_value = frames[frame_count - 1].value_id;
+    if (!loom_symbolic_expr_is_linear(&expression)) {
+      status = loom_symbolic_expr_value(context, completed_value, &expression);
+    }
+    if (iree_status_is_ok(status)) {
+      loom_symbolic_expr_override_facts(context, completed_value, &expression);
+      loom_symbolic_expr_memo_entry_t* completed_entry =
+          &context->memo_entries[completed_value];
+      completed_entry->expression = expression;
+      completed_entry->state = LOOM_SYMBOLIC_EXPR_MEMO_READY;
+      --frame_count;
+    }
   }
+
+  if (iree_status_is_ok(status)) {
+    *out_expression = context->memo_entries[value_id].expression;
+  } else {
+    for (iree_host_size_t i = 0; i < frame_count; ++i) {
+      loom_symbolic_expr_memo_entry_t* pending_entry =
+          &context->memo_entries[frames[i].value_id];
+      if (pending_entry->state == LOOM_SYMBOLIC_EXPR_MEMO_VISITING) {
+        pending_entry->state = LOOM_SYMBOLIC_EXPR_MEMO_EMPTY;
+      }
+    }
+  }
+  iree_arena_deinitialize(&transient_arena);
   return status;
 }

--- a/loom/src/loom/analysis/symbolic_expr_proof_test.cc
+++ b/loom/src/loom/analysis/symbolic_expr_proof_test.cc
@@ -25,6 +25,45 @@
 namespace loom {
 namespace {
 
+static iree_status_t ProveSemanticallyEquivalentUpperBound(
+    loom_symbolic_expr_context_t* context, loom_value_id_t relation_value,
+    loom_value_id_t query_value, loom_symbolic_proof_result_t* out_result) {
+  loom_condition_integer_relation_t relation = {
+      /*.relation=*/LOOM_SYMBOLIC_INTEGER_RELATION_LE,
+      /*.left=*/
+      {
+          /*.kind=*/LOOM_CONDITION_INTEGER_OPERAND_CONSTANT,
+          /*.value_id=*/LOOM_VALUE_ID_INVALID,
+          /*.constant=*/0,
+      },
+      /*.right=*/
+      {
+          /*.kind=*/LOOM_CONDITION_INTEGER_OPERAND_VALUE,
+          /*.value_id=*/relation_value,
+          /*.constant=*/0,
+      },
+  };
+  loom_condition_fact_set_t condition_facts = {
+      /*.integer_relations=*/&relation,
+      /*.integer_relation_count=*/1,
+      /*.integer_relation_capacity=*/1,
+  };
+  context->condition_facts = &condition_facts;
+  loom_symbolic_expr_context_reset(context);
+
+  loom_symbolic_expr_t zero = {};
+  loom_symbolic_expr_constant(0, &zero);
+  loom_symbolic_expr_t query = {};
+  iree_status_t status = loom_symbolic_expr_value(context, query_value, &query);
+  if (iree_status_is_ok(status)) {
+    status = loom_symbolic_expr_prove_le(context, &zero, &query, out_result);
+  }
+
+  context->condition_facts = nullptr;
+  loom_symbolic_expr_context_reset(context);
+  return status;
+}
+
 TEST_F(SymbolicExprTest, AddSubNormalizeAndCancelTerms) {
   loom_value_id_t value_id = DefineIndexValue();
   loom_symbolic_expr_t value_expression = {0};
@@ -51,6 +90,51 @@ TEST_F(SymbolicExprTest, AddSubNormalizeAndCancelTerms) {
   IREE_ASSERT_OK(loom_symbolic_expr_prove_le(
       &expression_context_, &value_plus_eight, &value_plus_four, &proof));
   EXPECT_EQ(proof, LOOM_SYMBOLIC_PROOF_FALSE);
+}
+
+TEST_F(SymbolicExprTest, SemanticMatchVisitsSharedProducerPairsOnce) {
+  loom_value_id_t source = DefineI64Value();
+  loom_value_id_t left = source;
+  loom_value_id_t right = source;
+  for (int i = 0; i < 16; ++i) {
+    left = BuildScalarAndI(left, left);
+    right = BuildScalarAndI(right, right);
+  }
+
+  loom_symbolic_proof_result_t proof = LOOM_SYMBOLIC_PROOF_UNKNOWN;
+  IREE_ASSERT_OK(ProveSemanticallyEquivalentUpperBound(&expression_context_,
+                                                       left, right, &proof));
+  EXPECT_EQ(proof, LOOM_SYMBOLIC_PROOF_TRUE);
+}
+
+TEST_F(SymbolicExprTest, SemanticMatchRejectsDistinctProducerLeaves) {
+  loom_value_id_t left = DefineI64Value();
+  loom_value_id_t right = DefineI64Value();
+  for (int i = 0; i < 8; ++i) {
+    left = BuildScalarAndI(left, left);
+    right = BuildScalarAndI(right, right);
+  }
+
+  loom_symbolic_proof_result_t proof = LOOM_SYMBOLIC_PROOF_UNKNOWN;
+  IREE_ASSERT_OK(ProveSemanticallyEquivalentUpperBound(&expression_context_,
+                                                       left, right, &proof));
+  EXPECT_EQ(proof, LOOM_SYMBOLIC_PROOF_UNKNOWN);
+}
+
+TEST_F(SymbolicExprTest, SemanticMatchRetainsProducerDepthLimit) {
+  loom_value_id_t source = DefineI64Value();
+  loom_value_id_t mask = DefineI64Value();
+  loom_value_id_t left = source;
+  loom_value_id_t right = source;
+  for (int i = 0; i < 17; ++i) {
+    left = BuildScalarAndI(left, mask);
+    right = BuildScalarAndI(right, mask);
+  }
+
+  loom_symbolic_proof_result_t proof = LOOM_SYMBOLIC_PROOF_UNKNOWN;
+  IREE_ASSERT_OK(ProveSemanticallyEquivalentUpperBound(&expression_context_,
+                                                       left, right, &proof));
+  EXPECT_EQ(proof, LOOM_SYMBOLIC_PROOF_UNKNOWN);
 }
 
 TEST_F(SymbolicExprTest, SimplifiesDifferenceToExistingValue) {

--- a/loom/src/loom/analysis/symbolic_expr_test.cc
+++ b/loom/src/loom/analysis/symbolic_expr_test.cc
@@ -128,6 +128,31 @@ TEST_F(SymbolicExprTest, MemoGrowthPreservesOuterExpansion) {
   EXPECT_EQ(memoized_expression.terms, expression.terms);
 }
 
+TEST_F(SymbolicExprTest, DeepProducerChainExpandsIteratively) {
+  loom_value_id_t source = DefineI64Value();
+  loom_value_id_t value = source;
+  for (int i = 0; i < 4096; ++i) {
+    loom_op_t* negate_op = nullptr;
+    IREE_ASSERT_OK(loom_scalar_negi_build(
+        &builder_, value, loom_type_scalar(LOOM_SCALAR_TYPE_I64),
+        LOOM_LOCATION_UNKNOWN, &negate_op));
+    value = loom_scalar_negi_result(negate_op);
+  }
+
+  loom_symbolic_expr_t expression = {0};
+  IREE_ASSERT_OK(
+      loom_symbolic_expr_from_value(&expression_context_, value, &expression));
+  ASSERT_TRUE(loom_symbolic_expr_is_linear(&expression));
+  ASSERT_EQ(expression.term_count, 1);
+  EXPECT_EQ(expression.terms[0].coefficient, 1);
+  EXPECT_EQ(expression.terms[0].value_id, source);
+
+  loom_symbolic_expr_t memoized_expression = {0};
+  IREE_ASSERT_OK(loom_symbolic_expr_from_value(&expression_context_, value,
+                                               &memoized_expression));
+  EXPECT_EQ(memoized_expression.terms, expression.terms);
+}
+
 TEST_F(SymbolicExprTest, ExpandsIndexMaddWithConstantMultiplier) {
   loom_value_id_t row = DefineIndexValue();
   loom_value_id_t column = DefineIndexValue();
@@ -157,6 +182,63 @@ TEST_F(SymbolicExprTest, DynamicMultiplyFallsBackToResultSymbol) {
                                       loom_type_scalar(LOOM_SCALAR_TYPE_INDEX),
                                       LOOM_LOCATION_UNKNOWN, &mul_op));
   loom_value_id_t result = loom_index_mul_result(mul_op);
+
+  loom_symbolic_expr_t expression = {0};
+  IREE_ASSERT_OK(
+      loom_symbolic_expr_from_value(&expression_context_, result, &expression));
+
+  ASSERT_TRUE(loom_symbolic_expr_is_linear(&expression));
+  ASSERT_EQ(expression.term_count, 1);
+  EXPECT_EQ(expression.terms[0].coefficient, 1);
+  EXPECT_EQ(expression.terms[0].value_id, result);
+}
+
+TEST_F(SymbolicExprTest, DynamicMaddFallsBackToResultSymbol) {
+  loom_value_id_t left = DefineIndexValue();
+  loom_value_id_t right = DefineIndexValue();
+  loom_value_id_t addend = DefineIndexValue();
+  loom_op_t* madd_op = nullptr;
+  IREE_ASSERT_OK(loom_index_madd_build(&builder_, left, right, addend,
+                                       loom_type_scalar(LOOM_SCALAR_TYPE_INDEX),
+                                       LOOM_LOCATION_UNKNOWN, &madd_op));
+  loom_value_id_t result = loom_index_madd_result(madd_op);
+
+  loom_symbolic_expr_t expression = {0};
+  IREE_ASSERT_OK(
+      loom_symbolic_expr_from_value(&expression_context_, result, &expression));
+
+  ASSERT_TRUE(loom_symbolic_expr_is_linear(&expression));
+  ASSERT_EQ(expression.term_count, 1);
+  EXPECT_EQ(expression.terms[0].coefficient, 1);
+  EXPECT_EQ(expression.terms[0].value_id, result);
+}
+
+TEST_F(SymbolicExprTest, ExpandsShiftWithExactAmount) {
+  loom_value_id_t value = DefineIndexValue();
+  loom_value_id_t shift = loom_index_constant_result(BuildIndexConstant(3));
+  loom_op_t* shift_op = nullptr;
+  IREE_ASSERT_OK(loom_index_shli_build(&builder_, value, shift,
+                                       loom_type_scalar(LOOM_SCALAR_TYPE_INDEX),
+                                       LOOM_LOCATION_UNKNOWN, &shift_op));
+
+  loom_symbolic_expr_t expression = {0};
+  IREE_ASSERT_OK(loom_symbolic_expr_from_value(
+      &expression_context_, loom_index_shli_result(shift_op), &expression));
+
+  ASSERT_TRUE(loom_symbolic_expr_is_linear(&expression));
+  ASSERT_EQ(expression.term_count, 1);
+  EXPECT_EQ(expression.terms[0].coefficient, 8);
+  EXPECT_EQ(expression.terms[0].value_id, value);
+}
+
+TEST_F(SymbolicExprTest, DynamicShiftFallsBackToResultSymbol) {
+  loom_value_id_t value = DefineIndexValue();
+  loom_value_id_t shift = DefineIndexValue();
+  loom_op_t* shift_op = nullptr;
+  IREE_ASSERT_OK(loom_index_shli_build(&builder_, value, shift,
+                                       loom_type_scalar(LOOM_SCALAR_TYPE_INDEX),
+                                       LOOM_LOCATION_UNKNOWN, &shift_op));
+  loom_value_id_t result = loom_index_shli_result(shift_op);
 
   loom_symbolic_expr_t expression = {0};
   IREE_ASSERT_OK(

--- a/loom/src/loom/analysis/symbolic_expr_test_fixture.h
+++ b/loom/src/loom/analysis/symbolic_expr_test_fixture.h
@@ -94,6 +94,14 @@ class SymbolicExprTest : public ::testing::Test {
     return op;
   }
 
+  loom_value_id_t BuildScalarAndI(loom_value_id_t lhs, loom_value_id_t rhs) {
+    loom_op_t* op = nullptr;
+    IREE_CHECK_OK(loom_scalar_andi_build(&builder_, lhs, rhs,
+                                         loom_type_scalar(LOOM_SCALAR_TYPE_I64),
+                                         LOOM_LOCATION_UNKNOWN, &op));
+    return loom_scalar_andi_result(op);
+  }
+
   iree_arena_block_pool_t block_pool_;
   iree_arena_allocator_t analysis_arena_;
   loom_context_t context_;

--- a/loom/src/loom/analysis/symbolic_value.c
+++ b/loom/src/loom/analysis/symbolic_value.c
@@ -616,67 +616,172 @@ iree_status_t loom_symbolic_values_match(loom_symbolic_expr_context_t* context,
   return iree_ok_status();
 }
 
-// Compares values produced by equivalent deterministic expression trees. This
-// is a bounded fallback for opaque terms in branch-relation proofs: CSE must
-// not move materializations across a convergent barrier, but their pure value
-// semantics remain equivalent.
-static iree_status_t loom_symbolic_values_semantically_match_bounded(
-    loom_symbolic_expr_context_t* context, loom_value_id_t left_value,
-    loom_value_id_t right_value, uint8_t remaining_depth,
-    uint16_t* remaining_pair_count, bool* out_match) {
-  IREE_RETURN_IF_ERROR(
-      loom_symbolic_values_match(context, left_value, right_value, out_match));
-  if (*out_match || remaining_depth == 0 || *remaining_pair_count == 0) {
-    return iree_ok_status();
-  }
+typedef struct loom_symbolic_semantic_match_frame_t {
+  // Left SSA value compared by this frame.
+  loom_value_id_t left_value;
 
-  left_value = loom_symbolic_expr_assumption_source_value(context, left_value);
-  right_value =
-      loom_symbolic_expr_assumption_source_value(context, right_value);
-  if (left_value == right_value) {
-    *out_match = true;
-    return iree_ok_status();
-  }
-  if (!context->module || left_value >= context->module->values.count ||
-      right_value >= context->module->values.count) {
-    return iree_ok_status();
-  }
+  // Right SSA value compared by this frame.
+  loom_value_id_t right_value;
 
-  const loom_value_t* left = loom_module_value(context->module, left_value);
-  const loom_value_t* right = loom_module_value(context->module, right_value);
-  if (loom_value_is_block_arg(left) || loom_value_is_block_arg(right)) {
-    return iree_ok_status();
-  }
-  const loom_op_t* left_op = loom_value_def_op(left);
-  const loom_op_t* right_op = loom_value_def_op(right);
-  if (!loom_symbolic_expr_ops_can_structurally_match(
-          context->module, left_op, right_op, loom_value_def_index(left),
-          loom_value_def_index(right))) {
-    return iree_ok_status();
-  }
+  // Remaining producer depth available to operand frames.
+  uint8_t remaining_depth;
 
-  --*remaining_pair_count;
-  const loom_value_id_t* left_operands = loom_op_const_operands(left_op);
-  const loom_value_id_t* right_operands = loom_op_const_operands(right_op);
-  for (uint16_t i = 0; i < left_op->operand_count; ++i) {
-    bool operands_match = false;
-    IREE_RETURN_IF_ERROR(loom_symbolic_values_semantically_match_bounded(
-        context, left_operands[i], right_operands[i], remaining_depth - 1,
-        remaining_pair_count, &operands_match));
-    if (!operands_match) return iree_ok_status();
+  // Next producer operand requiring comparison.
+  uint16_t next_operand;
+
+  // Structurally matched left producer, or NULL before frame entry.
+  const loom_op_t* left_op;
+
+  // Structurally matched right producer, or NULL before frame entry.
+  const loom_op_t* right_op;
+} loom_symbolic_semantic_match_frame_t;
+
+typedef struct loom_symbolic_semantic_match_pair_t {
+  // Canonically ordered lower SSA value ID.
+  loom_value_id_t lower_value;
+
+  // Canonically ordered upper SSA value ID.
+  loom_value_id_t upper_value;
+} loom_symbolic_semantic_match_pair_t;
+
+#define LOOM_SYMBOLIC_VALUE_SEMANTIC_MATCH_PAIR_TABLE_CAPACITY \
+  (LOOM_SYMBOLIC_VALUE_SEMANTIC_MATCH_PAIR_LIMIT * 2)
+static_assert((LOOM_SYMBOLIC_VALUE_SEMANTIC_MATCH_PAIR_TABLE_CAPACITY &
+               (LOOM_SYMBOLIC_VALUE_SEMANTIC_MATCH_PAIR_TABLE_CAPACITY - 1)) ==
+                  0,
+              "semantic match pair table capacity must be a power of two");
+
+// Inserts a canonically ordered value pair and returns true when it was new.
+// The table remains at most half full because the proof budget bounds inserts.
+static bool loom_symbolic_semantic_match_pair_insert(
+    loom_symbolic_semantic_match_pair_t* pair_table, loom_value_id_t left_value,
+    loom_value_id_t right_value) {
+  const loom_value_id_t lower_value = iree_min(left_value, right_value);
+  const loom_value_id_t upper_value = iree_max(left_value, right_value);
+  const uint32_t hash =
+      lower_value * UINT32_C(0x9E3779B1) ^ upper_value * UINT32_C(0x85EBCA77);
+  iree_host_size_t index =
+      hash & (LOOM_SYMBOLIC_VALUE_SEMANTIC_MATCH_PAIR_TABLE_CAPACITY - 1);
+  for (iree_host_size_t probe = 0;
+       probe < LOOM_SYMBOLIC_VALUE_SEMANTIC_MATCH_PAIR_TABLE_CAPACITY;
+       ++probe) {
+    loom_symbolic_semantic_match_pair_t* pair = &pair_table[index];
+    if (pair->lower_value == LOOM_VALUE_ID_INVALID) {
+      *pair = (loom_symbolic_semantic_match_pair_t){
+          .lower_value = lower_value,
+          .upper_value = upper_value,
+      };
+      return true;
+    }
+    if (pair->lower_value == lower_value && pair->upper_value == upper_value) {
+      return false;
+    }
+    index = (index + 1) &
+            (LOOM_SYMBOLIC_VALUE_SEMANTIC_MATCH_PAIR_TABLE_CAPACITY - 1);
   }
-  *out_match = true;
-  return iree_ok_status();
+  IREE_ASSERT_UNREACHABLE("symbolic semantic match pair table is full");
+  IREE_BUILTIN_UNREACHABLE();
 }
 
+// Compares deterministic producer DAGs when ordinary symbolic cancellation
+// cannot relate their separately materialized values. The explicit depth-first
+// traversal bounds producer depth and distinct pairs while visiting shared DAG
+// pairs only once.
 iree_status_t loom_symbolic_values_semantically_match(
     loom_symbolic_expr_context_t* context, loom_value_id_t left_value,
     loom_value_id_t right_value, bool* out_match) {
+  *out_match = false;
+
+  loom_symbolic_semantic_match_frame_t
+      frames[LOOM_SYMBOLIC_VALUE_SEMANTIC_MATCH_DEPTH_LIMIT + 1] = {
+          {
+              .left_value = left_value,
+              .right_value = right_value,
+              .remaining_depth = LOOM_SYMBOLIC_VALUE_SEMANTIC_MATCH_DEPTH_LIMIT,
+          },
+      };
+  iree_host_size_t frame_count = 1;
+
+  loom_symbolic_semantic_match_pair_t
+      pair_table[LOOM_SYMBOLIC_VALUE_SEMANTIC_MATCH_PAIR_TABLE_CAPACITY];
+  memset(pair_table, 0xFF, sizeof(pair_table));
   uint16_t remaining_pair_count = LOOM_SYMBOLIC_VALUE_SEMANTIC_MATCH_PAIR_LIMIT;
-  return loom_symbolic_values_semantically_match_bounded(
-      context, left_value, right_value,
-      LOOM_SYMBOLIC_VALUE_SEMANTIC_MATCH_DEPTH_LIMIT, &remaining_pair_count,
-      out_match);
+
+  while (frame_count > 0) {
+    loom_symbolic_semantic_match_frame_t* frame = &frames[frame_count - 1];
+    if (frame->left_op != NULL) {
+      if (frame->next_operand == frame->left_op->operand_count) {
+        --frame_count;
+        continue;
+      }
+      const uint16_t operand_index = frame->next_operand++;
+      const loom_value_id_t* left_operands =
+          loom_op_const_operands(frame->left_op);
+      const loom_value_id_t* right_operands =
+          loom_op_const_operands(frame->right_op);
+      IREE_ASSERT_LT(frame_count, IREE_ARRAYSIZE(frames));
+      frames[frame_count++] = (loom_symbolic_semantic_match_frame_t){
+          .left_value = left_operands[operand_index],
+          .right_value = right_operands[operand_index],
+          .remaining_depth = (uint8_t)(frame->remaining_depth - 1),
+      };
+      continue;
+    }
+
+    bool values_match = false;
+    IREE_RETURN_IF_ERROR(loom_symbolic_values_match(
+        context, frame->left_value, frame->right_value, &values_match));
+    if (values_match) {
+      --frame_count;
+      continue;
+    }
+    if (frame->remaining_depth == 0 || remaining_pair_count == 0) {
+      return iree_ok_status();
+    }
+
+    const loom_value_id_t normalized_left =
+        loom_symbolic_expr_assumption_source_value(context, frame->left_value);
+    const loom_value_id_t normalized_right =
+        loom_symbolic_expr_assumption_source_value(context, frame->right_value);
+    if (normalized_left == normalized_right) {
+      --frame_count;
+      continue;
+    }
+    if (!context->module || normalized_left >= context->module->values.count ||
+        normalized_right >= context->module->values.count) {
+      return iree_ok_status();
+    }
+
+    const loom_value_t* left =
+        loom_module_value(context->module, normalized_left);
+    const loom_value_t* right =
+        loom_module_value(context->module, normalized_right);
+    if (loom_value_is_block_arg(left) || loom_value_is_block_arg(right)) {
+      return iree_ok_status();
+    }
+    const loom_op_t* left_op = loom_value_def_op(left);
+    const loom_op_t* right_op = loom_value_def_op(right);
+    if (!loom_symbolic_expr_ops_can_structurally_match(
+            context->module, left_op, right_op, loom_value_def_index(left),
+            loom_value_def_index(right))) {
+      return iree_ok_status();
+    }
+    if (!loom_symbolic_semantic_match_pair_insert(pair_table, normalized_left,
+                                                  normalized_right)) {
+      --frame_count;
+      continue;
+    }
+
+    --remaining_pair_count;
+    frame->left_value = normalized_left;
+    frame->right_value = normalized_right;
+    frame->next_operand = 0;
+    frame->left_op = left_op;
+    frame->right_op = right_op;
+  }
+
+  *out_match = true;
+  return iree_ok_status();
 }
 
 static iree_status_t loom_symbolic_expr_value_matches_constant(


### PR DESCRIPTION
Symbolic expression analysis now traverses producer graphs with bounded explicit worklists instead of consuming the C stack. The replacement preserves existing proof budgets, memoization, cycle handling, and fallback semantics while making deeply authored expressions safe for the JIT.

**Design**

Semantic value matching uses a fixed depth-first frame array bounded by the existing producer-depth limit. A fixed open-addressed table records canonical value pairs, remains at most half full under the existing distinct-pair budget, and prevents shared DAG edges from repeatedly consuming proof work. Exhausting either established budget still returns an unknown proof rather than weakening the bound or claiming equivalence.

Expression expansion uses an explicit post-order continuation machine. Each frame records the producer operation category, continuation stage, ordered operands, and the one partial expression needed by a later operand. Ordinary expressions fit in an eight-frame inline array. Deeper producer chains grow through a per-query arena backed by the analysis context's shared block pool, then release all transient frames together when the query completes.

The continuation machine preserves operation-specific evaluation order and laziness. Dynamic multiplication and multiply-add stop before expanding unused addends, shifts inspect the amount before expanding the shifted value, and selects expand only the chosen arm when the condition is exact. Identity assumptions retain their relations, nonlinear results fall back to their original result symbol, and memo entries are published only after a frame completes.

Memo-table growth cannot invalidate traversal state because frames carry value IDs rather than memo pointers. Cycle encounters retain the existing symbolic fallback, while a failed query resets every still-visiting frame before releasing its transient arena.

**Impact**

Compiler behavior is no longer limited by the process stack for authored producer depth. Shared producer DAGs consume proof budget according to distinct compared pairs rather than repeated edges, allowing bounded structural proofs to reach their intended depth without making the analysis unbounded.

The common JIT path adds no heap allocation and no graph rediscovery. Semantic matching uses fixed stack storage derived from existing limits, and shallow expression expansion remains entirely inline. Arena growth is reserved for unusually deep producer chains and reuses the existing block pool.

Coverage exercises the public branch-relation proof path with shared producers, unequal leaves, and the retained depth boundary. Expression coverage includes memo relocation, exact and dynamic multiply-add, exact and dynamic shifts, selected values, and a 4,096-producer chain whose second query confirms the completed expression remains memoized.

**Reviewer Notes**

The highest-value review surfaces are continuation transitions in `symbolic_expr.c`, memo publication and error cleanup after frame growth, and the distinct-pair accounting in `symbolic_value.c`. The representation deliberately preserves the previous depth and work limits rather than replacing recursion with an unbounded traversal.
