### PR TITLE
[Loom] Explain the programming model

### DIFF
--- a/build_tools/devtools/install.py
+++ b/build_tools/devtools/install.py
@@ -63,7 +63,7 @@ TOOLS = {
     "bazelisk": Tool(
         version="1.29.0",
         install_names=("bazelisk", "bazel"),
-        groups=("bazel",),
+        groups=("bazel", "docs"),
         assets={
             "darwin-amd64": ToolAsset(
                 url="https://github.com/bazelbuild/bazelisk/releases/download/v1.29.0/bazelisk-darwin-amd64",

--- a/build_tools/devtools/install_test.py
+++ b/build_tools/devtools/install_test.py
@@ -46,10 +46,13 @@ class InstallTest(unittest.TestCase):
         for tool in (tool for tool in install.TOOLS.values() if tool.default):
             self.assertIn(platform_key, tool.assets)
 
-    def test_docs_group_selects_only_doxygen(self):
+    def test_docs_group_selects_documentation_build_tools(self):
         args = argparse.Namespace(list=False, group=["docs"], tools=[])
 
-        self.assertEqual(set(install.selected_tools(args)), {"doxygen"})
+        self.assertEqual(
+            set(install.selected_tools(args)),
+            {"bazelisk", "doxygen"},
+        )
 
     def test_extracts_zip_archive_files_with_recorded_hashes(self):
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/loom/docs/README.md
+++ b/loom/docs/README.md
@@ -10,8 +10,10 @@ Add the optional, pinned documentation toolchain to the repository environment:
 python dev.py setup --docs
 ```
 
-This installs the hash-locked Python requirements and the official pinned
-Doxygen binary into `.venv`; it does not depend on distribution packages.
+This installs the hash-locked Python requirements and the pinned Bazelisk and
+Doxygen binaries into `.venv`; it does not depend on distribution packages.
+The compiler-backed guide examples use Bazelisk to build the exact Loom tools
+from the current checkout before documentation is assembled.
 
 Build the strict static site:
 

--- a/loom/docs/examples/BUILD.bazel
+++ b/loom/docs/examples/BUILD.bazel
@@ -1,0 +1,14 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# bazel-to-cmake: skip
+
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+exports_files(["example.shlib"])

--- a/loom/docs/examples/example.shlib
+++ b/loom/docs/examples/example.shlib
@@ -1,0 +1,46 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# shellcheck shell=bash
+# shellcheck disable=SC2034  # Target configuration is consumed by the caller.
+
+loom_example_configure_target() {
+  LOOM_EXAMPLE_TARGET="$1"
+  case "${LOOM_EXAMPLE_TARGET}" in
+    gfx11-generic)
+      LOOM_EXAMPLE_BACKEND="amdgpu-hal"
+      ;;
+    *)
+      printf 'unsupported example target: %s\n' "${LOOM_EXAMPLE_TARGET}" >&2
+      printf 'supported targets: gfx11-generic\n' >&2
+      return 64
+      ;;
+  esac
+}
+
+loom_example_require_tool() {
+  local tool="$1"
+  if [[ "${tool}" == */* ]]; then
+    [[ -x "${tool}" ]] && return 0
+  elif command -v "${tool}" >/dev/null 2>&1; then
+    return 0
+  fi
+  printf 'required Loom tool not found: %s\n' "${tool}" >&2
+  return 127
+}
+
+loom_example_section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+loom_example_run_tool() {
+  local public_name="$1"
+  local executable="$2"
+  shift 2
+  printf '  $ %s' "${public_name}"
+  printf ' %q' "$@"
+  printf '\n'
+  "${executable}" "$@"
+}

--- a/loom/docs/examples/mental-model/.doc-generate.sh
+++ b/loom/docs/examples/mental-model/.doc-generate.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Builds the reader-facing example through run.sh, verifies its products, and
+# stages only generated Loom snippets for the documentation build.
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+
+if [[ "$#" -gt 1 ]]; then
+  printf 'usage: %s [output-directory]\n' "$0" >&2
+  exit 64
+fi
+
+if [[ -n "${RUNFILES_DIR:-}" ]]; then
+  workspace="${TEST_WORKSPACE:-_main}"
+  repo_root="${RUNFILES_DIR}/${workspace}"
+  export LOOM_FORMAT="${repo_root}/loom/src/loom/tools/loom-format/loom-format"
+  export LOOM_LINK="${repo_root}/loom/src/loom/tools/loom-link/loom-link"
+  export LOOM_COMPILE="${repo_root}/loom/src/loom/tools/loom-compile/loom-compile"
+  loom_check="${repo_root}/loom/src/loom/tools/loom-check/loom-check"
+else
+  repo_root="$(cd -- "${script_dir}/../../../.." && pwd -P)"
+  "${repo_root}/build_tools/bin/iree-bazel-build" \
+    --config=asan \
+    //loom/src/loom/tools/loom-format:loom-format \
+    //loom/src/loom/tools/loom-link:loom-link \
+    //loom/src/loom/tools/loom-compile:loom-compile \
+    //loom/src/loom/tools/loom-check:loom-check
+  export LOOM_FORMAT="${repo_root}/bazel-bin/loom/src/loom/tools/loom-format/loom-format"
+  export LOOM_LINK="${repo_root}/bazel-bin/loom/src/loom/tools/loom-link/loom-link"
+  export LOOM_COMPILE="${repo_root}/bazel-bin/loom/src/loom/tools/loom-compile/loom-compile"
+  loom_check="${repo_root}/bazel-bin/loom/src/loom/tools/loom-check/loom-check"
+fi
+
+if [[ ! -x "${loom_check}" ]]; then
+  printf 'required Loom tool not found: %s\n' "${loom_check}" >&2
+  exit 127
+fi
+
+output_dir="${1:-${TEST_UNDECLARED_OUTPUTS_DIR:-${repo_root}/build/loom-docs/examples/mental-model}}"
+mkdir -p -- "${output_dir}"
+output_dir="$(cd -- "${output_dir}" && pwd -P)"
+
+temporary_root="$(mktemp -d "${TMPDIR:-/tmp}/loom-doc-mental-model.XXXXXX")"
+cleanup() {
+  rm -rf -- "${temporary_root}"
+}
+trap cleanup EXIT
+
+artifact_root="${temporary_root}/artifacts"
+"${script_dir}/run.sh" gfx11-generic "${artifact_root}"
+
+kernel_dump="${artifact_root}/transform-gfx11.loom"
+kernel_output="${output_dir}/kernel-gfx11.loom"
+kernel_unformatted="${temporary_root}/kernel-gfx11.loom"
+awk '!found && /^low\.kernel\.def / { found = 1 } found { print }' \
+  "${kernel_dump}" >"${kernel_unformatted}"
+"${LOOM_FORMAT}" "${kernel_unformatted}" \
+  --to=text --output="${kernel_output}"
+"${LOOM_FORMAT}" --check "${kernel_output}"
+
+# Command-program materialization is not an installed-tool surface yet. Keep
+# this target-owned check provider behind the documentation build boundary.
+command_fixture="${temporary_root}/command-program.loom-test"
+{
+  printf '// RUN: emit command-program @transform\n\n'
+  sed -n '1,$p' "${artifact_root}/transform.loom"
+  printf '\n// ----\n'
+} >"${command_fixture}"
+
+update_log="${temporary_root}/command-program-update.log"
+set +e
+"${loom_check}" --update "${command_fixture}" >"${update_log}" 2>&1
+update_status="$?"
+set -e
+if [[ "${update_status}" -ne 0 && "${update_status}" -ne 1 ]]; then
+  sed -n '1,$p' "${update_log}" >&2
+  exit "${update_status}"
+fi
+if ! "${loom_check}" "${command_fixture}"; then
+  sed -n '1,$p' "${update_log}" >&2
+  exit 1
+fi
+
+command_output="${output_dir}/command-program.loom"
+awk 'found { print } $0 == "// ----" { found = 1 }' \
+  "${command_fixture}" >"${command_output}"
+
+grep -Fq '@transform_buffer' "${kernel_output}"
+grep -Fq 'amdgpu.global_load_b32_saddr' "${kernel_output}"
+grep -Fq 'amdgpu.v_add_f32' "${kernel_output}"
+grep -Fq 'amdgpu.global_store_b32_saddr' "${kernel_output}"
+grep -Fq '@transform() asm' "${command_output}"
+grep -Fq 'cmd.dispatch.direct' "${command_output}"
+
+printf 'Generated documentation snippets:\n'
+printf '  %s\n' "${kernel_output}" "${command_output}"

--- a/loom/docs/examples/mental-model/BUILD.bazel
+++ b/loom/docs/examples/mental-model/BUILD.bazel
@@ -1,0 +1,59 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# bazel-to-cmake: skip
+
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//loom/build_tools/bazel:defs.bzl", "loom_library")
+
+package(
+    default_visibility = ["//visibility:private"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+loom_library(
+    name = "motif",
+    srcs = ["motif.loom"],
+)
+
+loom_library(
+    name = "kernel",
+    srcs = ["kernel.loom"],
+    deps = [":motif"],
+)
+
+loom_library(
+    name = "model",
+    srcs = ["model.loom"],
+    deps = [":kernel"],
+)
+
+sh_test(
+    name = "doc_generate_test",
+    srcs = [".doc-generate.sh"],
+    data = [
+        "kernel.loom",
+        "model.loom",
+        "motif.loom",
+        "run.sh",
+        "//loom/docs/examples:example.shlib",
+        "//loom/src/loom/tools/loom-check",
+        "//loom/src/loom/tools/loom-compile",
+        "//loom/src/loom/tools/loom-format",
+        "//loom/src/loom/tools/loom-link",
+    ],
+    tags = ["hostonly"],
+)
+
+test_suite(
+    name = "test",
+    tests = [
+        ":doc_generate_test",
+        ":kernel_test",
+        ":model_test",
+        ":motif_test",
+    ],
+)

--- a/loom/docs/examples/mental-model/kernel.loom
+++ b/loom/docs/examples/mental-model/kernel.loom
@@ -1,0 +1,35 @@
+// Compile-time configuration states both the accepted domain and the values
+// that a composition root must bind.
+config.decl @guide.element_count : %value: index where [range(%value, 1, 1048576)]
+
+config.decl @guide.workgroup_size : %value: index where [range(%value, 32, 256), pow2(%value)]
+
+// The targetless kernel owns its physical launch and applies the transform
+// contract without naming one provider.
+kernel.def @transform_buffer() {
+  %unit = index.constant 1 : index
+  %element_count = config.get @guide.element_count : index
+  %workgroup_size = config.get @guide.workgroup_size : index
+  %rounding = index.sub %workgroup_size, %unit : index
+  %rounded_count = index.add %element_count, %rounding : index
+  %workgroups = index.div %rounded_count, %workgroup_size : index
+  kernel.launch.config workgroups(%workgroups, %unit, %unit) workgroup_size(%workgroup_size, %unit, %unit) : index
+} launch(%input: buffer, %output: buffer) {
+  %workgroup = kernel.workgroup.id<x> : index
+  %lane = kernel.workitem.id<x> : index
+  %element_count = config.get @guide.element_count : index
+  %workgroup_size = config.get @guide.workgroup_size : index
+  %element_index = index.madd %workgroup, %workgroup_size, %lane : index
+  %input_noalias, %output_noalias = buffer.assume.noalias %input, %output : buffer, buffer
+  %base = index.constant 0 : offset
+  %input_view = buffer.view %input_noalias[%base] : buffer -> view<[%element_count]xf32>
+  %output_view = buffer.view %output_noalias[%base] : buffer -> view<[%element_count]xf32>
+  %in_bounds = index.cmp ult, %element_index, %element_count : index
+  scf.if %in_bounds {
+    %bounded_index = index.assume %element_index [lt(%element_index, %element_count)] : index
+    %value = view.load %input_view[%bounded_index] : view<[%element_count]xf32> -> f32
+    %result = func.apply<guide.transform>(%value) : (f32) -> (f32)
+    view.store %result, %output_view[%bounded_index] : f32, view<[%element_count]xf32>
+  }
+  kernel.return
+}

--- a/loom/docs/examples/mental-model/model.loom
+++ b/loom/docs/examples/mental-model/model.loom
@@ -1,0 +1,9 @@
+// The declaration makes the exact dependency explicit in this source module.
+kernel.decl @transform_buffer() launch(%input: buffer, %output: buffer)
+
+// The command program owns the reusable schedule while buffers remain
+// replaceable at issue time.
+command.program.def public @transform() launch(%input: buffer, %output: buffer) {
+  kernel.launch @transform_buffer(%input, %output) : (buffer, buffer)
+  command.return
+}

--- a/loom/docs/examples/mental-model/motif.loom
+++ b/loom/docs/examples/mental-model/motif.loom
@@ -1,0 +1,16 @@
+// Targetless helpers and interchangeable providers remain reusable across
+// kernels, shapes, and targets.
+func.def inline @double(%value: f32) -> (f32) {
+  %doubled = scalar.addf %value, %value : f32
+  func.return %doubled : f32
+}
+
+func.template<guide.transform> requires [#target.subgroup.size<32>] priority(20) @wave32_transform(%value: f32) -> (f32) {
+  %result = func.call @double(%value) : (f32) -> (f32)
+  func.return %result : f32
+}
+
+func.template<guide.transform> priority(1) @portable_transform(%value: f32) -> (f32) {
+  %result = func.call @double(%value) : (f32) -> (f32)
+  func.return %result : f32
+}

--- a/loom/docs/examples/mental-model/run.sh
+++ b/loom/docs/examples/mental-model/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=loom/docs/examples/example.shlib
+source "${script_dir}/../example.shlib"
+
+if [[ "$#" -gt 2 ]]; then
+  printf 'usage: %s [target] [output-directory]\n' "$0" >&2
+  exit 64
+fi
+
+target="${1:-gfx11-generic}"
+output_dir="${2:-build/mental-model/${target}}"
+loom_example_configure_target "${target}"
+
+if [[ "${output_dir}" != /* ]]; then
+  output_dir="${PWD}/${output_dir}"
+fi
+mkdir -p -- "${output_dir}"
+output_dir="$(cd -- "${output_dir}" && pwd -P)"
+
+loom_format="${LOOM_FORMAT:-loom-format}"
+loom_link="${LOOM_LINK:-loom-link}"
+loom_compile="${LOOM_COMPILE:-loom-compile}"
+
+loom_example_require_tool "${loom_format}"
+loom_example_require_tool "${loom_link}"
+loom_example_require_tool "${loom_compile}"
+
+cd -- "${script_dir}"
+
+loom_example_section "Check the authored modules"
+loom_example_run_tool loom-format "${loom_format}" --check \
+  motif.loom kernel.loom model.loom
+
+loom_example_section "Link and specialize the command root"
+loom_example_run_tool loom-link "${loom_link}" \
+  model.loom \
+  --library=kernel.loom \
+  --library=motif.loom \
+  --mode=link \
+  --root=@transform \
+  --config=guide.element_count=1009 \
+  --config=guide.workgroup_size=64 \
+  --to=text \
+  --output="${output_dir}/transform.loom"
+
+loom_example_section "Compile the selected kernel for ${target}"
+loom_example_run_tool loom-compile "${loom_compile}" \
+  "${output_dir}/transform.loom" \
+  --backend="${LOOM_EXAMPLE_BACKEND}" \
+  --target="${LOOM_EXAMPLE_TARGET}" \
+  --root=@transform_buffer \
+  --output="${output_dir}/transform.vmfb" \
+  --emit-target-artifact="${output_dir}/transform.hsaco" \
+  --dump-ir-after=low-select-operand-forms \
+  --dump-ir-output="${output_dir}/transform-gfx11.loom"
+
+loom_example_section "Artifacts"
+printf '  %s\n' \
+  "${output_dir}/transform.loom" \
+  "${output_dir}/transform-gfx11.loom" \
+  "${output_dir}/transform.vmfb" \
+  "${output_dir}/transform.hsaco"

--- a/loom/docs/hooks/prepare.py
+++ b/loom/docs/hooks/prepare.py
@@ -18,9 +18,11 @@ from typing import Any
 DOCS_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = Path(__file__).resolve().parents[3]
 AUTHORED_SOURCE_ROOT = DOCS_ROOT / "src"
+EXAMPLE_SOURCE_ROOT = DOCS_ROOT / "examples"
 PYTHON_SOURCE_ROOT = REPO_ROOT / "loom" / "py"
 DEFAULT_WORK_ROOT = REPO_ROOT / "build" / "loom-docs"
 C_API_GENERATOR = REPO_ROOT / "loom" / "binding" / "c" / "doc" / "generate.sh"
+DOC_GENERATOR_NAME = ".doc-generate.sh"
 
 if str(PYTHON_SOURCE_ROOT) not in sys.path:
     sys.path.insert(0, str(PYTHON_SOURCE_ROOT))
@@ -82,7 +84,32 @@ def _generate_c_api(work_root: Path) -> Path:
     return html_root
 
 
-def _prepare_staged_source(staged_source_root: Path, c_api_html_root: Path) -> None:
+def _generate_example_outputs(work_root: Path) -> Path:
+    output_root = work_root / "examples"
+    _remove_generated_directory(output_root)
+    output_root.mkdir(parents=True)
+
+    environment = os.environ.copy()
+    python_bin_dir = str(Path(sys.executable).parent)
+    environment["PATH"] = python_bin_dir + os.pathsep + environment.get("PATH", "")
+    for generator in sorted(EXAMPLE_SOURCE_ROOT.rglob(DOC_GENERATOR_NAME)):
+        relative_package = generator.parent.relative_to(EXAMPLE_SOURCE_ROOT)
+        package_output_root = output_root / relative_package
+        package_output_root.mkdir(parents=True)
+        subprocess.run(
+            [str(generator), str(package_output_root)],
+            cwd=REPO_ROOT,
+            env=environment,
+            check=True,
+        )
+    return output_root
+
+
+def _prepare_staged_source(
+    staged_source_root: Path,
+    c_api_html_root: Path,
+    generated_example_root: Path,
+) -> None:
     _remove_generated_directory(staged_source_root)
     shutil.copytree(AUTHORED_SOURCE_ROOT, staged_source_root)
     files = generate_reference_files()
@@ -90,6 +117,10 @@ def _prepare_staged_source(staged_source_root: Path, c_api_html_root: Path) -> N
     shutil.copytree(
         c_api_html_root,
         staged_source_root / "reference" / "c-api" / "generated",
+    )
+    shutil.copytree(
+        generated_example_root,
+        staged_source_root / "generated" / "examples",
     )
 
 
@@ -99,14 +130,23 @@ def on_config(config: Any) -> Any:
     staged_source_root = _staged_source_root()
     staged_source_root.mkdir(parents=True, exist_ok=True)
     config["docs_dir"] = str(staged_source_root)
+    snippet_config = config.get("mdx_configs", {}).get("pymdownx.snippets")
+    if snippet_config is not None:
+        base_paths = snippet_config["base_path"]
+        if str(staged_source_root) not in base_paths:
+            base_paths.append(str(staged_source_root))
     return config
 
 
 def on_pre_build(config: Any) -> None:
     """Rebuilds the complete source tree before every MkDocs build."""
 
-    c_api_html_root = _generate_c_api(_work_root())
-    _prepare_staged_source(Path(config["docs_dir"]), c_api_html_root)
+    work_root = _work_root()
+    c_api_html_root = _generate_c_api(work_root)
+    generated_example_root = _generate_example_outputs(work_root)
+    _prepare_staged_source(
+        Path(config["docs_dir"]), c_api_html_root, generated_example_root
+    )
 
 
 def on_serve(server: Any, config: Any, builder: Any) -> Any:

--- a/loom/docs/hooks/prepare_test.py
+++ b/loom/docs/hooks/prepare_test.py
@@ -9,6 +9,9 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
 
 import prepare
 
@@ -22,6 +25,62 @@ class _FakeServer:
 
 
 class PrepareTest(unittest.TestCase):
+    def test_config_adds_generated_source_to_snippet_search_path(self) -> None:
+        config = {
+            "mdx_configs": {
+                "pymdownx.snippets": {
+                    "base_path": ["loom/docs"],
+                }
+            }
+        }
+
+        result = prepare.on_config(config)
+
+        self.assertIs(result, config)
+        self.assertEqual(
+            config["mdx_configs"]["pymdownx.snippets"]["base_path"],
+            ["loom/docs", str(prepare._staged_source_root())],
+        )
+
+    def test_example_generators_are_discovered_by_package(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            example_root = temporary_root / "source"
+            work_root = temporary_root / "work"
+            first_generator = example_root / "alpha" / prepare.DOC_GENERATOR_NAME
+            second_generator = (
+                example_root / "nested" / "beta" / prepare.DOC_GENERATOR_NAME
+            )
+            first_generator.parent.mkdir(parents=True)
+            second_generator.parent.mkdir(parents=True)
+            first_generator.touch()
+            second_generator.touch()
+            stale_output = work_root / "examples" / "stale.loom"
+            stale_output.parent.mkdir(parents=True)
+            stale_output.touch()
+
+            with (
+                mock.patch.object(prepare, "EXAMPLE_SOURCE_ROOT", example_root),
+                mock.patch.object(prepare.subprocess, "run") as run,
+            ):
+                output_root = prepare._generate_example_outputs(work_root)
+
+            self.assertEqual(output_root, work_root / "examples")
+            self.assertFalse(stale_output.exists())
+            self.assertEqual(
+                [call.args[0] for call in run.call_args_list],
+                [
+                    [str(first_generator), str(output_root / "alpha")],
+                    [
+                        str(second_generator),
+                        str(output_root / "nested" / "beta"),
+                    ],
+                ],
+            )
+            for call in run.call_args_list:
+                self.assertEqual(call.kwargs["cwd"], prepare.REPO_ROOT)
+                self.assertTrue(call.kwargs["check"])
+
     def test_live_reload_does_not_watch_generated_source(self) -> None:
         server = _FakeServer()
 

--- a/loom/docs/mkdocs.yml
+++ b/loom/docs/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
   - Loom: index.md
   - Get started:
       - Acquiring Loom: getting-started/acquiring-loom.md
+      - Mental model: getting-started/mental-model.md
   - Reference:
       - Reference map: reference/index.md
       - Dialects: reference/dialects/index.md

--- a/loom/docs/mkdocs.yml
+++ b/loom/docs/mkdocs.yml
@@ -16,6 +16,7 @@ hooks:
 
 watch:
   - src
+  - examples
   - loom_docs
   - ../py/loom/builtin_types.py
   - ../binding/c/doc

--- a/loom/docs/src/getting-started/mental-model.md
+++ b/loom/docs/src/getting-started/mental-model.md
@@ -1,0 +1,184 @@
+# Mental model
+
+Loom keeps a program understandable while it moves from reusable source to a
+target-specific artifact. Linking, specialization, launch configuration,
+correctness cases, benchmark workloads, and compiler evidence operate on the
+same program instead of meeting only after code has become opaque.
+
+The useful unit is therefore larger than an instruction stream and smaller
+than a framework. A Loom module can contain reusable computation, alternative
+implementations, dispatchable kernels, executable checks, and command programs.
+An application chooses which roots and facts matter, then asks Loom to link and
+specialize only that reachable program.
+
+## From source to artifacts
+
+`.loom` is the canonical, human-readable source form. `.loombc` preserves the
+same linkable program in bytecode. Neither form implies one target or one
+deployment strategy.
+
+```text
+authored modules + libraries + configuration + target profile
+                              │
+                      link and specialize
+                              │
+              lower the selected executable roots
+                              │
+       native code + launch contracts + compiler evidence
+```
+
+The same source can be compiled ahead of time, linked and specialized when a
+model is loaded, or JIT-compiled for a concrete invocation. Those choices
+change when facts become available; they do not require different kernel
+languages.
+
+Modules are ordinary composition boundaries. Public symbols can become roots
+for another module or an embedding, private symbols remain implementation
+details, and unreachable helpers and providers can disappear after selection.
+The linker resolves declared symbol relationships; merely placing a module in
+a library does not make its entire contents live.
+
+## Exact calls and selectable implementations
+
+Loom separates naming one implementation from requesting an implementation
+that satisfies a contract.
+
+| Source construct | Meaning |
+| --- | --- |
+| [`func.def`](../reference/dialects/func/ops/def.md) and [`func.call`](../reference/dialects/func/ops/call.md) | Define and call an exact helper by symbol. |
+| [`func.template`](../reference/dialects/func/ops/template.md) | Provide a visible implementation of a named contract. |
+| [`func.apply`](../reference/dialects/func/ops/apply.md) | Request an implementation of that contract at compile time. |
+
+An exact bit-manipulation helper is naturally a `func.call`. An operation whose
+best implementation depends on element format, shape facts, subgroup size, or
+target capabilities is naturally a `func.apply`. During specialization, Loom
+matches the reachable providers, their predicates and requirements, and the
+known facts. The selected provider becomes an ordinary callable boundary that
+normal inlining and optimization can remove.
+
+This is the foundation of a scalable library: callers name semantic demands;
+libraries provide reusable implementations; target selection remains a fact of
+the final compilation rather than a global property baked into every helper.
+The complete operation inventory lives in the generated
+[`func` dialect reference](../reference/dialects/func/index.md).
+
+## A kernel owns two contracts
+
+A [`kernel.def`](../reference/dialects/kernel/ops/def.md) contains a launch
+configuration region and a device body. They answer different questions.
+
+The launch configuration region receives workload values and computes the
+physical workgroup grid, required workgroup size, and optional cluster size.
+The body receives the arguments carried through the device launch ABI and uses
+workgroup, workitem, subgroup, and memory operations to perform the work.
+
+This distinction keeps a workload such as “process 1009 elements” separate
+from the physical decision “launch four workgroups of 256 invocations.” An
+embedding evaluates the compiled launch configuration for the workload; it
+does not reverse-engineer grid dimensions from a kernel name or duplicate the
+kernel's scheduling arithmetic.
+
+Workload arguments and device arguments are explicit even when the same value
+appears in both contracts. That explicit boundary lets Loom specialize launch
+geometry when facts are known while preserving a correct dynamic path when
+they are not. The generated [`kernel` dialect
+reference](../reference/dialects/kernel/index.md) defines the complete launch,
+execution, collective, and synchronization vocabulary.
+
+## Ask when a value becomes known
+
+Most confusion about specialization disappears once every value has a clear
+binding stage.
+
+| Value category | Binding stage | Role |
+| --- | --- | --- |
+| Configuration values | Link or compile time | Resolve [`config.decl`](../reference/dialects/config/ops/decl.md) through a matching definition and seed facts used by specialization. |
+| Target facts | Compile invocation | Describe capabilities such as subgroup size, supported types, and resource limits for the selected executable root. |
+| Kernel workload values | Launch-configuration evaluation | Compute the physical launch for one workload without pretending the values were compile-time constants. |
+| Kernel launch arguments | Device issue | Carry scalars and buffers through the selected target ABI into the kernel body. |
+| Command specialization arguments | Command-program specialization | Shape a reusable command artifact and its aggregate launch requirements. |
+| Command buffer bindings | Command-program issue | Attach concrete parameter, transient, input, and output storage without recompiling the schedule. |
+
+Configuration is not a hidden global flag. A module declares the values it
+requires, another input defines them, and ordinary symbol dependency analysis
+keeps their effect visible. Likewise, target requirements are compile-time
+selection constraints rather than runtime branches. Reusable code generally
+stays targetless; a provider names a target requirement only when its algorithm
+actually depends on one.
+
+The generated [`config`](../reference/dialects/config/index.md) and
+[`target`](../reference/dialects/target/index.md) references define those two
+fact sources.
+
+## Correctness and measurement stay beside the program
+
+A [`check.case`](../reference/dialects/check/ops/case.md) is an executable SSA
+program that creates inputs, launches code, obtains expected values, and states
+the comparison policy. A
+[`check.benchmark`](../reference/dialects/check/ops/benchmark.md) selects named
+assignments from a case for timing. The benchmark row does not copy the setup or
+invent a second workload description.
+
+Checks are test-only symbols, not deployment entry points. Keeping them in the
+same source gives formatters, verifiers, test runners, benchmark runners, and
+agents one authoritative statement of the workload while allowing published
+libraries to exclude the harness. The generated
+[`check` dialect reference](../reference/dialects/check/index.md) covers input
+generation, fixtures, requirements, expectations, and benchmark records.
+
+## Command programs move the same model upward
+
+A [`command.program.def`](../reference/dialects/command/ops/program-def.md)
+composes kernel launches, parameter views, resources, and serial or concurrent
+schedule regions into a reusable subgraph. Its leading specialization
+arguments participate in staged specialization and launch-count evaluation;
+its buffer bindings remain replaceable when the materialized program is
+issued.
+
+That separation allows one program to specialize around model structure and
+target facts while still accepting different weights, cache storage, inputs,
+and outputs. It is the same idea as a specialized kernel launch, applied to a
+larger ownership boundary rather than hidden behind a separate graph compiler.
+
+!!! info "Current command-program surface"
+
+    Command-program source, preparation, target-neutral lowering, and immutable
+    artifact infrastructure are present. A general installed-tool
+    materialization path is not yet a published user surface, so the guide does
+    not present an executable command-program tutorial yet.
+
+The generated [`command` dialect
+reference](../reference/dialects/command/index.md) documents the source
+constructs that exist today.
+
+## Embedding chooses the deployment policy
+
+Loom produces modules, target artifacts, launch contracts, diagnostics, and
+structured compiler reports. The embedding decides when compilation happens,
+where artifacts are cached, how executable code is loaded, and how work is
+issued to a device runtime.
+
+The public [`loomc` C API](../reference/c-api/index.md) exposes the in-memory
+source, link, specialization, compilation, emission, and launch-configuration
+boundaries needed to build those policies. Executable embedding examples in
+this guide are included only from checked programs that build against that API;
+the generated header reference remains authoritative for ownership, lifetime,
+threading, and failure contracts.
+
+## Working rules
+
+- Keep reusable algorithms targetless until a real implementation requirement
+  needs target facts.
+- Use an exact call for an exact helper and a contract application when the
+  implementation is intentionally substitutable.
+- Use configuration for compile-time product choices, workload arguments for
+  per-launch shape, and launch arguments for the device ABI.
+- Put correctness policy in `check.case`; make benchmarks select those checked
+  workloads instead of reconstructing them.
+- Keep motifs as functions and templates. Add a kernel ABI where the program
+  actually becomes dispatchable, and a command-program ABI where a reusable
+  subgraph becomes materializable.
+
+Continue with [Acquiring Loom](acquiring-loom.md) for the current installation
+status, or browse the [generated language reference](../reference/index.md) for
+the exact syntax and operation contracts.

--- a/loom/docs/src/getting-started/mental-model.md
+++ b/loom/docs/src/getting-started/mental-model.md
@@ -18,13 +18,13 @@ same linkable program in bytecode. Neither form implies one target or one
 deployment strategy.
 
 ```text
-authored modules + libraries + configuration + target profile
-                              │
-                      link and specialize
-                              │
-              lower the selected executable roots
-                              │
-       native code + launch contracts + compiler evidence
+motif.loom + kernel.loom + model.loom + configuration + target profile
+                                  │
+                          link and specialize
+                                  │
+                  lower the selected executable roots
+                                  │
+           native code + launch contracts + compiler evidence
 ```
 
 The same source can be compiled ahead of time, linked and specialized when a
@@ -59,6 +59,17 @@ normal inlining and optimization can remove.
 This is the foundation of a scalable library: callers name semantic demands;
 libraries provide reusable implementations; target selection remains a fact of
 the final compilation rather than a global property baked into every helper.
+This example defines an exact helper, a wave32-specific provider, and a
+portable provider for the same `guide.transform` contract:
+
+```loom title="motif.loom"
+--8<-- "examples/mental-model/motif.loom"
+```
+
+The wave32 provider is eligible only when the selected target establishes a
+subgroup size of 32. The fallback stays targetless, so the motif remains useful
+to targets that know nothing about AMDGPU.
+
 The complete operation inventory lives in the generated
 [`func` dialect reference](../reference/dialects/func/index.md).
 
@@ -85,6 +96,13 @@ they are not. The generated [`kernel` dialect
 reference](../reference/dialects/kernel/index.md) defines the complete launch,
 execution, collective, and synchronization vocabulary.
 
+The kernel below owns its launch geometry, states its configuration domain,
+and applies the motif contract without naming either provider:
+
+```loom title="kernel.loom"
+--8<-- "examples/mental-model/kernel.loom"
+```
+
 ## Ask when a value becomes known
 
 Most confusion about specialization disappears once every value has a clear
@@ -105,6 +123,22 @@ keeps their effect visible. Likewise, target requirements are compile-time
 selection constraints rather than runtime branches. Reusable code generally
 stays targetless; a provider names a target requirement only when its algorithm
 actually depends on one.
+
+Loom can preserve only information the program supplies. The ranges and
+divisibility predicates on a
+[`config.decl`](../reference/dialects/config/ops/decl.md) constrain a value even
+before a composition root binds it to one constant. An
+[`index.assume`](../reference/dialects/index/ops/assume.md) creates a refined SSA
+value carrying facts established by the surrounding program, such as the
+in-bounds index in `kernel.loom`. The `buffer.assume.*` family carries root
+alignment, memory-space, aliasing, and identity facts; the example's
+[`buffer.assume.noalias`](../reference/dialects/buffer/ops/assume-noalias.md)
+makes the input and output independence explicit.
+
+These are optimization inputs, not documentation comments. Shapes, ranges,
+alignment, aliasing, and target requirements survive linking and
+specialization so that each later stage can make a stronger decision without
+rediscovering information that the author or embedding already knew.
 
 The generated [`config`](../reference/dialects/config/index.md) and
 [`target`](../reference/dialects/target/index.md) references define those two
@@ -140,6 +174,13 @@ target facts while still accepting different weights, cache storage, inputs,
 and outputs. It is the same idea as a specialized kernel launch, applied to a
 larger ownership boundary rather than hidden behind a separate graph compiler.
 
+The outer module declares the exact kernel dependency and turns it into a
+one-dispatch reusable command program:
+
+```loom title="model.loom"
+--8<-- "examples/mental-model/model.loom"
+```
+
 !!! info "Current command-program surface"
 
     Command-program source, preparation, target-neutral lowering, and immutable
@@ -150,6 +191,40 @@ larger ownership boundary rather than hidden behind a separate graph compiler.
 The generated [`command` dialect
 reference](../reference/dialects/command/index.md) documents the source
 constructs that exist today.
+
+## Follow one composition to Low
+
+The three source listings above are checked `.loom` files, not prose copies.
+With the Loom tools on `PATH`, this command formats them, links and specializes
+the `@transform` root, compiles its kernel for the generic GFX11 profile, and
+prints every Loom command it runs:
+
+```shell
+loom/docs/examples/mental-model/run.sh \
+  gfx11-generic build/mental-model/gfx11-generic
+```
+
+The resulting directory contains the specialized `transform.loom`, a VMFB, an
+HSACO, and the captured target Low IR. The documentation build invokes that
+same script and regenerates the views below; neither output is checked-in
+source.
+
+=== "GFX11 kernel Low"
+
+    ```loom
+    --8<-- "generated/examples/mental-model/kernel-gfx11.loom"
+    ```
+
+=== "Command-program Low"
+
+    ```loom
+    --8<-- "generated/examples/mental-model/command-program.loom"
+    ```
+
+The GFX11 tab comes directly from the installed-tool workflow above. The
+command-program tab shows compiler-owned materialization of the same linked
+root. Until command-program materialization has a published installed-tool
+surface, treat that tab as verified compiler output rather than a CLI recipe.
 
 ## Embedding chooses the deployment policy
 
@@ -179,6 +254,6 @@ threading, and failure contracts.
   actually becomes dispatchable, and a command-program ABI where a reusable
   subgraph becomes materializable.
 
-Continue with [Acquiring Loom](acquiring-loom.md) for the current installation
-status, or browse the [generated language reference](../reference/index.md) for
-the exact syntax and operation contracts.
+Browse the [generated language reference](../reference/index.md) for exact
+syntax and operation contracts. If the Loom tools are not yet on `PATH`,
+[Acquiring Loom](acquiring-loom.md) describes the current installation status.

--- a/loom/docs/src/index.md
+++ b/loom/docs/src/index.md
@@ -15,6 +15,7 @@ cases, benchmark workloads, and compile evidence connected from readable IR to
 native artifacts.
 
 [Get Loom](getting-started/acquiring-loom.md){ .md-button .md-button--primary }
+[Learn the model](getting-started/mental-model.md){ .md-button }
 [Explore the reference](reference/index.md){ .md-button }
 
 </div>


### PR DESCRIPTION
Adds the first durable Start page for the Loom programming guide: a user-facing model of how source modules, library providers, target facts, launch contracts, checks, command programs, and embedding fit together.

The vocabulary is grounded in one compiler-checked composition spanning a targetless motif, a kernel that owns its launch and fact contracts, and a command program that declares and launches the kernel. The page distinguishes exact calls from compile-time provider selection, workload values from physical workgroup counts and device ABI arguments, and facts supplied by configuration, target profiles, index assumptions, and buffer assumptions.

The example exposes one reader-facing `run.sh` that prints and executes public Loom commands. A package-local documentation adapter reuses that path, validates its GFX11 and command-program Low products, and stages generated `.loom` snippets for MkDocs without checking compiler output into source. The generic staging convention lets later examples own their generation commands beside their programs, while the optional documentation toolchain now includes pinned Bazelisk so local and CI builds use the compiler from the current checkout.

Command-program materialization remains labeled as verified compiler output until its installed-tool surface is published. Exact syntax and operation contracts continue to come from the generated language reference rather than being duplicated in prose.
