### PR TITLE
[Loom] Normalize structural kernel entry resources

### DIFF
--- a/loom/src/loom/transforms/kernel/BUILD.bazel
+++ b/loom/src/loom/transforms/kernel/BUILD.bazel
@@ -34,7 +34,6 @@ loom_cc_library(
         "//loom/src/loom/ir",
         "//loom/src/loom/ops:op_defs",
         "//loom/src/loom/ops/buffer",
-        "//loom/src/loom/ops/func",
         "//loom/src/loom/ops/index",
         "//loom/src/loom/pass:types",
         "//loom/src/loom/pass:value_facts",

--- a/loom/src/loom/transforms/kernel/CMakeLists.txt
+++ b/loom/src/loom/transforms/kernel/CMakeLists.txt
@@ -37,7 +37,6 @@ loom_cc_library(
     iree::base
     loom::ir
     loom::ops::buffer
-    loom::ops::func
     loom::ops::index
     loom::ops::op_defs
     loom::pass::types

--- a/loom/src/loom/transforms/kernel/kernel_resources.c
+++ b/loom/src/loom/transforms/kernel/kernel_resources.c
@@ -10,14 +10,13 @@
 #include "loom/ir/scalar_type.h"
 #include "loom/ir/types.h"
 #include "loom/ops/buffer/ops.h"
-#include "loom/ops/func/ops.h"
 #include "loom/ops/index/ops.h"
 #include "loom/ops/op_defs.h"
 
-#define LOOM_KERNEL_RESOURCES_STATISTICS(V, statistics_type)       \
-  V(statistics_type, functions_normalized, "functions-normalized", \
-    "Number of exported device functions changed.")                \
-  V(statistics_type, view_args_normalized, "view-args-normalized", \
+#define LOOM_KERNEL_RESOURCES_STATISTICS(V, statistics_type)                 \
+  V(statistics_type, kernel_entries_normalized, "kernel-entries-normalized", \
+    "Number of kernel entry definitions changed.")                           \
+  V(statistics_type, view_args_normalized, "view-args-normalized",           \
     "Number of view-typed ABI arguments rewritten to buffer roots.")
 
 LOOM_PASS_STATISTICS_DEFINE(loom_kernel_resources_statistics,
@@ -27,7 +26,7 @@ LOOM_PASS_STATISTICS_DEFINE(loom_kernel_resources_statistics,
 static const loom_pass_info_t loom_kernel_resources_pass_info_storage = {
     .name = IREE_SVL("normalize-kernel-resources"),
     .description =
-        IREE_SVL("Normalize exported device resource args to buffer roots."),
+        IREE_SVL("Normalize kernel entry resource args to buffer roots."),
     .kind = LOOM_PASS_FUNCTION,
     .statistic_layout = &loom_kernel_resources_statistics_layout,
 };
@@ -39,14 +38,6 @@ const loom_pass_info_t* loom_normalize_kernel_resources_pass_info(void) {
 //===----------------------------------------------------------------------===//
 // Implementation
 //===----------------------------------------------------------------------===//
-
-static bool loom_kernel_resources_is_exported_device_function(
-    loom_func_like_t function) {
-  return loom_func_like_isa(function) &&
-         loom_func_like_visibility(function) == LOOM_FUNC_VISIBILITY_PUBLIC &&
-         loom_func_like_cc(function) == LOOM_FUNC_CC_DEVICE &&
-         loom_func_like_body(function) != NULL;
-}
 
 static iree_status_t loom_kernel_resources_build_zero_offset(
     loom_builder_t* builder, loom_location_id_t location,
@@ -81,15 +72,16 @@ static iree_status_t loom_kernel_resources_normalize_view_arg(
 iree_status_t loom_normalize_kernel_resources_run(loom_pass_t* pass,
                                                   loom_module_t* module,
                                                   loom_func_like_t function) {
-  if (!loom_kernel_resources_is_exported_device_function(function)) {
+  if (!loom_func_like_is_kernel_entry(function)) {
     return iree_ok_status();
   }
+  loom_region_t* body = loom_func_like_body(function);
+  if (!body) return iree_ok_status();
 
   uint16_t arg_count = 0;
   const loom_value_id_t* arg_ids = loom_func_like_arg_ids(function, &arg_count);
   if (arg_count == 0 || !arg_ids) return iree_ok_status();
 
-  loom_region_t* body = loom_func_like_body(function);
   loom_block_t* entry_block = loom_region_entry_block(body);
   loom_builder_t builder;
   loom_builder_initialize(module, &module->arena, entry_block, &builder);
@@ -118,9 +110,7 @@ iree_status_t loom_normalize_kernel_resources_run(loom_pass_t* pass,
   if (changed_function) {
     loom_kernel_resources_statistics_t* statistics =
         loom_kernel_resources_statistics(pass);
-    ++statistics->functions_normalized;
-  }
-  if (changed_function) {
+    ++statistics->kernel_entries_normalized;
     loom_pass_mark_changed(pass);
   }
   return iree_ok_status();

--- a/loom/src/loom/transforms/kernel/kernel_resources.h
+++ b/loom/src/loom/transforms/kernel/kernel_resources.h
@@ -6,10 +6,11 @@
 
 // Kernel resource ABI normalization.
 //
-// Exported device functions use ordered opaque buffer arguments as ABI resource
-// roots. Typed logical access must be made explicit inside the function body
-// via buffer.view so alias analyses and later slab-packing passes can reason
-// from a visible buffer root to every derived view.
+// Kernel entry definitions use ordered opaque buffer arguments as ABI resource
+// roots. Typed logical access must be made explicit inside the entry body via
+// buffer.view so alias analyses and later slab-packing passes can reason from a
+// visible buffer root to every derived view. Ordinary device functions retain
+// their authored callable signatures.
 
 #ifndef LOOM_TRANSFORMS_KERNEL_RESOURCES_H_
 #define LOOM_TRANSFORMS_KERNEL_RESOURCES_H_

--- a/loom/src/loom/transforms/kernel/test/kernel_resources.loom-test
+++ b/loom/src/loom/transforms/kernel/test/kernel_resources.loom-test
@@ -1,65 +1,48 @@
 // RUN: pass normalize-kernel-resources
 
-// Exported device function resource views normalize to ordered buffer ABI
-// roots plus explicit view derivations at the top of the body.
-func.def public device @independent_resources(%lhs: view<16xf32>, %rhs: view<16xf32>, %scale: f32) {
+// Kernel entry resource views normalize to ordered buffer ABI roots plus
+// explicit view derivations at the top of the body. Public device library
+// functions retain view signatures compatible with ordinary device callers.
+kernel.def @independent_resources() {
+  %c1 = index.constant 1 : index
+  kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
+} launch(%lhs: view<16xf32>, %rhs: view<16xf32>, %scale: f32) {
   %a = view.load %lhs[0] : view<16xf32> -> f32
   %b = view.load %rhs[1] : view<16xf32> -> f32
   test.use %a, %b, %scale : f32, f32, f32
-  func.return
+  kernel.return
+}
+
+func.def public device @library_value(%input: view<16xf32>) -> (f32) {
+  %value = view.load %input[0] : view<16xf32> -> f32
+  func.return %value : f32
+}
+
+func.def device @library_user(%input: view<16xf32>) -> (f32) {
+  %value = func.call @library_value(%input) : (view<16xf32>) -> (f32)
+  func.return %value : f32
 }
 
 // ----
-func.def public device @independent_resources(%lhs: buffer, %rhs: buffer, %scale: f32) {
-  %5 = index.constant 0 : offset
-  %6 = buffer.view %lhs[%5] : buffer -> view<16xf32>
-  %7 = buffer.view %rhs[%5] : buffer -> view<16xf32>
-  %a = view.load %6[0] : view<16xf32> -> f32
-  %b = view.load %7[1] : view<16xf32> -> f32
+kernel.def @independent_resources() {
+  %c1 = index.constant 1 : index
+  kernel.launch.config workgroups(%c1, %c1, %c1) workgroup_size(%c1, %c1, %c1) : index
+} launch(%lhs: buffer, %rhs: buffer, %scale: f32) {
+  %12 = index.constant 0 : offset
+  %13 = buffer.view %lhs[%12] : buffer -> view<16xf32>
+  %14 = buffer.view %rhs[%12] : buffer -> view<16xf32>
+  %a = view.load %13[0] : view<16xf32> -> f32
+  %b = view.load %14[1] : view<16xf32> -> f32
   test.use %a, %b, %scale : f32, f32, f32
-  func.return
+  kernel.return
 }
 
-// ====
-
-// Same-slab resources are already canonical: one ordered buffer root and
-// multiple explicit views derived from it preserve alias root identity.
-func.def public device @same_transient_slab(%slab: buffer, %offset_a: offset, %offset_b: offset) {
-  %layout = encoding.layout.dense : encoding<layout>
-  %a = buffer.view %slab[%offset_a] : buffer -> view<16xf32, %layout>
-  %b = buffer.view %slab[%offset_b] : buffer -> view<16xf32, %layout>
-  test.use %a, %b : view<16xf32, %layout>, view<16xf32, %layout>
-  func.return
+func.def public device @library_value(%input: view<16xf32>) -> (f32) {
+  %value = view.load %input[0] : view<16xf32> -> f32
+  func.return %value : f32
 }
 
-// ====
-
-// Parameters slabs use the same explicit root/view form; read-only behavior is
-// a fact of consuming ops and storage summaries, not a separate ABI kind.
-func.def public device @parameters_slab_read_views(%params: buffer, %weights_offset: offset, %scales_offset: offset, %row: index) {
-  %layout = encoding.layout.dense : encoding<layout>
-  %weights = buffer.view %params[%weights_offset] : buffer -> view<256xi8, %layout>
-  %scales = buffer.view %params[%scales_offset] : buffer -> view<16xf32, %layout>
-  %w = view.load %weights[%row] : view<256xi8, %layout> -> i8
-  %s = view.load %scales[0] : view<16xf32, %layout> -> f32
-  test.use %w, %s : i8, f32
-  func.return
-}
-
-// ====
-
-// Private device helpers may remain view-typed; this pass only normalizes
-// exported device ABI boundaries.
-func.def device @private_view_helper(%input: view<16xf32>) {
-  test.use %input : view<16xf32>
-  func.return
-}
-
-// ====
-
-// Public host functions are callable ABI boundaries but not device dispatch
-// resource boundaries, so view-typed args remain untouched here.
-func.def public host @public_host_view_helper(%input: view<16xf32>) {
-  test.use %input : view<16xf32>
-  func.return
+func.def device @library_user(%input: view<16xf32>) -> (f32) {
+  %value = func.call @library_value(%input) : (view<16xf32>) -> (f32)
+  func.return %value : f32
 }


### PR DESCRIPTION
Kernel resources now normalize from structural kernel-entry identity instead of inferring dispatchability from `public device` function attributes. `kernel.def` view parameters become ordered opaque `buffer` roots with explicit `buffer.view` derivations in the body, restoring the ABI normalization that became disconnected when kernels gained their own IR.

This preserves an important library boundary: `func.def public device` remains an ordinary callable device function. Its authored view signatures are not rewritten merely because the function is exported. A mixed regression keeps a public device function live through a typed device call while normalizing a neighboring kernel, so future changes cannot conflate public symbols with dispatch entries.
