### PR TITLE
[Loom] Bound selective linking at library scale

### DIFF
--- a/loom/binding/c/benchmark/BUILD.bazel
+++ b/loom/binding/c/benchmark/BUILD.bazel
@@ -30,6 +30,17 @@ iree_c_embed_data(
 )
 
 loom_cc_library(
+    name = "benchmark_support",
+    testonly = True,
+    srcs = ["util/benchmark_support.cc"],
+    hdrs = ["util/benchmark_support.h"],
+    deps = [
+        "//loom/binding/c:loomc",
+        "//runtime/src/iree/base",
+    ],
+)
+
+loom_cc_library(
     name = "compile_pool_prototype",
     testonly = True,
     srcs = ["util/compile_pool_prototype.c"],
@@ -49,6 +60,7 @@ loom_cc_library(
     hdrs = ["compile_throughput_benchmark.h"],
     deps = [
         ":benchmark_kernels",
+        ":benchmark_support",
         ":compile_pool_prototype",
         "//loom/binding/c:loomc",
         "//runtime/src/iree/base",

--- a/loom/binding/c/benchmark/BUILD.bazel
+++ b/loom/binding/c/benchmark/BUILD.bazel
@@ -81,3 +81,17 @@ loom_cc_benchmark(
         "//runtime/src/iree/testing:benchmark_main",
     ],
 )
+
+loom_cc_benchmark(
+    name = "link_throughput_benchmark",
+    srcs = ["link_throughput_benchmark.cc"],
+    args = [
+        "--benchmark_filter=Smoke",
+    ],
+    deps = [
+        ":benchmark_support",
+        "//loom/binding/c:loomc",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/testing:benchmark_main",
+    ],
+)

--- a/loom/binding/c/benchmark/CMakeLists.txt
+++ b/loom/binding/c/benchmark/CMakeLists.txt
@@ -27,6 +27,20 @@ iree_c_embed_data(
 
 loom_cc_library(
   NAME
+    benchmark_support
+  HDRS
+    "util/benchmark_support.h"
+  SRCS
+    "util/benchmark_support.cc"
+  DEPS
+    iree::base
+    loom::binding::c::loomc
+  TESTONLY
+  PUBLIC
+)
+
+loom_cc_library(
+  NAME
     compile_pool_prototype
   HDRS
     "util/compile_pool_prototype.h"
@@ -50,6 +64,7 @@ loom_cc_library(
     "compile_throughput_benchmark.cc"
   DEPS
     ::benchmark_kernels
+    ::benchmark_support
     ::compile_pool_prototype
     iree::base
     iree::third_party::google_benchmark

--- a/loom/binding/c/benchmark/CMakeLists.txt
+++ b/loom/binding/c/benchmark/CMakeLists.txt
@@ -88,4 +88,19 @@ loom_cc_benchmark(
   TESTONLY
 )
 
+loom_cc_benchmark(
+  NAME
+    link_throughput_benchmark
+  SRCS
+    "link_throughput_benchmark.cc"
+  DEPS
+    ::benchmark_support
+    iree::base
+    iree::testing::benchmark_main
+    loom::binding::c::loomc
+  ARGS
+    "--benchmark_filter=Smoke"
+  TESTONLY
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/loom/binding/c/benchmark/compile_throughput_benchmark.cc
+++ b/loom/binding/c/benchmark/compile_throughput_benchmark.cc
@@ -6,7 +6,6 @@
 
 #include "loom/binding/c/benchmark/compile_throughput_benchmark.h"
 
-#include <algorithm>
 #include <cstring>
 #include <string>
 #include <thread>
@@ -27,38 +26,6 @@ static bool ShouldSkipWorkerCount(::benchmark::State& state,
     return true;
   }
   return false;
-}
-
-static std::string FormatStatus(iree_status_t status) {
-  char buffer[4096] = {0};
-  iree_host_size_t length = 0;
-  iree_status_format(status, sizeof(buffer), buffer, &length);
-  return std::string(buffer, std::min(length, sizeof(buffer) - 1));
-}
-
-static iree_status_t MakeResultFailureStatus(const loomc_result_t* result,
-                                             const char* operation) {
-  if (result == nullptr) {
-    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                            "%s failed without producing a result", operation);
-  }
-
-  loomc_host_size_t diagnostic_count = loomc_result_diagnostic_count(result);
-  if (diagnostic_count == 0) {
-    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                            "%s failed without diagnostics", operation);
-  }
-
-  const loomc_diagnostic_t* diagnostic = loomc_result_diagnostic_at(result, 0);
-  if (diagnostic == nullptr) {
-    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
-                            "%s failed with an unreadable diagnostic",
-                            operation);
-  }
-  return iree_make_status(
-      IREE_STATUS_FAILED_PRECONDITION, "%s failed: %.*s: %.*s", operation,
-      (int)diagnostic->code.size, diagnostic->code.data,
-      (int)diagnostic->message.size, diagnostic->message.data);
 }
 
 static iree_status_t RunScenarioJob(void* user_data,
@@ -107,24 +74,6 @@ static iree_status_t CreateTextSourceFromViews(loomc_string_view_t identifier,
 }
 
 }  // namespace
-
-iree_allocator_t host_allocator() { return iree_allocator_system(); }
-
-loomc_allocator_t loom_allocator() {
-  return loomc_allocator_from_iree(host_allocator());
-}
-
-iree_status_t to_iree_status(loomc_status_t status) {
-  return iree_status_from_loomc(status);
-}
-
-iree_status_t RequireSucceededResult(const loomc_result_t* result,
-                                     const char* operation) {
-  if (result != nullptr && loomc_result_succeeded(result)) {
-    return iree_ok_status();
-  }
-  return MakeResultFailureStatus(result, operation);
-}
 
 const loomc_artifact_t* FindArtifact(const loomc_result_t* result,
                                      loomc_artifact_kind_t kind,

--- a/loom/binding/c/benchmark/compile_throughput_benchmark.h
+++ b/loom/binding/c/benchmark/compile_throughput_benchmark.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "iree/base/api.h"
+#include "loom/binding/c/benchmark/util/benchmark_support.h"
 #include "loomc/iree.h"
 
 namespace benchmark {
@@ -21,31 +22,6 @@ class State;
 }  // namespace benchmark
 
 namespace loomc::bench {
-
-template <typename T, void (*Release)(T*)>
-struct HandleDeleter {
-  void operator()(T* handle) const { Release(handle); }
-};
-
-template <typename T, void (*Release)(T*)>
-using HandlePtr = std::unique_ptr<T, HandleDeleter<T, Release>>;
-
-using CompilerPtr = HandlePtr<loomc_compiler_t, loomc_compiler_release>;
-using ContextPtr = HandlePtr<loomc_context_t, loomc_context_release>;
-using LinkIndexBuilderPtr =
-    HandlePtr<loomc_link_index_builder_t, loomc_link_index_builder_release>;
-using LinkIndexPtr = HandlePtr<loomc_link_index_t, loomc_link_index_release>;
-using LinkerPtr = HandlePtr<loomc_linker_t, loomc_linker_release>;
-using ModulePtr = HandlePtr<loomc_module_t, loomc_module_release>;
-using PassProgramPtr =
-    HandlePtr<loomc_pass_program_t, loomc_pass_program_release>;
-using ResultPtr = HandlePtr<loomc_result_t, loomc_result_release>;
-using SourcePtr = HandlePtr<loomc_source_t, loomc_source_release>;
-using TargetEnvironmentPtr =
-    HandlePtr<loomc_target_environment_t, loomc_target_environment_release>;
-using TargetProfilePtr =
-    HandlePtr<loomc_target_profile_t, loomc_target_profile_release>;
-using WorkspacePtr = HandlePtr<loomc_workspace_t, loomc_workspace_release>;
 
 struct WorkerSlot {
   // Invocation-local scratch workspace used by one compile-pool worker.
@@ -139,12 +115,6 @@ class TargetCompileScenario : public CompileScenario {
 using CompileScenarioFactory = std::unique_ptr<CompileScenario> (*)(
     const ::benchmark::State& state, const void* user_data);
 
-iree_allocator_t host_allocator();
-
-loomc_allocator_t loom_allocator();
-
-iree_status_t to_iree_status(loomc_status_t status);
-
 void RunCompileBenchmark(::benchmark::State& state,
                          CompileScenarioFactory factory, const void* user_data);
 
@@ -157,9 +127,6 @@ void RunCompileBenchmarkDirect(::benchmark::State& state,
 void RunCompileBenchmarkDirectCold(::benchmark::State& state,
                                    CompileScenarioFactory factory,
                                    const void* user_data);
-
-iree_status_t RequireSucceededResult(const loomc_result_t* result,
-                                     const char* operation);
 
 const loomc_artifact_t* FindArtifact(const loomc_result_t* result,
                                      loomc_artifact_kind_t kind,

--- a/loom/binding/c/benchmark/link_throughput_benchmark.cc
+++ b/loom/binding/c/benchmark/link_throughput_benchmark.cc
@@ -1,0 +1,496 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Benchmarks repeated selective links through the public LoomC API. The
+// reusable linker and frozen index own catalog-wide work while one worker-local
+// workspace supplies invocation storage and each link materializes one root
+// closure.
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "benchmark/benchmark.h"
+#include "iree/base/api.h"
+#include "loom/binding/c/benchmark/util/benchmark_support.h"
+#include "loomc/iree.h"
+
+namespace loomc::bench {
+namespace {
+
+static bool SkipOnError(benchmark::State& state, iree_status_t status) {
+  if (iree_status_is_ok(status)) {
+    return false;
+  }
+  const std::string message = FormatStatus(status);
+  iree_status_free(status);
+  state.SkipWithError(message.c_str());
+  return true;
+}
+
+static std::string RootName(uint32_t ordinal) {
+  char buffer[32] = {0};
+  const int length =
+      std::snprintf(buffer, sizeof(buffer), "@kernel_%08u", ordinal);
+  if (length <= 0 || length >= (int)sizeof(buffer)) {
+    std::abort();
+  }
+  return std::string(buffer, (size_t)length);
+}
+
+static void AppendFormatted(std::string& target, const char* format,
+                            uint32_t value) {
+  char buffer[128] = {0};
+  const int length = std::snprintf(buffer, sizeof(buffer), format, value);
+  if (length <= 0 || length >= (int)sizeof(buffer)) {
+    std::abort();
+  }
+  target.append(buffer, (size_t)length);
+}
+
+static std::string BuildCatalogSource(uint32_t root_count,
+                                      uint32_t values_per_root,
+                                      std::vector<std::string>* root_names) {
+  constexpr uint32_t kOperationsPerSourceLine = 4;
+  root_names->clear();
+  root_names->reserve(root_count);
+
+  std::string source;
+  source.reserve((size_t)root_count * (size_t)values_per_root * 64u);
+  source.append(
+      "func.def @shared_identity(%value: index) -> (index) {\n"
+      "  func.return %value : index\n"
+      "}\n\n");
+  for (uint32_t root_ordinal = 0; root_ordinal < root_count; ++root_ordinal) {
+    root_names->push_back(RootName(root_ordinal));
+    source.append("func.def public ");
+    source.append(root_names->back());
+    source.append("(%arg: index) -> (index) {\n");
+    source.append("  %one = index.constant 1 : index\n");
+    // Newlines are lexer whitespace. Packing several operations onto each
+    // physical line keeps large synthetic modules within the source-location
+    // line encoding without changing their token stream or IR shape.
+    for (uint32_t value_ordinal = 0; value_ordinal < values_per_root;
+         ++value_ordinal) {
+      if (value_ordinal % kOperationsPerSourceLine == 0) {
+        source.append("  ");
+      }
+      AppendFormatted(source, "%%value_%u = index.add ", value_ordinal);
+      if (value_ordinal == 0) {
+        source.append("%arg");
+      } else {
+        AppendFormatted(source, "%%value_%u", value_ordinal - 1);
+      }
+      source.append(", %one : index");
+      source.append(value_ordinal % kOperationsPerSourceLine ==
+                                kOperationsPerSourceLine - 1 ||
+                            value_ordinal == values_per_root - 1
+                        ? "\n"
+                        : " ");
+    }
+    source.append("  %result = func.call @shared_identity(");
+    if (values_per_root == 0) {
+      source.append("%arg");
+    } else {
+      AppendFormatted(source, "%%value_%u", values_per_root - 1);
+    }
+    source.append(") : (index) -> (index)\n");
+    source.append("  func.return %result : index\n}\n\n");
+  }
+  return source;
+}
+
+class LinkCatalogFixture {
+ public:
+  LinkCatalogFixture(uint32_t root_count, uint32_t values_per_root)
+      : root_count_(root_count), values_per_root_(values_per_root) {}
+
+  iree_status_t Initialize() {
+    loomc_context_t* context = nullptr;
+    IREE_RETURN_IF_ERROR(to_iree_status(loomc_context_create(
+        /*options=*/nullptr, loom_allocator(), &context)));
+    context_.reset(context);
+
+    source_text_ =
+        BuildCatalogSource(root_count_, values_per_root_, &root_names_);
+    const loomc_source_options_t source_options = {
+        /*.type=*/LOOMC_STRUCTURE_TYPE_SOURCE_OPTIONS,
+        /*.structure_size=*/sizeof(source_options),
+        /*.next=*/nullptr,
+        /*.format=*/LOOMC_SOURCE_FORMAT_TEXT,
+        /*.identifier=*/loomc_make_cstring_view("link_catalog.loom"),
+        /*.contents=*/
+        loomc_make_byte_span(source_text_.data(), source_text_.size()),
+        /*.storage=*/LOOMC_SOURCE_STORAGE_COPY,
+        /*.release=*/nullptr,
+        /*.release_user_data=*/nullptr,
+    };
+    loomc_source_t* source = nullptr;
+    IREE_RETURN_IF_ERROR(to_iree_status(
+        loomc_source_create(&source_options, loom_allocator(), &source)));
+    source_.reset(source);
+
+    loomc_linker_t* linker = nullptr;
+    IREE_RETURN_IF_ERROR(to_iree_status(loomc_linker_create(
+        context_.get(), /*options=*/nullptr, loom_allocator(), &linker)));
+    linker_.reset(linker);
+    return iree_ok_status();
+  }
+
+  iree_status_t BuildIndex(LinkIndexPtr* out_index) const {
+    out_index->reset();
+    loomc_link_index_builder_t* builder = nullptr;
+    IREE_RETURN_IF_ERROR(to_iree_status(loomc_link_index_builder_create(
+        context_.get(), /*options=*/nullptr, loom_allocator(), &builder)));
+    LinkIndexBuilderPtr builder_ptr(builder);
+
+    const loomc_link_index_source_options_t source_options = {
+        /*.provider_name=*/loomc_make_cstring_view("catalog"),
+        /*.role=*/LOOMC_LINK_PROVIDER_ROLE_INPUT,
+        /*.import_keys=*/nullptr,
+        /*.import_key_count=*/0,
+    };
+    IREE_RETURN_IF_ERROR(to_iree_status(loomc_link_index_builder_add_source(
+        builder_ptr.get(), source_.get(), &source_options,
+        /*out_slot=*/nullptr)));
+
+    loomc_link_index_t* index = nullptr;
+    loomc_result_t* result = nullptr;
+    iree_status_t status = to_iree_status(
+        loomc_link_index_builder_finish(builder_ptr.get(), &index, &result));
+    LinkIndexPtr index_ptr(index);
+    ResultPtr result_ptr(result);
+    IREE_RETURN_IF_ERROR(status);
+    IREE_RETURN_IF_ERROR(
+        RequireSucceededResult(result_ptr.get(), "link index construction"));
+    const loomc_host_size_t expected_symbol_count = root_count_ + 1;
+    if (loomc_link_index_symbol_count(index_ptr.get()) !=
+        expected_symbol_count) {
+      return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                              "link index has %" PRIhsz
+                              " symbols; expected %" PRIhsz,
+                              loomc_link_index_symbol_count(index_ptr.get()),
+                              expected_symbol_count);
+    }
+    out_index->reset(index_ptr.release());
+    return iree_ok_status();
+  }
+
+  iree_status_t CreateWorkspace(WorkspacePtr* out_workspace) const {
+    out_workspace->reset();
+    loomc_workspace_t* workspace = nullptr;
+    IREE_RETURN_IF_ERROR(to_iree_status(loomc_workspace_create(
+        /*options=*/nullptr, loom_allocator(), &workspace)));
+    out_workspace->reset(workspace);
+    return iree_ok_status();
+  }
+
+  iree_status_t Link(loomc_link_index_t* index, loomc_workspace_t* workspace,
+                     uint32_t root_ordinal, ModulePtr* out_module,
+                     ResultPtr* out_result) const {
+    out_module->reset();
+    out_result->reset();
+    const std::string& root = root_names_[root_ordinal];
+    const loomc_string_view_t root_symbol =
+        loomc_make_string_view(root.data(), root.size());
+    const loomc_link_options_t options = {
+        /*.type=*/LOOMC_STRUCTURE_TYPE_LINK_OPTIONS,
+        /*.structure_size=*/sizeof(options),
+        /*.next=*/nullptr,
+        /*.link_index=*/index,
+        /*.module_name=*/loomc_make_cstring_view("selected_kernel"),
+        /*.root_symbols=*/&root_symbol,
+        /*.root_symbol_count=*/1,
+        /*.flags=*/0,
+        /*.config=*/{},
+    };
+    loomc_module_t* module = nullptr;
+    loomc_result_t* result = nullptr;
+    iree_status_t status = to_iree_status(loomc_link_module(
+        linker_.get(), workspace, &options, &module, &result));
+    ModulePtr module_ptr(module);
+    ResultPtr result_ptr(result);
+    IREE_RETURN_IF_ERROR(status);
+    IREE_RETURN_IF_ERROR(
+        RequireSucceededResult(result_ptr.get(), "selective linking"));
+    if (!module_ptr) {
+      return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                              "selective linking produced no module");
+    }
+    out_module->reset(module_ptr.release());
+    out_result->reset(result_ptr.release());
+    return iree_ok_status();
+  }
+
+  iree_status_t VerifySelectedModule(const loomc_module_t* module,
+                                     uint32_t root_ordinal) const {
+    loomc_host_size_t function_count = 0;
+    loomc_result_t* result = nullptr;
+    iree_status_t status = to_iree_status(loomc_module_query_functions(
+        module, /*options=*/nullptr, loom_allocator(), /*function_capacity=*/0,
+        /*out_functions=*/nullptr, &function_count, &result));
+    ResultPtr result_ptr(result);
+    IREE_RETURN_IF_ERROR(status);
+    IREE_RETURN_IF_ERROR(
+        RequireSucceededResult(result_ptr.get(), "linked module query"));
+    if (function_count != 2) {
+      return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                              "selective link retained %" PRIhsz
+                              " functions; expected one root and one helper",
+                              function_count);
+    }
+
+    loomc_module_function_t function = {};
+    const std::string& root = root_names_[root_ordinal];
+    if (!loomc_module_try_lookup_function(
+            module, loomc_make_string_view(root.data(), root.size()),
+            &function) ||
+        !loomc_module_try_lookup_function(
+            module, loomc_make_cstring_view("@shared_identity"), &function)) {
+      return iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "selective link did not retain its root and shared helper");
+    }
+    return iree_ok_status();
+  }
+
+  uint32_t root_count() const { return root_count_; }
+
+  uint32_t values_per_root() const { return values_per_root_; }
+
+  size_t source_size() const { return source_text_.size(); }
+
+  uint64_t catalog_value_count() const {
+    return (uint64_t)root_count_ * ((uint64_t)values_per_root_ + 3u) + 1u;
+  }
+
+ private:
+  uint32_t root_count_ = 0;
+  uint32_t values_per_root_ = 0;
+  ContextPtr context_;
+  SourcePtr source_;
+  LinkerPtr linker_;
+  std::string source_text_;
+  std::vector<std::string> root_names_;
+};
+
+static void SetCatalogCounters(benchmark::State& state,
+                               const LinkCatalogFixture& fixture) {
+  state.counters["catalog_roots"] = (double)fixture.root_count();
+  state.counters["catalog_symbols"] = (double)fixture.root_count() + 1.0;
+  state.counters["catalog_ssa_values"] = (double)fixture.catalog_value_count();
+  state.counters["source_bytes"] = (double)fixture.source_size();
+  state.counters["values/root"] = (double)fixture.values_per_root();
+}
+
+static void SetWorkspaceCounters(benchmark::State& state,
+                                 const loomc_workspace_statistics_t& before,
+                                 const loomc_workspace_statistics_t& after) {
+  state.counters["workspace_block_size"] = (double)after.total_block_size;
+  state.counters["workspace_block_system_allocations"] =
+      (double)after.block_system_allocation_count;
+  state.counters["workspace_block_system_bytes"] =
+      (double)after.block_system_allocation_bytes;
+  state.counters["workspace_new_block_system_allocations"] =
+      (double)(after.block_system_allocation_count -
+               before.block_system_allocation_count);
+  state.counters["workspace_new_block_system_bytes"] =
+      (double)(after.block_system_allocation_bytes -
+               before.block_system_allocation_bytes);
+  state.counters["workspace_oversized_allocations"] =
+      (double)after.oversized_allocation_count;
+  state.counters["workspace_new_oversized_allocations"] =
+      (double)(after.oversized_allocation_count -
+               before.oversized_allocation_count);
+}
+
+static iree_status_t LinkBatch(const LinkCatalogFixture& fixture,
+                               loomc_link_index_t* index,
+                               loomc_workspace_t* workspace,
+                               std::vector<ModulePtr>* modules,
+                               std::vector<ResultPtr>* results) {
+  for (size_t i = 0; i < modules->size(); ++i) {
+    const uint32_t root_ordinal = (uint32_t)(i % fixture.root_count());
+    IREE_RETURN_IF_ERROR(fixture.Link(index, workspace, root_ordinal,
+                                      &(*modules)[i], &(*results)[i]));
+    benchmark::DoNotOptimize((*modules)[i].get());
+  }
+  return iree_ok_status();
+}
+
+static void ReleaseBatch(std::vector<ModulePtr>* modules,
+                         std::vector<ResultPtr>* results) {
+  for (ResultPtr& result : *results) {
+    result.reset();
+  }
+  for (ModulePtr& module : *modules) {
+    module.reset();
+  }
+}
+
+static void BM_LinkIndexBuild(benchmark::State& state) {
+  LinkCatalogFixture fixture((uint32_t)state.range(0),
+                             (uint32_t)state.range(1));
+  if (SkipOnError(state, fixture.Initialize())) {
+    return;
+  }
+
+  int64_t index_count = 0;
+  for (auto _ : state) {
+    LinkIndexPtr index;
+    if (SkipOnError(state, fixture.BuildIndex(&index))) {
+      break;
+    }
+    benchmark::DoNotOptimize(index.get());
+    ++index_count;
+    state.PauseTiming();
+    index.reset();
+    state.ResumeTiming();
+  }
+  SetCatalogCounters(state, fixture);
+  state.SetItemsProcessed(index_count * (fixture.root_count() + 1));
+  state.SetBytesProcessed(index_count * (int64_t)fixture.source_size());
+  state.counters["indexes/s"] =
+      benchmark::Counter(index_count, benchmark::Counter::kIsRate);
+}
+
+static void BM_SelectiveLinkBatch(benchmark::State& state) {
+  LinkCatalogFixture fixture((uint32_t)state.range(0),
+                             (uint32_t)state.range(1));
+  if (SkipOnError(state, fixture.Initialize())) {
+    return;
+  }
+  LinkIndexPtr index;
+  if (SkipOnError(state, fixture.BuildIndex(&index))) {
+    return;
+  }
+  WorkspacePtr workspace;
+  if (SkipOnError(state, fixture.CreateWorkspace(&workspace))) {
+    return;
+  }
+
+  const uint32_t links_per_batch = (uint32_t)state.range(2);
+  std::vector<ModulePtr> modules(links_per_batch);
+  std::vector<ResultPtr> results(links_per_batch);
+  if (SkipOnError(state, LinkBatch(fixture, index.get(), workspace.get(),
+                                   &modules, &results))) {
+    return;
+  }
+  if (SkipOnError(state, fixture.VerifySelectedModule(modules[0].get(),
+                                                      /*root_ordinal=*/0))) {
+    return;
+  }
+  ReleaseBatch(&modules, &results);
+
+  loomc_workspace_statistics_t before = {};
+  loomc_workspace_query_statistics(workspace.get(), &before);
+  int64_t total_links = 0;
+  for (auto _ : state) {
+    if (SkipOnError(state, LinkBatch(fixture, index.get(), workspace.get(),
+                                     &modules, &results))) {
+      break;
+    }
+    total_links += links_per_batch;
+    state.PauseTiming();
+    ReleaseBatch(&modules, &results);
+    state.ResumeTiming();
+  }
+  loomc_workspace_statistics_t after = {};
+  loomc_workspace_query_statistics(workspace.get(), &after);
+
+  SetCatalogCounters(state, fixture);
+  SetWorkspaceCounters(state, before, after);
+  state.counters["selected_functions"] = 2.0;
+  state.SetItemsProcessed(total_links);
+  state.counters["links/batch"] = (double)links_per_batch;
+  state.counters["links/s"] =
+      benchmark::Counter(total_links, benchmark::Counter::kIsRate);
+}
+
+static void BM_IndexOnceAndSelectiveLinkBatch(benchmark::State& state) {
+  LinkCatalogFixture fixture((uint32_t)state.range(0),
+                             (uint32_t)state.range(1));
+  if (SkipOnError(state, fixture.Initialize())) {
+    return;
+  }
+  WorkspacePtr workspace;
+  if (SkipOnError(state, fixture.CreateWorkspace(&workspace))) {
+    return;
+  }
+
+  const uint32_t links_per_batch = (uint32_t)state.range(2);
+  std::vector<ModulePtr> modules(links_per_batch);
+  std::vector<ResultPtr> results(links_per_batch);
+  loomc_workspace_statistics_t before = {};
+  loomc_workspace_query_statistics(workspace.get(), &before);
+  int64_t total_links = 0;
+  for (auto _ : state) {
+    LinkIndexPtr index;
+    if (SkipOnError(state, fixture.BuildIndex(&index)) ||
+        SkipOnError(state, LinkBatch(fixture, index.get(), workspace.get(),
+                                     &modules, &results))) {
+      break;
+    }
+    total_links += links_per_batch;
+    state.PauseTiming();
+    ReleaseBatch(&modules, &results);
+    index.reset();
+    state.ResumeTiming();
+  }
+  loomc_workspace_statistics_t after = {};
+  loomc_workspace_query_statistics(workspace.get(), &after);
+
+  SetCatalogCounters(state, fixture);
+  SetWorkspaceCounters(state, before, after);
+  state.counters["selected_functions"] = 2.0;
+  state.SetItemsProcessed(total_links);
+  state.counters["links/batch"] = (double)links_per_batch;
+  state.counters["links/s"] =
+      benchmark::Counter(total_links, benchmark::Counter::kIsRate);
+}
+
+static void CatalogScales(benchmark::Benchmark* benchmark) {
+  for (int64_t root_count : {1, 16, 64, 512}) {
+    benchmark->Args({root_count, 256});
+  }
+}
+
+static void SelectiveLinkScales(benchmark::Benchmark* benchmark) {
+  for (int64_t root_count : {1, 16, 64, 512}) {
+    for (int64_t links_per_batch : {1, 16, 64, 512}) {
+      benchmark->Args({root_count, 256, links_per_batch});
+    }
+  }
+}
+
+static void BM_LinkIndexBuild_Smoke(benchmark::State& state) {
+  BM_LinkIndexBuild(state);
+}
+
+static void BM_SelectiveLinkBatch_Smoke(benchmark::State& state) {
+  BM_SelectiveLinkBatch(state);
+}
+
+BENCHMARK(BM_LinkIndexBuild)
+    ->Apply(CatalogScales)
+    ->ArgNames({"catalog_roots", "values_per_root"});
+BENCHMARK(BM_SelectiveLinkBatch)
+    ->Apply(SelectiveLinkScales)
+    ->ArgNames({"catalog_roots", "values_per_root", "links_per_batch"});
+BENCHMARK(BM_IndexOnceAndSelectiveLinkBatch)
+    ->Args({512, 256, 388})
+    ->ArgNames({"catalog_roots", "values_per_root", "links_per_batch"});
+
+BENCHMARK(BM_LinkIndexBuild_Smoke)
+    ->Args({16, 16})
+    ->ArgNames({"catalog_roots", "values_per_root"});
+BENCHMARK(BM_SelectiveLinkBatch_Smoke)
+    ->Args({16, 16, 4})
+    ->ArgNames({"catalog_roots", "values_per_root", "links_per_batch"});
+
+}  // namespace
+}  // namespace loomc::bench

--- a/loom/binding/c/benchmark/link_throughput_benchmark.cc
+++ b/loom/binding/c/benchmark/link_throughput_benchmark.cc
@@ -55,7 +55,7 @@ static void AppendFormatted(std::string& target, const char* format,
 static std::string BuildCatalogSource(uint32_t root_count,
                                       uint32_t values_per_root,
                                       std::vector<std::string>* root_names) {
-  constexpr uint32_t kOperationsPerSourceLine = 4;
+  constexpr uint32_t kOperationsPerSourceLine = 128;
   root_names->clear();
   root_names->reserve(root_count);
 
@@ -106,8 +106,11 @@ static std::string BuildCatalogSource(uint32_t root_count,
 
 class LinkCatalogFixture {
  public:
-  LinkCatalogFixture(uint32_t root_count, uint32_t values_per_root)
-      : root_count_(root_count), values_per_root_(values_per_root) {}
+  LinkCatalogFixture(uint32_t root_count, uint32_t values_per_root,
+                     loomc_source_format_t source_format)
+      : root_count_(root_count),
+        values_per_root_(values_per_root),
+        source_format_(source_format) {}
 
   iree_status_t Initialize() {
     loomc_context_t* context = nullptr;
@@ -115,7 +118,7 @@ class LinkCatalogFixture {
         /*options=*/nullptr, loom_allocator(), &context)));
     context_.reset(context);
 
-    source_text_ =
+    std::string source_text =
         BuildCatalogSource(root_count_, values_per_root_, &root_names_);
     const loomc_source_options_t source_options = {
         /*.type=*/LOOMC_STRUCTURE_TYPE_SOURCE_OPTIONS,
@@ -124,7 +127,7 @@ class LinkCatalogFixture {
         /*.format=*/LOOMC_SOURCE_FORMAT_TEXT,
         /*.identifier=*/loomc_make_cstring_view("link_catalog.loom"),
         /*.contents=*/
-        loomc_make_byte_span(source_text_.data(), source_text_.size()),
+        loomc_make_byte_span(source_text.data(), source_text.size()),
         /*.storage=*/LOOMC_SOURCE_STORAGE_COPY,
         /*.release=*/nullptr,
         /*.release_user_data=*/nullptr,
@@ -132,7 +135,46 @@ class LinkCatalogFixture {
     loomc_source_t* source = nullptr;
     IREE_RETURN_IF_ERROR(to_iree_status(
         loomc_source_create(&source_options, loom_allocator(), &source)));
-    source_.reset(source);
+    SourcePtr text_source(source);
+
+    if (source_format_ == LOOMC_SOURCE_FORMAT_TEXT) {
+      source_.reset(text_source.release());
+    } else if (source_format_ == LOOMC_SOURCE_FORMAT_BYTECODE) {
+      loomc_workspace_t* workspace = nullptr;
+      IREE_RETURN_IF_ERROR(to_iree_status(loomc_workspace_create(
+          /*options=*/nullptr, loom_allocator(), &workspace)));
+      WorkspacePtr workspace_ptr(workspace);
+
+      loomc_module_t* module = nullptr;
+      loomc_result_t* result = nullptr;
+      iree_status_t status =
+          to_iree_status(loomc_module_deserialize_from_source(
+              context_.get(), workspace_ptr.get(), text_source.get(),
+              /*options=*/nullptr, loom_allocator(), &module, &result));
+      ModulePtr module_ptr(module);
+      ResultPtr result_ptr(result);
+      IREE_RETURN_IF_ERROR(status);
+      IREE_RETURN_IF_ERROR(
+          RequireSucceededResult(result_ptr.get(), "catalog parsing"));
+
+      const loomc_module_serialize_options_t serialize_options = {
+          /*.type=*/LOOMC_STRUCTURE_TYPE_MODULE_SERIALIZE_OPTIONS,
+          /*.structure_size=*/sizeof(serialize_options),
+          /*.next=*/nullptr,
+          /*.format=*/LOOMC_SOURCE_FORMAT_BYTECODE,
+          /*.identifier=*/loomc_make_cstring_view("link_catalog.loombc"),
+          /*.text_presentation=*/LOOMC_MODULE_TEXT_PRESENTATION_DEFAULT,
+      };
+      loomc_source_t* bytecode_source = nullptr;
+      IREE_RETURN_IF_ERROR(to_iree_status(loomc_module_serialize_to_source(
+          module_ptr.get(), &serialize_options, loom_allocator(),
+          &bytecode_source)));
+      source_.reset(bytecode_source);
+    } else {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "catalog source format must be text or bytecode");
+    }
+    source_size_ = loomc_source_contents(source_.get()).data_length;
 
     loomc_linker_t* linker = nullptr;
     IREE_RETURN_IF_ERROR(to_iree_status(loomc_linker_create(
@@ -262,19 +304,34 @@ class LinkCatalogFixture {
 
   uint32_t values_per_root() const { return values_per_root_; }
 
-  size_t source_size() const { return source_text_.size(); }
+  size_t source_size() const { return source_size_; }
+
+  loomc_source_format_t source_format() const { return source_format_; }
 
   uint64_t catalog_value_count() const {
     return (uint64_t)root_count_ * ((uint64_t)values_per_root_ + 3u) + 1u;
   }
 
+  uint64_t catalog_operation_count() const {
+    return catalog_value_count() + (uint64_t)root_count_ + 1u;
+  }
+
+  uint64_t selected_body_operation_count() const {
+    return (uint64_t)values_per_root_ + 4u;
+  }
+
+  uint64_t selected_operation_count() const {
+    return selected_body_operation_count() + 2u;
+  }
+
  private:
   uint32_t root_count_ = 0;
   uint32_t values_per_root_ = 0;
+  loomc_source_format_t source_format_ = LOOMC_SOURCE_FORMAT_UNKNOWN;
+  size_t source_size_ = 0;
   ContextPtr context_;
   SourcePtr source_;
   LinkerPtr linker_;
-  std::string source_text_;
   std::vector<std::string> root_names_;
 };
 
@@ -282,9 +339,24 @@ static void SetCatalogCounters(benchmark::State& state,
                                const LinkCatalogFixture& fixture) {
   state.counters["catalog_roots"] = (double)fixture.root_count();
   state.counters["catalog_symbols"] = (double)fixture.root_count() + 1.0;
+  state.counters["catalog_body_ops"] = (double)fixture.catalog_value_count();
+  state.counters["catalog_ir_ops"] = (double)fixture.catalog_operation_count();
   state.counters["catalog_ssa_values"] = (double)fixture.catalog_value_count();
+  state.counters["input_bytecode"] =
+      fixture.source_format() == LOOMC_SOURCE_FORMAT_BYTECODE ? 1.0 : 0.0;
   state.counters["source_bytes"] = (double)fixture.source_size();
+  state.counters["source_bytes/root"] =
+      (double)fixture.source_size() / (double)fixture.root_count();
   state.counters["values/root"] = (double)fixture.values_per_root();
+}
+
+static void SetSelectedClosureCounters(benchmark::State& state,
+                                       const LinkCatalogFixture& fixture) {
+  state.counters["selected_body_ops"] =
+      (double)fixture.selected_body_operation_count();
+  state.counters["selected_functions"] = 2.0;
+  state.counters["selected_ir_ops"] =
+      (double)fixture.selected_operation_count();
 }
 
 static void SetWorkspaceCounters(benchmark::State& state,
@@ -332,9 +404,10 @@ static void ReleaseBatch(std::vector<ModulePtr>* modules,
   }
 }
 
-static void BM_LinkIndexBuild(benchmark::State& state) {
-  LinkCatalogFixture fixture((uint32_t)state.range(0),
-                             (uint32_t)state.range(1));
+static void BM_LinkIndexBuildForFormat(benchmark::State& state,
+                                       loomc_source_format_t source_format) {
+  LinkCatalogFixture fixture((uint32_t)state.range(0), (uint32_t)state.range(1),
+                             source_format);
   if (SkipOnError(state, fixture.Initialize())) {
     return;
   }
@@ -358,9 +431,18 @@ static void BM_LinkIndexBuild(benchmark::State& state) {
       benchmark::Counter(index_count, benchmark::Counter::kIsRate);
 }
 
-static void BM_SelectiveLinkBatch(benchmark::State& state) {
-  LinkCatalogFixture fixture((uint32_t)state.range(0),
-                             (uint32_t)state.range(1));
+static void BM_LinkIndexBuild(benchmark::State& state) {
+  BM_LinkIndexBuildForFormat(state, LOOMC_SOURCE_FORMAT_TEXT);
+}
+
+static void BM_LinkIndexBuildBytecode(benchmark::State& state) {
+  BM_LinkIndexBuildForFormat(state, LOOMC_SOURCE_FORMAT_BYTECODE);
+}
+
+static void BM_SelectiveLinkBatchForFormat(
+    benchmark::State& state, loomc_source_format_t source_format) {
+  LinkCatalogFixture fixture((uint32_t)state.range(0), (uint32_t)state.range(1),
+                             source_format);
   if (SkipOnError(state, fixture.Initialize())) {
     return;
   }
@@ -404,16 +486,25 @@ static void BM_SelectiveLinkBatch(benchmark::State& state) {
 
   SetCatalogCounters(state, fixture);
   SetWorkspaceCounters(state, before, after);
-  state.counters["selected_functions"] = 2.0;
+  SetSelectedClosureCounters(state, fixture);
   state.SetItemsProcessed(total_links);
   state.counters["links/batch"] = (double)links_per_batch;
   state.counters["links/s"] =
       benchmark::Counter(total_links, benchmark::Counter::kIsRate);
 }
 
-static void BM_IndexOnceAndSelectiveLinkBatch(benchmark::State& state) {
-  LinkCatalogFixture fixture((uint32_t)state.range(0),
-                             (uint32_t)state.range(1));
+static void BM_SelectiveLinkBatch(benchmark::State& state) {
+  BM_SelectiveLinkBatchForFormat(state, LOOMC_SOURCE_FORMAT_TEXT);
+}
+
+static void BM_SelectiveLinkBatchBytecode(benchmark::State& state) {
+  BM_SelectiveLinkBatchForFormat(state, LOOMC_SOURCE_FORMAT_BYTECODE);
+}
+
+static void BM_IndexOnceAndSelectiveLinkBatchForFormat(
+    benchmark::State& state, loomc_source_format_t source_format) {
+  LinkCatalogFixture fixture((uint32_t)state.range(0), (uint32_t)state.range(1),
+                             source_format);
   if (SkipOnError(state, fixture.Initialize())) {
     return;
   }
@@ -446,17 +537,27 @@ static void BM_IndexOnceAndSelectiveLinkBatch(benchmark::State& state) {
 
   SetCatalogCounters(state, fixture);
   SetWorkspaceCounters(state, before, after);
-  state.counters["selected_functions"] = 2.0;
+  SetSelectedClosureCounters(state, fixture);
   state.SetItemsProcessed(total_links);
   state.counters["links/batch"] = (double)links_per_batch;
   state.counters["links/s"] =
       benchmark::Counter(total_links, benchmark::Counter::kIsRate);
 }
 
+static void BM_IndexOnceAndSelectiveLinkBatch(benchmark::State& state) {
+  BM_IndexOnceAndSelectiveLinkBatchForFormat(state, LOOMC_SOURCE_FORMAT_TEXT);
+}
+
+static void BM_IndexOnceAndSelectiveLinkBatchBytecode(benchmark::State& state) {
+  BM_IndexOnceAndSelectiveLinkBatchForFormat(state,
+                                             LOOMC_SOURCE_FORMAT_BYTECODE);
+}
+
 static void CatalogScales(benchmark::Benchmark* benchmark) {
   for (int64_t root_count : {1, 16, 64, 512}) {
     benchmark->Args({root_count, 256});
   }
+  benchmark->Args({4096, 512});
 }
 
 static void SelectiveLinkScales(benchmark::Benchmark* benchmark) {
@@ -465,30 +566,59 @@ static void SelectiveLinkScales(benchmark::Benchmark* benchmark) {
       benchmark->Args({root_count, 256, links_per_batch});
     }
   }
+  benchmark->Args({4096, 512, 80});
+  benchmark->Args({4096, 512, 388});
 }
 
 static void BM_LinkIndexBuild_Smoke(benchmark::State& state) {
   BM_LinkIndexBuild(state);
 }
 
+static void BM_LinkIndexBuildBytecode_Smoke(benchmark::State& state) {
+  BM_LinkIndexBuildBytecode(state);
+}
+
 static void BM_SelectiveLinkBatch_Smoke(benchmark::State& state) {
   BM_SelectiveLinkBatch(state);
+}
+
+static void BM_SelectiveLinkBatchBytecode_Smoke(benchmark::State& state) {
+  BM_SelectiveLinkBatchBytecode(state);
 }
 
 BENCHMARK(BM_LinkIndexBuild)
     ->Apply(CatalogScales)
     ->ArgNames({"catalog_roots", "values_per_root"});
+BENCHMARK(BM_LinkIndexBuildBytecode)
+    ->Apply(CatalogScales)
+    ->ArgNames({"catalog_roots", "values_per_root"});
 BENCHMARK(BM_SelectiveLinkBatch)
+    ->Apply(SelectiveLinkScales)
+    ->ArgNames({"catalog_roots", "values_per_root", "links_per_batch"});
+BENCHMARK(BM_SelectiveLinkBatchBytecode)
     ->Apply(SelectiveLinkScales)
     ->ArgNames({"catalog_roots", "values_per_root", "links_per_batch"});
 BENCHMARK(BM_IndexOnceAndSelectiveLinkBatch)
     ->Args({512, 256, 388})
+    ->Args({4096, 512, 80})
+    ->Args({4096, 512, 388})
+    ->ArgNames({"catalog_roots", "values_per_root", "links_per_batch"});
+BENCHMARK(BM_IndexOnceAndSelectiveLinkBatchBytecode)
+    ->Args({512, 256, 388})
+    ->Args({4096, 512, 80})
+    ->Args({4096, 512, 388})
     ->ArgNames({"catalog_roots", "values_per_root", "links_per_batch"});
 
 BENCHMARK(BM_LinkIndexBuild_Smoke)
     ->Args({16, 16})
     ->ArgNames({"catalog_roots", "values_per_root"});
+BENCHMARK(BM_LinkIndexBuildBytecode_Smoke)
+    ->Args({16, 16})
+    ->ArgNames({"catalog_roots", "values_per_root"});
 BENCHMARK(BM_SelectiveLinkBatch_Smoke)
+    ->Args({16, 16, 4})
+    ->ArgNames({"catalog_roots", "values_per_root", "links_per_batch"});
+BENCHMARK(BM_SelectiveLinkBatchBytecode_Smoke)
     ->Args({16, 16, 4})
     ->ArgNames({"catalog_roots", "values_per_root", "links_per_batch"});
 

--- a/loom/binding/c/benchmark/util/benchmark_support.cc
+++ b/loom/binding/c/benchmark/util/benchmark_support.cc
@@ -1,0 +1,67 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/binding/c/benchmark/util/benchmark_support.h"
+
+#include <algorithm>
+
+namespace loomc::bench {
+namespace {
+
+static iree_status_t MakeResultFailureStatus(const loomc_result_t* result,
+                                             const char* operation) {
+  if (result == nullptr) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "%s failed without producing a result", operation);
+  }
+
+  const loomc_host_size_t diagnostic_count =
+      loomc_result_diagnostic_count(result);
+  if (diagnostic_count == 0) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "%s failed without diagnostics", operation);
+  }
+
+  const loomc_diagnostic_t* diagnostic = loomc_result_diagnostic_at(result, 0);
+  if (diagnostic == nullptr) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "%s failed with an unreadable diagnostic",
+                            operation);
+  }
+  return iree_make_status(
+      IREE_STATUS_FAILED_PRECONDITION, "%s failed: %.*s: %.*s", operation,
+      (int)diagnostic->code.size, diagnostic->code.data,
+      (int)diagnostic->message.size, diagnostic->message.data);
+}
+
+}  // namespace
+
+iree_allocator_t host_allocator() { return iree_allocator_system(); }
+
+loomc_allocator_t loom_allocator() {
+  return loomc_allocator_from_iree(host_allocator());
+}
+
+iree_status_t to_iree_status(loomc_status_t status) {
+  return iree_status_from_loomc(status);
+}
+
+std::string FormatStatus(iree_status_t status) {
+  char buffer[4096] = {0};
+  iree_host_size_t length = 0;
+  iree_status_format(status, sizeof(buffer), buffer, &length);
+  return std::string(buffer, std::min(length, sizeof(buffer) - 1));
+}
+
+iree_status_t RequireSucceededResult(const loomc_result_t* result,
+                                     const char* operation) {
+  if (result != nullptr && loomc_result_succeeded(result)) {
+    return iree_ok_status();
+  }
+  return MakeResultFailureStatus(result, operation);
+}
+
+}  // namespace loomc::bench

--- a/loom/binding/c/benchmark/util/benchmark_support.h
+++ b/loom/binding/c/benchmark/util/benchmark_support.h
@@ -1,0 +1,56 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef LOOM_BINDING_C_BENCHMARK_UTIL_BENCHMARK_SUPPORT_H_
+#define LOOM_BINDING_C_BENCHMARK_UTIL_BENCHMARK_SUPPORT_H_
+
+#include <memory>
+#include <string>
+
+#include "iree/base/api.h"
+#include "loomc/iree.h"
+
+namespace loomc::bench {
+
+template <typename T, void (*Release)(T*)>
+struct HandleDeleter {
+  void operator()(T* handle) const { Release(handle); }
+};
+
+template <typename T, void (*Release)(T*)>
+using HandlePtr = std::unique_ptr<T, HandleDeleter<T, Release>>;
+
+using CompilerPtr = HandlePtr<loomc_compiler_t, loomc_compiler_release>;
+using ContextPtr = HandlePtr<loomc_context_t, loomc_context_release>;
+using LinkIndexBuilderPtr =
+    HandlePtr<loomc_link_index_builder_t, loomc_link_index_builder_release>;
+using LinkIndexPtr = HandlePtr<loomc_link_index_t, loomc_link_index_release>;
+using LinkerPtr = HandlePtr<loomc_linker_t, loomc_linker_release>;
+using ModulePtr = HandlePtr<loomc_module_t, loomc_module_release>;
+using PassProgramPtr =
+    HandlePtr<loomc_pass_program_t, loomc_pass_program_release>;
+using ResultPtr = HandlePtr<loomc_result_t, loomc_result_release>;
+using SourcePtr = HandlePtr<loomc_source_t, loomc_source_release>;
+using TargetEnvironmentPtr =
+    HandlePtr<loomc_target_environment_t, loomc_target_environment_release>;
+using TargetProfilePtr =
+    HandlePtr<loomc_target_profile_t, loomc_target_profile_release>;
+using WorkspacePtr = HandlePtr<loomc_workspace_t, loomc_workspace_release>;
+
+iree_allocator_t host_allocator();
+
+loomc_allocator_t loom_allocator();
+
+iree_status_t to_iree_status(loomc_status_t status);
+
+std::string FormatStatus(iree_status_t status);
+
+iree_status_t RequireSucceededResult(const loomc_result_t* result,
+                                     const char* operation);
+
+}  // namespace loomc::bench
+
+#endif  // LOOM_BINDING_C_BENCHMARK_UTIL_BENCHMARK_SUPPORT_H_

--- a/loom/src/loom/format/text/parser/parser.c
+++ b/loom/src/loom/format/text/parser/parser.c
@@ -280,10 +280,10 @@ static iree_status_t loom_parser_resolve_pending_successor_refs(
 }
 
 static iree_status_t loom_parser_verify_symbols_resolved(
-    loom_parser_t* parser) {
-  loom_symbol_reference_table_t reference_table;
+    loom_parser_t* parser, iree_arena_allocator_t* symbol_reference_arena,
+    loom_symbol_reference_table_t* out_symbol_references) {
   IREE_RETURN_IF_ERROR(loom_symbol_reference_table_build(
-      parser->module, &parser->parser_arena, &reference_table));
+      parser->module, symbol_reference_arena, out_symbol_references));
 
   for (iree_host_size_t i = 0;
        i < parser->symbol_origins.count && !loom_parser_at_error_limit(parser);
@@ -296,10 +296,11 @@ static iree_status_t loom_parser_verify_symbols_resolved(
     bool has_reference = false;
     bool has_availability = false;
     loom_symbol_reference_occurrence_id_t occurrence_id =
-        reference_table.symbols[origin.symbol_id].first_incoming_occurrence_id;
+        out_symbol_references->symbols[origin.symbol_id]
+            .first_incoming_occurrence_id;
     while (occurrence_id != LOOM_SYMBOL_REFERENCE_OCCURRENCE_ID_INVALID) {
       const loom_symbol_reference_occurrence_t* occurrence =
-          &reference_table.occurrences[occurrence_id];
+          &out_symbol_references->occurrences[occurrence_id];
       has_reference = true;
       if (occurrence->role == LOOM_SYMBOL_REFERENCE_ROLE_AVAILABILITY) {
         has_availability = true;
@@ -1157,13 +1158,17 @@ static iree_status_t loom_parse_module_body(loom_parser_t* parser) {
 // Public API
 //===----------------------------------------------------------------------===//
 
-iree_status_t loom_text_parse(iree_string_view_t source,
-                              iree_string_view_t filename,
-                              loom_context_t* context,
-                              iree_arena_block_pool_t* block_pool,
-                              const loom_text_parse_options_t* options,
-                              loom_module_t** out_module) {
+static iree_status_t loom_text_parse_impl(
+    iree_string_view_t source, iree_string_view_t filename,
+    loom_context_t* context, iree_arena_block_pool_t* block_pool,
+    const loom_text_parse_options_t* options,
+    iree_arena_allocator_t* symbol_reference_arena,
+    loom_symbol_reference_table_t* out_symbol_references,
+    loom_module_t** out_module) {
   *out_module = NULL;
+  if (out_symbol_references) {
+    *out_symbol_references = (loom_symbol_reference_table_t){0};
+  }
 
   // Allocate the module using the context's host allocator.
   loom_module_t* module = NULL;
@@ -1233,7 +1238,12 @@ iree_status_t loom_text_parse(iree_string_view_t source,
   // within this parse and must resolve before parsing completes. Availability
   // references intentionally preserve unresolved provider anchors.
   if (iree_status_is_ok(status) && parser.error_count == 0) {
-    status = loom_parser_verify_symbols_resolved(&parser);
+    loom_symbol_reference_table_t transient_symbol_references = {0};
+    status = loom_parser_verify_symbols_resolved(
+        &parser,
+        symbol_reference_arena ? symbol_reference_arena : &parser.parser_arena,
+        out_symbol_references ? out_symbol_references
+                              : &transient_symbol_references);
   }
 
   // Build use-def chains in one pass.
@@ -1247,6 +1257,9 @@ iree_status_t loom_text_parse(iree_string_view_t source,
 
   // Infrastructure failures propagate directly.
   if (!iree_status_is_ok(status)) {
+    if (out_symbol_references) {
+      *out_symbol_references = (loom_symbol_reference_table_t){0};
+    }
     loom_module_free(module);
     return status;
   }
@@ -1254,10 +1267,38 @@ iree_status_t loom_text_parse(iree_string_view_t source,
   // Parse errors were emitted as diagnostics but no infrastructure failure.
   // The caller checks *out_module; NULL means parse errors occurred.
   if (parser.error_count > 0) {
+    if (out_symbol_references) {
+      *out_symbol_references = (loom_symbol_reference_table_t){0};
+    }
     loom_module_free(module);
     return iree_ok_status();
   }
 
   *out_module = module;
   return iree_ok_status();
+}
+
+iree_status_t loom_text_parse(iree_string_view_t source,
+                              iree_string_view_t filename,
+                              loom_context_t* context,
+                              iree_arena_block_pool_t* block_pool,
+                              const loom_text_parse_options_t* options,
+                              loom_module_t** out_module) {
+  return loom_text_parse_impl(source, filename, context, block_pool, options,
+                              /*symbol_reference_arena=*/NULL,
+                              /*out_symbol_references=*/NULL, out_module);
+}
+
+iree_status_t loom_text_parse_with_symbol_references(
+    iree_string_view_t source, iree_string_view_t filename,
+    loom_context_t* context, iree_arena_block_pool_t* block_pool,
+    const loom_text_parse_options_t* options,
+    iree_arena_allocator_t* symbol_reference_arena,
+    loom_symbol_reference_table_t* out_symbol_references,
+    loom_module_t** out_module) {
+  IREE_ASSERT_ARGUMENT(symbol_reference_arena);
+  IREE_ASSERT_ARGUMENT(out_symbol_references);
+  return loom_text_parse_impl(source, filename, context, block_pool, options,
+                              symbol_reference_arena, out_symbol_references,
+                              out_module);
 }

--- a/loom/src/loom/format/text/parser/parser.h
+++ b/loom/src/loom/format/text/parser/parser.h
@@ -9,6 +9,7 @@
 
 #include "iree/base/api.h"
 #include "iree/base/internal/arena.h"
+#include "loom/analysis/symbol_references.h"
 #include "loom/error/diagnostic.h"
 #include "loom/format/text/low_asm.h"
 #include "loom/ir/ir.h"
@@ -75,6 +76,25 @@ iree_status_t loom_text_parse(iree_string_view_t source,
                               iree_arena_block_pool_t* block_pool,
                               const loom_text_parse_options_t* options,
                               loom_module_t** out_module);
+
+// Parses Loom IR text and returns the canonical symbol-reference analysis for
+// the parsed module snapshot.
+//
+// Parsing, diagnostics, and module ownership match loom_text_parse(). The
+// caller-provided |symbol_reference_arena| owns every array referenced by
+// |out_symbol_references|. The returned table borrows |*out_module| and remains
+// valid only while the arena is alive and the module has not been mutated.
+//
+// On a clean parse, |*out_module| and |*out_symbol_references| describe the
+// same module snapshot. On parse or infrastructure failure, |*out_module| is
+// NULL and |*out_symbol_references| is empty.
+iree_status_t loom_text_parse_with_symbol_references(
+    iree_string_view_t source, iree_string_view_t filename,
+    loom_context_t* context, iree_arena_block_pool_t* block_pool,
+    const loom_text_parse_options_t* options,
+    iree_arena_allocator_t* symbol_reference_arena,
+    loom_symbol_reference_table_t* out_symbol_references,
+    loom_module_t** out_module);
 
 #ifdef __cplusplus
 }

--- a/loom/src/loom/format/text/parser/parser_test.cc
+++ b/loom/src/loom/format/text/parser/parser_test.cc
@@ -1075,6 +1075,57 @@ TEST_F(ParserTest, AvailabilityOnlyUnresolvedSymbolIsAccepted) {
   loom_module_free(module);
 }
 
+TEST_F(ParserTest, ReturnsSymbolReferencesFromParsedSnapshot) {
+  const char* source =
+      "test.func @main() {\n"
+      "  test.symbol_array_attrs [@dependency] using [@provider]\n"
+      "  test.yield\n"
+      "}\n"
+      "test.record @dependency\n";
+  capture_.Reset();
+  loom_text_parse_options_t options = {
+      /*.diagnostic_sink=*/capture_.sink(),
+      /*.max_errors=*/100,
+  };
+  iree_arena_allocator_t symbol_reference_arena;
+  iree_arena_initialize(&block_pool_, &symbol_reference_arena);
+  loom_symbol_reference_table_t symbol_references = {0};
+  loom_module_t* module = nullptr;
+  IREE_ASSERT_OK(loom_text_parse_with_symbol_references(
+      iree_make_cstring_view(source), IREE_SV("test.loom"), &context_,
+      &block_pool_, &options, &symbol_reference_arena, &symbol_references,
+      &module));
+  ASSERT_TRUE(capture_.diagnostics.empty());
+  ASSERT_NE(module, nullptr);
+  EXPECT_EQ(symbol_references.module, module);
+  EXPECT_EQ(symbol_references.symbol_count, module->symbols.count);
+
+  const loom_symbol_id_t dependency_id = loom_module_find_symbol(
+      module, loom_module_lookup_string(module, IREE_SV("dependency")));
+  const loom_symbol_id_t provider_id = loom_module_find_symbol(
+      module, loom_module_lookup_string(module, IREE_SV("provider")));
+  ASSERT_NE(dependency_id, LOOM_SYMBOL_ID_INVALID);
+  ASSERT_NE(provider_id, LOOM_SYMBOL_ID_INVALID);
+
+  const loom_symbol_reference_occurrence_id_t dependency_occurrence_id =
+      symbol_references.symbols[dependency_id].first_incoming_occurrence_id;
+  const loom_symbol_reference_occurrence_id_t availability_occurrence_id =
+      symbol_references.symbols[provider_id].first_incoming_occurrence_id;
+  ASSERT_NE(dependency_occurrence_id,
+            LOOM_SYMBOL_REFERENCE_OCCURRENCE_ID_INVALID);
+  ASSERT_NE(availability_occurrence_id,
+            LOOM_SYMBOL_REFERENCE_OCCURRENCE_ID_INVALID);
+  const loom_symbol_reference_occurrence_t* dependency =
+      &symbol_references.occurrences[dependency_occurrence_id];
+  const loom_symbol_reference_occurrence_t* availability =
+      &symbol_references.occurrences[availability_occurrence_id];
+  EXPECT_EQ(dependency->role, LOOM_SYMBOL_REFERENCE_ROLE_DEPENDENCY);
+  EXPECT_EQ(availability->role, LOOM_SYMBOL_REFERENCE_ROLE_AVAILABILITY);
+
+  iree_arena_deinitialize(&symbol_reference_arena);
+  loom_module_free(module);
+}
+
 TEST_F(ParserTest, ParameterizedAttrsRoundTripInDeclarationOrder) {
   std::string text = RoundTrip(
       "test.record @target\n"

--- a/loom/src/loom/link/linker.c
+++ b/loom/src/loom/link/linker.c
@@ -7,6 +7,7 @@
 #include "loom/link/linker.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "loom/analysis/symbol_references.h"
@@ -2159,6 +2160,83 @@ iree_status_t loom_linker_add_module(loom_linker_t* linker,
   return status;
 }
 
+// Clones exact definitions in authored source operation order. Exact
+// selections are sorted by symbol ordinal, which is also source order for
+// ordinary modules. Authored operation moves can make those orders diverge;
+// only that uncommon case needs a sorted projection.
+static iree_status_t loom_linker_clone_exact_symbol_ops(
+    loom_linker_source_t* source) {
+  bool source_ordered = true;
+  bool has_definition = false;
+  uint64_t previous_block_ordinal = 0;
+  for (iree_host_size_t i = 0; i < source->exact.count; ++i) {
+    const uint16_t source_symbol_id = (uint16_t)source->exact.ordinals[i];
+    const loom_symbol_t* source_symbol =
+        &source->module->symbols.entries[source_symbol_id];
+    if (source_symbol->defining_op == NULL) {
+      continue;
+    }
+    const uint64_t block_ordinal = source_symbol->defining_op->block_ordinal;
+    if (has_definition && block_ordinal < previous_block_ordinal) {
+      source_ordered = false;
+      break;
+    }
+    has_definition = true;
+    previous_block_ordinal = block_ordinal;
+  }
+  if (source_ordered) {
+    iree_status_t status = iree_ok_status();
+    for (iree_host_size_t i = 0;
+         i < source->exact.count && iree_status_is_ok(status); ++i) {
+      const uint16_t source_symbol_id = (uint16_t)source->exact.ordinals[i];
+      const loom_symbol_t* source_symbol =
+          &source->module->symbols.entries[source_symbol_id];
+      if (source_symbol->defining_op == NULL) {
+        continue;
+      }
+      status = loom_linker_clone_or_merge_symbol_op(
+          source, source_symbol_id, source->target_symbols[i],
+          source->exact.outputs ? source->exact.outputs[i]
+                                : LOOM_LINKER_SYMBOL_OUTPUT_AUTHORED);
+    }
+    return status;
+  }
+
+  loom_linker_exact_symbol_op_t* selected_ops = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_arena_allocate_array(source->arena, source->exact.count,
+                                sizeof(*selected_ops), (void**)&selected_ops));
+
+  iree_host_size_t selected_op_count = 0;
+  for (iree_host_size_t i = 0; i < source->exact.count; ++i) {
+    const uint16_t source_symbol_id = (uint16_t)source->exact.ordinals[i];
+    const loom_symbol_t* source_symbol =
+        &source->module->symbols.entries[source_symbol_id];
+    if (source_symbol->defining_op == NULL) {
+      continue;
+    }
+    selected_ops[selected_op_count++] = (loom_linker_exact_symbol_op_t){
+        .source_op = source_symbol->defining_op,
+        .source_symbol_id = source_symbol_id,
+        .selection_ordinal = i,
+    };
+  }
+  loom_linker_sort_exact_symbol_ops(selected_ops, selected_op_count);
+
+  iree_status_t status = iree_ok_status();
+  for (iree_host_size_t i = 0;
+       i < selected_op_count && iree_status_is_ok(status); ++i) {
+    const loom_linker_exact_symbol_op_t* selected_op = &selected_ops[i];
+    status = loom_linker_clone_or_merge_symbol_op(
+        source, selected_op->source_symbol_id,
+        source->target_symbols[selected_op->selection_ordinal],
+        source->exact.outputs
+            ? source->exact.outputs[selected_op->selection_ordinal]
+            : LOOM_LINKER_SYMBOL_OUTPUT_AUTHORED);
+  }
+  return status;
+}
+
 static iree_status_t loom_linker_add_exact_selection(
     loom_linker_t* linker, const loom_module_t* source_module,
     loom_linker_exact_selection_t selection,
@@ -2227,7 +2305,7 @@ static iree_status_t loom_linker_add_exact_selection(
         &source, source_symbol_id, &source.target_symbols[i], &target_ref);
   }
 
-  if (selection.dense) {
+  if (iree_status_is_ok(status) && selection.dense) {
     const loom_block_t* source_block =
         loom_region_const_entry_block(source_module->body);
     for (const loom_op_t* source_op = source_block->first_op;
@@ -2246,37 +2324,8 @@ static iree_status_t loom_linker_add_exact_selection(
                                              /*before_op=*/NULL, &cloned_op);
       }
     }
-  } else {
-    loom_linker_exact_symbol_op_t* selected_ops = NULL;
-    if (iree_status_is_ok(status) && selection.count > 0) {
-      status = iree_arena_allocate_array(&source_arena, selection.count,
-                                         sizeof(*selected_ops),
-                                         (void**)&selected_ops);
-    }
-    iree_host_size_t selected_op_count = 0;
-    for (iree_host_size_t i = 0;
-         i < selection.count && iree_status_is_ok(status); ++i) {
-      const uint16_t source_symbol_id = (uint16_t)selection.ordinals[i];
-      const loom_op_t* source_op =
-          source_module->symbols.entries[source_symbol_id].defining_op;
-      if (!source_op) continue;
-      selected_ops[selected_op_count++] = (loom_linker_exact_symbol_op_t){
-          .source_op = source_op,
-          .source_symbol_id = source_symbol_id,
-          .selection_ordinal = i,
-      };
-    }
-    loom_linker_sort_exact_symbol_ops(selected_ops, selected_op_count);
-    for (iree_host_size_t i = 0;
-         i < selected_op_count && iree_status_is_ok(status); ++i) {
-      const loom_linker_exact_symbol_op_t* selected_op = &selected_ops[i];
-      status = loom_linker_clone_or_merge_symbol_op(
-          &source, selected_op->source_symbol_id,
-          source.target_symbols[selected_op->selection_ordinal],
-          source.exact.outputs
-              ? source.exact.outputs[selected_op->selection_ordinal]
-              : LOOM_LINKER_SYMBOL_OUTPUT_AUTHORED);
-    }
+  } else if (iree_status_is_ok(status)) {
+    status = loom_linker_clone_exact_symbol_ops(&source);
   }
 
   iree_host_size_t max_anchor_count = 0;

--- a/loom/src/loom/link/module_index.c
+++ b/loom/src/loom/link/module_index.c
@@ -919,57 +919,50 @@ static void loom_link_index_copy_dependency_occurrences(
   }
 }
 
-static iree_status_t loom_link_index_project_materialized_references(
+static iree_status_t loom_link_index_project_symbol_references(
     loom_link_module_index_t* index, loom_link_module_index_module_t* module,
-    const loom_module_t* source_module) {
-  iree_arena_allocator_t scratch_arena;
-  iree_arena_initialize(index->block_pool, &scratch_arena);
-
-  loom_symbol_reference_table_t table = {0};
+    const loom_symbol_reference_table_t* table) {
   uint32_t* dependency_values = NULL;
   uint8_t* dependency_source_root_region_indices_plus_one = NULL;
   loom_link_template_family_ordinal_t* template_demand_values = NULL;
   uint8_t* template_demand_source_root_region_indices_plus_one = NULL;
-  iree_status_t status =
-      loom_symbol_reference_table_build(source_module, &scratch_arena, &table);
-  if (iree_status_is_ok(status)) {
-    iree_host_size_t dependency_count = 0;
-    for (iree_host_size_t i = 0; i < table.occurrence_count; ++i) {
-      if (loom_symbol_reference_occurrence_is_dependency(
-              &table.occurrences[i])) {
-        ++dependency_count;
-      }
+  iree_status_t status = iree_ok_status();
+  iree_host_size_t dependency_count = 0;
+  for (iree_host_size_t i = 0; i < table->occurrence_count; ++i) {
+    if (loom_symbol_reference_occurrence_is_dependency(
+            &table->occurrences[i])) {
+      ++dependency_count;
     }
-    module->dependencies.root_count =
-        loom_link_index_count_dependency_occurrences(
-            &table, table.first_module_occurrence_id);
-    module->dependencies.count = dependency_count;
-    if (dependency_count > 0) {
-      status = iree_arena_allocate_array(&index->arena, dependency_count,
-                                         sizeof(*dependency_values),
-                                         (void**)&dependency_values);
-      module->dependencies.values = dependency_values;
-      if (iree_status_is_ok(status)) {
-        status = iree_arena_allocate_array(
-            &index->arena, dependency_count,
-            sizeof(*dependency_source_root_region_indices_plus_one),
-            (void**)&dependency_source_root_region_indices_plus_one);
-        module->dependencies.source_root_region_indices_plus_one =
-            dependency_source_root_region_indices_plus_one;
-      }
+  }
+  module->dependencies.root_count =
+      loom_link_index_count_dependency_occurrences(
+          table, table->first_module_occurrence_id);
+  module->dependencies.count = dependency_count;
+  if (dependency_count > 0) {
+    status = iree_arena_allocate_array(&index->arena, dependency_count,
+                                       sizeof(*dependency_values),
+                                       (void**)&dependency_values);
+    module->dependencies.values = dependency_values;
+    if (iree_status_is_ok(status)) {
+      status = iree_arena_allocate_array(
+          &index->arena, dependency_count,
+          sizeof(*dependency_source_root_region_indices_plus_one),
+          (void**)&dependency_source_root_region_indices_plus_one);
+      module->dependencies.source_root_region_indices_plus_one =
+          dependency_source_root_region_indices_plus_one;
     }
   }
 
   if (iree_status_is_ok(status)) {
-    module->template_demands.count = table.template_demands.count;
-    if (table.template_demands.count > 0) {
+    module->template_demands.count = table->template_demands.count;
+    if (table->template_demands.count > 0) {
       status = iree_arena_allocate_array(
-          &index->arena, table.template_demands.count,
+          &index->arena, table->template_demands.count,
           sizeof(*template_demand_values), (void**)&template_demand_values);
       module->template_demands.values = template_demand_values;
       if (iree_status_is_ok(status)) {
         status = iree_arena_allocate_array(
-            &index->arena, table.template_demands.count,
+            &index->arena, table->template_demands.count,
             sizeof(*template_demand_source_root_region_indices_plus_one),
             (void**)&template_demand_source_root_region_indices_plus_one);
         module->template_demands.source_root_region_indices_plus_one =
@@ -982,20 +975,20 @@ static iree_status_t loom_link_index_project_materialized_references(
   iree_host_size_t template_demand_position = 0;
   if (iree_status_is_ok(status)) {
     loom_link_index_copy_dependency_occurrences(
-        &table, table.first_module_occurrence_id, dependency_values,
+        table, table->first_module_occurrence_id, dependency_values,
         dependency_source_root_region_indices_plus_one, &dependency_position);
     for (iree_host_size_t symbol_index = 0;
-         symbol_index < table.symbol_count && iree_status_is_ok(status);
+         symbol_index < table->symbol_count && iree_status_is_ok(status);
          ++symbol_index) {
       loom_link_module_index_symbol_t* symbol =
           &index->symbols.values[module->symbol_start_ordinal + symbol_index];
       const loom_symbol_reference_symbol_occurrences_t* source =
-          &table.symbols[symbol_index];
+          &table->symbols[symbol_index];
       symbol->dependencies.first = (uint32_t)dependency_position;
       symbol->dependencies.count = loom_link_index_count_dependency_occurrences(
-          &table, source->first_outgoing_occurrence_id);
+          table, source->first_outgoing_occurrence_id);
       loom_link_index_copy_dependency_occurrences(
-          &table, source->first_outgoing_occurrence_id, dependency_values,
+          table, source->first_outgoing_occurrence_id, dependency_values,
           dependency_source_root_region_indices_plus_one, &dependency_position);
 
       symbol->template_demands.first = (uint32_t)template_demand_position;
@@ -1004,7 +997,7 @@ static iree_status_t loom_link_index_project_materialized_references(
       while (demand_id != LOOM_TEMPLATE_DEMAND_ID_INVALID &&
              iree_status_is_ok(status)) {
         const loom_template_demand_t* demand =
-            &table.template_demands.values[demand_id];
+            &table->template_demands.values[demand_id];
         loom_link_template_family_ordinal_t family_ordinal =
             LOOM_LINK_TEMPLATE_FAMILY_ORDINAL_INVALID;
         status = loom_link_index_resolve_template_family(
@@ -1020,6 +1013,22 @@ static iree_status_t loom_link_index_project_materialized_references(
         demand_id = demand->next_source_demand_id;
       }
     }
+  }
+
+  return status;
+}
+
+static iree_status_t loom_link_index_project_materialized_references(
+    loom_link_module_index_t* index, loom_link_module_index_module_t* module,
+    const loom_module_t* source_module) {
+  iree_arena_allocator_t scratch_arena;
+  iree_arena_initialize(index->block_pool, &scratch_arena);
+
+  loom_symbol_reference_table_t table = {0};
+  iree_status_t status =
+      loom_symbol_reference_table_build(source_module, &scratch_arena, &table);
+  if (iree_status_is_ok(status)) {
+    status = loom_link_index_project_symbol_references(index, module, &table);
   }
 
   iree_arena_deinitialize(&scratch_arena);
@@ -1431,25 +1440,30 @@ iree_status_t loom_link_module_index_add_text(
     iree_host_size_t* out_provider_ordinal) {
   IREE_ASSERT_ARGUMENT(index);
 
+  iree_arena_allocator_t symbol_reference_arena;
+  iree_arena_initialize(index->block_pool, &symbol_reference_arena);
+
+  loom_symbol_reference_table_t symbol_references = {0};
   loom_module_t* module = NULL;
-  IREE_RETURN_IF_ERROR(loom_text_parse(source, filename, index->context,
-                                       index->block_pool, parse_options,
-                                       &module));
-  if (!module) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "text provider '%.*s' did not parse into a module",
-                            (int)filename.size, filename.data);
+  iree_status_t status = loom_text_parse_with_symbol_references(
+      source, filename, index->context, index->block_pool, parse_options,
+      &symbol_reference_arena, &symbol_references, &module);
+  if (iree_status_is_ok(status) && !module) {
+    status =
+        iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                         "text provider '%.*s' did not parse into a module",
+                         (int)filename.size, filename.data);
   }
-  iree_status_t status = loom_link_index_validate_materialized_module(module);
-  if (!iree_status_is_ok(status)) {
-    loom_module_free(module);
-    return status;
+  if (iree_status_is_ok(status)) {
+    status = loom_link_index_validate_materialized_module(module);
   }
 
   loom_link_module_index_provider_t* provider = NULL;
-  status = loom_link_index_append_provider(index, LOOM_LINK_PROVIDER_TEXT,
-                                           filename, options, &provider);
   bool module_owned_by_index = false;
+  if (iree_status_is_ok(status)) {
+    status = loom_link_index_append_provider(index, LOOM_LINK_PROVIDER_TEXT,
+                                             filename, options, &provider);
+  }
   if (iree_status_is_ok(status)) {
     loom_link_module_index_module_t* indexed_module = NULL;
     status = loom_link_index_append_module(
@@ -1466,16 +1480,18 @@ iree_status_t loom_link_module_index_add_text(
           index, indexed_module, module);
     }
     if (iree_status_is_ok(status)) {
-      status = loom_link_index_project_materialized_references(
-          index, indexed_module, module);
+      status = loom_link_index_project_symbol_references(index, indexed_module,
+                                                         &symbol_references);
     }
     if (iree_status_is_ok(status)) {
       status = loom_link_index_project_materialized_provider_imports(
           index, indexed_module, module);
     }
   }
+
+  iree_arena_deinitialize(&symbol_reference_arena);
   if (!iree_status_is_ok(status)) {
-    if (!module_owned_by_index) {
+    if (module && !module_owned_by_index) {
       loom_module_free(module);
     }
     return status;

--- a/loom/src/loom/link/module_index_test.cc
+++ b/loom/src/loom/link/module_index_test.cc
@@ -384,7 +384,7 @@ func.def public @exported(%x: i32) -> (i32) {
 }
 
 TEST_F(ModuleIndexTest, ProjectsMaterializedAndBytecodeReferenceMetadata) {
-  loom_module_t* module = Parse(IREE_SV(R"(
+  const iree_string_view_t source = IREE_SV(R"(
 func.def public @entry(%x: i32) -> (i32) {
   %y = func.call @helper(%x) : (i32) -> (i32)
   %z = template.apply<@demo.contract>(%y) : (i32) -> (i32)
@@ -400,7 +400,8 @@ template.decl @demo.contract(%x: i32) -> (i32)
 template.def<@demo.contract> @provider(%x: i32) -> (i32) {
   template.return %x : i32
 }
-)"));
+)");
+  loom_module_t* module = Parse(source);
   std::vector<uint8_t> bytes = WriteModule(module);
 
   auto verify_index = [&](const loom_link_module_index_t* index) {
@@ -489,6 +490,13 @@ template.def<@demo.contract> @provider(%x: i32) -> (i32) {
       IREE_SV("library.loombc"), /*index_options=*/nullptr, &options,
       /*out_provider_ordinal=*/nullptr));
   verify_index(bytecode_index.get());
+
+  IndexPtr text_index = CreateIndex();
+  IREE_ASSERT_OK(loom_link_module_index_add_text(
+      text_index.get(), source, IREE_SV("library.loom"),
+      /*parse_options=*/nullptr, &options,
+      /*out_provider_ordinal=*/nullptr));
+  verify_index(text_index.get());
 }
 
 TEST_F(ModuleIndexTest, ProjectsMultiRootReferenceOriginsAcrossProviders) {


### PR DESCRIPTION
Make repeated selective links through the public LoomC API scale with the selected closure instead of the unselected library catalog. A frozen index is constructed once and reused across independent output modules; exact materialization no longer rescans every top-level source operation, and text-backed indexes reuse the parser's canonical symbol-reference analysis instead of rebuilding it from mutable IR.

An in-tree throughput benchmark now makes that complete lifecycle executable and measurable for both authoring text and deployment bytecode. It separates index construction, warm selective links, and index-plus-link batches; reports retained workspace allocation; and verifies that every output contains only its requested root and reachable helper.

## Keep exact materialization proportional to the closure

An exact link plan already identifies every defining operation selected from a source and carries its stable authored block ordinal. The linker previously discarded that information at materialization time, walked the source's complete top-level block, and rediscovered selected definitions. Selecting one symbol therefore grew with every unrelated symbol in the catalog.

Exact sources now clone their selected defining operations directly. The ordinary source-ordered case requires no projection allocation or sort; only an explicitly reordered selection is sorted by stable block ordinal to preserve deterministic authored order. Dense module addition continues to walk the complete body because non-symbol module metadata is intentionally part of an archive-style result.

In the isolated one-symbol witness, growing the source from 1 to 4,096 symbols previously raised exact projection from 2.384 microseconds to 32.613 microseconds. The direct path remains approximately flat across the same range and completes the 4,096-symbol case in 2.138 microseconds, a 15.3x improvement at the largest size.

## Reuse source analysis at the parser boundary

The text parser already builds the canonical symbol-reference table needed to validate unresolved references, but immediate link-index construction used to walk the complete parsed module again to reconstruct the same table. The analyzed parse entry point now returns that snapshot into caller-owned scratch storage, and text indexing projects dependency and template slices from it before releasing the arena.

Ordinary parsing remains self-contained, and indexing a caller-owned materialized module still performs its own analysis. No cached pass state is attached to mutable IR. Coverage holds the returned snapshot across parser teardown and verifies equivalent dependency and template projections for materialized, text, and bytecode providers.

On the 100.6 MB text fixture, controlled interleaved measurements reduce index construction from 800.339 ms to 763.809 ms, removing 36.529 ms or 4.56%. Deployment bytecode already carries serialized symbol-reference metadata and does not pay this text-only reconstruction cost.

## Exercise the public deployment lifecycle

The new benchmark uses only public LoomC handles and calls. Shared benchmark support owns allocator conversion, handle lifetimes, and result diagnostics so compile and link throughput harnesses use the same API discipline without depending on one another.

The largest fixture represents 4,096 independently selectable public roots plus one shared helper. Each root has 512 chained body operations—roughly a 500-line one-operation-per-line kernel body—giving 2,113,538 total IR operations in 100,581,462 bytes of text or 67,676,278 bytes of Loom bytecode. Every selective result is a standalone two-function closure containing 518 IR operations.

Optimized single-threaded measurements of the bytecode deployment path are:

| Lifecycle | Median time |
| --- | ---: |
| Index the 4,097-symbol catalog | 24.719 ms |
| Materialize 80 outputs from a warm index | 10.708 ms |
| Index once and materialize 80 outputs | 31.533 ms |
| Materialize 388 outputs from a warm index | 53.127 ms |
| Index once and materialize 388 outputs | 73.700 ms |

The warm rows retain every output during timing. Eighty bytecode outputs occupy 20.875 MiB of worker-local workspace; 388 occupy 97.875 MiB, 33% less than the equivalent text-backed outputs. After the untimed warmup, the reusable workspace acquires no additional system blocks.

These measurements stop at standalone Loom module materialization; specialization and hardware code generation remain separate compiler stages. They establish that a deployment library containing thousands of substantial kernels can be indexed once and selectively decomposed into dozens or hundreds of exact compilation units in tens of milliseconds rather than repeatedly paying whole-catalog analysis.

## Reviewer Notes

The highest-value review surfaces are the direct exact-selection path versus dense module addition in `linker.c`, the parser-owned symbol-reference snapshot lifetime at the text-index boundary, and the benchmark's public API ownership and closure checks. The benchmark keeps catalog size, selected closure size, batch size, source representation, and retained workspace visible as independent counters so future regressions cannot hide behind a smaller fixture or an accidental archive link.
