### PR TITLE
[HAL/Vulkan] Preserve absent buffer device addresses

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
@@ -105,6 +105,16 @@ iree_runtime_cc_test(
 )
 
 iree_runtime_cc_test(
+    name = "buffer_test",
+    srcs = ["buffer_test.cc"],
+    deps = [
+        ":vulkan",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_test(
     name = "command_buffer_test",
     srcs = ["command_buffer_test.cc"],
     deps = [

--- a/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
@@ -125,6 +125,21 @@ endif()
 if(IREE_HAL_DRIVER_VULKAN)
 iree_cc_test(
   NAME
+    buffer_test
+  SRCS
+    "buffer_test.cc"
+  DEPS
+    ::vulkan
+    iree::testing::gtest
+    iree::testing::gtest_main
+  LABELS
+    "iree-build-requirement=runtime.hal.vulkan"
+)
+endif()
+
+if(IREE_HAL_DRIVER_VULKAN)
+iree_cc_test(
+  NAME
     command_buffer_test
   SRCS
     "command_buffer_test.cc"

--- a/runtime/src/iree/hal/drivers/vulkan/buffer.c
+++ b/runtime/src/iree/hal/drivers/vulkan/buffer.c
@@ -392,10 +392,20 @@ iree_status_t iree_hal_vulkan_buffer_device_address(
   }
   iree_hal_vulkan_buffer_t* vulkan_buffer =
       iree_hal_vulkan_buffer_cast(allocated_buffer);
+  if (vulkan_buffer->device_address == 0) {
+    *out_device_address = 0;
+    return iree_ok_status();
+  }
   iree_device_size_t byte_offset = 0;
   IREE_RETURN_IF_ERROR(iree_hal_vulkan_buffer_resolve_backing_offset(
       buffer, backing_buffer, /*local_byte_offset=*/0, &byte_offset));
-  *out_device_address = vulkan_buffer->device_address + byte_offset;
+  uint64_t device_address = 0;
+  if (!iree_checked_add_u64(vulkan_buffer->device_address, byte_offset,
+                            &device_address)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "Vulkan buffer device address overflows");
+  }
+  *out_device_address = device_address;
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/hal/drivers/vulkan/buffer.h
+++ b/runtime/src/iree/hal/drivers/vulkan/buffer.h
@@ -85,7 +85,9 @@ iree_status_t iree_hal_vulkan_buffer_handle(iree_hal_buffer_t* buffer,
                                             VkDeviceMemory* out_memory,
                                             VkBuffer* out_handle);
 
-// Returns the Vulkan buffer device address backing |buffer|.
+// Returns the Vulkan buffer device address backing |buffer| plus its byte
+// offset. Returns 0 when the backing buffer has no device address. Fails if the
+// offset cannot be represented in a VkDeviceAddress.
 iree_status_t iree_hal_vulkan_buffer_device_address(
     iree_hal_buffer_t* buffer, VkDeviceAddress* out_device_address);
 

--- a/runtime/src/iree/hal/drivers/vulkan/buffer_test.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/buffer_test.cc
@@ -1,0 +1,152 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/vulkan/buffer.h"
+
+#include <cstdint>
+
+#include "iree/hal/drivers/vulkan/sparse_buffer.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree::hal::vulkan {
+namespace {
+
+static VkDeviceAddress g_sparse_device_address = 0;
+
+static VKAPI_ATTR VkDeviceAddress VKAPI_CALL FakeGetBufferDeviceAddress(
+    VkDevice device, const VkBufferDeviceAddressInfo* address_info) {
+  (void)device;
+  (void)address_info;
+  return g_sparse_device_address;
+}
+
+static VKAPI_ATTR void VKAPI_CALL
+FakeDestroyBuffer(VkDevice device, VkBuffer buffer,
+                  const VkAllocationCallbacks* allocation_callbacks) {
+  (void)device;
+  (void)buffer;
+  (void)allocation_callbacks;
+}
+
+class VulkanBufferTest : public ::testing::Test {
+ protected:
+  void TearDown() override {
+    iree_hal_buffer_release(buffer_);
+    iree_hal_buffer_release(allocated_buffer_);
+  }
+
+  iree_status_t CreateDenseBuffer(iree_device_size_t handle_offset,
+                                  VkDeviceAddress device_address) {
+    iree_hal_vulkan_device_syms_t syms = {};
+    return iree_hal_vulkan_buffer_create_borrowed(
+        &syms, reinterpret_cast<VkDevice>(static_cast<uintptr_t>(0x1000)),
+        iree_hal_buffer_placement_undefined(),
+        IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE, IREE_HAL_MEMORY_ACCESS_ALL,
+        IREE_HAL_BUFFER_USAGE_TRANSFER,
+        /*allocation_size=*/64, handle_offset,
+        /*byte_length=*/16, /*memory_property_flags=*/0,
+        /*non_coherent_atom_size=*/1, VK_NULL_HANDLE,
+        /*mapping_state=*/nullptr,
+        reinterpret_cast<VkBuffer>(static_cast<uintptr_t>(0x2000)),
+        device_address, iree_hal_buffer_release_callback_null(),
+        iree_allocator_system(), &buffer_);
+  }
+
+  iree_status_t CreateSparseSubspan(iree_device_size_t byte_offset,
+                                    VkDeviceAddress device_address) {
+    g_sparse_device_address = device_address;
+    iree_hal_vulkan_device_syms_t syms = {};
+    syms.vkGetBufferDeviceAddress = FakeGetBufferDeviceAddress;
+    syms.vkDestroyBuffer = FakeDestroyBuffer;
+    iree_hal_buffer_placement_t placement =
+        iree_hal_buffer_placement_undefined();
+    placement.device =
+        reinterpret_cast<iree_hal_device_t*>(static_cast<uintptr_t>(0x1000));
+    VkMemoryRequirements memory_requirements = {};
+    memory_requirements.size = 64;
+    memory_requirements.alignment = 1;
+    memory_requirements.memoryTypeBits = 1;
+    iree_status_t status = iree_hal_vulkan_sparse_buffer_create_unbound(
+        &syms, reinterpret_cast<VkDevice>(static_cast<uintptr_t>(0x2000)),
+        placement, IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+        IREE_HAL_MEMORY_ACCESS_ALL, IREE_HAL_BUFFER_USAGE_TRANSFER,
+        /*allocation_size=*/64,
+        /*byte_length=*/64,
+        reinterpret_cast<VkBuffer>(static_cast<uintptr_t>(0x3000)),
+        memory_requirements, iree_allocator_system(), &allocated_buffer_);
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_buffer_subspan(allocated_buffer_, byte_offset,
+                                       /*byte_length=*/16,
+                                       iree_allocator_system(), &buffer_);
+    }
+    return status;
+  }
+
+  iree_hal_buffer_t* allocated_buffer_ = nullptr;
+  iree_hal_buffer_t* buffer_ = nullptr;
+};
+
+TEST_F(VulkanBufferTest, DenseAddressIncludesHandleOffset) {
+  IREE_ASSERT_OK(
+      CreateDenseBuffer(/*handle_offset=*/4, /*device_address=*/0x10000));
+
+  VkDeviceAddress device_address = 0;
+  IREE_ASSERT_OK(
+      iree_hal_vulkan_buffer_device_address(buffer_, &device_address));
+  EXPECT_EQ(device_address, 0x10004u);
+}
+
+TEST_F(VulkanBufferTest, DenseMissingAddressRemainsMissing) {
+  IREE_ASSERT_OK(CreateDenseBuffer(/*handle_offset=*/4, /*device_address=*/0));
+
+  VkDeviceAddress device_address = UINT64_MAX;
+  IREE_ASSERT_OK(
+      iree_hal_vulkan_buffer_device_address(buffer_, &device_address));
+  EXPECT_EQ(device_address, 0u);
+}
+
+TEST_F(VulkanBufferTest, DenseAddressOverflowFails) {
+  IREE_ASSERT_OK(CreateDenseBuffer(/*handle_offset=*/4,
+                                   /*device_address=*/UINT64_MAX - 3));
+
+  VkDeviceAddress device_address = 0;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_OUT_OF_RANGE,
+      iree_hal_vulkan_buffer_device_address(buffer_, &device_address));
+}
+
+TEST_F(VulkanBufferTest, SparseAddressIncludesSubspanOffset) {
+  IREE_ASSERT_OK(
+      CreateSparseSubspan(/*byte_offset=*/4, /*device_address=*/0x10000));
+
+  VkDeviceAddress device_address = 0;
+  IREE_ASSERT_OK(
+      iree_hal_vulkan_buffer_device_address(buffer_, &device_address));
+  EXPECT_EQ(device_address, 0x10004u);
+}
+
+TEST_F(VulkanBufferTest, SparseMissingAddressRemainsMissing) {
+  IREE_ASSERT_OK(CreateSparseSubspan(/*byte_offset=*/4, /*device_address=*/0));
+
+  VkDeviceAddress device_address = UINT64_MAX;
+  IREE_ASSERT_OK(
+      iree_hal_vulkan_buffer_device_address(buffer_, &device_address));
+  EXPECT_EQ(device_address, 0u);
+}
+
+TEST_F(VulkanBufferTest, SparseAddressOverflowFails) {
+  IREE_ASSERT_OK(CreateSparseSubspan(/*byte_offset=*/4,
+                                     /*device_address=*/UINT64_MAX - 3));
+
+  VkDeviceAddress device_address = 0;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_OUT_OF_RANGE,
+      iree_hal_vulkan_buffer_device_address(buffer_, &device_address));
+}
+
+}  // namespace
+}  // namespace iree::hal::vulkan

--- a/runtime/src/iree/hal/drivers/vulkan/sparse_buffer.c
+++ b/runtime/src/iree/hal/drivers/vulkan/sparse_buffer.c
@@ -573,8 +573,18 @@ iree_status_t iree_hal_vulkan_sparse_buffer_device_address(
   }
   iree_hal_vulkan_sparse_buffer_t* vulkan_buffer =
       iree_hal_vulkan_sparse_buffer_cast(allocated_buffer);
-  *out_device_address =
-      vulkan_buffer->device_address + iree_hal_buffer_byte_offset(buffer);
+  if (vulkan_buffer->device_address == 0) {
+    *out_device_address = 0;
+    return iree_ok_status();
+  }
+  const iree_device_size_t byte_offset = iree_hal_buffer_byte_offset(buffer);
+  uint64_t device_address = 0;
+  if (!iree_checked_add_u64(vulkan_buffer->device_address, byte_offset,
+                            &device_address)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "Vulkan sparse buffer device address overflows");
+  }
+  *out_device_address = device_address;
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/hal/drivers/vulkan/sparse_buffer.h
+++ b/runtime/src/iree/hal/drivers/vulkan/sparse_buffer.h
@@ -97,7 +97,9 @@ iree_status_t iree_hal_vulkan_sparse_buffer_handle(iree_hal_buffer_t* buffer,
 iree_status_t iree_hal_vulkan_sparse_buffer_memory_requirements(
     iree_hal_buffer_t* buffer, VkMemoryRequirements* out_memory_requirements);
 
-// Returns the Vulkan buffer device address backing |buffer|.
+// Returns the Vulkan buffer device address backing |buffer| plus its byte
+// offset. Returns 0 when the backing buffer has no device address. Fails if the
+// offset cannot be represented in a VkDeviceAddress.
 iree_status_t iree_hal_vulkan_sparse_buffer_device_address(
     iree_hal_buffer_t* buffer, VkDeviceAddress* out_device_address);
 


### PR DESCRIPTION
`vkGetBufferDeviceAddress` reports zero when a buffer has no usable device address. Dense borrowed-buffer offsets and sparse subspan offsets were previously added unconditionally, turning that absence sentinel into a plausible nonzero pointer. The same unchecked arithmetic could wrap near the end of the 64-bit address space.

Returns zero unchanged before applying offsets and uses `iree_checked_add_u64` to reject unrepresentable addresses with `IREE_STATUS_OUT_OF_RANGE`. Focused coverage exercises ordinary offsets, zero-address propagation, and overflow through both borrowed dense buffers and real sparse-buffer subspans.