### PR TITLE
[Loom] Stream independent kernel specialization requests

### DIFF
--- a/loom/src/loom/link/index_materializer.c
+++ b/loom/src/loom/link/index_materializer.c
@@ -94,15 +94,6 @@ static void loom_link_index_provider_roots_append(
   roots->ordinals.values[roots->ordinals.count++] = symbol_ordinal;
 }
 
-static loom_link_template_provider_membership_t
-loom_link_index_provider_root_membership(
-    const loom_link_index_provider_roots_t* roots) {
-  return (loom_link_template_provider_membership_t){
-      .words = roots->membership.values,
-      .symbol_count = roots->membership.symbol_count,
-  };
-}
-
 static void loom_link_index_apply_provider_roots(
     const loom_link_index_provider_roots_t* roots,
     loom_link_plan_options_t* options) {
@@ -129,9 +120,7 @@ static iree_status_t loom_link_index_query_candidates(
   loom_template_provider_slice_t external_candidates =
       loom_template_provider_slice_empty();
   IREE_RETURN_IF_ERROR(loom_link_template_candidate_loader_load(
-      candidate_loader, plan, materialization,
-      loom_link_index_provider_root_membership(roots), arena,
-      &external_candidates));
+      candidate_loader, plan, materialization, arena, &external_candidates));
 
   loom_symbol_fact_table_t fact_table;
   loom_symbol_fact_table_initialize(&fact_table, arena);

--- a/loom/src/loom/link/template_candidate_loader.c
+++ b/loom/src/loom/link/template_candidate_loader.c
@@ -58,15 +58,6 @@ struct loom_link_template_candidate_loader_t {
   } modules;
 };
 
-static bool loom_link_template_provider_membership_contains(
-    loom_link_template_provider_membership_t membership,
-    iree_host_size_t symbol_ordinal) {
-  IREE_ASSERT(symbol_ordinal < membership.symbol_count);
-  return membership.words != NULL &&
-         (membership.words[symbol_ordinal >> 6] &
-          (UINT64_C(1) << (symbol_ordinal & 63u))) != 0;
-}
-
 static iree_status_t loom_link_template_candidate_initialize_bytecode_module(
     loom_link_template_candidate_loader_t* loader,
     loom_link_template_candidate_module_t* cache) {
@@ -276,7 +267,6 @@ void loom_link_template_candidate_loader_free(
 iree_status_t loom_link_template_candidate_loader_load(
     loom_link_template_candidate_loader_t* loader, const loom_link_plan_t* plan,
     loom_link_plan_materialization_t* materialization,
-    loom_link_template_provider_membership_t selected_providers,
     iree_arena_allocator_t* arena,
     loom_template_provider_slice_t* out_candidates) {
   IREE_ASSERT_ARGUMENT(loader);
@@ -286,9 +276,6 @@ iree_status_t loom_link_template_candidate_loader_load(
   IREE_ASSERT_ARGUMENT(arena);
   IREE_ASSERT_ARGUMENT(out_candidates);
   *out_candidates = loom_template_provider_slice_empty();
-  IREE_ASSERT(selected_providers.symbol_count ==
-              loom_link_module_index_symbol_count(loader->index));
-
   iree_host_size_t candidate_capacity = 0;
   IREE_RETURN_IF_ERROR(
       loom_link_template_candidate_capacity(loader, plan, &candidate_capacity));
@@ -320,8 +307,7 @@ iree_status_t loom_link_template_candidate_loader_load(
       const loom_link_module_index_symbol_t* provider =
           loom_link_module_index_symbol_at(loader->index, provider_ordinal);
       IREE_ASSERT(provider != NULL);
-      if (!loom_link_template_provider_membership_contains(selected_providers,
-                                                           provider_ordinal)) {
+      if (!loom_link_plan_contains_symbol(plan, provider_ordinal)) {
         const loom_link_module_index_module_t* source_module =
             loom_link_module_index_symbol_module(loader->index, provider);
         IREE_ASSERT(source_module != NULL);

--- a/loom/src/loom/link/template_candidate_loader.h
+++ b/loom/src/loom/link/template_candidate_loader.h
@@ -21,14 +21,6 @@ extern "C" {
 typedef struct loom_link_template_candidate_loader_t
     loom_link_template_candidate_loader_t;
 
-// Dense membership for provider symbols already selected by the link.
-typedef struct loom_link_template_provider_membership_t {
-  // Packed membership bits indexed by index-wide symbol ordinal.
-  const uint64_t* words;
-  // Number of index-wide symbol ordinals represented by words.
-  iree_host_size_t symbol_count;
-} loom_link_template_provider_membership_t;
-
 // Allocates a lazy candidate-header loader over |index|.
 //
 // The loader borrows |index| and |environment| for its lifetime. Materialized
@@ -46,15 +38,16 @@ void loom_link_template_candidate_loader_free(
 
 // Binds unselected candidates for families demanded by |plan|.
 //
-// Each candidate borrows its source-owned applicability facts while using the
-// already-linked family signature in materialization->module. This never adds
-// values, symbols, types, or operations to the materialized module. The
-// returned summaries belong to |arena| and are suitable as the external
-// catalog overlay for one selection query.
+// The plan's existing reachability bitmap identifies providers already present
+// in |materialization|. Each remaining candidate borrows its source-owned
+// applicability facts while using the already-linked family signature in
+// materialization->module. This never adds values, symbols, types, or
+// operations to the materialized module. The returned summaries belong to
+// |arena| and are suitable as the external catalog overlay for one selection
+// query.
 iree_status_t loom_link_template_candidate_loader_load(
     loom_link_template_candidate_loader_t* loader, const loom_link_plan_t* plan,
     loom_link_plan_materialization_t* materialization,
-    loom_link_template_provider_membership_t selected_providers,
     iree_arena_allocator_t* arena,
     loom_template_provider_slice_t* out_candidates);
 

--- a/loom/src/loom/transforms/kernel/BUILD.bazel
+++ b/loom/src/loom/transforms/kernel/BUILD.bazel
@@ -138,6 +138,52 @@ loom_cc_benchmark(
 )
 
 loom_cc_library(
+    name = "kernel_request_producer",
+    srcs = ["kernel_request_producer.c"],
+    hdrs = ["kernel_request_producer.h"],
+    deps = [
+        ":kernel_class_materializer",
+        "//loom/src/loom/analysis:symbol_facts",
+        "//loom/src/loom/analysis:symbol_references",
+        "//loom/src/loom/analysis:symbolic_expr",
+        "//loom/src/loom/analysis:template_provider_catalog",
+        "//loom/src/loom/ir",
+        "//loom/src/loom/link:index_materializer",
+        "//loom/src/loom/link:materialization_environment",
+        "//loom/src/loom/link:module_index",
+        "//loom/src/loom/link:template_candidate_loader",
+        "//loom/src/loom/ops:op_defs",
+        "//loom/src/loom/ops:type_registry",
+        "//loom/src/loom/ops/target",
+        "//loom/src/loom/transforms/symbol:template_decision_model",
+        "//loom/src/loom/util:fact_table",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal:arena",
+    ],
+)
+
+loom_cc_test(
+    name = "kernel_request_producer_test",
+    srcs = ["kernel_request_producer_test.cc"],
+    deps = [
+        ":kernel_request_producer",
+        "//loom/src/loom/format/bytecode:writer",
+        "//loom/src/loom/format/text:parser",
+        "//loom/src/loom/ir",
+        "//loom/src/loom/link:module_index",
+        "//loom/src/loom/ops:op_registry",
+        "//loom/src/loom/ops/kernel",
+        "//loom/src/loom/testing:module_ptr",
+        "//loom/src/loom/util:fact_table",
+        "//loom/src/loom/verify",
+        "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/io:stream",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+loom_cc_library(
     name = "kernel_async_legality",
     srcs = ["kernel_async_legality.c"],
     hdrs = ["kernel_async_legality.h"],

--- a/loom/src/loom/transforms/kernel/CMakeLists.txt
+++ b/loom/src/loom/transforms/kernel/CMakeLists.txt
@@ -148,6 +148,56 @@ loom_cc_benchmark(
 
 loom_cc_library(
   NAME
+    kernel_request_producer
+  HDRS
+    "kernel_request_producer.h"
+  SRCS
+    "kernel_request_producer.c"
+  DEPS
+    ::kernel_class_materializer
+    iree::base
+    iree::base::internal::arena
+    loom::analysis::symbol_facts
+    loom::analysis::symbol_references
+    loom::analysis::symbolic_expr
+    loom::analysis::template_provider_catalog
+    loom::ir
+    loom::link::index_materializer
+    loom::link::materialization_environment
+    loom::link::module_index
+    loom::link::template_candidate_loader
+    loom::ops::op_defs
+    loom::ops::target
+    loom::ops::type_registry
+    loom::transforms::symbol::template_decision_model
+    loom::util::fact_table
+  PUBLIC
+)
+
+loom_cc_test(
+  NAME
+    kernel_request_producer_test
+  SRCS
+    "kernel_request_producer_test.cc"
+  DEPS
+    ::kernel_request_producer
+    iree::base::internal::arena
+    iree::io::stream
+    iree::testing::gtest
+    iree::testing::gtest_main
+    loom::format::bytecode::writer
+    loom::format::text::parser
+    loom::ir
+    loom::link::module_index
+    loom::ops::kernel
+    loom::ops::op_registry
+    loom::testing::module_ptr
+    loom::util::fact_table
+    loom::verify
+)
+
+loom_cc_library(
+  NAME
     kernel_async_legality
   HDRS
     "kernel_async_legality.h"

--- a/loom/src/loom/transforms/kernel/kernel_class_materializer.c
+++ b/loom/src/loom/transforms/kernel/kernel_class_materializer.c
@@ -17,6 +17,12 @@
 #include "loom/rewrite/rewriter.h"
 #include "loom/transforms/symbol/template_rewrite.h"
 
+void loom_kernel_class_product_deinitialize(
+    loom_kernel_class_product_t* product) {
+  loom_module_free(product->module);
+  *product = (loom_kernel_class_product_t){0};
+}
+
 // Scalar dialect carrying one published assumption group.
 typedef uint8_t loom_kernel_class_assume_domain_t;
 enum loom_kernel_class_assume_domain_e {
@@ -328,9 +334,9 @@ iree_status_t loom_kernel_class_materialize(
     const loom_kernel_class_collection_t* collection,
     loom_decision_class_ordinal_t class_ordinal,
     iree_arena_block_pool_t* block_pool, iree_allocator_t allocator,
-    loom_module_t** out_module) {
+    loom_kernel_class_product_t* out_product) {
   IREE_ASSERT(class_ordinal < collection->class_count);
-  *out_module = NULL;
+  *out_product = (loom_kernel_class_product_t){0};
 
   iree_arena_allocator_t scratch_arena;
   iree_arena_initialize(block_pool, &scratch_arena);
@@ -406,9 +412,17 @@ iree_status_t loom_kernel_class_materialize(
   }
 
   if (rewriter_is_initialized) loom_rewriter_deinitialize(&rewriter);
+  const loom_symbol_ref_t target_kernel =
+      target_module != NULL
+          ? loom_ir_module_projection_target_symbol(
+                &module_projection, classifier->kernel_symbol_id)
+          : loom_symbol_ref_null();
   iree_arena_deinitialize(&scratch_arena);
   if (iree_status_is_ok(status)) {
-    *out_module = target_module;
+    *out_product = (loom_kernel_class_product_t){
+        .module = target_module,
+        .kernel = target_kernel,
+    };
   } else {
     loom_module_free(target_module);
   }

--- a/loom/src/loom/transforms/kernel/kernel_class_materializer.h
+++ b/loom/src/loom/transforms/kernel/kernel_class_materializer.h
@@ -18,14 +18,27 @@
 extern "C" {
 #endif  // __cplusplus
 
+// Independently owned source product for one live kernel class.
+typedef struct loom_kernel_class_product_t {
+  // Standalone source module owned by the product.
+  loom_module_t* module;
+
+  // Module-local root naming the specialized kernel definition in |module|.
+  loom_symbol_ref_t kernel;
+} loom_kernel_class_product_t;
+
+// Releases all storage owned by |product|.
+void loom_kernel_class_product_deinitialize(
+    loom_kernel_class_product_t* product);
+
 // Materializes one independently owned kernel source module for
 // |class_ordinal|.
 //
 // Accepted provider decisions become ordinary input assumptions followed by
 // exact template calls. Decisions intentionally skipped during collection
 // remain generic template applications. No classifier or collection state is
-// retained by the returned module, which the caller must free with
-// loom_module_free().
+// retained by the returned product. The caller must release it with
+// loom_kernel_class_product_deinitialize().
 //
 // The classifier, collection, and source module must describe the same
 // immutable compiler snapshot. |class_ordinal| must name a live class in
@@ -36,7 +49,7 @@ iree_status_t loom_kernel_class_materialize(
     const loom_kernel_class_collection_t* collection,
     loom_decision_class_ordinal_t class_ordinal,
     iree_arena_block_pool_t* block_pool, iree_allocator_t allocator,
-    loom_module_t** out_module);
+    loom_kernel_class_product_t* out_product);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/loom/src/loom/transforms/kernel/kernel_class_materializer_benchmark.cc
+++ b/loom/src/loom/transforms/kernel/kernel_class_materializer_benchmark.cc
@@ -181,10 +181,13 @@ class KernelClassMaterializerBenchmarkFixture {
   }
 
   loom_module_t* Materialize() {
-    loom_module_t* materialized_module = nullptr;
+    loom_kernel_class_product_t product = {};
     IREE_CHECK_OK(loom_kernel_class_materialize(
         &classifier_, &collection_, class_ordinal_, &block_pool_,
-        iree_allocator_system(), &materialized_module));
+        iree_allocator_system(), &product));
+    loom_module_t* materialized_module = product.module;
+    product.module = nullptr;
+    loom_kernel_class_product_deinitialize(&product);
     return materialized_module;
   }
 

--- a/loom/src/loom/transforms/kernel/kernel_class_materializer_test.cc
+++ b/loom/src/loom/transforms/kernel/kernel_class_materializer_test.cc
@@ -277,6 +277,7 @@ kernel.def @classified() {
   ASSERT_EQ(collection.skipped_decision_count, 1u);
 
   std::array<ModulePtr, 2> class_modules;
+  std::array<loom_symbol_ref_t, 2> class_kernels = {};
   std::array<bool, 2> class_is_large = {};
   std::array<iree_host_size_t, 2> class_member_counts = {};
   for (loom_decision_class_ordinal_t class_ordinal = 0;
@@ -296,11 +297,22 @@ kernel.def @classified() {
     class_member_counts[class_ordinal] =
         collection.classes[class_ordinal].member_count;
 
-    loom_module_t* class_module = nullptr;
+    loom_kernel_class_product_t product = {};
     IREE_ASSERT_OK(loom_kernel_class_materialize(
         &classifier, &collection, class_ordinal, &block_pool_,
-        iree_allocator_system(), &class_module));
-    class_modules[class_ordinal] = ModulePtr(class_module);
+        iree_allocator_system(), &product));
+    class_kernels[class_ordinal] = product.kernel;
+    class_modules[class_ordinal] = ModulePtr(product.module);
+    product.module = nullptr;
+    loom_kernel_class_product_deinitialize(&product);
+
+    ASSERT_EQ(class_kernels[class_ordinal].module_id, 0u);
+    ASSERT_LT(class_kernels[class_ordinal].symbol_id,
+              class_modules[class_ordinal]->symbols.count);
+    EXPECT_TRUE(loom_kernel_def_isa(
+        class_modules[class_ordinal]
+            ->symbols.entries[class_kernels[class_ordinal].symbol_id]
+            .defining_op));
   }
 
   // Published modules own only ordinary IR and survive every transient input.
@@ -496,16 +508,20 @@ kernel.def @classified() {
                                             trace->action_ordinal);
   ASSERT_FALSE(loom_symbol_ref_is_valid(selected_provider->symbol));
 
-  loom_module_t* class_module = nullptr;
+  loom_kernel_class_product_t product = {};
   IREE_ASSERT_OK(loom_kernel_class_materialize(
       &classifier, &collection, /*class_ordinal=*/0, &block_pool_,
-      iree_allocator_system(), &class_module));
+      iree_allocator_system(), &product));
+  loom_module_t* class_module = product.module;
   ModulePtr class_module_ptr(class_module);
+  product.module = nullptr;
+  const loom_symbol_ref_t class_kernel_ref = product.kernel;
+  loom_kernel_class_product_deinitialize(&product);
 
   // The published class owns only ordinary IR. The selected external body is
   // represented by an assumption feeding the still-generic request.
-  const loom_symbol_id_t class_kernel_symbol_id =
-      FindSymbol(class_module, IREE_SV("classified"));
+  ASSERT_EQ(class_kernel_ref.module_id, 0u);
+  const loom_symbol_id_t class_kernel_symbol_id = class_kernel_ref.symbol_id;
   const loom_func_like_t class_kernel = loom_func_like_cast(
       class_module,
       class_module->symbols.entries[class_kernel_symbol_id].defining_op);

--- a/loom/src/loom/transforms/kernel/kernel_request_producer.c
+++ b/loom/src/loom/transforms/kernel/kernel_request_producer.c
@@ -1,0 +1,247 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/transforms/kernel/kernel_request_producer.h"
+
+#include <string.h>
+
+#include "loom/analysis/symbol_facts.h"
+#include "loom/analysis/symbol_references.h"
+#include "loom/analysis/symbolic_expr.h"
+#include "loom/analysis/template_provider_catalog.h"
+#include "loom/ir/module.h"
+#include "loom/link/index_materializer.h"
+#include "loom/link/template_candidate_loader.h"
+#include "loom/ops/op_defs.h"
+#include "loom/ops/target/facts.h"
+#include "loom/ops/type_registry.h"
+#include "loom/transforms/symbol/template_decision_model.h"
+#include "loom/util/fact_table.h"
+
+struct loom_kernel_request_producer_t {
+  // Immutable provider-backed source universe.
+  const loom_link_module_index_t* index;
+
+  // Copied environment borrowing all referenced materialization resources.
+  loom_link_plan_materialization_environment_t environment;
+
+  // Lazy provider-header cache shared by every kernel publication.
+  loom_link_template_candidate_loader_t* candidate_loader;
+};
+
+iree_status_t loom_kernel_request_producer_allocate(
+    const loom_link_module_index_t* index,
+    const loom_link_plan_materialization_environment_t* environment,
+    loom_kernel_request_producer_t** out_producer) {
+  IREE_ASSERT_ARGUMENT(index);
+  IREE_ASSERT_ARGUMENT(environment);
+  IREE_ASSERT_ARGUMENT(environment->context);
+  IREE_ASSERT_ARGUMENT(environment->block_pool);
+  IREE_ASSERT_ARGUMENT(out_producer);
+  *out_producer = NULL;
+
+  loom_kernel_request_producer_t* producer = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+      environment->allocator, sizeof(*producer), (void**)&producer));
+  *producer = (loom_kernel_request_producer_t){
+      .index = index,
+      .environment = *environment,
+  };
+  iree_status_t status = loom_link_template_candidate_loader_allocate(
+      index, &producer->environment, &producer->candidate_loader);
+  if (iree_status_is_ok(status)) {
+    *out_producer = producer;
+  } else {
+    iree_allocator_free(environment->allocator, producer);
+  }
+  return status;
+}
+
+void loom_kernel_request_producer_free(
+    loom_kernel_request_producer_t* producer) {
+  if (producer == NULL) return;
+  const iree_allocator_t allocator = producer->environment.allocator;
+  loom_link_template_candidate_loader_free(producer->candidate_loader);
+  iree_allocator_free(allocator, producer);
+}
+
+static iree_status_t loom_kernel_request_resolve_target(
+    const loom_module_t* module, loom_func_like_t kernel,
+    loom_symbol_fact_table_t* symbol_facts,
+    loom_template_applicability_target_t* out_target) {
+  *out_target = (loom_template_applicability_target_t){
+      .witness = loom_func_like_target(kernel),
+  };
+  if (!loom_symbol_ref_is_valid(out_target->witness)) {
+    return iree_ok_status();
+  }
+  const loom_symbol_facts_base_t* base_facts = NULL;
+  IREE_RETURN_IF_ERROR(loom_symbol_fact_table_lookup_ref(
+      symbol_facts, module, out_target->witness, &base_facts));
+  const loom_target_symbol_facts_t* target_facts =
+      loom_target_symbol_facts_cast(base_facts);
+  IREE_ASSERT(target_facts != NULL);
+  out_target->facts = target_facts->projection;
+  return iree_ok_status();
+}
+
+iree_status_t loom_kernel_request_producer_publish(
+    loom_kernel_request_producer_t* producer,
+    iree_host_size_t source_symbol_ordinal,
+    const loom_kernel_class_site_t* sites, iree_host_size_t site_count,
+    const loom_kernel_class_collection_options_t* collection_options,
+    loom_kernel_request_sink_t sink, iree_arena_allocator_t* scratch_arena,
+    loom_kernel_class_collection_t* out_collection) {
+  IREE_ASSERT_ARGUMENT(producer);
+  IREE_ASSERT_ARGUMENT(sites);
+  IREE_ASSERT_GT(site_count, 0u);
+  IREE_ASSERT_ARGUMENT(collection_options);
+  IREE_ASSERT_ARGUMENT(sink.publish);
+  IREE_ASSERT_ARGUMENT(scratch_arena);
+  IREE_ASSERT_ARGUMENT(out_collection);
+  *out_collection = (loom_kernel_class_collection_t){0};
+
+  const loom_link_plan_root_facet_t root_facets[] = {
+      {
+          .symbol_ordinal = source_symbol_ordinal,
+          .kind = LOOM_LINK_SYMBOL_FACET_KERNEL_CONTRACT,
+      },
+      {
+          .symbol_ordinal = source_symbol_ordinal,
+          .kind = LOOM_LINK_SYMBOL_FACET_KERNEL_CONFIGURATION,
+      },
+      {
+          .symbol_ordinal = source_symbol_ordinal,
+          .kind = LOOM_LINK_SYMBOL_FACET_KERNEL_IMPLEMENTATION,
+      },
+  };
+  const loom_link_plan_options_t link_options = {
+      .mode = LOOM_LINK_PLAN_LINK,
+      .unresolved_policy = LOOM_LINK_PLAN_UNRESOLVED_ALLOW,
+      .root_facets =
+          {
+              .count = IREE_ARRAYSIZE(root_facets),
+              .values = root_facets,
+          },
+      .dependency_policy = LOOM_LINK_PLAN_DEPENDENCY_REQUESTED_FACETS,
+  };
+  loom_link_index_materialization_t materialization = {0};
+  iree_status_t status = loom_link_index_materialize(
+      producer->index, &link_options, &producer->environment,
+      IREE_SV("kernel_request_source"), &materialization);
+
+  loom_symbol_ref_t kernel_ref = loom_symbol_ref_null();
+  loom_func_like_t kernel = {0};
+  if (iree_status_is_ok(status)) {
+    IREE_ASSERT_LT(source_symbol_ordinal,
+                   materialization.product.target_symbols.count);
+    kernel_ref =
+        materialization.product.target_symbols.values[source_symbol_ordinal];
+    IREE_ASSERT(loom_symbol_ref_is_valid(kernel_ref));
+    IREE_ASSERT_EQ(kernel_ref.module_id, 0u);
+    IREE_ASSERT_LT(kernel_ref.symbol_id,
+                   materialization.product.module->symbols.count);
+    kernel = loom_func_like_cast(
+        materialization.product.module,
+        materialization.product.module->symbols.entries[kernel_ref.symbol_id]
+            .defining_op);
+    IREE_ASSERT(loom_func_like_is_kernel_entry(kernel));
+    IREE_ASSERT(loom_func_like_body(kernel) != NULL);
+  }
+
+  loom_template_provider_slice_t external_candidates =
+      loom_template_provider_slice_empty();
+  if (iree_status_is_ok(status)) {
+    status = loom_link_template_candidate_loader_load(
+        producer->candidate_loader, materialization.plan,
+        &materialization.product, scratch_arena, &external_candidates);
+  }
+
+  loom_symbol_reference_table_t references = {0};
+  if (iree_status_is_ok(status)) {
+    status = loom_symbol_reference_table_build(materialization.product.module,
+                                               scratch_arena, &references);
+  }
+  loom_symbol_fact_table_t symbol_facts = {0};
+  loom_symbol_fact_table_initialize(&symbol_facts, scratch_arena);
+  loom_template_provider_catalog_t providers = {0};
+  loom_template_provider_catalog_initialize(&providers, scratch_arena);
+  if (iree_status_is_ok(status)) {
+    status = loom_template_provider_catalog_build(
+        &providers, materialization.product.module, &symbol_facts,
+        external_candidates.providers, external_candidates.count);
+  }
+  loom_template_decision_model_catalog_t decision_models = {0};
+  if (iree_status_is_ok(status)) {
+    status = loom_template_decision_model_catalog_build(
+        materialization.product.module, &symbol_facts, &references, &providers,
+        scratch_arena, &decision_models);
+  }
+
+  loom_value_fact_table_t kernel_facts = {0};
+  if (iree_status_is_ok(status)) {
+    status = loom_value_fact_table_initialize(
+        &kernel_facts, scratch_arena,
+        materialization.product.module->values.count);
+  }
+  if (iree_status_is_ok(status)) {
+    loom_type_registry_configure_fact_context(&kernel_facts.context);
+    status = loom_value_fact_table_compute(
+        &kernel_facts, materialization.product.module, kernel);
+  }
+  loom_symbolic_expr_context_t expression_context = {0};
+  if (iree_status_is_ok(status)) {
+    loom_symbolic_expr_context_initialize(materialization.product.module,
+                                          &kernel_facts, scratch_arena,
+                                          &expression_context);
+  }
+  loom_template_applicability_target_t kernel_target = {0};
+  if (iree_status_is_ok(status)) {
+    status = loom_kernel_request_resolve_target(
+        materialization.product.module, kernel, &symbol_facts, &kernel_target);
+  }
+
+  loom_kernel_class_classifier_t classifier = {0};
+  if (iree_status_is_ok(status)) {
+    status = loom_kernel_class_classifier_build(
+        materialization.product.module, kernel_ref.symbol_id, &references,
+        &decision_models, &kernel_facts, &expression_context, &kernel_target,
+        scratch_arena, &classifier);
+  }
+  loom_kernel_class_collection_t collection = {0};
+  if (iree_status_is_ok(status)) {
+    status = loom_kernel_class_classifier_collect(
+        &classifier, sites, site_count, collection_options, scratch_arena,
+        &collection);
+  }
+
+  for (loom_decision_class_ordinal_t class_ordinal = 0;
+       class_ordinal < collection.class_count && iree_status_is_ok(status);
+       ++class_ordinal) {
+    loom_kernel_class_product_t product = {0};
+    status = loom_kernel_class_materialize(
+        &classifier, &collection, class_ordinal,
+        producer->environment.block_pool, producer->environment.allocator,
+        &product);
+    if (iree_status_is_ok(status)) {
+      const loom_kernel_request_t request = {
+          .source_symbol_ordinal = source_symbol_ordinal,
+          .class_ordinal = class_ordinal,
+          .member_count = collection.classes[class_ordinal].member_count,
+          .product = product,
+      };
+      product = (loom_kernel_class_product_t){0};
+      status = sink.publish(sink.user_data, request);
+    }
+    loom_kernel_class_product_deinitialize(&product);
+  }
+
+  if (iree_status_is_ok(status)) {
+    *out_collection = collection;
+  }
+  loom_link_index_materialization_deinitialize(&materialization);
+  return status;
+}

--- a/loom/src/loom/transforms/kernel/kernel_request_producer.h
+++ b/loom/src/loom/transforms/kernel/kernel_request_producer.h
@@ -1,0 +1,96 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Index-backed publication of independent kernel compilation requests.
+
+#ifndef LOOM_TRANSFORMS_KERNEL_KERNEL_REQUEST_PRODUCER_H_
+#define LOOM_TRANSFORMS_KERNEL_KERNEL_REQUEST_PRODUCER_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/arena.h"
+#include "loom/link/materialization_environment.h"
+#include "loom/link/module_index.h"
+#include "loom/transforms/kernel/kernel_class_materializer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct loom_kernel_request_producer_t loom_kernel_request_producer_t;
+
+// One independently owned source request for a live kernel class.
+typedef struct loom_kernel_request_t {
+  // Exact index-wide kernel definition ordinal rooted by this request.
+  iree_host_size_t source_symbol_ordinal;
+
+  // Dense class ordinal within this kernel publication.
+  loom_decision_class_ordinal_t class_ordinal;
+
+  // Number of launch sites assigned to this class.
+  iree_host_size_t member_count;
+
+  // Independently owned ordinary Loom source module and kernel root.
+  loom_kernel_class_product_t product;
+} loom_kernel_request_t;
+
+// Accepts ownership of one request at callback entry.
+//
+// The callback must release or transfer |request.product| even when returning
+// an error. A non-OK status stops publication before another class is
+// materialized.
+typedef iree_status_t (*loom_kernel_request_publish_fn_t)(
+    void* user_data, loom_kernel_request_t request);
+
+// Required sink for one publication operation.
+typedef struct loom_kernel_request_sink_t {
+  // Callback accepting each request.
+  loom_kernel_request_publish_fn_t publish;
+
+  // Opaque value passed to |publish|.
+  void* user_data;
+} loom_kernel_request_sink_t;
+
+// Allocates a reusable producer over an immutable provider index.
+//
+// The producer copies |*environment| and borrows |index| plus every resource
+// referenced by the copied environment for its lifetime. The caller may
+// discard the environment struct after this call, but its context, block pool,
+// low-representation codec, callbacks and their user data, and allocator
+// backing state must remain valid. Template provider headers are loaded lazily
+// and cached across kernel publications. Implementation bodies are
+// materialized only for the source kernel passed to publish.
+iree_status_t loom_kernel_request_producer_allocate(
+    const loom_link_module_index_t* index,
+    const loom_link_plan_materialization_environment_t* environment,
+    loom_kernel_request_producer_t** out_producer);
+
+// Frees |producer| and its persistent provider-header cache.
+void loom_kernel_request_producer_free(
+    loom_kernel_request_producer_t* producer);
+
+// Publishes every live semantic class of one indexed kernel definition.
+//
+// |sites| is the complete launch-site set for this kernel across the enclosing
+// product. Publication begins only after the bounded class collection closes,
+// because accepting a later site may conservatively collapse prior classes.
+// Each request is transferred before the next class is materialized.
+//
+// The returned collection is allocated from |scratch_arena| and remains valid
+// until that arena is reset. It maps the input sites to the published class
+// ordinals without retaining any product or source-module storage.
+iree_status_t loom_kernel_request_producer_publish(
+    loom_kernel_request_producer_t* producer,
+    iree_host_size_t source_symbol_ordinal,
+    const loom_kernel_class_site_t* sites, iree_host_size_t site_count,
+    const loom_kernel_class_collection_options_t* collection_options,
+    loom_kernel_request_sink_t sink, iree_arena_allocator_t* scratch_arena,
+    loom_kernel_class_collection_t* out_collection);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // LOOM_TRANSFORMS_KERNEL_KERNEL_REQUEST_PRODUCER_H_

--- a/loom/src/loom/transforms/kernel/kernel_request_producer_test.cc
+++ b/loom/src/loom/transforms/kernel/kernel_request_producer_test.cc
@@ -1,0 +1,337 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "loom/transforms/kernel/kernel_request_producer.h"
+
+#include <memory>
+#include <vector>
+
+#include "iree/io/vec_stream.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+#include "loom/format/bytecode/writer.h"
+#include "loom/format/text/parser.h"
+#include "loom/ir/context.h"
+#include "loom/link/module_index.h"
+#include "loom/ops/kernel/ops.h"
+#include "loom/ops/op_registry.h"
+#include "loom/testing/module_ptr.h"
+#include "loom/verify/verify.h"
+
+namespace loom {
+namespace {
+
+using ModulePtr = ::loom::testing::ModulePtr;
+
+struct IndexDeleter {
+  void operator()(loom_link_module_index_t* index) const {
+    loom_link_module_index_free(index);
+  }
+};
+using IndexPtr = std::unique_ptr<loom_link_module_index_t, IndexDeleter>;
+
+struct ProducerDeleter {
+  void operator()(loom_kernel_request_producer_t* producer) const {
+    loom_kernel_request_producer_free(producer);
+  }
+};
+using ProducerPtr =
+    std::unique_ptr<loom_kernel_request_producer_t, ProducerDeleter>;
+
+typedef struct RequestCapture {
+  std::vector<loom_kernel_request_t> requests;
+} RequestCapture;
+
+static iree_status_t CaptureRequest(void* user_data,
+                                    loom_kernel_request_t request) {
+  static_cast<RequestCapture*>(user_data)->requests.push_back(request);
+  return iree_ok_status();
+}
+
+typedef struct RejectRequestState {
+  iree_host_size_t call_count;
+} RejectRequestState;
+
+static iree_status_t RejectRequest(void* user_data,
+                                   loom_kernel_request_t request) {
+  RejectRequestState* state = static_cast<RejectRequestState*>(user_data);
+  ++state->call_count;
+  loom_kernel_class_product_deinitialize(&request.product);
+  return iree_make_status(IREE_STATUS_ABORTED, "request sink stopped");
+}
+
+class KernelRequestProducerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    iree_arena_block_pool_initialize(32 * 1024, iree_allocator_system(),
+                                     &block_pool_);
+    loom_context_initialize(iree_allocator_system(), &context_);
+    IREE_ASSERT_OK(loom_op_registry_register_all_dialects(&context_));
+    IREE_ASSERT_OK(loom_context_finalize(&context_));
+  }
+
+  void TearDown() override {
+    loom_context_deinitialize(&context_);
+    iree_arena_block_pool_deinitialize(&block_pool_);
+  }
+
+  ModulePtr ParseSource() {
+    const iree_string_view_t source = IREE_SV(R"(
+template.decl @request.schedule(%size: index)
+
+template.def<@request.schedule> priority(10) @large(%size: index) where [ge(%size, 128)] {
+  template.return
+}
+
+template.def<@request.schedule> priority(1) @small(%size: index) {
+  template.return
+}
+
+kernel.def @classified() {
+  %unit = index.constant 1 : index
+  kernel.launch.config workgroups(%unit, %unit, %unit) workgroup_size(%unit, %unit, %unit) : index
+} launch(%size: index) {
+  template.apply<@request.schedule>(%size) : (index)
+  kernel.return
+}
+)");
+    loom_text_parse_options_t parse_options = {};
+    parse_options.diagnostic_sink.fn = loom_diagnostic_stderr_sink;
+    parse_options.max_errors = 20;
+    loom_module_t* module = nullptr;
+    IREE_CHECK_OK(
+        loom_text_parse(source, IREE_SV("kernel_request_producer_test.loom"),
+                        &context_, &block_pool_, &parse_options, &module));
+    ModulePtr module_ptr(module);
+    Verify(module);
+    return module_ptr;
+  }
+
+  void Verify(const loom_module_t* module) {
+    loom_verify_options_t verify_options = {};
+    verify_options.sink.fn = loom_diagnostic_stderr_sink;
+    verify_options.max_errors = 20;
+    loom_verify_result_t verify_result = {};
+    IREE_CHECK_OK(loom_verify_module(module, &verify_options, &verify_result));
+    EXPECT_EQ(verify_result.error_count, 0u);
+  }
+
+  loom_symbol_id_t FindSymbol(const loom_module_t* module,
+                              iree_string_view_t name) {
+    const loom_string_id_t name_id = loom_module_lookup_string(module, name);
+    EXPECT_NE(name_id, LOOM_STRING_ID_INVALID);
+    if (name_id == LOOM_STRING_ID_INVALID) return LOOM_SYMBOL_ID_INVALID;
+    const loom_symbol_id_t symbol_id = loom_module_find_symbol(module, name_id);
+    EXPECT_NE(symbol_id, LOOM_SYMBOL_ID_INVALID);
+    return symbol_id;
+  }
+
+  std::vector<uint8_t> WriteModule(const loom_module_t* module) {
+    iree_io_stream_t* stream = nullptr;
+    IREE_CHECK_OK(iree_io_vec_stream_create(
+        IREE_IO_STREAM_MODE_WRITABLE | IREE_IO_STREAM_MODE_SEEKABLE |
+            IREE_IO_STREAM_MODE_READABLE | IREE_IO_STREAM_MODE_RESIZABLE,
+        4096, iree_allocator_system(), &stream));
+    IREE_CHECK_OK(loom_bytecode_write_module(
+        module, stream, /*options=*/nullptr, &block_pool_));
+    const iree_io_stream_pos_t length = iree_io_stream_length(stream);
+    std::vector<uint8_t> bytecode(length);
+    IREE_CHECK_OK(iree_io_stream_seek(stream, IREE_IO_STREAM_SEEK_SET, 0));
+    IREE_CHECK_OK(iree_io_stream_read(stream, bytecode.size(), bytecode.data(),
+                                      /*out_buffer_length=*/nullptr));
+    iree_io_stream_release(stream);
+    return bytecode;
+  }
+
+  IndexPtr CreateIndex() {
+    loom_link_module_index_t* index = nullptr;
+    IREE_CHECK_OK(loom_link_module_index_allocate(
+        &context_, &block_pool_, iree_allocator_system(), &index));
+    return IndexPtr(index);
+  }
+
+  iree_host_size_t AddMaterializedSource(loom_link_module_index_t* index,
+                                         const loom_module_t* module) {
+    const loom_link_module_index_add_options_t options = {
+        /*.provider_name=*/IREE_SV("kernel-source"),
+        /*.role=*/LOOM_LINK_PROVIDER_ROLE_INPUT,
+    };
+    iree_host_size_t provider_ordinal = 0;
+    IREE_CHECK_OK(loom_link_module_index_add_materialized(
+        index, module, &options, &provider_ordinal));
+    return SourceSymbolOrdinal(index, provider_ordinal, module);
+  }
+
+  iree_host_size_t AddBytecodeSource(loom_link_module_index_t* index,
+                                     const std::vector<uint8_t>& bytecode,
+                                     const loom_module_t* source_module) {
+    const loom_link_module_index_add_options_t options = {
+        /*.provider_name=*/IREE_SV("kernel-source"),
+        /*.role=*/LOOM_LINK_PROVIDER_ROLE_INPUT,
+    };
+    iree_host_size_t provider_ordinal = 0;
+    IREE_CHECK_OK(loom_link_module_index_add_bytecode(
+        index, iree_make_const_byte_span(bytecode.data(), bytecode.size()),
+        IREE_SV("kernel-source.loombc"), /*index_options=*/nullptr, &options,
+        &provider_ordinal));
+    return SourceSymbolOrdinal(index, provider_ordinal, source_module);
+  }
+
+  iree_host_size_t SourceSymbolOrdinal(const loom_link_module_index_t* index,
+                                       iree_host_size_t provider_ordinal,
+                                       const loom_module_t* source_module) {
+    const loom_link_module_index_provider_t* provider =
+        loom_link_module_index_provider_at(index, provider_ordinal);
+    EXPECT_NE(provider, nullptr);
+    if (provider == nullptr) return LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
+    const loom_link_module_index_module_t* indexed_module =
+        loom_link_module_index_module_at(index, provider->module_start_ordinal);
+    EXPECT_NE(indexed_module, nullptr);
+    if (indexed_module == nullptr) {
+      return LOOM_LINK_MODULE_INDEX_INVALID_ORDINAL;
+    }
+    return indexed_module->symbol_start_ordinal +
+           FindSymbol(source_module, IREE_SV("classified"));
+  }
+
+  ProducerPtr CreateProducer(const loom_link_module_index_t* index) {
+    const loom_link_plan_materialization_environment_t environment = {
+        /*.context=*/&context_,
+        /*.block_pool=*/&block_pool_,
+        /*.low_repr_environment=*/{},
+        /*.diagnostic_sink=*/nullptr,
+        /*.prepare_module=*/nullptr,
+        /*.user_data=*/nullptr,
+        /*.allocator=*/iree_allocator_system(),
+    };
+    loom_kernel_request_producer_t* producer = nullptr;
+    IREE_CHECK_OK(
+        loom_kernel_request_producer_allocate(index, &environment, &producer));
+    return ProducerPtr(producer);
+  }
+
+  void BuildSites(iree_arena_allocator_t* arena,
+                  loom_value_fact_table_t* out_facts,
+                  loom_kernel_class_site_t out_sites[2],
+                  loom_value_id_t out_argument_values[2]) {
+    IREE_CHECK_OK(
+        loom_value_fact_table_initialize(out_facts, arena, /*capacity=*/2));
+    out_facts->count = 2;
+    out_facts->entries[0] = loom_value_facts_exact_i64(64);
+    out_facts->entries[1] = loom_value_facts_exact_i64(256);
+    out_argument_values[0] = 0;
+    out_argument_values[1] = 1;
+    out_sites[0] = {
+        /*.facts=*/out_facts,
+        /*.argument_values=*/&out_argument_values[0],
+    };
+    out_sites[1] = {
+        /*.facts=*/out_facts,
+        /*.argument_values=*/&out_argument_values[1],
+    };
+  }
+
+  iree_arena_block_pool_t block_pool_;
+  loom_context_t context_ = {};
+};
+
+TEST_F(KernelRequestProducerTest,
+       PublishesBytecodeBackedClassesWithIndependentOwnership) {
+  ModulePtr source_module = ParseSource();
+  ASSERT_NE(source_module, nullptr);
+  std::vector<uint8_t> bytecode = WriteModule(source_module.get());
+  IndexPtr index = CreateIndex();
+  const iree_host_size_t source_symbol_ordinal =
+      AddBytecodeSource(index.get(), bytecode, source_module.get());
+  ProducerPtr producer = CreateProducer(index.get());
+
+  iree_arena_allocator_t scratch_arena;
+  iree_arena_initialize(&block_pool_, &scratch_arena);
+  loom_value_fact_table_t site_facts = {};
+  loom_kernel_class_site_t sites[2] = {};
+  loom_value_id_t argument_values[2] = {};
+  BuildSites(&scratch_arena, &site_facts, sites, argument_values);
+
+  RequestCapture capture;
+  const loom_kernel_class_collection_options_t collection_options =
+      loom_kernel_class_collection_options_default();
+  loom_kernel_class_collection_t collection = {};
+  IREE_ASSERT_OK(loom_kernel_request_producer_publish(
+      producer.get(), source_symbol_ordinal, sites, IREE_ARRAYSIZE(sites),
+      &collection_options,
+      (loom_kernel_request_sink_t){
+          /*.publish=*/CaptureRequest,
+          /*.user_data=*/&capture,
+      },
+      &scratch_arena, &collection));
+  ASSERT_EQ(collection.class_count, 2u);
+  EXPECT_NE(collection.site_classes[0], collection.site_classes[1]);
+
+  producer.reset();
+  index.reset();
+  source_module.reset();
+  bytecode.clear();
+  iree_arena_deinitialize(&scratch_arena);
+
+  ASSERT_EQ(capture.requests.size(), 2u);
+  for (const loom_kernel_request_t& request : capture.requests) {
+    EXPECT_EQ(request.source_symbol_ordinal, source_symbol_ordinal);
+    EXPECT_EQ(request.member_count, 1u);
+    ASSERT_NE(request.product.module, nullptr);
+    ASSERT_TRUE(loom_symbol_ref_is_valid(request.product.kernel));
+    ASSERT_LT(request.product.kernel.symbol_id,
+              request.product.module->symbols.count);
+    EXPECT_TRUE(
+        loom_kernel_def_isa(request.product.module->symbols
+                                .entries[request.product.kernel.symbol_id]
+                                .defining_op));
+    Verify(request.product.module);
+  }
+  EXPECT_NE(capture.requests[0].class_ordinal,
+            capture.requests[1].class_ordinal);
+  EXPECT_NE(capture.requests[0].product.module,
+            capture.requests[1].product.module);
+  for (loom_kernel_request_t& request : capture.requests) {
+    loom_kernel_class_product_deinitialize(&request.product);
+  }
+}
+
+TEST_F(KernelRequestProducerTest, StopsAfterSinkFailureTransfersOwnership) {
+  ModulePtr source_module = ParseSource();
+  ASSERT_NE(source_module, nullptr);
+  IndexPtr index = CreateIndex();
+  const iree_host_size_t source_symbol_ordinal =
+      AddMaterializedSource(index.get(), source_module.get());
+  ProducerPtr producer = CreateProducer(index.get());
+
+  iree_arena_allocator_t scratch_arena;
+  iree_arena_initialize(&block_pool_, &scratch_arena);
+  loom_value_fact_table_t site_facts = {};
+  loom_kernel_class_site_t sites[2] = {};
+  loom_value_id_t argument_values[2] = {};
+  BuildSites(&scratch_arena, &site_facts, sites, argument_values);
+
+  RejectRequestState state = {};
+  const loom_kernel_class_collection_options_t collection_options =
+      loom_kernel_class_collection_options_default();
+  loom_kernel_class_collection_t collection = {};
+  IREE_EXPECT_STATUS_IS(IREE_STATUS_ABORTED,
+                        loom_kernel_request_producer_publish(
+                            producer.get(), source_symbol_ordinal, sites,
+                            IREE_ARRAYSIZE(sites), &collection_options,
+                            (loom_kernel_request_sink_t){
+                                /*.publish=*/RejectRequest,
+                                /*.user_data=*/&state,
+                            },
+                            &scratch_arena, &collection));
+  EXPECT_EQ(state.call_count, 1u);
+  EXPECT_EQ(collection.class_count, 0u);
+
+  iree_arena_deinitialize(&scratch_arena);
+}
+
+}  // namespace
+}  // namespace loom


### PR DESCRIPTION
Kernel specialization classes can now leave their classifier as independent, ordinary Loom source products and stream directly into concurrent compilation, caching, or remote execution work. This turns the bounded semantic quotient introduced by the preceding classifier work into a real ownership boundary: one source kernel with thousands of launch sites may publish only the few generated programs those sites can actually select.

Each materialized class product owns both its standalone module and the projected module-local kernel root. Callers never recover compiler identity from a symbol spelling, retain a classifier arena, or search the cloned module after construction. The root projection is captured during the unavoidable clone traversal, so the stronger ownership contract adds no IR walk or lookup to the JIT path.

The new indexed request producer freezes one provider universe, loads reusable provider headers lazily, and opens only one requested implementation facet at a time. It classifies the complete launch-site set for that kernel before publication because a later site may conservatively collapse earlier classes; once the set closes, each live class transfers through the callback before the next class is materialized. Persistent storage is shared across publications while implementation and analysis scratch is bounded by the largest active kernel instead of the sum of the library.

Callback ownership is terminal at entry, including failure. A rejecting sink owns and must release the transferred product, cancellation stops before constructing another class, and the producer retains no published source or analysis state. Bytecode-backed providers are covered through destruction of the source index, source module, bytecode buffer, and scratch arena, proving that every accepted request is an independently usable compiler product rather than a view into producer lifetime.

Candidate loading now uses the link plan's existing O(1) provider-membership bitmap instead of reconstructing shadow membership for each query. This keeps the request path proportional to selected providers and live classes, with no provider-name lookup, source rediscovery, or second module traversal.

This cut adds no Loom text or bytecode syntax and no public LoomC surface. It is the compiler-internal ownership layer used by the following command-product API.
