### PR TITLE
[HRX] Export the allocation in hrx_buffer_get_device_ptr

### DIFF
--- a/libhrx/src/libhrx/buffer.c
+++ b/libhrx/src/libhrx/buffer.c
@@ -209,11 +209,29 @@ hrx_status_t hrx_buffer_get_device_ptr(hrx_buffer_t buffer, void** device_ptr) {
                                             "buffer or device_ptr is NULL"));
   }
   // For local-task (CPU) devices, the device pointer is available via mapping.
-  // For real GPU devices, this would use iree_hal_buffer_export.
-  // For now, map the buffer to get a usable pointer.
   if (buffer->mapped_ptr) {
     *device_ptr = buffer->mapped_ptr;
     HRX_RETURN_AND_END_ZONE(z0, hrx_ok_status());
+  }
+
+  // A device-local allocation has no host mapping, and asking for one fails.
+  // Export it instead: the allocator hands back the device address, which is
+  // what a peer copy, a DMA descriptor or an access grant all need. Without
+  // this the caller cannot address the memory at all.
+  iree_hal_allocator_t* allocator =
+      buffer->device ? buffer->device->allocator.hal_allocator : NULL;
+  if (allocator) {
+    iree_hal_external_buffer_t external;
+    memset(&external, 0, sizeof(external));
+    iree_status_t exported = iree_hal_allocator_export_buffer(
+        allocator, buffer->hal_buffer,
+        IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION,
+        IREE_HAL_EXTERNAL_BUFFER_FLAG_NONE, &external);
+    if (iree_status_is_ok(exported)) {
+      *device_ptr = (void*)(uintptr_t)external.handle.device_allocation.ptr;
+      HRX_RETURN_AND_END_ZONE(z0, hrx_ok_status());
+    }
+    iree_status_ignore(exported);
   }
 
   // Try to get a native allocation pointer.


### PR DESCRIPTION
`hrx_buffer_get_device_ptr` only ever tried a host mapping, so it returned `HRX_STATUS_UNAVAILABLE` for any device-local buffer. The comment beside it already said what was missing:

```c
// For local-task (CPU) devices, the device pointer is available via mapping.
// For real GPU devices, this would use iree_hal_buffer_export.
// For now, map the buffer to get a usable pointer.
```

The consequence is that nothing needing a device address is reachable through the C API:

- a peer copy has no source address to name;
- `hsa_amd_agents_allow_access` has no allocation to grant, so device pools stay `DISALLOWED_BY_DEFAULT`;
- a caller wanting `hsa_amd_memory_async_copy` cannot describe either end, and falls back to the HAL's blit kernels.

On an 8x gfx1201 box that last one is the difference between a copy engine and the shader cores: HIP reaches ~48 GB/s H2D and ~56 GB/s D2H on the same link where a blit-kernel copy measures about 8.

This exports the buffer through the owning device's allocator with `IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION` and returns the device pointer. The existing paths are untouched and still tried first, so an already-mapped buffer and a local-task device behave exactly as before, and a failed export falls through to the mapping attempt rather than becoming an error.

Tested on gfx1201 (Radeon AI PRO R9700, ROCm 7.13): device-local buffers now answer with an address, `hsa_amd_memory_async_copy` accepts both ends and completes, and the previous behaviour is unchanged for host-visible buffers.