### PR TITLE
[Loom] Compare target-specialized compile reports

### DIFF
--- a/loom/py/loom/reporting/BUILD.bazel
+++ b/loom/py/loom/reporting/BUILD.bazel
@@ -17,6 +17,7 @@ iree_py_library(
         "__init__.py",
         "compile_report.py",
         "compile_report_bank_service.py",
+        "compile_report_capabilities.py",
         "compile_report_suggestions.py",
         "compile_report_view.py",
     ],

--- a/loom/py/loom/reporting/CMakeLists.txt
+++ b/loom/py/loom/reporting/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_py_library(
     "__init__.py"
     "compile_report.py"
     "compile_report_bank_service.py"
+    "compile_report_capabilities.py"
     "compile_report_suggestions.py"
     "compile_report_view.py"
   IMPORTS

--- a/loom/py/loom/reporting/compile_report.py
+++ b/loom/py/loom/reporting/compile_report.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import cast
 
@@ -60,6 +61,30 @@ _ENVELOPE_CONTEXT_FIELDS = (
     "sample_id",
     "sample_index",
 )
+
+_TARGET_VARIANT_REPORT_FIELDS = frozenset(
+    (
+        "target_key",
+        "target_bundle",
+        "target_snapshot",
+        "target_config",
+    )
+)
+
+_TARGET_VARIANT_ENTRY_FIELDS = frozenset(
+    (
+        "target_bundle",
+        "target_snapshot",
+        "target_config",
+    )
+)
+
+
+class CompileReportComparisonMode(Enum):
+    """Identity contract used to compare two compile reports."""
+
+    EXACT = "exact"
+    TARGET = "target"
 
 
 class CompileReportError(ValueError):
@@ -282,8 +307,9 @@ def compile_report_entry_identity(
 def match_compile_report_entries(
     baseline: CompileReportDocument,
     candidate: CompileReportDocument,
+    comparison_mode: CompileReportComparisonMode = CompileReportComparisonMode.EXACT,
 ) -> tuple[CompileReportEntryPair, ...]:
-    """Checks strict comparability and returns exact entry pairs."""
+    """Checks the selected comparability contract and returns entry pairs."""
     differences: list[str] = []
     if baseline.status_code != 0:
         differences.append(
@@ -294,7 +320,22 @@ def match_compile_report_entries(
             f"candidate status is {candidate.status_name} ({candidate.status_code})"
         )
 
+    if comparison_mode is CompileReportComparisonMode.TARGET:
+        for document_role, document in (
+            ("baseline", baseline),
+            ("candidate", candidate),
+        ):
+            if not document.report.get("target_family"):
+                differences.append(f"{document_role} target_family is unavailable")
+            if not document.report.get("target_key"):
+                differences.append(f"{document_role} target_key is unavailable")
+
     for field in _REPORT_IDENTITY_FIELDS:
+        if (
+            comparison_mode is CompileReportComparisonMode.TARGET
+            and field in _TARGET_VARIANT_REPORT_FIELDS
+        ):
+            continue
         baseline_value = _canonical_value(baseline.report.get(field))
         candidate_value = _canonical_value(candidate.report.get(field))
         if baseline_value != candidate_value:
@@ -335,6 +376,11 @@ def match_compile_report_entries(
         baseline_entry = baseline_entries[identity]
         candidate_entry = candidate_entries[identity]
         for field in _ENTRY_CONTEXT_FIELDS:
+            if (
+                comparison_mode is CompileReportComparisonMode.TARGET
+                and field in _TARGET_VARIANT_ENTRY_FIELDS
+            ):
+                continue
             baseline_value = _canonical_value(baseline_entry.get(field))
             candidate_value = _canonical_value(candidate_entry.get(field))
             if baseline_value != candidate_value:
@@ -372,6 +418,37 @@ def report_identity_json(document: CompileReportDocument) -> dict[str, object]:
             {"key": key, "value": value} for key, value in document.config_bindings
         ]
     return identity
+
+
+def report_common_identity_json(
+    document: CompileReportDocument,
+    comparison_mode: CompileReportComparisonMode,
+) -> dict[str, object]:
+    """Returns identity fields held constant by a comparison contract."""
+    identity = report_identity_json(document)
+    if comparison_mode is CompileReportComparisonMode.TARGET:
+        for field in _TARGET_VARIANT_REPORT_FIELDS:
+            identity.pop(field, None)
+    return identity
+
+
+def report_target_identity_json(
+    document: CompileReportDocument,
+) -> dict[str, object]:
+    """Returns the selected target specialization identity."""
+    fields = (
+        "backend",
+        "target_family",
+        "target_key",
+        "target_bundle",
+        "target_snapshot",
+        "target_config",
+    )
+    return {
+        field: document.report[field]
+        for field in fields
+        if document.report.get(field) is not None
+    }
 
 
 def _validate_indexed_rows(

--- a/loom/py/loom/reporting/compile_report_capabilities.py
+++ b/loom/py/loom/reporting/compile_report_capabilities.py
@@ -1,0 +1,261 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Compact semantic diffs for selected target capability rows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loom.reporting.compile_report import CompileReportDocument, CompileReportError
+
+
+@dataclass(frozen=True)
+class _CapabilityIdentity:
+    function: str | None
+    target_family: str | None
+    namespace: str
+    key: str
+
+    def to_json_object(self) -> dict[str, object]:
+        identity: dict[str, object] = {
+            "namespace": self.namespace,
+            "key": self.key,
+        }
+        if self.function is not None:
+            identity["function"] = self.function
+        if self.target_family is not None:
+            identity["target_family"] = self.target_family
+        return identity
+
+
+@dataclass(frozen=True)
+class _CapabilityValue:
+    kind: str
+    value: bool | int | str | None
+
+    def to_json_object(self) -> dict[str, object]:
+        return {"kind": self.kind, "value": self.value}
+
+
+def build_target_capability_diff(
+    baseline: CompileReportDocument,
+    candidate: CompileReportDocument,
+) -> dict[str, object] | None:
+    """Builds a semantic diff of capabilities selected for emitted entries."""
+    baseline_capabilities = _parse_target_capabilities(baseline)
+    candidate_capabilities = _parse_target_capabilities(candidate)
+    if baseline_capabilities is None and candidate_capabilities is None:
+        return None
+    if baseline_capabilities is None or candidate_capabilities is None:
+        return {
+            "availability": {
+                "baseline": (
+                    "available" if baseline_capabilities is not None else "unavailable"
+                ),
+                "candidate": (
+                    "available" if candidate_capabilities is not None else "unavailable"
+                ),
+            },
+            "changed_count": 0,
+            "unchanged_count": 0,
+            "rows": [],
+        }
+
+    changed_rows = []
+    unchanged_count = 0
+    for identity in sorted(
+        set(baseline_capabilities) | set(candidate_capabilities),
+        key=_capability_identity_sort_key,
+    ):
+        baseline_capability = baseline_capabilities.get(identity)
+        candidate_capability = candidate_capabilities.get(identity)
+        if baseline_capability is None:
+            changed_rows.append(
+                {
+                    "identity": identity.to_json_object(),
+                    "status": "added",
+                    "candidate": candidate_capability.to_json_object(),
+                }
+            )
+            continue
+        if candidate_capability is None:
+            changed_rows.append(
+                {
+                    "identity": identity.to_json_object(),
+                    "status": "removed",
+                    "baseline": baseline_capability.to_json_object(),
+                }
+            )
+            continue
+        if baseline_capability == candidate_capability:
+            unchanged_count += 1
+            continue
+        changed_rows.append(
+            {
+                "identity": identity.to_json_object(),
+                "status": "changed",
+                "baseline": baseline_capability.to_json_object(),
+                "candidate": candidate_capability.to_json_object(),
+            }
+        )
+
+    return {
+        "changed_count": len(changed_rows),
+        "unchanged_count": unchanged_count,
+        "rows": changed_rows,
+    }
+
+
+def append_target_capability_diff_text(
+    lines: list[str],
+    capability_diff: dict[str, object],
+) -> None:
+    """Appends a compact human-readable capability diff."""
+    lines.append("")
+    lines.append("Target capabilities")
+    availability = capability_diff.get("availability")
+    if isinstance(availability, dict):
+        lines.append(
+            "  availability: "
+            f"baseline={availability['baseline']}, "
+            f"candidate={availability['candidate']}"
+        )
+        return
+    lines.append(
+        f"  rows: {capability_diff['changed_count']} changed, "
+        f"{capability_diff['unchanged_count']} unchanged"
+    )
+    for row_value in _require_list(capability_diff.get("rows"), "rows"):
+        row = _require_object(row_value, "row")
+        identity = _require_object(row.get("identity"), "row.identity")
+        function = identity.get("function")
+        function_prefix = f"{function} " if function else ""
+        label = f"{function_prefix}{identity['namespace']}.{identity['key']}"
+        status = row.get("status")
+        if status == "changed":
+            baseline = _require_object(row.get("baseline"), "row.baseline")
+            candidate = _require_object(row.get("candidate"), "row.candidate")
+            lines.append(
+                f"  {label}: {_format_value(baseline)} -> {_format_value(candidate)}"
+            )
+        elif status == "added":
+            candidate = _require_object(row.get("candidate"), "row.candidate")
+            lines.append(f"  {label}: added {_format_value(candidate)}")
+        elif status == "removed":
+            baseline = _require_object(row.get("baseline"), "row.baseline")
+            lines.append(f"  {label}: removed {_format_value(baseline)}")
+        else:
+            raise CompileReportError(
+                f"target capability row: invalid status {status!r}"
+            )
+
+
+def _parse_target_capabilities(
+    document: CompileReportDocument,
+) -> dict[_CapabilityIdentity, _CapabilityValue] | None:
+    value = document.report.get("target_capability_rows")
+    if value is None:
+        return None
+    container = _require_object(value, f"{document.source}.target_capability_rows")
+    rows = _require_list(
+        container.get("rows"), f"{document.source}.target_capability_rows.rows"
+    )
+    count = container.get("count")
+    if not isinstance(count, int) or isinstance(count, bool) or count != len(rows):
+        raise CompileReportError(
+            f"{document.source}.target_capability_rows.count: "
+            f"expected {len(rows)}, got {count!r}"
+        )
+
+    capabilities: dict[_CapabilityIdentity, _CapabilityValue] = {}
+    for index, row_value in enumerate(rows):
+        source = f"{document.source}.target_capability_rows.rows[{index}]"
+        row = _require_object(row_value, source)
+        identity = _CapabilityIdentity(
+            function=_optional_string(row.get("function"), f"{source}.function"),
+            target_family=_optional_string(
+                row.get("target_family"), f"{source}.target_family"
+            ),
+            namespace=_require_string(row.get("namespace"), f"{source}.namespace"),
+            key=_require_string(row.get("key"), f"{source}.key"),
+        )
+        if identity in capabilities:
+            raise CompileReportError(
+                f"{source}: duplicate target capability "
+                f"{identity.namespace}.{identity.key!s}"
+            )
+        capabilities[identity] = _parse_capability_value(row, source)
+    return capabilities
+
+
+def _capability_identity_sort_key(
+    identity: _CapabilityIdentity,
+) -> tuple[str, str, str, str]:
+    return (
+        identity.function or "",
+        identity.target_family or "",
+        identity.namespace,
+        identity.key,
+    )
+
+
+def _parse_capability_value(
+    row: dict[str, object],
+    source: str,
+) -> _CapabilityValue:
+    kind = _require_string(row.get("value_kind"), f"{source}.value_kind")
+    if kind == "none":
+        value: bool | int | str | None = None
+    elif kind == "bool":
+        value = row.get("value_bool")
+        if not isinstance(value, bool):
+            raise CompileReportError(f"{source}.value_bool: expected bool")
+    elif kind == "u64":
+        value = row.get("value_u64")
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise CompileReportError(f"{source}.value_u64: expected unsigned integer")
+    elif kind == "string":
+        value = _require_string(row.get("value_string"), f"{source}.value_string")
+    else:
+        raise CompileReportError(f"{source}.value_kind: unsupported kind {kind!r}")
+    return _CapabilityValue(kind=kind, value=value)
+
+
+def _format_value(value: dict[str, object]) -> str:
+    kind = value.get("kind")
+    payload = value.get("value")
+    if kind == "string":
+        return repr(payload)
+    if isinstance(payload, bool):
+        return "true" if payload else "false"
+    if payload is None:
+        return "none"
+    return str(payload)
+
+
+def _require_object(value: object, source: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise CompileReportError(f"{source}: expected object")
+    return value
+
+
+def _require_list(value: object, source: str) -> list[object]:
+    if not isinstance(value, list):
+        raise CompileReportError(f"{source}: expected array")
+    return value
+
+
+def _require_string(value: object, source: str) -> str:
+    if not isinstance(value, str):
+        raise CompileReportError(f"{source}: expected string")
+    return value
+
+
+def _optional_string(value: object, source: str) -> str | None:
+    if value is None:
+        return None
+    return _require_string(value, source)

--- a/loom/py/loom/reporting/compile_report_test.py
+++ b/loom/py/loom/reporting/compile_report_test.py
@@ -11,10 +11,15 @@ from copy import deepcopy
 import pytest
 
 from loom.reporting.compile_report import (
+    CompileReportComparisonMode,
     CompileReportError,
     IncomparableCompileReportsError,
     match_compile_report_entries,
     parse_compile_report,
+)
+from loom.reporting.compile_report_capabilities import (
+    append_target_capability_diff_text,
+    build_target_capability_diff,
 )
 from loom.reporting.compile_report_view import (
     build_compile_report_diff,
@@ -163,6 +168,44 @@ def _compile_report() -> dict[str, object]:
     }
 
 
+def _set_target_capabilities(
+    report: dict[str, object],
+    *,
+    processor: str,
+    descriptor_set: str,
+) -> None:
+    rows = [
+        {
+            "index": 0,
+            "function": "routed_linear",
+            "target_family": "AMDGPU",
+            "namespace": "amdgpu",
+            "key": "processor",
+            "value_kind": "string",
+            "value_string": processor,
+        },
+        {
+            "index": 1,
+            "function": "routed_linear",
+            "target_family": "AMDGPU",
+            "namespace": "amdgpu",
+            "key": "descriptor_set",
+            "value_kind": "string",
+            "value_string": descriptor_set,
+        },
+        {
+            "index": 2,
+            "function": "routed_linear",
+            "target_family": "AMDGPU",
+            "namespace": "target",
+            "key": "subgroup_size",
+            "value_kind": "u64",
+            "value_u64": 64,
+        },
+    ]
+    report["target_capability_rows"] = {"count": len(rows), "rows": rows}
+
+
 def test_parses_direct_and_benchmark_envelope_reports() -> None:
     report = _compile_report()
     direct = parse_compile_report(report, source="direct.json")
@@ -270,6 +313,127 @@ def test_rejects_incomparable_reports(mutate, message: str) -> None:
 
     with pytest.raises(IncomparableCompileReportsError, match=message):
         match_compile_report_entries(baseline, candidate)
+
+
+def test_target_comparison_permits_only_target_specialization_identity() -> None:
+    baseline = parse_compile_report(_compile_report(), source="baseline.json")
+    candidate_report = _compile_report()
+    candidate_report["target_key"] = "gfx1151"
+    candidate_report["target_bundle"] = "gfx11_5_wave64"
+    candidate_report["target_snapshot"] = "gfx11_5_wave64"
+    candidate_report["target_config"] = "gfx11_5_wave64"
+    candidate_entry = candidate_report["entries"]["rows"][0]
+    candidate_entry["target_bundle"] = "gfx11_5_wave64"
+    candidate_entry["target_snapshot"] = "gfx11_5_wave64"
+    candidate_entry["target_config"] = "gfx11_5_wave64"
+    candidate = parse_compile_report(candidate_report, source="candidate.json")
+
+    pairs = match_compile_report_entries(
+        baseline,
+        candidate,
+        CompileReportComparisonMode.TARGET,
+    )
+    view = build_compile_report_diff(
+        baseline,
+        candidate,
+        CompileReportComparisonMode.TARGET,
+    )
+
+    assert len(pairs) == 1
+    assert view["comparison_mode"] == "target"
+    assert view["identity"]["target_family"] == "AMDGPU"
+    assert "target_key" not in view["identity"]
+    assert view["targets"]["baseline"]["target_key"] == "gfx11-generic"
+    assert view["targets"]["candidate"]["target_key"] == "gfx1151"
+    assert view["changed_entry_count"] == 0
+    assert view["unchanged_entry_count"] == 1
+    text = format_compile_report_diff_text(view)
+    assert "comparison: target specialization" in text
+    assert "baseline target: AMDGPU/gfx11-generic via amdgpu-hal" in text
+    assert "candidate target: AMDGPU/gfx1151 via amdgpu-hal" in text
+    assert "reported entry evidence: unchanged" in text
+
+
+def test_target_comparison_diffs_selected_capabilities() -> None:
+    baseline_report = _compile_report()
+    _set_target_capabilities(
+        baseline_report,
+        processor="gfx1100",
+        descriptor_set="amdgpu.rdna3.core",
+    )
+    baseline = parse_compile_report(baseline_report, source="baseline.json")
+    candidate_report = _compile_report()
+    candidate_report["target_key"] = "gfx1151"
+    _set_target_capabilities(
+        candidate_report,
+        processor="gfx1151",
+        descriptor_set="amdgpu.rdna3_5.core",
+    )
+    candidate = parse_compile_report(candidate_report, source="candidate.json")
+
+    capability_diff = build_target_capability_diff(baseline, candidate)
+
+    assert capability_diff is not None
+    assert capability_diff["changed_count"] == 2
+    assert capability_diff["unchanged_count"] == 1
+    assert capability_diff["rows"][0]["identity"]["key"] == "descriptor_set"
+    assert capability_diff["rows"][0]["baseline"] == {
+        "kind": "string",
+        "value": "amdgpu.rdna3.core",
+    }
+    assert capability_diff["rows"][1]["identity"]["key"] == "processor"
+    lines: list[str] = []
+    append_target_capability_diff_text(lines, capability_diff)
+    text = "\n".join(lines)
+    assert "rows: 2 changed, 1 unchanged" in text
+    assert "'amdgpu.rdna3.core' -> 'amdgpu.rdna3_5.core'" in text
+
+    view = build_compile_report_diff(
+        baseline,
+        candidate,
+        CompileReportComparisonMode.TARGET,
+    )
+    assert view["target_capabilities"] == capability_diff
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda report: report.__setitem__("target_family", "SPIR-V"),
+            "target_family",
+        ),
+        (
+            lambda report: report.__setitem__("backend", "spirv-hal"),
+            "backend",
+        ),
+        (
+            lambda report: report["config_bindings"]["rows"][0].__setitem__(
+                "value", "1024"
+            ),
+            "config_bindings",
+        ),
+        (
+            lambda report: report["entries"]["rows"][0]["workload"][
+                "workgroup_count"
+            ].__setitem__("x", 6),
+            "workload",
+        ),
+    ],
+)
+def test_target_comparison_rejects_non_target_changes(mutate, message: str) -> None:
+    baseline = parse_compile_report(_compile_report())
+    candidate_report = _compile_report()
+    candidate_report["target_key"] = "gfx1151"
+    mutate(candidate_report)
+    candidate = parse_compile_report(candidate_report)
+
+    with pytest.raises(IncomparableCompileReportsError, match=message):
+        match_compile_report_entries(
+            baseline,
+            candidate,
+            CompileReportComparisonMode.TARGET,
+        )
 
 
 def test_show_separates_facts_analysis_and_unavailable_evidence() -> None:

--- a/loom/py/loom/reporting/compile_report_test.py
+++ b/loom/py/loom/reporting/compile_report_test.py
@@ -173,6 +173,7 @@ def _set_target_capabilities(
     *,
     processor: str,
     descriptor_set: str,
+    matrix_features: tuple[str, ...] = (),
 ) -> None:
     rows = [
         {
@@ -203,6 +204,18 @@ def _set_target_capabilities(
             "value_u64": 64,
         },
     ]
+    for matrix_feature in matrix_features:
+        rows.append(
+            {
+                "index": len(rows),
+                "function": "routed_linear",
+                "target_family": "AMDGPU",
+                "namespace": "amdgpu.matrix_feature",
+                "key": matrix_feature,
+                "value_kind": "bool",
+                "value_bool": True,
+            }
+        )
     report["target_capability_rows"] = {"count": len(rows), "rows": rows}
 
 
@@ -360,6 +373,7 @@ def test_target_comparison_diffs_selected_capabilities() -> None:
         baseline_report,
         processor="gfx1100",
         descriptor_set="amdgpu.rdna3.core",
+        matrix_features=("wmma-gfx11",),
     )
     baseline = parse_compile_report(baseline_report, source="baseline.json")
     candidate_report = _compile_report()
@@ -368,13 +382,14 @@ def test_target_comparison_diffs_selected_capabilities() -> None:
         candidate_report,
         processor="gfx1151",
         descriptor_set="amdgpu.rdna3_5.core",
+        matrix_features=("wmma-gfx12", "swmmac-gfx12"),
     )
     candidate = parse_compile_report(candidate_report, source="candidate.json")
 
     capability_diff = build_target_capability_diff(baseline, candidate)
 
     assert capability_diff is not None
-    assert capability_diff["changed_count"] == 2
+    assert capability_diff["changed_count"] == 5
     assert capability_diff["unchanged_count"] == 1
     assert capability_diff["rows"][0]["identity"]["key"] == "descriptor_set"
     assert capability_diff["rows"][0]["baseline"] == {
@@ -382,11 +397,27 @@ def test_target_comparison_diffs_selected_capabilities() -> None:
         "value": "amdgpu.rdna3.core",
     }
     assert capability_diff["rows"][1]["identity"]["key"] == "processor"
+    assert capability_diff["rows"][2] == {
+        "identity": {
+            "namespace": "amdgpu.matrix_feature",
+            "key": "swmmac-gfx12",
+            "function": "routed_linear",
+            "target_family": "AMDGPU",
+        },
+        "status": "added",
+        "candidate": {"kind": "bool", "value": True},
+    }
+    assert capability_diff["rows"][3]["identity"]["key"] == "wmma-gfx11"
+    assert capability_diff["rows"][3]["status"] == "removed"
+    assert capability_diff["rows"][4]["identity"]["key"] == "wmma-gfx12"
+    assert capability_diff["rows"][4]["status"] == "added"
     lines: list[str] = []
     append_target_capability_diff_text(lines, capability_diff)
     text = "\n".join(lines)
-    assert "rows: 2 changed, 1 unchanged" in text
+    assert "rows: 5 changed, 1 unchanged" in text
     assert "'amdgpu.rdna3.core' -> 'amdgpu.rdna3_5.core'" in text
+    assert "amdgpu.matrix_feature.wmma-gfx11: removed true" in text
+    assert "amdgpu.matrix_feature.wmma-gfx12: added true" in text
 
     view = build_compile_report_diff(
         baseline,

--- a/loom/py/loom/reporting/compile_report_view.py
+++ b/loom/py/loom/reporting/compile_report_view.py
@@ -13,17 +13,24 @@ from enum import Enum
 
 from loom.reporting.compile_report import (
     COMPILE_REPORT_SCHEMA_VERSION,
+    CompileReportComparisonMode,
     CompileReportDocument,
     CompileReportEntryIdentity,
     compile_report_entry_identity,
     match_compile_report_entries,
+    report_common_identity_json,
     report_identity_json,
+    report_target_identity_json,
 )
 from loom.reporting.compile_report_bank_service import (
     append_bank_service_diff_text,
     append_bank_service_show_text,
     build_bank_service_diff,
     build_bank_service_show,
+)
+from loom.reporting.compile_report_capabilities import (
+    append_target_capability_diff_text,
+    build_target_capability_diff,
 )
 
 SHOW_KIND = "loom.compile_report.show"
@@ -404,9 +411,10 @@ def build_compile_report_show(
 def build_compile_report_diff(
     baseline: CompileReportDocument,
     candidate: CompileReportDocument,
+    comparison_mode: CompileReportComparisonMode = CompileReportComparisonMode.EXACT,
 ) -> dict[str, object]:
-    """Builds a deterministic diff after enforcing exact comparability."""
-    pairs = match_compile_report_entries(baseline, candidate)
+    """Builds a deterministic diff under the selected identity contract."""
+    pairs = match_compile_report_entries(baseline, candidate, comparison_mode)
     entries = []
     unchanged_entry_count = 0
     for pair in pairs:
@@ -438,14 +446,24 @@ def build_compile_report_diff(
         "missing_evidence": "omitted_metrics_are_unavailable",
         "baseline_source": baseline.source,
         "candidate_source": candidate.source,
-        "identity": report_identity_json(baseline),
+        "comparison_mode": comparison_mode.value,
+        "identity": report_common_identity_json(baseline, comparison_mode),
         "changed_entry_count": len(entries),
         "unchanged_entry_count": unchanged_entry_count,
         "entries": entries,
     }
+    if comparison_mode is CompileReportComparisonMode.TARGET:
+        view["targets"] = {
+            "baseline": report_target_identity_json(baseline),
+            "candidate": report_target_identity_json(candidate),
+        }
     bank_service = build_bank_service_diff(baseline, candidate)
     if bank_service is not None:
         view["bank_service"] = bank_service
+    if comparison_mode is CompileReportComparisonMode.TARGET:
+        target_capabilities = build_target_capability_diff(baseline, candidate)
+        if target_capabilities is not None:
+            view["target_capabilities"] = target_capabilities
     return view
 
 
@@ -511,13 +529,43 @@ def format_compile_report_diff_text(view: dict[str, object]) -> str:
         "Loom compile report diff",
         f"  baseline: {view['baseline_source']}",
         f"  candidate: {view['candidate_source']}",
-        f"  target: {_format_target(identity)}",
-        f"  specialization: {_format_specialization(identity)}",
-        (
-            f"  entries: {view['changed_entry_count']} changed, "
-            f"{view['unchanged_entry_count']} unchanged"
-        ),
     ]
+    if view.get("comparison_mode") == CompileReportComparisonMode.TARGET.value:
+        targets = _expect_dict(view["targets"])
+        baseline_target = _expect_dict(targets["baseline"])
+        candidate_target = _expect_dict(targets["candidate"])
+        lines.extend(
+            (
+                "  comparison: target specialization",
+                f"  baseline target: {_format_target(baseline_target)}",
+                (
+                    "  baseline specialization: "
+                    f"{_format_specialization(baseline_target)}"
+                ),
+                f"  candidate target: {_format_target(candidate_target)}",
+                (
+                    "  candidate specialization: "
+                    f"{_format_specialization(candidate_target)}"
+                ),
+            )
+        )
+    else:
+        lines.extend(
+            (
+                f"  target: {_format_target(identity)}",
+                f"  specialization: {_format_specialization(identity)}",
+            )
+        )
+    lines.append(
+        f"  entries: {view['changed_entry_count']} changed, "
+        f"{view['unchanged_entry_count']} unchanged"
+    )
+    if (
+        view.get("comparison_mode") == CompileReportComparisonMode.TARGET.value
+        and view["changed_entry_count"] == 0
+        and view["unchanged_entry_count"] != 0
+    ):
+        lines.append("  reported entry evidence: unchanged")
     for entry_value in _expect_list(view["entries"]):
         entry = _expect_dict(entry_value)
         entry_identity = _expect_dict(entry["identity"])
@@ -538,6 +586,9 @@ def format_compile_report_diff_text(view: dict[str, object]) -> str:
     bank_service = view.get("bank_service")
     if isinstance(bank_service, dict):
         append_bank_service_diff_text(lines, bank_service)
+    target_capabilities = view.get("target_capabilities")
+    if isinstance(target_capabilities, dict):
+        append_target_capability_diff_text(lines, target_capabilities)
     return "\n".join(lines) + "\n"
 
 

--- a/loom/py/loom/tools/compile_report.py
+++ b/loom/py/loom/tools/compile_report.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TextIO
 
 from loom.reporting.compile_report import (
+    CompileReportComparisonMode,
     CompileReportError,
     IncomparableCompileReportsError,
     load_compile_report,
@@ -53,7 +54,11 @@ def run(args: argparse.Namespace, *, stdout: TextIO) -> int:
     elif args.command == "diff":
         baseline = load_compile_report(args.baseline)
         candidate = load_compile_report(args.candidate)
-        view = build_compile_report_diff(baseline, candidate)
+        view = build_compile_report_diff(
+            baseline,
+            candidate,
+            CompileReportComparisonMode(args.comparison),
+        )
         text = format_compile_report_diff_text(view)
     elif args.command == "suggest":
         document = load_compile_report(args.report)
@@ -94,10 +99,20 @@ def _create_argument_parser() -> argparse.ArgumentParser:
 
     diff_parser = subparsers.add_parser(
         "diff",
-        help="Compares reports with exact target and workload identity.",
+        help="Compares reports under a strict identity contract.",
     )
     diff_parser.add_argument("baseline", type=Path, help="Baseline report path.")
     diff_parser.add_argument("candidate", type=Path, help="Candidate report path.")
+    diff_parser.add_argument(
+        "--comparison",
+        choices=tuple(mode.value for mode in CompileReportComparisonMode),
+        default=CompileReportComparisonMode.EXACT.value,
+        help=(
+            "Identity contract. 'exact' requires identical compilation identity; "
+            "'target' permits only target specialization identity to vary within "
+            "one target and backend family. Defaults to exact."
+        ),
+    )
     _add_output_format_argument(diff_parser)
 
     suggest_parser = subparsers.add_parser(

--- a/loom/py/loom/tools/compile_report_test.py
+++ b/loom/py/loom/tools/compile_report_test.py
@@ -191,6 +191,81 @@ def test_diff_json_preserves_qualified_target_identity(
     assert view["changed_entry_count"] == 1
 
 
+def test_diff_target_comparison_preserves_both_specializations(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    candidate_path = tmp_path / "candidate.json"
+    _write_report(
+        baseline_path,
+        target_key="gfx1100",
+        target_record="amdgpu.rdna3.core",
+    )
+    _write_report(
+        candidate_path,
+        target_key="gfx1151",
+        target_record="amdgpu.rdna3_5.core",
+    )
+
+    assert (
+        main(
+            [
+                "diff",
+                str(baseline_path),
+                str(candidate_path),
+                "--comparison=target",
+                "--format=json",
+            ]
+        )
+        == 0
+    )
+
+    captured = capsys.readouterr()
+    view = json.loads(captured.out)
+    assert captured.err == ""
+    assert view["comparison_mode"] == "target"
+    assert view["targets"]["baseline"]["target_key"] == "gfx1100"
+    assert view["targets"]["candidate"]["target_key"] == "gfx1151"
+    assert view["changed_entry_count"] == 0
+    assert view["unchanged_entry_count"] == 1
+
+
+def test_diff_target_comparison_rejects_workload_changes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    baseline_path = tmp_path / "baseline.json"
+    candidate_path = tmp_path / "candidate.json"
+    _write_report(
+        baseline_path,
+        target_key="gfx1100",
+        target_record="amdgpu.rdna3.core",
+    )
+    _write_report(
+        candidate_path,
+        target_key="gfx1151",
+        target_record="amdgpu.rdna3_5.core",
+    )
+    candidate = json.loads(candidate_path.read_text(encoding="utf-8"))
+    candidate["workload"]["workgroup_count"]["x"] = 8
+    candidate_path.write_text(json.dumps(candidate), encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "diff",
+                str(baseline_path),
+                str(candidate_path),
+                "--comparison=target",
+            ]
+        )
+        == 2
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "workload" in captured.err
+
+
 def test_rejects_unversioned_report(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/loom/src/loom/target/emit/native/amdgpu/hal_kernel_library.c
+++ b/loom/src/loom/target/emit/native/amdgpu/hal_kernel_library.c
@@ -335,6 +335,8 @@ loom_amdgpu_hal_kernel_library_record_matrix_feature_capabilities(
 
   const iree_host_size_t feature_count =
       loom_amdgpu_matrix_feature_info_count();
+  const iree_string_view_t matrix_feature_namespace_name =
+      IREE_SV("amdgpu.matrix_feature");
   for (iree_host_size_t i = 0; i < feature_count; ++i) {
     const loom_amdgpu_matrix_feature_info_t* feature_info =
         loom_amdgpu_matrix_feature_info_at(i);
@@ -343,9 +345,9 @@ loom_amdgpu_hal_kernel_library_record_matrix_feature_capabilities(
       continue;
     }
     IREE_RETURN_IF_ERROR(
-        loom_amdgpu_hal_kernel_library_record_target_capability_string(
-            report, function_name, namespace_name, IREE_SV("matrix_feature"),
-            feature_info->name));
+        loom_amdgpu_hal_kernel_library_record_target_capability_bool(
+            report, function_name, matrix_feature_namespace_name,
+            feature_info->name, true));
   }
   return iree_ok_status();
 }

--- a/loom/src/loom/target/emit/native/amdgpu/hal_kernel_library_test.cc
+++ b/loom/src/loom/target/emit/native/amdgpu/hal_kernel_library_test.cc
@@ -122,6 +122,30 @@ bool HasTargetCapabilityU64(const loom_target_compile_report_t& report,
   return false;
 }
 
+bool HasTargetCapabilityBool(const loom_target_compile_report_t& report,
+                             const char* namespace_name,
+                             iree_string_view_t expected_key, bool value) {
+  const iree_string_view_t expected_namespace =
+      iree_make_cstring_view(namespace_name);
+  for (const loom_target_compile_report_vec_t* vec =
+           report.target_capability_rows.head;
+       vec != nullptr; vec = vec->next) {
+    const loom_target_compile_report_target_capability_row_t* rows =
+        static_cast<const loom_target_compile_report_target_capability_row_t*>(
+            loom_target_compile_report_vec_const_rows(vec));
+    for (iree_host_size_t i = 0; i < vec->count; ++i) {
+      const loom_target_compile_report_target_capability_row_t& row = rows[i];
+      if (row.value_kind == LOOM_TARGET_COMPILE_REPORT_CAPABILITY_VALUE_BOOL &&
+          iree_string_view_equal(row.namespace_name, expected_namespace) &&
+          iree_string_view_equal(row.key, expected_key) &&
+          (row.value_u64 != 0) == value) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 bool HasWaitCounter(const loom_target_compile_report_t& report,
                     uint32_t counter_id, const char* counter_name) {
   const iree_string_view_t expected_name = iree_make_cstring_view(counter_name);
@@ -1251,18 +1275,16 @@ TEST_F(AmdgpuHalKernelLibraryTest, RecordsMatrixFeatureCapabilities) {
     const char* processor_name;
     // Matrix feature profile expected for |processor_name|.
     const char* profile_name;
-    // Active matrix feature expected for |processor_name|.
-    const char* feature_name;
     // Native FP8/BF8 support kind expected for |processor_name|.
     const char* fp8_bf8_native_kind;
   };
   static constexpr MatrixFeatureReportCase kCases[] = {
-      {"gfx942", "mfma-gfx940", "mfma-gfx940-fp8", "unscaled"},
-      {"gfx950", "mfma-gfx950", "mfma-gfx950-scale-f8f6f4", "unscaled_scaled"},
-      {"gfx1100", "wmma-gfx11", "wmma-gfx11", "none"},
-      {"gfx1200", "wmma-gfx12", "wmma-gfx12", "unscaled"},
-      {"gfx1250", "wmma-gfx1250", "wmma-gfx1250-scale-f8f6f4",
-       "unscaled_scaled"},
+      {"gfx942", "mfma-gfx940", "unscaled"},
+      {"gfx950", "mfma-gfx950", "unscaled_scaled"},
+      {"gfx1100", "wmma-gfx11", "none"},
+      {"gfx1170", "wmma-gfx12", "unscaled"},
+      {"gfx1200", "wmma-gfx12", "unscaled"},
+      {"gfx1250", "wmma-gfx1250", "unscaled_scaled"},
   };
 
   iree_host_size_t checked_count = 0;
@@ -1302,9 +1324,6 @@ TEST_F(AmdgpuHalKernelLibraryTest, RecordsMatrixFeatureCapabilities) {
     EXPECT_TRUE(HasTargetCapabilityString(
         report, "amdgpu", "matrix_feature_profile", test_case.profile_name))
         << test_case.processor_name;
-    EXPECT_TRUE(HasTargetCapabilityString(report, "amdgpu", "matrix_feature",
-                                          test_case.feature_name))
-        << test_case.processor_name;
     EXPECT_TRUE(HasTargetCapabilityString(report, "amdgpu",
                                           "matrix_fp8_native_kind",
                                           test_case.fp8_bf8_native_kind))
@@ -1320,6 +1339,19 @@ TEST_F(AmdgpuHalKernelLibraryTest, RecordsMatrixFeatureCapabilities) {
     EXPECT_TRUE(HasTargetCapabilityU64(report, "amdgpu", "matrix_feature_bits",
                                        feature_bits))
         << test_case.processor_name;
+    for (iree_host_size_t i = 0; i < loom_amdgpu_matrix_feature_info_count();
+         ++i) {
+      const loom_amdgpu_matrix_feature_info_t* feature_info =
+          loom_amdgpu_matrix_feature_info_at(i);
+      ASSERT_NE(feature_info, nullptr);
+      if (!iree_all_bits_set(feature_bits, feature_info->feature_bit)) {
+        continue;
+      }
+      EXPECT_TRUE(HasTargetCapabilityBool(report, "amdgpu.matrix_feature",
+                                          feature_info->name, true))
+          << test_case.processor_name << ": "
+          << StringViewToString(feature_info->name);
+    }
     loom_amdgpu_hal_kernel_library_deinitialize(&library,
                                                 iree_allocator_system());
     loom_target_compile_report_deinitialize(&report);

--- a/loom/src/loom/test/corpus/authoring/README.md
+++ b/loom/src/loom/test/corpus/authoring/README.md
@@ -133,13 +133,25 @@ loom-compile-report \
 The JSON views are sparse so they can feed an autoresearch loop without
 replaying the full report. Omitted metrics are unavailable, not zero. `diff`
 requires exact schema, target, config, workload, and entry identity; it has no
-force mode for unlike compilations. `suggest` uses only explicitly registered
-target providers and reports unavailable target interpretation instead of
-guessing from bundle names. Findings carry an evidence tier. The default output
-contains only target models backed by public documentation or silicon
-calibration; `--include-experimental` additionally admits exact compiler proofs
-against hardware-unvalidated models. That opt-in is useful for pre-silicon
-search, but hardware timing still decides whether a candidate is adopted.
+force mode for unlike compilations. To compare two target specializations of
+the same source, config, workload, artifact family, and target family, select
+the bounded target comparison explicitly:
+
+```bash
+loom-compile-report \
+  diff /tmp/gfx1100.compile-report.json \
+       /tmp/gfx1151.compile-report.json --comparison=target
+```
+
+That mode permits only target key, bundle, snapshot, and target configuration
+identity to vary and renders both specializations. All other identity remains
+strict. `suggest` uses only explicitly registered target providers and reports
+unavailable target interpretation instead of guessing from bundle names.
+Findings carry an evidence tier. The default output contains only target models
+backed by public documentation or silicon calibration;
+`--include-experimental` additionally admits exact compiler proofs against
+hardware-unvalidated models. That opt-in is useful for pre-silicon search, but
+hardware timing still decides whether a candidate is adopted.
 
 Version-zero reports are ephemeral diagnostics co-versioned with the compiler.
 Regenerate them after changing compiler versions. Use the full report and


### PR DESCRIPTION
`loom-compile-report diff` can now compare two specializations of the same kernel for different targets without weakening its identity contract. Exact comparison remains the default; an explicit target mode holds source, export, configuration, workload, target family, and entry identity constant while allowing only selected target specialization fields to differ.

**Design**

The report API defines exact and target comparison modes rather than adding a force flag or a collection of independently relaxed fields. Target comparison requires both reports to publish a target family and target key, rejects unsuccessful compilations, and applies the existing strict report and entry checks after excluding only target key, bundle, snapshot, and target configuration. Backend and target family remain part of the common identity, so reports from different compilation models cannot produce plausible-looking deltas.

Diff output separates common workload identity from the two selected target identities. Text and JSON views name both processors and specializations before reporting artifact and compiler metrics. A target comparison whose entries and metrics are unchanged produces an explicit unchanged result, providing a bounded point at which compiler evidence has been exhausted and physical measurement becomes the next discriminator.

Selected target capabilities receive a semantic diff keyed by function, target family, namespace, and capability key. Values retain their published boolean, unsigned integer, string, or absent type. Added, removed, changed, and unchanged rows are distinguished without converting unavailable evidence into zero, and malformed or duplicate capability identities fail report parsing rather than being silently overwritten.

AMDGPU matrix features now publish as sparse boolean capabilities in a dedicated namespace, with the feature name as the key. The previous representation emitted every active feature under one repeated key with the feature name as its value, making profiles with overlapping feature sets ambiguous and impossible to compare. Sparse identities make added and removed matrix families explicit while preserving the existing aggregate profile and bitset facts.

**Impact**

Kernel authors can compare generic and exact targets, or two exact processors in one family, while retaining the same strictness used for ordinary optimization diffs. The result attributes changes to selected target facts and capabilities alongside instruction, resource, wait, occupancy, and artifact metrics instead of requiring manual JSON archaeology.

The comparison mode is intentionally evidentiary rather than predictive. Capability rows describe what the compiler selected, compile metrics describe the resulting artifact and analyses, and hardware timing remains a separate physical measurement. The tool does not infer that a native capability is faster or normalize incomparable workloads.

Existing exact comparisons are unchanged. Scripts that do not request target comparison retain the original identity checks and output contract, and there is no escape hatch for comparing different configurations, workloads, exports, backends, or target families.

**Reviewer Notes**

The highest-value review surfaces are the exact list of target-variant identity fields, typed capability parsing and duplicate rejection, and the AMDGPU matrix-feature identity change. The command-line surface should remain explicit enough that a target comparison cannot be selected accidentally.
