### PR TITLE
[HAL/AMDGPU] Add execution-scoped virtual memory access

### DIFF
--- a/libhrx/src/libhrx/allocator.c
+++ b/libhrx/src/libhrx/allocator.c
@@ -284,5 +284,6 @@ hrx_status_t hrx_allocator_virtual_memory_protect(
       allocator->hal_allocator, virtual_buffer->hal_buffer,
       (iree_device_size_t)virtual_offset, (iree_device_size_t)size,
       /*queue_affinity=*/IREE_HAL_QUEUE_AFFINITY_ANY,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL,
       (iree_hal_memory_protection_t)protection));
 }

--- a/libhrx/src/libhrx/vmm_slab_provider.c
+++ b/libhrx/src/libhrx/vmm_slab_provider.c
@@ -219,6 +219,7 @@ static iree_status_t hrx_vmm_slab_provider_acquire_slab(
     status = iree_hal_allocator_virtual_memory_protect(
         provider->allocator, slab->virtual_buffer, /*virtual_offset=*/0,
         allocation_size, provider->buffer_params.queue_affinity,
+        IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL,
         IREE_HAL_MEMORY_PROTECTION_READ_WRITE);
   }
 

--- a/runtime/src/iree/hal/allocator.c
+++ b/runtime/src/iree/hal/allocator.c
@@ -355,13 +355,23 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   IREE_ASSERT_ARGUMENT(allocator);
   IREE_ASSERT_ARGUMENT(virtual_buffer);
+  if (IREE_UNLIKELY(
+          access_scope == IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_NONE ||
+          iree_any_bit_set(access_scope,
+                           ~(iree_hal_virtual_memory_access_scope_t)
+                               IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid virtual-memory access scope 0x%08" PRIx32,
+                            access_scope);
+  }
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_status_t status = _VTABLE_DISPATCH(allocator, virtual_memory_protect)(
       allocator, virtual_buffer, virtual_offset, size, queue_affinity,
-      protection);
+      access_scope, protection);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/allocator.h
+++ b/runtime/src/iree/hal/allocator.h
@@ -254,6 +254,25 @@ typedef struct iree_hal_external_buffer_t {
 // mapped to a virtual address space.
 typedef struct iree_hal_physical_memory_t iree_hal_physical_memory_t;
 
+// Bitfield selecting the execution domains granted access to a virtual-memory
+// range. Queue affinity further restricts the selected domains to the topology
+// associated with those queues.
+enum iree_hal_virtual_memory_access_scope_bits_t {
+  IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_NONE = 0u,
+
+  // Device execution queues selected by queue affinity.
+  IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE = 1u << 0,
+
+  // Host execution domains associated with the selected device topology.
+  // For remote devices this refers to the execution-side host, not the caller.
+  IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST = 1u << 1,
+
+  IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL =
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE |
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST,
+};
+typedef uint32_t iree_hal_virtual_memory_access_scope_t;
+
 // Memory protection flags for controlling access to virtual address ranges.
 // Maps to mprotect/VirtualProtect (POSIX/Windows), cuMemSetAccess (CUDA), etc.
 enum iree_hal_memory_protection_bits_t {
@@ -592,9 +611,12 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_virtual_memory_unmap(
 // Sets access permissions for a virtual address range.
 //
 // |virtual_buffer| is the reserved VA range. |virtual_offset| and |size|
-// specify the range (must be page aligned). |queue_affinity| specifies which
-// device queues get the specified permissions. |protection| is a bitmask of
-// iree_hal_memory_protection_bits_t flags.
+// specify the range (must be page aligned). |queue_affinity| selects the device
+// topology where permissions apply and |access_scope| selects host execution,
+// device execution, or both within that topology. |protection| is a bitmask of
+// iree_hal_memory_protection_bits_t flags. Backends return
+// IREE_STATUS_UNIMPLEMENTED when they cannot independently enforce the
+// requested access scope.
 //
 // By default, reserved VA ranges have no access permissions. Callers must
 // explicitly grant permissions after mapping physical memory.
@@ -605,6 +627,7 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection);
 
 // Provides usage hints for a virtual address range to optimize performance.
@@ -732,6 +755,7 @@ typedef struct iree_hal_allocator_vtable_t {
       iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
       iree_device_size_t virtual_offset, iree_device_size_t size,
       iree_hal_queue_affinity_t queue_affinity,
+      iree_hal_virtual_memory_access_scope_t access_scope,
       iree_hal_memory_protection_t protection);
   iree_status_t(IREE_API_PTR* virtual_memory_advise)(
       iree_hal_allocator_t* IREE_RESTRICT allocator,

--- a/runtime/src/iree/hal/allocator_heap.c
+++ b/runtime/src/iree/hal/allocator_heap.c
@@ -371,6 +371,7 @@ static iree_status_t iree_hal_heap_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   return iree_make_status(IREE_STATUS_UNAVAILABLE,
                           "heap allocator does not support virtual memory");

--- a/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
@@ -149,6 +149,7 @@ iree_runtime_cc_library(
     name = "amdgpu",
     srcs = [
         "allocator.c",
+        "allocator.h",
         "aql_block_processor.c",
         "aql_block_processor.h",
         "aql_block_processor_profile.c",
@@ -251,7 +252,6 @@ iree_runtime_cc_library(
         "virtual_queue.h",
     ],
     hdrs = [
-        "allocator.h",
         "api.h",
     ],
     deps = [

--- a/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
@@ -149,7 +149,6 @@ iree_runtime_cc_library(
     name = "amdgpu",
     srcs = [
         "allocator.c",
-        "allocator.h",
         "aql_block_processor.c",
         "aql_block_processor.h",
         "aql_block_processor_profile.c",
@@ -252,6 +251,7 @@ iree_runtime_cc_library(
         "virtual_queue.h",
     ],
     hdrs = [
+        "allocator.h",
         "api.h",
     ],
     deps = [

--- a/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
@@ -188,10 +188,10 @@ iree_cc_library(
   NAME
     amdgpu
   HDRS
-    "allocator.h"
     "api.h"
   SRCS
     "allocator.c"
+    "allocator.h"
     "aql_block_processor.c"
     "aql_block_processor.h"
     "aql_block_processor_profile.c"

--- a/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
@@ -188,10 +188,10 @@ iree_cc_library(
   NAME
     amdgpu
   HDRS
+    "allocator.h"
     "api.h"
   SRCS
     "allocator.c"
-    "allocator.h"
     "aql_block_processor.c"
     "aql_block_processor.h"
     "aql_block_processor_profile.c"

--- a/runtime/src/iree/hal/drivers/amdgpu/access_policy.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/access_policy.c
@@ -31,19 +31,19 @@ iree_status_t iree_hal_amdgpu_access_agent_list_resolve(
     const iree_hal_amdgpu_topology_t* topology,
     iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain,
     iree_hal_queue_affinity_t queue_affinity,
-    iree_hal_amdgpu_memory_agent_classes_t agent_classes,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_amdgpu_access_agent_list_t* out_agent_list) {
   IREE_ASSERT_ARGUMENT(topology);
   IREE_ASSERT_ARGUMENT(out_agent_list);
   memset(out_agent_list, 0, sizeof(*out_agent_list));
 
   if (IREE_UNLIKELY(
-          agent_classes == IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_NONE ||
-          iree_any_bit_set(agent_classes,
-                           ~(iree_hal_amdgpu_memory_agent_classes_t)
-                               IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL))) {
+          access_scope == IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_NONE ||
+          iree_any_bit_set(access_scope,
+                           ~(iree_hal_virtual_memory_access_scope_t)
+                               IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL))) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "invalid AMDGPU memory agent classes");
+                            "invalid virtual-memory access scope");
   }
 
   if (IREE_UNLIKELY(queue_affinity_domain.physical_device_count >
@@ -79,14 +79,14 @@ iree_status_t iree_hal_amdgpu_access_agent_list_resolve(
       break;
     }
 
-    if (iree_all_bits_set(agent_classes,
-                          IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_DEVICE)) {
+    if (iree_all_bits_set(access_scope,
+                          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE)) {
       status = iree_hal_amdgpu_access_agent_list_append_unique(
           out_agent_list, topology->gpu_agents[physical_device_ordinal]);
     }
     if (iree_status_is_ok(status) &&
-        iree_all_bits_set(agent_classes,
-                          IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_HOST)) {
+        iree_all_bits_set(access_scope,
+                          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST)) {
       status = iree_hal_amdgpu_access_agent_list_append_unique(
           out_agent_list, topology->cpu_agents[cpu_agent_ordinal]);
     }

--- a/runtime/src/iree/hal/drivers/amdgpu/access_policy.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/access_policy.c
@@ -31,10 +31,20 @@ iree_status_t iree_hal_amdgpu_access_agent_list_resolve(
     const iree_hal_amdgpu_topology_t* topology,
     iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain,
     iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_amdgpu_memory_agent_classes_t agent_classes,
     iree_hal_amdgpu_access_agent_list_t* out_agent_list) {
   IREE_ASSERT_ARGUMENT(topology);
   IREE_ASSERT_ARGUMENT(out_agent_list);
   memset(out_agent_list, 0, sizeof(*out_agent_list));
+
+  if (IREE_UNLIKELY(
+          agent_classes == IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_NONE ||
+          iree_any_bit_set(agent_classes,
+                           ~(iree_hal_amdgpu_memory_agent_classes_t)
+                               IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid AMDGPU memory agent classes");
+  }
 
   if (IREE_UNLIKELY(queue_affinity_domain.physical_device_count >
                     topology->gpu_agent_count)) {
@@ -69,9 +79,14 @@ iree_status_t iree_hal_amdgpu_access_agent_list_resolve(
       break;
     }
 
-    status = iree_hal_amdgpu_access_agent_list_append_unique(
-        out_agent_list, topology->gpu_agents[physical_device_ordinal]);
-    if (iree_status_is_ok(status)) {
+    if (iree_all_bits_set(agent_classes,
+                          IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_DEVICE)) {
+      status = iree_hal_amdgpu_access_agent_list_append_unique(
+          out_agent_list, topology->gpu_agents[physical_device_ordinal]);
+    }
+    if (iree_status_is_ok(status) &&
+        iree_all_bits_set(agent_classes,
+                          IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_HOST)) {
       status = iree_hal_amdgpu_access_agent_list_append_unique(
           out_agent_list, topology->cpu_agents[cpu_agent_ordinal]);
     }

--- a/runtime/src/iree/hal/drivers/amdgpu/access_policy.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/access_policy.h
@@ -8,7 +8,7 @@
 #define IREE_HAL_DRIVERS_AMDGPU_ACCESS_POLICY_H_
 
 #include "iree/base/api.h"
-#include "iree/hal/drivers/amdgpu/allocator.h"
+#include "iree/hal/allocator.h"
 #include "iree/hal/drivers/amdgpu/queue_affinity.h"
 #include "iree/hal/drivers/amdgpu/util/libhsa.h"
 #include "iree/hal/drivers/amdgpu/util/topology.h"
@@ -37,7 +37,7 @@ typedef struct iree_hal_amdgpu_access_agent_list_t {
 
 // Resolves the HSA agents that may access memory placed for |queue_affinity|.
 //
-// |agent_classes| selects whether the result contains each selected GPU agent,
+// |access_scope| selects whether the result contains each selected GPU agent,
 // its nearest CPU agent, or both.
 // IREE_HAL_QUEUE_AFFINITY_ANY selects the entire logical device topology,
 // while physical-device-local affinities stay scoped to that physical device.
@@ -45,7 +45,7 @@ iree_status_t iree_hal_amdgpu_access_agent_list_resolve(
     const iree_hal_amdgpu_topology_t* topology,
     iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain,
     iree_hal_queue_affinity_t queue_affinity,
-    iree_hal_amdgpu_memory_agent_classes_t agent_classes,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_amdgpu_access_agent_list_t* out_agent_list);
 
 // Grants |agent_list| access to an HSA memory pool allocation.

--- a/runtime/src/iree/hal/drivers/amdgpu/access_policy.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/access_policy.h
@@ -8,7 +8,7 @@
 #define IREE_HAL_DRIVERS_AMDGPU_ACCESS_POLICY_H_
 
 #include "iree/base/api.h"
-#include "iree/hal/api.h"
+#include "iree/hal/drivers/amdgpu/allocator.h"
 #include "iree/hal/drivers/amdgpu/queue_affinity.h"
 #include "iree/hal/drivers/amdgpu/util/libhsa.h"
 #include "iree/hal/drivers/amdgpu/util/topology.h"
@@ -37,16 +37,15 @@ typedef struct iree_hal_amdgpu_access_agent_list_t {
 
 // Resolves the HSA agents that may access memory placed for |queue_affinity|.
 //
-// The resulting list contains each selected GPU agent and its nearest CPU agent
-// from |topology|. IREE_HAL_QUEUE_AFFINITY_ANY therefore grants the entire
-// logical device topology, while physical-device-local affinities stay scoped
-// to that physical device. Sharing usage bits define how queues may share the
-// buffer within the requested placement; they do not expand the placement past
-// |queue_affinity|.
+// |agent_classes| selects whether the result contains each selected GPU agent,
+// its nearest CPU agent, or both.
+// IREE_HAL_QUEUE_AFFINITY_ANY selects the entire logical device topology,
+// while physical-device-local affinities stay scoped to that physical device.
 iree_status_t iree_hal_amdgpu_access_agent_list_resolve(
     const iree_hal_amdgpu_topology_t* topology,
     iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain,
     iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_amdgpu_memory_agent_classes_t agent_classes,
     iree_hal_amdgpu_access_agent_list_t* out_agent_list);
 
 // Grants |agent_list| access to an HSA memory pool allocation.

--- a/runtime/src/iree/hal/drivers/amdgpu/access_policy_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/access_policy_test.cc
@@ -59,7 +59,7 @@ TEST(AccessPolicyTest, AnySelectsLogicalTopologyAgents) {
   iree_hal_amdgpu_access_agent_list_t agent_list;
   IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve(
       &topology, ThreeGpuDomain(), IREE_HAL_QUEUE_AFFINITY_ANY,
-      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, &agent_list));
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL, &agent_list));
 
   EXPECT_EQ(agent_list.count, 5u);
   EXPECT_TRUE(AgentListContains(agent_list, topology.cpu_agents[0]));
@@ -75,7 +75,7 @@ TEST(AccessPolicyTest, PhysicalDeviceAffinitySelectsGpuAndNearestCpu) {
   iree_hal_amdgpu_access_agent_list_t agent_list;
   IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve(
       &topology, ThreeGpuDomain(), 0xCull,
-      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, &agent_list));
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL, &agent_list));
 
   EXPECT_EQ(agent_list.count, 2u);
   EXPECT_TRUE(AgentListContains(agent_list, topology.cpu_agents[0]));
@@ -88,7 +88,7 @@ TEST(AccessPolicyTest, CrossDeviceAffinityDeduplicatesCpuAgents) {
   iree_hal_amdgpu_access_agent_list_t agent_list;
   IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve(
       &topology, ThreeGpuDomain(), 0x5ull,
-      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, &agent_list));
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL, &agent_list));
 
   EXPECT_EQ(agent_list.count, 3u);
   EXPECT_TRUE(AgentListContains(agent_list, topology.cpu_agents[0]));
@@ -105,29 +105,29 @@ TEST(AccessPolicyTest, RejectsInvalidGpuCpuMap) {
       IREE_STATUS_OUT_OF_RANGE,
       iree_hal_amdgpu_access_agent_list_resolve(
           &topology, ThreeGpuDomain(), 0x4ull,
-          IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, &agent_list));
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL, &agent_list));
 }
 
-TEST(AccessPolicyTest, AccessScopeSelectsAgentClass) {
+TEST(AccessPolicyTest, AccessScopeSelectsExecutionDomain) {
   iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
 
   iree_hal_amdgpu_access_agent_list_t host_agents;
   IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve(
       &topology, ThreeGpuDomain(), 0x5ull,
-      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_HOST, &host_agents));
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST, &host_agents));
   EXPECT_EQ(host_agents.count, 1u);
   EXPECT_TRUE(AgentListContains(host_agents, topology.cpu_agents[0]));
 
   iree_hal_amdgpu_access_agent_list_t device_agents;
   IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve(
       &topology, ThreeGpuDomain(), 0x5ull,
-      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_DEVICE, &device_agents));
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE, &device_agents));
   EXPECT_EQ(device_agents.count, 2u);
   EXPECT_TRUE(AgentListContains(device_agents, topology.gpu_agents[0]));
   EXPECT_TRUE(AgentListContains(device_agents, topology.gpu_agents[1]));
 }
 
-TEST(AccessPolicyTest, RequiresAnAgentClass) {
+TEST(AccessPolicyTest, RequiresAccessScope) {
   iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
 
   iree_hal_amdgpu_access_agent_list_t agent_list;
@@ -135,10 +135,10 @@ TEST(AccessPolicyTest, RequiresAnAgentClass) {
       IREE_STATUS_INVALID_ARGUMENT,
       iree_hal_amdgpu_access_agent_list_resolve(
           &topology, ThreeGpuDomain(), IREE_HAL_QUEUE_AFFINITY_ANY,
-          IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_NONE, &agent_list));
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_NONE, &agent_list));
 }
 
-TEST(AccessPolicyTest, RejectsUnknownAgentClasses) {
+TEST(AccessPolicyTest, RejectsUnknownAccessScopes) {
   iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
 
   iree_hal_amdgpu_access_agent_list_t agent_list;
@@ -146,7 +146,7 @@ TEST(AccessPolicyTest, RejectsUnknownAgentClasses) {
       IREE_STATUS_INVALID_ARGUMENT,
       iree_hal_amdgpu_access_agent_list_resolve(
           &topology, ThreeGpuDomain(), IREE_HAL_QUEUE_AFFINITY_ANY,
-          (iree_hal_amdgpu_memory_agent_classes_t)(1u << 7), &agent_list));
+          (iree_hal_virtual_memory_access_scope_t)(1u << 7), &agent_list));
 }
 
 }  // namespace

--- a/runtime/src/iree/hal/drivers/amdgpu/access_policy_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/access_policy_test.cc
@@ -58,7 +58,8 @@ TEST(AccessPolicyTest, AnySelectsLogicalTopologyAgents) {
 
   iree_hal_amdgpu_access_agent_list_t agent_list;
   IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve(
-      &topology, ThreeGpuDomain(), IREE_HAL_QUEUE_AFFINITY_ANY, &agent_list));
+      &topology, ThreeGpuDomain(), IREE_HAL_QUEUE_AFFINITY_ANY,
+      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, &agent_list));
 
   EXPECT_EQ(agent_list.count, 5u);
   EXPECT_TRUE(AgentListContains(agent_list, topology.cpu_agents[0]));
@@ -73,7 +74,8 @@ TEST(AccessPolicyTest, PhysicalDeviceAffinitySelectsGpuAndNearestCpu) {
 
   iree_hal_amdgpu_access_agent_list_t agent_list;
   IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve(
-      &topology, ThreeGpuDomain(), 0xCull, &agent_list));
+      &topology, ThreeGpuDomain(), 0xCull,
+      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, &agent_list));
 
   EXPECT_EQ(agent_list.count, 2u);
   EXPECT_TRUE(AgentListContains(agent_list, topology.cpu_agents[0]));
@@ -85,7 +87,8 @@ TEST(AccessPolicyTest, CrossDeviceAffinityDeduplicatesCpuAgents) {
 
   iree_hal_amdgpu_access_agent_list_t agent_list;
   IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve(
-      &topology, ThreeGpuDomain(), 0x5ull, &agent_list));
+      &topology, ThreeGpuDomain(), 0x5ull,
+      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, &agent_list));
 
   EXPECT_EQ(agent_list.count, 3u);
   EXPECT_TRUE(AgentListContains(agent_list, topology.cpu_agents[0]));
@@ -98,9 +101,52 @@ TEST(AccessPolicyTest, RejectsInvalidGpuCpuMap) {
   topology.gpu_cpu_map[1] = 2;
 
   iree_hal_amdgpu_access_agent_list_t agent_list;
-  IREE_EXPECT_STATUS_IS(IREE_STATUS_OUT_OF_RANGE,
-                        iree_hal_amdgpu_access_agent_list_resolve(
-                            &topology, ThreeGpuDomain(), 0x4ull, &agent_list));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_OUT_OF_RANGE,
+      iree_hal_amdgpu_access_agent_list_resolve(
+          &topology, ThreeGpuDomain(), 0x4ull,
+          IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, &agent_list));
+}
+
+TEST(AccessPolicyTest, AccessScopeSelectsAgentClass) {
+  iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
+
+  iree_hal_amdgpu_access_agent_list_t host_agents;
+  IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve(
+      &topology, ThreeGpuDomain(), 0x5ull,
+      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_HOST, &host_agents));
+  EXPECT_EQ(host_agents.count, 1u);
+  EXPECT_TRUE(AgentListContains(host_agents, topology.cpu_agents[0]));
+
+  iree_hal_amdgpu_access_agent_list_t device_agents;
+  IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve(
+      &topology, ThreeGpuDomain(), 0x5ull,
+      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_DEVICE, &device_agents));
+  EXPECT_EQ(device_agents.count, 2u);
+  EXPECT_TRUE(AgentListContains(device_agents, topology.gpu_agents[0]));
+  EXPECT_TRUE(AgentListContains(device_agents, topology.gpu_agents[1]));
+}
+
+TEST(AccessPolicyTest, RequiresAnAgentClass) {
+  iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
+
+  iree_hal_amdgpu_access_agent_list_t agent_list;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_access_agent_list_resolve(
+          &topology, ThreeGpuDomain(), IREE_HAL_QUEUE_AFFINITY_ANY,
+          IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_NONE, &agent_list));
+}
+
+TEST(AccessPolicyTest, RejectsUnknownAgentClasses) {
+  iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
+
+  iree_hal_amdgpu_access_agent_list_t agent_list;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_access_agent_list_resolve(
+          &topology, ThreeGpuDomain(), IREE_HAL_QUEUE_AFFINITY_ANY,
+          (iree_hal_amdgpu_memory_agent_classes_t)(1u << 7), &agent_list));
 }
 
 }  // namespace

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator.c
@@ -301,7 +301,7 @@ static iree_status_t iree_hal_amdgpu_allocator_resolve_access_agents(
   return iree_hal_amdgpu_access_agent_list_resolve(
       allocator->topology,
       iree_hal_amdgpu_allocator_queue_affinity_domain(allocator),
-      queue_affinity, IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, out_agent_list);
+      queue_affinity, IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL, out_agent_list);
 }
 
 static bool iree_hal_amdgpu_allocator_find_gpu_agent_ordinal(
@@ -2053,6 +2053,7 @@ static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   iree_hal_amdgpu_allocator_t* allocator =
       iree_hal_amdgpu_allocator_cast(base_allocator);
@@ -2060,23 +2061,7 @@ static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_protect(
       iree_hal_amdgpu_allocator_require_virtual_memory(allocator));
   return iree_hal_amdgpu_virtual_memory_protect(
       allocator->virtual_memory, virtual_buffer, virtual_offset, size,
-      queue_affinity, IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, protection);
-}
-
-IREE_API_EXPORT iree_status_t
-iree_hal_amdgpu_allocator_virtual_memory_protect_agents(
-    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* virtual_buffer,
-    iree_device_size_t virtual_offset, iree_device_size_t size,
-    iree_hal_queue_affinity_t queue_affinity,
-    iree_hal_amdgpu_memory_agent_classes_t agent_classes,
-    iree_hal_memory_protection_t protection) {
-  iree_hal_amdgpu_allocator_t* allocator =
-      iree_hal_amdgpu_allocator_cast(base_allocator);
-  IREE_RETURN_IF_ERROR(
-      iree_hal_amdgpu_allocator_require_virtual_memory(allocator));
-  return iree_hal_amdgpu_virtual_memory_protect(
-      allocator->virtual_memory, virtual_buffer, virtual_offset, size,
-      queue_affinity, agent_classes, protection);
+      queue_affinity, access_scope, protection);
 }
 
 static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_advise(

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator.c
@@ -301,7 +301,7 @@ static iree_status_t iree_hal_amdgpu_allocator_resolve_access_agents(
   return iree_hal_amdgpu_access_agent_list_resolve(
       allocator->topology,
       iree_hal_amdgpu_allocator_queue_affinity_domain(allocator),
-      queue_affinity, out_agent_list);
+      queue_affinity, IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, out_agent_list);
 }
 
 static bool iree_hal_amdgpu_allocator_find_gpu_agent_ordinal(
@@ -416,11 +416,19 @@ static iree_status_t iree_hal_amdgpu_allocator_query_device_pointer_range(
   }
 
   iree_host_size_t owner_ordinal = 0;
-  if (IREE_UNLIKELY(!iree_hal_amdgpu_allocator_find_gpu_agent_ordinal(
-          allocator, pointer_info.agentOwner, &owner_ordinal))) {
+  const bool owner_is_local_gpu =
+      iree_hal_amdgpu_allocator_find_gpu_agent_ordinal(
+          allocator, pointer_info.agentOwner, &owner_ordinal);
+  hsa_device_type_t owner_device_type = HSA_DEVICE_TYPE_CPU;
+  IREE_RETURN_IF_ERROR(iree_hsa_agent_get_info(
+      IREE_LIBHSA(allocator->libhsa), pointer_info.agentOwner,
+      HSA_AGENT_INFO_DEVICE, &owner_device_type));
+  const bool owner_is_gpu = owner_device_type == HSA_DEVICE_TYPE_GPU;
+  const bool owner_is_cpu = owner_device_type == HSA_DEVICE_TYPE_CPU;
+  if (IREE_UNLIKELY(!owner_is_gpu && !owner_is_cpu)) {
     return iree_make_status(
         IREE_STATUS_PERMISSION_DENIED,
-        "device allocation is owned by an HSA GPU agent outside the AMDGPU HAL "
+        "device allocation is owned by an HSA agent outside the AMDGPU HAL "
         "logical topology");
   }
 
@@ -439,23 +447,29 @@ static iree_status_t iree_hal_amdgpu_allocator_query_device_pointer_range(
   }
 
   const iree_hal_amdgpu_physical_device_t* owner_device =
-      allocator->logical_device->physical_devices[owner_ordinal];
+      owner_is_local_gpu
+          ? allocator->logical_device->physical_devices[owner_ordinal]
+          : NULL;
   const bool direct_host_access =
       owner_device && owner_device->memory_system.svm.direct_host_access;
-  iree_hal_memory_type_t actual_memory_type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
-  if (fine_grained && direct_host_access) {
-    actual_memory_type |=
-        IREE_HAL_MEMORY_TYPE_HOST_VISIBLE | IREE_HAL_MEMORY_TYPE_HOST_COHERENT;
+  iree_hal_memory_type_t actual_memory_type = 0;
+  if (owner_is_gpu) {
+    actual_memory_type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
+    if (fine_grained && direct_host_access) {
+      actual_memory_type |= IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                            IREE_HAL_MEMORY_TYPE_HOST_COHERENT;
+    }
+  } else {
+    actual_memory_type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                         IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                         IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+    if (fine_grained) {
+      actual_memory_type |= IREE_HAL_MEMORY_TYPE_HOST_COHERENT;
+    }
   }
 
   const iree_hal_memory_type_t required_memory_type =
       requested_memory_type & ~IREE_HAL_MEMORY_TYPE_OPTIMAL;
-  if (IREE_UNLIKELY(iree_any_bit_set(required_memory_type,
-                                     IREE_HAL_MEMORY_TYPE_HOST_LOCAL))) {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "device allocation import cannot satisfy HOST_LOCAL memory");
-  }
   if (IREE_UNLIKELY(
           !iree_all_bits_set(actual_memory_type, required_memory_type))) {
     return iree_make_status(
@@ -485,7 +499,10 @@ static iree_status_t iree_hal_amdgpu_allocator_query_device_pointer_range(
   out_range->agent_base = pointer_info.agentBaseAddress;
   out_range->allocation_size = allocation_size;
   out_range->memory_type = actual_memory_type;
-  out_range->physical_device_ordinal = (uint32_t)owner_ordinal;
+  // CPU and external GPU owners have no local profiling ordinal, but their
+  // allocations can still be imported and made accessible to local agents.
+  out_range->physical_device_ordinal =
+      owner_is_local_gpu ? (uint32_t)owner_ordinal : UINT32_MAX;
   return iree_ok_status();
 }
 
@@ -772,8 +789,9 @@ iree_status_t iree_hal_amdgpu_allocator_create(
     iree_hal_allocator_statistics_t* statistics = NULL;
     IREE_STATISTICS(statistics = &allocator->statistics);
     status = iree_hal_amdgpu_virtual_memory_state_create(
-        libhsa, topology, (iree_hal_device_t*)logical_device, statistics,
-        host_allocator, &allocator->virtual_memory);
+        libhsa, topology, (iree_hal_device_t*)logical_device,
+        logical_device->queue_affinity_mask, statistics, host_allocator,
+        &allocator->virtual_memory);
   }
 
   if (iree_status_is_ok(status)) {
@@ -992,14 +1010,14 @@ iree_hal_amdgpu_allocator_query_buffer_compatibility(
                         IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
                             IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE) &&
       !iree_all_bits_set(params->type, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL);
+  const bool placement_is_device_addressable = iree_any_bit_set(
+      placement.memory_type,
+      IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE);
   const bool device_allocation_import_compatible =
       allocation_size_valid && allocation_alignment_valid &&
-      iree_all_bits_set(placement.memory_type,
-                        IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL);
+      placement_is_device_addressable;
   const bool device_allocation_export_compatible =
-      allocation_compatible &&
-      iree_all_bits_set(placement.memory_type,
-                        IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL);
+      allocation_compatible && placement_is_device_addressable;
   if (!allocation_compatible && !host_allocation_import_compatible &&
       !device_allocation_import_compatible) {
     return IREE_HAL_BUFFER_COMPATIBILITY_NONE;
@@ -1880,12 +1898,13 @@ static iree_status_t iree_hal_amdgpu_allocator_export_buffer(
   switch (requested_type) {
     case IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION: {
       if (IREE_UNLIKELY(
-              !iree_all_bits_set(iree_hal_buffer_memory_type(buffer),
-                                 IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL))) {
+              !iree_any_bit_set(iree_hal_buffer_memory_type(buffer),
+                                IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+                                    IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE))) {
         return iree_make_status(
             IREE_STATUS_UNAVAILABLE,
-            "AMDGPU buffer memory type is not supported for export as an "
-            "external device allocation");
+            "AMDGPU buffer is not device-visible and cannot be exported as "
+            "an external device allocation");
       }
       out_external_buffer->handle.device_allocation.ptr =
           (uint64_t)(uintptr_t)view_ptr;
@@ -2041,7 +2060,23 @@ static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_protect(
       iree_hal_amdgpu_allocator_require_virtual_memory(allocator));
   return iree_hal_amdgpu_virtual_memory_protect(
       allocator->virtual_memory, virtual_buffer, virtual_offset, size,
-      queue_affinity, protection);
+      queue_affinity, IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, protection);
+}
+
+IREE_API_EXPORT iree_status_t
+iree_hal_amdgpu_allocator_virtual_memory_protect_agents(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* virtual_buffer,
+    iree_device_size_t virtual_offset, iree_device_size_t size,
+    iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_amdgpu_memory_agent_classes_t agent_classes,
+    iree_hal_memory_protection_t protection) {
+  iree_hal_amdgpu_allocator_t* allocator =
+      iree_hal_amdgpu_allocator_cast(base_allocator);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_allocator_require_virtual_memory(allocator));
+  return iree_hal_amdgpu_virtual_memory_protect(
+      allocator->virtual_memory, virtual_buffer, virtual_offset, size,
+      queue_affinity, agent_classes, protection);
 }
 
 static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_advise(

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator.h
@@ -33,27 +33,4 @@ iree_status_t iree_hal_amdgpu_allocator_create(
     const iree_hal_amdgpu_topology_t* topology, iree_allocator_t host_allocator,
     iree_hal_allocator_t** out_allocator);
 
-// Bitfield selecting AMDGPU agent classes updated by virtual-memory
-// protection operations.
-typedef uint32_t iree_hal_amdgpu_memory_agent_classes_t;
-enum iree_hal_amdgpu_memory_agent_class_bits_e {
-  IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_NONE = 0u,
-  IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_HOST = 1u << 0,
-  IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_DEVICE = 1u << 1,
-  IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL =
-      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_HOST |
-      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_DEVICE,
-};
-
-// Sets virtual-memory permissions for only the selected AMDGPU agent classes.
-// The reservation may originate from another AMDGPU allocator in the same
-// process because ROCr virtual addresses are process-global.
-IREE_API_EXPORT iree_status_t
-iree_hal_amdgpu_allocator_virtual_memory_protect_agents(
-    iree_hal_allocator_t* allocator, iree_hal_buffer_t* virtual_buffer,
-    iree_device_size_t virtual_offset, iree_device_size_t size,
-    iree_hal_queue_affinity_t queue_affinity,
-    iree_hal_amdgpu_memory_agent_classes_t agent_classes,
-    iree_hal_memory_protection_t protection);
-
 #endif  // IREE_HAL_DRIVERS_AMDGPU_ALLOCATOR_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator.h
@@ -9,8 +9,8 @@
 
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
-#include "iree/hal/drivers/amdgpu/util/libhsa.h"
 
+typedef struct iree_hal_amdgpu_libhsa_t iree_hal_amdgpu_libhsa_t;
 typedef struct iree_hal_amdgpu_logical_device_t
     iree_hal_amdgpu_logical_device_t;
 typedef struct iree_hal_amdgpu_topology_t iree_hal_amdgpu_topology_t;
@@ -32,5 +32,28 @@ iree_status_t iree_hal_amdgpu_allocator_create(
     const iree_hal_amdgpu_libhsa_t* libhsa,
     const iree_hal_amdgpu_topology_t* topology, iree_allocator_t host_allocator,
     iree_hal_allocator_t** out_allocator);
+
+// Bitfield selecting AMDGPU agent classes updated by virtual-memory
+// protection operations.
+typedef uint32_t iree_hal_amdgpu_memory_agent_classes_t;
+enum iree_hal_amdgpu_memory_agent_class_bits_e {
+  IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_NONE = 0u,
+  IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_HOST = 1u << 0,
+  IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_DEVICE = 1u << 1,
+  IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL =
+      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_HOST |
+      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_DEVICE,
+};
+
+// Sets virtual-memory permissions for only the selected AMDGPU agent classes.
+// The reservation may originate from another AMDGPU allocator in the same
+// process because ROCr virtual addresses are process-global.
+IREE_API_EXPORT iree_status_t
+iree_hal_amdgpu_allocator_virtual_memory_protect_agents(
+    iree_hal_allocator_t* allocator, iree_hal_buffer_t* virtual_buffer,
+    iree_device_size_t virtual_offset, iree_device_size_t size,
+    iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_amdgpu_memory_agent_classes_t agent_classes,
+    iree_hal_memory_protection_t protection);
 
 #endif  // IREE_HAL_DRIVERS_AMDGPU_ALLOCATOR_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
@@ -416,6 +416,7 @@ TEST_F(AllocatorTest, VirtualMemoryLifecycleUsesNativeState) {
   IREE_ASSERT_NOT_OK(iree_hal_allocator_virtual_memory_protect(
       allocator, virtual_memory.get(), /*virtual_offset=*/0,
       recommended_page_size, kQueueAffinity0,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL,
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
 
   VirtualMemoryMapping mapping(allocator, virtual_memory.get(),
@@ -436,6 +437,12 @@ TEST_F(AllocatorTest, VirtualMemoryLifecycleUsesNativeState) {
   IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
       allocator, virtual_memory.get(), /*virtual_offset=*/0,
       recommended_page_size, kQueueAffinity0,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
+      IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
+      allocator, virtual_memory.get(), /*virtual_offset=*/0,
+      recommended_page_size, kQueueAffinity0,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST,
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
 
   constexpr iree_device_size_t kTouchedSize = 256;
@@ -518,6 +525,7 @@ TEST_F(AllocatorTest, VirtualMemoryMapsMinimumGranuleAcrossPools) {
   IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
       allocator, virtual_memory.get(), /*virtual_offset=*/0,
       host_minimum_page_size, kQueueAffinity0,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL,
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
 
   IREE_ASSERT_OK(mapping.Unmap());

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
@@ -1572,7 +1572,77 @@ TEST_F(AllocatorTest, DeviceAllocationExportReportsHsaPointer) {
   iree_hal_buffer_release(buffer);
 }
 
-TEST_F(AllocatorTest, ExternalBufferExportRejectsUnsupportedRequests) {
+TEST_F(AllocatorTest, HostAllocationExportsAndImportsAsDevicePointer) {
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(&libhsa_, &topology_, host_allocator_));
+
+  iree_hal_buffer_params_t params = {0};
+  params.type =
+      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+      IREE_HAL_MEMORY_TYPE_HOST_COHERENT | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+  params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER |
+                 IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
+                 IREE_HAL_BUFFER_USAGE_MAPPING_SCOPED;
+
+  constexpr iree_device_size_t kAllocationSize = 4096;
+  iree_hal_buffer_params_t resolved_params = {};
+  iree_device_size_t resolved_allocation_size = 0;
+  const iree_hal_buffer_compatibility_t compatibility =
+      iree_hal_allocator_query_buffer_compatibility(
+          test_device.allocator(), params, kAllocationSize, &resolved_params,
+          &resolved_allocation_size);
+  EXPECT_TRUE(iree_all_bits_set(compatibility,
+                                IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE |
+                                    IREE_HAL_BUFFER_COMPATIBILITY_IMPORTABLE |
+                                    IREE_HAL_BUFFER_COMPATIBILITY_EXPORTABLE));
+
+  iree_hal_buffer_t* buffer = nullptr;
+  IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
+      test_device.allocator(), params, kAllocationSize, &buffer));
+
+  iree_hal_external_buffer_t external_buffer = {};
+  IREE_ASSERT_OK(iree_hal_allocator_export_buffer(
+      test_device.allocator(), buffer,
+      IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION,
+      IREE_HAL_EXTERNAL_BUFFER_FLAG_NONE, &external_buffer));
+  EXPECT_EQ(external_buffer.type,
+            IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION);
+  EXPECT_NE(external_buffer.handle.device_allocation.ptr, 0u);
+  EXPECT_EQ(external_buffer.size, kAllocationSize);
+
+  int release_count = 0;
+  iree_hal_buffer_release_callback_t callback = {};
+  callback.fn = CountingReleaseCallback;
+  callback.user_data = &release_count;
+  iree_hal_buffer_t* imported_buffer = nullptr;
+  IREE_ASSERT_OK(iree_hal_allocator_import_buffer(test_device.allocator(),
+                                                  params, &external_buffer,
+                                                  callback, &imported_buffer));
+  EXPECT_TRUE(iree_all_bits_set(iree_hal_buffer_memory_type(imported_buffer),
+                                params.type));
+
+  constexpr uint32_t kPattern = 0xA7011C5u;
+  IREE_ASSERT_OK(QueueFillAndWait(
+      test_device.device(), IREE_HAL_QUEUE_AFFINITY_ANY, imported_buffer,
+      kAllocationSize, &kPattern, sizeof(kPattern)));
+  iree_hal_buffer_mapping_t mapping = {};
+  IREE_ASSERT_OK(iree_hal_buffer_map_range(
+      buffer, IREE_HAL_MAPPING_MODE_SCOPED, IREE_HAL_MEMORY_ACCESS_READ,
+      /*byte_offset=*/0, IREE_HAL_WHOLE_BUFFER, &mapping));
+  const uint32_t* values =
+      reinterpret_cast<const uint32_t*>(mapping.contents.data);
+  for (iree_host_size_t i = 0;
+       i < mapping.contents.data_length / sizeof(uint32_t); ++i) {
+    EXPECT_EQ(values[i], kPattern);
+  }
+  IREE_ASSERT_OK(iree_hal_buffer_unmap_range(&mapping));
+
+  iree_hal_buffer_release(imported_buffer);
+  EXPECT_EQ(release_count, 1);
+  iree_hal_buffer_release(buffer);
+}
+
+TEST_F(AllocatorTest, ExternalBufferExportRejectsUnsupportedHandleType) {
   TestLogicalDevice test_device;
   IREE_ASSERT_OK(test_device.Initialize(&libhsa_, &topology_, host_allocator_));
 
@@ -1581,18 +1651,11 @@ TEST_F(AllocatorTest, ExternalBufferExportRejectsUnsupportedRequests) {
       IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
 
-  iree_hal_buffer_t* buffer = NULL;
+  iree_hal_buffer_t* buffer = nullptr;
   IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
       test_device.allocator(), params, /*allocation_size=*/4096, &buffer));
 
   iree_hal_external_buffer_t external_buffer = {};
-  IREE_EXPECT_STATUS_IS(
-      IREE_STATUS_UNAVAILABLE,
-      iree_hal_allocator_export_buffer(
-          test_device.allocator(), buffer,
-          IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION,
-          IREE_HAL_EXTERNAL_BUFFER_FLAG_NONE, &external_buffer));
-
   IREE_EXPECT_STATUS_IS(
       IREE_STATUS_UNAVAILABLE,
       iree_hal_allocator_export_buffer(

--- a/runtime/src/iree/hal/drivers/amdgpu/buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/buffer.c
@@ -249,6 +249,17 @@ bool iree_hal_amdgpu_buffer_uses_release_callback(
          buffer->release_callback.user_data == release_callback.user_data;
 }
 
+bool iree_hal_amdgpu_buffer_uses_release_callback_function(
+    iree_hal_buffer_t* base_buffer, iree_hal_buffer_release_fn_t release_fn) {
+  if (!iree_hal_resource_is((const iree_hal_resource_t*)base_buffer,
+                            &iree_hal_amdgpu_buffer_vtable)) {
+    return false;
+  }
+  const iree_hal_amdgpu_buffer_t* buffer =
+      (const iree_hal_amdgpu_buffer_t*)base_buffer;
+  return buffer->release_callback.fn == release_fn;
+}
+
 void iree_hal_amdgpu_buffer_disarm_storage(
     iree_hal_buffer_t* base_buffer,
     iree_hal_buffer_release_callback_t release_callback) {

--- a/runtime/src/iree/hal/drivers/amdgpu/buffer.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/buffer.h
@@ -128,6 +128,11 @@ bool iree_hal_amdgpu_buffer_uses_release_callback(
     iree_hal_buffer_t* buffer,
     iree_hal_buffer_release_callback_t release_callback);
 
+// Returns true if |buffer| is a direct AMDGPU buffer using the given callback
+// function, regardless of callback user data.
+bool iree_hal_amdgpu_buffer_uses_release_callback_function(
+    iree_hal_buffer_t* buffer, iree_hal_buffer_release_fn_t release_fn);
+
 // Disarms callback-owned storage that has already been released externally.
 //
 // |buffer| must be a direct AMDGPU buffer using exactly |release_callback|.

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_staging.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_staging.c
@@ -128,7 +128,7 @@ static iree_status_t iree_hal_amdgpu_staging_pool_resolve_access_agents(
   };
   return iree_hal_amdgpu_access_agent_list_resolve(
       topology, domain, queue_affinity_mask,
-      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, out_agent_list);
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL, out_agent_list);
 }
 
 static void iree_hal_amdgpu_staging_allocation_release(

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_staging.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_staging.c
@@ -127,7 +127,8 @@ static iree_status_t iree_hal_amdgpu_staging_pool_resolve_access_agents(
       .queue_count_per_physical_device = topology->gpu_agent_queue_count,
   };
   return iree_hal_amdgpu_access_agent_list_resolve(
-      topology, domain, queue_affinity_mask, out_agent_list);
+      topology, domain, queue_affinity_mask,
+      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, out_agent_list);
 }
 
 static void iree_hal_amdgpu_staging_allocation_release(

--- a/runtime/src/iree/hal/drivers/amdgpu/slab_provider.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/slab_provider.c
@@ -191,7 +191,7 @@ static iree_status_t iree_hal_amdgpu_slab_provider_resolve_access_agents(
   };
   return iree_hal_amdgpu_access_agent_list_resolve(
       provider->topology, domain, provider->queue_affinity_mask,
-      out_agent_list);
+      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, out_agent_list);
 }
 
 static iree_status_t iree_hal_amdgpu_slab_provider_build_vmem_access_descs(

--- a/runtime/src/iree/hal/drivers/amdgpu/slab_provider.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/slab_provider.c
@@ -191,7 +191,7 @@ static iree_status_t iree_hal_amdgpu_slab_provider_resolve_access_agents(
   };
   return iree_hal_amdgpu_access_agent_list_resolve(
       provider->topology, domain, provider->queue_affinity_mask,
-      IREE_HAL_AMDGPU_MEMORY_AGENT_CLASS_ALL, out_agent_list);
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL, out_agent_list);
 }
 
 static iree_status_t iree_hal_amdgpu_slab_provider_build_vmem_access_descs(

--- a/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
@@ -24,8 +24,6 @@ typedef struct iree_hal_amdgpu_virtual_memory_range_t {
   // Byte length of the ROCr virtual reservation.
   iree_device_size_t size;
 
-  // HAL queues permitted to access the reservation.
-  iree_hal_queue_affinity_t queue_affinity;
 } iree_hal_amdgpu_virtual_memory_range_t;
 
 struct iree_hal_physical_memory_t {
@@ -57,6 +55,9 @@ struct iree_hal_amdgpu_virtual_memory_state_t {
 
   // Unowned HAL device used to validate reservation ownership.
   iree_hal_device_t* device;
+
+  // Queues represented by the logical device that owns this VMM state.
+  iree_hal_queue_affinity_t supported_queue_affinity;
 
   // Unowned allocator statistics updated for physical allocations.
   iree_hal_allocator_statistics_t* statistics;
@@ -204,7 +205,32 @@ static iree_status_t iree_hal_amdgpu_virtual_memory_resolve_range(
   *out_range = (iree_hal_amdgpu_virtual_memory_range_t){
       .base_ptr = base_ptr,
       .size = iree_hal_buffer_allocation_size(virtual_buffer),
-      .queue_affinity = placement.queue_affinity,
+  };
+  return iree_ok_status();
+}
+
+// Resolves a reservation created by any AMDGPU logical device. ROCr virtual
+// addresses are process-global, so a different logical device may update the
+// access permissions for its own agents. Ownership-sensitive operations still
+// use iree_hal_amdgpu_virtual_memory_resolve_range above.
+static iree_status_t iree_hal_amdgpu_virtual_memory_resolve_access_range(
+    iree_hal_buffer_t* virtual_buffer,
+    iree_hal_amdgpu_virtual_memory_range_t* out_range) {
+  *out_range = (iree_hal_amdgpu_virtual_memory_range_t){0};
+  if (!iree_hal_amdgpu_buffer_uses_release_callback_function(
+          virtual_buffer, iree_hal_amdgpu_virtual_memory_release_reservation)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "virtual buffer is not an AMDGPU virtual-memory reservation");
+  }
+  void* base_ptr = iree_hal_amdgpu_buffer_device_pointer(virtual_buffer);
+  if (IREE_UNLIKELY(!base_ptr)) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "AMDGPU virtual reservation has no device address");
+  }
+  *out_range = (iree_hal_amdgpu_virtual_memory_range_t){
+      .base_ptr = base_ptr,
+      .size = iree_hal_buffer_allocation_size(virtual_buffer),
   };
   return iree_ok_status();
 }
@@ -212,6 +238,7 @@ static iree_status_t iree_hal_amdgpu_virtual_memory_resolve_range(
 iree_status_t iree_hal_amdgpu_virtual_memory_state_create(
     const iree_hal_amdgpu_libhsa_t* libhsa,
     const iree_hal_amdgpu_topology_t* topology, iree_hal_device_t* device,
+    iree_hal_queue_affinity_t supported_queue_affinity,
     iree_hal_allocator_statistics_t* statistics,
     iree_allocator_t host_allocator,
     iree_hal_amdgpu_virtual_memory_state_t** out_state) {
@@ -228,6 +255,7 @@ iree_status_t iree_hal_amdgpu_virtual_memory_state_create(
       .libhsa = libhsa,
       .topology = topology,
       .device = device,
+      .supported_queue_affinity = supported_queue_affinity,
       .statistics = statistics,
       .host_allocator = host_allocator,
   };
@@ -417,11 +445,6 @@ iree_status_t iree_hal_amdgpu_virtual_memory_map(
   IREE_ASSERT_ARGUMENT(state);
   IREE_ASSERT_ARGUMENT(virtual_buffer);
   IREE_ASSERT_ARGUMENT(physical_memory);
-  if (physical_memory->state != state) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "physical memory belongs to a different AMDGPU "
-                            "VMM context");
-  }
   if (IREE_UNLIKELY(physical_offset != 0 ||
                     size != physical_memory->allocation_size)) {
     return iree_make_status(
@@ -450,8 +473,11 @@ iree_status_t iree_hal_amdgpu_virtual_memory_map(
         "AMDGPU virtual-memory map address is not aligned to the physical "
         "allocation granule");
   }
-  return iree_hsa_amd_vmem_map(IREE_LIBHSA(state->libhsa), map_ptr, size,
-                               /*in_offset=*/0,
+  // ROCr allocation handles and virtual addresses are process-global. The
+  // reservation and physical allocation may therefore originate from
+  // different logical-device allocators in the same process.
+  return iree_hsa_amd_vmem_map(IREE_LIBHSA(physical_memory->state->libhsa),
+                               map_ptr, size, /*in_offset=*/0,
                                physical_memory->allocation_handle, /*flags=*/0);
 }
 
@@ -481,6 +507,7 @@ iree_status_t iree_hal_amdgpu_virtual_memory_protect(
     iree_hal_amdgpu_virtual_memory_state_t* state,
     iree_hal_buffer_t* virtual_buffer, iree_device_size_t virtual_offset,
     iree_device_size_t size, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_amdgpu_memory_agent_classes_t agent_classes,
     iree_hal_memory_protection_t protection) {
   IREE_ASSERT_ARGUMENT(state);
   IREE_ASSERT_ARGUMENT(virtual_buffer);
@@ -495,8 +522,8 @@ iree_status_t iree_hal_amdgpu_virtual_memory_protect(
   }
 
   iree_hal_amdgpu_virtual_memory_range_t range;
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_virtual_memory_resolve_range(
-      state, virtual_buffer, &range));
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_virtual_memory_resolve_access_range(
+      virtual_buffer, &range));
   if (IREE_UNLIKELY(size == 0 ||
                     !iree_hal_amdgpu_virtual_memory_range_is_in_bounds(
                         range.size, virtual_offset, size))) {
@@ -506,13 +533,13 @@ iree_status_t iree_hal_amdgpu_virtual_memory_protect(
   }
 
   const iree_hal_amdgpu_queue_affinity_domain_t domain = {
-      .supported_affinity = range.queue_affinity,
+      .supported_affinity = state->supported_queue_affinity,
       .physical_device_count = state->topology->gpu_agent_count,
       .queue_count_per_physical_device = state->topology->gpu_agent_queue_count,
   };
   iree_hal_amdgpu_access_agent_list_t agent_list;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_access_agent_list_resolve(
-      state->topology, domain, queue_affinity, &agent_list));
+      state->topology, domain, queue_affinity, agent_classes, &agent_list));
 
   hsa_amd_memory_access_desc_t access_descs[IREE_HAL_AMDGPU_MAX_CPU_AGENT +
                                             IREE_HAL_AMDGPU_MAX_GPU_AGENT];

--- a/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
@@ -507,7 +507,7 @@ iree_status_t iree_hal_amdgpu_virtual_memory_protect(
     iree_hal_amdgpu_virtual_memory_state_t* state,
     iree_hal_buffer_t* virtual_buffer, iree_device_size_t virtual_offset,
     iree_device_size_t size, iree_hal_queue_affinity_t queue_affinity,
-    iree_hal_amdgpu_memory_agent_classes_t agent_classes,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   IREE_ASSERT_ARGUMENT(state);
   IREE_ASSERT_ARGUMENT(virtual_buffer);
@@ -539,7 +539,7 @@ iree_status_t iree_hal_amdgpu_virtual_memory_protect(
   };
   iree_hal_amdgpu_access_agent_list_t agent_list;
   IREE_RETURN_IF_ERROR(iree_hal_amdgpu_access_agent_list_resolve(
-      state->topology, domain, queue_affinity, agent_classes, &agent_list));
+      state->topology, domain, queue_affinity, access_scope, &agent_list));
 
   hsa_amd_memory_access_desc_t access_descs[IREE_HAL_AMDGPU_MAX_CPU_AGENT +
                                             IREE_HAL_AMDGPU_MAX_GPU_AGENT];

--- a/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.h
@@ -9,7 +9,6 @@
 
 #include "iree/base/api.h"
 #include "iree/hal/allocator.h"
-#include "iree/hal/drivers/amdgpu/allocator.h"
 #include "iree/hal/drivers/amdgpu/util/libhsa.h"
 
 #ifdef __cplusplus
@@ -104,7 +103,7 @@ iree_status_t iree_hal_amdgpu_virtual_memory_protect(
     iree_hal_amdgpu_virtual_memory_state_t* state,
     iree_hal_buffer_t* virtual_buffer, iree_device_size_t virtual_offset,
     iree_device_size_t size, iree_hal_queue_affinity_t queue_affinity,
-    iree_hal_amdgpu_memory_agent_classes_t agent_classes,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection);
 
 // Validates an advisory virtual-address range and otherwise performs no work.

--- a/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.h
@@ -9,6 +9,7 @@
 
 #include "iree/base/api.h"
 #include "iree/hal/allocator.h"
+#include "iree/hal/drivers/amdgpu/allocator.h"
 #include "iree/hal/drivers/amdgpu/util/libhsa.h"
 
 #ifdef __cplusplus
@@ -52,6 +53,7 @@ typedef struct iree_hal_amdgpu_virtual_memory_placement_t {
 iree_status_t iree_hal_amdgpu_virtual_memory_state_create(
     const iree_hal_amdgpu_libhsa_t* libhsa,
     const iree_hal_amdgpu_topology_t* topology, iree_hal_device_t* device,
+    iree_hal_queue_affinity_t supported_queue_affinity,
     iree_hal_allocator_statistics_t* statistics,
     iree_allocator_t host_allocator,
     iree_hal_amdgpu_virtual_memory_state_t** out_state);
@@ -102,6 +104,7 @@ iree_status_t iree_hal_amdgpu_virtual_memory_protect(
     iree_hal_amdgpu_virtual_memory_state_t* state,
     iree_hal_buffer_t* virtual_buffer, iree_device_size_t virtual_offset,
     iree_device_size_t size, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_amdgpu_memory_agent_classes_t agent_classes,
     iree_hal_memory_protection_t protection);
 
 // Validates an advisory virtual-address range and otherwise performs no work.

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
@@ -845,6 +845,7 @@ static iree_status_t iree_hal_cuda_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   return iree_make_status(IREE_STATUS_UNAVAILABLE,
                           "CUDA allocator does not support virtual memory");

--- a/runtime/src/iree/hal/drivers/hip/hip_allocator.c
+++ b/runtime/src/iree/hal/drivers/hip/hip_allocator.c
@@ -1118,6 +1118,7 @@ static iree_status_t iree_hal_hip_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   return iree_make_status(IREE_STATUS_UNAVAILABLE,
                           "HIP allocator does not support virtual memory");

--- a/runtime/src/iree/hal/drivers/metal/direct_allocator.m
+++ b/runtime/src/iree/hal/drivers/metal/direct_allocator.m
@@ -515,7 +515,7 @@ static iree_status_t iree_hal_metal_allocator_virtual_memory_protect(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer, iree_device_size_t virtual_offset,
     iree_device_size_t size, iree_hal_queue_affinity_t queue_affinity,
-    iree_hal_memory_protection_t protection) {
+    iree_hal_virtual_memory_access_scope_t access_scope, iree_hal_memory_protection_t protection) {
   return iree_make_status(IREE_STATUS_UNAVAILABLE,
                           "Metal allocator does not support virtual memory");
 }

--- a/runtime/src/iree/hal/drivers/null/allocator.c
+++ b/runtime/src/iree/hal/drivers/null/allocator.c
@@ -396,6 +396,7 @@ static iree_status_t iree_hal_null_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   return iree_make_status(IREE_STATUS_UNAVAILABLE,
                           "null allocator does not support virtual memory");

--- a/runtime/src/iree/hal/drivers/vulkan/allocator.c
+++ b/runtime/src/iree/hal/drivers/vulkan/allocator.c
@@ -2832,6 +2832,7 @@ static iree_status_t iree_hal_vulkan_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   iree_hal_vulkan_allocator_t* allocator =
       iree_hal_vulkan_allocator_cast(base_allocator);
@@ -2840,6 +2841,12 @@ static iree_status_t iree_hal_vulkan_allocator_virtual_memory_protect(
   IREE_RETURN_IF_ERROR(
       iree_hal_vulkan_allocator_require_virtual_buffer(virtual_buffer));
   (void)queue_affinity;
+  if (IREE_UNLIKELY(access_scope !=
+                    IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE)) {
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "Vulkan sparse virtual memory supports only device access scope");
+  }
   VkMemoryRequirements memory_requirements = {0};
   IREE_RETURN_IF_ERROR(iree_hal_vulkan_sparse_buffer_memory_requirements(
       virtual_buffer, &memory_requirements));

--- a/runtime/src/iree/hal/drivers/vulkan/cts/allocator_virtual_memory_test.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/cts/allocator_virtual_memory_test.cc
@@ -111,6 +111,7 @@ TEST_P(VulkanVirtualMemoryTest, ReserveMapTransferUnmap) {
   iree_status_t protect_status = iree_hal_allocator_virtual_memory_protect(
       device_allocator_, virtual_buffer.get(), /*virtual_offset=*/0,
       recommended_page_size, IREE_HAL_QUEUE_AFFINITY_ANY,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE);
   IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION, protect_status);
 
@@ -120,6 +121,7 @@ TEST_P(VulkanVirtualMemoryTest, ReserveMapTransferUnmap) {
   IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
       device_allocator_, virtual_buffer.get(), /*virtual_offset=*/0,
       recommended_page_size, IREE_HAL_QUEUE_AFFINITY_ANY,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
 
   constexpr iree_device_size_t kTouchedSize = 256;

--- a/runtime/src/iree/hal/drivers/vulkan/cts/bda_spirv_test.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/cts/bda_spirv_test.cc
@@ -939,10 +939,12 @@ TEST_P(BdaSpirvTest, CommandBufferExecutesBdaShaderWithSparseBindings) {
   IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
       device_allocator_, input_buffer.get(), /*virtual_offset=*/0,
       recommended_page_size, IREE_HAL_QUEUE_AFFINITY_ANY,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
   IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
       device_allocator_, output_buffer.get(), /*virtual_offset=*/0,
       recommended_page_size, IREE_HAL_QUEUE_AFFINITY_ANY,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
 
   const int32_t input_pattern = 5;

--- a/runtime/src/iree/hal/replay/recorder_allocator.c
+++ b/runtime/src/iree/hal/replay/recorder_allocator.c
@@ -511,6 +511,7 @@ static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   iree_hal_replay_recorder_allocator_t* allocator =
       iree_hal_replay_recorder_allocator_cast(base_allocator);
@@ -524,7 +525,7 @@ static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_protect(
       iree_hal_allocator_virtual_memory_protect(
           allocator->base_allocator,
           iree_hal_replay_recorder_buffer_base_or_self(virtual_buffer),
-          virtual_offset, size, queue_affinity, protection));
+          virtual_offset, size, queue_affinity, access_scope, protection));
 }
 
 static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_advise(

--- a/runtime/src/iree/hal/utils/caching_allocator.c
+++ b/runtime/src/iree/hal/utils/caching_allocator.c
@@ -885,12 +885,13 @@ static iree_status_t iree_hal_caching_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   iree_hal_caching_allocator_t* allocator =
       iree_hal_caching_allocator_cast(base_allocator);
   return iree_hal_allocator_virtual_memory_protect(
       allocator->device_allocator, virtual_buffer, virtual_offset, size,
-      queue_affinity, protection);
+      queue_affinity, access_scope, protection);
 }
 
 static iree_status_t iree_hal_caching_allocator_virtual_memory_advise(

--- a/runtime/src/iree/hal/utils/debug_allocator.c
+++ b/runtime/src/iree/hal/utils/debug_allocator.c
@@ -339,12 +339,13 @@ static iree_status_t iree_hal_debug_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   iree_hal_debug_allocator_t* allocator =
       iree_hal_debug_allocator_cast(base_allocator);
   return iree_hal_allocator_virtual_memory_protect(
       allocator->device_allocator, virtual_buffer, virtual_offset, size,
-      queue_affinity, protection);
+      queue_affinity, access_scope, protection);
 }
 
 static iree_status_t iree_hal_debug_allocator_virtual_memory_advise(


### PR DESCRIPTION
  ## Summary

  Add portable host and device execution scopes to the HAL virtual-memory protection API and implement them in the
  AMDGPU backend.

  This enables callers to distinguish between memory accessible by device execution, host execution, or both. Queue
  affinity continues to select the participating device topology, while the new access scope independently selects the
  execution domains receiving access.

  AMDGPU resolves these portable scopes to native agents internally. Native agent handles and access-policy details
  remain private to the driver.

  The change also improves host-memory imports by preserving both the original host address and the agent-visible
  address when native registration produces different values.

  ## Motivation

  HIP virtual-memory APIs such as hipMemSetAccess require independent host and device access control. Queue affinity
  alone cannot represent this distinction because host execution is not a device queue.

  Handling this through an AMDGPU-private API would require HRX to identify the concrete backend and directly call
  driver internals. That would break HAL encapsulation and would not work through allocator wrappers, proxies, or remote
  execution.

  The generic execution-scope contract preserves the requested policy through the HAL boundary while leaving each
  backend responsible for translating or rejecting it.

  ## Implementation

  - Add host, device, and combined virtual-memory access scopes to the HAL allocator API.
  - Forward the scope through caching, debugging, replay, and other allocator wrappers.
  - Have backends return IREE_STATUS_UNIMPLEMENTED when they cannot independently enforce a valid scope.
  - Resolve AMDGPU scopes to bounded, deduplicated native agent lists.
  - Keep native topology and agent handles internal to AMDGPU.
  - Preserve separate host and agent-visible addresses for imported host memory.
  - Remove the AMDGPU-private scoped-protection entry point.
  - Keep all topology resolution and native access updates off the dispatch hot path.

  ## HIP functionality enabled

  This supports the backend requirements for:

  - hipMemSetAccess and hipMemGetAccess
  - Host-only and device-only VMM permissions
  - Managed and registered host memory
  - Multi-device host-visible allocations
  - VMM-backed asynchronous allocation and memory pools
