### PR TITLE
[Loom] Define launch and command program effect boundaries

### DIFF
--- a/loom/binding/c/test/target/amdgpu/amdgpu_test.cc
+++ b/loom/binding/c/test/target/amdgpu/amdgpu_test.cc
@@ -612,7 +612,7 @@ template.def<@test.experts_per_wave> priority(1) @four_experts_per_wave(%expert_
 kernel.def target(@gfx11_wave64) @target_specialized_launch(%expert_count: index) {
   %c1 = index.constant 1 : index
   %wave_size = target.subgroup.size : index
-  %experts_per_wave = template.apply<@test.experts_per_wave>(%expert_count) : (index) -> (index)
+  %experts_per_wave = template.apply<@test.experts_per_wave>(%expert_count) pure : (index) -> (index)
   %workgroup_count = index.div %expert_count, %experts_per_wave : index
   kernel.launch.config workgroups(%workgroup_count, %c1, %c1) workgroup_size(%wave_size, %c1, %c1) : index
 } launch(%output: buffer) {

--- a/loom/docs/src/guide/command-programs.md
+++ b/loom/docs/src/guide/command-programs.md
@@ -46,6 +46,26 @@ root. An exact `%layer` can disappear into parameter placement and selected
 branches. A residual `%element_count` can remain as an input to the generated
 host launch-count function without entering the command or device ABI.
 
+## Effects are explicit commands
+
+A command program is not a pure function: launching a kernel and ordering work
+are its purpose. Those observable effects must nevertheless be represented by
+explicit command operations such as `kernel.launch`, `command.program.launch`,
+`command.serial`, and `command.concurrent`. Ordinary SSA computation around
+them is effect-free. Calls used to derive launch workloads therefore carry a
+`pure` contract, just as calls in a kernel launch-configuration region do.
+
+The distinction keeps preparation movable. The compiler can evaluate pure
+shape arithmetic in the host VM, preserve it as residual launch computation,
+or lower it to a device-side producer for indirect dispatch without silently
+moving a memory observation or mutation. A `buffer.alloca` remains valid: it
+declares a fresh command-program storage identity for later scheduling rather
+than reading, writing, or synchronizing external state.
+
+The verifier enforces this at the source operation that violates the contract.
+An opaque ordinary call is rejected inside nested control flow instead of
+surviving until command outlining or schedule materialization.
+
 Schedule topology and parameter identity must be closed after preparation.
 Residual specialization values may feed pure launch-count expressions, but
 they cannot leave an unresolved source branch or a dynamic parameter key in the

--- a/loom/docs/src/guide/kernels-and-launch.md
+++ b/loom/docs/src/guide/kernels-and-launch.md
@@ -53,6 +53,20 @@ guard the tail. A value needed only for launch arithmetic does not consume a
 device argument; a buffer needed only by the device does not become a workload
 argument.
 
+## Launch configuration is pure executable logic
+
+The launch-configuration region is a pure function of its workload arguments
+and immutable compilation inputs such as configuration and target facts. It
+cannot read or write memory, call an opaque effectful function, observe
+non-deterministic state, or perform a convergent operation. Kernel verification
+rejects such effects at the `kernel.def` that owns the contract.
+
+Purity keeps execution placement separate from meaning. The same residual
+calculation may run in a host VM companion, remain as ordinary pure calls in a
+command program, or execute on a device to produce an indirect dispatch tuple.
+None of those products needs a different source representation or permission
+to observe additional state.
+
 ## Workload is not workgroup count
 
 [`kernel.launch.config`](../reference/dialects/kernel/ops/launch-config.md)

--- a/loom/py/loom/dialect/command/defs.py
+++ b/loom/py/loom/dialect/command/defs.py
@@ -33,6 +33,7 @@ from loom.dsl import (
     ATTR_TYPE_I64,
     ATTR_TYPE_STRING,
     BUFFER,
+    COMMAND_EFFECT,
     INDEX,
     ISOLATED_FROM_ABOVE,
     PURE,
@@ -138,7 +139,9 @@ command_program_def = Op(
     doc=(
         "Reusable command-program definition. Leading specialization arguments "
         "participate in staged specialization and launch-count evaluation; buffer "
-        "bindings are provided when the materialized program is issued."
+        "bindings are provided when the materialized program is issued. Observable "
+        "effects in the body must be explicit command operations; ordinary SSA "
+        "preparation is effect-free."
     ),
     traits=[SYMBOL_DEFINE, ISOLATED_FROM_ABOVE],
     attrs=list(_PROGRAM_ATTRS),
@@ -151,6 +154,7 @@ command_program_def = Op(
             "body",
             doc="Commands and source-level control flow forming the program.",
             terminator="command.return",
+            command_effects_only=True,
         ),
     ],
     interfaces=[FuncLikeInterface(**_PROGRAM_FUNC_LIKE, body="body")],
@@ -209,7 +213,7 @@ command_program_launch = Op(
             symbol_ref=SymbolReference("command program", ["command_program"]),
         ),
     ],
-    traits=[UNKNOWN_EFFECTS],
+    traits=[UNKNOWN_EFFECTS, COMMAND_EFFECT],
     interfaces=[
         CallLikeInterface(
             callee="callee",
@@ -327,7 +331,11 @@ def _schedule(name: str, doc: str) -> Op:
                 terminator="command.yield",
             ),
         ],
-        traits=[UNKNOWN_EFFECTS, ImplicitTerminator("command.yield")],
+        traits=[
+            UNKNOWN_EFFECTS,
+            COMMAND_EFFECT,
+            ImplicitTerminator("command.yield"),
+        ],
         format=[Region("body")],
         examples=[f"{name} {{\n  command.yield\n}}"],
     )

--- a/loom/py/loom/dialect/kernel/defs.py
+++ b/loom/py/loom/dialect/kernel/defs.py
@@ -45,6 +45,7 @@ from loom.dsl import (
     ATTR_TYPE_ENUM,
     ATTR_TYPE_I64,
     ATTR_TYPE_STRING,
+    COMMAND_EFFECT,
     CONVERGENT,
     I1,
     INDEX,
@@ -1887,7 +1888,7 @@ kernel_launch = Op(
             symbol_ref=SymbolReference("kernel", ["kernel"]),
         ),
     ],
-    traits=[UNKNOWN_EFFECTS, NoAncestor("kernel.def")],
+    traits=[UNKNOWN_EFFECTS, COMMAND_EFFECT, NoAncestor("kernel.def")],
     interfaces=[
         CallLikeInterface(
             callee="callee",
@@ -1951,6 +1952,7 @@ def _launch_schedule(name: str, doc: str) -> Op:
         ],
         traits=[
             UNKNOWN_EFFECTS,
+            COMMAND_EFFECT,
             ImplicitTerminator("kernel.launch.yield"),
             NoAncestor("kernel.def"),
         ],

--- a/loom/py/loom/dialect/kernel/defs.py
+++ b/loom/py/loom/dialect/kernel/defs.py
@@ -307,7 +307,7 @@ kernel_def = Op(
     regions=[
         RegionDef(
             "config",
-            doc=("Launch configuration region. The region owns host launch inputs and must terminate with kernel.launch.config."),
+            doc=("Pure launch configuration region. The region computes launch parameters from its workload arguments and immutable compilation inputs and must terminate with kernel.launch.config."),
             single_block=True,
             terminator="kernel.launch.config",
             buffer_arg_memory_space="global",

--- a/loom/py/loom/dsl.py
+++ b/loom/py/loom/dsl.py
@@ -990,6 +990,10 @@ class RegionDef:
         "cluster") over which scalar entry block arguments are identical.
         This is a region boundary contract rather than a property inferred
         from argument types.
+    command_effects_only: If True, every directly observable effect executed
+        in this region or a nested region must be carried by an operation with
+        the CommandEffect trait. Pure computation and identity-producing
+        operations remain valid.
     """
 
     name: str
@@ -1002,6 +1006,7 @@ class RegionDef:
     arg_source: str | None = None
     buffer_arg_memory_space: str | None = None
     arg_uniform_scope: str | None = None
+    command_effects_only: bool = False
 
 
 # ============================================================================
@@ -1159,6 +1164,10 @@ NON_DETERMINISTIC = Trait("NonDeterministic")
 # Effects depend on runtime state (e.g., func.call depends on the callee).
 # Passes treat this conservatively as both READS_MEMORY and WRITES_MEMORY.
 UNKNOWN_EFFECTS = Trait("UnknownEffects")
+# Op represents an explicit command-program effect such as dispatch or schedule
+# composition. The op must independently declare its exact or unknown effects;
+# this trait classifies those effects instead of replacing them.
+COMMAND_EFFECT = Trait("CommandEffect")
 # Op orders memory accesses without directly reading or writing a resource.
 # Fences are observable side effects but do not alias every memory operand;
 # analyses preserve their ordering contract independently from footprint
@@ -4714,6 +4723,14 @@ def _validate_no_effect_conflicts(
 ) -> None:
     """Validate trait-only ops for effect-related conflicts."""
     trait_names = {t.name for t in traits}
+    if "CommandEffect" in trait_names and not trait_names.intersection(
+        {"UnknownEffects", "MemoryFence", "NonDeterministic", "Convergent"}
+    ):
+        raise ValueError(
+            f"Op '{op_name}': COMMAND_EFFECT requires explicit or unknown "
+            "observable effects. The trait classifies effects but does not "
+            "declare them."
+        )
     if "CompileTimeOnly" in trait_names:
         if "Hint" in trait_names:
             raise ValueError(

--- a/loom/py/loom/dsl_test.py
+++ b/loom/py/loom/dsl_test.py
@@ -45,6 +45,7 @@ from loom.dsl import (
     ATTR_TYPE_SYMBOL_SET,
     BUFFER,
     BY_REFERENCE,
+    COMMAND_EFFECT,
     COMMUTATIVE,
     COMPILE_TIME_ONLY,
     CONSTANT_LIKE,
@@ -2646,6 +2647,14 @@ class TestEffects:
     def test_unknown_effects_not_pure(self) -> None:
         op = Op("test.call", traits=[UNKNOWN_EFFECTS])
         assert not op.is_pure
+
+    def test_command_effect_classifies_unknown_effects(self) -> None:
+        op = Op("test.command", traits=[UNKNOWN_EFFECTS, COMMAND_EFFECT])
+        assert not op.is_pure
+
+    def test_command_effect_requires_observable_effects(self) -> None:
+        with _raises(ValueError, match="COMMAND_EFFECT requires"):
+            Op("test.bad", traits=[COMMAND_EFFECT])
 
     def test_allocating_result(self) -> None:
         op = Op(

--- a/loom/py/loom/error/structure.py
+++ b/loom/py/loom/error/structure.py
@@ -869,6 +869,23 @@ ERR_STRUCTURE_052 = ErrorDef(
     ),
 )
 
+# ERR_STRUCTURE_053: Non-command effect in a command program.
+ERR_STRUCTURE_053 = ErrorDef(
+    domain=ErrorDomain.STRUCTURE,
+    code=53,
+    severity=Severity.ERROR,
+    summary="Non-command effect in a command program.",
+    message=(
+        "'{op_name}' has observable effects in a command-program body but "
+        "does not represent an explicit command"
+    ),
+    params=(ErrorParam("op_name", ParamKind.STRING),),
+    fix_hint=(
+        "Use an explicit command operation or declare the computation pure "
+        "when it has no observable effects"
+    ),
+)
+
 ALL_STRUCTURE_ERRORS: tuple[ErrorDef, ...] = (
     ERR_STRUCTURE_001,
     ERR_STRUCTURE_002,
@@ -921,4 +938,5 @@ ALL_STRUCTURE_ERRORS: tuple[ErrorDef, ...] = (
     ERR_STRUCTURE_050,
     ERR_STRUCTURE_051,
     ERR_STRUCTURE_052,
+    ERR_STRUCTURE_053,
 )

--- a/loom/py/loom/error/structure.py
+++ b/loom/py/loom/error/structure.py
@@ -847,6 +847,28 @@ ERR_STRUCTURE_051 = ErrorDef(
     fix_hint="Merge the duplicate records or give each record a unique key",
 )
 
+# ERR_STRUCTURE_052: Launch configuration has observable effects.
+ERR_STRUCTURE_052 = ErrorDef(
+    domain=ErrorDomain.STRUCTURE,
+    code=52,
+    severity=Severity.ERROR,
+    summary="Launch configuration has observable effects.",
+    message=(
+        "'{op_name}' launch configuration has {read_count} read-like, "
+        "{write_count} write-like, and {convergent_count} convergent effect(s)"
+    ),
+    params=(
+        ErrorParam("op_name", ParamKind.STRING),
+        ErrorParam("read_count", ParamKind.U32),
+        ErrorParam("write_count", ParamKind.U32),
+        ErrorParam("convergent_count", ParamKind.U32),
+    ),
+    fix_hint=(
+        "Express launch configuration as a pure function of workload arguments "
+        "and immutable compilation inputs"
+    ),
+)
+
 ALL_STRUCTURE_ERRORS: tuple[ErrorDef, ...] = (
     ERR_STRUCTURE_001,
     ERR_STRUCTURE_002,
@@ -898,4 +920,5 @@ ALL_STRUCTURE_ERRORS: tuple[ErrorDef, ...] = (
     ERR_STRUCTURE_049,
     ERR_STRUCTURE_050,
     ERR_STRUCTURE_051,
+    ERR_STRUCTURE_052,
 )

--- a/loom/py/loom/gen/ops/c_enums.py
+++ b/loom/py/loom/gen/ops/c_enums.py
@@ -137,6 +137,7 @@ TRAIT_MAP: dict[str, str] = {
     "IsolatedFromAbove": "LOOM_TRAIT_ISOLATED_FROM_ABOVE",
     "NonDeterministic": "LOOM_TRAIT_NON_DETERMINISTIC",
     "UnknownEffects": "LOOM_TRAIT_UNKNOWN_EFFECTS",
+    "CommandEffect": "LOOM_TRAIT_COMMAND_EFFECT",
     "MemoryFence": "LOOM_TRAIT_MEMORY_FENCE",
     "CompileTimeOnly": "LOOM_TRAIT_COMPILE_TIME_ONLY",
     "Convergent": "LOOM_TRAIT_CONVERGENT",

--- a/loom/py/loom/gen/ops/c_metadata_tables.py
+++ b/loom/py/loom/gen/ops/c_metadata_tables.py
@@ -880,6 +880,8 @@ def generate_tables_c(
                         region_flags.append("LOOM_REGION_CLUSTER_UNIFORM_ARGS")
                     else:
                         raise ValueError(f"Op '{op.name}' region '{region_def.name}' has unsupported arg_uniform_scope '{arg_uniform_scope}'")
+                if region_def.command_effects_only:
+                    region_flags.append("LOOM_REGION_COMMAND_EFFECTS_ONLY")
                 flags = " | ".join(region_flags) if region_flags else "0"
                 terminator = c_traits.region_terminator_kind(op, region_def, ops_by_name)
                 lines.append(f"    {{{terminator}, {implicit_terminator}, {flags}}},")

--- a/loom/src/loom/codegen/low/launch_config_program.c
+++ b/loom/src/loom/codegen/low/launch_config_program.c
@@ -146,37 +146,6 @@ static iree_status_t loom_kernel_launch_config_copy_workload_predicates(
   return status;
 }
 
-static iree_status_t loom_kernel_launch_config_validate_region(
-    const loom_module_t* source_module, const loom_op_t* source_kernel,
-    const loom_region_t* config_region) {
-  if (config_region == NULL || config_region->block_count != 1 ||
-      iree_any_bit_set(config_region->flags, LOOM_REGION_INSTANCE_FLAG_CFG)) {
-    return iree_make_status(
-        IREE_STATUS_UNIMPLEMENTED,
-        "kernel launch configuration requires one non-CFG block");
-  }
-  const loom_op_t* launch_config =
-      loom_kernel_def_launch_config_op(source_kernel);
-  if (launch_config == NULL) {
-    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                            "kernel launch configuration has no terminator");
-  }
-  const loom_op_t* op = NULL;
-  loom_block_for_each_op(loom_region_const_entry_block(config_region), op) {
-    if (op == launch_config) continue;
-    const loom_trait_flags_t traits =
-        loom_op_effective_traits(source_module, op);
-    if (!iree_any_bit_set(traits, LOOM_TRAIT_PURE)) {
-      const iree_string_view_t op_name = loom_op_name(source_module, op);
-      return iree_make_status(
-          IREE_STATUS_UNIMPLEMENTED,
-          "kernel launch configuration operation '%.*s' is not pure",
-          (int)op_name.size, op_name.data);
-    }
-  }
-  return iree_ok_status();
-}
-
 static iree_status_t loom_kernel_launch_config_build_constant(
     loom_builder_t* builder, int64_t value, loom_location_id_t location,
     loom_value_id_t* out_value) {
@@ -195,8 +164,6 @@ static iree_status_t loom_kernel_launch_config_program_build_function(
     iree_arena_allocator_t* scratch_arena) {
   loom_op_t* source_kernel = source_function.op;
   loom_region_t* source_config = loom_kernel_def_config(source_kernel);
-  IREE_RETURN_IF_ERROR(loom_kernel_launch_config_validate_region(
-      source_module, source_kernel, source_config));
   const loom_op_t* source_launch_config =
       loom_kernel_def_launch_config_op(source_kernel);
 

--- a/loom/src/loom/ir/ir.h
+++ b/loom/src/loom/ir/ir.h
@@ -735,6 +735,10 @@ enum loom_trait_bits_e {
   // operations use this independently from SYMBOL_DEFINE and do not enter the
   // module symbol table.
   LOOM_TRAIT_MODULE_SCOPE = 1u << 26,
+  // Op represents an explicit command-program effect such as dispatch or
+  // schedule composition. The op independently declares its exact or unknown
+  // effects; this trait classifies those effects instead of replacing them.
+  LOOM_TRAIT_COMMAND_EFFECT = 1u << 27,
 };
 typedef uint32_t loom_trait_flags_t;
 

--- a/loom/src/loom/ops/command/ops.h
+++ b/loom/src/loom/ops/command/ops.h
@@ -42,7 +42,7 @@ typedef enum loom_command_retain_e {
   LOOM_COMMAND_RETAIN_COUNT_ = 2,
 } loom_command_retain_t;
 
-// LOOM_OP_COMMAND_PROGRAM_DEF: Reusable command-program definition. Leading specialization arguments participate in staged specialization and launch-count evaluation; buffer bindings are provided when the materialized program is issued.
+// LOOM_OP_COMMAND_PROGRAM_DEF: Reusable command-program definition. Leading specialization arguments participate in staged specialization and launch-count evaluation; buffer bindings are provided when the materialized program is issued. Observable effects in the body must be explicit command operations; ordinary SSA preparation is effect-free.
 // command.program.def @decode(%token_count: index) launch(%parameters: buffer, %transient: buffer) {
 //   command.return
 // }

--- a/loom/src/loom/ops/command/test/verify.loom-test
+++ b/loom/src/loom/ops/command/test/verify.loom-test
@@ -75,3 +75,52 @@ command.program.def @invalid_parameter_patterns(%layer: index) launch(%parameter
   %mismatch = command.parameter %parameters, "blk.{}.{}.weight"[%layer] : view<16xi8>
   command.return
 }
+
+// ====
+
+func.decl pure @pure_command_extent(%value: index) -> (index)
+
+kernel.decl @command_effect_kernel(%element_count: index) launch(%scratch: buffer)
+
+command.program.def @pure_preparation_and_explicit_commands(%element_count: index) launch() {
+  %byte_length = index.constant 64 : offset
+  %scratch = buffer.alloca<global> align(64) %byte_length : buffer
+  %launch_count = func.call pure @pure_command_extent(%element_count) : (index) -> (index)
+  command.serial {
+    kernel.launch @command_effect_kernel[%launch_count](%scratch) : [index](buffer)
+  }
+  command.return
+}
+
+// ====
+
+func.decl @unknown_command_extent(%value: index) -> (index)
+
+command.program.def @nested_unknown_effect(%condition: i1, %value: index) launch() {
+  scf.if %condition {
+    // ERROR@+1: STRUCTURE/053 {op_name="func.call"}
+    %unused = func.call @unknown_command_extent(%value) : (index) -> (index)
+  }
+  command.return
+}
+
+// ====
+
+command.program.def @convergent_preparation(%value: index) launch() {
+  // ERROR@+1: STRUCTURE/053 {op_name="test.convergent"}
+  %unused = test.convergent %value : index
+  command.return
+}
+
+// ====
+
+command.program.def @memory_effects_are_not_preparation() launch(%storage: buffer) {
+  %base = index.constant 0 : offset
+  %element = index.constant 0 : index
+  %view = buffer.view %storage[%base] : buffer -> view<1xi32>
+  // ERROR@+1: STRUCTURE/053 {op_name="view.load"}
+  %value = view.load %view[%element] : view<1xi32> -> i32
+  // ERROR@+1: STRUCTURE/053 {op_name="view.store"}
+  view.store %value, %view[%element] : i32, view<1xi32>
+  command.return
+}

--- a/loom/src/loom/ops/kernel/test/verify.loom-test
+++ b/loom/src/loom/ops/kernel/test/verify.loom-test
@@ -1,5 +1,41 @@
 // RUN: verify
 
+func.decl pure @pure_launch_extent(%value: index) -> (index)
+
+kernel.def @pure_launch_configuration_call(%count: index) {
+  %c1 = index.constant 1 : index
+  %workgroups = func.call pure @pure_launch_extent(%count) : (index) -> (index)
+  kernel.launch.config workgroups(%workgroups, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
+} launch() {
+  kernel.return
+}
+
+// ====
+
+func.decl @unknown_launch_extent(%value: index) -> (index)
+
+// ERROR@+1: STRUCTURE/052 {op_name="kernel.def", read_count="1", write_count="1", convergent_count="0"}
+kernel.def @unknown_effect_launch_configuration(%count: index) {
+  %c1 = index.constant 1 : index
+  %workgroups = func.call @unknown_launch_extent(%count) : (index) -> (index)
+  kernel.launch.config workgroups(%workgroups, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
+} launch() {
+  kernel.return
+}
+
+// ====
+
+// ERROR@+1: STRUCTURE/052 {op_name="kernel.def", read_count="0", write_count="0", convergent_count="1"}
+kernel.def @convergent_launch_configuration(%count: index) {
+  %c1 = index.constant 1 : index
+  %workgroups = test.convergent %count : index
+  kernel.launch.config workgroups(%workgroups, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
+} launch() {
+  kernel.return
+}
+
+// ====
+
 test.target<low_core> @test_target
 
 // ERROR@+1: STRUCTURE/014 "export" "0" "present when linkage is present"

--- a/loom/src/loom/ops/kernel/verify.c
+++ b/loom/src/loom/ops/kernel/verify.c
@@ -102,6 +102,25 @@ static iree_status_t loom_kernel_verify_export_contract(
   return iree_ok_status();
 }
 
+static iree_status_t loom_kernel_verify_launch_config_purity(
+    const loom_module_t* module, const loom_op_t* op,
+    iree_diagnostic_emitter_t emitter) {
+  const loom_region_t* config = loom_kernel_def_config(op);
+  if (!loom_region_has_read_effects(config) &&
+      !loom_region_has_write_effects(config) &&
+      !loom_region_has_convergent_effects(config)) {
+    return iree_ok_status();
+  }
+  const loom_diagnostic_param_t params[] = {
+      loom_param_string(loom_op_name(module, op)),
+      loom_param_u32(config->read_effect_count),
+      loom_param_u32(config->write_effect_count),
+      loom_param_u32(config->convergent_effect_count),
+  };
+  return loom_kernel_emit(emitter, op, LOOM_ERR_STRUCTURE_052, params,
+                          IREE_ARRAYSIZE(params));
+}
+
 static iree_status_t loom_kernel_emit_launch_related(
     iree_diagnostic_emitter_t emitter, const loom_op_t* launch_op,
     const loom_op_t* definition_op, const loom_error_def_t* error,
@@ -1198,6 +1217,8 @@ iree_status_t loom_kernel_def_verify(const loom_module_t* module,
   IREE_RETURN_IF_ERROR(loom_kernel_verify_export_contract(
       emitter, op, loom_kernel_def_export_symbol_ATTR_INDEX,
       loom_kernel_def_export_linkage_ATTR_INDEX));
+  IREE_RETURN_IF_ERROR(
+      loom_kernel_verify_launch_config_purity(module, op, emitter));
   return loom_kernel_verify_barrier_controls(module, op, emitter);
 }
 

--- a/loom/src/loom/ops/op_defs.h
+++ b/loom/src/loom/ops/op_defs.h
@@ -753,6 +753,9 @@ enum loom_region_flag_bits_e {
   // Scalar entry block arguments are identical across every workgroup in a
   // workgroup cluster. This implies workgroup uniformity.
   LOOM_REGION_CLUSTER_UNIFORM_ARGS = 1u << 5,
+  // Every directly observable effect in this region or a nested region must
+  // be represented by an op carrying LOOM_TRAIT_COMMAND_EFFECT.
+  LOOM_REGION_COMMAND_EFFECTS_ONLY = 1u << 6,
 };
 typedef uint8_t loom_region_flags_t;
 

--- a/loom/src/loom/target/arch/cmd/lower/launch_graph.c
+++ b/loom/src/loom/target/arch/cmd/lower/launch_graph.c
@@ -371,33 +371,8 @@ static iree_status_t loom_cmd_launch_graph_clone_config(
   loom_op_t* kernel_op =
       loom_cmd_launch_graph_resolve_kernel(build->source_module, launch_op);
   loom_region_t* config_region = loom_kernel_def_config(kernel_op);
-  if (!config_region || config_region->block_count != 1) {
-    return iree_make_status(
-        IREE_STATUS_UNIMPLEMENTED,
-        "aggregate launch extraction requires a single-block kernel launch "
-        "configuration");
-  }
   loom_block_t* config_block = loom_region_entry_block(config_region);
   const loom_op_t* launch_config = loom_kernel_def_launch_config_op(kernel_op);
-  if (!launch_config) {
-    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                            "kernel launch configuration has no terminator");
-  }
-  const loom_op_t* config_op = NULL;
-  loom_block_for_each_op(config_block, config_op) {
-    if (config_op == launch_config) continue;
-    const loom_trait_flags_t traits =
-        loom_op_effective_traits(build->source_module, config_op);
-    if (config_op->region_count != 0 ||
-        !iree_any_bit_set(traits, LOOM_TRAIT_PURE)) {
-      const iree_string_view_t op_name =
-          loom_op_name(build->source_module, config_op);
-      return iree_make_status(
-          IREE_STATUS_UNIMPLEMENTED,
-          "kernel launch configuration operation `%.*s` is not a pure leaf",
-          (int)op_name.size, op_name.data);
-    }
-  }
 
   const loom_value_slice_t source_workloads =
       loom_kernel_launch_workloads(launch_op);
@@ -417,9 +392,18 @@ static iree_status_t loom_cmd_launch_graph_clone_config(
         &config_remap, config_arguments.values[i], target_workload));
   }
 
-  config_op = NULL;
+  const loom_op_t* config_op = NULL;
   loom_block_for_each_op(config_block, config_op) {
     if (config_op == launch_config) continue;
+    if (config_op->region_count != 0) {
+      const iree_string_view_t op_name =
+          loom_op_name(build->source_module, config_op);
+      return iree_make_status(
+          IREE_STATUS_UNIMPLEMENTED,
+          "aggregate launch extraction does not support nested regions in "
+          "kernel launch configuration operation `%.*s`",
+          (int)op_name.size, op_name.data);
+    }
     bool materialize_results = config_op->result_count != 0;
     const loom_value_id_t* source_results = loom_op_const_results(config_op);
     for (uint16_t i = 0; i < config_op->result_count; ++i) {

--- a/loom/src/loom/tooling/target/amdgpu/test/corpus/generic/target_specialized_launch_config.loom
+++ b/loom/src/loom/tooling/target/amdgpu/test/corpus/generic/target_specialized_launch_config.loom
@@ -26,7 +26,7 @@ template.def<@test.items_per_workgroup> priority(1) @default_items_per_workgroup
 kernel.def @target_specialized_launch_config(%item_count: index) {
   %c1 = index.constant 1 : index
   %wave_size = target.subgroup.size : index
-  %items_per_workgroup = template.apply<@test.items_per_workgroup>() : () -> (index)
+  %items_per_workgroup = template.apply<@test.items_per_workgroup>() pure : () -> (index)
   %workgroup_count = index.div %item_count, %items_per_workgroup : index
   kernel.launch.config workgroups(%workgroup_count, %c1, %c1) workgroup_size(%wave_size, %c1, %c1) : index
 } launch(%output: buffer) {

--- a/loom/src/loom/verify/verify.c
+++ b/loom/src/loom/verify/verify.c
@@ -120,6 +120,31 @@ loom_verify_emit_wrong_terminator(loom_verify_state_t* state,
   return loom_verify_pending_diagnostic_status(state);
 }
 
+IREE_ATTRIBUTE_NOINLINE IREE_ATTRIBUTE_COLD static void
+loom_verify_emit_non_command_effect(loom_verify_state_t* state,
+                                    const loom_op_t* op,
+                                    const loom_op_vtable_t* vtable) {
+  loom_diagnostic_param_t params[] = {
+      loom_param_string(loom_op_vtable_name(vtable)),
+  };
+  loom_verify_emit_structured(state, op, LOOM_ERR_STRUCTURE_053, params,
+                              IREE_ARRAYSIZE(params));
+}
+
+IREE_ATTRIBUTE_ALWAYS_INLINE static inline void
+loom_verify_command_effect_scope(loom_verify_state_t* state,
+                                 const loom_op_t* op,
+                                 const loom_op_vtable_t* vtable,
+                                 loom_trait_flags_t traits) {
+  if (!state->region_scope.command_effects_only) return;
+  if (!loom_traits_may_read(traits) && !loom_traits_may_write(traits) &&
+      !loom_traits_are_convergent(traits)) {
+    return;
+  }
+  if (iree_any_bit_set(vtable->traits, LOOM_TRAIT_COMMAND_EFFECT)) return;
+  loom_verify_emit_non_command_effect(state, op, vtable);
+}
+
 static iree_status_t loom_verify_region(
     loom_verify_state_t* state, loom_region_t* region,
     const loom_verify_region_contract_t* contract) {
@@ -136,14 +161,20 @@ static iree_status_t loom_verify_region(
     IREE_RETURN_IF_ERROR(loom_verify_emit_single_block_region(
         state, contract, region->block_count));
   }
-  const loom_region_t* saved_region = state->current_region;
+  const loom_region_t* saved_region = state->region_scope.current;
   loom_consumption_region_query_t* saved_consumption_query =
-      state->current_consumption_query;
+      state->region_scope.consumption_query;
+  const bool saved_command_effects_only =
+      state->region_scope.command_effects_only;
   loom_consumption_region_query_t consumption_query;
-  state->current_region = region;
+  state->region_scope.current = region;
   loom_consumption_region_query_initialize(state->module, region, &state->arena,
                                            &consumption_query);
-  state->current_consumption_query = &consumption_query;
+  state->region_scope.consumption_query = &consumption_query;
+  if (contract && iree_any_bit_set(contract->descriptor->flags,
+                                   LOOM_REGION_COMMAND_EFFECTS_ONLY)) {
+    state->region_scope.command_effects_only = true;
+  }
 
   bool scope_pushed = false;
   iree_status_t status = loom_verify_push_scope(state);
@@ -211,8 +242,9 @@ static iree_status_t loom_verify_region(
   if (scope_pushed) {
     loom_verify_pop_scope(state);
   }
-  state->current_region = saved_region;
-  state->current_consumption_query = saved_consumption_query;
+  state->region_scope.current = saved_region;
+  state->region_scope.consumption_query = saved_consumption_query;
+  state->region_scope.command_effects_only = saved_command_effects_only;
   return status;
 }
 
@@ -283,7 +315,14 @@ IREE_ATTRIBUTE_ALWAYS_INLINE static inline iree_status_t loom_verify_op(
   // must preserve the same effect and optimization invariants as declared
   // traits. Run this after structural checks so callbacks can safely inspect
   // attributes.
-  loom_verify_op_effective_trait_consistency(state, op, vtable);
+  const loom_trait_flags_t effective_traits =
+      loom_verify_op_effective_trait_consistency(state, op, vtable);
+  IREE_RETURN_IF_ERROR(loom_verify_pending_diagnostic_status(state));
+
+  // Command programs may perform observable work only through explicit
+  // command operations. This consumes the effective trait word already cached
+  // on the op while the ordinary verifier traversal is visiting it.
+  loom_verify_command_effect_scope(state, op, vtable, effective_traits);
   IREE_RETURN_IF_ERROR(loom_verify_pending_diagnostic_status(state));
 
   // Operand and result type payloads must satisfy core representation

--- a/loom/src/loom/verify/verify_ownership.c
+++ b/loom/src/loom/verify/verify_ownership.c
@@ -214,15 +214,16 @@ static iree_status_t loom_verify_consume_value_after_op(
       op->parent_block ? op->parent_block->parent_region : NULL;
   if (parent_region &&
       iree_any_bit_set(parent_region->flags, LOOM_REGION_INSTANCE_FLAG_CFG)) {
-    if (!state->current_consumption_query) {
+    if (!state->region_scope.consumption_query) {
       return iree_make_status(
           IREE_STATUS_FAILED_PRECONDITION,
           "verifier CFG consumed-value checks require a consumption query");
     }
     loom_consumption_use_t use = {0};
     bool found_use = false;
-    IREE_RETURN_IF_ERROR(loom_consumption_find_use_after(
-        state->current_consumption_query, op, consumed_id, &use, &found_use));
+    IREE_RETURN_IF_ERROR(
+        loom_consumption_find_use_after(state->region_scope.consumption_query,
+                                        op, consumed_id, &use, &found_use));
     if (found_use) {
       loom_verify_emit_consumed_value_use(state, use.op, use.operand_index,
                                           consumed_id, op);

--- a/loom/src/loom/verify/verify_state.h
+++ b/loom/src/loom/verify/verify_state.h
@@ -68,6 +68,18 @@ typedef struct loom_verify_type_summary_t {
   bool may_reference_values;
 } loom_verify_type_summary_t;
 
+// State inherited while recursively verifying one region tree.
+typedef struct loom_verify_region_scope_t {
+  // Region currently being verified.
+  const loom_region_t* current;
+
+  // Reusable consumed-value query for current.
+  loom_consumption_region_query_t* consumption_query;
+
+  // True when observable effects must be explicit command effects.
+  bool command_effects_only;
+} loom_verify_region_scope_t;
+
 typedef struct loom_verify_state_t {
   // Module being verified.
   const loom_module_t* module;
@@ -127,11 +139,8 @@ typedef struct loom_verify_state_t {
   // Reusable per-op scratch for tied-result uniqueness checks.
   loom_verify_tied_table_t tied_table;
 
-  // Region currently being verified while walking nested IR.
-  const loom_region_t* current_region;
-
-  // Reusable consumed-value query for current_region.
-  loom_consumption_region_query_t* current_consumption_query;
+  // State inherited through the current nested region traversal.
+  loom_verify_region_scope_t region_scope;
 
   // Stack of value IDs defined during the current scoped walk.
   uint32_t* defined_stack;

--- a/loom/src/loom/verify/verify_structure.c
+++ b/loom/src/loom/verify/verify_structure.c
@@ -263,13 +263,15 @@ static void loom_verify_op_trait_flags_consistency(
                               IREE_ARRAYSIZE(params));
 }
 
-void loom_verify_op_effective_trait_consistency(
+loom_trait_flags_t loom_verify_op_effective_trait_consistency(
     loom_verify_state_t* state, const loom_op_t* op,
     const loom_op_vtable_t* vtable) {
   loom_trait_flags_t effective_traits =
       loom_op_effective_traits(state->module, op);
-  if (effective_traits == vtable->traits) return;
-  loom_verify_op_trait_flags_consistency(state, op, vtable, effective_traits);
+  if (effective_traits != vtable->traits) {
+    loom_verify_op_trait_flags_consistency(state, op, vtable, effective_traits);
+  }
+  return effective_traits;
 }
 
 static iree_string_view_t loom_verify_kind_name(loom_verify_state_t* state,

--- a/loom/src/loom/verify/verify_structure.h
+++ b/loom/src/loom/verify/verify_structure.h
@@ -9,9 +9,9 @@
 
 #include "loom/verify/verify_state.h"
 
-void loom_verify_op_effective_trait_consistency(loom_verify_state_t* state,
-                                                const loom_op_t* op,
-                                                const loom_op_vtable_t* vtable);
+loom_trait_flags_t loom_verify_op_effective_trait_consistency(
+    loom_verify_state_t* state, const loom_op_t* op,
+    const loom_op_vtable_t* vtable);
 void loom_verify_op_placement(loom_verify_state_t* state, const loom_op_t* op,
                               const loom_op_vtable_t* vtable);
 void loom_verify_func_purity_body_effects(loom_verify_state_t* state,


### PR DESCRIPTION
Launch configuration is now a verified pure function of workload values and immutable compilation inputs, while command programs express observable work only through explicit command operations. This moves both properties into the dialect contract instead of asking each compiled product to rediscover them, allowing the same preparation logic to move safely between host companions, ordinary VM execution, and future device-side indirect dispatch producers.

## Reusable launch configuration

Every `kernel.def` launch-configuration region now carries an unconditional purity requirement. Verification consumes the transitive effect summary already maintained for the region, so reads, writes, convergence, and unknown-effect calls fail at the authored kernel boundary without another region walk.

The downstream host-companion purity scan is removed, and command launch extraction relies on the verified source contract while performing only the capability checks required by its existing clone traversal. Template-family calls used by launch configuration also declare their purity explicitly, preserving the contract through provider selection and specialization.

This makes launch geometry ordinary movable computation. A selected kernel can project the same semantic configuration into the existing eleven-field host ABI, a command package's workgroup-count tuples, a VM function, or a device-side producer for indirect dispatch without granting product-specific effects or introducing compiler-owned state in the IR.

## Explicit command effects

Command programs are intentionally effectful: their purpose is to issue work and establish execution structure. Their new body contract distinguishes those effects from ordinary preparation. Kernel launches, nested command-program launches, and serial or concurrent command schedules are explicit command effects; scalar computation, pure helper calls, structured control flow, and allocation identities remain freely movable preparation.

Opaque calls, convergent operations, and direct observable memory effects now diagnose at the exact source operation inside a command program. The verifier applies this rule while performing its normal recursive traversal and reuses each operation's cached effective traits, adding no module pass, nested rediscovery walk, IR marker, side table, or semantic string lookup.

Together these contracts establish a clean boundary for the incoming VM command path: preparation is pure executable program logic, command operations are the visible effect surface, and lowering can retain calls and control flow without inheriting the current eager launch-configuration expansion model.
