### PR TITLE
[HAL/AMDGPU] Model ROCr AQL queue execution modes

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/device/atomic_live_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/device/atomic_live_test.cc
@@ -277,6 +277,9 @@ TEST_F(AtomicLiveTest, CompleteKernelMatrix) {
   hsa_queue_t* queues[2] = {};
   iree_hal_amdgpu_aql_ring_t rings[2] = {};
   iree_hsa_signal_t completion_signals[2] = {};
+  iree_hal_amdgpu_aql_queue_execution_mode_t aql_queue_execution_mode;
+  IREE_ASSERT_OK(iree_hal_amdgpu_query_aql_queue_execution_mode(
+      &libhsa, gpu_agent, &aql_queue_execution_mode));
   iree_hsa_signal_t copy_signal = {};
   IREE_ASSERT_OK(iree_hsa_amd_signal_create(
       IREE_LIBHSA(&libhsa), /*initial_value=*/1, /*num_consumers=*/0,
@@ -297,7 +300,8 @@ TEST_F(AtomicLiveTest, CompleteKernelMatrix) {
         HsaQueueErrorCallback, &queue_errors[i], UINT32_MAX, UINT32_MAX,
         &queues[i]));
     iree_hal_amdgpu_aql_ring_initialize(
-        &libhsa, reinterpret_cast<iree_amd_queue_t*>(queues[i]), &rings[i]);
+        &libhsa, reinterpret_cast<iree_amd_queue_t*>(queues[i]),
+        aql_queue_execution_mode, &rings[i]);
   }
 
   const iree_hal_atomic_width_t widths[] = {

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue.c
@@ -773,6 +773,7 @@ iree_status_t iree_hal_amdgpu_host_queue_initialize(
     iree_hal_queue_affinity_t queue_affinity, iree_host_size_t queue_ordinal,
     iree_host_size_t physical_queue_ordinal,
     iree_thread_affinity_t completion_thread_affinity,
+    iree_hal_amdgpu_aql_queue_execution_mode_t aql_queue_execution_mode,
     iree_hal_amdgpu_wait_barrier_strategy_t wait_barrier_strategy,
     iree_hal_amdgpu_vendor_packet_capability_flags_t vendor_packet_capabilities,
     iree_hal_amdgpu_pm4_timestamp_strategy_t pm4_timestamp_strategy,
@@ -897,7 +898,8 @@ iree_status_t iree_hal_amdgpu_host_queue_initialize(
   if (iree_status_is_ok(status)) {
     out_queue->hardware_queue = hardware_queue;
     iree_hal_amdgpu_aql_ring_initialize(
-        libhsa, (iree_amd_queue_t*)hardware_queue, &out_queue->aql_ring);
+        libhsa, (iree_amd_queue_t*)hardware_queue, aql_queue_execution_mode,
+        &out_queue->aql_ring);
   }
 
   // Initialize the kernarg ring from the selected HSA memory pool.

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue.h
@@ -84,7 +84,7 @@ typedef struct iree_hal_amdgpu_host_queue_post_drain_action_t
 
 // Memory policy used for queue profiling records.
 typedef struct iree_hal_amdgpu_host_queue_profiling_memory_t {
-  // HSA memory pool used for device-owned raw completion-signal records.
+  // HSA memory pool used for raw completion-signal timestamp records.
   hsa_amd_memory_pool_t signal_memory_pool;
   // HSA memory pool used for host-readable, device-writable event records.
   hsa_amd_memory_pool_t event_memory_pool;
@@ -649,6 +649,9 @@ void iree_hal_amdgpu_host_queue_enqueue_post_drain_action(
 // ring used for queue-ordered submission metadata. Zero disables the optional
 // upload ring; non-zero values must be powers of two.
 //
+// |aql_queue_execution_mode| identifies whether the GPU or a ROCr host worker
+// consumes AQL packets and selects the matching doorbell notification path.
+//
 // |vendor_packet_capabilities| describes the AQL/PM4 vendor-packet support
 // selected from the physical device ISA. Queues allocate dynamic PM4 IB slots
 // when AQL_PM4_IB is available so BARRIER_VALUE-based CDNA queues can still use
@@ -675,6 +678,7 @@ iree_status_t iree_hal_amdgpu_host_queue_initialize(
     iree_hal_queue_affinity_t queue_affinity, iree_host_size_t queue_ordinal,
     iree_host_size_t physical_queue_ordinal,
     iree_thread_affinity_t completion_thread_affinity,
+    iree_hal_amdgpu_aql_queue_execution_mode_t aql_queue_execution_mode,
     iree_hal_amdgpu_wait_barrier_strategy_t wait_barrier_strategy,
     iree_hal_amdgpu_vendor_packet_capability_flags_t vendor_packet_capabilities,
     iree_hal_amdgpu_pm4_timestamp_strategy_t pm4_timestamp_strategy,

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_profile_events.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_profile_events.c
@@ -44,7 +44,7 @@ iree_hal_amdgpu_host_queue_require_profiling_signal_memory_pool(
   }
   return iree_make_status(
       IREE_STATUS_UNAVAILABLE,
-      "AMDGPU HSA timestamp profiling requires device-local signal memory");
+      "AMDGPU HSA timestamp profiling requires completion-signal memory");
 }
 
 static iree_status_t
@@ -72,12 +72,12 @@ iree_hal_amdgpu_host_queue_initialize_profiling_completion_signals(
   IREE_TRACE_ZONE_BEGIN(z0);
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, signal_count);
 
-  // Raw profiling signals are command-processor timestamp scratch records that
-  // intentionally live in device-local memory. They are not ROCR-created host
-  // HSA signal objects, but the packet completion_signal field still carries a
-  // signal ABI pointer; initialize and arm the ABI-visible user-signal fields
-  // on-device so stricter CP implementations treat each dispatch completion as
-  // a normal signal transition while populating start/end timestamps.
+  // Raw profiling signals are command-processor timestamp scratch records.
+  // They are not ROCR-created host HSA signal objects, but the packet
+  // completion_signal field still carries a signal ABI pointer; initialize and
+  // arm the ABI-visible user-signal fields on-device so both hardware queues
+  // and host-translated queues treat each dispatch completion as a normal
+  // signal transition while populating start/end timestamps.
   iree_hsa_kernel_dispatch_packet_t dispatch_packet;
   memset(&dispatch_packet, 0, sizeof(dispatch_packet));
   iree_hal_amdgpu_dispatch_timestamp_signal_initialize_args_t kernargs;

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
@@ -892,7 +892,7 @@ iree_hal_amdgpu_physical_device_initialize_device_library_and_blit_context(
 }
 
 static iree_status_t
-iree_hal_amdgpu_physical_device_initialize_vendor_packet_strategy(
+iree_hal_amdgpu_physical_device_initialize_queue_execution_strategy(
     const iree_hal_amdgpu_system_t* system,
     const iree_hal_amdgpu_physical_device_options_t* options,
     hsa_agent_t device_agent,
@@ -908,10 +908,24 @@ iree_hal_amdgpu_physical_device_initialize_vendor_packet_strategy(
   const iree_hal_amdgpu_gfxip_version_t gfxip_version =
       agent_target->primary_isa.identity.version;
 
+  iree_hal_amdgpu_aql_queue_execution_mode_t aql_queue_execution_mode;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_query_aql_queue_execution_mode(
+      &system->libhsa, device_agent, &aql_queue_execution_mode));
   iree_hal_amdgpu_vendor_packet_capability_flags_t vendor_packet_capabilities =
-      iree_hal_amdgpu_select_vendor_packet_capabilities(gfxip_version);
+      0;
   iree_hal_amdgpu_pm4_timestamp_strategy_t pm4_timestamp_strategy =
-      iree_hal_amdgpu_select_pm4_timestamp_strategy(gfxip_version);
+      IREE_HAL_AMDGPU_PM4_TIMESTAMP_STRATEGY_NONE;
+  // ROCr's PM4-emulated queues only promise the core AQL packet families. Its
+  // host translator does not expose vendor PM4 IB execution as a public
+  // contract. Native queues are consumed by the GPU and can use packet
+  // families supported by the agent's gfx IP.
+  if (aql_queue_execution_mode ==
+      IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_NATIVE) {
+    vendor_packet_capabilities =
+        iree_hal_amdgpu_select_vendor_packet_capabilities(gfxip_version);
+    pm4_timestamp_strategy =
+        iree_hal_amdgpu_select_pm4_timestamp_strategy(gfxip_version);
+  }
   iree_hal_amdgpu_wait_barrier_strategy_t wait_barrier_strategy =
       IREE_HAL_AMDGPU_WAIT_BARRIER_STRATEGY_DEFER;
   if (!options->force_wait_barrier_defer) {
@@ -919,6 +933,7 @@ iree_hal_amdgpu_physical_device_initialize_vendor_packet_strategy(
         vendor_packet_capabilities);
   }
   out_physical_device->agent_target = agent_target;
+  out_physical_device->aql_queue_execution_mode = aql_queue_execution_mode;
   out_physical_device->vendor_packet_capabilities = vendor_packet_capabilities;
   out_physical_device->wait_barrier_strategy = wait_barrier_strategy;
   out_physical_device->pm4_timestamp_strategy = pm4_timestamp_strategy;
@@ -1052,8 +1067,9 @@ iree_status_t iree_hal_amdgpu_physical_device_initialize(
             system, device_agent, device_ordinal, out_physical_device);
   }
   if (iree_status_is_ok(status)) {
-    status = iree_hal_amdgpu_physical_device_initialize_vendor_packet_strategy(
-        system, options, device_agent, out_physical_device);
+    status =
+        iree_hal_amdgpu_physical_device_initialize_queue_execution_strategy(
+            system, options, device_agent, out_physical_device);
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_physical_device_initialize_atomic_pm4_context(
@@ -1220,13 +1236,19 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
   iree_hal_amdgpu_physical_device_select_kernarg_ring_memory(
       physical_device, host_memory_pools, &kernarg_ring_memory);
   iree_hal_amdgpu_host_queue_profiling_memory_t profiling_memory = {0};
-  // Raw profiling completion signals are user-signal-shaped CP timestamp
-  // targets initialized by a device dispatch, so they can live in coarse
-  // device memory.
+  hsa_amd_memory_pool_t device_signal_memory_pool = {0};
   if (physical_device->coarse_block_pools.small.is_initialized) {
-    profiling_memory.signal_memory_pool =
+    device_signal_memory_pool =
         physical_device->coarse_block_pools.small.memory_pool;
   }
+  // Raw profiling completion signals are user-signal-shaped CP timestamp
+  // targets. Native AQL queues retire them on the device. ROCr's PM4-emulated
+  // queues may retire them from the host translation worker when the device
+  // lacks platform atomics, so they require shared fine memory.
+  profiling_memory.signal_memory_pool =
+      iree_hal_amdgpu_select_profiling_completion_signal_memory_pool(
+          device_signal_memory_pool, host_memory_pools->fine_pool,
+          physical_device->aql_queue_execution_mode);
   // Event records are serialized by the CPU after the GPU writes timestamp
   // fields. Prefer CPU-visible device-coarse memory when available so devices
   // without fine-grained memory can still profile. Otherwise fall back to
@@ -1271,6 +1293,7 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
         &kernarg_ring_memory.descriptor, host_memory_pools->fine_pool,
         frontier_tracker, queue_axis, resolved.queue_affinity,
         logical_queue_ordinal, queue_ordinal, completion_thread_affinity,
+        physical_device->aql_queue_execution_mode,
         physical_device->wait_barrier_strategy,
         physical_device->vendor_packet_capabilities,
         physical_device->pm4_timestamp_strategy, epoch_signal_table,

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device.h
@@ -311,6 +311,8 @@ typedef struct iree_hal_amdgpu_physical_device_t {
   // Per-host-queue device-visible control upload ring capacity in bytes. Zero
   // disables the optional upload ring.
   uint32_t host_queue_upload_capacity;
+  // Component that consumes this GPU agent's AQL queue packets.
+  iree_hal_amdgpu_aql_queue_execution_mode_t aql_queue_execution_mode;
   // AMD vendor-packet capabilities selected from this GPU agent's ISA.
   iree_hal_amdgpu_vendor_packet_capability_flags_t vendor_packet_capabilities;
   // Hardware strategy selected for cross-queue epoch waits on this GPU agent.

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device_capabilities.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device_capabilities.c
@@ -775,6 +775,16 @@ iree_hal_amdgpu_select_prepublished_kernarg_storage(
   return iree_hal_amdgpu_aql_prepublished_kernarg_storage_device_fine_host_coherent();
 }
 
+hsa_amd_memory_pool_t
+iree_hal_amdgpu_select_profiling_completion_signal_memory_pool(
+    hsa_amd_memory_pool_t device_memory_pool,
+    hsa_amd_memory_pool_t host_memory_pool,
+    iree_hal_amdgpu_aql_queue_execution_mode_t execution_mode) {
+  return execution_mode == IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_PM4_EMULATED
+             ? host_memory_pool
+             : device_memory_pool;
+}
+
 iree_hal_amdgpu_vendor_packet_capability_flags_t
 iree_hal_amdgpu_select_vendor_packet_capabilities(
     iree_hal_amdgpu_gfxip_version_t version) {

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device_capabilities.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device_capabilities.h
@@ -10,6 +10,7 @@
 #include "iree/base/api.h"
 #include "iree/hal/device.h"
 #include "iree/hal/drivers/amdgpu/aql_prepublished_kernarg_storage.h"
+#include "iree/hal/drivers/amdgpu/util/aql_ring.h"
 #include "iree/hal/drivers/amdgpu/util/kernarg_ring.h"
 #include "iree/hal/drivers/amdgpu/util/libhsa.h"
 #include "iree/hal/drivers/amdgpu/util/pm4_capabilities.h"
@@ -340,6 +341,15 @@ bool iree_hal_amdgpu_memory_system_requires_svm_access_attributes(
 iree_hal_amdgpu_aql_prepublished_kernarg_storage_t
 iree_hal_amdgpu_select_prepublished_kernarg_storage(
     hsa_amd_memory_pool_t fine_block_memory_pool, bool direct_host_access);
+
+// Selects storage for raw dispatch-profiling completion signals.
+// PM4-emulated queues may retire completion signals from a ROCr host worker and
+// therefore use the shared host pool. Native queues use the device-local pool.
+hsa_amd_memory_pool_t
+iree_hal_amdgpu_select_profiling_completion_signal_memory_pool(
+    hsa_amd_memory_pool_t device_memory_pool,
+    hsa_amd_memory_pool_t host_memory_pool,
+    iree_hal_amdgpu_aql_queue_execution_mode_t execution_mode);
 
 // Selects AMD vendor AQL packet and PM4 packet-family capabilities from the
 // parsed gfx IP version.

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device_capabilities_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device_capabilities_test.cc
@@ -938,6 +938,23 @@ TEST_F(PhysicalDeviceCapabilitiesTest, SelectsPrepublishedKernargStorage) {
                                     IREE_HAL_MEMORY_TYPE_HOST_COHERENT));
 }
 
+TEST_F(PhysicalDeviceCapabilitiesTest,
+       SelectsProfilingCompletionSignalMemoryPool) {
+  const hsa_amd_memory_pool_t device_memory_pool = MemoryPool(42);
+  const hsa_amd_memory_pool_t host_memory_pool = MemoryPool(43);
+
+  EXPECT_EQ(iree_hal_amdgpu_select_profiling_completion_signal_memory_pool(
+                device_memory_pool, host_memory_pool,
+                IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_NATIVE)
+                .handle,
+            device_memory_pool.handle);
+  EXPECT_EQ(iree_hal_amdgpu_select_profiling_completion_signal_memory_pool(
+                device_memory_pool, host_memory_pool,
+                IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_PM4_EMULATED)
+                .handle,
+            host_memory_pool.handle);
+}
+
 TEST_F(PhysicalDeviceCapabilitiesTest, SelectsCdnaPm4FamilyCapabilities) {
   constexpr iree_hal_amdgpu_vendor_packet_capability_flags_t
       kExpectedCapabilities =

--- a/runtime/src/iree/hal/drivers/amdgpu/util/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/BUILD.bazel
@@ -305,6 +305,7 @@ iree_runtime_cc_library(
 iree_runtime_cc_library(
     name = "queue_primitives",
     srcs = [
+        "aql_ring.c",
         "kernarg_ring.c",
         "notification_ring.c",
         "queue_upload_ring.c",
@@ -326,6 +327,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base/internal:arena",
         "//runtime/src/iree/base/threading",
         "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/drivers/amdgpu/abi",
         "//runtime/src/iree/hal/utils:resource_set",
     ],
 )

--- a/runtime/src/iree/hal/drivers/amdgpu/util/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/CMakeLists.txt
@@ -426,6 +426,7 @@ iree_cc_library(
     "queue_upload_ring.h"
     "signal_pool.h"
   SRCS
+    "aql_ring.c"
     "kernarg_ring.c"
     "notification_ring.c"
     "queue_upload_ring.c"
@@ -438,6 +439,7 @@ iree_cc_library(
     iree::base::internal::arena
     iree::base::threading
     iree::hal
+    iree::hal::drivers::amdgpu::abi
     iree::hal::utils::resource_set
   PUBLIC
 )

--- a/runtime/src/iree/hal/drivers/amdgpu/util/aql_ring.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/aql_ring.c
@@ -1,0 +1,25 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/util/aql_ring.h"
+
+iree_status_t iree_hal_amdgpu_query_aql_queue_execution_mode(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t device_agent,
+    iree_hal_amdgpu_aql_queue_execution_mode_t* out_execution_mode) {
+  IREE_ASSERT_ARGUMENT(libhsa);
+  IREE_ASSERT_ARGUMENT(out_execution_mode);
+
+  bool pm4_emulation = false;
+  IREE_RETURN_IF_ERROR(
+      iree_hsa_agent_get_info(
+          IREE_LIBHSA(libhsa), device_agent,
+          (hsa_agent_info_t)HSA_AMD_AGENT_INFO_PM4_EMULATION, &pm4_emulation),
+      "querying HSA_AMD_AGENT_INFO_PM4_EMULATION");
+  *out_execution_mode =
+      pm4_emulation ? IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_PM4_EMULATED
+                    : IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_NATIVE;
+  return iree_ok_status();
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/util/aql_ring.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/aql_ring.h
@@ -10,7 +10,7 @@
 // The ring caches hot pointers from iree_amd_queue_t at initialization:
 // ring base, mask, doorbell MMIO pointer, and the atomic write/read dispatch
 // IDs. All hot-path operations are inline with zero libhsa indirection except
-// ringing a non-DOORBELL-kind doorbell, which goes through HSA signal-store.
+// when the queue execution mode or signal kind requires HSA signal-store.
 //
 // Thread safety:
 //   reserve() is multi-producer safe (atomic_fetch_add on write_dispatch_id).
@@ -62,6 +62,19 @@ static_assert(sizeof(iree_hal_amdgpu_aql_packet_t) == 64,
 // iree_hal_amdgpu_aql_ring_t
 //===----------------------------------------------------------------------===//
 
+// Identifies the component that consumes an agent's AQL queue packets.
+typedef enum iree_hal_amdgpu_aql_queue_execution_mode_e {
+  // The GPU scheduler consumes AQL packets directly.
+  IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_NATIVE = 0,
+  // A ROCr host worker translates supported AQL packets into PM4 submissions.
+  IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_PM4_EMULATED = 1,
+} iree_hal_amdgpu_aql_queue_execution_mode_t;
+
+// Queries the AQL queue execution mode reported for |device_agent|.
+iree_status_t iree_hal_amdgpu_query_aql_queue_execution_mode(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t device_agent,
+    iree_hal_amdgpu_aql_queue_execution_mode_t* out_execution_mode);
+
 // Cached hardware AQL ring buffer state. Initialized once from iree_amd_queue_t
 // and used for all subsequent packet operations. The cached pointers avoid
 // repeated indirection through the queue descriptor on the hot path.
@@ -80,11 +93,11 @@ typedef struct iree_hal_amdgpu_aql_ring_t {
   // How the doorbell gets rung; both fields represent the queue's doorbell
   // signal.
   struct {
-    // Cached hardware doorbell MMIO pointer, or NULL when the queue's doorbell
-    // signal is not DOORBELL-kind (then ring via |signal| below). When
-    // non-NULL, writing a packet ID here wakes the CP to process new packets
-    // via a direct atomic store to MMIO — no libhsa indirection. Resolved at
-    // init from the doorbell signal's iree_amd_signal_t.hardware_doorbell_ptr.
+    // Cached hardware doorbell MMIO pointer, or NULL when the queue must be
+    // rung through |signal| below. When non-NULL, writing a packet ID here
+    // wakes the CP to process new packets via a direct atomic store to MMIO.
+    // PM4-emulated queues always use the signal path because ROCr must notify
+    // its host translation worker in addition to updating the exposed value.
     volatile int64_t* ptr;
     // Doorbell signal handle, used when |ptr| is NULL (non-DOORBELL-kind
     // doorbell signals, e.g. interrupt-backed USER-kind): ring through the HSA
@@ -105,11 +118,12 @@ typedef struct iree_hal_amdgpu_aql_ring_t {
   const volatile int64_t* read_dispatch_id;
 } iree_hal_amdgpu_aql_ring_t;
 
-// Initializes the AQL ring from a hardware queue descriptor.
-// Resolves the doorbell pointer from the signal's iree_amd_signal_t and
-// caches all hot pointers for zero-indirection access.
+// Initializes the AQL ring from a hardware queue descriptor. Resolves the
+// doorbell notification strategy from |execution_mode| and the signal's
+// iree_amd_signal_t, then caches all hot pointers for zero-indirection access.
 static inline void iree_hal_amdgpu_aql_ring_initialize(
     const iree_hal_amdgpu_libhsa_t* libhsa, iree_amd_queue_t* hardware_queue,
+    iree_hal_amdgpu_aql_queue_execution_mode_t execution_mode,
     iree_hal_amdgpu_aql_ring_t* out_ring) {
   out_ring->base =
       (iree_hal_amdgpu_aql_packet_t*)hardware_queue->hsa_queue.base_address;
@@ -119,17 +133,18 @@ static inline void iree_hal_amdgpu_aql_ring_initialize(
   //
   // Only DOORBELL-kind signals expose a directly-writable hardware_doorbell_ptr
   // (a memory-mapped doorbell register); writing a packet ID there wakes the CP
-  // with zero libhsa indirection. Other signal kinds — e.g. the
-  // interrupt-backed USER-kind doorbells some ROCm builds hand back for AQL
-  // queues — store a signal value in that same union slot rather than an MMIO
-  // pointer, so the raw write would fault. For those we leave |doorbell.ptr|
-  // NULL and ring via the HSA signal-store API using the cached handle +
-  // libhsa.
+  // with zero libhsa indirection. Other signal kinds store a signal value in
+  // that same union slot rather than an MMIO pointer, so the raw write would
+  // fault. A PM4-emulated queue may also expose a DOORBELL-kind signal whose
+  // pointer names a software value; the HSA signal store must additionally
+  // notify ROCr's host translation worker. Those cases ring through the public
+  // HSA signal API.
   out_ring->libhsa = libhsa;
   out_ring->doorbell.signal = hardware_queue->hsa_queue.doorbell_signal;
   iree_amd_signal_t* doorbell_signal =
       (iree_amd_signal_t*)hardware_queue->hsa_queue.doorbell_signal.handle;
-  if (doorbell_signal &&
+  if (execution_mode == IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_NATIVE &&
+      doorbell_signal &&
       doorbell_signal->kind == IREE_AMD_SIGNAL_KIND_DOORBELL) {
     out_ring->doorbell.ptr =
         (volatile int64_t*)doorbell_signal->hardware_doorbell_ptr;

--- a/runtime/src/iree/hal/drivers/amdgpu/util/aql_ring_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/aql_ring_test.cc
@@ -16,6 +16,79 @@
 
 namespace {
 
+constexpr iree_hal_amdgpu_aql_queue_execution_mode_t kNativeAqlQueue =
+    IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_NATIVE;
+constexpr iree_hal_amdgpu_aql_queue_execution_mode_t kPm4EmulatedAqlQueue =
+    IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_PM4_EMULATED;
+
+#if !IREE_HAL_AMDGPU_LIBHSA_STATIC
+
+struct AqlQueueExecutionQuery {
+  bool pm4_emulation = false;
+  hsa_status_t status = HSA_STATUS_SUCCESS;
+  uint32_t query_count = 0;
+};
+
+static hsa_status_t HSA_API FakeAqlQueueExecutionAgentGetInfo(
+    hsa_agent_t agent, hsa_agent_info_t attribute, void* value) {
+  auto* query = reinterpret_cast<AqlQueueExecutionQuery*>(
+      static_cast<uintptr_t>(agent.handle));
+  if (!query || !value ||
+      attribute != (hsa_agent_info_t)HSA_AMD_AGENT_INFO_PM4_EMULATION) {
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+  ++query->query_count;
+  if (query->status == HSA_STATUS_SUCCESS) {
+    std::memcpy(value, &query->pm4_emulation, sizeof(query->pm4_emulation));
+  }
+  return query->status;
+}
+
+static iree_hal_amdgpu_libhsa_t AqlQueueExecutionQueryLibhsa() {
+  iree_hal_amdgpu_libhsa_t libhsa = {};
+  libhsa.hsa_agent_get_info = FakeAqlQueueExecutionAgentGetInfo;
+  return libhsa;
+}
+
+static hsa_agent_t AqlQueueExecutionQueryAgent(AqlQueueExecutionQuery* query) {
+  return hsa_agent_t{static_cast<uint64_t>(reinterpret_cast<uintptr_t>(query))};
+}
+
+TEST(AqlRingTest, QueriesAqlQueueExecutionMode) {
+  iree_hal_amdgpu_libhsa_t libhsa = AqlQueueExecutionQueryLibhsa();
+  AqlQueueExecutionQuery query;
+  iree_hal_amdgpu_aql_queue_execution_mode_t execution_mode =
+      kPm4EmulatedAqlQueue;
+
+  IREE_ASSERT_OK(iree_hal_amdgpu_query_aql_queue_execution_mode(
+      &libhsa, AqlQueueExecutionQueryAgent(&query), &execution_mode));
+  EXPECT_EQ(execution_mode, kNativeAqlQueue);
+  EXPECT_EQ(query.query_count, 1u);
+
+  query.pm4_emulation = true;
+  IREE_ASSERT_OK(iree_hal_amdgpu_query_aql_queue_execution_mode(
+      &libhsa, AqlQueueExecutionQueryAgent(&query), &execution_mode));
+  EXPECT_EQ(execution_mode, kPm4EmulatedAqlQueue);
+  EXPECT_EQ(query.query_count, 2u);
+}
+
+TEST(AqlRingTest, AqlQueueExecutionQueryFailurePropagates) {
+  iree_hal_amdgpu_libhsa_t libhsa = AqlQueueExecutionQueryLibhsa();
+  AqlQueueExecutionQuery query;
+  query.status = HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  iree_hal_amdgpu_aql_queue_execution_mode_t execution_mode =
+      kPm4EmulatedAqlQueue;
+
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_query_aql_queue_execution_mode(
+          &libhsa, AqlQueueExecutionQueryAgent(&query), &execution_mode));
+  EXPECT_EQ(execution_mode, kPm4EmulatedAqlQueue);
+  EXPECT_EQ(query.query_count, 1u);
+}
+
+#endif  // !IREE_HAL_AMDGPU_LIBHSA_STATIC
+
 // Fills the queue fields aql_ring_initialize reads: the packet ring base/size
 // and the doorbell signal handle. The dispatch-id fields are read by address
 // and left zero.
@@ -64,9 +137,8 @@ TEST(AqlRingTest, CommitsExtendedDispatchFormatAndSetupAtomically) {
   EXPECT_EQ(packet.extended_dispatch.setup, 3u);
 }
 
-// A DOORBELL-kind signal exposes an MMIO register pointer in the union, so
-// initialize caches it for the inline fast path and records all hot pointers.
-TEST(AqlRingTest, InitializeResolvesMmioPointerForDoorbellKind) {
+// Native queues can write a DOORBELL-kind signal's MMIO pointer directly.
+TEST(AqlRingTest, NativeQueueResolvesMmioPointerForDoorbellKind) {
   volatile int64_t doorbell_mmio = 0;
   iree_amd_signal_t signal = {};
   signal.kind = IREE_AMD_SIGNAL_KIND_DOORBELL;
@@ -78,9 +150,8 @@ TEST(AqlRingTest, InitializeResolvesMmioPointerForDoorbellKind) {
 
   iree_hal_amdgpu_libhsa_t libhsa = {};
   iree_hal_amdgpu_aql_ring_t ring = {};
-  iree_hal_amdgpu_aql_ring_initialize(&libhsa, &queue, &ring);
+  iree_hal_amdgpu_aql_ring_initialize(&libhsa, &queue, kNativeAqlQueue, &ring);
 
-  // DOORBELL kind resolves to the MMIO pointer.
   EXPECT_EQ((void*)ring.doorbell.ptr, (void*)&doorbell_mmio);
   // The signal handle and libhsa are cached regardless of kind.
   EXPECT_EQ(ring.doorbell.signal.handle, (uint64_t)&signal);
@@ -90,6 +161,28 @@ TEST(AqlRingTest, InitializeResolvesMmioPointerForDoorbellKind) {
   EXPECT_EQ(ring.mask, IREE_ARRAYSIZE(packets) - 1);
   EXPECT_EQ((void*)ring.write_dispatch_id, (void*)&queue.write_dispatch_id);
   EXPECT_EQ((void*)ring.read_dispatch_id, (void*)&queue.read_dispatch_id);
+}
+
+// PM4-emulated queues must notify ROCr's host translation worker through the
+// HSA signal API even when the exposed signal has DOORBELL kind.
+TEST(AqlRingTest, Pm4EmulatedQueueUsesHsaSignalForDoorbellKind) {
+  volatile int64_t doorbell_value = 0;
+  iree_amd_signal_t signal = {};
+  signal.kind = IREE_AMD_SIGNAL_KIND_DOORBELL;
+  signal.hardware_doorbell_ptr = (volatile uint64_t*)&doorbell_value;
+
+  iree_hal_amdgpu_aql_packet_t packets[4] = {};
+  iree_amd_queue_t queue = {};
+  ConfigureQueue(packets, IREE_ARRAYSIZE(packets), &signal, &queue);
+
+  iree_hal_amdgpu_libhsa_t libhsa = {};
+  iree_hal_amdgpu_aql_ring_t ring = {};
+  iree_hal_amdgpu_aql_ring_initialize(&libhsa, &queue, kPm4EmulatedAqlQueue,
+                                      &ring);
+
+  EXPECT_EQ((void*)ring.doorbell.ptr, nullptr);
+  EXPECT_EQ(ring.doorbell.signal.handle, (uint64_t)&signal);
+  EXPECT_EQ(ring.libhsa, &libhsa);
 }
 
 // A USER-kind signal stores a value (not a pointer) in the same union slot, so
@@ -105,7 +198,7 @@ TEST(AqlRingTest, InitializeLeavesPointerNullForUserKind) {
 
   iree_hal_amdgpu_libhsa_t libhsa = {};
   iree_hal_amdgpu_aql_ring_t ring = {};
-  iree_hal_amdgpu_aql_ring_initialize(&libhsa, &queue, &ring);
+  iree_hal_amdgpu_aql_ring_initialize(&libhsa, &queue, kNativeAqlQueue, &ring);
 
   EXPECT_EQ((void*)ring.doorbell.ptr, nullptr);
   EXPECT_EQ(ring.doorbell.signal.handle, (uint64_t)&signal);
@@ -121,7 +214,7 @@ TEST(AqlRingTest, InitializeLeavesPointerNullForNullSignal) {
 
   iree_hal_amdgpu_libhsa_t libhsa = {};
   iree_hal_amdgpu_aql_ring_t ring = {};
-  iree_hal_amdgpu_aql_ring_initialize(&libhsa, &queue, &ring);
+  iree_hal_amdgpu_aql_ring_initialize(&libhsa, &queue, kNativeAqlQueue, &ring);
 
   EXPECT_EQ((void*)ring.doorbell.ptr, nullptr);
   EXPECT_EQ(ring.doorbell.signal.handle, 0u);

--- a/runtime/src/iree/hal/drivers/amdgpu/util/feedback_channel_live_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/feedback_channel_live_test.cc
@@ -358,9 +358,13 @@ TEST_F(FeedbackChannelLiveTest, DeviceProducerSignalsHost) {
   IREE_ASSERT_OK(iree_hsa_queue_create(
       IREE_LIBHSA(&libhsa), gpu_agent, /*size=*/64, HSA_QUEUE_TYPE_MULTI,
       HsaQueueErrorCallback, &queue_error, UINT32_MAX, UINT32_MAX, &queue));
+  iree_hal_amdgpu_aql_queue_execution_mode_t aql_queue_execution_mode;
+  IREE_ASSERT_OK(iree_hal_amdgpu_query_aql_queue_execution_mode(
+      &libhsa, gpu_agent, &aql_queue_execution_mode));
   iree_hal_amdgpu_aql_ring_t aql_ring;
   iree_hal_amdgpu_aql_ring_initialize(
-      &libhsa, reinterpret_cast<iree_amd_queue_t*>(queue), &aql_ring);
+      &libhsa, reinterpret_cast<iree_amd_queue_t*>(queue),
+      aql_queue_execution_mode, &aql_ring);
 
   hsa_signal_t completion_signal = iree_hsa_signal_null();
   IREE_ASSERT_OK(iree_hsa_amd_signal_create(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/pm4_dispatch_live_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/pm4_dispatch_live_test.cc
@@ -485,6 +485,14 @@ class PM4DispatchLiveTest : public ::testing::Test {
       GTEST_SKIP() << "CPU and GPU agents are required, skipping tests";
     }
 
+    IREE_ASSERT_OK(iree_hal_amdgpu_query_aql_queue_execution_mode(
+        &libhsa, topology.gpu_agents[0], &aql_queue_execution_mode));
+    if (aql_queue_execution_mode ==
+        IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_PM4_EMULATED) {
+      GTEST_SKIP()
+          << "ROCr PM4-emulated queues do not execute vendor AQL packets";
+    }
+
     if (!QueryAgentCodeObjectTarget(&libhsa, topology.gpu_agents[0],
                                     &agent_gfxip_version, &agent_exact_target,
                                     &agent_code_object_target)) {
@@ -516,6 +524,7 @@ class PM4DispatchLiveTest : public ::testing::Test {
   static iree_hal_amdgpu_libhsa_t libhsa;
   static iree_hal_amdgpu_topology_t topology;
   static iree_hal_amdgpu_gfxip_version_t agent_gfxip_version;
+  static iree_hal_amdgpu_aql_queue_execution_mode_t aql_queue_execution_mode;
   static iree_hal_amdgpu_vendor_packet_capability_flags_t
       agent_pm4_barrier_capabilities;
   static std::string agent_exact_target;
@@ -527,6 +536,8 @@ iree_allocator_t PM4DispatchLiveTest::host_allocator;
 iree_hal_amdgpu_libhsa_t PM4DispatchLiveTest::libhsa;
 iree_hal_amdgpu_topology_t PM4DispatchLiveTest::topology;
 iree_hal_amdgpu_gfxip_version_t PM4DispatchLiveTest::agent_gfxip_version;
+iree_hal_amdgpu_aql_queue_execution_mode_t
+    PM4DispatchLiveTest::aql_queue_execution_mode;
 iree_hal_amdgpu_vendor_packet_capability_flags_t
     PM4DispatchLiveTest::agent_pm4_barrier_capabilities;
 std::string PM4DispatchLiveTest::agent_exact_target;
@@ -607,7 +618,8 @@ TEST_F(PM4DispatchLiveTest, AqlAndAqlPm4IbLaunchMixedKernels) {
       HsaQueueErrorCallback, &queue_error, UINT32_MAX, UINT32_MAX, &queue));
   iree_hal_amdgpu_aql_ring_t aql_ring;
   iree_hal_amdgpu_aql_ring_initialize(
-      &libhsa, reinterpret_cast<iree_amd_queue_t*>(queue), &aql_ring);
+      &libhsa, reinterpret_cast<iree_amd_queue_t*>(queue),
+      aql_queue_execution_mode, &aql_ring);
 
   hsa_signal_t completion_signal = iree_hsa_signal_null();
   IREE_ASSERT_OK(iree_hsa_amd_signal_create(
@@ -980,7 +992,8 @@ TEST_F(PM4DispatchLiveTest, NativeMemoryPacketMatrix) {
       HsaQueueErrorCallback, &queue_error, UINT32_MAX, UINT32_MAX, &queue));
   iree_hal_amdgpu_aql_ring_t aql_ring;
   iree_hal_amdgpu_aql_ring_initialize(
-      &libhsa, reinterpret_cast<iree_amd_queue_t*>(queue), &aql_ring);
+      &libhsa, reinterpret_cast<iree_amd_queue_t*>(queue),
+      aql_queue_execution_mode, &aql_ring);
   hsa_signal_t completion_signal = iree_hsa_signal_null();
   IREE_ASSERT_OK(iree_hsa_amd_signal_create(
       IREE_LIBHSA(&libhsa), /*initial_value=*/1, /*num_consumers=*/0,


### PR DESCRIPTION
HRX publishes AQL packets directly into HSA queue rings and previously selected queue behavior from the doorbell signal representation and GPU ISA alone. That assumes the GPU scheduler consumes the ring. ROCr can instead expose a PM4-emulated AQL queue consumed by a host translation worker, where the ring format is unchanged but notification, packet support, and profiling-memory requirements are different.

This change queries `HSA_AMD_AGENT_INFO_PM4_EMULATION` once while initializing each physical device and records whether its AQL queues are native or PM4-emulated. Native queues with hardware doorbells retain the direct MMIO notification path. PM4-emulated queues always publish through the HSA signal-store API so ROCr can wake its host translation worker after packets are committed.

Queue mode also becomes an explicit capability boundary. Native queues retain the vendor AQL packet families and PM4 timestamp strategies supported by their GPU ISA. PM4-emulated queues expose only ROCr's core AQL contract, use deferred wait barriers instead of vendor packets, and allocate profiling completion records from host-fine memory so both the host translator and device can access them.

The mode is resolved before queue creation and reduced to the existing cached doorbell-pointer choice. Submission performs no capability query or ISA inference: native queues still execute one direct atomic MMIO store, while PM4-emulated queues take the preselected HSA signal-store path.

Unit tests cover capability-query success and failure, native versus emulated doorbell selection, signal-store publication, and profiling-memory selection. Live AQL tests query the reported mode, continue exercising core dispatches on both modes, and avoid vendor-packet tests where ROCr does not advertise that execution contract. The change depends only on the upstream ROCr agent query, not the unpublished Windows runtime patch series.
