### PR TITLE
Import a device allocation when the params ask for one

### DIFF
--- a/libhrx/src/libhrx/allocator.c
+++ b/libhrx/src/libhrx/allocator.c
@@ -84,12 +84,27 @@ hrx_status_t hrx_allocator_import_buffer(hrx_allocator_t allocator,
       .queue_affinity = (iree_hal_queue_affinity_t)params.queue_affinity,
   };
 
+  // A device-local request is describing another allocation on this platform,
+  // not a host pointer: that is how a peer's memory is brought into this
+  // allocator so a queue may copy out of it. Importing it as a host allocation
+  // is rejected, and there is no other way to name it through this API.
+  const bool device_allocation =
+      iree_all_bits_set((iree_hal_memory_type_t)params.type,
+                        IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL) &&
+      !iree_any_bit_set((iree_hal_memory_type_t)params.type,
+                        IREE_HAL_MEMORY_TYPE_HOST_VISIBLE);
   iree_hal_external_buffer_t ext = {
-      .type = IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION,
+      .type = device_allocation
+                  ? IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION
+                  : IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION,
       .flags = 0,
       .size = (iree_device_size_t)size,
-      .handle.host_allocation.ptr = host_ptr,
   };
+  if (device_allocation) {
+    ext.handle.device_allocation.ptr = (uint64_t)(uintptr_t)host_ptr;
+  } else {
+    ext.handle.host_allocation.ptr = host_ptr;
+  }
 
   iree_hal_buffer_t* hal_buffer = NULL;
   iree_status_t status = iree_hal_allocator_import_buffer(


### PR DESCRIPTION
`hrx_allocator_import_buffer` always builds a `HOST_ALLOCATION` external buffer:

```c
iree_hal_external_buffer_t ext = {
    .type = IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION,
    ...
    .handle.host_allocation.ptr = host_ptr,
};
```

So a device address cannot be imported at all — the allocator rejects a device pointer described as host memory. That leaves no way to bring one device's memory into another's allocator, which is exactly what a cross-device copy needs: `hrx_queue_copy` / `hrx_stream_copy_buffer` will not accept another device's `hrx_buffer_t`, and passing one faults the GPU rather than returning an error.

When the requested memory type is device-local and not host-visible, the import now describes an `IREE_HAL_EXTERNAL_BUFFER_TYPE_DEVICE_ALLOCATION`. Host imports take the same path they always did.

Paired with #393 (device-pointer export), a peer copy becomes expressible through the C API: get the source's device pointer, import it into the destination's allocator, copy on the destination's queue.

Built and exercised on 8x gfx1201 (Radeon AI PRO R9700, ROCm 7.13).