### PR TITLE
[Loom] Bind MLP row capacity in quickstart

### DIFF
--- a/loom/README.md
+++ b/loom/README.md
@@ -82,7 +82,8 @@ You can also run the benchmark planner directly:
 ```bash
 python dev.py bazel run //loom/src/loom/tools/iree-benchmark-loom:iree-benchmark-loom -- \
   loom/src/loom/test/corpus/authoring/mlp_down_projection_residual_bf16.loom \
-  --dry-run
+  --dry-run \
+  --config=mlp_down_projection_residual_bf16.row_capacity=3584
 ```
 
 The Bazel HAL driver registry defaults to host-only drivers. On an
@@ -95,6 +96,7 @@ python dev.py bazel run \
   --//runtime/config/hal:drivers=amdgpu,local-sync,local-task,null \
   //loom/src/loom/tools/iree-benchmark-loom:iree-benchmark-loom -- \
   loom/src/loom/test/corpus/authoring/mlp_down_projection_residual_bf16.loom \
+  --config=mlp_down_projection_residual_bf16.row_capacity=3584 \
   --device=amdgpu \
   --measure=dispatch_complete \
   --iterations=1 \


### PR DESCRIPTION
## Summary
- bind the MLP row-capacity config in the direct planner and AMDGPU quickstart commands
- align the README with the canonical Bazel/CMake authoring tests so launch geometry resolves before dispatch

## Test plan
- [x] run the corrected `--dry-run` planner command
- [x] run the corrected AMDGPU correctness-and-timing smoke on an 8x MI350X (`gfx950`) system


Made with [Cursor](https://cursor.com)