### PR TITLE
[HAL/AMDGPU] Split ASAN shadow writes across VMM slabs

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
@@ -356,6 +356,53 @@ TEST_F(AllocatorTest, AsanHostLocalShadowBackingMapsPinnedHostSlabs) {
   EXPECT_EQ(shadow_byte, kHeapRedzoneShadowValue);
 }
 
+TEST_F(AllocatorTest, AsanShadowWritesSplitPhysicalSlabs) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.asan.enabled = 1;
+  options.asan.shadow_slab_size = 2 * 1024 * 1024;
+  options.asan.quarantine_size = 0;
+  if (const char* reason = QueryHostIncompatibilityReason(&options)) {
+    GTEST_SKIP() << reason;
+  }
+
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.InitializeWithOptions(
+      &options, &libhsa_, &topology_, host_allocator_));
+
+  iree_hal_amdgpu_asan_state_t* asan_state =
+      &test_device.logical_device()->asan;
+  iree_hal_amdgpu_shadow_map_t* shadow_map =
+      iree_hal_amdgpu_asan_state_shadow_map(asan_state);
+  ASSERT_NE(shadow_map, nullptr);
+
+  // Publish a small application range whose shadow bytes straddle two
+  // independently backed physical slabs. Both publication and release must
+  // split their HSA memory operations at the slab boundary.
+  const iree_device_size_t shadow_granule = (iree_device_size_t)1ull
+                                            << shadow_map->shadow_scale_shift;
+  const uint64_t owned_application_base =
+      reinterpret_cast<uintptr_t>(asan_state->owned_application_base_ptr);
+  const uint64_t owned_shadow_offset =
+      owned_application_base >> shadow_map->shadow_scale_shift;
+  const uint64_t slab_boundary_shadow_offset =
+      iree_device_align(owned_shadow_offset + 4, shadow_map->slab_size);
+  const uint64_t application_address = (slab_boundary_shadow_offset - 4)
+                                       << shadow_map->shadow_scale_shift;
+  const iree_device_size_t application_length = 8 * shadow_granule;
+  ASSERT_LE(application_address,
+            owned_application_base + asan_state->owned_application_size);
+  ASSERT_LE(application_length, owned_application_base +
+                                    asan_state->owned_application_size -
+                                    application_address);
+
+  IREE_ASSERT_OK(iree_hal_amdgpu_asan_state_publish_allocated_range(
+      asan_state, application_address, application_length, application_address,
+      application_length));
+  iree_hal_amdgpu_asan_state_publish_released_range(
+      asan_state, application_address, application_length);
+}
+
 TEST_F(AllocatorTest,
        AsanDeviceLocalAllocationQuarantinesReleasedApplicationRange) {
   iree_hal_amdgpu_logical_device_options_t options;

--- a/runtime/src/iree/hal/drivers/amdgpu/asan_state.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/asan_state.c
@@ -29,7 +29,10 @@ static uint32_t iree_hal_amdgpu_asan_shadow_fill_pattern(uint8_t value) {
          ((uint32_t)value << 8) | (uint32_t)value;
 }
 
-static iree_status_t iree_hal_amdgpu_asan_write_shadow_bytes(
+// Writes bytes contained within one physical shadow slab. Shadow slabs occupy
+// contiguous virtual addresses but may be backed by independent HSA VMM
+// allocations, so an HSA memory operation must never cross a slab boundary.
+static iree_status_t iree_hal_amdgpu_asan_write_shadow_slab_bytes(
     iree_hal_amdgpu_asan_state_t* state, uint64_t shadow_address,
     iree_device_size_t length, uint8_t value) {
   if (length == 0) return iree_ok_status();
@@ -70,7 +73,25 @@ static iree_status_t iree_hal_amdgpu_asan_write_shadow_bytes(
   return iree_ok_status();
 }
 
-static void iree_hal_amdgpu_asan_write_shadow_bytes_raw(
+static iree_status_t iree_hal_amdgpu_asan_write_shadow_bytes(
+    iree_hal_amdgpu_asan_state_t* state, uint64_t shadow_address,
+    iree_device_size_t length, uint8_t value) {
+  const uint64_t shadow_base =
+      (uint64_t)(uintptr_t)state->shadow_map.reservation_base_ptr;
+  while (length > 0) {
+    const iree_device_size_t slab_offset =
+        (shadow_address - shadow_base) % state->shadow_map.slab_size;
+    const iree_device_size_t slab_length =
+        iree_min(length, state->shadow_map.slab_size - slab_offset);
+    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_asan_write_shadow_slab_bytes(
+        state, shadow_address, slab_length, value));
+    shadow_address += slab_length;
+    length -= slab_length;
+  }
+  return iree_ok_status();
+}
+
+static void iree_hal_amdgpu_asan_write_shadow_slab_bytes_raw(
     iree_hal_amdgpu_asan_state_t* state, uint64_t shadow_address,
     iree_device_size_t length, uint8_t value) {
   if (length == 0) return;
@@ -102,6 +123,23 @@ static void iree_hal_amdgpu_asan_write_shadow_bytes_raw(
     iree_hal_amdgpu_hsa_cleanup_assert_success(iree_hsa_memory_copy_raw(
         state->libhsa, (void*)(uintptr_t)shadow_address, fill_bytes,
         (size_t)length));
+  }
+}
+
+static void iree_hal_amdgpu_asan_write_shadow_bytes_raw(
+    iree_hal_amdgpu_asan_state_t* state, uint64_t shadow_address,
+    iree_device_size_t length, uint8_t value) {
+  const uint64_t shadow_base =
+      (uint64_t)(uintptr_t)state->shadow_map.reservation_base_ptr;
+  while (length > 0) {
+    const iree_device_size_t slab_offset =
+        (shadow_address - shadow_base) % state->shadow_map.slab_size;
+    const iree_device_size_t slab_length =
+        iree_min(length, state->shadow_map.slab_size - slab_offset);
+    iree_hal_amdgpu_asan_write_shadow_slab_bytes_raw(state, shadow_address,
+                                                     slab_length, value);
+    shadow_address += slab_length;
+    length -= slab_length;
   }
 }
 


### PR DESCRIPTION
AMDGPU ASAN presents one contiguous virtual shadow reservation while backing that reservation with independent HSA VMM allocations. Publishing or releasing an application range that crosses a physical shadow-slab boundary could therefore issue one HSA fill or copy across two allocations, violating the HSA memory-operation contract.

Partition shadow writes at each physical slab boundary before issuing HSA operations. The status-returning allocation publication path and the infallible release path share the same traversal while retaining their existing aligned fill and prefix/suffix copy behavior.

The allocator regression constructs an application range whose shadow bytes straddle two slabs and exercises both publication and release through the real AMDGPU ASAN state.
