### PR TITLE
[CI] Retain Bazel execution profiles

### DIFF
--- a/.github/workflows/ci_iree_bazel.yml
+++ b/.github/workflows/ci_iree_bazel.yml
@@ -165,9 +165,20 @@ jobs:
           test -d "${HRX_ROCM_ROOT}/include"
 
       - name: Run IREE Bazel CI
+        id: iree_bazel_ci
         run: |
-          echo "python3 build_tools/devtools/ci.py ${{ matrix.command }} --keep-going"
-          python3 build_tools/devtools/ci.py ${{ matrix.command }} --keep-going
+          echo "python3 build_tools/devtools/ci.py ${{ matrix.command }} --bazel-profile-dir ${RUNNER_TEMP}/bazel-profiles --keep-going"
+          python3 build_tools/devtools/ci.py ${{ matrix.command }} \
+            --bazel-profile-dir "${RUNNER_TEMP}/bazel-profiles" --keep-going
+
+      - name: Upload Bazel profiles
+        if: ${{ always() && steps.iree_bazel_ci.outcome != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bazel-profiles-${{ matrix.command }}-attempt-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/bazel-profiles/*.profile.gz
+          if-no-files-found: error
+          compression-level: 0
 
   linux_bazel_vulkan:
     name: Linux / Vulkan
@@ -215,9 +226,20 @@ jobs:
           test -d "${HRX_ROCM_ROOT}/include"
 
       - name: Run IREE Bazel CI
+        id: iree_bazel_ci
         run: |
-          echo "python3 build_tools/devtools/ci.py iree-bazel-vulkan --keep-going"
-          python3 build_tools/devtools/ci.py iree-bazel-vulkan --keep-going
+          echo "python3 build_tools/devtools/ci.py iree-bazel-vulkan --bazel-profile-dir ${RUNNER_TEMP}/bazel-profiles --keep-going"
+          python3 build_tools/devtools/ci.py iree-bazel-vulkan \
+            --bazel-profile-dir "${RUNNER_TEMP}/bazel-profiles" --keep-going
+
+      - name: Upload Bazel profiles
+        if: ${{ always() && steps.iree_bazel_ci.outcome != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bazel-profiles-iree-bazel-vulkan-attempt-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/bazel-profiles/*.profile.gz
+          if-no-files-found: error
+          compression-level: 0
 
   linux_bazel_amdgpu:
     name: ${{ matrix.name }}
@@ -326,7 +348,18 @@ jobs:
         run: bash .github/scripts/check_rocm_environment.sh
 
       - name: Run IREE Bazel CI
+        id: iree_bazel_ci
         run: |
-          echo "python3 build_tools/devtools/ci.py ${{ matrix.command }} --amdgpu-target ${{ matrix.target_selector }} --keep-going"
+          echo "python3 build_tools/devtools/ci.py ${{ matrix.command }} --amdgpu-target ${{ matrix.target_selector }} --bazel-profile-dir ${RUNNER_TEMP}/bazel-profiles --keep-going"
           python3 build_tools/devtools/ci.py ${{ matrix.command }} \
-            --amdgpu-target "${{ matrix.target_selector }}" --keep-going
+            --amdgpu-target "${{ matrix.target_selector }}" \
+            --bazel-profile-dir "${RUNNER_TEMP}/bazel-profiles" --keep-going
+
+      - name: Upload Bazel profiles
+        if: ${{ always() && steps.iree_bazel_ci.outcome != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bazel-profiles-${{ matrix.command }}-${{ matrix.target_selector }}-attempt-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/bazel-profiles/*.profile.gz
+          if-no-files-found: error
+          compression-level: 0

--- a/build_tools/devtools/ci.py
+++ b/build_tools/devtools/ci.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -815,7 +816,7 @@ def tilelang_importer_steps(command_name: str) -> list[CiStep]:
     ]
 
 
-def steps_from_args(args: argparse.Namespace) -> list[CiStep]:
+def _steps_from_args(args: argparse.Namespace) -> list[CiStep]:
     is_amdgpu_command = (
         args.command in BAZEL_COMMANDS and BAZEL_COMMANDS[args.command][0] == "amdgpu"
     ) or (
@@ -878,6 +879,59 @@ def steps_from_args(args: argparse.Namespace) -> list[CiStep]:
     if bazel_target == "vulkan":
         return vulkan_steps(targets)
     raise ValueError(f"unknown Bazel CI target: {bazel_target}")
+
+
+def add_bazel_profiles(steps: list[CiStep], profile_dir: Path) -> list[CiStep]:
+    profiled_steps = []
+    profile_owners = {}
+    for step in steps:
+        if step.argv[1:4] not in (
+            ("dev.py", "bazel", "build"),
+            ("dev.py", "bazel", "test"),
+        ):
+            profiled_steps.append(step)
+            continue
+
+        if any(
+            arg == "--profile" or arg.startswith("--profile=") for arg in step.argv[4:]
+        ):
+            raise ValueError(f"{step.name} already configures a Bazel profile")
+        profile_stem = "-".join(
+            token.lower() for token in re.findall(r"[A-Za-z0-9]+", step.name)
+        )
+        if not profile_stem:
+            raise ValueError(f"cannot derive a Bazel profile name from {step.name!r}")
+        profile_path = profile_dir / f"{profile_stem}.profile.gz"
+        if previous_owner := profile_owners.get(profile_path):
+            raise ValueError(
+                f"Bazel profile path collision between {previous_owner!r} and "
+                f"{step.name!r}: {profile_path}"
+            )
+        profile_owners[profile_path] = step.name
+        profiled_steps.append(
+            CiStep(
+                step.name,
+                step.argv[:4] + (f"--profile={profile_path}",) + step.argv[4:],
+                step.env,
+            )
+        )
+    return profiled_steps
+
+
+def bazel_profile_dir(args: argparse.Namespace) -> Path | None:
+    if args.bazel_profile_dir is None:
+        return None
+    return args.bazel_profile_dir.expanduser().resolve()
+
+
+def steps_from_args(args: argparse.Namespace) -> list[CiStep]:
+    profile_dir = bazel_profile_dir(args)
+    if profile_dir is not None and args.command not in BAZEL_COMMANDS:
+        raise ValueError("--bazel-profile-dir is only supported for Bazel CI commands")
+    steps = _steps_from_args(args)
+    if profile_dir is not None:
+        steps = add_bazel_profiles(steps, profile_dir)
+    return steps
 
 
 def github_actions_enabled() -> bool:
@@ -1014,6 +1068,14 @@ def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--bazel-profile-dir",
+        type=Path,
+        help=(
+            "Write one compressed Bazel execution profile per build/test phase "
+            "to this directory. Only supported for Bazel CI commands."
+        ),
+    )
+    parser.add_argument(
         "--target",
         action="append",
         help=(
@@ -1026,8 +1088,12 @@ def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_arguments(argv)
+    steps = steps_from_args(args)
+    profile_dir = bazel_profile_dir(args)
+    if profile_dir is not None and not args.dry_run:
+        profile_dir.mkdir(parents=True, exist_ok=True)
     return run_steps(
-        steps_from_args(args),
+        steps,
         dry_run=args.dry_run,
         keep_going=args.keep_going,
         verbose=args.verbose,

--- a/build_tools/devtools/ci_test.py
+++ b/build_tools/devtools/ci_test.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import contextlib
 import io
 import re
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -77,6 +78,71 @@ class CiTest(unittest.TestCase):
             "--test_tag_filters=" + ",".join(ci_config.CPU_RESOURCE_TAG_EXCLUDES),
             text,
         )
+
+    def test_bazel_profiles_are_named_for_each_build_and_test_phase(self):
+        profile_dir = Path("/tmp/iree-bazel-profiles")
+        args = ci.parse_arguments(
+            [
+                "iree-bazel-cpu",
+                "--target",
+                "//runtime/...",
+                "--bazel-profile-dir",
+                str(profile_dir),
+            ]
+        )
+
+        steps = ci.steps_from_args(args)
+
+        self.assertEqual(
+            [
+                arg
+                for step in steps
+                for arg in step.argv
+                if arg.startswith("--profile=")
+            ],
+            [
+                f"--profile={profile_dir}/build-iree.profile.gz",
+                f"--profile={profile_dir}/test-iree.profile.gz",
+            ],
+        )
+
+    def test_bazel_profile_names_must_be_unique(self):
+        duplicate_steps = [
+            ci.bazel_build_step("Compile IREE", ("//runtime/...",)),
+            ci.bazel_test_step("Compile IREE", ("//runtime/...",)),
+        ]
+
+        with self.assertRaisesRegex(ValueError, "Bazel profile path collision"):
+            ci.add_bazel_profiles(duplicate_steps, Path("/tmp/profiles"))
+
+    def test_non_bazel_commands_reject_bazel_profile_directory(self):
+        for command in ("iree-cmake-cpu", "iree-importers-tilelang"):
+            with self.subTest(command=command):
+                args = ci.parse_arguments(
+                    [command, "--bazel-profile-dir", "/tmp/profiles"]
+                )
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "--bazel-profile-dir is only supported for Bazel CI commands",
+                ):
+                    ci.steps_from_args(args)
+
+    def test_main_creates_bazel_profile_directory_only_when_executing(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            profile_dir = Path(temporary_dir) / "profiles"
+            argv = [
+                "iree-bazel-cpu",
+                "--target",
+                "//runtime/...",
+                "--bazel-profile-dir",
+                str(profile_dir),
+            ]
+            with mock.patch.object(ci, "run_steps", return_value=0):
+                self.assertEqual(ci.main([*argv, "--dry-run"]), 0)
+                self.assertFalse(profile_dir.exists())
+
+                self.assertEqual(ci.main(argv), 0)
+                self.assertTrue(profile_dir.is_dir())
 
     def test_bazel_default_targets_include_loom(self):
         args = ci.parse_arguments(["iree-bazel-cpu"])
@@ -794,13 +860,59 @@ class CiTest(unittest.TestCase):
         self.assertNotIn("iree-bazel-amdgpu-msan", block)
         self.assertNotIn("iree-bazel-amdgpu-sanitizers", block)
 
+    def test_bazel_workflow_uploads_profiles_for_each_attempted_job(self):
+        cases = (
+            (
+                "linux_bazel_cpu",
+                "bazel-profiles-${{ matrix.command }}-attempt-"
+                "${{ github.run_attempt }}",
+            ),
+            (
+                "linux_bazel_vulkan",
+                "bazel-profiles-iree-bazel-vulkan-attempt-${{ github.run_attempt }}",
+            ),
+            (
+                "linux_bazel_amdgpu",
+                "bazel-profiles-${{ matrix.command }}-"
+                "${{ matrix.target_selector }}-attempt-${{ github.run_attempt }}",
+            ),
+        )
+        for job_name, artifact_name in cases:
+            with self.subTest(job=job_name):
+                block = self.workflow_job_block(
+                    ".github/workflows/ci_iree_bazel.yml", job_name
+                )
+                self.assertIn("id: iree_bazel_ci", block)
+                self.assertIn(
+                    '--bazel-profile-dir "${RUNNER_TEMP}/bazel-profiles"', block
+                )
+                self.assertIn(
+                    "if: ${{ always() && steps.iree_bazel_ci.outcome != 'skipped' }}",
+                    block,
+                )
+                self.assertIn(
+                    "uses: actions/upload-artifact@"
+                    "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1",
+                    block,
+                )
+                self.assertIn(f"name: {artifact_name}", block)
+                self.assertIn(
+                    "path: ${{ runner.temp }}/bazel-profiles/*.profile.gz", block
+                )
+                self.assertIn("if-no-files-found: error", block)
+                self.assertIn("compression-level: 0", block)
+                self.assertLess(
+                    block.index("name: Run IREE Bazel CI"),
+                    block.index("name: Upload Bazel profiles"),
+                )
+
     def test_bazel_vulkan_workflow_has_no_nonexecuting_sanitizer_lane(self):
         block = self.workflow_job_block(
             ".github/workflows/ci_iree_bazel.yml", "linux_bazel_vulkan"
         )
         self.assertIn("name: Linux / Vulkan", block)
         self.assertIn(
-            "python3 build_tools/devtools/ci.py iree-bazel-vulkan --keep-going",
+            "python3 build_tools/devtools/ci.py iree-bazel-vulkan",
             block,
         )
         self.assertNotIn("matrix.", block)


### PR DESCRIPTION
Bazel execution profiles from every CPU, Vulkan, and AMDGPU CI job are now retained as GitHub artifacts. Each Bazel build/test phase writes to stable, human-readable file names, and the upload step runs after successful or failed execution; missing profiles fail loudly instead of silently losing the evidence needed to explain a critical path or regression.

Artifacts are qualified by matrix command, GPU selector where applicable, and workflow run attempt. This keeps parallel jobs distinct and preserves a failed attempt when a job is rerun. Profiles are already gzip-compressed, so upload skips redundant compression.

The source-tree runner owns profile creation rather than making workflows scrape Bazel's cache. The new option is Bazel-only, creates its output directory only for real execution, rejects name collisions, and leaves dry runs side-effect-free.
