### PR TITLE
[Loom] Simplify documentation copyright

### DIFF
--- a/loom/docs/mkdocs.yml
+++ b/loom/docs/mkdocs.yml
@@ -137,4 +137,4 @@ validation:
 extra_css:
   - stylesheets/extra.css
 
-copyright: Copyright &copy; 2026 Advanced Micro Devices, Inc.
+copyright: "&copy; 2026 Advanced Micro Devices, Inc."


### PR DESCRIPTION
Renders the Loom documentation footer as
`© 2026 Advanced Micro Devices, Inc.` exactly. This removes the redundant
leading `Copyright` word while retaining the HTML entity in the MkDocs source.
