### PR TITLE
[HRX] Fix graph executable ownership and payload alignment

### DIFF
--- a/libhrx/src/libhrx/graph_exec.c
+++ b/libhrx/src/libhrx/graph_exec.c
@@ -4,6 +4,8 @@
 // Graph execution: instantiation of graph templates into executable blocks,
 // and launch of those blocks onto a stream.
 
+#include <string.h>
+
 #include "hrx_internal.h"
 #include "iree/base/api.h"
 #include "iree/hal/utils/resource_set.h"
@@ -351,10 +353,9 @@ iree_status_t hrx_graph_exec_instantiate_locked(
       z0, hrx_graph_schedule_nodes(node_blocks, node_count, additional_edges,
                                    &exec->arena_allocator, &schedule));
 
-  exec->block_count = schedule.block_count;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_arena_allocate(&exec->arena_allocator,
-                              exec->block_count * sizeof(*exec->blocks),
+                              schedule.block_count * sizeof(*exec->blocks),
                               (void**)&exec->blocks));
 
   if (schedule.partition_count == 0) {
@@ -377,33 +378,57 @@ iree_status_t hrx_graph_exec_instantiate_locked(
       }
     }
   }
-  exec->semaphore_count = semaphore_count;
-
-  if (exec->semaphore_count > 0) {
+  if (semaphore_count > 0) {
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0,
-        iree_arena_allocate(&exec->arena_allocator,
-                            exec->semaphore_count * sizeof(*exec->semaphores),
-                            (void**)&exec->semaphores));
+        z0, iree_arena_allocate(&exec->arena_allocator,
+                                semaphore_count * sizeof(*exec->semaphores),
+                                (void**)&exec->semaphores));
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0, iree_arena_allocate(
                 &exec->arena_allocator,
-                exec->semaphore_count * sizeof(*exec->semaphore_base_values),
+                semaphore_count * sizeof(*exec->semaphore_base_values),
                 (void**)&exec->semaphore_base_values));
 
-    iree_hal_device_t* hal_device = exec->device->hal_device;
-    for (uint32_t i = 0; i < exec->semaphore_count; i++) {
-      IREE_RETURN_AND_END_ZONE_IF_ERROR(
-          z0, iree_hal_semaphore_create(hal_device, IREE_HAL_QUEUE_AFFINITY_ANY,
-                                        0ull, IREE_HAL_SEMAPHORE_FLAG_NONE,
-                                        &exec->semaphores[i]));
-      exec->semaphore_base_values[i] = 0;
-    }
+    // Arena memory is uninitialized. Zeroing up front keeps the arrays
+    // well-defined if the creation loop below fails part way through, and is
+    // what leaves every base value at zero when it succeeds.
+    memset(exec->semaphores, 0, semaphore_count * sizeof(*exec->semaphores));
+    memset(exec->semaphore_base_values, 0,
+           semaphore_count * sizeof(*exec->semaphore_base_values));
 
-    IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_hal_resource_set_insert(
-                exec->resource_set, exec->semaphore_count, exec->semaphores));
+    // The insert retains a resource the set has not already seen rather than
+    // consuming the creation reference, so each semaphore is released once
+    // inserted and the set holds it until the executable is destroyed;
+    // exec->semaphores stores borrowed pointers. Releasing after inserting is
+    // valid only because these semaphores are freshly created: an insert handed
+    // a resource the set already holds returns without retaining. Launching
+    // takes further references: the queue retains the semaphores an operation
+    // waits on and clones the signal list, so work in flight keeps them alive
+    // independently of the executable.
+    iree_hal_device_t* hal_device = exec->device->hal_device;
+    iree_status_t status = iree_ok_status();
+    for (uint32_t i = 0; iree_status_is_ok(status) && i < semaphore_count;
+         i++) {
+      iree_hal_semaphore_t* semaphore = NULL;
+      status = iree_hal_semaphore_create(
+          hal_device, IREE_HAL_QUEUE_AFFINITY_ANY, 0ull,
+          IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore);
+      if (iree_status_is_ok(status)) {
+        status =
+            iree_hal_resource_set_insert(exec->resource_set, 1, &semaphore);
+        iree_hal_semaphore_release(semaphore);
+      }
+      if (iree_status_is_ok(status)) {
+        exec->semaphores[i] = semaphore;
+      }
+    }
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, status);
   }
+
+  // Published only once every semaphore has been created, so a failure above
+  // returns with the count still zero rather than describing an array of null
+  // entries as populated.
+  exec->semaphore_count = semaphore_count;
 
   uint32_t block_index = 0;
   uint32_t semaphore_index = 0;
@@ -442,27 +467,37 @@ iree_status_t hrx_graph_exec_instantiate_locked(
                     partition->start_index, partition->count,
                     wait_semaphore_count, block_signal_count, &block, &ptrs));
 
-        // Create command buffer for recording.
+        // Create the command buffer this block records into. The insert retains
+        // a resource the set has not already seen rather than consuming the
+        // creation reference, so the block stores a borrowed pointer whose
+        // lifetime is the set's; releasing after inserting is valid only
+        // because this command buffer is freshly created. The creation
+        // reference is dropped exactly once below, past the last use of the
+        // local on every path: an insert that fails has taken no reference of
+        // its own, so releasing there frees the command buffer rather than
+        // stranding it. Nothing reaches the block until exec->blocks is written
+        // at the end of this iteration, and destruction discards the arena the
+        // attributes live in without walking it, so a reference held only by
+        // the attributes is a reference nothing can drop.
+        iree_hal_command_buffer_t* command_buffer = NULL;
         IREE_RETURN_AND_END_ZONE_IF_ERROR(
-            z0,
-            iree_hal_command_buffer_create(
-                exec->device->hal_device,
-                IREE_HAL_COMMAND_BUFFER_MODE_UNRETAINED,
-                IREE_HAL_COMMAND_CATEGORY_ANY, IREE_HAL_QUEUE_AFFINITY_ANY,
-                /*binding_capacity=*/0, &ptrs.attrs->execute.command_buffer));
-        ptrs.attrs->execute.flags = IREE_HAL_EXECUTE_FLAG_NONE;
-
-        IREE_RETURN_AND_END_ZONE_IF_ERROR(
-            z0,
-            iree_hal_resource_set_insert(exec->resource_set, 1,
-                                         &ptrs.attrs->execute.command_buffer));
-        iree_hal_command_buffer_release(ptrs.attrs->execute.command_buffer);
-
-        IREE_RETURN_AND_END_ZONE_IF_ERROR(
-            z0, hrx_graph_record_partition(
-                    exec, schedule.sorted_nodes, partition->start_index,
-                    partition->count, schedule.node_index_map, s,
-                    additional_edges, ptrs.attrs->execute.command_buffer));
+            z0, iree_hal_command_buffer_create(
+                    exec->device->hal_device,
+                    IREE_HAL_COMMAND_BUFFER_MODE_UNRETAINED,
+                    IREE_HAL_COMMAND_CATEGORY_ANY, IREE_HAL_QUEUE_AFFINITY_ANY,
+                    /*binding_capacity=*/0, &command_buffer));
+        iree_status_t status = iree_hal_resource_set_insert(exec->resource_set,
+                                                            1, &command_buffer);
+        if (iree_status_is_ok(status)) {
+          ptrs.attrs->execute.command_buffer = command_buffer;
+          ptrs.attrs->execute.flags = IREE_HAL_EXECUTE_FLAG_NONE;
+          status = hrx_graph_record_partition(
+              exec, schedule.sorted_nodes, partition->start_index,
+              partition->count, schedule.node_index_map, s, additional_edges,
+              command_buffer);
+        }
+        iree_hal_command_buffer_release(command_buffer);
+        IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, status);
 
         if (wait_semaphore_count > 0) {
           for (uint16_t w = 0; w < wait_semaphore_count; w++) {
@@ -528,6 +563,11 @@ iree_status_t hrx_graph_exec_instantiate_locked(
       exec->blocks[block_index++] = block;
     }
   }
+
+  // Published only once every entry has been constructed. A failure above
+  // returns with the count still zero rather than describing the uninitialized
+  // arena bytes past the failure point as blocks.
+  exec->block_count = block_index;
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();

--- a/libhrx/src/libhrx/graph_exec.c
+++ b/libhrx/src/libhrx/graph_exec.c
@@ -80,14 +80,32 @@ typedef struct hrx_graph_exec_block_t {
   uint32_t node_count;
   uint16_t wait_semaphore_count;
   uint16_t signal_semaphore_count;
+  // Type-specific attributes, stored inline so the compiler supplies the
+  // pointer alignment the union requires and the block header ends on that
+  // same boundary.
+  hrx_graph_block_attrs_t attrs;
   // Variable-length trailing data follows.
 } hrx_graph_exec_block_t;
 
+// Blocks are carved out of an arena, which guarantees iree_max_align_t and
+// nothing stronger.
+static_assert(iree_alignof(hrx_graph_exec_block_t) <= iree_max_align_t,
+              "block alignment must be satisfiable by an arena allocation");
+
+// The first trailing region begins at the end of the header and holds
+// uint32_t, so the header's size decides whether that region is aligned.
+// The region order only keeps the regions aligned relative to each other;
+// this assert is what pins the offset they start from.
+static_assert(sizeof(hrx_graph_exec_block_t) % iree_alignof(uint32_t) == 0,
+              "block header must end on the first trailing region's alignment");
+
+// Resolved pointers to a block's payload: the attributes stored inline in the
+// block and the variable-length arrays trailing it.
 typedef struct hrx_graph_block_ptrs_t {
-  uint16_t* wait_semaphore_indices;
   uint32_t* wait_payload_deltas;
-  uint16_t* signal_semaphore_indices;
   uint32_t* signal_payload_deltas;
+  uint16_t* wait_semaphore_indices;
+  uint16_t* signal_semaphore_indices;
   hrx_graph_block_attrs_t* attrs;
 } hrx_graph_block_ptrs_t;
 
@@ -95,18 +113,23 @@ typedef struct hrx_graph_block_ptrs_t {
 // Block helpers
 //===----------------------------------------------------------------------===//
 
+// Resolves the payload pointers for |block|. The trailing arrays run in
+// descending alignment order - both payload delta arrays before both semaphore
+// index arrays - starting at the end of the block header, whose size is a
+// multiple of the block's own alignment. Every region therefore lands on its
+// natural alignment and the block holds no interior padding.
+// hrx_graph_block_allocate sizes the allocation from this same order.
 static inline void hrx_graph_block_get_ptrs(hrx_graph_exec_block_t* block,
                                             hrx_graph_block_ptrs_t* out_ptrs) {
   uint8_t* ptr = (uint8_t*)block + sizeof(*block);
-  out_ptrs->wait_semaphore_indices = (uint16_t*)ptr;
-  ptr += block->wait_semaphore_count * sizeof(uint16_t);
   out_ptrs->wait_payload_deltas = (uint32_t*)ptr;
   ptr += block->wait_semaphore_count * sizeof(uint32_t);
-  out_ptrs->signal_semaphore_indices = (uint16_t*)ptr;
-  ptr += block->signal_semaphore_count * sizeof(uint16_t);
   out_ptrs->signal_payload_deltas = (uint32_t*)ptr;
   ptr += block->signal_semaphore_count * sizeof(uint32_t);
-  out_ptrs->attrs = (hrx_graph_block_attrs_t*)ptr;
+  out_ptrs->wait_semaphore_indices = (uint16_t*)ptr;
+  ptr += block->wait_semaphore_count * sizeof(uint16_t);
+  out_ptrs->signal_semaphore_indices = (uint16_t*)ptr;
+  out_ptrs->attrs = &block->attrs;
 }
 
 static iree_status_t hrx_graph_block_allocate(
@@ -114,12 +137,12 @@ static iree_status_t hrx_graph_block_allocate(
     uint32_t node_start_index, uint32_t node_count,
     uint16_t wait_semaphore_count, uint16_t signal_semaphore_count,
     hrx_graph_exec_block_t** out_block, hrx_graph_block_ptrs_t* out_ptrs) {
+  // Region order matches hrx_graph_block_get_ptrs.
   iree_host_size_t size = sizeof(hrx_graph_exec_block_t);
-  size += wait_semaphore_count * sizeof(uint16_t);
   size += wait_semaphore_count * sizeof(uint32_t);
-  size += signal_semaphore_count * sizeof(uint16_t);
   size += signal_semaphore_count * sizeof(uint32_t);
-  size += sizeof(hrx_graph_block_attrs_t);
+  size += wait_semaphore_count * sizeof(uint16_t);
+  size += signal_semaphore_count * sizeof(uint16_t);
 
   hrx_graph_exec_block_t* block = NULL;
   IREE_RETURN_IF_ERROR(iree_arena_allocate(arena, size, (void**)&block));

--- a/libhrx/src/libhrx/graph_exec_test.cc
+++ b/libhrx/src/libhrx/graph_exec_test.cc
@@ -251,4 +251,73 @@ TEST(GraphScheduleTest, AdditionalDependencyStaysOnProducerWorkstream) {
   iree_arena_block_pool_deinitialize(&block_pool);
 }
 
+class GraphExecSemaphoreTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    IREE_ASSERT_OK(hrx_status_to_iree(hrx_cpu_initialize(/*flags=*/0)));
+    IREE_ASSERT_OK(
+        hrx_status_to_iree(hrx_cpu_device_get(/*index=*/0, &device_)));
+  }
+
+  void TearDown() override {
+    IREE_EXPECT_OK(hrx_status_to_iree(hrx_cpu_shutdown()));
+  }
+
+  hrx_device_t device_ = nullptr;
+};
+
+// Instantiation creates the semaphores that join consecutive partitions and
+// hands ownership of them to the executable resource set. Destroying the
+// executable must therefore drop every reference it took on them. Needing more
+// than one partition to have any internal semaphore at all makes this the only
+// coverage of a block whose payload carries trailing arrays, so it is also what
+// exercises the block payload region layout.
+TEST_F(GraphExecSemaphoreTest,
+       InstantiationLeavesSemaphoresOwnedOnlyByExecutable) {
+  hrx_graph_t graph = nullptr;
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_graph_create(device_, 0, &graph)));
+
+  // Host calls are not recordable so each one forms its own partition; a chain
+  // of three yields two internal semaphores.
+  const hrx_graph_host_call_node_attrs_t attrs = {
+      /*.fn=*/[](void* user_data) -> hrx_status_t { return hrx_ok_status(); },
+      /*.user_data=*/nullptr,
+  };
+  hrx_graph_node_t previous_node = nullptr;
+  for (int i = 0; i < 3; ++i) {
+    hrx_graph_node_t node = nullptr;
+    IREE_ASSERT_OK(hrx_status_to_iree(hrx_graph_add_host_call_node(
+        graph, previous_node ? &previous_node : nullptr, previous_node ? 1 : 0,
+        &attrs, &node)));
+    previous_node = node;
+  }
+
+  hrx_graph_exec_t exec = nullptr;
+  IREE_ASSERT_OK(hrx_status_to_iree(hrx_graph_instantiate(graph, 0, &exec)));
+  ASSERT_EQ(exec->semaphore_count, 2u);
+
+  // Take an independent reference on each semaphore so the reference counts
+  // stay observable once the executable is gone.
+  std::vector<iree_hal_semaphore_t*> semaphores;
+  for (uint32_t i = 0; i < exec->semaphore_count; ++i) {
+    ASSERT_NE(exec->semaphores[i], nullptr);
+    EXPECT_EQ(exec->semaphore_base_values[i], 0u);
+    iree_hal_semaphore_retain(exec->semaphores[i]);
+    semaphores.push_back(exec->semaphores[i]);
+  }
+
+  hrx_graph_exec_release(exec);
+  hrx_graph_release(graph);
+
+  for (iree_hal_semaphore_t* semaphore : semaphores) {
+    // Every HAL object begins with an iree_hal_resource_t, which is what makes
+    // its reference count reachable from an opaque handle.
+    EXPECT_EQ(
+        iree_atomic_ref_count_load(
+            &reinterpret_cast<iree_hal_resource_t*>(semaphore)->ref_count),
+        1);
+    iree_hal_semaphore_release(semaphore);
+  }
+}
+
 }  // namespace

--- a/libhrx/src/libhrx/hrx_internal.h
+++ b/libhrx/src/libhrx/hrx_internal.h
@@ -432,7 +432,7 @@ typedef struct hrx_graph_exec_s {
   uint32_t block_count;
 
   uint32_t semaphore_count;
-  iree_hal_semaphore_t** semaphores;
+  iree_hal_semaphore_t** semaphores;  // borrowed; owned by resource_set
   uint64_t* semaphore_base_values;
 
   iree_hal_resource_set_t* resource_set;


### PR DESCRIPTION
## Motivation

The `hrx_*` graph executable path leaked the creation reference for every internal semaphore and could strand a successfully created prefix when instantiation failed. Both that path and the HIP/common streaming graph path also placed pointer-bearing block attributes and 32-bit payload deltas at byte offsets that were not naturally aligned for common partition shapes.

## Summary

- Transfers each freshly created internal semaphore and recorded command buffer to the executable resource set individually, then releases the creation reference.
- Publishes semaphore and block counts only after their arrays are fully constructed.
- Stores block attributes inline and orders trailing payload arrays by descending alignment in both graph executable implementations.
- Adds a three-host-call regression that creates two internal partition semaphores and verifies executable destruction drops its references.

## Design

`exec->semaphores` is a borrowed array; the resource set owns the internal semaphores for the executable lifetime, while submitted queue work takes the references it needs in flight. Creation, insertion, and release complete within each iteration, so partial instantiation has no unowned prefix. Recordable-block command buffers use the same ownership transfer.

Each variable-length block now places its attribute union in the compiler-laid-out header. The trailing `uint32_t` delta arrays precede the `uint16_t` index arrays. Static assertions require the arena to satisfy the header alignment and the header size to align the first trailing region. On the current HAL queue model, recorded command buffers are created for the canonical dispatch queue family, and internal semaphores use all-family affinity because graph blocks may submit to dispatch and transfer queues.

## Scope

The ownership and delayed-publication changes apply to the `hrx_*` implementation. The common streaming implementation already had single-owner internal semaphores and receives only the block-layout correction.

## Testing

Validated with TheRock ROCm 7.14.0a20260622 and its Clang toolchain:

- `rocm-sdk test` — 27/27 checks passed.
- `bazel test --config=presubmit //libhrx/...` — 43 tests passed and 8 were skipped.
- The same libhrx suite under `--config=asan`, `--config=ubsan`, and `--config=tsan` — 43 tests passed and 8 were skipped in each configuration.
- ClangFormat 22.1.3 dry-run and `git diff --check` passed.

Closes #378.
