### PR TITLE
[HAL] Document semaphore signal monotonicity contract

### DIFF
--- a/runtime/src/iree/hal/semaphore.h
+++ b/runtime/src/iree/hal/semaphore.h
@@ -396,7 +396,10 @@ IREE_API_EXPORT iree_status_t
 iree_hal_semaphore_query(iree_hal_semaphore_t* semaphore, uint64_t* out_value);
 
 // Signals the |semaphore| to the given payload value.
-// The call is ignored if the current payload value exceeds |new_value|.
+// The payload advances monotonically: |new_value| must be strictly greater
+// than the current payload value, so values may be skipped but never
+// repeated. Returns IREE_STATUS_INVALID_ARGUMENT without advancing the
+// payload if |new_value| is at or below the current payload.
 // |frontier| is an optional causal frontier to merge into the semaphore's
 // accumulated frontier. Pass NULL for local-only signals where cross-device
 // causal tracking is not needed.


### PR DESCRIPTION
`iree_hal_semaphore_signal()` now documents the monotonicity rule its implementation enforces: `new_value` must be strictly greater than the current payload, so timeline values may be skipped but never repeated, and a signal at or below the current payload returns `IREE_STATUS_INVALID_ARGUMENT` without advancing the payload. Backend signal implementations reach that rule through the shared `iree_async_semaphore_advance_timeline()`, and `runtime/src/iree/async/semaphore_test.cc` covers both the below-current and equal-to-current cases.

## Motivation

The previous comment said the call is ignored when the current payload exceeds `new_value`. That is wrong twice over: the call is rejected with a status rather than silently dropped, and the "exceeds" framing left equality looking permitted when signaling the value already reached is rejected as well. A caller reading only the header would reasonably discard the returned status on a stale or duplicate signal, throwing away the report of what this contract treats as a programming error — a duplicate signal or non-monotonic scheduling. Filed as https://github.com/ROCm/hrx-system/issues/379.

Documentation only. The comment now matches behavior that was already in place; no code paths change.
