### PR TITLE
[HAL/AMDGPU] Centralize queue error status ownership

### DIFF
--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue.c
@@ -422,21 +422,21 @@ static iree_host_size_t iree_hal_amdgpu_host_queue_drain_completions_locked(
   // thread). If the queue has faulted, no further epochs will advance;
   // fail all pending entries so waiters get the actual GPU error instead
   // of hanging or timing out.
-  iree_status_t error = (iree_status_t)iree_atomic_load(
-      &queue->error_status, iree_memory_order_acquire);
+  const intptr_t error_status =
+      iree_hal_amdgpu_host_queue_load_error_status_raw(queue);
   const uint64_t previous_epoch = (uint64_t)iree_atomic_load(
       &queue->notification_ring.epoch.last_drained, iree_memory_order_relaxed);
   iree_hal_amdgpu_reclaim_positions_t reclaim_positions = {0};
   iree_host_size_t count = 0;
-  if (IREE_UNLIKELY(error)) {
+  if (IREE_UNLIKELY(error_status != 0)) {
     count = iree_hal_amdgpu_notification_ring_fail_all_reclaim_positions(
-        &queue->notification_ring, error,
+        &queue->notification_ring, (iree_status_t)error_status,
         iree_hal_amdgpu_host_queue_reclaim_retire_fn(queue), queue,
         &reclaim_positions);
     iree_hal_amdgpu_host_queue_clear_profile_events(queue);
     iree_async_frontier_tracker_fail_axis(
         queue->frontier_tracker, queue->axis,
-        iree_status_from_code(iree_status_code(error)));
+        iree_status_from_code(iree_status_code((iree_status_t)error_status)));
   } else {
     count = iree_hal_amdgpu_notification_ring_drain_reclaim_positions(
         &queue->notification_ring,
@@ -473,25 +473,6 @@ iree_host_size_t iree_hal_amdgpu_host_queue_drain_completions_for_waiter(
       iree_hal_amdgpu_host_queue_drain_completions_locked(queue);
   iree_slim_mutex_unlock(&queue->locks.completion_drain_mutex);
   return count;
-}
-
-// Returns the queue's recorded failure without transferring ownership. The
-// queue owns the status until it is taken by deinitialization.
-static iree_status_t iree_hal_amdgpu_host_queue_error_status(
-    iree_hal_amdgpu_host_queue_t* queue) {
-  return (iree_status_t)iree_atomic_load(&queue->error_status,
-                                         iree_memory_order_acquire);
-}
-
-static bool iree_hal_amdgpu_host_queue_has_error(
-    iree_hal_amdgpu_host_queue_t* queue) {
-  return !iree_status_is_ok(iree_hal_amdgpu_host_queue_error_status(queue));
-}
-
-static iree_status_t iree_hal_amdgpu_host_queue_clone_error_status(
-    iree_hal_amdgpu_host_queue_t* queue) {
-  iree_status_t error = iree_hal_amdgpu_host_queue_error_status(queue);
-  return iree_status_is_ok(error) ? iree_ok_status() : iree_status_clone(error);
 }
 
 static bool iree_hal_amdgpu_host_queue_store_error(
@@ -763,14 +744,16 @@ static int iree_hal_amdgpu_host_queue_completion_thread_main(void* entry_arg) {
         // is a no-op; on the failure path it is what makes the drain final.
         iree_hal_amdgpu_host_queue_close_submission(queue);
         iree_hal_amdgpu_host_queue_drain_completions(queue);
-        if (iree_hal_amdgpu_host_queue_has_error(queue)) {
+        const intptr_t error_status =
+            iree_hal_amdgpu_host_queue_load_error_status_raw(queue);
+        if (error_status != 0) {
           // Capacity-parked pending operations are retried by post-drain
           // callbacks and the drain's own pass can enqueue more. Flush them
           // under closed admission so they observe cancellation and run their
           // normal failure path instead of being destroyed under the callback.
           iree_hal_amdgpu_host_queue_run_post_drain_actions(queue);
           iree_hal_amdgpu_host_queue_cancel_pending(
-              queue, iree_hal_amdgpu_host_queue_error_status(queue));
+              queue, (iree_status_t)error_status);
         }
         keep_running = false;
       }

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue.h
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue.h
@@ -581,6 +581,31 @@ typedef struct iree_hal_amdgpu_host_queue_t {
   iree_hal_amdgpu_host_queue_frontier_t frontier;
 } iree_hal_amdgpu_host_queue_t;
 
+// Loads the queue-owned terminal error as an opaque raw value. Zero means the
+// queue has not failed. A nonzero value remains owned by |queue| and must be
+// cloned before crossing an ownership boundary.
+static inline intptr_t iree_hal_amdgpu_host_queue_load_error_status_raw(
+    const iree_hal_amdgpu_host_queue_t* queue) {
+  return iree_atomic_load(&queue->error_status, iree_memory_order_acquire);
+}
+
+// Returns true when the queue has recorded a terminal error.
+static inline bool iree_hal_amdgpu_host_queue_has_error(
+    const iree_hal_amdgpu_host_queue_t* queue) {
+  return iree_hal_amdgpu_host_queue_load_error_status_raw(queue) != 0;
+}
+
+// Returns an owned clone of the queue's terminal error, or OK when the queue
+// has not failed.
+static inline iree_status_t iree_hal_amdgpu_host_queue_clone_error_status(
+    const iree_hal_amdgpu_host_queue_t* queue) {
+  const intptr_t error_status =
+      iree_hal_amdgpu_host_queue_load_error_status_raw(queue);
+  return IREE_LIKELY(error_status == 0)
+             ? iree_ok_status()
+             : iree_status_clone((iree_status_t)error_status);
+}
+
 // Returns a pointer to the queue's accumulated frontier. The returned pointer
 // is layout-compatible with iree_async_frontier_t and valid for all frontier
 // APIs (compare, merge, etc.). Valid for the lifetime of the queue.

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_replay.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_command_buffer_replay.c
@@ -164,9 +164,8 @@ static iree_status_t iree_hal_amdgpu_command_buffer_replay_create(
 // same cause as every other operation that transition settles.
 static iree_status_t iree_hal_amdgpu_command_buffer_replay_clone_queue_error(
     iree_hal_amdgpu_command_buffer_replay_t* replay) {
-  iree_status_t error = (iree_status_t)iree_atomic_load(
-      &replay->queue->error_status, iree_memory_order_acquire);
-  if (!iree_status_is_ok(error)) return iree_status_clone(error);
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_host_queue_clone_error_status(replay->queue));
   if (IREE_UNLIKELY(replay->queue->is_shutting_down)) {
     return iree_make_status(IREE_STATUS_CANCELLED, "queue shutting down");
   }

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_file.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_file.c
@@ -167,13 +167,6 @@ static void iree_hal_amdgpu_file_action_fail_with_borrowed_status(
                                iree_status_clone(status));
 }
 
-static iree_status_t iree_hal_amdgpu_file_action_clone_queue_error(
-    iree_hal_amdgpu_file_action_state_t* state) {
-  iree_status_t error = (iree_status_t)iree_atomic_load(
-      &state->queue->error_status, iree_memory_order_acquire);
-  return iree_status_is_ok(error) ? iree_ok_status() : iree_status_clone(error);
-}
-
 static void iree_hal_amdgpu_file_action_signal_capacity_post_drain(
     void* user_data);
 
@@ -183,7 +176,8 @@ static iree_status_t iree_hal_amdgpu_file_action_submit_signal_barrier(
     return iree_ok_status();
   }
 
-  IREE_RETURN_IF_ERROR(iree_hal_amdgpu_file_action_clone_queue_error(state));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_amdgpu_host_queue_clone_error_status(state->queue));
 
   iree_hal_amdgpu_wait_resolution_t resolution;
   memset(&resolution, 0, sizeof(resolution));

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_pending.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_pending.c
@@ -842,13 +842,6 @@ iree_status_t iree_hal_amdgpu_pending_op_start(iree_hal_amdgpu_pending_op_t* op,
   return iree_hal_amdgpu_pending_op_enqueue_waits(op);
 }
 
-static iree_status_t iree_hal_amdgpu_host_queue_clone_error_status(
-    iree_hal_amdgpu_host_queue_t* queue) {
-  iree_status_t error = (iree_status_t)iree_atomic_load(
-      &queue->error_status, iree_memory_order_acquire);
-  return iree_status_is_ok(error) ? iree_ok_status() : iree_status_clone(error);
-}
-
 // Allocates and initializes a pending operation from a fresh arena.
 // Clones the wait semaphore list. Allocates the retained_resources array
 // with |max_resource_count| capacity and populates the first entries with

--- a/runtime/src/iree/hal/drivers/amdgpu/host_queue_staging.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/host_queue_staging.c
@@ -627,13 +627,6 @@ static const iree_hal_resource_vtable_t
         .destroy = iree_hal_amdgpu_staging_transfer_destroy,
 };
 
-static iree_status_t iree_hal_amdgpu_staging_transfer_clone_queue_error(
-    iree_hal_amdgpu_staging_transfer_t* transfer) {
-  iree_status_t error = (iree_status_t)iree_atomic_load(
-      &transfer->queue->error_status, iree_memory_order_acquire);
-  return iree_status_is_ok(error) ? iree_ok_status() : iree_status_clone(error);
-}
-
 static void iree_hal_amdgpu_staging_transfer_record_failure(
     iree_hal_amdgpu_staging_transfer_t* transfer, iree_status_t status) {
   if (iree_status_is_ok(status)) return;
@@ -653,7 +646,7 @@ static iree_status_t iree_hal_amdgpu_staging_transfer_submit_signal_barrier(
   }
 
   IREE_RETURN_IF_ERROR(
-      iree_hal_amdgpu_staging_transfer_clone_queue_error(transfer));
+      iree_hal_amdgpu_host_queue_clone_error_status(transfer->queue));
 
   iree_hal_amdgpu_wait_resolution_t resolution;
   memset(&resolution, 0, sizeof(resolution));
@@ -818,7 +811,7 @@ static iree_status_t iree_hal_amdgpu_staging_chunk_submit_copy(
     iree_hal_amdgpu_staging_chunk_t* chunk) {
   iree_hal_amdgpu_staging_transfer_t* transfer = chunk->transfer;
   IREE_RETURN_IF_ERROR(
-      iree_hal_amdgpu_staging_transfer_clone_queue_error(transfer));
+      iree_hal_amdgpu_host_queue_clone_error_status(transfer->queue));
 
   iree_hal_amdgpu_wait_resolution_t resolution;
   memset(&resolution, 0, sizeof(resolution));
@@ -941,7 +934,7 @@ static iree_status_t iree_hal_amdgpu_staging_chunk_submit_read(
     iree_hal_amdgpu_staging_chunk_t* chunk) {
   iree_hal_amdgpu_staging_transfer_t* transfer = chunk->transfer;
   IREE_RETURN_IF_ERROR(
-      iree_hal_amdgpu_staging_transfer_clone_queue_error(transfer));
+      iree_hal_amdgpu_host_queue_clone_error_status(transfer->queue));
 
   iree_async_operation_zero(&chunk->read_op.base, sizeof(chunk->read_op));
   iree_async_operation_initialize(&chunk->read_op.base,
@@ -967,7 +960,7 @@ static iree_status_t iree_hal_amdgpu_staging_chunk_submit_write(
     iree_hal_amdgpu_staging_chunk_t* chunk) {
   iree_hal_amdgpu_staging_transfer_t* transfer = chunk->transfer;
   IREE_RETURN_IF_ERROR(
-      iree_hal_amdgpu_staging_transfer_clone_queue_error(transfer));
+      iree_hal_amdgpu_host_queue_clone_error_status(transfer->queue));
 
   iree_async_operation_zero(&chunk->write_op.base, sizeof(chunk->write_op));
   iree_async_operation_initialize(
@@ -1131,7 +1124,7 @@ static void iree_hal_amdgpu_staging_transfer_pump(
 static iree_status_t iree_hal_amdgpu_staging_transfer_start(
     iree_hal_amdgpu_staging_transfer_t* transfer) {
   IREE_RETURN_IF_ERROR(
-      iree_hal_amdgpu_staging_transfer_clone_queue_error(transfer));
+      iree_hal_amdgpu_host_queue_clone_error_status(transfer->queue));
   // The transfer buffer may be a queue_alloca result whose backing is only
   // staged when the operation is submitted. Validate the device pointer here,
   // after the host action's wait set has been satisfied.

--- a/runtime/src/iree/hal/drivers/amdgpu/profile_counters.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/profile_counters.c
@@ -2214,11 +2214,7 @@ static iree_status_t iree_hal_amdgpu_host_queue_wait_profile_counter_range(
         wait_timeout_hint, HSA_WAIT_STATE_BLOCKED);
     if (signal_value == 0) return iree_ok_status();
 
-    iree_status_t queue_error = (iree_status_t)iree_atomic_load(
-        &queue->error_status, iree_memory_order_acquire);
-    if (IREE_UNLIKELY(!iree_status_is_ok(queue_error))) {
-      return iree_status_clone(queue_error);
-    }
+    IREE_RETURN_IF_ERROR(iree_hal_amdgpu_host_queue_clone_error_status(queue));
   }
 }
 

--- a/runtime/src/iree/hal/drivers/amdgpu/semaphore.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/semaphore.c
@@ -231,9 +231,11 @@ static bool iree_hal_amdgpu_semaphore_epoch_is_reached(
 
 static iree_status_t iree_hal_amdgpu_host_queue_epoch_wait_check_error(
     const iree_hal_amdgpu_host_queue_epoch_wait_t* wait_state) {
-  iree_status_t error = (iree_status_t)iree_atomic_load(
-      wait_state->error_status, iree_memory_order_acquire);
-  return iree_status_is_ok(error) ? iree_ok_status() : iree_status_clone(error);
+  const intptr_t error_status =
+      iree_atomic_load(wait_state->error_status, iree_memory_order_acquire);
+  return IREE_LIKELY(error_status == 0)
+             ? iree_ok_status()
+             : iree_status_clone((iree_status_t)error_status);
 }
 
 static uint64_t iree_hal_amdgpu_host_queue_epoch_wait_hint(

--- a/runtime/src/iree/hal/drivers/amdgpu/util/queue_benchmark.cc
+++ b/runtime/src/iree/hal/drivers/amdgpu/util/queue_benchmark.cc
@@ -557,11 +557,8 @@ class QueueBenchmark : public benchmark::Fixture {
           HSA_WAIT_STATE_BLOCKED);
       if (signal_value < compare_value) return iree_ok_status();
 
-      iree_status_t queue_error = (iree_status_t)iree_atomic_load(
-          &host_queue->error_status, iree_memory_order_acquire);
-      if (IREE_UNLIKELY(!iree_status_is_ok(queue_error))) {
-        return iree_status_clone(queue_error);
-      }
+      IREE_RETURN_IF_ERROR(
+          iree_hal_amdgpu_host_queue_clone_error_status(host_queue));
     }
   }
 


### PR DESCRIPTION
AMDGPU host queues retain their first terminal `iree_status_t` in an atomic slot until queue teardown. Several queue consumers reconstructed those pointer-tagged bits as ordinary status locals, making queue-owned storage appear owned by the reader and defeating the status lifetime contract.

This change gives the queue representation one explicit status access surface: an opaque raw load for the two borrowed notification paths, a presence query, and an owned clone operation for every path that returns the failure. File actions, staging transfers, pending operations, command-buffer replay, profiling waits, semaphores, and the queue benchmark now use that shared contract instead of carrying local copies of the atomic reinterpretation.

The common operations remain inline because they sit on queue submission and wait paths. Successful checks still perform exactly one acquire load; status cloning remains confined to the unlikely terminal-error path. The consolidation also removes the duplicate helper implementations and lets status ownership analysis prove that no borrowed queue status escapes as an unconsumed owned value.
