### PR TITLE
[Runtime] Add portable open-file resizing

### DIFF
--- a/runtime/src/iree/io/file_contents_test.cc
+++ b/runtime/src/iree/io/file_contents_test.cc
@@ -272,6 +272,30 @@ TEST(FileContents, CreateOverwritesSharedAsyncFileAndResizes) {
   iree_io_file_contents_free(read_contents);
 }
 
+TEST(FileContents, ResizeOpenFilePreservesPrefixAcrossShrinkAndExtend) {
+  iree::testing::TempFilePath path("iree_file_contents_test");
+  const uint8_t initial_contents[] = {0x11, 0x22, 0x33, 0x44};
+  IREE_ASSERT_OK(iree_io_file_contents_write(
+      path.path_view(),
+      iree_make_const_byte_span(initial_contents, sizeof(initial_contents)),
+      iree_allocator_system()));
+
+  iree_io_file_handle_t* handle = NULL;
+  IREE_ASSERT_OK(iree_io_file_handle_open(
+      IREE_IO_FILE_MODE_READ | IREE_IO_FILE_MODE_WRITE, path.path_view(),
+      iree_allocator_system(), &handle));
+  IREE_EXPECT_OK(iree_io_file_handle_resize(handle, 2));
+  IREE_EXPECT_OK(iree_io_file_handle_resize(handle, 6));
+  iree_io_file_handle_release(handle);
+
+  iree_io_file_contents_t* read_contents = NULL;
+  IREE_ASSERT_OK(iree_io_file_contents_read(
+      path.path_view(), iree_allocator_system(), &read_contents));
+  ASSERT_EQ(read_contents->const_buffer.data_length, 6);
+  EXPECT_EQ(memcmp(read_contents->const_buffer.data, initial_contents, 2), 0);
+  iree_io_file_contents_free(read_contents);
+}
+
 #if defined(IREE_PLATFORM_WINDOWS)
 
 TEST(FileContents, ReadWriteLongUtf8Path) {

--- a/runtime/src/iree/io/file_handle.c
+++ b/runtime/src/iree/io/file_handle.c
@@ -188,6 +188,85 @@ iree_io_file_handle_flush(iree_io_file_handle_t* handle) {
   return status;
 }
 
+static iree_status_t iree_io_platform_fd_resize(int fd, uint64_t new_size) {
+#if IREE_FILE_IO_ENABLE
+
+#if defined(IREE_PLATFORM_WINDOWS)
+  if (new_size > INT64_MAX) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "file size %" PRIu64
+                            " exceeds the Windows signed 64-bit limit",
+                            new_size);
+  }
+  intptr_t os_handle = _get_osfhandle(fd);
+  if (os_handle == -1) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid file descriptor");
+  }
+  FILE_END_OF_FILE_INFO end_of_file_info = {0};
+  end_of_file_info.EndOfFile.QuadPart = (LONGLONG)new_size;
+  if (!SetFileInformationByHandle((HANDLE)os_handle, FileEndOfFileInfo,
+                                  &end_of_file_info,
+                                  sizeof(end_of_file_info))) {
+    return iree_make_status(iree_status_code_from_win32_error(GetLastError()),
+                            "unable to resize file to %" PRIu64 " bytes",
+                            new_size);
+  }
+#else
+  off_t platform_size = (off_t)new_size;
+  if (platform_size < 0 || (uint64_t)platform_size != new_size) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "file size %" PRIu64
+                            " exceeds the platform file offset limit",
+                            new_size);
+  }
+  if (ftruncate(fd, platform_size) == -1) {
+    return iree_make_status(iree_status_code_from_errno(errno),
+                            "unable to resize file to %" PRIu64 " bytes",
+                            new_size);
+  }
+#endif  // IREE_PLATFORM_WINDOWS
+  return iree_ok_status();
+
+#else
+  return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                          "file support has been compiled out of this binary; "
+                          "set IREE_FILE_IO_ENABLE=1 to include it");
+#endif  // IREE_FILE_IO_ENABLE
+}
+
+IREE_API_EXPORT iree_status_t
+iree_io_file_handle_resize(iree_io_file_handle_t* handle, uint64_t new_size) {
+  IREE_ASSERT_ARGUMENT(handle);
+  if (!iree_all_bits_set(handle->access, IREE_IO_FILE_ACCESS_WRITE)) {
+    return iree_make_status(IREE_STATUS_PERMISSION_DENIED,
+                            "file handle does not allow writes");
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, (int64_t)new_size);
+  iree_status_t status = iree_ok_status();
+  switch (handle->primitive.type) {
+    case IREE_IO_FILE_HANDLE_TYPE_HOST_ALLOCATION: {
+      status =
+          iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                           "host allocation file handles have fixed extents");
+      break;
+    }
+    case IREE_IO_FILE_HANDLE_TYPE_FD: {
+      status = iree_io_platform_fd_resize(handle->primitive.value.fd, new_size);
+      break;
+    }
+    default: {
+      status = iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                                "resize not supported on handle type %d",
+                                (int)handle->primitive.type);
+      break;
+    }
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 //===----------------------------------------------------------------------===//
 // iree_io_file_handle_t utilities
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/io/file_handle.h
+++ b/runtime/src/iree/io/file_handle.h
@@ -197,6 +197,15 @@ static inline iree_io_file_handle_primitive_value_t iree_io_file_handle_value(
 IREE_API_EXPORT iree_status_t
 iree_io_file_handle_flush(iree_io_file_handle_t* handle);
 
+// Resizes the platform file backing |handle| to |new_size| bytes.
+//
+// The handle must allow IREE_IO_FILE_ACCESS_WRITE. Shrinking discards the
+// truncated range; the contents of a newly extended range are
+// platform-defined. Host-allocation handles have fixed extents and cannot be
+// resized.
+IREE_API_EXPORT iree_status_t
+iree_io_file_handle_resize(iree_io_file_handle_t* handle, uint64_t new_size);
+
 //===----------------------------------------------------------------------===//
 // iree_io_file_handle_t platform files
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Adds a handle-stable resize operation for writable descriptor-backed files so asynchronous imports can observe truncation without reopening a pathname.

POSIX uses ftruncate and Windows uses SetFileInformationByHandle. Fixed host allocations and sizes outside the platform offset range fail explicitly; extension bytes retain platform-defined semantics.