### PR TITLE
[Loom] Name link facets by semantic role

### DIFF
--- a/loom/src/loom/link/BUILD.bazel
+++ b/loom/src/loom/link/BUILD.bazel
@@ -85,8 +85,14 @@ loom_cc_test(
 
 loom_cc_library(
     name = "module_index",
-    srcs = ["module_index.c"],
-    hdrs = ["module_index.h"],
+    srcs = [
+        "module_index.c",
+        "symbol_facet.c",
+    ],
+    hdrs = [
+        "module_index.h",
+        "symbol_facet.h",
+    ],
     deps = [
         ":symbol_policy",
         "//loom/src/loom/analysis:symbol_references",
@@ -326,6 +332,7 @@ loom_cc_test(
         "//loom/src/loom/format/text:parser",
         "//loom/src/loom/ir",
         "//loom/src/loom/ops/check",
+        "//loom/src/loom/ops/command",
         "//loom/src/loom/ops/config",
         "//loom/src/loom/ops/func",
         "//loom/src/loom/ops/module",

--- a/loom/src/loom/link/CMakeLists.txt
+++ b/loom/src/loom/link/CMakeLists.txt
@@ -95,8 +95,10 @@ loom_cc_library(
     module_index
   HDRS
     "module_index.h"
+    "symbol_facet.h"
   SRCS
     "module_index.c"
+    "symbol_facet.c"
   DEPS
     ::symbol_policy
     iree::base
@@ -369,6 +371,7 @@ loom_cc_test(
     loom::format::text::parser
     loom::ir
     loom::ops::check
+    loom::ops::command
     loom::ops::config
     loom::ops::func
     loom::ops::module

--- a/loom/src/loom/link/kernel_config_materializer.c
+++ b/loom/src/loom/link/kernel_config_materializer.c
@@ -52,19 +52,15 @@ iree_status_t loom_link_plan_build_kernel_configuration(
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                             "kernel symbol ordinal is out of range");
   }
-  const loom_link_symbol_facet_schema_t schema = kernel->facets.schema;
-  if (!iree_any_bit_set(schema.interfaces, LOOM_SYMBOL_INTERFACE_KERNEL)) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "selected symbol is not a kernel");
-  }
-  if (schema.kernel_configuration_region_index_plus_one == 0) {
+  if (loom_link_module_index_symbol_facet_ordinal(
+          kernel, LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION) ==
+      LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL) {
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                            "selected kernel has no configuration root");
+                            "selected symbol has no kernel configuration");
   }
   const loom_link_plan_root_facet_t root = {
       .symbol_ordinal = kernel_symbol_ordinal,
-      .source_root_region_index_plus_one =
-          schema.kernel_configuration_region_index_plus_one,
+      .kind = LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION,
   };
   loom_link_plan_options_t options = {0};
   options.mode = LOOM_LINK_PLAN_SELECTIVE;
@@ -99,8 +95,7 @@ static iree_status_t loom_link_kernel_config_resolve_source(
   }
   if (!loom_link_plan_contains_facet(
           plan, kernel_symbol_ordinal,
-          indexed_symbol->facets.schema
-              .kernel_configuration_region_index_plus_one)) {
+          LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION)) {
     return iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,
         "kernel configuration is not selected by the link plan");

--- a/loom/src/loom/link/kernel_config_materializer_test.cc
+++ b/loom/src/loom/link/kernel_config_materializer_test.cc
@@ -185,10 +185,23 @@ kernel.def @dispatch_rows(%element_count: index) {
     EXPECT_EQ(kernel->facets.schema.kernel_configuration_region_index_plus_one,
               1u);
     EXPECT_EQ(kernel->facets.schema.body_region_index_plus_one, 2u);
+    EXPECT_EQ(kernel->facets.schema.facet_count, 3u);
     EXPECT_EQ(loom_link_module_index_facet_count(index), 3u);
-    EXPECT_EQ(loom_link_module_index_symbol_facet_ordinal(kernel, 0), 0u);
-    EXPECT_EQ(loom_link_module_index_symbol_facet_ordinal(kernel, 1), 1u);
-    EXPECT_EQ(loom_link_module_index_symbol_facet_ordinal(kernel, 2), 2u);
+    EXPECT_EQ(loom_link_module_index_symbol_facet_kind_at(kernel, 0),
+              LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT);
+    EXPECT_EQ(loom_link_module_index_symbol_facet_kind_at(kernel, 1),
+              LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION);
+    EXPECT_EQ(loom_link_module_index_symbol_facet_kind_at(kernel, 2),
+              LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION);
+    EXPECT_EQ(loom_link_module_index_symbol_facet_ordinal(
+                  kernel, LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT),
+              0u);
+    EXPECT_EQ(loom_link_module_index_symbol_facet_ordinal(
+                  kernel, LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION),
+              1u);
+    EXPECT_EQ(loom_link_module_index_symbol_facet_ordinal(
+                  kernel, LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION),
+              2u);
   };
 
   IndexPtr materialized_index = CreateIndex();
@@ -288,17 +301,18 @@ kernel.def target(@dispatch_target) @dispatch_rows(%element_count: index) {
     EXPECT_FALSE(loom_link_plan_contains_symbol(config_plan.get(),
                                                 implementation_only->ordinal));
     EXPECT_TRUE(
-        loom_link_plan_contains_facet(config_plan.get(), kernel->ordinal, 0));
+        loom_link_plan_contains_facet(config_plan.get(), kernel->ordinal,
+                                      LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT));
     EXPECT_TRUE(loom_link_plan_contains_facet(
         config_plan.get(), kernel->ordinal,
-        kernel->facets.schema.kernel_configuration_region_index_plus_one));
+        LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION));
     EXPECT_FALSE(loom_link_plan_contains_facet(
         config_plan.get(), kernel->ordinal,
-        kernel->facets.schema.body_region_index_plus_one));
+        LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION));
 
     PlanPtr full_plan = BuildPlan(index.get(), IREE_SV("dispatch_rows"));
     EXPECT_EQ(loom_link_plan_symbol_count(full_plan.get()), 3u);
-    EXPECT_EQ(loom_link_plan_facet_count(full_plan.get()), 6u);
+    EXPECT_EQ(loom_link_plan_facet_count(full_plan.get()), 5u);
     EXPECT_TRUE(
         loom_link_plan_contains_symbol(full_plan.get(), kernel->ordinal));
     EXPECT_TRUE(
@@ -307,10 +321,10 @@ kernel.def target(@dispatch_target) @dispatch_rows(%element_count: index) {
                                                implementation_only->ordinal));
     EXPECT_TRUE(loom_link_plan_contains_facet(
         full_plan.get(), kernel->ordinal,
-        kernel->facets.schema.kernel_configuration_region_index_plus_one));
+        LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION));
     EXPECT_TRUE(loom_link_plan_contains_facet(
         full_plan.get(), kernel->ordinal,
-        kernel->facets.schema.body_region_index_plus_one));
+        LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION));
 
     loom_link_plan_materialization_environment_t environment = {};
     environment.context = &context_;
@@ -419,15 +433,15 @@ kernel.def target(@dispatch_target) @dispatch_rows(%element_count: index) {
                                                materialized_kernel->ordinal));
     EXPECT_FALSE(loom_link_plan_contains_symbol(
         materialized_plan.get(), materialized_implementation_only->ordinal));
-    EXPECT_TRUE(loom_link_plan_contains_facet(materialized_plan.get(),
-                                              materialized_kernel->ordinal, 0));
     EXPECT_TRUE(loom_link_plan_contains_facet(
         materialized_plan.get(), materialized_kernel->ordinal,
-        materialized_kernel->facets.schema
-            .kernel_configuration_region_index_plus_one));
+        LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT));
+    EXPECT_TRUE(loom_link_plan_contains_facet(
+        materialized_plan.get(), materialized_kernel->ordinal,
+        LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION));
     EXPECT_FALSE(loom_link_plan_contains_facet(
         materialized_plan.get(), materialized_kernel->ordinal,
-        materialized_kernel->facets.schema.body_region_index_plus_one));
+        LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION));
   }
   loom_module_free(source_module);
 
@@ -449,14 +463,14 @@ kernel.def target(@dispatch_target) @dispatch_rows(%element_count: index) {
   EXPECT_FALSE(
       loom_link_plan_contains_symbol(plan.get(), implementation_only->ordinal));
   EXPECT_TRUE(
-      loom_link_plan_contains_facet(plan.get(), indexed_kernel->ordinal, 0));
+      loom_link_plan_contains_facet(plan.get(), indexed_kernel->ordinal,
+                                    LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT));
   EXPECT_TRUE(loom_link_plan_contains_facet(
       plan.get(), indexed_kernel->ordinal,
-      indexed_kernel->facets.schema
-          .kernel_configuration_region_index_plus_one));
+      LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION));
   EXPECT_FALSE(loom_link_plan_contains_facet(
       plan.get(), indexed_kernel->ordinal,
-      indexed_kernel->facets.schema.body_region_index_plus_one));
+      LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION));
 
   const loom_link_module_index_provider_t* provider =
       loom_link_module_index_symbol_provider(index.get(), indexed_kernel);

--- a/loom/src/loom/link/module_index.c
+++ b/loom/src/loom/link/module_index.c
@@ -65,7 +65,7 @@ struct loom_link_module_index_t {
     // Allocated record capacity.
     iree_host_size_t capacity;
   } symbols;
-  // Total contract and root-region facets across indexed symbols.
+  // Total semantic facets across indexed symbols.
   iree_host_size_t facet_count;
   // Exported INPUT-provider symbols in stable provider order.
   struct {
@@ -564,9 +564,8 @@ static iree_status_t loom_link_index_append_symbol(
         loom_link_index_reserve_input_exports(index, input_export_count));
   }
   iree_host_size_t facet_count = 0;
-  if (!iree_host_size_checked_add(
-          index->facet_count,
-          (iree_host_size_t)facet_schema.root_region_count + 1, &facet_count)) {
+  if (!iree_host_size_checked_add(index->facet_count, facet_schema.facet_count,
+                                  &facet_count)) {
     return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
                             "link symbol facet count overflow");
   }
@@ -608,6 +607,42 @@ static iree_status_t loom_link_index_append_symbol(
 //===----------------------------------------------------------------------===//
 // Symbol classification
 //===----------------------------------------------------------------------===//
+
+// Extracts materialized/text structural roles before applying the shared
+// linker facet classifier. No linker metadata is stored on operation
+// definitions or reconstructed by walking symbol bodies.
+static loom_link_symbol_facet_schema_t
+loom_link_classify_materialized_symbol_facets(const loom_op_t* defining_op,
+                                              const loom_op_vtable_t* vtable) {
+  if (!defining_op || !vtable || !vtable->symbol_def) {
+    return loom_link_symbol_facet_schema_classify(
+        /*interfaces=*/0, /*root_region_count=*/0,
+        /*body_region_index_plus_one=*/0,
+        /*kernel_configuration_region_index_plus_one=*/0);
+  }
+  uint8_t body_region_index_plus_one = 0;
+  if (vtable->func_like &&
+      vtable->func_like->body_region_index != LOOM_REGION_INDEX_NONE) {
+    body_region_index_plus_one =
+        (uint8_t)(vtable->func_like->body_region_index + 1);
+  }
+  return loom_link_symbol_facet_schema_classify(
+      vtable->symbol_def->interfaces, defining_op->region_count,
+      body_region_index_plus_one,
+      vtable->symbol_def->kernel_workload_region_index_plus_one);
+}
+
+// Extracts the equivalent roles from validated bytecode metadata. Keeping the
+// representation adapters adjacent makes materialized, text, and bytecode
+// providers share one semantic policy.
+static loom_link_symbol_facet_schema_t
+loom_link_classify_bytecode_symbol_facets(
+    const loom_bytecode_symbol_metadata_t* symbol) {
+  return loom_link_symbol_facet_schema_classify(
+      symbol->interfaces, symbol->root_region_count,
+      symbol->body_region_index_plus_one,
+      symbol->kernel_workload_region_index_plus_one);
+}
 
 static bool loom_link_materialized_symbol_has_visibility_attr(
     const loom_module_t* module, const loom_symbol_t* symbol) {
@@ -764,18 +799,8 @@ static iree_status_t loom_link_index_module_materialized_symbols(
     const loom_op_t* defining_op = symbol->defining_op;
     const loom_op_vtable_t* vtable =
         defining_op ? loom_op_vtable(source_module, defining_op) : NULL;
-    loom_link_symbol_facet_schema_t facet_schema = {0};
-    if (vtable && vtable->symbol_def) {
-      facet_schema.interfaces = vtable->symbol_def->interfaces;
-      facet_schema.root_region_count = defining_op->region_count;
-      facet_schema.kernel_configuration_region_index_plus_one =
-          vtable->symbol_def->kernel_workload_region_index_plus_one;
-      if (vtable->func_like &&
-          vtable->func_like->body_region_index != LOOM_REGION_INDEX_NONE) {
-        facet_schema.body_region_index_plus_one =
-            (uint8_t)(vtable->func_like->body_region_index + 1);
-      }
-    }
+    const loom_link_symbol_facet_schema_t facet_schema =
+        loom_link_classify_materialized_symbol_facets(defining_op, vtable);
     IREE_RETURN_IF_ERROR(loom_link_index_append_symbol(
         index, module, name, symbol->kind, identity,
         loom_link_materialized_symbol_flags(source_module, symbol),
@@ -1007,13 +1032,8 @@ static iree_status_t loom_link_index_module_bytecode_symbols(
     const loom_bytecode_symbol_metadata_t* symbol =
         &bytecode_module->symbols[i];
     loom_link_symbol_flags_t flags = loom_link_bytecode_symbol_flags(symbol);
-    const loom_link_symbol_facet_schema_t facet_schema = {
-        .interfaces = symbol->interfaces,
-        .root_region_count = symbol->root_region_count,
-        .body_region_index_plus_one = symbol->body_region_index_plus_one,
-        .kernel_configuration_region_index_plus_one =
-            symbol->kernel_workload_region_index_plus_one,
-    };
+    const loom_link_symbol_facet_schema_t facet_schema =
+        loom_link_classify_bytecode_symbol_facets(symbol);
     IREE_RETURN_IF_ERROR(loom_link_index_append_symbol(
         index, module, symbol->name,
         loom_link_bytecode_symbol_kind(symbol->kind),
@@ -1506,13 +1526,34 @@ const loom_link_module_index_symbol_t* loom_link_module_index_symbol_at(
   return &index->symbols.values[ordinal];
 }
 
-iree_host_size_t loom_link_module_index_symbol_facet_ordinal(
+loom_link_symbol_facet_kind_t loom_link_module_index_symbol_facet_kind_at(
+    const loom_link_module_index_symbol_t* symbol, uint8_t ordinal) {
+  return symbol ? loom_link_symbol_facet_schema_kind_at(&symbol->facets.schema,
+                                                        ordinal)
+                : LOOM_LINK_SYMBOL_FACET_INVALID;
+}
+
+loom_link_symbol_facet_kind_t
+loom_link_module_index_symbol_source_root_facet_kind(
     const loom_link_module_index_symbol_t* symbol,
     uint8_t source_root_region_index_plus_one) {
-  IREE_ASSERT(symbol);
-  IREE_ASSERT_LE(source_root_region_index_plus_one,
-                 symbol->facets.schema.root_region_count);
-  return symbol->facets.start_ordinal + source_root_region_index_plus_one;
+  return symbol ? loom_link_symbol_facet_schema_source_root_kind(
+                      &symbol->facets.schema, source_root_region_index_plus_one)
+                : LOOM_LINK_SYMBOL_FACET_INVALID;
+}
+
+iree_host_size_t loom_link_module_index_symbol_facet_ordinal(
+    const loom_link_module_index_symbol_t* symbol,
+    loom_link_symbol_facet_kind_t kind) {
+  if (!symbol || kind == LOOM_LINK_SYMBOL_FACET_INVALID) {
+    return LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
+  }
+  for (uint8_t i = 0; i < symbol->facets.schema.facet_count; ++i) {
+    if (loom_link_module_index_symbol_facet_kind_at(symbol, i) == kind) {
+      return symbol->facets.start_ordinal + i;
+    }
+  }
+  return LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
 }
 
 loom_link_module_index_symbol_ordinal_list_t

--- a/loom/src/loom/link/module_index.h
+++ b/loom/src/loom/link/module_index.h
@@ -19,6 +19,7 @@
 #include "loom/format/bytecode/index.h"
 #include "loom/format/text/parser.h"
 #include "loom/ir/ir.h"
+#include "loom/link/symbol_facet.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -107,21 +108,6 @@ enum loom_link_symbol_flag_bits_e {
   LOOM_LINK_SYMBOL_FLAG_TEST_ONLY = 1u << 6,
 };
 typedef uint32_t loom_link_symbol_flags_t;
-
-// Structural projection points exposed by one indexed symbol definition.
-// Contract references use source root zero; independently bounded root regions
-// use their one-based source region index.
-typedef struct loom_link_symbol_facet_schema_t {
-  // Structural symbol interfaces declared by the defining operation.
-  loom_symbol_interface_flags_t interfaces;
-  // Number of root region slots declared by the defining operation.
-  uint8_t root_region_count;
-  // Function body source root region index plus one, or zero when absent.
-  uint8_t body_region_index_plus_one;
-  // Kernel configuration source root region index plus one, or zero when
-  // absent.
-  uint8_t kernel_configuration_region_index_plus_one;
-} loom_link_symbol_facet_schema_t;
 
 // Options applied when adding a provider to an index.
 typedef struct loom_link_module_index_add_options_t {
@@ -236,8 +222,8 @@ typedef struct loom_link_module_index_symbol_t {
   struct {
     // Schema projected from the defining operation during source indexing.
     loom_link_symbol_facet_schema_t schema;
-    // Index-wide ordinal of the contract facet. Root region facets immediately
-    // follow in source region order.
+    // Index-wide ordinal of the first semantic facet. Remaining facets follow
+    // in the order returned by loom_link_module_index_symbol_facet_kind_at().
     iree_host_size_t start_ordinal;
   } facets;
   // Slice in the owning module's flat dependency occurrence array.
@@ -347,12 +333,25 @@ iree_host_size_t loom_link_module_index_facet_count(
 const loom_link_module_index_symbol_t* loom_link_module_index_symbol_at(
     const loom_link_module_index_t* index, iree_host_size_t ordinal);
 
-// Returns the index-wide facet ordinal for |source_root_region_index_plus_one|.
-// Zero selects the symbol contract. The source root must be present in the
-// symbol facet schema.
-iree_host_size_t loom_link_module_index_symbol_facet_ordinal(
+// Returns semantic facet |ordinal| from |symbol|'s compact schema, or INVALID
+// when ordinal is out of range.
+loom_link_symbol_facet_kind_t loom_link_module_index_symbol_facet_kind_at(
+    const loom_link_module_index_symbol_t* symbol, uint8_t ordinal);
+
+// Classifies a physical source root as one semantic facet, or INVALID when the
+// source root is outside the schema. Zero names the symbol contract; positive
+// values name one-based root-region slots from materialized/text/bytecode
+// provider metadata.
+loom_link_symbol_facet_kind_t
+loom_link_module_index_symbol_source_root_facet_kind(
     const loom_link_module_index_symbol_t* symbol,
     uint8_t source_root_region_index_plus_one);
+
+// Returns the index-wide ordinal for semantic |kind|, or INVALID when |symbol|
+// does not expose that facet.
+iree_host_size_t loom_link_module_index_symbol_facet_ordinal(
+    const loom_link_module_index_symbol_t* symbol,
+    loom_link_symbol_facet_kind_t kind);
 
 // Returns exported symbols owned by INPUT providers.
 //

--- a/loom/src/loom/link/planner.c
+++ b/loom/src/loom/link/planner.c
@@ -34,19 +34,19 @@ typedef struct loom_link_plan_live_cause_t {
 } loom_link_plan_live_cause_t;
 
 typedef enum loom_link_plan_facet_request_mode_e {
-  // Select the symbol contract only.
-  LOOM_LINK_PLAN_FACET_REQUEST_CONTRACT = 0,
-  // Select the contract and one independently bounded root region.
-  LOOM_LINK_PLAN_FACET_REQUEST_ROOT_REGION = 1,
-  // Select the contract and every root region.
+  // Select the symbol's primary contract/definition facet only.
+  LOOM_LINK_PLAN_FACET_REQUEST_PRIMARY = 0,
+  // Select the primary facet and one exact semantic facet.
+  LOOM_LINK_PLAN_FACET_REQUEST_EXACT = 1,
+  // Select every semantic facet.
   LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE = 2,
 } loom_link_plan_facet_request_mode_t;
 
 typedef struct loom_link_plan_facet_request_t {
   // Selection mode defining the requested structural projection.
   loom_link_plan_facet_request_mode_t mode;
-  // Source root region index plus one for ROOT_REGION mode.
-  uint8_t source_root_region_index_plus_one;
+  // Semantic facet for EXACT mode.
+  loom_link_symbol_facet_kind_t kind;
 } loom_link_plan_facet_request_t;
 
 typedef enum loom_link_plan_facet_expansion_mode_e {
@@ -606,7 +606,7 @@ static iree_status_t loom_link_plan_append_symbol(
       .symbol_ordinal = symbol->ordinal,
       .reason = cause.reason,
       .cause_ordinal = cause.symbol_plan_ordinal,
-      .contract_facet_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
+      .primary_facet_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
       .selected_facet_count = 0,
       .root_name = cause.root_name,
   };
@@ -624,8 +624,7 @@ static iree_status_t loom_link_plan_append_symbol(
 
 static iree_status_t loom_link_plan_append_facet(
     loom_link_plan_t* plan, const loom_link_module_index_symbol_t* symbol,
-    uint8_t source_root_region_index_plus_one,
-    iree_host_size_t symbol_plan_ordinal,
+    loom_link_symbol_facet_kind_t kind, iree_host_size_t symbol_plan_ordinal,
     loom_link_plan_facet_expansion_mode_t expansion_mode,
     loom_link_plan_live_cause_t cause,
     iree_host_size_t* out_facet_plan_ordinal) {
@@ -642,8 +641,7 @@ static iree_status_t loom_link_plan_append_facet(
               .ordinal = facet_plan_ordinal,
               .symbol_plan_ordinal = symbol_plan_ordinal,
               .symbol_ordinal = symbol->ordinal,
-              .source_root_region_index_plus_one =
-                  source_root_region_index_plus_one,
+              .kind = kind,
               .reason = cause.reason,
               .cause_ordinal = cause.facet_plan_ordinal,
           },
@@ -651,8 +649,8 @@ static iree_status_t loom_link_plan_append_facet(
   };
   plan->facets.count = facet_count;
   ++plan->symbols.values[symbol_plan_ordinal].selected_facet_count;
-  if (source_root_region_index_plus_one == 0) {
-    plan->symbols.values[symbol_plan_ordinal].contract_facet_ordinal =
+  if (kind == loom_link_module_index_symbol_facet_kind_at(symbol, 0)) {
+    plan->symbols.values[symbol_plan_ordinal].primary_facet_ordinal =
         facet_plan_ordinal;
   }
   if (out_facet_plan_ordinal) {
@@ -663,23 +661,21 @@ static iree_status_t loom_link_plan_append_facet(
 
 static bool loom_link_plan_facet_is_selected(
     const loom_link_plan_t* plan, iree_host_size_t symbol_plan_ordinal,
-    uint8_t source_root_region_index_plus_one) {
+    loom_link_symbol_facet_kind_t kind) {
   const loom_link_plan_symbol_t* symbol_selection =
       &plan->symbols.values[symbol_plan_ordinal];
   const loom_link_module_index_symbol_t* symbol =
       loom_link_module_index_symbol_at(plan->index,
                                        symbol_selection->symbol_ordinal);
-  const uint16_t complete_facet_count =
-      (uint16_t)symbol->facets.schema.root_region_count + 1;
+  const uint16_t complete_facet_count = symbol->facets.schema.facet_count;
   if (symbol_selection->selected_facet_count == complete_facet_count) {
     return true;
   }
-  for (iree_host_size_t i = symbol_selection->contract_facet_ordinal;
+  for (iree_host_size_t i = symbol_selection->primary_facet_ordinal;
        i < plan->facets.count; ++i) {
     const loom_link_plan_facet_t* facet = &plan->facets.values[i].selection;
     if (facet->symbol_plan_ordinal == symbol_plan_ordinal &&
-        facet->source_root_region_index_plus_one ==
-            source_root_region_index_plus_one) {
+        facet->kind == kind) {
       return true;
     }
   }
@@ -700,16 +696,15 @@ static bool loom_link_plan_facet_request_is_selected(
   }
   const loom_link_plan_symbol_t* symbol_selection =
       &plan->symbols.values[symbol_plan_ordinal];
-  const uint16_t complete_facet_count =
-      (uint16_t)symbol->facets.schema.root_region_count + 1;
+  const uint16_t complete_facet_count = symbol->facets.schema.facet_count;
   if (symbol_selection->selected_facet_count == complete_facet_count) {
     return true;
   }
-  if (request.mode == LOOM_LINK_PLAN_FACET_REQUEST_ROOT_REGION) {
-    return loom_link_plan_facet_is_selected(
-        plan, symbol_plan_ordinal, request.source_root_region_index_plus_one);
+  if (request.mode == LOOM_LINK_PLAN_FACET_REQUEST_EXACT) {
+    return loom_link_plan_facet_is_selected(plan, symbol_plan_ordinal,
+                                            request.kind);
   }
-  return request.mode == LOOM_LINK_PLAN_FACET_REQUEST_CONTRACT;
+  return request.mode == LOOM_LINK_PLAN_FACET_REQUEST_PRIMARY;
 }
 
 static iree_status_t loom_link_plan_select_required_symbol_facets(
@@ -725,16 +720,13 @@ static iree_status_t loom_link_plan_select_required_symbol_facets(
                             "unknown link facet request mode %u",
                             (unsigned)request.mode);
   }
-  if (request.mode == LOOM_LINK_PLAN_FACET_REQUEST_ROOT_REGION &&
-      (request.source_root_region_index_plus_one == 0 ||
-       request.source_root_region_index_plus_one >
-           symbol->facets.schema.root_region_count)) {
+  if (request.mode == LOOM_LINK_PLAN_FACET_REQUEST_EXACT &&
+      loom_link_module_index_symbol_facet_ordinal(symbol, request.kind) ==
+          LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL) {
     return iree_make_status(
-        IREE_STATUS_OUT_OF_RANGE,
-        "source root region %u is outside symbol '@%.*s' with %u roots",
-        (unsigned)request.source_root_region_index_plus_one,
-        (int)symbol->name.size, symbol->name.data,
-        (unsigned)symbol->facets.schema.root_region_count);
+        IREE_STATUS_INVALID_ARGUMENT,
+        "semantic facet 0x%04X is not exposed by symbol '@%.*s'",
+        (unsigned)request.kind, (int)symbol->name.size, symbol->name.data);
   }
   if (loom_link_plan_facet_request_is_selected(plan, symbol, request)) {
     return iree_ok_status();
@@ -770,26 +762,27 @@ static iree_status_t loom_link_plan_select_required_symbol_facets(
     const loom_link_plan_facet_expansion_mode_t expansion_mode =
         needs_complete_expansion ? LOOM_LINK_PLAN_FACET_EXPANSION_COMPLETE
                                  : LOOM_LINK_PLAN_FACET_EXPANSION_EXACT;
+    const loom_link_symbol_facet_kind_t primary_kind =
+        loom_link_module_index_symbol_facet_kind_at(symbol, 0);
     IREE_RETURN_IF_ERROR(loom_link_plan_append_facet(
-        plan, symbol, 0, symbol_plan_ordinal, expansion_mode, cause,
+        plan, symbol, primary_kind, symbol_plan_ordinal, expansion_mode, cause,
         /*out_facet_plan_ordinal=*/NULL));
     needs_complete_expansion = false;
   }
-  if (request.mode == LOOM_LINK_PLAN_FACET_REQUEST_ROOT_REGION) {
-    const uint8_t source_root = request.source_root_region_index_plus_one;
+  if (request.mode == LOOM_LINK_PLAN_FACET_REQUEST_EXACT) {
     if (!loom_link_plan_facet_is_selected(plan, symbol_plan_ordinal,
-                                          source_root)) {
+                                          request.kind)) {
       IREE_RETURN_IF_ERROR(loom_link_plan_append_facet(
-          plan, symbol, source_root, symbol_plan_ordinal,
+          plan, symbol, request.kind, symbol_plan_ordinal,
           LOOM_LINK_PLAN_FACET_EXPANSION_EXACT, cause,
           /*out_facet_plan_ordinal=*/NULL));
     }
   } else if (request.mode == LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE) {
-    for (uint16_t source_root = 1;
-         source_root <= symbol->facets.schema.root_region_count;
-         ++source_root) {
-      if (!loom_link_plan_facet_is_selected(plan, symbol_plan_ordinal,
-                                            (uint8_t)source_root)) {
+    for (uint8_t facet_ordinal = 1;
+         facet_ordinal < symbol->facets.schema.facet_count; ++facet_ordinal) {
+      const loom_link_symbol_facet_kind_t kind =
+          loom_link_module_index_symbol_facet_kind_at(symbol, facet_ordinal);
+      if (!loom_link_plan_facet_is_selected(plan, symbol_plan_ordinal, kind)) {
         loom_link_plan_facet_expansion_mode_t expansion_mode =
             LOOM_LINK_PLAN_FACET_EXPANSION_EXACT;
         if (batch_complete_expansion) {
@@ -798,15 +791,13 @@ static iree_status_t loom_link_plan_select_required_symbol_facets(
                                : LOOM_LINK_PLAN_FACET_EXPANSION_NONE;
         }
         IREE_RETURN_IF_ERROR(loom_link_plan_append_facet(
-            plan, symbol, (uint8_t)source_root, symbol_plan_ordinal,
-            expansion_mode, cause,
+            plan, symbol, kind, symbol_plan_ordinal, expansion_mode, cause,
             /*out_facet_plan_ordinal=*/NULL));
         needs_complete_expansion = false;
       }
     }
   }
-  const uint16_t complete_facet_count =
-      (uint16_t)symbol->facets.schema.root_region_count + 1;
+  const uint16_t complete_facet_count = symbol->facets.schema.facet_count;
   if (plan->symbols.values[symbol_plan_ordinal].selected_facet_count !=
           complete_facet_count &&
       plan->symbol_ordinals.values == NULL) {
@@ -863,7 +854,7 @@ static iree_status_t loom_link_plan_resolve_declaration(
   const loom_link_plan_live_cause_t cause = {
       .reason = LOOM_LINK_PLAN_LIVE_DEPENDENCY,
       .symbol_plan_ordinal = declaration_plan_ordinal,
-      .facet_plan_ordinal = declaration_selection->contract_facet_ordinal,
+      .facet_plan_ordinal = declaration_selection->primary_facet_ordinal,
       .root_name = iree_string_view_empty(),
   };
   IREE_RETURN_IF_ERROR(loom_link_plan_select_required_symbol(
@@ -928,20 +919,37 @@ static iree_status_t loom_link_plan_select_dependency_target(
                                                NULL);
 }
 
-static iree_status_t loom_link_plan_expand_dependency_slice(
+static iree_status_t loom_link_plan_expand_module_dependencies(
     loom_link_plan_t* plan, const loom_link_plan_options_t* options,
-    const loom_link_module_index_module_t* module, uint32_t first,
-    uint32_t count, uint8_t source_root_region_index_plus_one,
+    const loom_link_module_index_module_t* module,
     loom_link_plan_live_cause_t cause) {
-  if (count == 0) {
-    return iree_ok_status();
-  }
-  const uint32_t* dependencies = module->dependencies.values + first;
+  const uint32_t count = module->dependencies.root_count;
+  const uint32_t* dependencies = module->dependencies.values;
   for (uint32_t i = 0; i < count; ++i) {
-    if (module->dependencies.source_root_region_indices_plus_one[first + i] !=
-        source_root_region_index_plus_one) {
-      continue;
-    }
+    IREE_ASSERT_EQ(module->dependencies.source_root_region_indices_plus_one[i],
+                   0);
+    IREE_RETURN_IF_ERROR(loom_link_plan_select_dependency_target(
+        plan, options, module, dependencies[i], cause));
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t loom_link_plan_expand_symbol_facet_dependencies(
+    loom_link_plan_t* plan, const loom_link_plan_options_t* options,
+    const loom_link_module_index_symbol_t* symbol,
+    const loom_link_module_index_module_t* module,
+    loom_link_symbol_facet_kind_t kind, loom_link_plan_live_cause_t cause) {
+  if (symbol->dependencies.count == 0) return iree_ok_status();
+  const uint32_t first = symbol->dependencies.first;
+  const uint32_t* dependencies = module->dependencies.values + first;
+  for (uint32_t i = 0; i < symbol->dependencies.count; ++i) {
+    const uint8_t source_root_region_index_plus_one =
+        module->dependencies.source_root_region_indices_plus_one[first + i];
+    const loom_link_symbol_facet_kind_t source_kind =
+        loom_link_module_index_symbol_source_root_facet_kind(
+            symbol, source_root_region_index_plus_one);
+    IREE_ASSERT_NE(source_kind, LOOM_LINK_SYMBOL_FACET_INVALID);
+    if (source_kind != kind) continue;
     IREE_RETURN_IF_ERROR(loom_link_plan_select_dependency_target(
         plan, options, module, dependencies[i], cause));
   }
@@ -969,20 +977,22 @@ static iree_status_t loom_link_plan_record_template_family_demand(
   return iree_ok_status();
 }
 
-static iree_status_t loom_link_plan_record_template_family_demands(
-    loom_link_plan_t* plan, const loom_link_module_index_module_t* module,
-    uint32_t first, uint32_t count, uint8_t source_root_region_index_plus_one) {
-  if (count == 0) {
-    return iree_ok_status();
-  }
+static iree_status_t loom_link_plan_record_symbol_facet_template_demands(
+    loom_link_plan_t* plan, const loom_link_module_index_symbol_t* symbol,
+    const loom_link_module_index_module_t* module,
+    loom_link_symbol_facet_kind_t kind) {
+  if (symbol->template_demands.count == 0) return iree_ok_status();
+  const uint32_t first = symbol->template_demands.first;
   const loom_link_template_family_ordinal_t* template_families =
       module->template_demands.values + first;
-  for (uint32_t i = 0; i < count; ++i) {
-    if (module->template_demands
-            .source_root_region_indices_plus_one[first + i] !=
-        source_root_region_index_plus_one) {
-      continue;
-    }
+  for (uint32_t i = 0; i < symbol->template_demands.count; ++i) {
+    const uint8_t source_root_region_index_plus_one =
+        module->template_demands.source_root_region_indices_plus_one[first + i];
+    const loom_link_symbol_facet_kind_t source_kind =
+        loom_link_module_index_symbol_source_root_facet_kind(
+            symbol, source_root_region_index_plus_one);
+    IREE_ASSERT_NE(source_kind, LOOM_LINK_SYMBOL_FACET_INVALID);
+    if (source_kind != kind) continue;
     IREE_RETURN_IF_ERROR(loom_link_plan_record_template_family_demand(
         plan, template_families[i]));
   }
@@ -991,31 +1001,36 @@ static iree_status_t loom_link_plan_record_template_family_demands(
 
 static iree_host_size_t loom_link_plan_find_facet_plan_ordinal(
     const loom_link_plan_t* plan, iree_host_size_t symbol_plan_ordinal,
-    uint8_t source_root_region_index_plus_one) {
+    loom_link_symbol_facet_kind_t kind) {
   const loom_link_plan_symbol_t* symbol_selection =
       &plan->symbols.values[symbol_plan_ordinal];
-  IREE_ASSERT_NE(symbol_selection->contract_facet_ordinal,
+  const loom_link_module_index_symbol_t* symbol =
+      loom_link_module_index_symbol_at(plan->index,
+                                       symbol_selection->symbol_ordinal);
+  IREE_ASSERT_NE(symbol_selection->primary_facet_ordinal,
                  LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL);
+  const iree_host_size_t index_facet_ordinal =
+      loom_link_module_index_symbol_facet_ordinal(symbol, kind);
+  IREE_ASSERT_NE(index_facet_ordinal, LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL);
   const iree_host_size_t contiguous_ordinal =
-      symbol_selection->contract_facet_ordinal +
-      source_root_region_index_plus_one;
+      symbol_selection->primary_facet_ordinal +
+      (index_facet_ordinal - symbol->facets.start_ordinal);
   IREE_ASSERT_LT(contiguous_ordinal, plan->facets.count);
   const loom_link_plan_facet_t* facet =
       &plan->facets.values[contiguous_ordinal].selection;
   IREE_ASSERT_EQ(facet->symbol_plan_ordinal, symbol_plan_ordinal);
-  IREE_ASSERT_EQ(facet->source_root_region_index_plus_one,
-                 source_root_region_index_plus_one);
+  IREE_ASSERT_EQ(facet->kind, kind);
   return contiguous_ordinal;
 }
 
 static loom_link_plan_live_cause_t loom_link_plan_facet_dependency_cause(
     const loom_link_plan_t* plan, iree_host_size_t symbol_plan_ordinal,
-    uint8_t source_root_region_index_plus_one) {
+    loom_link_symbol_facet_kind_t kind) {
   return (loom_link_plan_live_cause_t){
       .reason = LOOM_LINK_PLAN_LIVE_DEPENDENCY,
       .symbol_plan_ordinal = symbol_plan_ordinal,
       .facet_plan_ordinal = loom_link_plan_find_facet_plan_ordinal(
-          plan, symbol_plan_ordinal, source_root_region_index_plus_one),
+          plan, symbol_plan_ordinal, kind),
       .root_name = iree_string_view_empty(),
   };
 }
@@ -1033,9 +1048,13 @@ static iree_status_t loom_link_plan_expand_complete_symbol(
       const uint8_t source_root_region_index_plus_one =
           module->dependencies
               .source_root_region_indices_plus_one[dependency_first + i];
+      const loom_link_symbol_facet_kind_t source_kind =
+          loom_link_module_index_symbol_source_root_facet_kind(
+              symbol, source_root_region_index_plus_one);
+      IREE_ASSERT_NE(source_kind, LOOM_LINK_SYMBOL_FACET_INVALID);
       const loom_link_plan_live_cause_t cause =
-          loom_link_plan_facet_dependency_cause(
-              plan, symbol_plan_ordinal, source_root_region_index_plus_one);
+          loom_link_plan_facet_dependency_cause(plan, symbol_plan_ordinal,
+                                                source_kind);
       IREE_RETURN_IF_ERROR(loom_link_plan_select_dependency_target(
           plan, options, module, dependencies[i], cause));
     }
@@ -1070,19 +1089,18 @@ static iree_status_t loom_link_plan_expand_facet(
     return iree_ok_status();
   }
   if (work_item.expansion_mode == LOOM_LINK_PLAN_FACET_EXPANSION_COMPLETE) {
-    const iree_host_size_t contract_facet_ordinal =
-        plan->symbols.values[facet.symbol_plan_ordinal].contract_facet_ordinal;
+    const iree_host_size_t primary_facet_ordinal =
+        plan->symbols.values[facet.symbol_plan_ordinal].primary_facet_ordinal;
     const loom_link_plan_live_cause_t module_cause = {
         .reason = LOOM_LINK_PLAN_LIVE_DEPENDENCY,
         .symbol_plan_ordinal = facet.symbol_plan_ordinal,
-        .facet_plan_ordinal = contract_facet_ordinal,
+        .facet_plan_ordinal = primary_facet_ordinal,
         .root_name = iree_string_view_empty(),
     };
     if (!loom_link_plan_bitmap_test_and_set(&plan->reachability.modules,
                                             module->ordinal)) {
-      IREE_RETURN_IF_ERROR(loom_link_plan_expand_dependency_slice(
-          plan, options, module, /*first=*/0, module->dependencies.root_count,
-          /*source_root_region_index_plus_one=*/0, module_cause));
+      IREE_RETURN_IF_ERROR(loom_link_plan_expand_module_dependencies(
+          plan, options, module, module_cause));
     }
     return loom_link_plan_expand_complete_symbol(plan, options, symbol, module,
                                                  facet.symbol_plan_ordinal);
@@ -1096,17 +1114,13 @@ static iree_status_t loom_link_plan_expand_facet(
 
   if (!loom_link_plan_bitmap_test_and_set(&plan->reachability.modules,
                                           module->ordinal)) {
-    IREE_RETURN_IF_ERROR(loom_link_plan_expand_dependency_slice(
-        plan, options, module, /*first=*/0, module->dependencies.root_count,
-        /*source_root_region_index_plus_one=*/0, cause));
+    IREE_RETURN_IF_ERROR(loom_link_plan_expand_module_dependencies(
+        plan, options, module, cause));
   }
-  IREE_RETURN_IF_ERROR(loom_link_plan_expand_dependency_slice(
-      plan, options, module, symbol->dependencies.first,
-      symbol->dependencies.count, facet.source_root_region_index_plus_one,
-      cause));
-  return loom_link_plan_record_template_family_demands(
-      plan, module, symbol->template_demands.first,
-      symbol->template_demands.count, facet.source_root_region_index_plus_one);
+  IREE_RETURN_IF_ERROR(loom_link_plan_expand_symbol_facet_dependencies(
+      plan, options, symbol, module, facet.kind, cause));
+  return loom_link_plan_record_symbol_facet_template_demands(
+      plan, symbol, module, facet.kind);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1236,11 +1250,8 @@ static iree_status_t loom_link_plan_select_root_facets(
     const loom_link_module_index_symbol_t* symbol =
         loom_link_module_index_symbol_at(plan->index, root.symbol_ordinal);
     const loom_link_plan_facet_request_t request = {
-        .mode = root.source_root_region_index_plus_one == 0
-                    ? LOOM_LINK_PLAN_FACET_REQUEST_CONTRACT
-                    : LOOM_LINK_PLAN_FACET_REQUEST_ROOT_REGION,
-        .source_root_region_index_plus_one =
-            root.source_root_region_index_plus_one,
+        .mode = LOOM_LINK_PLAN_FACET_REQUEST_EXACT,
+        .kind = root.kind,
     };
     const loom_link_plan_live_cause_t cause = {
         .reason = LOOM_LINK_PLAN_LIVE_ROOT,
@@ -1460,14 +1471,14 @@ bool loom_link_plan_contains_symbol(const loom_link_plan_t* plan,
 
 bool loom_link_plan_contains_facet(const loom_link_plan_t* plan,
                                    iree_host_size_t symbol_ordinal,
-                                   uint8_t source_root_region_index_plus_one) {
+                                   loom_link_symbol_facet_kind_t kind) {
   if (!plan) {
     return false;
   }
   const loom_link_module_index_symbol_t* symbol =
       loom_link_module_index_symbol_at(plan->index, symbol_ordinal);
-  if (!symbol || source_root_region_index_plus_one >
-                     symbol->facets.schema.root_region_count) {
+  if (!symbol || loom_link_module_index_symbol_facet_ordinal(symbol, kind) ==
+                     LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL) {
     return false;
   }
   if (!loom_link_plan_bitmap_contains(&plan->reachability.symbols,
@@ -1483,8 +1494,7 @@ bool loom_link_plan_contains_facet(const loom_link_plan_t* plan,
       plan, symbol_ordinal, &symbol_plan_ordinal);
   IREE_ASSERT(found);
   return found &&
-         loom_link_plan_facet_is_selected(plan, symbol_plan_ordinal,
-                                          source_root_region_index_plus_one);
+         loom_link_plan_facet_is_selected(plan, symbol_plan_ordinal, kind);
 }
 
 bool loom_link_plan_symbol_imports_resolved(const loom_link_plan_t* plan,

--- a/loom/src/loom/link/planner.h
+++ b/loom/src/loom/link/planner.h
@@ -65,14 +65,13 @@ typedef bool (*loom_link_plan_strip_symbol_fn_t)(
     void* user_data, const loom_link_module_index_t* index,
     const loom_link_module_index_symbol_t* symbol);
 
-// One identity-resolved selective root facet. The symbol contract is always
-// selected. A nonzero source root also selects that independently bounded root
-// region without selecting sibling roots.
+// One identity-resolved selective root facet. The symbol's primary
+// contract/definition facet is always selected with the requested facet.
 typedef struct loom_link_plan_root_facet_t {
   // Index-wide symbol ordinal resolved by the requesting subsystem.
   iree_host_size_t symbol_ordinal;
-  // Source root region index plus one, or zero for the contract alone.
-  uint8_t source_root_region_index_plus_one;
+  // Semantic facet requested by the selective link product.
+  loom_link_symbol_facet_kind_t kind;
 } loom_link_plan_root_facet_t;
 
 // Options controlling one planning operation.
@@ -121,9 +120,9 @@ typedef struct loom_link_plan_symbol_t {
   loom_link_plan_live_reason_t reason;
   // Plan-local ordinal that caused this dependency, or INVALID_ORDINAL.
   iree_host_size_t cause_ordinal;
-  // Plan-local contract facet ordinal for this symbol.
-  iree_host_size_t contract_facet_ordinal;
-  // Number of selected contract and root-region facets.
+  // Plan-local ordinal of the selected primary contract/definition facet.
+  iree_host_size_t primary_facet_ordinal;
+  // Number of selected semantic facets.
   uint16_t selected_facet_count;
   // Root name that caused this selection when reason is ROOT.
   iree_string_view_t root_name;
@@ -137,8 +136,8 @@ typedef struct loom_link_plan_facet_t {
   iree_host_size_t symbol_plan_ordinal;
   // Index-wide symbol ordinal owning this facet.
   iree_host_size_t symbol_ordinal;
-  // Source root region index plus one, or zero for the symbol contract.
-  uint8_t source_root_region_index_plus_one;
+  // Selected semantic facet.
+  loom_link_symbol_facet_kind_t kind;
   // Why this facet is live.
   loom_link_plan_live_reason_t reason;
   // Plan-local facet ordinal that caused this selection, or INVALID_ORDINAL.
@@ -192,11 +191,11 @@ loom_link_template_family_ordinal_t loom_link_plan_demanded_template_family_at(
 bool loom_link_plan_contains_symbol(const loom_link_plan_t* plan,
                                     iree_host_size_t symbol_ordinal);
 
-// Returns true when the contract or named source root of |symbol_ordinal| is
-// live in |plan|. Every valid facet of an archive-selected symbol is live.
+// Returns true when semantic |kind| of |symbol_ordinal| is live in |plan|.
+// Every valid facet of an archive-selected symbol is live.
 bool loom_link_plan_contains_facet(const loom_link_plan_t* plan,
                                    iree_host_size_t symbol_ordinal,
-                                   uint8_t source_root_region_index_plus_one);
+                                   loom_link_symbol_facet_kind_t kind);
 
 // Returns true when a concrete provider satisfied |symbol_ordinal|'s
 // compile-time provider imports. Every availability anchor for the symbol is

--- a/loom/src/loom/link/planner_test.cc
+++ b/loom/src/loom/link/planner_test.cc
@@ -20,6 +20,7 @@
 #include "loom/ir/context.h"
 #include "loom/ir/module.h"
 #include "loom/ops/check/ops.h"
+#include "loom/ops/command/ops.h"
 #include "loom/ops/config/ops.h"
 #include "loom/ops/func/ops.h"
 #include "loom/ops/module/ops.h"
@@ -55,6 +56,8 @@ class LinkPlannerTest : public ::testing::Test {
     loom_context_initialize(iree_allocator_system(), &context_);
     RegisterDialect(LOOM_DIALECT_CHECK, loom_check_dialect_vtables,
                     loom_check_dialect_op_semantics);
+    RegisterDialect(LOOM_DIALECT_COMMAND, loom_command_dialect_vtables,
+                    loom_command_dialect_op_semantics);
     RegisterDialect(LOOM_DIALECT_CONFIG, loom_config_dialect_vtables,
                     loom_config_dialect_op_semantics);
     RegisterDialect(LOOM_DIALECT_FUNC, loom_func_dialect_vtables,
@@ -162,6 +165,23 @@ class LinkPlannerTest : public ::testing::Test {
     IREE_CHECK_OK(loom_link_module_index_add_bytecode(
         index, iree_make_const_byte_span(bytes.data(), bytes.size()), name,
         /*index_options=*/nullptr, &options, &provider_ordinal));
+    return provider_ordinal;
+  }
+
+  iree_host_size_t AddText(loom_link_module_index_t* index,
+                           iree_string_view_t source, iree_string_view_t name,
+                           loom_link_provider_role_t role) {
+    loom_link_module_index_add_options_t options = {
+        /*.provider_name=*/name,
+        /*.role=*/role,
+    };
+    loom_text_parse_options_t parse_options = {
+        /*.diagnostic_sink=*/{},
+        /*.max_errors=*/20,
+    };
+    iree_host_size_t provider_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
+    IREE_CHECK_OK(loom_link_module_index_add_text(
+        index, source, name, &parse_options, &options, &provider_ordinal));
     return provider_ordinal;
   }
 
@@ -338,8 +358,8 @@ func.def @unused_private(%x: i32) -> (i32) {
 }
 
 TEST_F(LinkPlannerTest,
-       FacetRootsFilterAndUpgradeMultiRegionClosureAcrossProviders) {
-  loom_module_t* module = Parse(IREE_SV(R"(
+       OrdinaryDefinitionFacetCombinesEveryRootAcrossProviderForms) {
+  const iree_string_view_t source = IREE_SV(R"(
 test.record @config_dependency
 test.record @implementation_dependency
 
@@ -350,23 +370,11 @@ test.split_func @split_root() {
   test.symbol_array_attrs [@implementation_dependency] using []
   test.yield
 }
-)"));
+)");
+  loom_module_t* module = Parse(source);
   const std::vector<uint8_t> bytecode = WriteModule(module);
 
   auto verify_index = [&](const loom_link_module_index_t* index) {
-    auto find_plan_facet = [](const loom_link_plan_t* plan,
-                              iree_host_size_t symbol_ordinal,
-                              uint8_t source_root_region_index_plus_one) {
-      for (iree_host_size_t i = 0; i < loom_link_plan_facet_count(plan); ++i) {
-        const loom_link_plan_facet_t* facet = loom_link_plan_facet_at(plan, i);
-        if (facet->symbol_ordinal == symbol_ordinal &&
-            facet->source_root_region_index_plus_one ==
-                source_root_region_index_plus_one) {
-          return facet;
-        }
-      }
-      return static_cast<const loom_link_plan_facet_t*>(nullptr);
-    };
     const loom_link_module_index_module_t* indexed_module =
         loom_link_module_index_module_at(index, 0);
     ASSERT_NE(indexed_module, nullptr);
@@ -383,68 +391,133 @@ test.split_func @split_root() {
     ASSERT_NE(config_dependency, nullptr);
     ASSERT_NE(implementation_dependency, nullptr);
 
-    const loom_link_plan_root_facet_t config_root = {
-        /*.symbol_ordinal=*/root->ordinal,
-        /*.source_root_region_index_plus_one=*/1,
-    };
-    loom_link_plan_options_t config_options = {};
-    config_options.mode = LOOM_LINK_PLAN_SELECTIVE;
-    config_options.root_facets = {1, &config_root};
-    PlanPtr config_plan = BuildPlan(index, &config_options);
-    EXPECT_TRUE(ContainsSymbol(config_plan.get(), root));
-    EXPECT_TRUE(ContainsSymbol(config_plan.get(), config_dependency));
-    EXPECT_FALSE(ContainsSymbol(config_plan.get(), implementation_dependency));
-    EXPECT_TRUE(
-        loom_link_plan_contains_facet(config_plan.get(), root->ordinal, 0));
-    EXPECT_TRUE(
-        loom_link_plan_contains_facet(config_plan.get(), root->ordinal, 1));
-    EXPECT_FALSE(
-        loom_link_plan_contains_facet(config_plan.get(), root->ordinal, 2));
-    const loom_link_plan_facet_t* config_root_facet =
-        find_plan_facet(config_plan.get(), root->ordinal, 1);
-    const loom_link_plan_facet_t* config_dependency_facet =
-        find_plan_facet(config_plan.get(), config_dependency->ordinal, 0);
-    ASSERT_NE(config_root_facet, nullptr);
-    ASSERT_NE(config_dependency_facet, nullptr);
-    EXPECT_EQ(config_dependency_facet->cause_ordinal,
-              config_root_facet->ordinal);
+    EXPECT_EQ(root->facets.schema.root_region_count, 2u);
+    EXPECT_EQ(root->facets.schema.facet_count, 1u);
+    EXPECT_EQ(loom_link_module_index_symbol_facet_kind_at(root, 0),
+              LOOM_LINK_SYMBOL_FACET_DEFINITION);
+    EXPECT_EQ(loom_link_module_index_symbol_source_root_facet_kind(root, 0),
+              LOOM_LINK_SYMBOL_FACET_DEFINITION);
+    EXPECT_EQ(loom_link_module_index_symbol_source_root_facet_kind(root, 1),
+              LOOM_LINK_SYMBOL_FACET_DEFINITION);
+    EXPECT_EQ(loom_link_module_index_symbol_source_root_facet_kind(root, 2),
+              LOOM_LINK_SYMBOL_FACET_DEFINITION);
 
-    const loom_link_plan_root_facet_t upgraded_roots[] = {
-        config_root,
-        {
-            /*.symbol_ordinal=*/root->ordinal,
-            /*.source_root_region_index_plus_one=*/2,
-        },
+    const loom_link_plan_root_facet_t definition_root = {
+        /*.symbol_ordinal=*/root->ordinal,
+        /*.kind=*/LOOM_LINK_SYMBOL_FACET_DEFINITION,
     };
-    loom_link_plan_options_t upgraded_options = {};
-    upgraded_options.mode = LOOM_LINK_PLAN_SELECTIVE;
-    upgraded_options.root_facets = {IREE_ARRAYSIZE(upgraded_roots),
-                                    upgraded_roots};
-    PlanPtr upgraded_plan = BuildPlan(index, &upgraded_options);
-    EXPECT_TRUE(ContainsSymbol(upgraded_plan.get(), root));
-    EXPECT_TRUE(ContainsSymbol(upgraded_plan.get(), config_dependency));
-    EXPECT_TRUE(ContainsSymbol(upgraded_plan.get(), implementation_dependency));
-    EXPECT_TRUE(
-        loom_link_plan_contains_facet(upgraded_plan.get(), root->ordinal, 0));
-    EXPECT_TRUE(
-        loom_link_plan_contains_facet(upgraded_plan.get(), root->ordinal, 1));
-    EXPECT_TRUE(
-        loom_link_plan_contains_facet(upgraded_plan.get(), root->ordinal, 2));
-    const loom_link_plan_facet_t* implementation_root_facet =
-        find_plan_facet(upgraded_plan.get(), root->ordinal, 2);
-    const loom_link_plan_facet_t* implementation_dependency_facet =
-        find_plan_facet(upgraded_plan.get(), implementation_dependency->ordinal,
-                        0);
-    ASSERT_NE(implementation_root_facet, nullptr);
-    ASSERT_NE(implementation_dependency_facet, nullptr);
-    EXPECT_EQ(implementation_dependency_facet->cause_ordinal,
-              implementation_root_facet->ordinal);
+    loom_link_plan_options_t options = {};
+    options.mode = LOOM_LINK_PLAN_SELECTIVE;
+    options.root_facets = {1, &definition_root};
+    PlanPtr plan = BuildPlan(index, &options);
+    EXPECT_TRUE(ContainsSymbol(plan.get(), root));
+    EXPECT_TRUE(ContainsSymbol(plan.get(), config_dependency));
+    EXPECT_TRUE(ContainsSymbol(plan.get(), implementation_dependency));
+    EXPECT_EQ(loom_link_plan_facet_count(plan.get()), 3u);
+    EXPECT_TRUE(loom_link_plan_contains_facet(
+        plan.get(), root->ordinal, LOOM_LINK_SYMBOL_FACET_DEFINITION));
   };
 
   IndexPtr materialized_index = CreateIndex();
   AddMaterialized(materialized_index.get(), module, IREE_SV("materialized"),
                   LOOM_LINK_PROVIDER_ROLE_INPUT);
   verify_index(materialized_index.get());
+
+  IndexPtr text_index = CreateIndex();
+  AddText(text_index.get(), source, IREE_SV("module.loom"),
+          LOOM_LINK_PROVIDER_ROLE_INPUT);
+  verify_index(text_index.get());
+
+  IndexPtr bytecode_index = CreateIndex();
+  AddBytecode(bytecode_index.get(), bytecode, IREE_SV("module.loombc"),
+              LOOM_LINK_PROVIDER_ROLE_INPUT);
+  verify_index(bytecode_index.get());
+}
+
+TEST_F(LinkPlannerTest,
+       CommandFacetsSeparateContractAndImplementationAcrossProviderForms) {
+  const iree_string_view_t source = IREE_SV(R"(
+command.program.def @leaf() launch() {
+  command.return
+}
+
+command.program.def @root() launch() {
+  command.program.launch @leaf() : ()
+  command.return
+}
+)");
+  loom_module_t* module = Parse(source);
+  const std::vector<uint8_t> bytecode = WriteModule(module);
+
+  auto verify_index = [&](const loom_link_module_index_t* index) {
+    const loom_link_module_index_symbol_t* root =
+        loom_link_module_index_lookup_name(index, IREE_SV("root"));
+    const loom_link_module_index_symbol_t* leaf =
+        loom_link_module_index_lookup_name(index, IREE_SV("leaf"));
+    ASSERT_NE(root, nullptr);
+    ASSERT_NE(leaf, nullptr);
+    EXPECT_EQ(root->facets.schema.facet_count, 2u);
+    EXPECT_EQ(loom_link_module_index_symbol_facet_kind_at(root, 0),
+              LOOM_LINK_SYMBOL_FACET_COMMAND_CONTRACT);
+    EXPECT_EQ(loom_link_module_index_symbol_facet_kind_at(root, 1),
+              LOOM_LINK_SYMBOL_FACET_COMMAND_IMPLEMENTATION);
+
+    const loom_link_plan_root_facet_t contract_root = {
+        /*.symbol_ordinal=*/root->ordinal,
+        /*.kind=*/LOOM_LINK_SYMBOL_FACET_COMMAND_CONTRACT,
+    };
+    loom_link_plan_options_t contract_options = {};
+    contract_options.mode = LOOM_LINK_PLAN_SELECTIVE;
+    contract_options.root_facets = {1, &contract_root};
+    PlanPtr contract_plan = BuildPlan(index, &contract_options);
+    EXPECT_TRUE(ContainsSymbol(contract_plan.get(), root));
+    EXPECT_FALSE(ContainsSymbol(contract_plan.get(), leaf));
+    EXPECT_TRUE(
+        loom_link_plan_contains_facet(contract_plan.get(), root->ordinal,
+                                      LOOM_LINK_SYMBOL_FACET_COMMAND_CONTRACT));
+    EXPECT_FALSE(loom_link_plan_contains_facet(
+        contract_plan.get(), root->ordinal,
+        LOOM_LINK_SYMBOL_FACET_COMMAND_IMPLEMENTATION));
+
+    const loom_link_plan_root_facet_t invalid_root = {
+        /*.symbol_ordinal=*/root->ordinal,
+        /*.kind=*/LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION,
+    };
+    loom_link_plan_options_t invalid_options = {};
+    invalid_options.mode = LOOM_LINK_PLAN_SELECTIVE;
+    invalid_options.root_facets = {1, &invalid_root};
+    PlanPtr invalid_plan;
+    IREE_EXPECT_STATUS_IS(
+        IREE_STATUS_INVALID_ARGUMENT,
+        BuildPlanStatus(index, &invalid_options, &invalid_plan));
+
+    const loom_link_plan_root_facet_t implementation_root = {
+        /*.symbol_ordinal=*/root->ordinal,
+        /*.kind=*/LOOM_LINK_SYMBOL_FACET_COMMAND_IMPLEMENTATION,
+    };
+    loom_link_plan_options_t implementation_options = {};
+    implementation_options.mode = LOOM_LINK_PLAN_SELECTIVE;
+    implementation_options.root_facets = {1, &implementation_root};
+    PlanPtr implementation_plan = BuildPlan(index, &implementation_options);
+    EXPECT_TRUE(ContainsSymbol(implementation_plan.get(), root));
+    EXPECT_TRUE(ContainsSymbol(implementation_plan.get(), leaf));
+    EXPECT_TRUE(
+        loom_link_plan_contains_facet(implementation_plan.get(), root->ordinal,
+                                      LOOM_LINK_SYMBOL_FACET_COMMAND_CONTRACT));
+    EXPECT_TRUE(loom_link_plan_contains_facet(
+        implementation_plan.get(), root->ordinal,
+        LOOM_LINK_SYMBOL_FACET_COMMAND_IMPLEMENTATION));
+  };
+
+  IndexPtr materialized_index = CreateIndex();
+  AddMaterialized(materialized_index.get(), module, IREE_SV("materialized"),
+                  LOOM_LINK_PROVIDER_ROLE_INPUT);
+  verify_index(materialized_index.get());
+
+  IndexPtr text_index = CreateIndex();
+  AddText(text_index.get(), source, IREE_SV("module.loom"),
+          LOOM_LINK_PROVIDER_ROLE_INPUT);
+  verify_index(text_index.get());
 
   IndexPtr bytecode_index = CreateIndex();
   AddBytecode(bytecode_index.get(), bytecode, IREE_SV("module.loombc"),

--- a/loom/src/loom/link/symbol_facet.c
+++ b/loom/src/loom/link/symbol_facet.c
@@ -1,0 +1,133 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/link/symbol_facet.h"
+
+#include "loom/ir/ir.h"
+
+static_assert((LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT >> 8) ==
+                  LOOM_DIALECT_KERNEL,
+              "kernel facets must remain in the kernel dialect namespace");
+static_assert((LOOM_LINK_SYMBOL_FACET_COMMAND_CONTRACT >> 8) ==
+                  LOOM_DIALECT_COMMAND,
+              "command facets must remain in the command dialect namespace");
+
+typedef enum loom_link_symbol_facet_family_e {
+  LOOM_LINK_SYMBOL_FACET_FAMILY_DEFINITION = 0,
+  LOOM_LINK_SYMBOL_FACET_FAMILY_KERNEL = 1,
+  LOOM_LINK_SYMBOL_FACET_FAMILY_COMMAND = 2,
+} loom_link_symbol_facet_family_t;
+
+// Returns the one semantic facet family selected by structural interfaces.
+// This is the single policy point to extend when another symbol interface
+// gains independently selectable linker projections.
+static loom_link_symbol_facet_family_t loom_link_symbol_facet_family(
+    loom_symbol_interface_flags_t interfaces) {
+  const bool is_kernel =
+      iree_any_bit_set(interfaces, LOOM_SYMBOL_INTERFACE_KERNEL);
+  const bool is_command =
+      iree_any_bit_set(interfaces, LOOM_SYMBOL_INTERFACE_COMMAND_PROGRAM);
+  IREE_ASSERT(!(is_kernel && is_command));
+  if (is_kernel) return LOOM_LINK_SYMBOL_FACET_FAMILY_KERNEL;
+  if (is_command) return LOOM_LINK_SYMBOL_FACET_FAMILY_COMMAND;
+  return LOOM_LINK_SYMBOL_FACET_FAMILY_DEFINITION;
+}
+
+loom_link_symbol_facet_schema_t loom_link_symbol_facet_schema_classify(
+    loom_symbol_interface_flags_t interfaces, uint8_t root_region_count,
+    uint8_t body_region_index_plus_one,
+    uint8_t kernel_configuration_region_index_plus_one) {
+  loom_link_symbol_facet_schema_t schema = {
+      .interfaces = interfaces,
+      .root_region_count = root_region_count,
+      .body_region_index_plus_one = body_region_index_plus_one,
+      .kernel_configuration_region_index_plus_one =
+          kernel_configuration_region_index_plus_one,
+      .facet_count = 1,
+  };
+  switch (loom_link_symbol_facet_family(interfaces)) {
+    case LOOM_LINK_SYMBOL_FACET_FAMILY_KERNEL:
+      IREE_ASSERT(!body_region_index_plus_one ||
+                  body_region_index_plus_one !=
+                      kernel_configuration_region_index_plus_one);
+      schema.facet_count += kernel_configuration_region_index_plus_one != 0;
+      schema.facet_count += body_region_index_plus_one != 0;
+      IREE_ASSERT_EQ(schema.facet_count, root_region_count + 1);
+      break;
+    case LOOM_LINK_SYMBOL_FACET_FAMILY_COMMAND:
+      IREE_ASSERT_EQ(kernel_configuration_region_index_plus_one, 0);
+      schema.facet_count += body_region_index_plus_one != 0;
+      IREE_ASSERT_EQ(schema.facet_count, root_region_count + 1);
+      break;
+    case LOOM_LINK_SYMBOL_FACET_FAMILY_DEFINITION:
+      break;
+  }
+  return schema;
+}
+
+loom_link_symbol_facet_kind_t loom_link_symbol_facet_schema_kind_at(
+    const loom_link_symbol_facet_schema_t* schema, uint8_t ordinal) {
+  if (!schema || ordinal >= schema->facet_count) {
+    return LOOM_LINK_SYMBOL_FACET_INVALID;
+  }
+  switch (loom_link_symbol_facet_family(schema->interfaces)) {
+    case LOOM_LINK_SYMBOL_FACET_FAMILY_KERNEL: {
+      uint8_t next_ordinal = 0;
+      if (ordinal == next_ordinal++) {
+        return LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT;
+      }
+      if (schema->kernel_configuration_region_index_plus_one != 0 &&
+          ordinal == next_ordinal++) {
+        return LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION;
+      }
+      if (schema->body_region_index_plus_one != 0 && ordinal == next_ordinal) {
+        return LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION;
+      }
+      break;
+    }
+    case LOOM_LINK_SYMBOL_FACET_FAMILY_COMMAND:
+      return ordinal == 0 ? LOOM_LINK_SYMBOL_FACET_COMMAND_CONTRACT
+                          : LOOM_LINK_SYMBOL_FACET_COMMAND_IMPLEMENTATION;
+    case LOOM_LINK_SYMBOL_FACET_FAMILY_DEFINITION:
+      return LOOM_LINK_SYMBOL_FACET_DEFINITION;
+  }
+  IREE_ASSERT_UNREACHABLE("facet ordinal is absent from its classified schema");
+  return LOOM_LINK_SYMBOL_FACET_INVALID;
+}
+
+loom_link_symbol_facet_kind_t loom_link_symbol_facet_schema_source_root_kind(
+    const loom_link_symbol_facet_schema_t* schema,
+    uint8_t source_root_region_index_plus_one) {
+  if (!schema ||
+      source_root_region_index_plus_one > schema->root_region_count) {
+    return LOOM_LINK_SYMBOL_FACET_INVALID;
+  }
+  if (source_root_region_index_plus_one == 0) {
+    return loom_link_symbol_facet_schema_kind_at(schema, 0);
+  }
+  switch (loom_link_symbol_facet_family(schema->interfaces)) {
+    case LOOM_LINK_SYMBOL_FACET_FAMILY_KERNEL:
+      if (source_root_region_index_plus_one ==
+          schema->kernel_configuration_region_index_plus_one) {
+        return LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION;
+      }
+      if (source_root_region_index_plus_one ==
+          schema->body_region_index_plus_one) {
+        return LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION;
+      }
+      break;
+    case LOOM_LINK_SYMBOL_FACET_FAMILY_COMMAND:
+      if (source_root_region_index_plus_one ==
+          schema->body_region_index_plus_one) {
+        return LOOM_LINK_SYMBOL_FACET_COMMAND_IMPLEMENTATION;
+      }
+      break;
+    case LOOM_LINK_SYMBOL_FACET_FAMILY_DEFINITION:
+      return LOOM_LINK_SYMBOL_FACET_DEFINITION;
+  }
+  IREE_ASSERT_UNREACHABLE("source root is absent from its classified schema");
+  return LOOM_LINK_SYMBOL_FACET_INVALID;
+}

--- a/loom/src/loom/link/symbol_facet.h
+++ b/loom/src/loom/link/symbol_facet.h
@@ -1,0 +1,81 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Linker-owned semantic projections of symbol definitions.
+
+#ifndef LOOM_LINK_SYMBOL_FACET_H_
+#define LOOM_LINK_SYMBOL_FACET_H_
+
+#include "iree/base/api.h"
+#include "loom/ir/attribute_schema.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Stable semantic identity for one linker-owned symbol projection.
+//
+// Dialect-specific values use the defining dialect ID in the high byte and a
+// manually assigned local ID in the low byte. Provider bytecode retains
+// physical source-root indices; the module index translates those indices to
+// these semantic identities before planning decisions are made.
+typedef uint16_t loom_link_symbol_facet_kind_t;
+enum loom_link_symbol_facet_kind_e {
+  LOOM_LINK_SYMBOL_FACET_INVALID = 0,
+  LOOM_LINK_SYMBOL_FACET_DEFINITION = 0x0001,
+  LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT = 0x1001,
+  LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION = 0x1002,
+  LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION = 0x1003,
+  LOOM_LINK_SYMBOL_FACET_COMMAND_CONTRACT = 0x1E01,
+  LOOM_LINK_SYMBOL_FACET_COMMAND_IMPLEMENTATION = 0x1E02,
+};
+
+// Compact source-role schema used to classify one indexed symbol's facets.
+// This is derived once from existing structural interfaces and region roles;
+// operation definitions do not carry linker metadata.
+typedef struct loom_link_symbol_facet_schema_t {
+  // Structural symbol interfaces declared by the defining operation.
+  loom_symbol_interface_flags_t interfaces;
+  // Number of root region slots declared by the defining operation.
+  uint8_t root_region_count;
+  // Function body source root region index plus one, or zero when absent.
+  uint8_t body_region_index_plus_one;
+  // Kernel configuration source root region index plus one, or zero when
+  // absent.
+  uint8_t kernel_configuration_region_index_plus_one;
+  // Number of distinct semantic facets exposed by the symbol.
+  uint8_t facet_count;
+} loom_link_symbol_facet_schema_t;
+
+static_assert(sizeof(loom_link_symbol_facet_schema_t) == 8,
+              "link symbol facet schemas must remain 8 bytes");
+
+// Classifies existing structural symbol metadata into a compact linker
+// schema. Kernel and command interfaces currently own every root on their
+// defining operations; adding an auxiliary root to either interface must
+// update this classifier rather than creating another physical-root facet.
+loom_link_symbol_facet_schema_t loom_link_symbol_facet_schema_classify(
+    loom_symbol_interface_flags_t interfaces, uint8_t root_region_count,
+    uint8_t body_region_index_plus_one,
+    uint8_t kernel_configuration_region_index_plus_one);
+
+// Returns semantic facet |ordinal| from |schema|, or INVALID when ordinal is
+// out of range.
+loom_link_symbol_facet_kind_t loom_link_symbol_facet_schema_kind_at(
+    const loom_link_symbol_facet_schema_t* schema, uint8_t ordinal);
+
+// Classifies a physical source root as one semantic facet, or INVALID when the
+// source root is outside or unaccounted for by |schema|. Zero names the symbol
+// contract; positive values name one-based root-region slots.
+loom_link_symbol_facet_kind_t loom_link_symbol_facet_schema_source_root_kind(
+    const loom_link_symbol_facet_schema_t* schema,
+    uint8_t source_root_region_index_plus_one);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LOOM_LINK_SYMBOL_FACET_H_


### PR DESCRIPTION
Loom's linker previously exposed a symbol contract and each physical root region as independent graph facets. That happened to describe today's kernel layout, but it also made provider representation details part of the planning API: ordinary multi-region definitions acquired bogus independent facets, command programs could not name their contract and implementation separately, and callers had to know source-region ordinals.

This change makes facets semantic linker identities. Ordinary symbols expose a single Definition facet; kernels expose Contract, Configuration, and Implementation; and command programs expose Contract and Implementation. The kernel configuration product now requests its role directly, and selective command planning can stop at the command contract without accidentally pulling the command body.

One linker-local policy classifies those roles from the structural metadata that providers already publish. Materialized, text, and bytecode providers all derive the same compact schema while they are indexed, and existing dependency edges are translated as the planner traverses them. This adds no operation metadata, bytecode table, module walk, string matching, or copied payload.

Locked optimized benchmark coverage varies the unopened kernel implementation from 42 bytes through 1 MiB. Semantic configuration planning remains 0.925–0.954 microseconds and fits O(1) at 0.952 microseconds with 5% RMS; configuration projection remains 4.060–4.135 microseconds and fits O(1) at 4.142 microseconds with 2% RMS. Every plan selects the same two symbols and three semantic facets regardless of implementation size.

Keeping the policy centralized is deliberate. New semantic projections have one reviewable place to define their ownership, and a future operation interface can replace that classifier without changing the planner or product consumers. The result is a representation-independent graph boundary for the body-blind command and kernel products that follow.
