### PR TITLE
[AMDGPU] Add lazy queue provisioning for execution contexts

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/api.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/api.h
@@ -28,7 +28,26 @@ typedef uint32_t iree_hal_amdgpu_device_create_params_extension_type_t;
 enum iree_hal_amdgpu_device_create_params_extension_type_e {
   // Provides one opaque hostcall service for each physical device.
   IREE_HAL_AMDGPU_DEVICE_CREATE_PARAMS_EXTENSION_TYPE_HOSTCALL_PROVIDER = 1u,
+  // Configures eager and lazily activated host queue counts.
+  IREE_HAL_AMDGPU_DEVICE_CREATE_PARAMS_EXTENSION_TYPE_HOST_QUEUES = 2u,
 };
+
+// AMDGPU device creation extension controlling host queue provisioning.
+//
+// The device allocates |capacity| queue slots and advertises them through its
+// queue affinities. The first |initial_count| queues are initialized when the
+// device is assigned to its topology. Remaining queues are initialized on
+// first use, avoiding HSA queue and ring allocation costs until needed.
+typedef struct iree_hal_amdgpu_host_queue_extension_t {
+  // Common device creation extension prefix.
+  iree_hal_device_create_params_extension_t base;
+
+  // Maximum number of host queues per physical device.
+  iree_host_size_t capacity;
+
+  // Number of host queues initialized during device setup.
+  iree_host_size_t initial_count;
+} iree_hal_amdgpu_host_queue_extension_t;
 
 // Scalar physical-device facts available to opaque hostcall providers.
 typedef struct iree_hal_amdgpu_hostcall_provider_device_info_t {
@@ -494,6 +513,21 @@ IREE_API_EXPORT iree_status_t iree_hal_amdgpu_logical_device_create(
     const iree_hal_amdgpu_topology_t* topology,
     const iree_hal_device_create_params_t* create_params,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device);
+
+// Replaces the execution-unit mask of one idle AMDGPU host queue.
+//
+// Each bit in |mask| controls one execution unit. |mask_bit_count| must be a
+// multiple of 32 and describe the complete mask expected by the device. A zero
+// bit count with a NULL mask restores the device default.
+//
+// This is persistent queue configuration, not a submission. The caller must
+// exclusively own the exact one-bit |queue_affinity| and ensure all prior work
+// has completed before changing or restoring the mask. The queue must remain
+// exclusive until its default mask has been restored.
+IREE_API_EXPORT iree_status_t
+iree_hal_amdgpu_device_queue_set_execution_unit_mask(
+    iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
+    iree_host_size_t mask_bit_count, const uint32_t* mask);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_amdgpu_driver_t

--- a/runtime/src/iree/hal/drivers/amdgpu/api.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/api.h
@@ -34,10 +34,10 @@ enum iree_hal_amdgpu_device_create_params_extension_type_e {
 
 // AMDGPU device creation extension controlling host queue provisioning.
 //
-// The device allocates |capacity| queue slots and advertises them through its
-// queue affinities. The first |initial_count| queues are initialized when the
-// device is assigned to its topology. Remaining queues are initialized on
-// first use, avoiding HSA queue and ring allocation costs until needed.
+// The device allocates |capacity| queue slots. The first |initial_count| queues
+// are ordinary queues advertised through the device specification and are
+// initialized when the device is assigned to its topology. Remaining slots are
+// reserved for backend-specific execution queues and initialized when acquired.
 typedef struct iree_hal_amdgpu_host_queue_extension_t {
   // Common device creation extension prefix.
   iree_hal_device_create_params_extension_t base;
@@ -48,6 +48,10 @@ typedef struct iree_hal_amdgpu_host_queue_extension_t {
   // Number of host queues initialized during device setup.
   iree_host_size_t initial_count;
 } iree_hal_amdgpu_host_queue_extension_t;
+
+// Opaque reservation of one specialized AMDGPU execution queue.
+typedef struct iree_hal_amdgpu_execution_queue_t
+    iree_hal_amdgpu_execution_queue_t;
 
 // Scalar physical-device facts available to opaque hostcall providers.
 typedef struct iree_hal_amdgpu_hostcall_provider_device_info_t {
@@ -514,20 +518,39 @@ IREE_API_EXPORT iree_status_t iree_hal_amdgpu_logical_device_create(
     const iree_hal_device_create_params_t* create_params,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device);
 
-// Replaces the execution-unit mask of one idle AMDGPU host queue.
+// Acquires a specialized execution queue with an immutable execution-unit mask.
 //
 // Each bit in |mask| controls one execution unit. |mask_bit_count| must be a
-// multiple of 32 and describe the complete mask expected by the device. A zero
-// bit count with a NULL mask restores the device default.
+// multiple of 32 and describe the complete mask expected by the selected
+// physical device. |device_affinity| selects the physical device but does not
+// identify or reserve a queue.
 //
-// This is persistent queue configuration, not a submission. The caller must
-// exclusively own the exact one-bit |queue_affinity| and ensure all prior work
-// has completed before changing or restoring the mask. The queue must remain
-// exclusive until its default mask has been restored.
-IREE_API_EXPORT iree_status_t
-iree_hal_amdgpu_device_queue_set_execution_unit_mask(
-    iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
-    iree_host_size_t mask_bit_count, const uint32_t* mask);
+// Acquisitions with the same physical device and exact mask share one backend
+// queue. A distinct mask consumes another specialized queue slot and fails with
+// IREE_STATUS_RESOURCE_EXHAUSTED when all slots are in use. Callers multiplex
+// their virtual execution streams using the exact affinity returned by
+// iree_hal_amdgpu_execution_queue_affinity and must stop submitting before
+// their final release. The driver restores the default mask before reusing the
+// slot for a different configuration.
+IREE_API_EXPORT iree_status_t iree_hal_amdgpu_execution_queue_acquire(
+    iree_hal_device_t* device, iree_hal_queue_affinity_t device_affinity,
+    iree_host_size_t mask_bit_count, const uint32_t* mask,
+    iree_hal_amdgpu_execution_queue_t** out_execution_queue);
+
+// Retains |execution_queue| for another owner.
+IREE_API_EXPORT void iree_hal_amdgpu_execution_queue_retain(
+    iree_hal_amdgpu_execution_queue_t* execution_queue);
+
+// Releases |execution_queue| and restores its queue's default mask after the
+// final owner has stopped submitting work.
+IREE_API_EXPORT void iree_hal_amdgpu_execution_queue_release(
+    iree_hal_amdgpu_execution_queue_t* execution_queue);
+
+// Returns the exact private affinity used to route work through the
+// reservation.
+IREE_API_EXPORT iree_hal_queue_affinity_t
+iree_hal_amdgpu_execution_queue_affinity(
+    const iree_hal_amdgpu_execution_queue_t* execution_queue);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_amdgpu_driver_t

--- a/runtime/src/iree/hal/drivers/amdgpu/api.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/api.h
@@ -537,10 +537,6 @@ IREE_API_EXPORT iree_status_t iree_hal_amdgpu_execution_queue_acquire(
     iree_host_size_t mask_bit_count, const uint32_t* mask,
     iree_hal_amdgpu_execution_queue_t** out_execution_queue);
 
-// Retains |execution_queue| for another owner.
-IREE_API_EXPORT void iree_hal_amdgpu_execution_queue_retain(
-    iree_hal_amdgpu_execution_queue_t* execution_queue);
-
 // Releases |execution_queue| and restores its queue's default mask after the
 // final owner has stopped submitting work.
 IREE_API_EXPORT void iree_hal_amdgpu_execution_queue_release(

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue.c
@@ -506,8 +506,9 @@ static void iree_hal_amdgpu_host_queue_request_completion_thread_stop(
   }
 }
 
-iree_status_t iree_hal_amdgpu_host_queue_wait_for_setup_epoch(
-    iree_hal_amdgpu_host_queue_t* queue, uint64_t epoch) {
+static iree_status_t iree_hal_amdgpu_host_queue_wait_for_epoch(
+    iree_hal_amdgpu_host_queue_t* queue, uint64_t epoch,
+    bool drain_completions) {
   IREE_ASSERT_ARGUMENT(queue);
   if (epoch == 0) return iree_ok_status();
   if (!queue->hardware_queue || !queue->notification_ring.epoch.signal.handle) {
@@ -579,8 +580,87 @@ iree_status_t iree_hal_amdgpu_host_queue_wait_for_setup_epoch(
   }
 
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_host_queue_clone_error_status(queue));
-  iree_hal_amdgpu_host_queue_drain_completions_for_waiter(queue);
+  if (drain_completions) {
+    iree_hal_amdgpu_host_queue_drain_completions_for_waiter(queue);
+  }
   return iree_hal_amdgpu_host_queue_clone_error_status(queue);
+}
+
+iree_status_t iree_hal_amdgpu_host_queue_wait_for_setup_epoch(
+    iree_hal_amdgpu_host_queue_t* queue, uint64_t epoch) {
+  return iree_hal_amdgpu_host_queue_wait_for_epoch(queue, epoch,
+                                                   /*drain_completions=*/true);
+}
+
+iree_status_t iree_hal_amdgpu_host_queue_begin_execution_lease(
+    iree_hal_amdgpu_host_queue_t* queue, uint32_t mask_bit_count,
+    const uint32_t* mask, bool* out_queue_reusable) {
+  IREE_ASSERT_ARGUMENT(queue);
+  IREE_ASSERT_ARGUMENT(mask);
+  IREE_ASSERT_ARGUMENT(out_queue_reusable);
+  *out_queue_reusable = false;
+
+  iree_slim_mutex_lock(&queue->locks.submission_mutex);
+  // Keep the submission gate closed until exact native configuration succeeds.
+  queue->is_shutting_down = true;
+  iree_status_t status = iree_ok_status();
+  bool mask_update_attempted = false;
+  if (IREE_UNLIKELY(queue->pending_head != NULL)) {
+    status = iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "cannot configure an AMDGPU execution queue with deferred work");
+  } else {
+    mask_update_attempted = true;
+    status = iree_hsa_amd_queue_cu_set_mask(IREE_LIBHSA(queue->libhsa),
+                                            queue->hardware_queue,
+                                            mask_bit_count, mask);
+  }
+  if (iree_status_is_ok(status)) {
+    queue->is_shutting_down = false;
+  } else if (mask_update_attempted) {
+    // A failed mask update may have modified the native queue. Only make the
+    // slot reusable if restoring the default mask succeeds.
+    iree_status_t reset_status = iree_hsa_amd_queue_cu_set_mask(
+        IREE_LIBHSA(queue->libhsa), queue->hardware_queue,
+        /*mask_bit_count=*/0, /*mask=*/NULL);
+    *out_queue_reusable = iree_status_is_ok(reset_status);
+    status = iree_status_join(status, reset_status);
+  }
+  iree_slim_mutex_unlock(&queue->locks.submission_mutex);
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_host_queue_end_execution_lease(
+    iree_hal_amdgpu_host_queue_t* queue) {
+  IREE_ASSERT_ARGUMENT(queue);
+
+  iree_slim_mutex_lock(&queue->locks.submission_mutex);
+  queue->is_shutting_down = true;
+  iree_status_t status = iree_ok_status();
+  uint64_t final_epoch = 0;
+  if (IREE_UNLIKELY(queue->pending_head != NULL)) {
+    status = iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "cannot release an AMDGPU execution queue with deferred work");
+  } else {
+    final_epoch = queue->notification_ring.epoch.next_submission;
+  }
+  iree_slim_mutex_unlock(&queue->locks.submission_mutex);
+
+  if (iree_status_is_ok(status)) {
+    // The completion thread owns normal notification draining and any
+    // continuations it discovers. This waiter only establishes GPU idleness.
+    status = iree_hal_amdgpu_host_queue_wait_for_epoch(
+        queue, final_epoch, /*drain_completions=*/false);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_slim_mutex_lock(&queue->locks.submission_mutex);
+    status = iree_hsa_amd_queue_cu_set_mask(
+        IREE_LIBHSA(queue->libhsa), queue->hardware_queue,
+        /*mask_bit_count=*/0, /*mask=*/NULL);
+    iree_slim_mutex_unlock(&queue->locks.submission_mutex);
+  }
+  return status;
 }
 
 static hsa_signal_value_t iree_hal_amdgpu_host_queue_last_drained_signal_value(

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue.h
@@ -745,6 +745,19 @@ iree_host_size_t iree_hal_amdgpu_host_queue_drain_completions_for_waiter(
 iree_status_t iree_hal_amdgpu_host_queue_wait_for_setup_epoch(
     iree_hal_amdgpu_host_queue_t* queue, uint64_t epoch);
 
+// Applies an immutable execution-unit mask and opens the queue for a
+// specialized lease. If native configuration fails, restores the default mask
+// before reporting the queue as reusable through |out_queue_reusable|.
+iree_status_t iree_hal_amdgpu_host_queue_begin_execution_lease(
+    iree_hal_amdgpu_host_queue_t* queue, uint32_t mask_bit_count,
+    const uint32_t* mask, bool* out_queue_reusable);
+
+// Closes a specialized queue to new submissions, waits for all committed work
+// to complete, and restores the default execution-unit mask. Deferred work at
+// final release violates the lease contract and leaves the queue quarantined.
+iree_status_t iree_hal_amdgpu_host_queue_end_execution_lease(
+    iree_hal_amdgpu_host_queue_t* queue);
+
 // Enables or disables HSA dispatch timestamp population for this queue.
 //
 // This toggles the ROCR queue profiler bit. It is a cold profiling-session

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profiling_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profiling_test.cc
@@ -1276,7 +1276,9 @@ TEST_F(HostQueueCommandBufferProfilingTest,
       test_device.logical_device();
   ASSERT_GT(logical_device->physical_device_count, 0u);
   for (iree_host_size_t i = 0; i < logical_device->physical_device_count; ++i) {
-    ASSERT_GT(logical_device->physical_devices[i]->host_queue_count, 0u);
+    ASSERT_GT(iree_hal_amdgpu_physical_device_host_queue_count(
+                  logical_device->physical_devices[i]),
+              0u);
   }
 
   CommandBufferProfileSink sink = {};
@@ -1318,7 +1320,9 @@ TEST_F(HostQueueCommandBufferProfilingTest,
     const iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[sample.physical_device_ordinal];
     const uint32_t expected_queue_ordinal =
-        (uint32_t)(physical_device->host_queue_count - 1);
+        (uint32_t)(iree_hal_amdgpu_physical_device_host_queue_count(
+                       physical_device) -
+                   1);
     EXPECT_EQ(sample.physical_device_ordinal, physical_device->device_ordinal);
     EXPECT_EQ(expected_queue_ordinal, sample.queue_ordinal);
     EXPECT_LT(sample.start_tick, sample.end_tick);

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_test.cc
@@ -88,7 +88,9 @@ class ScopedHostcallBufferAddress {
     EXPECT_EQ(physical_device_->hostcall_provider_state, nullptr);
     state_.device_address = device_address;
     physical_device_->hostcall_provider_state = &state_;
-    for (iree_host_size_t i = 0; i < physical_device_->host_queue_count; ++i) {
+    const iree_host_size_t host_queue_count =
+        iree_hal_amdgpu_physical_device_host_queue_count(physical_device_);
+    for (iree_host_size_t i = 0; i < host_queue_count; ++i) {
       EXPECT_EQ(physical_device_->host_queues[i].hostcall_buffer, nullptr);
       physical_device_->host_queues[i].hostcall_buffer =
           reinterpret_cast<void*>(device_address);
@@ -96,7 +98,9 @@ class ScopedHostcallBufferAddress {
   }
 
   ~ScopedHostcallBufferAddress() {
-    for (iree_host_size_t i = 0; i < physical_device_->host_queue_count; ++i) {
+    const iree_host_size_t host_queue_count =
+        iree_hal_amdgpu_physical_device_host_queue_count(physical_device_);
+    for (iree_host_size_t i = 0; i < host_queue_count; ++i) {
       physical_device_->host_queues[i].hostcall_buffer = nullptr;
     }
     physical_device_->hostcall_provider_state = nullptr;

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_test_util.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_test_util.h
@@ -83,7 +83,10 @@ class TestLogicalDevice {
     if (logical_device->physical_device_count == 0) return NULL;
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[0];
-    if (physical_device->host_queue_count == 0) return NULL;
+    if (iree_hal_amdgpu_physical_device_host_queue_count(physical_device) ==
+        0) {
+      return NULL;
+    }
     return &physical_device->host_queues[0];
   }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_pending_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_pending_test.cc
@@ -100,7 +100,10 @@ class TestLogicalDevice {
     if (logical_device->physical_device_count == 0) return NULL;
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[0];
-    if (physical_device->host_queue_count == 0) return NULL;
+    if (iree_hal_amdgpu_physical_device_host_queue_count(physical_device) ==
+        0) {
+      return NULL;
+    }
     return &physical_device->host_queues[0];
   }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_staging_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_staging_test.cc
@@ -241,7 +241,8 @@ class HostQueueStagingTest : public ::testing::Test {
     iree_hal_amdgpu_host_queue_t* first_host_queue() const {
       iree_hal_amdgpu_physical_device_t* physical_device =
           this->first_physical_device();
-      if (!physical_device || physical_device->host_queue_count == 0) {
+      if (!physical_device || iree_hal_amdgpu_physical_device_host_queue_count(
+                                  physical_device) == 0) {
         return NULL;
       }
       return &physical_device->host_queues[0];

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_submission_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_submission_test.cc
@@ -7,6 +7,7 @@
 #include "iree/hal/drivers/amdgpu/host_queue_submission.h"
 
 #include <cstdint>
+#include <vector>
 
 #include "iree/hal/api.h"
 #include "iree/hal/cts/util/test_base.h"
@@ -73,10 +74,13 @@ class TestLogicalDevice {
       const iree_hal_amdgpu_logical_device_options_t* options,
       const iree_hal_amdgpu_libhsa_t* libhsa,
       const iree_hal_amdgpu_topology_t* topology,
-      iree_allocator_t host_allocator) {
+      iree_allocator_t host_allocator,
+      const iree_hal_device_create_params_extension_t* extension = nullptr) {
     IREE_RETURN_IF_ERROR(create_context_.Initialize(host_allocator));
+    iree_hal_device_create_params_t create_params = *create_context_.params();
+    create_params.next = extension;
     IREE_RETURN_IF_ERROR(iree_hal_amdgpu_logical_device_create(
-        IREE_SV("amdgpu"), options, libhsa, topology, create_context_.params(),
+        IREE_SV("amdgpu"), options, libhsa, topology, &create_params,
         host_allocator, &base_device_));
     return iree_hal_device_group_create_from_device(
         base_device_, create_context_.frontier_tracker(), host_allocator,
@@ -176,6 +180,56 @@ class TestLogicalDeviceGroup {
   // Group owning the topology borrowed by both logical devices.
   iree_hal_device_group_t* device_group_ = NULL;
 };
+
+TEST_F(HostQueueSubmissionTest, ExecutionQueuesShareIdenticalMasks) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  iree_hal_amdgpu_host_queue_extension_t queue_extension = {
+      /*.base=*/
+      {
+          /*.type=*/
+          IREE_HAL_AMDGPU_DEVICE_CREATE_PARAMS_EXTENSION_TYPE_HOST_QUEUES,
+          /*.next=*/nullptr,
+      },
+      /*.capacity=*/IREE_HAL_AMDGPU_DEFAULT_GPU_AGENT_QUEUE_COUNT + 1,
+      /*.initial_count=*/IREE_HAL_AMDGPU_DEFAULT_GPU_AGENT_QUEUE_COUNT,
+  };
+
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(
+      &options, &libhsa_, &topology_, host_allocator_, &queue_extension.base));
+  auto* logical_device = reinterpret_cast<iree_hal_amdgpu_logical_device_t*>(
+      test_device.base_device());
+  ASSERT_GT(logical_device->physical_device_count, 0u);
+  const iree_host_size_t compute_unit_count =
+      logical_device->physical_devices[0]->compute_unit_count;
+  const iree_host_size_t mask_word_count = (compute_unit_count + 31) / 32;
+  std::vector<uint32_t> mask(mask_word_count, UINT32_MAX);
+  if (compute_unit_count % 32 != 0) {
+    mask.back() = (UINT32_C(1) << (compute_unit_count % 32)) - 1;
+  }
+
+  iree_hal_amdgpu_execution_queue_t* first_queue = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_execution_queue_acquire(
+      test_device.base_device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+      mask_word_count * 32, mask.data(), &first_queue));
+  ASSERT_NE(first_queue, nullptr);
+  iree_hal_amdgpu_execution_queue_t* second_queue = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_execution_queue_acquire(
+      test_device.base_device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+      mask_word_count * 32, mask.data(), &second_queue));
+  EXPECT_EQ(second_queue, first_queue);
+  EXPECT_EQ(iree_hal_amdgpu_execution_queue_affinity(second_queue),
+            iree_hal_amdgpu_execution_queue_affinity(first_queue));
+  EXPECT_NE(iree_hal_amdgpu_execution_queue_affinity(first_queue),
+            IREE_HAL_QUEUE_AFFINITY_ANY);
+
+  iree_hal_amdgpu_execution_queue_release(first_queue);
+  EXPECT_NE(logical_device->execution_queue_head, nullptr);
+  iree_hal_amdgpu_execution_queue_release(second_queue);
+  EXPECT_EQ(logical_device->execution_queue_head, nullptr);
+  EXPECT_EQ(logical_device->leased_execution_queue_affinity, 0u);
+}
 
 TEST_F(HostQueueSubmissionTest, GroupedLogicalDeviceQueueFrontiersAreDistinct) {
   iree_hal_amdgpu_logical_device_options_t options;

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_submission_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_submission_test.cc
@@ -93,7 +93,10 @@ class TestLogicalDevice {
     if (logical_device->physical_device_count == 0) return NULL;
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[0];
-    if (physical_device->host_queue_count == 0) return NULL;
+    if (iree_hal_amdgpu_physical_device_host_queue_count(physical_device) ==
+        0) {
+      return NULL;
+    }
     return &physical_device->host_queues[0];
   }
 
@@ -166,7 +169,10 @@ class TestLogicalDeviceGroup {
     if (logical_device->physical_device_count == 0) return NULL;
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[0];
-    if (physical_device->host_queue_count == 0) return NULL;
+    if (iree_hal_amdgpu_physical_device_host_queue_count(physical_device) ==
+        0) {
+      return NULL;
+    }
     return &physical_device->host_queues[0];
   }
 
@@ -232,6 +238,63 @@ TEST_F(HostQueueSubmissionTest, ExecutionQueuesShareIdenticalMasks) {
   iree_hal_amdgpu_execution_queue_release(second_queue);
   EXPECT_EQ(logical_device->execution_queue_head, nullptr);
   EXPECT_EQ(logical_device->leased_execution_queue_affinity, 0u);
+}
+
+TEST_F(HostQueueSubmissionTest, SpecializedQueueAffinityRequiresAnActiveLease) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  iree_hal_amdgpu_host_queue_extension_t queue_extension = {
+      /*.base=*/
+      {
+          /*.type=*/
+          IREE_HAL_AMDGPU_DEVICE_CREATE_PARAMS_EXTENSION_TYPE_HOST_QUEUES,
+          /*.next=*/nullptr,
+      },
+      /*.capacity=*/IREE_HAL_AMDGPU_DEFAULT_GPU_AGENT_QUEUE_COUNT + 1,
+      /*.initial_count=*/IREE_HAL_AMDGPU_DEFAULT_GPU_AGENT_QUEUE_COUNT,
+  };
+
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(
+      &options, &libhsa_, &topology_, host_allocator_, &queue_extension.base));
+  auto* logical_device = reinterpret_cast<iree_hal_amdgpu_logical_device_t*>(
+      test_device.base_device());
+  ASSERT_GT(logical_device->physical_device_count, 0u);
+  iree_hal_amdgpu_physical_device_t* physical_device =
+      logical_device->physical_devices[0];
+  const iree_hal_queue_affinity_t specialized_affinity =
+      (iree_hal_queue_affinity_t)1ull
+      << physical_device->host_queue_ordinary_count;
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION,
+                        iree_hal_device_queue_flush(test_device.base_device(),
+                                                    specialized_affinity));
+
+  const iree_host_size_t compute_unit_count =
+      physical_device->compute_unit_count;
+  const iree_host_size_t mask_word_count = (compute_unit_count + 31) / 32;
+  std::vector<uint32_t> mask(mask_word_count, UINT32_MAX);
+  if (compute_unit_count % 32 != 0) {
+    mask.back() = (UINT32_C(1) << (compute_unit_count % 32)) - 1;
+  }
+  iree_hal_amdgpu_execution_queue_t* execution_queue = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_execution_queue_acquire(
+      test_device.base_device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+      mask_word_count * 32, mask.data(), &execution_queue));
+  ASSERT_NE(execution_queue, nullptr);
+  ASSERT_EQ(iree_hal_amdgpu_execution_queue_affinity(execution_queue),
+            specialized_affinity);
+  IREE_ASSERT_OK(iree_hal_device_queue_barrier(
+      test_device.base_device(), specialized_affinity,
+      iree_hal_semaphore_list_empty(), iree_hal_semaphore_list_empty(),
+      IREE_HAL_EXECUTE_FLAG_NONE));
+
+  // Final release must wait for the submitted packet before restoring the
+  // native queue configuration and making the slot reusable.
+  iree_hal_amdgpu_execution_queue_release(execution_queue);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION,
+                        iree_hal_device_queue_flush(test_device.base_device(),
+                                                    specialized_affinity));
 }
 
 TEST_F(HostQueueSubmissionTest, ExecutionQueueCapacityIsBoundedAndReusable) {

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_submission_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_submission_test.cc
@@ -223,10 +223,127 @@ TEST_F(HostQueueSubmissionTest, ExecutionQueuesShareIdenticalMasks) {
             iree_hal_amdgpu_execution_queue_affinity(first_queue));
   EXPECT_NE(iree_hal_amdgpu_execution_queue_affinity(first_queue),
             IREE_HAL_QUEUE_AFFINITY_ANY);
+  EXPECT_EQ(iree_hal_amdgpu_execution_queue_affinity(first_queue) &
+                logical_device->ordinary_queue_affinity_mask,
+            0u);
 
   iree_hal_amdgpu_execution_queue_release(first_queue);
   EXPECT_NE(logical_device->execution_queue_head, nullptr);
   iree_hal_amdgpu_execution_queue_release(second_queue);
+  EXPECT_EQ(logical_device->execution_queue_head, nullptr);
+  EXPECT_EQ(logical_device->leased_execution_queue_affinity, 0u);
+}
+
+TEST_F(HostQueueSubmissionTest, ExecutionQueueCapacityIsBoundedAndReusable) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  iree_hal_amdgpu_host_queue_extension_t queue_extension = {
+      /*.base=*/
+      {
+          /*.type=*/
+          IREE_HAL_AMDGPU_DEVICE_CREATE_PARAMS_EXTENSION_TYPE_HOST_QUEUES,
+          /*.next=*/nullptr,
+      },
+      /*.capacity=*/IREE_HAL_AMDGPU_DEFAULT_GPU_AGENT_QUEUE_COUNT + 1,
+      /*.initial_count=*/IREE_HAL_AMDGPU_DEFAULT_GPU_AGENT_QUEUE_COUNT,
+  };
+
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(
+      &options, &libhsa_, &topology_, host_allocator_, &queue_extension.base));
+  auto* logical_device = reinterpret_cast<iree_hal_amdgpu_logical_device_t*>(
+      test_device.base_device());
+  ASSERT_GT(logical_device->physical_device_count, 0u);
+  const iree_host_size_t compute_unit_count =
+      logical_device->physical_devices[0]->compute_unit_count;
+  ASSERT_GE(compute_unit_count, 4u);
+  const iree_host_size_t mask_word_count = (compute_unit_count + 31) / 32;
+  std::vector<uint32_t> first_mask(mask_word_count, UINT32_MAX);
+  if (compute_unit_count % 32 != 0) {
+    first_mask.back() = (UINT32_C(1) << (compute_unit_count % 32)) - 1;
+  }
+  std::vector<uint32_t> second_mask = first_mask;
+  second_mask[0] &= ~UINT32_C(3);
+
+  iree_hal_amdgpu_execution_queue_t* first_queue = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_execution_queue_acquire(
+      test_device.base_device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+      mask_word_count * 32, first_mask.data(), &first_queue));
+  const iree_hal_queue_affinity_t reusable_affinity =
+      iree_hal_amdgpu_execution_queue_affinity(first_queue);
+
+  iree_hal_amdgpu_execution_queue_t* second_queue = nullptr;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_RESOURCE_EXHAUSTED,
+      iree_hal_amdgpu_execution_queue_acquire(
+          test_device.base_device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+          mask_word_count * 32, second_mask.data(), &second_queue));
+  EXPECT_EQ(second_queue, nullptr);
+
+  iree_hal_amdgpu_execution_queue_release(first_queue);
+  IREE_ASSERT_OK(iree_hal_amdgpu_execution_queue_acquire(
+      test_device.base_device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+      mask_word_count * 32, second_mask.data(), &second_queue));
+  EXPECT_EQ(iree_hal_amdgpu_execution_queue_affinity(second_queue),
+            reusable_affinity);
+  iree_hal_amdgpu_execution_queue_release(second_queue);
+}
+
+TEST_F(HostQueueSubmissionTest,
+       ExecutionQueueRejectsInvalidMasksWithoutReservation) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  iree_hal_amdgpu_host_queue_extension_t queue_extension = {
+      /*.base=*/
+      {
+          /*.type=*/
+          IREE_HAL_AMDGPU_DEVICE_CREATE_PARAMS_EXTENSION_TYPE_HOST_QUEUES,
+          /*.next=*/nullptr,
+      },
+      /*.capacity=*/IREE_HAL_AMDGPU_DEFAULT_GPU_AGENT_QUEUE_COUNT + 1,
+      /*.initial_count=*/IREE_HAL_AMDGPU_DEFAULT_GPU_AGENT_QUEUE_COUNT,
+  };
+
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(
+      &options, &libhsa_, &topology_, host_allocator_, &queue_extension.base));
+  auto* logical_device = reinterpret_cast<iree_hal_amdgpu_logical_device_t*>(
+      test_device.base_device());
+  ASSERT_GT(logical_device->physical_device_count, 0u);
+  const iree_host_size_t compute_unit_count =
+      logical_device->physical_devices[0]->compute_unit_count;
+  const iree_host_size_t mask_word_count = (compute_unit_count + 31) / 32;
+
+  iree_hal_amdgpu_execution_queue_t* execution_queue = nullptr;
+  std::vector<uint32_t> wrong_size_mask(mask_word_count + 1, UINT32_MAX);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_execution_queue_acquire(
+          test_device.base_device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+          wrong_size_mask.size() * 32, wrong_size_mask.data(),
+          &execution_queue));
+  EXPECT_EQ(execution_queue, nullptr);
+
+  std::vector<uint32_t> empty_mask(mask_word_count, 0);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_execution_queue_acquire(
+          test_device.base_device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+          empty_mask.size() * 32, empty_mask.data(), &execution_queue));
+  EXPECT_EQ(execution_queue, nullptr);
+
+  if (compute_unit_count % 32 != 0) {
+    std::vector<uint32_t> out_of_range_mask(mask_word_count, 0);
+    out_of_range_mask.back() = UINT32_C(1) << (compute_unit_count % 32);
+    IREE_EXPECT_STATUS_IS(
+        IREE_STATUS_INVALID_ARGUMENT,
+        iree_hal_amdgpu_execution_queue_acquire(
+            test_device.base_device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+            out_of_range_mask.size() * 32, out_of_range_mask.data(),
+            &execution_queue));
+    EXPECT_EQ(execution_queue, nullptr);
+  }
+
   EXPECT_EQ(logical_device->execution_queue_head, nullptr);
   EXPECT_EQ(logical_device->leased_execution_queue_affinity, 0u);
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_timestamp_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_timestamp_test.cc
@@ -84,7 +84,10 @@ class TestLogicalDevice {
   iree_hal_amdgpu_host_queue_t* first_host_queue() const {
     iree_hal_amdgpu_physical_device_t* physical_device =
         this->first_physical_device();
-    if (!physical_device || physical_device->host_queue_count == 0) return NULL;
+    if (!physical_device || iree_hal_amdgpu_physical_device_host_queue_count(
+                                physical_device) == 0) {
+      return NULL;
+    }
     return &physical_device->host_queues[0];
   }
 
@@ -100,8 +103,10 @@ class TestLogicalDevice {
          device_index < device->physical_device_count; ++device_index) {
       iree_hal_amdgpu_physical_device_t* physical_device =
           device->physical_devices[device_index];
-      for (iree_host_size_t queue_index = 0;
-           queue_index < physical_device->host_queue_count; ++queue_index) {
+      const iree_host_size_t host_queue_count =
+          iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
+      for (iree_host_size_t queue_index = 0; queue_index < host_queue_count;
+           ++queue_index) {
         iree_hal_amdgpu_host_queue_t* queue =
             &physical_device->host_queues[queue_index];
         iree_slim_mutex_lock(&queue->locks.submission_mutex);

--- a/runtime/src/iree/hal/drivers/amdgpu/hostcall_provider_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/hostcall_provider_test.cc
@@ -391,7 +391,9 @@ TEST_F(HostcallProviderTest, EagerPhysicalLifecycleAndFailurePublication) {
               provider_context->notification_token);
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
-    for (iree_host_size_t j = 0; j < physical_device->host_queue_count; ++j) {
+    const iree_host_size_t host_queue_count =
+        iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
+    for (iree_host_size_t j = 0; j < host_queue_count; ++j) {
       EXPECT_EQ(physical_device->host_queues[j].hostcall_buffer,
                 reinterpret_cast<void*>(hostcall_state->device_address));
     }

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -39,6 +39,30 @@
 // Utilities
 //===----------------------------------------------------------------------===//
 
+struct iree_hal_amdgpu_execution_queue_t {
+  // Next execution queue in the logical-device registry.
+  struct iree_hal_amdgpu_execution_queue_t* next;
+
+  // Logical device owning the reserved queue. Retained.
+  iree_hal_amdgpu_logical_device_t* logical_device;
+
+  // Number of clients sharing this immutable queue configuration.
+  // Protected by the logical device execution queue mutex.
+  iree_host_size_t reference_count;
+
+  // Exact private affinity routing submissions to the reserved queue.
+  iree_hal_queue_affinity_t queue_affinity;
+
+  // Physical device selected by the queue configuration.
+  iree_host_size_t physical_device_ordinal;
+
+  // Number of bits stored in execution_unit_mask.
+  iree_host_size_t execution_unit_mask_bit_count;
+
+  // Immutable execution-unit mask applied to the reserved queue.
+  uint32_t execution_unit_mask[];
+};
+
 static iree_hal_amdgpu_queue_affinity_domain_t
 iree_hal_amdgpu_logical_device_queue_affinity_domain(
     const iree_hal_amdgpu_logical_device_t* logical_device) {
@@ -48,6 +72,18 @@ iree_hal_amdgpu_logical_device_queue_affinity_domain(
       .queue_count_per_physical_device =
           logical_device->system->topology.gpu_agent_queue_count,
   };
+}
+
+static iree_hal_amdgpu_queue_affinity_domain_t
+iree_hal_amdgpu_logical_device_submission_affinity_domain(
+    const iree_hal_amdgpu_logical_device_t* logical_device,
+    iree_hal_queue_affinity_t queue_affinity) {
+  iree_hal_amdgpu_queue_affinity_domain_t domain =
+      iree_hal_amdgpu_logical_device_queue_affinity_domain(logical_device);
+  if (queue_affinity == IREE_HAL_QUEUE_AFFINITY_ANY) {
+    domain.supported_affinity = logical_device->ordinary_queue_affinity_mask;
+  }
+  return domain;
 }
 
 static iree_status_t iree_hal_amdgpu_logical_device_resolve_create_extensions(
@@ -1622,7 +1658,8 @@ static iree_status_t iree_hal_amdgpu_logical_device_select_host_queue(
 
   iree_hal_amdgpu_queue_affinity_resolved_t resolved;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_queue_affinity_resolve(
-      iree_hal_amdgpu_logical_device_queue_affinity_domain(logical_device),
+      iree_hal_amdgpu_logical_device_submission_affinity_domain(logical_device,
+                                                                queue_affinity),
       queue_affinity, &resolved));
   return iree_hal_amdgpu_logical_device_queue_from_ordinal(
       logical_device, resolved.queue_ordinal, out_queue);
@@ -1646,7 +1683,8 @@ iree_hal_amdgpu_logical_device_select_queue_pool_physical_device(
 
   iree_hal_amdgpu_queue_affinity_resolved_t resolved;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_queue_affinity_resolve(
-      iree_hal_amdgpu_logical_device_queue_affinity_domain(logical_device),
+      iree_hal_amdgpu_logical_device_submission_affinity_domain(logical_device,
+                                                                queue_affinity),
       queue_affinity, &resolved));
   *out_physical_device =
       logical_device->physical_devices[resolved.physical_device_ordinal];
@@ -1666,7 +1704,8 @@ iree_hal_amdgpu_logical_device_normalize_command_buffer_affinity(
   *out_device_ordinal = 0;
 
   return iree_hal_amdgpu_queue_affinity_normalize_for_physical_device(
-      iree_hal_amdgpu_logical_device_queue_affinity_domain(logical_device),
+      iree_hal_amdgpu_logical_device_submission_affinity_domain(logical_device,
+                                                                queue_affinity),
       queue_affinity, out_queue_affinity, out_device_ordinal);
 }
 
@@ -1869,6 +1908,7 @@ static iree_status_t iree_hal_amdgpu_logical_device_verify_physical_options(
 
 static iree_status_t iree_hal_amdgpu_logical_device_allocate_storage(
     iree_string_view_t identifier, const iree_hal_amdgpu_topology_t* topology,
+    iree_host_size_t host_queue_initial_count,
     iree_host_size_t physical_device_size, iree_allocator_t host_allocator,
     iree_hal_amdgpu_logical_device_t** out_logical_device) {
   *out_logical_device = NULL;
@@ -1892,12 +1932,19 @@ static iree_status_t iree_hal_amdgpu_logical_device_allocate_storage(
       .queue_count_per_physical_device = topology->gpu_agent_queue_count,
   };
   iree_hal_queue_affinity_t logical_queue_affinity_mask = 0;
+  iree_hal_queue_affinity_t ordinary_queue_affinity_mask = 0;
   for (iree_host_size_t i = 0; i < topology->gpu_agent_count; ++i) {
     iree_hal_queue_affinity_t physical_device_affinity = 0;
     IREE_RETURN_IF_ERROR(iree_hal_amdgpu_queue_affinity_for_physical_device(
         queue_affinity_domain, i, &physical_device_affinity));
     iree_hal_queue_affinity_or_into(logical_queue_affinity_mask,
                                     physical_device_affinity);
+    const iree_host_size_t queue_ordinal_base =
+        i * topology->gpu_agent_queue_count;
+    for (iree_host_size_t j = 0; j < host_queue_initial_count; ++j) {
+      ordinary_queue_affinity_mask |= (iree_hal_queue_affinity_t)1ull
+                                      << (queue_ordinal_base + j);
+    }
   }
 
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(host_allocator, total_size,
@@ -1921,11 +1968,15 @@ static iree_status_t iree_hal_amdgpu_logical_device_allocate_storage(
   // Setup physical device table first so failure cleanup has a valid table.
   logical_device->physical_device_count = topology->gpu_agent_count;
   logical_device->queue_affinity_mask = logical_queue_affinity_mask;
+  logical_device->ordinary_queue_affinity_mask = ordinary_queue_affinity_mask;
+  logical_device->leased_execution_queue_affinity = 0;
+  logical_device->execution_queue_head = NULL;
   iree_atomic_store(&logical_device->active_queue_affinity, 0,
                     iree_memory_order_relaxed);
   iree_atomic_store(&logical_device->queue_topology_frozen, 0,
                     iree_memory_order_relaxed);
   iree_slim_mutex_initialize(&logical_device->host_queue_activation_mutex);
+  iree_slim_mutex_initialize(&logical_device->execution_queue_mutex);
   uint8_t* physical_device_base =
       (uint8_t*)logical_device + physical_device_data_offset;
   for (iree_host_size_t i = 0; i < logical_device->physical_device_count; ++i) {
@@ -2028,13 +2079,13 @@ static iree_status_t iree_hal_amdgpu_logical_device_create_device_spec(
     const iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
     if (IREE_UNLIKELY(physical_device->device_ordinal > UINT32_MAX ||
-                      physical_device->host_queue_capacity > UINT32_MAX)) {
+                      physical_device->host_queue_initial_count > UINT32_MAX)) {
       status =
           iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                            "AMDGPU device spec physical row out of range: "
                            "device_ordinal=%" PRIhsz ", queue_count=%" PRIhsz,
                            physical_device->device_ordinal,
-                           physical_device->host_queue_capacity);
+                           physical_device->host_queue_initial_count);
       break;
     }
 
@@ -2062,7 +2113,7 @@ static iree_status_t iree_hal_amdgpu_logical_device_create_device_spec(
     physical_params->physical_ordinal =
         (uint32_t)physical_device->device_ordinal;
     physical_params->queue_count =
-        (uint32_t)physical_device->host_queue_capacity;
+        (uint32_t)physical_device->host_queue_initial_count;
     physical_params->compute_unit_count = physical_device->compute_unit_count;
     physical_params->wavefront_size = physical_device->wavefront_size;
     physical_params->maximum_waves_per_compute_unit =
@@ -2213,8 +2264,9 @@ iree_status_t iree_hal_amdgpu_logical_device_create(
   iree_hal_amdgpu_logical_device_t* logical_device = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_amdgpu_logical_device_allocate_storage(
-              identifier, device_topology, physical_device_size, host_allocator,
-              &logical_device));
+              identifier, device_topology,
+              physical_device_options.host_queue_initial_count,
+              physical_device_size, host_allocator, &logical_device));
   iree_status_t status =
       iree_hal_amdgpu_logical_device_initialize_host_resources(
           logical_device, &resolved_options, create_params, host_allocator);
@@ -2341,6 +2393,7 @@ static void iree_hal_amdgpu_logical_device_destroy(
 
   iree_hal_amdgpu_profile_metadata_deinitialize(
       &logical_device->profile_metadata);
+  iree_slim_mutex_deinitialize(&logical_device->execution_queue_mutex);
   iree_slim_mutex_deinitialize(&logical_device->host_queue_activation_mutex);
 
   // Note that these may be used by other child data types and must be freed
@@ -3079,7 +3132,10 @@ static iree_status_t iree_hal_amdgpu_logical_device_import_file(
       iree_hal_amdgpu_logical_device_cast(base_device);
 
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_queue_affinity_normalize(
-      logical_device->queue_affinity_mask, queue_affinity, &queue_affinity));
+      queue_affinity == IREE_HAL_QUEUE_AFFINITY_ANY
+          ? logical_device->ordinary_queue_affinity_mask
+          : logical_device->queue_affinity_mask,
+      queue_affinity, &queue_affinity));
 
   return iree_hal_file_from_handle(
       iree_hal_device_allocator(base_device), queue_affinity, access, handle,
@@ -3358,7 +3414,10 @@ static iree_status_t iree_hal_amdgpu_logical_device_queue_flush(
   IREE_RETURN_IF_ERROR(
       iree_hal_amdgpu_logical_device_check_failure(logical_device));
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_queue_affinity_normalize(
-      logical_device->queue_affinity_mask, queue_affinity, &queue_affinity));
+      queue_affinity == IREE_HAL_QUEUE_AFFINITY_ANY
+          ? logical_device->ordinary_queue_affinity_mask
+          : logical_device->queue_affinity_mask,
+      queue_affinity, &queue_affinity));
 
   IREE_HAL_FOR_QUEUE_AFFINITY(queue_affinity) {
     iree_hal_amdgpu_virtual_queue_t* queue = NULL;
@@ -3369,73 +3428,247 @@ static iree_status_t iree_hal_amdgpu_logical_device_queue_flush(
   return iree_ok_status();
 }
 
-IREE_API_EXPORT iree_status_t
-iree_hal_amdgpu_device_queue_set_execution_unit_mask(
-    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
-    iree_host_size_t mask_bit_count, const uint32_t* mask) {
+IREE_API_EXPORT iree_status_t iree_hal_amdgpu_execution_queue_acquire(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t device_affinity,
+    iree_host_size_t mask_bit_count, const uint32_t* mask,
+    iree_hal_amdgpu_execution_queue_t** out_execution_queue) {
   IREE_ASSERT_ARGUMENT(base_device);
-  if (IREE_UNLIKELY((mask_bit_count == 0) != (mask == NULL))) {
+  IREE_ASSERT_ARGUMENT(out_execution_queue);
+  *out_execution_queue = NULL;
+  if (IREE_UNLIKELY(mask_bit_count == 0 || mask == NULL ||
+                    mask_bit_count % 32 != 0 || mask_bit_count > UINT32_MAX)) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
-        "execution-unit mask and bit count must both be empty or non-empty");
-  }
-  if (IREE_UNLIKELY(mask_bit_count % 32 != 0 || mask_bit_count > UINT32_MAX)) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "execution-unit mask bit count must be a multiple of 32 representable "
-        "by the device API");
-  }
-  if (IREE_UNLIKELY(queue_affinity == 0 ||
-                    (queue_affinity & (queue_affinity - 1)) != 0)) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "execution-unit masks require one exact queue");
+        "execution-unit mask must be non-empty and have a bit count that is a "
+        "multiple of 32 representable by the device API");
   }
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_hal_amdgpu_logical_device_t* logical_device =
       iree_hal_amdgpu_logical_device_cast(base_device);
   iree_status_t status =
       iree_hal_amdgpu_logical_device_check_failure(logical_device);
-
-  iree_hal_amdgpu_queue_affinity_resolved_t resolved;
+  iree_hal_amdgpu_execution_queue_t* execution_queue = NULL;
+  iree_hal_amdgpu_queue_affinity_resolved_t resolved = {0};
+  iree_host_size_t physical_device_ordinal = 0;
+  iree_host_size_t mask_size = 0;
+  iree_host_size_t allocation_size = 0;
+  bool queue_reserved = false;
   if (iree_status_is_ok(status)) {
+    iree_hal_amdgpu_queue_affinity_resolved_t device_resolved;
     status = iree_hal_amdgpu_queue_affinity_resolve(
         iree_hal_amdgpu_logical_device_queue_affinity_domain(logical_device),
-        queue_affinity, &resolved);
-  }
-  if (iree_status_is_ok(status)) {
-    iree_hal_amdgpu_physical_device_t* physical_device =
-        logical_device->physical_devices[resolved.physical_device_ordinal];
-    const iree_host_size_t expected_mask_bit_count =
-        iree_host_align((iree_host_size_t)physical_device->compute_unit_count,
-                        32);
-    if (IREE_UNLIKELY(mask && mask_bit_count != expected_mask_bit_count)) {
-      status = iree_make_status(
-          IREE_STATUS_INVALID_ARGUMENT,
-          "execution-unit mask has %" PRIhsz " bits; physical device requires "
-          "%" PRIhsz,
-          mask_bit_count, expected_mask_bit_count);
+        device_affinity, &device_resolved);
+    if (iree_status_is_ok(status)) {
+      physical_device_ordinal = device_resolved.physical_device_ordinal;
     }
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_amdgpu_logical_device_ensure_host_queue(logical_device,
-                                                              &resolved);
+    iree_hal_amdgpu_physical_device_t* physical_device =
+        logical_device->physical_devices[physical_device_ordinal];
+    const iree_host_size_t expected_mask_bit_count = iree_host_align(
+        (iree_host_size_t)physical_device->compute_unit_count, 32);
+    if (IREE_UNLIKELY(mask_bit_count != expected_mask_bit_count)) {
+      status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "execution-unit mask has %" PRIhsz
+                                " bits; physical device requires "
+                                "%" PRIhsz,
+                                mask_bit_count, expected_mask_bit_count);
+    }
+    bool has_enabled_unit = false;
+    for (iree_host_size_t i = 0; i < mask_bit_count / 32; ++i) {
+      has_enabled_unit |= mask[i] != 0;
+    }
+    const uint32_t final_word_bit_count =
+        physical_device->compute_unit_count % 32;
+    if (iree_status_is_ok(status) && final_word_bit_count != 0) {
+      const uint32_t valid_final_word_mask =
+          (UINT32_C(1) << final_word_bit_count) - 1;
+      if (IREE_UNLIKELY(mask[mask_bit_count / 32 - 1] &
+                        ~valid_final_word_mask)) {
+        status = iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "execution-unit mask enables units outside the physical device");
+      }
+    }
+    if (iree_status_is_ok(status) && IREE_UNLIKELY(!has_enabled_unit)) {
+      status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "execution-unit mask enables no units");
+    }
   }
+  if (iree_status_is_ok(status)) {
+    if (IREE_UNLIKELY(!iree_host_size_checked_mul(mask_bit_count / 32,
+                                                  sizeof(*mask), &mask_size) ||
+                      !iree_host_size_checked_add(sizeof(*execution_queue),
+                                                  mask_size,
+                                                  &allocation_size))) {
+      status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                "execution queue allocation size overflow");
+    } else {
+      status = iree_allocator_malloc(logical_device->host_allocator,
+                                     allocation_size, (void**)&execution_queue);
+    }
+  }
+  if (iree_status_is_ok(status)) {
+    execution_queue->next = NULL;
+    execution_queue->logical_device = logical_device;
+    execution_queue->reference_count = 1;
+    execution_queue->queue_affinity = 0;
+    execution_queue->physical_device_ordinal = physical_device_ordinal;
+    execution_queue->execution_unit_mask_bit_count = mask_bit_count;
+    memcpy(execution_queue->execution_unit_mask, mask, mask_size);
+
+    iree_hal_amdgpu_physical_device_t* physical_device =
+        logical_device->physical_devices[physical_device_ordinal];
+    iree_slim_mutex_lock(&logical_device->execution_queue_mutex);
+    for (iree_hal_amdgpu_execution_queue_t* current =
+             logical_device->execution_queue_head;
+         current; current = current->next) {
+      if (current->physical_device_ordinal == physical_device_ordinal &&
+          current->execution_unit_mask_bit_count == mask_bit_count &&
+          memcmp(current->execution_unit_mask, mask, mask_size) == 0) {
+        ++current->reference_count;
+        *out_execution_queue = current;
+        break;
+      }
+    }
+    if (!*out_execution_queue) {
+      for (iree_host_size_t i = physical_device->host_queue_initial_count;
+           i < physical_device->host_queue_capacity; ++i) {
+        const iree_host_size_t queue_ordinal =
+            physical_device_ordinal *
+                logical_device->system->topology.gpu_agent_queue_count +
+            i;
+        const iree_hal_queue_affinity_t candidate =
+            (iree_hal_queue_affinity_t)1ull << queue_ordinal;
+        if (iree_any_bit_set(logical_device->leased_execution_queue_affinity,
+                             candidate)) {
+          continue;
+        }
+        status = iree_hal_amdgpu_queue_affinity_resolve_ordinal(
+            iree_hal_amdgpu_logical_device_queue_affinity_domain(
+                logical_device),
+            queue_ordinal, &resolved);
+        if (iree_status_is_ok(status)) {
+          logical_device->leased_execution_queue_affinity |= candidate;
+          queue_reserved = true;
+        }
+        break;
+      }
+    }
+    if (iree_status_is_ok(status) && !*out_execution_queue && !queue_reserved) {
+      status = iree_make_status(
+          IREE_STATUS_RESOURCE_EXHAUSTED,
+          "no specialized AMDGPU execution queue is available on physical "
+          "device %" PRIhsz,
+          physical_device_ordinal);
+    }
+    if (iree_status_is_ok(status) && queue_reserved) {
+      status = iree_hal_amdgpu_logical_device_ensure_host_queue(logical_device,
+                                                                &resolved);
+    }
+    if (iree_status_is_ok(status) && queue_reserved) {
+      iree_hal_amdgpu_host_queue_t* queue =
+          &logical_device->physical_devices[resolved.physical_device_ordinal]
+               ->host_queues[resolved.physical_queue_ordinal];
+
+      // Configuration is a cold control-plane operation. Holding the registry
+      // mutex prevents a duplicate mask acquisition from consuming another
+      // slot before this queue is fully configured and published.
+      iree_slim_mutex_lock(&queue->locks.submission_mutex);
+      status = iree_hsa_amd_queue_cu_set_mask(IREE_LIBHSA(queue->libhsa),
+                                              queue->hardware_queue,
+                                              (uint32_t)mask_bit_count, mask);
+      iree_slim_mutex_unlock(&queue->locks.submission_mutex);
+    }
+    if (iree_status_is_ok(status) && queue_reserved) {
+      execution_queue->queue_affinity = (iree_hal_queue_affinity_t)1ull
+                                        << resolved.queue_ordinal;
+      execution_queue->next = logical_device->execution_queue_head;
+      logical_device->execution_queue_head = execution_queue;
+      iree_hal_device_retain(base_device);
+      *out_execution_queue = execution_queue;
+    } else if (queue_reserved) {
+      logical_device->leased_execution_queue_affinity &=
+          ~((iree_hal_queue_affinity_t)1ull << resolved.queue_ordinal);
+    }
+    iree_slim_mutex_unlock(&logical_device->execution_queue_mutex);
+  }
+  if (*out_execution_queue != execution_queue) {
+    iree_allocator_free(logical_device->host_allocator, execution_queue);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT void iree_hal_amdgpu_execution_queue_retain(
+    iree_hal_amdgpu_execution_queue_t* execution_queue) {
+  if (!execution_queue) return;
+  iree_hal_amdgpu_logical_device_t* logical_device =
+      execution_queue->logical_device;
+  iree_slim_mutex_lock(&logical_device->execution_queue_mutex);
+  ++execution_queue->reference_count;
+  iree_slim_mutex_unlock(&logical_device->execution_queue_mutex);
+}
+
+IREE_API_EXPORT void iree_hal_amdgpu_execution_queue_release(
+    iree_hal_amdgpu_execution_queue_t* execution_queue) {
+  if (!execution_queue) return;
+
+  iree_hal_amdgpu_logical_device_t* logical_device =
+      execution_queue->logical_device;
+  const iree_hal_queue_affinity_t queue_affinity =
+      execution_queue->queue_affinity;
+  iree_slim_mutex_lock(&logical_device->execution_queue_mutex);
+  if (--execution_queue->reference_count != 0) {
+    iree_slim_mutex_unlock(&logical_device->execution_queue_mutex);
+    return;
+  }
+
+  iree_hal_amdgpu_execution_queue_t** current =
+      &logical_device->execution_queue_head;
+  while (*current && *current != execution_queue) {
+    current = &(*current)->next;
+  }
+  IREE_ASSERT(*current == execution_queue);
+
+  iree_hal_amdgpu_queue_affinity_resolved_t resolved = {0};
+  iree_status_t status = iree_hal_amdgpu_queue_affinity_resolve(
+      iree_hal_amdgpu_logical_device_queue_affinity_domain(logical_device),
+      queue_affinity, &resolved);
   if (iree_status_is_ok(status)) {
     iree_hal_amdgpu_host_queue_t* queue =
         &logical_device->physical_devices[resolved.physical_device_ordinal]
              ->host_queues[resolved.physical_queue_ordinal];
-
-    // Queue-mask changes are cold control-plane operations. Serialize them
-    // with packet publication so a caller satisfying the idle/exclusive
-    // contract cannot race a submission already entering the queue.
     iree_slim_mutex_lock(&queue->locks.submission_mutex);
-    status = iree_hsa_amd_queue_cu_set_mask(IREE_LIBHSA(queue->libhsa),
-                                            queue->hardware_queue,
-                                            (uint32_t)mask_bit_count, mask);
+    status = iree_hsa_amd_queue_cu_set_mask(
+        IREE_LIBHSA(queue->libhsa), queue->hardware_queue,
+        /*mask_bit_count=*/0, /*mask=*/NULL);
     iree_slim_mutex_unlock(&queue->locks.submission_mutex);
   }
-  IREE_TRACE_ZONE_END(z0);
-  return status;
+  *current = execution_queue->next;
+  if (iree_status_is_ok(status)) {
+    logical_device->leased_execution_queue_affinity &= ~queue_affinity;
+  }
+  iree_slim_mutex_unlock(&logical_device->execution_queue_mutex);
+
+  const iree_allocator_t host_allocator = logical_device->host_allocator;
+  iree_allocator_free(host_allocator, execution_queue);
+  if (!iree_status_is_ok(status)) {
+    iree_hal_amdgpu_logical_device_error_handler(
+        logical_device,
+        iree_status_annotate_f(status,
+                               "restoring specialized AMDGPU queue affinity "
+                               "0x%016" PRIx64,
+                               (uint64_t)queue_affinity));
+  }
+  iree_hal_device_release((iree_hal_device_t*)logical_device);
+}
+
+IREE_API_EXPORT iree_hal_queue_affinity_t
+iree_hal_amdgpu_execution_queue_affinity(
+    const iree_hal_amdgpu_execution_queue_t* execution_queue) {
+  return execution_queue ? execution_queue->queue_affinity
+                         : IREE_HAL_QUEUE_AFFINITY_ANY;
 }
 
 static iree_status_t

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -50,10 +50,11 @@ iree_hal_amdgpu_logical_device_queue_affinity_domain(
   };
 }
 
-static iree_status_t iree_hal_amdgpu_logical_device_resolve_hostcall_provider(
-    const void* next,
-    const iree_hal_amdgpu_hostcall_provider_t** out_provider) {
+static iree_status_t iree_hal_amdgpu_logical_device_resolve_create_extensions(
+    const void* next, const iree_hal_amdgpu_hostcall_provider_t** out_provider,
+    const iree_hal_amdgpu_host_queue_extension_t** out_host_queues) {
   *out_provider = NULL;
+  *out_host_queues = NULL;
   while (next) {
     const iree_hal_device_create_params_extension_t* extension =
         (const iree_hal_device_create_params_extension_t*)next;
@@ -77,10 +78,83 @@ static iree_status_t iree_hal_amdgpu_logical_device_resolve_hostcall_provider(
             "and deinitialize callbacks");
       }
       *out_provider = provider;
+    } else if (
+        extension->type ==
+        IREE_HAL_AMDGPU_DEVICE_CREATE_PARAMS_EXTENSION_TYPE_HOST_QUEUES) {
+      if (IREE_UNLIKELY(*out_host_queues)) {
+        return iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "AMDGPU device creation contains duplicate host queue "
+            "configurations");
+      }
+      *out_host_queues =
+          (const iree_hal_amdgpu_host_queue_extension_t*)extension;
     }
     next = extension->next;
   }
   return iree_ok_status();
+}
+
+static iree_status_t iree_hal_amdgpu_logical_device_ensure_host_queue(
+    iree_hal_amdgpu_logical_device_t* logical_device,
+    const iree_hal_amdgpu_queue_affinity_resolved_t* resolved) {
+  iree_hal_amdgpu_physical_device_t* physical_device =
+      logical_device->physical_devices[resolved->physical_device_ordinal];
+  if (resolved->physical_queue_ordinal <
+      physical_device->host_queue_initial_count) {
+    return iree_ok_status();
+  }
+
+  const uint64_t queue_bit = (uint64_t)1ull << resolved->queue_ordinal;
+  if (iree_any_bit_set(
+          (uint64_t)iree_atomic_load(&logical_device->active_queue_affinity,
+                                     iree_memory_order_acquire),
+          queue_bit)) {
+    return iree_ok_status();
+  }
+
+  iree_slim_mutex_lock(&logical_device->host_queue_activation_mutex);
+  iree_status_t status = iree_ok_status();
+  const uint64_t active_queue_affinity = (uint64_t)iree_atomic_load(
+      &logical_device->active_queue_affinity, iree_memory_order_relaxed);
+  if (!iree_any_bit_set(active_queue_affinity, queue_bit)) {
+    if (IREE_UNLIKELY(iree_atomic_load(&logical_device->queue_topology_frozen,
+                                       iree_memory_order_acquire) != 0)) {
+      status = iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "cannot activate a new AMDGPU host queue while profiling is active");
+    } else if (IREE_UNLIKELY(!logical_device->frontier_tracker)) {
+      status = iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "cannot activate an AMDGPU host queue before topology assignment");
+    } else {
+      const iree_host_size_t previous_queue_count =
+          physical_device->host_queue_count;
+      status = iree_hal_amdgpu_physical_device_ensure_host_queue(
+          (iree_hal_device_t*)logical_device, logical_device->system,
+          logical_device->proactor, logical_device->frontier_tracker,
+          logical_device->axis, logical_device->host_queue_epoch_table,
+          &logical_device->feedback, resolved->physical_queue_ordinal,
+          logical_device->host_allocator, physical_device);
+      // Publish every queue initialized by the attempt, including a successful
+      // prefix when initialization of the requested queue fails.
+      if (physical_device->host_queue_count > previous_queue_count) {
+        uint64_t activated_queue_affinity = 0;
+        const iree_host_size_t queue_ordinal_base =
+            resolved->queue_ordinal - resolved->physical_queue_ordinal;
+        for (iree_host_size_t i = previous_queue_count;
+             i < physical_device->host_queue_count; ++i) {
+          activated_queue_affinity |= (uint64_t)1ull
+                                      << (queue_ordinal_base + i);
+        }
+        iree_atomic_fetch_or(&logical_device->active_queue_affinity,
+                             activated_queue_affinity,
+                             iree_memory_order_release);
+      }
+    }
+  }
+  iree_slim_mutex_unlock(&logical_device->host_queue_activation_mutex);
+  return status;
 }
 
 // Returns the queue for a flattened logical queue ordinal.
@@ -96,6 +170,8 @@ static iree_status_t iree_hal_amdgpu_logical_device_queue_from_ordinal(
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_queue_affinity_resolve_ordinal(
       iree_hal_amdgpu_logical_device_queue_affinity_domain(logical_device),
       queue_ordinal, &resolved));
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_logical_device_ensure_host_queue(
+      logical_device, &resolved));
 
   iree_hal_amdgpu_physical_device_t* physical_device =
       logical_device->physical_devices[resolved.physical_device_ordinal];
@@ -1642,6 +1718,10 @@ bool iree_hal_amdgpu_logical_device_lookup_host_queue_epoch_wait(
 static void iree_hal_amdgpu_logical_device_deassign_frontier(
     iree_hal_amdgpu_logical_device_t* logical_device) {
   IREE_TRACE_ZONE_BEGIN(z0);
+  iree_atomic_store(&logical_device->queue_topology_frozen, 0,
+                    iree_memory_order_release);
+  iree_atomic_store(&logical_device->active_queue_affinity, 0,
+                    iree_memory_order_release);
   for (iree_host_size_t i = 0; i < logical_device->physical_device_count; ++i) {
     iree_hal_amdgpu_physical_device_deassign_frontier(
         logical_device->physical_devices[i]);
@@ -1726,6 +1806,9 @@ static void iree_hal_amdgpu_logical_device_translate_physical_options(
   out_options->host_block_pool_initial_capacity =
       options->preallocate_pools ? 16 : 0;
   out_options->host_queue_count = topology->gpu_agent_queue_count;
+  out_options->host_queue_initial_count =
+      iree_min((iree_host_size_t)IREE_HAL_AMDGPU_DEFAULT_GPU_AGENT_QUEUE_COUNT,
+               out_options->host_queue_count);
   out_options->host_queue_aql_capacity = options->host_queues.aql_capacity;
   out_options->host_queue_notification_capacity =
       options->host_queues.notification_capacity;
@@ -1813,6 +1896,11 @@ static iree_status_t iree_hal_amdgpu_logical_device_allocate_storage(
   // Setup physical device table first so failure cleanup has a valid table.
   logical_device->physical_device_count = topology->gpu_agent_count;
   logical_device->queue_affinity_mask = logical_queue_affinity_mask;
+  iree_atomic_store(&logical_device->active_queue_affinity, 0,
+                    iree_memory_order_relaxed);
+  iree_atomic_store(&logical_device->queue_topology_frozen, 0,
+                    iree_memory_order_relaxed);
+  iree_slim_mutex_initialize(&logical_device->host_queue_activation_mutex);
   uint8_t* physical_device_base =
       (uint8_t*)logical_device + physical_device_data_offset;
   for (iree_host_size_t i = 0; i < logical_device->physical_device_count; ++i) {
@@ -1915,12 +2003,13 @@ static iree_status_t iree_hal_amdgpu_logical_device_create_device_spec(
     const iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
     if (IREE_UNLIKELY(physical_device->device_ordinal > UINT32_MAX ||
-                      physical_device->host_queue_count > UINT32_MAX)) {
-      status = iree_make_status(
-          IREE_STATUS_OUT_OF_RANGE,
-          "AMDGPU device spec physical row out of range: "
-          "device_ordinal=%" PRIhsz ", queue_count=%" PRIhsz,
-          physical_device->device_ordinal, physical_device->host_queue_count);
+                      physical_device->host_queue_capacity > UINT32_MAX)) {
+      status =
+          iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                           "AMDGPU device spec physical row out of range: "
+                           "device_ordinal=%" PRIhsz ", queue_count=%" PRIhsz,
+                           physical_device->device_ordinal,
+                           physical_device->host_queue_capacity);
       break;
     }
 
@@ -1947,7 +2036,8 @@ static iree_status_t iree_hal_amdgpu_logical_device_create_device_spec(
     physical_params->numa.node_id = physical_device->host_numa_node;
     physical_params->physical_ordinal =
         (uint32_t)physical_device->device_ordinal;
-    physical_params->queue_count = (uint32_t)physical_device->host_queue_count;
+    physical_params->queue_count =
+        (uint32_t)physical_device->host_queue_capacity;
     physical_params->compute_unit_count = physical_device->compute_unit_count;
     physical_params->wavefront_size = physical_device->wavefront_size;
     physical_params->maximum_waves_per_compute_unit =
@@ -2007,10 +2097,11 @@ iree_status_t iree_hal_amdgpu_logical_device_create(
       "verifying device creation parameters");
 
   const iree_hal_amdgpu_hostcall_provider_t* hostcall_provider = NULL;
+  const iree_hal_amdgpu_host_queue_extension_t* host_queue_extension = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0,
-      iree_hal_amdgpu_logical_device_resolve_hostcall_provider(
-          create_params->next, &hostcall_provider),
+      iree_hal_amdgpu_logical_device_resolve_create_extensions(
+          create_params->next, &hostcall_provider, &host_queue_extension),
       "resolving AMDGPU device creation extensions");
 
   iree_hal_amdgpu_logical_device_options_t resolved_options = *options;
@@ -2036,16 +2127,51 @@ iree_status_t iree_hal_amdgpu_logical_device_create(
       z0, iree_hal_amdgpu_topology_verify(topology, libhsa),
       "verifying topology");
 
+  iree_hal_amdgpu_topology_t resolved_topology;
+  const iree_hal_amdgpu_topology_t* device_topology = topology;
+  if (host_queue_extension) {
+    const iree_host_size_t maximum_queue_count =
+        IREE_HAL_MAX_QUEUES / topology->gpu_agent_count;
+    if (IREE_UNLIKELY(host_queue_extension->capacity == 0 ||
+                      host_queue_extension->capacity > maximum_queue_count ||
+                      host_queue_extension->initial_count == 0 ||
+                      host_queue_extension->initial_count >
+                          host_queue_extension->capacity)) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "AMDGPU host queue configuration requires 1 <= initial_count <= "
+          "capacity <= %" PRIhsz " (got initial_count=%" PRIhsz
+          ", capacity=%" PRIhsz ")",
+          maximum_queue_count, host_queue_extension->initial_count,
+          host_queue_extension->capacity);
+    }
+    resolved_topology = *topology;
+    resolved_topology.gpu_agent_queue_count = host_queue_extension->capacity;
+    device_topology = &resolved_topology;
+  }
+
   // Verify the parameters prior to creating resources.
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0,
       iree_hal_amdgpu_logical_device_options_verify(&resolved_options, libhsa,
-                                                    topology),
+                                                    device_topology),
       "verifying logical device options");
 
   iree_hal_amdgpu_physical_device_options_t physical_device_options = {0};
   iree_hal_amdgpu_logical_device_translate_physical_options(
-      &resolved_options, topology, &physical_device_options);
+      &resolved_options, device_topology, &physical_device_options);
+  if (host_queue_extension) {
+    physical_device_options.host_queue_initial_count =
+        host_queue_extension->initial_count;
+  }
+  // TSAN publishes queue-specific state into executable variants during load.
+  // Initialize every advertised queue before those immutable variants can be
+  // constructed instead of permitting a partially configured late queue.
+  if (resolved_options.tsan.enabled) {
+    physical_device_options.host_queue_initial_count =
+        physical_device_options.host_queue_count;
+  }
 
   // Verify all GPU agents meet the required physical device options. Each
   // embedded physical device has the same layout because all physical devices
@@ -2055,14 +2181,14 @@ iree_status_t iree_hal_amdgpu_logical_device_create(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0,
       iree_hal_amdgpu_logical_device_verify_physical_options(
-          &physical_device_options, libhsa, topology),
+          &physical_device_options, libhsa, device_topology),
       "verifying physical device options");
 
   // Allocate the logical device and all nested physical device data structures.
   iree_hal_amdgpu_logical_device_t* logical_device = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_amdgpu_logical_device_allocate_storage(
-              identifier, topology, physical_device_size, host_allocator,
+              identifier, device_topology, physical_device_size, host_allocator,
               &logical_device));
   iree_status_t status =
       iree_hal_amdgpu_logical_device_initialize_host_resources(
@@ -2074,12 +2200,13 @@ iree_status_t iree_hal_amdgpu_logical_device_create(
       resolved_options.suppress_device_fine_memory;
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_logical_device_initialize_system_and_allocator(
-        logical_device, &resolved_options, libhsa, topology, host_allocator);
+        logical_device, &resolved_options, libhsa, device_topology,
+        host_allocator);
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_logical_device_initialize_physical_devices(
-        logical_device, topology, &physical_device_options, hostcall_provider,
-        host_allocator);
+        logical_device, device_topology, &physical_device_options,
+        hostcall_provider, host_allocator);
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_logical_device_create_device_spec(
@@ -2189,6 +2316,7 @@ static void iree_hal_amdgpu_logical_device_destroy(
 
   iree_hal_amdgpu_profile_metadata_deinitialize(
       &logical_device->profile_metadata);
+  iree_slim_mutex_deinitialize(&logical_device->host_queue_activation_mutex);
 
   // Note that these may be used by other child data types and must be freed
   // last.
@@ -2638,15 +2766,30 @@ static iree_status_t iree_hal_amdgpu_logical_device_assign_topology_info(
        device_ordinal < logical_device->physical_device_count &&
        iree_status_is_ok(status);
        ++device_ordinal) {
-    const iree_host_size_t host_ordinal =
-        system->topology.gpu_cpu_map[device_ordinal];
     status = iree_hal_amdgpu_physical_device_assign_frontier(
         base_device, system, logical_device->proactor,
         topology_info->frontier.tracker, topology_info->frontier.base_axis,
         logical_device->host_queue_epoch_table, &logical_device->feedback,
-        &system->host_memory_pools[host_ordinal],
         logical_device->host_allocator,
         logical_device->physical_devices[device_ordinal]);
+  }
+  if (iree_status_is_ok(status)) {
+    uint64_t active_queue_affinity = 0;
+    for (iree_host_size_t device_ordinal = 0;
+         device_ordinal < logical_device->physical_device_count;
+         ++device_ordinal) {
+      const iree_hal_amdgpu_physical_device_t* physical_device =
+          logical_device->physical_devices[device_ordinal];
+      const iree_host_size_t queue_ordinal_base =
+          device_ordinal * system->topology.gpu_agent_queue_count;
+      for (iree_host_size_t queue_ordinal = 0;
+           queue_ordinal < physical_device->host_queue_count; ++queue_ordinal) {
+        active_queue_affinity |= (uint64_t)1ull
+                                 << (queue_ordinal_base + queue_ordinal);
+      }
+    }
+    iree_atomic_store(&logical_device->active_queue_affinity,
+                      active_queue_affinity, iree_memory_order_release);
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_tsan_state_assign_queues(
@@ -3201,6 +3344,61 @@ static iree_status_t iree_hal_amdgpu_logical_device_queue_flush(
   return iree_ok_status();
 }
 
+IREE_API_EXPORT iree_status_t
+iree_hal_amdgpu_device_queue_set_execution_unit_mask(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    iree_host_size_t mask_bit_count, const uint32_t* mask) {
+  IREE_ASSERT_ARGUMENT(base_device);
+  if (IREE_UNLIKELY((mask_bit_count == 0) != (mask == NULL))) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "execution-unit mask and bit count must both be empty or non-empty");
+  }
+  if (IREE_UNLIKELY(mask_bit_count % 32 != 0 || mask_bit_count > UINT32_MAX)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "execution-unit mask bit count must be a multiple of 32 representable "
+        "by the device API");
+  }
+  if (IREE_UNLIKELY(queue_affinity == 0 ||
+                    (queue_affinity & (queue_affinity - 1)) != 0)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "execution-unit masks require one exact queue");
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_hal_amdgpu_logical_device_t* logical_device =
+      iree_hal_amdgpu_logical_device_cast(base_device);
+  iree_status_t status =
+      iree_hal_amdgpu_logical_device_check_failure(logical_device);
+
+  iree_hal_amdgpu_queue_affinity_resolved_t resolved;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_amdgpu_queue_affinity_resolve(
+        iree_hal_amdgpu_logical_device_queue_affinity_domain(logical_device),
+        queue_affinity, &resolved);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_amdgpu_logical_device_ensure_host_queue(logical_device,
+                                                              &resolved);
+  }
+  if (iree_status_is_ok(status)) {
+    iree_hal_amdgpu_host_queue_t* queue =
+        &logical_device->physical_devices[resolved.physical_device_ordinal]
+             ->host_queues[resolved.physical_queue_ordinal];
+
+    // Queue-mask changes are cold control-plane operations. Serialize them
+    // with packet publication so a caller satisfying the idle/exclusive
+    // contract cannot race a submission already entering the queue.
+    iree_slim_mutex_lock(&queue->locks.submission_mutex);
+    status = iree_hsa_amd_queue_cu_set_mask(IREE_LIBHSA(queue->libhsa),
+                                            queue->hardware_queue,
+                                            (uint32_t)mask_bit_count, mask);
+    iree_slim_mutex_unlock(&queue->locks.submission_mutex);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static iree_status_t
 iree_hal_amdgpu_logical_device_verify_queue_device_profiling_supported(
     iree_hal_amdgpu_logical_device_t* logical_device) {
@@ -3255,6 +3453,13 @@ static iree_status_t iree_hal_amdgpu_logical_device_profiling_begin(
         iree_hal_amdgpu_logical_device_verify_queue_device_profiling_supported(
             logical_device));
   }
+  // Profiling setup installs per-queue state over the current active set. Stop
+  // new queue activation and drain any activation already in progress before
+  // taking that snapshot. Existing exact-affinity queues remain usable.
+  iree_atomic_store(&logical_device->queue_topology_frozen, 1,
+                    iree_memory_order_release);
+  iree_slim_mutex_lock(&logical_device->host_queue_activation_mutex);
+  iree_slim_mutex_unlock(&logical_device->host_queue_activation_mutex);
 
   bool sink_session_begun = false;
   bool hsa_profiling_enabled = false;
@@ -3415,6 +3620,8 @@ static iree_status_t iree_hal_amdgpu_logical_device_profiling_begin(
     iree_hal_amdgpu_profile_counter_session_free(counter_session);
     iree_hal_amdgpu_profile_trace_session_free(trace_session);
     iree_hal_amdgpu_profile_device_metrics_session_free(device_metrics_session);
+    iree_atomic_store(&logical_device->queue_topology_frozen, 0,
+                      iree_memory_order_release);
   }
   return status;
 }
@@ -3535,6 +3742,8 @@ static iree_status_t iree_hal_amdgpu_logical_device_profiling_end(
   iree_hal_amdgpu_profile_counter_session_free(counter_session);
   iree_hal_amdgpu_profile_trace_session_free(trace_session);
   iree_hal_amdgpu_profile_device_metrics_session_free(device_metrics_session);
+  iree_atomic_store(&logical_device->queue_topology_frozen, 0,
+                    iree_memory_order_release);
   return status;
 }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -157,6 +157,31 @@ static iree_status_t iree_hal_amdgpu_logical_device_ensure_host_queue(
   return status;
 }
 
+static iree_status_t iree_hal_amdgpu_logical_device_activate_all_host_queues(
+    iree_hal_amdgpu_logical_device_t* logical_device) {
+  const iree_hal_amdgpu_queue_affinity_domain_t domain =
+      iree_hal_amdgpu_logical_device_queue_affinity_domain(logical_device);
+  for (iree_host_size_t physical_device_ordinal = 0;
+       physical_device_ordinal < logical_device->physical_device_count;
+       ++physical_device_ordinal) {
+    const iree_hal_amdgpu_physical_device_t* physical_device =
+        logical_device->physical_devices[physical_device_ordinal];
+    if (physical_device->host_queue_count ==
+        physical_device->host_queue_capacity) {
+      continue;
+    }
+    const iree_host_size_t queue_ordinal =
+        physical_device_ordinal * domain.queue_count_per_physical_device +
+        physical_device->host_queue_capacity - 1;
+    iree_hal_amdgpu_queue_affinity_resolved_t resolved;
+    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_queue_affinity_resolve_ordinal(
+        domain, queue_ordinal, &resolved));
+    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_logical_device_ensure_host_queue(
+        logical_device, &resolved));
+  }
+  return iree_ok_status();
+}
+
 // Returns the queue for a flattened logical queue ordinal.
 static iree_status_t iree_hal_amdgpu_logical_device_queue_from_ordinal(
     iree_hal_amdgpu_logical_device_t* logical_device,
@@ -3378,6 +3403,20 @@ iree_hal_amdgpu_device_queue_set_execution_unit_mask(
         queue_affinity, &resolved);
   }
   if (iree_status_is_ok(status)) {
+    iree_hal_amdgpu_physical_device_t* physical_device =
+        logical_device->physical_devices[resolved.physical_device_ordinal];
+    const iree_host_size_t expected_mask_bit_count =
+        iree_host_align((iree_host_size_t)physical_device->compute_unit_count,
+                        32);
+    if (IREE_UNLIKELY(mask && mask_bit_count != expected_mask_bit_count)) {
+      status = iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "execution-unit mask has %" PRIhsz " bits; physical device requires "
+          "%" PRIhsz,
+          mask_bit_count, expected_mask_bit_count);
+    }
+  }
+  if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_logical_device_ensure_host_queue(logical_device,
                                                               &resolved);
   }
@@ -3453,9 +3492,11 @@ static iree_status_t iree_hal_amdgpu_logical_device_profiling_begin(
         iree_hal_amdgpu_logical_device_verify_queue_device_profiling_supported(
             logical_device));
   }
-  // Profiling setup installs per-queue state over the current active set. Stop
-  // new queue activation and drain any activation already in progress before
-  // taking that snapshot. Existing exact-affinity queues remain usable.
+  // Profiling installs state for a fixed queue set. Materialize every
+  // advertised queue before freezing that set so profiling does not make a
+  // previously unused queue affinity unavailable.
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_logical_device_activate_all_host_queues(logical_device));
   iree_atomic_store(&logical_device->queue_topology_frozen, 1,
                     iree_memory_order_release);
   iree_slim_mutex_lock(&logical_device->host_queue_activation_mutex);

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -137,23 +137,14 @@ static iree_status_t iree_hal_amdgpu_logical_device_ensure_host_queue(
   iree_hal_amdgpu_physical_device_t* physical_device =
       logical_device->physical_devices[resolved->physical_device_ordinal];
   if (resolved->physical_queue_ordinal <
-      physical_device->host_queue_initial_count) {
-    return iree_ok_status();
-  }
-
-  const uint64_t queue_bit = (uint64_t)1ull << resolved->queue_ordinal;
-  if (iree_any_bit_set(
-          (uint64_t)iree_atomic_load(&logical_device->active_queue_affinity,
-                                     iree_memory_order_acquire),
-          queue_bit)) {
+      iree_hal_amdgpu_physical_device_host_queue_count(physical_device)) {
     return iree_ok_status();
   }
 
   iree_slim_mutex_lock(&logical_device->host_queue_activation_mutex);
   iree_status_t status = iree_ok_status();
-  const uint64_t active_queue_affinity = (uint64_t)iree_atomic_load(
-      &logical_device->active_queue_affinity, iree_memory_order_relaxed);
-  if (!iree_any_bit_set(active_queue_affinity, queue_bit)) {
+  if (resolved->physical_queue_ordinal >=
+      iree_hal_amdgpu_physical_device_host_queue_count(physical_device)) {
     if (IREE_UNLIKELY(iree_atomic_load(&logical_device->queue_topology_frozen,
                                        iree_memory_order_acquire) != 0)) {
       status = iree_make_status(
@@ -164,29 +155,12 @@ static iree_status_t iree_hal_amdgpu_logical_device_ensure_host_queue(
           IREE_STATUS_FAILED_PRECONDITION,
           "cannot activate an AMDGPU host queue before topology assignment");
     } else {
-      const iree_host_size_t previous_queue_count =
-          physical_device->host_queue_count;
       status = iree_hal_amdgpu_physical_device_ensure_host_queue(
           (iree_hal_device_t*)logical_device, logical_device->system,
           logical_device->proactor, logical_device->frontier_tracker,
           logical_device->axis, logical_device->host_queue_epoch_table,
           &logical_device->feedback, resolved->physical_queue_ordinal,
           logical_device->host_allocator, physical_device);
-      // Publish every queue initialized by the attempt, including a successful
-      // prefix when initialization of the requested queue fails.
-      if (physical_device->host_queue_count > previous_queue_count) {
-        uint64_t activated_queue_affinity = 0;
-        const iree_host_size_t queue_ordinal_base =
-            resolved->queue_ordinal - resolved->physical_queue_ordinal;
-        for (iree_host_size_t i = previous_queue_count;
-             i < physical_device->host_queue_count; ++i) {
-          activated_queue_affinity |= (uint64_t)1ull
-                                      << (queue_ordinal_base + i);
-        }
-        iree_atomic_fetch_or(&logical_device->active_queue_affinity,
-                             activated_queue_affinity,
-                             iree_memory_order_release);
-      }
     }
   }
   iree_slim_mutex_unlock(&logical_device->host_queue_activation_mutex);
@@ -202,7 +176,7 @@ static iree_status_t iree_hal_amdgpu_logical_device_activate_all_host_queues(
        ++physical_device_ordinal) {
     const iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[physical_device_ordinal];
-    if (physical_device->host_queue_count ==
+    if (iree_hal_amdgpu_physical_device_host_queue_count(physical_device) ==
         physical_device->host_queue_capacity) {
       continue;
     }
@@ -231,19 +205,22 @@ static iree_status_t iree_hal_amdgpu_logical_device_queue_from_ordinal(
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_queue_affinity_resolve_ordinal(
       iree_hal_amdgpu_logical_device_queue_affinity_domain(logical_device),
       queue_ordinal, &resolved));
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_logical_device_ensure_host_queue(
-      logical_device, &resolved));
-
   iree_hal_amdgpu_physical_device_t* physical_device =
       logical_device->physical_devices[resolved.physical_device_ordinal];
   if (IREE_UNLIKELY(resolved.physical_queue_ordinal >=
-                    physical_device->host_queue_count)) {
-    return iree_make_status(IREE_STATUS_INTERNAL,
-                            "queue affinity ordinal %" PRIhsz
-                            " maps to invalid host queue ordinal "
-                            "%" PRIhsz " on physical device %" PRIhsz,
-                            queue_ordinal, resolved.physical_queue_ordinal,
-                            resolved.physical_device_ordinal);
+                    physical_device->host_queue_ordinary_count)) {
+    // Ordinary queues are initialized before device publication. Specialized
+    // queues are initialized before lease publication, and the acquire load
+    // makes their queue storage visible without another activation lookup.
+    const uint64_t submission_affinity = (uint64_t)iree_atomic_load(
+        &logical_device->execution_queue_submission_affinity,
+        iree_memory_order_acquire);
+    if (!iree_any_bit_set(submission_affinity, resolved.queue_affinity)) {
+      return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                              "specialized AMDGPU queue affinity 0x%016" PRIx64
+                              " has no active execution queue lease",
+                              (uint64_t)resolved.queue_affinity);
+    }
   }
 
   *out_queue =
@@ -1083,20 +1060,22 @@ static iree_status_t iree_hal_amdgpu_logical_device_write_profile_devices(
        ++i) {
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
+    const iree_host_size_t host_queue_count =
+        iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
     if (IREE_UNLIKELY(physical_device->device_ordinal > UINT32_MAX ||
-                      physical_device->host_queue_count > UINT32_MAX)) {
+                      host_queue_count > UINT32_MAX)) {
       status = iree_make_status(
           IREE_STATUS_OUT_OF_RANGE,
           "profile device metadata ordinals out of range: device=%" PRIhsz
           ", queue_count=%" PRIhsz,
-          physical_device->device_ordinal, physical_device->host_queue_count);
+          physical_device->device_ordinal, host_queue_count);
       break;
     }
 
     records[i] = iree_hal_profile_device_record_default();
     records[i].physical_device_ordinal =
         (uint32_t)physical_device->device_ordinal;
-    records[i].queue_count = (uint32_t)physical_device->host_queue_count;
+    records[i].queue_count = (uint32_t)host_queue_count;
     records[i].flags |= IREE_HAL_PROFILE_DEVICE_FLAG_TIMESTAMP_FREQUENCY;
     records[i].timestamp_frequency_hz = physical_device->timestamp_frequency_hz;
     if (physical_device->has_physical_device_uuid) {
@@ -1133,7 +1112,9 @@ static iree_status_t iree_hal_amdgpu_logical_device_write_profile_queues(
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
     if (IREE_UNLIKELY(!iree_host_size_checked_add(
-            record_count, physical_device->host_queue_count, &record_count))) {
+            record_count,
+            iree_hal_amdgpu_physical_device_host_queue_count(physical_device),
+            &record_count))) {
       IREE_TRACE_ZONE_END(z0);
       return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                               "profile queue metadata count overflow");
@@ -1173,9 +1154,10 @@ static iree_status_t iree_hal_amdgpu_logical_device_write_profile_queues(
     }
     const uint32_t physical_device_ordinal =
         (uint32_t)physical_device->device_ordinal;
+    const iree_host_size_t host_queue_count =
+        iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
     for (iree_host_size_t j = 0;
-         j < physical_device->host_queue_count && iree_status_is_ok(status);
-         ++j) {
+         j < host_queue_count && iree_status_is_ok(status); ++j) {
       if (IREE_UNLIKELY(j > UINT32_MAX)) {
         status = iree_make_status(
             IREE_STATUS_OUT_OF_RANGE,
@@ -1316,9 +1298,10 @@ static iree_status_t iree_hal_amdgpu_logical_device_write_profile_events(
        ++i) {
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
+    const iree_host_size_t host_queue_count =
+        iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
     for (iree_host_size_t j = 0;
-         j < physical_device->host_queue_count && iree_status_is_ok(status);
-         ++j) {
+         j < host_queue_count && iree_status_is_ok(status); ++j) {
       status = iree_hal_amdgpu_host_queue_write_profile_events(
           &physical_device->host_queues[j], sink, session_id);
     }
@@ -1355,7 +1338,9 @@ static void iree_hal_amdgpu_logical_device_set_queue_profiling_enabled(
   for (iree_host_size_t i = 0; i < logical_device->physical_device_count; ++i) {
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
-    for (iree_host_size_t j = 0; j < physical_device->host_queue_count; ++j) {
+    const iree_host_size_t host_queue_count =
+        iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
+    for (iree_host_size_t j = 0; j < host_queue_count; ++j) {
       iree_hal_amdgpu_host_queue_set_profile_flags(
           &physical_device->host_queues[j], flags);
     }
@@ -1373,9 +1358,10 @@ iree_hal_amdgpu_logical_device_ensure_queue_device_profile_event_storage(
        ++i) {
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
+    const iree_host_size_t host_queue_count =
+        iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
     for (iree_host_size_t j = 0;
-         j < physical_device->host_queue_count && iree_status_is_ok(status);
-         ++j) {
+         j < host_queue_count && iree_status_is_ok(status); ++j) {
       iree_hal_amdgpu_host_queue_t* queue = &physical_device->host_queues[j];
       status = iree_hal_amdgpu_host_queue_ensure_profile_event_storage(queue);
       if (iree_status_is_ok(status)) {
@@ -1434,14 +1420,17 @@ static iree_status_t iree_hal_amdgpu_logical_device_set_hsa_profiling_enabled(
 static bool iree_hal_amdgpu_logical_device_is_profile_counter_range_queue(
     const iree_hal_amdgpu_physical_device_t* physical_device,
     iree_host_size_t queue_ordinal) {
-  return queue_ordinal + 1 == physical_device->host_queue_count;
+  return queue_ordinal + 1 ==
+         iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
 }
 
 static iree_hal_amdgpu_host_queue_t*
 iree_hal_amdgpu_logical_device_select_profile_counter_range_queue(
     iree_hal_amdgpu_physical_device_t* physical_device) {
-  if (physical_device->host_queue_count == 0) return NULL;
-  return &physical_device->host_queues[physical_device->host_queue_count - 1];
+  const iree_host_size_t host_queue_count =
+      iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
+  if (host_queue_count == 0) return NULL;
+  return &physical_device->host_queues[host_queue_count - 1];
 }
 
 static iree_status_t
@@ -1466,9 +1455,10 @@ iree_hal_amdgpu_logical_device_set_counter_profiling_enabled(
        ++i) {
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
+    const iree_host_size_t host_queue_count =
+        iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
     for (iree_host_size_t j = 0;
-         j < physical_device->host_queue_count && iree_status_is_ok(status);
-         ++j) {
+         j < host_queue_count && iree_status_is_ok(status); ++j) {
       iree_hal_amdgpu_host_queue_t* queue = &physical_device->host_queues[j];
       if (enabled) {
         iree_hal_amdgpu_profile_counter_enable_flags_t flags =
@@ -1494,7 +1484,9 @@ iree_hal_amdgpu_logical_device_set_counter_profiling_enabled(
          ++i) {
       iree_hal_amdgpu_physical_device_t* physical_device =
           logical_device->physical_devices[i];
-      for (iree_host_size_t j = 0; j < physical_device->host_queue_count; ++j) {
+      const iree_host_size_t host_queue_count =
+          iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
+      for (iree_host_size_t j = 0; j < host_queue_count; ++j) {
         iree_hal_amdgpu_host_queue_disable_profile_counters(
             &physical_device->host_queues[j]);
       }
@@ -1522,7 +1514,8 @@ iree_hal_amdgpu_logical_device_start_profile_counter_ranges(
        ++i) {
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
-    if (IREE_UNLIKELY(physical_device->host_queue_count == 0)) {
+    if (IREE_UNLIKELY(iree_hal_amdgpu_physical_device_host_queue_count(
+                          physical_device) == 0)) {
       status = iree_make_status(IREE_STATUS_INTERNAL,
                                 "logical device physical device has no host "
                                 "queues (initialization incomplete)");
@@ -1573,7 +1566,8 @@ iree_hal_amdgpu_logical_device_flush_profile_counter_ranges(
        ++i) {
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
-    if (IREE_UNLIKELY(physical_device->host_queue_count == 0)) {
+    if (IREE_UNLIKELY(iree_hal_amdgpu_physical_device_host_queue_count(
+                          physical_device) == 0)) {
       status = iree_make_status(IREE_STATUS_INTERNAL,
                                 "logical device physical device has no host "
                                 "queues (initialization incomplete)");
@@ -1606,9 +1600,10 @@ static iree_status_t iree_hal_amdgpu_logical_device_set_trace_profiling_enabled(
        ++i) {
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
+    const iree_host_size_t host_queue_count =
+        iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
     for (iree_host_size_t j = 0;
-         j < physical_device->host_queue_count && iree_status_is_ok(status);
-         ++j) {
+         j < host_queue_count && iree_status_is_ok(status); ++j) {
       iree_hal_amdgpu_host_queue_t* queue = &physical_device->host_queues[j];
       if (enabled) {
         status = iree_hal_amdgpu_host_queue_enable_profile_traces(
@@ -1629,8 +1624,10 @@ static iree_status_t iree_hal_amdgpu_logical_device_set_trace_profiling_enabled(
          ++i) {
       iree_hal_amdgpu_physical_device_t* physical_device =
           logical_device->physical_devices[i];
-      for (iree_host_size_t j = 0; j < physical_device->host_queue_count &&
-                                   seen_queue_count < changed_queue_count;
+      const iree_host_size_t host_queue_count =
+          iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
+      for (iree_host_size_t j = 0;
+           j < host_queue_count && seen_queue_count < changed_queue_count;
            ++j, ++seen_queue_count) {
         iree_hal_amdgpu_host_queue_disable_profile_traces(
             &physical_device->host_queues[j]);
@@ -1758,7 +1755,8 @@ bool iree_hal_amdgpu_logical_device_lookup_host_queue_epoch_wait(
   iree_hal_amdgpu_physical_device_t* physical_device =
       logical_device->physical_devices[resolved.physical_device_ordinal];
 
-  if (resolved.physical_queue_ordinal >= physical_device->host_queue_count) {
+  if (resolved.physical_queue_ordinal >=
+      iree_hal_amdgpu_physical_device_host_queue_count(physical_device)) {
     return false;
   }
   iree_hal_amdgpu_host_queue_t* queue =
@@ -1782,8 +1780,6 @@ static void iree_hal_amdgpu_logical_device_deassign_frontier(
     iree_hal_amdgpu_logical_device_t* logical_device) {
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_atomic_store(&logical_device->queue_topology_frozen, 0,
-                    iree_memory_order_release);
-  iree_atomic_store(&logical_device->active_queue_affinity, 0,
                     iree_memory_order_release);
   for (iree_host_size_t i = 0; i < logical_device->physical_device_count; ++i) {
     iree_hal_amdgpu_physical_device_deassign_frontier(
@@ -1869,9 +1865,11 @@ static void iree_hal_amdgpu_logical_device_translate_physical_options(
   out_options->host_block_pool_initial_capacity =
       options->preallocate_pools ? 16 : 0;
   out_options->host_queue_count = topology->gpu_agent_queue_count;
-  out_options->host_queue_initial_count =
+  out_options->host_queue_ordinary_count =
       iree_min((iree_host_size_t)IREE_HAL_AMDGPU_DEFAULT_GPU_AGENT_QUEUE_COUNT,
                out_options->host_queue_count);
+  out_options->host_queue_initial_count =
+      out_options->host_queue_ordinary_count;
   out_options->host_queue_aql_capacity = options->host_queues.aql_capacity;
   out_options->host_queue_notification_capacity =
       options->host_queues.notification_capacity;
@@ -1907,7 +1905,7 @@ static iree_status_t iree_hal_amdgpu_logical_device_verify_physical_options(
 
 static iree_status_t iree_hal_amdgpu_logical_device_allocate_storage(
     iree_string_view_t identifier, const iree_hal_amdgpu_topology_t* topology,
-    iree_host_size_t host_queue_initial_count,
+    iree_host_size_t host_queue_ordinary_count,
     iree_host_size_t physical_device_size, iree_allocator_t host_allocator,
     iree_hal_amdgpu_logical_device_t** out_logical_device) {
   *out_logical_device = NULL;
@@ -1940,7 +1938,7 @@ static iree_status_t iree_hal_amdgpu_logical_device_allocate_storage(
                                     physical_device_affinity);
     const iree_host_size_t queue_ordinal_base =
         i * topology->gpu_agent_queue_count;
-    for (iree_host_size_t j = 0; j < host_queue_initial_count; ++j) {
+    for (iree_host_size_t j = 0; j < host_queue_ordinary_count; ++j) {
       ordinary_queue_affinity_mask |= (iree_hal_queue_affinity_t)1ull
                                       << (queue_ordinal_base + j);
     }
@@ -1969,9 +1967,9 @@ static iree_status_t iree_hal_amdgpu_logical_device_allocate_storage(
   logical_device->queue_affinity_mask = logical_queue_affinity_mask;
   logical_device->ordinary_queue_affinity_mask = ordinary_queue_affinity_mask;
   logical_device->leased_execution_queue_affinity = 0;
-  logical_device->execution_queue_head = NULL;
-  iree_atomic_store(&logical_device->active_queue_affinity, 0,
+  iree_atomic_store(&logical_device->execution_queue_submission_affinity, 0,
                     iree_memory_order_relaxed);
+  logical_device->execution_queue_head = NULL;
   iree_atomic_store(&logical_device->queue_topology_frozen, 0,
                     iree_memory_order_relaxed);
   iree_slim_mutex_initialize(&logical_device->host_queue_activation_mutex);
@@ -2078,13 +2076,14 @@ static iree_status_t iree_hal_amdgpu_logical_device_create_device_spec(
     const iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
     if (IREE_UNLIKELY(physical_device->device_ordinal > UINT32_MAX ||
-                      physical_device->host_queue_initial_count > UINT32_MAX)) {
+                      physical_device->host_queue_ordinary_count >
+                          UINT32_MAX)) {
       status =
           iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                            "AMDGPU device spec physical row out of range: "
                            "device_ordinal=%" PRIhsz ", queue_count=%" PRIhsz,
                            physical_device->device_ordinal,
-                           physical_device->host_queue_initial_count);
+                           physical_device->host_queue_ordinary_count);
       break;
     }
 
@@ -2112,7 +2111,7 @@ static iree_status_t iree_hal_amdgpu_logical_device_create_device_spec(
     physical_params->physical_ordinal =
         (uint32_t)physical_device->device_ordinal;
     physical_params->queue_count =
-        (uint32_t)physical_device->host_queue_initial_count;
+        (uint32_t)physical_device->host_queue_ordinary_count;
     physical_params->compute_unit_count = physical_device->compute_unit_count;
     physical_params->wavefront_size = physical_device->wavefront_size;
     physical_params->maximum_waves_per_compute_unit =
@@ -2237,12 +2236,14 @@ iree_status_t iree_hal_amdgpu_logical_device_create(
   iree_hal_amdgpu_logical_device_translate_physical_options(
       &resolved_options, device_topology, &physical_device_options);
   if (host_queue_extension) {
+    physical_device_options.host_queue_ordinary_count =
+        host_queue_extension->initial_count;
     physical_device_options.host_queue_initial_count =
         host_queue_extension->initial_count;
   }
   // TSAN publishes queue-specific state into executable variants during load.
-  // Initialize every advertised queue before those immutable variants can be
-  // constructed instead of permitting a partially configured late queue.
+  // Initialize every queue before those immutable variants can be constructed
+  // without changing which queues are ordinary or specialized.
   if (resolved_options.tsan.enabled) {
     physical_device_options.host_queue_initial_count =
         physical_device_options.host_queue_count;
@@ -2264,7 +2265,7 @@ iree_status_t iree_hal_amdgpu_logical_device_create(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_amdgpu_logical_device_allocate_storage(
               identifier, device_topology,
-              physical_device_options.host_queue_initial_count,
+              physical_device_options.host_queue_ordinary_count,
               physical_device_size, host_allocator, &logical_device));
   iree_status_t status =
       iree_hal_amdgpu_logical_device_initialize_host_resources(
@@ -2342,7 +2343,9 @@ static void iree_hal_amdgpu_logical_device_destroy(
          ++i) {
       iree_hal_amdgpu_physical_device_t* physical_device =
           logical_device->physical_devices[i];
-      for (iree_host_size_t j = 0; j < physical_device->host_queue_count; ++j) {
+      const iree_host_size_t host_queue_count =
+          iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
+      for (iree_host_size_t j = 0; j < host_queue_count; ++j) {
         iree_hal_amdgpu_host_queue_disable_profile_traces(
             &physical_device->host_queues[j]);
       }
@@ -2355,7 +2358,9 @@ static void iree_hal_amdgpu_logical_device_destroy(
          ++i) {
       iree_hal_amdgpu_physical_device_t* physical_device =
           logical_device->physical_devices[i];
-      for (iree_host_size_t j = 0; j < physical_device->host_queue_count; ++j) {
+      const iree_host_size_t host_queue_count =
+          iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
+      for (iree_host_size_t j = 0; j < host_queue_count; ++j) {
         iree_hal_amdgpu_host_queue_disable_profile_counters(
             &physical_device->host_queues[j]);
       }
@@ -2851,24 +2856,6 @@ static iree_status_t iree_hal_amdgpu_logical_device_assign_topology_info(
         logical_device->physical_devices[device_ordinal]);
   }
   if (iree_status_is_ok(status)) {
-    uint64_t active_queue_affinity = 0;
-    for (iree_host_size_t device_ordinal = 0;
-         device_ordinal < logical_device->physical_device_count;
-         ++device_ordinal) {
-      const iree_hal_amdgpu_physical_device_t* physical_device =
-          logical_device->physical_devices[device_ordinal];
-      const iree_host_size_t queue_ordinal_base =
-          device_ordinal * system->topology.gpu_agent_queue_count;
-      for (iree_host_size_t queue_ordinal = 0;
-           queue_ordinal < physical_device->host_queue_count; ++queue_ordinal) {
-        active_queue_affinity |= (uint64_t)1ull
-                                 << (queue_ordinal_base + queue_ordinal);
-      }
-    }
-    iree_atomic_store(&logical_device->active_queue_affinity,
-                      active_queue_affinity, iree_memory_order_release);
-  }
-  if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_tsan_state_assign_queues(
         &logical_device->tsan, logical_device->physical_device_count,
         logical_device->physical_devices);
@@ -2905,7 +2892,7 @@ static iree_status_t iree_hal_amdgpu_logical_device_create_aql_command_buffer(
   return iree_hal_amdgpu_aql_command_buffer_create(
       logical_device->device_allocator, mode, command_categories,
       effective_queue_affinity, binding_capacity, device_ordinal,
-      physical_device->host_queue_count,
+      iree_hal_amdgpu_physical_device_host_queue_count(physical_device),
       iree_hal_amdgpu_tsan_state_is_enabled(&logical_device->tsan)
           ? logical_device->tsan.device_states[device_ordinal]
                 .config.shadow_slot_count
@@ -3089,26 +3076,52 @@ static iree_status_t iree_hal_amdgpu_logical_device_load_executable(
   iree_hal_amdgpu_logical_device_t* logical_device =
       iree_hal_amdgpu_logical_device_cast(base_device);
 
+  // Queue activation makes the live count mutable. Capture count and scope
+  // records under the activation mutex so the stack allocation and fill pass
+  // describe one coherent queue set.
+  iree_slim_mutex_lock(&logical_device->host_queue_activation_mutex);
+  iree_status_t status = iree_ok_status();
   iree_host_size_t queue_scope_count = 0;
-  for (iree_host_size_t i = 0; i < logical_device->physical_device_count; ++i) {
-    queue_scope_count += logical_device->physical_devices[i]->host_queue_count;
+  for (iree_host_size_t i = 0;
+       i < logical_device->physical_device_count && iree_status_is_ok(status);
+       ++i) {
+    if (!iree_host_size_checked_add(
+            queue_scope_count,
+            iree_hal_amdgpu_physical_device_host_queue_count(
+                logical_device->physical_devices[i]),
+            &queue_scope_count)) {
+      status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                "executable queue scope count overflow");
+    }
   }
   iree_hal_amdgpu_queue_scope_t* queue_scopes = NULL;
-  if (queue_scope_count != 0) {
-    queue_scopes = (iree_hal_amdgpu_queue_scope_t*)iree_alloca(
-        queue_scope_count * sizeof(queue_scopes[0]));
+  iree_host_size_t queue_scopes_size = 0;
+  if (iree_status_is_ok(status) && queue_scope_count != 0) {
+    if (!iree_host_size_checked_mul(queue_scope_count, sizeof(queue_scopes[0]),
+                                    &queue_scopes_size)) {
+      status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                "executable queue scope size overflow");
+    }
+  }
+  if (iree_status_is_ok(status) && queue_scope_count != 0) {
+    queue_scopes =
+        (iree_hal_amdgpu_queue_scope_t*)iree_alloca(queue_scopes_size);
     iree_host_size_t queue_scope_ordinal = 0;
     for (iree_host_size_t i = 0; i < logical_device->physical_device_count;
          ++i) {
       iree_hal_amdgpu_physical_device_t* physical_device =
           logical_device->physical_devices[i];
-      for (iree_host_size_t j = 0; j < physical_device->host_queue_count; ++j) {
+      const iree_host_size_t host_queue_count =
+          iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
+      for (iree_host_size_t j = 0; j < host_queue_count; ++j) {
         iree_hal_amdgpu_host_queue_query_scope(
             &physical_device->host_queues[j],
             &queue_scopes[queue_scope_ordinal++]);
       }
     }
   }
+  iree_slim_mutex_unlock(&logical_device->host_queue_activation_mutex);
+  IREE_RETURN_IF_ERROR(status);
 
   uint64_t executable_id = 0;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_logical_device_allocate_executable_id(
@@ -3452,6 +3465,7 @@ IREE_API_EXPORT iree_status_t iree_hal_amdgpu_execution_queue_acquire(
   iree_host_size_t mask_size = 0;
   iree_host_size_t allocation_size = 0;
   bool queue_reserved = false;
+  bool queue_reusable = false;
   if (iree_status_is_ok(status)) {
     iree_hal_amdgpu_queue_affinity_resolved_t device_resolved;
     status = iree_hal_amdgpu_queue_affinity_resolve(
@@ -3538,7 +3552,7 @@ IREE_API_EXPORT iree_status_t iree_hal_amdgpu_execution_queue_acquire(
       }
     }
     if (iree_status_is_ok(status) && !*out_execution_queue) {
-      for (iree_host_size_t i = physical_device->host_queue_initial_count;
+      for (iree_host_size_t i = physical_device->host_queue_ordinary_count;
            i < physical_device->host_queue_capacity; ++i) {
         const iree_host_size_t queue_ordinal =
             physical_device_ordinal *
@@ -3571,33 +3585,41 @@ IREE_API_EXPORT iree_status_t iree_hal_amdgpu_execution_queue_acquire(
     if (iree_status_is_ok(status) && queue_reserved) {
       status = iree_hal_amdgpu_logical_device_ensure_host_queue(logical_device,
                                                                 &resolved);
+      // No native queue configuration was attempted. The reservation can be
+      // retried even if activation initialized an earlier queue in the prefix.
+      if (!iree_status_is_ok(status)) queue_reusable = true;
     }
     if (iree_status_is_ok(status) && queue_reserved) {
       iree_hal_amdgpu_host_queue_t* queue =
           &logical_device->physical_devices[resolved.physical_device_ordinal]
                ->host_queues[resolved.physical_queue_ordinal];
 
-      // Configuration is a cold control-plane operation. Holding the registry
-      // mutex prevents a duplicate mask acquisition from consuming another
-      // slot before this queue is fully configured and published.
-      iree_slim_mutex_lock(&queue->locks.submission_mutex);
-      status = iree_hsa_amd_queue_cu_set_mask(IREE_LIBHSA(queue->libhsa),
-                                              queue->hardware_queue,
-                                              (uint32_t)mask_bit_count, mask);
-      iree_slim_mutex_unlock(&queue->locks.submission_mutex);
+      status = iree_hal_amdgpu_host_queue_begin_execution_lease(
+          queue, (uint32_t)mask_bit_count, mask, &queue_reusable);
     }
     if (iree_status_is_ok(status) && queue_reserved) {
       execution_queue->queue_affinity = (iree_hal_queue_affinity_t)1ull
                                         << resolved.queue_ordinal;
       execution_queue->next = logical_device->execution_queue_head;
       logical_device->execution_queue_head = execution_queue;
+      iree_atomic_fetch_or(&logical_device->execution_queue_submission_affinity,
+                           execution_queue->queue_affinity,
+                           iree_memory_order_release);
       iree_hal_device_retain(base_device);
       *out_execution_queue = execution_queue;
-    } else if (queue_reserved) {
+    } else if (queue_reserved && queue_reusable) {
       logical_device->leased_execution_queue_affinity &=
           ~((iree_hal_queue_affinity_t)1ull << resolved.queue_ordinal);
     }
     iree_slim_mutex_unlock(&logical_device->execution_queue_mutex);
+  }
+  if (!iree_status_is_ok(status) && queue_reserved && !queue_reusable) {
+    iree_hal_amdgpu_logical_device_error_handler(
+        logical_device,
+        iree_status_annotate_f(
+            iree_status_clone(status),
+            "quarantining specialized AMDGPU queue affinity 0x%016" PRIx64,
+            (uint64_t)resolved.queue_affinity));
   }
   if (*out_execution_queue != execution_queue) {
     iree_allocator_free(logical_device->host_allocator, execution_queue);
@@ -3626,6 +3648,10 @@ IREE_API_EXPORT void iree_hal_amdgpu_execution_queue_release(
     current = &(*current)->next;
   }
   IREE_ASSERT(*current == execution_queue);
+  *current = execution_queue->next;
+  iree_atomic_fetch_and(&logical_device->execution_queue_submission_affinity,
+                        (uint64_t)~queue_affinity, iree_memory_order_release);
+  iree_slim_mutex_unlock(&logical_device->execution_queue_mutex);
 
   iree_hal_amdgpu_queue_affinity_resolved_t resolved = {0};
   iree_status_t status = iree_hal_amdgpu_queue_affinity_resolve(
@@ -3635,17 +3661,13 @@ IREE_API_EXPORT void iree_hal_amdgpu_execution_queue_release(
     iree_hal_amdgpu_host_queue_t* queue =
         &logical_device->physical_devices[resolved.physical_device_ordinal]
              ->host_queues[resolved.physical_queue_ordinal];
-    iree_slim_mutex_lock(&queue->locks.submission_mutex);
-    status = iree_hsa_amd_queue_cu_set_mask(
-        IREE_LIBHSA(queue->libhsa), queue->hardware_queue,
-        /*mask_bit_count=*/0, /*mask=*/NULL);
-    iree_slim_mutex_unlock(&queue->locks.submission_mutex);
+    status = iree_hal_amdgpu_host_queue_end_execution_lease(queue);
   }
-  *current = execution_queue->next;
   if (iree_status_is_ok(status)) {
+    iree_slim_mutex_lock(&logical_device->execution_queue_mutex);
     logical_device->leased_execution_queue_affinity &= ~queue_affinity;
+    iree_slim_mutex_unlock(&logical_device->execution_queue_mutex);
   }
-  iree_slim_mutex_unlock(&logical_device->execution_queue_mutex);
 
   const iree_allocator_t host_allocator = logical_device->host_allocator;
   iree_allocator_free(host_allocator, execution_queue);

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -1644,10 +1644,9 @@ static iree_status_t iree_hal_amdgpu_logical_device_set_trace_profiling_enabled(
 
 // Selects one host queue from |queue_affinity| after intersecting with this
 // logical device's supported queues. The current policy is deterministic
-// first-set-bit selection, which is enough to honor explicit HIP stream
-// affinities and keeps the CTS path stable. A multi-bit affinity therefore acts
-// as "any of these queues"; queue_flush handles multi-bit masks by iterating
-// all selected queues instead.
+// first-set-bit selection, which is enough to honor explicit virtual-client
+// affinities. A multi-bit affinity therefore acts as "any of these queues";
+// queue_flush handles multi-bit masks by iterating all selected queues instead.
 static iree_status_t iree_hal_amdgpu_logical_device_select_host_queue(
     iree_hal_amdgpu_logical_device_t* logical_device,
     iree_hal_queue_affinity_t queue_affinity,
@@ -3475,8 +3474,10 @@ IREE_API_EXPORT iree_status_t iree_hal_amdgpu_execution_queue_acquire(
                                 mask_bit_count, expected_mask_bit_count);
     }
     bool has_enabled_unit = false;
-    for (iree_host_size_t i = 0; i < mask_bit_count / 32; ++i) {
-      has_enabled_unit |= mask[i] != 0;
+    if (iree_status_is_ok(status)) {
+      for (iree_host_size_t i = 0; i < mask_bit_count / 32; ++i) {
+        has_enabled_unit |= mask[i] != 0;
+      }
     }
     const uint32_t final_word_bit_count =
         physical_device->compute_unit_count % 32;
@@ -3526,12 +3527,17 @@ IREE_API_EXPORT iree_status_t iree_hal_amdgpu_execution_queue_acquire(
       if (current->physical_device_ordinal == physical_device_ordinal &&
           current->execution_unit_mask_bit_count == mask_bit_count &&
           memcmp(current->execution_unit_mask, mask, mask_size) == 0) {
-        ++current->reference_count;
-        *out_execution_queue = current;
+        if (IREE_UNLIKELY(current->reference_count == IREE_HOST_SIZE_MAX)) {
+          status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                                    "execution queue reference count overflow");
+        } else {
+          ++current->reference_count;
+          *out_execution_queue = current;
+        }
         break;
       }
     }
-    if (!*out_execution_queue) {
+    if (iree_status_is_ok(status) && !*out_execution_queue) {
       for (iree_host_size_t i = physical_device->host_queue_initial_count;
            i < physical_device->host_queue_capacity; ++i) {
         const iree_host_size_t queue_ordinal =
@@ -3598,16 +3604,6 @@ IREE_API_EXPORT iree_status_t iree_hal_amdgpu_execution_queue_acquire(
   }
   IREE_TRACE_ZONE_END(z0);
   return status;
-}
-
-IREE_API_EXPORT void iree_hal_amdgpu_execution_queue_retain(
-    iree_hal_amdgpu_execution_queue_t* execution_queue) {
-  if (!execution_queue) return;
-  iree_hal_amdgpu_logical_device_t* logical_device =
-      execution_queue->logical_device;
-  iree_slim_mutex_lock(&logical_device->execution_queue_mutex);
-  ++execution_queue->reference_count;
-  iree_slim_mutex_unlock(&logical_device->execution_queue_mutex);
 }
 
 IREE_API_EXPORT void iree_hal_amdgpu_execution_queue_release(

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.h
@@ -153,12 +153,14 @@ typedef struct iree_hal_amdgpu_logical_device_t {
   // Protected by |execution_queue_mutex|.
   iree_hal_queue_affinity_t leased_execution_queue_affinity;
 
+  // Specialized queue affinities configured and open for submission. Published
+  // only after native mask configuration succeeds and cleared before final
+  // retirement begins.
+  iree_atomic_uint64_t execution_queue_submission_affinity;
+
   // Distinct immutable specialized queue configurations. Protected by
   // |execution_queue_mutex|.
   struct iree_hal_amdgpu_execution_queue_t* execution_queue_head;
-
-  // Queue affinities whose host queue storage has been initialized.
-  iree_atomic_uint64_t active_queue_affinity;
 
   // Non-zero while profiling requires the active queue set to remain stable.
   iree_atomic_int32_t queue_topology_frozen;

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.h
@@ -146,6 +146,15 @@ typedef struct iree_hal_amdgpu_logical_device_t {
   // Mask indicating which queue affinities are valid.
   iree_hal_queue_affinity_t queue_affinity_mask;
 
+  // Queue affinities whose host queue storage has been initialized.
+  iree_atomic_uint64_t active_queue_affinity;
+
+  // Non-zero while profiling requires the active queue set to remain stable.
+  iree_atomic_int32_t queue_topology_frozen;
+
+  // Serializes cold activation of lazily provisioned host queues.
+  iree_slim_mutex_t host_queue_activation_mutex;
+
   // Selected command-buffer recording and replay implementation.
   iree_hal_amdgpu_command_buffer_mode_t command_buffer_mode;
 

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.h
@@ -143,8 +143,19 @@ typedef struct iree_hal_amdgpu_logical_device_t {
   // deregistered by each host queue before this table is freed.
   iree_hal_amdgpu_epoch_signal_table_t* host_queue_epoch_table;
 
-  // Mask indicating which queue affinities are valid.
+  // Mask indicating all ordinary and specialized queue affinities.
   iree_hal_queue_affinity_t queue_affinity_mask;
+
+  // Ordinary queue affinities used to resolve public ANY submissions.
+  iree_hal_queue_affinity_t ordinary_queue_affinity_mask;
+
+  // Specialized queue affinities currently owned by execution queue leases.
+  // Protected by |execution_queue_mutex|.
+  iree_hal_queue_affinity_t leased_execution_queue_affinity;
+
+  // Distinct immutable specialized queue configurations. Protected by
+  // |execution_queue_mutex|.
+  struct iree_hal_amdgpu_execution_queue_t* execution_queue_head;
 
   // Queue affinities whose host queue storage has been initialized.
   iree_atomic_uint64_t active_queue_affinity;
@@ -154,6 +165,9 @@ typedef struct iree_hal_amdgpu_logical_device_t {
 
   // Serializes cold activation of lazily provisioned host queues.
   iree_slim_mutex_t host_queue_activation_mutex;
+
+  // Serializes specialized execution queue acquisition and release.
+  iree_slim_mutex_t execution_queue_mutex;
 
   // Selected command-buffer recording and replay implementation.
   iree_hal_amdgpu_command_buffer_mode_t command_buffer_mode;

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
@@ -208,6 +208,7 @@ void iree_hal_amdgpu_physical_device_options_initialize(
 
   out_options->host_queue_count =
       IREE_HAL_AMDGPU_PHYSICAL_DEVICE_DEFAULT_QUEUE_COUNT;
+  out_options->host_queue_ordinary_count = out_options->host_queue_count;
   out_options->host_queue_initial_count = out_options->host_queue_count;
   out_options->host_queue_aql_capacity =
       IREE_HAL_AMDGPU_PHYSICAL_DEVICE_DEFAULT_HOST_QUEUE_AQL_CAPACITY;
@@ -266,13 +267,23 @@ iree_status_t iree_hal_amdgpu_physical_device_options_verify(
         "(got %" PRIhsz ")",
         UINT8_MAX, options->host_queue_count);
   }
-  if (options->host_queue_initial_count == 0 ||
+  if (options->host_queue_ordinary_count == 0 ||
+      options->host_queue_ordinary_count > options->host_queue_count) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "ordinary host queue count must be in [1, host_queue_count] "
+        "(got ordinary=%" PRIhsz ", capacity=%" PRIhsz ")",
+        options->host_queue_ordinary_count, options->host_queue_count);
+  }
+  if (options->host_queue_initial_count < options->host_queue_ordinary_count ||
       options->host_queue_initial_count > options->host_queue_count) {
     return iree_make_status(
         IREE_STATUS_OUT_OF_RANGE,
-        "initial host queue count must be in [1, host_queue_count] "
-        "(got initial=%" PRIhsz ", capacity=%" PRIhsz ")",
-        options->host_queue_initial_count, options->host_queue_count);
+        "initial host queue count must be in "
+        "[host_queue_ordinary_count, host_queue_count] "
+        "(got initial=%" PRIhsz ", ordinary=%" PRIhsz ", capacity=%" PRIhsz ")",
+        options->host_queue_initial_count, options->host_queue_ordinary_count,
+        options->host_queue_count);
   }
   if (!iree_host_size_is_power_of_two(options->host_queue_aql_capacity) ||
       !iree_host_size_is_power_of_two(
@@ -364,8 +375,12 @@ static iree_status_t iree_hal_amdgpu_physical_device_initialize_identity(
   out_physical_device->device_ordinal = device_ordinal;
   out_physical_device->host_memory_pools = *host_memory_pools;
   out_physical_device->host_queue_capacity = options->host_queue_count;
+  out_physical_device->host_queue_ordinary_count =
+      options->host_queue_ordinary_count;
   out_physical_device->host_queue_initial_count =
       options->host_queue_initial_count;
+  iree_atomic_store(&out_physical_device->host_queue_count, 0,
+                    iree_memory_order_relaxed);
   out_physical_device->host_queue_aql_capacity =
       options->host_queue_aql_capacity;
   out_physical_device->host_queue_notification_capacity =
@@ -1237,7 +1252,8 @@ static iree_status_t iree_hal_amdgpu_physical_device_initialize_host_queue(
       physical_device->host_queue_upload_capacity, host_allocator,
       &physical_device->host_queues[queue_ordinal]);
   if (iree_status_is_ok(status)) {
-    physical_device->host_queue_count = queue_ordinal + 1;
+    iree_atomic_store(&physical_device->host_queue_count,
+                      (int32_t)(queue_ordinal + 1), iree_memory_order_release);
   }
   return status;
 }
@@ -1259,7 +1275,8 @@ iree_status_t iree_hal_amdgpu_physical_device_ensure_host_queue(
   }
 
   iree_status_t status = iree_ok_status();
-  for (iree_host_size_t i = physical_device->host_queue_count;
+  for (iree_host_size_t i =
+           iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
        i <= queue_ordinal && iree_status_is_ok(status); ++i) {
     status = iree_hal_amdgpu_physical_device_initialize_host_queue(
         logical_device, system, proactor, frontier_tracker, base_axis,
@@ -1301,10 +1318,13 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
 void iree_hal_amdgpu_physical_device_deassign_frontier(
     iree_hal_amdgpu_physical_device_t* physical_device) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  for (iree_host_size_t i = 0; i < physical_device->host_queue_count; ++i) {
+  const iree_host_size_t host_queue_count =
+      iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
+  for (iree_host_size_t i = 0; i < host_queue_count; ++i) {
     iree_hal_amdgpu_host_queue_deinitialize(&physical_device->host_queues[i]);
   }
-  physical_device->host_queue_count = 0;
+  iree_atomic_store(&physical_device->host_queue_count, 0,
+                    iree_memory_order_release);
   if (physical_device->default_pool_set.entries) {
     iree_hal_pool_set_deinitialize(&physical_device->default_pool_set);
   }
@@ -1327,9 +1347,10 @@ iree_status_t iree_hal_amdgpu_physical_device_set_hsa_profiling_enabled(
 
   iree_status_t status = iree_ok_status();
   iree_host_size_t changed_count = 0;
+  const iree_host_size_t host_queue_count =
+      iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
   for (iree_host_size_t i = 0;
-       i < physical_device->host_queue_count && iree_status_is_ok(status);
-       ++i) {
+       i < host_queue_count && iree_status_is_ok(status); ++i) {
     status = iree_hal_amdgpu_host_queue_set_hsa_profiling_enabled(
         &physical_device->host_queues[i], enabled);
     if (iree_status_is_ok(status)) {
@@ -1344,8 +1365,7 @@ iree_status_t iree_hal_amdgpu_physical_device_set_hsa_profiling_enabled(
                       &physical_device->host_queues[i], false));
     }
   } else if (!enabled) {
-    for (iree_host_size_t i = changed_count;
-         i < physical_device->host_queue_count; ++i) {
+    for (iree_host_size_t i = changed_count; i < host_queue_count; ++i) {
       status = iree_status_join(
           status, iree_hal_amdgpu_host_queue_set_hsa_profiling_enabled(
                       &physical_device->host_queues[i], false));
@@ -1422,7 +1442,9 @@ iree_status_t iree_hal_amdgpu_physical_device_trim(
   IREE_ASSERT_ARGUMENT(physical_device);
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  for (iree_host_size_t i = 0; i < physical_device->host_queue_count; ++i) {
+  const iree_host_size_t host_queue_count =
+      iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
+  for (iree_host_size_t i = 0; i < host_queue_count; ++i) {
     physical_device->host_queues[i].base.vtable->trim(
         &physical_device->host_queues[i].base);
   }

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
@@ -208,6 +208,7 @@ void iree_hal_amdgpu_physical_device_options_initialize(
 
   out_options->host_queue_count =
       IREE_HAL_AMDGPU_PHYSICAL_DEVICE_DEFAULT_QUEUE_COUNT;
+  out_options->host_queue_initial_count = out_options->host_queue_count;
   out_options->host_queue_aql_capacity =
       IREE_HAL_AMDGPU_PHYSICAL_DEVICE_DEFAULT_HOST_QUEUE_AQL_CAPACITY;
   out_options->host_queue_notification_capacity =
@@ -264,6 +265,14 @@ iree_status_t iree_hal_amdgpu_physical_device_options_verify(
         "host queue count must be in [1, %u] to fit the queue-axis encoding "
         "(got %" PRIhsz ")",
         UINT8_MAX, options->host_queue_count);
+  }
+  if (options->host_queue_initial_count == 0 ||
+      options->host_queue_initial_count > options->host_queue_count) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "initial host queue count must be in [1, host_queue_count] "
+        "(got initial=%" PRIhsz ", capacity=%" PRIhsz ")",
+        options->host_queue_initial_count, options->host_queue_count);
   }
   if (!iree_host_size_is_power_of_two(options->host_queue_aql_capacity) ||
       !iree_host_size_is_power_of_two(
@@ -355,6 +364,8 @@ static iree_status_t iree_hal_amdgpu_physical_device_initialize_identity(
   out_physical_device->device_ordinal = device_ordinal;
   out_physical_device->host_memory_pools = *host_memory_pools;
   out_physical_device->host_queue_capacity = options->host_queue_count;
+  out_physical_device->host_queue_initial_count =
+      options->host_queue_initial_count;
   out_physical_device->host_queue_aql_capacity =
       options->host_queue_aql_capacity;
   out_physical_device->host_queue_notification_capacity =
@@ -1146,7 +1157,7 @@ static iree_status_t iree_hal_amdgpu_physical_device_create_default_pools(
   return status;
 }
 
-iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
+static iree_status_t iree_hal_amdgpu_physical_device_initialize_host_queue(
     iree_hal_device_t* logical_device, iree_hal_amdgpu_system_t* system,
     iree_async_proactor_t* proactor,
     iree_async_frontier_tracker_t* frontier_tracker,
@@ -1154,13 +1165,9 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
     iree_hal_amdgpu_epoch_signal_table_t* epoch_signal_table,
     iree_hal_amdgpu_feedback_state_t* feedback_state,
     const iree_hal_amdgpu_host_memory_pools_t* host_memory_pools,
-    iree_allocator_t host_allocator,
+    iree_host_size_t queue_ordinal, iree_allocator_t host_allocator,
     iree_hal_amdgpu_physical_device_t* physical_device) {
-  IREE_TRACE_ZONE_BEGIN(z0);
-
   iree_hal_amdgpu_libhsa_t* libhsa = &system->libhsa;
-  iree_status_t status = iree_hal_amdgpu_physical_device_create_default_pools(
-      physical_device, epoch_signal_table, host_allocator);
   const iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain = {
       .supported_affinity = IREE_HAL_QUEUE_AFFINITY_ANY,
       .physical_device_count = system->topology.gpu_agent_count,
@@ -1198,45 +1205,89 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
     profiling_memory.event_access_agents = &physical_device->device_agent;
     profiling_memory.event_access_agent_count = 1;
   }
-  for (iree_host_size_t queue_ordinal = 0;
-       queue_ordinal < physical_device->host_queue_capacity &&
-       iree_status_is_ok(status);
-       ++queue_ordinal) {
-    const iree_host_size_t logical_queue_ordinal =
-        physical_device->device_ordinal * physical_device->host_queue_capacity +
-        queue_ordinal;
-    iree_hal_amdgpu_queue_affinity_resolved_t resolved;
-    iree_async_axis_t queue_axis = 0;
-    status = iree_hal_amdgpu_queue_affinity_make_axis(
-        queue_affinity_domain, base_axis, logical_queue_ordinal, &resolved,
-        &queue_axis);
-    if (!iree_status_is_ok(status)) break;
-    iree_thread_affinity_t completion_thread_affinity;
-    iree_thread_affinity_set_group_any(physical_device->host_numa_node,
-                                       &completion_thread_affinity);
-    status = iree_hal_amdgpu_host_queue_initialize(
-        libhsa, logical_device,
-        iree_hal_amdgpu_physical_device_hostcall_buffer(physical_device),
-        proactor, physical_device->device_agent,
-        &kernarg_ring_memory.descriptor, host_memory_pools->fine_pool,
-        frontier_tracker, queue_axis, resolved.queue_affinity,
-        logical_queue_ordinal, queue_ordinal, completion_thread_affinity,
-        physical_device->wait_barrier_strategy,
-        physical_device->vendor_packet_capabilities,
-        physical_device->pm4_timestamp_strategy, epoch_signal_table,
-        feedback_state, &physical_device->fine_host_block_pool,
-        profiling_memory, &physical_device->buffer_transfer_context,
-        &physical_device->default_pool_set, physical_device->default_pool,
-        &physical_device->transient_buffer_pool,
-        &physical_device->file_staging_pool, physical_device->device_ordinal,
-        physical_device->host_queue_aql_capacity,
-        physical_device->host_queue_notification_capacity,
-        physical_device->host_queue_kernarg_capacity,
-        physical_device->host_queue_upload_capacity, host_allocator,
-        &physical_device->host_queues[queue_ordinal]);
-    if (iree_status_is_ok(status)) {
-      physical_device->host_queue_count = queue_ordinal + 1;
-    }
+
+  const iree_host_size_t logical_queue_ordinal =
+      physical_device->device_ordinal * physical_device->host_queue_capacity +
+      queue_ordinal;
+  iree_hal_amdgpu_queue_affinity_resolved_t resolved;
+  iree_async_axis_t queue_axis = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_queue_affinity_make_axis(
+      queue_affinity_domain, base_axis, logical_queue_ordinal, &resolved,
+      &queue_axis));
+  iree_thread_affinity_t completion_thread_affinity;
+  iree_thread_affinity_set_group_any(physical_device->host_numa_node,
+                                     &completion_thread_affinity);
+  iree_status_t status = iree_hal_amdgpu_host_queue_initialize(
+      libhsa, logical_device,
+      iree_hal_amdgpu_physical_device_hostcall_buffer(physical_device),
+      proactor, physical_device->device_agent, &kernarg_ring_memory.descriptor,
+      host_memory_pools->fine_pool, frontier_tracker, queue_axis,
+      resolved.queue_affinity, logical_queue_ordinal, queue_ordinal,
+      completion_thread_affinity, physical_device->wait_barrier_strategy,
+      physical_device->vendor_packet_capabilities,
+      physical_device->pm4_timestamp_strategy, epoch_signal_table,
+      feedback_state, &physical_device->fine_host_block_pool, profiling_memory,
+      &physical_device->buffer_transfer_context,
+      &physical_device->default_pool_set, physical_device->default_pool,
+      &physical_device->transient_buffer_pool,
+      &physical_device->file_staging_pool, physical_device->device_ordinal,
+      physical_device->host_queue_aql_capacity,
+      physical_device->host_queue_notification_capacity,
+      physical_device->host_queue_kernarg_capacity,
+      physical_device->host_queue_upload_capacity, host_allocator,
+      &physical_device->host_queues[queue_ordinal]);
+  if (iree_status_is_ok(status)) {
+    physical_device->host_queue_count = queue_ordinal + 1;
+  }
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_physical_device_ensure_host_queue(
+    iree_hal_device_t* logical_device, iree_hal_amdgpu_system_t* system,
+    iree_async_proactor_t* proactor,
+    iree_async_frontier_tracker_t* frontier_tracker,
+    iree_async_axis_t base_axis,
+    iree_hal_amdgpu_epoch_signal_table_t* epoch_signal_table,
+    iree_hal_amdgpu_feedback_state_t* feedback_state,
+    iree_host_size_t queue_ordinal, iree_allocator_t host_allocator,
+    iree_hal_amdgpu_physical_device_t* physical_device) {
+  if (IREE_UNLIKELY(queue_ordinal >= physical_device->host_queue_capacity)) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "host queue ordinal %" PRIhsz " exceeds capacity %" PRIhsz,
+        queue_ordinal, physical_device->host_queue_capacity);
+  }
+
+  iree_status_t status = iree_ok_status();
+  for (iree_host_size_t i = physical_device->host_queue_count;
+       i <= queue_ordinal && iree_status_is_ok(status); ++i) {
+    status = iree_hal_amdgpu_physical_device_initialize_host_queue(
+        logical_device, system, proactor, frontier_tracker, base_axis,
+        epoch_signal_table, feedback_state, &physical_device->host_memory_pools,
+        i, host_allocator, physical_device);
+  }
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
+    iree_hal_device_t* logical_device, iree_hal_amdgpu_system_t* system,
+    iree_async_proactor_t* proactor,
+    iree_async_frontier_tracker_t* frontier_tracker,
+    iree_async_axis_t base_axis,
+    iree_hal_amdgpu_epoch_signal_table_t* epoch_signal_table,
+    iree_hal_amdgpu_feedback_state_t* feedback_state,
+    iree_allocator_t host_allocator,
+    iree_hal_amdgpu_physical_device_t* physical_device) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status = iree_hal_amdgpu_physical_device_create_default_pools(
+      physical_device, epoch_signal_table, host_allocator);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_amdgpu_physical_device_ensure_host_queue(
+        logical_device, system, proactor, frontier_tracker, base_axis,
+        epoch_signal_table, feedback_state,
+        physical_device->host_queue_initial_count - 1, host_allocator,
+        physical_device);
   }
 
   if (!iree_status_is_ok(status)) {

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device.h
@@ -132,8 +132,11 @@ typedef struct iree_hal_amdgpu_physical_device_options_t {
 
   // Maximum number of host queues available for this physical device.
   iree_host_size_t host_queue_count;
+  // Number of ordinary queues exposed through the generic HAL device spec.
+  iree_host_size_t host_queue_ordinary_count;
   // Number of host queues initialized when the device frontier is assigned.
-  // Remaining queue slots are initialized on first use.
+  // This may exceed |host_queue_ordinary_count| when instrumentation requires
+  // queue-local state to be fixed before executable loading.
   iree_host_size_t host_queue_initial_count;
   // Per-host-queue HSA AQL ring capacity in packets.
   uint32_t host_queue_aql_capacity;
@@ -303,6 +306,8 @@ typedef struct iree_hal_amdgpu_physical_device_t {
 
   // Total number of host queue slots allocated in |host_queues|.
   iree_host_size_t host_queue_capacity;
+  // Number of ordinary queues exposed through the generic HAL device spec.
+  iree_host_size_t host_queue_ordinary_count;
   // Number of host queues initialized when the device frontier is assigned.
   iree_host_size_t host_queue_initial_count;
   // Per-host-queue HSA AQL ring capacity in packets.
@@ -321,11 +326,20 @@ typedef struct iree_hal_amdgpu_physical_device_t {
   // Queue-local PM4 timestamp strategy selected from this GPU agent's ISA.
   iree_hal_amdgpu_pm4_timestamp_strategy_t pm4_timestamp_strategy;
 
-  // Number of live host queues initialized in |host_queues|.
-  iree_host_size_t host_queue_count;
+  // Number of live host queues initialized in |host_queues|. Queue activation
+  // stores with release ordering after initialization is complete; readers load
+  // with acquire ordering before accessing the corresponding queue storage.
+  iree_atomic_int32_t host_queue_count;
   // One or more host queues mapped to HSA queues on this physical device.
   iree_hal_amdgpu_host_queue_t host_queues[/*host_queue_count*/];
 } iree_hal_amdgpu_physical_device_t;
+
+// Returns the number of fully initialized host queues.
+static inline iree_host_size_t iree_hal_amdgpu_physical_device_host_queue_count(
+    const iree_hal_amdgpu_physical_device_t* physical_device) {
+  return (iree_host_size_t)iree_atomic_load(&physical_device->host_queue_count,
+                                            iree_memory_order_acquire);
+}
 
 // Returns the aligned heap size in bytes required to store the physical device
 // data structure. Requires that the options have been verified.

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device.h
@@ -130,8 +130,11 @@ typedef struct iree_hal_amdgpu_physical_device_options_t {
   // Initial block count preallocated for the host block pool.
   iree_host_size_t host_block_pool_initial_capacity;
 
-  // Number of host queues created for this physical device.
+  // Maximum number of host queues available for this physical device.
   iree_host_size_t host_queue_count;
+  // Number of host queues initialized when the device frontier is assigned.
+  // Remaining queue slots are initialized on first use.
+  iree_host_size_t host_queue_initial_count;
   // Per-host-queue HSA AQL ring capacity in packets.
   uint32_t host_queue_aql_capacity;
   // Per-host-queue completion/reclaim ring capacity.
@@ -300,6 +303,8 @@ typedef struct iree_hal_amdgpu_physical_device_t {
 
   // Total number of host queue slots allocated in |host_queues|.
   iree_host_size_t host_queue_capacity;
+  // Number of host queues initialized when the device frontier is assigned.
+  iree_host_size_t host_queue_initial_count;
   // Per-host-queue HSA AQL ring capacity in packets.
   uint32_t host_queue_aql_capacity;
   // Per-host-queue completion/reclaim ring capacity.
@@ -351,8 +356,19 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
     iree_async_axis_t base_axis,
     iree_hal_amdgpu_epoch_signal_table_t* epoch_signal_table,
     iree_hal_amdgpu_feedback_state_t* feedback_state,
-    const iree_hal_amdgpu_host_memory_pools_t* host_memory_pools,
     iree_allocator_t host_allocator,
+    iree_hal_amdgpu_physical_device_t* physical_device);
+
+// Initializes host queues through |queue_ordinal|. The caller must serialize
+// this with other queue activation and device teardown operations.
+iree_status_t iree_hal_amdgpu_physical_device_ensure_host_queue(
+    iree_hal_device_t* logical_device, iree_hal_amdgpu_system_t* system,
+    iree_async_proactor_t* proactor,
+    iree_async_frontier_tracker_t* frontier_tracker,
+    iree_async_axis_t base_axis,
+    iree_hal_amdgpu_epoch_signal_table_t* epoch_signal_table,
+    iree_hal_amdgpu_feedback_state_t* feedback_state,
+    iree_host_size_t queue_ordinal, iree_allocator_t host_allocator,
     iree_hal_amdgpu_physical_device_t* physical_device);
 
 // Deinitializes any host queues initialized by assign_frontier.

--- a/runtime/src/iree/hal/drivers/amdgpu/tsan_state.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/tsan_state.c
@@ -158,9 +158,10 @@ iree_status_t iree_hal_amdgpu_tsan_state_assign_queues(
     iree_hal_amdgpu_tsan_memory_policy_t memory_policy;
     status = iree_hal_amdgpu_tsan_state_select_memory_policy(physical_device,
                                                              &memory_policy);
+    const iree_host_size_t host_queue_count =
+        iree_hal_amdgpu_physical_device_host_queue_count(physical_device);
     for (iree_host_size_t j = 0;
-         j < physical_device->host_queue_count && iree_status_is_ok(status);
-         ++j) {
+         j < host_queue_count && iree_status_is_ok(status); ++j) {
       const iree_host_size_t queue_ordinal =
           physical_device->device_ordinal *
               physical_device->host_queue_capacity +

--- a/runtime/src/iree/hal/drivers/amdgpu/util/queue_benchmark.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/queue_benchmark.cc
@@ -445,7 +445,8 @@ class QueueBenchmark : public benchmark::Fixture {
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[resolved.physical_device_ordinal];
     if (IREE_UNLIKELY(resolved.physical_queue_ordinal >=
-                      physical_device->host_queue_count)) {
+                      iree_hal_amdgpu_physical_device_host_queue_count(
+                          physical_device))) {
       return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                               "queue ordinal has no initialized host queue");
     }
@@ -481,7 +482,8 @@ class QueueBenchmark : public benchmark::Fixture {
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[resolved.physical_device_ordinal];
     if (IREE_UNLIKELY(resolved.physical_queue_ordinal >=
-                      physical_device->host_queue_count)) {
+                      iree_hal_amdgpu_physical_device_host_queue_count(
+                          physical_device))) {
       return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                               "producer axis has no initialized host queue");
     }


### PR DESCRIPTION
 ## Summary

  Add AMDGPU queue provisioning needed to support execution contexts with
  restricted execution-unit masks.

  The device now distinguishes between:

  - queue capacity reserved for stable affinity ordinals; and
  - the initial queue count created during device initialization.

  Ordinary queues are created eagerly. Additional specialized queues are created
  lazily when first selected, avoiding the resource cost of creating every
  possible queue up front.

  ## Motivation

  HIP execution contexts can restrict streams to an exact set of execution units.
  The restriction is a persistent property of the underlying HSA queue, not a
  per-dispatch parameter. Each concurrently usable restriction therefore requires
  an independently owned queue.

  This enables follow-on support for APIs including:

  - `hipExtStreamCreateWithCUMask`
  - `hipExtStreamGetCUMask`
  - `hipDevSmResourceSplit`
  - `hipDevSmResourceSplitByCount`
  - execution-resource and green-context creation
  - streams created from restricted execution resources

  ## Design

  Queue-affinity ordinals remain stable for the lifetime of the device. The
  logical device reserves storage for the full configured capacity while only
  materializing the initial queue set during device creation.

  Selecting an inactive ordinal activates the required queue under a dedicated
  activation mutex. The queue is published through the active-queue mask only
  after its initialization completes. Subsequent use of an active queue avoids
  the activation lock.

  The ordinary dispatch path is unchanged: initial queue ordinals return before
  the lazy-activation atomic check or mutex.

  A private AMDGPU operation configures an exact execution-unit mask on an
  exclusively owned queue. It validates the complete mask width and serializes the
  native mask operation with queue submission. The owner remains responsible for
  ensuring that the queue is idle before changing or restoring its mask.

  Profiling requires a fixed queue topology, so all advertised queues are
  materialized before profiling freezes that topology.

  ## Validation

  The implementation rejects:

  - duplicate queue configuration extensions;
  - invalid capacity or initial-count combinations;
  - out-of-range and non-singular queue affinities;
  - null, partial, or incorrectly sized execution-unit masks; and
  - queue activation after profiling has frozen the topology.

  The focused AMDGPU target builds successfully:

  `python dev.py --cmake-build-dir build/pair-amdgpu-check cmake build
  iree_hal_drivers_amdgpu_amdgpu --parallel 16`

  ## API Scope

  The new configuration and mask operations are private to the AMDGPU driver.
  No generic HAL interface changes are introduced.

  This boundary is intentional: persistent HSA queue masks and native queue
  lifecycle management are AMDGPU-specific, while execution-resource policy and
  queue ownership remain in the HIP integration layer.