### PR TITLE
[Loom] Bound select placement without analysis state

### DIFF
--- a/loom/src/loom/target/arch/amdgpu/lower/support.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/support.c
@@ -1306,6 +1306,15 @@ static bool loom_amdgpu_select_payload_prefers_vgpr(
           loom_module_value_type(module, source_value_id))) {
     return true;
   }
+  // Statusless module-local queries have no active-bit table. Keep their
+  // select inspection bounded because condition-mask and result placement
+  // query each other.
+  if (analysis == NULL) {
+    return loom_amdgpu_source_value_facts_prefer_vgpr(module, fact_table,
+                                                      source_value_id) ||
+           loom_amdgpu_source_value_directly_prefers_vgpr(
+               module, source_value_id, condition_value_id);
+  }
   return loom_amdgpu_analyzed_source_value_prefers_vgpr(
       module, fact_table, view_regions, analysis, source_value_id);
 }
@@ -2587,7 +2596,10 @@ static bool loom_amdgpu_source_value_prefers_vgpr_impl(
     return false;
   }
 
-  if (iree_any_bit_set(producer_flags,
+  // Recursive select propagation requires the active-bit table because the
+  // selected result can participate in condition-mask classification.
+  if (analysis != NULL &&
+      iree_any_bit_set(producer_flags,
                        LOOM_AMDGPU_SOURCE_PRODUCER_SCF_SELECT) &&
       loom_value_def_index(value) == 0) {
     return loom_amdgpu_analyzed_source_value_prefers_vgpr(

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_memory_global.loom-test
@@ -2565,6 +2565,48 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1
 // ====
 
 amdgpu.target<gfx11-generic> @target
+kernel.def target(@target) @selected_workgroup_load() {
+  %unit = index.constant 1 : index
+  %workgroup_count = index.constant 64 : index
+  kernel.launch.config workgroups(%workgroup_count, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
+} launch(%input: buffer, %output: buffer, %element_count: index) {
+  %base = index.constant 0 : offset
+  %c0 = index.constant 0 : index
+  %bounded_element_count = index.assume %element_count [range(%element_count, 1, 1024)] : index
+  %input_view = buffer.view %input[%base] : buffer -> view<[%bounded_element_count]xf32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<1xf32, #dense>
+  %workgroup = kernel.workgroup.id<x> : index
+  %valid = index.cmp ult, %workgroup, %bounded_element_count : index
+  %safe_workgroup = scf.select %valid, %workgroup, %c0 : index
+  %input_index = index.assume %safe_workgroup [lt(%safe_workgroup, %bounded_element_count)] : index
+  %value = view.load %input_view[%input_index] : view<[%bounded_element_count]xf32, #dense> -> f32
+  view.store %value, %output_view[%c0] : f32, view<1xf32, #dense>
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(64, 1, 1) @selected_workgroup_load(%bounded_element_count: reg<amdgpu.sgpr>) asm {
+  %workgroup = live_in<amdgpu.workgroup_id.x> : reg<amdgpu.sgpr>
+  %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<amdgpu.sgpr x2>
+  %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 4} : reg<amdgpu.sgpr x2>
+  %c0 = s_mov_b32 0
+  %valid = s_cmp_lt_u32 %workgroup, %bounded_element_count
+  %input_index = s_cselect_b32 %workgroup, %c0, %valid
+  %22 = v_mov_b32 0
+  %23 = s_lshl_b32_rhs_inline %input_index, 2
+  %24 = slice %input_view[0] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %25 = slice %input_view[1] : reg<amdgpu.sgpr x2> -> reg<amdgpu.sgpr>
+  %27 = s_add_u32 %24, %23
+  %28 = s_addc_u32 %25, %c0
+  %29 = concat(%27, %28) : (reg<amdgpu.sgpr>, reg<amdgpu.sgpr>) -> reg<amdgpu.sgpr x2>
+  %value = global_load_b32_saddr %22, %29
+  global_store_b32_saddr %22, %value, %output_view
+  return
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
 kernel.def target(@target) @loaded_i32_row_stride_f32_to_f16_store() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index

--- a/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_global.loom-test
+++ b/loom/src/loom/target/arch/llvmir/test/source_low/corpus/memory_global.loom-test
@@ -1956,6 +1956,44 @@ llvmir.target<object> @target {
   triple = "loom-direct64-unknown-none",
   data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
 }
+kernel.def target(@target) @selected_workgroup_load() {
+  %unit = index.constant 1 : index
+  %workgroup_count = index.constant 64 : index
+  kernel.launch.config workgroups(%workgroup_count, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
+} launch(%input: buffer, %output: buffer, %element_count: index) {
+  %base = index.constant 0 : offset
+  %c0 = index.constant 0 : index
+  %bounded_element_count = index.assume %element_count [range(%element_count, 1, 1024)] : index
+  %input_view = buffer.view %input[%base] : buffer -> view<[%bounded_element_count]xf32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<1xf32, #dense>
+  %workgroup = kernel.workgroup.id<x> : index
+  %valid = index.cmp ult, %workgroup, %bounded_element_count : index
+  %safe_workgroup = scf.select %valid, %workgroup, %c0 : index
+  %input_index = index.assume %safe_workgroup [lt(%safe_workgroup, %bounded_element_count)] : index
+  %value = view.load %input_view[%input_index] : view<[%bounded_element_count]xf32, #dense> -> f32
+  view.store %value, %output_view[%c0] : f32, view<1xf32, #dense>
+  kernel.return
+}
+
+// ----
+low.kernel.def target<llvmir.generic.core>(@target) workgroup_size(1, 1, 1) workgroup_count(64, 1, 1) @selected_workgroup_load(%bounded_element_count: reg<llvmir.i64>) asm {
+  %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer} : reg<llvmir.ptr>
+  %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer} : reg<llvmir.ptr>
+  %c0 = const.i64 0
+  %workgroup = kernel.workgroup_id.x
+  %valid = cmp.ult.i64 %workgroup, %bounded_element_count
+  %input_index = select.i64 %valid, %workgroup, %c0
+  %value = load.indexed.f32 %input_view, %input_index, 0, 4
+  store.f32 %value, %output_view, 0
+  return
+}
+
+// ====
+
+llvmir.target<object> @target {
+  triple = "loom-direct64-unknown-none",
+  data_layout = "e-p:64:64-i64:64-n8:16:32:64-S128"
+}
 kernel.def target(@target) @loaded_i32_row_stride_f32_to_f16_store() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index

--- a/loom/src/loom/test/corpus/source_low/memory_global.loom-test
+++ b/loom/src/loom/test/corpus/source_low/memory_global.loom-test
@@ -1108,6 +1108,27 @@ kernel.def @selected_i32_row_shift_store() {
 
 // ====
 
+kernel.def @selected_workgroup_load() {
+  %unit = index.constant 1 : index
+  %workgroup_count = index.constant 64 : index
+  kernel.launch.config workgroups(%workgroup_count, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
+} launch(%input: buffer, %output: buffer, %element_count: index) {
+  %base = index.constant 0 : offset
+  %c0 = index.constant 0 : index
+  %bounded_element_count = index.assume %element_count [range(%element_count, 1, 1024)] : index
+  %input_view = buffer.view %input[%base] : buffer -> view<[%bounded_element_count]xf32, #dense>
+  %output_view = buffer.view %output[%base] : buffer -> view<1xf32, #dense>
+  %workgroup = kernel.workgroup.id<x> : index
+  %valid = index.cmp ult, %workgroup, %bounded_element_count : index
+  %safe_workgroup = scf.select %valid, %workgroup, %c0 : index
+  %input_index = index.assume %safe_workgroup [lt(%safe_workgroup, %bounded_element_count)] : index
+  %value = view.load %input_view[%input_index] : view<[%bounded_element_count]xf32, #dense> -> f32
+  view.store %value, %output_view[%c0] : f32, view<1xf32, #dense>
+  kernel.return
+}
+
+// ====
+
 kernel.def @loaded_i32_row_stride_f32_to_f16_store() {
   %unit = index.constant 1 : index
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index


### PR DESCRIPTION
Conservative module-local AMDGPU placement queries have no analysis cache, but native scalar select placement routed select payloads through the full mutually recursive analysis. A dynamic workgroup clamp could then cycle between its condition and result until the compiler stack overflowed.

Restore the bounded direct producer-and-fact predicate only when no analysis state exists. Context-backed lowering and legality continue to use the full cached analysis, preserving native scalar-float placement precision. Source-low corpus coverage exercises a dynamic workgroup clamp feeding a global memory address.