### PR TITLE
[HAL] Remove inline command buffer execution mode

### DIFF
--- a/loom/binding/c/test/target/iree_hal_execution.cc
+++ b/loom/binding/c/test/target/iree_hal_execution.cc
@@ -375,9 +375,7 @@ iree_status_t DispatchAndWait(iree_hal_device_t* device,
   uint64_t signal_value = 1;
 
   iree_status_t status = iree_hal_command_buffer_create(
-      device,
-      IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT |
-          IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION,
+      device, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
       IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
       /*binding_capacity=*/0, &command_buffer);
   if (iree_status_is_ok(status)) {

--- a/runtime/src/iree/hal/buffer_transfer.c
+++ b/runtime/src/iree/hal/buffer_transfer.c
@@ -37,26 +37,13 @@ static iree_status_t iree_hal_device_transfer_and_wait(
   IREE_ASSERT_ARGUMENT(!transfer_count || transfer_commands);
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  // We only want to allow inline execution if we have not been instructed to
-  // wait on a semaphore and it hasn't yet been signaled.
-  iree_hal_command_buffer_mode_t mode = IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT;
-  if (wait_semaphore) {
-    uint64_t current_value = 0ull;
-    IREE_RETURN_AND_END_ZONE_IF_ERROR(
-        z0, iree_hal_semaphore_query(wait_semaphore, &current_value));
-    if (current_value >= wait_value) {
-      mode |= IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION;
-    }
-  } else {
-    mode |= IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION;
-  }
-
   // Create a command buffer performing all of the transfer operations.
   iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_create_transfer_command_buffer(
-              device, mode, IREE_HAL_QUEUE_AFFINITY_ANY, transfer_count,
-              transfer_commands, &command_buffer));
+              device, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
+              IREE_HAL_QUEUE_AFFINITY_ANY, transfer_count, transfer_commands,
+              &command_buffer));
 
   // Perform a full submit-and-wait. On devices with multiple queues this can
   // run out-of-order/overlapped with other work and return earlier than device

--- a/runtime/src/iree/hal/command_buffer.c
+++ b/runtime/src/iree/hal/command_buffer.c
@@ -47,8 +47,6 @@ iree_hal_command_buffer_mode_format(iree_hal_command_buffer_mode_t value,
                                     iree_bitfield_string_temp_t* out_temp) {
   static const iree_bitfield_string_mapping_t mappings[] = {
       {IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT, IREE_SVL("ONE_SHOT")},
-      {IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION,
-       IREE_SVL("ALLOW_INLINE_EXECUTION")},
       {IREE_HAL_COMMAND_BUFFER_MODE_UNVALIDATED, IREE_SVL("UNVALIDATED")},
       {IREE_HAL_COMMAND_BUFFER_MODE_UNRETAINED, IREE_SVL("UNRETAINED")},
       {IREE_HAL_COMMAND_BUFFER_MODE_RETAIN_PROFILE_METADATA,
@@ -138,18 +136,6 @@ IREE_API_EXPORT iree_status_t iree_hal_command_buffer_create(
   IREE_ASSERT_ARGUMENT(device);
   IREE_ASSERT_ARGUMENT(out_command_buffer);
   *out_command_buffer = NULL;
-
-  if (iree_all_bits_set(mode,
-                        IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION)) {
-    if (!iree_all_bits_set(mode, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT)) {
-      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                              "inline command buffers must be one-shot");
-    } else if (binding_capacity > 0) {
-      return iree_make_status(
-          IREE_STATUS_INVALID_ARGUMENT,
-          "inline command buffers cannot have indirect bindings");
-    }
-  }
 
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_status_t status =

--- a/runtime/src/iree/hal/command_buffer.h
+++ b/runtime/src/iree/hal/command_buffer.h
@@ -38,25 +38,6 @@ enum iree_hal_command_buffer_mode_bits_t {
   // If this bit is not set the command buffer may be submitted multiple times.
   IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT = 1u << 0,
 
-  // Indicates that the command buffer execution is allowed to execute inline
-  // with recording. The exact execution behavior is unspecified by the API and
-  // intentionally unknowable and must always assume to happen entirely
-  // asynchronously and that it will only have completed after waiting on device
-  // idle or the wait semaphores specified in the submission are signaled.
-  //
-  // Local backends can use this to avoid recording when the calling program can
-  // guarantee that it makes no assumptions about execution being deferred until
-  // a submission. The command buffer must still be submitted for scheduling and
-  // must have no wait semaphores specified. This allows the same program code
-  // to execute work both synchronously and asynchronously as remote backends
-  // are allowed to ignore this.
-  //
-  // Remote backends can use this to flush the command buffer more aggressively
-  // to begin early execution and overlap with continued recording.
-  //
-  // Requires IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT.
-  IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION = 1u << 4,
-
   // Disables additional command buffer validation (if present).
   // By default all command buffers will be validated if
   // `IREE_HAL_COMMAND_BUFFER_VALIDATION_ENABLE=1` - if shimming command buffers
@@ -413,11 +394,9 @@ enum iree_hal_dispatch_flag_bits_t {
   // the submitting thread without multi-worker tile distribution. Devices are
   // free to ignore this hint and use their normal execution path.
   //
-  // This parallels IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION at the
-  // individual dispatch level. Useful for queue_dispatch operations where a
-  // single dispatch is submitted directly (no command buffer) and the caller
-  // knows the workload is small enough that worker wake-up latency would
-  // dominate the total cost.
+  // Useful for queue_dispatch operations where a single dispatch is submitted
+  // directly and the caller knows the workload is small enough that worker
+  // wake-up latency would dominate the total cost.
   IREE_HAL_DISPATCH_FLAG_ALLOW_INLINE_EXECUTION = 1ull << 5,
 
   // Allows queue_dispatch implementations to borrow resource lifetimes instead

--- a/runtime/src/iree/hal/device.c
+++ b/runtime/src/iree/hal/device.c
@@ -598,24 +598,6 @@ IREE_API_EXPORT iree_status_t iree_hal_device_queue_execute(
                         signal_semaphore_list.payload_values));
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  // TODO(benvanik): move into devices instead? then a synchronous/inline device
-  // could assert the waits are resolved instead of blanket failing on an
-  // already-resolved semaphore. This would make using stream-ordered
-  // allocations easier.
-  if (wait_semaphore_list.count > 0 && command_buffer &&
-      iree_all_bits_set(iree_hal_command_buffer_mode(command_buffer),
-                        IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION)) {
-    // Inline command buffers are not allowed to wait (as they could have
-    // already been executed!). This is a requirement of the API so we
-    // validate it across all backends even if they don't support inline
-    // execution and ignore it.
-    IREE_TRACE_ZONE_END(z0);
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "inline command buffer submitted with a wait; inline command "
-        "buffers must be ready to execute immediately");
-  }
-
   // Validate command buffer bindings against the provided binding tables.
   // This will error out if a binding table is required but not provided or if
   // any binding in the table does not match the requirements of the command

--- a/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/aql_command_buffer.c
@@ -814,12 +814,6 @@ iree_status_t iree_hal_amdgpu_aql_command_buffer_create(
   IREE_ASSERT_ARGUMENT(out_command_buffer);
   *out_command_buffer = NULL;
 
-  if (iree_any_bit_set(mode,
-                       IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION) &&
-      !iree_all_bits_set(mode, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT)) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "ALLOW_INLINE_EXECUTION requires ONE_SHOT mode");
-  }
   if (IREE_UNLIKELY(!program_block_pool)) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "command-buffer program block pool is required");

--- a/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/logical_device.c
@@ -2754,10 +2754,8 @@ static bool iree_hal_amdgpu_logical_device_can_auto_select_pm4_command_buffer(
   if (iree_any_bit_set(mode, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT)) {
     return false;
   }
-  const iree_hal_command_buffer_mode_t unsupported_modes =
-      IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION |
-      IREE_HAL_COMMAND_BUFFER_MODE_RETAIN_DISPATCH_METADATA;
-  if (iree_any_bit_set(mode, unsupported_modes)) {
+  if (iree_any_bit_set(mode,
+                       IREE_HAL_COMMAND_BUFFER_MODE_RETAIN_DISPATCH_METADATA)) {
     return false;
   }
   const iree_hal_command_category_t supported_categories =

--- a/runtime/src/iree/hal/drivers/amdgpu/pm4_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/amdgpu/pm4_command_buffer.c
@@ -1938,14 +1938,12 @@ static iree_status_t iree_hal_amdgpu_pm4_command_buffer_verify_create(
         IREE_STATUS_UNIMPLEMENTED,
         "PM4 command buffers require reusable command-buffer mode");
   }
-  const iree_hal_command_buffer_mode_t unsupported_modes =
-      IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION |
-      IREE_HAL_COMMAND_BUFFER_MODE_RETAIN_DISPATCH_METADATA;
-  if (iree_any_bit_set(mode, unsupported_modes)) {
-    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                            "PM4 command-buffer mode bits 0x%08" PRIx32
-                            " are not implemented",
-                            mode & unsupported_modes);
+  if (iree_any_bit_set(mode,
+                       IREE_HAL_COMMAND_BUFFER_MODE_RETAIN_DISPATCH_METADATA)) {
+    return iree_make_status(
+        IREE_STATUS_UNIMPLEMENTED,
+        "PM4 command-buffer mode bits 0x%08" PRIx32 " are not implemented",
+        mode & IREE_HAL_COMMAND_BUFFER_MODE_RETAIN_DISPATCH_METADATA);
   }
   const iree_hal_command_category_t supported_categories =
       IREE_HAL_COMMAND_CATEGORY_DISPATCH | IREE_HAL_COMMAND_CATEGORY_ATOMIC |

--- a/runtime/src/iree/hal/drivers/local_task/block_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/local_task/block_command_buffer.c
@@ -509,12 +509,6 @@ iree_status_t iree_hal_block_command_buffer_create(
   IREE_ASSERT_ARGUMENT(out_command_buffer);
   *out_command_buffer = NULL;
 
-  if (iree_any_bit_set(mode,
-                       IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION) &&
-      !iree_all_bits_set(mode, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT)) {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "ALLOW_INLINE_EXECUTION requires ONE_SHOT mode");
-  }
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_host_size_t total_size = 0;

--- a/runtime/src/iree/tooling/function_util.c
+++ b/runtime/src/iree/tooling/function_util.c
@@ -191,9 +191,7 @@ iree_status_t iree_tooling_transfer_variants(
   iree_hal_command_buffer_t* command_buffer = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_command_buffer_create(
-              target_device,
-              IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT |
-                  IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION,
+              target_device, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
               IREE_HAL_COMMAND_CATEGORY_TRANSFER, target_params.queue_affinity,
               /*binding_capacity=*/0, &command_buffer));
 


### PR DESCRIPTION
Command buffers can no longer execute while they are still being recorded.

The removed mode let a backend begin arbitrary command-buffer work before submission while requiring callers to treat completion as asynchronous. Making that unknowable implementation choice legal also prohibited indirect bindings and submission waits, so an otherwise valid command stream could become invalid based on a backend behavior the caller could neither request reliably nor observe.

Local-sync owned the last implementation and has been deleted. Retained drivers either ignored the mode, validated its one-shot requirement without acting on it, or rejected it. This removes the mode, its cross-backend submission restrictions, and the remaining tooling and Loom callers. Synchronous transfers now record ordinary one-shot command buffers without querying a semaphore solely to select a dead execution path.

The separate direct-dispatch inline hint remains because local-task implements it as an explicit queue operation rather than hidden command-buffer behavior.
