### PR TITLE
[HAL/Vulkan] Route byte transfers across queue families

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/allocator.c
+++ b/runtime/src/iree/hal/drivers/vulkan/allocator.c
@@ -13,6 +13,7 @@
 #include "iree/base/threading/mutex.h"
 #include "iree/hal/drivers/vulkan/atomic.h"
 #include "iree/hal/drivers/vulkan/buffer.h"
+#include "iree/hal/drivers/vulkan/device_plan.h"
 #include "iree/hal/drivers/vulkan/queue.h"
 #include "iree/hal/drivers/vulkan/slab_provider.h"
 #include "iree/hal/drivers/vulkan/sparse_buffer.h"
@@ -148,6 +149,13 @@ struct iree_hal_vulkan_allocator_t {
   // Queue affinity bits supported by this logical device.
   iree_hal_queue_affinity_t queue_affinity_mask;
 
+  // Number of initialized queue_families entries.
+  iree_host_size_t queue_family_count;
+
+  // Vulkan queue families addressable through HAL queue affinities.
+  iree_hal_vulkan_allocator_queue_family_t
+      queue_families[IREE_HAL_VULKAN_MAX_QUEUE_LANES];
+
   // Internal queue lane used to perform sparse memory binding. Borrowed.
   iree_hal_vulkan_queue_t* sparse_binding_queue;
 
@@ -220,6 +228,8 @@ iree_status_t iree_hal_vulkan_allocator_create(
     iree_hal_vulkan_features_t enabled_features,
     iree_hal_vulkan_device_extensions_t enabled_extensions,
     iree_hal_queue_affinity_t queue_affinity_mask,
+    iree_host_size_t queue_family_count,
+    const iree_hal_vulkan_allocator_queue_family_t* queue_families,
     iree_hal_vulkan_queue_t* sparse_binding_queue,
     iree_async_proactor_t* proactor, iree_allocator_t host_allocator,
     iree_hal_allocator_t** out_allocator) {
@@ -227,9 +237,64 @@ iree_status_t iree_hal_vulkan_allocator_create(
   IREE_ASSERT_ARGUMENT(syms);
   IREE_ASSERT_ARGUMENT(logical_device);
   IREE_ASSERT_ARGUMENT(physical_device);
+  IREE_ASSERT_ARGUMENT(queue_families);
   IREE_ASSERT_ARGUMENT(proactor);
   IREE_ASSERT_ARGUMENT(out_allocator);
   *out_allocator = NULL;
+  if (queue_family_count == 0 ||
+      queue_family_count > IREE_HAL_VULKAN_MAX_QUEUE_LANES) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "Vulkan allocator queue family mapping count %" PRIhsz
+        " is outside the supported range [1, %d]",
+        queue_family_count, IREE_HAL_VULKAN_MAX_QUEUE_LANES);
+  }
+  iree_hal_queue_affinity_t mapped_queue_affinity = 0;
+  for (iree_host_size_t i = 0; i < queue_family_count; ++i) {
+    const iree_hal_vulkan_allocator_queue_family_t* queue_family =
+        &queue_families[i];
+    if (iree_hal_queue_affinity_count(queue_family->queue_affinity) != 1) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "Vulkan allocator queue family mapping %" PRIhsz
+                              " must select exactly one HAL queue affinity bit",
+                              i);
+    }
+    if ((queue_family->queue_affinity & queue_affinity_mask) !=
+        queue_family->queue_affinity) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "Vulkan allocator queue family mapping %" PRIhsz
+                              " selects affinity 0x%016" PRIx64
+                              " outside the device mask 0x%016" PRIx64,
+                              i, queue_family->queue_affinity,
+                              queue_affinity_mask);
+    }
+    if (queue_family->family_index >= physical_device->queue_family_count) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "Vulkan allocator queue family mapping %" PRIhsz
+          " selects family %u but the physical device exposes %u families",
+          i, queue_family->family_index, physical_device->queue_family_count);
+    }
+    for (iree_host_size_t j = 0; j < i; ++j) {
+      if (queue_families[j].queue_affinity == queue_family->queue_affinity &&
+          queue_families[j].family_index != queue_family->family_index) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "Vulkan allocator queue affinity 0x%016" PRIx64
+                                " maps to conflicting families %u and %u",
+                                queue_family->queue_affinity,
+                                queue_families[j].family_index,
+                                queue_family->family_index);
+      }
+    }
+    mapped_queue_affinity |= queue_family->queue_affinity;
+  }
+  if (mapped_queue_affinity != queue_affinity_mask) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "Vulkan allocator queue family mappings cover affinity 0x%016" PRIx64
+        " but the device exposes 0x%016" PRIx64,
+        mapped_queue_affinity, queue_affinity_mask);
+  }
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_hal_vulkan_allocator_t* allocator = NULL;
@@ -254,6 +319,9 @@ iree_status_t iree_hal_vulkan_allocator_create(
   allocator->enabled_features = enabled_features;
   allocator->enabled_extensions = enabled_extensions;
   allocator->queue_affinity_mask = queue_affinity_mask;
+  allocator->queue_family_count = queue_family_count;
+  memcpy(allocator->queue_families, queue_families,
+         queue_family_count * sizeof(queue_families[0]));
   allocator->sparse_binding_queue = sparse_binding_queue;
   iree_slim_mutex_initialize(&allocator->virtual_memory_mutex);
 
@@ -1197,13 +1265,49 @@ static iree_status_t iree_hal_vulkan_allocator_create_buffer_handle(
     VkBuffer* out_buffer) {
   *out_buffer = VK_NULL_HANDLE;
 
+  iree_hal_queue_affinity_t queue_affinity =
+      iree_hal_queue_affinity_is_any(params->queue_affinity)
+          ? allocator->queue_affinity_mask
+          : params->queue_affinity;
+  iree_hal_queue_affinity_and_into(queue_affinity,
+                                   allocator->queue_affinity_mask);
+  uint32_t queue_family_indices[IREE_HAL_VULKAN_MAX_QUEUE_LANES] = {0};
+  uint32_t queue_family_index_count = 0;
+  for (iree_host_size_t i = 0; i < allocator->queue_family_count; ++i) {
+    const iree_hal_vulkan_allocator_queue_family_t* queue_family =
+        &allocator->queue_families[i];
+    if (!iree_any_bit_set(queue_affinity, queue_family->queue_affinity)) {
+      continue;
+    }
+    bool is_duplicate = false;
+    for (uint32_t j = 0; j < queue_family_index_count; ++j) {
+      if (queue_family_indices[j] == queue_family->family_index) {
+        is_duplicate = true;
+        break;
+      }
+    }
+    if (!is_duplicate) {
+      queue_family_indices[queue_family_index_count++] =
+          queue_family->family_index;
+    }
+  }
+  if (queue_family_index_count == 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "Vulkan buffer has no accessible queue family");
+  }
+
   VkBufferCreateInfo create_info = {
       .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
       .pNext = create_info_pnext,
       .flags = create_flags,
       .size = (VkDeviceSize)allocation_size,
       .usage = iree_hal_vulkan_buffer_usage_from_hal(allocator, params->usage),
-      .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+      .sharingMode = queue_family_index_count > 1 ? VK_SHARING_MODE_CONCURRENT
+                                                  : VK_SHARING_MODE_EXCLUSIVE,
+      .queueFamilyIndexCount =
+          queue_family_index_count > 1 ? queue_family_index_count : 0,
+      .pQueueFamilyIndices =
+          queue_family_index_count > 1 ? queue_family_indices : NULL,
   };
   return iree_vkCreateBuffer(IREE_VULKAN_DEVICE(&allocator->syms),
                              allocator->logical_device, &create_info,
@@ -2026,11 +2130,12 @@ static iree_status_t iree_hal_vulkan_allocator_import_buffer(
   iree_hal_buffer_params_t compat_params = *params;
   iree_hal_vulkan_allocator_normalize_host_allocation_import_params(
       &compat_params);
+  iree_hal_buffer_params_t query_params = compat_params;
   iree_hal_buffer_compatibility_t compatibility =
       IREE_HAL_BUFFER_COMPATIBILITY_NONE;
   if (iree_status_is_ok(status)) {
     compatibility = iree_hal_vulkan_allocator_query_buffer_compatibility(
-        base_allocator, &compat_params, &allocation_size);
+        base_allocator, &query_params, &allocation_size);
     if (!iree_all_bits_set(compatibility,
                            IREE_HAL_BUFFER_COMPATIBILITY_IMPORTABLE)) {
 #if IREE_STATUS_MODE
@@ -2102,7 +2207,10 @@ static iree_status_t iree_hal_vulkan_allocator_import_buffer(
     status = iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
         "allocator cannot find a Vulkan memory type compatible with the "
-        "imported host pointer");
+        "imported host pointer; buffer memory type bits=0x%08" PRIx32
+        ", host pointer memory type bits=0x%08" PRIx32,
+        memory_requirements.memoryTypeBits,
+        host_pointer_properties.memoryTypeBits);
   }
 
   VkDeviceMemory device_memory = VK_NULL_HANDLE;

--- a/runtime/src/iree/hal/drivers/vulkan/allocator.h
+++ b/runtime/src/iree/hal/drivers/vulkan/allocator.h
@@ -23,6 +23,15 @@ extern "C" {
 typedef struct iree_hal_vulkan_allocator_t iree_hal_vulkan_allocator_t;
 typedef struct iree_hal_vulkan_queue_t iree_hal_vulkan_queue_t;
 
+// Maps one HAL queue affinity bit to its Vulkan queue family.
+typedef struct iree_hal_vulkan_allocator_queue_family_t {
+  // HAL queue affinity bit selecting this family.
+  iree_hal_queue_affinity_t queue_affinity;
+
+  // Vulkan queue family index used by the selected queue.
+  uint32_t family_index;
+} iree_hal_vulkan_allocator_queue_family_t;
+
 typedef enum iree_hal_vulkan_queue_alloca_strategy_e {
   // Invalid zero value used to catch uninitialized alloca plans.
   IREE_HAL_VULKAN_QUEUE_ALLOCA_STRATEGY_NONE = 0,
@@ -59,6 +68,8 @@ iree_status_t iree_hal_vulkan_allocator_create(
     iree_hal_vulkan_features_t enabled_features,
     iree_hal_vulkan_device_extensions_t enabled_extensions,
     iree_hal_queue_affinity_t queue_affinity_mask,
+    iree_host_size_t queue_family_count,
+    const iree_hal_vulkan_allocator_queue_family_t* queue_families,
     iree_hal_vulkan_queue_t* sparse_binding_queue,
     iree_async_proactor_t* proactor, iree_allocator_t host_allocator,
     iree_hal_allocator_t** out_allocator);

--- a/runtime/src/iree/hal/drivers/vulkan/buffer.c
+++ b/runtime/src/iree/hal/drivers/vulkan/buffer.c
@@ -347,6 +347,38 @@ iree_status_t iree_hal_vulkan_buffer_resolve_backing_offset(
   return iree_ok_status();
 }
 
+bool iree_hal_vulkan_buffer_range_is_dword_aligned(
+    iree_hal_buffer_t* buffer, iree_device_size_t local_byte_offset,
+    iree_device_size_t local_byte_length) {
+  const iree_device_size_t dword_size = sizeof(uint32_t);
+  if (local_byte_length == 0) return true;
+  if (local_byte_length % dword_size != 0) return false;
+
+  iree_hal_buffer_t* backing_buffer = buffer;
+  iree_hal_buffer_t* allocated_buffer =
+      iree_hal_buffer_allocated_buffer(buffer);
+  if (iree_hal_local_transient_buffer_isa(allocated_buffer)) {
+    backing_buffer =
+        iree_hal_local_transient_buffer_backing_buffer(allocated_buffer);
+    if (!backing_buffer) return false;
+  }
+
+  iree_device_size_t offset_remainder = local_byte_offset % dword_size;
+  offset_remainder += iree_hal_buffer_byte_offset(backing_buffer) % dword_size;
+  allocated_buffer = iree_hal_buffer_allocated_buffer(backing_buffer);
+  if (iree_hal_vulkan_buffer_isa(allocated_buffer)) {
+    const iree_hal_vulkan_buffer_t* vulkan_buffer =
+        iree_hal_vulkan_buffer_cast(allocated_buffer);
+    offset_remainder += vulkan_buffer->handle_offset % dword_size;
+  } else if (!iree_hal_vulkan_sparse_buffer_isa(allocated_buffer)) {
+    return false;
+  }
+  if (backing_buffer != buffer) {
+    offset_remainder += iree_hal_buffer_byte_offset(buffer) % dword_size;
+  }
+  return offset_remainder % dword_size == 0;
+}
+
 iree_status_t iree_hal_vulkan_buffer_handle(iree_hal_buffer_t* buffer,
                                             VkDeviceMemory* out_memory,
                                             VkBuffer* out_handle) {

--- a/runtime/src/iree/hal/drivers/vulkan/buffer.h
+++ b/runtime/src/iree/hal/drivers/vulkan/buffer.h
@@ -80,6 +80,16 @@ iree_status_t iree_hal_vulkan_buffer_resolve_backing_offset(
     iree_device_size_t local_byte_offset,
     iree_device_size_t* out_backing_byte_offset);
 
+// Returns true when |buffer|'s resolved Vulkan range has dword-aligned offset
+// and length.
+//
+// Buffers without a currently recordable Vulkan backing return false. This is
+// a conservative routing query only; queue submission remains responsible for
+// validating the buffer and reporting lifecycle or compatibility failures.
+bool iree_hal_vulkan_buffer_range_is_dword_aligned(
+    iree_hal_buffer_t* buffer, iree_device_size_t local_byte_offset,
+    iree_device_size_t local_byte_length);
+
 // Returns the Vulkan memory and buffer handles backing |buffer|.
 iree_status_t iree_hal_vulkan_buffer_handle(iree_hal_buffer_t* buffer,
                                             VkDeviceMemory* out_memory,

--- a/runtime/src/iree/hal/drivers/vulkan/command_buffer.c
+++ b/runtime/src/iree/hal/drivers/vulkan/command_buffer.c
@@ -1774,6 +1774,77 @@ static iree_status_t iree_hal_vulkan_command_buffer_record_copy_native(
       IREE_SV("copy source"), copy_buffer->target_ref, IREE_SV("copy target"));
 }
 
+iree_status_t iree_hal_vulkan_command_buffer_required_queue_flags(
+    iree_hal_command_buffer_t* base_command_buffer,
+    iree_hal_buffer_binding_table_t binding_table,
+    VkQueueFlags* out_required_queue_flags) {
+  IREE_ASSERT_ARGUMENT(base_command_buffer);
+  IREE_ASSERT_ARGUMENT(out_required_queue_flags);
+  *out_required_queue_flags = 0;
+  iree_hal_vulkan_command_buffer_t* command_buffer =
+      iree_hal_vulkan_command_buffer_cast(base_command_buffer);
+
+  iree_hal_vulkan_command_buffer_iterator_t iterator =
+      iree_hal_vulkan_command_buffer_iterator(command_buffer);
+  const iree_hal_vulkan_command_t* command = NULL;
+  while (iree_hal_vulkan_command_buffer_iterator_next(
+      &iterator, &command, /*out_command_index=*/NULL)) {
+    VkDeviceSize source_offset = 0;
+    VkDeviceSize source_length = 0;
+    VkDeviceSize target_offset = 0;
+    VkDeviceSize target_length = 0;
+    VkBuffer source_handle = VK_NULL_HANDLE;
+    VkBuffer target_handle = VK_NULL_HANDLE;
+    switch (command->type) {
+      case IREE_HAL_VULKAN_COMMAND_TYPE_FILL_BUFFER: {
+        const iree_hal_vulkan_command_fill_buffer_t* fill_buffer =
+            iree_hal_vulkan_command_fill_buffer_payload(command);
+        IREE_RETURN_IF_ERROR(
+            iree_hal_vulkan_command_buffer_resolve_native_buffer_ref(
+                binding_table, fill_buffer->target_ref, IREE_SV("fill target"),
+                &target_handle, &target_offset, &target_length));
+        break;
+      }
+      case IREE_HAL_VULKAN_COMMAND_TYPE_UPDATE_BUFFER: {
+        const iree_hal_vulkan_command_update_buffer_t* update_buffer =
+            iree_hal_vulkan_command_update_buffer_payload(command);
+        IREE_RETURN_IF_ERROR(
+            iree_hal_vulkan_command_buffer_resolve_native_buffer_ref(
+                binding_table, update_buffer->target_ref,
+                IREE_SV("update target"), &target_handle, &target_offset,
+                &target_length));
+        break;
+      }
+      case IREE_HAL_VULKAN_COMMAND_TYPE_COPY_BUFFER: {
+        const iree_hal_vulkan_command_copy_buffer_t* copy_buffer =
+            iree_hal_vulkan_command_copy_buffer_payload(command);
+        IREE_RETURN_IF_ERROR(
+            iree_hal_vulkan_command_buffer_resolve_native_buffer_ref(
+                binding_table, copy_buffer->source_ref, IREE_SV("copy source"),
+                &source_handle, &source_offset, &source_length));
+        IREE_RETURN_IF_ERROR(
+            iree_hal_vulkan_command_buffer_resolve_native_buffer_ref(
+                binding_table, copy_buffer->target_ref, IREE_SV("copy target"),
+                &target_handle, &target_offset, &target_length));
+        break;
+      }
+      default:
+        continue;
+    }
+    const bool source_is_dword_aligned =
+        source_offset % sizeof(uint32_t) == 0 &&
+        source_length % sizeof(uint32_t) == 0;
+    const bool target_is_dword_aligned =
+        target_offset % sizeof(uint32_t) == 0 &&
+        target_length % sizeof(uint32_t) == 0;
+    if (!source_is_dword_aligned || !target_is_dword_aligned) {
+      *out_required_queue_flags = VK_QUEUE_COMPUTE_BIT;
+      return iree_ok_status();
+    }
+  }
+  return iree_ok_status();
+}
+
 static void iree_hal_vulkan_command_buffer_record_execution_barrier_native(
     const iree_hal_vulkan_device_syms_t* syms,
     VkCommandBuffer native_command_buffer,

--- a/runtime/src/iree/hal/drivers/vulkan/command_buffer.h
+++ b/runtime/src/iree/hal/drivers/vulkan/command_buffer.h
@@ -45,6 +45,13 @@ bool iree_hal_vulkan_command_buffer_is_empty(
 bool iree_hal_vulkan_command_buffer_has_native_commands(
     iree_hal_command_buffer_t* command_buffer);
 
+// Returns native Vulkan queue capabilities required to replay |command_buffer|
+// with |binding_table|.
+iree_status_t iree_hal_vulkan_command_buffer_required_queue_flags(
+    iree_hal_command_buffer_t* command_buffer,
+    iree_hal_buffer_binding_table_t binding_table,
+    VkQueueFlags* out_required_queue_flags);
+
 // Returns the number of dispatch commands recorded in |command_buffer|.
 iree_host_size_t iree_hal_vulkan_command_buffer_dispatch_count(
     iree_hal_command_buffer_t* command_buffer);

--- a/runtime/src/iree/hal/drivers/vulkan/cts/file_test.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/cts/file_test.cc
@@ -107,8 +107,6 @@ TEST_P(VulkanFileTest, NativeFileShortReadExceedsStagingRingFails) {
   const iree_device_size_t import_length = 20 * 1024 * 1024 + 31;
   const iree_device_size_t actual_length = 4 * 1024 * 1024 + 17;
   const std::vector<uint8_t> import_contents(import_length, 0);
-  const std::vector<uint8_t> actual_contents =
-      MakeDeterministicBytes(actual_length);
 
   iree::testing::TempFilePath path("iree_vulkan_hal_cts_native_file_short");
   IREE_ASSERT_OK(iree_io_file_contents_write(
@@ -130,10 +128,7 @@ TEST_P(VulkanFileTest, NativeFileShortReadExceedsStagingRingFails) {
       IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE, handle.get(),
       IREE_HAL_EXTERNAL_FILE_FLAG_NONE, file.out()));
 
-  IREE_ASSERT_OK(iree_io_file_contents_write(
-      path.path_view(),
-      iree_make_const_byte_span(actual_contents.data(), actual_contents.size()),
-      iree_allocator_system()));
+  IREE_ASSERT_OK(iree_io_file_handle_resize(handle.get(), actual_length));
 
   Ref<iree_hal_buffer_t> target_buffer;
   IREE_ASSERT_OK(CreateZeroedDeviceBuffer(import_length, target_buffer.out()));

--- a/runtime/src/iree/hal/drivers/vulkan/logical_device.c
+++ b/runtime/src/iree/hal/drivers/vulkan/logical_device.c
@@ -20,6 +20,7 @@
 #include "iree/async/frontier_tracker.h"
 #include "iree/async/util/proactor_pool.h"
 #include "iree/hal/drivers/vulkan/allocator.h"
+#include "iree/hal/drivers/vulkan/buffer.h"
 #include "iree/hal/drivers/vulkan/builtins.h"
 #include "iree/hal/drivers/vulkan/command_buffer.h"
 #include "iree/hal/drivers/vulkan/debug_utils.h"
@@ -963,17 +964,16 @@ iree_hal_vulkan_logical_device_preferred_queue_role_for_command_categories(
 static VkQueueFlags
 iree_hal_vulkan_logical_device_required_queue_flags_for_command_categories(
     iree_hal_command_category_t command_categories) {
-  VkQueueFlags queue_flags = 0;
   if (iree_any_bit_set(command_categories,
                        IREE_HAL_COMMAND_CATEGORY_DISPATCH |
                            IREE_HAL_COMMAND_CATEGORY_ATOMIC)) {
-    queue_flags |= VK_QUEUE_COMPUTE_BIT;
+    return VK_QUEUE_COMPUTE_BIT;
   }
   if (iree_any_bit_set(command_categories,
                        IREE_HAL_COMMAND_CATEGORY_TRANSFER)) {
-    queue_flags |= VK_QUEUE_TRANSFER_BIT;
+    return VK_QUEUE_TRANSFER_BIT;
   }
-  return queue_flags;
+  return 0;
 }
 
 static iree_status_t
@@ -1021,6 +1021,34 @@ static iree_status_t iree_hal_vulkan_logical_device_select_queue_lane(
       device, preferred_role, required_flags, queue_affinity, out_queue);
 }
 
+static bool iree_hal_vulkan_logical_device_buffer_range_requires_compute(
+    iree_hal_buffer_t* buffer, iree_device_size_t offset,
+    iree_device_size_t length) {
+  return !iree_hal_vulkan_buffer_range_is_dword_aligned(buffer, offset, length);
+}
+
+static bool iree_hal_vulkan_logical_device_file_range_requires_compute(
+    iree_hal_file_t* file, uint64_t offset, iree_device_size_t length) {
+  iree_hal_buffer_t* storage_buffer = iree_hal_file_storage_buffer(file);
+  if (!storage_buffer) return false;
+  if (offset > IREE_DEVICE_SIZE_MAX) return true;
+  return iree_hal_vulkan_logical_device_buffer_range_requires_compute(
+      storage_buffer, (iree_device_size_t)offset, length);
+}
+
+static iree_status_t iree_hal_vulkan_logical_device_select_transfer_queue_lane(
+    iree_hal_vulkan_logical_device_t* device,
+    iree_hal_queue_affinity_t queue_affinity, bool requires_compute,
+    iree_hal_vulkan_queue_t** out_queue) {
+  const iree_hal_vulkan_queue_role_t preferred_role =
+      requires_compute ? IREE_HAL_VULKAN_QUEUE_ROLE_COMPUTE
+                       : IREE_HAL_VULKAN_QUEUE_ROLE_TRANSFER;
+  const VkQueueFlags required_queue_flags =
+      requires_compute ? VK_QUEUE_COMPUTE_BIT : VK_QUEUE_TRANSFER_BIT;
+  return iree_hal_vulkan_logical_device_select_queue_lane(
+      device, preferred_role, required_queue_flags, queue_affinity, out_queue);
+}
+
 static iree_status_t
 iree_hal_vulkan_logical_device_resolve_command_buffer_queue_affinity(
     iree_hal_vulkan_logical_device_t* device,
@@ -1061,10 +1089,14 @@ static iree_status_t iree_hal_vulkan_logical_device_create_command_buffer(
   const VkQueueFlags required_queue_flags =
       iree_hal_vulkan_logical_device_required_queue_flags_for_command_categories(
           command_categories);
-  IREE_RETURN_IF_ERROR(iree_hal_vulkan_logical_device_select_queue_lane(
-      device, preferred_role, required_queue_flags, queue_affinity, &queue));
+  IREE_RETURN_IF_ERROR(iree_hal_vulkan_queue_affinity_normalize(
+      device->queues.affinity_mask, queue_affinity, &queue_affinity));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_vulkan_logical_device_select_queue_lane_from_normalized_affinity(
+          device, preferred_role, required_queue_flags, queue_affinity,
+          &queue));
   return iree_hal_vulkan_command_buffer_create(
-      device->device_allocator, mode, command_categories, queue->queue_affinity,
+      device->device_allocator, mode, command_categories, queue_affinity,
       binding_capacity, &device->builtins.atomic_pipelines,
       &device->command_buffer_block_pool, device->host_allocator,
       out_command_buffer);
@@ -1249,10 +1281,13 @@ static iree_status_t iree_hal_vulkan_logical_device_queue_fill(
     iree_host_size_t pattern_length, iree_hal_fill_flags_t flags) {
   iree_hal_vulkan_logical_device_t* device =
       iree_hal_vulkan_logical_device_cast(base_device);
+  const bool requires_compute =
+      iree_hal_vulkan_logical_device_buffer_range_requires_compute(
+          target_buffer, target_offset, length);
   iree_hal_vulkan_queue_t* queue = NULL;
-  IREE_RETURN_IF_ERROR(iree_hal_vulkan_logical_device_select_queue_lane(
-      device, IREE_HAL_VULKAN_QUEUE_ROLE_TRANSFER, VK_QUEUE_TRANSFER_BIT,
-      queue_affinity, &queue));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_vulkan_logical_device_select_transfer_queue_lane(
+          device, queue_affinity, requires_compute, &queue));
   return iree_hal_vulkan_queue_submit_fill(
       queue, wait_semaphore_list, signal_semaphore_list, target_buffer,
       target_offset, length, pattern, pattern_length, flags);
@@ -1267,10 +1302,13 @@ static iree_status_t iree_hal_vulkan_logical_device_queue_update(
     iree_device_size_t length, iree_hal_update_flags_t flags) {
   iree_hal_vulkan_logical_device_t* device =
       iree_hal_vulkan_logical_device_cast(base_device);
+  const bool requires_compute =
+      iree_hal_vulkan_logical_device_buffer_range_requires_compute(
+          target_buffer, target_offset, length);
   iree_hal_vulkan_queue_t* queue = NULL;
-  IREE_RETURN_IF_ERROR(iree_hal_vulkan_logical_device_select_queue_lane(
-      device, IREE_HAL_VULKAN_QUEUE_ROLE_TRANSFER, VK_QUEUE_TRANSFER_BIT,
-      queue_affinity, &queue));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_vulkan_logical_device_select_transfer_queue_lane(
+          device, queue_affinity, requires_compute, &queue));
   return iree_hal_vulkan_queue_submit_update(
       queue, wait_semaphore_list, signal_semaphore_list, source_buffer,
       source_offset, target_buffer, target_offset, length, flags);
@@ -1285,10 +1323,17 @@ static iree_status_t iree_hal_vulkan_logical_device_queue_copy(
     iree_device_size_t length, iree_hal_copy_flags_t flags) {
   iree_hal_vulkan_logical_device_t* device =
       iree_hal_vulkan_logical_device_cast(base_device);
+  const bool source_requires_compute =
+      iree_hal_vulkan_logical_device_buffer_range_requires_compute(
+          source_buffer, source_offset, length);
+  const bool target_requires_compute =
+      iree_hal_vulkan_logical_device_buffer_range_requires_compute(
+          target_buffer, target_offset, length);
   iree_hal_vulkan_queue_t* queue = NULL;
-  IREE_RETURN_IF_ERROR(iree_hal_vulkan_logical_device_select_queue_lane(
-      device, IREE_HAL_VULKAN_QUEUE_ROLE_TRANSFER, VK_QUEUE_TRANSFER_BIT,
-      queue_affinity, &queue));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_vulkan_logical_device_select_transfer_queue_lane(
+          device, queue_affinity,
+          source_requires_compute || target_requires_compute, &queue));
   return iree_hal_vulkan_queue_submit_copy(
       queue, wait_semaphore_list, signal_semaphore_list, source_buffer,
       source_offset, target_buffer, target_offset, length, flags);
@@ -1303,10 +1348,15 @@ static iree_status_t iree_hal_vulkan_logical_device_queue_read(
     iree_device_size_t length, iree_hal_read_flags_t flags) {
   iree_hal_vulkan_logical_device_t* device =
       iree_hal_vulkan_logical_device_cast(base_device);
+  const bool requires_compute =
+      iree_hal_vulkan_logical_device_buffer_range_requires_compute(
+          target_buffer, target_offset, length) ||
+      iree_hal_vulkan_logical_device_file_range_requires_compute(
+          source_file, source_offset, length);
   iree_hal_vulkan_queue_t* queue = NULL;
-  IREE_RETURN_IF_ERROR(iree_hal_vulkan_logical_device_select_queue_lane(
-      device, IREE_HAL_VULKAN_QUEUE_ROLE_TRANSFER, VK_QUEUE_TRANSFER_BIT,
-      queue_affinity, &queue));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_vulkan_logical_device_select_transfer_queue_lane(
+          device, queue_affinity, requires_compute, &queue));
   return iree_hal_vulkan_queue_submit_read(
       queue, wait_semaphore_list, signal_semaphore_list, source_file,
       source_offset, target_buffer, target_offset, length, flags);
@@ -1321,10 +1371,15 @@ static iree_status_t iree_hal_vulkan_logical_device_queue_write(
     iree_device_size_t length, iree_hal_write_flags_t flags) {
   iree_hal_vulkan_logical_device_t* device =
       iree_hal_vulkan_logical_device_cast(base_device);
+  const bool requires_compute =
+      iree_hal_vulkan_logical_device_buffer_range_requires_compute(
+          source_buffer, source_offset, length) ||
+      iree_hal_vulkan_logical_device_file_range_requires_compute(
+          target_file, target_offset, length);
   iree_hal_vulkan_queue_t* queue = NULL;
-  IREE_RETURN_IF_ERROR(iree_hal_vulkan_logical_device_select_queue_lane(
-      device, IREE_HAL_VULKAN_QUEUE_ROLE_TRANSFER, VK_QUEUE_TRANSFER_BIT,
-      queue_affinity, &queue));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_vulkan_logical_device_select_transfer_queue_lane(
+          device, queue_affinity, requires_compute, &queue));
   return iree_hal_vulkan_queue_submit_write(
       queue, wait_semaphore_list, signal_semaphore_list, source_buffer,
       source_offset, target_file, target_offset, length, flags);
@@ -1420,16 +1475,25 @@ static iree_status_t iree_hal_vulkan_logical_device_queue_execute(
         binding_table.count);
   }
   iree_hal_vulkan_queue_t* queue = NULL;
-  const iree_hal_vulkan_queue_role_t preferred_role =
+  iree_hal_vulkan_queue_role_t preferred_role =
       is_empty_command_buffer
           ? IREE_HAL_VULKAN_QUEUE_ROLE_COMPUTE
           : iree_hal_vulkan_logical_device_preferred_queue_role_for_command_categories(
                 iree_hal_command_buffer_allowed_categories(command_buffer));
-  const VkQueueFlags required_queue_flags =
+  VkQueueFlags required_queue_flags =
       is_empty_command_buffer
           ? 0
           : iree_hal_vulkan_logical_device_required_queue_flags_for_command_categories(
                 iree_hal_command_buffer_allowed_categories(command_buffer));
+  if (!is_empty_command_buffer) {
+    VkQueueFlags native_required_queue_flags = 0;
+    IREE_RETURN_IF_ERROR(iree_hal_vulkan_command_buffer_required_queue_flags(
+        command_buffer, binding_table, &native_required_queue_flags));
+    if (iree_any_bit_set(native_required_queue_flags, VK_QUEUE_COMPUTE_BIT)) {
+      preferred_role = IREE_HAL_VULKAN_QUEUE_ROLE_COMPUTE;
+      required_queue_flags = VK_QUEUE_COMPUTE_BIT;
+    }
+  }
   if (is_empty_command_buffer) {
     IREE_RETURN_IF_ERROR(iree_hal_vulkan_logical_device_select_queue_lane(
         device, preferred_role, required_queue_flags, queue_affinity, &queue));
@@ -1780,10 +1844,21 @@ static iree_status_t iree_hal_vulkan_logical_device_initialize_proactor(
 static iree_status_t iree_hal_vulkan_logical_device_initialize_allocator(
     iree_hal_vulkan_logical_device_t* device) {
   IREE_ASSERT_ARGUMENT(device);
+  const iree_hal_vulkan_allocator_queue_family_t queue_families[] = {
+      {
+          .queue_affinity = device->queues.compute.selection.affinity,
+          .family_index = device->queues.compute.selection.family_index,
+      },
+      {
+          .queue_affinity = device->queues.transfer.selection.affinity,
+          .family_index = device->queues.transfer.selection.family_index,
+      },
+  };
   return iree_hal_vulkan_allocator_create(
       (iree_hal_device_t*)device, &device->syms, device->logical_device,
       &device->physical_device, device->enabled_features,
       device->enabled_extensions, device->queues.affinity_mask,
+      IREE_ARRAYSIZE(queue_families), queue_families,
       device->queues.sparse_binding_lane, device->proactor,
       device->host_allocator, &device->device_allocator);
 }

--- a/runtime/src/iree/io/file_contents_test.cc
+++ b/runtime/src/iree/io/file_contents_test.cc
@@ -272,6 +272,30 @@ TEST(FileContents, CreateOverwritesSharedAsyncFileAndResizes) {
   iree_io_file_contents_free(read_contents);
 }
 
+TEST(FileContents, ResizeOpenFilePreservesPrefixAcrossShrinkAndExtend) {
+  iree::testing::TempFilePath path("iree_file_contents_test");
+  const uint8_t initial_contents[] = {0x11, 0x22, 0x33, 0x44};
+  IREE_ASSERT_OK(iree_io_file_contents_write(
+      path.path_view(),
+      iree_make_const_byte_span(initial_contents, sizeof(initial_contents)),
+      iree_allocator_system()));
+
+  iree_io_file_handle_t* handle = NULL;
+  IREE_ASSERT_OK(iree_io_file_handle_open(
+      IREE_IO_FILE_MODE_READ | IREE_IO_FILE_MODE_WRITE, path.path_view(),
+      iree_allocator_system(), &handle));
+  IREE_EXPECT_OK(iree_io_file_handle_resize(handle, 2));
+  IREE_EXPECT_OK(iree_io_file_handle_resize(handle, 6));
+  iree_io_file_handle_release(handle);
+
+  iree_io_file_contents_t* read_contents = NULL;
+  IREE_ASSERT_OK(iree_io_file_contents_read(
+      path.path_view(), iree_allocator_system(), &read_contents));
+  ASSERT_EQ(read_contents->const_buffer.data_length, 6);
+  EXPECT_EQ(memcmp(read_contents->const_buffer.data, initial_contents, 2), 0);
+  iree_io_file_contents_free(read_contents);
+}
+
 #if defined(IREE_PLATFORM_WINDOWS)
 
 TEST(FileContents, ReadWriteLongUtf8Path) {

--- a/runtime/src/iree/io/file_handle.c
+++ b/runtime/src/iree/io/file_handle.c
@@ -188,6 +188,85 @@ iree_io_file_handle_flush(iree_io_file_handle_t* handle) {
   return status;
 }
 
+static iree_status_t iree_io_platform_fd_resize(int fd, uint64_t new_size) {
+#if IREE_FILE_IO_ENABLE
+
+#if defined(IREE_PLATFORM_WINDOWS)
+  if (new_size > INT64_MAX) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "file size %" PRIu64
+                            " exceeds the Windows signed 64-bit limit",
+                            new_size);
+  }
+  intptr_t os_handle = _get_osfhandle(fd);
+  if (os_handle == -1) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid file descriptor");
+  }
+  FILE_END_OF_FILE_INFO end_of_file_info = {0};
+  end_of_file_info.EndOfFile.QuadPart = (LONGLONG)new_size;
+  if (!SetFileInformationByHandle((HANDLE)os_handle, FileEndOfFileInfo,
+                                  &end_of_file_info,
+                                  sizeof(end_of_file_info))) {
+    return iree_make_status(iree_status_code_from_win32_error(GetLastError()),
+                            "unable to resize file to %" PRIu64 " bytes",
+                            new_size);
+  }
+#else
+  off_t platform_size = (off_t)new_size;
+  if (platform_size < 0 || (uint64_t)platform_size != new_size) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "file size %" PRIu64
+                            " exceeds the platform file offset limit",
+                            new_size);
+  }
+  if (ftruncate(fd, platform_size) == -1) {
+    return iree_make_status(iree_status_code_from_errno(errno),
+                            "unable to resize file to %" PRIu64 " bytes",
+                            new_size);
+  }
+#endif  // IREE_PLATFORM_WINDOWS
+  return iree_ok_status();
+
+#else
+  return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                          "file support has been compiled out of this binary; "
+                          "set IREE_FILE_IO_ENABLE=1 to include it");
+#endif  // IREE_FILE_IO_ENABLE
+}
+
+IREE_API_EXPORT iree_status_t
+iree_io_file_handle_resize(iree_io_file_handle_t* handle, uint64_t new_size) {
+  IREE_ASSERT_ARGUMENT(handle);
+  if (!iree_all_bits_set(handle->access, IREE_IO_FILE_ACCESS_WRITE)) {
+    return iree_make_status(IREE_STATUS_PERMISSION_DENIED,
+                            "file handle does not allow writes");
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)new_size);
+  iree_status_t status = iree_ok_status();
+  switch (handle->primitive.type) {
+    case IREE_IO_FILE_HANDLE_TYPE_HOST_ALLOCATION: {
+      status =
+          iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                           "host allocation file handles have fixed extents");
+      break;
+    }
+    case IREE_IO_FILE_HANDLE_TYPE_FD: {
+      status = iree_io_platform_fd_resize(handle->primitive.value.fd, new_size);
+      break;
+    }
+    default: {
+      status = iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                                "resize not supported on handle type %d",
+                                (int)handle->primitive.type);
+      break;
+    }
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 //===----------------------------------------------------------------------===//
 // iree_io_file_handle_t utilities
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/io/file_handle.h
+++ b/runtime/src/iree/io/file_handle.h
@@ -197,6 +197,15 @@ static inline iree_io_file_handle_primitive_value_t iree_io_file_handle_value(
 IREE_API_EXPORT iree_status_t
 iree_io_file_handle_flush(iree_io_file_handle_t* handle);
 
+// Resizes the platform file backing |handle| to |new_size| bytes.
+//
+// The handle must allow IREE_IO_FILE_ACCESS_WRITE. Shrinking discards the
+// truncated range; the contents of a newly extended range are
+// platform-defined. Host-allocation handles have fixed extents and cannot be
+// resized.
+IREE_API_EXPORT iree_status_t
+iree_io_file_handle_resize(iree_io_file_handle_t* handle, uint64_t new_size);
+
 //===----------------------------------------------------------------------===//
 // iree_io_file_handle_t platform files
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Makes Vulkan buffer ownership and transfer-lane selection preserve the queue and byte-range contracts exposed by the HAL.

Buffers accessible from more than one queue family now use concurrent sharing with the exact normalized family set, while command buffers retain their normalized affinity so submission selects a compatible queue lane after bindings resolve.

Native Vulkan fill, update, and copy commands are used only for dword-aligned resolved ranges. Byte-granular direct, deferred, and storage-backed file transfers route through the compute-capable path instead of issuing invalid transfer commands.

The file CTS truncates its already-imported file through a new portable writable-handle resize operation. The operation uses the live descriptor or HANDLE and therefore preserves handle identity rather than reopening a path behind an active import.

Clock-correlation changes are intentionally excluded and reviewed separately.