### PR TITLE
[Loom] Materialize exact target facts as IR

### DIFF
--- a/loom/binding/c/test/link_test.cc
+++ b/loom/binding/c/test/link_test.cc
@@ -83,6 +83,7 @@ static iree_status_t RegisterFakeTargetContext(loom_context_t* context) {
 
 static const loom_target_provider_t kFakeTargetProvider = {
     /*.profile_type=*/&kFakeTargetProfileType,
+    /*.materialize_definition=*/nullptr,
     /*.register_context=*/RegisterFakeTargetContext,
     /*.initialize_low_descriptor_registry=*/nullptr,
     /*.initialize_low_lower_policy_registry=*/nullptr,

--- a/loom/binding/c/test/target_test.cc
+++ b/loom/binding/c/test/target_test.cc
@@ -143,6 +143,7 @@ static const loom_target_provider_t kEmptyProvider = {};
 
 static const loom_target_provider_t kFakeElfProvider = {
     /*.profile_type=*/nullptr,
+    /*.materialize_definition=*/nullptr,
     /*.register_context=*/nullptr,
     /*.initialize_low_descriptor_registry=*/nullptr,
     /*.initialize_low_lower_policy_registry=*/nullptr,
@@ -163,6 +164,7 @@ static const loom_target_provider_t kFakeElfProvider = {
 
 static const loom_target_provider_t kFakeWasmProvider = {
     /*.profile_type=*/nullptr,
+    /*.materialize_definition=*/nullptr,
     /*.register_context=*/nullptr,
     /*.initialize_low_descriptor_registry=*/nullptr,
     /*.initialize_low_lower_policy_registry=*/nullptr,

--- a/loom/src/loom/target/arch/amdgpu/ops/target.c
+++ b/loom/src/loom/target/arch/amdgpu/ops/target.c
@@ -15,6 +15,79 @@
 #include "loom/target/arch/amdgpu/profile.h"
 #include "loom/target/arch/amdgpu/records/target_records.h"
 
+iree_status_t loom_amdgpu_target_materialize_definition(
+    loom_builder_t* builder, const loom_target_facts_t* base_facts,
+    loom_symbol_ref_t symbol, loom_location_id_t location,
+    loom_op_t** out_target_op) {
+  const loom_amdgpu_target_facts_t* facts =
+      loom_amdgpu_target_facts_cast(base_facts);
+  IREE_ASSERT(facts != NULL);
+  IREE_ASSERT(facts->identity.target != NULL);
+  IREE_ASSERT_EQ(facts->identity.target->target_kind, facts->base.selector);
+  static_assert(LOOM_TARGET_FACT_FIELD_COUNT_ == 30,
+                "AMDGPU target flags reserve the first 30 bits for common "
+                "target facts");
+  static_assert(LOOM_AMDGPU_TARGET_BUILD_FLAG_HAS_CODEGEN_FORMAT ==
+                    (1u << LOOM_TARGET_FACT_FIELD_CODEGEN_FORMAT),
+                "AMDGPU target flags must follow target fact ordinals");
+  static_assert(LOOM_AMDGPU_TARGET_BUILD_FLAG_HAS_CONTRACT_FEATURE_BITS ==
+                    (1u << LOOM_TARGET_FACT_FIELD_CONTRACT_FEATURE_BITS),
+                "AMDGPU target flags must follow target fact ordinals");
+
+  loom_amdgpu_target_build_flags_t build_flags =
+      (loom_amdgpu_target_build_flags_t)facts->base.authored_fields;
+  loom_amdgpu_target_identity_t default_identity = {0};
+  loom_amdgpu_target_identity_initialize(facts->identity.target,
+                                         &default_identity);
+  if (facts->identity.amdhsa_features.sramecc !=
+      default_identity.amdhsa_features.sramecc) {
+    build_flags |= LOOM_AMDGPU_TARGET_BUILD_FLAG_HAS_SRAMECC;
+  }
+  if (facts->identity.amdhsa_features.xnack !=
+      default_identity.amdhsa_features.xnack) {
+    build_flags |= LOOM_AMDGPU_TARGET_BUILD_FLAG_HAS_XNACK;
+  }
+
+  loom_string_id_t export_symbol = LOOM_STRING_ID_INVALID;
+  if (iree_any_bit_set(build_flags,
+                       LOOM_AMDGPU_TARGET_BUILD_FLAG_HAS_EXPORT_SYMBOL)) {
+    IREE_RETURN_IF_ERROR(loom_builder_intern_string(
+        builder, facts->base.storage.export_plan.export_symbol,
+        &export_symbol));
+  }
+  loom_string_id_t contract_set_key = LOOM_STRING_ID_INVALID;
+  if (iree_any_bit_set(build_flags,
+                       LOOM_AMDGPU_TARGET_BUILD_FLAG_HAS_CONTRACT_SET_KEY)) {
+    IREE_RETURN_IF_ERROR(loom_builder_intern_string(
+        builder, facts->base.storage.config.contract_set_key,
+        &contract_set_key));
+  }
+
+  const loom_target_snapshot_t* snapshot = &facts->base.storage.snapshot;
+  const loom_target_export_plan_t* export_plan =
+      &facts->base.storage.export_plan;
+  const loom_target_config_t* config = &facts->base.storage.config;
+  return loom_amdgpu_target_build(
+      builder, build_flags,
+      (loom_amdgpu_target_kind_t)facts->identity.target->target_kind, symbol,
+      snapshot->codegen_format, snapshot->artifact_format,
+      snapshot->default_pointer_bitwidth, snapshot->index_bitwidth,
+      snapshot->offset_bitwidth, snapshot->max_workgroup_size.x,
+      snapshot->max_workgroup_size.y, snapshot->max_workgroup_size.z,
+      snapshot->max_flat_workgroup_size, snapshot->max_workgroup_storage_bytes,
+      snapshot->subgroup_size, snapshot->max_grid_size.x,
+      snapshot->max_grid_size.y, snapshot->max_grid_size.z,
+      snapshot->max_flat_grid_size, snapshot->max_workgroup_count.x,
+      snapshot->max_workgroup_count.y, snapshot->max_workgroup_count.z,
+      snapshot->memory_spaces.generic, snapshot->memory_spaces.global,
+      snapshot->memory_spaces.workgroup, snapshot->memory_spaces.constant,
+      snapshot->memory_spaces.private_memory, snapshot->memory_spaces.host,
+      snapshot->memory_spaces.descriptor, export_plan->abi_kind, export_symbol,
+      export_plan->linkage, contract_set_key, config->contract_feature_bits,
+      facts->identity.amdhsa_features.sramecc,
+      facts->identity.amdhsa_features.xnack, location, out_target_op);
+}
+
 static iree_string_view_t loom_amdgpu_target_record_symbol_name(
     const loom_module_t* module, const loom_op_t* target_op) {
   loom_symbol_ref_t symbol_ref = loom_amdgpu_target_symbol(target_op);

--- a/loom/src/loom/target/arch/amdgpu/ops/target.c
+++ b/loom/src/loom/target/arch/amdgpu/ops/target.c
@@ -21,9 +21,6 @@ iree_status_t loom_amdgpu_target_materialize_definition(
     loom_op_t** out_target_op) {
   const loom_amdgpu_target_facts_t* facts =
       loom_amdgpu_target_facts_cast(base_facts);
-  IREE_ASSERT(facts != NULL);
-  IREE_ASSERT(facts->identity.target != NULL);
-  IREE_ASSERT_EQ(facts->identity.target->target_kind, facts->base.selector);
   static_assert(LOOM_TARGET_FACT_FIELD_COUNT_ == 30,
                 "AMDGPU target flags reserve the first 30 bits for common "
                 "target facts");

--- a/loom/src/loom/target/arch/amdgpu/ops/target.h
+++ b/loom/src/loom/target/arch/amdgpu/ops/target.h
@@ -50,6 +50,12 @@ void loom_amdgpu_target_record_resolve_properties(
     const loom_op_t* target_op, const loom_target_bundle_t* common,
     loom_amdgpu_target_properties_t* out_properties);
 
+// Materializes exact AMDGPU context facts as an amdgpu.target definition.
+iree_status_t loom_amdgpu_target_materialize_definition(
+    loom_builder_t* builder, const loom_target_facts_t* base_facts,
+    loom_symbol_ref_t symbol, loom_location_id_t location,
+    loom_op_t** out_target_op);
+
 iree_status_t loom_amdgpu_target_record_verify(
     const loom_module_t* module, const loom_op_t* op,
     iree_diagnostic_emitter_t emitter);

--- a/loom/src/loom/target/arch/amdgpu/provider.c
+++ b/loom/src/loom/target/arch/amdgpu/provider.c
@@ -16,6 +16,7 @@
 #include "loom/target/arch/amdgpu/lower/lower.h"
 #include "loom/target/arch/amdgpu/math_policy.h"
 #include "loom/target/arch/amdgpu/ops/registry.h"
+#include "loom/target/arch/amdgpu/ops/target.h"
 #include "loom/target/arch/amdgpu/pass_registry.h"
 #include "loom/target/arch/amdgpu/profile.h"
 
@@ -112,6 +113,7 @@ static iree_status_t loom_amdgpu_provider_contribute_pipeline(
 
 const loom_target_provider_t loom_amdgpu_target_provider = {
     .profile_type = &loom_amdgpu_target_profile_type,
+    .materialize_definition = loom_amdgpu_target_materialize_definition,
     .register_context = loom_amdgpu_ops_register_dialect,
     .initialize_low_descriptor_registry =
         loom_amdgpu_low_descriptor_registry_initialize,

--- a/loom/src/loom/target/arch/amdgpu/provider_test.cc
+++ b/loom/src/loom/target/arch/amdgpu/provider_test.cc
@@ -78,6 +78,86 @@ static loom_amdgpu_target_identity_t MakeTargetIdentity(
   return identity;
 }
 
+static void ExpectTargetFactsEqual(const loom_amdgpu_target_facts_t& expected,
+                                   const loom_amdgpu_target_facts_t& actual) {
+  EXPECT_EQ(actual.base.fact_type, expected.base.fact_type);
+  EXPECT_EQ(actual.base.selector, expected.base.selector);
+  EXPECT_EQ(actual.base.authored_fields, expected.base.authored_fields);
+
+  const loom_target_snapshot_t& expected_snapshot =
+      expected.base.storage.snapshot;
+  const loom_target_snapshot_t& actual_snapshot = actual.base.storage.snapshot;
+  EXPECT_EQ(actual_snapshot.codegen_format, expected_snapshot.codegen_format);
+  EXPECT_EQ(actual_snapshot.artifact_format, expected_snapshot.artifact_format);
+  EXPECT_EQ(actual_snapshot.default_pointer_bitwidth,
+            expected_snapshot.default_pointer_bitwidth);
+  EXPECT_EQ(actual_snapshot.index_bitwidth, expected_snapshot.index_bitwidth);
+  EXPECT_EQ(actual_snapshot.offset_bitwidth, expected_snapshot.offset_bitwidth);
+  EXPECT_EQ(actual_snapshot.max_workgroup_size.x,
+            expected_snapshot.max_workgroup_size.x);
+  EXPECT_EQ(actual_snapshot.max_workgroup_size.y,
+            expected_snapshot.max_workgroup_size.y);
+  EXPECT_EQ(actual_snapshot.max_workgroup_size.z,
+            expected_snapshot.max_workgroup_size.z);
+  EXPECT_EQ(actual_snapshot.max_flat_workgroup_size,
+            expected_snapshot.max_flat_workgroup_size);
+  EXPECT_EQ(actual_snapshot.max_workgroup_storage_bytes,
+            expected_snapshot.max_workgroup_storage_bytes);
+  EXPECT_EQ(actual_snapshot.subgroup_size, expected_snapshot.subgroup_size);
+  EXPECT_EQ(actual_snapshot.max_grid_size.x, expected_snapshot.max_grid_size.x);
+  EXPECT_EQ(actual_snapshot.max_grid_size.y, expected_snapshot.max_grid_size.y);
+  EXPECT_EQ(actual_snapshot.max_grid_size.z, expected_snapshot.max_grid_size.z);
+  EXPECT_EQ(actual_snapshot.max_flat_grid_size,
+            expected_snapshot.max_flat_grid_size);
+  EXPECT_EQ(actual_snapshot.max_workgroup_count.x,
+            expected_snapshot.max_workgroup_count.x);
+  EXPECT_EQ(actual_snapshot.max_workgroup_count.y,
+            expected_snapshot.max_workgroup_count.y);
+  EXPECT_EQ(actual_snapshot.max_workgroup_count.z,
+            expected_snapshot.max_workgroup_count.z);
+  EXPECT_EQ(actual_snapshot.memory_spaces.generic,
+            expected_snapshot.memory_spaces.generic);
+  EXPECT_EQ(actual_snapshot.memory_spaces.global,
+            expected_snapshot.memory_spaces.global);
+  EXPECT_EQ(actual_snapshot.memory_spaces.workgroup,
+            expected_snapshot.memory_spaces.workgroup);
+  EXPECT_EQ(actual_snapshot.memory_spaces.constant,
+            expected_snapshot.memory_spaces.constant);
+  EXPECT_EQ(actual_snapshot.memory_spaces.private_memory,
+            expected_snapshot.memory_spaces.private_memory);
+  EXPECT_EQ(actual_snapshot.memory_spaces.host,
+            expected_snapshot.memory_spaces.host);
+  EXPECT_EQ(actual_snapshot.memory_spaces.descriptor,
+            expected_snapshot.memory_spaces.descriptor);
+
+  const loom_target_export_plan_t& expected_export =
+      expected.base.storage.export_plan;
+  const loom_target_export_plan_t& actual_export =
+      actual.base.storage.export_plan;
+  EXPECT_EQ(actual_export.abi_kind, expected_export.abi_kind);
+  EXPECT_EQ(actual_export.linkage, expected_export.linkage);
+  EXPECT_TRUE(iree_string_view_equal(actual_export.export_symbol,
+                                     expected_export.export_symbol));
+  EXPECT_EQ(actual_export.hal_kernel.required_workgroup_size.x,
+            expected_export.hal_kernel.required_workgroup_size.x);
+  EXPECT_EQ(actual_export.hal_kernel.required_workgroup_size.y,
+            expected_export.hal_kernel.required_workgroup_size.y);
+  EXPECT_EQ(actual_export.hal_kernel.required_workgroup_size.z,
+            expected_export.hal_kernel.required_workgroup_size.z);
+  EXPECT_EQ(actual_export.hal_kernel.flat_workgroup_size_min,
+            expected_export.hal_kernel.flat_workgroup_size_min);
+  EXPECT_EQ(actual_export.hal_kernel.flat_workgroup_size_max,
+            expected_export.hal_kernel.flat_workgroup_size_max);
+
+  EXPECT_TRUE(
+      iree_string_view_equal(actual.base.storage.config.contract_set_key,
+                             expected.base.storage.config.contract_set_key));
+  EXPECT_EQ(actual.base.storage.config.contract_feature_bits,
+            expected.base.storage.config.contract_feature_bits);
+  EXPECT_TRUE(
+      loom_amdgpu_target_identity_equal(&actual.identity, &expected.identity));
+}
+
 class AmdgpuProviderTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -338,6 +418,98 @@ TEST_F(AmdgpuProviderTest, ProvidesLoweringPolicyForEveryDescriptorSet) {
         nullptr)
         << "descriptor set ordinal " << i;
   }
+}
+
+TEST_F(AmdgpuProviderTest, MaterializesEveryStructuredProfile) {
+  const iree_host_size_t target_count = loom_amdgpu_target_info_target_count();
+  ASSERT_NE(target_count, 0u);
+  for (iree_host_size_t i = 0; i < target_count; ++i) {
+    const loom_amdgpu_target_info_t* target =
+        loom_amdgpu_target_info_target_at(i);
+    ASSERT_NE(target, nullptr);
+    loom_amdgpu_target_identity_t identity = {};
+    loom_amdgpu_target_identity_initialize(target, &identity);
+    loom_amdgpu_target_profile_t profile = {};
+    IREE_ASSERT_OK(loom_amdgpu_target_profile_initialize(&identity, &profile));
+    loom_target_facts_t* profile_facts = nullptr;
+    IREE_ASSERT_OK(loom_target_profile_project_facts(
+        &profile.base, &analysis_arena_, &profile_facts));
+
+    ModulePtr module;
+    IREE_ASSERT_OK(AllocateModule(target->name, &module));
+    loom_string_id_t target_name_id = LOOM_STRING_ID_INVALID;
+    IREE_ASSERT_OK(loom_module_intern_string(module.get(), IREE_SV("target"),
+                                             &target_name_id));
+    loom_symbol_id_t target_symbol_id = LOOM_SYMBOL_ID_INVALID;
+    IREE_ASSERT_OK(loom_module_add_symbol(module.get(), target_name_id,
+                                          &target_symbol_id));
+    const loom_symbol_ref_t target_ref = {
+        /*.module_id=*/0,
+        /*.symbol_id=*/target_symbol_id,
+    };
+    loom_builder_t builder;
+    loom_builder_initialize(module.get(), &module->arena,
+                            loom_module_block(module.get()), &builder);
+    loom_op_t* target_op = nullptr;
+    IREE_ASSERT_OK(loom_amdgpu_target_provider.materialize_definition(
+        &builder, profile_facts, target_ref, LOOM_LOCATION_UNKNOWN,
+        &target_op));
+    ASSERT_NE(target_op, nullptr);
+
+    loom_symbol_fact_table_reset(&fact_table_);
+    const loom_target_symbol_facts_t* materialized_symbol_facts =
+        Target(module.get(), target_ref);
+    const loom_amdgpu_target_facts_t* materialized_facts =
+        loom_amdgpu_target_facts_cast(materialized_symbol_facts->projection);
+    ASSERT_NE(materialized_facts, nullptr);
+    const loom_amdgpu_target_facts_t* expected_facts =
+        loom_amdgpu_target_facts_cast(profile_facts);
+    ASSERT_NE(expected_facts, nullptr);
+    ExpectTargetFactsEqual(*expected_facts, *materialized_facts);
+  }
+}
+
+TEST_F(AmdgpuProviderTest, MaterializesAuthoredRefinements) {
+  ModulePtr source =
+      Parse(IREE_SV("amdgpu.target<gfx942> @source {subgroup_size = 64, "
+                    "max_workgroup_storage_bytes = 32768, "
+                    "export_symbol = \"roundtrip_export\", "
+                    "contract_set_key = \"roundtrip.contract\", "
+                    "contract_feature_bits = 5, sramecc = on, xnack = off}\n"));
+  const loom_target_symbol_facts_t* source_symbol_facts =
+      Target(source.get(), FindSymbolRef(source.get(), IREE_SV("source")));
+  const loom_amdgpu_target_facts_t* source_facts =
+      loom_amdgpu_target_facts_cast(source_symbol_facts->projection);
+  ASSERT_NE(source_facts, nullptr);
+
+  ModulePtr materialized;
+  IREE_ASSERT_OK(AllocateModule(IREE_SV("materialized"), &materialized));
+  loom_string_id_t target_name_id = LOOM_STRING_ID_INVALID;
+  IREE_ASSERT_OK(loom_module_intern_string(
+      materialized.get(), IREE_SV("sealed_target"), &target_name_id));
+  loom_symbol_id_t target_symbol_id = LOOM_SYMBOL_ID_INVALID;
+  IREE_ASSERT_OK(loom_module_add_symbol(materialized.get(), target_name_id,
+                                        &target_symbol_id));
+  const loom_symbol_ref_t target_ref = {
+      /*.module_id=*/0,
+      /*.symbol_id=*/target_symbol_id,
+  };
+  loom_builder_t builder;
+  loom_builder_initialize(materialized.get(), &materialized->arena,
+                          loom_module_block(materialized.get()), &builder);
+  loom_op_t* target_op = nullptr;
+  IREE_ASSERT_OK(loom_amdgpu_target_provider.materialize_definition(
+      &builder, source_symbol_facts->projection, target_ref,
+      LOOM_LOCATION_UNKNOWN, &target_op));
+  ASSERT_NE(target_op, nullptr);
+
+  loom_symbol_fact_table_reset(&fact_table_);
+  const loom_target_symbol_facts_t* materialized_symbol_facts =
+      Target(materialized.get(), target_ref);
+  const loom_amdgpu_target_facts_t* materialized_facts =
+      loom_amdgpu_target_facts_cast(materialized_symbol_facts->projection);
+  ASSERT_NE(materialized_facts, nullptr);
+  ExpectTargetFactsEqual(*source_facts, *materialized_facts);
 }
 
 TEST_F(AmdgpuProviderTest, SeparatesIdentityAndSpecializationRequirements) {

--- a/loom/src/loom/target/callgraph_specialization.c
+++ b/loom/src/loom/target/callgraph_specialization.c
@@ -538,8 +538,6 @@ static iree_status_t loom_target_callgraph_seed_versions(
     loom_target_function_version_t* version = loom_target_function_version_cast(
         loom_target_function_version_snapshot_handle_at(&snapshot, symbol_id));
     if (version == NULL) continue;
-    IREE_ASSERT(version->target_context_facts != NULL);
-    IREE_ASSERT(version->target_provider != NULL);
     IREE_RETURN_IF_ERROR(
         loom_target_callgraph_prepare_symbol(state, symbol_id));
     loom_target_callgraph_context_t* context = NULL;

--- a/loom/src/loom/target/callgraph_specialization.c
+++ b/loom/src/loom/target/callgraph_specialization.c
@@ -73,6 +73,9 @@ struct loom_target_callgraph_context_t {
   // Stable compiler-owned facts represented by this context.
   const loom_target_facts_t* facts;
 
+  // Direct target-family interface retained with |facts|.
+  const loom_target_provider_t* target_provider;
+
   // Requirement applied to construct this context, or NULL for a targetless
   // root context.
   const loom_target_facts_t* applied_requirement;
@@ -300,10 +303,12 @@ static iree_status_t loom_target_callgraph_prepare_symbol(
 
 static loom_target_callgraph_context_t* loom_target_callgraph_find_root_context(
     const loom_target_callgraph_state_t* state,
+    const loom_target_provider_t* target_provider,
     const loom_target_facts_t* facts, const loom_target_facts_t* requirement) {
   for (loom_target_callgraph_context_t* context = state->root_contexts;
        context != NULL; context = context->next_root) {
-    if (context->facts == facts &&
+    if (context->target_provider == target_provider &&
+        context->facts == facts &&
         context->applied_requirement == requirement) {
       return context;
     }
@@ -312,11 +317,12 @@ static loom_target_callgraph_context_t* loom_target_callgraph_find_root_context(
 }
 
 static iree_status_t loom_target_callgraph_get_root_context(
-    loom_target_callgraph_state_t* state, const loom_target_facts_t* facts,
-    const loom_target_facts_t* requirement,
+    loom_target_callgraph_state_t* state,
+    const loom_target_provider_t* target_provider,
+    const loom_target_facts_t* facts, const loom_target_facts_t* requirement,
     loom_target_callgraph_context_t** out_context) {
-  *out_context =
-      loom_target_callgraph_find_root_context(state, facts, requirement);
+  *out_context = loom_target_callgraph_find_root_context(state, target_provider,
+                                                         facts, requirement);
   if (*out_context != NULL) return iree_ok_status();
 
   loom_target_callgraph_context_t* context = NULL;
@@ -324,6 +330,7 @@ static iree_status_t loom_target_callgraph_get_root_context(
                                            (void**)&context));
   *context = (loom_target_callgraph_context_t){
       .facts = facts,
+      .target_provider = target_provider,
       .applied_requirement = requirement,
       .next_root = state->root_contexts,
   };
@@ -437,6 +444,7 @@ static iree_status_t loom_target_callgraph_derive_context(
                                            (void**)&context));
   *context = (loom_target_callgraph_context_t){
       .facts = derived_facts,
+      .target_provider = parent->target_provider,
       .applied_requirement = callee->authored_target_requirement,
       .parent = parent,
       .next_sibling = parent->first_child,
@@ -531,11 +539,12 @@ static iree_status_t loom_target_callgraph_seed_versions(
         loom_target_function_version_snapshot_handle_at(&snapshot, symbol_id));
     if (version == NULL) continue;
     IREE_ASSERT(version->target_context_facts != NULL);
+    IREE_ASSERT(version->target_provider != NULL);
     IREE_RETURN_IF_ERROR(
         loom_target_callgraph_prepare_symbol(state, symbol_id));
     loom_target_callgraph_context_t* context = NULL;
     IREE_RETURN_IF_ERROR(loom_target_callgraph_get_root_context(
-        state, version->target_context_facts,
+        state, version->target_provider, version->target_context_facts,
         state->symbols[symbol_id].authored_target_requirement, &context));
     loom_target_callgraph_row_id_t row_id =
         LOOM_TARGET_CALLGRAPH_ROW_ID_INVALID;
@@ -756,6 +765,7 @@ static iree_status_t loom_target_callgraph_prepare_materializations(
             },
         .authored_target_name = info->authored_target_name,
         .authored_target_facts = info->authored_target_requirement,
+        .target_provider = row->context->target_provider,
         .target_context_facts = row->context->facts,
         .effective_target_facts = effective_facts,
     };

--- a/loom/src/loom/target/callgraph_specialization_test.cc
+++ b/loom/src/loom/target/callgraph_specialization_test.cc
@@ -347,6 +347,13 @@ func.def public @wide() -> (index) {
   ASSERT_NE(middle64_version, nullptr);
   ASSERT_NE(leaf32_version, nullptr);
   ASSERT_NE(leaf64_version, nullptr);
+  EXPECT_EQ(left_version->target_provider, &kTestProvider);
+  EXPECT_EQ(right_version->target_provider, &kTestProvider);
+  EXPECT_EQ(wide_version->target_provider, &kTestProvider);
+  EXPECT_EQ(middle32_version->target_provider, &kTestProvider);
+  EXPECT_EQ(middle64_version->target_provider, &kTestProvider);
+  EXPECT_EQ(leaf32_version->target_provider, &kTestProvider);
+  EXPECT_EQ(leaf64_version->target_provider, &kTestProvider);
   EXPECT_EQ(left_version->target_context_facts,
             right_version->target_context_facts);
   EXPECT_EQ(left_version->target_context_facts,

--- a/loom/src/loom/target/function_version.c
+++ b/loom/src/loom/target/function_version.c
@@ -46,17 +46,8 @@ iree_status_t loom_target_function_version_snapshot_build(
     const loom_target_function_version_t* function_version =
         loom_target_function_version_const_cast(version_handle);
     if (function_version == NULL) continue;
-    IREE_ASSERT(function_version->effective_target_facts != NULL);
     const loom_symbol_ref_t function_ref =
         loom_func_like_callee(function_version->base.function);
-    IREE_ASSERT(loom_symbol_ref_is_valid(function_ref));
-    IREE_ASSERT(function_ref.module_id == 0);
-    IREE_ASSERT(function_ref.symbol_id < module->symbols.count);
-    IREE_ASSERT(module->symbols.entries[function_ref.symbol_id].defining_op ==
-                function_version->base.function.op);
-    IREE_ASSERT(
-        out_snapshot->version_handles_by_symbol[function_ref.symbol_id] ==
-        NULL);
     out_snapshot->version_handles_by_symbol[function_ref.symbol_id] =
         version_handle;
   }

--- a/loom/src/loom/target/function_version.h
+++ b/loom/src/loom/target/function_version.h
@@ -31,19 +31,20 @@ typedef struct loom_target_function_version_t {
   // Facts projected from the authored target witness, or NULL when absent.
   const loom_target_facts_t* authored_target_facts;
 
-  // Target-family provider selected with the structured profile. This direct
-  // interface remains paired with every derived context so artifact boundaries
-  // can materialize facts without rediscovering their family.
+  // Non-NULL target-family provider selected with the structured profile. Its
+  // |profile_type| is non-NULL and remains paired with every derived context so
+  // artifact boundaries can materialize facts without rediscovering their
+  // family.
   const loom_target_provider_t* target_provider;
 
   // Exact invocation context inherited by retained semantic callees.
   //
-  // These facts contain the profile projection and authored target requirement
-  // without function-local ABI or export overlays.
+  // This non-NULL fact set contains the profile projection and authored target
+  // requirement without function-local ABI or export overlays.
   const loom_target_facts_t* target_context_facts;
 
-  // Exact invocation-refined facts used to compile this function version,
-  // including its function-local ABI and export contract.
+  // Non-NULL exact invocation-refined facts used to compile this function
+  // version, including its function-local ABI and export contract.
   const loom_target_facts_t* effective_target_facts;
 } loom_target_function_version_t;
 
@@ -74,7 +75,6 @@ loom_target_function_version_effective_facts(
   const loom_target_function_version_t* target_version =
       loom_target_function_version_const_cast(version);
   if (target_version == NULL) return NULL;
-  IREE_ASSERT(target_version->effective_target_facts != NULL);
   return target_version->effective_target_facts;
 }
 
@@ -117,7 +117,6 @@ static inline loom_function_version_t*
 loom_target_function_version_snapshot_handle_at(
     const loom_target_function_version_snapshot_t* snapshot,
     loom_symbol_id_t symbol_id) {
-  IREE_ASSERT_LT(symbol_id, snapshot->symbol_count);
   return snapshot->version_handles_by_symbol != NULL
              ? snapshot->version_handles_by_symbol[symbol_id]
              : NULL;

--- a/loom/src/loom/target/function_version.h
+++ b/loom/src/loom/target/function_version.h
@@ -18,6 +18,8 @@
 extern "C" {
 #endif
 
+typedef struct loom_target_provider_t loom_target_provider_t;
+
 typedef struct loom_target_function_version_t {
   // Generic compiler function-version base. Must remain the first field.
   loom_function_version_t base;
@@ -28,6 +30,11 @@ typedef struct loom_target_function_version_t {
 
   // Facts projected from the authored target witness, or NULL when absent.
   const loom_target_facts_t* authored_target_facts;
+
+  // Target-family provider selected with the structured profile. This direct
+  // interface remains paired with every derived context so artifact boundaries
+  // can materialize facts without rediscovering their family.
+  const loom_target_provider_t* target_provider;
 
   // Exact invocation context inherited by retained semantic callees.
   //

--- a/loom/src/loom/target/pass_environment.c
+++ b/loom/src/loom/target/pass_environment.c
@@ -123,9 +123,6 @@ iree_status_t loom_target_pass_resolve_function_facts(
   const loom_target_function_version_t* version =
       loom_target_function_version_const_cast(pass->function_version);
   if (version != NULL) {
-    IREE_ASSERT(version->base.function.op == function.op &&
-                version->base.function.vtable == function.vtable);
-    IREE_ASSERT(version->effective_target_facts != NULL);
     *out_facts = version->effective_target_facts;
     *out_resolved = true;
     return iree_ok_status();
@@ -136,7 +133,6 @@ iree_status_t loom_target_pass_resolve_function_facts(
     return iree_ok_status();
   }
 
-  IREE_ASSERT(pass->instance_arena != NULL);
   loom_symbol_fact_table_t fact_table = {0};
   loom_symbol_fact_table_initialize(&fact_table, pass->instance_arena);
   const loom_symbol_facts_base_t* base_facts = NULL;

--- a/loom/src/loom/target/predicate.c
+++ b/loom/src/loom/target/predicate.c
@@ -130,10 +130,6 @@ static iree_status_t loom_target_pass_predicate_resolve_facts(
   const loom_target_function_version_t* function_version =
       loom_target_function_version_const_cast(context->function_version);
   if (function_version != NULL) {
-    IREE_ASSERT(function_version->base.function.op == context->function.op &&
-                function_version->base.function.vtable ==
-                    context->function.vtable);
-    IREE_ASSERT(function_version->effective_target_facts != NULL);
     *out_facts = function_version->effective_target_facts;
     *out_valid = true;
     return iree_ok_status();

--- a/loom/src/loom/target/provider.c
+++ b/loom/src/loom/target/provider.c
@@ -333,7 +333,7 @@ const loom_pass_registry_t* loom_target_environment_pass_registry(
       &environment->pass_registry_storage);
 }
 
-bool loom_target_environment_supports_profile_type(
+const loom_target_provider_t* loom_target_environment_lookup_profile_provider(
     const loom_target_environment_t* environment,
     const loom_target_profile_type_t* profile_type) {
   IREE_ASSERT_ARGUMENT(environment);
@@ -341,10 +341,10 @@ bool loom_target_environment_supports_profile_type(
   for (iree_host_size_t i = 0; i < environment->provider_set->provider_count;
        ++i) {
     if (environment->provider_set->providers[i]->profile_type == profile_type) {
-      return true;
+      return environment->provider_set->providers[i];
     }
   }
-  return false;
+  return NULL;
 }
 
 iree_status_t loom_target_environment_contribute_pipeline(

--- a/loom/src/loom/target/provider.h
+++ b/loom/src/loom/target/provider.h
@@ -58,6 +58,16 @@ typedef struct loom_builder_t loom_builder_t;
 typedef struct loom_target_environment_t loom_target_environment_t;
 typedef struct loom_target_provider_t loom_target_provider_t;
 
+// Materializes exact target-context facts as an ordinary target definition.
+//
+// The facts must have been projected by the provider's |profile_type| and may
+// include compatible authored target requirements. Builder allocation and
+// string interning are the only fallible operations for verified facts.
+typedef iree_status_t (*loom_target_materialize_definition_fn_t)(
+    loom_builder_t* builder, const loom_target_facts_t* facts,
+    loom_symbol_ref_t symbol, loom_location_id_t location,
+    loom_op_t** out_target_op);
+
 // Target emission artifact storage release callback.
 typedef void (*loom_target_emit_artifact_release_fn_t)(
     void* storage, iree_allocator_t allocator);
@@ -224,6 +234,10 @@ struct loom_target_provider_t {
   // Target-family profile representation owned by this provider, or NULL when
   // the provider contributes no profile-driven semantics.
   const loom_target_profile_type_t* profile_type;
+  // Optional inverse materializer for facts projected by |profile_type|.
+  // Providers without an ordinary target-IR representation leave this NULL
+  // and cannot seal target-bound artifacts.
+  loom_target_materialize_definition_fn_t materialize_definition;
   // Optional function that registers target-owned dialects.
   loom_target_provider_context_registration_fn_t register_context;
   // Optional function that initializes target-low descriptor-set providers.
@@ -401,11 +415,12 @@ loom_target_emitter_list_t loom_target_environment_emitter_list(
 const loom_pass_registry_t* loom_target_environment_pass_registry(
     const loom_target_environment_t* environment);
 
-// Returns whether |environment| owns |profile_type|.
+// Returns the provider owning |profile_type|, or NULL when not linked.
 //
 // This is a cold external-input boundary check used before accepting a
-// structured profile for specialization.
-bool loom_target_environment_supports_profile_type(
+// structured profile for specialization. Callers retain the returned provider
+// with projected facts instead of resolving the family again downstream.
+const loom_target_provider_t* loom_target_environment_lookup_profile_provider(
     const loom_target_environment_t* environment,
     const loom_target_profile_type_t* profile_type);
 

--- a/loom/src/loom/target/provider_test.cc
+++ b/loom/src/loom/target/provider_test.cc
@@ -132,6 +132,7 @@ class TargetProviderTest : public ::testing::Test {
 TEST_F(TargetProviderTest, ContributesPassIrByPhase) {
   static const loom_target_provider_t materialization_provider = {
       /*.profile_type=*/{},
+      /*.materialize_definition=*/{},
       /*.register_context=*/{},
       /*.initialize_low_descriptor_registry=*/{},
       /*.initialize_low_lower_policy_registry=*/{},
@@ -147,6 +148,7 @@ TEST_F(TargetProviderTest, ContributesPassIrByPhase) {
   };
   static const loom_target_provider_t preparation_provider = {
       /*.profile_type=*/{},
+      /*.materialize_definition=*/{},
       /*.register_context=*/{},
       /*.initialize_low_descriptor_registry=*/{},
       /*.initialize_low_lower_policy_registry=*/{},
@@ -221,6 +223,7 @@ TEST_F(TargetProviderTest, ComposesTargetPassRegistries) {
   };
   static const loom_target_provider_t first_provider = {
       /*.profile_type=*/{},
+      /*.materialize_definition=*/{},
       /*.register_context=*/{},
       /*.initialize_low_descriptor_registry=*/{},
       /*.initialize_low_lower_policy_registry=*/{},
@@ -235,6 +238,7 @@ TEST_F(TargetProviderTest, ComposesTargetPassRegistries) {
   };
   static const loom_target_provider_t second_provider = {
       /*.profile_type=*/{},
+      /*.materialize_definition=*/{},
       /*.register_context=*/{},
       /*.initialize_low_descriptor_registry=*/{},
       /*.initialize_low_lower_policy_registry=*/{},
@@ -274,7 +278,7 @@ TEST_F(TargetProviderTest, ComposesTargetPassRegistries) {
   loom_target_environment_deinitialize(&environment);
 }
 
-TEST_F(TargetProviderTest, ReportsOwnedProfileTypes) {
+TEST_F(TargetProviderTest, LooksUpProfileProvider) {
   static const loom_target_profile_type_t kOwnedProfileType = {
       /*.name=*/IREE_SVL("owned"),
   };
@@ -293,10 +297,12 @@ TEST_F(TargetProviderTest, ReportsOwnedProfileTypes) {
   IREE_ASSERT_OK(
       loom_target_environment_initialize(&provider_set, &environment));
 
-  EXPECT_TRUE(loom_target_environment_supports_profile_type(
-      &environment, &kOwnedProfileType));
-  EXPECT_FALSE(loom_target_environment_supports_profile_type(
-      &environment, &kUnownedProfileType));
+  EXPECT_EQ(loom_target_environment_lookup_profile_provider(&environment,
+                                                            &kOwnedProfileType),
+            &provider);
+  EXPECT_EQ(loom_target_environment_lookup_profile_provider(
+                &environment, &kUnownedProfileType),
+            nullptr);
 
   loom_target_environment_deinitialize(&environment);
 }

--- a/loom/src/loom/target/specialization.c
+++ b/loom/src/loom/target/specialization.c
@@ -26,6 +26,9 @@ typedef struct loom_target_resolved_specialization_t {
   // Structured profile borrowed from the request.
   const loom_target_profile_t* target_profile;
 
+  // Provider owning |target_profile| and every fact derived from it.
+  const loom_target_provider_t* target_provider;
+
   // Profile facts projected once for all requests sharing |target_profile|.
   const loom_target_facts_t* projected_profile_facts;
 
@@ -261,6 +264,7 @@ static iree_status_t loom_target_specialization_prepare_versions(
             specialization->authored_target_facts != NULL
                 ? specialization->authored_target_facts->projection
                 : NULL,
+        .target_provider = specialization->target_provider,
         .target_context_facts = target_context_facts,
         .effective_target_facts = function_facts,
     };
@@ -312,8 +316,10 @@ iree_status_t loom_target_specialize_functions(
                               " has no complete target profile",
                               i);
     }
-    if (!loom_target_environment_supports_profile_type(
-            environment, request->target_profile->type)) {
+    const loom_target_provider_t* target_provider =
+        loom_target_environment_lookup_profile_provider(
+            environment, request->target_profile->type);
+    if (target_provider == NULL) {
       return iree_make_status(
           IREE_STATUS_INVALID_ARGUMENT,
           "target specialization request %" PRIhsz
@@ -326,6 +332,7 @@ iree_status_t loom_target_specialize_functions(
         &specializations[i]));
     request_ordinals[specializations[i].function_name_id] = i;
     specializations[i].target_profile = request->target_profile;
+    specializations[i].target_provider = target_provider;
   }
 
   loom_target_function_version_t* target_versions = NULL;

--- a/loom/src/loom/target/specialization_test.cc
+++ b/loom/src/loom/target/specialization_test.cc
@@ -72,6 +72,7 @@ static TestTargetProfile MakeTestProfile(loom_test_target_kind_t kind) {
 
 static const loom_target_provider_t kTestProvider = {
     /*.profile_type=*/&kTestProfileType,
+    /*.materialize_definition=*/nullptr,
     /*.register_context=*/nullptr,
     /*.initialize_low_descriptor_registry=*/nullptr,
     /*.initialize_low_lower_policy_registry=*/nullptr,
@@ -264,6 +265,7 @@ func.def public target(@unrequested_family) @unrequested() {
       loom_target_function_version_list_find(&result.function_versions.list,
                                              generic);
   ASSERT_NE(generic_version, nullptr);
+  EXPECT_EQ(generic_version->target_provider, &kTestProvider);
   ASSERT_NE(generic_version->authored_target_facts, nullptr);
   EXPECT_EQ(generic_version->authored_target_facts->selector,
             LOOM_TEST_TARGET_KIND_LOW_CORE);
@@ -275,6 +277,7 @@ func.def public target(@unrequested_family) @unrequested() {
       loom_target_function_version_list_find(&result.function_versions.list,
                                              targetless);
   ASSERT_NE(targetless_version, nullptr);
+  EXPECT_EQ(targetless_version->target_provider, &kTestProvider);
   EXPECT_EQ(targetless_version->authored_target_facts, nullptr);
   ASSERT_NE(targetless_version->effective_target_facts, nullptr);
   EXPECT_EQ(targetless_version->effective_target_facts->selector,

--- a/loom/src/loom/tooling/execution/hal/testbench_actual.c
+++ b/loom/src/loom/tooling/execution/hal/testbench_actual.c
@@ -663,8 +663,6 @@ iree_status_t loom_run_hal_testbench_actual_provider_compile(
       loom_target_function_version_list_find(
           &provider->launch_config_pipeline_result.function_versions.list,
           launch_config_func);
-  IREE_ASSERT(launch_config_function_version != NULL);
-  IREE_ASSERT(launch_config_function_version->effective_target_facts != NULL);
   provider->launch_config_target_facts =
       launch_config_function_version->effective_target_facts;
 

--- a/loom/src/loom/tooling/execution/testing/execution_provider_verify_test.cc
+++ b/loom/src/loom/tooling/execution/testing/execution_provider_verify_test.cc
@@ -47,6 +47,7 @@ const loom_run_execution_backend_t* const kDuplicateFakeExecutionBackends[] = {
 
 const loom_target_provider_t kCoreTestTargetProvider = {
     /*.profile_type=*/{},
+    /*.materialize_definition=*/{},
     /*.register_context=*/{},
     /*.initialize_low_descriptor_registry=*/
     loom_target_core_test_low_descriptor_registry_initialize,

--- a/loom/src/loom/tools/loom-check/execute_test.cc
+++ b/loom/src/loom/tools/loom-check/execute_test.cc
@@ -81,6 +81,7 @@ void InitializeTestLowLowerPolicyRegistryForProvider(
 
 const loom_target_provider_t kTestTargetProvider = {
     /*.profile_type=*/{},
+    /*.materialize_definition=*/{},
     /*.register_context=*/{},
     /*.initialize_low_descriptor_registry=*/
     InitializeTestLowDescriptorRegistryForProvider,


### PR DESCRIPTION
Target specialization now preserves the provider that owns each structured profile alongside the exact facts derived from it. Providers can materialize those facts as ordinary target definitions, allowing a specialized function unit to carry a hermetic target witness without a registry search or process-local side state.

The provider follows each function version through root specialization and derived callgraph contexts. This keeps the family interface and immutable fact representation paired at the point where target profiles first cross the external-input boundary. Function versions document the resulting provider, context facts, and effective facts as complete construction-time invariants, and their consumers use those records directly.

AMDGPU implements the first facts-to-definition inverse. It reconstructs the selected target identity, target-ID features, authored common target fields, ABI and export properties, and contract configuration as normal `amdgpu.target` IR. Materializing and projecting that definition reproduces the same structured facts for every AMDGPU profile and for explicitly authored refinements.

## Reviewer Notes

The central ownership change is in the target provider and function-version records. The AMDGPU implementation is deliberately an ordinary IR builder rather than a serialization or artifact-specific mechanism, so any later compiler partition can own and serialize the resulting module normally.
