### PR TITLE
[HAL/AMDGPU] Scope VMM protection to selected GPU agents

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/access_policy.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/access_policy.c
@@ -27,15 +27,12 @@ static iree_status_t iree_hal_amdgpu_access_agent_list_append_unique(
   return iree_ok_status();
 }
 
-iree_status_t iree_hal_amdgpu_access_agent_list_resolve(
+static iree_status_t iree_hal_amdgpu_access_agent_list_select_devices(
     const iree_hal_amdgpu_topology_t* topology,
     iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain,
     iree_hal_queue_affinity_t queue_affinity,
-    iree_hal_amdgpu_access_agent_list_t* out_agent_list) {
-  IREE_ASSERT_ARGUMENT(topology);
-  IREE_ASSERT_ARGUMENT(out_agent_list);
-  memset(out_agent_list, 0, sizeof(*out_agent_list));
-
+    iree_hal_amdgpu_queue_affinity_physical_device_set_t*
+        out_physical_device_set) {
   if (IREE_UNLIKELY(queue_affinity_domain.physical_device_count >
                     topology->gpu_agent_count)) {
     return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
@@ -45,9 +42,50 @@ iree_status_t iree_hal_amdgpu_access_agent_list_resolve(
                             topology->gpu_agent_count);
   }
 
+  return iree_hal_amdgpu_queue_affinity_select_physical_devices(
+      queue_affinity_domain, queue_affinity, out_physical_device_set);
+}
+
+iree_status_t iree_hal_amdgpu_access_agent_list_resolve_queue_agents(
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain,
+    iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_amdgpu_access_agent_list_t* out_agent_list) {
+  IREE_ASSERT_ARGUMENT(topology);
+  IREE_ASSERT_ARGUMENT(out_agent_list);
+  memset(out_agent_list, 0, sizeof(*out_agent_list));
+
   iree_hal_amdgpu_queue_affinity_physical_device_set_t physical_device_set;
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_queue_affinity_select_physical_devices(
-      queue_affinity_domain, queue_affinity, &physical_device_set));
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_access_agent_list_select_devices(
+      topology, queue_affinity_domain, queue_affinity, &physical_device_set));
+
+  iree_status_t status = iree_ok_status();
+  for (iree_host_size_t physical_device_ordinal = 0;
+       physical_device_ordinal < topology->gpu_agent_count &&
+       iree_status_is_ok(status);
+       ++physical_device_ordinal) {
+    if (!iree_all_bits_set(physical_device_set.physical_device_mask,
+                           ((uint64_t)1) << physical_device_ordinal)) {
+      continue;
+    }
+    status = iree_hal_amdgpu_access_agent_list_append_unique(
+        out_agent_list, topology->gpu_agents[physical_device_ordinal]);
+  }
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_access_agent_list_resolve_memory_agents(
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain,
+    iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_amdgpu_access_agent_list_t* out_agent_list) {
+  IREE_ASSERT_ARGUMENT(topology);
+  IREE_ASSERT_ARGUMENT(out_agent_list);
+  memset(out_agent_list, 0, sizeof(*out_agent_list));
+
+  iree_hal_amdgpu_queue_affinity_physical_device_set_t physical_device_set;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_access_agent_list_select_devices(
+      topology, queue_affinity_domain, queue_affinity, &physical_device_set));
 
   iree_status_t status = iree_ok_status();
   for (iree_host_size_t physical_device_ordinal = 0;

--- a/runtime/src/iree/hal/drivers/amdgpu/access_policy.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/access_policy.h
@@ -30,10 +30,21 @@ typedef struct iree_hal_amdgpu_access_agent_list_t {
   // Number of initialized entries in |values|.
   uint32_t count;
 
-  // HSA agents to pass to hsa_amd_agents_allow_access or hsa_amd_memory_lock.
+  // HSA agents to pass to memory allocation, locking, or VMM access APIs.
   hsa_agent_t
       values[IREE_HAL_AMDGPU_MAX_CPU_AGENT + IREE_HAL_AMDGPU_MAX_GPU_AGENT];
 } iree_hal_amdgpu_access_agent_list_t;
+
+// Resolves the GPU agents selected by |queue_affinity|.
+//
+// The resulting list contains each selected GPU agent and no CPU agents. This
+// is used for operations whose contract grants access to device queues rather
+// than to every host and device participant in a memory placement.
+iree_status_t iree_hal_amdgpu_access_agent_list_resolve_queue_agents(
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain,
+    iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_amdgpu_access_agent_list_t* out_agent_list);
 
 // Resolves the HSA agents that may access memory placed for |queue_affinity|.
 //
@@ -43,7 +54,7 @@ typedef struct iree_hal_amdgpu_access_agent_list_t {
 // to that physical device. Sharing usage bits define how queues may share the
 // buffer within the requested placement; they do not expand the placement past
 // |queue_affinity|.
-iree_status_t iree_hal_amdgpu_access_agent_list_resolve(
+iree_status_t iree_hal_amdgpu_access_agent_list_resolve_memory_agents(
     const iree_hal_amdgpu_topology_t* topology,
     iree_hal_amdgpu_queue_affinity_domain_t queue_affinity_domain,
     iree_hal_queue_affinity_t queue_affinity,

--- a/runtime/src/iree/hal/drivers/amdgpu/access_policy_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/access_policy_test.cc
@@ -57,7 +57,7 @@ TEST(AccessPolicyTest, AnySelectsLogicalTopologyAgents) {
   iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
 
   iree_hal_amdgpu_access_agent_list_t agent_list;
-  IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve(
+  IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve_memory_agents(
       &topology, ThreeGpuDomain(), IREE_HAL_QUEUE_AFFINITY_ANY, &agent_list));
 
   EXPECT_EQ(agent_list.count, 5u);
@@ -72,7 +72,7 @@ TEST(AccessPolicyTest, PhysicalDeviceAffinitySelectsGpuAndNearestCpu) {
   iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
 
   iree_hal_amdgpu_access_agent_list_t agent_list;
-  IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve(
+  IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve_memory_agents(
       &topology, ThreeGpuDomain(), 0xCull, &agent_list));
 
   EXPECT_EQ(agent_list.count, 2u);
@@ -84,7 +84,7 @@ TEST(AccessPolicyTest, CrossDeviceAffinityDeduplicatesCpuAgents) {
   iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
 
   iree_hal_amdgpu_access_agent_list_t agent_list;
-  IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve(
+  IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve_memory_agents(
       &topology, ThreeGpuDomain(), 0x5ull, &agent_list));
 
   EXPECT_EQ(agent_list.count, 3u);
@@ -99,8 +99,24 @@ TEST(AccessPolicyTest, RejectsInvalidGpuCpuMap) {
 
   iree_hal_amdgpu_access_agent_list_t agent_list;
   IREE_EXPECT_STATUS_IS(IREE_STATUS_OUT_OF_RANGE,
-                        iree_hal_amdgpu_access_agent_list_resolve(
+                        iree_hal_amdgpu_access_agent_list_resolve_memory_agents(
                             &topology, ThreeGpuDomain(), 0x4ull, &agent_list));
+}
+
+TEST(AccessPolicyTest, QueueAgentsDoNotDependOnCpuMappings) {
+  iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
+  topology.gpu_cpu_map[0] = topology.cpu_agent_count;
+  topology.gpu_cpu_map[1] = topology.cpu_agent_count;
+
+  iree_hal_amdgpu_access_agent_list_t agent_list;
+  IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve_queue_agents(
+      &topology, ThreeGpuDomain(), 0x5ull, &agent_list));
+
+  EXPECT_EQ(agent_list.count, 2u);
+  EXPECT_TRUE(AgentListContains(agent_list, topology.gpu_agents[0]));
+  EXPECT_TRUE(AgentListContains(agent_list, topology.gpu_agents[1]));
+  EXPECT_FALSE(AgentListContains(agent_list, topology.cpu_agents[0]));
+  EXPECT_FALSE(AgentListContains(agent_list, topology.cpu_agents[1]));
 }
 
 }  // namespace

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator.c
@@ -392,7 +392,7 @@ static iree_status_t iree_hal_amdgpu_allocator_resolve_access_agents(
     const iree_hal_amdgpu_allocator_t* allocator,
     iree_hal_queue_affinity_t queue_affinity,
     iree_hal_amdgpu_access_agent_list_t* out_agent_list) {
-  return iree_hal_amdgpu_access_agent_list_resolve(
+  return iree_hal_amdgpu_access_agent_list_resolve_memory_agents(
       allocator->topology,
       iree_hal_amdgpu_allocator_queue_affinity_domain(allocator),
       queue_affinity, out_agent_list);

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_staging.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_staging.c
@@ -126,7 +126,7 @@ static iree_status_t iree_hal_amdgpu_staging_pool_resolve_access_agents(
       .physical_device_count = topology->gpu_agent_count,
       .queue_count_per_physical_device = topology->gpu_agent_queue_count,
   };
-  return iree_hal_amdgpu_access_agent_list_resolve(
+  return iree_hal_amdgpu_access_agent_list_resolve_memory_agents(
       topology, domain, queue_affinity_mask, out_agent_list);
 }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/slab_provider.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/slab_provider.c
@@ -191,7 +191,7 @@ static iree_status_t iree_hal_amdgpu_slab_provider_resolve_access_agents(
       .queue_count_per_physical_device =
           provider->topology->gpu_agent_queue_count,
   };
-  return iree_hal_amdgpu_access_agent_list_resolve(
+  return iree_hal_amdgpu_access_agent_list_resolve_memory_agents(
       provider->topology, domain, provider->queue_affinity_mask,
       out_agent_list);
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
@@ -540,7 +540,7 @@ iree_status_t iree_hal_amdgpu_virtual_memory_protect(
       .queue_count_per_physical_device = state->topology->gpu_agent_queue_count,
   };
   iree_hal_amdgpu_access_agent_list_t agent_list;
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_access_agent_list_resolve(
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_access_agent_list_resolve_queue_agents(
       state->topology, domain, queue_affinity, &agent_list));
 
   hsa_amd_memory_access_desc_t access_descs[IREE_HAL_AMDGPU_MAX_CPU_AGENT +


### PR DESCRIPTION
AMDGPU currently uses one access-agent policy for both memory placement and virtual-memory protection. That policy expands queue affinity into the selected GPU agents plus each GPU's nearest CPU agent. Including those CPU agents is intentional for allocations, host locking, staging pools, and other memory placements, but it violates the virtual-memory protection contract: queue affinity identifies the device queues receiving access, not additional host agents.

This change separates those policies explicitly. Queue-agent resolution returns only the GPUs selected by queue affinity, while memory-agent resolution additionally includes and deduplicates their nearest CPU agents. Both paths share the same affinity validation and physical-device selection.

Virtual-memory protection now supplies only the queue-agent list to `hsa_amd_vmem_set_access`. Allocator, staging, and slab placement paths retain their existing memory-agent behavior. Device-only VMM permissions therefore no longer grant unintended CPU access or depend on an unrelated GPU-to-CPU topology mapping, while host-accessible memory behavior remains unchanged.

Focused access-policy tests preserve both sides of the contract: queue-agent selection contains no CPUs and does not consult CPU mappings, while memory-agent selection continues to include nearest CPUs, deduplicate shared CPUs, and reject invalid topology mappings. This affects cold allocation and protection paths only; queue submission and dispatch behavior are unchanged.
