### PR TITLE
[CI] Deploy Loom documentation from main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,10 +34,6 @@ on:
       - "loom/py/loom/**"
       - "loom/src/loom/editor/textmate/**"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 
@@ -46,6 +42,9 @@ jobs:
     name: Linux / Documentation
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    concurrency:
+      group: ${{ github.workflow }}-build-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -73,8 +72,28 @@ jobs:
           test -f build/loom-pages/loom/reference/dialects/index.html
           test -f build/loom-pages/loom/reference/c-api/generated/index.html
 
-      - name: Upload review artifact
+      - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: build/loom-pages
           retention-days: 7
+
+  deploy_docs:
+    name: GitHub Pages
+    if: github.ref == 'refs/heads/main'
+    needs: build_docs
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
+    steps:
+      - name: Deploy Pages artifact
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/build_tools/devtools/ci_test.py
+++ b/build_tools/devtools/ci_test.py
@@ -1061,9 +1061,14 @@ class CiTest(unittest.TestCase):
             block,
         )
 
-    def test_loom_docs_workflow_builds_review_artifact_without_deploy_access(self):
+    def test_loom_docs_workflow_reviews_every_change_and_deploys_only_main(self):
         text = Path(".github/workflows/docs.yml").read_text()
-        block = self.workflow_job_block(".github/workflows/docs.yml", "build_docs")
+        build_block = self.workflow_job_block(
+            ".github/workflows/docs.yml", "build_docs"
+        )
+        deploy_block = self.workflow_job_block(
+            ".github/workflows/docs.yml", "deploy_docs"
+        )
 
         for path in (
             '"requirements-analysis.lock.txt"',
@@ -1075,33 +1080,55 @@ class CiTest(unittest.TestCase):
             '"loom/src/loom/editor/textmate/**"',
         ):
             self.assertIn(f"- {path}", text)
-        self.assertIn("runs-on: ubuntu-24.04", block)
-        self.assertIn("python3 dev.py setup --docs", block)
-        self.assertIn("loom_docs.highlight_test", block)
+        self.assertIn("runs-on: ubuntu-24.04", build_block)
+        self.assertIn("python3 dev.py setup --docs", build_block)
+        self.assertIn("loom_docs.highlight_test", build_block)
         self.assertIn(
             "--site-dir build/loom-pages/loom",
-            block,
+            build_block,
         )
         self.assertIn(
             "test -f build/loom-pages/loom/reference/dialects/index.html",
-            block,
+            build_block,
         )
         self.assertIn(
             "test -f build/loom-pages/loom/reference/c-api/generated/index.html",
-            block,
+            build_block,
         )
         self.assertIn(
             "uses: actions/upload-pages-artifact@"
             "fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0",
-            block,
+            build_block,
         )
-        self.assertIn("path: build/loom-pages", block)
+        self.assertIn("path: build/loom-pages", build_block)
+        self.assertIn(
+            "group: ${{ github.workflow }}-build-${{ github.ref }}", build_block
+        )
+        self.assertIn("cancel-in-progress: true", build_block)
+        self.assertNotIn("pages: write", build_block)
+        self.assertNotIn("id-token: write", build_block)
+        self.assertNotIn("actions/deploy-pages", build_block)
+
+        self.assertIn("if: github.ref == 'refs/heads/main'", deploy_block)
+        self.assertIn("needs: build_docs", deploy_block)
+        self.assertIn("pages: write", deploy_block)
+        self.assertIn("id-token: write", deploy_block)
+        self.assertIn("name: github-pages", deploy_block)
+        self.assertIn("url: ${{ steps.deployment.outputs.page_url }}", deploy_block)
+        self.assertIn("group: github-pages", deploy_block)
+        self.assertIn("cancel-in-progress: false", deploy_block)
+        self.assertIn("id: deployment", deploy_block)
+        self.assertIn(
+            "uses: actions/deploy-pages@"
+            "cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0",
+            deploy_block,
+        )
+        self.assertEqual(text.count("pages: write"), 1)
+        self.assertEqual(text.count("id-token: write"), 1)
+        self.assertEqual(text.count("actions/deploy-pages@"), 1)
         self.assertNotIn("apt-get", text)
         self.assertNotIn("pip install", text)
         self.assertNotIn("sudo", text)
-        self.assertNotIn("pages: write", text)
-        self.assertNotIn("id-token: write", text)
-        self.assertNotIn("actions/deploy-pages", text)
 
     def test_xfails_project_to_ctest_regexes(self):
         self.assertIn(

--- a/loom/binding/c/include/loomc/launch_config.h
+++ b/loom/binding/c/include/loomc/launch_config.h
@@ -183,10 +183,14 @@ LOOMC_API_EXPORT loomc_status_t loomc_launch_config_program_load(
     loomc_launch_config_program_t** out_program);
 
 /// Retains `program` for another owner.
+///
+/// @param program Program to retain.
 LOOMC_API_EXPORT void loomc_launch_config_program_retain(
     loomc_launch_config_program_t* program);
 
 /// Releases `program` from one owner. Passing `NULL` is allowed.
+///
+/// @param program Program to release. Passing `NULL` is allowed.
 LOOMC_API_EXPORT void loomc_launch_config_program_release(
     loomc_launch_config_program_t* program);
 


### PR DESCRIPTION
Publishes the existing strict Loom documentation artifact from `main` while
retaining the same read-only build and review artifact on pull requests and
`main-staging`.

The build and deployment trust zones are separate. Documentation builds are
cancellable and inherit only `contents: read`; a non-cancellable deployment
job runs only for `refs/heads/main`, targets the `github-pages` environment,
and alone receives `pages: write` and `id-token: write`. It consumes the exact
artifact assembled beneath `/loom/`, leaving the Pages root available for
future runtime and libhrx documentation siblings.

The repository does not yet have a Pages site configured. A repository
administrator must select **Settings → Pages → Build and deployment → GitHub
Actions** once before the first mainline deployment. This is equivalent to
creating the Pages site with `build_type: workflow`; ordinary deployments then
remain owned entirely by this workflow.
