### PR TITLE
[HIP] Name the dl target by its owning package

### DIFF
--- a/libhrx/cts/BUILD.bazel
+++ b/libhrx/cts/BUILD.bazel
@@ -177,8 +177,8 @@ hrx_cc_test(
     target_compatible_with = _LINUX_COMPATIBILITY,
     deps = [
         ":amdgpu_executable_test_kernels",
-        "//build_tools:dl",
         "//build_tools/amdgpu:target_map_h",
+        "//build_tools/bazel:dl",
         "//libhrx/src/binding/hip:launch_params",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",


### PR DESCRIPTION
`//libhrx/cts:hip_event_timing_test` depends on `//build_tools:dl`, which does not resolve. `dl` was moved to `//build_tools/bazel` and the `build_tools` root package was deleted outright in #422, so Bazel cannot analyze `//libhrx/...`: `no such package 'build_tools'`. Every other test in the file already names `//build_tools/bazel:dl`.

This is red on main now, in two jobs. `Linux / AMDGPU Build + Host Tests` fails analysis and skips its test step entirely, and `Linux / Presubmit` fails twice over — the clang-tidy sweep hits the same unresolved label, and `Bazel-to-CMake --check` reports drift because regenerating `libhrx/cts/CMakeLists.txt` from the stale label yields `iree::build_tools::dl` where the committed file has `${CMAKE_DL_LIBS}`, which is what `//build_tools/bazel:dl` maps to. Naming the current label settles both.

The label was correct when #210 was written and its CI was green against the main of that moment; #422 landed in the window between that run and the merge. Nothing conflicted, because the rename rewrote five call sites that #210 never touched while #210 added a sixth that #422 could not see, so the merge was textually clean and semantically stale.

Verified on this change: `//libhrx/...` analyzes 227 of 227 targets (226 of 227 without it, failing with the CI error verbatim), builds clean with `--//runtime/config/hal:drivers=amdgpu`, and the host lane the Bazel job runs — `--test_tag_filters=-runtime-resource=amd-gpu` — passes 26 of 26. `bazel_to_cmake.py --check` and buildifier are both clean, and neither is without the change.
