### PR TITLE
[HAL/AMDGPU] Add virtual-memory access scopes

### DIFF
--- a/libhrx/cts/tests/virtual_memory/virtual_memory_test.cpp
+++ b/libhrx/cts/tests/virtual_memory/virtual_memory_test.cpp
@@ -5,6 +5,46 @@
 
 #include "hrx_test_fixture.hpp"
 
+namespace {
+
+static void IgnoreCleanupStatus(hrx_status_t status) {
+  if (!hrx_status_is_ok(status)) hrx().status_ignore(status);
+}
+
+class VirtualMemoryResources {
+ public:
+  explicit VirtualMemoryResources(hrx_allocator_t allocator)
+      : allocator(allocator) {}
+
+  ~VirtualMemoryResources() {
+    if (is_mapped) {
+      IgnoreCleanupStatus(hrx().allocator_virtual_memory_unmap(
+          allocator, virtual_buffer, /*virtual_offset=*/0, size));
+    }
+    if (physical_memory) {
+      IgnoreCleanupStatus(
+          hrx().allocator_physical_memory_free(allocator, physical_memory));
+    }
+    if (virtual_buffer) {
+      IgnoreCleanupStatus(
+          hrx().allocator_virtual_memory_release(allocator, virtual_buffer));
+    }
+  }
+
+  // Unowned allocator that outlives all resources in this helper.
+  hrx_allocator_t allocator = nullptr;
+  // Owned virtual address reservation released by the destructor.
+  hrx_buffer_t virtual_buffer = nullptr;
+  // Owned physical allocation freed by the destructor.
+  hrx_physical_memory_t physical_memory = nullptr;
+  // Size in bytes of the reservation, allocation, and mapping.
+  size_t size = 0;
+  // Whether the physical allocation is currently mapped.
+  bool is_mapped = false;
+};
+
+}  // namespace
+
 TEST_CASE_METHOD(HrxTestFixture, "query virtual memory support",
                  "[virtual_memory][query]") {
   hrx_allocator_t alloc = hrx().device_allocator(device_);
@@ -14,8 +54,7 @@ TEST_CASE_METHOD(HrxTestFixture, "query virtual memory support",
   REQUIRE_OK(hrx().allocator_query_virtual_memory(
       alloc, HRX_MEMORY_TYPE_DEVICE_LOCAL, &supported, &min_page, &rec_page));
 
-  // The task driver does not support VM — just verify the query doesn't crash
-  // and returns consistent values.
+  // Supported and unsupported allocators report consistent granularity values.
   if (supported) {
     REQUIRE(min_page > 0);
     REQUIRE(rec_page >= min_page);
@@ -25,8 +64,8 @@ TEST_CASE_METHOD(HrxTestFixture, "query virtual memory support",
   }
 }
 
-TEST_CASE_METHOD(HrxTestFixture, "reserve fails gracefully without VM support",
-                 "[virtual_memory][reserve]") {
+TEST_CASE_METHOD(HrxTestFixture, "virtual memory lifecycle",
+                 "[virtual_memory][lifecycle]") {
   hrx_allocator_t alloc = hrx().device_allocator(device_);
 
   bool supported = false;
@@ -35,12 +74,41 @@ TEST_CASE_METHOD(HrxTestFixture, "reserve fails gracefully without VM support",
       alloc, HRX_MEMORY_TYPE_DEVICE_LOCAL, &supported, &min_page, &rec_page));
 
   if (!supported) {
-    // Reserve should fail with UNAVAILABLE.
     hrx_buffer_t vbuf = nullptr;
     hrx_status_t s =
         hrx().allocator_virtual_memory_reserve(alloc, 0, 1024 * 1024, &vbuf);
     REQUIRE(!hrx_status_is_ok(s));
     hrx().status_ignore(s);
+    return;
   }
-  // If VM is supported, a full reserve/map/unmap/release cycle would go here.
+
+  REQUIRE(min_page > 0);
+  REQUIRE(rec_page >= min_page);
+  VirtualMemoryResources resources(alloc);
+  resources.size = rec_page;
+
+  REQUIRE_OK(hrx().allocator_virtual_memory_reserve(
+      alloc, /*affinity=*/0, resources.size, &resources.virtual_buffer));
+  REQUIRE(resources.virtual_buffer != nullptr);
+  REQUIRE_OK(hrx().allocator_physical_memory_allocate(
+      alloc, HRX_MEMORY_TYPE_DEVICE_LOCAL, resources.size,
+      &resources.physical_memory));
+  REQUIRE(resources.physical_memory != nullptr);
+  REQUIRE_OK(hrx().allocator_virtual_memory_map(
+      alloc, resources.virtual_buffer, /*virtual_offset=*/0,
+      resources.physical_memory, /*physical_offset=*/0, resources.size));
+  resources.is_mapped = true;
+  REQUIRE_OK(hrx().allocator_virtual_memory_protect(
+      alloc, resources.virtual_buffer, /*virtual_offset=*/0, resources.size,
+      HRX_MEMORY_PROTECTION_READ_WRITE));
+
+  REQUIRE_OK(hrx().allocator_virtual_memory_unmap(
+      alloc, resources.virtual_buffer, /*virtual_offset=*/0, resources.size));
+  resources.is_mapped = false;
+  REQUIRE_OK(
+      hrx().allocator_physical_memory_free(alloc, resources.physical_memory));
+  resources.physical_memory = nullptr;
+  REQUIRE_OK(
+      hrx().allocator_virtual_memory_release(alloc, resources.virtual_buffer));
+  resources.virtual_buffer = nullptr;
 }

--- a/libhrx/src/libhrx/allocator.c
+++ b/libhrx/src/libhrx/allocator.c
@@ -304,5 +304,6 @@ hrx_status_t hrx_allocator_virtual_memory_protect(
       allocator->hal_allocator, virtual_buffer->hal_buffer,
       (iree_device_size_t)virtual_offset, (iree_device_size_t)size,
       /*queue_family_affinity=*/IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
       (iree_hal_memory_protection_t)protection));
 }

--- a/libhrx/src/libhrx/vmm_slab_provider.c
+++ b/libhrx/src/libhrx/vmm_slab_provider.c
@@ -219,6 +219,7 @@ static iree_status_t hrx_vmm_slab_provider_acquire_slab(
     status = iree_hal_allocator_virtual_memory_protect(
         provider->allocator, slab->virtual_buffer, /*virtual_offset=*/0,
         allocation_size, provider->buffer_params.queue_family_affinity,
+        IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
         IREE_HAL_MEMORY_PROTECTION_READ_WRITE);
   }
 

--- a/runtime/src/iree/hal/allocator.c
+++ b/runtime/src/iree/hal/allocator.c
@@ -356,13 +356,23 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   IREE_ASSERT_ARGUMENT(allocator);
   IREE_ASSERT_ARGUMENT(virtual_buffer);
+  if (IREE_UNLIKELY(
+          access_scope == IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_NONE ||
+          iree_any_bit_set(access_scope,
+                           ~(iree_hal_virtual_memory_access_scope_t)
+                               IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid virtual-memory access scope 0x%08" PRIx32,
+                            access_scope);
+  }
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_status_t status = _VTABLE_DISPATCH(allocator, virtual_memory_protect)(
       allocator, virtual_buffer, virtual_offset, size, queue_family_affinity,
-      protection);
+      access_scope, protection);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/allocator.h
+++ b/runtime/src/iree/hal/allocator.h
@@ -233,6 +233,26 @@ typedef struct iree_hal_external_buffer_t {
 // mapped to a virtual address space.
 typedef struct iree_hal_physical_memory_t iree_hal_physical_memory_t;
 
+// Bitfield selecting the execution domains whose access permissions are
+// updated by a virtual-memory protection operation. Queue family affinity
+// restricts the selected domains to the topology associated with those
+// families. Permissions for domains omitted from the scope are unchanged.
+enum iree_hal_virtual_memory_access_scope_bits_t {
+  IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_NONE = 0u,
+
+  // Device execution domains selected by queue family affinity.
+  IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE = 1u << 0,
+
+  // Host execution domains associated with the selected device topology.
+  // For remote devices this is the execution-side host, not the caller.
+  IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST = 1u << 1,
+
+  IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL =
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE |
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST,
+};
+typedef uint32_t iree_hal_virtual_memory_access_scope_t;
+
 // Memory protection flags for controlling access to virtual address ranges.
 // Maps to the equivalent host or device virtual memory protection API.
 enum iree_hal_memory_protection_bits_t {
@@ -572,9 +592,13 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_virtual_memory_unmap(
 // Sets access permissions for a virtual address range.
 //
 // |virtual_buffer| is the reserved VA range. |virtual_offset| and |size|
-// specify the range (must be page aligned). |queue_family_affinity| specifies
-// which queue families get the specified permissions. |protection| is a
-// bitmask of iree_hal_memory_protection_bits_t flags.
+// specify the range (must be page aligned). |queue_family_affinity| selects
+// the device topology where permissions apply and |access_scope| selects the
+// execution domains updated within that topology. Domains omitted from
+// |access_scope| retain their existing permissions. |protection| is a bitmask
+// of iree_hal_memory_protection_bits_t flags. Backends return
+// IREE_STATUS_UNIMPLEMENTED when they cannot independently update the
+// requested access scope.
 //
 // By default, reserved VA ranges have no access permissions. Callers must
 // explicitly grant permissions after mapping physical memory.
@@ -585,6 +609,7 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection);
 
 // Provides usage hints for a virtual address range to optimize performance.
@@ -714,6 +739,7 @@ typedef struct iree_hal_allocator_vtable_t {
       iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
       iree_device_size_t virtual_offset, iree_device_size_t size,
       iree_hal_queue_family_affinity_t queue_family_affinity,
+      iree_hal_virtual_memory_access_scope_t access_scope,
       iree_hal_memory_protection_t protection);
   iree_status_t(IREE_API_PTR* virtual_memory_advise)(
       iree_hal_allocator_t* IREE_RESTRICT allocator,

--- a/runtime/src/iree/hal/allocator_heap.c
+++ b/runtime/src/iree/hal/allocator_heap.c
@@ -378,6 +378,7 @@ static iree_status_t iree_hal_heap_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   return iree_make_status(IREE_STATUS_UNAVAILABLE,
                           "heap allocator does not support virtual memory");

--- a/runtime/src/iree/hal/drivers/amdgpu/access_policy.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/access_policy.c
@@ -129,6 +129,62 @@ iree_status_t iree_hal_amdgpu_access_agent_list_resolve_queue_family_agents(
   return status;
 }
 
+iree_status_t iree_hal_amdgpu_access_agent_list_resolve_scope_agents(
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
+    iree_hal_amdgpu_access_agent_list_t* out_agent_list) {
+  IREE_ASSERT_ARGUMENT(topology);
+  IREE_ASSERT_ARGUMENT(out_agent_list);
+  memset(out_agent_list, 0, sizeof(*out_agent_list));
+
+  if (IREE_UNLIKELY(
+          access_scope == IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_NONE ||
+          iree_any_bit_set(access_scope,
+                           ~(iree_hal_virtual_memory_access_scope_t)
+                               IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL))) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "invalid AMDGPU virtual-memory access scope");
+  }
+
+  iree_hal_amdgpu_gpu_agent_mask_t gpu_agent_mask = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_access_agent_list_select_families(
+      topology, queue_family_affinity, &gpu_agent_mask));
+
+  iree_status_t status = iree_ok_status();
+  for (iree_host_size_t physical_device_ordinal = 0;
+       physical_device_ordinal < topology->gpu_agent_count &&
+       iree_status_is_ok(status);
+       ++physical_device_ordinal) {
+    if (!iree_all_bits_set(gpu_agent_mask, ((uint64_t)1)
+                                               << physical_device_ordinal)) {
+      continue;
+    }
+    if (iree_any_bit_set(access_scope,
+                         IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE)) {
+      status = iree_hal_amdgpu_access_agent_list_append_unique(
+          out_agent_list, topology->gpu_agents[physical_device_ordinal]);
+    }
+    if (iree_status_is_ok(status) &&
+        iree_any_bit_set(access_scope,
+                         IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST)) {
+      const iree_host_size_t cpu_agent_ordinal =
+          topology->gpu_cpu_map[physical_device_ordinal];
+      if (IREE_UNLIKELY(cpu_agent_ordinal >= topology->cpu_agent_count)) {
+        status =
+            iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                             "AMDGPU topology maps GPU agent ordinal %" PRIhsz
+                             " to invalid CPU agent ordinal %" PRIhsz,
+                             physical_device_ordinal, cpu_agent_ordinal);
+        break;
+      }
+      status = iree_hal_amdgpu_access_agent_list_append_unique(
+          out_agent_list, topology->cpu_agents[cpu_agent_ordinal]);
+    }
+  }
+  return status;
+}
+
 iree_status_t iree_hal_amdgpu_access_allow_agent_list(
     const iree_hal_amdgpu_libhsa_t* libhsa,
     const iree_hal_amdgpu_access_agent_list_t* agent_list, const void* ptr) {

--- a/runtime/src/iree/hal/drivers/amdgpu/access_policy.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/access_policy.h
@@ -57,6 +57,16 @@ iree_status_t iree_hal_amdgpu_access_agent_list_resolve_memory_agents(
     iree_hal_queue_family_affinity_t queue_family_affinity,
     iree_hal_amdgpu_access_agent_list_t* out_agent_list);
 
+// Resolves the HSA agents selected by virtual-memory |access_scope|.
+//
+// DEVICE selects the GPU agents represented by |queue_family_affinity|, HOST
+// selects their nearest CPU agents, and ALL selects the union of both sets.
+iree_status_t iree_hal_amdgpu_access_agent_list_resolve_scope_agents(
+    const iree_hal_amdgpu_topology_t* topology,
+    iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
+    iree_hal_amdgpu_access_agent_list_t* out_agent_list);
+
 // Grants |agent_list| access to an HSA memory pool allocation.
 iree_status_t iree_hal_amdgpu_access_allow_agent_list(
     const iree_hal_amdgpu_libhsa_t* libhsa,

--- a/runtime/src/iree/hal/drivers/amdgpu/access_policy_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/access_policy_test.cc
@@ -99,5 +99,123 @@ TEST(AccessPolicyTest, RejectsInvalidGpuCpuMap) {
           &topology, iree_hal_make_queue_family_affinity(1), &agent_list));
 }
 
+TEST(AccessPolicyTest, DeviceScopeSelectsOnlyGpuAgents) {
+  iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
+
+  iree_hal_amdgpu_access_agent_list_t agent_list;
+  IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve_scope_agents(
+      &topology, iree_hal_make_queue_family_affinity(1),
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE, &agent_list));
+
+  EXPECT_EQ(agent_list.count, 1u);
+  EXPECT_TRUE(AgentListContains(agent_list, topology.gpu_agents[1]));
+  EXPECT_FALSE(AgentListContains(agent_list, topology.cpu_agents[0]));
+  EXPECT_FALSE(AgentListContains(agent_list, topology.cpu_agents[1]));
+}
+
+TEST(AccessPolicyTest, HostScopeSelectsAndDeduplicatesNearestCpuAgents) {
+  iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
+
+  iree_hal_amdgpu_access_agent_list_t agent_list;
+  IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve_scope_agents(
+      &topology,
+      iree_hal_make_queue_family_affinity(0) |
+          iree_hal_make_queue_family_affinity(1),
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST, &agent_list));
+
+  EXPECT_EQ(agent_list.count, 1u);
+  EXPECT_TRUE(AgentListContains(agent_list, topology.cpu_agents[0]));
+  EXPECT_FALSE(AgentListContains(agent_list, topology.gpu_agents[0]));
+  EXPECT_FALSE(AgentListContains(agent_list, topology.gpu_agents[1]));
+}
+
+TEST(AccessPolicyTest, AllScopeSelectsLogicalTopologyAgents) {
+  iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
+
+  iree_hal_amdgpu_access_agent_list_t agent_list;
+  IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve_scope_agents(
+      &topology, IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL, &agent_list));
+
+  EXPECT_EQ(agent_list.count, 5u);
+  EXPECT_TRUE(AgentListContains(agent_list, topology.cpu_agents[0]));
+  EXPECT_TRUE(AgentListContains(agent_list, topology.cpu_agents[1]));
+  EXPECT_TRUE(AgentListContains(agent_list, topology.gpu_agents[0]));
+  EXPECT_TRUE(AgentListContains(agent_list, topology.gpu_agents[1]));
+  EXPECT_TRUE(AgentListContains(agent_list, topology.gpu_agents[2]));
+}
+
+TEST(AccessPolicyTest, ScopeRejectsNoneAndUnknownBits) {
+  iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
+
+  iree_hal_amdgpu_access_agent_list_t agent_list;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_access_agent_list_resolve_scope_agents(
+          &topology, IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_NONE, &agent_list));
+  EXPECT_EQ(agent_list.count, 0u);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_access_agent_list_resolve_scope_agents(
+          &topology, IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
+          (iree_hal_virtual_memory_access_scope_t)1u << 31, &agent_list));
+  EXPECT_EQ(agent_list.count, 0u);
+}
+
+TEST(AccessPolicyTest, ScopeRejectsInvalidQueueFamilyAffinities) {
+  iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
+
+  iree_hal_amdgpu_access_agent_list_t agent_list;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_access_agent_list_resolve_scope_agents(
+          &topology, /*queue_family_affinity=*/0,
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE, &agent_list));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_amdgpu_access_agent_list_resolve_scope_agents(
+          &topology, iree_hal_make_queue_family_affinity(3),
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE, &agent_list));
+}
+
+TEST(AccessPolicyTest, DeviceScopeDoesNotDependOnCpuMappings) {
+  iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
+  topology.gpu_cpu_map[0] = topology.cpu_agent_count;
+  topology.gpu_cpu_map[1] = topology.cpu_agent_count;
+
+  iree_hal_amdgpu_access_agent_list_t agent_list;
+  IREE_ASSERT_OK(iree_hal_amdgpu_access_agent_list_resolve_scope_agents(
+      &topology,
+      iree_hal_make_queue_family_affinity(0) |
+          iree_hal_make_queue_family_affinity(1),
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE, &agent_list));
+  EXPECT_EQ(agent_list.count, 2u);
+}
+
+TEST(AccessPolicyTest, HostScopeRejectsInvalidGpuCpuMap) {
+  iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
+  topology.gpu_cpu_map[1] = topology.cpu_agent_count;
+
+  iree_hal_amdgpu_access_agent_list_t agent_list;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_OUT_OF_RANGE,
+      iree_hal_amdgpu_access_agent_list_resolve_scope_agents(
+          &topology, iree_hal_make_queue_family_affinity(1),
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST, &agent_list));
+}
+
+TEST(AccessPolicyTest, ScopeRejectsTopologyBeyondFamilyCapacity) {
+  iree_hal_amdgpu_topology_t topology = MakeThreeGpuTopology();
+  topology.gpu_agent_count = IREE_HAL_MAX_QUEUE_FAMILIES + 1;
+
+  iree_hal_amdgpu_access_agent_list_t agent_list;
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_OUT_OF_RANGE,
+      iree_hal_amdgpu_access_agent_list_resolve_scope_agents(
+          &topology, IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE, &agent_list));
+}
+
 }  // namespace
 }  // namespace iree::hal::amdgpu

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator.c
@@ -2209,6 +2209,7 @@ static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   iree_hal_amdgpu_allocator_t* allocator =
       iree_hal_amdgpu_allocator_cast(base_allocator);
@@ -2216,7 +2217,7 @@ static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_protect(
       iree_hal_amdgpu_allocator_require_virtual_memory(allocator));
   return iree_hal_amdgpu_virtual_memory_protect(
       allocator->virtual_memory, virtual_buffer, virtual_offset, size,
-      queue_family_affinity, protection);
+      queue_family_affinity, access_scope, protection);
 }
 
 static iree_status_t iree_hal_amdgpu_allocator_virtual_memory_advise(

--- a/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/allocator_test.cc
@@ -470,7 +470,36 @@ TEST_F(AllocatorTest, VirtualMemoryLifecycleUsesNativeState) {
   IREE_ASSERT_NOT_OK(iree_hal_allocator_virtual_memory_protect(
       allocator, virtual_memory.get(), /*virtual_offset=*/0,
       recommended_page_size, kQueueFamilyAffinity0,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_virtual_memory_protect(
+          allocator, virtual_memory.get(), /*virtual_offset=*/0,
+          recommended_page_size, kQueueFamilyAffinity0,
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_NONE,
+          IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_virtual_memory_protect(
+          allocator, virtual_memory.get(), /*virtual_offset=*/0,
+          recommended_page_size, kQueueFamilyAffinity0,
+          (iree_hal_virtual_memory_access_scope_t)1u << 31,
+          IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_virtual_memory_protect(
+          allocator, virtual_memory.get(), /*virtual_offset=*/0,
+          recommended_page_size, /*queue_family_affinity=*/0,
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
+          IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_virtual_memory_protect(
+          allocator, virtual_memory.get(), /*virtual_offset=*/0,
+          recommended_page_size, iree_hal_make_queue_family_affinity(1),
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
+          IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
 
   VirtualMemoryMapping mapping(allocator, virtual_memory.get(),
                                /*virtual_offset=*/0, recommended_page_size);
@@ -490,6 +519,7 @@ TEST_F(AllocatorTest, VirtualMemoryLifecycleUsesNativeState) {
   IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
       allocator, virtual_memory.get(), /*virtual_offset=*/0,
       recommended_page_size, kQueueFamilyAffinity0,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
 
   constexpr iree_device_size_t kTouchedSize = 256;
@@ -578,7 +608,47 @@ TEST_F(AllocatorTest, VirtualMemoryMapsMinimumGranuleAcrossPools) {
   IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
       allocator, virtual_memory.get(), /*virtual_offset=*/0,
       host_minimum_page_size, kQueueFamilyAffinity0,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST,
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+
+  volatile uint32_t* host_ptr = static_cast<volatile uint32_t*>(
+      iree_hal_amdgpu_buffer_device_pointer(virtual_memory.get()));
+  ASSERT_NE(nullptr, host_ptr);
+  constexpr uint32_t kHostPattern = 0x484F5354u;
+  host_ptr[0] = kHostPattern;
+  EXPECT_EQ(kHostPattern, host_ptr[0]);
+
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
+      allocator, virtual_memory.get(), /*virtual_offset=*/0,
+      host_minimum_page_size, kQueueFamilyAffinity0,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL,
+      IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+
+  constexpr iree_device_size_t kTouchedSize = 256;
+  ASSERT_GE(host_minimum_page_size, kTouchedSize);
+  constexpr uint32_t kDevicePattern = 0x414C4C21u;
+  IREE_ASSERT_OK(QueueFillAndWait(test_device.device(), test_device.queue(),
+                                  virtual_memory.get(), kTouchedSize,
+                                  &kDevicePattern, sizeof(kDevicePattern)));
+  for (iree_host_size_t i = 0; i < kTouchedSize / sizeof(uint32_t); ++i) {
+    EXPECT_EQ(kDevicePattern, host_ptr[i]);
+  }
+
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
+      allocator, virtual_memory.get(), /*virtual_offset=*/0,
+      host_minimum_page_size, kQueueFamilyAffinity0,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST,
+      IREE_HAL_MEMORY_PROTECTION_NONE));
+  hsa_access_permission_t gpu_permission = HSA_ACCESS_PERMISSION_NONE;
+  IREE_ASSERT_OK(iree_hsa_amd_vmem_get_access(
+      IREE_LIBHSA(&libhsa_), const_cast<uint32_t*>(host_ptr), &gpu_permission,
+      topology_.gpu_agents[0]));
+  EXPECT_EQ(HSA_ACCESS_PERMISSION_RW, gpu_permission);
+  hsa_access_permission_t cpu_permission = HSA_ACCESS_PERMISSION_RW;
+  IREE_ASSERT_OK(iree_hsa_amd_vmem_get_access(
+      IREE_LIBHSA(&libhsa_), const_cast<uint32_t*>(host_ptr), &cpu_permission,
+      topology_.cpu_agents[topology_.gpu_cpu_map[0]]));
+  EXPECT_EQ(HSA_ACCESS_PERMISSION_NONE, cpu_permission);
 
   IREE_ASSERT_OK(mapping.Unmap());
 }
@@ -651,7 +721,8 @@ TEST_F(AllocatorTest,
   IREE_ASSERT_OK(mapping.Map(physical_memory.get()));
   IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
       allocator, virtual_memory.get(), /*virtual_offset=*/0, mapping_size,
-      kQueueFamilyAffinity0, IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+      kQueueFamilyAffinity0, IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
+      IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
 
   constexpr iree_device_size_t kTouchedSize = 256;
   constexpr uint32_t kPattern = 0xC2055DE1u;

--- a/runtime/src/iree/hal/drivers/amdgpu/util/libhsa_tables.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/libhsa_tables.h
@@ -227,6 +227,10 @@ IREE_HAL_AMDGPU_LIBHSA_PFN(TRACE_ALWAYS, hsa_status_t, hsa_amd_vmem_set_access,
                                 const hsa_amd_memory_access_desc_t* desc,
                                 size_t desc_cnt),
                            ARGS(va, size, desc, desc_cnt))
+IREE_HAL_AMDGPU_LIBHSA_PFN(TRACE_ALWAYS, hsa_status_t, hsa_amd_vmem_get_access,
+                           DECL(void* va, hsa_access_permission_t* perms,
+                                hsa_agent_t agent_handle),
+                           ARGS(va, perms, agent_handle))
 
 IREE_HAL_AMDGPU_LIBHSA_PFN(TRACE_ALWAYS, hsa_status_t,
                            hsa_amd_vmem_handle_create,

--- a/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.c
@@ -502,6 +502,7 @@ iree_status_t iree_hal_amdgpu_virtual_memory_protect(
     iree_hal_buffer_t* virtual_buffer, iree_device_size_t virtual_offset,
     iree_device_size_t size,
     iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   IREE_ASSERT_ARGUMENT(state);
   IREE_ASSERT_ARGUMENT(virtual_buffer);
@@ -539,9 +540,8 @@ iree_status_t iree_hal_amdgpu_virtual_memory_protect(
         queue_family_affinity, range.queue_family_affinity);
   }
   iree_hal_amdgpu_access_agent_list_t agent_list;
-  IREE_RETURN_IF_ERROR(
-      iree_hal_amdgpu_access_agent_list_resolve_queue_family_agents(
-          state->topology, queue_family_affinity, &agent_list));
+  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_access_agent_list_resolve_scope_agents(
+      state->topology, queue_family_affinity, access_scope, &agent_list));
 
   hsa_amd_memory_access_desc_t access_descs[IREE_HAL_AMDGPU_MAX_CPU_AGENT +
                                             IREE_HAL_AMDGPU_MAX_GPU_AGENT];

--- a/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/virtual_memory.h
@@ -112,6 +112,7 @@ iree_status_t iree_hal_amdgpu_virtual_memory_protect(
     iree_hal_buffer_t* virtual_buffer, iree_device_size_t virtual_offset,
     iree_device_size_t size,
     iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection);
 
 // Validates an advisory virtual-address range and otherwise performs no work.

--- a/runtime/src/iree/hal/drivers/vulkan/allocator.c
+++ b/runtime/src/iree/hal/drivers/vulkan/allocator.c
@@ -2788,6 +2788,7 @@ static iree_status_t iree_hal_vulkan_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   iree_hal_vulkan_allocator_t* allocator =
       iree_hal_vulkan_allocator_cast(base_allocator);
@@ -2806,6 +2807,12 @@ static iree_status_t iree_hal_vulkan_allocator_virtual_memory_protect(
         "Vulkan virtual protection queue family affinity 0x%016" PRIx64
         " is outside the reservation affinity 0x%016" PRIx64,
         queue_family_affinity, reservation_affinity);
+  }
+  if (IREE_UNLIKELY(access_scope !=
+                    IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE)) {
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "Vulkan sparse virtual memory supports only device access scope");
   }
   VkMemoryRequirements memory_requirements = {0};
   IREE_RETURN_IF_ERROR(iree_hal_vulkan_sparse_buffer_memory_requirements(

--- a/runtime/src/iree/hal/drivers/vulkan/cts/allocator_virtual_memory_test.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/cts/allocator_virtual_memory_test.cc
@@ -89,17 +89,68 @@ TEST_P(VulkanVirtualMemoryTest, ReserveMapTransferUnmap) {
   }
 
   iree_hal_buffer_params_t params = DeviceLocalVirtualMemoryParams();
+  const iree_hal_queue_family_ordinal_t reservation_family_ordinal =
+      iree_hal_queue_family_ordinal(iree_hal_queue_family(transfer_queue_));
+  const iree_hal_queue_family_affinity_t reservation_family_affinity =
+      iree_hal_make_queue_family_affinity(reservation_family_ordinal);
+  const iree_hal_queue_family_affinity_t outside_reservation_affinity =
+      iree_hal_make_queue_family_affinity((reservation_family_ordinal + 1) %
+                                          IREE_HAL_MAX_QUEUE_FAMILIES);
+  params.queue_family_affinity = reservation_family_affinity;
   iree_device_size_t recommended_page_size =
       QueryRecommendedPageSize(device_allocator_, params);
   ASSERT_NE(0u, recommended_page_size);
 
   VirtualBufferRef virtual_buffer(device_allocator_);
   IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_reserve(
-      device_allocator_, IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
-      recommended_page_size, virtual_buffer.out()));
+      device_allocator_, reservation_family_affinity, recommended_page_size,
+      virtual_buffer.out()));
   ASSERT_TRUE(virtual_buffer.get());
   EXPECT_EQ(recommended_page_size,
             iree_hal_buffer_byte_length(virtual_buffer.get()));
+
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_virtual_memory_protect(
+          device_allocator_, virtual_buffer.get(), /*virtual_offset=*/0,
+          recommended_page_size, IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_NONE,
+          IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_virtual_memory_protect(
+          device_allocator_, virtual_buffer.get(), /*virtual_offset=*/0,
+          recommended_page_size, IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
+          (iree_hal_virtual_memory_access_scope_t)1u << 31,
+          IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_virtual_memory_protect(
+          device_allocator_, virtual_buffer.get(), /*virtual_offset=*/0,
+          recommended_page_size, /*queue_family_affinity=*/0,
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
+          IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_virtual_memory_protect(
+          device_allocator_, virtual_buffer.get(), /*virtual_offset=*/0,
+          recommended_page_size, outside_reservation_affinity,
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
+          IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_UNIMPLEMENTED,
+      iree_hal_allocator_virtual_memory_protect(
+          device_allocator_, virtual_buffer.get(), /*virtual_offset=*/0,
+          recommended_page_size, IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_HOST,
+          IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_UNIMPLEMENTED,
+      iree_hal_allocator_virtual_memory_protect(
+          device_allocator_, virtual_buffer.get(), /*virtual_offset=*/0,
+          recommended_page_size, IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
+          IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL,
+          IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
 
   PhysicalMemoryRef physical_memory(device_allocator_);
   IREE_ASSERT_OK(iree_hal_allocator_physical_memory_allocate(
@@ -110,6 +161,7 @@ TEST_P(VulkanVirtualMemoryTest, ReserveMapTransferUnmap) {
   iree_status_t protect_status = iree_hal_allocator_virtual_memory_protect(
       device_allocator_, virtual_buffer.get(), /*virtual_offset=*/0,
       recommended_page_size, IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE);
   IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION, protect_status);
 
@@ -119,6 +171,7 @@ TEST_P(VulkanVirtualMemoryTest, ReserveMapTransferUnmap) {
   IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
       device_allocator_, virtual_buffer.get(), /*virtual_offset=*/0,
       recommended_page_size, IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
 
   constexpr iree_device_size_t kTouchedSize = 256;

--- a/runtime/src/iree/hal/drivers/vulkan/cts/bda_spirv_test.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/cts/bda_spirv_test.cc
@@ -940,10 +940,12 @@ TEST_P(BdaSpirvTest, CommandBufferExecutesBdaShaderWithSparseBindings) {
   IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
       device_allocator_, input_buffer.get(), /*virtual_offset=*/0,
       recommended_page_size, IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
   IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
       device_allocator_, output_buffer.get(), /*virtual_offset=*/0,
       recommended_page_size, IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
       IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
 
   const int32_t input_pattern = 5;

--- a/runtime/src/iree/hal/replay/BUILD.bazel
+++ b/runtime/src/iree/hal/replay/BUILD.bazel
@@ -97,6 +97,8 @@ iree_runtime_cc_library(
         "execute_operation.h",
         "execute_state.c",
         "execute_state.h",
+        "execute_vmm.c",
+        "execute_vmm.h",
     ],
     hdrs = ["execute.h"],
     deps = [
@@ -158,6 +160,23 @@ iree_runtime_cc_test(
     ],
 )
 
+iree_runtime_cc_test(
+    name = "execute_vmm_test",
+    srcs = [
+        "execute_operation.h",
+        "execute_state.h",
+        "execute_vmm_test.cc",
+    ],
+    deps = [
+        ":execute",
+        ":file_reader",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
 iree_cmake_extra_content(
     content = """
 if(TARGET iree::hal::drivers::task::registration)
@@ -171,6 +190,7 @@ iree_runtime_cc_test(
     deps = [
         ":execute",
         ":file_reader",
+        ":file_writer",
         ":recorder",
         "//runtime/src/iree/async",
         "//runtime/src/iree/async/util:proactor_pool",
@@ -201,6 +221,7 @@ iree_runtime_cc_test(
         "//runtime/src/iree/base",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/drivers/task/registration",
+        "//runtime/src/iree/hal/memory:passthrough_pool",
         "//runtime/src/iree/testing:gtest",
         "//runtime/src/iree/testing:gtest_main",
     ],
@@ -234,6 +255,7 @@ if(TARGET iree::hal::drivers::task::registration)
 iree_runtime_cc_test(
     name = "recorder_test",
     srcs = [
+        "recorder_allocator.h",
         "recorder_record.h",
         "recorder_test.cc",
     ],

--- a/runtime/src/iree/hal/replay/CMakeLists.txt
+++ b/runtime/src/iree/hal/replay/CMakeLists.txt
@@ -110,6 +110,8 @@ iree_cc_library(
     "execute_operation.h"
     "execute_state.c"
     "execute_state.h"
+    "execute_vmm.c"
+    "execute_vmm.h"
   DEPS
     ::digest
     ::file_reader
@@ -169,6 +171,22 @@ iree_cc_test(
     iree::testing::gtest_main
 )
 
+iree_cc_test(
+  NAME
+    execute_vmm_test
+  SRCS
+    "execute_operation.h"
+    "execute_state.h"
+    "execute_vmm_test.cc"
+  DEPS
+    ::execute
+    ::file_reader
+    iree::base
+    iree::hal
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 if(TARGET iree::hal::drivers::task::registration)
 
 iree_cc_test(
@@ -179,6 +197,7 @@ iree_cc_test(
   DEPS
     ::execute
     ::file_reader
+    ::file_writer
     ::recorder
     iree::async
     iree::async::util::proactor_pool
@@ -208,6 +227,7 @@ iree_cc_test(
     iree::base
     iree::hal
     iree::hal::drivers::task::registration
+    iree::hal::memory::passthrough_pool
     iree::testing::gtest
     iree::testing::gtest_main
 )
@@ -232,6 +252,7 @@ iree_cc_test(
   NAME
     recorder_test
   SRCS
+    "recorder_allocator.h"
     "recorder_record.h"
     "recorder_test.cc"
   DEPS

--- a/runtime/src/iree/hal/replay/dump_json.c
+++ b/runtime/src/iree/hal/replay/dump_json.c
@@ -327,6 +327,122 @@ static iree_status_t iree_hal_replay_dump_append_json_payload(
           builder, "data_range", &data_range));
       return iree_string_builder_append_cstring(builder, "}");
     }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(iree_hal_replay_allocator_virtual_memory_reserve_payload_t)));
+      iree_hal_replay_allocator_virtual_memory_reserve_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_string_builder_append_format(
+          builder,
+          ",\"payload\":{\"queue_family_affinity\":%" PRIu64
+          ",\"size\":%" PRIu64 "}",
+          payload.queue_family_affinity, payload.size);
+    }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(iree_hal_replay_allocator_virtual_memory_release_payload_t)));
+      iree_hal_replay_allocator_virtual_memory_release_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_string_builder_append_format(
+          builder, ",\"payload\":{\"virtual_buffer_id\":%" PRIu64 "}",
+          payload.virtual_buffer_id);
+    }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(
+              iree_hal_replay_allocator_physical_memory_allocate_payload_t)));
+      iree_hal_replay_allocator_physical_memory_allocate_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      if (IREE_UNLIKELY(payload.allocation.reserved0 != 0 ||
+                        payload.allocation.reserved1 != 0)) {
+        return iree_make_status(
+            IREE_STATUS_DATA_LOSS,
+            "replay physical memory allocation reserved fields must be zero");
+      }
+      return iree_string_builder_append_format(
+          builder,
+          ",\"payload\":{\"allocation_size\":%" PRIu64
+          ",\"queue_family_affinity\":%" PRIu64 ",\"min_alignment\":%" PRIu64
+          ",\"usage\":%" PRIu32 ",\"type\":%" PRIu32 ",\"access\":%" PRIu16 "}",
+          payload.allocation.allocation_size,
+          payload.allocation.queue_family_affinity,
+          payload.allocation.min_alignment, payload.allocation.usage,
+          payload.allocation.type, payload.allocation.access);
+    }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_FREE: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(iree_hal_replay_allocator_physical_memory_free_payload_t)));
+      iree_hal_replay_allocator_physical_memory_free_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_string_builder_append_format(
+          builder, ",\"payload\":{\"physical_memory_id\":%" PRIu64 "}",
+          payload.physical_memory_id);
+    }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(iree_hal_replay_allocator_virtual_memory_map_payload_t)));
+      iree_hal_replay_allocator_virtual_memory_map_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_string_builder_append_format(
+          builder,
+          ",\"payload\":{\"virtual_buffer_id\":%" PRIu64
+          ",\"physical_memory_id\":%" PRIu64 ",\"virtual_offset\":%" PRIu64
+          ",\"physical_offset\":%" PRIu64 ",\"size\":%" PRIu64 "}",
+          payload.virtual_buffer_id, payload.physical_memory_id,
+          payload.virtual_offset, payload.physical_offset, payload.size);
+    }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(iree_hal_replay_allocator_virtual_memory_unmap_payload_t)));
+      iree_hal_replay_allocator_virtual_memory_unmap_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_string_builder_append_format(
+          builder,
+          ",\"payload\":{\"virtual_buffer_id\":%" PRIu64
+          ",\"virtual_offset\":%" PRIu64 ",\"size\":%" PRIu64 "}",
+          payload.virtual_buffer_id, payload.virtual_offset, payload.size);
+    }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(iree_hal_replay_allocator_virtual_memory_protect_payload_t)));
+      iree_hal_replay_allocator_virtual_memory_protect_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      if (IREE_UNLIKELY(payload.reserved0 != 0)) {
+        return iree_make_status(
+            IREE_STATUS_DATA_LOSS,
+            "replay virtual memory protect reserved fields must be zero");
+      }
+      return iree_string_builder_append_format(
+          builder,
+          ",\"payload\":{\"virtual_buffer_id\":%" PRIu64
+          ",\"virtual_offset\":%" PRIu64 ",\"size\":%" PRIu64
+          ",\"queue_family_affinity\":%" PRIu64 ",\"access_scope\":%" PRIu32
+          ",\"protection\":%" PRIu64 "}",
+          payload.virtual_buffer_id, payload.virtual_offset, payload.size,
+          payload.queue_family_affinity, payload.access_scope,
+          payload.protection);
+    }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(iree_hal_replay_allocator_virtual_memory_advise_payload_t)));
+      iree_hal_replay_allocator_virtual_memory_advise_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_string_builder_append_format(
+          builder,
+          ",\"payload\":{\"virtual_buffer_id\":%" PRIu64
+          ",\"virtual_offset\":%" PRIu64 ",\"size\":%" PRIu64
+          ",\"queue_family_affinity\":%" PRIu64 ",\"advice\":%" PRIu64 "}",
+          payload.virtual_buffer_id, payload.virtual_offset, payload.size,
+          payload.queue_family_affinity, payload.advice);
+    }
     case IREE_HAL_REPLAY_PAYLOAD_TYPE_BUFFER_RANGE: {
       IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
           record, sizeof(iree_hal_replay_buffer_range_payload_t)));

--- a/runtime/src/iree/hal/replay/dump_test.cc
+++ b/runtime/src/iree/hal/replay/dump_test.cc
@@ -6,7 +6,9 @@
 
 #include "iree/hal/replay/dump.h"
 
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <utility>
 #include <vector>
@@ -405,6 +407,123 @@ static std::vector<uint8_t> MakeExecutableLoadReplayFileStorage() {
   return storage;
 }
 
+static iree_hal_replay_file_record_metadata_t MakeAllocatorOperationMetadata(
+    uint64_t sequence_ordinal, iree_hal_replay_payload_type_t payload_type,
+    iree_hal_replay_operation_code_t operation_code,
+    iree_hal_replay_object_id_t related_object_id) {
+  iree_hal_replay_file_record_metadata_t metadata = {};
+  metadata.sequence_ordinal = sequence_ordinal;
+  metadata.device_id = 1;
+  metadata.object_id = 2;
+  metadata.related_object_id = related_object_id;
+  metadata.record_type = IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION;
+  metadata.payload_type = payload_type;
+  metadata.object_type = IREE_HAL_REPLAY_OBJECT_TYPE_ALLOCATOR;
+  metadata.operation_code = operation_code;
+  return metadata;
+}
+
+static std::vector<uint8_t> MakeVmmReplayFileStorage() {
+  ReplayFileBuilder builder(/*capacity=*/8192);
+
+  iree_hal_replay_file_record_metadata_t physical_object_metadata = {};
+  physical_object_metadata.sequence_ordinal = 0;
+  physical_object_metadata.object_id = 23;
+  physical_object_metadata.record_type =
+      IREE_HAL_REPLAY_FILE_RECORD_TYPE_OBJECT;
+  physical_object_metadata.object_type =
+      IREE_HAL_REPLAY_OBJECT_TYPE_PHYSICAL_MEMORY;
+  builder.Append(physical_object_metadata, 0, nullptr);
+
+  iree_hal_replay_allocator_virtual_memory_reserve_payload_t reserve = {};
+  reserve.queue_family_affinity = 3;
+  reserve.size = 4096;
+  builder.Append(
+      MakeAllocatorOperationMetadata(
+          1, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE,
+          IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE, 17),
+      reserve);
+
+  iree_hal_replay_allocator_virtual_memory_release_payload_t release = {};
+  release.virtual_buffer_id = 17;
+  builder.Append(
+      MakeAllocatorOperationMetadata(
+          2, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
+          IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE, 17),
+      release);
+
+  iree_hal_replay_allocator_physical_memory_allocate_payload_t allocate = {};
+  allocate.allocation.allocation_size = 8192;
+  allocate.allocation.queue_family_affinity = 5;
+  allocate.allocation.min_alignment = 4096;
+  allocate.allocation.usage = 0x10;
+  allocate.allocation.type = 0x20;
+  allocate.allocation.access = 0x3;
+  builder.Append(
+      MakeAllocatorOperationMetadata(
+          3, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+          IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+          23),
+      allocate);
+
+  iree_hal_replay_allocator_physical_memory_free_payload_t free = {};
+  free.physical_memory_id = 23;
+  builder.Append(
+      MakeAllocatorOperationMetadata(
+          4, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
+          IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_FREE, 23),
+      free);
+
+  iree_hal_replay_allocator_virtual_memory_map_payload_t map = {};
+  map.virtual_buffer_id = 17;
+  map.physical_memory_id = 23;
+  map.virtual_offset = 128;
+  map.physical_offset = 256;
+  map.size = 1024;
+  builder.Append(
+      MakeAllocatorOperationMetadata(
+          5, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+          IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_MAP, 17),
+      map);
+
+  iree_hal_replay_allocator_virtual_memory_unmap_payload_t unmap = {};
+  unmap.virtual_buffer_id = 17;
+  unmap.virtual_offset = 128;
+  unmap.size = 1024;
+  builder.Append(
+      MakeAllocatorOperationMetadata(
+          6, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+          IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP, 17),
+      unmap);
+
+  iree_hal_replay_allocator_virtual_memory_protect_payload_t protect = {};
+  protect.virtual_buffer_id = 17;
+  protect.virtual_offset = 512;
+  protect.size = 2048;
+  protect.queue_family_affinity = 9;
+  protect.access_scope = 3;
+  protect.protection = 5;
+  builder.Append(
+      MakeAllocatorOperationMetadata(
+          7, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT,
+          IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT, 17),
+      protect);
+
+  iree_hal_replay_allocator_virtual_memory_advise_payload_t advise = {};
+  advise.virtual_buffer_id = 17;
+  advise.virtual_offset = 768;
+  advise.size = 512;
+  advise.queue_family_affinity = 11;
+  advise.advice = 6;
+  builder.Append(
+      MakeAllocatorOperationMetadata(
+          8, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE,
+          IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE, 17),
+      advise);
+
+  return builder.Finish();
+}
+
 TEST(ReplayDumpTest, EmitsTextSummary) {
   std::vector<uint8_t> storage = MakeReplayFileStorage();
   iree_hal_replay_dump_options_t options =
@@ -414,6 +533,7 @@ TEST(ReplayDumpTest, EmitsTextSummary) {
   IREE_ASSERT_OK(
       DumpReplayToString(MakeReplayFileContents(storage), &options, &output));
 
+  EXPECT_THAT(output, HasSubstr("IREE HAL replay v7.1"));
   EXPECT_THAT(output, HasSubstr("summary:"));
   EXPECT_THAT(output, HasSubstr("hermetic: yes"));
   EXPECT_THAT(output, HasSubstr("strict_replay_supported: yes"));
@@ -436,6 +556,8 @@ TEST(ReplayDumpTest, EmitsJsonlWithPayloadRanges) {
       DumpReplayToString(MakeReplayFileContents(storage), &options, &output));
 
   EXPECT_THAT(output, HasSubstr("\"kind\":\"file\""));
+  EXPECT_THAT(output, HasSubstr("\"version_major\":7"));
+  EXPECT_THAT(output, HasSubstr("\"version_minor\":1"));
   EXPECT_THAT(output, HasSubstr("\"kind\":\"summary\""));
   EXPECT_THAT(output, HasSubstr("\"hermetic\":true"));
   EXPECT_THAT(output, HasSubstr("\"environment_referenced\":false"));
@@ -444,6 +566,171 @@ TEST(ReplayDumpTest, EmitsJsonlWithPayloadRanges) {
   EXPECT_THAT(output, HasSubstr("\"payload_type\":\"buffer_object\""));
   EXPECT_THAT(output, HasSubstr("\"payload_range\""));
   EXPECT_THAT(output, HasSubstr("\"allocation_size\":256"));
+}
+
+TEST(ReplayDumpTest, DefinesV71VmmWireSchema) {
+  EXPECT_EQ(7u, IREE_HAL_REPLAY_FILE_VERSION_MAJOR);
+  EXPECT_EQ(1u, IREE_HAL_REPLAY_FILE_VERSION_MINOR);
+  EXPECT_EQ(9u, IREE_HAL_REPLAY_OBJECT_TYPE_PHYSICAL_MEMORY);
+  EXPECT_STREQ("physical_memory",
+               iree_hal_replay_object_type_string(
+                   IREE_HAL_REPLAY_OBJECT_TYPE_PHYSICAL_MEMORY));
+
+  struct NamedPayloadType {
+    iree_hal_replay_payload_type_t type;
+    uint32_t value;
+    const char* name;
+  };
+  const NamedPayloadType vmm_payload_types[] = {
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE, 46,
+       "allocator_virtual_memory_reserve"},
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE, 47,
+       "allocator_virtual_memory_release"},
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE, 48,
+       "allocator_physical_memory_allocate"},
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_FREE, 49,
+       "allocator_physical_memory_free"},
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP, 50,
+       "allocator_virtual_memory_map"},
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP, 51,
+       "allocator_virtual_memory_unmap"},
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT, 52,
+       "allocator_virtual_memory_protect"},
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE, 53,
+       "allocator_virtual_memory_advise"},
+  };
+  for (const NamedPayloadType& payload_type : vmm_payload_types) {
+    EXPECT_EQ(payload_type.value, payload_type.type);
+    EXPECT_STREQ(payload_type.name,
+                 iree_hal_replay_payload_type_string(payload_type.type));
+  }
+
+  const iree_hal_replay_payload_type_t exact_queue_payload_types[] = {
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_PROVISIONED_QUEUE_OBJECT,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_TRANSFER,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_READ,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_WRITE,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ALLOCA,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_DEALLOCA,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_BARRIER,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_EXECUTE,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_FAMILY_COMMAND_BUFFER_OBJECT,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_WAIT,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_STORE,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_RMW,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_TIMESTAMP,
+  };
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(exact_queue_payload_types);
+       ++i) {
+    EXPECT_EQ(33u + i, exact_queue_payload_types[i]);
+  }
+
+  const iree_hal_replay_operation_code_t vmm_operation_codes[] = {
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE,
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT,
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE,
+  };
+  for (iree_host_size_t i = 0; i < IREE_ARRAYSIZE(vmm_operation_codes); ++i) {
+    EXPECT_EQ(106u + i, vmm_operation_codes[i]);
+  }
+
+  EXPECT_EQ(16u,
+            sizeof(iree_hal_replay_allocator_virtual_memory_reserve_payload_t));
+  EXPECT_EQ(8u,
+            sizeof(iree_hal_replay_allocator_virtual_memory_release_payload_t));
+  EXPECT_EQ(
+      40u,
+      sizeof(iree_hal_replay_allocator_physical_memory_allocate_payload_t));
+  EXPECT_EQ(8u,
+            sizeof(iree_hal_replay_allocator_physical_memory_free_payload_t));
+  EXPECT_EQ(40u,
+            sizeof(iree_hal_replay_allocator_virtual_memory_map_payload_t));
+  EXPECT_EQ(24u,
+            sizeof(iree_hal_replay_allocator_virtual_memory_unmap_payload_t));
+  EXPECT_EQ(48u,
+            sizeof(iree_hal_replay_allocator_virtual_memory_protect_payload_t));
+  EXPECT_EQ(40u,
+            sizeof(iree_hal_replay_allocator_virtual_memory_advise_payload_t));
+  EXPECT_EQ(32u,
+            offsetof(iree_hal_replay_allocator_virtual_memory_protect_payload_t,
+                     access_scope));
+  EXPECT_EQ(36u,
+            offsetof(iree_hal_replay_allocator_virtual_memory_protect_payload_t,
+                     reserved0));
+  EXPECT_EQ(40u,
+            offsetof(iree_hal_replay_allocator_virtual_memory_protect_payload_t,
+                     protection));
+}
+
+TEST(ReplayDumpTest, EmitsVmmPayloads) {
+  std::vector<uint8_t> storage = MakeVmmReplayFileStorage();
+  iree_hal_replay_dump_options_t options =
+      iree_hal_replay_dump_options_default();
+
+  std::string text_output;
+  IREE_ASSERT_OK(DumpReplayToString(MakeReplayFileContents(storage), &options,
+                                    &text_output));
+  EXPECT_THAT(text_output, HasSubstr("object=physical_memory(9)"));
+  const char* payload_names[] = {
+      "allocator_virtual_memory_reserve",   "allocator_virtual_memory_release",
+      "allocator_physical_memory_allocate", "allocator_physical_memory_free",
+      "allocator_virtual_memory_map",       "allocator_virtual_memory_unmap",
+      "allocator_virtual_memory_protect",   "allocator_virtual_memory_advise",
+  };
+  for (const char* payload_name : payload_names) {
+    EXPECT_THAT(text_output, HasSubstr(std::string("payload=") + payload_name));
+  }
+  EXPECT_THAT(text_output, HasSubstr("queue_family_affinity=3 size=4096"));
+  EXPECT_THAT(text_output, HasSubstr("physical_memory_id=23"));
+  EXPECT_THAT(text_output, HasSubstr("virtual_offset=128 physical_offset=256"));
+  EXPECT_THAT(text_output,
+              HasSubstr("queue_family_affinity=9 access_scope=0x00000003 "
+                        "protection=0x0000000000000005"));
+
+  options.format = IREE_HAL_REPLAY_DUMP_FORMAT_JSONL;
+  std::string json_output;
+  IREE_ASSERT_OK(DumpReplayToString(MakeReplayFileContents(storage), &options,
+                                    &json_output));
+  EXPECT_THAT(json_output, HasSubstr("\"object_type\":\"physical_memory\""));
+  for (const char* payload_name : payload_names) {
+    EXPECT_THAT(json_output, HasSubstr(std::string("\"payload_type\":\"") +
+                                       payload_name + "\""));
+  }
+  EXPECT_THAT(json_output,
+              HasSubstr("\"queue_family_affinity\":9,\"access_scope\":3,"
+                        "\"protection\":5"));
+}
+
+TEST(ReplayDumpTest, DecodesUnalignedVmmPayloads) {
+  std::vector<uint8_t> storage = MakeVmmReplayFileStorage();
+  iree_const_byte_span_t contents = MakeReplayFileContents(storage);
+  std::vector<uint8_t> unaligned_storage(contents.data_length + 1, 0);
+  std::memcpy(unaligned_storage.data() + 1, contents.data,
+              contents.data_length);
+  iree_const_byte_span_t unaligned_contents = iree_make_const_byte_span(
+      unaligned_storage.data() + 1, contents.data_length);
+
+  iree_hal_replay_dump_options_t options =
+      iree_hal_replay_dump_options_default();
+  std::string text_output;
+  IREE_ASSERT_OK(
+      DumpReplayToString(unaligned_contents, &options, &text_output));
+  EXPECT_THAT(text_output,
+              HasSubstr("virtual_offset=512 size=2048 "
+                        "queue_family_affinity=9 access_scope=0x00000003"));
+
+  options.format = IREE_HAL_REPLAY_DUMP_FORMAT_JSONL;
+  std::string json_output;
+  IREE_ASSERT_OK(
+      DumpReplayToString(unaligned_contents, &options, &json_output));
+  EXPECT_THAT(json_output,
+              HasSubstr("\"virtual_offset\":512,\"size\":2048,"
+                        "\"queue_family_affinity\":9,\"access_scope\":3"));
 }
 
 TEST(ReplayDumpTest, EmitsScopes) {
@@ -1163,6 +1450,114 @@ TEST(ReplayDumpTest, EmitsAtomicOperations) {
                         "\"operation\":1,\"operation_name\":\"subtract\""));
   EXPECT_THAT(json_output, HasSubstr("\"wait_semaphores_range\""));
   EXPECT_THAT(json_output, HasSubstr("\"signal_semaphores_range\""));
+}
+
+TEST(ReplayDumpTest, RejectsMalformedVmmPayloadSizes) {
+  struct FixedPayloadSchema {
+    iree_hal_replay_payload_type_t payload_type;
+    iree_hal_replay_operation_code_t operation_code;
+    iree_host_size_t payload_size;
+  };
+  const FixedPayloadSchema schemas[] = {
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE,
+       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE,
+       sizeof(iree_hal_replay_allocator_virtual_memory_reserve_payload_t)},
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
+       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
+       sizeof(iree_hal_replay_allocator_virtual_memory_release_payload_t)},
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+       sizeof(iree_hal_replay_allocator_physical_memory_allocate_payload_t)},
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
+       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
+       sizeof(iree_hal_replay_allocator_physical_memory_free_payload_t)},
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+       sizeof(iree_hal_replay_allocator_virtual_memory_map_payload_t)},
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+       sizeof(iree_hal_replay_allocator_virtual_memory_unmap_payload_t)},
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT,
+       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT,
+       sizeof(iree_hal_replay_allocator_virtual_memory_protect_payload_t)},
+      {IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE,
+       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE,
+       sizeof(iree_hal_replay_allocator_virtual_memory_advise_payload_t)},
+  };
+
+  for (const FixedPayloadSchema& schema : schemas) {
+    const iree_host_size_t malformed_sizes[] = {schema.payload_size - 1,
+                                                schema.payload_size + 1};
+    for (iree_host_size_t malformed_size : malformed_sizes) {
+      SCOPED_TRACE(::testing::Message()
+                   << "payload_type=" << schema.payload_type
+                   << " payload_size=" << malformed_size);
+      ReplayFileBuilder builder(/*capacity=*/4096);
+      std::vector<uint8_t> payload(malformed_size, 0);
+      iree_const_byte_span_t payload_span =
+          iree_make_const_byte_span(payload.data(), payload.size());
+      builder.Append(MakeAllocatorOperationMetadata(0, schema.payload_type,
+                                                    schema.operation_code, 17),
+                     1, &payload_span);
+      std::vector<uint8_t> storage = builder.Finish();
+
+      iree_hal_replay_dump_options_t options =
+          iree_hal_replay_dump_options_default();
+      std::string output;
+      IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS,
+                            DumpReplayToString(MakeReplayFileContents(storage),
+                                               &options, &output));
+      options.format = IREE_HAL_REPLAY_DUMP_FORMAT_JSONL;
+      output.clear();
+      IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS,
+                            DumpReplayToString(MakeReplayFileContents(storage),
+                                               &options, &output));
+    }
+  }
+}
+
+TEST(ReplayDumpTest, RejectsReservedVmmPayloadFields) {
+  auto expect_rejected = [](iree_hal_replay_payload_type_t payload_type,
+                            iree_hal_replay_operation_code_t operation_code,
+                            const auto& payload) {
+    ReplayFileBuilder builder(/*capacity=*/4096);
+    builder.Append(
+        MakeAllocatorOperationMetadata(0, payload_type, operation_code, 17),
+        payload);
+    std::vector<uint8_t> storage = builder.Finish();
+
+    iree_hal_replay_dump_options_t options =
+        iree_hal_replay_dump_options_default();
+    std::string output;
+    IREE_EXPECT_STATUS_IS(
+        IREE_STATUS_DATA_LOSS,
+        DumpReplayToString(MakeReplayFileContents(storage), &options, &output));
+    options.format = IREE_HAL_REPLAY_DUMP_FORMAT_JSONL;
+    output.clear();
+    IREE_EXPECT_STATUS_IS(
+        IREE_STATUS_DATA_LOSS,
+        DumpReplayToString(MakeReplayFileContents(storage), &options, &output));
+  };
+
+  iree_hal_replay_allocator_physical_memory_allocate_payload_t allocate = {};
+  allocate.allocation.reserved0 = 1;
+  expect_rejected(
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+      allocate);
+
+  allocate.allocation.reserved0 = 0;
+  allocate.allocation.reserved1 = 1;
+  expect_rejected(
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+      allocate);
+
+  iree_hal_replay_allocator_virtual_memory_protect_payload_t protect = {};
+  protect.reserved0 = 1;
+  expect_rejected(
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT,
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT, protect);
 }
 
 TEST(ReplayDumpTest, RejectsMalformedAtomicPayloadLayouts) {

--- a/runtime/src/iree/hal/replay/dump_text.c
+++ b/runtime/src/iree/hal/replay/dump_text.c
@@ -241,6 +241,117 @@ static iree_status_t iree_hal_replay_dump_append_text_payload(
           payload.external_type, payload.external_flags, data_offset,
           payload.data_length);
     }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(iree_hal_replay_allocator_virtual_memory_reserve_payload_t)));
+      iree_hal_replay_allocator_virtual_memory_reserve_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_string_builder_append_format(
+          builder, " queue_family_affinity=%" PRIu64 " size=%" PRIu64,
+          payload.queue_family_affinity, payload.size);
+    }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(iree_hal_replay_allocator_virtual_memory_release_payload_t)));
+      iree_hal_replay_allocator_virtual_memory_release_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_string_builder_append_format(
+          builder, " virtual_buffer_id=%" PRIu64, payload.virtual_buffer_id);
+    }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(
+              iree_hal_replay_allocator_physical_memory_allocate_payload_t)));
+      iree_hal_replay_allocator_physical_memory_allocate_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      if (IREE_UNLIKELY(payload.allocation.reserved0 != 0 ||
+                        payload.allocation.reserved1 != 0)) {
+        return iree_make_status(
+            IREE_STATUS_DATA_LOSS,
+            "replay physical memory allocation reserved fields must be zero");
+      }
+      return iree_string_builder_append_format(
+          builder,
+          " allocation_size=%" PRIu64 " queue_family_affinity=%" PRIu64
+          " min_alignment=%" PRIu64 " usage=0x%08" PRIx32 " type=0x%08" PRIx32
+          " access=0x%04" PRIx16,
+          payload.allocation.allocation_size,
+          payload.allocation.queue_family_affinity,
+          payload.allocation.min_alignment, payload.allocation.usage,
+          payload.allocation.type, payload.allocation.access);
+    }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_FREE: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(iree_hal_replay_allocator_physical_memory_free_payload_t)));
+      iree_hal_replay_allocator_physical_memory_free_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_string_builder_append_format(
+          builder, " physical_memory_id=%" PRIu64, payload.physical_memory_id);
+    }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(iree_hal_replay_allocator_virtual_memory_map_payload_t)));
+      iree_hal_replay_allocator_virtual_memory_map_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_string_builder_append_format(
+          builder,
+          " virtual_buffer_id=%" PRIu64 " physical_memory_id=%" PRIu64
+          " virtual_offset=%" PRIu64 " physical_offset=%" PRIu64
+          " size=%" PRIu64,
+          payload.virtual_buffer_id, payload.physical_memory_id,
+          payload.virtual_offset, payload.physical_offset, payload.size);
+    }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(iree_hal_replay_allocator_virtual_memory_unmap_payload_t)));
+      iree_hal_replay_allocator_virtual_memory_unmap_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_string_builder_append_format(
+          builder,
+          " virtual_buffer_id=%" PRIu64 " virtual_offset=%" PRIu64
+          " size=%" PRIu64,
+          payload.virtual_buffer_id, payload.virtual_offset, payload.size);
+    }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(iree_hal_replay_allocator_virtual_memory_protect_payload_t)));
+      iree_hal_replay_allocator_virtual_memory_protect_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      if (IREE_UNLIKELY(payload.reserved0 != 0)) {
+        return iree_make_status(
+            IREE_STATUS_DATA_LOSS,
+            "replay virtual memory protect reserved fields must be zero");
+      }
+      return iree_string_builder_append_format(
+          builder,
+          " virtual_buffer_id=%" PRIu64 " virtual_offset=%" PRIu64
+          " size=%" PRIu64 " queue_family_affinity=%" PRIu64
+          " access_scope=0x%08" PRIx32 " protection=0x%016" PRIx64,
+          payload.virtual_buffer_id, payload.virtual_offset, payload.size,
+          payload.queue_family_affinity, payload.access_scope,
+          payload.protection);
+    }
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
+          record,
+          sizeof(iree_hal_replay_allocator_virtual_memory_advise_payload_t)));
+      iree_hal_replay_allocator_virtual_memory_advise_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_string_builder_append_format(
+          builder,
+          " virtual_buffer_id=%" PRIu64 " virtual_offset=%" PRIu64
+          " size=%" PRIu64 " queue_family_affinity=%" PRIu64
+          " advice=0x%016" PRIx64,
+          payload.virtual_buffer_id, payload.virtual_offset, payload.size,
+          payload.queue_family_affinity, payload.advice);
+    }
     case IREE_HAL_REPLAY_PAYLOAD_TYPE_BUFFER_RANGE: {
       IREE_RETURN_IF_ERROR(iree_hal_replay_dump_payload_length_check(
           record, sizeof(iree_hal_replay_buffer_range_payload_t)));

--- a/runtime/src/iree/hal/replay/execute.c
+++ b/runtime/src/iree/hal/replay/execute.c
@@ -73,6 +73,8 @@ typedef struct iree_hal_replay_plan_command_buffer_dispatch_t {
 } iree_hal_replay_plan_command_buffer_dispatch_t;
 
 typedef struct iree_hal_replay_plan_queue_execute_t {
+  // Captured device object id used to allocate private queue completions.
+  iree_hal_replay_object_id_t device_id;
   // Captured exact queue object id receiving the operation.
   iree_hal_replay_object_id_t queue_id;
   // Captured command buffer object id.
@@ -92,6 +94,40 @@ typedef struct iree_hal_replay_plan_queue_execute_t {
   // Unaligned serialized queue binding bytes borrowed from the replay file.
   const uint8_t* binding_data;
 } iree_hal_replay_plan_queue_execute_t;
+
+// Static completion dependencies for one exact-queue submission.
+typedef struct iree_hal_replay_plan_queue_dependency_t {
+  // Whether the record submits queue work.
+  bool is_submission;
+  // Sequence ordinal of the queue submission record.
+  uint64_t sequence_ordinal;
+  // Captured exact queue object id receiving the submission.
+  iree_hal_replay_object_id_t queue_id;
+  // Whether completion depends on a value read from device memory.
+  bool may_wait_on_device_memory;
+  // Whether replay waits for its private completion before the next record.
+  bool requires_immediate_completion;
+  // Captured command buffer object id, or NONE for direct queue operations.
+  iree_hal_replay_object_id_t command_buffer_id;
+  // Number of serialized wait semaphore timepoints.
+  iree_host_size_t wait_semaphore_count;
+  // Unaligned serialized wait semaphore bytes borrowed from the replay file.
+  const uint8_t* wait_semaphore_data;
+  // Number of serialized signal semaphore timepoints.
+  iree_host_size_t signal_semaphore_count;
+  // Unaligned serialized signal semaphore bytes borrowed from the replay file.
+  const uint8_t* signal_semaphore_data;
+  // Trailing payload bytes after both semaphore lists.
+  const uint8_t* trailing_data;
+} iree_hal_replay_plan_queue_dependency_t;
+
+typedef struct iree_hal_replay_plan_semaphore_state_t {
+  // Whether the semaphore has been defined by a preceding record.
+  bool is_defined;
+  // Greatest value statically known to become reachable without crossing a
+  // completion boundary.
+  uint64_t known_value;
+} iree_hal_replay_plan_semaphore_state_t;
 
 typedef struct iree_hal_replay_plan_record_t {
   // Parsed replay record borrowed from the original replay file.
@@ -291,6 +327,7 @@ static iree_status_t iree_hal_replay_plan_prepare_queue_execute(
     return iree_make_status(IREE_STATUS_DATA_LOSS,
                             "replay queue execute has no command buffer");
   }
+  out_execute->device_id = record->header.device_id;
   out_execute->queue_id = record->header.object_id;
   out_execute->command_buffer_id = payload.command_buffer_id;
   out_execute->flags = payload.flags;
@@ -305,6 +342,538 @@ static iree_status_t iree_hal_replay_plan_prepare_queue_execute(
   out_execute->binding_count = (iree_host_size_t)payload.binding_count;
   out_execute->binding_data = cursor;
   return iree_ok_status();
+}
+
+static iree_status_t iree_hal_replay_plan_queue_trailing_size(
+    uint64_t element_count, iree_host_size_t element_size,
+    uint64_t additional_size, iree_host_size_t* out_size) {
+  *out_size = 0;
+  if (IREE_UNLIKELY(
+          element_count > IREE_HOST_SIZE_MAX ||
+          additional_size > IREE_HOST_SIZE_MAX ||
+          !iree_host_size_checked_mul((iree_host_size_t)element_count,
+                                      element_size, out_size) ||
+          !iree_host_size_checked_add(
+              *out_size, (iree_host_size_t)additional_size, out_size))) {
+    return iree_make_status(
+        IREE_STATUS_DATA_LOSS,
+        "replay queue dependency trailing payload size overflow");
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_replay_plan_prepare_queue_dependency_lists(
+    const iree_hal_replay_file_record_t* record,
+    iree_hal_replay_payload_type_t payload_type, iree_host_size_t header_length,
+    uint64_t wait_semaphore_count, uint64_t signal_semaphore_count,
+    uint64_t trailing_payload_length,
+    iree_hal_replay_plan_queue_dependency_t* out_dependency) {
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+      record, payload_type, header_length));
+  if (IREE_UNLIKELY(wait_semaphore_count > IREE_HOST_SIZE_MAX ||
+                    signal_semaphore_count > IREE_HOST_SIZE_MAX ||
+                    trailing_payload_length > IREE_HOST_SIZE_MAX)) {
+    return iree_make_status(IREE_STATUS_DATA_LOSS,
+                            "replay queue dependency length exceeds host size");
+  }
+  const iree_host_size_t wait_count = (iree_host_size_t)wait_semaphore_count;
+  const iree_host_size_t signal_count =
+      (iree_host_size_t)signal_semaphore_count;
+  iree_host_size_t wait_size = 0;
+  iree_host_size_t signal_size = 0;
+  iree_host_size_t expected_length = 0;
+  if (IREE_UNLIKELY(
+          !iree_host_size_checked_mul(
+              wait_count, sizeof(iree_hal_replay_semaphore_timepoint_payload_t),
+              &wait_size) ||
+          !iree_host_size_checked_mul(
+              signal_count,
+              sizeof(iree_hal_replay_semaphore_timepoint_payload_t),
+              &signal_size) ||
+          !iree_host_size_checked_add(header_length, wait_size,
+                                      &expected_length) ||
+          !iree_host_size_checked_add(expected_length, signal_size,
+                                      &expected_length) ||
+          !iree_host_size_checked_add(expected_length,
+                                      (iree_host_size_t)trailing_payload_length,
+                                      &expected_length) ||
+          expected_length != record->payload.data_length)) {
+    return iree_make_status(IREE_STATUS_DATA_LOSS,
+                            "replay queue dependency payload length mismatch");
+  }
+  const uint8_t* cursor = record->payload.data + header_length;
+  out_dependency->is_submission = true;
+  out_dependency->sequence_ordinal = record->header.sequence_ordinal;
+  out_dependency->queue_id = record->header.object_id;
+  out_dependency->wait_semaphore_count = wait_count;
+  out_dependency->wait_semaphore_data = cursor;
+  cursor += wait_size;
+  out_dependency->signal_semaphore_count = signal_count;
+  out_dependency->signal_semaphore_data = cursor;
+  cursor += signal_size;
+  out_dependency->trailing_data = cursor;
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_replay_plan_prepare_queue_dependency(
+    const iree_hal_replay_file_record_t* record,
+    iree_hal_replay_plan_queue_dependency_t* out_dependency) {
+  memset(out_dependency, 0, sizeof(*out_dependency));
+  if (record->header.record_type !=
+          IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION ||
+      record->header.status_code != IREE_STATUS_OK) {
+    return iree_ok_status();
+  }
+  switch (record->header.operation_code) {
+    case IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_TRANSFER: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_TRANSFER,
+          sizeof(iree_hal_replay_queue_transfer_payload_t)));
+      iree_hal_replay_queue_transfer_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      iree_host_size_t trailing_size = 0;
+      IREE_RETURN_IF_ERROR(iree_hal_replay_plan_queue_trailing_size(
+          payload.operation_count,
+          sizeof(iree_hal_replay_queue_transfer_operation_payload_t),
+          payload.data_length, &trailing_size));
+      IREE_RETURN_IF_ERROR(iree_hal_replay_plan_prepare_queue_dependency_lists(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_TRANSFER, sizeof(payload),
+          payload.wait_semaphore_count, payload.signal_semaphore_count,
+          trailing_size, out_dependency));
+      for (iree_host_size_t i = 0; i < payload.operation_count; ++i) {
+        iree_hal_replay_queue_transfer_operation_payload_t operation;
+        memcpy(&operation,
+               out_dependency->trailing_data + i * sizeof(operation),
+               sizeof(operation));
+        if ((operation.type ==
+                 IREE_HAL_REPLAY_QUEUE_TRANSFER_OPERATION_TYPE_UPLOAD &&
+             operation.target_ref.length != 0) ||
+            (operation.type ==
+                 IREE_HAL_REPLAY_QUEUE_TRANSFER_OPERATION_TYPE_DOWNLOAD &&
+             operation.source_ref.length != 0)) {
+          out_dependency->requires_immediate_completion = true;
+        }
+      }
+      return iree_ok_status();
+    }
+    case IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_READ: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_READ,
+          sizeof(iree_hal_replay_queue_read_payload_t)));
+      iree_hal_replay_queue_read_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_hal_replay_plan_prepare_queue_dependency_lists(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_READ, sizeof(payload),
+          payload.wait_semaphore_count, payload.signal_semaphore_count,
+          payload.captured_data_length, out_dependency);
+    }
+    case IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_WRITE: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_WRITE,
+          sizeof(iree_hal_replay_queue_write_payload_t)));
+      iree_hal_replay_queue_write_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_hal_replay_plan_prepare_queue_dependency_lists(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_WRITE, sizeof(payload),
+          payload.wait_semaphore_count, payload.signal_semaphore_count,
+          /*trailing_payload_length=*/0, out_dependency);
+    }
+    case IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_ALLOCA: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ALLOCA,
+          sizeof(iree_hal_replay_queue_alloca_payload_t)));
+      iree_hal_replay_queue_alloca_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      iree_host_size_t trailing_size = 0;
+      IREE_RETURN_IF_ERROR(iree_hal_replay_plan_queue_trailing_size(
+          payload.request_count,
+          sizeof(iree_hal_replay_queue_alloca_request_payload_t),
+          /*additional_size=*/0, &trailing_size));
+      return iree_hal_replay_plan_prepare_queue_dependency_lists(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ALLOCA, sizeof(payload),
+          payload.wait_semaphore_count, payload.signal_semaphore_count,
+          trailing_size, out_dependency);
+    }
+    case IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_DEALLOCA: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_DEALLOCA,
+          sizeof(iree_hal_replay_queue_dealloca_payload_t)));
+      iree_hal_replay_queue_dealloca_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      iree_host_size_t trailing_size = 0;
+      IREE_RETURN_IF_ERROR(iree_hal_replay_plan_queue_trailing_size(
+          payload.buffer_count, sizeof(iree_hal_replay_object_id_t),
+          /*additional_size=*/0, &trailing_size));
+      return iree_hal_replay_plan_prepare_queue_dependency_lists(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_DEALLOCA, sizeof(payload),
+          payload.wait_semaphore_count, payload.signal_semaphore_count,
+          trailing_size, out_dependency);
+    }
+    case IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_BARRIER: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_BARRIER,
+          sizeof(iree_hal_replay_queue_barrier_payload_t)));
+      iree_hal_replay_queue_barrier_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_hal_replay_plan_prepare_queue_dependency_lists(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_BARRIER, sizeof(payload),
+          payload.wait_semaphore_count, payload.signal_semaphore_count,
+          /*trailing_payload_length=*/0, out_dependency);
+    }
+    case IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_EXECUTE: {
+      iree_hal_replay_plan_queue_execute_t execute;
+      memset(&execute, 0, sizeof(execute));
+      IREE_RETURN_IF_ERROR(
+          iree_hal_replay_plan_prepare_queue_execute(record, &execute));
+      out_dependency->is_submission = true;
+      out_dependency->sequence_ordinal = record->header.sequence_ordinal;
+      out_dependency->queue_id = record->header.object_id;
+      out_dependency->command_buffer_id = execute.command_buffer_id;
+      out_dependency->wait_semaphore_count = execute.wait_semaphore_count;
+      out_dependency->wait_semaphore_data = execute.wait_semaphore_data;
+      out_dependency->signal_semaphore_count = execute.signal_semaphore_count;
+      out_dependency->signal_semaphore_data = execute.signal_semaphore_data;
+      out_dependency->trailing_data = execute.binding_data;
+      return iree_ok_status();
+    }
+    case IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_DISPATCH: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_DISPATCH,
+          sizeof(iree_hal_replay_dispatch_payload_t)));
+      iree_hal_replay_dispatch_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      iree_host_size_t wait_offset = 0;
+      iree_host_size_t wait_size = 0;
+      iree_host_size_t signal_offset = 0;
+      iree_host_size_t signal_size = 0;
+      iree_host_size_t constants_offset = 0;
+      iree_host_size_t binding_offset = 0;
+      iree_host_size_t binding_size = 0;
+      IREE_RETURN_IF_ERROR(iree_hal_replay_executor_dispatch_layout(
+          record, &payload, &wait_offset, &wait_size, &signal_offset,
+          &signal_size, &constants_offset, &binding_offset, &binding_size));
+      (void)wait_size;
+      (void)signal_size;
+      (void)constants_offset;
+      (void)binding_offset;
+      (void)binding_size;
+      out_dependency->is_submission = true;
+      out_dependency->sequence_ordinal = record->header.sequence_ordinal;
+      out_dependency->queue_id = record->header.object_id;
+      out_dependency->wait_semaphore_count =
+          (iree_host_size_t)payload.wait_semaphore_count;
+      out_dependency->wait_semaphore_data = record->payload.data + wait_offset;
+      out_dependency->signal_semaphore_count =
+          (iree_host_size_t)payload.signal_semaphore_count;
+      out_dependency->signal_semaphore_data =
+          record->payload.data + signal_offset;
+      out_dependency->may_wait_on_device_memory = true;
+      return iree_ok_status();
+    }
+    case IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_ATOMIC_WAIT: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_WAIT,
+          sizeof(iree_hal_replay_queue_atomic_wait_payload_t)));
+      iree_hal_replay_queue_atomic_wait_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      out_dependency->may_wait_on_device_memory = true;
+      return iree_hal_replay_plan_prepare_queue_dependency_lists(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_WAIT,
+          sizeof(payload), payload.wait_semaphore_count,
+          payload.signal_semaphore_count, /*trailing_payload_length=*/0,
+          out_dependency);
+    }
+    case IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_ATOMIC_STORE: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_STORE,
+          sizeof(iree_hal_replay_queue_atomic_store_payload_t)));
+      iree_hal_replay_queue_atomic_store_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_hal_replay_plan_prepare_queue_dependency_lists(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_STORE,
+          sizeof(payload), payload.wait_semaphore_count,
+          payload.signal_semaphore_count, /*trailing_payload_length=*/0,
+          out_dependency);
+    }
+    case IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_ATOMIC_RMW: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_RMW,
+          sizeof(iree_hal_replay_queue_atomic_rmw_payload_t)));
+      iree_hal_replay_queue_atomic_rmw_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_hal_replay_plan_prepare_queue_dependency_lists(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_RMW,
+          sizeof(payload), payload.wait_semaphore_count,
+          payload.signal_semaphore_count, /*trailing_payload_length=*/0,
+          out_dependency);
+    }
+    case IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_TIMESTAMP: {
+      IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_TIMESTAMP,
+          sizeof(iree_hal_replay_queue_timestamp_payload_t)));
+      iree_hal_replay_queue_timestamp_payload_t payload;
+      memcpy(&payload, record->payload.data, sizeof(payload));
+      return iree_hal_replay_plan_prepare_queue_dependency_lists(
+          record, IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_TIMESTAMP, sizeof(payload),
+          payload.wait_semaphore_count, payload.signal_semaphore_count,
+          /*trailing_payload_length=*/0, out_dependency);
+    }
+    default:
+      return iree_ok_status();
+  }
+}
+
+static bool iree_hal_replay_plan_queue_dependency_can_complete(
+    const iree_hal_replay_plan_queue_dependency_t* dependency,
+    const iree_hal_replay_plan_semaphore_state_t* semaphore_states,
+    const bool* command_buffer_may_wait_on_device_memory) {
+  if (dependency->may_wait_on_device_memory) return false;
+  if (dependency->command_buffer_id != IREE_HAL_REPLAY_OBJECT_ID_NONE &&
+      command_buffer_may_wait_on_device_memory[dependency->command_buffer_id]) {
+    return false;
+  }
+  for (iree_host_size_t i = 0; i < dependency->wait_semaphore_count; ++i) {
+    iree_hal_replay_semaphore_timepoint_payload_t wait;
+    memcpy(&wait, dependency->wait_semaphore_data + i * sizeof(wait),
+           sizeof(wait));
+    if (semaphore_states[wait.semaphore_id].known_value < wait.value) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static void iree_hal_replay_plan_publish_queue_signals(
+    const iree_hal_replay_plan_queue_dependency_t* dependency,
+    iree_hal_replay_plan_semaphore_state_t* semaphore_states) {
+  for (iree_host_size_t i = 0; i < dependency->signal_semaphore_count; ++i) {
+    iree_hal_replay_semaphore_timepoint_payload_t signal;
+    memcpy(&signal, dependency->signal_semaphore_data + i * sizeof(signal),
+           sizeof(signal));
+    semaphore_states[signal.semaphore_id].known_value = iree_max(
+        semaphore_states[signal.semaphore_id].known_value, signal.value);
+  }
+}
+
+static bool iree_hal_replay_plan_is_completion_boundary(
+    const iree_hal_replay_file_record_t* record) {
+  if (record->header.record_type !=
+          IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION ||
+      record->header.status_code != IREE_STATUS_OK) {
+    return false;
+  }
+  return record->header.operation_code ==
+             IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP ||
+         record->header.operation_code ==
+             IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT;
+}
+
+static iree_status_t iree_hal_replay_plan_verify_completion_dependencies(
+    const iree_hal_replay_plan_t* plan) {
+  iree_hal_replay_plan_semaphore_state_t* semaphore_states = NULL;
+  bool* command_buffer_may_wait_on_device_memory = NULL;
+  bool* queue_has_pending_dependency = NULL;
+  iree_hal_replay_plan_queue_dependency_t* pending_dependencies = NULL;
+  iree_status_t status = iree_ok_status();
+
+  iree_host_size_t semaphore_states_size = 0;
+  iree_host_size_t object_flags_size = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_mul(plan->object_capacity,
+                                                sizeof(*semaphore_states),
+                                                &semaphore_states_size) ||
+                    !iree_host_size_checked_mul(
+                        plan->object_capacity,
+                        sizeof(*command_buffer_may_wait_on_device_memory),
+                        &object_flags_size))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "replay dependency table size overflow");
+  }
+  status = iree_allocator_malloc(plan->host_allocator, semaphore_states_size,
+                                 (void**)&semaphore_states);
+  if (iree_status_is_ok(status)) {
+    status = iree_allocator_malloc(
+        plan->host_allocator, object_flags_size,
+        (void**)&command_buffer_may_wait_on_device_memory);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_allocator_malloc(plan->host_allocator, object_flags_size,
+                                   (void**)&queue_has_pending_dependency);
+  }
+  if (iree_status_is_ok(status)) {
+    memset(semaphore_states, 0, semaphore_states_size);
+    memset(command_buffer_may_wait_on_device_memory, 0, object_flags_size);
+    memset(queue_has_pending_dependency, 0, object_flags_size);
+  }
+
+  iree_host_size_t pending_dependencies_size = 0;
+  if (iree_status_is_ok(status) && plan->record_count != 0 &&
+      IREE_UNLIKELY(!iree_host_size_checked_mul(plan->record_count,
+                                                sizeof(*pending_dependencies),
+                                                &pending_dependencies_size))) {
+    status = iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "replay pending dependency table overflow");
+  }
+  if (iree_status_is_ok(status) && pending_dependencies_size != 0) {
+    status =
+        iree_allocator_malloc(plan->host_allocator, pending_dependencies_size,
+                              (void**)&pending_dependencies);
+  }
+
+  iree_host_size_t pending_dependency_count = 0;
+  bool reaches_following_records = true;
+  for (iree_host_size_t i = 0;
+       i < plan->record_count && iree_status_is_ok(status) &&
+       reaches_following_records;
+       ++i) {
+    const iree_hal_replay_file_record_t* record = &plan->records[i].file_record;
+    if (record->header.record_type ==
+            IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION &&
+        record->header.status_code == IREE_STATUS_OK) {
+      if (record->header.operation_code ==
+          IREE_HAL_REPLAY_OPERATION_CODE_DEVICE_CREATE_SEMAPHORE) {
+        status = iree_hal_replay_executor_require_payload(
+            record, IREE_HAL_REPLAY_PAYLOAD_TYPE_SEMAPHORE_OBJECT,
+            sizeof(iree_hal_replay_semaphore_object_payload_t));
+        if (iree_status_is_ok(status) && record->header.related_object_id !=
+                                             IREE_HAL_REPLAY_OBJECT_ID_NONE) {
+          iree_hal_replay_semaphore_object_payload_t payload;
+          memcpy(&payload, record->payload.data, sizeof(payload));
+          iree_hal_replay_plan_semaphore_state_t* semaphore_state =
+              &semaphore_states[record->header.related_object_id];
+          semaphore_state->is_defined = true;
+          semaphore_state->known_value = payload.initial_value;
+        }
+      } else if (
+          (record->header.operation_code ==
+               IREE_HAL_REPLAY_OPERATION_CODE_COMMAND_BUFFER_ATOMIC_WAIT ||
+           record->header.operation_code ==
+               IREE_HAL_REPLAY_OPERATION_CODE_COMMAND_BUFFER_DISPATCH) &&
+          record->header.object_id < plan->object_capacity) {
+        command_buffer_may_wait_on_device_memory[record->header.object_id] =
+            true;
+      }
+    }
+    if (!iree_status_is_ok(status)) break;
+
+    iree_hal_replay_plan_queue_dependency_t dependency;
+    status = iree_hal_replay_plan_prepare_queue_dependency(record, &dependency);
+    if (!iree_status_is_ok(status)) break;
+    if (dependency.is_submission) {
+      if (dependency.queue_id == IREE_HAL_REPLAY_OBJECT_ID_NONE ||
+          dependency.queue_id >= plan->object_capacity) {
+        status = iree_make_status(
+            IREE_STATUS_DATA_LOSS,
+            "replay queue id %" PRIu64 " is invalid at sequence %" PRIu64,
+            dependency.queue_id, dependency.sequence_ordinal);
+      }
+      if (!iree_status_is_ok(status)) break;
+      if (dependency.command_buffer_id != IREE_HAL_REPLAY_OBJECT_ID_NONE &&
+          dependency.command_buffer_id >= plan->object_capacity) {
+        status = iree_make_status(
+            IREE_STATUS_DATA_LOSS,
+            "replay queue command buffer id is outside the object table");
+      }
+      for (iree_host_size_t j = 0;
+           j < dependency.wait_semaphore_count && iree_status_is_ok(status);
+           ++j) {
+        iree_hal_replay_semaphore_timepoint_payload_t wait;
+        memcpy(&wait, dependency.wait_semaphore_data + j * sizeof(wait),
+               sizeof(wait));
+        if (wait.semaphore_id >= plan->object_capacity ||
+            !semaphore_states[wait.semaphore_id].is_defined) {
+          status =
+              iree_make_status(IREE_STATUS_DATA_LOSS,
+                               "replay queue wait semaphore id %" PRIu64
+                               " is not defined at sequence %" PRIu64,
+                               wait.semaphore_id, dependency.sequence_ordinal);
+        }
+      }
+      for (iree_host_size_t j = 0;
+           j < dependency.signal_semaphore_count && iree_status_is_ok(status);
+           ++j) {
+        iree_hal_replay_semaphore_timepoint_payload_t signal;
+        memcpy(&signal, dependency.signal_semaphore_data + j * sizeof(signal),
+               sizeof(signal));
+        if (signal.semaphore_id >= plan->object_capacity ||
+            !semaphore_states[signal.semaphore_id].is_defined) {
+          status = iree_make_status(IREE_STATUS_DATA_LOSS,
+                                    "replay queue signal semaphore id %" PRIu64
+                                    " is not defined at sequence %" PRIu64,
+                                    signal.semaphore_id,
+                                    dependency.sequence_ordinal);
+        }
+      }
+      if (!iree_status_is_ok(status)) break;
+
+      const bool can_complete =
+          !queue_has_pending_dependency[dependency.queue_id] &&
+          iree_hal_replay_plan_queue_dependency_can_complete(
+              &dependency, semaphore_states,
+              command_buffer_may_wait_on_device_memory);
+      if (can_complete) {
+        iree_hal_replay_plan_publish_queue_signals(&dependency,
+                                                   semaphore_states);
+      } else if (dependency.requires_immediate_completion) {
+        status = iree_make_status(
+            IREE_STATUS_FAILED_PRECONDITION,
+            "replay queue operation at sequence %" PRIu64
+            " requires immediate completion but has an unresolved forward or "
+            "device-memory dependency",
+            dependency.sequence_ordinal);
+      } else if (dependency.signal_semaphore_count != 0) {
+        // Captured-signal submissions already wait immediately. If one cannot
+        // be proven to complete then replay cannot reach following records;
+        // leave that existing behavior outside this private-boundary check.
+        reaches_following_records = false;
+      } else {
+        pending_dependencies[pending_dependency_count++] = dependency;
+      }
+
+      iree_host_size_t retained_dependency_count = 0;
+      for (iree_host_size_t j = 0; j < pending_dependency_count; ++j) {
+        queue_has_pending_dependency[pending_dependencies[j].queue_id] = false;
+      }
+      for (iree_host_size_t j = 0; j < pending_dependency_count; ++j) {
+        const bool has_queue_predecessor =
+            queue_has_pending_dependency[pending_dependencies[j].queue_id];
+        if (has_queue_predecessor ||
+            !iree_hal_replay_plan_queue_dependency_can_complete(
+                &pending_dependencies[j], semaphore_states,
+                command_buffer_may_wait_on_device_memory)) {
+          queue_has_pending_dependency[pending_dependencies[j].queue_id] = true;
+          pending_dependencies[retained_dependency_count++] =
+              pending_dependencies[j];
+        }
+      }
+      pending_dependency_count = retained_dependency_count;
+    }
+
+    if (iree_hal_replay_plan_is_completion_boundary(record) &&
+        pending_dependency_count != 0) {
+      status = iree_make_status(
+          IREE_STATUS_FAILED_PRECONDITION,
+          "replay completion boundary at sequence %" PRIu64
+          " cannot wait for queue operation at sequence %" PRIu64
+          " with an unresolved forward or device-memory dependency",
+          record->header.sequence_ordinal,
+          pending_dependencies[0].sequence_ordinal);
+    }
+  }
+  if (iree_status_is_ok(status) && reaches_following_records &&
+      pending_dependency_count != 0) {
+    status = iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "replay end-of-file cannot wait for queue operation at sequence "
+        "%" PRIu64 " with an unresolved forward or device-memory dependency",
+        pending_dependencies[0].sequence_ordinal);
+  }
+
+  iree_allocator_free(plan->host_allocator, pending_dependencies);
+  iree_allocator_free(plan->host_allocator, queue_has_pending_dependency);
+  iree_allocator_free(plan->host_allocator,
+                      command_buffer_may_wait_on_device_memory);
+  iree_allocator_free(plan->host_allocator, semaphore_states);
+  return status;
 }
 
 static iree_status_t iree_hal_replay_plan_prepare_record(
@@ -433,6 +1002,9 @@ IREE_API_EXPORT iree_status_t iree_hal_replay_plan_create(
     if (iree_status_is_ok(status)) {
       status = iree_hal_replay_plan_prepare_record(plan_record);
     }
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_replay_plan_verify_completion_dependencies(plan);
   }
   if (iree_status_is_ok(status)) {
     *out_plan = plan;
@@ -614,7 +1186,8 @@ static iree_status_t iree_hal_replay_plan_execute_queue_execute(
           queue_execute->wait_semaphore_data,
           queue_execute->wait_semaphore_count *
               sizeof(iree_hal_replay_semaphore_timepoint_payload_t)),
-      queue_execute->wait_semaphore_count, &wait_storage));
+      queue_execute->wait_semaphore_count, /*additional_capacity=*/0,
+      &wait_storage));
   iree_hal_replay_semaphore_list_storage_t signal_storage;
   iree_status_t status = iree_hal_replay_executor_make_semaphore_list(
       executor,
@@ -622,7 +1195,8 @@ static iree_status_t iree_hal_replay_plan_execute_queue_execute(
           queue_execute->signal_semaphore_data,
           queue_execute->signal_semaphore_count *
               sizeof(iree_hal_replay_semaphore_timepoint_payload_t)),
-      queue_execute->signal_semaphore_count, &signal_storage);
+      queue_execute->signal_semaphore_count, /*additional_capacity=*/1,
+      &signal_storage);
 
   iree_hal_replay_buffer_binding_table_storage_t binding_storage = {0};
   if (iree_status_is_ok(status)) {
@@ -660,20 +1234,26 @@ static iree_status_t iree_hal_replay_plan_execute_queue_execute(
         executor, queue_execute->command_buffer_id,
         IREE_HAL_REPLAY_OBJECT_TYPE_COMMAND_BUFFER, &command_buffer_entry);
   }
+  iree_hal_replay_object_entry_t* device_entry = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_replay_executor_lookup(executor, queue_execute->device_id,
+                                             IREE_HAL_REPLAY_OBJECT_TYPE_DEVICE,
+                                             &device_entry);
+  }
+  iree_hal_replay_queue_completion_t* completion = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_replay_executor_prepare_queue_completion(
+        executor, device_entry->value.device, queue_entry->value.queue,
+        &signal_storage, &completion);
+  }
   if (iree_status_is_ok(status)) {
     status = iree_hal_queue_execute(
         queue_entry->value.queue, wait_storage.list, signal_storage.list,
         command_buffer_entry->value.command_buffer, binding_storage.table,
         queue_execute->flags);
   }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_queue_flush(queue_entry->value.queue);
-  }
-  if (iree_status_is_ok(status) && signal_storage.list.count != 0) {
-    status = iree_hal_semaphore_list_wait(signal_storage.list,
-                                          iree_infinite_timeout(),
-                                          IREE_ASYNC_WAIT_FLAG_NONE);
-  }
+  status = iree_hal_replay_executor_finalize_queue_completion(
+      executor, completion, /*flush_queue=*/true, status);
 
   iree_hal_replay_buffer_binding_table_storage_deinitialize(
       &binding_storage, executor->host_allocator);
@@ -762,8 +1342,15 @@ IREE_API_EXPORT iree_status_t iree_hal_replay_plan_execute(
         iree_hal_device_group_device_count(executor.device_group));
   }
 
-  iree_hal_replay_executor_deinitialize(&executor);
-  return status;
+  if (!iree_status_is_ok(status) && executor.queue_completion_count != 0) {
+    // A failed record can prevent later producers from being submitted.
+    // Waiting on accepted work could block forever, while releasing replay
+    // state could race that work. Retain all executor-owned dependencies for
+    // process lifetime.
+    return status;
+  }
+  return iree_status_join(status,
+                          iree_hal_replay_executor_deinitialize(&executor));
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_replay_execute_file(

--- a/runtime/src/iree/hal/replay/execute_atomic_test.cc
+++ b/runtime/src/iree/hal/replay/execute_atomic_test.cc
@@ -11,8 +11,10 @@
 
 #include "execute_operation.h"
 #include "execute_state.h"
+#include "iree/async/frontier_tracker.h"
 #include "iree/async/util/proactor_pool.h"
 #include "iree/hal/drivers/task/registration/driver_module.h"
+#include "iree/hal/memory/passthrough_pool.h"
 #include "iree/testing/gtest.h"
 #include "iree/testing/status_matchers.h"
 
@@ -23,6 +25,7 @@ static constexpr iree_hal_replay_object_id_t kBufferId = 2;
 static constexpr iree_hal_replay_object_id_t kCommandBufferId = 3;
 static constexpr iree_hal_replay_object_id_t kWaitSemaphoreId = 4;
 static constexpr iree_hal_replay_object_id_t kSignalSemaphoreId = 5;
+static constexpr iree_hal_replay_object_id_t kDeviceId = 6;
 
 typedef enum AtomicInvocationKind {
   kAtomicInvocationNone = 0,
@@ -53,6 +56,8 @@ typedef struct AtomicInvocation {
   iree_host_size_t signal_semaphore_count;
   // First signal semaphore timepoint passed to a queue operation.
   CapturedSemaphoreTimepoint signal_timepoint;
+  // Executor-private signal timepoint appended after captured signals.
+  CapturedSemaphoreTimepoint private_signal_timepoint;
   // Atomic target reference passed to the backend.
   iree_hal_buffer_ref_t target_ref;
   // Atomic wait parameters passed to the backend.
@@ -79,6 +84,18 @@ typedef struct CapturingQueue {
   AtomicInvocation invocation;
   // Total number of atomic backend invocations.
   iree_host_size_t invocation_count;
+  // Number of flush calls received by this exact queue.
+  iree_host_size_t flush_count;
+  // Status returned instead of accepting a queue submission.
+  iree_status_code_t submission_status_code;
+  // Status returned from queue flush.
+  iree_status_code_t flush_status_code;
+  // Whether to fail the executor-private signal instead of signaling it.
+  bool fail_private_signal;
+  // Most recent transfer operation captured by the backend.
+  iree_hal_transfer_operation_t transfer_operation;
+  // Number of transfer transactions received by the backend.
+  iree_host_size_t transfer_invocation_count;
 } CapturingQueue;
 
 static CapturingCommandBuffer* CastCommandBuffer(
@@ -186,10 +203,41 @@ static AtomicInvocation* BeginQueueInvocation(
     invocation->signal_timepoint.value =
         signal_semaphore_list.payload_values[0];
   }
+  if (signal_semaphore_list.count != 0) {
+    const iree_host_size_t private_index = signal_semaphore_list.count - 1;
+    invocation->private_signal_timepoint.semaphore =
+        signal_semaphore_list.semaphores[private_index];
+    invocation->private_signal_timepoint.value =
+        signal_semaphore_list.payload_values[private_index];
+  }
   invocation->target_ref = iree_hal_make_buffer_ref(
       target_buffer, target_offset, iree_hal_atomic_width_byte_count(width));
   ++queue->invocation_count;
   return invocation;
+}
+
+static iree_status_t CompleteQueueInvocation(
+    CapturingQueue* queue,
+    const iree_hal_semaphore_list_t signal_semaphore_list) {
+  if (queue->submission_status_code != IREE_STATUS_OK) {
+    return iree_make_status(queue->submission_status_code,
+                            "injected queue submission failure");
+  }
+  if (!queue->fail_private_signal) {
+    return iree_hal_semaphore_list_signal(signal_semaphore_list,
+                                          /*frontier=*/nullptr);
+  }
+  for (iree_host_size_t i = 0; i + 1 < signal_semaphore_list.count; ++i) {
+    IREE_RETURN_IF_ERROR(iree_hal_semaphore_signal(
+        signal_semaphore_list.semaphores[i],
+        signal_semaphore_list.payload_values[i], /*frontier=*/nullptr));
+  }
+  IREE_ASSERT(signal_semaphore_list.count != 0);
+  iree_hal_semaphore_fail(
+      signal_semaphore_list.semaphores[signal_semaphore_list.count - 1],
+      iree_make_status(IREE_STATUS_ABORTED,
+                       "injected private completion failure"));
+  return iree_ok_status();
 }
 
 static iree_status_t CapturingQueueAtomicWait(
@@ -202,8 +250,7 @@ static iree_status_t CapturingQueueAtomicWait(
       base_queue, kAtomicInvocationWait, wait_semaphore_list,
       signal_semaphore_list, target_buffer, target_offset, params.width);
   invocation->wait_params = params;
-  return iree_hal_semaphore_list_signal(signal_semaphore_list,
-                                        /*frontier=*/nullptr);
+  return CompleteQueueInvocation(CastQueue(base_queue), signal_semaphore_list);
 }
 
 static iree_status_t CapturingQueueAtomicStore(
@@ -216,8 +263,7 @@ static iree_status_t CapturingQueueAtomicStore(
       base_queue, kAtomicInvocationStore, wait_semaphore_list,
       signal_semaphore_list, target_buffer, target_offset, params.width);
   invocation->store_params = params;
-  return iree_hal_semaphore_list_signal(signal_semaphore_list,
-                                        /*frontier=*/nullptr);
+  return CompleteQueueInvocation(CastQueue(base_queue), signal_semaphore_list);
 }
 
 static iree_status_t CapturingQueueAtomicRmw(
@@ -230,13 +276,31 @@ static iree_status_t CapturingQueueAtomicRmw(
       base_queue, kAtomicInvocationRmw, wait_semaphore_list,
       signal_semaphore_list, target_buffer, target_offset, params.width);
   invocation->rmw_params = params;
-  return iree_hal_semaphore_list_signal(signal_semaphore_list,
-                                        /*frontier=*/nullptr);
+  return CompleteQueueInvocation(CastQueue(base_queue), signal_semaphore_list);
+}
+
+static iree_status_t CapturingQueueTransfer(
+    iree_hal_queue_t* base_queue,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_host_size_t operation_count,
+    const iree_hal_transfer_operation_t* operations) {
+  CapturingQueue* queue = CastQueue(base_queue);
+  BeginQueueInvocation(base_queue, kAtomicInvocationNone, wait_semaphore_list,
+                       signal_semaphore_list, /*target_buffer=*/nullptr,
+                       /*target_offset=*/0, IREE_HAL_ATOMIC_WIDTH_32);
+  if (operation_count != 0) queue->transfer_operation = operations[0];
+  ++queue->transfer_invocation_count;
+  return CompleteQueueInvocation(queue, signal_semaphore_list);
 }
 
 static iree_status_t CapturingQueueFlush(iree_hal_queue_t* base_queue) {
-  (void)base_queue;
-  return iree_ok_status();
+  CapturingQueue* queue = CastQueue(base_queue);
+  ++queue->flush_count;
+  return queue->flush_status_code == IREE_STATUS_OK
+             ? iree_ok_status()
+             : iree_make_status(queue->flush_status_code,
+                                "injected queue flush failure");
 }
 
 static iree_hal_device_t* CreateTaskDevice() {
@@ -264,6 +328,23 @@ static iree_hal_device_t* CreateTaskDevice() {
   return device;
 }
 
+static iree_hal_device_group_t* CreateTaskDeviceGroup() {
+  iree_hal_device_t* device = CreateTaskDevice();
+  iree_async_frontier_tracker_t* frontier_tracker = nullptr;
+  IREE_CHECK_OK(iree_async_frontier_tracker_create(
+      iree_async_frontier_tracker_options_default(), iree_allocator_system(),
+      &frontier_tracker));
+  iree_hal_device_group_builder_t builder;
+  iree_hal_device_group_builder_initialize(&builder, frontier_tracker);
+  iree_async_frontier_tracker_release(frontier_tracker);
+  IREE_CHECK_OK(iree_hal_device_group_builder_add_device(&builder, device));
+  iree_hal_device_group_t* group = nullptr;
+  IREE_CHECK_OK(iree_hal_device_group_builder_finalize(
+      &builder, iree_allocator_system(), &group));
+  iree_hal_device_release(device);
+  return group;
+}
+
 class OperationRecord {
  public:
   template <typename Payload>
@@ -289,12 +370,21 @@ class OperationRecord {
     record_.header.operation_code = operation_code;
     record_.header.payload_type = payload_type;
     record_.header.object_id = object_id;
+    record_.header.device_id = kDeviceId;
     record_.header.status_code = IREE_STATUS_OK;
     RefreshPayloadSpan();
   }
 
   void AppendPayloadByte(uint8_t value) {
     payload_storage_.push_back(value);
+    RefreshPayloadSpan();
+  }
+
+  template <typename Payload>
+  void AppendPayload(const Payload& payload) {
+    const iree_host_size_t old_size = payload_storage_.size();
+    payload_storage_.resize(old_size + sizeof(payload));
+    memcpy(payload_storage_.data() + old_size, &payload, sizeof(payload));
     RefreshPayloadSpan();
   }
 
@@ -318,7 +408,8 @@ class ReplayAtomicExecutionTest : public ::testing::Test {
     task_device_ = CreateTaskDevice();
 
     const iree_hal_buffer_params_t buffer_params = {
-        /*.usage=*/IREE_HAL_BUFFER_USAGE_STORAGE,
+        /*.usage=*/IREE_HAL_BUFFER_USAGE_STORAGE |
+            IREE_HAL_BUFFER_USAGE_TRANSFER,
         /*.access=*/IREE_HAL_MEMORY_ACCESS_ALL,
         /*.type=*/IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
             IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
@@ -366,6 +457,7 @@ class ReplayAtomicExecutionTest : public ::testing::Test {
     queue_vtable_.atomic_wait = CapturingQueueAtomicWait;
     queue_vtable_.atomic_store = CapturingQueueAtomicStore;
     queue_vtable_.atomic_rmw = CapturingQueueAtomicRmw;
+    queue_vtable_.transfer = CapturingQueueTransfer;
     queue_vtable_.flush = CapturingQueueFlush;
     iree_hal_queue_initialize(iree_hal_queue_family(task_queue), &queue_vtable_,
                               &queue_.base);
@@ -391,12 +483,14 @@ class ReplayAtomicExecutionTest : public ::testing::Test {
     signal_semaphore_entry.value.semaphore = signal_semaphore_;
     StoreObject(kSignalSemaphoreId, IREE_HAL_REPLAY_OBJECT_TYPE_SEMAPHORE,
                 signal_semaphore_entry);
+    iree_hal_replay_object_entry_t device_entry = {};
+    device_entry.value.device = task_device_;
+    StoreObject(kDeviceId, IREE_HAL_REPLAY_OBJECT_TYPE_DEVICE, device_entry);
   }
 
   void TearDown() override {
-    iree_hal_replay_executor_deinitialize(&executor_);
+    iree_status_ignore(iree_hal_replay_executor_deinitialize(&executor_));
     iree_allocator_free(iree_allocator_system(), validation_state_);
-    iree_hal_device_release(task_device_);
   }
 
   void StoreObject(iree_hal_replay_object_id_t object_id,
@@ -576,9 +670,13 @@ TEST_F(ReplayAtomicExecutionTest, ReplaysQueueOperations) {
   EXPECT_EQ(1u, queue_.invocation.wait_semaphore_count);
   EXPECT_EQ(wait_semaphore_, queue_.invocation.wait_timepoint.semaphore);
   EXPECT_EQ(7u, queue_.invocation.wait_timepoint.value);
-  EXPECT_EQ(1u, queue_.invocation.signal_semaphore_count);
+  EXPECT_EQ(2u, queue_.invocation.signal_semaphore_count);
   EXPECT_EQ(signal_semaphore_, queue_.invocation.signal_timepoint.semaphore);
   EXPECT_EQ(9u, queue_.invocation.signal_timepoint.value);
+  EXPECT_NE(signal_semaphore_,
+            queue_.invocation.private_signal_timepoint.semaphore);
+  EXPECT_EQ(1u, queue_.invocation.private_signal_timepoint.value);
+  EXPECT_EQ(0u, executor_.queue_completion_count);
   EXPECT_EQ(target_buffer_, queue_.invocation.target_ref.buffer);
   EXPECT_EQ(8u, queue_.invocation.target_ref.offset);
   EXPECT_EQ(wait_payload.params.value, queue_.invocation.wait_params.value);
@@ -630,6 +728,171 @@ TEST_F(ReplayAtomicExecutionTest, ReplaysQueueOperations) {
   EXPECT_EQ(rmw_payload.params.width, queue_.invocation.rmw_params.width);
   EXPECT_EQ(rmw_payload.params.operation,
             queue_.invocation.rmw_params.operation);
+}
+
+TEST_F(ReplayAtomicExecutionTest, TracksPrivateCompletionWithoutWireSignal) {
+  OperationRecord record;
+  iree_hal_replay_queue_atomic_store_payload_t payload = {};
+  payload.target_ref = DirectTarget(/*offset=*/0, /*length=*/4);
+  payload.params.value = 1;
+  payload.params.width = IREE_HAL_ATOMIC_WIDTH_32;
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_ATOMIC_STORE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_STORE, kQueueId,
+               payload);
+
+  IREE_ASSERT_OK(Replay(record));
+  ASSERT_EQ(1u, executor_.queue_completion_count);
+  EXPECT_EQ(1u, queue_.invocation.signal_semaphore_count);
+  EXPECT_EQ(executor_.queue_completions[0].semaphore,
+            queue_.invocation.private_signal_timepoint.semaphore);
+  EXPECT_EQ(executor_.queue_completions[0].value,
+            queue_.invocation.private_signal_timepoint.value);
+  EXPECT_EQ(1u, queue_.flush_count);
+
+  IREE_ASSERT_OK(iree_hal_replay_executor_drain_queue_completions(&executor_));
+  EXPECT_EQ(0u, executor_.queue_completion_count);
+  EXPECT_EQ(2u, queue_.flush_count);
+}
+
+TEST_F(ReplayAtomicExecutionTest, SubmissionFailureIsNotTracked) {
+  queue_.submission_status_code = IREE_STATUS_RESOURCE_EXHAUSTED;
+  OperationRecord record;
+  iree_hal_replay_queue_atomic_store_payload_t payload = {};
+  payload.target_ref = DirectTarget(/*offset=*/0, /*length=*/4);
+  payload.params.value = 1;
+  payload.params.width = IREE_HAL_ATOMIC_WIDTH_32;
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_ATOMIC_STORE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_STORE, kQueueId,
+               payload);
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, Replay(record));
+  EXPECT_EQ(0u, executor_.queue_completion_count);
+  EXPECT_EQ(0u, queue_.flush_count);
+}
+
+TEST_F(ReplayAtomicExecutionTest, PrivateCompletionWaitFailureIsRetained) {
+  queue_.fail_private_signal = true;
+  OperationRecord record;
+  iree_hal_replay_queue_atomic_store_payload_t payload = {};
+  payload.target_ref = DirectTarget(/*offset=*/0, /*length=*/4);
+  payload.signal_semaphore_count = 1;
+  payload.params.value = 1;
+  payload.params.width = IREE_HAL_ATOMIC_WIDTH_32;
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_ATOMIC_STORE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_STORE, kQueueId,
+               payload, {SignalTimepoint(9)});
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED, Replay(record));
+  ASSERT_EQ(1u, executor_.queue_completion_count);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_ABORTED,
+      iree_hal_replay_executor_drain_queue_completions(&executor_));
+  EXPECT_EQ(1u, executor_.queue_completion_count);
+
+  // A failed timeline semaphore cannot recover. Release the retained private
+  // test timepoint explicitly so fixture teardown can validate other objects.
+  iree_hal_semaphore_release(executor_.queue_completions[0].semaphore);
+  memset(&executor_.queue_completions[0], 0,
+         sizeof(executor_.queue_completions[0]));
+  executor_.queue_completion_count = 0;
+  queue_.fail_private_signal = false;
+}
+
+TEST_F(ReplayAtomicExecutionTest,
+       TransferStagingIsRetainedAcrossWaitFailureUntilDrain) {
+  queue_.fail_private_signal = true;
+  OperationRecord record;
+  iree_hal_replay_queue_transfer_payload_t payload = {};
+  payload.operation_count = 1;
+  payload.data_length = 4;
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_TRANSFER,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_TRANSFER, kQueueId, payload);
+  iree_hal_replay_queue_transfer_operation_payload_t operation = {};
+  operation.type = IREE_HAL_REPLAY_QUEUE_TRANSFER_OPERATION_TYPE_UPLOAD;
+  operation.target_ref = DirectTarget(/*offset=*/0, /*length=*/4);
+  operation.data_length = 4;
+  record.AppendPayload(operation);
+  record.AppendPayloadByte(0x10);
+  record.AppendPayloadByte(0x20);
+  record.AppendPayloadByte(0x30);
+  record.AppendPayloadByte(0x40);
+  const uint8_t* captured_data =
+      record.get()->payload.data + sizeof(payload) + sizeof(operation);
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED, Replay(record));
+  ASSERT_EQ(1u, queue_.transfer_invocation_count);
+  ASSERT_EQ(1u, executor_.queue_completion_count);
+  iree_hal_replay_queue_completion_t* completion =
+      &executor_.queue_completions[0];
+  ASSERT_NE(nullptr, completion->retained_host_allocation);
+  EXPECT_EQ(completion->retained_host_allocation,
+            queue_.transfer_operation.upload.source);
+  EXPECT_NE(captured_data, queue_.transfer_operation.upload.source);
+  EXPECT_EQ(0, memcmp(queue_.transfer_operation.upload.source, captured_data,
+                      payload.data_length));
+
+  // Substitute a recoverable test timepoint after proving that the first wait
+  // failure retained both the completion and its borrowed staging allocation.
+  iree_hal_semaphore_release(completion->semaphore);
+  completion->semaphore = nullptr;
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      task_device_, /*queue_family_affinity=*/
+      iree_hal_make_queue_family_affinity(0),
+      /*initial_value=*/0, IREE_HAL_SEMAPHORE_FLAG_DEFAULT,
+      &completion->semaphore));
+  IREE_ASSERT_OK(iree_hal_semaphore_signal(completion->semaphore,
+                                           completion->value,
+                                           /*frontier=*/nullptr));
+  queue_.fail_private_signal = false;
+  IREE_ASSERT_OK(iree_hal_replay_executor_drain_queue_completions(&executor_));
+  EXPECT_EQ(0u, executor_.queue_completion_count);
+  EXPECT_EQ(nullptr, executor_.queue_completions[0].retained_host_allocation);
+}
+
+TEST_F(ReplayAtomicExecutionTest, BufferRangeDataIsNotACompletionBoundary) {
+  OperationRecord record;
+  iree_hal_replay_queue_atomic_store_payload_t queue_payload = {};
+  queue_payload.target_ref = DirectTarget(/*offset=*/0, /*length=*/4);
+  queue_payload.params.value = 1;
+  queue_payload.params.width = IREE_HAL_ATOMIC_WIDTH_32;
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_ATOMIC_STORE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_STORE, kQueueId,
+               queue_payload);
+  IREE_ASSERT_OK(Replay(record));
+  ASSERT_EQ(1u, executor_.queue_completion_count);
+  ASSERT_EQ(1u, queue_.flush_count);
+
+  iree_hal_replay_buffer_range_data_payload_t range_payload = {};
+  range_payload.byte_length = 1;
+  range_payload.data_length = 1;
+  range_payload.mapping_mode = IREE_HAL_MAPPING_MODE_SCOPED;
+  range_payload.memory_access = IREE_HAL_MEMORY_ACCESS_WRITE;
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_BUFFER_FLUSH_RANGE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_BUFFER_RANGE_DATA, kBufferId,
+               range_payload);
+  record.AppendPayloadByte(0x5A);
+  IREE_ASSERT_OK(Replay(record));
+  EXPECT_EQ(1u, executor_.queue_completion_count);
+  EXPECT_EQ(1u, queue_.flush_count);
+
+  IREE_ASSERT_OK(iree_hal_replay_executor_drain_queue_completions(&executor_));
+}
+
+TEST_F(ReplayAtomicExecutionTest, DeinitializeDrainsPendingCompletionAtEof) {
+  OperationRecord record;
+  iree_hal_replay_queue_atomic_store_payload_t payload = {};
+  payload.target_ref = DirectTarget(/*offset=*/0, /*length=*/4);
+  payload.params.value = 1;
+  payload.params.width = IREE_HAL_ATOMIC_WIDTH_32;
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_ATOMIC_STORE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_STORE, kQueueId,
+               payload);
+  IREE_ASSERT_OK(Replay(record));
+  ASSERT_EQ(1u, executor_.queue_completion_count);
+
+  IREE_ASSERT_OK(iree_hal_replay_executor_deinitialize(&executor_));
+  EXPECT_EQ(0u, executor_.queue_completion_count);
+  EXPECT_EQ(2u, queue_.flush_count);
 }
 
 TEST_F(ReplayAtomicExecutionTest, RejectsMalformedRecords) {
@@ -701,6 +964,76 @@ TEST_F(ReplayAtomicExecutionTest, RejectsMalformedRecords) {
                queue_payload, {WaitTimepoint(), SignalTimepoint(9)});
   IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS, Replay(record));
   EXPECT_EQ(0u, queue_.invocation_count);
+}
+
+TEST(ReplayExecutorLifecycleTest,
+     ReleasesQueueAllocaBufferBeforeHigherIdQueuePool) {
+  iree_hal_device_group_t* device_group = CreateTaskDeviceGroup();
+  iree_hal_device_t* device =
+      iree_hal_device_group_device_at(device_group, /*index=*/0);
+  iree_hal_queue_t* queue =
+      iree_hal_device_queue(device, /*family_ordinal=*/0, /*queue_ordinal=*/0);
+  ASSERT_NE(nullptr, queue);
+
+  iree_hal_queue_pool_backend_t backend = {};
+  IREE_ASSERT_OK(iree_hal_device_query_queue_pool_backend(
+      device, iree_hal_queue_family(queue), &backend));
+  iree_hal_passthrough_pool_options_t pool_options = {};
+  pool_options.asan = backend.asan;
+  iree_hal_pool_t* pool = nullptr;
+  IREE_ASSERT_OK(iree_hal_passthrough_pool_create(
+      pool_options, backend.slab_provider, backend.notification,
+      iree_allocator_system(), &pool));
+
+  iree_hal_semaphore_t* signal_semaphore = nullptr;
+  IREE_ASSERT_OK(iree_hal_semaphore_create(
+      device, iree_hal_make_queue_family_affinity(0), /*initial_value=*/0,
+      IREE_HAL_SEMAPHORE_FLAG_DEFAULT, &signal_semaphore));
+  iree_hal_semaphore_t* signal_semaphores[] = {signal_semaphore};
+  uint64_t signal_values[] = {1};
+  const iree_hal_semaphore_list_t signal_list = {
+      IREE_ARRAYSIZE(signal_semaphores), signal_semaphores, signal_values};
+  const iree_hal_pool_reservation_request_t request = {
+      /*.params=*/
+      {
+          /*.usage=*/IREE_HAL_BUFFER_USAGE_TRANSFER,
+          /*.access=*/IREE_HAL_MEMORY_ACCESS_ALL,
+          /*.type=*/IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+              IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
+          /*.queue_family_affinity=*/iree_hal_make_queue_family_affinity(0),
+      },
+      /*.allocation_size=*/16,
+  };
+  iree_hal_buffer_t* buffer = nullptr;
+  IREE_ASSERT_OK(iree_hal_queue_alloca(queue, iree_hal_semaphore_list_empty(),
+                                       signal_list, pool,
+                                       /*request_count=*/1, &request, &buffer));
+  IREE_ASSERT_OK(iree_hal_semaphore_wait(signal_semaphore, /*value=*/1,
+                                         iree_infinite_timeout(),
+                                         IREE_ASYNC_WAIT_FLAG_NONE));
+  iree_hal_semaphore_release(signal_semaphore);
+
+  iree_hal_replay_execute_options_t options =
+      iree_hal_replay_execute_options_default();
+  iree_hal_replay_executor_t executor = {};
+  IREE_ASSERT_OK(iree_hal_replay_executor_initialize(
+      &executor, iree_const_byte_span_empty(), /*object_capacity=*/8,
+      device_group, &options, iree_allocator_system()));
+  iree_hal_replay_object_entry_t buffer_entry = {};
+  buffer_entry.value.buffer = buffer;
+  IREE_ASSERT_OK(iree_hal_replay_executor_store(
+      &executor, /*object_id=*/1, IREE_HAL_REPLAY_OBJECT_TYPE_BUFFER,
+      buffer_entry));
+  iree_hal_queue_retain(queue);
+  iree_hal_replay_object_entry_t queue_entry = {};
+  queue_entry.value.queue = queue;
+  queue_entry.queue_allocation_pool = pool;
+  IREE_ASSERT_OK(iree_hal_replay_executor_store(
+      &executor, /*object_id=*/7, IREE_HAL_REPLAY_OBJECT_TYPE_QUEUE,
+      queue_entry));
+
+  IREE_ASSERT_OK(iree_hal_replay_executor_deinitialize(&executor));
+  iree_hal_device_group_release(device_group);
 }
 
 }  // namespace

--- a/runtime/src/iree/hal/replay/execute_object.c
+++ b/runtime/src/iree/hal/replay/execute_object.c
@@ -1084,6 +1084,81 @@ static iree_status_t iree_hal_replay_executor_import_buffer(
   return status;
 }
 
+static iree_status_t iree_hal_replay_executor_virtual_memory_reserve(
+    iree_hal_replay_executor_t* executor,
+    const iree_hal_replay_file_record_t* record) {
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+      record, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE,
+      sizeof(iree_hal_replay_allocator_virtual_memory_reserve_payload_t)));
+  if (IREE_UNLIKELY(
+          record->payload.data_length !=
+          sizeof(iree_hal_replay_allocator_virtual_memory_reserve_payload_t))) {
+    return iree_make_status(IREE_STATUS_DATA_LOSS,
+                            "replay virtual memory reserve payload length "
+                            "mismatch");
+  }
+  iree_hal_replay_allocator_virtual_memory_reserve_payload_t payload;
+  memcpy(&payload, record->payload.data, sizeof(payload));
+
+  iree_hal_replay_object_entry_t* allocator_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(
+      executor, record->header.object_id, IREE_HAL_REPLAY_OBJECT_TYPE_ALLOCATOR,
+      &allocator_entry));
+  iree_hal_buffer_t* virtual_buffer = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_virtual_memory_reserve(
+      allocator_entry->value.allocator, payload.queue_family_affinity,
+      payload.size, &virtual_buffer));
+
+  iree_hal_allocator_retain(allocator_entry->value.allocator);
+  iree_hal_replay_object_entry_t entry = {
+      .owning_allocator = allocator_entry->value.allocator,
+      .value.buffer = virtual_buffer,
+  };
+  return iree_hal_replay_executor_store(
+      executor, record->header.related_object_id,
+      IREE_HAL_REPLAY_OBJECT_TYPE_BUFFER, entry);
+}
+
+static iree_status_t iree_hal_replay_executor_physical_memory_allocate(
+    iree_hal_replay_executor_t* executor,
+    const iree_hal_replay_file_record_t* record) {
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+      record, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+      sizeof(iree_hal_replay_allocator_physical_memory_allocate_payload_t)));
+  if (IREE_UNLIKELY(
+          record->payload.data_length !=
+          sizeof(
+              iree_hal_replay_allocator_physical_memory_allocate_payload_t))) {
+    return iree_make_status(IREE_STATUS_DATA_LOSS,
+                            "replay physical memory allocation payload length "
+                            "mismatch");
+  }
+  iree_hal_replay_allocator_physical_memory_allocate_payload_t payload;
+  memcpy(&payload, record->payload.data, sizeof(payload));
+
+  iree_hal_replay_object_entry_t* allocator_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(
+      executor, record->header.object_id, IREE_HAL_REPLAY_OBJECT_TYPE_ALLOCATOR,
+      &allocator_entry));
+  iree_hal_buffer_params_t params;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_make_buffer_params(
+      &payload.allocation, &params));
+  iree_hal_physical_memory_t* physical_memory = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_physical_memory_allocate(
+      allocator_entry->value.allocator, params,
+      payload.allocation.allocation_size, executor->host_allocator,
+      &physical_memory));
+
+  iree_hal_allocator_retain(allocator_entry->value.allocator);
+  iree_hal_replay_object_entry_t entry = {
+      .owning_allocator = allocator_entry->value.allocator,
+      .value.physical_memory = {.handle = physical_memory},
+  };
+  return iree_hal_replay_executor_store(
+      executor, record->header.related_object_id,
+      IREE_HAL_REPLAY_OBJECT_TYPE_PHYSICAL_MEMORY, entry);
+}
+
 static iree_status_t iree_hal_replay_executor_replay_buffer_range_data(
     iree_hal_replay_executor_t* executor,
     const iree_hal_replay_file_record_t* record) {
@@ -1125,6 +1200,11 @@ iree_status_t iree_hal_replay_executor_replay_object_operation(
       return iree_hal_replay_executor_allocate_buffer(executor, record);
     case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_IMPORT_BUFFER:
       return iree_hal_replay_executor_import_buffer(executor, record);
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE:
+      return iree_hal_replay_executor_virtual_memory_reserve(executor, record);
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE:
+      return iree_hal_replay_executor_physical_memory_allocate(executor,
+                                                               record);
     case IREE_HAL_REPLAY_OPERATION_CODE_BUFFER_FLUSH_RANGE:
     case IREE_HAL_REPLAY_OPERATION_CODE_BUFFER_UNMAP_RANGE:
       if (record->header.payload_type ==

--- a/runtime/src/iree/hal/replay/execute_operation.c
+++ b/runtime/src/iree/hal/replay/execute_operation.c
@@ -12,6 +12,7 @@
 
 #include "iree/hal/memory/passthrough_pool.h"
 #include "iree/hal/replay/execute_object.h"
+#include "iree/hal/replay/execute_vmm.h"
 
 static iree_status_t iree_hal_replay_executor_allocate_array(
     iree_hal_replay_executor_t* executor, iree_host_size_t element_count,
@@ -68,6 +69,20 @@ static iree_status_t iree_hal_replay_executor_require_fixed_payload(
                             "replay fixed payload length mismatch");
   }
   return iree_ok_status();
+}
+
+static iree_status_t iree_hal_replay_executor_prepare_record_completion(
+    iree_hal_replay_executor_t* executor,
+    const iree_hal_replay_file_record_t* record, iree_hal_queue_t* queue,
+    iree_hal_replay_semaphore_list_storage_t* signal_storage,
+    iree_hal_replay_queue_completion_t** out_completion) {
+  iree_hal_replay_object_entry_t* device_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(
+      executor, record->header.device_id, IREE_HAL_REPLAY_OBJECT_TYPE_DEVICE,
+      &device_entry));
+  return iree_hal_replay_executor_prepare_queue_completion(
+      executor, device_entry->value.device, queue, signal_storage,
+      out_completion);
 }
 
 static iree_hal_atomic_wait_params_t
@@ -389,6 +404,8 @@ static iree_status_t iree_hal_replay_executor_queue_transfer(
 
   iree_status_t status = iree_ok_status();
   iree_host_size_t download_data_length = 0;
+  bool has_upload_data = false;
+  bool requires_host_data_completion = false;
   for (iree_host_size_t i = 0; i < operation_count && iree_status_is_ok(status);
        ++i) {
     iree_hal_replay_queue_transfer_operation_payload_t operation_payload;
@@ -397,6 +414,18 @@ static iree_status_t iree_hal_replay_executor_queue_transfer(
            sizeof(operation_payload));
     status = iree_hal_replay_executor_validate_transfer_operation(
         &operation_payload, data, &download_data_length);
+    if (iree_status_is_ok(status) &&
+        operation_payload.type ==
+            IREE_HAL_REPLAY_QUEUE_TRANSFER_OPERATION_TYPE_UPLOAD &&
+        operation_payload.target_ref.length != 0) {
+      has_upload_data = true;
+      requires_host_data_completion = true;
+    } else if (iree_status_is_ok(status) &&
+               operation_payload.type ==
+                   IREE_HAL_REPLAY_QUEUE_TRANSFER_OPERATION_TYPE_DOWNLOAD &&
+               operation_payload.source_ref.length != 0) {
+      requires_host_data_completion = true;
+    }
     if (!iree_status_is_ok(status)) {
       status = iree_status_annotate_f(status, "transfer operation %" PRIhsz, i);
     }
@@ -415,11 +444,29 @@ static iree_status_t iree_hal_replay_executor_queue_transfer(
                                    (void**)&operations);
     if (iree_status_is_ok(status)) memset(operations, 0, operations_size);
   }
-  uint8_t* download_data = NULL;
-  if (iree_status_is_ok(status) && download_data_length != 0) {
-    status = iree_allocator_malloc(
-        executor->host_allocator, download_data_length, (void**)&download_data);
+  const iree_host_size_t upload_data_length =
+      has_upload_data ? data.data_length : 0;
+  iree_host_size_t host_staging_data_length = 0;
+  if (iree_status_is_ok(status) && IREE_UNLIKELY(!iree_host_size_checked_add(
+                                       upload_data_length, download_data_length,
+                                       &host_staging_data_length))) {
+    status = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                              "replay transfer host staging overflow");
   }
+  uint8_t* host_staging_data = NULL;
+  if (iree_status_is_ok(status) && host_staging_data_length != 0) {
+    status = iree_allocator_malloc(executor->host_allocator,
+                                   host_staging_data_length,
+                                   (void**)&host_staging_data);
+  }
+  iree_const_byte_span_t transfer_data = data;
+  if (iree_status_is_ok(status) && upload_data_length != 0) {
+    memcpy(host_staging_data, data.data, upload_data_length);
+    transfer_data =
+        iree_make_const_byte_span(host_staging_data, upload_data_length);
+  }
+  uint8_t* download_data =
+      host_staging_data ? host_staging_data + upload_data_length : NULL;
 
   iree_host_size_t download_data_offset = 0;
   for (iree_host_size_t i = 0; i < operation_count && iree_status_is_ok(status);
@@ -440,7 +487,7 @@ static iree_status_t iree_hal_replay_executor_queue_transfer(
             executor, &operation_payload.target_ref, &target_ref);
         if (iree_status_is_ok(status)) {
           status = iree_hal_replay_executor_transfer_data_span(
-              data, &operation_payload, &operation_data);
+              transfer_data, &operation_payload, &operation_data);
         }
         if (iree_status_is_ok(status)) {
           operation->fill.target_buffer = target_ref.buffer;
@@ -458,7 +505,7 @@ static iree_status_t iree_hal_replay_executor_queue_transfer(
             executor, &operation_payload.target_ref, &target_ref);
         if (iree_status_is_ok(status)) {
           status = iree_hal_replay_executor_transfer_data_span(
-              data, &operation_payload, &operation_data);
+              transfer_data, &operation_payload, &operation_data);
         }
         if (iree_status_is_ok(status)) {
           operation->update.source_buffer = operation_data.data;
@@ -493,7 +540,7 @@ static iree_status_t iree_hal_replay_executor_queue_transfer(
             executor, &operation_payload.target_ref, &target_ref);
         if (iree_status_is_ok(status)) {
           status = iree_hal_replay_executor_transfer_data_span(
-              data, &operation_payload, &operation_data);
+              transfer_data, &operation_payload, &operation_data);
         }
         if (iree_status_is_ok(status)) {
           operation->upload.source = operation_data.data;
@@ -526,18 +573,26 @@ static iree_status_t iree_hal_replay_executor_queue_transfer(
     }
   }
 
+  iree_hal_replay_queue_completion_t* completion = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_replay_executor_prepare_record_completion(
+        executor, record, queue_entry->value.queue, &signal_storage,
+        &completion);
+  }
+  if (iree_status_is_ok(status) && requires_host_data_completion) {
+    completion->retained_host_allocation = host_staging_data;
+    host_staging_data = NULL;
+    completion->wait_immediately = true;
+  }
   if (iree_status_is_ok(status)) {
     status = iree_hal_queue_transfer(queue_entry->value.queue,
                                      wait_storage.list, signal_storage.list,
                                      operation_count, operations);
   }
-  if (iree_status_is_ok(status) && signal_storage.list.count != 0) {
-    status = iree_hal_semaphore_list_wait(signal_storage.list,
-                                          iree_infinite_timeout(),
-                                          IREE_ASYNC_WAIT_FLAG_NONE);
-  }
+  status = iree_hal_replay_executor_finalize_queue_completion(
+      executor, completion, /*flush_queue=*/false, status);
 
-  iree_allocator_free(executor->host_allocator, download_data);
+  iree_allocator_free(executor->host_allocator, host_staging_data);
   iree_allocator_free(executor->host_allocator, operations);
   iree_hal_replay_semaphore_list_storage_deinitialize(&signal_storage,
                                                       executor->host_allocator);
@@ -584,6 +639,13 @@ static iree_status_t iree_hal_replay_executor_queue_read_exact(
         "replay queue read captured data length does not match target length");
   }
 
+  iree_hal_replay_queue_completion_t* completion = NULL;
+  if (iree_status_is_ok(status) &&
+      (payload.captured_data_length != 0 || file_entry->value.file)) {
+    status = iree_hal_replay_executor_prepare_record_completion(
+        executor, record, queue_entry->value.queue, &signal_storage,
+        &completion);
+  }
   if (iree_status_is_ok(status) && payload.captured_data_length != 0) {
     status = iree_hal_queue_update(
         queue_entry->value.queue, wait_storage.list, signal_storage.list,
@@ -599,11 +661,8 @@ static iree_status_t iree_hal_replay_executor_queue_read_exact(
         file_entry->value.file, payload.source_offset, target_ref.buffer,
         target_ref.offset, target_ref.length, payload.flags);
   }
-  if (iree_status_is_ok(status) && signal_storage.list.count != 0) {
-    status = iree_hal_semaphore_list_wait(signal_storage.list,
-                                          iree_infinite_timeout(),
-                                          IREE_ASYNC_WAIT_FLAG_NONE);
-  }
+  status = iree_hal_replay_executor_finalize_queue_completion(
+      executor, completion, /*flush_queue=*/false, status);
   iree_hal_replay_semaphore_list_storage_deinitialize(&signal_storage,
                                                       executor->host_allocator);
   iree_hal_replay_semaphore_list_storage_deinitialize(&wait_storage,
@@ -647,17 +706,20 @@ static iree_status_t iree_hal_replay_executor_queue_write_exact(
         iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                          "replay queue write requires an imported target file");
   }
+  iree_hal_replay_queue_completion_t* completion = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_replay_executor_prepare_record_completion(
+        executor, record, queue_entry->value.queue, &signal_storage,
+        &completion);
+  }
   if (iree_status_is_ok(status)) {
     status = iree_hal_queue_write(
         queue_entry->value.queue, wait_storage.list, signal_storage.list,
         source_ref.buffer, source_ref.offset, file_entry->value.file,
         payload.target_offset, source_ref.length, payload.flags);
   }
-  if (iree_status_is_ok(status) && signal_storage.list.count != 0) {
-    status = iree_hal_semaphore_list_wait(signal_storage.list,
-                                          iree_infinite_timeout(),
-                                          IREE_ASYNC_WAIT_FLAG_NONE);
-  }
+  status = iree_hal_replay_executor_finalize_queue_completion(
+      executor, completion, /*flush_queue=*/false, status);
   iree_hal_replay_semaphore_list_storage_deinitialize(&signal_storage,
                                                       executor->host_allocator);
   iree_hal_replay_semaphore_list_storage_deinitialize(&wait_storage,
@@ -751,15 +813,16 @@ static iree_status_t iree_hal_replay_executor_queue_alloca(
           request_payloads[i].allocation.allocation_size;
     }
   }
+  iree_hal_replay_queue_completion_t* completion = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_replay_executor_prepare_record_completion(
+        executor, record, queue_entry->value.queue, &signal_storage,
+        &completion);
+  }
   if (iree_status_is_ok(status)) {
     status = iree_hal_queue_alloca(queue_entry->value.queue, wait_storage.list,
                                    signal_storage.list, pool, request_count,
                                    requests, buffers);
-  }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_semaphore_list_wait(signal_storage.list,
-                                          iree_infinite_timeout(),
-                                          IREE_ASYNC_WAIT_FLAG_NONE);
   }
   if (iree_status_is_ok(status)) {
     for (iree_host_size_t i = 0; i < request_count; ++i) {
@@ -772,6 +835,8 @@ static iree_status_t iree_hal_replay_executor_queue_alloca(
       buffers[i] = NULL;
     }
   }
+  status = iree_hal_replay_executor_finalize_queue_completion(
+      executor, completion, /*flush_queue=*/false, status);
   if (buffers) {
     for (iree_host_size_t i = 0; i < request_count; ++i) {
       iree_hal_buffer_release(buffers[i]);
@@ -848,16 +913,19 @@ static iree_status_t iree_hal_replay_executor_queue_dealloca(
       }
     }
   }
+  iree_hal_replay_queue_completion_t* completion = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_replay_executor_prepare_record_completion(
+        executor, record, queue_entry->value.queue, &signal_storage,
+        &completion);
+  }
   if (iree_status_is_ok(status)) {
     status =
         iree_hal_queue_dealloca(queue_entry->value.queue, wait_storage.list,
                                 signal_storage.list, buffer_count, buffers);
   }
-  if (iree_status_is_ok(status) && signal_storage.list.count != 0) {
-    status = iree_hal_semaphore_list_wait(signal_storage.list,
-                                          iree_infinite_timeout(),
-                                          IREE_ASYNC_WAIT_FLAG_NONE);
-  }
+  status = iree_hal_replay_executor_finalize_queue_completion(
+      executor, completion, /*flush_queue=*/false, status);
   iree_allocator_free(executor->host_allocator, buffers);
   iree_allocator_free(executor->host_allocator, buffer_ids);
   iree_hal_replay_semaphore_list_storage_deinitialize(&signal_storage,
@@ -892,16 +960,20 @@ static iree_status_t iree_hal_replay_executor_queue_atomic_wait(
     status = iree_hal_replay_executor_make_direct_atomic_buffer_ref(
         executor, &payload.target_ref, payload.params.width, &target_ref);
   }
+  iree_hal_replay_queue_completion_t* completion = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_replay_executor_prepare_record_completion(
+        executor, record, queue_entry->value.queue, &signal_storage,
+        &completion);
+  }
   if (iree_status_is_ok(status)) {
     status = iree_hal_queue_atomic_wait(
         queue_entry->value.queue, wait_storage.list, signal_storage.list,
         target_ref.buffer, target_ref.offset,
         iree_hal_replay_executor_atomic_wait_params(payload.params));
   }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_replay_executor_flush_queue_and_wait(
-        queue_entry->value.queue, signal_storage.list);
-  }
+  status = iree_hal_replay_executor_finalize_queue_completion(
+      executor, completion, /*flush_queue=*/true, status);
   iree_hal_replay_semaphore_list_storage_deinitialize(&signal_storage,
                                                       executor->host_allocator);
   iree_hal_replay_semaphore_list_storage_deinitialize(&wait_storage,
@@ -934,16 +1006,20 @@ static iree_status_t iree_hal_replay_executor_queue_atomic_store(
     status = iree_hal_replay_executor_make_direct_atomic_buffer_ref(
         executor, &payload.target_ref, payload.params.width, &target_ref);
   }
+  iree_hal_replay_queue_completion_t* completion = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_replay_executor_prepare_record_completion(
+        executor, record, queue_entry->value.queue, &signal_storage,
+        &completion);
+  }
   if (iree_status_is_ok(status)) {
     status = iree_hal_queue_atomic_store(
         queue_entry->value.queue, wait_storage.list, signal_storage.list,
         target_ref.buffer, target_ref.offset,
         iree_hal_replay_executor_atomic_store_params(payload.params));
   }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_replay_executor_flush_queue_and_wait(
-        queue_entry->value.queue, signal_storage.list);
-  }
+  status = iree_hal_replay_executor_finalize_queue_completion(
+      executor, completion, /*flush_queue=*/true, status);
   iree_hal_replay_semaphore_list_storage_deinitialize(&signal_storage,
                                                       executor->host_allocator);
   iree_hal_replay_semaphore_list_storage_deinitialize(&wait_storage,
@@ -976,16 +1052,20 @@ static iree_status_t iree_hal_replay_executor_queue_atomic_rmw(
     status = iree_hal_replay_executor_make_direct_atomic_buffer_ref(
         executor, &payload.target_ref, payload.params.width, &target_ref);
   }
+  iree_hal_replay_queue_completion_t* completion = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_replay_executor_prepare_record_completion(
+        executor, record, queue_entry->value.queue, &signal_storage,
+        &completion);
+  }
   if (iree_status_is_ok(status)) {
     status = iree_hal_queue_atomic_rmw(
         queue_entry->value.queue, wait_storage.list, signal_storage.list,
         target_ref.buffer, target_ref.offset,
         iree_hal_replay_executor_atomic_rmw_params(payload.params));
   }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_replay_executor_flush_queue_and_wait(
-        queue_entry->value.queue, signal_storage.list);
-  }
+  status = iree_hal_replay_executor_finalize_queue_completion(
+      executor, completion, /*flush_queue=*/true, status);
   iree_hal_replay_semaphore_list_storage_deinitialize(&signal_storage,
                                                       executor->host_allocator);
   iree_hal_replay_semaphore_list_storage_deinitialize(&wait_storage,
@@ -1018,15 +1098,19 @@ static iree_status_t iree_hal_replay_executor_queue_timestamp(
     status = iree_hal_replay_executor_make_buffer_ref(
         executor, &payload.target_ref, &target_ref);
   }
+  iree_hal_replay_queue_completion_t* completion = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_replay_executor_prepare_record_completion(
+        executor, record, queue_entry->value.queue, &signal_storage,
+        &completion);
+  }
   if (iree_status_is_ok(status)) {
     status = iree_hal_queue_timestamp(
         queue_entry->value.queue, wait_storage.list, signal_storage.list,
         target_ref.buffer, target_ref.offset, payload.flags);
   }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_replay_executor_flush_queue_and_wait(
-        queue_entry->value.queue, signal_storage.list);
-  }
+  status = iree_hal_replay_executor_finalize_queue_completion(
+      executor, completion, /*flush_queue=*/true, status);
   iree_hal_replay_semaphore_list_storage_deinitialize(&signal_storage,
                                                       executor->host_allocator);
   iree_hal_replay_semaphore_list_storage_deinitialize(&wait_storage,
@@ -1335,13 +1419,15 @@ static iree_status_t iree_hal_replay_executor_queue_dispatch(
   IREE_RETURN_IF_ERROR(iree_hal_replay_executor_make_semaphore_list(
       executor,
       iree_make_const_byte_span(record->payload.data + wait_offset, wait_size),
-      (iree_host_size_t)payload.wait_semaphore_count, &wait_storage));
+      (iree_host_size_t)payload.wait_semaphore_count,
+      /*additional_capacity=*/0, &wait_storage));
   iree_hal_replay_semaphore_list_storage_t signal_storage = {0};
   iree_status_t status = iree_hal_replay_executor_make_semaphore_list(
       executor,
       iree_make_const_byte_span(record->payload.data + signal_offset,
                                 signal_size),
-      (iree_host_size_t)payload.signal_semaphore_count, &signal_storage);
+      (iree_host_size_t)payload.signal_semaphore_count,
+      /*additional_capacity=*/1, &signal_storage);
 
   iree_hal_replay_buffer_ref_list_storage_t binding_storage = {0};
   if (iree_status_is_ok(status)) {
@@ -1370,6 +1456,7 @@ static iree_status_t iree_hal_replay_executor_queue_dispatch(
         executor, payload.executable_id, IREE_HAL_REPLAY_OBJECT_TYPE_EXECUTABLE,
         &executable_entry);
   }
+  iree_hal_replay_queue_completion_t* completion = NULL;
   if (iree_status_is_ok(status)) {
     iree_hal_dispatch_config_t config;
     memset(&config, 0, sizeof(config));
@@ -1389,16 +1476,19 @@ static iree_status_t iree_hal_replay_executor_queue_dispatch(
           payload.function_ordinal, &function);
     }
     if (iree_status_is_ok(status)) {
+      status = iree_hal_replay_executor_prepare_record_completion(
+          executor, record, queue_entry->value.queue, &signal_storage,
+          &completion);
+    }
+    if (iree_status_is_ok(status)) {
       status = iree_hal_queue_dispatch(
           queue_entry->value.queue, wait_storage.list, signal_storage.list,
           executable_entry->value.executable.handle, function, config,
           constants, binding_storage.list, payload.flags);
     }
   }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_replay_executor_flush_queue_and_wait(
-        queue_entry->value.queue, signal_storage.list);
-  }
+  status = iree_hal_replay_executor_finalize_queue_completion(
+      executor, completion, /*flush_queue=*/true, status);
 
   iree_hal_replay_buffer_ref_list_storage_deinitialize(
       &binding_storage, executor->host_allocator);
@@ -1537,24 +1627,26 @@ static iree_status_t iree_hal_replay_executor_queue_barrier(
   iree_hal_replay_semaphore_list_storage_t wait_storage = {0};
   IREE_RETURN_IF_ERROR(iree_hal_replay_executor_make_semaphore_list(
       executor, iree_make_const_byte_span(cursor, wait_size),
-      (iree_host_size_t)payload.wait_semaphore_count, &wait_storage));
+      (iree_host_size_t)payload.wait_semaphore_count,
+      /*additional_capacity=*/0, &wait_storage));
   cursor += wait_size;
   iree_hal_replay_semaphore_list_storage_t signal_storage = {0};
   iree_status_t status = iree_hal_replay_executor_make_semaphore_list(
       executor, iree_make_const_byte_span(cursor, signal_size),
-      (iree_host_size_t)payload.signal_semaphore_count, &signal_storage);
+      (iree_host_size_t)payload.signal_semaphore_count,
+      /*additional_capacity=*/1, &signal_storage);
+  iree_hal_replay_queue_completion_t* completion = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_replay_executor_prepare_record_completion(
+        executor, record, queue_entry->value.queue, &signal_storage,
+        &completion);
+  }
   if (iree_status_is_ok(status)) {
     status = iree_hal_queue_barrier(queue_entry->value.queue, wait_storage.list,
                                     signal_storage.list, payload.flags);
   }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_queue_flush(queue_entry->value.queue);
-  }
-  if (iree_status_is_ok(status) && signal_storage.list.count != 0) {
-    status = iree_hal_semaphore_list_wait(signal_storage.list,
-                                          iree_infinite_timeout(),
-                                          IREE_ASYNC_WAIT_FLAG_NONE);
-  }
+  status = iree_hal_replay_executor_finalize_queue_completion(
+      executor, completion, /*flush_queue=*/true, status);
   iree_hal_replay_semaphore_list_storage_deinitialize(&signal_storage,
                                                       executor->host_allocator);
   iree_hal_replay_semaphore_list_storage_deinitialize(&wait_storage,
@@ -1613,12 +1705,14 @@ static iree_status_t iree_hal_replay_executor_queue_execute_exact(
   iree_hal_replay_semaphore_list_storage_t wait_storage = {0};
   IREE_RETURN_IF_ERROR(iree_hal_replay_executor_make_semaphore_list(
       executor, iree_make_const_byte_span(cursor, wait_size),
-      (iree_host_size_t)payload.wait_semaphore_count, &wait_storage));
+      (iree_host_size_t)payload.wait_semaphore_count,
+      /*additional_capacity=*/0, &wait_storage));
   cursor += wait_size;
   iree_hal_replay_semaphore_list_storage_t signal_storage = {0};
   iree_status_t status = iree_hal_replay_executor_make_semaphore_list(
       executor, iree_make_const_byte_span(cursor, signal_size),
-      (iree_host_size_t)payload.signal_semaphore_count, &signal_storage);
+      (iree_host_size_t)payload.signal_semaphore_count,
+      /*additional_capacity=*/1, &signal_storage);
   cursor += signal_size;
   iree_hal_replay_buffer_binding_table_storage_t binding_storage = {0};
   if (iree_status_is_ok(status)) {
@@ -1644,20 +1738,20 @@ static iree_status_t iree_hal_replay_executor_queue_execute_exact(
       };
     }
   }
+  iree_hal_replay_queue_completion_t* completion = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_replay_executor_prepare_record_completion(
+        executor, record, queue_entry->value.queue, &signal_storage,
+        &completion);
+  }
   if (iree_status_is_ok(status)) {
     status = iree_hal_queue_execute(queue_entry->value.queue, wait_storage.list,
                                     signal_storage.list,
                                     command_buffer_entry->value.command_buffer,
                                     binding_storage.table, payload.flags);
   }
-  if (iree_status_is_ok(status)) {
-    status = iree_hal_queue_flush(queue_entry->value.queue);
-  }
-  if (iree_status_is_ok(status) && signal_storage.list.count != 0) {
-    status = iree_hal_semaphore_list_wait(signal_storage.list,
-                                          iree_infinite_timeout(),
-                                          IREE_ASYNC_WAIT_FLAG_NONE);
-  }
+  status = iree_hal_replay_executor_finalize_queue_completion(
+      executor, completion, /*flush_queue=*/true, status);
   iree_hal_replay_buffer_binding_table_storage_deinitialize(
       &binding_storage, executor->host_allocator);
   iree_hal_replay_semaphore_list_storage_deinitialize(&signal_storage,
@@ -1691,6 +1785,7 @@ iree_status_t iree_hal_replay_executor_replay_operation(
     case IREE_HAL_REPLAY_OPERATION_CODE_DEVICE_PROFILING_END:
     case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_TRIM:
     case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_QUERY_MEMORY_HEAPS:
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_QUERY_GRANULARITY:
     case IREE_HAL_REPLAY_OPERATION_CODE_BUFFER_INVALIDATE_RANGE:
     case IREE_HAL_REPLAY_OPERATION_CODE_COMMAND_BUFFER_BEGIN_DEBUG_GROUP:
     case IREE_HAL_REPLAY_OPERATION_CODE_COMMAND_BUFFER_END_DEBUG_GROUP:
@@ -1707,9 +1802,18 @@ iree_status_t iree_hal_replay_executor_replay_operation(
     case IREE_HAL_REPLAY_OPERATION_CODE_DEVICE_CREATE_SEMAPHORE:
     case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_ALLOCATE_BUFFER:
     case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_IMPORT_BUFFER:
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE:
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE:
     case IREE_HAL_REPLAY_OPERATION_CODE_BUFFER_FLUSH_RANGE:
     case IREE_HAL_REPLAY_OPERATION_CODE_BUFFER_UNMAP_RANGE:
       return iree_hal_replay_executor_replay_object_operation(executor, record);
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE:
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_FREE:
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_MAP:
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP:
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT:
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE:
+      return iree_hal_replay_executor_replay_vmm_operation(executor, record);
     case IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_TRANSFER:
       return iree_hal_replay_executor_queue_transfer(executor, record);
     case IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_READ:

--- a/runtime/src/iree/hal/replay/execute_state.c
+++ b/runtime/src/iree/hal/replay/execute_state.c
@@ -9,9 +9,10 @@
 #include <inttypes.h>
 #include <string.h>
 
-static void iree_hal_replay_executor_release_entry(
-    iree_hal_replay_executor_t* executor,
+static iree_status_t iree_hal_replay_executor_release_entry(
+    iree_hal_replay_executor_t* executor, iree_hal_replay_object_id_t object_id,
     iree_hal_replay_object_entry_t* entry) {
+  iree_status_t status = iree_ok_status();
   switch (entry->type) {
     case IREE_HAL_REPLAY_OBJECT_TYPE_DEVICE:
       iree_hal_device_release(entry->value.device);
@@ -20,7 +21,19 @@ static void iree_hal_replay_executor_release_entry(
       iree_hal_allocator_release(entry->value.allocator);
       break;
     case IREE_HAL_REPLAY_OBJECT_TYPE_BUFFER:
-      iree_hal_buffer_release(entry->value.buffer);
+      if (entry->owning_allocator) {
+        if (iree_hal_replay_executor_has_virtual_memory_mapping(executor,
+                                                                object_id)) {
+          return iree_make_status(
+              IREE_STATUS_FAILED_PRECONDITION,
+              "replay virtual reservation still has live mappings");
+        }
+        status = iree_hal_allocator_virtual_memory_release(
+            entry->owning_allocator, entry->value.buffer);
+        if (!iree_status_is_ok(status)) return status;
+      } else {
+        iree_hal_buffer_release(entry->value.buffer);
+      }
       break;
     case IREE_HAL_REPLAY_OBJECT_TYPE_COMMAND_BUFFER:
       iree_hal_command_buffer_release(entry->value.command_buffer);
@@ -40,21 +53,114 @@ static void iree_hal_replay_executor_release_entry(
       iree_hal_pool_release(entry->queue_allocation_pool);
       iree_hal_queue_release(entry->value.queue);
       break;
+    case IREE_HAL_REPLAY_OBJECT_TYPE_PHYSICAL_MEMORY:
+      if (iree_hal_replay_executor_has_physical_memory_mapping(executor,
+                                                               object_id)) {
+        return iree_make_status(
+            IREE_STATUS_FAILED_PRECONDITION,
+            "replay physical allocation still has live mappings");
+      }
+      status = iree_hal_allocator_physical_memory_free(
+          entry->owning_allocator, entry->value.physical_memory.handle);
+      if (!iree_status_is_ok(status)) return status;
+      break;
     default:
       break;
   }
+  iree_hal_allocator_release(entry->owning_allocator);
   memset(entry, 0, sizeof(*entry));
+  return status;
 }
 
-void iree_hal_replay_executor_deinitialize(
+iree_status_t iree_hal_replay_executor_deinitialize(
     iree_hal_replay_executor_t* executor) {
-  if (!executor->objects) return;
-  for (iree_host_size_t i = executor->object_capacity; i > 0; --i) {
-    iree_hal_replay_executor_release_entry(executor, &executor->objects[i - 1]);
+  iree_status_t status =
+      iree_hal_replay_executor_drain_queue_completions(executor);
+  if (!iree_status_is_ok(status)) return status;
+
+  iree_allocator_free(executor->host_allocator, executor->queue_completions);
+  executor->queue_completions = NULL;
+  executor->queue_completion_count = 0;
+  executor->queue_completion_capacity = 0;
+
+  iree_host_size_t retained_mapping_count = 0;
+  const iree_host_size_t mapping_count = executor->virtual_memory_mapping_count;
+  for (iree_host_size_t i = 0; i < mapping_count; ++i) {
+    const iree_hal_replay_virtual_memory_mapping_t mapping =
+        executor->virtual_memory_mappings[i];
+    iree_hal_replay_object_entry_t* virtual_buffer_entry = NULL;
+    iree_status_t unmap_status = iree_hal_replay_executor_lookup(
+        executor, mapping.virtual_buffer_id, IREE_HAL_REPLAY_OBJECT_TYPE_BUFFER,
+        &virtual_buffer_entry);
+    if (iree_status_is_ok(unmap_status)) {
+      unmap_status = iree_hal_allocator_virtual_memory_unmap(
+          virtual_buffer_entry->owning_allocator,
+          virtual_buffer_entry->value.buffer, mapping.virtual_offset,
+          mapping.size);
+    }
+    if (!iree_status_is_ok(unmap_status)) {
+      executor->virtual_memory_mappings[retained_mapping_count++] = mapping;
+    }
+    status = iree_status_join(status, unmap_status);
   }
+  executor->virtual_memory_mapping_count = retained_mapping_count;
+  if (!iree_status_is_ok(status)) return status;
+
+  // Release leaf objects before queue, allocator, and device roots regardless
+  // of replay object id assignment. Queue-allocated buffers borrow state from
+  // the queue's replay pool and must all be gone before that pool is released.
+  iree_status_t object_status = iree_ok_status();
+  for (iree_host_size_t i = executor->object_capacity; i > 0; --i) {
+    const iree_hal_replay_object_type_t type = executor->objects[i - 1].type;
+    if (type == IREE_HAL_REPLAY_OBJECT_TYPE_QUEUE ||
+        type == IREE_HAL_REPLAY_OBJECT_TYPE_ALLOCATOR ||
+        type == IREE_HAL_REPLAY_OBJECT_TYPE_DEVICE) {
+      continue;
+    }
+    object_status = iree_status_join(
+        object_status, iree_hal_replay_executor_release_entry(
+                           executor, i - 1, &executor->objects[i - 1]));
+  }
+  if (!iree_status_is_ok(object_status)) return object_status;
+  for (iree_host_size_t i = executor->object_capacity; i > 0; --i) {
+    if (executor->objects[i - 1].type != IREE_HAL_REPLAY_OBJECT_TYPE_QUEUE) {
+      continue;
+    }
+    object_status = iree_status_join(
+        object_status, iree_hal_replay_executor_release_entry(
+                           executor, i - 1, &executor->objects[i - 1]));
+  }
+  if (!iree_status_is_ok(object_status)) return object_status;
+  for (iree_host_size_t i = executor->object_capacity; i > 0; --i) {
+    if (executor->objects[i - 1].type !=
+        IREE_HAL_REPLAY_OBJECT_TYPE_ALLOCATOR) {
+      continue;
+    }
+    object_status = iree_status_join(
+        object_status, iree_hal_replay_executor_release_entry(
+                           executor, i - 1, &executor->objects[i - 1]));
+  }
+  if (!iree_status_is_ok(object_status)) return object_status;
+  for (iree_host_size_t i = executor->object_capacity; i > 0; --i) {
+    if (executor->objects[i - 1].type != IREE_HAL_REPLAY_OBJECT_TYPE_DEVICE) {
+      continue;
+    }
+    object_status = iree_status_join(
+        object_status, iree_hal_replay_executor_release_entry(
+                           executor, i - 1, &executor->objects[i - 1]));
+  }
+  if (!iree_status_is_ok(object_status)) return object_status;
   iree_allocator_free(executor->host_allocator, executor->objects);
   executor->objects = NULL;
   executor->object_capacity = 0;
+  iree_allocator_free(executor->host_allocator,
+                      executor->virtual_memory_mappings);
+  executor->virtual_memory_mappings = NULL;
+  executor->virtual_memory_mapping_count = 0;
+  executor->virtual_memory_mapping_capacity = 0;
+  iree_hal_device_group_release(executor->device_group);
+  executor->device_group = NULL;
+  return iree_ok_status();
 }
 
 iree_status_t iree_hal_replay_executor_lookup(
@@ -88,21 +194,258 @@ iree_status_t iree_hal_replay_executor_store(
   entry.type = object_type;
   if (IREE_UNLIKELY(object_id == IREE_HAL_REPLAY_OBJECT_ID_NONE ||
                     object_id >= executor->object_capacity)) {
-    iree_hal_replay_executor_release_entry(executor, &entry);
-    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
-                            "replay object id %" PRIu64
-                            " exceeds object table capacity",
-                            object_id);
+    iree_status_t status = iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                                            "replay object id %" PRIu64
+                                            " exceeds object table capacity",
+                                            object_id);
+    return iree_status_join(
+        status, iree_hal_replay_executor_release_entry(
+                    executor, IREE_HAL_REPLAY_OBJECT_ID_NONE, &entry));
   }
   iree_hal_replay_object_entry_t* existing = &executor->objects[object_id];
   if (existing->type != IREE_HAL_REPLAY_OBJECT_TYPE_NONE) {
-    iree_hal_replay_executor_release_entry(executor, &entry);
-    return iree_make_status(IREE_STATUS_ALREADY_EXISTS,
-                            "replay object id %" PRIu64 " is already assigned",
-                            object_id);
+    iree_status_t status = iree_make_status(
+        IREE_STATUS_ALREADY_EXISTS,
+        "replay object id %" PRIu64 " is already assigned", object_id);
+    return iree_status_join(
+        status, iree_hal_replay_executor_release_entry(
+                    executor, IREE_HAL_REPLAY_OBJECT_ID_NONE, &entry));
   }
   *existing = entry;
   return iree_ok_status();
+}
+
+iree_status_t iree_hal_replay_executor_forget(
+    iree_hal_replay_executor_t* executor, iree_hal_replay_object_id_t object_id,
+    iree_hal_replay_object_type_t expected_type) {
+  iree_hal_replay_object_entry_t* entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(executor, object_id,
+                                                       expected_type, &entry));
+  iree_hal_allocator_release(entry->owning_allocator);
+  memset(entry, 0, sizeof(*entry));
+  return iree_ok_status();
+}
+
+static iree_status_t
+iree_hal_replay_executor_reserve_virtual_memory_mapping_capacity(
+    iree_hal_replay_executor_t* executor, iree_host_size_t minimum_capacity) {
+  if (minimum_capacity <= executor->virtual_memory_mapping_capacity) {
+    return iree_ok_status();
+  }
+  iree_host_size_t new_capacity =
+      executor->virtual_memory_mapping_capacity
+          ? executor->virtual_memory_mapping_capacity
+          : 8;
+  while (new_capacity < minimum_capacity) {
+    if (IREE_UNLIKELY(
+            !iree_host_size_checked_mul(new_capacity, 2, &new_capacity))) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "replay VMM mapping capacity overflow");
+    }
+  }
+  iree_host_size_t allocation_size = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+          new_capacity, sizeof(*executor->virtual_memory_mappings),
+          &allocation_size))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "replay VMM mapping table size overflow");
+  }
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_realloc(executor->host_allocator, allocation_size,
+                             (void**)&executor->virtual_memory_mappings));
+  executor->virtual_memory_mapping_capacity = new_capacity;
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_replay_executor_map_virtual_memory(
+    iree_hal_replay_executor_t* executor, iree_hal_allocator_t* allocator,
+    iree_hal_replay_object_id_t virtual_buffer_id,
+    iree_hal_replay_object_id_t physical_memory_id,
+    iree_device_size_t virtual_offset, iree_device_size_t physical_offset,
+    iree_device_size_t size) {
+  if (IREE_UNLIKELY(size == 0 || virtual_offset + size < virtual_offset ||
+                    physical_offset + size < physical_offset)) {
+    return iree_make_status(IREE_STATUS_DATA_LOSS,
+                            "replay virtual memory map range is invalid");
+  }
+  iree_hal_replay_object_entry_t* virtual_buffer_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(
+      executor, virtual_buffer_id, IREE_HAL_REPLAY_OBJECT_TYPE_BUFFER,
+      &virtual_buffer_entry));
+  iree_hal_replay_object_entry_t* physical_memory_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(
+      executor, physical_memory_id, IREE_HAL_REPLAY_OBJECT_TYPE_PHYSICAL_MEMORY,
+      &physical_memory_entry));
+  if (IREE_UNLIKELY(virtual_buffer_entry->owning_allocator != allocator ||
+                    physical_memory_entry->owning_allocator != allocator)) {
+    return iree_make_status(
+        IREE_STATUS_DATA_LOSS,
+        "replay virtual and physical memory must share an allocator");
+  }
+
+  const iree_device_size_t virtual_end = virtual_offset + size;
+  for (iree_host_size_t i = 0; i < executor->virtual_memory_mapping_count;
+       ++i) {
+    const iree_hal_replay_virtual_memory_mapping_t* mapping =
+        &executor->virtual_memory_mappings[i];
+    if (mapping->virtual_buffer_id == virtual_buffer_id &&
+        virtual_offset < mapping->virtual_offset + mapping->size &&
+        mapping->virtual_offset < virtual_end) {
+      return iree_make_status(
+          IREE_STATUS_DATA_LOSS,
+          "replay virtual memory map overlaps a live mapping");
+    }
+  }
+  iree_host_size_t required_capacity = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_add(
+          executor->virtual_memory_mapping_count, 1, &required_capacity))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "replay VMM mapping count overflow");
+  }
+  IREE_RETURN_IF_ERROR(
+      iree_hal_replay_executor_reserve_virtual_memory_mapping_capacity(
+          executor, required_capacity));
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_virtual_memory_map(
+      allocator, virtual_buffer_entry->value.buffer, virtual_offset,
+      physical_memory_entry->value.physical_memory.handle, physical_offset,
+      size));
+  executor->virtual_memory_mappings[executor->virtual_memory_mapping_count++] =
+      (iree_hal_replay_virtual_memory_mapping_t){
+          .virtual_buffer_id = virtual_buffer_id,
+          .physical_memory_id = physical_memory_id,
+          .virtual_offset = virtual_offset,
+          .physical_offset = physical_offset,
+          .size = size,
+      };
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_replay_executor_unmap_virtual_memory(
+    iree_hal_replay_executor_t* executor, iree_hal_allocator_t* allocator,
+    iree_hal_replay_object_id_t virtual_buffer_id,
+    iree_device_size_t virtual_offset, iree_device_size_t size) {
+  if (IREE_UNLIKELY(size == 0 || virtual_offset + size < virtual_offset)) {
+    return iree_make_status(IREE_STATUS_DATA_LOSS,
+                            "replay virtual memory unmap range is invalid");
+  }
+  iree_hal_replay_object_entry_t* virtual_buffer_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(
+      executor, virtual_buffer_id, IREE_HAL_REPLAY_OBJECT_TYPE_BUFFER,
+      &virtual_buffer_entry));
+  if (IREE_UNLIKELY(virtual_buffer_entry->owning_allocator != allocator)) {
+    return iree_make_status(
+        IREE_STATUS_DATA_LOSS,
+        "replay virtual memory reservation belongs to another allocator");
+  }
+
+  const iree_device_size_t virtual_end = virtual_offset + size;
+  iree_host_size_t replacement_capacity = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_add(
+          executor->virtual_memory_mapping_count, 1, &replacement_capacity))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "replay VMM mapping count overflow");
+  }
+  iree_host_size_t allocation_size = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+          replacement_capacity, sizeof(*executor->virtual_memory_mappings),
+          &allocation_size))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "replay VMM mapping table size overflow");
+  }
+  iree_hal_replay_virtual_memory_mapping_t* replacement_mappings = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(executor->host_allocator,
+                                             allocation_size,
+                                             (void**)&replacement_mappings));
+
+  iree_device_size_t covered_size = 0;
+  iree_host_size_t replacement_count = 0;
+  for (iree_host_size_t i = 0; i < executor->virtual_memory_mapping_count;
+       ++i) {
+    const iree_hal_replay_virtual_memory_mapping_t mapping =
+        executor->virtual_memory_mappings[i];
+    const iree_device_size_t mapping_end =
+        mapping.virtual_offset + mapping.size;
+    if (mapping.virtual_buffer_id != virtual_buffer_id ||
+        mapping_end <= virtual_offset ||
+        virtual_end <= mapping.virtual_offset) {
+      replacement_mappings[replacement_count++] = mapping;
+      continue;
+    }
+
+    const iree_device_size_t intersection_start =
+        iree_max(mapping.virtual_offset, virtual_offset);
+    const iree_device_size_t intersection_end =
+        iree_min(mapping_end, virtual_end);
+    const iree_device_size_t intersection_size =
+        intersection_end - intersection_start;
+    if (IREE_UNLIKELY(covered_size + intersection_size < covered_size)) {
+      iree_allocator_free(executor->host_allocator, replacement_mappings);
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "replay VMM unmap coverage overflow");
+    }
+    covered_size += intersection_size;
+    if (mapping.virtual_offset < virtual_offset) {
+      iree_hal_replay_virtual_memory_mapping_t prefix = mapping;
+      prefix.size = virtual_offset - mapping.virtual_offset;
+      replacement_mappings[replacement_count++] = prefix;
+    }
+    if (virtual_end < mapping_end) {
+      iree_hal_replay_virtual_memory_mapping_t suffix = mapping;
+      suffix.physical_offset += virtual_end - mapping.virtual_offset;
+      suffix.virtual_offset = virtual_end;
+      suffix.size = mapping_end - virtual_end;
+      replacement_mappings[replacement_count++] = suffix;
+    }
+  }
+
+  if (IREE_UNLIKELY(covered_size != size)) {
+    iree_allocator_free(executor->host_allocator, replacement_mappings);
+    return iree_make_status(
+        IREE_STATUS_DATA_LOSS,
+        "replay virtual memory unmap range is not fully mapped");
+  }
+  iree_status_t status =
+      iree_hal_replay_executor_drain_queue_completions(executor);
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_allocator_virtual_memory_unmap(
+        allocator, virtual_buffer_entry->value.buffer, virtual_offset, size);
+  }
+  if (!iree_status_is_ok(status)) {
+    iree_allocator_free(executor->host_allocator, replacement_mappings);
+    return status;
+  }
+  iree_allocator_free(executor->host_allocator,
+                      executor->virtual_memory_mappings);
+  executor->virtual_memory_mappings = replacement_mappings;
+  executor->virtual_memory_mapping_count = replacement_count;
+  executor->virtual_memory_mapping_capacity = replacement_capacity;
+  return iree_ok_status();
+}
+
+bool iree_hal_replay_executor_has_virtual_memory_mapping(
+    const iree_hal_replay_executor_t* executor,
+    iree_hal_replay_object_id_t virtual_buffer_id) {
+  for (iree_host_size_t i = 0; i < executor->virtual_memory_mapping_count;
+       ++i) {
+    if (executor->virtual_memory_mappings[i].virtual_buffer_id ==
+        virtual_buffer_id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool iree_hal_replay_executor_has_physical_memory_mapping(
+    const iree_hal_replay_executor_t* executor,
+    iree_hal_replay_object_id_t physical_memory_id) {
+  for (iree_host_size_t i = 0; i < executor->virtual_memory_mapping_count;
+       ++i) {
+    if (executor->virtual_memory_mappings[i].physical_memory_id ==
+        physical_memory_id) {
+      return true;
+    }
+  }
+  return false;
 }
 
 iree_status_t iree_hal_replay_executor_allocate_function_map(
@@ -154,7 +497,11 @@ iree_status_t iree_hal_replay_executor_initialize(
   executor->host_allocator = host_allocator;
   executor->options = options;
   executor->object_capacity = object_capacity;
-  if (executor->object_capacity == 0) return iree_ok_status();
+  if (executor->object_capacity == 0) {
+    executor->device_group = device_group;
+    iree_hal_device_group_retain(executor->device_group);
+    return iree_ok_status();
+  }
   iree_host_size_t object_table_size = 0;
   if (IREE_UNLIKELY(!iree_host_size_checked_mul(executor->object_capacity,
                                                 sizeof(*executor->objects),
@@ -165,6 +512,8 @@ iree_status_t iree_hal_replay_executor_initialize(
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(host_allocator, object_table_size,
                                              (void**)&executor->objects));
   memset(executor->objects, 0, object_table_size);
+  executor->device_group = device_group;
+  iree_hal_device_group_retain(executor->device_group);
   return iree_ok_status();
 }
 
@@ -261,11 +610,11 @@ void iree_hal_replay_semaphore_list_storage_deinitialize(
 
 iree_status_t iree_hal_replay_executor_make_semaphore_list(
     iree_hal_replay_executor_t* executor, iree_const_byte_span_t payloads,
-    iree_host_size_t count,
+    iree_host_size_t count, iree_host_size_t additional_capacity,
     iree_hal_replay_semaphore_list_storage_t* out_storage) {
   memset(out_storage, 0, sizeof(*out_storage));
-  if (count == 0) return iree_ok_status();
   iree_host_size_t expected_length = 0;
+  iree_host_size_t capacity = 0;
   if (IREE_UNLIKELY(!iree_host_size_checked_mul(
                         count,
                         sizeof(iree_hal_replay_semaphore_timepoint_payload_t),
@@ -274,18 +623,33 @@ iree_status_t iree_hal_replay_executor_make_semaphore_list(
     return iree_make_status(IREE_STATUS_DATA_LOSS,
                             "replay semaphore list payload length mismatch");
   }
+  if (IREE_UNLIKELY(
+          !iree_host_size_checked_add(count, additional_capacity, &capacity))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "replay semaphore list capacity overflow");
+  }
+  if (capacity == 0) return iree_ok_status();
   iree_status_t status = iree_ok_status();
-  if (count <= IREE_HAL_REPLAY_INLINE_SEMAPHORE_LIST_CAPACITY) {
+  if (capacity <= IREE_HAL_REPLAY_INLINE_SEMAPHORE_LIST_CAPACITY) {
     out_storage->semaphores = out_storage->inline_storage.semaphores;
     out_storage->payload_values = out_storage->inline_storage.payload_values;
   } else {
-    status = iree_allocator_malloc(executor->host_allocator,
-                                   count * sizeof(*out_storage->semaphores),
+    iree_host_size_t semaphores_size = 0;
+    iree_host_size_t payload_values_size = 0;
+    if (IREE_UNLIKELY(
+            !iree_host_size_checked_mul(
+                capacity, sizeof(*out_storage->semaphores), &semaphores_size) ||
+            !iree_host_size_checked_mul(capacity,
+                                        sizeof(*out_storage->payload_values),
+                                        &payload_values_size))) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "replay semaphore list allocation overflow");
+    }
+    status = iree_allocator_malloc(executor->host_allocator, semaphores_size,
                                    (void**)&out_storage->allocated.semaphores);
     if (iree_status_is_ok(status)) {
       status =
-          iree_allocator_malloc(executor->host_allocator,
-                                count * sizeof(*out_storage->payload_values),
+          iree_allocator_malloc(executor->host_allocator, payload_values_size,
                                 (void**)&out_storage->allocated.payload_values);
     }
     if (iree_status_is_ok(status)) {
@@ -361,11 +725,13 @@ iree_status_t iree_hal_replay_executor_make_queue_semaphore_lists(
   const uint8_t* cursor = record->payload.data + header_length;
   IREE_RETURN_IF_ERROR(iree_hal_replay_executor_make_semaphore_list(
       executor, iree_make_const_byte_span(cursor, wait_size),
-      (iree_host_size_t)wait_semaphore_count, out_wait_storage));
+      (iree_host_size_t)wait_semaphore_count, /*additional_capacity=*/0,
+      out_wait_storage));
   cursor += wait_size;
   iree_status_t status = iree_hal_replay_executor_make_semaphore_list(
       executor, iree_make_const_byte_span(cursor, signal_size),
-      (iree_host_size_t)signal_semaphore_count, out_signal_storage);
+      (iree_host_size_t)signal_semaphore_count, /*additional_capacity=*/1,
+      out_signal_storage);
   cursor += signal_size;
   if (!iree_status_is_ok(status)) {
     iree_hal_replay_semaphore_list_storage_deinitialize(
@@ -439,12 +805,133 @@ iree_status_t iree_hal_replay_buffer_binding_table_storage_initialize(
   return iree_ok_status();
 }
 
-iree_status_t iree_hal_replay_executor_flush_queue_and_wait(
-    iree_hal_queue_t* queue, const iree_hal_semaphore_list_t signal_list) {
-  IREE_RETURN_IF_ERROR(iree_hal_queue_flush(queue));
-  if (signal_list.count == 0) return iree_ok_status();
-  return iree_hal_semaphore_list_wait(signal_list, iree_infinite_timeout(),
-                                      IREE_ASYNC_WAIT_FLAG_NONE);
+static iree_status_t iree_hal_replay_executor_reserve_queue_completion_capacity(
+    iree_hal_replay_executor_t* executor, iree_host_size_t minimum_capacity) {
+  if (minimum_capacity <= executor->queue_completion_capacity) {
+    return iree_ok_status();
+  }
+  iree_host_size_t new_capacity = executor->queue_completion_capacity
+                                      ? executor->queue_completion_capacity
+                                      : 4;
+  while (new_capacity < minimum_capacity) {
+    if (IREE_UNLIKELY(
+            !iree_host_size_checked_mul(new_capacity, 2, &new_capacity))) {
+      return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                              "replay queue completion capacity overflow");
+    }
+  }
+  iree_host_size_t allocation_size = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_mul(
+          new_capacity, sizeof(*executor->queue_completions),
+          &allocation_size))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "replay queue completion table size overflow");
+  }
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_realloc(executor->host_allocator, allocation_size,
+                             (void**)&executor->queue_completions));
+  executor->queue_completion_capacity = new_capacity;
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_replay_executor_prepare_queue_completion(
+    iree_hal_replay_executor_t* executor, iree_hal_device_t* device,
+    iree_hal_queue_t* queue,
+    iree_hal_replay_semaphore_list_storage_t* signal_storage,
+    iree_hal_replay_queue_completion_t** out_completion) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_ASSERT_ARGUMENT(queue);
+  IREE_ASSERT_ARGUMENT(signal_storage);
+  IREE_ASSERT_ARGUMENT(out_completion);
+  *out_completion = NULL;
+  iree_host_size_t required_capacity = 0;
+  if (IREE_UNLIKELY(!iree_host_size_checked_add(
+          executor->queue_completion_count, 1, &required_capacity))) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "replay queue completion count overflow");
+  }
+  IREE_RETURN_IF_ERROR(
+      iree_hal_replay_executor_reserve_queue_completion_capacity(
+          executor, required_capacity));
+  iree_hal_replay_queue_completion_t* completion =
+      &executor->queue_completions[executor->queue_completion_count];
+  memset(completion, 0, sizeof(*completion));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_create(
+      device,
+      iree_hal_make_queue_family_affinity(
+          iree_hal_queue_family_ordinal(iree_hal_queue_family(queue))),
+      /*initial_value=*/0, IREE_HAL_SEMAPHORE_FLAG_DEFAULT,
+      &completion->semaphore));
+  completion->queue = queue;
+  completion->value = 1;
+  completion->wait_immediately = signal_storage->list.count != 0;
+  const iree_host_size_t signal_index = signal_storage->list.count++;
+  signal_storage->semaphores[signal_index] = completion->semaphore;
+  signal_storage->payload_values[signal_index] = completion->value;
+  *out_completion = completion;
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_replay_executor_finalize_queue_completion(
+    iree_hal_replay_executor_t* executor,
+    iree_hal_replay_queue_completion_t* completion, bool flush_queue,
+    iree_status_t operation_status) {
+  if (!completion) return operation_status;
+  if (!iree_status_is_ok(operation_status)) {
+    iree_allocator_free(executor->host_allocator,
+                        completion->retained_host_allocation);
+    iree_hal_semaphore_release(completion->semaphore);
+    memset(completion, 0, sizeof(*completion));
+    return operation_status;
+  }
+  IREE_ASSERT(completion ==
+              &executor->queue_completions[executor->queue_completion_count]);
+  ++executor->queue_completion_count;
+  iree_status_ignore(operation_status);
+  iree_status_t status =
+      flush_queue ? iree_hal_queue_flush(completion->queue) : iree_ok_status();
+  if (!iree_status_is_ok(status) || !completion->wait_immediately) {
+    return status;
+  }
+  status = iree_hal_semaphore_wait(completion->semaphore, completion->value,
+                                   iree_infinite_timeout(),
+                                   IREE_ASYNC_WAIT_FLAG_NONE);
+  if (!iree_status_is_ok(status)) return status;
+  iree_allocator_free(executor->host_allocator,
+                      completion->retained_host_allocation);
+  iree_hal_semaphore_release(completion->semaphore);
+  memset(completion, 0, sizeof(*completion));
+  --executor->queue_completion_count;
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_replay_executor_drain_queue_completions(
+    iree_hal_replay_executor_t* executor) {
+  iree_status_t status = iree_ok_status();
+  for (iree_host_size_t i = 0; i < executor->queue_completion_count; ++i) {
+    status = iree_status_join(
+        status, iree_hal_queue_flush(executor->queue_completions[i].queue));
+  }
+  if (!iree_status_is_ok(status)) return status;
+  for (iree_host_size_t i = 0; i < executor->queue_completion_count; ++i) {
+    iree_hal_replay_queue_completion_t* completion =
+        &executor->queue_completions[i];
+    status = iree_status_join(
+        status, iree_hal_semaphore_wait(
+                    completion->semaphore, completion->value,
+                    iree_infinite_timeout(), IREE_ASYNC_WAIT_FLAG_NONE));
+  }
+  if (!iree_status_is_ok(status)) return status;
+  for (iree_host_size_t i = 0; i < executor->queue_completion_count; ++i) {
+    iree_hal_replay_queue_completion_t* completion =
+        &executor->queue_completions[i];
+    iree_allocator_free(executor->host_allocator,
+                        completion->retained_host_allocation);
+    iree_hal_semaphore_release(completion->semaphore);
+    memset(completion, 0, sizeof(*completion));
+  }
+  executor->queue_completion_count = 0;
+  return iree_ok_status();
 }
 
 iree_status_t iree_hal_replay_executor_dispatch_layout(

--- a/runtime/src/iree/hal/replay/execute_state.h
+++ b/runtime/src/iree/hal/replay/execute_state.h
@@ -28,10 +28,18 @@ typedef struct iree_hal_replay_executable_entry_t {
   iree_hal_executable_function_t* function_map;
 } iree_hal_replay_executable_entry_t;
 
+// Allocator-owned opaque physical memory reconstructed for replay.
+typedef struct iree_hal_replay_physical_memory_entry_t {
+  // Live physical memory handle owned by the enclosing entry's allocator.
+  iree_hal_physical_memory_t* handle;
+} iree_hal_replay_physical_memory_entry_t;
+
 // One retained object in the dense replay object table.
 typedef struct iree_hal_replay_object_entry_t {
   // Captured object type stored in this entry.
   iree_hal_replay_object_type_t type;
+  // Retained allocator owning a VMM reservation or physical allocation.
+  iree_hal_allocator_t* owning_allocator;
   // Retained HAL resource or executable state selected by |type|.
   union {
     // Retained HAL device.
@@ -50,11 +58,41 @@ typedef struct iree_hal_replay_object_entry_t {
     iree_hal_file_t* file;
     // Retained exact HAL queue.
     iree_hal_queue_t* queue;
+    // Allocator-owned opaque physical memory state.
+    iree_hal_replay_physical_memory_entry_t physical_memory;
   } value;
   // Lazily created functional-replay pool for a queue object, or NULL.
   // Buffer entries and every other object type leave this field NULL.
   iree_hal_pool_t* queue_allocation_pool;
 } iree_hal_replay_object_entry_t;
+
+// One live virtual-to-physical range reconstructed during replay.
+typedef struct iree_hal_replay_virtual_memory_mapping_t {
+  // Stable replay object id of the virtual address reservation.
+  iree_hal_replay_object_id_t virtual_buffer_id;
+  // Stable replay object id of the backing physical allocation.
+  iree_hal_replay_object_id_t physical_memory_id;
+  // Byte offset of the mapped range in the virtual reservation.
+  iree_device_size_t virtual_offset;
+  // Byte offset of the mapped range in the physical allocation.
+  iree_device_size_t physical_offset;
+  // Byte length of the mapped range.
+  iree_device_size_t size;
+} iree_hal_replay_virtual_memory_mapping_t;
+
+// Executor-private completion attached to one accepted exact-queue operation.
+typedef struct iree_hal_replay_queue_completion_t {
+  // Borrowed exact queue retained by the replay object table.
+  iree_hal_queue_t* queue;
+  // Retained private semaphore signaled by the accepted queue operation.
+  iree_hal_semaphore_t* semaphore;
+  // Semaphore timeline value signaling completion of the operation.
+  uint64_t value;
+  // Host allocation borrowed by the operation until terminal completion.
+  void* retained_host_allocation;
+  // True when public signal ordering or borrowed host data requires a wait.
+  bool wait_immediately;
+} iree_hal_replay_queue_completion_t;
 
 // Mutable state owned by one prepared-plan execution.
 typedef struct iree_hal_replay_executor_t {
@@ -70,6 +108,18 @@ typedef struct iree_hal_replay_executor_t {
   iree_hal_replay_object_entry_t* objects;
   // Number of entries in |objects|.
   iree_host_size_t object_capacity;
+  // Live VMM ranges that retain their reservation and physical dependencies.
+  iree_hal_replay_virtual_memory_mapping_t* virtual_memory_mappings;
+  // Number of entries in |virtual_memory_mappings|.
+  iree_host_size_t virtual_memory_mapping_count;
+  // Allocated entry capacity of |virtual_memory_mappings|.
+  iree_host_size_t virtual_memory_mapping_capacity;
+  // Private completion timepoints for accepted exact-queue submissions.
+  iree_hal_replay_queue_completion_t* queue_completions;
+  // Number of entries in |queue_completions|.
+  iree_host_size_t queue_completion_count;
+  // Allocated entry capacity of |queue_completions|.
+  iree_host_size_t queue_completion_capacity;
   // Next caller-provided device consumed by a device object record.
   iree_host_size_t next_device_index;
 } iree_hal_replay_executor_t;
@@ -143,7 +193,7 @@ iree_status_t iree_hal_replay_executor_initialize(
     const iree_hal_replay_execute_options_t* options,
     iree_allocator_t host_allocator);
 
-void iree_hal_replay_executor_deinitialize(
+iree_status_t iree_hal_replay_executor_deinitialize(
     iree_hal_replay_executor_t* executor);
 
 iree_status_t iree_hal_replay_executor_lookup(
@@ -155,6 +205,36 @@ iree_status_t iree_hal_replay_executor_store(
     iree_hal_replay_executor_t* executor, iree_hal_replay_object_id_t object_id,
     iree_hal_replay_object_type_t object_type,
     iree_hal_replay_object_entry_t entry);
+
+// Removes an allocator-consumed object without releasing its handle again.
+iree_status_t iree_hal_replay_executor_forget(
+    iree_hal_replay_executor_t* executor, iree_hal_replay_object_id_t object_id,
+    iree_hal_replay_object_type_t expected_type);
+
+// Maps memory and records the live range only after backend acceptance.
+iree_status_t iree_hal_replay_executor_map_virtual_memory(
+    iree_hal_replay_executor_t* executor, iree_hal_allocator_t* allocator,
+    iree_hal_replay_object_id_t virtual_buffer_id,
+    iree_hal_replay_object_id_t physical_memory_id,
+    iree_device_size_t virtual_offset, iree_device_size_t physical_offset,
+    iree_device_size_t size);
+
+// Drains exact queues, unmaps memory, and removes only successfully unmapped
+// coverage from the live range ledger.
+iree_status_t iree_hal_replay_executor_unmap_virtual_memory(
+    iree_hal_replay_executor_t* executor, iree_hal_allocator_t* allocator,
+    iree_hal_replay_object_id_t virtual_buffer_id,
+    iree_device_size_t virtual_offset, iree_device_size_t size);
+
+// Returns true when a reservation still has live replay mappings.
+bool iree_hal_replay_executor_has_virtual_memory_mapping(
+    const iree_hal_replay_executor_t* executor,
+    iree_hal_replay_object_id_t virtual_buffer_id);
+
+// Returns true when a physical allocation still backs live replay mappings.
+bool iree_hal_replay_executor_has_physical_memory_mapping(
+    const iree_hal_replay_executor_t* executor,
+    iree_hal_replay_object_id_t physical_memory_id);
 
 iree_status_t iree_hal_replay_executor_allocate_function_map(
     iree_hal_replay_executor_t* executor, iree_host_size_t function_count,
@@ -190,7 +270,7 @@ void iree_hal_replay_semaphore_list_storage_deinitialize(
 
 iree_status_t iree_hal_replay_executor_make_semaphore_list(
     iree_hal_replay_executor_t* executor, iree_const_byte_span_t payloads,
-    iree_host_size_t count,
+    iree_host_size_t count, iree_host_size_t additional_capacity,
     iree_hal_replay_semaphore_list_storage_t* out_storage);
 
 iree_status_t iree_hal_replay_executor_make_queue_semaphore_lists(
@@ -218,8 +298,23 @@ iree_status_t iree_hal_replay_buffer_binding_table_storage_initialize(
     iree_hal_replay_executor_t* executor, iree_host_size_t count,
     iree_hal_replay_buffer_binding_table_storage_t* out_storage);
 
-iree_status_t iree_hal_replay_executor_flush_queue_and_wait(
-    iree_hal_queue_t* queue, const iree_hal_semaphore_list_t signal_list);
+// Appends a fresh private completion timepoint before a queue submission.
+iree_status_t iree_hal_replay_executor_prepare_queue_completion(
+    iree_hal_replay_executor_t* executor, iree_hal_device_t* device,
+    iree_hal_queue_t* queue,
+    iree_hal_replay_semaphore_list_storage_t* signal_storage,
+    iree_hal_replay_queue_completion_t** out_completion);
+
+// Consumes |operation_status|, retaining only accepted submissions for drain.
+iree_status_t iree_hal_replay_executor_finalize_queue_completion(
+    iree_hal_replay_executor_t* executor,
+    iree_hal_replay_queue_completion_t* completion, bool flush_queue,
+    iree_status_t operation_status);
+
+// Flushes and waits for every accepted exact-queue submission since the last
+// successful drain.
+iree_status_t iree_hal_replay_executor_drain_queue_completions(
+    iree_hal_replay_executor_t* executor);
 
 iree_status_t iree_hal_replay_executor_dispatch_layout(
     const iree_hal_replay_file_record_t* record,

--- a/runtime/src/iree/hal/replay/execute_test.cc
+++ b/runtime/src/iree/hal/replay/execute_test.cc
@@ -19,6 +19,7 @@
 #include "iree/hal/drivers/task/registration/driver_module.h"
 #include "iree/hal/memory/passthrough_pool.h"
 #include "iree/hal/replay/file_reader.h"
+#include "iree/hal/replay/file_writer.h"
 #include "iree/hal/replay/recorder.h"
 #include "iree/hal/testing/mock_device.h"
 #include "iree/io/file_contents.h"
@@ -129,6 +130,515 @@ static iree_const_byte_span_t GetCapturedFileContents(
                                    (iree_host_size_t)file_header.file_length);
 }
 
+static void AppendReplayRecord(
+    iree_hal_replay_file_writer_t* writer,
+    const iree_hal_replay_file_record_metadata_t& metadata,
+    std::initializer_list<iree_const_byte_span_t> payload_iovecs) {
+  IREE_CHECK_OK(iree_hal_replay_file_writer_append_record(
+      writer, &metadata, payload_iovecs.size(), payload_iovecs.begin(),
+      /*out_payload_range=*/nullptr));
+}
+
+static void AppendDeviceObjectRecord(iree_hal_replay_file_writer_t* writer,
+                                     uint64_t sequence_ordinal,
+                                     iree_hal_replay_object_id_t device_id) {
+  const iree_hal_replay_file_record_metadata_t metadata = {
+      /*.sequence_ordinal=*/sequence_ordinal,
+      /*.thread_id=*/0,
+      /*.device_id=*/device_id,
+      /*.object_id=*/device_id,
+      /*.related_object_id=*/IREE_HAL_REPLAY_OBJECT_ID_NONE,
+      /*.record_type=*/IREE_HAL_REPLAY_FILE_RECORD_TYPE_OBJECT,
+      /*.record_flags=*/IREE_HAL_REPLAY_FILE_RECORD_FLAG_NONE,
+      /*.payload_type=*/IREE_HAL_REPLAY_PAYLOAD_TYPE_NONE,
+      /*.object_type=*/IREE_HAL_REPLAY_OBJECT_TYPE_DEVICE,
+      /*.operation_code=*/IREE_HAL_REPLAY_OPERATION_CODE_NONE,
+      /*.status_code=*/IREE_STATUS_OK,
+  };
+  AppendReplayRecord(writer, metadata, {});
+}
+
+static void AppendQueueObjectRecord(iree_hal_replay_file_writer_t* writer,
+                                    uint64_t sequence_ordinal,
+                                    iree_hal_replay_object_id_t device_id,
+                                    iree_hal_replay_object_id_t queue_id,
+                                    uint32_t queue_ordinal) {
+  const iree_hal_replay_provisioned_queue_object_payload_t payload = {
+      /*.family_ordinal=*/0,
+      /*.queue_ordinal=*/queue_ordinal,
+      /*.reserved0=*/0,
+  };
+  const iree_hal_replay_file_record_metadata_t metadata = {
+      /*.sequence_ordinal=*/sequence_ordinal,
+      /*.thread_id=*/0,
+      /*.device_id=*/device_id,
+      /*.object_id=*/queue_id,
+      /*.related_object_id=*/IREE_HAL_REPLAY_OBJECT_ID_NONE,
+      /*.record_type=*/IREE_HAL_REPLAY_FILE_RECORD_TYPE_OBJECT,
+      /*.record_flags=*/IREE_HAL_REPLAY_FILE_RECORD_FLAG_NONE,
+      /*.payload_type=*/IREE_HAL_REPLAY_PAYLOAD_TYPE_PROVISIONED_QUEUE_OBJECT,
+      /*.object_type=*/IREE_HAL_REPLAY_OBJECT_TYPE_QUEUE,
+      /*.operation_code=*/IREE_HAL_REPLAY_OPERATION_CODE_NONE,
+      /*.status_code=*/IREE_STATUS_OK,
+  };
+  AppendReplayRecord(writer, metadata,
+                     {iree_make_const_byte_span(&payload, sizeof(payload))});
+}
+
+static void AppendSemaphoreCreateRecord(
+    iree_hal_replay_file_writer_t* writer, uint64_t sequence_ordinal,
+    iree_hal_replay_object_id_t device_id,
+    iree_hal_replay_object_id_t semaphore_id) {
+  const iree_hal_replay_semaphore_object_payload_t payload = {
+      /*.queue_family_affinity=*/iree_hal_make_queue_family_affinity(0),
+      /*.initial_value=*/0,
+      /*.flags=*/IREE_HAL_SEMAPHORE_FLAG_DEFAULT,
+      /*.reserved0=*/0,
+  };
+  const iree_hal_replay_file_record_metadata_t metadata = {
+      /*.sequence_ordinal=*/sequence_ordinal,
+      /*.thread_id=*/0,
+      /*.device_id=*/device_id,
+      /*.object_id=*/device_id,
+      /*.related_object_id=*/semaphore_id,
+      /*.record_type=*/IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION,
+      /*.record_flags=*/IREE_HAL_REPLAY_FILE_RECORD_FLAG_NONE,
+      /*.payload_type=*/IREE_HAL_REPLAY_PAYLOAD_TYPE_SEMAPHORE_OBJECT,
+      /*.object_type=*/IREE_HAL_REPLAY_OBJECT_TYPE_DEVICE,
+      /*.operation_code=*/
+      IREE_HAL_REPLAY_OPERATION_CODE_DEVICE_CREATE_SEMAPHORE,
+      /*.status_code=*/IREE_STATUS_OK,
+  };
+  AppendReplayRecord(writer, metadata,
+                     {iree_make_const_byte_span(&payload, sizeof(payload))});
+}
+
+static void AppendQueueBarrierRecord(iree_hal_replay_file_writer_t* writer,
+                                     uint64_t sequence_ordinal,
+                                     iree_hal_replay_object_id_t device_id,
+                                     iree_hal_replay_object_id_t queue_id,
+                                     iree_hal_replay_object_id_t semaphore_id,
+                                     bool is_wait) {
+  const iree_hal_replay_queue_barrier_payload_t payload = {
+      /*.flags=*/IREE_HAL_QUEUE_BARRIER_FLAG_NONE,
+      /*.wait_semaphore_count=*/is_wait ? 1u : 0u,
+      /*.signal_semaphore_count=*/is_wait ? 0u : 1u,
+      /*.reserved0=*/0,
+  };
+  const iree_hal_replay_semaphore_timepoint_payload_t timepoint = {
+      /*.semaphore_id=*/semaphore_id,
+      /*.value=*/1,
+  };
+  const iree_hal_replay_file_record_metadata_t metadata = {
+      /*.sequence_ordinal=*/sequence_ordinal,
+      /*.thread_id=*/0,
+      /*.device_id=*/device_id,
+      /*.object_id=*/queue_id,
+      /*.related_object_id=*/IREE_HAL_REPLAY_OBJECT_ID_NONE,
+      /*.record_type=*/IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION,
+      /*.record_flags=*/IREE_HAL_REPLAY_FILE_RECORD_FLAG_NONE,
+      /*.payload_type=*/IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_BARRIER,
+      /*.object_type=*/IREE_HAL_REPLAY_OBJECT_TYPE_QUEUE,
+      /*.operation_code=*/IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_BARRIER,
+      /*.status_code=*/IREE_STATUS_OK,
+  };
+  AppendReplayRecord(
+      writer, metadata,
+      {iree_make_const_byte_span(&payload, sizeof(payload)),
+       iree_make_const_byte_span(&timepoint, sizeof(timepoint))});
+}
+
+static void AppendQueueAtomicWaitRecord(iree_hal_replay_file_writer_t* writer,
+                                        uint64_t sequence_ordinal,
+                                        iree_hal_replay_object_id_t device_id,
+                                        iree_hal_replay_object_id_t queue_id) {
+  iree_hal_replay_queue_atomic_wait_payload_t payload = {};
+  payload.target_ref.buffer_id = queue_id + 10;
+  payload.target_ref.length = 4;
+  payload.params.value = 1;
+  payload.params.mask = UINT32_MAX;
+  payload.params.width = IREE_HAL_ATOMIC_WIDTH_32;
+  payload.params.condition = IREE_HAL_ATOMIC_WAIT_CONDITION_EQUAL;
+  const iree_hal_replay_file_record_metadata_t metadata = {
+      /*.sequence_ordinal=*/sequence_ordinal,
+      /*.thread_id=*/0,
+      /*.device_id=*/device_id,
+      /*.object_id=*/queue_id,
+      /*.related_object_id=*/payload.target_ref.buffer_id,
+      /*.record_type=*/IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION,
+      /*.record_flags=*/IREE_HAL_REPLAY_FILE_RECORD_FLAG_NONE,
+      /*.payload_type=*/IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_WAIT,
+      /*.object_type=*/IREE_HAL_REPLAY_OBJECT_TYPE_QUEUE,
+      /*.operation_code=*/IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_ATOMIC_WAIT,
+      /*.status_code=*/IREE_STATUS_OK,
+  };
+  AppendReplayRecord(writer, metadata,
+                     {iree_make_const_byte_span(&payload, sizeof(payload))});
+}
+
+static void AppendImmediateQueueTransferRecord(
+    iree_hal_replay_file_writer_t* writer, uint64_t sequence_ordinal,
+    iree_hal_replay_object_id_t device_id,
+    iree_hal_replay_object_id_t queue_id) {
+  const iree_hal_replay_queue_transfer_payload_t payload = {
+      /*.wait_semaphore_count=*/0,
+      /*.signal_semaphore_count=*/0,
+      /*.operation_count=*/1,
+      /*.data_length=*/0,
+  };
+  iree_hal_replay_queue_transfer_operation_payload_t operation = {};
+  operation.type = IREE_HAL_REPLAY_QUEUE_TRANSFER_OPERATION_TYPE_DOWNLOAD;
+  operation.source_ref.buffer_id = queue_id + 11;
+  operation.source_ref.length = 4;
+  const iree_hal_replay_file_record_metadata_t metadata = {
+      /*.sequence_ordinal=*/sequence_ordinal,
+      /*.thread_id=*/0,
+      /*.device_id=*/device_id,
+      /*.object_id=*/queue_id,
+      /*.related_object_id=*/IREE_HAL_REPLAY_OBJECT_ID_NONE,
+      /*.record_type=*/IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION,
+      /*.record_flags=*/IREE_HAL_REPLAY_FILE_RECORD_FLAG_NONE,
+      /*.payload_type=*/IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_TRANSFER,
+      /*.object_type=*/IREE_HAL_REPLAY_OBJECT_TYPE_QUEUE,
+      /*.operation_code=*/IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_TRANSFER,
+      /*.status_code=*/IREE_STATUS_OK,
+  };
+  AppendReplayRecord(
+      writer, metadata,
+      {iree_make_const_byte_span(&payload, sizeof(payload)),
+       iree_make_const_byte_span(&operation, sizeof(operation))});
+}
+
+static void AppendDispatchRecord(
+    iree_hal_replay_file_writer_t* writer, uint64_t sequence_ordinal,
+    iree_hal_replay_object_id_t device_id,
+    iree_hal_replay_object_id_t target_id,
+    iree_hal_replay_object_id_t executable_id,
+    iree_hal_replay_operation_code_t operation_code) {
+  iree_hal_replay_dispatch_payload_t payload = {};
+  payload.executable_id = executable_id;
+  payload.workgroup_size[0] = 1;
+  payload.workgroup_size[1] = 1;
+  payload.workgroup_size[2] = 1;
+  payload.workgroup_count[0] = 1;
+  payload.workgroup_count[1] = 1;
+  payload.workgroup_count[2] = 1;
+  const bool is_queue_dispatch =
+      operation_code == IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_DISPATCH;
+  const iree_hal_replay_file_record_metadata_t metadata = {
+      /*.sequence_ordinal=*/sequence_ordinal,
+      /*.thread_id=*/0,
+      /*.device_id=*/device_id,
+      /*.object_id=*/target_id,
+      /*.related_object_id=*/
+      is_queue_dispatch ? executable_id : IREE_HAL_REPLAY_OBJECT_ID_NONE,
+      /*.record_type=*/IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION,
+      /*.record_flags=*/IREE_HAL_REPLAY_FILE_RECORD_FLAG_NONE,
+      /*.payload_type=*/IREE_HAL_REPLAY_PAYLOAD_TYPE_DISPATCH,
+      /*.object_type=*/
+      static_cast<iree_hal_replay_object_type_t>(
+          is_queue_dispatch ? IREE_HAL_REPLAY_OBJECT_TYPE_QUEUE
+                            : IREE_HAL_REPLAY_OBJECT_TYPE_COMMAND_BUFFER),
+      /*.operation_code=*/operation_code,
+      /*.status_code=*/IREE_STATUS_OK,
+  };
+  AppendReplayRecord(writer, metadata,
+                     {iree_make_const_byte_span(&payload, sizeof(payload))});
+}
+
+static void AppendCommandBufferCreateRecords(
+    iree_hal_replay_file_writer_t* writer, uint64_t* sequence_ordinal,
+    iree_hal_replay_object_id_t device_id,
+    iree_hal_replay_object_id_t command_buffer_id) {
+  const iree_hal_replay_queue_family_command_buffer_object_payload_t payload = {
+      /*.mode=*/IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
+      /*.command_categories=*/IREE_HAL_COMMAND_CATEGORY_DISPATCH,
+      /*.queue_family_ordinal=*/0,
+      /*.reserved0=*/0,
+      /*.binding_capacity=*/0,
+  };
+  const iree_hal_replay_file_record_metadata_t operation_metadata = {
+      /*.sequence_ordinal=*/(*sequence_ordinal)++,
+      /*.thread_id=*/0,
+      /*.device_id=*/device_id,
+      /*.object_id=*/device_id,
+      /*.related_object_id=*/command_buffer_id,
+      /*.record_type=*/IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION,
+      /*.record_flags=*/IREE_HAL_REPLAY_FILE_RECORD_FLAG_NONE,
+      /*.payload_type=*/
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_FAMILY_COMMAND_BUFFER_OBJECT,
+      /*.object_type=*/IREE_HAL_REPLAY_OBJECT_TYPE_DEVICE,
+      /*.operation_code=*/
+      IREE_HAL_REPLAY_OPERATION_CODE_DEVICE_CREATE_COMMAND_BUFFER,
+      /*.status_code=*/IREE_STATUS_OK,
+  };
+  AppendReplayRecord(writer, operation_metadata,
+                     {iree_make_const_byte_span(&payload, sizeof(payload))});
+  const iree_hal_replay_file_record_metadata_t object_metadata = {
+      /*.sequence_ordinal=*/(*sequence_ordinal)++,
+      /*.thread_id=*/0,
+      /*.device_id=*/device_id,
+      /*.object_id=*/command_buffer_id,
+      /*.related_object_id=*/IREE_HAL_REPLAY_OBJECT_ID_NONE,
+      /*.record_type=*/IREE_HAL_REPLAY_FILE_RECORD_TYPE_OBJECT,
+      /*.record_flags=*/IREE_HAL_REPLAY_FILE_RECORD_FLAG_NONE,
+      /*.payload_type=*/
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_FAMILY_COMMAND_BUFFER_OBJECT,
+      /*.object_type=*/IREE_HAL_REPLAY_OBJECT_TYPE_COMMAND_BUFFER,
+      /*.operation_code=*/IREE_HAL_REPLAY_OPERATION_CODE_NONE,
+      /*.status_code=*/IREE_STATUS_OK,
+  };
+  AppendReplayRecord(writer, object_metadata,
+                     {iree_make_const_byte_span(&payload, sizeof(payload))});
+}
+
+static void AppendQueueExecuteRecord(
+    iree_hal_replay_file_writer_t* writer, uint64_t sequence_ordinal,
+    iree_hal_replay_object_id_t device_id, iree_hal_replay_object_id_t queue_id,
+    iree_hal_replay_object_id_t command_buffer_id) {
+  const iree_hal_replay_queue_execute_payload_t payload = {
+      /*.command_buffer_id=*/command_buffer_id,
+      /*.flags=*/IREE_HAL_QUEUE_EXECUTE_FLAG_NONE,
+      /*.wait_semaphore_count=*/0,
+      /*.signal_semaphore_count=*/0,
+      /*.binding_count=*/0,
+  };
+  const iree_hal_replay_file_record_metadata_t metadata = {
+      /*.sequence_ordinal=*/sequence_ordinal,
+      /*.thread_id=*/0,
+      /*.device_id=*/device_id,
+      /*.object_id=*/queue_id,
+      /*.related_object_id=*/command_buffer_id,
+      /*.record_type=*/IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION,
+      /*.record_flags=*/IREE_HAL_REPLAY_FILE_RECORD_FLAG_NONE,
+      /*.payload_type=*/IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_EXECUTE,
+      /*.object_type=*/IREE_HAL_REPLAY_OBJECT_TYPE_QUEUE,
+      /*.operation_code=*/IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_EXECUTE,
+      /*.status_code=*/IREE_STATUS_OK,
+  };
+  AppendReplayRecord(writer, metadata,
+                     {iree_make_const_byte_span(&payload, sizeof(payload))});
+}
+
+static void AppendVmmProtectRecord(iree_hal_replay_file_writer_t* writer,
+                                   uint64_t sequence_ordinal,
+                                   iree_hal_replay_object_id_t device_id) {
+  constexpr iree_hal_replay_object_id_t kAllocatorId = 20;
+  constexpr iree_hal_replay_object_id_t kVirtualBufferId = 21;
+  const iree_hal_replay_allocator_virtual_memory_protect_payload_t payload = {
+      /*.virtual_buffer_id=*/kVirtualBufferId,
+      /*.virtual_offset=*/0,
+      /*.size=*/4096,
+      /*.queue_family_affinity=*/iree_hal_make_queue_family_affinity(0),
+      /*.access_scope=*/IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
+      /*.reserved0=*/0,
+      /*.protection=*/IREE_HAL_MEMORY_PROTECTION_READ,
+  };
+  const iree_hal_replay_file_record_metadata_t metadata = {
+      /*.sequence_ordinal=*/sequence_ordinal,
+      /*.thread_id=*/0,
+      /*.device_id=*/device_id,
+      /*.object_id=*/kAllocatorId,
+      /*.related_object_id=*/kVirtualBufferId,
+      /*.record_type=*/IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION,
+      /*.record_flags=*/IREE_HAL_REPLAY_FILE_RECORD_FLAG_NONE,
+      /*.payload_type=*/
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT,
+      /*.object_type=*/IREE_HAL_REPLAY_OBJECT_TYPE_ALLOCATOR,
+      /*.operation_code=*/
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT,
+      /*.status_code=*/IREE_STATUS_OK,
+  };
+  AppendReplayRecord(writer, metadata,
+                     {iree_make_const_byte_span(&payload, sizeof(payload))});
+}
+
+static void AppendVmmUnmapRecord(iree_hal_replay_file_writer_t* writer,
+                                 uint64_t sequence_ordinal,
+                                 iree_hal_replay_object_id_t device_id) {
+  constexpr iree_hal_replay_object_id_t kAllocatorId = 20;
+  constexpr iree_hal_replay_object_id_t kVirtualBufferId = 21;
+  const iree_hal_replay_allocator_virtual_memory_unmap_payload_t payload = {
+      /*.virtual_buffer_id=*/kVirtualBufferId,
+      /*.virtual_offset=*/0,
+      /*.size=*/4096,
+  };
+  const iree_hal_replay_file_record_metadata_t metadata = {
+      /*.sequence_ordinal=*/sequence_ordinal,
+      /*.thread_id=*/0,
+      /*.device_id=*/device_id,
+      /*.object_id=*/kAllocatorId,
+      /*.related_object_id=*/kVirtualBufferId,
+      /*.record_type=*/IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION,
+      /*.record_flags=*/IREE_HAL_REPLAY_FILE_RECORD_FLAG_NONE,
+      /*.payload_type=*/
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+      /*.object_type=*/IREE_HAL_REPLAY_OBJECT_TYPE_ALLOCATOR,
+      /*.operation_code=*/
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+      /*.status_code=*/IREE_STATUS_OK,
+  };
+  AppendReplayRecord(writer, metadata,
+                     {iree_make_const_byte_span(&payload, sizeof(payload))});
+}
+
+static void AppendScopeBeginRecord(iree_hal_replay_file_writer_t* writer,
+                                   uint64_t sequence_ordinal) {
+  const iree_hal_replay_scope_payload_t payload = {
+      /*.name_length=*/4,
+      /*.flags=*/IREE_HAL_REPLAY_SCOPE_FLAG_NONE,
+      /*.reserved0=*/0,
+      /*.reserved1=*/0,
+  };
+  const iree_hal_replay_file_record_metadata_t metadata = {
+      /*.sequence_ordinal=*/sequence_ordinal,
+      /*.thread_id=*/0,
+      /*.device_id=*/IREE_HAL_REPLAY_OBJECT_ID_NONE,
+      /*.object_id=*/IREE_HAL_REPLAY_OBJECT_ID_NONE,
+      /*.related_object_id=*/IREE_HAL_REPLAY_OBJECT_ID_NONE,
+      /*.record_type=*/IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION,
+      /*.record_flags=*/IREE_HAL_REPLAY_FILE_RECORD_FLAG_NONE,
+      /*.payload_type=*/IREE_HAL_REPLAY_PAYLOAD_TYPE_REPLAY_SCOPE,
+      /*.object_type=*/IREE_HAL_REPLAY_OBJECT_TYPE_NONE,
+      /*.operation_code=*/IREE_HAL_REPLAY_OPERATION_CODE_REPLAY_SCOPE_BEGIN,
+      /*.status_code=*/IREE_STATUS_OK,
+  };
+  AppendReplayRecord(writer, metadata,
+                     {iree_make_const_byte_span(&payload, sizeof(payload)),
+                      iree_make_const_byte_span("fail", 4)});
+}
+
+typedef enum QueueDependencyReplayShape {
+  kForwardDependencyAcrossVmmBoundary,
+  kForwardDependencyAcrossVmmUnmapBoundary,
+  kSatisfiedDependencyBeforeVmmBoundary,
+  kDeviceMemoryDependencyAcrossVmmBoundary,
+  kImmediateCompletionBehindDeviceMemoryWait,
+  kCallbackErrorBeforeProducer,
+} QueueDependencyReplayShape;
+
+static std::vector<uint8_t> MakeQueueDependencyReplay(
+    QueueDependencyReplayShape shape) {
+  constexpr iree_hal_replay_object_id_t kDeviceId = 1;
+  constexpr iree_hal_replay_object_id_t kConsumerQueueId = 2;
+  constexpr iree_hal_replay_object_id_t kProducerQueueId = 3;
+  constexpr iree_hal_replay_object_id_t kSemaphoreId = 4;
+  std::vector<uint8_t> storage(32768, 0);
+  iree_io_file_handle_t* file_handle = nullptr;
+  IREE_CHECK_OK(iree_io_file_handle_wrap_host_allocation(
+      IREE_IO_FILE_ACCESS_READ | IREE_IO_FILE_ACCESS_WRITE,
+      iree_make_byte_span(storage.data(), storage.size()),
+      iree_io_file_handle_release_callback_null(), iree_allocator_system(),
+      &file_handle));
+  iree_hal_replay_file_writer_t* writer = nullptr;
+  IREE_CHECK_OK(iree_hal_replay_file_writer_allocate(
+      file_handle, iree_allocator_system(), &writer));
+  iree_io_file_handle_release(file_handle);
+
+  uint64_t sequence_ordinal = 0;
+  AppendDeviceObjectRecord(writer, sequence_ordinal++, kDeviceId);
+  AppendQueueObjectRecord(writer, sequence_ordinal++, kDeviceId,
+                          kConsumerQueueId, /*queue_ordinal=*/0);
+  if (shape != kCallbackErrorBeforeProducer &&
+      shape != kDeviceMemoryDependencyAcrossVmmBoundary &&
+      shape != kImmediateCompletionBehindDeviceMemoryWait) {
+    AppendQueueObjectRecord(writer, sequence_ordinal++, kDeviceId,
+                            kProducerQueueId, /*queue_ordinal=*/1);
+  }
+  AppendSemaphoreCreateRecord(writer, sequence_ordinal++, kDeviceId,
+                              kSemaphoreId);
+
+  if (shape == kSatisfiedDependencyBeforeVmmBoundary) {
+    AppendQueueBarrierRecord(writer, sequence_ordinal++, kDeviceId,
+                             kProducerQueueId, kSemaphoreId,
+                             /*is_wait=*/false);
+  }
+  if (shape == kDeviceMemoryDependencyAcrossVmmBoundary ||
+      shape == kImmediateCompletionBehindDeviceMemoryWait) {
+    AppendQueueAtomicWaitRecord(writer, sequence_ordinal++, kDeviceId,
+                                kConsumerQueueId);
+  } else {
+    AppendQueueBarrierRecord(writer, sequence_ordinal++, kDeviceId,
+                             kConsumerQueueId, kSemaphoreId,
+                             /*is_wait=*/true);
+  }
+  if (shape == kImmediateCompletionBehindDeviceMemoryWait) {
+    AppendImmediateQueueTransferRecord(writer, sequence_ordinal++, kDeviceId,
+                                       kConsumerQueueId);
+  }
+  if (shape == kCallbackErrorBeforeProducer) {
+    AppendScopeBeginRecord(writer, sequence_ordinal++);
+    AppendQueueObjectRecord(writer, sequence_ordinal++, kDeviceId,
+                            kProducerQueueId, /*queue_ordinal=*/1);
+  } else if (shape == kForwardDependencyAcrossVmmUnmapBoundary) {
+    AppendVmmUnmapRecord(writer, sequence_ordinal++, kDeviceId);
+  } else {
+    AppendVmmProtectRecord(writer, sequence_ordinal++, kDeviceId);
+  }
+  if (shape == kForwardDependencyAcrossVmmBoundary ||
+      shape == kForwardDependencyAcrossVmmUnmapBoundary ||
+      shape == kCallbackErrorBeforeProducer) {
+    AppendQueueBarrierRecord(writer, sequence_ordinal++, kDeviceId,
+                             kProducerQueueId, kSemaphoreId,
+                             /*is_wait=*/false);
+  }
+
+  IREE_CHECK_OK(iree_hal_replay_file_writer_close(writer));
+  iree_hal_replay_file_writer_free(writer);
+  return storage;
+}
+
+typedef enum OpaqueDispatchReplayShape {
+  kDirectDispatchBeforeVmmBoundary,
+  kCommandBufferDispatchAtEndOfFile,
+  kBoundedCommandBufferAtEndOfFile,
+} OpaqueDispatchReplayShape;
+
+static std::vector<uint8_t> MakeOpaqueDispatchReplay(
+    OpaqueDispatchReplayShape shape) {
+  constexpr iree_hal_replay_object_id_t kDeviceId = 1;
+  constexpr iree_hal_replay_object_id_t kQueueId = 2;
+  constexpr iree_hal_replay_object_id_t kCommandBufferId = 3;
+  constexpr iree_hal_replay_object_id_t kExecutableId = 4;
+  std::vector<uint8_t> storage(32768, 0);
+  iree_io_file_handle_t* file_handle = nullptr;
+  IREE_CHECK_OK(iree_io_file_handle_wrap_host_allocation(
+      IREE_IO_FILE_ACCESS_READ | IREE_IO_FILE_ACCESS_WRITE,
+      iree_make_byte_span(storage.data(), storage.size()),
+      iree_io_file_handle_release_callback_null(), iree_allocator_system(),
+      &file_handle));
+  iree_hal_replay_file_writer_t* writer = nullptr;
+  IREE_CHECK_OK(iree_hal_replay_file_writer_allocate(
+      file_handle, iree_allocator_system(), &writer));
+  iree_io_file_handle_release(file_handle);
+
+  uint64_t sequence_ordinal = 0;
+  AppendDeviceObjectRecord(writer, sequence_ordinal++, kDeviceId);
+  AppendQueueObjectRecord(writer, sequence_ordinal++, kDeviceId, kQueueId,
+                          /*queue_ordinal=*/0);
+  if (shape == kDirectDispatchBeforeVmmBoundary) {
+    AppendDispatchRecord(writer, sequence_ordinal++, kDeviceId, kQueueId,
+                         kExecutableId,
+                         IREE_HAL_REPLAY_OPERATION_CODE_QUEUE_DISPATCH);
+    AppendVmmProtectRecord(writer, sequence_ordinal++, kDeviceId);
+  } else {
+    AppendCommandBufferCreateRecords(writer, &sequence_ordinal, kDeviceId,
+                                     kCommandBufferId);
+    if (shape == kCommandBufferDispatchAtEndOfFile) {
+      AppendDispatchRecord(
+          writer, sequence_ordinal++, kDeviceId, kCommandBufferId,
+          kExecutableId,
+          IREE_HAL_REPLAY_OPERATION_CODE_COMMAND_BUFFER_DISPATCH);
+    }
+    AppendQueueExecuteRecord(writer, sequence_ordinal++, kDeviceId, kQueueId,
+                             kCommandBufferId);
+  }
+
+  IREE_CHECK_OK(iree_hal_replay_file_writer_close(writer));
+  iree_hal_replay_file_writer_free(writer);
+  return storage;
+}
+
 static iree_status_t NoopHostCall(void* user_data, const uint64_t args[4],
                                   iree_hal_host_call_context_t* context) {
   (void)user_data;
@@ -161,6 +671,184 @@ static iree_status_t RecordReplayScopeEvent(
   text.append(event->name.data, event->name.size);
   state->events->push_back(text);
   return iree_ok_status();
+}
+
+static iree_status_t FailReplayScopeEvent(
+    void* user_data, const iree_hal_replay_scope_event_t* event) {
+  (void)event;
+  iree_host_size_t* invocation_count = (iree_host_size_t*)user_data;
+  ++*invocation_count;
+  return iree_make_status(IREE_STATUS_ABORTED, "injected replay scope failure");
+}
+
+static IREE_ALLOCATOR_INLINE_STORAGE(g_callback_failure_host_storage,
+                                     64 * 1024);
+static iree_hal_device_group_t* g_callback_failure_device_group = nullptr;
+
+TEST(ReplayExecuteTest,
+     RejectsForwardQueueDependencyAcrossVmmBoundaryBeforeExecution) {
+  std::vector<uint8_t> storage =
+      MakeQueueDependencyReplay(kForwardDependencyAcrossVmmBoundary);
+  iree_hal_replay_plan_t* plan = nullptr;
+
+  iree::Status status =
+      iree::internal::ConsumeForTest(iree_hal_replay_plan_create(
+          GetCapturedFileContents(storage), iree_allocator_system(), &plan));
+
+  EXPECT_EQ(status.code(), iree::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(
+      status.ToString(),
+      ::testing::HasSubstr(
+          "replay completion boundary at sequence 5 cannot wait for queue "
+          "operation at sequence 4 with an unresolved forward or "
+          "device-memory dependency"));
+  EXPECT_EQ(plan, nullptr);
+}
+
+TEST(ReplayExecuteTest,
+     RejectsForwardQueueDependencyAcrossVmmUnmapBoundaryBeforeExecution) {
+  std::vector<uint8_t> storage =
+      MakeQueueDependencyReplay(kForwardDependencyAcrossVmmUnmapBoundary);
+  iree_hal_replay_plan_t* plan = nullptr;
+
+  iree::Status status =
+      iree::internal::ConsumeForTest(iree_hal_replay_plan_create(
+          GetCapturedFileContents(storage), iree_allocator_system(), &plan));
+
+  EXPECT_EQ(status.code(), iree::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(
+      status.ToString(),
+      ::testing::HasSubstr(
+          "replay completion boundary at sequence 5 cannot wait for queue "
+          "operation at sequence 4 with an unresolved forward or "
+          "device-memory dependency"));
+  EXPECT_EQ(plan, nullptr);
+}
+
+TEST(ReplayExecuteTest, AllowsSatisfiedQueueDependencyBeforeVmmBoundary) {
+  std::vector<uint8_t> storage =
+      MakeQueueDependencyReplay(kSatisfiedDependencyBeforeVmmBoundary);
+  iree_hal_replay_plan_t* plan = nullptr;
+
+  IREE_ASSERT_OK(iree_hal_replay_plan_create(GetCapturedFileContents(storage),
+                                             iree_allocator_system(), &plan));
+
+  iree_hal_replay_plan_destroy(plan);
+}
+
+TEST(ReplayExecuteTest,
+     RejectsDeviceMemoryQueueDependencyAcrossVmmBoundaryBeforeExecution) {
+  std::vector<uint8_t> storage =
+      MakeQueueDependencyReplay(kDeviceMemoryDependencyAcrossVmmBoundary);
+  iree_hal_replay_plan_t* plan = nullptr;
+
+  iree::Status status =
+      iree::internal::ConsumeForTest(iree_hal_replay_plan_create(
+          GetCapturedFileContents(storage), iree_allocator_system(), &plan));
+
+  EXPECT_EQ(status.code(), iree::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(
+      status.ToString(),
+      ::testing::HasSubstr(
+          "replay completion boundary at sequence 4 cannot wait for queue "
+          "operation at sequence 3 with an unresolved forward or "
+          "device-memory dependency"));
+  EXPECT_EQ(plan, nullptr);
+}
+
+TEST(ReplayExecuteTest, RejectsOpaqueDirectQueueDispatchBeforeVmmBoundary) {
+  std::vector<uint8_t> storage =
+      MakeOpaqueDispatchReplay(kDirectDispatchBeforeVmmBoundary);
+  iree_hal_replay_plan_t* plan = nullptr;
+
+  iree::Status status =
+      iree::internal::ConsumeForTest(iree_hal_replay_plan_create(
+          GetCapturedFileContents(storage), iree_allocator_system(), &plan));
+
+  EXPECT_EQ(status.code(), iree::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(
+      status.ToString(),
+      ::testing::HasSubstr(
+          "replay completion boundary at sequence 3 cannot wait for queue "
+          "operation at sequence 2 with an unresolved forward or "
+          "device-memory dependency"));
+  EXPECT_EQ(plan, nullptr);
+}
+
+TEST(ReplayExecuteTest, RejectsOpaqueCommandBufferDispatchAtEndOfFile) {
+  std::vector<uint8_t> storage =
+      MakeOpaqueDispatchReplay(kCommandBufferDispatchAtEndOfFile);
+  iree_hal_replay_plan_t* plan = nullptr;
+
+  iree::Status status =
+      iree::internal::ConsumeForTest(iree_hal_replay_plan_create(
+          GetCapturedFileContents(storage), iree_allocator_system(), &plan));
+
+  EXPECT_EQ(status.code(), iree::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(
+      status.ToString(),
+      ::testing::HasSubstr(
+          "replay end-of-file cannot wait for queue operation at sequence 5 "
+          "with an unresolved forward or device-memory dependency"));
+  EXPECT_EQ(plan, nullptr);
+}
+
+TEST(ReplayExecuteTest, AllowsBoundedCommandBufferAtEndOfFile) {
+  std::vector<uint8_t> storage =
+      MakeOpaqueDispatchReplay(kBoundedCommandBufferAtEndOfFile);
+  iree_hal_replay_plan_t* plan = nullptr;
+
+  IREE_ASSERT_OK(iree_hal_replay_plan_create(GetCapturedFileContents(storage),
+                                             iree_allocator_system(), &plan));
+
+  iree_hal_replay_plan_destroy(plan);
+}
+
+TEST(ReplayExecuteTest,
+     RejectsImmediateOperationBehindBlockedSameQueuePredecessor) {
+  std::vector<uint8_t> storage =
+      MakeQueueDependencyReplay(kImmediateCompletionBehindDeviceMemoryWait);
+  iree_hal_replay_plan_t* plan = nullptr;
+
+  iree::Status status =
+      iree::internal::ConsumeForTest(iree_hal_replay_plan_create(
+          GetCapturedFileContents(storage), iree_allocator_system(), &plan));
+
+  EXPECT_EQ(status.code(), iree::StatusCode::kFailedPrecondition);
+  EXPECT_THAT(
+      status.ToString(),
+      ::testing::HasSubstr(
+          "replay queue operation at sequence 4 requires immediate completion "
+          "but has an unresolved forward or device-memory dependency"));
+  EXPECT_EQ(plan, nullptr);
+}
+
+TEST(ReplayExecuteTest, ReturnsCallbackErrorWithPendingQueueCompletion) {
+  std::vector<uint8_t> storage =
+      MakeQueueDependencyReplay(kCallbackErrorBeforeProducer);
+  iree_host_size_t invocation_count = 0;
+  iree_hal_replay_execute_options_t options =
+      iree_hal_replay_execute_options_default();
+  options.scope_event_callback.fn = FailReplayScopeEvent;
+  options.scope_event_callback.user_data = &invocation_count;
+  ASSERT_EQ(g_callback_failure_device_group, nullptr);
+  g_callback_failure_device_group = CreateTaskDeviceGroup();
+  iree_allocator_t host_allocator =
+      iree_allocator_inline_arena(&g_callback_failure_host_storage.header);
+
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_ABORTED,
+      iree_hal_replay_execute_file(GetCapturedFileContents(storage),
+                                   g_callback_failure_device_group, &options,
+                                   host_allocator));
+
+  EXPECT_EQ(invocation_count, 1u);
+  // The executor retains its dependencies on this error path so accepted work
+  // remains valid for process lifetime. Keep the caller's device-group owner
+  // and fixed host storage alive for the same lifetime.
+  // This rooting is only LeakSanitizer hygiene for the deliberate containment;
+  // it is not a production substitute for durable ownership and eventual
+  // cleanup of accepted work.
 }
 
 typedef struct MockExecutableFunctionRecord {

--- a/runtime/src/iree/hal/replay/execute_vmm.c
+++ b/runtime/src/iree/hal/replay/execute_vmm.c
@@ -1,0 +1,260 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/replay/execute_vmm.h"
+
+#include <inttypes.h>
+#include <string.h>
+
+static iree_status_t iree_hal_replay_executor_require_fixed_vmm_payload(
+    const iree_hal_replay_file_record_t* record,
+    iree_hal_replay_payload_type_t payload_type,
+    iree_host_size_t payload_length) {
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_payload(
+      record, payload_type, payload_length));
+  if (IREE_UNLIKELY(record->payload.data_length != payload_length)) {
+    return iree_make_status(IREE_STATUS_DATA_LOSS,
+                            "replay VMM payload length mismatch");
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_replay_executor_lookup_owned_reservation(
+    iree_hal_replay_executor_t* executor, iree_hal_allocator_t* allocator,
+    iree_hal_replay_object_id_t virtual_buffer_id,
+    iree_hal_replay_object_entry_t** out_entry) {
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(
+      executor, virtual_buffer_id, IREE_HAL_REPLAY_OBJECT_TYPE_BUFFER,
+      out_entry));
+  if (IREE_UNLIKELY(!(*out_entry)->owning_allocator ||
+                    (*out_entry)->owning_allocator != allocator)) {
+    return iree_make_status(
+        IREE_STATUS_DATA_LOSS,
+        "replay virtual memory reservation belongs to another allocator");
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_replay_executor_lookup_owned_physical_memory(
+    iree_hal_replay_executor_t* executor, iree_hal_allocator_t* allocator,
+    iree_hal_replay_object_id_t physical_memory_id,
+    iree_hal_replay_object_entry_t** out_entry) {
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(
+      executor, physical_memory_id, IREE_HAL_REPLAY_OBJECT_TYPE_PHYSICAL_MEMORY,
+      out_entry));
+  if (IREE_UNLIKELY((*out_entry)->owning_allocator != allocator)) {
+    return iree_make_status(
+        IREE_STATUS_DATA_LOSS,
+        "replay physical memory belongs to another allocator");
+  }
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_replay_executor_virtual_memory_release(
+    iree_hal_replay_executor_t* executor,
+    const iree_hal_replay_file_record_t* record) {
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_fixed_vmm_payload(
+      record, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
+      sizeof(iree_hal_replay_allocator_virtual_memory_release_payload_t)));
+  iree_hal_replay_allocator_virtual_memory_release_payload_t payload;
+  memcpy(&payload, record->payload.data, sizeof(payload));
+  if (IREE_UNLIKELY(payload.virtual_buffer_id !=
+                    record->header.related_object_id)) {
+    return iree_make_status(
+        IREE_STATUS_DATA_LOSS,
+        "replay virtual memory release object ids do not match");
+  }
+
+  iree_hal_replay_object_entry_t* allocator_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(
+      executor, record->header.object_id, IREE_HAL_REPLAY_OBJECT_TYPE_ALLOCATOR,
+      &allocator_entry));
+  iree_hal_replay_object_entry_t* buffer_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup_owned_reservation(
+      executor, allocator_entry->value.allocator, payload.virtual_buffer_id,
+      &buffer_entry));
+  if (IREE_UNLIKELY(iree_hal_replay_executor_has_virtual_memory_mapping(
+          executor, payload.virtual_buffer_id))) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "replay virtual memory reservation is released while still mapped");
+  }
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_virtual_memory_release(
+      allocator_entry->value.allocator, buffer_entry->value.buffer));
+  return iree_hal_replay_executor_forget(executor, payload.virtual_buffer_id,
+                                         IREE_HAL_REPLAY_OBJECT_TYPE_BUFFER);
+}
+
+static iree_status_t iree_hal_replay_executor_physical_memory_free(
+    iree_hal_replay_executor_t* executor,
+    const iree_hal_replay_file_record_t* record) {
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_fixed_vmm_payload(
+      record, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
+      sizeof(iree_hal_replay_allocator_physical_memory_free_payload_t)));
+  iree_hal_replay_allocator_physical_memory_free_payload_t payload;
+  memcpy(&payload, record->payload.data, sizeof(payload));
+  if (IREE_UNLIKELY(payload.physical_memory_id !=
+                    record->header.related_object_id)) {
+    return iree_make_status(
+        IREE_STATUS_DATA_LOSS,
+        "replay physical memory free object ids do not match");
+  }
+
+  iree_hal_replay_object_entry_t* allocator_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(
+      executor, record->header.object_id, IREE_HAL_REPLAY_OBJECT_TYPE_ALLOCATOR,
+      &allocator_entry));
+  iree_hal_replay_object_entry_t* physical_memory_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup_owned_physical_memory(
+      executor, allocator_entry->value.allocator, payload.physical_memory_id,
+      &physical_memory_entry));
+  if (IREE_UNLIKELY(iree_hal_replay_executor_has_physical_memory_mapping(
+          executor, payload.physical_memory_id))) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "replay physical memory is freed while still mapped");
+  }
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_physical_memory_free(
+      allocator_entry->value.allocator,
+      physical_memory_entry->value.physical_memory.handle));
+  return iree_hal_replay_executor_forget(
+      executor, payload.physical_memory_id,
+      IREE_HAL_REPLAY_OBJECT_TYPE_PHYSICAL_MEMORY);
+}
+
+static iree_status_t iree_hal_replay_executor_virtual_memory_map(
+    iree_hal_replay_executor_t* executor,
+    const iree_hal_replay_file_record_t* record) {
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_fixed_vmm_payload(
+      record, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+      sizeof(iree_hal_replay_allocator_virtual_memory_map_payload_t)));
+  iree_hal_replay_allocator_virtual_memory_map_payload_t payload;
+  memcpy(&payload, record->payload.data, sizeof(payload));
+  if (IREE_UNLIKELY(payload.virtual_buffer_id !=
+                    record->header.related_object_id)) {
+    return iree_make_status(
+        IREE_STATUS_DATA_LOSS,
+        "replay virtual memory map object ids do not match");
+  }
+
+  iree_hal_replay_object_entry_t* allocator_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(
+      executor, record->header.object_id, IREE_HAL_REPLAY_OBJECT_TYPE_ALLOCATOR,
+      &allocator_entry));
+  return iree_hal_replay_executor_map_virtual_memory(
+      executor, allocator_entry->value.allocator, payload.virtual_buffer_id,
+      payload.physical_memory_id, payload.virtual_offset,
+      payload.physical_offset, payload.size);
+}
+
+static iree_status_t iree_hal_replay_executor_virtual_memory_unmap(
+    iree_hal_replay_executor_t* executor,
+    const iree_hal_replay_file_record_t* record) {
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_fixed_vmm_payload(
+      record, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+      sizeof(iree_hal_replay_allocator_virtual_memory_unmap_payload_t)));
+  iree_hal_replay_allocator_virtual_memory_unmap_payload_t payload;
+  memcpy(&payload, record->payload.data, sizeof(payload));
+  if (IREE_UNLIKELY(payload.virtual_buffer_id !=
+                    record->header.related_object_id)) {
+    return iree_make_status(
+        IREE_STATUS_DATA_LOSS,
+        "replay virtual memory unmap object ids do not match");
+  }
+
+  iree_hal_replay_object_entry_t* allocator_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(
+      executor, record->header.object_id, IREE_HAL_REPLAY_OBJECT_TYPE_ALLOCATOR,
+      &allocator_entry));
+  return iree_hal_replay_executor_unmap_virtual_memory(
+      executor, allocator_entry->value.allocator, payload.virtual_buffer_id,
+      payload.virtual_offset, payload.size);
+}
+
+static iree_status_t iree_hal_replay_executor_virtual_memory_protect(
+    iree_hal_replay_executor_t* executor,
+    const iree_hal_replay_file_record_t* record) {
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_fixed_vmm_payload(
+      record, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT,
+      sizeof(iree_hal_replay_allocator_virtual_memory_protect_payload_t)));
+  iree_hal_replay_allocator_virtual_memory_protect_payload_t payload;
+  memcpy(&payload, record->payload.data, sizeof(payload));
+  if (IREE_UNLIKELY(payload.virtual_buffer_id !=
+                        record->header.related_object_id ||
+                    payload.reserved0 != 0)) {
+    return iree_make_status(
+        IREE_STATUS_DATA_LOSS,
+        "replay virtual memory protect metadata is invalid");
+  }
+
+  iree_hal_replay_object_entry_t* allocator_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(
+      executor, record->header.object_id, IREE_HAL_REPLAY_OBJECT_TYPE_ALLOCATOR,
+      &allocator_entry));
+  iree_hal_replay_object_entry_t* buffer_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup_owned_reservation(
+      executor, allocator_entry->value.allocator, payload.virtual_buffer_id,
+      &buffer_entry));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_replay_executor_drain_queue_completions(executor));
+  return iree_hal_allocator_virtual_memory_protect(
+      allocator_entry->value.allocator, buffer_entry->value.buffer,
+      payload.virtual_offset, payload.size, payload.queue_family_affinity,
+      payload.access_scope, payload.protection);
+}
+
+static iree_status_t iree_hal_replay_executor_virtual_memory_advise(
+    iree_hal_replay_executor_t* executor,
+    const iree_hal_replay_file_record_t* record) {
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_require_fixed_vmm_payload(
+      record, IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE,
+      sizeof(iree_hal_replay_allocator_virtual_memory_advise_payload_t)));
+  iree_hal_replay_allocator_virtual_memory_advise_payload_t payload;
+  memcpy(&payload, record->payload.data, sizeof(payload));
+  if (IREE_UNLIKELY(payload.virtual_buffer_id !=
+                    record->header.related_object_id)) {
+    return iree_make_status(
+        IREE_STATUS_DATA_LOSS,
+        "replay virtual memory advise object ids do not match");
+  }
+
+  iree_hal_replay_object_entry_t* allocator_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup(
+      executor, record->header.object_id, IREE_HAL_REPLAY_OBJECT_TYPE_ALLOCATOR,
+      &allocator_entry));
+  iree_hal_replay_object_entry_t* buffer_entry = NULL;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_executor_lookup_owned_reservation(
+      executor, allocator_entry->value.allocator, payload.virtual_buffer_id,
+      &buffer_entry));
+  return iree_hal_allocator_virtual_memory_advise(
+      allocator_entry->value.allocator, buffer_entry->value.buffer,
+      payload.virtual_offset, payload.size, payload.queue_family_affinity,
+      payload.advice);
+}
+
+iree_status_t iree_hal_replay_executor_replay_vmm_operation(
+    iree_hal_replay_executor_t* executor,
+    const iree_hal_replay_file_record_t* record) {
+  switch (record->header.operation_code) {
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE:
+      return iree_hal_replay_executor_virtual_memory_release(executor, record);
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_FREE:
+      return iree_hal_replay_executor_physical_memory_free(executor, record);
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_MAP:
+      return iree_hal_replay_executor_virtual_memory_map(executor, record);
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP:
+      return iree_hal_replay_executor_virtual_memory_unmap(executor, record);
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT:
+      return iree_hal_replay_executor_virtual_memory_protect(executor, record);
+    case IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE:
+      return iree_hal_replay_executor_virtual_memory_advise(executor, record);
+    default:
+      return iree_make_status(
+          IREE_STATUS_UNIMPLEMENTED,
+          "replay VMM operation %s is not implemented",
+          iree_hal_replay_operation_code_string(record->header.operation_code));
+  }
+}

--- a/runtime/src/iree/hal/replay/execute_vmm.h
+++ b/runtime/src/iree/hal/replay/execute_vmm.h
@@ -1,0 +1,25 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_REPLAY_EXECUTE_VMM_H_
+#define IREE_HAL_REPLAY_EXECUTE_VMM_H_
+
+#include "iree/hal/replay/execute_state.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Executes a successful virtual-memory lifecycle operation record.
+iree_status_t iree_hal_replay_executor_replay_vmm_operation(
+    iree_hal_replay_executor_t* executor,
+    const iree_hal_replay_file_record_t* record);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_REPLAY_EXECUTE_VMM_H_

--- a/runtime/src/iree/hal/replay/execute_vmm_test.cc
+++ b/runtime/src/iree/hal/replay/execute_vmm_test.cc
@@ -1,0 +1,794 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "execute_operation.h"
+#include "execute_state.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+static constexpr iree_hal_replay_object_id_t kAllocatorId = 1;
+static constexpr iree_hal_replay_object_id_t kVirtualBufferId = 2;
+static constexpr iree_hal_replay_object_id_t kPhysicalMemoryId = 3;
+static constexpr iree_hal_queue_family_affinity_t kQueueFamilyAffinity =
+    UINT64_C(1) << 2;
+static constexpr iree_device_size_t kReservationSize = 16384;
+static constexpr iree_device_size_t kVirtualOffset = 4096;
+static constexpr iree_device_size_t kPhysicalOffset = 8192;
+static constexpr iree_device_size_t kMappingSize = 4096;
+
+typedef struct VmmAllocatorState {
+  bool fail_reserve = false;
+  bool fail_release = false;
+  bool fail_physical_allocate = false;
+  bool fail_physical_free = false;
+  bool fail_map = false;
+  bool fail_unmap = false;
+  bool fail_protect = false;
+  bool fail_advise = false;
+  iree_host_size_t reserve_attempt_count = 0;
+  iree_host_size_t release_attempt_count = 0;
+  iree_host_size_t physical_allocate_attempt_count = 0;
+  iree_host_size_t physical_free_attempt_count = 0;
+  iree_host_size_t map_attempt_count = 0;
+  iree_host_size_t unmap_attempt_count = 0;
+  iree_host_size_t protect_attempt_count = 0;
+  iree_host_size_t advise_attempt_count = 0;
+  iree_hal_buffer_t* virtual_buffer = nullptr;
+  iree_hal_physical_memory_t* physical_memory = nullptr;
+  bool is_mapped = false;
+  iree_hal_queue_family_affinity_t reserve_queue_family_affinity = 0;
+  iree_device_size_t reserve_size = 0;
+  iree_hal_buffer_params_t physical_params = {};
+  iree_device_size_t physical_size = 0;
+  iree_device_size_t map_virtual_offset = 0;
+  iree_device_size_t map_physical_offset = 0;
+  iree_device_size_t map_size = 0;
+  iree_device_size_t unmap_virtual_offset = 0;
+  iree_device_size_t unmap_size = 0;
+  iree_hal_queue_family_affinity_t protect_queue_family_affinity = 0;
+  iree_hal_virtual_memory_access_scope_t protect_access_scope = 0;
+  iree_hal_memory_protection_t protection = 0;
+  iree_hal_queue_family_affinity_t advise_queue_family_affinity = 0;
+  iree_hal_memory_advice_t advice = 0;
+} VmmAllocatorState;
+
+typedef struct VmmTestPhysicalMemory {
+  iree_allocator_t host_allocator;
+} VmmTestPhysicalMemory;
+
+typedef struct VmmTestAllocator {
+  iree_hal_resource_t resource;
+  iree_allocator_t host_allocator;
+  iree_hal_allocator_t* heap_allocator;
+  VmmAllocatorState* state;
+} VmmTestAllocator;
+
+extern const iree_hal_allocator_vtable_t vmm_test_allocator_vtable;
+
+static VmmTestAllocator* vmm_test_allocator_cast(
+    iree_hal_allocator_t* base_allocator) {
+  IREE_HAL_ASSERT_TYPE(base_allocator, &vmm_test_allocator_vtable);
+  return reinterpret_cast<VmmTestAllocator*>(base_allocator);
+}
+
+static void vmm_test_allocator_destroy(iree_hal_allocator_t* base_allocator) {
+  VmmTestAllocator* allocator = vmm_test_allocator_cast(base_allocator);
+  iree_allocator_t host_allocator = allocator->host_allocator;
+  iree_hal_allocator_release(allocator->heap_allocator);
+  iree_allocator_free(host_allocator, allocator);
+}
+
+static iree_allocator_t vmm_test_allocator_host_allocator(
+    const iree_hal_allocator_t* base_allocator) {
+  return reinterpret_cast<const VmmTestAllocator*>(base_allocator)
+      ->host_allocator;
+}
+
+static bool vmm_test_allocator_supports_virtual_memory(
+    iree_hal_allocator_t* base_allocator) {
+  (void)base_allocator;
+  return true;
+}
+
+static iree_status_t vmm_test_allocator_query_granularity(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_params_t params,
+    iree_device_size_t* out_minimum_page_size,
+    iree_device_size_t* out_recommended_page_size) {
+  (void)base_allocator;
+  (void)params;
+  *out_minimum_page_size = 4096;
+  *out_recommended_page_size = 65536;
+  return iree_ok_status();
+}
+
+static iree_status_t vmm_test_allocator_virtual_memory_reserve(
+    iree_hal_allocator_t* base_allocator,
+    iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_device_size_t size, iree_hal_buffer_t** out_virtual_buffer) {
+  VmmTestAllocator* allocator = vmm_test_allocator_cast(base_allocator);
+  VmmAllocatorState* state = allocator->state;
+  ++state->reserve_attempt_count;
+  if (state->fail_reserve) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "injected reserve failure");
+  }
+  if (state->virtual_buffer) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test reservation is already live");
+  }
+  iree_hal_buffer_params_t params = {
+      /*.usage=*/IREE_HAL_BUFFER_USAGE_STORAGE,
+      /*.access=*/IREE_HAL_MEMORY_ACCESS_ALL,
+      /*.type=*/IREE_HAL_MEMORY_TYPE_HOST_LOCAL,
+      /*.queue_family_affinity=*/IREE_HAL_QUEUE_FAMILY_AFFINITY_ANY,
+      /*.min_alignment=*/4096,
+  };
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
+      allocator->heap_allocator, params, size, out_virtual_buffer));
+  state->virtual_buffer = *out_virtual_buffer;
+  state->reserve_queue_family_affinity = queue_family_affinity;
+  state->reserve_size = size;
+  return iree_ok_status();
+}
+
+static iree_status_t vmm_test_allocator_virtual_memory_release(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* virtual_buffer) {
+  VmmAllocatorState* state = vmm_test_allocator_cast(base_allocator)->state;
+  ++state->release_attempt_count;
+  if (state->fail_release) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "injected release failure");
+  }
+  if (virtual_buffer != state->virtual_buffer || state->is_mapped) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test reservation state mismatch");
+  }
+  state->virtual_buffer = nullptr;
+  iree_hal_buffer_release(virtual_buffer);
+  return iree_ok_status();
+}
+
+static iree_status_t vmm_test_allocator_physical_memory_allocate(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_params_t params,
+    iree_device_size_t size, iree_allocator_t host_allocator,
+    iree_hal_physical_memory_t** out_physical_memory) {
+  VmmAllocatorState* state = vmm_test_allocator_cast(base_allocator)->state;
+  ++state->physical_allocate_attempt_count;
+  if (state->fail_physical_allocate) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "injected physical allocation failure");
+  }
+  if (state->physical_memory) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test physical allocation is already live");
+  }
+  VmmTestPhysicalMemory* physical_memory = nullptr;
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(host_allocator, sizeof(*physical_memory),
+                            reinterpret_cast<void**>(&physical_memory)));
+  physical_memory->host_allocator = host_allocator;
+  state->physical_memory =
+      reinterpret_cast<iree_hal_physical_memory_t*>(physical_memory);
+  state->physical_params = params;
+  state->physical_size = size;
+  *out_physical_memory = state->physical_memory;
+  return iree_ok_status();
+}
+
+static iree_status_t vmm_test_allocator_physical_memory_free(
+    iree_hal_allocator_t* base_allocator,
+    iree_hal_physical_memory_t* physical_memory) {
+  VmmAllocatorState* state = vmm_test_allocator_cast(base_allocator)->state;
+  ++state->physical_free_attempt_count;
+  if (state->fail_physical_free) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "injected physical free failure");
+  }
+  if (physical_memory != state->physical_memory || state->is_mapped) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test physical allocation state mismatch");
+  }
+  VmmTestPhysicalMemory* test_physical_memory =
+      reinterpret_cast<VmmTestPhysicalMemory*>(physical_memory);
+  state->physical_memory = nullptr;
+  iree_allocator_free(test_physical_memory->host_allocator,
+                      test_physical_memory);
+  return iree_ok_status();
+}
+
+static iree_status_t vmm_test_allocator_virtual_memory_map(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* virtual_buffer,
+    iree_device_size_t virtual_offset,
+    iree_hal_physical_memory_t* physical_memory,
+    iree_device_size_t physical_offset, iree_device_size_t size) {
+  VmmAllocatorState* state = vmm_test_allocator_cast(base_allocator)->state;
+  ++state->map_attempt_count;
+  if (state->fail_map) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "injected map failure");
+  }
+  if (virtual_buffer != state->virtual_buffer ||
+      physical_memory != state->physical_memory || state->is_mapped ||
+      virtual_offset + size > state->reserve_size ||
+      physical_offset + size > state->physical_size) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test mapping state mismatch");
+  }
+  state->is_mapped = true;
+  state->map_virtual_offset = virtual_offset;
+  state->map_physical_offset = physical_offset;
+  state->map_size = size;
+  return iree_ok_status();
+}
+
+static iree_status_t vmm_test_allocator_virtual_memory_unmap(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* virtual_buffer,
+    iree_device_size_t virtual_offset, iree_device_size_t size) {
+  VmmAllocatorState* state = vmm_test_allocator_cast(base_allocator)->state;
+  ++state->unmap_attempt_count;
+  if (state->fail_unmap) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "injected unmap failure");
+  }
+  if (virtual_buffer != state->virtual_buffer || !state->is_mapped ||
+      virtual_offset != state->map_virtual_offset || size != state->map_size) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test unmapping state mismatch");
+  }
+  state->is_mapped = false;
+  state->unmap_virtual_offset = virtual_offset;
+  state->unmap_size = size;
+  return iree_ok_status();
+}
+
+static iree_status_t vmm_test_allocator_virtual_memory_protect(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* virtual_buffer,
+    iree_device_size_t virtual_offset, iree_device_size_t size,
+    iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
+    iree_hal_memory_protection_t protection) {
+  VmmAllocatorState* state = vmm_test_allocator_cast(base_allocator)->state;
+  ++state->protect_attempt_count;
+  if (state->fail_protect) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "injected protect failure");
+  }
+  if (virtual_buffer != state->virtual_buffer || !state->is_mapped ||
+      virtual_offset != state->map_virtual_offset || size != state->map_size) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test protection state mismatch");
+  }
+  state->protect_queue_family_affinity = queue_family_affinity;
+  state->protect_access_scope = access_scope;
+  state->protection = protection;
+  return iree_ok_status();
+}
+
+static iree_status_t vmm_test_allocator_virtual_memory_advise(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* virtual_buffer,
+    iree_device_size_t virtual_offset, iree_device_size_t size,
+    iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_hal_memory_advice_t advice) {
+  VmmAllocatorState* state = vmm_test_allocator_cast(base_allocator)->state;
+  ++state->advise_attempt_count;
+  if (state->fail_advise) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "injected advise failure");
+  }
+  if (virtual_buffer != state->virtual_buffer || !state->is_mapped ||
+      virtual_offset != state->map_virtual_offset || size != state->map_size) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test advice state mismatch");
+  }
+  state->advise_queue_family_affinity = queue_family_affinity;
+  state->advice = advice;
+  return iree_ok_status();
+}
+
+const iree_hal_allocator_vtable_t vmm_test_allocator_vtable = {
+    /*.destroy=*/vmm_test_allocator_destroy,
+    /*.host_allocator=*/vmm_test_allocator_host_allocator,
+    /*.trim=*/nullptr,
+    /*.query_statistics=*/nullptr,
+    /*.query_memory_heaps=*/nullptr,
+    /*.query_buffer_compatibility=*/nullptr,
+    /*.allocate_buffer=*/nullptr,
+    /*.deallocate_buffer=*/nullptr,
+    /*.import_buffer=*/nullptr,
+    /*.export_buffer=*/nullptr,
+    /*.supports_virtual_memory=*/vmm_test_allocator_supports_virtual_memory,
+    /*.virtual_memory_query_granularity=*/
+    vmm_test_allocator_query_granularity,
+    /*.virtual_memory_reserve=*/vmm_test_allocator_virtual_memory_reserve,
+    /*.virtual_memory_release=*/vmm_test_allocator_virtual_memory_release,
+    /*.physical_memory_allocate=*/
+    vmm_test_allocator_physical_memory_allocate,
+    /*.physical_memory_free=*/vmm_test_allocator_physical_memory_free,
+    /*.virtual_memory_map=*/vmm_test_allocator_virtual_memory_map,
+    /*.virtual_memory_unmap=*/vmm_test_allocator_virtual_memory_unmap,
+    /*.virtual_memory_protect=*/vmm_test_allocator_virtual_memory_protect,
+    /*.virtual_memory_advise=*/vmm_test_allocator_virtual_memory_advise,
+};
+
+static iree_status_t CreateVmmTestAllocator(
+    VmmAllocatorState* state, iree_allocator_t host_allocator,
+    iree_hal_allocator_t** out_allocator) {
+  *out_allocator = nullptr;
+  iree_hal_allocator_t* heap_allocator = nullptr;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_allocator_create_heap(IREE_SV("replay-vmm-test"), host_allocator,
+                                     host_allocator, &heap_allocator));
+  VmmTestAllocator* allocator = nullptr;
+  iree_status_t status = iree_allocator_malloc(
+      host_allocator, sizeof(*allocator), reinterpret_cast<void**>(&allocator));
+  if (!iree_status_is_ok(status)) {
+    iree_hal_allocator_release(heap_allocator);
+    return status;
+  }
+  memset(allocator, 0, sizeof(*allocator));
+  iree_hal_resource_initialize(&vmm_test_allocator_vtable,
+                               &allocator->resource);
+  allocator->host_allocator = host_allocator;
+  allocator->heap_allocator = heap_allocator;
+  allocator->state = state;
+  *out_allocator = reinterpret_cast<iree_hal_allocator_t*>(allocator);
+  return iree_ok_status();
+}
+
+class OperationRecord {
+ public:
+  template <typename Payload>
+  void Reset(iree_hal_replay_operation_code_t operation_code,
+             iree_hal_replay_payload_type_t payload_type,
+             iree_hal_replay_object_id_t object_id,
+             iree_hal_replay_object_id_t related_object_id,
+             const Payload& payload, bool unaligned = false) {
+    const iree_host_size_t payload_offset = unaligned ? 1 : 0;
+    payload_storage_.assign(payload_offset + sizeof(payload), 0);
+    memcpy(payload_storage_.data() + payload_offset, &payload, sizeof(payload));
+    memset(&record_, 0, sizeof(record_));
+    record_.header.record_type = IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION;
+    record_.header.operation_code = operation_code;
+    record_.header.payload_type = payload_type;
+    record_.header.object_id = object_id;
+    record_.header.related_object_id = related_object_id;
+    record_.header.status_code = IREE_STATUS_OK;
+    record_.payload = iree_make_const_byte_span(
+        payload_storage_.data() + payload_offset, sizeof(payload));
+  }
+
+  const iree_hal_replay_file_record_t* get() const { return &record_; }
+
+ private:
+  std::vector<uint8_t> payload_storage_;
+  iree_hal_replay_file_record_t record_ = {};
+};
+
+class ReplayVmmExecutionTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    options_ = iree_hal_replay_execute_options_default();
+    IREE_ASSERT_OK(iree_hal_replay_executor_initialize(
+        &executor_, iree_const_byte_span_empty(), /*object_capacity=*/8,
+        /*device_group=*/nullptr, &options_, iree_allocator_system()));
+    initialized_ = true;
+    iree_hal_allocator_t* allocator = nullptr;
+    IREE_ASSERT_OK(
+        CreateVmmTestAllocator(&state_, iree_allocator_system(), &allocator));
+    iree_hal_replay_object_entry_t entry = {};
+    entry.value.allocator = allocator;
+    IREE_ASSERT_OK(iree_hal_replay_executor_store(
+        &executor_, kAllocatorId, IREE_HAL_REPLAY_OBJECT_TYPE_ALLOCATOR,
+        entry));
+  }
+
+  void TearDown() override {
+    if (!initialized_) return;
+    state_.fail_release = false;
+    state_.fail_physical_free = false;
+    state_.fail_unmap = false;
+    iree_status_ignore(iree_hal_replay_executor_deinitialize(&executor_));
+  }
+
+  iree_status_t Replay(const OperationRecord& record) {
+    return iree_hal_replay_executor_replay_operation(&executor_, record.get());
+  }
+
+  void Reserve(OperationRecord* record, bool unaligned = false) {
+    const iree_hal_replay_allocator_virtual_memory_reserve_payload_t payload = {
+        /*.queue_family_affinity=*/kQueueFamilyAffinity,
+        /*.size=*/kReservationSize,
+    };
+    record->Reset(
+        IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE,
+        IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE,
+        kAllocatorId, kVirtualBufferId, payload, unaligned);
+    IREE_ASSERT_OK(Replay(*record));
+  }
+
+  void AllocatePhysical(OperationRecord* record, bool unaligned = false) {
+    iree_hal_replay_allocator_physical_memory_allocate_payload_t payload = {};
+    payload.allocation.allocation_size = kReservationSize;
+    payload.allocation.queue_family_affinity = kQueueFamilyAffinity;
+    payload.allocation.min_alignment = 4096;
+    payload.allocation.usage = IREE_HAL_BUFFER_USAGE_STORAGE;
+    payload.allocation.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
+    payload.allocation.access =
+        IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE;
+    record->Reset(
+        IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+        IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+        kAllocatorId, kPhysicalMemoryId, payload, unaligned);
+    IREE_ASSERT_OK(Replay(*record));
+  }
+
+  void Map(OperationRecord* record, bool unaligned = false) {
+    const iree_hal_replay_allocator_virtual_memory_map_payload_t payload = {
+        /*.virtual_buffer_id=*/kVirtualBufferId,
+        /*.physical_memory_id=*/kPhysicalMemoryId,
+        /*.virtual_offset=*/kVirtualOffset,
+        /*.physical_offset=*/kPhysicalOffset,
+        /*.size=*/kMappingSize,
+    };
+    record->Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+                  IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+                  kAllocatorId, kVirtualBufferId, payload, unaligned);
+    IREE_ASSERT_OK(Replay(*record));
+  }
+
+  VmmAllocatorState state_;
+  iree_hal_replay_execute_options_t options_ = {};
+  iree_hal_replay_executor_t executor_ = {};
+  bool initialized_ = false;
+};
+
+TEST_F(ReplayVmmExecutionTest, ReplaysCompletePackedLifecycle) {
+  OperationRecord record;
+  Reserve(&record, /*unaligned=*/true);
+  AllocatePhysical(&record, /*unaligned=*/true);
+  Map(&record, /*unaligned=*/true);
+
+  ASSERT_EQ(1u, executor_.virtual_memory_mapping_count);
+  EXPECT_EQ(kVirtualBufferId,
+            executor_.virtual_memory_mappings[0].virtual_buffer_id);
+  EXPECT_EQ(kPhysicalMemoryId,
+            executor_.virtual_memory_mappings[0].physical_memory_id);
+  EXPECT_EQ(kVirtualOffset,
+            executor_.virtual_memory_mappings[0].virtual_offset);
+  EXPECT_EQ(kPhysicalOffset,
+            executor_.virtual_memory_mappings[0].physical_offset);
+  EXPECT_EQ(kMappingSize, executor_.virtual_memory_mappings[0].size);
+  EXPECT_EQ(IREE_HAL_REPLAY_OBJECT_TYPE_BUFFER,
+            executor_.objects[kVirtualBufferId].type);
+  EXPECT_EQ(IREE_HAL_REPLAY_OBJECT_TYPE_PHYSICAL_MEMORY,
+            executor_.objects[kPhysicalMemoryId].type);
+
+  const iree_hal_replay_allocator_virtual_memory_protect_payload_t
+      protect_payload = {
+          /*.virtual_buffer_id=*/kVirtualBufferId,
+          /*.virtual_offset=*/kVirtualOffset,
+          /*.size=*/kMappingSize,
+          /*.queue_family_affinity=*/kQueueFamilyAffinity,
+          /*.access_scope=*/IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL,
+          /*.reserved0=*/0,
+          /*.protection=*/IREE_HAL_MEMORY_PROTECTION_READ_WRITE,
+      };
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT,
+               kAllocatorId, kVirtualBufferId, protect_payload,
+               /*unaligned=*/true);
+  IREE_ASSERT_OK(Replay(record));
+  EXPECT_EQ(kQueueFamilyAffinity, state_.protect_queue_family_affinity);
+  EXPECT_EQ(IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_ALL,
+            state_.protect_access_scope);
+  EXPECT_EQ(IREE_HAL_MEMORY_PROTECTION_READ_WRITE, state_.protection);
+
+  const iree_hal_replay_allocator_virtual_memory_advise_payload_t
+      advise_payload = {
+          /*.virtual_buffer_id=*/kVirtualBufferId,
+          /*.virtual_offset=*/kVirtualOffset,
+          /*.size=*/kMappingSize,
+          /*.queue_family_affinity=*/kQueueFamilyAffinity,
+          /*.advice=*/IREE_HAL_MEMORY_ADVICE_WILL_NEED,
+      };
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE,
+               kAllocatorId, kVirtualBufferId, advise_payload,
+               /*unaligned=*/true);
+  IREE_ASSERT_OK(Replay(record));
+  EXPECT_EQ(kQueueFamilyAffinity, state_.advise_queue_family_affinity);
+  EXPECT_EQ(IREE_HAL_MEMORY_ADVICE_WILL_NEED, state_.advice);
+
+  const iree_hal_replay_allocator_virtual_memory_unmap_payload_t unmap_payload =
+      {
+          /*.virtual_buffer_id=*/kVirtualBufferId,
+          /*.virtual_offset=*/kVirtualOffset,
+          /*.size=*/kMappingSize,
+      };
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+               kAllocatorId, kVirtualBufferId, unmap_payload,
+               /*unaligned=*/true);
+  IREE_ASSERT_OK(Replay(record));
+  EXPECT_EQ(0u, executor_.virtual_memory_mapping_count);
+
+  const iree_hal_replay_allocator_physical_memory_free_payload_t free_payload =
+      {
+          /*.physical_memory_id=*/kPhysicalMemoryId,
+      };
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
+               kAllocatorId, kPhysicalMemoryId, free_payload,
+               /*unaligned=*/true);
+  IREE_ASSERT_OK(Replay(record));
+  const iree_hal_replay_allocator_virtual_memory_release_payload_t
+      release_payload = {
+          /*.virtual_buffer_id=*/kVirtualBufferId,
+      };
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
+               kAllocatorId, kVirtualBufferId, release_payload,
+               /*unaligned=*/true);
+  IREE_ASSERT_OK(Replay(record));
+
+  EXPECT_EQ(IREE_HAL_REPLAY_OBJECT_TYPE_NONE,
+            executor_.objects[kVirtualBufferId].type);
+  EXPECT_EQ(IREE_HAL_REPLAY_OBJECT_TYPE_NONE,
+            executor_.objects[kPhysicalMemoryId].type);
+  EXPECT_EQ(kQueueFamilyAffinity, state_.reserve_queue_family_affinity);
+  EXPECT_EQ(kReservationSize, state_.reserve_size);
+  EXPECT_EQ(kQueueFamilyAffinity, state_.physical_params.queue_family_affinity);
+  EXPECT_EQ(kReservationSize, state_.physical_size);
+  EXPECT_EQ(kVirtualOffset, state_.map_virtual_offset);
+  EXPECT_EQ(kPhysicalOffset, state_.map_physical_offset);
+  EXPECT_EQ(kMappingSize, state_.map_size);
+  EXPECT_EQ(kVirtualOffset, state_.unmap_virtual_offset);
+  EXPECT_EQ(kMappingSize, state_.unmap_size);
+}
+
+TEST_F(ReplayVmmExecutionTest, RejectsInvalidIdsTypesAndRanges) {
+  OperationRecord record;
+  Reserve(&record);
+  AllocatePhysical(&record);
+
+  iree_hal_replay_allocator_virtual_memory_map_payload_t map_payload = {
+      /*.virtual_buffer_id=*/kVirtualBufferId,
+      /*.physical_memory_id=*/kPhysicalMemoryId,
+      /*.virtual_offset=*/kVirtualOffset,
+      /*.physical_offset=*/kPhysicalOffset,
+      /*.size=*/0,
+  };
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+               kAllocatorId, kVirtualBufferId, map_payload);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS, Replay(record));
+  EXPECT_EQ(0u, state_.map_attempt_count);
+
+  map_payload.size = kMappingSize;
+  map_payload.physical_memory_id = kVirtualBufferId;
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+               kAllocatorId, kVirtualBufferId, map_payload);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION, Replay(record));
+  EXPECT_EQ(0u, state_.map_attempt_count);
+
+  map_payload.physical_memory_id = kPhysicalMemoryId;
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+               kAllocatorId, kPhysicalMemoryId, map_payload);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS, Replay(record));
+  EXPECT_EQ(0u, state_.map_attempt_count);
+
+  Map(&record);
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+               kAllocatorId, kVirtualBufferId, map_payload);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS, Replay(record));
+  EXPECT_EQ(1u, state_.map_attempt_count);
+
+  const iree_hal_replay_allocator_virtual_memory_unmap_payload_t
+      uncovered_payload = {
+          /*.virtual_buffer_id=*/kVirtualBufferId,
+          /*.virtual_offset=*/kVirtualOffset + kMappingSize,
+          /*.size=*/kMappingSize,
+      };
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+               kAllocatorId, kVirtualBufferId, uncovered_payload);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS, Replay(record));
+  EXPECT_EQ(0u, state_.unmap_attempt_count);
+
+  iree_hal_replay_allocator_virtual_memory_protect_payload_t protect_payload = {
+      /*.virtual_buffer_id=*/kVirtualBufferId,
+      /*.virtual_offset=*/kVirtualOffset,
+      /*.size=*/kMappingSize,
+      /*.queue_family_affinity=*/kQueueFamilyAffinity,
+      /*.access_scope=*/IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
+      /*.reserved0=*/1,
+      /*.protection=*/IREE_HAL_MEMORY_PROTECTION_READ,
+  };
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT,
+               kAllocatorId, kVirtualBufferId, protect_payload);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_DATA_LOSS, Replay(record));
+  EXPECT_EQ(0u, state_.protect_attempt_count);
+
+  const iree_hal_replay_allocator_virtual_memory_unmap_payload_t unmap_payload =
+      {
+          /*.virtual_buffer_id=*/kVirtualBufferId,
+          /*.virtual_offset=*/kVirtualOffset,
+          /*.size=*/kMappingSize,
+      };
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+               kAllocatorId, kVirtualBufferId, unmap_payload);
+  IREE_ASSERT_OK(Replay(record));
+}
+
+TEST_F(ReplayVmmExecutionTest, BackendFailuresRetainRetryableObjects) {
+  OperationRecord record;
+  state_.fail_reserve = true;
+  const iree_hal_replay_allocator_virtual_memory_reserve_payload_t
+      reserve_payload = {
+          /*.queue_family_affinity=*/kQueueFamilyAffinity,
+          /*.size=*/kReservationSize,
+      };
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE,
+               kAllocatorId, kVirtualBufferId, reserve_payload);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, Replay(record));
+  EXPECT_EQ(IREE_HAL_REPLAY_OBJECT_TYPE_NONE,
+            executor_.objects[kVirtualBufferId].type);
+  state_.fail_reserve = false;
+  Reserve(&record);
+
+  state_.fail_physical_allocate = true;
+  iree_hal_replay_allocator_physical_memory_allocate_payload_t
+      allocate_payload = {};
+  allocate_payload.allocation.allocation_size = kReservationSize;
+  record.Reset(
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+      kAllocatorId, kPhysicalMemoryId, allocate_payload);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, Replay(record));
+  EXPECT_EQ(IREE_HAL_REPLAY_OBJECT_TYPE_NONE,
+            executor_.objects[kPhysicalMemoryId].type);
+  state_.fail_physical_allocate = false;
+  AllocatePhysical(&record);
+
+  state_.fail_map = true;
+  const iree_hal_replay_allocator_virtual_memory_map_payload_t map_payload = {
+      /*.virtual_buffer_id=*/kVirtualBufferId,
+      /*.physical_memory_id=*/kPhysicalMemoryId,
+      /*.virtual_offset=*/kVirtualOffset,
+      /*.physical_offset=*/kPhysicalOffset,
+      /*.size=*/kMappingSize,
+  };
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+               kAllocatorId, kVirtualBufferId, map_payload);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, Replay(record));
+  EXPECT_EQ(0u, executor_.virtual_memory_mapping_count);
+  state_.fail_map = false;
+
+  const iree_hal_replay_allocator_physical_memory_free_payload_t free_payload =
+      {
+          /*.physical_memory_id=*/kPhysicalMemoryId,
+      };
+  state_.fail_physical_free = true;
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
+               kAllocatorId, kPhysicalMemoryId, free_payload);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, Replay(record));
+  EXPECT_EQ(IREE_HAL_REPLAY_OBJECT_TYPE_PHYSICAL_MEMORY,
+            executor_.objects[kPhysicalMemoryId].type);
+  state_.fail_physical_free = false;
+  IREE_ASSERT_OK(Replay(record));
+
+  const iree_hal_replay_allocator_virtual_memory_release_payload_t
+      release_payload = {
+          /*.virtual_buffer_id=*/kVirtualBufferId,
+      };
+  state_.fail_release = true;
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
+               kAllocatorId, kVirtualBufferId, release_payload);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, Replay(record));
+  EXPECT_EQ(IREE_HAL_REPLAY_OBJECT_TYPE_BUFFER,
+            executor_.objects[kVirtualBufferId].type);
+  state_.fail_release = false;
+  IREE_ASSERT_OK(Replay(record));
+}
+
+TEST_F(ReplayVmmExecutionTest, FailedUnmapRetainsDependenciesUntilRetry) {
+  OperationRecord record;
+  Reserve(&record);
+  AllocatePhysical(&record);
+  Map(&record);
+
+  const iree_hal_replay_allocator_virtual_memory_unmap_payload_t unmap_payload =
+      {
+          /*.virtual_buffer_id=*/kVirtualBufferId,
+          /*.virtual_offset=*/kVirtualOffset,
+          /*.size=*/kMappingSize,
+      };
+  state_.fail_unmap = true;
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+               kAllocatorId, kVirtualBufferId, unmap_payload);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED, Replay(record));
+  ASSERT_EQ(1u, executor_.virtual_memory_mapping_count);
+
+  const iree_hal_replay_allocator_physical_memory_free_payload_t free_payload =
+      {
+          /*.physical_memory_id=*/kPhysicalMemoryId,
+      };
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
+               kAllocatorId, kPhysicalMemoryId, free_payload);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION, Replay(record));
+  EXPECT_EQ(0u, state_.physical_free_attempt_count);
+
+  const iree_hal_replay_allocator_virtual_memory_release_payload_t
+      release_payload = {
+          /*.virtual_buffer_id=*/kVirtualBufferId,
+      };
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
+               kAllocatorId, kVirtualBufferId, release_payload);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_FAILED_PRECONDITION, Replay(record));
+  EXPECT_EQ(0u, state_.release_attempt_count);
+
+  state_.fail_unmap = false;
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+               kAllocatorId, kVirtualBufferId, unmap_payload);
+  IREE_ASSERT_OK(Replay(record));
+  EXPECT_EQ(0u, executor_.virtual_memory_mapping_count);
+
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
+               kAllocatorId, kPhysicalMemoryId, free_payload);
+  IREE_ASSERT_OK(Replay(record));
+  record.Reset(IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
+               IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
+               kAllocatorId, kVirtualBufferId, release_payload);
+  IREE_ASSERT_OK(Replay(record));
+}
+
+TEST_F(ReplayVmmExecutionTest, FailedCleanupRetainsMappedResources) {
+  OperationRecord record;
+  Reserve(&record);
+  AllocatePhysical(&record);
+  Map(&record);
+  state_.fail_unmap = true;
+
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_RESOURCE_EXHAUSTED,
+                        iree_hal_replay_executor_deinitialize(&executor_));
+  EXPECT_TRUE(state_.is_mapped);
+  EXPECT_NE(nullptr, state_.virtual_buffer);
+  EXPECT_NE(nullptr, state_.physical_memory);
+  EXPECT_EQ(0u, state_.physical_free_attempt_count);
+  EXPECT_EQ(0u, state_.release_attempt_count);
+  EXPECT_EQ(1u, executor_.virtual_memory_mapping_count);
+
+  state_.fail_unmap = false;
+  IREE_ASSERT_OK(iree_hal_replay_executor_deinitialize(&executor_));
+  initialized_ = false;
+  EXPECT_FALSE(state_.is_mapped);
+  EXPECT_EQ(nullptr, state_.virtual_buffer);
+  EXPECT_EQ(nullptr, state_.physical_memory);
+  EXPECT_EQ(1u, state_.physical_free_attempt_count);
+  EXPECT_EQ(1u, state_.release_attempt_count);
+}
+
+}  // namespace

--- a/runtime/src/iree/hal/replay/format.c
+++ b/runtime/src/iree/hal/replay/format.c
@@ -47,6 +47,8 @@ IREE_API_EXPORT const char* iree_hal_replay_object_type_string(
       return "semaphore";
     case IREE_HAL_REPLAY_OBJECT_TYPE_FILE:
       return "file";
+    case IREE_HAL_REPLAY_OBJECT_TYPE_PHYSICAL_MEMORY:
+      return "physical_memory";
     case IREE_HAL_REPLAY_OBJECT_TYPE_CHANNEL:
       return "channel";
     case IREE_HAL_REPLAY_OBJECT_TYPE_HOST_CALL:
@@ -259,6 +261,22 @@ IREE_API_EXPORT const char* iree_hal_replay_payload_type_string(
       return "queue_atomic_rmw";
     case IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_TIMESTAMP:
       return "queue_timestamp";
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE:
+      return "allocator_virtual_memory_reserve";
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE:
+      return "allocator_virtual_memory_release";
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE:
+      return "allocator_physical_memory_allocate";
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_FREE:
+      return "allocator_physical_memory_free";
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP:
+      return "allocator_virtual_memory_map";
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP:
+      return "allocator_virtual_memory_unmap";
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT:
+      return "allocator_virtual_memory_protect";
+    case IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE:
+      return "allocator_virtual_memory_advise";
     default:
       return "unknown";
   }

--- a/runtime/src/iree/hal/replay/format.h
+++ b/runtime/src/iree/hal/replay/format.h
@@ -23,7 +23,7 @@ extern "C" {
 #define IREE_HAL_REPLAY_FILE_VERSION_MAJOR 7u
 
 // Minor version of the IREE HAL replay file format.
-#define IREE_HAL_REPLAY_FILE_VERSION_MINOR 0u
+#define IREE_HAL_REPLAY_FILE_VERSION_MINOR 1u
 
 // Session-local object identifier used by replay records.
 typedef uint64_t iree_hal_replay_object_id_t;
@@ -70,6 +70,7 @@ enum iree_hal_replay_object_type_e {
   IREE_HAL_REPLAY_OBJECT_TYPE_EXECUTABLE = 6u,
   IREE_HAL_REPLAY_OBJECT_TYPE_SEMAPHORE = 7u,
   IREE_HAL_REPLAY_OBJECT_TYPE_FILE = 8u,
+  IREE_HAL_REPLAY_OBJECT_TYPE_PHYSICAL_MEMORY = 9u,
   IREE_HAL_REPLAY_OBJECT_TYPE_CHANNEL = 10u,
   IREE_HAL_REPLAY_OBJECT_TYPE_HOST_CALL = 11u,
   IREE_HAL_REPLAY_OBJECT_TYPE_QUEUE = 12u,
@@ -185,6 +186,14 @@ enum iree_hal_replay_payload_type_e {
   IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_STORE = 43u,
   IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_ATOMIC_RMW = 44u,
   IREE_HAL_REPLAY_PAYLOAD_TYPE_QUEUE_TIMESTAMP = 45u,
+  IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE = 46u,
+  IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE = 47u,
+  IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE = 48u,
+  IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_FREE = 49u,
+  IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP = 50u,
+  IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP = 51u,
+  IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT = 52u,
+  IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE = 53u,
 };
 
 // Type of one operation in a captured exact-queue transfer transaction.
@@ -295,6 +304,112 @@ typedef struct iree_hal_replay_allocator_import_buffer_payload_t {
   // Captured byte length following this payload header.
   uint64_t data_length;
 } iree_hal_replay_allocator_import_buffer_payload_t;
+
+// Payload describing a virtual address reservation request.
+typedef struct iree_hal_replay_allocator_virtual_memory_reserve_payload_t {
+  // Queue family affinity constraining devices that may access the reservation.
+  uint64_t queue_family_affinity;
+  // Requested reservation size, in bytes.
+  uint64_t size;
+} iree_hal_replay_allocator_virtual_memory_reserve_payload_t;
+static_assert(
+    sizeof(iree_hal_replay_allocator_virtual_memory_reserve_payload_t) == 16,
+    "virtual memory reserve replay payload must be 16 bytes");
+
+// Payload identifying a virtual address reservation being released.
+typedef struct iree_hal_replay_allocator_virtual_memory_release_payload_t {
+  // Session-local buffer id assigned to the virtual address reservation.
+  iree_hal_replay_object_id_t virtual_buffer_id;
+} iree_hal_replay_allocator_virtual_memory_release_payload_t;
+static_assert(
+    sizeof(iree_hal_replay_allocator_virtual_memory_release_payload_t) == 8,
+    "virtual memory release replay payload must be 8 bytes");
+
+// Payload describing a physical memory allocation request.
+typedef struct iree_hal_replay_allocator_physical_memory_allocate_payload_t {
+  // Canonical allocation parameters and requested physical allocation size.
+  iree_hal_replay_allocator_allocate_buffer_payload_t allocation;
+} iree_hal_replay_allocator_physical_memory_allocate_payload_t;
+static_assert(
+    sizeof(iree_hal_replay_allocator_physical_memory_allocate_payload_t) == 40,
+    "physical memory allocate replay payload must be 40 bytes");
+
+// Payload identifying a physical memory handle being freed.
+typedef struct iree_hal_replay_allocator_physical_memory_free_payload_t {
+  // Session-local id assigned to the physical memory handle.
+  iree_hal_replay_object_id_t physical_memory_id;
+} iree_hal_replay_allocator_physical_memory_free_payload_t;
+static_assert(
+    sizeof(iree_hal_replay_allocator_physical_memory_free_payload_t) == 8,
+    "physical memory free replay payload must be 8 bytes");
+
+// Payload describing a physical-to-virtual memory mapping.
+typedef struct iree_hal_replay_allocator_virtual_memory_map_payload_t {
+  // Session-local buffer id assigned to the virtual address reservation.
+  iree_hal_replay_object_id_t virtual_buffer_id;
+  // Session-local id assigned to the physical memory handle.
+  iree_hal_replay_object_id_t physical_memory_id;
+  // Byte offset within the virtual address reservation.
+  uint64_t virtual_offset;
+  // Byte offset within the physical memory allocation.
+  uint64_t physical_offset;
+  // Mapping size, in bytes.
+  uint64_t size;
+} iree_hal_replay_allocator_virtual_memory_map_payload_t;
+static_assert(sizeof(iree_hal_replay_allocator_virtual_memory_map_payload_t) ==
+                  40,
+              "virtual memory map replay payload must be 40 bytes");
+
+// Payload describing a virtual memory unmapping.
+typedef struct iree_hal_replay_allocator_virtual_memory_unmap_payload_t {
+  // Session-local buffer id assigned to the virtual address reservation.
+  iree_hal_replay_object_id_t virtual_buffer_id;
+  // Byte offset within the virtual address reservation.
+  uint64_t virtual_offset;
+  // Unmapping size, in bytes.
+  uint64_t size;
+} iree_hal_replay_allocator_virtual_memory_unmap_payload_t;
+static_assert(
+    sizeof(iree_hal_replay_allocator_virtual_memory_unmap_payload_t) == 24,
+    "virtual memory unmap replay payload must be 24 bytes");
+
+// Payload describing a virtual memory protection update.
+typedef struct iree_hal_replay_allocator_virtual_memory_protect_payload_t {
+  // Session-local buffer id assigned to the virtual address reservation.
+  iree_hal_replay_object_id_t virtual_buffer_id;
+  // Byte offset within the virtual address reservation.
+  uint64_t virtual_offset;
+  // Protection range size, in bytes.
+  uint64_t size;
+  // Queue family affinity selecting the topology where protection applies.
+  uint64_t queue_family_affinity;
+  // Host/device execution scope receiving the protection.
+  uint32_t access_scope;
+  // Reserved for future protection metadata; must be zero.
+  uint32_t reserved0;
+  // Memory protection bits applied to the range.
+  uint64_t protection;
+} iree_hal_replay_allocator_virtual_memory_protect_payload_t;
+static_assert(
+    sizeof(iree_hal_replay_allocator_virtual_memory_protect_payload_t) == 48,
+    "virtual memory protect replay payload must be 48 bytes");
+
+// Payload describing a virtual memory usage hint.
+typedef struct iree_hal_replay_allocator_virtual_memory_advise_payload_t {
+  // Session-local buffer id assigned to the virtual address reservation.
+  iree_hal_replay_object_id_t virtual_buffer_id;
+  // Byte offset within the virtual address reservation.
+  uint64_t virtual_offset;
+  // Advised range size, in bytes.
+  uint64_t size;
+  // Queue family affinity selecting the topology where the advice applies.
+  uint64_t queue_family_affinity;
+  // Memory advice bits applied to the range.
+  uint64_t advice;
+} iree_hal_replay_allocator_virtual_memory_advise_payload_t;
+static_assert(
+    sizeof(iree_hal_replay_allocator_virtual_memory_advise_payload_t) == 40,
+    "virtual memory advise replay payload must be 40 bytes");
 
 // Payload describing a buffer byte range operation.
 typedef struct iree_hal_replay_buffer_range_payload_t {

--- a/runtime/src/iree/hal/replay/recorder.c
+++ b/runtime/src/iree/hal/replay/recorder.c
@@ -364,6 +364,23 @@ iree_status_t iree_hal_replay_recorder_end_operation(
       pending_record, operation_status, 0, NULL);
 }
 
+iree_status_t iree_hal_replay_recorder_end_passthrough_operation_with_payload(
+    iree_hal_replay_pending_record_t* pending_record,
+    iree_status_t operation_status, iree_host_size_t iovec_count,
+    const iree_const_byte_span_t* iovecs) {
+  iree_hal_replay_recorder_t* recorder = pending_record->recorder;
+  if (!recorder) return operation_status;
+  pending_record->metadata.status_code =
+      (uint32_t)iree_status_code(operation_status);
+  iree_status_t record_status = iree_hal_replay_file_writer_append_record(
+      recorder->writer, &pending_record->metadata, iovec_count, iovecs, NULL);
+  iree_hal_replay_recorder_fail_locked(recorder,
+                                       iree_status_code(record_status));
+  iree_slim_mutex_unlock(&recorder->mutex);
+  iree_status_free(record_status);
+  return operation_status;
+}
+
 iree_status_t iree_hal_replay_recorder_end_creation_operation(
     iree_hal_replay_pending_record_t* pending_record,
     iree_status_t operation_status, iree_host_size_t operation_iovec_count,

--- a/runtime/src/iree/hal/replay/recorder_allocator.c
+++ b/runtime/src/iree/hal/replay/recorder_allocator.c
@@ -8,6 +8,7 @@
 
 #include <string.h>
 
+#include "iree/base/threading/mutex.h"
 #include "iree/hal/replay/recorder_buffer.h"
 #include "iree/hal/replay/recorder_record.h"
 
@@ -19,6 +20,9 @@
 //===----------------------------------------------------------------------===//
 // iree_hal_replay_recorder_allocator_t
 //===----------------------------------------------------------------------===//
+
+typedef struct iree_hal_replay_recorder_physical_memory_t
+    iree_hal_replay_recorder_physical_memory_t;
 
 typedef struct iree_hal_replay_recorder_allocator_t {
   // HAL resource header for the recording wrapper allocator.
@@ -35,7 +39,21 @@ typedef struct iree_hal_replay_recorder_allocator_t {
   iree_hal_replay_object_id_t device_id;
   // Session-local object id assigned to this allocator.
   iree_hal_replay_object_id_t allocator_id;
+  // Serializes reservation and physical-memory validation with backend use.
+  iree_slim_mutex_t virtual_memory_mutex;
+  // Live physical-memory tokens created by this exact recorder allocator.
+  iree_hal_replay_recorder_physical_memory_t* physical_memory_list;
 } iree_hal_replay_recorder_allocator_t;
+
+// Recording wrapper for an allocator-owned opaque physical memory handle.
+struct iree_hal_replay_recorder_physical_memory_t {
+  // Underlying allocator handle forwarded to the backend.
+  iree_hal_physical_memory_t* base_physical_memory;
+  // Session-local object ID assigned to the physical memory handle.
+  iree_hal_replay_object_id_t physical_memory_id;
+  // Next live token in the originating allocator registry.
+  iree_hal_replay_recorder_physical_memory_t* next;
+};
 
 static const iree_hal_allocator_vtable_t
     iree_hal_replay_recorder_allocator_vtable;
@@ -80,6 +98,37 @@ static iree_status_t iree_hal_replay_recorder_allocator_begin_operation(
       payload_type, out_pending_record);
 }
 
+// Begins a stateful VMM operation if capture is still available. A terminal
+// capture error does not prevent release/free forwarding to the backend.
+static void iree_hal_replay_recorder_allocator_begin_passthrough_operation(
+    iree_hal_replay_recorder_allocator_t* allocator,
+    iree_hal_replay_object_id_t related_object_id,
+    iree_hal_replay_operation_code_t operation_code,
+    iree_hal_replay_payload_type_t payload_type,
+    iree_hal_replay_pending_record_t* out_pending_record) {
+  iree_status_t status = iree_hal_replay_recorder_allocator_begin_operation(
+      allocator, related_object_id, operation_code, payload_type,
+      out_pending_record);
+  if (!iree_status_is_ok(status)) {
+    iree_status_free(status);
+    memset(out_pending_record, 0, sizeof(*out_pending_record));
+  }
+}
+
+// Finds a physical-memory token while |virtual_memory_mutex| is held. Pointer
+// equality is checked before the opaque public token is dereferenced.
+static iree_hal_replay_recorder_physical_memory_t*
+iree_hal_replay_recorder_allocator_find_physical_memory_locked(
+    iree_hal_replay_recorder_allocator_t* allocator,
+    iree_hal_physical_memory_t* physical_memory) {
+  iree_hal_replay_recorder_physical_memory_t* current =
+      allocator->physical_memory_list;
+  while (current && (iree_hal_physical_memory_t*)current != physical_memory) {
+    current = current->next;
+  }
+  return current;
+}
+
 static void iree_hal_replay_recorder_allocator_destroy(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator) {
   iree_hal_replay_recorder_allocator_t* allocator =
@@ -87,6 +136,8 @@ static void iree_hal_replay_recorder_allocator_destroy(
   iree_allocator_t host_allocator = allocator->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
 
+  IREE_ASSERT(allocator->physical_memory_list == NULL);
+  iree_slim_mutex_deinitialize(&allocator->virtual_memory_mutex);
   iree_hal_allocator_release(allocator->base_allocator);
   iree_hal_replay_recorder_release(allocator->recorder);
   iree_allocator_free(host_allocator, allocator);
@@ -187,8 +238,8 @@ static iree_status_t iree_hal_replay_recorder_allocator_allocate_buffer(
   if (iree_status_is_ok(status)) {
     status = iree_hal_replay_recorder_buffer_create_proxy(
         allocator->recorder, allocator->device_id, buffer_id,
-        allocator->placement_device, base_buffer, allocator->host_allocator,
-        &replay_buffer);
+        IREE_HAL_REPLAY_OBJECT_ID_NONE, allocator->placement_device,
+        base_buffer, allocator->host_allocator, &replay_buffer);
   }
 
   iree_hal_replay_buffer_object_payload_t object_payload;
@@ -289,8 +340,8 @@ static iree_status_t iree_hal_replay_recorder_allocator_import_buffer(
   if (iree_status_is_ok(status)) {
     status = iree_hal_replay_recorder_buffer_create_proxy(
         allocator->recorder, allocator->device_id, buffer_id,
-        allocator->placement_device, base_buffer, allocator->host_allocator,
-        &replay_buffer);
+        IREE_HAL_REPLAY_OBJECT_ID_NONE, allocator->placement_device,
+        base_buffer, allocator->host_allocator, &replay_buffer);
   }
 
   iree_hal_replay_buffer_object_payload_t object_payload;
@@ -378,10 +429,17 @@ static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_reserve(
       allocator->recorder, &buffer_id));
 
   iree_hal_replay_pending_record_t pending_record;
+  const iree_hal_replay_allocator_virtual_memory_reserve_payload_t payload = {
+      .queue_family_affinity = queue_family_affinity,
+      .size = size,
+  };
+  const iree_const_byte_span_t operation_iovec =
+      iree_make_const_byte_span((const uint8_t*)&payload, sizeof(payload));
   IREE_RETURN_IF_ERROR(iree_hal_replay_recorder_allocator_begin_operation(
       allocator, buffer_id,
       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE,
-      IREE_HAL_REPLAY_PAYLOAD_TYPE_NONE, &pending_record));
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE,
+      &pending_record));
 
   iree_hal_buffer_t* base_buffer = NULL;
   iree_hal_buffer_t* replay_buffer = NULL;
@@ -390,8 +448,8 @@ static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_reserve(
   if (iree_status_is_ok(status)) {
     status = iree_hal_replay_recorder_buffer_create_proxy(
         allocator->recorder, allocator->device_id, buffer_id,
-        allocator->placement_device, base_buffer, allocator->host_allocator,
-        &replay_buffer);
+        allocator->allocator_id, allocator->placement_device, base_buffer,
+        allocator->host_allocator, &replay_buffer);
   }
 
   iree_hal_replay_buffer_object_payload_t object_payload;
@@ -404,8 +462,9 @@ static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_reserve(
   iree_const_byte_span_t object_iovec = iree_make_const_byte_span(
       (const uint8_t*)&object_payload, sizeof(object_payload));
   status = iree_hal_replay_recorder_end_creation_operation(
-      &pending_record, status, 0, NULL, IREE_HAL_REPLAY_OBJECT_TYPE_BUFFER,
-      buffer_id, IREE_HAL_REPLAY_PAYLOAD_TYPE_BUFFER_OBJECT, 1, &object_iovec);
+      &pending_record, status, 1, &operation_iovec,
+      IREE_HAL_REPLAY_OBJECT_TYPE_BUFFER, buffer_id,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_BUFFER_OBJECT, 1, &object_iovec);
 
   if (iree_status_is_ok(status)) {
     *out_virtual_buffer = replay_buffer;
@@ -421,16 +480,37 @@ static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_release(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer) {
   iree_hal_replay_recorder_allocator_t* allocator =
       iree_hal_replay_recorder_allocator_cast(base_allocator);
+  iree_slim_mutex_lock(&allocator->virtual_memory_mutex);
+  iree_hal_replay_object_id_t virtual_buffer_id =
+      IREE_HAL_REPLAY_OBJECT_ID_NONE;
+  iree_hal_buffer_t* base_buffer = NULL;
+  iree_status_t status = iree_hal_replay_recorder_buffer_resolve_virtual_memory(
+      virtual_buffer, allocator->recorder, allocator->allocator_id,
+      &virtual_buffer_id, &base_buffer);
+  if (!iree_status_is_ok(status)) {
+    iree_slim_mutex_unlock(&allocator->virtual_memory_mutex);
+    return status;
+  }
+  const iree_hal_replay_allocator_virtual_memory_release_payload_t payload = {
+      .virtual_buffer_id = virtual_buffer_id,
+  };
+  const iree_const_byte_span_t iovec =
+      iree_make_const_byte_span((const uint8_t*)&payload, sizeof(payload));
   iree_hal_replay_pending_record_t pending_record;
-  IREE_RETURN_IF_ERROR(iree_hal_replay_recorder_allocator_begin_operation(
-      allocator, IREE_HAL_REPLAY_OBJECT_ID_NONE,
+  iree_hal_replay_recorder_allocator_begin_passthrough_operation(
+      allocator, virtual_buffer_id,
       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
-      IREE_HAL_REPLAY_PAYLOAD_TYPE_NONE, &pending_record));
-  return iree_hal_replay_recorder_end_operation(
-      &pending_record,
-      iree_hal_allocator_virtual_memory_release(
-          allocator->base_allocator,
-          iree_hal_replay_recorder_buffer_base_or_self(virtual_buffer)));
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE,
+      &pending_record);
+  status = iree_hal_allocator_virtual_memory_release(allocator->base_allocator,
+                                                     base_buffer);
+  if (iree_status_is_ok(status)) {
+    iree_hal_replay_recorder_buffer_consume_virtual_memory(virtual_buffer);
+  }
+  status = iree_hal_replay_recorder_end_passthrough_operation_with_payload(
+      &pending_record, status, 1, &iovec);
+  iree_slim_mutex_unlock(&allocator->virtual_memory_mutex);
+  return status;
 }
 
 static iree_status_t
@@ -441,15 +521,60 @@ iree_hal_replay_recorder_allocator_physical_memory_allocate(
     iree_hal_physical_memory_t** IREE_RESTRICT out_physical_memory) {
   iree_hal_replay_recorder_allocator_t* allocator =
       iree_hal_replay_recorder_allocator_cast(base_allocator);
+  *out_physical_memory = NULL;
+
+  iree_hal_replay_object_id_t physical_memory_id =
+      IREE_HAL_REPLAY_OBJECT_ID_NONE;
+  IREE_RETURN_IF_ERROR(iree_hal_replay_recorder_reserve_object_id(
+      allocator->recorder, &physical_memory_id));
+
+  iree_hal_replay_allocator_physical_memory_allocate_payload_t payload;
+  iree_hal_replay_recorder_allocator_make_allocate_buffer_payload(
+      &params, size, &payload.allocation);
+  const iree_const_byte_span_t operation_iovec =
+      iree_make_const_byte_span((const uint8_t*)&payload, sizeof(payload));
   iree_hal_replay_pending_record_t pending_record;
   IREE_RETURN_IF_ERROR(iree_hal_replay_recorder_allocator_begin_operation(
-      allocator, IREE_HAL_REPLAY_OBJECT_ID_NONE,
+      allocator, physical_memory_id,
       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
-      IREE_HAL_REPLAY_PAYLOAD_TYPE_NONE, &pending_record));
-  return iree_hal_replay_recorder_end_operation(
-      &pending_record, iree_hal_allocator_physical_memory_allocate(
-                           allocator->base_allocator, params, size,
-                           host_allocator, out_physical_memory));
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE,
+      &pending_record));
+
+  iree_hal_physical_memory_t* base_physical_memory = NULL;
+  iree_hal_replay_recorder_physical_memory_t* replay_physical_memory = NULL;
+  iree_status_t status = iree_hal_allocator_physical_memory_allocate(
+      allocator->base_allocator, params, size, host_allocator,
+      &base_physical_memory);
+  if (iree_status_is_ok(status)) {
+    status = iree_allocator_malloc(allocator->host_allocator,
+                                   sizeof(*replay_physical_memory),
+                                   (void**)&replay_physical_memory);
+  }
+  if (iree_status_is_ok(status)) {
+    replay_physical_memory->base_physical_memory = base_physical_memory;
+    replay_physical_memory->physical_memory_id = physical_memory_id;
+    replay_physical_memory->next = NULL;
+  }
+  status = iree_hal_replay_recorder_end_creation_operation(
+      &pending_record, status, 1, &operation_iovec,
+      IREE_HAL_REPLAY_OBJECT_TYPE_PHYSICAL_MEMORY, physical_memory_id,
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_NONE, 0, NULL);
+  if (iree_status_is_ok(status)) {
+    iree_slim_mutex_lock(&allocator->virtual_memory_mutex);
+    replay_physical_memory->next = allocator->physical_memory_list;
+    allocator->physical_memory_list = replay_physical_memory;
+    iree_slim_mutex_unlock(&allocator->virtual_memory_mutex);
+    *out_physical_memory = (iree_hal_physical_memory_t*)replay_physical_memory;
+    return iree_ok_status();
+  }
+
+  if (base_physical_memory) {
+    status = iree_status_join(
+        status, iree_hal_allocator_physical_memory_free(
+                    allocator->base_allocator, base_physical_memory));
+  }
+  iree_allocator_free(allocator->host_allocator, replay_physical_memory);
+  return status;
 }
 
 static iree_status_t iree_hal_replay_recorder_allocator_physical_memory_free(
@@ -457,14 +582,43 @@ static iree_status_t iree_hal_replay_recorder_allocator_physical_memory_free(
     iree_hal_physical_memory_t* IREE_RESTRICT physical_memory) {
   iree_hal_replay_recorder_allocator_t* allocator =
       iree_hal_replay_recorder_allocator_cast(base_allocator);
+  iree_slim_mutex_lock(&allocator->virtual_memory_mutex);
+  iree_hal_replay_recorder_physical_memory_t* replay_physical_memory =
+      iree_hal_replay_recorder_allocator_find_physical_memory_locked(
+          allocator, physical_memory);
+  if (IREE_UNLIKELY(!replay_physical_memory)) {
+    iree_slim_mutex_unlock(&allocator->virtual_memory_mutex);
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "physical memory was not allocated by this replay recorder allocator");
+  }
+  const iree_hal_replay_allocator_physical_memory_free_payload_t payload = {
+      .physical_memory_id = replay_physical_memory->physical_memory_id,
+  };
+  const iree_const_byte_span_t iovec =
+      iree_make_const_byte_span((const uint8_t*)&payload, sizeof(payload));
   iree_hal_replay_pending_record_t pending_record;
-  IREE_RETURN_IF_ERROR(iree_hal_replay_recorder_allocator_begin_operation(
-      allocator, IREE_HAL_REPLAY_OBJECT_ID_NONE,
+  iree_hal_replay_recorder_allocator_begin_passthrough_operation(
+      allocator, replay_physical_memory->physical_memory_id,
       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
-      IREE_HAL_REPLAY_PAYLOAD_TYPE_NONE, &pending_record));
-  return iree_hal_replay_recorder_end_operation(
-      &pending_record, iree_hal_allocator_physical_memory_free(
-                           allocator->base_allocator, physical_memory));
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_PHYSICAL_MEMORY_FREE,
+      &pending_record);
+  iree_status_t status = iree_hal_allocator_physical_memory_free(
+      allocator->base_allocator, replay_physical_memory->base_physical_memory);
+  const bool consumed = iree_status_is_ok(status);
+  if (consumed) {
+    iree_hal_replay_recorder_physical_memory_t** link =
+        &allocator->physical_memory_list;
+    while (*link != replay_physical_memory) link = &(*link)->next;
+    *link = replay_physical_memory->next;
+  }
+  status = iree_hal_replay_recorder_end_passthrough_operation_with_payload(
+      &pending_record, status, 1, &iovec);
+  iree_slim_mutex_unlock(&allocator->virtual_memory_mutex);
+  if (consumed) {
+    iree_allocator_free(allocator->host_allocator, replay_physical_memory);
+  }
+  return status;
 }
 
 static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_map(
@@ -475,17 +629,47 @@ static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_map(
     iree_device_size_t physical_offset, iree_device_size_t size) {
   iree_hal_replay_recorder_allocator_t* allocator =
       iree_hal_replay_recorder_allocator_cast(base_allocator);
+  iree_slim_mutex_lock(&allocator->virtual_memory_mutex);
+  iree_hal_replay_object_id_t virtual_buffer_id =
+      IREE_HAL_REPLAY_OBJECT_ID_NONE;
+  iree_hal_buffer_t* base_buffer = NULL;
+  iree_status_t status = iree_hal_replay_recorder_buffer_resolve_virtual_memory(
+      virtual_buffer, allocator->recorder, allocator->allocator_id,
+      &virtual_buffer_id, &base_buffer);
+  iree_hal_replay_recorder_physical_memory_t* replay_physical_memory =
+      iree_hal_replay_recorder_allocator_find_physical_memory_locked(
+          allocator, physical_memory);
+  if (iree_status_is_ok(status) && !replay_physical_memory) {
+    status = iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "physical memory was not allocated by this replay recorder allocator");
+  }
+  if (!iree_status_is_ok(status)) {
+    iree_slim_mutex_unlock(&allocator->virtual_memory_mutex);
+    return status;
+  }
+  const iree_hal_replay_allocator_virtual_memory_map_payload_t payload = {
+      .virtual_buffer_id = virtual_buffer_id,
+      .physical_memory_id = replay_physical_memory->physical_memory_id,
+      .virtual_offset = virtual_offset,
+      .physical_offset = physical_offset,
+      .size = size,
+  };
+  const iree_const_byte_span_t iovec =
+      iree_make_const_byte_span((const uint8_t*)&payload, sizeof(payload));
   iree_hal_replay_pending_record_t pending_record;
-  IREE_RETURN_IF_ERROR(iree_hal_replay_recorder_allocator_begin_operation(
-      allocator, IREE_HAL_REPLAY_OBJECT_ID_NONE,
+  iree_hal_replay_recorder_allocator_begin_passthrough_operation(
+      allocator, virtual_buffer_id,
       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
-      IREE_HAL_REPLAY_PAYLOAD_TYPE_NONE, &pending_record));
-  return iree_hal_replay_recorder_end_operation(
-      &pending_record,
-      iree_hal_allocator_virtual_memory_map(
-          allocator->base_allocator,
-          iree_hal_replay_recorder_buffer_base_or_self(virtual_buffer),
-          virtual_offset, physical_memory, physical_offset, size));
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_MAP,
+      &pending_record);
+  status = iree_hal_allocator_virtual_memory_map(
+      allocator->base_allocator, base_buffer, virtual_offset,
+      replay_physical_memory->base_physical_memory, physical_offset, size);
+  status = iree_hal_replay_recorder_end_passthrough_operation_with_payload(
+      &pending_record, status, 1, &iovec);
+  iree_slim_mutex_unlock(&allocator->virtual_memory_mutex);
+  return status;
 }
 
 static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_unmap(
@@ -494,17 +678,36 @@ static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_unmap(
     iree_device_size_t virtual_offset, iree_device_size_t size) {
   iree_hal_replay_recorder_allocator_t* allocator =
       iree_hal_replay_recorder_allocator_cast(base_allocator);
+  iree_slim_mutex_lock(&allocator->virtual_memory_mutex);
+  iree_hal_replay_object_id_t virtual_buffer_id =
+      IREE_HAL_REPLAY_OBJECT_ID_NONE;
+  iree_hal_buffer_t* base_buffer = NULL;
+  iree_status_t status = iree_hal_replay_recorder_buffer_resolve_virtual_memory(
+      virtual_buffer, allocator->recorder, allocator->allocator_id,
+      &virtual_buffer_id, &base_buffer);
+  if (!iree_status_is_ok(status)) {
+    iree_slim_mutex_unlock(&allocator->virtual_memory_mutex);
+    return status;
+  }
+  const iree_hal_replay_allocator_virtual_memory_unmap_payload_t payload = {
+      .virtual_buffer_id = virtual_buffer_id,
+      .virtual_offset = virtual_offset,
+      .size = size,
+  };
+  const iree_const_byte_span_t iovec =
+      iree_make_const_byte_span((const uint8_t*)&payload, sizeof(payload));
   iree_hal_replay_pending_record_t pending_record;
-  IREE_RETURN_IF_ERROR(iree_hal_replay_recorder_allocator_begin_operation(
-      allocator, IREE_HAL_REPLAY_OBJECT_ID_NONE,
+  iree_hal_replay_recorder_allocator_begin_passthrough_operation(
+      allocator, virtual_buffer_id,
       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
-      IREE_HAL_REPLAY_PAYLOAD_TYPE_NONE, &pending_record));
-  return iree_hal_replay_recorder_end_operation(
-      &pending_record,
-      iree_hal_allocator_virtual_memory_unmap(
-          allocator->base_allocator,
-          iree_hal_replay_recorder_buffer_base_or_self(virtual_buffer),
-          virtual_offset, size));
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP,
+      &pending_record);
+  status = iree_hal_allocator_virtual_memory_unmap(
+      allocator->base_allocator, base_buffer, virtual_offset, size);
+  status = iree_hal_replay_recorder_end_passthrough_operation_with_payload(
+      &pending_record, status, 1, &iovec);
+  iree_slim_mutex_unlock(&allocator->virtual_memory_mutex);
+  return status;
 }
 
 static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_protect(
@@ -512,20 +715,44 @@ static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_protect(
     iree_hal_buffer_t* IREE_RESTRICT virtual_buffer,
     iree_device_size_t virtual_offset, iree_device_size_t size,
     iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
     iree_hal_memory_protection_t protection) {
   iree_hal_replay_recorder_allocator_t* allocator =
       iree_hal_replay_recorder_allocator_cast(base_allocator);
+  iree_slim_mutex_lock(&allocator->virtual_memory_mutex);
+  iree_hal_replay_object_id_t virtual_buffer_id =
+      IREE_HAL_REPLAY_OBJECT_ID_NONE;
+  iree_hal_buffer_t* base_buffer = NULL;
+  iree_status_t status = iree_hal_replay_recorder_buffer_resolve_virtual_memory(
+      virtual_buffer, allocator->recorder, allocator->allocator_id,
+      &virtual_buffer_id, &base_buffer);
+  if (!iree_status_is_ok(status)) {
+    iree_slim_mutex_unlock(&allocator->virtual_memory_mutex);
+    return status;
+  }
+  const iree_hal_replay_allocator_virtual_memory_protect_payload_t payload = {
+      .virtual_buffer_id = virtual_buffer_id,
+      .virtual_offset = virtual_offset,
+      .size = size,
+      .queue_family_affinity = queue_family_affinity,
+      .access_scope = access_scope,
+      .protection = protection,
+  };
+  const iree_const_byte_span_t iovec =
+      iree_make_const_byte_span((const uint8_t*)&payload, sizeof(payload));
   iree_hal_replay_pending_record_t pending_record;
-  IREE_RETURN_IF_ERROR(iree_hal_replay_recorder_allocator_begin_operation(
-      allocator, IREE_HAL_REPLAY_OBJECT_ID_NONE,
+  iree_hal_replay_recorder_allocator_begin_passthrough_operation(
+      allocator, virtual_buffer_id,
       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT,
-      IREE_HAL_REPLAY_PAYLOAD_TYPE_NONE, &pending_record));
-  return iree_hal_replay_recorder_end_operation(
-      &pending_record,
-      iree_hal_allocator_virtual_memory_protect(
-          allocator->base_allocator,
-          iree_hal_replay_recorder_buffer_base_or_self(virtual_buffer),
-          virtual_offset, size, queue_family_affinity, protection));
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT,
+      &pending_record);
+  status = iree_hal_allocator_virtual_memory_protect(
+      allocator->base_allocator, base_buffer, virtual_offset, size,
+      queue_family_affinity, access_scope, protection);
+  status = iree_hal_replay_recorder_end_passthrough_operation_with_payload(
+      &pending_record, status, 1, &iovec);
+  iree_slim_mutex_unlock(&allocator->virtual_memory_mutex);
+  return status;
 }
 
 static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_advise(
@@ -536,17 +763,39 @@ static iree_status_t iree_hal_replay_recorder_allocator_virtual_memory_advise(
     iree_hal_memory_advice_t advice) {
   iree_hal_replay_recorder_allocator_t* allocator =
       iree_hal_replay_recorder_allocator_cast(base_allocator);
+  iree_slim_mutex_lock(&allocator->virtual_memory_mutex);
+  iree_hal_replay_object_id_t virtual_buffer_id =
+      IREE_HAL_REPLAY_OBJECT_ID_NONE;
+  iree_hal_buffer_t* base_buffer = NULL;
+  iree_status_t status = iree_hal_replay_recorder_buffer_resolve_virtual_memory(
+      virtual_buffer, allocator->recorder, allocator->allocator_id,
+      &virtual_buffer_id, &base_buffer);
+  if (!iree_status_is_ok(status)) {
+    iree_slim_mutex_unlock(&allocator->virtual_memory_mutex);
+    return status;
+  }
+  const iree_hal_replay_allocator_virtual_memory_advise_payload_t payload = {
+      .virtual_buffer_id = virtual_buffer_id,
+      .virtual_offset = virtual_offset,
+      .size = size,
+      .queue_family_affinity = queue_family_affinity,
+      .advice = advice,
+  };
+  const iree_const_byte_span_t iovec =
+      iree_make_const_byte_span((const uint8_t*)&payload, sizeof(payload));
   iree_hal_replay_pending_record_t pending_record;
-  IREE_RETURN_IF_ERROR(iree_hal_replay_recorder_allocator_begin_operation(
-      allocator, IREE_HAL_REPLAY_OBJECT_ID_NONE,
+  iree_hal_replay_recorder_allocator_begin_passthrough_operation(
+      allocator, virtual_buffer_id,
       IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE,
-      IREE_HAL_REPLAY_PAYLOAD_TYPE_NONE, &pending_record));
-  return iree_hal_replay_recorder_end_operation(
-      &pending_record,
-      iree_hal_allocator_virtual_memory_advise(
-          allocator->base_allocator,
-          iree_hal_replay_recorder_buffer_base_or_self(virtual_buffer),
-          virtual_offset, size, queue_family_affinity, advice));
+      IREE_HAL_REPLAY_PAYLOAD_TYPE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE,
+      &pending_record);
+  status = iree_hal_allocator_virtual_memory_advise(
+      allocator->base_allocator, base_buffer, virtual_offset, size,
+      queue_family_affinity, advice);
+  status = iree_hal_replay_recorder_end_passthrough_operation_with_payload(
+      &pending_record, status, 1, &iovec);
+  iree_slim_mutex_unlock(&allocator->virtual_memory_mutex);
+  return status;
 }
 
 iree_status_t iree_hal_replay_recorder_wrap_allocator(
@@ -562,6 +811,7 @@ iree_status_t iree_hal_replay_recorder_wrap_allocator(
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(host_allocator, sizeof(*allocator),
                                              (void**)&allocator));
   memset(allocator, 0, sizeof(*allocator));
+  iree_slim_mutex_initialize(&allocator->virtual_memory_mutex);
   iree_hal_resource_initialize(&iree_hal_replay_recorder_allocator_vtable,
                                &allocator->resource);
   allocator->host_allocator = host_allocator;
@@ -579,6 +829,7 @@ iree_status_t iree_hal_replay_recorder_wrap_allocator(
   if (iree_status_is_ok(status)) {
     *out_allocator = (iree_hal_allocator_t*)allocator;
   } else {
+    iree_slim_mutex_deinitialize(&allocator->virtual_memory_mutex);
     iree_hal_allocator_release(allocator->base_allocator);
     iree_hal_replay_recorder_release(allocator->recorder);
     iree_allocator_free(host_allocator, allocator);

--- a/runtime/src/iree/hal/replay/recorder_buffer.c
+++ b/runtime/src/iree/hal/replay/recorder_buffer.c
@@ -33,6 +33,9 @@ struct iree_hal_replay_recorder_buffer_t {
   iree_hal_replay_object_id_t device_id;
   // Session-local object id assigned to this buffer.
   iree_hal_replay_object_id_t buffer_id;
+  // Recorder allocator ID for virtual reservations, or NONE for ordinary
+  // buffers.
+  iree_hal_replay_object_id_t virtual_memory_allocator_id;
   // Mutex guarding active write mappings.
   iree_slim_mutex_t mutex;
   // Active write mappings whose flush/unmap bytes may need capture.
@@ -123,9 +126,10 @@ void iree_hal_replay_recorder_buffer_ref_make_payload(
 
 iree_status_t iree_hal_replay_recorder_buffer_create_proxy(
     iree_hal_replay_recorder_t* recorder, iree_hal_replay_object_id_t device_id,
-    iree_hal_replay_object_id_t buffer_id, iree_hal_device_t* placement_device,
-    iree_hal_buffer_t* base_buffer, iree_allocator_t host_allocator,
-    iree_hal_buffer_t** out_buffer) {
+    iree_hal_replay_object_id_t buffer_id,
+    iree_hal_replay_object_id_t virtual_memory_allocator_id,
+    iree_hal_device_t* placement_device, iree_hal_buffer_t* base_buffer,
+    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer) {
   IREE_ASSERT_ARGUMENT(recorder);
   IREE_ASSERT_ARGUMENT(base_buffer);
   IREE_ASSERT_ARGUMENT(out_buffer);
@@ -140,8 +144,8 @@ iree_status_t iree_hal_replay_recorder_buffer_create_proxy(
   IREE_RETURN_IF_ERROR(
       iree_hal_replay_recorder_buffer_allocate_proxy(host_allocator, &buffer));
   *out_buffer = iree_hal_replay_recorder_buffer_initialize_proxy(
-      recorder, device_id, buffer_id, placement_device, base_buffer,
-      host_allocator, buffer);
+      recorder, device_id, buffer_id, virtual_memory_allocator_id,
+      placement_device, base_buffer, host_allocator, buffer);
   return iree_ok_status();
 }
 
@@ -165,8 +169,10 @@ void iree_hal_replay_recorder_buffer_free_proxy(
 
 iree_hal_buffer_t* iree_hal_replay_recorder_buffer_initialize_proxy(
     iree_hal_replay_recorder_t* recorder, iree_hal_replay_object_id_t device_id,
-    iree_hal_replay_object_id_t buffer_id, iree_hal_device_t* placement_device,
-    iree_hal_buffer_t* base_buffer, iree_allocator_t host_allocator,
+    iree_hal_replay_object_id_t buffer_id,
+    iree_hal_replay_object_id_t virtual_memory_allocator_id,
+    iree_hal_device_t* placement_device, iree_hal_buffer_t* base_buffer,
+    iree_allocator_t host_allocator,
     iree_hal_replay_recorder_buffer_t* buffer) {
   IREE_ASSERT_ARGUMENT(recorder);
   IREE_ASSERT_ARGUMENT(base_buffer);
@@ -191,9 +197,41 @@ iree_hal_buffer_t* iree_hal_replay_recorder_buffer_initialize_proxy(
   iree_hal_buffer_retain(buffer->base_buffer);
   buffer->device_id = device_id;
   buffer->buffer_id = buffer_id;
+  buffer->virtual_memory_allocator_id = virtual_memory_allocator_id;
   iree_slim_mutex_initialize(&buffer->mutex);
 
   return &buffer->base;
+}
+
+iree_status_t iree_hal_replay_recorder_buffer_resolve_virtual_memory(
+    iree_hal_buffer_t* buffer, iree_hal_replay_recorder_t* expected_recorder,
+    iree_hal_replay_object_id_t expected_allocator_id,
+    iree_hal_replay_object_id_t* out_buffer_id,
+    iree_hal_buffer_t** out_base_buffer) {
+  IREE_ASSERT_ARGUMENT(out_buffer_id);
+  IREE_ASSERT_ARGUMENT(out_base_buffer);
+  *out_buffer_id = IREE_HAL_REPLAY_OBJECT_ID_NONE;
+  *out_base_buffer = NULL;
+  if (IREE_UNLIKELY(!buffer || !iree_hal_replay_recorder_buffer_isa(buffer))) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "virtual memory reservation was not created by this replay recorder "
+        "allocator");
+  }
+  iree_hal_replay_recorder_buffer_t* replay_buffer =
+      iree_hal_replay_recorder_buffer_cast(buffer);
+  if (IREE_UNLIKELY(replay_buffer->recorder != expected_recorder ||
+                    replay_buffer->virtual_memory_allocator_id !=
+                        expected_allocator_id ||
+                    !replay_buffer->base_buffer)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "virtual memory reservation belongs to another replay recorder "
+        "allocator or was already released");
+  }
+  *out_buffer_id = replay_buffer->buffer_id;
+  *out_base_buffer = replay_buffer->base_buffer;
+  return iree_ok_status();
 }
 
 iree_hal_buffer_t* iree_hal_replay_recorder_buffer_base_or_self(
@@ -201,6 +239,14 @@ iree_hal_buffer_t* iree_hal_replay_recorder_buffer_base_or_self(
   return iree_hal_replay_recorder_buffer_isa(buffer)
              ? iree_hal_replay_recorder_buffer_cast(buffer)->base_buffer
              : buffer;
+}
+
+void iree_hal_replay_recorder_buffer_consume_virtual_memory(
+    iree_hal_buffer_t* buffer) {
+  iree_hal_replay_recorder_buffer_t* replay_buffer =
+      iree_hal_replay_recorder_buffer_cast(buffer);
+  replay_buffer->base_buffer = NULL;
+  iree_hal_buffer_release(buffer);
 }
 
 iree_status_t iree_hal_replay_recorder_buffer_unwrap_for_call(

--- a/runtime/src/iree/hal/replay/recorder_buffer.h
+++ b/runtime/src/iree/hal/replay/recorder_buffer.h
@@ -37,9 +37,10 @@ iree_hal_replay_object_id_t iree_hal_replay_recorder_find_buffer_id(
 
 iree_status_t iree_hal_replay_recorder_buffer_create_proxy(
     iree_hal_replay_recorder_t* recorder, iree_hal_replay_object_id_t device_id,
-    iree_hal_replay_object_id_t buffer_id, iree_hal_device_t* placement_device,
-    iree_hal_buffer_t* base_buffer, iree_allocator_t host_allocator,
-    iree_hal_buffer_t** out_buffer);
+    iree_hal_replay_object_id_t buffer_id,
+    iree_hal_replay_object_id_t virtual_memory_allocator_id,
+    iree_hal_device_t* placement_device, iree_hal_buffer_t* base_buffer,
+    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer);
 
 // Allocates uninitialized proxy storage so a caller can complete all fallible
 // host allocation before submitting a queue operation.
@@ -55,11 +56,26 @@ void iree_hal_replay_recorder_buffer_free_proxy(
 // Initialization is infallible and transfers no caller-owned references.
 iree_hal_buffer_t* iree_hal_replay_recorder_buffer_initialize_proxy(
     iree_hal_replay_recorder_t* recorder, iree_hal_replay_object_id_t device_id,
-    iree_hal_replay_object_id_t buffer_id, iree_hal_device_t* placement_device,
-    iree_hal_buffer_t* base_buffer, iree_allocator_t host_allocator,
-    iree_hal_replay_recorder_buffer_t* buffer);
+    iree_hal_replay_object_id_t buffer_id,
+    iree_hal_replay_object_id_t virtual_memory_allocator_id,
+    iree_hal_device_t* placement_device, iree_hal_buffer_t* base_buffer,
+    iree_allocator_t host_allocator, iree_hal_replay_recorder_buffer_t* buffer);
+
+// Resolves a live virtual memory reservation created by |expected_recorder| and
+// |expected_allocator_id|. Foreign, ordinary, subspan, and consumed buffers
+// are rejected without exposing a backend handle.
+iree_status_t iree_hal_replay_recorder_buffer_resolve_virtual_memory(
+    iree_hal_buffer_t* buffer, iree_hal_replay_recorder_t* expected_recorder,
+    iree_hal_replay_object_id_t expected_allocator_id,
+    iree_hal_replay_object_id_t* out_buffer_id,
+    iree_hal_buffer_t** out_base_buffer);
 
 iree_hal_buffer_t* iree_hal_replay_recorder_buffer_base_or_self(
+    iree_hal_buffer_t* buffer);
+
+// Detaches the backend reservation consumed by a successful release and drops
+// the caller-owned recording proxy reference.
+void iree_hal_replay_recorder_buffer_consume_virtual_memory(
     iree_hal_buffer_t* buffer);
 
 iree_status_t iree_hal_replay_recorder_buffer_unwrap_for_call(

--- a/runtime/src/iree/hal/replay/recorder_queue.c
+++ b/runtime/src/iree/hal/replay/recorder_queue.c
@@ -1491,8 +1491,9 @@ static iree_status_t iree_hal_replay_recorder_queue_alloca(
       storage.replay_buffers[i] =
           iree_hal_replay_recorder_buffer_initialize_proxy(
               queue->recorder, queue->device_id, buffer_id,
-              queue->placement_device, storage.base_buffers[i],
-              queue->host_allocator, storage.proxy_buffers[i]);
+              IREE_HAL_REPLAY_OBJECT_ID_NONE, queue->placement_device,
+              storage.base_buffers[i], queue->host_allocator,
+              storage.proxy_buffers[i]);
       storage.proxy_buffers[i] = NULL;
       if (can_record) {
         iree_hal_replay_recorder_buffer_make_object_payload(

--- a/runtime/src/iree/hal/replay/recorder_record.h
+++ b/runtime/src/iree/hal/replay/recorder_record.h
@@ -110,6 +110,17 @@ iree_status_t iree_hal_replay_recorder_end_operation_with_payload(
     iree_status_t operation_status, iree_host_size_t iovec_count,
     const iree_const_byte_span_t* iovecs);
 
+// Completes a forwarded stateful operation without allowing capture I/O to
+// change the status observed by the caller. Capture failures remain latched on
+// the recorder and are reported by iree_hal_replay_recorder_close.
+//
+// A zero-initialized |pending_record| skips recording so stateful teardown can
+// still reach the wrapped allocator after capture has become terminal.
+iree_status_t iree_hal_replay_recorder_end_passthrough_operation_with_payload(
+    iree_hal_replay_pending_record_t* pending_record,
+    iree_status_t operation_status, iree_host_size_t iovec_count,
+    const iree_const_byte_span_t* iovecs);
+
 // Completes a creation operation and atomically appends its successfully
 // created object record before releasing the recorder mutex. Returns
 // |operation_status| unchanged; record write failures become terminal recorder

--- a/runtime/src/iree/hal/replay/recorder_test.cc
+++ b/runtime/src/iree/hal/replay/recorder_test.cc
@@ -16,6 +16,7 @@
 #include "iree/hal/drivers/task/registration/driver_module.h"
 #include "iree/hal/replay/execute.h"
 #include "iree/hal/replay/file_reader.h"
+#include "iree/hal/replay/recorder_allocator.h"
 #include "iree/hal/replay/recorder_record.h"
 #include "iree/hal/testing/mock_device.h"
 #include "iree/io/file_contents.h"
@@ -1492,6 +1493,802 @@ TEST(ReplayRecorderTest, RecordsExactQueueAtomicOperations) {
   EXPECT_EQ(signal_timepoint.semaphore_id, rmw_signal_timepoint.semaphore_id);
   EXPECT_EQ(7u, rmw_wait_timepoint.value);
   EXPECT_EQ(11u, rmw_signal_timepoint.value);
+}
+
+// Minimal VMM allocator used to verify recorder identity and forwarding rules.
+typedef struct RecorderVmmAllocatorState {
+  iree_host_size_t reserve_count = 0;
+  iree_host_size_t release_attempt_count = 0;
+  iree_host_size_t release_count = 0;
+  iree_host_size_t physical_allocate_count = 0;
+  iree_host_size_t physical_free_attempt_count = 0;
+  iree_host_size_t physical_free_count = 0;
+  iree_host_size_t map_count = 0;
+  iree_host_size_t unmap_count = 0;
+  iree_host_size_t protect_count = 0;
+  iree_host_size_t advise_count = 0;
+  iree_host_size_t release_failures_remaining = 0;
+  iree_host_size_t physical_free_failures_remaining = 0;
+  iree_hal_buffer_t* virtual_buffer = nullptr;
+  iree_hal_physical_memory_t* physical_memory = nullptr;
+  bool is_mapped = false;
+  iree_hal_queue_family_affinity_t reserve_queue_family_affinity = 0;
+  iree_device_size_t reserve_size = 0;
+  iree_hal_buffer_params_t physical_params = {};
+  iree_device_size_t physical_size = 0;
+  iree_device_size_t map_virtual_offset = 0;
+  iree_device_size_t map_physical_offset = 0;
+  iree_device_size_t map_size = 0;
+  iree_hal_queue_family_affinity_t protect_queue_family_affinity = 0;
+  iree_hal_virtual_memory_access_scope_t protect_access_scope = 0;
+  iree_hal_memory_protection_t protection = 0;
+  iree_hal_queue_family_affinity_t advise_queue_family_affinity = 0;
+  iree_hal_memory_advice_t advice = 0;
+} RecorderVmmAllocatorState;
+
+typedef struct RecorderVmmPhysicalMemory {
+  iree_allocator_t host_allocator;
+} RecorderVmmPhysicalMemory;
+
+typedef struct RecorderVmmAllocator {
+  iree_hal_resource_t resource;
+  iree_allocator_t host_allocator;
+  iree_hal_allocator_t* heap_allocator;
+  RecorderVmmAllocatorState* state;
+} RecorderVmmAllocator;
+
+extern const iree_hal_allocator_vtable_t recorder_vmm_allocator_vtable;
+
+static RecorderVmmAllocator* RecorderVmmAllocatorCast(
+    iree_hal_allocator_t* base_allocator) {
+  IREE_HAL_ASSERT_TYPE(base_allocator, &recorder_vmm_allocator_vtable);
+  return reinterpret_cast<RecorderVmmAllocator*>(base_allocator);
+}
+
+static void RecorderVmmAllocatorDestroy(iree_hal_allocator_t* base_allocator) {
+  RecorderVmmAllocator* allocator = RecorderVmmAllocatorCast(base_allocator);
+  iree_allocator_t host_allocator = allocator->host_allocator;
+  iree_hal_allocator_release(allocator->heap_allocator);
+  iree_allocator_free(host_allocator, allocator);
+}
+
+static iree_allocator_t RecorderVmmAllocatorHostAllocator(
+    const iree_hal_allocator_t* base_allocator) {
+  const RecorderVmmAllocator* allocator =
+      reinterpret_cast<const RecorderVmmAllocator*>(base_allocator);
+  return allocator->host_allocator;
+}
+
+static iree_status_t RecorderVmmAllocatorAllocateBuffer(
+    iree_hal_allocator_t* base_allocator,
+    const iree_hal_buffer_params_t* params, iree_device_size_t allocation_size,
+    iree_hal_buffer_t** out_buffer) {
+  RecorderVmmAllocator* allocator = RecorderVmmAllocatorCast(base_allocator);
+  return iree_hal_allocator_allocate_buffer(allocator->heap_allocator, *params,
+                                            allocation_size, out_buffer);
+}
+
+static bool RecorderVmmAllocatorSupportsVirtualMemory(
+    iree_hal_allocator_t* base_allocator) {
+  return true;
+}
+
+static iree_status_t RecorderVmmAllocatorQueryGranularity(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_params_t params,
+    iree_device_size_t* out_minimum_page_size,
+    iree_device_size_t* out_recommended_page_size) {
+  *out_minimum_page_size = 4096;
+  *out_recommended_page_size = 65536;
+  return iree_ok_status();
+}
+
+static iree_status_t RecorderVmmAllocatorReserve(
+    iree_hal_allocator_t* base_allocator,
+    iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_device_size_t size, iree_hal_buffer_t** out_virtual_buffer) {
+  RecorderVmmAllocator* allocator = RecorderVmmAllocatorCast(base_allocator);
+  RecorderVmmAllocatorState* state = allocator->state;
+  if (state->virtual_buffer) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test allocator already has a reservation");
+  }
+  iree_hal_buffer_params_t params = {};
+  params.usage = IREE_HAL_BUFFER_USAGE_STORAGE;
+  params.access = IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE;
+  params.type =
+      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
+  params.queue_family_affinity = queue_family_affinity;
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
+      allocator->heap_allocator, params, size, out_virtual_buffer));
+  state->virtual_buffer = *out_virtual_buffer;
+  state->reserve_queue_family_affinity = queue_family_affinity;
+  state->reserve_size = size;
+  ++state->reserve_count;
+  return iree_ok_status();
+}
+
+static iree_status_t RecorderVmmAllocatorRelease(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* virtual_buffer) {
+  RecorderVmmAllocator* allocator = RecorderVmmAllocatorCast(base_allocator);
+  RecorderVmmAllocatorState* state = allocator->state;
+  ++state->release_attempt_count;
+  if (virtual_buffer != state->virtual_buffer) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "test reservation handle mismatch");
+  }
+  if (state->release_failures_remaining) {
+    --state->release_failures_remaining;
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "injected reservation release failure");
+  }
+  if (state->is_mapped) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test reservation is still mapped");
+  }
+  state->virtual_buffer = nullptr;
+  ++state->release_count;
+  iree_hal_buffer_release(virtual_buffer);
+  return iree_ok_status();
+}
+
+static iree_status_t RecorderVmmAllocatorAllocatePhysicalMemory(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_params_t params,
+    iree_device_size_t size, iree_allocator_t host_allocator,
+    iree_hal_physical_memory_t** out_physical_memory) {
+  RecorderVmmAllocator* allocator = RecorderVmmAllocatorCast(base_allocator);
+  RecorderVmmAllocatorState* state = allocator->state;
+  if (state->physical_memory) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test allocator already has physical memory");
+  }
+  RecorderVmmPhysicalMemory* physical_memory = nullptr;
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(host_allocator, sizeof(*physical_memory),
+                            reinterpret_cast<void**>(&physical_memory)));
+  physical_memory->host_allocator = host_allocator;
+  state->physical_memory =
+      reinterpret_cast<iree_hal_physical_memory_t*>(physical_memory);
+  state->physical_params = params;
+  state->physical_size = size;
+  ++state->physical_allocate_count;
+  *out_physical_memory = state->physical_memory;
+  return iree_ok_status();
+}
+
+static iree_status_t RecorderVmmAllocatorFreePhysicalMemory(
+    iree_hal_allocator_t* base_allocator,
+    iree_hal_physical_memory_t* physical_memory) {
+  RecorderVmmAllocator* allocator = RecorderVmmAllocatorCast(base_allocator);
+  RecorderVmmAllocatorState* state = allocator->state;
+  ++state->physical_free_attempt_count;
+  if (physical_memory != state->physical_memory) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "test physical memory handle mismatch");
+  }
+  if (state->physical_free_failures_remaining) {
+    --state->physical_free_failures_remaining;
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "injected physical memory free failure");
+  }
+  if (state->is_mapped) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test physical memory is still mapped");
+  }
+  RecorderVmmPhysicalMemory* test_physical_memory =
+      reinterpret_cast<RecorderVmmPhysicalMemory*>(physical_memory);
+  iree_allocator_t host_allocator = test_physical_memory->host_allocator;
+  state->physical_memory = nullptr;
+  ++state->physical_free_count;
+  iree_allocator_free(host_allocator, test_physical_memory);
+  return iree_ok_status();
+}
+
+static iree_status_t RecorderVmmAllocatorMap(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* virtual_buffer,
+    iree_device_size_t virtual_offset,
+    iree_hal_physical_memory_t* physical_memory,
+    iree_device_size_t physical_offset, iree_device_size_t size) {
+  RecorderVmmAllocator* allocator = RecorderVmmAllocatorCast(base_allocator);
+  RecorderVmmAllocatorState* state = allocator->state;
+  if (virtual_buffer != state->virtual_buffer ||
+      physical_memory != state->physical_memory || state->is_mapped) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test mapping state mismatch");
+  }
+  state->is_mapped = true;
+  state->map_virtual_offset = virtual_offset;
+  state->map_physical_offset = physical_offset;
+  state->map_size = size;
+  ++state->map_count;
+  return iree_ok_status();
+}
+
+static iree_status_t RecorderVmmAllocatorUnmap(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* virtual_buffer,
+    iree_device_size_t virtual_offset, iree_device_size_t size) {
+  RecorderVmmAllocator* allocator = RecorderVmmAllocatorCast(base_allocator);
+  RecorderVmmAllocatorState* state = allocator->state;
+  if (virtual_buffer != state->virtual_buffer || !state->is_mapped ||
+      virtual_offset != state->map_virtual_offset || size != state->map_size) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test unmapping state mismatch");
+  }
+  state->is_mapped = false;
+  ++state->unmap_count;
+  return iree_ok_status();
+}
+
+static iree_status_t RecorderVmmAllocatorProtect(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* virtual_buffer,
+    iree_device_size_t virtual_offset, iree_device_size_t size,
+    iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_hal_virtual_memory_access_scope_t access_scope,
+    iree_hal_memory_protection_t protection) {
+  RecorderVmmAllocator* allocator = RecorderVmmAllocatorCast(base_allocator);
+  RecorderVmmAllocatorState* state = allocator->state;
+  if (virtual_buffer != state->virtual_buffer || !state->is_mapped ||
+      virtual_offset != state->map_virtual_offset || size != state->map_size) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test protection state mismatch");
+  }
+  state->protect_queue_family_affinity = queue_family_affinity;
+  state->protect_access_scope = access_scope;
+  state->protection = protection;
+  ++state->protect_count;
+  return iree_ok_status();
+}
+
+static iree_status_t RecorderVmmAllocatorAdvise(
+    iree_hal_allocator_t* base_allocator, iree_hal_buffer_t* virtual_buffer,
+    iree_device_size_t virtual_offset, iree_device_size_t size,
+    iree_hal_queue_family_affinity_t queue_family_affinity,
+    iree_hal_memory_advice_t advice) {
+  RecorderVmmAllocator* allocator = RecorderVmmAllocatorCast(base_allocator);
+  RecorderVmmAllocatorState* state = allocator->state;
+  if (virtual_buffer != state->virtual_buffer || !state->is_mapped ||
+      virtual_offset != state->map_virtual_offset || size != state->map_size) {
+    return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
+                            "test advice state mismatch");
+  }
+  state->advise_queue_family_affinity = queue_family_affinity;
+  state->advice = advice;
+  ++state->advise_count;
+  return iree_ok_status();
+}
+
+const iree_hal_allocator_vtable_t recorder_vmm_allocator_vtable = {
+    /*.destroy=*/RecorderVmmAllocatorDestroy,
+    /*.host_allocator=*/RecorderVmmAllocatorHostAllocator,
+    /*.trim=*/nullptr,
+    /*.query_statistics=*/nullptr,
+    /*.query_memory_heaps=*/nullptr,
+    /*.query_buffer_compatibility=*/nullptr,
+    /*.allocate_buffer=*/RecorderVmmAllocatorAllocateBuffer,
+    /*.deallocate_buffer=*/nullptr,
+    /*.import_buffer=*/nullptr,
+    /*.export_buffer=*/nullptr,
+    /*.supports_virtual_memory=*/RecorderVmmAllocatorSupportsVirtualMemory,
+    /*.virtual_memory_query_granularity=*/
+    RecorderVmmAllocatorQueryGranularity,
+    /*.virtual_memory_reserve=*/RecorderVmmAllocatorReserve,
+    /*.virtual_memory_release=*/RecorderVmmAllocatorRelease,
+    /*.physical_memory_allocate=*/RecorderVmmAllocatorAllocatePhysicalMemory,
+    /*.physical_memory_free=*/RecorderVmmAllocatorFreePhysicalMemory,
+    /*.virtual_memory_map=*/RecorderVmmAllocatorMap,
+    /*.virtual_memory_unmap=*/RecorderVmmAllocatorUnmap,
+    /*.virtual_memory_protect=*/RecorderVmmAllocatorProtect,
+    /*.virtual_memory_advise=*/RecorderVmmAllocatorAdvise,
+};
+
+static iree_hal_allocator_t* CreateRecorderVmmAllocator(
+    RecorderVmmAllocatorState* state) {
+  iree_hal_allocator_t* heap_allocator = nullptr;
+  IREE_CHECK_OK(iree_hal_allocator_create_heap(
+      IREE_SV("recorder-vmm-test"), iree_allocator_system(),
+      iree_allocator_system(), &heap_allocator));
+  RecorderVmmAllocator* allocator = nullptr;
+  IREE_CHECK_OK(iree_allocator_malloc(iree_allocator_system(),
+                                      sizeof(*allocator),
+                                      reinterpret_cast<void**>(&allocator)));
+  iree_hal_resource_initialize(&recorder_vmm_allocator_vtable,
+                               &allocator->resource);
+  allocator->host_allocator = iree_allocator_system();
+  allocator->heap_allocator = heap_allocator;
+  allocator->state = state;
+  return reinterpret_cast<iree_hal_allocator_t*>(allocator);
+}
+
+static iree_hal_allocator_t* WrapRecorderVmmAllocator(
+    iree_hal_replay_recorder_t* recorder, iree_hal_replay_object_id_t device_id,
+    iree_hal_allocator_t* base_allocator) {
+  iree_hal_allocator_t* wrapped_allocator = nullptr;
+  IREE_CHECK_OK(iree_hal_replay_recorder_wrap_allocator(
+      recorder, device_id, /*placement_device=*/nullptr, base_allocator,
+      iree_allocator_system(), &wrapped_allocator));
+  return wrapped_allocator;
+}
+
+constexpr iree_hal_queue_family_affinity_t kRecorderVmmQueueFamilyAffinity = 1;
+constexpr iree_device_size_t kRecorderVmmReservationSize = 16384;
+constexpr iree_device_size_t kRecorderVmmVirtualOffset = 4096;
+constexpr iree_device_size_t kRecorderVmmPhysicalOffset = 8192;
+constexpr iree_device_size_t kRecorderVmmMappingSize = 4096;
+
+static iree_hal_buffer_params_t RecorderVmmPhysicalParams() {
+  iree_hal_buffer_params_t params = {};
+  params.usage = IREE_HAL_BUFFER_USAGE_STORAGE;
+  params.access = IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE;
+  params.type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
+  params.queue_family_affinity = kRecorderVmmQueueFamilyAffinity;
+  params.min_alignment = 4096;
+  return params;
+}
+
+static bool HasCapturedObject(const std::vector<uint8_t>& storage,
+                              iree_hal_replay_object_type_t object_type,
+                              iree_hal_replay_object_id_t object_id) {
+  iree_hal_replay_file_header_t file_header;
+  iree_host_size_t offset = 0;
+  IREE_CHECK_OK(iree_hal_replay_file_parse_header(
+      iree_make_const_byte_span(storage.data(), storage.size()), &file_header,
+      &offset));
+  const iree_const_byte_span_t file_contents = iree_make_const_byte_span(
+      storage.data(), static_cast<iree_host_size_t>(file_header.file_length));
+  while (offset < file_contents.data_length) {
+    iree_hal_replay_file_record_t record;
+    IREE_CHECK_OK(iree_hal_replay_file_parse_record(file_contents, offset,
+                                                    &record, &offset));
+    if (record.header.record_type == IREE_HAL_REPLAY_FILE_RECORD_TYPE_OBJECT &&
+        record.header.object_type == object_type &&
+        record.header.object_id == object_id) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static iree_host_size_t FindCapturedOperationOffset(
+    const std::vector<uint8_t>& storage,
+    iree_hal_replay_operation_code_t operation_code) {
+  iree_hal_replay_file_header_t file_header;
+  iree_host_size_t offset = 0;
+  IREE_CHECK_OK(iree_hal_replay_file_parse_header(
+      iree_make_const_byte_span(storage.data(), storage.size()), &file_header,
+      &offset));
+  const iree_const_byte_span_t file_contents = iree_make_const_byte_span(
+      storage.data(), static_cast<iree_host_size_t>(file_header.file_length));
+  while (offset < file_contents.data_length) {
+    const iree_host_size_t record_offset = offset;
+    iree_hal_replay_file_record_t record;
+    IREE_CHECK_OK(iree_hal_replay_file_parse_record(file_contents, offset,
+                                                    &record, &offset));
+    if (record.header.record_type ==
+            IREE_HAL_REPLAY_FILE_RECORD_TYPE_OPERATION &&
+        record.header.operation_code == operation_code) {
+      return record_offset;
+    }
+  }
+  return 0;
+}
+
+static std::vector<uint8_t> CaptureMinimalRecorderVmmLifecycle() {
+  std::vector<uint8_t> storage(16384, 0);
+  iree_hal_replay_recorder_t* recorder = CreateHostAllocationRecorder(&storage);
+  RecorderVmmAllocatorState state;
+  iree_hal_allocator_t* base_allocator = CreateRecorderVmmAllocator(&state);
+  iree_hal_allocator_t* allocator =
+      WrapRecorderVmmAllocator(recorder, /*device_id=*/1, base_allocator);
+  iree_hal_buffer_t* virtual_buffer = nullptr;
+  IREE_CHECK_OK(iree_hal_allocator_virtual_memory_reserve(
+      allocator, kRecorderVmmQueueFamilyAffinity, kRecorderVmmReservationSize,
+      &virtual_buffer));
+  iree_hal_physical_memory_t* physical_memory = nullptr;
+  IREE_CHECK_OK(iree_hal_allocator_physical_memory_allocate(
+      allocator, RecorderVmmPhysicalParams(), kRecorderVmmReservationSize,
+      iree_allocator_system(), &physical_memory));
+  IREE_CHECK_OK(
+      iree_hal_allocator_physical_memory_free(allocator, physical_memory));
+  IREE_CHECK_OK(
+      iree_hal_allocator_virtual_memory_release(allocator, virtual_buffer));
+  IREE_CHECK_OK(iree_hal_replay_recorder_close(recorder));
+  iree_hal_allocator_release(allocator);
+  iree_hal_allocator_release(base_allocator);
+  iree_hal_replay_recorder_release(recorder);
+  return storage;
+}
+
+TEST(ReplayRecorderVmmTest, RecordsStableIdsAndCompletePayloads) {
+  std::vector<uint8_t> storage(32768, 0);
+  iree_hal_replay_recorder_t* recorder = CreateHostAllocationRecorder(&storage);
+  RecorderVmmAllocatorState state;
+  iree_hal_allocator_t* base_allocator = CreateRecorderVmmAllocator(&state);
+  iree_hal_allocator_t* allocator =
+      WrapRecorderVmmAllocator(recorder, /*device_id=*/1, base_allocator);
+
+  const iree_hal_buffer_params_t physical_params = RecorderVmmPhysicalParams();
+  iree_hal_buffer_t* virtual_buffer = nullptr;
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_reserve(
+      allocator, kRecorderVmmQueueFamilyAffinity, kRecorderVmmReservationSize,
+      &virtual_buffer));
+  const uintptr_t virtual_buffer_address =
+      reinterpret_cast<uintptr_t>(virtual_buffer);
+  iree_hal_physical_memory_t* physical_memory = nullptr;
+  IREE_ASSERT_OK(iree_hal_allocator_physical_memory_allocate(
+      allocator, physical_params, kRecorderVmmReservationSize,
+      iree_allocator_system(), &physical_memory));
+  const uintptr_t physical_memory_address =
+      reinterpret_cast<uintptr_t>(physical_memory);
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_map(
+      allocator, virtual_buffer, kRecorderVmmVirtualOffset, physical_memory,
+      kRecorderVmmPhysicalOffset, kRecorderVmmMappingSize));
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_protect(
+      allocator, virtual_buffer, kRecorderVmmVirtualOffset,
+      kRecorderVmmMappingSize, kRecorderVmmQueueFamilyAffinity,
+      IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
+      IREE_HAL_MEMORY_PROTECTION_READ_WRITE));
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_advise(
+      allocator, virtual_buffer, kRecorderVmmVirtualOffset,
+      kRecorderVmmMappingSize, kRecorderVmmQueueFamilyAffinity,
+      IREE_HAL_MEMORY_ADVICE_WILL_NEED));
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_unmap(
+      allocator, virtual_buffer, kRecorderVmmVirtualOffset,
+      kRecorderVmmMappingSize));
+  IREE_ASSERT_OK(
+      iree_hal_allocator_physical_memory_free(allocator, physical_memory));
+  IREE_ASSERT_OK(
+      iree_hal_allocator_virtual_memory_release(allocator, virtual_buffer));
+  IREE_ASSERT_OK(iree_hal_replay_recorder_close(recorder));
+
+  const auto records = ParseOperationRecords(storage);
+  const auto* reserve_record = FindOperationRecord(
+      records, IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RESERVE);
+  ASSERT_NE(nullptr, reserve_record);
+  ASSERT_EQ(sizeof(iree_hal_replay_allocator_virtual_memory_reserve_payload_t),
+            reserve_record->payload.data_length);
+  iree_hal_replay_allocator_virtual_memory_reserve_payload_t reserve_payload;
+  memcpy(&reserve_payload, reserve_record->payload.data,
+         sizeof(reserve_payload));
+  const iree_hal_replay_object_id_t virtual_buffer_id =
+      reserve_record->header.related_object_id;
+  EXPECT_NE(IREE_HAL_REPLAY_OBJECT_ID_NONE, virtual_buffer_id);
+  EXPECT_NE(virtual_buffer_address, static_cast<uintptr_t>(virtual_buffer_id));
+  EXPECT_EQ(kRecorderVmmQueueFamilyAffinity,
+            reserve_payload.queue_family_affinity);
+  EXPECT_EQ(kRecorderVmmReservationSize, reserve_payload.size);
+  EXPECT_TRUE(HasCapturedObject(storage, IREE_HAL_REPLAY_OBJECT_TYPE_BUFFER,
+                                virtual_buffer_id));
+
+  const auto* allocate_record = FindOperationRecord(
+      records,
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_ALLOCATE);
+  ASSERT_NE(nullptr, allocate_record);
+  ASSERT_EQ(
+      sizeof(iree_hal_replay_allocator_physical_memory_allocate_payload_t),
+      allocate_record->payload.data_length);
+  iree_hal_replay_allocator_physical_memory_allocate_payload_t allocate_payload;
+  memcpy(&allocate_payload, allocate_record->payload.data,
+         sizeof(allocate_payload));
+  const iree_hal_replay_object_id_t physical_memory_id =
+      allocate_record->header.related_object_id;
+  EXPECT_NE(IREE_HAL_REPLAY_OBJECT_ID_NONE, physical_memory_id);
+  EXPECT_NE(virtual_buffer_id, physical_memory_id);
+  EXPECT_NE(physical_memory_address,
+            static_cast<uintptr_t>(physical_memory_id));
+  EXPECT_EQ(kRecorderVmmReservationSize,
+            allocate_payload.allocation.allocation_size);
+  EXPECT_EQ(physical_params.queue_family_affinity,
+            allocate_payload.allocation.queue_family_affinity);
+  EXPECT_EQ(physical_params.min_alignment,
+            allocate_payload.allocation.min_alignment);
+  EXPECT_EQ(physical_params.usage, allocate_payload.allocation.usage);
+  EXPECT_EQ(physical_params.type, allocate_payload.allocation.type);
+  EXPECT_EQ(physical_params.access, allocate_payload.allocation.access);
+  EXPECT_EQ(0u, allocate_payload.allocation.reserved0);
+  EXPECT_EQ(0u, allocate_payload.allocation.reserved1);
+  EXPECT_TRUE(HasCapturedObject(storage,
+                                IREE_HAL_REPLAY_OBJECT_TYPE_PHYSICAL_MEMORY,
+                                physical_memory_id));
+
+  const auto* map_record = FindOperationRecord(
+      records, IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_MAP);
+  ASSERT_NE(nullptr, map_record);
+  ASSERT_EQ(sizeof(iree_hal_replay_allocator_virtual_memory_map_payload_t),
+            map_record->payload.data_length);
+  iree_hal_replay_allocator_virtual_memory_map_payload_t map_payload;
+  memcpy(&map_payload, map_record->payload.data, sizeof(map_payload));
+  EXPECT_EQ(virtual_buffer_id, map_payload.virtual_buffer_id);
+  EXPECT_EQ(physical_memory_id, map_payload.physical_memory_id);
+  EXPECT_EQ(kRecorderVmmVirtualOffset, map_payload.virtual_offset);
+  EXPECT_EQ(kRecorderVmmPhysicalOffset, map_payload.physical_offset);
+  EXPECT_EQ(kRecorderVmmMappingSize, map_payload.size);
+
+  const auto* protect_record = FindOperationRecord(
+      records, IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_PROTECT);
+  ASSERT_NE(nullptr, protect_record);
+  ASSERT_EQ(sizeof(iree_hal_replay_allocator_virtual_memory_protect_payload_t),
+            protect_record->payload.data_length);
+  iree_hal_replay_allocator_virtual_memory_protect_payload_t protect_payload;
+  memcpy(&protect_payload, protect_record->payload.data,
+         sizeof(protect_payload));
+  EXPECT_EQ(virtual_buffer_id, protect_payload.virtual_buffer_id);
+  EXPECT_EQ(kRecorderVmmVirtualOffset, protect_payload.virtual_offset);
+  EXPECT_EQ(kRecorderVmmMappingSize, protect_payload.size);
+  EXPECT_EQ(kRecorderVmmQueueFamilyAffinity,
+            protect_payload.queue_family_affinity);
+  EXPECT_EQ(IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
+            protect_payload.access_scope);
+  EXPECT_EQ(0u, protect_payload.reserved0);
+  EXPECT_EQ(IREE_HAL_MEMORY_PROTECTION_READ_WRITE, protect_payload.protection);
+
+  const auto* advise_record = FindOperationRecord(
+      records, IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_ADVISE);
+  ASSERT_NE(nullptr, advise_record);
+  iree_hal_replay_allocator_virtual_memory_advise_payload_t advise_payload;
+  ASSERT_EQ(sizeof(advise_payload), advise_record->payload.data_length);
+  memcpy(&advise_payload, advise_record->payload.data, sizeof(advise_payload));
+  EXPECT_EQ(virtual_buffer_id, advise_payload.virtual_buffer_id);
+  EXPECT_EQ(kRecorderVmmQueueFamilyAffinity,
+            advise_payload.queue_family_affinity);
+  EXPECT_EQ(IREE_HAL_MEMORY_ADVICE_WILL_NEED, advise_payload.advice);
+
+  const auto* unmap_record = FindOperationRecord(
+      records, IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_UNMAP);
+  ASSERT_NE(nullptr, unmap_record);
+  iree_hal_replay_allocator_virtual_memory_unmap_payload_t unmap_payload;
+  ASSERT_EQ(sizeof(unmap_payload), unmap_record->payload.data_length);
+  memcpy(&unmap_payload, unmap_record->payload.data, sizeof(unmap_payload));
+  EXPECT_EQ(virtual_buffer_id, unmap_payload.virtual_buffer_id);
+  EXPECT_EQ(kRecorderVmmVirtualOffset, unmap_payload.virtual_offset);
+  EXPECT_EQ(kRecorderVmmMappingSize, unmap_payload.size);
+
+  const auto* free_record = FindOperationRecord(
+      records, IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_FREE);
+  ASSERT_NE(nullptr, free_record);
+  iree_hal_replay_allocator_physical_memory_free_payload_t free_payload;
+  ASSERT_EQ(sizeof(free_payload), free_record->payload.data_length);
+  memcpy(&free_payload, free_record->payload.data, sizeof(free_payload));
+  EXPECT_EQ(physical_memory_id, free_payload.physical_memory_id);
+
+  const auto* release_record = FindOperationRecord(
+      records, IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE);
+  ASSERT_NE(nullptr, release_record);
+  iree_hal_replay_allocator_virtual_memory_release_payload_t release_payload;
+  ASSERT_EQ(sizeof(release_payload), release_record->payload.data_length);
+  memcpy(&release_payload, release_record->payload.data,
+         sizeof(release_payload));
+  EXPECT_EQ(virtual_buffer_id, release_payload.virtual_buffer_id);
+
+  EXPECT_EQ(1u, state.reserve_count);
+  EXPECT_EQ(1u, state.physical_allocate_count);
+  EXPECT_EQ(1u, state.map_count);
+  EXPECT_EQ(1u, state.unmap_count);
+  EXPECT_EQ(1u, state.protect_count);
+  EXPECT_EQ(1u, state.advise_count);
+  EXPECT_EQ(kRecorderVmmQueueFamilyAffinity,
+            state.protect_queue_family_affinity);
+  EXPECT_EQ(IREE_HAL_VIRTUAL_MEMORY_ACCESS_SCOPE_DEVICE,
+            state.protect_access_scope);
+
+  iree_hal_allocator_release(allocator);
+  iree_hal_allocator_release(base_allocator);
+  iree_hal_replay_recorder_release(recorder);
+}
+
+TEST(ReplayRecorderVmmTest, RejectsForeignRawAndConsumedHandles) {
+  std::vector<uint8_t> storage(32768, 0);
+  iree_hal_replay_recorder_t* recorder = CreateHostAllocationRecorder(&storage);
+  RecorderVmmAllocatorState state_a;
+  RecorderVmmAllocatorState state_b;
+  iree_hal_allocator_t* base_allocator_a = CreateRecorderVmmAllocator(&state_a);
+  iree_hal_allocator_t* base_allocator_b = CreateRecorderVmmAllocator(&state_b);
+  iree_hal_allocator_t* allocator_a =
+      WrapRecorderVmmAllocator(recorder, /*device_id=*/1, base_allocator_a);
+  iree_hal_allocator_t* allocator_b =
+      WrapRecorderVmmAllocator(recorder, /*device_id=*/1, base_allocator_b);
+
+  iree_hal_buffer_t* virtual_buffer_a = nullptr;
+  iree_hal_buffer_t* virtual_buffer_b = nullptr;
+  iree_hal_physical_memory_t* physical_memory_a = nullptr;
+  iree_hal_physical_memory_t* physical_memory_b = nullptr;
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_reserve(
+      allocator_a, kRecorderVmmQueueFamilyAffinity, kRecorderVmmReservationSize,
+      &virtual_buffer_a));
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_reserve(
+      allocator_b, kRecorderVmmQueueFamilyAffinity, kRecorderVmmReservationSize,
+      &virtual_buffer_b));
+  IREE_ASSERT_OK(iree_hal_allocator_physical_memory_allocate(
+      allocator_a, RecorderVmmPhysicalParams(), kRecorderVmmReservationSize,
+      iree_allocator_system(), &physical_memory_a));
+  IREE_ASSERT_OK(iree_hal_allocator_physical_memory_allocate(
+      allocator_b, RecorderVmmPhysicalParams(), kRecorderVmmReservationSize,
+      iree_allocator_system(), &physical_memory_b));
+
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_virtual_memory_map(
+          allocator_b, virtual_buffer_b, kRecorderVmmVirtualOffset,
+          physical_memory_a, kRecorderVmmPhysicalOffset,
+          kRecorderVmmMappingSize));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_virtual_memory_map(
+          allocator_a, virtual_buffer_b, kRecorderVmmVirtualOffset,
+          physical_memory_a, kRecorderVmmPhysicalOffset,
+          kRecorderVmmMappingSize));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_physical_memory_free(allocator_b, physical_memory_a));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_virtual_memory_release(allocator_b, virtual_buffer_a));
+  auto* raw_physical_memory = reinterpret_cast<iree_hal_physical_memory_t*>(
+      static_cast<uintptr_t>(0x1234));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_virtual_memory_map(
+          allocator_a, virtual_buffer_a, kRecorderVmmVirtualOffset,
+          raw_physical_memory, kRecorderVmmPhysicalOffset,
+          kRecorderVmmMappingSize));
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_INVALID_ARGUMENT,
+                        iree_hal_allocator_physical_memory_free(
+                            allocator_a, raw_physical_memory));
+
+  iree_hal_buffer_t* ordinary_buffer = nullptr;
+  IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
+      allocator_a, RecorderVmmPhysicalParams(), /*allocation_size=*/64,
+      &ordinary_buffer));
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_virtual_memory_release(allocator_a, ordinary_buffer));
+  iree_hal_buffer_release(ordinary_buffer);
+
+  EXPECT_EQ(0u, state_a.map_count);
+  EXPECT_EQ(0u, state_b.map_count);
+  EXPECT_EQ(0u, state_a.release_attempt_count);
+  EXPECT_EQ(0u, state_b.release_attempt_count);
+  EXPECT_EQ(0u, state_a.physical_free_attempt_count);
+  EXPECT_EQ(0u, state_b.physical_free_attempt_count);
+
+  IREE_ASSERT_OK(
+      iree_hal_allocator_physical_memory_free(allocator_a, physical_memory_a));
+  IREE_ASSERT_OK(
+      iree_hal_allocator_physical_memory_free(allocator_b, physical_memory_b));
+  IREE_ASSERT_OK(
+      iree_hal_allocator_virtual_memory_release(allocator_a, virtual_buffer_a));
+  IREE_ASSERT_OK(
+      iree_hal_allocator_virtual_memory_release(allocator_b, virtual_buffer_b));
+  IREE_ASSERT_OK(iree_hal_replay_recorder_close(recorder));
+
+  iree_hal_allocator_release(allocator_b);
+  iree_hal_allocator_release(allocator_a);
+  iree_hal_allocator_release(base_allocator_b);
+  iree_hal_allocator_release(base_allocator_a);
+  iree_hal_replay_recorder_release(recorder);
+}
+
+TEST(ReplayRecorderVmmTest, FailedConsumptionIsRetryableAndSuccessIsFinal) {
+  std::vector<uint8_t> storage(32768, 0);
+  iree_hal_replay_recorder_t* recorder = CreateHostAllocationRecorder(&storage);
+  RecorderVmmAllocatorState state;
+  state.release_failures_remaining = 1;
+  state.physical_free_failures_remaining = 1;
+  iree_hal_allocator_t* base_allocator = CreateRecorderVmmAllocator(&state);
+  iree_hal_allocator_t* allocator =
+      WrapRecorderVmmAllocator(recorder, /*device_id=*/1, base_allocator);
+
+  iree_hal_buffer_t* virtual_buffer = nullptr;
+  iree_hal_physical_memory_t* physical_memory = nullptr;
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_reserve(
+      allocator, kRecorderVmmQueueFamilyAffinity, kRecorderVmmReservationSize,
+      &virtual_buffer));
+  IREE_ASSERT_OK(iree_hal_allocator_physical_memory_allocate(
+      allocator, RecorderVmmPhysicalParams(), kRecorderVmmReservationSize,
+      iree_allocator_system(), &physical_memory));
+  iree_hal_buffer_retain(virtual_buffer);
+
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_RESOURCE_EXHAUSTED,
+      iree_hal_allocator_virtual_memory_release(allocator, virtual_buffer));
+  EXPECT_NE(nullptr, state.virtual_buffer);
+  EXPECT_EQ(1u, state.release_attempt_count);
+  IREE_ASSERT_OK(
+      iree_hal_allocator_virtual_memory_release(allocator, virtual_buffer));
+  EXPECT_EQ(nullptr, state.virtual_buffer);
+  EXPECT_EQ(2u, state.release_attempt_count);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_virtual_memory_release(allocator, virtual_buffer));
+  EXPECT_EQ(2u, state.release_attempt_count);
+  iree_hal_buffer_release(virtual_buffer);
+
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_RESOURCE_EXHAUSTED,
+      iree_hal_allocator_physical_memory_free(allocator, physical_memory));
+  EXPECT_NE(nullptr, state.physical_memory);
+  EXPECT_EQ(1u, state.physical_free_attempt_count);
+  IREE_ASSERT_OK(
+      iree_hal_allocator_physical_memory_free(allocator, physical_memory));
+  EXPECT_EQ(nullptr, state.physical_memory);
+  EXPECT_EQ(2u, state.physical_free_attempt_count);
+  IREE_EXPECT_STATUS_IS(
+      IREE_STATUS_INVALID_ARGUMENT,
+      iree_hal_allocator_physical_memory_free(allocator, physical_memory));
+  EXPECT_EQ(2u, state.physical_free_attempt_count);
+  IREE_ASSERT_OK(iree_hal_replay_recorder_close(recorder));
+
+  const auto records = ParseOperationRecords(storage);
+  iree_hal_replay_object_id_t release_id = IREE_HAL_REPLAY_OBJECT_ID_NONE;
+  iree_hal_replay_object_id_t free_id = IREE_HAL_REPLAY_OBJECT_ID_NONE;
+  iree_host_size_t release_record_count = 0;
+  iree_host_size_t free_record_count = 0;
+  for (const auto& record : records) {
+    if (record.header.operation_code ==
+        IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_VIRTUAL_MEMORY_RELEASE) {
+      iree_hal_replay_allocator_virtual_memory_release_payload_t payload;
+      ASSERT_EQ(sizeof(payload), record.payload.data_length);
+      memcpy(&payload, record.payload.data, sizeof(payload));
+      if (release_id == IREE_HAL_REPLAY_OBJECT_ID_NONE) {
+        release_id = payload.virtual_buffer_id;
+      }
+      EXPECT_EQ(release_id, payload.virtual_buffer_id);
+      ++release_record_count;
+    } else if (record.header.operation_code ==
+               IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_FREE) {
+      iree_hal_replay_allocator_physical_memory_free_payload_t payload;
+      ASSERT_EQ(sizeof(payload), record.payload.data_length);
+      memcpy(&payload, record.payload.data, sizeof(payload));
+      if (free_id == IREE_HAL_REPLAY_OBJECT_ID_NONE) {
+        free_id = payload.physical_memory_id;
+      }
+      EXPECT_EQ(free_id, payload.physical_memory_id);
+      ++free_record_count;
+    }
+  }
+  EXPECT_EQ(2u, release_record_count);
+  EXPECT_EQ(2u, free_record_count);
+
+  iree_hal_allocator_release(allocator);
+  iree_hal_allocator_release(base_allocator);
+  iree_hal_replay_recorder_release(recorder);
+}
+
+TEST(ReplayRecorderVmmTest, AppendFailureDoesNotBlockVmmTeardown) {
+  const std::vector<uint8_t> complete_storage =
+      CaptureMinimalRecorderVmmLifecycle();
+  const iree_host_size_t free_offset = FindCapturedOperationOffset(
+      complete_storage,
+      IREE_HAL_REPLAY_OPERATION_CODE_ALLOCATOR_PHYSICAL_MEMORY_FREE);
+  ASSERT_NE(0u, free_offset);
+  std::vector<uint8_t> storage(free_offset, 0);
+  iree_hal_replay_recorder_t* recorder = CreateHostAllocationRecorder(&storage);
+  RecorderVmmAllocatorState state;
+  iree_hal_allocator_t* base_allocator = CreateRecorderVmmAllocator(&state);
+  iree_hal_allocator_t* allocator =
+      WrapRecorderVmmAllocator(recorder, /*device_id=*/1, base_allocator);
+
+  iree_hal_buffer_t* virtual_buffer = nullptr;
+  iree_hal_physical_memory_t* physical_memory = nullptr;
+  IREE_ASSERT_OK(iree_hal_allocator_virtual_memory_reserve(
+      allocator, kRecorderVmmQueueFamilyAffinity, kRecorderVmmReservationSize,
+      &virtual_buffer));
+  IREE_ASSERT_OK(iree_hal_allocator_physical_memory_allocate(
+      allocator, RecorderVmmPhysicalParams(), kRecorderVmmReservationSize,
+      iree_allocator_system(), &physical_memory));
+
+  IREE_EXPECT_OK(
+      iree_hal_allocator_physical_memory_free(allocator, physical_memory));
+  EXPECT_EQ(1u, state.physical_free_count);
+  EXPECT_EQ(nullptr, state.physical_memory);
+  IREE_EXPECT_OK(
+      iree_hal_allocator_virtual_memory_release(allocator, virtual_buffer));
+  EXPECT_EQ(1u, state.release_count);
+  EXPECT_EQ(nullptr, state.virtual_buffer);
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_OUT_OF_RANGE,
+                        iree_hal_replay_recorder_close(recorder));
+
+  iree_hal_allocator_release(allocator);
+  iree_hal_allocator_release(base_allocator);
+  iree_hal_replay_recorder_release(recorder);
 }
 
 }  // namespace


### PR DESCRIPTION
## Motivation

HAL queue family affinity selects a device topology, but it cannot express whether virtual-memory protection applies to the selected device agents, their associated host agents, or both. AMDGPU needs that distinction, while backends that cannot enforce a requested scope need an explicit portable failure mode.

The replay allocator advertises the virtual-memory capability of its wrapped allocator, so successful virtual-memory operations also need complete capture and replay support.

## Summary

- Add `DEVICE`, `HOST`, and `ALL` virtual-memory access scopes and reject empty or unknown scopes before backend dispatch.
- Resolve AMDGPU scopes to the selected GPU agents, their associated CPU agents, or the deduplicated union. Keep Vulkan device-only and return `UNIMPLEMENTED` for valid host-access requests it cannot enforce.
- Advance replay format 7.0 to 7.1 and record, dump, and replay reservation, release, physical allocation/free, map, unmap, protect, and advise operations with stable object identities.

## Design

Queue family affinity continues to select topology; access scope selects the execution domains within it. The recorder validates reservation and physical-memory provenance before forwarding operations and consumes their identities only after successful release or free.

The executor validates payloads, object types, allocator ownership, and ranges, then tracks live mappings and tears resources down leaf-first. Queue completion signals and transfer staging remain alive until accepted work completes. Preflight rejects unresolved forward semaphore dependencies and opaque device-memory waits before a protect, unmap, or end-of-file completion drain, preventing replay from waiting forever before a required producer is submitted.

## Testing

- Replay: 6/6 targets and 101/101 cases passed normally; 101/101 cases passed under default-layering ASAN, with no ASAN/LSan diagnostics.
- AMDGPU access policy: 12/12 cases passed. Vulkan VMM/BDA: 30/30 cases passed.
- The full libhrx build passed 229/229 targets; host VMM CTS passed 2/2 cases.
- Clang-format passed for 39/39 changed C/C++ files; BUILD-to-CMake passed 1/1; cumulative diff hygiene and the pinned TheRock SDK `7.14.0a20260622` self-test (27/27) passed. No system ROCm userspace was used.
