### PR TITLE
[Infra] Harden repository tooling boundaries

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -139,6 +139,10 @@ build:fuzzer --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 # Local/generated configuration.
 # -----------------------------------------------------------------------------
 
+# Repository-owned opt-in integrations define named configs here. They do not
+# change ordinary builds unless selected explicitly.
+import %workspace%/build_tools/nativelink/nativelink.bazelrc
+
 # Generated configuration and local machine overrides stay out of version
 # control. Local overrides are imported last so they can adjust generated
 # settings for a specific checkout.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -422,6 +422,15 @@ target set plus explicit debug emitters and execution substrates.
 
 Other Bazel-native overrides belong in `.bazelrc.local`.
 
+## Optional Local NativeLink Execution
+
+NativeLink can provide one shared Bazel action cache and execution limit across
+multiple local worktrees. The repository provides an inert named Bazel config
+and a loopback-only local server configuration; ordinary builds remain
+unchanged until `--config=nativelink` is selected. See the
+[local NativeLink guide](build_tools/nativelink/README.md) for installation,
+startup, verification, capacity, and trust-boundary details.
+
 ## Loom Importers
 
 Importer frontends are optional dependency lanes. Start with the importer-local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,10 +95,11 @@ python dev.py cmake precommit
 With no input option, `precommit` checks staged, unstaged, and untracked files.
 Use `--base <git-ref>` to check the branch diff from the merge base through
 `HEAD` plus local changes. Use `--staged` when you explicitly want staged files
-only. Use `--profile default`, `--profile paranoid`, or `--profile ci` to select
-the check profile for one manual run. The Bazel lane defaults to `paranoid` for
-precommit. The CMake lane defaults to `default`; select `paranoid` or `ci` to
-add affected project CMake/CTest checks.
+only. `--amend` checks the exact amended candidate by comparing the index with
+`HEAD^`; that mode is always non-mutating. Use `--profile default`, `--profile
+paranoid`, or `--profile ci` to select the check profile for one manual run. The
+Bazel lane defaults to `paranoid` for precommit. The CMake lane defaults to
+`default`; select `paranoid` or `ci` to add affected project CMake/CTest checks.
 
 Use the fix command when you want mechanical repairs:
 
@@ -130,11 +131,24 @@ or:
 python dev.py cmake hook --profile default
 ```
 
-The hook validates commit scope: files staged for commit plus files changed by
-`HEAD`, so amended commits include the commit being replaced without checking
-the full branch. Test-bearing hook profiles apply mechanical fixups before
-running the same profile in non-mutating check mode. Lane-specific hook policy
-is stored in ignored `lefthook-local.yml`. Re-run
+The hook treats the Git index as the ordinary commit boundary. Test-bearing
+profiles first apply fixups to staged existing files and generated outputs
+derived from selected inputs. If the index changes, the attempt stops before
+tests and prints every changed staged path. Review `git diff --cached` and retry
+the same commit; the repaired candidate then receives read-only hygiene, tests,
+and static analysis. Lefthook's `fail_on_changes` check remains an independent
+guard against committing hook mutations without review.
+
+A candidate file that also has unstaged changes is an incoherent formatter
+input: the index contains one version while whole-file tools see another. The
+hook stops with the exact paths. Running `python dev.py <lane> fix` before
+selecting hunks, then staging the intended hunks again, keeps the commit narrow
+without letting a formatter stage the rest of the file.
+
+Git's pre-commit event does not identify an amend operation. Explicit
+`python dev.py <lane> precommit --amend` validates the index against `HEAD^`
+without granting mutation authority to files inherited from `HEAD`.
+Lane-specific hook policy is stored in ignored `lefthook-local.yml`. Re-run
 `python dev.py <lane> hook --profile <profile>` to change the profile used by
 Git commits.
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,9 @@ python dev.py cmake precommit
 `precommit` checks staged, unstaged, and untracked files. Use
 `python dev.py <lane> precommit --base <git-ref>` to check the branch diff from
 the merge base through `HEAD` plus local changes, or `--staged` for staged
-files only. Add `--profile default`, `--profile paranoid`, or `--profile ci`
-to select the check profile for a manual run. Re-run
+files only. `--amend` checks the exact amended candidate, the index relative to
+`HEAD^`, without writing files. Add `--profile default`, `--profile paranoid`,
+or `--profile ci` to select the check profile for a manual run. Re-run
 `python dev.py <lane> hook --profile <profile>` to change the default profile
 used by Git commits. Use `python dev.py <lane> presubmit` for the full-tree
 CI-shaped check.
@@ -146,10 +147,11 @@ python dev.py bazel fix
 python dev.py cmake fix
 ```
 
-Test-bearing Git commit-hook profiles apply mechanical fixups before running
-the same profile in non-mutating check mode. The hook validates commit scope,
-not the full branch: files staged for commit plus files changed by `HEAD`, so
-amended commits include the commit being replaced. See
+Test-bearing Git commit-hook profiles apply mechanical fixups only to staged
+files and declared generated outputs. When a fixer changes the index, the hook
+names those paths and stops before tests; reviewing the staged diff and retrying
+the commit runs the non-mutating validation. A candidate path with unstaged
+hunks stops before fixers run, preserving partial-staging intent. See
 `CONTRIBUTING.md` for contributor setup and `build_tools/lefthook/README.md`
 for the hook architecture.
 

--- a/build_tools/devtools/cli.py
+++ b/build_tools/devtools/cli.py
@@ -451,7 +451,8 @@ def parse_arguments(argv: list[str]) -> argparse.Namespace:
     if sum(selected_tool_modes) > 1:
         parser.error("--venv, --system, and --tool-root are mutually exclusive")
     if getattr(args, "paths", None) and (
-        getattr(args, "base", None) is not None
+        getattr(args, "amend", False)
+        or getattr(args, "base", None) is not None
         or getattr(args, "staged", False)
         or getattr(args, "commit", False)
     ):
@@ -798,7 +799,7 @@ def add_lane_commands(subparsers: argparse._SubParsersAction, lane: str) -> None
             input_group,
             "--commit",
             action="store_true",
-            help="Check the Git hook commit scope.",
+            help="Legacy alias for --staged.",
         )
         add_argument(
             input_group,
@@ -884,7 +885,7 @@ def add_lane_commands(subparsers: argparse._SubParsersAction, lane: str) -> None
             input_group,
             "--commit",
             action="store_true",
-            help="Check the Git hook commit scope.",
+            help="Legacy alias for --staged.",
         )
         add_argument(
             input_group,
@@ -920,6 +921,12 @@ def add_lane_commands(subparsers: argparse._SubParsersAction, lane: str) -> None
     precommit_input_group = precommit_parser.add_mutually_exclusive_group()
     add_argument(
         precommit_input_group,
+        "--amend",
+        action="store_true",
+        help="Check the exact amended commit candidate without applying fixups.",
+    )
+    add_argument(
+        precommit_input_group,
         "--base",
         metavar="GIT_REF",
         help="Check branch changes since GIT_REF plus local changes.",
@@ -928,7 +935,7 @@ def add_lane_commands(subparsers: argparse._SubParsersAction, lane: str) -> None
         precommit_input_group,
         "--commit",
         action="store_true",
-        help="Check the Git hook commit scope.",
+        help="Legacy alias for --staged.",
     )
     add_argument(
         precommit_input_group,
@@ -1426,6 +1433,7 @@ def handle_precommit(args: argparse.Namespace) -> CommandPlan:
         args.lane,
         existing_or_system_environment(args),
         args.profile,
+        amend=args.amend,
         base=args.base,
         commit=args.commit,
         cmake_build_dir=configured_cmake_build_dir(args)

--- a/build_tools/devtools/cli_test.py
+++ b/build_tools/devtools/cli_test.py
@@ -1170,12 +1170,26 @@ class CliTest(unittest.TestCase):
 
         self.assertEqual(len(plan.steps), 2)
         self.assertIn("--fix", plan.steps[0].argv)
+        self.assertIn("--fail-on-fix", plan.steps[0].argv)
         self.assertIn("--hygiene", plan.steps[0].argv)
         self.assertIn("--check", plan.steps[1].argv)
-        self.assertNotIn("--hygiene", plan.steps[1].argv)
+        self.assertNotIn("--fail-on-fix", plan.steps[1].argv)
+        self.assertIn("--hygiene", plan.steps[1].argv)
         self.assertIn("--tests", plan.steps[1].argv)
         self.assertIn("--static-analysis", plan.steps[1].argv)
         self.assertIn("--commit", description)
+        self.assertNotIn("--changed", description)
+
+    def test_bazel_precommit_amend_scope_is_check_only(self):
+        args = cli.parse_arguments(["bazel", "precommit", "--amend"])
+
+        plan = args.handler(args)
+        description = plan.describe()
+
+        self.assertEqual(len(plan.steps), 1)
+        self.assertIn("--check", plan.steps[0].argv)
+        self.assertNotIn("--fix", plan.steps[0].argv)
+        self.assertIn("--amend", description)
         self.assertNotIn("--changed", description)
 
     def test_bazel_precommit_can_use_staged_files(self):
@@ -1186,9 +1200,10 @@ class CliTest(unittest.TestCase):
 
         self.assertEqual(len(plan.steps), 2)
         self.assertIn("--fix", plan.steps[0].argv)
+        self.assertIn("--fail-on-fix", plan.steps[0].argv)
         self.assertIn("--hygiene", plan.steps[0].argv)
         self.assertIn("--check", plan.steps[1].argv)
-        self.assertNotIn("--hygiene", plan.steps[1].argv)
+        self.assertIn("--hygiene", plan.steps[1].argv)
         self.assertIn("--tests", plan.steps[1].argv)
         self.assertIn("--static-analysis", plan.steps[1].argv)
         self.assertIn("--staged", description)
@@ -1204,7 +1219,7 @@ class CliTest(unittest.TestCase):
         self.assertIn("--fix", plan.steps[0].argv)
         self.assertIn("--hygiene", plan.steps[0].argv)
         self.assertIn("--check", plan.steps[1].argv)
-        self.assertNotIn("--hygiene", plan.steps[1].argv)
+        self.assertIn("--hygiene", plan.steps[1].argv)
         self.assertIn("--tests", plan.steps[1].argv)
         self.assertIn("--static-analysis", plan.steps[1].argv)
         self.assertIn("README.md dev.py", description)
@@ -1293,7 +1308,7 @@ class CliTest(unittest.TestCase):
         )
         self.assertNotIn("run: python dev.py", step.content)
         self.assertIn(
-            "bazel precommit --profile ci --commit --verbose",
+            "bazel precommit --profile ci --staged --verbose",
             step.content,
         )
 
@@ -1318,7 +1333,7 @@ class CliTest(unittest.TestCase):
         self.assertIn(str(cli.REPO_ROOT / "dev.py"), step.content)
         self.assertNotIn("run: python dev.py", step.content)
         self.assertIn(
-            "cmake precommit --profile default --commit",
+            "cmake precommit --profile default --staged",
             step.content,
         )
 
@@ -1366,13 +1381,14 @@ class CliTest(unittest.TestCase):
         output = self.parse_help(["bazel", "precommit", "--help"])
 
         self.assertIn("staged, unstaged, and untracked files", output)
+        self.assertIn("--amend", output)
         self.assertIn("--commit", output)
         self.assertIn("--base", output)
         self.assertIn("--staged", output)
         self.assertIn("Explicit paths", output)
         self.assertNotIn("generated Git hook", output)
         self.assertIn("mechanical fixups", output)
-        self.assertIn("non-mutating check mode", output)
+        self.assertIn("retry runs non-mutating hygiene", output)
 
     def test_presubmit_help_calls_out_full_tree_default(self):
         output = self.parse_help(["bazel", "presubmit", "--help"])

--- a/build_tools/devtools/help_text.py
+++ b/build_tools/devtools/help_text.py
@@ -140,9 +140,11 @@ installed and this checkout should not get a local tool environment.""",
 This writes ignored lefthook-local.yml with the selected build system/profile
 and then runs lefthook install. Re-run this command with a different --profile
 to change the default profile used by Git commits. The installed hook uses
-commit scope: staged files plus files changed by HEAD, so amended commits
-validate the commit being replaced. Tool output streams while the hook runs so
-long builds and tests remain visibly active.""",
+the staged index as its validation and mutation boundary. A fix that changes
+the index stops the attempt before tests and prints the review/retry action.
+Explicit `precommit --amend` provides read-only amended-candidate validation.
+Tool output streams while the hook runs so long builds and tests remain visibly
+active.""",
         )
     if command == "configure":
         if lane == "bazel":
@@ -391,23 +393,28 @@ Use `python dev.py {lane} precommit` for local changes only.""",
             epilog=f"""Examples:
   python dev.py {lane} precommit
   python dev.py {lane} precommit --profile {default_profile}
-  python dev.py {lane} precommit --commit
+  python dev.py {lane} precommit --amend
   python dev.py {lane} precommit --base origin/main
   python dev.py {lane} precommit --staged
   python dev.py {lane} precommit README.md CONTRIBUTING.md
   python dev.py {lane} precommit --verbose
 
 With no input option, precommit checks staged, unstaged, and untracked files.
-`--commit` checks the Git hook scope: staged files plus files changed by HEAD.
+`--staged` checks the current index candidate. `--commit` is a compatibility
+alias with the same staged-only meaning. `--amend` non-mutatingly checks the
+exact amended candidate by comparing the index with HEAD's first parent.
 `--base` checks branch changes from the merge base with the given ref through
 HEAD, plus local staged, unstaged, and untracked files.
 Explicit paths check only those files for narrow manual runs.
 The default profile is {default_profile}. Use --profile to select default,
 paranoid, or ci for this run.
-Commit-scope, staged-file, and explicit-path runs with profiles that run tests,
-currently paranoid and ci, apply mechanical fixups before running the same
-profile in non-mutating check mode. Broader local-change runs and the profile
-named default are check-only.
+Staged-file and explicit-path runs with profiles that run tests, currently
+paranoid and ci, apply bounded mechanical fixups first. If a fixer changes the
+index, that attempt stops before tests and names every changed staged path. The
+retry runs non-mutating hygiene, tests, and static analysis against the repaired
+candidate. Candidate files with unstaged hunks stop at the index boundary so a
+whole-file formatter cannot absorb those hunks. Broader local-change runs,
+explicit amend validation, and the profile named default are check-only.
 
 {lane_scope}""",
         )

--- a/build_tools/devtools/hooks.py
+++ b/build_tools/devtools/hooks.py
@@ -53,7 +53,7 @@ def hook_content(lane: str, profile: str, python_executable: str) -> str:
             "precommit",
             "--profile",
             profile,
-            "--commit",
+            "--staged",
             "--verbose",
         ]
     )
@@ -69,7 +69,7 @@ def hook_content(lane: str, profile: str, python_executable: str) -> str:
 
 # Local {lane_name}-lane hook policy.
 # Installed by `python dev.py {lane} hook --profile {profile}`.
-# Test-bearing commit-scope precommit profiles apply fixups before validation.
+# Test-bearing staged precommit profiles apply fixups before validation.
 # Tool output streams live so long-running builds remain observable.
 
 pre-commit:

--- a/build_tools/devtools/presubmit.py
+++ b/build_tools/devtools/presubmit.py
@@ -117,6 +117,7 @@ def precommit_plan(
     lane: str,
     tool_env: ToolEnvironment,
     profile: str,
+    amend: bool = False,
     base: str | None = None,
     commit: bool = False,
     cmake_build_dir: Path | None = None,
@@ -134,6 +135,8 @@ def precommit_plan(
     input_args: list[str] = []
     if paths:
         input_args += paths
+    elif amend:
+        input_args.append("--amend")
     elif base is not None:
         input_args += ["--base", base]
     elif commit:
@@ -152,7 +155,9 @@ def precommit_plan(
             "--lane",
             lane,
             "--fix",
+            "--fail-on-fix",
             "--hygiene",
+            "--print-plan",
             *input_args,
             "--profile",
             profile,
@@ -174,12 +179,13 @@ def precommit_plan(
         "--lane",
         lane,
         "--check",
+        "--print-plan",
         *input_args,
         "--profile",
         profile,
     ]
     if should_autofix:
-        command += ["--tests", "--static-analysis"]
+        command += ["--hygiene", "--tests", "--static-analysis"]
     if verbose:
         command.append("--verbose")
     plan.add(

--- a/build_tools/devtools/smoke_test_lib.py
+++ b/build_tools/devtools/smoke_test_lib.py
@@ -58,8 +58,18 @@ def parse_arguments(description: str) -> argparse.Namespace:
 
 
 def git_paths(*args: str) -> list[str]:
+    git_dir = subprocess.check_output(
+        ["git", "rev-parse", "--absolute-git-dir"],
+        cwd=REPO_ROOT,
+        text=True,
+    ).strip()
     result = subprocess.run(
-        ["git", *args],
+        [
+            "git",
+            f"--git-dir={git_dir}",
+            f"--work-tree={REPO_ROOT}",
+            *args,
+        ],
         cwd=REPO_ROOT,
         check=True,
         stdout=subprocess.PIPE,

--- a/build_tools/lefthook/README.md
+++ b/build_tools/lefthook/README.md
@@ -10,23 +10,23 @@ routing. Project-specific policy stays in each project under
 
 A successful Git commit must not commit stale formatter or generated-file
 output or private work-tracking breadcrumbs. The generated Git commit hook uses
-commit scope: files staged for commit plus files changed by `HEAD`, so
-`git commit --amend` validates the commit being replaced without scanning the
-full feature branch. Test-bearing hook profiles run a mechanical fix pass first,
-stage files owned by those fixers, and then run the same profile in
-non-mutating check mode:
+the Git index as both the ordinary validation boundary and the authority for
+mechanical mutation. Files present only in `HEAD`, the unstaged worktree, or an
+unrelated dirty change set never become fixer inputs merely because a commit is
+running. Test-bearing hook profiles start with a bounded mechanical fix pass:
 
 ```bash
-python dev.py <lane> precommit --profile <profile> --commit
+python dev.py <lane> precommit --profile <profile> --staged
 ```
 
-This fix-then-check path is used for `paranoid` and `ci` when the input is the
-generated hook's commit scope or an explicit `--staged` precommit. The mutating
-pass is limited to hygiene fixers and is also the hygiene validation boundary:
-unfixable diagnostics fail there. The validation pass then runs affected tests
-and static analysis once against the post-fix tree. Broader local-change
-precommit runs stay check-only. The `default` profile remains check-only. Local
-fixups are also available through explicit commands:
+This path is used for `paranoid` and `ci` with staged or explicit inputs. When
+the pass changes the index, it prints the exact paths and returns nonzero before
+tests. Lefthook's `fail_on_changes: always` independently observes the mutation.
+The next commit attempt finds the repaired index unchanged and continues through
+read-only hygiene, affected tests, and static analysis. This two-pass contract
+makes the review boundary visible instead of silently adding formatter output
+to a commit. Broader local-change precommit runs and the `default` profile stay
+check-only. Local fixups are also available through explicit commands:
 
 ```bash
 python dev.py bazel fix
@@ -34,9 +34,30 @@ python dev.py cmake fix
 ```
 
 `fix` applies staged hygiene repairs and stages files owned by those fixers.
-`precommit` checks the current local change set, with autofix enabled for
-commit-scope, staged, and explicit-path test-bearing runs. `presubmit` is
+Bazel-to-CMake receives only selected BUILD/CMake inputs and may stage their
+same-directory generated output. Converter-wide inputs are checked without
+writing. Loom artifact maintenance updates only families whose owned outputs
+were selected; the read-only retry detects source changes that require an
+explicit regeneration. `precommit` checks the current local change set, with
+autofix enabled for staged and explicit-path test-bearing runs. `presubmit` is
 non-mutating and runs the full-tree CI-shaped profile.
+
+Whole-file tools cannot faithfully consume a candidate file that also contains
+unstaged hunks. That state fails before mutation and names each conflicting
+path. Running `python dev.py <lane> fix` before selecting hunks, then staging the
+intended hunks again, retains the narrow commit boundary.
+
+Git's pre-commit event provides no amend discriminator. Amend validation is an
+explicit read-only operation:
+
+```bash
+python dev.py <lane> precommit --profile <profile> --amend
+```
+
+It compares the current index with `HEAD^`, which is the exact tree that an
+amend would write relative to the replaced commit's parent. The compatibility
+spelling `--commit` now has the same staged-only semantics as `--staged`, keeping
+previously installed hook configurations safe.
 
 The `commit-msg` hook validates the final Git commit message text. The subject
 line must start with a bracketed subsystem tag such as `[Loom]`, `[HRX]`,
@@ -125,8 +146,10 @@ python dev.py cmake presubmit --profile default
 
 ## Lefthook Groups
 
-The installed Git commit hook runs fixups first with `paranoid` or `ci` and
-then validates the same commit-scope set; with `default` it is check-only.
+The installed Git commit hook runs staged fixups first with `paranoid` or `ci`.
+An unchanged fix pass proceeds directly to read-only validation; a changed pass
+stops for review and validation runs on the retry. The `default` profile is
+check-only.
 
 `dev.py` installs lane-specific local hook policy into ignored
 `lefthook-local.yml`:

--- a/build_tools/lefthook/presubmit.py
+++ b/build_tools/lefthook/presubmit.py
@@ -270,8 +270,16 @@ def parse_arguments() -> argparse.Namespace:
         "--commit",
         action="store_true",
         help=(
-            "Use files staged for commit plus files changed by HEAD. This is "
-            "the Git hook scope and covers amended commit contents."
+            "Use files staged for commit. This legacy Git-hook spelling is "
+            "equivalent to --staged."
+        ),
+    )
+    inputs.add_argument(
+        "--amend",
+        action="store_true",
+        help=(
+            "Use the exact amended commit candidate: the index compared with "
+            "HEAD's first parent. This scope is check-only."
         ),
     )
     inputs.add_argument("--all", action="store_true", help="Use all tracked files.")
@@ -328,6 +336,14 @@ def parse_arguments() -> argparse.Namespace:
         help="Print the selected plan before running it.",
     )
     parser.add_argument(
+        "--fail-on-fix",
+        action="store_true",
+        help=(
+            "Return a failure after staging any fix so a Git hook stops before "
+            "test-bearing validation and retries against the repaired index."
+        ),
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         help="Stream command output and print exact commands.",
@@ -344,12 +360,17 @@ def parse_arguments() -> argparse.Namespace:
         args.changed
         or args.staged
         or args.commit
+        or args.amend
         or args.all
         or args.base
         or args.since
         or args.files_from
     ):
         parser.error("explicit paths cannot be combined with another input mode")
+    if args.fix and args.amend:
+        parser.error("--amend is a non-mutating validation scope; use --check")
+    if args.fail_on_fix and not args.fix:
+        parser.error("--fail-on-fix requires --fix")
     apply_profile_defaults(args)
     return args
 
@@ -368,6 +389,7 @@ def apply_profile_defaults(args: argparse.Namespace) -> None:
         and not args.changed
         and not args.staged
         and not args.commit
+        and not args.amend
         and not args.all
         and not args.base
         and not args.since
@@ -641,37 +663,69 @@ def unique_paths(paths: list[str]) -> list[str]:
     return unique
 
 
+def git_diff_files(*revisions: str, cached: bool = False) -> list[str]:
+    command = ["diff"]
+    if cached:
+        command.append("--cached")
+    command += ["--name-only", "-z", "--no-renames", *revisions, "--"]
+    return git_list(command)
+
+
+def git_unstaged_files(paths: list[str]) -> list[str]:
+    if not paths:
+        return []
+    return git_list(
+        [
+            "--literal-pathspecs",
+            "diff",
+            "--name-only",
+            "-z",
+            "--no-renames",
+            "--",
+            *paths,
+        ]
+    )
+
+
 def changed_files() -> list[str]:
     return unique_paths(
         [
-            *git_list(["diff", "--cached", "--name-only", "-z", "--diff-filter=ACMR"]),
-            *git_list(["diff", "--name-only", "-z", "--diff-filter=ACMR"]),
+            *git_diff_files(cached=True),
+            *git_diff_files(),
             *git_list(["ls-files", "--others", "--exclude-standard", "-z"]),
         ]
     )
 
 
-def head_commit_files() -> list[str]:
+def empty_tree() -> str:
+    result = subprocess.run(
+        ["git", "hash-object", "-t", "tree", "--stdin"],
+        cwd=REPO_ROOT,
+        check=True,
+        input=b"",
+        stdout=subprocess.PIPE,
+    )
+    return result.stdout.decode("ascii").strip()
+
+
+def amend_base() -> str:
     result = subprocess.run(
         ["git", "rev-parse", "--verify", "HEAD^"],
         cwd=REPO_ROOT,
-        stdout=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
     )
-    if result.returncode != 0:
-        return []
-    return git_list(
-        ["diff", "--name-only", "-z", "--diff-filter=ACMR", "HEAD^", "HEAD", "--"]
-    )
+    if result.returncode == 0:
+        return result.stdout.decode("ascii").strip()
+    return empty_tree()
 
 
 def commit_files() -> list[str]:
-    return unique_paths(
-        [
-            *git_list(["diff", "--cached", "--name-only", "-z", "--diff-filter=ACMR"]),
-            *head_commit_files(),
-        ]
-    )
+    return git_diff_files(cached=True)
+
+
+def amend_files() -> list[str]:
+    return git_diff_files(amend_base(), cached=True)
 
 
 def tracked_files() -> list[str]:
@@ -693,9 +747,7 @@ def presubmit_inputs(args: argparse.Namespace) -> PresubmitInputs:
             changed_paths=paths,
         )
     if args.staged:
-        paths = git_list(
-            ["diff", "--cached", "--name-only", "-z", "--diff-filter=ACMR"]
-        )
+        paths = git_diff_files(cached=True)
         return PresubmitInputs(
             mode="staged",
             selected_paths=paths,
@@ -705,6 +757,13 @@ def presubmit_inputs(args: argparse.Namespace) -> PresubmitInputs:
         paths = commit_files()
         return PresubmitInputs(
             mode="commit",
+            selected_paths=paths,
+            changed_paths=paths,
+        )
+    if args.amend:
+        paths = amend_files()
+        return PresubmitInputs(
+            mode="amend",
             selected_paths=paths,
             changed_paths=paths,
         )
@@ -719,16 +778,7 @@ def presubmit_inputs(args: argparse.Namespace) -> PresubmitInputs:
     if args.base:
         paths = unique_paths(
             [
-                *git_list(
-                    [
-                        "diff",
-                        "--name-only",
-                        "-z",
-                        "--diff-filter=ACMR",
-                        f"{args.base}...HEAD",
-                        "--",
-                    ]
-                ),
+                *git_diff_files(f"{args.base}...HEAD"),
                 *changed_files(),
             ]
         )
@@ -747,9 +797,7 @@ def presubmit_inputs(args: argparse.Namespace) -> PresubmitInputs:
             selected_paths=paths,
             changed_paths=paths,
         )
-    paths = git_list(
-        ["diff", "--name-only", "-z", "--diff-filter=ACMR", args.since, "--"]
-    )
+    paths = git_diff_files(args.since)
     return PresubmitInputs(
         mode="since",
         selected_paths=paths,
@@ -759,6 +807,42 @@ def presubmit_inputs(args: argparse.Namespace) -> PresubmitInputs:
 
 def selected_files(args: argparse.Namespace) -> list[str]:
     return presubmit_inputs(args).selected_paths
+
+
+def index_worktree_conflicts(inputs: PresubmitInputs) -> list[str]:
+    selected_path_set = set(inputs.selected_paths)
+    unstaged_path_set = set(git_unstaged_files(inputs.selected_paths))
+    if inputs.mode in ("staged", "commit", "amend"):
+        return sorted(selected_path_set.intersection(unstaged_path_set))
+    if inputs.mode == "explicit":
+        staged_path_set = set(commit_files())
+        return sorted(
+            selected_path_set.intersection(unstaged_path_set, staged_path_set)
+        )
+    return []
+
+
+def validate_index_worktree_coherence(
+    args: argparse.Namespace, inputs: PresubmitInputs
+) -> bool:
+    conflict_paths = index_worktree_conflicts(inputs)
+    if not conflict_paths:
+        return True
+    print_section("Index Boundary")
+    print(
+        "[fail] Candidate paths also contain unstaged changes. Presubmit tools "
+        "consume whole working-tree files, so continuing would validate or "
+        "stage content outside the candidate:"
+    )
+    for path in conflict_paths:
+        print(f"  {path}")
+    print(
+        "[next] Keep the commit narrow by running "
+        f"`python dev.py {args.lane} fix` before partial staging, then stage "
+        "only the intended hunks again. A whole-file commit boundary also "
+        "resolves this state."
+    )
+    return False
 
 
 def existing_files(paths: list[str]) -> list[str]:
@@ -787,6 +871,53 @@ def stage_files(paths: list[str], verbose: bool) -> bool:
     if not has_unstaged_changes(paths):
         return True
     return run_command(["git", "add", "--", *paths], "Stage local fixups", verbose)
+
+
+def index_tree() -> str:
+    result = subprocess.run(
+        ["git", "write-tree"],
+        cwd=REPO_ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    return result.stdout.decode("ascii").strip()
+
+
+def changed_index_paths(before_tree: str) -> list[str]:
+    after_tree = index_tree()
+    if after_tree == before_tree:
+        return []
+    return git_list(
+        [
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "-z",
+            "-r",
+            "--no-renames",
+            before_tree,
+            after_tree,
+        ]
+    )
+
+
+def print_fix_summary(paths: list[str], *, stops_for_retry: bool) -> None:
+    if not paths:
+        return
+    print_section("Index Fixups")
+    print(f"[fix] Mechanical fixups changed {len(paths)} staged path(s):")
+    for path in paths:
+        print(f"  {path}")
+    if stops_for_retry:
+        print(
+            "[next] This commit attempt stops before tests. Review `git diff "
+            "--cached`, then retry the same commit; the repaired index will "
+            "receive non-mutating hygiene, tests, and static analysis."
+        )
+        print(
+            "[note] Lefthook's fail_on_changes policy independently prevents "
+            "a hook-modified index from being committed without review."
+        )
 
 
 def is_buildifier_file(path: str) -> bool:
@@ -1178,16 +1309,47 @@ def run_watchwords(paths: list[str]) -> bool:
 
 def run_build_filename_check(paths: list[str]) -> bool:
     ok = True
-    for path in paths:
+    for path in existing_files(paths):
         if Path(path).name == "BUILD":
             print(f"{path}: use BUILD.bazel instead of BUILD")
             ok = False
     return ok
 
 
-def run_bazel_to_cmake(fix: bool, verbose: bool) -> bool:
+def is_bazel_to_cmake_global_trigger(path: str) -> bool:
+    return (
+        Path(path).name == ".bazel_to_cmake.cfg.py"
+        or path == "loom/build_tools/amdgpu/target_config.bzl"
+        or path.startswith(
+            (
+                "build_tools/bazel_to_cmake/",
+                "loom/requirements/",
+                "runtime/requirements/",
+            )
+        )
+    )
+
+
+def bazel_to_cmake_input_paths(paths: list[str]) -> list[str]:
+    return existing_files(
+        [
+            path
+            for path in paths
+            if Path(path).name in {"BUILD", "BUILD.bazel", "CMakeLists.txt"}
+        ]
+    )
+
+
+def run_bazel_to_cmake(paths: list[str], fix: bool, verbose: bool) -> bool:
     command = [sys.executable, "build_tools/bazel_to_cmake/bazel_to_cmake.py"]
-    command.append("--stage-updates" if fix else "--check")
+    if any(is_bazel_to_cmake_global_trigger(path) for path in paths):
+        command.append("--check")
+        return run_command(command, "Bazel-to-CMake", verbose)
+
+    input_paths = bazel_to_cmake_input_paths(paths)
+    if not input_paths:
+        return skip_step("Bazel-to-CMake", "no selected Bazel/CMake files")
+    command += ["--stage-updates" if fix else "--check", *input_paths]
     return run_command(command, "Bazel-to-CMake", verbose)
 
 
@@ -1240,7 +1402,7 @@ def run_hygiene(paths: list[str], fix: bool, verbose: bool) -> bool:
     ok = run_buildifier(paths, fix=fix, verbose=verbose) and ok
     ok = run_ruff(paths, fix=fix, verbose=verbose) and ok
     ok = run_clang_format(paths, fix=fix, verbose=verbose) and ok
-    ok = run_bazel_to_cmake(fix=fix, verbose=verbose) and ok
+    ok = run_bazel_to_cmake(paths, fix=fix, verbose=verbose) and ok
     ok = run_amdgpu_target_map(paths, fix=fix, verbose=verbose) and ok
     return ok
 
@@ -2200,6 +2362,8 @@ def print_plan(
         input_mode = "changed"
     elif args.commit:
         input_mode = "commit"
+    elif args.amend:
+        input_mode = "amend"
     elif args.all:
         input_mode = "all"
     elif args.base:
@@ -2223,7 +2387,13 @@ def print_plan(
     print(f"  lane: {args.lane}")
     print(f"  profile: {args.profile}")
     print(f"  mode: {mutation}")
-    print(f"  input: {input_mode} ({len(paths)} file(s))")
+    print(f"  validation input: {input_mode} ({len(paths)} path(s))")
+    if args.fix:
+        print(
+            "  mutation input: selected existing files and declared generated outputs"
+        )
+    else:
+        print("  mutation input: none (read-only)")
     print("  scopes: " + ", ".join(scopes))
     if projects:
         print("  projects: " + ", ".join(project.name for project in projects))
@@ -2256,6 +2426,8 @@ def dev_py_rerun_command(args: argparse.Namespace, verbose: bool) -> list[str]:
         ]
         if args.base:
             command += ["--base", args.base]
+        elif args.amend:
+            command.append("--amend")
         elif args.commit:
             command.append("--commit")
         elif args.staged or args.paths:
@@ -2366,18 +2538,27 @@ def run_presubmit(
 def run_presubmit_with_source_guard(
     args: argparse.Namespace, inputs: PresubmitInputs, projects: list[Project]
 ) -> int:
+    before_tree = index_tree() if args.fix else None
     snapshot = NonEmptyTrackedFileSnapshot.capture_tracked_package_initializers(
         REPO_ROOT
     )
     result = run_presubmit(args, inputs, projects)
     if not snapshot.verify(REPO_ROOT):
         result = 1
+    if before_tree is not None:
+        fixed_paths = changed_index_paths(before_tree)
+        stops_for_retry = bool(fixed_paths and args.fail_on_fix)
+        print_fix_summary(fixed_paths, stops_for_retry=stops_for_retry)
+        if stops_for_retry:
+            result = 1
     return result
 
 
 def main() -> int:
     args = parse_arguments()
     inputs = presubmit_inputs(args)
+    if not validate_index_worktree_coherence(args, inputs):
+        return 1
     projects = projects_for_paths(inputs.selected_paths)
     if args.fix:
         with source_mutation_lock(REPO_ROOT, "root-presubmit-fix"):

--- a/build_tools/lefthook/presubmit_test.py
+++ b/build_tools/lefthook/presubmit_test.py
@@ -10,6 +10,7 @@ import contextlib
 import importlib.util
 import io
 import os
+import subprocess
 import sys
 import tempfile
 import types
@@ -42,6 +43,86 @@ def input_scope(
 
 
 class PresubmitTest(unittest.TestCase):
+    def test_commit_scope_excludes_head_only_paths(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repo_root = Path(temporary_directory)
+
+            def git(*args: str) -> subprocess.CompletedProcess[str]:
+                return subprocess.run(
+                    ["git", *args],
+                    cwd=repo_root,
+                    check=True,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+
+            git("init", "--quiet")
+            git("config", "user.name", "Presubmit Test")
+            git("config", "user.email", "presubmit@example.com")
+            (repo_root / "runtime/deleted").mkdir(parents=True)
+            (repo_root / "loom").mkdir()
+            (repo_root / "head_only.c").write_text("int value = 0;\n")
+            (repo_root / "staged.txt").write_text("base\n")
+            (repo_root / "runtime/deleted/BUILD.bazel").write_text("# build\n")
+            (repo_root / "runtime/old.c").write_text("int old_value;\n")
+            git("add", ".")
+            git("commit", "--quiet", "-m", "base")
+
+            (repo_root / "head_only.c").write_text("int value = 1;\n")
+            git("add", "head_only.c")
+            git("commit", "--quiet", "-m", "head")
+            with mock.patch.object(presubmit, "REPO_ROOT", repo_root):
+                candidate_base_tree = presubmit.index_tree()
+            (repo_root / "staged.txt").write_text("candidate\n")
+            git("add", "staged.txt")
+            (repo_root / "runtime/deleted/BUILD.bazel").unlink()
+            git("add", "runtime/deleted/BUILD.bazel")
+            git("mv", "runtime/old.c", "loom/new.c")
+
+            with mock.patch.object(presubmit, "REPO_ROOT", repo_root):
+                commit_paths = presubmit.commit_files()
+                self.assertEqual(
+                    set(commit_paths),
+                    {
+                        "loom/new.c",
+                        "runtime/deleted/BUILD.bazel",
+                        "runtime/old.c",
+                        "staged.txt",
+                    },
+                )
+                self.assertEqual(
+                    set(presubmit.amend_files()),
+                    {"head_only.c", *commit_paths},
+                )
+                self.assertEqual(
+                    set(presubmit.changed_index_paths(candidate_base_tree)),
+                    set(commit_paths),
+                )
+
+            self.assertEqual(git("status", "--short", "head_only.c").stdout, "")
+
+            with (repo_root / "staged.txt").open("a") as staged_file:
+                staged_file.write("unstaged\n")
+            with mock.patch.object(presubmit, "REPO_ROOT", repo_root):
+                self.assertEqual(
+                    presubmit.index_worktree_conflicts(
+                        input_scope(commit_paths, mode="staged")
+                    ),
+                    ["staged.txt"],
+                )
+
+    def test_deleted_paths_route_affected_projects_without_entering_fixers(self):
+        projects = presubmit.projects_for_paths(
+            ["runtime/deleted/BUILD.bazel", "loom/deleted.loom"]
+        )
+
+        self.assertEqual({project.name for project in projects}, {"runtime", "loom"})
+        with mock.patch.object(presubmit, "existing_files", return_value=[]):
+            self.assertTrue(
+                presubmit.run_build_filename_check(["runtime/deleted/BUILD"])
+            )
+
     def test_semgrep_candidates_require_configured_prefix_and_extension(self):
         with (
             mock.patch.object(presubmit, "SEMGREP_PATH_PREFIXES", ("project/src/",)),
@@ -154,6 +235,168 @@ class PresubmitTest(unittest.TestCase):
             self.assertTrue(presubmit.stage_files(["build_tools/file.py"], False))
 
         self.assertEqual(run_command.call_args.args[0][0:3], ["git", "add", "--"])
+
+    def test_fixing_the_index_stops_before_validation_and_names_paths(self):
+        args = types.SimpleNamespace(fail_on_fix=True, fix=True)
+        snapshot = mock.Mock()
+        snapshot.verify.return_value = True
+        output = io.StringIO()
+        with (
+            mock.patch.object(presubmit, "index_tree", return_value="before"),
+            mock.patch.object(
+                presubmit.NonEmptyTrackedFileSnapshot,
+                "capture_tracked_package_initializers",
+                return_value=snapshot,
+            ),
+            mock.patch.object(presubmit, "run_presubmit", return_value=0),
+            mock.patch.object(
+                presubmit,
+                "changed_index_paths",
+                return_value=["generated/output.cmake", "staged.c"],
+            ),
+            contextlib.redirect_stdout(output),
+        ):
+            self.assertEqual(
+                presubmit.run_presubmit_with_source_guard(
+                    args, input_scope(["staged.c"], mode="staged"), []
+                ),
+                1,
+            )
+
+        summary = output.getvalue()
+        self.assertIn("generated/output.cmake", summary)
+        self.assertIn("staged.c", summary)
+        self.assertIn("stops before tests", summary)
+        self.assertIn("git diff --cached", summary)
+        snapshot.verify.assert_called_once_with(presubmit.REPO_ROOT)
+
+    def test_fix_retry_contract_uses_the_real_index(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repo_root = Path(temporary_directory)
+
+            def git(*args: str) -> None:
+                subprocess.run(
+                    ["git", *args],
+                    cwd=repo_root,
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+
+            git("init", "--quiet")
+            git("config", "user.name", "Presubmit Test")
+            git("config", "user.email", "presubmit@example.com")
+            source_path = repo_root / "source.py"
+            source_path.write_text("value = 'base'\n")
+            git("add", "source.py")
+            git("commit", "--quiet", "-m", "base")
+            source_path.write_text("value =  'candidate'\n")
+            git("add", "source.py")
+
+            run_count = 0
+
+            def run_presubmit(*_args) -> int:
+                nonlocal run_count
+                run_count += 1
+                if run_count == 1:
+                    source_path.write_text("value = 'candidate'\n")
+                    git("add", "source.py")
+                return 0
+
+            args = types.SimpleNamespace(fail_on_fix=True, fix=True)
+            snapshot = mock.Mock()
+            snapshot.verify.return_value = True
+            output = io.StringIO()
+            with (
+                mock.patch.object(presubmit, "REPO_ROOT", repo_root),
+                mock.patch.object(
+                    presubmit.NonEmptyTrackedFileSnapshot,
+                    "capture_tracked_package_initializers",
+                    return_value=snapshot,
+                ),
+                mock.patch.object(
+                    presubmit, "run_presubmit", side_effect=run_presubmit
+                ),
+                contextlib.redirect_stdout(output),
+            ):
+                inputs = input_scope(["source.py"], mode="staged")
+                self.assertEqual(
+                    presubmit.run_presubmit_with_source_guard(args, inputs, []), 1
+                )
+                self.assertEqual(
+                    presubmit.run_presubmit_with_source_guard(args, inputs, []), 0
+                )
+
+            self.assertEqual(run_count, 2)
+            self.assertIn("source.py", output.getvalue())
+            self.assertIn("stops before tests", output.getvalue())
+
+    def test_bazel_to_cmake_fix_receives_only_selected_build_files(self):
+        selected_paths = ["runtime/src/iree/base/BUILD.bazel"]
+        with (
+            mock.patch.object(presubmit, "existing_files", return_value=selected_paths),
+            mock.patch.object(
+                presubmit, "run_command", return_value=True
+            ) as run_command,
+        ):
+            self.assertTrue(
+                presubmit.run_bazel_to_cmake(
+                    [*selected_paths, "runtime/src/iree/base/status.c"],
+                    fix=True,
+                    verbose=False,
+                )
+            )
+
+        command = run_command.call_args.args[0]
+        self.assertIn("--stage-updates", command)
+        self.assertEqual(command[-1], selected_paths[0])
+        self.assertNotIn("runtime/src/iree/base/status.c", command)
+
+    def test_bazel_to_cmake_global_fix_is_read_only(self):
+        with mock.patch.object(
+            presubmit, "run_command", return_value=True
+        ) as run_command:
+            self.assertTrue(
+                presubmit.run_bazel_to_cmake(
+                    ["build_tools/bazel_to_cmake/bazel_to_cmake.py"],
+                    fix=True,
+                    verbose=False,
+                )
+            )
+
+        command = run_command.call_args.args[0]
+        self.assertIn("--check", command)
+        self.assertNotIn("--stage-updates", command)
+
+        self.assertTrue(
+            presubmit.is_bazel_to_cmake_global_trigger(
+                "runtime/requirements/package_policy.bzl"
+            )
+        )
+        self.assertTrue(
+            presubmit.is_bazel_to_cmake_global_trigger(
+                "loom/build_tools/amdgpu/target_config.bzl"
+            )
+        )
+
+    def test_bazel_to_cmake_skips_unrelated_paths(self):
+        with (
+            mock.patch.object(presubmit, "existing_files", return_value=[]),
+            mock.patch.object(presubmit, "skip_step", return_value=True) as skip_step,
+            mock.patch.object(presubmit, "run_command") as run_command,
+        ):
+            self.assertTrue(
+                presubmit.run_bazel_to_cmake(
+                    ["build_tools/lefthook/presubmit.py"],
+                    fix=True,
+                    verbose=False,
+                )
+            )
+
+        skip_step.assert_called_once_with(
+            "Bazel-to-CMake", "no selected Bazel/CMake files"
+        )
+        run_command.assert_not_called()
 
     def test_clang_tidy_candidates_require_configured_prefix_and_extension(self):
         with (

--- a/build_tools/nativelink/README.md
+++ b/build_tools/nativelink/README.md
@@ -1,0 +1,102 @@
+# Local NativeLink Quickstart
+
+NativeLink can provide one shared Bazel action cache and execution limit across
+multiple local worktrees. This is an opt-in developer configuration: ordinary
+builds remain unchanged until `--config=nativelink` is selected. Same-machine
+remote execution adds hashing, RPC, and artifact-materialization work, so its
+payoff comes from cross-worktree cache hits and globally bounded concurrency,
+not from making one cold build faster.
+
+`../../.bazelrc` imports `nativelink.bazelrc`, which only defines the named
+configuration. `local.json5` runs a persistent cache, scheduler, and local
+worker in one process on two loopback listeners.
+
+## Install NativeLink
+
+The checked-in configuration targets NativeLink 1.6.5 on Linux x86-64. Install
+the pinned release from the
+[official NativeLink release](https://github.com/TraceMachina/nativelink/releases/tag/v1.6.5):
+
+```bash
+NATIVELINK_VERSION=1.6.5
+NATIVELINK_ARCHIVE="nativelink-${NATIVELINK_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+NATIVELINK_DOWNLOAD_DIRECTORY="$(mktemp -d)"
+
+curl -fL \
+  --output "${NATIVELINK_DOWNLOAD_DIRECTORY}/${NATIVELINK_ARCHIVE}" \
+  "https://github.com/TraceMachina/nativelink/releases/download/v${NATIVELINK_VERSION}/${NATIVELINK_ARCHIVE}"
+printf '%s  %s\n' \
+  093d2e0baac5311444762449b703a45b738d570065d2e17c2db1fcf39d8ad051 \
+  "${NATIVELINK_DOWNLOAD_DIRECTORY}/${NATIVELINK_ARCHIVE}" | \
+  sha256sum --check
+tar -xzf "${NATIVELINK_DOWNLOAD_DIRECTORY}/${NATIVELINK_ARCHIVE}" \
+  -C "${NATIVELINK_DOWNLOAD_DIRECTORY}"
+install -Dm0755 "${NATIVELINK_DOWNLOAD_DIRECTORY}/nativelink" \
+  "${HOME}/.local/bin/nativelink"
+"${HOME}/.local/bin/nativelink" --version
+```
+
+## Start the Local Service
+
+From the repository root, choose a persistent state directory outside the
+checkout, create its private stores, and start NativeLink in one terminal:
+
+```bash
+export NATIVELINK_STATE_ROOT="${XDG_CACHE_HOME:-${HOME}/.cache}/iree-nativelink"
+install -d -m0700 \
+  "${NATIVELINK_STATE_ROOT}" \
+  "${NATIVELINK_STATE_ROOT}/cas" \
+  "${NATIVELINK_STATE_ROOT}/cas/content" \
+  "${NATIVELINK_STATE_ROOT}/cas/temp" \
+  "${NATIVELINK_STATE_ROOT}/ac" \
+  "${NATIVELINK_STATE_ROOT}/ac/content" \
+  "${NATIVELINK_STATE_ROOT}/ac/temp" \
+  "${NATIVELINK_STATE_ROOT}/worker" \
+  "${NATIVELINK_STATE_ROOT}/worker/cas" \
+  "${NATIVELINK_STATE_ROOT}/worker/cas/content" \
+  "${NATIVELINK_STATE_ROOT}/worker/cas/temp" \
+  "${NATIVELINK_STATE_ROOT}/worker/actions"
+"${HOME}/.local/bin/nativelink" build_tools/nativelink/local.json5
+```
+
+## Opt a Build In
+
+From another terminal, confirm that the client and worker APIs are both
+listening:
+
+```bash
+ss -ltn '( sport = :50051 or sport = :50061 )'
+```
+
+Two `LISTEN` rows mean NativeLink is ready. Opt an ordinary wrapper command
+into both the shared cache and local worker:
+
+```bash
+build_tools/bin/iree-bazel-build \
+  --config=nativelink \
+  //runtime/src/iree/base:base
+```
+
+The first cache-cold build should report `remote` processes. Run the same
+command from another configured worktree to verify `remote cache hit` entries;
+different worktrees may still execute actions whose source or configuration
+inputs differ. The named config disables any separately configured Bazel disk
+cache only while selected, avoiding duplicate local reads and writes without
+deleting either cache. Requested outputs are downloaded; intermediate outputs
+remain in NativeLink unless the invocation adds
+`--remote_download_outputs=all`.
+
+## Capacity and Trust Boundary
+
+The default limits are 48 GB for the persistent CAS, 2 GB for the action cache,
+12 GB for the worker's fast CAS, and 16 concurrent actions. Override them
+before launch with `NATIVELINK_CAS_MAX_BYTES`, `NATIVELINK_AC_MAX_BYTES`,
+`NATIVELINK_WORKER_CACHE_MAX_BYTES`, and
+`NATIVELINK_MAX_INFLIGHT_TASKS`.
+
+Both APIs bind to loopback, but actions run directly on the host with the
+developer's authority so configured compilers and SDKs remain visible. This is
+appropriate only for trusted local checkouts; it is not a network deployment
+or an isolation boundary. Stop NativeLink only after builds are idle. Stopping
+the process is not a benchmark admission hold, and this quickstart does not
+claim restart-safe drain or queue control.

--- a/build_tools/nativelink/local.json5
+++ b/build_tools/nativelink/local.json5
@@ -1,0 +1,170 @@
+// Copyright 2026 The IREE Authors
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Single-machine NativeLink cache, scheduler, and local execution worker.
+// NATIVELINK_STATE_ROOT must name a persistent directory outside the checkout.
+// The client and worker APIs listen only on loopback.
+{
+  stores: [
+    {
+      name: "CAS_MAIN_STORE",
+      filesystem: {
+        content_path: "${NATIVELINK_STATE_ROOT}/cas/content",
+        temp_path: "${NATIVELINK_STATE_ROOT}/cas/temp",
+        eviction_policy: {
+          max_bytes: "${NATIVELINK_CAS_MAX_BYTES:-48000000000}",
+        },
+      },
+    },
+    {
+      name: "AC_MAIN_STORE",
+      filesystem: {
+        content_path: "${NATIVELINK_STATE_ROOT}/ac/content",
+        temp_path: "${NATIVELINK_STATE_ROOT}/ac/temp",
+        eviction_policy: {
+          max_bytes: "${NATIVELINK_AC_MAX_BYTES:-2000000000}",
+        },
+      },
+    },
+    {
+      name: "WORKER_FAST_SLOW_STORE",
+      fast_slow: {
+        fast: {
+          filesystem: {
+            content_path: "${NATIVELINK_STATE_ROOT}/worker/cas/content",
+            temp_path: "${NATIVELINK_STATE_ROOT}/worker/cas/temp",
+            eviction_policy: {
+              max_bytes: "${NATIVELINK_WORKER_CACHE_MAX_BYTES:-12000000000}",
+            },
+          },
+        },
+        fast_direction: "get",
+        slow: {
+          ref_store: {
+            name: "CAS_MAIN_STORE",
+          },
+        },
+      },
+    },
+  ],
+  schedulers: [
+    {
+      name: "MAIN_SCHEDULER",
+      simple: {
+        supported_platform_properties: {
+          cpu_count: "minimum",
+          OSFamily: "priority",
+          "container-image": "priority",
+        },
+        retain_completed_for_s: "${NATIVELINK_RETAIN_COMPLETED_SECONDS:-3600}sec",
+        client_action_timeout_s: "${NATIVELINK_CLIENT_ACTION_TIMEOUT_SECONDS:-3600}sec",
+        worker_timeout_s: 10,
+        fallback_match_interval_s: 1,
+      },
+    },
+  ],
+  workers: [
+    {
+      local: {
+        name: "local-iree-",
+        worker_api_endpoint: {
+          uri: "${NATIVELINK_WORKER_API_ENDPOINT:-grpc://127.0.0.1:50061}",
+        },
+        max_action_timeout_s: "${NATIVELINK_MAX_ACTION_TIMEOUT_SECONDS:-21600}sec",
+        max_upload_timeout_s: 3600,
+        max_inflight_tasks: "${NATIVELINK_MAX_INFLIGHT_TASKS:-16}",
+        cas_fast_slow_store: "WORKER_FAST_SLOW_STORE",
+        upload_action_result: {
+          ac_store: "AC_MAIN_STORE",
+        },
+        work_directory: "${NATIVELINK_STATE_ROOT}/worker/actions",
+        platform_properties: {
+          cpu_count: {
+            query_cmd: "nproc",
+          },
+          OSFamily: {
+            values: [
+              "linux",
+              "",
+            ],
+          },
+          "container-image": {
+            values: [
+              "",
+            ],
+          },
+        },
+
+        // This developer configuration executes trusted repository actions
+        // directly on the host so configured toolchains remain visible.
+        use_namespaces: false,
+      },
+    },
+  ],
+  servers: [
+    {
+      name: "client",
+      listener: {
+        http: {
+          socket_address: "${NATIVELINK_CLIENT_LISTEN_ADDRESS:-127.0.0.1:50051}",
+          advanced_http: {
+            http2_keep_alive_interval: 10,
+            experimental_http2_keep_alive_timeout_s: 20,
+          },
+        },
+      },
+      services: {
+        cas: [
+          {
+            cas_store: "CAS_MAIN_STORE",
+          },
+        ],
+        ac: [
+          {
+            ac_store: "AC_MAIN_STORE",
+          },
+        ],
+        bytestream: [
+          {
+            cas_store: "CAS_MAIN_STORE",
+          },
+        ],
+        execution: [
+          {
+            cas_store: "CAS_MAIN_STORE",
+            scheduler: "MAIN_SCHEDULER",
+          },
+        ],
+        capabilities: [
+          {
+            remote_execution: {
+              scheduler: "MAIN_SCHEDULER",
+            },
+          },
+        ],
+      },
+    },
+    {
+      name: "worker-api",
+      listener: {
+        http: {
+          socket_address: "${NATIVELINK_WORKER_API_LISTEN_ADDRESS:-127.0.0.1:50061}",
+          advanced_http: {
+            http2_keep_alive_interval: 10,
+            experimental_http2_keep_alive_timeout_s: 20,
+          },
+        },
+      },
+      services: {
+        worker_api: {
+          scheduler: "MAIN_SCHEDULER",
+        },
+        health: {},
+      },
+    },
+  ],
+  global: {
+    max_open_files: 24576,
+    default_digest_hash_function: "sha256",
+  },
+}

--- a/build_tools/nativelink/nativelink.bazelrc
+++ b/build_tools/nativelink/nativelink.bazelrc
@@ -1,0 +1,16 @@
+# Copyright 2026 The IREE Authors
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Opt-in local NativeLink cache and execution. The server configuration binds
+# this endpoint to loopback; selecting it for another server requires TLS and a
+# deliberate remote trust policy.
+build:nativelink --remote_cache=grpc://127.0.0.1:50051
+build:nativelink --remote_executor=grpc://127.0.0.1:50051
+build:nativelink --remote_default_exec_properties=cpu_count=1
+build:nativelink --remote_local_fallback=false
+build:nativelink --remote_download_outputs=toplevel
+
+# A separately configured Bazel disk cache would duplicate reads and writes on
+# the same machine and obscure which cache served an action. This only disables
+# the disk cache while --config=nativelink is selected; it deletes nothing.
+build:nativelink --disk_cache=

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,7 +14,7 @@ pre-commit:
   fail_on_changes: always
   commands:
     precommit:
-      run: python dev.py bazel precommit --profile paranoid --commit
+      run: python dev.py bazel precommit --profile paranoid --staged
 
 commit-msg:
   commands:

--- a/loom/build_tools/cmake/loom_generated.cmake
+++ b/loom/build_tools/cmake/loom_generated.cmake
@@ -14,7 +14,10 @@
 # Generated commands record input freshness in a private stamp and expose their
 # artifacts as byproducts. Generators that preserve an artifact's timestamp
 # when its contents are unchanged can then avoid invalidating C/C++ consumers
-# without leaving Make to repeat the generator on every build.
+# without leaving Make to repeat the generator on every build. Producer targets
+# depend only on the stamp: CMake's Makefile generators do not emit standalone
+# rules for BYPRODUCTS, while the explicit producer-to-consumer target edges
+# ensure the artifacts exist before compilation begins.
 
 function(_loom_python_command_prefix OUTPUT_PREFIX GENERATOR)
   iree_py_library_collect_package_dirs(_GENERATOR_PACKAGE_DIRS "${GENERATOR}")
@@ -27,6 +30,13 @@ function(_loom_python_command_prefix OUTPUT_PREFIX GENERATOR)
   set(${OUTPUT_PREFIX}
     "${CMAKE_COMMAND}" -E env "PYTHONPATH=${_GENERATOR_PYTHONPATH}"
     PARENT_SCOPE
+  )
+endfunction()
+
+function(_loom_add_generated_target TARGET_NAME STAMP_PATH)
+  add_custom_target("${TARGET_NAME}"
+    DEPENDS
+      "${STAMP_PATH}"
   )
 endfunction()
 
@@ -103,11 +113,7 @@ function(_loom_generated_files)
     PROPERTIES GENERATED TRUE
   )
 
-  add_custom_target("${_GEN_TARGET}"
-    DEPENDS
-      "${_GEN_STAMP}"
-      ${_OUTPUTS}
-  )
+  _loom_add_generated_target("${_GEN_TARGET}" "${_GEN_STAMP}")
   iree_register_generated_compile_input("${_GEN_TARGET}"
     OUTPUTS ${_OUTPUTS}
   )
@@ -292,11 +298,7 @@ function(loom_generated_cc_library)
     PROPERTIES GENERATED TRUE
   )
 
-  add_custom_target("${_GEN_TARGET}"
-    DEPENDS
-      "${_GEN_STAMP}"
-      ${_OUTPUTS}
-  )
+  _loom_add_generated_target("${_GEN_TARGET}" "${_GEN_STAMP}")
   iree_register_generated_compile_input("${_GEN_TARGET}"
     OUTPUTS ${_OUTPUTS}
   )

--- a/loom/build_tools/cmake/loom_low_descriptor.cmake
+++ b/loom/build_tools/cmake/loom_low_descriptor.cmake
@@ -176,11 +176,7 @@ function(loom_target_table_cc_library)
     VERBATIM
   )
 
-  add_custom_target("${_GEN_TARGET}"
-    DEPENDS
-      "${_GEN_STAMP}"
-      ${_OUTPUTS}
-  )
+  _loom_add_generated_target("${_GEN_TARGET}" "${_GEN_STAMP}")
   iree_register_generated_compile_input("${_GEN_TARGET}"
     OUTPUTS
       ${_OUTPUTS}
@@ -318,11 +314,7 @@ function(loom_target_contract_table_cc_libraries)
     VERBATIM
   )
 
-  add_custom_target("${_GEN_TARGET}"
-    DEPENDS
-      "${_GEN_STAMP}"
-      ${_OUTPUTS}
-  )
+  _loom_add_generated_target("${_GEN_TARGET}" "${_GEN_STAMP}")
   iree_register_generated_compile_input("${_GEN_TARGET}"
     OUTPUTS
       ${_OUTPUTS}

--- a/loom/build_tools/presubmit.py
+++ b/loom/build_tools/presubmit.py
@@ -98,11 +98,18 @@ def should_run_presubmit(files_from: str | None) -> bool:
     )
 
 
-def run_generated_artifact_maintenance(fix: bool) -> bool:
+def run_generated_artifact_maintenance(
+    fix: bool, files_from: str | None = None
+) -> bool:
     print("loom presubmit: Checked-in generated artifacts")
-    result = checked_in_artifacts.maintain_checked_in_artifacts(
-        "update" if fix else "check"
-    )
+    if fix and files_from is not None:
+        result = checked_in_artifacts.maintain_checked_in_artifacts(
+            "update", writable_paths=selected_files(files_from)
+        )
+    else:
+        result = checked_in_artifacts.maintain_checked_in_artifacts(
+            "update" if fix else "check"
+        )
     if not result.ok:
         return False
     if not fix:
@@ -329,7 +336,7 @@ def run_presubmit(args: argparse.Namespace) -> int:
         return 0
     ok = True
     if args.hygiene:
-        ok = run_generated_artifact_maintenance(args.fix) and ok
+        ok = run_generated_artifact_maintenance(args.fix, args.files_from) and ok
         ok = (
             run_source_format_maintenance(
                 lane=args.lane,

--- a/loom/build_tools/presubmit_test.py
+++ b/loom/build_tools/presubmit_test.py
@@ -102,6 +102,37 @@ class LoomPresubmitTest(unittest.TestCase):
             changed_paths,
         )
 
+    def test_generated_artifact_fix_passes_only_selected_paths_as_writable(self):
+        selected_paths = ["loom/py/loom/dialect/__init__.py"]
+        result = types.SimpleNamespace(ok=True, changed_paths=())
+        with (
+            mock.patch.object(
+                self.presubmit, "selected_files", return_value=selected_paths
+            ),
+            mock.patch.object(
+                self.presubmit.checked_in_artifacts,
+                "maintain_checked_in_artifacts",
+                return_value=result,
+            ) as maintain_checked_in_artifacts,
+            mock.patch.object(
+                self.presubmit.project_presubmit, "stage_changed_paths"
+            ) as stage_changed_paths,
+        ):
+            self.assertTrue(
+                self.presubmit.run_generated_artifact_maintenance(
+                    fix=True, files_from="paths.txt"
+                )
+            )
+
+        maintain_checked_in_artifacts.assert_called_once_with(
+            "update", writable_paths=selected_paths
+        )
+        stage_changed_paths.assert_called_once_with(
+            self.presubmit.PROJECT_NAME,
+            self.presubmit.REPO_ROOT,
+            (),
+        )
+
     def test_generated_artifact_failure_does_not_stage_partial_updates(self):
         result = types.SimpleNamespace(
             ok=False,
@@ -555,7 +586,7 @@ class LoomPresubmitTest(unittest.TestCase):
         ):
             self.assertEqual(self.presubmit.run_presubmit(args), 1)
 
-        generated_artifact_maintenance.assert_called_once_with(False)
+        generated_artifact_maintenance.assert_called_once_with(False, None)
         source_format_maintenance.assert_called_once_with(
             lane="bazel", files_from=None, fix=False
         )
@@ -589,7 +620,7 @@ class LoomPresubmitTest(unittest.TestCase):
         ):
             self.assertEqual(self.presubmit.run_presubmit(args), 1)
 
-        generated_artifact_maintenance.assert_called_once_with(False)
+        generated_artifact_maintenance.assert_called_once_with(False, None)
         source_format_maintenance.assert_called_once_with(
             lane="bazel", files_from=None, fix=False
         )

--- a/loom/py/loom/gen/bootstrap.py
+++ b/loom/py/loom/gen/bootstrap.py
@@ -29,6 +29,3 @@ def ensure_repository_packages_on_path(start: str | Path | None = None) -> Path:
     package_roots = [str(repo_root / "loom" / "py"), str(repo_root)]
     sys.path[:] = package_roots + [path for path in sys.path if path not in package_roots]
     return repo_root
-
-
-REPO_ROOT = find_repo_root(__file__)

--- a/loom/py/loom/gen/bootstrap_test.py
+++ b/loom/py/loom/gen/bootstrap_test.py
@@ -14,6 +14,25 @@ from pathlib import Path
 from loom.gen import bootstrap
 
 
+def test_import_does_not_require_repository_layout(tmp_path: Path) -> None:
+    module_path = tmp_path / "runfiles" / "_main" / "loom" / "py" / "loom" / "gen" / "bootstrap.py"
+    module_path.parent.mkdir(parents=True)
+    module_path.write_bytes(Path(bootstrap.__file__).read_bytes())
+
+    spec = importlib.util.spec_from_file_location("materialized_loom_bootstrap", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    materialized_bootstrap = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(materialized_bootstrap)
+
+    try:
+        materialized_bootstrap.find_repo_root(module_path)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("materialized runfiles unexpectedly contained a Loom repository")
+
+
 def test_repository_packages_precede_ambient_imports(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     script_path = repo_root / "loom" / "py" / "loom" / "gen" / "run.py"

--- a/loom/py/loom/gen/checked_in_artifacts.py
+++ b/loom/py/loom/gen/checked_in_artifacts.py
@@ -91,11 +91,17 @@ def checked_in_artifact_families() -> tuple[GeneratedFileFamily, ...]:
 
 def maintain_checked_in_artifacts(
     mode: GeneratedFileMaintenanceMode,
+    *,
+    writable_paths: Sequence[str] | None = None,
 ) -> GeneratedFileMaintenanceResult:
-    """Checks or updates every registered checked-in artifact family."""
+    """Checks all families or updates only families owning writable paths."""
+    families = checked_in_artifact_families()
+    if mode == "update" and writable_paths is not None:
+        writable_path_set = set(writable_paths)
+        families = tuple(family for family in families if writable_path_set.intersection((*family.file_set.output_paths, *family.file_set.obsolete_paths)))
     return maintain_generated_file_families(
         _bootstrap.REPO_ROOT,
-        checked_in_artifact_families(),
+        families,
         mode=mode,
     )
 

--- a/loom/py/loom/gen/checked_in_artifacts.py
+++ b/loom/py/loom/gen/checked_in_artifacts.py
@@ -12,6 +12,7 @@ import argparse
 import importlib.util
 import sys
 from collections.abc import Sequence
+from pathlib import Path
 from types import ModuleType
 
 from loom.gen import bootstrap as _bootstrap
@@ -28,27 +29,28 @@ from loom.gen.target.arch.x86 import x86_packed_dot_contract
 from loom.gen.test import numeric_conversion_matrix
 
 _AMDGPU_TARGET_CONFIG_MODULE_NAME = "loom_build_tools_amdgpu_target_config"
+# Source checkouts and declared build trees preserve paths below top-level loom.
+_AMDGPU_TARGET_CONFIG_PATH = Path(__file__).resolve().parents[3] / "build_tools/amdgpu/target_config.py"
 
 
 def _load_amdgpu_target_config() -> ModuleType:
     existing_module = sys.modules.get(_AMDGPU_TARGET_CONFIG_MODULE_NAME)
     if existing_module is not None:
         return existing_module
-    module_path = _bootstrap.REPO_ROOT / "loom/build_tools/amdgpu/target_config.py"
     spec = importlib.util.spec_from_file_location(
         _AMDGPU_TARGET_CONFIG_MODULE_NAME,
-        module_path,
+        _AMDGPU_TARGET_CONFIG_PATH,
     )
     if spec is None or spec.loader is None:
-        raise RuntimeError(f"could not load {module_path}")
+        raise RuntimeError(f"could not load {_AMDGPU_TARGET_CONFIG_PATH}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
 
 
-def checked_in_artifact_families() -> tuple[GeneratedFileFamily, ...]:
-    """Returns every checked-in Loom generated artifact family."""
+def checked_in_artifact_families(*, repository_root: Path | None = None) -> tuple[GeneratedFileFamily, ...]:
+    """Returns each family, discovering obsolete files when a root is given."""
     amdgpu_target_config = _load_amdgpu_target_config()
     return (
         GeneratedFileFamily(
@@ -59,7 +61,7 @@ def checked_in_artifact_families() -> tuple[GeneratedFileFamily, ...]:
         GeneratedFileFamily(
             description=builders_pyi.DESCRIPTION,
             regenerate_command=builders_pyi.REGENERATE_COMMAND,
-            file_set=builders_pyi.checked_in_file_set(),
+            file_set=builders_pyi.checked_in_file_set(repository_root),
         ),
         GeneratedFileFamily(
             description=c_tables.DESCRIPTION,
@@ -74,7 +76,7 @@ def checked_in_artifact_families() -> tuple[GeneratedFileFamily, ...]:
         GeneratedFileFamily(
             description=textmate.DESCRIPTION,
             regenerate_command=textmate.REGENERATE_COMMAND,
-            file_set=textmate.checked_in_file_set(),
+            file_set=textmate.checked_in_file_set(repository_root),
         ),
         GeneratedFileFamily(
             description=x86_packed_dot_contract.DESCRIPTION,
@@ -95,12 +97,13 @@ def maintain_checked_in_artifacts(
     writable_paths: Sequence[str] | None = None,
 ) -> GeneratedFileMaintenanceResult:
     """Checks all families or updates only families owning writable paths."""
-    families = checked_in_artifact_families()
+    repository_root = _bootstrap.find_repo_root()
+    families = checked_in_artifact_families(repository_root=repository_root)
     if mode == "update" and writable_paths is not None:
         writable_path_set = set(writable_paths)
         families = tuple(family for family in families if writable_path_set.intersection((*family.file_set.output_paths, *family.file_set.obsolete_paths)))
     return maintain_generated_file_families(
-        _bootstrap.REPO_ROOT,
+        repository_root,
         families,
         mode=mode,
     )

--- a/loom/py/loom/gen/checked_in_artifacts_test.py
+++ b/loom/py/loom/gen/checked_in_artifacts_test.py
@@ -102,6 +102,11 @@ def test_update_selects_only_families_owning_writable_paths() -> None:
             checked_in_artifacts,
             "checked_in_artifact_families",
             return_value=(first_family, second_family),
+        ) as checked_in_artifact_families,
+        mock.patch.object(
+            checked_in_artifacts._bootstrap,
+            "find_repo_root",
+            return_value=mock.sentinel.repository_root,
         ),
         mock.patch.object(
             checked_in_artifacts,
@@ -112,8 +117,9 @@ def test_update_selects_only_families_owning_writable_paths() -> None:
         result = checked_in_artifacts.maintain_checked_in_artifacts("update", writable_paths=["generated/second.txt"])
 
     assert result.ok
+    checked_in_artifact_families.assert_called_once_with(repository_root=mock.sentinel.repository_root)
     maintain_generated_file_families.assert_called_once_with(
-        checked_in_artifacts._bootstrap.REPO_ROOT,
+        mock.sentinel.repository_root,
         (second_family,),
         mode="update",
     )

--- a/loom/py/loom/gen/checked_in_artifacts_test.py
+++ b/loom/py/loom/gen/checked_in_artifacts_test.py
@@ -11,6 +11,7 @@ from unittest import mock
 
 from loom.gen import checked_in_artifacts
 from loom.gen.support.generated_file import (
+    GeneratedFileFamily,
     GeneratedFileMaintenanceResult,
     GeneratedFileSet,
 )
@@ -83,6 +84,39 @@ def test_registered_artifact_ownership_is_disjoint() -> None:
             owners[path] = family.description
 
     assert owners
+
+
+def test_update_selects_only_families_owning_writable_paths() -> None:
+    first_family = GeneratedFileFamily(
+        description="first",
+        regenerate_command="generate first",
+        file_set=GeneratedFileSet.from_mapping({"generated/first.txt": "first\n"}),
+    )
+    second_family = GeneratedFileFamily(
+        description="second",
+        regenerate_command="generate second",
+        file_set=GeneratedFileSet.from_mapping({"generated/second.txt": "second\n"}),
+    )
+    with (
+        mock.patch.object(
+            checked_in_artifacts,
+            "checked_in_artifact_families",
+            return_value=(first_family, second_family),
+        ),
+        mock.patch.object(
+            checked_in_artifacts,
+            "maintain_generated_file_families",
+            return_value=GeneratedFileMaintenanceResult(True),
+        ) as maintain_generated_file_families,
+    ):
+        result = checked_in_artifacts.maintain_checked_in_artifacts("update", writable_paths=["generated/second.txt"])
+
+    assert result.ok
+    maintain_generated_file_families.assert_called_once_with(
+        checked_in_artifacts._bootstrap.REPO_ROOT,
+        (second_family,),
+        mode="update",
+    )
 
 
 def test_main_selects_check_and_update_modes() -> None:

--- a/loom/py/loom/gen/editor/textmate.py
+++ b/loom/py/loom/gen/editor/textmate.py
@@ -466,17 +466,17 @@ def _output_files() -> dict[str, str]:
     return {(_OUTPUT_ROOT / filename).as_posix(): contents for filename, contents in generate_all_grammars(ops, type_defs).items()}
 
 
-def _obsolete_output_paths(expected_paths: set[str]) -> tuple[str, ...]:
-    existing_paths = (path.relative_to(_bootstrap.REPO_ROOT).as_posix() for path in (_bootstrap.REPO_ROOT / _OUTPUT_ROOT).glob("*.tmLanguage.json") if path.is_file() or path.is_symlink())
+def _obsolete_output_paths(repository_root: Path, expected_paths: set[str]) -> tuple[str, ...]:
+    existing_paths = (path.relative_to(repository_root).as_posix() for path in (repository_root / _OUTPUT_ROOT).glob("*.tmLanguage.json") if path.is_file() or path.is_symlink())
     return tuple(sorted(path for path in existing_paths if path not in expected_paths))
 
 
-def checked_in_file_set() -> GeneratedFileSet:
-    """Returns the complete checked-in TextMate grammar ownership set."""
+def checked_in_file_set(repository_root: Path | None = None) -> GeneratedFileSet:
+    """Returns expected grammars and any obsolete files under a given root."""
     files = _output_files()
     return GeneratedFileSet.from_mapping(
         files,
-        obsolete_paths=_obsolete_output_paths(set(files)),
+        obsolete_paths=(_obsolete_output_paths(repository_root, set(files)) if repository_root is not None else ()),
     )
 
 
@@ -484,9 +484,10 @@ def maintain_checked_in_files(
     mode: GeneratedFileMaintenanceMode,
 ) -> GeneratedFileMaintenanceResult:
     """Checks or updates all checked-in TextMate grammars."""
+    repository_root = _bootstrap.find_repo_root()
     return maintain_generated_file_set(
-        _bootstrap.REPO_ROOT,
-        checked_in_file_set(),
+        repository_root,
+        checked_in_file_set(repository_root),
         mode=mode,
         description=DESCRIPTION,
         regenerate_command=REGENERATE_COMMAND,

--- a/loom/py/loom/gen/editor/textmate_test.py
+++ b/loom/py/loom/gen/editor/textmate_test.py
@@ -158,15 +158,12 @@ def test_checked_in_file_set_owns_only_generated_grammars(tmp_path: Path) -> Non
     (tmp_path / obsolete_path).write_text("obsolete\n", encoding="utf-8")
     neighbor_path = expected_file.parent / "README.md"
     neighbor_path.write_text("authored\n", encoding="utf-8")
-    with (
-        mock.patch.object(textmate._bootstrap, "REPO_ROOT", tmp_path),
-        mock.patch.object(
-            textmate,
-            "_output_files",
-            return_value={expected_path: "expected\n"},
-        ),
+    with mock.patch.object(
+        textmate,
+        "_output_files",
+        return_value={expected_path: "expected\n"},
     ):
-        generated_file_set = textmate.checked_in_file_set()
+        generated_file_set = textmate.checked_in_file_set(tmp_path)
 
     assert generated_file_set.output_paths == (expected_path,)
     assert generated_file_set.obsolete_paths == (obsolete_path,)

--- a/loom/py/loom/gen/ops/c_tables.py
+++ b/loom/py/loom/gen/ops/c_tables.py
@@ -175,7 +175,7 @@ def maintain_checked_in_files(
 ) -> GeneratedFileMaintenanceResult:
     """Checks or updates all checked-in C table artifacts."""
     return maintain_generated_file_set(
-        _bootstrap.REPO_ROOT,
+        _bootstrap.find_repo_root(),
         checked_in_file_set(),
         mode=mode,
         description=DESCRIPTION,

--- a/loom/py/loom/gen/python/builders_pyi.py
+++ b/loom/py/loom/gen/python/builders_pyi.py
@@ -13,6 +13,7 @@ import re
 import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from loom.builder_model import (
@@ -378,18 +379,18 @@ def _output_files() -> dict[str, str]:
     )
 
 
-def _obsolete_output_paths(expected_paths: set[str]) -> tuple[str, ...]:
-    dialect_root = _bootstrap.REPO_ROOT / "loom" / "py" / "loom" / "dialect"
-    existing_paths = (path.relative_to(_bootstrap.REPO_ROOT).as_posix() for path in dialect_root.glob("*/builders/**/*.pyi") if path.is_file())
+def _obsolete_output_paths(repository_root: Path, expected_paths: set[str]) -> tuple[str, ...]:
+    dialect_root = repository_root / "loom" / "py" / "loom" / "dialect"
+    existing_paths = (path.relative_to(repository_root).as_posix() for path in dialect_root.glob("*/builders/**/*.pyi") if path.is_file())
     return tuple(sorted(path for path in existing_paths if path not in expected_paths))
 
 
-def checked_in_file_set() -> GeneratedFileSet:
-    """Returns the complete checked-in builder-stub ownership set."""
+def checked_in_file_set(repository_root: Path | None = None) -> GeneratedFileSet:
+    """Returns expected stubs and any obsolete files under a given root."""
     files = _output_files()
     return GeneratedFileSet.from_mapping(
         files,
-        obsolete_paths=_obsolete_output_paths(set(files)),
+        obsolete_paths=(_obsolete_output_paths(repository_root, set(files)) if repository_root is not None else ()),
     )
 
 
@@ -397,9 +398,10 @@ def maintain_checked_in_files(
     mode: GeneratedFileMaintenanceMode,
 ) -> GeneratedFileMaintenanceResult:
     """Checks or updates all checked-in builder stubs."""
+    repository_root = _bootstrap.find_repo_root()
     return maintain_generated_file_set(
-        _bootstrap.REPO_ROOT,
-        checked_in_file_set(),
+        repository_root,
+        checked_in_file_set(repository_root),
         mode=mode,
         description=DESCRIPTION,
         regenerate_command=REGENERATE_COMMAND,

--- a/loom/py/loom/gen/python/builders_pyi_test.py
+++ b/loom/py/loom/gen/python/builders_pyi_test.py
@@ -118,15 +118,12 @@ def test_checked_in_file_set_owns_only_generated_stubs(
     (tmp_path / obsolete_path).write_text("obsolete\n", encoding="utf-8")
     neighbor_path = expected_file.parent / "helpers.py"
     neighbor_path.write_text("authored\n", encoding="utf-8")
-    with (
-        mock.patch.object(builders_pyi._bootstrap, "REPO_ROOT", tmp_path),
-        mock.patch.object(
-            builders_pyi,
-            "_output_files",
-            return_value={expected_path: "expected\n"},
-        ),
+    with mock.patch.object(
+        builders_pyi,
+        "_output_files",
+        return_value={expected_path: "expected\n"},
     ):
-        generated_file_set = builders_pyi.checked_in_file_set()
+        generated_file_set = builders_pyi.checked_in_file_set(tmp_path)
 
     assert generated_file_set.output_paths == (expected_path,)
     assert generated_file_set.obsolete_paths == (obsolete_path,)

--- a/loom/py/loom/gen/python/package_inits.py
+++ b/loom/py/loom/gen/python/package_inits.py
@@ -137,7 +137,7 @@ def maintain_checked_in_files(
 ) -> GeneratedFileMaintenanceResult:
     """Checks or updates all checked-in package initializers."""
     return maintain_generated_file_set(
-        _bootstrap.REPO_ROOT,
+        _bootstrap.find_repo_root(),
         checked_in_file_set(),
         mode=mode,
         description=DESCRIPTION,

--- a/loom/py/loom/gen/target/arch/x86/BUILD.bazel
+++ b/loom/py/loom/gen/target/arch/x86/BUILD.bazel
@@ -73,6 +73,7 @@ iree_py_binary(
     main = "x86_packed_dot_contract.py",
     visibility = GENERATOR_VISIBILITY,
     deps = [
+        "//loom/py/loom/gen:bootstrap",
         "//loom/py/loom/gen/support",
         "//loom/py/loom/target:low_descriptors",
         "//loom/py/loom/target/arch/x86:target_info",

--- a/loom/py/loom/gen/target/arch/x86/CMakeLists.txt
+++ b/loom/py/loom/gen/target/arch/x86/CMakeLists.txt
@@ -66,6 +66,7 @@ iree_py_library(
     "__init__.py"
     "x86_packed_dot_contract.py"
   DEPS
+    loom::py::loom::gen::bootstrap
     loom::py::loom::gen::support::support
     loom::py::loom::target::low_descriptors
     loom::py::loom::target::arch::x86::target_info

--- a/loom/py/loom/gen/target/arch/x86/x86_packed_dot_contract.py
+++ b/loom/py/loom/gen/target/arch/x86/x86_packed_dot_contract.py
@@ -14,17 +14,16 @@ from collections.abc import Sequence
 from pathlib import Path
 
 
-def _ensure_runtime_py_on_path() -> Path:
-    repo_root = Path(__file__).resolve().parents[7]
-    runtime_py = repo_root / "loom/py"
+def _ensure_runtime_py_on_path() -> None:
+    runtime_py = Path(__file__).resolve().parents[5]
     runtime_py_string = str(runtime_py)
     if runtime_py_string not in sys.path:
         sys.path.insert(0, runtime_py_string)
-    return repo_root
 
 
-REPO_ROOT = _ensure_runtime_py_on_path()
+_ensure_runtime_py_on_path()
 
+from loom.gen import bootstrap as _bootstrap  # noqa: E402
 from loom.gen.support.c import c_string_literal as _c_string_literal  # noqa: E402
 from loom.gen.support.files import write_text_file  # noqa: E402
 from loom.gen.support.generated_file import (  # noqa: E402
@@ -150,7 +149,7 @@ def maintain_checked_in_files(
 ) -> GeneratedFileMaintenanceResult:
     """Checks or updates the checked-in packed-dot contract header."""
     return maintain_generated_file_set(
-        REPO_ROOT,
+        _bootstrap.find_repo_root(),
         checked_in_file_set(),
         mode=mode,
         description=DESCRIPTION,

--- a/loom/py/loom/gen/test/numeric_conversion_matrix.py
+++ b/loom/py/loom/gen/test/numeric_conversion_matrix.py
@@ -727,7 +727,7 @@ def maintain_checked_in_files(
 ) -> GeneratedFileMaintenanceResult:
     """Checks or updates all checked-in FP8 conversion witnesses."""
     return maintain_generated_file_set(
-        _bootstrap.REPO_ROOT,
+        _bootstrap.find_repo_root(),
         checked_in_file_set(),
         mode=mode,
         description=DESCRIPTION,


### PR DESCRIPTION
Repository tooling now keeps its inputs and mutation authority explicit across Git hooks, CMake and Bazel generators, and optional local remote execution. This prevents partial commits from absorbing unrelated files, lets Loom generation run in materialized remote runfiles and with both CMake generator families, and provides a repository-owned NativeLink setup without changing ordinary builds.

- Commit hooks use the index as the only ordinary mutation boundary. Explicit amend validation is read-only, generated fixers are bounded to selected families and outputs, and fixer mutations stop with exact review-and-retry diagnostics before tests.
- Loom generated CMake targets depend on completion stamps while registered producer-to-consumer target edges order byproducts, preserving content-stable outputs under Make and Ninja.
- Loom generator imports no longer discover the checkout at module import time. Repository discovery is confined to source-maintenance entry points, and Bazel declares the required runfiles.
- `--config=nativelink` opts into a checked-in loopback cache, scheduler, and worker topology with pinned installation, persistent capacity, cache-coexistence, and host-trust guidance. The imported config is inert otherwise.

## Reviewer Notes

The highest-value review surfaces are the index/worktree boundary and fail-after-fix path in `build_tools/lefthook/presubmit.py`, the stamp and target ordering in `loom/build_tools/cmake/loom_generated.cmake`, and the split between build-time runfiles and source-maintenance repository discovery. The NativeLink files are deliberately opt-in and bind both APIs to loopback.
