### PR TITLE
[Loom] Define SPIR-V ordinary-vector conversion contracts

### DIFF
--- a/loom/py/loom/gen/target/arch/spirv/BUILD.bazel
+++ b/loom/py/loom/gen/target/arch/spirv/BUILD.bazel
@@ -119,6 +119,7 @@ iree_py_binary(
         "//loom/py/loom/target/arch/spirv:descriptors",
         "//loom/py/loom/target/arch/spirv:ordinary_vector",
         "//loom/py/loom/target/arch/spirv:ordinary_vector_integer",
+        "//loom/py/loom/target/arch/spirv:ordinary_vector_integer_conversion",
         "//loom/py/loom/target/arch/spirv:scalar_alu",
         "//loom/py/loom/target/arch/spirv:scalar_constant",
         "//loom/py/loom/target/arch/spirv:scalar_conversion",

--- a/loom/py/loom/gen/target/arch/spirv/BUILD.bazel
+++ b/loom/py/loom/gen/target/arch/spirv/BUILD.bazel
@@ -118,6 +118,7 @@ iree_py_binary(
         "//loom/py/loom/target/arch/spirv:cooperative_matrix",
         "//loom/py/loom/target/arch/spirv:descriptors",
         "//loom/py/loom/target/arch/spirv:ordinary_vector",
+        "//loom/py/loom/target/arch/spirv:ordinary_vector_bit_layout",
         "//loom/py/loom/target/arch/spirv:ordinary_vector_integer",
         "//loom/py/loom/target/arch/spirv:ordinary_vector_integer_conversion",
         "//loom/py/loom/target/arch/spirv:scalar_alu",

--- a/loom/py/loom/gen/target/arch/spirv/CMakeLists.txt
+++ b/loom/py/loom/gen/target/arch/spirv/CMakeLists.txt
@@ -106,6 +106,7 @@ iree_py_library(
     loom::py::loom::target::arch::spirv::cooperative_matrix
     loom::py::loom::target::arch::spirv::descriptors
     loom::py::loom::target::arch::spirv::ordinary_vector
+    loom::py::loom::target::arch::spirv::ordinary_vector_bit_layout
     loom::py::loom::target::arch::spirv::ordinary_vector_integer
     loom::py::loom::target::arch::spirv::ordinary_vector_integer_conversion
     loom::py::loom::target::arch::spirv::scalar_alu

--- a/loom/py/loom/gen/target/arch/spirv/CMakeLists.txt
+++ b/loom/py/loom/gen/target/arch/spirv/CMakeLists.txt
@@ -107,6 +107,7 @@ iree_py_library(
     loom::py::loom::target::arch::spirv::descriptors
     loom::py::loom::target::arch::spirv::ordinary_vector
     loom::py::loom::target::arch::spirv::ordinary_vector_integer
+    loom::py::loom::target::arch::spirv::ordinary_vector_integer_conversion
     loom::py::loom::target::arch::spirv::scalar_alu
     loom::py::loom::target::arch::spirv::scalar_constant
     loom::py::loom::target::arch::spirv::scalar_conversion

--- a/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows.py
+++ b/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows.py
@@ -41,6 +41,9 @@ from loom.target.arch.spirv.ordinary_vector import (  # noqa: E402
     OrdinaryVectorInstructionType,
     OrdinaryVectorType,
 )
+from loom.target.arch.spirv.ordinary_vector_bit_layout import (  # noqa: E402
+    ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTIONS,
+)
 from loom.target.arch.spirv.ordinary_vector_integer import (  # noqa: E402
     ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
 )
@@ -619,6 +622,7 @@ def _ordinary_vector_rows() -> list[_PacketRow]:
             *ORDINARY_VECTOR_INSTRUCTIONS,
             *ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
             *ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS,
+            *ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTIONS,
         )
     ]
 

--- a/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows.py
+++ b/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows.py
@@ -44,6 +44,9 @@ from loom.target.arch.spirv.ordinary_vector import (  # noqa: E402
 from loom.target.arch.spirv.ordinary_vector_integer import (  # noqa: E402
     ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
 )
+from loom.target.arch.spirv.ordinary_vector_integer_conversion import (  # noqa: E402
+    ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS,
+)
 from loom.target.arch.spirv.scalar_alu import (  # noqa: E402
     BOOLEAN_BINARY_OPERATIONS,
     BOOLEAN_CONSTANTS,
@@ -615,6 +618,7 @@ def _ordinary_vector_rows() -> list[_PacketRow]:
         for row in (
             *ORDINARY_VECTOR_INSTRUCTIONS,
             *ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
+            *ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS,
         )
     ]
 

--- a/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows_test.py
+++ b/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows_test.py
@@ -26,11 +26,15 @@ from loom.target.arch.spirv.ordinary_vector import (
     ORDINARY_VECTOR_INSTRUCTIONS,
     ORDINARY_VECTOR_TYPES,
     OrdinaryVectorComponentKind,
+    OrdinaryVectorInstruction,
     OrdinaryVectorInstructionType,
     OrdinaryVectorType,
 )
 from loom.target.arch.spirv.ordinary_vector_integer import (
     ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
+)
+from loom.target.arch.spirv.ordinary_vector_integer_conversion import (
+    ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS,
 )
 from loom.target.arch.spirv.scalar_alu import (
     BOOLEAN_BINARY_OPERATIONS,
@@ -623,16 +627,17 @@ def _expected_ordinary_vector_value(
     return f"{{.value_class = {component_type.vector_value_class}, .scalar_type = {component_type.scalar_enum}, .vector = {{.lane_count = {vector_type.lane_count}}}}}"
 
 
-def test_generation_emits_complete_ordinary_vector_integer_matrix() -> None:
-    instruction_keys = {instruction.key for instruction in ORDINARY_VECTOR_INTEGER_INSTRUCTIONS}
+def _assert_generated_ordinary_vector_instructions(
+    instructions: tuple[OrdinaryVectorInstruction, ...],
+) -> None:
+    instruction_keys = {instruction.key for instruction in instructions}
     packet_rows_by_key = {row.descriptor_key: row for row in _packet_rows() if row.descriptor_key in instruction_keys}
     descriptors_by_key = {descriptor.key: descriptor for descriptor in SPIRV_LOGICAL_CORE_DESCRIPTOR_SET.descriptors if descriptor.key in instruction_keys}
 
-    assert len(instruction_keys) == 309
     assert packet_rows_by_key.keys() == instruction_keys
     assert descriptors_by_key.keys() == instruction_keys
 
-    for instruction in ORDINARY_VECTOR_INTEGER_INSTRUCTIONS:
+    for instruction in instructions:
         assert isinstance(instruction.result_type, OrdinaryVectorType)
         assert all(isinstance(operand_type, OrdinaryVectorType) for operand_type in instruction.operand_types)
 
@@ -650,6 +655,16 @@ def test_generation_emits_complete_ordinary_vector_integer_matrix() -> None:
         assert descriptor.feature_mask_words == ((instruction.feature_bits,) if instruction.feature_bits else ())
         assert descriptor.immediates == ()
         assert tuple(operand.reg_alts[0].reg_class for operand in descriptor.operands) == ("spirv.id",) * (len(instruction.operand_types) + 1)
+
+
+def test_generation_emits_complete_ordinary_vector_integer_matrix() -> None:
+    assert len(ORDINARY_VECTOR_INTEGER_INSTRUCTIONS) == 309
+    _assert_generated_ordinary_vector_instructions(ORDINARY_VECTOR_INTEGER_INSTRUCTIONS)
+
+
+def test_generation_emits_complete_ordinary_vector_integer_conversions() -> None:
+    assert len(ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS) == 54
+    _assert_generated_ordinary_vector_instructions(ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS)
 
 
 def test_generation_compacts_only_repeated_four_operand_types() -> None:

--- a/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows_test.py
+++ b/loom/py/loom/gen/target/arch/spirv/spirv_packet_rows_test.py
@@ -30,6 +30,9 @@ from loom.target.arch.spirv.ordinary_vector import (
     OrdinaryVectorInstructionType,
     OrdinaryVectorType,
 )
+from loom.target.arch.spirv.ordinary_vector_bit_layout import (
+    ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTIONS,
+)
 from loom.target.arch.spirv.ordinary_vector_integer import (
     ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
 )
@@ -621,10 +624,10 @@ def test_generation_emits_complete_ordinary_vector_structural_matrix() -> None:
 def _expected_ordinary_vector_value(
     value_type: OrdinaryVectorInstructionType,
 ) -> str:
-    assert isinstance(value_type, OrdinaryVectorType)
-    vector_type = value_type
-    component_type = vector_type.component_type
-    return f"{{.value_class = {component_type.vector_value_class}, .scalar_type = {component_type.scalar_enum}, .vector = {{.lane_count = {vector_type.lane_count}}}}}"
+    if isinstance(value_type, OrdinaryVectorType):
+        component_type = value_type.component_type
+        return f"{{.value_class = {component_type.vector_value_class}, .scalar_type = {component_type.scalar_enum}, .vector = {{.lane_count = {value_type.lane_count}}}}}"
+    return f"{{.value_class = {value_type.scalar_value_class}, .scalar_type = {value_type.scalar_enum}}}"
 
 
 def _assert_generated_ordinary_vector_instructions(
@@ -638,9 +641,6 @@ def _assert_generated_ordinary_vector_instructions(
     assert descriptors_by_key.keys() == instruction_keys
 
     for instruction in instructions:
-        assert isinstance(instruction.result_type, OrdinaryVectorType)
-        assert all(isinstance(operand_type, OrdinaryVectorType) for operand_type in instruction.operand_types)
-
         row = packet_rows_by_key[instruction.key]
         assert row.opcode == instruction.opcode
         assert row.form == instruction.packet_form
@@ -665,6 +665,11 @@ def test_generation_emits_complete_ordinary_vector_integer_matrix() -> None:
 def test_generation_emits_complete_ordinary_vector_integer_conversions() -> None:
     assert len(ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS) == 54
     _assert_generated_ordinary_vector_instructions(ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS)
+
+
+def test_generation_emits_complete_ordinary_vector_bit_layout_rows() -> None:
+    assert len(ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTIONS) == 102
+    _assert_generated_ordinary_vector_instructions(ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTIONS)
 
 
 def test_generation_compacts_only_repeated_four_operand_types() -> None:

--- a/loom/py/loom/target/arch/spirv/BUILD.bazel
+++ b/loom/py/loom/target/arch/spirv/BUILD.bazel
@@ -81,6 +81,7 @@ iree_py_library(
         ":cooperative_matrix",
         ":features",
         ":ordinary_vector",
+        ":ordinary_vector_bit_layout",
         ":ordinary_vector_integer",
         ":ordinary_vector_integer_conversion",
         ":scalar_alu",
@@ -107,6 +108,7 @@ iree_py_test(
         ":cooperative_matrix",
         ":descriptors",
         ":ordinary_vector",
+        ":ordinary_vector_bit_layout",
         ":ordinary_vector_integer",
         ":ordinary_vector_integer_conversion",
         ":scalar_alu",
@@ -176,6 +178,36 @@ iree_py_test(
     main = "pytest_style_runner.py",
     deps = [
         ":ordinary_vector",
+    ],
+)
+
+iree_py_library(
+    name = "ordinary_vector_bit_layout",
+    srcs = [
+        "__init__.py",
+        "ordinary_vector_bit_layout.py",
+    ],
+    deps = [
+        ":ordinary_vector",
+        ":scalar_conversion",
+    ],
+)
+
+iree_py_test(
+    name = "ordinary_vector_bit_layout_test",
+    size = "small",
+    srcs = [
+        "ordinary_vector_bit_layout_test.py",
+        "//loom/py/loom/tools:pytest_style_runner.py",
+    ],
+    args = ["loom.target.arch.spirv.ordinary_vector_bit_layout_test"],
+    main = "pytest_style_runner.py",
+    deps = [
+        ":ordinary_vector",
+        ":ordinary_vector_bit_layout",
+        ":ordinary_vector_integer",
+        ":ordinary_vector_integer_conversion",
+        ":scalar_conversion",
     ],
 )
 

--- a/loom/py/loom/target/arch/spirv/BUILD.bazel
+++ b/loom/py/loom/target/arch/spirv/BUILD.bazel
@@ -82,6 +82,7 @@ iree_py_library(
         ":features",
         ":ordinary_vector",
         ":ordinary_vector_integer",
+        ":ordinary_vector_integer_conversion",
         ":scalar_alu",
         ":scalar_constant",
         ":scalar_conversion",
@@ -107,6 +108,7 @@ iree_py_test(
         ":descriptors",
         ":ordinary_vector",
         ":ordinary_vector_integer",
+        ":ordinary_vector_integer_conversion",
         ":scalar_alu",
         ":scalar_constant",
         ":scalar_conversion",
@@ -202,6 +204,37 @@ iree_py_test(
         ":features",
         ":ordinary_vector",
         ":ordinary_vector_integer",
+    ],
+)
+
+iree_py_library(
+    name = "ordinary_vector_integer_conversion",
+    srcs = [
+        "__init__.py",
+        "ordinary_vector_integer_conversion.py",
+    ],
+    deps = [
+        ":ordinary_vector",
+        ":ordinary_vector_integer",
+        ":scalar_alu",
+        ":scalar_conversion",
+    ],
+)
+
+iree_py_test(
+    name = "ordinary_vector_integer_conversion_test",
+    size = "small",
+    srcs = [
+        "ordinary_vector_integer_conversion_test.py",
+        "//loom/py/loom/tools:pytest_style_runner.py",
+    ],
+    args = ["loom.target.arch.spirv.ordinary_vector_integer_conversion_test"],
+    main = "pytest_style_runner.py",
+    deps = [
+        ":ordinary_vector",
+        ":ordinary_vector_integer",
+        ":ordinary_vector_integer_conversion",
+        ":scalar_conversion",
     ],
 )
 

--- a/loom/py/loom/target/arch/spirv/CMakeLists.txt
+++ b/loom/py/loom/target/arch/spirv/CMakeLists.txt
@@ -73,6 +73,7 @@ iree_py_library(
     loom::py::loom::target::arch::spirv::features
     loom::py::loom::target::arch::spirv::ordinary_vector
     loom::py::loom::target::arch::spirv::ordinary_vector_integer
+    loom::py::loom::target::arch::spirv::ordinary_vector_integer_conversion
     loom::py::loom::target::arch::spirv::scalar_alu
     loom::py::loom::target::arch::spirv::scalar_constant
     loom::py::loom::target::arch::spirv::scalar_conversion
@@ -98,6 +99,7 @@ iree_py_test(
     loom::py::loom::target::arch::spirv::descriptors
     loom::py::loom::target::arch::spirv::ordinary_vector
     loom::py::loom::target::arch::spirv::ordinary_vector_integer
+    loom::py::loom::target::arch::spirv::ordinary_vector_integer_conversion
     loom::py::loom::target::arch::spirv::scalar_alu
     loom::py::loom::target::arch::spirv::scalar_constant
     loom::py::loom::target::arch::spirv::scalar_conversion
@@ -200,6 +202,42 @@ iree_py_test(
     loom::py::loom::target::arch::spirv::features
     loom::py::loom::target::arch::spirv::ordinary_vector
     loom::py::loom::target::arch::spirv::ordinary_vector_integer
+  PACKAGE_DIRS
+    "${PROJECT_SOURCE_DIR}/loom/py"
+    "${PROJECT_BINARY_DIR}/loom/py"
+    "${PROJECT_SOURCE_DIR}"
+  TIMEOUT
+    60
+)
+
+iree_py_library(
+  NAME
+    ordinary_vector_integer_conversion
+  SRCS
+    "__init__.py"
+    "ordinary_vector_integer_conversion.py"
+  DEPS
+    loom::py::loom::target::arch::spirv::ordinary_vector
+    loom::py::loom::target::arch::spirv::ordinary_vector_integer
+    loom::py::loom::target::arch::spirv::scalar_alu
+    loom::py::loom::target::arch::spirv::scalar_conversion
+)
+
+iree_py_test(
+  NAME
+    ordinary_vector_integer_conversion_test
+  MAIN
+    "../../../tools/pytest_style_runner.py"
+  SRCS
+    "ordinary_vector_integer_conversion_test.py"
+    "../../../tools/pytest_style_runner.py"
+  ARGS
+    "loom.target.arch.spirv.ordinary_vector_integer_conversion_test"
+  DEPS
+    loom::py::loom::target::arch::spirv::ordinary_vector
+    loom::py::loom::target::arch::spirv::ordinary_vector_integer
+    loom::py::loom::target::arch::spirv::ordinary_vector_integer_conversion
+    loom::py::loom::target::arch::spirv::scalar_conversion
   PACKAGE_DIRS
     "${PROJECT_SOURCE_DIR}/loom/py"
     "${PROJECT_BINARY_DIR}/loom/py"

--- a/loom/py/loom/target/arch/spirv/CMakeLists.txt
+++ b/loom/py/loom/target/arch/spirv/CMakeLists.txt
@@ -72,6 +72,7 @@ iree_py_library(
     loom::py::loom::target::arch::spirv::cooperative_matrix
     loom::py::loom::target::arch::spirv::features
     loom::py::loom::target::arch::spirv::ordinary_vector
+    loom::py::loom::target::arch::spirv::ordinary_vector_bit_layout
     loom::py::loom::target::arch::spirv::ordinary_vector_integer
     loom::py::loom::target::arch::spirv::ordinary_vector_integer_conversion
     loom::py::loom::target::arch::spirv::scalar_alu
@@ -98,6 +99,7 @@ iree_py_test(
     loom::py::loom::target::arch::spirv::cooperative_matrix
     loom::py::loom::target::arch::spirv::descriptors
     loom::py::loom::target::arch::spirv::ordinary_vector
+    loom::py::loom::target::arch::spirv::ordinary_vector_bit_layout
     loom::py::loom::target::arch::spirv::ordinary_vector_integer
     loom::py::loom::target::arch::spirv::ordinary_vector_integer_conversion
     loom::py::loom::target::arch::spirv::scalar_alu
@@ -169,6 +171,41 @@ iree_py_test(
     "loom.target.arch.spirv.ordinary_vector_test"
   DEPS
     loom::py::loom::target::arch::spirv::ordinary_vector
+  PACKAGE_DIRS
+    "${PROJECT_SOURCE_DIR}/loom/py"
+    "${PROJECT_BINARY_DIR}/loom/py"
+    "${PROJECT_SOURCE_DIR}"
+  TIMEOUT
+    60
+)
+
+iree_py_library(
+  NAME
+    ordinary_vector_bit_layout
+  SRCS
+    "__init__.py"
+    "ordinary_vector_bit_layout.py"
+  DEPS
+    loom::py::loom::target::arch::spirv::ordinary_vector
+    loom::py::loom::target::arch::spirv::scalar_conversion
+)
+
+iree_py_test(
+  NAME
+    ordinary_vector_bit_layout_test
+  MAIN
+    "../../../tools/pytest_style_runner.py"
+  SRCS
+    "ordinary_vector_bit_layout_test.py"
+    "../../../tools/pytest_style_runner.py"
+  ARGS
+    "loom.target.arch.spirv.ordinary_vector_bit_layout_test"
+  DEPS
+    loom::py::loom::target::arch::spirv::ordinary_vector
+    loom::py::loom::target::arch::spirv::ordinary_vector_bit_layout
+    loom::py::loom::target::arch::spirv::ordinary_vector_integer
+    loom::py::loom::target::arch::spirv::ordinary_vector_integer_conversion
+    loom::py::loom::target::arch::spirv::scalar_conversion
   PACKAGE_DIRS
     "${PROJECT_SOURCE_DIR}/loom/py"
     "${PROJECT_BINARY_DIR}/loom/py"

--- a/loom/py/loom/target/arch/spirv/descriptors.py
+++ b/loom/py/loom/target/arch/spirv/descriptors.py
@@ -31,6 +31,9 @@ from loom.target.arch.spirv.ordinary_vector import (
 from loom.target.arch.spirv.ordinary_vector_integer import (
     ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
 )
+from loom.target.arch.spirv.ordinary_vector_integer_conversion import (
+    ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS,
+)
 from loom.target.arch.spirv.scalar_alu import (
     BOOLEAN_BINARY_OPERATIONS,
     BOOLEAN_CONSTANTS,
@@ -1337,6 +1340,10 @@ SPIRV_LOGICAL_CORE_DESCRIPTOR_SET = DescriptorSet(
         *(
             _ordinary_vector_descriptor(row)
             for row in ORDINARY_VECTOR_INTEGER_INSTRUCTIONS
+        ),
+        *(
+            _ordinary_vector_descriptor(row)
+            for row in ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS
         ),
         _coordinate_copy_descriptor(),
         _ternary_same_type_descriptor(

--- a/loom/py/loom/target/arch/spirv/descriptors.py
+++ b/loom/py/loom/target/arch/spirv/descriptors.py
@@ -28,6 +28,9 @@ from loom.target.arch.spirv.ordinary_vector import (
     OrdinaryVectorInstructionType,
     OrdinaryVectorType,
 )
+from loom.target.arch.spirv.ordinary_vector_bit_layout import (
+    ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTIONS,
+)
 from loom.target.arch.spirv.ordinary_vector_integer import (
     ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
 )
@@ -1344,6 +1347,10 @@ SPIRV_LOGICAL_CORE_DESCRIPTOR_SET = DescriptorSet(
         *(
             _ordinary_vector_descriptor(row)
             for row in ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS
+        ),
+        *(
+            _ordinary_vector_descriptor(row)
+            for row in ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTIONS
         ),
         _coordinate_copy_descriptor(),
         _ternary_same_type_descriptor(

--- a/loom/py/loom/target/arch/spirv/descriptors_test.py
+++ b/loom/py/loom/target/arch/spirv/descriptors_test.py
@@ -23,6 +23,9 @@ from loom.target.arch.spirv.ordinary_vector import (
 from loom.target.arch.spirv.ordinary_vector_integer import (
     ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
 )
+from loom.target.arch.spirv.ordinary_vector_integer_conversion import (
+    ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS,
+)
 from loom.target.arch.spirv.scalar_alu import (
     BOOLEAN_BINARY_OPERATIONS,
     BOOLEAN_CONSTANTS,
@@ -116,6 +119,7 @@ def test_result_asm_recipes_cover_every_spirv_descriptor_family() -> None:
     for row in (
         *ORDINARY_VECTOR_INSTRUCTIONS,
         *ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
+        *ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS,
     ):
         component_type = (
             row.result_type.component_type

--- a/loom/py/loom/target/arch/spirv/descriptors_test.py
+++ b/loom/py/loom/target/arch/spirv/descriptors_test.py
@@ -20,6 +20,9 @@ from loom.target.arch.spirv.ordinary_vector import (
     OrdinaryVectorComponentType,
     OrdinaryVectorType,
 )
+from loom.target.arch.spirv.ordinary_vector_bit_layout import (
+    ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTIONS,
+)
 from loom.target.arch.spirv.ordinary_vector_integer import (
     ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
 )
@@ -120,6 +123,7 @@ def test_result_asm_recipes_cover_every_spirv_descriptor_family() -> None:
         *ORDINARY_VECTOR_INSTRUCTIONS,
         *ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
         *ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS,
+        *ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTIONS,
     ):
         component_type = (
             row.result_type.component_type

--- a/loom/py/loom/target/arch/spirv/ordinary_vector_bit_layout.py
+++ b/loom/py/loom/target/arch/spirv/ordinary_vector_bit_layout.py
@@ -1,0 +1,219 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Source-of-truth rows for exact SPIR-V ordinary-vector bit layout."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loom.target.arch.spirv.ordinary_vector import (
+    NATIVE_ORDINARY_VECTOR_LANE_COUNTS,
+    ORDINARY_VECTOR_COMPONENT_TYPES,
+    ORDINARY_VECTOR_TYPES,
+    OrdinaryVectorComponentType,
+    OrdinaryVectorInstruction,
+    OrdinaryVectorInstructionType,
+    OrdinaryVectorType,
+)
+from loom.target.arch.spirv.scalar_conversion import SCALAR_BITCAST_CONVERSIONS
+
+ORDINARY_VECTOR_BIT_LAYOUT_ELEMENT_TYPES = (
+    "i8",
+    "i16",
+    "i32",
+    "i64",
+    "f16",
+    "bf16",
+    "f32",
+    "f64",
+)
+ORDINARY_VECTOR_BIT_LAYOUT_LANE_COUNTS = (
+    1,
+    *NATIVE_ORDINARY_VECTOR_LANE_COUNTS,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OrdinaryVectorBitLayoutType:
+    """One logical source vector and its exact SPIR-V value representation."""
+
+    element_type: str
+    lane_count: int
+    value_type: OrdinaryVectorInstructionType
+
+    def __post_init__(self) -> None:
+        if self.element_type not in ORDINARY_VECTOR_BIT_LAYOUT_ELEMENT_TYPES:
+            raise ValueError(
+                f"unsupported bit-layout element type {self.element_type!r}"
+            )
+        if self.lane_count not in ORDINARY_VECTOR_BIT_LAYOUT_LANE_COUNTS:
+            raise ValueError("bit-layout vectors require 1-4 static lanes")
+        if isinstance(self.value_type, OrdinaryVectorType):
+            if self.lane_count == 1 or self.value_type.lane_count != self.lane_count:
+                raise ValueError(
+                    "native bit-layout vector representation has wrong lanes"
+                )
+            component_type = self.value_type.component_type
+        else:
+            if self.lane_count != 1:
+                raise ValueError("only v1 may use a scalar bit-layout representation")
+            component_type = self.value_type
+        if self.element_type not in component_type.source_types:
+            raise ValueError("bit-layout element and SPIR-V component must correspond")
+
+    @property
+    def component_type(self) -> OrdinaryVectorComponentType:
+        if isinstance(self.value_type, OrdinaryVectorType):
+            return self.value_type.component_type
+        return self.value_type
+
+    @property
+    def suffix(self) -> str:
+        return self.value_type.suffix
+
+    @property
+    def total_bit_width(self) -> int:
+        return self.lane_count * self.component_type.bit_width
+
+
+@dataclass(frozen=True, slots=True)
+class OrdinaryVectorBitLayoutCase:
+    """One exact equal-total-bit source/result representation pair."""
+
+    source: OrdinaryVectorBitLayoutType
+    result: OrdinaryVectorBitLayoutType
+
+    def __post_init__(self) -> None:
+        if self.source.total_bit_width != self.result.total_bit_width:
+            raise ValueError("bit-layout casts require equal total bit widths")
+        smaller_lane_count = min(
+            self.source.lane_count,
+            self.result.lane_count,
+        )
+        larger_lane_count = max(
+            self.source.lane_count,
+            self.result.lane_count,
+        )
+        if larger_lane_count % smaller_lane_count != 0:
+            raise ValueError("bit-layout component counts must divide exactly")
+
+    @property
+    def is_identity(self) -> bool:
+        return self.source == self.result
+
+    @property
+    def key(self) -> str:
+        return f"spirv.op_bitcast.{self.source.suffix}.{self.result.suffix}"
+
+    @property
+    def feature_bits(self) -> int:
+        return self.source.value_type.feature_bits | self.result.value_type.feature_bits
+
+    @property
+    def instruction(self) -> OrdinaryVectorInstruction:
+        if self.is_identity:
+            raise ValueError("identity bit-layout cases alias their input")
+        return OrdinaryVectorInstruction(
+            key=self.key,
+            mnemonic=(f"OpBitcast.{self.source.suffix}.{self.result.suffix}"),
+            opcode="LOOM_SPIRV_OP_BITCAST",
+            packet_form="LOOM_SPIRV_PACKET_FORM_UNARY_TYPED",
+            result_type=self.result.value_type,
+            operand_names=("input",),
+            operand_types=(self.source.value_type,),
+        )
+
+
+_SELECTED_COMPONENT_TYPE_PAIRS = tuple(
+    (element_type, component_type)
+    for component_type in ORDINARY_VECTOR_COMPONENT_TYPES
+    for element_type in component_type.source_types
+    if element_type in ORDINARY_VECTOR_BIT_LAYOUT_ELEMENT_TYPES
+)
+_COMPONENT_TYPES_BY_ELEMENT_TYPE = dict(_SELECTED_COMPONENT_TYPE_PAIRS)
+if len(_COMPONENT_TYPES_BY_ELEMENT_TYPE) != len(_SELECTED_COMPONENT_TYPE_PAIRS) or set(
+    _COMPONENT_TYPES_BY_ELEMENT_TYPE
+) != set(ORDINARY_VECTOR_BIT_LAYOUT_ELEMENT_TYPES):
+    raise ValueError("bit-layout element types require unique SPIR-V components")
+
+_NATIVE_VECTOR_TYPES_BY_COMPONENT_AND_LANE = {
+    (vector_type.component_type, vector_type.lane_count): vector_type
+    for vector_type in ORDINARY_VECTOR_TYPES
+}
+if len(_NATIVE_VECTOR_TYPES_BY_COMPONENT_AND_LANE) != len(ORDINARY_VECTOR_TYPES):
+    raise ValueError("ordinary-vector component and lane pairs must be unique")
+
+
+def _bit_layout_type(
+    element_type: str,
+    lane_count: int,
+) -> OrdinaryVectorBitLayoutType:
+    component_type = _COMPONENT_TYPES_BY_ELEMENT_TYPE[element_type]
+    value_type: OrdinaryVectorInstructionType = component_type
+    if lane_count != 1:
+        value_type = _NATIVE_VECTOR_TYPES_BY_COMPONENT_AND_LANE[
+            (component_type, lane_count)
+        ]
+    return OrdinaryVectorBitLayoutType(
+        element_type=element_type,
+        lane_count=lane_count,
+        value_type=value_type,
+    )
+
+
+ORDINARY_VECTOR_BIT_LAYOUT_TYPES = tuple(
+    _bit_layout_type(element_type, lane_count)
+    for element_type in ORDINARY_VECTOR_BIT_LAYOUT_ELEMENT_TYPES
+    for lane_count in ORDINARY_VECTOR_BIT_LAYOUT_LANE_COUNTS
+)
+
+ORDINARY_VECTOR_BIT_LAYOUT_CASES = tuple(
+    OrdinaryVectorBitLayoutCase(source, result)
+    for source in ORDINARY_VECTOR_BIT_LAYOUT_TYPES
+    for result in ORDINARY_VECTOR_BIT_LAYOUT_TYPES
+    if source.total_bit_width == result.total_bit_width
+)
+
+ORDINARY_VECTOR_BIT_LAYOUT_ALIAS_CASES = tuple(
+    case for case in ORDINARY_VECTOR_BIT_LAYOUT_CASES if case.is_identity
+)
+
+ORDINARY_VECTOR_BIT_LAYOUT_DIRECT_CASES = tuple(
+    case for case in ORDINARY_VECTOR_BIT_LAYOUT_CASES if not case.is_identity
+)
+
+_SCALAR_BITCASTS_BY_KEY = {row.key: row for row in SCALAR_BITCAST_CONVERSIONS}
+if len(_SCALAR_BITCASTS_BY_KEY) != len(SCALAR_BITCAST_CONVERSIONS):
+    raise ValueError("scalar bitcast descriptor keys must be unique")
+
+ORDINARY_VECTOR_BIT_LAYOUT_REUSED_SCALAR_CASES = tuple(
+    case
+    for case in ORDINARY_VECTOR_BIT_LAYOUT_DIRECT_CASES
+    if case.key in _SCALAR_BITCASTS_BY_KEY
+)
+if {
+    case.key for case in ORDINARY_VECTOR_BIT_LAYOUT_REUSED_SCALAR_CASES
+} != _SCALAR_BITCASTS_BY_KEY.keys():
+    raise ValueError("scalar bitcast descriptors must match selected v1 cases")
+for case in ORDINARY_VECTOR_BIT_LAYOUT_REUSED_SCALAR_CASES:
+    scalar_row = _SCALAR_BITCASTS_BY_KEY[case.key]
+    if (
+        scalar_row.display_mnemonic
+        != f"OpBitcast.{case.source.suffix}.{case.result.suffix}"
+        or scalar_row.feature_bits != case.feature_bits
+    ):
+        raise ValueError("scalar bitcast descriptor must match its v1 case")
+
+ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTION_CASES = tuple(
+    case
+    for case in ORDINARY_VECTOR_BIT_LAYOUT_DIRECT_CASES
+    if case.key not in _SCALAR_BITCASTS_BY_KEY
+)
+
+ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTIONS = tuple(
+    case.instruction for case in ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTION_CASES
+)

--- a/loom/py/loom/target/arch/spirv/ordinary_vector_bit_layout_test.py
+++ b/loom/py/loom/target/arch/spirv/ordinary_vector_bit_layout_test.py
@@ -1,0 +1,168 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from collections import Counter
+
+import pytest
+
+from loom.target.arch.spirv.ordinary_vector import (
+    ORDINARY_VECTOR_INSTRUCTIONS,
+    OrdinaryVectorComponentKind,
+    OrdinaryVectorType,
+)
+from loom.target.arch.spirv.ordinary_vector_bit_layout import (
+    ORDINARY_VECTOR_BIT_LAYOUT_ALIAS_CASES,
+    ORDINARY_VECTOR_BIT_LAYOUT_CASES,
+    ORDINARY_VECTOR_BIT_LAYOUT_DIRECT_CASES,
+    ORDINARY_VECTOR_BIT_LAYOUT_ELEMENT_TYPES,
+    ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTION_CASES,
+    ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTIONS,
+    ORDINARY_VECTOR_BIT_LAYOUT_LANE_COUNTS,
+    ORDINARY_VECTOR_BIT_LAYOUT_REUSED_SCALAR_CASES,
+    ORDINARY_VECTOR_BIT_LAYOUT_TYPES,
+    OrdinaryVectorBitLayoutCase,
+)
+from loom.target.arch.spirv.ordinary_vector_integer import (
+    ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
+)
+from loom.target.arch.spirv.ordinary_vector_integer_conversion import (
+    ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS,
+)
+from loom.target.arch.spirv.scalar_conversion import SCALAR_BITCAST_CONVERSIONS
+
+
+def test_bit_layout_type_matrix_has_one_exact_representation_per_source() -> None:
+    assert len(ORDINARY_VECTOR_BIT_LAYOUT_TYPES) == 32
+    assert {
+        (value_type.element_type, value_type.lane_count)
+        for value_type in ORDINARY_VECTOR_BIT_LAYOUT_TYPES
+    } == {
+        (element_type, lane_count)
+        for element_type in ORDINARY_VECTOR_BIT_LAYOUT_ELEMENT_TYPES
+        for lane_count in ORDINARY_VECTOR_BIT_LAYOUT_LANE_COUNTS
+    }
+
+    for value_type in ORDINARY_VECTOR_BIT_LAYOUT_TYPES:
+        assert value_type.component_type.kind in {
+            OrdinaryVectorComponentKind.SIGNED_INTEGER,
+            OrdinaryVectorComponentKind.FLOAT,
+        }
+        assert value_type.total_bit_width == (
+            value_type.lane_count * value_type.component_type.bit_width
+        )
+        if value_type.lane_count == 1:
+            assert value_type.value_type is value_type.component_type
+            assert value_type.suffix == value_type.component_type.suffix
+        else:
+            assert isinstance(value_type.value_type, OrdinaryVectorType)
+            assert value_type.value_type.lane_count == value_type.lane_count
+            assert value_type.suffix.startswith(f"v{value_type.lane_count}")
+
+
+def test_bit_layout_cases_are_the_exact_equal_total_bit_product() -> None:
+    assert len(ORDINARY_VECTOR_BIT_LAYOUT_CASES) == 140
+    assert len(ORDINARY_VECTOR_BIT_LAYOUT_ALIAS_CASES) == 32
+    assert len(ORDINARY_VECTOR_BIT_LAYOUT_DIRECT_CASES) == 108
+    assert {
+        (case.source, case.result) for case in ORDINARY_VECTOR_BIT_LAYOUT_CASES
+    } == {
+        (source, result)
+        for source in ORDINARY_VECTOR_BIT_LAYOUT_TYPES
+        for result in ORDINARY_VECTOR_BIT_LAYOUT_TYPES
+        if source.total_bit_width == result.total_bit_width
+    }
+    assert Counter(
+        case.source.total_bit_width for case in ORDINARY_VECTOR_BIT_LAYOUT_DIRECT_CASES
+    ) == {
+        16: 12,
+        32: 30,
+        48: 6,
+        64: 42,
+        96: 2,
+        128: 12,
+        192: 2,
+        256: 2,
+    }
+    assert {case.source for case in ORDINARY_VECTOR_BIT_LAYOUT_ALIAS_CASES} == (
+        set(ORDINARY_VECTOR_BIT_LAYOUT_TYPES)
+    )
+    assert all(
+        case.source == case.result for case in ORDINARY_VECTOR_BIT_LAYOUT_ALIAS_CASES
+    )
+
+
+def test_bit_layout_reuses_every_existing_scalar_descriptor() -> None:
+    assert len(SCALAR_BITCAST_CONVERSIONS) == 6
+    assert len(ORDINARY_VECTOR_BIT_LAYOUT_REUSED_SCALAR_CASES) == 6
+    assert {case.key for case in ORDINARY_VECTOR_BIT_LAYOUT_REUSED_SCALAR_CASES} == {
+        row.key for row in SCALAR_BITCAST_CONVERSIONS
+    }
+    assert all(
+        case.source.lane_count == 1 and case.result.lane_count == 1
+        for case in ORDINARY_VECTOR_BIT_LAYOUT_REUSED_SCALAR_CASES
+    )
+    scalar_rows_by_key = {row.key: row for row in SCALAR_BITCAST_CONVERSIONS}
+    for case in ORDINARY_VECTOR_BIT_LAYOUT_REUSED_SCALAR_CASES:
+        scalar_row = scalar_rows_by_key[case.key]
+        assert scalar_row.display_mnemonic == (
+            f"OpBitcast.{case.source.suffix}.{case.result.suffix}"
+        )
+        assert scalar_row.feature_bits == case.feature_bits
+
+
+def test_bit_layout_instruction_rows_are_exact_and_unique() -> None:
+    assert len(ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTION_CASES) == 102
+    assert len(ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTIONS) == 102
+
+    keys = tuple(row.key for row in ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTIONS)
+    assert len(set(keys)) == len(keys)
+    assert set(keys).isdisjoint(
+        row.key
+        for row in (
+            *ORDINARY_VECTOR_INSTRUCTIONS,
+            *ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
+            *ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS,
+        )
+    )
+    assert set(keys).isdisjoint(row.key for row in SCALAR_BITCAST_CONVERSIONS)
+
+    for case, instruction in zip(
+        ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTION_CASES,
+        ORDINARY_VECTOR_BIT_LAYOUT_INSTRUCTIONS,
+        strict=True,
+    ):
+        assert instruction == case.instruction
+        assert instruction.key == case.key
+        assert instruction.mnemonic == (
+            f"OpBitcast.{case.source.suffix}.{case.result.suffix}"
+        )
+        assert instruction.opcode == "LOOM_SPIRV_OP_BITCAST"
+        assert instruction.packet_form == "LOOM_SPIRV_PACKET_FORM_UNARY_TYPED"
+        assert instruction.result_type == case.result.value_type
+        assert instruction.operand_names == ("input",)
+        assert instruction.operand_types == (case.source.value_type,)
+        assert instruction.feature_bits == case.feature_bits
+
+
+def test_identity_bit_layout_cases_have_no_instruction() -> None:
+    for case in ORDINARY_VECTOR_BIT_LAYOUT_ALIAS_CASES:
+        with pytest.raises(ValueError, match="alias their input"):
+            _ = case.instruction
+
+
+def test_bit_layout_case_rejects_unequal_total_widths() -> None:
+    source = next(
+        value_type
+        for value_type in ORDINARY_VECTOR_BIT_LAYOUT_TYPES
+        if value_type.element_type == "i8" and value_type.lane_count == 1
+    )
+    result = next(
+        value_type
+        for value_type in ORDINARY_VECTOR_BIT_LAYOUT_TYPES
+        if value_type.element_type == "i16" and value_type.lane_count == 1
+    )
+    with pytest.raises(ValueError, match="equal total bit widths"):
+        OrdinaryVectorBitLayoutCase(source, result)

--- a/loom/py/loom/target/arch/spirv/ordinary_vector_integer_conversion.py
+++ b/loom/py/loom/target/arch/spirv/ordinary_vector_integer_conversion.py
@@ -1,0 +1,135 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Source-of-truth rows for native SPIR-V vector integer conversions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loom.target.arch.spirv.ordinary_vector import (
+    NATIVE_ORDINARY_VECTOR_LANE_COUNTS,
+    OrdinaryVectorInstruction,
+    OrdinaryVectorType,
+)
+from loom.target.arch.spirv.ordinary_vector_integer import (
+    ORDINARY_VECTOR_INTEGER_TYPE_PAIRS,
+)
+from loom.target.arch.spirv.scalar_alu import ScalarAluType
+from loom.target.arch.spirv.scalar_conversion import (
+    SIGNED_INTEGER_WIDTH_CONVERSIONS,
+    UNSIGNED_INTEGER_WIDTH_CONVERSIONS,
+    ScalarConversion,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OrdinaryVectorIntegerConversion:
+    """One scalar integer conversion lifted to a native vector type pair."""
+
+    scalar_conversion: ScalarConversion
+    source_type: OrdinaryVectorType
+    result_type: OrdinaryVectorType
+
+    def __post_init__(self) -> None:
+        if self.source_type.lane_count != self.result_type.lane_count:
+            raise ValueError("ordinary-vector conversion lane counts must match")
+        for scalar_type, vector_type in (
+            (self.scalar_conversion.source_type, self.source_type),
+            (self.scalar_conversion.result_type, self.result_type),
+        ):
+            component_type = vector_type.component_type
+            if component_type.suffix != scalar_type.suffix:
+                raise ValueError("scalar and vector conversion types must correspond")
+            if component_type.scalar_enum != scalar_type.scalar_enum:
+                raise ValueError("scalar and vector conversion encodings must match")
+            if component_type.feature_atoms != scalar_type.feature_atoms:
+                raise ValueError("scalar and vector conversion features must match")
+
+    @property
+    def instruction(self) -> OrdinaryVectorInstruction:
+        scalar_conversion = self.scalar_conversion
+        return OrdinaryVectorInstruction(
+            key=(
+                f"spirv.op_{scalar_conversion.descriptor_suffix}."
+                f"{self.source_type.suffix}.{self.result_type.suffix}"
+            ),
+            mnemonic=(
+                f"{scalar_conversion.mnemonic}."
+                f"{self.source_type.suffix}.{self.result_type.suffix}"
+            ),
+            opcode=scalar_conversion.opcode,
+            packet_form="LOOM_SPIRV_PACKET_FORM_UNARY_TYPED",
+            result_type=self.result_type,
+            operand_names=("input",),
+            operand_types=(self.source_type,),
+        )
+
+
+_INTEGER_VECTOR_TYPES_BY_SCALAR_SUFFIX_AND_LANE = {
+    (vector_type.component_type.suffix, type_pair.lane_count): vector_type
+    for type_pair in ORDINARY_VECTOR_INTEGER_TYPE_PAIRS
+    for vector_type in (type_pair.signed, type_pair.unsigned)
+}
+if len(_INTEGER_VECTOR_TYPES_BY_SCALAR_SUFFIX_AND_LANE) != (
+    2 * len(ORDINARY_VECTOR_INTEGER_TYPE_PAIRS)
+):
+    raise ValueError("integer vector scalar suffix and lane pairs must be unique")
+
+
+def _integer_vector_type(
+    scalar_type: ScalarAluType,
+    lane_count: int,
+) -> OrdinaryVectorType:
+    vector_type = _INTEGER_VECTOR_TYPES_BY_SCALAR_SUFFIX_AND_LANE.get(
+        (scalar_type.suffix, lane_count)
+    )
+    if vector_type is None:
+        raise ValueError(
+            f"{scalar_type.suffix}: missing v{lane_count} integer vector type"
+        )
+    return vector_type
+
+
+def _lift_integer_conversion(
+    scalar_conversion: ScalarConversion,
+) -> tuple[OrdinaryVectorIntegerConversion, ...]:
+    return tuple(
+        OrdinaryVectorIntegerConversion(
+            scalar_conversion=scalar_conversion,
+            source_type=_integer_vector_type(
+                scalar_conversion.source_type,
+                lane_count,
+            ),
+            result_type=_integer_vector_type(
+                scalar_conversion.result_type,
+                lane_count,
+            ),
+        )
+        for lane_count in NATIVE_ORDINARY_VECTOR_LANE_COUNTS
+    )
+
+
+SIGNED_ORDINARY_VECTOR_INTEGER_CONVERSIONS = tuple(
+    vector_conversion
+    for scalar_conversion in SIGNED_INTEGER_WIDTH_CONVERSIONS
+    for vector_conversion in _lift_integer_conversion(scalar_conversion)
+)
+
+UNSIGNED_ORDINARY_VECTOR_INTEGER_CONVERSIONS = tuple(
+    vector_conversion
+    for scalar_conversion in UNSIGNED_INTEGER_WIDTH_CONVERSIONS
+    for vector_conversion in _lift_integer_conversion(scalar_conversion)
+)
+
+ORDINARY_VECTOR_INTEGER_CONVERSIONS = (
+    *SIGNED_ORDINARY_VECTOR_INTEGER_CONVERSIONS,
+    *UNSIGNED_ORDINARY_VECTOR_INTEGER_CONVERSIONS,
+)
+
+ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS = tuple(
+    conversion.instruction for conversion in ORDINARY_VECTOR_INTEGER_CONVERSIONS
+)

--- a/loom/py/loom/target/arch/spirv/ordinary_vector_integer_conversion_test.py
+++ b/loom/py/loom/target/arch/spirv/ordinary_vector_integer_conversion_test.py
@@ -1,0 +1,135 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from collections import Counter
+
+from loom.target.arch.spirv.ordinary_vector import (
+    NATIVE_ORDINARY_VECTOR_LANE_COUNTS,
+    ORDINARY_VECTOR_INSTRUCTIONS,
+    OrdinaryVectorComponentKind,
+)
+from loom.target.arch.spirv.ordinary_vector_integer import (
+    ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
+)
+from loom.target.arch.spirv.ordinary_vector_integer_conversion import (
+    ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS,
+    ORDINARY_VECTOR_INTEGER_CONVERSIONS,
+    SIGNED_ORDINARY_VECTOR_INTEGER_CONVERSIONS,
+    UNSIGNED_ORDINARY_VECTOR_INTEGER_CONVERSIONS,
+)
+from loom.target.arch.spirv.scalar_conversion import (
+    SIGNED_INTEGER_WIDTH_CONVERSIONS,
+    UNSIGNED_INTEGER_WIDTH_CONVERSIONS,
+)
+
+
+def test_integer_conversion_matrix_is_the_exact_scalar_lane_cross_product() -> None:
+    assert len(SIGNED_INTEGER_WIDTH_CONVERSIONS) == 12
+    assert len(UNSIGNED_INTEGER_WIDTH_CONVERSIONS) == 6
+    assert len(SIGNED_ORDINARY_VECTOR_INTEGER_CONVERSIONS) == 36
+    assert len(UNSIGNED_ORDINARY_VECTOR_INTEGER_CONVERSIONS) == 18
+    assert len(ORDINARY_VECTOR_INTEGER_CONVERSIONS) == 54
+
+    assert {
+        (conversion.scalar_conversion, conversion.source_type.lane_count)
+        for conversion in SIGNED_ORDINARY_VECTOR_INTEGER_CONVERSIONS
+    } == {
+        (scalar_conversion, lane_count)
+        for scalar_conversion in SIGNED_INTEGER_WIDTH_CONVERSIONS
+        for lane_count in NATIVE_ORDINARY_VECTOR_LANE_COUNTS
+    }
+    assert {
+        (conversion.scalar_conversion, conversion.source_type.lane_count)
+        for conversion in UNSIGNED_ORDINARY_VECTOR_INTEGER_CONVERSIONS
+    } == {
+        (scalar_conversion, lane_count)
+        for scalar_conversion in UNSIGNED_INTEGER_WIDTH_CONVERSIONS
+        for lane_count in NATIVE_ORDINARY_VECTOR_LANE_COUNTS
+    }
+
+
+def test_integer_conversion_rows_preserve_semantics_and_native_types() -> None:
+    for conversion in SIGNED_ORDINARY_VECTOR_INTEGER_CONVERSIONS:
+        assert conversion.source_type.component_type.kind == (
+            OrdinaryVectorComponentKind.SIGNED_INTEGER
+        )
+        assert conversion.result_type.component_type.kind == (
+            OrdinaryVectorComponentKind.SIGNED_INTEGER
+        )
+        source_width = conversion.source_type.component_type.bit_width
+        result_width = conversion.result_type.component_type.bit_width
+        if conversion.scalar_conversion.source_op_key == "extsi":
+            assert source_width < result_width
+        else:
+            assert conversion.scalar_conversion.source_op_key == "trunci"
+            assert source_width > result_width
+
+    for conversion in UNSIGNED_ORDINARY_VECTOR_INTEGER_CONVERSIONS:
+        assert conversion.scalar_conversion.source_op_key == "extui"
+        assert conversion.source_type.component_type.kind == (
+            OrdinaryVectorComponentKind.UNSIGNED_INTEGER
+        )
+        assert conversion.result_type.component_type.kind == (
+            OrdinaryVectorComponentKind.UNSIGNED_INTEGER
+        )
+        assert (
+            conversion.source_type.component_type.bit_width
+            < conversion.result_type.component_type.bit_width
+        )
+
+    for conversion in ORDINARY_VECTOR_INTEGER_CONVERSIONS:
+        scalar_conversion = conversion.scalar_conversion
+        assert conversion.source_type.lane_count == conversion.result_type.lane_count
+        assert conversion.source_type.component_type.suffix == (
+            scalar_conversion.source_type.suffix
+        )
+        assert conversion.result_type.component_type.suffix == (
+            scalar_conversion.result_type.suffix
+        )
+        assert conversion.instruction.feature_bits == scalar_conversion.feature_bits
+
+
+def test_integer_conversion_instructions_are_exact_and_unique() -> None:
+    assert len(ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS) == 54
+    instruction_keys = tuple(
+        instruction.key
+        for instruction in ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS
+    )
+    assert len(set(instruction_keys)) == len(instruction_keys)
+    assert set(instruction_keys).isdisjoint(
+        instruction.key
+        for instruction in (
+            *ORDINARY_VECTOR_INSTRUCTIONS,
+            *ORDINARY_VECTOR_INTEGER_INSTRUCTIONS,
+        )
+    )
+    assert Counter(
+        instruction.opcode
+        for instruction in ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS
+    ) == {
+        "LOOM_SPIRV_OP_S_CONVERT": 36,
+        "LOOM_SPIRV_OP_U_CONVERT": 18,
+    }
+
+    for conversion, instruction in zip(
+        ORDINARY_VECTOR_INTEGER_CONVERSIONS,
+        ORDINARY_VECTOR_INTEGER_CONVERSION_INSTRUCTIONS,
+        strict=True,
+    ):
+        assert instruction == conversion.instruction
+        assert instruction.packet_form == "LOOM_SPIRV_PACKET_FORM_UNARY_TYPED"
+        assert instruction.key == (
+            f"spirv.op_{conversion.scalar_conversion.descriptor_suffix}."
+            f"{conversion.source_type.suffix}.{conversion.result_type.suffix}"
+        )
+        assert instruction.mnemonic == (
+            f"{conversion.scalar_conversion.mnemonic}."
+            f"{conversion.source_type.suffix}.{conversion.result_type.suffix}"
+        )
+        assert instruction.opcode == conversion.scalar_conversion.opcode
+        assert instruction.result_type == conversion.result_type
+        assert instruction.operand_names == ("input",)
+        assert instruction.operand_types == (conversion.source_type,)

--- a/loom/py/loom/target/arch/spirv/scalar_conversion.py
+++ b/loom/py/loom/target/arch/spirv/scalar_conversion.py
@@ -252,13 +252,14 @@ def _bitcast_conversions() -> tuple[ScalarConversion, ...]:
 
 SIGNED_INTEGER_WIDTH_CONVERSIONS = _integer_width_conversions()
 UNSIGNED_INTEGER_WIDTH_CONVERSIONS = _unsigned_integer_width_conversions()
+SCALAR_BITCAST_CONVERSIONS = _bitcast_conversions()
 
 DIRECT_SCALAR_CONVERSIONS = (
     *SIGNED_INTEGER_WIDTH_CONVERSIONS,
     *_float_width_conversions(),
     *_signed_integer_to_float_conversions(),
     *_float_to_signed_integer_conversions(),
-    *_bitcast_conversions(),
+    *SCALAR_BITCAST_CONVERSIONS,
 )
 
 UNSIGNED_SCALAR_CONVERSIONS = (

--- a/loom/py/loom/target/arch/spirv/scalar_conversion.py
+++ b/loom/py/loom/target/arch/spirv/scalar_conversion.py
@@ -250,8 +250,11 @@ def _bitcast_conversions() -> tuple[ScalarConversion, ...]:
     return tuple(rows)
 
 
+SIGNED_INTEGER_WIDTH_CONVERSIONS = _integer_width_conversions()
+UNSIGNED_INTEGER_WIDTH_CONVERSIONS = _unsigned_integer_width_conversions()
+
 DIRECT_SCALAR_CONVERSIONS = (
-    *_integer_width_conversions(),
+    *SIGNED_INTEGER_WIDTH_CONVERSIONS,
     *_float_width_conversions(),
     *_signed_integer_to_float_conversions(),
     *_float_to_signed_integer_conversions(),
@@ -259,7 +262,7 @@ DIRECT_SCALAR_CONVERSIONS = (
 )
 
 UNSIGNED_SCALAR_CONVERSIONS = (
-    *_unsigned_integer_width_conversions(),
+    *UNSIGNED_INTEGER_WIDTH_CONVERSIONS,
     *_unsigned_integer_to_float_conversions(),
     *_float_to_unsigned_integer_conversions(),
 )

--- a/loom/src/loom/target/emit/spirv/BUILD.bazel
+++ b/loom/src/loom/target/emit/spirv/BUILD.bazel
@@ -251,6 +251,7 @@ loom_check_test_suite(
         "test/memory_scalar_addressing.loom-test",
         "test/memory_workgroup_scalar_addressing.loom-test",
         "test/ordinary_vector_integer.loom-test",
+        "test/ordinary_vector_integer_conversion.loom-test",
         "test/ordinary_vector_structure.loom-test",
         "test/source_ordinary_vector_structure.loom-test",
         "test/source_structured_control.loom-test",

--- a/loom/src/loom/target/emit/spirv/BUILD.bazel
+++ b/loom/src/loom/target/emit/spirv/BUILD.bazel
@@ -250,6 +250,7 @@ loom_check_test_suite(
         "test/integer_boolean.loom-test",
         "test/memory_scalar_addressing.loom-test",
         "test/memory_workgroup_scalar_addressing.loom-test",
+        "test/ordinary_vector_bit_layout.loom-test",
         "test/ordinary_vector_integer.loom-test",
         "test/ordinary_vector_integer_conversion.loom-test",
         "test/ordinary_vector_structure.loom-test",

--- a/loom/src/loom/target/emit/spirv/CMakeLists.txt
+++ b/loom/src/loom/target/emit/spirv/CMakeLists.txt
@@ -289,6 +289,7 @@ loom_check_test_suite(
     "test/memory_scalar_addressing.loom-test"
     "test/memory_workgroup_scalar_addressing.loom-test"
     "test/ordinary_vector_integer.loom-test"
+    "test/ordinary_vector_integer_conversion.loom-test"
     "test/ordinary_vector_structure.loom-test"
     "test/source_ordinary_vector_structure.loom-test"
     "test/source_structured_control.loom-test"

--- a/loom/src/loom/target/emit/spirv/CMakeLists.txt
+++ b/loom/src/loom/target/emit/spirv/CMakeLists.txt
@@ -288,6 +288,7 @@ loom_check_test_suite(
     "test/integer_boolean.loom-test"
     "test/memory_scalar_addressing.loom-test"
     "test/memory_workgroup_scalar_addressing.loom-test"
+    "test/ordinary_vector_bit_layout.loom-test"
     "test/ordinary_vector_integer.loom-test"
     "test/ordinary_vector_integer_conversion.loom-test"
     "test/ordinary_vector_structure.loom-test"

--- a/loom/src/loom/target/emit/spirv/test/ordinary_vector_bit_layout.loom-test
+++ b/loom/src/loom/target/emit/spirv/test/ordinary_vector_bit_layout.loom-test
@@ -1,0 +1,123 @@
+// RUN: emit spirv-dis validate
+// REQUIRES: spirv-dis, spirv-val
+
+spirv.target<vulkan1_3> @target
+
+low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) @ordinary_vector_bit_layout() asm {
+  %one = OpConstant.i32 1
+  %two = OpConstant.i32 2
+  %three = OpConstant.i32 3
+  %four = OpConstant.i32 4
+
+  %lane_change_source = OpCompositeConstruct.v4i32 %one, %two, %three, %four
+  %lane_change_packed = OpBitcast.v4i32.v2i64 %lane_change_source
+  %lane_change_result = OpBitcast.v2i64.v4i32 %lane_change_packed
+  %lane_change_first = OpCompositeExtract.v4i32.i32 %lane_change_result, 0
+  %lane_change_last = OpCompositeExtract.v4i32.i32 %lane_change_result, 3
+
+  %scalar_change_source = OpCompositeConstruct.v2i32 %one, %two
+  %scalar_change_packed = OpBitcast.v2i32.i64 %scalar_change_source
+  %scalar_change_result = OpBitcast.i64.v2i32 %scalar_change_packed
+  %scalar_change_last = OpCompositeExtract.v2i32.i32 %scalar_change_result, 1
+
+  %same_lanes_source = OpCompositeConstruct.v3i32 %one, %two, %three
+  %same_lanes_float = OpBitcast.v3i32.v3f32 %same_lanes_source
+  %same_lanes_result = OpBitcast.v3f32.v3i32 %same_lanes_float
+  %same_lanes_last = OpCompositeExtract.v3i32.i32 %same_lanes_result, 2
+
+  %first_ok = OpIEqual %lane_change_first, %one
+  %last_ok = OpIEqual %lane_change_last, %four
+  %scalar_change_ok = OpIEqual %scalar_change_last, %two
+  %same_lanes_ok = OpIEqual %same_lanes_last, %three
+  %lane_change_ok = OpLogicalAnd.bool %first_ok, %last_ok
+  %shape_change_ok = OpLogicalAnd.bool %lane_change_ok, %scalar_change_ok
+  %all_ok = OpLogicalAnd.bool %shape_change_ok, %same_lanes_ok
+  low.scf.if %all_ok {
+    OpControlBarrier.workgroup.workgroup.acq_rel
+  }
+  return
+}
+
+// ----
+               OpCapability Shader
+               OpCapability VulkanMemoryModel
+               OpCapability PhysicalStorageBufferAddresses
+               OpCapability Int64
+               OpExtension "SPV_KHR_vulkan_memory_model"
+               OpExtension "SPV_KHR_physical_storage_buffer"
+               OpMemoryModel PhysicalStorageBuffer64 Vulkan
+               OpEntryPoint GLCompute %ordinary_vector_bit_layout "ordinary_vector_bit_layout"
+               OpExecutionMode %ordinary_vector_bit_layout LocalSize 1 1 1
+               OpName %ordinary_vector_bit_layout "ordinary_vector_bit_layout"
+               OpName %one "one"
+               OpName %two "two"
+               OpName %three "three"
+               OpName %four "four"
+               OpName %lane_change_source "lane_change_source"
+               OpName %lane_change_packed "lane_change_packed"
+               OpName %lane_change_result "lane_change_result"
+               OpName %lane_change_first "lane_change_first"
+               OpName %lane_change_last "lane_change_last"
+               OpName %scalar_change_source "scalar_change_source"
+               OpName %scalar_change_packed "scalar_change_packed"
+               OpName %scalar_change_result "scalar_change_result"
+               OpName %scalar_change_last "scalar_change_last"
+               OpName %same_lanes_source "same_lanes_source"
+               OpName %same_lanes_float "same_lanes_float"
+               OpName %same_lanes_result "same_lanes_result"
+               OpName %same_lanes_last "same_lanes_last"
+               OpName %first_ok "first_ok"
+               OpName %last_ok "last_ok"
+               OpName %scalar_change_ok "scalar_change_ok"
+               OpName %same_lanes_ok "same_lanes_ok"
+               OpName %lane_change_ok "lane_change_ok"
+               OpName %shape_change_ok "shape_change_ok"
+               OpName %all_ok "all_ok"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+        %one = OpConstant %int 1
+        %two = OpConstant %int 2
+      %three = OpConstant %int 3
+       %four = OpConstant %int 4
+      %v4int = OpTypeVector %int 4
+       %long = OpTypeInt 64 1
+     %v2long = OpTypeVector %long 2
+      %v2int = OpTypeVector %int 2
+      %v3int = OpTypeVector %int 3
+      %float = OpTypeFloat 32
+    %v3float = OpTypeVector %float 3
+       %bool = OpTypeBool
+       %uint = OpTypeInt 32 0
+     %uint_2 = OpConstant %uint 2
+   %uint_264 = OpConstant %uint 264
+%ordinary_vector_bit_layout = OpFunction %void None %3
+          %4 = OpLabel
+%lane_change_source = OpCompositeConstruct %v4int %one %two %three %four
+%lane_change_packed = OpBitcast %v2long %lane_change_source
+%lane_change_result = OpBitcast %v4int %lane_change_packed
+%lane_change_first = OpCompositeExtract %int %lane_change_result 0
+%lane_change_last = OpCompositeExtract %int %lane_change_result 3
+%scalar_change_source = OpCompositeConstruct %v2int %one %two
+%scalar_change_packed = OpBitcast %long %scalar_change_source
+%scalar_change_result = OpBitcast %v2int %scalar_change_packed
+%scalar_change_last = OpCompositeExtract %int %scalar_change_result 1
+%same_lanes_source = OpCompositeConstruct %v3int %one %two %three
+%same_lanes_float = OpBitcast %v3float %same_lanes_source
+%same_lanes_result = OpBitcast %v3int %same_lanes_float
+%same_lanes_last = OpCompositeExtract %int %same_lanes_result 2
+   %first_ok = OpIEqual %bool %lane_change_first %one
+    %last_ok = OpIEqual %bool %lane_change_last %four
+%scalar_change_ok = OpIEqual %bool %scalar_change_last %two
+%same_lanes_ok = OpIEqual %bool %same_lanes_last %three
+%lane_change_ok = OpLogicalAnd %bool %first_ok %last_ok
+%shape_change_ok = OpLogicalAnd %bool %lane_change_ok %scalar_change_ok
+     %all_ok = OpLogicalAnd %bool %shape_change_ok %same_lanes_ok
+               OpSelectionMerge %39 None
+               OpBranchConditional %all_ok %38 %39
+         %38 = OpLabel
+               OpControlBarrier %uint_2 %uint_2 %uint_264
+               OpBranch %39
+         %39 = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/loom/src/loom/target/emit/spirv/test/ordinary_vector_integer_conversion.loom-test
+++ b/loom/src/loom/target/emit/spirv/test/ordinary_vector_integer_conversion.loom-test
@@ -1,0 +1,128 @@
+// RUN: emit spirv-dis validate
+// REQUIRES: spirv-dis, spirv-val
+
+spirv.target<vulkan1_3> @target
+
+low.func.def target<spirv.logical.core>(@target) abi(shader_entry_point) @ordinary_vector_integer_conversion() asm {
+  %minus_one_i32 = OpConstant.i32 -1
+  %one_i32 = OpConstant.i32 1
+  %two_i32 = OpConstant.i32 2
+  %three_i32 = OpConstant.i32 3
+  %signed_input = OpCompositeConstruct.v2i32 %minus_one_i32, %two_i32
+  %signed_wide = OpSConvert.v2i32.v2i64 %signed_input
+  %signed_result = OpCompositeExtract.v2i64.i64 %signed_wide, 0
+
+  %one_i64 = OpConstant.i64 1
+  %two_i64 = OpConstant.i64 2
+  %three_i64 = OpConstant.i64 3
+  %wide_input = OpCompositeConstruct.v3i64 %one_i64, %two_i64, %three_i64
+  %narrow = OpSConvert.v3i64.v3i32 %wide_input
+  %narrow_result = OpCompositeExtract.v3i32.i32 %narrow, 2
+
+  %unsigned_signed_input = OpCompositeConstruct.v4i32 %minus_one_i32, %one_i32, %two_i32, %three_i32
+  %unsigned_input = OpBitcast.v4i32.v4u32 %unsigned_signed_input
+  %unsigned_wide = OpUConvert.v4u32.v4u64 %unsigned_input
+  %unsigned_signed_wide = OpBitcast.v4u64.v4i64 %unsigned_wide
+  %unsigned_result = OpCompositeExtract.v4i64.i64 %unsigned_signed_wide, 0
+
+  %expected_signed = OpConstant.i64 -1
+  %expected_unsigned = OpConstant.i64 4294967295
+  %signed_ok = OpIEqual.i64 %signed_result, %expected_signed
+  %narrow_ok = OpIEqual %narrow_result, %three_i32
+  %unsigned_ok = OpIEqual.i64 %unsigned_result, %expected_unsigned
+  %signed_and_narrow_ok = OpLogicalAnd.bool %signed_ok, %narrow_ok
+  %all_ok = OpLogicalAnd.bool %signed_and_narrow_ok, %unsigned_ok
+  low.scf.if %all_ok {
+    OpControlBarrier.workgroup.workgroup.acq_rel
+  }
+  return
+}
+
+// ----
+               OpCapability Shader
+               OpCapability VulkanMemoryModel
+               OpCapability PhysicalStorageBufferAddresses
+               OpCapability Int64
+               OpExtension "SPV_KHR_vulkan_memory_model"
+               OpExtension "SPV_KHR_physical_storage_buffer"
+               OpMemoryModel PhysicalStorageBuffer64 Vulkan
+               OpEntryPoint GLCompute %ordinary_vector_integer_conversion "ordinary_vector_integer_conversion"
+               OpExecutionMode %ordinary_vector_integer_conversion LocalSize 1 1 1
+               OpName %ordinary_vector_integer_conversion "ordinary_vector_integer_conversion"
+               OpName %minus_one_i32 "minus_one_i32"
+               OpName %one_i32 "one_i32"
+               OpName %two_i32 "two_i32"
+               OpName %three_i32 "three_i32"
+               OpName %signed_input "signed_input"
+               OpName %signed_wide "signed_wide"
+               OpName %signed_result "signed_result"
+               OpName %one_i64 "one_i64"
+               OpName %two_i64 "two_i64"
+               OpName %three_i64 "three_i64"
+               OpName %wide_input "wide_input"
+               OpName %narrow "narrow"
+               OpName %narrow_result "narrow_result"
+               OpName %unsigned_signed_input "unsigned_signed_input"
+               OpName %unsigned_input "unsigned_input"
+               OpName %unsigned_wide "unsigned_wide"
+               OpName %unsigned_signed_wide "unsigned_signed_wide"
+               OpName %unsigned_result "unsigned_result"
+               OpName %expected_signed "expected_signed"
+               OpName %expected_unsigned "expected_unsigned"
+               OpName %signed_ok "signed_ok"
+               OpName %narrow_ok "narrow_ok"
+               OpName %unsigned_ok "unsigned_ok"
+               OpName %signed_and_narrow_ok "signed_and_narrow_ok"
+               OpName %all_ok "all_ok"
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+%minus_one_i32 = OpConstant %int -1
+    %one_i32 = OpConstant %int 1
+    %two_i32 = OpConstant %int 2
+  %three_i32 = OpConstant %int 3
+      %v2int = OpTypeVector %int 2
+       %long = OpTypeInt 64 1
+     %v2long = OpTypeVector %long 2
+    %one_i64 = OpConstant %long 1
+    %two_i64 = OpConstant %long 2
+  %three_i64 = OpConstant %long 3
+     %v3long = OpTypeVector %long 3
+      %v3int = OpTypeVector %int 3
+      %v4int = OpTypeVector %int 4
+       %uint = OpTypeInt 32 0
+     %v4uint = OpTypeVector %uint 4
+      %ulong = OpTypeInt 64 0
+    %v4ulong = OpTypeVector %ulong 4
+     %v4long = OpTypeVector %long 4
+%expected_signed = OpConstant %long -1
+%expected_unsigned = OpConstant %long 4294967295
+       %bool = OpTypeBool
+     %uint_2 = OpConstant %uint 2
+   %uint_264 = OpConstant %uint 264
+%ordinary_vector_integer_conversion = OpFunction %void None %3
+          %4 = OpLabel
+%signed_input = OpCompositeConstruct %v2int %minus_one_i32 %two_i32
+%signed_wide = OpSConvert %v2long %signed_input
+%signed_result = OpCompositeExtract %long %signed_wide 0
+ %wide_input = OpCompositeConstruct %v3long %one_i64 %two_i64 %three_i64
+     %narrow = OpSConvert %v3int %wide_input
+%narrow_result = OpCompositeExtract %int %narrow 2
+%unsigned_signed_input = OpCompositeConstruct %v4int %minus_one_i32 %one_i32 %two_i32 %three_i32
+%unsigned_input = OpBitcast %v4uint %unsigned_signed_input
+%unsigned_wide = OpUConvert %v4ulong %unsigned_input
+%unsigned_signed_wide = OpBitcast %v4long %unsigned_wide
+%unsigned_result = OpCompositeExtract %long %unsigned_signed_wide 0
+  %signed_ok = OpIEqual %bool %signed_result %expected_signed
+  %narrow_ok = OpIEqual %bool %narrow_result %three_i32
+%unsigned_ok = OpIEqual %bool %unsigned_result %expected_unsigned
+%signed_and_narrow_ok = OpLogicalAnd %bool %signed_ok %narrow_ok
+     %all_ok = OpLogicalAnd %bool %signed_and_narrow_ok %unsigned_ok
+               OpSelectionMerge %44 None
+               OpBranchConditional %all_ok %43 %44
+         %43 = OpLabel
+               OpControlBarrier %uint_2 %uint_2 %uint_264
+               OpBranch %44
+         %44 = OpLabel
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
Complete SPIR-V's native ordinary-vector conversion surface at target Low for integer width changes and exact equal-width reinterpretation. This closes whole physical operation families rather than adding witness-specific rows: signed extension and truncation across i8/i16/i32/i64, unsigned widening across the same widths, and every legal exact bit-layout pair across integer, F16, BF16, F32, and F64 values.

The representation policy stays uniform across both families. SPIR-V has no one-lane vector, so v1 uses the corresponding scalar target value; v2-v4 remain native vectors. Width conversions preserve lane count. Bit-layout casts may change scalar/vector shape or lane count only when total bit width is equal and the smaller component count divides the larger exactly, matching the SPIR-V `OpBitcast` contract. Identity layout cases alias their input instead of manufacturing an invalid same-type instruction.

## IR Shape

Integer conversions preserve native vector information through signed and target-private unsigned forms:

```loom
%signed_wide = OpSConvert.v2i32.v2i64 %signed_input
%narrow = OpSConvert.v3i64.v3i32 %wide_input

%unsigned_input = OpBitcast.v4i32.v4u32 %signed_input
%unsigned_wide = OpUConvert.v4u32.v4u64 %unsigned_input
%unsigned_as_signed = OpBitcast.v4u64.v4i64 %unsigned_wide
```

Exact layout casts cover same-lane reinterpretation, vector lane repacking, and the scalar/vector boundary without shuffles or component reconstruction:

```loom
%packed = OpBitcast.v4i32.v2i64 %words
%words_again = OpBitcast.v2i64.v4i32 %packed

%scalar = OpBitcast.v2i32.i64 %pair
%pair_again = OpBitcast.i64.v2i32 %scalar

%float_bits = OpBitcast.v3i32.v3f32 %integer_bits
```

## Design

Native integer rows are lifted from the scalar conversion authority and retain their originating scalar semantic. Opcode choice, component types, and feature requirements therefore cannot drift between scalar and vector tables. The complete native matrix contributes 36 signed conversion rows and 18 unsigned widening rows through the existing typed-unary packet form.

The bit-layout authority derives 32 canonical v1-v4 representations from the established SPIR-V component tables and enumerates the exact equal-total-width product. Of 108 non-identity cases, six reuse existing scalar descriptors and 102 become new physical rows; 32 identity cases remain explicit aliases. Generation fails if a reused scalar key, mnemonic, or feature requirement diverges from its canonical v1 case.

Both families use the existing descriptor, packet, and typed-unary emitter contracts. There is no new C emitter branch, scalarization path, lane reconstruction, allocation, or HAL/runtime change. Feature requirements are derived from the operand and result types selected by each instruction.

Source-level expansion remains separate until authored target requirements have their public typed representation. This change adds no private feature snapshot or internal feature ordinal to IR; its boundary is compact, directly authorable target assembly that already emits validated SPIR-V.

## Reviewer Notes

The highest-value review surface is the two Python authorities and their correspondence with generated descriptors and packet rows. The intended invariant is that adding a component type or lane form either participates in the complete legal matrix or fails generation; no per-op list is maintained in parallel.

The scalar/vector `OpBitcast` cases are intentional. SPIR-V explicitly permits numerical scalar/vector reinterpretation when total bit width and component-count divisibility hold, and the structural value-type work lets the existing emitter intern either result shape without special handling.
