### PR TITLE
[HAL/AMDGPU] Snapshot static indirect dispatch tables at queue issue

### DIFF
--- a/runtime/src/iree/hal/command_buffer.h
+++ b/runtime/src/iree/hal/command_buffer.h
@@ -494,10 +494,10 @@ typedef struct iree_hal_dispatch_config_t {
   //   operation producing the parameters and the dispatch to ensure the proper
   //   values are observed.
   // - IREE_HAL_DISPATCH_FLAG_STATIC_INDIRECT_PARAMETERS:
-  //   Device _may_ fetch the workgroup count at any point after the command
-  //   buffer submission is issued (all wait conditions satisfied) as the
-  //   flag indicates the parameters will not change during the execution of
-  //   the command buffer.
+  //   Device _may_ fetch the workgroup count as soon as the command buffer is
+  //   issued, including before its wait conditions are satisfied. The caller
+  //   must ensure the parameters have their final values before issuing the
+  //   containing queue operation and remain unchanged during execution.
   // The workgroup count buffer must have been allocated with
   // IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMETERS and be of
   // IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE.
@@ -541,10 +541,12 @@ enum iree_hal_dispatch_flag_bits_t {
   // ignored.
   IREE_HAL_DISPATCH_FLAG_DYNAMIC_INDIRECT_PARAMETERS = 1ull << 0,
 
-  // Indirect parameters such as workgroup count are static at the time the
-  // command buffer is issued. This is in contrast to dynamic parameters that
-  // may be changed by dispatches within the same command buffer. Enabling when
-  // known can lead to lower dispatch overhead.
+  // Indirect parameters such as workgroup count are static when the queue
+  // operation is issued. Implementations may snapshot the parameters during
+  // the queue call before wait conditions are satisfied. This is in contrast
+  // to dynamic parameters that may be changed by preceding queue operations or
+  // commands within the same command buffer. Enabling when known can lead to
+  // lower dispatch overhead.
   IREE_HAL_DISPATCH_FLAG_STATIC_INDIRECT_PARAMETERS = 1ull << 1,
 
   // Disables HAL ABI handling. The provided constants are passed through as

--- a/runtime/src/iree/hal/cts/command_buffer/dispatch_indirect_parameters_test.cc
+++ b/runtime/src/iree/hal/cts/command_buffer/dispatch_indirect_parameters_test.cc
@@ -207,6 +207,8 @@ TEST_P(DispatchIndirectParametersTest, StaticParametersFromQueueUpdate) {
       device_, IREE_HAL_QUEUE_AFFINITY_ANY, empty_wait, update_signal,
       parameter_data, /*source_offset=*/0, parameter_buffer,
       /*target_offset=*/0, sizeof(parameter_data), IREE_HAL_UPDATE_FLAG_NONE));
+  IREE_ASSERT_OK(iree_hal_semaphore_list_wait(
+      update_signal, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE));
 
   iree_hal_buffer_binding_t binding_table_values[2];
   iree_hal_buffer_binding_table_t binding_table =
@@ -253,6 +255,8 @@ TEST_P(DispatchIndirectParametersTest, WholeBufferParameterRef) {
       device_, IREE_HAL_QUEUE_AFFINITY_ANY, empty_wait, update_signal,
       parameter_data, /*source_offset=*/0, parameter_buffer,
       /*target_offset=*/0, sizeof(parameter_data), IREE_HAL_UPDATE_FLAG_NONE));
+  IREE_ASSERT_OK(iree_hal_semaphore_list_wait(
+      update_signal, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE));
 
   iree_hal_buffer_binding_t binding_table_values[2];
   iree_hal_buffer_binding_table_t binding_table =

--- a/runtime/src/iree/hal/cts/queue/queue_dispatch_test.cc
+++ b/runtime/src/iree/hal/cts/queue/queue_dispatch_test.cc
@@ -644,6 +644,11 @@ class QueueDispatchIndirectParametersTest : public CtsTestBase<> {
         parameter_data, /*source_offset=*/0, parameter_buffer,
         /*target_offset=*/0, sizeof(parameter_data),
         IREE_HAL_UPDATE_FLAG_NONE));
+    if (iree_any_bit_set(flags,
+                         IREE_HAL_DISPATCH_FLAG_STATIC_INDIRECT_PARAMETERS)) {
+      IREE_ASSERT_OK(iree_hal_semaphore_list_wait(
+          update_signal, iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE));
+    }
 
     iree_hal_buffer_ref_t binding_refs[1] = {
         iree_hal_make_buffer_ref(output_buffer, /*offset=*/0,

--- a/runtime/src/iree/hal/drivers/amdgpu/abi/command_buffer.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/abi/command_buffer.h
@@ -84,6 +84,9 @@ typedef enum iree_hal_amdgpu_command_buffer_dispatch_flag_bits_e {
       1u << 1,
   // The dispatch uses the AMD extended packet with |workgroup_cluster_size|.
   IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_WORKGROUP_CLUSTER = 1u << 2,
+  // Indirect workgroup counts are immutable for this command-buffer issue.
+  IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_STATIC_INDIRECT_PARAMETERS =
+      1u << 3,
 } iree_hal_amdgpu_command_buffer_dispatch_flag_bits_t;
 
 // Kernarg storage mode for a dispatch command.
@@ -148,10 +151,10 @@ typedef struct IREE_AMDGPU_ALIGNAS(8)
   uint32_t rodata_length;
   // Number of dispatch command records in this block.
   uint16_t dispatch_count;
-  // Number of dispatch command records using indirect parameters.
-  uint16_t indirect_dispatch_count;
-  // Number of profile marker command records in this block.
-  uint16_t profile_marker_count;
+  // Number of dispatch commands using static indirect parameters.
+  uint16_t static_indirect_dispatch_count;
+  // Reserved for future block-level dispatch metadata.
+  uint16_t reserved0;
   // Terminator opcode from iree_hal_amdgpu_command_buffer_opcode_t.
   uint8_t terminator_opcode;
   // Block flags from iree_hal_amdgpu_command_buffer_block_flag_bits_t.

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor.c
@@ -308,8 +308,9 @@ iree_hal_amdgpu_aql_block_processor_dispatch_kernarg_block_count(
 static iree_status_t
 iree_hal_amdgpu_aql_block_processor_write_dispatch_packet_body(
     const iree_hal_amdgpu_command_buffer_dispatch_command_t* dispatch_command,
-    uint64_t kernel_object, iree_hal_amdgpu_aql_packet_t* packet,
-    uint8_t* kernarg_data, iree_hsa_signal_t completion_signal,
+    const uint32_t* workgroup_count_override, uint64_t kernel_object,
+    iree_hal_amdgpu_aql_packet_t* packet, uint8_t* kernarg_data,
+    iree_hsa_signal_t completion_signal,
     iree_hal_amdgpu_aql_packet_control_t packet_control, uint16_t* out_header,
     uint16_t* out_setup) {
   iree_hal_amdgpu_aql_dispatch_params_t params = {
@@ -320,9 +321,12 @@ iree_hal_amdgpu_aql_block_processor_write_dispatch_packet_body(
       .packet_control = packet_control,
       .completion_signal = completion_signal,
   };
+  const uint32_t* workgroup_count = workgroup_count_override
+                                        ? workgroup_count_override
+                                        : dispatch_command->workgroup_count;
   for (iree_host_size_t i = 0; i < 3; ++i) {
     params.workgroup_size[i] = dispatch_command->workgroup_size[i];
-    params.workgroup_count[i] = dispatch_command->workgroup_count[i];
+    params.workgroup_count[i] = workgroup_count[i];
     params.workgroup_cluster_size[i] =
         dispatch_command->workgroup_cluster_size[i];
   }
@@ -470,6 +474,13 @@ iree_hal_amdgpu_aql_block_processor_replay_dispatch_indirect_params_ptr(
       return iree_ok_status();
     case IREE_HAL_AMDGPU_COMMAND_BUFFER_BINDING_SOURCE_FLAG_DYNAMIC |
         IREE_HAL_AMDGPU_COMMAND_BUFFER_BINDING_SOURCE_FLAG_INDIRECT_PARAMETERS: {
+      if (processor->bindings.ptrs) {
+        *out_workgroup_count_ptr =
+            (const uint32_t*)(uintptr_t)(processor->bindings
+                                             .ptrs[binding_source->slot] +
+                                         binding_source->offset_or_pointer);
+        return iree_ok_status();
+      }
       iree_hal_buffer_ref_t resolved_ref = {0};
       IREE_RETURN_IF_ERROR(iree_hal_buffer_binding_table_resolve_ref(
           processor->bindings.table,
@@ -523,6 +534,7 @@ iree_hal_amdgpu_aql_block_processor_replay_dispatch_packet_body(
     const iree_hal_amdgpu_command_buffer_block_header_t* block,
     const iree_hal_amdgpu_command_buffer_dispatch_command_t* dispatch_command,
     iree_hal_amdgpu_aql_packet_t* packet, uint8_t* kernarg_data,
+    const uint32_t* workgroup_count_override,
     iree_hsa_signal_t completion_signal,
     iree_hal_amdgpu_aql_packet_control_t packet_control, uint16_t* out_header,
     uint16_t* out_setup) {
@@ -548,9 +560,19 @@ iree_hal_amdgpu_aql_block_processor_replay_dispatch_packet_body(
   IREE_RETURN_IF_ERROR(
       iree_hal_amdgpu_aql_block_processor_resolve_dispatch_kernel_object(
           processor, dispatch_command, &kernel_object));
+  if (workgroup_count_override) {
+    iree_amdgpu_kernel_implicit_args_t* implicit_args =
+        iree_hal_amdgpu_aql_block_processor_dispatch_implicit_args_ptr(
+            dispatch_command, kernarg_data);
+    if (implicit_args) {
+      for (iree_host_size_t i = 0; i < 3; ++i) {
+        implicit_args->block_count[i] = workgroup_count_override[i];
+      }
+    }
+  }
   return iree_hal_amdgpu_aql_block_processor_write_dispatch_packet_body(
-      dispatch_command, kernel_object, packet, kernarg_data, completion_signal,
-      packet_control, out_header, out_setup);
+      dispatch_command, workgroup_count_override, kernel_object, packet,
+      kernarg_data, completion_signal, packet_control, out_header, out_setup);
 }
 
 static iree_status_t
@@ -567,8 +589,9 @@ iree_hal_amdgpu_aql_block_processor_replay_indirect_dispatch_packet_bodies(
   IREE_RETURN_IF_ERROR(
       iree_hal_amdgpu_aql_block_processor_replay_dispatch_packet_body(
           processor, block, dispatch_command, dispatch_packet,
-          dispatch_kernarg_data, completion_signal, dispatch_packet_control,
-          &dispatch_header, out_dispatch_setup));
+          dispatch_kernarg_data, /*workgroup_count_override=*/NULL,
+          completion_signal, dispatch_packet_control, &dispatch_header,
+          out_dispatch_setup));
 
   const iree_hal_amdgpu_command_buffer_binding_source_t* binding_sources =
       (const iree_hal_amdgpu_command_buffer_binding_source_t*)((const uint8_t*)
@@ -851,8 +874,8 @@ static iree_status_t iree_hal_amdgpu_aql_block_processor_emit_direct_dispatch(
   iree_status_t status =
       iree_hal_amdgpu_aql_block_processor_replay_dispatch_packet_body(
           processor, block, dispatch_command, packet, kernarg_data,
-          iree_hsa_signal_null(), packet_control,
-          &processor->packets.headers[dispatch_packet_index],
+          /*workgroup_count_override=*/NULL, iree_hsa_signal_null(),
+          packet_control, &processor->packets.headers[dispatch_packet_index],
           &processor->packets.setups[dispatch_packet_index]);
   if (iree_status_is_ok(status)) {
     ++state->packets.emitted;
@@ -870,6 +893,73 @@ static iree_status_t iree_hal_amdgpu_aql_block_processor_emit_indirect_dispatch(
     uint32_t payload_acquire_packet_count,
     const iree_hal_amdgpu_command_buffer_dispatch_command_t* dispatch_command,
     iree_hal_amdgpu_aql_block_processor_state_t* state) {
+  const bool resolve_on_host =
+      iree_hal_amdgpu_aql_block_processor_dispatch_uses_static_indirect(
+          dispatch_command) &&
+      iree_any_bit_set(
+          processor->flags,
+          IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_FLAG_HOST_RESOLVE_STATIC_INDIRECT);
+  if (resolve_on_host) {
+    const uint32_t dispatch_packet_index = state->packets.emitted;
+    iree_hal_amdgpu_aql_packet_t* dispatch_packet =
+        iree_hal_amdgpu_aql_block_processor_packet(processor,
+                                                   dispatch_packet_index);
+    const iree_hal_amdgpu_command_buffer_binding_source_t* binding_sources =
+        (const iree_hal_amdgpu_command_buffer_binding_source_t*)((const uint8_t*)
+                                                                     block +
+                                                                 dispatch_command
+                                                                     ->binding_source_offset);
+    const iree_hal_amdgpu_command_buffer_binding_source_t*
+        indirect_params_source =
+            &binding_sources[dispatch_command->payload.binding_source_count];
+    const uint32_t* workgroup_count = NULL;
+    IREE_RETURN_IF_ERROR(
+        iree_hal_amdgpu_aql_block_processor_replay_dispatch_indirect_params_ptr(
+            processor, indirect_params_source, &workgroup_count));
+
+    iree_hal_amdgpu_aql_block_processor_packet_flags_t dispatch_packet_flags =
+        iree_hal_amdgpu_aql_block_processor_command_packet_flags(
+            &dispatch_command->header);
+    if (iree_hal_amdgpu_aql_block_processor_is_block_final(
+            block, state, /*recorded_packet_count=*/2) &&
+        iree_all_bits_set(
+            processor->flags,
+            IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_FLAG_FINAL_PAYLOAD_PACKET)) {
+      dispatch_packet_flags |=
+          IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_PACKET_FLAG_FINAL;
+    }
+    const iree_hsa_fence_scope_t payload_acquire_scope =
+        iree_hal_amdgpu_aql_block_processor_payload_acquire_scope(
+            processor, state, payload_acquire_packet_count,
+            dispatch_packet_index, &dispatch_command->header,
+            dispatch_packet_flags);
+    const iree_hal_amdgpu_aql_packet_control_t dispatch_packet_control =
+        iree_hal_amdgpu_aql_block_processor_packet_control(
+            processor, dispatch_packet_index, payload_acquire_scope,
+            dispatch_packet_flags);
+    uint8_t* dispatch_kernarg_data = NULL;
+    if (iree_hal_amdgpu_aql_block_processor_dispatch_uses_queue_kernargs(
+            dispatch_command)) {
+      dispatch_kernarg_data =
+          processor->kernargs.blocks[state->kernargs.block].data;
+    }
+    iree_status_t status =
+        iree_hal_amdgpu_aql_block_processor_replay_dispatch_packet_body(
+            processor, block, dispatch_command, dispatch_packet,
+            dispatch_kernarg_data, workgroup_count, iree_hsa_signal_null(),
+            dispatch_packet_control,
+            &processor->packets.headers[dispatch_packet_index],
+            &processor->packets.setups[dispatch_packet_index]);
+    if (iree_status_is_ok(status)) {
+      ++state->packets.emitted;
+      state->packets.recorded += 2;
+      state->kernargs.block +=
+          iree_hal_amdgpu_aql_block_processor_dispatch_target_kernarg_block_count(
+              dispatch_command);
+    }
+    return status;
+  }
+
   const uint32_t patch_packet_index = state->packets.emitted++;
   const uint32_t dispatch_packet_index = state->packets.emitted;
   iree_hal_amdgpu_aql_packet_t* patch_packet =

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor.c
@@ -193,6 +193,13 @@ iree_hal_amdgpu_aql_block_processor_execution_barrier_packet_flags(void) {
       IREE_HSA_FENCE_SCOPE_NONE, IREE_HSA_FENCE_SCOPE_NONE);
 }
 
+static iree_hal_amdgpu_aql_block_processor_packet_flags_t
+iree_hal_amdgpu_aql_block_processor_agent_barrier_packet_flags(void) {
+  return iree_hal_amdgpu_aql_block_processor_packet_flags_set_fence_scopes(
+      IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_PACKET_FLAG_EXECUTION_BARRIER,
+      IREE_HSA_FENCE_SCOPE_AGENT, IREE_HSA_FENCE_SCOPE_AGENT);
+}
+
 static iree_hal_amdgpu_aql_block_processor_packet_flag_pair_t
 iree_hal_amdgpu_aql_block_processor_split_command_packet_flags(
     const iree_hal_amdgpu_command_buffer_command_header_t* command) {
@@ -227,6 +234,14 @@ static bool iree_hal_amdgpu_aql_block_processor_dispatch_uses_indirect(
   return iree_any_bit_set(
       dispatch_command->dispatch_flags,
       IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_INDIRECT_PARAMETERS);
+}
+
+static bool iree_hal_amdgpu_aql_block_processor_dispatch_uses_static_indirect(
+    const iree_hal_amdgpu_command_buffer_dispatch_command_t* dispatch_command) {
+  return iree_all_bits_set(
+      dispatch_command->dispatch_flags,
+      IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_INDIRECT_PARAMETERS |
+          IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_STATIC_INDIRECT_PARAMETERS);
 }
 
 static iree_status_t
@@ -888,10 +903,14 @@ static iree_status_t iree_hal_amdgpu_aql_block_processor_emit_indirect_dispatch(
           &processor->packets.setups[patch_packet_index],
           &processor->packets.setups[dispatch_packet_index]);
   if (iree_status_is_ok(status)) {
+    const iree_hal_amdgpu_aql_block_processor_packet_flags_t required_patch_flags =
+        iree_hal_amdgpu_aql_block_processor_dispatch_uses_static_indirect(
+            dispatch_command)
+            ? iree_hal_amdgpu_aql_block_processor_agent_barrier_packet_flags()
+            : iree_hal_amdgpu_aql_block_processor_execution_barrier_packet_flags();
     const iree_hal_amdgpu_aql_block_processor_packet_flags_t patch_flags =
         iree_hal_amdgpu_aql_block_processor_packet_flags_merge(
-            iree_hal_amdgpu_aql_block_processor_execution_barrier_packet_flags(),
-            command_flags.first);
+            required_patch_flags, command_flags.first);
     const iree_hsa_fence_scope_t patch_acquire_scope =
         iree_hal_amdgpu_aql_block_processor_payload_acquire_scope(
             processor, state, payload_acquire_packet_count, patch_packet_index,

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor.h
@@ -23,6 +23,9 @@ enum iree_hal_amdgpu_aql_block_processor_flag_bits_t {
   IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_FLAG_NONE = 0u,
   // The final recorded payload packet carries terminal signal release scope.
   IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_FLAG_FINAL_PAYLOAD_PACKET = 1u << 0,
+  // Static-indirect dispatches snapshot their workgroup counts on the host.
+  IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_FLAG_HOST_RESOLVE_STATIC_INDIRECT = 1u
+                                                                          << 1,
 };
 
 typedef uint8_t iree_hal_amdgpu_aql_block_processor_terminator_t;

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor_profile.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor_profile.c
@@ -212,6 +212,15 @@ static bool iree_hal_amdgpu_aql_block_processor_profile_dispatch_uses_indirect(
       IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_INDIRECT_PARAMETERS);
 }
 
+static bool
+iree_hal_amdgpu_aql_block_processor_profile_dispatch_uses_static_indirect(
+    const iree_hal_amdgpu_command_buffer_dispatch_command_t* dispatch_command) {
+  return iree_all_bits_set(
+      dispatch_command->dispatch_flags,
+      IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_INDIRECT_PARAMETERS |
+          IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_STATIC_INDIRECT_PARAMETERS);
+}
+
 static iree_status_t
 iree_hal_amdgpu_aql_block_processor_profile_validate_dispatch_encoding(
     const iree_hal_amdgpu_command_buffer_dispatch_command_t* dispatch_command) {
@@ -1125,10 +1134,14 @@ iree_hal_amdgpu_aql_block_processor_profile_emit_indirect_dispatch(
           &processor->packets.setups[patch_packet_index],
           &processor->packets.setups[dispatch_packet_index]);
   if (iree_status_is_ok(status)) {
+    const iree_hal_amdgpu_host_queue_command_buffer_packet_flags_t required_patch_flags =
+        iree_hal_amdgpu_aql_block_processor_profile_dispatch_uses_static_indirect(
+            dispatch_command)
+            ? iree_hal_amdgpu_aql_block_processor_profile_agent_barrier_packet_flags()
+            : iree_hal_amdgpu_aql_block_processor_profile_execution_barrier_packet_flags();
     const iree_hal_amdgpu_host_queue_command_buffer_packet_flags_t patch_flags =
         iree_hal_amdgpu_aql_block_processor_profile_packet_flags_merge(
-            iree_hal_amdgpu_aql_block_processor_profile_execution_barrier_packet_flags(),
-            command_packet_flags.first);
+            required_patch_flags, command_packet_flags.first);
     const iree_hsa_fence_scope_t patch_acquire_scope =
         iree_hal_amdgpu_aql_block_processor_profile_payload_acquire_scope(
             processor, state, patch_packet_index, &dispatch_command->header,

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor_profile.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor_profile.c
@@ -289,8 +289,9 @@ iree_hal_amdgpu_aql_block_processor_profile_dispatch_kernarg_block_count(
 static iree_status_t
 iree_hal_amdgpu_aql_block_processor_profile_write_dispatch_packet_body(
     const iree_hal_amdgpu_command_buffer_dispatch_command_t* dispatch_command,
-    uint64_t kernel_object, iree_hal_amdgpu_aql_packet_t* packet,
-    uint8_t* kernarg_data, iree_hsa_signal_t completion_signal,
+    const uint32_t* workgroup_count_override, uint64_t kernel_object,
+    iree_hal_amdgpu_aql_packet_t* packet, uint8_t* kernarg_data,
+    iree_hsa_signal_t completion_signal,
     iree_hal_amdgpu_aql_packet_control_t packet_control, uint16_t* out_header,
     uint16_t* out_setup) {
   iree_hal_amdgpu_aql_dispatch_params_t params = {
@@ -301,9 +302,12 @@ iree_hal_amdgpu_aql_block_processor_profile_write_dispatch_packet_body(
       .packet_control = packet_control,
       .completion_signal = completion_signal,
   };
+  const uint32_t* workgroup_count = workgroup_count_override
+                                        ? workgroup_count_override
+                                        : dispatch_command->workgroup_count;
   for (iree_host_size_t i = 0; i < 3; ++i) {
     params.workgroup_size[i] = dispatch_command->workgroup_size[i];
-    params.workgroup_count[i] = dispatch_command->workgroup_count[i];
+    params.workgroup_count[i] = workgroup_count[i];
     params.workgroup_cluster_size[i] =
         dispatch_command->workgroup_cluster_size[i];
   }
@@ -454,6 +458,13 @@ iree_hal_amdgpu_aql_block_processor_profile_replay_dispatch_indirect_params_ptr(
       return iree_ok_status();
     case IREE_HAL_AMDGPU_COMMAND_BUFFER_BINDING_SOURCE_FLAG_DYNAMIC |
         IREE_HAL_AMDGPU_COMMAND_BUFFER_BINDING_SOURCE_FLAG_INDIRECT_PARAMETERS: {
+      if (processor->bindings.ptrs) {
+        *out_workgroup_count_ptr =
+            (const uint32_t*)(uintptr_t)(processor->bindings
+                                             .ptrs[binding_source->slot] +
+                                         binding_source->offset_or_pointer);
+        return iree_ok_status();
+      }
       iree_hal_buffer_ref_t resolved_ref = {0};
       IREE_RETURN_IF_ERROR(iree_hal_buffer_binding_table_resolve_ref(
           processor->bindings.table,
@@ -506,6 +517,7 @@ iree_hal_amdgpu_aql_block_processor_profile_replay_dispatch_packet_body(
     const iree_hal_amdgpu_aql_block_processor_profile_t* processor,
     const iree_hal_amdgpu_command_buffer_dispatch_command_t* dispatch_command,
     iree_hal_amdgpu_aql_packet_t* packet, uint8_t* kernarg_data,
+    const uint32_t* workgroup_count_override,
     iree_hsa_signal_t completion_signal,
     iree_hal_amdgpu_aql_packet_control_t packet_control, uint16_t* out_header,
     uint16_t* out_setup) {
@@ -530,9 +542,19 @@ iree_hal_amdgpu_aql_block_processor_profile_replay_dispatch_packet_body(
   IREE_RETURN_IF_ERROR(
       iree_hal_amdgpu_aql_block_processor_profile_resolve_dispatch_kernel_object(
           processor, dispatch_command, &kernel_object));
+  if (workgroup_count_override) {
+    iree_amdgpu_kernel_implicit_args_t* implicit_args =
+        iree_hal_amdgpu_aql_block_processor_profile_dispatch_implicit_args_ptr(
+            dispatch_command, kernarg_data);
+    if (implicit_args) {
+      for (iree_host_size_t i = 0; i < 3; ++i) {
+        implicit_args->block_count[i] = workgroup_count_override[i];
+      }
+    }
+  }
   return iree_hal_amdgpu_aql_block_processor_profile_write_dispatch_packet_body(
-      dispatch_command, kernel_object, packet, kernarg_data, completion_signal,
-      packet_control, out_header, out_setup);
+      dispatch_command, workgroup_count_override, kernel_object, packet,
+      kernarg_data, completion_signal, packet_control, out_header, out_setup);
 }
 
 static iree_status_t
@@ -548,8 +570,8 @@ iree_hal_amdgpu_aql_block_processor_profile_replay_indirect_dispatch_packet_bodi
   IREE_RETURN_IF_ERROR(
       iree_hal_amdgpu_aql_block_processor_profile_replay_dispatch_packet_body(
           processor, dispatch_command, dispatch_packet, dispatch_kernarg_data,
-          completion_signal, dispatch_packet_control, &dispatch_header,
-          out_dispatch_setup));
+          /*workgroup_count_override=*/NULL, completion_signal,
+          dispatch_packet_control, &dispatch_header, out_dispatch_setup));
 
   const iree_hal_amdgpu_command_buffer_binding_source_t* binding_sources =
       (const iree_hal_amdgpu_command_buffer_binding_source_t*)((const uint8_t*)
@@ -830,6 +852,7 @@ iree_hal_amdgpu_aql_block_processor_profile_completion_signal(
 static void iree_hal_amdgpu_aql_block_processor_profile_emit_source(
     const iree_hal_amdgpu_aql_block_processor_profile_t* processor,
     iree_hal_amdgpu_aql_block_processor_dispatch_profile_t profile,
+    const uint32_t* workgroup_count_override,
     iree_hal_amdgpu_aql_block_processor_profile_state_t* state) {
   if (!iree_hal_amdgpu_aql_block_processor_dispatch_profile_has(
           profile,
@@ -838,8 +861,8 @@ static void iree_hal_amdgpu_aql_block_processor_profile_emit_source(
   }
   iree_hal_amdgpu_host_queue_record_command_buffer_profile_dispatch_source(
       processor->queue, processor->profile.command_buffer_id, profile.dispatch,
-      processor->profile.dispatch_events, processor->profile.harvest_sources,
-      &state->profile.event);
+      workgroup_count_override, processor->profile.dispatch_events,
+      processor->profile.harvest_sources, &state->profile.event);
 }
 
 static const iree_hal_amdgpu_aql_block_processor_profile_dispatch_t*
@@ -1041,12 +1064,13 @@ iree_hal_amdgpu_aql_block_processor_profile_emit_direct_dispatch(
           packet_flags);
   iree_status_t status =
       iree_hal_amdgpu_aql_block_processor_profile_replay_dispatch_packet_body(
-          processor, dispatch_command, packet, kernarg_data, completion_signal,
-          packet_control, &processor->packets.headers[dispatch_packet_index],
+          processor, dispatch_command, packet, kernarg_data,
+          /*workgroup_count_override=*/NULL, completion_signal, packet_control,
+          &processor->packets.headers[dispatch_packet_index],
           &processor->packets.setups[dispatch_packet_index]);
   if (iree_status_is_ok(status)) {
-    iree_hal_amdgpu_aql_block_processor_profile_emit_source(processor, profile,
-                                                            state);
+    iree_hal_amdgpu_aql_block_processor_profile_emit_source(
+        processor, profile, /*workgroup_count_override=*/NULL, state);
     ++state->packets.emitted;
     ++state->packets.recorded;
     state->kernargs.block +=
@@ -1080,14 +1104,19 @@ iree_hal_amdgpu_aql_block_processor_profile_emit_indirect_dispatch(
   const iree_hal_amdgpu_host_queue_command_buffer_packet_flags_t
       profile_packet_flags =
           iree_hal_amdgpu_aql_block_processor_profile_packet_flags(profile);
-  const iree_hal_amdgpu_aql_block_processor_profile_packet_flag_pair_t
-      command_packet_flags =
-          iree_hal_amdgpu_aql_block_processor_profile_split_command_packet_flags(
-              &dispatch_command->header);
   const iree_hal_amdgpu_aql_block_processor_dispatch_profile_flags_t
       profile_flags = profile.flags;
+  const bool resolve_on_host =
+      iree_hal_amdgpu_aql_block_processor_profile_dispatch_uses_static_indirect(
+          dispatch_command) &&
+      iree_any_bit_set(
+          processor->flags,
+          IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_PROFILE_FLAG_HOST_RESOLVE_STATIC_INDIRECT);
 
-  const uint32_t patch_packet_index = state->packets.emitted++;
+  uint32_t patch_packet_index = 0;
+  if (!resolve_on_host) {
+    patch_packet_index = state->packets.emitted++;
+  }
   if (iree_any_bit_set(
           profile_flags,
           IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_DISPATCH_PROFILE_FLAG_COUNTER_PACKETS)) {
@@ -1107,64 +1136,117 @@ iree_hal_amdgpu_aql_block_processor_profile_emit_indirect_dispatch(
         state);
   }
   const uint32_t dispatch_packet_index = state->packets.emitted;
-  iree_hal_amdgpu_aql_packet_t* patch_packet =
-      iree_hal_amdgpu_aql_block_processor_profile_packet(processor,
-                                                         patch_packet_index);
   iree_hal_amdgpu_aql_packet_t* dispatch_packet =
       iree_hal_amdgpu_aql_block_processor_profile_packet(processor,
                                                          dispatch_packet_index);
+  const iree_hal_amdgpu_command_buffer_binding_source_t* binding_sources =
+      (const iree_hal_amdgpu_command_buffer_binding_source_t*)((const uint8_t*)
+                                                                   processor
+                                                                       ->block +
+                                                               dispatch_command
+                                                                   ->binding_source_offset);
+  const iree_hal_amdgpu_command_buffer_binding_source_t*
+      indirect_params_source =
+          &binding_sources[dispatch_command->payload.binding_source_count];
+  const uint32_t* workgroup_count = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_aql_block_processor_profile_replay_dispatch_indirect_params_ptr(
+          processor, indirect_params_source, &workgroup_count));
   const iree_hsa_signal_t completion_signal =
       iree_hal_amdgpu_aql_block_processor_profile_completion_signal(
           processor, state, profile);
-  const iree_hal_amdgpu_host_queue_command_buffer_packet_flags_t
-      dispatch_packet_flags =
-          iree_hal_amdgpu_aql_block_processor_profile_packet_flags_merge(
-              command_packet_flags.final, profile_packet_flags);
-  const iree_hal_amdgpu_aql_packet_control_t dispatch_packet_control =
-      iree_hal_amdgpu_aql_block_processor_profile_packet_control(
-          processor, dispatch_packet_index, IREE_HSA_FENCE_SCOPE_NONE,
-          dispatch_packet_flags);
 
-  iree_status_t status =
-      iree_hal_amdgpu_aql_block_processor_profile_replay_indirect_dispatch_packet_bodies(
-          processor, dispatch_command, patch_packet, dispatch_packet,
-          processor->kernargs.blocks[state->kernargs.block].data,
-          processor->kernargs.blocks[state->kernargs.block + 1].data,
-          completion_signal, dispatch_packet_control,
-          &processor->packets.setups[patch_packet_index],
-          &processor->packets.setups[dispatch_packet_index]);
-  if (iree_status_is_ok(status)) {
-    const iree_hal_amdgpu_host_queue_command_buffer_packet_flags_t required_patch_flags =
-        iree_hal_amdgpu_aql_block_processor_profile_dispatch_uses_static_indirect(
-            dispatch_command)
-            ? iree_hal_amdgpu_aql_block_processor_profile_agent_barrier_packet_flags()
-            : iree_hal_amdgpu_aql_block_processor_profile_execution_barrier_packet_flags();
-    const iree_hal_amdgpu_host_queue_command_buffer_packet_flags_t patch_flags =
-        iree_hal_amdgpu_aql_block_processor_profile_packet_flags_merge(
-            required_patch_flags, command_packet_flags.first);
-    const iree_hsa_fence_scope_t patch_acquire_scope =
+  iree_status_t status = iree_ok_status();
+  if (resolve_on_host) {
+    const iree_hal_amdgpu_host_queue_command_buffer_packet_flags_t
+        dispatch_packet_flags =
+            iree_hal_amdgpu_aql_block_processor_profile_packet_flags_merge(
+                iree_hal_amdgpu_aql_block_processor_profile_command_packet_flags(
+                    &dispatch_command->header),
+                profile_packet_flags);
+    const iree_hsa_fence_scope_t payload_acquire_scope =
         iree_hal_amdgpu_aql_block_processor_profile_payload_acquire_scope(
-            processor, state, patch_packet_index, &dispatch_command->header,
-            patch_flags);
-    iree_hal_amdgpu_aql_block_processor_profile_emit_source(processor, profile,
-                                                            state);
-    // The patch dispatch publishes the following dispatch packet header, so it
-    // must retire before the CP observes that slot.
-    processor->packets.headers[patch_packet_index] =
-        iree_hal_amdgpu_aql_make_header(
-            IREE_HSA_PACKET_TYPE_KERNEL_DISPATCH,
-            iree_hal_amdgpu_aql_block_processor_profile_packet_control(
-                processor, patch_packet_index, patch_acquire_scope,
-                patch_flags));
-    // The patch dispatch publishes the target dispatch header after it has
-    // updated dynamic workgroup counts on device.
-    processor->packets.headers[dispatch_packet_index] =
-        IREE_HSA_PACKET_TYPE_INVALID;
+            processor, state, dispatch_packet_index, &dispatch_command->header,
+            dispatch_packet_flags);
+    const iree_hal_amdgpu_aql_packet_control_t dispatch_packet_control =
+        iree_hal_amdgpu_aql_block_processor_profile_packet_control(
+            processor, dispatch_packet_index, payload_acquire_scope,
+            dispatch_packet_flags);
+    uint8_t* dispatch_kernarg_data = NULL;
+    if (iree_hal_amdgpu_aql_block_processor_profile_dispatch_uses_queue_kernargs(
+            dispatch_command)) {
+      dispatch_kernarg_data =
+          processor->kernargs.blocks[state->kernargs.block].data;
+    }
+    status =
+        iree_hal_amdgpu_aql_block_processor_profile_replay_dispatch_packet_body(
+            processor, dispatch_command, dispatch_packet, dispatch_kernarg_data,
+            workgroup_count, completion_signal, dispatch_packet_control,
+            &processor->packets.headers[dispatch_packet_index],
+            &processor->packets.setups[dispatch_packet_index]);
+  } else {
+    iree_hal_amdgpu_aql_packet_t* patch_packet =
+        iree_hal_amdgpu_aql_block_processor_profile_packet(processor,
+                                                           patch_packet_index);
+    const iree_hal_amdgpu_aql_block_processor_profile_packet_flag_pair_t
+        command_packet_flags =
+            iree_hal_amdgpu_aql_block_processor_profile_split_command_packet_flags(
+                &dispatch_command->header);
+    const iree_hal_amdgpu_host_queue_command_buffer_packet_flags_t
+        dispatch_packet_flags =
+            iree_hal_amdgpu_aql_block_processor_profile_packet_flags_merge(
+                command_packet_flags.final, profile_packet_flags);
+    const iree_hal_amdgpu_aql_packet_control_t dispatch_packet_control =
+        iree_hal_amdgpu_aql_block_processor_profile_packet_control(
+            processor, dispatch_packet_index, IREE_HSA_FENCE_SCOPE_NONE,
+            dispatch_packet_flags);
+    status =
+        iree_hal_amdgpu_aql_block_processor_profile_replay_indirect_dispatch_packet_bodies(
+            processor, dispatch_command, patch_packet, dispatch_packet,
+            processor->kernargs.blocks[state->kernargs.block].data,
+            processor->kernargs.blocks[state->kernargs.block + 1].data,
+            completion_signal, dispatch_packet_control,
+            &processor->packets.setups[patch_packet_index],
+            &processor->packets.setups[dispatch_packet_index]);
+    if (iree_status_is_ok(status)) {
+      const iree_hal_amdgpu_host_queue_command_buffer_packet_flags_t required_patch_flags =
+          iree_hal_amdgpu_aql_block_processor_profile_dispatch_uses_static_indirect(
+              dispatch_command)
+              ? iree_hal_amdgpu_aql_block_processor_profile_agent_barrier_packet_flags()
+              : iree_hal_amdgpu_aql_block_processor_profile_execution_barrier_packet_flags();
+      const iree_hal_amdgpu_host_queue_command_buffer_packet_flags_t
+          patch_flags =
+              iree_hal_amdgpu_aql_block_processor_profile_packet_flags_merge(
+                  required_patch_flags, command_packet_flags.first);
+      const iree_hsa_fence_scope_t patch_acquire_scope =
+          iree_hal_amdgpu_aql_block_processor_profile_payload_acquire_scope(
+              processor, state, patch_packet_index, &dispatch_command->header,
+              patch_flags);
+      // The patch dispatch publishes the following dispatch packet header, so
+      // it must retire before the CP observes that slot.
+      processor->packets.headers[patch_packet_index] =
+          iree_hal_amdgpu_aql_make_header(
+              IREE_HSA_PACKET_TYPE_KERNEL_DISPATCH,
+              iree_hal_amdgpu_aql_block_processor_profile_packet_control(
+                  processor, patch_packet_index, patch_acquire_scope,
+                  patch_flags));
+      // The patch dispatch publishes the target dispatch header after it has
+      // updated dynamic workgroup counts on device.
+      processor->packets.headers[dispatch_packet_index] =
+          IREE_HSA_PACKET_TYPE_INVALID;
+    }
+  }
+  if (iree_status_is_ok(status)) {
+    iree_hal_amdgpu_aql_block_processor_profile_emit_source(
+        processor, profile, resolve_on_host ? workgroup_count : NULL, state);
     state->packets.emitted = dispatch_packet_index + /*dispatch packet=*/1;
     state->packets.recorded += 2;
     state->kernargs.block +=
-        iree_hal_amdgpu_aql_block_processor_profile_dispatch_kernarg_block_count(
-            dispatch_command);
+        resolve_on_host
+            ? iree_hal_amdgpu_aql_block_processor_profile_dispatch_target_kernarg_block_count(
+                  dispatch_command)
+            : iree_hal_amdgpu_aql_block_processor_profile_dispatch_kernarg_block_count(
+                  dispatch_command);
     if (iree_any_bit_set(
             profile_flags,
             IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_DISPATCH_PROFILE_FLAG_TRACE_PACKETS)) {

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor_profile.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor_profile.h
@@ -26,6 +26,9 @@ enum iree_hal_amdgpu_aql_block_processor_profile_flag_bits_t {
   IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_PROFILE_FLAG_DISPATCH_PACKETS = 1u << 0,
   // This block reserves a whole-block queue-device timestamp event.
   IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_PROFILE_FLAG_QUEUE_DEVICE_EVENT = 1u << 1,
+  // Static-indirect dispatches snapshot their workgroup counts on the host.
+  IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_PROFILE_FLAG_HOST_RESOLVE_STATIC_INDIRECT =
+      1u << 2,
 };
 
 typedef uint8_t iree_hal_amdgpu_aql_block_processor_profile_terminator_t;

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor_test.cc
@@ -1097,6 +1097,129 @@ TEST(AqlBlockProcessorTest,
   EXPECT_EQ(packet_headers[1], IREE_HSA_PACKET_TYPE_INVALID);
 }
 
+TEST(AqlBlockProcessorTest,
+     StaticIndirectHostResolutionEmitsOnlyTargetDispatch) {
+  uint32_t workgroup_count[3] = {7, 5, 3};
+  IndirectDispatchBlock block = MakeIndirectDispatchBlock(workgroup_count);
+  block.header.static_indirect_dispatch_count = 1;
+  block.dispatch_command.dispatch_flags |=
+      IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_STATIC_INDIRECT_PARAMETERS;
+  block.dispatch_command.implicit_args_offset_qwords = 0;
+
+  alignas(64) iree_hal_amdgpu_aql_packet_t packets[8] = {};
+  iree_hal_amdgpu_aql_ring_t ring = {};
+  ring.base = packets;
+  ring.mask = IREE_ARRAYSIZE(packets) - 1u;
+  uint16_t packet_header = 0;
+  uint16_t packet_setup = 0;
+  iree_hal_amdgpu_kernarg_block_t kernarg_block = {};
+  iree_hal_amdgpu_aql_block_processor_t processor = MakeProcessor(
+      &ring, /*packet_count=*/1, &packet_header, &packet_setup, &kernarg_block,
+      /*kernarg_block_count=*/1,
+      IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_FLAG_FINAL_PAYLOAD_PACKET |
+          IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_FLAG_HOST_RESOLVE_STATIC_INDIRECT,
+      IREE_HSA_FENCE_SCOPE_NONE, IREE_HSA_FENCE_SCOPE_SYSTEM,
+      IREE_HSA_FENCE_SCOPE_NONE);
+
+  iree_hal_amdgpu_aql_block_processor_result_t result;
+  IREE_ASSERT_OK(iree_hal_amdgpu_aql_block_processor_invoke(
+      &processor, &block.header, &result));
+
+  EXPECT_EQ(result.packets.recorded, 2u);
+  EXPECT_EQ(result.packets.emitted, 1u);
+  EXPECT_EQ(result.kernargs.consumed, 1u);
+  EXPECT_EQ(AqlHeaderField(packet_header, IREE_HSA_PACKET_HEADER_TYPE,
+                           IREE_HSA_PACKET_HEADER_WIDTH_TYPE),
+            IREE_HSA_PACKET_TYPE_KERNEL_DISPATCH);
+  const iree_hsa_kernel_dispatch_packet_t& dispatch_packet =
+      packets[4].dispatch;
+  EXPECT_EQ(dispatch_packet.kernel_object,
+            block.dispatch_command.kernel_object);
+  EXPECT_EQ(dispatch_packet.kernarg_address, kernarg_block.data);
+  EXPECT_EQ(dispatch_packet.grid_size[0],
+            workgroup_count[0] * block.dispatch_command.workgroup_size[0]);
+  EXPECT_EQ(dispatch_packet.grid_size[1],
+            workgroup_count[1] * block.dispatch_command.workgroup_size[1]);
+  EXPECT_EQ(dispatch_packet.grid_size[2],
+            workgroup_count[2] * block.dispatch_command.workgroup_size[2]);
+  const auto* implicit_args =
+      reinterpret_cast<const iree_amdgpu_kernel_implicit_args_t*>(
+          kernarg_block.data);
+  EXPECT_EQ(implicit_args->block_count[0], workgroup_count[0]);
+  EXPECT_EQ(implicit_args->block_count[1], workgroup_count[1]);
+  EXPECT_EQ(implicit_args->block_count[2], workgroup_count[2]);
+
+  workgroup_count[0] = 13;
+  workgroup_count[1] = 2;
+  workgroup_count[2] = 1;
+  std::memset(packets, 0, sizeof(packets));
+  std::memset(&kernarg_block, 0, sizeof(kernarg_block));
+  IREE_ASSERT_OK(iree_hal_amdgpu_aql_block_processor_invoke(
+      &processor, &block.header, &result));
+  EXPECT_EQ(dispatch_packet.grid_size[0],
+            workgroup_count[0] * block.dispatch_command.workgroup_size[0]);
+  EXPECT_EQ(dispatch_packet.grid_size[1],
+            workgroup_count[1] * block.dispatch_command.workgroup_size[1]);
+  EXPECT_EQ(dispatch_packet.grid_size[2],
+            workgroup_count[2] * block.dispatch_command.workgroup_size[2]);
+  EXPECT_EQ(implicit_args->block_count[0], workgroup_count[0]);
+  EXPECT_EQ(implicit_args->block_count[1], workgroup_count[1]);
+  EXPECT_EQ(implicit_args->block_count[2], workgroup_count[2]);
+}
+
+TEST(AqlBlockProcessorTest,
+     ProfiledStaticIndirectHostResolutionEmitsOnlyTargetDispatch) {
+  const uint32_t workgroup_count[3] = {11, 7, 2};
+  IndirectDispatchBlock block = MakeIndirectDispatchBlock(workgroup_count);
+  block.header.static_indirect_dispatch_count = 1;
+  block.dispatch_command.dispatch_flags |=
+      IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_STATIC_INDIRECT_PARAMETERS;
+  block.dispatch_command.implicit_args_offset_qwords = 0;
+
+  alignas(64) iree_hal_amdgpu_aql_packet_t packets[8] = {};
+  iree_hal_amdgpu_host_queue_t queue = {};
+  queue.aql_ring.base = packets;
+  queue.aql_ring.mask = IREE_ARRAYSIZE(packets) - 1u;
+  iree_hal_amdgpu_wait_resolution_t resolution = {};
+  uint16_t packet_header = 0;
+  uint16_t packet_setup = 0;
+  iree_hal_amdgpu_kernarg_block_t kernarg_block = {};
+  iree_hal_amdgpu_aql_block_processor_profile_t processor = {};
+  processor.queue = &queue;
+  processor.block = &block.header;
+  processor.submission.resolution = &resolution;
+  processor.packets.first_payload_id = 4;
+  processor.packets.count = 1;
+  processor.packets.headers = &packet_header;
+  processor.packets.setups = &packet_setup;
+  processor.kernargs.blocks = &kernarg_block;
+  processor.kernargs.count = 1;
+  processor.flags =
+      IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_PROFILE_FLAG_HOST_RESOLVE_STATIC_INDIRECT;
+
+  iree_hal_amdgpu_aql_block_processor_profile_result_t result;
+  IREE_ASSERT_OK(
+      iree_hal_amdgpu_aql_block_processor_profile_invoke(&processor, &result));
+
+  EXPECT_EQ(result.packets.recorded, 2u);
+  EXPECT_EQ(result.packets.emitted, 1u);
+  EXPECT_EQ(result.kernargs.consumed, 1u);
+  EXPECT_EQ(AqlHeaderField(packet_header, IREE_HSA_PACKET_HEADER_TYPE,
+                           IREE_HSA_PACKET_HEADER_WIDTH_TYPE),
+            IREE_HSA_PACKET_TYPE_KERNEL_DISPATCH);
+  const iree_hsa_kernel_dispatch_packet_t& dispatch_packet =
+      packets[4].dispatch;
+  EXPECT_EQ(dispatch_packet.kernel_object,
+            block.dispatch_command.kernel_object);
+  EXPECT_EQ(dispatch_packet.kernarg_address, kernarg_block.data);
+  EXPECT_EQ(dispatch_packet.grid_size[0],
+            workgroup_count[0] * block.dispatch_command.workgroup_size[0]);
+  EXPECT_EQ(dispatch_packet.grid_size[1],
+            workgroup_count[1] * block.dispatch_command.workgroup_size[1]);
+  EXPECT_EQ(dispatch_packet.grid_size[2],
+            workgroup_count[2] * block.dispatch_command.workgroup_size[2]);
+}
+
 TEST(AqlBlockProcessorTest, IndirectDispatchSplitsCommandBarrierScopes) {
   const iree_hal_amdgpu_device_kernels_t kernels = MakeTransferKernels();
   const iree_hal_amdgpu_device_buffer_transfer_context_t transfer_context =

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_block_processor_test.cc
@@ -347,7 +347,7 @@ static IndirectDispatchBlock MakeIndirectDispatchBlock(
                         2 * sizeof(iree_hal_amdgpu_kernarg_block_t),
                         &block.header);
   block.header.dispatch_count = 1;
-  block.header.indirect_dispatch_count = 1;
+  block.header.static_indirect_dispatch_count = 0;
   block.header.binding_source_count = 1;
   block.header.binding_source_offset =
       offsetof(IndirectDispatchBlock, indirect_params_source);
@@ -1056,6 +1056,45 @@ TEST(AqlBlockProcessorTest, IndirectDispatchEmitsPatchThenUnpublishedDispatch) {
             IREE_HSA_FENCE_SCOPE_NONE);
   EXPECT_EQ(AqlHeaderReleaseScope(packet_headers[0]),
             IREE_HSA_FENCE_SCOPE_NONE);
+}
+
+TEST(AqlBlockProcessorTest,
+     StaticIndirectDispatchFallbackPublishesAgentVisiblePatch) {
+  const iree_hal_amdgpu_device_kernels_t kernels = MakeTransferKernels();
+  const iree_hal_amdgpu_device_buffer_transfer_context_t transfer_context =
+      MakeTransferContext(&kernels);
+  const uint32_t workgroup_count[3] = {7, 5, 3};
+  IndirectDispatchBlock block = MakeIndirectDispatchBlock(workgroup_count);
+  block.header.static_indirect_dispatch_count = 1;
+  block.dispatch_command.dispatch_flags |=
+      IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_STATIC_INDIRECT_PARAMETERS;
+
+  alignas(64) iree_hal_amdgpu_aql_packet_t packets[8] = {};
+  iree_hal_amdgpu_aql_ring_t ring = {};
+  ring.base = packets;
+  ring.mask = IREE_ARRAYSIZE(packets) - 1u;
+  uint16_t packet_headers[2] = {};
+  uint16_t packet_setups[2] = {};
+  iree_hal_amdgpu_kernarg_block_t kernarg_blocks[2] = {};
+  iree_hal_amdgpu_aql_block_processor_t processor = MakeProcessor(
+      &ring, /*packet_count=*/2, packet_headers, packet_setups, kernarg_blocks,
+      /*kernarg_block_count=*/2,
+      IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_FLAG_FINAL_PAYLOAD_PACKET,
+      IREE_HSA_FENCE_SCOPE_NONE, IREE_HSA_FENCE_SCOPE_SYSTEM,
+      IREE_HSA_FENCE_SCOPE_NONE, &transfer_context);
+
+  iree_hal_amdgpu_aql_block_processor_result_t result;
+  IREE_ASSERT_OK(iree_hal_amdgpu_aql_block_processor_invoke(
+      &processor, &block.header, &result));
+
+  EXPECT_EQ(result.packets.recorded, 2u);
+  EXPECT_EQ(result.packets.emitted, 2u);
+  EXPECT_TRUE(AqlHeaderHasBarrier(packet_headers[0]));
+  EXPECT_EQ(AqlHeaderAcquireScope(packet_headers[0]),
+            IREE_HSA_FENCE_SCOPE_AGENT);
+  EXPECT_EQ(AqlHeaderReleaseScope(packet_headers[0]),
+            IREE_HSA_FENCE_SCOPE_AGENT);
+  EXPECT_EQ(packet_headers[1], IREE_HSA_PACKET_TYPE_INVALID);
 }
 
 TEST(AqlBlockProcessorTest, IndirectDispatchSplitsCommandBarrierScopes) {

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
@@ -241,6 +241,20 @@ typedef struct iree_hal_amdgpu_aql_command_buffer_t {
     // Number of queue-local shadow slots available to one live block span.
     uint32_t shadow_slot_count;
   } tsan_shadow_spans;
+  // Static-indirect parameter sources summarized during recording.
+  struct {
+    // Dynamic binding slots referenced by static-indirect dispatches.
+    uint32_t* dynamic_slots;
+    // Bit set indexed by binding slot for recording-time deduplication.
+    uint64_t* dynamic_slot_bits;
+    // Number of populated entries in |dynamic_slots|.
+    uint32_t dynamic_slot_count;
+    // Number of static-indirect dispatches recorded.
+    uint32_t dispatch_count;
+    // True when at least one direct source cannot be read efficiently by the
+    // host at queue issue time.
+    bool has_device_only_source;
+  } static_indirect;
   // Builder used only during begin/end recording.
   iree_hal_amdgpu_aql_program_builder_t builder;
   // Program produced by end() and consumed by queue execution.
@@ -318,6 +332,8 @@ static void iree_hal_amdgpu_aql_command_buffer_reset_resources(
   command_buffer->dispatch_summaries.count = 0;
   command_buffer->tsan_shadow_spans.block.first = NULL;
   command_buffer->tsan_shadow_spans.block.current = NULL;
+  memset(&command_buffer->static_indirect, 0,
+         sizeof(command_buffer->static_indirect));
 }
 
 static void iree_hal_amdgpu_aql_command_buffer_discard_recording(
@@ -849,6 +865,12 @@ iree_status_t iree_hal_amdgpu_aql_command_buffer_create(
         " is outside uint32_t storage",
         queue_count_per_physical_device);
   }
+  if (IREE_UNLIKELY(binding_capacity > UINT32_MAX)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "command-buffer binding capacity %" PRIhsz
+                            " exceeds uint32_t storage",
+                            binding_capacity);
+  }
   switch (prepublished_kernarg_storage.mode) {
     case IREE_HAL_AMDGPU_AQL_PREPUBLISHED_KERNARG_STORAGE_MODE_DISABLED:
     case IREE_HAL_AMDGPU_AQL_PREPUBLISHED_KERNARG_STORAGE_MODE_DEVICE_FINE_HOST_COHERENT:
@@ -938,6 +960,36 @@ const iree_hal_amdgpu_aql_program_t* iree_hal_amdgpu_aql_command_buffer_program(
   iree_hal_amdgpu_aql_command_buffer_t* command_buffer =
       iree_hal_amdgpu_aql_command_buffer_cast(base_command_buffer);
   return &command_buffer->program;
+}
+
+iree_hal_amdgpu_aql_static_indirect_replay_mode_t
+iree_hal_amdgpu_aql_command_buffer_select_static_indirect_replay_mode(
+    iree_hal_command_buffer_t* base_command_buffer,
+    iree_hal_buffer_binding_table_t binding_table) {
+  iree_hal_amdgpu_aql_command_buffer_t* command_buffer =
+      iree_hal_amdgpu_aql_command_buffer_cast(base_command_buffer);
+  if (command_buffer->static_indirect.dispatch_count == 0 ||
+      command_buffer->static_indirect.has_device_only_source) {
+    return IREE_HAL_AMDGPU_AQL_STATIC_INDIRECT_REPLAY_MODE_DEVICE_PATCH;
+  }
+
+  const iree_hal_memory_type_t required_memory_type =
+      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_COHERENT;
+  if (command_buffer->static_indirect.dynamic_slot_count != 0 &&
+      !binding_table.bindings) {
+    return IREE_HAL_AMDGPU_AQL_STATIC_INDIRECT_REPLAY_MODE_DEVICE_PATCH;
+  }
+  for (uint32_t i = 0; i < command_buffer->static_indirect.dynamic_slot_count;
+       ++i) {
+    const uint32_t slot = command_buffer->static_indirect.dynamic_slots[i];
+    if (slot >= binding_table.count || !binding_table.bindings[slot].buffer ||
+        !iree_all_bits_set(
+            iree_hal_buffer_memory_type(binding_table.bindings[slot].buffer),
+            required_memory_type)) {
+      return IREE_HAL_AMDGPU_AQL_STATIC_INDIRECT_REPLAY_MODE_DEVICE_PATCH;
+    }
+  }
+  return IREE_HAL_AMDGPU_AQL_STATIC_INDIRECT_REPLAY_MODE_HOST_RESOLVE;
 }
 
 iree_host_size_t iree_hal_amdgpu_aql_command_buffer_device_ordinal(
@@ -1645,6 +1697,74 @@ iree_hal_amdgpu_aql_command_buffer_check_indirect_workgroup_count_ref(
 }
 
 static iree_status_t
+iree_hal_amdgpu_aql_command_buffer_ensure_static_indirect_slot_storage(
+    iree_hal_amdgpu_aql_command_buffer_t* command_buffer) {
+  if (command_buffer->static_indirect.dynamic_slots) return iree_ok_status();
+
+  const uint32_t binding_capacity = command_buffer->base.binding_capacity;
+  const iree_host_size_t slot_word_count =
+      iree_host_size_ceil_div(binding_capacity, 64);
+  iree_host_size_t slot_offset = 0;
+  iree_host_size_t slot_bits_offset = 0;
+  iree_host_size_t total_size = 0;
+  IREE_RETURN_IF_ERROR(IREE_STRUCT_LAYOUT(
+      0, &total_size,
+      IREE_STRUCT_FIELD(binding_capacity, uint32_t, &slot_offset),
+      IREE_STRUCT_FIELD(slot_word_count, uint64_t, &slot_bits_offset)));
+
+  uint8_t* storage = NULL;
+  IREE_RETURN_IF_ERROR(iree_arena_allocate(&command_buffer->recording_arena,
+                                           total_size, (void**)&storage));
+  memset(storage, 0, total_size);
+  command_buffer->static_indirect.dynamic_slots =
+      (uint32_t*)(storage + slot_offset);
+  command_buffer->static_indirect.dynamic_slot_bits =
+      (uint64_t*)(storage + slot_bits_offset);
+  return iree_ok_status();
+}
+
+static iree_status_t
+iree_hal_amdgpu_aql_command_buffer_record_static_indirect_source(
+    iree_hal_amdgpu_aql_command_buffer_t* command_buffer,
+    iree_hal_buffer_ref_t buffer_ref,
+    const iree_hal_amdgpu_command_buffer_binding_source_t* binding_source) {
+  ++command_buffer->static_indirect.dispatch_count;
+  if (iree_any_bit_set(
+          binding_source->flags,
+          IREE_HAL_AMDGPU_COMMAND_BUFFER_BINDING_SOURCE_FLAG_STATIC_BUFFER)) {
+    command_buffer->static_indirect.has_device_only_source = true;
+    return iree_ok_status();
+  }
+  if (iree_any_bit_set(
+          binding_source->flags,
+          IREE_HAL_AMDGPU_COMMAND_BUFFER_BINDING_SOURCE_FLAG_DYNAMIC)) {
+    IREE_RETURN_IF_ERROR(
+        iree_hal_amdgpu_aql_command_buffer_ensure_static_indirect_slot_storage(
+            command_buffer));
+    const uint32_t slot = binding_source->slot;
+    uint64_t* slot_bits =
+        &command_buffer->static_indirect.dynamic_slot_bits[slot / 64u];
+    const uint64_t slot_mask = 1ull << (slot % 64u);
+    if ((*slot_bits & slot_mask) == 0) {
+      *slot_bits |= slot_mask;
+      command_buffer->static_indirect
+          .dynamic_slots[command_buffer->static_indirect.dynamic_slot_count++] =
+          slot;
+    }
+    return iree_ok_status();
+  }
+
+  const iree_hal_memory_type_t required_memory_type =
+      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_COHERENT;
+  if (!buffer_ref.buffer ||
+      !iree_all_bits_set(iree_hal_buffer_memory_type(buffer_ref.buffer),
+                         required_memory_type)) {
+    command_buffer->static_indirect.has_device_only_source = true;
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t
 iree_hal_amdgpu_aql_command_buffer_write_indirect_parameter_source(
     iree_hal_amdgpu_aql_command_buffer_t* command_buffer,
     iree_hal_buffer_ref_t buffer_ref,
@@ -1655,12 +1775,13 @@ iree_hal_amdgpu_aql_command_buffer_write_indirect_parameter_source(
           buffer_ref));
 
   if (!buffer_ref.buffer) {
-    if (IREE_UNLIKELY(buffer_ref.buffer_slot == UINT32_MAX)) {
+    if (IREE_UNLIKELY(buffer_ref.buffer_slot >=
+                      command_buffer->base.binding_capacity)) {
       return iree_make_status(
           IREE_STATUS_OUT_OF_RANGE,
-          "indirect workgroup count binding slot %u exceeds binding count "
-          "storage",
-          buffer_ref.buffer_slot);
+          "indirect workgroup count binding slot %u exceeds binding capacity "
+          "%u",
+          buffer_ref.buffer_slot, command_buffer->base.binding_capacity);
     }
     command_buffer->base.binding_count = iree_max(
         command_buffer->base.binding_count, buffer_ref.buffer_slot + 1);
@@ -2659,6 +2780,13 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_write_dispatch_payload(
         iree_hal_amdgpu_aql_command_buffer_write_indirect_parameter_source(
             command_buffer, inputs->config.workgroup_count_ref,
             parameter_source));
+    if (iree_hal_amdgpu_aql_dispatch_plan_uses_static_indirect_parameters(
+            plan)) {
+      IREE_RETURN_IF_ERROR(
+          iree_hal_amdgpu_aql_command_buffer_record_static_indirect_source(
+              command_buffer, inputs->config.workgroup_count_ref,
+              parameter_source));
+    }
   }
   if (iree_hal_amdgpu_aql_dispatch_layout_prepublishes_kernargs(layout)) {
     return iree_ok_status();

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
@@ -1886,6 +1886,7 @@ typedef enum iree_hal_amdgpu_aql_dispatch_plan_flag_bits_e {
   IREE_HAL_AMDGPU_AQL_DISPATCH_PLAN_FLAG_CUSTOM_DIRECT_ARGUMENTS = 1u << 0,
   IREE_HAL_AMDGPU_AQL_DISPATCH_PLAN_FLAG_INDIRECT_PARAMETERS = 1u << 1,
   IREE_HAL_AMDGPU_AQL_DISPATCH_PLAN_FLAG_QUEUE_SCOPED_KERNEL_OBJECT = 1u << 2,
+  IREE_HAL_AMDGPU_AQL_DISPATCH_PLAN_FLAG_STATIC_INDIRECT_PARAMETERS = 1u << 3,
 } iree_hal_amdgpu_aql_dispatch_plan_flag_bits_t;
 
 typedef uint32_t iree_hal_amdgpu_aql_dispatch_plan_flags_t;
@@ -1968,6 +1969,14 @@ static bool iree_hal_amdgpu_aql_dispatch_plan_uses_indirect_parameters(
     const iree_hal_amdgpu_aql_dispatch_plan_t* plan) {
   return iree_any_bit_set(
       plan->flags, IREE_HAL_AMDGPU_AQL_DISPATCH_PLAN_FLAG_INDIRECT_PARAMETERS);
+}
+
+static bool iree_hal_amdgpu_aql_dispatch_plan_uses_static_indirect_parameters(
+    const iree_hal_amdgpu_aql_dispatch_plan_t* plan) {
+  return iree_all_bits_set(
+      plan->flags,
+      IREE_HAL_AMDGPU_AQL_DISPATCH_PLAN_FLAG_INDIRECT_PARAMETERS |
+          IREE_HAL_AMDGPU_AQL_DISPATCH_PLAN_FLAG_STATIC_INDIRECT_PARAMETERS);
 }
 
 static bool iree_hal_amdgpu_aql_dispatch_plan_uses_queue_scoped_kernel_object(
@@ -2161,6 +2170,11 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_prepare_dispatch_plan(
   if (iree_hal_dispatch_uses_indirect_parameters(inputs->flags)) {
     out_plan->flags |=
         IREE_HAL_AMDGPU_AQL_DISPATCH_PLAN_FLAG_INDIRECT_PARAMETERS;
+  }
+  if (iree_any_bit_set(inputs->flags,
+                       IREE_HAL_DISPATCH_FLAG_STATIC_INDIRECT_PARAMETERS)) {
+    out_plan->flags |=
+        IREE_HAL_AMDGPU_AQL_DISPATCH_PLAN_FLAG_STATIC_INDIRECT_PARAMETERS;
   }
   out_plan->kernarg_storage_mode =
       IREE_HAL_AMDGPU_COMMAND_BUFFER_KERNARG_STORAGE_MODE_NATIVE_INLINE;
@@ -2406,6 +2420,10 @@ static void iree_hal_amdgpu_aql_command_buffer_initialize_dispatch_command(
       uses_indirect_parameters
           ? IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_INDIRECT_PARAMETERS
           : IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_NONE;
+  if (iree_hal_amdgpu_aql_dispatch_plan_uses_static_indirect_parameters(plan)) {
+    dispatch_command->dispatch_flags |=
+        IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_STATIC_INDIRECT_PARAMETERS;
+  }
   if (uses_queue_scoped_kernel_object) {
     dispatch_command->dispatch_flags |=
         IREE_HAL_AMDGPU_COMMAND_BUFFER_DISPATCH_FLAG_QUEUE_SCOPED_KERNEL_OBJECT;
@@ -2574,8 +2592,10 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_append_dispatch_command(
   iree_hal_amdgpu_command_buffer_command_header_t* header = NULL;
   const bool uses_indirect_parameters =
       iree_hal_amdgpu_aql_dispatch_plan_uses_indirect_parameters(plan);
+  const bool uses_static_indirect_parameters =
+      iree_hal_amdgpu_aql_dispatch_plan_uses_static_indirect_parameters(plan);
   uint8_t command_flags =
-      uses_indirect_parameters
+      uses_indirect_parameters && !uses_static_indirect_parameters
           ? IREE_HAL_AMDGPU_COMMAND_BUFFER_COMMAND_FLAG_HAS_BARRIER
           : IREE_HAL_AMDGPU_COMMAND_BUFFER_COMMAND_FLAG_NONE;
   if (iree_hal_amdgpu_aql_command_buffer_tsan_should_force_barrier(
@@ -2608,8 +2628,8 @@ static iree_status_t iree_hal_amdgpu_aql_command_buffer_append_dispatch_command(
   iree_hal_amdgpu_aql_command_buffer_initialize_dispatch_command(
       command_buffer, inputs, plan, layout, kernarg_template_reference, header,
       *out_binding_sources);
-  if (uses_indirect_parameters) {
-    ++command_buffer->builder.current_block.indirect_dispatch_count;
+  if (uses_static_indirect_parameters) {
+    ++command_buffer->builder.current_block.static_indirect_dispatch_count;
   }
   *out_dispatch_command =
       (iree_hal_amdgpu_command_buffer_dispatch_command_t*)header;

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.h
@@ -88,6 +88,26 @@ typedef struct iree_hal_amdgpu_aql_command_buffer_dispatch_summary_t {
 const iree_hal_amdgpu_aql_program_t* iree_hal_amdgpu_aql_command_buffer_program(
     iree_hal_command_buffer_t* command_buffer);
 
+// Queue-issue strategy for static-indirect dispatch parameters.
+typedef uint8_t iree_hal_amdgpu_aql_static_indirect_replay_mode_t;
+enum iree_hal_amdgpu_aql_static_indirect_replay_mode_e {
+  // Device patch dispatches resolve workgroup counts before their targets.
+  IREE_HAL_AMDGPU_AQL_STATIC_INDIRECT_REPLAY_MODE_DEVICE_PATCH = 0u,
+  // The host snapshots workgroup counts into target packets during queue issue.
+  IREE_HAL_AMDGPU_AQL_STATIC_INDIRECT_REPLAY_MODE_HOST_RESOLVE = 1u,
+};
+
+// Selects one static-indirect replay mode for the complete command buffer.
+//
+// Direct sources are classified while recording. Dynamic sources are checked
+// only for the unique binding slots referenced by static-indirect dispatches.
+// Host resolution is selected only when every source is host-local and
+// coherent; otherwise all static-indirect dispatches use device patching.
+iree_hal_amdgpu_aql_static_indirect_replay_mode_t
+iree_hal_amdgpu_aql_command_buffer_select_static_indirect_replay_mode(
+    iree_hal_command_buffer_t* command_buffer,
+    iree_hal_buffer_binding_table_t binding_table);
+
 // Returns the physical device ordinal this command buffer was recorded for.
 iree_host_size_t iree_hal_amdgpu_aql_command_buffer_device_ordinal(
     iree_hal_command_buffer_t* command_buffer);

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_program_builder.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_program_builder.c
@@ -179,8 +179,7 @@ static iree_status_t iree_hal_amdgpu_aql_program_builder_begin_block(
   builder->current_block.command_count = 0;
   builder->current_block.binding_source_count = 0;
   builder->current_block.dispatch_count = 0;
-  builder->current_block.indirect_dispatch_count = 0;
-  builder->current_block.profile_marker_count = 0;
+  builder->current_block.static_indirect_dispatch_count = 0;
   builder->current_block.aql_packet_count = 0;
   builder->current_block.kernarg_length = 0;
   builder->current_block.initial_barrier_packet_count = 0;
@@ -206,9 +205,8 @@ static void iree_hal_amdgpu_aql_program_builder_finalize_block(
   block->aql_packet_count = builder->current_block.aql_packet_count;
   block->kernarg_length = builder->current_block.kernarg_length;
   block->dispatch_count = builder->current_block.dispatch_count;
-  block->indirect_dispatch_count =
-      builder->current_block.indirect_dispatch_count;
-  block->profile_marker_count = builder->current_block.profile_marker_count;
+  block->static_indirect_dispatch_count =
+      builder->current_block.static_indirect_dispatch_count;
   block->initial_barrier_packet_count =
       iree_any_bit_set(
           builder->current_block.flags,
@@ -608,8 +606,6 @@ iree_status_t iree_hal_amdgpu_aql_program_builder_append_command(
   ++builder->current_block.command_count;
   if (opcode == IREE_HAL_AMDGPU_COMMAND_BUFFER_OPCODE_DISPATCH) {
     ++builder->current_block.dispatch_count;
-  } else if (opcode == IREE_HAL_AMDGPU_COMMAND_BUFFER_OPCODE_PROFILE_MARKER) {
-    ++builder->current_block.profile_marker_count;
   }
   builder->current_block.binding_source_count += binding_source_count;
   builder->current_block.aql_packet_count += aql_packet_count;

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_program_builder.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_program_builder.h
@@ -105,10 +105,8 @@ typedef struct iree_hal_amdgpu_aql_program_builder_t {
     uint16_t binding_source_count;
     // Number of dispatch command records emitted into the block.
     uint16_t dispatch_count;
-    // Number of indirect dispatch command records emitted into the block.
-    uint16_t indirect_dispatch_count;
-    // Number of profile marker command records emitted into the block.
-    uint16_t profile_marker_count;
+    // Number of static indirect dispatch command records in the block.
+    uint16_t static_indirect_dispatch_count;
     // Worst-case AQL packet count emitted by the block.
     uint32_t aql_packet_count;
     // Worst-case kernarg byte count emitted by the block.

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_program_builder_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_program_builder_test.cc
@@ -199,8 +199,7 @@ TEST_F(AqlProgramBuilderTest, AppendsCommandAndBindingSources) {
   EXPECT_EQ(block->command_count, 2u);
   EXPECT_EQ(block->binding_source_count, 2u);
   EXPECT_EQ(block->dispatch_count, 1u);
-  EXPECT_EQ(block->indirect_dispatch_count, 0u);
-  EXPECT_EQ(block->profile_marker_count, 0u);
+  EXPECT_EQ(block->static_indirect_dispatch_count, 0u);
   EXPECT_EQ(block->aql_packet_count, 1u);
   EXPECT_EQ(block->kernarg_length, 128u);
   EXPECT_EQ(block->terminator_opcode,

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer.c
@@ -732,11 +732,15 @@ iree_status_t iree_hal_amdgpu_host_queue_submit_command_buffer(
   }
   iree_hal_resource_t* command_buffer_resource =
       (iree_hal_resource_t*)command_buffer;
+  const iree_hal_amdgpu_aql_static_indirect_replay_mode_t static_indirect_mode =
+      iree_hal_amdgpu_aql_command_buffer_select_static_indirect_replay_mode(
+          command_buffer, binding_table);
   bool ready = false;
   iree_status_t status = iree_hal_amdgpu_host_queue_submit_command_buffer_block(
       queue, resolution, signal_semaphore_list, command_buffer, binding_table,
-      /*binding_ptrs=*/NULL, program->first_block, inout_binding_resource_set,
-      (iree_hal_amdgpu_reclaim_action_t){0}, &command_buffer_resource,
+      /*binding_ptrs=*/NULL, program->first_block, static_indirect_mode,
+      inout_binding_resource_set, (iree_hal_amdgpu_reclaim_action_t){0},
+      &command_buffer_resource,
       /*operation_resource_count=*/1,
       IREE_HAL_AMDGPU_HOST_QUEUE_SUBMISSION_FLAG_RETAIN_RESOURCES, &ready);
   if (!iree_status_is_ok(status)) {

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_block.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_block.c
@@ -255,9 +255,10 @@ static iree_status_t iree_hal_amdgpu_host_queue_write_command_buffer_block(
     const uint64_t* binding_ptrs, uint64_t first_payload_packet_id,
     uint32_t packet_index_base, iree_hal_amdgpu_kernarg_block_t* kernarg_blocks,
     uint16_t* packet_headers, uint16_t* packet_setups,
+    iree_hal_amdgpu_aql_static_indirect_replay_mode_t static_indirect_mode,
     iree_hal_amdgpu_profile_dispatch_event_reservation_t profile_events,
-    uint32_t emitted_packet_count, uint32_t profile_counter_set_count,
-    uint32_t profile_trace_packet_count,
+    uint32_t emitted_packet_count, uint32_t emitted_kernarg_block_count,
+    uint32_t profile_counter_set_count, uint32_t profile_trace_packet_count,
     iree_hal_amdgpu_profile_dispatch_harvest_source_t* profile_harvest_sources,
     iree_hal_amdgpu_aql_block_processor_profile_dispatch_list_t
         profile_dispatches) {
@@ -296,9 +297,7 @@ static iree_status_t iree_hal_amdgpu_host_queue_write_command_buffer_block(
         .kernargs =
             {
                 .blocks = kernarg_blocks,
-                .count = (uint32_t)iree_host_size_ceil_div(
-                    block->kernarg_length,
-                    sizeof(iree_hal_amdgpu_kernarg_block_t)),
+                .count = emitted_kernarg_block_count,
             },
         .submission =
             {
@@ -313,9 +312,13 @@ static iree_status_t iree_hal_amdgpu_host_queue_write_command_buffer_block(
                 .acquire_scope = payload_acquire_scope,
             },
         .flags =
-            packet_index_base == 0
-                ? IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_FLAG_FINAL_PAYLOAD_PACKET
-                : IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_FLAG_NONE,
+            (packet_index_base == 0
+                 ? IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_FLAG_FINAL_PAYLOAD_PACKET
+                 : IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_FLAG_NONE) |
+            (static_indirect_mode ==
+                     IREE_HAL_AMDGPU_AQL_STATIC_INDIRECT_REPLAY_MODE_HOST_RESOLVE
+                 ? IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_FLAG_HOST_RESOLVE_STATIC_INDIRECT
+                 : IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_FLAG_NONE),
     };
     iree_hal_amdgpu_aql_block_processor_initialize(&processor_params,
                                                    &processor);
@@ -346,6 +349,11 @@ static iree_status_t iree_hal_amdgpu_host_queue_write_command_buffer_block(
   if (packet_index_base != 0) {
     profile_flags |=
         IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_PROFILE_FLAG_QUEUE_DEVICE_EVENT;
+  }
+  if (static_indirect_mode ==
+      IREE_HAL_AMDGPU_AQL_STATIC_INDIRECT_REPLAY_MODE_HOST_RESOLVE) {
+    profile_flags |=
+        IREE_HAL_AMDGPU_AQL_BLOCK_PROCESSOR_PROFILE_FLAG_HOST_RESOLVE_STATIC_INDIRECT;
   }
   iree_hal_amdgpu_aql_block_processor_profile_t processor;
   const iree_hal_amdgpu_aql_block_processor_profile_t processor_params = {
@@ -380,9 +388,7 @@ static iree_status_t iree_hal_amdgpu_host_queue_write_command_buffer_block(
       .kernargs =
           {
               .blocks = kernarg_blocks,
-              .count = (uint32_t)iree_host_size_ceil_div(
-                  block->kernarg_length,
-                  sizeof(iree_hal_amdgpu_kernarg_block_t)),
+              .count = emitted_kernarg_block_count,
           },
       .payload =
           {
@@ -659,6 +665,7 @@ iree_status_t iree_hal_amdgpu_host_queue_submit_command_buffer_block(
     iree_hal_command_buffer_t* command_buffer,
     iree_hal_buffer_binding_table_t binding_table, const uint64_t* binding_ptrs,
     const iree_hal_amdgpu_command_buffer_block_header_t* block,
+    iree_hal_amdgpu_aql_static_indirect_replay_mode_t static_indirect_mode,
     iree_hal_resource_set_t** inout_binding_resource_set,
     iree_hal_amdgpu_reclaim_action_t pre_signal_action,
     iree_hal_resource_t* const* operation_resources,
@@ -668,8 +675,16 @@ iree_status_t iree_hal_amdgpu_host_queue_submit_command_buffer_block(
   *out_ready = false;
   const uint64_t command_buffer_id =
       iree_hal_amdgpu_aql_command_buffer_profile_id(command_buffer);
-  const uint32_t kernarg_block_count = (uint32_t)iree_host_size_ceil_div(
-      block->kernarg_length, sizeof(iree_hal_amdgpu_kernarg_block_t));
+  const uint32_t recorded_kernarg_block_count =
+      (uint32_t)iree_host_size_ceil_div(
+          block->kernarg_length, sizeof(iree_hal_amdgpu_kernarg_block_t));
+  const uint32_t omitted_patch_count =
+      static_indirect_mode ==
+              IREE_HAL_AMDGPU_AQL_STATIC_INDIRECT_REPLAY_MODE_HOST_RESOLVE
+          ? block->static_indirect_dispatch_count
+          : 0u;
+  const uint32_t emitted_kernarg_block_count =
+      recorded_kernarg_block_count - omitted_patch_count;
   iree_arena_allocator_t scratch_arena;
   iree_arena_initialize(queue->block_pool, &scratch_arena);
   iree_hal_amdgpu_aql_block_processor_profile_dispatch_list_t
@@ -725,12 +740,10 @@ iree_status_t iree_hal_amdgpu_host_queue_submit_command_buffer_block(
     }
   }
 
-  uint32_t recorded_packet_count = 0;
   uint32_t emitted_packet_count = 0;
   if (iree_status_is_ok(status)) {
-    recorded_packet_count =
-        block->aql_packet_count + extra_profile_packet_count;
-    emitted_packet_count = recorded_packet_count;
+    emitted_packet_count = block->aql_packet_count +
+                           extra_profile_packet_count - omitted_patch_count;
   }
   if (iree_status_is_ok(status) &&
       iree_hal_amdgpu_host_queue_should_profile_queue_device_events(queue)) {
@@ -816,8 +829,8 @@ iree_status_t iree_hal_amdgpu_host_queue_submit_command_buffer_block(
     status = iree_hal_amdgpu_host_queue_try_begin_kernel_submission(
         queue, resolution, signal_semaphore_list, operation_resource_count,
         payload_packet_count,
-        kernarg_block_count + profile_harvest_kernarg_block_count, out_ready,
-        &submission);
+        emitted_kernarg_block_count + profile_harvest_kernarg_block_count,
+        out_ready, &submission);
   }
   if (iree_status_is_ok(status) && *out_ready) {
     submission_begun = true;
@@ -848,7 +861,7 @@ iree_status_t iree_hal_amdgpu_host_queue_submit_command_buffer_block(
               &queue->transfer_context->kernels
                    ->iree_hal_amdgpu_device_timestamp_harvest_dispatch_records,
               profile_events.event_count, &profile_harvest_packet->dispatch,
-              submission.kernargs.blocks[kernarg_block_count].data);
+              submission.kernargs.blocks[emitted_kernarg_block_count].data);
       profile_harvest_setup = profile_harvest_packet->dispatch.setup;
     }
     uint16_t* packet_headers = NULL;
@@ -859,14 +872,15 @@ iree_status_t iree_hal_amdgpu_host_queue_submit_command_buffer_block(
               queue, emitted_packet_count, &scratch_arena, &packet_headers,
               &packet_setups);
     }
-    iree_hal_amdgpu_kernarg_block_t* recorded_kernarg_blocks =
+    iree_hal_amdgpu_kernarg_block_t* emitted_kernarg_blocks =
         submission.kernargs.blocks;
     if (iree_status_is_ok(status)) {
       status = iree_hal_amdgpu_host_queue_write_command_buffer_block(
           queue, resolution, signal_semaphore_list, command_buffer,
           binding_table, block, block_binding_ptrs, first_payload_packet_id,
-          profile_queue_device_prefix_packet_count, recorded_kernarg_blocks,
-          packet_headers, packet_setups, profile_events, recorded_packet_count,
+          profile_queue_device_prefix_packet_count, emitted_kernarg_blocks,
+          packet_headers, packet_setups, static_indirect_mode, profile_events,
+          emitted_packet_count, emitted_kernarg_block_count,
           profile_counter_set_count, profile_trace_packet_count,
           profile_harvest_sources, profile_dispatches);
     }

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_block.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_block.h
@@ -7,6 +7,7 @@
 #ifndef IREE_HAL_DRIVERS_AMDGPU_HOST_QUEUE_COMMAND_BUFFER_BLOCK_H_
 #define IREE_HAL_DRIVERS_AMDGPU_HOST_QUEUE_COMMAND_BUFFER_BLOCK_H_
 
+#include "iree/hal/drivers/amdgpu/aql_command_buffer.h"
 #include "iree/hal/drivers/amdgpu/host_queue_command_buffer.h"
 
 #ifdef __cplusplus
@@ -22,6 +23,7 @@ iree_status_t iree_hal_amdgpu_host_queue_submit_command_buffer_block(
     iree_hal_command_buffer_t* command_buffer,
     iree_hal_buffer_binding_table_t binding_table, const uint64_t* binding_ptrs,
     const iree_hal_amdgpu_command_buffer_block_header_t* block,
+    iree_hal_amdgpu_aql_static_indirect_replay_mode_t static_indirect_mode,
     iree_hal_resource_set_t** inout_binding_resource_set,
     iree_hal_amdgpu_reclaim_action_t pre_signal_action,
     iree_hal_resource_t* const* operation_resources,

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profile.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profile.c
@@ -168,6 +168,7 @@ iree_hal_amdgpu_host_queue_initialize_command_buffer_dispatch_summary_event(
 void iree_hal_amdgpu_host_queue_record_command_buffer_profile_dispatch_source(
     iree_hal_amdgpu_host_queue_t* queue, uint64_t command_buffer_id,
     const iree_hal_amdgpu_aql_block_processor_profile_dispatch_t* dispatch,
+    const uint32_t* workgroup_count_override,
     iree_hal_amdgpu_profile_dispatch_event_reservation_t profile_events,
     iree_hal_amdgpu_profile_dispatch_harvest_source_t* profile_harvest_sources,
     uint32_t* inout_profile_event_index) {
@@ -179,6 +180,10 @@ void iree_hal_amdgpu_host_queue_record_command_buffer_profile_dispatch_source(
           queue, profile_event_position);
   iree_hal_amdgpu_host_queue_initialize_command_buffer_dispatch_summary_event(
       event, command_buffer_id, dispatch->summary);
+  if (workgroup_count_override) {
+    memcpy(event->workgroup_count, workgroup_count_override,
+           sizeof(event->workgroup_count));
+  }
   profile_harvest_sources[profile_event_index].completion_signal =
       iree_hal_amdgpu_host_queue_profiling_completion_signal_ptr(
           queue, profile_event_position);

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profile.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_profile.h
@@ -34,6 +34,7 @@ iree_hal_amdgpu_host_queue_select_command_buffer_profile_dispatches(
 void iree_hal_amdgpu_host_queue_record_command_buffer_profile_dispatch_source(
     iree_hal_amdgpu_host_queue_t* queue, uint64_t command_buffer_id,
     const iree_hal_amdgpu_aql_block_processor_profile_dispatch_t* dispatch,
+    const uint32_t* workgroup_count_override,
     iree_hal_amdgpu_profile_dispatch_event_reservation_t profile_events,
     iree_hal_amdgpu_profile_dispatch_harvest_source_t* profile_harvest_sources,
     uint32_t* inout_profile_event_index);

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_replay.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_replay.c
@@ -39,6 +39,8 @@ typedef struct iree_hal_amdgpu_command_buffer_replay_t {
   iree_hal_resource_set_t* binding_resource_set;
   // Immutable recorded AQL program borrowed from |command_buffer|.
   const iree_hal_amdgpu_aql_program_t* program;
+  // Static-indirect strategy selected once for the complete queue issue.
+  iree_hal_amdgpu_aql_static_indirect_replay_mode_t static_indirect_mode;
   // Next command-buffer block to evaluate or submit.
   const iree_hal_amdgpu_command_buffer_block_header_t* current_block;
   // Wait resolution that prefixes the next packet submission.
@@ -153,6 +155,9 @@ static iree_status_t iree_hal_amdgpu_command_buffer_replay_create(
     }
     replay->binding_ptrs = binding_ptrs;
   }
+  replay->static_indirect_mode =
+      iree_hal_amdgpu_aql_command_buffer_select_static_indirect_replay_mode(
+          command_buffer, replay->binding_table);
 
   *out_replay = replay;
   return iree_ok_status();
@@ -329,7 +334,8 @@ static iree_status_t iree_hal_amdgpu_command_buffer_replay_resume_under_lock(
       status = iree_hal_amdgpu_host_queue_submit_command_buffer_block(
           replay->queue, current_resolution, replay->signal_semaphore_list,
           replay->command_buffer, replay->binding_table, replay->binding_ptrs,
-          replay->current_block, /*inout_binding_resource_set=*/NULL,
+          replay->current_block, replay->static_indirect_mode,
+          /*inout_binding_resource_set=*/NULL,
           (iree_hal_amdgpu_reclaim_action_t){0}, &replay_resource,
           /*operation_resource_count=*/1,
           IREE_HAL_AMDGPU_HOST_QUEUE_SUBMISSION_FLAG_RETAIN_RESOURCES, &ready);
@@ -354,7 +360,8 @@ static iree_status_t iree_hal_amdgpu_command_buffer_replay_resume_under_lock(
     status = iree_hal_amdgpu_host_queue_submit_command_buffer_block(
         replay->queue, current_resolution, iree_hal_semaphore_list_empty(),
         replay->command_buffer, replay->binding_table, replay->binding_ptrs,
-        replay->current_block, /*inout_binding_resource_set=*/NULL,
+        replay->current_block, replay->static_indirect_mode,
+        /*inout_binding_resource_set=*/NULL,
         (iree_hal_amdgpu_reclaim_action_t){0}, &replay_resource,
         /*operation_resource_count=*/1,
         IREE_HAL_AMDGPU_HOST_QUEUE_SUBMISSION_FLAG_RETAIN_RESOURCES, &ready);

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_test.cc
@@ -2140,6 +2140,143 @@ TEST_F(HostQueueCommandBufferTest, DynamicDispatchUsesBindingTableSlots) {
 }
 
 TEST_F(HostQueueCommandBufferTest,
+       StaticIndirectDispatchSnapshotsHostLocalLaunchTable) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.preallocate_pools = 0;
+
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(
+      test_device.Initialize(&options, &libhsa_, &topology_, host_allocator_));
+
+  iree_hal_executable_t* executable = NULL;
+  IREE_ASSERT_OK(LoadCtsExecutable(
+      test_device.base_device(),
+      iree_make_cstring_view("command_buffer_dispatch_multi_workgroup_test."
+                             "bin"),
+      &executable));
+
+  constexpr iree_host_size_t kOutputElementCount = 32;
+  constexpr uint32_t kSentinelValue = 0xCDCDCDCDu;
+  Ref<iree_hal_buffer_t> output_buffer;
+  IREE_ASSERT_OK(CreateHostVisibleDispatchBuffer(
+      test_device.allocator(), kOutputElementCount * sizeof(uint32_t),
+      output_buffer.out()));
+  std::array<uint32_t, kOutputElementCount> output_values;
+  output_values.fill(kSentinelValue);
+  IREE_ASSERT_OK(iree_hal_buffer_map_write(
+      output_buffer, /*target_offset=*/0, output_values.data(),
+      output_values.size() * sizeof(output_values[0])));
+
+  Ref<iree_hal_buffer_t> launch_table;
+  IREE_ASSERT_OK(CreateHostLocalIndirectParameterBuffer(
+      test_device.allocator(), sizeof(uint32_t[3]), launch_table.out()));
+  uint32_t workgroup_count[3] = {4, 1, 1};
+  IREE_ASSERT_OK(iree_hal_buffer_map_write(launch_table, /*target_offset=*/0,
+                                           workgroup_count,
+                                           sizeof(workgroup_count)));
+
+  iree_hal_dispatch_config_t dispatch_config = {};
+  dispatch_config.workgroup_count_ref = iree_hal_make_indirect_buffer_ref(
+      /*buffer_slot=*/1, /*offset=*/0, sizeof(workgroup_count));
+  const iree_hal_buffer_ref_t output_ref = iree_hal_make_indirect_buffer_ref(
+      /*buffer_slot=*/0, /*offset=*/0,
+      output_values.size() * sizeof(output_values[0]));
+  const iree_hal_buffer_ref_list_t dispatch_bindings = {
+      /*count=*/1,
+      /*values=*/&output_ref,
+  };
+
+  Ref<iree_hal_command_buffer_t> command_buffer;
+  IREE_ASSERT_OK(iree_hal_command_buffer_create(
+      test_device.base_device(), IREE_HAL_COMMAND_BUFFER_MODE_DEFAULT,
+      IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
+      /*binding_capacity=*/2, command_buffer.out()));
+  IREE_ASSERT_OK(iree_hal_command_buffer_begin(command_buffer));
+  IREE_ASSERT_OK(iree_hal_command_buffer_dispatch(
+      command_buffer, executable, iree_hal_executable_function_from_index(0),
+      dispatch_config, iree_const_byte_span_empty(), dispatch_bindings,
+      IREE_HAL_DISPATCH_FLAG_STATIC_INDIRECT_PARAMETERS));
+  IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
+
+  const iree_hal_amdgpu_aql_program_t* program =
+      iree_hal_amdgpu_aql_command_buffer_program(command_buffer);
+  ASSERT_NE(program->first_block, nullptr);
+  ASSERT_EQ(program->first_block->aql_packet_count, 2u);
+  ASSERT_EQ(program->first_block->static_indirect_dispatch_count, 1u);
+
+  const std::array<iree_hal_buffer_binding_t, 2> bindings = {{
+      {
+          /*buffer=*/output_buffer.get(),
+          /*offset=*/0,
+          /*length=*/IREE_HAL_WHOLE_BUFFER,
+      },
+      {
+          /*buffer=*/launch_table.get(),
+          /*offset=*/0,
+          /*length=*/IREE_HAL_WHOLE_BUFFER,
+      },
+  }};
+  const iree_hal_buffer_binding_table_t binding_table = {
+      /*count=*/bindings.size(),
+      /*bindings=*/bindings.data(),
+  };
+  EXPECT_EQ(
+      iree_hal_amdgpu_aql_command_buffer_select_static_indirect_replay_mode(
+          command_buffer, binding_table),
+      IREE_HAL_AMDGPU_AQL_STATIC_INDIRECT_REPLAY_MODE_HOST_RESOLVE);
+
+  Ref<iree_hal_semaphore_t> signal;
+  IREE_ASSERT_OK(CreateSemaphore(test_device.base_device(), signal.out()));
+  iree_hal_semaphore_t* signal_ptr = signal.get();
+  uint64_t signal_value = 1;
+  iree_hal_semaphore_list_t signal_list = {
+      /*count=*/1,
+      /*semaphores=*/&signal_ptr,
+      /*payload_values=*/&signal_value,
+  };
+  IREE_ASSERT_OK(iree_hal_device_queue_execute(
+      test_device.base_device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+      iree_hal_semaphore_list_empty(), signal_list, command_buffer,
+      binding_table, IREE_HAL_EXECUTE_FLAG_NONE));
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(signal, signal_value,
+                                         iree_infinite_timeout(),
+                                         IREE_ASYNC_WAIT_FLAG_NONE));
+
+  IREE_ASSERT_OK(iree_hal_buffer_map_read(
+      output_buffer, /*source_offset=*/0, output_values.data(),
+      output_values.size() * sizeof(output_values[0])));
+  for (iree_host_size_t i = 0; i < output_values.size(); ++i) {
+    EXPECT_EQ(output_values[i], i < workgroup_count[0] ? i : kSentinelValue);
+  }
+
+  output_values.fill(kSentinelValue);
+  IREE_ASSERT_OK(iree_hal_buffer_map_write(
+      output_buffer, /*target_offset=*/0, output_values.data(),
+      output_values.size() * sizeof(output_values[0])));
+  workgroup_count[0] = 7;
+  IREE_ASSERT_OK(iree_hal_buffer_map_write(launch_table, /*target_offset=*/0,
+                                           workgroup_count,
+                                           sizeof(workgroup_count)));
+  signal_value = 2;
+  IREE_ASSERT_OK(iree_hal_device_queue_execute(
+      test_device.base_device(), IREE_HAL_QUEUE_AFFINITY_ANY,
+      iree_hal_semaphore_list_empty(), signal_list, command_buffer,
+      binding_table, IREE_HAL_EXECUTE_FLAG_NONE));
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(signal, signal_value,
+                                         iree_infinite_timeout(),
+                                         IREE_ASYNC_WAIT_FLAG_NONE));
+  IREE_ASSERT_OK(iree_hal_buffer_map_read(
+      output_buffer, /*source_offset=*/0, output_values.data(),
+      output_values.size() * sizeof(output_values[0])));
+  for (iree_host_size_t i = 0; i < output_values.size(); ++i) {
+    EXPECT_EQ(output_values[i], i < workgroup_count[0] ? i : kSentinelValue);
+  }
+
+  iree_hal_executable_release(executable);
+}
+
+TEST_F(HostQueueCommandBufferTest,
        CommandBufferRejectsCrossPhysicalDeviceQueue) {
   if (topology_.gpu_agent_count < 2) {
     GTEST_SKIP() << "fewer than two compatible GPU agents";

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_test_util.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_test_util.h
@@ -155,6 +155,20 @@ static iree_status_t CreateHostVisibleIndirectParameterBuffer(
                                             out_buffer);
 }
 
+static iree_status_t CreateHostLocalIndirectParameterBuffer(
+    iree_hal_allocator_t* allocator, iree_device_size_t buffer_size,
+    iree_hal_buffer_t** out_buffer) {
+  iree_hal_buffer_params_t params = {0};
+  params.type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+                IREE_HAL_MEMORY_TYPE_HOST_COHERENT |
+                IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+  params.access = IREE_HAL_MEMORY_ACCESS_ALL;
+  params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMETERS |
+                 IREE_HAL_BUFFER_USAGE_MAPPING;
+  return iree_hal_allocator_allocate_buffer(allocator, params, buffer_size,
+                                            out_buffer);
+}
+
 static bool IsAmdgpuCtsExecutableTarget(
     const iree::hal::cts::ExecutableTarget& target) {
   if (target.family == nullptr || target.target_key == nullptr ||


### PR DESCRIPTION
Static indirect dispatch parameters are now explicitly final when their containing queue operation is issued. Implementations may snapshot them during the queue call, before wait conditions are satisfied, while dynamic indirect parameters retain their queue- and command-produced semantics.

The AMDGPU AQL command buffer preserves that distinction in its recorded program and summarizes the static parameter sources needed by replay. Each queue issue selects one strategy for the complete command buffer. When every static source is host-local and coherent, replay reads the bound launch table while publishing ordinary target packets, including exact implicit block counts, and omits the patch packets, patch kernargs, and indirect-only barriers. If any source is device-resident, replay retains the existing device patch path. The reusable command buffer and its binding table remain unchanged between issues.

Packet and kernarg reservations compact to the selected replay shape, including profiled execution. Command-operation metadata continues to describe the portable logical dispatches, while profile events report the snapped grid used for each host-resolved execution.

This lets a compiler or application evaluate all static launch configurations directly into one mapped host-local/device-visible table and issue a reusable command buffer without one device patch dispatch per logical launch.

### Reviewer Notes

The primary contract change is the issue-time readiness language on `IREE_HAL_DISPATCH_FLAG_STATIC_INDIRECT_PARAMETERS`. The AMDGPU review surface then follows that contract through recording-time source summaries, queue-issue strategy selection, and exact replay compaction. Device-produced dynamic indirect dispatches are deliberately unchanged.
