### PR TITLE
[Loom] Benchmark disjoint cluster-async compilation

### DIFF
--- a/loom/binding/c/benchmark/target/amdgpu/compile_throughput_benchmark.cc
+++ b/loom/binding/c/benchmark/target/amdgpu/compile_throughput_benchmark.cc
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <initializer_list>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -23,6 +24,7 @@ namespace {
 using loomc::bench::CloneModule;
 using loomc::bench::CompileScenario;
 using loomc::bench::CreateBenchmarkKernelSource;
+using loomc::bench::CreateTextSource;
 using loomc::bench::CreateWorkspace;
 using loomc::bench::DeserializeSource;
 using loomc::bench::loom_allocator;
@@ -47,25 +49,16 @@ struct AmdgpuBenchmarkTarget {
 constexpr AmdgpuBenchmarkTarget kGfx1100Target = {"gfx1100"};
 constexpr AmdgpuBenchmarkTarget kGfx942Target = {"gfx942"};
 constexpr AmdgpuBenchmarkTarget kGfx1200Target = {"gfx1200"};
+constexpr AmdgpuBenchmarkTarget kGfx1250Target = {"gfx1250"};
 
-class AmdgpuI32ChainScenario final : public TargetCompileScenario {
+class AmdgpuTargetCompileScenario : public TargetCompileScenario {
  public:
-  AmdgpuI32ChainScenario(
-      iree_host_size_t job_count,
-      std::initializer_list<iree_host_size_t> operation_counts,
+  explicit AmdgpuTargetCompileScenario(
       AmdgpuBenchmarkTarget target, iree_host_size_t workspace_block_size = 0)
-      : TargetCompileScenario(workspace_block_size),
-        job_count_(std::max<iree_host_size_t>(job_count, 1)),
-        target_(target) {
-    operation_counts_.reserve(operation_counts.size());
-    for (iree_host_size_t operation_count : operation_counts) {
-      operation_count = std::max<iree_host_size_t>(operation_count, 1);
-      operation_counts_.push_back(
-          {operation_count, std::to_string(operation_count)});
-    }
-  }
+      : TargetCompileScenario(workspace_block_size), target_(target) {}
 
-  iree_status_t SetUp(iree_host_size_t worker_count) override {
+ protected:
+  iree_status_t SetUpAmdgpuTarget(iree_host_size_t worker_count) {
     TargetEnvironmentPtr target_environment;
     loomc_target_environment_t* raw_target_environment = nullptr;
     IREE_RETURN_IF_ERROR(to_iree_status(loomc_target_environment_create_amdgpu(
@@ -90,9 +83,80 @@ class AmdgpuI32ChainScenario final : public TargetCompileScenario {
         &raw_profile)));
     TargetProfilePtr target_profile(raw_profile);
 
-    IREE_RETURN_IF_ERROR(SetUpTarget(
+    return SetUpTarget(
         worker_count, std::move(target_environment), std::move(target_profile),
-        loomc_make_cstring_view("benchmark-amdgpu-prepared-low")));
+        loomc_make_cstring_view("benchmark-amdgpu-prepared-low"));
+  }
+
+  iree_status_t EmitAmdgpuArtifact(WorkspacePtr& workspace, ModulePtr& module,
+                                   loomc_string_view_t identifier) {
+    loomc_amdgpu_emit_options_t amdgpu_options = {
+        /*.type=*/LOOMC_STRUCTURE_TYPE_AMDGPU_EMIT_OPTIONS,
+        /*.structure_size=*/sizeof(amdgpu_options),
+        /*.next=*/nullptr,
+        /*.runtime_globals=*/LOOMC_AMDGPU_RUNTIME_GLOBAL_NONE,
+    };
+    loomc_emit_options_t emit_options = {
+        /*.type=*/LOOMC_STRUCTURE_TYPE_EMIT_OPTIONS,
+        /*.structure_size=*/sizeof(emit_options),
+        /*.next=*/&amdgpu_options,
+        /*.artifact_format=*/
+        loomc_make_cstring_view(LOOMC_ARTIFACT_FORMAT_AMDGPU_HSACO),
+        /*.identifier=*/identifier,
+        /*.artifact_flags=*/LOOMC_EMIT_ARTIFACT_FLAG_PRIMARY,
+    };
+
+    loomc_result_t* raw_result = nullptr;
+    iree_status_t status = to_iree_status(
+        loomc_emit_module(target_environment(), workspace.get(), module.get(),
+                          &emit_options, loom_allocator(), &raw_result));
+    ResultPtr result(raw_result);
+    IREE_RETURN_IF_ERROR(status);
+    IREE_RETURN_IF_ERROR(
+        RequireSucceededResult(result.get(), "AMDGPU emission"));
+
+    constexpr uint8_t kElfMagic[] = {0x7F, 'E', 'L', 'F'};
+    int64_t artifact_bytes = 0;
+    IREE_RETURN_IF_ERROR(ValidateArtifact(
+        result.get(), LOOMC_ARTIFACT_KIND_EXECUTABLE,
+        loomc_make_cstring_view(LOOMC_ARTIFACT_FORMAT_AMDGPU_HSACO),
+        sizeof(kElfMagic), "AMDGPU HSACO executable", &artifact_bytes));
+    const loomc_artifact_t* artifact = loomc::bench::FindArtifact(
+        result.get(), LOOMC_ARTIFACT_KIND_EXECUTABLE,
+        loomc_make_cstring_view(LOOMC_ARTIFACT_FORMAT_AMDGPU_HSACO));
+    if (std::memcmp(artifact->contents.data, kElfMagic, sizeof(kElfMagic)) !=
+        0) {
+      return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                              "AMDGPU executable is not an ELF image");
+    }
+
+    RecordArtifactBytes(artifact_bytes);
+    return iree_ok_status();
+  }
+
+ private:
+  // Immutable target row selected by the benchmark registration.
+  AmdgpuBenchmarkTarget target_;
+};
+
+class AmdgpuI32ChainScenario final : public AmdgpuTargetCompileScenario {
+ public:
+  AmdgpuI32ChainScenario(
+      iree_host_size_t job_count,
+      std::initializer_list<iree_host_size_t> operation_counts,
+      AmdgpuBenchmarkTarget target, iree_host_size_t workspace_block_size = 0)
+      : AmdgpuTargetCompileScenario(target, workspace_block_size),
+        job_count_(std::max<iree_host_size_t>(job_count, 1)) {
+    operation_counts_.reserve(operation_counts.size());
+    for (iree_host_size_t operation_count : operation_counts) {
+      operation_count = std::max<iree_host_size_t>(operation_count, 1);
+      operation_counts_.push_back(
+          {operation_count, std::to_string(operation_count)});
+    }
+  }
+
+  iree_status_t SetUp(iree_host_size_t worker_count) override {
+    IREE_RETURN_IF_ERROR(SetUpAmdgpuTarget(worker_count));
     IREE_RETURN_IF_ERROR(CreateBenchmarkKernelSource(
         loomc_make_cstring_view("i32_memory_chain.loom"), &source_));
     IREE_RETURN_IF_ERROR(
@@ -144,7 +208,8 @@ class AmdgpuI32ChainScenario final : public TargetCompileScenario {
     IREE_RETURN_IF_ERROR(CompileModuleToPreparedLow(
         workspace, module, loomc_make_cstring_view("i32_memory_chain"),
         loomc_make_cstring_view("amdgpu_i32_chain"), config_options));
-    return EmitAmdgpuArtifact(workspace, module);
+    return EmitAmdgpuArtifact(
+        workspace, module, loomc_make_cstring_view("i32_memory_chain.hsaco"));
   }
 
   void SetExtraCounters(::benchmark::State& state) const override {
@@ -167,61 +232,138 @@ class AmdgpuI32ChainScenario final : public TargetCompileScenario {
     std::string text;
   };
 
-  iree_status_t EmitAmdgpuArtifact(WorkspacePtr& workspace, ModulePtr& module) {
-    loomc_amdgpu_emit_options_t amdgpu_options = {
-        /*.type=*/LOOMC_STRUCTURE_TYPE_AMDGPU_EMIT_OPTIONS,
-        /*.structure_size=*/sizeof(amdgpu_options),
-        /*.next=*/nullptr,
-        /*.runtime_globals=*/LOOMC_AMDGPU_RUNTIME_GLOBAL_NONE,
-    };
-    loomc_emit_options_t emit_options = {
-        /*.type=*/LOOMC_STRUCTURE_TYPE_EMIT_OPTIONS,
-        /*.structure_size=*/sizeof(emit_options),
-        /*.next=*/&amdgpu_options,
-        /*.artifact_format=*/
-        loomc_make_cstring_view(LOOMC_ARTIFACT_FORMAT_AMDGPU_HSACO),
-        /*.identifier=*/loomc_make_cstring_view("i32_memory_chain.hsaco"),
-        /*.artifact_flags=*/LOOMC_EMIT_ARTIFACT_FLAG_PRIMARY,
-    };
-
-    loomc_result_t* raw_result = nullptr;
-    iree_status_t status = to_iree_status(
-        loomc_emit_module(target_environment(), workspace.get(), module.get(),
-                          &emit_options, loom_allocator(), &raw_result));
-    ResultPtr result(raw_result);
-    IREE_RETURN_IF_ERROR(status);
-    IREE_RETURN_IF_ERROR(
-        RequireSucceededResult(result.get(), "AMDGPU emission"));
-
-    constexpr uint8_t kElfMagic[] = {0x7F, 'E', 'L', 'F'};
-    int64_t artifact_bytes = 0;
-    IREE_RETURN_IF_ERROR(ValidateArtifact(
-        result.get(), LOOMC_ARTIFACT_KIND_EXECUTABLE,
-        loomc_make_cstring_view(LOOMC_ARTIFACT_FORMAT_AMDGPU_HSACO),
-        sizeof(kElfMagic), "AMDGPU HSACO executable", &artifact_bytes));
-    const loomc_artifact_t* artifact = loomc::bench::FindArtifact(
-        result.get(), LOOMC_ARTIFACT_KIND_EXECUTABLE,
-        loomc_make_cstring_view(LOOMC_ARTIFACT_FORMAT_AMDGPU_HSACO));
-    if (std::memcmp(artifact->contents.data, kElfMagic, sizeof(kElfMagic)) !=
-        0) {
-      return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                              "AMDGPU executable is not an ELF image");
-    }
-
-    RecordArtifactBytes(artifact_bytes);
-    return iree_ok_status();
-  }
-
   // Number of kernels compiled by each benchmark iteration.
   iree_host_size_t job_count_ = 0;
 
   // Cyclic sequence of arithmetic-chain sizes compiled by each iteration.
   std::vector<OperationCount> operation_counts_;
 
-  // Immutable target row selected by this benchmark registration.
-  AmdgpuBenchmarkTarget target_;
-
   // Compact targetless source shared by all invocations.
+  SourcePtr source_;
+
+  // Setup-only workspace retaining the parsed template module.
+  WorkspacePtr template_workspace_;
+
+  // Immutable parsed template cloned into worker workspaces.
+  ModulePtr template_module_;
+};
+
+static std::string BuildAmdgpuClusterAsyncDisjointSource(
+    iree_host_size_t transfer_count) {
+  constexpr uint64_t kPacketByteCount = 16;
+  constexpr uint64_t kWorkgroupSize = 64;
+  const uint64_t lane_stride = transfer_count * kPacketByteCount;
+  const uint64_t storage_byte_count = kWorkgroupSize * lane_stride;
+
+  std::ostringstream source;
+  source << R"(
+kernel.def export("cluster_async_disjoint") @cluster_async_disjoint() {
+  %one = index.constant 1 : index
+  %two = index.constant 2 : index
+  %workgroup_size = index.constant 64 : index
+  kernel.launch.config workgroups(%one, %two, %one) workgroup_size(%workgroup_size, %one, %one) cluster_size(%one, %two, %one) : index
+} launch(%input: buffer) {
+  %zero = index.constant 0 : offset
+  %lane_stride = index.constant )"
+         << lane_stride << R"( : index
+  %storage_bytes = index.constant )"
+         << storage_byte_count << R"( : offset
+  %participants = scalar.constant 3 : i32
+  %lane = kernel.workitem.id<x> : index
+  %lane_base = index.mul %lane, %lane_stride : index
+  %global = buffer.assume.memory_space<global> %input : buffer
+  %source = buffer.view %global[%zero] : buffer -> view<16xi8>
+  %scratch = buffer.alloca<workgroup> align(16) %storage_bytes : buffer
+)";
+
+  for (iree_host_size_t i = 0; i < transfer_count; ++i) {
+    source << "  %slot" << i << " = index.constant " << i * kPacketByteCount
+           << " : index\n"
+           << "  %dest_index" << i << " = index.add %lane_base, %slot" << i
+           << " : index\n"
+           << "  %dest_offset" << i << " = index.cast %dest_index" << i
+           << " : index to offset\n"
+           << "  %dest" << i << " = buffer.view %scratch[%dest_offset" << i
+           << "] : buffer -> view<16xi8>\n";
+  }
+  for (iree_host_size_t i = 0; i < transfer_count; ++i) {
+    source << "  %copy" << i
+           << " = kernel.async.cluster.gather %source to %dest" << i
+           << " using %participants {cache_scope = device, cache_temporal = "
+              "regular} : view<16xi8> to view<16xi8>, i32 -> "
+              "kernel.async.token\n";
+  }
+
+  source << "  %group = kernel.async.group ";
+  for (iree_host_size_t i = 0; i < transfer_count; ++i) {
+    if (i != 0) source << ", ";
+    source << "%copy" << i;
+  }
+  source << " : ";
+  for (iree_host_size_t i = 0; i < transfer_count; ++i) {
+    if (i != 0) source << ", ";
+    source << "kernel.async.token";
+  }
+  source << R"( -> kernel.async.group
+  kernel.async.wait %group {newer_groups = 0} : kernel.async.group
+  kernel.return
+}
+)";
+  return source.str();
+}
+
+class AmdgpuClusterAsyncDisjointScenario final
+    : public AmdgpuTargetCompileScenario {
+ public:
+  AmdgpuClusterAsyncDisjointScenario(iree_host_size_t job_count,
+                                     iree_host_size_t transfer_count,
+                                     AmdgpuBenchmarkTarget target)
+      : AmdgpuTargetCompileScenario(target),
+        job_count_(std::max<iree_host_size_t>(job_count, 1)),
+        transfer_count_(std::max<iree_host_size_t>(transfer_count, 1)) {}
+
+  iree_status_t SetUp(iree_host_size_t worker_count) override {
+    IREE_RETURN_IF_ERROR(SetUpAmdgpuTarget(worker_count));
+    IREE_RETURN_IF_ERROR(CreateTextSource(
+        "cluster_async_disjoint.loom",
+        BuildAmdgpuClusterAsyncDisjointSource(transfer_count_), &source_));
+    IREE_RETURN_IF_ERROR(
+        CreateWorkspace(/*block_size=*/0, &template_workspace_));
+    return DeserializeSource(context_.get(), template_workspace_.get(),
+                             source_.get(), &template_module_);
+  }
+
+  iree_host_size_t job_count() const override { return job_count_; }
+
+  iree_status_t RunJob(iree_host_size_t worker_ordinal,
+                       iree_host_size_t job_ordinal) override {
+    (void)job_ordinal;
+    WorkspacePtr& workspace = workspace_at(worker_ordinal);
+    ModulePtr module;
+    IREE_RETURN_IF_ERROR(
+        CloneModule(template_module_.get(), workspace.get(), &module));
+    const loomc_config_options_t config_options = {};
+    IREE_RETURN_IF_ERROR(CompileModuleToPreparedLow(
+        workspace, module, loomc_make_cstring_view("cluster_async_disjoint"),
+        loomc_make_cstring_view("amdgpu_cluster_async_disjoint"),
+        config_options));
+    return EmitAmdgpuArtifact(
+        workspace, module,
+        loomc_make_cstring_view("cluster_async_disjoint.hsaco"));
+  }
+
+  void SetExtraCounters(::benchmark::State& state) const override {
+    state.counters["transfer_count"] = (double)transfer_count_;
+  }
+
+ private:
+  // Number of kernels compiled by each benchmark iteration.
+  iree_host_size_t job_count_ = 0;
+
+  // Number of pairwise-disjoint cluster transfers in each kernel.
+  iree_host_size_t transfer_count_ = 0;
+
+  // Generated targetless source shared by all invocations.
   SourcePtr source_;
 
   // Setup-only workspace retaining the parsed template module.
@@ -259,6 +401,15 @@ static std::unique_ptr<CompileScenario> CreateAmdgpuI32ChainWorkspaceScenario(
       *target, (iree_host_size_t)state.range(3));
 }
 
+static std::unique_ptr<CompileScenario>
+CreateAmdgpuClusterAsyncDisjointScenario(const ::benchmark::State& state,
+                                         const void* user_data) {
+  const auto* target = static_cast<const AmdgpuBenchmarkTarget*>(user_data);
+  return std::make_unique<AmdgpuClusterAsyncDisjointScenario>(
+      (iree_host_size_t)state.range(1), (iree_host_size_t)state.range(2),
+      *target);
+}
+
 static void BM_AmdgpuI32ChainSmoke(::benchmark::State& state,
                                    const AmdgpuBenchmarkTarget* target) {
   RunCompileBenchmarkDirect(state, CreateAmdgpuI32ChainScenario, target);
@@ -271,6 +422,16 @@ BENCHMARK_CAPTURE(BM_AmdgpuI32ChainSmoke, Gfx942, &kGfx942Target)
     ->UseRealTime();
 BENCHMARK_CAPTURE(BM_AmdgpuI32ChainSmoke, Gfx1200, &kGfx1200Target)
     ->Args({1, 1, 16})
+    ->UseRealTime();
+
+static void BM_AmdgpuClusterAsyncDisjointSmoke(
+    ::benchmark::State& state, const AmdgpuBenchmarkTarget* target) {
+  RunCompileBenchmarkDirect(state, CreateAmdgpuClusterAsyncDisjointScenario,
+                            target);
+}
+BENCHMARK_CAPTURE(BM_AmdgpuClusterAsyncDisjointSmoke, Gfx1250, &kGfx1250Target)
+    ->Args({1, 1, 1})
+    ->Args({1, 1, 4})
     ->UseRealTime();
 
 static void BM_AmdgpuI32ChainCold(::benchmark::State& state,
@@ -351,5 +512,29 @@ LOOM_BENCHMARK_AMDGPU_I32_CHAIN(Gfx942, &kGfx942Target);
 LOOM_BENCHMARK_AMDGPU_I32_CHAIN(Gfx1200, &kGfx1200Target);
 
 #undef LOOM_BENCHMARK_AMDGPU_I32_CHAIN
+
+static void BM_AmdgpuClusterAsyncDisjointCold(
+    ::benchmark::State& state, const AmdgpuBenchmarkTarget* target) {
+  RunCompileBenchmarkDirectCold(state, CreateAmdgpuClusterAsyncDisjointScenario,
+                                target);
+}
+BENCHMARK_CAPTURE(BM_AmdgpuClusterAsyncDisjointCold, Gfx1250, &kGfx1250Target)
+    ->Args({1, 1, 1})
+    ->Args({1, 1, 4})
+    ->Args({1, 1, 64})
+    ->Iterations(1)
+    ->UseRealTime();
+
+static void BM_AmdgpuClusterAsyncDisjoint(::benchmark::State& state,
+                                          const AmdgpuBenchmarkTarget* target) {
+  RunCompileBenchmarkDirect(state, CreateAmdgpuClusterAsyncDisjointScenario,
+                            target);
+}
+BENCHMARK_CAPTURE(BM_AmdgpuClusterAsyncDisjoint, Gfx1250, &kGfx1250Target)
+    ->Args({1, 1, 1})
+    ->Args({1, 1, 4})
+    ->Args({1, 1, 16})
+    ->Args({1, 1, 64})
+    ->UseRealTime();
 
 }  // namespace


### PR DESCRIPTION
Adds a gfx1250 source-to-HSACO compile-throughput workload that scales from
one to sixty-four pairwise-disjoint cluster-to-LDS transfers. This gives
memory-dependency and wait-planning changes a production C API JIT witness:
the one-transfer row isolates minimum-work overhead while larger rows expose
dependency construction, scheduling, and workspace amplification.

The new scenario shares AMDGPU target setup and HSACO validation with the
existing integer-chain benchmark, preserving identical compilation boundaries.
Source generation, parsing, and warmup remain outside steady-state timing;
single-iteration cold rows retain first-workspace-growth behavior.

## Reviewer Notes

The generated LDS destination intervals are disjoint by both lane and transfer.
The existing benchmark smoke test now covers the one- and four-transfer gfx1250
rows.
