### PR TITLE
[Loom] Publish source authoring lint

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,6 +24,7 @@ register_toolchains(
     "//loom/build_tools/bazel:source_tools_benchmark_toolchain",
     "//loom/build_tools/bazel:source_tools_compile_toolchain",
     "//loom/build_tools/bazel:source_tools_format_toolchain",
+    "//loom/build_tools/bazel:source_tools_lint_toolchain",
     "//loom/build_tools/bazel:source_tools_link_toolchain",
     "//loom/build_tools/bazel:source_tools_test_toolchain",
 )

--- a/loom/build_tools/bazel/BUILD.bazel
+++ b/loom/build_tools/bazel/BUILD.bazel
@@ -21,6 +21,8 @@ toolchain_type(name = "compile_toolchain_type")
 
 toolchain_type(name = "format_toolchain_type")
 
+toolchain_type(name = "lint_toolchain_type")
+
 toolchain_type(name = "link_toolchain_type")
 
 toolchain_type(name = "test_toolchain_type")
@@ -31,5 +33,6 @@ loom_tools_toolchains(
     compile_tool = "//loom/src/loom/tools/loom-compile",
     format_tool = "//loom/src/loom/tools/loom-format",
     link_tool = "//loom/src/loom/tools/loom-link",
+    lint_tool = "//loom/py/loom/tools:loom-lint",
     test_tool = "//loom/src/loom/tools/iree-test-loom",
 )

--- a/loom/build_tools/bazel/loom_library.bzl
+++ b/loom/build_tools/bazel/loom_library.bzl
@@ -12,6 +12,7 @@ load("//build_tools/bazel:requirements.bzl", "apply_test_requirements")
 _LOOM_BENCHMARK_TOOLCHAIN_TYPE = Label("//loom/build_tools/bazel:benchmark_toolchain_type")
 _LOOM_COMPILE_TOOLCHAIN_TYPE = Label("//loom/build_tools/bazel:compile_toolchain_type")
 _LOOM_FORMAT_TOOLCHAIN_TYPE = Label("//loom/build_tools/bazel:format_toolchain_type")
+_LOOM_LINT_TOOLCHAIN_TYPE = Label("//loom/build_tools/bazel:lint_toolchain_type")
 _LOOM_LINK_TOOLCHAIN_TYPE = Label("//loom/build_tools/bazel:link_toolchain_type")
 _LOOM_TEST_TOOLCHAIN_TYPE = Label("//loom/build_tools/bazel:test_toolchain_type")
 
@@ -385,6 +386,31 @@ _loom_format_test = rule(
     toolchains = [_LOOM_FORMAT_TOOLCHAIN_TYPE],
 )
 
+def _loom_lint_test_impl(ctx):
+    tool = ctx.toolchains[_LOOM_LINT_TOOLCHAIN_TYPE].tool
+    output = _write_test_launcher(ctx, tool, ctx.file.src, [])
+    return [
+        DefaultInfo(
+            executable = output,
+            files = depset([output]),
+            runfiles = _tool_runfiles(ctx, tool, [ctx.file.src]),
+        ),
+    ]
+
+_loom_lint_test = rule(
+    implementation = _loom_lint_test_impl,
+    attrs = {
+        "src": attr.label(
+            allow_single_file = [".loom"],
+            mandatory = True,
+            doc = "Authored Loom text source to check.",
+        ),
+    },
+    doc = "Checks authoring policy in one Loom source file.",
+    test = True,
+    toolchains = [_LOOM_LINT_TOOLCHAIN_TYPE],
+)
+
 def _loom_plan_test_impl(ctx):
     tool = ctx.toolchains[_LOOM_BENCHMARK_TOOLCHAIN_TYPE].tool
     module = ctx.attr.library[LoomLibraryInfo].module
@@ -544,6 +570,15 @@ def _declare_library(
 
     tests = []
     for index, src in enumerate(srcs):
+        lint_test_name = "%s_lint_%d_test" % (name, index)
+        _loom_lint_test(
+            name = lint_test_name,
+            src = src,
+            tags = tags + ["hostonly"],
+            visibility = ["//visibility:private"],
+        )
+        tests.append(lint_test_name)
+
         test_name = "%s_format_%d_test" % (name, index)
         _loom_format_test(
             name = test_name,

--- a/loom/build_tools/bazel/loom_toolchain.bzl
+++ b/loom/build_tools/bazel/loom_toolchain.bzl
@@ -11,6 +11,7 @@ _TOOLCHAIN_TYPES = {
     "compile": Label("//loom/build_tools/bazel:compile_toolchain_type"),
     "format": Label("//loom/build_tools/bazel:format_toolchain_type"),
     "link": Label("//loom/build_tools/bazel:link_toolchain_type"),
+    "lint": Label("//loom/build_tools/bazel:lint_toolchain_type"),
     "test": Label("//loom/build_tools/bazel:test_toolchain_type"),
 }
 
@@ -47,6 +48,7 @@ def loom_tools_toolchains(
         benchmark_tool,
         compile_tool,
         format_tool,
+        lint_tool,
         link_tool,
         test_tool,
         exec_compatible_with = [],
@@ -58,14 +60,16 @@ def loom_tools_toolchains(
 
     The macro emits ``<name>_<role>`` implementations and
     ``<name>_<role>_toolchain`` registrations for the benchmark, compile,
-    format, link, and test roles. Splitting the roles prevents a rule using one
-    executable from configuring the dependency graphs of the other tools.
+    format, lint, link, and test roles. Splitting the roles prevents a rule
+    using one executable from configuring the dependency graphs of the other
+    tools.
     """
     tools = {
         "benchmark": benchmark_tool,
         "compile": compile_tool,
         "format": format_tool,
         "link": link_tool,
+        "lint": lint_tool,
         "test": test_tool,
     }
     for role, tool in tools.items():
@@ -77,8 +81,8 @@ def loom_tools_toolchains(
             visibility = ["//visibility:private"],
         )
         toolchain_kwargs = {
-            "name": implementation_name + "_toolchain",
             "exec_compatible_with": exec_compatible_with,
+            "name": implementation_name + "_toolchain",
             "tags": tags,
             "target_compatible_with": target_compatible_with,
             "target_settings": target_settings,

--- a/loom/build_tools/linters/loom_source_lint.py
+++ b/loom/build_tools/linters/loom_source_lint.py
@@ -28,11 +28,6 @@ large hand-maintained emitter. Backend source files must stay below the reviewed
 size ceiling and must not introduce broad `internal.h` umbrella headers as a
 cosmetic split.
 
-Checked Loom text is a user-facing reference surface. Across every `.loom` file
-and every authored `.loom-test` input, constant SSA names must carry a program
-role or use the numeric `%c<literal>` convention instead of spelling the
-literal in English.
-
 The authoring corpus additionally rejects stale boundary-proof boilerplate that
 agents are likely to copy into generated kernels: redundant kernel-buffer
 memory-space assumes, sentinel-sized views, late index-to-offset byte-address
@@ -47,13 +42,9 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-LOOM_PROJECT_ROOT = REPO_ROOT / "loom"
 LOOM_SOURCE_ROOT = REPO_ROOT / "loom" / "src" / "loom"
 AUTHORING_CORPUS_ROOT = LOOM_SOURCE_ROOT / "test" / "corpus" / "authoring"
 SOURCE_SUFFIXES = {".c", ".cc", ".h"}
-LOOM_TEXT_SUFFIXES = {".loom", ".loom-test"}
-LOOM_TEST_CASE_SEPARATOR_PREFIX = "// ===="
-LOOM_TEST_EXPECTED_SEPARATOR = "// ----"
 SPIRV_BACKEND_RELATIVE_ROOTS = (
     "loom/src/loom/target/arch/spirv",
     "loom/src/loom/target/emit/spirv",
@@ -140,67 +131,6 @@ AUTHORING_INDEX_TO_OFFSET_CAST_PATTERN = re.compile(
 )
 AUTHORING_BYTE_STRIDE_INDEX_PATTERN = re.compile(
     r"%nb(?:\d+|_[A-Za-z0-9_]*)?\b\s*:\s*index\b"
-)
-LOOM_CONSTANT_RESULT_PATTERN = re.compile(
-    r"%(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
-    r"[A-Za-z_][A-Za-z0-9_.]*\.constant\b"
-)
-# Type, domain, unit, and duplicate markers can decorate either side of a
-# spelled literal without giving it a program role. Semantic continuations
-# such as zero_point and fourth_word_ordinal remain intact.
-LOOM_NUMBER_NAME_DECORATOR_PATTERN = re.compile(
-    r"(?:"
-    r"(?:[su]?i\d+|(?:bf|fp|f)\d+)(?:x\d+|v)?"
-    r"|index|offset|scalars?|vectors?"
-    r"|bytes?|bits?|elements?|lanes?|rows?|columns?|words?|values?"
-    r"|all|[a-z]"
-    r")"
-)
-LOOM_NUMBER_WORDS = tuple(
-    sorted(
-        (
-            "zero",
-            "one",
-            "two",
-            "three",
-            "four",
-            "five",
-            "six",
-            "seven",
-            "eight",
-            "nine",
-            "ten",
-            "eleven",
-            "twelve",
-            "thirteen",
-            "fourteen",
-            "fifteen",
-            "sixteen",
-            "seventeen",
-            "eighteen",
-            "nineteen",
-            "twenty",
-            "thirty",
-            "forty",
-            "fifty",
-            "sixty",
-            "seventy",
-            "eighty",
-            "ninety",
-            "hundred",
-            "thousand",
-            "million",
-            "billion",
-            "trillion",
-        ),
-        key=len,
-        reverse=True,
-    )
-)
-LOOM_NUMBER_CONNECTOR = "and"
-LOOM_NUMBER_SIGN_PREFIXES = ("negative", "positive", "minus", "plus", "neg")
-LOOM_CONSTANT_NAME_MESSAGE = (
-    "Loom constant SSA names must describe a program role or use %c<literal>"
 )
 
 
@@ -490,123 +420,6 @@ def _iter_authoring_loom_files() -> list[Path]:
     )
 
 
-def _iter_checked_loom_files() -> list[Path]:
-    return sorted(
-        path
-        for path in LOOM_PROJECT_ROOT.rglob("*")
-        if path.is_file() and path.suffix in LOOM_TEXT_SUFFIXES
-    )
-
-
-def _is_spelled_number_sequence(text: str) -> bool:
-    """Returns whether text can be segmented entirely into number words."""
-
-    for prefix in LOOM_NUMBER_SIGN_PREFIXES:
-        if text.startswith(prefix):
-            text = text.removeprefix(prefix)
-            break
-    if not text:
-        return False
-
-    # Each state records whether the previous token was numeric. `and` is an
-    # interior connector, not a number by itself: this accepts
-    # `onehundredandone` while leaving semantic names such as `and_zero`
-    # alone.
-    reachable = {(0, False)}
-    for start in range(len(text)):
-        states = tuple(
-            previous_was_number
-            for position, previous_was_number in reachable
-            if position == start
-        )
-        for previous_was_number in states:
-            for word in LOOM_NUMBER_WORDS:
-                if text.startswith(word, start):
-                    reachable.add((start + len(word), True))
-            if previous_was_number and text.startswith(LOOM_NUMBER_CONNECTOR, start):
-                reachable.add((start + len(LOOM_NUMBER_CONNECTOR), False))
-    return (len(text), True) in reachable
-
-
-def _is_spelled_number_or_plural(text: str) -> bool:
-    """Returns whether text is a spelled number or its English plural."""
-
-    if _is_spelled_number_sequence(text):
-        return True
-
-    singular_candidates: list[str] = []
-    if text.endswith("ies"):
-        singular_candidates.append(text[:-3] + "y")
-    if text.endswith("es"):
-        singular_candidates.append(text[:-2])
-    if text.endswith("s"):
-        singular_candidates.append(text[:-1])
-    return any(
-        _is_spelled_number_sequence(candidate) for candidate in singular_candidates
-    )
-
-
-def _is_spelled_number_constant_name(name: str) -> bool:
-    """Returns whether name communicates only a spelled numeric literal."""
-
-    tokens = [token for token in name.lower().split("_") if token]
-    while len(tokens) > 1:
-        stripped_decorator = False
-        if LOOM_NUMBER_NAME_DECORATOR_PATTERN.fullmatch(tokens[0]):
-            tokens.pop(0)
-            stripped_decorator = True
-        if len(tokens) > 1 and LOOM_NUMBER_NAME_DECORATOR_PATTERN.fullmatch(tokens[-1]):
-            tokens.pop()
-            stripped_decorator = True
-        if not stripped_decorator:
-            break
-    return _is_spelled_number_or_plural("".join(tokens))
-
-
-def _iter_loom_input_lines(path: Path, text: str) -> list[tuple[int, str]]:
-    """Returns source lines, excluding runner-owned `.loom-test` expectations."""
-
-    lines: list[tuple[int, str]] = []
-    is_loom_test = path.suffix == ".loom-test"
-    in_expected_section = False
-    for line_number, line in enumerate(text.splitlines(), start=1):
-        if is_loom_test:
-            if line.startswith(LOOM_TEST_CASE_SEPARATOR_PREFIX):
-                in_expected_section = False
-                continue
-            if line.strip() == LOOM_TEST_EXPECTED_SEPARATOR:
-                in_expected_section = True
-                continue
-            if in_expected_section:
-                continue
-        lines.append((line_number, line))
-    return lines
-
-
-def _scan_loom_constant_name_text(path: Path, text: str) -> list[Finding]:
-    findings: list[Finding] = []
-    for line_number, line in _iter_loom_input_lines(path, text):
-        stripped_line = _strip_line_comments(line).strip()
-        if not stripped_line:
-            continue
-        for match in LOOM_CONSTANT_RESULT_PATTERN.finditer(stripped_line):
-            name = match.group("name")
-            if _is_spelled_number_constant_name(name):
-                findings.append(
-                    Finding(
-                        path=path,
-                        line=line_number,
-                        message=LOOM_CONSTANT_NAME_MESSAGE,
-                        context=(
-                            f"%{name} spells the literal in English; use a "
-                            "program-role name such as %batch_size, or %c512 "
-                            "when the literal itself is the only meaning"
-                        ),
-                    )
-                )
-    return findings
-
-
 def _scan_authoring_text(path: Path, text: str) -> list[Finding]:
     findings: list[Finding] = []
     for line_number, line in enumerate(text.splitlines(), start=1):
@@ -860,30 +673,6 @@ def _expect_target_execution_self_test(
     return False
 
 
-def _expect_loom_constant_name_self_test(
-    name: str,
-    relative_path: str,
-    text: str,
-    expected_lines: tuple[int, ...],
-) -> bool:
-    path = REPO_ROOT / relative_path
-    findings = _scan_loom_constant_name_text(path, text)
-    actual = tuple(
-        (_relative_path(finding.path), finding.line, finding.message)
-        for finding in findings
-    )
-    expected = tuple(
-        (relative_path, line, LOOM_CONSTANT_NAME_MESSAGE) for line in expected_lines
-    )
-    if actual == expected:
-        print(f"  PASS  {name}")
-        return True
-    print(f"  FAIL  {name}")
-    print(f"        expected: {expected!r}")
-    print(f"        actual:   {actual!r}")
-    return False
-
-
 def _expect_authoring_self_test(
     name: str, text: str, expected_messages: tuple[str, ...]
 ) -> bool:
@@ -1041,124 +830,6 @@ kernel.def @copy(%n: index) {
   kernel.return
 }
 """
-    ok &= _expect_loom_constant_name_self_test(
-        "checked Loom semantic and numeric-literal names pass",
-        "loom/src/loom/test/corpus/authoring/self_test.loom",
-        checked_loom_happy_path,
-        (),
-    )
-    ok &= _expect_loom_constant_name_self_test(
-        "standalone simple English number name fails",
-        "loom/src/loom/test/self_test.loom",
-        "%two = index.constant 2 : index\n",
-        (1,),
-    )
-    ok &= _expect_loom_constant_name_self_test(
-        "standalone concatenated English number name fails",
-        "loom/src/loom/test/self_test.loom",
-        "%fivehundredtwelve = index.constant 512 : index\n",
-        (1,),
-    )
-    ok &= _expect_loom_constant_name_self_test(
-        "standalone underscored English number name fails",
-        "loom/src/loom/test/self_test.loom",
-        "%thirty_two = index.constant 32 : index\n",
-        (1,),
-    )
-    ok &= _expect_loom_constant_name_self_test(
-        "standalone type-suffixed English number name fails",
-        "loom/src/loom/test/self_test.loom",
-        "%zero_f32x4 = vector.constant 0.0 : vector<4xf32>\n",
-        (1,),
-    )
-    ok &= _expect_loom_constant_name_self_test(
-        "standalone unit-suffixed English number name fails",
-        "loom/src/loom/test/self_test.loom",
-        "%four_bytes = index.constant 4 : offset\n",
-        (1,),
-    )
-    ok &= _expect_loom_constant_name_self_test(
-        "standalone signed English number name fails",
-        "loom/src/loom/test/self_test.loom",
-        "%negative_one = scalar.constant -1 : i32\n",
-        (1,),
-    )
-    ok &= _expect_loom_constant_name_self_test(
-        "prefix and suffix decorators do not make numeric names semantic",
-        "loom/src/loom/test/self_test.loom",
-        (
-            "%i32_zero = scalar.constant 0 : i32\n"
-            "%zero_scalar = scalar.constant 0 : i32\n"
-            "%positive_zero = scalar.constant 0.0 : f32\n"
-            "%neg_one = scalar.constant -1 : i32\n"
-            "%all_ones = scalar.constant -1 : i32\n"
-            "%zero_a = scalar.constant 0 : i32\n"
-            "%f16_ones = vector.constant 1.0 : vector<4xf16>\n"
-        ),
-        (1, 2, 3, 4, 5, 6, 7),
-    )
-    ok &= _expect_loom_constant_name_self_test(
-        "plural English number names fail",
-        "loom/src/loom/test/self_test.loom",
-        (
-            "%ones = scalar.constant 1 : i32\n"
-            "%zeroes = vector.constant 0 : vector<4xi32>\n"
-            "%sixes = vector.constant 6 : vector<4xi32>\n"
-            "%twenties = vector.constant 20 : vector<4xi32>\n"
-        ),
-        (1, 2, 3, 4),
-    )
-    ok &= _expect_loom_constant_name_self_test(
-        "English number connector and scale words fail",
-        "loom/src/loom/test/self_test.loom",
-        (
-            "%one_hundred_and_one = index.constant 101 : index\n"
-            "%thousand = index.constant 1000 : index\n"
-        ),
-        (1, 2),
-    )
-    ok &= _expect_loom_constant_name_self_test(
-        "semantic and connector-derived names pass",
-        "loom/src/loom/test/self_test.loom",
-        (
-            "%and = index.constant 15 : index\n"
-            "%and_zero = index.constant 0 : index\n"
-            "%zero_point = scalar.constant 128 : i32\n"
-            "%zero_exponent = scalar.constant 0 : i32\n"
-            "%two_pi = scalar.constant 6.283185 : f32\n"
-            "%positive_signed_zero = scalar.constant 0.0 : f32\n"
-            "%all_bits_set = scalar.constant -1 : i32\n"
-            "%f32_sign_threshold = scalar.constant 0.0 : f32\n"
-            "%nonzero = scalar.constant true : i1\n"
-            "%fourth_word_ordinal = scalar.constant 4 : i32\n"
-        ),
-        (),
-    )
-    ok &= _expect_loom_constant_name_self_test(
-        "loom-test expected output is excluded",
-        "loom/src/loom/test/self_test.loom-test",
-        (
-            "%batch_size = index.constant 512 : index\n"
-            "// ----\n"
-            "%fivehundredtwelve = index.constant 512 : index\n"
-            "%and_zero = index.constant 0 : index\n"
-        ),
-        (),
-    )
-    ok &= _expect_loom_constant_name_self_test(
-        "loom-test case boundaries restore authored input",
-        "loom/src/loom/test/self_test.loom-test",
-        (
-            "%two = index.constant 2 : index\n"
-            "// ----\n"
-            "%fivehundredtwelve = index.constant 512 : index\n"
-            "// ==== second case\n"
-            "%thirty_two = index.constant 32 : index\n"
-            "// ----\n"
-            "%sixty_four = index.constant 64 : index\n"
-        ),
-        (1, 5),
-    )
     ok &= _expect_authoring_self_test(
         "authoring happy-path source passes",
         checked_loom_happy_path,
@@ -1201,14 +872,11 @@ def main() -> int:
         findings.extend(_scan_core_tooling_flags_guardrails(path))
         findings.extend(_scan_target_execution_guardrails(path))
         findings.extend(_scan_spirv_backend_guardrails(path))
-    loom_files = _iter_checked_loom_files()
-    for path in loom_files:
-        findings.extend(_scan_loom_constant_name_text(path, path.read_text()))
     for path in _iter_authoring_loom_files():
         findings.extend(_scan_authoring_corpus(path))
 
     if not findings:
-        print(f"loom-source-lint: PASS ({len(loom_files)} Loom text files scanned)")
+        print("loom-source-lint: PASS")
         return 0
 
     print("loom-source-lint: FAIL: Loom source invariant violation.")

--- a/loom/build_tools/presubmit.py
+++ b/loom/build_tools/presubmit.py
@@ -43,6 +43,10 @@ CTEST_RESOURCE_LABEL_EXCLUDE_REGEX = "runtime-resource="
 CI_LOOM_TARGETS = "amdgpu,iree_vm,llvmir,spirv,x86"
 LOOM_FORMAT_BAZEL_TARGET = "//loom/src/loom/tools/loom-format:loom-format"
 LOOM_FORMAT_CMAKE_TARGET = "loom::tools::loom-format"
+LOOM_LINT_BAZEL_TARGET = "//loom/py/loom/tools:loom-lint"
+LOOM_LINT_CMAKE_TARGET = "loom::py::loom::tools::loom-lint"
+LOOM_LINT_PYTHON_SOURCE = "loom/py/loom/tools/source_lint.py"
+LOOM_LINT_SUFFIXES = frozenset({".loom", ".loom-test"})
 # Syntax-corpus modules retain their exact parser/printer fixture contract rather
 # than the verified canonical-source contract enforced by loom-format.
 LOOM_FORMAT_EXCLUDED_PREFIXES = ("loom/src/loom/test/corpus/text/",)
@@ -133,7 +137,7 @@ def existing_format_source_paths(paths: list[str]) -> list[str]:
     )
 
 
-def tracked_format_source_paths() -> list[str] | None:
+def _tracked_project_paths() -> list[str] | None:
     result = subprocess.run(
         ["git", "--literal-pathspecs", "ls-files", "-z", "--", PROJECT_ROOT],
         cwd=REPO_ROOT,
@@ -144,13 +148,44 @@ def tracked_format_source_paths() -> list[str] | None:
     )
     if result.returncode != 0:
         print(
-            "loom presubmit: failed to query tracked Loom source files",
+            "loom presubmit: failed to query tracked Loom project files",
             file=sys.stderr,
         )
         if result.stderr:
             print(result.stderr.rstrip(), file=sys.stderr)
         return None
-    return existing_format_source_paths(result.stdout.split("\0"))
+    return result.stdout.split("\0")
+
+
+def tracked_format_source_paths() -> list[str] | None:
+    paths = _tracked_project_paths()
+    return None if paths is None else existing_format_source_paths(paths)
+
+
+def is_lint_source_path(path: str) -> bool:
+    source_path = PurePosixPath(path)
+    return (
+        "\\" not in path
+        and source_path.as_posix() == path
+        and ".." not in source_path.parts
+        and path.startswith(PROJECT_ROOT)
+        and source_path.suffix in LOOM_LINT_SUFFIXES
+    )
+
+
+def existing_lint_source_paths(paths: list[str]) -> list[str]:
+    return sorted(
+        {
+            path
+            for path in paths
+            if is_lint_source_path(path) and (REPO_ROOT / path).is_file()
+        }
+    )
+
+
+def tracked_lint_source_paths() -> list[str] | None:
+    paths = _tracked_project_paths()
+    return None if paths is None else existing_lint_source_paths(paths)
 
 
 def run_source_format_maintenance(
@@ -200,14 +235,48 @@ def run_source_format_maintenance(
     )
 
 
-def run_source_lint() -> bool:
-    return run_command(
+def run_source_lint(*, lane: str, files_from: str | None) -> bool:
+    tracked_paths = tracked_lint_source_paths()
+    if tracked_paths is None:
+        return False
+    selected_paths = (
+        []
+        if files_from is None
+        else existing_lint_source_paths(selected_files(files_from))
+    )
+    check_paths = sorted(set(tracked_paths).union(selected_paths))
+
+    public_lint_ok = True
+    if check_paths:
+        if lane == "bazel":
+            linter_path = project_presubmit.build_and_resolve_executable(
+                PROJECT_NAME,
+                REPO_ROOT,
+                lane=lane,
+                bazel_target=LOOM_LINT_BAZEL_TARGET,
+                cmake_target=LOOM_LINT_CMAKE_TARGET,
+                bazel_args=("--config=locked",),
+            )
+            linter_command = [] if linter_path is None else [str(linter_path)]
+        elif lane == "cmake":
+            # CMake models Python entrypoints as source-bearing custom targets,
+            # not native executable artifacts. The public linter is deliberately
+            # standalone, so the source lane can invoke that same entrypoint.
+            linter_command = [sys.executable, LOOM_LINT_PYTHON_SOURCE]
+        else:
+            raise ValueError(f"unknown lane: {lane}")
+        public_lint_ok = bool(linter_command) and run_command(
+            [*linter_command, *check_paths], "Loom authoring policy"
+        )
+
+    repository_lint_ok = run_command(
         [
             sys.executable,
             "loom/build_tools/linters/loom_source_lint.py",
         ],
-        "Loom source invariants",
+        "Loom repository invariants",
     )
+    return public_lint_ok and repository_lint_ok
 
 
 def bazel_test_command() -> list[str]:
@@ -269,7 +338,7 @@ def run_presubmit(args: argparse.Namespace) -> int:
             )
             and ok
         )
-        ok = run_source_lint() and ok
+        ok = run_source_lint(lane=args.lane, files_from=args.files_from) and ok
     if args.tests:
         if args.lane == "bazel":
             ok = run_bazel_tests() and ok

--- a/loom/build_tools/presubmit_test.py
+++ b/loom/build_tools/presubmit_test.py
@@ -429,18 +429,101 @@ class LoomPresubmitTest(unittest.TestCase):
         )
         stage_changed_paths.assert_not_called()
 
-    def test_source_lint_is_project_owned_and_read_only(self):
-        with mock.patch.object(
-            self.presubmit, "run_command", return_value=True
-        ) as run_command:
-            self.assertTrue(self.presubmit.run_source_lint())
+    def test_source_lint_classification_is_strict(self):
+        self.assertTrue(self.presubmit.is_lint_source_path("loom/a.loom"))
+        self.assertTrue(self.presubmit.is_lint_source_path("loom/a.loom-test"))
+        self.assertFalse(self.presubmit.is_lint_source_path("loom/a.txt"))
+        self.assertFalse(self.presubmit.is_lint_source_path("loom/../a.loom"))
+        self.assertFalse(self.presubmit.is_lint_source_path("other/a.loom"))
 
-        run_command.assert_called_once_with(
+    def test_source_lint_uses_public_tool_then_private_guardrails(self):
+        linter_path = Path("/tools/loom-lint")
+        with (
+            mock.patch.object(
+                self.presubmit,
+                "tracked_lint_source_paths",
+                return_value=["loom/a.loom", "loom/b.loom-test"],
+            ),
+            mock.patch.object(
+                self.presubmit.project_presubmit,
+                "build_and_resolve_executable",
+                return_value=linter_path,
+            ) as build_and_resolve_executable,
+            mock.patch.object(
+                self.presubmit, "run_command", return_value=True
+            ) as run_command,
+        ):
+            self.assertTrue(
+                self.presubmit.run_source_lint(lane="bazel", files_from=None)
+            )
+
+        build_and_resolve_executable.assert_called_once_with(
+            "loom",
+            self.presubmit.REPO_ROOT,
+            lane="bazel",
+            bazel_target="//loom/py/loom/tools:loom-lint",
+            cmake_target="loom::py::loom::tools::loom-lint",
+            bazel_args=("--config=locked",),
+        )
+        self.assertEqual(
+            run_command.call_args_list,
             [
-                sys.executable,
-                "loom/build_tools/linters/loom_source_lint.py",
+                mock.call(
+                    [
+                        str(linter_path),
+                        "loom/a.loom",
+                        "loom/b.loom-test",
+                    ],
+                    "Loom authoring policy",
+                ),
+                mock.call(
+                    [
+                        sys.executable,
+                        "loom/build_tools/linters/loom_source_lint.py",
+                    ],
+                    "Loom repository invariants",
+                ),
             ],
-            "Loom source invariants",
+        )
+
+    def test_source_lint_cmake_lane_invokes_public_python_entrypoint(self):
+        with (
+            mock.patch.object(
+                self.presubmit,
+                "tracked_lint_source_paths",
+                return_value=["loom/a.loom"],
+            ),
+            mock.patch.object(
+                self.presubmit.project_presubmit, "build_and_resolve_executable"
+            ) as build_and_resolve_executable,
+            mock.patch.object(
+                self.presubmit, "run_command", return_value=True
+            ) as run_command,
+        ):
+            self.assertTrue(
+                self.presubmit.run_source_lint(lane="cmake", files_from=None)
+            )
+
+        build_and_resolve_executable.assert_not_called()
+        self.assertEqual(
+            run_command.call_args_list,
+            [
+                mock.call(
+                    [
+                        sys.executable,
+                        "loom/py/loom/tools/source_lint.py",
+                        "loom/a.loom",
+                    ],
+                    "Loom authoring policy",
+                ),
+                mock.call(
+                    [
+                        sys.executable,
+                        "loom/build_tools/linters/loom_source_lint.py",
+                    ],
+                    "Loom repository invariants",
+                ),
+            ],
         )
 
     def test_generated_artifact_drift_fails_presubmit(self):
@@ -476,7 +559,7 @@ class LoomPresubmitTest(unittest.TestCase):
         source_format_maintenance.assert_called_once_with(
             lane="bazel", files_from=None, fix=False
         )
-        source_lint.assert_called_once_with()
+        source_lint.assert_called_once_with(lane="bazel", files_from=None)
         bazel_tests.assert_called_once_with()
 
     def test_source_lint_failure_fails_project_hygiene(self):
@@ -510,7 +593,7 @@ class LoomPresubmitTest(unittest.TestCase):
         source_format_maintenance.assert_called_once_with(
             lane="bazel", files_from=None, fix=False
         )
-        source_lint.assert_called_once_with()
+        source_lint.assert_called_once_with(lane="bazel", files_from=None)
         bazel_tests.assert_not_called()
 
     def test_test_phase_does_not_repeat_hygiene_checks(self):

--- a/loom/docs/src/workflows/format-and-verify.md
+++ b/loom/docs/src/workflows/format-and-verify.md
@@ -1,5 +1,27 @@
 # Format and verify source
 
+`loom-lint` checks authoring policy that is meaningful to people and agents but
+does not change program behavior. `loom-format` independently parses, verifies,
+and prints complete Loom modules. Keeping those contracts separate lets the
+formatter canonicalize syntax without inventing semantic names.
+
+## Check authoring policy
+
+Lint one or more explicit source files:
+
+```shell
+loom-lint motif.loom kernel.loom model.loom
+```
+
+The initial rule requires constant SSA names to carry a program role, such as
+`%batch_size`, or use the compact `%c<literal>` form, such as `%c512`. A name
+such as `%fivehundredtwelve` only repeats the literal and fails with its source
+location and the `constant-name` rule identifier.
+
+`loom-lint` also accepts `.loom-test` containers and checks only authored input
+sections. Runner-owned expected output is excluded. Inputs are always explicit;
+the tool does not discover a repository, build graph, or Git change set.
+
 `loom-format` parses, verifies, and prints complete Loom modules. It is the
 source equivalent of a language formatter and the text/bytecode conversion
 boundary for linkable modules.

--- a/loom/py/loom/tools/BUILD.bazel
+++ b/loom/py/loom/tools/BUILD.bazel
@@ -52,11 +52,26 @@ iree_py_library(
     ],
 )
 
+iree_py_library(
+    name = "source_lint",
+    srcs = [
+        "__init__.py",
+        "source_lint.py",
+    ],
+)
+
 iree_py_binary(
     name = "loom-compile-report",
     srcs = ["compile_report.py"],
     main = "compile_report.py",
     deps = [":compile_report"],
+)
+
+iree_py_binary(
+    name = "loom-lint",
+    srcs = ["source_lint.py"],
+    main = "source_lint.py",
+    deps = [":source_lint"],
 )
 
 iree_py_binary(
@@ -72,6 +87,7 @@ iree_py_test(
         "compile_report_test.py",
         "loom_opt_test.py",
         "pytest_style_runner.py",
+        "source_lint_test.py",
         "source_surface_test.py",
     ],
     args = [
@@ -79,12 +95,14 @@ iree_py_test(
         "loom.tools.compile_report_test",
         "loom.tools.loom_opt_test",
         "loom.tools.source_surface_test",
+        "loom.tools.source_lint_test",
     ],
     main = "pytest_style_runner.py",
     deps = [
         ":amdgpu_asm",
         ":compile_report",
         ":loom_opt",
+        ":source_lint",
         ":tools",
     ],
 )

--- a/loom/py/loom/tools/CMakeLists.txt
+++ b/loom/py/loom/tools/CMakeLists.txt
@@ -51,6 +51,14 @@ iree_py_library(
 
 iree_py_library(
   NAME
+    source_lint
+  SRCS
+    "__init__.py"
+    "source_lint.py"
+)
+
+iree_py_library(
+  NAME
     loom-compile-report
   MAIN
     "compile_report.py"
@@ -58,6 +66,17 @@ iree_py_library(
     "compile_report.py"
   DEPS
     loom::py::loom::tools::compile_report
+)
+
+iree_py_library(
+  NAME
+    loom-lint
+  MAIN
+    "source_lint.py"
+  SRCS
+    "source_lint.py"
+  DEPS
+    loom::py::loom::tools::source_lint
 )
 
 iree_py_library(
@@ -79,16 +98,19 @@ iree_py_test(
     "compile_report_test.py"
     "loom_opt_test.py"
     "pytest_style_runner.py"
+    "source_lint_test.py"
     "source_surface_test.py"
   ARGS
     "loom.tools.amdgpu_asm_test"
     "loom.tools.compile_report_test"
     "loom.tools.loom_opt_test"
     "loom.tools.source_surface_test"
+    "loom.tools.source_lint_test"
   DEPS
     loom::py::loom::tools::amdgpu_asm
     loom::py::loom::tools::compile_report
     loom::py::loom::tools::loom_opt
+    loom::py::loom::tools::source_lint
     loom::py::loom::tools::tools
   PACKAGE_DIRS
     "${PROJECT_SOURCE_DIR}/loom/py"

--- a/loom/py/loom/tools/source_lint.py
+++ b/loom/py/loom/tools/source_lint.py
@@ -1,0 +1,302 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Command-line authoring policy checks for explicit Loom source files."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TextIO
+
+SUPPORTED_SUFFIXES = frozenset({".loom", ".loom-test"})
+CONSTANT_NAME_RULE = "constant-name"
+
+_CONSTANT_RESULT_PATTERN = re.compile(
+    r"(?P<result>%(?P<name>[A-Za-z_][A-Za-z0-9_]*))\s*=\s*"
+    r"(?P<operation>[A-Za-z_][A-Za-z0-9_.]*constant)\b"
+)
+
+# Type, domain, unit, and duplicate markers can decorate either side of a
+# spelled literal without giving it a program role. Semantic continuations
+# such as zero_point and fourth_word_ordinal remain intact.
+_NUMBER_NAME_DECORATOR_PATTERN = re.compile(
+    r"(?:"
+    r"(?:[su]?i\d+|(?:bf|fp|f)\d+)(?:x\d+|v)?"
+    r"|index|offset|scalars?|vectors?"
+    r"|bytes?|bits?|elements?|lanes?|rows?|columns?|words?|values?"
+    r"|all|[a-z]"
+    r")"
+)
+_NUMBER_WORDS = tuple(
+    sorted(
+        (
+            "zero",
+            "one",
+            "two",
+            "three",
+            "four",
+            "five",
+            "six",
+            "seven",
+            "eight",
+            "nine",
+            "ten",
+            "eleven",
+            "twelve",
+            "thirteen",
+            "fourteen",
+            "fifteen",
+            "sixteen",
+            "seventeen",
+            "eighteen",
+            "nineteen",
+            "twenty",
+            "thirty",
+            "forty",
+            "fifty",
+            "sixty",
+            "seventy",
+            "eighty",
+            "ninety",
+            "hundred",
+            "thousand",
+            "million",
+            "billion",
+            "trillion",
+        ),
+        key=len,
+        reverse=True,
+    )
+)
+_NUMBER_CONNECTOR = "and"
+_NUMBER_SIGN_PREFIXES = ("negative", "positive", "minus", "plus", "neg")
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One source policy violation."""
+
+    path: Path
+    line: int
+    column: int
+    name: str
+
+    def format(self) -> str:
+        return (
+            f"{self.path}:{self.line}:{self.column}: error: constant SSA name "
+            f"%{self.name} spells a numeric literal in English; use a "
+            "program-role name or %c<literal> "
+            f"[{CONSTANT_NAME_RULE}]"
+        )
+
+
+class SourceLintError(Exception):
+    """An invalid invocation input or source read failure."""
+
+
+def _is_spelled_number_sequence(text: str) -> bool:
+    for prefix in _NUMBER_SIGN_PREFIXES:
+        if text.startswith(prefix):
+            text = text.removeprefix(prefix)
+            break
+    if not text:
+        return False
+
+    # Each state records whether the previous token was numeric. `and` is an
+    # interior connector, not a number by itself: this accepts
+    # `onehundredandone` while leaving semantic names such as `and_zero` alone.
+    reachable = {(0, False)}
+    for start in range(len(text)):
+        states = tuple(
+            previous_was_number
+            for position, previous_was_number in reachable
+            if position == start
+        )
+        for previous_was_number in states:
+            for word in _NUMBER_WORDS:
+                if text.startswith(word, start):
+                    reachable.add((start + len(word), True))
+            if previous_was_number and text.startswith(_NUMBER_CONNECTOR, start):
+                reachable.add((start + len(_NUMBER_CONNECTOR), False))
+    return (len(text), True) in reachable
+
+
+def _is_spelled_number_or_plural(text: str) -> bool:
+    if _is_spelled_number_sequence(text):
+        return True
+
+    singular_candidates: list[str] = []
+    if text.endswith("ies"):
+        singular_candidates.append(text[:-3] + "y")
+    if text.endswith("es"):
+        singular_candidates.append(text[:-2])
+    if text.endswith("s"):
+        singular_candidates.append(text[:-1])
+    return any(
+        _is_spelled_number_sequence(candidate) for candidate in singular_candidates
+    )
+
+
+def _is_spelled_number_constant_name(name: str) -> bool:
+    tokens = [token for token in name.lower().split("_") if token]
+    while len(tokens) > 1:
+        stripped_decorator = False
+        if _NUMBER_NAME_DECORATOR_PATTERN.fullmatch(tokens[0]):
+            tokens.pop(0)
+            stripped_decorator = True
+        if len(tokens) > 1 and _NUMBER_NAME_DECORATOR_PATTERN.fullmatch(tokens[-1]):
+            tokens.pop()
+            stripped_decorator = True
+        if not stripped_decorator:
+            break
+    return _is_spelled_number_or_plural("".join(tokens))
+
+
+def _blank_preserving_newlines(text: str) -> str:
+    return "".join(character if character in "\r\n" else " " for character in text)
+
+
+def _mask_source_line(line: str, in_string: bool) -> tuple[str, bool]:
+    """Masks comments and quoted strings without changing source positions."""
+
+    masked = list(line)
+    position = 0
+    while position < len(line):
+        character = line[position]
+        if character in "\r\n":
+            position += 1
+            continue
+        if in_string:
+            masked[position] = " "
+            if character == "\\" and position + 1 < len(line):
+                position += 1
+                if line[position] not in "\r\n":
+                    masked[position] = " "
+            elif character == '"':
+                in_string = False
+            position += 1
+            continue
+        if character == '"':
+            masked[position] = " "
+            in_string = True
+            position += 1
+            continue
+        if character == "/" and position + 1 < len(line) and line[position + 1] == "/":
+            for comment_position in range(position, len(line)):
+                if line[comment_position] not in "\r\n":
+                    masked[comment_position] = " "
+            break
+        position += 1
+    return "".join(masked), in_string
+
+
+def _mask_authored_source(path: Path, text: str) -> str:
+    """Returns position-preserving authored code suitable for lexical checks."""
+
+    is_loom_test = path.suffix == ".loom-test"
+    in_expected_section = False
+    in_string = False
+    masked_lines: list[str] = []
+    for line in text.splitlines(keepends=True):
+        stripped_line = line.strip()
+        if is_loom_test and stripped_line.startswith("// ===="):
+            in_expected_section = False
+            in_string = False
+            masked_lines.append(_blank_preserving_newlines(line))
+            continue
+        if is_loom_test and stripped_line == "// ----":
+            in_expected_section = True
+            in_string = False
+            masked_lines.append(_blank_preserving_newlines(line))
+            continue
+        if in_expected_section:
+            masked_lines.append(_blank_preserving_newlines(line))
+            continue
+        masked_line, in_string = _mask_source_line(line, in_string)
+        masked_lines.append(masked_line)
+    return "".join(masked_lines)
+
+
+def lint_source(path: Path, text: str) -> list[Finding]:
+    """Returns authoring-policy findings for one supported source."""
+
+    masked_source = _mask_authored_source(path, text)
+    findings: list[Finding] = []
+    for match in _CONSTANT_RESULT_PATTERN.finditer(masked_source):
+        name = match.group("name")
+        if not _is_spelled_number_constant_name(name):
+            continue
+        source_offset = match.start("result")
+        line = masked_source.count("\n", 0, source_offset) + 1
+        line_start = masked_source.rfind("\n", 0, source_offset) + 1
+        findings.append(
+            Finding(
+                path=path,
+                line=line,
+                column=source_offset - line_start + 1,
+                name=name,
+            )
+        )
+    return findings
+
+
+def _read_source(path: Path) -> str:
+    if path.suffix not in SUPPORTED_SUFFIXES:
+        supported = ", ".join(sorted(SUPPORTED_SUFFIXES))
+        raise SourceLintError(
+            f"unsupported source suffix for {path}; expected {supported}"
+        )
+    if not path.is_file():
+        raise SourceLintError(f"source file does not exist: {path}")
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise SourceLintError(f"cannot read source file {path}: {error}") from error
+
+
+def run(paths: Sequence[Path], *, stderr: TextIO) -> int:
+    """Lints explicit paths and returns the public process exit code."""
+
+    findings: list[Finding] = []
+    try:
+        for path in paths:
+            findings.extend(lint_source(path, _read_source(path)))
+    except SourceLintError as error:
+        stderr.write(f"loom-lint: error: {error}\n")
+        return 2
+
+    for finding in findings:
+        stderr.write(finding.format() + "\n")
+    return 1 if findings else 0
+
+
+def _create_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="loom-lint",
+        description="Checks authoring policy in explicit Loom source files.",
+    )
+    parser.add_argument(
+        "sources",
+        type=Path,
+        nargs="+",
+        metavar="SOURCE",
+        help="A .loom module or .loom-test source container.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _create_argument_parser().parse_args(argv)
+    return run(args.sources, stderr=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/loom/py/loom/tools/source_lint_test.py
+++ b/loom/py/loom/tools/source_lint_test.py
@@ -1,0 +1,168 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from loom.tools.source_lint import CONSTANT_NAME_RULE, lint_source, main
+
+
+def _finding_names(source: str, suffix: str = ".loom") -> list[str]:
+    return [finding.name for finding in lint_source(Path("source" + suffix), source)]
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "two",
+        "fivehundredtwelve",
+        "thirty_two",
+        "zero_f32x4",
+        "four_bytes",
+        "negative_one",
+        "i32_fivehundredtwelve_bytes",
+        "all_ones",
+        "ones",
+        "zeroes",
+        "sixes",
+        "twenties",
+        "one_hundred_and_one",
+        "thousand",
+    ],
+)
+def test_spelled_numeric_constant_names_fail(name: str) -> None:
+    source = f"%{name} = index.constant 1 : index\n"
+
+    assert _finding_names(source) == [name]
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "batch_size",
+        "c512",
+        "c0_i32",
+        "zero_point",
+        "zero_exponent",
+        "two_pi",
+        "positive_signed_zero",
+        "all_bits_set",
+        "f32_sign_threshold",
+        "nonzero",
+        "fourth_word_ordinal",
+        "and",
+        "and_zero",
+    ],
+)
+def test_semantic_and_compact_numeric_names_pass(name: str) -> None:
+    source = f"%{name} = scalar.constant 1 : i32\n"
+
+    assert _finding_names(source) == []
+
+
+def test_constant_operation_and_assignment_may_span_lines() -> None:
+    source = """module {
+  %fivehundredtwelve
+      =
+      index.constant 512 : index
+}
+"""
+
+    findings = lint_source(Path("multiline.loom"), source)
+
+    assert [(finding.line, finding.column, finding.name) for finding in findings] == [
+        (2, 3, "fivehundredtwelve")
+    ]
+
+
+def test_all_constant_operation_spellings_share_the_rule() -> None:
+    source = """%one = scalar.constant 1 : i32
+%two = vector.constant 2 : vector<4xi32>
+%three = test.clause_constant value(3) : i32
+%four = test.effectful_constant 4 : i32
+"""
+
+    assert _finding_names(source) == ["one", "two", "three", "four"]
+
+
+def test_comments_and_string_literals_are_not_authored_operations() -> None:
+    source = """// %one = index.constant 1 : index
+test.string "%two = index.constant 2 : index // still a string"
+test.string "escaped \\" %three = index.constant 3 : index"
+%batch_size = index.constant 512 : index // %four = index.constant 4 : index
+"""
+
+    assert _finding_names(source) == []
+
+
+def test_loom_test_expected_output_is_excluded_and_cases_restore_input() -> None:
+    source = """%two = index.constant 2 : index
+// ----
+%fivehundredtwelve = index.constant 512 : index
+// ==== second case
+%thirty_two = index.constant 32 : index
+// ----
+%sixty_four = index.constant 64 : index
+"""
+
+    findings = lint_source(Path("cases.loom-test"), source)
+
+    assert [(finding.line, finding.name) for finding in findings] == [
+        (1, "two"),
+        (5, "thirty_two"),
+    ]
+
+
+def test_cli_reports_source_location_rule_and_remedy(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source_path = tmp_path / "bad.loom"
+    source_path.write_text(
+        "module {\n  %fivehundredtwelve = index.constant 512 : index\n}\n",
+        encoding="utf-8",
+    )
+
+    assert main([str(source_path)]) == 1
+
+    diagnostic = capsys.readouterr().err
+    assert f"{source_path}:2:3: error:" in diagnostic
+    assert "%fivehundredtwelve" in diagnostic
+    assert "%c<literal>" in diagnostic
+    assert f"[{CONSTANT_NAME_RULE}]" in diagnostic
+
+
+def test_cli_accepts_clean_batches(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    first_path = tmp_path / "first.loom"
+    first_path.write_text("%c1 = index.constant 1 : index\n", encoding="utf-8")
+    second_path = tmp_path / "second.loom-test"
+    second_path.write_text("%batch_size = index.constant 1 : index\n", encoding="utf-8")
+
+    assert main([str(first_path), str(second_path)]) == 0
+    assert capsys.readouterr().err == ""
+
+
+def test_cli_rejects_unsupported_inputs(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source_path = tmp_path / "source.txt"
+    source_path.write_text("%one = index.constant 1 : index\n", encoding="utf-8")
+
+    assert main([str(source_path)]) == 2
+    assert "unsupported source suffix" in capsys.readouterr().err
+
+
+def test_cli_rejects_missing_inputs(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source_path = tmp_path / "missing.loom"
+
+    assert main([str(source_path)]) == 2
+    assert "source file does not exist" in capsys.readouterr().err


### PR DESCRIPTION
Publishes `loom-lint` as a target-neutral authoring-policy tool for explicit `.loom` and `.loom-test` inputs. The initial `constant-name` rule rejects SSA names that spell numeric literals in English, reports stable source locations and a compact `%c<literal>` remedy, and excludes runner-owned expected output in `.loom-test` containers.

Lint remains independent from `loom-format`: formatting continues to parse, verify, and canonicalize program text, while lint checks human-facing source conventions without mutating input. The public CLI has distinct clean, findings, and input-error exit codes and performs no repository, Git, or build-graph discovery.

## Library Integration

Adds an independent lint role to the Loom Bazel toolchain so selecting a linter does not configure compiler, linker, runner, or benchmark dependency graphs. Every authored source declared through the public Loom library rules now receives a private host-side lint test alongside its existing format test, making the policy automatic for external source repositories.

## Repository Migration

Moves hrx-system presubmit onto the same public executable and removes the duplicated constant-name scanner and its private tests. Compiler-repository C, BUILD, target, and authoring-corpus guardrails remain in the repository-only linter, preserving the boundary between stable source policy and internal implementation policy.

## Reviewer Notes

The highest-value review surfaces are the position-preserving lexical masking of comments, strings, and `.loom-test` expected sections; the separation between lint and format contracts; and the independent Bazel toolchain edge generated for every authored library source.
