### PR TITLE
[AMDGPU] Expose loaded-kernel resource metadata

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/api.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/api.h
@@ -495,6 +495,16 @@ IREE_API_EXPORT iree_status_t iree_hal_amdgpu_logical_device_create(
     const iree_hal_device_create_params_t* create_params,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device);
 
+// Queries immutable metadata for one executable function.
+IREE_API_EXPORT iree_status_t
+iree_hal_amdgpu_executable_query_function_attributes(
+    iree_hal_executable_t* executable, iree_hal_executable_function_t function,
+    uint32_t* out_maximum_workgroup_invocations,
+    uint32_t* out_workgroup_local_memory_size,
+    uint32_t* out_private_memory_size, uint32_t* out_register_count,
+    uint32_t* out_maximum_dynamic_workgroup_local_memory_size,
+    bool* out_requires_uniform_workgroups);
+
 //===----------------------------------------------------------------------===//
 // iree_hal_amdgpu_driver_t
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/hal/drivers/amdgpu/executable.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable.c
@@ -7,6 +7,7 @@
 #include "iree/hal/drivers/amdgpu/executable.h"
 
 #include "iree/base/internal/debugging.h"
+#include "iree/hal/drivers/amdgpu/api.h"
 #include "iree/hal/drivers/amdgpu/asan_state.h"
 #include "iree/hal/drivers/amdgpu/buffer.h"
 #include "iree/hal/drivers/amdgpu/executable_global_resolver.h"
@@ -1597,6 +1598,19 @@ static iree_status_t iree_hal_amdgpu_executable_initialize_export_infos(
       IREE_RETURN_IF_ERROR(iree_hal_amdgpu_executable_validate_workgroup_size(
           reflection->symbol_name, metadata_export->workgroup_size, limits));
     }
+    const uint32_t maximum_workgroup_invocations =
+        metadata_export->max_workgroup_size != 0
+            ? metadata_export->max_workgroup_size
+            : limits->max_workgroup_size;
+    if (IREE_UNLIKELY(maximum_workgroup_invocations >
+                      limits->max_workgroup_size)) {
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "AMDGPU kernel `%.*s` maximum workgroup size %u exceeds device "
+          "maximum %u",
+          (int)reflection->symbol_name.size, reflection->symbol_name.data,
+          maximum_workgroup_invocations, limits->max_workgroup_size);
+    }
 
     executable->custom_direct_only_exports[i] = custom_direct_only;
     executable->export_parameter_offsets[i] = reflection->parameter_offset;
@@ -2105,6 +2119,53 @@ uint64_t iree_hal_amdgpu_executable_id(iree_hal_executable_t* base_executable) {
   iree_hal_amdgpu_executable_t* executable =
       iree_hal_amdgpu_executable_cast(base_executable);
   return executable->executable_id;
+}
+
+IREE_API_EXPORT iree_status_t
+iree_hal_amdgpu_executable_query_function_attributes(
+    iree_hal_executable_t* base_executable,
+    iree_hal_executable_function_t function,
+    uint32_t* out_maximum_workgroup_invocations,
+    uint32_t* out_workgroup_local_memory_size,
+    uint32_t* out_private_memory_size, uint32_t* out_register_count,
+    uint32_t* out_maximum_dynamic_workgroup_local_memory_size,
+    bool* out_requires_uniform_workgroups) {
+  IREE_ASSERT_ARGUMENT(base_executable);
+  IREE_ASSERT_ARGUMENT(out_maximum_workgroup_invocations);
+  IREE_ASSERT_ARGUMENT(out_workgroup_local_memory_size);
+  IREE_ASSERT_ARGUMENT(out_private_memory_size);
+  IREE_ASSERT_ARGUMENT(out_register_count);
+  IREE_ASSERT_ARGUMENT(out_maximum_dynamic_workgroup_local_memory_size);
+  IREE_ASSERT_ARGUMENT(out_requires_uniform_workgroups);
+  *out_maximum_workgroup_invocations = 0;
+  *out_workgroup_local_memory_size = 0;
+  *out_private_memory_size = 0;
+  *out_register_count = 0;
+  *out_maximum_dynamic_workgroup_local_memory_size = 0;
+  *out_requires_uniform_workgroups = false;
+
+  const iree_hal_amdgpu_executable_t* executable =
+      iree_hal_amdgpu_executable_const_cast(base_executable);
+  if (IREE_UNLIKELY(!iree_hal_executable_function_is_index_in_range(
+          function, executable->kernel_count))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "function id %" PRIu64
+                            " out of range; executable has %" PRIhsz " exports",
+                            function.value, executable->kernel_count);
+  }
+  const uint32_t export_ordinal = iree_hal_executable_function_index(function);
+  const iree_hal_amdgpu_executable_export_t* metadata_export =
+      &executable->metadata->exports[export_ordinal];
+  *out_maximum_workgroup_invocations = metadata_export->max_workgroup_size;
+  *out_workgroup_local_memory_size = metadata_export->fixed_group_segment_size;
+  *out_private_memory_size = metadata_export->fixed_private_segment_size;
+  *out_register_count = metadata_export->vgpr_count;
+  *out_maximum_dynamic_workgroup_local_memory_size =
+      metadata_export->max_dynamic_workgroup_local_memory;
+  *out_requires_uniform_workgroups = iree_all_bits_set(
+      metadata_export->flags,
+      IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_REQUIRES_UNIFORM_WORKGROUPS);
+  return iree_ok_status();
 }
 
 static void iree_hal_amdgpu_executable_destroy(

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata.h
@@ -40,6 +40,8 @@ typedef enum iree_hal_amdgpu_executable_export_flag_bits_e {
       1u << 0,
   // Export can only be launched with caller-provided native kernargs.
   IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_CUSTOM_DIRECT_ONLY = 1u << 1,
+  // Export rejects dispatches that would create a partial workgroup.
+  IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_REQUIRES_UNIFORM_WORKGROUPS = 1u << 2,
 } iree_hal_amdgpu_executable_export_flag_bits_t;
 typedef uint32_t iree_hal_amdgpu_executable_export_flags_t;
 
@@ -100,6 +102,10 @@ typedef struct iree_hal_amdgpu_executable_export_t {
   uint32_t fixed_group_segment_size;
   // Fixed private segment byte size reported by executable metadata.
   uint32_t fixed_private_segment_size;
+  // Maximum total work-items per workgroup accepted by this export.
+  uint32_t max_workgroup_size;
+  // Vector registers allocated per work-item by this export.
+  uint32_t vgpr_count;
   // Maximum dynamic group-memory byte count accepted for this export.
   uint32_t max_dynamic_workgroup_local_memory;
   // Native kernarg layout record for normal metadata-described dispatch.

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco.c
@@ -307,6 +307,7 @@ iree_status_t iree_hal_amdgpu_executable_metadata_calculate_hsaco_counts(
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "AMDGPU metadata export count overflow");
   }
+
   for (iree_host_size_t i = 0; i < hsaco_metadata->kernel_count; ++i) {
     iree_hal_amdgpu_hsaco_kernel_load_plan_t load_plan;
     IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_load_plan_analyze_kernel(

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco.c
@@ -307,7 +307,6 @@ iree_status_t iree_hal_amdgpu_executable_metadata_calculate_hsaco_counts(
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "AMDGPU metadata export count overflow");
   }
-
   for (iree_host_size_t i = 0; i < hsaco_metadata->kernel_count; ++i) {
     iree_hal_amdgpu_hsaco_kernel_load_plan_t load_plan;
     IREE_RETURN_IF_ERROR(iree_hal_amdgpu_hsaco_load_plan_analyze_kernel(
@@ -531,10 +530,15 @@ iree_status_t iree_hal_amdgpu_executable_metadata_populate_from_hsaco(
     reflection->parameter_count = (uint32_t)load_plan.parameter_count;
 
     iree_hal_amdgpu_executable_export_t* export_info = &metadata->exports[i];
-    export_info->flags = IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_NONE;
+    export_info->flags =
+        kernel->uniform_workgroup_size
+            ? IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_REQUIRES_UNIFORM_WORKGROUPS
+            : IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_NONE;
     export_info->fixed_group_segment_size = kernel->group_segment_fixed_size;
     export_info->fixed_private_segment_size =
         kernel->private_segment_fixed_size;
+    export_info->max_workgroup_size = kernel->max_flat_workgroup_size;
+    export_info->vgpr_count = kernel->vgpr_count;
     export_info->max_dynamic_workgroup_local_memory =
         UINT32_MAX - kernel->group_segment_fixed_size;
     iree_hal_amdgpu_hsaco_load_plan_populate_workgroup_size(kernel,

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_metadata_hsaco_test.cc
@@ -122,8 +122,11 @@ static iree_hal_amdgpu_hsaco_metadata_kernel_t MakeKernel(
       /*.kernarg_segment_alignment=*/8,
       /*.group_segment_fixed_size=*/16,
       /*.private_segment_fixed_size=*/32,
+      /*.max_flat_workgroup_size=*/256,
+      /*.vgpr_count=*/40,
       /*.required_workgroup_size=*/{},
       /*.has_required_workgroup_size=*/{},
+      /*.uniform_workgroup_size=*/{},
       /*.workgroup_cluster_size=*/{},
       /*.has_workgroup_cluster_size=*/{},
       /*.arg_count=*/args.size(),
@@ -169,6 +172,7 @@ TEST(ExecutableMetadataHsacoTest, PopulatesSparseInterleavedKernelLayout) {
                  ViewFromCodeObjectData(source_code_object_data, "test.kd"),
                  /*kernarg_segment_size=*/40, args);
   kernel.has_required_workgroup_size = true;
+  kernel.uniform_workgroup_size = true;
   kernel.required_workgroup_size[0] = 4;
   kernel.required_workgroup_size[1] = 2;
   kernel.required_workgroup_size[2] = 1;
@@ -208,7 +212,8 @@ TEST(ExecutableMetadataHsacoTest, PopulatesSparseInterleavedKernelLayout) {
             loaded_code_object_data.data_length);
 
   const iree_hal_amdgpu_executable_export_t& export_info = metadata->exports[0];
-  EXPECT_EQ(export_info.flags, IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_NONE);
+  EXPECT_EQ(export_info.flags,
+            IREE_HAL_AMDGPU_EXECUTABLE_EXPORT_FLAG_REQUIRES_UNIFORM_WORKGROUPS);
   EXPECT_EQ(export_info.workgroup_size[0], 4);
   EXPECT_EQ(export_info.workgroup_size[1], 2);
   EXPECT_EQ(export_info.workgroup_size[2], 1);
@@ -217,6 +222,8 @@ TEST(ExecutableMetadataHsacoTest, PopulatesSparseInterleavedKernelLayout) {
   EXPECT_EQ(export_info.workgroup_cluster_size[2], 1);
   EXPECT_EQ(export_info.fixed_group_segment_size, 16);
   EXPECT_EQ(export_info.fixed_private_segment_size, 32);
+  EXPECT_EQ(export_info.max_workgroup_size, 256);
+  EXPECT_EQ(export_info.vgpr_count, 40);
 
   const iree_hal_amdgpu_kernarg_layout_t* layout = nullptr;
   IREE_ASSERT_OK(iree_hal_amdgpu_executable_metadata_resolve_layout(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -1037,6 +1037,11 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_parse_kernel(
       }
       IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_read_uint32(
           reader, &out_kernel->max_flat_workgroup_size));
+      if (out_kernel->max_flat_workgroup_size == 0) {
+        return iree_make_status(
+            IREE_STATUS_OUT_OF_RANGE,
+            "AMDGPU maximum flat workgroup size must be at least one");
+      }
       fields.has_max_flat_workgroup_size = true;
     } else if (iree_string_view_equal(key, IREE_SV(".vgpr_count"))) {
       if (fields.has_vgpr_count) {
@@ -1106,7 +1111,9 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_parse_kernel(
   if (!fields.has_symbol_name || !fields.has_kernarg_segment_size ||
       !fields.has_kernarg_segment_alignment ||
       !fields.has_group_segment_fixed_size ||
-      !fields.has_private_segment_fixed_size || !fields.has_args) {
+      !fields.has_private_segment_fixed_size ||
+      !fields.has_max_flat_workgroup_size || !fields.has_vgpr_count ||
+      !fields.has_args) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "AMDGPU kernel metadata missing required fields");
   }

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.c
@@ -630,7 +630,10 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_kernel_fields_t {
   bool has_kernarg_segment_alignment;
   bool has_group_segment_fixed_size;
   bool has_private_segment_fixed_size;
+  bool has_max_flat_workgroup_size;
+  bool has_vgpr_count;
   bool has_required_workgroup_size;
+  bool has_uniform_workgroup_size;
   bool has_workgroup_cluster_size;
   bool has_args;
 } iree_hal_amdgpu_hsaco_metadata_kernel_fields_t;
@@ -1027,6 +1030,21 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_parse_kernel(
       IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_read_uint32(
           reader, &out_kernel->private_segment_fixed_size));
       fields.has_private_segment_fixed_size = true;
+    } else if (iree_string_view_equal(key,
+                                      IREE_SV(".max_flat_workgroup_size"))) {
+      if (fields.has_max_flat_workgroup_size) {
+        return iree_hal_amdgpu_hsaco_metadata_duplicate_field_status(key);
+      }
+      IREE_RETURN_IF_ERROR(iree_hal_amdgpu_msgpack_read_uint32(
+          reader, &out_kernel->max_flat_workgroup_size));
+      fields.has_max_flat_workgroup_size = true;
+    } else if (iree_string_view_equal(key, IREE_SV(".vgpr_count"))) {
+      if (fields.has_vgpr_count) {
+        return iree_hal_amdgpu_hsaco_metadata_duplicate_field_status(key);
+      }
+      IREE_RETURN_IF_ERROR(
+          iree_hal_amdgpu_msgpack_read_uint32(reader, &out_kernel->vgpr_count));
+      fields.has_vgpr_count = true;
     } else if (iree_string_view_equal(key, IREE_SV(".reqd_workgroup_size"))) {
       if (fields.has_required_workgroup_size) {
         return iree_hal_amdgpu_hsaco_metadata_duplicate_field_status(key);
@@ -1035,6 +1053,21 @@ static iree_status_t iree_hal_amdgpu_hsaco_metadata_parse_kernel(
           reader, out_kernel->required_workgroup_size));
       out_kernel->has_required_workgroup_size = true;
       fields.has_required_workgroup_size = true;
+    } else if (iree_string_view_equal(key,
+                                      IREE_SV(".uniform_work_group_size"))) {
+      if (fields.has_uniform_workgroup_size) {
+        return iree_hal_amdgpu_hsaco_metadata_duplicate_field_status(key);
+      }
+      uint32_t uniform_workgroup_size = 0;
+      IREE_RETURN_IF_ERROR(
+          iree_hal_amdgpu_msgpack_read_uint32(reader, &uniform_workgroup_size));
+      if (uniform_workgroup_size > 1) {
+        return iree_make_status(
+            IREE_STATUS_OUT_OF_RANGE,
+            "AMDGPU uniform workgroup metadata must be zero or one");
+      }
+      out_kernel->uniform_workgroup_size = uniform_workgroup_size != 0;
+      fields.has_uniform_workgroup_size = true;
     } else if (iree_string_view_equal(key, IREE_SV(".cluster_dims"))) {
       if (fields.has_workgroup_cluster_size) {
         return iree_hal_amdgpu_hsaco_metadata_duplicate_field_status(key);

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata.h
@@ -82,10 +82,16 @@ typedef struct iree_hal_amdgpu_hsaco_metadata_kernel_t {
   uint32_t group_segment_fixed_size;
   // Fixed private segment size from `.private_segment_fixed_size`.
   uint32_t private_segment_fixed_size;
+  // Maximum total work-items per workgroup from `.max_flat_workgroup_size`.
+  uint32_t max_flat_workgroup_size;
+  // Vector registers allocated per work-item from `.vgpr_count`.
+  uint32_t vgpr_count;
   // Required workgroup size from `.reqd_workgroup_size`, if present.
   uint32_t required_workgroup_size[3];
   // True when |required_workgroup_size| was present.
   bool has_required_workgroup_size;
+  // True when `.uniform_work_group_size` requires full workgroups.
+  bool uniform_workgroup_size;
   // Required nontrivial workgroup-cluster size from `.cluster_dims`, if
   // present.
   uint8_t workgroup_cluster_size[3];

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
@@ -131,6 +131,8 @@ enum BuildKernelMetadataFlagBits : uint32_t {
   kBuildKernelMetadataOutOfRangeArg = 1u << 0,
   kBuildKernelMetadataUnknownValueKind = 1u << 1,
   kBuildKernelMetadataClusterDimensions = 1u << 2,
+  kBuildKernelMetadataUniformWorkgroups = 1u << 3,
+  kBuildKernelMetadataInvalidUniformWorkgroups = 1u << 4,
 };
 
 static std::vector<uint8_t> BuildKernelMetadata(
@@ -141,6 +143,10 @@ static std::vector<uint8_t> BuildKernelMetadata(
       (flags & kBuildKernelMetadataUnknownValueKind) != 0;
   const bool has_cluster_dimensions =
       (flags & kBuildKernelMetadataClusterDimensions) != 0;
+  const bool uniform_workgroups =
+      (flags & kBuildKernelMetadataUniformWorkgroups) != 0;
+  const bool invalid_uniform_workgroups =
+      (flags & kBuildKernelMetadataInvalidUniformWorkgroups) != 0;
   std::vector<uint8_t> output;
   AppendMsgPackMap(&output, 3);
 
@@ -156,18 +162,27 @@ static std::vector<uint8_t> BuildKernelMetadata(
 
   AppendMsgPackString(&output, IREE_SV("amdhsa.kernels"));
   AppendMsgPackArray(&output, 1);
-  AppendMsgPackMap(&output, 8 + (has_cluster_dimensions ? 1 : 0));
+  AppendMsgPackMap(
+      &output, 10 + (has_cluster_dimensions ? 1 : 0) +
+                   (uniform_workgroups || invalid_uniform_workgroups ? 1 : 0));
   AppendStringField(&output, IREE_SV(".name"), IREE_SV("vector_add"));
   AppendStringField(&output, IREE_SV(".symbol"), IREE_SV("vector_add.kd"));
   AppendUintField(&output, IREE_SV(".kernarg_segment_size"), 24);
   AppendUintField(&output, IREE_SV(".kernarg_segment_align"), 8);
   AppendUintField(&output, IREE_SV(".group_segment_fixed_size"), 1024);
   AppendUintField(&output, IREE_SV(".private_segment_fixed_size"), 64);
+  AppendUintField(&output, IREE_SV(".max_flat_workgroup_size"), 256);
+  AppendUintField(&output, IREE_SV(".vgpr_count"), 40);
   AppendMsgPackString(&output, IREE_SV(".reqd_workgroup_size"));
   AppendMsgPackArray(&output, 3);
   AppendMsgPackUint(&output, 16);
   AppendMsgPackUint(&output, 4);
   AppendMsgPackUint(&output, 1);
+
+  if (uniform_workgroups || invalid_uniform_workgroups) {
+    AppendUintField(&output, IREE_SV(".uniform_work_group_size"),
+                    invalid_uniform_workgroups ? 2 : 1);
+  }
 
   if (has_cluster_dimensions) {
     AppendMsgPackString(&output, IREE_SV(".cluster_dims"));
@@ -482,7 +497,8 @@ static std::string ToString(iree_string_view_t value) {
 }
 
 TEST(HsacoMetadataTest, ParsesValidMetadata) {
-  std::vector<uint8_t> elf = BuildElfWithMetadata(BuildKernelMetadata());
+  std::vector<uint8_t> elf = BuildElfWithMetadata(
+      BuildKernelMetadata(kBuildKernelMetadataUniformWorkgroups));
 
   iree_hal_amdgpu_hsaco_metadata_t metadata;
   IREE_ASSERT_OK(iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
@@ -504,10 +520,13 @@ TEST(HsacoMetadataTest, ParsesValidMetadata) {
   EXPECT_EQ(kernel.kernarg_segment_alignment, 8);
   EXPECT_EQ(kernel.group_segment_fixed_size, 1024);
   EXPECT_EQ(kernel.private_segment_fixed_size, 64);
+  EXPECT_EQ(kernel.max_flat_workgroup_size, 256);
+  EXPECT_EQ(kernel.vgpr_count, 40);
   ASSERT_TRUE(kernel.has_required_workgroup_size);
   EXPECT_EQ(kernel.required_workgroup_size[0], 16);
   EXPECT_EQ(kernel.required_workgroup_size[1], 4);
   EXPECT_EQ(kernel.required_workgroup_size[2], 1);
+  EXPECT_TRUE(kernel.uniform_workgroup_size);
   EXPECT_FALSE(kernel.has_workgroup_cluster_size);
   ASSERT_EQ(kernel.arg_count, 4);
   ASSERT_EQ(kernel.args, metadata.args);
@@ -543,6 +562,16 @@ TEST(HsacoMetadataTest, ParsesValidMetadata) {
             IREE_HAL_AMDGPU_HSACO_METADATA_ARG_KIND_BY_VALUE);
 
   iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
+}
+
+TEST(HsacoMetadataTest, RejectsInvalidUniformWorkgroupValue) {
+  std::vector<uint8_t> elf = BuildElfWithMetadata(
+      BuildKernelMetadata(kBuildKernelMetadataInvalidUniformWorkgroups));
+
+  iree_hal_amdgpu_hsaco_metadata_t metadata;
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_OUT_OF_RANGE,
+                        iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
+                            ByteSpan(elf), iree_allocator_system(), &metadata));
 }
 
 TEST(HsacoMetadataTest, FindsKernelBySymbol) {
@@ -663,7 +692,6 @@ TEST(HsacoMetadataTest, DiscoversElfSymbolsWithoutSynthesizingKernels) {
   EXPECT_EQ(ToString(metadata.elf_kernel_symbols[0].name), "extra_kernel");
   EXPECT_EQ(ToString(metadata.elf_kernel_symbols[0].symbol_name),
             "extra_kernel.kd");
-
   iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
 }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/hsaco_metadata_test.cc
@@ -133,6 +133,9 @@ enum BuildKernelMetadataFlagBits : uint32_t {
   kBuildKernelMetadataClusterDimensions = 1u << 2,
   kBuildKernelMetadataUniformWorkgroups = 1u << 3,
   kBuildKernelMetadataInvalidUniformWorkgroups = 1u << 4,
+  kBuildKernelMetadataOmitMaxFlatWorkgroupSize = 1u << 5,
+  kBuildKernelMetadataOmitVgprCount = 1u << 6,
+  kBuildKernelMetadataZeroMaxFlatWorkgroupSize = 1u << 7,
 };
 
 static std::vector<uint8_t> BuildKernelMetadata(
@@ -147,6 +150,11 @@ static std::vector<uint8_t> BuildKernelMetadata(
       (flags & kBuildKernelMetadataUniformWorkgroups) != 0;
   const bool invalid_uniform_workgroups =
       (flags & kBuildKernelMetadataInvalidUniformWorkgroups) != 0;
+  const bool omit_max_flat_workgroup_size =
+      (flags & kBuildKernelMetadataOmitMaxFlatWorkgroupSize) != 0;
+  const bool omit_vgpr_count = (flags & kBuildKernelMetadataOmitVgprCount) != 0;
+  const bool zero_max_flat_workgroup_size =
+      (flags & kBuildKernelMetadataZeroMaxFlatWorkgroupSize) != 0;
   std::vector<uint8_t> output;
   AppendMsgPackMap(&output, 3);
 
@@ -163,7 +171,9 @@ static std::vector<uint8_t> BuildKernelMetadata(
   AppendMsgPackString(&output, IREE_SV("amdhsa.kernels"));
   AppendMsgPackArray(&output, 1);
   AppendMsgPackMap(
-      &output, 10 + (has_cluster_dimensions ? 1 : 0) +
+      &output, 10 - (omit_max_flat_workgroup_size ? 1 : 0) -
+                   (omit_vgpr_count ? 1 : 0) +
+                   (has_cluster_dimensions ? 1 : 0) +
                    (uniform_workgroups || invalid_uniform_workgroups ? 1 : 0));
   AppendStringField(&output, IREE_SV(".name"), IREE_SV("vector_add"));
   AppendStringField(&output, IREE_SV(".symbol"), IREE_SV("vector_add.kd"));
@@ -171,8 +181,13 @@ static std::vector<uint8_t> BuildKernelMetadata(
   AppendUintField(&output, IREE_SV(".kernarg_segment_align"), 8);
   AppendUintField(&output, IREE_SV(".group_segment_fixed_size"), 1024);
   AppendUintField(&output, IREE_SV(".private_segment_fixed_size"), 64);
-  AppendUintField(&output, IREE_SV(".max_flat_workgroup_size"), 256);
-  AppendUintField(&output, IREE_SV(".vgpr_count"), 40);
+  if (!omit_max_flat_workgroup_size) {
+    AppendUintField(&output, IREE_SV(".max_flat_workgroup_size"),
+                    zero_max_flat_workgroup_size ? 0 : 256);
+  }
+  if (!omit_vgpr_count) {
+    AppendUintField(&output, IREE_SV(".vgpr_count"), 40);
+  }
   AppendMsgPackString(&output, IREE_SV(".reqd_workgroup_size"));
   AppendMsgPackArray(&output, 3);
   AppendMsgPackUint(&output, 16);
@@ -574,6 +589,16 @@ TEST(HsacoMetadataTest, RejectsInvalidUniformWorkgroupValue) {
                             ByteSpan(elf), iree_allocator_system(), &metadata));
 }
 
+TEST(HsacoMetadataTest, RejectsZeroMaximumFlatWorkgroupSize) {
+  std::vector<uint8_t> elf = BuildElfWithMetadata(
+      BuildKernelMetadata(kBuildKernelMetadataZeroMaxFlatWorkgroupSize));
+
+  iree_hal_amdgpu_hsaco_metadata_t metadata;
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_OUT_OF_RANGE,
+                        iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
+                            ByteSpan(elf), iree_allocator_system(), &metadata));
+}
+
 TEST(HsacoMetadataTest, FindsKernelBySymbol) {
   std::vector<uint8_t> elf = BuildElfWithMetadata(BuildKernelMetadata());
 
@@ -679,6 +704,22 @@ TEST(HsacoMetadataTest, RejectsMalformedMessagePackMetadata) {
                             ByteSpan(elf), iree_allocator_system(), &metadata));
 }
 
+TEST(HsacoMetadataTest, RejectsMissingResourceMetadata) {
+  const uint32_t missing_resource_flags[] = {
+      kBuildKernelMetadataOmitMaxFlatWorkgroupSize,
+      kBuildKernelMetadataOmitVgprCount,
+  };
+  for (uint32_t flags : missing_resource_flags) {
+    std::vector<uint8_t> elf = BuildElfWithMetadata(BuildKernelMetadata(flags));
+
+    iree_hal_amdgpu_hsaco_metadata_t metadata;
+    IREE_EXPECT_STATUS_IS(
+        IREE_STATUS_INVALID_ARGUMENT,
+        iree_hal_amdgpu_hsaco_metadata_initialize_from_elf(
+            ByteSpan(elf), iree_allocator_system(), &metadata));
+  }
+}
+
 TEST(HsacoMetadataTest, DiscoversElfSymbolsWithoutSynthesizingKernels) {
   std::vector<uint8_t> elf = AddSyntheticCandidateSymbolSection(
       BuildElfWithMetadata(BuildKernelMetadata()));
@@ -692,6 +733,7 @@ TEST(HsacoMetadataTest, DiscoversElfSymbolsWithoutSynthesizingKernels) {
   EXPECT_EQ(ToString(metadata.elf_kernel_symbols[0].name), "extra_kernel");
   EXPECT_EQ(ToString(metadata.elf_kernel_symbols[0].symbol_name),
             "extra_kernel.kd");
+
   iree_hal_amdgpu_hsaco_metadata_deinitialize(&metadata);
 }
 


### PR DESCRIPTION
  ## Summary

  Parse, validate, and expose immutable kernel resource metadata from the HSACO image selected by the AMDGPU executable
  loader.

  The change records the following properties for each loaded kernel:

  - maximum flat workgroup size;
  - fixed group-segment memory;
  - fixed private-segment memory;
  - vector register count;
  - maximum dynamic group-segment memory; and
  - whether the kernel requires uniform workgroups.

  A private AMDGPU query returns these properties for a loaded executable function. This does not extend the generic HAL
  interface.

  ## Motivation

  HIP exposes loaded-kernel properties and uses them for launch validation and occupancy calculations. This supports
  downstream implementations of:

  - hipFuncGetAttribute
  - hipFuncGetAttributes
  - occupancy query APIs
  - dynamic shared-memory validation
  - ordinary and extended kernel launch validation
  - partial-workgroup validation
  - cooperative-launch resource checks

  These values must describe the exact architecture-specific HSACO image selected by the executable loader. Reparsing a
  module in the HIP layer could inspect the wrong image and would duplicate the code-object parser.

  ## Design

  The existing AMDGPU HSACO metadata parser reads the additional resource fields while loading the selected image.
  Values are normalized into immutable per-export metadata owned by the executable.

  Executable loading rejects:

  - missing required resource fields;
  - duplicate fields;
  - invalid metadata types;
  - invalid uniform-workgroup values;
  - zero maximum flat workgroup sizes; and
  - workgroup limits exceeding the physical-device limit.

  The private query validates the function ordinal and copies the stored values to the caller. It does not expose
  MessagePack nodes, code-object storage, or parser internals.

  The AMDGPU driver reports immutable executable facts only. HIP-specific attribute mapping, occupancy policy, and
  launch policy remain in the binding layer.

  ## Performance

  Metadata parsing and validation occur once during executable loading.

  The query reads immutable fields directly and requires no allocation, parsing, search, or synchronization. Ordinary
  kernel dispatch does not call the query and gains no additional hot-path work.

  ## API Boundary

  This is an AMDGPU-private API because the values come from HSACO metadata and have backend-specific semantics. Other
  executable formats are not required to invent equivalents, and no generic HAL vtable or interface is changed.