### PR TITLE
[Loom] Expose glibc spawn closefrom declaration

### DIFF
--- a/loom/src/loom/target/tool/process_linux.c
+++ b/loom/src/loom/target/tool/process_linux.c
@@ -4,6 +4,12 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// _GNU_SOURCE must be defined before any system header so that <spawn.h>
+// declares posix_spawn_file_actions_addclosefrom_np on glibc.
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif  // _GNU_SOURCE
+
 #include "loom/target/tool/process_platform.h"
 
 #if defined(IREE_PLATFORM_LINUX) || defined(IREE_PLATFORM_ANDROID)


### PR DESCRIPTION
## Summary
- define `_GNU_SOURCE` before system headers in the Linux process runner
- expose `posix_spawn_file_actions_addclosefrom_np` on glibc 2.34+ strict builds while preserving the existing fallback on other libc versions

## Test plan
- [x] `python dev.py bazel build //loom/src/loom/target/tool:process`
- [x] `python dev.py bazel test --test_output=errors //loom/src/loom/target/tool:process_test`
- [x] build all ten targets from `loom/README.md` without workaround flags
- [ ] `python dev.py bazel precommit` (937 tests passed and 19 skipped; the SUT's unrelated LLVM 14 tool test rejects opaque-pointer IR)


Made with [Cursor](https://cursor.com)