### PR TITLE
[Loom] Link kernel configurations without implementations

### DIFF
--- a/loom/py/loom/format/bytecode/reader.py
+++ b/loom/py/loom/format/bytecode/reader.py
@@ -193,6 +193,7 @@ class BytecodeReader:
         self._module_op_count = 0
         self._wire_symbol_names: list[str] = []
         self._wire_symbol_kinds: list[int] = []
+        self._wire_symbol_root_region_counts: list[int] = []
 
     def read(self) -> Module:
         """Read and return the module."""
@@ -1046,6 +1047,7 @@ class BytecodeReader:
                 source_module = self._strings[source_module_id]
                 source_symbol = self._strings[source_symbol_id]
 
+            root_region_count = 0
             if kind <= 4:  # Function and template signature symbol kinds.
                 op_table_index_plus1, offset = decode_varint(sym_data, offset)
                 if op_table_index_plus1 == 0:
@@ -1163,6 +1165,7 @@ class BytecodeReader:
                     )
                 )
                 decoded_region_payload_count += region_payload_count
+                root_region_count = len(regions)
 
                 # Build the attributes dict for this func-like op.
                 symbol_field = self._symbol_field_for_op(op_name)
@@ -1307,15 +1310,17 @@ class BytecodeReader:
                 )
                 module.add_symbol(symbol)
             elif kind == SymbolKind.RECORD.value:
-                offset, region_payload_count = self._read_record_symbol_payload(
-                    sym_data,
-                    offset,
-                    ir_data,
-                    module,
-                    name,
-                    flags,
-                    source_module,
-                    source_symbol,
+                offset, region_payload_count, root_region_count = (
+                    self._read_record_symbol_payload(
+                        sym_data,
+                        offset,
+                        ir_data,
+                        module,
+                        name,
+                        flags,
+                        source_module,
+                        source_symbol,
+                    )
                 )
                 decoded_region_payload_count += region_payload_count
             elif kind == SYMBOL_KIND_ANCHOR:
@@ -1323,6 +1328,7 @@ class BytecodeReader:
                     raise BytecodeError("provider anchor must be private and unflagged")
             else:
                 raise BytecodeError(f"unsupported symbol kind: {kind}")
+            self._wire_symbol_root_region_counts.append(root_region_count)
 
         for (
             symbol,
@@ -1425,7 +1431,10 @@ class BytecodeReader:
         if symbol_count != len(self._wire_symbol_names):
             raise BytecodeError("SYMBOL_REFERENCES row count does not match SYMBOLS")
         minimum_encoded_bytes = (
-            1 + symbol_count * 2 + total_dependency_count + total_template_demand_count
+            1
+            + symbol_count * 2
+            + total_dependency_count * 2
+            + total_template_demand_count * 2
         )
         if minimum_encoded_bytes > len(data) - offset:
             raise BytecodeError(
@@ -1437,22 +1446,34 @@ class BytecodeReader:
         if module_dependency_count > total_dependency_count:
             raise BytecodeError("module dependency count exceeds declared total")
 
-        def read_dependencies(count: int, offset: int) -> int:
+        def read_dependencies(
+            count: int, offset: int, source_root_region_count: int
+        ) -> int:
             nonlocal decoded_dependency_count
             for _ in range(count):
+                source_root_region_index_plus_one, offset = decode_varint(data, offset)
+                if source_root_region_index_plus_one > source_root_region_count:
+                    raise BytecodeError(
+                        "dependency source root region index is out of range"
+                    )
                 dependency, offset = decode_varint(data, offset)
                 if dependency >= symbol_count:
                     raise BytecodeError("dependency symbol index is out of range")
                 decoded_dependency_count += 1
             return offset
 
-        offset = read_dependencies(module_dependency_count, offset)
+        offset = read_dependencies(module_dependency_count, offset, 0)
         decoded_template_demand_count = 0
-        for _ in range(symbol_count):
+        for symbol_index in range(symbol_count):
+            source_root_region_count = self._wire_symbol_root_region_counts[
+                symbol_index
+            ]
             dependency_count, offset = decode_varint(data, offset)
             if dependency_count > total_dependency_count - decoded_dependency_count:
                 raise BytecodeError("symbol dependency count exceeds declared total")
-            offset = read_dependencies(dependency_count, offset)
+            offset = read_dependencies(
+                dependency_count, offset, source_root_region_count
+            )
 
             template_demand_count, offset = decode_varint(data, offset)
             if (
@@ -1463,6 +1484,11 @@ class BytecodeReader:
                     "symbol contract demand count exceeds declared total"
                 )
             for _ in range(template_demand_count):
+                source_root_region_index_plus_one, offset = decode_varint(data, offset)
+                if source_root_region_index_plus_one > source_root_region_count:
+                    raise BytecodeError(
+                        "template demand source root region index is out of range"
+                    )
                 family_symbol_ordinal, offset = decode_varint(data, offset)
                 if family_symbol_ordinal >= symbol_count:
                     raise BytecodeError(
@@ -1487,7 +1513,7 @@ class BytecodeReader:
         flags: int,
         source_module: str,
         source_symbol: str,
-    ) -> tuple[int, int]:
+    ) -> tuple[int, int, int]:
         """Read one RECORD symbol payload and append it to ``module``."""
         op_table_index_plus1, offset = decode_varint(sym_data, offset)
         if op_table_index_plus1 == 0:
@@ -1535,7 +1561,7 @@ class BytecodeReader:
             source_symbol=source_symbol,
         )
         module.add_symbol(symbol)
-        return offset, region_payload_count
+        return offset, region_payload_count, len(record_regions)
 
     def _validate_symbol_header(self, flags: int, kind: int, visibility: int) -> None:
         """Validate the common symbol record header."""

--- a/loom/py/loom/format/bytecode/reader_test.py
+++ b/loom/py/loom/format/bytecode/reader_test.py
@@ -522,6 +522,44 @@ class TestMalformedSymbolReferences:
         with pytest.raises(BytecodeError, match="declared records exceed"):
             read_module(bytes(data))
 
+    def test_dependency_source_root_must_belong_to_owning_symbol(self) -> None:
+        module = Module(name="test")
+        _make_func(module, "target", [], is_declaration=True)
+        _make_func(
+            module,
+            "caller",
+            [],
+            ops=[
+                Operation(
+                    name="func.call",
+                    attributes={"callee": SymbolName("target")},
+                ),
+                Operation(name="test.yield"),
+            ],
+        )
+        data = bytearray(write_module(module))
+        module_offset, _module_length = _module_range(data)
+        _entry_offset, section_offset, _section_length = _find_section_entry(
+            data, SECTION_SYMBOL_REFERENCES
+        )
+        offset = module_offset + section_offset
+        symbol_count, offset = decode_varint(data, offset)
+        dependency_count, offset = decode_varint(data, offset)
+        template_demand_count, offset = decode_varint(data, offset)
+        module_dependency_count, offset = decode_varint(data, offset)
+        assert (symbol_count, dependency_count, template_demand_count) == (2, 1, 0)
+        assert module_dependency_count == 0
+        target_dependency_count, offset = decode_varint(data, offset)
+        target_demand_count, offset = decode_varint(data, offset)
+        caller_dependency_count, offset = decode_varint(data, offset)
+        assert (target_dependency_count, target_demand_count) == (0, 0)
+        assert caller_dependency_count == 1
+        assert data[offset] == 1
+        data[offset] = 2
+
+        with pytest.raises(BytecodeError, match="source root region index"):
+            read_module(bytes(data))
+
 
 class TestMalformedLocationMode:
     def test_full_locations_mode_is_rejected_until_implemented(self) -> None:

--- a/loom/py/loom/format/bytecode/writer.py
+++ b/loom/py/loom/format/bytecode/writer.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import struct
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from typing import Any, ClassVar, cast
 
 from loom.dsl import FuncLikeInterface, SymbolReferenceRole
@@ -180,7 +181,7 @@ BYTECODE_IR_KIND_BY_TYPE_KIND: dict[int, TypeKind] = {
 
 # File magic and version.
 MAGIC = b"LOOM"
-FORMAT_VERSION = 30
+FORMAT_VERSION = 31
 PRODUCER = "loom-py"
 
 SOURCE_TRIVIA_LEADING_BLANK_LINE = 1
@@ -272,6 +273,22 @@ class NumberingContext:
 # ============================================================================
 
 
+@dataclass(frozen=True, slots=True)
+class _SymbolReferenceSourceScope:
+    """Symbol and independently serializable root that own a reference."""
+
+    symbol_index: int | None = None
+    root_region_index_plus_one: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class _SymbolReferenceRecord:
+    """Wire symbol reference with its source contract or root region."""
+
+    source_root_region_index_plus_one: int
+    target_symbol_index: int
+
+
 class _SymbolReferenceProjectionBuilder:
     """Builds wire-symbol dependency and abstract-provider rows."""
 
@@ -280,49 +297,56 @@ class _SymbolReferenceProjectionBuilder:
         module: Module,
         wire_symbol_indices: dict[str, int],
         op_decls_by_name: Mapping[str, Any],
-        numbering: NumberingContext,
     ) -> None:
         self._module = module
         self._wire_symbol_indices = wire_symbol_indices
         self._op_decls_by_name = op_decls_by_name
-        self._numbering = numbering
-        self._module_dependencies: list[int] = []
-        self._symbol_dependencies: list[list[int]] = [[] for _ in wire_symbol_indices]
-        self._symbol_template_demands: list[list[int]] = [
+        self._module_dependencies: list[_SymbolReferenceRecord] = []
+        self._symbol_dependencies: list[list[_SymbolReferenceRecord]] = [
+            [] for _ in wire_symbol_indices
+        ]
+        self._symbol_template_demands: list[list[_SymbolReferenceRecord]] = [
             [] for _ in wire_symbol_indices
         ]
 
     def build(
         self,
     ) -> tuple[
-        tuple[int, ...],
-        tuple[tuple[int, ...], ...],
-        tuple[tuple[int, ...], ...],
+        tuple[_SymbolReferenceRecord, ...],
+        tuple[tuple[_SymbolReferenceRecord, ...], ...],
+        tuple[tuple[_SymbolReferenceRecord, ...], ...],
     ]:
         """Builds rows in the linked-list order used by the C analysis."""
+        module_scope = _SymbolReferenceSourceScope()
         for operation in self._module.body.ops:
-            self._visit_operation(None, operation)
+            self._visit_operation(module_scope, operation)
         for encoding in self._module.encodings:
-            self._visit_encoding(None, encoding)
+            self._visit_encoding(module_scope, encoding)
         return (
             tuple(reversed(self._module_dependencies)),
             tuple(tuple(reversed(row)) for row in self._symbol_dependencies),
             tuple(tuple(reversed(row)) for row in self._symbol_template_demands),
         )
 
-    def _add_dependency(self, source_symbol_index: int | None, name: str) -> None:
+    def _add_dependency(
+        self, source_scope: _SymbolReferenceSourceScope, name: str
+    ) -> None:
         try:
             target_symbol_index = self._wire_symbol_indices[name]
         except KeyError as exc:
             raise ValueError(f"unresolved symbol dependency {name!r}") from exc
-        if source_symbol_index is None:
-            self._module_dependencies.append(target_symbol_index)
+        record = _SymbolReferenceRecord(
+            source_root_region_index_plus_one=source_scope.root_region_index_plus_one,
+            target_symbol_index=target_symbol_index,
+        )
+        if source_scope.symbol_index is None:
+            self._module_dependencies.append(record)
         else:
-            self._symbol_dependencies[source_symbol_index].append(target_symbol_index)
+            self._symbol_dependencies[source_scope.symbol_index].append(record)
 
     def _visit_attr(
         self,
-        source_symbol_index: int | None,
+        source_scope: _SymbolReferenceSourceScope,
         value: Any,
         attr_def: Any | None = None,
     ) -> None:
@@ -334,92 +358,104 @@ class _SymbolReferenceProjectionBuilder:
         )
         if attr_type == "symbol" or isinstance(value, SymbolName):
             if not is_availability:
-                self._add_dependency(source_symbol_index, str(value))
+                self._add_dependency(source_scope, str(value))
             return
         if attr_type == "symbol_array" or isinstance(value, SymbolNameArray):
             if not is_availability:
                 for name in value:
-                    self._add_dependency(source_symbol_index, str(name))
+                    self._add_dependency(source_scope, str(name))
             return
         if attr_type == "symbol_set" or isinstance(value, SymbolNameSet):
             if not is_availability:
                 for name in value:
-                    self._add_dependency(source_symbol_index, str(name))
+                    self._add_dependency(source_scope, str(name))
             return
         if isinstance(value, _IR_TYPE_CLASSES):
-            self._visit_type(source_symbol_index, cast(Type, value))
+            self._visit_type(source_scope, cast(Type, value))
             return
         if isinstance(value, EncodingInstance):
-            self._visit_encoding(source_symbol_index, value)
+            self._visit_encoding(source_scope, value)
             return
         if isinstance(value, ParameterizedAttr):
             for parameter, slot in zip(
                 value.definition.parameters, value.slots, strict=True
             ):
                 if slot is not None:
-                    self._visit_attr(source_symbol_index, slot, parameter)
+                    self._visit_attr(source_scope, slot, parameter)
             return
         if isinstance(value, ParameterizedAttrArray):
             for element in value:
-                self._visit_attr(source_symbol_index, element)
+                self._visit_attr(source_scope, element)
             return
         if isinstance(value, Mapping):
             for nested_value in value.values():
-                self._visit_attr(source_symbol_index, nested_value)
+                self._visit_attr(source_scope, nested_value)
             return
         if isinstance(value, list | tuple):
             for nested_value in value:
-                self._visit_attr(source_symbol_index, nested_value)
+                self._visit_attr(source_scope, nested_value)
 
     def _visit_encoding(
-        self, source_symbol_index: int | None, encoding: EncodingInstance
+        self,
+        source_scope: _SymbolReferenceSourceScope,
+        encoding: EncodingInstance,
     ) -> None:
         for _, parameter_value in encoding.params:
-            self._visit_attr(source_symbol_index, parameter_value)
+            self._visit_attr(source_scope, parameter_value)
 
-    def _visit_type(self, source_symbol_index: int | None, ir_type: Type) -> None:
+    def _visit_type(
+        self, source_scope: _SymbolReferenceSourceScope, ir_type: Type
+    ) -> None:
         match ir_type:
             case ShapedType(element_type=element_type, encoding=encoding):
-                self._visit_type(source_symbol_index, element_type)
+                self._visit_type(source_scope, element_type)
                 if isinstance(encoding, EncodingInstance):
-                    self._visit_encoding(source_symbol_index, encoding)
+                    self._visit_encoding(source_scope, encoding)
             case FunctionType(arg_types=args, result_types=results):
                 for nested_type in (*args, *results):
-                    self._visit_type(source_symbol_index, nested_type)
+                    self._visit_type(source_scope, nested_type)
             case DialectType(params=parameters):
                 for nested_type in parameters:
-                    self._visit_type(source_symbol_index, nested_type)
+                    self._visit_type(source_scope, nested_type)
             case ParameterizedType(definition=definition, slots=slots):
                 for parameter, value in zip(definition.params, slots, strict=True):
                     if value is not None:
-                        self._visit_attr(source_symbol_index, value, parameter)
+                        self._visit_attr(source_scope, value, parameter)
             case RegisterType(value_type=value_type) if value_type is not None:
-                self._visit_type(source_symbol_index, value_type)
+                self._visit_type(source_scope, value_type)
             case _:
                 pass
 
-    def _visit_value(self, source_symbol_index: int | None, value_id: int) -> None:
+    def _visit_value(
+        self, source_scope: _SymbolReferenceSourceScope, value_id: int
+    ) -> None:
         if 0 <= value_id < len(self._module.values):
-            self._visit_type(source_symbol_index, self._module.values[value_id].type)
+            self._visit_type(source_scope, self._module.values[value_id].type)
 
-    def _visit_region(self, source_symbol_index: int | None, region: Region) -> None:
+    def _visit_region(
+        self, source_scope: _SymbolReferenceSourceScope, region: Region
+    ) -> None:
         for block in region.blocks:
             for argument_id in block.arg_ids:
-                self._visit_value(source_symbol_index, argument_id)
+                self._visit_value(source_scope, argument_id)
             for operation in block.ops:
-                self._visit_operation(source_symbol_index, operation)
+                self._visit_operation(source_scope, operation)
 
     def _visit_operation(
-        self, source_symbol_index: int | None, operation: Operation
+        self, source_scope: _SymbolReferenceSourceScope, operation: Operation
     ) -> None:
         op_decl = self._op_decls_by_name.get(operation.name)
         symbol_def = getattr(op_decl, "symbol_def", None)
-        nested_source_symbol_index = source_symbol_index
+        nested_source_scope = source_scope
+        defines_symbol = False
         if symbol_def is not None:
             symbol_name = operation.attributes.get(symbol_def.field)
             if isinstance(symbol_name, str):
                 try:
-                    nested_source_symbol_index = self._wire_symbol_indices[symbol_name]
+                    nested_source_scope = _SymbolReferenceSourceScope(
+                        symbol_index=self._wire_symbol_indices[symbol_name]
+                    )
+                    defines_symbol = True
                 except KeyError as exc:
                     raise ValueError(
                         f"symbol-defining operation {operation.name!r} names "
@@ -428,7 +464,7 @@ class _SymbolReferenceProjectionBuilder:
 
         if operation.name == "template.apply":
             family = operation.attributes.get("family")
-            if nested_source_symbol_index is None:
+            if nested_source_scope.symbol_index is None:
                 raise ValueError("template.apply is not owned by a module symbol")
             if not isinstance(family, str):
                 raise ValueError("template.apply family must be a symbol")
@@ -438,22 +474,33 @@ class _SymbolReferenceProjectionBuilder:
                 raise ValueError(
                     f"template.apply references unknown family {family!r}"
                 ) from exc
-            self._symbol_template_demands[nested_source_symbol_index].append(
-                family_symbol_ordinal
+            self._symbol_template_demands[nested_source_scope.symbol_index].append(
+                _SymbolReferenceRecord(
+                    source_root_region_index_plus_one=(
+                        nested_source_scope.root_region_index_plus_one
+                    ),
+                    target_symbol_index=family_symbol_ordinal,
+                )
             )
 
         for value_id in (*operation.operands, *operation.results):
-            self._visit_value(nested_source_symbol_index, value_id)
+            self._visit_value(nested_source_scope, value_id)
         for key, value in operation.attributes.items():
             if symbol_def is not None and key == symbol_def.field:
                 continue
             self._visit_attr(
-                nested_source_symbol_index,
+                nested_source_scope,
                 value,
                 attr_def_for_op(self._op_decls_by_name, operation.name, key),
             )
-        for region in operation.regions:
-            self._visit_region(nested_source_symbol_index, region)
+        for region_index, region in enumerate(operation.regions):
+            child_source_scope = nested_source_scope
+            if defines_symbol:
+                child_source_scope = _SymbolReferenceSourceScope(
+                    symbol_index=nested_source_scope.symbol_index,
+                    root_region_index_plus_one=region_index + 1,
+                )
+            self._visit_region(child_source_scope, region)
 
 
 # ============================================================================
@@ -506,7 +553,6 @@ class BytecodeWriter:
             self._module,
             self._wire_symbol_indices,
             self._op_decls_by_name,
-            self._ctx,
         ).build()
 
     # --- Pass 1: Numbering ---
@@ -2314,19 +2360,22 @@ class BytecodeWriter:
         buf.write_varint(total_dependency_count)
         buf.write_varint(total_template_demand_count)
         buf.write_varint(len(self._module_dependencies))
-        for target_symbol_index in self._module_dependencies:
-            buf.write_varint(target_symbol_index)
+        for dependency in self._module_dependencies:
+            buf.write_varint(dependency.source_root_region_index_plus_one)
+            buf.write_varint(dependency.target_symbol_index)
         for dependencies, template_demands in zip(
             self._symbol_dependencies,
             self._symbol_template_demands,
             strict=True,
         ):
             buf.write_varint(len(dependencies))
-            for target_symbol_index in dependencies:
-                buf.write_varint(target_symbol_index)
+            for dependency in dependencies:
+                buf.write_varint(dependency.source_root_region_index_plus_one)
+                buf.write_varint(dependency.target_symbol_index)
             buf.write_varint(len(template_demands))
-            for family_symbol_ordinal in template_demands:
-                buf.write_varint(family_symbol_ordinal)
+            for demand in template_demands:
+                buf.write_varint(demand.source_root_region_index_plus_one)
+                buf.write_varint(demand.target_symbol_index)
         return buf.get_bytes()
 
     # --- File assembly ---

--- a/loom/py/loom/format/bytecode/writer_test.py
+++ b/loom/py/loom/format/bytecode/writer_test.py
@@ -63,6 +63,7 @@ from loom.format.bytecode.writer import (
     LOCATION_MODE_NO_LOCATIONS,
     LOCATION_MODE_SOURCE_LOCATIONS,
     SECTION_LOCATIONS,
+    SECTION_SYMBOL_REFERENCES,
     write_module,
 )
 from loom.format.text.parser import Parser
@@ -164,6 +165,23 @@ def _section_kinds(data: bytes | bytearray) -> list[int]:
         section_kinds.append(struct.unpack_from("<H", data, offset)[0])
         offset += 32
     return section_kinds
+
+
+def _section_payload(data: bytes, section_kind: int) -> bytes:
+    module_offset, _module_length = _module_range(data)
+    offset = module_offset
+    section_count, offset = decode_varint(data, offset)
+    for _ in range(4):
+        _count, offset = decode_varint(data, offset)
+    for _ in range(section_count):
+        kind = struct.unpack_from("<H", data, offset)[0]
+        section_offset = struct.unpack_from("<Q", data, offset + 8)[0]
+        section_length = struct.unpack_from("<Q", data, offset + 16)[0]
+        if kind == section_kind:
+            absolute_offset = module_offset + section_offset
+            return data[absolute_offset : absolute_offset + section_length]
+        offset += 32
+    raise AssertionError(f"missing section kind {section_kind}")
 
 
 def _test_ptr_register_type(
@@ -555,6 +573,54 @@ class TestFileHeader:
         m1 = _make_func_module()
         m2 = _make_func_module()
         assert write_module(m1) == write_module(m2)
+
+
+class TestSymbolReferencesSection:
+    def test_records_retain_contract_and_root_region_origins(self) -> None:
+        module = _text_parser().parse(
+            "test.record @config_dependency\n"
+            "test.record @implementation_dependency\n"
+            "template.decl @demo.contract() -> (index)\n"
+            "test.split_func @split_root() {\n"
+            "  test.symbol_array_attrs [@config_dependency] using []\n"
+            "  test.yield\n"
+            "} launch {\n"
+            "  test.symbol_array_attrs [@implementation_dependency] using []\n"
+            "  %result = template.apply<@demo.contract>() : () -> (index)\n"
+            "  test.yield\n"
+            "}\n"
+        )
+        data = _section_payload(write_module(module), SECTION_SYMBOL_REFERENCES)
+        offset = 0
+        symbol_count, offset = decode_varint(data, offset)
+        dependency_count, offset = decode_varint(data, offset)
+        template_demand_count, offset = decode_varint(data, offset)
+        module_dependency_count, offset = decode_varint(data, offset)
+        assert (symbol_count, dependency_count, template_demand_count) == (4, 3, 1)
+        assert module_dependency_count == 0
+
+        rows: list[tuple[list[tuple[int, int]], list[tuple[int, int]]]] = []
+        for _ in range(symbol_count):
+            row_dependency_count, offset = decode_varint(data, offset)
+            dependencies = []
+            for _ in range(row_dependency_count):
+                source_root, offset = decode_varint(data, offset)
+                target_symbol, offset = decode_varint(data, offset)
+                dependencies.append((source_root, target_symbol))
+            row_template_demand_count, offset = decode_varint(data, offset)
+            template_demands = []
+            for _ in range(row_template_demand_count):
+                source_root, offset = decode_varint(data, offset)
+                family_symbol, offset = decode_varint(data, offset)
+                template_demands.append((source_root, family_symbol))
+            rows.append((dependencies, template_demands))
+
+        assert rows[:3] == [([], []), ([], []), ([], [])]
+        assert rows[3] == (
+            [(2, 2), (2, 1), (1, 0)],
+            [(2, 2)],
+        )
+        assert offset == len(data)
 
 
 class TestModuleDirectory:

--- a/loom/src/loom/analysis/symbol_references.c
+++ b/loom/src/loom/analysis/symbol_references.c
@@ -60,6 +60,14 @@ typedef struct loom_symbol_reference_builder_t {
   } template_providers;
 } loom_symbol_reference_builder_t;
 
+// Symbol definition and root region currently owning a reference occurrence.
+typedef struct loom_symbol_reference_source_scope_t {
+  // Module-local owning symbol, or invalid for module-root references.
+  loom_symbol_id_t symbol_id;
+  // Root region slot on symbol_id plus one, or zero for its contract.
+  uint8_t root_region_index_plus_one;
+} loom_symbol_reference_source_scope_t;
+
 static void loom_symbol_reference_initialize_symbol_occurrences(
     loom_symbol_reference_symbol_occurrences_t* symbols,
     iree_host_size_t symbol_count) {
@@ -92,17 +100,18 @@ static iree_status_t loom_symbol_reference_builder_initialize(
 }
 
 static iree_status_t loom_symbol_reference_builder_append_occurrence(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope,
     loom_symbol_id_t target_symbol_id,
     loom_symbol_reference_occurrence_kind_t kind,
     loom_symbol_reference_role_t role, uint16_t attr_index,
     const loom_op_t* user_op) {
-  if (source_symbol_id != LOOM_SYMBOL_ID_INVALID &&
-      source_symbol_id >= builder->module->symbols.count) {
+  if (source_scope.symbol_id != LOOM_SYMBOL_ID_INVALID &&
+      source_scope.symbol_id >= builder->module->symbols.count) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
         "source symbol id %u is out of range for %" PRIhsz " symbols",
-        (unsigned)source_symbol_id, builder->module->symbols.count);
+        (unsigned)source_scope.symbol_id, builder->module->symbols.count);
   }
   if (target_symbol_id >= builder->module->symbols.count) {
     return iree_make_status(
@@ -127,10 +136,12 @@ static iree_status_t loom_symbol_reference_builder_append_occurrence(
   loom_symbol_reference_occurrence_t* occurrence =
       &builder->occurrences[occurrence_id];
   *occurrence = (loom_symbol_reference_occurrence_t){
-      .source_symbol_id = source_symbol_id,
+      .source_symbol_id = source_scope.symbol_id,
       .target_symbol_id = target_symbol_id,
       .kind = kind,
       .role = role,
+      .source_root_region_index_plus_one =
+          source_scope.root_region_index_plus_one,
       .attr_index = attr_index,
       .user_op = user_op,
       .next_outgoing_occurrence_id =
@@ -142,7 +153,7 @@ static iree_status_t loom_symbol_reference_builder_append_occurrence(
       occurrence_id;
   ++builder->symbols[target_symbol_id].incoming_count;
 
-  if (source_symbol_id == LOOM_SYMBOL_ID_INVALID) {
+  if (source_scope.symbol_id == LOOM_SYMBOL_ID_INVALID) {
     occurrence->next_outgoing_occurrence_id =
         builder->first_module_occurrence_id;
     builder->first_module_occurrence_id = occurrence_id;
@@ -150,15 +161,16 @@ static iree_status_t loom_symbol_reference_builder_append_occurrence(
     return iree_ok_status();
   }
   occurrence->next_outgoing_occurrence_id =
-      builder->symbols[source_symbol_id].first_outgoing_occurrence_id;
-  builder->symbols[source_symbol_id].first_outgoing_occurrence_id =
+      builder->symbols[source_scope.symbol_id].first_outgoing_occurrence_id;
+  builder->symbols[source_scope.symbol_id].first_outgoing_occurrence_id =
       occurrence_id;
-  ++builder->symbols[source_symbol_id].outgoing_count;
+  ++builder->symbols[source_scope.symbol_id].outgoing_count;
   return iree_ok_status();
 }
 
 static iree_status_t loom_symbol_reference_add_ref(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope,
     loom_symbol_ref_t target_ref, loom_symbol_reference_occurrence_kind_t kind,
     loom_symbol_reference_role_t role, uint16_t attr_index,
     const loom_op_t* user_op) {
@@ -166,14 +178,15 @@ static iree_status_t loom_symbol_reference_add_ref(
     return iree_ok_status();
   }
   return loom_symbol_reference_builder_append_occurrence(
-      builder, source_symbol_id, target_ref.symbol_id, kind, role, attr_index,
+      builder, source_scope, target_ref.symbol_id, kind, role, attr_index,
       user_op);
 }
 
 static iree_status_t loom_symbol_reference_append_template_demand(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope,
     const loom_op_t* apply_op) {
-  if (source_symbol_id >= builder->module->symbols.count) {
+  if (source_scope.symbol_id >= builder->module->symbols.count) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "template.apply is not owned by a module symbol");
   }
@@ -214,10 +227,12 @@ static iree_status_t loom_symbol_reference_append_template_demand(
   const loom_template_demand_id_t demand_id =
       (loom_template_demand_id_t)builder->template_demands.count++;
   loom_symbol_reference_symbol_occurrences_t* source =
-      &builder->symbols[source_symbol_id];
+      &builder->symbols[source_scope.symbol_id];
   builder->template_demands.values[demand_id] = (loom_template_demand_t){
       .family_symbol_id = family.symbol_id,
-      .source_symbol_id = source_symbol_id,
+      .source_symbol_id = source_scope.symbol_id,
+      .source_root_region_index_plus_one =
+          source_scope.root_region_index_plus_one,
       .apply_op = apply_op,
       .next_source_demand_id = source->first_template_demand_id,
   };
@@ -322,18 +337,21 @@ static bool loom_symbol_reference_attr_may_contain_ref(loom_attribute_t attr) {
 }
 
 static iree_status_t loom_symbol_reference_visit_type(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
-    loom_type_t type, loom_symbol_reference_occurrence_kind_t kind,
-    uint16_t attr_index, const loom_op_t* user_op);
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope, loom_type_t type,
+    loom_symbol_reference_occurrence_kind_t kind, uint16_t attr_index,
+    const loom_op_t* user_op);
 
 static iree_status_t loom_symbol_reference_visit_attr(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
-    loom_attribute_t attr, const loom_attr_descriptor_t* descriptor,
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope, loom_attribute_t attr,
+    const loom_attr_descriptor_t* descriptor,
     loom_symbol_reference_occurrence_kind_t kind, uint16_t attr_index,
     const loom_op_t* user_op, uint8_t dict_depth);
 
 static iree_status_t loom_symbol_reference_visit_encoding(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope,
     const loom_encoding_t* encoding,
     loom_symbol_reference_occurrence_kind_t kind, uint16_t attr_index,
     const loom_op_t* user_op) {
@@ -345,16 +363,17 @@ static iree_status_t loom_symbol_reference_visit_encoding(
   }
   for (uint8_t i = 0; i < encoding->attribute_count; ++i) {
     IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_attr(
-        builder, source_symbol_id, encoding->attributes[i].value,
+        builder, source_scope, encoding->attributes[i].value,
         /*descriptor=*/NULL, kind, attr_index, user_op, /*dict_depth=*/0));
   }
   return iree_ok_status();
 }
 
 static iree_status_t loom_symbol_reference_visit_static_encoding(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
-    uint16_t encoding_id, loom_symbol_reference_occurrence_kind_t kind,
-    uint16_t attr_index, const loom_op_t* user_op) {
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope, uint16_t encoding_id,
+    loom_symbol_reference_occurrence_kind_t kind, uint16_t attr_index,
+    const loom_op_t* user_op) {
   if (encoding_id == 0) return iree_ok_status();
   const loom_encoding_t* encoding =
       loom_module_encoding(builder->module, encoding_id);
@@ -365,34 +384,34 @@ static iree_status_t loom_symbol_reference_visit_static_encoding(
         " encodings",
         (unsigned)encoding_id, builder->module->encodings.count);
   }
-  return loom_symbol_reference_visit_encoding(
-      builder, source_symbol_id, encoding, kind, attr_index, user_op);
+  return loom_symbol_reference_visit_encoding(builder, source_scope, encoding,
+                                              kind, attr_index, user_op);
 }
 
 static iree_status_t loom_symbol_reference_visit_type_sequence(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
-    const loom_type_t* types, uint16_t type_count,
-    loom_symbol_reference_occurrence_kind_t kind, uint16_t attr_index,
-    const loom_op_t* user_op) {
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope, const loom_type_t* types,
+    uint16_t type_count, loom_symbol_reference_occurrence_kind_t kind,
+    uint16_t attr_index, const loom_op_t* user_op) {
   if (!types) return iree_ok_status();
   for (uint16_t i = 0; i < type_count; ++i) {
     IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_type(
-        builder, source_symbol_id, types[i], kind, attr_index, user_op));
+        builder, source_scope, types[i], kind, attr_index, user_op));
   }
   return iree_ok_status();
 }
 
 static iree_status_t loom_symbol_reference_visit_type(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
-    loom_type_t type, loom_symbol_reference_occurrence_kind_t kind,
-    uint16_t attr_index, const loom_op_t* user_op) {
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope, loom_type_t type,
+    loom_symbol_reference_occurrence_kind_t kind, uint16_t attr_index,
+    const loom_op_t* user_op) {
   loom_type_kind_t type_kind = loom_type_kind(type);
   if (!loom_type_kind_is_valid(type_kind)) return iree_ok_status();
 
   if (loom_type_has_static_encoding(type)) {
     IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_static_encoding(
-        builder, source_symbol_id, type.encoding_id, kind, attr_index,
-        user_op));
+        builder, source_scope, type.encoding_id, kind, attr_index, user_op));
   }
 
   switch (type_kind) {
@@ -400,13 +419,13 @@ static iree_status_t loom_symbol_reference_visit_type(
       const loom_func_type_data_t* data = loom_type_func_data(type);
       if (!data) return iree_ok_status();
       return loom_symbol_reference_visit_type_sequence(
-          builder, source_symbol_id, data->types,
+          builder, source_scope, data->types,
           (uint16_t)(data->arg_count + data->result_count), kind, attr_index,
           user_op);
     }
     case LOOM_TYPE_DIALECT:
       return loom_symbol_reference_visit_type_sequence(
-          builder, source_symbol_id, loom_type_dialect_params(type),
+          builder, source_scope, loom_type_dialect_params(type),
           loom_type_dialect_param_count(type), kind, attr_index, user_op);
     case LOOM_TYPE_PARAMETERIZED: {
       const loom_parameterized_type_descriptor_t* descriptor =
@@ -416,7 +435,7 @@ static iree_status_t loom_symbol_reference_visit_type(
       uint8_t parameter_count = loom_type_parameterized_parameter_count(type);
       for (uint8_t i = 0; i < parameter_count; ++i) {
         IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_attr(
-            builder, source_symbol_id, parameters[i],
+            builder, source_scope, parameters[i],
             &descriptor->parameter_descriptors[i], kind, attr_index, user_op,
             /*dict_depth=*/1));
       }
@@ -425,7 +444,7 @@ static iree_status_t loom_symbol_reference_visit_type(
     case LOOM_TYPE_REGISTER: {
       const loom_type_t* value_type = loom_type_register_value_type(type);
       return value_type ? loom_symbol_reference_visit_type(
-                              builder, source_symbol_id, *value_type, kind,
+                              builder, source_scope, *value_type, kind,
                               attr_index, user_op)
                         : iree_ok_status();
     }
@@ -435,8 +454,9 @@ static iree_status_t loom_symbol_reference_visit_type(
 }
 
 static iree_status_t loom_symbol_reference_visit_attr(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
-    loom_attribute_t attr, const loom_attr_descriptor_t* descriptor,
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope, loom_attribute_t attr,
+    const loom_attr_descriptor_t* descriptor,
     loom_symbol_reference_occurrence_kind_t kind, uint16_t attr_index,
     const loom_op_t* user_op, uint8_t dict_depth) {
   switch ((loom_attr_kind_t)attr.kind) {
@@ -446,7 +466,7 @@ static iree_status_t loom_symbol_reference_visit_attr(
           descriptor->reference.symbol_ref) {
         role = descriptor->reference.symbol_ref->role;
       }
-      return loom_symbol_reference_add_ref(builder, source_symbol_id,
+      return loom_symbol_reference_add_ref(builder, source_scope,
                                            loom_attr_as_symbol(attr), kind,
                                            role, attr_index, user_op);
     }
@@ -461,9 +481,9 @@ static iree_status_t loom_symbol_reference_visit_attr(
                                          ? loom_attr_as_symbol_set(attr)
                                          : loom_attr_as_symbol_array(attr);
       for (uint16_t i = 0; i < refs.count; ++i) {
-        IREE_RETURN_IF_ERROR(loom_symbol_reference_add_ref(
-            builder, source_symbol_id, refs.values[i], kind, role, attr_index,
-            user_op));
+        IREE_RETURN_IF_ERROR(
+            loom_symbol_reference_add_ref(builder, source_scope, refs.values[i],
+                                          kind, role, attr_index, user_op));
       }
       return iree_ok_status();
     }
@@ -477,12 +497,11 @@ static iree_status_t loom_symbol_reference_visit_attr(
             (unsigned)attr.type_id, builder->module->types.count);
       }
       return loom_symbol_reference_visit_type(
-          builder, source_symbol_id,
-          builder->module->types.entries[attr.type_id],
+          builder, source_scope, builder->module->types.entries[attr.type_id],
           LOOM_SYMBOL_REFERENCE_OCCURRENCE_TYPE_ATTR, attr_index, user_op);
     case LOOM_ATTR_ENCODING:
       return loom_symbol_reference_visit_static_encoding(
-          builder, source_symbol_id, attr.encoding_id,
+          builder, source_scope, attr.encoding_id,
           LOOM_SYMBOL_REFERENCE_OCCURRENCE_ENCODING_ATTR, attr_index, user_op);
     case LOOM_ATTR_DICT:
       if (dict_depth >= LOOM_ATTR_AGGREGATE_MAX_NESTING_DEPTH) {
@@ -505,7 +524,7 @@ static iree_status_t loom_symbol_reference_visit_attr(
       }
       for (uint16_t i = 0; i < attr.count; ++i) {
         IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_attr(
-            builder, source_symbol_id, attr.dict_entries[i].value,
+            builder, source_scope, attr.dict_entries[i].value,
             /*descriptor=*/NULL, nested_kind, attr_index, user_op,
             (uint8_t)(dict_depth + 1)));
       }
@@ -522,7 +541,7 @@ static iree_status_t loom_symbol_reference_visit_attr(
               builder->module->context, loom_attr_as_parameterized_kind(attr));
       for (uint16_t i = 0; i < attr.count; ++i) {
         IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_attr(
-            builder, source_symbol_id, attr.parameterized_slots[i],
+            builder, source_scope, attr.parameterized_slots[i],
             &family_descriptor->parameter_descriptors[i],
             LOOM_SYMBOL_REFERENCE_OCCURRENCE_NESTED_ATTR, attr_index, user_op,
             (uint8_t)(dict_depth + 1)));
@@ -537,7 +556,7 @@ static iree_status_t loom_symbol_reference_visit_attr(
       }
       for (uint16_t i = 0; i < attr.count; ++i) {
         IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_attr(
-            builder, source_symbol_id, attr.parameterized_array[i],
+            builder, source_scope, attr.parameterized_array[i],
             /*descriptor=*/NULL, LOOM_SYMBOL_REFERENCE_OCCURRENCE_NESTED_ATTR,
             attr_index, user_op, (uint8_t)(dict_depth + 1)));
       }
@@ -565,8 +584,9 @@ loom_symbol_reference_direct_attr_kind(const loom_op_vtable_t* vtable,
 }
 
 static iree_status_t loom_symbol_reference_visit_value_type(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
-    loom_value_id_t value_id, const loom_op_t* user_op) {
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope, loom_value_id_t value_id,
+    const loom_op_t* user_op) {
   if (value_id == LOOM_VALUE_ID_INVALID ||
       value_id >= builder->module->values.count) {
     return iree_ok_status();
@@ -576,14 +596,14 @@ static iree_status_t loom_symbol_reference_visit_value_type(
     return iree_ok_status();
   }
   return loom_symbol_reference_visit_type(
-      builder, source_symbol_id, type,
-      LOOM_SYMBOL_REFERENCE_OCCURRENCE_VALUE_TYPE,
+      builder, source_scope, type, LOOM_SYMBOL_REFERENCE_OCCURRENCE_VALUE_TYPE,
       LOOM_SYMBOL_REFERENCE_ATTR_INDEX_NONE, user_op);
 }
 
 static iree_status_t loom_symbol_reference_visit_op_defined_value_types(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
-    const loom_op_t* op, const loom_op_vtable_t* vtable) {
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope, const loom_op_t* op,
+    const loom_op_vtable_t* vtable) {
   if (vtable && vtable->func_like &&
       vtable->func_like->args_operand_field_index != LOOM_OPERAND_INDEX_NONE) {
     // Operand-backed signatures define every operand. Kernel declarations may
@@ -591,31 +611,33 @@ static iree_status_t loom_symbol_reference_visit_op_defined_value_types(
     const loom_value_id_t* operands = loom_op_operands(op);
     for (uint16_t i = 0; i < op->operand_count; ++i) {
       IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_value_type(
-          builder, source_symbol_id, operands[i], op));
+          builder, source_scope, operands[i], op));
     }
   }
   const loom_value_id_t* results = loom_op_results(op);
   for (uint16_t i = 0; i < op->result_count; ++i) {
     IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_value_type(
-        builder, source_symbol_id, results[i], op));
+        builder, source_scope, results[i], op));
   }
   return iree_ok_status();
 }
 
 static iree_status_t loom_symbol_reference_visit_block_arg_types(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope,
     const loom_block_t* block) {
   for (uint16_t i = 0; i < block->arg_count; ++i) {
     IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_value_type(
-        builder, source_symbol_id, loom_block_arg_id(block, i),
+        builder, source_scope, loom_block_arg_id(block, i),
         /*user_op=*/NULL));
   }
   return iree_ok_status();
 }
 
 static iree_status_t loom_symbol_reference_visit_op_attrs(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
-    const loom_op_t* op, const loom_op_vtable_t* vtable) {
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope, const loom_op_t* op,
+    const loom_op_vtable_t* vtable) {
   const loom_attribute_t* attrs = loom_op_const_attrs(op);
   for (uint8_t i = 0; i < op->attribute_count; ++i) {
     if (vtable && vtable->symbol_def &&
@@ -630,44 +652,52 @@ static iree_status_t loom_symbol_reference_visit_op_attrs(
     loom_symbol_reference_occurrence_kind_t kind =
         loom_symbol_reference_direct_attr_kind(vtable, descriptor, i);
     IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_attr(
-        builder, source_symbol_id, attrs[i], descriptor, kind, i, op,
+        builder, source_scope, attrs[i], descriptor, kind, i, op,
         /*dict_depth=*/0));
   }
   return iree_ok_status();
 }
 
 static iree_status_t loom_symbol_reference_visit_region(
-    loom_symbol_reference_builder_t* builder, loom_symbol_id_t source_symbol_id,
+    loom_symbol_reference_builder_t* builder,
+    loom_symbol_reference_source_scope_t source_scope,
     const loom_region_t* region) {
   if (!region) return iree_ok_status();
   const loom_block_t* block = NULL;
   loom_region_for_each_block(region, block) {
     IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_block_arg_types(
-        builder, source_symbol_id, block));
+        builder, source_scope, block));
     const loom_op_t* op = NULL;
     loom_block_for_each_op(block, op) {
       const loom_op_vtable_t* vtable = loom_op_vtable(builder->module, op);
-      loom_symbol_id_t nested_source_symbol_id = source_symbol_id;
+      loom_symbol_reference_source_scope_t nested_source_scope = source_scope;
       const loom_symbol_id_t op_symbol_id =
           loom_op_defining_symbol_id(builder->module, op, vtable);
       if (op_symbol_id != LOOM_SYMBOL_ID_INVALID) {
-        nested_source_symbol_id = op_symbol_id;
+        nested_source_scope = (loom_symbol_reference_source_scope_t){
+            .symbol_id = op_symbol_id,
+        };
         IREE_RETURN_IF_ERROR(loom_symbol_reference_append_template_provider(
             builder, op_symbol_id,
             &builder->module->symbols.entries[op_symbol_id]));
       }
       if (loom_template_apply_isa(op)) {
         IREE_RETURN_IF_ERROR(loom_symbol_reference_append_template_demand(
-            builder, nested_source_symbol_id, op));
+            builder, nested_source_scope, op));
       }
       IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_op_defined_value_types(
-          builder, nested_source_symbol_id, op, vtable));
+          builder, nested_source_scope, op, vtable));
       IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_op_attrs(
-          builder, nested_source_symbol_id, op, vtable));
+          builder, nested_source_scope, op, vtable));
       loom_region_t** regions = loom_op_regions(op);
       for (uint8_t i = 0; i < op->region_count; ++i) {
+        loom_symbol_reference_source_scope_t child_source_scope =
+            nested_source_scope;
+        if (op_symbol_id != LOOM_SYMBOL_ID_INVALID) {
+          child_source_scope.root_region_index_plus_one = (uint8_t)(i + 1);
+        }
         IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_region(
-            builder, nested_source_symbol_id, regions[i]));
+            builder, child_source_scope, regions[i]));
       }
     }
   }
@@ -676,9 +706,12 @@ static iree_status_t loom_symbol_reference_visit_region(
 
 static iree_status_t loom_symbol_reference_visit_module_encodings(
     loom_symbol_reference_builder_t* builder) {
+  const loom_symbol_reference_source_scope_t module_scope = {
+      .symbol_id = LOOM_SYMBOL_ID_INVALID,
+  };
   for (iree_host_size_t i = 0; i < builder->module->encodings.count; ++i) {
     IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_encoding(
-        builder, LOOM_SYMBOL_ID_INVALID, &builder->module->encodings.entries[i],
+        builder, module_scope, &builder->module->encodings.entries[i],
         LOOM_SYMBOL_REFERENCE_OCCURRENCE_MODULE_ENCODING,
         LOOM_SYMBOL_REFERENCE_ATTR_INDEX_NONE, /*user_op=*/NULL));
   }
@@ -705,8 +738,11 @@ iree_status_t loom_symbol_reference_table_build(
   loom_symbol_reference_builder_t builder = {0};
   IREE_RETURN_IF_ERROR(
       loom_symbol_reference_builder_initialize(module, arena, &builder));
-  IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_region(
-      &builder, LOOM_SYMBOL_ID_INVALID, module->body));
+  const loom_symbol_reference_source_scope_t module_scope = {
+      .symbol_id = LOOM_SYMBOL_ID_INVALID,
+  };
+  IREE_RETURN_IF_ERROR(
+      loom_symbol_reference_visit_region(&builder, module_scope, module->body));
   IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_module_encodings(&builder));
 
   *out_table = (loom_symbol_reference_table_t){

--- a/loom/src/loom/analysis/symbol_references.h
+++ b/loom/src/loom/analysis/symbol_references.h
@@ -77,6 +77,8 @@ typedef struct loom_symbol_reference_occurrence_t {
   loom_symbol_reference_occurrence_kind_t kind;
   // Compile-time graph role declared by the owning attribute schema.
   loom_symbol_reference_role_t role;
+  // Root region slot on the source symbol plus one, or zero for its contract.
+  uint8_t source_root_region_index_plus_one;
   // Attribute index on user_op when the occurrence came from an op attribute.
   uint16_t attr_index;
   // Operation that owns the occurrence, or NULL for module-root records.
@@ -106,10 +108,12 @@ typedef struct loom_template_demand_t {
   loom_symbol_id_t family_symbol_id;
   // Symbol whose definition owns the application.
   loom_symbol_id_t source_symbol_id;
+  // Root region slot on source_symbol_id plus one, or zero for its contract.
+  uint8_t source_root_region_index_plus_one;
 } loom_template_demand_t;
 
-static_assert(sizeof(loom_template_demand_t) == 16,
-              "template demands must remain 16 bytes");
+static_assert(sizeof(loom_template_demand_t) == 24,
+              "template demands must remain 24 bytes");
 
 // One available template provider indexed by its implemented family.
 typedef struct loom_template_provider_reference_t {

--- a/loom/src/loom/analysis/symbol_references_test.cc
+++ b/loom/src/loom/analysis/symbol_references_test.cc
@@ -238,8 +238,73 @@ func.def @entry() -> (index) {
   ASSERT_NE(call_occurrence->user_op, nullptr);
   EXPECT_EQ(call_occurrence->user_op->kind, LOOM_OP_FUNC_CALL);
 
+  EXPECT_EQ(read_occurrence->source_root_region_index_plus_one, 1u);
+  EXPECT_EQ(write_occurrence->source_root_region_index_plus_one, 1u);
+  EXPECT_EQ(call_occurrence->source_root_region_index_plus_one, 1u);
+
   EXPECT_EQ(table.symbols[state].incoming_count, 2u);
   EXPECT_EQ(table.symbols[reader].incoming_count, 1u);
+}
+
+TEST_F(SymbolReferencesTest, OccurrencesRetainContractAndRootRegionOrigins) {
+  ModulePtr module = ParseModule(R"(
+target.generic<reference> @header_target
+func.decl @body_dependency()
+
+func.def target(@header_target) @single_root() {
+  func.call @body_dependency() : () -> ()
+  func.return
+}
+
+test.record @config_dependency
+test.record @implementation_dependency
+test.split_func @split_root() {
+  test.symbol_array_attrs [@config_dependency] using []
+  test.yield
+} launch {
+  test.symbol_array_attrs [@implementation_dependency] using []
+  test.yield
+}
+)");
+
+  const loom_symbol_id_t header_target =
+      FindSymbol(module.get(), IREE_SV("header_target"));
+  const loom_symbol_id_t body_dependency =
+      FindSymbol(module.get(), IREE_SV("body_dependency"));
+  const loom_symbol_id_t single_root =
+      FindSymbol(module.get(), IREE_SV("single_root"));
+  const loom_symbol_id_t config_dependency =
+      FindSymbol(module.get(), IREE_SV("config_dependency"));
+  const loom_symbol_id_t implementation_dependency =
+      FindSymbol(module.get(), IREE_SV("implementation_dependency"));
+  const loom_symbol_id_t split_root =
+      FindSymbol(module.get(), IREE_SV("split_root"));
+
+  const loom_symbol_reference_table_t table = BuildTable(module.get());
+
+  const loom_symbol_reference_occurrence_t* header_occurrence =
+      FindOccurrence(table, single_root, header_target,
+                     LOOM_SYMBOL_REFERENCE_OCCURRENCE_SYMBOL_ATTR);
+  ASSERT_NE(header_occurrence, nullptr);
+  EXPECT_EQ(header_occurrence->source_root_region_index_plus_one, 0u);
+
+  const loom_symbol_reference_occurrence_t* body_occurrence =
+      FindOccurrence(table, single_root, body_dependency,
+                     LOOM_SYMBOL_REFERENCE_OCCURRENCE_CALL);
+  ASSERT_NE(body_occurrence, nullptr);
+  EXPECT_EQ(body_occurrence->source_root_region_index_plus_one, 1u);
+
+  const loom_symbol_reference_occurrence_t* config_occurrence =
+      FindOccurrence(table, split_root, config_dependency,
+                     LOOM_SYMBOL_REFERENCE_OCCURRENCE_SYMBOL_ATTR);
+  ASSERT_NE(config_occurrence, nullptr);
+  EXPECT_EQ(config_occurrence->source_root_region_index_plus_one, 1u);
+
+  const loom_symbol_reference_occurrence_t* implementation_occurrence =
+      FindOccurrence(table, split_root, implementation_dependency,
+                     LOOM_SYMBOL_REFERENCE_OCCURRENCE_SYMBOL_ATTR);
+  ASSERT_NE(implementation_occurrence, nullptr);
+  EXPECT_EQ(implementation_occurrence->source_root_region_index_plus_one, 2u);
 }
 
 TEST_F(SymbolReferencesTest, TemplateDemandsRetainOwningSymbol) {
@@ -286,6 +351,7 @@ func.def public @entry(%arg: i32) -> (i32) {
     const loom_template_demand_t& demand =
         table.template_demands.values[demand_id];
     EXPECT_EQ(demand.source_symbol_id, source_symbol_id);
+    EXPECT_EQ(demand.source_root_region_index_plus_one, 1u);
     EXPECT_EQ(demand.family_symbol_id, family_symbol_id);
     ASSERT_NE(demand.apply_op, nullptr);
     EXPECT_EQ(demand.apply_op->kind, LOOM_OP_TEMPLATE_APPLY);

--- a/loom/src/loom/format/bytecode/format.h
+++ b/loom/src/loom/format/bytecode/format.h
@@ -62,7 +62,7 @@
 //
 //   offset  size  field
 //   0       4     magic: "LOOM" (0x4C 0x4F 0x4F 0x4D)
-//   4       1     format_version (currently 30)
+//   4       1     format_version (LOOM_BYTECODE_FORMAT_VERSION)
 //   5       1     location_mode (see loom_bytecode_location_mode_t)
 //   6       2     module_count
 //   8       4     file_string_pool_length (bytes)
@@ -85,7 +85,7 @@ extern "C" {
 
 #define LOOM_BYTECODE_MAGIC "LOOM"
 #define LOOM_BYTECODE_MAGIC_LENGTH 4
-#define LOOM_BYTECODE_FORMAT_VERSION 30
+#define LOOM_BYTECODE_FORMAT_VERSION 31
 
 #define LOOM_BYTECODE_SOURCE_TRIVIA_LEADING_BLANK_LINE (1u << 0)
 #define LOOM_BYTECODE_SOURCE_TRIVIA_COMMENT_COUNT_SHIFT 1
@@ -721,13 +721,13 @@ typedef enum loom_bytecode_section_kind_e {
 // ==========================================================================
 //
 // Canonical dependency metadata used to plan a selected symbol closure without
-// reading IR bodies. Dependency targets are direct SYMBOLS ordinals. Abstract
-// provider demands are STRINGS IDs naming template.apply contract keys.
+// reading IR bodies. Dependency targets and abstract provider demands are
+// direct SYMBOLS ordinals.
 //
 // Availability-only references, including module.import anchors, are excluded.
 // Those remain represented solely by PROVIDER_IMPORTS. Rows preserve every
 // dependency occurrence and contract demand in deterministic analysis order;
-// repeated targets and keys are valid. Closure planners use dense selection
+// repeated targets and families are valid. Closure planners use dense selection
 // bitmaps to coalesce repeated work while traversing only reached rows.
 //
 // The module dependency row contains references owned by module-level records,
@@ -741,14 +741,17 @@ typedef enum loom_bytecode_section_kind_e {
 //   [total_template_demand_count: varint]
 //   [module_dependency_count: varint]
 //   For each module dependency:
+//     [source_root_region_index_plus_one: varint] (must be zero)
 //     [target_symbol_index: varint]
 //   For each symbol in SYMBOLS ordinal order:
 //     [dependency_count: varint]
 //     For each dependency:
+//       [source_root_region_index_plus_one: varint]
 //       [target_symbol_index: varint]
 //     [template_demand_count: varint]
 //     For each abstract provider demand:
-//       [contract_string_id: varint]
+//       [source_root_region_index_plus_one: varint]
+//       [family_symbol_index: varint]
 
 // ==========================================================================
 // IR section

--- a/loom/src/loom/format/bytecode/index.h
+++ b/loom/src/loom/format/bytecode/index.h
@@ -128,6 +128,8 @@ typedef struct loom_bytecode_symbol_metadata_t {
   // Workload/configuration entry in this symbol's payload list plus one, or
   // zero when absent.
   uint8_t kernel_workload_region_payload_ordinal_plus_one;
+  // Number of root region slots declared by the defining operation.
+  uint8_t root_region_count;
   // Global declaration-local value count, or zero for non-global symbols.
   uint64_t local_value_count;
   // Source SYMBOLS ordinal naming the provider's template family, or

--- a/loom/src/loom/format/bytecode/index.h
+++ b/loom/src/loom/format/bytecode/index.h
@@ -263,6 +263,10 @@ typedef struct loom_bytecode_module_metadata_t {
   // The module-root slice begins at zero; symbol slices are described by
   // symbol_references. Targets may repeat within a slice.
   uint32_t* dependency_symbol_indices;
+  // Arena-owned source root region indices plus one parallel to
+  // dependency_symbol_indices. Zero identifies a source symbol contract or
+  // module-root occurrence.
+  uint8_t* dependency_source_root_region_indices_plus_one;
   // One dependency and template-demand slice per SYMBOLS ordinal.
   loom_bytecode_symbol_reference_metadata_t* symbol_references;
   // Total number of template-family demand occurrences.
@@ -270,6 +274,9 @@ typedef struct loom_bytecode_module_metadata_t {
   // Arena-owned family SYMBOLS ordinals in deterministic demand order and
   // sliced by symbol_references. Ordinals may repeat within a slice.
   uint32_t* template_demand_family_symbol_ordinals;
+  // Arena-owned source root region indices plus one parallel to
+  // template_demand_family_symbol_ordinals.
+  uint8_t* template_demand_source_root_region_indices_plus_one;
 } loom_bytecode_module_metadata_t;
 
 // Resolves a source STRINGS ordinal to its module-local SYMBOLS ordinal.

--- a/loom/src/loom/format/bytecode/reader/symbol.c
+++ b/loom/src/loom/format/bytecode/reader/symbol.c
@@ -170,6 +170,7 @@ static iree_status_t loom_bytecode_reader_decode_region_payloads(
     iree_host_size_t* payload_index,
     loom_bytecode_region_payload_metadata_t* payloads,
     loom_bytecode_symbol_metadata_t* symbol_metadata) {
+  symbol_metadata->root_region_count = vtable->region_count;
   const uint64_t count_offset =
       loom_bytecode_reader_cursor_absolute_position(cursor);
   uint64_t payload_count = 0;

--- a/loom/src/loom/format/bytecode/reader/validation.c
+++ b/loom/src/loom/format/bytecode/reader/validation.c
@@ -392,12 +392,12 @@ static inline iree_status_t loom_bytecode_reader_begin_symbol_references(
   iree_host_size_t minimum_encoded_bytes = 0;
   if (!iree_host_size_checked_mul_add(1, (iree_host_size_t)symbol_count, 2,
                                       &minimum_encoded_bytes) ||
-      !iree_host_size_checked_add(minimum_encoded_bytes,
-                                  (iree_host_size_t)dependency_count,
-                                  &minimum_encoded_bytes) ||
-      !iree_host_size_checked_add(minimum_encoded_bytes,
-                                  (iree_host_size_t)template_demand_count,
-                                  &minimum_encoded_bytes)) {
+      !iree_host_size_checked_mul_add(minimum_encoded_bytes,
+                                      (iree_host_size_t)dependency_count, 2,
+                                      &minimum_encoded_bytes) ||
+      !iree_host_size_checked_mul_add(minimum_encoded_bytes,
+                                      (iree_host_size_t)template_demand_count,
+                                      2, &minimum_encoded_bytes)) {
     return loom_bytecode_reader_emit_invalid_field(
         &reader->decoder, IREE_SV("SYMBOL_REFERENCES"), IREE_SV("header"), 0,
         IREE_SV("record_counts"), table.header_offset,
@@ -422,7 +422,21 @@ static inline iree_status_t loom_bytecode_reader_decode_dependency(
     loom_bytecode_module_reader_t* reader,
     loom_bytecode_symbol_reference_table_t* table,
     iree_string_view_t record_name, iree_host_size_t record_index,
+    uint8_t source_root_region_count,
+    uint8_t* out_source_root_region_index_plus_one,
     uint32_t* out_symbol_index) {
+  const uint64_t source_root_region_offset =
+      loom_bytecode_reader_cursor_absolute_position(&table->cursor);
+  uint64_t source_root_region_index_plus_one = 0;
+  IREE_RETURN_IF_ERROR(loom_bytecode_reader_read_uvarint(
+      &reader->decoder, &table->cursor, &source_root_region_index_plus_one));
+  if (source_root_region_index_plus_one > source_root_region_count) {
+    return loom_bytecode_reader_emit_invalid_field(
+        &reader->decoder, IREE_SV("SYMBOL_REFERENCES"), record_name,
+        record_index, IREE_SV("source_root_region_index_plus_one"),
+        source_root_region_offset,
+        IREE_SV("reference_source_root_region_index_is_out_of_range"));
+  }
   const uint64_t dependency_offset =
       loom_bytecode_reader_cursor_absolute_position(&table->cursor);
   uint64_t dependency = 0;
@@ -434,6 +448,8 @@ static inline iree_status_t loom_bytecode_reader_decode_dependency(
         record_index, IREE_SV("target_symbol_index"), dependency_offset,
         IREE_SV("dependency_symbol_index_is_out_of_range"));
   }
+  *out_source_root_region_index_plus_one =
+      (uint8_t)source_root_region_index_plus_one;
   *out_symbol_index = (uint32_t)dependency;
   return iree_ok_status();
 }
@@ -441,10 +457,23 @@ static inline iree_status_t loom_bytecode_reader_decode_dependency(
 static inline iree_status_t loom_bytecode_reader_decode_template_demand(
     loom_bytecode_module_reader_t* reader,
     loom_bytecode_symbol_reference_table_t* table,
-    iree_host_size_t demand_index, uint32_t* out_family_symbol_ordinal) {
+    iree_host_size_t demand_index, uint8_t source_root_region_count,
+    uint8_t* out_source_root_region_index_plus_one,
+    uint32_t* out_family_symbol_ordinal) {
   return loom_bytecode_reader_decode_dependency(
       reader, table, IREE_SV("template_demand"), demand_index,
+      source_root_region_count, out_source_root_region_index_plus_one,
       out_family_symbol_ordinal);
+}
+
+static uint8_t loom_bytecode_reader_symbol_root_region_count(
+    const loom_bytecode_module_reader_t* reader,
+    iree_host_size_t symbol_index) {
+  const uint32_t defining_op_ordinal =
+      reader->view.symbols.defining_op_ordinals[symbol_index];
+  if (defining_op_ordinal == UINT32_MAX) return 0;
+  IREE_ASSERT_LT(defining_op_ordinal, reader->view.ops.count);
+  return reader->view.ops.values[defining_op_ordinal]->region_count;
 }
 
 static inline iree_status_t loom_bytecode_reader_finish_symbol_references(
@@ -491,14 +520,19 @@ static iree_status_t loom_bytecode_reader_read_symbol_references(
   iree_host_size_t dependency_index = 0;
   for (iree_host_size_t i = 0; i < (iree_host_size_t)module_dependency_count;
        ++i, ++dependency_index) {
+    uint8_t source_root_region_index_plus_one = 0;
     uint32_t dependency = 0;
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_decode_dependency(
-        reader, &table, IREE_SV("module_dependency"), i, &dependency));
+        reader, &table, IREE_SV("module_dependency"), i,
+        /*source_root_region_count=*/0, &source_root_region_index_plus_one,
+        &dependency));
   }
 
   iree_host_size_t template_demand_index = 0;
   for (iree_host_size_t symbol_index = 0; symbol_index < table.symbol_count;
        ++symbol_index) {
+    const uint8_t source_root_region_count =
+        loom_bytecode_reader_symbol_root_region_count(reader, symbol_index);
     const uint64_t dependency_count_offset =
         loom_bytecode_reader_cursor_absolute_position(&table.cursor);
     uint64_t dependency_count = 0;
@@ -512,9 +546,11 @@ static iree_status_t loom_bytecode_reader_read_symbol_references(
     }
     for (iree_host_size_t i = 0; i < (iree_host_size_t)dependency_count;
          ++i, ++dependency_index) {
+      uint8_t source_root_region_index_plus_one = 0;
       uint32_t dependency = 0;
       IREE_RETURN_IF_ERROR(loom_bytecode_reader_decode_dependency(
-          reader, &table, IREE_SV("dependency"), i, &dependency));
+          reader, &table, IREE_SV("dependency"), i, source_root_region_count,
+          &source_root_region_index_plus_one, &dependency));
     }
 
     const uint64_t template_demand_count_offset =
@@ -532,9 +568,11 @@ static iree_status_t loom_bytecode_reader_read_symbol_references(
     }
     for (iree_host_size_t i = 0; i < (iree_host_size_t)template_demand_count;
          ++i, ++template_demand_index) {
+      uint8_t source_root_region_index_plus_one = 0;
       uint32_t family_symbol_ordinal = 0;
       IREE_RETURN_IF_ERROR(loom_bytecode_reader_decode_template_demand(
-          reader, &table, template_demand_index, &family_symbol_ordinal));
+          reader, &table, template_demand_index, source_root_region_count,
+          &source_root_region_index_plus_one, &family_symbol_ordinal));
     }
   }
 
@@ -1060,12 +1098,21 @@ static iree_status_t loom_bytecode_reader_index_symbol_references(
         retained_arena, table.dependency_count,
         sizeof(*metadata->dependency_symbol_indices),
         (void**)&metadata->dependency_symbol_indices));
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        retained_arena, table.dependency_count,
+        sizeof(*metadata->dependency_source_root_region_indices_plus_one),
+        (void**)&metadata->dependency_source_root_region_indices_plus_one));
   }
   if (table.template_demand_count > 0) {
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
         retained_arena, table.template_demand_count,
         sizeof(*metadata->template_demand_family_symbol_ordinals),
         (void**)&metadata->template_demand_family_symbol_ordinals));
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        retained_arena, table.template_demand_count,
+        sizeof(*metadata->template_demand_source_root_region_indices_plus_one),
+        (void**)&metadata
+            ->template_demand_source_root_region_indices_plus_one));
   }
 
   const uint64_t module_dependency_count_offset =
@@ -1086,12 +1133,17 @@ static iree_status_t loom_bytecode_reader_index_symbol_references(
        ++i, ++dependency_index) {
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_decode_dependency(
         reader, &table, IREE_SV("module_dependency"), i,
+        /*source_root_region_count=*/0,
+        &metadata
+             ->dependency_source_root_region_indices_plus_one[dependency_index],
         &metadata->dependency_symbol_indices[dependency_index]));
   }
 
   iree_host_size_t template_demand_index = 0;
   for (iree_host_size_t symbol_index = 0; symbol_index < table.symbol_count;
        ++symbol_index) {
+    const uint8_t source_root_region_count =
+        loom_bytecode_reader_symbol_root_region_count(reader, symbol_index);
     const uint64_t dependency_count_offset =
         loom_bytecode_reader_cursor_absolute_position(&table.cursor);
     uint64_t dependency_count = 0;
@@ -1110,7 +1162,9 @@ static iree_status_t loom_bytecode_reader_index_symbol_references(
     for (iree_host_size_t i = 0; i < (iree_host_size_t)dependency_count;
          ++i, ++dependency_index) {
       IREE_RETURN_IF_ERROR(loom_bytecode_reader_decode_dependency(
-          reader, &table, IREE_SV("dependency"), i,
+          reader, &table, IREE_SV("dependency"), i, source_root_region_count,
+          &metadata->dependency_source_root_region_indices_plus_one
+               [dependency_index],
           &metadata->dependency_symbol_indices[dependency_index]));
     }
 
@@ -1132,7 +1186,9 @@ static iree_status_t loom_bytecode_reader_index_symbol_references(
     for (iree_host_size_t i = 0; i < (iree_host_size_t)template_demand_count;
          ++i, ++template_demand_index) {
       IREE_RETURN_IF_ERROR(loom_bytecode_reader_decode_template_demand(
-          reader, &table, template_demand_index,
+          reader, &table, template_demand_index, source_root_region_count,
+          &metadata->template_demand_source_root_region_indices_plus_one
+               [template_demand_index],
           &metadata->template_demand_family_symbol_ordinals
                [template_demand_index]));
     }

--- a/loom/src/loom/format/bytecode/reader_test.cc
+++ b/loom/src/loom/format/bytecode/reader_test.cc
@@ -139,10 +139,16 @@ class ReaderTest : public ::testing::Test {
     size_t total_template_demand_count = 0;
     // Byte offsets of module-root dependency target ordinals.
     std::vector<size_t> module_dependencies;
+    // Byte offsets of module-root dependency source origins.
+    std::vector<size_t> module_dependency_origins;
     // Byte offsets of dependency target ordinals by source symbol.
     std::vector<std::vector<size_t>> symbol_dependencies;
+    // Byte offsets of dependency source origins by source symbol.
+    std::vector<std::vector<size_t>> symbol_dependency_origins;
     // Byte offsets of template-family symbol ordinals by source symbol.
     std::vector<std::vector<size_t>> symbol_template_demands;
+    // Byte offsets of template-demand source origins by source symbol.
+    std::vector<std::vector<size_t>> symbol_template_demand_origins;
   };
 
   void SetUp() override {
@@ -2130,19 +2136,29 @@ class ReaderTest : public ::testing::Test {
 
     const uint64_t module_dependency_count = ReadUVarint(bytes, &offset);
     layout.module_dependencies.reserve((size_t)module_dependency_count);
+    layout.module_dependency_origins.reserve((size_t)module_dependency_count);
     for (uint64_t i = 0; i < module_dependency_count; ++i) {
+      layout.module_dependency_origins.push_back(offset);
+      ReadUVarint(bytes, &offset);
       layout.module_dependencies.push_back(offset);
       ReadUVarint(bytes, &offset);
     }
 
     layout.symbol_dependencies.reserve((size_t)symbol_count);
+    layout.symbol_dependency_origins.reserve((size_t)symbol_count);
     layout.symbol_template_demands.reserve((size_t)symbol_count);
+    layout.symbol_template_demand_origins.reserve((size_t)symbol_count);
     for (uint64_t i = 0; i < symbol_count; ++i) {
       const uint64_t dependency_count = ReadUVarint(bytes, &offset);
       std::vector<size_t>& dependency_offsets =
           layout.symbol_dependencies.emplace_back();
+      std::vector<size_t>& dependency_origin_offsets =
+          layout.symbol_dependency_origins.emplace_back();
       dependency_offsets.reserve((size_t)dependency_count);
+      dependency_origin_offsets.reserve((size_t)dependency_count);
       for (uint64_t j = 0; j < dependency_count; ++j) {
+        dependency_origin_offsets.push_back(offset);
+        ReadUVarint(bytes, &offset);
         dependency_offsets.push_back(offset);
         ReadUVarint(bytes, &offset);
       }
@@ -2150,8 +2166,13 @@ class ReaderTest : public ::testing::Test {
       const uint64_t template_demand_count = ReadUVarint(bytes, &offset);
       std::vector<size_t>& family_ordinal_offsets =
           layout.symbol_template_demands.emplace_back();
+      std::vector<size_t>& demand_origin_offsets =
+          layout.symbol_template_demand_origins.emplace_back();
       family_ordinal_offsets.reserve((size_t)template_demand_count);
+      demand_origin_offsets.reserve((size_t)template_demand_count);
       for (uint64_t j = 0; j < template_demand_count; ++j) {
+        demand_origin_offsets.push_back(offset);
+        ReadUVarint(bytes, &offset);
         family_ordinal_offsets.push_back(offset);
         ReadUVarint(bytes, &offset);
       }
@@ -3262,9 +3283,13 @@ TEST_F(ReaderTest, IndexesRawDependencyOccurrencesBySourceSymbol) {
   EXPECT_EQ(module_metadata.module_dependency_count, 0u);
   ASSERT_EQ(module_metadata.dependency_count, 3u);
   ASSERT_NE(module_metadata.dependency_symbol_indices, nullptr);
+  ASSERT_NE(module_metadata.dependency_source_root_region_indices_plus_one,
+            nullptr);
   ASSERT_NE(module_metadata.symbol_references, nullptr);
   EXPECT_EQ(module_metadata.template_demand_count, 0u);
   EXPECT_EQ(module_metadata.template_demand_family_symbol_ordinals, nullptr);
+  EXPECT_EQ(module_metadata.template_demand_source_root_region_indices_plus_one,
+            nullptr);
 
   EXPECT_EQ(module_metadata.symbol_references[0].dependency_count, 0u);
   EXPECT_EQ(module_metadata.symbol_references[1].dependency_count, 0u);
@@ -3273,6 +3298,12 @@ TEST_F(ReaderTest, IndexesRawDependencyOccurrencesBySourceSymbol) {
   EXPECT_EQ(module_metadata.dependency_symbol_indices[0], 1u);
   EXPECT_EQ(module_metadata.dependency_symbol_indices[1], 0u);
   EXPECT_EQ(module_metadata.dependency_symbol_indices[2], 1u);
+  EXPECT_EQ(module_metadata.dependency_source_root_region_indices_plus_one[0],
+            1u);
+  EXPECT_EQ(module_metadata.dependency_source_root_region_indices_plus_one[1],
+            1u);
+  EXPECT_EQ(module_metadata.dependency_source_root_region_indices_plus_one[2],
+            1u);
 
   iree_arena_deinitialize(&metadata_arena);
   loom_module_free(module);
@@ -3298,8 +3329,12 @@ TEST_F(ReaderTest, IndexesEveryAbstractProviderDemand) {
   EXPECT_EQ(module_metadata.summary.template_demand_count, 2u);
   ASSERT_EQ(module_metadata.dependency_count, 2u);
   ASSERT_NE(module_metadata.dependency_symbol_indices, nullptr);
+  ASSERT_NE(module_metadata.dependency_source_root_region_indices_plus_one,
+            nullptr);
   ASSERT_EQ(module_metadata.template_demand_count, 2u);
   ASSERT_NE(module_metadata.template_demand_family_symbol_ordinals, nullptr);
+  ASSERT_NE(module_metadata.template_demand_source_root_region_indices_plus_one,
+            nullptr);
   ASSERT_NE(module_metadata.symbol_references, nullptr);
   EXPECT_EQ(module_metadata.symbol_references[1].first_template_demand_index,
             0u);
@@ -3310,6 +3345,16 @@ TEST_F(ReaderTest, IndexesEveryAbstractProviderDemand) {
   EXPECT_EQ(module_metadata.dependency_symbol_indices[1], 0u);
   EXPECT_EQ(module_metadata.template_demand_family_symbol_ordinals[0], 0u);
   EXPECT_EQ(module_metadata.template_demand_family_symbol_ordinals[1], 0u);
+  EXPECT_EQ(module_metadata.dependency_source_root_region_indices_plus_one[0],
+            1u);
+  EXPECT_EQ(module_metadata.dependency_source_root_region_indices_plus_one[1],
+            1u);
+  EXPECT_EQ(
+      module_metadata.template_demand_source_root_region_indices_plus_one[0],
+      1u);
+  EXPECT_EQ(
+      module_metadata.template_demand_source_root_region_indices_plus_one[1],
+      1u);
 
   iree_arena_deinitialize(&metadata_arena);
   loom_module_free(module);
@@ -3463,9 +3508,15 @@ TEST_F(ReaderTest, PreservesPhysicalSymbolDefinitionOrder) {
   const uint32_t* dependency_symbol_indices =
       module_metadata.dependency_symbol_indices +
       function_references.first_dependency_index;
+  const uint8_t* dependency_origins =
+      module_metadata.dependency_source_root_region_indices_plus_one +
+      function_references.first_dependency_index;
   EXPECT_EQ(dependency_symbol_indices[0], 1u);
   EXPECT_EQ(dependency_symbol_indices[1], 2u);
   EXPECT_EQ(dependency_symbol_indices[2], 1u);
+  EXPECT_EQ(dependency_origins[0], 1u);
+  EXPECT_EQ(dependency_origins[1], 1u);
+  EXPECT_EQ(dependency_origins[2], 1u);
   iree_arena_deinitialize(&metadata_arena);
 
   loom_module_t* read_module = nullptr;
@@ -5376,6 +5427,21 @@ TEST_F(ReaderTest, RejectsSymbolReferenceTargetOutsideSymbolTable) {
   loom_module_free(module);
 }
 
+TEST_F(ReaderTest, RejectsSymbolReferenceOriginOutsideSourceRoots) {
+  loom_module_t* module = CreateSymbolArrayModule();
+  auto bytes = WriteModule(module);
+  SymbolReferenceLayout layout = ReadSymbolReferenceLayout(bytes);
+  ASSERT_EQ(layout.symbol_dependency_origins.size(), 3u);
+  ASSERT_EQ(layout.symbol_dependency_origins[2].size(), 3u);
+  const size_t origin_offset = layout.symbol_dependency_origins[2][0];
+  ASSERT_LT(origin_offset, bytes.size());
+  bytes[origin_offset] = 2;
+
+  ExpectReadError(bytes, "ERR_BYTECODE_006");
+
+  loom_module_free(module);
+}
+
 TEST_F(ReaderTest, RejectsSymbolReferenceCountBeyondSectionPayload) {
   loom_module_t* module = CreateSymbolArrayModule();
   auto bytes = WriteModule(module);
@@ -5398,6 +5464,21 @@ TEST_F(ReaderTest, RejectsTemplateDemandFamilyOutsideSymbolTable) {
   const size_t family_ordinal_offset = layout.symbol_template_demands[1][0];
   ASSERT_LT(family_ordinal_offset, bytes.size());
   bytes[family_ordinal_offset] = 0x7F;
+
+  ExpectReadError(bytes, "ERR_BYTECODE_006");
+
+  loom_module_free(module);
+}
+
+TEST_F(ReaderTest, RejectsTemplateDemandOriginOutsideSourceRoots) {
+  loom_module_t* module = CreateTemplateDemandModule();
+  auto bytes = WriteModule(module);
+  SymbolReferenceLayout layout = ReadSymbolReferenceLayout(bytes);
+  ASSERT_EQ(layout.symbol_template_demand_origins.size(), 2u);
+  ASSERT_EQ(layout.symbol_template_demand_origins[1].size(), 2u);
+  const size_t origin_offset = layout.symbol_template_demand_origins[1][0];
+  ASSERT_LT(origin_offset, bytes.size());
+  bytes[origin_offset] = 2;
 
   ExpectReadError(bytes, "ERR_BYTECODE_006");
 

--- a/loom/src/loom/format/bytecode/writer.c
+++ b/loom/src/loom/format/bytecode/writer.c
@@ -4591,6 +4591,8 @@ static iree_status_t loom_bytecode_write_dependency_row(
         &table->occurrences[occurrence_id];
     if (loom_symbol_reference_occurrence_is_dependency(occurrence)) {
       IREE_RETURN_IF_ERROR(loom_bytecode_page_writer_write_uvarint(
+          page_writer, occurrence->source_root_region_index_plus_one));
+      IREE_RETURN_IF_ERROR(loom_bytecode_page_writer_write_uvarint(
           page_writer, loom_bytecode_wire_symbol_ordinal(
                            numbering, occurrence->target_symbol_id)));
     }
@@ -4631,6 +4633,8 @@ static iree_status_t loom_bytecode_write_symbol_references_section(
     while (demand_id != LOOM_TEMPLATE_DEMAND_ID_INVALID) {
       const loom_template_demand_t* demand =
           &table->template_demands.values[demand_id];
+      IREE_RETURN_IF_ERROR(loom_bytecode_page_writer_write_uvarint(
+          page_writer, demand->source_root_region_index_plus_one));
       IREE_RETURN_IF_ERROR(loom_bytecode_page_writer_write_uvarint(
           page_writer, loom_bytecode_wire_symbol_ordinal(
                            numbering, demand->family_symbol_id)));

--- a/loom/src/loom/link/kernel_config_materializer.c
+++ b/loom/src/loom/link/kernel_config_materializer.c
@@ -39,6 +39,40 @@ typedef struct loom_link_kernel_config_symbol_resolver_t {
   loom_module_t* output_module;
 } loom_link_kernel_config_symbol_resolver_t;
 
+iree_status_t loom_link_plan_build_kernel_configuration(
+    const loom_link_module_index_t* index,
+    iree_host_size_t kernel_symbol_ordinal, iree_allocator_t allocator,
+    loom_link_plan_t** out_plan) {
+  IREE_ASSERT_ARGUMENT(index);
+  IREE_ASSERT_ARGUMENT(out_plan);
+  *out_plan = NULL;
+  const loom_link_module_index_symbol_t* kernel =
+      loom_link_module_index_symbol_at(index, kernel_symbol_ordinal);
+  if (kernel == NULL) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "kernel symbol ordinal is out of range");
+  }
+  const loom_link_symbol_facet_schema_t schema = kernel->facets.schema;
+  if (!iree_any_bit_set(schema.interfaces, LOOM_SYMBOL_INTERFACE_KERNEL)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "selected symbol is not a kernel");
+  }
+  if (schema.kernel_configuration_region_index_plus_one == 0) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "selected kernel has no configuration root");
+  }
+  const loom_link_plan_root_facet_t root = {
+      .symbol_ordinal = kernel_symbol_ordinal,
+      .source_root_region_index_plus_one =
+          schema.kernel_configuration_region_index_plus_one,
+  };
+  loom_link_plan_options_t options = {0};
+  options.mode = LOOM_LINK_PLAN_SELECTIVE;
+  options.root_facets.count = 1;
+  options.root_facets.values = &root;
+  return loom_link_plan_build(index, &options, allocator, out_plan);
+}
+
 static loom_diagnostic_sink_t loom_link_kernel_config_diagnostic_sink(
     const loom_link_plan_materialization_environment_t* environment,
     const loom_link_module_index_provider_t* provider) {
@@ -62,6 +96,14 @@ static iree_status_t loom_link_kernel_config_resolve_source(
   if (!loom_link_plan_contains_symbol(plan, kernel_symbol_ordinal)) {
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                             "kernel symbol is not selected by the link plan");
+  }
+  if (!loom_link_plan_contains_facet(
+          plan, kernel_symbol_ordinal,
+          indexed_symbol->facets.schema
+              .kernel_configuration_region_index_plus_one)) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "kernel configuration is not selected by the link plan");
   }
   const loom_link_module_index_provider_t* provider =
       loom_link_module_index_symbol_provider(index, indexed_symbol);

--- a/loom/src/loom/link/kernel_config_materializer.h
+++ b/loom/src/loom/link/kernel_config_materializer.h
@@ -25,6 +25,17 @@ typedef struct loom_link_kernel_config_materialization_t {
   loom_symbol_ref_t configuration_function;
 } loom_link_kernel_config_materialization_t;
 
+// Builds a selective plan rooted at one kernel contract and configuration
+// facet. The implementation facet and its exclusive closure remain unselected.
+//
+// |kernel_symbol_ordinal| is an index-wide identity for a kernel definition
+// with an independently bounded configuration root. Materialized, text, and
+// bytecode providers use the same indexed facet schema.
+iree_status_t loom_link_plan_build_kernel_configuration(
+    const loom_link_module_index_t* index,
+    iree_host_size_t kernel_symbol_ordinal, iree_allocator_t allocator,
+    loom_link_plan_t** out_plan);
+
 // Materializes the contract and launch configuration of one selected bytecode
 // kernel without reading its implementation root region.
 //

--- a/loom/src/loom/link/kernel_config_materializer_benchmark.cc
+++ b/loom/src/loom/link/kernel_config_materializer_benchmark.cc
@@ -51,12 +51,7 @@ class KernelConfigFixture {
         /*options=*/nullptr, /*out_provider_ordinal=*/nullptr));
     kernel_ = loom_link_module_index_lookup_name(index_, IREE_SV("benchmark"));
     if (kernel_ == nullptr) std::abort();
-    const iree_string_view_t roots[] = {IREE_SV("benchmark")};
-    loom_link_plan_options_t plan_options = {};
-    plan_options.mode = LOOM_LINK_PLAN_SELECTIVE;
-    plan_options.root_symbols = {IREE_ARRAYSIZE(roots), roots};
-    CheckStatus(loom_link_plan_build(index_, &plan_options,
-                                     iree_allocator_system(), &plan_));
+    plan_ = BuildPlan();
 
     const loom_link_module_index_provider_t* provider =
         loom_link_module_index_symbol_provider(index_, kernel_);
@@ -105,6 +100,13 @@ class KernelConfigFixture {
         plan_, kernel_->ordinal, &environment, IREE_SV("projected"),
         &materialization));
     return materialization;
+  }
+
+  loom_link_plan_t* BuildPlan() const {
+    loom_link_plan_t* plan = nullptr;
+    CheckStatus(loom_link_plan_build_kernel_configuration(
+        index_, kernel_->ordinal, iree_allocator_system(), &plan));
+    return plan;
   }
 
   iree_host_size_t config_payload_bytes() const {
@@ -201,11 +203,37 @@ static void BM_MaterializeKernelConfig(benchmark::State& state) {
   state.SetComplexityN(fixture.implementation_payload_bytes());
 }
 
+static void BM_PlanKernelConfig(benchmark::State& state) {
+  KernelConfigFixture fixture(static_cast<iree_host_size_t>(state.range(0)));
+  iree_host_size_t selected_facet_count = 0;
+  iree_host_size_t selected_symbol_count = 0;
+  for (auto _ : state) {
+    loom_link_plan_t* plan = fixture.BuildPlan();
+    selected_facet_count = loom_link_plan_facet_count(plan);
+    selected_symbol_count = loom_link_plan_symbol_count(plan);
+    benchmark::DoNotOptimize(plan);
+    state.PauseTiming();
+    loom_link_plan_free(plan);
+    state.ResumeTiming();
+  }
+  state.counters["configuration_payload_bytes"] =
+      static_cast<double>(fixture.config_payload_bytes());
+  state.counters["implementation_payload_bytes"] =
+      static_cast<double>(fixture.implementation_payload_bytes());
+  state.counters["selected_facets"] = static_cast<double>(selected_facet_count);
+  state.counters["selected_symbols"] =
+      static_cast<double>(selected_symbol_count);
+  state.SetComplexityN(fixture.implementation_payload_bytes());
+}
+
 static void ImplementationPayloadScales(benchmark::Benchmark* benchmark) {
   benchmark->Arg(0)->Arg(4 * 1024)->Arg(64 * 1024)->Arg(1024 * 1024);
 }
 
 BENCHMARK(BM_MaterializeKernelConfig)
+    ->Apply(ImplementationPayloadScales)
+    ->Complexity(benchmark::o1);
+BENCHMARK(BM_PlanKernelConfig)
     ->Apply(ImplementationPayloadScales)
     ->Complexity(benchmark::o1);
 

--- a/loom/src/loom/link/kernel_config_materializer_test.cc
+++ b/loom/src/loom/link/kernel_config_materializer_test.cc
@@ -91,6 +91,45 @@ class KernelConfigMaterializerTest : public ::testing::Test {
     return bytes;
   }
 
+  void AddText(loom_link_module_index_t* index, iree_string_view_t source) {
+    loom_text_parse_options_t parse_options = {};
+    parse_options.diagnostic_sink = {loom_diagnostic_stderr_sink, nullptr};
+    parse_options.max_errors = 20;
+    IREE_CHECK_OK(loom_link_module_index_add_text(
+        index, source, IREE_SV("provider.loom"), &parse_options,
+        /*options=*/nullptr, /*out_provider_ordinal=*/nullptr));
+  }
+
+  const loom_symbol_t* FindSymbol(const loom_module_t* module,
+                                  iree_string_view_t name) {
+    for (iree_host_size_t i = 0; i < module->symbols.count; ++i) {
+      const loom_symbol_t* symbol = &module->symbols.entries[i];
+      if (iree_string_view_equal(module->strings.entries[symbol->name_id],
+                                 name)) {
+        return symbol;
+      }
+    }
+    return nullptr;
+  }
+
+  void VerifyBytecodeRoundTrip(const loom_module_t* module) {
+    const std::vector<uint8_t> bytecode = Write(module);
+    loom_bytecode_read_options_t options = {};
+    options.diagnostic_sink = {loom_diagnostic_stderr_sink, nullptr};
+    options.verify_module = true;
+    options.verify_max_errors = 20;
+    loom_bytecode_read_result_t result = {};
+    loom_module_t* roundtrip_module = nullptr;
+    IREE_ASSERT_OK(loom_bytecode_read_module(
+        iree_make_const_byte_span(bytecode.data(), bytecode.size()),
+        IREE_SV("roundtrip.loombc"), &context_, &block_pool_, &options, &result,
+        &roundtrip_module, iree_allocator_system()));
+    ASSERT_EQ(result.error_count, 0u);
+    ASSERT_NE(roundtrip_module, nullptr);
+    Verify(roundtrip_module);
+    loom_module_free(roundtrip_module);
+  }
+
   IndexPtr CreateIndex() {
     loom_link_module_index_t* index = nullptr;
     IREE_CHECK_OK(loom_link_module_index_allocate(
@@ -124,14 +163,15 @@ class KernelConfigMaterializerTest : public ::testing::Test {
 
 TEST_F(KernelConfigMaterializerTest,
        IndexesKernelFacetSchemaAcrossProviderForms) {
-  loom_module_t* source_module = Parse(IREE_SV(R"(
+  const iree_string_view_t source = IREE_SV(R"(
 kernel.def @dispatch_rows(%element_count: index) {
   %one = index.constant 1 : index
   kernel.launch.config workgroups(%element_count, %one, %one) workgroup_size(%one, %one, %one) : index
 } launch(%source: buffer) {
   kernel.return
 }
-)"));
+)");
+  loom_module_t* source_module = Parse(source);
   Verify(source_module);
   const std::vector<uint8_t> bytecode = Write(source_module);
 
@@ -157,6 +197,10 @@ kernel.def @dispatch_rows(%element_count: index) {
       /*out_provider_ordinal=*/nullptr));
   verify_index(materialized_index.get());
 
+  IndexPtr text_index = CreateIndex();
+  AddText(text_index.get(), source);
+  verify_index(text_index.get());
+
   IndexPtr bytecode_index = CreateIndex();
   IREE_ASSERT_OK(loom_link_module_index_add_bytecode(
       bytecode_index.get(),
@@ -164,6 +208,170 @@ kernel.def @dispatch_rows(%element_count: index) {
       IREE_SV("provider.loombc"), /*index_options=*/nullptr,
       /*options=*/nullptr, /*out_provider_ordinal=*/nullptr));
   verify_index(bytecode_index.get());
+
+  loom_module_free(source_module);
+}
+
+TEST_F(KernelConfigMaterializerTest,
+       ReconstructsCompleteKernelAcrossProviderForms) {
+  const iree_string_view_t source = IREE_SV(R"(
+target.generic<reference> @dispatch_target
+
+func.def pure @implementation_only(%value: index) -> (index) {
+  func.return %value : index
+}
+
+kernel.def target(@dispatch_target) @dispatch_rows(%element_count: index) {
+  %one = index.constant 1 : index
+  %subgroup_size = target.subgroup.size : index
+  %workgroup_count = index.div %element_count, %subgroup_size : index
+  kernel.launch.config workgroups(%workgroup_count, %one, %one) workgroup_size(%subgroup_size, %one, %one) : index
+} launch(%stride: index) {
+  %unused = func.call @implementation_only(%stride) : (index) -> (index)
+  kernel.return
+}
+)");
+  loom_module_t* source_module = Parse(source);
+  Verify(source_module);
+  const std::vector<uint8_t> bytecode = Write(source_module);
+
+  enum class ProviderForm {
+    kMaterialized,
+    kText,
+    kBytecode,
+  };
+  const ProviderForm provider_forms[] = {
+      ProviderForm::kMaterialized,
+      ProviderForm::kText,
+      ProviderForm::kBytecode,
+  };
+  for (ProviderForm provider_form : provider_forms) {
+    IndexPtr index = CreateIndex();
+    switch (provider_form) {
+      case ProviderForm::kMaterialized:
+        IREE_ASSERT_OK(loom_link_module_index_add_materialized(
+            index.get(), source_module, /*options=*/nullptr,
+            /*out_provider_ordinal=*/nullptr));
+        break;
+      case ProviderForm::kText:
+        AddText(index.get(), source);
+        break;
+      case ProviderForm::kBytecode:
+        IREE_ASSERT_OK(loom_link_module_index_add_bytecode(
+            index.get(),
+            iree_make_const_byte_span(bytecode.data(), bytecode.size()),
+            IREE_SV("provider.loombc"), /*index_options=*/nullptr,
+            /*options=*/nullptr, /*out_provider_ordinal=*/nullptr));
+        break;
+    }
+
+    const loom_link_module_index_symbol_t* kernel =
+        loom_link_module_index_lookup_name(index.get(),
+                                           IREE_SV("dispatch_rows"));
+    const loom_link_module_index_symbol_t* implementation_only =
+        loom_link_module_index_lookup_name(index.get(),
+                                           IREE_SV("implementation_only"));
+    const loom_link_module_index_symbol_t* target =
+        loom_link_module_index_lookup_name(index.get(),
+                                           IREE_SV("dispatch_target"));
+    ASSERT_NE(kernel, nullptr);
+    ASSERT_NE(implementation_only, nullptr);
+    ASSERT_NE(target, nullptr);
+
+    PlanPtr config_plan = BuildConfigPlan(index.get(), kernel->ordinal);
+    EXPECT_EQ(loom_link_plan_symbol_count(config_plan.get()), 2u);
+    EXPECT_EQ(loom_link_plan_facet_count(config_plan.get()), 3u);
+    EXPECT_TRUE(
+        loom_link_plan_contains_symbol(config_plan.get(), kernel->ordinal));
+    EXPECT_TRUE(
+        loom_link_plan_contains_symbol(config_plan.get(), target->ordinal));
+    EXPECT_FALSE(loom_link_plan_contains_symbol(config_plan.get(),
+                                                implementation_only->ordinal));
+    EXPECT_TRUE(
+        loom_link_plan_contains_facet(config_plan.get(), kernel->ordinal, 0));
+    EXPECT_TRUE(loom_link_plan_contains_facet(
+        config_plan.get(), kernel->ordinal,
+        kernel->facets.schema.kernel_configuration_region_index_plus_one));
+    EXPECT_FALSE(loom_link_plan_contains_facet(
+        config_plan.get(), kernel->ordinal,
+        kernel->facets.schema.body_region_index_plus_one));
+
+    PlanPtr full_plan = BuildPlan(index.get(), IREE_SV("dispatch_rows"));
+    EXPECT_EQ(loom_link_plan_symbol_count(full_plan.get()), 3u);
+    EXPECT_EQ(loom_link_plan_facet_count(full_plan.get()), 6u);
+    EXPECT_TRUE(
+        loom_link_plan_contains_symbol(full_plan.get(), kernel->ordinal));
+    EXPECT_TRUE(
+        loom_link_plan_contains_symbol(full_plan.get(), target->ordinal));
+    EXPECT_TRUE(loom_link_plan_contains_symbol(full_plan.get(),
+                                               implementation_only->ordinal));
+    EXPECT_TRUE(loom_link_plan_contains_facet(
+        full_plan.get(), kernel->ordinal,
+        kernel->facets.schema.kernel_configuration_region_index_plus_one));
+    EXPECT_TRUE(loom_link_plan_contains_facet(
+        full_plan.get(), kernel->ordinal,
+        kernel->facets.schema.body_region_index_plus_one));
+
+    loom_link_plan_materialization_environment_t environment = {};
+    environment.context = &context_;
+    environment.block_pool = &block_pool_;
+    environment.allocator = iree_allocator_system();
+    iree_arena_allocator_t materialization_arena;
+    iree_arena_initialize(&block_pool_, &materialization_arena);
+    loom_link_plan_materialization_t materialization = {};
+    IREE_ASSERT_OK(loom_link_plan_materialize(
+        full_plan.get(), &environment, IREE_SV("full"), &materialization_arena,
+        &materialization));
+    std::unique_ptr<loom_module_t, decltype(&loom_module_free)> full_module(
+        materialization.module, loom_module_free);
+    Verify(full_module.get());
+    ASSERT_EQ(full_module->symbols.count, 3u);
+
+    const loom_symbol_t* full_kernel =
+        FindSymbol(full_module.get(), IREE_SV("dispatch_rows"));
+    const loom_symbol_t* full_helper =
+        FindSymbol(full_module.get(), IREE_SV("implementation_only"));
+    const loom_symbol_t* full_target =
+        FindSymbol(full_module.get(), IREE_SV("dispatch_target"));
+    ASSERT_NE(full_kernel, nullptr);
+    ASSERT_NE(full_helper, nullptr);
+    ASSERT_NE(full_target, nullptr);
+    ASSERT_TRUE(loom_kernel_def_isa(full_kernel->defining_op));
+    ASSERT_TRUE(loom_func_def_isa(full_helper->defining_op));
+    ASSERT_TRUE(loom_target_generic_isa(full_target->defining_op));
+
+    loom_block_t* config_block = loom_region_entry_block(
+        loom_kernel_def_config(full_kernel->defining_op));
+    ASSERT_NE(config_block, nullptr);
+    ASSERT_TRUE(loom_kernel_launch_config_isa(config_block->last_op));
+    loom_block_t* body_block =
+        loom_region_entry_block(loom_kernel_def_body(full_kernel->defining_op));
+    ASSERT_NE(body_block, nullptr);
+    ASSERT_TRUE(loom_kernel_return_isa(body_block->last_op));
+    const loom_op_t* implementation_call = nullptr;
+    const loom_op_t* body_op = nullptr;
+    loom_block_for_each_op(body_block, body_op) {
+      if (loom_func_call_isa(body_op)) {
+        implementation_call = body_op;
+      }
+    }
+    ASSERT_NE(implementation_call, nullptr);
+    const loom_symbol_ref_t implementation_ref =
+        loom_func_call_callee(implementation_call);
+    ASSERT_EQ(implementation_ref.module_id, 0u);
+    ASSERT_LT(implementation_ref.symbol_id, full_module->symbols.count);
+    EXPECT_EQ(
+        full_module->symbols.entries[implementation_ref.symbol_id].defining_op,
+        full_helper->defining_op);
+    const loom_symbol_ref_t target_ref =
+        loom_kernel_def_target(full_kernel->defining_op);
+    ASSERT_EQ(target_ref.module_id, 0u);
+    ASSERT_LT(target_ref.symbol_id, full_module->symbols.count);
+    EXPECT_EQ(full_module->symbols.entries[target_ref.symbol_id].defining_op,
+              full_target->defining_op);
+    VerifyBytecodeRoundTrip(full_module.get());
+    iree_arena_deinitialize(&materialization_arena);
+  }
 
   loom_module_free(source_module);
 }

--- a/loom/src/loom/link/kernel_config_materializer_test.cc
+++ b/loom/src/loom/link/kernel_config_materializer_test.cc
@@ -115,6 +115,52 @@ class KernelConfigMaterializerTest : public ::testing::Test {
 };
 
 TEST_F(KernelConfigMaterializerTest,
+       IndexesKernelFacetSchemaAcrossProviderForms) {
+  loom_module_t* source_module = Parse(IREE_SV(R"(
+kernel.def @dispatch_rows(%element_count: index) {
+  %one = index.constant 1 : index
+  kernel.launch.config workgroups(%element_count, %one, %one) workgroup_size(%one, %one, %one) : index
+} launch(%source: buffer) {
+  kernel.return
+}
+)"));
+  Verify(source_module);
+  const std::vector<uint8_t> bytecode = Write(source_module);
+
+  auto verify_index = [](const loom_link_module_index_t* index) {
+    const loom_link_module_index_symbol_t* kernel =
+        loom_link_module_index_lookup_name(index, IREE_SV("dispatch_rows"));
+    ASSERT_NE(kernel, nullptr);
+    EXPECT_TRUE(iree_any_bit_set(kernel->facets.schema.interfaces,
+                                 LOOM_SYMBOL_INTERFACE_KERNEL));
+    EXPECT_EQ(kernel->facets.schema.root_region_count, 2u);
+    EXPECT_EQ(kernel->facets.schema.kernel_configuration_region_index_plus_one,
+              1u);
+    EXPECT_EQ(kernel->facets.schema.body_region_index_plus_one, 2u);
+    EXPECT_EQ(loom_link_module_index_facet_count(index), 3u);
+    EXPECT_EQ(loom_link_module_index_symbol_facet_ordinal(kernel, 0), 0u);
+    EXPECT_EQ(loom_link_module_index_symbol_facet_ordinal(kernel, 1), 1u);
+    EXPECT_EQ(loom_link_module_index_symbol_facet_ordinal(kernel, 2), 2u);
+  };
+
+  IndexPtr materialized_index = CreateIndex();
+  IREE_ASSERT_OK(loom_link_module_index_add_materialized(
+      materialized_index.get(), source_module, /*options=*/nullptr,
+      /*out_provider_ordinal=*/nullptr));
+  verify_index(materialized_index.get());
+
+  IndexPtr bytecode_index = CreateIndex();
+  IREE_ASSERT_OK(loom_link_module_index_add_bytecode(
+      bytecode_index.get(),
+      iree_make_const_byte_span(bytecode.data(), bytecode.size()),
+      IREE_SV("provider.loombc"), /*index_options=*/nullptr,
+      /*options=*/nullptr, /*out_provider_ordinal=*/nullptr));
+  verify_index(bytecode_index.get());
+
+  loom_module_free(source_module);
+}
+
+TEST_F(KernelConfigMaterializerTest,
        ProjectsConfigurationWithoutReadingPoisonedImplementation) {
   loom_module_t* source_module = Parse(IREE_SV(R"(
 target.generic<reference> @dispatch_target

--- a/loom/src/loom/link/kernel_config_materializer_test.cc
+++ b/loom/src/loom/link/kernel_config_materializer_test.cc
@@ -110,6 +110,14 @@ class KernelConfigMaterializerTest : public ::testing::Test {
     return PlanPtr(plan);
   }
 
+  PlanPtr BuildConfigPlan(loom_link_module_index_t* index,
+                          iree_host_size_t kernel_symbol_ordinal) {
+    loom_link_plan_t* plan = nullptr;
+    IREE_CHECK_OK(loom_link_plan_build_kernel_configuration(
+        index, kernel_symbol_ordinal, iree_allocator_system(), &plan));
+    return PlanPtr(plan);
+  }
+
   iree_arena_block_pool_t block_pool_;
   loom_context_t context_;
 };
@@ -183,6 +191,36 @@ kernel.def target(@dispatch_target) @dispatch_rows(%element_count: index) {
 )"));
   Verify(source_module);
   std::vector<uint8_t> bytecode = Write(source_module);
+
+  {
+    IndexPtr materialized_index = CreateIndex();
+    IREE_ASSERT_OK(loom_link_module_index_add_materialized(
+        materialized_index.get(), source_module, /*options=*/nullptr,
+        /*out_provider_ordinal=*/nullptr));
+    const loom_link_module_index_symbol_t* materialized_kernel =
+        loom_link_module_index_lookup_name(materialized_index.get(),
+                                           IREE_SV("dispatch_rows"));
+    const loom_link_module_index_symbol_t* materialized_implementation_only =
+        loom_link_module_index_lookup_name(materialized_index.get(),
+                                           IREE_SV("implementation_only"));
+    ASSERT_NE(materialized_kernel, nullptr);
+    ASSERT_NE(materialized_implementation_only, nullptr);
+    PlanPtr materialized_plan =
+        BuildConfigPlan(materialized_index.get(), materialized_kernel->ordinal);
+    EXPECT_TRUE(loom_link_plan_contains_symbol(materialized_plan.get(),
+                                               materialized_kernel->ordinal));
+    EXPECT_FALSE(loom_link_plan_contains_symbol(
+        materialized_plan.get(), materialized_implementation_only->ordinal));
+    EXPECT_TRUE(loom_link_plan_contains_facet(materialized_plan.get(),
+                                              materialized_kernel->ordinal, 0));
+    EXPECT_TRUE(loom_link_plan_contains_facet(
+        materialized_plan.get(), materialized_kernel->ordinal,
+        materialized_kernel->facets.schema
+            .kernel_configuration_region_index_plus_one));
+    EXPECT_FALSE(loom_link_plan_contains_facet(
+        materialized_plan.get(), materialized_kernel->ordinal,
+        materialized_kernel->facets.schema.body_region_index_plus_one));
+  }
   loom_module_free(source_module);
 
   IndexPtr index = CreateIndex();
@@ -195,13 +233,22 @@ kernel.def target(@dispatch_target) @dispatch_rows(%element_count: index) {
   const loom_link_module_index_symbol_t* indexed_kernel =
       loom_link_module_index_lookup_name(index.get(), IREE_SV("dispatch_rows"));
   ASSERT_NE(indexed_kernel, nullptr);
-  PlanPtr plan = BuildPlan(index.get(), IREE_SV("dispatch_rows"));
+  PlanPtr plan = BuildConfigPlan(index.get(), indexed_kernel->ordinal);
   const loom_link_module_index_symbol_t* implementation_only =
       loom_link_module_index_lookup_name(index.get(),
                                          IREE_SV("implementation_only"));
   ASSERT_NE(implementation_only, nullptr);
-  EXPECT_TRUE(
+  EXPECT_FALSE(
       loom_link_plan_contains_symbol(plan.get(), implementation_only->ordinal));
+  EXPECT_TRUE(
+      loom_link_plan_contains_facet(plan.get(), indexed_kernel->ordinal, 0));
+  EXPECT_TRUE(loom_link_plan_contains_facet(
+      plan.get(), indexed_kernel->ordinal,
+      indexed_kernel->facets.schema
+          .kernel_configuration_region_index_plus_one));
+  EXPECT_FALSE(loom_link_plan_contains_facet(
+      plan.get(), indexed_kernel->ordinal,
+      indexed_kernel->facets.schema.body_region_index_plus_one));
 
   const loom_link_module_index_provider_t* provider =
       loom_link_module_index_symbol_provider(index.get(), indexed_kernel);
@@ -324,9 +371,12 @@ kernel.def target(@dispatch_target) @dispatch_rows(%element_count: index) {
 
   iree_arena_allocator_t materialization_arena;
   iree_arena_initialize(&block_pool_, &materialization_arena);
+  PlanPtr full_plan = BuildPlan(index.get(), IREE_SV("dispatch_rows"));
+  EXPECT_TRUE(loom_link_plan_contains_symbol(full_plan.get(),
+                                             implementation_only->ordinal));
   loom_link_plan_materialization_t full_materialization = {};
   iree_status_t full_status =
-      loom_link_plan_materialize(plan.get(), &environment, IREE_SV("full"),
+      loom_link_plan_materialize(full_plan.get(), &environment, IREE_SV("full"),
                                  &materialization_arena, &full_materialization);
   IREE_EXPECT_NOT_OK(full_status);
   loom_module_free(full_materialization.module);

--- a/loom/src/loom/link/module_index.c
+++ b/loom/src/loom/link/module_index.c
@@ -846,13 +846,16 @@ static uint32_t loom_link_index_count_dependency_occurrences(
 static void loom_link_index_copy_dependency_occurrences(
     const loom_symbol_reference_table_t* table,
     loom_symbol_reference_occurrence_id_t first_occurrence_id, uint32_t* values,
-    iree_host_size_t* position) {
+    uint8_t* source_root_region_indices_plus_one, iree_host_size_t* position) {
   loom_symbol_reference_occurrence_id_t occurrence_id = first_occurrence_id;
   while (occurrence_id != LOOM_SYMBOL_REFERENCE_OCCURRENCE_ID_INVALID) {
     const loom_symbol_reference_occurrence_t* occurrence =
         &table->occurrences[occurrence_id];
     if (loom_symbol_reference_occurrence_is_dependency(occurrence)) {
-      values[(*position)++] = occurrence->target_symbol_id;
+      values[*position] = occurrence->target_symbol_id;
+      source_root_region_indices_plus_one[*position] =
+          occurrence->source_root_region_index_plus_one;
+      ++*position;
     }
     occurrence_id = occurrence->next_outgoing_occurrence_id;
   }
@@ -866,7 +869,9 @@ static iree_status_t loom_link_index_project_materialized_references(
 
   loom_symbol_reference_table_t table = {0};
   uint32_t* dependency_values = NULL;
+  uint8_t* dependency_source_root_region_indices_plus_one = NULL;
   loom_link_template_family_ordinal_t* template_demand_values = NULL;
+  uint8_t* template_demand_source_root_region_indices_plus_one = NULL;
   iree_status_t status =
       loom_symbol_reference_table_build(source_module, &scratch_arena, &table);
   if (iree_status_is_ok(status)) {
@@ -886,6 +891,14 @@ static iree_status_t loom_link_index_project_materialized_references(
                                          sizeof(*dependency_values),
                                          (void**)&dependency_values);
       module->dependencies.values = dependency_values;
+      if (iree_status_is_ok(status)) {
+        status = iree_arena_allocate_array(
+            &index->arena, dependency_count,
+            sizeof(*dependency_source_root_region_indices_plus_one),
+            (void**)&dependency_source_root_region_indices_plus_one);
+        module->dependencies.source_root_region_indices_plus_one =
+            dependency_source_root_region_indices_plus_one;
+      }
     }
   }
 
@@ -896,6 +909,14 @@ static iree_status_t loom_link_index_project_materialized_references(
           &index->arena, table.template_demands.count,
           sizeof(*template_demand_values), (void**)&template_demand_values);
       module->template_demands.values = template_demand_values;
+      if (iree_status_is_ok(status)) {
+        status = iree_arena_allocate_array(
+            &index->arena, table.template_demands.count,
+            sizeof(*template_demand_source_root_region_indices_plus_one),
+            (void**)&template_demand_source_root_region_indices_plus_one);
+        module->template_demands.source_root_region_indices_plus_one =
+            template_demand_source_root_region_indices_plus_one;
+      }
     }
   }
 
@@ -904,7 +925,7 @@ static iree_status_t loom_link_index_project_materialized_references(
   if (iree_status_is_ok(status)) {
     loom_link_index_copy_dependency_occurrences(
         &table, table.first_module_occurrence_id, dependency_values,
-        &dependency_position);
+        dependency_source_root_region_indices_plus_one, &dependency_position);
     for (iree_host_size_t symbol_index = 0;
          symbol_index < table.symbol_count && iree_status_is_ok(status);
          ++symbol_index) {
@@ -917,7 +938,7 @@ static iree_status_t loom_link_index_project_materialized_references(
           &table, source->first_outgoing_occurrence_id);
       loom_link_index_copy_dependency_occurrences(
           &table, source->first_outgoing_occurrence_id, dependency_values,
-          &dependency_position);
+          dependency_source_root_region_indices_plus_one, &dependency_position);
 
       symbol->template_demands.first = (uint32_t)template_demand_position;
       symbol->template_demands.count = source->template_demand_count;
@@ -932,7 +953,11 @@ static iree_status_t loom_link_index_project_materialized_references(
             index, module->symbol_start_ordinal + demand->family_symbol_id,
             &family_ordinal);
         if (iree_status_is_ok(status)) {
-          template_demand_values[template_demand_position++] = family_ordinal;
+          template_demand_values[template_demand_position] = family_ordinal;
+          template_demand_source_root_region_indices_plus_one
+              [template_demand_position] =
+                  demand->source_root_region_index_plus_one;
+          ++template_demand_position;
         }
         demand_id = demand->next_source_demand_id;
       }
@@ -964,7 +989,11 @@ static iree_status_t loom_link_index_project_bytecode_references(
   module->dependencies.root_count = bytecode_module->module_dependency_count;
   module->dependencies.count = bytecode_module->dependency_count;
   module->dependencies.values = bytecode_module->dependency_symbol_indices;
+  module->dependencies.source_root_region_indices_plus_one =
+      bytecode_module->dependency_source_root_region_indices_plus_one;
   module->template_demands.count = bytecode_module->template_demand_count;
+  module->template_demands.source_root_region_indices_plus_one =
+      bytecode_module->template_demand_source_root_region_indices_plus_one;
   loom_link_template_family_ordinal_t* template_demand_values = NULL;
   if (bytecode_module->template_demand_count > 0) {
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(

--- a/loom/src/loom/link/module_index.c
+++ b/loom/src/loom/link/module_index.c
@@ -65,6 +65,8 @@ struct loom_link_module_index_t {
     // Allocated record capacity.
     iree_host_size_t capacity;
   } symbols;
+  // Total contract and root-region facets across indexed symbols.
+  iree_host_size_t facet_count;
   // Exported INPUT-provider symbols in stable provider order.
   struct {
     // Growable index-wide symbol ordinal storage.
@@ -537,7 +539,8 @@ static iree_status_t loom_link_index_append_module(
 static iree_status_t loom_link_index_append_symbol(
     loom_link_module_index_t* index, loom_link_module_index_module_t* module,
     iree_string_view_t name, loom_symbol_kind_t kind,
-    loom_link_symbol_identity_t identity, loom_link_symbol_flags_t flags) {
+    loom_link_symbol_identity_t identity, loom_link_symbol_flags_t flags,
+    loom_link_symbol_facet_schema_t facet_schema) {
   const iree_host_size_t symbol_ordinal = index->symbols.count;
   iree_host_size_t symbol_count = 0;
   if (!iree_host_size_checked_add(symbol_ordinal, 1, &symbol_count)) {
@@ -560,6 +563,13 @@ static iree_status_t loom_link_index_append_symbol(
     IREE_RETURN_IF_ERROR(
         loom_link_index_reserve_input_exports(index, input_export_count));
   }
+  iree_host_size_t facet_count = 0;
+  if (!iree_host_size_checked_add(
+          index->facet_count,
+          (iree_host_size_t)facet_schema.root_region_count + 1, &facet_count)) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "link symbol facet count overflow");
+  }
   loom_link_module_index_symbol_t* symbol =
       &index->symbols.values[symbol_ordinal];
   *symbol = (loom_link_module_index_symbol_t){
@@ -571,6 +581,11 @@ static iree_status_t loom_link_index_append_symbol(
       .template_family_ordinal = LOOM_LINK_TEMPLATE_FAMILY_ORDINAL_INVALID,
       .identity = identity,
       .flags = flags,
+      .facets =
+          {
+              .schema = facet_schema,
+              .start_ordinal = index->facet_count,
+          },
       .next =
           {
               .same_name_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
@@ -581,6 +596,7 @@ static iree_status_t loom_link_index_append_symbol(
 
   ++module->symbol_count;
   index->symbols.count = symbol_count;
+  index->facet_count = facet_count;
   IREE_RETURN_IF_ERROR(
       loom_link_index_insert_symbol_name(index, symbol_ordinal));
   if (is_input_export) {
@@ -745,9 +761,25 @@ static iree_status_t loom_link_index_module_materialized_symbols(
         loom_link_symbol_has_global_identity(source_module, symbol)
             ? LOOM_LINK_SYMBOL_IDENTITY_GLOBAL
             : LOOM_LINK_SYMBOL_IDENTITY_PRIVATE;
+    const loom_op_t* defining_op = symbol->defining_op;
+    const loom_op_vtable_t* vtable =
+        defining_op ? loom_op_vtable(source_module, defining_op) : NULL;
+    loom_link_symbol_facet_schema_t facet_schema = {0};
+    if (vtable && vtable->symbol_def) {
+      facet_schema.interfaces = vtable->symbol_def->interfaces;
+      facet_schema.root_region_count = defining_op->region_count;
+      facet_schema.kernel_configuration_region_index_plus_one =
+          vtable->symbol_def->kernel_workload_region_index_plus_one;
+      if (vtable->func_like &&
+          vtable->func_like->body_region_index != LOOM_REGION_INDEX_NONE) {
+        facet_schema.body_region_index_plus_one =
+            (uint8_t)(vtable->func_like->body_region_index + 1);
+      }
+    }
     IREE_RETURN_IF_ERROR(loom_link_index_append_symbol(
         index, module, name, symbol->kind, identity,
-        loom_link_materialized_symbol_flags(source_module, symbol)));
+        loom_link_materialized_symbol_flags(source_module, symbol),
+        facet_schema));
   }
   return iree_ok_status();
 }
@@ -975,10 +1007,18 @@ static iree_status_t loom_link_index_module_bytecode_symbols(
     const loom_bytecode_symbol_metadata_t* symbol =
         &bytecode_module->symbols[i];
     loom_link_symbol_flags_t flags = loom_link_bytecode_symbol_flags(symbol);
+    const loom_link_symbol_facet_schema_t facet_schema = {
+        .interfaces = symbol->interfaces,
+        .root_region_count = symbol->root_region_count,
+        .body_region_index_plus_one = symbol->body_region_index_plus_one,
+        .kernel_configuration_region_index_plus_one =
+            symbol->kernel_workload_region_index_plus_one,
+    };
     IREE_RETURN_IF_ERROR(loom_link_index_append_symbol(
         index, module, symbol->name,
         loom_link_bytecode_symbol_kind(symbol->kind),
-        loom_link_bytecode_symbol_identity(symbol, flags), flags));
+        loom_link_bytecode_symbol_identity(symbol, flags), flags,
+        facet_schema));
   }
   return iree_ok_status();
 }
@@ -1453,12 +1493,26 @@ iree_host_size_t loom_link_module_index_symbol_count(
   return index ? index->symbols.count : 0;
 }
 
+iree_host_size_t loom_link_module_index_facet_count(
+    const loom_link_module_index_t* index) {
+  return index ? index->facet_count : 0;
+}
+
 const loom_link_module_index_symbol_t* loom_link_module_index_symbol_at(
     const loom_link_module_index_t* index, iree_host_size_t ordinal) {
   if (!index || ordinal >= index->symbols.count) {
     return NULL;
   }
   return &index->symbols.values[ordinal];
+}
+
+iree_host_size_t loom_link_module_index_symbol_facet_ordinal(
+    const loom_link_module_index_symbol_t* symbol,
+    uint8_t source_root_region_index_plus_one) {
+  IREE_ASSERT(symbol);
+  IREE_ASSERT_LE(source_root_region_index_plus_one,
+                 symbol->facets.schema.root_region_count);
+  return symbol->facets.start_ordinal + source_root_region_index_plus_one;
 }
 
 loom_link_module_index_symbol_ordinal_list_t

--- a/loom/src/loom/link/module_index.h
+++ b/loom/src/loom/link/module_index.h
@@ -168,6 +168,9 @@ typedef struct loom_link_module_index_module_t {
     // Module-local target symbol ordinals in deterministic occurrence order.
     // Targets may repeat within a source row.
     const uint32_t* values;
+    // Source root region indices plus one parallel to values. Zero identifies
+    // a source symbol contract or a module-root occurrence.
+    const uint8_t* source_root_region_indices_plus_one;
   } dependencies;
   // Abstract template-family demand occurrences owned by this module.
   struct {
@@ -176,6 +179,8 @@ typedef struct loom_link_module_index_module_t {
     // Dense index family ordinals in deterministic demand order. Ordinals may
     // repeat within a source row.
     const loom_link_template_family_ordinal_t* values;
+    // Source root region indices plus one parallel to values.
+    const uint8_t* source_root_region_indices_plus_one;
   } template_demands;
   // Compile-time provider imports and their symbol-to-import projection.
   struct {

--- a/loom/src/loom/link/module_index.h
+++ b/loom/src/loom/link/module_index.h
@@ -108,6 +108,21 @@ enum loom_link_symbol_flag_bits_e {
 };
 typedef uint32_t loom_link_symbol_flags_t;
 
+// Structural projection points exposed by one indexed symbol definition.
+// Contract references use source root zero; independently bounded root regions
+// use their one-based source region index.
+typedef struct loom_link_symbol_facet_schema_t {
+  // Structural symbol interfaces declared by the defining operation.
+  loom_symbol_interface_flags_t interfaces;
+  // Number of root region slots declared by the defining operation.
+  uint8_t root_region_count;
+  // Function body source root region index plus one, or zero when absent.
+  uint8_t body_region_index_plus_one;
+  // Kernel configuration source root region index plus one, or zero when
+  // absent.
+  uint8_t kernel_configuration_region_index_plus_one;
+} loom_link_symbol_facet_schema_t;
+
 // Options applied when adding a provider to an index.
 typedef struct loom_link_module_index_add_options_t {
   // Stable provider label for diagnostics and deterministic private naming.
@@ -217,6 +232,14 @@ typedef struct loom_link_module_index_symbol_t {
   loom_link_symbol_identity_t identity;
   // Linker-index symbol flags.
   loom_link_symbol_flags_t flags;
+  // Independently selectable structural projections of this symbol.
+  struct {
+    // Schema projected from the defining operation during source indexing.
+    loom_link_symbol_facet_schema_t schema;
+    // Index-wide ordinal of the contract facet. Root region facets immediately
+    // follow in source region order.
+    iree_host_size_t start_ordinal;
+  } facets;
   // Slice in the owning module's flat dependency occurrence array.
   struct {
     // First occurrence index.
@@ -316,9 +339,20 @@ const loom_link_module_index_module_t* loom_link_module_index_module_at(
 iree_host_size_t loom_link_module_index_symbol_count(
     const loom_link_module_index_t* index);
 
+// Returns the number of index-wide structural symbol facets.
+iree_host_size_t loom_link_module_index_facet_count(
+    const loom_link_module_index_t* index);
+
 // Returns symbol |ordinal|, or NULL if out of range.
 const loom_link_module_index_symbol_t* loom_link_module_index_symbol_at(
     const loom_link_module_index_t* index, iree_host_size_t ordinal);
+
+// Returns the index-wide facet ordinal for |source_root_region_index_plus_one|.
+// Zero selects the symbol contract. The source root must be present in the
+// symbol facet schema.
+iree_host_size_t loom_link_module_index_symbol_facet_ordinal(
+    const loom_link_module_index_symbol_t* symbol,
+    uint8_t source_root_region_index_plus_one);
 
 // Returns exported symbols owned by INPUT providers.
 //

--- a/loom/src/loom/link/module_index_test.cc
+++ b/loom/src/loom/link/module_index_test.cc
@@ -426,22 +426,31 @@ template.def<@demo.contract> @provider(%x: i32) -> (i32) {
     ASSERT_NE(provider, nullptr);
     ASSERT_NE(family_declaration, nullptr);
     auto has_dependency = [&](const loom_link_module_index_symbol_t* source,
-                              const loom_link_module_index_symbol_t* target) {
+                              const loom_link_module_index_symbol_t* target,
+                              uint8_t expected_source_root) {
       for (iree_host_size_t i = 0; i < source->dependencies.count; ++i) {
-        if (indexed_module->dependencies
-                .values[source->dependencies.first + i] ==
+        const iree_host_size_t dependency_index =
+            source->dependencies.first + i;
+        if (indexed_module->dependencies.values[dependency_index] ==
             target->module_symbol_ordinal) {
+          EXPECT_EQ(indexed_module->dependencies
+                        .source_root_region_indices_plus_one[dependency_index],
+                    expected_source_root);
           return true;
         }
       }
       return false;
     };
     ASSERT_EQ(entry->dependencies.count, 2u);
-    EXPECT_TRUE(has_dependency(entry, helper));
-    EXPECT_TRUE(has_dependency(entry, family_declaration));
+    EXPECT_TRUE(has_dependency(entry, helper, 1u));
+    EXPECT_TRUE(has_dependency(entry, family_declaration, 1u));
     ASSERT_EQ(provider->dependencies.count, 1u);
-    EXPECT_TRUE(has_dependency(provider, family_declaration));
+    EXPECT_TRUE(has_dependency(provider, family_declaration, 0u));
     ASSERT_EQ(entry->template_demands.count, 1u);
+    EXPECT_EQ(
+        indexed_module->template_demands
+            .source_root_region_indices_plus_one[entry->template_demands.first],
+        1u);
 
     ASSERT_EQ(loom_link_module_index_template_family_count(index), 1u);
     const loom_link_template_family_ordinal_t family_ordinal =
@@ -460,6 +469,79 @@ template.def<@demo.contract> @provider(%x: i32) -> (i32) {
     EXPECT_EQ(family->providers.last_symbol_ordinal, provider->ordinal);
     EXPECT_EQ(provider->next.template_provider_ordinal,
               LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL);
+  };
+
+  loom_link_module_index_add_options_t options = {
+      /*.provider_name=*/IREE_SV("library"),
+      /*.role=*/LOOM_LINK_PROVIDER_ROLE_LIBRARY,
+  };
+  IndexPtr materialized_index = CreateIndex();
+  IREE_ASSERT_OK(loom_link_module_index_add_materialized(
+      materialized_index.get(), module, &options,
+      /*out_provider_ordinal=*/nullptr));
+  verify_index(materialized_index.get());
+
+  IndexPtr bytecode_index = CreateIndex();
+  IREE_ASSERT_OK(loom_link_module_index_add_bytecode(
+      bytecode_index.get(),
+      iree_make_const_byte_span(bytes.data(), bytes.size()),
+      IREE_SV("library.loombc"), /*index_options=*/nullptr, &options,
+      /*out_provider_ordinal=*/nullptr));
+  verify_index(bytecode_index.get());
+}
+
+TEST_F(ModuleIndexTest, ProjectsMultiRootReferenceOriginsAcrossProviders) {
+  loom_module_t* module = Parse(IREE_SV(R"(
+test.record @config_dependency
+test.record @implementation_dependency
+
+test.split_func @split_root() {
+  test.symbol_array_attrs [@config_dependency] using []
+  test.yield
+} launch {
+  test.symbol_array_attrs [@implementation_dependency] using []
+  test.yield
+}
+)"));
+  std::vector<uint8_t> bytes = WriteModule(module);
+
+  auto verify_index = [&](const loom_link_module_index_t* index) {
+    const loom_link_module_index_module_t* indexed_module =
+        loom_link_module_index_module_at(index, 0);
+    ASSERT_NE(indexed_module, nullptr);
+    const loom_link_module_index_symbol_t* split_root =
+        loom_link_module_index_lookup_private(index, indexed_module,
+                                              IREE_SV("split_root"));
+    const loom_link_module_index_symbol_t* config_dependency =
+        loom_link_module_index_lookup_private(index, indexed_module,
+                                              IREE_SV("config_dependency"));
+    const loom_link_module_index_symbol_t* implementation_dependency =
+        loom_link_module_index_lookup_private(
+            index, indexed_module, IREE_SV("implementation_dependency"));
+    ASSERT_NE(split_root, nullptr);
+    ASSERT_NE(config_dependency, nullptr);
+    ASSERT_NE(implementation_dependency, nullptr);
+    ASSERT_EQ(split_root->dependencies.count, 2u);
+
+    bool found_config_dependency = false;
+    bool found_implementation_dependency = false;
+    for (uint32_t i = 0; i < split_root->dependencies.count; ++i) {
+      const uint32_t occurrence_index = split_root->dependencies.first + i;
+      const uint32_t target =
+          indexed_module->dependencies.values[occurrence_index];
+      const uint8_t origin =
+          indexed_module->dependencies
+              .source_root_region_indices_plus_one[occurrence_index];
+      if (target == config_dependency->module_symbol_ordinal) {
+        EXPECT_EQ(origin, 1u);
+        found_config_dependency = true;
+      } else if (target == implementation_dependency->module_symbol_ordinal) {
+        EXPECT_EQ(origin, 2u);
+        found_implementation_dependency = true;
+      }
+    }
+    EXPECT_TRUE(found_config_dependency);
+    EXPECT_TRUE(found_implementation_dependency);
   };
 
   loom_link_module_index_add_options_t options = {

--- a/loom/src/loom/link/planner.c
+++ b/loom/src/loom/link/planner.c
@@ -15,6 +15,56 @@ typedef struct loom_link_plan_bitmap_t {
   iree_host_size_t bit_count;
 } loom_link_plan_bitmap_t;
 
+typedef struct loom_link_plan_symbol_ordinal_map_entry_t {
+  // Index-wide symbol ordinal, or INVALID_ORDINAL for an empty slot.
+  iree_host_size_t symbol_ordinal;
+  // Plan-local symbol ordinal associated with symbol_ordinal.
+  iree_host_size_t plan_ordinal;
+} loom_link_plan_symbol_ordinal_map_entry_t;
+
+typedef struct loom_link_plan_live_cause_t {
+  // Why the selected symbol or facet is live.
+  loom_link_plan_live_reason_t reason;
+  // Plan-local symbol ordinal causing this selection, or INVALID_ORDINAL.
+  iree_host_size_t symbol_plan_ordinal;
+  // Plan-local facet ordinal causing this selection, or INVALID_ORDINAL.
+  iree_host_size_t facet_plan_ordinal;
+  // Authored root name when reason is ROOT.
+  iree_string_view_t root_name;
+} loom_link_plan_live_cause_t;
+
+typedef enum loom_link_plan_facet_request_mode_e {
+  // Select the symbol contract only.
+  LOOM_LINK_PLAN_FACET_REQUEST_CONTRACT = 0,
+  // Select the contract and one independently bounded root region.
+  LOOM_LINK_PLAN_FACET_REQUEST_ROOT_REGION = 1,
+  // Select the contract and every root region.
+  LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE = 2,
+} loom_link_plan_facet_request_mode_t;
+
+typedef struct loom_link_plan_facet_request_t {
+  // Selection mode defining the requested structural projection.
+  loom_link_plan_facet_request_mode_t mode;
+  // Source root region index plus one for ROOT_REGION mode.
+  uint8_t source_root_region_index_plus_one;
+} loom_link_plan_facet_request_t;
+
+typedef enum loom_link_plan_facet_expansion_mode_e {
+  // This selected facet is accounted for by another complete-symbol item.
+  LOOM_LINK_PLAN_FACET_EXPANSION_NONE = 0,
+  // Expand only references originating in this selected facet.
+  LOOM_LINK_PLAN_FACET_EXPANSION_EXACT = 1,
+  // Expand every selected facet of the symbol in one dependency pass.
+  LOOM_LINK_PLAN_FACET_EXPANSION_COMPLETE = 2,
+} loom_link_plan_facet_expansion_mode_t;
+
+typedef struct loom_link_plan_facet_work_item_t {
+  // Public selected-facet record.
+  loom_link_plan_facet_t selection;
+  // Closure expansion performed when this work item is reached.
+  loom_link_plan_facet_expansion_mode_t expansion_mode;
+} loom_link_plan_facet_work_item_t;
+
 struct loom_link_plan_t {
   // Provider index this plan selects from.
   const loom_link_module_index_t* index;
@@ -31,6 +81,15 @@ struct loom_link_plan_t {
     // Allocated selection capacity.
     iree_host_size_t capacity;
   } symbols;
+  // Live facet selections in stable worklist order.
+  struct {
+    // Growable facet selection storage.
+    loom_link_plan_facet_work_item_t* values;
+    // Number of live facet selections.
+    iree_host_size_t count;
+    // Allocated facet selection capacity.
+    iree_host_size_t capacity;
+  } facets;
   // Reachable template families in stable first-demand order.
   struct {
     // Growable dense family ordinal storage.
@@ -53,6 +112,13 @@ struct loom_link_plan_t {
     // Template families already recorded as demanded.
     loom_link_plan_bitmap_t template_families;
   } reachability;
+  // Reverse map allocated only when the plan contains a partial symbol.
+  struct {
+    // Open-addressed symbol-to-plan entries.
+    loom_link_plan_symbol_ordinal_map_entry_t* values;
+    // Power-of-two slot capacity.
+    iree_host_size_t capacity;
+  } symbol_ordinals;
   // Reused while filtering one declaration's candidates by bound provider.
   loom_link_plan_bitmap_t candidate_providers;
 };
@@ -77,6 +143,16 @@ static iree_status_t loom_link_plan_reserve_symbols(loom_link_plan_t* plan,
   return iree_allocator_grow_array(
       plan->allocator, count, sizeof(*plan->symbols.values),
       &plan->symbols.capacity, (void**)&plan->symbols.values);
+}
+
+static iree_status_t loom_link_plan_reserve_facets(loom_link_plan_t* plan,
+                                                   iree_host_size_t count) {
+  if (count <= plan->facets.capacity) {
+    return iree_ok_status();
+  }
+  return iree_allocator_grow_array(
+      plan->allocator, count, sizeof(*plan->facets.values),
+      &plan->facets.capacity, (void**)&plan->facets.values);
 }
 
 static iree_status_t loom_link_plan_reserve_demanded_template_families(
@@ -209,6 +285,107 @@ static bool loom_link_plan_bitmap_test_and_set(loom_link_plan_bitmap_t* bitmap,
 static void loom_link_plan_bitmap_clear(loom_link_plan_bitmap_t* bitmap,
                                         iree_host_size_t ordinal) {
   bitmap->values[ordinal / 64] &= ~(UINT64_C(1) << (ordinal % 64));
+}
+
+static iree_host_size_t loom_link_plan_hash_symbol_ordinal(
+    iree_host_size_t symbol_ordinal) {
+  uint64_t value = (uint64_t)symbol_ordinal;
+  value ^= value >> 30;
+  value *= UINT64_C(0xBF58476D1CE4E5B9);
+  value ^= value >> 27;
+  value *= UINT64_C(0x94D049BB133111EB);
+  value ^= value >> 31;
+  return (iree_host_size_t)value;
+}
+
+static iree_host_size_t loom_link_plan_symbol_ordinal_map_slot(
+    const loom_link_plan_symbol_ordinal_map_entry_t* values,
+    iree_host_size_t capacity, iree_host_size_t symbol_ordinal) {
+  iree_host_size_t slot =
+      loom_link_plan_hash_symbol_ordinal(symbol_ordinal) & (capacity - 1);
+  while (values[slot].symbol_ordinal !=
+             LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL &&
+         values[slot].symbol_ordinal != symbol_ordinal) {
+    slot = (slot + 1) & (capacity - 1);
+  }
+  return slot;
+}
+
+static void loom_link_plan_insert_symbol_ordinal(
+    loom_link_plan_symbol_ordinal_map_entry_t* values,
+    iree_host_size_t capacity, iree_host_size_t symbol_ordinal,
+    iree_host_size_t plan_ordinal) {
+  const iree_host_size_t slot =
+      loom_link_plan_symbol_ordinal_map_slot(values, capacity, symbol_ordinal);
+  IREE_ASSERT_EQ(values[slot].symbol_ordinal,
+                 LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL);
+  values[slot] = (loom_link_plan_symbol_ordinal_map_entry_t){
+      .symbol_ordinal = symbol_ordinal,
+      .plan_ordinal = plan_ordinal,
+  };
+}
+
+static iree_status_t loom_link_plan_reserve_symbol_ordinals(
+    loom_link_plan_t* plan, iree_host_size_t required_count) {
+  if (plan->symbol_ordinals.capacity / 2 >= required_count) {
+    return iree_ok_status();
+  }
+  iree_host_size_t capacity = plan->symbol_ordinals.capacity;
+  if (capacity == 0) {
+    capacity = 8;
+  }
+  while (capacity / 2 < required_count) {
+    if (capacity > IREE_HOST_SIZE_MAX / 2) {
+      return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                              "link plan symbol ordinal map overflow");
+    }
+    capacity *= 2;
+  }
+
+  loom_link_plan_symbol_ordinal_map_entry_t* values = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc_array(
+      plan->allocator, capacity, sizeof(*values), (void**)&values));
+  for (iree_host_size_t i = 0; i < capacity; ++i) {
+    values[i].symbol_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
+  }
+  for (iree_host_size_t i = 0; i < plan->symbols.count; ++i) {
+    loom_link_plan_insert_symbol_ordinal(
+        values, capacity, plan->symbols.values[i].symbol_ordinal, i);
+  }
+  iree_allocator_free(plan->allocator, plan->symbol_ordinals.values);
+  plan->symbol_ordinals.values = values;
+  plan->symbol_ordinals.capacity = capacity;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_link_plan_lookup_symbol_ordinal(
+    loom_link_plan_t* plan, iree_host_size_t symbol_ordinal,
+    iree_host_size_t* out_plan_ordinal) {
+  IREE_RETURN_IF_ERROR(
+      loom_link_plan_reserve_symbol_ordinals(plan, plan->symbols.count));
+  const iree_host_size_t slot = loom_link_plan_symbol_ordinal_map_slot(
+      plan->symbol_ordinals.values, plan->symbol_ordinals.capacity,
+      symbol_ordinal);
+  IREE_ASSERT_EQ(plan->symbol_ordinals.values[slot].symbol_ordinal,
+                 symbol_ordinal);
+  *out_plan_ordinal = plan->symbol_ordinals.values[slot].plan_ordinal;
+  return iree_ok_status();
+}
+
+static bool loom_link_plan_try_lookup_symbol_ordinal(
+    const loom_link_plan_t* plan, iree_host_size_t symbol_ordinal,
+    iree_host_size_t* out_plan_ordinal) {
+  if (plan->symbol_ordinals.values == NULL) {
+    return false;
+  }
+  const iree_host_size_t slot = loom_link_plan_symbol_ordinal_map_slot(
+      plan->symbol_ordinals.values, plan->symbol_ordinals.capacity,
+      symbol_ordinal);
+  if (plan->symbol_ordinals.values[slot].symbol_ordinal != symbol_ordinal) {
+    return false;
+  }
+  *out_plan_ordinal = plan->symbol_ordinals.values[slot].plan_ordinal;
+  return true;
 }
 
 static bool loom_link_plan_symbol_is_stripped(
@@ -404,19 +581,12 @@ static iree_status_t loom_link_plan_check_concrete_global_collision(
   return iree_ok_status();
 }
 
-// Appends |symbol| if it has not already been selected. |out_plan_ordinal| is
-// set only for a new selection so callers never need a reverse ordinal map.
+// Appends one newly selected symbol.
 static iree_status_t loom_link_plan_append_symbol(
     loom_link_plan_t* plan, const loom_link_module_index_symbol_t* symbol,
-    loom_link_plan_live_reason_t reason, iree_host_size_t cause_ordinal,
-    iree_string_view_t root_name, iree_host_size_t* out_plan_ordinal) {
-  if (out_plan_ordinal) {
-    *out_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
-  }
-  if (loom_link_plan_bitmap_contains(&plan->reachability.symbols,
-                                     symbol->ordinal)) {
-    return iree_ok_status();
-  }
+    loom_link_plan_live_cause_t cause, iree_host_size_t* out_plan_ordinal) {
+  IREE_ASSERT(!loom_link_plan_bitmap_contains(&plan->reachability.symbols,
+                                              symbol->ordinal));
   IREE_RETURN_IF_ERROR(
       loom_link_plan_check_concrete_global_collision(plan, symbol));
 
@@ -427,29 +597,147 @@ static iree_status_t loom_link_plan_append_symbol(
                             "link plan symbol count overflow");
   }
   IREE_RETURN_IF_ERROR(loom_link_plan_reserve_symbols(plan, symbol_count));
+  if (plan->symbol_ordinals.values) {
+    IREE_RETURN_IF_ERROR(
+        loom_link_plan_reserve_symbol_ordinals(plan, symbol_count));
+  }
   plan->symbols.values[plan_ordinal] = (loom_link_plan_symbol_t){
       .ordinal = plan_ordinal,
       .symbol_ordinal = symbol->ordinal,
-      .reason = reason,
-      .cause_ordinal = cause_ordinal,
-      .root_name = root_name,
+      .reason = cause.reason,
+      .cause_ordinal = cause.symbol_plan_ordinal,
+      .contract_facet_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
+      .selected_facet_count = 0,
+      .root_name = cause.root_name,
   };
   loom_link_plan_bitmap_test_and_set(&plan->reachability.symbols,
                                      symbol->ordinal);
   plan->symbols.count = symbol_count;
-  if (out_plan_ordinal) {
-    *out_plan_ordinal = plan_ordinal;
+  if (plan->symbol_ordinals.values) {
+    loom_link_plan_insert_symbol_ordinal(plan->symbol_ordinals.values,
+                                         plan->symbol_ordinals.capacity,
+                                         symbol->ordinal, plan_ordinal);
+  }
+  *out_plan_ordinal = plan_ordinal;
+  return iree_ok_status();
+}
+
+static iree_status_t loom_link_plan_append_facet(
+    loom_link_plan_t* plan, const loom_link_module_index_symbol_t* symbol,
+    uint8_t source_root_region_index_plus_one,
+    iree_host_size_t symbol_plan_ordinal,
+    loom_link_plan_facet_expansion_mode_t expansion_mode,
+    loom_link_plan_live_cause_t cause,
+    iree_host_size_t* out_facet_plan_ordinal) {
+  const iree_host_size_t facet_plan_ordinal = plan->facets.count;
+  iree_host_size_t facet_count = 0;
+  if (!iree_host_size_checked_add(facet_plan_ordinal, 1, &facet_count)) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "link plan facet count overflow");
+  }
+  IREE_RETURN_IF_ERROR(loom_link_plan_reserve_facets(plan, facet_count));
+  plan->facets.values[facet_plan_ordinal] = (loom_link_plan_facet_work_item_t){
+      .selection =
+          {
+              .ordinal = facet_plan_ordinal,
+              .symbol_plan_ordinal = symbol_plan_ordinal,
+              .symbol_ordinal = symbol->ordinal,
+              .source_root_region_index_plus_one =
+                  source_root_region_index_plus_one,
+              .reason = cause.reason,
+              .cause_ordinal = cause.facet_plan_ordinal,
+          },
+      .expansion_mode = expansion_mode,
+  };
+  plan->facets.count = facet_count;
+  ++plan->symbols.values[symbol_plan_ordinal].selected_facet_count;
+  if (source_root_region_index_plus_one == 0) {
+    plan->symbols.values[symbol_plan_ordinal].contract_facet_ordinal =
+        facet_plan_ordinal;
+  }
+  if (out_facet_plan_ordinal) {
+    *out_facet_plan_ordinal = facet_plan_ordinal;
   }
   return iree_ok_status();
 }
 
-static iree_status_t loom_link_plan_select_required_symbol(
+static bool loom_link_plan_facet_is_selected(
+    const loom_link_plan_t* plan, iree_host_size_t symbol_plan_ordinal,
+    uint8_t source_root_region_index_plus_one) {
+  const loom_link_plan_symbol_t* symbol_selection =
+      &plan->symbols.values[symbol_plan_ordinal];
+  const loom_link_module_index_symbol_t* symbol =
+      loom_link_module_index_symbol_at(plan->index,
+                                       symbol_selection->symbol_ordinal);
+  const uint16_t complete_facet_count =
+      (uint16_t)symbol->facets.schema.root_region_count + 1;
+  if (symbol_selection->selected_facet_count == complete_facet_count) {
+    return true;
+  }
+  for (iree_host_size_t i = symbol_selection->contract_facet_ordinal;
+       i < plan->facets.count; ++i) {
+    const loom_link_plan_facet_t* facet = &plan->facets.values[i].selection;
+    if (facet->symbol_plan_ordinal == symbol_plan_ordinal &&
+        facet->source_root_region_index_plus_one ==
+            source_root_region_index_plus_one) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool loom_link_plan_facet_request_is_selected(
+    const loom_link_plan_t* plan, const loom_link_module_index_symbol_t* symbol,
+    loom_link_plan_facet_request_t request) {
+  if (!loom_link_plan_bitmap_contains(&plan->reachability.symbols,
+                                      symbol->ordinal)) {
+    return false;
+  }
+  iree_host_size_t symbol_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
+  if (!loom_link_plan_try_lookup_symbol_ordinal(plan, symbol->ordinal,
+                                                &symbol_plan_ordinal)) {
+    return true;
+  }
+  const loom_link_plan_symbol_t* symbol_selection =
+      &plan->symbols.values[symbol_plan_ordinal];
+  const uint16_t complete_facet_count =
+      (uint16_t)symbol->facets.schema.root_region_count + 1;
+  if (symbol_selection->selected_facet_count == complete_facet_count) {
+    return true;
+  }
+  if (request.mode == LOOM_LINK_PLAN_FACET_REQUEST_ROOT_REGION) {
+    return loom_link_plan_facet_is_selected(
+        plan, symbol_plan_ordinal, request.source_root_region_index_plus_one);
+  }
+  return request.mode == LOOM_LINK_PLAN_FACET_REQUEST_CONTRACT;
+}
+
+static iree_status_t loom_link_plan_select_required_symbol_facets(
     loom_link_plan_t* plan, const loom_link_plan_options_t* options,
     const loom_link_module_index_symbol_t* symbol,
-    loom_link_plan_live_reason_t reason, iree_host_size_t cause_ordinal,
-    iree_string_view_t root_name, iree_host_size_t* out_plan_ordinal) {
-  if (out_plan_ordinal) {
-    *out_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
+    loom_link_plan_facet_request_t request, loom_link_plan_live_cause_t cause,
+    iree_host_size_t* out_new_symbol_plan_ordinal) {
+  if (out_new_symbol_plan_ordinal) {
+    *out_new_symbol_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
+  }
+  if (request.mode > LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "unknown link facet request mode %u",
+                            (unsigned)request.mode);
+  }
+  if (request.mode == LOOM_LINK_PLAN_FACET_REQUEST_ROOT_REGION &&
+      (request.source_root_region_index_plus_one == 0 ||
+       request.source_root_region_index_plus_one >
+           symbol->facets.schema.root_region_count)) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "source root region %u is outside symbol '@%.*s' with %u roots",
+        (unsigned)request.source_root_region_index_plus_one,
+        (int)symbol->name.size, symbol->name.data,
+        (unsigned)symbol->facets.schema.root_region_count);
+  }
+  if (loom_link_plan_facet_request_is_selected(plan, symbol, request)) {
+    return iree_ok_status();
   }
   if (loom_link_plan_symbol_is_stripped(options, plan, symbol)) {
     if (options &&
@@ -460,8 +748,84 @@ static iree_status_t loom_link_plan_select_required_symbol(
                             "required symbol '@%.*s' was stripped",
                             (int)symbol->name.size, symbol->name.data);
   }
-  return loom_link_plan_append_symbol(plan, symbol, reason, cause_ordinal,
-                                      root_name, out_plan_ordinal);
+
+  iree_host_size_t symbol_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
+  const bool is_new_symbol = !loom_link_plan_bitmap_contains(
+      &plan->reachability.symbols, symbol->ordinal);
+  if (is_new_symbol) {
+    IREE_RETURN_IF_ERROR(loom_link_plan_append_symbol(plan, symbol, cause,
+                                                      &symbol_plan_ordinal));
+    if (out_new_symbol_plan_ordinal) {
+      *out_new_symbol_plan_ordinal = symbol_plan_ordinal;
+    }
+  } else {
+    IREE_RETURN_IF_ERROR(loom_link_plan_lookup_symbol_ordinal(
+        plan, symbol->ordinal, &symbol_plan_ordinal));
+  }
+
+  const bool batch_complete_expansion =
+      is_new_symbol && request.mode == LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE;
+  bool needs_complete_expansion = batch_complete_expansion;
+  if (plan->symbols.values[symbol_plan_ordinal].selected_facet_count == 0) {
+    const loom_link_plan_facet_expansion_mode_t expansion_mode =
+        needs_complete_expansion ? LOOM_LINK_PLAN_FACET_EXPANSION_COMPLETE
+                                 : LOOM_LINK_PLAN_FACET_EXPANSION_EXACT;
+    IREE_RETURN_IF_ERROR(loom_link_plan_append_facet(
+        plan, symbol, 0, symbol_plan_ordinal, expansion_mode, cause,
+        /*out_facet_plan_ordinal=*/NULL));
+    needs_complete_expansion = false;
+  }
+  if (request.mode == LOOM_LINK_PLAN_FACET_REQUEST_ROOT_REGION) {
+    const uint8_t source_root = request.source_root_region_index_plus_one;
+    if (!loom_link_plan_facet_is_selected(plan, symbol_plan_ordinal,
+                                          source_root)) {
+      IREE_RETURN_IF_ERROR(loom_link_plan_append_facet(
+          plan, symbol, source_root, symbol_plan_ordinal,
+          LOOM_LINK_PLAN_FACET_EXPANSION_EXACT, cause,
+          /*out_facet_plan_ordinal=*/NULL));
+    }
+  } else if (request.mode == LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE) {
+    for (uint16_t source_root = 1;
+         source_root <= symbol->facets.schema.root_region_count;
+         ++source_root) {
+      if (!loom_link_plan_facet_is_selected(plan, symbol_plan_ordinal,
+                                            (uint8_t)source_root)) {
+        loom_link_plan_facet_expansion_mode_t expansion_mode =
+            LOOM_LINK_PLAN_FACET_EXPANSION_EXACT;
+        if (batch_complete_expansion) {
+          expansion_mode = needs_complete_expansion
+                               ? LOOM_LINK_PLAN_FACET_EXPANSION_COMPLETE
+                               : LOOM_LINK_PLAN_FACET_EXPANSION_NONE;
+        }
+        IREE_RETURN_IF_ERROR(loom_link_plan_append_facet(
+            plan, symbol, (uint8_t)source_root, symbol_plan_ordinal,
+            expansion_mode, cause,
+            /*out_facet_plan_ordinal=*/NULL));
+        needs_complete_expansion = false;
+      }
+    }
+  }
+  const uint16_t complete_facet_count =
+      (uint16_t)symbol->facets.schema.root_region_count + 1;
+  if (plan->symbols.values[symbol_plan_ordinal].selected_facet_count !=
+          complete_facet_count &&
+      plan->symbol_ordinals.values == NULL) {
+    IREE_RETURN_IF_ERROR(
+        loom_link_plan_reserve_symbol_ordinals(plan, plan->symbols.count));
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_link_plan_select_required_symbol(
+    loom_link_plan_t* plan, const loom_link_plan_options_t* options,
+    const loom_link_module_index_symbol_t* symbol,
+    loom_link_plan_live_cause_t cause,
+    iree_host_size_t* out_new_symbol_plan_ordinal) {
+  const loom_link_plan_facet_request_t request = {
+      .mode = LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE,
+  };
+  return loom_link_plan_select_required_symbol_facets(
+      plan, options, symbol, request, cause, out_new_symbol_plan_ordinal);
 }
 
 static iree_status_t loom_link_plan_resolve_declaration(
@@ -494,10 +858,17 @@ static iree_status_t loom_link_plan_resolve_declaration(
   if (!selected_symbol) {
     return iree_ok_status();
   }
+  const loom_link_plan_symbol_t* declaration_selection =
+      &plan->symbols.values[declaration_plan_ordinal];
+  const loom_link_plan_live_cause_t cause = {
+      .reason = LOOM_LINK_PLAN_LIVE_DEPENDENCY,
+      .symbol_plan_ordinal = declaration_plan_ordinal,
+      .facet_plan_ordinal = declaration_selection->contract_facet_ordinal,
+      .root_name = iree_string_view_empty(),
+  };
   IREE_RETURN_IF_ERROR(loom_link_plan_select_required_symbol(
-      plan, options, selected_symbol, LOOM_LINK_PLAN_LIVE_DEPENDENCY,
-      declaration_plan_ordinal, iree_string_view_empty(),
-      /*out_plan_ordinal=*/NULL));
+      plan, options, selected_symbol, cause,
+      /*out_new_symbol_plan_ordinal=*/NULL));
   if (imports.count != 0) {
     loom_link_plan_bitmap_test_and_set(
         &plan->reachability.resolved_declarations, declaration->ordinal);
@@ -508,8 +879,7 @@ static iree_status_t loom_link_plan_resolve_declaration(
 static iree_status_t loom_link_plan_select_global_reference(
     loom_link_plan_t* plan, const loom_link_plan_options_t* options,
     const loom_link_module_index_symbol_t* referenced_symbol,
-    loom_link_plan_live_reason_t reason, iree_host_size_t cause_ordinal,
-    iree_string_view_t root_name) {
+    loom_link_plan_live_cause_t cause) {
   const bool is_local_declaration =
       loom_link_plan_symbol_is_declaration_like(referenced_symbol);
   const loom_link_module_index_symbol_t* selected_symbol =
@@ -529,8 +899,7 @@ static iree_status_t loom_link_plan_select_global_reference(
   iree_host_size_t selected_plan_ordinal =
       LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
   IREE_RETURN_IF_ERROR(loom_link_plan_select_required_symbol(
-      plan, options, selected_symbol, reason, cause_ordinal, root_name,
-      &selected_plan_ordinal));
+      plan, options, selected_symbol, cause, &selected_plan_ordinal));
   if (selected_plan_ordinal == LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL) {
     return iree_ok_status();
   }
@@ -545,33 +914,36 @@ static iree_status_t loom_link_plan_select_global_reference(
 static iree_status_t loom_link_plan_select_dependency_target(
     loom_link_plan_t* plan, const loom_link_plan_options_t* options,
     const loom_link_module_index_module_t* module, uint32_t target_symbol_id,
-    iree_host_size_t cause_ordinal) {
+    loom_link_plan_live_cause_t cause) {
   IREE_ASSERT_LT(target_symbol_id, module->symbol_count);
   const loom_link_module_index_symbol_t* target =
       loom_link_module_index_symbol_at(
           plan->index, module->symbol_start_ordinal + target_symbol_id);
   IREE_ASSERT(target);
   if (target->identity == LOOM_LINK_SYMBOL_IDENTITY_GLOBAL) {
-    return loom_link_plan_select_global_reference(
-        plan, options, target, LOOM_LINK_PLAN_LIVE_DEPENDENCY, cause_ordinal,
-        iree_string_view_empty());
+    return loom_link_plan_select_global_reference(plan, options, target, cause);
   }
-  return loom_link_plan_select_required_symbol(
-      plan, options, target, LOOM_LINK_PLAN_LIVE_DEPENDENCY, cause_ordinal,
-      iree_string_view_empty(), /*out_plan_ordinal=*/NULL);
+  return loom_link_plan_select_required_symbol(plan, options, target, cause,
+                                               /*out_new_symbol_plan_ordinal=*/
+                                               NULL);
 }
 
 static iree_status_t loom_link_plan_expand_dependency_slice(
     loom_link_plan_t* plan, const loom_link_plan_options_t* options,
     const loom_link_module_index_module_t* module, uint32_t first,
-    uint32_t count, iree_host_size_t cause_ordinal) {
+    uint32_t count, uint8_t source_root_region_index_plus_one,
+    loom_link_plan_live_cause_t cause) {
   if (count == 0) {
     return iree_ok_status();
   }
   const uint32_t* dependencies = module->dependencies.values + first;
   for (uint32_t i = 0; i < count; ++i) {
+    if (module->dependencies.source_root_region_indices_plus_one[first + i] !=
+        source_root_region_index_plus_one) {
+      continue;
+    }
     IREE_RETURN_IF_ERROR(loom_link_plan_select_dependency_target(
-        plan, options, module, dependencies[i], cause_ordinal));
+        plan, options, module, dependencies[i], cause));
   }
   return iree_ok_status();
 }
@@ -599,43 +971,142 @@ static iree_status_t loom_link_plan_record_template_family_demand(
 
 static iree_status_t loom_link_plan_record_template_family_demands(
     loom_link_plan_t* plan, const loom_link_module_index_module_t* module,
-    uint32_t first, uint32_t count) {
+    uint32_t first, uint32_t count, uint8_t source_root_region_index_plus_one) {
   if (count == 0) {
     return iree_ok_status();
   }
   const loom_link_template_family_ordinal_t* template_families =
       module->template_demands.values + first;
   for (uint32_t i = 0; i < count; ++i) {
+    if (module->template_demands
+            .source_root_region_indices_plus_one[first + i] !=
+        source_root_region_index_plus_one) {
+      continue;
+    }
     IREE_RETURN_IF_ERROR(loom_link_plan_record_template_family_demand(
         plan, template_families[i]));
   }
   return iree_ok_status();
 }
 
-static iree_status_t loom_link_plan_expand_symbol(
+static iree_host_size_t loom_link_plan_find_facet_plan_ordinal(
+    const loom_link_plan_t* plan, iree_host_size_t symbol_plan_ordinal,
+    uint8_t source_root_region_index_plus_one) {
+  const loom_link_plan_symbol_t* symbol_selection =
+      &plan->symbols.values[symbol_plan_ordinal];
+  IREE_ASSERT_NE(symbol_selection->contract_facet_ordinal,
+                 LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL);
+  const iree_host_size_t contiguous_ordinal =
+      symbol_selection->contract_facet_ordinal +
+      source_root_region_index_plus_one;
+  IREE_ASSERT_LT(contiguous_ordinal, plan->facets.count);
+  const loom_link_plan_facet_t* facet =
+      &plan->facets.values[contiguous_ordinal].selection;
+  IREE_ASSERT_EQ(facet->symbol_plan_ordinal, symbol_plan_ordinal);
+  IREE_ASSERT_EQ(facet->source_root_region_index_plus_one,
+                 source_root_region_index_plus_one);
+  return contiguous_ordinal;
+}
+
+static loom_link_plan_live_cause_t loom_link_plan_facet_dependency_cause(
+    const loom_link_plan_t* plan, iree_host_size_t symbol_plan_ordinal,
+    uint8_t source_root_region_index_plus_one) {
+  return (loom_link_plan_live_cause_t){
+      .reason = LOOM_LINK_PLAN_LIVE_DEPENDENCY,
+      .symbol_plan_ordinal = symbol_plan_ordinal,
+      .facet_plan_ordinal = loom_link_plan_find_facet_plan_ordinal(
+          plan, symbol_plan_ordinal, source_root_region_index_plus_one),
+      .root_name = iree_string_view_empty(),
+  };
+}
+
+static iree_status_t loom_link_plan_expand_complete_symbol(
     loom_link_plan_t* plan, const loom_link_plan_options_t* options,
-    iree_host_size_t plan_ordinal) {
-  const iree_host_size_t symbol_ordinal =
-      plan->symbols.values[plan_ordinal].symbol_ordinal;
+    const loom_link_module_index_symbol_t* symbol,
+    const loom_link_module_index_module_t* module,
+    iree_host_size_t symbol_plan_ordinal) {
+  if (symbol->dependencies.count != 0) {
+    const uint32_t dependency_first = symbol->dependencies.first;
+    const uint32_t* dependencies =
+        module->dependencies.values + dependency_first;
+    for (uint32_t i = 0; i < symbol->dependencies.count; ++i) {
+      const uint8_t source_root_region_index_plus_one =
+          module->dependencies
+              .source_root_region_indices_plus_one[dependency_first + i];
+      const loom_link_plan_live_cause_t cause =
+          loom_link_plan_facet_dependency_cause(
+              plan, symbol_plan_ordinal, source_root_region_index_plus_one);
+      IREE_RETURN_IF_ERROR(loom_link_plan_select_dependency_target(
+          plan, options, module, dependencies[i], cause));
+    }
+  }
+
+  if (symbol->template_demands.count != 0) {
+    const uint32_t demand_first = symbol->template_demands.first;
+    const loom_link_template_family_ordinal_t* template_families =
+        module->template_demands.values + demand_first;
+    for (uint32_t i = 0; i < symbol->template_demands.count; ++i) {
+      IREE_RETURN_IF_ERROR(loom_link_plan_record_template_family_demand(
+          plan, template_families[i]));
+    }
+  }
+
+  return iree_ok_status();
+}
+
+static iree_status_t loom_link_plan_expand_facet(
+    loom_link_plan_t* plan, const loom_link_plan_options_t* options,
+    iree_host_size_t facet_plan_ordinal) {
+  const loom_link_plan_facet_work_item_t work_item =
+      plan->facets.values[facet_plan_ordinal];
+  const loom_link_plan_facet_t facet = work_item.selection;
   const loom_link_module_index_symbol_t* symbol =
-      loom_link_module_index_symbol_at(plan->index, symbol_ordinal);
+      loom_link_module_index_symbol_at(plan->index, facet.symbol_ordinal);
   const loom_link_module_index_module_t* module =
       loom_link_module_index_symbol_module(plan->index, symbol);
   IREE_ASSERT(symbol);
   IREE_ASSERT(module);
+  if (work_item.expansion_mode == LOOM_LINK_PLAN_FACET_EXPANSION_NONE) {
+    return iree_ok_status();
+  }
+  if (work_item.expansion_mode == LOOM_LINK_PLAN_FACET_EXPANSION_COMPLETE) {
+    const iree_host_size_t contract_facet_ordinal =
+        plan->symbols.values[facet.symbol_plan_ordinal].contract_facet_ordinal;
+    const loom_link_plan_live_cause_t module_cause = {
+        .reason = LOOM_LINK_PLAN_LIVE_DEPENDENCY,
+        .symbol_plan_ordinal = facet.symbol_plan_ordinal,
+        .facet_plan_ordinal = contract_facet_ordinal,
+        .root_name = iree_string_view_empty(),
+    };
+    if (!loom_link_plan_bitmap_test_and_set(&plan->reachability.modules,
+                                            module->ordinal)) {
+      IREE_RETURN_IF_ERROR(loom_link_plan_expand_dependency_slice(
+          plan, options, module, /*first=*/0, module->dependencies.root_count,
+          /*source_root_region_index_plus_one=*/0, module_cause));
+    }
+    return loom_link_plan_expand_complete_symbol(plan, options, symbol, module,
+                                                 facet.symbol_plan_ordinal);
+  }
+  const loom_link_plan_live_cause_t cause = {
+      .reason = LOOM_LINK_PLAN_LIVE_DEPENDENCY,
+      .symbol_plan_ordinal = facet.symbol_plan_ordinal,
+      .facet_plan_ordinal = facet_plan_ordinal,
+      .root_name = iree_string_view_empty(),
+  };
 
   if (!loom_link_plan_bitmap_test_and_set(&plan->reachability.modules,
                                           module->ordinal)) {
     IREE_RETURN_IF_ERROR(loom_link_plan_expand_dependency_slice(
         plan, options, module, /*first=*/0, module->dependencies.root_count,
-        plan_ordinal));
+        /*source_root_region_index_plus_one=*/0, cause));
   }
   IREE_RETURN_IF_ERROR(loom_link_plan_expand_dependency_slice(
       plan, options, module, symbol->dependencies.first,
-      symbol->dependencies.count, plan_ordinal));
+      symbol->dependencies.count, facet.source_root_region_index_plus_one,
+      cause));
   return loom_link_plan_record_template_family_demands(
       plan, module, symbol->template_demands.first,
-      symbol->template_demands.count);
+      symbol->template_demands.count, facet.source_root_region_index_plus_one);
 }
 
 //===----------------------------------------------------------------------===//
@@ -652,10 +1123,16 @@ static iree_status_t loom_link_plan_select_archive(
     if (loom_link_plan_symbol_is_stripped(options, plan, symbol)) {
       continue;
     }
-    IREE_RETURN_IF_ERROR(loom_link_plan_append_symbol(
-        plan, symbol, LOOM_LINK_PLAN_LIVE_ARCHIVE,
-        LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL, iree_string_view_empty(),
-        /*out_plan_ordinal=*/NULL));
+    const loom_link_plan_live_cause_t cause = {
+        .reason = LOOM_LINK_PLAN_LIVE_ARCHIVE,
+        .symbol_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
+        .facet_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
+        .root_name = iree_string_view_empty(),
+    };
+    iree_host_size_t symbol_plan_ordinal =
+        LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
+    IREE_RETURN_IF_ERROR(loom_link_plan_append_symbol(plan, symbol, cause,
+                                                      &symbol_plan_ordinal));
   }
   for (iree_host_size_t i = 0; i < plan->symbols.count; ++i) {
     const loom_link_module_index_symbol_t* symbol =
@@ -678,10 +1155,14 @@ static iree_status_t loom_link_plan_select_root(
   }
   const loom_link_module_index_symbol_t* root =
       loom_link_module_index_lookup_global(plan->index, normalized_name);
+  const loom_link_plan_live_cause_t cause = {
+      .reason = LOOM_LINK_PLAN_LIVE_ROOT,
+      .symbol_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
+      .facet_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
+      .root_name = root_name,
+  };
   if (root) {
-    return loom_link_plan_select_global_reference(
-        plan, options, root, LOOM_LINK_PLAN_LIVE_ROOT,
-        LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL, root_name);
+    return loom_link_plan_select_global_reference(plan, options, root, cause);
   }
 
   const loom_link_module_index_symbol_t* private_root = NULL;
@@ -705,9 +1186,8 @@ static iree_status_t loom_link_plan_select_root(
                             (int)normalized_name.size, normalized_name.data);
   }
   return loom_link_plan_select_required_symbol(
-      plan, options, private_root, LOOM_LINK_PLAN_LIVE_ROOT,
-      LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL, root_name,
-      /*out_plan_ordinal=*/NULL);
+      plan, options, private_root, cause,
+      /*out_new_symbol_plan_ordinal=*/NULL);
 }
 
 static iree_status_t loom_link_plan_select_input_exports(
@@ -718,10 +1198,59 @@ static iree_status_t loom_link_plan_select_input_exports(
     const loom_link_module_index_symbol_t* symbol =
         loom_link_module_index_symbol_at(plan->index, input_exports.values[i]);
     iree_host_size_t root_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
+    const loom_link_plan_live_cause_t cause = {
+        .reason = LOOM_LINK_PLAN_LIVE_ROOT,
+        .symbol_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
+        .facet_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
+        .root_name = symbol->name,
+    };
     IREE_RETURN_IF_ERROR(loom_link_plan_select_required_symbol(
-        plan, options, symbol, LOOM_LINK_PLAN_LIVE_ROOT,
-        LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL, symbol->name,
-        &root_plan_ordinal));
+        plan, options, symbol, cause, &root_plan_ordinal));
+    if (root_plan_ordinal != LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL) {
+      IREE_RETURN_IF_ERROR(loom_link_plan_resolve_declaration(
+          plan, options, symbol, root_plan_ordinal));
+    }
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_link_plan_select_root_facets(
+    loom_link_plan_t* plan, const loom_link_plan_options_t* options) {
+  const iree_host_size_t root_count = options ? options->root_facets.count : 0;
+  const loom_link_plan_root_facet_t* roots =
+      options ? options->root_facets.values : NULL;
+  if (root_count != 0 && roots == NULL) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "root_facets count is non-zero but values is NULL");
+  }
+  const iree_host_size_t symbol_count =
+      loom_link_module_index_symbol_count(plan->index);
+  for (iree_host_size_t i = 0; i < root_count; ++i) {
+    const loom_link_plan_root_facet_t root = roots[i];
+    if (root.symbol_ordinal >= symbol_count) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "root facet symbol ordinal %" PRIhsz
+                              " is outside the %" PRIhsz "-symbol index",
+                              root.symbol_ordinal, symbol_count);
+    }
+    const loom_link_module_index_symbol_t* symbol =
+        loom_link_module_index_symbol_at(plan->index, root.symbol_ordinal);
+    const loom_link_plan_facet_request_t request = {
+        .mode = root.source_root_region_index_plus_one == 0
+                    ? LOOM_LINK_PLAN_FACET_REQUEST_CONTRACT
+                    : LOOM_LINK_PLAN_FACET_REQUEST_ROOT_REGION,
+        .source_root_region_index_plus_one =
+            root.source_root_region_index_plus_one,
+    };
+    const loom_link_plan_live_cause_t cause = {
+        .reason = LOOM_LINK_PLAN_LIVE_ROOT,
+        .symbol_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
+        .facet_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
+        .root_name = symbol->name,
+    };
+    iree_host_size_t root_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
+    IREE_RETURN_IF_ERROR(loom_link_plan_select_required_symbol_facets(
+        plan, options, symbol, request, cause, &root_plan_ordinal));
     if (root_plan_ordinal != LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL) {
       IREE_RETURN_IF_ERROR(loom_link_plan_resolve_declaration(
           plan, options, symbol, root_plan_ordinal));
@@ -745,6 +1274,7 @@ static iree_status_t loom_link_plan_select_roots(
     IREE_RETURN_IF_ERROR(loom_link_plan_select_root(
         plan, options, options->root_symbols.values[i]));
   }
+  IREE_RETURN_IF_ERROR(loom_link_plan_select_root_facets(plan, options));
   if (plan->symbols.count == 0) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
@@ -789,10 +1319,15 @@ static iree_status_t loom_link_plan_select_template_providers(
                               symbol_ordinal, (int)symbol->name.size,
                               symbol->name.data);
     }
+    const loom_link_plan_live_cause_t cause = {
+        .reason = LOOM_LINK_PLAN_LIVE_PROVIDER,
+        .symbol_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
+        .facet_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
+        .root_name = iree_string_view_empty(),
+    };
     IREE_RETURN_IF_ERROR(loom_link_plan_select_required_symbol(
-        plan, options, symbol, LOOM_LINK_PLAN_LIVE_PROVIDER,
-        LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL, iree_string_view_empty(),
-        /*out_plan_ordinal=*/NULL));
+        plan, options, symbol, cause,
+        /*out_new_symbol_plan_ordinal=*/NULL));
   }
   return iree_ok_status();
 }
@@ -801,8 +1336,8 @@ static iree_status_t loom_link_plan_select_selective(
     loom_link_plan_t* plan, const loom_link_plan_options_t* options) {
   IREE_RETURN_IF_ERROR(loom_link_plan_select_roots(plan, options));
   IREE_RETURN_IF_ERROR(loom_link_plan_select_template_providers(plan, options));
-  for (iree_host_size_t i = 0; i < plan->symbols.count; ++i) {
-    IREE_RETURN_IF_ERROR(loom_link_plan_expand_symbol(plan, options, i));
+  for (iree_host_size_t i = 0; i < plan->facets.count; ++i) {
+    IREE_RETURN_IF_ERROR(loom_link_plan_expand_facet(plan, options, i));
   }
   return iree_ok_status();
 }
@@ -863,8 +1398,10 @@ void loom_link_plan_free(loom_link_plan_t* plan) {
     return;
   }
   iree_allocator_free(plan->allocator, plan->candidate_providers.values);
+  iree_allocator_free(plan->allocator, plan->symbol_ordinals.values);
   iree_allocator_free(plan->allocator, plan->reachability.storage);
   iree_allocator_free(plan->allocator, plan->demanded_template_families.values);
+  iree_allocator_free(plan->allocator, plan->facets.values);
   iree_allocator_free(plan->allocator, plan->symbols.values);
   iree_allocator_free(plan->allocator, plan);
 }
@@ -890,6 +1427,18 @@ const loom_link_plan_symbol_t* loom_link_plan_symbol_at(
   return &plan->symbols.values[ordinal];
 }
 
+iree_host_size_t loom_link_plan_facet_count(const loom_link_plan_t* plan) {
+  return plan ? plan->facets.count : 0;
+}
+
+const loom_link_plan_facet_t* loom_link_plan_facet_at(
+    const loom_link_plan_t* plan, iree_host_size_t ordinal) {
+  if (!plan || ordinal >= plan->facets.count) {
+    return NULL;
+  }
+  return &plan->facets.values[ordinal].selection;
+}
+
 iree_host_size_t loom_link_plan_demanded_template_family_count(
     const loom_link_plan_t* plan) {
   return plan ? plan->demanded_template_families.count : 0;
@@ -907,6 +1456,35 @@ bool loom_link_plan_contains_symbol(const loom_link_plan_t* plan,
                                     iree_host_size_t symbol_ordinal) {
   return plan && loom_link_plan_bitmap_contains(&plan->reachability.symbols,
                                                 symbol_ordinal);
+}
+
+bool loom_link_plan_contains_facet(const loom_link_plan_t* plan,
+                                   iree_host_size_t symbol_ordinal,
+                                   uint8_t source_root_region_index_plus_one) {
+  if (!plan) {
+    return false;
+  }
+  const loom_link_module_index_symbol_t* symbol =
+      loom_link_module_index_symbol_at(plan->index, symbol_ordinal);
+  if (!symbol || source_root_region_index_plus_one >
+                     symbol->facets.schema.root_region_count) {
+    return false;
+  }
+  if (!loom_link_plan_bitmap_contains(&plan->reachability.symbols,
+                                      symbol_ordinal)) {
+    return false;
+  }
+  if (plan->mode == LOOM_LINK_PLAN_ARCHIVE ||
+      plan->symbol_ordinals.values == NULL) {
+    return true;
+  }
+  iree_host_size_t symbol_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
+  const bool found = loom_link_plan_try_lookup_symbol_ordinal(
+      plan, symbol_ordinal, &symbol_plan_ordinal);
+  IREE_ASSERT(found);
+  return found &&
+         loom_link_plan_facet_is_selected(plan, symbol_plan_ordinal,
+                                          source_root_region_index_plus_one);
 }
 
 bool loom_link_plan_symbol_imports_resolved(const loom_link_plan_t* plan,

--- a/loom/src/loom/link/planner.h
+++ b/loom/src/loom/link/planner.h
@@ -65,6 +65,16 @@ typedef bool (*loom_link_plan_strip_symbol_fn_t)(
     void* user_data, const loom_link_module_index_t* index,
     const loom_link_module_index_symbol_t* symbol);
 
+// One identity-resolved selective root facet. The symbol contract is always
+// selected. A nonzero source root also selects that independently bounded root
+// region without selecting sibling roots.
+typedef struct loom_link_plan_root_facet_t {
+  // Index-wide symbol ordinal resolved by the requesting subsystem.
+  iree_host_size_t symbol_ordinal;
+  // Source root region index plus one, or zero for the contract alone.
+  uint8_t source_root_region_index_plus_one;
+} loom_link_plan_root_facet_t;
+
 // Options controlling one planning operation.
 typedef struct loom_link_plan_options_t {
   // Planning mode. Zero defaults to ARCHIVE.
@@ -92,6 +102,13 @@ typedef struct loom_link_plan_options_t {
     // Index-wide template.def/template.ukernel symbol ordinals.
     const iree_host_size_t* values;
   } selected_template_providers;
+  // Identity-resolved facet roots for SELECTIVE mode.
+  struct {
+    // Number of root facet requests.
+    iree_host_size_t count;
+    // Root facet requests in caller-defined stable order.
+    const loom_link_plan_root_facet_t* values;
+  } root_facets;
 } loom_link_plan_options_t;
 
 // One live symbol selection in a plan.
@@ -104,9 +121,29 @@ typedef struct loom_link_plan_symbol_t {
   loom_link_plan_live_reason_t reason;
   // Plan-local ordinal that caused this dependency, or INVALID_ORDINAL.
   iree_host_size_t cause_ordinal;
+  // Plan-local contract facet ordinal for this symbol.
+  iree_host_size_t contract_facet_ordinal;
+  // Number of selected contract and root-region facets.
+  uint16_t selected_facet_count;
   // Root name that caused this selection when reason is ROOT.
   iree_string_view_t root_name;
 } loom_link_plan_symbol_t;
+
+// One live structural symbol facet in a selective plan.
+typedef struct loom_link_plan_facet_t {
+  // Plan-local facet ordinal.
+  iree_host_size_t ordinal;
+  // Plan-local symbol selection owning this facet.
+  iree_host_size_t symbol_plan_ordinal;
+  // Index-wide symbol ordinal owning this facet.
+  iree_host_size_t symbol_ordinal;
+  // Source root region index plus one, or zero for the symbol contract.
+  uint8_t source_root_region_index_plus_one;
+  // Why this facet is live.
+  loom_link_plan_live_reason_t reason;
+  // Plan-local facet ordinal that caused this selection, or INVALID_ORDINAL.
+  iree_host_size_t cause_ordinal;
+} loom_link_plan_facet_t;
 
 // Builds a link plan from |index|.
 //
@@ -134,6 +171,14 @@ iree_host_size_t loom_link_plan_symbol_count(const loom_link_plan_t* plan);
 const loom_link_plan_symbol_t* loom_link_plan_symbol_at(
     const loom_link_plan_t* plan, iree_host_size_t ordinal);
 
+// Returns the number of explicit structural facet selections in a selective
+// plan. Archive plans retain complete symbols without enumerating facets.
+iree_host_size_t loom_link_plan_facet_count(const loom_link_plan_t* plan);
+
+// Returns live facet selection |ordinal|, or NULL if out of range.
+const loom_link_plan_facet_t* loom_link_plan_facet_at(
+    const loom_link_plan_t* plan, iree_host_size_t ordinal);
+
 // Returns the number of reachable template-family demands.
 iree_host_size_t loom_link_plan_demanded_template_family_count(
     const loom_link_plan_t* plan);
@@ -146,6 +191,12 @@ loom_link_template_family_ordinal_t loom_link_plan_demanded_template_family_at(
 // Returns true when |symbol_ordinal| is live in |plan|.
 bool loom_link_plan_contains_symbol(const loom_link_plan_t* plan,
                                     iree_host_size_t symbol_ordinal);
+
+// Returns true when the contract or named source root of |symbol_ordinal| is
+// live in |plan|. Every valid facet of an archive-selected symbol is live.
+bool loom_link_plan_contains_facet(const loom_link_plan_t* plan,
+                                   iree_host_size_t symbol_ordinal,
+                                   uint8_t source_root_region_index_plus_one);
 
 // Returns true when a concrete provider satisfied |symbol_ordinal|'s
 // compile-time provider imports. Every availability anchor for the symbol is

--- a/loom/src/loom/link/planner_benchmark.cc
+++ b/loom/src/loom/link/planner_benchmark.cc
@@ -653,6 +653,7 @@ static void BenchmarkPlan(benchmark::State& state, loom_link_plan_mode_t mode,
       /*.root_symbols=*/root_symbols,
   };
 
+  iree_host_size_t selected_facet_count = 0;
   for (auto _ : state) {
     loom_link_plan_t* plan = nullptr;
     CheckStatus(
@@ -660,11 +661,13 @@ static void BenchmarkPlan(benchmark::State& state, loom_link_plan_mode_t mode,
     if (loom_link_plan_symbol_count(plan) != expected_symbol_count) {
       std::abort();
     }
+    selected_facet_count = loom_link_plan_facet_count(plan);
     benchmark::DoNotOptimize(plan);
     state.PauseTiming();
     loom_link_plan_free(plan);
     state.ResumeTiming();
   }
+  state.counters["selected_facets"] = static_cast<double>(selected_facet_count);
   SetCounters(state, fixture, expected_symbol_count);
   loom_link_module_index_free(index);
 }

--- a/loom/src/loom/link/planner_test.cc
+++ b/loom/src/loom/link/planner_test.cc
@@ -337,6 +337,121 @@ func.def @unused_private(%x: i32) -> (i32) {
   EXPECT_EQ(planned_helper->cause_ordinal, planned_entry->ordinal);
 }
 
+TEST_F(LinkPlannerTest,
+       FacetRootsFilterAndUpgradeMultiRegionClosureAcrossProviders) {
+  loom_module_t* module = Parse(IREE_SV(R"(
+test.record @config_dependency
+test.record @implementation_dependency
+
+test.split_func @split_root() {
+  test.symbol_array_attrs [@config_dependency] using []
+  test.yield
+} launch {
+  test.symbol_array_attrs [@implementation_dependency] using []
+  test.yield
+}
+)"));
+  const std::vector<uint8_t> bytecode = WriteModule(module);
+
+  auto verify_index = [&](const loom_link_module_index_t* index) {
+    auto find_plan_facet = [](const loom_link_plan_t* plan,
+                              iree_host_size_t symbol_ordinal,
+                              uint8_t source_root_region_index_plus_one) {
+      for (iree_host_size_t i = 0; i < loom_link_plan_facet_count(plan); ++i) {
+        const loom_link_plan_facet_t* facet = loom_link_plan_facet_at(plan, i);
+        if (facet->symbol_ordinal == symbol_ordinal &&
+            facet->source_root_region_index_plus_one ==
+                source_root_region_index_plus_one) {
+          return facet;
+        }
+      }
+      return static_cast<const loom_link_plan_facet_t*>(nullptr);
+    };
+    const loom_link_module_index_module_t* indexed_module =
+        loom_link_module_index_module_at(index, 0);
+    ASSERT_NE(indexed_module, nullptr);
+    const loom_link_module_index_symbol_t* root =
+        loom_link_module_index_lookup_private(index, indexed_module,
+                                              IREE_SV("split_root"));
+    const loom_link_module_index_symbol_t* config_dependency =
+        loom_link_module_index_lookup_private(index, indexed_module,
+                                              IREE_SV("config_dependency"));
+    const loom_link_module_index_symbol_t* implementation_dependency =
+        loom_link_module_index_lookup_private(
+            index, indexed_module, IREE_SV("implementation_dependency"));
+    ASSERT_NE(root, nullptr);
+    ASSERT_NE(config_dependency, nullptr);
+    ASSERT_NE(implementation_dependency, nullptr);
+
+    const loom_link_plan_root_facet_t config_root = {
+        /*.symbol_ordinal=*/root->ordinal,
+        /*.source_root_region_index_plus_one=*/1,
+    };
+    loom_link_plan_options_t config_options = {};
+    config_options.mode = LOOM_LINK_PLAN_SELECTIVE;
+    config_options.root_facets = {1, &config_root};
+    PlanPtr config_plan = BuildPlan(index, &config_options);
+    EXPECT_TRUE(ContainsSymbol(config_plan.get(), root));
+    EXPECT_TRUE(ContainsSymbol(config_plan.get(), config_dependency));
+    EXPECT_FALSE(ContainsSymbol(config_plan.get(), implementation_dependency));
+    EXPECT_TRUE(
+        loom_link_plan_contains_facet(config_plan.get(), root->ordinal, 0));
+    EXPECT_TRUE(
+        loom_link_plan_contains_facet(config_plan.get(), root->ordinal, 1));
+    EXPECT_FALSE(
+        loom_link_plan_contains_facet(config_plan.get(), root->ordinal, 2));
+    const loom_link_plan_facet_t* config_root_facet =
+        find_plan_facet(config_plan.get(), root->ordinal, 1);
+    const loom_link_plan_facet_t* config_dependency_facet =
+        find_plan_facet(config_plan.get(), config_dependency->ordinal, 0);
+    ASSERT_NE(config_root_facet, nullptr);
+    ASSERT_NE(config_dependency_facet, nullptr);
+    EXPECT_EQ(config_dependency_facet->cause_ordinal,
+              config_root_facet->ordinal);
+
+    const loom_link_plan_root_facet_t upgraded_roots[] = {
+        config_root,
+        {
+            /*.symbol_ordinal=*/root->ordinal,
+            /*.source_root_region_index_plus_one=*/2,
+        },
+    };
+    loom_link_plan_options_t upgraded_options = {};
+    upgraded_options.mode = LOOM_LINK_PLAN_SELECTIVE;
+    upgraded_options.root_facets = {IREE_ARRAYSIZE(upgraded_roots),
+                                    upgraded_roots};
+    PlanPtr upgraded_plan = BuildPlan(index, &upgraded_options);
+    EXPECT_TRUE(ContainsSymbol(upgraded_plan.get(), root));
+    EXPECT_TRUE(ContainsSymbol(upgraded_plan.get(), config_dependency));
+    EXPECT_TRUE(ContainsSymbol(upgraded_plan.get(), implementation_dependency));
+    EXPECT_TRUE(
+        loom_link_plan_contains_facet(upgraded_plan.get(), root->ordinal, 0));
+    EXPECT_TRUE(
+        loom_link_plan_contains_facet(upgraded_plan.get(), root->ordinal, 1));
+    EXPECT_TRUE(
+        loom_link_plan_contains_facet(upgraded_plan.get(), root->ordinal, 2));
+    const loom_link_plan_facet_t* implementation_root_facet =
+        find_plan_facet(upgraded_plan.get(), root->ordinal, 2);
+    const loom_link_plan_facet_t* implementation_dependency_facet =
+        find_plan_facet(upgraded_plan.get(), implementation_dependency->ordinal,
+                        0);
+    ASSERT_NE(implementation_root_facet, nullptr);
+    ASSERT_NE(implementation_dependency_facet, nullptr);
+    EXPECT_EQ(implementation_dependency_facet->cause_ordinal,
+              implementation_root_facet->ordinal);
+  };
+
+  IndexPtr materialized_index = CreateIndex();
+  AddMaterialized(materialized_index.get(), module, IREE_SV("materialized"),
+                  LOOM_LINK_PROVIDER_ROLE_INPUT);
+  verify_index(materialized_index.get());
+
+  IndexPtr bytecode_index = CreateIndex();
+  AddBytecode(bytecode_index.get(), bytecode, IREE_SV("module.loombc"),
+              LOOM_LINK_PROVIDER_ROLE_INPUT);
+  verify_index(bytecode_index.get());
+}
+
 TEST_F(LinkPlannerTest, SelectiveRootIgnoresModuleAvailabilityReferences) {
   loom_module_t* module = Parse(IREE_SV(R"(
 test.record @available


### PR DESCRIPTION
Loom can now plan and materialize a kernel's launch configuration without making its implementation body or implementation-only dependencies live. This completes the first bounded vertical slice of structural symbol facets: the symbol contract and each independently bounded root region are distinct closure nodes, so selecting a kernel configuration retains the kernel ABI and configuration dependencies while leaving sibling implementation roots unopened.

Symbol-reference analysis records the contract or root region that owns each dependency and template demand during its existing canonical traversal. Bytecode format version 31 carries those compact source-root identities alongside the existing symbol ordinals, and validated bytecode, text, and materialized providers all project the same representation into the module index. Planning remains ordinal-based: it does not reopen IR, compare symbol strings, or add another module walk.

The planner attributes every selected dependency to its originating facet and exposes exact facet liveness to consumers. Complete symbols still use a batched expansion that scans their dependency row once, archive plans retain their existing dense symbol state without enumerating facets, and the reverse symbol map is allocated only when a plan actually contains a partial symbol. This keeps ordinary whole-symbol linking on its established path while making partial closure precise.

The first production consumer is kernel configuration extraction. A dedicated planning entry point selects the kernel contract and configuration root, and the bytecode materializer requires that exact facet before projecting the private target declaration, kernel declaration, and pure configuration function. The production-path corpus exercises materialized IR, text, and bytecode providers; configuration-only plans exclude body helpers, while complete plans reconstruct verified kernel definitions with both regions, remapped target and helper references, and a verified bytecode round trip. A poisoned implementation payload remains unread during configuration planning and materialization but is observed by complete materialization.

Optimized benchmark coverage varies the unopened implementation from 42 bytes through 1 MiB. Configuration planning remains 0.873–0.893 microseconds and fits O(1) at 0.887 microseconds with 2% RMS; configuration materialization remains 3.979–4.006 microseconds and fits O(1) at 3.992 microseconds with 1% RMS. A one-symbol selective leaf remains 0.798 microseconds, and a 4,096-symbol complete dependency chain remains linear at 91.37 nanoseconds per selected symbol.
