### PR TITLE
[Loom] Generate target table families once

### DIFF
--- a/loom/.bazel_to_cmake.cfg.py
+++ b/loom/.bazel_to_cmake.cfg.py
@@ -595,6 +595,65 @@ class LoomBuildFileFunctions(bazel_to_cmake_converter.BuildFileFunctions):
         )
         self._emit_platform_guard_end(target_compatible_with)
 
+    def loom_generated_textual_header_family(
+        self,
+        name,
+        generator,
+        outputs,
+        output_flags,
+        args=None,
+        inputs=None,
+        comment=None,
+        tags=None,
+        testonly=None,
+        target_compatible_with=None,
+        visibility=None,
+        **kwargs,
+    ):
+        if self._should_skip_target(tags=tags, **kwargs):
+            return
+        target_compatible_with = self._apply_loom_target_compatible_with(
+            target_compatible_with
+        )
+
+        name_block = self._convert_string_arg_block("NAME", name, quote=False)
+        generator_block = self._convert_single_target_block("GENERATOR", generator)
+        outputs_block = self._convert_string_list_block("OUTPUTS", outputs, sort=False)
+        output_flags_block = self._convert_string_list_block(
+            "OUTPUT_FLAGS", output_flags, sort=False
+        )
+        args_block, platform_args_block = self._convert_platform_select_strings(
+            name,
+            "ARGS",
+            self._convert_generated_args(args),
+            sort=False,
+        )
+        inputs_block, platform_inputs_block = self._convert_platform_select_strings(
+            name,
+            "INPUTS",
+            self._convert_generated_inputs(inputs),
+            sort=False,
+        )
+        comment_block = self._convert_string_arg_block("COMMENT", comment)
+
+        self._emit_platform_guard_begin(target_compatible_with)
+        if platform_args_block:
+            self._converter.body += platform_args_block
+        if platform_inputs_block:
+            self._converter.body += platform_inputs_block
+        self._converter.body += (
+            f"loom_generated_textual_header_family(\n"
+            f"{name_block}"
+            f"{generator_block}"
+            f"{outputs_block}"
+            f"{output_flags_block}"
+            f"{args_block}"
+            f"{inputs_block}"
+            f"{comment_block}"
+            f")\n\n"
+        )
+        self._emit_platform_guard_end(target_compatible_with)
+
     def loom_generated_cc_library(
         self,
         name,

--- a/loom/build_tools/bazel/build_defs.bzl
+++ b/loom/build_tools/bazel/build_defs.bzl
@@ -79,6 +79,39 @@ def _loom_output_args(flags, outputs):
         output_args[_loom_output_basename(outputs[i])] = _loom_output_arg(flags[i])
     return output_args
 
+def _loom_generated_textual_headers(
+        name,
+        generator,
+        outputs,
+        output_flags,
+        args = [],
+        inputs = [],
+        tags = [],
+        visibility = None,
+        comment = None):
+    if not outputs:
+        fail("generated textual headers require at least one output")
+    if len(output_flags) != len(outputs):
+        fail("generated textual header output flags and outputs must be paired")
+
+    rule_kwargs = {}
+    if visibility != None:
+        rule_kwargs["visibility"] = visibility
+    if comment != None:
+        rule_kwargs["progress_message"] = comment
+    rule_kwargs["tags"] = tags + ["skip-bazel_to_cmake"]
+    rule_kwargs = apply_loom_target_policy(rule_kwargs)
+
+    iree_generated_files(
+        name = name,
+        srcs = inputs,
+        outs = outputs,
+        args = _loom_bazel_generator_args(args),
+        output_args = _loom_output_args(output_flags, outputs),
+        tool = generator,
+        **rule_kwargs
+    )
+
 def loom_generated_textual_header(
         name,
         generator,
@@ -103,22 +136,57 @@ def loom_generated_textual_header(
       comment: Optional progress message for the generator action.
     """
 
-    rule_kwargs = {}
-    if visibility != None:
-        rule_kwargs["visibility"] = visibility
-    if comment != None:
-        rule_kwargs["progress_message"] = comment
-    rule_kwargs["tags"] = tags + ["skip-bazel_to_cmake"]
-    rule_kwargs = apply_loom_target_policy(rule_kwargs)
-
-    iree_generated_files(
+    _loom_generated_textual_headers(
         name = name,
-        srcs = inputs,
-        outs = [output],
-        args = _loom_bazel_generator_args(args),
-        output_args = _loom_output_args([output_flag], [output]),
-        tool = generator,
-        **rule_kwargs
+        generator = generator,
+        outputs = [output],
+        output_flags = [output_flag],
+        args = args,
+        inputs = inputs,
+        tags = tags,
+        visibility = visibility,
+        comment = comment,
+    )
+
+def loom_generated_textual_header_family(
+        name,
+        generator,
+        outputs,
+        output_flags,
+        args = [],
+        inputs = [],
+        tags = [],
+        visibility = None,
+        comment = None):
+    """Generates a coherent family of textual headers in one action.
+
+    The generator must derive all outputs from the same materialized source
+    model. Outputs that can be generated independently belong in separate
+    singular actions so their invalidation and scheduling remain precise.
+
+    Args:
+      name: Generator action target name.
+      generator: Executable label that writes every textual header.
+      outputs: Generated textual header filenames.
+      output_flags: Generator flags paired positionally with outputs.
+      args: Generator arguments before the output flags.
+      inputs: Source data labels consumed by the generator.
+      tags: Additional Bazel tags for the generator action.
+      visibility: Passed through to the generator action.
+      comment: Optional progress message for the generator action.
+    """
+    if len(outputs) < 2:
+        fail("generated textual header families require at least two outputs")
+    _loom_generated_textual_headers(
+        name = name,
+        generator = generator,
+        outputs = outputs,
+        output_flags = output_flags,
+        args = args,
+        inputs = inputs,
+        tags = tags,
+        visibility = visibility,
+        comment = comment,
     )
 
 def loom_low_descriptor_data_archive(

--- a/loom/build_tools/cmake/loom_generated.cmake
+++ b/loom/build_tools/cmake/loom_generated.cmake
@@ -25,6 +25,82 @@ function(_loom_python_command_prefix OUTPUT_PREFIX GENERATOR)
   )
 endfunction()
 
+function(_loom_generated_textual_headers)
+  cmake_parse_arguments(
+    _RULE
+    ""
+    "NAME;GENERATOR;COMMENT"
+    "OUTPUTS;OUTPUT_FLAGS;ARGS;INPUTS"
+    ${ARGN}
+  )
+
+  if(NOT _RULE_NAME)
+    message(FATAL_ERROR "generated textual headers require NAME")
+  endif()
+  if(NOT _RULE_GENERATOR)
+    message(FATAL_ERROR "generated textual headers require GENERATOR")
+  endif()
+  list(LENGTH _RULE_OUTPUTS _OUTPUT_COUNT)
+  if(_OUTPUT_COUNT EQUAL 0)
+    message(FATAL_ERROR "generated textual headers require at least one output")
+  endif()
+  list(LENGTH _RULE_OUTPUT_FLAGS _OUTPUT_FLAG_COUNT)
+  if(NOT _OUTPUT_FLAG_COUNT EQUAL _OUTPUT_COUNT)
+    message(FATAL_ERROR
+      "generated textual header output flags and outputs must be paired")
+  endif()
+
+  set(_OUTPUTS)
+  set(_OUTPUT_ARGS)
+  math(EXPR _OUTPUT_LAST "${_OUTPUT_COUNT} - 1")
+  foreach(_INDEX RANGE 0 ${_OUTPUT_LAST})
+    list(GET _RULE_OUTPUTS ${_INDEX} _OUTPUT)
+    list(GET _RULE_OUTPUT_FLAGS ${_INDEX} _OUTPUT_FLAG)
+    set(_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/${_OUTPUT}")
+    list(APPEND _OUTPUTS "${_OUTPUT_PATH}")
+    list(APPEND _OUTPUT_ARGS "${_OUTPUT_FLAG}=${_OUTPUT_PATH}")
+  endforeach()
+  if(NOT _RULE_COMMENT)
+    set(_RULE_COMMENT "Generating ${_RULE_NAME}")
+  endif()
+
+  iree_py_library_main(_GENERATOR "${_RULE_GENERATOR}")
+  iree_py_library_collect_sources(_GENERATOR_INPUTS "${_RULE_GENERATOR}")
+  _loom_python_command_prefix(_PYTHON_COMMAND_PREFIX "${_RULE_GENERATOR}")
+
+  add_custom_command(
+    OUTPUT
+      ${_OUTPUTS}
+    COMMAND
+      ${_PYTHON_COMMAND_PREFIX}
+      "${Python3_EXECUTABLE}"
+      "${_GENERATOR}"
+      ${_RULE_ARGS}
+      ${_OUTPUT_ARGS}
+    DEPENDS
+      ${_GENERATOR_INPUTS}
+      ${_RULE_INPUTS}
+    COMMENT
+      "${_RULE_COMMENT}"
+    VERBATIM
+  )
+  set_source_files_properties(
+    ${_RULE_OUTPUTS}
+    ${_OUTPUTS}
+    PROPERTIES GENERATED TRUE
+  )
+
+  iree_package_name(_PACKAGE_NAME)
+  set(_GEN_TARGET "${_PACKAGE_NAME}_${_RULE_NAME}")
+  add_custom_target("${_GEN_TARGET}"
+    DEPENDS
+      ${_OUTPUTS}
+  )
+  iree_register_generated_compile_input("${_GEN_TARGET}"
+    OUTPUTS ${_OUTPUTS}
+  )
+endfunction()
+
 function(loom_generated_textual_header)
   cmake_parse_arguments(
     _RULE
@@ -47,45 +123,40 @@ function(loom_generated_textual_header)
     message(FATAL_ERROR "loom_generated_textual_header requires OUTPUT_FLAG")
   endif()
 
-  set(_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${_RULE_OUTPUT}")
-  if(NOT _RULE_COMMENT)
-    set(_RULE_COMMENT "Generating ${_RULE_NAME}")
+  _loom_generated_textual_headers(
+    NAME "${_RULE_NAME}"
+    GENERATOR "${_RULE_GENERATOR}"
+    OUTPUTS "${_RULE_OUTPUT}"
+    OUTPUT_FLAGS "${_RULE_OUTPUT_FLAG}"
+    ARGS ${_RULE_ARGS}
+    INPUTS ${_RULE_INPUTS}
+    COMMENT "${_RULE_COMMENT}"
+  )
+endfunction()
+
+function(loom_generated_textual_header_family)
+  cmake_parse_arguments(
+    _RULE
+    ""
+    "NAME;GENERATOR;COMMENT"
+    "OUTPUTS;OUTPUT_FLAGS;ARGS;INPUTS"
+    ${ARGN}
+  )
+
+  list(LENGTH _RULE_OUTPUTS _OUTPUT_COUNT)
+  if(_OUTPUT_COUNT LESS 2)
+    message(FATAL_ERROR
+      "loom_generated_textual_header_family requires at least two outputs")
   endif()
 
-  iree_py_library_main(_GENERATOR "${_RULE_GENERATOR}")
-  iree_py_library_collect_sources(_GENERATOR_INPUTS "${_RULE_GENERATOR}")
-  _loom_python_command_prefix(_PYTHON_COMMAND_PREFIX "${_RULE_GENERATOR}")
-
-  add_custom_command(
-    OUTPUT
-      "${_OUTPUT}"
-    COMMAND
-      ${_PYTHON_COMMAND_PREFIX}
-      "${Python3_EXECUTABLE}"
-      "${_GENERATOR}"
-      ${_RULE_ARGS}
-      "${_RULE_OUTPUT_FLAG}=${_OUTPUT}"
-    DEPENDS
-      ${_GENERATOR_INPUTS}
-      ${_RULE_INPUTS}
-    COMMENT
-      "${_RULE_COMMENT}"
-    VERBATIM
-  )
-  set_source_files_properties(
-    "${_RULE_OUTPUT}"
-    "${_OUTPUT}"
-    PROPERTIES GENERATED TRUE
-  )
-
-  iree_package_name(_PACKAGE_NAME)
-  set(_GEN_TARGET "${_PACKAGE_NAME}_${_RULE_NAME}")
-  add_custom_target("${_GEN_TARGET}"
-    DEPENDS
-      "${_OUTPUT}"
-  )
-  iree_register_generated_compile_input("${_GEN_TARGET}"
-    OUTPUTS "${_OUTPUT}"
+  _loom_generated_textual_headers(
+    NAME "${_RULE_NAME}"
+    GENERATOR "${_RULE_GENERATOR}"
+    OUTPUTS ${_RULE_OUTPUTS}
+    OUTPUT_FLAGS ${_RULE_OUTPUT_FLAGS}
+    ARGS ${_RULE_ARGS}
+    INPUTS ${_RULE_INPUTS}
+    COMMENT "${_RULE_COMMENT}"
   )
 endfunction()
 

--- a/loom/py/loom/gen/target/arch/amdgpu/descriptors/amdgpu_descriptors.py
+++ b/loom/py/loom/gen/target/arch/amdgpu/descriptors/amdgpu_descriptors.py
@@ -25,8 +25,7 @@ def _ensure_runtime_py_on_path() -> None:
 _ensure_runtime_py_on_path()
 
 from loom.gen.target.low.low_descriptors import (  # noqa: E402
-    generate_descriptor_set,
-    generate_descriptor_set_shared_source,
+    generate_descriptor_set_family,
     write_descriptor_set_to_paths,
 )
 from loom.target.arch.amdgpu.descriptors import (  # noqa: E402
@@ -153,25 +152,25 @@ def main(argv: Sequence[str] | None = None) -> int:
             descriptor_set,
             view_descriptor_sets,
         )
-        generated = generate_descriptor_set(descriptor_set)
+        generated = generate_descriptor_set_family(
+            storage_descriptor_set,
+            (descriptor_set, *view_descriptor_sets),
+        )
         args.header.parent.mkdir(parents=True, exist_ok=True)
         args.source.parent.mkdir(parents=True, exist_ok=True)
-        args.header.write_text(generated.header, encoding="utf-8")
-        args.source.write_text(
-            generate_descriptor_set_shared_source(
-                storage_descriptor_set,
-                (descriptor_set, *view_descriptor_sets),
-            ),
-            encoding="utf-8",
-        )
-        for view_info, view_descriptor_set in zip(view_infos, view_descriptor_sets, strict=True):
+        args.header.write_text(generated.view_headers[0], encoding="utf-8")
+        args.source.write_text(generated.source, encoding="utf-8")
+        for view_info, view_header in zip(
+            view_infos,
+            generated.view_headers[1:],
+            strict=True,
+        ):
             view_header_path = view_headers.get(view_info.generator_target)
             if view_header_path is None:
                 continue
-            view_generated = generate_descriptor_set(view_descriptor_set)
             view_header_path.parent.mkdir(parents=True, exist_ok=True)
             view_header_path.write_text(
-                view_generated.header,
+                view_header,
                 encoding="utf-8",
             )
         return 0

--- a/loom/py/loom/gen/target/arch/amdgpu/descriptors/amdgpu_descriptors_test.py
+++ b/loom/py/loom/gen/target/arch/amdgpu/descriptors/amdgpu_descriptors_test.py
@@ -88,14 +88,14 @@ def test_storage_generation_reuses_parsed_isa_for_declared_views() -> None:
         descriptor_count = 2 if target == view_target else 1
         return _descriptor_set(target, descriptor_count)
 
-    def generate_descriptor_set(descriptor_set: DescriptorSet) -> SimpleNamespace:
-        return SimpleNamespace(header=f"// {descriptor_set.key}\n")
-
-    def generate_descriptor_set_shared_source(
+    def generate_descriptor_set_family(
         storage_descriptor_set: DescriptorSet,
         view_descriptor_sets: tuple[DescriptorSet, ...],
-    ) -> str:
-        return "// shared\n"
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            source="// shared\n",
+            view_headers=tuple(f"// {descriptor_set.key}\n" for descriptor_set in view_descriptor_sets),
+        )
 
     def descriptor_set_info_by_target(target: str) -> AmdgpuDescriptorSetInfo:
         if target == storage_target:
@@ -146,13 +146,8 @@ def test_storage_generation_reuses_parsed_isa_for_declared_views() -> None:
         ),
         mock.patch.object(
             amdgpu_descriptors,
-            "generate_descriptor_set",
-            generate_descriptor_set,
-        ),
-        mock.patch.object(
-            amdgpu_descriptors,
-            "generate_descriptor_set_shared_source",
-            generate_descriptor_set_shared_source,
+            "generate_descriptor_set_family",
+            generate_descriptor_set_family,
         ),
     ):
         tmp_path = Path(temporary_directory)

--- a/loom/py/loom/gen/target/arch/x86/x86_descriptors.py
+++ b/loom/py/loom/gen/target/arch/x86/x86_descriptors.py
@@ -26,9 +26,7 @@ def _ensure_runtime_py_on_path() -> None:
 _ensure_runtime_py_on_path()
 
 from loom.gen.target.low.low_descriptors import (  # noqa: E402
-    generate_descriptor_set,
-    generate_descriptor_set_shared_header,
-    generate_descriptor_set_shared_source,
+    generate_descriptor_set_family,
     write_descriptor_set_to_paths,
 )
 from loom.target.arch.x86.target_info import (  # noqa: E402
@@ -156,27 +154,20 @@ def main(argv: Sequence[str] | None = None) -> int:
             descriptor_set,
             view_descriptor_sets,
         )
-        generated = generate_descriptor_set(descriptor_set)
+        generated = generate_descriptor_set_family(
+            storage_descriptor_set,
+            (*view_descriptor_sets, descriptor_set),
+        )
         args.header.parent.mkdir(parents=True, exist_ok=True)
         args.source.parent.mkdir(parents=True, exist_ok=True)
-        args.header.write_text(generated.header, encoding="utf-8")
-        args.source.write_text(
-            generate_descriptor_set_shared_source(
-                storage_descriptor_set,
-                (*view_descriptor_sets, descriptor_set),
-            ),
-            encoding="utf-8",
-        )
-        for view_info, view_descriptor_set in zip(
+        args.header.write_text(generated.view_headers[-1], encoding="utf-8")
+        args.source.write_text(generated.source, encoding="utf-8")
+        for view_info, view_header in zip(
             view_infos,
-            view_descriptor_sets,
+            generated.view_headers[:-1],
             strict=True,
         ):
             view_header_path = view_headers[view_info.generator_target]
-            view_header = generate_descriptor_set_shared_header(
-                storage_descriptor_set,
-                view_descriptor_set,
-            )
             view_header_path.parent.mkdir(parents=True, exist_ok=True)
             view_header_path.write_text(
                 view_header,

--- a/loom/py/loom/gen/target/low/compiled.py
+++ b/loom/py/loom/gen/target/low/compiled.py
@@ -56,6 +56,16 @@ class GeneratedDescriptorSet:
     source: str
 
 
+@dataclass(frozen=True, slots=True)
+class GeneratedDescriptorSetFamily:
+    """C artifacts emitted from one compiled storage set and its views."""
+
+    # Shared C source implementing every descriptor-set view.
+    source: str
+    # Public C headers paired positionally with the requested view specs.
+    view_headers: tuple[str, ...]
+
+
 @dataclass(slots=True)
 class CompiledDescriptorSet:
     spec: DescriptorSet

--- a/loom/py/loom/gen/target/low/low_descriptors.py
+++ b/loom/py/loom/gen/target/low/low_descriptors.py
@@ -17,7 +17,11 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from loom.gen.target.low import c_emit, compiler, views
-from loom.gen.target.low.compiled import DescriptorAllowlist, GeneratedDescriptorSet
+from loom.gen.target.low.compiled import (
+    DescriptorAllowlist,
+    GeneratedDescriptorSet,
+    GeneratedDescriptorSetFamily,
+)
 from loom.target.low_descriptors import DescriptorSet
 
 
@@ -32,11 +36,11 @@ def generate_descriptor_set(
     )
 
 
-def generate_descriptor_set_shared_source(
+def generate_descriptor_set_family(
     storage_spec: DescriptorSet,
     view_specs: Sequence[DescriptorSet],
-) -> str:
-    """Generates one C source containing shared storage and multiple set views.
+) -> GeneratedDescriptorSetFamily:
+    """Generates shared C storage and public headers for descriptor-set views.
 
     Each view selects descriptors from |storage_spec| by stable key. Supporting
     tables are shared as a storage superset, while descriptor, operand-form, and
@@ -54,24 +58,13 @@ def generate_descriptor_set_shared_source(
         required_schedule_class_names=required_schedule_class_names,
     )
     descriptor_set_views = tuple(views.descriptor_set_view_for_spec(compiled, view_spec) for view_spec in view_specs)
-    return c_emit.emit_source_for_views(compiled, views=descriptor_set_views)
-
-
-def generate_descriptor_set_shared_header(
-    storage_spec: DescriptorSet,
-    view_spec: DescriptorSet,
-) -> str:
-    """Generates a public view header for a shared descriptor storage source."""
-
-    required_schedule_class_names = tuple(sorted({descriptor.schedule_class for descriptor in view_spec.descriptors if descriptor.schedule_class is not None}))
-    compiled = compiler.compile_descriptor_set(
-        storage_spec,
-        allowlist=None,
-        allow_ambiguous_asm_mnemonics=True,
-        required_schedule_class_names=required_schedule_class_names,
+    return GeneratedDescriptorSetFamily(
+        source=c_emit.emit_source_for_views(
+            compiled,
+            views=descriptor_set_views,
+        ),
+        view_headers=tuple(c_emit.emit_header_for_spec(compiled, view_spec) for view_spec in view_specs),
     )
-    views.descriptor_set_view_for_spec(compiled, view_spec)
-    return c_emit.emit_header_for_spec(compiled, view_spec)
 
 
 def write_descriptor_set_to_paths(

--- a/loom/py/loom/gen/target/low/low_descriptors_test.py
+++ b/loom/py/loom/gen/target/low/low_descriptors_test.py
@@ -17,7 +17,7 @@ from loom.gen.target.low import compiler, views
 from loom.gen.target.low.low_descriptors import (
     DescriptorAllowlist,
     generate_descriptor_set,
-    generate_descriptor_set_shared_source,
+    generate_descriptor_set_family,
 )
 from loom.ir import ScalarTypeKind
 from loom.target.low_descriptors import (
@@ -994,7 +994,7 @@ def test_operand_forms_preserve_assembly_implicit_packet_sources() -> None:
     assert compiled.operand_form_operand_indices == [0]
 
 
-def test_shared_source_emits_one_storage_table_with_multiple_views() -> None:
+def test_descriptor_set_family_emits_one_storage_table_and_ordered_headers() -> None:
     base_view = replace(
         TEST_LOW_CORE_DESCRIPTOR_SET,
         descriptors=TEST_LOW_CORE_DESCRIPTOR_SET.descriptors[:1],
@@ -1012,10 +1012,11 @@ def test_shared_source_emits_one_storage_table_with_multiple_views() -> None:
         descriptors=extension_view.descriptors,
     )
 
-    source = generate_descriptor_set_shared_source(
+    generated = generate_descriptor_set_family(
         storage_set,
         (base_view, extension_view),
     )
+    source = generated.source
 
     assert source.count("static const loom_low_descriptor_t kTestLowCoreDescriptors[]") == 1
     assert "kTestLowExtensionCoreDescriptors" not in source
@@ -1025,6 +1026,8 @@ def test_shared_source_emits_one_storage_table_with_multiple_views() -> None:
     assert ".descriptor_count = 1," in source
     assert ".descriptor_count = 2," in source
     assert ("const loom_low_descriptor_set_t* loom_test_low_extension_core_descriptor_set(void)") in source
+    assert "loom_test_low_core_descriptor_set(void)" in generated.view_headers[0]
+    assert "loom_test_low_extension_core_descriptor_set(void)" in generated.view_headers[1]
 
 
 def test_descriptor_set_view_selects_shared_schedule_class() -> None:
@@ -1102,7 +1105,7 @@ def test_descriptor_set_view_rejects_local_schedule_definition() -> None:
         )
 
 
-def test_shared_source_emits_prefix_view_local_asm_forms() -> None:
+def test_descriptor_set_family_emits_prefix_view_local_asm_forms() -> None:
     storage_descriptor = replace(
         TEST_LOW_ADD_I32_DESCRIPTOR,
         asm_forms=(
@@ -1138,10 +1141,10 @@ def test_shared_source_emits_prefix_view_local_asm_forms() -> None:
         descriptors=(storage_descriptor,),
     )
 
-    source = generate_descriptor_set_shared_source(
+    source = generate_descriptor_set_family(
         storage_set,
         (view, storage_set),
-    )
+    ).source
 
     assert "storage.add.i32" in source
     assert '"add.i32"' in source
@@ -1154,7 +1157,7 @@ def test_shared_source_emits_prefix_view_local_asm_forms() -> None:
     assert ".result_value_type_start = 1," in source
 
 
-def test_shared_source_compares_derived_descriptor_projections() -> None:
+def test_descriptor_set_family_compares_derived_descriptor_projections() -> None:
     descriptor = replace(
         TEST_LOW_ADD_I32_DESCRIPTOR,
         constraints=(Constraint(ConstraintKind.EARLY_CLOBBER, 0),),
@@ -1164,15 +1167,15 @@ def test_shared_source_compares_derived_descriptor_projections() -> None:
         descriptors=(descriptor,),
     )
 
-    source = generate_descriptor_set_shared_source(
+    source = generate_descriptor_set_family(
         descriptor_set,
         (descriptor_set,),
-    )
+    ).source
 
     assert ".flags = LOOM_LOW_OPERAND_FLAG_EARLY_CLOBBER," in source
 
 
-def test_shared_source_requires_view_canonical_asm_for_authorable_surface() -> None:
+def test_descriptor_set_family_requires_view_canonical_asm_for_authorable_surface() -> None:
     view_descriptor = replace(TEST_LOW_ADD_I32_DESCRIPTOR, asm_forms=())
     view = replace(
         TEST_LOW_CORE_DESCRIPTOR_SET,
@@ -1192,13 +1195,13 @@ def test_shared_source_requires_view_canonical_asm_for_authorable_surface() -> N
         ValueError,
         match=re.escape("descriptor set view 'test.low.view.core' descriptor 'test.add.i32' is authorable asm but does not declare exactly one canonical asm form; found 0"),
     ):
-        generate_descriptor_set_shared_source(
+        generate_descriptor_set_family(
             storage_set,
             (view,),
         )
 
 
-def test_shared_source_allows_view_local_non_authorable_surface() -> None:
+def test_descriptor_set_family_allows_view_local_non_authorable_surface() -> None:
     view_descriptor = replace(
         TEST_LOW_ADD_I32_DESCRIPTOR,
         asm_forms=(),
@@ -1219,16 +1222,16 @@ def test_shared_source_allows_view_local_non_authorable_surface() -> None:
         descriptors=(TEST_LOW_ADD_I32_DESCRIPTOR,),
     )
 
-    source = generate_descriptor_set_shared_source(
+    source = generate_descriptor_set_family(
         storage_set,
         (view,),
-    )
+    ).source
 
     assert "static const loom_low_descriptor_t kTestLowViewCoreDescriptors[]" in source
     assert ".canonical_asm_form_ordinal = LOOM_LOW_ASM_FORM_ORDINAL_NONE" in source
 
 
-def test_shared_source_emits_sibling_view_descriptor_surfaces() -> None:
+def test_descriptor_set_family_emits_sibling_view_descriptor_surfaces() -> None:
     first_view = replace(
         TEST_LOW_CORE_DESCRIPTOR_SET,
         descriptors=(TEST_LOW_CONST_I32_DESCRIPTOR,),
@@ -1249,10 +1252,10 @@ def test_shared_source_emits_sibling_view_descriptor_surfaces() -> None:
         ),
     )
 
-    source = generate_descriptor_set_shared_source(
+    source = generate_descriptor_set_family(
         storage_set,
         (first_view, sibling_view, storage_set),
-    )
+    ).source
 
     assert source.count("static const loom_low_operand_t kTestLowCoreOperands[]") == 1
     assert "static const loom_low_descriptor_t kTestLowSiblingCoreDescriptors[]" in source

--- a/loom/src/loom/target/arch/amdgpu/descriptors/BUILD.bazel
+++ b/loom/src/loom/target/arch/amdgpu/descriptors/BUILD.bazel
@@ -19,6 +19,7 @@ load(
     "//loom/build_tools/bazel:build_defs.bzl",
     "loom_cc_library",
     "loom_generated_textual_header",
+    "loom_generated_textual_header_family",
     "loom_low_descriptor_cc_library",
     "loom_low_descriptor_data_archive",
     "loom_low_descriptor_exclude_from_cmake_all",
@@ -91,113 +92,51 @@ _AMDGPU_PLANNING_FACT_VISIBILITY = [
     "//loom/src/loom/target/arch/amdgpu/planning:__pkg__",
 ]
 
-loom_generated_textual_header(
-    name = "wait_packet_descriptor_ranges_gen",
+loom_generated_textual_header_family(
+    name = "wait_packet_tables_gen",
     args = _AMDGPU_ISA_XML_ARGS,
+    comment = "Generating AMDGPU wait-packet table family",
     generator = _AMDGPU_WAIT_PACKET_TABLE_GENERATOR,
     inputs = _AMDGPU_ISA_XML_INPUTS,
-    output = "wait_packet_descriptor_ranges.inl",
-    output_flag = "--descriptor-ranges",
+    output_flags = [
+        "--descriptor-ranges",
+        "--descriptor-rows",
+        "--descriptor-lookups",
+        "--immediate-rows",
+        "--selection-rows",
+    ],
+    outputs = [
+        "wait_packet_descriptor_ranges.inl",
+        "wait_packet_descriptors.inl",
+        "wait_packet_descriptor_lookups.inl",
+        "wait_packet_immediates.inl",
+        "wait_packet_selections.inl",
+    ],
     visibility = _AMDGPU_PLANNING_FACT_VISIBILITY,
 )
 
-loom_generated_textual_header(
-    name = "wait_packet_descriptors_gen",
+loom_generated_textual_header_family(
+    name = "vopd_component_tables_gen",
     args = _AMDGPU_ISA_XML_ARGS,
-    generator = _AMDGPU_WAIT_PACKET_TABLE_GENERATOR,
-    inputs = _AMDGPU_ISA_XML_INPUTS,
-    output = "wait_packet_descriptors.inl",
-    output_flag = "--descriptor-rows",
-    visibility = _AMDGPU_PLANNING_FACT_VISIBILITY,
-)
-
-loom_generated_textual_header(
-    name = "wait_packet_descriptor_lookups_gen",
-    args = _AMDGPU_ISA_XML_ARGS,
-    generator = _AMDGPU_WAIT_PACKET_TABLE_GENERATOR,
-    inputs = _AMDGPU_ISA_XML_INPUTS,
-    output = "wait_packet_descriptor_lookups.inl",
-    output_flag = "--descriptor-lookups",
-    visibility = _AMDGPU_PLANNING_FACT_VISIBILITY,
-)
-
-loom_generated_textual_header(
-    name = "wait_packet_immediates_gen",
-    args = _AMDGPU_ISA_XML_ARGS,
-    generator = _AMDGPU_WAIT_PACKET_TABLE_GENERATOR,
-    inputs = _AMDGPU_ISA_XML_INPUTS,
-    output = "wait_packet_immediates.inl",
-    output_flag = "--immediate-rows",
-    visibility = _AMDGPU_PLANNING_FACT_VISIBILITY,
-)
-
-loom_generated_textual_header(
-    name = "wait_packet_selections_gen",
-    args = _AMDGPU_ISA_XML_ARGS,
-    generator = _AMDGPU_WAIT_PACKET_TABLE_GENERATOR,
-    inputs = _AMDGPU_ISA_XML_INPUTS,
-    output = "wait_packet_selections.inl",
-    output_flag = "--selection-rows",
-    visibility = _AMDGPU_PLANNING_FACT_VISIBILITY,
-)
-
-loom_generated_textual_header(
-    name = "vopd_component_rules_gen",
-    args = _AMDGPU_ISA_XML_ARGS,
+    comment = "Generating AMDGPU VOPD component table family",
     generator = _AMDGPU_VOPD_COMPONENT_TABLE_GENERATOR,
     inputs = _AMDGPU_ISA_XML_INPUTS,
-    output = "vopd_component_rules.inl",
-    output_flag = "--component-rules",
-    visibility = _AMDGPU_PLANNING_FACT_VISIBILITY,
-)
-
-loom_generated_textual_header(
-    name = "vopd_component_descriptor_lookup_ranges_gen",
-    args = _AMDGPU_ISA_XML_ARGS,
-    generator = _AMDGPU_VOPD_COMPONENT_TABLE_GENERATOR,
-    inputs = _AMDGPU_ISA_XML_INPUTS,
-    output = "vopd_component_descriptor_lookup_ranges.inl",
-    output_flag = "--descriptor-lookup-ranges",
-    visibility = _AMDGPU_PLANNING_FACT_VISIBILITY,
-)
-
-loom_generated_textual_header(
-    name = "vopd_component_descriptor_lookups_gen",
-    args = _AMDGPU_ISA_XML_ARGS,
-    generator = _AMDGPU_VOPD_COMPONENT_TABLE_GENERATOR,
-    inputs = _AMDGPU_ISA_XML_INPUTS,
-    output = "vopd_component_descriptor_lookups.inl",
-    output_flag = "--descriptor-lookups",
-    visibility = _AMDGPU_PLANNING_FACT_VISIBILITY,
-)
-
-loom_generated_textual_header(
-    name = "vopd_pair_affinity_ranges_gen",
-    args = _AMDGPU_ISA_XML_ARGS,
-    generator = _AMDGPU_VOPD_COMPONENT_TABLE_GENERATOR,
-    inputs = _AMDGPU_ISA_XML_INPUTS,
-    output = "vopd_pair_affinity_ranges.inl",
-    output_flag = "--pair-affinity-ranges",
-    visibility = _AMDGPU_PLANNING_FACT_VISIBILITY,
-)
-
-loom_generated_textual_header(
-    name = "vopd_pair_affinities_gen",
-    args = _AMDGPU_ISA_XML_ARGS,
-    generator = _AMDGPU_VOPD_COMPONENT_TABLE_GENERATOR,
-    inputs = _AMDGPU_ISA_XML_INPUTS,
-    output = "vopd_pair_affinities.inl",
-    output_flag = "--pair-affinities",
-    visibility = _AMDGPU_PLANNING_FACT_VISIBILITY,
-)
-
-loom_generated_textual_header(
-    name = "vopd_pair_placement_recipes_gen",
-    args = _AMDGPU_ISA_XML_ARGS,
-    generator = _AMDGPU_VOPD_COMPONENT_TABLE_GENERATOR,
-    inputs = _AMDGPU_ISA_XML_INPUTS,
-    output = "vopd_pair_placement_recipes.inl",
-    output_flag = "--pair-placement-recipes",
+    output_flags = [
+        "--component-rules",
+        "--descriptor-lookup-ranges",
+        "--descriptor-lookups",
+        "--pair-affinity-ranges",
+        "--pair-affinities",
+        "--pair-placement-recipes",
+    ],
+    outputs = [
+        "vopd_component_rules.inl",
+        "vopd_component_descriptor_lookup_ranges.inl",
+        "vopd_component_descriptor_lookups.inl",
+        "vopd_pair_affinity_ranges.inl",
+        "vopd_pair_affinities.inl",
+        "vopd_pair_placement_recipes.inl",
+    ],
     visibility = _AMDGPU_PLANNING_FACT_VISIBILITY,
 )
 

--- a/loom/src/loom/target/arch/amdgpu/descriptors/CMakeLists.txt
+++ b/loom/src/loom/target/arch/amdgpu/descriptors/CMakeLists.txt
@@ -27,118 +27,22 @@ endif()
 iree_add_all_subdirs()
 
 if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
+loom_generated_textual_header_family(
   NAME
-    wait_packet_descriptor_ranges_gen
+    wait_packet_tables_gen
   GENERATOR
     loom::py::loom::gen::target::arch::amdgpu::descriptors::wait_packet_tables
-  OUTPUT
+  OUTPUTS
     "wait_packet_descriptor_ranges.inl"
-  OUTPUT_FLAG
-    "--descriptor-ranges"
-  ARGS
-    "--isa-xml=cdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "--isa-xml=cdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "--isa-xml=rdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "--isa-xml=rdna3_5:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "--isa-xml=rdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-  INPUTS
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "loom_amdgpu_isa_xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    wait_packet_descriptors_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::descriptors::wait_packet_tables
-  OUTPUT
     "wait_packet_descriptors.inl"
-  OUTPUT_FLAG
-    "--descriptor-rows"
-  ARGS
-    "--isa-xml=cdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "--isa-xml=cdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "--isa-xml=rdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "--isa-xml=rdna3_5:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "--isa-xml=rdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-  INPUTS
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "loom_amdgpu_isa_xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    wait_packet_descriptor_lookups_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::descriptors::wait_packet_tables
-  OUTPUT
     "wait_packet_descriptor_lookups.inl"
-  OUTPUT_FLAG
-    "--descriptor-lookups"
-  ARGS
-    "--isa-xml=cdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "--isa-xml=cdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "--isa-xml=rdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "--isa-xml=rdna3_5:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "--isa-xml=rdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-  INPUTS
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "loom_amdgpu_isa_xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    wait_packet_immediates_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::descriptors::wait_packet_tables
-  OUTPUT
     "wait_packet_immediates.inl"
-  OUTPUT_FLAG
-    "--immediate-rows"
-  ARGS
-    "--isa-xml=cdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "--isa-xml=cdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "--isa-xml=rdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "--isa-xml=rdna3_5:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "--isa-xml=rdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-  INPUTS
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "loom_amdgpu_isa_xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    wait_packet_selections_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::descriptors::wait_packet_tables
-  OUTPUT
     "wait_packet_selections.inl"
-  OUTPUT_FLAG
+  OUTPUT_FLAGS
+    "--descriptor-ranges"
+    "--descriptor-rows"
+    "--descriptor-lookups"
+    "--immediate-rows"
     "--selection-rows"
   ARGS
     "--isa-xml=cdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
@@ -153,148 +57,30 @@ loom_generated_textual_header(
     "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
     "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
     "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
+  COMMENT
+    "Generating AMDGPU wait-packet table family"
 )
 endif()
 
 if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
+loom_generated_textual_header_family(
   NAME
-    vopd_component_rules_gen
+    vopd_component_tables_gen
   GENERATOR
     loom::py::loom::gen::target::arch::amdgpu::descriptors::vopd_component_tables
-  OUTPUT
+  OUTPUTS
     "vopd_component_rules.inl"
-  OUTPUT_FLAG
-    "--component-rules"
-  ARGS
-    "--isa-xml=cdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "--isa-xml=cdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "--isa-xml=rdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "--isa-xml=rdna3_5:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "--isa-xml=rdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-  INPUTS
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "loom_amdgpu_isa_xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    vopd_component_descriptor_lookup_ranges_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::descriptors::vopd_component_tables
-  OUTPUT
     "vopd_component_descriptor_lookup_ranges.inl"
-  OUTPUT_FLAG
-    "--descriptor-lookup-ranges"
-  ARGS
-    "--isa-xml=cdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "--isa-xml=cdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "--isa-xml=rdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "--isa-xml=rdna3_5:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "--isa-xml=rdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-  INPUTS
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "loom_amdgpu_isa_xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    vopd_component_descriptor_lookups_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::descriptors::vopd_component_tables
-  OUTPUT
     "vopd_component_descriptor_lookups.inl"
-  OUTPUT_FLAG
-    "--descriptor-lookups"
-  ARGS
-    "--isa-xml=cdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "--isa-xml=cdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "--isa-xml=rdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "--isa-xml=rdna3_5:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "--isa-xml=rdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-  INPUTS
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "loom_amdgpu_isa_xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    vopd_pair_affinity_ranges_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::descriptors::vopd_component_tables
-  OUTPUT
     "vopd_pair_affinity_ranges.inl"
-  OUTPUT_FLAG
-    "--pair-affinity-ranges"
-  ARGS
-    "--isa-xml=cdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "--isa-xml=cdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "--isa-xml=rdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "--isa-xml=rdna3_5:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "--isa-xml=rdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-  INPUTS
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "loom_amdgpu_isa_xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    vopd_pair_affinities_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::descriptors::vopd_component_tables
-  OUTPUT
     "vopd_pair_affinities.inl"
-  OUTPUT_FLAG
-    "--pair-affinities"
-  ARGS
-    "--isa-xml=cdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "--isa-xml=cdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "--isa-xml=rdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "--isa-xml=rdna3_5:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "--isa-xml=rdna4:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-  INPUTS
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
-    "loom_amdgpu_isa_xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna4.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
-    "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    vopd_pair_placement_recipes_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::descriptors::vopd_component_tables
-  OUTPUT
     "vopd_pair_placement_recipes.inl"
-  OUTPUT_FLAG
+  OUTPUT_FLAGS
+    "--component-rules"
+    "--descriptor-lookup-ranges"
+    "--descriptor-lookups"
+    "--pair-affinity-ranges"
+    "--pair-affinities"
     "--pair-placement-recipes"
   ARGS
     "--isa-xml=cdna3:${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_cdna3.xml"
@@ -309,6 +95,8 @@ loom_generated_textual_header(
     "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3.xml"
     "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna3_5.xml"
     "${_LOOM_AMDGPU_ISA_XML_SOURCE_DIR}/amdgpu_isa_rdna4.xml"
+  COMMENT
+    "Generating AMDGPU VOPD component table family"
 )
 endif()
 


### PR DESCRIPTION
AMDGPU table generators now own coherent output families instead of reconstructing the same ISA-derived model once per textual fragment. The five wait-packet fragments and six VOPD fragments are each generated by one hermetic action, with matching Bazel, CMake, and Bazel-to-CMake contracts. Existing output filenames and consumer labels remain unchanged.

Low descriptor generation now follows the same ownership boundary. A storage descriptor set and all of its public views are compiled and validated once, then that shared model emits the common C source and positionally paired headers. The AMDGPU gfx125x and x86 packed-dot families use this path, while independent descriptor sets keep the existing singular generator path.

The configured Loom generator graph falls from 258 to 240 actions. XML-consuming actions fall from 54 to 36, and unique per-process XML parses fall from 166 to 76; wait and VOPD alone fall from 22 configured actions and 110 parses to four actions and 20 parses. The gfx125x descriptor family's compile-and-render phase falls from roughly 8.5 seconds to 2.0 seconds, while x86's 12-view family falls from roughly 0.51 seconds to 0.10 seconds. Every affected AMDGPU and x86 generated C/header artifact remains byte-identical through both Bazel and CMake.

Retained Bazel execution profiles from the [exact main branch point](https://github.com/ROCm/hrx-system/actions/runs/31515005306) and the [PR](https://github.com/ROCm/hrx-system/actions/runs/31517357953) confirm that the improvement reaches CI:

| Configuration | Generator actions | Generator critical path | Complete critical path | Bazel command |
| --- | ---: | ---: | ---: | ---: |
| CPU | 257 → 239 | 17.14s → 8.50s (-50.4%) | 20.91s → 13.82s (-33.9%) | 84.06s → 70.76s (-15.8%) |
| CPU ASAN | 257 → 239 | 17.55s → 9.73s (-44.6%) | 48.49s → 39.98s (-17.5%) | 113.25s → 124.61s (+10.0%) |
| CPU MSAN | 257 → 239 | 18.22s → 8.67s (-52.4%) | 22.11s → 16.43s (-25.7%) | 93.85s → 85.70s (-8.7%) |
| CPU TSAN | 257 → 239 | 18.27s → 8.54s (-53.2%) | 66.19s → 45.49s (-31.3%) | 130.74s → 104.50s (-20.1%) |
| CPU UBSAN | 257 → 239 | 17.71s → 8.74s (-50.6%) | 56.12s → 43.43s (-22.6%) | 135.25s → 120.56s (-10.9%) |
| AMDGPU gfx110X | 219 → 204 | 8.00s → 3.46s (-56.7%) | 8.83s → 5.29s (-40.1%) | 61.41s → 141.44s (+130.3%) |
| AMDGPU gfx1151 | 245 → 221 | 11.92s → 6.90s (-42.1%) | 13.21s → 7.86s (-40.5%) | 94.41s → 75.32s (-20.2%) |
| AMDGPU gfx120X | 234 → 211 | 8.38s → 4.14s (-50.6%) | 9.14s → 6.75s (-26.1%) | 65.62s → 63.02s (-4.0%) |

All five CPU configurations remove exactly 18 generator actions, the generator component on Bazel's critical path falls by 44.6-53.2%, and the complete critical path falls by 17.5-33.9%. Four of five total Bazel commands improve, with a median 10.9% reduction. The gfx110X command ran on a substantially weaker execution envelope—roughly 12 concurrent local actions versus 32 and less than half the average Bazel CPU utilization—yet its generator and complete critical paths still improve by 56.7% and 40.1%.

This deliberately stops at correcting generator ownership. It does not introduce persistent workers, caches, or serialized ISA intermediates: after family consolidation, XML parsing is a small fraction of the remaining gfx125x action, so those mechanisms would add architecture without addressing the measured critical phase.
