### PR TITLE
[HAL/Vulkan] Share buffers across queue families

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/allocator.c
+++ b/runtime/src/iree/hal/drivers/vulkan/allocator.c
@@ -13,6 +13,7 @@
 #include "iree/base/threading/mutex.h"
 #include "iree/hal/drivers/vulkan/atomic.h"
 #include "iree/hal/drivers/vulkan/buffer.h"
+#include "iree/hal/drivers/vulkan/device_plan.h"
 #include "iree/hal/drivers/vulkan/queue.h"
 #include "iree/hal/drivers/vulkan/slab_provider.h"
 #include "iree/hal/drivers/vulkan/sparse_buffer.h"
@@ -46,6 +47,18 @@ typedef struct iree_hal_vulkan_allocator_memory_placement_t {
   // HAL memory type exposed by allocated buffers.
   iree_hal_memory_type_t memory_type;
 } iree_hal_vulkan_allocator_memory_placement_t;
+
+typedef struct iree_hal_vulkan_allocator_buffer_sharing_t {
+  // Vulkan sharing mode derived from the buffer queue affinity.
+  VkSharingMode mode;
+
+  // Number of queue_family_indices entries passed to Vulkan. This is zero for
+  // exclusive sharing and greater than one for concurrent sharing.
+  uint32_t queue_family_index_count;
+
+  // Deduplicated Vulkan queue families used for concurrent sharing.
+  uint32_t queue_family_indices[IREE_HAL_VULKAN_MAX_QUEUE_LANES];
+} iree_hal_vulkan_allocator_buffer_sharing_t;
 
 typedef struct iree_hal_vulkan_allocator_pool_pair_t {
   // Slab provider acquiring whole Vulkan buffers for this memory type.
@@ -148,6 +161,13 @@ struct iree_hal_vulkan_allocator_t {
   // Queue affinity bits supported by this logical device.
   iree_hal_queue_affinity_t queue_affinity_mask;
 
+  // Number of initialized queue_families entries.
+  iree_host_size_t queue_family_count;
+
+  // Vulkan queue families addressable through HAL queue affinities.
+  iree_hal_vulkan_allocator_queue_family_t
+      queue_families[IREE_HAL_VULKAN_MAX_QUEUE_LANES];
+
   // Internal queue lane used to perform sparse memory binding. Borrowed.
   iree_hal_vulkan_queue_t* sparse_binding_queue;
 
@@ -213,6 +233,68 @@ static void iree_hal_vulkan_allocator_deinitialize_virtual_memory_registry(
   iree_slim_mutex_deinitialize(&allocator->virtual_memory_mutex);
 }
 
+static iree_status_t iree_hal_vulkan_allocator_validate_queue_family_mappings(
+    const iree_hal_vulkan_physical_device_snapshot_t* physical_device,
+    iree_hal_queue_affinity_t queue_affinity_mask,
+    iree_host_size_t queue_family_count,
+    const iree_hal_vulkan_allocator_queue_family_t* queue_families) {
+  if (queue_family_count == 0 ||
+      queue_family_count > IREE_HAL_VULKAN_MAX_QUEUE_LANES) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "Vulkan allocator queue family mapping count %" PRIhsz
+        " is outside the supported range [1, %d]",
+        queue_family_count, IREE_HAL_VULKAN_MAX_QUEUE_LANES);
+  }
+  iree_hal_queue_affinity_t mapped_queue_affinity = 0;
+  for (iree_host_size_t i = 0; i < queue_family_count; ++i) {
+    const iree_hal_vulkan_allocator_queue_family_t* queue_family =
+        &queue_families[i];
+    if (iree_hal_queue_affinity_count(queue_family->queue_affinity) != 1) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "Vulkan allocator queue family mapping %" PRIhsz
+                              " must select exactly one HAL queue affinity bit",
+                              i);
+    }
+    if ((queue_family->queue_affinity & queue_affinity_mask) !=
+        queue_family->queue_affinity) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "Vulkan allocator queue family mapping %" PRIhsz
+                              " selects affinity 0x%016" PRIx64
+                              " outside the device mask 0x%016" PRIx64,
+                              i, queue_family->queue_affinity,
+                              queue_affinity_mask);
+    }
+    if (queue_family->family_index >= physical_device->queue_family_count) {
+      return iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "Vulkan allocator queue family mapping %" PRIhsz
+          " selects family %u but the physical device exposes %u families",
+          i, queue_family->family_index, physical_device->queue_family_count);
+    }
+    for (iree_host_size_t j = 0; j < i; ++j) {
+      if (queue_families[j].queue_affinity == queue_family->queue_affinity &&
+          queue_families[j].family_index != queue_family->family_index) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "Vulkan allocator queue affinity 0x%016" PRIx64
+                                " maps to conflicting families %u and %u",
+                                queue_family->queue_affinity,
+                                queue_families[j].family_index,
+                                queue_family->family_index);
+      }
+    }
+    mapped_queue_affinity |= queue_family->queue_affinity;
+  }
+  if (mapped_queue_affinity != queue_affinity_mask) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "Vulkan allocator queue family mappings cover affinity 0x%016" PRIx64
+        " but the device exposes 0x%016" PRIx64,
+        mapped_queue_affinity, queue_affinity_mask);
+  }
+  return iree_ok_status();
+}
+
 iree_status_t iree_hal_vulkan_allocator_create(
     iree_hal_device_t* parent_device, const iree_hal_vulkan_device_syms_t* syms,
     VkDevice logical_device,
@@ -220,6 +302,8 @@ iree_status_t iree_hal_vulkan_allocator_create(
     iree_hal_vulkan_features_t enabled_features,
     iree_hal_vulkan_device_extensions_t enabled_extensions,
     iree_hal_queue_affinity_t queue_affinity_mask,
+    iree_host_size_t queue_family_count,
+    const iree_hal_vulkan_allocator_queue_family_t* queue_families,
     iree_hal_vulkan_queue_t* sparse_binding_queue,
     iree_async_proactor_t* proactor, iree_allocator_t host_allocator,
     iree_hal_allocator_t** out_allocator) {
@@ -227,9 +311,13 @@ iree_status_t iree_hal_vulkan_allocator_create(
   IREE_ASSERT_ARGUMENT(syms);
   IREE_ASSERT_ARGUMENT(logical_device);
   IREE_ASSERT_ARGUMENT(physical_device);
+  IREE_ASSERT_ARGUMENT(queue_families);
   IREE_ASSERT_ARGUMENT(proactor);
   IREE_ASSERT_ARGUMENT(out_allocator);
   *out_allocator = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_vulkan_allocator_validate_queue_family_mappings(
+      physical_device, queue_affinity_mask, queue_family_count,
+      queue_families));
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_hal_vulkan_allocator_t* allocator = NULL;
@@ -254,6 +342,9 @@ iree_status_t iree_hal_vulkan_allocator_create(
   allocator->enabled_features = enabled_features;
   allocator->enabled_extensions = enabled_extensions;
   allocator->queue_affinity_mask = queue_affinity_mask;
+  allocator->queue_family_count = queue_family_count;
+  memcpy(allocator->queue_families, queue_families,
+         queue_family_count * sizeof(queue_families[0]));
   allocator->sparse_binding_queue = sparse_binding_queue;
   iree_slim_mutex_initialize(&allocator->virtual_memory_mutex);
 
@@ -1190,6 +1281,49 @@ static VkBufferUsageFlags iree_hal_vulkan_buffer_usage_from_hal(
   return usage;
 }
 
+static iree_status_t iree_hal_vulkan_allocator_resolve_buffer_sharing(
+    const iree_hal_vulkan_allocator_t* allocator,
+    iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_vulkan_allocator_buffer_sharing_t* out_sharing) {
+  memset(out_sharing, 0, sizeof(*out_sharing));
+  out_sharing->mode = VK_SHARING_MODE_EXCLUSIVE;
+
+  if (iree_hal_queue_affinity_is_any(queue_affinity)) {
+    queue_affinity = allocator->queue_affinity_mask;
+  } else {
+    iree_hal_queue_affinity_and_into(queue_affinity,
+                                     allocator->queue_affinity_mask);
+  }
+  uint32_t selected_family_count = 0;
+  for (iree_host_size_t i = 0; i < allocator->queue_family_count; ++i) {
+    const iree_hal_vulkan_allocator_queue_family_t* queue_family =
+        &allocator->queue_families[i];
+    if (!iree_any_bit_set(queue_affinity, queue_family->queue_affinity)) {
+      continue;
+    }
+    bool is_duplicate = false;
+    for (uint32_t j = 0; j < selected_family_count; ++j) {
+      if (out_sharing->queue_family_indices[j] == queue_family->family_index) {
+        is_duplicate = true;
+        break;
+      }
+    }
+    if (!is_duplicate) {
+      out_sharing->queue_family_indices[selected_family_count++] =
+          queue_family->family_index;
+    }
+  }
+  if (selected_family_count == 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "Vulkan buffer has no accessible queue family");
+  }
+  if (selected_family_count > 1) {
+    out_sharing->mode = VK_SHARING_MODE_CONCURRENT;
+    out_sharing->queue_family_index_count = selected_family_count;
+  }
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_vulkan_allocator_create_buffer_handle(
     iree_hal_vulkan_allocator_t* allocator,
     const iree_hal_buffer_params_t* params, iree_device_size_t allocation_size,
@@ -1197,13 +1331,21 @@ static iree_status_t iree_hal_vulkan_allocator_create_buffer_handle(
     VkBuffer* out_buffer) {
   *out_buffer = VK_NULL_HANDLE;
 
+  iree_hal_vulkan_allocator_buffer_sharing_t sharing;
+  IREE_RETURN_IF_ERROR(iree_hal_vulkan_allocator_resolve_buffer_sharing(
+      allocator, params->queue_affinity, &sharing));
+
   VkBufferCreateInfo create_info = {
       .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
       .pNext = create_info_pnext,
       .flags = create_flags,
       .size = (VkDeviceSize)allocation_size,
       .usage = iree_hal_vulkan_buffer_usage_from_hal(allocator, params->usage),
-      .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+      .sharingMode = sharing.mode,
+      .queueFamilyIndexCount = sharing.queue_family_index_count,
+      .pQueueFamilyIndices = sharing.queue_family_index_count
+                                 ? sharing.queue_family_indices
+                                 : NULL,
   };
   return iree_vkCreateBuffer(IREE_VULKAN_DEVICE(&allocator->syms),
                              allocator->logical_device, &create_info,

--- a/runtime/src/iree/hal/drivers/vulkan/allocator.c
+++ b/runtime/src/iree/hal/drivers/vulkan/allocator.c
@@ -2168,11 +2168,12 @@ static iree_status_t iree_hal_vulkan_allocator_import_buffer(
   iree_hal_buffer_params_t compat_params = *params;
   iree_hal_vulkan_allocator_normalize_host_allocation_import_params(
       &compat_params);
+  iree_hal_buffer_params_t query_params = compat_params;
   iree_hal_buffer_compatibility_t compatibility =
       IREE_HAL_BUFFER_COMPATIBILITY_NONE;
   if (iree_status_is_ok(status)) {
     compatibility = iree_hal_vulkan_allocator_query_buffer_compatibility(
-        base_allocator, &compat_params, &allocation_size);
+        base_allocator, &query_params, &allocation_size);
     if (!iree_all_bits_set(compatibility,
                            IREE_HAL_BUFFER_COMPATIBILITY_IMPORTABLE)) {
 #if IREE_STATUS_MODE
@@ -2244,7 +2245,10 @@ static iree_status_t iree_hal_vulkan_allocator_import_buffer(
     status = iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
         "allocator cannot find a Vulkan memory type compatible with the "
-        "imported host pointer");
+        "imported host pointer; buffer memory type bits=0x%08" PRIx32
+        ", host pointer memory type bits=0x%08" PRIx32,
+        memory_requirements.memoryTypeBits,
+        host_pointer_properties.memoryTypeBits);
   }
 
   VkDeviceMemory device_memory = VK_NULL_HANDLE;

--- a/runtime/src/iree/hal/drivers/vulkan/allocator.h
+++ b/runtime/src/iree/hal/drivers/vulkan/allocator.h
@@ -23,6 +23,15 @@ extern "C" {
 typedef struct iree_hal_vulkan_allocator_t iree_hal_vulkan_allocator_t;
 typedef struct iree_hal_vulkan_queue_t iree_hal_vulkan_queue_t;
 
+// Maps one HAL queue affinity bit to its Vulkan queue family.
+typedef struct iree_hal_vulkan_allocator_queue_family_t {
+  // HAL queue affinity bit selecting this family.
+  iree_hal_queue_affinity_t queue_affinity;
+
+  // Vulkan queue family index used by the selected queue.
+  uint32_t family_index;
+} iree_hal_vulkan_allocator_queue_family_t;
+
 typedef enum iree_hal_vulkan_queue_alloca_strategy_e {
   // Invalid zero value used to catch uninitialized alloca plans.
   IREE_HAL_VULKAN_QUEUE_ALLOCA_STRATEGY_NONE = 0,
@@ -59,6 +68,8 @@ iree_status_t iree_hal_vulkan_allocator_create(
     iree_hal_vulkan_features_t enabled_features,
     iree_hal_vulkan_device_extensions_t enabled_extensions,
     iree_hal_queue_affinity_t queue_affinity_mask,
+    iree_host_size_t queue_family_count,
+    const iree_hal_vulkan_allocator_queue_family_t* queue_families,
     iree_hal_vulkan_queue_t* sparse_binding_queue,
     iree_async_proactor_t* proactor, iree_allocator_t host_allocator,
     iree_hal_allocator_t** out_allocator);

--- a/runtime/src/iree/hal/drivers/vulkan/logical_device.c
+++ b/runtime/src/iree/hal/drivers/vulkan/logical_device.c
@@ -1780,10 +1780,21 @@ static iree_status_t iree_hal_vulkan_logical_device_initialize_proactor(
 static iree_status_t iree_hal_vulkan_logical_device_initialize_allocator(
     iree_hal_vulkan_logical_device_t* device) {
   IREE_ASSERT_ARGUMENT(device);
+  const iree_hal_vulkan_allocator_queue_family_t queue_families[] = {
+      {
+          .queue_affinity = device->queues.compute.selection.affinity,
+          .family_index = device->queues.compute.selection.family_index,
+      },
+      {
+          .queue_affinity = device->queues.transfer.selection.affinity,
+          .family_index = device->queues.transfer.selection.family_index,
+      },
+  };
   return iree_hal_vulkan_allocator_create(
       (iree_hal_device_t*)device, &device->syms, device->logical_device,
       &device->physical_device, device->enabled_features,
       device->enabled_extensions, device->queues.affinity_mask,
+      IREE_ARRAYSIZE(queue_families), queue_families,
       device->queues.sparse_binding_lane, device->proactor,
       device->host_allocator, &device->device_allocator);
 }


### PR DESCRIPTION
Carries the device's HAL queue-affinity-to-Vulkan-family mapping into buffer allocation. Buffers visible to multiple distinct families use concurrent sharing with exactly those deduplicated families; single-family buffers remain exclusive.

Host-pointer imports preserve the normalized placement parameters used for the import even when compatibility probing rewrites a copy for sparse fallback. Memory-type failures report both intersected masks.