### PR TITLE
[HAL] Share profile clock alignment validation

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
@@ -256,6 +256,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/memory:tlsf_pool",
         "//runtime/src/iree/hal/memory:tracing",
         "//runtime/src/iree/hal/utils:files",
+        "//runtime/src/iree/hal/utils:profile_clock_alignment",
         "//runtime/src/iree/hal/utils:resource_set",
         "//third_party:vulkan_headers",
     ],

--- a/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
@@ -310,6 +310,7 @@ iree_cc_library(
     iree::hal::memory::tlsf_pool
     iree::hal::memory::tracing
     iree::hal::utils::files
+    iree::hal::utils::profile_clock_alignment
     iree::hal::utils::resource_set
     iree::third_party::vulkan_headers
   PUBLIC

--- a/runtime/src/iree/hal/drivers/vulkan/logical_device.c
+++ b/runtime/src/iree/hal/drivers/vulkan/logical_device.c
@@ -386,13 +386,7 @@ static uint64_t iree_hal_vulkan_host_time_domain_timestamp_ns(
 static void iree_hal_vulkan_profile_clock_alignment_reset(
     iree_hal_vulkan_profile_clock_alignment_t* clock_alignment) {
   iree_slim_mutex_lock(&clock_alignment->mutex);
-  clock_alignment->minimum_clock_tick = UINT64_MAX;
-  clock_alignment->maximum_clock_tick = 0;
-  clock_alignment->minimum_event_tick = UINT64_MAX;
-  clock_alignment->maximum_event_tick = 0;
-  clock_alignment->has_clock_ticks = false;
-  clock_alignment->has_event_ticks = false;
-  clock_alignment->has_invalid_alignment = false;
+  iree_hal_profile_clock_alignment_reset(&clock_alignment->state);
   iree_slim_mutex_unlock(&clock_alignment->mutex);
 }
 
@@ -400,24 +394,9 @@ static bool iree_hal_vulkan_profile_clock_alignment_record_clock_tick(
     iree_hal_vulkan_profile_clock_alignment_t* clock_alignment,
     uint64_t calibrated_device_tick) {
   iree_slim_mutex_lock(&clock_alignment->mutex);
-  if (clock_alignment->has_clock_ticks) {
-    clock_alignment->minimum_clock_tick =
-        iree_min(clock_alignment->minimum_clock_tick, calibrated_device_tick);
-    clock_alignment->maximum_clock_tick =
-        iree_max(clock_alignment->maximum_clock_tick, calibrated_device_tick);
-  } else {
-    clock_alignment->minimum_clock_tick = calibrated_device_tick;
-    clock_alignment->maximum_clock_tick = calibrated_device_tick;
-    clock_alignment->has_clock_ticks = true;
-  }
-  if (clock_alignment->has_event_ticks &&
-      (clock_alignment->minimum_event_tick <
-           clock_alignment->minimum_clock_tick ||
-       clock_alignment->maximum_event_tick >
-           clock_alignment->maximum_clock_tick)) {
-    clock_alignment->has_invalid_alignment = true;
-  }
-  const bool has_invalid_alignment = clock_alignment->has_invalid_alignment;
+  const bool has_invalid_alignment =
+      iree_hal_profile_clock_alignment_record_clock_tick(
+          &clock_alignment->state, calibrated_device_tick);
   iree_slim_mutex_unlock(&clock_alignment->mutex);
   return has_invalid_alignment;
 }

--- a/runtime/src/iree/hal/drivers/vulkan/queue.c
+++ b/runtime/src/iree/hal/drivers/vulkan/queue.c
@@ -3429,16 +3429,8 @@ static void iree_hal_vulkan_queue_profile_record_device_tick_range(
   if (!clock_alignment) return;
 
   iree_slim_mutex_lock(&clock_alignment->mutex);
-  if (clock_alignment->has_event_ticks) {
-    clock_alignment->minimum_event_tick =
-        iree_min(clock_alignment->minimum_event_tick, start_tick);
-    clock_alignment->maximum_event_tick =
-        iree_max(clock_alignment->maximum_event_tick, end_tick);
-  } else {
-    clock_alignment->minimum_event_tick = start_tick;
-    clock_alignment->maximum_event_tick = end_tick;
-    clock_alignment->has_event_ticks = true;
-  }
+  iree_hal_profile_clock_alignment_record_event_range(&clock_alignment->state,
+                                                      start_tick, end_tick);
   iree_slim_mutex_unlock(&clock_alignment->mutex);
 }
 
@@ -3458,6 +3450,13 @@ static iree_status_t iree_hal_vulkan_queue_profile_read_native_timestamps(
     return iree_status_from_vk_result(__FILE__, __LINE__, result,
                                       "vkGetQueryPoolResults");
   }
+
+  // Aggregate the submission's timestamp envelope locally. Profiling batches
+  // may contain many dispatches, and publishing once avoids serializing every
+  // event on the logical-device clock-alignment mutex.
+  uint64_t minimum_event_tick = UINT64_MAX;
+  uint64_t maximum_event_tick = 0;
+  bool has_event_ticks = false;
   if (submission->profile.queue_start_query !=
       IREE_HAL_VULKAN_PROFILE_QUERY_ABSENT) {
     const uint64_t start_tick =
@@ -3469,8 +3468,9 @@ static iree_status_t iree_hal_vulkan_queue_profile_read_native_timestamps(
           IREE_STATUS_DATA_LOSS,
           "Vulkan queue device profiling timestamp range is not monotonic");
     }
-    iree_hal_vulkan_queue_profile_record_device_tick_range(queue, start_tick,
-                                                           end_tick);
+    minimum_event_tick = start_tick;
+    maximum_event_tick = end_tick;
+    has_event_ticks = true;
   }
   for (uint32_t i = 0; i < submission->profile.dispatch_query_count; ++i) {
     const uint32_t query_index =
@@ -3482,8 +3482,13 @@ static iree_status_t iree_hal_vulkan_queue_profile_read_native_timestamps(
           IREE_STATUS_DATA_LOSS,
           "Vulkan dispatch profiling timestamp range is not monotonic");
     }
-    iree_hal_vulkan_queue_profile_record_device_tick_range(queue, start_tick,
-                                                           end_tick);
+    minimum_event_tick = iree_min(minimum_event_tick, start_tick);
+    maximum_event_tick = iree_max(maximum_event_tick, end_tick);
+    has_event_ticks = true;
+  }
+  if (has_event_ticks) {
+    iree_hal_vulkan_queue_profile_record_device_tick_range(
+        queue, minimum_event_tick, maximum_event_tick);
   }
   return iree_ok_status();
 }

--- a/runtime/src/iree/hal/drivers/vulkan/queue.h
+++ b/runtime/src/iree/hal/drivers/vulkan/queue.h
@@ -23,6 +23,7 @@
 #include "iree/hal/drivers/vulkan/semaphore.h"
 #include "iree/hal/drivers/vulkan/util/libvulkan.h"
 #include "iree/hal/local/profile.h"
+#include "iree/hal/utils/profile_clock_alignment.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,29 +57,11 @@ typedef struct iree_hal_vulkan_queue_staging_ring_t
 // Logical-device-owned clock alignment state shared with queue lanes while
 // profiling is active.
 typedef struct iree_hal_vulkan_profile_clock_alignment_t {
-  // Mutex protecting the sampled tick ranges and invalid-alignment flag.
+  // Mutex protecting |state| across queue harvest and device sampling.
   iree_slim_mutex_t mutex;
 
-  // Earliest calibrated device clock tick observed during the session.
-  uint64_t minimum_clock_tick;
-
-  // Latest calibrated device clock tick observed during the session.
-  uint64_t maximum_clock_tick;
-
-  // Earliest device event tick observed during the active profiling session.
-  uint64_t minimum_event_tick;
-
-  // Latest device event tick observed during the active profiling session.
-  uint64_t maximum_event_tick;
-
-  // True when at least one calibrated device clock tick has been observed.
-  bool has_clock_ticks;
-
-  // True when at least one device event tick has been observed.
-  bool has_event_ticks;
-
-  // True when calibrated device timestamps are not aligned with event ticks.
-  bool has_invalid_alignment;
+  // Sampled device clock and event tick ranges for the active session.
+  iree_hal_profile_clock_alignment_t state;
 } iree_hal_vulkan_profile_clock_alignment_t;
 
 typedef enum iree_hal_vulkan_queue_role_e {

--- a/runtime/src/iree/hal/utils/BUILD.bazel
+++ b/runtime/src/iree/hal/utils/BUILD.bazel
@@ -242,6 +242,25 @@ iree_runtime_cc_library(
 )
 
 iree_runtime_cc_library(
+    name = "profile_clock_alignment",
+    srcs = ["profile_clock_alignment.c"],
+    hdrs = ["profile_clock_alignment.h"],
+    deps = [
+        "//runtime/src/iree/base",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "profile_clock_alignment_test",
+    srcs = ["profile_clock_alignment_test.cc"],
+    deps = [
+        ":profile_clock_alignment",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "statistics_sink",
     srcs = ["statistics_sink.c"],
     hdrs = ["statistics_sink.h"],

--- a/runtime/src/iree/hal/utils/CMakeLists.txt
+++ b/runtime/src/iree/hal/utils/CMakeLists.txt
@@ -280,6 +280,29 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    profile_clock_alignment
+  HDRS
+    "profile_clock_alignment.h"
+  SRCS
+    "profile_clock_alignment.c"
+  DEPS
+    iree::base
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    profile_clock_alignment_test
+  SRCS
+    "profile_clock_alignment_test.cc"
+  DEPS
+    ::profile_clock_alignment
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
+iree_cc_library(
+  NAME
     statistics_sink
   HDRS
     "statistics_sink.h"

--- a/runtime/src/iree/hal/utils/profile_clock_alignment.c
+++ b/runtime/src/iree/hal/utils/profile_clock_alignment.c
@@ -1,0 +1,58 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/utils/profile_clock_alignment.h"
+
+#include <string.h>
+
+void iree_hal_profile_clock_alignment_reset(
+    iree_hal_profile_clock_alignment_t* alignment) {
+  IREE_ASSERT_ARGUMENT(alignment);
+  memset(alignment, 0, sizeof(*alignment));
+  alignment->minimum_clock_tick = UINT64_MAX;
+  alignment->minimum_event_tick = UINT64_MAX;
+}
+
+void iree_hal_profile_clock_alignment_record_event_range(
+    iree_hal_profile_clock_alignment_t* alignment, uint64_t start_tick,
+    uint64_t end_tick) {
+  IREE_ASSERT_ARGUMENT(alignment);
+  if (IREE_UNLIKELY(end_tick < start_tick)) {
+    alignment->has_invalid_alignment = true;
+    return;
+  }
+  if (alignment->has_event_ticks) {
+    alignment->minimum_event_tick =
+        iree_min(alignment->minimum_event_tick, start_tick);
+    alignment->maximum_event_tick =
+        iree_max(alignment->maximum_event_tick, end_tick);
+  } else {
+    alignment->minimum_event_tick = start_tick;
+    alignment->maximum_event_tick = end_tick;
+    alignment->has_event_ticks = true;
+  }
+}
+
+bool iree_hal_profile_clock_alignment_record_clock_tick(
+    iree_hal_profile_clock_alignment_t* alignment, uint64_t clock_tick) {
+  IREE_ASSERT_ARGUMENT(alignment);
+  if (alignment->has_clock_ticks) {
+    alignment->minimum_clock_tick =
+        iree_min(alignment->minimum_clock_tick, clock_tick);
+    alignment->maximum_clock_tick =
+        iree_max(alignment->maximum_clock_tick, clock_tick);
+  } else {
+    alignment->minimum_clock_tick = clock_tick;
+    alignment->maximum_clock_tick = clock_tick;
+    alignment->has_clock_ticks = true;
+  }
+  if (alignment->has_event_ticks &&
+      (alignment->minimum_event_tick < alignment->minimum_clock_tick ||
+       alignment->maximum_event_tick > alignment->maximum_clock_tick)) {
+    alignment->has_invalid_alignment = true;
+  }
+  return alignment->has_invalid_alignment;
+}

--- a/runtime/src/iree/hal/utils/profile_clock_alignment.h
+++ b/runtime/src/iree/hal/utils/profile_clock_alignment.h
@@ -1,0 +1,75 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_UTILS_PROFILE_CLOCK_ALIGNMENT_H_
+#define IREE_HAL_UTILS_PROFILE_CLOCK_ALIGNMENT_H_
+
+#include "iree/base/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Tracks whether calibrated device clock samples bound device event ticks.
+//
+// Clock samples and event timestamps intended for the same device timeline
+// must share an epoch. A producer records its first clock sample before device
+// work, records event ranges as they are harvested, and records another clock
+// sample after each harvest. Once an event falls outside the sampled clock
+// range the alignment is permanently invalid for the session.
+//
+// The tracker owns no synchronization. Callers must serialize all mutations or
+// provide an external lock shared by clock-sampling and event-harvest paths.
+typedef struct iree_hal_profile_clock_alignment_t {
+  // Earliest calibrated device clock tick observed during the session.
+  uint64_t minimum_clock_tick;
+
+  // Latest calibrated device clock tick observed during the session.
+  uint64_t maximum_clock_tick;
+
+  // Earliest device event tick observed during the session.
+  uint64_t minimum_event_tick;
+
+  // Latest device event tick observed during the session.
+  uint64_t maximum_event_tick;
+
+  // True when at least one calibrated device clock tick has been observed.
+  bool has_clock_ticks;
+
+  // True when at least one device event tick has been observed.
+  bool has_event_ticks;
+
+  // True when an event range is malformed or outside sampled clock ticks.
+  bool has_invalid_alignment;
+} iree_hal_profile_clock_alignment_t;
+
+// Resets |alignment| for a new profiling session.
+void iree_hal_profile_clock_alignment_reset(
+    iree_hal_profile_clock_alignment_t* alignment);
+
+// Records one inclusive device event tick range.
+//
+// A reversed range permanently invalidates alignment for the session. A valid
+// range is not compared until a subsequent clock sample is recorded, allowing
+// the ending sample to extend the clock bounds beyond newly harvested events.
+// A range may summarize any number of events; batch-oriented producers should
+// coalesce each harvest and record its minimum and maximum ticks once.
+void iree_hal_profile_clock_alignment_record_event_range(
+    iree_hal_profile_clock_alignment_t* alignment, uint64_t start_tick,
+    uint64_t end_tick);
+
+// Records one calibrated device clock tick.
+//
+// Returns true when alignment has been invalidated at any point in the active
+// session.
+bool iree_hal_profile_clock_alignment_record_clock_tick(
+    iree_hal_profile_clock_alignment_t* alignment, uint64_t clock_tick);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_UTILS_PROFILE_CLOCK_ALIGNMENT_H_

--- a/runtime/src/iree/hal/utils/profile_clock_alignment_test.cc
+++ b/runtime/src/iree/hal/utils/profile_clock_alignment_test.cc
@@ -1,0 +1,100 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/utils/profile_clock_alignment.h"
+
+#include "iree/testing/gtest.h"
+
+namespace iree::hal {
+namespace {
+
+TEST(ProfileClockAlignmentTest, EventBoundedByClockSamplesIsAligned) {
+  iree_hal_profile_clock_alignment_t alignment;
+  iree_hal_profile_clock_alignment_reset(&alignment);
+
+  EXPECT_FALSE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 100));
+  iree_hal_profile_clock_alignment_record_event_range(&alignment, 120, 180);
+  EXPECT_FALSE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 200));
+}
+
+TEST(ProfileClockAlignmentTest, EventWaitsForEndingClockSample) {
+  iree_hal_profile_clock_alignment_t alignment;
+  iree_hal_profile_clock_alignment_reset(&alignment);
+
+  EXPECT_FALSE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 100));
+  iree_hal_profile_clock_alignment_record_event_range(&alignment, 120, 250);
+  EXPECT_FALSE(alignment.has_invalid_alignment);
+  EXPECT_FALSE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 300));
+}
+
+TEST(ProfileClockAlignmentTest, MultipleEventRangesTrackEnvelope) {
+  iree_hal_profile_clock_alignment_t alignment;
+  iree_hal_profile_clock_alignment_reset(&alignment);
+
+  EXPECT_FALSE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 100));
+  iree_hal_profile_clock_alignment_record_event_range(&alignment, 160, 180);
+  iree_hal_profile_clock_alignment_record_event_range(&alignment, 120, 140);
+  EXPECT_EQ(120, alignment.minimum_event_tick);
+  EXPECT_EQ(180, alignment.maximum_event_tick);
+  EXPECT_FALSE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 200));
+}
+
+TEST(ProfileClockAlignmentTest, ShiftedEventClockIsPermanentlyUnaligned) {
+  iree_hal_profile_clock_alignment_t alignment;
+  iree_hal_profile_clock_alignment_reset(&alignment);
+
+  EXPECT_FALSE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 100));
+  iree_hal_profile_clock_alignment_record_event_range(&alignment, 1120, 1180);
+  EXPECT_TRUE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 200));
+  EXPECT_TRUE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 1200));
+}
+
+TEST(ProfileClockAlignmentTest, EventBeforeInitialSampleIsUnaligned) {
+  iree_hal_profile_clock_alignment_t alignment;
+  iree_hal_profile_clock_alignment_reset(&alignment);
+
+  EXPECT_FALSE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 100));
+  iree_hal_profile_clock_alignment_record_event_range(&alignment, 80, 120);
+  EXPECT_TRUE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 200));
+}
+
+TEST(ProfileClockAlignmentTest, ReversedEventRangeIsUnaligned) {
+  iree_hal_profile_clock_alignment_t alignment;
+  iree_hal_profile_clock_alignment_reset(&alignment);
+
+  iree_hal_profile_clock_alignment_record_event_range(&alignment, 200, 100);
+  EXPECT_TRUE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 300));
+}
+
+TEST(ProfileClockAlignmentTest, ResetStartsIndependentSession) {
+  iree_hal_profile_clock_alignment_t alignment;
+  iree_hal_profile_clock_alignment_reset(&alignment);
+  iree_hal_profile_clock_alignment_record_event_range(&alignment, 200, 100);
+  EXPECT_TRUE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 300));
+
+  iree_hal_profile_clock_alignment_reset(&alignment);
+  EXPECT_FALSE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 400));
+  iree_hal_profile_clock_alignment_record_event_range(&alignment, 450, 500);
+  EXPECT_FALSE(
+      iree_hal_profile_clock_alignment_record_clock_tick(&alignment, 550));
+}
+
+}  // namespace
+}  // namespace iree::hal


### PR DESCRIPTION
Profile clock correlations are only usable when harvested device-event timestamps share the sampled device-clock epoch. Factor that validation into a synchronization-neutral HAL utility with a sticky session result, so drivers can apply one contract without coupling their queue implementations.

Vulkan keeps the state behind its existing profiling opt-in, coalesces every completed submission's timestamp ranges locally, and publishes one envelope under one mutex acquisition regardless of dispatch count. Ordinary unprofiled submission and completion paths gain no clock-alignment work.

This stack contains the Vulkan consumer only. AMDGPU integration is deliberately excluded until the shared contract and its cost model have landed independently.