### PR TITLE
[Loom] Preserve providers across nested contract selection

### DIFF
--- a/loom/src/loom/analysis/BUILD.bazel
+++ b/loom/src/loom/analysis/BUILD.bazel
@@ -672,6 +672,7 @@ loom_cc_library(
         ":scc",
         "//loom/src/loom/ir",
         "//loom/src/loom/ops:op_defs",
+        "//loom/src/loom/ops/func",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:arena",
     ],

--- a/loom/src/loom/analysis/CMakeLists.txt
+++ b/loom/src/loom/analysis/CMakeLists.txt
@@ -774,6 +774,7 @@ loom_cc_library(
     iree::base
     iree::base::internal::arena
     loom::ir
+    loom::ops::func
     loom::ops::op_defs
   PUBLIC
 )

--- a/loom/src/loom/analysis/symbol_dependencies.c
+++ b/loom/src/loom/analysis/symbol_dependencies.c
@@ -10,6 +10,7 @@
 
 #include "loom/ir/context.h"
 #include "loom/ir/module.h"
+#include "loom/ops/func/ops.h"
 #include "loom/ops/op_defs.h"
 
 typedef struct loom_symbol_dependency_builder_t {
@@ -29,6 +30,12 @@ typedef struct loom_symbol_dependency_builder_t {
   loom_symbol_dependency_edge_id_t first_module_edge_id;
   // Number of module-root edges.
   uint32_t module_edge_count;
+  // Mutable abstract contract-demand storage.
+  loom_func_contract_demand_t* contract_demands;
+  // Number of live contract-demand entries.
+  iree_host_size_t contract_demand_count;
+  // Number of allocated contract-demand slots.
+  iree_host_size_t contract_demand_capacity;
 } loom_symbol_dependency_builder_t;
 
 static void loom_symbol_dependency_initialize_symbol_edges(
@@ -38,6 +45,7 @@ static void loom_symbol_dependency_initialize_symbol_edges(
     symbols[i] = (loom_symbol_dependency_symbol_edges_t){
         .first_outgoing_edge_id = LOOM_SYMBOL_DEPENDENCY_EDGE_ID_INVALID,
         .first_incoming_edge_id = LOOM_SYMBOL_DEPENDENCY_EDGE_ID_INVALID,
+        .first_contract_demand_id = LOOM_FUNC_CONTRACT_DEMAND_ID_INVALID,
     };
   }
 }
@@ -129,6 +137,48 @@ static iree_status_t loom_symbol_dependency_add_ref(
   return loom_symbol_dependency_builder_append_edge(builder, source_symbol_id,
                                                     target_ref.symbol_id, kind,
                                                     attr_index, user_op);
+}
+
+static iree_status_t loom_symbol_dependency_append_contract_demand(
+    loom_symbol_dependency_builder_t* builder,
+    loom_symbol_id_t source_symbol_id, const loom_op_t* apply_op) {
+  if (source_symbol_id >= builder->module->symbols.count) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "func.apply is not owned by a module symbol");
+  }
+  const loom_string_id_t contract_id = loom_func_apply_contract(apply_op);
+  if (contract_id == LOOM_STRING_ID_INVALID ||
+      contract_id >= builder->module->strings.count) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "func.apply has an invalid contract string id");
+  }
+  if (builder->contract_demand_count >= UINT32_MAX) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "symbol dependency table exceeds %u abstract "
+                            "provider demands",
+                            (unsigned)(UINT32_MAX - 1));
+  }
+  if (builder->contract_demand_count >= builder->contract_demand_capacity) {
+    IREE_RETURN_IF_ERROR(iree_arena_grow_array(
+        builder->arena, builder->contract_demand_count,
+        builder->contract_demand_count + 1, sizeof(*builder->contract_demands),
+        &builder->contract_demand_capacity,
+        (void**)&builder->contract_demands));
+  }
+
+  const loom_func_contract_demand_id_t demand_id =
+      (loom_func_contract_demand_id_t)builder->contract_demand_count++;
+  loom_symbol_dependency_symbol_edges_t* source =
+      &builder->symbols[source_symbol_id];
+  builder->contract_demands[demand_id] = (loom_func_contract_demand_t){
+      .contract_id = contract_id,
+      .source_symbol_id = source_symbol_id,
+      .apply_op = apply_op,
+      .next_source_demand_id = source->first_contract_demand_id,
+  };
+  source->first_contract_demand_id = demand_id;
+  ++source->contract_demand_count;
+  return iree_ok_status();
 }
 
 static iree_status_t loom_symbol_dependency_visit_type(
@@ -426,6 +476,10 @@ static iree_status_t loom_symbol_dependency_visit_region(
       if (loom_op_defining_symbol_ref(builder->module, op, &op_symbol_ref)) {
         nested_source_symbol_id = op_symbol_ref.symbol_id;
       }
+      if (loom_func_apply_isa(op)) {
+        IREE_RETURN_IF_ERROR(loom_symbol_dependency_append_contract_demand(
+            builder, nested_source_symbol_id, op));
+      }
       IREE_RETURN_IF_ERROR(loom_symbol_dependency_visit_op_value_types(
           builder, nested_source_symbol_id, op));
       IREE_RETURN_IF_ERROR(loom_symbol_dependency_visit_op_attrs(
@@ -483,6 +537,8 @@ iree_status_t loom_symbol_dependency_table_build(
       .edge_count = builder.edge_count,
       .first_module_edge_id = builder.first_module_edge_id,
       .module_edge_count = builder.module_edge_count,
+      .contract_demands = builder.contract_demands,
+      .contract_demand_count = builder.contract_demand_count,
   };
   return iree_ok_status();
 }

--- a/loom/src/loom/analysis/symbol_dependencies.c
+++ b/loom/src/loom/analysis/symbol_dependencies.c
@@ -36,6 +36,8 @@ typedef struct loom_symbol_dependency_builder_t {
   iree_host_size_t contract_demand_count;
   // Number of allocated contract-demand slots.
   iree_host_size_t contract_demand_capacity;
+  // Dense bitset indexed by module string ID for demanded contracts.
+  uint64_t* contract_demand_bits;
 } loom_symbol_dependency_builder_t;
 
 static void loom_symbol_dependency_initialize_symbol_edges(
@@ -165,6 +167,15 @@ static iree_status_t loom_symbol_dependency_append_contract_demand(
         &builder->contract_demand_capacity,
         (void**)&builder->contract_demands));
   }
+  if (!builder->contract_demand_bits) {
+    const iree_host_size_t word_count =
+        (builder->module->strings.count + 63u) / 64u;
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        builder->arena, word_count, sizeof(*builder->contract_demand_bits),
+        (void**)&builder->contract_demand_bits));
+    memset(builder->contract_demand_bits, 0,
+           word_count * sizeof(*builder->contract_demand_bits));
+  }
 
   const loom_func_contract_demand_id_t demand_id =
       (loom_func_contract_demand_id_t)builder->contract_demand_count++;
@@ -178,6 +189,8 @@ static iree_status_t loom_symbol_dependency_append_contract_demand(
   };
   source->first_contract_demand_id = demand_id;
   ++source->contract_demand_count;
+  builder->contract_demand_bits[contract_id >> 6] |= UINT64_C(1)
+                                                     << (contract_id & 63u);
   return iree_ok_status();
 }
 
@@ -539,6 +552,7 @@ iree_status_t loom_symbol_dependency_table_build(
       .module_edge_count = builder.module_edge_count,
       .contract_demands = builder.contract_demands,
       .contract_demand_count = builder.contract_demand_count,
+      .contract_demand_bits = builder.contract_demand_bits,
   };
   return iree_ok_status();
 }

--- a/loom/src/loom/analysis/symbol_dependencies.h
+++ b/loom/src/loom/analysis/symbol_dependencies.h
@@ -129,7 +129,19 @@ typedef struct loom_symbol_dependency_table_t {
   const loom_func_contract_demand_t* contract_demands;
   // Number of entries in contract_demands.
   iree_host_size_t contract_demand_count;
+  // Dense bitset indexed by module string ID for demanded contracts, or NULL
+  // when the module contains no abstract contract demands.
+  const uint64_t* contract_demand_bits;
 } loom_symbol_dependency_table_t;
+
+// Returns true when at least one func.apply demands |contract_id|.
+// |contract_id| must be valid in the table's module string table.
+static inline bool loom_symbol_dependency_contract_is_demanded(
+    const loom_symbol_dependency_table_t* table, loom_string_id_t contract_id) {
+  return table->contract_demand_bits &&
+         (table->contract_demand_bits[contract_id >> 6] &
+          (UINT64_C(1) << (contract_id & 63u))) != 0;
+}
 
 // Builds the symbol dependency table for |module| into |arena|.
 iree_status_t loom_symbol_dependency_table_build(

--- a/loom/src/loom/analysis/symbol_dependencies.h
+++ b/loom/src/loom/analysis/symbol_dependencies.h
@@ -30,6 +30,11 @@ typedef uint32_t loom_symbol_dependency_edge_id_t;
 #define LOOM_SYMBOL_DEPENDENCY_EDGE_ID_INVALID \
   ((loom_symbol_dependency_edge_id_t)UINT32_MAX)
 
+// Index into a symbol dependency table's abstract contract-demand array.
+typedef uint32_t loom_func_contract_demand_id_t;
+#define LOOM_FUNC_CONTRACT_DEMAND_ID_INVALID \
+  ((loom_func_contract_demand_id_t)UINT32_MAX)
+
 // Sentinel for edges that are not attached to a concrete op attribute.
 #define LOOM_SYMBOL_DEPENDENCY_ATTR_INDEX_NONE ((uint16_t)UINT16_MAX)
 
@@ -74,7 +79,21 @@ typedef struct loom_symbol_dependency_edge_t {
   loom_symbol_dependency_edge_id_t next_incoming_edge_id;
 } loom_symbol_dependency_edge_t;
 
-// Incoming/outgoing edge-list heads for one symbol.
+// One abstract func.apply provider demand.
+typedef struct loom_func_contract_demand_t {
+  // Interned provider contract requested by the application.
+  loom_string_id_t contract_id;
+  // Symbol whose definition owns the application.
+  loom_symbol_id_t source_symbol_id;
+  // Reserved padding.
+  uint16_t reserved;
+  // func.apply operation carrying this demand.
+  const loom_op_t* apply_op;
+  // Next demand owned by the same source symbol.
+  loom_func_contract_demand_id_t next_source_demand_id;
+} loom_func_contract_demand_t;
+
+// Concrete edge and abstract demand list heads for one symbol.
 typedef struct loom_symbol_dependency_symbol_edges_t {
   // First edge whose source_symbol_id is this symbol.
   loom_symbol_dependency_edge_id_t first_outgoing_edge_id;
@@ -84,6 +103,10 @@ typedef struct loom_symbol_dependency_symbol_edges_t {
   uint32_t outgoing_count;
   // Number of incoming occurrence edges.
   uint32_t incoming_count;
+  // First abstract provider demand owned by this symbol.
+  loom_func_contract_demand_id_t first_contract_demand_id;
+  // Number of abstract provider demands owned by this symbol.
+  uint32_t contract_demand_count;
 } loom_symbol_dependency_symbol_edges_t;
 
 // Built dependency table for one module snapshot.
@@ -102,6 +125,10 @@ typedef struct loom_symbol_dependency_table_t {
   loom_symbol_dependency_edge_id_t first_module_edge_id;
   // Number of module-root edges.
   uint32_t module_edge_count;
+  // Abstract func.apply provider demands owned by module symbols.
+  const loom_func_contract_demand_t* contract_demands;
+  // Number of entries in contract_demands.
+  iree_host_size_t contract_demand_count;
 } loom_symbol_dependency_table_t;
 
 // Builds the symbol dependency table for |module| into |arena|.

--- a/loom/src/loom/analysis/symbol_dependencies_test.cc
+++ b/loom/src/loom/analysis/symbol_dependencies_test.cc
@@ -249,11 +249,17 @@ func.def public @entry(%arg: i32) -> (i32) {
   const loom_symbol_id_t entry = FindSymbol(module.get(), IREE_SV("entry"));
   const loom_string_id_t contract_id =
       loom_module_lookup_string(module.get(), IREE_SV("demo.contract"));
+  const loom_string_id_t undemanded_contract_id =
+      loom_module_lookup_string(module.get(), IREE_SV("outer.contract"));
   ASSERT_NE(contract_id, LOOM_STRING_ID_INVALID);
+  ASSERT_NE(undemanded_contract_id, LOOM_STRING_ID_INVALID);
 
   const loom_symbol_dependency_table_t table = BuildTable(module.get());
 
   ASSERT_EQ(table.contract_demand_count, 2u);
+  EXPECT_TRUE(loom_symbol_dependency_contract_is_demanded(&table, contract_id));
+  EXPECT_FALSE(loom_symbol_dependency_contract_is_demanded(
+      &table, undemanded_contract_id));
   const loom_symbol_id_t source_symbol_ids[] = {outer_provider, entry};
   for (loom_symbol_id_t source_symbol_id : source_symbol_ids) {
     ASSERT_EQ(table.symbols[source_symbol_id].contract_demand_count, 1u);

--- a/loom/src/loom/analysis/symbol_dependencies_test.cc
+++ b/loom/src/loom/analysis/symbol_dependencies_test.cc
@@ -227,6 +227,50 @@ func.def @entry() -> (index) {
   EXPECT_EQ(table.symbols[reader].incoming_count, 1u);
 }
 
+TEST_F(SymbolDependenciesTest, ContractDemandsRetainOwningSymbol) {
+  ModulePtr module = ParseModule(R"(
+func.template<outer.contract> @outer_provider(%value: i32) -> (i32) {
+  %result = func.apply<demo.contract>(%value) : (i32) -> (i32)
+  func.return %result : i32
+}
+
+func.template<demo.contract> @demo_provider(%value: i32) -> (i32) {
+  func.return %value : i32
+}
+
+func.def public @entry(%arg: i32) -> (i32) {
+  %result = func.apply<demo.contract>(%arg) : (i32) -> (i32)
+  func.return %result : i32
+}
+)");
+
+  const loom_symbol_id_t outer_provider =
+      FindSymbol(module.get(), IREE_SV("outer_provider"));
+  const loom_symbol_id_t entry = FindSymbol(module.get(), IREE_SV("entry"));
+  const loom_string_id_t contract_id =
+      loom_module_lookup_string(module.get(), IREE_SV("demo.contract"));
+  ASSERT_NE(contract_id, LOOM_STRING_ID_INVALID);
+
+  const loom_symbol_dependency_table_t table = BuildTable(module.get());
+
+  ASSERT_EQ(table.contract_demand_count, 2u);
+  const loom_symbol_id_t source_symbol_ids[] = {outer_provider, entry};
+  for (loom_symbol_id_t source_symbol_id : source_symbol_ids) {
+    ASSERT_EQ(table.symbols[source_symbol_id].contract_demand_count, 1u);
+    loom_func_contract_demand_id_t demand_id =
+        table.symbols[source_symbol_id].first_contract_demand_id;
+    ASSERT_NE(demand_id, LOOM_FUNC_CONTRACT_DEMAND_ID_INVALID);
+    const loom_func_contract_demand_t& demand =
+        table.contract_demands[demand_id];
+    EXPECT_EQ(demand.source_symbol_id, source_symbol_id);
+    EXPECT_EQ(demand.contract_id, contract_id);
+    ASSERT_NE(demand.apply_op, nullptr);
+    EXPECT_EQ(demand.apply_op->kind, LOOM_OP_FUNC_APPLY);
+    EXPECT_EQ(demand.next_source_demand_id,
+              LOOM_FUNC_CONTRACT_DEMAND_ID_INVALID);
+  }
+}
+
 TEST_F(SymbolDependenciesTest, OpenParameterizedArraysAreNotSymbolReferences) {
   ModulePtr module = ParseModule(R"(
 func.template<demo.contract> requires [#target.subgroup.size<64>] @conditional(%arg: i32) -> (i32) {

--- a/loom/src/loom/analysis/symbol_liveness.c
+++ b/loom/src/loom/analysis/symbol_liveness.c
@@ -9,10 +9,9 @@
 #include <string.h>
 
 #include "loom/ir/module.h"
-#include "loom/ops/op_defs.h"
 
 typedef struct loom_symbol_liveness_worklist_t {
-  // Symbol ids still waiting for defining-op traversal.
+  // Symbol ids still waiting for dependency expansion.
   loom_symbol_id_t* entries;
 
   // Number of queued symbol ids.
@@ -145,7 +144,8 @@ static iree_status_t loom_symbol_liveness_mark_module_root_edges(
 
 static iree_status_t loom_symbol_liveness_visit_contributors(
     loom_symbol_liveness_state_t* state, loom_symbol_id_t source_symbol_id,
-    const loom_symbol_t* source_symbol, const loom_op_t* op) {
+    const loom_symbol_t* source_symbol,
+    const loom_func_contract_demand_t* demand) {
   if (!state->has_contributors) {
     return iree_ok_status();
   }
@@ -160,41 +160,9 @@ static iree_status_t loom_symbol_liveness_visit_contributors(
   for (iree_host_size_t i = 0; i < state->options.contributor_count; ++i) {
     const loom_symbol_liveness_contributor_t* contributor =
         &state->options.contributors[i];
-    if (!contributor->visit_op) continue;
-    IREE_RETURN_IF_ERROR(
-        contributor->visit_op(contributor->user_data, &context, op));
-  }
-  return iree_ok_status();
-}
-
-static iree_status_t loom_symbol_liveness_scan_op(
-    loom_symbol_liveness_state_t* state, loom_symbol_id_t source_symbol_id,
-    const loom_symbol_t* source_symbol, const loom_op_t* op) {
-  if (!op || iree_any_bit_set(op->flags, LOOM_OP_FLAG_DEAD)) {
-    return iree_ok_status();
-  }
-
-  loom_symbol_ref_t nested_symbol_ref = loom_symbol_ref_null();
-  if (loom_op_defining_symbol_ref(state->module, op, &nested_symbol_ref) &&
-      nested_symbol_ref.symbol_id != source_symbol_id) {
-    return iree_ok_status();
-  }
-
-  IREE_RETURN_IF_ERROR(loom_symbol_liveness_visit_contributors(
-      state, source_symbol_id, source_symbol, op));
-
-  loom_region_t** regions = loom_op_regions(op);
-  for (uint8_t i = 0; i < op->region_count; ++i) {
-    const loom_region_t* region = regions[i];
-    if (!region) continue;
-    const loom_block_t* block = NULL;
-    loom_region_for_each_block(region, block) {
-      const loom_op_t* nested_op = NULL;
-      loom_block_for_each_op(block, nested_op) {
-        IREE_RETURN_IF_ERROR(loom_symbol_liveness_scan_op(
-            state, source_symbol_id, source_symbol, nested_op));
-      }
-    }
+    if (!contributor->visit_contract_demand) continue;
+    IREE_RETURN_IF_ERROR(contributor->visit_contract_demand(
+        contributor->user_data, &context, demand));
   }
   return iree_ok_status();
 }
@@ -216,8 +184,15 @@ static iree_status_t loom_symbol_liveness_traverse_symbol(
 
   if (!state->has_contributors) return iree_ok_status();
   const loom_symbol_t* symbol = &state->module->symbols.entries[symbol_id];
-  IREE_RETURN_IF_ERROR(loom_symbol_liveness_scan_op(state, symbol_id, symbol,
-                                                    symbol->defining_op));
+  loom_func_contract_demand_id_t demand_id =
+      state->dependencies->symbols[symbol_id].first_contract_demand_id;
+  while (demand_id != LOOM_FUNC_CONTRACT_DEMAND_ID_INVALID) {
+    const loom_func_contract_demand_t* demand =
+        &state->dependencies->contract_demands[demand_id];
+    IREE_RETURN_IF_ERROR(loom_symbol_liveness_visit_contributors(
+        state, symbol_id, symbol, demand));
+    demand_id = demand->next_source_demand_id;
+  }
   return iree_ok_status();
 }
 
@@ -227,7 +202,7 @@ static bool loom_symbol_liveness_options_have_contributors(
     return false;
   }
   for (iree_host_size_t i = 0; i < options->contributor_count; ++i) {
-    if (options->contributors[i].visit_op) return true;
+    if (options->contributors[i].visit_contract_demand) return true;
   }
   return false;
 }

--- a/loom/src/loom/analysis/symbol_liveness.h
+++ b/loom/src/loom/analysis/symbol_liveness.h
@@ -8,7 +8,7 @@
 //
 // The engine computes live module symbols from an explicit root policy,
 // concrete symbol dependency edges, and optional dialect/provider contributed
-// edges discovered while scanning reachable symbol bodies.
+// edges derived from indexed abstract contract demands.
 
 #ifndef LOOM_ANALYSIS_SYMBOL_LIVENESS_H_
 #define LOOM_ANALYSIS_SYMBOL_LIVENESS_H_
@@ -42,11 +42,11 @@ typedef bool (*loom_symbol_liveness_root_query_fn_t)(
     void* user_data, const loom_module_t* module, loom_symbol_id_t symbol_id,
     const loom_symbol_t* symbol);
 
-// Visits one operation inside a reachable symbol body and may add synthetic
-// liveness edges through loom_symbol_liveness_mark_* helpers.
-typedef iree_status_t (*loom_symbol_liveness_visit_op_fn_t)(
+// Visits one abstract contract demand owned by a reachable symbol and may add
+// synthetic liveness edges through loom_symbol_liveness_mark_* helpers.
+typedef iree_status_t (*loom_symbol_liveness_visit_contract_demand_fn_t)(
     void* user_data, loom_symbol_liveness_contributor_context_t* context,
-    const loom_op_t* op);
+    const loom_func_contract_demand_t* demand);
 
 // Context passed to liveness contributors.
 typedef struct loom_symbol_liveness_contributor_context_t {
@@ -71,10 +71,11 @@ typedef struct loom_symbol_liveness_contributor_context_t {
 
 // Dialect/provider liveness contributor.
 typedef struct loom_symbol_liveness_contributor_t {
-  // Optional callback invoked for each op in reachable symbol bodies.
-  loom_symbol_liveness_visit_op_fn_t visit_op;
+  // Optional callback invoked for each contract demand owned by a reachable
+  // symbol.
+  loom_symbol_liveness_visit_contract_demand_fn_t visit_contract_demand;
 
-  // Opaque payload passed to visit_op.
+  // Opaque payload passed to visit_contract_demand.
   void* user_data;
 } loom_symbol_liveness_contributor_t;
 

--- a/loom/src/loom/analysis/symbol_liveness_test.cc
+++ b/loom/src/loom/analysis/symbol_liveness_test.cc
@@ -37,12 +37,11 @@ static bool RootPublicFunc(void* user_data, const loom_module_t* module,
          loom_func_like_visibility(function) == LOOM_FUNC_VISIBILITY_PUBLIC;
 }
 
-static iree_status_t MarkProviderForApply(
+static iree_status_t MarkProviderForDemand(
     void* user_data, loom_symbol_liveness_contributor_context_t* context,
-    const loom_op_t* op) {
+    const loom_func_contract_demand_t* demand) {
   ApplyEdgeTestState* state = (ApplyEdgeTestState*)user_data;
-  if (!loom_func_apply_isa(op)) return iree_ok_status();
-  if (loom_func_apply_contract(op) != state->contract_id) {
+  if (demand->contract_id != state->contract_id) {
     return iree_ok_status();
   }
   return loom_symbol_liveness_mark_symbol_id(context,
@@ -169,7 +168,7 @@ func.def @dead_user(%arg0: i32) -> (i32) {
   };
   ASSERT_NE(apply_state.contract_id, LOOM_STRING_ID_INVALID);
   loom_symbol_liveness_contributor_t contributor = {
-      /*.visit_op=*/MarkProviderForApply,
+      /*.visit_contract_demand=*/MarkProviderForDemand,
       /*.user_data=*/&apply_state,
   };
   loom_symbol_liveness_options_t options = {

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_nested_template_expansion.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_nested_template_expansion.loom-test
@@ -62,6 +62,7 @@ kernel.def target(@target) @nested_kernel_template_expansion() {
   kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
 } launch() {
   func.apply<nested.kernel_outer>() : ()
+  func.apply<nested.kernel_inner>() : ()
   kernel.return
 }
 

--- a/loom/src/loom/transforms/symbol/inline_callables.c
+++ b/loom/src/loom/transforms/symbol/inline_callables.c
@@ -684,6 +684,13 @@ static bool loom_inline_symbol_can_transfer(const loom_inline_state_t* state,
   if (!loom_inline_symbol_is_transferable(state->module, info->symbol)) {
     return false;
   }
+  const loom_string_id_t contract_id =
+      loom_func_like_implements(info->function);
+  if (contract_id != LOOM_STRING_ID_INVALID &&
+      loom_symbol_dependency_contract_is_demanded(&state->dependencies,
+                                                  contract_id)) {
+    return false;
+  }
   return loom_func_like_body(info->function) != NULL;
 }
 

--- a/loom/src/loom/transforms/symbol/template_selection.c
+++ b/loom/src/loom/transforms/symbol/template_selection.c
@@ -1897,12 +1897,11 @@ static iree_status_t loom_template_selection_analyze_apply(
       possible_count, best_match_count, highest_provider_priority);
 }
 
-static iree_status_t loom_template_selection_visit_reachable_op(
+static iree_status_t loom_template_selection_visit_reachable_demand(
     void* user_data, loom_symbol_liveness_contributor_context_t* context,
-    const loom_op_t* op) {
-  if (!loom_func_apply_isa(op)) return iree_ok_status();
+    const loom_func_contract_demand_t* demand) {
   return loom_template_selection_analyze_apply(
-      (loom_template_selection_state_t*)user_data, context, op);
+      (loom_template_selection_state_t*)user_data, context, demand->apply_op);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2079,7 +2078,7 @@ static iree_status_t loom_template_selection_execute_rewrites(
 static iree_status_t loom_template_selection_build_liveness(
     loom_template_selection_state_t* state) {
   loom_symbol_liveness_contributor_t contributor = {
-      .visit_op = loom_template_selection_visit_reachable_op,
+      .visit_contract_demand = loom_template_selection_visit_reachable_demand,
       .user_data = state,
   };
   loom_symbol_liveness_options_t options = {

--- a/loom/src/loom/transforms/symbol/test/inline_callables.loom-test
+++ b/loom/src/loom/transforms/symbol/test/inline_callables.loom-test
@@ -246,6 +246,46 @@ func.def public @entry(%arg: i32) -> (i32) {
 
 // RUN: pass inline-callables
 
+func.template<test.addi> inline @double_template(%value: i32) -> (i32) {
+  %doubled = test.addi %value, %value : i32
+  func.return %doubled : i32
+}
+
+func.def inline @apply_double(%value: i32) -> (i32) {
+  %result = func.apply<test.addi>(%value) : (i32) -> (i32)
+  func.return %result : i32
+}
+
+func.def public @exact_entry(%arg: i32) -> (i32) {
+  %result = func.call @double_template(%arg) : (i32) -> (i32)
+  func.return %result : i32
+}
+
+func.def public @abstract_entry(%arg: i32) -> (i32) {
+  %result = func.call @apply_double(%arg) : (i32) -> (i32)
+  func.return %result : i32
+}
+
+// ----
+func.template<test.addi> inline @double_template(%value: i32) -> (i32) {
+  %doubled = test.addi %value, %value : i32
+  func.return %doubled : i32
+}
+
+func.def public @exact_entry(%arg: i32) -> (i32) {
+  %doubled = test.addi %arg, %arg : i32
+  func.return %doubled : i32
+}
+
+func.def public @abstract_entry(%arg: i32) -> (i32) {
+  %result = func.apply<test.addi>(%arg) : (i32) -> (i32)
+  func.return %result : i32
+}
+
+// ====
+
+// RUN: pass inline-callables
+
 func.def inline @unpack_block(%packed: i32) -> (i32) {
   %unpacked = test.addi %packed, %packed : i32
   func.return %unpacked : i32


### PR DESCRIPTION
Nested template expansion may intentionally leave a `func.apply` unresolved until its caller has concrete target and placement facts. `inline-callables` previously considered only concrete symbol references when deciding whether an exact call could consume a private provider body. If another live demand for that provider remained abstract, the exact call moved the body out of the provider and a later selection pass reported `LOWERING/045 no_provider` for a contract that had been validly authored.

This change makes abstract provider demand part of the canonical symbol dependency snapshot. Each `func.apply` occurrence is indexed under the symbol that owns it while the existing module-use traversal is already visiting the operation. Template-selection liveness consumes those indexed occurrences instead of recursively rescanning every reachable function body, so the stronger dependency model also removes a redundant traversal.

The dependency snapshot maintains a lazy one-bit-per-interned-string summary of demanded contracts. Transfer eligibility is therefore one integer-ID bit test: an exact call clones a provider body while any unresolved application can still select that contract, and destructive transfer remains available once all abstract demands have been resolved. There is no string matching, provider catalog rebuild, additional IR walk, or compiler-generated state in the IR.

The production regression exercises the original composition boundary: a placement-sensitive nested provider using subgroup reduction, workgroup scratch, and barriers, plus a second live demand for the same contract. Both sites now select successfully while ordinary fully resolved templates retain the existing transfer behavior.
