### PR TITLE
[HAL] Split task and Vulkan transient buffers

### DIFF
--- a/runtime/src/iree/hal/drivers/local_task/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/local_task/BUILD.bazel
@@ -17,6 +17,19 @@ package(
 )
 
 iree_runtime_cc_library(
+    name = "transient_buffer",
+    srcs = ["transient_buffer.c"],
+    hdrs = ["transient_buffer.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//runtime/src/iree/async",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/threading",
+        "//runtime/src/iree/hal",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "block_builder",
     srcs = [
         "block_builder.c",
@@ -59,6 +72,7 @@ iree_runtime_cc_library(
         ":block_builder",
         ":block_command_ops",
         ":block_isa",
+        ":transient_buffer",
         "//runtime/src/iree/async",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base/internal:arena",
@@ -66,7 +80,6 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/local:atomic",
         "//runtime/src/iree/hal/local:executable_library",
         "//runtime/src/iree/hal/local:executable_loader",
-        "//runtime/src/iree/hal/local:transient_buffer",
         "//runtime/src/iree/hal/utils:resource_set",
     ],
 )
@@ -173,6 +186,7 @@ iree_runtime_cc_library(
         ":block_command_buffer",
         ":block_command_ops",
         ":block_processor",
+        ":transient_buffer",
         "//runtime/src/iree/async",
         "//runtime/src/iree/async/util:proactor_pool",
         "//runtime/src/iree/base",
@@ -189,7 +203,6 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/local:executable_library",
         "//runtime/src/iree/hal/local:executable_loader",
         "//runtime/src/iree/hal/local:profile",
-        "//runtime/src/iree/hal/local:transient_buffer",
         "//runtime/src/iree/hal/memory:cpu_slab_provider",
         "//runtime/src/iree/hal/memory:passthrough_pool",
         "//runtime/src/iree/hal/memory:tlsf_pool",

--- a/runtime/src/iree/hal/drivers/local_task/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_task/CMakeLists.txt
@@ -11,6 +11,21 @@ iree_add_all_subdirs()
 
 iree_cc_library(
   NAME
+    transient_buffer
+  HDRS
+    "transient_buffer.h"
+  SRCS
+    "transient_buffer.c"
+  DEPS
+    iree::async
+    iree::base
+    iree::base::threading
+    iree::hal
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     block_builder
   HDRS
     "block_builder.h"
@@ -49,6 +64,7 @@ iree_cc_library(
     ::block_builder
     ::block_command_ops
     ::block_isa
+    ::transient_buffer
     iree::async
     iree::base
     iree::base::internal::arena
@@ -56,7 +72,6 @@ iree_cc_library(
     iree::hal::local::atomic
     iree::hal::local::executable_library
     iree::hal::local::executable_loader
-    iree::hal::local::transient_buffer
     iree::hal::utils::resource_set
   PUBLIC
 )
@@ -158,6 +173,7 @@ iree_cc_library(
     ::block_command_buffer
     ::block_command_ops
     ::block_processor
+    ::transient_buffer
     iree::async
     iree::async::util::proactor_pool
     iree::base
@@ -174,7 +190,6 @@ iree_cc_library(
     iree::hal::local::executable_library
     iree::hal::local::executable_loader
     iree::hal::local::profile
-    iree::hal::local::transient_buffer
     iree::hal::memory::cpu_slab_provider
     iree::hal::memory::passthrough_pool
     iree::hal::memory::tlsf_pool

--- a/runtime/src/iree/hal/drivers/local_task/block_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/local_task/block_command_buffer.c
@@ -15,10 +15,10 @@
 #include "iree/hal/drivers/local_task/block_builder.h"
 #include "iree/hal/drivers/local_task/block_command_ops.h"
 #include "iree/hal/drivers/local_task/block_isa.h"
+#include "iree/hal/drivers/local_task/transient_buffer.h"
 #include "iree/hal/local/atomic.h"
 #include "iree/hal/local/executable_library.h"
 #include "iree/hal/local/local_executable.h"
-#include "iree/hal/local/transient_buffer.h"
 #include "iree/hal/utils/resource_set.h"
 
 //===----------------------------------------------------------------------===//
@@ -374,7 +374,7 @@ static void iree_hal_block_command_buffer_profile_append_dispatch(
 // if the backing is already committed while the command buffer records.
 static bool iree_hal_block_command_buffer_needs_late_binding(
     iree_hal_buffer_t* buffer) {
-  return iree_hal_local_transient_buffer_isa(buffer);
+  return iree_hal_task_transient_buffer_isa(buffer);
 }
 
 // Finds or appends a late direct binding for a transient buffer. Late slots are

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -19,11 +19,11 @@
 #include "iree/hal/drivers/local_task/block_command_buffer.h"
 #include "iree/hal/drivers/local_task/task_queue.h"
 #include "iree/hal/drivers/local_task/task_semaphore.h"
+#include "iree/hal/drivers/local_task/transient_buffer.h"
 #include "iree/hal/local/atomic.h"
 #include "iree/hal/local/device_spec_builder.h"
 #include "iree/hal/local/executable_environment.h"
 #include "iree/hal/local/profile.h"
-#include "iree/hal/local/transient_buffer.h"
 #include "iree/hal/memory/cpu_slab_provider.h"
 #include "iree/hal/memory/passthrough_pool.h"
 #include "iree/hal/memory/tlsf_pool.h"
@@ -744,7 +744,7 @@ static iree_status_t iree_hal_task_device_prepare_alloca_wrapper(
     placement.flags |= IREE_HAL_BUFFER_PLACEMENT_FLAG_INDETERMINATE_LIFETIME;
   }
 
-  IREE_RETURN_IF_ERROR(iree_hal_local_transient_buffer_create(
+  IREE_RETURN_IF_ERROR(iree_hal_task_transient_buffer_create(
       placement, *params, allocation_size, allocation_size,
       iree_hal_allocator_host_allocator(iree_hal_device_allocator(base_device)),
       out_buffer));
@@ -840,7 +840,7 @@ static iree_status_t iree_hal_task_device_queue_dealloca(
   const iree_hal_buffer_placement_t placement =
       iree_hal_buffer_allocation_placement(buffer);
   if (placement.device == base_device &&
-      iree_hal_local_transient_buffer_isa(buffer)) {
+      iree_hal_task_transient_buffer_isa(buffer)) {
     // Native dealloca: decommit the transient buffer in the queue drain handler
     // after all wait semaphores have been satisfied and before signaling
     // dealloca completion.

--- a/runtime/src/iree/hal/drivers/local_task/task_queue.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_queue.c
@@ -23,9 +23,9 @@
 #include "iree/hal/drivers/local_task/block_command_buffer.h"
 #include "iree/hal/drivers/local_task/block_command_ops.h"
 #include "iree/hal/drivers/local_task/block_processor.h"
+#include "iree/hal/drivers/local_task/transient_buffer.h"
 #include "iree/hal/local/atomic.h"
 #include "iree/hal/local/local_executable.h"
-#include "iree/hal/local/transient_buffer.h"
 #include "iree/hal/utils/resource_set.h"
 
 #if !defined(NDEBUG)
@@ -339,7 +339,7 @@ static void iree_hal_task_queue_profile_set_transient_buffer(
       iree_hal_task_queue_profile_operation(operation);
   if (!profile_operation) return;
   profile_operation->allocation_id =
-      iree_hal_local_transient_buffer_profile_id(transient_buffer);
+      iree_hal_task_transient_buffer_profile_id(transient_buffer);
   profile_operation->payload_length =
       iree_hal_buffer_byte_length(transient_buffer);
 }
@@ -1750,7 +1750,7 @@ static iree_status_t iree_hal_task_queue_drain_alloca_submit_reservation(
     const iree_async_frontier_t* reservation_failure_frontier) {
   iree_hal_task_queue_profile_record_queue_event(operation, iree_time_now());
   iree_hal_task_queue_profile_start_host_execution(operation);
-  iree_hal_local_transient_buffer_attach_reservation(
+  iree_hal_task_transient_buffer_attach_reservation(
       operation->alloca.transient_buffer, operation->alloca.pool, reservation);
 
   iree_hal_buffer_t* backing_buffer = NULL;
@@ -1758,7 +1758,7 @@ static iree_status_t iree_hal_task_queue_drain_alloca_submit_reservation(
       operation->alloca.pool, operation->alloca.params, reservation,
       IREE_HAL_POOL_MATERIALIZE_FLAG_NONE, &backing_buffer);
   if (iree_status_is_ok(status)) {
-    iree_hal_local_transient_buffer_stage_backing(
+    iree_hal_task_transient_buffer_stage_backing(
         operation->alloca.transient_buffer, backing_buffer);
     iree_hal_task_queue_profile_record_memory_event(
         operation, IREE_HAL_PROFILE_MEMORY_EVENT_TYPE_POOL_MATERIALIZE,
@@ -1770,7 +1770,7 @@ static iree_status_t iree_hal_task_queue_drain_alloca_submit_reservation(
   iree_hal_buffer_release(backing_buffer);
 
   if (iree_status_is_ok(status)) {
-    iree_hal_local_transient_buffer_commit(operation->alloca.transient_buffer);
+    iree_hal_task_transient_buffer_commit(operation->alloca.transient_buffer);
     iree_hal_task_queue_profile_record_memory_event(
         operation, IREE_HAL_PROFILE_MEMORY_EVENT_TYPE_QUEUE_ALLOCA,
         IREE_HAL_PROFILE_MEMORY_EVENT_FLAG_QUEUE_OPERATION, acquire_result,
@@ -1779,7 +1779,7 @@ static iree_status_t iree_hal_task_queue_drain_alloca_submit_reservation(
                                      : 0);
     iree_hal_task_queue_op_complete(operation);
   } else {
-    iree_hal_local_transient_buffer_release_reservation(
+    iree_hal_task_transient_buffer_release_reservation(
         operation->alloca.transient_buffer, reservation_failure_frontier);
     iree_hal_task_queue_profile_record_memory_event(
         operation, IREE_HAL_PROFILE_MEMORY_EVENT_TYPE_POOL_RELEASE,
@@ -1944,9 +1944,8 @@ static void iree_hal_task_queue_drain_dealloca(
     iree_hal_task_queue_op_t* operation) {
   iree_hal_pool_t* pool = NULL;
   iree_hal_pool_reservation_t reservation;
-  const bool has_reservation =
-      iree_hal_local_transient_buffer_query_reservation(
-          operation->dealloca.transient_buffer, &pool, &reservation);
+  const bool has_reservation = iree_hal_task_transient_buffer_query_reservation(
+      operation->dealloca.transient_buffer, &pool, &reservation);
   const iree_hal_buffer_params_t params = {
       .type = iree_hal_buffer_memory_type(operation->dealloca.transient_buffer),
       .access =
@@ -1955,15 +1954,14 @@ static void iree_hal_task_queue_drain_dealloca(
           iree_hal_buffer_allowed_usage(operation->dealloca.transient_buffer),
   };
 
-  iree_hal_local_transient_buffer_decommit(
-      operation->dealloca.transient_buffer);
+  iree_hal_task_transient_buffer_decommit(operation->dealloca.transient_buffer);
 
   const uint64_t epoch =
       iree_hal_task_queue_op_reserve_completion_epoch(operation);
   iree_async_single_frontier_t death_frontier;
   iree_async_single_frontier_initialize(&death_frontier, operation->axis,
                                         epoch);
-  iree_hal_local_transient_buffer_release_reservation(
+  iree_hal_task_transient_buffer_release_reservation(
       operation->dealloca.transient_buffer,
       iree_async_single_frontier_as_const_frontier(&death_frontier));
   iree_hal_task_queue_profile_record_memory_event(

--- a/runtime/src/iree/hal/drivers/local_task/transient_buffer.c
+++ b/runtime/src/iree/hal/drivers/local_task/transient_buffer.c
@@ -1,0 +1,319 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/drivers/local_task/transient_buffer.h"
+
+#include "iree/base/threading/mutex.h"
+
+static iree_atomic_int64_t iree_hal_task_transient_buffer_next_profile_id =
+    IREE_ATOMIC_VAR_INIT(1);
+
+// Vtable dispatch for forwarding to the committed buffer's implementation.
+// Equivalent to IREE_HAL_VTABLE_DISPATCH from detail.h but accessible from
+// this driver-private implementation (detail.h is module-private to HAL core).
+static inline const iree_hal_buffer_vtable_t*
+iree_hal_task_transient_buffer_committed_vtable(iree_hal_buffer_t* buffer) {
+  return (const iree_hal_buffer_vtable_t*)((const iree_hal_resource_t*)buffer)
+      ->vtable;
+}
+
+struct iree_hal_task_transient_buffer_t {
+  // Base HAL buffer resource exposed to callers.
+  iree_hal_buffer_t base;
+
+  // Host allocator used for wrapper storage and teardown.
+  iree_allocator_t host_allocator;
+
+  // Stable nonzero id used to join profile rows for this wrapper lifetime.
+  uint64_t profile_id;
+
+  // Guards all staged backing, committed backing, and reservation state.
+  iree_slim_mutex_t mutex;
+
+  // Materialized backing buffer staged for a future commit. Retained by the
+  // wrapper while non-NULL.
+  iree_hal_buffer_t* staged_backing;
+
+  // Materialized backing buffer visible to accessors after commit.
+  iree_hal_buffer_t* committed_backing;
+
+  // Borrowed pool that owns |reservation| when armed.
+  iree_hal_pool_t* reservation_pool;
+
+  // Optional queue-allocation reservation owned by this wrapper while armed.
+  iree_hal_pool_reservation_t reservation;
+
+  // Nonzero while the wrapper still owns |reservation|.
+  int32_t reservation_armed;
+};
+
+static const iree_hal_buffer_vtable_t iree_hal_task_transient_buffer_vtable;
+
+static iree_hal_task_transient_buffer_t* iree_hal_task_transient_buffer_cast(
+    iree_hal_buffer_t* buffer) {
+  return (iree_hal_task_transient_buffer_t*)buffer;
+}
+
+static iree_status_t iree_hal_task_transient_buffer_retain_host_backing(
+    iree_hal_task_transient_buffer_t* buffer,
+    iree_hal_buffer_t** out_backing_buffer) {
+  *out_backing_buffer = NULL;
+  iree_slim_mutex_lock(&buffer->mutex);
+  iree_hal_buffer_t* backing_buffer = buffer->committed_backing;
+  if (IREE_UNLIKELY(!backing_buffer)) {
+    iree_slim_mutex_unlock(&buffer->mutex);
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "transient buffer has not been committed; ensure the alloca signal "
+        "semaphores are satisfied before accessing it");
+  }
+  iree_hal_buffer_retain(backing_buffer);
+  iree_slim_mutex_unlock(&buffer->mutex);
+  *out_backing_buffer = backing_buffer;
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_task_transient_buffer_create(
+    iree_hal_buffer_placement_t placement, iree_hal_buffer_params_t params,
+    iree_device_size_t allocation_size, iree_device_size_t byte_length,
+    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer) {
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  *out_buffer = NULL;
+  if (IREE_UNLIKELY(byte_length > allocation_size)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "transient buffer byte length (%" PRIu64
+                            ") exceeds allocation size (%" PRIu64 ")",
+                            (uint64_t)byte_length, (uint64_t)allocation_size);
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_task_transient_buffer_t* buffer = NULL;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_allocator_malloc(host_allocator, sizeof(*buffer), (void**)&buffer));
+
+  iree_hal_buffer_initialize(
+      placement, /*allocated_buffer=*/&buffer->base, allocation_size,
+      /*byte_offset=*/0, byte_length, params.type, params.access, params.usage,
+      &iree_hal_task_transient_buffer_vtable, &buffer->base);
+  buffer->host_allocator = host_allocator;
+  buffer->profile_id = (uint64_t)iree_atomic_fetch_add(
+      &iree_hal_task_transient_buffer_next_profile_id, 1,
+      iree_memory_order_relaxed);
+  iree_slim_mutex_initialize(&buffer->mutex);
+  buffer->staged_backing = NULL;
+  buffer->committed_backing = NULL;
+  buffer->reservation_pool = NULL;
+  memset(&buffer->reservation, 0, sizeof(buffer->reservation));
+  buffer->reservation_armed = 0;
+
+  *out_buffer = &buffer->base;
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+bool iree_hal_task_transient_buffer_isa(const iree_hal_buffer_t* buffer) {
+  return iree_hal_resource_is(&buffer->resource,
+                              &iree_hal_task_transient_buffer_vtable);
+}
+
+uint64_t iree_hal_task_transient_buffer_profile_id(
+    iree_hal_buffer_t* base_buffer) {
+  iree_hal_task_transient_buffer_t* buffer =
+      iree_hal_task_transient_buffer_cast(base_buffer);
+  return buffer->profile_id;
+}
+
+void iree_hal_task_transient_buffer_attach_reservation(
+    iree_hal_buffer_t* base_buffer, iree_hal_pool_t* pool,
+    const iree_hal_pool_reservation_t* reservation) {
+  iree_hal_task_transient_buffer_t* buffer =
+      iree_hal_task_transient_buffer_cast(base_buffer);
+  IREE_ASSERT_ARGUMENT(pool);
+  IREE_ASSERT_ARGUMENT(reservation);
+  iree_slim_mutex_lock(&buffer->mutex);
+  IREE_ASSERT_TRUE(buffer->reservation_pool == NULL);
+  IREE_ASSERT_TRUE(buffer->reservation_armed == 0);
+  buffer->reservation_pool = pool;
+  buffer->reservation = *reservation;
+  buffer->reservation_armed = 1;
+  iree_slim_mutex_unlock(&buffer->mutex);
+}
+
+void iree_hal_task_transient_buffer_stage_backing(
+    iree_hal_buffer_t* base_buffer, iree_hal_buffer_t* backing) {
+  iree_hal_task_transient_buffer_t* buffer =
+      iree_hal_task_transient_buffer_cast(base_buffer);
+  IREE_ASSERT_ARGUMENT(backing);
+  iree_slim_mutex_lock(&buffer->mutex);
+  IREE_ASSERT_TRUE(buffer->staged_backing == NULL);
+  IREE_ASSERT_TRUE(buffer->committed_backing == NULL);
+  iree_hal_buffer_retain(backing);
+  buffer->staged_backing = backing;
+  iree_slim_mutex_unlock(&buffer->mutex);
+}
+
+void iree_hal_task_transient_buffer_commit(iree_hal_buffer_t* base_buffer) {
+  iree_hal_task_transient_buffer_t* buffer =
+      iree_hal_task_transient_buffer_cast(base_buffer);
+  iree_slim_mutex_lock(&buffer->mutex);
+  IREE_ASSERT_TRUE(buffer->staged_backing != NULL);
+  IREE_ASSERT_TRUE(buffer->committed_backing == NULL);
+  buffer->committed_backing = buffer->staged_backing;
+  iree_slim_mutex_unlock(&buffer->mutex);
+}
+
+void iree_hal_task_transient_buffer_decommit(iree_hal_buffer_t* base_buffer) {
+  iree_hal_task_transient_buffer_t* buffer =
+      iree_hal_task_transient_buffer_cast(base_buffer);
+  iree_slim_mutex_lock(&buffer->mutex);
+  iree_hal_buffer_t* staged_backing = buffer->staged_backing;
+  buffer->staged_backing = NULL;
+  buffer->committed_backing = NULL;
+  iree_slim_mutex_unlock(&buffer->mutex);
+  iree_hal_buffer_release(staged_backing);
+}
+
+bool iree_hal_task_transient_buffer_query_reservation(
+    iree_hal_buffer_t* base_buffer, iree_hal_pool_t** out_pool,
+    iree_hal_pool_reservation_t* out_reservation) {
+  iree_hal_task_transient_buffer_t* buffer =
+      iree_hal_task_transient_buffer_cast(base_buffer);
+  iree_slim_mutex_lock(&buffer->mutex);
+  const bool has_reservation =
+      buffer->reservation_pool != NULL && buffer->reservation_armed;
+  if (has_reservation) {
+    if (out_pool) *out_pool = buffer->reservation_pool;
+    if (out_reservation) *out_reservation = buffer->reservation;
+  }
+  iree_slim_mutex_unlock(&buffer->mutex);
+  return has_reservation;
+}
+
+void iree_hal_task_transient_buffer_release_reservation(
+    iree_hal_buffer_t* base_buffer,
+    const iree_async_frontier_t* death_frontier) {
+  iree_hal_task_transient_buffer_t* buffer =
+      iree_hal_task_transient_buffer_cast(base_buffer);
+  iree_hal_pool_t* pool = NULL;
+  iree_hal_pool_reservation_t reservation;
+  iree_slim_mutex_lock(&buffer->mutex);
+  const int32_t was_armed = buffer->reservation_armed;
+  if (was_armed) {
+    pool = buffer->reservation_pool;
+    reservation = buffer->reservation;
+    buffer->reservation_armed = 0;
+  }
+  iree_slim_mutex_unlock(&buffer->mutex);
+  if (was_armed) {
+    iree_hal_pool_release_reservation(pool, &reservation, death_frontier);
+    iree_slim_mutex_lock(&buffer->mutex);
+    buffer->reservation_pool = NULL;
+    memset(&buffer->reservation, 0, sizeof(buffer->reservation));
+    iree_slim_mutex_unlock(&buffer->mutex);
+  }
+}
+
+static void iree_hal_task_transient_buffer_destroy(
+    iree_hal_buffer_t* base_buffer) {
+  iree_hal_task_transient_buffer_t* buffer =
+      iree_hal_task_transient_buffer_cast(base_buffer);
+  iree_allocator_t host_allocator = buffer->host_allocator;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_task_transient_buffer_decommit(base_buffer);
+  iree_hal_task_transient_buffer_release_reservation(base_buffer,
+                                                     /*death_frontier=*/NULL);
+
+  iree_slim_mutex_deinitialize(&buffer->mutex);
+  iree_allocator_free(host_allocator, buffer);
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static iree_status_t iree_hal_task_transient_buffer_map_range(
+    iree_hal_buffer_t* base_buffer, iree_hal_mapping_mode_t mapping_mode,
+    iree_hal_memory_access_t memory_access,
+    iree_device_size_t local_byte_offset, iree_device_size_t local_byte_length,
+    iree_hal_buffer_mapping_t* mapping) {
+  iree_hal_task_transient_buffer_t* buffer =
+      iree_hal_task_transient_buffer_cast(base_buffer);
+  iree_hal_buffer_t* committed = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_task_transient_buffer_retain_host_backing(buffer, &committed));
+  iree_status_t status =
+      iree_hal_task_transient_buffer_committed_vtable(committed)->map_range(
+          committed, mapping_mode, memory_access, local_byte_offset,
+          local_byte_length, mapping);
+  if (iree_status_is_ok(status)) {
+    if (mapping->impl.is_persistent) {
+      iree_hal_buffer_release(committed);
+    } else {
+      iree_hal_buffer_t* mapped_buffer = mapping->buffer;
+      // Scoped maps own their mapped storage until unmap. Transfer that mapping
+      // ownership from the transient wrapper to the committed backing buffer so
+      // a queue-ordered decommit cannot invalidate the unmap path.
+      mapping->buffer = committed;
+      iree_hal_buffer_release(mapped_buffer);
+    }
+  } else {
+    iree_hal_buffer_release(committed);
+  }
+  return status;
+}
+
+static iree_status_t iree_hal_task_transient_buffer_unmap_range(
+    iree_hal_buffer_t* base_buffer, iree_device_size_t local_byte_offset,
+    iree_device_size_t local_byte_length, iree_hal_buffer_mapping_t* mapping) {
+  iree_hal_task_transient_buffer_t* buffer =
+      iree_hal_task_transient_buffer_cast(base_buffer);
+  iree_hal_buffer_t* committed = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_task_transient_buffer_retain_host_backing(buffer, &committed));
+  iree_status_t status =
+      iree_hal_task_transient_buffer_committed_vtable(committed)->unmap_range(
+          committed, local_byte_offset, local_byte_length, mapping);
+  iree_hal_buffer_release(committed);
+  return status;
+}
+
+static iree_status_t iree_hal_task_transient_buffer_invalidate_range(
+    iree_hal_buffer_t* base_buffer, iree_device_size_t local_byte_offset,
+    iree_device_size_t local_byte_length) {
+  iree_hal_task_transient_buffer_t* buffer =
+      iree_hal_task_transient_buffer_cast(base_buffer);
+  iree_hal_buffer_t* committed = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_task_transient_buffer_retain_host_backing(buffer, &committed));
+  iree_status_t status =
+      iree_hal_task_transient_buffer_committed_vtable(committed)
+          ->invalidate_range(committed, local_byte_offset, local_byte_length);
+  iree_hal_buffer_release(committed);
+  return status;
+}
+
+static iree_status_t iree_hal_task_transient_buffer_flush_range(
+    iree_hal_buffer_t* base_buffer, iree_device_size_t local_byte_offset,
+    iree_device_size_t local_byte_length) {
+  iree_hal_task_transient_buffer_t* buffer =
+      iree_hal_task_transient_buffer_cast(base_buffer);
+  iree_hal_buffer_t* committed = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_task_transient_buffer_retain_host_backing(buffer, &committed));
+  iree_status_t status =
+      iree_hal_task_transient_buffer_committed_vtable(committed)->flush_range(
+          committed, local_byte_offset, local_byte_length);
+  iree_hal_buffer_release(committed);
+  return status;
+}
+
+static const iree_hal_buffer_vtable_t iree_hal_task_transient_buffer_vtable = {
+    .recycle = iree_hal_buffer_recycle,
+    .destroy = iree_hal_task_transient_buffer_destroy,
+    .map_range = iree_hal_task_transient_buffer_map_range,
+    .unmap_range = iree_hal_task_transient_buffer_unmap_range,
+    .invalidate_range = iree_hal_task_transient_buffer_invalidate_range,
+    .flush_range = iree_hal_task_transient_buffer_flush_range,
+};

--- a/runtime/src/iree/hal/drivers/local_task/transient_buffer.h
+++ b/runtime/src/iree/hal/drivers/local_task/transient_buffer.h
@@ -1,0 +1,101 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Transient buffer: a reservation handle for queue-ordered local-task
+// allocations.
+//
+// Queue allocators can return a transient buffer to the caller before the
+// physical backing is ready, then commit a real backing buffer once queue
+// ordering allows it. queue_dealloca can later decommit the wrapper while the
+// transient buffer object itself remains live so stale host references fail
+// cleanly with IREE_STATUS_FAILED_PRECONDITION instead of accessing freed
+// storage.
+
+#ifndef IREE_HAL_DRIVERS_LOCAL_TASK_TRANSIENT_BUFFER_H_
+#define IREE_HAL_DRIVERS_LOCAL_TASK_TRANSIENT_BUFFER_H_
+
+#include "iree/async/frontier.h"
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef struct iree_hal_task_transient_buffer_t
+    iree_hal_task_transient_buffer_t;
+
+// Creates a transient buffer with the given metadata but no backing memory.
+// The buffer starts in the uncommitted state.
+//
+// |allocation_size| is the physical reservation size to report through
+// iree_hal_buffer_allocation_size() and |byte_length| is the logical byte range
+// exposed by the wrapper. |byte_length| must be <= |allocation_size|.
+//
+// |placement| must include IREE_HAL_BUFFER_PLACEMENT_FLAG_ASYNCHRONOUS so the
+// HAL dealloca path routes through the owning driver's queue_dealloca vtable.
+iree_status_t iree_hal_task_transient_buffer_create(
+    iree_hal_buffer_placement_t placement, iree_hal_buffer_params_t params,
+    iree_device_size_t allocation_size, iree_device_size_t byte_length,
+    iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer);
+
+// Returns true if |buffer| is a local-task transient buffer wrapper.
+bool iree_hal_task_transient_buffer_isa(const iree_hal_buffer_t* buffer);
+
+// Returns the stable profiling id assigned to this transient buffer wrapper.
+//
+// The id is nonzero and unique across wrappers owned by this driver. Producers
+// use it as a session-local allocation id during an active profile capture.
+uint64_t iree_hal_task_transient_buffer_profile_id(iree_hal_buffer_t* buffer);
+
+// Attaches a pool reservation to the transient buffer. The wrapper keeps only
+// a borrowed pointer to |pool| and takes ownership of |reservation| until
+// iree_hal_task_transient_buffer_release_reservation() or wrapper destroy.
+void iree_hal_task_transient_buffer_attach_reservation(
+    iree_hal_buffer_t* buffer, iree_hal_pool_t* pool,
+    const iree_hal_pool_reservation_t* reservation);
+
+// Stages a materialized backing buffer view for a future commit. The backing
+// buffer is retained, but remains invisible to map/flush/invalidate calls until
+// iree_hal_task_transient_buffer_commit() publishes it.
+void iree_hal_task_transient_buffer_stage_backing(iree_hal_buffer_t* buffer,
+                                                  iree_hal_buffer_t* backing);
+
+// Publishes the staged backing buffer. Must be called exactly once while the
+// wrapper is uncommitted and has a staged backing view.
+void iree_hal_task_transient_buffer_commit(iree_hal_buffer_t* buffer);
+
+// Decommits the backing buffer and returns the wrapper to the uncommitted
+// state. Any staged-but-uncommitted backing view is also released. Queue
+// implementations use this in the dealloca wait-satisfied/signal-before window
+// so target-visible release effects occur before user-visible completion. Safe
+// to call on an already-uncommitted wrapper.
+void iree_hal_task_transient_buffer_decommit(iree_hal_buffer_t* buffer);
+
+// Returns the attached pool reservation without transferring ownership.
+//
+// This is a cold diagnostic/profiling helper. Returns false when the wrapper
+// has no live reservation or the reservation has already been released.
+bool iree_hal_task_transient_buffer_query_reservation(
+    iree_hal_buffer_t* buffer, iree_hal_pool_t** out_pool,
+    iree_hal_pool_reservation_t* out_reservation);
+
+// Releases the attached reservation exactly once. If the wrapper has no
+// reservation or the reservation was already released, this is a no-op.
+//
+// |death_frontier| is forwarded to iree_hal_pool_release_reservation() when
+// the reservation is still owned. Pass NULL for an immediately reusable
+// reservation in synchronous/drain-ordered paths. This updates pool reuse
+// metadata; target-visible release effects are performed by the queue before
+// publishing dealloca completion.
+void iree_hal_task_transient_buffer_release_reservation(
+    iree_hal_buffer_t* buffer, const iree_async_frontier_t* death_frontier);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_LOCAL_TASK_TRANSIENT_BUFFER_H_

--- a/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/vulkan/BUILD.bazel
@@ -191,6 +191,19 @@ iree_runtime_cc_test(
 )
 
 iree_runtime_cc_library(
+    name = "transient_buffer",
+    srcs = ["transient_buffer.c"],
+    hdrs = ["transient_buffer.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//runtime/src/iree/async",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/threading",
+        "//runtime/src/iree/hal",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "vulkan",
     srcs = [
         "allocator.c",
@@ -238,6 +251,7 @@ iree_runtime_cc_library(
     deps = [
         ":api",
         ":device_spec_builder",
+        ":transient_buffer",
         "//runtime/src/iree/async",
         "//runtime/src/iree/async/util:proactor_pool",
         "//runtime/src/iree/base",
@@ -250,7 +264,6 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/drivers/vulkan/device:library",
         "//runtime/src/iree/hal/drivers/vulkan/util:libvulkan",
         "//runtime/src/iree/hal/local:profile",
-        "//runtime/src/iree/hal/local:transient_buffer",
         "//runtime/src/iree/hal/memory:passthrough_pool",
         "//runtime/src/iree/hal/memory:slab_provider",
         "//runtime/src/iree/hal/memory:tlsf_pool",

--- a/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
@@ -246,6 +246,23 @@ endif()
 if(IREE_HAL_DRIVER_VULKAN)
 iree_cc_library(
   NAME
+    transient_buffer
+  HDRS
+    "transient_buffer.h"
+  SRCS
+    "transient_buffer.c"
+  DEPS
+    iree::async
+    iree::base
+    iree::base::threading
+    iree::hal
+  PUBLIC
+)
+endif()
+
+if(IREE_HAL_DRIVER_VULKAN)
+iree_cc_library(
+  NAME
     vulkan
   SRCS
     "allocator.c"
@@ -292,6 +309,7 @@ iree_cc_library(
   DEPS
     ::api
     ::device_spec_builder
+    ::transient_buffer
     iree::async
     iree::async::util::proactor_pool
     iree::base
@@ -304,7 +322,6 @@ iree_cc_library(
     iree::hal::drivers::vulkan::device::library
     iree::hal::drivers::vulkan::util::libvulkan
     iree::hal::local::profile
-    iree::hal::local::transient_buffer
     iree::hal::memory::passthrough_pool
     iree::hal::memory::slab_provider
     iree::hal::memory::tlsf_pool

--- a/runtime/src/iree/hal/drivers/vulkan/buffer.c
+++ b/runtime/src/iree/hal/drivers/vulkan/buffer.c
@@ -10,7 +10,7 @@
 
 #include "iree/base/threading/mutex.h"
 #include "iree/hal/drivers/vulkan/sparse_buffer.h"
-#include "iree/hal/local/transient_buffer.h"
+#include "iree/hal/drivers/vulkan/transient_buffer.h"
 
 //===----------------------------------------------------------------------===//
 // iree_hal_vulkan_buffer_t
@@ -293,9 +293,9 @@ iree_status_t iree_hal_vulkan_buffer_resolve_backing(
   *out_backing_buffer = NULL;
   iree_hal_buffer_t* allocated_buffer =
       iree_hal_buffer_allocated_buffer(buffer);
-  if (iree_hal_local_transient_buffer_isa(allocated_buffer)) {
+  if (iree_hal_vulkan_transient_buffer_isa(allocated_buffer)) {
     iree_hal_buffer_t* backing_buffer =
-        iree_hal_local_transient_buffer_backing_buffer(allocated_buffer);
+        iree_hal_vulkan_transient_buffer_backing_buffer(allocated_buffer);
     if (!backing_buffer) {
       return iree_make_status(
           IREE_STATUS_FAILED_PRECONDITION,

--- a/runtime/src/iree/hal/drivers/vulkan/queue.c
+++ b/runtime/src/iree/hal/drivers/vulkan/queue.c
@@ -18,7 +18,7 @@
 #include "iree/hal/drivers/vulkan/command_buffer.h"
 #include "iree/hal/drivers/vulkan/executable.h"
 #include "iree/hal/drivers/vulkan/sparse_buffer.h"
-#include "iree/hal/local/transient_buffer.h"
+#include "iree/hal/drivers/vulkan/transient_buffer.h"
 #include "iree/hal/utils/memory_file.h"
 
 #define IREE_HAL_VULKAN_QUEUE_DESCRIPTOR_SLOT_ABSENT UINT32_MAX
@@ -3093,10 +3093,10 @@ static uint64_t iree_hal_vulkan_queue_profile_allocation_id(
     const iree_hal_vulkan_queue_pending_submission_t* submission) {
   switch (submission->kind) {
     case IREE_HAL_VULKAN_QUEUE_SUBMISSION_KIND_ALLOCA:
-      return iree_hal_local_transient_buffer_profile_id(
+      return iree_hal_vulkan_transient_buffer_profile_id(
           submission->alloca.buffer);
     case IREE_HAL_VULKAN_QUEUE_SUBMISSION_KIND_DEALLOCA:
-      return iree_hal_local_transient_buffer_profile_id(
+      return iree_hal_vulkan_transient_buffer_profile_id(
           submission->dealloca.buffer);
     default:
       return 0;
@@ -3921,17 +3921,17 @@ static void iree_hal_vulkan_queue_execute_host_call(
 
 static bool iree_hal_vulkan_queue_buffer_has_recordable_backing(
     iree_hal_buffer_t* buffer) {
-  return !iree_hal_local_transient_buffer_isa(buffer) ||
-         iree_hal_local_transient_buffer_backing_buffer(buffer) != NULL;
+  return !iree_hal_vulkan_transient_buffer_isa(buffer) ||
+         iree_hal_vulkan_transient_buffer_backing_buffer(buffer) != NULL;
 }
 
 static iree_status_t iree_hal_vulkan_queue_validate_recordable_backing(
     iree_hal_buffer_t* buffer, iree_string_view_t usage) {
-  if (!iree_hal_local_transient_buffer_isa(buffer)) return iree_ok_status();
-  if (iree_hal_local_transient_buffer_backing_buffer(buffer)) {
+  if (!iree_hal_vulkan_transient_buffer_isa(buffer)) return iree_ok_status();
+  if (iree_hal_vulkan_transient_buffer_backing_buffer(buffer)) {
     return iree_ok_status();
   }
-  if (iree_hal_local_transient_buffer_is_dealloca_queued(buffer)) {
+  if (iree_hal_vulkan_transient_buffer_is_dealloca_queued(buffer)) {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
         "Vulkan queue %.*s buffer has been queued for deallocation",
@@ -4321,11 +4321,11 @@ static void iree_hal_vulkan_queue_complete_alloca(
   const iree_async_frontier_t* frontier =
       iree_async_fixed_frontier_as_const_frontier(&submission->frontier);
   if (iree_status_is_ok(completion_status)) {
-    iree_hal_local_transient_buffer_commit(submission->alloca.buffer);
+    iree_hal_vulkan_transient_buffer_commit(submission->alloca.buffer);
     iree_hal_pool_t* pool = NULL;
     iree_hal_pool_reservation_t reservation;
     const bool has_reservation =
-        iree_hal_local_transient_buffer_query_reservation(
+        iree_hal_vulkan_transient_buffer_query_reservation(
             submission->alloca.buffer, &pool, &reservation);
     iree_hal_vulkan_queue_profile_record_memory_event(
         submission, IREE_HAL_PROFILE_MEMORY_EVENT_TYPE_QUEUE_ALLOCA,
@@ -4338,10 +4338,10 @@ static void iree_hal_vulkan_queue_complete_alloca(
     iree_hal_pool_t* pool = NULL;
     iree_hal_pool_reservation_t reservation;
     const bool has_reservation =
-        iree_hal_local_transient_buffer_query_reservation(
+        iree_hal_vulkan_transient_buffer_query_reservation(
             submission->alloca.buffer, &pool, &reservation);
-    iree_hal_local_transient_buffer_decommit(submission->alloca.buffer);
-    iree_hal_local_transient_buffer_release_reservation(
+    iree_hal_vulkan_transient_buffer_decommit(submission->alloca.buffer);
+    iree_hal_vulkan_transient_buffer_release_reservation(
         submission->alloca.buffer, submission->alloca.wait_frontier);
     iree_hal_vulkan_queue_profile_record_memory_event(
         submission, IREE_HAL_PROFILE_MEMORY_EVENT_TYPE_QUEUE_ALLOCA,
@@ -4380,7 +4380,7 @@ static void iree_hal_vulkan_queue_complete_dealloca(
     iree_hal_pool_t* pool = NULL;
     iree_hal_pool_reservation_t reservation;
     const bool has_reservation =
-        iree_hal_local_transient_buffer_query_reservation(
+        iree_hal_vulkan_transient_buffer_query_reservation(
             submission->dealloca.buffer, &pool, &reservation);
     const iree_hal_buffer_params_t params = {
         .type = iree_hal_buffer_memory_type(submission->dealloca.buffer),
@@ -4389,8 +4389,8 @@ static void iree_hal_vulkan_queue_complete_dealloca(
     };
     const iree_device_size_t allocation_size =
         iree_hal_buffer_allocation_size(submission->dealloca.buffer);
-    iree_hal_local_transient_buffer_decommit(submission->dealloca.buffer);
-    iree_hal_local_transient_buffer_release_reservation(
+    iree_hal_vulkan_transient_buffer_decommit(submission->dealloca.buffer);
+    iree_hal_vulkan_transient_buffer_release_reservation(
         submission->dealloca.buffer, frontier);
     iree_hal_vulkan_queue_profile_record_memory_event(
         submission, IREE_HAL_PROFILE_MEMORY_EVENT_TYPE_QUEUE_DEALLOCA,
@@ -4503,10 +4503,10 @@ static void iree_hal_vulkan_queue_fail_unsubmitted_submission(
       iree_hal_pool_t* alloca_pool = NULL;
       iree_hal_pool_reservation_t alloca_reservation;
       const bool alloca_has_reservation =
-          iree_hal_local_transient_buffer_query_reservation(
+          iree_hal_vulkan_transient_buffer_query_reservation(
               submission->alloca.buffer, &alloca_pool, &alloca_reservation);
-      iree_hal_local_transient_buffer_decommit(submission->alloca.buffer);
-      iree_hal_local_transient_buffer_release_reservation(
+      iree_hal_vulkan_transient_buffer_decommit(submission->alloca.buffer);
+      iree_hal_vulkan_transient_buffer_release_reservation(
           submission->alloca.buffer, submission->alloca.wait_frontier);
       iree_hal_vulkan_queue_profile_record_memory_event(
           submission, IREE_HAL_PROFILE_MEMORY_EVENT_TYPE_QUEUE_ALLOCA,
@@ -4535,7 +4535,7 @@ static void iree_hal_vulkan_queue_fail_unsubmitted_submission(
       break;
     }
     case IREE_HAL_VULKAN_QUEUE_SUBMISSION_KIND_DEALLOCA: {
-      iree_hal_local_transient_buffer_abort_dealloca(
+      iree_hal_vulkan_transient_buffer_abort_dealloca(
           submission->dealloca.buffer);
       const iree_hal_buffer_params_t dealloca_params = {
           .type = iree_hal_buffer_memory_type(submission->dealloca.buffer),
@@ -4666,7 +4666,7 @@ static void iree_hal_vulkan_queue_alloca_pool_notification_end_observe(
 
 static bool iree_hal_vulkan_queue_alloca_has_staged_backing(
     iree_hal_vulkan_queue_pending_submission_t* submission) {
-  return iree_hal_local_transient_buffer_backing_buffer(
+  return iree_hal_vulkan_transient_buffer_backing_buffer(
              submission->alloca.buffer) != NULL;
 }
 
@@ -4698,10 +4698,10 @@ static iree_status_t iree_hal_vulkan_queue_stage_alloca_reservation(
       submission->alloca.pool, submission->alloca.params, reservation,
       IREE_HAL_POOL_MATERIALIZE_FLAG_NONE, &backing_buffer);
   if (iree_status_is_ok(status)) {
-    iree_hal_local_transient_buffer_attach_reservation(
+    iree_hal_vulkan_transient_buffer_attach_reservation(
         submission->alloca.buffer, submission->alloca.pool, reservation);
-    iree_hal_local_transient_buffer_stage_backing(submission->alloca.buffer,
-                                                  backing_buffer);
+    iree_hal_vulkan_transient_buffer_stage_backing(submission->alloca.buffer,
+                                                   backing_buffer);
     submission->alloca.wait_frontier =
         acquire_result == IREE_HAL_POOL_ACQUIRE_OK_NEEDS_WAIT ? wait_frontier
                                                               : NULL;
@@ -4769,8 +4769,8 @@ static iree_status_t iree_hal_vulkan_queue_stage_alloca_sparse_backing(
                               "queue_alloca");
   }
   if (iree_status_is_ok(status)) {
-    iree_hal_local_transient_buffer_stage_backing(submission->alloca.buffer,
-                                                  backing_buffer);
+    iree_hal_vulkan_transient_buffer_stage_backing(submission->alloca.buffer,
+                                                   backing_buffer);
     submission->sparse_bind.buffer = sparse_buffer_handle;
     submission->sparse_bind.binds = binds;
     submission->sparse_bind.bind_count = (uint32_t)bind_count;
@@ -6427,7 +6427,7 @@ static iree_status_t iree_hal_vulkan_queue_create_transient_buffer(
   if (iree_all_bits_set(flags, IREE_HAL_ALLOCA_FLAG_INDETERMINATE_LIFETIME)) {
     placement.flags |= IREE_HAL_BUFFER_PLACEMENT_FLAG_INDETERMINATE_LIFETIME;
   }
-  return iree_hal_local_transient_buffer_create(
+  return iree_hal_vulkan_transient_buffer_create(
       placement, params, allocation_size, byte_length, queue->host_allocator,
       out_buffer);
 }
@@ -6572,13 +6572,13 @@ iree_status_t iree_hal_vulkan_queue_submit_dealloca(
         "unsupported Vulkan queue dealloca flags: 0x%" PRIx64, flags);
   }
   if (iree_status_is_ok(status) &&
-      !iree_hal_local_transient_buffer_isa(buffer)) {
+      !iree_hal_vulkan_transient_buffer_isa(buffer)) {
     status = iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                               "Vulkan queue_dealloca buffer was not returned "
                               "by Vulkan queue_alloca");
   }
   if (iree_status_is_ok(status) &&
-      !iree_hal_local_transient_buffer_begin_dealloca(buffer)) {
+      !iree_hal_vulkan_transient_buffer_begin_dealloca(buffer)) {
     status = iree_make_status(
         IREE_STATUS_FAILED_PRECONDITION,
         "Vulkan transient buffer has already been queued for deallocation");
@@ -6610,15 +6610,15 @@ iree_status_t iree_hal_vulkan_queue_submit_dealloca(
     submission = NULL;
   }
   if (submission) {
-    iree_hal_local_transient_buffer_abort_dealloca(buffer);
+    iree_hal_vulkan_transient_buffer_abort_dealloca(buffer);
     if (!iree_status_is_ok(status)) {
       iree_hal_vulkan_queue_fail_signal_list(submission->signal_semaphore_list,
                                              iree_status_clone(status));
     }
     iree_hal_vulkan_queue_pending_submission_destroy(queue, submission);
   } else if (!iree_status_is_ok(status) &&
-             iree_hal_local_transient_buffer_isa(buffer)) {
-    iree_hal_local_transient_buffer_abort_dealloca(buffer);
+             iree_hal_vulkan_transient_buffer_isa(buffer)) {
+    iree_hal_vulkan_transient_buffer_abort_dealloca(buffer);
   }
 
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree/hal/drivers/vulkan/transient_buffer.c
+++ b/runtime/src/iree/hal/drivers/vulkan/transient_buffer.c
@@ -4,23 +4,23 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/hal/local/transient_buffer.h"
+#include "iree/hal/drivers/vulkan/transient_buffer.h"
 
 #include "iree/base/threading/mutex.h"
 
-static iree_atomic_int64_t iree_hal_local_transient_buffer_next_profile_id =
+static iree_atomic_int64_t iree_hal_vulkan_transient_buffer_next_profile_id =
     IREE_ATOMIC_VAR_INIT(1);
 
 // Vtable dispatch for forwarding to the committed buffer's implementation.
 // Equivalent to IREE_HAL_VTABLE_DISPATCH from detail.h but accessible from
-// this HAL-local utility (detail.h is module-private to the HAL core).
+// this driver-private implementation (detail.h is module-private to HAL core).
 static inline const iree_hal_buffer_vtable_t*
-iree_hal_local_transient_buffer_committed_vtable(iree_hal_buffer_t* buffer) {
+iree_hal_vulkan_transient_buffer_committed_vtable(iree_hal_buffer_t* buffer) {
   return (const iree_hal_buffer_vtable_t*)((const iree_hal_resource_t*)buffer)
       ->vtable;
 }
 
-struct iree_hal_local_transient_buffer_t {
+struct iree_hal_vulkan_transient_buffer_t {
   // Base HAL buffer resource exposed to callers.
   iree_hal_buffer_t base;
 
@@ -53,15 +53,15 @@ struct iree_hal_local_transient_buffer_t {
   int32_t dealloca_queued;
 };
 
-static const iree_hal_buffer_vtable_t iree_hal_local_transient_buffer_vtable;
+static const iree_hal_buffer_vtable_t iree_hal_vulkan_transient_buffer_vtable;
 
-static iree_hal_local_transient_buffer_t* iree_hal_local_transient_buffer_cast(
-    iree_hal_buffer_t* buffer) {
-  return (iree_hal_local_transient_buffer_t*)buffer;
+static iree_hal_vulkan_transient_buffer_t*
+iree_hal_vulkan_transient_buffer_cast(iree_hal_buffer_t* buffer) {
+  return (iree_hal_vulkan_transient_buffer_t*)buffer;
 }
 
-static iree_status_t iree_hal_local_transient_buffer_retain_host_backing(
-    iree_hal_local_transient_buffer_t* buffer,
+static iree_status_t iree_hal_vulkan_transient_buffer_retain_host_backing(
+    iree_hal_vulkan_transient_buffer_t* buffer,
     iree_hal_buffer_t** out_backing_buffer) {
   *out_backing_buffer = NULL;
   iree_slim_mutex_lock(&buffer->mutex);
@@ -85,7 +85,7 @@ static iree_status_t iree_hal_local_transient_buffer_retain_host_backing(
   return iree_ok_status();
 }
 
-iree_status_t iree_hal_local_transient_buffer_create(
+iree_status_t iree_hal_vulkan_transient_buffer_create(
     iree_hal_buffer_placement_t placement, iree_hal_buffer_params_t params,
     iree_device_size_t allocation_size, iree_device_size_t byte_length,
     iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer) {
@@ -99,7 +99,7 @@ iree_status_t iree_hal_local_transient_buffer_create(
   }
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_hal_local_transient_buffer_t* buffer = NULL;
+  iree_hal_vulkan_transient_buffer_t* buffer = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0,
       iree_allocator_malloc(host_allocator, sizeof(*buffer), (void**)&buffer));
@@ -107,10 +107,10 @@ iree_status_t iree_hal_local_transient_buffer_create(
   iree_hal_buffer_initialize(
       placement, /*allocated_buffer=*/&buffer->base, allocation_size,
       /*byte_offset=*/0, byte_length, params.type, params.access, params.usage,
-      &iree_hal_local_transient_buffer_vtable, &buffer->base);
+      &iree_hal_vulkan_transient_buffer_vtable, &buffer->base);
   buffer->host_allocator = host_allocator;
   buffer->profile_id = (uint64_t)iree_atomic_fetch_add(
-      &iree_hal_local_transient_buffer_next_profile_id, 1,
+      &iree_hal_vulkan_transient_buffer_next_profile_id, 1,
       iree_memory_order_relaxed);
   iree_slim_mutex_initialize(&buffer->mutex);
   buffer->staged_backing = NULL;
@@ -125,33 +125,23 @@ iree_status_t iree_hal_local_transient_buffer_create(
   return iree_ok_status();
 }
 
-bool iree_hal_local_transient_buffer_isa(const iree_hal_buffer_t* buffer) {
+bool iree_hal_vulkan_transient_buffer_isa(const iree_hal_buffer_t* buffer) {
   return iree_hal_resource_is(&buffer->resource,
-                              &iree_hal_local_transient_buffer_vtable);
+                              &iree_hal_vulkan_transient_buffer_vtable);
 }
 
-bool iree_hal_local_transient_buffer_is_committed(
+uint64_t iree_hal_vulkan_transient_buffer_profile_id(
     iree_hal_buffer_t* base_buffer) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
-  iree_slim_mutex_lock(&buffer->mutex);
-  const bool is_committed = buffer->committed_backing != NULL;
-  iree_slim_mutex_unlock(&buffer->mutex);
-  return is_committed;
-}
-
-uint64_t iree_hal_local_transient_buffer_profile_id(
-    iree_hal_buffer_t* base_buffer) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   return buffer->profile_id;
 }
 
-void iree_hal_local_transient_buffer_attach_reservation(
+void iree_hal_vulkan_transient_buffer_attach_reservation(
     iree_hal_buffer_t* base_buffer, iree_hal_pool_t* pool,
     const iree_hal_pool_reservation_t* reservation) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   IREE_ASSERT_ARGUMENT(pool);
   IREE_ASSERT_ARGUMENT(reservation);
   iree_slim_mutex_lock(&buffer->mutex);
@@ -163,10 +153,10 @@ void iree_hal_local_transient_buffer_attach_reservation(
   iree_slim_mutex_unlock(&buffer->mutex);
 }
 
-void iree_hal_local_transient_buffer_stage_backing(
+void iree_hal_vulkan_transient_buffer_stage_backing(
     iree_hal_buffer_t* base_buffer, iree_hal_buffer_t* backing) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   IREE_ASSERT_ARGUMENT(backing);
   iree_slim_mutex_lock(&buffer->mutex);
   IREE_ASSERT_TRUE(buffer->staged_backing == NULL);
@@ -176,9 +166,9 @@ void iree_hal_local_transient_buffer_stage_backing(
   iree_slim_mutex_unlock(&buffer->mutex);
 }
 
-void iree_hal_local_transient_buffer_commit(iree_hal_buffer_t* base_buffer) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+void iree_hal_vulkan_transient_buffer_commit(iree_hal_buffer_t* base_buffer) {
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   iree_slim_mutex_lock(&buffer->mutex);
   IREE_ASSERT_TRUE(buffer->staged_backing != NULL);
   IREE_ASSERT_TRUE(buffer->committed_backing == NULL);
@@ -186,9 +176,9 @@ void iree_hal_local_transient_buffer_commit(iree_hal_buffer_t* base_buffer) {
   iree_slim_mutex_unlock(&buffer->mutex);
 }
 
-void iree_hal_local_transient_buffer_decommit(iree_hal_buffer_t* base_buffer) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+void iree_hal_vulkan_transient_buffer_decommit(iree_hal_buffer_t* base_buffer) {
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   iree_slim_mutex_lock(&buffer->mutex);
   iree_hal_buffer_t* staged_backing = buffer->staged_backing;
   buffer->staged_backing = NULL;
@@ -197,20 +187,20 @@ void iree_hal_local_transient_buffer_decommit(iree_hal_buffer_t* base_buffer) {
   iree_hal_buffer_release(staged_backing);
 }
 
-bool iree_hal_local_transient_buffer_is_dealloca_queued(
+bool iree_hal_vulkan_transient_buffer_is_dealloca_queued(
     iree_hal_buffer_t* base_buffer) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   iree_slim_mutex_lock(&buffer->mutex);
   const bool is_dealloca_queued = buffer->dealloca_queued != 0;
   iree_slim_mutex_unlock(&buffer->mutex);
   return is_dealloca_queued;
 }
 
-bool iree_hal_local_transient_buffer_begin_dealloca(
+bool iree_hal_vulkan_transient_buffer_begin_dealloca(
     iree_hal_buffer_t* base_buffer) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   bool owns_dealloca = false;
   iree_slim_mutex_lock(&buffer->mutex);
   if (!buffer->dealloca_queued) {
@@ -221,30 +211,30 @@ bool iree_hal_local_transient_buffer_begin_dealloca(
   return owns_dealloca;
 }
 
-void iree_hal_local_transient_buffer_abort_dealloca(
+void iree_hal_vulkan_transient_buffer_abort_dealloca(
     iree_hal_buffer_t* base_buffer) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   iree_slim_mutex_lock(&buffer->mutex);
   buffer->dealloca_queued = 0;
   iree_slim_mutex_unlock(&buffer->mutex);
 }
 
-iree_hal_buffer_t* iree_hal_local_transient_buffer_backing_buffer(
+iree_hal_buffer_t* iree_hal_vulkan_transient_buffer_backing_buffer(
     iree_hal_buffer_t* base_buffer) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   iree_slim_mutex_lock(&buffer->mutex);
   iree_hal_buffer_t* backing = buffer->staged_backing;
   iree_slim_mutex_unlock(&buffer->mutex);
   return backing;
 }
 
-bool iree_hal_local_transient_buffer_query_reservation(
+bool iree_hal_vulkan_transient_buffer_query_reservation(
     iree_hal_buffer_t* base_buffer, iree_hal_pool_t** out_pool,
     iree_hal_pool_reservation_t* out_reservation) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   iree_slim_mutex_lock(&buffer->mutex);
   const bool has_reservation =
       buffer->reservation_pool != NULL && buffer->reservation_armed;
@@ -256,11 +246,11 @@ bool iree_hal_local_transient_buffer_query_reservation(
   return has_reservation;
 }
 
-void iree_hal_local_transient_buffer_release_reservation(
+void iree_hal_vulkan_transient_buffer_release_reservation(
     iree_hal_buffer_t* base_buffer,
     const iree_async_frontier_t* death_frontier) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   iree_hal_pool_t* pool = NULL;
   iree_hal_pool_reservation_t reservation;
   iree_slim_mutex_lock(&buffer->mutex);
@@ -280,34 +270,34 @@ void iree_hal_local_transient_buffer_release_reservation(
   }
 }
 
-static void iree_hal_local_transient_buffer_destroy(
+static void iree_hal_vulkan_transient_buffer_destroy(
     iree_hal_buffer_t* base_buffer) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   iree_allocator_t host_allocator = buffer->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_hal_local_transient_buffer_decommit(base_buffer);
-  iree_hal_local_transient_buffer_release_reservation(base_buffer,
-                                                      /*death_frontier=*/NULL);
+  iree_hal_vulkan_transient_buffer_decommit(base_buffer);
+  iree_hal_vulkan_transient_buffer_release_reservation(base_buffer,
+                                                       /*death_frontier=*/NULL);
 
   iree_slim_mutex_deinitialize(&buffer->mutex);
   iree_allocator_free(host_allocator, buffer);
   IREE_TRACE_ZONE_END(z0);
 }
 
-static iree_status_t iree_hal_local_transient_buffer_map_range(
+static iree_status_t iree_hal_vulkan_transient_buffer_map_range(
     iree_hal_buffer_t* base_buffer, iree_hal_mapping_mode_t mapping_mode,
     iree_hal_memory_access_t memory_access,
     iree_device_size_t local_byte_offset, iree_device_size_t local_byte_length,
     iree_hal_buffer_mapping_t* mapping) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   iree_hal_buffer_t* committed = NULL;
   IREE_RETURN_IF_ERROR(
-      iree_hal_local_transient_buffer_retain_host_backing(buffer, &committed));
+      iree_hal_vulkan_transient_buffer_retain_host_backing(buffer, &committed));
   iree_status_t status =
-      iree_hal_local_transient_buffer_committed_vtable(committed)->map_range(
+      iree_hal_vulkan_transient_buffer_committed_vtable(committed)->map_range(
           committed, mapping_mode, memory_access, local_byte_offset,
           local_byte_length, mapping);
   if (iree_status_is_ok(status)) {
@@ -327,56 +317,57 @@ static iree_status_t iree_hal_local_transient_buffer_map_range(
   return status;
 }
 
-static iree_status_t iree_hal_local_transient_buffer_unmap_range(
+static iree_status_t iree_hal_vulkan_transient_buffer_unmap_range(
     iree_hal_buffer_t* base_buffer, iree_device_size_t local_byte_offset,
     iree_device_size_t local_byte_length, iree_hal_buffer_mapping_t* mapping) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   iree_hal_buffer_t* committed = NULL;
   IREE_RETURN_IF_ERROR(
-      iree_hal_local_transient_buffer_retain_host_backing(buffer, &committed));
+      iree_hal_vulkan_transient_buffer_retain_host_backing(buffer, &committed));
   iree_status_t status =
-      iree_hal_local_transient_buffer_committed_vtable(committed)->unmap_range(
+      iree_hal_vulkan_transient_buffer_committed_vtable(committed)->unmap_range(
           committed, local_byte_offset, local_byte_length, mapping);
   iree_hal_buffer_release(committed);
   return status;
 }
 
-static iree_status_t iree_hal_local_transient_buffer_invalidate_range(
+static iree_status_t iree_hal_vulkan_transient_buffer_invalidate_range(
     iree_hal_buffer_t* base_buffer, iree_device_size_t local_byte_offset,
     iree_device_size_t local_byte_length) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   iree_hal_buffer_t* committed = NULL;
   IREE_RETURN_IF_ERROR(
-      iree_hal_local_transient_buffer_retain_host_backing(buffer, &committed));
+      iree_hal_vulkan_transient_buffer_retain_host_backing(buffer, &committed));
   iree_status_t status =
-      iree_hal_local_transient_buffer_committed_vtable(committed)
+      iree_hal_vulkan_transient_buffer_committed_vtable(committed)
           ->invalidate_range(committed, local_byte_offset, local_byte_length);
   iree_hal_buffer_release(committed);
   return status;
 }
 
-static iree_status_t iree_hal_local_transient_buffer_flush_range(
+static iree_status_t iree_hal_vulkan_transient_buffer_flush_range(
     iree_hal_buffer_t* base_buffer, iree_device_size_t local_byte_offset,
     iree_device_size_t local_byte_length) {
-  iree_hal_local_transient_buffer_t* buffer =
-      iree_hal_local_transient_buffer_cast(base_buffer);
+  iree_hal_vulkan_transient_buffer_t* buffer =
+      iree_hal_vulkan_transient_buffer_cast(base_buffer);
   iree_hal_buffer_t* committed = NULL;
   IREE_RETURN_IF_ERROR(
-      iree_hal_local_transient_buffer_retain_host_backing(buffer, &committed));
+      iree_hal_vulkan_transient_buffer_retain_host_backing(buffer, &committed));
   iree_status_t status =
-      iree_hal_local_transient_buffer_committed_vtable(committed)->flush_range(
+      iree_hal_vulkan_transient_buffer_committed_vtable(committed)->flush_range(
           committed, local_byte_offset, local_byte_length);
   iree_hal_buffer_release(committed);
   return status;
 }
 
-static const iree_hal_buffer_vtable_t iree_hal_local_transient_buffer_vtable = {
-    .recycle = iree_hal_buffer_recycle,
-    .destroy = iree_hal_local_transient_buffer_destroy,
-    .map_range = iree_hal_local_transient_buffer_map_range,
-    .unmap_range = iree_hal_local_transient_buffer_unmap_range,
-    .invalidate_range = iree_hal_local_transient_buffer_invalidate_range,
-    .flush_range = iree_hal_local_transient_buffer_flush_range,
+static const iree_hal_buffer_vtable_t iree_hal_vulkan_transient_buffer_vtable =
+    {
+        .recycle = iree_hal_buffer_recycle,
+        .destroy = iree_hal_vulkan_transient_buffer_destroy,
+        .map_range = iree_hal_vulkan_transient_buffer_map_range,
+        .unmap_range = iree_hal_vulkan_transient_buffer_unmap_range,
+        .invalidate_range = iree_hal_vulkan_transient_buffer_invalidate_range,
+        .flush_range = iree_hal_vulkan_transient_buffer_flush_range,
 };

--- a/runtime/src/iree/hal/drivers/vulkan/transient_buffer.h
+++ b/runtime/src/iree/hal/drivers/vulkan/transient_buffer.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Transient buffer: a reservation handle for queue-ordered local allocations.
+// Transient buffer: a reservation handle for queue-ordered Vulkan allocations.
 //
 // Queue allocators can return a transient buffer to the caller before the
 // physical backing is ready, then commit a real backing buffer once queue
@@ -13,8 +13,8 @@
 // cleanly with IREE_STATUS_FAILED_PRECONDITION instead of accessing freed
 // storage.
 
-#ifndef IREE_HAL_LOCAL_TRANSIENT_BUFFER_H_
-#define IREE_HAL_LOCAL_TRANSIENT_BUFFER_H_
+#ifndef IREE_HAL_DRIVERS_VULKAN_TRANSIENT_BUFFER_H_
+#define IREE_HAL_DRIVERS_VULKAN_TRANSIENT_BUFFER_H_
 
 #include "iree/async/frontier.h"
 #include "iree/base/api.h"
@@ -24,8 +24,8 @@
 extern "C" {
 #endif  // __cplusplus
 
-typedef struct iree_hal_local_transient_buffer_t
-    iree_hal_local_transient_buffer_t;
+typedef struct iree_hal_vulkan_transient_buffer_t
+    iree_hal_vulkan_transient_buffer_t;
 
 // Creates a transient buffer with the given metadata but no backing memory.
 // The buffer starts in the uncommitted state.
@@ -36,76 +36,69 @@ typedef struct iree_hal_local_transient_buffer_t
 //
 // |placement| must include IREE_HAL_BUFFER_PLACEMENT_FLAG_ASYNCHRONOUS so the
 // HAL dealloca path routes through the owning driver's queue_dealloca vtable.
-iree_status_t iree_hal_local_transient_buffer_create(
+iree_status_t iree_hal_vulkan_transient_buffer_create(
     iree_hal_buffer_placement_t placement, iree_hal_buffer_params_t params,
     iree_device_size_t allocation_size, iree_device_size_t byte_length,
     iree_allocator_t host_allocator, iree_hal_buffer_t** out_buffer);
 
-// Returns true if |buffer| is a local transient buffer wrapper.
-bool iree_hal_local_transient_buffer_isa(const iree_hal_buffer_t* buffer);
-
-// Returns true if |buffer| has a committed backing buffer visible to callers.
-//
-// This is a cheap state query for queue implementations that need to decide
-// whether a transient can be mapped immediately or must be resolved after its
-// queue allocation dependency has completed.
-bool iree_hal_local_transient_buffer_is_committed(iree_hal_buffer_t* buffer);
+// Returns true if |buffer| is a Vulkan transient buffer wrapper.
+bool iree_hal_vulkan_transient_buffer_isa(const iree_hal_buffer_t* buffer);
 
 // Returns the stable profiling id assigned to this transient buffer wrapper.
 //
-// The id is process-global and nonzero. Producers use it as a session-local
-// allocation id whenever the wrapper participates in an active profile capture.
-uint64_t iree_hal_local_transient_buffer_profile_id(iree_hal_buffer_t* buffer);
+// The id is nonzero and unique across wrappers owned by this driver. Producers
+// use it as a session-local allocation id during an active profile capture.
+uint64_t iree_hal_vulkan_transient_buffer_profile_id(iree_hal_buffer_t* buffer);
 
 // Attaches a pool reservation to the transient buffer. The wrapper keeps only
 // a borrowed pointer to |pool| and takes ownership of |reservation| until
-// iree_hal_local_transient_buffer_release_reservation() or wrapper destroy.
-void iree_hal_local_transient_buffer_attach_reservation(
+// iree_hal_vulkan_transient_buffer_release_reservation() or wrapper destroy.
+void iree_hal_vulkan_transient_buffer_attach_reservation(
     iree_hal_buffer_t* buffer, iree_hal_pool_t* pool,
     const iree_hal_pool_reservation_t* reservation);
 
 // Stages a materialized backing buffer view for a future commit. The backing
 // buffer is retained, but remains invisible to map/flush/invalidate calls until
-// iree_hal_local_transient_buffer_commit() publishes it.
-void iree_hal_local_transient_buffer_stage_backing(iree_hal_buffer_t* buffer,
-                                                   iree_hal_buffer_t* backing);
+// iree_hal_vulkan_transient_buffer_commit() publishes it.
+void iree_hal_vulkan_transient_buffer_stage_backing(iree_hal_buffer_t* buffer,
+                                                    iree_hal_buffer_t* backing);
 
 // Publishes the staged backing buffer. Must be called exactly once while the
 // wrapper is uncommitted and has a staged backing view.
-void iree_hal_local_transient_buffer_commit(iree_hal_buffer_t* buffer);
+void iree_hal_vulkan_transient_buffer_commit(iree_hal_buffer_t* buffer);
 
 // Decommits the backing buffer and returns the wrapper to the uncommitted
 // state. Any staged-but-uncommitted backing view is also released. Queue
 // implementations use this in the dealloca wait-satisfied/signal-before window
 // so target-visible release effects occur before user-visible completion. Safe
 // to call on an already-uncommitted wrapper.
-void iree_hal_local_transient_buffer_decommit(iree_hal_buffer_t* buffer);
+void iree_hal_vulkan_transient_buffer_decommit(iree_hal_buffer_t* buffer);
 
 // Returns true if queue_dealloca has been accepted for the transient buffer.
-bool iree_hal_local_transient_buffer_is_dealloca_queued(
+bool iree_hal_vulkan_transient_buffer_is_dealloca_queued(
     iree_hal_buffer_t* buffer);
 
 // Marks the wrapper as queued for deallocation. Returns false if deallocation
 // was already queued. Queue implementations call this before accepting a
 // queue_dealloca so double-deallocation fails before any queue state changes.
-bool iree_hal_local_transient_buffer_begin_dealloca(iree_hal_buffer_t* buffer);
+bool iree_hal_vulkan_transient_buffer_begin_dealloca(iree_hal_buffer_t* buffer);
 
 // Clears a queued-deallocation marker after submission failure. Must only be
 // called when no deallocation completion action can still run.
-void iree_hal_local_transient_buffer_abort_dealloca(iree_hal_buffer_t* buffer);
+void iree_hal_vulkan_transient_buffer_abort_dealloca(iree_hal_buffer_t* buffer);
 
 // Returns the staged backing buffer used for queue packet emission, or NULL if
 // no backing has been staged. This is intentionally less strict than committed
 // host access: queue submissions may resolve backing storage before the alloca
 // signal is visible to users, relying on semaphore dependencies for ordering.
-iree_hal_buffer_t* iree_hal_local_transient_buffer_backing_buffer(
+iree_hal_buffer_t* iree_hal_vulkan_transient_buffer_backing_buffer(
     iree_hal_buffer_t* buffer);
 
 // Returns the attached pool reservation without transferring ownership.
 //
 // This is a cold diagnostic/profiling helper. Returns false when the wrapper
 // has no live reservation or the reservation has already been released.
-bool iree_hal_local_transient_buffer_query_reservation(
+bool iree_hal_vulkan_transient_buffer_query_reservation(
     iree_hal_buffer_t* buffer, iree_hal_pool_t** out_pool,
     iree_hal_pool_reservation_t* out_reservation);
 
@@ -117,11 +110,11 @@ bool iree_hal_local_transient_buffer_query_reservation(
 // reservation in synchronous/drain-ordered paths. This updates pool reuse
 // metadata; target-visible release effects are performed by the queue before
 // publishing dealloca completion.
-void iree_hal_local_transient_buffer_release_reservation(
+void iree_hal_vulkan_transient_buffer_release_reservation(
     iree_hal_buffer_t* buffer, const iree_async_frontier_t* death_frontier);
 
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus
 
-#endif  // IREE_HAL_LOCAL_TRANSIENT_BUFFER_H_
+#endif  // IREE_HAL_DRIVERS_VULKAN_TRANSIENT_BUFFER_H_

--- a/runtime/src/iree/hal/local/BUILD.bazel
+++ b/runtime/src/iree/hal/local/BUILD.bazel
@@ -255,15 +255,3 @@ iree_runtime_cc_test(
         "//runtime/src/iree/testing:gtest_main",
     ],
 )
-
-iree_runtime_cc_library(
-    name = "transient_buffer",
-    srcs = ["transient_buffer.c"],
-    hdrs = ["transient_buffer.h"],
-    deps = [
-        "//runtime/src/iree/async",
-        "//runtime/src/iree/base",
-        "//runtime/src/iree/base/threading",
-        "//runtime/src/iree/hal",
-    ],
-)

--- a/runtime/src/iree/hal/local/CMakeLists.txt
+++ b/runtime/src/iree/hal/local/CMakeLists.txt
@@ -289,19 +289,4 @@ iree_cc_test(
     iree::testing::gtest_main
 )
 
-iree_cc_library(
-  NAME
-    transient_buffer
-  HDRS
-    "transient_buffer.h"
-  SRCS
-    "transient_buffer.c"
-  DEPS
-    iree::async
-    iree::base
-    iree::base::threading
-    iree::hal
-  PUBLIC
-)
-
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###


### PR DESCRIPTION
Local-task and Vulkan now own separate transient-buffer implementations instead of sharing a representation under `hal/local`.

The shared wrapper began as CPU queue-allocation infrastructure. Vulkan later added queued-deallocation tracking, submission rollback, and direct backing access to that same object. The result was an inverted ownership boundary: Vulkan reached into a CPU implementation directory, while local-task carried a field, a host-access branch, and APIs that only Vulkan exercised.

This moves the wrapper into each driver, gives each implementation its own symbol family, and makes both Bazel targets package-private. The local-task object drops queued-deallocation state, rollback, direct backing access, and the unused committed-state query. The Vulkan object retains the pending-submission validation and rollback semantics its queue requires.

The common mapping and backing-forwarding mechanics are deliberately driver-owned rather than factored back into another shared representation. Local-task and Vulkan have different queue and lifetime contracts; sharing this object would couple those contracts again and make changes in one implementation impose representation and hot-path costs on the other.

Vulkan’s only remaining dependency on `hal/local` is now the profile recorder, which has a distinct producer model and can be separated independently.
