### PR TITLE
[HRX/CUDA] Fix inverted query results and build the binding under Bazel

### DIFF
--- a/libhrx/src/binding/common/BUILD.bazel
+++ b/libhrx/src/binding/common/BUILD.bazel
@@ -88,6 +88,22 @@ hrx_cc_library(
     ],
 )
 
+hrx_cc_library(
+    name = "streaming_query_test_util",
+    testonly = True,
+    hdrs = ["streaming_query_test_util.h"],
+    includes = [".."],
+    deps = [
+        ":common",
+        "//runtime/src/iree/async",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal",
+        "//runtime/src/iree/base/threading",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/testing:gtest",
+    ],
+)
+
 hrx_cc_test(
     name = "function_attributes_test",
     srcs = ["function_attributes_test.cc"],
@@ -155,6 +171,42 @@ hrx_cc_test(
     target_compatible_with = ["@platforms//os:linux"],
     deps = [
         ":common",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+hrx_cc_test(
+    name = "context_test",
+    srcs = ["context_test.cc"],
+    deps = [
+        ":common",
+        ":streaming_query_test_util",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+hrx_cc_test(
+    name = "event_test",
+    srcs = ["event_test.cc"],
+    deps = [
+        ":common",
+        ":streaming_query_test_util",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+hrx_cc_test(
+    name = "stream_test",
+    srcs = ["stream_test.cc"],
+    deps = [
+        ":common",
+        ":streaming_query_test_util",
         "//runtime/src/iree/base",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",

--- a/libhrx/src/binding/common/CMakeLists.txt
+++ b/libhrx/src/binding/common/CMakeLists.txt
@@ -81,6 +81,27 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_library(
+  NAME
+    streaming_query_test_util
+  HDRS
+    "streaming_query_test_util.h"
+  DEPS
+    ::common
+    iree::async
+    iree::base
+    iree::base::internal
+    iree::base::threading
+    iree::hal
+    iree::testing::gtest
+    libhrx_defs
+  TESTONLY
+  INCLUDES
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>"
+  PUBLIC
+)
+
 iree_cc_test(
   NAME
     function_attributes_test
@@ -161,6 +182,48 @@ iree_cc_test(
     libhrx_defs
 )
 endif()
+
+iree_cc_test(
+  NAME
+    context_test
+  SRCS
+    "context_test.cc"
+  DEPS
+    ::common
+    ::streaming_query_test_util
+    iree::base
+    iree::testing::gtest
+    iree::testing::gtest_main
+    libhrx_defs
+)
+
+iree_cc_test(
+  NAME
+    event_test
+  SRCS
+    "event_test.cc"
+  DEPS
+    ::common
+    ::streaming_query_test_util
+    iree::base
+    iree::testing::gtest
+    iree::testing::gtest_main
+    libhrx_defs
+)
+
+iree_cc_test(
+  NAME
+    stream_test
+  SRCS
+    "stream_test.cc"
+  DEPS
+    ::common
+    ::streaming_query_test_util
+    iree::base
+    iree::testing::gtest
+    iree::testing::gtest_main
+    libhrx_defs
+)
 
 iree_cc_binary_benchmark(
   NAME

--- a/libhrx/src/binding/common/context_test.cc
+++ b/libhrx/src/binding/common/context_test.cc
@@ -1,0 +1,65 @@
+// Copyright 2026 The HRX Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/internal.h"
+#include "common/streaming_query_test_util.h"
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+using ::iree::hal::stream::FailedTimelineValue;
+using ::iree::hal::stream::QueryableContext;
+using ::iree::hal::stream::QueryableStream;
+
+TEST(StreamingContextQueryTest, AllStreamsCompleteReportsComplete) {
+  QueryableStream first(/*timeline_value=*/5, /*pending_value=*/5);
+  QueryableStream second(/*timeline_value=*/7, /*pending_value=*/7);
+  QueryableContext context({&first, &second});
+
+  int status = -1;
+  IREE_ASSERT_OK(iree_hal_streaming_context_query(context.get(), &status));
+  EXPECT_EQ(status, 0);
+  EXPECT_EQ(second.get()->completed_value, 7u);
+}
+
+// The first stream the list holds that is busy is the answer, and the streams
+// the list holds after it are left alone. A complete stream advances its
+// completed value when it is queried, so the third stream's completed value
+// staying 0 is what shows the walk stopped at the second.
+TEST(StreamingContextQueryTest, BusyStreamReportsNotCompleteAndEndsTheWalk) {
+  QueryableStream complete(/*timeline_value=*/5, /*pending_value=*/5);
+  QueryableStream busy(/*timeline_value=*/4, /*pending_value=*/5);
+  QueryableStream behind(/*timeline_value=*/7, /*pending_value=*/7);
+  QueryableContext context({&complete, &busy, &behind});
+
+  int status = -1;
+  IREE_ASSERT_OK(iree_hal_streaming_context_query(context.get(), &status));
+  EXPECT_EQ(status, 1);
+  EXPECT_EQ(complete.get()->completed_value, 5u);
+  EXPECT_EQ(behind.get()->completed_value, 0u);
+}
+
+// A stream whose timeline reports a failure ends the walk and hands that
+// failure back, which is the answer iree_hal_streaming_stream_query gives for
+// the stream on its own. |status| is meaningful only on success, so only the
+// returned status and the untouched stream the list holds after the failure
+// are checked.
+TEST(StreamingContextQueryTest, FailedStreamTimelineIsPropagated) {
+  QueryableStream complete(/*timeline_value=*/5, /*pending_value=*/5);
+  QueryableStream failed(FailedTimelineValue(IREE_STATUS_ABORTED),
+                         /*pending_value=*/5);
+  QueryableStream behind(/*timeline_value=*/7, /*pending_value=*/7);
+  QueryableContext context({&complete, &failed, &behind});
+
+  int status = -1;
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED, iree_hal_streaming_context_query(
+                                                 context.get(), &status));
+  EXPECT_EQ(behind.get()->completed_value, 0u);
+}
+
+}  // namespace

--- a/libhrx/src/binding/common/event_test.cc
+++ b/libhrx/src/binding/common/event_test.cc
@@ -1,0 +1,69 @@
+// Copyright 2026 The HRX Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/internal.h"
+#include "common/streaming_query_test_util.h"
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+using ::iree::hal::stream::FailedTimelineValue;
+using ::iree::hal::stream::QueryableEvent;
+
+TEST(StreamingEventQueryTest, UnreachedRecordedPointReportsNotComplete) {
+  QueryableEvent event(/*timeline_value=*/4, /*record_value=*/5);
+
+  int status = -1;
+  IREE_ASSERT_OK(iree_hal_streaming_event_query(event.get(), &status));
+  EXPECT_EQ(status, 1);
+}
+
+// The timeline reaching the recorded point reports complete, and so does a
+// timeline that has run past it: the point is a lower bound, not an equality.
+TEST(StreamingEventQueryTest, ReachedRecordedPointReportsComplete) {
+  QueryableEvent event(/*timeline_value=*/5, /*record_value=*/5);
+
+  int status = -1;
+  IREE_ASSERT_OK(iree_hal_streaming_event_query(event.get(), &status));
+  EXPECT_EQ(status, 0);
+
+  event.set_timeline_value(6);
+  status = -1;
+  IREE_ASSERT_OK(iree_hal_streaming_event_query(event.get(), &status));
+  EXPECT_EQ(status, 0);
+}
+
+// An event names no timeline until a record of it is submitted: a record taken
+// during stream capture produces no submission and leaves the point alone, and
+// an event never passed to a record has never held one. A point naming no
+// timeline reads as reached, so the query reports complete.
+TEST(StreamingEventQueryTest, EventWithNoRecordReportsComplete) {
+  QueryableEvent event;
+
+  int status = -1;
+  IREE_ASSERT_OK(iree_hal_streaming_event_query(event.get(), &status));
+  EXPECT_EQ(status, 0);
+}
+
+// A failed timeline is returned, not folded into a completion answer. The
+// recorded value sits below the failure sentinel the HAL reports alongside the
+// status, so a query that dropped the status would read the timeline as reached
+// and answer complete - the worst of the three possible answers.
+TEST(StreamingEventQueryTest, FailedTimelineIsPropagated) {
+  QueryableEvent event(FailedTimelineValue(IREE_STATUS_ABORTED),
+                       /*record_value=*/5);
+
+  // |status| is meaningful only on success, so only the returned status is
+  // checked. The spy's destructor checks that the query released the reference
+  // it took even on this path.
+  int status = -1;
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED,
+                        iree_hal_streaming_event_query(event.get(), &status));
+}
+
+}  // namespace

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -249,11 +249,15 @@ struct iree_hal_streaming_context_t {
   // Host allocator.
   iree_allocator_t host_allocator;
 
-  // Stream tracking (non-owning references - streams are not retained).
-  // NOTE: Streams are NOT retained by this list to avoid reference cycles.
-  // Streams must unregister themselves before destruction.
-  iree_hal_streaming_stream_t** streams;  // Non-owning pointers.
+  // Streams registered with this context. The list holds a reference to each
+  // entry: iree_hal_streaming_context_register_stream retains on insert and
+  // iree_hal_streaming_context_unregister_stream releases once the entry is
+  // unlinked, so a registered stream stays alive for as long as the list names
+  // it.
+  iree_hal_streaming_stream_t** streams;
+  // Number of entries in |streams| currently valid.
   iree_host_size_t stream_count;
+  // Allocated capacity of |streams|.
   iree_host_size_t stream_capacity;
 
   // Dedicated mutex for stream list access.

--- a/libhrx/src/binding/common/internal.h
+++ b/libhrx/src/binding/common/internal.h
@@ -1601,6 +1601,13 @@ iree_status_t iree_hal_streaming_context_synchronize_blocking_streams(
     iree_hal_streaming_stream_t* except_stream);
 
 // Queries whether any stream in the context still has queued work.
+// |status| is meaningful only on success, where 0 is complete and 1 is not
+// complete. Streams are walked in the order the context's stream list holds
+// them, which unregistering a stream permutes, and the walk ends at the first
+// stream that is not complete or whose query fails; the streams the list holds
+// after that one are neither flushed nor queried. Any failure is returned,
+// including one from snapshotting the stream list before any stream is walked.
+// Synchronization: stream flush (flushes each stream it queries).
 iree_status_t iree_hal_streaming_context_query(
     iree_hal_streaming_context_t* context, int* status);
 
@@ -1693,7 +1700,10 @@ iree_status_t iree_hal_streaming_stream_begin_locked(
 iree_status_t iree_hal_streaming_stream_flush(
     iree_hal_streaming_stream_t* stream);
 
-// Synchronization: none (queries stream status, non-blocking).
+// Queries whether the stream still has queued work.
+// |status| is meaningful only on success, where 0 is complete and 1 is not
+// complete. A timeline that reports a failure fails the query.
+// Synchronization: stream flush (flushes the stream before querying it).
 iree_status_t iree_hal_streaming_stream_query(
     iree_hal_streaming_stream_t* stream, int* status);
 
@@ -1778,6 +1788,10 @@ iree_status_t iree_hal_streaming_event_create(
 void iree_hal_streaming_event_retain(iree_hal_streaming_event_t* event);
 void iree_hal_streaming_event_release(iree_hal_streaming_event_t* event);
 
+// Queries whether the point the event's last submitted record names has been
+// reached. An event with no submitted record reports complete.
+// |status| is meaningful only on success, where 0 is complete and 1 is not
+// complete. A timeline that reports a failure fails the query.
 // Synchronization: none (queries event status, non-blocking).
 iree_status_t iree_hal_streaming_event_query(iree_hal_streaming_event_t* event,
                                              int* status);

--- a/libhrx/src/binding/common/stream_test.cc
+++ b/libhrx/src/binding/common/stream_test.cc
@@ -1,0 +1,61 @@
+// Copyright 2026 The HRX Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "common/internal.h"
+#include "common/streaming_query_test_util.h"
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+using ::iree::hal::stream::FailedTimelineValue;
+using ::iree::hal::stream::QueryableStream;
+
+TEST(StreamingStreamQueryTest, UnreachedPendingValueReportsNotComplete) {
+  QueryableStream stream(/*timeline_value=*/4, /*pending_value=*/5);
+
+  int status = -1;
+  IREE_ASSERT_OK(iree_hal_streaming_stream_query(stream.get(), &status));
+  EXPECT_EQ(status, 1);
+}
+
+// The timeline reaching the pending value reports complete, and so does a
+// timeline that has run past it: the pending value is a lower bound, not an
+// equality. A complete answer also advances the stream's completed value to
+// what the timeline reported.
+TEST(StreamingStreamQueryTest, ReachedPendingValueReportsComplete) {
+  QueryableStream stream(/*timeline_value=*/5, /*pending_value=*/5);
+
+  int status = -1;
+  IREE_ASSERT_OK(iree_hal_streaming_stream_query(stream.get(), &status));
+  EXPECT_EQ(status, 0);
+  EXPECT_EQ(stream.get()->completed_value, 5u);
+
+  stream.set_timeline_value(6);
+  status = -1;
+  IREE_ASSERT_OK(iree_hal_streaming_stream_query(stream.get(), &status));
+  EXPECT_EQ(status, 0);
+  EXPECT_EQ(stream.get()->completed_value, 6u);
+}
+
+// A failed timeline is returned, not folded into a completion answer, which is
+// the answer iree_hal_streaming_event_query gives as well. The pending value
+// sits below the failure sentinel the HAL reports alongside the status, so a
+// query that dropped the status would read the timeline as reached and answer
+// complete.
+TEST(StreamingStreamQueryTest, FailedTimelineIsPropagated) {
+  QueryableStream stream(FailedTimelineValue(IREE_STATUS_ABORTED),
+                         /*pending_value=*/5);
+
+  // |status| is meaningful only on success, so only the returned status is
+  // checked.
+  int status = -1;
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED,
+                        iree_hal_streaming_stream_query(stream.get(), &status));
+}
+
+}  // namespace

--- a/libhrx/src/binding/common/streaming_query_test_util.h
+++ b/libhrx/src/binding/common/streaming_query_test_util.h
@@ -1,0 +1,284 @@
+// Copyright 2026 The HRX Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_EXPERIMENTAL_STREAMING_QUERY_TEST_UTIL_H_
+#define IREE_EXPERIMENTAL_STREAMING_QUERY_TEST_UTIL_H_
+
+#include <cstdint>
+#include <initializer_list>
+#include <vector>
+
+#include "common/internal.h"
+#include "iree/async/semaphore.h"
+#include "iree/base/api.h"
+#include "iree/base/internal/atomics.h"
+#include "iree/base/threading/mutex.h"
+#include "iree/hal/api.h"
+#include "iree/testing/gtest.h"
+
+namespace iree::hal::stream {
+
+// Timeline value an implementation reports for a timeline that has failed with
+// |code|. iree_hal_semaphore_query decodes it back into a status and reports
+// IREE_HAL_SEMAPHORE_FAILURE_VALUE as the value, which is above every value
+// these fixtures record, so a query that dropped the status would read the
+// timeline as reached and answer complete. A bare code owns no allocation, so
+// the encoded status needs no consumer to free it.
+//
+// IREE_STATUS_INTERNAL is rejected: it is what the decoder synthesizes for a
+// failure value carrying no encoded status, so a suite asserting on it would
+// pass whether or not the code survived the round trip.
+inline uint64_t FailedTimelineValue(iree_status_code_t code) {
+  EXPECT_NE(code, IREE_STATUS_INTERNAL)
+      << "iree_hal_semaphore_failure_as_status synthesizes "
+         "IREE_STATUS_INTERNAL for a failure value carrying no encoded status, "
+         "so asserting on it cannot show the code made the round trip";
+  return iree_hal_status_as_semaphore_failure(iree_status_from_code(code));
+}
+
+// HAL semaphore reporting a caller-chosen timeline value from every query.
+//
+// Standard layout with |resource| first, so the address of a spy is a valid
+// iree_hal_semaphore_t. Its storage is automatic, so destruction through the
+// HAL is never correct: the destroy entry fails the test, and the destructor
+// requires the reference count back at the one initialization left it at. That
+// is what makes a query's retain and release observable.
+struct TimelineSemaphoreSpy {
+  explicit TimelineSemaphoreSpy(uint64_t initial_timeline_value);
+  ~TimelineSemaphoreSpy();
+  TimelineSemaphoreSpy(const TimelineSemaphoreSpy&) = delete;
+  TimelineSemaphoreSpy& operator=(const TimelineSemaphoreSpy&) = delete;
+
+  iree_hal_semaphore_t* get();
+
+  // {ref_count, vtable} header that iree_hal_resource_t and
+  // iree_async_semaphore_t share, which is what lets the HAL dispatch to the
+  // vtable below.
+  iree_hal_resource_t resource;
+  // Value every query reports.
+  uint64_t timeline_value;
+};
+
+// Reports the caller-chosen value. Reached through iree_hal_semaphore_query.
+inline uint64_t TimelineSemaphoreSpyQuery(iree_async_semaphore_t* semaphore) {
+  return reinterpret_cast<TimelineSemaphoreSpy*>(semaphore)->timeline_value;
+}
+
+// Reached only when a release drops the last reference, which for a spy with
+// automatic storage means one release too many.
+inline void TimelineSemaphoreSpyDestroy(iree_async_semaphore_t* semaphore) {
+  (void)semaphore;
+  ADD_FAILURE() << "test semaphore released more times than it was retained";
+}
+
+// Only destroy and query are ever dispatched: iree_hal_semaphore_query
+// dispatches query, and a release that drops the last reference dispatches
+// destroy. The remaining entries stay null; no query path reaches them.
+inline constexpr iree_hal_semaphore_vtable_t kTimelineSemaphoreSpyVtable = {
+    /*.async=*/{
+        /*.destroy=*/TimelineSemaphoreSpyDestroy,
+        /*.query=*/TimelineSemaphoreSpyQuery,
+        /*.signal=*/nullptr,
+        /*.on_fail=*/nullptr,
+    },
+    /*.wait=*/nullptr,
+    /*.import_timepoint=*/nullptr,
+    /*.export_timepoint=*/nullptr,
+};
+
+inline TimelineSemaphoreSpy::TimelineSemaphoreSpy(
+    uint64_t initial_timeline_value)
+    : timeline_value(initial_timeline_value) {
+  iree_hal_resource_initialize(&kTimelineSemaphoreSpyVtable, &resource);
+}
+
+inline TimelineSemaphoreSpy::~TimelineSemaphoreSpy() {
+  EXPECT_EQ(iree_atomic_ref_count_load(&resource.ref_count), 1)
+      << "test semaphore left with an unreleased reference";
+}
+
+inline iree_hal_semaphore_t* TimelineSemaphoreSpy::get() {
+  return reinterpret_cast<iree_hal_semaphore_t*>(this);
+}
+
+// An iree_hal_streaming_stream_t carrying only the timeline state a query
+// reads. No context, no device and no command buffer, so the flush a query
+// performs first takes the stream mutex and submits nothing.
+class QueryableStream {
+ public:
+  // A stream whose timeline reports |timeline_value| and whose last accepted
+  // submission signals |pending_value|.
+  QueryableStream(uint64_t timeline_value, uint64_t pending_value);
+  ~QueryableStream();
+  QueryableStream(const QueryableStream&) = delete;
+  QueryableStream& operator=(const QueryableStream&) = delete;
+
+  // Moves the timeline the stream queries to |timeline_value|.
+  void set_timeline_value(uint64_t timeline_value);
+
+  iree_hal_streaming_stream_t* get();
+
+ private:
+  // Declared first so it is destroyed last, after |stream_| is torn down.
+  TimelineSemaphoreSpy semaphore_;
+  // The constructor sets the reference count, the mutex, the timeline
+  // semaphore and the pending value; the member initializer zeroes the rest.
+  // That zeroing is load-bearing: a query also reads command_buffer, through
+  // the flush it performs first, and reads and updates completed_value. The
+  // reference count is initialized the way iree_hal_streaming_stream_create
+  // initializes it, so the fixture holds the one reference a create caller
+  // owns; a context here borrows its streams and takes no second reference, so
+  // the count moves only when a query moves it.
+  iree_hal_streaming_stream_t stream_ = {};
+};
+
+inline QueryableStream::QueryableStream(uint64_t timeline_value,
+                                        uint64_t pending_value)
+    : semaphore_(timeline_value) {
+  iree_atomic_ref_count_init(&stream_.ref_count);
+  iree_slim_mutex_initialize(&stream_.mutex);
+  stream_.timeline_semaphore = semaphore_.get();
+  stream_.pending_value = pending_value;
+}
+
+// The stream borrows the spy: production has a stream create and own its
+// timeline, but the fixture holds this one as a member declared ahead of
+// |stream_|, so it already outlives the stream and a retain/release pair would
+// only cancel itself. The count the spy checks at teardown therefore moves only
+// when a query moves it.
+inline QueryableStream::~QueryableStream() {
+  // A context query retains every stream in its snapshot and releases it after
+  // the walk. No tested path moves the event or context fixture's own count, so
+  // this is the only one of the three that has anything to check.
+  EXPECT_EQ(iree_atomic_ref_count_load(&stream_.ref_count), 1)
+      << "test stream left with an unreleased reference";
+  iree_slim_mutex_deinitialize(&stream_.mutex);
+}
+
+inline void QueryableStream::set_timeline_value(uint64_t timeline_value) {
+  semaphore_.timeline_value = timeline_value;
+}
+
+inline iree_hal_streaming_stream_t* QueryableStream::get() { return &stream_; }
+
+// An iree_hal_streaming_event_t carrying only the state a query reads.
+class QueryableEvent {
+ public:
+  // An event with no submitted record.
+  QueryableEvent();
+  // An event whose record names |record_value| on a timeline reporting
+  // |timeline_value|, published through the commit the record paths use.
+  QueryableEvent(uint64_t timeline_value, uint64_t record_value);
+  ~QueryableEvent();
+  QueryableEvent(const QueryableEvent&) = delete;
+  QueryableEvent& operator=(const QueryableEvent&) = delete;
+
+  // Moves the timeline the recorded point names to |timeline_value|.
+  void set_timeline_value(uint64_t timeline_value);
+
+  iree_hal_streaming_event_t* get();
+
+ private:
+  // Declared first so it is destroyed last, after |event_| has released the
+  // reference its recorded point holds. An event with no submitted record never
+  // names it, which keeps one fixture shape for both cases.
+  TimelineSemaphoreSpy semaphore_;
+  // The constructor sets the reference count, the mutex and, for a recorded
+  // event, the point; the member initializer zeroes the rest. The reference
+  // count is initialized the way iree_hal_streaming_event_create initializes
+  // it; no query path moves it.
+  iree_hal_streaming_event_t event_ = {};
+};
+
+inline QueryableEvent::QueryableEvent() : semaphore_(0) {
+  iree_atomic_ref_count_init(&event_.ref_count);
+  iree_slim_mutex_initialize(&event_.mutex);
+}
+
+inline QueryableEvent::QueryableEvent(uint64_t timeline_value,
+                                      uint64_t record_value)
+    : semaphore_(timeline_value) {
+  iree_atomic_ref_count_init(&event_.ref_count);
+  iree_slim_mutex_initialize(&event_.mutex);
+  const iree_hal_streaming_recorded_point_t point = {
+      /*.semaphore=*/semaphore_.get(),
+      /*.value=*/record_value,
+      /*.ordered_after_stream_id=*/0,
+      /*.ordered_after_stream_value=*/0,
+      /*.record_time_ns=*/0,
+  };
+  iree_hal_streaming_event_commit_recorded_point(&event_, point);
+}
+
+// Mirrors iree_hal_streaming_event_destroy: the event owns the reference its
+// recorded point holds, and the mutex is deinitialized after it.
+inline QueryableEvent::~QueryableEvent() {
+  iree_hal_semaphore_release(event_.recorded_point.semaphore);
+  iree_slim_mutex_deinitialize(&event_.mutex);
+}
+
+inline void QueryableEvent::set_timeline_value(uint64_t timeline_value) {
+  semaphore_.timeline_value = timeline_value;
+}
+
+inline iree_hal_streaming_event_t* QueryableEvent::get() { return &event_; }
+
+// An iree_hal_streaming_context_t carrying only the stream list a query reads.
+// The streams are borrowed: production's list retains every stream it names and
+// releases it on unregister, but the QueryableStream fixtures here stay owned
+// by the caller, which must keep them alive for as long as the context.
+class QueryableContext {
+ public:
+  // A context whose stream list holds |streams| in the order given.
+  explicit QueryableContext(std::initializer_list<QueryableStream*> streams);
+  ~QueryableContext();
+  QueryableContext(const QueryableContext&) = delete;
+  QueryableContext& operator=(const QueryableContext&) = delete;
+
+  iree_hal_streaming_context_t* get();
+
+ private:
+  // Backing storage for |context_.streams|. Nothing may register a stream into
+  // this context: the array is owned by this vector, while
+  // iree_hal_streaming_context_register_stream would grow it through
+  // |context_.host_allocator|.
+  std::vector<iree_hal_streaming_stream_t*> streams_;
+  // The constructor sets the reference count, the stream-list mutex, the stream
+  // array and the host allocator; the member initializer zeroes the rest. The
+  // allocator is load-bearing: a query copies the stream list into an
+  // allocation taken from it and frees that allocation through it. The
+  // reference count is initialized the way iree_hal_streaming_context_create
+  // initializes it; no query path moves it.
+  iree_hal_streaming_context_t context_ = {};
+};
+
+inline QueryableContext::QueryableContext(
+    std::initializer_list<QueryableStream*> streams) {
+  streams_.reserve(streams.size());
+  for (QueryableStream* stream : streams) {
+    streams_.push_back(stream->get());
+  }
+  iree_atomic_ref_count_init(&context_.ref_count);
+  iree_slim_mutex_initialize(&context_.stream_list_mutex);
+  context_.streams = streams_.data();
+  context_.stream_count = (iree_host_size_t)streams_.size();
+  // No query path reads the capacity, but a capacity below the count would
+  // describe an array this is not.
+  context_.stream_capacity = (iree_host_size_t)streams_.size();
+  context_.host_allocator = iree_allocator_system();
+}
+
+inline QueryableContext::~QueryableContext() {
+  iree_slim_mutex_deinitialize(&context_.stream_list_mutex);
+}
+
+inline iree_hal_streaming_context_t* QueryableContext::get() {
+  return &context_;
+}
+
+}  // namespace iree::hal::stream
+
+#endif  // IREE_EXPERIMENTAL_STREAMING_QUERY_TEST_UTIL_H_

--- a/libhrx/src/binding/cuda/BUILD.bazel
+++ b/libhrx/src/binding/cuda/BUILD.bazel
@@ -1,0 +1,35 @@
+# Copyright 2026 The HRX Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load(
+    "//libhrx/build_tools/bazel:cc.bzl",
+    "hrx_cc_library",
+)
+
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+hrx_cc_library(
+    name = "cuda",
+    srcs = [
+        "driver.c",
+        "runtime.c",
+    ],
+    hdrs = [
+        "api.h",
+        "driver.h",
+        "runtime.h",
+    ],
+    # These sources are the definitions of the CUDA entry points, so CUDAAPI
+    # must select the exporting spelling. Read only on Windows; the CMake
+    # target that compiles the same sources defines it too.
+    copts = ["-DIREE_HAL_STREAMING_CUDA_EXPORTS"],
+    includes = ["../.."],
+    deps = ["//libhrx/src/binding/common"],
+)

--- a/libhrx/src/binding/cuda/BUILD.bazel
+++ b/libhrx/src/binding/cuda/BUILD.bazel
@@ -7,6 +7,7 @@
 load(
     "//libhrx/build_tools/bazel:cc.bzl",
     "hrx_cc_library",
+    "hrx_cc_test",
 )
 
 package(
@@ -32,4 +33,23 @@ hrx_cc_library(
     copts = ["-DIREE_HAL_STREAMING_CUDA_EXPORTS"],
     includes = ["../.."],
     deps = ["//libhrx/src/binding/common"],
+)
+
+hrx_cc_test(
+    name = "driver_query_test",
+    srcs = ["driver_query_test.cc"],
+    # CUDAAPI has no spelling for a statically linked entry point: it resolves
+    # to __declspec(dllexport) in the sources that define these functions and
+    # to __declspec(dllimport) here, which includes the same headers without
+    # the define, so on Windows this test would look for __imp_ symbols in a
+    # static archive. A Windows port needs a third spelling of the export macro
+    # before relaxing this constraint.
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        ":cuda",
+        "//libhrx/src/binding/common:streaming_query_test_util",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
 )

--- a/libhrx/src/binding/cuda/driver.c
+++ b/libhrx/src/binding/cuda/driver.c
@@ -346,15 +346,13 @@ CUDAAPI CUresult cuCtxDestroy(CUcontext ctx) {
 
   // Check if this is the current context.
   // If so, clear it from TLS to avoid a dangling reference.
-  if (ctx && ctx == (CUcontext)iree_hal_streaming_context_current()) {
+  if (ctx == (CUcontext)iree_hal_streaming_context_current()) {
     // This will release the TLS reference.
     iree_hal_streaming_context_set_current(NULL);
   }
 
   // Release the context.
-  if (ctx) {
-    iree_hal_streaming_context_release((iree_hal_streaming_context_t*)ctx);
-  }
+  iree_hal_streaming_context_release((iree_hal_streaming_context_t*)ctx);
 
   IREE_TRACE_ZONE_END(z0);
   return CUDA_SUCCESS;

--- a/libhrx/src/binding/cuda/driver.c
+++ b/libhrx/src/binding/cuda/driver.c
@@ -1120,9 +1120,10 @@ CUDAAPI CUresult cuEventQuery(CUevent hEvent) {
   int is_complete = 0;
   iree_status_t status = iree_hal_streaming_event_query(
       (iree_hal_streaming_event_t*)hEvent, &is_complete);
+  // is_complete == 0 means complete, is_complete == 1 means not complete.
   CUresult result =
       iree_status_is_ok(status)
-          ? (is_complete == 1 ? CUDA_SUCCESS : CUDA_ERROR_NOT_READY)
+          ? (is_complete == 0 ? CUDA_SUCCESS : CUDA_ERROR_NOT_READY)
           : iree_status_to_cu_result(status);
   return result;
 }
@@ -2792,9 +2793,10 @@ CUDAAPI CUresult cuStreamQuery(CUstream hStream) {
   int is_complete = 0;
   iree_status_t status = iree_hal_streaming_stream_query(
       (iree_hal_streaming_stream_t*)hStream, &is_complete);
+  // is_complete == 0 means complete, is_complete == 1 means not complete.
   CUresult result =
       iree_status_is_ok(status)
-          ? (is_complete == 1 ? CUDA_SUCCESS : CUDA_ERROR_NOT_READY)
+          ? (is_complete == 0 ? CUDA_SUCCESS : CUDA_ERROR_NOT_READY)
           : iree_status_to_cu_result(status);
   return result;
 }

--- a/libhrx/src/binding/cuda/driver.c
+++ b/libhrx/src/binding/cuda/driver.c
@@ -1071,9 +1071,6 @@ CUDAAPI CUresult cuEventCreateWithFlags(CUevent* event, unsigned flags) {
   }
 
   CUresult result = iree_status_to_cu_result(status);
-  if (!iree_status_is_ok(status)) {
-    iree_status_ignore(status);
-  }
   IREE_TRACE_ZONE_END(z0);
   return result;
 }
@@ -1749,9 +1746,6 @@ CUDAAPI CUresult cuMemset(void* dst, int value, size_t sizeBytes) {
       sizeof(pattern), context->default_stream);
 
   CUresult result = iree_status_to_cu_result(status);
-  if (!iree_status_is_ok(status)) {
-    iree_status_ignore(status);
-  }
   IREE_TRACE_ZONE_END(z0);
   return result;
 }
@@ -1778,9 +1772,6 @@ CUDAAPI CUresult cuMemsetAsync(void* dst, int value, size_t sizeBytes,
               : context->default_stream);
 
   CUresult result = iree_status_to_cu_result(status);
-  if (!iree_status_is_ok(status)) {
-    iree_status_ignore(status);
-  }
   IREE_TRACE_ZONE_END(z0);
   return result;
 }
@@ -1825,9 +1816,6 @@ CUDAAPI CUresult cuMemcpyWithStream(void* dst, const void* src,
   }
 
   CUresult result = iree_status_to_cu_result(status);
-  if (!iree_status_is_ok(status)) {
-    iree_status_ignore(status);
-  }
   IREE_TRACE_ZONE_END(z0);
   return result;
 }
@@ -2651,9 +2639,6 @@ CUDAAPI CUresult cuStreamCreateWithFlags(CUstream* phStream,
   }
 
   CUresult result = iree_status_to_cu_result(status);
-  if (!iree_status_is_ok(status)) {
-    iree_status_ignore(status);
-  }
   IREE_TRACE_ZONE_END(z0);
   return result;
 }

--- a/libhrx/src/binding/cuda/driver_query_test.cc
+++ b/libhrx/src/binding/cuda/driver_query_test.cc
@@ -1,0 +1,76 @@
+// Copyright 2026 The HRX Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "binding/cuda/driver.h"
+#include "common/streaming_query_test_util.h"
+#include "iree/base/api.h"
+#include "iree/testing/gtest.h"
+
+namespace {
+
+using ::iree::hal::stream::FailedTimelineValue;
+using ::iree::hal::stream::QueryableEvent;
+using ::iree::hal::stream::QueryableStream;
+
+// cuEventQuery runs no initialization and consults no current context, so a
+// hand-built event drives it directly.
+TEST(CudaDriverQueryTest, EventQueryIsNotReadyBeforeTheRecordIsReached) {
+  QueryableEvent event(/*timeline_value=*/4, /*record_value=*/5);
+
+  EXPECT_EQ(cuEventQuery(reinterpret_cast<CUevent>(event.get())),
+            CUDA_ERROR_NOT_READY);
+}
+
+TEST(CudaDriverQueryTest, EventQuerySucceedsOnceTheRecordIsReached) {
+  QueryableEvent event(/*timeline_value=*/5, /*record_value=*/5);
+
+  EXPECT_EQ(cuEventQuery(reinterpret_cast<CUevent>(event.get())), CUDA_SUCCESS);
+}
+
+// A failed query is an error, not a completion answer. The entry point starts
+// its out-parameter at 0 and reads 0 as complete, so the iree_status_is_ok
+// guard ahead of that read is what keeps a failure from returning CUDA_SUCCESS
+// off the initializer. IREE_STATUS_ABORTED is the code these two tests use
+// because iree_status_to_cu_result maps it through its default arm to
+// CUDA_ERROR_UNKNOWN, distinct from both CUDA_SUCCESS and CUDA_ERROR_NOT_READY;
+// IREE_STATUS_UNAVAILABLE maps to CUDA_ERROR_NOT_READY, which would not tell a
+// propagated failure apart from a not-complete answer. What these two pin is
+// that the answer is an error at all; that the timeline's own code reaches the
+// caller intact is pinned a layer down, where the encoding is decoded.
+TEST(CudaDriverQueryTest, EventQueryReportsAFailedTimelineAsAnError) {
+  QueryableEvent event(FailedTimelineValue(IREE_STATUS_ABORTED),
+                       /*record_value=*/5);
+
+  EXPECT_EQ(cuEventQuery(reinterpret_cast<CUevent>(event.get())),
+            CUDA_ERROR_UNKNOWN);
+}
+
+// cuStreamQuery consults the current context only to resolve a null handle,
+// which no test here passes, so a hand-built stream drives it directly.
+TEST(CudaDriverQueryTest, StreamQueryIsNotReadyWhileWorkIsPending) {
+  QueryableStream stream(/*timeline_value=*/4, /*pending_value=*/5);
+
+  EXPECT_EQ(cuStreamQuery(reinterpret_cast<CUstream>(stream.get())),
+            CUDA_ERROR_NOT_READY);
+}
+
+TEST(CudaDriverQueryTest, StreamQuerySucceedsOnceThePendingValueIsReached) {
+  QueryableStream stream(/*timeline_value=*/5, /*pending_value=*/5);
+
+  EXPECT_EQ(cuStreamQuery(reinterpret_cast<CUstream>(stream.get())),
+            CUDA_SUCCESS);
+}
+
+// The same guard, in cuStreamQuery.
+TEST(CudaDriverQueryTest, StreamQueryReportsAFailedTimelineAsAnError) {
+  QueryableStream stream(FailedTimelineValue(IREE_STATUS_ABORTED),
+                         /*pending_value=*/5);
+
+  EXPECT_EQ(cuStreamQuery(reinterpret_cast<CUstream>(stream.get())),
+            CUDA_ERROR_UNKNOWN);
+}
+
+}  // namespace

--- a/libhrx/src/binding/cuda/runtime.c
+++ b/libhrx/src/binding/cuda/runtime.c
@@ -237,7 +237,7 @@ cudaError_t CUDAAPI cudaGetLastError(void) {
 
 cudaError_t CUDAAPI cudaPeekAtLastError(void) { return iree_cuda_thread_error; }
 
-const char* CUDAAPI cudaGetErrorString(cudaError_t error) {
+CUDAAPI const char* cudaGetErrorString(cudaError_t error) {
   // TODO: Implement full error string mapping.
   switch (error) {
     case cudaSuccess:
@@ -255,7 +255,7 @@ const char* CUDAAPI cudaGetErrorString(cudaError_t error) {
   }
 }
 
-const char* CUDAAPI cudaGetErrorName(cudaError_t error) {
+CUDAAPI const char* cudaGetErrorName(cudaError_t error) {
   // TODO: Implement full error name mapping.
   switch (error) {
     case cudaSuccess:


### PR DESCRIPTION
`cuStreamQuery` and `cuEventQuery` had their completion test inverted. `iree_hal_streaming_stream_query` and `iree_hal_streaming_event_query` write 0 into the out-parameter when the stream or event has drained and 1 while work is outstanding; both entry points compared against 1, so each returned `CUDA_SUCCESS` exactly while work was still queued and `CUDA_ERROR_NOT_READY` once it had completed. A caller polling for `CUDA_SUCCESS` reads buffers and reuses allocations while the work behind them is in flight. Both now map 0 to `CUDA_SUCCESS`, matching `hipStreamQuery` and `hipEventQuery`, and the convention is stated on the three query declarations in `common/internal.h` rather than only inside the bodies producing it.

Nothing compiled these sources, which is why the inversion survived. `binding/cuda` had no `BUILD.bazel`, and `libhrx/CMakeLists.txt` adds the directory only under `LIBHRX_BUILD_CUDA_BINDING`, which defaults OFF and which nothing in the tree sets. A Bazel library over `driver.c` and `runtime.c` puts them under `//libhrx/...`, which CI builds and tests on every change.

Compiling and linting them surfaced three more defects:

- `cuEventCreateWithFlags`, `cuMemset`, `cuMemsetAsync`, `cuMemcpyWithStream` and `cuStreamCreateWithFlags` each followed `iree_status_to_cu_result`, which consumes the status it is given, with an `iree_status_ignore` guarded on the same non-OK value. Both free, so every failure path through those five freed one status twice: an abort under an allocator that detects double frees, silent heap corruption otherwise.
- `cudaGetErrorString` and `cudaGetErrorName` spelled `CUDAAPI` after the `const char*`, where it lands inside the declarator instead of among the declaration specifiers. GCC discards it with a `-Wattributes` diagnostic that `-Werror` makes fatal, and the `_WIN32` `__declspec` spelling does not parse there at all.
- Two dead null guards in `cuCtxDestroy`, which already returns `CUDA_ERROR_INVALID_VALUE` on a null `ctx` before either could distinguish anything.

Four host-only suites cover the convention: three over the streaming producers, and one over `cuStreamQuery` and `cuEventQuery` themselves, because an end-to-end test cannot tell this convention from its mirror image — inverting both ends leaves every answer unchanged. Each pins the failed-timeline case too, where `iree_hal_semaphore_query` reports `IREE_HAL_SEMAPHORE_FAILURE_VALUE`, a sentinel above every value a stream records, so dropping the status would read the timeline as reached and answer complete. The double-free half carries no test: all five entry points return early unless `iree_hal_streaming_context_current()` is non-NULL, and a streaming context needs a live HAL device the host-only fixtures lack.

Closes #377
