### PR TITLE
[Loom] Preserve requested facets through selective linking

### DIFF
--- a/loom/py/loom/format/bytecode/reader.py
+++ b/loom/py/loom/format/bytecode/reader.py
@@ -52,6 +52,7 @@ from loom.format.bytecode.writer import (
     SECTION_TYPES,
     SOURCE_TRIVIA_COMMENT_COUNT_SHIFT,
     SOURCE_TRIVIA_LEADING_BLANK_LINE,
+    SYMBOL_INTERFACE_FLAG_MASK,
     SYMBOL_KIND_ANCHOR,
 )
 from loom.ir import (
@@ -1433,7 +1434,7 @@ class BytecodeReader:
         minimum_encoded_bytes = (
             1
             + symbol_count * 2
-            + total_dependency_count * 2
+            + total_dependency_count * 3
             + total_template_demand_count * 2
         )
         if minimum_encoded_bytes > len(data) - offset:
@@ -1459,6 +1460,9 @@ class BytecodeReader:
                 dependency, offset = decode_varint(data, offset)
                 if dependency >= symbol_count:
                     raise BytecodeError("dependency symbol index is out of range")
+                target_interfaces, offset = decode_varint(data, offset)
+                if target_interfaces & ~SYMBOL_INTERFACE_FLAG_MASK:
+                    raise BytecodeError("dependency target interfaces are invalid")
                 decoded_dependency_count += 1
             return offset
 

--- a/loom/py/loom/format/bytecode/reader_test.py
+++ b/loom/py/loom/format/bytecode/reader_test.py
@@ -560,6 +560,46 @@ class TestMalformedSymbolReferences:
         with pytest.raises(BytecodeError, match="source root region index"):
             read_module(bytes(data))
 
+    def test_dependency_target_interfaces_must_be_known(self) -> None:
+        module = Module(name="test")
+        _make_func(module, "target", [], is_declaration=True)
+        _make_func(
+            module,
+            "caller",
+            [],
+            ops=[
+                Operation(
+                    name="func.call",
+                    attributes={"callee": SymbolName("target")},
+                ),
+                Operation(name="test.yield"),
+            ],
+        )
+        data = bytearray(write_module(module))
+        module_offset, _module_length = _module_range(data)
+        _entry_offset, section_offset, _section_length = _find_section_entry(
+            data, SECTION_SYMBOL_REFERENCES
+        )
+        offset = module_offset + section_offset
+        symbol_count, offset = decode_varint(data, offset)
+        dependency_count, offset = decode_varint(data, offset)
+        template_demand_count, offset = decode_varint(data, offset)
+        module_dependency_count, offset = decode_varint(data, offset)
+        assert (symbol_count, dependency_count, template_demand_count) == (2, 1, 0)
+        assert module_dependency_count == 0
+        target_dependency_count, offset = decode_varint(data, offset)
+        target_demand_count, offset = decode_varint(data, offset)
+        caller_dependency_count, offset = decode_varint(data, offset)
+        assert (target_dependency_count, target_demand_count) == (0, 0)
+        assert caller_dependency_count == 1
+        _source_root, offset = decode_varint(data, offset)
+        _target_symbol, offset = decode_varint(data, offset)
+        assert data[offset : offset + 2] == b"\x80\x02"
+        data[offset + 1] = 0x40
+
+        with pytest.raises(BytecodeError, match="target interfaces"):
+            read_module(bytes(data))
+
 
 class TestMalformedLocationMode:
     def test_full_locations_mode_is_rejected_until_implemented(self) -> None:

--- a/loom/py/loom/format/bytecode/writer.py
+++ b/loom/py/loom/format/bytecode/writer.py
@@ -181,8 +181,25 @@ BYTECODE_IR_KIND_BY_TYPE_KIND: dict[int, TypeKind] = {
 
 # File magic and version.
 MAGIC = b"LOOM"
-FORMAT_VERSION = 31
+FORMAT_VERSION = 32
 PRODUCER = "loom-py"
+
+SYMBOL_INTERFACE_BITS = {
+    "func_like": 1 << 0,
+    "global": 1 << 1,
+    "executable": 1 << 2,
+    "record": 1 << 3,
+    "target": 1 << 4,
+    "config": 1 << 5,
+    "rodata": 1 << 6,
+    "kernel": 1 << 7,
+    "callable": 1 << 8,
+    "command_program": 1 << 9,
+    "template_family": 1 << 10,
+    "template_provider": 1 << 11,
+    "kernel_entry": 1 << 12,
+}
+SYMBOL_INTERFACE_FLAG_MASK = (1 << 13) - 1
 
 SOURCE_TRIVIA_LEADING_BLANK_LINE = 1
 SOURCE_TRIVIA_COMMENT_COUNT_SHIFT = 1
@@ -287,6 +304,7 @@ class _SymbolReferenceRecord:
 
     source_root_region_index_plus_one: int
     target_symbol_index: int
+    target_interfaces: int = 0
 
 
 class _SymbolReferenceProjectionBuilder:
@@ -329,7 +347,10 @@ class _SymbolReferenceProjectionBuilder:
         )
 
     def _add_dependency(
-        self, source_scope: _SymbolReferenceSourceScope, name: str
+        self,
+        source_scope: _SymbolReferenceSourceScope,
+        name: str,
+        target_interfaces: int,
     ) -> None:
         try:
             target_symbol_index = self._wire_symbol_indices[name]
@@ -338,6 +359,7 @@ class _SymbolReferenceProjectionBuilder:
         record = _SymbolReferenceRecord(
             source_root_region_index_plus_one=source_scope.root_region_index_plus_one,
             target_symbol_index=target_symbol_index,
+            target_interfaces=target_interfaces,
         )
         if source_scope.symbol_index is None:
             self._module_dependencies.append(record)
@@ -356,19 +378,23 @@ class _SymbolReferenceProjectionBuilder:
             symbol_ref is not None
             and symbol_ref.role is SymbolReferenceRole.AVAILABILITY
         )
+        target_interfaces = 0
+        if symbol_ref is not None:
+            for interface in symbol_ref.interfaces:
+                target_interfaces |= SYMBOL_INTERFACE_BITS[interface]
         if attr_type == "symbol" or isinstance(value, SymbolName):
             if not is_availability:
-                self._add_dependency(source_scope, str(value))
+                self._add_dependency(source_scope, str(value), target_interfaces)
             return
         if attr_type == "symbol_array" or isinstance(value, SymbolNameArray):
             if not is_availability:
                 for name in value:
-                    self._add_dependency(source_scope, str(name))
+                    self._add_dependency(source_scope, str(name), target_interfaces)
             return
         if attr_type == "symbol_set" or isinstance(value, SymbolNameSet):
             if not is_availability:
                 for name in value:
-                    self._add_dependency(source_scope, str(name))
+                    self._add_dependency(source_scope, str(name), target_interfaces)
             return
         if isinstance(value, _IR_TYPE_CLASSES):
             self._visit_type(source_scope, cast(Type, value))
@@ -2363,6 +2389,7 @@ class BytecodeWriter:
         for dependency in self._module_dependencies:
             buf.write_varint(dependency.source_root_region_index_plus_one)
             buf.write_varint(dependency.target_symbol_index)
+            buf.write_varint(dependency.target_interfaces)
         for dependencies, template_demands in zip(
             self._symbol_dependencies,
             self._symbol_template_demands,
@@ -2372,6 +2399,7 @@ class BytecodeWriter:
             for dependency in dependencies:
                 buf.write_varint(dependency.source_root_region_index_plus_one)
                 buf.write_varint(dependency.target_symbol_index)
+                buf.write_varint(dependency.target_interfaces)
             buf.write_varint(len(template_demands))
             for demand in template_demands:
                 buf.write_varint(demand.source_root_region_index_plus_one)

--- a/loom/py/loom/format/bytecode/writer_test.py
+++ b/loom/py/loom/format/bytecode/writer_test.py
@@ -64,6 +64,7 @@ from loom.format.bytecode.writer import (
     LOCATION_MODE_SOURCE_LOCATIONS,
     SECTION_LOCATIONS,
     SECTION_SYMBOL_REFERENCES,
+    SYMBOL_INTERFACE_BITS,
     write_module,
 )
 from loom.format.text.parser import Parser
@@ -599,14 +600,15 @@ class TestSymbolReferencesSection:
         assert (symbol_count, dependency_count, template_demand_count) == (4, 3, 1)
         assert module_dependency_count == 0
 
-        rows: list[tuple[list[tuple[int, int]], list[tuple[int, int]]]] = []
+        rows: list[tuple[list[tuple[int, int, int]], list[tuple[int, int]]]] = []
         for _ in range(symbol_count):
             row_dependency_count, offset = decode_varint(data, offset)
             dependencies = []
             for _ in range(row_dependency_count):
                 source_root, offset = decode_varint(data, offset)
                 target_symbol, offset = decode_varint(data, offset)
-                dependencies.append((source_root, target_symbol))
+                target_interfaces, offset = decode_varint(data, offset)
+                dependencies.append((source_root, target_symbol, target_interfaces))
             row_template_demand_count, offset = decode_varint(data, offset)
             template_demands = []
             for _ in range(row_template_demand_count):
@@ -617,7 +619,11 @@ class TestSymbolReferencesSection:
 
         assert rows[:3] == [([], []), ([], []), ([], [])]
         assert rows[3] == (
-            [(2, 2), (2, 1), (1, 0)],
+            [
+                (2, 2, SYMBOL_INTERFACE_BITS["template_family"]),
+                (2, 1, SYMBOL_INTERFACE_BITS["record"]),
+                (1, 0, SYMBOL_INTERFACE_BITS["record"]),
+            ],
             [(2, 2)],
         )
         assert offset == len(data)

--- a/loom/src/loom/analysis/BUILD.bazel
+++ b/loom/src/loom/analysis/BUILD.bazel
@@ -691,6 +691,7 @@ loom_cc_test(
         "//loom/src/loom/ops/config",
         "//loom/src/loom/ops/func",
         "//loom/src/loom/ops/global",
+        "//loom/src/loom/ops/kernel",
         "//loom/src/loom/ops/target",
         "//loom/src/loom/ops/template",
         "//loom/src/loom/ops/test",

--- a/loom/src/loom/analysis/CMakeLists.txt
+++ b/loom/src/loom/analysis/CMakeLists.txt
@@ -796,6 +796,7 @@ loom_cc_test(
     loom::ops::config
     loom::ops::func
     loom::ops::global
+    loom::ops::kernel
     loom::ops::op_defs
     loom::ops::target
     loom::ops::template

--- a/loom/src/loom/analysis/symbol_references.c
+++ b/loom/src/loom/analysis/symbol_references.c
@@ -104,7 +104,8 @@ static iree_status_t loom_symbol_reference_builder_append_occurrence(
     loom_symbol_reference_source_scope_t source_scope,
     loom_symbol_id_t target_symbol_id,
     loom_symbol_reference_occurrence_kind_t kind,
-    loom_symbol_reference_role_t role, uint16_t attr_index,
+    loom_symbol_reference_role_t role,
+    loom_symbol_interface_flags_t target_interfaces, uint8_t attr_index,
     const loom_op_t* user_op) {
   if (source_scope.symbol_id != LOOM_SYMBOL_ID_INVALID &&
       source_scope.symbol_id >= builder->module->symbols.count) {
@@ -138,6 +139,7 @@ static iree_status_t loom_symbol_reference_builder_append_occurrence(
   *occurrence = (loom_symbol_reference_occurrence_t){
       .source_symbol_id = source_scope.symbol_id,
       .target_symbol_id = target_symbol_id,
+      .target_interfaces = target_interfaces,
       .kind = kind,
       .role = role,
       .source_root_region_index_plus_one =
@@ -172,14 +174,15 @@ static iree_status_t loom_symbol_reference_add_ref(
     loom_symbol_reference_builder_t* builder,
     loom_symbol_reference_source_scope_t source_scope,
     loom_symbol_ref_t target_ref, loom_symbol_reference_occurrence_kind_t kind,
-    loom_symbol_reference_role_t role, uint16_t attr_index,
+    loom_symbol_reference_role_t role,
+    loom_symbol_interface_flags_t target_interfaces, uint8_t attr_index,
     const loom_op_t* user_op) {
   if (!loom_symbol_ref_is_valid(target_ref) || target_ref.module_id != 0) {
     return iree_ok_status();
   }
   return loom_symbol_reference_builder_append_occurrence(
-      builder, source_scope, target_ref.symbol_id, kind, role, attr_index,
-      user_op);
+      builder, source_scope, target_ref.symbol_id, kind, role,
+      target_interfaces, attr_index, user_op);
 }
 
 static iree_status_t loom_symbol_reference_append_template_demand(
@@ -339,21 +342,21 @@ static bool loom_symbol_reference_attr_may_contain_ref(loom_attribute_t attr) {
 static iree_status_t loom_symbol_reference_visit_type(
     loom_symbol_reference_builder_t* builder,
     loom_symbol_reference_source_scope_t source_scope, loom_type_t type,
-    loom_symbol_reference_occurrence_kind_t kind, uint16_t attr_index,
+    loom_symbol_reference_occurrence_kind_t kind, uint8_t attr_index,
     const loom_op_t* user_op);
 
 static iree_status_t loom_symbol_reference_visit_attr(
     loom_symbol_reference_builder_t* builder,
     loom_symbol_reference_source_scope_t source_scope, loom_attribute_t attr,
     const loom_attr_descriptor_t* descriptor,
-    loom_symbol_reference_occurrence_kind_t kind, uint16_t attr_index,
+    loom_symbol_reference_occurrence_kind_t kind, uint8_t attr_index,
     const loom_op_t* user_op, uint8_t dict_depth);
 
 static iree_status_t loom_symbol_reference_visit_encoding(
     loom_symbol_reference_builder_t* builder,
     loom_symbol_reference_source_scope_t source_scope,
     const loom_encoding_t* encoding,
-    loom_symbol_reference_occurrence_kind_t kind, uint16_t attr_index,
+    loom_symbol_reference_occurrence_kind_t kind, uint8_t attr_index,
     const loom_op_t* user_op) {
   if (!encoding || encoding->attribute_count == 0) return iree_ok_status();
   if (!encoding->attributes) {
@@ -372,7 +375,7 @@ static iree_status_t loom_symbol_reference_visit_encoding(
 static iree_status_t loom_symbol_reference_visit_static_encoding(
     loom_symbol_reference_builder_t* builder,
     loom_symbol_reference_source_scope_t source_scope, uint16_t encoding_id,
-    loom_symbol_reference_occurrence_kind_t kind, uint16_t attr_index,
+    loom_symbol_reference_occurrence_kind_t kind, uint8_t attr_index,
     const loom_op_t* user_op) {
   if (encoding_id == 0) return iree_ok_status();
   const loom_encoding_t* encoding =
@@ -392,7 +395,7 @@ static iree_status_t loom_symbol_reference_visit_type_sequence(
     loom_symbol_reference_builder_t* builder,
     loom_symbol_reference_source_scope_t source_scope, const loom_type_t* types,
     uint16_t type_count, loom_symbol_reference_occurrence_kind_t kind,
-    uint16_t attr_index, const loom_op_t* user_op) {
+    uint8_t attr_index, const loom_op_t* user_op) {
   if (!types) return iree_ok_status();
   for (uint16_t i = 0; i < type_count; ++i) {
     IREE_RETURN_IF_ERROR(loom_symbol_reference_visit_type(
@@ -404,7 +407,7 @@ static iree_status_t loom_symbol_reference_visit_type_sequence(
 static iree_status_t loom_symbol_reference_visit_type(
     loom_symbol_reference_builder_t* builder,
     loom_symbol_reference_source_scope_t source_scope, loom_type_t type,
-    loom_symbol_reference_occurrence_kind_t kind, uint16_t attr_index,
+    loom_symbol_reference_occurrence_kind_t kind, uint8_t attr_index,
     const loom_op_t* user_op) {
   loom_type_kind_t type_kind = loom_type_kind(type);
   if (!loom_type_kind_is_valid(type_kind)) return iree_ok_status();
@@ -457,33 +460,37 @@ static iree_status_t loom_symbol_reference_visit_attr(
     loom_symbol_reference_builder_t* builder,
     loom_symbol_reference_source_scope_t source_scope, loom_attribute_t attr,
     const loom_attr_descriptor_t* descriptor,
-    loom_symbol_reference_occurrence_kind_t kind, uint16_t attr_index,
+    loom_symbol_reference_occurrence_kind_t kind, uint8_t attr_index,
     const loom_op_t* user_op, uint8_t dict_depth) {
   switch ((loom_attr_kind_t)attr.kind) {
     case LOOM_ATTR_SYMBOL: {
       loom_symbol_reference_role_t role = LOOM_SYMBOL_REFERENCE_ROLE_DEPENDENCY;
+      loom_symbol_interface_flags_t target_interfaces = 0;
       if (descriptor && descriptor->attr_kind == LOOM_ATTR_SYMBOL &&
           descriptor->reference.symbol_ref) {
         role = descriptor->reference.symbol_ref->role;
+        target_interfaces = descriptor->reference.symbol_ref->interfaces;
       }
-      return loom_symbol_reference_add_ref(builder, source_scope,
-                                           loom_attr_as_symbol(attr), kind,
-                                           role, attr_index, user_op);
+      return loom_symbol_reference_add_ref(
+          builder, source_scope, loom_attr_as_symbol(attr), kind, role,
+          target_interfaces, attr_index, user_op);
     }
     case LOOM_ATTR_SYMBOL_ARRAY:
     case LOOM_ATTR_SYMBOL_SET: {
       loom_symbol_reference_role_t role = LOOM_SYMBOL_REFERENCE_ROLE_DEPENDENCY;
+      loom_symbol_interface_flags_t target_interfaces = 0;
       if (descriptor && descriptor->attr_kind == attr.kind &&
           descriptor->reference.symbol_ref) {
         role = descriptor->reference.symbol_ref->role;
+        target_interfaces = descriptor->reference.symbol_ref->interfaces;
       }
       loom_symbol_ref_array_t refs = attr.kind == LOOM_ATTR_SYMBOL_SET
                                          ? loom_attr_as_symbol_set(attr)
                                          : loom_attr_as_symbol_array(attr);
       for (uint16_t i = 0; i < refs.count; ++i) {
-        IREE_RETURN_IF_ERROR(
-            loom_symbol_reference_add_ref(builder, source_scope, refs.values[i],
-                                          kind, role, attr_index, user_op));
+        IREE_RETURN_IF_ERROR(loom_symbol_reference_add_ref(
+            builder, source_scope, refs.values[i], kind, role,
+            target_interfaces, attr_index, user_op));
       }
       return iree_ok_status();
     }

--- a/loom/src/loom/analysis/symbol_references.h
+++ b/loom/src/loom/analysis/symbol_references.h
@@ -42,7 +42,7 @@ typedef uint32_t loom_template_provider_reference_id_t;
   ((loom_template_provider_reference_id_t)UINT32_MAX)
 
 // Sentinel for occurrences not attached to a concrete op attribute.
-#define LOOM_SYMBOL_REFERENCE_ATTR_INDEX_NONE ((uint16_t)UINT16_MAX)
+#define LOOM_SYMBOL_REFERENCE_ATTR_INDEX_NONE ((uint8_t)UINT8_MAX)
 
 // Classifies where a symbol reference occurrence was found.
 typedef enum loom_symbol_reference_occurrence_kind_e {
@@ -73,20 +73,23 @@ typedef struct loom_symbol_reference_occurrence_t {
   loom_symbol_id_t source_symbol_id;
   // Module-local symbol referenced by this occurrence.
   loom_symbol_id_t target_symbol_id;
-  // Classified source of the occurrence.
-  loom_symbol_reference_occurrence_kind_t kind;
-  // Compile-time graph role declared by the owning attribute schema.
-  loom_symbol_reference_role_t role;
-  // Root region slot on the source symbol plus one, or zero for its contract.
-  uint8_t source_root_region_index_plus_one;
-  // Attribute index on user_op when the occurrence came from an op attribute.
-  uint16_t attr_index;
-  // Operation that owns the occurrence, or NULL for module-root records.
-  const loom_op_t* user_op;
+  // Target interfaces accepted by the owning attribute schema, or zero when
+  // the reference has no structural interface constraint.
+  loom_symbol_interface_flags_t target_interfaces;
   // Next occurrence with the same source symbol.
   loom_symbol_reference_occurrence_id_t next_outgoing_occurrence_id;
   // Next occurrence with the same target symbol.
   loom_symbol_reference_occurrence_id_t next_incoming_occurrence_id;
+  // Attribute index on user_op when the occurrence came from an op attribute.
+  uint8_t attr_index;
+  // Classified source of the occurrence.
+  uint8_t kind;
+  // Compile-time graph role declared by the owning attribute schema.
+  loom_symbol_reference_role_t role;
+  // Root region slot on the source symbol plus one, or zero for its contract.
+  uint8_t source_root_region_index_plus_one;
+  // Operation that owns the occurrence, or NULL for module-root records.
+  const loom_op_t* user_op;
 } loom_symbol_reference_occurrence_t;
 
 static_assert(sizeof(loom_symbol_reference_occurrence_t) == 32,

--- a/loom/src/loom/analysis/symbol_references_test.cc
+++ b/loom/src/loom/analysis/symbol_references_test.cc
@@ -18,6 +18,7 @@
 #include "loom/ops/config/ops.h"
 #include "loom/ops/func/ops.h"
 #include "loom/ops/global/ops.h"
+#include "loom/ops/kernel/ops.h"
 #include "loom/ops/op_defs.h"
 #include "loom/ops/target/ops.h"
 #include "loom/ops/template/ops.h"
@@ -39,6 +40,7 @@ class SymbolReferencesTest : public ::testing::Test {
     RegisterDialect(LOOM_DIALECT_CONFIG, loom_config_dialect_vtables);
     RegisterDialect(LOOM_DIALECT_FUNC, loom_func_dialect_vtables);
     RegisterDialect(LOOM_DIALECT_GLOBAL, loom_global_dialect_vtables);
+    RegisterDialect(LOOM_DIALECT_KERNEL, loom_kernel_dialect_vtables);
     RegisterDialect(LOOM_DIALECT_TARGET, loom_target_dialect_vtables);
     RegisterDialect(LOOM_DIALECT_TEMPLATE, loom_template_dialect_vtables);
     IREE_ASSERT_OK(loom_test_dialect_register(&context_));
@@ -225,18 +227,22 @@ func.def @entry() -> (index) {
   ASSERT_NE(read_occurrence, nullptr);
   ASSERT_NE(read_occurrence->user_op, nullptr);
   EXPECT_EQ(read_occurrence->user_op->kind, LOOM_OP_GLOBAL_LOAD);
+  EXPECT_EQ(read_occurrence->target_interfaces,
+            LOOM_SYMBOL_INTERFACE_GLOBAL | LOOM_SYMBOL_INTERFACE_RODATA);
 
   const loom_symbol_reference_occurrence_t* write_occurrence = FindOccurrence(
       table, writer, state, LOOM_SYMBOL_REFERENCE_OCCURRENCE_GLOBAL_ACCESS);
   ASSERT_NE(write_occurrence, nullptr);
   ASSERT_NE(write_occurrence->user_op, nullptr);
   EXPECT_EQ(write_occurrence->user_op->kind, LOOM_OP_GLOBAL_STORE);
+  EXPECT_EQ(write_occurrence->target_interfaces, LOOM_SYMBOL_INTERFACE_GLOBAL);
 
   const loom_symbol_reference_occurrence_t* call_occurrence = FindOccurrence(
       table, entry, reader, LOOM_SYMBOL_REFERENCE_OCCURRENCE_CALL);
   ASSERT_NE(call_occurrence, nullptr);
   ASSERT_NE(call_occurrence->user_op, nullptr);
   EXPECT_EQ(call_occurrence->user_op->kind, LOOM_OP_FUNC_CALL);
+  EXPECT_EQ(call_occurrence->target_interfaces, LOOM_SYMBOL_INTERFACE_CALLABLE);
 
   EXPECT_EQ(read_occurrence->source_root_region_index_plus_one, 1u);
   EXPECT_EQ(write_occurrence->source_root_region_index_plus_one, 1u);
@@ -244,6 +250,42 @@ func.def @entry() -> (index) {
 
   EXPECT_EQ(table.symbols[state].incoming_count, 2u);
   EXPECT_EQ(table.symbols[reader].incoming_count, 1u);
+}
+
+TEST_F(SymbolReferencesTest, KernelReferencesRetainDistinctTargetInterfaces) {
+  ModulePtr module = ParseModule(R"(
+kernel.decl @logical() launch()
+kernel.entry.decl @configured() where [workgroup_size(1, 1, 1)]
+
+func.def @entry() {
+  kernel.launch @logical() : ()
+  kernel.dispatch @configured[]() : []()
+  func.return
+}
+)");
+
+  const loom_symbol_id_t logical = FindSymbol(module.get(), IREE_SV("logical"));
+  const loom_symbol_id_t configured =
+      FindSymbol(module.get(), IREE_SV("configured"));
+  const loom_symbol_id_t entry = FindSymbol(module.get(), IREE_SV("entry"));
+
+  const loom_symbol_reference_table_t table = BuildTable(module.get());
+
+  const loom_symbol_reference_occurrence_t* launch_occurrence = FindOccurrence(
+      table, entry, logical, LOOM_SYMBOL_REFERENCE_OCCURRENCE_CALL);
+  ASSERT_NE(launch_occurrence, nullptr);
+  ASSERT_NE(launch_occurrence->user_op, nullptr);
+  EXPECT_EQ(launch_occurrence->user_op->kind, LOOM_OP_KERNEL_LAUNCH);
+  EXPECT_EQ(launch_occurrence->target_interfaces, LOOM_SYMBOL_INTERFACE_KERNEL);
+
+  const loom_symbol_reference_occurrence_t* dispatch_occurrence =
+      FindOccurrence(table, entry, configured,
+                     LOOM_SYMBOL_REFERENCE_OCCURRENCE_CALL);
+  ASSERT_NE(dispatch_occurrence, nullptr);
+  ASSERT_NE(dispatch_occurrence->user_op, nullptr);
+  EXPECT_EQ(dispatch_occurrence->user_op->kind, LOOM_OP_KERNEL_DISPATCH);
+  EXPECT_EQ(dispatch_occurrence->target_interfaces,
+            LOOM_SYMBOL_INTERFACE_KERNEL_ENTRY);
 }
 
 TEST_F(SymbolReferencesTest, OccurrencesRetainContractAndRootRegionOrigins) {

--- a/loom/src/loom/format/bytecode/format.h
+++ b/loom/src/loom/format/bytecode/format.h
@@ -85,7 +85,7 @@ extern "C" {
 
 #define LOOM_BYTECODE_MAGIC "LOOM"
 #define LOOM_BYTECODE_MAGIC_LENGTH 4
-#define LOOM_BYTECODE_FORMAT_VERSION 31
+#define LOOM_BYTECODE_FORMAT_VERSION 32
 
 #define LOOM_BYTECODE_SOURCE_TRIVIA_LEADING_BLANK_LINE (1u << 0)
 #define LOOM_BYTECODE_SOURCE_TRIVIA_COMMENT_COUNT_SHIFT 1
@@ -743,11 +743,13 @@ typedef enum loom_bytecode_section_kind_e {
 //   For each module dependency:
 //     [source_root_region_index_plus_one: varint] (must be zero)
 //     [target_symbol_index: varint]
+//     [target_interfaces: varint]
 //   For each symbol in SYMBOLS ordinal order:
 //     [dependency_count: varint]
 //     For each dependency:
 //       [source_root_region_index_plus_one: varint]
 //       [target_symbol_index: varint]
+//       [target_interfaces: varint]
 //     [template_demand_count: varint]
 //     For each abstract provider demand:
 //       [source_root_region_index_plus_one: varint]

--- a/loom/src/loom/format/bytecode/index.h
+++ b/loom/src/loom/format/bytecode/index.h
@@ -294,6 +294,9 @@ typedef struct loom_bytecode_module_metadata_t {
   // The module-root slice begins at zero; symbol slices are described by
   // symbol_references. Targets may repeat within a slice.
   uint32_t* dependency_symbol_indices;
+  // Arena-owned target interface constraints parallel to
+  // dependency_symbol_indices. Zero accepts any target interface.
+  loom_symbol_interface_flags_t* dependency_target_interfaces;
   // Arena-owned source root region indices plus one parallel to
   // dependency_symbol_indices. Zero identifies a source symbol contract or
   // module-root occurrence.

--- a/loom/src/loom/format/bytecode/reader/selected_tables.c
+++ b/loom/src/loom/format/bytecode/reader/selected_tables.c
@@ -76,11 +76,20 @@ static iree_status_t loom_bytecode_selected_table_project_source(
     *out_target_source_id = (loom_source_id_t)target_id;
     return iree_ok_status();
   }
+  const iree_string_view_t source_name =
+      materializer->metadata->sources.values[source_ordinal];
   loom_source_id_t target_source_id = LOOM_SOURCE_ID_INVALID;
-  IREE_RETURN_IF_ERROR(loom_module_append_source(
-      materializer->output_module,
-      materializer->metadata->sources.values[source_ordinal],
-      &target_source_id));
+  for (iree_host_size_t i = 0; i < materializer->sources.inherited_count; ++i) {
+    if (iree_string_view_equal(materializer->output_module->sources.entries[i],
+                               source_name)) {
+      target_source_id = (loom_source_id_t)i;
+      break;
+    }
+  }
+  if (target_source_id == LOOM_SOURCE_ID_INVALID) {
+    IREE_RETURN_IF_ERROR(loom_module_append_source(
+        materializer->output_module, source_name, &target_source_id));
+  }
   IREE_RETURN_IF_ERROR(loom_bytecode_selected_projection_insert(
       &materializer->projection,
       LOOM_BYTECODE_SELECTED_PROJECTION_DOMAIN_SOURCE, source_ordinal,
@@ -105,6 +114,10 @@ void loom_bytecode_selected_table_materializer_initialize(
       .output_module = output_module,
       .symbol_resolver = symbol_resolver,
       .allocator = allocator,
+      .sources =
+          {
+              .inherited_count = output_module->sources.count,
+          },
   };
   loom_bytecode_selected_projection_initialize(allocator,
                                                &out_materializer->projection);

--- a/loom/src/loom/format/bytecode/reader/selected_tables.h
+++ b/loom/src/loom/format/bytecode/reader/selected_tables.h
@@ -97,6 +97,11 @@ typedef struct loom_bytecode_selected_table_materializer_t {
   iree_allocator_t allocator;
   // Reached source identity to compact output identity map.
   loom_bytecode_selected_projection_t projection;
+  // Source-table state captured before this materializer appends entries.
+  struct {
+    // Number of caller-provided entries that reached sources may reuse.
+    iree_host_size_t inherited_count;
+  } sources;
   // Explicit dependency stack reused across root resolutions.
   struct {
     // Allocator-owned frames in dependency order.
@@ -109,6 +114,10 @@ typedef struct loom_bytecode_selected_table_materializer_t {
 } loom_bytecode_selected_table_materializer_t;
 
 // Initializes an empty reached-only table materializer.
+//
+// Source names already present in |output_module| are inherited and reused by
+// reached locations. Sources appended by this materializer remain unique by
+// the validated source metadata and reached-source projection.
 void loom_bytecode_selected_table_materializer_initialize(
     loom_bytecode_reader_decoder_t* decoder, iree_const_byte_span_t bytecode,
     loom_context_t* context, const loom_bytecode_module_metadata_t* metadata,

--- a/loom/src/loom/format/bytecode/reader/selected_tables_test.cc
+++ b/loom/src/loom/format/bytecode/reader/selected_tables_test.cc
@@ -225,6 +225,47 @@ TEST_F(BytecodeSelectedTablesTest, MaterializesOnlyReachedMixedTableFacts) {
   loom_bytecode_selected_table_materializer_deinitialize(&materializer);
 }
 
+TEST_F(BytecodeSelectedTablesTest, ReusesInheritedSourceWhenComposingLocation) {
+  iree_string_view_t sources[] = {IREE_SV("model.loom")};
+  std::vector<uint8_t> bytecode;
+  loom_bytecode_table_entry_metadata_t locations[2] = {};
+  locations[0].entry_offset = bytecode.size();
+  bytecode.insert(bytecode.end(), {LOOM_LOCATION_NONE, 0x00});
+  locations[0].entry_length = bytecode.size() - locations[0].entry_offset;
+  locations[1].entry_offset = bytecode.size();
+  bytecode.insert(bytecode.end(), {
+                                      LOOM_LOCATION_FILE,
+                                      0x00,  // Flags.
+                                      0x00,  // Source ordinal.
+                                      0x01,
+                                      0x02,
+                                      0x03,
+                                      0x04,  // Coordinates.
+                                  });
+  locations[1].entry_length = bytecode.size() - locations[1].entry_offset;
+  loom_bytecode_module_metadata_t metadata = {};
+  metadata.sources = {IREE_ARRAYSIZE(sources), sources};
+  metadata.locations = {IREE_ARRAYSIZE(locations), locations};
+
+  loom_source_id_t inherited_source_id = LOOM_SOURCE_ID_INVALID;
+  IREE_ASSERT_OK(
+      loom_module_append_source(module_, sources[0], &inherited_source_id));
+  ASSERT_EQ(inherited_source_id, 0u);
+  loom_bytecode_selected_table_materializer_t materializer =
+      MakeMaterializer(bytecode, &metadata);
+
+  loom_location_id_t target_location_id = LOOM_LOCATION_UNKNOWN;
+  IREE_ASSERT_OK(loom_bytecode_selected_table_materialize_location(
+      &materializer, /*source_location_id=*/1, &target_location_id));
+  EXPECT_EQ(target_location_id, 1u);
+  ASSERT_EQ(module_->locations.count, 2u);
+  EXPECT_EQ(module_->locations.entries[1].file.source_id, inherited_source_id);
+  ASSERT_EQ(module_->sources.count, 1u);
+  EXPECT_TRUE(iree_string_view_equal(module_->sources.entries[0], sources[0]));
+
+  loom_bytecode_selected_table_materializer_deinitialize(&materializer);
+}
+
 TEST_F(BytecodeSelectedTablesTest, ResolvesExternalSymbolsByDenseSourceIndex) {
   iree_string_view_t strings[] = {
       IREE_SV("unused"),

--- a/loom/src/loom/format/bytecode/reader/validation.c
+++ b/loom/src/loom/format/bytecode/reader/validation.c
@@ -393,7 +393,7 @@ static inline iree_status_t loom_bytecode_reader_begin_symbol_references(
   if (!iree_host_size_checked_mul_add(1, (iree_host_size_t)symbol_count, 2,
                                       &minimum_encoded_bytes) ||
       !iree_host_size_checked_mul_add(minimum_encoded_bytes,
-                                      (iree_host_size_t)dependency_count, 2,
+                                      (iree_host_size_t)dependency_count, 3,
                                       &minimum_encoded_bytes) ||
       !iree_host_size_checked_mul_add(minimum_encoded_bytes,
                                       (iree_host_size_t)template_demand_count,
@@ -418,7 +418,7 @@ static inline iree_status_t loom_bytecode_reader_begin_symbol_references(
   return iree_ok_status();
 }
 
-static inline iree_status_t loom_bytecode_reader_decode_dependency(
+static inline iree_status_t loom_bytecode_reader_decode_reference_edge(
     loom_bytecode_module_reader_t* reader,
     loom_bytecode_symbol_reference_table_t* table,
     iree_string_view_t record_name, iree_host_size_t record_index,
@@ -454,13 +454,38 @@ static inline iree_status_t loom_bytecode_reader_decode_dependency(
   return iree_ok_status();
 }
 
+static inline iree_status_t loom_bytecode_reader_decode_dependency(
+    loom_bytecode_module_reader_t* reader,
+    loom_bytecode_symbol_reference_table_t* table,
+    iree_string_view_t record_name, iree_host_size_t record_index,
+    uint8_t source_root_region_count,
+    uint8_t* out_source_root_region_index_plus_one, uint32_t* out_symbol_index,
+    loom_symbol_interface_flags_t* out_target_interfaces) {
+  IREE_RETURN_IF_ERROR(loom_bytecode_reader_decode_reference_edge(
+      reader, table, record_name, record_index, source_root_region_count,
+      out_source_root_region_index_plus_one, out_symbol_index));
+  const uint64_t target_interfaces_offset =
+      loom_bytecode_reader_cursor_absolute_position(&table->cursor);
+  uint64_t target_interfaces = 0;
+  IREE_RETURN_IF_ERROR(loom_bytecode_reader_read_uvarint(
+      &reader->decoder, &table->cursor, &target_interfaces));
+  if ((target_interfaces & ~((uint64_t)LOOM_SYMBOL_INTERFACE_FLAG_MASK)) != 0) {
+    return loom_bytecode_reader_emit_invalid_field(
+        &reader->decoder, IREE_SV("SYMBOL_REFERENCES"), record_name,
+        record_index, IREE_SV("target_interfaces"), target_interfaces_offset,
+        IREE_SV("dependency_target_interfaces_are_invalid"));
+  }
+  *out_target_interfaces = (loom_symbol_interface_flags_t)target_interfaces;
+  return iree_ok_status();
+}
+
 static inline iree_status_t loom_bytecode_reader_decode_template_demand(
     loom_bytecode_module_reader_t* reader,
     loom_bytecode_symbol_reference_table_t* table,
     iree_host_size_t demand_index, uint8_t source_root_region_count,
     uint8_t* out_source_root_region_index_plus_one,
     uint32_t* out_family_symbol_ordinal) {
-  return loom_bytecode_reader_decode_dependency(
+  return loom_bytecode_reader_decode_reference_edge(
       reader, table, IREE_SV("template_demand"), demand_index,
       source_root_region_count, out_source_root_region_index_plus_one,
       out_family_symbol_ordinal);
@@ -522,10 +547,11 @@ static iree_status_t loom_bytecode_reader_read_symbol_references(
        ++i, ++dependency_index) {
     uint8_t source_root_region_index_plus_one = 0;
     uint32_t dependency = 0;
+    loom_symbol_interface_flags_t target_interfaces = 0;
     IREE_RETURN_IF_ERROR(loom_bytecode_reader_decode_dependency(
         reader, &table, IREE_SV("module_dependency"), i,
         /*source_root_region_count=*/0, &source_root_region_index_plus_one,
-        &dependency));
+        &dependency, &target_interfaces));
   }
 
   iree_host_size_t template_demand_index = 0;
@@ -548,9 +574,10 @@ static iree_status_t loom_bytecode_reader_read_symbol_references(
          ++i, ++dependency_index) {
       uint8_t source_root_region_index_plus_one = 0;
       uint32_t dependency = 0;
+      loom_symbol_interface_flags_t target_interfaces = 0;
       IREE_RETURN_IF_ERROR(loom_bytecode_reader_decode_dependency(
           reader, &table, IREE_SV("dependency"), i, source_root_region_count,
-          &source_root_region_index_plus_one, &dependency));
+          &source_root_region_index_plus_one, &dependency, &target_interfaces));
     }
 
     const uint64_t template_demand_count_offset =
@@ -1100,6 +1127,10 @@ static iree_status_t loom_bytecode_reader_index_symbol_references(
         (void**)&metadata->dependency_symbol_indices));
     IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
         retained_arena, table.dependency_count,
+        sizeof(*metadata->dependency_target_interfaces),
+        (void**)&metadata->dependency_target_interfaces));
+    IREE_RETURN_IF_ERROR(iree_arena_allocate_array(
+        retained_arena, table.dependency_count,
         sizeof(*metadata->dependency_source_root_region_indices_plus_one),
         (void**)&metadata->dependency_source_root_region_indices_plus_one));
   }
@@ -1136,7 +1167,8 @@ static iree_status_t loom_bytecode_reader_index_symbol_references(
         /*source_root_region_count=*/0,
         &metadata
              ->dependency_source_root_region_indices_plus_one[dependency_index],
-        &metadata->dependency_symbol_indices[dependency_index]));
+        &metadata->dependency_symbol_indices[dependency_index],
+        &metadata->dependency_target_interfaces[dependency_index]));
   }
 
   iree_host_size_t template_demand_index = 0;
@@ -1165,7 +1197,8 @@ static iree_status_t loom_bytecode_reader_index_symbol_references(
           reader, &table, IREE_SV("dependency"), i, source_root_region_count,
           &metadata->dependency_source_root_region_indices_plus_one
                [dependency_index],
-          &metadata->dependency_symbol_indices[dependency_index]));
+          &metadata->dependency_symbol_indices[dependency_index],
+          &metadata->dependency_target_interfaces[dependency_index]));
     }
 
     const uint64_t template_demand_count_offset =

--- a/loom/src/loom/format/bytecode/reader_test.cc
+++ b/loom/src/loom/format/bytecode/reader_test.cc
@@ -141,10 +141,14 @@ class ReaderTest : public ::testing::Test {
     std::vector<size_t> module_dependencies;
     // Byte offsets of module-root dependency source origins.
     std::vector<size_t> module_dependency_origins;
+    // Byte offsets of module-root dependency target interface constraints.
+    std::vector<size_t> module_dependency_target_interfaces;
     // Byte offsets of dependency target ordinals by source symbol.
     std::vector<std::vector<size_t>> symbol_dependencies;
     // Byte offsets of dependency source origins by source symbol.
     std::vector<std::vector<size_t>> symbol_dependency_origins;
+    // Byte offsets of dependency target interface constraints by source symbol.
+    std::vector<std::vector<size_t>> symbol_dependency_target_interfaces;
     // Byte offsets of template-family symbol ordinals by source symbol.
     std::vector<std::vector<size_t>> symbol_template_demands;
     // Byte offsets of template-demand source origins by source symbol.
@@ -2137,15 +2141,20 @@ class ReaderTest : public ::testing::Test {
     const uint64_t module_dependency_count = ReadUVarint(bytes, &offset);
     layout.module_dependencies.reserve((size_t)module_dependency_count);
     layout.module_dependency_origins.reserve((size_t)module_dependency_count);
+    layout.module_dependency_target_interfaces.reserve(
+        (size_t)module_dependency_count);
     for (uint64_t i = 0; i < module_dependency_count; ++i) {
       layout.module_dependency_origins.push_back(offset);
       ReadUVarint(bytes, &offset);
       layout.module_dependencies.push_back(offset);
       ReadUVarint(bytes, &offset);
+      layout.module_dependency_target_interfaces.push_back(offset);
+      ReadUVarint(bytes, &offset);
     }
 
     layout.symbol_dependencies.reserve((size_t)symbol_count);
     layout.symbol_dependency_origins.reserve((size_t)symbol_count);
+    layout.symbol_dependency_target_interfaces.reserve((size_t)symbol_count);
     layout.symbol_template_demands.reserve((size_t)symbol_count);
     layout.symbol_template_demand_origins.reserve((size_t)symbol_count);
     for (uint64_t i = 0; i < symbol_count; ++i) {
@@ -2154,12 +2163,17 @@ class ReaderTest : public ::testing::Test {
           layout.symbol_dependencies.emplace_back();
       std::vector<size_t>& dependency_origin_offsets =
           layout.symbol_dependency_origins.emplace_back();
+      std::vector<size_t>& dependency_target_interface_offsets =
+          layout.symbol_dependency_target_interfaces.emplace_back();
       dependency_offsets.reserve((size_t)dependency_count);
       dependency_origin_offsets.reserve((size_t)dependency_count);
+      dependency_target_interface_offsets.reserve((size_t)dependency_count);
       for (uint64_t j = 0; j < dependency_count; ++j) {
         dependency_origin_offsets.push_back(offset);
         ReadUVarint(bytes, &offset);
         dependency_offsets.push_back(offset);
+        ReadUVarint(bytes, &offset);
+        dependency_target_interface_offsets.push_back(offset);
         ReadUVarint(bytes, &offset);
       }
 
@@ -3513,12 +3527,18 @@ TEST_F(ReaderTest, PreservesPhysicalSymbolDefinitionOrder) {
   const uint8_t* dependency_origins =
       module_metadata.dependency_source_root_region_indices_plus_one +
       function_references.first_dependency_index;
+  const loom_symbol_interface_flags_t* dependency_target_interfaces =
+      module_metadata.dependency_target_interfaces +
+      function_references.first_dependency_index;
   EXPECT_EQ(dependency_symbol_indices[0], 1u);
   EXPECT_EQ(dependency_symbol_indices[1], 2u);
   EXPECT_EQ(dependency_symbol_indices[2], 1u);
   EXPECT_EQ(dependency_origins[0], 1u);
   EXPECT_EQ(dependency_origins[1], 1u);
   EXPECT_EQ(dependency_origins[2], 1u);
+  EXPECT_EQ(dependency_target_interfaces[0], LOOM_SYMBOL_INTERFACE_RECORD);
+  EXPECT_EQ(dependency_target_interfaces[1], LOOM_SYMBOL_INTERFACE_RECORD);
+  EXPECT_EQ(dependency_target_interfaces[2], LOOM_SYMBOL_INTERFACE_RECORD);
   iree_arena_deinitialize(&metadata_arena);
 
   loom_module_t* read_module = nullptr;
@@ -5474,6 +5494,24 @@ TEST_F(ReaderTest, RejectsSymbolReferenceOriginOutsideSourceRoots) {
   const size_t origin_offset = layout.symbol_dependency_origins[2][0];
   ASSERT_LT(origin_offset, bytes.size());
   bytes[origin_offset] = 2;
+
+  ExpectReadError(bytes, "ERR_BYTECODE_006");
+
+  loom_module_free(module);
+}
+
+TEST_F(ReaderTest, RejectsSymbolReferenceUnknownTargetInterfaces) {
+  loom_module_t* module = CreateSymbolArrayModule();
+  auto bytes = WriteModule(module);
+  SymbolReferenceLayout layout = ReadSymbolReferenceLayout(bytes);
+  ASSERT_EQ(layout.symbol_dependency_target_interfaces.size(), 3u);
+  ASSERT_EQ(layout.symbol_dependency_target_interfaces[2].size(), 3u);
+  const size_t interfaces_offset =
+      layout.symbol_dependency_target_interfaces[2][0];
+  ASSERT_LT(interfaces_offset + 2, bytes.size());
+  bytes[interfaces_offset] = 0x80;
+  bytes[interfaces_offset + 1] = 0x80;
+  bytes[interfaces_offset + 2] = 0x01;
 
   ExpectReadError(bytes, "ERR_BYTECODE_006");
 

--- a/loom/src/loom/format/bytecode/writer/symbol.c
+++ b/loom/src/loom/format/bytecode/writer/symbol.c
@@ -858,6 +858,8 @@ static iree_status_t loom_bytecode_write_dependency_row(
       IREE_RETURN_IF_ERROR(loom_bytecode_page_writer_write_uvarint(
           page_writer, loom_bytecode_wire_symbol_ordinal(
                            numbering, occurrence->target_symbol_id)));
+      IREE_RETURN_IF_ERROR(loom_bytecode_page_writer_write_uvarint(
+          page_writer, occurrence->target_interfaces));
     }
     occurrence_id = occurrence->next_outgoing_occurrence_id;
   }

--- a/loom/src/loom/ir/attribute_schema.h
+++ b/loom/src/loom/ir/attribute_schema.h
@@ -60,6 +60,8 @@ enum loom_symbol_interface_bits_e {
   LOOM_SYMBOL_INTERFACE_TEMPLATE_PROVIDER = 1u << 11,
   // Symbol defines or declares an executable kernel entry ABI.
   LOOM_SYMBOL_INTERFACE_KERNEL_ENTRY = 1u << 12,
+  // All symbol interface bits understood by this compiler version.
+  LOOM_SYMBOL_INTERFACE_FLAG_MASK = (1u << 13) - 1,
 };
 
 enum loom_symbol_reference_role_e {

--- a/loom/src/loom/link/BUILD.bazel
+++ b/loom/src/loom/link/BUILD.bazel
@@ -349,6 +349,7 @@ loom_cc_test(
         "//loom/src/loom/ops/command",
         "//loom/src/loom/ops/config",
         "//loom/src/loom/ops/func",
+        "//loom/src/loom/ops/kernel",
         "//loom/src/loom/ops/module",
         "//loom/src/loom/ops/target",
         "//loom/src/loom/ops/template",

--- a/loom/src/loom/link/CMakeLists.txt
+++ b/loom/src/loom/link/CMakeLists.txt
@@ -391,6 +391,7 @@ loom_cc_test(
     loom::ops::command
     loom::ops::config
     loom::ops::func
+    loom::ops::kernel
     loom::ops::module
     loom::ops::target
     loom::ops::template

--- a/loom/src/loom/link/linker.c
+++ b/loom/src/loom/link/linker.c
@@ -1437,43 +1437,6 @@ static iree_status_t loom_linker_replace_output_attr(
   return iree_ok_status();
 }
 
-static void loom_linker_internalize_symbol_output(loom_linker_t* linker,
-                                                  loom_op_t* target_op) {
-  const loom_op_vtable_t* target_vtable =
-      loom_op_vtable(linker->target_module, target_op);
-  const loom_symbol_definition_descriptor_t* target_definition =
-      target_vtable->symbol_def;
-  const uint8_t target_visibility_attr_index =
-      loom_symbol_definition_visibility_attr_index(target_definition);
-  const uint8_t target_retain_attr_index =
-      target_definition->retain_attr_index_plus_one
-          ? target_definition->retain_attr_index_plus_one - 1
-          : LOOM_ATTR_INDEX_NONE;
-
-  if (target_visibility_attr_index != LOOM_ATTR_INDEX_NONE) {
-    loom_op_attrs(target_op)[target_visibility_attr_index] = loom_attr_absent();
-  }
-  if (target_retain_attr_index != LOOM_ATTR_INDEX_NONE) {
-    loom_op_attrs(target_op)[target_retain_attr_index] = loom_attr_absent();
-  }
-  loom_func_like_t target_func =
-      loom_func_like_cast(linker->target_module, target_op);
-  if (loom_func_like_isa(target_func)) {
-    const uint8_t export_attr_indices[] = {
-        target_func.vtable->export_symbol_attr_index,
-        target_func.vtable->export_attrs_attr_index,
-        target_func.vtable->export_linkage_attr_index,
-    };
-    for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(export_attr_indices); ++i) {
-      if (export_attr_indices[i] != LOOM_ATTR_INDEX_NONE) {
-        loom_op_attrs(target_op)[export_attr_indices[i]] = loom_attr_absent();
-      }
-    }
-  }
-  loom_module_link_symbol_defining_op(linker->target_module, target_op,
-                                      target_vtable);
-}
-
 static iree_status_t loom_linker_apply_root_symbol_output(
     loom_linker_source_t* source, const loom_module_t* root_module,
     loom_op_t* root_op, loom_symbol_ref_t target_ref, loom_op_t* target_op) {
@@ -1572,7 +1535,7 @@ static iree_status_t loom_linker_apply_symbol_output(
     return iree_ok_status();
   }
   if (output == LOOM_LINKER_SYMBOL_OUTPUT_DEPENDENCY) {
-    loom_linker_internalize_symbol_output(source->linker, target_op);
+    loom_link_symbol_internalize(source->linker->target_module, target_op);
     return iree_ok_status();
   }
   return loom_linker_apply_root_symbol_output(source, root_module, root_op,

--- a/loom/src/loom/link/linker.c
+++ b/loom/src/loom/link/linker.c
@@ -110,6 +110,8 @@ struct loom_linker_t {
 typedef struct loom_linker_exact_selection_t {
   // Strictly increasing module-local source ordinals, or NULL when dense.
   const iree_host_size_t* ordinals;
+  // Omitted source symbols already projected into the target module.
+  loom_linker_source_symbol_binding_list_t bindings;
   // Output dispositions in source-selection order, or NULL when authored.
   const loom_linker_symbol_output_t* outputs;
   // Number of selected source symbols.
@@ -526,6 +528,49 @@ static iree_status_t loom_linker_map_exact_source_symbol(
       out_target_ref);
 }
 
+static iree_host_size_t loom_linker_find_source_binding(
+    loom_linker_source_symbol_binding_list_t bindings,
+    uint16_t source_symbol_id) {
+  iree_host_size_t low = 0;
+  iree_host_size_t high = bindings.count;
+  while (low < high) {
+    const iree_host_size_t middle = low + (high - low) / 2;
+    const uint32_t candidate = bindings.values[middle].source_ordinal;
+    if (candidate < source_symbol_id) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+  return low < bindings.count &&
+                 bindings.values[low].source_ordinal == source_symbol_id
+             ? low
+             : IREE_HOST_SIZE_MAX;
+}
+
+static iree_status_t loom_linker_map_bound_exact_source_symbol(
+    loom_linker_source_t* source, uint16_t source_symbol_id,
+    loom_symbol_ref_t* out_target_ref) {
+  const iree_host_size_t selection_ordinal =
+      loom_linker_find_exact_source_symbol(source, source_symbol_id);
+  if (selection_ordinal != IREE_HOST_SIZE_MAX) {
+    return loom_linker_resolve_source_symbol(
+        source, source_symbol_id, &source->target_symbols[selection_ordinal],
+        out_target_ref);
+  }
+  const iree_host_size_t binding_ordinal =
+      loom_linker_find_source_binding(source->exact.bindings, source_symbol_id);
+  if (binding_ordinal == IREE_HOST_SIZE_MAX) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "exact link selection missed reachable source symbol ref "
+        "{module=0, symbol=%u}",
+        (unsigned)source_symbol_id);
+  }
+  *out_target_ref = source->exact.bindings.values[binding_ordinal].target;
+  return iree_ok_status();
+}
+
 static iree_status_t loom_linker_validate_symbol_remap(
     const loom_linker_source_t* source, const loom_module_t* source_module,
     loom_module_t* target_module, loom_symbol_ref_t source_ref) {
@@ -580,6 +625,17 @@ static iree_status_t loom_linker_remap_exact_symbol(
       source, source_module, target_module, source_ref));
   return loom_linker_map_exact_source_symbol(source, source_ref.symbol_id,
                                              out_target_ref);
+}
+
+static iree_status_t loom_linker_remap_bound_exact_symbol(
+    void* user_data, const loom_module_t* source_module,
+    loom_module_t* target_module, loom_symbol_ref_t source_ref,
+    loom_symbol_ref_t* out_target_ref) {
+  loom_linker_source_t* source = (loom_linker_source_t*)user_data;
+  IREE_RETURN_IF_ERROR(loom_linker_validate_symbol_remap(
+      source, source_module, target_module, source_ref));
+  return loom_linker_map_bound_exact_source_symbol(source, source_ref.symbol_id,
+                                                   out_target_ref);
 }
 
 static iree_status_t loom_linker_remap_dense_symbol(
@@ -2278,10 +2334,14 @@ static iree_status_t loom_linker_add_exact_selection(
       .exact = selection,
   };
   source.exact.outputs = source_outputs.values;
-  source.symbol_remap = loom_ir_remap_symbol_callback_make(
-      selection.dense ? loom_linker_remap_dense_symbol
-                      : loom_linker_remap_exact_symbol,
-      &source);
+  loom_ir_remap_symbol_fn_t remap_symbol = loom_linker_remap_exact_symbol;
+  if (selection.dense) {
+    remap_symbol = loom_linker_remap_dense_symbol;
+  } else if (selection.bindings.count != 0) {
+    remap_symbol = loom_linker_remap_bound_exact_symbol;
+  }
+  source.symbol_remap =
+      loom_ir_remap_symbol_callback_make(remap_symbol, &source);
 
   iree_status_t status = iree_ok_status();
   if (out_target_symbols.count > 0) {
@@ -2347,11 +2407,16 @@ static iree_status_t loom_linker_add_exact_selection(
          j < provider_import->anchors.count && iree_status_is_ok(status); ++j) {
       const uint16_t source_symbol_id =
           (uint16_t)provider_import->anchors.ordinals[j];
-      status = selection.dense
-                   ? loom_linker_map_dense_source_symbol(
-                         &source, source_symbol_id, &target_anchors[j])
-                   : loom_linker_map_exact_source_symbol(
-                         &source, source_symbol_id, &target_anchors[j]);
+      if (selection.dense) {
+        status = loom_linker_map_dense_source_symbol(&source, source_symbol_id,
+                                                     &target_anchors[j]);
+      } else if (selection.bindings.count != 0) {
+        status = loom_linker_map_bound_exact_source_symbol(
+            &source, source_symbol_id, &target_anchors[j]);
+      } else {
+        status = loom_linker_map_exact_source_symbol(&source, source_symbol_id,
+                                                     &target_anchors[j]);
+      }
     }
     if (iree_status_is_ok(status)) {
       status = loom_link_provider_import_sink_append(
@@ -2368,6 +2433,7 @@ static iree_status_t loom_linker_add_exact_selection(
 iree_status_t loom_linker_add_module_symbols(
     loom_linker_t* linker, const loom_module_t* source_module,
     loom_linker_source_symbol_list_t source_symbols,
+    loom_linker_source_symbol_binding_list_t source_bindings,
     loom_linker_source_symbol_output_list_t source_outputs,
     loom_linker_source_provider_import_list_t provider_imports,
     loom_linker_target_symbol_list_t out_target_symbols) {
@@ -2381,6 +2447,7 @@ iree_status_t loom_linker_add_module_symbols(
       linker, source_module,
       (loom_linker_exact_selection_t){
           .ordinals = source_symbols.ordinals,
+          .bindings = source_bindings,
           .count = source_symbols.count,
       },
       source_outputs, provider_imports, out_target_symbols);

--- a/loom/src/loom/link/linker.h
+++ b/loom/src/loom/link/linker.h
@@ -94,6 +94,30 @@ typedef struct loom_linker_source_symbol_list_t {
   const iree_host_size_t* ordinals;
 } loom_linker_source_symbol_list_t;
 
+// One omitted source symbol already projected into this linker's target.
+typedef struct loom_linker_source_symbol_binding_t {
+  // Module-local source symbol ordinal referenced by selected source IR.
+  uint32_t source_ordinal;
+  // Existing linker-target symbol replacing source_ordinal.
+  loom_symbol_ref_t target;
+} loom_linker_source_symbol_binding_t;
+
+// Exact source-to-target bindings accompanying one sparse selection.
+typedef struct loom_linker_source_symbol_binding_list_t {
+  // Number of entries in values.
+  iree_host_size_t count;
+  // Strictly increasing bindings owned by the caller for the add duration.
+  // Bound ordinals must be in range and absent from source_symbols; target
+  // refs must come from an earlier add to this linker.
+  const loom_linker_source_symbol_binding_t* values;
+} loom_linker_source_symbol_binding_list_t;
+
+// Returns an empty exact source-symbol binding list.
+static inline loom_linker_source_symbol_binding_list_t
+loom_linker_source_symbol_binding_list_empty(void) {
+  return (loom_linker_source_symbol_binding_list_t){0};
+}
+
 // Caller-provided output storage for projected target symbol references.
 typedef struct loom_linker_target_symbol_list_t {
   // Number of writable entries in values.
@@ -172,9 +196,12 @@ iree_status_t loom_linker_add_module(loom_linker_t* linker,
 // Adds an exact precomputed source symbol selection to |linker|.
 //
 // |source_symbols| must be strictly increasing. The caller owns dependency
-// closure: references from selected IR to omitted source symbols fail rather
-// than triggering reachability discovery. |provider_imports| names retained
-// availability rows in the same source ordinal domain. When
+// closure: references from selected IR to omitted source symbols fail unless
+// |source_bindings| explicitly maps them to symbols projected by a prior add.
+// Bindings do not clone, merge, or otherwise inspect the omitted source
+// definition; the caller owns compatibility with the projected target.
+// |provider_imports| names retained availability rows in the same source
+// ordinal domain. When
 // |source_outputs| is non-empty it must have one entry per selected source
 // symbol. Authored disposition preserves the source linkage surface;
 // dependency disposition internalizes it; root disposition preserves and
@@ -186,6 +213,7 @@ iree_status_t loom_linker_add_module(loom_linker_t* linker,
 iree_status_t loom_linker_add_module_symbols(
     loom_linker_t* linker, const loom_module_t* source_module,
     loom_linker_source_symbol_list_t source_symbols,
+    loom_linker_source_symbol_binding_list_t source_bindings,
     loom_linker_source_symbol_output_list_t source_outputs,
     loom_linker_source_provider_import_list_t provider_imports,
     loom_linker_target_symbol_list_t out_target_symbols);

--- a/loom/src/loom/link/linker_test.cc
+++ b/loom/src/loom/link/linker_test.cc
@@ -1017,6 +1017,7 @@ func.def @zeta(%x: i32) -> (i32) {
           /*.count=*/IREE_ARRAYSIZE(projected_symbols),
           /*.ordinals=*/projected_symbols,
       },
+      loom_linker_source_symbol_binding_list_empty(),
       loom_linker_source_symbol_output_list_empty(),
       (loom_linker_source_provider_import_list_t){
           /*.count=*/IREE_ARRAYSIZE(provider_imports),
@@ -1074,6 +1075,7 @@ func.def @helper() {
                                 /*.count=*/IREE_ARRAYSIZE(symbols),
                                 /*.ordinals=*/symbols,
                             },
+                            loom_linker_source_symbol_binding_list_empty(),
                             loom_linker_source_symbol_output_list_empty(),
                             (loom_linker_source_provider_import_list_t){
                                 /*.count=*/IREE_ARRAYSIZE(provider_imports),
@@ -1087,6 +1089,7 @@ func.def @helper() {
   IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
                         loom_linker_add_module_symbols(
                             linker, source, /*source_symbols=*/{},
+                            loom_linker_source_symbol_binding_list_empty(),
                             loom_linker_source_symbol_output_list_empty(),
                             (loom_linker_source_provider_import_list_t){
                                 /*.count=*/IREE_ARRAYSIZE(provider_imports),
@@ -1202,6 +1205,7 @@ func.def @unused_corpus(%x: i32) -> (i32) {
           /*.count=*/IREE_ARRAYSIZE(harness_symbols),
           /*.ordinals=*/harness_symbols,
       },
+      loom_linker_source_symbol_binding_list_empty(),
       loom_linker_source_symbol_output_list_empty(),
       loom_linker_source_provider_import_list_empty(),
       loom_linker_target_symbol_list_empty()));
@@ -1212,6 +1216,7 @@ func.def @unused_corpus(%x: i32) -> (i32) {
           /*.count=*/IREE_ARRAYSIZE(corpus_symbols),
           /*.ordinals=*/corpus_symbols,
       },
+      loom_linker_source_symbol_binding_list_empty(),
       loom_linker_source_symbol_output_list_empty(),
       loom_linker_source_provider_import_list_empty(),
       loom_linker_target_symbol_list_empty()));
@@ -1331,6 +1336,7 @@ func.def @second() {
           /*.count=*/IREE_ARRAYSIZE(source_symbols),
           /*.ordinals=*/source_symbols,
       },
+      loom_linker_source_symbol_binding_list_empty(),
       loom_linker_source_symbol_output_list_empty(),
       loom_linker_source_provider_import_list_empty(),
       loom_linker_target_symbol_list_empty()));
@@ -1371,10 +1377,68 @@ func.def public @caller(%x: i32) -> (i32) {
                                 /*.count=*/IREE_ARRAYSIZE(source_symbols),
                                 /*.ordinals=*/source_symbols,
                             },
+                            loom_linker_source_symbol_binding_list_empty(),
                             loom_linker_source_symbol_output_list_empty(),
                             loom_linker_source_provider_import_list_empty(),
                             loom_linker_target_symbol_list_empty()));
   loom_linker_free(linker);
+}
+
+TEST_F(LinkerTest, ExactSelectionUsesPreviouslyProjectedBinding) {
+  loom_module_t* projected = Parse(IREE_SV(R"(
+func.decl @projected_helper(%x: i32) -> (i32)
+)"));
+  loom_module_t* source = Parse(IREE_SV(R"(
+func.def @helper(%x: i32) -> (i32) {
+  func.return %x : i32
+}
+
+func.def public @caller(%x: i32) -> (i32) {
+  %y = func.call @helper(%x) : (i32) -> (i32)
+  func.return %y : i32
+}
+)"));
+
+  loom_linker_t* linker = CreateIncrementalLinker();
+  loom_symbol_ref_t projected_target = loom_symbol_ref_null();
+  IREE_ASSERT_OK(loom_linker_add_exact_module(
+      linker, projected, loom_linker_source_symbol_output_list_empty(),
+      loom_linker_source_provider_import_list_empty(),
+      (loom_linker_target_symbol_list_t){
+          /*.count=*/1,
+          /*.values=*/&projected_target,
+      }));
+  ASSERT_TRUE(loom_symbol_ref_is_valid(projected_target));
+
+  const iree_host_size_t source_symbols[] = {1};
+  const loom_linker_source_symbol_binding_t source_bindings[] = {{
+      /*.source_ordinal=*/0,
+      /*.target=*/projected_target,
+  }};
+  IREE_ASSERT_OK(loom_linker_add_module_symbols(
+      linker, source,
+      (loom_linker_source_symbol_list_t){
+          /*.count=*/IREE_ARRAYSIZE(source_symbols),
+          /*.ordinals=*/source_symbols,
+      },
+      (loom_linker_source_symbol_binding_list_t){
+          /*.count=*/IREE_ARRAYSIZE(source_bindings),
+          /*.values=*/source_bindings,
+      },
+      loom_linker_source_symbol_output_list_empty(),
+      loom_linker_source_provider_import_list_empty(),
+      loom_linker_target_symbol_list_empty()));
+
+  loom_module_t* linked = nullptr;
+  IREE_ASSERT_OK(loom_linker_finish(linker, &linked));
+  loom_linker_free(linker);
+  modules_.push_back(linked);
+  Verify(linked);
+
+  const std::string text = Print(linked);
+  EXPECT_NE(text.find("func.decl @projected_helper"), std::string::npos);
+  EXPECT_NE(text.find("func.call @projected_helper"), std::string::npos);
+  EXPECT_EQ(text.find("func.def @helper"), std::string::npos);
 }
 
 TEST_F(LinkerTest, ExactSelectionRejectsMalformedOrdinals) {
@@ -1396,6 +1460,7 @@ func.def @second() {
                                 /*.count=*/1,
                                 /*.ordinals=*/nullptr,
                             },
+                            loom_linker_source_symbol_binding_list_empty(),
                             loom_linker_source_symbol_output_list_empty(),
                             loom_linker_source_provider_import_list_empty(),
                             loom_linker_target_symbol_list_empty()));
@@ -1407,6 +1472,7 @@ func.def @second() {
                                 /*.count=*/IREE_ARRAYSIZE(duplicate_symbols),
                                 /*.ordinals=*/duplicate_symbols,
                             },
+                            loom_linker_source_symbol_binding_list_empty(),
                             loom_linker_source_symbol_output_list_empty(),
                             loom_linker_source_provider_import_list_empty(),
                             loom_linker_target_symbol_list_empty()));
@@ -1418,6 +1484,7 @@ func.def @second() {
                                 /*.count=*/IREE_ARRAYSIZE(descending_symbols),
                                 /*.ordinals=*/descending_symbols,
                             },
+                            loom_linker_source_symbol_binding_list_empty(),
                             loom_linker_source_symbol_output_list_empty(),
                             loom_linker_source_provider_import_list_empty(),
                             loom_linker_target_symbol_list_empty()));
@@ -1429,6 +1496,7 @@ func.def @second() {
                                 /*.count=*/IREE_ARRAYSIZE(out_of_range_symbols),
                                 /*.ordinals=*/out_of_range_symbols,
                             },
+                            loom_linker_source_symbol_binding_list_empty(),
                             loom_linker_source_symbol_output_list_empty(),
                             loom_linker_source_provider_import_list_empty(),
                             loom_linker_target_symbol_list_empty()));

--- a/loom/src/loom/link/module_index.c
+++ b/loom/src/loom/link/module_index.c
@@ -904,6 +904,7 @@ static uint32_t loom_link_index_count_dependency_occurrences(
 static void loom_link_index_copy_dependency_occurrences(
     const loom_symbol_reference_table_t* table,
     loom_symbol_reference_occurrence_id_t first_occurrence_id, uint32_t* values,
+    loom_symbol_interface_flags_t* target_interfaces,
     uint8_t* source_root_region_indices_plus_one, iree_host_size_t* position) {
   loom_symbol_reference_occurrence_id_t occurrence_id = first_occurrence_id;
   while (occurrence_id != LOOM_SYMBOL_REFERENCE_OCCURRENCE_ID_INVALID) {
@@ -911,6 +912,7 @@ static void loom_link_index_copy_dependency_occurrences(
         &table->occurrences[occurrence_id];
     if (loom_symbol_reference_occurrence_is_dependency(occurrence)) {
       values[*position] = occurrence->target_symbol_id;
+      target_interfaces[*position] = occurrence->target_interfaces;
       source_root_region_indices_plus_one[*position] =
           occurrence->source_root_region_index_plus_one;
       ++*position;
@@ -923,6 +925,7 @@ static iree_status_t loom_link_index_project_symbol_references(
     loom_link_module_index_t* index, loom_link_module_index_module_t* module,
     const loom_symbol_reference_table_t* table) {
   uint32_t* dependency_values = NULL;
+  loom_symbol_interface_flags_t* dependency_target_interfaces = NULL;
   uint8_t* dependency_source_root_region_indices_plus_one = NULL;
   loom_link_template_family_ordinal_t* template_demand_values = NULL;
   uint8_t* template_demand_source_root_region_indices_plus_one = NULL;
@@ -943,6 +946,12 @@ static iree_status_t loom_link_index_project_symbol_references(
                                        sizeof(*dependency_values),
                                        (void**)&dependency_values);
     module->dependencies.values = dependency_values;
+    if (iree_status_is_ok(status)) {
+      status = iree_arena_allocate_array(&index->arena, dependency_count,
+                                         sizeof(*dependency_target_interfaces),
+                                         (void**)&dependency_target_interfaces);
+      module->dependencies.target_interfaces = dependency_target_interfaces;
+    }
     if (iree_status_is_ok(status)) {
       status = iree_arena_allocate_array(
           &index->arena, dependency_count,
@@ -976,6 +985,7 @@ static iree_status_t loom_link_index_project_symbol_references(
   if (iree_status_is_ok(status)) {
     loom_link_index_copy_dependency_occurrences(
         table, table->first_module_occurrence_id, dependency_values,
+        dependency_target_interfaces,
         dependency_source_root_region_indices_plus_one, &dependency_position);
     for (iree_host_size_t symbol_index = 0;
          symbol_index < table->symbol_count && iree_status_is_ok(status);
@@ -989,6 +999,7 @@ static iree_status_t loom_link_index_project_symbol_references(
           table, source->first_outgoing_occurrence_id);
       loom_link_index_copy_dependency_occurrences(
           table, source->first_outgoing_occurrence_id, dependency_values,
+          dependency_target_interfaces,
           dependency_source_root_region_indices_plus_one, &dependency_position);
 
       symbol->template_demands.first = (uint32_t)template_demand_position;
@@ -1059,6 +1070,8 @@ static iree_status_t loom_link_index_project_bytecode_references(
   module->dependencies.root_count = bytecode_module->module_dependency_count;
   module->dependencies.count = bytecode_module->dependency_count;
   module->dependencies.values = bytecode_module->dependency_symbol_indices;
+  module->dependencies.target_interfaces =
+      bytecode_module->dependency_target_interfaces;
   module->dependencies.source_root_region_indices_plus_one =
       bytecode_module->dependency_source_root_region_indices_plus_one;
   module->template_demands.count = bytecode_module->template_demand_count;

--- a/loom/src/loom/link/module_index.h
+++ b/loom/src/loom/link/module_index.h
@@ -169,6 +169,9 @@ typedef struct loom_link_module_index_module_t {
     // Module-local target symbol ordinals in deterministic occurrence order.
     // Targets may repeat within a source row.
     const uint32_t* values;
+    // Target interface constraints parallel to values. Zero accepts any
+    // target interface.
+    const loom_symbol_interface_flags_t* target_interfaces;
     // Source root region indices plus one parallel to values. Zero identifies
     // a source symbol contract or a module-root occurrence.
     const uint8_t* source_root_region_indices_plus_one;

--- a/loom/src/loom/link/module_index_test.cc
+++ b/loom/src/loom/link/module_index_test.cc
@@ -428,7 +428,9 @@ template.def<@demo.contract> @provider(%x: i32) -> (i32) {
     ASSERT_NE(family_declaration, nullptr);
     auto has_dependency = [&](const loom_link_module_index_symbol_t* source,
                               const loom_link_module_index_symbol_t* target,
-                              uint8_t expected_source_root) {
+                              uint8_t expected_source_root,
+                              loom_symbol_interface_flags_t
+                                  expected_target_interfaces) {
       for (iree_host_size_t i = 0; i < source->dependencies.count; ++i) {
         const iree_host_size_t dependency_index =
             source->dependencies.first + i;
@@ -437,16 +439,22 @@ template.def<@demo.contract> @provider(%x: i32) -> (i32) {
           EXPECT_EQ(indexed_module->dependencies
                         .source_root_region_indices_plus_one[dependency_index],
                     expected_source_root);
+          EXPECT_EQ(
+              indexed_module->dependencies.target_interfaces[dependency_index],
+              expected_target_interfaces);
           return true;
         }
       }
       return false;
     };
     ASSERT_EQ(entry->dependencies.count, 2u);
-    EXPECT_TRUE(has_dependency(entry, helper, 1u));
-    EXPECT_TRUE(has_dependency(entry, family_declaration, 1u));
+    EXPECT_TRUE(
+        has_dependency(entry, helper, 1u, LOOM_SYMBOL_INTERFACE_CALLABLE));
+    EXPECT_TRUE(has_dependency(entry, family_declaration, 1u,
+                               LOOM_SYMBOL_INTERFACE_TEMPLATE_FAMILY));
     ASSERT_EQ(provider->dependencies.count, 1u);
-    EXPECT_TRUE(has_dependency(provider, family_declaration, 0u));
+    EXPECT_TRUE(has_dependency(provider, family_declaration, 0u,
+                               LOOM_SYMBOL_INTERFACE_TEMPLATE_FAMILY));
     ASSERT_EQ(entry->template_demands.count, 1u);
     EXPECT_EQ(
         indexed_module->template_demands
@@ -541,11 +549,15 @@ test.split_func @split_root() {
       const uint8_t origin =
           indexed_module->dependencies
               .source_root_region_indices_plus_one[occurrence_index];
+      const loom_symbol_interface_flags_t target_interfaces =
+          indexed_module->dependencies.target_interfaces[occurrence_index];
       if (target == config_dependency->module_symbol_ordinal) {
         EXPECT_EQ(origin, 1u);
+        EXPECT_EQ(target_interfaces, LOOM_SYMBOL_INTERFACE_RECORD);
         found_config_dependency = true;
       } else if (target == implementation_dependency->module_symbol_ordinal) {
         EXPECT_EQ(origin, 2u);
+        EXPECT_EQ(target_interfaces, LOOM_SYMBOL_INTERFACE_RECORD);
         found_implementation_dependency = true;
       }
     }

--- a/loom/src/loom/link/plan_materializer.c
+++ b/loom/src/loom/link/plan_materializer.c
@@ -150,7 +150,8 @@ static iree_status_t loom_link_plan_materialize_module(
                                             out_target_symbols);
     } else {
       status = loom_linker_add_module_symbols(
-          linker, module->materialized_module, source_symbols, source_outputs,
+          linker, module->materialized_module, source_symbols,
+          loom_linker_source_symbol_binding_list_empty(), source_outputs,
           provider_imports, out_target_symbols);
     }
   } else {

--- a/loom/src/loom/link/planner.c
+++ b/loom/src/loom/link/planner.c
@@ -973,24 +973,56 @@ static iree_status_t loom_link_plan_select_global_reference(
 // Closure expansion
 //===----------------------------------------------------------------------===//
 
+// Maps one authored symbol-reference contract to the semantic provider
+// projection needed by that use. Logical launches consume configuration but
+// not implementation, while physical dispatches consume only the entry
+// contract. Every other reference retains the complete-symbol behavior.
+static loom_link_plan_facet_request_t loom_link_plan_dependency_facet_request(
+    const loom_link_plan_options_t* options,
+    loom_symbol_interface_flags_t target_interfaces) {
+  if (!options ||
+      options->dependency_policy == LOOM_LINK_PLAN_DEPENDENCY_COMPLETE) {
+    return (loom_link_plan_facet_request_t){
+        .mode = LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE,
+    };
+  }
+  IREE_ASSERT(options->dependency_policy ==
+              LOOM_LINK_PLAN_DEPENDENCY_REQUESTED_FACETS);
+  const bool requests_kernel =
+      iree_any_bit_set(target_interfaces, LOOM_SYMBOL_INTERFACE_KERNEL);
+  const bool requests_kernel_entry =
+      iree_any_bit_set(target_interfaces, LOOM_SYMBOL_INTERFACE_KERNEL_ENTRY);
+  IREE_ASSERT(!(requests_kernel && requests_kernel_entry));
+  if (requests_kernel) {
+    return (loom_link_plan_facet_request_t){
+        .mode = LOOM_LINK_PLAN_FACET_REQUEST_EXACT,
+        .kind = LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION,
+    };
+  }
+  return (loom_link_plan_facet_request_t){
+      .mode = requests_kernel_entry ? LOOM_LINK_PLAN_FACET_REQUEST_PRIMARY
+                                    : LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE,
+  };
+}
+
 static iree_status_t loom_link_plan_select_dependency_target(
     loom_link_plan_t* plan, const loom_link_plan_options_t* options,
     const loom_link_module_index_module_t* module, uint32_t target_symbol_id,
+    loom_symbol_interface_flags_t target_interfaces,
     loom_link_plan_live_cause_t cause) {
   IREE_ASSERT_LT(target_symbol_id, module->symbol_count);
   const loom_link_module_index_symbol_t* target =
       loom_link_module_index_symbol_at(
           plan->index, module->symbol_start_ordinal + target_symbol_id);
   IREE_ASSERT(target);
+  const loom_link_plan_facet_request_t request =
+      loom_link_plan_dependency_facet_request(options, target_interfaces);
   if (target->identity == LOOM_LINK_SYMBOL_IDENTITY_GLOBAL) {
-    const loom_link_plan_facet_request_t request = {
-        .mode = LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE,
-    };
     return loom_link_plan_select_global_reference(plan, options, target,
                                                   request, cause);
   }
-  return loom_link_plan_select_required_symbol(
-      plan, options, target, cause,
+  return loom_link_plan_select_required_symbol_facets(
+      plan, options, target, request, cause,
       /*out_new_symbol_plan_ordinal=*/NULL);
 }
 
@@ -1000,11 +1032,13 @@ static iree_status_t loom_link_plan_expand_module_dependencies(
     loom_link_plan_live_cause_t cause) {
   const uint32_t count = module->dependencies.root_count;
   const uint32_t* dependencies = module->dependencies.values;
+  const loom_symbol_interface_flags_t* target_interfaces =
+      module->dependencies.target_interfaces;
   for (uint32_t i = 0; i < count; ++i) {
     IREE_ASSERT_EQ(module->dependencies.source_root_region_indices_plus_one[i],
                    0);
     IREE_RETURN_IF_ERROR(loom_link_plan_select_dependency_target(
-        plan, options, module, dependencies[i], cause));
+        plan, options, module, dependencies[i], target_interfaces[i], cause));
   }
   return iree_ok_status();
 }
@@ -1017,6 +1051,8 @@ static iree_status_t loom_link_plan_expand_symbol_facet_dependencies(
   if (symbol->dependencies.count == 0) return iree_ok_status();
   const uint32_t first = symbol->dependencies.first;
   const uint32_t* dependencies = module->dependencies.values + first;
+  const loom_symbol_interface_flags_t* target_interfaces =
+      module->dependencies.target_interfaces + first;
   for (uint32_t i = 0; i < symbol->dependencies.count; ++i) {
     const uint8_t source_root_region_index_plus_one =
         module->dependencies.source_root_region_indices_plus_one[first + i];
@@ -1026,7 +1062,7 @@ static iree_status_t loom_link_plan_expand_symbol_facet_dependencies(
     IREE_ASSERT_NE(source_kind, LOOM_LINK_SYMBOL_FACET_INVALID);
     if (source_kind != kind) continue;
     IREE_RETURN_IF_ERROR(loom_link_plan_select_dependency_target(
-        plan, options, module, dependencies[i], cause));
+        plan, options, module, dependencies[i], target_interfaces[i], cause));
   }
   return iree_ok_status();
 }
@@ -1121,6 +1157,8 @@ static iree_status_t loom_link_plan_expand_complete_symbol(
     const uint32_t dependency_first = symbol->dependencies.first;
     const uint32_t* dependencies =
         module->dependencies.values + dependency_first;
+    const loom_symbol_interface_flags_t* target_interfaces =
+        module->dependencies.target_interfaces + dependency_first;
     for (uint32_t i = 0; i < symbol->dependencies.count; ++i) {
       const uint8_t source_root_region_index_plus_one =
           module->dependencies
@@ -1133,7 +1171,7 @@ static iree_status_t loom_link_plan_expand_complete_symbol(
           loom_link_plan_facet_dependency_cause(plan, symbol_plan_ordinal,
                                                 source_kind);
       IREE_RETURN_IF_ERROR(loom_link_plan_select_dependency_target(
-          plan, options, module, dependencies[i], cause));
+          plan, options, module, dependencies[i], target_interfaces[i], cause));
     }
   }
 

--- a/loom/src/loom/link/planner.c
+++ b/loom/src/loom/link/planner.c
@@ -49,6 +49,22 @@ typedef struct loom_link_plan_facet_request_t {
   loom_link_symbol_facet_kind_t kind;
 } loom_link_plan_facet_request_t;
 
+// Provider resolution has not been attempted for this selected symbol.
+#define LOOM_LINK_PLAN_PROVIDER_UNCHECKED_ORDINAL \
+  LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL
+// Provider resolution completed without selecting a concrete definition.
+#define LOOM_LINK_PLAN_PROVIDER_ABSENT_ORDINAL \
+  (LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL - 1)
+
+typedef struct loom_link_plan_symbol_work_item_t {
+  // Public selected-symbol record.
+  loom_link_plan_symbol_t selection;
+  // Last selected facet for O(1) append to this symbol's facet chain.
+  iree_host_size_t last_facet_plan_ordinal;
+  // Index-wide concrete provider symbol ordinal, UNCHECKED, or ABSENT.
+  iree_host_size_t resolved_provider_symbol_ordinal;
+} loom_link_plan_symbol_work_item_t;
+
 typedef enum loom_link_plan_facet_expansion_mode_e {
   // This selected facet is accounted for by another complete-symbol item.
   LOOM_LINK_PLAN_FACET_EXPANSION_NONE = 0,
@@ -63,6 +79,8 @@ typedef struct loom_link_plan_facet_work_item_t {
   loom_link_plan_facet_t selection;
   // Closure expansion performed when this work item is reached.
   loom_link_plan_facet_expansion_mode_t expansion_mode;
+  // Next selected facet of the same symbol, or INVALID_ORDINAL.
+  iree_host_size_t next_symbol_facet_plan_ordinal;
 } loom_link_plan_facet_work_item_t;
 
 struct loom_link_plan_t {
@@ -75,7 +93,7 @@ struct loom_link_plan_t {
   // Live symbol selections in stable worklist order.
   struct {
     // Growable selection storage.
-    loom_link_plan_symbol_t* values;
+    loom_link_plan_symbol_work_item_t* values;
     // Number of live selections.
     iree_host_size_t count;
     // Allocated selection capacity.
@@ -352,7 +370,7 @@ static iree_status_t loom_link_plan_reserve_symbol_ordinals(
   }
   for (iree_host_size_t i = 0; i < plan->symbols.count; ++i) {
     loom_link_plan_insert_symbol_ordinal(
-        values, capacity, plan->symbols.values[i].symbol_ordinal, i);
+        values, capacity, plan->symbols.values[i].selection.symbol_ordinal, i);
   }
   iree_allocator_free(plan->allocator, plan->symbol_ordinals.values);
   plan->symbol_ordinals.values = values;
@@ -431,17 +449,20 @@ static bool loom_link_plan_symbol_satisfies_declaration(
   }
   return !loom_link_plan_symbol_is_declaration_like(candidate) &&
          iree_any_bit_set(candidate->flags,
-                          LOOM_LINK_SYMBOL_FLAG_CONCRETE_DEFINITION);
+                          LOOM_LINK_SYMBOL_FLAG_CONCRETE_DEFINITION) &&
+         iree_all_bits_set(candidate->facets.schema.interfaces,
+                           declaration->facets.schema.interfaces);
 }
 
 static const loom_link_module_index_symbol_t*
 loom_link_plan_find_unconstrained_definition_for_declaration(
-    const loom_link_plan_t* plan,
+    const loom_link_plan_t* plan, const loom_link_plan_options_t* options,
     const loom_link_module_index_symbol_t* declaration) {
   const loom_link_module_index_symbol_t* symbol =
       loom_link_module_index_lookup_name(plan->index, declaration->name);
   while (symbol) {
-    if (loom_link_plan_symbol_satisfies_declaration(declaration, symbol)) {
+    if (loom_link_plan_symbol_satisfies_declaration(declaration, symbol) &&
+        !loom_link_plan_symbol_is_stripped(options, plan, symbol)) {
       return symbol;
     }
     symbol = loom_link_module_index_next_same_name(plan->index, symbol);
@@ -603,14 +624,20 @@ static iree_status_t loom_link_plan_append_symbol(
     IREE_RETURN_IF_ERROR(
         loom_link_plan_reserve_symbol_ordinals(plan, symbol_count));
   }
-  plan->symbols.values[plan_ordinal] = (loom_link_plan_symbol_t){
-      .ordinal = plan_ordinal,
-      .symbol_ordinal = symbol->ordinal,
-      .reason = cause.reason,
-      .cause_ordinal = cause.symbol_plan_ordinal,
-      .primary_facet_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
-      .selected_facet_count = 0,
-      .root_name = cause.root_name,
+  plan->symbols.values[plan_ordinal] = (loom_link_plan_symbol_work_item_t){
+      .selection =
+          {
+              .ordinal = plan_ordinal,
+              .symbol_ordinal = symbol->ordinal,
+              .reason = cause.reason,
+              .cause_ordinal = cause.symbol_plan_ordinal,
+              .primary_facet_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
+              .selected_facet_count = 0,
+              .root_name = cause.root_name,
+          },
+      .last_facet_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
+      .resolved_provider_symbol_ordinal =
+          LOOM_LINK_PLAN_PROVIDER_UNCHECKED_ORDINAL,
   };
   loom_link_plan_bitmap_test_and_set(&plan->reachability.symbols,
                                      symbol->ordinal);
@@ -648,12 +675,20 @@ static iree_status_t loom_link_plan_append_facet(
               .cause_ordinal = cause.facet_plan_ordinal,
           },
       .expansion_mode = expansion_mode,
+      .next_symbol_facet_plan_ordinal = LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL,
   };
   plan->facets.count = facet_count;
-  ++plan->symbols.values[symbol_plan_ordinal].selected_facet_count;
+  loom_link_plan_symbol_work_item_t* symbol_work_item =
+      &plan->symbols.values[symbol_plan_ordinal];
+  if (symbol_work_item->last_facet_plan_ordinal !=
+      LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL) {
+    plan->facets.values[symbol_work_item->last_facet_plan_ordinal]
+        .next_symbol_facet_plan_ordinal = facet_plan_ordinal;
+  }
+  symbol_work_item->last_facet_plan_ordinal = facet_plan_ordinal;
+  ++symbol_work_item->selection.selected_facet_count;
   if (kind == loom_link_module_index_symbol_facet_kind_at(symbol, 0)) {
-    plan->symbols.values[symbol_plan_ordinal].primary_facet_ordinal =
-        facet_plan_ordinal;
+    symbol_work_item->selection.primary_facet_ordinal = facet_plan_ordinal;
   }
   if (out_facet_plan_ordinal) {
     *out_facet_plan_ordinal = facet_plan_ordinal;
@@ -665,7 +700,7 @@ static bool loom_link_plan_facet_is_selected(
     const loom_link_plan_t* plan, iree_host_size_t symbol_plan_ordinal,
     loom_link_symbol_facet_kind_t kind) {
   const loom_link_plan_symbol_t* symbol_selection =
-      &plan->symbols.values[symbol_plan_ordinal];
+      &plan->symbols.values[symbol_plan_ordinal].selection;
   const loom_link_module_index_symbol_t* symbol =
       loom_link_module_index_symbol_at(plan->index,
                                        symbol_selection->symbol_ordinal);
@@ -673,13 +708,14 @@ static bool loom_link_plan_facet_is_selected(
   if (symbol_selection->selected_facet_count == complete_facet_count) {
     return true;
   }
-  for (iree_host_size_t i = symbol_selection->primary_facet_ordinal;
-       i < plan->facets.count; ++i) {
-    const loom_link_plan_facet_t* facet = &plan->facets.values[i].selection;
-    if (facet->symbol_plan_ordinal == symbol_plan_ordinal &&
-        facet->kind == kind) {
+  iree_host_size_t facet_plan_ordinal = symbol_selection->primary_facet_ordinal;
+  while (facet_plan_ordinal != LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL) {
+    const loom_link_plan_facet_work_item_t* facet_work_item =
+        &plan->facets.values[facet_plan_ordinal];
+    if (facet_work_item->selection.kind == kind) {
       return true;
     }
+    facet_plan_ordinal = facet_work_item->next_symbol_facet_plan_ordinal;
   }
   return false;
 }
@@ -697,7 +733,7 @@ static bool loom_link_plan_facet_request_is_selected(
     return true;
   }
   const loom_link_plan_symbol_t* symbol_selection =
-      &plan->symbols.values[symbol_plan_ordinal];
+      &plan->symbols.values[symbol_plan_ordinal].selection;
   const uint16_t complete_facet_count = symbol->facets.schema.facet_count;
   if (symbol_selection->selected_facet_count == complete_facet_count) {
     return true;
@@ -760,7 +796,8 @@ static iree_status_t loom_link_plan_select_required_symbol_facets(
   const bool batch_complete_expansion =
       is_new_symbol && request.mode == LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE;
   bool needs_complete_expansion = batch_complete_expansion;
-  if (plan->symbols.values[symbol_plan_ordinal].selected_facet_count == 0) {
+  if (plan->symbols.values[symbol_plan_ordinal]
+          .selection.selected_facet_count == 0) {
     const loom_link_plan_facet_expansion_mode_t expansion_mode =
         needs_complete_expansion ? LOOM_LINK_PLAN_FACET_EXPANSION_COMPLETE
                                  : LOOM_LINK_PLAN_FACET_EXPANSION_EXACT;
@@ -800,8 +837,8 @@ static iree_status_t loom_link_plan_select_required_symbol_facets(
     }
   }
   const uint16_t complete_facet_count = symbol->facets.schema.facet_count;
-  if (plan->symbols.values[symbol_plan_ordinal].selected_facet_count !=
-          complete_facet_count &&
+  if (plan->symbols.values[symbol_plan_ordinal]
+              .selection.selected_facet_count != complete_facet_count &&
       plan->symbol_ordinals.values == NULL) {
     IREE_RETURN_IF_ERROR(
         loom_link_plan_reserve_symbol_ordinals(plan, plan->symbols.count));
@@ -824,7 +861,8 @@ static iree_status_t loom_link_plan_select_required_symbol(
 static iree_status_t loom_link_plan_resolve_declaration(
     loom_link_plan_t* plan, const loom_link_plan_options_t* options,
     const loom_link_module_index_symbol_t* declaration,
-    iree_host_size_t declaration_plan_ordinal) {
+    iree_host_size_t declaration_plan_ordinal,
+    loom_link_plan_facet_request_t provider_request) {
   if (!loom_link_plan_symbol_is_declaration_like(declaration)) {
     return iree_ok_status();
   }
@@ -835,32 +873,47 @@ static iree_status_t loom_link_plan_resolve_declaration(
       LOOM_LINK_TEMPLATE_FAMILY_ORDINAL_INVALID) {
     return iree_ok_status();
   }
+  loom_link_plan_symbol_work_item_t* declaration_work_item =
+      &plan->symbols.values[declaration_plan_ordinal];
   const loom_link_module_index_provider_import_list_t imports =
       loom_link_module_index_symbol_provider_imports(plan->index, declaration);
   const loom_link_module_index_symbol_t* selected_symbol = NULL;
-  if (imports.count != 0) {
-    IREE_RETURN_IF_ERROR(loom_link_plan_find_imported_symbol_for_declaration(
-        plan, options, declaration, imports, &selected_symbol));
+  if (declaration_work_item->resolved_provider_symbol_ordinal ==
+      LOOM_LINK_PLAN_PROVIDER_ABSENT_ORDINAL) {
+    return iree_ok_status();
+  } else if (declaration_work_item->resolved_provider_symbol_ordinal !=
+             LOOM_LINK_PLAN_PROVIDER_UNCHECKED_ORDINAL) {
+    selected_symbol = loom_link_module_index_symbol_at(
+        plan->index, declaration_work_item->resolved_provider_symbol_ordinal);
+    IREE_ASSERT(selected_symbol);
   } else {
-    // Declarations without provider constraints resolve by ordinary global
-    // symbol identity across the explicitly supplied module universe.
-    selected_symbol =
-        loom_link_plan_find_unconstrained_definition_for_declaration(
-            plan, declaration);
+    if (imports.count != 0) {
+      IREE_RETURN_IF_ERROR(loom_link_plan_find_imported_symbol_for_declaration(
+          plan, options, declaration, imports, &selected_symbol));
+    } else {
+      // Declarations without provider constraints resolve by ordinary global
+      // symbol identity across the explicitly supplied module universe.
+      selected_symbol =
+          loom_link_plan_find_unconstrained_definition_for_declaration(
+              plan, options, declaration);
+    }
+    declaration_work_item->resolved_provider_symbol_ordinal =
+        selected_symbol ? selected_symbol->ordinal
+                        : LOOM_LINK_PLAN_PROVIDER_ABSENT_ORDINAL;
   }
   if (!selected_symbol) {
     return iree_ok_status();
   }
   const loom_link_plan_symbol_t* declaration_selection =
-      &plan->symbols.values[declaration_plan_ordinal];
+      &declaration_work_item->selection;
   const loom_link_plan_live_cause_t cause = {
       .reason = LOOM_LINK_PLAN_LIVE_DEPENDENCY,
       .symbol_plan_ordinal = declaration_plan_ordinal,
       .facet_plan_ordinal = declaration_selection->primary_facet_ordinal,
       .root_name = iree_string_view_empty(),
   };
-  IREE_RETURN_IF_ERROR(loom_link_plan_select_required_symbol(
-      plan, options, selected_symbol, cause,
+  IREE_RETURN_IF_ERROR(loom_link_plan_select_required_symbol_facets(
+      plan, options, selected_symbol, provider_request, cause,
       /*out_new_symbol_plan_ordinal=*/NULL));
   if (imports.count != 0) {
     loom_link_plan_bitmap_test_and_set(
@@ -872,13 +925,13 @@ static iree_status_t loom_link_plan_resolve_declaration(
 static iree_status_t loom_link_plan_select_global_reference(
     loom_link_plan_t* plan, const loom_link_plan_options_t* options,
     const loom_link_module_index_symbol_t* referenced_symbol,
-    loom_link_plan_live_cause_t cause) {
-  const bool is_local_declaration =
+    loom_link_plan_facet_request_t request, loom_link_plan_live_cause_t cause) {
+  const bool references_local_declaration =
       loom_link_plan_symbol_is_declaration_like(referenced_symbol);
   const loom_link_module_index_symbol_t* selected_symbol =
-      is_local_declaration ? referenced_symbol
-                           : loom_link_module_index_lookup_global(
-                                 plan->index, referenced_symbol->name);
+      references_local_declaration ? referenced_symbol
+                                   : loom_link_module_index_lookup_global(
+                                         plan->index, referenced_symbol->name);
   if (!selected_symbol) {
     if (options &&
         options->unresolved_policy == LOOM_LINK_PLAN_UNRESOLVED_ALLOW) {
@@ -891,13 +944,29 @@ static iree_status_t loom_link_plan_select_global_reference(
 
   iree_host_size_t selected_plan_ordinal =
       LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
-  IREE_RETURN_IF_ERROR(loom_link_plan_select_required_symbol(
-      plan, options, selected_symbol, cause, &selected_plan_ordinal));
-  if (selected_plan_ordinal == LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL) {
+  const bool selected_is_declaration =
+      loom_link_plan_symbol_is_declaration_like(selected_symbol);
+  const loom_link_plan_facet_request_t selection_request =
+      selected_is_declaration
+          ? (loom_link_plan_facet_request_t){
+                .mode = LOOM_LINK_PLAN_FACET_REQUEST_PRIMARY,
+            }
+          : request;
+  IREE_RETURN_IF_ERROR(loom_link_plan_select_required_symbol_facets(
+      plan, options, selected_symbol, selection_request, cause,
+      &selected_plan_ordinal));
+  if (!selected_is_declaration) {
+    return iree_ok_status();
+  }
+  if (selected_plan_ordinal == LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL &&
+      !loom_link_plan_try_lookup_symbol_ordinal(plan, selected_symbol->ordinal,
+                                                &selected_plan_ordinal)) {
+    // A previous complete selection needs no projection upgrade. An unresolved
+    // provider also remains unresolved against the immutable index/options.
     return iree_ok_status();
   }
   return loom_link_plan_resolve_declaration(plan, options, selected_symbol,
-                                            selected_plan_ordinal);
+                                            selected_plan_ordinal, request);
 }
 
 //===----------------------------------------------------------------------===//
@@ -914,11 +983,15 @@ static iree_status_t loom_link_plan_select_dependency_target(
           plan->index, module->symbol_start_ordinal + target_symbol_id);
   IREE_ASSERT(target);
   if (target->identity == LOOM_LINK_SYMBOL_IDENTITY_GLOBAL) {
-    return loom_link_plan_select_global_reference(plan, options, target, cause);
+    const loom_link_plan_facet_request_t request = {
+        .mode = LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE,
+    };
+    return loom_link_plan_select_global_reference(plan, options, target,
+                                                  request, cause);
   }
-  return loom_link_plan_select_required_symbol(plan, options, target, cause,
-                                               /*out_new_symbol_plan_ordinal=*/
-                                               NULL);
+  return loom_link_plan_select_required_symbol(
+      plan, options, target, cause,
+      /*out_new_symbol_plan_ordinal=*/NULL);
 }
 
 static iree_status_t loom_link_plan_expand_module_dependencies(
@@ -1006,24 +1079,25 @@ static iree_host_size_t loom_link_plan_find_facet_plan_ordinal(
     const loom_link_plan_t* plan, iree_host_size_t symbol_plan_ordinal,
     loom_link_symbol_facet_kind_t kind) {
   const loom_link_plan_symbol_t* symbol_selection =
-      &plan->symbols.values[symbol_plan_ordinal];
+      &plan->symbols.values[symbol_plan_ordinal].selection;
   const loom_link_module_index_symbol_t* symbol =
       loom_link_module_index_symbol_at(plan->index,
                                        symbol_selection->symbol_ordinal);
   IREE_ASSERT_NE(symbol_selection->primary_facet_ordinal,
                  LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL);
-  const iree_host_size_t index_facet_ordinal =
-      loom_link_module_index_symbol_facet_ordinal(symbol, kind);
-  IREE_ASSERT_NE(index_facet_ordinal, LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL);
-  const iree_host_size_t contiguous_ordinal =
-      symbol_selection->primary_facet_ordinal +
-      (index_facet_ordinal - symbol->facets.start_ordinal);
-  IREE_ASSERT_LT(contiguous_ordinal, plan->facets.count);
-  const loom_link_plan_facet_t* facet =
-      &plan->facets.values[contiguous_ordinal].selection;
-  IREE_ASSERT_EQ(facet->symbol_plan_ordinal, symbol_plan_ordinal);
-  IREE_ASSERT_EQ(facet->kind, kind);
-  return contiguous_ordinal;
+  IREE_ASSERT_NE(loom_link_module_index_symbol_facet_ordinal(symbol, kind),
+                 LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL);
+  iree_host_size_t facet_plan_ordinal = symbol_selection->primary_facet_ordinal;
+  while (facet_plan_ordinal != LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL) {
+    const loom_link_plan_facet_work_item_t* facet_work_item =
+        &plan->facets.values[facet_plan_ordinal];
+    if (facet_work_item->selection.kind == kind) {
+      return facet_plan_ordinal;
+    }
+    facet_plan_ordinal = facet_work_item->next_symbol_facet_plan_ordinal;
+  }
+  IREE_ASSERT_UNREACHABLE("selected symbol facet is absent from its worklist");
+  return LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
 }
 
 static loom_link_plan_live_cause_t loom_link_plan_facet_dependency_cause(
@@ -1093,7 +1167,8 @@ static iree_status_t loom_link_plan_expand_facet(
   }
   if (work_item.expansion_mode == LOOM_LINK_PLAN_FACET_EXPANSION_COMPLETE) {
     const iree_host_size_t primary_facet_ordinal =
-        plan->symbols.values[facet.symbol_plan_ordinal].primary_facet_ordinal;
+        plan->symbols.values[facet.symbol_plan_ordinal]
+            .selection.primary_facet_ordinal;
     const loom_link_plan_live_cause_t module_cause = {
         .reason = LOOM_LINK_PLAN_LIVE_DEPENDENCY,
         .symbol_plan_ordinal = facet.symbol_plan_ordinal,
@@ -1154,9 +1229,12 @@ static iree_status_t loom_link_plan_select_archive(
   for (iree_host_size_t i = 0; i < plan->symbols.count; ++i) {
     const loom_link_module_index_symbol_t* symbol =
         loom_link_module_index_symbol_at(
-            plan->index, plan->symbols.values[i].symbol_ordinal);
-    IREE_RETURN_IF_ERROR(
-        loom_link_plan_resolve_declaration(plan, options, symbol, i));
+            plan->index, plan->symbols.values[i].selection.symbol_ordinal);
+    const loom_link_plan_facet_request_t provider_request = {
+        .mode = LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE,
+    };
+    IREE_RETURN_IF_ERROR(loom_link_plan_resolve_declaration(
+        plan, options, symbol, i, provider_request));
   }
   return iree_ok_status();
 }
@@ -1179,7 +1257,11 @@ static iree_status_t loom_link_plan_select_root(
       .root_name = root_name,
   };
   if (root) {
-    return loom_link_plan_select_global_reference(plan, options, root, cause);
+    const loom_link_plan_facet_request_t request = {
+        .mode = LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE,
+    };
+    return loom_link_plan_select_global_reference(plan, options, root, request,
+                                                  cause);
   }
 
   const loom_link_module_index_symbol_t* private_root = NULL;
@@ -1224,8 +1306,11 @@ static iree_status_t loom_link_plan_select_input_exports(
     IREE_RETURN_IF_ERROR(loom_link_plan_select_required_symbol(
         plan, options, symbol, cause, &root_plan_ordinal));
     if (root_plan_ordinal != LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL) {
+      const loom_link_plan_facet_request_t provider_request = {
+          .mode = LOOM_LINK_PLAN_FACET_REQUEST_COMPLETE,
+      };
       IREE_RETURN_IF_ERROR(loom_link_plan_resolve_declaration(
-          plan, options, symbol, root_plan_ordinal));
+          plan, options, symbol, root_plan_ordinal, provider_request));
     }
   }
   return iree_ok_status();
@@ -1267,7 +1352,7 @@ static iree_status_t loom_link_plan_select_root_facets(
         plan, options, symbol, request, cause, &root_plan_ordinal));
     if (root_plan_ordinal != LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL) {
       IREE_RETURN_IF_ERROR(loom_link_plan_resolve_declaration(
-          plan, options, symbol, root_plan_ordinal));
+          plan, options, symbol, root_plan_ordinal, request));
     }
   }
   return iree_ok_status();
@@ -1438,7 +1523,7 @@ const loom_link_plan_symbol_t* loom_link_plan_symbol_at(
   if (!plan || ordinal >= plan->symbols.count) {
     return NULL;
   }
-  return &plan->symbols.values[ordinal];
+  return &plan->symbols.values[ordinal].selection;
 }
 
 iree_host_size_t loom_link_plan_facet_count(const loom_link_plan_t* plan) {

--- a/loom/src/loom/link/planner.h
+++ b/loom/src/loom/link/planner.h
@@ -47,6 +47,14 @@ typedef enum loom_link_plan_test_symbol_policy_e {
   LOOM_LINK_PLAN_TEST_SYMBOL_STRIP = 1,
 } loom_link_plan_test_symbol_policy_t;
 
+// Policy for projecting dependencies reached through symbol references.
+typedef enum loom_link_plan_dependency_policy_e {
+  // Retain complete referenced symbols for ordinary source composition.
+  LOOM_LINK_PLAN_DEPENDENCY_COMPLETE = 0,
+  // Preserve the exact semantic interfaces requested by each reference.
+  LOOM_LINK_PLAN_DEPENDENCY_REQUESTED_FACETS = 1,
+} loom_link_plan_dependency_policy_t;
+
 // Reason a planned symbol is live.
 typedef enum loom_link_plan_live_reason_e {
   // Selected because archive mode includes every linkable symbol.
@@ -108,6 +116,8 @@ typedef struct loom_link_plan_options_t {
     // Root facet requests in caller-defined stable order.
     const loom_link_plan_root_facet_t* values;
   } root_facets;
+  // Dependency projection policy. Zero defaults to complete source symbols.
+  loom_link_plan_dependency_policy_t dependency_policy;
 } loom_link_plan_options_t;
 
 // One live symbol selection in a plan.

--- a/loom/src/loom/link/planner_benchmark.cc
+++ b/loom/src/loom/link/planner_benchmark.cc
@@ -1112,6 +1112,7 @@ static void BenchmarkExactLink(benchmark::State& state,
     state.ResumeTiming();
     CheckStatus(loom_linker_add_module_symbols(
         linker, fixture.module(), source_symbols,
+        loom_linker_source_symbol_binding_list_empty(),
         loom_linker_source_symbol_output_list_empty(),
         loom_linker_source_provider_import_list_empty(),
         loom_linker_target_symbol_list_empty()));

--- a/loom/src/loom/link/planner_test.cc
+++ b/loom/src/loom/link/planner_test.cc
@@ -624,93 +624,209 @@ func.def @interleaved_dependency() {
   verify_index(bytecode_index.get());
 }
 
-TEST_F(LinkPlannerTest,
-       KernelDeclarationSelectsStructurallyCompatibleProviderOnce) {
-  loom_module_t* harness = Parse(IREE_SV(R"(
-kernel.decl @target(%count: index) launch()
+TEST_F(LinkPlannerTest, KernelReferencesSelectOnlyTheirRequiredFacets) {
+  const iree_string_view_t harness_source = IREE_SV(R"(
+kernel.decl @configured(%count: index) launch()
+kernel.entry.decl @dispatched() where [workgroup_size(1, 1, 1)]
 
 func.def @interleaved_dependency() {
   func.return
 }
 
+config.def @local_configuration_dependency = 1 : index
+
+func.def @local_implementation_dependency() {
+  func.return
+}
+
+kernel.def @local(%count: index) {
+  %configured = config.get @local_configuration_dependency : index
+  kernel.launch.config workgroups(%count, %configured, %configured) workgroup_size(%configured, %configured, %configured) : index
+} launch() {
+  func.call @local_implementation_dependency() : () -> ()
+  kernel.return
+}
+
 func.def public @entry(%count: index) {
-  kernel.launch @target[%count]() : [index]()
+  kernel.launch @configured[%count]() : [index]()
   func.call @interleaved_dependency() : () -> ()
-  kernel.launch @target[%count]() : [index]()
+  kernel.launch @configured[%count]() : [index]()
+  kernel.launch @local[%count]() : [index]()
+  kernel.dispatch @dispatched[%count]() : [index]()
   func.return
 }
-)"));
-  loom_module_t* wrong_library = Parse(IREE_SV(R"(
-func.def @target(%count: index) {
+)");
+  const iree_string_view_t wrong_library_source = IREE_SV(R"(
+func.def @configured(%count: index) {
   func.return
 }
-)"));
-  loom_module_t* library = Parse(IREE_SV(R"(
-func.def @configuration_dependency(%value: index) -> (index) {
-  func.return %value : index
-}
+)");
+  const iree_string_view_t library_source = IREE_SV(R"(
+config.def @configuration_dependency = 1 : index
+config.def @dispatched_configuration_dependency = 1 : index
 
 func.def @implementation_dependency() {
   func.return
 }
 
-kernel.def @target(%count: index) {
-  %configured = func.call @configuration_dependency(%count) : (index) -> (index)
-  kernel.launch.config workgroups(%configured, %configured, %configured) workgroup_size(%configured, %configured, %configured) : index
+kernel.def @configured(%count: index) {
+  %configured = config.get @configuration_dependency : index
+  kernel.launch.config workgroups(%count, %configured, %configured) workgroup_size(%configured, %configured, %configured) : index
 } launch() {
   func.call @implementation_dependency() : () -> ()
   kernel.return
 }
-)"));
 
-  IndexPtr index = CreateIndex();
-  AddMaterialized(index.get(), harness, IREE_SV("harness"),
-                  LOOM_LINK_PROVIDER_ROLE_INPUT);
-  AddMaterialized(index.get(), wrong_library, IREE_SV("wrong-library"),
-                  LOOM_LINK_PROVIDER_ROLE_LIBRARY);
-  AddMaterialized(index.get(), library, IREE_SV("library"),
-                  LOOM_LINK_PROVIDER_ROLE_LIBRARY);
-  iree_string_view_t roots[] = {IREE_SV("@entry")};
-  loom_link_plan_options_t options = {
-      /*.mode=*/LOOM_LINK_PLAN_SELECTIVE,
-      /*.root_symbols=*/{/*.count=*/IREE_ARRAYSIZE(roots), /*.values=*/roots},
+kernel.def @dispatched(%count: index) {
+  %configured = config.get @dispatched_configuration_dependency : index
+  kernel.launch.config workgroups(%count, %configured, %configured) workgroup_size(%configured, %configured, %configured) : index
+} launch() {
+  func.call @implementation_dependency() : () -> ()
+  kernel.return
+}
+)");
+  loom_module_t* harness = Parse(harness_source);
+  ASSERT_NE(harness, nullptr);
+  loom_module_t* wrong_library = Parse(wrong_library_source);
+  ASSERT_NE(wrong_library, nullptr);
+  loom_module_t* library = Parse(library_source);
+  ASSERT_NE(library, nullptr);
+  const std::vector<uint8_t> harness_bytecode = WriteModule(harness);
+  const std::vector<uint8_t> wrong_library_bytecode =
+      WriteModule(wrong_library);
+  const std::vector<uint8_t> library_bytecode = WriteModule(library);
+
+  auto verify_index = [&](const loom_link_module_index_t* index) {
+    iree_string_view_t roots[] = {IREE_SV("@entry")};
+    loom_link_plan_options_t options = {
+        /*.mode=*/LOOM_LINK_PLAN_SELECTIVE,
+        /*.root_symbols=*/{/*.count=*/IREE_ARRAYSIZE(roots), /*.values=*/roots},
+        /*.include_input_exports=*/false,
+        /*.unresolved_policy=*/LOOM_LINK_PLAN_UNRESOLVED_ERROR,
+        /*.test_symbol_policy=*/LOOM_LINK_PLAN_TEST_SYMBOL_KEEP,
+        /*.strip_symbol=*/nullptr,
+        /*.strip_symbol_user_data=*/nullptr,
+        /*.provider_resolver=*/nullptr,
+        /*.selected_template_providers=*/{},
+        /*.root_facets=*/{},
+        /*.dependency_policy=*/LOOM_LINK_PLAN_DEPENDENCY_REQUESTED_FACETS,
+    };
+    PlanPtr plan = BuildPlan(index, &options);
+
+    const loom_link_module_index_symbol_t* configured_declaration =
+        loom_link_module_index_lookup_global(index, IREE_SV("configured"));
+    ASSERT_NE(configured_declaration, nullptr);
+    const loom_link_module_index_symbol_t* wrong_provider =
+        loom_link_module_index_next_same_name(index, configured_declaration);
+    ASSERT_NE(wrong_provider, nullptr);
+    const loom_link_module_index_symbol_t* configured_provider =
+        loom_link_module_index_next_same_name(index, wrong_provider);
+    ASSERT_NE(configured_provider, nullptr);
+    const loom_link_module_index_symbol_t* dispatched_declaration =
+        loom_link_module_index_lookup_global(index, IREE_SV("dispatched"));
+    ASSERT_NE(dispatched_declaration, nullptr);
+    const loom_link_module_index_symbol_t* dispatched_provider =
+        loom_link_module_index_next_same_name(index, dispatched_declaration);
+    ASSERT_NE(dispatched_provider, nullptr);
+    const loom_link_module_index_module_t* library_module =
+        loom_link_module_index_module_at(index, 2);
+    const loom_link_module_index_module_t* harness_module =
+        loom_link_module_index_module_at(index, 0);
+    ASSERT_NE(harness_module, nullptr);
+    ASSERT_NE(library_module, nullptr);
+    const loom_link_module_index_symbol_t* local =
+        loom_link_module_index_lookup_private(index, harness_module,
+                                              IREE_SV("local"));
+    const loom_link_module_index_symbol_t* local_configuration_dependency =
+        loom_link_module_index_lookup_global(
+            index, IREE_SV("local_configuration_dependency"));
+    const loom_link_module_index_symbol_t* local_implementation_dependency =
+        loom_link_module_index_lookup_private(
+            index, harness_module, IREE_SV("local_implementation_dependency"));
+    const loom_link_module_index_symbol_t* configuration_dependency =
+        loom_link_module_index_lookup_global(
+            index, IREE_SV("configuration_dependency"));
+    const loom_link_module_index_symbol_t* implementation_dependency =
+        loom_link_module_index_lookup_private(
+            index, library_module, IREE_SV("implementation_dependency"));
+    const loom_link_module_index_symbol_t* dispatched_configuration_dependency =
+        loom_link_module_index_lookup_global(
+            index, IREE_SV("dispatched_configuration_dependency"));
+    ASSERT_NE(configuration_dependency, nullptr);
+    ASSERT_NE(dispatched_configuration_dependency, nullptr);
+    ASSERT_NE(implementation_dependency, nullptr);
+    ASSERT_NE(local, nullptr);
+    ASSERT_NE(local_configuration_dependency, nullptr);
+    ASSERT_NE(local_implementation_dependency, nullptr);
+
+    EXPECT_TRUE(ContainsSymbol(plan.get(), local));
+    EXPECT_TRUE(loom_link_plan_contains_facet(
+        plan.get(), local->ordinal, LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT));
+    EXPECT_TRUE(loom_link_plan_contains_facet(
+        plan.get(), local->ordinal,
+        LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION));
+    EXPECT_FALSE(loom_link_plan_contains_facet(
+        plan.get(), local->ordinal,
+        LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION));
+    EXPECT_TRUE(ContainsSymbol(plan.get(), local_configuration_dependency));
+    EXPECT_FALSE(ContainsSymbol(plan.get(), local_implementation_dependency));
+
+    EXPECT_TRUE(ContainsSymbol(plan.get(), configured_declaration));
+    EXPECT_FALSE(ContainsSymbol(plan.get(), wrong_provider));
+    EXPECT_TRUE(ContainsSymbol(plan.get(), configured_provider));
+    EXPECT_TRUE(
+        loom_link_plan_contains_facet(plan.get(), configured_provider->ordinal,
+                                      LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT));
+    EXPECT_TRUE(loom_link_plan_contains_facet(
+        plan.get(), configured_provider->ordinal,
+        LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION));
+    EXPECT_FALSE(loom_link_plan_contains_facet(
+        plan.get(), configured_provider->ordinal,
+        LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION));
+    EXPECT_TRUE(ContainsSymbol(plan.get(), configuration_dependency));
+
+    EXPECT_TRUE(ContainsSymbol(plan.get(), dispatched_declaration));
+    EXPECT_TRUE(ContainsSymbol(plan.get(), dispatched_provider));
+    EXPECT_TRUE(
+        loom_link_plan_contains_facet(plan.get(), dispatched_provider->ordinal,
+                                      LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT));
+    EXPECT_FALSE(loom_link_plan_contains_facet(
+        plan.get(), dispatched_provider->ordinal,
+        LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION));
+    EXPECT_FALSE(loom_link_plan_contains_facet(
+        plan.get(), dispatched_provider->ordinal,
+        LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION));
+    EXPECT_FALSE(
+        ContainsSymbol(plan.get(), dispatched_configuration_dependency));
+    EXPECT_FALSE(ContainsSymbol(plan.get(), implementation_dependency));
   };
-  PlanPtr plan = BuildPlan(index.get(), &options);
 
-  const loom_link_module_index_symbol_t* declaration =
-      loom_link_module_index_lookup_global(index.get(), IREE_SV("target"));
-  ASSERT_NE(declaration, nullptr);
-  const loom_link_module_index_symbol_t* wrong_provider =
-      loom_link_module_index_next_same_name(index.get(), declaration);
-  ASSERT_NE(wrong_provider, nullptr);
-  const loom_link_module_index_symbol_t* provider =
-      loom_link_module_index_next_same_name(index.get(), wrong_provider);
-  ASSERT_NE(provider, nullptr);
-  const loom_link_module_index_module_t* library_module =
-      loom_link_module_index_module_at(index.get(), 2);
-  ASSERT_NE(library_module, nullptr);
-  const loom_link_module_index_symbol_t* configuration_dependency =
-      loom_link_module_index_lookup_private(
-          index.get(), library_module, IREE_SV("configuration_dependency"));
-  const loom_link_module_index_symbol_t* implementation_dependency =
-      loom_link_module_index_lookup_private(
-          index.get(), library_module, IREE_SV("implementation_dependency"));
-  ASSERT_NE(configuration_dependency, nullptr);
-  ASSERT_NE(implementation_dependency, nullptr);
+  IndexPtr materialized_index = CreateIndex();
+  AddMaterialized(materialized_index.get(), harness, IREE_SV("harness"),
+                  LOOM_LINK_PROVIDER_ROLE_INPUT);
+  AddMaterialized(materialized_index.get(), wrong_library,
+                  IREE_SV("wrong-library"), LOOM_LINK_PROVIDER_ROLE_LIBRARY);
+  AddMaterialized(materialized_index.get(), library, IREE_SV("library"),
+                  LOOM_LINK_PROVIDER_ROLE_LIBRARY);
+  verify_index(materialized_index.get());
 
-  EXPECT_TRUE(ContainsSymbol(plan.get(), declaration));
-  EXPECT_FALSE(ContainsSymbol(plan.get(), wrong_provider));
-  EXPECT_TRUE(ContainsSymbol(plan.get(), provider));
-  EXPECT_TRUE(loom_link_plan_contains_facet(
-      plan.get(), provider->ordinal, LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT));
-  EXPECT_TRUE(loom_link_plan_contains_facet(
-      plan.get(), provider->ordinal,
-      LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION));
-  EXPECT_TRUE(loom_link_plan_contains_facet(
-      plan.get(), provider->ordinal,
-      LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION));
-  EXPECT_TRUE(ContainsSymbol(plan.get(), configuration_dependency));
-  EXPECT_TRUE(ContainsSymbol(plan.get(), implementation_dependency));
+  IndexPtr text_index = CreateIndex();
+  AddText(text_index.get(), harness_source, IREE_SV("harness.loom"),
+          LOOM_LINK_PROVIDER_ROLE_INPUT);
+  AddText(text_index.get(), wrong_library_source, IREE_SV("wrong-library.loom"),
+          LOOM_LINK_PROVIDER_ROLE_LIBRARY);
+  AddText(text_index.get(), library_source, IREE_SV("library.loom"),
+          LOOM_LINK_PROVIDER_ROLE_LIBRARY);
+  verify_index(text_index.get());
+
+  IndexPtr bytecode_index = CreateIndex();
+  AddBytecode(bytecode_index.get(), harness_bytecode, IREE_SV("harness.loombc"),
+              LOOM_LINK_PROVIDER_ROLE_INPUT);
+  AddBytecode(bytecode_index.get(), wrong_library_bytecode,
+              IREE_SV("wrong-library.loombc"), LOOM_LINK_PROVIDER_ROLE_LIBRARY);
+  AddBytecode(bytecode_index.get(), library_bytecode, IREE_SV("library.loombc"),
+              LOOM_LINK_PROVIDER_ROLE_LIBRARY);
+  verify_index(bytecode_index.get());
 }
 
 TEST_F(LinkPlannerTest, SelectiveRootIgnoresModuleAvailabilityReferences) {

--- a/loom/src/loom/link/planner_test.cc
+++ b/loom/src/loom/link/planner_test.cc
@@ -23,6 +23,7 @@
 #include "loom/ops/command/ops.h"
 #include "loom/ops/config/ops.h"
 #include "loom/ops/func/ops.h"
+#include "loom/ops/kernel/ops.h"
 #include "loom/ops/module/ops.h"
 #include "loom/ops/target/ops.h"
 #include "loom/ops/template/ops.h"
@@ -62,6 +63,8 @@ class LinkPlannerTest : public ::testing::Test {
                     loom_config_dialect_op_semantics);
     RegisterDialect(LOOM_DIALECT_FUNC, loom_func_dialect_vtables,
                     loom_func_dialect_op_semantics);
+    RegisterDialect(LOOM_DIALECT_KERNEL, loom_kernel_dialect_vtables,
+                    loom_kernel_dialect_op_semantics);
     RegisterDialect(LOOM_DIALECT_MODULE, loom_module_dialect_vtables,
                     loom_module_dialect_op_semantics);
     RegisterDialect(LOOM_DIALECT_TARGET, loom_target_dialect_vtables,
@@ -523,6 +526,191 @@ command.program.def @root() launch() {
   AddBytecode(bytecode_index.get(), bytecode, IREE_SV("module.loombc"),
               LOOM_LINK_PROVIDER_ROLE_INPUT);
   verify_index(bytecode_index.get());
+}
+
+TEST_F(LinkPlannerTest, InterleavedKernelFacetUpgradesPreservePerSymbolChains) {
+  const iree_string_view_t source = IREE_SV(R"(
+func.def @configuration_dependency(%value: index) -> (index) {
+  func.return %value : index
+}
+
+func.def @implementation_dependency() {
+  func.return
+}
+
+kernel.def @target(%count: index) {
+  %configured = func.call @configuration_dependency(%count) : (index) -> (index)
+  kernel.launch.config workgroups(%configured, %configured, %configured) workgroup_size(%configured, %configured, %configured) : index
+} launch() {
+  func.call @implementation_dependency() : () -> ()
+  kernel.return
+}
+
+func.def @interleaved_dependency() {
+  func.return
+}
+)");
+  loom_module_t* module = Parse(source);
+  const std::vector<uint8_t> bytecode = WriteModule(module);
+
+  auto verify_index = [&](const loom_link_module_index_t* index) {
+    const loom_link_module_index_module_t* indexed_module =
+        loom_link_module_index_module_at(index, 0);
+    ASSERT_NE(indexed_module, nullptr);
+    const loom_link_module_index_symbol_t* target =
+        loom_link_module_index_lookup_private(index, indexed_module,
+                                              IREE_SV("target"));
+    const loom_link_module_index_symbol_t* configuration_dependency =
+        loom_link_module_index_lookup_private(
+            index, indexed_module, IREE_SV("configuration_dependency"));
+    const loom_link_module_index_symbol_t* implementation_dependency =
+        loom_link_module_index_lookup_private(
+            index, indexed_module, IREE_SV("implementation_dependency"));
+    const loom_link_module_index_symbol_t* interleaved_dependency =
+        loom_link_module_index_lookup_private(
+            index, indexed_module, IREE_SV("interleaved_dependency"));
+    ASSERT_NE(target, nullptr);
+    ASSERT_NE(configuration_dependency, nullptr);
+    ASSERT_NE(implementation_dependency, nullptr);
+    ASSERT_NE(interleaved_dependency, nullptr);
+
+    const loom_link_plan_root_facet_t roots[] = {
+        {
+            /*.symbol_ordinal=*/target->ordinal,
+            /*.kind=*/LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION,
+        },
+        {
+            /*.symbol_ordinal=*/interleaved_dependency->ordinal,
+            /*.kind=*/LOOM_LINK_SYMBOL_FACET_DEFINITION,
+        },
+        {
+            /*.symbol_ordinal=*/target->ordinal,
+            /*.kind=*/LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION,
+        },
+    };
+    loom_link_plan_options_t options = {};
+    options.mode = LOOM_LINK_PLAN_SELECTIVE;
+    options.root_facets.count = IREE_ARRAYSIZE(roots);
+    options.root_facets.values = roots;
+    PlanPtr plan = BuildPlan(index, &options);
+
+    EXPECT_TRUE(ContainsSymbol(plan.get(), target));
+    EXPECT_TRUE(loom_link_plan_contains_facet(
+        plan.get(), target->ordinal, LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT));
+    EXPECT_TRUE(loom_link_plan_contains_facet(
+        plan.get(), target->ordinal,
+        LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION));
+    EXPECT_TRUE(loom_link_plan_contains_facet(
+        plan.get(), target->ordinal,
+        LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION));
+    EXPECT_TRUE(ContainsSymbol(plan.get(), configuration_dependency));
+    EXPECT_TRUE(ContainsSymbol(plan.get(), interleaved_dependency));
+    EXPECT_TRUE(ContainsSymbol(plan.get(), implementation_dependency));
+  };
+
+  IndexPtr materialized_index = CreateIndex();
+  AddMaterialized(materialized_index.get(), module, IREE_SV("materialized"),
+                  LOOM_LINK_PROVIDER_ROLE_INPUT);
+  verify_index(materialized_index.get());
+
+  IndexPtr text_index = CreateIndex();
+  AddText(text_index.get(), source, IREE_SV("module.loom"),
+          LOOM_LINK_PROVIDER_ROLE_INPUT);
+  verify_index(text_index.get());
+
+  IndexPtr bytecode_index = CreateIndex();
+  AddBytecode(bytecode_index.get(), bytecode, IREE_SV("module.loombc"),
+              LOOM_LINK_PROVIDER_ROLE_INPUT);
+  verify_index(bytecode_index.get());
+}
+
+TEST_F(LinkPlannerTest,
+       KernelDeclarationSelectsStructurallyCompatibleProviderOnce) {
+  loom_module_t* harness = Parse(IREE_SV(R"(
+kernel.decl @target(%count: index) launch()
+
+func.def @interleaved_dependency() {
+  func.return
+}
+
+func.def public @entry(%count: index) {
+  kernel.launch @target[%count]() : [index]()
+  func.call @interleaved_dependency() : () -> ()
+  kernel.launch @target[%count]() : [index]()
+  func.return
+}
+)"));
+  loom_module_t* wrong_library = Parse(IREE_SV(R"(
+func.def @target(%count: index) {
+  func.return
+}
+)"));
+  loom_module_t* library = Parse(IREE_SV(R"(
+func.def @configuration_dependency(%value: index) -> (index) {
+  func.return %value : index
+}
+
+func.def @implementation_dependency() {
+  func.return
+}
+
+kernel.def @target(%count: index) {
+  %configured = func.call @configuration_dependency(%count) : (index) -> (index)
+  kernel.launch.config workgroups(%configured, %configured, %configured) workgroup_size(%configured, %configured, %configured) : index
+} launch() {
+  func.call @implementation_dependency() : () -> ()
+  kernel.return
+}
+)"));
+
+  IndexPtr index = CreateIndex();
+  AddMaterialized(index.get(), harness, IREE_SV("harness"),
+                  LOOM_LINK_PROVIDER_ROLE_INPUT);
+  AddMaterialized(index.get(), wrong_library, IREE_SV("wrong-library"),
+                  LOOM_LINK_PROVIDER_ROLE_LIBRARY);
+  AddMaterialized(index.get(), library, IREE_SV("library"),
+                  LOOM_LINK_PROVIDER_ROLE_LIBRARY);
+  iree_string_view_t roots[] = {IREE_SV("@entry")};
+  loom_link_plan_options_t options = {
+      /*.mode=*/LOOM_LINK_PLAN_SELECTIVE,
+      /*.root_symbols=*/{/*.count=*/IREE_ARRAYSIZE(roots), /*.values=*/roots},
+  };
+  PlanPtr plan = BuildPlan(index.get(), &options);
+
+  const loom_link_module_index_symbol_t* declaration =
+      loom_link_module_index_lookup_global(index.get(), IREE_SV("target"));
+  ASSERT_NE(declaration, nullptr);
+  const loom_link_module_index_symbol_t* wrong_provider =
+      loom_link_module_index_next_same_name(index.get(), declaration);
+  ASSERT_NE(wrong_provider, nullptr);
+  const loom_link_module_index_symbol_t* provider =
+      loom_link_module_index_next_same_name(index.get(), wrong_provider);
+  ASSERT_NE(provider, nullptr);
+  const loom_link_module_index_module_t* library_module =
+      loom_link_module_index_module_at(index.get(), 2);
+  ASSERT_NE(library_module, nullptr);
+  const loom_link_module_index_symbol_t* configuration_dependency =
+      loom_link_module_index_lookup_private(
+          index.get(), library_module, IREE_SV("configuration_dependency"));
+  const loom_link_module_index_symbol_t* implementation_dependency =
+      loom_link_module_index_lookup_private(
+          index.get(), library_module, IREE_SV("implementation_dependency"));
+  ASSERT_NE(configuration_dependency, nullptr);
+  ASSERT_NE(implementation_dependency, nullptr);
+
+  EXPECT_TRUE(ContainsSymbol(plan.get(), declaration));
+  EXPECT_FALSE(ContainsSymbol(plan.get(), wrong_provider));
+  EXPECT_TRUE(ContainsSymbol(plan.get(), provider));
+  EXPECT_TRUE(loom_link_plan_contains_facet(
+      plan.get(), provider->ordinal, LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT));
+  EXPECT_TRUE(loom_link_plan_contains_facet(
+      plan.get(), provider->ordinal,
+      LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION));
+  EXPECT_TRUE(loom_link_plan_contains_facet(
+      plan.get(), provider->ordinal,
+      LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION));
+  EXPECT_TRUE(ContainsSymbol(plan.get(), configuration_dependency));
+  EXPECT_TRUE(ContainsSymbol(plan.get(), implementation_dependency));
 }
 
 TEST_F(LinkPlannerTest, SelectiveRootIgnoresModuleAvailabilityReferences) {

--- a/loom/src/loom/link/symbol_policy.c
+++ b/loom/src/loom/link/symbol_policy.c
@@ -6,6 +6,7 @@
 
 #include "loom/link/symbol_policy.h"
 
+#include "loom/ir/context.h"
 #include "loom/ops/op_defs.h"
 
 bool loom_link_symbol_is_declaration(const loom_symbol_t* symbol) {
@@ -39,4 +40,36 @@ bool loom_link_symbol_has_global_identity(const loom_module_t* module,
   return loom_func_like_import_module(func) != LOOM_STRING_ID_INVALID ||
          loom_func_like_import_symbol(func) != LOOM_STRING_ID_INVALID ||
          loom_func_like_export_symbol(func) != LOOM_STRING_ID_INVALID;
+}
+
+void loom_link_symbol_internalize(loom_module_t* module, loom_op_t* op) {
+  const loom_op_vtable_t* vtable = loom_op_vtable(module, op);
+  const loom_symbol_definition_descriptor_t* definition = vtable->symbol_def;
+  const uint8_t visibility_attr_index =
+      loom_symbol_definition_visibility_attr_index(definition);
+  const uint8_t retain_attr_index =
+      definition->retain_attr_index_plus_one
+          ? definition->retain_attr_index_plus_one - 1
+          : LOOM_ATTR_INDEX_NONE;
+
+  if (visibility_attr_index != LOOM_ATTR_INDEX_NONE) {
+    loom_op_attrs(op)[visibility_attr_index] = loom_attr_absent();
+  }
+  if (retain_attr_index != LOOM_ATTR_INDEX_NONE) {
+    loom_op_attrs(op)[retain_attr_index] = loom_attr_absent();
+  }
+  const loom_func_like_t function = loom_func_like_cast(module, op);
+  if (loom_func_like_isa(function)) {
+    const uint8_t export_attr_indices[] = {
+        function.vtable->export_symbol_attr_index,
+        function.vtable->export_attrs_attr_index,
+        function.vtable->export_linkage_attr_index,
+    };
+    for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(export_attr_indices); ++i) {
+      if (export_attr_indices[i] != LOOM_ATTR_INDEX_NONE) {
+        loom_op_attrs(op)[export_attr_indices[i]] = loom_attr_absent();
+      }
+    }
+  }
+  loom_module_link_symbol_defining_op(module, op, vtable);
 }

--- a/loom/src/loom/link/symbol_policy.h
+++ b/loom/src/loom/link/symbol_policy.h
@@ -36,6 +36,13 @@ bool loom_link_symbol_is_concrete_definition(const loom_symbol_t* symbol);
 bool loom_link_symbol_has_global_identity(const loom_module_t* module,
                                           const loom_symbol_t* symbol);
 
+// Internalizes |op|'s symbol definition within |module|.
+//
+// Public visibility, retention, and function export metadata are removed
+// together so the operation and symbol table continue to describe the same
+// private dependency. |op| must define a module-local symbol.
+void loom_link_symbol_internalize(loom_module_t* module, loom_op_t* op);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Loom's selective linker now preserves the structural capability requested by every symbol reference. A logical workload launch can request a kernel contract and launch configuration without making the implementation body live, while an already configured dispatch can request only a dispatchable entry contract. Materialized IR, authoring text, and deployment bytecode all project the same interface-aware dependency graph without adding another source traversal.

## Interface-aware references

The distinction comes from the authored operation schema rather than kernel-specific inspection in the linker:

```loom
// The callee attribute requires the logical `kernel` interface.
kernel.launch @gemm[%m, %n, %k](%lhs, %rhs, %output) : [index, index, index](buffer, buffer, buffer)

// The callee attribute requires only the configured `kernel_entry` interface.
kernel.dispatch @gemm_entry[%grid_x, %grid_y](%lhs, %rhs, %output) : [index, index](buffer, buffer, buffer)
```

Generated symbol-reference analysis records the required interface mask with each occurrence during its existing canonical walk. The module index retains that mask beside the dependency ordinal, and text indexing reuses the parser-owned reference snapshot introduced by the bounded-linking work. The occurrence record remains 32 bytes by representing its generated attribute ordinal in the actual eight-bit domain, so the richer contract does not enlarge the per-reference hot-path representation.

## Exact facet planning

Link plans now choose their dependency policy explicitly. Ordinary composition retains complete referenced symbols exactly as before. Product-oriented plans use `LOOM_LINK_PLAN_DEPENDENCY_REQUESTED_FACETS` to preserve only the contract, root region, or structural interface requested by each reference.

Provider resolution is cached per declaration and requires one concrete definition to satisfy the declaration's complete requested interface set. Repeated demands reuse that provider, while stripped or partially compatible candidates cannot hide a later valid definition. Selected facets are maintained in per-symbol chains, removing both the global membership scan and the assumption that facets for one symbol occupy a contiguous plan-ordinal range as later projections upgrade the selection.

An exact source projection may also bind an omitted source symbol to a target symbol produced by an earlier linker add. This is the rendezvous needed when one facet has been reconstructed as ordinary IR but selected dependent IR still refers to the source identity:

```text
source symbol @gemm
  contract facet ---------> projected target @gemm
  configuration facet ----> projected target @gemm$config
  implementation facet ---> unopened

selected helper reference to source @gemm
  ------------------------> explicit binding to projected target @gemm
```

Bindings are sorted, exact, and non-discovering. They neither inspect nor clone the omitted definition. Shared symbol policy internalizes projected dependencies consistently by clearing visibility, retention, and function export metadata as one representation change.

## Composed bytecode projections

Selected bytecode regions can append into a module that already contains materialized dependencies. Source identities inherited from the destination are reused, newly reached sources remain append-only, and comparisons are bounded to the inherited prefix instead of growing quadratically with entries appended by the same projection.

The SYMBOL_REFERENCES bytecode section now stores a `target_interfaces` varint beside each dependency symbol index. This advances Loom bytecode from format version 31 to 32. C and Python readers validate the same interface mask, and C and Python writers emit the same dependency layout.

## Migration

Existing version-31 `.loombc` artifacts must be regenerated; authoring text and caller-owned materialized modules require no source migration. Ordinary link-plan construction remains complete-symbol by default, so only consumers deliberately building decomposed products opt into requested-facet dependency projection.

Internal callers of `loom_linker_add_module_symbols` must pass the new exact source-binding list. Callers with no preprojected symbols use `loom_linker_source_symbol_binding_list_empty()`. Consumers that do provide bindings must map omitted source ordinals to symbols returned by an earlier add to the same linker; the linker does not infer compatibility or widen the selected closure.
