### PR TITLE
[Loom] Expose glibc spawn close-from declaration

### DIFF
--- a/loom/src/loom/target/tool/process_linux.c
+++ b/loom/src/loom/target/tool/process_linux.c
@@ -4,6 +4,10 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE 1
+#endif  // _DEFAULT_SOURCE
+
 #include "loom/target/tool/process_platform.h"
 
 #if defined(IREE_PLATFORM_LINUX) || defined(IREE_PLATFORM_ANDROID)


### PR DESCRIPTION
Strict ISO C builds hide glibc's default feature namespace, so the Linux external-tool process path cannot compile its use of `posix_spawn_file_actions_addclosefrom_np` even when the libc provides it.

Define `_DEFAULT_SOURCE` before the first header in `process_linux.c`. This is the narrow glibc contract that exposes the declaration through `__USE_MISC`, unlike the broader `_GNU_SOURCE`, and scopes it to the only translation unit consuming the extension. The glibc 2.34 capability check, older-libc fallback, and descriptor inheritance behavior remain unchanged.

This supersedes #312 while preserving its report and attribution. Thanks @dan-garvey for finding the strict-build failure.