### PR TITLE
[CI] Raise the GPU test job timeout above artifact download time

### DIFF
--- a/.github/workflows/test_core_linux_gpu.yml
+++ b/.github/workflows/test_core_linux_gpu.yml
@@ -87,7 +87,7 @@ jobs:
   test_core_linux_gpu:
     name: ${{ inputs.name || 'Linux / CMake / GPU gfx942' }}
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     env:
       HRX_OUTPUT_DIR: ${{ github.workspace }}/build/linux-gpu
       HRX_ARTIFACT_DOWNLOAD_DIR: ${{ github.workspace }}/build/linux-gpu/artifacts


### PR DESCRIPTION
`Test CMake Linux GPU` gives its job a 20 minute budget, and the job spends most of that budget downloading `hrx-tests-linux-x86_64` before it runs a single test. That artifact is 2.01 GiB today, and the slowest transfer of it ever observed to finish on the `linux-gfx942-1gpu-ccs-csp-ossci-rocm` pool ran at 1.66 MB/s (1,923,387,866 bytes in 19m17s on 2026-08-13). At that rate today's artifact needs 21m36s by itself, which is already more than the whole job budget before checkout, the venv, extraction, or a single test — and core Linux CI on `main` has concluded `cancelled` on 60 of its last 90 push runs, every one of them a GPU job hitting this wall.

Over the 81 `Linux / CMake / GPU gfx942` job runs triggered by pushes to `main` between 2026-08-11 and 2026-08-27, 59 were cancelled: 58 between 20m02s and 20m16s of wall time and one at 21m53s where cancel delivery lagged, so the configured budget rather than a random stall. 57 of the 59 died inside the `Download test package artifact` step, whose log goes quiet after `Starting download of artifact to: ...` and picks up minutes later at `##[error]The operation was canceled.`, with no ctest output anywhere in the job. The other two got the artifact after 18m17s and 19m17s and were then cut off partway through `ctest`. The work being protected is small: across the 22 runs that finished, the test step takes 43 to 53 seconds and `ctest` reports 94 to 105 tests passing in 34 to 43 seconds.

30 minutes leaves 26 to 28 minutes for the transfer, depending on how slow the rest of the job is that day — non-download overhead is 1m14s to 1m55s across the 22 finished runs, and closer to 4 minutes on a day when checkout and pip are crawling too. That clears the 21m36s projection with minutes to spare while still bounding a hung test at a wall worth having, given the test step normally runs under a minute; 25 would not clear it. The honest limit on this evidence is that 57 of the 59 transfer measurements are truncated by the very timeout being changed, four of them still running past 19m17s when they were killed, so 30 is sized from the slowest transfer that actually completed projected onto today's artifact, not from a measured maximum.

This gives the job time to finish; it does not make the transfer faster. The same bytes move in a median of 64 seconds on the gfx1201 pool, so what is slow here is this pool's throughput rather than the artifact's size. `Linux / CMake / GPU gfx1201` is the same job definition with different runner labels and is covered by the same change; its one cancellation in this window came from `ctest` hitting the default 60 second per-test timeout over and over on that runner rather than from a slow download, which this change does not address and which will now have 30 minutes rather than 20 to burn if it recurs.
