### PR TITLE
[Loom] Scope function-pass dominance analysis

### DIFF
--- a/loom/src/loom/transforms/cfg/cfg_simplify.c
+++ b/loom/src/loom/transforms/cfg/cfg_simplify.c
@@ -2184,7 +2184,10 @@ static iree_status_t loom_cfg_simplify_process_function_once(
 
 iree_status_t loom_cfg_simplify_run(loom_pass_t* pass, loom_module_t* module,
                                     loom_func_like_t function) {
-  if (!loom_func_like_body(function)) return iree_ok_status();
+  loom_region_t* body = loom_func_like_body(function);
+  if (!body) {
+    return iree_ok_status();
+  }
 
   loom_rewriter_t rewriter = {0};
   IREE_RETURN_IF_ERROR(
@@ -2217,13 +2220,12 @@ iree_status_t loom_cfg_simplify_run(loom_pass_t* pass, loom_module_t* module,
         &fact_table);
     if (!iree_status_is_ok(status)) break;
 
-    status = loom_cfg_simplify_mark_cfg_regions(loom_func_like_body(function),
-                                                &analysis_arena);
+    status = loom_cfg_simplify_mark_cfg_regions(body, &analysis_arena);
     if (!iree_status_is_ok(status)) break;
 
     loom_dominance_info_t dominance = {0};
-    status =
-        loom_dominance_info_initialize(module, &analysis_arena, &dominance);
+    status = loom_dominance_info_initialize_region(module, body,
+                                                   &analysis_arena, &dominance);
     if (!iree_status_is_ok(status)) break;
 
     state.fact_table = fact_table;

--- a/loom/src/loom/transforms/cleanup/cse.c
+++ b/loom/src/loom/transforms/cleanup/cse.c
@@ -834,11 +834,7 @@ iree_status_t loom_cse_run(loom_pass_t* pass, loom_module_t* module,
     }
   }
 
-  loom_dominance_info_t dominance = {0};
-  IREE_RETURN_IF_ERROR(
-      loom_dominance_info_initialize(module, pass->arena, &dominance));
-
-  // Scope arena: holds all scope structs and hash table arrays.
+  // Scope arena: holds dominance, scope structs, and hash table arrays.
   // Reset between root regions to bound peak memory to the largest single
   // function-like region. Shares the pass arena's block pool.
   iree_arena_allocator_t scope_arena;
@@ -856,6 +852,13 @@ iree_status_t loom_cse_run(loom_pass_t* pass, loom_module_t* module,
     if (!region) continue;
 
     iree_arena_reset(&scope_arena);
+    loom_dominance_info_t dominance = {0};
+    status = loom_dominance_info_initialize_region(module, region, &scope_arena,
+                                                   &dominance);
+    if (!iree_status_is_ok(status)) {
+      break;
+    }
+
     stack.count = 0;
     status = loom_cse_push_region_block_frames(&stack, pass->arena,
                                                &scope_arena, &dominance, region,


### PR DESCRIPTION
Scope dominance construction in CFG simplification and CSE to the function-like region each invocation actually transforms. Compiling a multi-entry artifact no longer rebuilds dominator state for every unrelated function once per root, while the transformation semantics and emitted hardware code remain unchanged.

## Match analysis ownership to pass scope

Both passes are function passes: the pass interpreter invokes them with one `loom_func_like_t`, and no dominance relationship crosses that function's root regions. They nevertheless initialized dominance from the complete module body. In a module containing many independent kernels, every function invocation therefore reconstructed CFG and dominance state for all of its siblings.

CFG simplification now initializes dominance from the current function body on each simplification iteration. It still rebuilds after a CFG rewrite, exactly where invalidation requires it, but unrelated module regions never enter that analysis.

CSE now initializes dominance independently for each root region it traverses and stores it in the same resettable scope arena as that root's CSE scopes and hash tables. Resetting the arena between roots bounds analysis lifetime and peak temporary storage to the largest region processed by the invocation. Module-level dominance entry points remain available for the passes and queries that genuinely operate on a complete module.

This is an ownership correction rather than a cache. It adds no persistent module state, invalidation protocol, lookup table, or cross-function analysis lifetime.

## Remove a production-scale multiplier

The production witness is a captured Qwen prefill compilation unit containing 128 independent `kernel.def` roots in 1.1 MiB of Loom bytecode. An optimized control/candidate/control/candidate/control run compiled the exact same artifact through AMDGPU code generation:

| Implementation | Wall time |
| --- | ---: |
| Whole-module dominance, control median | 17.210 s |
| Function-scoped dominance, candidate midpoint | 4.575 s |

Scoping the analysis removes 73.4% of end-to-end compilation time, a 3.76x speedup. Control and candidate produce byte-identical 648 KiB HSACO outputs, demonstrating that the change removes redundant analysis rather than altering optimization or code generation.

The witness deliberately retains the unusual 128-entry module shape so the former multiplier remains observable. Ordinary single-entry kernels preserve the same analysis and transformation behavior; multi-entry artifacts now pay dominance only for the function being processed.

## Reviewer Notes

The review surface is intentionally small: confirm that CFG simplification rebuilds region-local dominance at its existing rewrite invalidation point, and that CSE's dominance lifetime matches the resettable per-root scope arena. No caller-visible API or IR contract changes.
