### PR TITLE
[Loom/AMDGPU] Suggest report-guided scheduling experiments

### DIFF
--- a/loom/py/loom/target/arch/amdgpu/compile_report_suggestions.py
+++ b/loom/py/loom/target/arch/amdgpu/compile_report_suggestions.py
@@ -63,7 +63,7 @@ class AmdgpuCompileReportSuggestionProvider:
                 unavailable_reason="unknown_target_key",
             )
 
-        suggestions = []
+        suggestions = list(_suggest_vmem_source_reuse(document))
         for entry in document.entries:
             entry_index = entry["index"]
             entry_name = compile_report_entry_identity(entry).display_name()
@@ -100,6 +100,90 @@ class AmdgpuCompileReportSuggestionProvider:
 
 
 AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER = AmdgpuCompileReportSuggestionProvider()
+
+
+def _suggest_vmem_source_reuse(
+    document: CompileReportDocument,
+) -> tuple[CompileReportSuggestion, ...]:
+    rows_value = document.report.get("wait_reason_summary_rows")
+    if rows_value is None:
+        return ()
+    rows = _report_indexed_rows(
+        _report_object(rows_value, "wait_reason_summary_rows"),
+        "wait_reason_summary_rows",
+    )
+    suggestions = []
+    for position, row in enumerate(rows):
+        if row.get("counter") != "vmem_load" or row.get("reason") != (
+            "amdgpu.memory_source_reuse"
+        ):
+            continue
+        row_path = f"wait_reason_summary_rows.rows[{position}]"
+        summary = _report_object(row.get("summary"), f"{row_path}.summary")
+        action_count = _report_integer(
+            summary.get("action_count"), f"{row_path}.summary.action_count"
+        )
+        full_drain_count = _report_integer(
+            summary.get("full_drain_count"),
+            f"{row_path}.summary.full_drain_count",
+        )
+        # Isolated source-register reuse is ordinary scheduling fallout. Surface
+        # only a repeated pattern that dominates both its reason and the entry.
+        if full_drain_count < 8 or full_drain_count * 2 < action_count:
+            continue
+        function_name = _optional_report_string(
+            row.get("function"), f"{row_path}.function"
+        )
+        entry = _entry_for_function(document, function_name)
+        if entry is None:
+            continue
+        entry_index = entry["index"]
+        wait_plan = _object_at(entry, "wait_plan")
+        if wait_plan is None:
+            continue
+        wait_plan_path = f"entries.rows[{entry_index}].wait_plan"
+        total_full_drain_count = _report_integer(
+            wait_plan.get("full_drain_count"),
+            f"{wait_plan_path}.full_drain_count",
+        )
+        if total_full_drain_count == 0 or full_drain_count * 4 < total_full_drain_count:
+            continue
+        max_outstanding = _report_integer(
+            summary.get("max_full_drain_outstanding_before"),
+            f"{row_path}.summary.max_full_drain_outstanding_before",
+        )
+        suggestions.append(
+            CompileReportSuggestion(
+                suggestion_id="amdgpu.vmem_source_reuse_serialization",
+                entry_name=compile_report_entry_identity(entry).display_name(),
+                action=(
+                    "Reduce global-load source-state turnover by consolidating "
+                    "or staging loads, preserving independent address state, "
+                    "or scheduling more work before source-register reuse; "
+                    "then require memory-source full drains to fall before "
+                    "benchmarking."
+                ),
+                evidence=(
+                    CompileReportSuggestionEvidence(
+                        path=f"{row_path}.summary.action_count",
+                        value=action_count,
+                    ),
+                    CompileReportSuggestionEvidence(
+                        path=f"{row_path}.summary.full_drain_count",
+                        value=full_drain_count,
+                    ),
+                    CompileReportSuggestionEvidence(
+                        path=(f"{row_path}.summary.max_full_drain_outstanding_before"),
+                        value=max_outstanding,
+                    ),
+                    CompileReportSuggestionEvidence(
+                        path=(f"{wait_plan_path}.full_drain_count"),
+                        value=total_full_drain_count,
+                    ),
+                ),
+            )
+        )
+    return tuple(suggestions)
 
 
 def _suggest_spill_traffic(

--- a/loom/py/loom/target/arch/amdgpu/compile_report_suggestions.py
+++ b/loom/py/loom/target/arch/amdgpu/compile_report_suggestions.py
@@ -63,7 +63,7 @@ class AmdgpuCompileReportSuggestionProvider:
                 unavailable_reason="unknown_target_key",
             )
 
-        suggestions = list(_suggest_vmem_source_reuse(document))
+        suggestions = list(_suggest_wait_serialization(document))
         for entry in document.entries:
             entry_index = entry["index"]
             entry_name = compile_report_entry_identity(entry).display_name()
@@ -102,7 +102,7 @@ class AmdgpuCompileReportSuggestionProvider:
 AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER = AmdgpuCompileReportSuggestionProvider()
 
 
-def _suggest_vmem_source_reuse(
+def _suggest_wait_serialization(
     document: CompileReportDocument,
 ) -> tuple[CompileReportSuggestion, ...]:
     rows_value = document.report.get("wait_reason_summary_rows")
@@ -114,9 +114,13 @@ def _suggest_vmem_source_reuse(
     )
     suggestions = []
     for position, row in enumerate(rows):
-        if row.get("counter") != "vmem_load" or row.get("reason") != (
-            "amdgpu.memory_source_reuse"
-        ):
+        counter = row.get("counter")
+        reason = row.get("reason")
+        is_vmem_source_reuse = (
+            counter == "vmem_load" and reason == "amdgpu.memory_source_reuse"
+        )
+        is_lds_ssa_use = counter == "lds" and reason == "amdgpu.ssa_use"
+        if not is_vmem_source_reuse and not is_lds_ssa_use:
             continue
         row_path = f"wait_reason_summary_rows.rows[{position}]"
         summary = _report_object(row.get("summary"), f"{row_path}.summary")
@@ -127,8 +131,8 @@ def _suggest_vmem_source_reuse(
             summary.get("full_drain_count"),
             f"{row_path}.summary.full_drain_count",
         )
-        # Isolated source-register reuse is ordinary scheduling fallout. Surface
-        # only a repeated pattern that dominates both its reason and the entry.
+        # Isolated waits are ordinary scheduling fallout. Surface only repeated
+        # full drains that dominate their reason and materially affect the entry.
         if full_drain_count < 8 or full_drain_count * 2 < action_count:
             continue
         function_name = _optional_report_string(
@@ -146,23 +150,61 @@ def _suggest_vmem_source_reuse(
             wait_plan.get("full_drain_count"),
             f"{wait_plan_path}.full_drain_count",
         )
-        if total_full_drain_count == 0 or full_drain_count * 4 < total_full_drain_count:
+        if total_full_drain_count == 0:
             continue
-        max_outstanding = _report_integer(
-            summary.get("max_full_drain_outstanding_before"),
-            f"{row_path}.summary.max_full_drain_outstanding_before",
-        )
+        if is_vmem_source_reuse:
+            if full_drain_count * 4 < total_full_drain_count:
+                continue
+            max_full_drain_outstanding = _report_integer(
+                summary.get("max_full_drain_outstanding_before"),
+                f"{row_path}.summary.max_full_drain_outstanding_before",
+            )
+            suggestion_id = "amdgpu.vmem_source_reuse_serialization"
+            action = (
+                "Reduce global-load source-state turnover by consolidating "
+                "or staging loads, preserving independent address state, "
+                "or scheduling more work before source-register reuse; "
+                "then require memory-source full drains to fall before "
+                "benchmarking."
+            )
+            reason_evidence = (
+                CompileReportSuggestionEvidence(
+                    path=(f"{row_path}.summary.max_full_drain_outstanding_before"),
+                    value=max_full_drain_outstanding,
+                ),
+            )
+        else:
+            if full_drain_count * 5 < total_full_drain_count:
+                continue
+            partial_wait_count = _report_integer(
+                summary.get("partial_wait_count"),
+                f"{row_path}.summary.partial_wait_count",
+            )
+            max_outstanding = _report_integer(
+                summary.get("max_outstanding_before"),
+                f"{row_path}.summary.max_outstanding_before",
+            )
+            suggestion_id = "amdgpu.lds_ssa_use_serialization"
+            action = (
+                "Issue independent LDS or DS producers before consuming their "
+                "SSA results so waits can remain partial; then require "
+                "LDS SSA-use full drains to fall before benchmarking."
+            )
+            reason_evidence = (
+                CompileReportSuggestionEvidence(
+                    path=f"{row_path}.summary.partial_wait_count",
+                    value=partial_wait_count,
+                ),
+                CompileReportSuggestionEvidence(
+                    path=f"{row_path}.summary.max_outstanding_before",
+                    value=max_outstanding,
+                ),
+            )
         suggestions.append(
             CompileReportSuggestion(
-                suggestion_id="amdgpu.vmem_source_reuse_serialization",
+                suggestion_id=suggestion_id,
                 entry_name=compile_report_entry_identity(entry).display_name(),
-                action=(
-                    "Reduce global-load source-state turnover by consolidating "
-                    "or staging loads, preserving independent address state, "
-                    "or scheduling more work before source-register reuse; "
-                    "then require memory-source full drains to fall before "
-                    "benchmarking."
-                ),
+                action=action,
                 evidence=(
                     CompileReportSuggestionEvidence(
                         path=f"{row_path}.summary.action_count",
@@ -172,10 +214,7 @@ def _suggest_vmem_source_reuse(
                         path=f"{row_path}.summary.full_drain_count",
                         value=full_drain_count,
                     ),
-                    CompileReportSuggestionEvidence(
-                        path=(f"{row_path}.summary.max_full_drain_outstanding_before"),
-                        value=max_outstanding,
-                    ),
+                    *reason_evidence,
                     CompileReportSuggestionEvidence(
                         path=(f"{wait_plan_path}.full_drain_count"),
                         value=total_full_drain_count,

--- a/loom/py/loom/target/arch/amdgpu/compile_report_suggestions.py
+++ b/loom/py/loom/target/arch/amdgpu/compile_report_suggestions.py
@@ -82,6 +82,11 @@ class AmdgpuCompileReportSuggestionProvider:
             )
             if residency_suggestion is not None:
                 suggestions.append(residency_suggestion)
+            communication_suggestion = _suggest_single_subgroup_communication(
+                entry, entry_name, path_prefix
+            )
+            if communication_suggestion is not None:
+                suggestions.append(communication_suggestion)
             wave_suggestion = _suggest_nondefault_wave_size(
                 entry,
                 entry_name,
@@ -381,6 +386,74 @@ def _suggest_nondefault_wave_size(
                 value=default_wave_size,
             ),
         ),
+    )
+
+
+def _suggest_single_subgroup_communication(
+    entry: dict[str, object],
+    entry_name: str,
+    path_prefix: str,
+) -> CompileReportSuggestion | None:
+    workgroup_size = _object_at(entry, "workload", "workgroup_size")
+    target_resources = _object_at(entry, "target_resources")
+    instruction_mix = _object_at(entry, "static_instruction_mix")
+    if workgroup_size is None or target_resources is None or instruction_mix is None:
+        return None
+    flat_workgroup_size = _integer(workgroup_size.get("flat"))
+    subgroup_size = _integer(target_resources.get("subgroup_size"))
+    barrier_count = _integer(instruction_mix.get("barrier_count"))
+    if (
+        flat_workgroup_size is None
+        or flat_workgroup_size == 0
+        or subgroup_size is None
+        or subgroup_size == 0
+        or flat_workgroup_size > subgroup_size
+        or barrier_count is None
+        or barrier_count == 0
+    ):
+        return None
+
+    evidence = [
+        CompileReportSuggestionEvidence(
+            path=f"{path_prefix}.workload.workgroup_size.flat",
+            value=flat_workgroup_size,
+        ),
+        CompileReportSuggestionEvidence(
+            path=f"{path_prefix}.target_resources.subgroup_size",
+            value=subgroup_size,
+        ),
+        CompileReportSuggestionEvidence(
+            path=f"{path_prefix}.static_instruction_mix.barrier_count",
+            value=barrier_count,
+        ),
+    ]
+    local_memory_instruction_count = _integer(instruction_mix.get("local_memory_count"))
+    if local_memory_instruction_count is not None:
+        evidence.append(
+            CompileReportSuggestionEvidence(
+                path=(f"{path_prefix}.static_instruction_mix.local_memory_count"),
+                value=local_memory_instruction_count,
+            )
+        )
+    local_memory_bytes = _integer(entry.get("local_memory_bytes"))
+    if local_memory_bytes is not None:
+        evidence.append(
+            CompileReportSuggestionEvidence(
+                path=f"{path_prefix}.local_memory_bytes",
+                value=local_memory_bytes,
+            )
+        )
+    return CompileReportSuggestion(
+        suggestion_id="amdgpu.single_subgroup_workgroup_communication",
+        entry_name=entry_name,
+        action=(
+            "The workgroup fits within one subgroup but still emits workgroup "
+            "barriers. Inspect whether workgroup exchange or reduction can use "
+            "subgroup operations, or whether the barriers are redundant; then "
+            "require barrier and local-memory traffic to fall before "
+            "benchmarking."
+        ),
+        evidence=tuple(evidence),
     )
 
 

--- a/loom/py/loom/target/arch/amdgpu/compile_report_suggestions_test.py
+++ b/loom/py/loom/target/arch/amdgpu/compile_report_suggestions_test.py
@@ -279,6 +279,36 @@ def _add_vmem_source_reuse_evidence(
     }
 
 
+def _add_lds_ssa_use_evidence(
+    report: dict[str, object],
+    *,
+    action_count: int,
+    ssa_use_full_drain_count: int,
+    ssa_use_partial_wait_count: int,
+    total_full_drain_count: int,
+    max_outstanding_before: int,
+) -> None:
+    entry = report["entries"]["rows"][0]
+    entry["wait_plan"] = {"full_drain_count": total_full_drain_count}
+    report["wait_reason_summary_rows"] = {
+        "count": 1,
+        "rows": [
+            {
+                "index": 0,
+                "function": "routed_linear",
+                "counter": "lds",
+                "reason": "amdgpu.ssa_use",
+                "summary": {
+                    "action_count": action_count,
+                    "full_drain_count": ssa_use_full_drain_count,
+                    "partial_wait_count": ssa_use_partial_wait_count,
+                    "max_outstanding_before": max_outstanding_before,
+                },
+            }
+        ],
+    }
+
+
 def test_suggests_ordered_experiments_from_exact_target_evidence() -> None:
     document = parse_compile_report(_compile_report(), source="report.json")
 
@@ -404,6 +434,48 @@ def test_ignores_sparse_vmem_source_reuse_serialization(
     result = AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER.suggest(document)
 
     assert "amdgpu.vmem_source_reuse_serialization" not in {
+        suggestion.suggestion_id for suggestion in result.suggestions
+    }
+
+
+def test_suggests_dominant_lds_ssa_use_serialization() -> None:
+    report = _compile_report()
+    _add_lds_ssa_use_evidence(
+        report,
+        action_count=27,
+        ssa_use_full_drain_count=27,
+        ssa_use_partial_wait_count=0,
+        total_full_drain_count=125,
+        max_outstanding_before=1,
+    )
+    document = parse_compile_report(report)
+
+    result = AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER.suggest(document)
+
+    suggestion = result.suggestions[0]
+    assert suggestion.suggestion_id == "amdgpu.lds_ssa_use_serialization"
+    assert "independent LDS or DS producers" in suggestion.action
+    evidence = {item.path: item.value for item in suggestion.evidence}
+    assert evidence["wait_reason_summary_rows.rows[0].summary.full_drain_count"] == 27
+    assert evidence["wait_reason_summary_rows.rows[0].summary.partial_wait_count"] == 0
+    assert evidence["entries.rows[0].wait_plan.full_drain_count"] == 125
+
+
+def test_ignores_pipelined_lds_ssa_uses() -> None:
+    report = _compile_report()
+    _add_lds_ssa_use_evidence(
+        report,
+        action_count=27,
+        ssa_use_full_drain_count=3,
+        ssa_use_partial_wait_count=24,
+        total_full_drain_count=101,
+        max_outstanding_before=4,
+    )
+    document = parse_compile_report(report)
+
+    result = AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER.suggest(document)
+
+    assert "amdgpu.lds_ssa_use_serialization" not in {
         suggestion.suggestion_id for suggestion in result.suggestions
     }
 

--- a/loom/py/loom/target/arch/amdgpu/compile_report_suggestions_test.py
+++ b/loom/py/loom/target/arch/amdgpu/compile_report_suggestions_test.py
@@ -309,6 +309,28 @@ def _add_lds_ssa_use_evidence(
     }
 
 
+def _add_single_subgroup_communication_evidence(
+    report: dict[str, object],
+    *,
+    flat_workgroup_size: int,
+    barrier_count: int,
+) -> None:
+    entry = report["entries"]["rows"][0]
+    entry["workload"] = {
+        "workgroup_size": {
+            "x": flat_workgroup_size,
+            "y": 1,
+            "z": 1,
+            "flat": flat_workgroup_size,
+        }
+    }
+    entry["local_memory_bytes"] = 528
+    entry["static_instruction_mix"] = {
+        "barrier_count": barrier_count,
+        "local_memory_count": 16,
+    }
+
+
 def test_suggests_ordered_experiments_from_exact_target_evidence() -> None:
     document = parse_compile_report(_compile_report(), source="report.json")
 
@@ -476,6 +498,57 @@ def test_ignores_pipelined_lds_ssa_uses() -> None:
     result = AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER.suggest(document)
 
     assert "amdgpu.lds_ssa_use_serialization" not in {
+        suggestion.suggestion_id for suggestion in result.suggestions
+    }
+
+
+def test_suggests_single_subgroup_workgroup_communication() -> None:
+    report = _compile_report()
+    _add_single_subgroup_communication_evidence(
+        report,
+        flat_workgroup_size=64,
+        barrier_count=4,
+    )
+    document = parse_compile_report(report)
+
+    result = AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER.suggest(document)
+
+    suggestion = next(
+        suggestion
+        for suggestion in result.suggestions
+        if suggestion.suggestion_id == "amdgpu.single_subgroup_workgroup_communication"
+    )
+    assert "fits within one subgroup" in suggestion.action
+    evidence = {item.path: item.value for item in suggestion.evidence}
+    assert evidence["entries.rows[0].workload.workgroup_size.flat"] == 64
+    assert evidence["entries.rows[0].target_resources.subgroup_size"] == 64
+    assert evidence["entries.rows[0].static_instruction_mix.barrier_count"] == 4
+    assert evidence["entries.rows[0].static_instruction_mix.local_memory_count"] == 16
+    assert evidence["entries.rows[0].local_memory_bytes"] == 528
+
+
+@pytest.mark.parametrize(
+    ("flat_workgroup_size", "barrier_count"),
+    [
+        (128, 4),
+        (64, 0),
+    ],
+)
+def test_ignores_multi_subgroup_or_barrier_free_communication(
+    flat_workgroup_size: int,
+    barrier_count: int,
+) -> None:
+    report = _compile_report()
+    _add_single_subgroup_communication_evidence(
+        report,
+        flat_workgroup_size=flat_workgroup_size,
+        barrier_count=barrier_count,
+    )
+    document = parse_compile_report(report)
+
+    result = AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER.suggest(document)
+
+    assert "amdgpu.single_subgroup_workgroup_communication" not in {
         suggestion.suggestion_id for suggestion in result.suggestions
     }
 

--- a/loom/py/loom/target/arch/amdgpu/compile_report_suggestions_test.py
+++ b/loom/py/loom/target/arch/amdgpu/compile_report_suggestions_test.py
@@ -252,6 +252,33 @@ def _add_fragment_packet_evidence(
     }
 
 
+def _add_vmem_source_reuse_evidence(
+    report: dict[str, object],
+    *,
+    action_count: int,
+    source_reuse_full_drain_count: int,
+    total_full_drain_count: int,
+) -> None:
+    entry = report["entries"]["rows"][0]
+    entry["wait_plan"] = {"full_drain_count": total_full_drain_count}
+    report["wait_reason_summary_rows"] = {
+        "count": 1,
+        "rows": [
+            {
+                "index": 0,
+                "function": "routed_linear",
+                "counter": "vmem_load",
+                "reason": "amdgpu.memory_source_reuse",
+                "summary": {
+                    "action_count": action_count,
+                    "full_drain_count": source_reuse_full_drain_count,
+                    "max_full_drain_outstanding_before": 3,
+                },
+            }
+        ],
+    }
+
+
 def test_suggests_ordered_experiments_from_exact_target_evidence() -> None:
     document = parse_compile_report(_compile_report(), source="report.json")
 
@@ -332,6 +359,53 @@ def test_private_memory_is_reported_once_without_spill_evidence() -> None:
         "amdgpu.residency_cliff",
         "amdgpu.nondefault_wave_size",
     ]
+
+
+def test_suggests_dominant_vmem_source_reuse_serialization() -> None:
+    report = _compile_report()
+    _add_vmem_source_reuse_evidence(
+        report,
+        action_count=30,
+        source_reuse_full_drain_count=30,
+        total_full_drain_count=107,
+    )
+    document = parse_compile_report(report)
+
+    result = AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER.suggest(document)
+
+    suggestion = result.suggestions[0]
+    assert suggestion.suggestion_id == "amdgpu.vmem_source_reuse_serialization"
+    assert "source-state turnover" in suggestion.action
+    evidence = {item.path: item.value for item in suggestion.evidence}
+    assert evidence["wait_reason_summary_rows.rows[0].summary.full_drain_count"] == 30
+    assert evidence["entries.rows[0].wait_plan.full_drain_count"] == 107
+
+
+@pytest.mark.parametrize(
+    ("source_reuse_full_drain_count", "total_full_drain_count"),
+    [
+        (7, 100),
+        (30, 121),
+    ],
+)
+def test_ignores_sparse_vmem_source_reuse_serialization(
+    source_reuse_full_drain_count: int,
+    total_full_drain_count: int,
+) -> None:
+    report = _compile_report()
+    _add_vmem_source_reuse_evidence(
+        report,
+        action_count=source_reuse_full_drain_count,
+        source_reuse_full_drain_count=source_reuse_full_drain_count,
+        total_full_drain_count=total_full_drain_count,
+    )
+    document = parse_compile_report(report)
+
+    result = AMDGPU_COMPILE_REPORT_SUGGESTION_PROVIDER.suggest(document)
+
+    assert "amdgpu.vmem_source_reuse_serialization" not in {
+        suggestion.suggestion_id for suggestion in result.suggestions
+    }
 
 
 def test_fragment_packet_expansion_cites_source_packets_and_pressure() -> None:


### PR DESCRIPTION
AMDGPU compile-report suggestions now identify three scheduling pathologies directly from compiler evidence: dominant global-load source-reuse drains, dominant LDS SSA-use drains, and workgroup barriers in launches that fit within one subgroup. Each suggestion cites the exact report paths supporting it and proposes a bounded source experiment whose expected report change must occur before hardware benchmarking.

**Design**

The suggestion provider consumes existing target report rows rather than adding compiler analysis or rescanning IR. Wait serialization uses the planner-owned wait-reason summaries and each entry's aggregate wait plan. Single-subgroup communication uses the published launch geometry, subgroup size, static barrier count, and available LDS evidence. Missing evidence remains unavailable and suppresses the corresponding suggestion.

VMEM source-reuse advice requires at least eight full drains, requires full drains to account for at least half of actions attributed to that reason, and requires the reason to contribute at least one quarter of all full drains in the entry. The suggestion cites action count, reason-local full drains, maximum outstanding loads before a full drain, and entry-wide full drains. Its experiment is to consolidate or stage loads, preserve independent address state, or schedule more work before source-register reuse, then confirm the source-reuse drains actually fall.

LDS SSA-use advice applies the same repeated-and-dominant guard, with a one-fifth entry-wide contribution threshold. It cites reason-local full and partial waits, maximum outstanding LDS operations, and entry-wide full drains. Its experiment is to issue independent LDS or DS producers before consuming their SSA results, then confirm that full drains become partial or disappear.

Single-subgroup communication advice requires a known nonzero workgroup size no larger than the selected subgroup and at least one emitted workgroup barrier. It cites launch and subgroup sizes, barrier count, and local-memory instruction and byte counts when available. The suggestion asks the author to test subgroup exchange or reduction, or prove the barrier redundant, without claiming that either transformation is automatically profitable.

**Impact**

Kernel authors and optimization agents no longer need to mine raw wait summaries to recognize these recurring failure modes. The output names the limiting mechanism, links to authoritative evidence, describes one falsifiable intervention, and preserves device timing as the final physical discriminator.

The thresholds intentionally leave isolated waits and minor contributors silent. Suggestions disappear when the targeted drains or barriers disappear, allowing automated loops to determine whether an edit changed the intended mechanism before spending benchmark time.

Interpretation remains target-owned. Generic report infrastructure validates and presents suggestions, while AMDGPU defines the meaning of its counters, wait reasons, subgroup resources, and scheduling experiments. No AMDGPU policy leaks into the shared reporting package.

**Examples**

A routed linear kernel exposes global-load source reuse as 25 full drains out of 25 reason-local actions and 78 full drains across the entry. The suggested experiment names the source-state mechanism and makes reducing those drains the gate before benchmarking:

```text
[amdgpu.vmem_source_reuse_serialization] qwen3_moe_routed_down_q6k_q8_1_x4
  confidence: high
  action: Reduce global-load source-state turnover by consolidating or staging loads, preserving independent address state, or scheduling more work before source-register reuse; then require memory-source full drains to fall before benchmarking.
  evidence:
    wait_reason_summary_rows.rows[2].summary.action_count: 25
    wait_reason_summary_rows.rows[2].summary.full_drain_count: 25
    wait_reason_summary_rows.rows[2].summary.max_full_drain_outstanding_before: 1
    entries.rows[0].wait_plan.full_drain_count: 78
```

A quantization kernel fits all 32 workitems in one subgroup but still emits three workgroup barriers and eight local-memory instructions. The tool directs the author toward subgroup communication or barrier removal while preserving hardware measurement as the profitability test:

```text
[amdgpu.single_subgroup_workgroup_communication] ggml_quantize_q8_1_x4_f32
  confidence: high
  action: The workgroup fits within one subgroup but still emits workgroup barriers. Inspect whether workgroup exchange or reduction can use subgroup operations, or whether the barriers are redundant; then require barrier and local-memory traffic to fall before benchmarking.
  evidence:
    entries.rows[0].workload.workgroup_size.flat: 32
    entries.rows[0].target_resources.subgroup_size: 32
    entries.rows[0].static_instruction_mix.barrier_count: 3
    entries.rows[0].static_instruction_mix.local_memory_count: 8
    entries.rows[0].local_memory_bytes: 144
```

**Reviewer Notes**

The highest-value review surfaces are the dominance thresholds, mapping of global wait-reason rows back to compiled entries, and the distinction between report-backed evidence and suggested experiments. Tests cover positive signals and the principal silence boundaries for sparse drains, already-pipelined LDS use, multi-subgroup workgroups, and barrier-free kernels.
