### PR TITLE
[Loom/AMDGPU] Lower single-wave communication directly

### DIFF
--- a/loom/py/loom/target/arch/amdgpu/contracts/dispatch_ownership.py
+++ b/loom/py/loom/target/arch/amdgpu/contracts/dispatch_ownership.py
@@ -61,6 +61,9 @@ _ROW_MACRO_SIGNATURES = {
     "STRUCTURAL_DIRECT_STORAGE_ROW": _RowMacroSignature(
         argument_count=5, storage_policy_argument=4
     ),
+    "STRUCTURAL_DATA_STORAGE_REPORT_KEY_ROW": _RowMacroSignature(
+        argument_count=7, storage_policy_argument=5, report_key_argument=6
+    ),
     "VALUE_STRUCTURAL_DIRECT_STORAGE_ROW": _RowMacroSignature(
         argument_count=5, storage_policy_argument=4
     ),
@@ -148,6 +151,7 @@ _REPORT_KEY_NAMES = frozenset(
         "LOOM_AMDGPU_REPORT_KEY_FRAGMENT_REPACK_STRATEGY",
         "LOOM_AMDGPU_REPORT_KEY_FRAGMENT_MEMORY_STRATEGY",
         "LOOM_AMDGPU_REPORT_KEY_TABLE_LOOKUP_STRATEGY",
+        "LOOM_AMDGPU_REPORT_KEY_KERNEL_BARRIER_STRATEGY",
         "LOOM_AMDGPU_REPORT_KEY_SUBGROUP_REDUCE_STRATEGY",
         "LOOM_AMDGPU_REPORT_KEY_SUBGROUP_BROADCAST_STRATEGY",
         "LOOM_AMDGPU_REPORT_KEY_VECTOR_16BIT_FLOAT_CONVERSION_STRATEGY",

--- a/loom/py/loom/target/arch/amdgpu/descriptors/alu.py
+++ b/loom/py/loom/target/arch/amdgpu/descriptors/alu.py
@@ -1483,6 +1483,25 @@ def _v_readlane_b32_src1_inline_overlay() -> AmdgpuDescriptorOverlay:
         ),
         immediate_fields=("SRC1",),
         immediates=(replace(_source_inline_u32_immediate("lane"), unsigned_max=63),),
+        fixed_encoding_fields=(("SRC2", 0),),
+        effects=(_CONVERGENT_EFFECT,),
+    )
+
+
+def _v_readlane_b32_src1_sgpr_overlay() -> AmdgpuDescriptorOverlay:
+    return AmdgpuDescriptorOverlay(
+        descriptor_key="amdgpu.v_readlane_b32.src1_sgpr",
+        instruction_name="V_READLANE_B32",
+        mnemonic="v_readlane_b32_src1_sgpr",
+        encoding_name="ENC_VOP3",
+        semantic_tag="lane.read.b32",
+        schedule_class=_SCHEDULE_VALU,
+        operands=(
+            AmdgpuOperandOverlay("VDST", _sgpr_result()),
+            AmdgpuOperandOverlay("SRC0", _vgpr_operand("value")),
+            AmdgpuOperandOverlay("SRC1", _sgpr_operand("lane")),
+        ),
+        fixed_encoding_fields=(("SRC2", 0),),
         effects=(_CONVERGENT_EFFECT,),
     )
 
@@ -7035,6 +7054,7 @@ __all__ = (
     "_v_rcp_f32_overlay",
     "_v_readfirstlane_b32_overlay",
     "_v_readlane_b32_src1_inline_overlay",
+    "_v_readlane_b32_src1_sgpr_overlay",
     "_v_rndne_f32_overlay",
     "_v_rsq_f32_overlay",
     "_v_sin_f32_overlay",

--- a/loom/py/loom/target/arch/amdgpu/descriptors/sets.py
+++ b/loom/py/loom/target/arch/amdgpu/descriptors/sets.py
@@ -1015,6 +1015,7 @@ def _gfx11_core_overlays() -> tuple[AmdgpuDescriptorOverlay, ...]:
         _v_max_u32_overlay(),
         _v_readfirstlane_b32_overlay(),
         _v_readlane_b32_src1_inline_overlay(),
+        _v_readlane_b32_src1_sgpr_overlay(),
         *_integer_bitwise_shift_overlays(),
         *_integer_bitwise_permute_overlays(),
         _v_permlanex16_b32_src12_inline_overlay(),

--- a/loom/py/loom/target/arch/amdgpu/descriptors_test.py
+++ b/loom/py/loom/target/arch/amdgpu/descriptors_test.py
@@ -294,6 +294,15 @@ def test_generic_descriptor_contracts_are_member_intersections() -> None:
     )
 
 
+def test_v_readlane_b32_reserves_unused_vop3_source() -> None:
+    overlays = {overlay.descriptor_key: overlay for overlay in _gfx11_core_overlays()}
+    for descriptor_key in (
+        "amdgpu.v_readlane_b32.src1_inline",
+        "amdgpu.v_readlane_b32.src1_sgpr",
+    ):
+        assert overlays[descriptor_key].fixed_encoding_fields == (("SRC2", 0),)
+
+
 def _descriptor_set(*descriptors: Descriptor) -> DescriptorSet:
     return DescriptorSet(
         key="amdgpu.test.core",

--- a/loom/src/loom/target/arch/amdgpu/lower/plan.h
+++ b/loom/src/loom/target/arch/amdgpu/lower/plan.h
@@ -1009,7 +1009,7 @@ typedef enum loom_amdgpu_kernel_barrier_lowering_kind_e {
   LOOM_AMDGPU_KERNEL_BARRIER_LOWERING_KIND_NONE = 0,
   // Emit a full workgroup barrier packet.
   LOOM_AMDGPU_KERNEL_BARRIER_LOWERING_KIND_S_BARRIER = 1,
-  // Emit a wait packet that drains LDS effects for a single-wave workgroup.
+  // Emit a memory-ordering wait that drains LDS effects without rendezvous.
   LOOM_AMDGPU_KERNEL_BARRIER_LOWERING_KIND_LDS_WAIT = 2,
   // Emit the split signal/wait barrier packet pair used by GFX12+ targets.
   LOOM_AMDGPU_KERNEL_BARRIER_LOWERING_KIND_SPLIT_BARRIER = 3,

--- a/loom/src/loom/target/arch/amdgpu/lower/plan.h
+++ b/loom/src/loom/target/arch/amdgpu/lower/plan.h
@@ -821,7 +821,7 @@ typedef enum loom_amdgpu_subgroup_payload_kind_e {
 typedef enum loom_amdgpu_subgroup_broadcast_strategy_e {
   // Read the named lane directly through the target's native subgroup crossbar.
   LOOM_AMDGPU_SUBGROUP_BROADCAST_STRATEGY_BPERMUTE = 0,
-  // Read one statically named lane into an SGPR and publish it to every lane.
+  // Read one subgroup-uniform lane into an SGPR and publish it to every lane.
   LOOM_AMDGPU_SUBGROUP_BROADCAST_STRATEGY_SCALAR_READLANE = 1,
 } loom_amdgpu_subgroup_broadcast_strategy_t;
 

--- a/loom/src/loom/target/arch/amdgpu/lower/registry.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/registry.c
@@ -166,8 +166,10 @@ enum loom_amdgpu_report_key_kind_e {
   LOOM_AMDGPU_REPORT_KEY_SUBGROUP_BROADCAST_STRATEGY = 8,
   // Report the invocation-local vector-transform strategy.
   LOOM_AMDGPU_REPORT_KEY_VECTOR_TRANSFORM_STRATEGY = 9,
+  // Report the synchronization strategy selected for a kernel barrier.
+  LOOM_AMDGPU_REPORT_KEY_KERNEL_BARRIER_STRATEGY = 10,
   // Maximum report-key kind accepted by dispatch rows.
-  LOOM_AMDGPU_REPORT_KEY_MAX = LOOM_AMDGPU_REPORT_KEY_VECTOR_TRANSFORM_STRATEGY,
+  LOOM_AMDGPU_REPORT_KEY_MAX = LOOM_AMDGPU_REPORT_KEY_KERNEL_BARRIER_STRATEGY,
 };
 
 // Packing constants bridge the storage and preselection enum domains into the
@@ -922,6 +924,8 @@ LOOM_AMDGPU_DEFINE_DATA_EMIT(loom_amdgpu_emit_sanitizer_race_sync_dispatch,
 
 #define LOOM_AMDGPU_STRUCTURAL_DIRECT_STORAGE_ROW \
   LOOM_AMDGPU_INTERNAL_DIRECT_STORAGE_ROW
+#define LOOM_AMDGPU_STRUCTURAL_DATA_STORAGE_REPORT_KEY_ROW \
+  LOOM_AMDGPU_INTERNAL_DATA_STORAGE_REPORT_KEY_ROW
 #define LOOM_AMDGPU_VALUE_STRUCTURAL_DIRECT_STORAGE_ROW \
   LOOM_AMDGPU_INTERNAL_DIRECT_STORAGE_ROW
 #define LOOM_AMDGPU_VALUE_STRUCTURAL_DIRECT_POLICY_ROW \
@@ -1015,6 +1019,7 @@ static const loom_amdgpu_lower_dispatch_table_t
 #undef LOOM_AMDGPU_VALUE_STRUCTURAL_DIRECT_POLICY_ROW
 #undef LOOM_AMDGPU_VALUE_STRUCTURAL_DIRECT_STORAGE_ROW
 #undef LOOM_AMDGPU_STRUCTURAL_DIRECT_STORAGE_ROW
+#undef LOOM_AMDGPU_STRUCTURAL_DATA_STORAGE_REPORT_KEY_ROW
 #undef LOOM_AMDGPU_INTERNAL_DATA_STORAGE_ROW
 #undef LOOM_AMDGPU_INTERNAL_DATA_ROW
 #undef LOOM_AMDGPU_INTERNAL_DATA_SOURCE_ROW
@@ -1357,6 +1362,29 @@ static iree_string_view_t loom_amdgpu_workgroup_reduce_plan_key(
       plan->publication_kind);
 }
 
+static iree_string_view_t loom_amdgpu_kernel_barrier_plan_key(
+    const loom_op_t* source_op, const loom_amdgpu_kernel_barrier_plan_t* plan) {
+  switch (plan->kind) {
+    case LOOM_AMDGPU_KERNEL_BARRIER_LOWERING_KIND_S_BARRIER:
+      return IREE_SV(
+          "amdgpu.kernel_barrier.strategy.s_barrier.workgroup_rendezvous");
+    case LOOM_AMDGPU_KERNEL_BARRIER_LOWERING_KIND_LDS_WAIT:
+      return loom_kernel_barrier_scope(source_op) == LOOM_ATOMIC_SCOPE_SUBGROUP
+                 ? IREE_SV(
+                       "amdgpu.kernel_barrier.strategy.lds_wait."
+                       "subgroup_scope")
+                 : IREE_SV(
+                       "amdgpu.kernel_barrier.strategy.lds_wait."
+                       "single_subgroup_workgroup");
+    case LOOM_AMDGPU_KERNEL_BARRIER_LOWERING_KIND_SPLIT_BARRIER:
+      return IREE_SV(
+          "amdgpu.kernel_barrier.strategy.split_barrier.workgroup_rendezvous");
+    case LOOM_AMDGPU_KERNEL_BARRIER_LOWERING_KIND_NONE:
+      return iree_string_view_empty();
+  }
+  return iree_string_view_empty();
+}
+
 static iree_string_view_t loom_amdgpu_subgroup_broadcast_plan_key(
     const loom_amdgpu_subgroup_broadcast_plan_t* plan) {
   switch (plan->strategy) {
@@ -1463,10 +1491,16 @@ static iree_string_view_t loom_amdgpu_plan_key(
     const loom_op_t* source_op, loom_low_lower_plan_t plan) {
   (void)user_data;
   (void)context;
-  (void)source_op;
   const loom_amdgpu_lower_dispatch_row_t* row =
       loom_amdgpu_find_lower_dispatch_row(plan.id);
   switch (loom_amdgpu_dispatch_row_report_key_kind(row)) {
+    case LOOM_AMDGPU_REPORT_KEY_KERNEL_BARRIER_STRATEGY:
+      if (plan.target_data == NULL) {
+        return iree_string_view_empty();
+      }
+      return loom_amdgpu_kernel_barrier_plan_key(
+          source_op,
+          (const loom_amdgpu_kernel_barrier_plan_t*)plan.target_data);
     case LOOM_AMDGPU_REPORT_KEY_WORKGROUP_REDUCE_PUBLICATION:
       if (plan.target_data == NULL) {
         return iree_string_view_empty();

--- a/loom/src/loom/target/arch/amdgpu/lower/registry_tables.inl
+++ b/loom/src/loom/target/arch/amdgpu/lower/registry_tables.inl
@@ -587,12 +587,13 @@ static const loom_amdgpu_lower_dispatch_row_t
 static const loom_amdgpu_lower_dispatch_row_t
     kAmdgpuKernelDispatchRows[LOOM_OP_KERNEL_COUNT_] = {
         [LOOM_AMDGPU_OP_INDEX(LOOM_OP_KERNEL_BARRIER)] =
-            LOOM_AMDGPU_STRUCTURAL_DIRECT_STORAGE_ROW(
-                LOOM_OP_KERNEL_BARRIER,
+            LOOM_AMDGPU_STRUCTURAL_DATA_STORAGE_REPORT_KEY_ROW(
+                LOOM_OP_KERNEL_BARRIER, loom_amdgpu_kernel_barrier_plan_t,
                 loom_amdgpu_select_kernel_barrier_dispatch,
                 loom_amdgpu_emit_kernel_barrier_dispatch,
                 loom_amdgpu_low_legality_verify_kernel_barrier,
-                LOOM_AMDGPU_STORAGE_NONE),
+                LOOM_AMDGPU_STORAGE_NONE,
+                LOOM_AMDGPU_REPORT_KEY_KERNEL_BARRIER_STRATEGY),
         [LOOM_AMDGPU_OP_INDEX(LOOM_OP_KERNEL_WORKITEM_ID)] =
             LOOM_AMDGPU_STRUCTURAL_DIRECT_STORAGE_ROW(
                 LOOM_OP_KERNEL_WORKITEM_ID,

--- a/loom/src/loom/target/arch/amdgpu/lower/subgroup.h
+++ b/loom/src/loom/target/arch/amdgpu/lower/subgroup.h
@@ -42,6 +42,13 @@ iree_status_t loom_amdgpu_emit_subgroup_readlane_register(
     loom_value_id_t source_value, uint32_t lane, loom_type_t result_type,
     loom_value_id_t* out_low_result);
 
+// Reads one subgroup-uniform lane selected by an SGPR into an SGPR.
+iree_status_t loom_amdgpu_emit_subgroup_readlane_sgpr_register(
+    loom_low_lower_context_t* context, const loom_op_t* source_op,
+    const loom_low_lower_resolved_descriptor_t* descriptor,
+    loom_value_id_t source_value, loom_value_id_t source_lane,
+    loom_type_t result_type, loom_value_id_t* out_low_result);
+
 // Emits one direct DPP or DS swizzle cross-lane read for a 32-bit payload
 // register.
 iree_status_t loom_amdgpu_emit_direct_crosslane_register(

--- a/loom/src/loom/target/arch/amdgpu/lower/subgroup_broadcast.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/subgroup_broadcast.c
@@ -21,6 +21,8 @@
 typedef struct loom_amdgpu_subgroup_broadcast_shape_t {
   // Exact source lane when known during planning, or UINT32_MAX when dynamic.
   uint32_t exact_source_lane;
+  // Whether every active lane observes the same source lane.
+  bool source_lane_is_subgroup_uniform;
 } loom_amdgpu_subgroup_broadcast_shape_t;
 
 static bool loom_amdgpu_subgroup_broadcast_resolve_shape(
@@ -36,11 +38,14 @@ static bool loom_amdgpu_subgroup_broadcast_resolve_shape(
       return false;
     }
     out_shape->exact_source_lane = (uint32_t)exact_value;
+    out_shape->source_lane_is_subgroup_uniform = true;
     return true;
   }
 
   const loom_value_facts_t facts =
       loom_value_fact_table_lookup(fact_table, source_lane);
+  out_shape->source_lane_is_subgroup_uniform =
+      loom_value_facts_is_subgroup_uniform(facts);
   return !loom_value_facts_is_float(facts) && facts.range_lo >= 0 &&
          facts.range_hi < (int64_t)wavefront_size;
 }
@@ -90,13 +95,17 @@ iree_status_t loom_amdgpu_select_kernel_subgroup_broadcast_plan(
     }
     out_plan->strategy = LOOM_AMDGPU_SUBGROUP_BROADCAST_STRATEGY_BPERMUTE;
   } else {
-    if (shape.exact_source_lane == UINT32_MAX) {
+    if (shape.exact_source_lane == UINT32_MAX &&
+        !shape.source_lane_is_subgroup_uniform) {
       return iree_ok_status();
     }
+    const loom_amdgpu_descriptor_ref_t exchange_descriptor_ref =
+        shape.exact_source_lane == UINT32_MAX
+            ? LOOM_AMDGPU_DESCRIPTOR_REF_V_READLANE_B32_SRC1_SGPR
+            : LOOM_AMDGPU_DESCRIPTOR_REF_V_READLANE_B32_SRC1_INLINE;
     const loom_amdgpu_descriptor_resolution_t resolutions[] = {
         {
-            .descriptor_ref =
-                LOOM_AMDGPU_DESCRIPTOR_REF_V_READLANE_B32_SRC1_INLINE,
+            .descriptor_ref = exchange_descriptor_ref,
             .out_descriptor = &out_plan->exchange_descriptor,
         },
         {
@@ -195,6 +204,7 @@ iree_status_t loom_amdgpu_lower_kernel_subgroup_broadcast(
       context, source_op, plan->value, plan->payload_kind, &low_value));
 
   loom_value_id_t low_source_byte_offset = LOOM_VALUE_ID_INVALID;
+  loom_value_id_t low_source_lane = LOOM_VALUE_ID_INVALID;
   loom_type_t scalar_type = loom_type_none();
   switch (plan->strategy) {
     case LOOM_AMDGPU_SUBGROUP_BROADCAST_STRATEGY_BPERMUTE:
@@ -203,7 +213,6 @@ iree_status_t loom_amdgpu_lower_kernel_subgroup_broadcast(
             context, source_op, LOOM_AMDGPU_DESCRIPTOR_REF_V_MOV_B32,
             plan->exact_source_lane * 4u, lane_type, &low_source_byte_offset));
       } else {
-        loom_value_id_t low_source_lane = LOOM_VALUE_ID_INVALID;
         IREE_RETURN_IF_ERROR(loom_low_lower_lookup_value(
             context, plan->source_lane, &low_source_lane));
         IREE_RETURN_IF_ERROR(loom_amdgpu_materialize_low_vgpr_b32(
@@ -213,10 +222,14 @@ iree_status_t loom_amdgpu_lower_kernel_subgroup_broadcast(
             &low_source_byte_offset));
       }
       break;
-    case LOOM_AMDGPU_SUBGROUP_BROADCAST_STRATEGY_SCALAR_READLANE:
-      IREE_ASSERT_NE(plan->exact_source_lane, UINT32_MAX);
+    case LOOM_AMDGPU_SUBGROUP_BROADCAST_STRATEGY_SCALAR_READLANE: {
       IREE_RETURN_IF_ERROR(loom_amdgpu_make_sgpr_type(context, &scalar_type));
+      if (plan->exact_source_lane == UINT32_MAX) {
+        IREE_RETURN_IF_ERROR(loom_low_lower_lookup_value(
+            context, plan->source_lane, &low_source_lane));
+      }
       break;
+    }
     default:
       IREE_ASSERT_UNREACHABLE("unsupported AMDGPU subgroup broadcast strategy");
   }
@@ -237,9 +250,17 @@ iree_status_t loom_amdgpu_lower_kernel_subgroup_broadcast(
       }
       case LOOM_AMDGPU_SUBGROUP_BROADCAST_STRATEGY_SCALAR_READLANE: {
         loom_value_id_t scalar_register = LOOM_VALUE_ID_INVALID;
-        IREE_RETURN_IF_ERROR(loom_amdgpu_emit_subgroup_readlane_register(
-            context, source_op, &plan->exchange_descriptor, low_source_register,
-            plan->exact_source_lane, scalar_type, &scalar_register));
+        if (plan->exact_source_lane != UINT32_MAX) {
+          IREE_RETURN_IF_ERROR(loom_amdgpu_emit_subgroup_readlane_register(
+              context, source_op, &plan->exchange_descriptor,
+              low_source_register, plan->exact_source_lane, scalar_type,
+              &scalar_register));
+        } else {
+          IREE_RETURN_IF_ERROR(loom_amdgpu_emit_subgroup_readlane_sgpr_register(
+              context, source_op, &plan->exchange_descriptor,
+              low_source_register, low_source_lane, scalar_type,
+              &scalar_register));
+        }
         IREE_RETURN_IF_ERROR(loom_amdgpu_emit_resolved_vgpr_unary(
             context, source_op, &plan->scalar_copy_descriptor, scalar_register,
             lane_type, &result_registers[i]));
@@ -339,15 +360,19 @@ iree_status_t loom_amdgpu_low_legality_verify_kernel_subgroup_broadcast(
         context, op, LOOM_AMDGPU_DESCRIPTOR_REF_DS_BPERMUTE_B32,
         IREE_SV("descriptor.ds_bpermute_b32"));
   }
-  if (shape.exact_source_lane == UINT32_MAX) {
+  if (shape.exact_source_lane == UINT32_MAX &&
+      !shape.source_lane_is_subgroup_uniform) {
     return loom_amdgpu_low_legality_reject(
-        context, op, IREE_SV("subgroup_broadcast.native_width"));
+        context, op, IREE_SV("subgroup_broadcast.uniform_lane"));
   }
+  const loom_amdgpu_descriptor_ref_t exchange_descriptor_ref =
+      shape.exact_source_lane == UINT32_MAX
+          ? LOOM_AMDGPU_DESCRIPTOR_REF_V_READLANE_B32_SRC1_SGPR
+          : LOOM_AMDGPU_DESCRIPTOR_REF_V_READLANE_B32_SRC1_INLINE;
   const loom_amdgpu_low_legality_descriptor_requirement_t requirements[] = {
       {
           .constraint_key = IREE_SVL("descriptor.v_readlane_b32"),
-          .descriptor_ref =
-              LOOM_AMDGPU_DESCRIPTOR_REF_V_READLANE_B32_SRC1_INLINE,
+          .descriptor_ref = exchange_descriptor_ref,
       },
       {
           .constraint_key = IREE_SVL("descriptor.v_mov_b32_copy"),

--- a/loom/src/loom/target/arch/amdgpu/lower/subgroup_crosslane.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/subgroup_crosslane.c
@@ -186,6 +186,26 @@ iree_status_t loom_amdgpu_emit_subgroup_readlane_register(
   return iree_ok_status();
 }
 
+iree_status_t loom_amdgpu_emit_subgroup_readlane_sgpr_register(
+    loom_low_lower_context_t* context, const loom_op_t* source_op,
+    const loom_low_lower_resolved_descriptor_t* descriptor,
+    loom_value_id_t source_value, loom_value_id_t source_lane,
+    loom_type_t result_type, loom_value_id_t* out_low_result) {
+  *out_low_result = LOOM_VALUE_ID_INVALID;
+  const loom_value_id_t operands[] = {
+      source_value,
+      source_lane,
+  };
+  loom_op_t* low_op = NULL;
+  IREE_RETURN_IF_ERROR(loom_low_lower_emit_resolved_descriptor_op(
+      context, descriptor, operands, IREE_ARRAYSIZE(operands),
+      loom_make_named_attr_slice(NULL, 0), &result_type, 1,
+      /*tied_results=*/NULL, /*tied_result_count=*/0, source_op->location,
+      &low_op));
+  *out_low_result = loom_value_slice_get(loom_low_op_results(low_op), 0);
+  return iree_ok_status();
+}
+
 iree_status_t loom_amdgpu_emit_direct_crosslane_register(
     loom_low_lower_context_t* context, const loom_op_t* source_op,
     const loom_low_lower_resolved_descriptor_t* descriptor,

--- a/loom/src/loom/target/arch/amdgpu/lower/sync.c
+++ b/loom/src/loom/target/arch/amdgpu/lower/sync.c
@@ -11,6 +11,7 @@
 #include "loom/target/arch/amdgpu/lower/emit.h"
 #include "loom/target/arch/amdgpu/lower/legality.h"
 #include "loom/target/arch/amdgpu/lower/system_memory.h"
+#include "loom/target/arch/amdgpu/lower/topology.h"
 #include "loom/target/arch/amdgpu/planning/wait_packets.h"
 #include "loom/target/arch/amdgpu/planning/wait_plan.h"
 #include "loom/target/arch/amdgpu/refs/target_refs.h"
@@ -46,6 +47,31 @@ static bool loom_amdgpu_kernel_barrier_global_ordering_available(
   }
   return !loom_amdgpu_kernel_barrier_global_ordering_has_acquire(source_op) ||
          loom_amdgpu_system_memory_acquire_ordering_available(descriptor_set);
+}
+
+static bool loom_amdgpu_workgroup_is_single_subgroup(
+    const loom_module_t* module, loom_func_like_t function,
+    const loom_target_bundle_t* bundle,
+    const loom_value_fact_table_t* fact_table) {
+  uint32_t flat_workgroup_size = 0;
+  return loom_amdgpu_required_flat_workgroup_size_from_facts(
+             module, function, bundle, fact_table, &flat_workgroup_size) &&
+         flat_workgroup_size <= loom_amdgpu_target_wavefront_size(bundle);
+}
+
+static bool loom_amdgpu_kernel_barrier_is_memory_order_only(
+    const loom_module_t* module, loom_func_like_t function,
+    const loom_target_bundle_t* bundle,
+    const loom_value_fact_table_t* fact_table, const loom_op_t* source_op) {
+  if (loom_amdgpu_kernel_barrier_is_global_memory(source_op)) {
+    return false;
+  }
+  if (loom_kernel_barrier_scope(source_op) == LOOM_ATOMIC_SCOPE_SUBGROUP) {
+    return true;
+  }
+  return loom_kernel_barrier_scope(source_op) == LOOM_ATOMIC_SCOPE_WORKGROUP &&
+         loom_amdgpu_workgroup_is_single_subgroup(module, function, bundle,
+                                                  fact_table);
 }
 
 static iree_status_t loom_amdgpu_select_kernel_barrier_lds_wait(
@@ -137,10 +163,19 @@ iree_status_t loom_amdgpu_select_kernel_barrier_plan(
   }
 
   loom_amdgpu_kernel_barrier_plan_t local_plan = {0};
-  if (loom_kernel_barrier_scope(source_op) == LOOM_ATOMIC_SCOPE_SUBGROUP) {
+  const bool is_memory_order_only =
+      loom_amdgpu_kernel_barrier_is_memory_order_only(
+          loom_low_lower_context_module(context),
+          loom_low_lower_context_source_function(context),
+          loom_low_lower_context_bundle(context),
+          loom_low_lower_context_fact_table(context), source_op);
+  if (is_memory_order_only) {
     IREE_RETURN_IF_ERROR(
         loom_amdgpu_select_kernel_barrier_lds_wait(context, &local_plan));
-  } else {
+  }
+  if (local_plan.kind == LOOM_AMDGPU_KERNEL_BARRIER_LOWERING_KIND_NONE &&
+      (!is_memory_order_only ||
+       loom_kernel_barrier_scope(source_op) == LOOM_ATOMIC_SCOPE_WORKGROUP)) {
     IREE_RETURN_IF_ERROR(
         loom_amdgpu_select_workgroup_barrier_plan(context, &local_plan));
   }
@@ -243,12 +278,18 @@ iree_status_t loom_amdgpu_low_legality_verify_kernel_barrier(
     return iree_ok_status();
   }
 
-  if (loom_kernel_barrier_scope(op) == LOOM_ATOMIC_SCOPE_SUBGROUP) {
-    if (!loom_amdgpu_workgroup_memory_wait_lowering_available(descriptor_set)) {
-      return loom_amdgpu_low_legality_reject(
-          context, op, IREE_SV("descriptor.workgroup_memory_wait"));
-    }
+  const bool is_memory_order_only =
+      loom_amdgpu_kernel_barrier_is_memory_order_only(
+          loom_target_low_legality_module(context),
+          loom_target_low_legality_function(context), bundle,
+          loom_target_low_legality_fact_table(context), op);
+  if (is_memory_order_only &&
+      loom_amdgpu_workgroup_memory_wait_lowering_available(descriptor_set)) {
     return iree_ok_status();
+  }
+  if (loom_kernel_barrier_scope(op) == LOOM_ATOMIC_SCOPE_SUBGROUP) {
+    return loom_amdgpu_low_legality_reject(
+        context, op, IREE_SV("descriptor.workgroup_memory_wait"));
   }
 
   if (!loom_amdgpu_workgroup_barrier_lowering_available(descriptor_set)) {

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_ml_attention.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_ml_attention.loom-test
@@ -228,7 +228,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 
   %output_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 1024} : reg<amdgpu.sgpr x2>
   %34 = copy %init : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
   %carried_init = v_wmma_f32_16x16x16_bf16 %lhs, %rhs0, %34
-  s_barrier
+  s_waitcnt {lgkmcnt = 0}
   %36 = copy %carried_init : reg<amdgpu.vgpr x8> -> reg<amdgpu.vgpr x8>
   %output = v_wmma_f32_16x16x16_bf16 %lhs, %rhs1, %36
   %38 = v_lshlrev_b32_src0_inline %32, 2

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma.loom-test
@@ -441,7 +441,7 @@ low.kernel.def target<amdgpu.rdna3.core>(@target) workgroup_size(32, 1, 1) workg
   %rhs_loaded = global_load_b128_saddr %60, %rhs_buffer_view
   low.op<amdgpu.ds_write_b128>(%60, %lhs_loaded) {offset = 0} memory_access([0, 3, 17, -1, 43, 16, 0, 16, 3, 0, 496, 16, 512]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr x4>)
   low.op<amdgpu.ds_write_b128>(%60, %rhs_loaded) {offset = 512} memory_access([0, 3, 18, -1, 43, 16, 0, 16, 3, 512, 1008, 528, 1024]) : (reg<amdgpu.vgpr>, reg<amdgpu.vgpr x4>)
-  s_barrier
+  s_waitcnt {lgkmcnt = 0}
   %66 = v_and_b32_src0_inline %tid, 15
   %67 = v_lshlrev_b32_src0_inline %66, 5
   %68 = low.op<amdgpu.ds_read_b128>(%67) {offset = 0} memory_access([0, 3, 17, -1, 3, 0, 0, 0, 0, 0, 0, 0, 0]) : (reg<amdgpu.vgpr>) -> reg<amdgpu.vgpr x4>

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_fragment_epilogue.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_mma_fragment_epilogue.loom-test
@@ -329,7 +329,7 @@ low.kernel.def target<amdgpu.rdna3.core>(@target) workgroup_size(32, 1, 1) workg
   %76 = v_mul_f32_src0_inline %59, 1073741824
   %78 = v_mul_f32_src0_inline %61, 1073741824
   %80 = v_mul_f32_src0_inline %63, 1073741824
-  s_barrier
+  s_waitcnt {lgkmcnt = 0}
   %82 = v_and_b32_src0_inline %19, 15
   %83 = v_and_b32_src0_inline %82, 1
   %84 = v_cmp_eq_i32_src1_inline %83 {rhs = 0}

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_nested_template_expansion.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_nested_template_expansion.loom-test
@@ -78,6 +78,6 @@ low.func.def target<amdgpu.gfx11.generic.core>(@target) abi(hal_kernel) @nested_
 }
 
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @nested_kernel_template_expansion() asm {
-  s_barrier
+  s_waitcnt {lgkmcnt = 0}
   return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_broadcast_wave64.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_broadcast_wave64.loom-test
@@ -78,3 +78,40 @@ low.kernel.def target<amdgpu.rdna3_5.core>(@target) workgroup_size(64, 1, 1) wor
   global_store_b128_saddr %40, %broadcast, %output_view
   return
 }
+
+// ====
+
+amdgpu.target<gfx1151> @target {subgroup_size = 64}
+
+kernel.def target(@target) @subgroup_broadcast_i32_uniform_dynamic_lane_wave64(%source_lane: index) {
+  %c1 = index.constant 1 : index
+  %c64 = index.constant 64 : index
+  kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
+} launch(%source_lane: index, %input: buffer, %output: buffer) {
+  %bounded_source_lane = index.assume %source_lane [range(%source_lane, 0, 63)] : index
+  %source_lane_i32 = index.cast %bounded_source_lane : index to i32
+  %tid = kernel.workitem.id<x> : index
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32>
+  %loaded = vector.load %input_view[%tid] : view<64xi32> -> vector<1xi32>
+  %value = vector.extract %loaded[0] : vector<1xi32> -> i32
+  %broadcast = kernel.subgroup.broadcast %value from %source_lane_i32 : i32, i32
+  %result = vector.from_elements %broadcast : vector<1xi32>
+  vector.store %result, %output_view[%tid] : vector<1xi32>, view<64xi32>
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.rdna3_5.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @subgroup_broadcast_i32_uniform_dynamic_lane_wave64(%source_lane_i32: reg<amdgpu.sgpr>) asm {
+  %tid = live_in<amdgpu.workitem_id.x> : reg<amdgpu.vgpr>
+  %input_view = resource<hal_binding> {index = 0, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
+  %output_view = resource<hal_binding> {index = 1, source_type = hal.buffer, extent = 256} : reg<amdgpu.sgpr x2>
+  %22 = v_lshlrev_b32_src0_inline %tid, 2
+  %value = global_load_b32_saddr %22, %input_view
+  %24 = v_readlane_b32_src1_sgpr %value, %source_lane_i32
+  %result = v_mov_b32_copy %24
+  %26 = v_lshlrev_b32_src0_inline %tid, 2
+  global_store_b32_saddr %26, %result, %output_view
+  return
+}

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_collective_diagnostics.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_subgroup_collective_diagnostics.loom-test
@@ -388,7 +388,7 @@ kernel.def target(@target) @subgroup_active_mask_i32_wave64_rejected() {
 // ====
 
 amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
-kernel.def target(@target) @subgroup_broadcast_dynamic_wave64_native_width_rejected() {
+kernel.def target(@target) @subgroup_broadcast_lane_varying_wave64_rejected() {
   %c1 = index.constant 1 : index
   %c64 = index.constant 64 : index
   kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c64, %c1, %c1) : index
@@ -397,7 +397,7 @@ kernel.def target(@target) @subgroup_broadcast_dynamic_wave64_native_width_rejec
   %value = index.cast %workitem : index to i32
   %lane_id = kernel.subgroup.lane.id : index
   %lane = index.cast %lane_id : index to i32
-  // ERROR@+1: AMDGPU/023 {constraint_key="subgroup_broadcast.native_width"}
+  // ERROR@+1: AMDGPU/023 {constraint_key="subgroup_broadcast.uniform_lane"}
   %broadcast = kernel.subgroup.broadcast %value from %lane : i32, i32
   kernel.return
 }

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sync_kernel.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sync_kernel.loom-test
@@ -13,7 +13,26 @@ kernel.def target(@target) @single_wave_barrier() {
 
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @single_wave_barrier() asm {
-  s_barrier
+  s_waitcnt {lgkmcnt = 0}
+  return
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
+
+kernel.def target(@target) @single_wave64_barrier() {
+  %unit = index.constant 1 : index
+  %threads = index.constant 64 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
+} launch() {
+  kernel.barrier<workgroup> scope(workgroup) ordering(acq_rel)
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @single_wave64_barrier() asm {
+  s_waitcnt {lgkmcnt = 0}
   return
 }
 
@@ -33,6 +52,48 @@ kernel.def target(@target) @multi_wave_barrier() {
 // ----
 low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @multi_wave_barrier() asm {
   s_barrier
+  return
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
+
+kernel.def target(@target) @unknown_workgroup_size_barrier(%threads: index) {
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
+} launch() {
+  kernel.barrier<workgroup> scope(workgroup) ordering(acq_rel)
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_count(1, 1, 1) @unknown_workgroup_size_barrier() asm {
+  s_barrier
+  return
+}
+
+// ====
+
+amdgpu.target<gfx11-generic> @target
+
+kernel.def target(@target) @single_wave_global_barrier() {
+  %unit = index.constant 1 : index
+  %threads = index.constant 32 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
+} launch() {
+  kernel.barrier<global> scope(workgroup) ordering(acq_rel)
+  kernel.return
+}
+
+// ----
+low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @single_wave_global_barrier() asm {
+  s_waitcnt {vmcnt = 0}
+  s_waitcnt_vscnt {vscnt = 0}
+  s_barrier
+  s_waitcnt {vmcnt = 0}
+  buffer_gl1_inv
+  buffer_gl0_inv
   return
 }
 
@@ -137,8 +198,7 @@ kernel.def target(@target) @single_wave_barrier_gfx12() {
 
 // ----
 low.kernel.def target<amdgpu.gfx12.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @single_wave_barrier_gfx12() asm {
-  s_barrier_signal_all
-  s_barrier_wait_all
+  s_wait_dscnt {dscnt = 0}
   return
 }
 
@@ -220,8 +280,7 @@ kernel.def target(@target) @single_wave_barrier_gfx12_5() {
 
 // ----
 low.kernel.def target<amdgpu.gfx12_5.generic.core>(@target) workgroup_size(32, 1, 1) workgroup_count(1, 1, 1) @single_wave_barrier_gfx12_5() asm {
-  s_barrier_signal_all
-  s_barrier_wait_all
+  s_wait_dscnt {dscnt = 0}
   return
 }
 
@@ -279,7 +338,7 @@ kernel.def target(@target) @single_wave_barrier_gfx9_4() {
 
 // ----
 low.kernel.def target<amdgpu.gfx9_4.generic.core>(@target) workgroup_size(64, 1, 1) workgroup_count(1, 1, 1) @single_wave_barrier_gfx9_4() asm {
-  s_barrier
+  s_waitcnt {lgkmcnt = 0}
   return
 }
 
@@ -379,7 +438,7 @@ low.kernel.def target<amdgpu.gfx11.generic.core>(@target) workgroup_size(64, 1, 
   %13, %14 = s_and_saveexec_b64 %is_zero
   low.cond_br %14, ^_bb1, ^_bb2 : reg<amdgpu.scc>
 ^_bb1:
-  s_barrier
+  s_waitcnt {lgkmcnt = 0}
   low.br ^_bb2
 ^_bb2:
   s_mov_b64_exec %13

--- a/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sync_kernel_report.loom-test
+++ b/loom/src/loom/target/arch/amdgpu/test/source_low/source_low_sync_kernel_report.loom-test
@@ -1,0 +1,18 @@
+// RUN: pass-report source-to-low,low-dce
+
+amdgpu.target<gfx11-generic> @target {subgroup_size = 64}
+
+kernel.def target(@target) @report_single_subgroup_workgroup_barrier() {
+  %unit = index.constant 1 : index
+  %threads = index.constant 64 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%threads, %unit, %unit) : index
+} launch() {
+  kernel.barrier<workgroup> scope(workgroup) ordering(acq_rel)
+  kernel.return
+}
+
+// ----
+COMPILE-REPORT: summary artifact=none status=OK function=- backend=- bundle=- export=- export_symbol=- config=- lowered=-
+COMPILE-REPORT: workload workgroup_size=64x1x1 flat_workgroup_size=64 workgroup_count=1x1x1 dispatch_workgroup_count=1 dispatch_workitem_count=64
+COMPILE-REPORT: source_low selected_ops=1 emitted_ops=1 rows=1
+COMPILE-REPORT: source_low[0] function=report_single_subgroup_workgroup_barrier source_op=kernel.barrier selection=plan plan_key=amdgpu.kernel_barrier.strategy.lds_wait.single_subgroup_workgroup emitted_ops=1

--- a/loom/src/loom/test/corpus/authoring/hip/hip_authoring.test.json
+++ b/loom/src/loom/test/corpus/authoring/hip/hip_authoring.test.json
@@ -721,7 +721,7 @@
             "\"cluster_size\":{\"x\":1,\"y\":2,\"z\":1,\"flat\":2}",
             "\"local_memory_bytes\":512",
             "\"explicit_action_count\":1",
-            "\"barrier_count\":2"
+            "\"barrier_count\":0"
           ]
         }
       },

--- a/loom/src/loom/tooling/target/amdgpu/test/BUILD.bazel
+++ b/loom/src/loom/tooling/target/amdgpu/test/BUILD.bazel
@@ -36,6 +36,7 @@ iree_execution_test_suite(
         "gfx1250_configured_fragment_bank.loom",
         "long_sopp_branch.loom",
         "selected_root_amdgpu.loom",
+        "single_subgroup_barrier.loom",
         "target_family_template_provider_amdgpu.loom",
         "wave64_named_lane_broadcast.loom",
     ],

--- a/loom/src/loom/tooling/target/amdgpu/test/CMakeLists.txt
+++ b/loom/src/loom/tooling/target/amdgpu/test/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_execution_test_suite(
     "${PROJECT_SOURCE_DIR}/loom/src/loom/tooling/target/amdgpu/test/gfx1250_configured_fragment_bank.loom"
     "${PROJECT_SOURCE_DIR}/loom/src/loom/tooling/target/amdgpu/test/long_sopp_branch.loom"
     "${PROJECT_SOURCE_DIR}/loom/src/loom/tooling/target/amdgpu/test/selected_root_amdgpu.loom"
+    "${PROJECT_SOURCE_DIR}/loom/src/loom/tooling/target/amdgpu/test/single_subgroup_barrier.loom"
     "${PROJECT_SOURCE_DIR}/loom/src/loom/tooling/target/amdgpu/test/target_family_template_provider_amdgpu.loom"
     "${PROJECT_SOURCE_DIR}/loom/src/loom/tooling/target/amdgpu/test/wave64_named_lane_broadcast.loom"
   LABELS

--- a/loom/src/loom/tooling/target/amdgpu/test/loom-compile-amdgpu.test.json
+++ b/loom/src/loom/tooling/target/amdgpu/test/loom-compile-amdgpu.test.json
@@ -2,6 +2,65 @@
   "version": 1,
   "cases": [
     {
+      "name": "lowers single-subgroup workgroup barriers to memory ordering waits",
+      "steps": [
+        {
+          "name": "compile-gfx11-generic",
+          "run": {
+            "tool": "loom-compile",
+            "args": [
+              "{srcdir}/single_subgroup_barrier.loom",
+              "--backend=amdgpu-hal",
+              "--target=gfx11-generic",
+              "--output={tmp}/single_subgroup_barrier_gfx11.hal",
+              "--emit-target-artifact={tmp}/single_subgroup_barrier_gfx11.hsaco",
+              "--compile-report=details",
+              "--compile-report-output={tmp}/single_subgroup_barrier_gfx11_report.json"
+            ]
+          },
+          "files": [
+            {
+              "path": "{tmp}/single_subgroup_barrier_gfx11.hal",
+              "non_empty": true
+            },
+            {
+              "path": "{tmp}/single_subgroup_barrier_gfx11.hsaco",
+              "non_empty": true
+            },
+            {
+              "path": "{tmp}/single_subgroup_barrier_gfx11_report.json",
+              "contains": [
+                "amdgpu.kernel_barrier.strategy.lds_wait.single_subgroup_workgroup"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "compile-gfx1151",
+          "run": {
+            "tool": "loom-compile",
+            "args": [
+              "{srcdir}/single_subgroup_barrier.loom",
+              "--backend=amdgpu-hal",
+              "--target=gfx1151",
+              "--output={tmp}/single_subgroup_barrier_gfx1151.hal",
+              "--emit-target-artifact={tmp}/single_subgroup_barrier_gfx1151.hsaco"
+            ]
+          },
+          "files": [
+            {
+              "path": "{tmp}/single_subgroup_barrier_gfx1151.hal",
+              "non_empty": true
+            },
+            {
+              "path": "{tmp}/single_subgroup_barrier_gfx1151.hsaco",
+              "non_empty": true
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "compiles exact and uniform dynamic wave64 broadcasts across native wave32 halves",
       "steps": [
         {

--- a/loom/src/loom/tooling/target/amdgpu/test/loom-compile-amdgpu.test.json
+++ b/loom/src/loom/tooling/target/amdgpu/test/loom-compile-amdgpu.test.json
@@ -2,7 +2,7 @@
   "version": 1,
   "cases": [
     {
-      "name": "compiles named-lane wave64 broadcasts across native wave32 halves",
+      "name": "compiles exact and uniform dynamic wave64 broadcasts across native wave32 halves",
       "steps": [
         {
           "name": "compile-gfx11-generic",

--- a/loom/src/loom/tooling/target/amdgpu/test/single_subgroup_barrier.loom
+++ b/loom/src/loom/tooling/target/amdgpu/test/single_subgroup_barrier.loom
@@ -1,0 +1,29 @@
+// A WG64/wave64 workgroup needs LDS ordering but has no second wave with
+// which to rendezvous.
+amdgpu.target<gfx11-generic> @wave64_target {subgroup_size = 64}
+
+kernel.def target(@wave64_target) @single_subgroup_exchange() {
+  %unit = index.constant 1 : index
+  %wave_size = index.constant 64 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%wave_size, %unit, %unit) : index
+} launch(%input: buffer, %output: buffer) {
+  %lane0 = kernel.subgroup.lane.id : index
+  %lane = index.assume %lane0 [range(%lane0, 0, 63)] : index
+  %cohort_source_offset = index.constant 1 : index
+  %cohort_width = index.constant 16 : index
+  %cohort = index.div %lane, %cohort_width : index
+  %cohort_base = index.mul %cohort, %cohort_width : index
+  %source_lane = index.add %cohort_base, %cohort_source_offset : index
+  %buffer_base = index.constant 0 : offset
+  %stage_bytes = index.constant 256 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32>
+  %stage = buffer.alloca<workgroup> align(16) %stage_bytes : buffer
+  %stage_view = buffer.view %stage[%buffer_base] : buffer -> view<64xi32>
+  %value = view.load %input_view[%lane] : view<64xi32> -> i32
+  view.store %value, %stage_view[%lane] : i32, view<64xi32>
+  kernel.barrier<workgroup> scope(workgroup) ordering(acq_rel)
+  %broadcast = view.load %stage_view[%source_lane] : view<64xi32> -> i32
+  view.store %broadcast, %output_view[%lane] : i32, view<64xi32>
+  kernel.return
+}

--- a/loom/src/loom/tooling/target/amdgpu/test/wave64_named_lane_broadcast.loom
+++ b/loom/src/loom/tooling/target/amdgpu/test/wave64_named_lane_broadcast.loom
@@ -15,3 +15,20 @@ kernel.def target(@wave64_target) @wave64_named_lane_broadcast() {
   view.store %broadcast, %output_view[%lane] : i32, view<64xi32>
   kernel.return
 }
+
+kernel.def target(@wave64_target) @wave64_uniform_dynamic_lane_broadcast(%source_lane: index) {
+  %unit = index.constant 1 : index
+  %wave_size = index.constant 64 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%wave_size, %unit, %unit) : index
+} launch(%source_lane: index, %input: buffer, %output: buffer) {
+  %bounded_source_lane = index.assume %source_lane [range(%source_lane, 0, 63)] : index
+  %source_lane_i32 = index.cast %bounded_source_lane : index to i32
+  %lane = kernel.subgroup.lane.id : index
+  %buffer_base = index.constant 0 : offset
+  %input_view = buffer.view %input[%buffer_base] : buffer -> view<64xi32>
+  %output_view = buffer.view %output[%buffer_base] : buffer -> view<64xi32>
+  %value = view.load %input_view[%lane] : view<64xi32> -> i32
+  %broadcast = kernel.subgroup.broadcast %value from %source_lane_i32 : i32, i32
+  view.store %broadcast, %output_view[%lane] : i32, view<64xi32>
+  kernel.return
+}


### PR DESCRIPTION
Lowers the remaining AMDGPU communication cases that can be proven to stay inside one hardware wave: named-lane wave64 broadcasts with runtime-uniform selectors and workgroup-memory barriers for launches containing exactly one subgroup. This removes unsupported source restrictions and redundant cross-wave rendezvous without weakening the behavior of genuinely multi-wave kernels.

## Dynamic wave64 broadcast

Wave64 named-lane broadcast now selects `V_READLANE_B32` when the source lane is either exact or subgroup-uniform with a proven in-range value. Exact lanes retain the inline-immediate encoding, while dynamic uniform lanes use a new SGPR-source descriptor on gfx11 and gfx115x. Lane-varying and unbounded selectors remain rejected, and both readlane forms explicitly reserve the unused VOP3 `SRC2` field as zero.

## Single-subgroup barriers

A workgroup-memory barrier whose fact-aware launch topology proves an exact workgroup size no larger than the selected wavefront now drains LDS effects without emitting a cross-wave rendezvous. Multi-subgroup launches, unknown topology, and global-memory barriers retain their full workgroup synchronization. Targets without the required LDS wait packet can still fall back to a workgroup barrier, while subgroup-scoped barriers continue to reject any target that cannot honor their narrower control-flow contract.

Compile reports now identify whether each barrier selected subgroup-scoped LDS ordering, single-subgroup workgroup ordering, or full workgroup rendezvous, making the topology decision visible to downstream tooling and regression coverage.

## Reviewer Notes

The commits retain the dependency order for focused review: the first adds the SGPR readlane descriptor and wave64 broadcast path; the second proves the single-subgroup topology invariant and applies it consistently in selection, Low legality, reporting, and native artifact coverage.
