### PR TITLE
[Loom] Legalize long AMDGPU SOPP branches

### DIFF
--- a/loom/src/loom/target/emit/native/amdgpu/BUILD.bazel
+++ b/loom/src/loom/target/emit/native/amdgpu/BUILD.bazel
@@ -78,6 +78,7 @@ loom_cc_library(
     srcs = ["assembly.c"],
     hdrs = ["assembly.h"],
     deps = [
+        ":branch_layout",
         ":register_class",
         ":storage_layout",
         "//loom/src/loom/codegen/low:allocation",

--- a/loom/src/loom/target/emit/native/amdgpu/BUILD.bazel
+++ b/loom/src/loom/target/emit/native/amdgpu/BUILD.bazel
@@ -53,6 +53,27 @@ loom_cc_library(
 )
 
 loom_cc_library(
+    name = "branch_layout",
+    srcs = ["branch_layout.c"],
+    hdrs = ["branch_layout.h"],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal:arena",
+    ],
+)
+
+loom_cc_test(
+    name = "branch_layout_test",
+    srcs = ["branch_layout_test.cc"],
+    deps = [
+        ":branch_layout",
+        "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+loom_cc_library(
     name = "assembly",
     srcs = ["assembly.c"],
     hdrs = ["assembly.h"],

--- a/loom/src/loom/target/emit/native/amdgpu/BUILD.bazel
+++ b/loom/src/loom/target/emit/native/amdgpu/BUILD.bazel
@@ -226,6 +226,7 @@ loom_cc_library(
     srcs = ["encoding.c"],
     hdrs = ["encoding.h"],
     deps = [
+        ":branch_layout",
         ":register_class",
         ":storage_layout",
         ":text_fixup",

--- a/loom/src/loom/target/emit/native/amdgpu/CMakeLists.txt
+++ b/loom/src/loom/target/emit/native/amdgpu/CMakeLists.txt
@@ -25,6 +25,38 @@ endif()
 if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU)
 loom_cc_library(
   NAME
+    branch_layout
+  HDRS
+    "branch_layout.h"
+  SRCS
+    "branch_layout.c"
+  DEPS
+    iree::base
+    iree::base::internal::arena
+  PUBLIC
+)
+endif()
+
+if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU)
+loom_cc_test(
+  NAME
+    branch_layout_test
+  SRCS
+    "branch_layout_test.cc"
+  DEPS
+    ::branch_layout
+    iree::base::internal::arena
+    iree::testing::gtest
+    iree::testing::gtest_main
+  LABELS
+    "iree-build-requirement=loom.target.arch.amdgpu"
+    "iree-build-requirement=loom.emit.amdgpu"
+)
+endif()
+
+if(LOOM_TARGET_ARCH_AMDGPU AND LOOM_EMIT_AMDGPU)
+loom_cc_library(
+  NAME
     assembly
   HDRS
     "assembly.h"

--- a/loom/src/loom/target/emit/native/amdgpu/CMakeLists.txt
+++ b/loom/src/loom/target/emit/native/amdgpu/CMakeLists.txt
@@ -63,6 +63,7 @@ loom_cc_library(
   SRCS
     "assembly.c"
   DEPS
+    ::branch_layout
     ::register_class
     ::storage_layout
     iree::base

--- a/loom/src/loom/target/emit/native/amdgpu/CMakeLists.txt
+++ b/loom/src/loom/target/emit/native/amdgpu/CMakeLists.txt
@@ -254,6 +254,7 @@ loom_cc_library(
   SRCS
     "encoding.c"
   DEPS
+    ::branch_layout
     ::register_class
     ::storage_layout
     ::text_fixup

--- a/loom/src/loom/target/emit/native/amdgpu/assembly.c
+++ b/loom/src/loom/target/emit/native/amdgpu/assembly.c
@@ -73,11 +73,22 @@ typedef struct loom_amdgpu_assembly_traversal_state_t {
   uint8_t current_vgpr_msb_mode;
 } loom_amdgpu_assembly_traversal_state_t;
 
+typedef struct loom_amdgpu_assembly_branch_state_t {
+  // Exact converged branch-island layout, or NULL when no islands were needed.
+  const loom_amdgpu_branch_layout_t* layout;
+  // Next original branch edge consumed from |layout|.
+  iree_host_size_t next_edge_index;
+  // Next island group consumed from |layout|.
+  iree_host_size_t next_group_index;
+} loom_amdgpu_assembly_branch_state_t;
+
 typedef struct loom_amdgpu_assembly_emit_state_t {
   // Function-local storage layout shared by all storage-address packets.
   const loom_amdgpu_storage_layout_t* storage_layout;
   // Target packet plan and its emission-order consumption cursors.
   loom_amdgpu_assembly_packet_plan_state_t packet_plan;
+  // Function-local branch placement and emission cursors.
+  loom_amdgpu_assembly_branch_state_t branches;
   // Packet traversal and simulated architectural state.
   loom_amdgpu_assembly_traversal_state_t traversal;
 } loom_amdgpu_assembly_emit_state_t;
@@ -2111,6 +2122,62 @@ static iree_status_t loom_amdgpu_append_materialized_wait_packet(
   return iree_string_builder_append_cstring(context->builder, "\n");
 }
 
+static iree_status_t loom_amdgpu_append_branch_target_label(
+    const loom_amdgpu_assembly_emit_state_t* state,
+    const loom_native_assembly_packet_context_t* context,
+    loom_amdgpu_branch_target_t target) {
+  switch (target.kind) {
+    case LOOM_AMDGPU_BRANCH_TARGET_BLOCK: {
+      IREE_ASSERT_LT(target.index, context->schedule->block_count);
+      return loom_native_assembly_append_block_label(
+          context->schedule, context->schedule->blocks[target.index].block,
+          context->builder);
+    }
+    case LOOM_AMDGPU_BRANCH_TARGET_ISLAND:
+      IREE_ASSERT(state->branches.layout != NULL);
+      IREE_ASSERT_LT(target.index, state->branches.layout->island_count);
+      return iree_string_builder_append_format(
+          context->builder, ".Lbranch_island%" PRIu32, target.index);
+    default:
+      IREE_ASSERT_UNREACHABLE("invalid AMDGPU branch target kind");
+      IREE_BUILTIN_UNREACHABLE();
+  }
+}
+
+static iree_status_t loom_amdgpu_append_branch_groups_before_packet(
+    loom_amdgpu_assembly_emit_state_t* state,
+    const loom_native_assembly_packet_context_t* context) {
+  if (state->branches.layout == NULL) return iree_ok_status();
+  while (state->branches.next_group_index <
+         state->branches.layout->group_count) {
+    const iree_host_size_t group_index = state->branches.next_group_index;
+    const loom_amdgpu_branch_layout_group_t* group =
+        &state->branches.layout->groups[group_index];
+    if (group->packet_index != context->packet->packet_index) break;
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+        context->builder, "  s_branch .Lbranch_island_group_end%" PRIhsz "\n",
+        group_index));
+    for (uint32_t i = 0; i < group->island_count; ++i) {
+      const uint32_t island_index = group->island_start + i;
+      IREE_ASSERT_LT(island_index, state->branches.layout->island_count);
+      const loom_amdgpu_branch_layout_island_t* island =
+          &state->branches.layout->islands[island_index];
+      IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+          context->builder, ".Lbranch_island%" PRIu32 ":\n  s_branch ",
+          island_index));
+      IREE_RETURN_IF_ERROR(loom_amdgpu_append_branch_target_label(
+          state, context, island->target));
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(context->builder, "\n"));
+    }
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+        context->builder, ".Lbranch_island_group_end%" PRIhsz ":\n",
+        group_index));
+    ++state->branches.next_group_index;
+  }
+  return iree_ok_status();
+}
+
 static iree_status_t loom_amdgpu_prepare_packet(
     void* user_data, const loom_native_assembly_packet_context_t* context) {
   loom_amdgpu_assembly_emit_state_t* state =
@@ -2285,9 +2352,11 @@ static iree_status_t loom_amdgpu_append_wait_states_before_packet(
   return iree_ok_status();
 }
 
-static iree_status_t loom_amdgpu_append_waits_before_packet(
+static iree_status_t loom_amdgpu_append_insertions_before_packet(
     void* user_data, const loom_native_assembly_packet_context_t* context) {
   IREE_RETURN_IF_ERROR(loom_amdgpu_prepare_packet(user_data, context));
+  IREE_RETURN_IF_ERROR(loom_amdgpu_append_branch_groups_before_packet(
+      (loom_amdgpu_assembly_emit_state_t*)user_data, context));
   IREE_RETURN_IF_ERROR(
       loom_amdgpu_append_address_state_before_packet(user_data, context));
   IREE_RETURN_IF_ERROR(
@@ -3409,6 +3478,21 @@ static iree_status_t loom_amdgpu_append_return_packet(
   return iree_string_builder_append_cstring(context->builder, "s_endpgm");
 }
 
+static iree_status_t loom_amdgpu_append_original_branch_target(
+    loom_amdgpu_assembly_emit_state_t* state,
+    const loom_native_assembly_packet_context_t* context,
+    const loom_block_t* direct_target) {
+  if (state->branches.layout == NULL) {
+    return loom_native_assembly_append_block_label(
+        context->schedule, direct_target, context->builder);
+  }
+  IREE_ASSERT_LT(state->branches.next_edge_index,
+                 state->branches.layout->edge_count);
+  const loom_amdgpu_branch_layout_edge_t* edge =
+      &state->branches.layout->edges[state->branches.next_edge_index++];
+  return loom_amdgpu_append_branch_target_label(state, context, edge->target);
+}
+
 static iree_status_t loom_amdgpu_append_branch_packet(
     void* user_data, const loom_native_assembly_packet_context_t* context) {
   loom_amdgpu_assembly_emit_state_t* emit_state =
@@ -3441,8 +3525,7 @@ static iree_status_t loom_amdgpu_append_branch_packet(
   }
   IREE_RETURN_IF_ERROR(
       iree_string_builder_append_cstring(context->builder, "s_branch "));
-  return loom_native_assembly_append_block_label(context->schedule, dest,
-                                                 context->builder);
+  return loom_amdgpu_append_original_branch_target(emit_state, context, dest);
 }
 
 static iree_status_t loom_amdgpu_verify_scc_condition_assignment(
@@ -3465,7 +3548,8 @@ static iree_status_t loom_amdgpu_verify_scc_condition_assignment(
 
 static iree_status_t loom_amdgpu_append_cond_branch_packet(
     void* user_data, const loom_native_assembly_packet_context_t* context) {
-  (void)user_data;
+  loom_amdgpu_assembly_emit_state_t* emit_state =
+      (loom_amdgpu_assembly_emit_state_t*)user_data;
   const loom_op_t* op = context->packet->node->op;
   IREE_RETURN_IF_ERROR(loom_amdgpu_verify_scc_condition_assignment(
       context, loom_low_cond_br_condition(op)));
@@ -3482,26 +3566,26 @@ static iree_status_t loom_amdgpu_append_cond_branch_packet(
     }
     IREE_RETURN_IF_ERROR(
         iree_string_builder_append_cstring(context->builder, "s_branch "));
-    return loom_native_assembly_append_block_label(context->schedule, true_dest,
-                                                   context->builder);
+    return loom_amdgpu_append_original_branch_target(emit_state, context,
+                                                     true_dest);
   }
   if (true_block_index == current_block_index + 1) {
     IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(context->builder,
                                                             "s_cbranch_scc0 "));
-    return loom_native_assembly_append_block_label(
-        context->schedule, false_dest, context->builder);
+    return loom_amdgpu_append_original_branch_target(emit_state, context,
+                                                     false_dest);
   }
   IREE_RETURN_IF_ERROR(
       iree_string_builder_append_cstring(context->builder, "s_cbranch_scc1 "));
-  IREE_RETURN_IF_ERROR(loom_native_assembly_append_block_label(
-      context->schedule, true_dest, context->builder));
+  IREE_RETURN_IF_ERROR(loom_amdgpu_append_original_branch_target(
+      emit_state, context, true_dest));
   if (false_block_index == current_block_index + 1) {
     return iree_ok_status();
   }
   IREE_RETURN_IF_ERROR(
       iree_string_builder_append_cstring(context->builder, "\n  s_branch "));
-  return loom_native_assembly_append_block_label(context->schedule, false_dest,
-                                                 context->builder);
+  return loom_amdgpu_append_original_branch_target(emit_state, context,
+                                                   false_dest);
 }
 
 static iree_status_t loom_amdgpu_verify_assembly_target(
@@ -3591,6 +3675,10 @@ iree_status_t loom_amdgpu_emit_assembly_fragment_with_options(
       packet_plan ? &packet_plan->wait_states : NULL;
   const loom_amdgpu_vopd_plan_t* vopd_plan =
       packet_plan ? &packet_plan->vopd_plan : NULL;
+  const loom_amdgpu_branch_layout_t* branch_layout =
+      options && options->branch_layout && options->branch_layout->island_count
+          ? options->branch_layout
+          : NULL;
 
   loom_amdgpu_assembly_emit_state_t emit_state = {
       .storage_layout = storage_layout,
@@ -3601,6 +3689,10 @@ iree_status_t loom_amdgpu_emit_assembly_fragment_with_options(
               .wait_states = wait_states,
               .vopd_plan = vopd_plan,
           },
+      .branches =
+          {
+              .layout = branch_layout,
+          },
       .traversal =
           {
               .current_block_index = LOOM_LOW_PACKET_INDEX_NONE,
@@ -3610,7 +3702,7 @@ iree_status_t loom_amdgpu_emit_assembly_fragment_with_options(
       loom_amdgpu_assembly_options(
           &emit_state,
           (loom_native_assembly_append_packet_callback_t){
-              .fn = loom_amdgpu_append_waits_before_packet,
+              .fn = loom_amdgpu_append_insertions_before_packet,
               .user_data = &emit_state,
           },
           (loom_native_assembly_append_packet_callback_t){
@@ -3631,6 +3723,12 @@ iree_status_t loom_amdgpu_emit_assembly_fragment_with_options(
   if (wait_states != NULL) {
     IREE_ASSERT_EQ(emit_state.packet_plan.next_wait_state_index,
                    wait_states->state_count);
+  }
+  if (branch_layout != NULL) {
+    IREE_ASSERT_EQ(emit_state.branches.next_edge_index,
+                   branch_layout->edge_count);
+    IREE_ASSERT_EQ(emit_state.branches.next_group_index,
+                   branch_layout->group_count);
   }
   return iree_ok_status();
 }

--- a/loom/src/loom/target/emit/native/amdgpu/assembly.c
+++ b/loom/src/loom/target/emit/native/amdgpu/assembly.c
@@ -49,9 +49,7 @@ typedef enum loom_amdgpu_register_part_mask_e {
   LOOM_AMDGPU_REGISTER_PART_MASK_HIGH16 = 0x2u,
 } loom_amdgpu_register_part_mask_t;
 
-typedef struct loom_amdgpu_assembly_emit_state_t {
-  // Function-local storage layout shared by all storage-address packets.
-  const loom_amdgpu_storage_layout_t* storage_layout;
+typedef struct loom_amdgpu_assembly_packet_plan_state_t {
   // Address-state plan consumed in scheduled insertion order.
   const loom_amdgpu_address_state_plan_t* address_state;
   // Wait-packet plan consumed in scheduled insertion order.
@@ -60,16 +58,28 @@ typedef struct loom_amdgpu_assembly_emit_state_t {
   const loom_amdgpu_wait_state_plan_t* wait_states;
   // VOPD plan used to replace paired descriptor packets.
   const loom_amdgpu_vopd_plan_t* vopd_plan;
-  // Current scheduled block, or LOOM_LOW_PACKET_INDEX_NONE before emission.
-  uint32_t current_block_index;
-  // Low byte of MODE's current VGPR-MSB selector state.
-  uint8_t current_vgpr_msb_mode;
   // Next address-state transition to compare with the scheduled packet.
   iree_host_size_t next_address_state_index;
   // Next wait-packet row to compare with the current scheduled packet.
   iree_host_size_t next_wait_packet_index;
   // Next wait-state row to compare with the current scheduled packet.
   iree_host_size_t next_wait_state_index;
+} loom_amdgpu_assembly_packet_plan_state_t;
+
+typedef struct loom_amdgpu_assembly_traversal_state_t {
+  // Current scheduled block, or LOOM_LOW_PACKET_INDEX_NONE before emission.
+  uint32_t current_block_index;
+  // Low byte of MODE's current VGPR-MSB selector state.
+  uint8_t current_vgpr_msb_mode;
+} loom_amdgpu_assembly_traversal_state_t;
+
+typedef struct loom_amdgpu_assembly_emit_state_t {
+  // Function-local storage layout shared by all storage-address packets.
+  const loom_amdgpu_storage_layout_t* storage_layout;
+  // Target packet plan and its emission-order consumption cursors.
+  loom_amdgpu_assembly_packet_plan_state_t packet_plan;
+  // Packet traversal and simulated architectural state.
+  loom_amdgpu_assembly_traversal_state_t traversal;
 } loom_amdgpu_assembly_emit_state_t;
 
 static iree_string_view_t loom_amdgpu_descriptor_key(
@@ -2106,25 +2116,25 @@ static iree_status_t loom_amdgpu_prepare_packet(
   loom_amdgpu_assembly_emit_state_t* state =
       (loom_amdgpu_assembly_emit_state_t*)user_data;
   const uint32_t block_index = context->packet->node->block_index;
-  if (state->current_block_index == LOOM_LOW_PACKET_INDEX_NONE) {
-    state->current_block_index = block_index;
+  if (state->traversal.current_block_index == LOOM_LOW_PACKET_INDEX_NONE) {
+    state->traversal.current_block_index = block_index;
     return iree_ok_status();
   }
-  if (state->current_block_index == block_index) {
+  if (state->traversal.current_block_index == block_index) {
     return iree_ok_status();
   }
-  if (state->address_state == NULL) {
-    if (state->current_vgpr_msb_mode != 0) {
+  if (state->packet_plan.address_state == NULL) {
+    if (state->traversal.current_vgpr_msb_mode != 0) {
       return iree_make_status(
           IREE_STATUS_FAILED_PRECONDITION,
           "AMDGPU assembly left VGPR-MSB address state active at the end of "
           "block %" PRIu32,
-          state->current_block_index);
+          state->traversal.current_block_index);
     }
   } else {
-    IREE_ASSERT_EQ(state->current_vgpr_msb_mode, 0);
+    IREE_ASSERT_EQ(state->traversal.current_vgpr_msb_mode, 0);
   }
-  state->current_block_index = block_index;
+  state->traversal.current_block_index = block_index;
   return iree_ok_status();
 }
 
@@ -2141,13 +2151,14 @@ static iree_status_t loom_amdgpu_append_address_state_before_packet(
     void* user_data, const loom_native_assembly_packet_context_t* context) {
   loom_amdgpu_assembly_emit_state_t* state =
       (loom_amdgpu_assembly_emit_state_t*)user_data;
-  if (state->address_state == NULL) {
+  if (state->packet_plan.address_state == NULL) {
     return iree_ok_status();
   }
-  while (state->next_address_state_index <
-         state->address_state->transition_count) {
+  while (state->packet_plan.next_address_state_index <
+         state->packet_plan.address_state->transition_count) {
     const loom_amdgpu_address_state_transition_t* transition =
-        &state->address_state->transitions[state->next_address_state_index];
+        &state->packet_plan.address_state
+             ->transitions[state->packet_plan.next_address_state_index];
     if (!loom_amdgpu_address_state_matches_packet(transition,
                                                   context->packet)) {
       return iree_ok_status();
@@ -2164,8 +2175,8 @@ static iree_status_t loom_amdgpu_append_address_state_before_packet(
     IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
         context->builder, "  %.*s %" PRIu16 "\n", (int)mnemonic.size,
         mnemonic.data, transition->mode_immediate));
-    state->current_vgpr_msb_mode = new_mode;
-    ++state->next_address_state_index;
+    state->traversal.current_vgpr_msb_mode = new_mode;
+    ++state->packet_plan.next_address_state_index;
   }
   return iree_ok_status();
 }
@@ -2183,18 +2194,20 @@ static iree_status_t loom_amdgpu_append_wait_packets_before_packet(
     void* user_data, const loom_native_assembly_packet_context_t* context) {
   loom_amdgpu_assembly_emit_state_t* state =
       (loom_amdgpu_assembly_emit_state_t*)user_data;
-  if (state->wait_packets == NULL) {
+  if (state->packet_plan.wait_packets == NULL) {
     return iree_ok_status();
   }
-  while (state->next_wait_packet_index < state->wait_packets->packet_count) {
+  while (state->packet_plan.next_wait_packet_index <
+         state->packet_plan.wait_packets->packet_count) {
     const loom_amdgpu_wait_packet_t* wait_packet =
-        &state->wait_packets->packets[state->next_wait_packet_index];
+        &state->packet_plan.wait_packets
+             ->packets[state->packet_plan.next_wait_packet_index];
     if (!loom_amdgpu_wait_packet_matches_packet(wait_packet, context->packet)) {
       return iree_ok_status();
     }
     IREE_RETURN_IF_ERROR(loom_amdgpu_append_materialized_wait_packet(
-        context, wait_packet, state->wait_packets));
-    ++state->next_wait_packet_index;
+        context, wait_packet, state->packet_plan.wait_packets));
+    ++state->packet_plan.next_wait_packet_index;
   }
   return iree_ok_status();
 }
@@ -2254,18 +2267,20 @@ static iree_status_t loom_amdgpu_append_wait_states_before_packet(
     void* user_data, const loom_native_assembly_packet_context_t* context) {
   loom_amdgpu_assembly_emit_state_t* state =
       (loom_amdgpu_assembly_emit_state_t*)user_data;
-  if (state->wait_states == NULL) {
+  if (state->packet_plan.wait_states == NULL) {
     return iree_ok_status();
   }
-  while (state->next_wait_state_index < state->wait_states->state_count) {
+  while (state->packet_plan.next_wait_state_index <
+         state->packet_plan.wait_states->state_count) {
     const loom_amdgpu_wait_state_t* wait_state =
-        &state->wait_states->states[state->next_wait_state_index];
+        &state->packet_plan.wait_states
+             ->states[state->packet_plan.next_wait_state_index];
     if (!loom_amdgpu_wait_state_matches_packet(wait_state, context->packet)) {
       return iree_ok_status();
     }
     IREE_RETURN_IF_ERROR(
         loom_amdgpu_append_wait_state_action(context, wait_state));
-    ++state->next_wait_state_index;
+    ++state->packet_plan.next_wait_state_index;
   }
   return iree_ok_status();
 }
@@ -2330,7 +2345,7 @@ static iree_status_t loom_amdgpu_append_move_line_prefix(
 static iree_status_t loom_amdgpu_append_vgpr_msb_mode(
     loom_amdgpu_assembly_move_state_t* state, uint8_t new_mode) {
   IREE_ASSERT(state->emit_state != NULL);
-  if (state->emit_state->current_vgpr_msb_mode == new_mode) {
+  if (state->emit_state->traversal.current_vgpr_msb_mode == new_mode) {
     return iree_ok_status();
   }
   const loom_low_descriptor_t* descriptor =
@@ -2342,21 +2357,24 @@ static iree_status_t loom_amdgpu_append_vgpr_msb_mode(
       state->context->schedule->target.descriptor_set,
       descriptor->mnemonic_string_offset);
   const uint16_t immediate =
-      (uint16_t)(((uint16_t)state->emit_state->current_vgpr_msb_mode << 8) |
+      (uint16_t)(((uint16_t)state->emit_state->traversal.current_vgpr_msb_mode
+                  << 8) |
                  new_mode);
   IREE_RETURN_IF_ERROR(loom_amdgpu_append_move_line_prefix(state));
   IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
       state->context->builder, "%.*s %" PRIu16, (int)mnemonic.size,
       mnemonic.data, immediate));
   ++state->emitted_count;
-  state->emit_state->current_vgpr_msb_mode = new_mode;
+  state->emit_state->traversal.current_vgpr_msb_mode = new_mode;
   return iree_ok_status();
 }
 
 static iree_status_t loom_amdgpu_append_vgpr_msb_requirement(
     loom_amdgpu_assembly_move_state_t* state, uint8_t mask, uint8_t value) {
   const uint8_t current_mode =
-      state->emit_state == NULL ? 0 : state->emit_state->current_vgpr_msb_mode;
+      state->emit_state == NULL
+          ? 0
+          : state->emit_state->traversal.current_vgpr_msb_mode;
   const uint8_t new_mode = (uint8_t)((current_mode & ~mask) | (value & mask));
   return loom_amdgpu_append_vgpr_msb_mode(state, new_mode);
 }
@@ -2428,7 +2446,7 @@ static iree_status_t loom_amdgpu_emit_move_range(
       .emit_state = emit_state,
   };
   const uint8_t saved_mode =
-      emit_state == NULL ? 0 : emit_state->current_vgpr_msb_mode;
+      emit_state == NULL ? 0 : emit_state->traversal.current_vgpr_msb_mode;
   for (iree_host_size_t i = 0; i < move_range.count; ++i) {
     const loom_low_move_t* move =
         &context->allocation->moves[move_range.start + i];
@@ -2512,7 +2530,7 @@ static iree_status_t loom_amdgpu_append_storage_address_packet(
       .emit_state = emit_state,
   };
   const uint8_t saved_mode =
-      emit_state == NULL ? 0 : emit_state->current_vgpr_msb_mode;
+      emit_state == NULL ? 0 : emit_state->traversal.current_vgpr_msb_mode;
   const uint32_t window = LOOM_AMDGPU_VGPR_MSB_WINDOW_SIZE;
   uint8_t mask = 0;
   uint8_t value = 0;
@@ -3335,7 +3353,7 @@ static iree_status_t loom_amdgpu_update_vgpr_msb_mode_after_descriptor(
                             "%" PRId64 " is not a u16",
                             mode);
   }
-  state->current_vgpr_msb_mode = (uint8_t)((uint16_t)mode & 0xFFu);
+  state->traversal.current_vgpr_msb_mode = (uint8_t)((uint16_t)mode & 0xFFu);
   return iree_ok_status();
 }
 
@@ -3343,12 +3361,12 @@ static iree_status_t loom_amdgpu_append_stateful_descriptor_packet(
     void* user_data, const loom_native_assembly_packet_context_t* context) {
   loom_amdgpu_assembly_emit_state_t* state =
       (loom_amdgpu_assembly_emit_state_t*)user_data;
-  if (state == NULL || state->address_state == NULL) {
+  if (state == NULL || state->packet_plan.address_state == NULL) {
     const loom_amdgpu_address_state_requirement_t requirement =
         loom_amdgpu_address_state_requirement_for_packet(context->allocation,
                                                          context->packet);
     const uint8_t current_mode =
-        state == NULL ? 0 : state->current_vgpr_msb_mode;
+        state == NULL ? 0 : state->traversal.current_vgpr_msb_mode;
     if ((current_mode & requirement.mask) !=
         (requirement.value & requirement.mask)) {
       return iree_make_status(
@@ -3365,22 +3383,23 @@ static iree_status_t loom_amdgpu_append_vopd_or_descriptor_packet(
     void* user_data, const loom_native_assembly_packet_context_t* context) {
   loom_amdgpu_assembly_emit_state_t* state =
       (loom_amdgpu_assembly_emit_state_t*)user_data;
-  if (state == NULL || state->vopd_plan == NULL) {
+  if (state == NULL || state->packet_plan.vopd_plan == NULL) {
     return loom_amdgpu_append_stateful_descriptor_packet(user_data, context);
   }
   const loom_amdgpu_vopd_packet_t* vopd_packet =
-      loom_amdgpu_vopd_plan_packet_at(state->vopd_plan,
+      loom_amdgpu_vopd_plan_packet_at(state->packet_plan.vopd_plan,
                                       context->packet->packet_index);
   if (vopd_packet == NULL) {
     return loom_amdgpu_append_stateful_descriptor_packet(user_data, context);
   }
-  IREE_ASSERT(vopd_packet->pair_index < state->vopd_plan->pair_count);
+  IREE_ASSERT(vopd_packet->pair_index <
+              state->packet_plan.vopd_plan->pair_count);
   if (vopd_packet->role == LOOM_AMDGPU_VOPD_PACKET_ROLE_SECOND) {
     return iree_ok_status();
   }
   IREE_ASSERT(vopd_packet->role == LOOM_AMDGPU_VOPD_PACKET_ROLE_FIRST);
   const loom_amdgpu_vopd_pair_t* pair =
-      &state->vopd_plan->pairs[vopd_packet->pair_index];
+      &state->packet_plan.vopd_plan->pairs[vopd_packet->pair_index];
   return loom_amdgpu_append_vopd_pair_packet(context, pair);
 }
 
@@ -3575,11 +3594,17 @@ iree_status_t loom_amdgpu_emit_assembly_fragment_with_options(
 
   loom_amdgpu_assembly_emit_state_t emit_state = {
       .storage_layout = storage_layout,
-      .address_state = address_state,
-      .wait_packets = wait_packets,
-      .wait_states = wait_states,
-      .vopd_plan = vopd_plan,
-      .current_block_index = LOOM_LOW_PACKET_INDEX_NONE,
+      .packet_plan =
+          {
+              .address_state = address_state,
+              .wait_packets = wait_packets,
+              .wait_states = wait_states,
+              .vopd_plan = vopd_plan,
+          },
+      .traversal =
+          {
+              .current_block_index = LOOM_LOW_PACKET_INDEX_NONE,
+          },
   };
   const loom_native_assembly_format_options_t format_options =
       loom_amdgpu_assembly_options(
@@ -3595,16 +3620,17 @@ iree_status_t loom_amdgpu_emit_assembly_fragment_with_options(
   IREE_RETURN_IF_ERROR(loom_native_assembly_format_fragment(
       schedule, allocation, &format_options, builder, scratch_arena));
   if (address_state != NULL) {
-    IREE_ASSERT_EQ(emit_state.next_address_state_index,
+    IREE_ASSERT_EQ(emit_state.packet_plan.next_address_state_index,
                    address_state->transition_count);
   }
-  IREE_ASSERT_EQ(emit_state.current_vgpr_msb_mode, 0);
+  IREE_ASSERT_EQ(emit_state.traversal.current_vgpr_msb_mode, 0);
   if (wait_packets != NULL) {
-    IREE_ASSERT_EQ(emit_state.next_wait_packet_index,
+    IREE_ASSERT_EQ(emit_state.packet_plan.next_wait_packet_index,
                    wait_packets->packet_count);
   }
   if (wait_states != NULL) {
-    IREE_ASSERT_EQ(emit_state.next_wait_state_index, wait_states->state_count);
+    IREE_ASSERT_EQ(emit_state.packet_plan.next_wait_state_index,
+                   wait_states->state_count);
   }
   return iree_ok_status();
 }

--- a/loom/src/loom/target/emit/native/amdgpu/assembly.h
+++ b/loom/src/loom/target/emit/native/amdgpu/assembly.h
@@ -14,6 +14,7 @@
 #include "iree/base/string_builder.h"
 #include "loom/codegen/low/allocation.h"
 #include "loom/codegen/low/schedule/types.h"
+#include "loom/target/emit/native/amdgpu/branch_layout.h"
 #include "loom/target/emit/native/amdgpu/storage_layout.h"
 
 #ifdef __cplusplus
@@ -25,6 +26,8 @@ typedef struct loom_amdgpu_assembly_fragment_options_t {
   const struct loom_amdgpu_packet_plan_t* packet_plan;
   // Optional function-local storage layout shared with kernel metadata.
   const loom_amdgpu_storage_layout_t* storage_layout;
+  // Optional exact branch-island layout shared with native encoding.
+  const loom_amdgpu_branch_layout_t* branch_layout;
 } loom_amdgpu_assembly_fragment_options_t;
 
 // Emits an AMDGPU assembly fragment for one scheduled and allocated AMDGPU

--- a/loom/src/loom/target/emit/native/amdgpu/branch_layout.c
+++ b/loom/src/loom/target/emit/native/amdgpu/branch_layout.c
@@ -1,0 +1,492 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/target/emit/native/amdgpu/branch_layout.h"
+
+#include <inttypes.h>
+#include <limits.h>
+
+typedef struct loom_amdgpu_branch_layout_path_node_t {
+  // Original edge whose trampoline path owns this island.
+  uint32_t edge_index;
+  // Input anchor holding this island.
+  uint32_t anchor_index;
+  // Next path node, or LOOM_AMDGPU_BRANCH_ISLAND_NONE for the final block.
+  uint32_t next_node_index;
+  // Island-table index assigned by the most recent physical layout.
+  uint32_t final_island_index;
+  // Final byte offset of the island branch instruction.
+  uint64_t final_byte_offset;
+} loom_amdgpu_branch_layout_path_node_t;
+
+typedef struct loom_amdgpu_branch_layout_scratch_group_t {
+  // Input anchor shared by the co-located islands.
+  uint32_t anchor_index;
+  // First node in the physically sorted scratch node-index table.
+  uint32_t sorted_node_start;
+  // Number of co-located island nodes.
+  uint32_t node_count;
+  // Final byte offset of the normal-flow skip branch.
+  uint64_t final_byte_offset;
+  // Total bytes occupied by the skip branch and its islands.
+  uint64_t byte_length;
+} loom_amdgpu_branch_layout_scratch_group_t;
+
+typedef struct loom_amdgpu_branch_layout_build_state_t {
+  // Immutable measured native layout.
+  const loom_amdgpu_branch_layout_input_t* input;
+  // Arena owning scratch and final tables.
+  iree_arena_allocator_t* arena;
+  // First path node for each original edge.
+  uint32_t* edge_head_node_indices;
+  // Mutable island nodes in creation order.
+  loom_amdgpu_branch_layout_path_node_t* nodes;
+  // Number of initialized entries in |nodes|.
+  uint32_t node_count;
+  // Allocated entry capacity of |nodes| and parallel scratch tables.
+  iree_host_size_t node_capacity;
+  // Node indices sorted into physical anchor order.
+  uint32_t* sorted_node_indices;
+  // Allocated entry capacity of |sorted_node_indices|.
+  iree_host_size_t sorted_node_capacity;
+  // Co-located groups rebuilt after every island insertion.
+  loom_amdgpu_branch_layout_scratch_group_t* groups;
+  // Allocated entry capacity of |groups|.
+  iree_host_size_t group_capacity;
+  // Number of initialized entries in |groups|.
+  uint32_t group_count;
+} loom_amdgpu_branch_layout_build_state_t;
+
+static bool loom_amdgpu_branch_layout_offset_fits(uint64_t source_byte_offset,
+                                                  uint64_t target_byte_offset,
+                                                  int16_t* out_displacement) {
+  IREE_ASSERT_LE(source_byte_offset, (uint64_t)INT64_MAX - 4u);
+  IREE_ASSERT_LE(target_byte_offset, (uint64_t)INT64_MAX);
+  const int64_t relative_byte_offset =
+      (int64_t)target_byte_offset - ((int64_t)source_byte_offset + 4);
+  IREE_ASSERT_EQ(relative_byte_offset % 4, 0);
+  const int64_t relative_dword_offset = relative_byte_offset / 4;
+  if (relative_dword_offset < INT16_MIN || relative_dword_offset > INT16_MAX) {
+    return false;
+  }
+  if (out_displacement != NULL) {
+    *out_displacement = (int16_t)relative_dword_offset;
+  }
+  return true;
+}
+
+static bool loom_amdgpu_branch_layout_node_precedes(
+    const loom_amdgpu_branch_layout_build_state_t* state,
+    uint32_t lhs_node_index, uint32_t rhs_node_index) {
+  const loom_amdgpu_branch_layout_path_node_t* lhs =
+      &state->nodes[lhs_node_index];
+  const loom_amdgpu_branch_layout_path_node_t* rhs =
+      &state->nodes[rhs_node_index];
+  if (lhs->anchor_index != rhs->anchor_index) {
+    return lhs->anchor_index < rhs->anchor_index;
+  }
+  return lhs_node_index < rhs_node_index;
+}
+
+static void loom_amdgpu_branch_layout_sort_nodes(
+    loom_amdgpu_branch_layout_build_state_t* state) {
+  for (uint32_t i = 0; i < state->node_count; ++i) {
+    state->sorted_node_indices[i] = i;
+  }
+  for (uint32_t i = 1; i < state->node_count; ++i) {
+    const uint32_t key = state->sorted_node_indices[i];
+    uint32_t position = i;
+    while (position != 0 &&
+           loom_amdgpu_branch_layout_node_precedes(
+               state, key, state->sorted_node_indices[position - 1])) {
+      state->sorted_node_indices[position] =
+          state->sorted_node_indices[position - 1];
+      --position;
+    }
+    state->sorted_node_indices[position] = key;
+  }
+}
+
+static uint64_t loom_amdgpu_branch_layout_translate_offset(
+    const loom_amdgpu_branch_layout_build_state_t* state, uint64_t byte_offset,
+    bool include_equal_groups) {
+  uint64_t translated_offset = byte_offset;
+  for (uint32_t i = 0; i < state->group_count; ++i) {
+    const loom_amdgpu_branch_layout_scratch_group_t* group = &state->groups[i];
+    const uint64_t group_base_offset =
+        state->input->anchors[group->anchor_index].byte_offset;
+    if (group_base_offset > byte_offset ||
+        (!include_equal_groups && group_base_offset == byte_offset)) {
+      break;
+    }
+    translated_offset += group->byte_length;
+  }
+  return translated_offset;
+}
+
+static iree_status_t loom_amdgpu_branch_layout_rebuild_physical_layout(
+    loom_amdgpu_branch_layout_build_state_t* state) {
+  state->group_count = 0;
+  if (state->node_count == 0) return iree_ok_status();
+  loom_amdgpu_branch_layout_sort_nodes(state);
+
+  uint64_t inserted_byte_count = 0;
+  uint32_t sorted_node_index = 0;
+  while (sorted_node_index < state->node_count) {
+    const uint32_t first_node_index =
+        state->sorted_node_indices[sorted_node_index];
+    const uint32_t anchor_index = state->nodes[first_node_index].anchor_index;
+    uint32_t group_node_count = 1;
+    while (sorted_node_index + group_node_count < state->node_count) {
+      const uint32_t next_node_index =
+          state->sorted_node_indices[sorted_node_index + group_node_count];
+      if (state->nodes[next_node_index].anchor_index != anchor_index) break;
+      ++group_node_count;
+    }
+    if (group_node_count > INT16_MAX) {
+      return iree_make_status(
+          IREE_STATUS_RESOURCE_EXHAUSTED,
+          "AMDGPU branch relaxation requires %" PRIu32
+          " co-located islands, exceeding the SOPP skip range",
+          group_node_count);
+    }
+    const uint64_t group_byte_length = ((uint64_t)group_node_count + 1u) * 4u;
+    const uint64_t base_byte_offset =
+        state->input->anchors[anchor_index].byte_offset;
+    const uint64_t remaining_layout_bytes =
+        (uint64_t)INT64_MAX - state->input->byte_length - inserted_byte_count;
+    if (group_byte_length > remaining_layout_bytes) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "AMDGPU relaxed branch layout overflowed");
+    }
+    const uint64_t final_group_byte_offset =
+        base_byte_offset + inserted_byte_count;
+    state->groups[state->group_count++] =
+        (loom_amdgpu_branch_layout_scratch_group_t){
+            .anchor_index = anchor_index,
+            .sorted_node_start = sorted_node_index,
+            .node_count = group_node_count,
+            .final_byte_offset = final_group_byte_offset,
+            .byte_length = group_byte_length,
+        };
+    for (uint32_t i = 0; i < group_node_count; ++i) {
+      const uint32_t node_index =
+          state->sorted_node_indices[sorted_node_index + i];
+      state->nodes[node_index].final_island_index = sorted_node_index + i;
+      state->nodes[node_index].final_byte_offset =
+          final_group_byte_offset + ((uint64_t)i + 1u) * 4u;
+    }
+    inserted_byte_count += group_byte_length;
+    sorted_node_index += group_node_count;
+  }
+  return iree_ok_status();
+}
+
+static bool loom_amdgpu_branch_layout_path_uses_anchor(
+    const loom_amdgpu_branch_layout_build_state_t* state, uint32_t edge_index,
+    uint32_t anchor_index) {
+  uint32_t node_index = state->edge_head_node_indices[edge_index];
+  while (node_index != LOOM_AMDGPU_BRANCH_ISLAND_NONE) {
+    const loom_amdgpu_branch_layout_path_node_t* node =
+        &state->nodes[node_index];
+    if (node->anchor_index == anchor_index) return true;
+    node_index = node->next_node_index;
+  }
+  return false;
+}
+
+static uint32_t loom_amdgpu_branch_layout_select_midpoint_anchor(
+    const loom_amdgpu_branch_layout_build_state_t* state, uint32_t edge_index,
+    uint64_t source_base_byte_offset, uint64_t target_base_byte_offset) {
+  const uint64_t lower = source_base_byte_offset < target_base_byte_offset
+                             ? source_base_byte_offset
+                             : target_base_byte_offset;
+  const uint64_t upper = source_base_byte_offset < target_base_byte_offset
+                             ? target_base_byte_offset
+                             : source_base_byte_offset;
+  const uint64_t midpoint = lower + (upper - lower) / 2u;
+  uint32_t selected_anchor_index = LOOM_AMDGPU_BRANCH_ISLAND_NONE;
+  uint64_t selected_distance = UINT64_MAX;
+  for (iree_host_size_t i = 0; i < state->input->anchor_count; ++i) {
+    const uint64_t anchor_byte_offset = state->input->anchors[i].byte_offset;
+    if (anchor_byte_offset <= lower || anchor_byte_offset >= upper) continue;
+    if (loom_amdgpu_branch_layout_path_uses_anchor(state, edge_index,
+                                                   (uint32_t)i)) {
+      continue;
+    }
+    const uint64_t distance = anchor_byte_offset < midpoint
+                                  ? midpoint - anchor_byte_offset
+                                  : anchor_byte_offset - midpoint;
+    if (distance < selected_distance) {
+      selected_anchor_index = (uint32_t)i;
+      selected_distance = distance;
+    }
+  }
+  return selected_anchor_index;
+}
+
+static iree_status_t loom_amdgpu_branch_layout_grow_nodes(
+    loom_amdgpu_branch_layout_build_state_t* state) {
+  if (state->node_count < state->node_capacity) return iree_ok_status();
+  IREE_RETURN_IF_ERROR(iree_arena_grow_array(
+      state->arena, state->node_count, state->node_count + 1,
+      sizeof(*state->nodes), &state->node_capacity, (void**)&state->nodes));
+  IREE_RETURN_IF_ERROR(iree_arena_grow_array(
+      state->arena, state->node_count, state->node_capacity,
+      sizeof(*state->sorted_node_indices), &state->sorted_node_capacity,
+      (void**)&state->sorted_node_indices));
+  IREE_RETURN_IF_ERROR(iree_arena_grow_array(
+      state->arena, state->node_count, state->node_capacity,
+      sizeof(*state->groups), &state->group_capacity, (void**)&state->groups));
+  return iree_ok_status();
+}
+
+static iree_status_t loom_amdgpu_branch_layout_insert_island(
+    loom_amdgpu_branch_layout_build_state_t* state, uint32_t edge_index,
+    uint32_t source_node_index, uint32_t target_node_index,
+    uint64_t source_base_byte_offset, uint64_t target_base_byte_offset) {
+  const uint32_t anchor_index =
+      loom_amdgpu_branch_layout_select_midpoint_anchor(
+          state, edge_index, source_base_byte_offset, target_base_byte_offset);
+  if (anchor_index == LOOM_AMDGPU_BRANCH_ISLAND_NONE) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "AMDGPU branch relaxation has no packet boundary between native "
+        "offsets %" PRIu64 " and %" PRIu64,
+        source_base_byte_offset, target_base_byte_offset);
+  }
+  if (state->node_count == UINT32_MAX) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "AMDGPU branch-island count overflowed");
+  }
+  IREE_RETURN_IF_ERROR(loom_amdgpu_branch_layout_grow_nodes(state));
+  const uint32_t new_node_index = state->node_count++;
+  state->nodes[new_node_index] = (loom_amdgpu_branch_layout_path_node_t){
+      .edge_index = edge_index,
+      .anchor_index = anchor_index,
+      .next_node_index = target_node_index,
+      .final_island_index = LOOM_AMDGPU_BRANCH_ISLAND_NONE,
+  };
+  if (source_node_index == LOOM_AMDGPU_BRANCH_ISLAND_NONE) {
+    state->edge_head_node_indices[edge_index] = new_node_index;
+  } else {
+    state->nodes[source_node_index].next_node_index = new_node_index;
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_amdgpu_branch_layout_relax_first_long_segment(
+    loom_amdgpu_branch_layout_build_state_t* state, bool* out_changed) {
+  *out_changed = false;
+  for (uint32_t edge_index = 0; edge_index < state->input->edge_count;
+       ++edge_index) {
+    const loom_amdgpu_branch_layout_input_edge_t* edge =
+        &state->input->edges[edge_index];
+    uint32_t source_node_index = LOOM_AMDGPU_BRANCH_ISLAND_NONE;
+    uint64_t source_base_byte_offset = edge->source_byte_offset;
+    uint64_t source_final_byte_offset =
+        loom_amdgpu_branch_layout_translate_offset(
+            state, edge->source_byte_offset, /*include_equal_groups=*/true);
+    uint32_t target_node_index = state->edge_head_node_indices[edge_index];
+    while (true) {
+      uint64_t target_base_byte_offset = 0;
+      uint64_t target_final_byte_offset = 0;
+      if (target_node_index == LOOM_AMDGPU_BRANCH_ISLAND_NONE) {
+        const uint32_t target_block_index = edge->target_block_index;
+        IREE_ASSERT_LT(target_block_index, state->input->block_count);
+        target_base_byte_offset =
+            state->input->blocks[target_block_index].byte_offset;
+        target_final_byte_offset = loom_amdgpu_branch_layout_translate_offset(
+            state, target_base_byte_offset, /*include_equal_groups=*/false);
+      } else {
+        const loom_amdgpu_branch_layout_path_node_t* target_node =
+            &state->nodes[target_node_index];
+        target_base_byte_offset =
+            state->input->anchors[target_node->anchor_index].byte_offset;
+        target_final_byte_offset = target_node->final_byte_offset;
+      }
+      if (!loom_amdgpu_branch_layout_offset_fits(
+              source_final_byte_offset, target_final_byte_offset, NULL)) {
+        IREE_RETURN_IF_ERROR(loom_amdgpu_branch_layout_insert_island(
+            state, edge_index, source_node_index, target_node_index,
+            source_base_byte_offset, target_base_byte_offset));
+        *out_changed = true;
+        return iree_ok_status();
+      }
+      if (target_node_index == LOOM_AMDGPU_BRANCH_ISLAND_NONE) break;
+      source_node_index = target_node_index;
+      const loom_amdgpu_branch_layout_path_node_t* source_node =
+          &state->nodes[source_node_index];
+      source_base_byte_offset =
+          state->input->anchors[source_node->anchor_index].byte_offset;
+      source_final_byte_offset = source_node->final_byte_offset;
+      target_node_index = source_node->next_node_index;
+    }
+  }
+  return iree_ok_status();
+}
+
+static loom_amdgpu_branch_target_t loom_amdgpu_branch_layout_node_target(
+    const loom_amdgpu_branch_layout_build_state_t* state,
+    const loom_amdgpu_branch_layout_input_edge_t* edge, uint32_t node_index) {
+  if (node_index == LOOM_AMDGPU_BRANCH_ISLAND_NONE) {
+    return (loom_amdgpu_branch_target_t){
+        .kind = LOOM_AMDGPU_BRANCH_TARGET_BLOCK,
+        .index = edge->target_block_index,
+    };
+  }
+  return (loom_amdgpu_branch_target_t){
+      .kind = LOOM_AMDGPU_BRANCH_TARGET_ISLAND,
+      .index = state->nodes[node_index].final_island_index,
+  };
+}
+
+static uint64_t loom_amdgpu_branch_layout_target_final_offset(
+    const loom_amdgpu_branch_layout_build_state_t* state,
+    const loom_amdgpu_branch_layout_input_edge_t* edge, uint32_t node_index) {
+  if (node_index != LOOM_AMDGPU_BRANCH_ISLAND_NONE) {
+    return state->nodes[node_index].final_byte_offset;
+  }
+  const uint64_t block_byte_offset =
+      state->input->blocks[edge->target_block_index].byte_offset;
+  return loom_amdgpu_branch_layout_translate_offset(
+      state, block_byte_offset, /*include_equal_groups=*/false);
+}
+
+static iree_status_t loom_amdgpu_branch_layout_export(
+    const loom_amdgpu_branch_layout_build_state_t* state,
+    loom_amdgpu_branch_layout_t* out_layout) {
+  if (state->node_count == 0) return iree_ok_status();
+
+  loom_amdgpu_branch_layout_edge_t* edges = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      state->arena, state->input->edge_count, sizeof(*edges), (void**)&edges));
+  loom_amdgpu_branch_layout_island_t* islands = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      state->arena, state->node_count, sizeof(*islands), (void**)&islands));
+  loom_amdgpu_branch_layout_group_t* groups = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      state->arena, state->group_count, sizeof(*groups), (void**)&groups));
+
+  for (uint32_t edge_index = 0; edge_index < state->input->edge_count;
+       ++edge_index) {
+    const loom_amdgpu_branch_layout_input_edge_t* input_edge =
+        &state->input->edges[edge_index];
+    const uint32_t target_node_index =
+        state->edge_head_node_indices[edge_index];
+    const uint64_t source_final_byte_offset =
+        loom_amdgpu_branch_layout_translate_offset(
+            state, input_edge->source_byte_offset,
+            /*include_equal_groups=*/true);
+    const uint64_t target_final_byte_offset =
+        loom_amdgpu_branch_layout_target_final_offset(state, input_edge,
+                                                      target_node_index);
+    int16_t displacement = 0;
+    const bool displacement_fits = loom_amdgpu_branch_layout_offset_fits(
+        source_final_byte_offset, target_final_byte_offset, &displacement);
+    IREE_ASSERT(displacement_fits);
+    (void)displacement_fits;
+    edges[edge_index] = (loom_amdgpu_branch_layout_edge_t){
+        .target = loom_amdgpu_branch_layout_node_target(state, input_edge,
+                                                        target_node_index),
+        .relative_dword_offset = displacement,
+    };
+  }
+
+  for (uint32_t sorted_index = 0; sorted_index < state->node_count;
+       ++sorted_index) {
+    const uint32_t node_index = state->sorted_node_indices[sorted_index];
+    const loom_amdgpu_branch_layout_path_node_t* node =
+        &state->nodes[node_index];
+    const uint32_t owner_edge_index = node->edge_index;
+    IREE_ASSERT_LT(owner_edge_index, state->input->edge_count);
+    const loom_amdgpu_branch_layout_input_edge_t* owner_edge =
+        &state->input->edges[owner_edge_index];
+    const uint64_t target_final_byte_offset =
+        loom_amdgpu_branch_layout_target_final_offset(state, owner_edge,
+                                                      node->next_node_index);
+    int16_t displacement = 0;
+    const bool displacement_fits = loom_amdgpu_branch_layout_offset_fits(
+        node->final_byte_offset, target_final_byte_offset, &displacement);
+    IREE_ASSERT(displacement_fits);
+    (void)displacement_fits;
+    islands[sorted_index] = (loom_amdgpu_branch_layout_island_t){
+        .target = loom_amdgpu_branch_layout_node_target(state, owner_edge,
+                                                        node->next_node_index),
+        .relative_dword_offset = displacement,
+    };
+  }
+
+  for (uint32_t group_index = 0; group_index < state->group_count;
+       ++group_index) {
+    const loom_amdgpu_branch_layout_scratch_group_t* scratch_group =
+        &state->groups[group_index];
+    groups[group_index] = (loom_amdgpu_branch_layout_group_t){
+        .packet_index =
+            state->input->anchors[scratch_group->anchor_index].packet_index,
+        .island_start = scratch_group->sorted_node_start,
+        .island_count = scratch_group->node_count,
+    };
+  }
+
+  uint64_t inserted_byte_count = 0;
+  for (uint32_t i = 0; i < state->group_count; ++i) {
+    inserted_byte_count += state->groups[i].byte_length;
+  }
+  if (state->input->byte_length > UINT64_MAX - inserted_byte_count) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "AMDGPU relaxed branch layout overflowed");
+  }
+  *out_layout = (loom_amdgpu_branch_layout_t){
+      .byte_length = state->input->byte_length + inserted_byte_count,
+      .edges = edges,
+      .edge_count = state->input->edge_count,
+      .islands = islands,
+      .island_count = state->node_count,
+      .groups = groups,
+      .group_count = state->group_count,
+  };
+  return iree_ok_status();
+}
+
+iree_status_t loom_amdgpu_branch_layout_build(
+    const loom_amdgpu_branch_layout_input_t* input,
+    iree_arena_allocator_t* arena, loom_amdgpu_branch_layout_t* out_layout) {
+  *out_layout = (loom_amdgpu_branch_layout_t){0};
+  if (input->edge_count == 0) return iree_ok_status();
+  if (input->byte_length > (uint64_t)INT64_MAX) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "AMDGPU native instruction stream exceeds signed layout range");
+  }
+  if (input->block_count > UINT32_MAX || input->edge_count > UINT32_MAX ||
+      input->anchor_count > UINT32_MAX) {
+    return iree_make_status(
+        IREE_STATUS_RESOURCE_EXHAUSTED,
+        "AMDGPU branch layout exceeds 32-bit table capacity");
+  }
+  uint32_t* edge_head_node_indices = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+      arena, input->edge_count, sizeof(*edge_head_node_indices),
+      (void**)&edge_head_node_indices));
+  for (iree_host_size_t i = 0; i < input->edge_count; ++i) {
+    edge_head_node_indices[i] = LOOM_AMDGPU_BRANCH_ISLAND_NONE;
+  }
+  loom_amdgpu_branch_layout_build_state_t state = {
+      .input = input,
+      .arena = arena,
+      .edge_head_node_indices = edge_head_node_indices,
+  };
+  while (true) {
+    IREE_RETURN_IF_ERROR(
+        loom_amdgpu_branch_layout_rebuild_physical_layout(&state));
+    bool changed = false;
+    IREE_RETURN_IF_ERROR(
+        loom_amdgpu_branch_layout_relax_first_long_segment(&state, &changed));
+    if (!changed) break;
+  }
+  return loom_amdgpu_branch_layout_export(&state, out_layout);
+}

--- a/loom/src/loom/target/emit/native/amdgpu/branch_layout.h
+++ b/loom/src/loom/target/emit/native/amdgpu/branch_layout.h
@@ -1,0 +1,134 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// AMDGPU SOPP branch-island layout over measured native packet offsets.
+
+#ifndef LOOM_TARGET_EMIT_NATIVE_AMDGPU_BRANCH_LAYOUT_H_
+#define LOOM_TARGET_EMIT_NATIVE_AMDGPU_BRANCH_LAYOUT_H_
+
+#include <stdint.h>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/arena.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Sentinel for an absent branch-island index.
+#define LOOM_AMDGPU_BRANCH_ISLAND_NONE UINT32_MAX
+
+// One measured basic-block start in the unrelaxed native stream.
+typedef struct loom_amdgpu_branch_layout_block_t {
+  // Byte offset of the block label in the unrelaxed stream.
+  uint64_t byte_offset;
+} loom_amdgpu_branch_layout_block_t;
+
+// One emitted SOPP branch in native emission order.
+typedef struct loom_amdgpu_branch_layout_input_edge_t {
+  // Byte offset of the branch instruction in the unrelaxed stream.
+  uint64_t source_byte_offset;
+  // Index of the destination in the measured block table.
+  uint32_t target_block_index;
+} loom_amdgpu_branch_layout_input_edge_t;
+
+// A legal insertion boundary before one scheduled packet.
+typedef struct loom_amdgpu_branch_layout_anchor_t {
+  // Byte offset before the packet in the unrelaxed stream.
+  uint64_t byte_offset;
+  // Packet index identifying the insertion boundary during emission.
+  uint32_t packet_index;
+} loom_amdgpu_branch_layout_anchor_t;
+
+// Measured unrelaxed layout consumed by branch relaxation.
+typedef struct loom_amdgpu_branch_layout_input_t {
+  // Total byte length of the unrelaxed native instruction stream.
+  uint64_t byte_length;
+  // Basic-block start offsets in physical emission order.
+  const loom_amdgpu_branch_layout_block_t* blocks;
+  // Number of entries in |blocks|.
+  iree_host_size_t block_count;
+  // Emitted SOPP control-flow edges in physical emission order.
+  const loom_amdgpu_branch_layout_input_edge_t* edges;
+  // Number of entries in |edges|.
+  iree_host_size_t edge_count;
+  // Sorted legal branch-island insertion boundaries.
+  const loom_amdgpu_branch_layout_anchor_t* anchors;
+  // Number of entries in |anchors|.
+  iree_host_size_t anchor_count;
+} loom_amdgpu_branch_layout_input_t;
+
+typedef uint8_t loom_amdgpu_branch_target_kind_t;
+enum loom_amdgpu_branch_target_kind_e {
+  // The target index names an original scheduled block.
+  LOOM_AMDGPU_BRANCH_TARGET_BLOCK = 0,
+  // The target index names a branch island in the relaxed plan.
+  LOOM_AMDGPU_BRANCH_TARGET_ISLAND = 1,
+};
+
+// Symbolic destination shared by assembly and binary emission.
+typedef struct loom_amdgpu_branch_target_t {
+  // Namespace containing |index|.
+  loom_amdgpu_branch_target_kind_t kind;
+  // Block or island index selected by |kind|.
+  uint32_t index;
+} loom_amdgpu_branch_target_t;
+
+// One original edge after final branch-island placement.
+typedef struct loom_amdgpu_branch_layout_edge_t {
+  // Direct block or first branch-island destination.
+  loom_amdgpu_branch_target_t target;
+  // Signed SOPP displacement from the instruction following the branch.
+  int16_t relative_dword_offset;
+} loom_amdgpu_branch_layout_edge_t;
+
+// One unconditional branch island inserted into the native stream.
+typedef struct loom_amdgpu_branch_layout_island_t {
+  // Direct next-island or final-block destination.
+  loom_amdgpu_branch_target_t target;
+  // Signed SOPP displacement from the instruction following the island.
+  int16_t relative_dword_offset;
+} loom_amdgpu_branch_layout_island_t;
+
+// Co-located islands inserted before one scheduled packet.
+typedef struct loom_amdgpu_branch_layout_group_t {
+  // Packet index identifying the insertion boundary during emission.
+  uint32_t packet_index;
+  // First entry owned by this group in the plan island table.
+  uint32_t island_start;
+  // Number of contiguous island entries owned by this group.
+  uint32_t island_count;
+} loom_amdgpu_branch_layout_group_t;
+
+// Immutable exact layout shared by native assembly and binary emission.
+typedef struct loom_amdgpu_branch_layout_t {
+  // Final instruction-stream byte length including branch islands.
+  uint64_t byte_length;
+  // Original edges in native emission order.
+  const loom_amdgpu_branch_layout_edge_t* edges;
+  // Number of entries in |edges|.
+  iree_host_size_t edge_count;
+  // Inserted unconditional branch islands grouped by insertion boundary.
+  const loom_amdgpu_branch_layout_island_t* islands;
+  // Number of entries in |islands|.
+  iree_host_size_t island_count;
+  // Island groups in scheduled packet order.
+  const loom_amdgpu_branch_layout_group_t* groups;
+  // Number of entries in |groups|.
+  iree_host_size_t group_count;
+} loom_amdgpu_branch_layout_t;
+
+// Builds an exact converged branch-island layout. Empty output means every
+// measured edge is directly encodable and the original bytes remain unchanged.
+iree_status_t loom_amdgpu_branch_layout_build(
+    const loom_amdgpu_branch_layout_input_t* input,
+    iree_arena_allocator_t* arena, loom_amdgpu_branch_layout_t* out_layout);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_TARGET_EMIT_NATIVE_AMDGPU_BRANCH_LAYOUT_H_

--- a/loom/src/loom/target/emit/native/amdgpu/branch_layout_test.cc
+++ b/loom/src/loom/target/emit/native/amdgpu/branch_layout_test.cc
@@ -1,0 +1,198 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/target/emit/native/amdgpu/branch_layout.h"
+
+#include <array>
+#include <cstdint>
+
+#include "iree/base/internal/arena.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace loom {
+namespace {
+
+static loom_amdgpu_branch_layout_block_t BlockAt(uint64_t byte_offset) {
+  return {/*byte_offset=*/byte_offset};
+}
+
+static loom_amdgpu_branch_layout_input_edge_t EdgeTo(
+    uint64_t source_byte_offset, uint32_t target_block_index) {
+  return {/*source_byte_offset=*/source_byte_offset,
+          /*target_block_index=*/target_block_index};
+}
+
+static loom_amdgpu_branch_layout_anchor_t AnchorAt(uint64_t byte_offset,
+                                                   uint32_t packet_index) {
+  return {/*byte_offset=*/byte_offset, /*packet_index=*/packet_index};
+}
+
+class AmdgpuBranchLayoutTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    iree_arena_block_pool_initialize(4096, iree_allocator_system(),
+                                     &block_pool_);
+    iree_arena_initialize(&block_pool_, &arena_);
+  }
+
+  void TearDown() override {
+    iree_arena_deinitialize(&arena_);
+    iree_arena_block_pool_deinitialize(&block_pool_);
+  }
+
+  template <size_t BlockCount, size_t EdgeCount, size_t AnchorCount>
+  loom_amdgpu_branch_layout_t Build(
+      uint64_t byte_length,
+      const std::array<loom_amdgpu_branch_layout_block_t, BlockCount>& blocks,
+      const std::array<loom_amdgpu_branch_layout_input_edge_t, EdgeCount>&
+          edges,
+      const std::array<loom_amdgpu_branch_layout_anchor_t, AnchorCount>&
+          anchors) {
+    const loom_amdgpu_branch_layout_input_t input = {
+        /*byte_length=*/byte_length,
+        /*blocks=*/blocks.data(),
+        /*block_count=*/blocks.size(),
+        /*edges=*/edges.data(),
+        /*edge_count=*/edges.size(),
+        /*anchors=*/anchors.data(),
+        /*anchor_count=*/anchors.size(),
+    };
+    loom_amdgpu_branch_layout_t layout = {};
+    IREE_EXPECT_OK(loom_amdgpu_branch_layout_build(&input, &arena_, &layout));
+    return layout;
+  }
+
+  iree_arena_block_pool_t block_pool_;
+  iree_arena_allocator_t arena_;
+};
+
+TEST_F(AmdgpuBranchLayoutTest, LeavesSignedRangeBoundariesUnchanged) {
+  constexpr uint64_t kForwardTarget = 4u + uint64_t{INT16_MAX} * 4u;
+  constexpr uint64_t kBackwardSource = uint64_t{INT16_MAX} * 4u;
+  const std::array blocks = {
+      BlockAt(0),
+      BlockAt(kForwardTarget),
+  };
+  const std::array edges = {
+      EdgeTo(/*source_byte_offset=*/0, /*target_block_index=*/1),
+      EdgeTo(/*source_byte_offset=*/kBackwardSource,
+             /*target_block_index=*/0),
+  };
+  const std::array<loom_amdgpu_branch_layout_anchor_t, 0> anchors = {};
+
+  const loom_amdgpu_branch_layout_t layout =
+      Build(kForwardTarget + 4u, blocks, edges, anchors);
+  EXPECT_EQ(layout.island_count, 0u);
+  EXPECT_EQ(layout.group_count, 0u);
+  EXPECT_EQ(layout.edge_count, 0u);
+}
+
+TEST_F(AmdgpuBranchLayoutTest, RelaxesJustOutsideForwardRange) {
+  constexpr uint64_t kTarget = 4u + (uint64_t{INT16_MAX} + 1u) * 4u;
+  const std::array blocks = {
+      BlockAt(0),
+      BlockAt(kTarget),
+  };
+  const std::array edges = {
+      EdgeTo(/*source_byte_offset=*/0, /*target_block_index=*/1),
+  };
+  const std::array anchors = {
+      AnchorAt(/*byte_offset=*/(kTarget / 8u) * 4u, /*packet_index=*/7),
+  };
+
+  const loom_amdgpu_branch_layout_t layout =
+      Build(kTarget + 4u, blocks, edges, anchors);
+  ASSERT_EQ(layout.edge_count, 1u);
+  ASSERT_EQ(layout.island_count, 1u);
+  ASSERT_EQ(layout.group_count, 1u);
+  EXPECT_EQ(layout.byte_length, kTarget + 12u);
+  EXPECT_EQ(layout.groups[0].packet_index, 7u);
+  EXPECT_EQ(layout.groups[0].island_count, 1u);
+  EXPECT_EQ(layout.edges[0].target.kind, LOOM_AMDGPU_BRANCH_TARGET_ISLAND);
+  EXPECT_EQ(layout.edges[0].target.index, 0u);
+  EXPECT_EQ(layout.islands[0].target.kind, LOOM_AMDGPU_BRANCH_TARGET_BLOCK);
+  EXPECT_EQ(layout.islands[0].target.index, 1u);
+  EXPECT_EQ(layout.edges[0].relative_dword_offset, 16384);
+  EXPECT_EQ(layout.islands[0].relative_dword_offset, 16385);
+}
+
+TEST_F(AmdgpuBranchLayoutTest, RelaxesJustOutsideBackwardRange) {
+  constexpr uint64_t kSource = (uint64_t{-INT16_MIN} + 1u) * 4u - 4u;
+  const std::array blocks = {
+      BlockAt(0),
+  };
+  const std::array edges = {
+      EdgeTo(/*source_byte_offset=*/kSource, /*target_block_index=*/0),
+  };
+  const std::array anchors = {
+      AnchorAt(/*byte_offset=*/kSource / 2u, /*packet_index=*/11),
+  };
+
+  const loom_amdgpu_branch_layout_t layout =
+      Build(kSource + 4u, blocks, edges, anchors);
+  ASSERT_EQ(layout.edge_count, 1u);
+  ASSERT_EQ(layout.island_count, 1u);
+  EXPECT_EQ(layout.edges[0].relative_dword_offset, -16386);
+  EXPECT_EQ(layout.islands[0].relative_dword_offset, -16386);
+}
+
+TEST_F(AmdgpuBranchLayoutTest, RecomputesDirectSiblingEdgeAfterInsertion) {
+  constexpr uint64_t kFarTarget = 4u + (uint64_t{INT16_MAX} + 1u) * 4u;
+  constexpr uint64_t kNearTarget = 70u * 1024u;
+  const std::array blocks = {
+      BlockAt(0),
+      BlockAt(kNearTarget),
+      BlockAt(kFarTarget),
+  };
+  const std::array edges = {
+      EdgeTo(/*source_byte_offset=*/0, /*target_block_index=*/2),
+      EdgeTo(/*source_byte_offset=*/4, /*target_block_index=*/1),
+  };
+  const std::array anchors = {
+      AnchorAt(/*byte_offset=*/(kFarTarget / 8u) * 4u,
+               /*packet_index=*/5),
+  };
+
+  const loom_amdgpu_branch_layout_t layout =
+      Build(kFarTarget + 4u, blocks, edges, anchors);
+  ASSERT_EQ(layout.edge_count, 2u);
+  ASSERT_EQ(layout.island_count, 1u);
+  EXPECT_EQ(layout.edges[1].target.kind, LOOM_AMDGPU_BRANCH_TARGET_BLOCK);
+  EXPECT_EQ(layout.edges[1].target.index, 1u);
+  EXPECT_EQ(layout.edges[1].relative_dword_offset, 17920);
+}
+
+TEST_F(AmdgpuBranchLayoutTest, BuildsConvergedMultiHopPath) {
+  constexpr uint64_t kTarget = 1024u * 1024u;
+  const std::array blocks = {
+      BlockAt(0),
+      BlockAt(kTarget),
+  };
+  const std::array edges = {
+      EdgeTo(/*source_byte_offset=*/0, /*target_block_index=*/1),
+  };
+  std::array<loom_amdgpu_branch_layout_anchor_t, 15> anchors = {};
+  for (uint32_t i = 0; i < anchors.size(); ++i) {
+    anchors[i] =
+        AnchorAt(uint64_t{i + 1u} * 64u * 1024u, /*packet_index=*/i + 1u);
+  }
+
+  const loom_amdgpu_branch_layout_t layout =
+      Build(kTarget + 4u, blocks, edges, anchors);
+  ASSERT_GT(layout.island_count, 1u);
+  for (iree_host_size_t i = 0; i < layout.edge_count; ++i) {
+    EXPECT_GE(layout.edges[i].relative_dword_offset, INT16_MIN);
+    EXPECT_LE(layout.edges[i].relative_dword_offset, INT16_MAX);
+  }
+  for (iree_host_size_t i = 0; i < layout.island_count; ++i) {
+    EXPECT_GE(layout.islands[i].relative_dword_offset, INT16_MIN);
+    EXPECT_LE(layout.islands[i].relative_dword_offset, INT16_MAX);
+  }
+}
+
+}  // namespace
+}  // namespace loom

--- a/loom/src/loom/target/emit/native/amdgpu/encoding.c
+++ b/loom/src/loom/target/emit/native/amdgpu/encoding.c
@@ -1620,12 +1620,19 @@ static iree_status_t loom_amdgpu_encode_branch_groups_before_packet(
     IREE_RETURN_IF_ERROR(
         loom_amdgpu_encode_sopp_simm16(state, state->inputs.target->sopp.branch,
                                        (uint16_t)group->island_count));
+    loom_amdgpu_record_native_insertion(
+        state, LOOM_AMDGPU_NATIVE_INSERTION_BRANCH_ISLAND_SKIP,
+        LOOM_AMDGPU_DESCRIPTOR_REF_NONE, (uint16_t)group->island_count);
     for (uint32_t i = 0; i < group->island_count; ++i) {
       const loom_amdgpu_branch_layout_island_t* island =
           &emission->layout->islands[group->island_start + i];
       IREE_RETURN_IF_ERROR(loom_amdgpu_encode_sopp_simm16(
           state, state->inputs.target->sopp.branch,
           (uint16_t)island->relative_dword_offset));
+      loom_amdgpu_record_native_insertion(
+          state, LOOM_AMDGPU_NATIVE_INSERTION_BRANCH_ISLAND_HOP,
+          LOOM_AMDGPU_DESCRIPTOR_REF_NONE,
+          (uint16_t)island->relative_dword_offset);
     }
     ++emission->next_group_index;
   }
@@ -2351,11 +2358,24 @@ static iree_status_t loom_amdgpu_encode_instruction_stream_internal(
         iree_arena_allocate_array(arena, sizing_state.text_fixups.count,
                                   sizeof(text_fixups[0]), (void**)&text_fixups);
   }
+  iree_host_size_t native_insertion_capacity =
+      sizing_state.native_insertions.count;
+  if (active_branch_layout != NULL &&
+      iree_all_bits_set(
+          flags,
+          LOOM_AMDGPU_ENCODE_INSTRUCTION_STREAM_FLAG_CAPTURE_NATIVE_INSERTIONS)) {
+    IREE_ASSERT_LE(active_branch_layout->group_count,
+                   IREE_HOST_SIZE_MAX - native_insertion_capacity);
+    native_insertion_capacity += active_branch_layout->group_count;
+    IREE_ASSERT_LE(active_branch_layout->island_count,
+                   IREE_HOST_SIZE_MAX - native_insertion_capacity);
+    native_insertion_capacity += active_branch_layout->island_count;
+  }
   loom_amdgpu_native_insertion_t* native_insertions = NULL;
-  if (iree_status_is_ok(status) && sizing_state.native_insertions.count != 0) {
-    status = iree_arena_allocate_array(
-        arena, sizing_state.native_insertions.count,
-        sizeof(native_insertions[0]), (void**)&native_insertions);
+  if (iree_status_is_ok(status) && native_insertion_capacity != 0) {
+    status = iree_arena_allocate_array(arena, native_insertion_capacity,
+                                       sizeof(native_insertions[0]),
+                                       (void**)&native_insertions);
   }
   loom_amdgpu_encode_state_t writing_state = {
       .inputs = inputs,
@@ -2373,7 +2393,7 @@ static iree_status_t loom_amdgpu_encode_instruction_stream_internal(
       .native_insertions =
           {
               .values = native_insertions,
-              .capacity = sizing_state.native_insertions.count,
+              .capacity = native_insertion_capacity,
           },
       .branches =
           {
@@ -2398,7 +2418,7 @@ static iree_status_t loom_amdgpu_encode_instruction_stream_internal(
     IREE_ASSERT_EQ(writing_state.text_fixups.count,
                    sizing_state.text_fixups.count);
     IREE_ASSERT_EQ(writing_state.native_insertions.count,
-                   sizing_state.native_insertions.count);
+                   native_insertion_capacity);
     *out_stream = (loom_amdgpu_encoded_instruction_stream_t){
         .text = iree_make_const_byte_span(data, writing_state.stream.length),
         .instruction_count = writing_state.stream.instruction_count,

--- a/loom/src/loom/target/emit/native/amdgpu/encoding.c
+++ b/loom/src/loom/target/emit/native/amdgpu/encoding.c
@@ -2399,16 +2399,15 @@ static iree_status_t loom_amdgpu_encode_instruction_stream_internal(
                    sizing_state.text_fixups.count);
     IREE_ASSERT_EQ(writing_state.native_insertions.count,
                    sizing_state.native_insertions.count);
-    if (final_byte_length != 0) {
-      *out_stream = (loom_amdgpu_encoded_instruction_stream_t){
-          .text = iree_make_const_byte_span(data, writing_state.stream.length),
-          .instruction_count = writing_state.stream.instruction_count,
-          .text_fixups = text_fixups,
-          .text_fixup_count = writing_state.text_fixups.count,
-          .native_insertions = native_insertions,
-          .native_insertion_count = writing_state.native_insertions.count,
-      };
-    }
+    *out_stream = (loom_amdgpu_encoded_instruction_stream_t){
+        .text = iree_make_const_byte_span(data, writing_state.stream.length),
+        .instruction_count = writing_state.stream.instruction_count,
+        .branch_layout = branch_layout,
+        .text_fixups = text_fixups,
+        .text_fixup_count = writing_state.text_fixups.count,
+        .native_insertions = native_insertions,
+        .native_insertion_count = writing_state.native_insertions.count,
+    };
   }
   loom_low_allocation_release_value_scratch(&scratch);
   return status;

--- a/loom/src/loom/target/emit/native/amdgpu/encoding.c
+++ b/loom/src/loom/target/emit/native/amdgpu/encoding.c
@@ -18,10 +18,16 @@
 #include "loom/target/arch/amdgpu/planning/packet_plan.h"
 #include "loom/target/arch/amdgpu/refs/target_refs.h"
 #include "loom/target/arch/amdgpu/target_info.h"
+#include "loom/target/emit/native/amdgpu/branch_layout.h"
 #include "loom/target/emit/native/amdgpu/register_class.h"
 #include "loom/target/emit/native/amdgpu/storage_layout.h"
 
 #define LOOM_AMDGPU_SGPR_COUNT 128u
+
+// Maximum byte distance between an unrelaxed block boundary and branch packet
+// for which every possible signed SOPP displacement is directly encodable.
+#define LOOM_AMDGPU_SOPP_BRANCH_SPAN_BYTE_COUNT \
+  ((uint64_t)(-(int64_t)INT16_MIN) * 4u)
 
 typedef uint8_t loom_amdgpu_pc_component_t;
 enum loom_amdgpu_pc_component_e {
@@ -133,9 +139,37 @@ typedef struct loom_amdgpu_encode_traversal_state_t {
   loom_amdgpu_pc_register_state_t pc_registers[LOOM_AMDGPU_SGPR_COUNT];
 } loom_amdgpu_encode_traversal_state_t;
 
-typedef struct loom_amdgpu_encode_branch_state_t {
+typedef struct loom_amdgpu_encode_branch_measurement_t {
   // Planned byte offset for each scheduled block.
-  iree_host_size_t* block_offsets;
+  loom_amdgpu_branch_layout_block_t* blocks;
+  // Emitted SOPP edges captured during exact branch measurement.
+  loom_amdgpu_branch_layout_input_edge_t* edges;
+  // Capacity of |edges|.
+  iree_host_size_t edge_capacity;
+  // Number of entries written to |edges|.
+  iree_host_size_t edge_count;
+  // Positive-size packet boundaries captured during exact measurement.
+  loom_amdgpu_branch_layout_anchor_t* anchors;
+  // Capacity of |anchors|.
+  iree_host_size_t anchor_capacity;
+  // Number of entries written to |anchors|.
+  iree_host_size_t anchor_count;
+} loom_amdgpu_encode_branch_measurement_t;
+
+typedef struct loom_amdgpu_encode_branch_emission_t {
+  // Optional converged island layout consumed during the writing pass.
+  const loom_amdgpu_branch_layout_t* layout;
+  // Next original edge consumed from |layout|.
+  iree_host_size_t next_edge_index;
+  // Next island group consumed from |layout|.
+  iree_host_size_t next_group_index;
+} loom_amdgpu_encode_branch_emission_t;
+
+typedef struct loom_amdgpu_encode_branch_state_t {
+  // Unrelaxed offsets and optional exceptional-path measurements.
+  loom_amdgpu_encode_branch_measurement_t measurement;
+  // Final relaxed plan and writing-pass cursors.
+  loom_amdgpu_encode_branch_emission_t emission;
 } loom_amdgpu_encode_branch_state_t;
 
 typedef struct loom_amdgpu_encode_state_t {
@@ -1524,20 +1558,38 @@ static iree_status_t loom_amdgpu_encode_branch_offset(
                             "in the scheduled low function");
   }
   if (state->stream.data == NULL) {
+    loom_amdgpu_encode_branch_measurement_t* measurement =
+        &state->branches.measurement;
+    if (measurement->edges != NULL) {
+      IREE_ASSERT_LT(measurement->edge_count, measurement->edge_capacity);
+      measurement->edges[measurement->edge_count++] =
+          (loom_amdgpu_branch_layout_input_edge_t){
+              .source_byte_offset = state->stream.length,
+              .target_block_index = target_block_index,
+          };
+    }
     return iree_ok_status();
   }
-  IREE_ASSERT(state->branches.block_offsets != NULL);
+  loom_amdgpu_encode_branch_emission_t* emission = &state->branches.emission;
+  if (emission->layout != NULL) {
+    IREE_ASSERT_LT(emission->next_edge_index, emission->layout->edge_count);
+    const loom_amdgpu_branch_layout_edge_t* edge =
+        &emission->layout->edges[emission->next_edge_index++];
+    *out_immediate = (uint16_t)edge->relative_dword_offset;
+    return iree_ok_status();
+  }
+  const loom_amdgpu_branch_layout_block_t* blocks =
+      state->branches.measurement.blocks;
+  IREE_ASSERT(blocks != NULL);
   if (state->stream.length > (iree_host_size_t)INT64_MAX - 4 ||
-      state->branches.block_offsets[target_block_index] >
-          (iree_host_size_t)INT64_MAX) {
+      blocks[target_block_index].byte_offset > (uint64_t)INT64_MAX) {
     return iree_make_status(
         IREE_STATUS_OUT_OF_RANGE,
         "AMDGPU native encoding branch target byte offset exceeds int64_t");
   }
 
   const int64_t branch_base_offset = (int64_t)state->stream.length + 4;
-  const int64_t target_offset =
-      (int64_t)state->branches.block_offsets[target_block_index];
+  const int64_t target_offset = (int64_t)blocks[target_block_index].byte_offset;
   const int64_t relative_byte_offset = target_offset - branch_base_offset;
   if ((relative_byte_offset % 4) != 0) {
     return iree_make_status(
@@ -1554,6 +1606,29 @@ static iree_status_t loom_amdgpu_encode_branch_offset(
   }
   *out_immediate =
       (uint16_t)((uint32_t)relative_dword_offset & UINT32_C(0xFFFF));
+  return iree_ok_status();
+}
+
+static iree_status_t loom_amdgpu_encode_branch_groups_before_packet(
+    loom_amdgpu_encode_state_t* state, iree_host_size_t packet_index) {
+  loom_amdgpu_encode_branch_emission_t* emission = &state->branches.emission;
+  if (emission->layout == NULL) return iree_ok_status();
+  while (emission->next_group_index < emission->layout->group_count) {
+    const loom_amdgpu_branch_layout_group_t* group =
+        &emission->layout->groups[emission->next_group_index];
+    if (group->packet_index != packet_index) break;
+    IREE_RETURN_IF_ERROR(
+        loom_amdgpu_encode_sopp_simm16(state, state->inputs.target->sopp.branch,
+                                       (uint16_t)group->island_count));
+    for (uint32_t i = 0; i < group->island_count; ++i) {
+      const loom_amdgpu_branch_layout_island_t* island =
+          &emission->layout->islands[group->island_start + i];
+      IREE_RETURN_IF_ERROR(loom_amdgpu_encode_sopp_simm16(
+          state, state->inputs.target->sopp.branch,
+          (uint16_t)island->relative_dword_offset));
+    }
+    ++emission->next_group_index;
+  }
   return iree_ok_status();
 }
 
@@ -1938,6 +2013,95 @@ static iree_status_t loom_amdgpu_resolve_immediate_name_ids(
   return iree_ok_status();
 }
 
+typedef struct loom_amdgpu_branch_measurement_requirements_t {
+  // Exact number of emitted non-fallthrough SOPP edges.
+  iree_host_size_t edge_count;
+  // Whether at least one edge may exceed the signed SOPP range.
+  bool may_require_relaxation;
+} loom_amdgpu_branch_measurement_requirements_t;
+
+static void loom_amdgpu_accumulate_branch_measurement_requirement(
+    const loom_low_schedule_table_t* schedule,
+    const loom_amdgpu_branch_layout_block_t* blocks, uint64_t byte_length,
+    uint32_t source_block_index, const loom_block_t* target_block,
+    loom_amdgpu_branch_measurement_requirements_t* requirements) {
+  ++requirements->edge_count;
+  const uint32_t target_block_index =
+      loom_low_packet_block_index(schedule, target_block);
+  IREE_ASSERT_NE(target_block_index, LOOM_LOW_PACKET_INDEX_NONE);
+  const uint64_t source_start = blocks[source_block_index].byte_offset;
+  const uint64_t source_end = source_block_index + 1u < schedule->block_count
+                                  ? blocks[source_block_index + 1u].byte_offset
+                                  : byte_length;
+  const uint64_t target = blocks[target_block_index].byte_offset;
+  if ((target > source_start &&
+       target - source_start > LOOM_AMDGPU_SOPP_BRANCH_SPAN_BYTE_COUNT) ||
+      (source_end > target &&
+       source_end - target > LOOM_AMDGPU_SOPP_BRANCH_SPAN_BYTE_COUNT)) {
+    requirements->may_require_relaxation = true;
+  }
+}
+
+static loom_amdgpu_branch_measurement_requirements_t
+loom_amdgpu_query_branch_measurement_requirements(
+    const loom_low_schedule_table_t* schedule,
+    const loom_amdgpu_branch_layout_block_t* blocks, uint64_t byte_length) {
+  loom_amdgpu_branch_measurement_requirements_t requirements = {0};
+  if (byte_length <= LOOM_AMDGPU_SOPP_BRANCH_SPAN_BYTE_COUNT) {
+    return requirements;
+  }
+  for (uint32_t block_index = 0; block_index < schedule->block_count;
+       ++block_index) {
+    const loom_low_schedule_block_t* block = &schedule->blocks[block_index];
+    if (block->scheduled_node_count == 0) continue;
+    const loom_low_packet_view_t packet = loom_low_packet_at_block_ordinal(
+        schedule, block_index, block->scheduled_node_count - 1u);
+    const loom_op_t* op = packet.node->op;
+    if (loom_low_br_isa(op)) {
+      const loom_block_t* target_block = loom_low_br_dest(op);
+      const uint32_t target_block_index =
+          loom_low_packet_block_index(schedule, target_block);
+      IREE_ASSERT_NE(target_block_index, LOOM_LOW_PACKET_INDEX_NONE);
+      if (target_block_index != block_index + 1u) {
+        loom_amdgpu_accumulate_branch_measurement_requirement(
+            schedule, blocks, byte_length, block_index, target_block,
+            &requirements);
+      }
+      continue;
+    }
+    if (!loom_low_cond_br_isa(op)) continue;
+    const loom_block_t* true_target = loom_low_cond_br_true_dest(op);
+    const loom_block_t* false_target = loom_low_cond_br_false_dest(op);
+    const uint32_t true_target_index =
+        loom_low_packet_block_index(schedule, true_target);
+    const uint32_t false_target_index =
+        loom_low_packet_block_index(schedule, false_target);
+    IREE_ASSERT_NE(true_target_index, LOOM_LOW_PACKET_INDEX_NONE);
+    IREE_ASSERT_NE(false_target_index, LOOM_LOW_PACKET_INDEX_NONE);
+    if (true_target == false_target) {
+      if (true_target_index != block_index + 1u) {
+        loom_amdgpu_accumulate_branch_measurement_requirement(
+            schedule, blocks, byte_length, block_index, true_target,
+            &requirements);
+      }
+    } else if (true_target_index == block_index + 1u) {
+      loom_amdgpu_accumulate_branch_measurement_requirement(
+          schedule, blocks, byte_length, block_index, false_target,
+          &requirements);
+    } else {
+      loom_amdgpu_accumulate_branch_measurement_requirement(
+          schedule, blocks, byte_length, block_index, true_target,
+          &requirements);
+      if (false_target_index != block_index + 1u) {
+        loom_amdgpu_accumulate_branch_measurement_requirement(
+            schedule, blocks, byte_length, block_index, false_target,
+            &requirements);
+      }
+    }
+  }
+  return requirements;
+}
+
 static iree_status_t loom_amdgpu_encode_instruction_stream_into_state(
     loom_amdgpu_encode_state_t* state) {
   state->stream.length = 0;
@@ -1949,6 +2113,10 @@ static iree_status_t loom_amdgpu_encode_instruction_stream_into_state(
   state->packet_plan.next_address_state_index = 0;
   state->packet_plan.next_wait_packet_index = 0;
   state->packet_plan.next_wait_state_index = 0;
+  state->branches.measurement.edge_count = 0;
+  state->branches.measurement.anchor_count = 0;
+  state->branches.emission.next_edge_index = 0;
+  state->branches.emission.next_group_index = 0;
   memset(state->traversal.pc_registers, 0,
          sizeof(state->traversal.pc_registers));
   for (iree_host_size_t block_index = 0;
@@ -1957,8 +2125,9 @@ static iree_status_t loom_amdgpu_encode_instruction_stream_into_state(
         &state->inputs.schedule->blocks[block_index];
     memset(state->traversal.pc_registers, 0,
            sizeof(state->traversal.pc_registers));
-    if (state->branches.block_offsets != NULL) {
-      state->branches.block_offsets[block_index] = state->stream.length;
+    if (state->branches.measurement.blocks != NULL) {
+      state->branches.measurement.blocks[block_index].byte_offset =
+          state->stream.length;
     }
     for (uint32_t scheduled_ordinal = 0;
          scheduled_ordinal < block->scheduled_node_count; ++scheduled_ordinal) {
@@ -1967,9 +2136,24 @@ static iree_status_t loom_amdgpu_encode_instruction_stream_into_state(
       const loom_low_packet_view_t packet =
           loom_low_packet_at(state->inputs.schedule, packet_index);
       state->traversal.current_packet = &packet;
+      IREE_RETURN_IF_ERROR(
+          loom_amdgpu_encode_branch_groups_before_packet(state, packet_index));
+      const iree_host_size_t packet_start = state->stream.length;
       iree_status_t status = loom_amdgpu_encode_packet(state, &packet);
       state->traversal.current_packet = NULL;
       IREE_RETURN_IF_ERROR(status);
+      loom_amdgpu_encode_branch_measurement_t* measurement =
+          &state->branches.measurement;
+      if (measurement->anchors != NULL &&
+          state->stream.length != packet_start) {
+        IREE_ASSERT_LT(measurement->anchor_count, measurement->anchor_capacity);
+        IREE_ASSERT_LE(packet_index, UINT32_MAX);
+        measurement->anchors[measurement->anchor_count++] =
+            (loom_amdgpu_branch_layout_anchor_t){
+                .byte_offset = packet_start,
+                .packet_index = (uint32_t)packet_index,
+            };
+      }
     }
     if (state->packet_plan.address_state == NULL) {
       if (state->traversal.current_vgpr_msb_mode != 0) {
@@ -1992,6 +2176,12 @@ static iree_status_t loom_amdgpu_encode_instruction_stream_into_state(
   if (state->packet_plan.wait_states != NULL) {
     IREE_ASSERT_EQ(state->packet_plan.next_wait_state_index,
                    state->packet_plan.wait_states->state_count);
+  }
+  if (state->branches.emission.layout != NULL) {
+    IREE_ASSERT_EQ(state->branches.emission.next_edge_index,
+                   state->branches.emission.layout->edge_count);
+    IREE_ASSERT_EQ(state->branches.emission.next_group_index,
+                   state->branches.emission.layout->group_count);
   }
   return iree_ok_status();
 }
@@ -2052,11 +2242,11 @@ static iree_status_t loom_amdgpu_encode_instruction_stream_internal(
           schedule->target.descriptor_set,
           LOOM_AMDGPU_DESCRIPTOR_REF_S_ADDC_U32_RHS_SYMBOL_REL32_HI),
   };
-  iree_host_size_t* block_offsets = NULL;
+  loom_amdgpu_branch_layout_block_t* branch_blocks = NULL;
   if (schedule->block_count != 0) {
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(arena, schedule->block_count,
-                                                   sizeof(*block_offsets),
-                                                   (void**)&block_offsets));
+                                                   sizeof(*branch_blocks),
+                                                   (void**)&branch_blocks));
   }
 
   loom_low_allocation_value_scratch_t scratch = {0};
@@ -2084,17 +2274,76 @@ static iree_status_t loom_amdgpu_encode_instruction_stream_internal(
       .packet_plan = packet_plan_state,
       .branches =
           {
-              .block_offsets = block_offsets,
+              .measurement =
+                  {
+                      .blocks = branch_blocks,
+                  },
           },
   };
   if (iree_status_is_ok(status)) {
     status = loom_amdgpu_encode_instruction_stream_into_state(&sizing_state);
   }
 
+  loom_amdgpu_branch_layout_t branch_layout = {0};
+  if (iree_status_is_ok(status)) {
+    const loom_amdgpu_branch_measurement_requirements_t requirements =
+        loom_amdgpu_query_branch_measurement_requirements(
+            schedule, branch_blocks, sizing_state.stream.length);
+    if (requirements.may_require_relaxation) {
+      loom_amdgpu_branch_layout_input_edge_t* measured_edges = NULL;
+      status = iree_arena_allocate_array(arena, requirements.edge_count,
+                                         sizeof(*measured_edges),
+                                         (void**)&measured_edges);
+      loom_amdgpu_branch_layout_anchor_t* measured_anchors = NULL;
+      if (iree_status_is_ok(status)) {
+        status = iree_arena_allocate_array(
+            arena, schedule->scheduled_node_count, sizeof(*measured_anchors),
+            (void**)&measured_anchors);
+      }
+      if (iree_status_is_ok(status)) {
+        sizing_state.branches.measurement.edges = measured_edges;
+        sizing_state.branches.measurement.edge_capacity =
+            requirements.edge_count;
+        sizing_state.branches.measurement.anchors = measured_anchors;
+        sizing_state.branches.measurement.anchor_capacity =
+            schedule->scheduled_node_count;
+        status =
+            loom_amdgpu_encode_instruction_stream_into_state(&sizing_state);
+      }
+      if (iree_status_is_ok(status)) {
+        IREE_ASSERT_EQ(sizing_state.branches.measurement.edge_count,
+                       requirements.edge_count);
+        const loom_amdgpu_branch_layout_input_t branch_layout_input = {
+            .byte_length = sizing_state.stream.length,
+            .blocks = branch_blocks,
+            .block_count = schedule->block_count,
+            .edges = measured_edges,
+            .edge_count = sizing_state.branches.measurement.edge_count,
+            .anchors = measured_anchors,
+            .anchor_count = sizing_state.branches.measurement.anchor_count,
+        };
+        status = loom_amdgpu_branch_layout_build(&branch_layout_input, arena,
+                                                 &branch_layout);
+      }
+    }
+  }
+
+  iree_host_size_t final_byte_length = sizing_state.stream.length;
+  const loom_amdgpu_branch_layout_t* active_branch_layout = NULL;
+  if (iree_status_is_ok(status) && branch_layout.island_count != 0) {
+    if (branch_layout.byte_length > IREE_HOST_SIZE_MAX) {
+      status = iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "AMDGPU relaxed branch layout exceeds host address range");
+    } else {
+      final_byte_length = (iree_host_size_t)branch_layout.byte_length;
+      active_branch_layout = &branch_layout;
+    }
+  }
+
   uint8_t* data = NULL;
-  if (iree_status_is_ok(status) && sizing_state.stream.length != 0) {
-    status =
-        iree_arena_allocate(arena, sizing_state.stream.length, (void**)&data);
+  if (iree_status_is_ok(status) && final_byte_length != 0) {
+    status = iree_arena_allocate(arena, final_byte_length, (void**)&data);
   }
   loom_amdgpu_hsaco_text_fixup_t* text_fixups = NULL;
   if (iree_status_is_ok(status) && sizing_state.text_fixups.count != 0) {
@@ -2114,7 +2363,7 @@ static iree_status_t loom_amdgpu_encode_instruction_stream_internal(
       .stream =
           {
               .data = data,
-              .capacity = sizing_state.stream.length,
+              .capacity = final_byte_length,
           },
       .text_fixups =
           {
@@ -2128,21 +2377,29 @@ static iree_status_t loom_amdgpu_encode_instruction_stream_internal(
           },
       .branches =
           {
-              .block_offsets = block_offsets,
+              .measurement =
+                  {
+                      .blocks = branch_blocks,
+                  },
+              .emission =
+                  {
+                      .layout = active_branch_layout,
+                  },
           },
   };
-  if (iree_status_is_ok(status) && sizing_state.stream.length != 0) {
+  if (iree_status_is_ok(status) && final_byte_length != 0) {
     status = loom_amdgpu_encode_instruction_stream_into_state(&writing_state);
   }
   if (iree_status_is_ok(status)) {
-    IREE_ASSERT_EQ(writing_state.stream.length, sizing_state.stream.length);
+    IREE_ASSERT_EQ(writing_state.stream.length, final_byte_length);
     IREE_ASSERT_EQ(writing_state.stream.instruction_count,
-                   sizing_state.stream.instruction_count);
+                   sizing_state.stream.instruction_count +
+                       branch_layout.group_count + branch_layout.island_count);
     IREE_ASSERT_EQ(writing_state.text_fixups.count,
                    sizing_state.text_fixups.count);
     IREE_ASSERT_EQ(writing_state.native_insertions.count,
                    sizing_state.native_insertions.count);
-    if (sizing_state.stream.length != 0) {
+    if (final_byte_length != 0) {
       *out_stream = (loom_amdgpu_encoded_instruction_stream_t){
           .text = iree_make_const_byte_span(data, writing_state.stream.length),
           .instruction_count = writing_state.stream.instruction_count,

--- a/loom/src/loom/target/emit/native/amdgpu/encoding.c
+++ b/loom/src/loom/target/emit/native/amdgpu/encoding.c
@@ -55,7 +55,7 @@ typedef struct loom_amdgpu_native_descriptor_refs_t {
   const loom_low_descriptor_t* rel32_hi;
 } loom_amdgpu_native_descriptor_refs_t;
 
-typedef struct loom_amdgpu_encode_state_t {
+typedef struct loom_amdgpu_encode_inputs_t {
   // Schedule table being encoded.
   const loom_low_schedule_table_t* schedule;
   // Allocation table supplying physical locations.
@@ -72,6 +72,13 @@ typedef struct loom_amdgpu_encode_state_t {
   const loom_string_id_t* immediate_name_ids;
   // Number of entries in immediate_name_ids.
   iree_host_size_t immediate_name_id_count;
+  // Optional encoding products requested by the caller.
+  loom_amdgpu_encode_instruction_stream_flags_t flags;
+  // Cached descriptor rows needed by native encoding helper packets.
+  loom_amdgpu_native_descriptor_refs_t descriptors;
+} loom_amdgpu_encode_inputs_t;
+
+typedef struct loom_amdgpu_encode_packet_plan_state_t {
   // Optional planned address-state transitions consumed in scheduled order.
   const loom_amdgpu_address_state_plan_t* address_state;
   // Optional planned wait packets consumed in scheduled order.
@@ -80,16 +87,15 @@ typedef struct loom_amdgpu_encode_state_t {
   const loom_amdgpu_wait_state_plan_t* wait_states;
   // Optional planned VOPD pairs consumed by packet index.
   const loom_amdgpu_vopd_plan_t* vopd_plan;
-  // Optional encoding products requested by the caller.
-  loom_amdgpu_encode_instruction_stream_flags_t flags;
-  // Cached descriptor rows needed by native encoding helper packets.
-  loom_amdgpu_native_descriptor_refs_t descriptors;
-  // Scheduled packet currently being expanded into native instructions.
-  const loom_low_packet_view_t* current_packet;
-  // Low byte of MODE's current VGPR-MSB selector state.
-  uint8_t current_vgpr_msb_mode;
-  // Arena used for transient encoding scratch and final byte storage.
-  iree_arena_allocator_t* arena;
+  // Next address-state transition to compare with the scheduled packet.
+  iree_host_size_t next_address_state_index;
+  // Next wait-packet row to compare with the current scheduled packet.
+  iree_host_size_t next_wait_packet_index;
+  // Next wait-state row to compare with the current scheduled packet.
+  iree_host_size_t next_wait_state_index;
+} loom_amdgpu_encode_packet_plan_state_t;
+
+typedef struct loom_amdgpu_encode_stream_output_t {
   // Destination byte storage, or NULL during the sizing pass.
   uint8_t* data;
   // Capacity of |data| in bytes, or zero during the sizing pass.
@@ -98,28 +104,55 @@ typedef struct loom_amdgpu_encode_state_t {
   iree_host_size_t length;
   // Number of native instructions planned or written so far.
   uint64_t instruction_count;
+} loom_amdgpu_encode_stream_output_t;
+
+typedef struct loom_amdgpu_encode_text_fixup_output_t {
   // Text literal fixups, or NULL during the sizing pass.
-  loom_amdgpu_hsaco_text_fixup_t* text_fixups;
-  // Capacity of |text_fixups| in entries, or zero during the sizing pass.
-  iree_host_size_t text_fixup_capacity;
+  loom_amdgpu_hsaco_text_fixup_t* values;
+  // Capacity of |values| in entries, or zero during the sizing pass.
+  iree_host_size_t capacity;
   // Number of text literal fixups planned or written so far.
-  iree_host_size_t text_fixup_count;
+  iree_host_size_t count;
+} loom_amdgpu_encode_text_fixup_output_t;
+
+typedef struct loom_amdgpu_encode_native_insertion_output_t {
   // Native insertion rows, or NULL during the sizing pass.
-  loom_amdgpu_native_insertion_t* native_insertions;
-  // Capacity of |native_insertions|, or zero during the sizing pass.
-  iree_host_size_t native_insertion_capacity;
+  loom_amdgpu_native_insertion_t* values;
+  // Capacity of |values| in entries, or zero during the sizing pass.
+  iree_host_size_t capacity;
   // Number of native insertion rows planned or written so far.
-  iree_host_size_t native_insertion_count;
-  // Next address-state transition to compare with the scheduled packet.
-  iree_host_size_t next_address_state_index;
-  // Next wait-packet row to compare with the current scheduled packet.
-  iree_host_size_t next_wait_packet_index;
-  // Next wait-state row to compare with the current scheduled packet.
-  iree_host_size_t next_wait_state_index;
-  // Planned byte offset for each scheduled block.
-  iree_host_size_t* block_offsets;
+  iree_host_size_t count;
+} loom_amdgpu_encode_native_insertion_output_t;
+
+typedef struct loom_amdgpu_encode_traversal_state_t {
+  // Scheduled packet currently being expanded into native instructions.
+  const loom_low_packet_view_t* current_packet;
+  // Low byte of MODE's current VGPR-MSB selector state.
+  uint8_t current_vgpr_msb_mode;
   // Block-local per-SGPR PC component facts used by symbolic rel32 fixups.
   loom_amdgpu_pc_register_state_t pc_registers[LOOM_AMDGPU_SGPR_COUNT];
+} loom_amdgpu_encode_traversal_state_t;
+
+typedef struct loom_amdgpu_encode_branch_state_t {
+  // Planned byte offset for each scheduled block.
+  iree_host_size_t* block_offsets;
+} loom_amdgpu_encode_branch_state_t;
+
+typedef struct loom_amdgpu_encode_state_t {
+  // Immutable inputs shared by the sizing and writing passes.
+  loom_amdgpu_encode_inputs_t inputs;
+  // Target packet plan and its pass-local consumption cursors.
+  loom_amdgpu_encode_packet_plan_state_t packet_plan;
+  // Encoded instruction bytes and aggregate instruction count.
+  loom_amdgpu_encode_stream_output_t stream;
+  // Relocation records emitted alongside the instruction stream.
+  loom_amdgpu_encode_text_fixup_output_t text_fixups;
+  // Optional target-owned insertion records emitted for reports.
+  loom_amdgpu_encode_native_insertion_output_t native_insertions;
+  // Function-local branch placement state.
+  loom_amdgpu_encode_branch_state_t branches;
+  // Packet traversal and simulated architectural state.
+  loom_amdgpu_encode_traversal_state_t traversal;
 } loom_amdgpu_encode_state_t;
 
 static iree_string_view_t loom_amdgpu_descriptor_string(
@@ -130,15 +163,18 @@ static iree_string_view_t loom_amdgpu_descriptor_string(
 
 static void loom_amdgpu_append_u32(loom_amdgpu_encode_state_t* state,
                                    uint32_t value) {
-  if (state->data != NULL) {
-    IREE_ASSERT(state->length <= state->capacity &&
-                sizeof(value) <= state->capacity - state->length);
-    state->data[state->length + 0] = (uint8_t)(value & 0xFFu);
-    state->data[state->length + 1] = (uint8_t)((value >> 8) & 0xFFu);
-    state->data[state->length + 2] = (uint8_t)((value >> 16) & 0xFFu);
-    state->data[state->length + 3] = (uint8_t)((value >> 24) & 0xFFu);
+  if (state->stream.data != NULL) {
+    IREE_ASSERT(state->stream.length <= state->stream.capacity &&
+                sizeof(value) <= state->stream.capacity - state->stream.length);
+    state->stream.data[state->stream.length + 0] = (uint8_t)(value & 0xFFu);
+    state->stream.data[state->stream.length + 1] =
+        (uint8_t)((value >> 8) & 0xFFu);
+    state->stream.data[state->stream.length + 2] =
+        (uint8_t)((value >> 16) & 0xFFu);
+    state->stream.data[state->stream.length + 3] =
+        (uint8_t)((value >> 24) & 0xFFu);
   }
-  state->length += sizeof(value);
+  state->stream.length += sizeof(value);
 }
 
 static uint64_t loom_amdgpu_low_bit_mask(uint16_t bit_count) {
@@ -218,8 +254,8 @@ static uint16_t loom_amdgpu_packet_descriptor_operand_sgpr(
     const loom_amdgpu_encode_state_t* state,
     const loom_low_packet_view_t* packet, uint16_t descriptor_operand_index) {
   const loom_low_allocation_assignment_t* assignment =
-      loom_low_packet_descriptor_operand_assignment(state->allocation, packet,
-                                                    descriptor_operand_index);
+      loom_low_packet_descriptor_operand_assignment(
+          state->inputs.allocation, packet, descriptor_operand_index);
   IREE_ASSERT_LT(assignment->location_base, LOOM_AMDGPU_SGPR_COUNT);
   return (uint16_t)assignment->location_base;
 }
@@ -237,7 +273,8 @@ static void loom_amdgpu_sgpr_register_range(
 static void loom_amdgpu_invalidate_pc_register_range(
     loom_amdgpu_encode_state_t* state, uint32_t base, uint32_t count) {
   for (uint32_t i = 0; i < count; ++i) {
-    state->pc_registers[base + i] = (loom_amdgpu_pc_register_state_t){0};
+    state->traversal.pc_registers[base + i] =
+        (loom_amdgpu_pc_register_state_t){0};
   }
 }
 
@@ -245,7 +282,7 @@ static void loom_amdgpu_set_pc_register(loom_amdgpu_encode_state_t* state,
                                         uint16_t sgpr,
                                         uint64_t base_pc_byte_offset,
                                         loom_amdgpu_pc_component_t component) {
-  state->pc_registers[sgpr] = (loom_amdgpu_pc_register_state_t){
+  state->traversal.pc_registers[sgpr] = (loom_amdgpu_pc_register_state_t){
       .base_pc_byte_offset = base_pc_byte_offset,
       .component = component,
   };
@@ -254,7 +291,8 @@ static void loom_amdgpu_set_pc_register(loom_amdgpu_encode_state_t* state,
 static void loom_amdgpu_propagate_pc_register(loom_amdgpu_encode_state_t* state,
                                               uint16_t destination_sgpr,
                                               uint16_t source_sgpr) {
-  state->pc_registers[destination_sgpr] = state->pc_registers[source_sgpr];
+  state->traversal.pc_registers[destination_sgpr] =
+      state->traversal.pc_registers[source_sgpr];
 }
 
 static void loom_amdgpu_append_encoding_packet(
@@ -263,73 +301,77 @@ static void loom_amdgpu_append_encoding_packet(
   for (uint16_t i = 0; i < packet->word_count; ++i) {
     loom_amdgpu_append_u32(state, packet->words[i]);
   }
-  ++state->instruction_count;
+  ++state->stream.instruction_count;
 }
 
 static void loom_amdgpu_record_native_insertion(
     loom_amdgpu_encode_state_t* state, loom_amdgpu_native_insertion_kind_t kind,
     loom_amdgpu_descriptor_ref_t descriptor_ref, uint16_t immediate) {
   if (!iree_all_bits_set(
-          state->flags,
+          state->inputs.flags,
           LOOM_AMDGPU_ENCODE_INSTRUCTION_STREAM_FLAG_CAPTURE_NATIVE_INSERTIONS)) {
     return;
   }
-  if (state->native_insertions != NULL) {
-    IREE_ASSERT_LT(state->native_insertion_count,
-                   state->native_insertion_capacity);
-    const loom_low_schedule_node_t* node = state->current_packet->node;
-    state->native_insertions[state->native_insertion_count] =
+  if (state->native_insertions.values != NULL) {
+    IREE_ASSERT_LT(state->native_insertions.count,
+                   state->native_insertions.capacity);
+    const loom_low_schedule_node_t* node =
+        state->traversal.current_packet->node;
+    state->native_insertions.values[state->native_insertions.count] =
         (loom_amdgpu_native_insertion_t){
             .kind = kind,
             .block_index = node->block_index,
-            .node_index = state->current_packet->node_index,
+            .node_index = state->traversal.current_packet->node_index,
             .scheduled_ordinal = node->scheduled_ordinal,
             .immediate = immediate,
             .descriptor_ref = descriptor_ref,
         };
   }
-  ++state->native_insertion_count;
+  ++state->native_insertions.count;
 }
 
 static void loom_amdgpu_record_native_descriptor_insertion(
     loom_amdgpu_encode_state_t* state, loom_amdgpu_native_insertion_kind_t kind,
     const loom_low_descriptor_t* descriptor, uint16_t immediate) {
   if (!iree_all_bits_set(
-          state->flags,
+          state->inputs.flags,
           LOOM_AMDGPU_ENCODE_INSTRUCTION_STREAM_FLAG_CAPTURE_NATIVE_INSERTIONS)) {
     return;
   }
   const loom_amdgpu_descriptor_ref_t descriptor_ref =
       loom_amdgpu_descriptor_ref_for_descriptor(
-          state->schedule->target.descriptor_set, descriptor);
+          state->inputs.schedule->target.descriptor_set, descriptor);
   IREE_ASSERT_NE(descriptor_ref, LOOM_AMDGPU_DESCRIPTOR_REF_NONE);
   loom_amdgpu_record_native_insertion(state, kind, descriptor_ref, immediate);
 }
 
 static iree_status_t loom_amdgpu_encode_vgpr_msb_mode(
     loom_amdgpu_encode_state_t* state, uint8_t new_mode) {
-  if (state->current_vgpr_msb_mode == new_mode) {
+  if (state->traversal.current_vgpr_msb_mode == new_mode) {
     return iree_ok_status();
   }
-  IREE_ASSERT(state->descriptors.set_vgpr_msb != NULL);
+  IREE_ASSERT(state->inputs.descriptors.set_vgpr_msb != NULL);
   const uint16_t immediate =
-      (uint16_t)(((uint16_t)state->current_vgpr_msb_mode << 8) | new_mode);
+      (uint16_t)(((uint16_t)state->traversal.current_vgpr_msb_mode << 8) |
+                 new_mode);
   loom_amdgpu_encoding_packet_t encoded_packet;
   IREE_RETURN_IF_ERROR(loom_amdgpu_encoding_pack_sopp_simm16(
-      state->encoding_table, state->descriptors.set_vgpr_msb->encoding_id,
-      immediate, &encoded_packet));
+      state->inputs.encoding_table,
+      state->inputs.descriptors.set_vgpr_msb->encoding_id, immediate,
+      &encoded_packet));
   loom_amdgpu_append_encoding_packet(state, &encoded_packet);
   loom_amdgpu_record_native_insertion(
       state, LOOM_AMDGPU_NATIVE_INSERTION_ADDRESS_STATE,
       LOOM_AMDGPU_DESCRIPTOR_REF_S_SET_VGPR_MSB, immediate);
-  state->current_vgpr_msb_mode = new_mode;
+  state->traversal.current_vgpr_msb_mode = new_mode;
   return iree_ok_status();
 }
 
 static iree_status_t loom_amdgpu_encode_vgpr_msb_requirement(
     loom_amdgpu_encode_state_t* state, uint8_t mask, uint8_t value) {
   const uint8_t new_mode =
-      (uint8_t)((state->current_vgpr_msb_mode & ~mask) | (value & mask));
+      (uint8_t)((state->traversal.current_vgpr_msb_mode & ~mask) |
+                (value & mask));
   return loom_amdgpu_encode_vgpr_msb_mode(state, new_mode);
 }
 
@@ -347,13 +389,13 @@ static uint16_t loom_amdgpu_packet_descriptor_operand_vgpr_low_register(
     const loom_amdgpu_encode_state_t* state,
     const loom_low_packet_view_t* packet, uint16_t descriptor_operand_index) {
   const loom_low_descriptor_set_t* descriptor_set =
-      state->schedule->target.descriptor_set;
+      state->inputs.schedule->target.descriptor_set;
   const loom_low_operand_t* operand =
       &descriptor_set->operands[packet->descriptor->operand_start +
                                 descriptor_operand_index];
   const loom_low_allocation_assignment_t* assignment =
-      loom_low_packet_descriptor_operand_assignment(state->allocation, packet,
-                                                    descriptor_operand_index);
+      loom_low_packet_descriptor_operand_assignment(
+          state->inputs.allocation, packet, descriptor_operand_index);
   return loom_amdgpu_assignment_vgpr_low_register(assignment, operand);
 }
 
@@ -370,13 +412,13 @@ static iree_status_t loom_amdgpu_assignment_field_value(
     *out_value = loom_amdgpu_assignment_vgpr_low_register(assignment, operand);
     if (loom_amdgpu_encoding_field_uses_unified_source(
             operand->encoding_field_id)) {
-      *out_value += state->encoding_table->vector_source_vgpr0;
+      *out_value += state->inputs.encoding_table->vector_source_vgpr0;
     }
     return iree_ok_status();
   }
   iree_string_view_t register_class = iree_string_view_empty();
   IREE_RETURN_IF_ERROR(loom_low_allocation_assignment_register_class_name(
-      state->allocation, assignment, &register_class));
+      state->inputs.allocation, assignment, &register_class));
   return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                           "AMDGPU native encoding register class '%.*s' is not "
                           "supported by the generic packet encoder",
@@ -403,7 +445,7 @@ static uint16_t loom_amdgpu_descriptor_single_fixed_encoding_field_u16(
     const loom_amdgpu_encode_state_t* state,
     const loom_low_descriptor_t* descriptor) {
   const loom_low_descriptor_set_t* descriptor_set =
-      state->schedule->target.descriptor_set;
+      state->inputs.schedule->target.descriptor_set;
   const loom_low_encoding_field_value_t* field_value =
       &descriptor_set
            ->encoding_field_values[descriptor->encoding_field_value_start];
@@ -415,7 +457,7 @@ static bool loom_amdgpu_descriptor_operand_field_already_encoded(
     const loom_low_packet_view_t* packet, uint16_t operand_index,
     const loom_low_operand_t* operand) {
   const loom_low_descriptor_set_t* descriptor_set =
-      state->schedule->target.descriptor_set;
+      state->inputs.schedule->target.descriptor_set;
   const loom_low_operand_t* operands =
       &descriptor_set->operands[packet->descriptor->operand_start];
   for (uint16_t previous_index = 0; previous_index < operand_index;
@@ -452,9 +494,9 @@ static const loom_low_immediate_t* loom_amdgpu_descriptor_immediate(
 
 static loom_string_id_t loom_amdgpu_descriptor_immediate_name_id(
     const loom_amdgpu_encode_state_t* state, uint32_t immediate_row) {
-  IREE_ASSERT(state->immediate_name_ids != NULL);
-  IREE_ASSERT_LT(immediate_row, state->immediate_name_id_count);
-  return state->immediate_name_ids[immediate_row];
+  IREE_ASSERT(state->inputs.immediate_name_ids != NULL);
+  IREE_ASSERT_LT(immediate_row, state->inputs.immediate_name_id_count);
+  return state->inputs.immediate_name_ids[immediate_row];
 }
 
 static iree_status_t loom_amdgpu_read_immediate_field_value(
@@ -463,7 +505,7 @@ static iree_status_t loom_amdgpu_read_immediate_field_value(
     int64_t* out_value) {
   *out_value = 0;
   const loom_low_descriptor_set_t* descriptor_set =
-      state->schedule->target.descriptor_set;
+      state->inputs.schedule->target.descriptor_set;
   const uint32_t immediate_row = loom_amdgpu_descriptor_immediate_row(
       descriptor_set, packet->descriptor, descriptor_immediate_index);
   const loom_low_immediate_t* immediate =
@@ -500,7 +542,7 @@ static iree_string_view_t loom_amdgpu_read_immediate_field_name(
     const loom_amdgpu_encode_state_t* state,
     const loom_low_packet_view_t* packet, uint16_t descriptor_immediate_index) {
   const loom_low_descriptor_set_t* descriptor_set =
-      state->schedule->target.descriptor_set;
+      state->inputs.schedule->target.descriptor_set;
   const loom_low_immediate_t* immediate = loom_amdgpu_descriptor_immediate(
       descriptor_set, packet->descriptor, descriptor_immediate_index);
   return loom_amdgpu_descriptor_string(descriptor_set,
@@ -553,9 +595,9 @@ static bool loom_amdgpu_descriptor_semantic_tag_is(
   if (descriptor->semantic_tag_string_offset == LOOM_LOW_STRING_OFFSET_NONE) {
     return false;
   }
-  const iree_string_view_t semantic_tag =
-      loom_low_descriptor_set_string(state->schedule->target.descriptor_set,
-                                     descriptor->semantic_tag_string_offset);
+  const iree_string_view_t semantic_tag = loom_low_descriptor_set_string(
+      state->inputs.schedule->target.descriptor_set,
+      descriptor->semantic_tag_string_offset);
   return iree_string_view_equal(semantic_tag, expected_tag);
 }
 
@@ -577,21 +619,22 @@ static iree_status_t loom_amdgpu_symbol_name_from_attr(
   }
   const loom_symbol_ref_t symbol_ref = attr->value.symbol;
   if (!loom_symbol_ref_is_valid(symbol_ref) || symbol_ref.module_id != 0 ||
-      symbol_ref.symbol_id >= state->schedule->module->symbols.count) {
+      symbol_ref.symbol_id >= state->inputs.schedule->module->symbols.count) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
         "AMDGPU native encoding immediate '%.*s' references an invalid symbol",
         (int)field_name.size, field_name.data);
   }
   const loom_symbol_t* symbol =
-      &state->schedule->module->symbols.entries[symbol_ref.symbol_id];
-  if (symbol->name_id >= state->schedule->module->strings.count) {
+      &state->inputs.schedule->module->symbols.entries[symbol_ref.symbol_id];
+  if (symbol->name_id >= state->inputs.schedule->module->strings.count) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "AMDGPU native encoding immediate '%.*s' "
                             "references an unnamed symbol",
                             (int)field_name.size, field_name.data);
   }
-  *out_symbol_name = state->schedule->module->strings.entries[symbol->name_id];
+  *out_symbol_name =
+      state->inputs.schedule->module->strings.entries[symbol->name_id];
   return iree_ok_status();
 }
 
@@ -601,7 +644,7 @@ static iree_status_t loom_amdgpu_read_immediate_symbol(
     iree_string_view_t* out_symbol_name) {
   *out_symbol_name = iree_string_view_empty();
   const loom_low_descriptor_set_t* descriptor_set =
-      state->schedule->target.descriptor_set;
+      state->inputs.schedule->target.descriptor_set;
   const uint32_t immediate_row = loom_amdgpu_descriptor_immediate_row(
       descriptor_set, packet->descriptor, descriptor_immediate_index);
   const loom_low_immediate_t* immediate =
@@ -647,13 +690,13 @@ static loom_amdgpu_rel32_text_fixup_info_t
 loom_amdgpu_descriptor_rel32_text_fixup_info(
     const loom_amdgpu_encode_state_t* state,
     const loom_low_descriptor_t* descriptor) {
-  if (descriptor == state->descriptors.rel32_lo) {
+  if (descriptor == state->inputs.descriptors.rel32_lo) {
     return (loom_amdgpu_rel32_text_fixup_info_t){
         .kind = LOOM_AMDGPU_HSACO_TEXT_FIXUP_KIND_DATA_SYMBOL_REL32_LO,
         .pc_component = LOOM_AMDGPU_PC_COMPONENT_LO,
     };
   }
-  if (descriptor == state->descriptors.rel32_hi) {
+  if (descriptor == state->inputs.descriptors.rel32_hi) {
     return (loom_amdgpu_rel32_text_fixup_info_t){
         .kind = LOOM_AMDGPU_HSACO_TEXT_FIXUP_KIND_DATA_SYMBOL_REL32_HI,
         .pc_component = LOOM_AMDGPU_PC_COMPONENT_HI,
@@ -665,11 +708,11 @@ loom_amdgpu_descriptor_rel32_text_fixup_info(
 static void loom_amdgpu_append_text_fixup(
     loom_amdgpu_encode_state_t* state,
     const loom_amdgpu_hsaco_text_fixup_t* fixup) {
-  if (state->text_fixups != NULL) {
-    IREE_ASSERT_LT(state->text_fixup_count, state->text_fixup_capacity);
-    state->text_fixups[state->text_fixup_count] = *fixup;
+  if (state->text_fixups.values != NULL) {
+    IREE_ASSERT_LT(state->text_fixups.count, state->text_fixups.capacity);
+    state->text_fixups.values[state->text_fixups.count] = *fixup;
   }
-  ++state->text_fixup_count;
+  ++state->text_fixups.count;
 }
 
 static iree_status_t loom_amdgpu_packet_lhs_pc_base(
@@ -680,12 +723,12 @@ static iree_status_t loom_amdgpu_packet_lhs_pc_base(
   *out_base_pc_byte_offset = 0;
   const uint16_t lhs_operand_index = packet->descriptor->result_count;
   const loom_low_allocation_assignment_t* assignment =
-      loom_low_packet_descriptor_operand_assignment(state->allocation, packet,
-                                                    lhs_operand_index);
+      loom_low_packet_descriptor_operand_assignment(state->inputs.allocation,
+                                                    packet, lhs_operand_index);
   IREE_ASSERT_LT(assignment->location_base, LOOM_AMDGPU_SGPR_COUNT);
   const uint16_t sgpr_base = (uint16_t)assignment->location_base;
   const loom_amdgpu_pc_register_state_t pc_register =
-      state->pc_registers[sgpr_base];
+      state->traversal.pc_registers[sgpr_base];
   if (pc_register.component == LOOM_AMDGPU_PC_COMPONENT_NONE) {
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                             "AMDGPU native encoding rel32 add lhs s%" PRIu32
@@ -711,7 +754,7 @@ static iree_status_t loom_amdgpu_read_immediate_encoding_field_value(
   IREE_RETURN_IF_ERROR(loom_amdgpu_read_immediate_field_value(
       state, packet, descriptor_immediate_index, &value));
   const loom_low_descriptor_set_t* descriptor_set =
-      state->schedule->target.descriptor_set;
+      state->inputs.schedule->target.descriptor_set;
   const loom_low_immediate_t* immediate = loom_amdgpu_descriptor_immediate(
       descriptor_set, packet->descriptor, descriptor_immediate_index);
   if (immediate->kind == LOOM_LOW_IMMEDIATE_KIND_SIGNED) {
@@ -752,7 +795,7 @@ static iree_status_t loom_amdgpu_read_immediate_encoding_field_value(
     case LOOM_AMDGPU_IMMEDIATE_ENCODING_ID_SOURCE_INLINE_U32: {
       uint16_t source = 0;
       const bool encoded = loom_amdgpu_encoding_inline_u32_source(
-          state->encoding_table, (uint32_t)unsigned_value, &source);
+          state->inputs.encoding_table, (uint32_t)unsigned_value, &source);
       IREE_ASSERT(encoded);
       *out_value = source;
       return iree_ok_status();
@@ -760,7 +803,7 @@ static iree_status_t loom_amdgpu_read_immediate_encoding_field_value(
     case LOOM_AMDGPU_IMMEDIATE_ENCODING_ID_SOURCE_INLINE_F32: {
       uint16_t source = 0;
       const bool encoded = loom_amdgpu_encoding_inline_f32_source(
-          state->encoding_table, (uint32_t)unsigned_value, &source);
+          state->inputs.encoding_table, (uint32_t)unsigned_value, &source);
       IREE_ASSERT(encoded);
       *out_value = source;
       return iree_ok_status();
@@ -774,7 +817,7 @@ static iree_status_t loom_amdgpu_read_immediate_encoding_field_value(
 static iree_status_t loom_amdgpu_encode_sop1_s_mov_b32(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet) {
   uint16_t sdst = 0;
-  if (packet->descriptor == state->descriptors.s_mov_b32) {
+  if (packet->descriptor == state->inputs.descriptors.s_mov_b32) {
     sdst = loom_amdgpu_packet_descriptor_operand_sgpr(state, packet, 0);
   } else {
     sdst = loom_amdgpu_descriptor_single_fixed_encoding_field_u16(
@@ -785,14 +828,14 @@ static iree_status_t loom_amdgpu_encode_sop1_s_mov_b32(
       loom_amdgpu_read_immediate_u32(state, packet, 0, &imm32));
   loom_amdgpu_encoding_packet_t encoded_packet;
   IREE_RETURN_IF_ERROR(loom_amdgpu_encoding_pack_s_mov_b32_u32(
-      state->encoding_table, sdst, imm32, &encoded_packet));
+      state->inputs.encoding_table, sdst, imm32, &encoded_packet));
   loom_amdgpu_append_encoding_packet(state, &encoded_packet);
   return iree_ok_status();
 }
 
 static iree_status_t loom_amdgpu_encode_vop1_v_mov_b32(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet) {
-  IREE_ASSERT(packet->descriptor == state->descriptors.v_mov_b32);
+  IREE_ASSERT(packet->descriptor == state->inputs.descriptors.v_mov_b32);
   const uint16_t vdst =
       loom_amdgpu_packet_descriptor_operand_vgpr_low_register(state, packet, 0);
   uint32_t imm32 = 0;
@@ -800,7 +843,7 @@ static iree_status_t loom_amdgpu_encode_vop1_v_mov_b32(
       loom_amdgpu_read_immediate_u32(state, packet, 0, &imm32));
   loom_amdgpu_encoding_packet_t encoded_packet;
   IREE_RETURN_IF_ERROR(loom_amdgpu_encoding_pack_v_mov_b32_u32(
-      state->encoding_table, vdst, imm32, &encoded_packet));
+      state->inputs.encoding_table, vdst, imm32, &encoded_packet));
   loom_amdgpu_append_encoding_packet(state, &encoded_packet);
   return iree_ok_status();
 }
@@ -812,7 +855,7 @@ static iree_status_t loom_amdgpu_encode_s_mov_b32_register(
   }
   loom_amdgpu_encoding_packet_t encoded_packet;
   IREE_RETURN_IF_ERROR(loom_amdgpu_encoding_pack_s_mov_b32_sgpr(
-      state->encoding_table, sdst, ssrc0, &encoded_packet));
+      state->inputs.encoding_table, sdst, ssrc0, &encoded_packet));
   loom_amdgpu_append_encoding_packet(state, &encoded_packet);
   loom_amdgpu_propagate_pc_register(state, sdst, ssrc0);
   return iree_ok_status();
@@ -820,34 +863,34 @@ static iree_status_t loom_amdgpu_encode_s_mov_b32_register(
 
 static iree_status_t loom_amdgpu_encode_v_mov_b32_register(
     loom_amdgpu_encode_state_t* state, uint16_t vdst, uint16_t src0) {
-  if (state->encoding_table == NULL) {
+  if (state->inputs.encoding_table == NULL) {
     return iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,
         "AMDGPU native encoding descriptor set '%.*s' has no encoding table "
         "for v_mov_b32 register moves",
-        (int)state->target->key.size, state->target->key.data);
+        (int)state->inputs.target->key.size, state->inputs.target->key.data);
   }
 
   loom_amdgpu_encoding_packet_t encoded_packet;
   IREE_RETURN_IF_ERROR(loom_amdgpu_encoding_pack_v_mov_b32_vgpr(
-      state->encoding_table, vdst, src0, &encoded_packet));
+      state->inputs.encoding_table, vdst, src0, &encoded_packet));
   loom_amdgpu_append_encoding_packet(state, &encoded_packet);
   return iree_ok_status();
 }
 
 static iree_status_t loom_amdgpu_encode_v_mov_b32_u32(
     loom_amdgpu_encode_state_t* state, uint16_t vdst, uint32_t imm32) {
-  if (state->encoding_table == NULL) {
+  if (state->inputs.encoding_table == NULL) {
     return iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,
         "AMDGPU native encoding descriptor set '%.*s' has no encoding table "
         "for v_mov_b32 immediate moves",
-        (int)state->target->key.size, state->target->key.data);
+        (int)state->inputs.target->key.size, state->inputs.target->key.data);
   }
 
   loom_amdgpu_encoding_packet_t encoded_packet;
   IREE_RETURN_IF_ERROR(loom_amdgpu_encoding_pack_v_mov_b32_u32(
-      state->encoding_table, vdst, imm32, &encoded_packet));
+      state->inputs.encoding_table, vdst, imm32, &encoded_packet));
   loom_amdgpu_append_encoding_packet(state, &encoded_packet);
   return iree_ok_status();
 }
@@ -859,15 +902,16 @@ static iree_status_t loom_amdgpu_encode_vgpr_move_location(
   if (destination->location == source->location) {
     return iree_ok_status();
   }
-  if (state->encoding_table == NULL ||
-      state->encoding_table->vector_source_vgpr_count == 0) {
+  if (state->inputs.encoding_table == NULL ||
+      state->inputs.encoding_table->vector_source_vgpr_count == 0) {
     return iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,
         "AMDGPU native encoding descriptor set '%.*s' has no VGPR source "
         "window for move encoding",
-        (int)state->target->key.size, state->target->key.data);
+        (int)state->inputs.target->key.size, state->inputs.target->key.data);
   }
-  const uint32_t window = state->encoding_table->vector_source_vgpr_count;
+  const uint32_t window =
+      state->inputs.encoding_table->vector_source_vgpr_count;
   const uint32_t destination_bank = destination->location / window;
   const uint32_t source_bank = source->location / window;
   const uint16_t destination_low_register =
@@ -888,15 +932,16 @@ static iree_status_t loom_amdgpu_encode_vgpr_move_location(
 static iree_status_t loom_amdgpu_encode_vgpr_move_immediate(
     loom_amdgpu_encode_state_t* state, uint32_t destination_register,
     uint32_t imm32) {
-  if (state->encoding_table == NULL ||
-      state->encoding_table->vector_source_vgpr_count == 0) {
+  if (state->inputs.encoding_table == NULL ||
+      state->inputs.encoding_table->vector_source_vgpr_count == 0) {
     return iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,
         "AMDGPU native encoding descriptor set '%.*s' has no VGPR source "
         "window for immediate move encoding",
-        (int)state->target->key.size, state->target->key.data);
+        (int)state->inputs.target->key.size, state->inputs.target->key.data);
   }
-  const uint32_t window = state->encoding_table->vector_source_vgpr_count;
+  const uint32_t window =
+      state->inputs.encoding_table->vector_source_vgpr_count;
   const uint32_t destination_bank = destination_register / window;
   const uint16_t destination_low_register =
       (uint16_t)(destination_register % window);
@@ -904,7 +949,7 @@ static iree_status_t loom_amdgpu_encode_vgpr_move_immediate(
   uint8_t value = 0;
   loom_amdgpu_vgpr_msb_insert_requirement(LOOM_AMDGPU_VGPR_MSB_SLOT_DST,
                                           destination_bank, &mask, &value);
-  const uint8_t saved_mode = state->current_vgpr_msb_mode;
+  const uint8_t saved_mode = state->traversal.current_vgpr_msb_mode;
   IREE_RETURN_IF_ERROR(
       loom_amdgpu_encode_vgpr_msb_requirement(state, mask, value));
   IREE_RETURN_IF_ERROR(
@@ -940,10 +985,10 @@ static iree_status_t loom_amdgpu_encode_move(
 
 static iree_status_t loom_amdgpu_encode_move_range(
     loom_amdgpu_encode_state_t* state, loom_low_move_range_t move_range) {
-  const uint8_t saved_mode = state->current_vgpr_msb_mode;
+  const uint8_t saved_mode = state->traversal.current_vgpr_msb_mode;
   for (iree_host_size_t i = 0; i < move_range.count; ++i) {
     const loom_low_move_t* move =
-        &state->allocation->moves[move_range.start + i];
+        &state->inputs.allocation->moves[move_range.start + i];
     IREE_RETURN_IF_ERROR(
         loom_amdgpu_encode_move(state, &move->destination, &move->source));
   }
@@ -960,7 +1005,7 @@ static iree_status_t loom_amdgpu_encode_packet_moves(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet) {
   const loom_low_allocation_packet_move_group_t* group =
       loom_low_allocation_find_packet_move_group_by_source_ordinal(
-          state->allocation, packet->node->source_ordinal);
+          state->inputs.allocation, packet->node->source_ordinal);
   return loom_amdgpu_encode_move_range(state, group == NULL
                                                   ? (loom_low_move_range_t){0}
                                                   : group->move_group.moves);
@@ -985,7 +1030,7 @@ static iree_status_t loom_amdgpu_encode_sopp_simm16(
     loom_amdgpu_encode_state_t* state, uint16_t opcode, uint16_t immediate) {
   loom_amdgpu_encoding_packet_t encoded_packet;
   IREE_RETURN_IF_ERROR(loom_amdgpu_encoding_pack_sopp_simm16(
-      state->encoding_table, opcode, immediate, &encoded_packet));
+      state->inputs.encoding_table, opcode, immediate, &encoded_packet));
   loom_amdgpu_append_encoding_packet(state, &encoded_packet);
   return iree_ok_status();
 }
@@ -997,7 +1042,7 @@ static iree_status_t loom_amdgpu_encode_s_nop_cycles(
                                ? LOOM_AMDGPU_WAIT_STATE_MAX_S_NOP_CYCLES
                                : cycle_count;
     IREE_RETURN_IF_ERROR(loom_amdgpu_encode_sopp_simm16(
-        state, state->target->sopp.nop, (uint16_t)(chunk - 1)));
+        state, state->inputs.target->sopp.nop, (uint16_t)(chunk - 1)));
     loom_amdgpu_record_native_insertion(
         state, LOOM_AMDGPU_NATIVE_INSERTION_S_NOP,
         LOOM_AMDGPU_DESCRIPTOR_REF_NONE, (uint16_t)(chunk - 1));
@@ -1008,12 +1053,12 @@ static iree_status_t loom_amdgpu_encode_s_nop_cycles(
 
 static iree_status_t loom_amdgpu_encode_s_delay_alu(
     loom_amdgpu_encode_state_t* state, uint16_t delay_alu_immediate) {
-  if (state->target->sopp.delay_alu == 0) {
+  if (state->inputs.target->sopp.delay_alu == 0) {
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                             "AMDGPU target does not support S_DELAY_ALU");
   }
   IREE_RETURN_IF_ERROR(loom_amdgpu_encode_sopp_simm16(
-      state, state->target->sopp.delay_alu, delay_alu_immediate));
+      state, state->inputs.target->sopp.delay_alu, delay_alu_immediate));
   loom_amdgpu_record_native_insertion(
       state, LOOM_AMDGPU_NATIVE_INSERTION_S_DELAY_ALU,
       LOOM_AMDGPU_DESCRIPTOR_REF_S_DELAY_ALU, delay_alu_immediate);
@@ -1024,8 +1069,8 @@ static iree_status_t loom_amdgpu_encode_v_nop_slots(
     loom_amdgpu_encode_state_t* state, uint16_t issue_count) {
   for (uint16_t i = 0; i < issue_count; ++i) {
     loom_amdgpu_encoding_packet_t encoded_packet;
-    IREE_RETURN_IF_ERROR(loom_amdgpu_encoding_pack_v_nop(state->encoding_table,
-                                                         &encoded_packet));
+    IREE_RETURN_IF_ERROR(loom_amdgpu_encoding_pack_v_nop(
+        state->inputs.encoding_table, &encoded_packet));
     loom_amdgpu_append_encoding_packet(state, &encoded_packet);
     loom_amdgpu_record_native_insertion(state,
                                         LOOM_AMDGPU_NATIVE_INSERTION_V_NOP,
@@ -1074,7 +1119,7 @@ static void loom_amdgpu_push_immediate_encoding_field_values(
   }
 
   const loom_low_descriptor_set_t* descriptor_set =
-      state->schedule->target.descriptor_set;
+      state->inputs.schedule->target.descriptor_set;
   for (uint16_t i = 0; i < immediate->encoding_slice_count; ++i) {
     const loom_low_immediate_encoding_slice_t* slice =
         &descriptor_set
@@ -1092,7 +1137,7 @@ static iree_status_t loom_amdgpu_descriptor_literal_immediate_u32(
   *out_value = 0;
   *out_found = false;
   const loom_low_descriptor_set_t* descriptor_set =
-      state->schedule->target.descriptor_set;
+      state->inputs.schedule->target.descriptor_set;
   for (uint16_t i = 0; i < packet->descriptor->immediate_count; ++i) {
     const loom_low_immediate_t* immediate =
         loom_amdgpu_descriptor_immediate(descriptor_set, packet->descriptor, i);
@@ -1112,7 +1157,7 @@ static iree_status_t loom_amdgpu_try_encode_vop2_u32_vgpr_packet(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet,
     bool* out_encoded) {
   *out_encoded = false;
-  IREE_ASSERT(state->encoding_table != NULL);
+  IREE_ASSERT(state->inputs.encoding_table != NULL);
   if (packet->descriptor->result_count != 1 ||
       packet->descriptor->operand_count != 2) {
     return iree_ok_status();
@@ -1127,14 +1172,14 @@ static iree_status_t loom_amdgpu_try_encode_vop2_u32_vgpr_packet(
   }
   bool replaced_src0_literal = false;
   const loom_low_descriptor_set_t* descriptor_set =
-      state->schedule->target.descriptor_set;
+      state->inputs.schedule->target.descriptor_set;
   for (uint16_t i = 0; i < packet->descriptor->encoding_field_value_count;
        ++i) {
     const loom_low_encoding_field_value_t* field_value =
         &descriptor_set->encoding_field_values
              [packet->descriptor->encoding_field_value_start + i];
     if (loom_amdgpu_encoding_field_is_src0(field_value->encoding_field_id) &&
-        field_value->value == state->encoding_table->source_literal) {
+        field_value->value == state->inputs.encoding_table->source_literal) {
       replaced_src0_literal = true;
     }
   }
@@ -1149,8 +1194,8 @@ static iree_status_t loom_amdgpu_try_encode_vop2_u32_vgpr_packet(
           state, packet, packet->descriptor->result_count);
   loom_amdgpu_encoding_packet_t encoded_packet;
   IREE_RETURN_IF_ERROR(loom_amdgpu_encoding_pack_vop2_u32_vgpr(
-      state->encoding_table, packet->descriptor->encoding_id, vdst, literal,
-      vsrc1, &encoded_packet));
+      state->inputs.encoding_table, packet->descriptor->encoding_id, vdst,
+      literal, vsrc1, &encoded_packet));
   loom_amdgpu_append_encoding_packet(state, &encoded_packet);
   *out_encoded = true;
   return iree_ok_status();
@@ -1162,14 +1207,14 @@ static iree_status_t loom_amdgpu_try_encode_special_descriptor_packet(
   *out_encoded = false;
   switch (packet->descriptor->encoding_format_id) {
     case LOOM_AMDGPU_ENCODING_FORMAT_SOP1:
-      if (packet->descriptor == state->descriptors.s_mov_b32 ||
-          packet->descriptor == state->descriptors.s_mov_b32_m0_imm) {
+      if (packet->descriptor == state->inputs.descriptors.s_mov_b32 ||
+          packet->descriptor == state->inputs.descriptors.s_mov_b32_m0_imm) {
         IREE_RETURN_IF_ERROR(loom_amdgpu_encode_sop1_s_mov_b32(state, packet));
         *out_encoded = true;
       }
       return iree_ok_status();
     case LOOM_AMDGPU_ENCODING_FORMAT_VOP1_LITERAL:
-      if (packet->descriptor == state->descriptors.v_mov_b32) {
+      if (packet->descriptor == state->inputs.descriptors.v_mov_b32) {
         IREE_RETURN_IF_ERROR(loom_amdgpu_encode_vop1_v_mov_b32(state, packet));
         *out_encoded = true;
       }
@@ -1187,9 +1232,9 @@ static iree_status_t loom_amdgpu_try_encode_special_descriptor_packet(
 static iree_status_t loom_amdgpu_verify_unplanned_descriptor_address_state(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet) {
   const loom_amdgpu_address_state_requirement_t requirement =
-      loom_amdgpu_address_state_requirement_for_packet(state->allocation,
+      loom_amdgpu_address_state_requirement_for_packet(state->inputs.allocation,
                                                        packet);
-  if ((state->current_vgpr_msb_mode & requirement.mask) !=
+  if ((state->traversal.current_vgpr_msb_mode & requirement.mask) !=
       (requirement.value & requirement.mask)) {
     return iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,
@@ -1201,12 +1246,12 @@ static iree_status_t loom_amdgpu_verify_unplanned_descriptor_address_state(
 
 static iree_status_t loom_amdgpu_encode_generic_descriptor_packet(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet) {
-  IREE_ASSERT(state->encoding_table != NULL);
+  IREE_ASSERT(state->inputs.encoding_table != NULL);
   loom_amdgpu_encoding_field_value_t
       field_values[LOOM_AMDGPU_ENCODING_PACKET_FIELD_VALUE_CAPACITY];
   iree_host_size_t field_value_count = 0;
   const loom_low_descriptor_set_t* descriptor_set =
-      state->schedule->target.descriptor_set;
+      state->inputs.schedule->target.descriptor_set;
   const loom_amdgpu_rel32_text_fixup_info_t rel32_fixup =
       loom_amdgpu_descriptor_rel32_text_fixup_info(state, packet->descriptor);
   const bool has_rel32_text_fixup =
@@ -1246,8 +1291,8 @@ static iree_status_t loom_amdgpu_encode_generic_descriptor_packet(
       continue;
     }
     const loom_low_allocation_assignment_t* assignment =
-        loom_low_packet_descriptor_operand_assignment(state->allocation, packet,
-                                                      i);
+        loom_low_packet_descriptor_operand_assignment(state->inputs.allocation,
+                                                      packet, i);
     uint64_t value = 0;
     IREE_RETURN_IF_ERROR(
         loom_amdgpu_assignment_field_value(state, assignment, operand, &value));
@@ -1275,12 +1320,12 @@ static iree_status_t loom_amdgpu_encode_generic_descriptor_packet(
 
   loom_amdgpu_encoding_packet_t encoded_packet;
   IREE_RETURN_IF_ERROR(loom_amdgpu_encoding_pack(
-      state->encoding_table, packet->descriptor->encoding_format_id,
+      state->inputs.encoding_table, packet->descriptor->encoding_format_id,
       packet->descriptor->encoding_id, field_values, field_value_count,
       &encoded_packet));
   if (has_rel32_text_fixup) {
     iree_host_size_t literal_byte_offset = 0;
-    if (!iree_host_size_checked_add(state->length, sizeof(uint32_t),
+    if (!iree_host_size_checked_add(state->stream.length, sizeof(uint32_t),
                                     &literal_byte_offset)) {
       return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                               "AMDGPU native encoding rel32 literal offset "
@@ -1301,7 +1346,7 @@ static iree_status_t loom_amdgpu_encode_generic_descriptor_packet(
 
 static iree_status_t loom_amdgpu_encode_regular_descriptor_packet(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet) {
-  if (state->address_state == NULL) {
+  if (state->packet_plan.address_state == NULL) {
     IREE_RETURN_IF_ERROR(
         loom_amdgpu_verify_unplanned_descriptor_address_state(state, packet));
   }
@@ -1332,10 +1377,11 @@ static iree_status_t loom_amdgpu_encode_vopd_pair(
   loom_amdgpu_encoding_packet_t encoded_packet;
   if (iree_any_bit_set(pair->flags, LOOM_AMDGPU_VOPD_PAIR_FLAG_LITERAL)) {
     IREE_RETURN_IF_ERROR(loom_amdgpu_encoding_pack_vopdxy_literal(
-        state->encoding_table, &fields, pair->literal_u32, &encoded_packet));
+        state->inputs.encoding_table, &fields, pair->literal_u32,
+        &encoded_packet));
   } else {
     IREE_RETURN_IF_ERROR(loom_amdgpu_encoding_pack_vopdxy(
-        state->encoding_table, &fields, &encoded_packet));
+        state->inputs.encoding_table, &fields, &encoded_packet));
   }
   loom_amdgpu_append_encoding_packet(state, &encoded_packet);
   return iree_ok_status();
@@ -1345,50 +1391,52 @@ static iree_status_t loom_amdgpu_try_encode_vopd_packet(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet,
     bool* out_handled) {
   *out_handled = false;
-  if (state->vopd_plan == NULL) {
+  if (state->packet_plan.vopd_plan == NULL) {
     return iree_ok_status();
   }
   const loom_amdgpu_vopd_packet_t* vopd_packet =
-      loom_amdgpu_vopd_plan_packet_at(state->vopd_plan, packet->packet_index);
+      loom_amdgpu_vopd_plan_packet_at(state->packet_plan.vopd_plan,
+                                      packet->packet_index);
   if (vopd_packet == NULL) {
     return iree_ok_status();
   }
-  IREE_ASSERT(vopd_packet->pair_index < state->vopd_plan->pair_count);
+  IREE_ASSERT(vopd_packet->pair_index <
+              state->packet_plan.vopd_plan->pair_count);
   *out_handled = true;
   if (vopd_packet->role == LOOM_AMDGPU_VOPD_PACKET_ROLE_SECOND) {
     return iree_ok_status();
   }
   IREE_ASSERT(vopd_packet->role == LOOM_AMDGPU_VOPD_PACKET_ROLE_FIRST);
   const loom_amdgpu_vopd_pair_t* pair =
-      &state->vopd_plan->pairs[vopd_packet->pair_index];
+      &state->packet_plan.vopd_plan->pairs[vopd_packet->pair_index];
   return loom_amdgpu_encode_vopd_pair(state, pair);
 }
 
 static iree_status_t loom_amdgpu_encode_descriptor_packet(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet) {
   if (!loom_amdgpu_descriptor_set_info_has_flags(
-          state->target,
+          state->inputs.target,
           LOOM_AMDGPU_DESCRIPTOR_SET_INFO_FLAG_DESCRIPTOR_PACKET_ENCODING)) {
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                             "AMDGPU descriptor packet encoding for descriptor "
                             "set '%.*s' is not supported yet",
-                            (int)state->target->key.size,
-                            state->target->key.data);
+                            (int)state->inputs.target->key.size,
+                            state->inputs.target->key.data);
   }
-  if (state->encoding_table == NULL) {
+  if (state->inputs.encoding_table == NULL) {
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                             "AMDGPU native encoding has no bit table for "
                             "descriptor set '%.*s'",
-                            (int)state->target->key.size,
-                            state->target->key.data);
+                            (int)state->inputs.target->key.size,
+                            state->inputs.target->key.data);
   }
 
   const uint16_t encoding_format = packet->descriptor->encoding_format_id;
-  if (!loom_amdgpu_encoding_table_has_format(state->encoding_table,
+  if (!loom_amdgpu_encoding_table_has_format(state->inputs.encoding_table,
                                              encoding_format)) {
-    const iree_string_view_t key =
-        loom_amdgpu_descriptor_string(state->schedule->target.descriptor_set,
-                                      packet->descriptor->key_string_offset);
+    const iree_string_view_t key = loom_amdgpu_descriptor_string(
+        state->inputs.schedule->target.descriptor_set,
+        packet->descriptor->key_string_offset);
     iree_string_view_t format_name =
         loom_amdgpu_encoding_format_name(encoding_format);
     return iree_make_status(
@@ -1403,13 +1451,13 @@ static iree_status_t loom_amdgpu_encode_descriptor_packet(
 
 static iree_status_t loom_amdgpu_update_vgpr_msb_mode_after_descriptor(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet) {
-  if (state->descriptors.set_vgpr_msb == NULL ||
-      packet->descriptor != state->descriptors.set_vgpr_msb) {
+  if (state->inputs.descriptors.set_vgpr_msb == NULL ||
+      packet->descriptor != state->inputs.descriptors.set_vgpr_msb) {
     return iree_ok_status();
   }
   uint16_t mode = 0;
   IREE_RETURN_IF_ERROR(loom_amdgpu_read_immediate_u16(state, packet, 0, &mode));
-  state->current_vgpr_msb_mode = (uint8_t)(mode & 0xFFu);
+  state->traversal.current_vgpr_msb_mode = (uint8_t)(mode & 0xFFu);
   return iree_ok_status();
 }
 
@@ -1417,8 +1465,8 @@ static void loom_amdgpu_invalidate_pc_registers_after_descriptor(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet) {
   for (uint16_t i = 0; i < packet->descriptor->result_count; ++i) {
     const loom_low_allocation_assignment_t* assignment =
-        loom_low_packet_descriptor_operand_assignment(state->allocation, packet,
-                                                      i);
+        loom_low_packet_descriptor_operand_assignment(state->inputs.allocation,
+                                                      packet, i);
     if (assignment->descriptor_reg_class_id != LOOM_AMDGPU_REG_CLASS_ID_SGPR) {
       continue;
     }
@@ -1437,8 +1485,8 @@ static void loom_amdgpu_record_pc_registers_after_descriptor(
     return;
   }
   const loom_low_allocation_assignment_t* assignment =
-      loom_low_packet_descriptor_operand_assignment(state->allocation, packet,
-                                                    0);
+      loom_low_packet_descriptor_operand_assignment(state->inputs.allocation,
+                                                    packet, 0);
   uint16_t sgpr_base = 0;
   uint16_t sgpr_count = 0;
   loom_amdgpu_sgpr_register_range(assignment, &sgpr_base, &sgpr_count);
@@ -1460,7 +1508,8 @@ static void loom_amdgpu_update_pc_registers_after_descriptor(
 static iree_status_t loom_amdgpu_encode_return_packet(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet) {
   (void)packet;
-  return loom_amdgpu_encode_sopp_simm16(state, state->target->sopp.endpgm, 0);
+  return loom_amdgpu_encode_sopp_simm16(state,
+                                        state->inputs.target->sopp.endpgm, 0);
 }
 
 static iree_status_t loom_amdgpu_encode_branch_offset(
@@ -1468,26 +1517,27 @@ static iree_status_t loom_amdgpu_encode_branch_offset(
     uint16_t* out_immediate) {
   *out_immediate = 0;
   const uint32_t target_block_index =
-      loom_low_packet_block_index(state->schedule, target_block);
+      loom_low_packet_block_index(state->inputs.schedule, target_block);
   if (target_block_index == LOOM_LOW_PACKET_INDEX_NONE) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "AMDGPU native encoding branch target block is not "
                             "in the scheduled low function");
   }
-  if (state->data == NULL) {
+  if (state->stream.data == NULL) {
     return iree_ok_status();
   }
-  IREE_ASSERT(state->block_offsets != NULL);
-  if (state->length > (iree_host_size_t)INT64_MAX - 4 ||
-      state->block_offsets[target_block_index] > (iree_host_size_t)INT64_MAX) {
+  IREE_ASSERT(state->branches.block_offsets != NULL);
+  if (state->stream.length > (iree_host_size_t)INT64_MAX - 4 ||
+      state->branches.block_offsets[target_block_index] >
+          (iree_host_size_t)INT64_MAX) {
     return iree_make_status(
         IREE_STATUS_OUT_OF_RANGE,
         "AMDGPU native encoding branch target byte offset exceeds int64_t");
   }
 
-  const int64_t branch_base_offset = (int64_t)state->length + 4;
+  const int64_t branch_base_offset = (int64_t)state->stream.length + 4;
   const int64_t target_offset =
-      (int64_t)state->block_offsets[target_block_index];
+      (int64_t)state->branches.block_offsets[target_block_index];
   const int64_t relative_byte_offset = target_offset - branch_base_offset;
   if ((relative_byte_offset % 4) != 0) {
     return iree_make_status(
@@ -1515,7 +1565,7 @@ static iree_status_t loom_amdgpu_encode_branch_packet(
   if (args.count != 0) {
     const loom_low_allocation_edge_copy_group_t* group =
         loom_low_allocation_find_edge_copy_group_by_source_ordinal(
-            state->allocation, packet->node->source_ordinal);
+            state->inputs.allocation, packet->node->source_ordinal);
     if (!group) {
       return iree_make_status(
           IREE_STATUS_FAILED_PRECONDITION,
@@ -1526,29 +1576,29 @@ static iree_status_t loom_amdgpu_encode_branch_packet(
   }
   const uint32_t current_block_index = packet->node->block_index;
   const uint32_t dest_block_index =
-      loom_low_packet_block_index(state->schedule, dest);
+      loom_low_packet_block_index(state->inputs.schedule, dest);
   if (dest_block_index == current_block_index + 1) {
     return iree_ok_status();
   }
   uint16_t immediate = 0;
   IREE_RETURN_IF_ERROR(
       loom_amdgpu_encode_branch_offset(state, dest, &immediate));
-  return loom_amdgpu_encode_sopp_simm16(state, state->target->sopp.branch,
-                                        immediate);
+  return loom_amdgpu_encode_sopp_simm16(
+      state, state->inputs.target->sopp.branch, immediate);
 }
 
 static iree_status_t loom_amdgpu_encode_cond_branch_packet(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet) {
   const loom_op_t* op = packet->node->op;
   IREE_RETURN_IF_ERROR(loom_amdgpu_verify_scc_assignment(
-      state->allocation, loom_low_cond_br_condition(op)));
+      state->inputs.allocation, loom_low_cond_br_condition(op)));
   const loom_block_t* true_dest = loom_low_cond_br_true_dest(op);
   const loom_block_t* false_dest = loom_low_cond_br_false_dest(op);
   const uint32_t current_block_index = packet->node->block_index;
   const uint32_t true_block_index =
-      loom_low_packet_block_index(state->schedule, true_dest);
+      loom_low_packet_block_index(state->inputs.schedule, true_dest);
   const uint32_t false_block_index =
-      loom_low_packet_block_index(state->schedule, false_dest);
+      loom_low_packet_block_index(state->inputs.schedule, false_dest);
   if (true_dest == false_dest) {
     if (true_block_index == current_block_index + 1) {
       return iree_ok_status();
@@ -1556,30 +1606,33 @@ static iree_status_t loom_amdgpu_encode_cond_branch_packet(
     uint16_t immediate = 0;
     IREE_RETURN_IF_ERROR(
         loom_amdgpu_encode_branch_offset(state, true_dest, &immediate));
-    return loom_amdgpu_encode_sopp_simm16(state, state->target->sopp.branch,
-                                          immediate);
+    return loom_amdgpu_encode_sopp_simm16(
+        state, state->inputs.target->sopp.branch, immediate);
   }
   if (true_block_index == current_block_index + 1) {
     uint16_t false_immediate = 0;
     IREE_RETURN_IF_ERROR(
         loom_amdgpu_encode_branch_offset(state, false_dest, &false_immediate));
     return loom_amdgpu_encode_sopp_simm16(
-        state, state->target->sopp.conditional_branch_scc0, false_immediate);
+        state, state->inputs.target->sopp.conditional_branch_scc0,
+        false_immediate);
   }
   uint16_t true_immediate = 0;
   IREE_RETURN_IF_ERROR(
       loom_amdgpu_encode_branch_offset(state, true_dest, &true_immediate));
   if (false_block_index == current_block_index + 1) {
     return loom_amdgpu_encode_sopp_simm16(
-        state, state->target->sopp.conditional_branch_scc1, true_immediate);
+        state, state->inputs.target->sopp.conditional_branch_scc1,
+        true_immediate);
   }
   IREE_RETURN_IF_ERROR(loom_amdgpu_encode_sopp_simm16(
-      state, state->target->sopp.conditional_branch_scc1, true_immediate));
+      state, state->inputs.target->sopp.conditional_branch_scc1,
+      true_immediate));
   uint16_t false_immediate = 0;
   IREE_RETURN_IF_ERROR(
       loom_amdgpu_encode_branch_offset(state, false_dest, &false_immediate));
-  return loom_amdgpu_encode_sopp_simm16(state, state->target->sopp.branch,
-                                        false_immediate);
+  return loom_amdgpu_encode_sopp_simm16(
+      state, state->inputs.target->sopp.branch, false_immediate);
 }
 
 static iree_status_t loom_amdgpu_encode_live_in_packet(
@@ -1608,7 +1661,7 @@ static iree_status_t loom_amdgpu_encode_storage_address_packet(
   const loom_op_t* op = packet->node->op;
   loom_amdgpu_storage_layout_reference_t reference;
   loom_amdgpu_storage_layout_lookup_reference(
-      state->storage_layout, state->schedule->module,
+      state->inputs.storage_layout, state->inputs.schedule->module,
       loom_low_storage_address_storage(op), &reference);
   const uint64_t offset = (uint64_t)loom_low_storage_address_offset(op);
   uint64_t byte_offset = reference.reservation.byte_offset;
@@ -1625,7 +1678,7 @@ static iree_status_t loom_amdgpu_encode_storage_address_packet(
         "AMDGPU native encoding low.storage.address byte offset exceeds u32");
   }
   const loom_low_allocation_assignment_t* assignment =
-      loom_amdgpu_map_assignment(state->allocation,
+      loom_amdgpu_map_assignment(state->inputs.allocation,
                                  loom_low_storage_address_result(op));
   return loom_amdgpu_encode_vgpr_move_immediate(
       state, assignment->location_base, (uint32_t)(byte_offset + offset));
@@ -1658,19 +1711,19 @@ static uint16_t loom_amdgpu_wait_packet_immediate_value(
 static iree_status_t loom_amdgpu_encode_generic_wait_packet(
     loom_amdgpu_encode_state_t* state, const loom_low_descriptor_t* descriptor,
     const loom_amdgpu_wait_packet_t* wait_packet) {
-  if (state->encoding_table == NULL) {
+  if (state->inputs.encoding_table == NULL) {
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                             "AMDGPU native encoding has no bit table for "
                             "descriptor set '%.*s'",
-                            (int)state->target->key.size,
-                            state->target->key.data);
+                            (int)state->inputs.target->key.size,
+                            state->inputs.target->key.data);
   }
 
   loom_amdgpu_encoding_field_value_t
       field_values[LOOM_AMDGPU_ENCODING_PACKET_FIELD_VALUE_CAPACITY];
   iree_host_size_t field_value_count = 0;
   const loom_low_descriptor_set_t* descriptor_set =
-      state->schedule->target.descriptor_set;
+      state->inputs.schedule->target.descriptor_set;
   for (uint16_t i = 0; i < descriptor->encoding_field_value_count; ++i) {
     const loom_low_encoding_field_value_t* field_value =
         &descriptor_set
@@ -1693,7 +1746,7 @@ static iree_status_t loom_amdgpu_encode_generic_wait_packet(
       default_value = (uint16_t)descriptor_immediate->default_value;
     }
     const uint16_t value = loom_amdgpu_wait_packet_immediate_value(
-        state->wait_packets, wait_packet, i, default_value);
+        state->packet_plan.wait_packets, wait_packet, i, default_value);
     loom_amdgpu_push_encoding_field_value(
         field_values, &field_value_count,
         descriptor_immediate->encoding_field_id, value);
@@ -1701,7 +1754,7 @@ static iree_status_t loom_amdgpu_encode_generic_wait_packet(
 
   loom_amdgpu_encoding_packet_t encoded_packet;
   IREE_RETURN_IF_ERROR(loom_amdgpu_encoding_pack(
-      state->encoding_table, descriptor->encoding_format_id,
+      state->inputs.encoding_table, descriptor->encoding_format_id,
       descriptor->encoding_id, field_values, field_value_count,
       &encoded_packet));
   loom_amdgpu_append_encoding_packet(state, &encoded_packet);
@@ -1720,17 +1773,19 @@ static iree_status_t loom_amdgpu_encode_wait_packet(
 
 static iree_status_t loom_amdgpu_encode_wait_packets_before_packet(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet) {
-  if (state->wait_packets == NULL) {
+  if (state->packet_plan.wait_packets == NULL) {
     return iree_ok_status();
   }
-  while (state->next_wait_packet_index < state->wait_packets->packet_count) {
+  while (state->packet_plan.next_wait_packet_index <
+         state->packet_plan.wait_packets->packet_count) {
     const loom_amdgpu_wait_packet_t* wait_packet =
-        &state->wait_packets->packets[state->next_wait_packet_index];
+        &state->packet_plan.wait_packets
+             ->packets[state->packet_plan.next_wait_packet_index];
     if (!loom_amdgpu_wait_packet_matches_packet(wait_packet, packet)) {
       return iree_ok_status();
     }
     IREE_RETURN_IF_ERROR(loom_amdgpu_encode_wait_packet(state, wait_packet));
-    ++state->next_wait_packet_index;
+    ++state->packet_plan.next_wait_packet_index;
   }
   return iree_ok_status();
 }
@@ -1746,37 +1801,40 @@ static bool loom_amdgpu_address_state_matches_packet(
 
 static iree_status_t loom_amdgpu_encode_address_state_before_packet(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet) {
-  if (state->address_state == NULL) {
+  if (state->packet_plan.address_state == NULL) {
     return iree_ok_status();
   }
-  while (state->next_address_state_index <
-         state->address_state->transition_count) {
+  while (state->packet_plan.next_address_state_index <
+         state->packet_plan.address_state->transition_count) {
     const loom_amdgpu_address_state_transition_t* transition =
-        &state->address_state->transitions[state->next_address_state_index];
+        &state->packet_plan.address_state
+             ->transitions[state->packet_plan.next_address_state_index];
     if (!loom_amdgpu_address_state_matches_packet(transition, packet)) {
       return iree_ok_status();
     }
     const uint8_t new_mode = (uint8_t)(transition->mode_immediate & 0xFFu);
     IREE_RETURN_IF_ERROR(loom_amdgpu_encode_vgpr_msb_mode(state, new_mode));
-    ++state->next_address_state_index;
+    ++state->packet_plan.next_address_state_index;
   }
   return iree_ok_status();
 }
 
 static iree_status_t loom_amdgpu_encode_wait_states_before_packet(
     loom_amdgpu_encode_state_t* state, const loom_low_packet_view_t* packet) {
-  if (state->wait_states == NULL) {
+  if (state->packet_plan.wait_states == NULL) {
     return iree_ok_status();
   }
-  while (state->next_wait_state_index < state->wait_states->state_count) {
+  while (state->packet_plan.next_wait_state_index <
+         state->packet_plan.wait_states->state_count) {
     const loom_amdgpu_wait_state_t* wait_state =
-        &state->wait_states->states[state->next_wait_state_index];
+        &state->packet_plan.wait_states
+             ->states[state->packet_plan.next_wait_state_index];
     if (!loom_amdgpu_wait_state_matches_packet(wait_state, packet)) {
       return iree_ok_status();
     }
     IREE_RETURN_IF_ERROR(
         loom_amdgpu_encode_wait_state_action(state, wait_state));
-    ++state->next_wait_state_index;
+    ++state->packet_plan.next_wait_state_index;
   }
   return iree_ok_status();
 }
@@ -1799,11 +1857,11 @@ static iree_status_t loom_amdgpu_encode_packet(
     if (handled_vopd) {
       return iree_ok_status();
     }
-    const iree_host_size_t packet_start = state->length;
+    const iree_host_size_t packet_start = state->stream.length;
     IREE_RETURN_IF_ERROR(loom_amdgpu_encode_descriptor_packet(state, packet));
-    if (state->length != packet_start) {
+    if (state->stream.length != packet_start) {
       loom_amdgpu_update_pc_registers_after_descriptor(state, packet,
-                                                       state->length);
+                                                       state->stream.length);
     }
     return loom_amdgpu_update_vgpr_msb_mode_after_descriptor(state, packet);
   }
@@ -1832,7 +1890,8 @@ static iree_status_t loom_amdgpu_encode_packet(
     default:
       break;
   }
-  const loom_op_vtable_t* vtable = loom_op_vtable(state->schedule->module, op);
+  const loom_op_vtable_t* vtable =
+      loom_op_vtable(state->inputs.schedule->module, op);
   iree_string_view_t op_name =
       vtable ? loom_op_vtable_name(vtable) : IREE_SV("<unknown>");
   return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
@@ -1881,56 +1940,58 @@ static iree_status_t loom_amdgpu_resolve_immediate_name_ids(
 
 static iree_status_t loom_amdgpu_encode_instruction_stream_into_state(
     loom_amdgpu_encode_state_t* state) {
-  state->length = 0;
-  state->instruction_count = 0;
-  state->text_fixup_count = 0;
-  state->native_insertion_count = 0;
-  state->current_packet = NULL;
-  state->current_vgpr_msb_mode = 0;
-  state->next_address_state_index = 0;
-  state->next_wait_packet_index = 0;
-  state->next_wait_state_index = 0;
-  memset(state->pc_registers, 0, sizeof(state->pc_registers));
+  state->stream.length = 0;
+  state->stream.instruction_count = 0;
+  state->text_fixups.count = 0;
+  state->native_insertions.count = 0;
+  state->traversal.current_packet = NULL;
+  state->traversal.current_vgpr_msb_mode = 0;
+  state->packet_plan.next_address_state_index = 0;
+  state->packet_plan.next_wait_packet_index = 0;
+  state->packet_plan.next_wait_state_index = 0;
+  memset(state->traversal.pc_registers, 0,
+         sizeof(state->traversal.pc_registers));
   for (iree_host_size_t block_index = 0;
-       block_index < state->schedule->block_count; ++block_index) {
+       block_index < state->inputs.schedule->block_count; ++block_index) {
     const loom_low_schedule_block_t* block =
-        &state->schedule->blocks[block_index];
-    memset(state->pc_registers, 0, sizeof(state->pc_registers));
-    if (state->block_offsets != NULL) {
-      state->block_offsets[block_index] = state->length;
+        &state->inputs.schedule->blocks[block_index];
+    memset(state->traversal.pc_registers, 0,
+           sizeof(state->traversal.pc_registers));
+    if (state->branches.block_offsets != NULL) {
+      state->branches.block_offsets[block_index] = state->stream.length;
     }
     for (uint32_t scheduled_ordinal = 0;
          scheduled_ordinal < block->scheduled_node_count; ++scheduled_ordinal) {
       const iree_host_size_t packet_index =
           block->scheduled_node_start + scheduled_ordinal;
       const loom_low_packet_view_t packet =
-          loom_low_packet_at(state->schedule, packet_index);
-      state->current_packet = &packet;
+          loom_low_packet_at(state->inputs.schedule, packet_index);
+      state->traversal.current_packet = &packet;
       iree_status_t status = loom_amdgpu_encode_packet(state, &packet);
-      state->current_packet = NULL;
+      state->traversal.current_packet = NULL;
       IREE_RETURN_IF_ERROR(status);
     }
-    if (state->address_state == NULL) {
-      if (state->current_vgpr_msb_mode != 0) {
+    if (state->packet_plan.address_state == NULL) {
+      if (state->traversal.current_vgpr_msb_mode != 0) {
         return iree_make_status(
             IREE_STATUS_FAILED_PRECONDITION,
             "AMDGPU native encoding block left VGPR-MSB address state active");
       }
     } else {
-      IREE_ASSERT_EQ(state->current_vgpr_msb_mode, 0);
+      IREE_ASSERT_EQ(state->traversal.current_vgpr_msb_mode, 0);
     }
   }
-  if (state->address_state != NULL) {
-    IREE_ASSERT_EQ(state->next_address_state_index,
-                   state->address_state->transition_count);
+  if (state->packet_plan.address_state != NULL) {
+    IREE_ASSERT_EQ(state->packet_plan.next_address_state_index,
+                   state->packet_plan.address_state->transition_count);
   }
-  if (state->wait_packets != NULL) {
-    IREE_ASSERT_EQ(state->next_wait_packet_index,
-                   state->wait_packets->packet_count);
+  if (state->packet_plan.wait_packets != NULL) {
+    IREE_ASSERT_EQ(state->packet_plan.next_wait_packet_index,
+                   state->packet_plan.wait_packets->packet_count);
   }
-  if (state->wait_states != NULL) {
-    IREE_ASSERT_EQ(state->next_wait_state_index,
-                   state->wait_states->state_count);
+  if (state->packet_plan.wait_states != NULL) {
+    IREE_ASSERT_EQ(state->packet_plan.next_wait_state_index,
+                   state->packet_plan.wait_states->state_count);
   }
   return iree_ok_status();
 }
@@ -2001,7 +2062,7 @@ static iree_status_t loom_amdgpu_encode_instruction_stream_internal(
   loom_low_allocation_value_scratch_t scratch = {0};
   iree_status_t status =
       loom_low_allocation_acquire_value_scratch(allocation, &scratch);
-  loom_amdgpu_encode_state_t sizing_state = {
+  const loom_amdgpu_encode_inputs_t inputs = {
       .schedule = schedule,
       .allocation = allocation,
       .target = target,
@@ -2009,77 +2070,86 @@ static iree_status_t loom_amdgpu_encode_instruction_stream_internal(
       .storage_layout = storage_layout,
       .immediate_name_ids = immediate_name_ids,
       .immediate_name_id_count = immediate_name_id_count,
+      .flags = flags,
+      .descriptors = descriptors,
+  };
+  const loom_amdgpu_encode_packet_plan_state_t packet_plan_state = {
       .address_state = address_state,
       .wait_packets = wait_packets,
       .wait_states = wait_states,
       .vopd_plan = vopd_plan,
-      .flags = flags,
-      .descriptors = descriptors,
-      .arena = arena,
-      .block_offsets = block_offsets,
+  };
+  loom_amdgpu_encode_state_t sizing_state = {
+      .inputs = inputs,
+      .packet_plan = packet_plan_state,
+      .branches =
+          {
+              .block_offsets = block_offsets,
+          },
   };
   if (iree_status_is_ok(status)) {
     status = loom_amdgpu_encode_instruction_stream_into_state(&sizing_state);
   }
 
   uint8_t* data = NULL;
-  if (iree_status_is_ok(status) && sizing_state.length != 0) {
-    status = iree_arena_allocate(arena, sizing_state.length, (void**)&data);
+  if (iree_status_is_ok(status) && sizing_state.stream.length != 0) {
+    status =
+        iree_arena_allocate(arena, sizing_state.stream.length, (void**)&data);
   }
   loom_amdgpu_hsaco_text_fixup_t* text_fixups = NULL;
-  if (iree_status_is_ok(status) && sizing_state.text_fixup_count != 0) {
+  if (iree_status_is_ok(status) && sizing_state.text_fixups.count != 0) {
     status =
-        iree_arena_allocate_array(arena, sizing_state.text_fixup_count,
+        iree_arena_allocate_array(arena, sizing_state.text_fixups.count,
                                   sizeof(text_fixups[0]), (void**)&text_fixups);
   }
   loom_amdgpu_native_insertion_t* native_insertions = NULL;
-  if (iree_status_is_ok(status) && sizing_state.native_insertion_count != 0) {
+  if (iree_status_is_ok(status) && sizing_state.native_insertions.count != 0) {
     status = iree_arena_allocate_array(
-        arena, sizing_state.native_insertion_count,
+        arena, sizing_state.native_insertions.count,
         sizeof(native_insertions[0]), (void**)&native_insertions);
   }
   loom_amdgpu_encode_state_t writing_state = {
-      .schedule = schedule,
-      .allocation = allocation,
-      .target = target,
-      .encoding_table = encoding_table,
-      .storage_layout = storage_layout,
-      .immediate_name_ids = immediate_name_ids,
-      .immediate_name_id_count = immediate_name_id_count,
-      .address_state = address_state,
-      .wait_packets = wait_packets,
-      .wait_states = wait_states,
-      .vopd_plan = vopd_plan,
-      .flags = flags,
-      .descriptors = descriptors,
-      .arena = arena,
-      .data = data,
-      .capacity = sizing_state.length,
-      .text_fixups = text_fixups,
-      .text_fixup_capacity = sizing_state.text_fixup_count,
-      .native_insertions = native_insertions,
-      .native_insertion_capacity = sizing_state.native_insertion_count,
-      .block_offsets = block_offsets,
+      .inputs = inputs,
+      .packet_plan = packet_plan_state,
+      .stream =
+          {
+              .data = data,
+              .capacity = sizing_state.stream.length,
+          },
+      .text_fixups =
+          {
+              .values = text_fixups,
+              .capacity = sizing_state.text_fixups.count,
+          },
+      .native_insertions =
+          {
+              .values = native_insertions,
+              .capacity = sizing_state.native_insertions.count,
+          },
+      .branches =
+          {
+              .block_offsets = block_offsets,
+          },
   };
-  if (iree_status_is_ok(status) && sizing_state.length != 0) {
+  if (iree_status_is_ok(status) && sizing_state.stream.length != 0) {
     status = loom_amdgpu_encode_instruction_stream_into_state(&writing_state);
   }
   if (iree_status_is_ok(status)) {
-    IREE_ASSERT_EQ(writing_state.length, sizing_state.length);
-    IREE_ASSERT_EQ(writing_state.instruction_count,
-                   sizing_state.instruction_count);
-    IREE_ASSERT_EQ(writing_state.text_fixup_count,
-                   sizing_state.text_fixup_count);
-    IREE_ASSERT_EQ(writing_state.native_insertion_count,
-                   sizing_state.native_insertion_count);
-    if (sizing_state.length != 0) {
+    IREE_ASSERT_EQ(writing_state.stream.length, sizing_state.stream.length);
+    IREE_ASSERT_EQ(writing_state.stream.instruction_count,
+                   sizing_state.stream.instruction_count);
+    IREE_ASSERT_EQ(writing_state.text_fixups.count,
+                   sizing_state.text_fixups.count);
+    IREE_ASSERT_EQ(writing_state.native_insertions.count,
+                   sizing_state.native_insertions.count);
+    if (sizing_state.stream.length != 0) {
       *out_stream = (loom_amdgpu_encoded_instruction_stream_t){
-          .text = iree_make_const_byte_span(data, writing_state.length),
-          .instruction_count = writing_state.instruction_count,
+          .text = iree_make_const_byte_span(data, writing_state.stream.length),
+          .instruction_count = writing_state.stream.instruction_count,
           .text_fixups = text_fixups,
-          .text_fixup_count = writing_state.text_fixup_count,
+          .text_fixup_count = writing_state.text_fixups.count,
           .native_insertions = native_insertions,
-          .native_insertion_count = writing_state.native_insertion_count,
+          .native_insertion_count = writing_state.native_insertions.count,
       };
     }
   }

--- a/loom/src/loom/target/emit/native/amdgpu/encoding.h
+++ b/loom/src/loom/target/emit/native/amdgpu/encoding.h
@@ -34,6 +34,10 @@ typedef enum loom_amdgpu_native_insertion_kind_e {
   LOOM_AMDGPU_NATIVE_INSERTION_S_DELAY_ALU = 4,
   // A V_NOP vector issue packet.
   LOOM_AMDGPU_NATIVE_INSERTION_V_NOP = 5,
+  // An S_BRANCH skipping a co-located branch-island group.
+  LOOM_AMDGPU_NATIVE_INSERTION_BRANCH_ISLAND_SKIP = 6,
+  // An S_BRANCH implementing one branch-island hop.
+  LOOM_AMDGPU_NATIVE_INSERTION_BRANCH_ISLAND_HOP = 7,
 } loom_amdgpu_native_insertion_kind_t;
 
 // One target-owned instruction inserted while encoding a scheduled packet.

--- a/loom/src/loom/target/emit/native/amdgpu/encoding.h
+++ b/loom/src/loom/target/emit/native/amdgpu/encoding.h
@@ -13,6 +13,7 @@
 #include "iree/base/internal/arena.h"
 #include "loom/codegen/low/allocation.h"
 #include "loom/codegen/low/schedule/types.h"
+#include "loom/target/emit/native/amdgpu/branch_layout.h"
 #include "loom/target/emit/native/amdgpu/storage_layout.h"
 #include "loom/target/emit/native/amdgpu/text_fixup.h"
 
@@ -75,6 +76,9 @@ typedef struct loom_amdgpu_encoded_instruction_stream_t {
   iree_const_byte_span_t text;
   // Number of native instructions encoded in |text|.
   uint64_t instruction_count;
+  // Exact branch-island layout applied to |text|, or empty when every branch
+  // was directly encodable.
+  loom_amdgpu_branch_layout_t branch_layout;
   // Text literal fixups resolved after final HSACO section layout.
   const loom_amdgpu_hsaco_text_fixup_t* text_fixups;
   // Number of entries in |text_fixups|.

--- a/loom/src/loom/target/emit/native/amdgpu/kernel_assembly.c
+++ b/loom/src/loom/target/emit/native/amdgpu/kernel_assembly.c
@@ -278,6 +278,7 @@ static iree_status_t loom_amdgpu_kernel_assembly_emit(
   const loom_amdgpu_assembly_fragment_options_t assembly_options = {
       .packet_plan = options->packet_plan,
       .storage_layout = &record.storage_layout,
+      .branch_layout = options->branch_layout,
   };
   IREE_RETURN_IF_ERROR(loom_amdgpu_emit_assembly_fragment_with_options(
       schedule, allocation, &assembly_options, builder, scratch_arena));

--- a/loom/src/loom/target/emit/native/amdgpu/kernel_assembly.h
+++ b/loom/src/loom/target/emit/native/amdgpu/kernel_assembly.h
@@ -35,6 +35,8 @@ typedef struct loom_amdgpu_kernel_assembly_options_t {
   const loom_amdgpu_native_preflight_t* preflight;
   // Optional target-owned packet plan applied during assembly emission.
   const struct loom_amdgpu_packet_plan_t* packet_plan;
+  // Optional exact branch-island layout shared with native encoding.
+  const struct loom_amdgpu_branch_layout_t* branch_layout;
 } loom_amdgpu_kernel_assembly_options_t;
 
 // Emits complete AMDGPU assembly with target-owned ABI facts and optional

--- a/loom/src/loom/target/emit/native/amdgpu/kernel_emission.c
+++ b/loom/src/loom/target/emit/native/amdgpu/kernel_emission.c
@@ -379,22 +379,6 @@ iree_status_t loom_amdgpu_kernel_emission_build(
   IREE_RETURN_IF_ERROR(
       loom_amdgpu_kernel_emission_record_wait_plan(report, &packet_plan));
 
-  if (target_listing != NULL) {
-    if (iree_string_builder_size(target_listing) != 0) {
-      IREE_RETURN_IF_ERROR(
-          iree_string_builder_append_cstring(target_listing, "\n\n"));
-    }
-    const loom_amdgpu_kernel_assembly_options_t assembly_options = {
-        .abi_layout = abi_layout,
-        .abi_verify = abi_verify,
-        .preflight = preflight,
-        .packet_plan = &packet_plan,
-    };
-    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_kernel_assembly(
-        &frame->schedule, &frame->allocation, &assembly_options, target_listing,
-        table_arena));
-  }
-
   const loom_amdgpu_kernel_hsaco_options_t hsaco_options = {
       .abi_layout = abi_layout,
       .abi_verify = abi_verify,
@@ -408,6 +392,24 @@ iree_status_t loom_amdgpu_kernel_emission_build(
   IREE_RETURN_IF_ERROR(loom_amdgpu_build_kernel_hsaco_contribution(
       &frame->schedule, &frame->allocation, &hsaco_options, out_contribution,
       table_arena));
+
+  if (target_listing != NULL) {
+    if (iree_string_builder_size(target_listing) != 0) {
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_cstring(target_listing, "\n\n"));
+    }
+    const loom_amdgpu_kernel_assembly_options_t assembly_options = {
+        .abi_layout = abi_layout,
+        .abi_verify = abi_verify,
+        .preflight = preflight,
+        .packet_plan = &packet_plan,
+        .branch_layout = &out_contribution->branch_layout,
+    };
+    IREE_RETURN_IF_ERROR(loom_amdgpu_emit_kernel_assembly(
+        &frame->schedule, &frame->allocation, &assembly_options, target_listing,
+        table_arena));
+  }
+
   IREE_RETURN_IF_ERROR(loom_amdgpu_kernel_emission_record_native_insertions(
       report, frame, out_contribution));
   loom_amdgpu_kernel_emission_record_summary(report,

--- a/loom/src/loom/target/emit/native/amdgpu/kernel_emission.c
+++ b/loom/src/loom/target/emit/native/amdgpu/kernel_emission.c
@@ -272,6 +272,11 @@ static iree_status_t loom_amdgpu_kernel_emission_record_native_insertions(
         insertion_kind = LOOM_TARGET_COMPILE_REPORT_TARGET_INSERTION_DELAY;
         packet_key = IREE_SV("amdgpu.v_nop");
         break;
+      case LOOM_AMDGPU_NATIVE_INSERTION_BRANCH_ISLAND_SKIP:
+      case LOOM_AMDGPU_NATIVE_INSERTION_BRANCH_ISLAND_HOP:
+        insertion_kind = LOOM_TARGET_COMPILE_REPORT_TARGET_INSERTION_OTHER;
+        packet_key = IREE_SV("amdgpu.s_branch");
+        break;
       case LOOM_AMDGPU_NATIVE_INSERTION_NONE:
       default:
         IREE_ASSERT_UNREACHABLE(
@@ -307,7 +312,8 @@ static iree_status_t loom_amdgpu_kernel_emission_record_native_insertions(
         .static_packet_count = 1,
     };
     uint64_t execution_multiplier = 0;
-    if (dynamic_context.exact &&
+    if (insertion->kind != LOOM_AMDGPU_NATIVE_INSERTION_BRANCH_ISLAND_HOP &&
+        dynamic_context.exact &&
         loom_target_compile_report_low_node_execution_multiplier(
             frame->module, &dynamic_context.fact_table,
             dynamic_context.block_multipliers, node, &execution_multiplier)) {

--- a/loom/src/loom/target/emit/native/amdgpu/kernel_emission.h
+++ b/loom/src/loom/target/emit/native/amdgpu/kernel_emission.h
@@ -25,8 +25,9 @@ extern "C" {
 // Builds one native kernel contribution and optional assembly listing.
 //
 // This is the ownership boundary for target packet planning and native
-// instruction reporting. The same packet plan is applied to assembly and
-// machine-code emission so both products describe the same kernel.
+// instruction reporting. Assembly emission consumes the packet plan and exact
+// branch layout produced for machine-code emission so both products describe
+// the same kernel.
 iree_status_t loom_amdgpu_kernel_emission_build(
     const loom_low_emission_frame_t* frame,
     const loom_amdgpu_hal_kernel_abi_layout_t* abi_layout,

--- a/loom/src/loom/target/emit/native/amdgpu/kernel_hsaco.c
+++ b/loom/src/loom/target/emit/native/amdgpu/kernel_hsaco.c
@@ -103,6 +103,7 @@ iree_status_t loom_amdgpu_build_kernel_hsaco_contribution(
       .code_object_target_id = record.code_object_target_id,
       .processor = record.processor->name,
       .kernel = kernel,
+      .branch_layout = stream.branch_layout,
       .native_insertions = stream.native_insertions,
       .native_insertion_count = stream.native_insertion_count,
       .summary =

--- a/loom/src/loom/target/emit/native/amdgpu/kernel_hsaco.h
+++ b/loom/src/loom/target/emit/native/amdgpu/kernel_hsaco.h
@@ -111,6 +111,8 @@ typedef struct loom_amdgpu_kernel_hsaco_contribution_t {
   iree_string_view_t processor;
   // Kernel entry metadata, descriptor flags, and encoded native text.
   loom_amdgpu_hsaco_kernel_t kernel;
+  // Exact branch-island layout applied to |kernel.text|.
+  loom_amdgpu_branch_layout_t branch_layout;
   // Target-owned instructions inserted during native encoding when capture was
   // requested.
   const loom_amdgpu_native_insertion_t* native_insertions;

--- a/loom/src/loom/target/emit/native/amdgpu/kernel_hsaco_test.cc
+++ b/loom/src/loom/target/emit/native/amdgpu/kernel_hsaco_test.cc
@@ -188,6 +188,7 @@ loom_amdgpu_kernel_hsaco_contribution_t Contribution(
           /*.descriptor_options=*/{},
           /*.text=*/text,
       },
+      /*.branch_layout=*/{},
       /*.native_insertions=*/nullptr,
       /*.native_insertion_count=*/0,
       /*.summary=*/

--- a/loom/src/loom/tooling/target/amdgpu/test/BUILD.bazel
+++ b/loom/src/loom/tooling/target/amdgpu/test/BUILD.bazel
@@ -34,6 +34,7 @@ iree_execution_test_suite(
         "amdgpu_unused_kernargs.loom",
         "complete_authoring_module.loom",
         "gfx1250_configured_fragment_bank.loom",
+        "long_sopp_branch.loom",
         "selected_root_amdgpu.loom",
         "target_family_template_provider_amdgpu.loom",
     ],

--- a/loom/src/loom/tooling/target/amdgpu/test/CMakeLists.txt
+++ b/loom/src/loom/tooling/target/amdgpu/test/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_execution_test_suite(
     "${PROJECT_SOURCE_DIR}/loom/src/loom/tooling/target/amdgpu/test/amdgpu_unused_kernargs.loom"
     "${PROJECT_SOURCE_DIR}/loom/src/loom/tooling/target/amdgpu/test/complete_authoring_module.loom"
     "${PROJECT_SOURCE_DIR}/loom/src/loom/tooling/target/amdgpu/test/gfx1250_configured_fragment_bank.loom"
+    "${PROJECT_SOURCE_DIR}/loom/src/loom/tooling/target/amdgpu/test/long_sopp_branch.loom"
     "${PROJECT_SOURCE_DIR}/loom/src/loom/tooling/target/amdgpu/test/selected_root_amdgpu.loom"
     "${PROJECT_SOURCE_DIR}/loom/src/loom/tooling/target/amdgpu/test/target_family_template_provider_amdgpu.loom"
   LABELS

--- a/loom/src/loom/tooling/target/amdgpu/test/long_sopp_branch.loom
+++ b/loom/src/loom/tooling/target/amdgpu/test/long_sopp_branch.loom
@@ -1,0 +1,39 @@
+// Exercises native SOPP branch relaxation after access-sanitizer expansion.
+// The outer loop remains rolled while the inner reduction is statically
+// expanded into independently observable global loads.
+amdgpu.target<gfx11-generic> @long_sopp_branch_target {subgroup_size = 32}
+
+kernel.def target(@long_sopp_branch_target) @long_sopp_branch() {
+  %c1 = index.constant 1 : index
+  %c32 = index.constant 32 : index
+  kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c32, %c1, %c1) : index
+} launch(%input: buffer, %output: buffer) {
+  %c0 = index.constant 0 : index
+  %c1 = index.constant 1 : index
+  %c2 = index.constant 2 : index
+  %c32 = index.constant 32 : index
+  %c160 = index.constant 160 : index
+  %c5120 = index.constant 5120 : index
+  %c0_offset = index.constant 0 : offset
+  %c0_f32 = scalar.constant 0.0 : f32
+  %lane0 = kernel.workitem.id<x> : index
+  %lane = index.assume %lane0 [range(%lane0, 0, 31)] : index
+  %input_noalias, %output_noalias = buffer.assume.noalias %input, %output : buffer, buffer
+  %input_view = buffer.view %input_noalias[%c0_offset] : buffer -> view<10240xf32, #dense>
+  %output_view = buffer.view %output_noalias[%c0_offset] : buffer -> view<32xf32, #dense>
+  %sum = scf.for %pass = [%c0 to %c2 step %c1](%pass_accumulator = %c0_f32 : f32) -> (f32) {
+    %pass_base = index.mul %pass, %c5120 : index
+    %pass_sum = scf.for %element = [%c0 to %c160 step %c1](%element_accumulator = %pass_accumulator : f32) -> (f32) unroll {
+      %element_base = index.mul %element, %c32 : index
+      %pass_element = index.add %pass_base, %element_base : index
+      %input_index0 = index.add %pass_element, %lane : index
+      %input_index = index.assume %input_index0 [range(%input_index0, 0, 10239)] : index
+      %value = view.load %input_view[%input_index] : view<10240xf32, #dense> -> f32
+      %next = scalar.addf<reassoc|nnan|ninf|nsz> %element_accumulator, %value : f32
+      scf.yield %next : f32
+    }
+    scf.yield %pass_sum : f32
+  }
+  view.store %sum, %output_view[%lane] : f32, view<32xf32, #dense>
+  kernel.return
+}

--- a/loom/src/loom/tooling/target/amdgpu/test/loom-compile-amdgpu.test.json
+++ b/loom/src/loom/tooling/target/amdgpu/test/loom-compile-amdgpu.test.json
@@ -283,7 +283,9 @@
           "--root=long_sopp_branch",
           "--sanitizer=access",
           "--output={tmp}/long_sopp_branch.hal",
-          "--emit-target-artifact={tmp}/long_sopp_branch.hsaco"
+          "--emit-target-artifact={tmp}/long_sopp_branch.hsaco",
+          "--compile-report=details",
+          "--compile-report-output={tmp}/long_sopp_branch_report.json"
         ]
       },
       "files": [
@@ -294,6 +296,12 @@
         {
           "path": "{tmp}/long_sopp_branch.hsaco",
           "non_empty": true
+        },
+        {
+          "path": "{tmp}/long_sopp_branch_report.json",
+          "contains": [
+            "\"packet_key\":\"amdgpu.s_branch\""
+          ]
         }
       ]
     },

--- a/loom/src/loom/tooling/target/amdgpu/test/loom-compile-amdgpu.test.json
+++ b/loom/src/loom/tooling/target/amdgpu/test/loom-compile-amdgpu.test.json
@@ -273,6 +273,31 @@
       ]
     },
     {
+      "name": "relaxes long SOPP branches after sanitizer expansion",
+      "run": {
+        "tool": "loom-compile",
+        "args": [
+          "{srcdir}/long_sopp_branch.loom",
+          "--backend=amdgpu-hal",
+          "--target=gfx11-generic",
+          "--root=long_sopp_branch",
+          "--sanitizer=access",
+          "--output={tmp}/long_sopp_branch.hal",
+          "--emit-target-artifact={tmp}/long_sopp_branch.hsaco"
+        ]
+      },
+      "files": [
+        {
+          "path": "{tmp}/long_sopp_branch.hal",
+          "non_empty": true
+        },
+        {
+          "path": "{tmp}/long_sopp_branch.hsaco",
+          "non_empty": true
+        }
+      ]
+    },
+    {
       "name": "reports invocation-specialized targets to suggestion providers",
       "steps": [
         {


### PR DESCRIPTION
Large AMDGPU kernels can now encode control-flow edges beyond the signed 16-bit SOPP displacement range. Native emission relaxes each out-of-range edge through a converged chain of unconditional branch islands placed at existing packet boundaries, preserving normal fallthrough and conditional SCC/EXEC behavior without consuming scratch registers, LDS, or occupancy.

Relaxation is kept off the ordinary JIT path. The normal sizing traversal records block offsets as it emits, and streams no larger than the 128 KiB SOPP span return without another scan. Only a larger stream whose block geometry can contain a long edge receives an exact branch-measurement pass and layout planning. The planner works over compact offset, edge, and insertion-boundary tables and repeatedly accounts for its own code growth until every hop is encodable. Programs whose branches already fit retain byte-identical machine code.

The resulting layout is an immutable native-emission side product shared by executable encoding, textual assembly, and detailed compile reports. Assembly listings therefore expose the same redirected edges and island groups present in the HSACO rather than independently reconstructing control flow, while insertion reports account for both normal-flow skips and island hops without adding work when reporting is disabled.

The focused layout corpus covers the exact positive and negative signed boundaries, just-outside edges in both directions, conditional and fallthrough-sensitive control flow, co-located islands, and multi-hop convergence. A production-path Loom test expands an access-sanitized kernel far enough to reproduce the original +57,804-dword failure and requires native compilation, assembly emission, and structured reporting to agree on the relaxed result.
