### PR TITLE
[Loom] Reduce verified bytecode module load cost

### DIFF
--- a/loom/src/loom/format/bytecode/reader.c
+++ b/loom/src/loom/format/bytecode/reader.c
@@ -125,6 +125,10 @@ typedef struct loom_bytecode_body_reader_t {
   uint64_t value_capacity;               // Expected value count from summary.
   uint64_t next_value_number;            // Next value definition to decode.
   uint64_t available_value_count;        // Reserved prefix available to types.
+  // Next fresh module value ID reserved for this body.
+  loom_value_id_t next_fresh_value_id;
+  // Number of fresh module value IDs not yet assigned to body-local values.
+  uint64_t remaining_fresh_value_count;
   // Values already defined by the containing symbol signature.
   const loom_value_id_t* predefined_values;
   // Function-local value number of the first predefined region argument.
@@ -3048,6 +3052,16 @@ static iree_status_t loom_bytecode_body_reader_define_value(
   return iree_ok_status();
 }
 
+static iree_status_t loom_bytecode_body_reader_prepare_fresh_values(
+    loom_bytecode_body_reader_t* body_reader, iree_host_size_t count) {
+  loom_value_id_t base_value_id = LOOM_VALUE_ID_INVALID;
+  IREE_RETURN_IF_ERROR(loom_module_define_untyped_values(
+      body_reader->reader->output_module, count, &base_value_id));
+  body_reader->next_fresh_value_id = base_value_id;
+  body_reader->remaining_fresh_value_count = count;
+  return iree_ok_status();
+}
+
 static iree_status_t loom_bytecode_body_reader_reserve_value_defs(
     loom_bytecode_body_reader_t* body_reader, uint64_t count,
     loom_value_id_t* out_value_ids) {
@@ -3074,8 +3088,13 @@ static iree_status_t loom_bytecode_body_reader_reserve_value_defs(
             IREE_SV("predefined_value_is_not_present_in_the_module"));
       }
     } else {
-      IREE_RETURN_IF_ERROR(loom_module_define_value(
-          body_reader->reader->output_module, loom_type_none(), &value_id));
+      if (body_reader->remaining_fresh_value_count == 0) {
+        return loom_bytecode_reader_emit_invalid_ir_body(
+            body_reader, body_reader->body_offset,
+            IREE_SV("fresh_value_definition_exceeds_body_summary"));
+      }
+      value_id = body_reader->next_fresh_value_id++;
+      --body_reader->remaining_fresh_value_count;
     }
     body_reader->value_map[value_number] = value_id;
     if (out_value_ids) {
@@ -3670,6 +3689,16 @@ static iree_status_t loom_bytecode_reader_read_symbol_regions(
         &body_reader, body_reader.body_offset,
         IREE_SV("function_body_value_count_exceeds_host_size"));
   }
+  uint64_t predefined_value_count = 0;
+  for (uint8_t i = 0; i < predefined_region_count; ++i) {
+    predefined_value_count += predefined_regions[i].count;
+  }
+  if (iree_status_is_ok(status) && !loom_bytecode_reader_has_errors(reader) &&
+      predefined_value_count > value_count) {
+    status = loom_bytecode_reader_emit_invalid_ir_body(
+        &body_reader, body_reader.body_offset,
+        IREE_SV("predefined_value_count_exceeds_body_summary"));
+  }
   if (iree_status_is_ok(status) && !loom_bytecode_reader_has_errors(reader) &&
       predefined_region_count > parent_op->region_count) {
     status = loom_bytecode_reader_emit_invalid_ir_body(
@@ -3708,6 +3737,10 @@ static iree_status_t loom_bytecode_reader_read_symbol_regions(
     status = iree_arena_allocate_array(
         &body_arena, (iree_host_size_t)value_count, sizeof(loom_value_id_t),
         (void**)&body_reader.value_map);
+  }
+  if (iree_status_is_ok(status) && !loom_bytecode_reader_has_errors(reader)) {
+    status = loom_bytecode_body_reader_prepare_fresh_values(
+        &body_reader, (iree_host_size_t)(value_count - predefined_value_count));
   }
   if (iree_status_is_ok(status) && !loom_bytecode_reader_has_errors(reader)) {
     bool seen_regions[UINT8_MAX + 1] = {0};
@@ -4724,6 +4757,8 @@ static iree_status_t loom_bytecode_reader_materialize_function_symbol(
       .value_map = signature_values,
       .value_capacity = signature_value_count,
   };
+  IREE_RETURN_IF_ERROR(loom_bytecode_body_reader_prepare_fresh_values(
+      &signature_reader, signature_value_count));
   IREE_RETURN_IF_ERROR(loom_bytecode_body_reader_reserve_value_defs(
       &signature_reader, signature_value_count, signature_values));
   if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -5105,6 +5140,8 @@ static iree_status_t loom_bytecode_reader_materialize_global_symbol(
       .value_map = local_values,
       .value_capacity = local_value_count,
   };
+  IREE_RETURN_IF_ERROR(loom_bytecode_body_reader_prepare_fresh_values(
+      &global_reader, local_value_count));
   IREE_RETURN_IF_ERROR(loom_bytecode_body_reader_reserve_value_defs(
       &global_reader, local_value_count, local_values));
   if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();

--- a/loom/src/loom/format/bytecode/reader.c
+++ b/loom/src/loom/format/bytecode/reader.c
@@ -2829,10 +2829,14 @@ static iree_status_t loom_bytecode_body_reader_read_region(
     loom_bytecode_reader_cursor_t* cursor, loom_builder_t* builder,
     loom_op_t* parent_op, uint32_t depth, loom_region_t** out_region);
 
+// Resolves body-local dimension and encoding bindings in |base_type|. Returns
+// its canonical type-table ID when no binding changes the type, or INVALID
+// alongside the rebound type otherwise.
 static iree_status_t loom_bytecode_body_reader_bind_type(
     loom_bytecode_body_reader_t* body_reader,
     loom_bytecode_reader_cursor_t* cursor, loom_type_t base_type,
-    uint64_t dim_binding_count, loom_type_t* out_type) {
+    loom_type_id_t base_type_id, uint64_t dim_binding_count,
+    loom_type_t* out_type, loom_type_id_t* out_canonical_type_id) {
   loom_type_t type = base_type;
   uint8_t rank = loom_type_rank(base_type);
   uint64_t dynamic_count = 0;
@@ -2905,8 +2909,15 @@ static iree_status_t loom_bytecode_body_reader_bind_type(
   }
   uint16_t rebound_encoding_id = type.encoding_id;
 
+  if (dynamic_count == 0 && !loom_type_has_ssa_encoding(base_type)) {
+    *out_type = base_type;
+    *out_canonical_type_id = base_type_id;
+    return iree_ok_status();
+  }
+
   if (rank == 0) {
     *out_type = type;
+    *out_canonical_type_id = LOOM_TYPE_ID_INVALID;
     return iree_ok_status();
   }
   if (rank == 1) {
@@ -2937,6 +2948,7 @@ static iree_status_t loom_bytecode_body_reader_bind_type(
   type.encoding_flags = base_type.encoding_flags;
   type.encoding_id = rebound_encoding_id;
   *out_type = type;
+  *out_canonical_type_id = LOOM_TYPE_ID_INVALID;
   return iree_ok_status();
 }
 
@@ -2978,8 +2990,10 @@ static iree_status_t loom_bytecode_body_reader_define_value(
     return iree_ok_status();
 
   loom_type_t type = {0};
+  loom_type_id_t canonical_type_id = LOOM_TYPE_ID_INVALID;
   IREE_RETURN_IF_ERROR(loom_bytecode_body_reader_bind_type(
-      body_reader, cursor, base_type, dim_binding_count, &type));
+      body_reader, cursor, base_type, (loom_type_id_t)type_id,
+      dim_binding_count, &type, &canonical_type_id));
   if (loom_bytecode_reader_has_errors(body_reader->reader))
     return iree_ok_status();
 
@@ -3015,8 +3029,15 @@ static iree_status_t loom_bytecode_body_reader_define_value(
     return iree_ok_status();
   }
 
-  IREE_RETURN_IF_ERROR(loom_module_set_value_type(
-      body_reader->reader->output_module, value_id, type));
+  if (canonical_type_id != LOOM_TYPE_ID_INVALID) {
+    // This exact type-table entry has no body-local bindings and the reserved
+    // value is fresh, so installing it cannot invalidate type-use state.
+    loom_module_value(body_reader->reader->output_module, value_id)->type =
+        body_reader->reader->output_module->types.entries[canonical_type_id];
+  } else {
+    IREE_RETURN_IF_ERROR(loom_module_set_value_type(
+        body_reader->reader->output_module, value_id, type));
+  }
   if (value_name_id != LOOM_STRING_ID_INVALID) {
     IREE_RETURN_IF_ERROR(loom_module_set_value_name(
         body_reader->reader->output_module, value_id, value_name_id));

--- a/loom/src/loom/format/bytecode/reader_test.cc
+++ b/loom/src/loom/format/bytecode/reader_test.cc
@@ -2604,6 +2604,14 @@ TEST_F(ReaderTest, ReadsSsaEncodingBindings) {
 
 TEST_F(ReaderTest, ReadsCoResultDynamicDimBindings) {
   loom_module_t* module = CreateCoResultDimFunctionModule();
+  loom_op_t* source_func_op = module->symbols.entries[0].defining_op;
+  loom_region_t* source_body = loom_test_func_body(source_func_op);
+  loom_op_t* source_deflate_op = loom_region_entry_block(source_body)->first_op;
+  loom_value_slice_t source_results =
+      loom_test_deflate_results(source_deflate_op);
+  ASSERT_EQ(source_results.count, 2u);
+  EXPECT_TRUE(
+      loom_module_value_has_type_uses(module, source_results.values[1]));
   auto bytes = WriteModule(module);
 
   loom_module_t* read_module = nullptr;
@@ -2629,6 +2637,7 @@ TEST_F(ReaderTest, ReadsCoResultDynamicDimBindings) {
       loom_module_value_type(read_module, results.values[0]);
   ASSERT_TRUE(loom_type_dim_is_dynamic_at(output_type, 0));
   EXPECT_EQ(loom_type_dim_value_id_at(output_type, 0), results.values[1]);
+  EXPECT_TRUE(loom_module_value_has_type_uses(read_module, results.values[1]));
 
   loom_module_free(read_module);
   loom_module_free(module);

--- a/loom/src/loom/ir/module.c
+++ b/loom/src/loom/ir/module.c
@@ -199,6 +199,21 @@ static iree_status_t loom_value_table_ensure_capacity(loom_module_t* module) {
   return iree_ok_status();
 }
 
+static iree_status_t loom_value_table_reserve(loom_module_t* module,
+                                              iree_host_size_t count) {
+  loom_value_table_t* table = &module->values;
+  iree_host_size_t available_capacity =
+      loom_value_table_capacity(table) - table->count;
+  while (available_capacity < count) {
+    loom_value_segment_t* segment = NULL;
+    IREE_RETURN_IF_ERROR(loom_segmented_storage_append(
+        &table->segments, &module->arena, (void**)&segment));
+    loom_value_segment_initialize(segment);
+    available_capacity += LOOM_VALUE_SEGMENT_CAPACITY;
+  }
+  return iree_ok_status();
+}
+
 static void loom_value_u32_scratch_fill(loom_value_u32_scratch_t* scratch,
                                         iree_host_size_t value_count,
                                         int byte_value) {
@@ -1666,6 +1681,48 @@ iree_status_t loom_module_define_value(loom_module_t* module, loom_type_t type,
   }
 
   *out_value_id = id;
+  return iree_ok_status();
+}
+
+iree_status_t loom_module_define_untyped_values(
+    loom_module_t* module, iree_host_size_t count,
+    loom_value_id_t* out_base_value_id) {
+  *out_base_value_id = LOOM_VALUE_ID_INVALID;
+  if (count == 0) return iree_ok_status();
+  if (count > LOOM_VALUE_ID_INVALID - module->values.count) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "value table full (%" PRIhsz
+                            " entries, cannot append %" PRIhsz ")",
+                            module->values.count, count);
+  }
+
+  IREE_RETURN_IF_ERROR(loom_value_table_reserve(module, count));
+  const loom_value_id_t base_value_id = (loom_value_id_t)module->values.count;
+  const bool zero_scratch = module->scratch.values.state ==
+                                LOOM_VALUE_U32_SCRATCH_STATE_ACQUIRED_ZEROED ||
+                            module->scratch.values.state ==
+                                LOOM_VALUE_U32_SCRATCH_STATE_UNACQUIRED_ZEROED;
+  iree_host_size_t remaining_count = count;
+  iree_host_size_t value_ordinal = module->values.count;
+  module->values.count += count;
+  while (remaining_count > 0) {
+    loom_value_segment_t* segment = loom_value_table_segment_for_id(
+        &module->values, (loom_value_id_t)value_ordinal);
+    const iree_host_size_t segment_offset =
+        value_ordinal & LOOM_VALUE_SEGMENT_MASK;
+    const iree_host_size_t segment_count =
+        iree_min(remaining_count, LOOM_VALUE_SEGMENT_CAPACITY - segment_offset);
+    for (iree_host_size_t i = 0; i < segment_count; ++i) {
+      segment->values[segment_offset + i].name_id = LOOM_STRING_ID_INVALID;
+    }
+    if (zero_scratch) {
+      memset(&segment->u32_scratch[segment_offset], 0,
+             segment_count * sizeof(segment->u32_scratch[0]));
+    }
+    value_ordinal += segment_count;
+    remaining_count -= segment_count;
+  }
+  *out_base_value_id = base_value_id;
   return iree_ok_status();
 }
 

--- a/loom/src/loom/ir/module.h
+++ b/loom/src/loom/ir/module.h
@@ -149,6 +149,14 @@ static inline loom_type_t loom_block_arg_type(const loom_module_t* module,
 iree_status_t loom_module_define_value(loom_module_t* module, loom_type_t type,
                                        loom_value_id_t* out_value_id);
 
+// Defines a contiguous range of fresh SSA values with NONE types. Every value
+// is unnamed and has no defining operation. Decoders may use the returned base
+// ID to reserve forward references before assigning types and definitions.
+// Returns LOOM_VALUE_ID_INVALID when |count| is zero.
+iree_status_t loom_module_define_untyped_values(
+    loom_module_t* module, iree_host_size_t count,
+    loom_value_id_t* out_base_value_id);
+
 // Acquires the module value-ordinal scratch table for one compiler frame.
 //
 // Mutable modules are single-owner, so only one active local value mapping is

--- a/loom/src/loom/ir/module_test.cc
+++ b/loom/src/loom/ir/module_test.cc
@@ -832,6 +832,46 @@ TEST_F(ModuleTest, DefineValueSegmentGrowthKeepsPointersStable) {
   loom_module_free(module);
 }
 
+TEST_F(ModuleTest, DefineUntypedValuesPreservesRangeAndScratchState) {
+  loom_module_t* module = NULL;
+  IREE_ASSERT_OK(loom_module_allocate(&context_, IREE_SV("test"), &block_pool_,
+                                      NULL, iree_allocator_system(), &module));
+
+  loom_value_id_t typed_id = LOOM_VALUE_ID_INVALID;
+  IREE_ASSERT_OK(loom_module_define_value(
+      module, loom_type_scalar(LOOM_SCALAR_TYPE_F32), &typed_id));
+  loom_value_u32_scratch_acquire_zeroed(&module->scratch.values,
+                                        module->values.count);
+  loom_value_u32_scratch_store(&module->scratch.values, typed_id, 42);
+
+  const iree_host_size_t range_count = LOOM_VALUE_SEGMENT_CAPACITY + 7;
+  loom_value_id_t base_value_id = LOOM_VALUE_ID_INVALID;
+  IREE_ASSERT_OK(
+      loom_module_define_untyped_values(module, range_count, &base_value_id));
+  EXPECT_EQ(base_value_id, typed_id + 1);
+  EXPECT_EQ(module->values.count, range_count + 1);
+  EXPECT_EQ(loom_value_u32_scratch_load(&module->scratch.values, typed_id),
+            42u);
+  for (iree_host_size_t i = 0; i < range_count; ++i) {
+    const loom_value_id_t value_id = base_value_id + (loom_value_id_t)i;
+    const loom_value_t* value = loom_module_value(module, value_id);
+    EXPECT_EQ(loom_type_kind(value->type), LOOM_TYPE_NONE);
+    EXPECT_EQ(value->name_id, LOOM_STRING_ID_INVALID);
+    EXPECT_EQ(value->def, loom_value_def_make_none());
+    EXPECT_EQ(loom_value_u32_scratch_load(&module->scratch.values, value_id),
+              0u);
+  }
+  loom_value_u32_scratch_release_zeroed(&module->scratch.values);
+
+  loom_value_id_t empty_base_value_id = 0;
+  IREE_ASSERT_OK(
+      loom_module_define_untyped_values(module, 0, &empty_base_value_id));
+  EXPECT_EQ(empty_base_value_id, LOOM_VALUE_ID_INVALID);
+  EXPECT_EQ(module->values.count, range_count + 1);
+
+  loom_module_free(module);
+}
+
 TEST_F(ModuleTest, ValueOrdinalScratchTracksActiveFrameOnly) {
   loom_module_t* module = NULL;
   IREE_ASSERT_OK(loom_module_allocate(&context_, IREE_SV("test"), &block_pool_,
@@ -937,7 +977,7 @@ TEST_F(ModuleTest, ValueU32ScratchAliasesOrdinalAndZeroedModes) {
   loom_module_free(module);
 }
 
-TEST_F(ModuleTest, DefineValueRejectsInvalidSentinelId) {
+TEST_F(ModuleTest, DefineValuesRejectInvalidSentinelId) {
   loom_module_t* module = NULL;
   IREE_ASSERT_OK(loom_module_allocate(&context_, IREE_SV("test"), &block_pool_,
                                       NULL, iree_allocator_system(), &module));
@@ -949,6 +989,8 @@ TEST_F(ModuleTest, DefineValueRejectsInvalidSentinelId) {
       IREE_STATUS_RESOURCE_EXHAUSTED,
       loom_module_define_value(module, loom_type_scalar(LOOM_SCALAR_TYPE_F32),
                                &id));
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED,
+                        loom_module_define_untyped_values(module, 1, &id));
 
   loom_module_free(module);
 }

--- a/loom/src/loom/ir/types.c
+++ b/loom/src/loom/ir/types.c
@@ -457,12 +457,6 @@ static bool loom_type_has_value_ref_dims(loom_type_t type) {
   return loom_type_is_shaped(type) || loom_type_is_pool(type);
 }
 
-static bool loom_type_is_value_ref_free_leaf(loom_type_t type) {
-  return loom_type_is_scalar(type) ||
-         (loom_type_is_shaped(type) && loom_type_is_all_static(type) &&
-          !loom_type_has_ssa_encoding(type));
-}
-
 static iree_status_t loom_type_walk_value_ref_sequence(
     const loom_module_t* module, const loom_type_t* types, uint16_t type_count,
     loom_type_value_ref_callback_t callback, void* user_data) {
@@ -488,6 +482,7 @@ iree_status_t loom_type_walk_value_refs(const loom_module_t* module,
 
   loom_type_kind_t kind = loom_type_kind(type);
   if (!loom_type_kind_is_valid(kind)) return iree_ok_status();
+  if (!loom_type_may_reference_values(type)) return iree_ok_status();
 
   switch (kind) {
     case LOOM_TYPE_FUNCTION: {
@@ -516,10 +511,9 @@ iree_status_t loom_type_walk_value_refs(const loom_module_t* module,
 
     case LOOM_TYPE_REGISTER: {
       const loom_type_t* value_type = loom_type_register_value_type(type);
-      return value_type && !loom_type_is_value_ref_free_leaf(*value_type)
-                 ? loom_type_walk_value_refs(module, *value_type, callback,
-                                             user_data)
-                 : iree_ok_status();
+      return value_type ? loom_type_walk_value_refs(module, *value_type,
+                                                    callback, user_data)
+                        : iree_ok_status();
     }
 
     default:
@@ -600,6 +594,7 @@ bool loom_type_references_value(const loom_module_t* module, loom_type_t type,
   if (!module) return false;
   loom_type_kind_t kind = loom_type_kind(type);
   if (!loom_type_kind_is_valid(kind)) return false;
+  if (!loom_type_may_reference_values(type)) return false;
 
   switch (kind) {
     case LOOM_TYPE_FUNCTION: {
@@ -630,7 +625,7 @@ bool loom_type_references_value(const loom_module_t* module, loom_type_t type,
 
     case LOOM_TYPE_REGISTER: {
       const loom_type_t* value_type = loom_type_register_value_type(type);
-      return value_type && !loom_type_is_value_ref_free_leaf(*value_type) &&
+      return value_type &&
              loom_type_references_value(module, *value_type, value_id);
     }
 

--- a/loom/src/loom/ir/types.h
+++ b/loom/src/loom/ir/types.h
@@ -845,6 +845,24 @@ static inline const loom_type_t* loom_type_register_value_type(
   return data ? &data->value_type : NULL;
 }
 
+// Returns true if |type| may embed SSA value references. A false result proves
+// the type is reference-free. Compound types return true conservatively so
+// callers that need exact references can walk their nested payloads.
+static inline bool loom_type_may_reference_values(loom_type_t type) {
+  switch (loom_type_kind(type)) {
+    case LOOM_TYPE_FUNCTION:
+    case LOOM_TYPE_DIALECT:
+    case LOOM_TYPE_PARAMETERIZED:
+      return true;
+    case LOOM_TYPE_REGISTER:
+      return loom_type_register_has_value_type(type);
+    default:
+      return ((loom_type_is_shaped(type) || loom_type_is_pool(type)) &&
+              !loom_type_is_all_static(type)) ||
+             loom_type_has_ssa_encoding(type);
+  }
+}
+
 // Creates a pool type with a single block_size dimension.
 // Uses rank=1 and stores the packed dim in dims[0], following the same
 // packing as shaped types (loom_dim_pack_static / loom_dim_pack_dynamic).

--- a/loom/src/loom/ir/types_test.cc
+++ b/loom/src/loom/ir/types_test.cc
@@ -128,6 +128,45 @@ static iree_status_t CaptureValueRef(loom_value_id_t value_id,
   return iree_ok_status();
 }
 
+TEST(TypesTest, MayReferenceValuesConservativelyClassifiesTypes) {
+  loom_type_t scalar = loom_type_scalar(LOOM_SCALAR_TYPE_F32);
+  loom_type_t static_vector = loom_type_shaped_1d(
+      LOOM_TYPE_VECTOR, LOOM_SCALAR_TYPE_F32, loom_dim_pack_static(4), 0);
+  loom_type_t dynamic_vector = loom_type_shaped_1d(
+      LOOM_TYPE_VECTOR, LOOM_SCALAR_TYPE_F32, loom_dim_pack_dynamic(7), 0);
+  loom_type_t dynamic_view = loom_type_shaped_1d(
+      LOOM_TYPE_VIEW, LOOM_SCALAR_TYPE_F32, loom_dim_pack_static(4), 0);
+  dynamic_view.encoding_id = 9;
+  dynamic_view.encoding_flags = LOOM_ENCODING_FLAG_SSA;
+  loom_type_t static_pool = loom_type_pool(loom_dim_pack_static(4096));
+  loom_type_t dynamic_pool = loom_type_pool(loom_dim_pack_dynamic(11));
+  loom_register_type_data_t register_data = {42, 4, scalar};
+  loom_type_t function_type = {};
+  function_type.header = loom_type_make_raw_header(LOOM_TYPE_FUNCTION, 0, 0,
+                                                   LOOM_TYPE_FLAG_ALL_STATIC);
+  loom_type_t dialect_type = {};
+  dialect_type.header = loom_type_make_raw_header(LOOM_TYPE_DIALECT, 0, 0,
+                                                  LOOM_TYPE_FLAG_ALL_STATIC);
+  loom_type_t parameterized_type = {};
+  parameterized_type.header = loom_type_make_raw_header(
+      LOOM_TYPE_PARAMETERIZED, 0, 0, LOOM_TYPE_FLAG_ALL_STATIC);
+
+  EXPECT_FALSE(loom_type_may_reference_values(loom_type_none()));
+  EXPECT_FALSE(loom_type_may_reference_values(scalar));
+  EXPECT_FALSE(loom_type_may_reference_values(static_vector));
+  EXPECT_FALSE(loom_type_may_reference_values(static_pool));
+  EXPECT_FALSE(
+      loom_type_may_reference_values(loom_type_register_payload(42, 4)));
+  EXPECT_TRUE(loom_type_may_reference_values(dynamic_vector));
+  EXPECT_TRUE(loom_type_may_reference_values(dynamic_view));
+  EXPECT_TRUE(loom_type_may_reference_values(dynamic_pool));
+  EXPECT_TRUE(loom_type_may_reference_values(
+      loom_type_register_payload_with_value_type(&register_data)));
+  EXPECT_TRUE(loom_type_may_reference_values(function_type));
+  EXPECT_TRUE(loom_type_may_reference_values(dialect_type));
+  EXPECT_TRUE(loom_type_may_reference_values(parameterized_type));
+}
+
 class ModuleTypesTest : public ::testing::Test {
  protected:
   void SetUp() override {

--- a/loom/src/loom/ops/op_defs.c
+++ b/loom/src/loom/ops/op_defs.c
@@ -3027,15 +3027,8 @@ iree_status_t loom_builder_finalize_op(loom_builder_t* builder, loom_op_t* op) {
           loom_value_def_make_op(op, i);
     }
   }
-  for (uint16_t i = 0; i < op->result_count; ++i) {
-    if (results[i] != LOOM_VALUE_ID_INVALID) {
-      loom_type_t result_type =
-          loom_module_value_type(builder->module, results[i]);
-      if (!loom_type_may_reference_values(result_type)) continue;
-      IREE_RETURN_IF_ERROR(
-          loom_module_refresh_value_type_uses(builder->module, results[i]));
-    }
-  }
+  // Result type uses are installed when values are defined or their types
+  // change. Finalization only assigns the operation definition site.
   IREE_RETURN_IF_ERROR(
       loom_module_note_op_attribute_value_refs(builder->module, op));
   // Successor-bearing ops make their enclosing region unstructured CFG.

--- a/loom/src/loom/ops/op_defs.c
+++ b/loom/src/loom/ops/op_defs.c
@@ -3029,6 +3029,9 @@ iree_status_t loom_builder_finalize_op(loom_builder_t* builder, loom_op_t* op) {
   }
   for (uint16_t i = 0; i < op->result_count; ++i) {
     if (results[i] != LOOM_VALUE_ID_INVALID) {
+      loom_type_t result_type =
+          loom_module_value_type(builder->module, results[i]);
+      if (!loom_type_may_reference_values(result_type)) continue;
       IREE_RETURN_IF_ERROR(
           loom_module_refresh_value_type_uses(builder->module, results[i]));
     }


### PR DESCRIPTION
Verified Loombc loading was repeating work whose answers were already established by the artifact metadata and module type system. This change preserves canonical type provenance through body decoding, allocates bounded value ranges in bulk, makes reference-free types cheaply recognizable, and leaves type-use maintenance at value definition and mutation instead of repairing it again during operation finalization. The result is a smaller, more direct materialization path without weakening malformed-artifact rejection, changing retained IR, or introducing reader-specific builder modes.

## Design

### Preserve canonical type provenance

The bytecode type section validates, topologically materializes, and interns every structural type before function bodies are decoded. Body values previously discarded that provenance and sent unchanged types back through hashing and equality in the module interner.

Body-local type binding now returns both the materialized type and its canonical module type ID. A value installs the canonical entry directly only when no dynamic dimension or SSA encoding rebinding changed it. Rebound types continue through the ordinary interning and type-use path. This keeps the public bytecode validation boundary intact while carrying an already-proven fact into the consumer that needs it.

### Consume bounded value summaries in bulk

Function body metadata already bounds the number of values that materialization may define. The reader nevertheless paid the generic one-value growth and initialization path for every operation result.

The module can now define a contiguous range of untyped placeholder values in one operation. Body readers consume IDs from that range while preserving append-only ordering, scratch-state invariants, and predefined signature-value mappings. Dynamic bindings still use normal type mutation, and the reader retains its independent body-size and summary bounds for malformed input. Ordinary builders remain on their existing single-value path.

### Keep type-use ownership singular

An O(1), conservative type trait now answers whether a type may embed SSA value references. Scalars, static shaped types, untyped registers, and other leaf forms prove that they cannot; dynamic shapes, SSA encodings, function and dialect payloads, parameterized types, and typed registers conservatively retain exact walking.

The trait first removes pointless reference walks from common static results. The deeper cleanup then removes result type-use refresh from operation finalization entirely: value definition and type mutation already install those edges, and finalization owns only the operation definition site and operation-level bookkeeping. Co-result coverage proves the difficult case where one result's dynamic shape refers to a sibling result before serialization and after decoding.

## Performance

Measurements used fixed-iteration, alternating baseline/candidate runs and medians. The one-export artifact represents a compact launch library; the generated 1,024-export artifact is deliberately oversized so linear materialization costs are measurable.

| Boundary | Before | After | Change |
|---|---:|---:|---:|
| One-export materialization and verification | 10.23 us | 8.38 us | 18.1% lower |
| 1,024-export materialization | 6.60 ms | 4.56 ms | 31.0% lower |
| 1,024-export materialization and verification | 8.88 ms | 6.76 ms | 23.9% lower |

Counter profiling characterizes the remaining limit as instruction volume rather than memory latency. Materialization executes approximately 56.2 million instructions in 18.8 million cycles at 2.98 instructions/cycle, with 0.11% branch misses and 0.89% L1 data misses. Verification raises the totals to 81.2 million instructions and 28.3 million cycles while retaining similarly low miss rates. The 5 MB retained module represents only about 1.1 GB/s of output traffic at the measured load time.

The scaled module retains exactly 4,996,256 bytes before and after. The final profile is dominated by required wire decoding, region/value/use construction, location materialization, and verification. Operation-storage zeroing has only a 2.24% perfect-removal ceiling, so this series stops rather than changing a broad builder initialization contract around a low-ceiling hypothesis.

## Correctness And Representation

Canonical text, bytecode records, value IDs, retained type payloads, and module arena use are unchanged. The reader still validates every public reference, count, binding, and body summary. Canonical direct installation is unavailable whenever a body-local binding could introduce SSA references, and all such cases retain the existing canonicalization and type-use machinery.

The bulk value API preserves zero-count behavior, invalid-ID bounds, segmented value-table storage, and acquired scratch semantics. Type reference classification is conservative by construction: a false result proves that walking is unnecessary, while uncertainty always keeps the existing exact path.

## Reviewer Notes

The highest-value review surfaces are the canonical-type proof in body-local binding, the interaction between predefined signature values and bulk fresh ranges, the conservative boundary of `loom_type_may_reference_values`, and the ownership argument that makes finalization-time type-use repair redundant. The four commits follow that dependency order so each invariant can be reviewed independently.
