### PR TITLE
[Loom] Generate AMDGPU lowering table families together

### DIFF
--- a/loom/py/loom/gen/target/arch/amdgpu/lower/amdgpu_narrow_float_tables.py
+++ b/loom/py/loom/gen/target/arch/amdgpu/lower/amdgpu_narrow_float_tables.py
@@ -914,10 +914,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         and args.fp8_packed_repair_reason_rows is None
     ):
         parser.error("at least one output path is required")
+    descriptor_ref_key_set = (
+        set(amdgpu_descriptor_ref_keys())
+        if args.fp8_decode_plan_descriptor_rows is not None or args.fp8_native_descriptor_ref_rows is not None or args.fp8_scaled_descriptor_ref_rows is not None
+        else None
+    )
     if args.fp8_decode_plan_descriptor_rows is not None:
         _write_output(
             args.fp8_decode_plan_descriptor_rows,
-            _emit_fp8_decode_plan_descriptor_rows(),
+            _emit_fp8_decode_plan_descriptor_rows(descriptor_ref_key_set=descriptor_ref_key_set),
         )
     if args.fp8_encoded_operand_format_rows is not None:
         _write_output(
@@ -932,12 +937,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.fp8_native_descriptor_ref_rows is not None:
         _write_output(
             args.fp8_native_descriptor_ref_rows,
-            _emit_fp8_native_descriptor_ref_rows(),
+            _emit_fp8_native_descriptor_ref_rows(descriptor_ref_key_set=descriptor_ref_key_set),
         )
     if args.fp8_scaled_descriptor_ref_rows is not None:
         _write_output(
             args.fp8_scaled_descriptor_ref_rows,
-            _emit_fp8_scaled_descriptor_ref_rows(),
+            _emit_fp8_scaled_descriptor_ref_rows(descriptor_ref_key_set=descriptor_ref_key_set),
         )
     if args.fp8_subnormal_table_rows is not None:
         _write_output(

--- a/loom/py/loom/gen/target/arch/amdgpu/lower/candidates/amdgpu_candidates_test.py
+++ b/loom/py/loom/gen/target/arch/amdgpu/lower/candidates/amdgpu_candidates_test.py
@@ -240,8 +240,9 @@ def test_candidate_range_validation_rejects_uint16_overflow() -> None:
 
 
 def test_memory_generator_emits_data_fragments_only() -> None:
-    candidate_rows = amdgpu_memory_candidates._emit_candidate_rows()
-    candidate_ranges = amdgpu_memory_candidates._emit_candidate_ranges()
+    candidates = amdgpu_memory_candidates._ordered_candidates(amdgpu_memory_candidates.amdgpu_memory_descriptor_candidates())
+    candidate_rows = amdgpu_memory_candidates._emit_candidate_rows(candidates)
+    candidate_ranges = amdgpu_memory_candidates._emit_candidate_ranges(candidates)
 
     for source in (candidate_rows, candidate_ranges):
         assert "typedef " not in source

--- a/loom/py/loom/gen/target/arch/amdgpu/lower/candidates/amdgpu_memory_candidates.py
+++ b/loom/py/loom/gen/target/arch/amdgpu/lower/candidates/amdgpu_memory_candidates.py
@@ -260,8 +260,9 @@ def _generated_header() -> list[str]:
     ]
 
 
-def _emit_candidate_rows() -> str:
-    candidates = _ordered_candidates(amdgpu_memory_descriptor_candidates())
+def _emit_candidate_rows(
+    candidates: Sequence[AmdgpuMemoryDescriptorCandidate],
+) -> str:
     return (
         "\n".join(
             [
@@ -273,8 +274,9 @@ def _emit_candidate_rows() -> str:
     )
 
 
-def _emit_candidate_ranges() -> str:
-    candidates = _ordered_candidates(amdgpu_memory_descriptor_candidates())
+def _emit_candidate_ranges(
+    candidates: Sequence[AmdgpuMemoryDescriptorCandidate],
+) -> str:
     ranges = _candidate_ranges(candidates)
     return (
         "\n".join(
@@ -308,10 +310,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.candidate_rows is None and args.candidate_ranges is None:
         parser.error("at least one output path is required")
+    candidates = _ordered_candidates(amdgpu_memory_descriptor_candidates())
     if args.candidate_rows is not None:
-        _write_output(args.candidate_rows, _emit_candidate_rows())
+        _write_output(args.candidate_rows, _emit_candidate_rows(candidates))
     if args.candidate_ranges is not None:
-        _write_output(args.candidate_ranges, _emit_candidate_ranges())
+        _write_output(args.candidate_ranges, _emit_candidate_ranges(candidates))
     return 0
 
 

--- a/loom/src/loom/target/arch/amdgpu/lower/BUILD.bazel
+++ b/loom/src/loom/target/arch/amdgpu/lower/BUILD.bazel
@@ -75,18 +75,17 @@ loom_generated_textual_header_family(
     ],
 )
 
-loom_generated_textual_header(
-    name = "memory_cache_policy_encoding_rows_gen",
+loom_generated_textual_header_family(
+    name = "memory_cache_policy_tables_gen",
     generator = _AMDGPU_TARGET_INFO_GENERATOR,
-    output = "memory_cache_policy_encoding_rows.inl",
-    output_flag = "--cache-policy-encoding-rows",
-)
-
-loom_generated_textual_header(
-    name = "memory_cache_policy_temporal_th_gen",
-    generator = _AMDGPU_TARGET_INFO_GENERATOR,
-    output = "memory_cache_policy_temporal_th.inl",
-    output_flag = "--cache-policy-temporal-th",
+    output_flags = [
+        "--cache-policy-encoding-rows",
+        "--cache-policy-temporal-th",
+    ],
+    outputs = [
+        "memory_cache_policy_encoding_rows.inl",
+        "memory_cache_policy_temporal_th.inl",
+    ],
 )
 
 loom_generated_textual_header_family(

--- a/loom/src/loom/target/arch/amdgpu/lower/BUILD.bazel
+++ b/loom/src/loom/target/arch/amdgpu/lower/BUILD.bazel
@@ -9,6 +9,7 @@ load(
     "loom_cc_library",
     "loom_cc_test",
     "loom_generated_textual_header",
+    "loom_generated_textual_header_family",
 )
 
 package(
@@ -89,53 +90,27 @@ loom_generated_textual_header(
     output_flag = "--cache-policy-temporal-th",
 )
 
-loom_generated_textual_header(
-    name = "fp8_decode_plan_descriptor_rows_gen",
+loom_generated_textual_header_family(
+    name = "fp8_tables_gen",
     generator = _AMDGPU_NARROW_FLOAT_TABLE_GENERATOR,
-    output = "encoding/fp8_decode_plan_descriptor_rows.inl",
-    output_flag = "--fp8-decode-plan-descriptor-rows",
-)
-
-loom_generated_textual_header(
-    name = "fp8_encoded_operand_format_rows_gen",
-    generator = _AMDGPU_NARROW_FLOAT_TABLE_GENERATOR,
-    output = "encoding/fp8_encoded_operand_format_rows.inl",
-    output_flag = "--fp8-encoded-operand-format-rows",
-)
-
-loom_generated_textual_header(
-    name = "fp8_encoded_operand_schema_requirement_rows_gen",
-    generator = _AMDGPU_NARROW_FLOAT_TABLE_GENERATOR,
-    output = "encoding/fp8_encoded_operand_schema_requirement_rows.inl",
-    output_flag = "--fp8-encoded-operand-schema-requirement-rows",
-)
-
-loom_generated_textual_header(
-    name = "fp8_native_descriptor_ref_rows_gen",
-    generator = _AMDGPU_NARROW_FLOAT_TABLE_GENERATOR,
-    output = "encoding/fp8_native_descriptor_ref_rows.inl",
-    output_flag = "--fp8-native-descriptor-ref-rows",
-)
-
-loom_generated_textual_header(
-    name = "fp8_scaled_descriptor_ref_rows_gen",
-    generator = _AMDGPU_NARROW_FLOAT_TABLE_GENERATOR,
-    output = "encoding/fp8_scaled_descriptor_ref_rows.inl",
-    output_flag = "--fp8-scaled-descriptor-ref-rows",
-)
-
-loom_generated_textual_header(
-    name = "fp8_subnormal_table_rows_gen",
-    generator = _AMDGPU_NARROW_FLOAT_TABLE_GENERATOR,
-    output = "encoding/fp8_subnormal_table_rows.inl",
-    output_flag = "--fp8-subnormal-table-rows",
-)
-
-loom_generated_textual_header(
-    name = "fp8_packed_repair_reason_rows_gen",
-    generator = _AMDGPU_NARROW_FLOAT_TABLE_GENERATOR,
-    output = "encoding/fp8_packed_repair_reason_rows.inl",
-    output_flag = "--fp8-packed-repair-reason-rows",
+    output_flags = [
+        "--fp8-decode-plan-descriptor-rows",
+        "--fp8-encoded-operand-format-rows",
+        "--fp8-encoded-operand-schema-requirement-rows",
+        "--fp8-native-descriptor-ref-rows",
+        "--fp8-scaled-descriptor-ref-rows",
+        "--fp8-subnormal-table-rows",
+        "--fp8-packed-repair-reason-rows",
+    ],
+    outputs = [
+        "encoding/fp8_decode_plan_descriptor_rows.inl",
+        "encoding/fp8_encoded_operand_format_rows.inl",
+        "encoding/fp8_encoded_operand_schema_requirement_rows.inl",
+        "encoding/fp8_native_descriptor_ref_rows.inl",
+        "encoding/fp8_scaled_descriptor_ref_rows.inl",
+        "encoding/fp8_subnormal_table_rows.inl",
+        "encoding/fp8_packed_repair_reason_rows.inl",
+    ],
 )
 
 loom_cc_library(

--- a/loom/src/loom/target/arch/amdgpu/lower/BUILD.bazel
+++ b/loom/src/loom/target/arch/amdgpu/lower/BUILD.bazel
@@ -62,18 +62,17 @@ exports_files(
     visibility = ["//loom/py/loom/target/arch/amdgpu/contracts:__pkg__"],
 )
 
-loom_generated_textual_header(
-    name = "memory_descriptor_candidate_ranges_gen",
+loom_generated_textual_header_family(
+    name = "memory_descriptor_candidate_tables_gen",
     generator = _AMDGPU_MEMORY_CANDIDATE_GENERATOR,
-    output = "memory_descriptor_candidate_ranges.inl",
-    output_flag = "--candidate-ranges",
-)
-
-loom_generated_textual_header(
-    name = "memory_descriptor_candidates_gen",
-    generator = _AMDGPU_MEMORY_CANDIDATE_GENERATOR,
-    output = "memory_descriptor_candidates.inl",
-    output_flag = "--candidate-rows",
+    output_flags = [
+        "--candidate-ranges",
+        "--candidate-rows",
+    ],
+    outputs = [
+        "memory_descriptor_candidate_ranges.inl",
+        "memory_descriptor_candidates.inl",
+    ],
 )
 
 loom_generated_textual_header(

--- a/loom/src/loom/target/arch/amdgpu/lower/CMakeLists.txt
+++ b/loom/src/loom/target/arch/amdgpu/lower/CMakeLists.txt
@@ -87,92 +87,26 @@ loom_generated_textual_header(
 endif()
 
 if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
+loom_generated_textual_header_family(
   NAME
-    fp8_decode_plan_descriptor_rows_gen
+    fp8_tables_gen
   GENERATOR
     loom::py::loom::gen::target::arch::amdgpu::lower::narrow_float_tables
-  OUTPUT
+  OUTPUTS
     "encoding/fp8_decode_plan_descriptor_rows.inl"
-  OUTPUT_FLAG
-    "--fp8-decode-plan-descriptor-rows"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    fp8_encoded_operand_format_rows_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::lower::narrow_float_tables
-  OUTPUT
     "encoding/fp8_encoded_operand_format_rows.inl"
-  OUTPUT_FLAG
-    "--fp8-encoded-operand-format-rows"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    fp8_encoded_operand_schema_requirement_rows_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::lower::narrow_float_tables
-  OUTPUT
     "encoding/fp8_encoded_operand_schema_requirement_rows.inl"
-  OUTPUT_FLAG
-    "--fp8-encoded-operand-schema-requirement-rows"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    fp8_native_descriptor_ref_rows_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::lower::narrow_float_tables
-  OUTPUT
     "encoding/fp8_native_descriptor_ref_rows.inl"
-  OUTPUT_FLAG
-    "--fp8-native-descriptor-ref-rows"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    fp8_scaled_descriptor_ref_rows_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::lower::narrow_float_tables
-  OUTPUT
     "encoding/fp8_scaled_descriptor_ref_rows.inl"
-  OUTPUT_FLAG
-    "--fp8-scaled-descriptor-ref-rows"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    fp8_subnormal_table_rows_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::lower::narrow_float_tables
-  OUTPUT
     "encoding/fp8_subnormal_table_rows.inl"
-  OUTPUT_FLAG
-    "--fp8-subnormal-table-rows"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    fp8_packed_repair_reason_rows_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::lower::narrow_float_tables
-  OUTPUT
     "encoding/fp8_packed_repair_reason_rows.inl"
-  OUTPUT_FLAG
+  OUTPUT_FLAGS
+    "--fp8-decode-plan-descriptor-rows"
+    "--fp8-encoded-operand-format-rows"
+    "--fp8-encoded-operand-schema-requirement-rows"
+    "--fp8-native-descriptor-ref-rows"
+    "--fp8-scaled-descriptor-ref-rows"
+    "--fp8-subnormal-table-rows"
     "--fp8-packed-repair-reason-rows"
 )
 endif()

--- a/loom/src/loom/target/arch/amdgpu/lower/CMakeLists.txt
+++ b/loom/src/loom/target/arch/amdgpu/lower/CMakeLists.txt
@@ -35,27 +35,16 @@ loom_cc_library(
 endif()
 
 if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
+loom_generated_textual_header_family(
   NAME
-    memory_descriptor_candidate_ranges_gen
+    memory_descriptor_candidate_tables_gen
   GENERATOR
     loom::py::loom::gen::target::arch::amdgpu::lower::candidates::memory_candidates
-  OUTPUT
+  OUTPUTS
     "memory_descriptor_candidate_ranges.inl"
-  OUTPUT_FLAG
-    "--candidate-ranges"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    memory_descriptor_candidates_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::lower::candidates::memory_candidates
-  OUTPUT
     "memory_descriptor_candidates.inl"
-  OUTPUT_FLAG
+  OUTPUT_FLAGS
+    "--candidate-ranges"
     "--candidate-rows"
 )
 endif()

--- a/loom/src/loom/target/arch/amdgpu/lower/CMakeLists.txt
+++ b/loom/src/loom/target/arch/amdgpu/lower/CMakeLists.txt
@@ -50,27 +50,16 @@ loom_generated_textual_header_family(
 endif()
 
 if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
+loom_generated_textual_header_family(
   NAME
-    memory_cache_policy_encoding_rows_gen
+    memory_cache_policy_tables_gen
   GENERATOR
     loom::py::loom::gen::target::arch::amdgpu::target_info
-  OUTPUT
+  OUTPUTS
     "memory_cache_policy_encoding_rows.inl"
-  OUTPUT_FLAG
-    "--cache-policy-encoding-rows"
-)
-endif()
-
-if(LOOM_TARGET_ARCH_AMDGPU)
-loom_generated_textual_header(
-  NAME
-    memory_cache_policy_temporal_th_gen
-  GENERATOR
-    loom::py::loom::gen::target::arch::amdgpu::target_info
-  OUTPUT
     "memory_cache_policy_temporal_th.inl"
-  OUTPUT_FLAG
+  OUTPUT_FLAGS
+    "--cache-policy-encoding-rows"
     "--cache-policy-temporal-th"
 )
 endif()


### PR DESCRIPTION
AMDGPU lowering metadata now generates at the same granularity as its source and consumer contracts instead of launching one Python process per textual fragment.

The FP8 lowering model is emitted as one seven-output family covering format rows, schema requirements, descriptor references, subnormal behavior, and packed-repair policy. The generator also materializes the descriptor-reference vocabulary once and shares it across the three outputs that validate against it.

Memory descriptor candidates now use one ordered source sequence for both the candidate rows and the range index whose offsets address those rows. This makes the representation relationship explicit: the range table cannot be generated from a separately validated or separately sorted candidate sequence.

The memory cache-policy encoding rows and temporal TH map are likewise emitted as one cache-policy family. They share the target vocabulary and jointly define the lowering model consumed by `memory_cache.c`.

All generated filenames and bytes remain unchanged, so downstream C compilation and runtime behavior are unaffected. The configured Loom generator graph falls from 240 to 224 `IreeGenerate` actions across target and execution configurations.

| Table family | Previous processes | Family processes | Fresh-process median |
| --- | ---: | ---: | ---: |
| FP8 lowering | 7 | 1 | 3.002s → 0.569s |
| Memory candidates and ranges | 2 | 1 | 1.453s → 0.740s |
| Memory cache policy | 2 | 1 | 0.754s → 0.371s |

Together these families reduce their direct fresh-process generation cost from 5.21 seconds to 1.68 seconds while preserving precise family-scoped invalidation. Architecture descriptor shards, encoding shards, and contract shards remain independent because they have distinct source and specialization boundaries.
