### PR TITLE
[Loom] Keep documentation generation explicit

### DIFF
--- a/loom/docs/examples/elementwise-transform/BUILD.bazel
+++ b/loom/docs/examples/elementwise-transform/BUILD.bazel
@@ -6,7 +6,6 @@
 #
 # bazel-to-cmake: skip
 
-load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//loom/build_tools/bazel:defs.bzl", "loom_library")
 
 package(
@@ -31,27 +30,9 @@ loom_library(
     deps = [":kernel"],
 )
 
-sh_test(
-    name = "doc_generate_test",
-    srcs = [".doc-generate.sh"],
-    data = [
-        "kernel.loom",
-        "model.loom",
-        "motif.loom",
-        "run.sh",
-        "//loom/docs/examples:example.shlib",
-        "//loom/src/loom/tools/loom-check",
-        "//loom/src/loom/tools/loom-compile",
-        "//loom/src/loom/tools/loom-format",
-        "//loom/src/loom/tools/loom-link",
-    ],
-    tags = ["hostonly"],
-)
-
 test_suite(
     name = "test",
     tests = [
-        ":doc_generate_test",
         ":kernel_test",
         ":model_test",
         ":motif_test",

--- a/loom/docs/hooks/prepare.py
+++ b/loom/docs/hooks/prepare.py
@@ -128,7 +128,6 @@ def on_config(config: Any) -> Any:
     """Points MkDocs at an isolated, generated source tree."""
 
     staged_source_root = _staged_source_root()
-    staged_source_root.mkdir(parents=True, exist_ok=True)
     config["docs_dir"] = str(staged_source_root)
     snippet_config = config.get("mdx_configs", {}).get("pymdownx.snippets")
     if snippet_config is not None:

--- a/loom/docs/hooks/prepare_test.py
+++ b/loom/docs/hooks/prepare_test.py
@@ -34,12 +34,19 @@ class PrepareTest(unittest.TestCase):
             }
         }
 
-        result = prepare.on_config(config)
+        with TemporaryDirectory() as temporary_directory:
+            with mock.patch.dict(
+                prepare.os.environ,
+                {"LOOM_DOCS_WORK_DIR": temporary_directory},
+            ):
+                staged_source_root = prepare._staged_source_root()
+                result = prepare.on_config(config)
+                self.assertFalse(staged_source_root.exists())
 
         self.assertIs(result, config)
         self.assertEqual(
             config["mdx_configs"]["pymdownx.snippets"]["base_path"],
-            ["loom/docs", str(prepare._staged_source_root())],
+            ["loom/docs", str(staged_source_root)],
         )
 
     def test_example_generators_are_discovered_by_package(self) -> None:


### PR DESCRIPTION
Removes documentation snippet generation from the ordinary Bazel test graph so normal Loom builds and presubmit never assemble the generated guide. The checked example sources keep their formatting and compiler coverage, while package generators run only inside the explicit documentation build lifecycle.

Makes the MkDocs configuration hook side-effect free by deferring generated-directory creation to the build phase. Its unit test now proves that loading documentation configuration does not write to the filesystem.
