### PR TITLE
[Infra] Make Windows Bazel target contracts explicit

### DIFF
--- a/libhrx/cts/BUILD.bazel
+++ b/libhrx/cts/BUILD.bazel
@@ -19,7 +19,10 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
-AMD_GPU_CTS_TAGS = ["runtime-resource=amd-gpu"]
+AMD_GPU_CTS_TAGS = [
+    "iree-run-requirement=runtime.resource.amd_gpu",
+    "runtime-resource=amd-gpu",
+]
 
 _LINUX_COMPATIBILITY = ["@platforms//os:linux"]
 

--- a/libhrx/cts/CMakeLists.txt
+++ b/libhrx/cts/CMakeLists.txt
@@ -107,6 +107,7 @@ hrx_cc_test(
     "--hrx-library"
     "$<TARGET_FILE:libhrx::src::libhrx::hrx>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
 )
 
@@ -125,6 +126,7 @@ hrx_cc_test(
     "--hrx-library"
     "$<TARGET_FILE:libhrx::src::libhrx::hrx>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
 )
 
@@ -143,6 +145,7 @@ hrx_cc_test(
     "--hrx-library"
     "$<TARGET_FILE:libhrx::src::libhrx::hrx>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
 )
 
@@ -161,6 +164,7 @@ hrx_cc_test(
     "--hrx-library"
     "$<TARGET_FILE:libhrx::src::libhrx::hrx>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
 )
 
@@ -179,6 +183,7 @@ hrx_cc_test(
     "--hrx-library"
     "$<TARGET_FILE:libhrx::src::libhrx::hrx>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
 )
 
@@ -197,6 +202,7 @@ hrx_cc_test(
     "--hrx-library"
     "$<TARGET_FILE:libhrx::src::libhrx::hrx>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
 )
 
@@ -215,6 +221,7 @@ hrx_cc_test(
     "--hrx-library"
     "$<TARGET_FILE:libhrx::src::libhrx::hrx>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
 )
 
@@ -233,6 +240,7 @@ hrx_cc_test(
     "--hrx-library"
     "$<TARGET_FILE:libhrx::src::libhrx::hrx>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
 )
 
@@ -254,6 +262,7 @@ hrx_cc_test(
     "--hrx-library"
     "$<TARGET_FILE:libhrx::src::libhrx::hrx>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
 )
 
@@ -274,6 +283,7 @@ iree_cc_test(
   ENV
     "HRX_TEST_LIBAMDHIP64=$<TARGET_FILE:libhrx::src::binding::hip::amdhip64>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
   SANITIZER_SUPPRESSIONS
     lsan
@@ -303,6 +313,7 @@ iree_cc_test(
   ENV
     "HRX_TEST_LIBAMDHIP64=$<TARGET_FILE:libhrx::src::binding::hip::amdhip64>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
   SANITIZER_SUPPRESSIONS
     lsan
@@ -334,6 +345,7 @@ iree_cc_test(
   ENV
     "HRX_TEST_LIBAMDHIP64=$<TARGET_FILE:libhrx::src::binding::hip::amdhip64>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
   SANITIZER_SUPPRESSIONS
     lsan
@@ -363,6 +375,7 @@ iree_cc_test(
   ENV
     "HRX_TEST_LIBAMDHIP64=$<TARGET_FILE:libhrx::src::binding::hip::amdhip64>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
   SANITIZER_SUPPRESSIONS
     lsan
@@ -392,6 +405,7 @@ iree_cc_test(
   ENV
     "HRX_TEST_LIBAMDHIP64=$<TARGET_FILE:libhrx::src::binding::hip::amdhip64>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
     "manual"
   SANITIZER_SUPPRESSIONS
@@ -415,6 +429,7 @@ hrx_cc_test(
     "--hrx-library"
     "$<TARGET_FILE:libhrx::src::libhrx::hrx>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
 )
 
@@ -449,6 +464,7 @@ hrx_cc_test(
     "--hrx-library"
     "$<TARGET_FILE:libhrx::src::libhrx::hrx>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
 )
 
@@ -467,6 +483,7 @@ hrx_cc_test(
     "--hrx-library"
     "$<TARGET_FILE:libhrx::src::libhrx::hrx>"
   LABELS
+    "iree-run-requirement=runtime.resource.amd_gpu"
     "runtime-resource=amd-gpu"
 )
 

--- a/loom/py/loom/importers/check/mlir/BUILD.bazel
+++ b/loom/py/loom/importers/check/mlir/BUILD.bazel
@@ -15,6 +15,9 @@ package(
 _MLIR_IMPORTER_COMPATIBLE = iree_select({
     "//loom/config/import:mlir": [],
     "//conditions:default": ["@platforms//:incompatible"],
+}) + iree_select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
 })
 
 iree_py_library(

--- a/loom/py/loom/importers/check/tilelang/BUILD.bazel
+++ b/loom/py/loom/importers/check/tilelang/BUILD.bazel
@@ -15,6 +15,9 @@ package(
 _TILELANG_IMPORTER_COMPATIBLE = iree_select({
     "//loom/config/import:tilelang": [],
     "//conditions:default": ["@platforms//:incompatible"],
+}) + iree_select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
 })
 
 iree_py_library(

--- a/loom/py/loom/importers/mlir/BUILD.bazel
+++ b/loom/py/loom/importers/mlir/BUILD.bazel
@@ -15,6 +15,9 @@ package(
 _MLIR_IMPORTER_COMPATIBLE = iree_select({
     "//loom/config/import:mlir": [],
     "//conditions:default": ["@platforms//:incompatible"],
+}) + iree_select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
 })
 
 iree_py_library(

--- a/loom/py/loom/importers/tilelang/BUILD.bazel
+++ b/loom/py/loom/importers/tilelang/BUILD.bazel
@@ -15,6 +15,9 @@ package(
 _TILELANG_IMPORTER_COMPATIBLE = iree_select({
     "//loom/config/import:tilelang": [],
     "//conditions:default": ["@platforms//:incompatible"],
+}) + iree_select({
+    "@platforms//os:windows": ["@platforms//:incompatible"],
+    "//conditions:default": [],
 })
 
 iree_py_library(

--- a/loom/src/loom/target/tool/process_test.cc
+++ b/loom/src/loom/target/tool/process_test.cc
@@ -244,6 +244,16 @@ TEST(ToolProcessTest, DoesNotInheritUnrelatedWin32Handles) {
   loom_tool_process_result_deinitialize(&result, iree_allocator_system());
 }
 
+TEST(ToolProcessTest, MapsMissingPathExecutableToNotFound) {
+  loom_tool_process_result_t result = {0};
+  iree_status_t status = loom_tool_process_run(
+      IREE_SV("loom_process_missing_executable_7d56240f.exe"),
+      /*search_path=*/true, /*arguments=*/NULL, /*argument_count=*/0,
+      iree_allocator_system(), &result);
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_NOT_FOUND, status);
+}
+
 #endif  // IREE_PLATFORM_WINDOWS
 
 #if defined(IREE_PLATFORM_LINUX) || defined(IREE_PLATFORM_MACOS) || \


### PR DESCRIPTION
The repository-wide Bazel test graph needs target metadata to distinguish unsupported host tools from tests that merely require unavailable hardware. Optional MLIR and TileLang importer executables became compatible on Windows whenever their feature flags were enabled, while libhrx GPU CTS only carried its private resource tag.

Mark the optional importer executables and tests incompatible on Windows and give libhrx GPU CTS the canonical AMD GPU run requirement used by repository CI filters. Also cover the Win32 process launcher's missing-PATH-executable mapping so the host behavior relied on by external-tool tests stays explicit.

## Reviewer Notes

The importer libraries remain available; only executables and tests that need the unsupported external importer toolchains are platform-incompatible. The legacy libhrx resource label remains alongside the canonical label for its own CTS workflows. No production process behavior changes in this PR.
