### PR TITLE
[Infra] Isolate presubmit policy tests

### DIFF
--- a/build_tools/devtools/BUILD.bazel
+++ b/build_tools/devtools/BUILD.bazel
@@ -12,6 +12,12 @@ load("//build_tools/bazel:cc.bzl", "iree_cc_binary")
 
 package(default_visibility = ["//visibility:public"])
 
+# Repository tooling checks are owned by the changed-path-aware Presubmit lane.
+# Keep product/platform wildcard builds from rediscovering them in every job.
+_PRESUBMIT_TEST_SIZE = "small"
+
+_PRESUBMIT_TEST_TAGS = ["manual"]
+
 py_library(
     name = "devtools",
     srcs = [
@@ -67,10 +73,12 @@ py_binary(
     ],
     imports = ["build_tools/devtools"],
     main = "cli_smoke_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
 )
 
 py_test(
     name = "bazel_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "bazel.py",
         "bazel_launcher.py",
@@ -80,20 +88,24 @@ py_test(
         "fuzz.py",
     ],
     main = "bazel_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
     deps = ["//build_tools/bazel:compile_commands_merge_lib"],
 )
 
 py_test(
     name = "bazel_launcher_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "bazel_launcher.py",
         "bazel_launcher_test.py",
     ],
     main = "bazel_launcher_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
 )
 
 py_test(
     name = "ci_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "__init__.py",
         "ci.py",
@@ -116,10 +128,12 @@ py_test(
         "//:.github/workflows/test_core_linux_gpu_source.yml",
     ],
     main = "ci_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
 )
 
 py_test(
     name = "cli_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "aliases.py",
         "bazel.py",
@@ -142,20 +156,24 @@ py_test(
         "setup.py",
     ],
     main = "cli_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
     deps = ["//build_tools/bazel:compile_commands_merge_lib"],
 )
 
 py_test(
     name = "cmake_file_api_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "cmake_file_api.py",
         "cmake_file_api_test.py",
     ],
     main = "cmake_file_api_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
 )
 
 py_test(
     name = "cmake_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "__init__.py",
         "cmake.py",
@@ -169,19 +187,23 @@ py_test(
         "fuzz.py",
     ],
     main = "cmake_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
 )
 
 py_test(
     name = "command_plan_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "command_plan.py",
         "command_plan_test.py",
     ],
     main = "command_plan_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
 )
 
 py_test(
     name = "ctest_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "__init__.py",
         "command_plan.py",
@@ -190,19 +212,23 @@ py_test(
         "environment.py",
     ],
     main = "ctest_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
 )
 
 py_test(
     name = "environment_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "environment.py",
         "environment_test.py",
     ],
     main = "environment_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
 )
 
 py_test(
     name = "hooks_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "__init__.py",
         "command_plan.py",
@@ -211,46 +237,56 @@ py_test(
         "hooks_test.py",
     ],
     main = "hooks_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
 )
 
 py_test(
     name = "install_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "__init__.py",
         "install.py",
         "install_test.py",
     ],
     main = "install_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
 )
 
 py_test(
     name = "project_presubmit_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = ["project_presubmit_test.py"],
     main = "project_presubmit_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
     deps = [":devtools"],
 )
 
 py_test(
     name = "source_lock_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "source_lock.py",
         "source_lock_test.py",
     ],
     main = "source_lock_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
 )
 
 py_test(
     name = "smoke_test_lib_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "environment.py",
         "smoke_test_lib.py",
         "smoke_test_lib_test.py",
     ],
     main = "smoke_test_lib_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
 )
 
 py_test(
     name = "setup_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "__init__.py",
         "aliases.py",
@@ -261,4 +297,27 @@ py_test(
         "setup_test.py",
     ],
     main = "setup_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
+)
+
+test_suite(
+    name = "presubmit_tests",
+    tags = _PRESUBMIT_TEST_TAGS,
+    tests = [
+        ":bazel_launcher_test",
+        ":bazel_test",
+        ":ci_test",
+        ":cli_test",
+        ":cmake_file_api_test",
+        ":cmake_test",
+        ":command_plan_test",
+        ":ctest_test",
+        ":environment_test",
+        ":hooks_test",
+        ":install_test",
+        ":project_presubmit_test",
+        ":setup_test",
+        ":smoke_test_lib_test",
+        ":source_lock_test",
+    ],
 )

--- a/build_tools/lefthook/BUILD.bazel
+++ b/build_tools/lefthook/BUILD.bazel
@@ -4,25 +4,47 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# Python repository-policy tools have no CMake target surface.
+# bazel-to-cmake: skip
+
 load("@rules_python//python:defs.bzl", "py_test")
 
 package(default_visibility = ["//visibility:public"])
 
+# Repository policy tests are owned by the changed-path-aware Presubmit lane.
+# Keep product/platform wildcard builds from rediscovering them in every job.
+_PRESUBMIT_TEST_SIZE = "small"
+
+_PRESUBMIT_TEST_TAGS = ["manual"]
+
 py_test(
     name = "commit_msg_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "commit_msg.py",
         "commit_msg_test.py",
     ],
     main = "commit_msg_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
 )
 
 py_test(
     name = "presubmit_test",
+    size = _PRESUBMIT_TEST_SIZE,
     srcs = [
         "presubmit.py",
         "presubmit_test.py",
     ],
     main = "presubmit_test.py",
+    tags = _PRESUBMIT_TEST_TAGS,
     deps = ["//build_tools/devtools"],
+)
+
+test_suite(
+    name = "presubmit_tests",
+    tags = _PRESUBMIT_TEST_TAGS,
+    tests = [
+        ":commit_msg_test",
+        ":presubmit_test",
+    ],
 )

--- a/build_tools/lefthook/README.md
+++ b/build_tools/lefthook/README.md
@@ -194,9 +194,13 @@ The GitHub Presubmit workflow calls:
 python dev.py bazel presubmit --profile ci --no-project-tests
 ```
 
-That workflow still runs full tracked-tree hygiene, root devtools tests, and
-configured static-analysis providers. It skips runtime/libhrx/loom project
-tests because dedicated CI workflows own those project build and test lanes.
+That workflow still runs full tracked-tree hygiene, changed repository-tool
+test suites, and configured static-analysis providers. Developer workflow,
+Lefthook, and project-presubmit policy tests are tagged `manual` so product and
+platform wildcard builds do not rediscover them. The dispatcher selects their
+explicit suites only when the owning scripts, shared support, or workflow
+configuration changes. Runtime/libhrx/loom product tests remain skipped because
+dedicated CI workflows own those build and test lanes.
 
 `lefthook.yml` requires Lefthook 2.1.9 or newer because the repository uses
 custom manual hook groups in addition to Git hook names.

--- a/build_tools/lefthook/presubmit.py
+++ b/build_tools/lefthook/presubmit.py
@@ -157,6 +157,8 @@ class Project:
     name: str
     root: str
     script: str
+    presubmit_test_target: str | None = None
+    presubmit_test_dependencies: tuple[str, ...] = ()
 
 
 PROJECTS = (
@@ -164,6 +166,11 @@ PROJECTS = (
         name="runtime",
         root="runtime/",
         script="runtime/build_tools/presubmit.py",
+        presubmit_test_target="//runtime/build_tools:presubmit_tests",
+        presubmit_test_dependencies=(
+            "build_tools/devtools/BUILD.bazel",
+            "build_tools/devtools/project_presubmit.py",
+        ),
     ),
     Project(
         name="libhrx",
@@ -174,6 +181,13 @@ PROJECTS = (
         name="loom",
         root="loom/",
         script="loom/build_tools/presubmit.py",
+        presubmit_test_target="//loom/build_tools:presubmit_tests",
+        presubmit_test_dependencies=(
+            "build_tools/devtools/BUILD.bazel",
+            "build_tools/devtools/project_presubmit.py",
+            "build_tools/devtools/source_lock.py",
+            "loom/build_tools/linters/loom_source_lint.py",
+        ),
     ),
 )
 
@@ -184,20 +198,28 @@ GLOBAL_PROJECT_TRIGGERS = (
     ".bazel_to_cmake.cfg.py",
     "requirements",
 )
-ROOT_DEVTOOLS_TRIGGERS = (
-    ".github/workflows/docs.yml",
-    ".github/workflows/presubmit.yml",
-    "CONTRIBUTING.md",
-    "README.md",
+DEVTOOLS_TEST_TRIGGERS = (
+    ".github/workflows/",
     "dev.py",
-    "lefthook.yml",
     "requirements-analysis",
     "requirements-dev",
     "loom/docs/requirements",
-    "build_tools/static_analysis/",
     "build_tools/devtools/",
-    "build_tools/lefthook/",
 )
+LEFTHOOK_TEST_PATHS = frozenset(
+    {
+        ".github/workflows/presubmit.yml",
+        "lefthook.yml",
+        "build_tools/lefthook/BUILD.bazel",
+        "build_tools/lefthook/commit_msg.py",
+        "build_tools/lefthook/commit_msg_test.py",
+        "build_tools/lefthook/presubmit.py",
+        "build_tools/lefthook/presubmit_test.py",
+        "build_tools/devtools/source_lock.py",
+    }
+)
+DEVTOOLS_PRESUBMIT_TEST_TARGET = "//build_tools/devtools:presubmit_tests"
+LEFTHOOK_PRESUBMIT_TEST_TARGET = "//build_tools/lefthook:presubmit_tests"
 CLANG_TIDY_FULL_SCOPE_EXACT_PATHS = {
     ".bazelrc",
     ".bazelversion",
@@ -323,7 +345,10 @@ def parse_arguments() -> argparse.Namespace:
         dest="project_tests",
         action="store_false",
         default=True,
-        help="Skip runtime/libhrx/loom project tests while still running root devtools tests.",
+        help=(
+            "Skip runtime/libhrx/loom product tests while still running "
+            "changed repository-tool tests."
+        ),
     )
     parser.add_argument(
         "--static-analysis",
@@ -1555,9 +1580,35 @@ def run_project_presubmits(
     return ok
 
 
-def run_root_devtools_tests(paths: list[str], verbose: bool) -> bool:
-    if not any(is_root_devtools_trigger(path) for path in paths):
-        return skip_step("Root devtools tests", "no root devtools inputs")
+def is_project_presubmit_test_trigger(project: Project, path: str) -> bool:
+    script_stem = project.script.removesuffix(".py")
+    build_file = project.script.rpartition("/")[0] + "/BUILD.bazel"
+    return path in (
+        project.script,
+        f"{script_stem}_test.py",
+        build_file,
+        *project.presubmit_test_dependencies,
+    )
+
+
+def repository_tool_test_targets(paths: list[str]) -> list[str]:
+    targets = []
+    if any(is_devtools_test_trigger(path) for path in paths):
+        targets.append(DEVTOOLS_PRESUBMIT_TEST_TARGET)
+    if any(is_lefthook_test_trigger(path) for path in paths):
+        targets.append(LEFTHOOK_PRESUBMIT_TEST_TARGET)
+    for project in existing_project_scripts():
+        if project.presubmit_test_target and any(
+            is_project_presubmit_test_trigger(project, path) for path in paths
+        ):
+            targets.append(project.presubmit_test_target)
+    return targets
+
+
+def run_repository_tool_tests(paths: list[str], verbose: bool) -> bool:
+    test_targets = repository_tool_test_targets(paths)
+    if not test_targets:
+        return skip_step("Repository tool tests", "no repository tool inputs")
     ok = True
     ok = (
         run_command(
@@ -1565,37 +1616,37 @@ def run_root_devtools_tests(paths: list[str], verbose: bool) -> bool:
                 "bazel",
                 "test",
                 "--config=presubmit",
-                "//build_tools/devtools:all",
-                "//build_tools/lefthook:all",
+                *test_targets,
             ],
-            "Root devtools Bazel tests",
+            "Repository tool Bazel tests",
             verbose,
         )
         and ok
     )
-    ok = (
-        run_command(
-            [
-                "python",
-                "build_tools/devtools/cli_smoke_test.py",
-            ],
-            "Root devtools command smoke test",
-            verbose,
+    if DEVTOOLS_PRESUBMIT_TEST_TARGET in test_targets:
+        ok = (
+            run_command(
+                [
+                    "python",
+                    "build_tools/devtools/cli_smoke_test.py",
+                ],
+                "Root devtools command smoke test",
+                verbose,
+            )
+            and ok
         )
-        and ok
-    )
     return ok
 
 
-def run_root_devtools_tests_for_lane(
+def run_repository_tool_tests_for_lane(
     paths: list[str], lane: str, verbose: bool
 ) -> bool:
     if lane == "bazel":
-        return run_root_devtools_tests(paths, verbose)
+        return run_repository_tool_tests(paths, verbose)
     if lane != "cmake":
         raise ValueError(f"unknown lane: {lane}")
-    if not any(is_root_devtools_trigger(path) for path in paths):
-        return skip_step("Root devtools tests", "no root devtools inputs")
+    if not any(is_devtools_test_trigger(path) for path in paths):
+        return skip_step("Repository tool tests", "no devtools inputs")
     return run_command(
         [
             "python",
@@ -1613,15 +1664,19 @@ def run_root_devtools_tests_for_lane(
     )
 
 
-def is_root_devtools_trigger(path: str) -> bool:
+def is_devtools_test_trigger(path: str) -> bool:
     if path.startswith("requirements-") and (
         path.endswith(".in") or path.endswith(".lock.txt")
     ):
         return True
     return any(
         path == trigger or path.startswith(trigger)
-        for trigger in ROOT_DEVTOOLS_TRIGGERS
+        for trigger in DEVTOOLS_TEST_TRIGGERS
     )
+
+
+def is_lefthook_test_trigger(path: str) -> bool:
+    return path in LEFTHOOK_TEST_PATHS
 
 
 def run_semgrep(inputs: PresubmitInputs, profile: str, verbose: bool) -> bool:
@@ -2546,7 +2601,7 @@ def run_presubmit(
     if args.tests:
         print_section("Tests")
         ok = (
-            run_root_devtools_tests_for_lane(
+            run_repository_tool_tests_for_lane(
                 paths, lane=args.lane, verbose=args.verbose
             )
             and ok

--- a/build_tools/lefthook/presubmit_test.py
+++ b/build_tools/lefthook/presubmit_test.py
@@ -1059,18 +1059,80 @@ class PresubmitTest(unittest.TestCase):
         run_command.assert_not_called()
         self.assertIn("enforced by the Linux paranoid presubmit", output.getvalue())
 
-    def test_requirements_and_docs_workflow_trigger_root_devtools_tests(self):
+    def test_workflows_and_requirements_trigger_devtools_tests(self):
         self.assertTrue(
-            presubmit.is_root_devtools_trigger(".github/workflows/docs.yml")
+            presubmit.is_devtools_test_trigger(".github/workflows/docs.yml")
         )
-        self.assertTrue(presubmit.is_root_devtools_trigger("requirements-analysis.in"))
+        self.assertTrue(presubmit.is_devtools_test_trigger("requirements-analysis.in"))
         self.assertTrue(
-            presubmit.is_root_devtools_trigger("requirements-analysis.lock.txt")
+            presubmit.is_devtools_test_trigger("requirements-analysis.lock.txt")
         )
         self.assertTrue(
-            presubmit.is_root_devtools_trigger("loom/docs/requirements.lock.txt")
+            presubmit.is_devtools_test_trigger("loom/docs/requirements.lock.txt")
         )
-        self.assertFalse(presubmit.is_root_devtools_trigger("runtime/requirements.txt"))
+        self.assertFalse(presubmit.is_devtools_test_trigger("runtime/requirements.txt"))
+        self.assertFalse(presubmit.is_devtools_test_trigger("README.md"))
+
+    def test_repository_tool_tests_follow_changed_file_ownership(self):
+        cases = (
+            (
+                ["runtime/src/iree/base/status.c"],
+                [],
+            ),
+            (
+                [".github/workflows/ci_core_windows.yml"],
+                [presubmit.DEVTOOLS_PRESUBMIT_TEST_TARGET],
+            ),
+            (
+                [".github/workflows/presubmit.yml"],
+                [
+                    presubmit.DEVTOOLS_PRESUBMIT_TEST_TARGET,
+                    presubmit.LEFTHOOK_PRESUBMIT_TEST_TARGET,
+                ],
+            ),
+            (
+                ["build_tools/lefthook/presubmit.py"],
+                [presubmit.LEFTHOOK_PRESUBMIT_TEST_TARGET],
+            ),
+            (
+                ["build_tools/lefthook/README.md"],
+                [],
+            ),
+            (
+                ["runtime/build_tools/presubmit.py"],
+                ["//runtime/build_tools:presubmit_tests"],
+            ),
+            (
+                ["runtime/build_tools/BUILD.bazel"],
+                ["//runtime/build_tools:presubmit_tests"],
+            ),
+            (
+                ["runtime/build_tools/bazel/cc.bzl"],
+                [],
+            ),
+            (
+                ["loom/build_tools/linters/loom_source_lint.py"],
+                ["//loom/build_tools:presubmit_tests"],
+            ),
+            (
+                ["loom/build_tools/amdgpu/target_config.py"],
+                [],
+            ),
+            (
+                ["build_tools/devtools/project_presubmit.py"],
+                [
+                    presubmit.DEVTOOLS_PRESUBMIT_TEST_TARGET,
+                    "//runtime/build_tools:presubmit_tests",
+                    "//loom/build_tools:presubmit_tests",
+                ],
+            ),
+        )
+        for paths, expected_targets in cases:
+            with self.subTest(paths=paths):
+                self.assertEqual(
+                    presubmit.repository_tool_test_targets(paths),
+                    expected_targets,
+                )
 
     def test_existing_project_scripts_include_loom(self):
         self.assertIn(
@@ -1114,7 +1176,7 @@ class PresubmitTest(unittest.TestCase):
         self.assertEqual(description, "loom hygiene")
         self.assertFalse(verbose)
 
-    def test_disabling_project_tests_preserves_project_hygiene(self):
+    def test_disabling_project_tests_preserves_hygiene_and_tool_tests(self):
         project = presubmit.Project(
             name="loom",
             root="loom/",
@@ -1139,8 +1201,8 @@ class PresubmitTest(unittest.TestCase):
                 presubmit, "run_project_presubmits", return_value=True
             ) as run_project_presubmits,
             mock.patch.object(
-                presubmit, "run_root_devtools_tests_for_lane", return_value=True
-            ),
+                presubmit, "run_repository_tool_tests_for_lane", return_value=True
+            ) as run_repository_tool_tests,
             mock.patch.object(presubmit, "skip_step", return_value=True),
         ):
             self.assertEqual(
@@ -1156,6 +1218,9 @@ class PresubmitTest(unittest.TestCase):
         self.assertEqual(
             run_project_presubmits.call_args.kwargs["phase"],
             "hygiene",
+        )
+        run_repository_tool_tests.assert_called_once_with(
+            ["loom/test.loom"], lane="bazel", verbose=False
         )
 
 

--- a/loom/build_tools/BUILD.bazel
+++ b/loom/build_tools/BUILD.bazel
@@ -13,6 +13,7 @@ package(
 
 py_test(
     name = "presubmit_test",
+    size = "small",
     srcs = [
         "presubmit.py",
         "presubmit_test.py",
@@ -20,6 +21,7 @@ py_test(
     data = [
         "//loom/src/loom/test/corpus/authoring/linking:checks.loom",
     ],
+    tags = ["manual"],
     deps = [
         "//build_tools/devtools",
         "//loom/py/loom/gen:checked_in_artifacts",
@@ -28,7 +30,20 @@ py_test(
 
 py_test(
     name = "loom_source_lint_self_test",
+    size = "small",
     srcs = ["linters/loom_source_lint.py"],
     args = ["--self-test"],
     main = "linters/loom_source_lint.py",
+    tags = ["manual"],
+)
+
+# Project policy tests run in the repository Presubmit lane when this
+# build_tools subtree or its shared support changes.
+test_suite(
+    name = "presubmit_tests",
+    tags = ["manual"],
+    tests = [
+        ":loom_source_lint_self_test",
+        ":presubmit_test",
+    ],
 )

--- a/runtime/build_tools/BUILD.bazel
+++ b/runtime/build_tools/BUILD.bazel
@@ -13,9 +13,19 @@ package(
 
 py_test(
     name = "presubmit_test",
+    size = "small",
     srcs = [
         "presubmit.py",
         "presubmit_test.py",
     ],
+    tags = ["manual"],
     deps = ["//build_tools/devtools"],
+)
+
+# Project policy tests run in the repository Presubmit lane when this
+# build_tools subtree or its shared support changes.
+test_suite(
+    name = "presubmit_tests",
+    tags = ["manual"],
+    tests = [":presubmit_test"],
 )


### PR DESCRIPTION
Repository-policy unit tests currently participate in product wildcard target patterns, so compiler, sanitizer, feature, and platform jobs repeatedly run the same developer-workflow and presubmit tests. This is especially wasteful on Windows, where the Lefthook presubmit unit test alone can occupy roughly 25 seconds of an otherwise product-focused lane.

Make the existing Linux Presubmit workflow the sole CI owner for these tests. Developer-tool, Lefthook, Runtime policy, and Loom policy tests are now `manual` Bazel targets grouped into explicit `presubmit_tests` suites, so `//...`, `//runtime/...`, and `//loom/...` product patterns no longer discover them.

The changed-path-aware dispatcher selects only the relevant suites: workflow and devtool changes exercise devtools, Lefthook script changes exercise repository policy, project presubmit script and self-test changes exercise that project's policy, and shared project-presubmit support exercises its consumers. This selection remains active under `--no-project-tests`; that flag continues to suppress only Runtime, libhrx, and Loom product suites.

The direct devtools smoke binary follows the same ownership boundary, and the bounded policy unit tests are classified as Bazel `small` tests instead of inheriting the misleading `medium` default. Build-rule smoke tests remain in product/platform graphs because they validate configured platform behavior.

Reviewer Notes

The highest-value review surface is the target selector in `build_tools/lefthook/presubmit.py`: ordinary product paths select no policy suite, while shared support explicitly names the project suites whose scripts consume it. The BUILD target lists are intentionally explicit so a future policy test cannot silently join every product matrix.
