### PR TITLE
[Infra] Skip unavailable optional Semgrep

### DIFF
--- a/build_tools/lefthook/presubmit.py
+++ b/build_tools/lefthook/presubmit.py
@@ -1588,8 +1588,8 @@ def run_semgrep(inputs: PresubmitInputs, profile: str, verbose: bool) -> bool:
             "semgrep-core.exe is not distributed for native Windows; "
             "enforced by the Linux paranoid presubmit",
         )
-    if not require_static_tool("semgrep", "Semgrep", profile):
-        return False
+    if shutil.which("semgrep") is None:
+        return require_static_tool("semgrep", "Semgrep", profile)
 
     ok = True
     if validate_config:

--- a/build_tools/lefthook/presubmit_test.py
+++ b/build_tools/lefthook/presubmit_test.py
@@ -862,6 +862,23 @@ class PresubmitTest(unittest.TestCase):
         self.assertIn("[skip]", output.getvalue())
         self.assertIn("[fail]", output.getvalue())
 
+    def test_missing_semgrep_does_not_attempt_scan(self):
+        output = io.StringIO()
+        inputs = input_scope(["runtime/src/iree/base/status.c"])
+        with (
+            contextlib.redirect_stdout(output),
+            mock.patch.object(presubmit.shutil, "which", return_value=None),
+            mock.patch.object(presubmit, "run_command") as run_command,
+        ):
+            self.assertTrue(
+                presubmit.run_semgrep(inputs, profile="paranoid", verbose=False)
+            )
+            self.assertFalse(presubmit.run_semgrep(inputs, profile="ci", verbose=False))
+
+        run_command.assert_not_called()
+        self.assertIn("[skip]", output.getvalue())
+        self.assertIn("[fail]", output.getvalue())
+
     def test_semgrep_is_explicitly_delegated_to_linux_on_windows(self):
         output = io.StringIO()
         inputs = input_scope(["runtime/src/iree/base/status.c"])


### PR DESCRIPTION
Paranoid presubmit deliberately permits optional static-analysis tools to be absent, but `run_semgrep` treated the successful "optional tool missing" result as evidence that Semgrep existed and attempted to execute it.

Return the requirement result immediately when the binary is absent. Local paranoid hooks now skip the unavailable tool, while CI continues to fail because Semgrep is required there. The regression test covers both profiles and proves no scan command runs without the tool.