### PR TITLE
[Loom] Compact physical descriptor placement queries

### DIFF
--- a/loom/py/loom/gen/target/low/physical_validation_test.py
+++ b/loom/py/loom/gen/target/low/physical_validation_test.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import replace
+from itertools import combinations_with_replacement
 
 import pytest
 
@@ -88,6 +89,88 @@ def _descriptor_set(
         register_parts=(),
         descriptors=descriptors,
     )
+
+
+def test_physical_base_domain_matches_enumerated_contract() -> None:
+    windows = tuple(
+        validation._PhysicalAddressWindow(
+            window_size=window_size,
+            maximum_base_remainder=window_size - operand_width,
+        )
+        for window_size in range(1, 9)
+        for operand_width in range(1, window_size + 1)
+    )
+    window_sets = [()]
+    window_sets.extend((window,) for window in windows)
+    window_sets.extend(combinations_with_replacement(windows, 2))
+
+    for maximum_base in (-1, 0, 1, 7, 8, 15, 31):
+        for address_windows in window_sets:
+            expected_bases = tuple(base for base in range(maximum_base + 1) if all(base % window.window_size <= window.maximum_base_remainder for window in address_windows))
+            domain = validation._PhysicalBaseDomain(
+                maximum_base=maximum_base,
+                address_windows=tuple(address_windows),
+            )
+            for lower_bound in range(maximum_base + 2):
+                expected = next(
+                    (base for base in expected_bases if base >= lower_bound),
+                    None,
+                )
+                assert domain.first_at_or_above(lower_bound) == expected
+
+
+def test_physical_component_base_domain_combines_address_maps() -> None:
+    descriptor = _descriptor(
+        "test.address.maps",
+        (
+            _physical_operand(
+                "dst",
+                OperandRole.RESULT,
+                "test.phys",
+                unit_count=2,
+            ),
+            _physical_operand(
+                "bounded",
+                OperandRole.OPERAND,
+                "test.phys",
+                unit_count=2,
+                address_map_kind=OperandAddressMapKind.LOW_SUBSET,
+                addressable_unit_count=6,
+            ),
+            _physical_operand(
+                "windowed",
+                OperandRole.OPERAND,
+                "test.phys",
+                unit_count=2,
+                address_map_kind=OperandAddressMapKind.TARGET_STATE,
+                addressable_unit_count=4,
+                address_state_slot=1,
+            ),
+        ),
+        constraints=(
+            Constraint(ConstraintKind.TIED, 0, 1),
+            Constraint(ConstraintKind.TIED, 0, 2),
+        ),
+    )
+    component = validation._PhysicalComponent(
+        operand_indices=(0, 1, 2),
+        resource_keys=frozenset(("class:test.phys",)),
+        pre_width=2,
+        post_width=2,
+    )
+
+    domain = validation._component_base_domain(
+        descriptor,
+        component,
+        resource_capacity=16,
+        early_clobber_results=frozenset(),
+    )
+
+    assert domain.maximum_base == 4
+    assert domain.first_at_or_above(0) == 0
+    assert domain.first_at_or_above(2) == 2
+    assert domain.first_at_or_above(3) == 4
+    assert domain.first_at_or_above(5) is None
 
 
 def test_physical_descriptor_set_accepts_reserved_resource_envelope() -> None:

--- a/loom/py/loom/gen/target/low/validation.py
+++ b/loom/py/loom/gen/target/low/validation.py
@@ -77,6 +77,36 @@ class _PhysicalComponent:
     post_width: int
 
 
+@dataclass(frozen=True, slots=True)
+class _PhysicalAddressWindow:
+    # Allocation units in each independently addressable window.
+    window_size: int
+    # Largest base remainder that keeps the component inside one window.
+    maximum_base_remainder: int
+
+
+@dataclass(frozen=True, slots=True)
+class _PhysicalBaseDomain:
+    # Largest base that keeps the complete component inside the resource.
+    maximum_base: int
+    # Periodic address-window restrictions applied to candidate bases.
+    address_windows: tuple[_PhysicalAddressWindow, ...]
+
+    def first_at_or_above(self, lower_bound: int) -> int | None:
+        """Returns the least admissible base at or above `lower_bound`."""
+
+        candidate = lower_bound
+        while candidate <= self.maximum_base:
+            previous_candidate = candidate
+            for window in self.address_windows:
+                remainder = candidate % window.window_size
+                if remainder > window.maximum_base_remainder:
+                    candidate += window.window_size - remainder
+            if candidate == previous_candidate:
+                return candidate
+        return None
+
+
 def _physical_resource_key(register_class: RegClass) -> str:
     if register_class.alias_set_id:
         return f"alias:{register_class.alias_set_id}"
@@ -134,47 +164,44 @@ def _descriptor_tied_operand_roots(descriptor: Descriptor) -> tuple[int, ...]:
     return tuple(find(operand_index) for operand_index in range(len(parent)))
 
 
-def _operand_allows_base(operand: Operand, base: int) -> bool:
-    assigned_end = base + operand.unit_count
-    if operand.address_map_kind is OperandAddressMapKind.LOW_SUBSET:
-        return assigned_end <= operand.addressable_unit_count
-    if operand.address_map_kind is OperandAddressMapKind.TARGET_STATE:
-        window_size = operand.addressable_unit_count
-        return base // window_size == (assigned_end - 1) // window_size
-    return True
-
-
-def _component_allowed_bases(
+def _component_base_domain(
     descriptor: Descriptor,
     component: _PhysicalComponent,
     resource_capacity: int,
     early_clobber_results: frozenset[int],
-) -> tuple[int, ...]:
+) -> _PhysicalBaseDomain:
     component_width = max(component.pre_width, component.post_width)
-    if component_width > resource_capacity:
-        return ()
-    allowed_bases = []
-    for base in range(resource_capacity - component_width + 1):
-        is_allowed = True
-        for operand_index in component.operand_indices:
-            operand = descriptor.operands[operand_index]
-            reads_pre, writes_post = _operand_phase_accesses(
-                operand,
-                is_early_clobber=operand_index in early_clobber_results,
+    maximum_base = resource_capacity - component_width
+    address_windows = []
+    for operand_index in component.operand_indices:
+        operand = descriptor.operands[operand_index]
+        reads_pre, writes_post = _operand_phase_accesses(
+            operand,
+            is_early_clobber=operand_index in early_clobber_results,
+        )
+        if not reads_pre and not writes_post:
+            continue
+        if operand.address_map_kind is OperandAddressMapKind.LOW_SUBSET:
+            maximum_base = min(
+                maximum_base,
+                operand.addressable_unit_count - operand.unit_count,
             )
-            if not reads_pre and not writes_post:
-                continue
-            if not _operand_allows_base(operand, base):
-                is_allowed = False
-                break
-        if is_allowed:
-            allowed_bases.append(base)
-    return tuple(allowed_bases)
+        elif operand.address_map_kind is OperandAddressMapKind.TARGET_STATE:
+            address_windows.append(
+                _PhysicalAddressWindow(
+                    window_size=operand.addressable_unit_count,
+                    maximum_base_remainder=(operand.addressable_unit_count - operand.unit_count),
+                )
+            )
+    return _PhysicalBaseDomain(
+        maximum_base=maximum_base,
+        address_windows=tuple(address_windows),
+    )
 
 
 def _solve_physical_component_order_pair(
     components: Sequence[_PhysicalComponent],
-    allowed_bases: Sequence[tuple[int, ...]],
+    base_domains: Sequence[_PhysicalBaseDomain],
     pre_order: tuple[int, ...],
     post_order: tuple[int, ...],
 ) -> bool:
@@ -197,10 +224,7 @@ def _solve_physical_component_order_pair(
     while ready:
         component_index = ready.pop()
         visited_count += 1
-        base = next(
-            (candidate for candidate in allowed_bases[component_index] if candidate >= lower_bounds[component_index]),
-            None,
-        )
+        base = base_domains[component_index].first_at_or_above(lower_bounds[component_index])
         if base is None:
             return False
         for successor_index, width in successors[component_index]:
@@ -213,7 +237,7 @@ def _solve_physical_component_order_pair(
 
 def _physical_components_admit_placement(
     components: Sequence[_PhysicalComponent],
-    allowed_bases: Sequence[tuple[int, ...]],
+    base_domains: Sequence[_PhysicalBaseDomain],
 ) -> bool:
     pre_components = tuple(index for index, component in enumerate(components) if component.pre_width)
     post_components = tuple(index for index, component in enumerate(components) if component.post_width)
@@ -221,7 +245,7 @@ def _physical_components_admit_placement(
         for post_order in permutations(post_components):
             if _solve_physical_component_order_pair(
                 components,
-                allowed_bases,
+                base_domains,
                 pre_order,
                 post_order,
             ):
@@ -401,8 +425,8 @@ def validate_physical_descriptor_set(
                 limits.maximum_phase_order_pair_count,
                 descriptor_key=descriptor.key,
             )
-            allowed_bases = tuple(
-                _component_allowed_bases(
+            base_domains = tuple(
+                _component_base_domain(
                     descriptor,
                     component,
                     resource_capacity,
@@ -410,7 +434,7 @@ def validate_physical_descriptor_set(
                 )
                 for component in resource_components
             )
-            if any(not bases for bases in allowed_bases) or not (_physical_components_admit_placement(resource_components, allowed_bases)):
+            if any(domain.first_at_or_above(0) is None for domain in base_domains) or not _physical_components_admit_placement(resource_components, base_domains):
                 raise ValueError(
                     f"descriptor set '{descriptor_set.key}' descriptor '{descriptor.key}' physical resource '{resource_key}' does not admit a legal pre/post placement within {resource_capacity} units"
                 )


### PR DESCRIPTION
Low descriptor generation proves that every legal combination of physical operand alternatives can fit within each target-owned storage resource. That proof used to enumerate every legal register base for every tied component and materialize those bases into tuples. The phase-order solver then walked each tuple only to answer one question: what is the first legal base at or above this lower bound?

This change represents the same admissible-base domain directly. A component has one inclusive maximum base, tightened by resource capacity and `LOW_SUBSET` operands, plus periodic address-window constraints from `TARGET_STATE` operands. `DIRECT` operands add no restriction. The solver queries the least admissible base it needs, advancing across forbidden window suffixes until all constraints agree, without work proportional to the target's physical register capacity.

The representation remains an exact proof rather than a heuristic. Focused coverage compares the compact query against exhaustive enumeration across empty, single-window, and paired-window domains, including interacting window periods and unsatisfiable bounds. Separate integration coverage verifies that direct, bounded, and target-state operands produce the intended combined domain. The existing complete target generator suite continues to exercise the production validator, and gfx125x shared source plus generic, A0, and gfx1251 headers remain byte-identical.

The effect is most visible on wide physical namespaces such as gfx125x. Across seven production-shaped runs, complete gfx125x descriptor-family generation falls from a 3.29-second median to 2.36 seconds under the current system load, a 28% reduction. The physical-placement portion itself falls from 2.760 profiler seconds to roughly 0.1 seconds and removes about 6.8 million predicate calls. Smaller targets retain the same proof while avoiding capacity-scaled work they never needed.
