### PR TITLE
[CI] Restore AMDGPU and TileLang presubmits

### DIFF
--- a/.github/workflows/ci_importers.yml
+++ b/.github/workflows/ci_importers.yml
@@ -20,8 +20,7 @@ on:
       - "requirements-importers-*.in"
       - "requirements-importers-*.lock.txt"
       - "build_tools/devtools/**"
-      - "loom/config/**"
-      - "loom/py/loom/importers/**"
+      - "loom/**"
   push:
     branches:
       - main
@@ -37,8 +36,7 @@ on:
       - "requirements-importers-*.in"
       - "requirements-importers-*.lock.txt"
       - "build_tools/devtools/**"
-      - "loom/config/**"
-      - "loom/py/loom/importers/**"
+      - "loom/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/ci_iree_bazel.yml
+++ b/.github/workflows/ci_iree_bazel.yml
@@ -400,7 +400,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Adjust git config
-        run: git config --global --add safe.directory "$PWD"
+        run: |
+          mkdir -p "$HOME"
+          git config --global --add safe.directory "$PWD"
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/ci_iree_cmake.yml
+++ b/.github/workflows/ci_iree_cmake.yml
@@ -284,7 +284,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Adjust git config
-        run: git config --global --add safe.directory "$PWD"
+        run: |
+          mkdir -p "$HOME"
+          git config --global --add safe.directory "$PWD"
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/build_tools/devtools/BUILD.bazel
+++ b/build_tools/devtools/BUILD.bazel
@@ -251,6 +251,16 @@ py_test(
 )
 
 py_test(
+    name = "smoke_test_lib_test",
+    srcs = [
+        "environment.py",
+        "smoke_test_lib.py",
+        "smoke_test_lib_test.py",
+    ],
+    main = "smoke_test_lib_test.py",
+)
+
+py_test(
     name = "setup_test",
     srcs = [
         "__init__.py",

--- a/build_tools/devtools/ci_config.py
+++ b/build_tools/devtools/ci_config.py
@@ -50,6 +50,7 @@ BAZEL_REPOSITORY_INTEGRATION_TEST_TARGETS = (
     "//build_tools/devtools:bazel_test",
     "//build_tools/devtools:ci_test",
     "//build_tools/devtools:cli_test",
+    "//build_tools/devtools:smoke_test_lib_test",
 )
 BAZEL_REPOSITORY_INTEGRATION_DYNAMIC_LIBRARY_TARGET = (
     "//build_tools/bazel/test:dynamic_library_environment_binary_fixture"

--- a/build_tools/devtools/ci_test.py
+++ b/build_tools/devtools/ci_test.py
@@ -994,9 +994,7 @@ class CiTest(unittest.TestCase):
             with self.subTest(path=path):
                 block = self.workflow_job_block(path, job_name)
                 mkdir_command = 'mkdir -p "$HOME"'
-                git_config_command = (
-                    'git config --global --add safe.directory "$PWD"'
-                )
+                git_config_command = 'git config --global --add safe.directory "$PWD"'
                 self.assertIn(mkdir_command, block)
                 self.assertIn(git_config_command, block)
                 self.assertLess(
@@ -1343,15 +1341,16 @@ fi
                 self.assertIn('- "loom/**"', text)
                 self.assertNotIn('- "libhrx/**"', text)
 
-    def test_importer_workflow_is_path_scoped_and_uses_locked_cache_key(self):
+    def test_importer_workflow_covers_loom_changes_and_uses_locked_cache_key(self):
         text = Path(".github/workflows/ci_importers.yml").read_text()
 
         self.assertIn("name: CI Importers", text)
         self.assertIn('- "requirements-importers-*.lock.txt"', text)
         self.assertIn('- "requirements-importers-*.in"', text)
         self.assertIn('- "build_tools/devtools/**"', text)
-        self.assertIn('- "loom/config/**"', text)
-        self.assertIn('- "loom/py/loom/importers/**"', text)
+        self.assertIn('- "loom/**"', text)
+        self.assertNotIn('- "loom/config/**"', text)
+        self.assertNotIn('- "loom/py/loom/importers/**"', text)
         self.assertNotIn('- "runtime/**"', text)
         self.assertNotIn('- "libhrx/**"', text)
 

--- a/build_tools/devtools/ci_test.py
+++ b/build_tools/devtools/ci_test.py
@@ -986,6 +986,23 @@ class CiTest(unittest.TestCase):
         self.assertNotIn("iree-bazel-amdgpu-msan", block)
         self.assertNotIn("iree-bazel-amdgpu-sanitizers", block)
 
+    def test_amdgpu_container_jobs_initialize_git_home(self):
+        for path, job_name in (
+            (".github/workflows/ci_iree_bazel.yml", "linux_bazel_amdgpu"),
+            (".github/workflows/ci_iree_cmake.yml", "linux_cmake_amdgpu"),
+        ):
+            with self.subTest(path=path):
+                block = self.workflow_job_block(path, job_name)
+                mkdir_command = 'mkdir -p "$HOME"'
+                git_config_command = (
+                    'git config --global --add safe.directory "$PWD"'
+                )
+                self.assertIn(mkdir_command, block)
+                self.assertIn(git_config_command, block)
+                self.assertLess(
+                    block.index(mkdir_command), block.index(git_config_command)
+                )
+
     def test_bazel_workflow_uploads_profiles_for_each_attempted_job(self):
         cases = (
             (

--- a/build_tools/devtools/smoke_test_lib.py
+++ b/build_tools/devtools/smoke_test_lib.py
@@ -120,7 +120,22 @@ def run_command(
     env: dict[str, str] | None = None,
 ) -> None:
     print("smoke:", " ".join(command), flush=True)
-    subprocess.run(command, cwd=checkout, env=env, check=True)
+    result = subprocess.run(
+        command,
+        cwd=checkout,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode != 0:
+        if result.stdout:
+            print(
+                result.stdout,
+                file=sys.stderr,
+                end="" if result.stdout.endswith("\n") else "\n",
+            )
+        result.check_returncode()
 
 
 def run_bin_wrapper(checkout: Path, wrapper_name: str, args: list[str]) -> None:

--- a/build_tools/devtools/smoke_test_lib_test.py
+++ b/build_tools/devtools/smoke_test_lib_test.py
@@ -1,0 +1,65 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from __future__ import annotations
+
+import contextlib
+import io
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from build_tools.devtools import smoke_test_lib
+
+
+class RunCommandTest(unittest.TestCase):
+    def test_successful_command_output_is_suppressed(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            smoke_test_lib.run_command(
+                Path.cwd(),
+                [
+                    sys.executable,
+                    "-c",
+                    "print('successful ' + 'child output')",
+                ],
+            )
+
+        self.assertIn("smoke:", stdout.getvalue())
+        self.assertNotIn("successful child output", stdout.getvalue())
+        self.assertEqual(stderr.getvalue(), "")
+
+    def test_failed_command_output_is_reported(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        child = (
+            "import sys; "
+            "print('failed child stdout'); "
+            "print('failed child stderr', file=sys.stderr); "
+            "raise SystemExit(7)"
+        )
+
+        with (
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+            self.assertRaises(subprocess.CalledProcessError) as raised,
+        ):
+            smoke_test_lib.run_command(
+                Path.cwd(),
+                [sys.executable, "-c", child],
+            )
+
+        self.assertEqual(raised.exception.returncode, 7)
+        self.assertIn("smoke:", stdout.getvalue())
+        self.assertIn("failed child stdout", stderr.getvalue())
+        self.assertIn("failed child stderr", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/loom/py/loom/importers/tilelang/buffers.py
+++ b/loom/py/loom/importers/tilelang/buffers.py
@@ -364,7 +364,6 @@ def _flatten_logical_indices(
         product = context.builder.index.mul(
             lhs=running,
             rhs=extent,
-            results=[INDEX],
             name=context.fresh_name("mul"),
         )
         running = context.builder.index.add(
@@ -390,13 +389,11 @@ def _unflatten_physical_index(
         remapped[position] = context.builder.index.rem(
             lhs=running,
             rhs=extent,
-            results=[INDEX],
             name=context.fresh_name("rem"),
         )
         running = context.builder.index.div(
             lhs=running,
             rhs=extent,
-            results=[INDEX],
             name=context.fresh_name("div"),
         )
     remapped[0] = running

--- a/loom/py/loom/importers/tilelang/ops/calls.py
+++ b/loom/py/loom/importers/tilelang/ops/calls.py
@@ -394,7 +394,6 @@ def _convert_float_predicate_call(
         ValueRef,
         getattr(context.builder.scalar, builder_name)(
             input=input_value,
-            results=[I1],
             name=context.fresh_name(builder_name),
         ),
     )
@@ -462,17 +461,24 @@ def _convert_unary_integer_call(
             node_text(expr), f"call `{op_name}` operand is not mapped"
         )
         return None
-    index_like = str(input_value.type) == "index"
-    dialect = context.builder.index if index_like else context.builder.scalar
-    result_type = INDEX if index_like else context.type_converter.map_dtype(dtype(expr))
-    result = cast(
-        ValueRef,
-        getattr(dialect, builder_name)(
-            input=input_value,
-            results=[result_type],
-            name=context.fresh_name(builder_name),
-        ),
-    )
+    if str(input_value.type) == "index":
+        result = cast(
+            ValueRef,
+            getattr(context.builder.index, builder_name)(
+                input=input_value,
+                name=context.fresh_name(builder_name),
+            ),
+        )
+    else:
+        result_type = context.type_converter.map_dtype(dtype(expr))
+        result = cast(
+            ValueRef,
+            getattr(context.builder.scalar, builder_name)(
+                input=input_value,
+                results=[result_type],
+                name=context.fresh_name(builder_name),
+            ),
+        )
     _map_call_result(expr, context, result, op_name)
     return result
 
@@ -505,7 +511,6 @@ def _convert_bitwise_not_call(
         result = context.builder.index.xori(
             lhs=input_value,
             rhs=all_ones,
-            results=[input_value.type],
             name=context.fresh_name("noti"),
         )
         _map_call_result(expr, context, result, op_name, value_type=input_type)
@@ -561,7 +566,6 @@ def _convert_binary_integer_call(
             getattr(context.builder.index, index_builder_name)(
                 lhs=lhs,
                 rhs=rhs,
-                results=[INDEX],
                 name=context.fresh_name(index_builder_name),
             ),
         )
@@ -652,7 +656,6 @@ def _convert_ceildiv_call(
     result = context.builder.index.div(
         lhs=adjusted,
         rhs=rhs,
-        results=[INDEX],
         name=context.fresh_name("ceildiv"),
     )
     _map_call_result(expr, context, result, op_name, value_type="index")
@@ -1546,7 +1549,6 @@ def _tvm_mfma_accumulator_chunk_origin(
         chunk_offset = context.builder.index.mul(
             lhs=access.indices[0],
             rhs=context.ensure_constant(str(chunk_lanes), "index", f"c{chunk_lanes}"),
-            results=[INDEX],
             name=context.fresh_name("acc_offset"),
         )
         return (chunk_offset,)
@@ -1584,19 +1586,16 @@ def _tvm_mfma_accumulator_chunk_origin(
     row = context.builder.index.div(
         lhs=access.indices[0],
         rhs=chunks_per_row_value,
-        results=[INDEX],
         name=context.fresh_name("acc_row"),
     )
     chunk = context.builder.index.rem(
         lhs=access.indices[0],
         rhs=chunks_per_row_value,
-        results=[INDEX],
         name=context.fresh_name("acc_chunk"),
     )
     column = context.builder.index.mul(
         lhs=chunk,
         rhs=context.ensure_constant(str(chunk_lanes), "index", f"c{chunk_lanes}"),
-        results=[INDEX],
         name=context.fresh_name("acc_column"),
     )
     return (row, column)

--- a/loom/py/loom/importers/tilelang/ops/conditions.py
+++ b/loom/py/loom/importers/tilelang/ops/conditions.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from loom.builder import ValueRef
 from loom.importers.tilelang.context import TileLangConversionContext
 from loom.importers.tilelang.nodes import node_text
-from loom.ir import I1
 
 
 def coerce_condition(
@@ -30,7 +29,6 @@ def coerce_condition(
             predicate="ne",
             lhs=condition,
             rhs=zero,
-            results=[I1],
             name=context.fresh_name("cmp"),
         )
     if _is_integer_type(source_type):
@@ -39,7 +37,6 @@ def coerce_condition(
             predicate="ne",
             lhs=condition,
             rhs=zero,
-            results=[I1],
             name=context.fresh_name("cmp"),
         )
     context.record_blocked(

--- a/loom/py/loom/importers/tilelang/ops/distribution.py
+++ b/loom/py/loom/importers/tilelang/ops/distribution.py
@@ -19,7 +19,7 @@ from loom.importers.tilelang.context import (
 from loom.importers.tilelang.converter import TileLangConverter
 from loom.importers.tilelang.nodes import node_text
 from loom.importers.tilelang.ops.topology import THREAD_AXES, map_thread_axis
-from loom.ir import I1, INDEX
+from loom.ir import INDEX
 
 DistributedBodyEmitter = Callable[
     [tuple[ValueRef, ...], TileLangConversionContext], None
@@ -105,7 +105,6 @@ def materialize_distributed_1d_plan(
     lane_base = context.builder.index.mul(
         lhs=thread_index,
         rhs=lane_count,
-        results=[INDEX],
         name=context.fresh_name(f"{index_name}_base"),
     )
     return Distributed1DPlan(
@@ -147,7 +146,6 @@ def emit_distributed_1d(
                 predicate="slt",
                 lhs=plan.thread_index,
                 rhs=extent_value,
-                results=[I1],
                 name=context.fresh_name(f"{index_name}_active"),
             )
         context.map_distributed_index(
@@ -200,7 +198,6 @@ def emit_distributed_1d(
                 predicate="slt",
                 lhs=index,
                 rhs=extent_value,
-                results=[I1],
                 name=child.fresh_name(f"{index_name}_active"),
             )
         _emit_body(owner, child, (index,), emit_body, guard=guard)
@@ -251,7 +248,6 @@ def _emit_unrolled_lanes(
                 predicate="slt",
                 lhs=index,
                 rhs=extent_value,
-                results=[I1],
                 name=context.fresh_name(f"{index_name}_active"),
             )
         _emit_body(owner, context, (index,), emit_body, guard=guard)

--- a/loom/py/loom/importers/tilelang/ops/scalar.py
+++ b/loom/py/loom/importers/tilelang/ops/scalar.py
@@ -300,13 +300,14 @@ def convert_binary_expr(
     if index_like:
         builder_name = _BINARY_INDEX_OPS[kind]
         builder = getattr(context.builder.index, builder_name)
+        result_kwargs = {"results": [INDEX]} if builder_name in ("add", "sub") else {}
         result = cast(
             ValueRef,
             builder(
                 lhs=lhs,
                 rhs=rhs,
-                results=[INDEX],
                 name=context.fresh_name(builder_name),
+                **result_kwargs,
             ),
         )
         context.map_value(expr, result, "index")
@@ -388,14 +389,12 @@ def _convert_signed_floor_mod_expr(
         predicate="sge",
         lhs=rhs,
         rhs=zero,
-        results=[I1],
         name=context.fresh_name("divisor_nonnegative"),
     )
     remainder_nonnegative = context.builder.scalar.cmpi(
         predicate="sge",
         lhs=remainder,
         rhs=zero,
-        results=[I1],
         name=context.fresh_name("remainder_nonnegative"),
     )
     positive_case = context.builder.scalar.andi(
@@ -408,14 +407,12 @@ def _convert_signed_floor_mod_expr(
         predicate="slt",
         lhs=rhs,
         rhs=zero,
-        results=[I1],
         name=context.fresh_name("divisor_negative"),
     )
     remainder_nonpositive = context.builder.scalar.cmpi(
         predicate="sle",
         lhs=remainder,
         rhs=zero,
-        results=[I1],
         name=context.fresh_name("remainder_nonpositive"),
     )
     negative_case = context.builder.scalar.andi(
@@ -502,7 +499,6 @@ def _build_index_madd_expr(
         a=a,
         b=b,
         c=c,
-        results=[INDEX],
         name=context.fresh_name("madd"),
     )
     context.map_value(expr, result, "index")
@@ -566,7 +562,6 @@ def convert_compare(
         predicate=predicate,
         lhs=lhs,
         rhs=rhs,
-        results=[I1],
         name=context.fresh_name("cmp"),
     )
     context.map_value(expr, result, "i1")

--- a/loom/py/loom/importers/tilelang/ops/tileops.py
+++ b/loom/py/loom/importers/tilelang/ops/tileops.py
@@ -2019,7 +2019,6 @@ def _index_mul_const(
     return context.builder.index.mul(
         lhs=lhs,
         rhs=_index_const(context, rhs),
-        results=[INDEX],
         name=context.fresh_name(name),
     )
 
@@ -2033,7 +2032,6 @@ def _index_div_const(
     return context.builder.index.div(
         lhs=lhs,
         rhs=_index_const(context, rhs),
-        results=[INDEX],
         name=context.fresh_name(name),
     )
 
@@ -2047,7 +2045,6 @@ def _index_rem_const(
     return context.builder.index.rem(
         lhs=lhs,
         rhs=_index_const(context, rhs),
-        results=[INDEX],
         name=context.fresh_name(name),
     )
 
@@ -2851,13 +2848,11 @@ def _unflatten_loop_indices(
         indices[position] = context.builder.index.rem(
             lhs=running,
             rhs=extent,
-            results=[INDEX],
             name=context.fresh_name("i_rem"),
         )
         running = context.builder.index.div(
             lhs=running,
             rhs=extent,
-            results=[INDEX],
             name=context.fresh_name("i_div"),
         )
     indices[0] = running
@@ -2881,7 +2876,6 @@ def _unflatten_vector_chunk_indices(
     indices[-1] = context.builder.index.mul(
         lhs=indices[-1],
         rhs=lane_count_value,
-        results=[INDEX],
         name=context.fresh_name("i_offset"),
     )
     return tuple(indices)


### PR DESCRIPTION
Initialize container HOME before global Git configuration so dynamic AMDGPU runner pools, including gfx1151, reach toolchain setup and tests.

Repair TileLang call sites after schema-fixed result inference became authoritative, then broaden the importer workflow trigger to every Loom change. Shared builder and IR changes can no longer merge without TileLang integration being scheduled.

Capture successful wrapper smoke output while retaining command lines and complete failure diagnostics, keeping presubmit logs useful without repeated help text.