### PR TITLE
[HAL/AMDGPU] Reclaim resources before signaling completion

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_submission.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_submission.c
@@ -989,6 +989,8 @@ uint64_t iree_hal_amdgpu_host_queue_finish_kernel_submission(
       submission->kernargs.write_position;
   submission->reclaim_entry->queue_upload_write_position =
       submission->queue_upload.write_position;
+  submission->reclaim_entry->signal_semaphore_count =
+      (uint16_t)signal_semaphore_list.count;
   submission->reclaim_entry->count = submission->reclaim_resource_count;
   submission->reclaim_entry->pre_signal_action = submission->pre_signal_action;
   iree_hal_amdgpu_host_queue_merge_barrier_axes(queue, resolution);
@@ -1681,6 +1683,7 @@ uint64_t iree_hal_amdgpu_host_queue_finish_barrier_submission(
   }
   reclaim_entry->kernarg_write_position = (uint64_t)iree_atomic_load(
       &queue->kernarg_ring.write_position, iree_memory_order_relaxed);
+  reclaim_entry->signal_semaphore_count = (uint16_t)signal_semaphore_list.count;
   reclaim_entry->count = submission->reclaim_resource_count;
 
   iree_hal_amdgpu_host_queue_merge_barrier_axes(queue, resolution);

--- a/runtime/src/iree/hal/drivers/amdgpu/util/notification_ring.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/notification_ring.c
@@ -58,6 +58,7 @@ iree_status_t iree_hal_amdgpu_reclaim_entry_prepare(
   entry->kernarg_write_position = 0;
   entry->queue_upload_write_position = 0;
   entry->count = 0;
+  entry->signal_semaphore_count = 0;
   if (count <= IREE_HAL_AMDGPU_RECLAIM_INLINE_CAPACITY) {
     entry->resources = entry->inline_resources;
   } else {
@@ -85,6 +86,21 @@ iree_status_t iree_hal_amdgpu_reclaim_entry_prepare(
   return iree_ok_status();
 }
 
+// Releases operation resources while preserving the leading signal semaphore
+// references required by notification publication.
+static void iree_hal_amdgpu_reclaim_entry_release_operation_resources(
+    iree_hal_amdgpu_reclaim_entry_t* entry) {
+  IREE_ASSERT(entry->signal_semaphore_count <= entry->count,
+              "signal semaphore count %u exceeds resource count %u",
+              entry->signal_semaphore_count, entry->count);
+  for (uint16_t i = entry->signal_semaphore_count; i < entry->count; ++i) {
+    iree_hal_resource_release(entry->resources[i]);
+  }
+  iree_hal_resource_set_free(entry->resource_set);
+  entry->resource_set = NULL;
+  entry->count = entry->signal_semaphore_count;
+}
+
 void iree_hal_amdgpu_reclaim_entry_release(
     iree_hal_amdgpu_reclaim_entry_t* entry,
     iree_arena_block_pool_t* block_pool) {
@@ -110,6 +126,7 @@ void iree_hal_amdgpu_reclaim_entry_release(
   entry->kernarg_write_position = 0;
   entry->queue_upload_write_position = 0;
   entry->count = 0;
+  entry->signal_semaphore_count = 0;
 }
 
 static inline void iree_hal_amdgpu_reclaim_entry_execute_pre_signal_action(
@@ -583,7 +600,7 @@ iree_host_size_t iree_hal_amdgpu_notification_ring_drain_reclaim_positions(
 
   // Execute all pre-signal completion actions first so wrapper-visible state
   // transitions happen-before any semaphore publication for the completed
-  // epochs. This is intentionally a separate pass from post-signal resource
+  // epochs. This is intentionally a separate pass from operation resource
   // release to keep queue retire ordering explicit.
   for (uint64_t epoch = previous_drained; epoch < current_epoch; ++epoch) {
     uint32_t reclaim_index = (uint32_t)(epoch & (ring->capacity - 1));
@@ -596,6 +613,26 @@ iree_host_size_t iree_hal_amdgpu_notification_ring_drain_reclaim_positions(
       retire_fn(&ring->reclaim_entries[reclaim_index], epoch + 1,
                 IREE_HAL_AMDGPU_RECLAIM_RETIRE_FLAG_NONE, retire_user_data);
     }
+  }
+
+  // Capture queue-owned positions and release all operation resources before
+  // publishing user-visible completion. Signal semaphore references remain in
+  // each entry until after publication so notification pointers stay live.
+  uint64_t highest_kernarg_position = 0;
+  uint64_t highest_queue_upload_position = 0;
+  for (uint64_t epoch = previous_drained; epoch < current_epoch; ++epoch) {
+    uint32_t reclaim_index = (uint32_t)(epoch & (ring->capacity - 1));
+    iree_hal_amdgpu_reclaim_entry_t* reclaim_entry =
+        &ring->reclaim_entries[reclaim_index];
+    if (reclaim_entry->kernarg_write_position > highest_kernarg_position) {
+      highest_kernarg_position = reclaim_entry->kernarg_write_position;
+    }
+    if (reclaim_entry->queue_upload_write_position >
+        highest_queue_upload_position) {
+      highest_queue_upload_position =
+          reclaim_entry->queue_upload_write_position;
+    }
+    iree_hal_amdgpu_reclaim_entry_release_operation_resources(reclaim_entry);
   }
 
   // Single-slot coalescing: accumulate consecutive same-semaphore entries
@@ -663,21 +700,10 @@ iree_host_size_t iree_hal_amdgpu_notification_ring_drain_reclaim_positions(
     }
   }
 
-  // Release retained resources for all completed epochs.
-  uint64_t highest_kernarg_position = 0;
-  uint64_t highest_queue_upload_position = 0;
+  // Release the signal semaphore references preserved through publication and
+  // reset all completed reclaim entries.
   for (uint64_t epoch = previous_drained; epoch < current_epoch; ++epoch) {
     uint32_t reclaim_index = (uint32_t)(epoch & (ring->capacity - 1));
-    uint64_t kernarg_write_position =
-        ring->reclaim_entries[reclaim_index].kernarg_write_position;
-    if (kernarg_write_position > highest_kernarg_position) {
-      highest_kernarg_position = kernarg_write_position;
-    }
-    uint64_t queue_upload_write_position =
-        ring->reclaim_entries[reclaim_index].queue_upload_write_position;
-    if (queue_upload_write_position > highest_queue_upload_position) {
-      highest_queue_upload_position = queue_upload_write_position;
-    }
     iree_hal_amdgpu_reclaim_entry_release(&ring->reclaim_entries[reclaim_index],
                                           ring->block_pool);
   }
@@ -738,6 +764,26 @@ iree_host_size_t iree_hal_amdgpu_notification_ring_fail_all_reclaim_positions(
     }
   }
 
+  // Capture queue-owned positions and release operation resources before
+  // making queue failure visible. Failed signal semaphore references remain
+  // retained until their failure has been published.
+  uint64_t highest_kernarg_position = 0;
+  uint64_t highest_queue_upload_position = 0;
+  for (uint64_t epoch = last_drained; epoch < last_published; ++epoch) {
+    uint32_t reclaim_index = (uint32_t)(epoch & (ring->capacity - 1));
+    iree_hal_amdgpu_reclaim_entry_t* reclaim_entry =
+        &ring->reclaim_entries[reclaim_index];
+    if (reclaim_entry->kernarg_write_position > highest_kernarg_position) {
+      highest_kernarg_position = reclaim_entry->kernarg_write_position;
+    }
+    if (reclaim_entry->queue_upload_write_position >
+        highest_queue_upload_position) {
+      highest_queue_upload_position =
+          reclaim_entry->queue_upload_write_position;
+    }
+    iree_hal_amdgpu_reclaim_entry_release_operation_resources(reclaim_entry);
+  }
+
   iree_host_size_t failed_count = 0;
   uint64_t read = iree_hal_amdgpu_notification_ring_load_position(
       &ring->read, iree_memory_order_relaxed);
@@ -764,21 +810,10 @@ iree_host_size_t iree_hal_amdgpu_notification_ring_fail_all_reclaim_positions(
     ++failed_count;
   }
 
-  // Release retained resources for all epochs.
-  uint64_t highest_kernarg_position = 0;
-  uint64_t highest_queue_upload_position = 0;
+  // Release the signal semaphore references preserved through failure
+  // publication and reset all reclaim entries.
   for (uint64_t epoch = last_drained; epoch < last_published; ++epoch) {
     uint32_t reclaim_index = (uint32_t)(epoch & (ring->capacity - 1));
-    uint64_t kernarg_write_position =
-        ring->reclaim_entries[reclaim_index].kernarg_write_position;
-    if (kernarg_write_position > highest_kernarg_position) {
-      highest_kernarg_position = kernarg_write_position;
-    }
-    uint64_t queue_upload_write_position =
-        ring->reclaim_entries[reclaim_index].queue_upload_write_position;
-    if (queue_upload_write_position > highest_queue_upload_position) {
-      highest_queue_upload_position = queue_upload_write_position;
-    }
     iree_hal_amdgpu_reclaim_entry_release(&ring->reclaim_entries[reclaim_index],
                                           ring->block_pool);
   }

--- a/runtime/src/iree/hal/drivers/amdgpu/util/notification_ring.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/notification_ring.h
@@ -150,8 +150,8 @@ typedef struct iree_hal_amdgpu_reclaim_entry_t iree_hal_amdgpu_reclaim_entry_t;
 // buffer commit/decommit. |status| is OK for normal GPU completion and a
 // borrowed queue/device failure status when the queue fails outstanding work.
 // Any object referenced by |user_data| must also be retained in the reclaim
-// entry's post-signal |resources| array if its lifetime must extend past
-// callback execution.
+// entry's operation resources if its lifetime must extend through callback
+// execution.
 typedef void(IREE_API_PTR* iree_hal_amdgpu_reclaim_action_fn_t)(
     iree_hal_amdgpu_reclaim_entry_t* entry, void* user_data,
     const iree_status_t status);
@@ -200,7 +200,7 @@ struct iree_hal_amdgpu_reclaim_entry_t {
   // Pointer to the retained-resource pointer array. Points to inline_resources
   // when count <= INLINE_CAPACITY, otherwise to a block-pool-allocated array.
   iree_hal_resource_t** resources;
-  // Optional resource set released with this entry after user signals publish.
+  // Optional operation resource set released before user signals publish.
   iree_hal_resource_set_t* resource_set;
   // One bounded pre-signal action for this epoch. Executed before any
   // user-visible signal publication for the epoch when drain observes normal
@@ -225,10 +225,13 @@ struct iree_hal_amdgpu_reclaim_entry_t {
   uint32_t profile_event_count;
   // Number of queue device profiling events reserved by this epoch.
   uint32_t queue_device_event_count;
-  // Number of retained resources stored in |resources|.
+  // Number of retained resources stored in |resources|. Signal semaphores
+  // occupy the first |signal_semaphore_count| entries and operation resources
+  // occupy the remainder.
   uint16_t count;
-  // Reserved padding for stable layout.
-  uint16_t reserved[1];
+  // Number of leading |resources| entries retaining signal semaphores until
+  // their notifications have been published.
+  uint16_t signal_semaphore_count;
   // Inline retained-resource storage for common small submissions.
   iree_hal_resource_t*
       inline_resources[IREE_HAL_AMDGPU_RECLAIM_INLINE_CAPACITY];
@@ -244,8 +247,8 @@ iree_status_t iree_hal_amdgpu_reclaim_entry_prepare(
     iree_hal_amdgpu_reclaim_entry_t* entry, iree_arena_block_pool_t* block_pool,
     uint16_t count, iree_hal_resource_t*** out_resources);
 
-// Releases all resources in the entry and returns any overflow block to
-// the pool. Zeros entry->count.
+// Releases all remaining resources in the entry and returns any overflow block
+// to the pool. Zeros entry->count and entry->signal_semaphore_count.
 void iree_hal_amdgpu_reclaim_entry_release(
     iree_hal_amdgpu_reclaim_entry_t* entry,
     iree_arena_block_pool_t* block_pool);

--- a/runtime/src/iree/hal/drivers/amdgpu/util/notification_ring_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/notification_ring_test.cc
@@ -47,6 +47,25 @@ typedef struct RetireCallbackState {
   int callback_count;
 } RetireCallbackState;
 
+typedef struct ReleaseOrderResource {
+  // HAL resource header used by the reclaim entry.
+  iree_hal_resource_t resource;
+  // Semaphore that must remain unpublished when this resource is destroyed.
+  iree_async_semaphore_t* semaphore;
+  // Number of times the destroy callback has run.
+  int destroy_count;
+} ReleaseOrderResource;
+
+static void DestroyReleaseOrderResource(iree_hal_resource_t* base_resource) {
+  auto* resource = reinterpret_cast<ReleaseOrderResource*>(base_resource);
+  EXPECT_EQ(iree_async_semaphore_query(resource->semaphore), 0u);
+  ++resource->destroy_count;
+}
+
+static const iree_hal_resource_vtable_t kReleaseOrderResourceVTable = {
+    /*.destroy=*/DestroyReleaseOrderResource,
+};
+
 static void VerifySemaphoreNotVisibleBeforePreSignalAction(
     iree_hal_amdgpu_reclaim_entry_t* entry, void* user_data,
     const iree_status_t status) {
@@ -745,6 +764,41 @@ TEST_F(NotificationRingTest, PreSignalActionRunsBeforeSemaphorePublication) {
   iree_async_semaphore_release(semaphore);
 }
 
+TEST_F(NotificationRingTest,
+       OperationResourcesReleaseBeforeSemaphorePublication) {
+  IREE_ASSERT_OK_AND_ASSIGN(auto ring, InitializeRing());
+  iree_async_semaphore_t* semaphore = CreateSemaphore();
+
+  iree_hal_amdgpu_reclaim_entry_t* reclaim_entry =
+      ReclaimEntryForNextEpoch(ring.get());
+  iree_hal_resource_t** resources = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_reclaim_entry_prepare(
+      reclaim_entry, &block_pool, /*count=*/2, &resources));
+  iree_async_semaphore_retain(semaphore);
+  resources[0] = reinterpret_cast<iree_hal_resource_t*>(semaphore);
+  ReleaseOrderResource operation_resource = {};
+  iree_hal_resource_initialize(&kReleaseOrderResourceVTable,
+                               &operation_resource.resource);
+  operation_resource.semaphore = semaphore;
+  resources[1] = &operation_resource.resource;
+  reclaim_entry->signal_semaphore_count = 1;
+  reclaim_entry->count = 2;
+
+  uint64_t epoch = iree_hal_amdgpu_notification_ring_advance_epoch(ring.get());
+  PushNotification(ring.get(), epoch, semaphore, 1);
+  SimulateCompletions(ring.get(), 1);
+
+  uint64_t kernarg_position = 0;
+  EXPECT_EQ(
+      iree_hal_amdgpu_notification_ring_drain(
+          ring.get(), EmptyFrontier(), nullptr, nullptr, &kernarg_position),
+      1u);
+  EXPECT_EQ(operation_resource.destroy_count, 1);
+  EXPECT_EQ(iree_async_semaphore_query(semaphore), 1u);
+
+  iree_async_semaphore_release(semaphore);
+}
+
 TEST_F(NotificationRingTest, RetireCallbackRunsBeforeSemaphorePublication) {
   IREE_ASSERT_OK_AND_ASSIGN(auto ring, InitializeRing());
   iree_async_semaphore_t* semaphore = CreateSemaphore();
@@ -795,8 +849,21 @@ TEST_F(NotificationRingTest, FailAllRetireCallbackRunsBeforeSemaphoreFailure) {
   };
 
   iree_hal_amdgpu_reclaim_entry_t* reclaim_entry =
-      ReclaimEntryForNextEpoch(ring.get(), /*kernarg_write_position=*/64,
-                               /*queue_upload_write_position=*/256);
+      ReclaimEntryForNextEpoch(ring.get());
+  iree_hal_resource_t** resources = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_reclaim_entry_prepare(
+      reclaim_entry, &block_pool, /*count=*/2, &resources));
+  reclaim_entry->kernarg_write_position = 64;
+  reclaim_entry->queue_upload_write_position = 256;
+  iree_async_semaphore_retain(semaphore);
+  resources[0] = reinterpret_cast<iree_hal_resource_t*>(semaphore);
+  ReleaseOrderResource operation_resource = {};
+  iree_hal_resource_initialize(&kReleaseOrderResourceVTable,
+                               &operation_resource.resource);
+  operation_resource.semaphore = semaphore;
+  resources[1] = &operation_resource.resource;
+  reclaim_entry->signal_semaphore_count = 1;
+  reclaim_entry->count = 2;
   reclaim_entry->pre_signal_action = {
       /*.fn=*/VerifySemaphoreNotVisibleBeforeFailedPreSignalAction,
       /*.user_data=*/&action_state,
@@ -822,6 +889,7 @@ TEST_F(NotificationRingTest, FailAllRetireCallbackRunsBeforeSemaphoreFailure) {
   EXPECT_EQ(callback_state.flags, IREE_HAL_AMDGPU_RECLAIM_RETIRE_FLAG_FAILED);
   EXPECT_EQ(reclaim_positions.kernarg_write_position, 64u);
   EXPECT_EQ(reclaim_positions.queue_upload_write_position, 256u);
+  EXPECT_EQ(operation_resource.destroy_count, 1);
 
   iree_async_semaphore_release(semaphore);
 }


### PR DESCRIPTION
AMDGPU queue completion now drops operation-resource retains before publishing user-visible completion semaphores. Completion is therefore a real ownership boundary: once a waiter observes the signal, buffers and other submission resources are no longer held by the queue, so release callbacks and externally owned allocation teardown have completed.

Reclaim entries distinguish leading signal-semaphore references from operation references. The drain executes completion actions and retire hooks, releases operation resources and resource sets, publishes the coalesced signals, and then releases the signal references. Queue failure follows the same order. Signal semaphores remain alive through publication while imported-buffer callbacks can no longer race waiters destroying their backing allocations.

Notification-ring coverage uses a real HAL resource whose destructor verifies that the completion semaphore is not yet visible. This closes the race exposed by `AllocatorTest.HostAllocationImportUsesFinePoolAtomicContract`, where a waiter could observe completion while the queue still retained the imported buffer.
