### PR TITLE
[HAL/AMDGPU] Add fixed masked execution queues

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
@@ -147,11 +147,49 @@ iree_runtime_cc_library(
     ],
 )
 
+# CMake has no target visibility equivalent. Define an in-tree interface target
+# directly because iree_cc_library installs every non-test header target.
+iree_cmake_extra_content(
+    content = """
+if(IREE_HAL_DRIVER_AMDGPU)
+add_library(iree_hal_drivers_amdgpu_api_experimental INTERFACE)
+target_sources(iree_hal_drivers_amdgpu_api_experimental
+  INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api_experimental.h>"
+)
+target_link_libraries(iree_hal_drivers_amdgpu_api_experimental
+  INTERFACE
+    iree::base
+    iree::hal
+)
+iree_add_alias_library(
+  iree::hal::drivers::amdgpu::api_experimental
+  iree_hal_drivers_amdgpu_api_experimental
+)
+endif()
+""",
+    inline = True,
+)
+
+# Restricted experimental declarations are exposed only to in-tree libhrx
+# consumers and remain outside the installed AMDGPU API surface.
+iree_runtime_cc_library(
+    name = "api_experimental",
+    hdrs = ["api_experimental.h"],
+    tags = ["skip-bazel_to_cmake"],
+    visibility = ["//libhrx:__subpackages__"],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+    ],
+)
+
 iree_runtime_cc_library(
     name = "amdgpu",
     srcs = [
         "allocator.c",
         "allocator.h",
+        "api_experimental.h",
         "aql_atomic.c",
         "aql_atomic.h",
         "aql_block_processor.c",
@@ -601,6 +639,23 @@ iree_runtime_cc_test(
 )
 
 iree_runtime_cc_test(
+    name = "api_experimental_test",
+    srcs = ["api_experimental_test.cc"],
+    deps = [
+        ":amdgpu",
+        ":api_experimental",
+        ":headers",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/hal/cts/util:profile_test_util",
+        "//runtime/src/iree/hal/cts/util:test_base",
+        "//runtime/src/iree/hal/testing:mock_device",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+iree_runtime_cc_test(
     name = "driver_options_test",
     srcs = ["driver_options_test.cc"],
     deps = [
@@ -686,6 +741,7 @@ iree_runtime_cc_test(
     ],
     deps = [
         ":amdgpu",
+        ":api_experimental",
         ":headers",
         "//runtime/src/iree/base",
         "//runtime/src/iree/hal",

--- a/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/BUILD.bazel
@@ -649,6 +649,7 @@ iree_runtime_cc_test(
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/cts/util:profile_test_util",
         "//runtime/src/iree/hal/cts/util:test_base",
+        "//runtime/src/iree/hal/drivers/amdgpu/util:queue_primitives",
         "//runtime/src/iree/hal/testing:mock_device",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",

--- a/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
@@ -186,6 +186,23 @@ iree_cc_library(
 endif()
 
 if(IREE_HAL_DRIVER_AMDGPU)
+add_library(iree_hal_drivers_amdgpu_api_experimental INTERFACE)
+target_sources(iree_hal_drivers_amdgpu_api_experimental
+  INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api_experimental.h>"
+)
+target_link_libraries(iree_hal_drivers_amdgpu_api_experimental
+  INTERFACE
+    iree::base
+    iree::hal
+)
+iree_add_alias_library(
+  iree::hal::drivers::amdgpu::api_experimental
+  iree_hal_drivers_amdgpu_api_experimental
+)
+endif()
+
+if(IREE_HAL_DRIVER_AMDGPU)
 iree_cc_library(
   NAME
     amdgpu
@@ -194,6 +211,7 @@ iree_cc_library(
   SRCS
     "allocator.c"
     "allocator.h"
+    "api_experimental.h"
     "aql_atomic.c"
     "aql_atomic.h"
     "aql_block_processor.c"
@@ -738,6 +756,32 @@ endif()
 if(IREE_HAL_DRIVER_AMDGPU)
 iree_cc_test(
   NAME
+    api_experimental_test
+  SRCS
+    "api_experimental_test.cc"
+  DEPS
+    ::amdgpu
+    ::api_experimental
+    ::headers
+    iree::base
+    iree::hal
+    iree::hal::cts::util::profile_test_util
+    iree::hal::cts::util::test_base
+    iree::hal::testing::mock_device
+    iree::testing::gtest
+    iree::testing::gtest_main
+  LABELS
+    "iree-build-requirement=runtime.hal.amdgpu"
+    "iree-run-requirement=runtime.resource.amd_gpu"
+    "runtime-resource=amd-gpu"
+  RESOURCE_GROUP
+    iree-hal-drivers-amdgpu-tests
+)
+endif()
+
+if(IREE_HAL_DRIVER_AMDGPU)
+iree_cc_test(
+  NAME
     driver_options_test
   SRCS
     "driver_options_test.cc"
@@ -862,6 +906,7 @@ iree_cc_test(
     "host_queue_command_buffer_test_util.h"
   DEPS
     ::amdgpu
+    ::api_experimental
     ::headers
     iree::base
     iree::hal

--- a/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/CMakeLists.txt
@@ -767,6 +767,7 @@ iree_cc_test(
     iree::hal
     iree::hal::cts::util::profile_test_util
     iree::hal::cts::util::test_base
+    iree::hal::drivers::amdgpu::util::queue_primitives
     iree::hal::testing::mock_device
     iree::testing::gtest
     iree::testing::gtest_main

--- a/runtime/src/iree/hal/drivers/amdgpu/api.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/api.h
@@ -256,6 +256,11 @@ typedef struct iree_hal_amdgpu_logical_device_options_t {
     // metadata such as device-side command-buffer fixup inputs without using
     // the file staging pool.
     uint32_t upload_capacity;
+    // Number of additional fixed physical queues reserved for the restricted
+    // execution-queue compatibility API, up to 64. These queues are absent
+    // from the ordinary provisioned queue inventory and are created only after
+    // a caller binds one immutable execution-unit mask.
+    uint32_t experimental_execution_queue_count;
   } host_queues;
 
   // Per-physical-device queue_read/queue_write file staging policy.

--- a/runtime/src/iree/hal/drivers/amdgpu/api_experimental.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/api_experimental.h
@@ -29,7 +29,8 @@ typedef struct iree_hal_amdgpu_experimental_execution_queue_topology_t {
   iree_host_size_t private_physical_queue_count;
   // Number of native compute units addressable by an HSA queue mask.
   uint32_t native_compute_unit_count;
-  // Required alignment of enabled native CU runs in mask bits.
+  // Native mask group size and alignment in bits. Groups begin at bit zero and
+  // must each be wholly enabled or wholly disabled.
   uint32_t native_compute_unit_mask_alignment;
   // Number of hardware partitions interleaved across native mask bits. Native
   // bit N belongs to partition N modulo this count, and a confining mask must
@@ -54,19 +55,20 @@ iree_hal_amdgpu_experimental_execution_queue_query(
 // a queue, share equal masks, or recycle the queue for another mask.
 //
 // The mask must describe the selected physical device's complete native
-// execution-unit domain. The queue is created normally and the mask is applied
-// before the queue is published to any submitter. ROCr may reject masks it
-// cannot represent exactly. In particular, each interleaved hardware partition
-// reported by the topology must retain at least one enabled compute unit to
-// avoid queue non-progress. A process-wide HSA_CU_MASK is incompatible with
-// this exact-mask interface. Any
-// failure destroys the unpublished queue. On success |out_queue| receives the
-// exact masked queue. The returned pointer is borrowed from |device| and stays
-// valid until device teardown. The queue remains bound to the mask until then;
-// once configuration succeeds, every later attempt for that queue fails,
-// including one with an equal mask. Failed creation leaves the slot
-// unconfigured and may be retried. The caller owns all mapping, sharing,
-// capacity, and reuse policy above this boundary.
+// execution-unit domain. Each alignment-sized group reported by the topology,
+// beginning at native bit zero, must be wholly enabled or wholly disabled. The
+// queue is created normally and the mask is applied before the queue is
+// published to any submitter. ROCr may reject masks it cannot represent
+// exactly. In particular, each interleaved hardware partition reported by the
+// topology must retain at least one enabled compute unit to avoid queue
+// non-progress. A process-wide HSA_CU_MASK is incompatible with this exact-mask
+// interface. Any failure destroys the unpublished queue. On success |out_queue|
+// receives the exact masked queue. The returned pointer is borrowed from
+// |device| and stays valid until device teardown. The queue remains bound to
+// the mask until then; once configuration succeeds, every later attempt for
+// that queue fails, including one with an equal mask. Failed creation leaves
+// the slot unconfigured and may be retried. The caller owns all mapping,
+// sharing, capacity, and reuse policy above this boundary.
 IREE_API_EXPORT iree_status_t
 iree_hal_amdgpu_experimental_execution_queue_configure(
     iree_hal_device_t* device, iree_host_size_t physical_device_ordinal,

--- a/runtime/src/iree/hal/drivers/amdgpu/api_experimental.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/api_experimental.h
@@ -1,0 +1,81 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_DRIVERS_AMDGPU_API_EXPERIMENTAL_H_
+#define IREE_HAL_DRIVERS_AMDGPU_API_EXPERIMENTAL_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Temporary native AMDGPU bridge for libhrx HIP execution contexts.
+//
+// This restricted API accepts only an exact native in-process AMDGPU logical
+// device. It has no replay, remoting, or cross-backend representation and is
+// not a supported HAL extension. The AMDGPU queue replacement is expected to
+// delete it rather than preserve its shape.
+
+// Native queue topology required to provision an exact HSA queue mask.
+typedef struct iree_hal_amdgpu_experimental_execution_queue_topology_t {
+  // First physical queue ordinal reserved for caller-managed execution queues.
+  iree_host_size_t first_private_physical_queue_ordinal;
+  // Number of consecutive caller-managed physical queue ordinals.
+  iree_host_size_t private_physical_queue_count;
+  // Number of native compute units addressable by an HSA queue mask.
+  uint32_t native_compute_unit_count;
+  // Required alignment of enabled native CU runs in mask bits.
+  uint32_t native_compute_unit_mask_alignment;
+  // Number of hardware partitions interleaved across native mask bits. Native
+  // bit N belongs to partition N modulo this count, and a confining mask must
+  // enable at least one compute unit in every partition.
+  uint32_t native_compute_unit_mask_partition_count;
+} iree_hal_amdgpu_experimental_execution_queue_topology_t;
+
+// Queries the fixed queue range and execution-unit topology for one physical
+// device. |device| must be an exact native in-process AMDGPU logical device.
+// The returned facts are immutable for the logical-device lifetime.
+IREE_API_EXPORT iree_status_t
+iree_hal_amdgpu_experimental_execution_queue_query(
+    iree_hal_device_t* device, iree_host_size_t physical_device_ordinal,
+    iree_hal_amdgpu_experimental_execution_queue_topology_t* out_topology);
+
+// Binds one caller-selected fixed physical execution queue to an immutable
+// native compute-unit mask.
+//
+// |physical_device_ordinal| selects an exact physical device in |device|.
+// |physical_queue_ordinal| selects an exact queue in the private range returned
+// by iree_hal_amdgpu_experimental_execution_queue_query. AMDGPU does not choose
+// a queue, share equal masks, or recycle the queue for another mask.
+//
+// The mask must describe the selected physical device's complete native
+// execution-unit domain. The queue is created normally and the mask is applied
+// before the queue is published to any submitter. ROCr may reject masks it
+// cannot represent exactly. In particular, each interleaved hardware partition
+// reported by the topology must retain at least one enabled compute unit to
+// avoid queue non-progress. A process-wide HSA_CU_MASK is incompatible with
+// this exact-mask interface. Any
+// failure destroys the unpublished queue. On success |out_queue| receives the
+// exact masked queue. The returned pointer is borrowed from |device| and stays
+// valid until device teardown. The queue remains bound to the mask until then;
+// once configuration succeeds, every later attempt for that queue fails,
+// including one with an equal mask. Failed creation leaves the slot
+// unconfigured and may be retried. The caller owns all mapping, sharing,
+// capacity, and reuse policy above this boundary.
+IREE_API_EXPORT iree_status_t
+iree_hal_amdgpu_experimental_execution_queue_configure(
+    iree_hal_device_t* device, iree_host_size_t physical_device_ordinal,
+    iree_host_size_t physical_queue_ordinal,
+    iree_host_size_t native_mask_bit_count, const uint32_t* native_mask,
+    iree_hal_queue_t** out_queue);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_AMDGPU_API_EXPERIMENTAL_H_

--- a/runtime/src/iree/hal/drivers/amdgpu/api_experimental_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/api_experimental_test.cc
@@ -96,6 +96,113 @@ static hsa_status_t HSA_API RejectQueueCuMask(const hsa_queue_t* queue,
   (void)mask;
   return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 }
+
+static decltype(iree_hal_amdgpu_libhsa_t::hsa_agent_get_info)
+    native_aql_agent_get_info_delegate = nullptr;
+
+static hsa_status_t HSA_API NativeAqlAgentGetInfo(hsa_agent_t agent,
+                                                  hsa_agent_info_t attribute,
+                                                  void* value) {
+  if (attribute == (hsa_agent_info_t)HSA_AMD_AGENT_INFO_PM4_EMULATION) {
+    *static_cast<bool*>(value) = false;
+    return HSA_STATUS_SUCCESS;
+  }
+  return native_aql_agent_get_info_delegate(agent, attribute, value);
+}
+
+class ScopedNativeAqlLibhsa {
+ public:
+  ScopedNativeAqlLibhsa() = default;
+
+  ~ScopedNativeAqlLibhsa() {
+    if (!initialized_) return;
+    native_aql_agent_get_info_delegate = previous_agent_get_info_delegate_;
+    iree_hal_amdgpu_libhsa_deinitialize(&libhsa_);
+  }
+
+  iree_status_t Initialize(const iree_hal_amdgpu_libhsa_t* source_libhsa) {
+    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_libhsa_copy(source_libhsa, &libhsa_));
+    previous_agent_get_info_delegate_ = native_aql_agent_get_info_delegate;
+    native_aql_agent_get_info_delegate = libhsa_.hsa_agent_get_info;
+    libhsa_.hsa_agent_get_info = NativeAqlAgentGetInfo;
+    initialized_ = true;
+    return iree_ok_status();
+  }
+
+  const iree_hal_amdgpu_libhsa_t* libhsa() const { return &libhsa_; }
+
+  ScopedNativeAqlLibhsa(const ScopedNativeAqlLibhsa&) = delete;
+  ScopedNativeAqlLibhsa& operator=(const ScopedNativeAqlLibhsa&) = delete;
+
+ private:
+  bool initialized_ = false;
+  iree_hal_amdgpu_libhsa_t libhsa_ = {};
+  decltype(iree_hal_amdgpu_libhsa_t::hsa_agent_get_info)
+      previous_agent_get_info_delegate_ = nullptr;
+};
+
+class ScopedAgentTargetVersionOverride {
+ public:
+  ScopedAgentTargetVersionOverride(
+      iree_hal_amdgpu_physical_device_t* physical_device,
+      iree_hal_amdgpu_gfxip_version_t version)
+      : physical_device_(physical_device),
+        original_agent_target_(physical_device->agent_target),
+        agent_target_(*original_agent_target_) {
+    agent_target_.primary_isa.identity.version = version;
+    physical_device_->agent_target = &agent_target_;
+  }
+
+  ~ScopedAgentTargetVersionOverride() {
+    physical_device_->agent_target = original_agent_target_;
+  }
+
+  ScopedAgentTargetVersionOverride(const ScopedAgentTargetVersionOverride&) =
+      delete;
+  ScopedAgentTargetVersionOverride& operator=(
+      const ScopedAgentTargetVersionOverride&) = delete;
+
+ private:
+  iree_hal_amdgpu_physical_device_t* physical_device_;
+  const iree_hal_amdgpu_agent_target_t* original_agent_target_;
+  iree_hal_amdgpu_agent_target_t agent_target_;
+};
+
+static uint32_t queue_create_probe_call_count = 0;
+
+static hsa_status_t HSA_API
+ProbeQueueCreate(hsa_agent_t, uint32_t, hsa_queue_type32_t,
+                 void (*)(hsa_status_t, hsa_queue_t*, void*), void*, uint32_t,
+                 uint32_t, hsa_queue_t** queue) {
+  ++queue_create_probe_call_count;
+  *queue = nullptr;
+  return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+}
+
+class ScopedQueueCreateProbe {
+ public:
+  explicit ScopedQueueCreateProbe(
+      iree_hal_amdgpu_logical_device_t* logical_device)
+      : libhsa_(&logical_device->system->libhsa),
+        original_queue_create_(libhsa_->hsa_queue_create) {
+    queue_create_probe_call_count = 0;
+    libhsa_->hsa_queue_create = ProbeQueueCreate;
+  }
+
+  ~ScopedQueueCreateProbe() {
+    libhsa_->hsa_queue_create = original_queue_create_;
+  }
+
+  ScopedQueueCreateProbe(const ScopedQueueCreateProbe&) = delete;
+  ScopedQueueCreateProbe& operator=(const ScopedQueueCreateProbe&) = delete;
+
+  uint32_t call_count() const { return queue_create_probe_call_count; }
+  void ResetCallCount() { queue_create_probe_call_count = 0; }
+
+ private:
+  iree_hal_amdgpu_libhsa_t* libhsa_;
+  decltype(iree_hal_amdgpu_libhsa_t::hsa_queue_create) original_queue_create_;
+};
 #endif  // !IREE_HAL_AMDGPU_LIBHSA_STATIC
 
 iree_status_t SubmitFillAndWait(iree_hal_device_t* device,
@@ -353,6 +460,151 @@ TEST_F(AmdgpuExperimentalApiTest,
       valid_mask.size() * 32u, valid_mask.data(), &queue));
   ASSERT_NE(queue, nullptr);
   IREE_EXPECT_OK(SubmitFillAndWait(test_device.device(), queue));
+}
+
+TEST_F(AmdgpuExperimentalApiTest,
+       RejectsMisalignedNativeComputeUnitGroupsBeforeQueueCreation) {
+#if IREE_HAL_AMDGPU_LIBHSA_STATIC
+  GTEST_SKIP() << "deterministic HSA queue injection requires dynamic libhsa";
+#else
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.host_queues.experimental_execution_queue_count = 1;
+  ScopedNativeAqlLibhsa native_aql_libhsa;
+  IREE_ASSERT_OK(native_aql_libhsa.Initialize(&libhsa_));
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(&options, native_aql_libhsa.libhsa()));
+
+  iree_hal_amdgpu_logical_device_t* logical_device =
+      test_device.logical_device();
+  iree_hal_amdgpu_physical_device_t* physical_device =
+      logical_device->physical_devices[0];
+  const iree_hal_amdgpu_gfxip_version_t gfx10_version = {
+      .major = 10,
+      .minor = 0,
+      .stepping = 0,
+  };
+  ScopedAgentTargetVersionOverride target_override(physical_device,
+                                                   gfx10_version);
+
+  iree_hal_amdgpu_experimental_execution_queue_topology_t queue_topology;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_query(
+      test_device.device(), /*physical_device_ordinal=*/0, &queue_topology));
+  ASSERT_EQ(queue_topology.native_compute_unit_mask_alignment, 2u);
+  if (queue_topology.native_compute_unit_mask_partition_count >=
+      queue_topology.native_compute_unit_count) {
+    GTEST_SKIP() << "device is too small to clear one bit while preserving "
+                    "every hardware partition";
+  }
+
+  std::vector<uint32_t> aligned_mask =
+      MakeFullNativeMask(queue_topology.native_compute_unit_count);
+  std::vector<uint32_t> misaligned_mask = aligned_mask;
+  misaligned_mask[0] &= ~UINT32_C(1);
+  const iree_host_size_t private_queue_ordinal =
+      queue_topology.first_private_physical_queue_ordinal;
+  const iree_host_size_t initial_host_queue_count =
+      physical_device->host_queue_count;
+  ScopedQueueCreateProbe queue_create_probe(logical_device);
+
+  iree_hal_queue_t* queue = reinterpret_cast<iree_hal_queue_t*>(uintptr_t{1});
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_hal_amdgpu_experimental_execution_queue_configure(
+                            test_device.device(), /*physical_device_ordinal=*/0,
+                            private_queue_ordinal, misaligned_mask.size() * 32u,
+                            misaligned_mask.data(), &queue));
+  EXPECT_EQ(queue, nullptr);
+  EXPECT_EQ(queue_create_probe.call_count(), 0u);
+  EXPECT_EQ(physical_device->host_queue_count, initial_host_queue_count);
+  EXPECT_FALSE(iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+      physical_device, private_queue_ordinal));
+  EXPECT_EQ(iree_hal_amdgpu_physical_device_host_queue_private_initialized_mask(
+                physical_device),
+            0u);
+
+  queue_create_probe.ResetCallCount();
+  queue = reinterpret_cast<iree_hal_queue_t*>(uintptr_t{1});
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED,
+                        iree_hal_amdgpu_experimental_execution_queue_configure(
+                            test_device.device(), /*physical_device_ordinal=*/0,
+                            private_queue_ordinal, aligned_mask.size() * 32u,
+                            aligned_mask.data(), &queue));
+  EXPECT_EQ(queue, nullptr);
+  EXPECT_EQ(queue_create_probe.call_count(), 1u);
+  EXPECT_EQ(physical_device->host_queue_count, initial_host_queue_count);
+  EXPECT_FALSE(iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+      physical_device, private_queue_ordinal));
+  EXPECT_EQ(iree_hal_amdgpu_physical_device_host_queue_private_initialized_mask(
+                physical_device),
+            0u);
+#endif  // IREE_HAL_AMDGPU_LIBHSA_STATIC
+}
+
+TEST_F(AmdgpuExperimentalApiTest,
+       RejectsUndefinedMaskAlignmentBeforeQueueCreation) {
+#if IREE_HAL_AMDGPU_LIBHSA_STATIC
+  GTEST_SKIP() << "deterministic HSA queue injection requires dynamic libhsa";
+#else
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.host_queues.experimental_execution_queue_count = 1;
+  ScopedNativeAqlLibhsa native_aql_libhsa;
+  IREE_ASSERT_OK(native_aql_libhsa.Initialize(&libhsa_));
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(&options, native_aql_libhsa.libhsa()));
+
+  iree_hal_amdgpu_logical_device_t* logical_device =
+      test_device.logical_device();
+  iree_hal_amdgpu_physical_device_t* physical_device =
+      logical_device->physical_devices[0];
+  const iree_hal_amdgpu_gfxip_version_t undefined_version = {
+      .major = 13,
+      .minor = 0,
+      .stepping = 0,
+  };
+  ScopedAgentTargetVersionOverride target_override(physical_device,
+                                                   undefined_version);
+  ScopedQueueCreateProbe queue_create_probe(logical_device);
+
+  iree_hal_amdgpu_experimental_execution_queue_topology_t queue_topology = {
+      .first_private_physical_queue_ordinal = 1,
+      .private_physical_queue_count = 1,
+      .native_compute_unit_count = 1,
+      .native_compute_unit_mask_alignment = 1,
+      .native_compute_unit_mask_partition_count = 1,
+  };
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_UNIMPLEMENTED,
+                        iree_hal_amdgpu_experimental_execution_queue_query(
+                            test_device.device(), /*physical_device_ordinal=*/0,
+                            &queue_topology));
+  EXPECT_EQ(queue_topology.first_private_physical_queue_ordinal, 0u);
+  EXPECT_EQ(queue_topology.private_physical_queue_count, 0u);
+  EXPECT_EQ(queue_topology.native_compute_unit_count, 0u);
+  EXPECT_EQ(queue_topology.native_compute_unit_mask_alignment, 0u);
+  EXPECT_EQ(queue_topology.native_compute_unit_mask_partition_count, 0u);
+  EXPECT_EQ(queue_create_probe.call_count(), 0u);
+
+  std::vector<uint32_t> mask =
+      MakeFullNativeMask(physical_device->compute_unit_count);
+  const iree_host_size_t private_queue_ordinal =
+      physical_device->host_queue_ordinary_capacity;
+  const iree_host_size_t initial_host_queue_count =
+      physical_device->host_queue_count;
+  iree_hal_queue_t* queue = reinterpret_cast<iree_hal_queue_t*>(uintptr_t{1});
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_UNIMPLEMENTED,
+      iree_hal_amdgpu_experimental_execution_queue_configure(
+          test_device.device(), /*physical_device_ordinal=*/0,
+          private_queue_ordinal, mask.size() * 32u, mask.data(), &queue));
+  EXPECT_EQ(queue, nullptr);
+  EXPECT_EQ(queue_create_probe.call_count(), 0u);
+  EXPECT_EQ(physical_device->host_queue_count, initial_host_queue_count);
+  EXPECT_FALSE(iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+      physical_device, private_queue_ordinal));
+  EXPECT_EQ(iree_hal_amdgpu_physical_device_host_queue_private_initialized_mask(
+                physical_device),
+            0u);
+#endif  // IREE_HAL_AMDGPU_LIBHSA_STATIC
 }
 
 TEST_F(AmdgpuExperimentalApiTest,

--- a/runtime/src/iree/hal/drivers/amdgpu/api_experimental_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/api_experimental_test.cc
@@ -1,0 +1,552 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/api_experimental.h"
+
+#include <array>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+#include "iree/hal/cts/util/profile_test_util.h"
+#include "iree/hal/cts/util/test_base.h"
+#include "iree/hal/drivers/amdgpu/logical_device.h"
+#include "iree/hal/drivers/amdgpu/physical_device.h"
+#include "iree/hal/drivers/amdgpu/util/aql_ring.h"
+#include "iree/hal/testing/mock_device.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree::hal::amdgpu {
+namespace {
+
+class AmdgpuExperimentalApiTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    host_allocator_ = iree_allocator_system();
+    iree_status_t status = iree_hal_amdgpu_libhsa_initialize(
+        IREE_HAL_AMDGPU_LIBHSA_FLAG_NONE, iree_string_view_list_empty(),
+        host_allocator_, &libhsa_);
+    if (!iree_status_is_ok(status)) {
+      iree_status_fprint(stderr, status);
+      iree_status_free(status);
+      GTEST_SKIP() << "HSA not available, skipping live tests";
+    }
+    IREE_ASSERT_OK(iree_hal_amdgpu_topology_initialize_with_defaults(
+        &libhsa_, &topology_));
+    if (topology_.gpu_agent_count == 0) {
+      GTEST_SKIP() << "no GPU devices available, skipping live tests";
+    }
+  }
+
+  static void TearDownTestSuite() {
+    iree_hal_amdgpu_topology_deinitialize(&topology_);
+    iree_hal_amdgpu_libhsa_deinitialize(&libhsa_);
+  }
+
+  class TestLogicalDevice {
+   public:
+    ~TestLogicalDevice() {
+      iree_hal_device_release(device_);
+      iree_hal_device_group_release(device_group_);
+    }
+
+    iree_status_t Initialize(
+        const iree_hal_amdgpu_logical_device_options_t* options,
+        const iree_hal_amdgpu_libhsa_t* libhsa = &libhsa_) {
+      IREE_RETURN_IF_ERROR(create_context_.Initialize(host_allocator_));
+      IREE_RETURN_IF_ERROR(iree_hal_amdgpu_logical_device_create(
+          IREE_SV("amdgpu"), options, libhsa, &topology_,
+          create_context_.params(), host_allocator_, &device_));
+      return iree_hal_device_group_create_from_device(
+          device_, create_context_.frontier_tracker(), host_allocator_,
+          &device_group_);
+    }
+
+    iree_hal_device_t* device() const { return device_; }
+
+    iree_hal_amdgpu_logical_device_t* logical_device() const {
+      return (iree_hal_amdgpu_logical_device_t*)device_;
+    }
+
+   private:
+    iree::hal::cts::DeviceCreateContext create_context_;
+    iree_hal_device_t* device_ = nullptr;
+    iree_hal_device_group_t* device_group_ = nullptr;
+  };
+
+  static iree_allocator_t host_allocator_;
+  static iree_hal_amdgpu_libhsa_t libhsa_;
+  static iree_hal_amdgpu_topology_t topology_;
+};
+
+iree_allocator_t AmdgpuExperimentalApiTest::host_allocator_;
+iree_hal_amdgpu_libhsa_t AmdgpuExperimentalApiTest::libhsa_;
+iree_hal_amdgpu_topology_t AmdgpuExperimentalApiTest::topology_;
+
+#if !IREE_HAL_AMDGPU_LIBHSA_STATIC
+static hsa_status_t HSA_API RejectQueueCuMask(const hsa_queue_t* queue,
+                                              uint32_t mask_bit_count,
+                                              const uint32_t* mask) {
+  (void)queue;
+  (void)mask_bit_count;
+  (void)mask;
+  return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+}
+#endif  // !IREE_HAL_AMDGPU_LIBHSA_STATIC
+
+iree_status_t SubmitFillAndWait(iree_hal_device_t* device,
+                                iree_hal_queue_t* queue) {
+  const iree_hal_buffer_params_t buffer_params = {
+      /*.usage=*/IREE_HAL_BUFFER_USAGE_TRANSFER,
+      /*.access=*/IREE_HAL_MEMORY_ACCESS_ALL,
+      /*.type=*/IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+  };
+  iree_hal_buffer_t* buffer = nullptr;
+  iree_status_t status = iree_hal_allocator_allocate_buffer(
+      iree_hal_device_allocator(device), buffer_params, sizeof(uint32_t),
+      &buffer);
+  iree_hal_semaphore_t* semaphore = nullptr;
+  if (iree_status_is_ok(status)) {
+    const iree_hal_queue_family_affinity_t queue_family_affinity =
+        iree_hal_make_queue_family_affinity(
+            iree_hal_queue_family_ordinal(iree_hal_queue_family(queue)));
+    status = iree_hal_semaphore_create(
+        device, queue_family_affinity, /*initial_value=*/0,
+        IREE_HAL_SEMAPHORE_FLAG_NONE, &semaphore);
+  }
+  uint64_t payload_value = 1;
+  const iree_hal_semaphore_list_t signal_semaphore_list = {
+      /*.count=*/1,
+      /*.semaphores=*/&semaphore,
+      /*.payload_values=*/&payload_value,
+  };
+  if (iree_status_is_ok(status)) {
+    const uint32_t pattern = 0xA2A2A2A2u;
+    status = iree_hal_queue_fill(queue, iree_hal_semaphore_list_empty(),
+                                 signal_semaphore_list, buffer,
+                                 /*target_offset=*/0, sizeof(pattern), &pattern,
+                                 sizeof(pattern), IREE_HAL_FILL_FLAG_NONE);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_semaphore_wait(semaphore, payload_value,
+                                     iree_infinite_timeout(),
+                                     IREE_ASYNC_WAIT_FLAG_NONE);
+  }
+  iree_hal_semaphore_release(semaphore);
+  iree_hal_buffer_release(buffer);
+  return status;
+}
+
+static std::vector<uint32_t> MakeFullNativeMask(uint32_t compute_unit_count) {
+  const iree_host_size_t word_count = (compute_unit_count + 31u) / 32u;
+  std::vector<uint32_t> mask(word_count, UINT32_MAX);
+  const uint32_t tail_bit_count = compute_unit_count % 32u;
+  if (tail_bit_count != 0) {
+    mask.back() = (UINT32_C(1) << tail_bit_count) - 1u;
+  }
+  return mask;
+}
+
+TEST(AmdgpuExperimentalApiBoundaryTest, RejectsNonNativeDevice) {
+  iree_hal_mock_device_options_t options;
+  iree_hal_mock_device_options_initialize(&options);
+  options.identifier = IREE_SV("mock");
+  iree_hal_device_t* device = nullptr;
+  IREE_ASSERT_OK(
+      iree_hal_mock_device_create(&options, iree_allocator_system(), &device));
+
+  const uint32_t mask = 1;
+  iree_hal_queue_t* queue = reinterpret_cast<iree_hal_queue_t*>(uintptr_t{1});
+  iree_hal_amdgpu_experimental_execution_queue_topology_t topology = {
+      .first_private_physical_queue_ordinal = 1,
+  };
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION,
+                        iree_hal_amdgpu_experimental_execution_queue_query(
+                            device, /*physical_device_ordinal=*/0, &topology));
+  EXPECT_EQ(topology.first_private_physical_queue_ordinal, 0u);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION,
+                        iree_hal_amdgpu_experimental_execution_queue_configure(
+                            device, /*physical_device_ordinal=*/0,
+                            /*physical_queue_ordinal=*/0,
+                            /*mask_bit_count=*/32, &mask, &queue));
+  EXPECT_EQ(queue, nullptr);
+
+  iree_hal_device_release(device);
+}
+
+TEST_F(AmdgpuExperimentalApiTest,
+       ConfiguresAndSubmitsToCallerSelectedSparseProductionQueues) {
+  iree_hal_amdgpu_aql_queue_execution_mode_t execution_mode;
+  IREE_ASSERT_OK(iree_hal_amdgpu_query_aql_queue_execution_mode(
+      &libhsa_, topology_.gpu_agents[0], &execution_mode));
+  if (execution_mode != IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_NATIVE) {
+    GTEST_SKIP() << "fixed-mask queues require native GPU-consumed AQL";
+  }
+
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.host_queues.experimental_execution_queue_count = 2;
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(&options));
+
+  iree_hal_amdgpu_logical_device_t* logical_device =
+      test_device.logical_device();
+  ASSERT_GT(logical_device->physical_device_count, 0u);
+  iree_hal_amdgpu_physical_device_t* physical_device =
+      logical_device->physical_devices[0];
+  ASSERT_GT(physical_device->compute_unit_count, 0u);
+  ASSERT_EQ(physical_device->host_queue_capacity,
+            physical_device->host_queue_ordinary_capacity + 2);
+
+  iree_hal_amdgpu_experimental_execution_queue_topology_t queue_topology;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_query(
+      test_device.device(), /*physical_device_ordinal=*/0, &queue_topology));
+  EXPECT_EQ(queue_topology.first_private_physical_queue_ordinal,
+            physical_device->host_queue_ordinary_capacity);
+  EXPECT_EQ(queue_topology.private_physical_queue_count, 2u);
+  EXPECT_EQ(queue_topology.native_compute_unit_count,
+            physical_device->compute_unit_count);
+  EXPECT_TRUE(queue_topology.native_compute_unit_mask_alignment == 1u ||
+              queue_topology.native_compute_unit_mask_alignment == 2u);
+  EXPECT_GT(queue_topology.native_compute_unit_mask_partition_count, 0u);
+
+  const iree_host_size_t first_private_ordinal =
+      queue_topology.first_private_physical_queue_ordinal;
+  const iree_hal_device_queue_spec_t* queue_spec =
+      iree_hal_device_spec_queues(iree_hal_device_spec(test_device.device()));
+  ASSERT_NE(queue_spec, nullptr);
+  ASSERT_GT(queue_spec->family_count, 0u);
+  EXPECT_EQ(queue_spec->families[0].provisioned_queue_count,
+            physical_device->host_queue_ordinary_capacity);
+  EXPECT_EQ(
+      iree_hal_device_queue(test_device.device(), 0, first_private_ordinal),
+      nullptr);
+  EXPECT_EQ(
+      iree_hal_device_queue(test_device.device(), 0, first_private_ordinal + 1),
+      nullptr);
+  std::vector<uint32_t> mask =
+      MakeFullNativeMask(physical_device->compute_unit_count);
+  const iree_host_size_t mask_bit_count = mask.size() * 32u;
+
+  iree_hal_queue_t* private_queue = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_configure(
+      test_device.device(), /*physical_device_ordinal=*/0,
+      /*physical_queue_ordinal=*/
+      queue_topology.first_private_physical_queue_ordinal + 1, mask_bit_count,
+      mask.data(), &private_queue));
+  EXPECT_FALSE(iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+      physical_device, first_private_ordinal));
+  EXPECT_TRUE(iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+      physical_device, first_private_ordinal + 1));
+  EXPECT_EQ(physical_device->host_queue_count,
+            physical_device->host_queue_ordinary_count + 1);
+
+  ASSERT_NE(private_queue, nullptr);
+  EXPECT_EQ(private_queue,
+            &physical_device->host_queues[first_private_ordinal + 1].base);
+  EXPECT_EQ(iree_hal_queue_family(private_queue),
+            iree_hal_device_queue_family(test_device.device(), 0));
+  EXPECT_EQ(
+      iree_hal_device_queue(test_device.device(), 0, first_private_ordinal + 1),
+      nullptr);
+  IREE_ASSERT_OK(SubmitFillAndWait(test_device.device(), private_queue));
+  iree_hal_queue_t* ordinary_queue =
+      iree_hal_device_queue(test_device.device(), 0, 0);
+  ASSERT_NE(ordinary_queue, nullptr);
+  EXPECT_EQ(ordinary_queue, &physical_device->host_queues[0].base);
+  iree_hal_amdgpu_host_queue_t* ordinary_host_queue =
+      &physical_device->host_queues[0];
+  iree_hal_amdgpu_host_queue_t* private_host_queue =
+      &physical_device->host_queues[first_private_ordinal + 1];
+  const uint64_t ordinary_epoch_before =
+      ordinary_host_queue->notification_ring.epoch.next_submission;
+  const uint64_t private_epoch_before =
+      private_host_queue->notification_ring.epoch.next_submission;
+  IREE_ASSERT_OK(SubmitFillAndWait(test_device.device(), ordinary_queue));
+  EXPECT_GT(ordinary_host_queue->notification_ring.epoch.next_submission,
+            ordinary_epoch_before);
+  EXPECT_EQ(private_host_queue->notification_ring.epoch.next_submission,
+            private_epoch_before);
+  IREE_EXPECT_OK(iree_hal_queue_flush(private_queue));
+  IREE_EXPECT_OK(iree_hal_queue_flush(ordinary_queue));
+
+  iree_hal_queue_t* duplicate_queue = private_queue;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_ALREADY_EXISTS,
+      iree_hal_amdgpu_experimental_execution_queue_configure(
+          test_device.device(), /*physical_device_ordinal=*/0,
+          /*physical_queue_ordinal=*/first_private_ordinal + 1, mask_bit_count,
+          mask.data(), &duplicate_queue));
+  EXPECT_EQ(duplicate_queue, nullptr);
+
+  iree_hal_queue_t* first_private_queue = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_configure(
+      test_device.device(), /*physical_device_ordinal=*/0,
+      /*physical_queue_ordinal=*/first_private_ordinal, mask_bit_count,
+      mask.data(), &first_private_queue));
+  ASSERT_NE(first_private_queue, nullptr);
+  EXPECT_EQ(first_private_queue,
+            &physical_device->host_queues[first_private_ordinal].base);
+  IREE_ASSERT_OK(SubmitFillAndWait(test_device.device(), first_private_queue));
+  EXPECT_EQ(
+      iree_hal_device_queue(test_device.device(), 0, first_private_ordinal),
+      nullptr);
+  EXPECT_TRUE(iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+      physical_device, first_private_ordinal));
+  EXPECT_TRUE(iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+      physical_device, first_private_ordinal + 1));
+  EXPECT_EQ(physical_device->host_queue_count,
+            physical_device->host_queue_capacity);
+}
+
+TEST_F(AmdgpuExperimentalApiTest,
+       RejectsMasksThatLeaveHardwarePartitionsWithoutEnabledComputeUnits) {
+  iree_hal_amdgpu_aql_queue_execution_mode_t execution_mode;
+  IREE_ASSERT_OK(iree_hal_amdgpu_query_aql_queue_execution_mode(
+      &libhsa_, topology_.gpu_agents[0], &execution_mode));
+  if (execution_mode != IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_NATIVE) {
+    GTEST_SKIP() << "fixed-mask queues require native GPU-consumed AQL";
+  }
+
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.host_queues.experimental_execution_queue_count = 1;
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(&options));
+
+  iree_hal_amdgpu_experimental_execution_queue_topology_t queue_topology;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_query(
+      test_device.device(), /*physical_device_ordinal=*/0, &queue_topology));
+  if (queue_topology.native_compute_unit_mask_partition_count <=
+      queue_topology.native_compute_unit_mask_alignment) {
+    GTEST_SKIP() << "native mask groups span every interleaved partition";
+  }
+  iree_hal_amdgpu_physical_device_t* physical_device =
+      test_device.logical_device()->physical_devices[0];
+  const iree_host_size_t mask_word_count =
+      (queue_topology.native_compute_unit_count + 31u) / 32u;
+  std::vector<uint32_t> invalid_mask(mask_word_count, 0);
+  for (uint32_t bit = 0;
+       bit < queue_topology.native_compute_unit_mask_alignment; ++bit) {
+    invalid_mask[bit / 32u] |= UINT32_C(1) << (bit % 32u);
+  }
+  iree_hal_queue_t* queue = reinterpret_cast<iree_hal_queue_t*>(uintptr_t{1});
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_experimental_execution_queue_configure(
+          test_device.device(), /*physical_device_ordinal=*/0,
+          queue_topology.first_private_physical_queue_ordinal,
+          mask_word_count * 32u, invalid_mask.data(), &queue));
+  EXPECT_EQ(queue, nullptr);
+  EXPECT_FALSE(iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+      physical_device, queue_topology.first_private_physical_queue_ordinal));
+
+  std::vector<uint32_t> valid_mask =
+      MakeFullNativeMask(queue_topology.native_compute_unit_count);
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_configure(
+      test_device.device(), /*physical_device_ordinal=*/0,
+      queue_topology.first_private_physical_queue_ordinal,
+      valid_mask.size() * 32u, valid_mask.data(), &queue));
+  ASSERT_NE(queue, nullptr);
+  IREE_EXPECT_OK(SubmitFillAndWait(test_device.device(), queue));
+}
+
+TEST_F(AmdgpuExperimentalApiTest,
+       SetterFailureDestroysUnpublishedQueueAndPermitsRetry) {
+#if IREE_HAL_AMDGPU_LIBHSA_STATIC
+  GTEST_SKIP() << "deterministic HSA setter injection requires dynamic libhsa";
+#else
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.host_queues.experimental_execution_queue_count = 1;
+
+  iree_hal_amdgpu_libhsa_t hooked_libhsa;
+  IREE_ASSERT_OK(iree_hal_amdgpu_libhsa_copy(&libhsa_, &hooked_libhsa));
+  hooked_libhsa.hsa_amd_queue_cu_set_mask = RejectQueueCuMask;
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(&options, &hooked_libhsa));
+  iree_hal_amdgpu_libhsa_deinitialize(&hooked_libhsa);
+
+  iree_hal_amdgpu_logical_device_t* logical_device =
+      test_device.logical_device();
+  iree_hal_amdgpu_physical_device_t* physical_device =
+      logical_device->physical_devices[0];
+  iree_hal_amdgpu_experimental_execution_queue_topology_t queue_topology;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_query(
+      test_device.device(), /*physical_device_ordinal=*/0, &queue_topology));
+  std::vector<uint32_t> mask =
+      MakeFullNativeMask(queue_topology.native_compute_unit_count);
+  iree_hal_queue_t* queue = reinterpret_cast<iree_hal_queue_t*>(uintptr_t{1});
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_hal_amdgpu_experimental_execution_queue_configure(
+                            test_device.device(), /*physical_device_ordinal=*/0,
+                            queue_topology.first_private_physical_queue_ordinal,
+                            mask.size() * 32u, mask.data(), &queue));
+  EXPECT_EQ(queue, nullptr);
+  EXPECT_EQ(physical_device->host_queue_count,
+            physical_device->host_queue_ordinary_count);
+  EXPECT_FALSE(iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+      physical_device, queue_topology.first_private_physical_queue_ordinal));
+  EXPECT_EQ(iree_hal_amdgpu_physical_device_host_queue_private_initialized_mask(
+                physical_device),
+            0u);
+
+  logical_device->system->libhsa.hsa_amd_queue_cu_set_mask =
+      libhsa_.hsa_amd_queue_cu_set_mask;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_configure(
+      test_device.device(), /*physical_device_ordinal=*/0,
+      queue_topology.first_private_physical_queue_ordinal, mask.size() * 32u,
+      mask.data(), &queue));
+  ASSERT_NE(queue, nullptr);
+  IREE_EXPECT_OK(SubmitFillAndWait(test_device.device(), queue));
+#endif  // IREE_HAL_AMDGPU_LIBHSA_STATIC
+}
+
+TEST_F(AmdgpuExperimentalApiTest,
+       RejectsRuntimeWithoutProvableExactMaskInitialization) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.host_queues.experimental_execution_queue_count = 1;
+
+  iree_hal_amdgpu_libhsa_t inexact_libhsa;
+  IREE_ASSERT_OK(iree_hal_amdgpu_libhsa_copy(&libhsa_, &inexact_libhsa));
+  inexact_libhsa.exact_queue_cu_mask_supported = false;
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(&options, &inexact_libhsa));
+  iree_hal_amdgpu_libhsa_deinitialize(&inexact_libhsa);
+
+  iree_hal_amdgpu_logical_device_t* logical_device =
+      test_device.logical_device();
+  iree_hal_amdgpu_physical_device_t* physical_device =
+      logical_device->physical_devices[0];
+  iree_hal_amdgpu_experimental_execution_queue_topology_t queue_topology;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_query(
+      test_device.device(), /*physical_device_ordinal=*/0, &queue_topology));
+  std::vector<uint32_t> mask =
+      MakeFullNativeMask(queue_topology.native_compute_unit_count);
+  iree_hal_queue_t* queue = reinterpret_cast<iree_hal_queue_t*>(uintptr_t{1});
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION,
+                        iree_hal_amdgpu_experimental_execution_queue_configure(
+                            test_device.device(), /*physical_device_ordinal=*/0,
+                            queue_topology.first_private_physical_queue_ordinal,
+                            mask.size() * 32u, mask.data(), &queue));
+  EXPECT_EQ(queue, nullptr);
+  EXPECT_FALSE(iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+      physical_device, queue_topology.first_private_physical_queue_ordinal));
+}
+
+TEST_F(AmdgpuExperimentalApiTest,
+       ProfilingExcludesConfigurationUntilTheSessionEnds) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.host_queues.experimental_execution_queue_count = 1;
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(&options));
+
+  iree_hal_amdgpu_physical_device_t* physical_device =
+      test_device.logical_device()->physical_devices[0];
+  iree_hal_amdgpu_experimental_execution_queue_topology_t queue_topology;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_query(
+      test_device.device(), /*physical_device_ordinal=*/0, &queue_topology));
+  std::vector<uint32_t> mask =
+      MakeFullNativeMask(queue_topology.native_compute_unit_count);
+
+  iree::hal::cts::TestProfileSink sink;
+  iree::hal::cts::TestProfileSinkInitialize(&sink);
+  iree::hal::cts::DeviceProfilingScope profiling(test_device.device());
+  IREE_ASSERT_OK(profiling.Begin(IREE_HAL_DEVICE_PROFILING_DATA_QUEUE_EVENTS,
+                                 iree::hal::cts::TestProfileSinkAsBase(&sink)));
+
+  iree_hal_queue_t* queue = reinterpret_cast<iree_hal_queue_t*>(uintptr_t{1});
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION,
+                        iree_hal_amdgpu_experimental_execution_queue_configure(
+                            test_device.device(), /*physical_device_ordinal=*/0,
+                            queue_topology.first_private_physical_queue_ordinal,
+                            mask.size() * 32u, mask.data(), &queue));
+  EXPECT_EQ(queue, nullptr);
+  EXPECT_FALSE(iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+      physical_device, queue_topology.first_private_physical_queue_ordinal));
+
+  IREE_ASSERT_OK(profiling.End());
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_configure(
+      test_device.device(), /*physical_device_ordinal=*/0,
+      queue_topology.first_private_physical_queue_ordinal, mask.size() * 32u,
+      mask.data(), &queue));
+  ASSERT_NE(queue, nullptr);
+  IREE_EXPECT_OK(SubmitFillAndWait(test_device.device(), queue));
+}
+
+TEST_F(AmdgpuExperimentalApiTest,
+       ConcurrentConfigurationPublishesExactlyOneQueue) {
+  iree_hal_amdgpu_aql_queue_execution_mode_t execution_mode;
+  IREE_ASSERT_OK(iree_hal_amdgpu_query_aql_queue_execution_mode(
+      &libhsa_, topology_.gpu_agents[0], &execution_mode));
+  if (execution_mode != IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_NATIVE) {
+    GTEST_SKIP() << "fixed-mask queues require native GPU-consumed AQL";
+  }
+
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.host_queues.experimental_execution_queue_count = 1;
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(&options));
+
+  iree_hal_amdgpu_physical_device_t* physical_device =
+      test_device.logical_device()->physical_devices[0];
+  ASSERT_GT(physical_device->compute_unit_count, 0u);
+  const iree_host_size_t mask_word_count =
+      (physical_device->compute_unit_count + 31u) / 32u;
+  std::vector<uint32_t> full_mask(mask_word_count, UINT32_MAX);
+  const uint32_t tail_bit_count = physical_device->compute_unit_count % 32u;
+  if (tail_bit_count != 0) {
+    full_mask.back() = (UINT32_C(1) << tail_bit_count) - 1u;
+  }
+  iree_hal_amdgpu_experimental_execution_queue_topology_t queue_topology;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_query(
+      test_device.device(), /*physical_device_ordinal=*/0, &queue_topology));
+
+  std::array<iree_status_t, 2> statuses = {iree_ok_status(), iree_ok_status()};
+  std::array<iree_hal_queue_t*, 2> queues = {nullptr, nullptr};
+  std::array<std::thread, 2> threads;
+  for (iree_host_size_t i = 0; i < threads.size(); ++i) {
+    threads[i] = std::thread([&, i]() {
+      statuses[i] = iree_hal_amdgpu_experimental_execution_queue_configure(
+          test_device.device(), /*physical_device_ordinal=*/0,
+          /*physical_queue_ordinal=*/
+          queue_topology.first_private_physical_queue_ordinal,
+          mask_word_count * 32u, full_mask.data(), &queues[i]);
+    });
+  }
+  for (std::thread& thread : threads) thread.join();
+
+  iree_host_size_t success_count = 0;
+  iree_host_size_t already_exists_count = 0;
+  iree_hal_queue_t* configured_queue = nullptr;
+  for (iree_host_size_t i = 0; i < statuses.size(); ++i) {
+    const iree_status_code_t status_code = iree_status_code(statuses[i]);
+    if (status_code == IREE_STATUS_OK) {
+      ++success_count;
+      configured_queue = queues[i];
+    } else if (status_code == IREE_STATUS_ALREADY_EXISTS) {
+      ++already_exists_count;
+      EXPECT_EQ(queues[i], nullptr);
+    }
+    iree_status_free(statuses[i]);
+  }
+  EXPECT_EQ(success_count, 1u);
+  EXPECT_EQ(already_exists_count, 1u);
+  ASSERT_NE(configured_queue, nullptr);
+  EXPECT_EQ(
+      configured_queue,
+      &physical_device
+           ->host_queues[queue_topology.first_private_physical_queue_ordinal]
+           .base);
+  IREE_EXPECT_OK(SubmitFillAndWait(test_device.device(), configured_queue));
+}
+
+}  // namespace
+}  // namespace iree::hal::amdgpu

--- a/runtime/src/iree/hal/drivers/amdgpu/api_experimental_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/api_experimental_test.cc
@@ -269,7 +269,7 @@ TEST(AmdgpuExperimentalApiBoundaryTest, RejectsNonNativeDevice) {
   const uint32_t mask = 1;
   iree_hal_queue_t* queue = reinterpret_cast<iree_hal_queue_t*>(uintptr_t{1});
   iree_hal_amdgpu_experimental_execution_queue_topology_t topology = {
-      .first_private_physical_queue_ordinal = 1,
+      /*.first_private_physical_queue_ordinal=*/1,
   };
   IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION,
                         iree_hal_amdgpu_experimental_execution_queue_query(
@@ -480,9 +480,9 @@ TEST_F(AmdgpuExperimentalApiTest,
   iree_hal_amdgpu_physical_device_t* physical_device =
       logical_device->physical_devices[0];
   const iree_hal_amdgpu_gfxip_version_t gfx10_version = {
-      .major = 10,
-      .minor = 0,
-      .stepping = 0,
+      /*.major=*/10,
+      /*.minor=*/0,
+      /*.stepping=*/0,
   };
   ScopedAgentTargetVersionOverride target_override(physical_device,
                                                    gfx10_version);
@@ -558,20 +558,20 @@ TEST_F(AmdgpuExperimentalApiTest,
   iree_hal_amdgpu_physical_device_t* physical_device =
       logical_device->physical_devices[0];
   const iree_hal_amdgpu_gfxip_version_t undefined_version = {
-      .major = 13,
-      .minor = 0,
-      .stepping = 0,
+      /*.major=*/13,
+      /*.minor=*/0,
+      /*.stepping=*/0,
   };
   ScopedAgentTargetVersionOverride target_override(physical_device,
                                                    undefined_version);
   ScopedQueueCreateProbe queue_create_probe(logical_device);
 
   iree_hal_amdgpu_experimental_execution_queue_topology_t queue_topology = {
-      .first_private_physical_queue_ordinal = 1,
-      .private_physical_queue_count = 1,
-      .native_compute_unit_count = 1,
-      .native_compute_unit_mask_alignment = 1,
-      .native_compute_unit_mask_partition_count = 1,
+      /*.first_private_physical_queue_ordinal=*/1,
+      /*.private_physical_queue_count=*/1,
+      /*.native_compute_unit_count=*/1,
+      /*.native_compute_unit_mask_alignment=*/1,
+      /*.native_compute_unit_mask_partition_count=*/1,
   };
   IREE_EXPECT_STATUS_IS(IREE_STATUS_UNIMPLEMENTED,
                         iree_hal_amdgpu_experimental_execution_queue_query(

--- a/runtime/src/iree/hal/drivers/amdgpu/cts/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/amdgpu/cts/BUILD.bazel
@@ -76,6 +76,7 @@ iree_amdgpu_hal_cts_testdata(
         "testdata/command_buffer_dispatch_multi_workgroup_test.c",
         "testdata/command_buffer_dispatch_test.c",
         "testdata/executable_test.c",
+        "testdata/execution_queue_mask_test.c",
         "testdata/hostcall_buffer_test.c",
     ],
     identifier = "iree_cts_testdata_amdgpu",

--- a/runtime/src/iree/hal/drivers/amdgpu/cts/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/amdgpu/cts/CMakeLists.txt
@@ -93,6 +93,7 @@ iree_amdgpu_hal_cts_testdata(
     "testdata/command_buffer_dispatch_multi_workgroup_test.c"
     "testdata/command_buffer_dispatch_test.c"
     "testdata/executable_test.c"
+    "testdata/execution_queue_mask_test.c"
     "testdata/hostcall_buffer_test.c"
   TESTONLY
 )

--- a/runtime/src/iree/hal/drivers/amdgpu/cts/testdata/execution_queue_mask_test.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/cts/testdata/execution_queue_mask_test.c
@@ -1,0 +1,35 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/amdgpu/device/support/kernel.h"
+
+#define GETREG_IMMED(size, offset, reg) \
+  ((((size) - 1u) << 11) | ((offset) << 6) | (reg))
+
+IREE_AMDGPU_ATTRIBUTE_KERNEL void execution_queue_mask_test(uint32_t* output) {
+  if (iree_hal_amdgpu_device_local_id_x() != 0 ||
+      iree_hal_amdgpu_device_local_id_y() != 0 ||
+      iree_hal_amdgpu_device_local_id_z() != 0) {
+    return;
+  }
+
+#if defined(__gfx942__) || defined(__gfx9_4_generic__)
+  // Match HIP's gfx942 __smid decoding. HW_REG_HW_ID is register 4 and
+  // provides CU_ID[11:8] and SE_ID[14:13]. HW_REG_XCC_ID is register 20 and
+  // provides XCC_ID[3:0]. gfx942 has one shader array per shader engine, so
+  // (XCC, SE, CU) uniquely identifies the executing compute unit.
+  const uint32_t cu_id = __builtin_amdgcn_s_getreg(GETREG_IMMED(4, 8, 4));
+  const uint32_t se_id = __builtin_amdgcn_s_getreg(GETREG_IMMED(2, 13, 4));
+  const uint32_t xcc_id = __builtin_amdgcn_s_getreg(GETREG_IMMED(4, 0, 20));
+  const uint32_t execution_unit_id = (xcc_id << 6) | (se_id << 4) | cu_id;
+#else
+  // The host test executes only on gfx942. Retaining a definition for other
+  // target families keeps the shared CTS testdata aggregate buildable.
+  const uint32_t execution_unit_id = UINT32_MAX;
+#endif
+
+  output[iree_hal_amdgpu_device_group_id_x()] = execution_unit_id;
+}

--- a/runtime/src/iree/hal/drivers/amdgpu/driver_options_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/driver_options_test.cc
@@ -8,6 +8,7 @@
 
 #include "iree/hal/drivers/amdgpu/api.h"
 #include "iree/hal/drivers/amdgpu/logical_device.h"
+#include "iree/hal/drivers/amdgpu/physical_device.h"
 #include "iree/testing/gtest.h"
 #include "iree/testing/status_matchers.h"
 
@@ -38,6 +39,63 @@ TEST(AmdgpuDriverOptionsTest, LogicalDeviceParamsAreRejectedUntilDefined) {
                                           /*.count=*/1,
                                           /*.pairs=*/&pair,
                                       }));
+}
+
+TEST(AmdgpuDriverOptionsTest, LogicalDeviceDefaultsDisableExecutionQueues) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+
+  EXPECT_EQ(options.host_queues.experimental_execution_queue_count, 0u);
+}
+
+TEST(AmdgpuDriverOptionsTest, ParsesExperimentalExecutionQueueCount) {
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  const iree_string_pair_t pair =
+      iree_make_cstring_pair("experimental_execution_queue_count", "3");
+
+  IREE_EXPECT_OK(iree_hal_amdgpu_logical_device_options_parse(
+      &options, (iree_string_pair_list_t){
+                    /*.count=*/1,
+                    /*.pairs=*/&pair,
+                }));
+  EXPECT_EQ(options.host_queues.experimental_execution_queue_count, 3u);
+}
+
+TEST(AmdgpuDriverOptionsTest, RejectsInvalidExperimentalExecutionQueueCount) {
+  constexpr const char* kInvalidValues[] = {
+      "-1", "not-a-count", "4294967296", "12garbage", "",
+  };
+  for (const char* invalid_value : kInvalidValues) {
+    iree_hal_amdgpu_logical_device_options_t options;
+    iree_hal_amdgpu_logical_device_options_initialize(&options);
+    const iree_string_pair_t pair = iree_make_cstring_pair(
+        "experimental_execution_queue_count", invalid_value);
+
+    IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                          iree_hal_amdgpu_logical_device_options_parse(
+                              &options, (iree_string_pair_list_t){
+                                            /*.count=*/1,
+                                            /*.pairs=*/&pair,
+                                        }));
+  }
+}
+
+TEST(AmdgpuDriverOptionsTest, ValidatesPhysicalQueueAxisCountBoundary) {
+  iree_hal_amdgpu_physical_device_options_t options;
+  iree_hal_amdgpu_physical_device_options_initialize(&options);
+  iree_hal_amdgpu_libhsa_t libhsa = {};
+
+  options.host_queue_count = IREE_HAL_AMDGPU_MAX_QUEUE_AXIS_COUNT;
+  options.host_queue_ordinary_capacity = options.host_queue_count;
+  IREE_EXPECT_OK(iree_hal_amdgpu_physical_device_options_verify(
+      &options, &libhsa, hsa_agent_t{0}, hsa_agent_t{0}));
+
+  ++options.host_queue_count;
+  ++options.host_queue_ordinary_capacity;
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_OUT_OF_RANGE,
+                        iree_hal_amdgpu_physical_device_options_verify(
+                            &options, &libhsa, hsa_agent_t{0}, hsa_agent_t{0}));
 }
 
 TEST(AmdgpuDriverOptionsTest, LogicalDeviceDefaultsUseHostCopyPm4Publication) {

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_test.cc
@@ -421,25 +421,34 @@ TEST_F(ExecutableTest, RestrictiveExecutionQueueMasksConstrainKernelPlacement) {
                                          workgroup_size, &mask_b_ids));
 
   ASSERT_EQ(ordinary_ids.size(), queue_topology.native_compute_unit_count);
-  // KFD interleaves gfx9.4.3 CU-mask bits by XCC first: bits 0-7 select
-  // (XCC 0-7, SE 0, CU 0). The device kernel uses HIP's gfx942 __smid bit
-  // packing. Retaining one enabled CU in each XCC avoids queue non-progress.
-  // The exact IDs requested by bits {0..7} and {8..15} are therefore SE0/CU0
-  // and SE1/CU0 from every XCC, respectively.
-  const std::vector<uint32_t> expected_mask_a_ids = {0u,   64u,  128u, 192u,
-                                                     256u, 320u, 384u, 448u};
-  const std::vector<uint32_t> expected_mask_b_ids = {16u,  80u,  144u, 208u,
-                                                     272u, 336u, 400u, 464u};
-  EXPECT_EQ(mask_a_ids, expected_mask_a_ids);
-  EXPECT_EQ(mask_b_ids, expected_mask_b_ids);
-  EXPECT_EQ(mask_a_ids.size(), xcc_count);
-  EXPECT_EQ(mask_b_ids.size(), xcc_count);
-  EXPECT_TRUE(std::includes(expected_mask_a_ids.begin(),
-                            expected_mask_a_ids.end(), mask_a_ids.begin(),
-                            mask_a_ids.end()));
-  EXPECT_TRUE(std::includes(expected_mask_b_ids.begin(),
-                            expected_mask_b_ids.end(), mask_b_ids.begin(),
-                            mask_b_ids.end()));
+  // KFD interleaves gfx9.4.3 CU-mask bits by XCC across active CU slots.
+  // Harvested physical CU ordinals may differ between XCCs, so confinement is
+  // defined by one ordinary-queue-visible unit per XCC in the selected SE.
+  const auto expect_mask_topology = [&](const std::vector<uint32_t>& ids,
+                                        uint32_t expected_se_id) {
+    EXPECT_EQ(ids.size(), xcc_count);
+    std::vector<bool> observed_xccs(xcc_count, false);
+    for (uint32_t id : ids) {
+      const uint32_t xcc_id = id >> 6u;
+      const uint32_t se_id = (id >> 4u) & 0x3u;
+      const uint32_t physical_cu_id = id & 0xFu;
+      ASSERT_LT(xcc_id, xcc_count)
+          << "execution-unit ID " << id << " decodes to XCC " << xcc_id
+          << ", SE " << se_id << ", physical CU " << physical_cu_id;
+      EXPECT_EQ(se_id, expected_se_id)
+          << "execution-unit ID " << id << " decodes to XCC " << xcc_id
+          << ", SE " << se_id << ", physical CU " << physical_cu_id;
+      EXPECT_FALSE(observed_xccs[xcc_id])
+          << "execution-unit ID " << id << " repeats XCC " << xcc_id
+          << " at SE " << se_id << ", physical CU " << physical_cu_id;
+      observed_xccs[xcc_id] = true;
+    }
+    for (uint32_t xcc_id = 0; xcc_id < xcc_count; ++xcc_id) {
+      EXPECT_TRUE(observed_xccs[xcc_id]) << "missing XCC " << xcc_id;
+    }
+  };
+  expect_mask_topology(mask_a_ids, /*expected_se_id=*/0);
+  expect_mask_topology(mask_b_ids, /*expected_se_id=*/1);
   EXPECT_TRUE(std::includes(ordinary_ids.begin(), ordinary_ids.end(),
                             mask_a_ids.begin(), mask_a_ids.end()));
   EXPECT_TRUE(std::includes(ordinary_ids.begin(), ordinary_ids.end(),

--- a/runtime/src/iree/hal/drivers/amdgpu/executable_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/executable_test.cc
@@ -6,6 +6,11 @@
 
 #include "iree/hal/drivers/amdgpu/executable.h"
 
+#include <algorithm>
+#include <cstdlib>
+#include <vector>
+
+#include "iree/hal/drivers/amdgpu/api_experimental.h"
 #include "iree/hal/drivers/amdgpu/host_queue_command_buffer_test_util.h"
 #include "iree/hal/drivers/amdgpu/host_queue_dispatch.h"
 #include "iree/hal/drivers/amdgpu/physical_device.h"
@@ -51,6 +56,77 @@ class ExecutableTest : public ::testing::Test {
 iree_allocator_t ExecutableTest::host_allocator_;
 iree_hal_amdgpu_libhsa_t ExecutableTest::libhsa_;
 iree_hal_amdgpu_topology_t ExecutableTest::topology_;
+
+static iree_status_t ObserveExecutionUnitIds(
+    TestLogicalDevice& test_device, iree_hal_executable_t* executable,
+    iree_hal_queue_t* queue, uint32_t workgroup_count, uint32_t workgroup_size,
+    std::vector<uint32_t>* out_unique_ids) {
+  out_unique_ids->clear();
+  const iree_device_size_t output_size =
+      (iree_device_size_t)workgroup_count * sizeof(uint32_t);
+  Ref<iree_hal_buffer_t> output_buffer;
+  IREE_RETURN_IF_ERROR(CreateHostVisibleDispatchBuffer(
+      test_device.allocator(), output_size, output_buffer.out()));
+  std::vector<uint32_t> observations(workgroup_count, UINT32_MAX);
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_map_write(
+      output_buffer, /*target_offset=*/0, observations.data(), output_size));
+
+  iree_hal_buffer_ref_t binding = iree_hal_make_buffer_ref(
+      output_buffer, /*offset=*/0, iree_hal_buffer_byte_length(output_buffer));
+  const iree_hal_buffer_ref_list_t bindings = {
+      /*.count=*/1,
+      /*.values=*/&binding,
+  };
+  iree_hal_dispatch_config_t config =
+      iree_hal_make_static_dispatch_config(workgroup_count, 1, 1);
+  config.workgroup_size[0] = workgroup_size;
+  config.workgroup_size[1] = 1;
+  config.workgroup_size[2] = 1;
+
+  Ref<iree_hal_command_buffer_t> command_buffer;
+  IREE_RETURN_IF_ERROR(iree_hal_command_buffer_create(
+      test_device.base_device(), iree_hal_queue_family(queue),
+      IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT, IREE_HAL_COMMAND_CATEGORY_DISPATCH,
+      /*binding_capacity=*/0, command_buffer.out()));
+  IREE_RETURN_IF_ERROR(iree_hal_command_buffer_begin(command_buffer));
+  IREE_RETURN_IF_ERROR(iree_hal_command_buffer_dispatch(
+      command_buffer, executable, iree_hal_executable_function_from_index(0),
+      config, iree_const_byte_span_empty(), bindings,
+      IREE_HAL_DISPATCH_FLAG_NONE));
+  IREE_RETURN_IF_ERROR(iree_hal_command_buffer_end(command_buffer));
+
+  Ref<iree_hal_semaphore_t> signal;
+  IREE_RETURN_IF_ERROR(
+      CreateSemaphore(test_device.base_device(), signal.out()));
+  iree_hal_semaphore_t* signal_ptr = signal.get();
+  uint64_t signal_value = 1;
+  const iree_hal_semaphore_list_t signal_list = {
+      /*.count=*/1,
+      /*.semaphores=*/&signal_ptr,
+      /*.payload_values=*/&signal_value,
+  };
+  IREE_RETURN_IF_ERROR(iree_hal_queue_execute(
+      queue, iree_hal_semaphore_list_empty(), signal_list, command_buffer,
+      iree_hal_buffer_binding_table_empty(), IREE_HAL_QUEUE_EXECUTE_FLAG_NONE));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_wait(signal, signal_value,
+                                               iree_infinite_timeout(),
+                                               IREE_ASYNC_WAIT_FLAG_NONE));
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_map_read(
+      output_buffer, /*source_offset=*/0, observations.data(), output_size));
+
+  for (iree_host_size_t i = 0; i < observations.size(); ++i) {
+    if (IREE_UNLIKELY(observations[i] == UINT32_MAX)) {
+      return iree_make_status(
+          IREE_STATUS_DATA_LOSS,
+          "workgroup %" PRIhsz " did not record an execution-unit ID", i);
+    }
+  }
+  std::sort(observations.begin(), observations.end());
+  observations.erase(std::unique(observations.begin(), observations.end()),
+                     observations.end());
+  out_unique_ids->swap(observations);
+  return iree_ok_status();
+}
 
 TEST_F(ExecutableTest, PublishesAndEnforcesResourceLimits) {
   iree_hal_amdgpu_logical_device_options_t options;
@@ -149,6 +225,229 @@ TEST_F(ExecutableTest, PublishesAndEnforcesResourceLimits) {
   EXPECT_THAT(Status(record_aql_dispatch(
                   maximum_dynamic_workgroup_local_memory_size + 1)),
               StatusIs(StatusCode::kOutOfRange));
+}
+
+TEST_F(ExecutableTest,
+       AnyExecutableLoadedBeforePrivateQueueDispatchesAfterConfiguration) {
+  iree_hal_amdgpu_aql_queue_execution_mode_t execution_mode;
+  IREE_ASSERT_OK(iree_hal_amdgpu_query_aql_queue_execution_mode(
+      &libhsa_, topology_.gpu_agents[0], &execution_mode));
+  if (execution_mode != IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_NATIVE) {
+    GTEST_SKIP() << "fixed-mask queues require native GPU-consumed AQL";
+  }
+
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.command_buffer_mode = IREE_HAL_AMDGPU_COMMAND_BUFFER_MODE_AQL;
+  options.preallocate_pools = 0;
+  options.host_queues.experimental_execution_queue_count = 1;
+
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(
+      test_device.Initialize(&options, &libhsa_, &topology_, host_allocator_));
+
+  // Load the module while only ordinary queues are routable. This models HIP's
+  // context-wide module lifetime: a Green Context stream may be created later.
+  TwoDispatchCommandBuffer fixture;
+  IREE_ASSERT_OK(
+      InitializeTwoDispatchCommandBufferResources(&test_device, &fixture));
+
+  iree_hal_amdgpu_physical_device_t* physical_device =
+      test_device.logical_device()->physical_devices[0];
+  ASSERT_GT(physical_device->compute_unit_count, 0u);
+  const iree_host_size_t mask_word_count =
+      (physical_device->compute_unit_count + 31u) / 32u;
+  std::vector<uint32_t> full_mask(mask_word_count, UINT32_MAX);
+  const uint32_t tail_bit_count = physical_device->compute_unit_count % 32u;
+  if (tail_bit_count != 0) {
+    full_mask.back() = (UINT32_C(1) << tail_bit_count) - 1u;
+  }
+  iree_hal_amdgpu_experimental_execution_queue_topology_t queue_topology;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_query(
+      test_device.base_device(), /*physical_device_ordinal=*/0,
+      &queue_topology));
+
+  const iree_hal_queue_ordinal_t private_queue_ordinal =
+      (iree_hal_queue_ordinal_t)
+          queue_topology.first_private_physical_queue_ordinal;
+  iree_hal_queue_t* private_queue = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_configure(
+      test_device.base_device(), /*physical_device_ordinal=*/0,
+      private_queue_ordinal, mask_word_count * 32u, full_mask.data(),
+      &private_queue));
+  ASSERT_NE(private_queue, nullptr);
+
+  const iree_hal_amdgpu_executable_dispatch_descriptor_t* descriptor = nullptr;
+  IREE_ASSERT_OK(
+      iree_hal_amdgpu_executable_lookup_dispatch_descriptor_for_queue_ordinal(
+          fixture.executable, iree_hal_executable_function_from_index(0),
+          private_queue_ordinal, &descriptor));
+  ASSERT_NE(descriptor, nullptr);
+
+  IREE_ASSERT_OK(iree_hal_command_buffer_create(
+      test_device.base_device(), iree_hal_queue_family(private_queue),
+      IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT, IREE_HAL_COMMAND_CATEGORY_DISPATCH,
+      /*binding_capacity=*/0, fixture.command_buffer.out()));
+  IREE_ASSERT_OK(iree_hal_command_buffer_begin(fixture.command_buffer));
+  IREE_ASSERT_OK(AppendTwoDispatchOperations(&fixture));
+  IREE_ASSERT_OK(iree_hal_command_buffer_end(fixture.command_buffer));
+
+  Ref<iree_hal_semaphore_t> signal;
+  IREE_ASSERT_OK(CreateSemaphore(test_device.base_device(), signal.out()));
+  iree_hal_semaphore_t* signal_ptr = signal.get();
+  uint64_t signal_value = 1;
+  const iree_hal_semaphore_list_t signal_list = {
+      /*.count=*/1,
+      /*.semaphores=*/&signal_ptr,
+      /*.payload_values=*/&signal_value,
+  };
+  IREE_ASSERT_OK(iree_hal_queue_execute(
+      private_queue, iree_hal_semaphore_list_empty(), signal_list,
+      fixture.command_buffer, iree_hal_buffer_binding_table_empty(),
+      IREE_HAL_QUEUE_EXECUTE_FLAG_NONE));
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(signal, signal_value,
+                                         iree_infinite_timeout(),
+                                         IREE_ASYNC_WAIT_FLAG_NONE));
+  ExpectTwoDispatchOutputs(fixture);
+}
+
+TEST_F(ExecutableTest, RestrictiveExecutionQueueMasksConstrainKernelPlacement) {
+  ASSERT_EQ(std::getenv("HSA_CU_MASK"), nullptr)
+      << "this test requires an unrestricted process-level HSA CU mask";
+
+  iree_hal_amdgpu_aql_queue_execution_mode_t execution_mode;
+  IREE_ASSERT_OK(iree_hal_amdgpu_query_aql_queue_execution_mode(
+      &libhsa_, topology_.gpu_agents[0], &execution_mode));
+  if (execution_mode != IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_NATIVE) {
+    GTEST_SKIP() << "fixed-mask queues require native GPU-consumed AQL";
+  }
+
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.command_buffer_mode = IREE_HAL_AMDGPU_COMMAND_BUFFER_MODE_AQL;
+  options.preallocate_pools = 0;
+  options.host_queues.experimental_execution_queue_count = 2;
+
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(
+      test_device.Initialize(&options, &libhsa_, &topology_, host_allocator_));
+  iree_hal_amdgpu_logical_device_t* logical_device =
+      test_device.logical_device();
+  ASSERT_GT(logical_device->physical_device_count, 0u);
+  iree_hal_amdgpu_physical_device_t* physical_device =
+      logical_device->physical_devices[0];
+  ASSERT_NE(physical_device->agent_target, nullptr);
+  if (!iree_string_view_equal(
+          physical_device->agent_target->primary_isa.identity.processor,
+          IREE_SV("gfx942"))) {
+    GTEST_SKIP() << "execution-unit identity decoding is gfx942-specific";
+  }
+  uint32_t xcc_count = 0;
+  IREE_ASSERT_OK(iree_hsa_agent_get_info(
+      IREE_LIBHSA(&libhsa_), topology_.gpu_agents[0],
+      (hsa_agent_info_t)HSA_AMD_AGENT_INFO_NUM_XCC, &xcc_count));
+  if (xcc_count != 8u) {
+    GTEST_SKIP() << "exact gfx942 CU-mask decoding requires an unpartitioned "
+                    "8-XCC agent";
+  }
+
+  iree_hal_amdgpu_experimental_execution_queue_topology_t queue_topology;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_query(
+      test_device.base_device(), /*physical_device_ordinal=*/0,
+      &queue_topology));
+  ASSERT_EQ(queue_topology.native_compute_unit_count,
+            physical_device->compute_unit_count);
+  ASSERT_GE(queue_topology.native_compute_unit_count, 4u);
+  ASSERT_EQ(queue_topology.native_compute_unit_mask_alignment, 1u);
+  ASSERT_EQ(queue_topology.native_compute_unit_mask_partition_count, xcc_count);
+  ASSERT_GE(queue_topology.private_physical_queue_count, 2u);
+
+  // Load while only ordinary queues are routable, matching the context-wide
+  // module lifetime used by the HIP compatibility surface.
+  iree_hal_queue_t* ordinary_queue =
+      iree_hal_device_queue(test_device.base_device(), /*family_ordinal=*/0,
+                            /*queue_ordinal=*/0);
+  ASSERT_NE(ordinary_queue, nullptr);
+  Ref<iree_hal_executable_t> executable;
+  IREE_ASSERT_OK(LoadCtsExecutable(
+      test_device.base_device(), iree_hal_queue_family(ordinary_queue),
+      IREE_SV("execution_queue_mask_test.bin"), executable.out()));
+
+  const iree_host_size_t mask_word_count =
+      (queue_topology.native_compute_unit_count + 31u) / 32u;
+  const iree_host_size_t mask_bit_count = mask_word_count * 32u;
+  std::vector<uint32_t> mask_a(mask_word_count, 0);
+  std::vector<uint32_t> mask_b(mask_word_count, 0);
+  mask_a[0] = UINT32_C(0xFF);
+  mask_b[0] = UINT32_C(0xFF00);
+
+  iree_hal_queue_t* private_queue_a = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_configure(
+      test_device.base_device(), /*physical_device_ordinal=*/0,
+      queue_topology.first_private_physical_queue_ordinal, mask_bit_count,
+      mask_a.data(), &private_queue_a));
+  ASSERT_NE(private_queue_a, nullptr);
+  iree_hal_queue_t* private_queue_b = nullptr;
+  IREE_ASSERT_OK(iree_hal_amdgpu_experimental_execution_queue_configure(
+      test_device.base_device(), /*physical_device_ordinal=*/0,
+      queue_topology.first_private_physical_queue_ordinal + 1, mask_bit_count,
+      mask_b.data(), &private_queue_b));
+  ASSERT_NE(private_queue_b, nullptr);
+  ASSERT_NE(private_queue_a, private_queue_b);
+
+  uint32_t workgroup_size = 0;
+  IREE_ASSERT_OK(iree_hsa_agent_get_info(
+      IREE_LIBHSA(&libhsa_), topology_.gpu_agents[0],
+      HSA_AGENT_INFO_WORKGROUP_MAX_SIZE, &workgroup_size));
+  ASSERT_GT(workgroup_size, 0u);
+  constexpr uint32_t kWorkgroupsPerComputeUnit = 10;
+  ASSERT_LE(queue_topology.native_compute_unit_count,
+            UINT32_MAX / kWorkgroupsPerComputeUnit);
+  const uint32_t workgroup_count =
+      queue_topology.native_compute_unit_count * kWorkgroupsPerComputeUnit;
+  ASSERT_LE(workgroup_size, UINT32_MAX / workgroup_count);
+
+  std::vector<uint32_t> ordinary_ids;
+  std::vector<uint32_t> mask_a_ids;
+  std::vector<uint32_t> mask_b_ids;
+  IREE_ASSERT_OK(ObserveExecutionUnitIds(test_device, executable,
+                                         ordinary_queue, workgroup_count,
+                                         workgroup_size, &ordinary_ids));
+  IREE_ASSERT_OK(ObserveExecutionUnitIds(test_device, executable,
+                                         private_queue_a, workgroup_count,
+                                         workgroup_size, &mask_a_ids));
+  IREE_ASSERT_OK(ObserveExecutionUnitIds(test_device, executable,
+                                         private_queue_b, workgroup_count,
+                                         workgroup_size, &mask_b_ids));
+
+  ASSERT_EQ(ordinary_ids.size(), queue_topology.native_compute_unit_count);
+  // KFD interleaves gfx9.4.3 CU-mask bits by XCC first: bits 0-7 select
+  // (XCC 0-7, SE 0, CU 0). The device kernel uses HIP's gfx942 __smid bit
+  // packing. Retaining one enabled CU in each XCC avoids queue non-progress.
+  // The exact IDs requested by bits {0..7} and {8..15} are therefore SE0/CU0
+  // and SE1/CU0 from every XCC, respectively.
+  const std::vector<uint32_t> expected_mask_a_ids = {0u,   64u,  128u, 192u,
+                                                     256u, 320u, 384u, 448u};
+  const std::vector<uint32_t> expected_mask_b_ids = {16u,  80u,  144u, 208u,
+                                                     272u, 336u, 400u, 464u};
+  EXPECT_EQ(mask_a_ids, expected_mask_a_ids);
+  EXPECT_EQ(mask_b_ids, expected_mask_b_ids);
+  EXPECT_EQ(mask_a_ids.size(), xcc_count);
+  EXPECT_EQ(mask_b_ids.size(), xcc_count);
+  EXPECT_TRUE(std::includes(expected_mask_a_ids.begin(),
+                            expected_mask_a_ids.end(), mask_a_ids.begin(),
+                            mask_a_ids.end()));
+  EXPECT_TRUE(std::includes(expected_mask_b_ids.begin(),
+                            expected_mask_b_ids.end(), mask_b_ids.begin(),
+                            mask_b_ids.end()));
+  EXPECT_TRUE(std::includes(ordinary_ids.begin(), ordinary_ids.end(),
+                            mask_a_ids.begin(), mask_a_ids.end()));
+  EXPECT_TRUE(std::includes(ordinary_ids.begin(), ordinary_ids.end(),
+                            mask_b_ids.begin(), mask_b_ids.end()));
+  EXPECT_TRUE(
+      std::none_of(mask_a_ids.begin(), mask_a_ids.end(), [&](uint32_t id) {
+        return std::binary_search(mask_b_ids.begin(), mask_b_ids.end(), id);
+      }));
 }
 
 }  // namespace

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue.c
@@ -799,11 +799,53 @@ static void iree_hal_amdgpu_host_queue_error_callback(hsa_status_t status,
   iree_hal_amdgpu_host_queue_record_failure(queue, error);
 }
 
+static iree_status_t iree_hal_amdgpu_host_queue_create_hardware_queue(
+    const iree_hal_amdgpu_libhsa_t* libhsa, hsa_agent_t gpu_agent,
+    const iree_hal_amdgpu_host_queue_create_options_t* create_options,
+    uint32_t aql_queue_capacity, iree_hal_amdgpu_host_queue_t* callback_data,
+    hsa_queue_t** out_hardware_queue) {
+  *out_hardware_queue = NULL;
+  const uint32_t mask_bit_count = create_options->compute_unit_mask_bit_count;
+  const uint32_t* mask = create_options->compute_unit_mask;
+  if (IREE_UNLIKELY((mask_bit_count == 0) != (mask == NULL))) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "host queue CU mask and bit count must both be empty or non-empty");
+  }
+  if (IREE_UNLIKELY(mask_bit_count != 0 && mask_bit_count % 32 != 0)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "host queue CU mask must be a multiple of 32 bits");
+  }
+
+  hsa_queue_t* hardware_queue = NULL;
+  iree_status_t status = iree_hsa_queue_create(
+      IREE_LIBHSA(libhsa), gpu_agent, aql_queue_capacity, HSA_QUEUE_TYPE_MULTI,
+      iree_hal_amdgpu_host_queue_error_callback, callback_data,
+      /*private_segment_size=*/UINT32_MAX,
+      /*group_segment_size=*/UINT32_MAX, &hardware_queue);
+  if (iree_status_is_ok(status) && mask_bit_count != 0) {
+    status = iree_status_annotate(
+        iree_hsa_amd_queue_cu_set_mask(IREE_LIBHSA(libhsa), hardware_queue,
+                                       mask_bit_count, mask),
+        IREE_SV("applying immutable AMDGPU execution queue CU mask"));
+  }
+  if (!iree_status_is_ok(status)) {
+    if (hardware_queue) {
+      iree_hal_amdgpu_hsa_cleanup_assert_success(
+          iree_hsa_queue_destroy_raw(libhsa, hardware_queue));
+    }
+    return status;
+  }
+  *out_hardware_queue = hardware_queue;
+  return iree_ok_status();
+}
+
 iree_status_t iree_hal_amdgpu_host_queue_initialize(
     const iree_hal_queue_family_t* queue_family,
     const iree_hal_amdgpu_libhsa_t* libhsa, iree_hal_device_t* logical_device,
     void* hostcall_buffer, iree_async_proactor_t* proactor,
     hsa_agent_t gpu_agent,
+    const iree_hal_amdgpu_host_queue_create_options_t* create_options,
     const iree_hal_amdgpu_kernarg_ring_memory_t* kernarg_memory,
     hsa_amd_memory_pool_t pm4_ib_pool,
     iree_async_frontier_tracker_t* frontier_tracker, iree_async_axis_t axis,
@@ -829,6 +871,7 @@ iree_status_t iree_hal_amdgpu_host_queue_initialize(
   IREE_ASSERT_ARGUMENT(libhsa);
   IREE_ASSERT_ARGUMENT(logical_device);
   IREE_ASSERT_ARGUMENT(proactor);
+  IREE_ASSERT_ARGUMENT(create_options);
   IREE_ASSERT_ARGUMENT(kernarg_memory);
   IREE_ASSERT_ARGUMENT(frontier_tracker);
   IREE_ASSERT_ARGUMENT(epoch_table);
@@ -899,8 +942,11 @@ iree_status_t iree_hal_amdgpu_host_queue_initialize(
   // The optional tracker semaphore is an iree_async_semaphore_t bridge for
   // CPU-side wait integration. The queue's GPU-visible HSA epoch signal is
   // created by the notification ring below and registered in the epoch table.
-  iree_status_t status = iree_async_frontier_tracker_register_axis(
-      frontier_tracker, axis, /*semaphore=*/NULL);
+  // The owning physical device registers every reserved queue axis during
+  // topology setup. Keeping that table immutable is required by the frontier
+  // tracker's lock-free lookup contract and leaves failed lazy queue creation
+  // retryable on the same permanently reserved axis.
+  iree_status_t status = iree_ok_status();
 
   // Create the host-only stop signal before the hardware queue so the HSA error
   // callback always has a valid signal to wake if queue creation races with an
@@ -922,12 +968,9 @@ iree_status_t iree_hal_amdgpu_host_queue_initialize(
   // MULTI queues.
   hsa_queue_t* hardware_queue = NULL;
   if (iree_status_is_ok(status)) {
-    status = iree_hsa_queue_create(
-        IREE_LIBHSA(libhsa), gpu_agent, aql_queue_capacity,
-        HSA_QUEUE_TYPE_MULTI, iree_hal_amdgpu_host_queue_error_callback,
-        /*data=*/out_queue,
-        /*private_segment_size=*/UINT32_MAX,
-        /*group_segment_size=*/UINT32_MAX, &hardware_queue);
+    status = iree_hal_amdgpu_host_queue_create_hardware_queue(
+        libhsa, gpu_agent, create_options, aql_queue_capacity, out_queue,
+        &hardware_queue);
   }
 
   // Initialize the AQL ring from the hardware queue.
@@ -979,17 +1022,6 @@ iree_status_t iree_hal_amdgpu_host_queue_initialize(
         &out_queue->notification_ring);
   }
 
-  // Register this queue's epoch signal in the shared table for cross-queue
-  // barrier emission lookups. Must happen after notification ring init (which
-  // creates the epoch signal) and before any submissions.
-  if (iree_status_is_ok(status)) {
-    iree_hal_amdgpu_epoch_signal_table_register(
-        epoch_table, iree_async_axis_queue_index(axis),
-        iree_hal_amdgpu_notification_ring_epoch_signal(
-            &out_queue->notification_ring));
-    out_queue->epoch_table = epoch_table;
-  }
-
   if (iree_status_is_ok(status)) {
     iree_thread_create_params_t thread_params;
     memset(&thread_params, 0, sizeof(thread_params));
@@ -1002,6 +1034,17 @@ iree_status_t iree_hal_amdgpu_host_queue_initialize(
     status = iree_thread_create(
         iree_hal_amdgpu_host_queue_completion_thread_main, out_queue,
         thread_params, host_allocator, &out_queue->completion.thread);
+  }
+  // Publish the epoch signal only after every queue-owned resource and the
+  // completion service are live. Lazy private-queue lookups pair this release
+  // with an acquire; ordinary queues predate device publication. The physical
+  // device publishes queue routability in a later step.
+  if (iree_status_is_ok(status)) {
+    iree_hal_amdgpu_epoch_signal_table_register(
+        epoch_table, iree_async_axis_queue_index(axis),
+        iree_hal_amdgpu_notification_ring_epoch_signal(
+            &out_queue->notification_ring));
+    out_queue->epoch_table = epoch_table;
   }
   if (!iree_status_is_ok(status)) {
     iree_hal_amdgpu_host_queue_deinitialize(out_queue);
@@ -1099,13 +1142,10 @@ void iree_hal_amdgpu_host_queue_finish_deinitialize(
     queue->epoch_table = NULL;
   }
 
-  if (queue->frontier_tracker) {
-    iree_async_frontier_tracker_retire_axis(
-        queue->frontier_tracker, queue->axis,
-        iree_status_from_code(IREE_STATUS_CANCELLED));
-    queue->frontier_tracker = NULL;
-    queue->axis = 0;
-  }
+  // The physical device owns the permanently reserved frontier axis and
+  // retires it only after every queue sharing its assignment is quiescent.
+  queue->frontier_tracker = NULL;
+  queue->axis = 0;
 
   iree_hal_amdgpu_notification_ring_deinitialize(&queue->notification_ring);
 

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue.h
@@ -481,8 +481,10 @@ typedef struct iree_hal_amdgpu_host_queue_t {
   // when emitting AQL barrier-value packets for multi-axis dependencies.
   //
   // Borrowed from the logical device and valid for the lifetime of the queue.
-  // This queue's own epoch signal is registered at init and deregistered at
-  // deinit. Read-only during normal operation.
+  // This queue's own epoch signal is published at init and withdrawn at deinit.
+  // Ordinary queue signals predate device publication and use plain lookup
+  // loads; one release/acquire mask publishes lazily materialized private
+  // queues without mutating the table's identity or storage.
   iree_hal_amdgpu_epoch_signal_table_t* epoch_table;
 
   // Last semaphore pushed to the notification ring and its epoch. Used to
@@ -644,6 +646,17 @@ void iree_hal_amdgpu_host_queue_enqueue_post_drain_action(
     iree_hal_amdgpu_host_queue_post_drain_action_t* action,
     iree_hal_amdgpu_host_queue_post_drain_fn_t fn, void* user_data);
 
+// Immutable native attributes applied while creating one host queue.
+typedef struct iree_hal_amdgpu_host_queue_create_options_t {
+  // Number of bits in |compute_unit_mask|. Zero selects ordinary legacy queue
+  // creation without an explicit mask.
+  uint32_t compute_unit_mask_bit_count;
+  // Complete native CU mask applied before the new queue is published to any
+  // submission path. NULL exactly when |compute_unit_mask_bit_count| is zero.
+  // Borrowed for the duration of queue initialization.
+  const uint32_t* compute_unit_mask;
+} iree_hal_amdgpu_host_queue_create_options_t;
+
 // Initializes a host queue in caller-provided memory.
 // The caller must allocate at least sizeof(iree_hal_amdgpu_host_queue_t).
 //
@@ -651,13 +664,20 @@ void iree_hal_amdgpu_host_queue_enqueue_post_drain_action(
 // it, allocates a kernarg ring from |kernarg_memory|, creates the epoch signal
 // and notification ring, and starts the completion thread.
 //
+// |create_options| optionally applies a CU mask immediately after ordinary HSA
+// queue creation and before any queue-owned submission resource is published.
+// A failed mask operation destroys the native queue and fails initialization.
+//
 // |axis| is this queue's identity in the causal graph. Its device index is the
 // topology-assigned HAL logical device index and its queue index is the
 // flattened logical queue ordinal within that device.
 //
-// |epoch_table| is the logical-device epoch signal table for cross-queue
-// barrier emission. This queue registers its epoch signal in the table at init
-// and deregisters at deinit. The table must outlive the queue.
+// |frontier_tracker| must already contain |axis|; physical-device topology
+// setup permanently reserves every possible queue axis before concurrent
+// tracker lookups begin. |epoch_table| is the logical-device epoch signal table
+// for cross-queue barrier emission. This queue publishes its epoch signal after
+// full initialization and deregisters it at deinit. The table must outlive the
+// queue.
 //
 // |feedback_state| is borrowed from the logical device. When enabled, queue
 // retirement drains the physical-device feedback channel before releasing
@@ -705,6 +725,7 @@ iree_status_t iree_hal_amdgpu_host_queue_initialize(
     const iree_hal_amdgpu_libhsa_t* libhsa, iree_hal_device_t* logical_device,
     void* hostcall_buffer, iree_async_proactor_t* proactor,
     hsa_agent_t gpu_agent,
+    const iree_hal_amdgpu_host_queue_create_options_t* create_options,
     const iree_hal_amdgpu_kernarg_ring_memory_t* kernarg_memory,
     hsa_amd_memory_pool_t pm4_ib_pool,
     iree_async_frontier_tracker_t* frontier_tracker, iree_async_axis_t axis,

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_test.cc
@@ -1169,6 +1169,49 @@ TEST_F(HostQueueCommandBufferTest,
 }
 
 TEST_F(HostQueueCommandBufferTest,
+       AutoCommandBufferModeFallsBackToAqlForLargeReservedQueueSet) {
+  iree_hal_amdgpu_aql_queue_execution_mode_t execution_mode;
+  IREE_ASSERT_OK(iree_hal_amdgpu_query_aql_queue_execution_mode(
+      &libhsa_, topology_.gpu_agents[0], &execution_mode));
+  if (execution_mode != IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_NATIVE) {
+    GTEST_SKIP() << "fixed-mask queues require native GPU-consumed AQL";
+  }
+
+  iree_hal_amdgpu_logical_device_options_t options;
+  iree_hal_amdgpu_logical_device_options_initialize(&options);
+  options.command_buffer_mode = IREE_HAL_AMDGPU_COMMAND_BUFFER_MODE_AUTO;
+  options.host_queues.experimental_execution_queue_count = 64;
+  options.preallocate_pools = 0;
+
+  iree_hal_amdgpu_topology_t single_gpu_topology;
+  iree_hal_amdgpu_topology_initialize(&single_gpu_topology);
+  IREE_ASSERT_OK(iree_hal_amdgpu_topology_insert_gpu_agent(
+      &single_gpu_topology, &libhsa_, topology_.gpu_agents[0],
+      topology_.cpu_agents[topology_.gpu_cpu_map[0]]));
+  single_gpu_topology.gpu_agent_queue_count =
+      IREE_HAL_AMDGPU_DEFAULT_GPU_AGENT_QUEUE_COUNT;
+
+  TestLogicalDevice test_device;
+  IREE_ASSERT_OK(test_device.Initialize(&options, &libhsa_,
+                                        &single_gpu_topology, host_allocator_));
+
+  iree_hal_amdgpu_physical_device_t* physical_device =
+      test_device.logical_device()->physical_devices[0];
+  ASSERT_GT(physical_device->host_queue_capacity,
+            IREE_HAL_AMDGPU_PM4_PHYSICAL_QUEUE_CAPACITY);
+  ASSERT_EQ(physical_device->host_queue_ordinary_count, 1u);
+
+  Ref<iree_hal_command_buffer_t> command_buffer;
+  IREE_ASSERT_OK(iree_hal_command_buffer_create(
+      test_device.base_device(), iree_hal_queue_family(test_device.queue()),
+      IREE_HAL_COMMAND_BUFFER_MODE_DEFAULT, IREE_HAL_COMMAND_CATEGORY_DISPATCH,
+      /*binding_capacity=*/0, command_buffer.out()));
+  EXPECT_TRUE(iree_hal_amdgpu_aql_command_buffer_isa(command_buffer));
+  EXPECT_FALSE(iree_hal_amdgpu_pm4_command_buffer_isa(command_buffer));
+  iree_hal_amdgpu_topology_deinitialize(&single_gpu_topology);
+}
+
+TEST_F(HostQueueCommandBufferTest,
        Pm4DispatchDirectUsesThreadDimensionsForMultiWorkgroupDispatch) {
   constexpr uint32_t kWorkgroupCount = 32u;
 

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -12,6 +12,7 @@
 #include "iree/hal/drivers/amdgpu/abi/signal.h"
 #include "iree/hal/drivers/amdgpu/allocator.h"
 #include "iree/hal/drivers/amdgpu/api.h"
+#include "iree/hal/drivers/amdgpu/api_experimental.h"
 #include "iree/hal/drivers/amdgpu/aql_command_buffer.h"
 #include "iree/hal/drivers/amdgpu/aql_program_builder.h"
 #include "iree/hal/drivers/amdgpu/device_spec_builder.h"
@@ -213,10 +214,31 @@ iree_hal_amdgpu_logical_device_options_query_host_compatibility(
   return IREE_HAL_AMDGPU_LOGICAL_DEVICE_HOST_COMPATIBILITY_COMPATIBLE;
 }
 
+static bool iree_hal_amdgpu_parse_decimal_uint32(iree_string_view_t value,
+                                                 uint32_t* out_value) {
+  if (iree_string_view_is_empty(value)) return false;
+  uint32_t parsed_value = 0;
+  for (iree_host_size_t i = 0; i < value.size; ++i) {
+    const char character = value.data[i];
+    if (character < '0' || character > '9') return false;
+    const uint32_t digit = (uint32_t)(character - '0');
+    if (parsed_value > (UINT32_MAX - digit) / 10u) return false;
+    parsed_value = parsed_value * 10u + digit;
+  }
+  *out_value = parsed_value;
+  return true;
+}
+
 IREE_API_EXPORT iree_status_t iree_hal_amdgpu_logical_device_options_parse(
     iree_hal_amdgpu_logical_device_options_t* options,
     iree_string_pair_list_t params) {
   IREE_ASSERT_ARGUMENT(options);
+  if (params.count != 0 && !params.pairs) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "AMDGPU device option list has count %" PRIhsz
+                            " but no value storage",
+                            params.count);
+  }
   if (!params.count) return iree_ok_status();
   IREE_TRACE_ZONE_BEGIN(z0);
 
@@ -224,11 +246,23 @@ IREE_API_EXPORT iree_status_t iree_hal_amdgpu_logical_device_options_parse(
   for (iree_host_size_t i = 0; i < params.count && iree_status_is_ok(status);
        ++i) {
     const iree_string_pair_t* param = &params.pairs[i];
-    status = iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "AMDGPU logical device options do not support key/value parameter "
-        "'%.*s'",
-        (int)param->key.size, param->key.data);
+    if (iree_string_view_equal(param->key,
+                               IREE_SV("experimental_execution_queue_count"))) {
+      if (!iree_hal_amdgpu_parse_decimal_uint32(
+              param->value,
+              &options->host_queues.experimental_execution_queue_count)) {
+        status = iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "invalid AMDGPU experimental execution queue count '%.*s'",
+            (int)param->value.size, param->value.data);
+      }
+    } else {
+      status = iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "AMDGPU logical device options do not support key/value parameter "
+          "'%.*s'",
+          (int)param->key.size, param->key.data);
+    }
   }
 
   IREE_TRACE_ZONE_END(z0);
@@ -517,6 +551,16 @@ static iree_status_t iree_hal_amdgpu_logical_device_options_verify(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_amdgpu_logical_device_options_verify_supported_features(
               options));
+
+  if (options->host_queues.experimental_execution_queue_count != 0 &&
+      options->tsan.enabled) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0,
+        iree_make_status(
+            IREE_STATUS_UNIMPLEMENTED,
+            "experimental AMDGPU execution queues cannot be combined with "
+            "device TSAN because TSAN queue state is immutable after load"));
+  }
 
   if (options->host_block_pools.small.block_size <
           IREE_HAL_AMDGPU_LOGICAL_DEVICE_MIN_SMALL_HOST_BLOCK_SIZE ||
@@ -972,8 +1016,12 @@ static iree_status_t iree_hal_amdgpu_logical_device_write_profile_queues(
     const uint32_t physical_device_ordinal =
         (uint32_t)physical_device->device_ordinal;
     for (iree_host_size_t j = 0;
-         j < physical_device->host_queue_count && iree_status_is_ok(status);
+         j < physical_device->host_queue_capacity && iree_status_is_ok(status);
          ++j) {
+      if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+              physical_device, j)) {
+        continue;
+      }
       if (IREE_UNLIKELY(j > UINT32_MAX)) {
         status = iree_make_status(
             IREE_STATUS_OUT_OF_RANGE,
@@ -1115,8 +1163,12 @@ static iree_status_t iree_hal_amdgpu_logical_device_write_profile_events(
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
     for (iree_host_size_t j = 0;
-         j < physical_device->host_queue_count && iree_status_is_ok(status);
+         j < physical_device->host_queue_capacity && iree_status_is_ok(status);
          ++j) {
+      if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+              physical_device, j)) {
+        continue;
+      }
       status = iree_hal_amdgpu_host_queue_write_profile_events(
           &physical_device->host_queues[j], sink, session_id);
     }
@@ -1153,7 +1205,12 @@ static void iree_hal_amdgpu_logical_device_set_queue_profiling_enabled(
   for (iree_host_size_t i = 0; i < logical_device->physical_device_count; ++i) {
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
-    for (iree_host_size_t j = 0; j < physical_device->host_queue_count; ++j) {
+    for (iree_host_size_t j = 0; j < physical_device->host_queue_capacity;
+         ++j) {
+      if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+              physical_device, j)) {
+        continue;
+      }
       iree_hal_amdgpu_host_queue_set_profile_flags(
           &physical_device->host_queues[j], flags);
     }
@@ -1172,8 +1229,12 @@ iree_hal_amdgpu_logical_device_ensure_queue_device_profile_event_storage(
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
     for (iree_host_size_t j = 0;
-         j < physical_device->host_queue_count && iree_status_is_ok(status);
+         j < physical_device->host_queue_capacity && iree_status_is_ok(status);
          ++j) {
+      if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+              physical_device, j)) {
+        continue;
+      }
       iree_hal_amdgpu_host_queue_t* queue = &physical_device->host_queues[j];
       status = iree_hal_amdgpu_host_queue_ensure_profile_event_storage(queue);
       if (iree_status_is_ok(status)) {
@@ -1231,14 +1292,15 @@ static iree_status_t iree_hal_amdgpu_logical_device_set_hsa_profiling_enabled(
 static bool iree_hal_amdgpu_logical_device_is_profile_counter_range_queue(
     const iree_hal_amdgpu_physical_device_t* physical_device,
     iree_host_size_t queue_ordinal) {
-  return queue_ordinal + 1 == physical_device->host_queue_count;
+  return queue_ordinal + 1 == physical_device->host_queue_ordinary_count;
 }
 
 static iree_hal_amdgpu_host_queue_t*
 iree_hal_amdgpu_logical_device_select_profile_counter_range_queue(
     iree_hal_amdgpu_physical_device_t* physical_device) {
-  if (physical_device->host_queue_count == 0) return NULL;
-  return &physical_device->host_queues[physical_device->host_queue_count - 1];
+  if (physical_device->host_queue_ordinary_count == 0) return NULL;
+  return &physical_device
+              ->host_queues[physical_device->host_queue_ordinary_count - 1];
 }
 
 static iree_status_t
@@ -1264,8 +1326,12 @@ iree_hal_amdgpu_logical_device_set_counter_profiling_enabled(
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
     for (iree_host_size_t j = 0;
-         j < physical_device->host_queue_count && iree_status_is_ok(status);
+         j < physical_device->host_queue_capacity && iree_status_is_ok(status);
          ++j) {
+      if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+              physical_device, j)) {
+        continue;
+      }
       iree_hal_amdgpu_host_queue_t* queue = &physical_device->host_queues[j];
       if (enabled) {
         iree_hal_amdgpu_profile_counter_enable_flags_t flags =
@@ -1291,7 +1357,12 @@ iree_hal_amdgpu_logical_device_set_counter_profiling_enabled(
          ++i) {
       iree_hal_amdgpu_physical_device_t* physical_device =
           logical_device->physical_devices[i];
-      for (iree_host_size_t j = 0; j < physical_device->host_queue_count; ++j) {
+      for (iree_host_size_t j = 0; j < physical_device->host_queue_capacity;
+           ++j) {
+        if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+                physical_device, j)) {
+          continue;
+        }
         iree_hal_amdgpu_host_queue_disable_profile_counters(
             &physical_device->host_queues[j]);
       }
@@ -1319,7 +1390,7 @@ iree_hal_amdgpu_logical_device_start_profile_counter_ranges(
        ++i) {
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
-    if (IREE_UNLIKELY(physical_device->host_queue_count == 0)) {
+    if (IREE_UNLIKELY(physical_device->host_queue_ordinary_count == 0)) {
       status = iree_make_status(IREE_STATUS_INTERNAL,
                                 "logical device physical device has no host "
                                 "queues (initialization incomplete)");
@@ -1370,7 +1441,7 @@ iree_hal_amdgpu_logical_device_flush_profile_counter_ranges(
        ++i) {
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
-    if (IREE_UNLIKELY(physical_device->host_queue_count == 0)) {
+    if (IREE_UNLIKELY(physical_device->host_queue_ordinary_count == 0)) {
       status = iree_make_status(IREE_STATUS_INTERNAL,
                                 "logical device physical device has no host "
                                 "queues (initialization incomplete)");
@@ -1404,8 +1475,12 @@ static iree_status_t iree_hal_amdgpu_logical_device_set_trace_profiling_enabled(
     iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
     for (iree_host_size_t j = 0;
-         j < physical_device->host_queue_count && iree_status_is_ok(status);
+         j < physical_device->host_queue_capacity && iree_status_is_ok(status);
          ++j) {
+      if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+              physical_device, j)) {
+        continue;
+      }
       iree_hal_amdgpu_host_queue_t* queue = &physical_device->host_queues[j];
       if (enabled) {
         status = iree_hal_amdgpu_host_queue_enable_profile_traces(
@@ -1426,11 +1501,16 @@ static iree_status_t iree_hal_amdgpu_logical_device_set_trace_profiling_enabled(
          ++i) {
       iree_hal_amdgpu_physical_device_t* physical_device =
           logical_device->physical_devices[i];
-      for (iree_host_size_t j = 0; j < physical_device->host_queue_count &&
+      for (iree_host_size_t j = 0; j < physical_device->host_queue_capacity &&
                                    seen_queue_count < changed_queue_count;
-           ++j, ++seen_queue_count) {
+           ++j) {
+        if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+                physical_device, j)) {
+          continue;
+        }
         iree_hal_amdgpu_host_queue_disable_profile_traces(
             &physical_device->host_queues[j]);
+        ++seen_queue_count;
       }
     }
   }
@@ -1492,7 +1572,8 @@ bool iree_hal_amdgpu_logical_device_lookup_host_queue_epoch_wait(
   iree_hal_amdgpu_physical_device_t* physical_device =
       logical_device->physical_devices[physical_device_ordinal];
 
-  if (physical_queue_ordinal >= physical_device->host_queue_count) {
+  if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+          physical_device, physical_queue_ordinal)) {
     return false;
   }
   iree_hal_amdgpu_host_queue_t* queue =
@@ -1515,6 +1596,9 @@ bool iree_hal_amdgpu_logical_device_lookup_host_queue_epoch_wait(
 static void iree_hal_amdgpu_logical_device_deassign_frontier(
     iree_hal_amdgpu_logical_device_t* logical_device) {
   IREE_TRACE_ZONE_BEGIN(z0);
+  iree_atomic_store(&logical_device->execution_queue_configuration_frozen, 1,
+                    iree_memory_order_release);
+  iree_slim_mutex_lock(&logical_device->execution_queue_configuration_mutex);
   for (iree_host_size_t i = 0; i < logical_device->physical_device_count; ++i) {
     iree_hal_amdgpu_physical_device_deassign_frontier(
         logical_device->physical_devices[i]);
@@ -1531,6 +1615,9 @@ static void iree_hal_amdgpu_logical_device_deassign_frontier(
                         logical_device->host_queue_epoch_table);
     logical_device->host_queue_epoch_table = NULL;
   }
+  iree_atomic_store(&logical_device->execution_queue_configuration_frozen, 0,
+                    iree_memory_order_release);
+  iree_slim_mutex_unlock(&logical_device->execution_queue_configuration_mutex);
   IREE_TRACE_ZONE_END(z0);
 }
 
@@ -1599,6 +1686,9 @@ static void iree_hal_amdgpu_logical_device_translate_physical_options(
   out_options->host_block_pool_initial_capacity =
       options->preallocate_pools ? 16 : 0;
   out_options->host_queue_count = topology->gpu_agent_queue_count;
+  out_options->host_queue_ordinary_capacity =
+      topology->gpu_agent_queue_count -
+      options->host_queues.experimental_execution_queue_count;
   out_options->host_queue_aql_capacity = options->host_queues.aql_capacity;
   out_options->host_queue_notification_capacity =
       options->host_queues.notification_capacity;
@@ -1661,6 +1751,10 @@ static iree_status_t iree_hal_amdgpu_logical_device_allocate_storage(
   iree_atomic_store(&logical_device->epoch, 0, iree_memory_order_relaxed);
   iree_atomic_store(&logical_device->next_executable_id, 1,
                     iree_memory_order_relaxed);
+  iree_atomic_store(&logical_device->execution_queue_configuration_frozen, 0,
+                    iree_memory_order_relaxed);
+  iree_slim_mutex_initialize(
+      &logical_device->execution_queue_configuration_mutex);
   logical_device->next_profile_session_id = 1;
   iree_hal_amdgpu_profile_metadata_initialize(
       host_allocator, &logical_device->profile_metadata);
@@ -1771,13 +1865,14 @@ static iree_status_t iree_hal_amdgpu_logical_device_create_device_spec(
     const iree_hal_amdgpu_physical_device_t* physical_device =
         logical_device->physical_devices[i];
     if (IREE_UNLIKELY(physical_device->device_ordinal > UINT32_MAX ||
-                      physical_device->host_queue_capacity > UINT32_MAX)) {
+                      physical_device->host_queue_ordinary_capacity >
+                          UINT32_MAX)) {
       status =
           iree_make_status(IREE_STATUS_OUT_OF_RANGE,
                            "AMDGPU device spec physical row out of range: "
                            "device_ordinal=%" PRIhsz ", queue_count=%" PRIhsz,
                            physical_device->device_ordinal,
-                           physical_device->host_queue_capacity);
+                           physical_device->host_queue_ordinary_capacity);
       break;
     }
 
@@ -1805,7 +1900,7 @@ static iree_status_t iree_hal_amdgpu_logical_device_create_device_spec(
     physical_params->physical_ordinal =
         (uint32_t)physical_device->device_ordinal;
     physical_params->queue_count =
-        (uint32_t)physical_device->host_queue_capacity;
+        (uint32_t)physical_device->host_queue_ordinary_capacity;
     physical_params->compute_unit_count = physical_device->compute_unit_count;
     physical_params->wavefront_size = physical_device->wavefront_size;
     physical_params->maximum_waves_per_compute_unit =
@@ -1889,23 +1984,47 @@ iree_status_t iree_hal_amdgpu_logical_device_create(
         IREE_HAL_AMDGPU_LOGICAL_DEVICE_PM4_UPLOAD_CAPACITY_DEFAULT;
   }
 
+  iree_hal_amdgpu_topology_t resolved_topology = *topology;
+  if (resolved_options.host_queues.experimental_execution_queue_count > 64) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0,
+        iree_make_status(
+            IREE_STATUS_OUT_OF_RANGE,
+            "experimental AMDGPU execution queue count must not exceed 64 "
+            "(got %u)",
+            resolved_options.host_queues.experimental_execution_queue_count));
+  }
+  if (!iree_host_size_checked_add(
+          topology->gpu_agent_queue_count,
+          resolved_options.host_queues.experimental_execution_queue_count,
+          &resolved_topology.gpu_agent_queue_count)) {
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0,
+        iree_make_status(
+            IREE_STATUS_OUT_OF_RANGE,
+            "AMDGPU queues per physical device overflow when reserving %u "
+            "experimental queues",
+            resolved_options.host_queues.experimental_execution_queue_count));
+  }
+  const iree_hal_amdgpu_topology_t* device_topology = &resolved_topology;
+
   // Verify the topology is valid for a logical device.
   // This may have already been performed by the caller but doing it here
   // ensures all code paths must verify prior to creating a device.
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_amdgpu_topology_verify(topology, libhsa),
+      z0, iree_hal_amdgpu_topology_verify(device_topology, libhsa),
       "verifying topology");
 
   // Verify the parameters prior to creating resources.
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0,
       iree_hal_amdgpu_logical_device_options_verify(&resolved_options, libhsa,
-                                                    topology),
+                                                    device_topology),
       "verifying logical device options");
 
   iree_hal_amdgpu_physical_device_options_t physical_device_options = {0};
   iree_hal_amdgpu_logical_device_translate_physical_options(
-      &resolved_options, topology, &physical_device_options);
+      &resolved_options, device_topology, &physical_device_options);
 
   // Verify all GPU agents meet the required physical device options. Each
   // embedded physical device has the same layout because all physical devices
@@ -1915,14 +2034,14 @@ iree_status_t iree_hal_amdgpu_logical_device_create(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0,
       iree_hal_amdgpu_logical_device_verify_physical_options(
-          &physical_device_options, libhsa, topology),
+          &physical_device_options, libhsa, device_topology),
       "verifying physical device options");
 
   // Allocate the logical device and all nested physical device data structures.
   iree_hal_amdgpu_logical_device_t* logical_device = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_amdgpu_logical_device_allocate_storage(
-              identifier, topology, physical_device_size, host_allocator,
+              identifier, device_topology, physical_device_size, host_allocator,
               &logical_device));
   iree_status_t status =
       iree_hal_amdgpu_logical_device_initialize_host_resources(
@@ -1934,12 +2053,13 @@ iree_status_t iree_hal_amdgpu_logical_device_create(
       resolved_options.suppress_device_fine_memory;
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_logical_device_initialize_system_and_allocator(
-        logical_device, &resolved_options, libhsa, topology, host_allocator);
+        logical_device, &resolved_options, libhsa, device_topology,
+        host_allocator);
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_logical_device_initialize_physical_devices(
-        logical_device, topology, &physical_device_options, hostcall_provider,
-        host_allocator);
+        logical_device, device_topology, &physical_device_options,
+        hostcall_provider, host_allocator);
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_amdgpu_logical_device_create_device_spec(
@@ -2016,7 +2136,12 @@ static void iree_hal_amdgpu_logical_device_destroy(
          ++i) {
       iree_hal_amdgpu_physical_device_t* physical_device =
           logical_device->physical_devices[i];
-      for (iree_host_size_t j = 0; j < physical_device->host_queue_count; ++j) {
+      for (iree_host_size_t j = 0; j < physical_device->host_queue_capacity;
+           ++j) {
+        if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+                physical_device, j)) {
+          continue;
+        }
         iree_hal_amdgpu_host_queue_disable_profile_traces(
             &physical_device->host_queues[j]);
       }
@@ -2029,7 +2154,12 @@ static void iree_hal_amdgpu_logical_device_destroy(
          ++i) {
       iree_hal_amdgpu_physical_device_t* physical_device =
           logical_device->physical_devices[i];
-      for (iree_host_size_t j = 0; j < physical_device->host_queue_count; ++j) {
+      for (iree_host_size_t j = 0; j < physical_device->host_queue_capacity;
+           ++j) {
+        if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+                physical_device, j)) {
+          continue;
+        }
         iree_hal_amdgpu_host_queue_disable_profile_counters(
             &physical_device->host_queues[j]);
       }
@@ -2086,6 +2216,8 @@ static void iree_hal_amdgpu_logical_device_destroy(
 
   iree_async_proactor_pool_release(logical_device->proactor_pool);
 
+  iree_slim_mutex_deinitialize(
+      &logical_device->execution_queue_configuration_mutex);
   iree_allocator_free(host_allocator, logical_device);
 
   IREE_TRACE_ZONE_END(z0);
@@ -2171,7 +2303,7 @@ static iree_hal_queue_t* iree_hal_amdgpu_logical_device_queue(
   if (family_ordinal >= logical_device->physical_device_count) return NULL;
   iree_hal_amdgpu_physical_device_t* physical_device =
       logical_device->physical_devices[family_ordinal];
-  if (queue_ordinal >= physical_device->host_queue_count) return NULL;
+  if (queue_ordinal >= physical_device->host_queue_ordinary_count) return NULL;
   return &physical_device->host_queues[queue_ordinal].base;
 }
 
@@ -2533,7 +2665,10 @@ static iree_status_t iree_hal_amdgpu_logical_device_assign_topology_info(
         iree_async_axis_session(topology_info->frontier.base_axis),
         iree_async_axis_machine(topology_info->frontier.base_axis),
         iree_async_axis_device_index(topology_info->frontier.base_axis),
-        (uint16_t)logical_queue_count);
+        (uint16_t)logical_queue_count,
+        (uint16_t)system->topology.gpu_agent_queue_count,
+        (uint16_t)logical_device->physical_devices[0]
+            ->host_queue_ordinary_capacity);
   }
 
   for (iree_host_size_t device_ordinal = 0;
@@ -2591,7 +2726,7 @@ static iree_status_t iree_hal_amdgpu_logical_device_create_aql_command_buffer(
     iree_hal_command_buffer_t** out_command_buffer) {
   return iree_hal_amdgpu_aql_command_buffer_create(
       logical_device->device_allocator, queue_family, mode, command_categories,
-      binding_capacity, device_ordinal, physical_device->host_queue_count,
+      binding_capacity, device_ordinal, physical_device->host_queue_capacity,
       iree_hal_amdgpu_tsan_state_is_enabled(&logical_device->tsan)
           ? logical_device->tsan.device_states[device_ordinal]
                 .config.shadow_slot_count
@@ -2650,6 +2785,10 @@ static bool iree_hal_amdgpu_logical_device_can_auto_select_pm4_command_buffer(
           physical_device->vendor_packet_capabilities)) {
     return false;
   }
+  if (physical_device->host_queue_capacity >
+      IREE_HAL_AMDGPU_PM4_PHYSICAL_QUEUE_CAPACITY) {
+    return false;
+  }
   if (iree_hal_amdgpu_logical_device_profiling_requests_dispatch_timestamps(
           logical_device) &&
       !iree_hal_amdgpu_pm4_timestamp_strategy_supports_ranges(
@@ -2704,7 +2843,7 @@ static iree_status_t iree_hal_amdgpu_logical_device_create_pm4_command_buffer(
   }
   return iree_hal_amdgpu_pm4_command_buffer_create(
       logical_device->device_allocator, queue_family, mode, command_categories,
-      binding_capacity, device_ordinal, physical_device->host_queue_count,
+      binding_capacity, device_ordinal, physical_device->host_queue_capacity,
       flags, physical_device->vendor_packet_capabilities,
       &physical_device->atomic_pm4_context,
       &physical_device->buffer_transfer_context,
@@ -2771,14 +2910,26 @@ static iree_status_t iree_hal_amdgpu_logical_device_load_executable(
       iree_hal_queue_family_ordinal(queue_family);
   iree_hal_amdgpu_physical_device_t* physical_device =
       logical_device->physical_devices[queue_family_ordinal];
-  const iree_host_size_t queue_scope_count = physical_device->host_queue_count;
+  const iree_host_size_t queue_scope_count =
+      physical_device->host_queue_capacity;
   iree_hal_amdgpu_queue_scope_t* queue_scopes = NULL;
   if (queue_scope_count != 0) {
     queue_scopes = (iree_hal_amdgpu_queue_scope_t*)iree_alloca(
         queue_scope_count * sizeof(queue_scopes[0]));
-    for (iree_host_size_t i = 0; i < physical_device->host_queue_count; ++i) {
-      iree_hal_amdgpu_host_queue_query_scope(&physical_device->host_queues[i],
-                                             &queue_scopes[i]);
+    for (iree_host_size_t i = 0; i < queue_scope_count; ++i) {
+      if (iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+              physical_device, i)) {
+        iree_hal_amdgpu_host_queue_query_scope(&physical_device->host_queues[i],
+                                               &queue_scopes[i]);
+      } else {
+        // Private queues can be configured after executable load. TSAN is
+        // rejected with private queues, so only canonical queue identity is
+        // required for an unmaterialized slot.
+        queue_scopes[i] = (iree_hal_amdgpu_queue_scope_t){
+            .physical_device_ordinal = physical_device->device_ordinal,
+            .physical_queue_ordinal = (iree_hal_queue_ordinal_t)i,
+        };
+      }
     }
   }
 
@@ -2847,6 +2998,316 @@ static iree_status_t iree_hal_amdgpu_logical_device_query_queue_pool_backend(
   return iree_ok_status();
 }
 
+typedef struct iree_hal_amdgpu_execution_queue_native_topology_t {
+  uint32_t mask_alignment;
+  uint32_t mask_partition_count;
+} iree_hal_amdgpu_execution_queue_native_topology_t;
+
+static iree_status_t
+iree_hal_amdgpu_logical_device_query_execution_queue_native_topology(
+    iree_hal_amdgpu_logical_device_t* logical_device,
+    iree_hal_amdgpu_physical_device_t* physical_device,
+    iree_hal_amdgpu_execution_queue_native_topology_t* out_topology) {
+  memset(out_topology, 0, sizeof(*out_topology));
+  IREE_RETURN_IF_ERROR(
+      iree_hsa_agent_get_info(IREE_LIBHSA(&logical_device->system->libhsa),
+                              physical_device->device_agent,
+                              (hsa_agent_info_t)HSA_AMD_AGENT_INFO_NUM_XCC,
+                              &out_topology->mask_partition_count));
+  if (IREE_UNLIKELY(out_topology->mask_partition_count == 0)) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "physical device %" PRIhsz
+                            " reports no hardware CU-mask partitions",
+                            physical_device->device_ordinal);
+  }
+
+  const iree_hal_amdgpu_gfxip_version_t gfxip_version =
+      physical_device->agent_target->primary_isa.identity.version;
+  switch (gfxip_version.major) {
+    case 9:
+      out_topology->mask_alignment = 1;
+      break;
+    case 10:
+    case 11:
+      out_topology->mask_alignment = 2;
+      break;
+    case 12:
+      if (gfxip_version.minor != 0 && gfxip_version.minor != 5) {
+        return iree_make_status(
+            IREE_STATUS_UNIMPLEMENTED,
+            "AMDGPU execution queue topology is not defined for gfx%u.%u.%u",
+            gfxip_version.major, gfxip_version.minor, gfxip_version.stepping);
+      }
+      out_topology->mask_alignment = 2;
+      break;
+    default:
+      return iree_make_status(
+          IREE_STATUS_UNIMPLEMENTED,
+          "AMDGPU execution queue topology is not defined for gfx%u.%u.%u",
+          gfxip_version.major, gfxip_version.minor, gfxip_version.stepping);
+  }
+  if (IREE_UNLIKELY(physical_device->compute_unit_count %
+                        out_topology->mask_alignment !=
+                    0)) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "physical device %" PRIhsz
+        " reports incompatible native CU topology: %u CUs, %u-bit native "
+        "mask alignment, and %u hardware partitions",
+        physical_device->device_ordinal, physical_device->compute_unit_count,
+        out_topology->mask_alignment, out_topology->mask_partition_count);
+  }
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t
+iree_hal_amdgpu_experimental_execution_queue_query(
+    iree_hal_device_t* base_device, iree_host_size_t physical_device_ordinal,
+    iree_hal_amdgpu_experimental_execution_queue_topology_t* out_topology) {
+  if (IREE_UNLIKELY(!out_topology)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "out_topology must not be NULL");
+  }
+  memset(out_topology, 0, sizeof(*out_topology));
+  if (IREE_UNLIKELY(!iree_hal_resource_is(
+          base_device, &iree_hal_amdgpu_logical_device_vtable))) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "experimental execution queues require an exact native AMDGPU device");
+  }
+
+  iree_hal_amdgpu_logical_device_t* logical_device =
+      iree_hal_amdgpu_logical_device_cast(base_device);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_logical_device_check_failure(logical_device));
+  if (IREE_UNLIKELY(physical_device_ordinal >=
+                    logical_device->physical_device_count)) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "physical device ordinal %" PRIhsz " exceeds device count %" PRIhsz,
+        physical_device_ordinal, logical_device->physical_device_count);
+  }
+
+  iree_hal_amdgpu_physical_device_t* physical_device =
+      logical_device->physical_devices[physical_device_ordinal];
+  iree_hal_amdgpu_execution_queue_native_topology_t native_topology;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_logical_device_query_execution_queue_native_topology(
+          logical_device, physical_device, &native_topology));
+
+  *out_topology = (iree_hal_amdgpu_experimental_execution_queue_topology_t){
+      .first_private_physical_queue_ordinal =
+          physical_device->host_queue_ordinary_capacity,
+      .private_physical_queue_count =
+          physical_device->host_queue_capacity -
+          physical_device->host_queue_ordinary_capacity,
+      .native_compute_unit_count = physical_device->compute_unit_count,
+      .native_compute_unit_mask_alignment = native_topology.mask_alignment,
+      .native_compute_unit_mask_partition_count =
+          native_topology.mask_partition_count,
+  };
+  return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t
+iree_hal_amdgpu_experimental_execution_queue_configure(
+    iree_hal_device_t* base_device, iree_host_size_t physical_device_ordinal,
+    iree_host_size_t physical_queue_ordinal,
+    iree_host_size_t native_mask_bit_count, const uint32_t* native_mask,
+    iree_hal_queue_t** out_queue) {
+  if (IREE_UNLIKELY(!out_queue)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "out_queue must not be NULL");
+  }
+  *out_queue = NULL;
+  if (IREE_UNLIKELY(!iree_hal_resource_is(
+          base_device, &iree_hal_amdgpu_logical_device_vtable))) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "experimental execution queues require an exact native AMDGPU device");
+  }
+  if (IREE_UNLIKELY(native_mask_bit_count == 0 || !native_mask)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "execution queue configuration requires a non-empty CU mask");
+  }
+  if (IREE_UNLIKELY(native_mask_bit_count % 32 != 0 ||
+                    native_mask_bit_count > UINT32_MAX)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "CU mask bit count must be a multiple of 32 representable "
+        "by the device API");
+  }
+
+  iree_hal_amdgpu_logical_device_t* logical_device =
+      iree_hal_amdgpu_logical_device_cast(base_device);
+  if (IREE_UNLIKELY(
+          !logical_device->system->libhsa.exact_queue_cu_mask_supported)) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "exact AMDGPU execution queue masks require IREE-owned ROCr "
+        "initialization with HSA_CU_MASK unset");
+  }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status =
+      iree_hal_amdgpu_logical_device_check_failure(logical_device);
+  if (iree_status_is_ok(status) &&
+      IREE_UNLIKELY(physical_device_ordinal >=
+                    logical_device->physical_device_count)) {
+    status = iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "physical device ordinal %" PRIhsz " exceeds device count %" PRIhsz,
+        physical_device_ordinal, logical_device->physical_device_count);
+  }
+
+  iree_hal_amdgpu_physical_device_t* physical_device = NULL;
+  iree_hal_amdgpu_execution_queue_native_topology_t native_topology = {0};
+  if (iree_status_is_ok(status)) {
+    physical_device = logical_device->physical_devices[physical_device_ordinal];
+    if (IREE_UNLIKELY(physical_queue_ordinal <
+                          physical_device->host_queue_ordinary_capacity ||
+                      physical_queue_ordinal >=
+                          physical_device->host_queue_capacity)) {
+      status = iree_make_status(
+          IREE_STATUS_OUT_OF_RANGE,
+          "physical queue ordinal %" PRIhsz
+          " is outside private range [%" PRIhsz ", %" PRIhsz
+          ") on physical device %" PRIhsz,
+          physical_queue_ordinal, physical_device->host_queue_ordinary_capacity,
+          physical_device->host_queue_capacity, physical_device_ordinal);
+    } else {
+      status =
+          iree_hal_amdgpu_logical_device_query_execution_queue_native_topology(
+              logical_device, physical_device, &native_topology);
+    }
+  }
+
+  const iree_host_size_t mask_word_count = native_mask_bit_count / 32;
+  if (iree_status_is_ok(status)) {
+    const iree_host_size_t expected_mask_bit_count = iree_host_align(
+        (iree_host_size_t)physical_device->compute_unit_count, 32);
+    if (IREE_UNLIKELY(native_mask_bit_count != expected_mask_bit_count)) {
+      status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "CU mask has %" PRIhsz
+                                " bits; physical device requires "
+                                "%" PRIhsz,
+                                native_mask_bit_count, expected_mask_bit_count);
+    }
+  }
+
+  if (iree_status_is_ok(status)) {
+    bool has_enabled_compute_unit = false;
+    for (iree_host_size_t i = 0; i < mask_word_count; ++i) {
+      has_enabled_compute_unit |= native_mask[i] != 0;
+    }
+    const uint32_t tail_bit_count = physical_device->compute_unit_count % 32u;
+    if (IREE_UNLIKELY(tail_bit_count != 0 &&
+                      (native_mask[mask_word_count - 1] &
+                       ~((UINT32_C(1) << tail_bit_count) - 1u)) != 0)) {
+      status = iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "CU mask enables units outside physical device %" PRIhsz
+          "'s %u-unit domain",
+          physical_device_ordinal, physical_device->compute_unit_count);
+    } else if (IREE_UNLIKELY(!has_enabled_compute_unit)) {
+      status =
+          iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                           "CU mask must enable at least one compute unit");
+    }
+  }
+
+  if (iree_status_is_ok(status)) {
+    const uint32_t mask_alignment = native_topology.mask_alignment;
+    for (uint32_t group_start = 0;
+         group_start < physical_device->compute_unit_count;
+         group_start += mask_alignment) {
+      const bool group_enabled = (native_mask[group_start / 32u] &
+                                  (UINT32_C(1) << (group_start % 32u))) != 0;
+      for (uint32_t bit = group_start + 1; bit < group_start + mask_alignment;
+           ++bit) {
+        const bool bit_enabled =
+            (native_mask[bit / 32u] & (UINT32_C(1) << (bit % 32u))) != 0;
+        if (IREE_UNLIKELY(bit_enabled != group_enabled)) {
+          status = iree_make_status(
+              IREE_STATUS_INVALID_ARGUMENT,
+              "CU mask for physical device %" PRIhsz
+              " partially enables native group starting at bit %u; "
+              "%u-bit groups must be entirely enabled or disabled",
+              physical_device_ordinal, group_start, mask_alignment);
+          break;
+        }
+      }
+      if (!iree_status_is_ok(status)) break;
+    }
+  }
+
+  if (iree_status_is_ok(status)) {
+    const uint32_t partition_count = native_topology.mask_partition_count;
+    for (uint32_t partition = 0; partition < partition_count; ++partition) {
+      bool has_enabled_compute_unit = false;
+      for (iree_host_size_t bit = partition;
+           bit < physical_device->compute_unit_count; bit += partition_count) {
+        has_enabled_compute_unit |=
+            (native_mask[bit / 32u] & (UINT32_C(1) << (bit % 32u))) != 0;
+      }
+      if (IREE_UNLIKELY(!has_enabled_compute_unit)) {
+        status = iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "CU mask leaves hardware partition %u of %u with no enabled "
+            "compute unit",
+            partition, partition_count);
+        break;
+      }
+    }
+  }
+
+  if (iree_status_is_ok(status)) {
+    iree_slim_mutex_lock(&logical_device->execution_queue_configuration_mutex);
+    if (IREE_UNLIKELY(iree_atomic_load(
+                          &logical_device->execution_queue_configuration_frozen,
+                          iree_memory_order_acquire) != 0)) {
+      status = iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "cannot configure an AMDGPU execution queue while profiling or "
+          "topology teardown is active");
+    } else if (IREE_UNLIKELY(!logical_device->frontier_tracker)) {
+      status = iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "cannot configure an AMDGPU execution queue before topology "
+          "assignment");
+    }
+
+    if (iree_status_is_ok(status)) {
+      const iree_hal_amdgpu_host_queue_create_options_t create_options = {
+          .compute_unit_mask_bit_count = (uint32_t)native_mask_bit_count,
+          .compute_unit_mask = native_mask,
+      };
+      status = iree_hal_amdgpu_physical_device_ensure_host_queue(
+          base_device, logical_device->system, logical_device->proactor,
+          logical_device->frontier_tracker, logical_device->axis,
+          logical_device->host_queue_epoch_table, &logical_device->feedback,
+          physical_queue_ordinal, &create_options,
+          logical_device->host_allocator, physical_device);
+    }
+
+    if (iree_status_is_ok(status)) {
+      iree_hal_amdgpu_system_event_publish_queue_target_mask(
+          physical_device->system_event_target, physical_device->host_queues,
+          physical_device->host_queue_ordinary_count,
+          physical_device->host_queue_ordinary_capacity,
+          iree_hal_amdgpu_physical_device_host_queue_private_initialized_mask(
+              physical_device));
+      *out_queue = &physical_device->host_queues[physical_queue_ordinal].base;
+    }
+    iree_slim_mutex_unlock(
+        &logical_device->execution_queue_configuration_mutex);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 static iree_status_t
 iree_hal_amdgpu_logical_device_verify_queue_device_profiling_supported(
     iree_hal_amdgpu_logical_device_t* logical_device) {
@@ -2901,6 +3362,13 @@ static iree_status_t iree_hal_amdgpu_logical_device_profiling_begin(
         iree_hal_amdgpu_logical_device_verify_queue_device_profiling_supported(
             logical_device));
   }
+
+  // Profiling snapshots the current queue set. Exclude private queue
+  // construction for the full session without eagerly materializing slots.
+  iree_atomic_store(&logical_device->execution_queue_configuration_frozen, 1,
+                    iree_memory_order_release);
+  iree_slim_mutex_lock(&logical_device->execution_queue_configuration_mutex);
+  iree_slim_mutex_unlock(&logical_device->execution_queue_configuration_mutex);
 
   bool sink_session_begun = false;
   bool hsa_profiling_enabled = false;
@@ -3061,6 +3529,8 @@ static iree_status_t iree_hal_amdgpu_logical_device_profiling_begin(
     iree_hal_amdgpu_profile_counter_session_free(counter_session);
     iree_hal_amdgpu_profile_trace_session_free(trace_session);
     iree_hal_amdgpu_profile_device_metrics_session_free(device_metrics_session);
+    iree_atomic_store(&logical_device->execution_queue_configuration_frozen, 0,
+                      iree_memory_order_release);
   }
   return status;
 }
@@ -3181,6 +3651,8 @@ static iree_status_t iree_hal_amdgpu_logical_device_profiling_end(
   iree_hal_amdgpu_profile_counter_session_free(counter_session);
   iree_hal_amdgpu_profile_trace_session_free(trace_session);
   iree_hal_amdgpu_profile_device_metrics_session_free(device_metrics_session);
+  iree_atomic_store(&logical_device->execution_queue_configuration_frozen, 0,
+                    iree_memory_order_release);
   return status;
 }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -2999,7 +2999,9 @@ static iree_status_t iree_hal_amdgpu_logical_device_query_queue_pool_backend(
 }
 
 typedef struct iree_hal_amdgpu_execution_queue_native_topology_t {
+  // Number of native mask bits in each representable group.
   uint32_t mask_alignment;
+  // Number of hardware partitions interleaved across native mask bits.
   uint32_t mask_partition_count;
 } iree_hal_amdgpu_execution_queue_native_topology_t;
 

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.h
@@ -145,6 +145,12 @@ typedef struct iree_hal_amdgpu_logical_device_t {
   // deregistered by each host queue before this table is freed.
   iree_hal_amdgpu_epoch_signal_table_t* host_queue_epoch_table;
 
+  // Non-zero while profiling or teardown excludes private queue construction.
+  iree_atomic_int32_t execution_queue_configuration_frozen;
+
+  // Serializes one-shot private queue construction with profiling and teardown.
+  iree_slim_mutex_t execution_queue_configuration_mutex;
+
   // Selected command-buffer recording and replay implementation.
   iree_hal_amdgpu_command_buffer_mode_t command_buffer_mode;
 

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device.c
@@ -208,6 +208,8 @@ void iree_hal_amdgpu_physical_device_options_initialize(
 
   out_options->host_queue_count =
       IREE_HAL_AMDGPU_PHYSICAL_DEVICE_DEFAULT_QUEUE_COUNT;
+  out_options->host_queue_ordinary_capacity =
+      IREE_HAL_AMDGPU_PHYSICAL_DEVICE_DEFAULT_QUEUE_COUNT;
   out_options->host_queue_aql_capacity =
       IREE_HAL_AMDGPU_PHYSICAL_DEVICE_DEFAULT_HOST_QUEUE_AQL_CAPACITY;
   out_options->host_queue_notification_capacity =
@@ -258,13 +260,39 @@ iree_status_t iree_hal_amdgpu_physical_device_options_verify(
         options->device_block_pools.large.block_size);
   }
 
-  if (options->host_queue_count == 0 || options->host_queue_count > UINT8_MAX) {
-    return iree_make_status(
-        IREE_STATUS_OUT_OF_RANGE,
-        "host queue count must be in [1, %u] to fit the queue-axis encoding "
-        "(got %" PRIhsz ")",
-        UINT8_MAX, options->host_queue_count);
+  if (options->host_queue_count == 0 ||
+      options->host_queue_count > IREE_HAL_AMDGPU_MAX_QUEUE_AXIS_COUNT) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "host queue count must be in [1, %" PRIhsz
+                            "] to fit the queue-axis encoding "
+                            "(got %" PRIhsz ")",
+                            IREE_HAL_AMDGPU_MAX_QUEUE_AXIS_COUNT,
+                            options->host_queue_count);
   }
+  if (options->host_queue_ordinary_capacity == 0 ||
+      options->host_queue_ordinary_capacity > options->host_queue_count) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "ordinary host queue count must be in [1, %" PRIhsz
+                            "] (got %" PRIhsz ")",
+                            options->host_queue_count,
+                            options->host_queue_ordinary_capacity);
+  }
+  if (options->host_queue_count - options->host_queue_ordinary_capacity > 64) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "private host queue count must not exceed 64");
+  }
+  if (options->host_queue_ordinary_capacity < options->host_queue_count) {
+    iree_hal_amdgpu_aql_queue_execution_mode_t execution_mode;
+    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_query_aql_queue_execution_mode(
+        libhsa, gpu_agent, &execution_mode));
+    if (execution_mode != IREE_HAL_AMDGPU_AQL_QUEUE_EXECUTION_MODE_NATIVE) {
+      return iree_make_status(
+          IREE_STATUS_UNIMPLEMENTED,
+          "fixed-mask AMDGPU execution queues require native GPU-consumed "
+          "AQL queues");
+    }
+  }
+
   if (!iree_host_size_is_power_of_two(options->host_queue_aql_capacity) ||
       !iree_host_size_is_power_of_two(
           options->host_queue_notification_capacity) ||
@@ -358,6 +386,10 @@ static iree_status_t iree_hal_amdgpu_physical_device_initialize_identity(
       &out_physical_device->queue_family);
   out_physical_device->host_memory_pools = *host_memory_pools;
   out_physical_device->host_queue_capacity = options->host_queue_count;
+  out_physical_device->host_queue_ordinary_capacity =
+      options->host_queue_ordinary_capacity;
+  iree_atomic_store(&out_physical_device->host_queue_private_initialized_mask,
+                    0, iree_memory_order_relaxed);
   out_physical_device->host_queue_aql_capacity =
       options->host_queue_aql_capacity;
   out_physical_device->host_queue_notification_capacity =
@@ -1206,7 +1238,7 @@ static iree_status_t iree_hal_amdgpu_physical_device_create_default_pools(
   return status;
 }
 
-iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
+static iree_status_t iree_hal_amdgpu_physical_device_initialize_host_queue(
     iree_hal_device_t* logical_device, iree_hal_amdgpu_system_t* system,
     iree_async_proactor_t* proactor,
     iree_async_frontier_tracker_t* frontier_tracker,
@@ -1214,15 +1246,11 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
     iree_hal_amdgpu_epoch_signal_table_t* epoch_signal_table,
     iree_hal_amdgpu_feedback_state_t* feedback_state,
     const iree_hal_amdgpu_host_memory_pools_t* host_memory_pools,
-    iree_hal_amdgpu_system_event_agent_target_t* system_event_target,
+    iree_host_size_t queue_ordinal,
+    const iree_hal_amdgpu_host_queue_create_options_t* create_options,
     iree_allocator_t host_allocator,
     iree_hal_amdgpu_physical_device_t* physical_device) {
-  IREE_TRACE_ZONE_BEGIN(z0);
-
-  physical_device->system_event_target = system_event_target;
   iree_hal_amdgpu_libhsa_t* libhsa = &system->libhsa;
-  iree_status_t status = iree_hal_amdgpu_physical_device_create_default_pools(
-      physical_device, epoch_signal_table, host_allocator);
   iree_hal_amdgpu_physical_device_kernarg_ring_memory_t kernarg_ring_memory;
   iree_hal_amdgpu_physical_device_select_kernarg_ring_memory(
       physical_device, host_memory_pools, &kernarg_ring_memory);
@@ -1232,19 +1260,10 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
     device_signal_memory_pool =
         physical_device->coarse_block_pools.small.memory_pool;
   }
-  // Raw profiling completion signals are user-signal-shaped CP timestamp
-  // targets. Native AQL queues retire them on the device. ROCr's PM4-emulated
-  // queues may retire them from the host translation worker when the device
-  // lacks platform atomics, so they require shared fine memory.
   profiling_memory.signal_memory_pool =
       iree_hal_amdgpu_select_profiling_completion_signal_memory_pool(
           device_signal_memory_pool, host_memory_pools->fine_pool,
           physical_device->aql_queue_execution_mode);
-  // Event records are serialized by the CPU after the GPU writes timestamp
-  // fields. Prefer CPU-visible device-coarse memory when available so devices
-  // without fine-grained memory can still profile. Otherwise fall back to
-  // shared host-fine memory, which remains CPU-writable and device-visible on
-  // platforms where fine device memory is not directly host-accessible.
   if (iree_hal_amdgpu_cpu_visible_device_coarse_memory_is_available(
           &physical_device->cpu_visible_device_coarse_memory)) {
     profiling_memory.event_memory_pool =
@@ -1261,6 +1280,102 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
     profiling_memory.event_access_agents = &physical_device->device_agent;
     profiling_memory.event_access_agent_count = 1;
   }
+
+  const iree_host_size_t logical_queue_ordinal =
+      physical_device->device_ordinal * physical_device->host_queue_capacity +
+      queue_ordinal;
+  const iree_async_axis_t queue_axis = iree_async_axis_make_queue(
+      iree_async_axis_session(base_axis), iree_async_axis_machine(base_axis),
+      iree_async_axis_device_index(base_axis), (uint8_t)logical_queue_ordinal);
+  iree_thread_affinity_t completion_thread_affinity;
+  iree_thread_affinity_set_group_any(physical_device->host_numa_node,
+                                     &completion_thread_affinity);
+  iree_status_t status = iree_hal_amdgpu_host_queue_initialize(
+      &physical_device->queue_family, libhsa, logical_device,
+      iree_hal_amdgpu_physical_device_hostcall_buffer(physical_device),
+      proactor, physical_device->device_agent, create_options,
+      &kernarg_ring_memory.descriptor, host_memory_pools->fine_pool,
+      frontier_tracker, queue_axis, (iree_hal_queue_ordinal_t)queue_ordinal,
+      completion_thread_affinity, physical_device->aql_queue_execution_mode,
+      physical_device->wait_barrier_strategy,
+      physical_device->vendor_packet_capabilities,
+      physical_device->pm4_timestamp_strategy, epoch_signal_table,
+      feedback_state, &physical_device->fine_host_block_pool, profiling_memory,
+      &physical_device->buffer_transfer_context,
+      &physical_device->default_pool_set, physical_device->default_pool,
+      &physical_device->transient_buffer_pool,
+      &physical_device->file_staging_pool, physical_device->device_ordinal,
+      physical_device->host_queue_aql_capacity,
+      physical_device->host_queue_notification_capacity,
+      physical_device->host_queue_kernarg_capacity,
+      physical_device->host_queue_upload_capacity, host_allocator,
+      &physical_device->host_queues[queue_ordinal]);
+  if (iree_status_is_ok(status)) {
+    if (queue_ordinal < physical_device->host_queue_ordinary_capacity) {
+      IREE_ASSERT(queue_ordinal == physical_device->host_queue_ordinary_count);
+      ++physical_device->host_queue_ordinary_count;
+    } else {
+      const iree_host_size_t private_queue_ordinal =
+          queue_ordinal - physical_device->host_queue_ordinary_capacity;
+      IREE_ASSERT(private_queue_ordinal < 64);
+      iree_atomic_fetch_or(
+          &physical_device->host_queue_private_initialized_mask,
+          UINT64_C(1) << private_queue_ordinal, iree_memory_order_release);
+    }
+    ++physical_device->host_queue_count;
+  }
+  return status;
+}
+
+iree_status_t iree_hal_amdgpu_physical_device_ensure_host_queue(
+    iree_hal_device_t* logical_device, iree_hal_amdgpu_system_t* system,
+    iree_async_proactor_t* proactor,
+    iree_async_frontier_tracker_t* frontier_tracker,
+    iree_async_axis_t base_axis,
+    iree_hal_amdgpu_epoch_signal_table_t* epoch_signal_table,
+    iree_hal_amdgpu_feedback_state_t* feedback_state,
+    iree_host_size_t queue_ordinal,
+    const iree_hal_amdgpu_host_queue_create_options_t* create_options,
+    iree_allocator_t host_allocator,
+    iree_hal_amdgpu_physical_device_t* physical_device) {
+  if (IREE_UNLIKELY(queue_ordinal >= physical_device->host_queue_capacity)) {
+    return iree_make_status(
+        IREE_STATUS_OUT_OF_RANGE,
+        "host queue ordinal %" PRIhsz " exceeds capacity %" PRIhsz,
+        queue_ordinal, physical_device->host_queue_capacity);
+  }
+  if (IREE_UNLIKELY(iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+          physical_device, queue_ordinal))) {
+    return iree_make_status(IREE_STATUS_ALREADY_EXISTS,
+                            "AMDGPU host queue ordinal %" PRIhsz
+                            " is already initialized",
+                            queue_ordinal);
+  }
+  return iree_hal_amdgpu_physical_device_initialize_host_queue(
+      logical_device, system, proactor, frontier_tracker, base_axis,
+      epoch_signal_table, feedback_state, &physical_device->host_memory_pools,
+      queue_ordinal, create_options, host_allocator, physical_device);
+}
+
+iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
+    iree_hal_device_t* logical_device, iree_hal_amdgpu_system_t* system,
+    iree_async_proactor_t* proactor,
+    iree_async_frontier_tracker_t* frontier_tracker,
+    iree_async_axis_t base_axis,
+    iree_hal_amdgpu_epoch_signal_table_t* epoch_signal_table,
+    iree_hal_amdgpu_feedback_state_t* feedback_state,
+    const iree_hal_amdgpu_host_memory_pools_t* host_memory_pools,
+    iree_hal_amdgpu_system_event_agent_target_t* system_event_target,
+    iree_allocator_t host_allocator,
+    iree_hal_amdgpu_physical_device_t* physical_device) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  physical_device->system_event_target = system_event_target;
+  physical_device->frontier_tracker = frontier_tracker;
+  physical_device->frontier_base_axis = base_axis;
+  physical_device->registered_host_queue_axis_count = 0;
+
+  iree_status_t status = iree_ok_status();
   for (iree_host_size_t queue_ordinal = 0;
        queue_ordinal < physical_device->host_queue_capacity &&
        iree_status_is_ok(status);
@@ -1272,40 +1387,34 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
         iree_async_axis_session(base_axis), iree_async_axis_machine(base_axis),
         iree_async_axis_device_index(base_axis),
         (uint8_t)logical_queue_ordinal);
-    iree_thread_affinity_t completion_thread_affinity;
-    iree_thread_affinity_set_group_any(physical_device->host_numa_node,
-                                       &completion_thread_affinity);
-    status = iree_hal_amdgpu_host_queue_initialize(
-        &physical_device->queue_family, libhsa, logical_device,
-        iree_hal_amdgpu_physical_device_hostcall_buffer(physical_device),
-        proactor, physical_device->device_agent,
-        &kernarg_ring_memory.descriptor, host_memory_pools->fine_pool,
-        frontier_tracker, queue_axis, (iree_hal_queue_ordinal_t)queue_ordinal,
-        completion_thread_affinity, physical_device->aql_queue_execution_mode,
-        physical_device->wait_barrier_strategy,
-        physical_device->vendor_packet_capabilities,
-        physical_device->pm4_timestamp_strategy, epoch_signal_table,
-        feedback_state, &physical_device->fine_host_block_pool,
-        profiling_memory, &physical_device->buffer_transfer_context,
-        &physical_device->default_pool_set, physical_device->default_pool,
-        &physical_device->transient_buffer_pool,
-        &physical_device->file_staging_pool, physical_device->device_ordinal,
-        physical_device->host_queue_aql_capacity,
-        physical_device->host_queue_notification_capacity,
-        physical_device->host_queue_kernarg_capacity,
-        physical_device->host_queue_upload_capacity, host_allocator,
-        &physical_device->host_queues[queue_ordinal]);
+    status = iree_async_frontier_tracker_register_axis(
+        frontier_tracker, queue_axis, /*semaphore=*/NULL);
     if (iree_status_is_ok(status)) {
-      physical_device->host_queue_count = queue_ordinal + 1;
+      ++physical_device->registered_host_queue_axis_count;
     }
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_amdgpu_physical_device_create_default_pools(
+        physical_device, epoch_signal_table, host_allocator);
+  }
+  const iree_hal_amdgpu_host_queue_create_options_t create_options = {0};
+  for (iree_host_size_t queue_ordinal = 0;
+       queue_ordinal < physical_device->host_queue_ordinary_capacity &&
+       iree_status_is_ok(status);
+       ++queue_ordinal) {
+    status = iree_hal_amdgpu_physical_device_initialize_host_queue(
+        logical_device, system, proactor, frontier_tracker, base_axis,
+        epoch_signal_table, feedback_state, host_memory_pools, queue_ordinal,
+        &create_options, host_allocator, physical_device);
   }
 
   if (iree_status_is_ok(status)) {
-    // Publishing last means the unwind below has nothing to retire and no
-    // partially assigned physical device is ever a delivery target.
-    iree_hal_amdgpu_system_event_publish_queue_targets(
+    iree_hal_amdgpu_system_event_publish_queue_target_mask(
         physical_device->system_event_target, physical_device->host_queues,
-        physical_device->host_queue_count);
+        physical_device->host_queue_ordinary_count,
+        physical_device->host_queue_ordinary_capacity,
+        iree_hal_amdgpu_physical_device_host_queue_private_initialized_mask(
+            physical_device));
   } else {
     iree_hal_amdgpu_physical_device_deassign_frontier(physical_device);
   }
@@ -1319,49 +1428,75 @@ void iree_hal_amdgpu_physical_device_deassign_frontier(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // The physical device owns the initial queue references and must outlive all
-  // references retained by HAL users. Prove that lifetime invariant across all
-  // queues before beginning the irreversible shutdown sequence.
-  for (iree_host_size_t i = 0; i < physical_device->host_queue_count; ++i) {
+  // references retained by HAL users.
+  for (iree_host_size_t i = 0; i < physical_device->host_queue_capacity; ++i) {
+    if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+            physical_device, i)) {
+      continue;
+    }
     iree_atomic_ref_count_abort_if_uses(
         &physical_device->host_queues[i].base.resource.ref_count);
   }
 
-  // Close admission across every queue before blocking on any of them so
-  // teardown latency is not serialized across the device's queues.
-  for (iree_host_size_t i = 0; i < physical_device->host_queue_count; ++i) {
+  // Close admission across every queue before blocking on any of them.
+  for (iree_host_size_t i = 0; i < physical_device->host_queue_capacity; ++i) {
+    if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+            physical_device, i)) {
+      continue;
+    }
     iree_hal_amdgpu_host_queue_begin_deinitialize(
         &physical_device->host_queues[i]);
   }
 
-  // Queue delivery is retired only after this loop, and where the targets were
-  // published that is what releases these waits when the GPU can no longer
-  // advance an epoch. Unwinding a partly assigned device reaches the same loop
-  // with nothing published, and nothing to wait for either: publication is the
-  // last step of assignment and a queue that was never assigned has never been
-  // submitted to, so every wait here returns on its own.
-  for (iree_host_size_t i = 0; i < physical_device->host_queue_count; ++i) {
+  for (iree_host_size_t i = 0; i < physical_device->host_queue_capacity; ++i) {
+    if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+            physical_device, i)) {
+      continue;
+    }
     iree_hal_amdgpu_host_queue_wait_idle_before_deinitialize(
         &physical_device->host_queues[i]);
   }
 
-  // Every queue has passed its idle/error boundary, so nothing left to destroy
-  // depends on a fault to release it. Retirement returns once no callback can
-  // be inside these queues, which is what makes the destruction below safe. A
-  // callback delivering to some other device may still be running; it has no
-  // way to reach these queues once the store lands.
+  // No callback can retain a queue after this returns.
   iree_hal_amdgpu_system_event_retire_queue_targets(
       physical_device->system_event_target);
-  // The registration outlives frontier assignment but not the logical device,
-  // and it is removed before the physical devices are deinitialized. Dropping
-  // the borrow here keeps a later deassignment from reaching a freed target.
   physical_device->system_event_target = NULL;
 
-  for (iree_host_size_t i = 0; i < physical_device->host_queue_count; ++i) {
+  for (iree_host_size_t i = 0; i < physical_device->host_queue_capacity; ++i) {
+    if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+            physical_device, i)) {
+      continue;
+    }
     iree_hal_queue_t* queue = &physical_device->host_queues[i].base;
     iree_atomic_ref_count_abort_if_uses(&queue->resource.ref_count);
     iree_hal_queue_release(queue);
   }
   physical_device->host_queue_count = 0;
+  physical_device->host_queue_ordinary_count = 0;
+  iree_atomic_store(&physical_device->host_queue_private_initialized_mask, 0,
+                    iree_memory_order_release);
+
+  if (physical_device->frontier_tracker) {
+    for (iree_host_size_t i = 0;
+         i < physical_device->registered_host_queue_axis_count; ++i) {
+      const iree_host_size_t logical_queue_ordinal =
+          physical_device->device_ordinal *
+              physical_device->host_queue_capacity +
+          i;
+      const iree_async_axis_t queue_axis = iree_async_axis_make_queue(
+          iree_async_axis_session(physical_device->frontier_base_axis),
+          iree_async_axis_machine(physical_device->frontier_base_axis),
+          iree_async_axis_device_index(physical_device->frontier_base_axis),
+          (uint8_t)logical_queue_ordinal);
+      iree_async_frontier_tracker_retire_axis(
+          physical_device->frontier_tracker, queue_axis,
+          iree_status_from_code(IREE_STATUS_CANCELLED));
+    }
+  }
+  physical_device->registered_host_queue_axis_count = 0;
+  physical_device->frontier_base_axis = 0;
+  physical_device->frontier_tracker = NULL;
+
   if (physical_device->default_pool_set.entries) {
     iree_hal_pool_set_deinitialize(&physical_device->default_pool_set);
   }
@@ -1383,26 +1518,36 @@ iree_status_t iree_hal_amdgpu_physical_device_set_hsa_profiling_enabled(
   IREE_TRACE_ZONE_APPEND_VALUE_I64(z0, enabled ? 1 : 0);
 
   iree_status_t status = iree_ok_status();
-  iree_host_size_t changed_count = 0;
-  for (iree_host_size_t i = 0;
-       i < physical_device->host_queue_count && iree_status_is_ok(status);
-       ++i) {
-    status = iree_hal_amdgpu_host_queue_set_hsa_profiling_enabled(
-        &physical_device->host_queues[i], enabled);
-    if (iree_status_is_ok(status)) {
-      ++changed_count;
+  if (enabled) {
+    iree_host_size_t stopped_ordinal = 0;
+    for (; stopped_ordinal < physical_device->host_queue_capacity;
+         ++stopped_ordinal) {
+      if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+              physical_device, stopped_ordinal)) {
+        continue;
+      }
+      status = iree_hal_amdgpu_host_queue_set_hsa_profiling_enabled(
+          &physical_device->host_queues[stopped_ordinal], true);
+      if (!iree_status_is_ok(status)) break;
     }
-  }
-
-  if (!iree_status_is_ok(status) && enabled) {
-    for (iree_host_size_t i = 0; i < changed_count; ++i) {
-      status = iree_status_join(
-          status, iree_hal_amdgpu_host_queue_set_hsa_profiling_enabled(
-                      &physical_device->host_queues[i], false));
+    if (!iree_status_is_ok(status)) {
+      for (iree_host_size_t i = 0; i < stopped_ordinal; ++i) {
+        if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+                physical_device, i)) {
+          continue;
+        }
+        status = iree_status_join(
+            status, iree_hal_amdgpu_host_queue_set_hsa_profiling_enabled(
+                        &physical_device->host_queues[i], false));
+      }
     }
-  } else if (!enabled) {
-    for (iree_host_size_t i = changed_count;
-         i < physical_device->host_queue_count; ++i) {
+  } else {
+    for (iree_host_size_t i = 0; i < physical_device->host_queue_capacity;
+         ++i) {
+      if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+              physical_device, i)) {
+        continue;
+      }
       status = iree_status_join(
           status, iree_hal_amdgpu_host_queue_set_hsa_profiling_enabled(
                       &physical_device->host_queues[i], false));
@@ -1479,7 +1624,11 @@ iree_status_t iree_hal_amdgpu_physical_device_trim(
   IREE_ASSERT_ARGUMENT(physical_device);
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  for (iree_host_size_t i = 0; i < physical_device->host_queue_count; ++i) {
+  for (iree_host_size_t i = 0; i < physical_device->host_queue_capacity; ++i) {
+    if (!iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+            physical_device, i)) {
+      continue;
+    }
     iree_hal_amdgpu_host_queue_trim(&physical_device->host_queues[i]);
   }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/physical_device.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/physical_device.h
@@ -137,8 +137,10 @@ typedef struct iree_hal_amdgpu_physical_device_options_t {
   // Initial block count preallocated for the host block pool.
   iree_host_size_t host_block_pool_initial_capacity;
 
-  // Number of host queues created for this physical device.
+  // Maximum number of host queues reserved for this physical device.
   iree_host_size_t host_queue_count;
+  // Number of leading host queues created for ordinary HAL routing.
+  iree_host_size_t host_queue_ordinary_capacity;
   // Per-host-queue HSA AQL ring capacity in packets.
   uint32_t host_queue_aql_capacity;
   // Per-host-queue completion/reclaim ring capacity.
@@ -309,6 +311,8 @@ typedef struct iree_hal_amdgpu_physical_device_t {
 
   // Total number of host queue slots allocated in |host_queues|.
   iree_host_size_t host_queue_capacity;
+  // Fixed number of leading queue slots reserved for ordinary HAL routing.
+  iree_host_size_t host_queue_ordinary_capacity;
   // Per-host-queue HSA AQL ring capacity in packets.
   uint32_t host_queue_aql_capacity;
   // Per-host-queue completion/reclaim ring capacity.
@@ -332,17 +336,53 @@ typedef struct iree_hal_amdgpu_physical_device_t {
   // registration, which outlives frontier assignment.
   iree_hal_amdgpu_system_event_agent_target_t* system_event_target;
 
-  // Number of host queues in |host_queues| that have been initialized and not
-  // yet destroyed.
-  //
-  // Between the phases of deassignment this names queues in three conditions -
-  // still admitting work, closed but not yet destroyed, and destroyed - so it
-  // is not a safe bound for anything that must only touch usable queues.
-  // Asynchronous failure delivery is bounded by |system_event_target| instead.
+  // Frontier tracker borrowing every permanently reserved queue axis during
+  // one topology assignment.
+  iree_async_frontier_tracker_t* frontier_tracker;
+  // Topology-assigned base axis used to derive the reserved queue axes.
+  iree_async_axis_t frontier_base_axis;
+  // Number of leading physical queue axes registered in |frontier_tracker|.
+  iree_host_size_t registered_host_queue_axis_count;
+
+  // Bit i is set exactly while private queue slot
+  // |host_queue_ordinary_capacity + i| is fully initialized. Ordinary queues
+  // remain a leading prefix and do not consume this fixed private mask.
+  // Release publication lets concurrent cold-path readers safely inspect a
+  // newly materialized private queue.
+  iree_atomic_uint64_t host_queue_private_initialized_mask;
+  // Number of live leading ordinary queues.
+  iree_host_size_t host_queue_ordinary_count;
+  // Total number of initialized ordinary and private queues.
   iree_host_size_t host_queue_count;
-  // One or more host queues mapped to HSA queues on this physical device.
-  iree_hal_amdgpu_host_queue_t host_queues[/*host_queue_count*/];
+  // Fixed-capacity queue slot storage.
+  iree_hal_amdgpu_host_queue_t host_queues[/*host_queue_capacity*/];
 } iree_hal_amdgpu_physical_device_t;
+
+// Returns an acquire snapshot of all fully initialized private queue slots.
+static inline uint64_t
+iree_hal_amdgpu_physical_device_host_queue_private_initialized_mask(
+    const iree_hal_amdgpu_physical_device_t* physical_device) {
+  return (uint64_t)iree_atomic_load(
+      &physical_device->host_queue_private_initialized_mask,
+      iree_memory_order_acquire);
+}
+
+// Returns true if |queue_ordinal| names a fully initialized host queue.
+static inline bool iree_hal_amdgpu_physical_device_host_queue_is_initialized(
+    const iree_hal_amdgpu_physical_device_t* physical_device,
+    iree_host_size_t queue_ordinal) {
+  if (queue_ordinal >= physical_device->host_queue_capacity) return false;
+  if (queue_ordinal < physical_device->host_queue_ordinary_count) return true;
+  if (queue_ordinal < physical_device->host_queue_ordinary_capacity) {
+    return false;
+  }
+  const iree_host_size_t private_queue_ordinal =
+      queue_ordinal - physical_device->host_queue_ordinary_capacity;
+  if (private_queue_ordinal >= 64) return false;
+  return (iree_hal_amdgpu_physical_device_host_queue_private_initialized_mask(
+              physical_device) &
+          (UINT64_C(1) << private_queue_ordinal)) != 0;
+}
 
 // Returns the aligned heap size in bytes required to store the physical device
 // data structure. Requires that the options have been verified.
@@ -380,6 +420,21 @@ iree_status_t iree_hal_amdgpu_physical_device_assign_frontier(
     iree_hal_amdgpu_feedback_state_t* feedback_state,
     const iree_hal_amdgpu_host_memory_pools_t* host_memory_pools,
     iree_hal_amdgpu_system_event_agent_target_t* system_event_target,
+    iree_allocator_t host_allocator,
+    iree_hal_amdgpu_physical_device_t* physical_device);
+
+// Initializes exactly |queue_ordinal| with immutable |create_options|. Other
+// reserved slots are untouched. The caller must serialize this with other
+// queue activation and device teardown operations.
+iree_status_t iree_hal_amdgpu_physical_device_ensure_host_queue(
+    iree_hal_device_t* logical_device, iree_hal_amdgpu_system_t* system,
+    iree_async_proactor_t* proactor,
+    iree_async_frontier_tracker_t* frontier_tracker,
+    iree_async_axis_t base_axis,
+    iree_hal_amdgpu_epoch_signal_table_t* epoch_signal_table,
+    iree_hal_amdgpu_feedback_state_t* feedback_state,
+    iree_host_size_t queue_ordinal,
+    const iree_hal_amdgpu_host_queue_create_options_t* create_options,
     iree_allocator_t host_allocator,
     iree_hal_amdgpu_physical_device_t* physical_device);
 

--- a/runtime/src/iree/hal/drivers/amdgpu/system_event.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/system_event.c
@@ -32,9 +32,16 @@ struct iree_hal_amdgpu_system_event_agent_target_t {
   // the logical device allocation and outlives this target.
   iree_hal_amdgpu_host_queue_t* host_queues;
   // Number of leading entries in |host_queues| eligible for failure delivery.
-  // Zero before publication and after retirement. Written only under the
-  // registry mutex, by frontier assignment and deassignment.
-  iree_host_size_t live_queue_count;
+  // Written only under the registry mutex.
+  iree_host_size_t ordinary_queue_count;
+  // Ordinal in |host_queues| corresponding to bit 0 of |private_queue_mask|.
+  // Written only under the registry mutex.
+  iree_host_size_t private_queue_offset;
+  // Bit i selects |host_queues[private_queue_offset + i]| for failure
+  // delivery. Zero before publication and after retirement. Written only under
+  // the registry mutex, by frontier assignment, private queue materialization,
+  // and deassignment.
+  uint64_t private_queue_mask;
 };
 
 struct iree_hal_amdgpu_system_event_registration_t {
@@ -182,9 +189,18 @@ static bool iree_hal_amdgpu_system_event_deliver(const hsa_amd_event_t* event,
     for (iree_host_size_t i = 0; i < registration->agent_count; ++i) {
       iree_hal_amdgpu_system_event_agent_target_t* target =
           &registration->agent_targets[i];
-      for (iree_host_size_t j = 0; j < target->live_queue_count; ++j) {
+      for (iree_host_size_t j = 0; j < target->ordinary_queue_count; ++j) {
         iree_hal_amdgpu_host_queue_record_failure(
             &target->host_queues[j],
+            iree_hal_amdgpu_system_event_make_status(event));
+        delivered = true;
+      }
+      uint64_t private_queue_mask = target->private_queue_mask;
+      for (iree_host_size_t j = 0; private_queue_mask != 0;
+           ++j, private_queue_mask >>= 1) {
+        if ((private_queue_mask & UINT64_C(1)) == 0) continue;
+        iree_hal_amdgpu_host_queue_record_failure(
+            &target->host_queues[target->private_queue_offset + j],
             iree_hal_amdgpu_system_event_make_status(event));
         delivered = true;
       }
@@ -468,11 +484,23 @@ void iree_hal_amdgpu_system_event_publish_queue_targets(
     iree_hal_amdgpu_system_event_agent_target_t* target,
     iree_hal_amdgpu_host_queue_t* host_queues,
     iree_host_size_t live_queue_count) {
+  iree_hal_amdgpu_system_event_publish_queue_target_mask(
+      target, host_queues, live_queue_count, live_queue_count, 0);
+}
+
+void iree_hal_amdgpu_system_event_publish_queue_target_mask(
+    iree_hal_amdgpu_system_event_agent_target_t* target,
+    iree_hal_amdgpu_host_queue_t* host_queues,
+    iree_host_size_t ordinary_queue_count,
+    iree_host_size_t private_queue_offset, uint64_t private_queue_mask) {
   if (!target) return;
+  IREE_ASSERT_TRUE(ordinary_queue_count <= private_queue_offset);
 
   iree_mutex_lock(&iree_hal_amdgpu_system_event_registry.mutex);
   target->host_queues = host_queues;
-  target->live_queue_count = live_queue_count;
+  target->ordinary_queue_count = ordinary_queue_count;
+  target->private_queue_offset = private_queue_offset;
+  target->private_queue_mask = private_queue_mask;
   iree_mutex_unlock(&iree_hal_amdgpu_system_event_registry.mutex);
 }
 
@@ -485,6 +513,8 @@ void iree_hal_amdgpu_system_event_retire_queue_targets(
   // every device's teardown against every other device's fault delivery.
   iree_mutex_lock(&iree_hal_amdgpu_system_event_registry.mutex);
   target->host_queues = NULL;
-  target->live_queue_count = 0;
+  target->ordinary_queue_count = 0;
+  target->private_queue_offset = 0;
+  target->private_queue_mask = 0;
   iree_mutex_unlock(&iree_hal_amdgpu_system_event_registry.mutex);
 }

--- a/runtime/src/iree/hal/drivers/amdgpu/system_event.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/system_event.h
@@ -174,13 +174,30 @@ iree_hal_amdgpu_system_event_registration_lookup_agent(
 // Publishes the first |live_queue_count| entries of |host_queues| as the
 // failure targets for |target|'s agent. No-op when |target| is NULL.
 //
-// Called as the last step of physical-device frontier assignment, so a
-// partially assigned physical device never has published targets. Takes the
+// Called as the last step of physical-device frontier assignment. A partially
+// assigned physical device is never published, and a callback cannot observe
+// an uninitialized queue. Private queue additions use the form below. Takes the
 // registry mutex internally; the caller must not hold it.
 void iree_hal_amdgpu_system_event_publish_queue_targets(
     iree_hal_amdgpu_system_event_agent_target_t* target,
     iree_hal_amdgpu_host_queue_t* host_queues,
     iree_host_size_t live_queue_count);
+
+// Publishes the first |ordinary_queue_count| entries of |host_queues| and the
+// private entries selected by |private_queue_mask| as failure targets for
+// |target|'s agent. Bit i of the mask selects
+// |host_queues[private_queue_offset + i]|. The ordinary prefix is represented
+// separately so it is not limited to 64 queues; only the private range is
+// limited by the mask. Every selected private entry must exist and be fully
+// initialized, and |ordinary_queue_count| must not exceed
+// |private_queue_offset|. No-op when |target| is NULL.
+//
+// Takes the registry mutex internally; the caller must not hold it.
+void iree_hal_amdgpu_system_event_publish_queue_target_mask(
+    iree_hal_amdgpu_system_event_agent_target_t* target,
+    iree_hal_amdgpu_host_queue_t* host_queues,
+    iree_host_size_t ordinary_queue_count,
+    iree_host_size_t private_queue_offset, uint64_t private_queue_mask);
 
 // Retires queue failure delivery for |target|'s agent. Idempotent, and a no-op
 // when |target| is NULL. Returns once no callback can be inside |target|'s

--- a/runtime/src/iree/hal/drivers/amdgpu/system_event_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/system_event_test.cc
@@ -440,6 +440,42 @@ TEST_F(SystemEventTest, MatchedEventFailsPublishedQueues) {
   iree_hal_amdgpu_system_event_unregister_device(registration);
 }
 
+// The ordinary queue prefix is not limited by the private queue mask's width,
+// while caller-selected private queues may leave holes after their fixed
+// offset. Fault delivery visits both representations exactly and never touches
+// storage that does not hold a live queue.
+TEST_F(SystemEventTest, PublicationTargetsOrdinaryPrefixAndPrivateMask) {
+  const uint64_t agent_handles[] = {kAgentHandleA};
+  FakeLogicalDevice device;
+  device.Initialize(agent_handles, IREE_ARRAYSIZE(agent_handles));
+  constexpr iree_host_size_t kOrdinaryQueueCount = 70;
+  constexpr iree_host_size_t kPrivateQueueOffset = 72;
+  FakeHostQueues queues(76);
+  iree_hal_amdgpu_system_event_registration_t* registration = Register(device);
+  iree_hal_amdgpu_system_event_agent_target_t* target =
+      iree_hal_amdgpu_system_event_registration_lookup_agent(
+          registration, MakeAgent(kAgentHandleA));
+  constexpr uint64_t kPrivateQueueMask =
+      (UINT64_C(1) << 0) | (UINT64_C(1) << 3);
+  iree_hal_amdgpu_system_event_publish_queue_target_mask(
+      target, queues.queues(), kOrdinaryQueueCount, kPrivateQueueOffset,
+      kPrivateQueueMask);
+
+  EXPECT_EQ(DispatchMemoryFault(kAgentHandleA, kFaultAddress),
+            HSA_STATUS_SUCCESS);
+  for (iree_host_size_t i = 0; i < kOrdinaryQueueCount; ++i) {
+    EXPECT_EQ(queues.ErrorStatusCode(i), IREE_STATUS_ABORTED);
+  }
+  EXPECT_EQ(queues.ErrorStatusCode(70), IREE_STATUS_OK);
+  EXPECT_EQ(queues.ErrorStatusCode(71), IREE_STATUS_OK);
+  EXPECT_EQ(queues.ErrorStatusCode(72), IREE_STATUS_ABORTED);
+  EXPECT_EQ(queues.ErrorStatusCode(73), IREE_STATUS_OK);
+  EXPECT_EQ(queues.ErrorStatusCode(74), IREE_STATUS_OK);
+  EXPECT_EQ(queues.ErrorStatusCode(75), IREE_STATUS_ABORTED);
+
+  iree_hal_amdgpu_system_event_unregister_device(registration);
+}
+
 // A registration created before frontier assignment has no queue targets. It
 // still claims the event, because the device's sticky status can observe it.
 TEST_F(SystemEventTest, UnpublishedRegistrationClaimsWithoutFailingQueues) {

--- a/runtime/src/iree/hal/drivers/amdgpu/util/epoch_signal_table.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/epoch_signal_table.h
@@ -11,6 +11,7 @@
 
 #include "iree/async/frontier.h"
 #include "iree/base/api.h"
+#include "iree/base/internal/atomics.h"
 #include "iree/hal/drivers/amdgpu/util/libhsa.h"
 
 #ifdef __cplusplus
@@ -22,8 +23,9 @@ extern "C" {
 //===----------------------------------------------------------------------===//
 
 // Flat lookup table mapping one logical HAL device's queue indices to their
-// hsa_signal_t epoch signals. Shared read-only across all queues in the logical
-// device during normal operation; mutated only during queue init/deinit.
+// hsa_signal_t epoch signals. Ordinary queue signals are immutable after device
+// publication and use plain hot-path loads. Reserved private slots use scalable
+// release/acquire publication bits as they are materialized.
 //
 // The epoch signal is the single hsa_signal_t that the CP decrements on each
 // AQL packet completion. It is the mechanism by which tier 2 (device-side)
@@ -43,6 +45,11 @@ extern "C" {
 // deregisters during deinit. Lookup verifies the axis's session, machine, and
 // topology-assigned logical device index. Axes from another identity fail the
 // lookup and use the tier 3 host-deferral path.
+// Queue axes use an 8-bit flattened queue index, so four words cover the full
+// representable range.
+#define IREE_HAL_AMDGPU_EPOCH_SIGNAL_TABLE_REGISTRATION_WORD_COUNT \
+  (((iree_host_size_t)UINT8_MAX + 1 + 63) / 64)
+
 typedef struct iree_hal_amdgpu_epoch_signal_table_t {
   // Session epoch from the axis encoding. Used to verify that a lookup axis
   // belongs to the same session as this table. Prevents cross-session aliasing
@@ -58,11 +65,22 @@ typedef struct iree_hal_amdgpu_epoch_signal_table_t {
   uint8_t reserved0;
   // Number of flattened logical queues addressable by |signals|.
   uint16_t queue_count;
+  // Number of queue slots reserved for each physical device. Flattened queue
+  // indices are grouped by physical device using this fixed stride.
+  uint16_t queue_count_per_physical_device;
+  // Number of leading ordinary queue slots in each physical-device group.
+  // Remaining slots are private queues published dynamically.
+  uint16_t ordinary_queue_count_per_physical_device;
   // Reserved for future table flags.
-  uint8_t reserved[2];
+  uint16_t reserved1;
+  // Dynamic queue bits whose signals were published with release semantics.
+  // Private queue lookups acquire the corresponding word before reading
+  // |signals|. Ordinary queue lookups skip this array entirely because those
+  // signals predate device publication.
+  iree_atomic_uint64_t dynamically_registered_queue_mask
+      [IREE_HAL_AMDGPU_EPOCH_SIGNAL_TABLE_REGISTRATION_WORD_COUNT];
   // Epoch signals indexed by flattened logical queue index. Unregistered slots
-  // have handle == 0 (null signal). Registered slots contain the epoch signal
-  // from the queue's notification ring.
+  // have handle == 0.
   hsa_signal_t signals[];
 } iree_hal_amdgpu_epoch_signal_table_t;
 
@@ -78,15 +96,44 @@ static inline iree_host_size_t iree_hal_amdgpu_epoch_signal_table_size(
 // bytes. All signal slots are zeroed (unregistered).
 static inline void iree_hal_amdgpu_epoch_signal_table_initialize(
     iree_hal_amdgpu_epoch_signal_table_t* table, uint8_t session_epoch,
-    uint8_t machine_index, uint8_t device_index, uint16_t queue_count) {
+    uint8_t machine_index, uint8_t device_index, uint16_t queue_count,
+    uint16_t queue_count_per_physical_device,
+    uint16_t ordinary_queue_count_per_physical_device) {
+  IREE_ASSERT(
+      queue_count <=
+          IREE_HAL_AMDGPU_EPOCH_SIGNAL_TABLE_REGISTRATION_WORD_COUNT * 64,
+      "queue_count out of range");
+  IREE_ASSERT(queue_count_per_physical_device != 0,
+              "queue_count_per_physical_device must be non-zero");
+  IREE_ASSERT(queue_count % queue_count_per_physical_device == 0,
+              "queue_count must contain whole physical-device groups");
+  IREE_ASSERT(ordinary_queue_count_per_physical_device <=
+                  queue_count_per_physical_device,
+              "ordinary queue count exceeds queues per physical device");
   table->session_epoch = session_epoch;
   table->machine_index = machine_index;
   table->device_index = device_index;
   table->reserved0 = 0;
   table->queue_count = queue_count;
-  memset(table->reserved, 0, sizeof(table->reserved));
+  table->queue_count_per_physical_device = queue_count_per_physical_device;
+  table->ordinary_queue_count_per_physical_device =
+      ordinary_queue_count_per_physical_device;
+  table->reserved1 = 0;
+  for (iree_host_size_t i = 0;
+       i < IREE_HAL_AMDGPU_EPOCH_SIGNAL_TABLE_REGISTRATION_WORD_COUNT; ++i) {
+    iree_atomic_store(&table->dynamically_registered_queue_mask[i], 0,
+                      iree_memory_order_relaxed);
+  }
   memset(table->signals, 0,
          (iree_host_size_t)queue_count * sizeof(hsa_signal_t));
+}
+
+// Returns true if |queue_index| identifies a dynamically published private
+// queue instead of an ordinary queue created before device publication.
+static inline bool iree_hal_amdgpu_epoch_signal_table_queue_is_dynamic(
+    const iree_hal_amdgpu_epoch_signal_table_t* table, uint8_t queue_index) {
+  return queue_index % table->queue_count_per_physical_device >=
+         table->ordinary_queue_count_per_physical_device;
 }
 
 // Registers a queue's epoch signal in the table. Called during queue init
@@ -101,6 +148,12 @@ static inline void iree_hal_amdgpu_epoch_signal_table_register(
               "epoch signal slot already registered");
   IREE_ASSERT(epoch_signal.handle != 0, "cannot register null epoch signal");
   table->signals[queue_index] = epoch_signal;
+  if (iree_hal_amdgpu_epoch_signal_table_queue_is_dynamic(table, queue_index)) {
+    const iree_host_size_t word_index = queue_index / 64;
+    const uint64_t queue_bit = UINT64_C(1) << (queue_index % 64);
+    iree_atomic_fetch_or(&table->dynamically_registered_queue_mask[word_index],
+                         queue_bit, iree_memory_order_release);
+  }
 }
 
 // Deregisters a queue's epoch signal from the table. Called during queue
@@ -109,9 +162,26 @@ static inline void iree_hal_amdgpu_epoch_signal_table_register(
 static inline void iree_hal_amdgpu_epoch_signal_table_deregister(
     iree_hal_amdgpu_epoch_signal_table_t* table, uint8_t queue_index) {
   IREE_ASSERT(queue_index < table->queue_count, "queue_index out of range");
-  IREE_ASSERT(table->signals[queue_index].handle != 0,
-              "epoch signal slot not registered");
-  table->signals[queue_index].handle = 0;
+  if (iree_hal_amdgpu_epoch_signal_table_queue_is_dynamic(table, queue_index)) {
+    const iree_host_size_t word_index = queue_index / 64;
+    const uint64_t queue_bit = UINT64_C(1) << (queue_index % 64);
+    IREE_ASSERT(((uint64_t)iree_atomic_load(
+                     &table->dynamically_registered_queue_mask[word_index],
+                     iree_memory_order_relaxed) &
+                 queue_bit) != 0,
+                "epoch signal slot not registered");
+    iree_atomic_fetch_and(&table->dynamically_registered_queue_mask[word_index],
+                          ~queue_bit, iree_memory_order_release);
+    // Private slots retain their stale value after withdrawal so a reader that
+    // acquired the prior publication bit cannot race a plain handle write. The
+    // cleared bit excludes all later private lookups.
+  } else {
+    IREE_ASSERT(table->signals[queue_index].handle != 0,
+                "epoch signal slot not registered");
+    // Ordinary slots are only withdrawn after the device has excluded lookup
+    // readers and can be cleared directly.
+    table->signals[queue_index].handle = 0;
+  }
 }
 
 // Looks up the epoch signal for the queue identified by |axis|. Returns true
@@ -120,9 +190,9 @@ static inline void iree_hal_amdgpu_epoch_signal_table_deregister(
 // and the slot is registered. Returns false otherwise (caller should fall back
 // to tier 3).
 //
-// This is the hot-path lookup for tier 2 barrier emission. Three byte
-// comparisons (session + machine + device), one domain check, one bounds
-// check, and one array index.
+// This is the hot-path lookup for tier 2 barrier emission. Ordinary queues use
+// identity and bounds checks, one per-device classification, and a plain array
+// load. Private queues additionally acquire their dynamic publication bit.
 static inline bool iree_hal_amdgpu_epoch_signal_table_lookup(
     const iree_hal_amdgpu_epoch_signal_table_t* table, iree_async_axis_t axis,
     hsa_signal_t* out_signal) {
@@ -138,7 +208,17 @@ static inline bool iree_hal_amdgpu_epoch_signal_table_lookup(
   }
   uint8_t queue_index = iree_async_axis_queue_index(axis);
   if (queue_index >= table->queue_count) return false;
-  hsa_signal_t signal = table->signals[queue_index];
+  if (iree_hal_amdgpu_epoch_signal_table_queue_is_dynamic(table, queue_index)) {
+    const iree_host_size_t word_index = queue_index / 64;
+    const uint64_t queue_bit = UINT64_C(1) << (queue_index % 64);
+    if (((uint64_t)iree_atomic_load(
+             &table->dynamically_registered_queue_mask[word_index],
+             iree_memory_order_acquire) &
+         queue_bit) == 0) {
+      return false;
+    }
+  }
+  const hsa_signal_t signal = table->signals[queue_index];
   if (signal.handle == 0) return false;  // Slot not registered.
   *out_signal = signal;
   return true;

--- a/runtime/src/iree/hal/drivers/amdgpu/util/epoch_signal_table_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/epoch_signal_table_test.cc
@@ -6,6 +6,8 @@
 
 #include "iree/hal/drivers/amdgpu/util/epoch_signal_table.h"
 
+#include <atomic>
+#include <thread>
 #include <vector>
 
 #include "iree/testing/gtest.h"
@@ -15,12 +17,16 @@ namespace {
 class EpochSignalTable {
  public:
   EpochSignalTable(uint8_t session_epoch, uint8_t machine_index,
-                   uint8_t device_index, uint16_t queue_count) {
+                   uint8_t device_index, uint16_t queue_count,
+                   uint16_t queue_count_per_physical_device,
+                   uint16_t ordinary_queue_count_per_physical_device) {
     storage_.resize(iree_hal_amdgpu_epoch_signal_table_size(queue_count));
     table_ = reinterpret_cast<iree_hal_amdgpu_epoch_signal_table_t*>(
         storage_.data());
     iree_hal_amdgpu_epoch_signal_table_initialize(
-        table_, session_epoch, machine_index, device_index, queue_count);
+        table_, session_epoch, machine_index, device_index, queue_count,
+        queue_count_per_physical_device,
+        ordinary_queue_count_per_physical_device);
   }
 
   iree_hal_amdgpu_epoch_signal_table_t* get() { return table_; }
@@ -38,7 +44,9 @@ static hsa_signal_t MakeSignal(uint64_t handle) {
 
 TEST(EpochSignalTable, ResolvesFlattenedLogicalQueues) {
   EpochSignalTable table(/*session_epoch=*/5, /*machine_index=*/2,
-                         /*device_index=*/9, /*queue_count=*/4);
+                         /*device_index=*/9, /*queue_count=*/4,
+                         /*queue_count_per_physical_device=*/2,
+                         /*ordinary_queue_count_per_physical_device=*/2);
   for (uint8_t queue = 0; queue < 4; ++queue) {
     iree_hal_amdgpu_epoch_signal_table_register(table.get(), queue,
                                                 MakeSignal(100 + queue));
@@ -55,7 +63,9 @@ TEST(EpochSignalTable, ResolvesFlattenedLogicalQueues) {
 
 TEST(EpochSignalTable, RejectsForeignAxes) {
   EpochSignalTable table(/*session_epoch=*/3, /*machine_index=*/7,
-                         /*device_index=*/5, /*queue_count=*/2);
+                         /*device_index=*/5, /*queue_count=*/2,
+                         /*queue_count_per_physical_device=*/2,
+                         /*ordinary_queue_count_per_physical_device=*/2);
   iree_hal_amdgpu_epoch_signal_table_register(table.get(), 0, MakeSignal(100));
 
   const iree_async_axis_t foreign_axes[] = {
@@ -74,7 +84,9 @@ TEST(EpochSignalTable, RejectsForeignAxes) {
 
 TEST(EpochSignalTable, RejectsUnavailableQueues) {
   EpochSignalTable table(/*session_epoch=*/1, /*machine_index=*/0,
-                         /*device_index=*/4, /*queue_count=*/2);
+                         /*device_index=*/4, /*queue_count=*/2,
+                         /*queue_count_per_physical_device=*/2,
+                         /*ordinary_queue_count_per_physical_device=*/1);
   iree_hal_amdgpu_epoch_signal_table_register(table.get(), 0, MakeSignal(99));
 
   hsa_signal_t signal;
@@ -84,9 +96,11 @@ TEST(EpochSignalTable, RejectsUnavailableQueues) {
       table.get(), iree_async_axis_make_queue(1, 0, 4, 2), &signal));
 }
 
-TEST(EpochSignalTable, DeregisterRemovesQueue) {
+TEST(EpochSignalTable, DynamicDeregisterWithdrawsQueue) {
   EpochSignalTable table(/*session_epoch=*/1, /*machine_index=*/0,
-                         /*device_index=*/4, /*queue_count=*/2);
+                         /*device_index=*/4, /*queue_count=*/2,
+                         /*queue_count_per_physical_device=*/2,
+                         /*ordinary_queue_count_per_physical_device=*/1);
   iree_hal_amdgpu_epoch_signal_table_register(table.get(), 1, MakeSignal(77));
   const iree_async_axis_t axis = iree_async_axis_make_queue(1, 0, 4, 1);
   hsa_signal_t signal;
@@ -94,8 +108,96 @@ TEST(EpochSignalTable, DeregisterRemovesQueue) {
       iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
 
   iree_hal_amdgpu_epoch_signal_table_deregister(table.get(), 1);
+  EXPECT_EQ(table.get()->signals[1].handle, 77u);
   EXPECT_FALSE(
       iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
+}
+
+TEST(EpochSignalTable, OrdinaryDeregisterClearsSignal) {
+  EpochSignalTable table(/*session_epoch=*/1, /*machine_index=*/0,
+                         /*device_index=*/4, /*queue_count=*/2,
+                         /*queue_count_per_physical_device=*/2,
+                         /*ordinary_queue_count_per_physical_device=*/1);
+  iree_hal_amdgpu_epoch_signal_table_register(table.get(), 0, MakeSignal(77));
+  const iree_async_axis_t axis = iree_async_axis_make_queue(1, 0, 4, 0);
+
+  iree_hal_amdgpu_epoch_signal_table_deregister(table.get(), 0);
+  EXPECT_EQ(table.get()->signals[0].handle, 0u);
+  hsa_signal_t signal;
+  EXPECT_FALSE(
+      iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis, &signal));
+}
+
+TEST(EpochSignalTable, ConcurrentRegistrationPublishesSignal) {
+  EpochSignalTable table(/*session_epoch=*/1, /*machine_index=*/0,
+                         /*device_index=*/4, /*queue_count=*/128,
+                         /*queue_count_per_physical_device=*/128,
+                         /*ordinary_queue_count_per_physical_device=*/120);
+  const iree_async_axis_t axis = iree_async_axis_make_queue(1, 0, 4, 127);
+  std::atomic<bool> reader_started = false;
+  hsa_signal_t observed_signal = MakeSignal(0);
+  std::thread reader([&]() {
+    reader_started.store(true, std::memory_order_release);
+    while (!iree_hal_amdgpu_epoch_signal_table_lookup(table.get(), axis,
+                                                      &observed_signal)) {
+      std::this_thread::yield();
+    }
+  });
+  while (!reader_started.load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+
+  iree_hal_amdgpu_epoch_signal_table_register(table.get(), 127,
+                                              MakeSignal(123));
+  reader.join();
+  EXPECT_EQ(observed_signal.handle, 123u);
+}
+
+TEST(EpochSignalTable, OrdinaryLookupSkipsDynamicPublicationMask) {
+  EpochSignalTable table(/*session_epoch=*/1, /*machine_index=*/0,
+                         /*device_index=*/4, /*queue_count=*/256,
+                         /*queue_count_per_physical_device=*/128,
+                         /*ordinary_queue_count_per_physical_device=*/120);
+  iree_hal_amdgpu_epoch_signal_table_register(table.get(), 0, MakeSignal(123));
+  iree_hal_amdgpu_epoch_signal_table_register(table.get(), 128,
+                                              MakeSignal(456));
+  for (iree_host_size_t i = 0;
+       i < IREE_HAL_AMDGPU_EPOCH_SIGNAL_TABLE_REGISTRATION_WORD_COUNT; ++i) {
+    EXPECT_EQ(
+        iree_atomic_load(&table.get()->dynamically_registered_queue_mask[i],
+                         iree_memory_order_relaxed),
+        0);
+  }
+
+  hsa_signal_t signal = MakeSignal(0);
+  EXPECT_TRUE(iree_hal_amdgpu_epoch_signal_table_lookup(
+      table.get(), iree_async_axis_make_queue(1, 0, 4, 0), &signal));
+  EXPECT_EQ(signal.handle, 123u);
+  EXPECT_TRUE(iree_hal_amdgpu_epoch_signal_table_lookup(
+      table.get(), iree_async_axis_make_queue(1, 0, 4, 128), &signal));
+  EXPECT_EQ(signal.handle, 456u);
+  EXPECT_FALSE(iree_hal_amdgpu_epoch_signal_table_lookup(
+      table.get(), iree_async_axis_make_queue(1, 0, 4, 255), &signal));
+}
+
+TEST(EpochSignalTable, ResolvesDynamicQueuesAcrossPublicationWords) {
+  EpochSignalTable table(/*session_epoch=*/1, /*machine_index=*/0,
+                         /*device_index=*/4, /*queue_count=*/256,
+                         /*queue_count_per_physical_device=*/64,
+                         /*ordinary_queue_count_per_physical_device=*/56);
+  constexpr uint8_t kQueueIndices[] = {56, 63, 120, 127, 184, 191, 248, 255};
+  for (uint8_t queue_index : kQueueIndices) {
+    iree_hal_amdgpu_epoch_signal_table_register(table.get(), queue_index,
+                                                MakeSignal(1000 + queue_index));
+  }
+
+  for (uint8_t queue_index : kQueueIndices) {
+    hsa_signal_t signal = MakeSignal(0);
+    EXPECT_TRUE(iree_hal_amdgpu_epoch_signal_table_lookup(
+        table.get(), iree_async_axis_make_queue(1, 0, 4, queue_index),
+        &signal));
+    EXPECT_EQ(signal.handle, 1000u + queue_index);
+  }
 }
 
 }  // namespace

--- a/runtime/src/iree/hal/drivers/amdgpu/util/libhsa.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/libhsa.c
@@ -6,6 +6,8 @@
 
 #include "iree/hal/drivers/amdgpu/util/libhsa.h"
 
+#include <stdlib.h>
+
 #include "iree/base/internal/debugging.h"
 #include "iree/base/internal/dynamic_library.h"
 #include "iree/base/internal/path.h"
@@ -16,6 +18,9 @@
 
 // Maps an HSA status to an IREE status as best we can.
 static iree_status_code_t iree_hsa_status_code(hsa_status_t status) {
+  if (status == (hsa_status_t)HSA_STATUS_CU_MASK_REDUCED) {
+    return IREE_STATUS_FAILED_PRECONDITION;
+  }
   switch (status) {
     default:
       return IREE_STATUS_UNKNOWN;
@@ -70,6 +75,9 @@ static iree_status_code_t iree_hsa_status_code(hsa_status_t status) {
 
 // Returns the stringified form of the HSA status enum value.
 static const char* iree_hsa_status_string(hsa_status_t status) {
+  if (status == (hsa_status_t)HSA_STATUS_CU_MASK_REDUCED) {
+    return "HSA_STATUS_CU_MASK_REDUCED";
+  }
   switch (status) {
     default:
       return "?";
@@ -151,6 +159,9 @@ static const char* iree_hsa_status_string(hsa_status_t status) {
 // that we can customize the error messages to our uses (and avoid the need for
 // carrying the libhsa pointer to resolve statuses).
 static const char* iree_hsa_status_description(hsa_status_t status) {
+  if (status == (hsa_status_t)HSA_STATUS_CU_MASK_REDUCED) {
+    return "The requested queue CU mask was reduced by process-wide policy.";
+  }
   switch (status) {
     default:
       return "Unknown.";
@@ -488,6 +499,21 @@ IREE_API_EXPORT iree_status_t iree_hal_amdgpu_libhsa_initialize(
   memset(out_libhsa, 0, sizeof(*out_libhsa));
   iree_status_t status = iree_hal_amdgpu_libhsa_load_library(
       flags, search_paths, host_allocator, out_libhsa);
+
+  // ROCr snapshots HSA_CU_MASK during its first initialization. Per-queue
+  // callers cannot later query whether an already initialized process runtime
+  // captured a global mask, and current ROCr releases do not reliably report a
+  // reduced mask from hsa_amd_queue_cu_set_mask. Record the only state in which
+  // exact per-queue confinement is provable: IREE owns first initialization and
+  // no process-wide mask is present at that boundary.
+  if (iree_status_is_ok(status)) {
+    uint16_t version_major = 0;
+    const hsa_status_t preinitialize_status = iree_hsa_system_get_info_raw(
+        out_libhsa, HSA_SYSTEM_INFO_VERSION_MAJOR, &version_major);
+    out_libhsa->exact_queue_cu_mask_supported =
+        preinitialize_status == HSA_STATUS_ERROR_NOT_INITIALIZED &&
+        getenv("HSA_CU_MASK") == NULL;
+  }
 
   // Initialize HSA. If already loaded this increments the refcount to be paired
   // with the hsa_shut_down we call in deinitialize.

--- a/runtime/src/iree/hal/drivers/amdgpu/util/libhsa.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/libhsa.h
@@ -112,6 +112,10 @@ enum iree_hal_amdgpu_libhsa_flag_bits_e {
 typedef struct iree_hal_amdgpu_libhsa_t {
   // True if hsa_init was called and hsa_shut_down must be called.
   bool initialized;
+  // True when IREE observed an uninitialized ROCr runtime with no HSA_CU_MASK
+  // immediately before its successful hsa_init call. Only this state can
+  // support an exact per-queue CU-mask contract.
+  bool exact_queue_cu_mask_supported;
 
 #if !IREE_HAL_AMDGPU_LIBHSA_STATIC
 

--- a/runtime/src/iree/hal/drivers/amdgpu/util/libhsa_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/libhsa_test.cc
@@ -6,12 +6,32 @@
 
 #include "iree/hal/drivers/amdgpu/util/libhsa.h"
 
+#include <string>
+
 #include "iree/base/api.h"
 #include "iree/testing/gtest.h"
 #include "iree/testing/status_matchers.h"
 
 namespace iree::hal::amdgpu {
 namespace {
+
+TEST(LibHSATest, MapsReducedComputeUnitMaskStatus) {
+  iree_status_t status = iree_status_from_hsa_status(
+      __FILE__, __LINE__, (hsa_status_t)HSA_STATUS_CU_MASK_REDUCED,
+      "hsa_amd_queue_cu_set_mask", nullptr);
+  EXPECT_EQ(iree_status_code(status), IREE_STATUS_FAILED_PRECONDITION);
+
+  iree_allocator_t host_allocator = iree_allocator_system();
+  char* status_buffer = nullptr;
+  iree_host_size_t status_buffer_length = 0;
+  ASSERT_TRUE(iree_status_to_string(status, &host_allocator, &status_buffer,
+                                    &status_buffer_length));
+  const std::string status_text(status_buffer, status_buffer_length);
+  EXPECT_NE(status_text.find("HSA_STATUS_CU_MASK_REDUCED"), std::string::npos);
+  EXPECT_NE(status_text.find("process-wide policy"), std::string::npos);
+  iree_allocator_free(host_allocator, status_buffer);
+  iree_status_free(status);
+}
 
 // Tests that we can find, load, and unload HSA.
 // In ASAN builds it tests that we don't leak the library (though ROCR itself


### PR DESCRIPTION
## Motivation

libhrx HIP execution contexts need native AMDGPU queues whose execution is confined to caller-selected compute-unit sets. The HAL queue surface has no way to bind one specific physical queue to an exact native CU mask without moving libhrx's mapping and capacity policy into the driver.

## Summary

This change adds an in-tree AMDGPU bridge for querying a physical device's reserved queue range and native mask topology, configuring one selected slot, and returning its exact `iree_hal_queue_t`. An opt-in logical-device option reserves up to 64 additional slots per physical device. The default remains zero, and these slots remain outside ordinary HAL queue enumeration and lookup.

## Design

Each successful slot is bound once to one immutable mask until device teardown; AMDGPU does not choose, share, coalesce, or recycle slots. Before creating a queue, the driver validates the native device and ordinal, complete mask width and tail, nonempty selection, architecture-defined alignment groups, and coverage of every interleaved hardware partition. It then creates the HSA queue, applies the mask before publishing submission resources, and destroys the unpublished queue on failure so the slot can be retried. Exact masking requires native GPU-consumed AQL and IREE-owned ROCr initialization with `HSA_CU_MASK` unset. Permanently reserved queue axes and synchronized epoch, fault-delivery, profiling, and teardown bookkeeping support safe sparse publication.

## Testing

`clang-format` 22.1.3 dry-run and `git diff --check` were clean; AMDGPU Bazel-to-CMake regeneration produced no changes. Seven scoped AMDGPU targets passed on ROCm SDK 7.14.0a20260622 with gfx942. The AMDGPU `//libhrx/...` build passed, along with all 12 common binding tests and all 19 serialized libhrx GPU CTS. Mutation checks showed that removing alignment validation lets a misaligned mask reach queue creation, while inverting the predicate rejects the aligned control; the restored implementation passed both.
