### PR TITLE
[Loom] Update documentation copyright

### DIFF
--- a/loom/docs/mkdocs.yml
+++ b/loom/docs/mkdocs.yml
@@ -137,4 +137,4 @@ validation:
 extra_css:
   - stylesheets/extra.css
 
-copyright: Copyright &copy; 2026 The HRX Authors
+copyright: Copyright &copy; 2026 Advanced Micro Devices, Inc.


### PR DESCRIPTION
Updates the Loom documentation footer to identify Advanced Micro Devices, Inc.
as the copyright holder. The rendered site retains the typographic copyright
symbol through the existing HTML entity.
