### PR TITLE
[Loom] Preserve module file headers

### DIFF
--- a/loom/py/loom/format/bytecode/c_interop_test.py
+++ b/loom/py/loom/format/bytecode/c_interop_test.py
@@ -63,6 +63,8 @@ def _typed_register_module() -> tuple[Module, RegisterType]:
     parser.register_types(ALL_TEST_TYPES)
     parser.register_parameterized_attrs(ALL_TEST_PARAMETERIZED_ATTRS)
     module = parser.parse(
+        "// Bytecode interoperability coverage.\n"
+        "\n"
         "low.func.decl target<test.low.core> "
         "@typed_identity(%arg: reg<test.ptr : vector<4xi16>>) -> "
         "(reg<test.ptr : vector<4xi16>>)\n"
@@ -138,6 +140,8 @@ def main() -> None:
             parameterized_attrs=ALL_TEST_PARAMETERIZED_ATTRS,
             type_defs=ALL_TEST_TYPES,
         )
+        if loaded.file_header != ("Bytecode interoperability coverage.",):
+            raise AssertionError("file header did not survive C bytecode")
         if not any(value.type == register_type for value in loaded.values):
             raise AssertionError(
                 "Python reader did not recover the C-written structural register type"
@@ -148,12 +152,12 @@ def main() -> None:
         if enum_function is None:
             raise AssertionError("Python reader did not recover enum_arrays")
         if not enum_function.leading_blank_line or enum_function.comments != (
-            " Enum and parameterized attribute coverage.",
+            "Enum and parameterized attribute coverage.",
         ):
             raise AssertionError("symbol source trivia did not survive C bytecode")
         entry_block = enum_function.regions[0].blocks[0]
         if not entry_block.leading_blank_line or entry_block.comments != (
-            " Explicit entry block coverage.",
+            "Explicit entry block coverage.",
         ):
             raise AssertionError("block source trivia did not survive C bytecode")
         enum_op = entry_block.ops[0]
@@ -163,7 +167,7 @@ def main() -> None:
             raise AssertionError("open enum array did not survive C bytecode")
         options = [op.attributes["options"] for op in entry_block.ops[1:4]]
         if not entry_block.ops[1].leading_blank_line or entry_block.ops[1].comments != (
-            " Grouped operation coverage.",
+            "Grouped operation coverage.",
         ):
             raise AssertionError("commented op source trivia did not survive bytecode")
         if entry_block.ops[2].leading_blank_line:

--- a/loom/py/loom/format/bytecode/reader.py
+++ b/loom/py/loom/format/bytecode/reader.py
@@ -41,6 +41,7 @@ from loom.format.bytecode.writer import (
     SECTION_IR,
     SECTION_LOCATIONS,
     SECTION_OPS,
+    SECTION_SOURCE_TRIVIA,
     SECTION_SOURCES,
     SECTION_STRINGS,
     SECTION_SYMBOLS,
@@ -209,6 +210,10 @@ class BytecodeReader:
         module = Module()
         module.encodings = list(self._encodings)
         module.sources = list(self._sources)
+        if SECTION_SOURCE_TRIVIA in sections:
+            module.file_header = self._read_source_trivia_section(
+                sections[SECTION_SOURCE_TRIVIA]
+            )
 
         if self._location_mode == LOCATION_MODE_NO_LOCATIONS:
             if SECTION_LOCATIONS in sections:
@@ -803,7 +808,7 @@ class BytecodeReader:
     def _read_source_trivia(
         self, data: bytes, offset: int
     ) -> tuple[bool, tuple[str, ...], int]:
-        """Read a leading-blank bit and raw UTF-8 comment strings."""
+        """Read a leading-blank bit and normalized UTF-8 comment payloads."""
         source_trivia, offset = decode_varint(data, offset)
         leading_blank_line = (source_trivia & SOURCE_TRIVIA_LEADING_BLANK_LINE) != 0
         count = source_trivia >> SOURCE_TRIVIA_COMMENT_COUNT_SHIFT
@@ -816,8 +821,26 @@ class BytecodeReader:
             if len(comment_bytes) != length:
                 raise BytecodeError("comment extends past end of data")
             offset += length
-            comments.append(comment_bytes.decode("utf-8"))
+            try:
+                comment = comment_bytes.decode("utf-8")
+            except UnicodeDecodeError as error:
+                raise BytecodeError("comment is not valid UTF-8") from error
+            if comment.startswith(" "):
+                comment = comment[1:]
+            comments.append(comment)
         return leading_blank_line, tuple(comments), offset
+
+    def _read_source_trivia_section(
+        self, section: tuple[int, bytes]
+    ) -> tuple[str, ...]:
+        """Read module-owned source presentation."""
+        _, data = section
+        leading_blank_line, file_header, offset = self._read_source_trivia(data, 0)
+        if leading_blank_line:
+            raise BytecodeError("file header must not have a leading blank line")
+        if offset != len(data):
+            raise BytecodeError("SOURCE_TRIVIA section has trailing bytes")
+        return file_header
 
     def _map_value_ref(self, value_ref: int, value_map: list[int]) -> int:
         """Translate an available function-local value number to a module value id."""

--- a/loom/py/loom/format/bytecode/reader_test.py
+++ b/loom/py/loom/format/bytecode/reader_test.py
@@ -38,7 +38,9 @@ from loom.format.bytecode.writer import (
     SECTION_ENCODINGS,
     SECTION_IR,
     SECTION_LOCATIONS,
+    SECTION_SOURCE_TRIVIA,
     SECTION_SYMBOLS,
+    SOURCE_TRIVIA_LEADING_BLANK_LINE,
     write_module,
 )
 from loom.ir import (
@@ -449,6 +451,53 @@ class TestMalformedSectionDirectory:
         with pytest.raises(BytecodeError, match="unsupported flags"):
             read_module(bytes(data))
 
+    def test_file_header_leading_blank_line_is_rejected(self) -> None:
+        module = Module(name="test", file_header=("File overview.",))
+        data = bytearray(write_module(module))
+        module_offset, _module_length = _module_range(data)
+        _entry_offset, section_offset, _length = _find_section_entry(
+            data, SECTION_SOURCE_TRIVIA
+        )
+        payload_offset = module_offset + section_offset
+        assert data[payload_offset] == 2
+        data[payload_offset] |= SOURCE_TRIVIA_LEADING_BLANK_LINE
+
+        with pytest.raises(BytecodeError, match="leading blank line"):
+            read_module(bytes(data))
+
+    def test_invalid_utf8_file_header_is_rejected(self) -> None:
+        module = Module(name="test", file_header=("File overview.",))
+        data = bytearray(write_module(module))
+        module_offset, _module_length = _module_range(data)
+        _entry_offset, section_offset, _length = _find_section_entry(
+            data, SECTION_SOURCE_TRIVIA
+        )
+        payload_offset = module_offset + section_offset
+        _source_trivia, payload_offset = decode_varint(data, payload_offset)
+        _comment_length, payload_offset = decode_varint(data, payload_offset)
+        assert data[payload_offset] == ord(" ")
+        data[payload_offset + 1] = 0xFF
+
+        with pytest.raises(BytecodeError, match="not valid UTF-8"):
+            read_module(bytes(data))
+
+    def test_file_header_trailing_bytes_are_rejected(self) -> None:
+        module = Module(name="test", file_header=("File overview.",))
+        data = bytearray(write_module(module))
+        module_offset, module_length = _module_range(data)
+        entry_offset, section_offset, section_length = _find_section_entry(
+            data, SECTION_SOURCE_TRIVIA
+        )
+        assert module_offset + section_offset + section_length == len(data)
+        data.append(0)
+        struct.pack_into("<Q", data, entry_offset + 16, section_length + 1)
+        producer_end = data.index(0, 16)
+        directory_offset = (producer_end + 1 + 7) & ~7
+        struct.pack_into("<Q", data, directory_offset + 16, module_length + 1)
+
+        with pytest.raises(BytecodeError, match="trailing bytes"):
+            read_module(bytes(data))
+
 
 class TestMalformedLocationMode:
     def test_full_locations_mode_is_rejected_until_implemented(self) -> None:
@@ -518,7 +567,7 @@ class TestMalformedIrSection:
         func_op.regions[0].blocks[0].comments = ("x",)
         data = bytearray(write_module(module))
         source_trivia_offset = _root_block_source_trivia_offset(data)
-        assert data[source_trivia_offset : source_trivia_offset + 3] == b"\x02\x01x"
+        assert data[source_trivia_offset : source_trivia_offset + 3] == b"\x02\x02 "
         data[source_trivia_offset : source_trivia_offset + 3] = b"\x80\x80\x08"
 
         with pytest.raises(BytecodeError, match="comment count exceeds UINT16_MAX"):
@@ -1249,28 +1298,30 @@ class TestIRStructure:
 
     def test_source_trivia_roundtrip(self) -> None:
         module = _make_single_op_body_module()
+        module.file_header = ("File-level overview.", "Second header line.")
         func_op = module.symbols[0].op
         assert func_op is not None
         block = func_op.regions[0].blocks[0]
         body_op = block.ops[0]
         func_op.leading_blank_line = True
-        func_op.comments = (" symbol",)
+        func_op.comments = ("symbol",)
         block.leading_blank_line = True
-        block.comments = (" block",)
+        block.comments = ("block",)
         body_op.leading_blank_line = True
-        body_op.comments = (" operation",)
+        body_op.comments = ("operation",)
 
         loaded = _roundtrip(module)
+        assert loaded.file_header == module.file_header
         loaded_func_op = loaded.symbols[0].op
         assert loaded_func_op is not None
         loaded_block = loaded_func_op.regions[0].blocks[0]
         loaded_body_op = loaded_block.ops[0]
         assert loaded_func_op.leading_blank_line
-        assert loaded_func_op.comments == (" symbol",)
+        assert loaded_func_op.comments == ("symbol",)
         assert loaded_block.leading_blank_line
-        assert loaded_block.comments == (" block",)
+        assert loaded_block.comments == ("block",)
         assert loaded_body_op.leading_blank_line
-        assert loaded_body_op.comments == (" operation",)
+        assert loaded_body_op.comments == ("operation",)
 
     def test_op_with_results(self) -> None:
         module = Module(name="test")

--- a/loom/py/loom/format/bytecode/writer.py
+++ b/loom/py/loom/format/bytecode/writer.py
@@ -98,6 +98,7 @@ SECTION_LOCATIONS = 5
 SECTION_SYMBOLS = 6
 SECTION_IR = 7
 SECTION_RESOURCES = 8
+SECTION_SOURCE_TRIVIA = 9
 
 SECTION_WRITE_ORDER = (
     SECTION_IR,
@@ -108,6 +109,7 @@ SECTION_WRITE_ORDER = (
     SECTION_ENCODINGS,
     SECTION_OPS,
     SECTION_LOCATIONS,
+    SECTION_SOURCE_TRIVIA,
 )
 
 FUNCTION_SYMBOL_KINDS = frozenset(
@@ -748,6 +750,8 @@ class BytecodeWriter:
         sections[SECTION_OPS] = self._write_ops()
         if self._location_mode != LOCATION_MODE_NO_LOCATIONS:
             sections[SECTION_LOCATIONS] = self._write_locations()
+        if self._module.file_header:
+            sections[SECTION_SOURCE_TRIVIA] = self._write_source_trivia_section()
         ir_bytes, ir_offsets = self._write_ir()
         sections[SECTION_IR] = ir_bytes
         sections[SECTION_SYMBOLS] = self._write_symbols(ir_offsets)
@@ -769,6 +773,14 @@ class BytecodeWriter:
         buf.write_varint(len(sources))
         for source in sources:
             buf.write_string(source)
+        return buf.get_bytes()
+
+    def _write_source_trivia_section(self) -> bytes:
+        """Write module-owned source presentation."""
+        buf = ByteBuffer()
+        self._write_source_trivia(
+            buf, leading_blank_line=False, comments=self._module.file_header
+        )
         return buf.get_bytes()
 
     def _write_encodings(self) -> bytes:
@@ -1172,7 +1184,7 @@ class BytecodeWriter:
             source_trivia |= SOURCE_TRIVIA_LEADING_BLANK_LINE
         buf.write_varint(source_trivia)
         for comment in comments:
-            encoded = comment.encode("utf-8")
+            encoded = ((" " + comment) if comment else "").encode("utf-8")
             buf.write_varint(len(encoded))
             buf.write_bytes(encoded)
 

--- a/loom/py/loom/format/text/parser.py
+++ b/loom/py/loom/format/text/parser.py
@@ -1952,6 +1952,8 @@ class Parser:
             else None
         )
         tok = self._tokenizer
+        tok.peek()
+        self._module.file_header = tuple(tok.take_file_header())
 
         while not tok.at(TokenKind.EOF):
             # Attribute alias: #name = ...

--- a/loom/py/loom/format/text/parser_test.py
+++ b/loom/py/loom/format/text/parser_test.py
@@ -1916,6 +1916,36 @@ class TestRoundTrip:
             "}\n"
         )
 
+    def test_file_header_is_owned_by_the_module(self) -> None:
+        text = (
+            "// File-level overview.\n"
+            "//  Indented header detail.\n"
+            "\n"
+            "// Declaration documentation.\n"
+            "test.decl @documented()\n"
+        )
+        module = _op_parser().parse(text)
+        assert module.file_header == (
+            "File-level overview.",
+            " Indented header detail.",
+        )
+        declaration = module.symbols[0].op
+        assert declaration is not None
+        assert declaration.comments == ("Declaration documentation.",)
+        assert not declaration.leading_blank_line
+        assert _op_printer().print_module(module) == text
+
+    def test_comment_separator_space_is_canonicalized(self) -> None:
+        module = _op_parser().parse(
+            "//documentation\n//  indented detail\ntest.decl @documented()\n"
+        )
+        assert _op_printer().print_module(module) == (
+            "// documentation\n//  indented detail\ntest.decl @documented()\n"
+        )
+
+    def test_file_header_only_roundtrip(self) -> None:
+        self._roundtrip_text("// File-level overview.\n")
+
     def test_vertical_source_grouping_is_canonicalized(self) -> None:
         module = _op_parser().parse(
             "\n"

--- a/loom/py/loom/format/text/printer.py
+++ b/loom/py/loom/format/text/printer.py
@@ -1229,7 +1229,7 @@ class Printer:
     def _emit_comments(self, comments: tuple[str, ...]) -> None:
         """Emit leading line comments at the current indentation."""
         for comment in comments:
-            self._emit("//" + comment)
+            self._emit("//" + (" " + comment if comment else ""))
 
     # --- Module printing ---
 
@@ -1237,6 +1237,12 @@ class Printer:
         """Print a complete module to canonical text."""
         self._lines = []
         self._module = module
+        self._emit_comments(module.file_header)
+        if module.file_header and (
+            any(encoding.alias for encoding in module.encodings)
+            or any(symbol.op is not None for symbol in module.symbols)
+        ):
+            self._lines.append("")
         for encoding in module.encodings:
             if encoding.alias:
                 self._emit(

--- a/loom/py/loom/format/text/tokenizer.py
+++ b/loom/py/loom/format/text/tokenizer.py
@@ -203,6 +203,8 @@ class Tokenizer:
         "_peeked",
         "_comments",
         "_comment_start_line",
+        "_comment_end_line",
+        "_file_header_line_count",
         "_leading_blank_line",
         "_consumed_end_line",
         "in_dim_list",
@@ -217,6 +219,8 @@ class Tokenizer:
         self._peeked: Token | None = None
         self._comments: list[str] = []
         self._comment_start_line: int = 0
+        self._comment_end_line: int = 0
+        self._file_header_line_count: int = 0
         self._leading_blank_line: bool = False
         self._consumed_end_line: int = 0
         self.in_dim_list: bool = False
@@ -239,6 +243,8 @@ class Tokenizer:
         saved_peeked = self._peeked
         saved_comments = list(self._comments)
         saved_comment_start_line = self._comment_start_line
+        saved_comment_end_line = self._comment_end_line
+        saved_file_header_line_count = self._file_header_line_count
         saved_leading_blank_line = self._leading_blank_line
         saved_consumed_end_line = self._consumed_end_line
         saved_in_dim_list = self.in_dim_list
@@ -254,6 +260,8 @@ class Tokenizer:
             self._peeked = saved_peeked
             self._comments = saved_comments
             self._comment_start_line = saved_comment_start_line
+            self._comment_end_line = saved_comment_end_line
+            self._file_header_line_count = saved_file_header_line_count
             self._leading_blank_line = saved_leading_blank_line
             self._consumed_end_line = saved_consumed_end_line
             self.in_dim_list = saved_in_dim_list
@@ -301,12 +309,21 @@ class Tokenizer:
             return self.next()
         return None
 
+    def take_file_header(self) -> list[str]:
+        """Take the separated line-1 comment block, if present."""
+        file_header = self._comments[: self._file_header_line_count]
+        self._comments = self._comments[self._file_header_line_count :]
+        self._file_header_line_count = 0
+        return file_header
+
     def take_pending_source_trivia(self) -> tuple[list[str], bool]:
         """Return and clear comments and their leading source grouping."""
         comments = self._comments
         leading_blank_line = self._leading_blank_line
         self._comments = []
         self._comment_start_line = 0
+        self._comment_end_line = 0
+        self._file_header_line_count = 0
         self._leading_blank_line = False
         return comments, leading_blank_line
 
@@ -404,6 +421,13 @@ class Tokenizer:
             if character == "/" and self._peek_char() == "/":
                 if not self._comments:
                     self._comment_start_line = self._line
+                elif (
+                    self._comment_start_line == 1
+                    and self._file_header_line_count == 0
+                    and self._line > self._comment_end_line + 1
+                ):
+                    self._file_header_line_count = len(self._comments)
+                self._comment_end_line = self._line
                 comment_start = self._position + 2
                 self._advance()  # skip first /
                 self._advance()  # skip second /
@@ -412,6 +436,8 @@ class Tokenizer:
                 comment_text = self._source[comment_start : self._position]
                 if comment_text.endswith("\r"):
                     comment_text = comment_text[:-1]
+                if comment_text.startswith(" "):
+                    comment_text = comment_text[1:]
                 self._comments.append(comment_text)
                 continue
 
@@ -422,6 +448,15 @@ class Tokenizer:
         self._skip_whitespace_and_comments()
 
         source_start_line = self._comment_start_line or self._line
+        if (
+            self._comment_start_line == 1
+            and self._file_header_line_count == 0
+            and (
+                self._position == len(self._source)
+                or self._line > self._comment_end_line + 1
+            )
+        ):
+            self._file_header_line_count = len(self._comments)
         self._leading_blank_line = (
             self._consumed_end_line != 0
             and source_start_line > self._consumed_end_line + 1

--- a/loom/py/loom/format/text/tokenizer_test.py
+++ b/loom/py/loom/format/text/tokenizer_test.py
@@ -372,15 +372,34 @@ class TestComments:
         tokenizer = Tokenizer("// hello\n%x")
         tokenizer.peek()
         comments, leading_blank_line = tokenizer.take_pending_source_trivia()
-        assert comments == [" hello"]
+        assert comments == ["hello"]
         assert not leading_blank_line
 
     def test_multiple_comments(self) -> None:
         tokenizer = Tokenizer("// first\n// second\n%x")
         tokenizer.peek()
         comments, leading_blank_line = tokenizer.take_pending_source_trivia()
-        assert comments == [" first", " second"]
+        assert comments == ["first", "second"]
         assert not leading_blank_line
+
+    def test_file_header_is_separate_from_operation_comments(self) -> None:
+        adjacent = Tokenizer("// declaration\n%x")
+        adjacent.peek()
+        assert adjacent.take_file_header() == []
+        comments, leading_blank_line = adjacent.take_pending_source_trivia()
+        assert comments == ["declaration"]
+        assert not leading_blank_line
+
+        separated = Tokenizer("// file header\n\n// declaration\n%x")
+        separated.peek()
+        assert separated.take_file_header() == ["file header"]
+        comments, leading_blank_line = separated.take_pending_source_trivia()
+        assert comments == ["declaration"]
+        assert not leading_blank_line
+
+        header_only = Tokenizer("// file header")
+        assert header_only.peek().kind == TokenKind.EOF
+        assert header_only.take_file_header() == ["file header"]
 
     def test_leading_blank_line_before_comments_or_token(self) -> None:
         tokenizer = Tokenizer("\n0\n1\n\n// grouped\n2\n\n\n3")
@@ -399,7 +418,7 @@ class TestComments:
         assert tokenizer.peek_n(0).text == "2"
         assert tokenizer.peek().text == "2"
         comments, leading_blank_line = tokenizer.take_pending_source_trivia()
-        assert comments == [" grouped"]
+        assert comments == ["grouped"]
         assert leading_blank_line
 
         assert tokenizer.next().text == "2"

--- a/loom/py/loom/ir.py
+++ b/loom/py/loom/ir.py
@@ -1733,6 +1733,7 @@ class Operation:
     attributes: Mapping[str, Any] = field(default_factory=CanonicalAttrDict)
     regions: list[Region] = field(default_factory=list)
     location_id: int = LOCATION_UNKNOWN
+    # Leading line comments without // or its conventional separator space.
     comments: tuple[str, ...] = ()
     # True when one canonical empty source line precedes this operation.
     leading_blank_line: bool = False
@@ -1765,6 +1766,7 @@ class Block:
     label: str = ""
     arg_ids: list[int] = field(default_factory=list)
     ops: list[Operation] = field(default_factory=list)
+    # Leading line comments without // or its conventional separator space.
     comments: tuple[str, ...] = ()
     # True when one canonical empty source line precedes this explicit label.
     leading_blank_line: bool = False
@@ -2015,6 +2017,8 @@ class Module:
 
     name: str = ""
     flags: int = 0
+    # File header lines without // or its conventional separator space.
+    file_header: tuple[str, ...] = ()
 
     # Tables.
     strings: StringTable = field(default_factory=StringTable)

--- a/loom/src/loom/format/bytecode/format.h
+++ b/loom/src/loom/format/bytecode/format.h
@@ -143,6 +143,10 @@ typedef uint16_t loom_bytecode_module_flags_t;
 //   +-----------------------+
 //   | Section directory     |  Section kind + offset + length for each.
 //   +-----------------------+
+//   | IR section            |  Function bodies: ops, blocks, regions.
+//   +-----------------------+
+//   | SYMBOLS section       |  Symbol table with full metadata.
+//   +-----------------------+
 //   | STRINGS section       |  Interned string table.
 //   +-----------------------+
 //   | SOURCES section       |  Source identifiers (filenames, tags).
@@ -155,9 +159,7 @@ typedef uint16_t loom_bytecode_module_flags_t;
 //   +-----------------------+
 //   | LOCATIONS section     |  Location table.
 //   +-----------------------+
-//   | SYMBOLS section       |  Symbol table with full metadata.
-//   +-----------------------+
-//   | IR section            |  Function bodies: ops, blocks, regions.
+//   | SOURCE_TRIVIA section |  File-level source presentation.
 //   +-----------------------+
 //   | RESOURCES section     |  Large blobs: weights, executables, etc.
 //   |                       |  (last — keeps dense metadata up front,
@@ -211,9 +213,21 @@ typedef enum loom_bytecode_section_kind_e {
           // embedded weights, constant tensors.
           // Aligned, seekable, mmap-friendly.
           // Referenced by symbols and op attributes.
+  LOOM_BYTECODE_SECTION_SOURCE_TRIVIA =
+      9,  // Optional module-owned source presentation.
 } loom_bytecode_section_kind_t;
 
-#define LOOM_BYTECODE_SECTION_COUNT 9
+#define LOOM_BYTECODE_SECTION_COUNT 10
+
+// ==========================================================================
+// SOURCE_TRIVIA section
+// ==========================================================================
+//
+// Optional module-owned source presentation that is not attached to an
+// operation or block. The file header uses the ordinary source-trivia encoding
+// with a required zero leading-blank-line bit:
+//
+//   [file_header: source_trivia]
 
 // ==========================================================================
 // Reader validation requirements
@@ -504,6 +518,10 @@ typedef enum loom_bytecode_section_kind_e {
 // leading-comment count in bits 1 and above and a leading-blank-line bit in
 // bit 0. The comment count is therefore source_trivia >> 1. Writers
 // canonicalize any authored run of empty lines to the single retained bit.
+// Nonempty comment_data begins with the conventional single ASCII space after
+// the // marker. In-memory comment payloads omit that separator: writers add
+// exactly one and readers remove exactly one while retaining any additional
+// indentation. Empty comments have zero-length comment_data.
 //
 // Symbol entry format:
 //

--- a/loom/src/loom/format/bytecode/reader.c
+++ b/loom/src/loom/format/bytecode/reader.c
@@ -173,6 +173,8 @@ static const char* loom_bytecode_section_name(uint16_t kind) {
       return "IR";
     case LOOM_BYTECODE_SECTION_RESOURCES:
       return "RESOURCES";
+    case LOOM_BYTECODE_SECTION_SOURCE_TRIVIA:
+      return "SOURCE_TRIVIA";
     default:
       return "UNKNOWN";
   }
@@ -428,9 +430,20 @@ static iree_status_t loom_bytecode_reader_read_source_trivia(
     iree_const_byte_span_t span = iree_const_byte_span_empty();
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_span(reader, cursor, length, &span));
+    iree_string_view_t comment =
+        iree_make_string_view((const char*)span.data, span.data_length);
+    if (!iree_unicode_utf8_validate(comment)) {
+      return loom_bytecode_reader_emit_invalid_field(
+          reader, cursor->range_name, IREE_SV("comment_list"), i,
+          IREE_SV("comment"),
+          loom_bytecode_reader_cursor_absolute_position(cursor) - length,
+          IREE_SV("comment_is_not_valid_utf_8"));
+    }
+    if (iree_string_view_starts_with(comment, IREE_SV(" "))) {
+      comment = iree_string_view_remove_prefix(comment, 1);
+    }
     if (comments) {
-      comments[i] =
-          iree_make_string_view((const char*)span.data, span.data_length);
+      comments[i] = comment;
     }
   }
   if (out_leading_blank_line) {
@@ -454,6 +467,29 @@ static iree_status_t loom_bytecode_reader_expect_empty(
 
 static bool loom_bytecode_reader_string_is_valid_utf8(iree_string_view_t text) {
   return iree_unicode_utf8_validate(text);
+}
+
+static iree_status_t loom_bytecode_reader_read_file_header(
+    loom_bytecode_reader_state_t* reader,
+    const loom_bytecode_reader_section_t* section,
+    iree_arena_allocator_t* arena, const iree_string_view_t** out_lines,
+    iree_host_size_t* out_line_count) {
+  loom_bytecode_reader_cursor_t cursor;
+  loom_bytecode_reader_cursor_initialize(
+      section->bytes.data, section->bytes.data_length, section->absolute_offset,
+      IREE_SV("SOURCE_TRIVIA"), &cursor);
+  bool leading_blank_line = false;
+  IREE_RETURN_IF_ERROR(loom_bytecode_reader_read_source_trivia(
+      reader, &cursor, arena, &leading_blank_line, out_lines, out_line_count));
+  if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
+  if (leading_blank_line) {
+    return loom_bytecode_reader_emit_invalid_field(
+        reader, IREE_SV("SOURCE_TRIVIA"), IREE_SV("file_header"), 0,
+        IREE_SV("leading_blank_line"), section->absolute_offset,
+        IREE_SV("file_header_must_not_have_a_leading_blank_line"));
+  }
+  return loom_bytecode_reader_expect_empty(reader, &cursor,
+                                           IREE_SV("file_header"));
 }
 
 static iree_status_t loom_bytecode_reader_validate_string_ref(
@@ -6617,6 +6653,9 @@ static iree_status_t loom_bytecode_reader_read_module_metadata(
   const loom_bytecode_reader_section_t* locations_section =
       loom_bytecode_reader_find_section(sections, section_count,
                                         LOOM_BYTECODE_SECTION_LOCATIONS);
+  const loom_bytecode_reader_section_t* source_trivia_section =
+      loom_bytecode_reader_find_section(sections, section_count,
+                                        LOOM_BYTECODE_SECTION_SOURCE_TRIVIA);
   if (reader->result.location_mode ==
       LOOM_BYTECODE_LOCATION_MODE_NO_LOCATIONS) {
     if (locations_section) {
@@ -6651,6 +6690,12 @@ static iree_status_t loom_bytecode_reader_read_module_metadata(
   if (locations_section) {
     IREE_RETURN_IF_ERROR(
         loom_bytecode_reader_read_locations(reader, locations_section));
+    if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
+  }
+  if (source_trivia_section) {
+    IREE_RETURN_IF_ERROR(loom_bytecode_reader_read_file_header(
+        reader, source_trivia_section, reader->arena,
+        /*out_lines=*/NULL, /*out_line_count=*/NULL));
     if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
   }
   IREE_RETURN_IF_ERROR(
@@ -6720,6 +6765,9 @@ static iree_status_t loom_bytecode_reader_materialize_module(
   const loom_bytecode_reader_section_t* locations_section =
       loom_bytecode_reader_find_section(sections, section_count,
                                         LOOM_BYTECODE_SECTION_LOCATIONS);
+  const loom_bytecode_reader_section_t* source_trivia_section =
+      loom_bytecode_reader_find_section(sections, section_count,
+                                        LOOM_BYTECODE_SECTION_SOURCE_TRIVIA);
 
   IREE_RETURN_IF_ERROR(loom_bytecode_reader_materialize_strings(reader));
   if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
@@ -6727,6 +6775,16 @@ static iree_status_t loom_bytecode_reader_materialize_module(
   IREE_RETURN_IF_ERROR(loom_module_intern_string(
       reader->output_module, module->name, &module_name_id));
   reader->output_module->name_id = module_name_id;
+  if (source_trivia_section) {
+    const iree_string_view_t* file_header = NULL;
+    iree_host_size_t file_header_line_count = 0;
+    IREE_RETURN_IF_ERROR(loom_bytecode_reader_read_file_header(
+        reader, source_trivia_section, reader->arena, &file_header,
+        &file_header_line_count));
+    if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
+    IREE_RETURN_IF_ERROR(loom_module_attach_file_header(
+        reader->output_module, file_header, file_header_line_count));
+  }
   IREE_RETURN_IF_ERROR(loom_bytecode_reader_materialize_sources(reader));
   if (loom_bytecode_reader_has_errors(reader)) return iree_ok_status();
   IREE_RETURN_IF_ERROR(

--- a/loom/src/loom/format/bytecode/reader_test.cc
+++ b/loom/src/loom/format/bytecode/reader_test.cc
@@ -2013,9 +2013,15 @@ TEST_F(ReaderTest, PreservesSourceTrivia) {
   func_op->flags |= LOOM_OP_FLAG_LEADING_BLANK_LINE;
   entry_block->flags |= LOOM_BLOCK_FLAG_LEADING_BLANK_LINE;
   entry_block->first_op->flags |= LOOM_OP_FLAG_LEADING_BLANK_LINE;
-  const iree_string_view_t symbol_comments[] = {IREE_SV(" symbol")};
-  const iree_string_view_t block_comments[] = {IREE_SV(" block")};
-  const iree_string_view_t op_comments[] = {IREE_SV(" operation")};
+  const iree_string_view_t symbol_comments[] = {IREE_SV("symbol")};
+  const iree_string_view_t block_comments[] = {IREE_SV("block")};
+  const iree_string_view_t op_comments[] = {IREE_SV("operation")};
+  const iree_string_view_t file_header[] = {
+      IREE_SV("File-level overview."),
+      IREE_SV("Second header line."),
+  };
+  IREE_ASSERT_OK(loom_module_attach_file_header(module, file_header,
+                                                IREE_ARRAYSIZE(file_header)));
   IREE_ASSERT_OK(loom_module_attach_op_comments(
       module, func_op, symbol_comments, IREE_ARRAYSIZE(symbol_comments)));
   IREE_ASSERT_OK(loom_module_attach_block_comments(
@@ -2047,7 +2053,11 @@ TEST_F(ReaderTest, PreservesSourceTrivia) {
 
   iree_host_size_t comment_count = 0;
   const iree_string_view_t* comments =
-      loom_module_op_comments(read_module, read_func_op, &comment_count);
+      loom_module_file_header(read_module, &comment_count);
+  ASSERT_EQ(comment_count, IREE_ARRAYSIZE(file_header));
+  EXPECT_TRUE(iree_string_view_equal(comments[0], file_header[0]));
+  EXPECT_TRUE(iree_string_view_equal(comments[1], file_header[1]));
+  comments = loom_module_op_comments(read_module, read_func_op, &comment_count);
   ASSERT_EQ(comment_count, 1u);
   EXPECT_TRUE(iree_string_view_equal(comments[0], symbol_comments[0]));
   comments =
@@ -2060,6 +2070,62 @@ TEST_F(ReaderTest, PreservesSourceTrivia) {
   EXPECT_TRUE(iree_string_view_equal(comments[0], op_comments[0]));
 
   loom_module_free(read_module);
+  loom_module_free(module);
+}
+
+TEST_F(ReaderTest, RejectsFileHeaderLeadingBlankLine) {
+  loom_module_t* module = CreateModule("file_header");
+  const iree_string_view_t file_header[] = {IREE_SV("File overview.")};
+  IREE_ASSERT_OK(loom_module_attach_file_header(module, file_header,
+                                                IREE_ARRAYSIZE(file_header)));
+  auto bytes = WriteModule(module);
+  size_t offset =
+      SectionPayloadOffset(bytes, LOOM_BYTECODE_SECTION_SOURCE_TRIVIA);
+  ASSERT_EQ(bytes[offset], 2u);
+  bytes[offset] |= LOOM_BYTECODE_SOURCE_TRIVIA_LEADING_BLANK_LINE;
+
+  ExpectReadError(bytes, "ERR_BYTECODE_006");
+
+  loom_module_free(module);
+}
+
+TEST_F(ReaderTest, RejectsInvalidUtf8FileHeader) {
+  loom_module_t* module = CreateModule("file_header");
+  const iree_string_view_t file_header[] = {IREE_SV("File overview.")};
+  IREE_ASSERT_OK(loom_module_attach_file_header(module, file_header,
+                                                IREE_ARRAYSIZE(file_header)));
+  auto bytes = WriteModule(module);
+  size_t offset =
+      SectionPayloadOffset(bytes, LOOM_BYTECODE_SECTION_SOURCE_TRIVIA);
+  ASSERT_EQ(ReadUVarint(bytes, &offset), 2u);
+  ASSERT_GT(ReadUVarint(bytes, &offset), 1u);
+  ASSERT_EQ(bytes[offset], ' ');
+  bytes[offset + 1] = 0xFF;
+
+  ExpectReadError(bytes, "ERR_BYTECODE_006");
+
+  loom_module_free(module);
+}
+
+TEST_F(ReaderTest, RejectsFileHeaderTrailingBytes) {
+  loom_module_t* module = CreateModule("file_header");
+  const iree_string_view_t file_header[] = {IREE_SV("File overview.")};
+  IREE_ASSERT_OK(loom_module_attach_file_header(module, file_header,
+                                                IREE_ARRAYSIZE(file_header)));
+  auto bytes = WriteModule(module);
+  SectionEntry source_trivia =
+      FindSection(bytes, LOOM_BYTECODE_SECTION_SOURCE_TRIVIA);
+  ASSERT_NE(source_trivia.length, 0u);
+  ASSERT_EQ((uint64_t)bytes.size(),
+            ModuleOffset(bytes) + source_trivia.offset + source_trivia.length);
+  bytes.push_back(0);
+  WriteU64LE(&bytes, source_trivia.directory_entry_offset + 16,
+             source_trivia.length + 1);
+  WriteU64LE(&bytes, ModuleDirectoryOffset(bytes) + 16,
+             ModuleLength(bytes) + 1);
+
+  ExpectReadError(bytes, "ERR_BYTECODE_006");
+
   loom_module_free(module);
 }
 
@@ -3175,8 +3241,8 @@ TEST_F(ReaderTest, RejectsSourceTriviaCommentCountBeyondFieldWidth) {
   auto bytes = WriteModule(module);
   size_t source_trivia_offset = RootBlockSourceTriviaOffset(bytes);
   ASSERT_EQ(bytes[source_trivia_offset], 2u);
-  ASSERT_EQ(bytes[source_trivia_offset + 1], 1u);
-  ASSERT_EQ(bytes[source_trivia_offset + 2], 'x');
+  ASSERT_EQ(bytes[source_trivia_offset + 1], 2u);
+  ASSERT_EQ(bytes[source_trivia_offset + 2], ' ');
   bytes[source_trivia_offset] = 0x80;
   bytes[source_trivia_offset + 1] = 0x80;
   bytes[source_trivia_offset + 2] = 0x08;

--- a/loom/src/loom/format/bytecode/writer.c
+++ b/loom/src/loom/format/bytecode/writer.c
@@ -207,12 +207,26 @@ static iree_status_t loom_bytecode_page_writer_write_source_trivia(
   IREE_RETURN_IF_ERROR(
       loom_bytecode_page_writer_write_uvarint(writer, source_trivia));
   for (iree_host_size_t i = 0; i < comment_count; ++i) {
+    bool has_payload = !iree_string_view_is_empty(comments[i]);
+    iree_host_size_t wire_size = comments[i].size + (has_payload ? 1 : 0);
     IREE_RETURN_IF_ERROR(
-        loom_bytecode_page_writer_write_uvarint(writer, comments[i].size));
+        loom_bytecode_page_writer_write_uvarint(writer, wire_size));
+    if (has_payload) {
+      IREE_RETURN_IF_ERROR(loom_bytecode_page_writer_write_u8(writer, ' '));
+    }
     IREE_RETURN_IF_ERROR(loom_bytecode_page_writer_write(
         writer, comments[i].data, comments[i].size));
   }
   return iree_ok_status();
+}
+
+static iree_status_t loom_bytecode_write_source_trivia_section(
+    loom_bytecode_page_writer_t* writer, const loom_module_t* module) {
+  iree_host_size_t line_count = 0;
+  const iree_string_view_t* lines =
+      loom_module_file_header(module, &line_count);
+  return loom_bytecode_page_writer_write_source_trivia(
+      writer, /*leading_blank_line=*/false, lines, line_count);
 }
 
 //===----------------------------------------------------------------------===//
@@ -300,7 +314,13 @@ static iree_status_t loom_bytecode_emit_source_trivia(
       leading_blank_line, comment_count, &source_trivia));
   IREE_RETURN_IF_ERROR(loom_bytecode_emit_uvarint(builder, source_trivia));
   for (iree_host_size_t i = 0; i < comment_count; ++i) {
-    IREE_RETURN_IF_ERROR(loom_bytecode_emit_uvarint(builder, comments[i].size));
+    bool has_payload = !iree_string_view_is_empty(comments[i]);
+    iree_host_size_t wire_size = comments[i].size + (has_payload ? 1 : 0);
+    IREE_RETURN_IF_ERROR(loom_bytecode_emit_uvarint(builder, wire_size));
+    if (has_payload) {
+      IREE_RETURN_IF_ERROR(
+          iree_string_builder_append_string(builder, IREE_SV(" ")));
+    }
     IREE_RETURN_IF_ERROR(
         iree_string_builder_append_string(builder, comments[i]));
   }
@@ -4889,15 +4909,22 @@ iree_status_t loom_bytecode_write_module(
   // Module data starts at this offset.
   iree_host_size_t module_start = page_writer.total_written;
 
-  static const loom_bytecode_section_kind_t section_write_order[] = {
-      LOOM_BYTECODE_SECTION_IR,      LOOM_BYTECODE_SECTION_SYMBOLS,
-      LOOM_BYTECODE_SECTION_STRINGS, LOOM_BYTECODE_SECTION_SOURCES,
-      LOOM_BYTECODE_SECTION_TYPES,   LOOM_BYTECODE_SECTION_ENCODINGS,
-      LOOM_BYTECODE_SECTION_OPS,     LOOM_BYTECODE_SECTION_LOCATIONS,
-  };
-  uint32_t section_count = IREE_ARRAYSIZE(section_write_order);
-  if (location_mode == LOOM_BYTECODE_LOCATION_MODE_NO_LOCATIONS) {
-    --section_count;
+  loom_bytecode_section_kind_t section_write_order[LOOM_BYTECODE_SECTION_COUNT];
+  iree_host_size_t section_count = 0;
+  section_write_order[section_count++] = LOOM_BYTECODE_SECTION_IR;
+  section_write_order[section_count++] = LOOM_BYTECODE_SECTION_SYMBOLS;
+  section_write_order[section_count++] = LOOM_BYTECODE_SECTION_STRINGS;
+  section_write_order[section_count++] = LOOM_BYTECODE_SECTION_SOURCES;
+  section_write_order[section_count++] = LOOM_BYTECODE_SECTION_TYPES;
+  section_write_order[section_count++] = LOOM_BYTECODE_SECTION_ENCODINGS;
+  section_write_order[section_count++] = LOOM_BYTECODE_SECTION_OPS;
+  if (location_mode != LOOM_BYTECODE_LOCATION_MODE_NO_LOCATIONS) {
+    section_write_order[section_count++] = LOOM_BYTECODE_SECTION_LOCATIONS;
+  }
+  iree_host_size_t file_header_line_count = 0;
+  (void)loom_module_file_header(module, &file_header_line_count);
+  if (file_header_line_count > 0) {
+    section_write_order[section_count++] = LOOM_BYTECODE_SECTION_SOURCE_TRIVIA;
   }
   loom_bytecode_body_counts_t module_counts = {0};
   if (iree_status_is_ok(status)) {
@@ -5056,6 +5083,18 @@ iree_status_t loom_bytecode_write_module(
     }
   }
 
+  // Module-owned source presentation.
+  if (iree_status_is_ok(status) && file_header_line_count > 0) {
+    section_offsets[LOOM_BYTECODE_SECTION_SOURCE_TRIVIA] =
+        page_writer.total_written - module_start;
+    status = loom_bytecode_write_source_trivia_section(&page_writer, module);
+    if (iree_status_is_ok(status)) {
+      section_lengths[LOOM_BYTECODE_SECTION_SOURCE_TRIVIA] =
+          page_writer.total_written - module_start -
+          section_offsets[LOOM_BYTECODE_SECTION_SOURCE_TRIVIA];
+    }
+  }
+
   // Flush remaining page buffer, then seek back to patch the section
   // directory and module directory with correct offsets and lengths.
   if (iree_status_is_ok(status)) {
@@ -5069,14 +5108,9 @@ iree_status_t loom_bytecode_write_module(
                             (iree_io_stream_pos_t)section_dir_patch_position);
   }
   if (iree_status_is_ok(status)) {
-    for (iree_host_size_t i = 0;
-         i < IREE_ARRAYSIZE(section_write_order) && iree_status_is_ok(status);
+    for (iree_host_size_t i = 0; i < section_count && iree_status_is_ok(status);
          ++i) {
       loom_bytecode_section_kind_t kind = section_write_order[i];
-      if (kind == LOOM_BYTECODE_SECTION_LOCATIONS &&
-          location_mode == LOOM_BYTECODE_LOCATION_MODE_NO_LOCATIONS) {
-        continue;
-      }
       uint8_t entry[sizeof(loom_bytecode_section_dir_entry_t)] = {0};
       entry[0] = (uint8_t)kind;
       entry[1] = (uint8_t)((uint16_t)kind >> 8);

--- a/loom/src/loom/format/bytecode/writer_test.cc
+++ b/loom/src/loom/format/bytecode/writer_test.cc
@@ -515,10 +515,12 @@ TEST_F(WriterTest, SectionDirectoryHasWrittenSections) {
     found_kinds[kind] = true;
   }
 
-  for (int i = 0; i < LOOM_BYTECODE_SECTION_COUNT - 1; ++i) {
+  for (int i = LOOM_BYTECODE_SECTION_STRINGS; i <= LOOM_BYTECODE_SECTION_IR;
+       ++i) {
     EXPECT_TRUE(found_kinds[i]) << "missing section kind " << i;
   }
   EXPECT_FALSE(found_kinds[LOOM_BYTECODE_SECTION_RESOURCES]);
+  EXPECT_FALSE(found_kinds[LOOM_BYTECODE_SECTION_SOURCE_TRIVIA]);
 
   loom_module_free(module);
 }
@@ -779,8 +781,8 @@ TEST_F(WriterTest, FunctionBodySummaryAndOpTableRefsUseNewWireShape) {
                                       &addi_op));
   entry_block->flags |= LOOM_BLOCK_FLAG_LEADING_BLANK_LINE;
   addi_op->flags |= LOOM_OP_FLAG_LEADING_BLANK_LINE;
-  const iree_string_view_t block_comments[] = {IREE_SV(" block")};
-  const iree_string_view_t op_comments[] = {IREE_SV(" operation")};
+  const iree_string_view_t block_comments[] = {IREE_SV("block")};
+  const iree_string_view_t op_comments[] = {IREE_SV("operation")};
   IREE_ASSERT_OK(loom_module_attach_block_comments(
       module, entry_block, block_comments, IREE_ARRAYSIZE(block_comments)));
   IREE_ASSERT_OK(loom_module_attach_op_comments(module, addi_op, op_comments,
@@ -832,10 +834,14 @@ TEST_F(WriterTest, FunctionBodySummaryAndOpTableRefsUseNewWireShape) {
   ASSERT_EQ(block_source_trivia, 3u);
   uint64_t block_comment_length = 0;
   IREE_ASSERT_OK(loom_uvarint_decode(&cursor, &block_comment_length));
-  ASSERT_EQ(block_comment_length, block_comments[0].size);
-  iree_const_byte_span_t unused_comment = iree_const_byte_span_empty();
+  ASSERT_EQ(block_comment_length, block_comments[0].size + 1);
+  iree_const_byte_span_t block_comment = iree_const_byte_span_empty();
   IREE_ASSERT_OK(loom_bytecode_cursor_read_span(
-      &cursor, (iree_host_size_t)block_comment_length, &unused_comment));
+      &cursor, (iree_host_size_t)block_comment_length, &block_comment));
+  ASSERT_EQ(block_comment.data[0], ' ');
+  EXPECT_EQ(memcmp(block_comment.data + 1, block_comments[0].data,
+                   block_comments[0].size),
+            0);
   uint64_t block_arg_count = 0;
   IREE_ASSERT_OK(loom_uvarint_decode(&cursor, &block_arg_count));
   ASSERT_EQ(block_arg_count, 2u);
@@ -865,7 +871,13 @@ TEST_F(WriterTest, FunctionBodySummaryAndOpTableRefsUseNewWireShape) {
   ASSERT_EQ(op_source_trivia, 3u);
   uint64_t op_comment_length = 0;
   IREE_ASSERT_OK(loom_uvarint_decode(&cursor, &op_comment_length));
-  ASSERT_EQ(op_comment_length, op_comments[0].size);
+  ASSERT_EQ(op_comment_length, op_comments[0].size + 1);
+  iree_const_byte_span_t op_comment = iree_const_byte_span_empty();
+  IREE_ASSERT_OK(loom_bytecode_cursor_read_span(
+      &cursor, (iree_host_size_t)op_comment_length, &op_comment));
+  ASSERT_EQ(op_comment.data[0], ' ');
+  EXPECT_EQ(
+      memcmp(op_comment.data + 1, op_comments[0].data, op_comments[0].size), 0);
 
   loom_module_free(module);
 }

--- a/loom/src/loom/format/text/parser/parser.c
+++ b/loom/src/loom/format/text/parser/parser.c
@@ -1028,6 +1028,17 @@ iree_status_t loom_parse_region_with_syntax(
 //===----------------------------------------------------------------------===//
 
 static iree_status_t loom_parse_module_body(loom_parser_t* parser) {
+  // A separated line-1 comment block belongs to the source file rather than
+  // the first alias or operation. Peeking performs the initial trivia scan;
+  // taking the file header leaves any adjacent declaration comments pending.
+  (void)loom_tokenizer_peek(&parser->tokenizer);
+  const iree_string_view_t* file_header = NULL;
+  iree_host_size_t file_header_line_count = 0;
+  loom_tokenizer_take_file_header(&parser->tokenizer, &file_header,
+                                  &file_header_line_count);
+  IREE_RETURN_IF_ERROR(loom_module_attach_file_header(
+      parser->module, file_header, file_header_line_count));
+
   while (!loom_tokenizer_at(&parser->tokenizer, LOOM_TOKEN_EOF)) {
     if (loom_parser_at_error_limit(parser)) {
       break;

--- a/loom/src/loom/format/text/parser/parser_test.cc
+++ b/loom/src/loom/format/text/parser/parser_test.cc
@@ -686,6 +686,63 @@ TEST_F(ParserTest, OperationAndBlockCommentsRoundTrip) {
             "}\n");
 }
 
+TEST_F(ParserTest, FileHeaderRoundTrip) {
+  const char* source =
+      "// File-level overview.\n"
+      "//  Indented header detail.\n"
+      "\n"
+      "// Declaration documentation.\n"
+      "test.decl @documented()\n";
+  loom_module_t* module = ParseOk(source);
+  iree_host_size_t line_count = 0;
+  const iree_string_view_t* file_header =
+      loom_module_file_header(module, &line_count);
+  ASSERT_EQ(line_count, 2u);
+  EXPECT_TRUE(
+      iree_string_view_equal(file_header[0], IREE_SV("File-level overview.")));
+  EXPECT_TRUE(iree_string_view_equal(file_header[1],
+                                     IREE_SV(" Indented header detail.")));
+  loom_op_t* declaration = GetFirstFunctionOp(module);
+  ASSERT_NE(declaration, nullptr);
+  const iree_string_view_t* declaration_comments =
+      loom_module_op_comments(module, declaration, &line_count);
+  ASSERT_EQ(line_count, 1u);
+  EXPECT_TRUE(iree_string_view_equal(declaration_comments[0],
+                                     IREE_SV("Declaration documentation.")));
+  EXPECT_FALSE(
+      iree_any_bit_set(declaration->flags, LOOM_OP_FLAG_LEADING_BLANK_LINE));
+  loom_module_free(module);
+
+  EXPECT_EQ(RoundTrip(source), source);
+}
+
+TEST_F(ParserTest, FileHeaderPrecedesEncodingAliases) {
+  std::string text = RoundTrip(
+      "// File-level overview.\n"
+      "\n"
+      "#enc = #quantization<bits=8>\n"
+      "test.decl @uses_alias(%arg0: tile<4xf32, #enc>)\n");
+  EXPECT_EQ(text,
+            "// File-level overview.\n"
+            "\n"
+            "#enc = #quantization<bits=8>\n"
+            "test.decl @uses_alias(%arg0: tile<4xf32, #enc>)\n");
+}
+
+TEST_F(ParserTest, FileHeaderOnlyRoundTrip) {
+  EXPECT_EQ(RoundTrip("// File-level overview.\n"),
+            "// File-level overview.\n");
+}
+
+TEST_F(ParserTest, CanonicalizesCommentSeparatorSpace) {
+  EXPECT_EQ(RoundTrip("//documentation\n"
+                      "//  indented detail\n"
+                      "test.decl @documented()\n"),
+            "// documentation\n"
+            "//  indented detail\n"
+            "test.decl @documented()\n");
+}
+
 TEST_F(ParserTest, CanonicalizesVerticalSourceGrouping) {
   std::string text = RoundTrip(
       "test.func @grouped() {\n"

--- a/loom/src/loom/format/text/printer/context.c
+++ b/loom/src/loom/format/text/printer/context.c
@@ -108,7 +108,10 @@ static iree_status_t loom_print_leading_comments(
   for (iree_host_size_t i = 0; i < comment_count; ++i) {
     IREE_RETURN_IF_ERROR(loom_print_indent_at(ctx, indent));
     IREE_RETURN_IF_ERROR(loom_output_stream_write_cstring(ctx->stream, "//"));
-    IREE_RETURN_IF_ERROR(loom_output_stream_write(ctx->stream, comments[i]));
+    if (!iree_string_view_is_empty(comments[i])) {
+      IREE_RETURN_IF_ERROR(loom_output_stream_write_char(ctx->stream, ' '));
+      IREE_RETURN_IF_ERROR(loom_output_stream_write(ctx->stream, comments[i]));
+    }
     IREE_RETURN_IF_ERROR(loom_output_stream_write_char(ctx->stream, '\n'));
   }
   return iree_ok_status();

--- a/loom/src/loom/format/text/printer/printer.c
+++ b/loom/src/loom/format/text/printer/printer.c
@@ -9,6 +9,7 @@
 #include "loom/format/text/printer/atoms.h"
 #include "loom/format/text/printer/context.h"
 #include "loom/format/text/printer/regions.h"
+#include "loom/ir/module.h"
 
 static loom_print_context_t loom_print_context_make(
     const loom_module_t* module, loom_output_stream_t* stream,
@@ -21,6 +22,38 @@ static loom_print_context_t loom_print_context_make(
   context.flags = options ? options->flags : LOOM_TEXT_PRINT_DEFAULT;
   if (options) context.low_asm_environment = options->low_asm_environment;
   return context;
+}
+
+static bool loom_module_has_printable_content(const loom_module_t* module) {
+  for (uint16_t i = 0; i < module->encodings.count; ++i) {
+    if (module->encodings.entries[i].alias_id != LOOM_STRING_ID_INVALID) {
+      return true;
+    }
+  }
+  if (!module->body) return false;
+  for (uint16_t i = 0; i < module->body->block_count; ++i) {
+    const loom_block_t* block = loom_region_const_block(module->body, i);
+    if (block->label_id != LOOM_STRING_ID_INVALID || block->first_op) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static iree_status_t loom_print_file_header(const loom_module_t* module,
+                                            loom_output_stream_t* stream) {
+  iree_host_size_t line_count = 0;
+  const iree_string_view_t* lines =
+      loom_module_file_header(module, &line_count);
+  for (iree_host_size_t i = 0; i < line_count; ++i) {
+    IREE_RETURN_IF_ERROR(loom_output_stream_write_cstring(stream, "//"));
+    if (!iree_string_view_is_empty(lines[i])) {
+      IREE_RETURN_IF_ERROR(loom_output_stream_write_char(stream, ' '));
+      IREE_RETURN_IF_ERROR(loom_output_stream_write(stream, lines[i]));
+    }
+    IREE_RETURN_IF_ERROR(loom_output_stream_write_char(stream, '\n'));
+  }
+  return iree_ok_status();
 }
 
 iree_status_t loom_text_print_module(const loom_module_t* module,
@@ -42,7 +75,16 @@ iree_status_t loom_text_print_module_with_options(
   IREE_RETURN_IF_ERROR(loom_print_name_plan_initialize(module, &name_plan));
   loom_print_context_t ctx =
       loom_print_context_make(module, stream, options, &name_plan);
-  iree_status_t status = loom_print_encoding_aliases(&ctx, module);
+  iree_host_size_t file_header_line_count = 0;
+  (void)loom_module_file_header(module, &file_header_line_count);
+  iree_status_t status = loom_print_file_header(module, stream);
+  if (iree_status_is_ok(status) && file_header_line_count > 0 &&
+      loom_module_has_printable_content(module)) {
+    status = loom_output_stream_write_char(stream, '\n');
+  }
+  if (iree_status_is_ok(status)) {
+    status = loom_print_encoding_aliases(&ctx, module);
+  }
   if (iree_status_is_ok(status)) {
     status = loom_print_module_body(&ctx, module->body);
   }

--- a/loom/src/loom/format/text/printer/regions.c
+++ b/loom/src/loom/format/text/printer/regions.c
@@ -23,7 +23,10 @@ static iree_status_t loom_print_block_comments(loom_print_context_t* ctx,
   for (iree_host_size_t i = 0; i < comment_count; ++i) {
     IREE_RETURN_IF_ERROR(loom_print_indent_at(ctx, indent));
     IREE_RETURN_IF_ERROR(loom_output_stream_write_cstring(ctx->stream, "//"));
-    IREE_RETURN_IF_ERROR(loom_output_stream_write(ctx->stream, comments[i]));
+    if (!iree_string_view_is_empty(comments[i])) {
+      IREE_RETURN_IF_ERROR(loom_output_stream_write_char(ctx->stream, ' '));
+      IREE_RETURN_IF_ERROR(loom_output_stream_write(ctx->stream, comments[i]));
+    }
     IREE_RETURN_IF_ERROR(loom_output_stream_write_char(ctx->stream, '\n'));
   }
   return iree_ok_status();

--- a/loom/src/loom/format/text/tokenizer.c
+++ b/loom/src/loom/format/text/tokenizer.c
@@ -209,6 +209,8 @@ void loom_tokenizer_initialize(iree_string_view_t source,
   out_tokenizer->pending_comment_count = 0;
   out_tokenizer->pending_comment_capacity = 0;
   out_tokenizer->pending_comment_start_line = 0;
+  out_tokenizer->pending_comment_end_line = 0;
+  out_tokenizer->pending_file_header_line_count = 0;
   out_tokenizer->pending_leading_blank_line = false;
   out_tokenizer->status = iree_ok_status();
   out_tokenizer->consumed_end_line = 0;
@@ -286,6 +288,29 @@ iree_status_t loom_tokenizer_consume_status(loom_tokenizer_t* tokenizer) {
   return status;
 }
 
+void loom_tokenizer_take_file_header(loom_tokenizer_t* tokenizer,
+                                     const iree_string_view_t** out_lines,
+                                     iree_host_size_t* out_line_count) {
+  *out_lines = tokenizer->pending_comments;
+  *out_line_count = tokenizer->pending_file_header_line_count;
+  if (tokenizer->pending_file_header_line_count > 0 &&
+      tokenizer->pending_file_header_line_count ==
+          tokenizer->pending_comment_count) {
+    tokenizer->pending_comments = NULL;
+    tokenizer->pending_comment_count = 0;
+    tokenizer->pending_comment_capacity = 0;
+    tokenizer->pending_comment_start_line = 0;
+    tokenizer->pending_comment_end_line = 0;
+  } else if (tokenizer->pending_file_header_line_count > 0) {
+    tokenizer->pending_comments += tokenizer->pending_file_header_line_count;
+    tokenizer->pending_comment_count -=
+        tokenizer->pending_file_header_line_count;
+    tokenizer->pending_comment_capacity -=
+        tokenizer->pending_file_header_line_count;
+  }
+  tokenizer->pending_file_header_line_count = 0;
+}
+
 void loom_tokenizer_take_pending_comments(
     loom_tokenizer_t* tokenizer, const iree_string_view_t** out_comments,
     iree_host_size_t* out_comment_count, bool* out_leading_blank_line) {
@@ -298,12 +323,16 @@ void loom_tokenizer_take_pending_comments(
   }
   tokenizer->pending_comment_count = 0;
   tokenizer->pending_comment_start_line = 0;
+  tokenizer->pending_comment_end_line = 0;
+  tokenizer->pending_file_header_line_count = 0;
   tokenizer->pending_leading_blank_line = false;
 }
 
 void loom_tokenizer_discard_pending_comments(loom_tokenizer_t* tokenizer) {
   tokenizer->pending_comment_count = 0;
   tokenizer->pending_comment_start_line = 0;
+  tokenizer->pending_comment_end_line = 0;
+  tokenizer->pending_file_header_line_count = 0;
   tokenizer->pending_leading_blank_line = false;
 }
 
@@ -322,6 +351,9 @@ static iree_status_t loom_tokenizer_append_pending_comment(
         t->scratch_arena, t->pending_comment_count, /*minimum_capacity=*/8,
         sizeof(iree_string_view_t), &t->pending_comment_capacity,
         (void**)&t->pending_comments));
+  }
+  if (iree_string_view_starts_with(comment, IREE_SV(" "))) {
+    comment = iree_string_view_remove_prefix(comment, 1);
   }
   t->pending_comments[t->pending_comment_count++] = comment;
   return iree_ok_status();
@@ -342,7 +374,13 @@ static iree_status_t loom_tokenizer_skip_whitespace(loom_tokenizer_t* t) {
       // Line comment: skip to end of line with UTF-8-aware column tracking.
       if (t->pending_comment_count == 0) {
         t->pending_comment_start_line = t->line;
+      } else if (t->pending_comment_start_line == 1 &&
+                 t->pending_file_header_line_count == 0 &&
+                 (uint64_t)t->line >
+                     (uint64_t)t->pending_comment_end_line + 1) {
+        t->pending_file_header_line_count = t->pending_comment_count;
       }
+      t->pending_comment_end_line = t->line;
       iree_host_size_t comment_start = t->position + 2;
       t->position += 2;
       t->column += 2;
@@ -1045,6 +1083,12 @@ static iree_status_t loom_tokenizer_scan(loom_tokenizer_t* t,
 
   const uint32_t source_start_line =
       t->pending_comment_count > 0 ? t->pending_comment_start_line : t->line;
+  if (t->pending_comment_start_line == 1 &&
+      t->pending_file_header_line_count == 0 &&
+      (t->position == t->source.size ||
+       (uint64_t)t->line > (uint64_t)t->pending_comment_end_line + 1)) {
+    t->pending_file_header_line_count = t->pending_comment_count;
+  }
   t->pending_leading_blank_line =
       t->consumed_end_line != 0 &&
       (uint64_t)source_start_line > (uint64_t)t->consumed_end_line + 1;

--- a/loom/src/loom/format/text/tokenizer.h
+++ b/loom/src/loom/format/text/tokenizer.h
@@ -147,6 +147,10 @@ typedef struct loom_tokenizer_t {
   iree_host_size_t pending_comment_capacity;
   // Source line containing the first pending comment, or zero when none.
   uint32_t pending_comment_start_line;
+  // Source line containing the most recent pending comment, or zero when none.
+  uint32_t pending_comment_end_line;
+  // Number of initial line-1 comment lines forming a separated file header.
+  iree_host_size_t pending_file_header_line_count;
   // True when an empty source line precedes the pending comments or token.
   bool pending_leading_blank_line;
   iree_status_t status;
@@ -180,12 +184,24 @@ void loom_tokenizer_deinitialize(loom_tokenizer_t* tokenizer);
 // tokens plus |tokenizer->error| metadata.
 iree_status_t loom_tokenizer_consume_status(loom_tokenizer_t* tokenizer);
 
+// Takes a file header from pending source trivia. A file header is the
+// contiguous comment block beginning on source line 1 when an empty line
+// separates it from following source, or when no source follows it. Adjacent
+// line-1 comments remain pending for the first operation. The returned line
+// array is tokenizer-scratch storage; payloads are normalized slices into the
+// original source buffer that omit // and its conventional single separator
+// space.
+void loom_tokenizer_take_file_header(loom_tokenizer_t* tokenizer,
+                                     const iree_string_view_t** out_lines,
+                                     iree_host_size_t* out_line_count);
+
 // Returns pending source trivia collected while scanning leading whitespace
 // and clears it. |out_leading_blank_line| is true when at least one empty line
 // separates the previously consumed token from the first pending comment, or
 // from the lookahead token when there are no comments. File-leading whitespace
 // does not set it. The returned comment array is tokenizer-scratch storage;
-// payloads are slices into the original source buffer.
+// payloads are normalized slices into the original source buffer that omit //
+// and its conventional single separator space.
 void loom_tokenizer_take_pending_comments(
     loom_tokenizer_t* tokenizer, const iree_string_view_t** out_comments,
     iree_host_size_t* out_comment_count, bool* out_leading_blank_line);

--- a/loom/src/loom/format/text/tokenizer_test.cc
+++ b/loom/src/loom/format/text/tokenizer_test.cc
@@ -537,12 +537,52 @@ TEST(Tokenizer, CollectsPendingCommentsExactly) {
                                        &leading_blank_line);
   ASSERT_EQ(comment_count, 2u);
   EXPECT_FALSE(leading_blank_line);
-  EXPECT_TRUE(iree_string_view_equal(comments[0], IREE_SV(" first")));
+  EXPECT_TRUE(iree_string_view_equal(comments[0], IREE_SV("first")));
   EXPECT_TRUE(iree_string_view_equal(comments[1], IREE_SV("second")));
   loom_tokenizer_take_pending_comments(t.get(), &comments, &comment_count,
                                        &leading_blank_line);
   EXPECT_EQ(comment_count, 0u);
   EXPECT_FALSE(leading_blank_line);
+}
+
+TEST(Tokenizer, DistinguishesFileHeaderFromOperationComments) {
+  ScopedTokenizer adjacent("// declaration\n99");
+  EXPECT_EQ(adjacent.peek().kind, LOOM_TOKEN_INTEGER);
+  const iree_string_view_t* file_header = NULL;
+  iree_host_size_t file_header_line_count = 0;
+  loom_tokenizer_take_file_header(adjacent.get(), &file_header,
+                                  &file_header_line_count);
+  EXPECT_EQ(file_header_line_count, 0u);
+  const iree_string_view_t* comments = NULL;
+  iree_host_size_t comment_count = 0;
+  bool leading_blank_line = true;
+  loom_tokenizer_take_pending_comments(adjacent.get(), &comments,
+                                       &comment_count, &leading_blank_line);
+  EXPECT_EQ(comment_count, 1u);
+  EXPECT_FALSE(leading_blank_line);
+
+  ScopedTokenizer separated(
+      "// file header\n"
+      "\n"
+      "// declaration\n"
+      "99");
+  EXPECT_EQ(separated.peek().kind, LOOM_TOKEN_INTEGER);
+  loom_tokenizer_take_file_header(separated.get(), &file_header,
+                                  &file_header_line_count);
+  ASSERT_EQ(file_header_line_count, 1u);
+  EXPECT_TRUE(iree_string_view_equal(file_header[0], IREE_SV("file header")));
+  loom_tokenizer_take_pending_comments(separated.get(), &comments,
+                                       &comment_count, &leading_blank_line);
+  ASSERT_EQ(comment_count, 1u);
+  EXPECT_FALSE(leading_blank_line);
+  EXPECT_TRUE(iree_string_view_equal(comments[0], IREE_SV("declaration")));
+
+  ScopedTokenizer header_only("// file header");
+  EXPECT_EQ(header_only.peek().kind, LOOM_TOKEN_EOF);
+  loom_tokenizer_take_file_header(header_only.get(), &file_header,
+                                  &file_header_line_count);
+  ASSERT_EQ(file_header_line_count, 1u);
+  EXPECT_TRUE(iree_string_view_equal(file_header[0], IREE_SV("file header")));
 }
 
 TEST(Tokenizer, DetectsLeadingBlankLineBeforeCommentsOrToken) {
@@ -572,7 +612,7 @@ TEST(Tokenizer, DetectsLeadingBlankLineBeforeCommentsOrToken) {
                                        &leading_blank_line);
   ASSERT_EQ(comment_count, 1u);
   EXPECT_TRUE(leading_blank_line);
-  EXPECT_TRUE(iree_string_view_equal(comments[0], IREE_SV(" grouped")));
+  EXPECT_TRUE(iree_string_view_equal(comments[0], IREE_SV("grouped")));
 
   EXPECT_EQ(t.next().kind, LOOM_TOKEN_INTEGER);
   EXPECT_EQ(t.peek().line, 8u);

--- a/loom/src/loom/ir/ir.h
+++ b/loom/src/loom/ir/ir.h
@@ -2201,11 +2201,12 @@ typedef struct loom_type_use_table_t {
 typedef enum loom_comment_owner_kind_e {
   LOOM_COMMENT_OWNER_OP = 0,
   LOOM_COMMENT_OWNER_BLOCK = 1,
+  LOOM_COMMENT_OWNER_MODULE = 2,
 } loom_comment_owner_kind_t;
 
-// Leading comments attached to one operation or block label.
+// Source comments attached to the file, an operation, or a block label.
 typedef struct loom_comment_attachment_t {
-  // Operation or block pointer that owns the leading comments.
+  // IR object pointer that owns the source comments.
   const void* owner;
   // Kind tag describing the pointer stored in owner.
   loom_comment_owner_kind_t owner_kind;
@@ -2213,7 +2214,7 @@ typedef struct loom_comment_attachment_t {
   uint16_t reserved;
   // Number of line comments stored in comments.
   uint16_t comment_count;
-  // Module-arena-owned post-// comment payloads in source order.
+  // Module-owned comment payloads without // or its separator space.
   iree_string_view_t* comments;
 } loom_comment_attachment_t;
 
@@ -2318,7 +2319,7 @@ typedef struct loom_module_t {
   // reference LOOM_LOCATION_UNKNOWN (0).
   loom_location_table_t locations;
 
-  // Source comments attached to operations and explicit block labels.
+  // Source comments attached to this file, operations, and block labels.
   loom_comment_table_t comments;
 
   // Module body: a region with a single entry block. All top-level symbol ops

--- a/loom/src/loom/ir/module.c
+++ b/loom/src/loom/ir/module.c
@@ -1679,6 +1679,13 @@ static iree_status_t loom_module_attach_comments(
   return iree_ok_status();
 }
 
+iree_status_t loom_module_attach_file_header(loom_module_t* module,
+                                             const iree_string_view_t* lines,
+                                             iree_host_size_t line_count) {
+  return loom_module_attach_comments(module, LOOM_COMMENT_OWNER_MODULE, module,
+                                     lines, line_count);
+}
+
 iree_status_t loom_module_attach_op_comments(loom_module_t* module,
                                              const loom_op_t* op,
                                              const iree_string_view_t* comments,
@@ -1704,6 +1711,12 @@ static const iree_string_view_t* loom_module_comments(
   if (!attachment) return NULL;
   if (out_comment_count) *out_comment_count = attachment->comment_count;
   return attachment->comments;
+}
+
+const iree_string_view_t* loom_module_file_header(
+    const loom_module_t* module, iree_host_size_t* out_line_count) {
+  return loom_module_comments(module, LOOM_COMMENT_OWNER_MODULE, module,
+                              out_line_count);
 }
 
 const iree_string_view_t* loom_module_op_comments(

--- a/loom/src/loom/ir/module.h
+++ b/loom/src/loom/ir/module.h
@@ -254,18 +254,32 @@ iree_status_t loom_module_register_source(loom_module_t* module,
                                           iree_string_view_t name,
                                           loom_source_id_t* out_source_id);
 
-// Attaches leading source comments to |op|. Comment payloads are the exact
-// source bytes after each leading // marker and are copied into |module|.
+// Attaches the file header to |module|. Each line omits the leading // and its
+// conventional single separating space; additional indentation remains part
+// of the payload. The payloads are copied into |module|. A module has at most
+// one file header attachment.
+iree_status_t loom_module_attach_file_header(loom_module_t* module,
+                                             const iree_string_view_t* lines,
+                                             iree_host_size_t line_count);
+
+// Attaches leading source comments to |op|. Lines use the same normalized
+// payload convention as loom_module_attach_file_header.
 iree_status_t loom_module_attach_op_comments(loom_module_t* module,
                                              const loom_op_t* op,
                                              const iree_string_view_t* comments,
                                              iree_host_size_t comment_count);
 
-// Attaches leading source comments to |block|. Only explicit block labels need
-// comments; unlabeled entry blocks leave comments attached to the following op.
+// Attaches leading source comments to |block| using normalized line payloads.
+// Only explicit block labels need comments; unlabeled entry blocks leave
+// comments attached to the following op.
 iree_status_t loom_module_attach_block_comments(
     loom_module_t* module, const loom_block_t* block,
     const iree_string_view_t* comments, iree_host_size_t comment_count);
+
+// Looks up the file header attached to |module|. Returns NULL when absent and
+// sets |out_line_count| to zero.
+const iree_string_view_t* loom_module_file_header(
+    const loom_module_t* module, iree_host_size_t* out_line_count);
 
 // Looks up leading source comments attached to |op|. Returns NULL when |op| has
 // no comments and sets |out_comment_count| to zero.

--- a/loom/src/loom/rewrite/materialize_test.cc
+++ b/loom/src/loom/rewrite/materialize_test.cc
@@ -342,7 +342,7 @@ TEST_F(MaterializeTest, ClonesOperationAndBlockSourcePresentation) {
   loom_block_t* source_block = loom_region_entry_block(source_region);
   source_block->flags |= LOOM_BLOCK_FLAG_LEADING_BLANK_LINE;
   const iree_string_view_t block_comments[] = {
-      IREE_SV(" block heading"),
+      IREE_SV("block heading"),
   };
   IREE_ASSERT_OK(loom_module_attach_block_comments(
       source_, source_block, block_comments, IREE_ARRAYSIZE(block_comments)));
@@ -357,8 +357,8 @@ TEST_F(MaterializeTest, ClonesOperationAndBlockSourcePresentation) {
                                LOOM_LOCATION_UNKNOWN, &source_op));
   source_op->flags |= LOOM_OP_FLAG_LEADING_BLANK_LINE;
   const iree_string_view_t op_comments[] = {
-      IREE_SV(" operation heading"),
-      IREE_SV(" operation detail"),
+      IREE_SV("operation heading"),
+      IREE_SV("operation detail"),
   };
   IREE_ASSERT_OK(loom_module_attach_op_comments(source_, source_op, op_comments,
                                                 IREE_ARRAYSIZE(op_comments)));


### PR DESCRIPTION
Preserves a separated line-one comment block as module-owned file-header presentation instead of attaching it to the first declaration. Comments adjacent to the first operation remain declaration documentation, while a comment-only source retains its header through formatting.

## Comment Representation

Source comments now have one canonical in-memory spelling across C and Python: payloads omit the `//` marker and its conventional single separator space while retaining any additional indentation. Text tokenizers establish that representation and printers reconstruct canonical comment syntax, so `//documentation` formats to `// documentation` while `//  indented` retains its intentional extra space.

The file header is another attachment in the module comment table, owned by the module rather than a synthetic operation. This keeps file presentation distinct from operation and block documentation and avoids making the first declaration responsible for source-wide metadata.

## Bytecode Preservation

An optional `SOURCE_TRIVIA` section carries module-owned file-header lines through `.loombc` in both implementations. Existing operation and block source-trivia wire spelling remains stable: writers retain the conventional post-marker space and readers normalize it at the format boundary. Readers that do not recognize the optional section can skip it without rejecting the module.

## Reviewer Notes

The highest-value review surfaces are the tokenizer split between a separated file header and adjacent declaration comments, the module-owned attachment lifetime, and C/Python agreement on text and bytecode normalization.
