### PR TITLE
[Loom] Defer global collision validation to materialization

### DIFF
--- a/loom/src/loom/link/index_materializer_test.cc
+++ b/loom/src/loom/link/index_materializer_test.cc
@@ -649,6 +649,37 @@ template.def<@demo.choose> priority(1) @slow(%x: i32) -> (i32) {
 }
 
 TEST_F(LinkIndexMaterializerTest,
+       ArchiveRejectsDuplicatePublicConcreteDefinitions) {
+  loom_module_t* first = Parse(IREE_SV(R"(
+func.def public @same(%x: i32) -> (i32) {
+  func.return %x : i32
+}
+)"),
+                               IREE_SV("first.loom"));
+  loom_module_t* second = Parse(IREE_SV(R"(
+func.def public @same(%x: i32) -> (i32) {
+  func.return %x : i32
+}
+)"),
+                                IREE_SV("second.loom"));
+  const std::vector<uint8_t> second_bytecode = WriteModule(second);
+
+  IndexPtr index = CreateIndex();
+  AddMaterialized(index.get(), first, IREE_SV("first"),
+                  LOOM_LINK_PROVIDER_ROLE_INPUT);
+  AddBytecode(index.get(), second_bytecode, IREE_SV("second"),
+              LOOM_LINK_PROVIDER_ROLE_INPUT);
+
+  loom_link_index_materialization_t materialization = {};
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_ALREADY_EXISTS,
+      TryMaterialize(index.get(), IREE_SV("@same"), LOOM_LINK_PLAN_ARCHIVE,
+                     LOOM_LINK_PLAN_UNRESOLVED_ERROR, &materialization));
+  EXPECT_EQ(materialization.plan, nullptr);
+  EXPECT_EQ(materialization.module, nullptr);
+}
+
+TEST_F(LinkIndexMaterializerTest,
        SelectsTransitiveDiamondOnceAcrossBytecodeLibraries) {
   loom_module_t* root = Parse(IREE_SV(R"(
 template.decl @demo.left(%x: i32) -> (i32)

--- a/loom/src/loom/link/module_index.c
+++ b/loom/src/loom/link/module_index.c
@@ -1817,29 +1817,3 @@ loom_link_module_index_template_family_at(
   }
   return &index->template_families.values[ordinal];
 }
-
-iree_status_t loom_link_module_index_duplicate_global_status(
-    const loom_link_module_index_t* index,
-    const loom_link_module_index_symbol_t* selected,
-    const loom_link_module_index_symbol_t* duplicate) {
-  IREE_ASSERT_ARGUMENT(index);
-  IREE_ASSERT_ARGUMENT(selected);
-  IREE_ASSERT_ARGUMENT(duplicate);
-  const loom_link_module_index_module_t* selected_module =
-      &index->modules.values[selected->module_ordinal];
-  const loom_link_module_index_module_t* duplicate_module =
-      &index->modules.values[duplicate->module_ordinal];
-  const loom_link_module_index_provider_t* selected_provider =
-      &index->providers.values[selected_module->provider_ordinal];
-  const loom_link_module_index_provider_t* duplicate_provider =
-      &index->providers.values[duplicate_module->provider_ordinal];
-  return iree_make_status(
-      IREE_STATUS_ALREADY_EXISTS,
-      "global symbol '@%.*s' selected from provider '%.*s' module '%.*s' "
-      "conflicts with provider '%.*s' module '%.*s'",
-      (int)selected->name.size, selected->name.data,
-      (int)selected_provider->name.size, selected_provider->name.data,
-      (int)selected_module->name.size, selected_module->name.data,
-      (int)duplicate_provider->name.size, duplicate_provider->name.data,
-      (int)duplicate_module->name.size, duplicate_module->name.data);
-}

--- a/loom/src/loom/link/module_index.h
+++ b/loom/src/loom/link/module_index.h
@@ -452,13 +452,6 @@ loom_link_module_index_template_family_at(
     const loom_link_module_index_t* index,
     loom_link_template_family_ordinal_t ordinal);
 
-// Returns a status that names the two provider locations for a duplicate
-// global symbol. This is a diagnostic helper for planner conflict reporting.
-iree_status_t loom_link_module_index_duplicate_global_status(
-    const loom_link_module_index_t* index,
-    const loom_link_module_index_symbol_t* selected,
-    const loom_link_module_index_symbol_t* duplicate);
-
 #ifdef __cplusplus
 }
 #endif

--- a/loom/src/loom/link/module_index_test.cc
+++ b/loom/src/loom/link/module_index_test.cc
@@ -42,19 +42,6 @@ std::string StringViewToString(iree_string_view_t value) {
   return std::string(value.data, value.size);
 }
 
-std::string StatusToStringAndFree(iree_status_t status) {
-  iree_allocator_t allocator = iree_allocator_system();
-  char* buffer = nullptr;
-  iree_host_size_t buffer_length = 0;
-  std::string result = iree_status_code_string(iree_status_code(status));
-  if (iree_status_to_string(status, &allocator, &buffer, &buffer_length)) {
-    result.assign(buffer, buffer_length);
-    iree_allocator_free(allocator, buffer);
-  }
-  iree_status_free(status);
-  return result;
-}
-
 class ModuleIndexTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -267,13 +254,6 @@ func.def public @entry(%x: i32) -> (i32) {
   EXPECT_EQ(loom_link_module_index_next_global_duplicate(index.get(),
                                                          second_duplicate),
             nullptr);
-
-  std::string diagnostic =
-      StatusToStringAndFree(loom_link_module_index_duplicate_global_status(
-          index.get(), selected, duplicate));
-  EXPECT_THAT(diagnostic, ::testing::HasSubstr("@entry"));
-  EXPECT_THAT(diagnostic, ::testing::HasSubstr("input"));
-  EXPECT_THAT(diagnostic, ::testing::HasSubstr("kernel-lib"));
 }
 
 TEST_F(ModuleIndexTest, ImportedDeclarationsHaveGlobalIdentity) {

--- a/loom/src/loom/link/plan_materializer.c
+++ b/loom/src/loom/link/plan_materializer.c
@@ -246,6 +246,61 @@ static iree_status_t loom_link_plan_materialize_module(
   return status;
 }
 
+// Recovers provider-level context after the canonical linker rejects two
+// selected concrete definitions. Collision recovery is deliberately confined
+// to the failing path: valid plans rely only on the target module's symbol map
+// and never maintain a second per-plan name-membership structure.
+static iree_status_t loom_link_plan_annotate_global_collision(
+    iree_status_t status, const loom_link_plan_t* plan,
+    const loom_link_module_index_t* index,
+    const loom_link_plan_module_selection_t* selection) {
+  if (iree_status_code(status) != IREE_STATUS_ALREADY_EXISTS) {
+    return status;
+  }
+
+  for (iree_host_size_t i = 0; i < selection->symbols.count; ++i) {
+    const loom_link_module_index_symbol_t* symbol =
+        selection->symbols.values[i].source_symbol;
+    if (symbol->identity != LOOM_LINK_SYMBOL_IDENTITY_GLOBAL ||
+        !iree_any_bit_set(symbol->flags,
+                          LOOM_LINK_SYMBOL_FLAG_CONCRETE_DEFINITION)) {
+      continue;
+    }
+
+    const loom_link_module_index_symbol_t* previous =
+        loom_link_module_index_lookup_name(index, symbol->name);
+    while (previous) {
+      const bool is_prior_selected_definition =
+          previous->module_ordinal < symbol->module_ordinal &&
+          previous->identity == LOOM_LINK_SYMBOL_IDENTITY_GLOBAL &&
+          iree_any_bit_set(previous->flags,
+                           LOOM_LINK_SYMBOL_FLAG_CONCRETE_DEFINITION) &&
+          loom_link_plan_contains_symbol(plan, previous->ordinal);
+      if (is_prior_selected_definition) {
+        const loom_link_module_index_module_t* previous_module =
+            loom_link_module_index_symbol_module(index, previous);
+        const loom_link_module_index_provider_t* previous_provider =
+            loom_link_module_index_symbol_provider(index, previous);
+        const loom_link_module_index_module_t* current_module =
+            loom_link_module_index_symbol_module(index, symbol);
+        const loom_link_module_index_provider_t* current_provider =
+            loom_link_module_index_symbol_provider(index, symbol);
+        return iree_status_annotate_f(
+            status,
+            "global symbol '@%.*s' selected from provider '%.*s' module "
+            "'%.*s' conflicts with provider '%.*s' module '%.*s'",
+            (int)previous->name.size, previous->name.data,
+            (int)previous_provider->name.size, previous_provider->name.data,
+            (int)previous_module->name.size, previous_module->name.data,
+            (int)current_provider->name.size, current_provider->name.data,
+            (int)current_module->name.size, current_module->name.data);
+      }
+      previous = loom_link_module_index_next_same_name(index, previous);
+    }
+  }
+  return status;
+}
+
 static iree_status_t loom_link_plan_materialize_modules(
     const loom_link_plan_t* plan, const loom_link_module_index_t* index,
     const loom_link_plan_module_projection_t* projection,
@@ -283,6 +338,10 @@ static iree_status_t loom_link_plan_materialize_modules(
         source_symbol_ordinals, source_symbol_outputs, module_target_symbols,
         target_symbols, target_template_families, target_kernel_configurations,
         linker);
+    if (!iree_status_is_ok(status)) {
+      status = loom_link_plan_annotate_global_collision(
+          status, plan, index, &projection->modules.values[i]);
+    }
   }
   return status;
 }

--- a/loom/src/loom/link/planner.c
+++ b/loom/src/loom/link/planner.c
@@ -421,20 +421,6 @@ static bool loom_link_plan_symbol_is_stripped(
                                symbol);
 }
 
-static bool loom_link_plan_symbol_is_concrete_global(
-    const loom_link_module_index_symbol_t* symbol) {
-  if (symbol->identity != LOOM_LINK_SYMBOL_IDENTITY_GLOBAL) {
-    return false;
-  }
-  if (iree_any_bit_set(symbol->flags, LOOM_LINK_SYMBOL_FLAG_DECLARATION |
-                                          LOOM_LINK_SYMBOL_FLAG_IMPORT |
-                                          LOOM_LINK_SYMBOL_FLAG_CONFIG)) {
-    return false;
-  }
-  return iree_any_bit_set(symbol->flags,
-                          LOOM_LINK_SYMBOL_FLAG_CONCRETE_DEFINITION);
-}
-
 static bool loom_link_plan_symbol_is_declaration_like(
     const loom_link_module_index_symbol_t* symbol) {
   return iree_any_bit_set(symbol->flags, LOOM_LINK_SYMBOL_FLAG_DECLARATION |
@@ -583,36 +569,12 @@ static iree_status_t loom_link_plan_find_imported_symbol_for_declaration(
   return iree_ok_status();
 }
 
-static iree_status_t loom_link_plan_check_concrete_global_collision(
-    const loom_link_plan_t* plan,
-    const loom_link_module_index_symbol_t* symbol) {
-  if (!loom_link_plan_symbol_is_concrete_global(symbol)) {
-    return iree_ok_status();
-  }
-  const loom_link_module_index_symbol_t* candidate =
-      loom_link_module_index_lookup_name(plan->index, symbol->name);
-  while (candidate) {
-    if (candidate != symbol &&
-        loom_link_plan_symbol_is_concrete_global(candidate) &&
-        loom_link_plan_bitmap_contains(&plan->reachability.symbols,
-                                       candidate->ordinal)) {
-      return loom_link_module_index_duplicate_global_status(plan->index,
-                                                            candidate, symbol);
-    }
-    candidate = loom_link_module_index_next_same_name(plan->index, candidate);
-  }
-  return iree_ok_status();
-}
-
 // Appends one newly selected symbol.
 static iree_status_t loom_link_plan_append_symbol(
     loom_link_plan_t* plan, const loom_link_module_index_symbol_t* symbol,
     loom_link_plan_live_cause_t cause, iree_host_size_t* out_plan_ordinal) {
   IREE_ASSERT(!loom_link_plan_bitmap_contains(&plan->reachability.symbols,
                                               symbol->ordinal));
-  IREE_RETURN_IF_ERROR(
-      loom_link_plan_check_concrete_global_collision(plan, symbol));
-
   const iree_host_size_t plan_ordinal = plan->symbols.count;
   iree_host_size_t symbol_count = 0;
   if (!iree_host_size_checked_add(plan_ordinal, 1, &symbol_count)) {

--- a/loom/src/loom/link/planner.h
+++ b/loom/src/loom/link/planner.h
@@ -7,8 +7,8 @@
 // Metadata-first link planner.
 //
 // The planner consumes a provider-backed module index and produces an ordered
-// live-symbol selection. Materialization and cloning remain the responsibility
-// of the incremental linker sink.
+// live-symbol selection. Materialization, cloning, and definition contract
+// merging remain the responsibility of the incremental linker sink.
 
 #ifndef LOOM_LINK_PLANNER_H_
 #define LOOM_LINK_PLANNER_H_

--- a/loom/src/loom/link/planner_benchmark.cc
+++ b/loom/src/loom/link/planner_benchmark.cc
@@ -732,6 +732,48 @@ static void BM_Plan_InputExport_UnrelatedLibraryProviders(
   loom_link_module_index_free(index);
 }
 
+static void BM_Plan_InputExport_SameNameLibraryAlternatives(
+    benchmark::State& state) {
+  const uint32_t library_alternative_count = (uint32_t)state.range(0);
+  PlannerCatalogFixture fixture(/*symbol_count=*/1);
+  loom_link_module_index_t* index =
+      fixture.BuildDuplicateIndex(library_alternative_count + 1);
+  const loom_link_plan_options_t options = {
+      /*.mode=*/LOOM_LINK_PLAN_SELECTIVE,
+      /*.root_symbols=*/iree_string_view_list_empty(),
+      /*.include_input_exports=*/true,
+  };
+
+  for (auto _ : state) {
+    loom_link_plan_t* plan = nullptr;
+    CheckStatus(
+        loom_link_plan_build(index, &options, iree_allocator_system(), &plan));
+    if (loom_link_plan_symbol_count(plan) != 1) {
+      std::abort();
+    }
+    const loom_link_plan_symbol_t* root = loom_link_plan_symbol_at(plan, 0);
+    const loom_link_module_index_symbol_t* symbol =
+        loom_link_module_index_symbol_at(index, root->symbol_ordinal);
+    const loom_link_module_index_provider_t* provider =
+        loom_link_module_index_symbol_provider(index, symbol);
+    if (!provider || provider->role != LOOM_LINK_PROVIDER_ROLE_INPUT) {
+      std::abort();
+    }
+    benchmark::DoNotOptimize(plan);
+    state.PauseTiming();
+    loom_link_plan_free(plan);
+    state.ResumeTiming();
+  }
+  state.counters["library_alternatives"] =
+      static_cast<double>(library_alternative_count);
+  state.counters["providers"] =
+      static_cast<double>(library_alternative_count + 1);
+  state.counters["requester_exports"] = 1.0;
+  state.counters["selected_symbols"] = 1.0;
+  state.SetComplexityN(library_alternative_count);
+  loom_link_module_index_free(index);
+}
+
 static void BM_Plan_ImportedCandidateResolution(benchmark::State& state) {
   const uint32_t candidate_count = (uint32_t)state.range(0);
   ImportedCandidateFixture fixture(candidate_count);
@@ -1366,6 +1408,9 @@ BENCHMARK(BM_Plan_Archive_Catalog)->Apply(CatalogScales)->Complexity();
 BENCHMARK(BM_Plan_SelectiveLeaf_Catalog)->Apply(CatalogScales)->Complexity();
 BENCHMARK(BM_Plan_SelectiveChain_Catalog)->Apply(CatalogScales)->Complexity();
 BENCHMARK(BM_Plan_InputExport_UnrelatedLibraryProviders)
+    ->Apply(CatalogScales)
+    ->Complexity(benchmark::o1);
+BENCHMARK(BM_Plan_InputExport_SameNameLibraryAlternatives)
     ->Apply(CatalogScales)
     ->Complexity(benchmark::o1);
 BENCHMARK(BM_Plan_ImportedCandidateResolution)

--- a/loom/src/loom/link/planner_test.cc
+++ b/loom/src/loom/link/planner_test.cc
@@ -1816,30 +1816,6 @@ func.def public @unused(%x: i32) -> (i32) {
   EXPECT_EQ(loom_link_plan_symbol_count(plan.get()), 1u);
 }
 
-TEST_F(LinkPlannerTest, ArchiveRejectsDuplicatePublicConcreteDefinitions) {
-  loom_module_t* first = Parse(IREE_SV(R"(
-func.def public @same(%x: i32) -> (i32) {
-  func.return %x : i32
-}
-)"));
-  loom_module_t* second = Parse(IREE_SV(R"(
-func.def public @same(%x: i32) -> (i32) {
-  func.return %x : i32
-}
-)"));
-
-  IndexPtr index = CreateIndex();
-  AddMaterialized(index.get(), first, IREE_SV("first"),
-                  LOOM_LINK_PROVIDER_ROLE_INPUT);
-  AddMaterialized(index.get(), second, IREE_SV("second"),
-                  LOOM_LINK_PROVIDER_ROLE_INPUT);
-
-  PlanPtr plan;
-  IREE_EXPECT_STATUS_IS(
-      IREE_STATUS_ALREADY_EXISTS,
-      BuildPlanStatus(index.get(), /*options=*/nullptr, &plan));
-}
-
 TEST_F(LinkPlannerTest, InputExportsDoNotRootLibraryAlternatives) {
   loom_module_t* harness = Parse(IREE_SV(R"(
 func.decl public @same(%x: i32) -> (i32)


### PR DESCRIPTION
Metadata-only link planning now scales with the symbols selected into a JIT product instead of the number of same-name alternatives available across its libraries. A requester can select one exported implementation while thousands of unselected providers advertise the same public name without charging that provider diversity to every planning job.

The planner previously validated concrete-definition collisions by walking the module index's complete same-name chain whenever it selected a global. That mixed two ownership boundaries: planning determines reachability and provider choice, while the incremental linker already owns the canonical target symbol map and the complete declaration/definition/value merge policy. It also made the common valid path inspect definitions that were never selected.

This change removes collision validation and its diagnostic helper from metadata planning. Materialization streams the selected closure through the incremental linker as before, and the linker's required target-symbol lookup now performs the only definition merge validation. A genuine collision still reports both provider and module locations; that richer attribution is recovered from the existing plan and module index only after the linker has returned an error. Valid plans allocate no collision table, initialize no dense membership state, perform no additional sort, and never walk an unselected same-name chain.

The API boundary is consequently explicit: `loom_link_plan_build` produces an ordered live-symbol selection, while materialization validates whether those selected definitions compose. Production index-linking workflows already cross both stages. Regression coverage exercises the complete materialized-plus-bytecode path so duplicate rejection is tested at the layer that owns it.

| Same-name library alternatives | Before | After | Speedup |
| ---: | ---: | ---: | ---: |
| 1 | 0.706 µs | 0.690 µs | 1.02× |
| 16 | 0.755 µs | 0.682 µs | 1.11× |
| 64 | 0.873 µs | 0.675 µs | 1.29× |
| 512 | 2.310 µs | 0.699 µs | 3.31× |
| 4,096 | 13.243 µs | 0.737 µs | 18.0× |

At 4,096 alternatives, planning is only 6.8% above the one-alternative floor. The final composition is also faster than the rejected plan-local hash-table design, which measured 0.842 µs at the same scale, because it adds no parallel identity structure to the hot path.
