### PR TITLE
[CI] Build the gfx942 GPU tests from source

### DIFF
--- a/.github/workflows/ci_core_linux.yml
+++ b/.github/workflows/ci_core_linux.yml
@@ -97,44 +97,59 @@ jobs:
         -DIREE_HAL_AMDGPU_TARGETS=gfx942;gfx1151;gfx1201
       package: ${{ matrix.package }}
 
-  gpu_linux:
-    name: ${{ matrix.name }}
+  # gfx942 builds the tests it runs, because downloading the multi-gigabyte test
+  # package on this runner pool does not reliably finish inside a job timeout.
+  # The cmake_linux gate stays even though no artifact is consumed: GPU runners
+  # are scarce, so a compile failure should surface on the build pool first.
+  gpu_linux_gfx942:
+    name: Linux / CMake / GPU gfx942
     needs: cmake_linux
     if: ${{ needs.cmake_linux.result == 'success' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Linux / CMake / GPU gfx942
-            chip: gfx942
-            runner_labels: '["linux-gfx942-1gpu-ccs-csp-ossci-rocm"]'
-            ctest_exclude_regex: ""
-            experimental: false
-          - name: Linux / CMake / GPU gfx1201
-            chip: gfx1201
-            runner_labels: '["self-hosted", "Linux", "X64", "gpu_navi4x"]'
-            ctest_exclude_regex: ""
-            experimental: false
+    uses: ./.github/workflows/test_core_linux_gpu_source.yml
+    permissions:
+      contents: read
+    with:
+      name: Linux / CMake / GPU gfx942
+      runner_labels: '["linux-gfx942-1gpu-ccs-csp-ossci-rocm"]'
+      release_type: ${{ inputs.release_type || 'nightly' }}
+      run_id: ${{ inputs.run_id || '' }}
+      artifact_set: ${{ inputs.artifact_set || 'core' }}
+      amdgpu_targets: gfx942
+      device: gpu:0
+      ctest_exclude_regex: ""
+      ctest_label_regex: runtime-resource=amd-gpu
+      ctest_label_exclude_regex: manual
+      ctest_parallelism: 1
+      experimental: false
+
+  # gfx1201 downloads and runs the packages built by cmake_linux, so every pull
+  # request still answers whether the shipped packages extract and run on a
+  # machine that did not build them. It is the only job that asks that question.
+  gpu_linux_gfx1201:
+    name: Linux / CMake / GPU gfx1201
+    needs: cmake_linux
+    if: ${{ needs.cmake_linux.result == 'success' }}
     uses: ./.github/workflows/test_core_linux_gpu.yml
     permissions:
       actions: read
       contents: read
     with:
-      name: ${{ matrix.name }}
-      runner_labels: ${{ matrix.runner_labels }}
+      name: Linux / CMake / GPU gfx1201
+      runner_labels: '["self-hosted", "Linux", "X64", "gpu_navi4x"]'
       artifact_run_id: ${{ github.run_id }}
       device: gpu:0
-      ctest_exclude_regex: ${{ matrix.ctest_exclude_regex }}
+      ctest_exclude_regex: ""
       ctest_label_regex: runtime-resource=amd-gpu
       ctest_label_exclude_regex: manual
       ctest_parallelism: 1
-      experimental: ${{ matrix.experimental }}
+      experimental: false
 
   summary:
     name: Linux / CMake / CI / Summary
     needs:
       - cmake_linux
-      - gpu_linux
+      - gpu_linux_gfx942
+      - gpu_linux_gfx1201
     if: ${{ always() }}
     runs-on: ubuntu-24.04
     steps:
@@ -145,8 +160,13 @@ jobs:
           if [[ "${result}" != "success" ]]; then
             exit 1
           fi
-          result="${{ needs.gpu_linux.result }}"
-          echo "gpu_linux result: ${result}"
+          result="${{ needs.gpu_linux_gfx942.result }}"
+          echo "gpu_linux_gfx942 result: ${result}"
+          if [[ "${result}" != "success" ]]; then
+            exit 1
+          fi
+          result="${{ needs.gpu_linux_gfx1201.result }}"
+          echo "gpu_linux_gfx1201 result: ${result}"
           if [[ "${result}" != "success" ]]; then
             exit 1
           fi

--- a/.github/workflows/test_core_linux_gpu_source.yml
+++ b/.github/workflows/test_core_linux_gpu_source.yml
@@ -1,0 +1,197 @@
+# Copyright 2026 The HRX Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: Test CMake Linux GPU From Source
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        type: string
+        default: Linux / CMake / GPU gfx942
+      runner_labels:
+        type: string
+        description: "JSON array of labels that must all match the GPU runner."
+        required: true
+      release_type:
+        type: string
+        default: nightly
+      run_id:
+        type: string
+        default: ""
+      artifact_set:
+        type: string
+        default: core
+      amdgpu_targets:
+        type: string
+        description: "IREE_HAL_AMDGPU_TARGETS selectors this runner can execute."
+        required: true
+      device:
+        type: string
+        default: gpu:0
+      ctest_regex:
+        type: string
+        default: ""
+      ctest_exclude_regex:
+        type: string
+        default: ""
+      ctest_label_regex:
+        type: string
+        default: runtime-resource=amd-gpu
+      ctest_label_exclude_regex:
+        type: string
+        default: ""
+      ctest_parallelism:
+        type: number
+        default: 1
+      experimental:
+        type: boolean
+        default: false
+  # GitHub accepts at most ten workflow_dispatch inputs, which this list fills,
+  # so three of the thirteen above are dropped. The job name already falls back
+  # to a literal when `name` is absent, and the env block below falls back for
+  # release_type and artifact_set, so a dispatched run behaves like a call that
+  # takes their defaults. A dispatch cannot reach the other release channels
+  # and artifact sets `ci_core_linux.yml` can pass.
+  workflow_dispatch:
+    inputs:
+      runner_labels:
+        type: string
+        description: "JSON array of labels that must all match the GPU runner."
+        required: true
+      amdgpu_targets:
+        type: string
+        description: "IREE_HAL_AMDGPU_TARGETS selectors this runner can execute."
+        required: true
+      run_id:
+        type: string
+        description: "TheRock artifact run id. Empty means latest complete Linux run."
+        default: ""
+      device:
+        type: string
+        description: "libhrx CTS device spec."
+        default: gpu:0
+      ctest_regex:
+        type: string
+        description: "Optional CTest name regex for installed GPU tests."
+        default: ""
+      ctest_exclude_regex:
+        type: string
+        description: "Optional CTest name exclusion regex for installed GPU tests."
+        default: ""
+      ctest_label_regex:
+        type: string
+        description: "CTest label regex for GPU installed tests."
+        default: runtime-resource=amd-gpu
+      ctest_label_exclude_regex:
+        type: string
+        description: "CTest label exclusion regex."
+        default: ""
+      ctest_parallelism:
+        type: number
+        description: "CTest parallelism on the GPU runner."
+        default: 1
+      experimental:
+        type: boolean
+        description: >-
+          Report success even if the ROCm environment check or the installed
+          GPU tests fail. A failed environment check also skips the build and
+          the tests.
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  test_core_linux_gpu_source:
+    name: ${{ inputs.name || 'Linux / CMake / GPU gfx942' }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    container:
+      image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98
+      options: >-
+        --ipc host
+        --group-add video
+        --device /dev/kfd
+        --device /dev/dri
+        --group-add 993
+        --group-add 992
+        --group-add 110
+        --ulimit memlock=-1:-1
+        --security-opt seccomp=unconfined
+        --env-file /etc/podinfo/gha-gpu-isolation-settings
+        --user 0:0
+    timeout-minutes: 60
+    env:
+      HRX_OUTPUT_DIR: ${{ github.workspace }}/build/linux-gpu
+      HRX_RELEASE_TYPE: ${{ inputs.release_type || 'nightly' }}
+      HRX_RUN_ID: ${{ inputs.run_id }}
+      HRX_ARTIFACT_SET: ${{ inputs.artifact_set || 'core' }}
+      HRX_ROCM_ROOT: ${{ github.workspace }}/build/linux-gpu/rocm-root
+      HRX_DOWNLOAD_CACHE_DIR: ${{ github.workspace }}/build/linux-gpu/downloads
+      HRX_BUILD_DIR: ${{ github.workspace }}/build/linux-gpu/build/hrx-core
+      HRX_PUBLIC_INSTALL_DIR: ${{ github.workspace }}/build/linux-gpu/install/public
+      HRX_PUBLIC_DEPS_DIR: ${{ github.workspace }}/build/linux-gpu/install/public-deps
+      HRX_TESTS_INSTALL_DIR: ${{ github.workspace }}/build/linux-gpu/install/tests
+      HRX_COMPOSED_INSTALL_DIR: ${{ github.workspace }}/build/linux-gpu/install/composed
+      HRX_CMAKE_OPTIONS: "-DIREE_HAL_AMDGPU_TARGETS=${{ inputs.amdgpu_targets }}"
+      HRX_PREPARE_PUBLIC_DEPS: "true"
+      HRX_PACKAGE_SMOKE: "false"
+      HRX_TEST_GPU: "true"
+      HRX_CTS_DEVICE: ${{ inputs.device || 'gpu:0' }}
+      HRX_CTEST_REGEX: ${{ inputs.ctest_regex }}
+      HRX_CTEST_EXCLUDE_REGEX: ${{ inputs.ctest_exclude_regex }}
+      HRX_CTEST_LABEL_REGEX: ${{ inputs.ctest_label_regex }}
+      HRX_CTEST_LABEL_EXCLUDE_REGEX: ${{ inputs.ctest_label_exclude_regex }}
+      HRX_CTEST_PARALLELISM: ${{ inputs.ctest_parallelism || 1 }}
+      HRX_TEST_TMPDIR: ${{ github.workspace }}/build/linux-gpu/test-tmp
+      HRX_PYTHON: ${{ github.workspace }}/build/linux-gpu/python/bin/python3
+      PIP_CACHE_DIR: ${{ github.workspace }}/build/linux-gpu/caches/pip
+      ROCR_VISIBLE_DEVICES: "0"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Adjust git config
+        run: |
+          mkdir -p "$HOME"
+          git config --global --add safe.directory "$PWD"
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Fetch ROCm toolchain
+        run: bash .github/scripts/fetch_rocm_toolchain.sh
+
+      - name: Install CMake host tools
+        run: |
+          "${HRX_PYTHON}" -m pip install --upgrade cmake==3.31.6 ninja
+          echo "${HRX_OUTPUT_DIR}/python/bin" >> "${GITHUB_PATH}"
+
+      - name: Check tool versions
+        run: |
+          cmake --version
+          ctest --version
+          ninja --version
+          bash .github/scripts/check_rocm_device_toolchain.sh
+          test -d "${HRX_ROCM_ROOT}/include"
+
+      - name: Report ROCm environment
+        id: rocm_environment
+        continue-on-error: ${{ inputs.experimental }}
+        run: bash .github/scripts/check_rocm_environment.sh
+
+      - name: Build and install HRX
+        if: ${{ steps.rocm_environment.outcome == 'success' }}
+        run: |
+          "${HRX_PYTHON}" build_tools/ci/ci_core_linux.py build
+
+      - name: Run installed GPU tests
+        if: ${{ steps.rocm_environment.outcome == 'success' }}
+        continue-on-error: ${{ inputs.experimental }}
+        run: |
+          "${HRX_PYTHON}" build_tools/ci/ci_core_linux.py test

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,4 +19,5 @@ exports_files([
     ".github/workflows/docs.yml",
     ".github/workflows/presubmit.yml",
     ".github/workflows/test_core_linux_gpu.yml",
+    ".github/workflows/test_core_linux_gpu_source.yml",
 ])

--- a/build_tools/devtools/BUILD.bazel
+++ b/build_tools/devtools/BUILD.bazel
@@ -137,6 +137,7 @@ py_test(
         "//:.github/workflows/docs.yml",
         "//:.github/workflows/presubmit.yml",
         "//:.github/workflows/test_core_linux_gpu.yml",
+        "//:.github/workflows/test_core_linux_gpu_source.yml",
     ],
     main = "ci_test.py",
 )

--- a/build_tools/devtools/ci_test.py
+++ b/build_tools/devtools/ci_test.py
@@ -40,9 +40,19 @@ class CiTest(unittest.TestCase):
         ]
 
     def workflow_job_block(self, path: str, job_name: str) -> str:
+        """Returns the body of ``job_name`` in the workflow at ``path``.
+
+        A job body is blank lines and lines indented at least four spaces, so
+        the first line that is neither ends it: the next job's key, a comment
+        introducing that job, or anything after ``jobs:``. Letting a comment
+        run on into the preceding body would make assertions over that body
+        report the wrong thing in both directions -- ``assertIn`` could pass on
+        text belonging to the next job, and ``assertNotIn`` could fail on it.
+        """
         text = Path(path).read_text()
         match = re.search(
-            rf"^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_]+:\n|\Z)",
+            rf"^  {re.escape(job_name)}:\n"
+            r"(?P<body>.*?)(?=^(?![ \t]*\n)(?! {4})|\Z)",
             text,
             re.MULTILINE | re.DOTALL,
         )
@@ -995,6 +1005,10 @@ class CiTest(unittest.TestCase):
         for path, job_name in (
             (".github/workflows/ci_iree_bazel.yml", "linux_bazel_amdgpu"),
             (".github/workflows/ci_iree_cmake.yml", "linux_cmake_amdgpu"),
+            (
+                ".github/workflows/test_core_linux_gpu_source.yml",
+                "test_core_linux_gpu_source",
+            ),
         ):
             with self.subTest(path=path):
                 block = self.workflow_job_block(path, job_name)
@@ -1157,33 +1171,92 @@ fi
             )
 
     def test_core_gpu_workflow_routes_exact_gpu_labels(self):
-        block = self.workflow_job_block(
-            ".github/workflows/ci_core_linux.yml", "gpu_linux"
+        gfx942_block = self.workflow_job_block(
+            ".github/workflows/ci_core_linux.yml", "gpu_linux_gfx942"
+        )
+        self.assertIn("name: Linux / CMake / GPU gfx942", gfx942_block)
+        self.assertIn(
+            "uses: ./.github/workflows/test_core_linux_gpu_source.yml",
+            gfx942_block,
         )
         self.assertIn(
             "runner_labels: '[\"linux-gfx942-1gpu-ccs-csp-ossci-rocm\"]'",
-            block,
+            gfx942_block,
+        )
+        self.assertIn("amdgpu_targets: gfx942", gfx942_block)
+        self.assertNotIn("artifact_run_id", gfx942_block)
+        self.assertNotIn("gfx1201", gfx942_block)
+
+        gfx1201_block = self.workflow_job_block(
+            ".github/workflows/ci_core_linux.yml", "gpu_linux_gfx1201"
+        )
+        self.assertIn("name: Linux / CMake / GPU gfx1201", gfx1201_block)
+        self.assertIn(
+            "uses: ./.github/workflows/test_core_linux_gpu.yml", gfx1201_block
         )
         self.assertIn(
             'runner_labels: \'["self-hosted", "Linux", "X64", "gpu_navi4x"]\'',
-            block,
+            gfx1201_block,
+        )
+        self.assertIn("artifact_run_id: ${{ github.run_id }}", gfx1201_block)
+
+        summary_block = self.workflow_job_block(
+            ".github/workflows/ci_core_linux.yml", "summary"
+        )
+        for job in ("cmake_linux", "gpu_linux_gfx942", "gpu_linux_gfx1201"):
+            self.assertIn(f"- {job}", summary_block)
+            self.assertIn("needs." + job + ".result", summary_block)
+
+        for path, job_name in (
+            (".github/workflows/test_core_linux_gpu.yml", "test_core_linux_gpu"),
+            (
+                ".github/workflows/test_core_linux_gpu_source.yml",
+                "test_core_linux_gpu_source",
+            ),
+        ):
+            with self.subTest(path=path):
+                reusable_workflow = Path(path).read_text()
+                # Both workflows declare runner_labels once per trigger, so
+                # asserting one match would let either declaration satisfy the
+                # test for the other.
+                declarations = re.findall(
+                    r"^ +runner_labels:$", reusable_workflow, re.MULTILINE
+                )
+                required_declarations = re.findall(
+                    r"runner_labels:\n\s+type: string\n\s+description: "
+                    r'"JSON array of labels that must all match the GPU runner\."\n'
+                    r"\s+required: true",
+                    reusable_workflow,
+                )
+                self.assertEqual(len(declarations), 2)
+                self.assertEqual(len(required_declarations), len(declarations))
+                reusable_block = self.workflow_job_block(path, job_name)
+                self.assertRegex(
+                    reusable_block,
+                    r"(?m)^\s+runs-on: \$\{\{ fromJSON\(inputs\.runner_labels\) \}\}$",
+                )
+
+    def test_core_gpu_source_workflow_builds_instead_of_downloading(self):
+        block = self.workflow_job_block(
+            ".github/workflows/test_core_linux_gpu_source.yml",
+            "test_core_linux_gpu_source",
         )
 
-        reusable_workflow = Path(
-            ".github/workflows/test_core_linux_gpu.yml"
-        ).read_text()
-        self.assertRegex(
-            reusable_workflow,
-            r"runner_labels:\n\s+type: string\n\s+description: "
-            r'"JSON array of labels that must all match the GPU runner\."\n'
-            r"\s+required: true",
-        )
-        reusable_block = self.workflow_job_block(
-            ".github/workflows/test_core_linux_gpu.yml", "test_core_linux_gpu"
-        )
-        self.assertRegex(
-            reusable_block,
-            r"(?m)^\s+runs-on: \$\{\{ fromJSON\(inputs\.runner_labels\) \}\}$",
+        self.assertNotIn("actions/download-artifact", block)
+        self.assertNotIn("ci_core_linux.py extract-packages", block)
+        self.assertIn("bash .github/scripts/fetch_rocm_toolchain.sh", block)
+        self.assertIn('"${HRX_PYTHON}" build_tools/ci/ci_core_linux.py build', block)
+        self.assertIn('"${HRX_PYTHON}" build_tools/ci/ci_core_linux.py test', block)
+
+        # prepare_public_deps_root() synthesizes the runtime dependency overlay
+        # from the fetched ROCm root because no dependency package is unpacked.
+        self.assertIn('HRX_PREPARE_PUBLIC_DEPS: "true"', block)
+        self.assertIn('HRX_PACKAGE_SMOKE: "false"', block)
+        self.assertIn('HRX_TEST_GPU: "true"', block)
+        self.assertIn(
+            "HRX_CMAKE_OPTIONS: "
+            '"-DIREE_HAL_AMDGPU_TARGETS=${{ inputs.amdgpu_targets }}"',
+            block,
         )
 
     def test_core_windows_workflow_uses_generic_windows_runner(self):


### PR DESCRIPTION

The `Linux / CMake / GPU gfx942` job downloads a ~2 GiB `hrx-tests-linux-x86_64` package artifact before it can run a single test, and that download is what fails. Of the 283 instances of that job that reached a conclusion between 2026-08-11 and 2026-08-27, 84 succeeded, 157 were killed by the `timeout-minutes` cap (154 of them inside the test-package download), 38 ended when their whole run was cancelled, and 4 failed outright. The 157 is each job's own `exceeded the maximum execution time` check annotation rather than an inference from job duration. The 38 are counted apart because they are not this job failing at anything: `ci_core_linux.yml` sets `cancel-in-progress: true`, so a new push kills the run in flight, and gfx1201 collects 8 of the same over the same runs. Because the job feeds `Linux / CMake / CI / Summary`, its result puts a red check on every pull request in the repository regardless of what the pull request changes.

The cause is that runner pool's network route to artifact storage, not the artifact size and not the artifact service. In run `33027055677` the same 2,146,209,608-byte artifact from the same storage account took 1044 s on gfx942 (2.06 MB/s) and 49 s on gfx1201 (43.6 MB/s). The contrast shows up inside a single job as well: in gfx942 job `98586276484`, pip pulled its wheels from PyPI at 140-186 MB/s, and a minute later the same runner spent 17 s pulling the 6.8 MB dependency package out of blob storage, which is 0.40 MB/s. Raising the timeout does not fix it either: at that same 0.40 MB/s the 2 GB test package needs about 90 minutes.

So gfx942 now builds the tests it runs. A new reusable workflow, `.github/workflows/test_core_linux_gpu_source.yml`, checks out the repository on the GPU runner, fetches the ROCm toolchain with `.github/scripts/fetch_rocm_toolchain.sh`, and runs `build_tools/ci/ci_core_linux.py build` followed by `ci_core_linux.py test` with the same CTest selection the job uses today. There is no artifact download of any kind. `build_tools/ci/ci_core_linux.py` needed no changes; the only difference from the packaged path is environment variables. The most important one is `HRX_PREPARE_PUBLIC_DEPS=true`, which makes `prepare_public_deps_root()` synthesize the runtime dependency overlay out of the fetched ROCm root instead of out of an extracted `hrx-public-deps` package. `HRX_PACKAGE_SMOKE` stays `false` and every `HRX_CTEST_*` value is unchanged, so the selection is the one the packaged gfx942 job runs today: `-L runtime-resource=amd-gpu -LE manual` at parallelism 1, which reported `100% tests passed, 0 tests failed out of 105` in run `33027055677`. The from-source job itself has not run in CI yet, so that count is what the selection resolves to on this hardware, not a result this workflow has produced. Outside CI, the three phases this workflow drives — `ci_core_linux.py fetch-rocm`, then `build`, then `test` — were run directly on a gfx942 host with `HRX_PREPARE_PUBLIC_DEPS=true`, `HRX_PACKAGE_SMOKE=false`, `HRX_TEST_GPU=true`, `HRX_CTS_DEVICE=gpu:0`, that same selection at parallelism 1, an unmodified `ci_core_linux.py`, and no artifact download of any kind; that run reported the same `100% tests passed, 0 tests failed out of 105`. That exercises the phase composition, including the `prepare_public_deps_root()` synthesis above, which is the one genuinely new environment behavior here; it does not exercise the workflow file itself, the container, or the runner.

Compiling on the GPU runner costs nothing that was being saved elsewhere. Nothing in this CI caches compiler output — no ccache, no sccache, no `CMAKE_*_COMPILER_LAUNCHER`, and the repository's single `actions/cache` caches pip downloads for the importer lane — so no incremental state is lost by compiling on a different pool, and the gfx942 runner is the larger machine of the two involved: two EPYC 9454s, 192 logical CPUs, about 1.1 TiB of RAM. A from-source build on this exact runner label is also not new; `linux_cmake_amdgpu` in `.github/workflows/ci_iree_cmake.yml` has been doing one on `linux-gfx942-1gpu-ccs-csp-ossci-rocm` all along, and the new workflow reuses its container block, its ROCm fetch step, and its GPU device options verbatim rather than inventing new ones.

## gfx1201 keeps downloading the package, on purpose

`gpu_linux` was one matrix job covering two chips, and `jobs.<job_id>.uses` accepts no expressions or contexts, so a matrix `include` cannot select which workflow a job calls. It is now two jobs: `gpu_linux_gfx942` calling the new source workflow, and `gpu_linux_gfx1201` calling the existing `test_core_linux_gpu.yml` exactly as before. `test_core_linux_gpu.yml` is unchanged, including its `workflow_dispatch` entry point for validating a package from an arbitrary `artifact_run_id` by hand.

That split is deliberate. gfx1201 succeeded in 269 of the 285 instances that reached a conclusion over the same window (94.4%), with a 49 s download on a healthy pool, and it keeps downloading the packages that `cmake_linux` built, unpacking them onto a different machine with a different glibc, and running them there. So "does the shipped package extract and work on a machine that did not build it" keeps being answered on every pull request, with no nightly or post-merge package job needed to recover it. What is genuinely given up is that this question is now asked on one chip instead of two: the packaged install components, the dependency overlay, and the composed install root are no longer exercised on a CDNA part by any job. That is a real reduction, and it is the price of ending the timeout rate: 157 of the 283 concluded gfx942 job instances above, 55.5%. A periodic package job on the gfx942 pool would buy it back if the coverage turns out to matter.

Both jobs keep `needs: cmake_linux`, so a compile failure still stops on the build pool before it consumes a GPU runner, and both are listed in `summary`'s `needs:` and checked in its result script, so neither can go red silently.

The rendered check names are unchanged. Both halves of each name — the caller job's `name:` and the called workflow's job `name:` — are byte-identical to what they were, so branch protection and required-check matching are unaffected.

## Scope

This job compiles `IREE_HAL_AMDGPU_TARGETS=gfx942` only, while `cmake_linux` continues to compile `gfx942;gfx1151;gfx1201`. The multi-target compile therefore stays covered by `cmake_linux`, and narrowing the selector here does not change which tests exist: every use of `IREE_HAL_AMDGPU_TARGETS` in the runtime feeds `iree_amdgpu_hal_cts_testdata`, `iree_amdgpu_binary_variants_embed_data`, or `iree_amdgpu_library_variants`, all of which name libraries and embedded device binaries per code-object fragment rather than registering CTest tests. Loom is unaffected because `LOOM_TARGET_AMDGPU_TARGETS` defaults to `loom_defaults`, not `iree_hal`. So the change narrows the device code objects embedded in test data down to the ones this runner can actually execute, and nothing else.

`build_tools/devtools/ci_test.py` asserted on a workflow job block literally named `gpu_linux` and reads workflow YAML through an explicit `data` list, so the split required updating that test and the `data` list in `build_tools/devtools/BUILD.bazel` alongside `exports_files` in the root `BUILD.bazel`. The rewritten assertions pin the new routing — gfx942 to the source workflow with no `artifact_run_id`, gfx1201 to the package workflow with one — and a new test pins the properties that make the source job correct: no `actions/download-artifact`, no `extract-packages`, and the `HRX_PREPARE_PUBLIC_DEPS` / `HRX_PACKAGE_SMOKE` / `HRX_TEST_GPU` values the pipeline depends on.

Deliberately not included: no debug-info stripping, no test-package filtering, and no nightly or post-merge package job, since gfx1201 already keeps the packaging assertion alive on every pull request.

## A pre-existing mechanism this change newly exposes the gfx942 job to

Every job that calls `ci_core_linux.py fetch-rocm` resolves its own ROCm nightly independently. `fetch_rocm()` computes `latest = not bool(args.run_id)` and CI passes an empty `HRX_RUN_ID`, so each job discovers the newest complete run at the moment it starts. The four sanitizer variants of `cmake_linux` can already diverge from each other today for exactly this reason, and nothing here changes that.

What is new is that the gfx942 GPU job is now subject to it. Before, that job could not diverge from the build: it ran against the `hrx-public-deps-linux-x86_64` package, which was cut from `cmake_linux`'s ROCm root. Now it fetches its own root, and because it starts only after the whole `cmake_linux` matrix finishes, a nightly published inside that window puts the two on different ROCm builds. The job stays internally consistent — it builds and tests against the single root it fetched, which is a stronger guarantee than composing a build from one nightly with a test package from another — but a bad nightly landing in that window can now redden the gfx942 job on an unrelated pull request, which is the same class of noise this change removes elsewhere.

Fixing it means resolving the run id once and passing it down, which is a change to `fetch-rocm`'s callers across every lane and does not belong here. It deserves its own issue, which should also carry the condition under which the two GPU jobs re-converge on the packaged path.
