### PR TITLE
[Infra] Make AMDGPU test execution host-portable

### DIFF
--- a/build_tools/amdgpu/cts.cmake
+++ b/build_tools/amdgpu/cts.cmake
@@ -108,6 +108,7 @@ function(iree_amdgpu_hal_cts_testdata)
   endif()
 
   set(_TARGET_LIBS)
+  set(_TARGET_ORDINAL 0)
   foreach(_CODE_OBJECT_TARGET ${_CODE_OBJECT_TARGETS})
     iree_amdgpu_target_label_fragment(
       _TARGET_FRAGMENT
@@ -169,7 +170,11 @@ function(iree_amdgpu_hal_cts_testdata)
     set(_REGISTRATION_TARGET_NAME
       "${_RULE_TARGET_NAME}_${_TARGET_FRAGMENT}"
     )
-    set(_REGISTRATION "${_RULE_NAME}_${_TARGET_FRAGMENT}_registration.cc")
+    # The object directory already contains the full target fragment. Use the
+    # expansion ordinal to keep the private source basename unique without
+    # repeating that fragment in Windows object paths.
+    set(_REGISTRATION "${_RULE_NAME}_reg${_TARGET_ORDINAL}.cc")
+    math(EXPR _TARGET_ORDINAL "${_TARGET_ORDINAL} + 1")
     set(_REGISTRATION_TEMPLATE
       "${IREE_SOURCE_DIR}/runtime/src/iree/hal/cts/util/testdata_target.cc.tpl"
     )

--- a/build_tools/amdgpu/cts.cmake
+++ b/build_tools/amdgpu/cts.cmake
@@ -150,14 +150,18 @@ function(iree_amdgpu_hal_cts_testdata)
     endforeach()
 
     set(_DATA_NAME "${_RULE_NAME}_${_TARGET_FRAGMENT}_data")
-    set(_DATA_HEADER "${_DATA_NAME}.h")
+    # The object directory already contains the full data target name. Use the
+    # expansion ordinal to keep the generated source basename unique without
+    # repeating the target fragment in Windows object paths.
+    set(_DATA_FILE_NAME "${_RULE_NAME}_data${_TARGET_ORDINAL}")
+    set(_DATA_HEADER "${_DATA_FILE_NAME}.h")
     iree_c_embed_data(
       NAME
         "${_DATA_NAME}"
       SRCS
         ${_TARGET_SRCS}
       C_FILE_OUTPUT
-        "${_DATA_NAME}.c"
+        "${_DATA_FILE_NAME}.c"
       H_FILE_OUTPUT
         "${_DATA_HEADER}"
       IDENTIFIER
@@ -170,9 +174,6 @@ function(iree_amdgpu_hal_cts_testdata)
     set(_REGISTRATION_TARGET_NAME
       "${_RULE_TARGET_NAME}_${_TARGET_FRAGMENT}"
     )
-    # The object directory already contains the full target fragment. Use the
-    # expansion ordinal to keep the private source basename unique without
-    # repeating that fragment in Windows object paths.
     set(_REGISTRATION "${_RULE_NAME}_reg${_TARGET_ORDINAL}.cc")
     math(EXPR _TARGET_ORDINAL "${_TARGET_ORDINAL} + 1")
     set(_REGISTRATION_TEMPLATE

--- a/build_tools/devtools/ci.py
+++ b/build_tools/devtools/ci.py
@@ -186,7 +186,12 @@ def amdgpu_libhsa_test_env() -> tuple[tuple[str, str], ...]:
         rocm_root = os.environ.get("HRX_ROCM_ROOT")
         if not rocm_root:
             return ()
-        libhsa_path = str(Path(rocm_root) / "lib" / "libhsa-runtime64.so.1")
+        relative_path = (
+            Path("bin/hsa-runtime64.dll")
+            if sys.platform == "win32"
+            else Path("lib/libhsa-runtime64.so.1")
+        )
+        libhsa_path = str(Path(rocm_root) / relative_path)
     return (("IREE_HAL_AMDGPU_LIBHSA_PATH", libhsa_path),)
 
 
@@ -693,7 +698,7 @@ def cmake_amdgpu_steps(
             f"Test IREE CMake AMDGPU package tests{sanitizer_name}",
             regex="^iree/hal/drivers/amdgpu/",
             exclude_regex=xfail_regex,
-            env=sanitizer_env(sanitizer),
+            env=sanitizer_env(sanitizer) + amdgpu_libhsa_test_env(),
             parallelism=1,
         )
     )
@@ -713,7 +718,7 @@ def cmake_amdgpu_steps(
             label_regex=ci_config.AMDGPU_CTEST_RESOURCE_LABEL_REGEX,
             label_exclude_regex=resource_label_exclude_regex,
             exclude_regex=resource_exclude_regex,
-            env=sanitizer_env(sanitizer),
+            env=sanitizer_env(sanitizer) + amdgpu_libhsa_test_env(),
             parallelism=1,
         )
     )

--- a/build_tools/devtools/ci_test.py
+++ b/build_tools/devtools/ci_test.py
@@ -416,9 +416,14 @@ class CiTest(unittest.TestCase):
             steps = ci.steps_from_args(args)
 
         amdgpu_test = next(step for step in steps if step.name == "Test IREE / AMDGPU")
+        relative_path = (
+            Path("bin/hsa-runtime64.dll")
+            if ci.sys.platform == "win32"
+            else Path("lib/libhsa-runtime64.so.1")
+        )
         self.assertIn(
             "--test_env=IREE_HAL_AMDGPU_LIBHSA_PATH="
-            + str(Path("/tmp/rocm-root") / "lib" / "libhsa-runtime64.so.1"),
+            + str(Path("/tmp/rocm-root") / relative_path),
             amdgpu_test.argv,
         )
 
@@ -1696,6 +1701,24 @@ fi
             "-DIREE_HAL_AMDGPU_DEVICE_TOOLCHAIN_ROCM_PATH=/tmp/rocm-root",
             configure_step.argv,
         )
+
+    def test_cmake_amdgpu_tests_pin_libhsa_from_rocm_root(self):
+        args = ci.parse_arguments(["iree-cmake-amdgpu"])
+
+        with mock.patch.dict(
+            ci.os.environ,
+            {"HRX_ROCM_ROOT": "/tmp/rocm-root"},
+            clear=True,
+        ):
+            steps = ci.steps_from_args(args)
+            expected_env = ci.amdgpu_libhsa_test_env()
+
+        test_steps = [
+            step for step in steps if step.name.startswith("Test IREE CMake AMDGPU")
+        ]
+        self.assertEqual(len(test_steps), 2)
+        for step in test_steps:
+            self.assertEqual(step.env, expected_env)
 
     def test_cmake_amdgpu_tsan_excludes_only_host_incompatible_tests(self):
         args = ci.parse_arguments(["iree-cmake-amdgpu-tsan"])

--- a/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
@@ -805,7 +805,7 @@ iree_cmake_extra_content(
 )
 
 iree_amdgpu_hal_cts_testdata(
-    name = "testdata_amdgpu_pm4_command_buffer_benchmark",
+    name = "pm4_command_buffer_testdata",
     srcs = ["pm4_command_buffer_benchmark_testdata.c"],
     identifier = "iree_pm4_command_buffer_benchmark_testdata_amdgpu",
     internal_hdrs = [
@@ -826,7 +826,7 @@ iree_runtime_cc_benchmark(
     deps = [
         ":amdgpu",
         ":headers",
-        ":testdata_amdgpu_pm4_command_buffer_benchmark",
+        ":pm4_command_buffer_testdata",
         "//runtime/src/iree/async",
         "//runtime/src/iree/async/util:proactor_pool",
         "//runtime/src/iree/base",

--- a/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
@@ -1019,7 +1019,7 @@ endif()
 if(IREE_HAL_DRIVER_AMDGPU)
 iree_amdgpu_hal_cts_testdata(
   NAME
-    testdata_amdgpu_pm4_command_buffer_benchmark
+    pm4_command_buffer_testdata
   TARGET
     amdgcn-amd-amdhsa
   TARGETS
@@ -1050,7 +1050,7 @@ iree_cc_binary_benchmark(
   DEPS
     ::amdgpu
     ::headers
-    ::testdata_amdgpu_pm4_command_buffer_benchmark
+    ::pm4_command_buffer_testdata
     iree::async
     iree::async::util::proactor_pool
     iree::base


### PR DESCRIPTION
AMDGPU test infrastructure currently embeds long logical target names repeatedly into private build artifacts and lets CMake execution tests discover the HSA runtime through the ambient process environment. The former can exceed host toolchain path limits, while the latter can silently test a different ROCr installation than the fetched toolchain.

This change shortens only internal artifact names. The PM4 benchmark uses a compact private testdata target, while generated CMake registration and embed-data source basenames use their target-expansion ordinal instead of repeating the complete target fragment. Logical test names, CMake data-library targets, device target keys, embedded contents, registration identifiers, aggregate testdata targets, and benchmark behavior remain unchanged.

CMake AMDGPU execution tests now receive the same explicit HSA runtime selection as Bazel tests. When `IREE_HAL_AMDGPU_LIBHSA_PATH` is not already set, the test environment derives the platform-specific shared-library path from `HRX_ROCM_ROOT`: `bin/hsa-runtime64.dll` on Windows and `lib/libhsa-runtime64.so.1` elsewhere. An explicit runtime override continues to take precedence.

Together these changes make AMDGPU build and execution tests portable across host toolchains while ensuring that tests execute against the ROCr runtime associated with the selected ROCm toolchain. They do not change AMDGPU HAL runtime behavior or externally visible test identities.
