### PR TITLE
[Loom] Round-trip C99 hexadecimal float literals

### DIFF
--- a/build_tools/lefthook/presubmit.py
+++ b/build_tools/lefthook/presubmit.py
@@ -990,7 +990,11 @@ def clang_tidy_jobs() -> int:
             return 1
         return max(1, jobs)
     cpu_count = os.cpu_count() or 1
-    default_jobs = max(1, (cpu_count + CLANG_TIDY_DEFAULT_CORE_DIVISOR - 1) // 2)
+    default_jobs = max(
+        1,
+        (cpu_count + CLANG_TIDY_DEFAULT_CORE_DIVISOR - 1)
+        // CLANG_TIDY_DEFAULT_CORE_DIVISOR,
+    )
     return min(cpu_count, CLANG_TIDY_DEFAULT_MAX_JOBS, default_jobs)
 
 
@@ -1452,6 +1456,7 @@ def clang_tidy_bazel_command(
     ]
     if keep_going:
         command.append("--keep_going")
+    command += ["--jobs", str(clang_tidy_jobs())]
     output_groups = [
         CLANG_TIDY_LOCAL_OUTPUT_GROUP if local_outputs else CLANG_TIDY_OUTPUT_GROUP
     ]

--- a/build_tools/lefthook/presubmit_test.py
+++ b/build_tools/lefthook/presubmit_test.py
@@ -184,6 +184,14 @@ class PresubmitTest(unittest.TestCase):
         self.assertIn(f"--output_groups={presubmit.CLANG_TIDY_OUTPUT_GROUP}", command)
         self.assertEqual(command[-1], "//runtime/src/iree/base:all")
 
+    def test_clang_tidy_bazel_command_obeys_configured_jobs(self):
+        with mock.patch.dict(os.environ, {"IREE_CLANG_TIDY_JOBS": "7"}):
+            command = presubmit.clang_tidy_bazel_command(
+                ["//runtime/src/iree/base:all"]
+            )
+
+        self.assertEqual(command[2:4], ["--jobs", "7"])
+
     def test_clang_tidy_bazel_command_can_keep_going(self):
         command = presubmit.clang_tidy_bazel_command(
             ["//runtime/src/iree/base:all"],

--- a/loom/py/loom/format/text/parser.py
+++ b/loom/py/loom/format/text/parser.py
@@ -172,6 +172,16 @@ def _parse_special_float(text: str) -> float | None:
             return None
 
 
+def _parse_float_literal(text: str) -> float:
+    unsigned_text = text[1:] if text.startswith("-") else text
+    if unsigned_text.startswith(("0x", "0X")):
+        try:
+            return float.fromhex(text)
+        except OverflowError:
+            return float("-inf" if text.startswith("-") else "inf")
+    return float(text)
+
+
 def _concrete_type_for_constraint(constraint: TypeConstraint) -> Type | None:
     """Returns the concrete type implied by a singleton type constraint."""
     match constraint:
@@ -214,7 +224,7 @@ def _parse_generic_attr_value_from_tokens(
     if tokenizer.at(TokenKind.INTEGER):
         return int(tokenizer.next().text)
     if tokenizer.at(TokenKind.FLOAT):
-        return float(tokenizer.next().text)
+        return _parse_float_literal(tokenizer.next().text)
     if tokenizer.at(TokenKind.STRING):
         return tokenizer.next().text
     if (
@@ -736,7 +746,7 @@ def _parse_descriptor_attr_value_from_tokens(
             return int(tokenizer.expect(TokenKind.INTEGER).text)
         case "f64":
             if tokenizer.at(TokenKind.FLOAT):
-                return float(tokenizer.next().text)
+                return _parse_float_literal(tokenizer.next().text)
             if tokenizer.at(TokenKind.BARE_IDENT):
                 special_float = _parse_special_float(tokenizer.peek().text)
                 if special_float is not None:

--- a/loom/py/loom/format/text/parser_test.py
+++ b/loom/py/loom/format/text/parser_test.py
@@ -897,6 +897,61 @@ class TestParseConstantOp:
         op = _parse_op("%pi = test.constant 3.14 : f32")
         assert abs(op.attributes["value"] - 3.14) < 1e-10
 
+    def test_hexadecimal_float_cross_format_roundtrip(self) -> None:
+        source = """test.func @hexadecimal_float_constants() {
+  %f16 = test.constant 0x1.ffcp+15 : f16
+  %f16_min = test.constant 0x1p-14 : f16
+  %bf16 = test.constant 0x1.fep+127 : bf16
+  %f32 = test.constant 0x1.fffffep+127 : f32
+  %f64 = test.constant 0x1.fffffffffffffp+1023 : f64
+  %f64_min = test.constant 0x0.0000000000001p-1022 : f64
+  %negative_f64 = test.constant -0x1.fffffffffffffp+1023 : f64
+  %overflow = test.constant 0x1p+999999 : f64
+  %negative_overflow = test.constant -0x1p+999999 : f64
+  %underflow = test.constant 0x1p-999999 : f64
+  %negative_underflow = test.constant -0x1p-999999 : f64
+  test.yield
+}
+"""
+        module = _op_parser().parse(source)
+        function = module.symbols[0].op
+        assert function is not None
+        constants = function.regions[0].blocks[0].ops[:-1]
+        assert [op.attributes["value"] for op in constants] == [
+            65504.0,
+            6.103515625e-05,
+            3.3895313892515355e38,
+            3.4028234663852886e38,
+            1.7976931348623157e308,
+            5e-324,
+            -1.7976931348623157e308,
+            math.inf,
+            -math.inf,
+            0.0,
+            -0.0,
+        ]
+
+        canonical = _op_printer().print_module(module)
+        assert "0x" not in canonical
+        for expected in (
+            "%f16 = test.constant 65504.0 : f16",
+            "%f16_min = test.constant 6.103515625e-05 : f16",
+            "%bf16 = test.constant 3.3895313892515355e+38 : bf16",
+            "%f32 = test.constant 3.4028234663852886e+38 : f32",
+            "%f64 = test.constant 1.7976931348623157e+308 : f64",
+            "%f64_min = test.constant 4.9406564584124654e-324 : f64",
+            "%negative_f64 = test.constant -1.7976931348623157e+308 : f64",
+            "%overflow = test.constant inf : f64",
+            "%negative_overflow = test.constant -inf : f64",
+            "%underflow = test.constant 0.0 : f64",
+            "%negative_underflow = test.constant -0.0 : f64",
+        ):
+            assert expected in canonical
+        reparsed = _op_parser().parse(canonical)
+        assert _op_printer().print_module(reparsed) == canonical
+        loaded = read_module(write_module(module))
+        assert _op_printer().print_module(loaded) == canonical
+
     def test_special_float_values(self) -> None:
         nan_op = _parse_op("%nan = test.constant nan : f32")
         assert math.isnan(nan_op.attributes["value"])

--- a/loom/py/loom/format/text/tokenizer.py
+++ b/loom/py/loom/format/text/tokenizer.py
@@ -726,8 +726,9 @@ class Tokenizer:
         if is_negative:
             self._advance()
 
-        # Hex integer: 0x... (but not when in_dim_list — 'x' is a
-        # dimension separator, so '0' is a static dim of size 0).
+        # Hexadecimal integer or C99 hexadecimal float (but not when
+        # in_dim_list — 'x' is a dimension separator, so '0' is a static dim
+        # of size 0).
         if (
             self._char() == "0"
             and self._peek_char() in ("x", "X")
@@ -735,14 +736,46 @@ class Tokenizer:
         ):
             self._advance()  # 0
             self._advance()  # x
-            if self._char() not in "0123456789abcdefABCDEF":
-                raise ParseError(
-                    "expected hex digits after '0x'", location, self._filename
-                )
-            while self._char() in "0123456789abcdefABCDEF":
+            hex_digits = "0123456789abcdefABCDEF"
+            has_significand_digit = False
+            while self._char() in hex_digits:
+                has_significand_digit = True
                 self._advance()
+
+            has_radix_point = self._char() == "."
+            if has_radix_point:
+                self._advance()
+                while self._char() in hex_digits:
+                    has_significand_digit = True
+                    self._advance()
+
+            has_binary_exponent = self._char() in ("p", "P")
+            has_exponent_digit = False
+            if has_binary_exponent:
+                self._advance()
+                if self._char() in ("+", "-"):
+                    self._advance()
+                while self._char().isdigit():
+                    has_exponent_digit = True
+                    self._advance()
+
             text = self._source[start : self._position]
-            return self._make_token(TokenKind.INTEGER, text, location)
+            is_float = has_radix_point or has_binary_exponent
+            if not has_significand_digit:
+                literal_kind = "float" if is_float else "integer"
+                raise ParseError(
+                    f"invalid {literal_kind} literal '{text}'",
+                    location,
+                    self._filename,
+                )
+            if (has_radix_point and not has_binary_exponent) or (
+                has_binary_exponent and not has_exponent_digit
+            ):
+                raise ParseError(
+                    f"invalid float literal '{text}'", location, self._filename
+                )
+            kind = TokenKind.FLOAT if has_binary_exponent else TokenKind.INTEGER
+            return self._make_token(kind, text, location)
 
         # Decimal digits.
         while self._char().isdigit():
@@ -762,8 +795,9 @@ class Tokenizer:
             if self._char() in ("+", "-"):
                 self._advance()
             if not self._char().isdigit():
+                text = self._source[start : self._position]
                 raise ParseError(
-                    "expected digits in exponent", location, self._filename
+                    f"invalid float literal '{text}'", location, self._filename
                 )
             while self._char().isdigit():
                 self._advance()

--- a/loom/py/loom/format/text/tokenizer_test.py
+++ b/loom/py/loom/format/text/tokenizer_test.py
@@ -132,6 +132,10 @@ class TestInteger:
     def test_negative_hex(self) -> None:
         assert _texts("-0x1A") == ["-0x1A"]
 
+    def test_uppercase_hex_prefix(self) -> None:
+        assert _texts("0XdeadBEEF") == ["0XdeadBEEF"]
+        assert _kinds("0XdeadBEEF") == [TokenKind.INTEGER]
+
 
 class TestFloat:
     def test_simple(self) -> None:
@@ -151,6 +155,33 @@ class TestFloat:
 
     def test_negative_exponent(self) -> None:
         assert _texts("2.5E+10") == ["2.5E+10"]
+
+    @pytest.mark.parametrize(
+        "spelling",
+        [
+            "0x1p0",
+            "0x1.p0",
+            "0x.8p+1",
+            "0X1.FP-4",
+            "-0x0p+0",
+            "0x1.fffffep+127",
+        ],
+    )
+    def test_hexadecimal(self, spelling: str) -> None:
+        assert _texts(spelling) == [spelling]
+        assert _kinds(spelling) == [TokenKind.FLOAT]
+
+    @pytest.mark.parametrize(
+        "spelling",
+        ["0x.", "0x.p0", "0x1.", "0x1.2", "0x1p", "0x1p+", "1e", "1e-"],
+    )
+    def test_malformed(self, spelling: str) -> None:
+        with pytest.raises(ParseError, match="invalid float literal"):
+            _tokens(spelling)
+
+    def test_missing_hex_digits(self) -> None:
+        with pytest.raises(ParseError, match="invalid integer literal"):
+            _tokens("0x")
 
 
 class TestString:

--- a/loom/src/loom/format/text/parser/parser_test.cc
+++ b/loom/src/loom/format/text/parser/parser_test.cc
@@ -6,6 +6,7 @@
 
 #include "loom/format/text/parser/parser.h"
 
+#include <cmath>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -735,6 +736,65 @@ TEST_F(ParserTest, ConstantNegative) {
 TEST_F(ParserTest, ConstantZero) {
   std::string text = RoundTrip("%c = test.constant 0 : index\n");
   EXPECT_NE(text.find("test.constant 0 : index"), std::string::npos);
+}
+
+TEST_F(ParserTest, HexadecimalFloatConstantsRoundTripCanonically) {
+  const char* source =
+      "%f16 = test.constant 0x1.ffcp+15 : f16\n"
+      "%f16_min = test.constant 0x1p-14 : f16\n"
+      "%bf16 = test.constant 0x1.fep+127 : bf16\n"
+      "%f32 = test.constant 0x1.fffffep+127 : f32\n"
+      "%f64 = test.constant 0x1.fffffffffffffp+1023 : f64\n"
+      "%f64_min = test.constant 0x0.0000000000001p-1022 : f64\n"
+      "%negative_f64 = test.constant -0x1.fffffffffffffp+1023 : f64\n"
+      "%overflow = test.constant 0x1p+999999 : f64\n"
+      "%negative_overflow = test.constant -0x1p+999999 : f64\n"
+      "%underflow = test.constant 0x1p-999999 : f64\n"
+      "%negative_underflow = test.constant -0x1p-999999 : f64\n";
+  std::string text = RoundTrip(source);
+  EXPECT_EQ(text.find("0x"), std::string::npos);
+  for (const char* expected : {
+           "%f16 = test.constant 65504.0 : f16",
+           "%f16_min = test.constant 6.103515625e-05 : f16",
+           "%bf16 = test.constant 3.3895313892515355e+38 : bf16",
+           "%f32 = test.constant 3.4028234663852886e+38 : f32",
+           "%f64 = test.constant 1.7976931348623157e+308 : f64",
+           "%f64_min = test.constant 4.9406564584124654e-324 : f64",
+           "%negative_f64 = test.constant -1.7976931348623157e+308 : f64",
+           "%overflow = test.constant inf : f64",
+           "%negative_overflow = test.constant -inf : f64",
+           "%underflow = test.constant 0.0 : f64",
+           "%negative_underflow = test.constant -0.0 : f64",
+       }) {
+    EXPECT_NE(text.find(expected), std::string::npos) << expected;
+  }
+
+  loom_module_t* module = ParseOk(text.c_str());
+  if (!module) return;
+  loom_block_t* body = loom_module_block(module);
+  ASSERT_NE(body, nullptr);
+  ASSERT_EQ(body->op_count, 11u);
+  const double expected_values[] = {
+      0x1.ffcp+15,
+      0x1p-14,
+      0x1.fep+127,
+      0x1.fffffep+127,
+      0x1.fffffffffffffp+1023,
+      0x0.0000000000001p-1022,
+      -0x1.fffffffffffffp+1023,
+      INFINITY,
+      -INFINITY,
+      0.0,
+      -0.0,
+  };
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(expected_values); ++i) {
+    loom_op_t* op = loom_block_op(body, i);
+    ASSERT_NE(op, nullptr);
+    loom_attribute_t value = loom_test_constant_value(op);
+    ASSERT_EQ(value.kind, LOOM_ATTR_F64);
+    EXPECT_EQ(loom_attr_as_f64(value), expected_values[i]);
+  }
+  loom_module_free(module);
 }
 
 TEST_F(ParserTest, FunctionTypeConstantSupportsThousandArgsAndResults) {

--- a/loom/src/loom/format/text/tokenizer.c
+++ b/loom/src/loom/format/text/tokenizer.c
@@ -731,8 +731,24 @@ static iree_status_t loom_tokenizer_scan_string(loom_tokenizer_t* t,
   return iree_ok_status();
 }
 
+static iree_status_t loom_tokenizer_set_number_error(
+    loom_tokenizer_t* t, const loom_error_def_t* error, iree_host_size_t start,
+    uint32_t start_line, uint32_t start_column, loom_token_t* out_token) {
+  iree_string_view_t text =
+      iree_make_string_view(t->source.data + start, t->position - start);
+  loom_diagnostic_param_t params[] = {
+      loom_param_string(text),
+  };
+  IREE_RETURN_IF_ERROR(
+      loom_tokenizer_set_current_error(t, error, params, IREE_ARRAYSIZE(params),
+                                       start, start_line, start_column));
+  *out_token = loom_tokenizer_make_error_token(t);
+  return iree_ok_status();
+}
+
 // Scans a number (integer or float). Position is at the first digit or '-'.
-static loom_token_t loom_tokenizer_scan_number(loom_tokenizer_t* t) {
+static iree_status_t loom_tokenizer_scan_number(loom_tokenizer_t* t,
+                                                loom_token_t* out_token) {
   uint32_t start_line = t->line;
   uint32_t start_column = t->column;
   iree_host_size_t start = t->position;
@@ -743,18 +759,69 @@ static loom_token_t loom_tokenizer_scan_number(loom_tokenizer_t* t) {
     ++t->column;
   }
 
-  // Check for hex: 0x... (but not when in_dim_list — 'x' is a
-  // dimension separator, so '0' is a static dim of size 0).
-  if (loom_tokenizer_char(t) == '0' && loom_tokenizer_char_at(t, 1) == 'x' &&
+  // Check for hexadecimal integers and C99 hexadecimal floats (but not when
+  // in_dim_list — 'x' is a dimension separator, so '0' is a static dim of
+  // size 0).
+  char radix = loom_tokenizer_char_at(t, 1);
+  if (loom_tokenizer_char(t) == '0' && (radix == 'x' || radix == 'X') &&
       !t->in_dim_list) {
     t->position += 2;
     t->column += 2;
+
+    bool has_significand_digit = false;
     while (loom_is_hex_digit(loom_tokenizer_char(t))) {
+      has_significand_digit = true;
       ++t->position;
       ++t->column;
     }
-    return loom_tokenizer_make_verbatim_token(t, LOOM_TOKEN_INTEGER, start,
-                                              start_line, start_column);
+
+    bool has_radix_point = false;
+    if (loom_tokenizer_char(t) == '.') {
+      has_radix_point = true;
+      ++t->position;
+      ++t->column;
+      while (loom_is_hex_digit(loom_tokenizer_char(t))) {
+        has_significand_digit = true;
+        ++t->position;
+        ++t->column;
+      }
+    }
+
+    bool has_binary_exponent = false;
+    bool has_exponent_digit = false;
+    char exponent = loom_tokenizer_char(t);
+    if (exponent == 'p' || exponent == 'P') {
+      has_binary_exponent = true;
+      ++t->position;
+      ++t->column;
+      char sign = loom_tokenizer_char(t);
+      if (sign == '+' || sign == '-') {
+        ++t->position;
+        ++t->column;
+      }
+      while (loom_is_digit(loom_tokenizer_char(t))) {
+        has_exponent_digit = true;
+        ++t->position;
+        ++t->column;
+      }
+    }
+
+    bool is_float = has_radix_point || has_binary_exponent;
+    if (!has_significand_digit) {
+      return loom_tokenizer_set_number_error(
+          t, is_float ? LOOM_ERR_PARSE_016 : LOOM_ERR_PARSE_015, start,
+          start_line, start_column, out_token);
+    }
+    if ((has_radix_point && !has_binary_exponent) ||
+        (has_binary_exponent && !has_exponent_digit)) {
+      return loom_tokenizer_set_number_error(
+          t, LOOM_ERR_PARSE_016, start, start_line, start_column, out_token);
+    }
+
+    *out_token = loom_tokenizer_make_verbatim_token(
+        t, has_binary_exponent ? LOOM_TOKEN_FLOAT : LOOM_TOKEN_INTEGER, start,
+        start_line, start_column);
+    return iree_ok_status();
   }
 
   // Decimal digits.
@@ -788,15 +855,20 @@ static loom_token_t loom_tokenizer_scan_number(loom_tokenizer_t* t) {
       ++t->position;
       ++t->column;
     }
+    if (!loom_is_digit(loom_tokenizer_char(t))) {
+      return loom_tokenizer_set_number_error(
+          t, LOOM_ERR_PARSE_016, start, start_line, start_column, out_token);
+    }
     while (loom_is_digit(loom_tokenizer_char(t))) {
       ++t->position;
       ++t->column;
     }
   }
 
-  return loom_tokenizer_make_verbatim_token(
+  *out_token = loom_tokenizer_make_verbatim_token(
       t, is_float ? LOOM_TOKEN_FLOAT : LOOM_TOKEN_INTEGER, start, start_line,
       start_column);
+  return iree_ok_status();
 }
 
 // Scans an identifier or op name. Position is at the first ident char.
@@ -1076,8 +1148,7 @@ static iree_status_t loom_tokenizer_scan(loom_tokenizer_t* t,
 
   // Negative number: '-' followed by digit.
   if (c == '-' && loom_is_digit(loom_tokenizer_char_at(t, 1))) {
-    *out_token = loom_tokenizer_scan_number(t);
-    return iree_ok_status();
+    return loom_tokenizer_scan_number(t, out_token);
   }
 
   if (loom_tokenizer_has_delimited_prefix(t, IREE_SV("-inf")) ||
@@ -1092,8 +1163,7 @@ static iree_status_t loom_tokenizer_scan(loom_tokenizer_t* t,
 
   // Number.
   if (loom_is_digit(c)) {
-    *out_token = loom_tokenizer_scan_number(t);
-    return iree_ok_status();
+    return loom_tokenizer_scan_number(t, out_token);
   }
 
   // String literal.

--- a/loom/src/loom/format/text/tokenizer_test.cc
+++ b/loom/src/loom/format/text/tokenizer_test.cc
@@ -157,11 +157,17 @@ TEST(Tokenizer, NegativeInteger) {
 }
 
 TEST(Tokenizer, HexInteger) {
-  ScopedTokenizer t("0xFF");
-  loom_token_t token = t.next();
-  EXPECT_EQ(token.kind, LOOM_TOKEN_INTEGER);
-  EXPECT_TRUE(iree_string_view_equal(token.text, IREE_SV("0xFF")));
-  EXPECT_TRUE(iree_string_view_equal(token.source_text, IREE_SV("0xFF")));
+  for (const char* spelling : {"0xFF", "0XdeadBEEF", "-0x1A"}) {
+    SCOPED_TRACE(spelling);
+    ScopedTokenizer t(spelling);
+    loom_token_t token = t.next();
+    EXPECT_EQ(token.kind, LOOM_TOKEN_INTEGER);
+    EXPECT_TRUE(
+        iree_string_view_equal(token.text, iree_make_cstring_view(spelling)));
+    EXPECT_TRUE(iree_string_view_equal(token.source_text,
+                                       iree_make_cstring_view(spelling)));
+    EXPECT_EQ(t.next().kind, LOOM_TOKEN_EOF);
+  }
 }
 
 TEST(Tokenizer, Float) {
@@ -184,6 +190,45 @@ TEST(Tokenizer, NegativeFloat) {
   loom_token_t token = t.next();
   EXPECT_EQ(token.kind, LOOM_TOKEN_FLOAT);
   EXPECT_TRUE(iree_string_view_equal(token.text, IREE_SV("-0.5")));
+}
+
+TEST(Tokenizer, HexadecimalFloat) {
+  for (const char* spelling : {"0x1p0", "0x1.p0", "0x.8p+1", "0X1.FP-4",
+                               "-0x0p+0", "0x1.fffffep+127"}) {
+    SCOPED_TRACE(spelling);
+    ScopedTokenizer t(spelling);
+    loom_token_t token = t.next();
+    EXPECT_EQ(token.kind, LOOM_TOKEN_FLOAT);
+    EXPECT_TRUE(
+        iree_string_view_equal(token.text, iree_make_cstring_view(spelling)));
+    EXPECT_TRUE(iree_string_view_equal(token.source_text,
+                                       iree_make_cstring_view(spelling)));
+    EXPECT_EQ(t.next().kind, LOOM_TOKEN_EOF);
+    ExpectNoInfrastructureStatus(t.get());
+  }
+}
+
+TEST(Tokenizer, MalformedNumber) {
+  struct TestCase {
+    const char* spelling;
+    uint16_t error_code;
+  };
+  const TestCase test_cases[] = {
+      {"0x", 15},   {"0x.", 16},   {"0x.p0", 16}, {"0x1.", 16}, {"0x1.2", 16},
+      {"0x1p", 16}, {"0x1p+", 16}, {"1e", 16},    {"1e-", 16},
+  };
+  for (const TestCase& test_case : test_cases) {
+    SCOPED_TRACE(test_case.spelling);
+    ScopedTokenizer t(test_case.spelling);
+    iree_string_view_t spelling = iree_make_cstring_view(test_case.spelling);
+    ExpectNextErrorToken(
+        t.get(),
+        loom_error_def_lookup(LOOM_ERROR_DOMAIN_PARSE, test_case.error_code),
+        spelling, 1, 1, (uint32_t)spelling.size + 1);
+    ExpectErrorStringParam(t.get()->error, 0, spelling);
+    EXPECT_EQ(t.next().kind, LOOM_TOKEN_EOF);
+    ExpectNoInfrastructureStatus(t.get());
+  }
 }
 
 TEST(Tokenizer, NegativeSpecialFloat) {

--- a/loom/src/loom/ops/scalar/test/facts/arithmeticf.loom-test
+++ b/loom/src/loom/ops/scalar/test/facts/arithmeticf.loom-test
@@ -97,6 +97,32 @@ func.def @rounds_each_instruction() -> (f32, f64) {
 
 // ====
 
+// Hexadecimal attributes retain their exact binary64 payload in the IR while
+// constant semantics round that payload to the declared result type. Each
+// narrow input is exactly halfway between 1.0 and the next representable value
+// and therefore rounds to the even 1.0 encoding.
+func.def @hexadecimal_constants_round_to_declared_type() -> (i16, i16, i32, i64) {
+  %f16 = scalar.constant 0x1.002p0 : f16
+  %f16_bits = scalar.bitcast %f16 : f16 to i16
+  %bf16 = scalar.constant 0x1.01p0 : bf16
+  %bf16_bits = scalar.bitcast %bf16 : bf16 to i16
+  %f32 = scalar.constant 0x1.000001p0 : f32
+  %f32_bits = scalar.bitcast %f32 : f32 to i32
+  %f64 = scalar.constant 0x1.0000000000001p0 : f64
+  %f64_bits = scalar.bitcast %f64 : f64 to i64
+  func.return %f16_bits, %bf16_bits, %f32_bits, %f64_bits : i16, i16, i32, i64
+}
+// ----
+func.def @hexadecimal_constants_round_to_declared_type() -> (i16, i16, i32, i64) {
+  %f16_bits = scalar.constant 15360 : i16
+  %bf16_bits = scalar.constant 16256 : i16
+  %f32_bits = scalar.constant 1065353216 : i32
+  %f64_bits = scalar.constant 4607182418800017409 : i64
+  func.return %f16_bits, %bf16_bits, %f32_bits, %f64_bits : i16, i16, i32, i64
+}
+
+// ====
+
 // IEEE minimum and maximum choose opposite signed zeros.
 func.def @minmax_preserve_signed_zero_semantics() -> (i32, i32) {
   %positive_signed_zero = scalar.constant 0.0 : f32

--- a/runtime/src/iree/base/printf.c
+++ b/runtime/src/iree/base/printf.c
@@ -41,7 +41,7 @@
 //===----------------------------------------------------------------------===//
 // Portable math (no libm dependency)
 //===----------------------------------------------------------------------===//
-// Provides fma, fmod, floor, and modf equivalents without requiring -lm.
+// Provides FMA error tracking and a modf equivalent without requiring -lm.
 // Uses hardware FMA when the compilation target has it (single instruction,
 // no function call); falls back to the Dekker two-product algorithm otherwise.
 
@@ -87,19 +87,6 @@ static inline double iree_printf_mul_error(double a, double b, double product) {
 #endif  // FMA
 }
 
-// Portable floor: returns the largest integer <= x.
-// Only called on positive, finite values in our formatting paths.
-static inline double iree_printf_floor(double x) {
-  // Doubles >= 2^52 in magnitude are always integers (the significand cannot
-  // represent a fractional part at that scale).
-  if (x >= 4503599627370496.0) return x;
-  if (x <= -4503599627370496.0) return x;
-  double truncated = (double)(int64_t)x;
-  // C truncation rounds toward zero; floor rounds toward -infinity.
-  if (truncated > x) truncated -= 1.0;
-  return truncated;
-}
-
 // Portable modf: split value into integral and fractional parts.
 // Only called on positive, finite values in our formatting paths.
 static inline double iree_printf_modf(double value, double* integral_part) {
@@ -110,14 +97,6 @@ static inline double iree_printf_modf(double value, double* integral_part) {
   double truncated = (double)(int64_t)value;
   *integral_part = truncated;
   return value - truncated;
-}
-
-// Check if an integer-valued double is odd. Used for banker's rounding.
-// Doubles >= 2^53 in magnitude always represent even integers (the lowest
-// bit of the significand corresponds to 2 or more at that scale).
-static inline bool iree_printf_is_odd(double x) {
-  if (x >= 9007199254740992.0 || x <= -9007199254740992.0) return false;
-  return ((int64_t)x) & 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -673,10 +652,11 @@ static void iree_printf_format_pointer(iree_printf_output_t* out,
 // Precision: we do NOT need shortest-round-trip representation (Grisu/Ryu).
 // We need correctness to the displayed precision with correct rounding.
 //
-// Approach: IEEE 754 bit extraction for sign/special values, then arithmetic
-// decomposition into integral + fractional parts using int64_t digit
-// extraction. This is accurate to 17 significant digits (full double
-// precision). Precision is capped at 17; beyond that we pad with zeros.
+// Approach: IEEE 754 bit extraction for sign/special values. Exponential
+// formatting converts the exact binary coefficient to decimal integer limbs;
+// fixed formatting decomposes integral and fractional parts arithmetically.
+// Both are accurate to 17 significant digits (full double precision).
+// Precision is capped at 17; beyond that we pad with zeros.
 
 // Maximum precision we compute accurately. Beyond this, we emit zeros.
 // 17 significant digits covers the full precision of IEEE 754 double.
@@ -698,6 +678,157 @@ typedef union {
   double value;
   uint64_t bits;
 } iree_printf_double_bits_t;
+
+// Base-10 big integer used only while extracting exact floating-point digits.
+// The largest coefficient is (2^53-1)*5^1074, which has 767 decimal digits
+// and therefore fits in 86 base-1e9 limbs.
+#define IREE_PRINTF_BIGINT_BASE UINT32_C(1000000000)
+#define IREE_PRINTF_BIGINT_MAX_LIMBS 86
+typedef struct iree_printf_bigint_t {
+  uint32_t limbs[IREE_PRINTF_BIGINT_MAX_LIMBS];
+  int limb_count;
+} iree_printf_bigint_t;
+
+typedef struct iree_printf_decimal_digits_t {
+  uint64_t significand;
+  int exponent;
+} iree_printf_decimal_digits_t;
+
+static void iree_printf_bigint_initialize(uint64_t value,
+                                          iree_printf_bigint_t* out_value) {
+  memset(out_value, 0, sizeof(*out_value));
+  do {
+    out_value->limbs[out_value->limb_count++] =
+        (uint32_t)(value % IREE_PRINTF_BIGINT_BASE);
+    value /= IREE_PRINTF_BIGINT_BASE;
+  } while (value != 0);
+}
+
+static void iree_printf_bigint_multiply_small(iree_printf_bigint_t* value,
+                                              uint32_t multiplier) {
+  uint64_t carry = 0;
+  for (int i = 0; i < value->limb_count; ++i) {
+    const uint64_t product = (uint64_t)value->limbs[i] * multiplier + carry;
+    value->limbs[i] = (uint32_t)(product % IREE_PRINTF_BIGINT_BASE);
+    carry = product / IREE_PRINTF_BIGINT_BASE;
+  }
+  if (carry != 0) {
+    value->limbs[value->limb_count++] = (uint32_t)carry;
+  }
+}
+
+static uint32_t iree_printf_bigint_divide_by_10(iree_printf_bigint_t* value) {
+  uint64_t remainder = 0;
+  for (int i = value->limb_count - 1; i >= 0; --i) {
+    const uint64_t dividend =
+        remainder * IREE_PRINTF_BIGINT_BASE + value->limbs[i];
+    value->limbs[i] = (uint32_t)(dividend / 10);
+    remainder = dividend % 10;
+  }
+  while (value->limb_count > 1 && value->limbs[value->limb_count - 1] == 0) {
+    --value->limb_count;
+  }
+  return (uint32_t)remainder;
+}
+
+static int iree_printf_bigint_decimal_digit_count(
+    const iree_printf_bigint_t* value) {
+  uint32_t leading_limb = value->limbs[value->limb_count - 1];
+  int leading_digit_count = 1;
+  while (leading_limb >= 10) {
+    leading_limb /= 10;
+    ++leading_digit_count;
+  }
+  return (value->limb_count - 1) * 9 + leading_digit_count;
+}
+
+static uint64_t iree_printf_bigint_to_u64(const iree_printf_bigint_t* value) {
+  uint64_t result = 0;
+  for (int i = value->limb_count - 1; i >= 0; --i) {
+    result = result * IREE_PRINTF_BIGINT_BASE + value->limbs[i];
+  }
+  return result;
+}
+
+// Extracts |significant_digit_count| correctly-rounded decimal digits and the
+// base-10 exponent for a positive finite binary64 value. The binary value is
+// converted to an exact integer coefficient times a decimal power, then
+// rounded to nearest-even using the discarded decimal digits. This keeps
+// serialization-grade precision independent of libc and target floating-point
+// scaling behavior.
+static iree_printf_decimal_digits_t iree_printf_extract_significant_digits(
+    double value, int significant_digit_count) {
+  iree_printf_double_bits_t representation = {.value = value};
+  const int exponent_bits = (int)((representation.bits >> 52) & 0x7FF);
+  uint64_t coefficient = representation.bits & UINT64_C(0x000FFFFFFFFFFFFF);
+  int binary_exponent = -1074;
+  if (exponent_bits != 0) {
+    coefficient |= UINT64_C(1) << 52;
+    binary_exponent = exponent_bits - 1023 - 52;
+  }
+
+  // Remove powers of two from the coefficient before constructing the exact
+  // decimal form. This reduces DBL_MIN from 1074 multiplications by five to
+  // 1022 and makes exact powers of two particularly cheap.
+  while ((coefficient & 1) == 0) {
+    coefficient >>= 1;
+    ++binary_exponent;
+  }
+
+  iree_printf_bigint_t decimal_coefficient;
+  iree_printf_bigint_initialize(coefficient, &decimal_coefficient);
+  int decimal_scale = 0;
+  if (binary_exponent >= 0) {
+    for (int i = 0; i < binary_exponent; ++i) {
+      iree_printf_bigint_multiply_small(&decimal_coefficient, 2);
+    }
+  } else {
+    decimal_scale = -binary_exponent;
+    for (int i = 0; i < decimal_scale; ++i) {
+      iree_printf_bigint_multiply_small(&decimal_coefficient, 5);
+    }
+  }
+
+  iree_printf_decimal_digits_t result = {0};
+  const int decimal_digit_count =
+      iree_printf_bigint_decimal_digit_count(&decimal_coefficient);
+  result.exponent = decimal_digit_count - decimal_scale - 1;
+  const int discarded_digit_count =
+      decimal_digit_count - significant_digit_count;
+  bool sticky = false;
+  uint32_t round_digit = 0;
+  if (discarded_digit_count > 0) {
+    for (int i = 0; i < discarded_digit_count; ++i) {
+      const uint32_t discarded_digit =
+          iree_printf_bigint_divide_by_10(&decimal_coefficient);
+      if (i + 1 == discarded_digit_count) {
+        round_digit = discarded_digit;
+      } else {
+        sticky |= discarded_digit != 0;
+      }
+    }
+  }
+
+  uint64_t significand = iree_printf_bigint_to_u64(&decimal_coefficient);
+  for (int i = discarded_digit_count; i < 0; ++i) {
+    significand *= 10;
+  }
+  if (round_digit > 5 ||
+      (round_digit == 5 && (sticky || (significand & 1) != 0))) {
+    ++significand;
+  }
+
+  uint64_t significand_limit = 1;
+  for (int i = 0; i < significant_digit_count; ++i) {
+    significand_limit *= 10;
+  }
+  if (significand == significand_limit) {
+    significand /= 10;
+    ++result.exponent;
+  }
+  result.significand = significand;
+  return result;
+}
 
 static inline bool iree_printf_double_is_negative(double value) {
   iree_printf_double_bits_t u = {0};
@@ -805,49 +936,6 @@ static double iree_printf_pow10(int n) {
     }
   }
   return result;
-}
-
-// Compute value * 10^n with FMA-corrected error tracking (double-double).
-// Stores the high part in *out_result and returns the low part (error term),
-// such that *out_result + return_value = value * 10^n to extended precision.
-//
-// For n <= 22, pow10(n) is exactly representable as a double, so a single FMA
-// gives the exact error of the multiplication.
-//
-// For 22 < n <= 44, the multiplication is split into two exact steps:
-//   value * 10^n = (value * 10^22) * 10^(n-22)
-// Both 10^22 and 10^(n-22) are exactly representable (both <= 10^22). FMA
-// error terms from each step are combined for double-double precision.
-//
-// For n > 44, falls back to single-step with inexact pow10 (best-effort).
-static double iree_printf_mul_pow10_error(double value, int n,
-                                          double* out_result) {
-  if (n <= 22) {
-    double scale = iree_printf_pow10(n);
-    *out_result = value * scale;
-    return iree_printf_mul_error(value, scale, *out_result);
-  } else if (n <= 44) {
-    // Split 10^n = 10^22 * 10^(n-22) where both factors are exact doubles.
-    double scale_first = iree_printf_pow10(22);
-    double scale_second = iree_printf_pow10(n - 22);
-    // Step 1: value * 10^22 with error tracking.
-    double partial = value * scale_first;
-    double error_first = iree_printf_mul_error(value, scale_first, partial);
-    // Step 2: partial * 10^(n-22) with error tracking.
-    *out_result = partial * scale_second;
-    double error_second =
-        iree_printf_mul_error(partial, scale_second, *out_result);
-    // Combined error: the second step's error plus the first step's error
-    // propagated through the second multiplication.
-    return error_second + error_first * scale_second;
-  } else {
-    // n > 44: pow10(n) is not exactly representable, so error correction
-    // handles only the multiplication rounding, not the scale factor.
-    // Best-effort.
-    double scale = iree_printf_pow10(n);
-    *out_result = value * scale;
-    return iree_printf_mul_error(value, scale, *out_result);
-  }
 }
 
 // Format a non-negative, finite double in %f style (fixed-point notation).
@@ -1028,13 +1116,9 @@ static int iree_printf_format_fixed(char* buffer, double value, int precision,
 // buffer[mantissa_end..end] (the exponent suffix). The split point is stored
 // in |*out_exponent_offset|.
 //
-// Approach: compute all significant digits at once as a single integer via a
-// single division, rather than normalizing to [1,10) and routing through the
-// fixed-point formatter. The normalize → modf → multiply chain amplifies
-// representation error at rounding boundaries (e.g., 575537150/1e8 produces
-// 5.75537149999... instead of 5.7553715, flipping a banker's rounding
-// decision). By dividing by 10^(exponent - precision) instead, we keep the
-// full precision of the original value in a single operation.
+// The significant digits come from the exact binary64-to-decimal coefficient
+// above. Keeping digit extraction in integer arithmetic avoids normalization
+// error at rounding boundaries and remains exact at DBL_MAX and subnormals.
 static int iree_printf_format_exponential(
     char* buffer, double value, int precision, bool force_decimal_point,
     bool uppercase, int* out_trailing_zeros, int* out_exponent_offset) {
@@ -1064,281 +1148,18 @@ static int iree_printf_format_exponential(
     return position;
   }
 
-  // Compute the base-10 exponent.
-  int exponent = iree_printf_log10_approx(value);
-
   // We need (precision + 1) significant digits total: 1 before the decimal
-  // point and |precision| after. Clamp to our computational limit.
-  int sig_count = precision + 1;
-  int effective_sig_count = sig_count;
+  // point and |precision| after. Clamp to the full binary64 precision; larger
+  // requested precisions are emitted as trailing zeros.
+  int effective_sig_count = precision + 1;
   if (effective_sig_count > IREE_PRINTF_MAX_FLOAT_PRECISION) {
     effective_sig_count = IREE_PRINTF_MAX_FLOAT_PRECISION;
   }
 
-  // Scale the value so that its significant digits are an integer with
-  // exactly |effective_sig_count| digits: scaled ≈ value * 10^n where n is
-  // chosen to shift the significant digits above the decimal point.
-  //
-  // For normal doubles (exponents roughly -290 to +290), we do this in a
-  // single division/multiplication by 10^|scale_exponent|, which preserves
-  // full precision. For extreme exponents (subnormals, huge values near
-  // DBL_MAX), the scale factor itself would overflow double range, so we
-  // normalize in steps: first bring the value to [1, 10), then scale the
-  // normalized value by 10^(sig_count - 1).
-  uint64_t sig_max = (uint64_t)iree_printf_pow10(effective_sig_count);
-  uint64_t sig_min = sig_max / 10;
-  int scale_exponent = exponent - effective_sig_count + 1;
-  double scaled = 0.0;
-
-  if (scale_exponent > 290 || scale_exponent < -290) {
-    // Extreme exponent: normalize to [1, 10) in steps of at most 10^22
-    // (the largest power of 10 exactly representable as a double), then
-    // extract digits from the normalized value. This is slightly less
-    // precise than the single-step approach but doubles only have ~15.9
-    // decimal digits of precision anyway — the last 1-2 digits of a
-    // subnormal or extreme value are noise regardless.
-    double normalized = value;
-    int remaining = exponent;
-    if (remaining > 0) {
-      while (remaining > 22) {
-        normalized /= 1e22;
-        remaining -= 22;
-      }
-      normalized /= iree_printf_pow10(remaining);
-    } else if (remaining < 0) {
-      remaining = -remaining;
-      while (remaining > 22) {
-        normalized *= 1e22;
-        remaining -= 22;
-      }
-      normalized *= iree_printf_pow10(remaining);
-    }
-    // Correct for approximation errors.
-    while (normalized >= 10.0) {
-      normalized /= 10.0;
-      exponent++;
-    }
-    while (normalized < 1.0 && normalized > 0.0) {
-      normalized *= 10.0;
-      exponent--;
-    }
-    // Now normalized is in [1, 10). Scale to get sig_count digits.
-    scaled = normalized * iree_printf_pow10(effective_sig_count - 1);
-  } else {
-    // Normal case: single-step scaling preserves full precision.
-    if (scale_exponent >= 0) {
-      scaled = value / iree_printf_pow10(scale_exponent);
-    } else {
-      scaled = value * iree_printf_pow10(-scale_exponent);
-    }
-  }
-
-  // Round to nearest integer with banker's rounding (round-half-to-even).
-  //
-  // The naive approach (look at `scaled - floor(scaled)`) is unreliable
-  // because the division `value / 10^k` introduces up to 0.5 ULP error,
-  // which can turn a 0.4999... remainder into 0.5000..., flipping the
-  // rounding direction. This affects values larger than ~2^50 where the
-  // double division's rounding error is significant at the unit level.
-  //
-  // For the normal-range case (where we divided by 10^k), compute the exact
-  // remainder via double-double arithmetic: verify the truncated quotient
-  // with a double-double product, correct if the division rounded up, then
-  // use the double-double residual for the rounding decision.
-  uint64_t sig_integer = 0;
-  if (scale_exponent > 0 && scale_exponent <= 22) {
-    // Division path: scaled = value / 10^k where 10^k is exactly representable.
-    //
-    // For the truncated quotient (floor), use direct division and then verify
-    // with a double-double product. IEEE 754 correctly-rounded division can
-    // round the quotient up past an integer boundary when the true fractional
-    // part is close to 1.0 (specifically, when frac > 1.0 - 0.5*ULP at the
-    // quotient's magnitude). When this happens, (uint64_t)(value/divisor)
-    // gives Q+1 instead of Q. We detect and correct this by computing
-    // sig_integer * divisor as a double-double and checking if it exceeds
-    // value. After correction, the double-double residual gives the exact
-    // remainder for the rounding decision.
-    double divisor = iree_printf_pow10(scale_exponent);
-    double quotient = value / divisor;
-    sig_integer = (uint64_t)quotient;
-    // Verify the floor: double-double product sig_integer * divisor. If the
-    // product exceeds value, the division rounded up past the true floor.
-    double product_high = (double)sig_integer * divisor;
-    double product_low =
-        iree_printf_mul_error((double)sig_integer, divisor, product_high);
-    double residual = (value - product_high) - product_low;
-    if (residual < 0) {
-      // Division rounded up: true floor is sig_integer - 1. Adjust the
-      // remainder algebraically rather than recomputing via double-double
-      // (recomputing would require (double)sig_integer, which loses precision
-      // when sig_integer > 2^53).
-      sig_integer--;
-      residual += divisor;
-    }
-    double half = divisor * 0.5;
-    if (residual > half) {
-      sig_integer++;
-    } else if (residual == half) {
-      if (sig_integer & 1) sig_integer++;  // Banker's rounding.
-    }
-  } else if (scale_exponent < 0 && scale_exponent >= -290) {
-    // Multiplication path: scaled = value * 10^|n|. The multiplication can
-    // introduce rounding error from two sources: (1) the multiplication itself
-    // (up to 0.5 ULP), and (2) the pow10 scale factor being inexact for n > 22.
-    // Use iree_printf_mul_pow10_error to get a double-double result that
-    // corrects both sources (splitting into exact factors for 22 < n <= 44).
-    double mul_result = 0.0;
-    double mul_error =
-        iree_printf_mul_pow10_error(value, -scale_exponent, &mul_result);
-    sig_integer = (uint64_t)mul_result;
-    double sig_remainder = (mul_result - (double)sig_integer) + mul_error;
-    // The combined FMA error from the two-step multiplication can push the
-    // true remainder outside [0, 1). A negative remainder means the true
-    // product is below sig_integer; a remainder >= 1.0 means it is at least
-    // 1 above sig_integer. Normalize into [0, 1) before rounding.
-    while (sig_remainder >= 1.0) {
-      sig_integer++;
-      sig_remainder -= 1.0;
-    }
-    while (sig_remainder < 0.0) {
-      sig_integer--;
-      sig_remainder += 1.0;
-    }
-    if (sig_remainder > 0.5) {
-      sig_integer++;
-    } else if (sig_remainder == 0.5) {
-      if (sig_integer & 1) sig_integer++;
-    }
-  } else {
-    // Extreme exponents (multi-step normalization path): the value has been
-    // normalized through multiple divisions/multiplications, so FMA-based
-    // error correction isn't applicable. Direct rounding is sufficient since
-    // extreme-exponent values have inherently limited precision.
-    sig_integer = (uint64_t)scaled;
-    double sig_remainder = scaled - (double)sig_integer;
-    if (sig_remainder > 0.5) {
-      sig_integer++;
-    } else if (sig_remainder == 0.5) {
-      if (sig_integer & 1) sig_integer++;
-    }
-  }
-
-  // Handle exponent off by 1 in either direction. The log10 approximation can
-  // be off by 1, producing too many or too few digits. In either case,
-  // recompute with the corrected exponent so that rounding happens at the
-  // correct precision.
-  //
-  // This also handles carry from rounding (9999999.5 → 10000000): recomputing
-  // with exponent+1 gives the same correct result as truncation would, but
-  // without losing the rounding decision.
-  //
-  // For the recomputation we always use the single-step approach. The
-  // correction is at most ±1, so the new scale_exponent is within 1 of the
-  // old one — if the old one was in range, so is the new one. If we used the
-  // multi-step path (extreme exponent), the correction brings us back to the
-  // multi-step regime. To keep things simple, use the step-based normalization
-  // for recomputation when the new scale_exponent is extreme.
-  if (sig_integer >= sig_max || (sig_integer < sig_min && sig_integer > 0)) {
-    if (sig_integer >= sig_max) {
-      exponent++;
-    } else {
-      exponent--;
-    }
-    scale_exponent = exponent - effective_sig_count + 1;
-    if (scale_exponent > 290 || scale_exponent < -290) {
-      // Extreme: re-normalize in steps.
-      double normalized = value;
-      int remaining = exponent;
-      if (remaining > 0) {
-        while (remaining > 22) {
-          normalized /= 1e22;
-          remaining -= 22;
-        }
-        normalized /= iree_printf_pow10(remaining);
-      } else if (remaining < 0) {
-        remaining = -remaining;
-        while (remaining > 22) {
-          normalized *= 1e22;
-          remaining -= 22;
-        }
-        normalized *= iree_printf_pow10(remaining);
-      }
-      while (normalized >= 10.0) {
-        normalized /= 10.0;
-        exponent++;
-      }
-      while (normalized < 1.0 && normalized > 0.0) {
-        normalized *= 10.0;
-        exponent--;
-      }
-      scaled = normalized * iree_printf_pow10(effective_sig_count - 1);
-    } else {
-      if (scale_exponent >= 0) {
-        scaled = value / iree_printf_pow10(scale_exponent);
-      } else {
-        scaled = value * iree_printf_pow10(-scale_exponent);
-      }
-    }
-    sig_integer = (uint64_t)scaled;
-    // Use precise rounding for the recomputed value (same logic as above).
-    if (scale_exponent > 0 && scale_exponent <= 22) {
-      // Division path: direct quotient + double-double remainder rounding.
-      double divisor = iree_printf_pow10(scale_exponent);
-      double quotient = value / divisor;
-      sig_integer = (uint64_t)quotient;
-      double product_high = (double)sig_integer * divisor;
-      double product_low =
-          iree_printf_mul_error((double)sig_integer, divisor, product_high);
-      double residual = (value - product_high) - product_low;
-      if (residual < 0) {
-        // Same algebraic correction as the main division path above.
-        sig_integer--;
-        residual += divisor;
-      }
-      double half = divisor * 0.5;
-      if (residual > half) {
-        sig_integer++;
-      } else if (residual == half) {
-        if (sig_integer & 1) sig_integer++;
-      }
-    } else if (scale_exponent < 0 && scale_exponent >= -290) {
-      // Multiplication path recomputation: use two-step FMA (same as above).
-      double mul_result = 0.0;
-      double mul_error =
-          iree_printf_mul_pow10_error(value, -scale_exponent, &mul_result);
-      sig_integer = (uint64_t)mul_result;
-      double sig_remainder = (mul_result - (double)sig_integer) + mul_error;
-      while (sig_remainder >= 1.0) {
-        sig_integer++;
-        sig_remainder -= 1.0;
-      }
-      while (sig_remainder < 0.0) {
-        sig_integer--;
-        sig_remainder += 1.0;
-      }
-      if (sig_remainder > 0.5) {
-        sig_integer++;
-      } else if (sig_remainder == 0.5) {
-        if (sig_integer & 1) sig_integer++;
-      }
-    } else {
-      double sig_remainder = scaled - (double)sig_integer;
-      if (sig_remainder > 0.5) {
-        sig_integer++;
-      } else if (sig_remainder == 0.5) {
-        if (sig_integer & 1) sig_integer++;
-      }
-    }
-    // After correction, carry is still possible (value at exact power-of-10
-    // boundary). Use a loop rather than a single check: while a single carry
-    // (sig_integer == sig_max) is the expected case, a loop is defensive
-    // against hypothetical multi-digit overshoots from compounding FMA errors.
-    while (sig_integer >= sig_max) {
-      sig_integer /= 10;
-      exponent++;
-    }
-  }
-
+  const iree_printf_decimal_digits_t digits =
+      iree_printf_extract_significant_digits(value, effective_sig_count);
+  uint64_t sig_integer = digits.significand;
+  int exponent = digits.exponent;
   // Extract digits from the integer in reverse order.
   char sig_digits[IREE_PRINTF_MAX_FLOAT_PRECISION + 1];
   int digit_count = 0;
@@ -1494,58 +1315,13 @@ static void iree_printf_format_float(iree_printf_output_t* out,
 
     int exponent = 0;
     if (value != 0.0) {
-      exponent = iree_printf_log10_approx(value);
-      // Correct approximation.
-      double check = value / iree_printf_pow10(exponent);
-      if (check >= 10.0) {
-        exponent++;
-      } else if (check < 1.0) {
-        exponent--;
+      int effective_sig_precision = sig_precision;
+      if (effective_sig_precision > IREE_PRINTF_MAX_FLOAT_PRECISION) {
+        effective_sig_precision = IREE_PRINTF_MAX_FLOAT_PRECISION;
       }
-      // The C standard says the %g routing decision uses the exponent *after*
-      // rounding to sig_precision significant digits. If rounding carries over
-      // (e.g., 9.5 rounded to 1 sig digit becomes 10), the exponent increases.
-      // Use multiplication (not division) with error correction to get the
-      // exact scaled significand, then check if rounding carries.
-      int mul_exp = sig_precision - exponent - 1;
-      if (mul_exp >= 0 && mul_exp <= 22) {
-        double scale = iree_printf_pow10(mul_exp);
-        double scaled = value * scale;
-        double mul_err = iree_printf_mul_error(value, scale, scaled);
-        double int_part = iree_printf_floor(scaled);
-        double frac = (scaled - int_part) + mul_err;
-        if (frac < 0) {
-          int_part -= 1.0;
-          frac += 1.0;
-        }
-        bool rounds_up =
-            frac > 0.5 || (frac == 0.5 && iree_printf_is_odd(int_part));
-        if (rounds_up && (int_part + 1.0) >= iree_printf_pow10(sig_precision)) {
-          exponent++;
-        }
-      } else if (mul_exp < 0 && mul_exp >= -22) {
-        // Division path: value * 10^(-|mul_exp|) would lose precision, so
-        // divide instead. Division by exact pow10 (|mul_exp| <= 22) is safe.
-        // Use double-double product to get exact remainder (avoids precision
-        // loss when int_part > 2^53).
-        double divisor = iree_printf_pow10(-mul_exp);
-        double quotient = value / divisor;
-        double int_part = iree_printf_floor(quotient);
-        double product_high = int_part * divisor;
-        double product_low =
-            iree_printf_mul_error(int_part, divisor, product_high);
-        double remainder = (value - product_high) - product_low;
-        if (remainder < 0) {
-          int_part -= 1.0;
-          remainder += divisor;
-        }
-        double half = divisor * 0.5;
-        bool rounds_up = remainder > half ||
-                         (remainder == half && iree_printf_is_odd(int_part));
-        if (rounds_up && (int_part + 1.0) >= iree_printf_pow10(sig_precision)) {
-          exponent++;
-        }
-      }
+      exponent =
+          iree_printf_extract_significant_digits(value, effective_sig_precision)
+              .exponent;
     }
 
     if (exponent < -4 || exponent >= sig_precision) {

--- a/runtime/src/iree/base/printf_fuzz.cc
+++ b/runtime/src/iree/base/printf_fuzz.cc
@@ -122,11 +122,10 @@ static fuzz_spec_type fuzz_build_format_string(fuzz_input_t* input,
     position += snprintf(format + position, 16, "%d", width_byte % 64);
   }
 
-  // Precision. Capped to 15 to stay within our implementation's accurate
-  // range. With fmod-based rounding, we get exact remainder computation for
-  // the rounding decision, and exact quotients for up to 16 significant
-  // digits (quotient < 2^53). Precision 15 gives at most 16 significant
-  // digits for %e (precision + 1 leading digit), well within range.
+  // Precision. Capped to 15 because generated formats include the fixed-point
+  // path, whose arithmetic extraction is exact through 16 significant digits.
+  // Exponential formatting is independently exercised through all 17
+  // significant digits by the structured strategy below.
   // Strategy 4 independently tests integer precision up to 31.
   uint8_t precision_byte = fuzz_consume_u8(input);
   if (precision_byte >= 200) {
@@ -731,22 +730,23 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   //===--------------------------------------------------------------------===//
   {
     double value = fuzz_consume_double(&input);
-    uint8_t format_choice = fuzz_consume_u8(&input) % 4;
-    const char* formats[] = {"%f", "%e", "%g", "%.2f"};
+    uint8_t format_choice = fuzz_consume_u8(&input) % 5;
+    const char* formats[] = {"%f", "%e", "%g", "%.2f", "%.16e"};
 
     int iree_length = iree_snprintf(iree_buffer, sizeof(iree_buffer),
                                     formats[format_choice], value);
     int libc_length = snprintf(libc_buffer, sizeof(libc_buffer),
                                formats[format_choice], value);
 
-    // Compare if both succeeded and the value is in a range where our
-    // implementation matches libc exactly. For very large values (|v| > 1e18),
-    // the digits beyond 17 significant figures are implementation-defined
-    // artifacts of binary-to-decimal conversion, so exact comparison is not
-    // meaningful. For very small values and NaN/Inf, formatting may have
-    // acceptable platform differences.
+    // Exponential formatting extracts and rounds the exact binary64
+    // coefficient and must match libc across the entire finite range. Fixed
+    // formatting retains a narrower exact-comparison range, and %g may select
+    // that fixed path depending on the value.
+    bool compare_exactly =
+        format_choice == 1 || format_choice == 4 ||
+        (std::fabs(value) < 1e18 && std::fabs(value) > 1e-15);
     if (iree_length >= 0 && libc_length >= 0 && std::isfinite(value) &&
-        value == value && std::fabs(value) < 1e18 && std::fabs(value) > 1e-15) {
+        compare_exactly) {
       if (strcmp(iree_buffer, libc_buffer) != 0) {
         __builtin_trap();  // Mismatch — this is a bug.
       }

--- a/runtime/src/iree/base/printf_test.cc
+++ b/runtime/src/iree/base/printf_test.cc
@@ -461,13 +461,26 @@ TEST(Printf, FloatSubnormals) {
 }
 
 TEST(Printf, FloatExtremeValues) {
+  // The largest significand in the minimum normal binade expands to the
+  // maximum 767-digit exact coefficient used by exponential conversion.
+  const uint64_t widest_coefficient_bits = UINT64_C(0x001FFFFFFFFFFFFF);
+  double widest_coefficient_value = 0.0;
+  std::memcpy(&widest_coefficient_value, &widest_coefficient_bits,
+              sizeof(widest_coefficient_value));
+  ExpectMatchesLibc("%.16e", widest_coefficient_value);
+
   // Values near the limits of double range.
   ExpectMatchesLibc("%e", 1e300);
   ExpectMatchesLibc("%e", 1e308);
   ExpectMatchesLibc("%e", DBL_MAX);  // ~1.798e+308.
   ExpectMatchesLibc("%g", DBL_MAX);
+  ExpectMatchesLibc("%.16e", DBL_MAX);
+  ExpectMatchesLibc("%.17g", DBL_MAX);
   ExpectMatchesLibc("%e", DBL_MIN);  // Smallest normal: ~2.225e-308.
   ExpectMatchesLibc("%g", DBL_MIN);
+  ExpectMatchesLibc("%.17g", DBL_MIN);
+  ExpectMatchesLibc("%.17g", 5e-324);
+  ExpectMatchesLibc("%.17g", 0x1.fffffep+127);
 }
 
 TEST(Printf, FloatRoundingBoundary) {

--- a/runtime/src/iree/base/string_view.c
+++ b/runtime/src/iree/base/string_view.c
@@ -8,11 +8,21 @@
 
 #include <ctype.h>
 #include <errno.h>
+#include <float.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "iree/base/api.h"
+
+static_assert(FLT_RADIX == 2 && sizeof(float) == sizeof(uint32_t) &&
+                  FLT_MANT_DIG == 24 && FLT_MIN_EXP == -125 &&
+                  FLT_MAX_EXP == 128,
+              "iree_string_view_atof requires IEEE-754 binary32");
+static_assert(FLT_RADIX == 2 && sizeof(double) == sizeof(uint64_t) &&
+                  DBL_MANT_DIG == 53 && DBL_MIN_EXP == -1021 &&
+                  DBL_MAX_EXP == 1024,
+              "iree_string_view_atod requires IEEE-754 binary64");
 
 static inline size_t iree_min_host_size(iree_host_size_t a,
                                         iree_host_size_t b) {
@@ -200,22 +210,14 @@ IREE_API_EXPORT iree_string_view_t
 iree_string_view_trim(iree_string_view_t value) {
   if (iree_string_view_is_empty(value)) return value;
   iree_host_size_t start = 0;
-  iree_host_size_t end = value.size - 1;
-  while (value.size > 0 && start <= end) {
-    if (isspace(value.data[start])) {
-      start++;
-    } else {
-      break;
-    }
+  while (start < value.size && isspace((unsigned char)value.data[start])) {
+    ++start;
   }
-  while (end > start) {
-    if (isspace(value.data[end])) {
-      --end;
-    } else {
-      break;
-    }
+  iree_host_size_t end = value.size;
+  while (end > start && isspace((unsigned char)value.data[end - 1])) {
+    --end;
   }
-  return iree_make_string_view(value.data + start, end - start + 1);
+  return iree_make_string_view(value.data + start, end - start);
 }
 
 IREE_API_EXPORT iree_string_view_t iree_string_view_substr(
@@ -434,10 +436,262 @@ IREE_API_EXPORT bool iree_string_view_atoi_uint64(iree_string_view_t value,
   return iree_string_view_atoi_uint64_base(value, /*base=*/0, out_value);
 }
 
+typedef struct iree_hex_float_t {
+  // Sign bit parsed from the source spelling.
+  bool is_negative;
+  // First up to 64 bits of the integer significand, most significant first.
+  uint64_t prefix_bits;
+  // Number of valid bits in |prefix_bits|.
+  uint32_t prefix_bit_count;
+  // Bit width of the full integer significand after leading zero removal.
+  int64_t total_bit_count;
+  // Power of two applied to the integer significand.
+  int64_t binary_exponent;
+  // Whether a set bit exists after |prefix_bits|.
+  bool has_trailing_one;
+} iree_hex_float_t;
+
+static int64_t iree_saturating_add_int64(int64_t lhs, int64_t rhs) {
+  if (rhs > 0 && lhs > INT64_MAX - rhs) return INT64_MAX;
+  if (rhs < 0 && lhs < INT64_MIN - rhs) return INT64_MIN;
+  return lhs + rhs;
+}
+
+static int64_t iree_saturating_sub_int64(int64_t lhs, int64_t rhs) {
+  if (rhs == INT64_MIN) {
+    return lhs >= 0 ? INT64_MAX : INT64_MAX + lhs + 1;
+  }
+  return iree_saturating_add_int64(lhs, -rhs);
+}
+
+static int iree_hex_digit_value(char c) {
+  if (c >= '0' && c <= '9') return c - '0';
+  c = iree_tolower(c);
+  return c >= 'a' && c <= 'f' ? c - 'a' + 10 : -1;
+}
+
+static void iree_hex_float_append_significand_bits(iree_hex_float_t* parsed,
+                                                   uint32_t bits,
+                                                   uint32_t bit_count) {
+  parsed->total_bit_count =
+      iree_saturating_add_int64(parsed->total_bit_count, (int64_t)bit_count);
+  if (parsed->prefix_bit_count == 64) {
+    parsed->has_trailing_one |= bits != 0;
+    return;
+  }
+  const uint32_t available_bit_count = 64 - parsed->prefix_bit_count;
+  const uint32_t appended_bit_count =
+      bit_count < available_bit_count ? bit_count : available_bit_count;
+  parsed->prefix_bits = (parsed->prefix_bits << appended_bit_count) |
+                        (bits >> (bit_count - appended_bit_count));
+  parsed->prefix_bit_count += appended_bit_count;
+  if (appended_bit_count < bit_count) {
+    const uint32_t remaining_bit_count = bit_count - appended_bit_count;
+    parsed->has_trailing_one |=
+        (bits & ((UINT32_C(1) << remaining_bit_count) - 1)) != 0;
+  }
+}
+
+static bool iree_string_view_parse_hex_float(iree_string_view_t value,
+                                             iree_hex_float_t* out_parsed) {
+  memset(out_parsed, 0, sizeof(*out_parsed));
+  if (iree_string_view_is_empty(value) || value.size > INT64_MAX / 4) {
+    return false;
+  }
+
+  iree_host_size_t position = 0;
+  if (value.data[position] == '+' || value.data[position] == '-') {
+    out_parsed->is_negative = value.data[position] == '-';
+    if (++position == value.size) return false;
+  }
+  if (position + 2 > value.size || value.data[position] != '0' ||
+      iree_tolower(value.data[position + 1]) != 'x') {
+    return false;
+  }
+  position += 2;
+
+  bool saw_digit = false;
+  bool saw_nonzero_digit = false;
+  bool saw_point = false;
+  int64_t fractional_nibble_count = 0;
+  while (position < value.size) {
+    const char c = value.data[position];
+    if (c == '.' && !saw_point) {
+      saw_point = true;
+      ++position;
+      continue;
+    }
+    const int digit = iree_hex_digit_value(c);
+    if (digit < 0) break;
+    saw_digit = true;
+    if (saw_point) ++fractional_nibble_count;
+    if (!saw_nonzero_digit) {
+      if (digit == 0) {
+        ++position;
+        continue;
+      }
+      saw_nonzero_digit = true;
+      uint32_t first_bit_count = 4;
+      while ((digit & (1 << (first_bit_count - 1))) == 0) {
+        --first_bit_count;
+      }
+      iree_hex_float_append_significand_bits(out_parsed, (uint32_t)digit,
+                                             first_bit_count);
+    } else {
+      iree_hex_float_append_significand_bits(out_parsed, (uint32_t)digit, 4);
+    }
+    ++position;
+  }
+  if (!saw_digit || position == value.size ||
+      (value.data[position] != 'p' && value.data[position] != 'P')) {
+    return false;
+  }
+  ++position;
+
+  bool exponent_is_negative = false;
+  if (position < value.size &&
+      (value.data[position] == '+' || value.data[position] == '-')) {
+    exponent_is_negative = value.data[position] == '-';
+    ++position;
+  }
+  if (position == value.size || value.data[position] < '0' ||
+      value.data[position] > '9') {
+    return false;
+  }
+  int64_t explicit_exponent = 0;
+  while (position < value.size && value.data[position] >= '0' &&
+         value.data[position] <= '9') {
+    const int64_t digit = value.data[position] - '0';
+    if (explicit_exponent > (INT64_MAX - digit) / 10) {
+      explicit_exponent = INT64_MAX;
+    } else {
+      explicit_exponent = explicit_exponent * 10 + digit;
+    }
+    ++position;
+  }
+  if (position != value.size) return false;
+  if (exponent_is_negative) {
+    explicit_exponent =
+        explicit_exponent == INT64_MAX ? INT64_MIN : -explicit_exponent;
+  }
+  out_parsed->binary_exponent =
+      iree_saturating_sub_int64(explicit_exponent, fractional_nibble_count * 4);
+  return true;
+}
+
+static uint64_t iree_hex_float_prefix(const iree_hex_float_t* parsed,
+                                      uint32_t bit_count) {
+  if (bit_count == 0) return 0;
+  return parsed->prefix_bits >> (parsed->prefix_bit_count - bit_count);
+}
+
+static bool iree_hex_float_bit(const iree_hex_float_t* parsed,
+                               uint32_t bit_position) {
+  return ((parsed->prefix_bits >>
+           (parsed->prefix_bit_count - bit_position - 1)) &
+          1) != 0;
+}
+
+static bool iree_hex_float_has_one_after(const iree_hex_float_t* parsed,
+                                         uint32_t bit_position) {
+  const uint32_t remaining_prefix_bit_count =
+      parsed->prefix_bit_count - bit_position - 1;
+  if (remaining_prefix_bit_count != 0) {
+    const uint64_t mask = (UINT64_C(1) << remaining_prefix_bit_count) - 1;
+    if ((parsed->prefix_bits & mask) != 0) return true;
+  }
+  return parsed->has_trailing_one;
+}
+
+// Rounds the integer significand divided by 2^|right_shift| to nearest even.
+// The caller guarantees that the rounded result fits in 54 bits.
+static uint64_t iree_hex_float_round_right(const iree_hex_float_t* parsed,
+                                           int64_t right_shift) {
+  if (right_shift <= 0) {
+    const uint32_t left_shift = (uint32_t)-right_shift;
+    return parsed->prefix_bits << left_shift;
+  }
+  if (right_shift > parsed->total_bit_count) return 0;
+
+  const uint32_t quotient_bit_count =
+      (uint32_t)(parsed->total_bit_count - right_shift);
+  uint64_t quotient = iree_hex_float_prefix(parsed, quotient_bit_count);
+  const bool round_bit = iree_hex_float_bit(parsed, quotient_bit_count);
+  const bool sticky = iree_hex_float_has_one_after(parsed, quotient_bit_count);
+  if (round_bit && (sticky || (quotient & 1) != 0)) ++quotient;
+  return quotient;
+}
+
+static uint64_t iree_hex_float_to_ieee_bits(const iree_hex_float_t* parsed,
+                                            uint32_t precision,
+                                            int32_t minimum_exponent,
+                                            int32_t maximum_exponent,
+                                            int32_t exponent_bias,
+                                            uint32_t sign_bit_position) {
+  const uint64_t sign =
+      parsed->is_negative ? UINT64_C(1) << sign_bit_position : 0;
+  if (parsed->total_bit_count == 0) return sign;
+
+  int64_t exponent = iree_saturating_add_int64(parsed->binary_exponent,
+                                               parsed->total_bit_count - 1);
+  const uint64_t infinity_exponent =
+      (uint64_t)(maximum_exponent + exponent_bias + 1);
+  if (exponent > maximum_exponent) {
+    return sign | (infinity_exponent << (precision - 1));
+  }
+
+  if (exponent >= minimum_exponent) {
+    uint64_t significand =
+        iree_hex_float_round_right(parsed, parsed->total_bit_count - precision);
+    if (significand == (UINT64_C(1) << precision)) {
+      significand >>= 1;
+      if (++exponent > maximum_exponent) {
+        return sign | (infinity_exponent << (precision - 1));
+      }
+    }
+    const uint64_t fraction_mask = (UINT64_C(1) << (precision - 1)) - 1;
+    return sign | ((uint64_t)(exponent + exponent_bias) << (precision - 1)) |
+           (significand & fraction_mask);
+  }
+
+  const int64_t subnormal_exponent =
+      (int64_t)minimum_exponent - ((int64_t)precision - 1);
+  const int64_t right_shift =
+      iree_saturating_sub_int64(subnormal_exponent, parsed->binary_exponent);
+  const uint64_t fraction = iree_hex_float_round_right(parsed, right_shift);
+  if (fraction == (UINT64_C(1) << (precision - 1))) {
+    return sign | (UINT64_C(1) << (precision - 1));
+  }
+  return sign | fraction;
+}
+
+static bool iree_string_view_is_hex_float(iree_string_view_t value) {
+  iree_host_size_t position = 0;
+  if (value.size != 0 &&
+      (value.data[position] == '+' || value.data[position] == '-')) {
+    ++position;
+  }
+  return position + 2 <= value.size && value.data[position] == '0' &&
+         iree_tolower(value.data[position + 1]) == 'x';
+}
+
 IREE_API_EXPORT bool iree_string_view_atof(iree_string_view_t value,
                                            float* out_value) {
+  value = iree_string_view_trim(value);
+  if (iree_string_view_is_hex_float(value)) {
+    iree_hex_float_t parsed;
+    if (!iree_string_view_parse_hex_float(value, &parsed)) return false;
+    const uint32_t bits = (uint32_t)iree_hex_float_to_ieee_bits(
+        &parsed, FLT_MANT_DIG, FLT_MIN_EXP - 1, FLT_MAX_EXP - 1,
+        2 - FLT_MIN_EXP, 31);
+    float parsed_value = 0.0f;
+    memcpy(&parsed_value, &bits, sizeof(parsed_value));
+    *out_value = parsed_value;
+    return true;
+  }
+
   // Copy to scratch memory with a NUL terminator.
-  char temp[32] = {0};
+  char temp[64] = {0};
   if (iree_string_view_is_empty(value) || value.size >= IREE_ARRAYSIZE(temp)) {
     return false;
   }
@@ -446,15 +700,29 @@ IREE_API_EXPORT bool iree_string_view_atof(iree_string_view_t value,
   // Attempt to parse.
   errno = 0;
   char* end = NULL;
-  *out_value = strtof(temp, &end);
-  if (temp == end) return false;
-  return *out_value != 0 || errno == 0;
+  float parsed_value = strtof(temp, &end);
+  if (temp == end || end != temp + value.size) return false;
+  *out_value = parsed_value;
+  return true;
 }
 
 IREE_API_EXPORT bool iree_string_view_atod(iree_string_view_t value,
                                            double* out_value) {
+  value = iree_string_view_trim(value);
+  if (iree_string_view_is_hex_float(value)) {
+    iree_hex_float_t parsed;
+    if (!iree_string_view_parse_hex_float(value, &parsed)) return false;
+    const uint64_t bits =
+        iree_hex_float_to_ieee_bits(&parsed, DBL_MANT_DIG, DBL_MIN_EXP - 1,
+                                    DBL_MAX_EXP - 1, 2 - DBL_MIN_EXP, 63);
+    double parsed_value = 0.0;
+    memcpy(&parsed_value, &bits, sizeof(parsed_value));
+    *out_value = parsed_value;
+    return true;
+  }
+
   // Copy to scratch memory with a NUL terminator.
-  char temp[32] = {0};
+  char temp[64] = {0};
   if (iree_string_view_is_empty(value) || value.size >= IREE_ARRAYSIZE(temp)) {
     return false;
   }
@@ -463,9 +731,10 @@ IREE_API_EXPORT bool iree_string_view_atod(iree_string_view_t value,
   // Attempt to parse.
   errno = 0;
   char* end = NULL;
-  *out_value = strtod(temp, &end);
-  if (temp == end) return false;
-  return *out_value != 0 || errno == 0;
+  double parsed_value = strtod(temp, &end);
+  if (temp == end || end != temp + value.size) return false;
+  *out_value = parsed_value;
+  return true;
 }
 
 static bool iree_string_view_parse_hex_nibble(char c, uint8_t* out_b) {

--- a/runtime/src/iree/base/string_view.h
+++ b/runtime/src/iree/base/string_view.h
@@ -333,6 +333,17 @@ IREE_API_EXPORT bool iree_string_view_atoi_uint64_base(iree_string_view_t value,
                                                        uint64_t* out_value);
 IREE_API_EXPORT bool iree_string_view_atoi_uint64(iree_string_view_t value,
                                                   uint64_t* out_value);
+
+// Parses a floating-point number from the entire trimmed |value|.
+//
+// Decimal values and special values use the C floating-point spelling. C99
+// hexadecimal values require a `0x` prefix and `p` binary exponent, such as
+// `-0x1.8p+2`. Hexadecimal values are rounded directly to the destination type
+// with round-to-nearest-even semantics. Overflow and underflow are successful
+// parses that produce the corresponding infinity or signed zero.
+//
+// Returns false without modifying |out_value| if |value| is empty, malformed,
+// contains trailing characters, or exceeds the bounded decimal parser storage.
 IREE_API_EXPORT bool iree_string_view_atof(iree_string_view_t value,
                                            float* out_value);
 IREE_API_EXPORT bool iree_string_view_atod(iree_string_view_t value,

--- a/runtime/src/iree/base/string_view_fuzz.cc
+++ b/runtime/src/iree/base/string_view_fuzz.cc
@@ -11,6 +11,9 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "iree/base/api.h"
 
@@ -25,6 +28,61 @@ static const iree_bitfield_string_mapping_t kTestBitfieldMappings[] = {
     {0x10, IREE_SVL("MAPPABLE")},  // Bit 4.
     {0x20, IREE_SVL("COHERENT")},  // Bit 5.
 };
+
+static void iree_string_view_fuzz_structured_hex_float(const uint8_t* data,
+                                                       size_t size) {
+  if (size < 4) return;
+
+  static const char kHexDigits[] = "0123456789abcdef";
+  const size_t significand_byte_count = size - 3 < 32 ? size - 3 : 32;
+  const size_t significand_nibble_count = significand_byte_count * 2;
+  const size_t point_position = data[0] % (significand_nibble_count + 1);
+
+  char text[96];
+  size_t text_length = 0;
+  if ((data[0] & 0x80) != 0) text[text_length++] = '-';
+  text[text_length++] = '0';
+  text[text_length++] = (data[0] & 0x40) != 0 ? 'X' : 'x';
+  for (size_t i = 0; i <= significand_nibble_count; ++i) {
+    if (i == point_position) text[text_length++] = '.';
+    if (i == significand_nibble_count) break;
+    const uint8_t byte = data[3 + i / 2];
+    const uint8_t nibble =
+        (i & 1) == 0 ? (uint8_t)(byte >> 4) : (uint8_t)(byte & 0x0F);
+    text[text_length++] = kHexDigits[nibble];
+  }
+  text[text_length++] = (data[0] & 0x20) != 0 ? 'P' : 'p';
+  const int16_t exponent_bits = (int16_t)((uint16_t)data[1] << 8 | data[2]);
+  const int exponent_length = snprintf(
+      text + text_length, sizeof(text) - text_length, "%d", (int)exponent_bits);
+  if (exponent_length <= 0 ||
+      (size_t)exponent_length >= sizeof(text) - text_length) {
+    return;
+  }
+  text_length += (size_t)exponent_length;
+
+  const iree_string_view_t input =
+      iree_make_string_view(text, (iree_host_size_t)text_length);
+  float actual_f32 = 0.0f;
+  double actual_f64 = 0.0;
+  if (!iree_string_view_atof(input, &actual_f32) ||
+      !iree_string_view_atod(input, &actual_f64)) {
+    abort();
+  }
+
+  char* reference_end = NULL;
+  const float reference_f32 = strtof(text, &reference_end);
+  if (reference_end == text + text_length &&
+      memcmp(&actual_f32, &reference_f32, sizeof(actual_f32)) != 0) {
+    abort();
+  }
+  reference_end = NULL;
+  const double reference_f64 = strtod(text, &reference_end);
+  if (reference_end == text + text_length &&
+      memcmp(&actual_f64, &reference_f64, sizeof(actual_f64)) != 0) {
+    abort();
+  }
+}
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   iree_string_view_t input =
@@ -69,6 +127,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   //===--------------------------------------------------------------------===//
   // Floating point parsing
   //===--------------------------------------------------------------------===//
+
+  iree_string_view_fuzz_structured_hex_float(data, size);
 
   {
     float value_f32 = 0.0f;

--- a/runtime/src/iree/base/string_view_test.cc
+++ b/runtime/src/iree/base/string_view_test.cc
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <array>
+#include <cstdint>
+#include <cstring>
 #include <string>
 #include <string_view>
 
@@ -22,6 +24,18 @@ using testing::Eq;
 
 static std::string ToString(iree_string_view_t value) {
   return std::string(value.data, value.size);
+}
+
+static uint32_t FloatBits(float value) {
+  uint32_t bits = 0;
+  std::memcpy(&bits, &value, sizeof(bits));
+  return bits;
+}
+
+static uint64_t DoubleBits(double value) {
+  uint64_t bits = 0;
+  std::memcpy(&bits, &value, sizeof(bits));
+  return bits;
 }
 
 TEST(StringViewTest, Empty) {
@@ -776,6 +790,92 @@ TEST(StringViewTest, ParseEmptyNumber) {
   EXPECT_FALSE(iree_string_view_atoi_uint64(empty, &u64));
   EXPECT_FALSE(iree_string_view_atof(empty, &f32));
   EXPECT_FALSE(iree_string_view_atod(empty, &f64));
+}
+
+TEST(StringViewTest, ParseHexFloat32) {
+  struct TestCase {
+    const char* text;
+    uint32_t expected_bits;
+  };
+  const TestCase test_cases[] = {
+      {"0x0p+0", UINT32_C(0x00000000)},
+      {"-0X0P-100000", UINT32_C(0x80000000)},
+      {"+0x1p0", UINT32_C(0x3F800000)},
+      {"0x1.fffffep+127", UINT32_C(0x7F7FFFFF)},
+      {"0x1p-126", UINT32_C(0x00800000)},
+      {"0x1p-149", UINT32_C(0x00000001)},
+      // Round-to-nearest-even at an ordinary, subnormal, and overflow edge.
+      {"0x1.000001p0", UINT32_C(0x3F800000)},
+      {"0x1.000001000001p0", UINT32_C(0x3F800001)},
+      {"0x1.000003p0", UINT32_C(0x3F800002)},
+      {"0x1p-150", UINT32_C(0x00000000)},
+      {"0x1.000001p-150", UINT32_C(0x00000001)},
+      {"0x1.ffffffp+127", UINT32_C(0x7F800000)},
+  };
+  for (const TestCase& test_case : test_cases) {
+    float value = -42.0f;
+    EXPECT_TRUE(
+        iree_string_view_atof(iree_make_cstring_view(test_case.text), &value))
+        << test_case.text;
+    EXPECT_EQ(test_case.expected_bits, FloatBits(value)) << test_case.text;
+  }
+}
+
+TEST(StringViewTest, ParseHexFloat64) {
+  struct TestCase {
+    const char* text;
+    uint64_t expected_bits;
+  };
+  const TestCase test_cases[] = {
+      {"0x0p0", UINT64_C(0x0000000000000000)},
+      {"-0x0p0", UINT64_C(0x8000000000000000)},
+      {"0x1p0", UINT64_C(0x3FF0000000000000)},
+      {"0x1.fffffffffffffp+1023", UINT64_C(0x7FEFFFFFFFFFFFFF)},
+      {"0x1p-1022", UINT64_C(0x0010000000000000)},
+      {"0x1p-1074", UINT64_C(0x0000000000000001)},
+      {"0x1.00000000000008p0", UINT64_C(0x3FF0000000000000)},
+      {"0x1.0000000000000800000000001p0", UINT64_C(0x3FF0000000000001)},
+      {"0x1.00000000000018p0", UINT64_C(0x3FF0000000000002)},
+      {"0x1p-1075", UINT64_C(0x0000000000000000)},
+      {"0x1.0000000000001p-1075", UINT64_C(0x0000000000000001)},
+      {"0x1.fffffffffffff8p+1023", UINT64_C(0x7FF0000000000000)},
+      // Retain sticky information beyond the 64-bit parser prefix.
+      {"0x1.000000000000080000000000000000000000000000000000000000000001p0",
+       UINT64_C(0x3FF0000000000001)},
+  };
+  for (const TestCase& test_case : test_cases) {
+    double value = -42.0;
+    EXPECT_TRUE(
+        iree_string_view_atod(iree_make_cstring_view(test_case.text), &value))
+        << test_case.text;
+    EXPECT_EQ(test_case.expected_bits, DoubleBits(value)) << test_case.text;
+  }
+}
+
+TEST(StringViewTest, ParseFloatRequiresCompleteValidSpelling) {
+  const char* invalid_values[] = {
+      "0x",    "0xp0",  "0x.p0",  "0x1",        "0x1.",  "0x1p",
+      "0x1p+", "0x1p-", "0x1p0x", "1.25suffix", "--1.0", "   ",
+  };
+  for (const char* text : invalid_values) {
+    float f32 = 42.0f;
+    double f64 = 42.0;
+    EXPECT_FALSE(iree_string_view_atof(iree_make_cstring_view(text), &f32))
+        << text;
+    EXPECT_FALSE(iree_string_view_atod(iree_make_cstring_view(text), &f64))
+        << text;
+    EXPECT_EQ(42.0f, f32) << text;
+    EXPECT_EQ(42.0, f64) << text;
+  }
+}
+
+TEST(StringViewTest, ParseFloatTrimsWhitespace) {
+  float f32 = 0.0f;
+  double f64 = 0.0;
+  EXPECT_TRUE(iree_string_view_atof(IREE_SV(" \t0x1.8p+2\n"), &f32));
+  EXPECT_EQ(6.0f, f32);
+  EXPECT_TRUE(iree_string_view_atod(IREE_SV(" \t-1.25e+2\n"), &f64));
+  EXPECT_EQ(-125.0, f64);
 }
 
 TEST(StringViewTest, MatchPattern) {


### PR DESCRIPTION
Accept C99 hexadecimal floating-point literals across the shared IREE text-conversion APIs and both Loom frontends, then print their values through one exactly rounded canonical decimal representation. This closes the source contract hole where emitted or external IR can spell exact binary boundaries such as `0x1.fffffep+127`, while authored Loom rejected the radix point and the C and Python printers disagreed at finite extrema.

The complete path now preserves one value through every representation:

```text
C99 hexadecimal source
        |
        v
validated C/Python token grammar
        |
        v
exact binary64 Loom attribute
        |
        v
declared F16/BF16/F32/F64 semantics
        |
        v
exact canonical decimal text <----> bytecode
```

## Exact Shared Float Conversion

`iree_string_view_atof` and `iree_string_view_atod` now parse C99 hexadecimal significands directly into IEEE binary32 and binary64. The parser is allocation-free, consumes the complete string, preserves the output on failure, and rounds normal, subnormal, overflow, underflow, and halfway cases without routing through host locale or an intermediate floating-point value. Decimal parsing now follows the same complete-consumption contract.

The inverse exponential formatting path replaces approximate floating-point scaling and correction branches with a fixed-capacity base-1e9 integer coefficient. Decimal digit generation and exponent selection therefore round to nearest-even across the complete finite binary64 range, including maximum finite values and minimum subnormals. `%e` and exponential `%g` output no longer depend on a narrow magnitude window or emit a decimal spelling that reparses to infinity.

Boundary tests pin the IEEE transitions, and the structured string-conversion and printf fuzzers exercise grammar, rounding, and host-libc agreement across their supported domains.

## Unified Loom Source Behavior

The C and Python tokenizers implement the same hexadecimal number grammar: `0x` or `0X`, hexadecimal digits around an optional radix point, and a required `p` or `P` binary exponent for floating-point tokens. Signed values, exponent-only forms such as `0x1p0`, uppercase spellings, hexadecimal integers, and dimension-list separators retain their existing roles. Incomplete significands and exponents fail at the numeric token with structured parser diagnostics instead of fragmenting into misleading follow-on tokens.

The C parser consumes the shared IREE conversion, while Python uses `float.fromhex` with matching signed overflow behavior. Both printers now emit byte-for-byte identical canonical text for representative normal, subnormal, maximum-finite, signed-zero, overflow, and underflow values. Canonical text reparses stably through C, Python, and bytecode.

Scalar facts also exercise the production semantic boundary: hexadecimal attributes retain their exact binary64 payload in the IR, while constants round that payload to the declared F16, BF16, F32, or F64 result width. Halfway inputs prove round-to-nearest-even rather than merely checking that parsing succeeds.

## Bounded Presubmit Analysis

The Bazel clang-tidy invocation now receives the presubmit policy's existing job budget through `--jobs`. Bazel and clang-tidy therefore share one explicit parallelism bound instead of allowing the action scheduler to oversubscribe a constrained worker while analyzing broad packages such as `iree/base`.

## Reviewer Notes

The commits retain the dependency layers for focused review: shared parsing, analysis scheduling, exact formatting, and Loom integration. The user-visible Loom contract depends on both runtime numeric commits; the scheduling commit is independent but included so this feature branch exercises the same bounded analysis path that CI will run.
