### PR TITLE
[HAL/LocalTask] Serialize queue shutdown phases

### DIFF
--- a/runtime/src/iree/hal/drivers/local_task/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/local_task/BUILD.bazel
@@ -198,3 +198,20 @@ iree_runtime_cc_library(
         "//runtime/src/iree/task",
     ],
 )
+
+iree_runtime_cc_test(
+    name = "task_queue_test",
+    srcs = [
+        "task_queue_test.cc",
+    ],
+    deps = [
+        ":task_driver",
+        "//runtime/src/iree/async",
+        "//runtime/src/iree/async/util:proactor_pool",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/task",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)

--- a/runtime/src/iree/hal/drivers/local_task/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_task/CMakeLists.txt
@@ -184,4 +184,20 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_test(
+  NAME
+    task_queue_test
+  SRCS
+    "task_queue_test.cc"
+  DEPS
+    ::task_driver
+    iree::async
+    iree::async::util::proactor_pool
+    iree::base
+    iree::hal
+    iree::task
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/runtime/src/iree/hal/drivers/local_task/task_queue.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_queue.c
@@ -862,8 +862,14 @@ typedef struct iree_hal_task_queue_wait_entry_t {
 } iree_hal_task_queue_wait_entry_t;
 
 static bool iree_hal_task_queue_is_shutting_down(iree_hal_task_queue_t* queue) {
-  return iree_atomic_load(&queue->shutting_down, iree_memory_order_acquire) !=
-         0;
+  return iree_atomic_load(&queue->shutdown_phase, iree_memory_order_acquire) !=
+         IREE_HAL_TASK_QUEUE_SHUTDOWN_PHASE_RUNNING;
+}
+
+static bool iree_hal_task_queue_is_compute_shutting_down(
+    iree_hal_task_queue_t* queue) {
+  return iree_atomic_load(&queue->shutdown_phase, iree_memory_order_acquire) ==
+         IREE_HAL_TASK_QUEUE_SHUTDOWN_PHASE_COMPUTE;
 }
 
 static iree_status_t iree_hal_task_queue_make_shutdown_status(void) {
@@ -2467,8 +2473,9 @@ static iree_status_t iree_hal_task_queue_compute_process_drain(
     iree_task_process_drain_result_t* out_result) {
   iree_hal_task_queue_t* queue = (iree_hal_task_queue_t*)process->user_data;
 
-  // Check for shutdown.
-  if (iree_hal_task_queue_is_shutting_down(queue)) {
+  // Compute shutdown begins only after the control process has released and
+  // can no longer initialize or publish items into the compute pool.
+  if (iree_hal_task_queue_is_compute_shutting_down(queue)) {
     IREE_TRACE(iree_hal_task_queue_trace_compute_drain_event());
     out_result->did_work = false;
     out_result->completed = true;
@@ -2727,11 +2734,12 @@ static void iree_hal_task_queue_compute_process_release(
   //
   // All three classes are handled uniformly by compute_item_cleanup.
   //
-  // The pool scan is race-free because the slot release only fires after
-  // slot->active_drainers reaches the sentinel (no workers in drain), and
-  // the compute process's schedule_state transitions to IDLE exclusively in
-  // release_compute_process (never from drain), so no other slot lifetime
-  // can overlap this callback.
+  // The pool scan is race-free because compute shutdown is requested only by
+  // the control process release callback after the sole item producer has
+  // quiesced. The slot release also fires only after slot->active_drainers
+  // reaches the sentinel (no workers in drain), and the compute process's
+  // schedule_state transitions to IDLE exclusively in release_compute_process
+  // (never from drain), so no other slot lifetime can overlap this callback.
   for (iree_hal_task_queue_compute_item_t* item = queue->compute_item_head;
        item != NULL; item = item->next_allocated) {
     if (item->operation || item->processor_context ||
@@ -3070,6 +3078,16 @@ static iree_status_t iree_hal_task_queue_drain_write(
 // terminal status for us when no callback is installed.
 static void iree_hal_task_queue_process_release(iree_task_process_t* process) {
   iree_hal_task_queue_t* queue = (iree_hal_task_queue_t*)process->user_data;
+
+  // This callback is the control process's producer-quiescence barrier. Its
+  // single worker has returned from drain and can no longer allocate,
+  // initialize, or publish compute items. Only now may the compute process
+  // terminate and clean the full item pool.
+  iree_atomic_store(&queue->shutdown_phase,
+                    IREE_HAL_TASK_QUEUE_SHUTDOWN_PHASE_COMPUTE,
+                    iree_memory_order_release);
+  iree_task_executor_schedule_process(queue->executor, &queue->compute_process);
+
   iree_task_scope_end(&queue->scope);
   iree_atomic_fetch_sub(&queue->pending_process_release_count, 1,
                         iree_memory_order_release);
@@ -3307,6 +3325,9 @@ iree_status_t iree_hal_task_queue_initialize(
   iree_task_executor_retain(out_queue->executor);
   out_queue->proactor = proactor;
   iree_atomic_store(&out_queue->epoch, 0, iree_memory_order_relaxed);
+  iree_atomic_store(&out_queue->shutdown_phase,
+                    IREE_HAL_TASK_QUEUE_SHUTDOWN_PHASE_RUNNING,
+                    iree_memory_order_relaxed);
   out_queue->inline_transfer_threshold = inline_transfer_threshold;
   out_queue->small_block_pool = small_block_pool;
   out_queue->large_block_pool = large_block_pool;
@@ -3417,16 +3438,19 @@ void iree_hal_task_queue_retire_frontier(iree_hal_task_queue_t* queue) {
 void iree_hal_task_queue_deinitialize(iree_hal_task_queue_t* queue) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  // Signal both processes to complete. The next drain call on each sees this
-  // flag and returns completed=true, triggering normal process completion.
-  iree_atomic_store(&queue->shutting_down, 1, iree_memory_order_release);
-
-  // Schedule both processes so workers pick them up and see the shutdown flag.
-  // If a process is already being drained, schedule_process sets needs_drain
-  // and the worker will see shutting_down on the next iteration. If IDLE,
-  // schedule_process pushes it to the appropriate run list.
+  // Reject new work and request control-process termination. If the process is
+  // already being drained, schedule_process sets needs_drain and the worker
+  // observes the phase on its next iteration. If IDLE, schedule_process pushes
+  // it to the immediate run list.
+  //
+  // The control release callback advances to COMPUTE and schedules the compute
+  // process only after the control worker has left drain. This producer-first
+  // ordering prevents compute item cleanup from racing control item
+  // initialization and also remains live with a single-worker executor.
+  iree_atomic_store(&queue->shutdown_phase,
+                    IREE_HAL_TASK_QUEUE_SHUTDOWN_PHASE_CONTROL,
+                    iree_memory_order_release);
   iree_task_executor_schedule_process(queue->executor, &queue->process);
-  iree_task_executor_schedule_process(queue->executor, &queue->compute_process);
 
   // Wait for all outstanding operations and both processes to complete.
   // The wake_budget == 1 process's scope_end fires in its release callback.

--- a/runtime/src/iree/hal/drivers/local_task/task_queue.h
+++ b/runtime/src/iree/hal/drivers/local_task/task_queue.h
@@ -21,6 +21,10 @@
 //
 // Operations are arena-allocated at submit time and freed by the completion
 // callback. No per-submission task allocations at issue time.
+//
+// Shutdown first retires the control process, the sole compute-item producer,
+// and only its release callback requests compute-process termination. This
+// orders full-pool cleanup after producer quiescence without blocking a worker.
 
 #ifndef IREE_HAL_DRIVERS_LOCAL_TASK_TASK_QUEUE_H_
 #define IREE_HAL_DRIVERS_LOCAL_TASK_TASK_QUEUE_H_
@@ -418,6 +422,13 @@ typedef struct iree_hal_task_queue_debug_state_t {
 } iree_hal_task_queue_debug_state_t;
 #endif  // !defined(NDEBUG)
 
+// Ordered queue shutdown phases.
+typedef enum iree_hal_task_queue_shutdown_phase_e {
+  IREE_HAL_TASK_QUEUE_SHUTDOWN_PHASE_RUNNING = 0,
+  IREE_HAL_TASK_QUEUE_SHUTDOWN_PHASE_CONTROL = 1,
+  IREE_HAL_TASK_QUEUE_SHUTDOWN_PHASE_COMPUTE = 2,
+} iree_hal_task_queue_shutdown_phase_t;
+
 struct iree_hal_task_queue_t {
   // Affinity mask this queue processes.
   iree_hal_queue_affinity_t affinity;
@@ -488,17 +499,16 @@ struct iree_hal_task_queue_t {
   // by the submitting thread (fast path when all waits are satisfied).
   iree_hal_task_queue_op_slist_t ready_list;
 
-  // Set during deinitialize to signal the queue process to complete.
-  // The queue process checks this at the start of each drain call and
-  // returns completed=true when set, triggering normal process completion
-  // and scope_end via the release callback.
-  iree_atomic_int32_t shutting_down;
+  // Monotonic shutdown phase. RUNNING accepts work, CONTROL rejects new work
+  // and terminates the control process, and COMPUTE terminates the compute
+  // process after the control process has released its producer ownership.
+  iree_atomic_int32_t shutdown_phase;
 
   // The queue's persistent control process. Uses wake_budget == 1 and drains
   // operations from the ready list sequentially. When the ready list is empty,
   // the process returns did_work=false and the executor's sleeping protocol
-  // parks it. New submissions wake it via schedule_process. Completes when
-  // shutting_down is set during deinitialize.
+  // parks it. New submissions wake it via schedule_process. Completes during
+  // the CONTROL shutdown phase started by deinitialize.
   //
   // For COMMANDS operations, this process fills a recording item and pushes
   // it to compute_pending (delegating actual execution to the compute
@@ -529,7 +539,9 @@ struct iree_hal_task_queue_t {
   // stays in its slot until shutdown.
   //
   // Participates in the queue's scope: scope_begin at initialization,
-  // scope_end in the release callback after the last drainer exits.
+  // scope_end in the release callback after the last drainer exits. Completes
+  // only after the control process release callback advances shutdown to the
+  // COMPUTE phase, ensuring no producer can still touch the item pool.
   iree_alignas(iree_hardware_destructive_interference_size)
       iree_task_process_t compute_process;
 

--- a/runtime/src/iree/hal/drivers/local_task/task_queue_test.cc
+++ b/runtime/src/iree/hal/drivers/local_task/task_queue_test.cc
@@ -1,0 +1,127 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/async/frontier_tracker.h"
+#include "iree/async/util/proactor_pool.h"
+#include "iree/hal/device_group.h"
+#include "iree/hal/drivers/local_task/task_device.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+class TaskQueueShutdownTest
+    : public ::testing::TestWithParam<iree_host_size_t> {
+ protected:
+  void SetUp() override {
+    iree_task_topology_t topology;
+    iree_task_topology_initialize_from_group_count(GetParam(), &topology);
+    iree_task_executor_options_t executor_options;
+    iree_task_executor_options_initialize(&executor_options);
+    iree_status_t executor_status = iree_task_executor_create(
+        executor_options, &topology, iree_allocator_system(), &executor_);
+    iree_task_topology_deinitialize(&topology);
+    IREE_ASSERT_OK(executor_status);
+
+    IREE_ASSERT_OK(iree_hal_allocator_create_heap(
+        IREE_SV("task_queue_test"), iree_allocator_system(),
+        iree_allocator_system(), &device_allocator_));
+    IREE_ASSERT_OK(iree_async_proactor_pool_create(
+        /*node_count=*/1, /*node_ids=*/nullptr,
+        iree_async_proactor_pool_options_default(), iree_allocator_system(),
+        &proactor_pool_));
+  }
+
+  void TearDown() override {
+    iree_async_proactor_pool_release(proactor_pool_);
+    iree_hal_allocator_release(device_allocator_);
+    iree_task_executor_release(executor_);
+  }
+
+  iree_status_t CreateDeviceGroup(iree_hal_device_group_t** out_device_group) {
+    *out_device_group = nullptr;
+    iree_hal_task_device_params_t device_params;
+    iree_hal_task_device_params_initialize(&device_params);
+    iree_hal_device_create_params_t create_params =
+        iree_hal_device_create_params_default();
+    create_params.proactor_pool = proactor_pool_;
+    iree_hal_device_t* device = nullptr;
+    iree_status_t status = iree_hal_task_device_create(
+        IREE_SV("task_queue_test"), &device_params, /*queue_count=*/1,
+        &executor_, /*loader_count=*/0, /*loaders=*/nullptr, device_allocator_,
+        &create_params, iree_allocator_system(), &device);
+    iree_async_frontier_tracker_t* frontier_tracker = nullptr;
+    if (iree_status_is_ok(status)) {
+      status = iree_async_frontier_tracker_create(
+          iree_async_frontier_tracker_options_default(),
+          iree_allocator_system(), &frontier_tracker);
+    }
+    if (iree_status_is_ok(status)) {
+      status = iree_hal_device_group_create_from_device(
+          device, frontier_tracker, iree_allocator_system(), out_device_group);
+    }
+    iree_async_frontier_tracker_release(frontier_tracker);
+    iree_hal_device_release(device);
+    return status;
+  }
+
+  // Executor shared by each short-lived device in the test.
+  iree_task_executor_t* executor_ = nullptr;
+
+  // Heap allocator shared by each short-lived device in the test.
+  iree_hal_allocator_t* device_allocator_ = nullptr;
+
+  // Proactor pool shared by each short-lived device in the test.
+  iree_async_proactor_pool_t* proactor_pool_ = nullptr;
+};
+
+TEST_P(TaskQueueShutdownTest, ReleasesDeviceGroupWithAcceptedExecuteInFlight) {
+  // Repeated immediate destruction drives shutdown across the control-to-
+  // compute ownership handoff without externally waiting for completion.
+  // Device group release must either finish or cancel every accepted
+  // submission before it tears down the queue's compute item pool.
+  static constexpr int kIterationCount = 256;
+  for (int iteration = 0; iteration < kIterationCount; ++iteration) {
+    iree_hal_device_group_t* device_group = nullptr;
+    IREE_ASSERT_OK(CreateDeviceGroup(&device_group));
+    iree_hal_device_t* device =
+        iree_hal_device_group_device_at(device_group, 0);
+
+    iree_hal_command_buffer_t* command_buffer = nullptr;
+    IREE_ASSERT_OK(iree_hal_command_buffer_create(
+        device, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
+        IREE_HAL_COMMAND_CATEGORY_TRANSFER, IREE_HAL_QUEUE_AFFINITY_ANY,
+        /*binding_capacity=*/0, &command_buffer));
+    IREE_ASSERT_OK(iree_hal_command_buffer_begin(command_buffer));
+    IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
+
+    iree_hal_semaphore_t* signal_semaphore = nullptr;
+    IREE_ASSERT_OK(iree_hal_semaphore_create(
+        device, IREE_HAL_QUEUE_AFFINITY_ANY, /*initial_value=*/0,
+        IREE_HAL_SEMAPHORE_FLAG_DEFAULT, &signal_semaphore));
+    iree_hal_semaphore_t* signal_semaphores[] = {signal_semaphore};
+    uint64_t signal_values[] = {1};
+    const iree_hal_semaphore_list_t signal_list = {
+        IREE_ARRAYSIZE(signal_semaphores),
+        signal_semaphores,
+        signal_values,
+    };
+
+    IREE_ASSERT_OK(iree_hal_device_queue_execute(
+        device, IREE_HAL_QUEUE_AFFINITY_ANY, iree_hal_semaphore_list_empty(),
+        signal_list, command_buffer, iree_hal_buffer_binding_table_empty(),
+        IREE_HAL_EXECUTE_FLAG_NONE));
+
+    iree_hal_semaphore_release(signal_semaphore);
+    iree_hal_command_buffer_release(command_buffer);
+    iree_hal_device_group_release(device_group);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(WorkerCounts, TaskQueueShutdownTest,
+                         ::testing::Values(1, 4));
+
+}  // namespace


### PR DESCRIPTION
Local-task queue destruction now retires the single-worker control process before allowing the multi-worker compute process to terminate and reclaim its item pool.

The previous shared shutdown bit stopped both processes concurrently. A control worker that had already accepted a command could still initialize and publish a compute item while the compute release callback scanned and cleaned the same item, producing races, use-after-free behavior, and shutdown hangs. The queue now advances through monotonic running, control-shutdown, and compute-shutdown phases. The control release callback is the producer-quiescence barrier: only after it runs can compute termination be scheduled.

The transition remains callback-driven instead of blocking an executor worker, which preserves teardown liveness for single-worker executors. The compute release callback continues to own final full-pool cleanup after both producers and compute drainers have quiesced.

Regression coverage repeatedly destroys real local-task device groups with accepted queue work still in flight under both single-worker and multi-worker executor topologies. This is stacked on #469 so the shutdown repair can be reviewed independently from the local-sync removal.
